### PR TITLE
CTL-751: Wire phase-triage to produce + write a real reference-class estimate

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -245,6 +245,38 @@ export function applyTriageStatus({
   }
 }
 
+// ALLOWED_ESTIMATE_POINTS — the Fibonacci-derived points scale used by the
+// reference-class lookup tool (CTL-751). Only these values are accepted by
+// applyEstimate; anything else is rejected without calling linearis.
+const ALLOWED_ESTIMATE_POINTS = new Set([1, 3, 5, 8, 13]);
+
+// applyEstimate — write a numeric estimate to a ticket's Linear estimate field
+// (CTL-751). Best-effort, never throws; mirrors applyLabel shape (try/catch,
+// log.warn, tagged return). No read-back (the estimate field is not subject to
+// the label silent-success gap; a verifying read-back can be added as follow-up).
+export function applyEstimate({ ticket, estimate, exec = defaultExec }) {
+  if (!ALLOWED_ESTIMATE_POINTS.has(estimate)) {
+    return { applied: false, reason: "invalid-estimate" };
+  }
+  try {
+    const res = exec("linearis", ["issues", "update", ticket, "--estimate", String(estimate)]);
+    if (res.code !== 0) {
+      log.warn(
+        { ticket, estimate, code: res.code, stderr: res.stderr },
+        "linear-write: estimate write failed (exit non-zero)"
+      );
+      return { applied: false, reason: "transient" };
+    }
+    return { applied: true, reason: null };
+  } catch (err) {
+    log.warn(
+      { ticket, estimate, reason: "transient", err: err.message },
+      "linear-write: estimate write threw — swallowed"
+    );
+    return { applied: false, reason: "transient" };
+  }
+}
+
 // applyBlockedByRelation — additively write a durable blocked-by edge
 // (CTL-537). Best-effort, never throws; mirrors applyLabel but without a
 // read-back: a blocked-by relation is durable (research:140) and the seam

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -8,6 +8,7 @@ import {
   applyTriageStatus,
   removeLabel,
   applyBlockedByRelation,
+  applyEstimate,
   teamOf,
 } from "./linear-write.mjs";
 
@@ -379,5 +380,67 @@ describe("applyBlockedByRelation", () => {
     expect(r1.applied).toBe(true);
     expect(r2.applied).toBe(true);
     expect(calls).toHaveLength(2);
+  });
+});
+
+describe("applyEstimate", () => {
+  test("valid estimate, exec returns code:0 → applied:true, correct args", () => {
+    const calls = [];
+    const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const r = applyEstimate({ ticket: "CTL-1", estimate: 5, exec });
+    expect(r).toEqual({ applied: true, reason: null });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].cmd).toBe("linearis");
+    expect(calls[0].args).toEqual(["issues", "update", "CTL-1", "--estimate", "5"]);
+  });
+
+  test("exec returns code:1 → applied:false with non-null reason, does not throw", () => {
+    const exec = () => ({ code: 1, stdout: "", stderr: "some error" });
+    expect(() => applyEstimate({ ticket: "CTL-1", estimate: 5, exec })).not.toThrow();
+    const r = applyEstimate({ ticket: "CTL-1", estimate: 5, exec });
+    expect(r.applied).toBe(false);
+    expect(r.reason).not.toBeNull();
+  });
+
+  test("exec throws → applied:false, reason non-null, swallowed", () => {
+    const exec = () => { throw new Error("spawn boom"); };
+    expect(() => applyEstimate({ ticket: "CTL-1", estimate: 5, exec })).not.toThrow();
+    const r = applyEstimate({ ticket: "CTL-1", estimate: 5, exec });
+    expect(r.applied).toBe(false);
+    expect(r.reason).toBeTruthy();
+  });
+
+  test("invalid estimate 4 → applied:false, reason:invalid-estimate, exec not called", () => {
+    const calls = [];
+    const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const r = applyEstimate({ ticket: "CTL-1", estimate: 4, exec });
+    expect(r).toEqual({ applied: false, reason: "invalid-estimate" });
+    expect(calls).toHaveLength(0);
+  });
+
+  test("null estimate → applied:false, reason:invalid-estimate, exec not called", () => {
+    const calls = [];
+    const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const r = applyEstimate({ ticket: "CTL-1", estimate: null, exec });
+    expect(r).toEqual({ applied: false, reason: "invalid-estimate" });
+    expect(calls).toHaveLength(0);
+  });
+
+  test("string estimate 'x' → applied:false, reason:invalid-estimate, exec not called", () => {
+    const calls = [];
+    const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const r = applyEstimate({ ticket: "CTL-1", estimate: "x", exec });
+    expect(r).toEqual({ applied: false, reason: "invalid-estimate" });
+    expect(calls).toHaveLength(0);
+  });
+
+  test("all valid estimate values (1,3,5,8,13) are accepted", () => {
+    for (const est of [1, 3, 5, 8, 13]) {
+      const calls = [];
+      const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+      const r = applyEstimate({ ticket: "CTL-1", estimate: est, exec });
+      expect(r.applied).toBe(true);
+      expect(calls[0].args).toContain(String(est));
+    }
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -145,6 +145,21 @@ export function stageRankForTicket(signals) {
 }
 
 // readWorkerPriority — read workers/<T>/priority.json → {priority, createdAt}.
+// readTriageEstimate — read workers/<T>/triage.json and return the numeric
+// `.estimate` if it is one of the allowed Fibonacci points {1,3,5,8,13}
+// (CTL-751). Returns null on missing file, unparseable JSON, absent field,
+// or non-allowed value. Never throws.
+const ALLOWED_ESTIMATE_POINTS_SET = new Set([1, 3, 5, 8, 13]);
+function readTriageEstimate(orchDir, ticket) {
+  try {
+    const raw = readFileSync(join(orchDir, "workers", ticket, "triage.json"), "utf8");
+    const { estimate } = JSON.parse(raw);
+    return ALLOWED_ESTIMATE_POINTS_SET.has(estimate) ? estimate : null;
+  } catch {
+    return null;
+  }
+}
+
 // Missing or unreadable → {priority: 5, createdAt: null} (safe lowest-band
 // default). Never throws.
 export function readWorkerPriority(orchDir, ticket) {
@@ -1756,6 +1771,17 @@ export function schedulerTick(
           ticket,
           phase: next,
         });
+        // CTL-751: on triage→research advance, write the reference-class
+        // estimate to Linear if triage.json carries a valid numeric `.estimate`.
+        if (next === "research") {
+          const est = readTriageEstimate(orchDir, ticket);
+          if (est !== null) {
+            safeWrite(() => writeStatus.applyEstimate({ ticket, estimate: est }), {
+              ticket,
+              phase: next,
+            });
+          }
+        }
       } else {
         // CTL-611 Gap 1 demotion: rc=0 but no live bg job. Same on-disk
         // effects as a real rc!=0 failure so the broker / HUD / operator can

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5028,3 +5028,100 @@ describe("CTL-537 Phase 5: startScheduler forwards checkSequencing (runTick wiri
     expect(spyCount).toBeGreaterThan(0);
   });
 });
+
+describe("CTL-751: applyEstimate write-back on triage→research advance", () => {
+  const okDispatch = fakeDispatch();
+
+  function writeTriageJson(ticket, obj) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "triage.json"), JSON.stringify(obj));
+  }
+
+  function makeWriteStatus(estimateCalls) {
+    return {
+      applyPhaseStatus: () => {},
+      applyTerminalDone: () => {},
+      applyLabel: () => {},
+      applyEstimate: (a) => { estimateCalls.push(a); return { applied: true, reason: null }; },
+    };
+  }
+
+  test("triage.json with estimate:5 → applyEstimate called once with {ticket, estimate:5}", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-1", "triage", "done");
+    writeTriageJson("CTL-1", { estimated_scope: "medium", estimate: 5 });
+    const calls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: okDispatch,
+      writeStatus: makeWriteStatus(calls),
+      verifyDispatched: verifyOk,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ ticket: "CTL-1", estimate: 5 });
+  });
+
+  test("triage.json with no estimate → applyEstimate not called", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-1", "triage", "done");
+    writeTriageJson("CTL-1", { estimated_scope: "medium" });
+    const calls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: okDispatch,
+      writeStatus: makeWriteStatus(calls),
+      verifyDispatched: verifyOk,
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  test("triage.json with invalid estimate:4 → applyEstimate not called by scheduler", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-1", "triage", "done");
+    writeTriageJson("CTL-1", { estimated_scope: "medium", estimate: 4 });
+    const calls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: okDispatch,
+      writeStatus: makeWriteStatus(calls),
+      verifyDispatched: verifyOk,
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  test("advance to plan (not research) → applyEstimate not called", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-1", "triage", "done");
+    writeSignal("CTL-1", "research", "done");
+    writeTriageJson("CTL-1", { estimated_scope: "medium", estimate: 5 });
+    const calls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: okDispatch,
+      writeStatus: makeWriteStatus(calls),
+      verifyDispatched: verifyOk,
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  test("applyEstimate throwing does not break the tick", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-1", "triage", "done");
+    writeTriageJson("CTL-1", { estimated_scope: "medium", estimate: 5 });
+    const writeStatus = {
+      applyPhaseStatus: () => {},
+      applyTerminalDone: () => {},
+      applyLabel: () => {},
+      applyEstimate: () => { throw new Error("Linear exploded"); },
+    };
+    expect(() =>
+      schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch: okDispatch,
+        writeStatus,
+        verifyDispatched: verifyOk,
+      })
+    ).not.toThrow();
+  });
+});

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -278,8 +278,27 @@ The bash body above is fully self-sufficient — the e2e test exercises only tha
 runs this skill, it should:
 
 1. Run the bash body to produce the baseline `triage.json` and Linear comment.
+
 2. Read the ticket back, refine the classification + scope estimate with model-quality judgement,
    and re-write `triage.json` if anything changed.
+
+**2b. Anchor a numeric estimate against the reference class (CTL-751).** Run:
+
+```bash
+bun "${REPO_ROOT}/plugins/pm/scripts/estimate/reference-class-lookup.ts" \
+  --corpus "${REPO_ROOT}/plugins/pm/scripts/estimate/reference-class-corpus.json" \
+  --title "<ticket title>" --json
+```
+
+where `REPO_ROOT` is the repo root (the worktree's checkout path, e.g. the directory containing
+`plugins/`). Parse `reference_class.points` from the JSON output. If the command succeeds and
+yields a points value in `{1, 3, 5, 8, 13}`, re-write `triage.json` adding
+`"estimate": <points>` alongside the existing `estimated_scope` field. If the lookup errors or
+returns no usable points value, leave `triage.json` without an `estimate` field — the coordinator
+then skips the Linear estimate write for this ticket (Q4 design decision: no SCOPE_POINTS
+fallback for the Linear estimate field). The bash body intentionally does **not** write `estimate`
+(CTL-558 guard).
+
 3. If the refined fields differ materially, post a follow-up `linearis issues discuss` comment
    marking the refinement.
 

--- a/plugins/pm/scripts/estimate/__tests__/adapt-reference-corpus.test.ts
+++ b/plugins/pm/scripts/estimate/__tests__/adapt-reference-corpus.test.ts
@@ -1,0 +1,114 @@
+// adapt-reference-corpus.test.ts — Phase 1 unit tests (CTL-751)
+// Run: bun test plugins/pm/scripts/estimate/__tests__/adapt-reference-corpus.test.ts
+import { describe, test, expect } from "bun:test";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { adaptCorpus } from "../adapt-reference-corpus.ts";
+import { loadCorpus } from "../reference-class-lookup.ts";
+
+const FIXTURE_FLAT = {
+  _meta: {
+    generated: "2026-01-01T00:00:00Z",
+    source_ticket: "CTL-746",
+    n_tickets: 3,
+  },
+  "CTL-10": {
+    ticket: "CTL-10",
+    actuals: { turns: 84, cost_usd: 30.0, wall_time_hours: 2.5, sessions: 1, tokens: {} },
+    git: { commits: 3, loc_added: 200, loc_deleted: 50, files_changed: 6 },
+    heuristic: { tshirt: "S", points: 3, loc_total: 250 },
+  },
+  "CTL-20": {
+    ticket: "CTL-20",
+    actuals: { turns: 200, cost_usd: 80.0, wall_time_hours: 8.0, sessions: 2, tokens: {} },
+    git: null,
+    heuristic: { tshirt: "M", points: 5, loc_total: null },
+  },
+  "CTL-99": {
+    ticket: "CTL-99",
+    actuals: { turns: 50, cost_usd: 10.0, wall_time_hours: 1.0, sessions: 1, tokens: {} },
+    git: null,
+    heuristic: { tshirt: "XS" },  // no points → should be dropped
+  },
+};
+
+describe("adaptCorpus", () => {
+  test("drops _meta and entries with no heuristic.points", () => {
+    const corpus = adaptCorpus(FIXTURE_FLAT);
+    expect(corpus.entries).toBeArray();
+    expect(corpus.entries).toHaveLength(2);
+    const ids = corpus.entries.map((e) => e.ticket_id);
+    expect(ids).toContain("CTL-10");
+    expect(ids).toContain("CTL-20");
+    expect(ids).not.toContain("CTL-99");
+    expect(ids).not.toContain("_meta");
+  });
+
+  test("git-bearing entry maps signals correctly", () => {
+    const corpus = adaptCorpus(FIXTURE_FLAT);
+    const e = corpus.entries.find((x) => x.ticket_id === "CTL-10")!;
+    expect(e).toBeDefined();
+    // loc = loc_added + loc_deleted
+    expect(e.signals.loc).toBe(250);
+    // changed_files from git.files_changed
+    expect(e.signals.changed_files).toBe(6);
+    // actuals key rename: wall_time_hours → wall_hours
+    expect(e.actuals.wall_hours).toBe(2.5);
+    expect((e.actuals as any).wall_time_hours).toBeUndefined();
+    // tshirt + points from heuristic
+    expect(e.tshirt).toBe("S");
+    expect(e.points).toBe(3);
+    // cost_usd + turns preserved
+    expect(e.actuals.cost_usd).toBe(30.0);
+    expect(e.actuals.turns).toBe(84);
+  });
+
+  test("git-less entry has null signals.loc and null signals.changed_files", () => {
+    const corpus = adaptCorpus(FIXTURE_FLAT);
+    const e = corpus.entries.find((x) => x.ticket_id === "CTL-20")!;
+    expect(e).toBeDefined();
+    expect(e.signals.loc).toBeNull();
+    expect(e.signals.changed_files).toBeNull();
+  });
+
+  test("every entry has all required keys", () => {
+    const corpus = adaptCorpus(FIXTURE_FLAT);
+    for (const e of corpus.entries) {
+      expect(typeof e.ticket_id).toBe("string");
+      expect(typeof e.title).toBe("string");
+      expect(e.signals).toBeDefined();
+      expect("loc" in e.signals).toBe(true);
+      expect("changed_files" in e.signals).toBe(true);
+      expect(Array.isArray(e.signals.domains)).toBe(true);
+      expect(typeof e.signals.has_migration).toBe("boolean");
+      expect(typeof e.signals.has_frontend).toBe("boolean");
+      expect(typeof e.signals.has_backend).toBe("boolean");
+      expect(e.actuals).toBeDefined();
+      expect("cost_usd" in e.actuals).toBe(true);
+      expect("turns" in e.actuals).toBe(true);
+      expect("wall_hours" in e.actuals).toBe(true);
+      expect(typeof e.tshirt).toBe("string");
+      expect(typeof e.points).toBe("number");
+    }
+  });
+
+  test("loadCorpus accepts the output (round-trip via tmp file)", () => {
+    const corpus = adaptCorpus(FIXTURE_FLAT);
+    const tmp = join(tmpdir(), `ctl-751-test-${Date.now()}.json`);
+    try {
+      writeFileSync(tmp, JSON.stringify(corpus, null, 2), "utf8");
+      const loaded = loadCorpus(tmp);
+      expect(loaded.entries).toHaveLength(corpus.entries.length);
+    } finally {
+      try { unlinkSync(tmp); } catch {}
+    }
+  });
+
+  test("output has schema, generated_at, count fields", () => {
+    const corpus = adaptCorpus(FIXTURE_FLAT, "2026-01-01T00:00:00Z");
+    expect(corpus.schema).toBe("catalyst.estimation.corpus.v1");
+    expect(corpus.generated_at).toBe("2026-01-01T00:00:00Z");
+    expect(corpus.count).toBe(2);
+  });
+});

--- a/plugins/pm/scripts/estimate/__tests__/lookup-corpus-integration.test.ts
+++ b/plugins/pm/scripts/estimate/__tests__/lookup-corpus-integration.test.ts
@@ -1,0 +1,25 @@
+// lookup-corpus-integration.test.ts — Phase 2 integration gate (CTL-751)
+// Verifies the committed reference-class-corpus.json is consumable and
+// returns a valid points value. Fails until Phase 1's corpus is committed.
+// Run: bun test plugins/pm/scripts/estimate/__tests__/lookup-corpus-integration.test.ts
+import { describe, test, expect } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const LOOKUP = resolve(import.meta.dir, "../reference-class-lookup.ts");
+const CORPUS = resolve(import.meta.dir, "../reference-class-corpus.json");
+
+describe("reference-class-lookup corpus integration", () => {
+  test("lookup exits 0 and returns a valid points value", () => {
+    const r = spawnSync(
+      "bun",
+      [LOOKUP, "--corpus", CORPUS, "--title", "wire estimate write-back into scheduler", "--json"],
+      { encoding: "utf8" }
+    );
+    expect(r.status).toBe(0);
+    const json = JSON.parse(r.stdout);
+    const points = json.reference_class?.points;
+    expect([1, 3, 5, 8, 13]).toContain(points);
+    expect(Array.isArray(json.neighbors)).toBe(true);
+  });
+});

--- a/plugins/pm/scripts/estimate/adapt-reference-corpus.ts
+++ b/plugins/pm/scripts/estimate/adapt-reference-corpus.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env bun
+/**
+ * adapt-reference-corpus.ts — transform the flat CTL-746 corpus into the
+ * entries[] schema that reference-class-lookup.ts loadCorpus() consumes.
+ *
+ * Usage (CLI):
+ *   bun adapt-reference-corpus.ts [--in <flat.json>] [--out <corpus.json>]
+ *
+ * Defaults:
+ *   --in  thoughts/shared/pm/analyses/reference-corpus.json
+ *   --out plugins/pm/scripts/estimate/reference-class-corpus.json
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Corpus, CorpusEntry, TShirt } from "./reference-class-lookup.ts";
+
+/** Transform a flat CTL-746 corpus dict into the loadCorpus() entries[] schema. */
+export function adaptCorpus(flat: Record<string, any>, generatedAt?: string): Corpus {
+  const entries: CorpusEntry[] = [];
+  const meta = flat._meta ?? {};
+  const ts = generatedAt ?? meta.generated ?? new Date(0).toISOString();
+
+  for (const [key, raw] of Object.entries(flat)) {
+    if (key === "_meta" || typeof raw !== "object" || raw === null) continue;
+    const points = raw.heuristic?.points;
+    if (typeof points !== "number") continue;
+
+    const git = raw.git ?? null;
+    const loc = git ? (raw.git.loc_added ?? 0) + (raw.git.loc_deleted ?? 0) : null;
+    const changedFiles = git ? (raw.git.files_changed ?? null) : null;
+    const actuals = raw.actuals ?? {};
+
+    entries.push({
+      ticket_id: raw.ticket ?? key,
+      title: "",
+      tier: null as unknown as number,
+      tshirt: (raw.heuristic.tshirt ?? "M") as TShirt,
+      points,
+      confidence: "low",
+      rationale: "reconstructed from CTL-746 actuals corpus",
+      signals: {
+        loc,
+        changed_files: changedFiles,
+        domains: [],
+        has_migration: false,
+        has_frontend: false,
+        has_backend: false,
+      },
+      actuals: {
+        cost_usd: actuals.cost_usd ?? null,
+        turns: actuals.turns ?? null,
+        wall_hours: actuals.wall_time_hours ?? null,
+      },
+    });
+  }
+
+  return {
+    generated_at: ts,
+    schema: "catalyst.estimation.corpus.v1",
+    count: entries.length,
+    entries,
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const getFlag = (f: string) => {
+    const i = args.indexOf(f);
+    return i !== -1 && i + 1 < args.length ? args[i + 1] : null;
+  };
+
+  const repoRoot = resolve(import.meta.dir, "../../../..");
+  const inPath = resolve(
+    getFlag("--in") ?? `${repoRoot}/thoughts/shared/pm/analyses/reference-corpus.json`
+  );
+  const outPath = resolve(
+    getFlag("--out") ??
+      `${import.meta.dir}/reference-class-corpus.json`
+  );
+
+  const flat = JSON.parse(readFileSync(inPath, "utf8"));
+  const corpus = adaptCorpus(flat, flat._meta?.generated);
+  writeFileSync(outPath, JSON.stringify(corpus, null, 2) + "\n", "utf8");
+  console.log(`wrote ${corpus.count} entries to ${outPath}`);
+}
+
+if (import.meta.main) {
+  main().catch((e) => { console.error(e); process.exit(1); });
+}

--- a/plugins/pm/scripts/estimate/reference-class-corpus.json
+++ b/plugins/pm/scripts/estimate/reference-class-corpus.json
@@ -1,0 +1,25219 @@
+{
+  "generated_at": "2026-06-02",
+  "schema": "catalyst.estimation.corpus.v1",
+  "count": 1146,
+  "entries": [
+    {
+      "ticket_id": "ADV-87",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 269.8456,
+        "turns": 508,
+        "wall_hours": 25.057
+      }
+    },
+    {
+      "ticket_id": "ADV-203",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 266.304942,
+        "turns": 899,
+        "wall_hours": 14.1261
+      }
+    },
+    {
+      "ticket_id": "ADV-204",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 24.078333,
+        "turns": 98,
+        "wall_hours": 0.263
+      }
+    },
+    {
+      "ticket_id": "ADV-208",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 35.213501,
+        "turns": 110,
+        "wall_hours": 0.2035
+      }
+    },
+    {
+      "ticket_id": "ADV-209",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 79.286372,
+        "turns": 236,
+        "wall_hours": 0.4591
+      }
+    },
+    {
+      "ticket_id": "ADV-210",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 20.956761,
+        "turns": 84,
+        "wall_hours": 0.1533
+      }
+    },
+    {
+      "ticket_id": "ADV-211",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 23.4982,
+        "turns": 84,
+        "wall_hours": 0.1505
+      }
+    },
+    {
+      "ticket_id": "ADV-212",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 27.084495,
+        "turns": 106,
+        "wall_hours": 0.2003
+      }
+    },
+    {
+      "ticket_id": "ADV-213",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 35.377821,
+        "turns": 126,
+        "wall_hours": 0.1887
+      }
+    },
+    {
+      "ticket_id": "ADV-214",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 63.770595,
+        "turns": 242,
+        "wall_hours": 0.2921
+      }
+    },
+    {
+      "ticket_id": "ADV-215",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 33.42285,
+        "turns": 112,
+        "wall_hours": 0.2472
+      }
+    },
+    {
+      "ticket_id": "ADV-216",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 43.597924,
+        "turns": 119,
+        "wall_hours": 0.25
+      }
+    },
+    {
+      "ticket_id": "ADV-217",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 33.252489,
+        "turns": 128,
+        "wall_hours": 0.2449
+      }
+    },
+    {
+      "ticket_id": "ADV-218",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 32.261094,
+        "turns": 121,
+        "wall_hours": 0.1772
+      }
+    },
+    {
+      "ticket_id": "ADV-219",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 43.702478,
+        "turns": 156,
+        "wall_hours": 0.5008
+      }
+    },
+    {
+      "ticket_id": "ADV-220",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.65875,
+        "turns": 182,
+        "wall_hours": 0.5078
+      }
+    },
+    {
+      "ticket_id": "ADV-221",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 28.105506,
+        "turns": 94,
+        "wall_hours": 0.1697
+      }
+    },
+    {
+      "ticket_id": "ADV-222",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 22.218816,
+        "turns": 76,
+        "wall_hours": 0.1115
+      }
+    },
+    {
+      "ticket_id": "ADV-223",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 29.741583,
+        "turns": 112,
+        "wall_hours": 0.2365
+      }
+    },
+    {
+      "ticket_id": "ADV-224",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 96.336349,
+        "turns": 294,
+        "wall_hours": 0.5068
+      }
+    },
+    {
+      "ticket_id": "ADV-225",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 43.913638,
+        "turns": 139,
+        "wall_hours": 0.3276
+      }
+    },
+    {
+      "ticket_id": "ADV-226",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 40.348441,
+        "turns": 136,
+        "wall_hours": 0.3366
+      }
+    },
+    {
+      "ticket_id": "ADV-227",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 37.947504,
+        "turns": 135,
+        "wall_hours": 0.321
+      }
+    },
+    {
+      "ticket_id": "ADV-228",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 65.642416,
+        "turns": 248,
+        "wall_hours": 0.4049
+      }
+    },
+    {
+      "ticket_id": "ADV-229",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 56.960506,
+        "turns": 201,
+        "wall_hours": 0.8796
+      }
+    },
+    {
+      "ticket_id": "ADV-230",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 22.059828,
+        "turns": 81,
+        "wall_hours": 0.9966
+      }
+    },
+    {
+      "ticket_id": "ADV-231",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 52.451852,
+        "turns": 177,
+        "wall_hours": 0.787
+      }
+    },
+    {
+      "ticket_id": "ADV-232",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 85.200283,
+        "turns": 346,
+        "wall_hours": 1.1355
+      }
+    },
+    {
+      "ticket_id": "ADV-233",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 41.787207,
+        "turns": 155,
+        "wall_hours": 0.3612
+      }
+    },
+    {
+      "ticket_id": "ADV-234",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 24.353437,
+        "turns": 97,
+        "wall_hours": 0.2081
+      }
+    },
+    {
+      "ticket_id": "ADV-236",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 41.396605,
+        "turns": 128,
+        "wall_hours": 0.8054
+      }
+    },
+    {
+      "ticket_id": "ADV-237",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 41.298339,
+        "turns": 149,
+        "wall_hours": 0.2982
+      }
+    },
+    {
+      "ticket_id": "ADV-238",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 36.726033,
+        "turns": 143,
+        "wall_hours": 0.5776
+      }
+    },
+    {
+      "ticket_id": "ADV-239",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 46.712664,
+        "turns": 171,
+        "wall_hours": 0.3493
+      }
+    },
+    {
+      "ticket_id": "ADV-240",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 157.721704,
+        "turns": 313,
+        "wall_hours": 162.8372
+      }
+    },
+    {
+      "ticket_id": "ADV-241",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 104.628828,
+        "turns": 276,
+        "wall_hours": 72.2062
+      }
+    },
+    {
+      "ticket_id": "ADV-243",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 205.620369,
+        "turns": 506,
+        "wall_hours": 8.9988
+      }
+    },
+    {
+      "ticket_id": "ADV-244",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 270.978944,
+        "turns": 838,
+        "wall_hours": 55.9504
+      }
+    },
+    {
+      "ticket_id": "ADV-247",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 152.285741,
+        "turns": 397,
+        "wall_hours": 50.7703
+      }
+    },
+    {
+      "ticket_id": "ADV-248",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 86.949302,
+        "turns": 227,
+        "wall_hours": 71.204
+      }
+    },
+    {
+      "ticket_id": "ADV-250",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 60.800407,
+        "turns": 136,
+        "wall_hours": 19.2534
+      }
+    },
+    {
+      "ticket_id": "ADV-252",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 29.535456,
+        "turns": 93,
+        "wall_hours": 23.8271
+      }
+    },
+    {
+      "ticket_id": "ADV-253",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 23.557512,
+        "turns": 79,
+        "wall_hours": 0.1806
+      }
+    },
+    {
+      "ticket_id": "ADV-254",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 77.175488,
+        "turns": 229,
+        "wall_hours": 0.4159
+      }
+    },
+    {
+      "ticket_id": "ADV-255",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 30.110832,
+        "turns": 101,
+        "wall_hours": 0.2586
+      }
+    },
+    {
+      "ticket_id": "ADV-257",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 66.256287,
+        "turns": 264,
+        "wall_hours": 0.4217
+      }
+    },
+    {
+      "ticket_id": "ADV-258",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 71.522501,
+        "turns": 241,
+        "wall_hours": 0.3555
+      }
+    },
+    {
+      "ticket_id": "ADV-259",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 46.78212,
+        "turns": 156,
+        "wall_hours": 0.3659
+      }
+    },
+    {
+      "ticket_id": "ADV-260",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 30.102434,
+        "turns": 89,
+        "wall_hours": 0.1428
+      }
+    },
+    {
+      "ticket_id": "ADV-262",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 652.591365,
+        "turns": 1453,
+        "wall_hours": 128.3478
+      }
+    },
+    {
+      "ticket_id": "ADV-266",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 72.266343,
+        "turns": 189,
+        "wall_hours": 0.4645
+      }
+    },
+    {
+      "ticket_id": "ADV-268",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 51.263328,
+        "turns": 154,
+        "wall_hours": 22.401
+      }
+    },
+    {
+      "ticket_id": "ADV-274",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 109.99342,
+        "turns": 260,
+        "wall_hours": 1.6869
+      }
+    },
+    {
+      "ticket_id": "ADV-285",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 25.259478,
+        "turns": 67,
+        "wall_hours": 4.2089
+      }
+    },
+    {
+      "ticket_id": "ADV-287",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 89.295018,
+        "turns": 266,
+        "wall_hours": 0.6125
+      }
+    },
+    {
+      "ticket_id": "ADV-288",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 102.449241,
+        "turns": 244,
+        "wall_hours": 0.858
+      }
+    },
+    {
+      "ticket_id": "ADV-289",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 131.895943,
+        "turns": 366,
+        "wall_hours": 0.8839
+      }
+    },
+    {
+      "ticket_id": "ADV-290",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 100.790769,
+        "turns": 222,
+        "wall_hours": 0.6134
+      }
+    },
+    {
+      "ticket_id": "ADV-291",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 66.803254,
+        "turns": 163,
+        "wall_hours": 0.4069
+      }
+    },
+    {
+      "ticket_id": "ADV-292",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 58.711242,
+        "turns": 158,
+        "wall_hours": 0.4095
+      }
+    },
+    {
+      "ticket_id": "ADV-293",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 159.722754,
+        "turns": 340,
+        "wall_hours": 1.21
+      }
+    },
+    {
+      "ticket_id": "ADV-296",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 131.443906,
+        "turns": 302,
+        "wall_hours": 1.7577
+      }
+    },
+    {
+      "ticket_id": "ADV-297",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 58.152059,
+        "turns": 176,
+        "wall_hours": 0.9436
+      }
+    },
+    {
+      "ticket_id": "ADV-298",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 83.786757,
+        "turns": 198,
+        "wall_hours": 0.4762
+      }
+    },
+    {
+      "ticket_id": "ADV-299",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 39.88474,
+        "turns": 144,
+        "wall_hours": 0.2542
+      }
+    },
+    {
+      "ticket_id": "ADV-300",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 47.087198,
+        "turns": 57,
+        "wall_hours": 0.3232
+      }
+    },
+    {
+      "ticket_id": "ADV-301",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 133.640271,
+        "turns": 235,
+        "wall_hours": 12.4577
+      }
+    },
+    {
+      "ticket_id": "ADV-302",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 49.597943,
+        "turns": 139,
+        "wall_hours": 0.2344
+      }
+    },
+    {
+      "ticket_id": "ADV-303",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 44.634222,
+        "turns": 143,
+        "wall_hours": 0.2951
+      }
+    },
+    {
+      "ticket_id": "ADV-304",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 51.352505,
+        "turns": 143,
+        "wall_hours": 0.6289
+      }
+    },
+    {
+      "ticket_id": "ADV-305",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 60.876339,
+        "turns": 144,
+        "wall_hours": 0.3317
+      }
+    },
+    {
+      "ticket_id": "ADV-307",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 73.219894,
+        "turns": 213,
+        "wall_hours": 0.4711
+      }
+    },
+    {
+      "ticket_id": "ADV-308",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 115.238121,
+        "turns": 315,
+        "wall_hours": 0.5915
+      }
+    },
+    {
+      "ticket_id": "ADV-309",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 78.624906,
+        "turns": 174,
+        "wall_hours": 0.4939
+      }
+    },
+    {
+      "ticket_id": "ADV-311",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 83.122313,
+        "turns": 126,
+        "wall_hours": 14.7095
+      }
+    },
+    {
+      "ticket_id": "ADV-325",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 56.965188,
+        "turns": 197,
+        "wall_hours": 0.3971
+      }
+    },
+    {
+      "ticket_id": "ADV-326",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 33.971691,
+        "turns": 93,
+        "wall_hours": 0.3336
+      }
+    },
+    {
+      "ticket_id": "ADV-327",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 66.895424,
+        "turns": 195,
+        "wall_hours": 32.9424
+      }
+    },
+    {
+      "ticket_id": "ADV-329",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 78.702717,
+        "turns": 194,
+        "wall_hours": 0.4677
+      }
+    },
+    {
+      "ticket_id": "ADV-330",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 142.272069,
+        "turns": 454,
+        "wall_hours": 0.7035
+      }
+    },
+    {
+      "ticket_id": "ADV-331",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 46.441644,
+        "turns": 129,
+        "wall_hours": 0.2894
+      }
+    },
+    {
+      "ticket_id": "ADV-333",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 54.975969,
+        "turns": 174,
+        "wall_hours": 0.5227
+      }
+    },
+    {
+      "ticket_id": "ADV-334",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 27.053976,
+        "turns": 51,
+        "wall_hours": 0.1915
+      }
+    },
+    {
+      "ticket_id": "ADV-335",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 287.852478,
+        "turns": 807,
+        "wall_hours": 21.2274
+      }
+    },
+    {
+      "ticket_id": "ADV-336",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 33.590973,
+        "turns": 95,
+        "wall_hours": 33.354
+      }
+    },
+    {
+      "ticket_id": "ADV-344",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 74.220905,
+        "turns": 173,
+        "wall_hours": 0.4661
+      }
+    },
+    {
+      "ticket_id": "ADV-345",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 48.266965,
+        "turns": 95,
+        "wall_hours": 0.3178
+      }
+    },
+    {
+      "ticket_id": "ADV-346",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 99.182812,
+        "turns": 139,
+        "wall_hours": 0.6524
+      }
+    },
+    {
+      "ticket_id": "ADV-347",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 51.942135,
+        "turns": 90,
+        "wall_hours": 0.371
+      }
+    },
+    {
+      "ticket_id": "ADV-348",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 75.964239,
+        "turns": 111,
+        "wall_hours": 0.3461
+      }
+    },
+    {
+      "ticket_id": "ADV-349",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 117.001365,
+        "turns": 217,
+        "wall_hours": 1.6831
+      }
+    },
+    {
+      "ticket_id": "ADV-350",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 189.611273,
+        "turns": 261,
+        "wall_hours": 2.6381
+      }
+    },
+    {
+      "ticket_id": "ADV-351",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 118.283223,
+        "turns": 173,
+        "wall_hours": 1.4325
+      }
+    },
+    {
+      "ticket_id": "ADV-352",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 87.211192,
+        "turns": 182,
+        "wall_hours": 0.4226
+      }
+    },
+    {
+      "ticket_id": "ADV-353",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 96.845215,
+        "turns": 247,
+        "wall_hours": 1.4392
+      }
+    },
+    {
+      "ticket_id": "ADV-354",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 44.98668,
+        "turns": 169,
+        "wall_hours": 0.3156
+      }
+    },
+    {
+      "ticket_id": "ADV-355",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 70.312269,
+        "turns": 268,
+        "wall_hours": 0.6996
+      }
+    },
+    {
+      "ticket_id": "ADV-356",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 41.645709,
+        "turns": 131,
+        "wall_hours": 0.3014
+      }
+    },
+    {
+      "ticket_id": "ADV-357",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 60.221127,
+        "turns": 211,
+        "wall_hours": 0.4398
+      }
+    },
+    {
+      "ticket_id": "ADV-359",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 39.218178,
+        "turns": 131,
+        "wall_hours": 0.2636
+      }
+    },
+    {
+      "ticket_id": "ADV-361",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 48.425714,
+        "turns": 162,
+        "wall_hours": 7.2404
+      }
+    },
+    {
+      "ticket_id": "ADV-365",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 56.958902,
+        "turns": 189,
+        "wall_hours": 7.2167
+      }
+    },
+    {
+      "ticket_id": "ADV-367",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 28.030089,
+        "turns": 64,
+        "wall_hours": 0.1348
+      }
+    },
+    {
+      "ticket_id": "ADV-369",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 26.804762,
+        "turns": 57,
+        "wall_hours": 0.2666
+      }
+    },
+    {
+      "ticket_id": "ADV-370",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 40.264145,
+        "turns": 141,
+        "wall_hours": 7.2186
+      }
+    },
+    {
+      "ticket_id": "ADV-372",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 56.847174,
+        "turns": 203,
+        "wall_hours": 0.437
+      }
+    },
+    {
+      "ticket_id": "ADV-377",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 39.028369,
+        "turns": 117,
+        "wall_hours": 0.2395
+      }
+    },
+    {
+      "ticket_id": "ADV-378",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 26.274079,
+        "turns": 54,
+        "wall_hours": 0.3793
+      }
+    },
+    {
+      "ticket_id": "ADV-379",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 24.345748,
+        "turns": 52,
+        "wall_hours": 0.1598
+      }
+    },
+    {
+      "ticket_id": "ADV-380",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 28.6599,
+        "turns": 75,
+        "wall_hours": 0.1701
+      }
+    },
+    {
+      "ticket_id": "ADV-381",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 36.52482,
+        "turns": 113,
+        "wall_hours": 0.1931
+      }
+    },
+    {
+      "ticket_id": "ADV-382",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 38.607655,
+        "turns": 140,
+        "wall_hours": 0.2258
+      }
+    },
+    {
+      "ticket_id": "ADV-383",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 48.049582,
+        "turns": 132,
+        "wall_hours": 0.1906
+      }
+    },
+    {
+      "ticket_id": "ADV-384",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 180.190062,
+        "turns": 371,
+        "wall_hours": 2.4758
+      }
+    },
+    {
+      "ticket_id": "ADV-385",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 116.895965,
+        "turns": 285,
+        "wall_hours": 13.7004
+      }
+    },
+    {
+      "ticket_id": "ADV-386",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 65.21932,
+        "turns": 146,
+        "wall_hours": 0.3106
+      }
+    },
+    {
+      "ticket_id": "ADV-387",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 104.934396,
+        "turns": 216,
+        "wall_hours": 1.6672
+      }
+    },
+    {
+      "ticket_id": "ADV-388",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 59.767665,
+        "turns": 176,
+        "wall_hours": 0.3462
+      }
+    },
+    {
+      "ticket_id": "ADV-389",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 154.144868,
+        "turns": 277,
+        "wall_hours": 0.8671
+      }
+    },
+    {
+      "ticket_id": "ADV-392",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 5.407881,
+        "turns": 119,
+        "wall_hours": 3.849
+      }
+    },
+    {
+      "ticket_id": "ADV-393",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 35.706817,
+        "turns": 144,
+        "wall_hours": 6.2047
+      }
+    },
+    {
+      "ticket_id": "ADV-394",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 35.359191,
+        "turns": 92,
+        "wall_hours": 0.1792
+      }
+    },
+    {
+      "ticket_id": "ADV-395",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 49.950727,
+        "turns": 189,
+        "wall_hours": 0.4659
+      }
+    },
+    {
+      "ticket_id": "ADV-396",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 13.833021,
+        "turns": 12,
+        "wall_hours": 0.3976
+      }
+    },
+    {
+      "ticket_id": "ADV-399",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 81.090473,
+        "turns": 206,
+        "wall_hours": 0.4313
+      }
+    },
+    {
+      "ticket_id": "ADV-400",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 50.947445,
+        "turns": 154,
+        "wall_hours": 0.2695
+      }
+    },
+    {
+      "ticket_id": "ADV-401",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 160.131205,
+        "turns": 246,
+        "wall_hours": 0.7195
+      }
+    },
+    {
+      "ticket_id": "ADV-402",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 158.94555,
+        "turns": 281,
+        "wall_hours": 0.7289
+      }
+    },
+    {
+      "ticket_id": "ADV-403",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 104.153907,
+        "turns": 187,
+        "wall_hours": 0.7012
+      }
+    },
+    {
+      "ticket_id": "ADV-404",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 121.804304,
+        "turns": 199,
+        "wall_hours": 0.7907
+      }
+    },
+    {
+      "ticket_id": "ADV-405",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 50.809563,
+        "turns": 136,
+        "wall_hours": 0.3516
+      }
+    },
+    {
+      "ticket_id": "ADV-406",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 302.630061,
+        "turns": 531,
+        "wall_hours": 1.0313
+      }
+    },
+    {
+      "ticket_id": "ADV-409",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 56.395229,
+        "turns": 149,
+        "wall_hours": 0.2605
+      }
+    },
+    {
+      "ticket_id": "ADV-410",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 16.742127,
+        "turns": 67,
+        "wall_hours": 0.1142
+      }
+    },
+    {
+      "ticket_id": "ADV-411",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 98.675661,
+        "turns": 119,
+        "wall_hours": 0.3435
+      }
+    },
+    {
+      "ticket_id": "ADV-412",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 79.900727,
+        "turns": 143,
+        "wall_hours": 0.5114
+      }
+    },
+    {
+      "ticket_id": "ADV-413",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.253918,
+        "turns": 161,
+        "wall_hours": 0.336
+      }
+    },
+    {
+      "ticket_id": "ADV-418",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 101.470659,
+        "turns": 227,
+        "wall_hours": 4.1144
+      }
+    },
+    {
+      "ticket_id": "ADV-419",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.491579,
+        "turns": 177,
+        "wall_hours": 0.3179
+      }
+    },
+    {
+      "ticket_id": "ADV-421",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 44.340216,
+        "turns": 94,
+        "wall_hours": 0.189
+      }
+    },
+    {
+      "ticket_id": "ADV-422",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 51.816057,
+        "turns": 140,
+        "wall_hours": 1.5576
+      }
+    },
+    {
+      "ticket_id": "ADV-423",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 66.427521,
+        "turns": 217,
+        "wall_hours": 0.8129
+      }
+    },
+    {
+      "ticket_id": "ADV-424",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 8.827209,
+        "turns": 129,
+        "wall_hours": 0.3118
+      }
+    },
+    {
+      "ticket_id": "ADV-429",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 112.038399,
+        "turns": 301,
+        "wall_hours": 0.6134
+      }
+    },
+    {
+      "ticket_id": "ADV-432",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 45.543965,
+        "turns": 100,
+        "wall_hours": 0.1814
+      }
+    },
+    {
+      "ticket_id": "ADV-433",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 76.651681,
+        "turns": 210,
+        "wall_hours": 0.3824
+      }
+    },
+    {
+      "ticket_id": "ADV-436",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 112.033862,
+        "turns": 214,
+        "wall_hours": 0.404
+      }
+    },
+    {
+      "ticket_id": "ADV-437",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 80.786875,
+        "turns": 148,
+        "wall_hours": 0.4531
+      }
+    },
+    {
+      "ticket_id": "ADV-438",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 56.370728,
+        "turns": 120,
+        "wall_hours": 0.5323
+      }
+    },
+    {
+      "ticket_id": "ADV-439",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.724103,
+        "turns": 130,
+        "wall_hours": 0.1948
+      }
+    },
+    {
+      "ticket_id": "ADV-444",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 51.587898,
+        "turns": 120,
+        "wall_hours": 0.2399
+      }
+    },
+    {
+      "ticket_id": "ADV-449",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 15.40679,
+        "turns": 71,
+        "wall_hours": 0.2036
+      }
+    },
+    {
+      "ticket_id": "ADV-450",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 64.745726,
+        "turns": 258,
+        "wall_hours": 0.4605
+      }
+    },
+    {
+      "ticket_id": "ADV-451",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 111.91137,
+        "turns": 412,
+        "wall_hours": 1.073
+      }
+    },
+    {
+      "ticket_id": "ADV-452",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 49.493271,
+        "turns": 197,
+        "wall_hours": 0.9938
+      }
+    },
+    {
+      "ticket_id": "ADV-454",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 130.872014,
+        "turns": 215,
+        "wall_hours": 23.2994
+      }
+    },
+    {
+      "ticket_id": "ADV-457",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 28.557088,
+        "turns": 103,
+        "wall_hours": 0.217
+      }
+    },
+    {
+      "ticket_id": "ADV-458",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 46.627152,
+        "turns": 126,
+        "wall_hours": 0.2573
+      }
+    },
+    {
+      "ticket_id": "ADV-459",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 59.988732,
+        "turns": 211,
+        "wall_hours": 0.9293
+      }
+    },
+    {
+      "ticket_id": "ADV-462",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 68.622588,
+        "turns": 160,
+        "wall_hours": 0.2486
+      }
+    },
+    {
+      "ticket_id": "ADV-463",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 88.393292,
+        "turns": 212,
+        "wall_hours": 0.5179
+      }
+    },
+    {
+      "ticket_id": "ADV-464",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 45.529086,
+        "turns": 105,
+        "wall_hours": 0.2536
+      }
+    },
+    {
+      "ticket_id": "ADV-465",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 37.759569,
+        "turns": 96,
+        "wall_hours": 0.1755
+      }
+    },
+    {
+      "ticket_id": "ADV-466",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 111.531201,
+        "turns": 279,
+        "wall_hours": 0.6055
+      }
+    },
+    {
+      "ticket_id": "ADV-467",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 84.298632,
+        "turns": 195,
+        "wall_hours": 0.3448
+      }
+    },
+    {
+      "ticket_id": "ADV-468",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 59.352726,
+        "turns": 137,
+        "wall_hours": 0.2099
+      }
+    },
+    {
+      "ticket_id": "ADV-469",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 63.670429,
+        "turns": 189,
+        "wall_hours": 0.2458
+      }
+    },
+    {
+      "ticket_id": "ADV-470",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 85.568577,
+        "turns": 155,
+        "wall_hours": 0.2715
+      }
+    },
+    {
+      "ticket_id": "ADV-471",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 136.895778,
+        "turns": 260,
+        "wall_hours": 0.6099
+      }
+    },
+    {
+      "ticket_id": "ADV-472",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 207.31935,
+        "turns": 343,
+        "wall_hours": 0.6966
+      }
+    },
+    {
+      "ticket_id": "ADV-473",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 77.190336,
+        "turns": 186,
+        "wall_hours": 0.5255
+      }
+    },
+    {
+      "ticket_id": "ADV-474",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 53.08231,
+        "turns": 98,
+        "wall_hours": 0.5208
+      }
+    },
+    {
+      "ticket_id": "ADV-475",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 75.061125,
+        "turns": 95,
+        "wall_hours": 0.5476
+      }
+    },
+    {
+      "ticket_id": "ADV-477",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 66.128997,
+        "turns": 170,
+        "wall_hours": 5.1872
+      }
+    },
+    {
+      "ticket_id": "ADV-478",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 121.779541,
+        "turns": 271,
+        "wall_hours": 0.4836
+      }
+    },
+    {
+      "ticket_id": "ADV-480",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 96.021257,
+        "turns": 160,
+        "wall_hours": 0.7862
+      }
+    },
+    {
+      "ticket_id": "ADV-481",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 118.784967,
+        "turns": 184,
+        "wall_hours": 0.8249
+      }
+    },
+    {
+      "ticket_id": "ADV-482",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 118.720949,
+        "turns": 212,
+        "wall_hours": 0.8125
+      }
+    },
+    {
+      "ticket_id": "ADV-486",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 31.114791,
+        "turns": 65,
+        "wall_hours": 0.1639
+      }
+    },
+    {
+      "ticket_id": "ADV-487",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 37.084088,
+        "turns": 99,
+        "wall_hours": 0.2503
+      }
+    },
+    {
+      "ticket_id": "ADV-488",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 42.826886,
+        "turns": 190,
+        "wall_hours": 0.3447
+      }
+    },
+    {
+      "ticket_id": "ADV-492",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 58.477978,
+        "turns": 247,
+        "wall_hours": 19.3351
+      }
+    },
+    {
+      "ticket_id": "ADV-493",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 49.626905,
+        "turns": 154,
+        "wall_hours": 19.3348
+      }
+    },
+    {
+      "ticket_id": "ADV-494",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 23.870804,
+        "turns": 84,
+        "wall_hours": 0.1603
+      }
+    },
+    {
+      "ticket_id": "ADV-496",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 63.2425,
+        "turns": 239,
+        "wall_hours": 7.8349
+      }
+    },
+    {
+      "ticket_id": "ADV-497",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 143.543091,
+        "turns": 574,
+        "wall_hours": 2.9795
+      }
+    },
+    {
+      "ticket_id": "ADV-498",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 30.527818,
+        "turns": 107,
+        "wall_hours": 0.2411
+      }
+    },
+    {
+      "ticket_id": "ADV-499",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 40.922038,
+        "turns": 146,
+        "wall_hours": 0.2776
+      }
+    },
+    {
+      "ticket_id": "ADV-500",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 39.665205,
+        "turns": 129,
+        "wall_hours": 0.2606
+      }
+    },
+    {
+      "ticket_id": "ADV-501",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 39.56264,
+        "turns": 149,
+        "wall_hours": 0.2394
+      }
+    },
+    {
+      "ticket_id": "ADV-502",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 40.008687,
+        "turns": 140,
+        "wall_hours": 0.2741
+      }
+    },
+    {
+      "ticket_id": "ADV-503",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 49.284135,
+        "turns": 140,
+        "wall_hours": 0.3178
+      }
+    },
+    {
+      "ticket_id": "ADV-504",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 43.501523,
+        "turns": 141,
+        "wall_hours": 0.2877
+      }
+    },
+    {
+      "ticket_id": "ADV-505",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 78.018907,
+        "turns": 124,
+        "wall_hours": 0.2929
+      }
+    },
+    {
+      "ticket_id": "ADV-506",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 35.986723,
+        "turns": 119,
+        "wall_hours": 0.2645
+      }
+    },
+    {
+      "ticket_id": "ADV-507",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 74.332763,
+        "turns": 162,
+        "wall_hours": 0.4357
+      }
+    },
+    {
+      "ticket_id": "ADV-508",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 54.084004,
+        "turns": 186,
+        "wall_hours": 0.331
+      }
+    },
+    {
+      "ticket_id": "ADV-509",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 46.165144,
+        "turns": 159,
+        "wall_hours": 0.3711
+      }
+    },
+    {
+      "ticket_id": "ADV-510",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 69.76951,
+        "turns": 259,
+        "wall_hours": 0.4515
+      }
+    },
+    {
+      "ticket_id": "ADV-511",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 25.358024,
+        "turns": 118,
+        "wall_hours": 0.2422
+      }
+    },
+    {
+      "ticket_id": "ADV-512",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 100.825408,
+        "turns": 201,
+        "wall_hours": 0.4343
+      }
+    },
+    {
+      "ticket_id": "ADV-519",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 43.448271,
+        "turns": 117,
+        "wall_hours": 0.164
+      }
+    },
+    {
+      "ticket_id": "ADV-520",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 55.391082,
+        "turns": 181,
+        "wall_hours": 0.2493
+      }
+    },
+    {
+      "ticket_id": "ADV-521",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 153.411774,
+        "turns": 294,
+        "wall_hours": 0.5873
+      }
+    },
+    {
+      "ticket_id": "ADV-522",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 18.824264,
+        "turns": 72,
+        "wall_hours": 0.0868
+      }
+    },
+    {
+      "ticket_id": "ADV-523",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 29.009121,
+        "turns": 87,
+        "wall_hours": 0.1474
+      }
+    },
+    {
+      "ticket_id": "ADV-525",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 14.275983,
+        "turns": 59,
+        "wall_hours": 5.0038
+      }
+    },
+    {
+      "ticket_id": "ADV-526",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 28.128998,
+        "turns": 104,
+        "wall_hours": 5.84
+      }
+    },
+    {
+      "ticket_id": "ADV-553",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 37.603024,
+        "turns": 153,
+        "wall_hours": 0.2374
+      }
+    },
+    {
+      "ticket_id": "ADV-557",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 15.053169,
+        "turns": 279,
+        "wall_hours": 0.3872
+      }
+    },
+    {
+      "ticket_id": "ADV-558",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 16.385881,
+        "turns": 323,
+        "wall_hours": 0.6816
+      }
+    },
+    {
+      "ticket_id": "ADV-559",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 12.169869,
+        "turns": 228,
+        "wall_hours": 0.5135
+      }
+    },
+    {
+      "ticket_id": "ADV-560",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 10.177785,
+        "turns": 200,
+        "wall_hours": 0.4673
+      }
+    },
+    {
+      "ticket_id": "ADV-561",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 8.748948,
+        "turns": 163,
+        "wall_hours": 0.3075
+      }
+    },
+    {
+      "ticket_id": "ADV-562",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 16.611608,
+        "turns": 318,
+        "wall_hours": 0.5257
+      }
+    },
+    {
+      "ticket_id": "ADV-571",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 18.679091,
+        "turns": 84,
+        "wall_hours": 0.5836
+      }
+    },
+    {
+      "ticket_id": "ADV-607",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 17.412841,
+        "turns": 236,
+        "wall_hours": 0.3562
+      }
+    },
+    {
+      "ticket_id": "ADV-608",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 5.944699,
+        "turns": 101,
+        "wall_hours": 0.1728
+      }
+    },
+    {
+      "ticket_id": "ADV-609",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 24.983583,
+        "turns": 231,
+        "wall_hours": 80.6301
+      }
+    },
+    {
+      "ticket_id": "ADV-618",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 15.405699,
+        "turns": 286,
+        "wall_hours": 1.4363
+      }
+    },
+    {
+      "ticket_id": "ADV-619",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 5.169641,
+        "turns": 143,
+        "wall_hours": 1.2497
+      }
+    },
+    {
+      "ticket_id": "ADV-620",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 127.594647,
+        "turns": 525,
+        "wall_hours": 0.7286
+      }
+    },
+    {
+      "ticket_id": "ADV-621",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 207.067866,
+        "turns": 636,
+        "wall_hours": 0.6964
+      }
+    },
+    {
+      "ticket_id": "ADV-622",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 127.180796,
+        "turns": 510,
+        "wall_hours": 0.8013
+      }
+    },
+    {
+      "ticket_id": "ADV-623",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 124.055403,
+        "turns": 419,
+        "wall_hours": 0.6941
+      }
+    },
+    {
+      "ticket_id": "ADV-624",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 20.169579,
+        "turns": 63,
+        "wall_hours": 0.0516
+      }
+    },
+    {
+      "ticket_id": "ADV-625",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 40.377659,
+        "turns": 155,
+        "wall_hours": 0.1635
+      }
+    },
+    {
+      "ticket_id": "ADV-627",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 40.522473,
+        "turns": 173,
+        "wall_hours": 0.2645
+      }
+    },
+    {
+      "ticket_id": "ADV-628",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 20.398142,
+        "turns": 236,
+        "wall_hours": 76.2486
+      }
+    },
+    {
+      "ticket_id": "ADV-631",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 10.227383,
+        "turns": 226,
+        "wall_hours": 0.2781
+      }
+    },
+    {
+      "ticket_id": "ADV-633",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 51.15502,
+        "turns": 226,
+        "wall_hours": 0.5408
+      }
+    },
+    {
+      "ticket_id": "ADV-634",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 116.335302,
+        "turns": 379,
+        "wall_hours": 0.6959
+      }
+    },
+    {
+      "ticket_id": "ADV-635",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 139.608306,
+        "turns": 588,
+        "wall_hours": 18.9508
+      }
+    },
+    {
+      "ticket_id": "ADV-638",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 84.690318,
+        "turns": 333,
+        "wall_hours": 1.0477
+      }
+    },
+    {
+      "ticket_id": "ADV-639",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 42.851801,
+        "turns": 148,
+        "wall_hours": 0.2361
+      }
+    },
+    {
+      "ticket_id": "ADV-641",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 89.693793,
+        "turns": 375,
+        "wall_hours": 0.6035
+      }
+    },
+    {
+      "ticket_id": "ADV-645",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 121.930271,
+        "turns": 428,
+        "wall_hours": 0.7919
+      }
+    },
+    {
+      "ticket_id": "ADV-646",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 123.261055,
+        "turns": 289,
+        "wall_hours": 0.7023
+      }
+    },
+    {
+      "ticket_id": "ADV-647",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 75.76758,
+        "turns": 306,
+        "wall_hours": 4.3375
+      }
+    },
+    {
+      "ticket_id": "ADV-648",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 78.198883,
+        "turns": 243,
+        "wall_hours": 12.7414
+      }
+    },
+    {
+      "ticket_id": "ADV-649",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 183.275937,
+        "turns": 367,
+        "wall_hours": 0.4486
+      }
+    },
+    {
+      "ticket_id": "ADV-650",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 166.899294,
+        "turns": 321,
+        "wall_hours": 0.4969
+      }
+    },
+    {
+      "ticket_id": "ADV-651",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 89.422479,
+        "turns": 253,
+        "wall_hours": 20.6175
+      }
+    },
+    {
+      "ticket_id": "ADV-652",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 598.251135,
+        "turns": 1665,
+        "wall_hours": 27.5575
+      }
+    },
+    {
+      "ticket_id": "ADV-653",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 66.020663,
+        "turns": 246,
+        "wall_hours": 0.7223
+      }
+    },
+    {
+      "ticket_id": "ADV-655",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 124.391532,
+        "turns": 208,
+        "wall_hours": 6.1093
+      }
+    },
+    {
+      "ticket_id": "ADV-659",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 29.170876,
+        "turns": 114,
+        "wall_hours": 0.4387
+      }
+    },
+    {
+      "ticket_id": "ADV-660",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 92.063,
+        "turns": 188,
+        "wall_hours": 0.5164
+      }
+    },
+    {
+      "ticket_id": "ADV-661",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 52.616499,
+        "turns": 126,
+        "wall_hours": 0.325
+      }
+    },
+    {
+      "ticket_id": "ADV-662",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 204.138587,
+        "turns": 379,
+        "wall_hours": 0.996
+      }
+    },
+    {
+      "ticket_id": "ADV-663",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 93.276094,
+        "turns": 225,
+        "wall_hours": 0.4
+      }
+    },
+    {
+      "ticket_id": "ADV-664",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 76.033742,
+        "turns": 187,
+        "wall_hours": 0.4329
+      }
+    },
+    {
+      "ticket_id": "ADV-665",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 46.249119,
+        "turns": 153,
+        "wall_hours": 0.5787
+      }
+    },
+    {
+      "ticket_id": "ADV-666",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 103.931412,
+        "turns": 203,
+        "wall_hours": 0.4189
+      }
+    },
+    {
+      "ticket_id": "ADV-667",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 97.077171,
+        "turns": 210,
+        "wall_hours": 0.5313
+      }
+    },
+    {
+      "ticket_id": "ADV-668",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 174.203732,
+        "turns": 321,
+        "wall_hours": 0.7474
+      }
+    },
+    {
+      "ticket_id": "ADV-669",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 77.001552,
+        "turns": 179,
+        "wall_hours": 0.3272
+      }
+    },
+    {
+      "ticket_id": "ADV-670",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 26.311143,
+        "turns": 110,
+        "wall_hours": 10.9505
+      }
+    },
+    {
+      "ticket_id": "ADV-671",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 151.406126,
+        "turns": 584,
+        "wall_hours": 5.5649
+      }
+    },
+    {
+      "ticket_id": "ADV-672",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 105.378393,
+        "turns": 194,
+        "wall_hours": 0.286
+      }
+    },
+    {
+      "ticket_id": "ADV-673",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 167.346907,
+        "turns": 285,
+        "wall_hours": 0.4609
+      }
+    },
+    {
+      "ticket_id": "ADV-674",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 87.185552,
+        "turns": 318,
+        "wall_hours": 3.4526
+      }
+    },
+    {
+      "ticket_id": "ADV-675",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 99.662419,
+        "turns": 416,
+        "wall_hours": 2.2339
+      }
+    },
+    {
+      "ticket_id": "ADV-681",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 77.73405,
+        "turns": 113,
+        "wall_hours": 0.2396
+      }
+    },
+    {
+      "ticket_id": "ADV-683",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 164.590993,
+        "turns": 305,
+        "wall_hours": 0.5337
+      }
+    },
+    {
+      "ticket_id": "ADV-684",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 80.714131,
+        "turns": 193,
+        "wall_hours": 0.353
+      }
+    },
+    {
+      "ticket_id": "ADV-685",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 93.191233,
+        "turns": 217,
+        "wall_hours": 0.3461
+      }
+    },
+    {
+      "ticket_id": "ADV-686",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 78.155575,
+        "turns": 174,
+        "wall_hours": 0.2978
+      }
+    },
+    {
+      "ticket_id": "ADV-688",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 442.136664,
+        "turns": 672,
+        "wall_hours": 36.8331
+      }
+    },
+    {
+      "ticket_id": "ADV-689",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 45.568131,
+        "turns": 135,
+        "wall_hours": 0.1574
+      }
+    },
+    {
+      "ticket_id": "ADV-690",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 65.409033,
+        "turns": 168,
+        "wall_hours": 0.2867
+      }
+    },
+    {
+      "ticket_id": "ADV-691",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 39.752758,
+        "turns": 106,
+        "wall_hours": 0.2181
+      }
+    },
+    {
+      "ticket_id": "ADV-693",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 18.888281,
+        "turns": 21,
+        "wall_hours": 0.0236
+      }
+    },
+    {
+      "ticket_id": "ADV-694",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 31.706424,
+        "turns": 53,
+        "wall_hours": 0.0666
+      }
+    },
+    {
+      "ticket_id": "ADV-695",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 82.056817,
+        "turns": 185,
+        "wall_hours": 3.0029
+      }
+    },
+    {
+      "ticket_id": "ADV-696",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 65.495739,
+        "turns": 169,
+        "wall_hours": 0.2938
+      }
+    },
+    {
+      "ticket_id": "ADV-697",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 60.442323,
+        "turns": 151,
+        "wall_hours": 0.1881
+      }
+    },
+    {
+      "ticket_id": "ADV-698",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 59.257353,
+        "turns": 173,
+        "wall_hours": 0.317
+      }
+    },
+    {
+      "ticket_id": "ADV-699",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 33.810696,
+        "turns": 85,
+        "wall_hours": 0.0914
+      }
+    },
+    {
+      "ticket_id": "ADV-700",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 75.735232,
+        "turns": 167,
+        "wall_hours": 2.8378
+      }
+    },
+    {
+      "ticket_id": "ADV-701",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 85.098945,
+        "turns": 180,
+        "wall_hours": 0.4411
+      }
+    },
+    {
+      "ticket_id": "ADV-702",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 74.817888,
+        "turns": 183,
+        "wall_hours": 1.0824
+      }
+    },
+    {
+      "ticket_id": "ADV-703",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 58.487131,
+        "turns": 112,
+        "wall_hours": 0.1546
+      }
+    },
+    {
+      "ticket_id": "ADV-704",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 90.820729,
+        "turns": 222,
+        "wall_hours": 0.3535
+      }
+    },
+    {
+      "ticket_id": "ADV-705",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 74.537654,
+        "turns": 169,
+        "wall_hours": 0.3337
+      }
+    },
+    {
+      "ticket_id": "ADV-706",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 100.26216,
+        "turns": 223,
+        "wall_hours": 0.7039
+      }
+    },
+    {
+      "ticket_id": "ADV-707",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 171.782531,
+        "turns": 423,
+        "wall_hours": 0.8739
+      }
+    },
+    {
+      "ticket_id": "ADV-708",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 122.635997,
+        "turns": 319,
+        "wall_hours": 1.4253
+      }
+    },
+    {
+      "ticket_id": "ADV-709",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 39.278891,
+        "turns": 92,
+        "wall_hours": 0.1807
+      }
+    },
+    {
+      "ticket_id": "ADV-710",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 115.302271,
+        "turns": 355,
+        "wall_hours": 17.9779
+      }
+    },
+    {
+      "ticket_id": "ADV-712",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 28.114825,
+        "turns": 94,
+        "wall_hours": 0.1348
+      }
+    },
+    {
+      "ticket_id": "ADV-714",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 158.266476,
+        "turns": 241,
+        "wall_hours": 0.509
+      }
+    },
+    {
+      "ticket_id": "ADV-715",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 253.457054,
+        "turns": 380,
+        "wall_hours": 0.9128
+      }
+    },
+    {
+      "ticket_id": "ADV-717",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 89.194986,
+        "turns": 241,
+        "wall_hours": 1.8501
+      }
+    },
+    {
+      "ticket_id": "ADV-718",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 140.492894,
+        "turns": 302,
+        "wall_hours": 15.6889
+      }
+    },
+    {
+      "ticket_id": "ADV-724",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 102.539188,
+        "turns": 202,
+        "wall_hours": 0.3649
+      }
+    },
+    {
+      "ticket_id": "ADV-725",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 96.691914,
+        "turns": 228,
+        "wall_hours": 1.1839
+      }
+    },
+    {
+      "ticket_id": "ADV-726",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 90.116271,
+        "turns": 259,
+        "wall_hours": 1.2425
+      }
+    },
+    {
+      "ticket_id": "ADV-727",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 52.497339,
+        "turns": 174,
+        "wall_hours": 0.918
+      }
+    },
+    {
+      "ticket_id": "ADV-728",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 103.947618,
+        "turns": 148,
+        "wall_hours": 0.3028
+      }
+    },
+    {
+      "ticket_id": "ADV-729",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 76.170089,
+        "turns": 228,
+        "wall_hours": 1.4391
+      }
+    },
+    {
+      "ticket_id": "ADV-730",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 97.351308,
+        "turns": 271,
+        "wall_hours": 0.5755
+      }
+    },
+    {
+      "ticket_id": "ADV-731",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 60.683326,
+        "turns": 115,
+        "wall_hours": 3.9914
+      }
+    },
+    {
+      "ticket_id": "ADV-733",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 137.910065,
+        "turns": 315,
+        "wall_hours": 0.9819
+      }
+    },
+    {
+      "ticket_id": "ADV-734",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 231.819423,
+        "turns": 468,
+        "wall_hours": 1.3241
+      }
+    },
+    {
+      "ticket_id": "ADV-735",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 143.638174,
+        "turns": 330,
+        "wall_hours": 62.0439
+      }
+    },
+    {
+      "ticket_id": "ADV-736",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 7.44415,
+        "turns": 164,
+        "wall_hours": 0.2811
+      }
+    },
+    {
+      "ticket_id": "ADV-737",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 145.287789,
+        "turns": 340,
+        "wall_hours": 1.9329
+      }
+    },
+    {
+      "ticket_id": "ADV-738",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 24.357981,
+        "turns": 235,
+        "wall_hours": 0.949
+      }
+    },
+    {
+      "ticket_id": "ADV-739",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 8.451539,
+        "turns": 151,
+        "wall_hours": 2.5068
+      }
+    },
+    {
+      "ticket_id": "ADV-740",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 34.19696,
+        "turns": 380,
+        "wall_hours": 1.858
+      }
+    },
+    {
+      "ticket_id": "ADV-741",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 134.220077,
+        "turns": 262,
+        "wall_hours": 0.4641
+      }
+    },
+    {
+      "ticket_id": "ADV-744",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 7.625366,
+        "turns": 148,
+        "wall_hours": 0.7123
+      }
+    },
+    {
+      "ticket_id": "ADV-749",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 7.107287,
+        "turns": 150,
+        "wall_hours": 0.3757
+      }
+    },
+    {
+      "ticket_id": "ADV-750",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.867367,
+        "turns": 150,
+        "wall_hours": 0.3944
+      }
+    },
+    {
+      "ticket_id": "ADV-751",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.800216,
+        "turns": 100,
+        "wall_hours": 0.2072
+      }
+    },
+    {
+      "ticket_id": "ADV-752",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 26.374294,
+        "turns": 321,
+        "wall_hours": 2.0296
+      }
+    },
+    {
+      "ticket_id": "ADV-754",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 11.948153,
+        "turns": 211,
+        "wall_hours": 1.2294
+      }
+    },
+    {
+      "ticket_id": "ADV-755",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 24.727901,
+        "turns": 377,
+        "wall_hours": 5.2962
+      }
+    },
+    {
+      "ticket_id": "ADV-758",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 8.132813,
+        "turns": 181,
+        "wall_hours": 3.9051
+      }
+    },
+    {
+      "ticket_id": "ADV-759",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 5.027911,
+        "turns": 104,
+        "wall_hours": 0.1435
+      }
+    },
+    {
+      "ticket_id": "ADV-760",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 7.407827,
+        "turns": 150,
+        "wall_hours": 0.2467
+      }
+    },
+    {
+      "ticket_id": "ADV-761",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.333497,
+        "turns": 111,
+        "wall_hours": 0.1975
+      }
+    },
+    {
+      "ticket_id": "ADV-763",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 60.00533,
+        "turns": 314,
+        "wall_hours": 1.8225
+      }
+    },
+    {
+      "ticket_id": "ADV-764",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 23.268938,
+        "turns": 436,
+        "wall_hours": 4.1869
+      }
+    },
+    {
+      "ticket_id": "ADV-765",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 45.196179,
+        "turns": 850,
+        "wall_hours": 23.3062
+      }
+    },
+    {
+      "ticket_id": "ADV-767",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.843705,
+        "turns": 130,
+        "wall_hours": 0.2332
+      }
+    },
+    {
+      "ticket_id": "ADV-768",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 8.293399,
+        "turns": 160,
+        "wall_hours": 0.2614
+      }
+    },
+    {
+      "ticket_id": "ADV-769",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 14.432868,
+        "turns": 275,
+        "wall_hours": 1.7815
+      }
+    },
+    {
+      "ticket_id": "ADV-770",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 17.184983,
+        "turns": 283,
+        "wall_hours": 20.8156
+      }
+    },
+    {
+      "ticket_id": "ADV-772",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 149.616763,
+        "turns": 275,
+        "wall_hours": 0.6399
+      }
+    },
+    {
+      "ticket_id": "ADV-775",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 155.190121,
+        "turns": 1136,
+        "wall_hours": 8.7403
+      }
+    },
+    {
+      "ticket_id": "ADV-779",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 183.558558,
+        "turns": 388,
+        "wall_hours": 0.9872
+      }
+    },
+    {
+      "ticket_id": "ADV-782",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 233.109575,
+        "turns": 1207,
+        "wall_hours": 7.9399
+      }
+    },
+    {
+      "ticket_id": "ADV-783",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 186.559879,
+        "turns": 1142,
+        "wall_hours": 8.561
+      }
+    },
+    {
+      "ticket_id": "ADV-787",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 174.264717,
+        "turns": 479,
+        "wall_hours": 3.4835
+      }
+    },
+    {
+      "ticket_id": "ADV-788",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 134.072415,
+        "turns": 256,
+        "wall_hours": 0.4737
+      }
+    },
+    {
+      "ticket_id": "ADV-793",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 227.346016,
+        "turns": 739,
+        "wall_hours": 16.1706
+      }
+    },
+    {
+      "ticket_id": "ADV-798",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 99.183618,
+        "turns": 317,
+        "wall_hours": 3.0137
+      }
+    },
+    {
+      "ticket_id": "ADV-799",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 258.190138,
+        "turns": 1225,
+        "wall_hours": 8.8514
+      }
+    },
+    {
+      "ticket_id": "ADV-801",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 72.684342,
+        "turns": 138,
+        "wall_hours": 1.0793
+      }
+    },
+    {
+      "ticket_id": "ADV-802",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 37.991032,
+        "turns": 165,
+        "wall_hours": 0.6942
+      }
+    },
+    {
+      "ticket_id": "ADV-805",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 295.475507,
+        "turns": 1377,
+        "wall_hours": 8.305
+      }
+    },
+    {
+      "ticket_id": "ADV-806",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 103.033004,
+        "turns": 246,
+        "wall_hours": 1.5123
+      }
+    },
+    {
+      "ticket_id": "ADV-807",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 113.59734,
+        "turns": 212,
+        "wall_hours": 0.6122
+      }
+    },
+    {
+      "ticket_id": "ADV-808",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 143.465133,
+        "turns": 690,
+        "wall_hours": 0.8789
+      }
+    },
+    {
+      "ticket_id": "ADV-809",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 167.365647,
+        "turns": 1268,
+        "wall_hours": 8.3422
+      }
+    },
+    {
+      "ticket_id": "ADV-810",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 205.641426,
+        "turns": 728,
+        "wall_hours": 11.1459
+      }
+    },
+    {
+      "ticket_id": "ADV-811",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 89.719245,
+        "turns": 202,
+        "wall_hours": 0.4654
+      }
+    },
+    {
+      "ticket_id": "ADV-812",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 333.442964,
+        "turns": 570,
+        "wall_hours": 0.774
+      }
+    },
+    {
+      "ticket_id": "ADV-814",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 159.145761,
+        "turns": 236,
+        "wall_hours": 0.6935
+      }
+    },
+    {
+      "ticket_id": "ADV-816",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 125.918177,
+        "turns": 278,
+        "wall_hours": 57.5511
+      }
+    },
+    {
+      "ticket_id": "ADV-817",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 107.570994,
+        "turns": 271,
+        "wall_hours": 0.6537
+      }
+    },
+    {
+      "ticket_id": "ADV-818",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 173.506821,
+        "turns": 308,
+        "wall_hours": 0.8786
+      }
+    },
+    {
+      "ticket_id": "ADV-819",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 172.2024,
+        "turns": 277,
+        "wall_hours": 1.2248
+      }
+    },
+    {
+      "ticket_id": "ADV-820",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 87.687721,
+        "turns": 203,
+        "wall_hours": 0.8017
+      }
+    },
+    {
+      "ticket_id": "ADV-821",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 69.770415,
+        "turns": 159,
+        "wall_hours": 0.4015
+      }
+    },
+    {
+      "ticket_id": "ADV-822",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 125.795618,
+        "turns": 234,
+        "wall_hours": 0.918
+      }
+    },
+    {
+      "ticket_id": "ADV-825",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 86.263799,
+        "turns": 624,
+        "wall_hours": 0.6823
+      }
+    },
+    {
+      "ticket_id": "ADV-826",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 8.823403,
+        "turns": 139,
+        "wall_hours": 0.7497
+      }
+    },
+    {
+      "ticket_id": "ADV-827",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 124.505098,
+        "turns": 233,
+        "wall_hours": 1.3252
+      }
+    },
+    {
+      "ticket_id": "ADV-829",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 5.623869,
+        "turns": 102,
+        "wall_hours": 0.2296
+      }
+    },
+    {
+      "ticket_id": "ADV-830",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 196.722141,
+        "turns": 805,
+        "wall_hours": 12.2315
+      }
+    },
+    {
+      "ticket_id": "ADV-832",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 10.706978,
+        "turns": 233,
+        "wall_hours": 0.662
+      }
+    },
+    {
+      "ticket_id": "ADV-834",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 12.970885,
+        "turns": 249,
+        "wall_hours": 2.9919
+      }
+    },
+    {
+      "ticket_id": "ADV-835",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 17.069626,
+        "turns": 333,
+        "wall_hours": 1.4766
+      }
+    },
+    {
+      "ticket_id": "ADV-836",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 64.214517,
+        "turns": 132,
+        "wall_hours": 0.319
+      }
+    },
+    {
+      "ticket_id": "ADV-837",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 143.055204,
+        "turns": 308,
+        "wall_hours": 0.6775
+      }
+    },
+    {
+      "ticket_id": "ADV-838",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 155.270727,
+        "turns": 271,
+        "wall_hours": 0.6642
+      }
+    },
+    {
+      "ticket_id": "ADV-843",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 19.630932,
+        "turns": 41,
+        "wall_hours": 0.3126
+      }
+    },
+    {
+      "ticket_id": "ADV-845",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 141.105852,
+        "turns": 274,
+        "wall_hours": 0.7427
+      }
+    },
+    {
+      "ticket_id": "ADV-846",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 125.525694,
+        "turns": 265,
+        "wall_hours": 0.9822
+      }
+    },
+    {
+      "ticket_id": "ADV-847",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 152.235252,
+        "turns": 331,
+        "wall_hours": 1.119
+      }
+    },
+    {
+      "ticket_id": "ADV-849",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 108.609452,
+        "turns": 451,
+        "wall_hours": 1.2752
+      }
+    },
+    {
+      "ticket_id": "ADV-850",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 227.734825,
+        "turns": 618,
+        "wall_hours": 1.8819
+      }
+    },
+    {
+      "ticket_id": "ADV-851",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 7.919571,
+        "turns": 157,
+        "wall_hours": 1.2174
+      }
+    },
+    {
+      "ticket_id": "ADV-852",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 11.758631,
+        "turns": 187,
+        "wall_hours": 0.4419
+      }
+    },
+    {
+      "ticket_id": "ADV-853",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 11.180579,
+        "turns": 177,
+        "wall_hours": 1.1928
+      }
+    },
+    {
+      "ticket_id": "ADV-854",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 12.996793,
+        "turns": 257,
+        "wall_hours": 0.4707
+      }
+    },
+    {
+      "ticket_id": "ADV-855",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 3.918038,
+        "turns": 100,
+        "wall_hours": 0.5214
+      }
+    },
+    {
+      "ticket_id": "ADV-858",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 10.849835,
+        "turns": 212,
+        "wall_hours": 5.8129
+      }
+    },
+    {
+      "ticket_id": "ADV-859",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 30.260793,
+        "turns": 483,
+        "wall_hours": 17.8036
+      }
+    },
+    {
+      "ticket_id": "ADV-861",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 776.074011,
+        "turns": 1361,
+        "wall_hours": 25.9517
+      }
+    },
+    {
+      "ticket_id": "ADV-862",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 89.787586,
+        "turns": 191,
+        "wall_hours": 0.6991
+      }
+    },
+    {
+      "ticket_id": "ADV-864",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 99.840277,
+        "turns": 193,
+        "wall_hours": 0.6449
+      }
+    },
+    {
+      "ticket_id": "ADV-865",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 77.963502,
+        "turns": 148,
+        "wall_hours": 0.584
+      }
+    },
+    {
+      "ticket_id": "ADV-866",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 161.069784,
+        "turns": 255,
+        "wall_hours": 3.9153
+      }
+    },
+    {
+      "ticket_id": "ADV-868",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 139.589019,
+        "turns": 273,
+        "wall_hours": 0.6759
+      }
+    },
+    {
+      "ticket_id": "ADV-869",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 157.777275,
+        "turns": 268,
+        "wall_hours": 9.4945
+      }
+    },
+    {
+      "ticket_id": "ADV-870",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 75.212413,
+        "turns": 172,
+        "wall_hours": 0.4624
+      }
+    },
+    {
+      "ticket_id": "ADV-871",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 66.450694,
+        "turns": 153,
+        "wall_hours": 9.7755
+      }
+    },
+    {
+      "ticket_id": "ADV-873",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 81.458886,
+        "turns": 175,
+        "wall_hours": 0.3525
+      }
+    },
+    {
+      "ticket_id": "ADV-875",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 86.470146,
+        "turns": 147,
+        "wall_hours": 95.1113
+      }
+    },
+    {
+      "ticket_id": "ADV-876",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 48.803565,
+        "turns": 118,
+        "wall_hours": 0.202
+      }
+    },
+    {
+      "ticket_id": "ADV-877",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 123.997742,
+        "turns": 271,
+        "wall_hours": 90.5099
+      }
+    },
+    {
+      "ticket_id": "ADV-878",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 153.122834,
+        "turns": 316,
+        "wall_hours": 1.0325
+      }
+    },
+    {
+      "ticket_id": "ADV-879",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 219.075738,
+        "turns": 318,
+        "wall_hours": 28.9976
+      }
+    },
+    {
+      "ticket_id": "ADV-880",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.948105,
+        "turns": 101,
+        "wall_hours": 0.1627
+      }
+    },
+    {
+      "ticket_id": "ADV-881",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 243.612055,
+        "turns": 400,
+        "wall_hours": 1.0141
+      }
+    },
+    {
+      "ticket_id": "ADV-882",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 326.832884,
+        "turns": 915,
+        "wall_hours": 15.9114
+      }
+    },
+    {
+      "ticket_id": "ADV-884",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 119.575136,
+        "turns": 202,
+        "wall_hours": 2.0307
+      }
+    },
+    {
+      "ticket_id": "ADV-885",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 100.15649,
+        "turns": 172,
+        "wall_hours": 1.5105
+      }
+    },
+    {
+      "ticket_id": "ADV-887",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 31.992323,
+        "turns": 87,
+        "wall_hours": 0.1228
+      }
+    },
+    {
+      "ticket_id": "ADV-888",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 40.033555,
+        "turns": 121,
+        "wall_hours": 0.3128
+      }
+    },
+    {
+      "ticket_id": "ADV-889",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 242.981841,
+        "turns": 1152,
+        "wall_hours": 8.027
+      }
+    },
+    {
+      "ticket_id": "ADV-890",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 121.948401,
+        "turns": 230,
+        "wall_hours": 0.4729
+      }
+    },
+    {
+      "ticket_id": "ADV-891",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 135.446181,
+        "turns": 281,
+        "wall_hours": 0.4449
+      }
+    },
+    {
+      "ticket_id": "ADV-892",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 115.07183,
+        "turns": 281,
+        "wall_hours": 4.1415
+      }
+    },
+    {
+      "ticket_id": "ADV-893",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 109.747158,
+        "turns": 224,
+        "wall_hours": 15.1458
+      }
+    },
+    {
+      "ticket_id": "ADV-894",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 66.663795,
+        "turns": 141,
+        "wall_hours": 0.436
+      }
+    },
+    {
+      "ticket_id": "ADV-895",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 77.571014,
+        "turns": 175,
+        "wall_hours": 0.3918
+      }
+    },
+    {
+      "ticket_id": "ADV-896",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 149.679171,
+        "turns": 321,
+        "wall_hours": 7.1224
+      }
+    },
+    {
+      "ticket_id": "ADV-897",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 208.472064,
+        "turns": 375,
+        "wall_hours": 27.6667
+      }
+    },
+    {
+      "ticket_id": "ADV-898",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 58.75917,
+        "turns": 146,
+        "wall_hours": 1.6002
+      }
+    },
+    {
+      "ticket_id": "ADV-899",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 268.562981,
+        "turns": 449,
+        "wall_hours": 13.6017
+      }
+    },
+    {
+      "ticket_id": "ADV-900",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 47.209843,
+        "turns": 144,
+        "wall_hours": 2.3028
+      }
+    },
+    {
+      "ticket_id": "ADV-901",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 60.208797,
+        "turns": 167,
+        "wall_hours": 0.339
+      }
+    },
+    {
+      "ticket_id": "ADV-902",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 94.639948,
+        "turns": 219,
+        "wall_hours": 0.4258
+      }
+    },
+    {
+      "ticket_id": "ADV-903",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 94.301057,
+        "turns": 167,
+        "wall_hours": 0.5586
+      }
+    },
+    {
+      "ticket_id": "ADV-904",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 79.792304,
+        "turns": 186,
+        "wall_hours": 1.4842
+      }
+    },
+    {
+      "ticket_id": "ADV-905",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 73.332737,
+        "turns": 153,
+        "wall_hours": 1.1362
+      }
+    },
+    {
+      "ticket_id": "ADV-906",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 70.694033,
+        "turns": 146,
+        "wall_hours": 0.3047
+      }
+    },
+    {
+      "ticket_id": "ADV-907",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 123.914529,
+        "turns": 226,
+        "wall_hours": 0.6979
+      }
+    },
+    {
+      "ticket_id": "ADV-908",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 105.813616,
+        "turns": 205,
+        "wall_hours": 0.5155
+      }
+    },
+    {
+      "ticket_id": "ADV-909",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 321.887286,
+        "turns": 522,
+        "wall_hours": 1.5257
+      }
+    },
+    {
+      "ticket_id": "ADV-910",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 80.12563,
+        "turns": 179,
+        "wall_hours": 1.6682
+      }
+    },
+    {
+      "ticket_id": "ADV-913",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 180.090144,
+        "turns": 368,
+        "wall_hours": 0.6664
+      }
+    },
+    {
+      "ticket_id": "ADV-914",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 248.192119,
+        "turns": 456,
+        "wall_hours": 1.0333
+      }
+    },
+    {
+      "ticket_id": "ADV-915",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 72.143238,
+        "turns": 158,
+        "wall_hours": 0.3868
+      }
+    },
+    {
+      "ticket_id": "ADV-916",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 62.794646,
+        "turns": 124,
+        "wall_hours": 0.5927
+      }
+    },
+    {
+      "ticket_id": "ADV-917",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 107.338068,
+        "turns": 180,
+        "wall_hours": 0.7125
+      }
+    },
+    {
+      "ticket_id": "ADV-918",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 181.945666,
+        "turns": 327,
+        "wall_hours": 1.3932
+      }
+    },
+    {
+      "ticket_id": "ADV-919",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 143.255338,
+        "turns": 269,
+        "wall_hours": 0.7233
+      }
+    },
+    {
+      "ticket_id": "ADV-920",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 325.361788,
+        "turns": 489,
+        "wall_hours": 4.0574
+      }
+    },
+    {
+      "ticket_id": "ADV-921",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 237.563645,
+        "turns": 398,
+        "wall_hours": 2.4828
+      }
+    },
+    {
+      "ticket_id": "ADV-922",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 72.847566,
+        "turns": 143,
+        "wall_hours": 3.8338
+      }
+    },
+    {
+      "ticket_id": "ADV-923",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 184.842907,
+        "turns": 329,
+        "wall_hours": 0.8189
+      }
+    },
+    {
+      "ticket_id": "ADV-925",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 95.230983,
+        "turns": 219,
+        "wall_hours": 0.5285
+      }
+    },
+    {
+      "ticket_id": "ADV-926",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 69.352525,
+        "turns": 185,
+        "wall_hours": 0.5359
+      }
+    },
+    {
+      "ticket_id": "ADV-927",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 137.186173,
+        "turns": 257,
+        "wall_hours": 1.6209
+      }
+    },
+    {
+      "ticket_id": "ADV-928",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 35.478609,
+        "turns": 93,
+        "wall_hours": 0.9334
+      }
+    },
+    {
+      "ticket_id": "ADV-929",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 181.613934,
+        "turns": 535,
+        "wall_hours": 3.3488
+      }
+    },
+    {
+      "ticket_id": "ADV-931",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 101.9685,
+        "turns": 167,
+        "wall_hours": 0.4662
+      }
+    },
+    {
+      "ticket_id": "ADV-932",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 105.807706,
+        "turns": 230,
+        "wall_hours": 7.3197
+      }
+    },
+    {
+      "ticket_id": "ADV-933",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 45.252617,
+        "turns": 67,
+        "wall_hours": 0.1592
+      }
+    },
+    {
+      "ticket_id": "ADV-937",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 63.491444,
+        "turns": 157,
+        "wall_hours": 6.5252
+      }
+    },
+    {
+      "ticket_id": "ADV-938",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 194.212782,
+        "turns": 354,
+        "wall_hours": 1.0735
+      }
+    },
+    {
+      "ticket_id": "ADV-939",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 120.394706,
+        "turns": 260,
+        "wall_hours": 0.7804
+      }
+    },
+    {
+      "ticket_id": "ADV-944",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 113.665803,
+        "turns": 269,
+        "wall_hours": 2.826
+      }
+    },
+    {
+      "ticket_id": "ADV-946",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 122.751056,
+        "turns": 220,
+        "wall_hours": 0.868
+      }
+    },
+    {
+      "ticket_id": "ADV-947",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 37.379089,
+        "turns": 57,
+        "wall_hours": 0.1851
+      }
+    },
+    {
+      "ticket_id": "ADV-948",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 144.934571,
+        "turns": 276,
+        "wall_hours": 0.679
+      }
+    },
+    {
+      "ticket_id": "ADV-949",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 13.847132,
+        "turns": 318,
+        "wall_hours": 0.7403
+      }
+    },
+    {
+      "ticket_id": "ADV-950",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 135.490942,
+        "turns": 271,
+        "wall_hours": 1.083
+      }
+    },
+    {
+      "ticket_id": "ADV-951",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 68.299013,
+        "turns": 143,
+        "wall_hours": 2.842
+      }
+    },
+    {
+      "ticket_id": "ADV-952",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 147.696233,
+        "turns": 440,
+        "wall_hours": 4.4172
+      }
+    },
+    {
+      "ticket_id": "ADV-953",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.168747,
+        "turns": 119,
+        "wall_hours": 0.2884
+      }
+    },
+    {
+      "ticket_id": "ADV-954",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 70.338914,
+        "turns": 91,
+        "wall_hours": 0.3406
+      }
+    },
+    {
+      "ticket_id": "ADV-955",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 7.732701,
+        "turns": 138,
+        "wall_hours": 8.5851
+      }
+    },
+    {
+      "ticket_id": "ADV-956",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 12.1513,
+        "turns": 182,
+        "wall_hours": 6.159
+      }
+    },
+    {
+      "ticket_id": "ADV-957",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 9.485625,
+        "turns": 191,
+        "wall_hours": 0.4282
+      }
+    },
+    {
+      "ticket_id": "ADV-958",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 11.080242,
+        "turns": 209,
+        "wall_hours": 0.5258
+      }
+    },
+    {
+      "ticket_id": "ADV-959",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.14977,
+        "turns": 143,
+        "wall_hours": 0.2827
+      }
+    },
+    {
+      "ticket_id": "ADV-960",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 3.165942,
+        "turns": 78,
+        "wall_hours": 0.2785
+      }
+    },
+    {
+      "ticket_id": "ADV-973",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 173.869788,
+        "turns": 446,
+        "wall_hours": 3.2241
+      }
+    },
+    {
+      "ticket_id": "ADV-974",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 10.647024,
+        "turns": 169,
+        "wall_hours": 0.3829
+      }
+    },
+    {
+      "ticket_id": "ADV-975",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 8.997416,
+        "turns": 176,
+        "wall_hours": 0.5945
+      }
+    },
+    {
+      "ticket_id": "ADV-976",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 19.204171,
+        "turns": 358,
+        "wall_hours": 0.6971
+      }
+    },
+    {
+      "ticket_id": "ADV-977",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 13.125515,
+        "turns": 260,
+        "wall_hours": 0.7163
+      }
+    },
+    {
+      "ticket_id": "ADV-978",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 23.341618,
+        "turns": 431,
+        "wall_hours": 0.9412
+      }
+    },
+    {
+      "ticket_id": "ADV-979",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 56.228175,
+        "turns": 189,
+        "wall_hours": 2.8361
+      }
+    },
+    {
+      "ticket_id": "ADV-981",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 17.176676,
+        "turns": 297,
+        "wall_hours": 0.5082
+      }
+    },
+    {
+      "ticket_id": "ADV-982",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 9.481776,
+        "turns": 167,
+        "wall_hours": 9.6904
+      }
+    },
+    {
+      "ticket_id": "ADV-985",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 9.069164,
+        "turns": 180,
+        "wall_hours": 15.9077
+      }
+    },
+    {
+      "ticket_id": "ADV-986",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.059246,
+        "turns": 135,
+        "wall_hours": 0.3114
+      }
+    },
+    {
+      "ticket_id": "ADV-987",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 8.031962,
+        "turns": 135,
+        "wall_hours": 0.4136
+      }
+    },
+    {
+      "ticket_id": "ADV-988",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 32.650245,
+        "turns": 182,
+        "wall_hours": 1.1212
+      }
+    },
+    {
+      "ticket_id": "ADV-989",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 34.952021,
+        "turns": 331,
+        "wall_hours": 1.1553
+      }
+    },
+    {
+      "ticket_id": "ADV-991",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.5484,
+        "turns": 128,
+        "wall_hours": 2.6919
+      }
+    },
+    {
+      "ticket_id": "ADV-993",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 78.21401,
+        "turns": 511,
+        "wall_hours": 2.0544
+      }
+    },
+    {
+      "ticket_id": "ADV-994",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 97.503093,
+        "turns": 178,
+        "wall_hours": 0.6492
+      }
+    },
+    {
+      "ticket_id": "ADV-995",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 101.700005,
+        "turns": 177,
+        "wall_hours": 0.4512
+      }
+    },
+    {
+      "ticket_id": "ADV-996",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 108.087753,
+        "turns": 202,
+        "wall_hours": 0.7763
+      }
+    },
+    {
+      "ticket_id": "ADV-997",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 212.162454,
+        "turns": 280,
+        "wall_hours": 0.6032
+      }
+    },
+    {
+      "ticket_id": "ADV-998",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 243.060318,
+        "turns": 380,
+        "wall_hours": 3.5925
+      }
+    },
+    {
+      "ticket_id": "ADV-999",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 87.637776,
+        "turns": 123,
+        "wall_hours": 0.4075
+      }
+    },
+    {
+      "ticket_id": "ADV-1000",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 138.809316,
+        "turns": 268,
+        "wall_hours": 3.4726
+      }
+    },
+    {
+      "ticket_id": "ADV-1001",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 215.841371,
+        "turns": 314,
+        "wall_hours": 4.3736
+      }
+    },
+    {
+      "ticket_id": "ADV-1002",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 113.335669,
+        "turns": 234,
+        "wall_hours": 0.4136
+      }
+    },
+    {
+      "ticket_id": "ADV-1003",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 158.106844,
+        "turns": 189,
+        "wall_hours": 0.6363
+      }
+    },
+    {
+      "ticket_id": "ADV-1004",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 133.453808,
+        "turns": 243,
+        "wall_hours": 0.6499
+      }
+    },
+    {
+      "ticket_id": "ADV-1005",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 109.276482,
+        "turns": 207,
+        "wall_hours": 0.5533
+      }
+    },
+    {
+      "ticket_id": "ADV-1006",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 99.483068,
+        "turns": 187,
+        "wall_hours": 14.1707
+      }
+    },
+    {
+      "ticket_id": "ADV-1007",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 10.584402,
+        "turns": 192,
+        "wall_hours": 0.5289
+      }
+    },
+    {
+      "ticket_id": "ADV-1008",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 585.564439,
+        "turns": 807,
+        "wall_hours": 58.7664
+      }
+    },
+    {
+      "ticket_id": "ADV-1009",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 41.385922,
+        "turns": 133,
+        "wall_hours": 1.1182
+      }
+    },
+    {
+      "ticket_id": "ADV-1014",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 66.531456,
+        "turns": 131,
+        "wall_hours": 0.2759
+      }
+    },
+    {
+      "ticket_id": "ADV-1015",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 78.886736,
+        "turns": 165,
+        "wall_hours": 0.3287
+      }
+    },
+    {
+      "ticket_id": "ADV-1017",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 144.426186,
+        "turns": 375,
+        "wall_hours": 6.3728
+      }
+    },
+    {
+      "ticket_id": "ADV-1018",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 262.902197,
+        "turns": 1373,
+        "wall_hours": 8.1489
+      }
+    },
+    {
+      "ticket_id": "ADV-1019",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 10.446893,
+        "turns": 174,
+        "wall_hours": 0.887
+      }
+    },
+    {
+      "ticket_id": "ADV-1020",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 28.550073,
+        "turns": 485,
+        "wall_hours": 9.9045
+      }
+    },
+    {
+      "ticket_id": "ADV-1021",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 14.552138,
+        "turns": 240,
+        "wall_hours": 1.1199
+      }
+    },
+    {
+      "ticket_id": "ADV-1022",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 65.784964,
+        "turns": 407,
+        "wall_hours": 158.6184
+      }
+    },
+    {
+      "ticket_id": "ADV-1025",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 121.744758,
+        "turns": 238,
+        "wall_hours": 0.5007
+      }
+    },
+    {
+      "ticket_id": "ADV-1026",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 72.229073,
+        "turns": 101,
+        "wall_hours": 0.3387
+      }
+    },
+    {
+      "ticket_id": "ADV-1027",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 1747.844283,
+        "turns": 2584,
+        "wall_hours": 170.1351
+      }
+    },
+    {
+      "ticket_id": "ADV-1028",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.185761,
+        "turns": 170,
+        "wall_hours": 0.5372
+      }
+    },
+    {
+      "ticket_id": "ADV-1029",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 299.254557,
+        "turns": 803,
+        "wall_hours": 22.3568
+      }
+    },
+    {
+      "ticket_id": "ADV-1030",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 200.618068,
+        "turns": 559,
+        "wall_hours": 20.4454
+      }
+    },
+    {
+      "ticket_id": "ADV-1031",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 110.547915,
+        "turns": 266,
+        "wall_hours": 0.6235
+      }
+    },
+    {
+      "ticket_id": "ADV-1032",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 113.010609,
+        "turns": 340,
+        "wall_hours": 1.5547
+      }
+    },
+    {
+      "ticket_id": "ADV-1033",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 90.863742,
+        "turns": 154,
+        "wall_hours": 0.3425
+      }
+    },
+    {
+      "ticket_id": "ADV-1034",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 221.654811,
+        "turns": 469,
+        "wall_hours": 5.2783
+      }
+    },
+    {
+      "ticket_id": "ADV-1035",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 142.049393,
+        "turns": 299,
+        "wall_hours": 29.8473
+      }
+    },
+    {
+      "ticket_id": "ADV-1039",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 335.360055,
+        "turns": 243,
+        "wall_hours": 45.8042
+      }
+    },
+    {
+      "ticket_id": "ADV-1040",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 56.486198,
+        "turns": 99,
+        "wall_hours": 1.1285
+      }
+    },
+    {
+      "ticket_id": "ADV-1042",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 154.979721,
+        "turns": 295,
+        "wall_hours": 2.3537
+      }
+    },
+    {
+      "ticket_id": "ADV-1043",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 74.413701,
+        "turns": 151,
+        "wall_hours": 0.3683
+      }
+    },
+    {
+      "ticket_id": "ADV-1044",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 95.49674,
+        "turns": 168,
+        "wall_hours": 0.4256
+      }
+    },
+    {
+      "ticket_id": "ADV-1046",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 414.671172,
+        "turns": 420,
+        "wall_hours": 1.44
+      }
+    },
+    {
+      "ticket_id": "ADV-1047",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 109.972502,
+        "turns": 184,
+        "wall_hours": 0.5488
+      }
+    },
+    {
+      "ticket_id": "ADV-1048",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 117.761441,
+        "turns": 216,
+        "wall_hours": 0.3336
+      }
+    },
+    {
+      "ticket_id": "ADV-1049",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 40.384378,
+        "turns": 106,
+        "wall_hours": 0.2167
+      }
+    },
+    {
+      "ticket_id": "ADV-1050",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 53.683183,
+        "turns": 123,
+        "wall_hours": 0.2566
+      }
+    },
+    {
+      "ticket_id": "ADV-1051",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 98.050595,
+        "turns": 211,
+        "wall_hours": 146.8662
+      }
+    },
+    {
+      "ticket_id": "ADV-1052",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 139.772883,
+        "turns": 226,
+        "wall_hours": 0.6064
+      }
+    },
+    {
+      "ticket_id": "ADV-1053",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 65.559167,
+        "turns": 103,
+        "wall_hours": 0.2421
+      }
+    },
+    {
+      "ticket_id": "ADV-1055",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 201.374842,
+        "turns": 323,
+        "wall_hours": 0.7273
+      }
+    },
+    {
+      "ticket_id": "ADV-1057",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 299.156985,
+        "turns": 450,
+        "wall_hours": 1.0003
+      }
+    },
+    {
+      "ticket_id": "ADV-1059",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 163.369026,
+        "turns": 253,
+        "wall_hours": 0.5984
+      }
+    },
+    {
+      "ticket_id": "ADV-1060",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 265.824645,
+        "turns": 358,
+        "wall_hours": 86.8943
+      }
+    },
+    {
+      "ticket_id": "ADV-1061",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 191.997618,
+        "turns": 260,
+        "wall_hours": 1.0108
+      }
+    },
+    {
+      "ticket_id": "ADV-1063",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 195.875336,
+        "turns": 298,
+        "wall_hours": 0.6946
+      }
+    },
+    {
+      "ticket_id": "ADV-1064",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 70.856404,
+        "turns": 134,
+        "wall_hours": 0.2489
+      }
+    },
+    {
+      "ticket_id": "ADV-1067",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 170.462918,
+        "turns": 228,
+        "wall_hours": 0.5151
+      }
+    },
+    {
+      "ticket_id": "ADV-1068",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 267.124579,
+        "turns": 360,
+        "wall_hours": 0.6113
+      }
+    },
+    {
+      "ticket_id": "ADV-1069",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 244.744846,
+        "turns": 345,
+        "wall_hours": 0.8188
+      }
+    },
+    {
+      "ticket_id": "ADV-1070",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 59.719908,
+        "turns": 152,
+        "wall_hours": 0.9464
+      }
+    },
+    {
+      "ticket_id": "ADV-1074",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 58.551293,
+        "turns": 117,
+        "wall_hours": 0.381
+      }
+    },
+    {
+      "ticket_id": "ADV-1075",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 139.420659,
+        "turns": 252,
+        "wall_hours": 0.8071
+      }
+    },
+    {
+      "ticket_id": "ADV-1076",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 35.233573,
+        "turns": 93,
+        "wall_hours": 0.3233
+      }
+    },
+    {
+      "ticket_id": "ADV-1077",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 76.158436,
+        "turns": 176,
+        "wall_hours": 0.7732
+      }
+    },
+    {
+      "ticket_id": "ADV-1078",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 105.492794,
+        "turns": 149,
+        "wall_hours": 16.5547
+      }
+    },
+    {
+      "ticket_id": "ADV-1079",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 195.761068,
+        "turns": 264,
+        "wall_hours": 16.6107
+      }
+    },
+    {
+      "ticket_id": "ADV-1080",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 87.767301,
+        "turns": 228,
+        "wall_hours": 0.4403
+      }
+    },
+    {
+      "ticket_id": "ADV-1081",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 83.155934,
+        "turns": 164,
+        "wall_hours": 0.3965
+      }
+    },
+    {
+      "ticket_id": "ADV-1082",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 121.051314,
+        "turns": 157,
+        "wall_hours": 2.8762
+      }
+    },
+    {
+      "ticket_id": "ADV-1084",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 156.728472,
+        "turns": 295,
+        "wall_hours": 0.7381
+      }
+    },
+    {
+      "ticket_id": "ADV-1085",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 108.660971,
+        "turns": 201,
+        "wall_hours": 1.0487
+      }
+    },
+    {
+      "ticket_id": "ADV-1087",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 94.32975,
+        "turns": 236,
+        "wall_hours": 0.6802
+      }
+    },
+    {
+      "ticket_id": "ADV-1088",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 101.200569,
+        "turns": 223,
+        "wall_hours": 10.3725
+      }
+    },
+    {
+      "ticket_id": "ADV-1099",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 186.905293,
+        "turns": 526,
+        "wall_hours": 4.5265
+      }
+    },
+    {
+      "ticket_id": "ADV-1101",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 411.852082,
+        "turns": 1542,
+        "wall_hours": 8.7155
+      }
+    },
+    {
+      "ticket_id": "ADV-1103",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 245.4775,
+        "turns": 391,
+        "wall_hours": 1.1354
+      }
+    },
+    {
+      "ticket_id": "ADV-1107",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 88.745413,
+        "turns": 167,
+        "wall_hours": 1.79
+      }
+    },
+    {
+      "ticket_id": "ADV-1108",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 155.503827,
+        "turns": 262,
+        "wall_hours": 0.8129
+      }
+    },
+    {
+      "ticket_id": "ADV-1109",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 94.466088,
+        "turns": 146,
+        "wall_hours": 1.9227
+      }
+    },
+    {
+      "ticket_id": "ADV-1110",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 137.256973,
+        "turns": 283,
+        "wall_hours": 0.8722
+      }
+    },
+    {
+      "ticket_id": "ADV-1111",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 134.409135,
+        "turns": 265,
+        "wall_hours": 12.4671
+      }
+    },
+    {
+      "ticket_id": "ADV-1113",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 168.411953,
+        "turns": 238,
+        "wall_hours": 18.0494
+      }
+    },
+    {
+      "ticket_id": "ADV-1115",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 256.144938,
+        "turns": 713,
+        "wall_hours": 48.5122
+      }
+    },
+    {
+      "ticket_id": "ADV-1116",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 256.944858,
+        "turns": 691,
+        "wall_hours": 6.291
+      }
+    },
+    {
+      "ticket_id": "ADV-1117",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 128.910903,
+        "turns": 333,
+        "wall_hours": 5.8934
+      }
+    },
+    {
+      "ticket_id": "ADV-1118",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 122.89986,
+        "turns": 369,
+        "wall_hours": 6.0871
+      }
+    },
+    {
+      "ticket_id": "ADV-1119",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 294.85053,
+        "turns": 781,
+        "wall_hours": 2.7909
+      }
+    },
+    {
+      "ticket_id": "ADV-1120",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 270.220298,
+        "turns": 599,
+        "wall_hours": 13.4174
+      }
+    },
+    {
+      "ticket_id": "ADV-1122",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 151.791328,
+        "turns": 414,
+        "wall_hours": 4.9738
+      }
+    },
+    {
+      "ticket_id": "ADV-1123",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 188.721028,
+        "turns": 555,
+        "wall_hours": 40.1439
+      }
+    },
+    {
+      "ticket_id": "ADV-1124",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 323.977031,
+        "turns": 785,
+        "wall_hours": 5.396
+      }
+    },
+    {
+      "ticket_id": "ADV-1125",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 317.201739,
+        "turns": 732,
+        "wall_hours": 5.593
+      }
+    },
+    {
+      "ticket_id": "ADV-1126",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 164.519668,
+        "turns": 410,
+        "wall_hours": 14.8193
+      }
+    },
+    {
+      "ticket_id": "ADV-1127",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 228.937624,
+        "turns": 555,
+        "wall_hours": 5.1494
+      }
+    },
+    {
+      "ticket_id": "ADV-1128",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 227.347863,
+        "turns": 558,
+        "wall_hours": 4.4751
+      }
+    },
+    {
+      "ticket_id": "ADV-1129",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 572.689107,
+        "turns": 1319,
+        "wall_hours": 6.4698
+      }
+    },
+    {
+      "ticket_id": "ADV-1130",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 359.679456,
+        "turns": 963,
+        "wall_hours": 12.1782
+      }
+    },
+    {
+      "ticket_id": "ADV-1131",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 203.806838,
+        "turns": 565,
+        "wall_hours": 6.1015
+      }
+    },
+    {
+      "ticket_id": "ADV-1132",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 294.736557,
+        "turns": 659,
+        "wall_hours": 15.253
+      }
+    },
+    {
+      "ticket_id": "ADV-1133",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 266.839858,
+        "turns": 826,
+        "wall_hours": 1.6701
+      }
+    },
+    {
+      "ticket_id": "ADV-1134",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 371.755056,
+        "turns": 886,
+        "wall_hours": 22.265
+      }
+    },
+    {
+      "ticket_id": "ADV-1135",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 395.724639,
+        "turns": 960,
+        "wall_hours": 19.5818
+      }
+    },
+    {
+      "ticket_id": "ADV-1143",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 207.949823,
+        "turns": 353,
+        "wall_hours": 0.8024
+      }
+    },
+    {
+      "ticket_id": "ADV-1144",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 210.070281,
+        "turns": 346,
+        "wall_hours": 0.6865
+      }
+    },
+    {
+      "ticket_id": "ADV-1145",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 261.621615,
+        "turns": 434,
+        "wall_hours": 1.0956
+      }
+    },
+    {
+      "ticket_id": "ADV-1146",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 143.061003,
+        "turns": 295,
+        "wall_hours": 0.5557
+      }
+    },
+    {
+      "ticket_id": "ADV-1147",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 174.650133,
+        "turns": 275,
+        "wall_hours": 0.591
+      }
+    },
+    {
+      "ticket_id": "ADV-1149",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 202.258461,
+        "turns": 496,
+        "wall_hours": 22.3027
+      }
+    },
+    {
+      "ticket_id": "ADV-1154",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 155.824221,
+        "turns": 343,
+        "wall_hours": 1.9022
+      }
+    },
+    {
+      "ticket_id": "ADV-1155",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 72.895004,
+        "turns": 156,
+        "wall_hours": 0.3493
+      }
+    },
+    {
+      "ticket_id": "ADV-1156",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 232.719213,
+        "turns": 392,
+        "wall_hours": 0.6505
+      }
+    },
+    {
+      "ticket_id": "ADV-1157",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 384.881877,
+        "turns": 723,
+        "wall_hours": 3.3538
+      }
+    },
+    {
+      "ticket_id": "ADV-1163",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 84.374943,
+        "turns": 203,
+        "wall_hours": 0.5853
+      }
+    },
+    {
+      "ticket_id": "ADV-1165",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 91.811167,
+        "turns": 217,
+        "wall_hours": 0.4749
+      }
+    },
+    {
+      "ticket_id": "ADV-1168",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 108.586032,
+        "turns": 210,
+        "wall_hours": 0.6096
+      }
+    },
+    {
+      "ticket_id": "ADV-1169",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 98.035782,
+        "turns": 198,
+        "wall_hours": 0.4214
+      }
+    },
+    {
+      "ticket_id": "ADV-1170",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 180.745858,
+        "turns": 318,
+        "wall_hours": 1.2377
+      }
+    },
+    {
+      "ticket_id": "ADV-1171",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 117.170599,
+        "turns": 268,
+        "wall_hours": 0.9285
+      }
+    },
+    {
+      "ticket_id": "ADV-1172",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 84.3607,
+        "turns": 144,
+        "wall_hours": 0.812
+      }
+    },
+    {
+      "ticket_id": "ADV-1173",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 497.924753,
+        "turns": 661,
+        "wall_hours": 5.2718
+      }
+    },
+    {
+      "ticket_id": "ADV-1174",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 117.731019,
+        "turns": 222,
+        "wall_hours": 0.6615
+      }
+    },
+    {
+      "ticket_id": "ADV-1175",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 143.181984,
+        "turns": 243,
+        "wall_hours": 0.5141
+      }
+    },
+    {
+      "ticket_id": "ADV-1176",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 254.924324,
+        "turns": 379,
+        "wall_hours": 4.5836
+      }
+    },
+    {
+      "ticket_id": "ADV-1177",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 145.45649,
+        "turns": 282,
+        "wall_hours": 0.7741
+      }
+    },
+    {
+      "ticket_id": "ADV-1178",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 286.16027,
+        "turns": 526,
+        "wall_hours": 0.9325
+      }
+    },
+    {
+      "ticket_id": "ADV-1179",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 225.332832,
+        "turns": 426,
+        "wall_hours": 0.666
+      }
+    },
+    {
+      "ticket_id": "ADV-1180",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 74.485413,
+        "turns": 187,
+        "wall_hours": 0.4778
+      }
+    },
+    {
+      "ticket_id": "ADV-1181",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 70.386828,
+        "turns": 180,
+        "wall_hours": 0.6307
+      }
+    },
+    {
+      "ticket_id": "ADV-1184",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 62.571089,
+        "turns": 164,
+        "wall_hours": 0.3941
+      }
+    },
+    {
+      "ticket_id": "ADV-1185",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 118.363396,
+        "turns": 242,
+        "wall_hours": 0.788
+      }
+    },
+    {
+      "ticket_id": "ADV-1187",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 61.484067,
+        "turns": 165,
+        "wall_hours": 2.2372
+      }
+    },
+    {
+      "ticket_id": "ADV-1189",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 79.104641,
+        "turns": 191,
+        "wall_hours": 0.5147
+      }
+    },
+    {
+      "ticket_id": "ADV-1190",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 126.565368,
+        "turns": 388,
+        "wall_hours": 1.9064
+      }
+    },
+    {
+      "ticket_id": "ADV-1191",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 289.250304,
+        "turns": 768,
+        "wall_hours": 44.4978
+      }
+    },
+    {
+      "ticket_id": "ADV-1193",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 185.105056,
+        "turns": 479,
+        "wall_hours": 2.6583
+      }
+    },
+    {
+      "ticket_id": "ADV-1194",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 73.06674,
+        "turns": 193,
+        "wall_hours": 10.676
+      }
+    },
+    {
+      "ticket_id": "ADV-1195",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 60.144208,
+        "turns": 152,
+        "wall_hours": 11.3811
+      }
+    },
+    {
+      "ticket_id": "ADV-1196",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 100.033992,
+        "turns": 209,
+        "wall_hours": 10.6978
+      }
+    },
+    {
+      "ticket_id": "ADV-1197",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 9.690214,
+        "turns": 29,
+        "wall_hours": 0.0415
+      }
+    },
+    {
+      "ticket_id": "ADV-1198",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 41.177822,
+        "turns": 108,
+        "wall_hours": 0.2538
+      }
+    },
+    {
+      "ticket_id": "ADV-1199",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 77.664884,
+        "turns": 186,
+        "wall_hours": 0.5748
+      }
+    },
+    {
+      "ticket_id": "ADV-1200",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 113.153373,
+        "turns": 246,
+        "wall_hours": 0.662
+      }
+    },
+    {
+      "ticket_id": "ADV-1201",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 44.442984,
+        "turns": 123,
+        "wall_hours": 0.304
+      }
+    },
+    {
+      "ticket_id": "ADV-1202",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 210.827703,
+        "turns": 372,
+        "wall_hours": 0.8494
+      }
+    },
+    {
+      "ticket_id": "ADV-1206",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 191.816223,
+        "turns": 364,
+        "wall_hours": 0.871
+      }
+    },
+    {
+      "ticket_id": "ADV-1207",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 70.651391,
+        "turns": 140,
+        "wall_hours": 0.4103
+      }
+    },
+    {
+      "ticket_id": "ADV-1208",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 127.51833,
+        "turns": 232,
+        "wall_hours": 0.5511
+      }
+    },
+    {
+      "ticket_id": "ADV-1209",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 62.038252,
+        "turns": 125,
+        "wall_hours": 0.3823
+      }
+    },
+    {
+      "ticket_id": "ADV-1210",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 183.395631,
+        "turns": 321,
+        "wall_hours": 0.935
+      }
+    },
+    {
+      "ticket_id": "ADV-1212",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 22.431625,
+        "turns": 34,
+        "wall_hours": 0.062
+      }
+    },
+    {
+      "ticket_id": "ADV-1213",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 204.030575,
+        "turns": 768,
+        "wall_hours": 26.5299
+      }
+    },
+    {
+      "ticket_id": "ADV-1216",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 40.737519,
+        "turns": 87,
+        "wall_hours": 0.1987
+      }
+    },
+    {
+      "ticket_id": "ADV-1217",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 53.252921,
+        "turns": 146,
+        "wall_hours": 0.2567
+      }
+    },
+    {
+      "ticket_id": "ADV-1220",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 33.245734,
+        "turns": 107,
+        "wall_hours": 0.6156
+      }
+    },
+    {
+      "ticket_id": "ADV-1221",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 177.731869,
+        "turns": 317,
+        "wall_hours": 0.8777
+      }
+    },
+    {
+      "ticket_id": "ADV-1222",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 73.168648,
+        "turns": 315,
+        "wall_hours": 116.7578
+      }
+    },
+    {
+      "ticket_id": "ADV-1223",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 117.064819,
+        "turns": 252,
+        "wall_hours": 0.687
+      }
+    },
+    {
+      "ticket_id": "ADV-1228",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 38.901047,
+        "turns": 178,
+        "wall_hours": 22.6078
+      }
+    },
+    {
+      "ticket_id": "ADV-1233",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 507.032675,
+        "turns": 394,
+        "wall_hours": 22.9275
+      }
+    },
+    {
+      "ticket_id": "ADV-1235",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 89.726407,
+        "turns": 429,
+        "wall_hours": 25.0278
+      }
+    },
+    {
+      "ticket_id": "ADV-1236",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 47.527037,
+        "turns": 241,
+        "wall_hours": 28.6484
+      }
+    },
+    {
+      "ticket_id": "ADV-1237",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 136.853329,
+        "turns": 567,
+        "wall_hours": 25.2729
+      }
+    },
+    {
+      "ticket_id": "ADV-1238",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 101.441064,
+        "turns": 502,
+        "wall_hours": 29.0766
+      }
+    },
+    {
+      "ticket_id": "ADV-1239",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 266.980511,
+        "turns": 309,
+        "wall_hours": 28.7661
+      }
+    },
+    {
+      "ticket_id": "CTL-29",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 309,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 30.671979,
+        "turns": 84,
+        "wall_hours": 0.1309
+      }
+    },
+    {
+      "ticket_id": "CTL-30",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1006,
+        "changed_files": 14,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 49.627545,
+        "turns": 138,
+        "wall_hours": 0.2706
+      }
+    },
+    {
+      "ticket_id": "CTL-31",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 413,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 41.619327,
+        "turns": 140,
+        "wall_hours": 0.2709
+      }
+    },
+    {
+      "ticket_id": "CTL-32",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 486,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 70.005141,
+        "turns": 237,
+        "wall_hours": 0.4671
+      }
+    },
+    {
+      "ticket_id": "CTL-35",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1014,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-36",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 862,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 52.728687,
+        "turns": 139,
+        "wall_hours": 0.4969
+      }
+    },
+    {
+      "ticket_id": "CTL-37",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 881,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 29.358411,
+        "turns": 85,
+        "wall_hours": 0.2218
+      }
+    },
+    {
+      "ticket_id": "CTL-38",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 52.036837,
+        "turns": 211,
+        "wall_hours": 0.3594
+      }
+    },
+    {
+      "ticket_id": "CTL-39",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 135.965774,
+        "turns": 599,
+        "wall_hours": 2.6142
+      }
+    },
+    {
+      "ticket_id": "CTL-40",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 874,
+        "changed_files": 9,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 44.121912,
+        "turns": 159,
+        "wall_hours": 0.2543
+      }
+    },
+    {
+      "ticket_id": "CTL-41",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 111.052778,
+        "turns": 367,
+        "wall_hours": 2.2826
+      }
+    },
+    {
+      "ticket_id": "CTL-42",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 74.602592,
+        "turns": 267,
+        "wall_hours": 0.5263
+      }
+    },
+    {
+      "ticket_id": "CTL-43",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 79.265689,
+        "turns": 305,
+        "wall_hours": 2.0746
+      }
+    },
+    {
+      "ticket_id": "CTL-44",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1739,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 67.249766,
+        "turns": 245,
+        "wall_hours": 1.9786
+      }
+    },
+    {
+      "ticket_id": "CTL-45",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 63.933367,
+        "turns": 217,
+        "wall_hours": 1.8699
+      }
+    },
+    {
+      "ticket_id": "CTL-46",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 86.94868,
+        "turns": 362,
+        "wall_hours": 0.6522
+      }
+    },
+    {
+      "ticket_id": "CTL-47",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 154.657372,
+        "turns": 720,
+        "wall_hours": 2.7899
+      }
+    },
+    {
+      "ticket_id": "CTL-48",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 49.757316,
+        "turns": 125,
+        "wall_hours": 0.545
+      }
+    },
+    {
+      "ticket_id": "CTL-49",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 78.324601,
+        "turns": 260,
+        "wall_hours": 0.3842
+      }
+    },
+    {
+      "ticket_id": "CTL-50",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 65.737706,
+        "turns": 254,
+        "wall_hours": 0.6589
+      }
+    },
+    {
+      "ticket_id": "CTL-51",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 78.144475,
+        "turns": 338,
+        "wall_hours": 0.5905
+      }
+    },
+    {
+      "ticket_id": "CTL-52",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 89.347464,
+        "turns": 389,
+        "wall_hours": 2.367
+      }
+    },
+    {
+      "ticket_id": "CTL-53",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 97.815096,
+        "turns": 376,
+        "wall_hours": 0.4843
+      }
+    },
+    {
+      "ticket_id": "CTL-54",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 62.792724,
+        "turns": 221,
+        "wall_hours": 0.4131
+      }
+    },
+    {
+      "ticket_id": "CTL-58",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1014,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 51.225056,
+        "turns": 137,
+        "wall_hours": 0.2361
+      }
+    },
+    {
+      "ticket_id": "CTL-59",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 578,
+        "changed_files": 12,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 86.903292,
+        "turns": 253,
+        "wall_hours": 0.4219
+      }
+    },
+    {
+      "ticket_id": "CTL-60",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 991,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 51.901554,
+        "turns": 168,
+        "wall_hours": 0.4724
+      }
+    },
+    {
+      "ticket_id": "CTL-62",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 269,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 26.775765,
+        "turns": 101,
+        "wall_hours": 0.2058
+      }
+    },
+    {
+      "ticket_id": "CTL-63",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 579,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 51.756298,
+        "turns": 139,
+        "wall_hours": 0.2262
+      }
+    },
+    {
+      "ticket_id": "CTL-64",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 757,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 38.67604,
+        "turns": 153,
+        "wall_hours": 1.2947
+      }
+    },
+    {
+      "ticket_id": "CTL-69",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1126,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 45.545065,
+        "turns": 145,
+        "wall_hours": 0.2194
+      }
+    },
+    {
+      "ticket_id": "CTL-72",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 40.015873,
+        "turns": 193,
+        "wall_hours": 0.2774
+      }
+    },
+    {
+      "ticket_id": "CTL-73",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 40.987971,
+        "turns": 166,
+        "wall_hours": 0.2786
+      }
+    },
+    {
+      "ticket_id": "CTL-74",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 41.030871,
+        "turns": 179,
+        "wall_hours": 0.2949
+      }
+    },
+    {
+      "ticket_id": "CTL-75",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 37.16103,
+        "turns": 214,
+        "wall_hours": 0.3357
+      }
+    },
+    {
+      "ticket_id": "CTL-76",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 18.668886,
+        "turns": 81,
+        "wall_hours": 0.1414
+      }
+    },
+    {
+      "ticket_id": "CTL-77",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 111.783537,
+        "turns": 207,
+        "wall_hours": 0.3484
+      }
+    },
+    {
+      "ticket_id": "CTL-78",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 29.831249,
+        "turns": 137,
+        "wall_hours": 0.2762
+      }
+    },
+    {
+      "ticket_id": "CTL-80",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 34.307998,
+        "turns": 123,
+        "wall_hours": 0.2559
+      }
+    },
+    {
+      "ticket_id": "CTL-86",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 429,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 31.24488,
+        "turns": 113,
+        "wall_hours": 0.1867
+      }
+    },
+    {
+      "ticket_id": "CTL-87",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 320,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 26.044781,
+        "turns": 97,
+        "wall_hours": 0.2255
+      }
+    },
+    {
+      "ticket_id": "CTL-88",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 178,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 36.229331,
+        "turns": 113,
+        "wall_hours": 0.1937
+      }
+    },
+    {
+      "ticket_id": "CTL-90",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 686,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.401397,
+        "turns": 152,
+        "wall_hours": 1.0631
+      }
+    },
+    {
+      "ticket_id": "CTL-91",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 132,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 39.970446,
+        "turns": 94,
+        "wall_hours": 21.1224
+      }
+    },
+    {
+      "ticket_id": "CTL-94",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 276,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 82.050072,
+        "turns": 238,
+        "wall_hours": 2.7918
+      }
+    },
+    {
+      "ticket_id": "CTL-95",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 61,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 38.918971,
+        "turns": 120,
+        "wall_hours": 0.7905
+      }
+    },
+    {
+      "ticket_id": "CTL-97",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2358,
+        "changed_files": 23,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 113.410922,
+        "turns": 324,
+        "wall_hours": 0.5399
+      }
+    },
+    {
+      "ticket_id": "CTL-98",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 194,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 42.991587,
+        "turns": 127,
+        "wall_hours": 0.259
+      }
+    },
+    {
+      "ticket_id": "CTL-99",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1067,
+        "changed_files": 15,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 132.080474,
+        "turns": 448,
+        "wall_hours": 0.7176
+      }
+    },
+    {
+      "ticket_id": "CTL-100",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 826,
+        "changed_files": 12,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 59.935065,
+        "turns": 209,
+        "wall_hours": 0.6472
+      }
+    },
+    {
+      "ticket_id": "CTL-101",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 678,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 52.499975,
+        "turns": 172,
+        "wall_hours": 0.6205
+      }
+    },
+    {
+      "ticket_id": "CTL-102",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 603,
+        "changed_files": 9,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 44.919483,
+        "turns": 110,
+        "wall_hours": 0.5661
+      }
+    },
+    {
+      "ticket_id": "CTL-103",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1490,
+        "changed_files": 16,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 43.101324,
+        "turns": 145,
+        "wall_hours": 0.6454
+      }
+    },
+    {
+      "ticket_id": "CTL-104",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1123,
+        "changed_files": 18,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 113.272578,
+        "turns": 382,
+        "wall_hours": 0.8466
+      }
+    },
+    {
+      "ticket_id": "CTL-105",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 993,
+        "changed_files": 15,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 69.682142,
+        "turns": 193,
+        "wall_hours": 0.3725
+      }
+    },
+    {
+      "ticket_id": "CTL-106",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 723,
+        "changed_files": 10,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 46.428672,
+        "turns": 116,
+        "wall_hours": 0.2226
+      }
+    },
+    {
+      "ticket_id": "CTL-107",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1043,
+        "changed_files": 16,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 66.941946,
+        "turns": 158,
+        "wall_hours": 4.733
+      }
+    },
+    {
+      "ticket_id": "CTL-108",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1425,
+        "changed_files": 26,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 85.777566,
+        "turns": 271,
+        "wall_hours": 3.0628
+      }
+    },
+    {
+      "ticket_id": "CTL-109",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1828,
+        "changed_files": 27,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 72.748998,
+        "turns": 247,
+        "wall_hours": 0.6777
+      }
+    },
+    {
+      "ticket_id": "CTL-110",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 3339,
+        "changed_files": 18,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 133.633701,
+        "turns": 421,
+        "wall_hours": 1.0073
+      }
+    },
+    {
+      "ticket_id": "CTL-111",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 363,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 66.846401,
+        "turns": 149,
+        "wall_hours": 0.2909
+      }
+    },
+    {
+      "ticket_id": "CTL-112",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 4031,
+        "changed_files": 52,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 116.094053,
+        "turns": 411,
+        "wall_hours": 0.7128
+      }
+    },
+    {
+      "ticket_id": "CTL-113",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 738,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 47.229987,
+        "turns": 185,
+        "wall_hours": 0.7925
+      }
+    },
+    {
+      "ticket_id": "CTL-115",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 477,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 79.592973,
+        "turns": 145,
+        "wall_hours": 0.3605
+      }
+    },
+    {
+      "ticket_id": "CTL-116",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 635,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 73.894854,
+        "turns": 174,
+        "wall_hours": 0.3611
+      }
+    },
+    {
+      "ticket_id": "CTL-118",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 601,
+        "changed_files": 12,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 72.513267,
+        "turns": 210,
+        "wall_hours": 17.9114
+      }
+    },
+    {
+      "ticket_id": "CTL-120",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 281,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 43.116777,
+        "turns": 138,
+        "wall_hours": 0.4149
+      }
+    },
+    {
+      "ticket_id": "CTL-121",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 494,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 43.714539,
+        "turns": 133,
+        "wall_hours": 0.8522
+      }
+    },
+    {
+      "ticket_id": "CTL-122",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 80,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 60.281056,
+        "turns": 164,
+        "wall_hours": 0.7064
+      }
+    },
+    {
+      "ticket_id": "CTL-123",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1011,
+        "changed_files": 13,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 59.854591,
+        "turns": 120,
+        "wall_hours": 0.7718
+      }
+    },
+    {
+      "ticket_id": "CTL-124",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 53.878015,
+        "turns": 98,
+        "wall_hours": 0.7429
+      }
+    },
+    {
+      "ticket_id": "CTL-125",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 768,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 64.713658,
+        "turns": 218,
+        "wall_hours": 0.4371
+      }
+    },
+    {
+      "ticket_id": "CTL-126",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1373,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 64.618356,
+        "turns": 164,
+        "wall_hours": 0.3624
+      }
+    },
+    {
+      "ticket_id": "CTL-127",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 73,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 45.263436,
+        "turns": 126,
+        "wall_hours": 0.2308
+      }
+    },
+    {
+      "ticket_id": "CTL-130",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 214,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 24.600738,
+        "turns": 113,
+        "wall_hours": 0.3327
+      }
+    },
+    {
+      "ticket_id": "CTL-133",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 329,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 39.096102,
+        "turns": 200,
+        "wall_hours": 0.2444
+      }
+    },
+    {
+      "ticket_id": "CTL-136",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1268,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 83.188036,
+        "turns": 207,
+        "wall_hours": 0.4417
+      }
+    },
+    {
+      "ticket_id": "CTL-137",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1532,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 110.656302,
+        "turns": 231,
+        "wall_hours": 0.7906
+      }
+    },
+    {
+      "ticket_id": "CTL-138",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1122,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.641907,
+        "turns": 159,
+        "wall_hours": 0.2556
+      }
+    },
+    {
+      "ticket_id": "CTL-139",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1029,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 77.631944,
+        "turns": 151,
+        "wall_hours": 4.8028
+      }
+    },
+    {
+      "ticket_id": "CTL-140",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1315,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.354978,
+        "turns": 154,
+        "wall_hours": 0.3273
+      }
+    },
+    {
+      "ticket_id": "CTL-141",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1065,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 106.141367,
+        "turns": 260,
+        "wall_hours": 4.6092
+      }
+    },
+    {
+      "ticket_id": "CTL-142",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1152,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 77.986829,
+        "turns": 179,
+        "wall_hours": 0.5825
+      }
+    },
+    {
+      "ticket_id": "CTL-143",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1007,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 75.587706,
+        "turns": 215,
+        "wall_hours": 0.5097
+      }
+    },
+    {
+      "ticket_id": "CTL-144",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2145,
+        "changed_files": 22,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 159.264576,
+        "turns": 267,
+        "wall_hours": 5.1297
+      }
+    },
+    {
+      "ticket_id": "CTL-145",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 810,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 116.818705,
+        "turns": 239,
+        "wall_hours": 0.7174
+      }
+    },
+    {
+      "ticket_id": "CTL-146",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 113,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 37.548945,
+        "turns": 111,
+        "wall_hours": 0.4042
+      }
+    },
+    {
+      "ticket_id": "CTL-147",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 184,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 55.504776,
+        "turns": 121,
+        "wall_hours": 0.2559
+      }
+    },
+    {
+      "ticket_id": "CTL-148",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 550,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 56.519733,
+        "turns": 140,
+        "wall_hours": 0.4523
+      }
+    },
+    {
+      "ticket_id": "CTL-150",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 585,
+        "changed_files": 17,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 53.33733,
+        "turns": 166,
+        "wall_hours": 0.3265
+      }
+    },
+    {
+      "ticket_id": "CTL-152",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 603,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 77.142162,
+        "turns": 220,
+        "wall_hours": 0.3664
+      }
+    },
+    {
+      "ticket_id": "CTL-154",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 487,
+        "changed_files": 14,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 60.091282,
+        "turns": 143,
+        "wall_hours": 0.2641
+      }
+    },
+    {
+      "ticket_id": "CTL-157",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 682,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 79.850532,
+        "turns": 174,
+        "wall_hours": 0.6288
+      }
+    },
+    {
+      "ticket_id": "CTL-158",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 505,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 66.337928,
+        "turns": 149,
+        "wall_hours": 0.5384
+      }
+    },
+    {
+      "ticket_id": "CTL-159",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 866,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 64.31379,
+        "turns": 124,
+        "wall_hours": 0.4926
+      }
+    },
+    {
+      "ticket_id": "CTL-165",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 119,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.170902,
+        "turns": 104,
+        "wall_hours": 39.4771
+      }
+    },
+    {
+      "ticket_id": "CTL-166",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 885,
+        "changed_files": 14,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 169.75339,
+        "turns": 420,
+        "wall_hours": 13.7973
+      }
+    },
+    {
+      "ticket_id": "CTL-168",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1491,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 102.331374,
+        "turns": 217,
+        "wall_hours": 0.8118
+      }
+    },
+    {
+      "ticket_id": "CTL-169",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 121.704873,
+        "turns": 255,
+        "wall_hours": 0.9132
+      }
+    },
+    {
+      "ticket_id": "CTL-170",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 326,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 50.79681,
+        "turns": 128,
+        "wall_hours": 0.4191
+      }
+    },
+    {
+      "ticket_id": "CTL-171",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 798,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 69.98294,
+        "turns": 170,
+        "wall_hours": 0.6805
+      }
+    },
+    {
+      "ticket_id": "CTL-172",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 89.767826,
+        "turns": 206,
+        "wall_hours": 0.507
+      }
+    },
+    {
+      "ticket_id": "CTL-176",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 513,
+        "changed_files": 9,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 56.908451,
+        "turns": 142,
+        "wall_hours": 0.3283
+      }
+    },
+    {
+      "ticket_id": "CTL-178",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 3196,
+        "changed_files": 15,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 123.191806,
+        "turns": 337,
+        "wall_hours": 1.4395
+      }
+    },
+    {
+      "ticket_id": "CTL-182",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 122.711754,
+        "turns": 231,
+        "wall_hours": 7.4294
+      }
+    },
+    {
+      "ticket_id": "CTL-183",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 828,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 85.157211,
+        "turns": 156,
+        "wall_hours": 2.5588
+      }
+    },
+    {
+      "ticket_id": "CTL-184",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 316,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 54.395991,
+        "turns": 109,
+        "wall_hours": 0.4452
+      }
+    },
+    {
+      "ticket_id": "CTL-191",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 34.021476,
+        "turns": 74,
+        "wall_hours": 0.0828
+      }
+    },
+    {
+      "ticket_id": "CTL-192",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 294,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 39.050262,
+        "turns": 159,
+        "wall_hours": 0.4331
+      }
+    },
+    {
+      "ticket_id": "CTL-193",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 531,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 8.01057,
+        "turns": 134,
+        "wall_hours": 0.3448
+      }
+    },
+    {
+      "ticket_id": "CTL-195",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 59,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 19.867864,
+        "turns": 112,
+        "wall_hours": 0.1403
+      }
+    },
+    {
+      "ticket_id": "CTL-198",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 65,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 19.239493,
+        "turns": 76,
+        "wall_hours": 2.0714
+      }
+    },
+    {
+      "ticket_id": "CTL-199",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 8,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 12.84701,
+        "turns": 53,
+        "wall_hours": 1.5681
+      }
+    },
+    {
+      "ticket_id": "CTL-200",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 217,
+        "changed_files": 12,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 44.72983,
+        "turns": 157,
+        "wall_hours": 67.5322
+      }
+    },
+    {
+      "ticket_id": "CTL-201",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 35,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-202",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 3349,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 38.141107,
+        "turns": 687,
+        "wall_hours": 118.1902
+      }
+    },
+    {
+      "ticket_id": "CTL-203",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 116,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 20.34447,
+        "turns": 109,
+        "wall_hours": 81.2456
+      }
+    },
+    {
+      "ticket_id": "CTL-207",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 530,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 62.870377,
+        "turns": 193,
+        "wall_hours": 48.2583
+      }
+    },
+    {
+      "ticket_id": "CTL-208",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 164,
+        "changed_files": 10,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 85.431916,
+        "turns": 159,
+        "wall_hours": 13.9759
+      }
+    },
+    {
+      "ticket_id": "CTL-209",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 4596,
+        "changed_files": 28,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 445.403048,
+        "turns": 785,
+        "wall_hours": 18.3357
+      }
+    },
+    {
+      "ticket_id": "CTL-210",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2396,
+        "changed_files": 22,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 127.113662,
+        "turns": 277,
+        "wall_hours": 0.5476
+      }
+    },
+    {
+      "ticket_id": "CTL-211",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1484,
+        "changed_files": 20,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 126.080304,
+        "turns": 289,
+        "wall_hours": 0.5289
+      }
+    },
+    {
+      "ticket_id": "CTL-215",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 727,
+        "changed_files": 15,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 55.6227,
+        "turns": 150,
+        "wall_hours": 1.6339
+      }
+    },
+    {
+      "ticket_id": "CTL-216",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 980,
+        "changed_files": 9,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 87.531639,
+        "turns": 197,
+        "wall_hours": 0.3396
+      }
+    },
+    {
+      "ticket_id": "CTL-217",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 678,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 78.896066,
+        "turns": 178,
+        "wall_hours": 0.2855
+      }
+    },
+    {
+      "ticket_id": "CTL-219",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 700,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.88786,
+        "turns": 128,
+        "wall_hours": 0.225
+      }
+    },
+    {
+      "ticket_id": "CTL-222",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 371,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 89.539531,
+        "turns": 160,
+        "wall_hours": 0.3588
+      }
+    },
+    {
+      "ticket_id": "CTL-223",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 107,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 43.403405,
+        "turns": 126,
+        "wall_hours": 0.6124
+      }
+    },
+    {
+      "ticket_id": "CTL-224",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1034,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 81.519414,
+        "turns": 155,
+        "wall_hours": 0.4743
+      }
+    },
+    {
+      "ticket_id": "CTL-225",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2360,
+        "changed_files": 28,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 121.468287,
+        "turns": 241,
+        "wall_hours": 0.5716
+      }
+    },
+    {
+      "ticket_id": "CTL-226",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 691,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 111.269886,
+        "turns": 208,
+        "wall_hours": 0.3875
+      }
+    },
+    {
+      "ticket_id": "CTL-227",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 275,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 125.510049,
+        "turns": 235,
+        "wall_hours": 0.8095
+      }
+    },
+    {
+      "ticket_id": "CTL-228",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 761,
+        "changed_files": 9,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 90.397645,
+        "turns": 182,
+        "wall_hours": 0.6006
+      }
+    },
+    {
+      "ticket_id": "CTL-229",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 808,
+        "changed_files": 9,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 95.792894,
+        "turns": 225,
+        "wall_hours": 0.4443
+      }
+    },
+    {
+      "ticket_id": "CTL-230",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 636,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 49.818375,
+        "turns": 108,
+        "wall_hours": 0.2759
+      }
+    },
+    {
+      "ticket_id": "CTL-231",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 111,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 54.212297,
+        "turns": 137,
+        "wall_hours": 0.523
+      }
+    },
+    {
+      "ticket_id": "CTL-232",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1008,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 72.52488,
+        "turns": 134,
+        "wall_hours": 0.5225
+      }
+    },
+    {
+      "ticket_id": "CTL-233",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 144,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 65.103165,
+        "turns": 152,
+        "wall_hours": 0.5498
+      }
+    },
+    {
+      "ticket_id": "CTL-234",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 683,
+        "changed_files": 10,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 79.427894,
+        "turns": 213,
+        "wall_hours": 1.9618
+      }
+    },
+    {
+      "ticket_id": "CTL-236",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 11,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 61.310475,
+        "turns": 101,
+        "wall_hours": 1.6843
+      }
+    },
+    {
+      "ticket_id": "CTL-237",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 392,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 84.749289,
+        "turns": 203,
+        "wall_hours": 0.5872
+      }
+    },
+    {
+      "ticket_id": "CTL-238",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 910,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 201.197013,
+        "turns": 398,
+        "wall_hours": 0.5663
+      }
+    },
+    {
+      "ticket_id": "CTL-239",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 207,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 83.069765,
+        "turns": 193,
+        "wall_hours": 0.4632
+      }
+    },
+    {
+      "ticket_id": "CTL-240",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 365,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 55.508342,
+        "turns": 170,
+        "wall_hours": 1.3102
+      }
+    },
+    {
+      "ticket_id": "CTL-241",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 2.863765,
+        "turns": 37,
+        "wall_hours": 0.121
+      }
+    },
+    {
+      "ticket_id": "CTL-242",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 252,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 16.011421,
+        "turns": 293,
+        "wall_hours": 0.6887
+      }
+    },
+    {
+      "ticket_id": "CTL-243",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 212,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 78.573045,
+        "turns": 178,
+        "wall_hours": 0.3775
+      }
+    },
+    {
+      "ticket_id": "CTL-244",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 442,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 23.692456,
+        "turns": 308,
+        "wall_hours": 0.6609
+      }
+    },
+    {
+      "ticket_id": "CTL-245",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 51,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 51.060435,
+        "turns": 115,
+        "wall_hours": 0.4609
+      }
+    },
+    {
+      "ticket_id": "CTL-247",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 201,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 3.196182,
+        "turns": 80,
+        "wall_hours": 0.1654
+      }
+    },
+    {
+      "ticket_id": "CTL-248",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 72,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.370816,
+        "turns": 104,
+        "wall_hours": 0.1222
+      }
+    },
+    {
+      "ticket_id": "CTL-249",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 176,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 5.260695,
+        "turns": 109,
+        "wall_hours": 0.2273
+      }
+    },
+    {
+      "ticket_id": "CTL-250",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 56,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.69564,
+        "turns": 118,
+        "wall_hours": 0.2128
+      }
+    },
+    {
+      "ticket_id": "CTL-251",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 130,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.150041,
+        "turns": 118,
+        "wall_hours": 0.2261
+      }
+    },
+    {
+      "ticket_id": "CTL-252",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 612,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 11.652817,
+        "turns": 211,
+        "wall_hours": 0.4719
+      }
+    },
+    {
+      "ticket_id": "CTL-253",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 566,
+        "changed_files": 13,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 76.444441,
+        "turns": 172,
+        "wall_hours": 0.3022
+      }
+    },
+    {
+      "ticket_id": "CTL-254",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 359,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 102.971366,
+        "turns": 198,
+        "wall_hours": 0.4602
+      }
+    },
+    {
+      "ticket_id": "CTL-255",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 665,
+        "changed_files": 12,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 9.669809,
+        "turns": 143,
+        "wall_hours": 0.4082
+      }
+    },
+    {
+      "ticket_id": "CTL-256",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 691,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 19.657333,
+        "turns": 174,
+        "wall_hours": 47.0884
+      }
+    },
+    {
+      "ticket_id": "CTL-257",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 103,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 9.237592,
+        "turns": 160,
+        "wall_hours": 0.3476
+      }
+    },
+    {
+      "ticket_id": "CTL-258",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 299,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 5.970855,
+        "turns": 124,
+        "wall_hours": 0.1388
+      }
+    },
+    {
+      "ticket_id": "CTL-259",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 3,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.632029,
+        "turns": 128,
+        "wall_hours": 0.2221
+      }
+    },
+    {
+      "ticket_id": "CTL-260",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 394,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 3.897451,
+        "turns": 87,
+        "wall_hours": 0.1702
+      }
+    },
+    {
+      "ticket_id": "CTL-261",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 639,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 33.445081,
+        "turns": 204,
+        "wall_hours": 1.0741
+      }
+    },
+    {
+      "ticket_id": "CTL-262",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 160,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.96129,
+        "turns": 125,
+        "wall_hours": 0.1739
+      }
+    },
+    {
+      "ticket_id": "CTL-263",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 406,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 29.063816,
+        "turns": 262,
+        "wall_hours": 1.1345
+      }
+    },
+    {
+      "ticket_id": "CTL-264",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 76,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.468513,
+        "turns": 99,
+        "wall_hours": 0.2837
+      }
+    },
+    {
+      "ticket_id": "CTL-265",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.279533,
+        "turns": 152,
+        "wall_hours": 0.4199
+      }
+    },
+    {
+      "ticket_id": "CTL-266",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 9.740382,
+        "turns": 185,
+        "wall_hours": 2.9314
+      }
+    },
+    {
+      "ticket_id": "CTL-267",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 5,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.039285,
+        "turns": 112,
+        "wall_hours": 0.211
+      }
+    },
+    {
+      "ticket_id": "CTL-268",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 7,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 12.95963,
+        "turns": 363,
+        "wall_hours": 0.7192
+      }
+    },
+    {
+      "ticket_id": "CTL-269",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 370,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 117.775413,
+        "turns": 197,
+        "wall_hours": 0.4845
+      }
+    },
+    {
+      "ticket_id": "CTL-270",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 30,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 84.762017,
+        "turns": 170,
+        "wall_hours": 2.6922
+      }
+    },
+    {
+      "ticket_id": "CTL-271",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 10.064718,
+        "turns": 187,
+        "wall_hours": 18.7433
+      }
+    },
+    {
+      "ticket_id": "CTL-272",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 54,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.79274,
+        "turns": 146,
+        "wall_hours": 0.1843
+      }
+    },
+    {
+      "ticket_id": "CTL-273",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 534,
+        "changed_files": 9,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.62507,
+        "turns": 378,
+        "wall_hours": 0.3741
+      }
+    },
+    {
+      "ticket_id": "CTL-274",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 169,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 54.280605,
+        "turns": 161,
+        "wall_hours": 0.2792
+      }
+    },
+    {
+      "ticket_id": "CTL-275",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 33,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 5.379271,
+        "turns": 112,
+        "wall_hours": 0.1604
+      }
+    },
+    {
+      "ticket_id": "CTL-276",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1326,
+        "changed_files": 26,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 8.722406,
+        "turns": 195,
+        "wall_hours": 0.2337
+      }
+    },
+    {
+      "ticket_id": "CTL-277",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1443,
+        "changed_files": 34,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 9.417979,
+        "turns": 202,
+        "wall_hours": 0.3765
+      }
+    },
+    {
+      "ticket_id": "CTL-278",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 757,
+        "changed_files": 17,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 9.82183,
+        "turns": 224,
+        "wall_hours": 0.3819
+      }
+    },
+    {
+      "ticket_id": "CTL-279",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 12,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.354281,
+        "turns": 147,
+        "wall_hours": 0.4734
+      }
+    },
+    {
+      "ticket_id": "CTL-280",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2445,
+        "changed_files": 67,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 9.085322,
+        "turns": 196,
+        "wall_hours": 0.4058
+      }
+    },
+    {
+      "ticket_id": "CTL-281",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 185,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.495349,
+        "turns": 149,
+        "wall_hours": 0.1992
+      }
+    },
+    {
+      "ticket_id": "CTL-282",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1069,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 14.858989,
+        "turns": 282,
+        "wall_hours": 0.8189
+      }
+    },
+    {
+      "ticket_id": "CTL-283",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 290,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 7.424896,
+        "turns": 145,
+        "wall_hours": 5.6712
+      }
+    },
+    {
+      "ticket_id": "CTL-284",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1248,
+        "changed_files": 12,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 217.433015,
+        "turns": 421,
+        "wall_hours": 43.1909
+      }
+    },
+    {
+      "ticket_id": "CTL-285",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 521,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 20.312534,
+        "turns": 319,
+        "wall_hours": 2.3691
+      }
+    },
+    {
+      "ticket_id": "CTL-286",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1659,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 297.329697,
+        "turns": 478,
+        "wall_hours": 188.6385
+      }
+    },
+    {
+      "ticket_id": "CTL-299",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 820,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-300",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 5075,
+        "changed_files": 38,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 407.876577,
+        "turns": 828,
+        "wall_hours": 12.5265
+      }
+    },
+    {
+      "ticket_id": "CTL-301",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 80,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 51.791877,
+        "turns": 145,
+        "wall_hours": 0.2363
+      }
+    },
+    {
+      "ticket_id": "CTL-303",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 4202,
+        "changed_files": 36,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 9.849522,
+        "turns": 176,
+        "wall_hours": 0.4365
+      }
+    },
+    {
+      "ticket_id": "CTL-306",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 966,
+        "changed_files": 26,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 9.69389,
+        "turns": 144,
+        "wall_hours": 0.652
+      }
+    },
+    {
+      "ticket_id": "CTL-307",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1240,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 77.791409,
+        "turns": 172,
+        "wall_hours": 0.4484
+      }
+    },
+    {
+      "ticket_id": "CTL-308",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 60,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-310",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 51,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 5.881418,
+        "turns": 101,
+        "wall_hours": 0.1073
+      }
+    },
+    {
+      "ticket_id": "CTL-311",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 22,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 5.521039,
+        "turns": 96,
+        "wall_hours": 0.2207
+      }
+    },
+    {
+      "ticket_id": "CTL-312",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 966,
+        "changed_files": 20,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 13.219533,
+        "turns": 256,
+        "wall_hours": 0.6093
+      }
+    },
+    {
+      "ticket_id": "CTL-313",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2207,
+        "changed_files": 15,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 131.408842,
+        "turns": 246,
+        "wall_hours": 0.7156
+      }
+    },
+    {
+      "ticket_id": "CTL-314",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 244,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 54.752462,
+        "turns": 176,
+        "wall_hours": 0.2356
+      }
+    },
+    {
+      "ticket_id": "CTL-315",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1315,
+        "changed_files": 27,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 54.685688,
+        "turns": 157,
+        "wall_hours": 0.3398
+      }
+    },
+    {
+      "ticket_id": "CTL-316",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1203,
+        "changed_files": 22,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 55.875942,
+        "turns": 135,
+        "wall_hours": 0.8055
+      }
+    },
+    {
+      "ticket_id": "CTL-317",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 63,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 37.60938,
+        "turns": 66,
+        "wall_hours": 0.3345
+      }
+    },
+    {
+      "ticket_id": "CTL-319",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 562,
+        "changed_files": 45,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-320",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 94,
+        "changed_files": 12,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.513068,
+        "turns": 99,
+        "wall_hours": 0.1129
+      }
+    },
+    {
+      "ticket_id": "CTL-321",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 103,
+        "changed_files": 21,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.799758,
+        "turns": 162,
+        "wall_hours": 0.2081
+      }
+    },
+    {
+      "ticket_id": "CTL-322",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 5637,
+        "changed_files": 18,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.740963,
+        "turns": 133,
+        "wall_hours": 0.2375
+      }
+    },
+    {
+      "ticket_id": "CTL-323",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 116,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.3422,
+        "turns": 88,
+        "wall_hours": 0.1282
+      }
+    },
+    {
+      "ticket_id": "CTL-324",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 235,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 58.041267,
+        "turns": 148,
+        "wall_hours": 0.4883
+      }
+    },
+    {
+      "ticket_id": "CTL-325",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 222,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 54.19283,
+        "turns": 147,
+        "wall_hours": 0.259
+      }
+    },
+    {
+      "ticket_id": "CTL-326",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 301,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 61.725093,
+        "turns": 155,
+        "wall_hours": 0.224
+      }
+    },
+    {
+      "ticket_id": "CTL-327",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 95,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 56.508077,
+        "turns": 147,
+        "wall_hours": 0.3452
+      }
+    },
+    {
+      "ticket_id": "CTL-330",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 125,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 65.521047,
+        "turns": 127,
+        "wall_hours": 0.2001
+      }
+    },
+    {
+      "ticket_id": "CTL-331",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 390,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 93.171047,
+        "turns": 183,
+        "wall_hours": 0.624
+      }
+    },
+    {
+      "ticket_id": "CTL-332",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 82,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 83.878607,
+        "turns": 140,
+        "wall_hours": 0.3351
+      }
+    },
+    {
+      "ticket_id": "CTL-334",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 48,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 83.985842,
+        "turns": 186,
+        "wall_hours": 2.9557
+      }
+    },
+    {
+      "ticket_id": "CTL-336",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 154,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 38.483201,
+        "turns": 106,
+        "wall_hours": 0.1194
+      }
+    },
+    {
+      "ticket_id": "CTL-337",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 229,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 76.372757,
+        "turns": 210,
+        "wall_hours": 2.2086
+      }
+    },
+    {
+      "ticket_id": "CTL-339",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 478,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 107.826626,
+        "turns": 147,
+        "wall_hours": 5.7808
+      }
+    },
+    {
+      "ticket_id": "CTL-340",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 196,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.609938,
+        "turns": 124,
+        "wall_hours": 0.1421
+      }
+    },
+    {
+      "ticket_id": "CTL-341",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 310,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 81.487972,
+        "turns": 196,
+        "wall_hours": 0.3017
+      }
+    },
+    {
+      "ticket_id": "CTL-342",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 16,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 47.209361,
+        "turns": 126,
+        "wall_hours": 0.7487
+      }
+    },
+    {
+      "ticket_id": "CTL-343",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1034,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 121.060582,
+        "turns": 254,
+        "wall_hours": 0.451
+      }
+    },
+    {
+      "ticket_id": "CTL-344",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 594,
+        "changed_files": 17,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 132.617253,
+        "turns": 271,
+        "wall_hours": 0.5583
+      }
+    },
+    {
+      "ticket_id": "CTL-346",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 77,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 50.100774,
+        "turns": 109,
+        "wall_hours": 0.1424
+      }
+    },
+    {
+      "ticket_id": "CTL-348",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 128,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 55.148902,
+        "turns": 154,
+        "wall_hours": 0.4808
+      }
+    },
+    {
+      "ticket_id": "CTL-349",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2245,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.985805,
+        "turns": 146,
+        "wall_hours": 11.7471
+      }
+    },
+    {
+      "ticket_id": "CTL-350",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1062,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 143.449824,
+        "turns": 333,
+        "wall_hours": 7.67
+      }
+    },
+    {
+      "ticket_id": "CTL-351",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 106,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 154.249228,
+        "turns": 418,
+        "wall_hours": 7.2595
+      }
+    },
+    {
+      "ticket_id": "CTL-352",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 667,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 85.393496,
+        "turns": 206,
+        "wall_hours": 0.3951
+      }
+    },
+    {
+      "ticket_id": "CTL-353",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 371,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-354",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 14,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 58.478812,
+        "turns": 130,
+        "wall_hours": 0.1913
+      }
+    },
+    {
+      "ticket_id": "CTL-355",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 167,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-357",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1047,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 90.716676,
+        "turns": 223,
+        "wall_hours": 0.3308
+      }
+    },
+    {
+      "ticket_id": "CTL-358",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 48,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-359",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 96,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 50.474393,
+        "turns": 145,
+        "wall_hours": 5.5423
+      }
+    },
+    {
+      "ticket_id": "CTL-360",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 113,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 125.576513,
+        "turns": 362,
+        "wall_hours": 1.453
+      }
+    },
+    {
+      "ticket_id": "CTL-361",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 129,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 74.395452,
+        "turns": 169,
+        "wall_hours": 49.042
+      }
+    },
+    {
+      "ticket_id": "CTL-362",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 614,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 132.220126,
+        "turns": 243,
+        "wall_hours": 0.8177
+      }
+    },
+    {
+      "ticket_id": "CTL-363",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 169,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 58.467186,
+        "turns": 145,
+        "wall_hours": 49.0414
+      }
+    },
+    {
+      "ticket_id": "CTL-364",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 217,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 75.445309,
+        "turns": 152,
+        "wall_hours": 0.3586
+      }
+    },
+    {
+      "ticket_id": "CTL-365",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 249,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 70.586446,
+        "turns": 193,
+        "wall_hours": 0.8815
+      }
+    },
+    {
+      "ticket_id": "CTL-366",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 101,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 82.380235,
+        "turns": 211,
+        "wall_hours": 1.2234
+      }
+    },
+    {
+      "ticket_id": "CTL-367",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 209,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 58.623739,
+        "turns": 129,
+        "wall_hours": 0.2729
+      }
+    },
+    {
+      "ticket_id": "CTL-368",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 84,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 37.064321,
+        "turns": 105,
+        "wall_hours": 0.6973
+      }
+    },
+    {
+      "ticket_id": "CTL-369",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 142,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 64.607907,
+        "turns": 126,
+        "wall_hours": 0.2186
+      }
+    },
+    {
+      "ticket_id": "CTL-370",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 368,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 94.516363,
+        "turns": 202,
+        "wall_hours": 0.5248
+      }
+    },
+    {
+      "ticket_id": "CTL-371",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 79,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 55.161111,
+        "turns": 107,
+        "wall_hours": 0.137
+      }
+    },
+    {
+      "ticket_id": "CTL-372",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 103,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 78.149499,
+        "turns": 145,
+        "wall_hours": 0.5231
+      }
+    },
+    {
+      "ticket_id": "CTL-373",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 326,
+        "changed_files": 15,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 115.280208,
+        "turns": 245,
+        "wall_hours": 0.8485
+      }
+    },
+    {
+      "ticket_id": "CTL-374",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1053,
+        "changed_files": 15,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 199.590294,
+        "turns": 320,
+        "wall_hours": 1.0581
+      }
+    },
+    {
+      "ticket_id": "CTL-378",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2427,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 260.654487,
+        "turns": 527,
+        "wall_hours": 18.8953
+      }
+    },
+    {
+      "ticket_id": "CTL-380",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 208,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 171.692446,
+        "turns": 447,
+        "wall_hours": 46.8721
+      }
+    },
+    {
+      "ticket_id": "CTL-381",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 786,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 156.828082,
+        "turns": 376,
+        "wall_hours": 1.8279
+      }
+    },
+    {
+      "ticket_id": "CTL-383",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 131,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 73.046148,
+        "turns": 186,
+        "wall_hours": 0.5332
+      }
+    },
+    {
+      "ticket_id": "CTL-384",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 85,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 10.00748,
+        "turns": 171,
+        "wall_hours": 2.3778
+      }
+    },
+    {
+      "ticket_id": "CTL-385",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 227,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 84.316543,
+        "turns": 229,
+        "wall_hours": 0.4733
+      }
+    },
+    {
+      "ticket_id": "CTL-386",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 523,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 10.901094,
+        "turns": 188,
+        "wall_hours": 0.4183
+      }
+    },
+    {
+      "ticket_id": "CTL-387",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 191,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 135.603092,
+        "turns": 277,
+        "wall_hours": 0.9181
+      }
+    },
+    {
+      "ticket_id": "CTL-388",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 242,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 69.369709,
+        "turns": 166,
+        "wall_hours": 0.2721
+      }
+    },
+    {
+      "ticket_id": "CTL-389",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 198,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 11.842079,
+        "turns": 217,
+        "wall_hours": 0.4604
+      }
+    },
+    {
+      "ticket_id": "CTL-390",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 893,
+        "changed_files": 23,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 357.924967,
+        "turns": 346,
+        "wall_hours": 1.2206
+      }
+    },
+    {
+      "ticket_id": "CTL-391",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 676,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 138.560431,
+        "turns": 247,
+        "wall_hours": 0.7347
+      }
+    },
+    {
+      "ticket_id": "CTL-392",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1541,
+        "changed_files": 13,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 122.879987,
+        "turns": 281,
+        "wall_hours": 0.7745
+      }
+    },
+    {
+      "ticket_id": "CTL-393",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 62,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 8.883797,
+        "turns": 199,
+        "wall_hours": 22.0957
+      }
+    },
+    {
+      "ticket_id": "CTL-394",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 860,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 17.45141,
+        "turns": 296,
+        "wall_hours": 21.2096
+      }
+    },
+    {
+      "ticket_id": "CTL-395",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 153,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 7.785619,
+        "turns": 158,
+        "wall_hours": 0.3902
+      }
+    },
+    {
+      "ticket_id": "CTL-396",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 393,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 12.967738,
+        "turns": 262,
+        "wall_hours": 0.4997
+      }
+    },
+    {
+      "ticket_id": "CTL-397",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1091,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 13.511015,
+        "turns": 260,
+        "wall_hours": 12.1095
+      }
+    },
+    {
+      "ticket_id": "CTL-398",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 38,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.466176,
+        "turns": 89,
+        "wall_hours": 0.5266
+      }
+    },
+    {
+      "ticket_id": "CTL-399",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 138,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 10.748916,
+        "turns": 202,
+        "wall_hours": 0.4427
+      }
+    },
+    {
+      "ticket_id": "CTL-400",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 79,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.030647,
+        "turns": 73,
+        "wall_hours": 0.1372
+      }
+    },
+    {
+      "ticket_id": "CTL-401",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 70,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.029006,
+        "turns": 102,
+        "wall_hours": 0.1595
+      }
+    },
+    {
+      "ticket_id": "CTL-402",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 47,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.08661,
+        "turns": 136,
+        "wall_hours": 0.2381
+      }
+    },
+    {
+      "ticket_id": "CTL-403",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 668,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 13.229339,
+        "turns": 267,
+        "wall_hours": 0.4226
+      }
+    },
+    {
+      "ticket_id": "CTL-404",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 93,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 8.628159,
+        "turns": 155,
+        "wall_hours": 0.2792
+      }
+    },
+    {
+      "ticket_id": "CTL-405",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 447,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.766498,
+        "turns": 138,
+        "wall_hours": 0.2879
+      }
+    },
+    {
+      "ticket_id": "CTL-406",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 114,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.401464,
+        "turns": 105,
+        "wall_hours": 0.2173
+      }
+    },
+    {
+      "ticket_id": "CTL-407",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 208,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 5.66226,
+        "turns": 122,
+        "wall_hours": 0.3785
+      }
+    },
+    {
+      "ticket_id": "CTL-408",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 340,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 8.723652,
+        "turns": 152,
+        "wall_hours": 11.1349
+      }
+    },
+    {
+      "ticket_id": "CTL-409",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 137,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 7.935088,
+        "turns": 159,
+        "wall_hours": 1.2402
+      }
+    },
+    {
+      "ticket_id": "CTL-412",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 105,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.625995,
+        "turns": 158,
+        "wall_hours": 0.2045
+      }
+    },
+    {
+      "ticket_id": "CTL-413",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 64,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 2.760031,
+        "turns": 79,
+        "wall_hours": 0.1474
+      }
+    },
+    {
+      "ticket_id": "CTL-414",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 57,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.863432,
+        "turns": 102,
+        "wall_hours": 0.2047
+      }
+    },
+    {
+      "ticket_id": "CTL-415",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 163,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 7.985266,
+        "turns": 150,
+        "wall_hours": 0.7933
+      }
+    },
+    {
+      "ticket_id": "CTL-416",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 30,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.769547,
+        "turns": 108,
+        "wall_hours": 0.1716
+      }
+    },
+    {
+      "ticket_id": "CTL-417",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 67,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.065535,
+        "turns": 85,
+        "wall_hours": 0.2046
+      }
+    },
+    {
+      "ticket_id": "CTL-418",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 247,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 8.869729,
+        "turns": 167,
+        "wall_hours": 0.4301
+      }
+    },
+    {
+      "ticket_id": "CTL-419",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 385,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 13.951394,
+        "turns": 305,
+        "wall_hours": 0.7784
+      }
+    },
+    {
+      "ticket_id": "CTL-420",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 27,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 7.467113,
+        "turns": 121,
+        "wall_hours": 0.5806
+      }
+    },
+    {
+      "ticket_id": "CTL-421",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 21,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.510982,
+        "turns": 151,
+        "wall_hours": 0.383
+      }
+    },
+    {
+      "ticket_id": "CTL-422",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 8,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 2.734484,
+        "turns": 73,
+        "wall_hours": 0.2498
+      }
+    },
+    {
+      "ticket_id": "CTL-423",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 24,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.132947,
+        "turns": 105,
+        "wall_hours": 0.5946
+      }
+    },
+    {
+      "ticket_id": "CTL-424",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 225,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 7.355709,
+        "turns": 165,
+        "wall_hours": 0.3413
+      }
+    },
+    {
+      "ticket_id": "CTL-425",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 153,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.926926,
+        "turns": 157,
+        "wall_hours": 0.6035
+      }
+    },
+    {
+      "ticket_id": "CTL-426",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 298,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 7.897491,
+        "turns": 162,
+        "wall_hours": 0.4388
+      }
+    },
+    {
+      "ticket_id": "CTL-427",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 15,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.172318,
+        "turns": 100,
+        "wall_hours": 0.3032
+      }
+    },
+    {
+      "ticket_id": "CTL-429",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 16,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 3.172155,
+        "turns": 79,
+        "wall_hours": 0.115
+      }
+    },
+    {
+      "ticket_id": "CTL-430",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 13,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 2.803125,
+        "turns": 65,
+        "wall_hours": 0.0575
+      }
+    },
+    {
+      "ticket_id": "CTL-431",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 94,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 71.928562,
+        "turns": 160,
+        "wall_hours": 0.4243
+      }
+    },
+    {
+      "ticket_id": "CTL-432",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 53,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 68.723978,
+        "turns": 165,
+        "wall_hours": 0.353
+      }
+    },
+    {
+      "ticket_id": "CTL-433",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 4,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 41.886237,
+        "turns": 133,
+        "wall_hours": 0.6283
+      }
+    },
+    {
+      "ticket_id": "CTL-434",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 469,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 88.431817,
+        "turns": 190,
+        "wall_hours": 1.2093
+      }
+    },
+    {
+      "ticket_id": "CTL-435",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 255,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 129.637294,
+        "turns": 245,
+        "wall_hours": 1.497
+      }
+    },
+    {
+      "ticket_id": "CTL-436",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 6,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 66.598123,
+        "turns": 144,
+        "wall_hours": 0.3
+      }
+    },
+    {
+      "ticket_id": "CTL-437",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 21.332918,
+        "turns": 57,
+        "wall_hours": 0.1084
+      }
+    },
+    {
+      "ticket_id": "CTL-438",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 8,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.323754,
+        "turns": 146,
+        "wall_hours": 0.3583
+      }
+    },
+    {
+      "ticket_id": "CTL-439",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 222,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 92.395295,
+        "turns": 194,
+        "wall_hours": 0.369
+      }
+    },
+    {
+      "ticket_id": "CTL-447",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 421,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 84.038719,
+        "turns": 178,
+        "wall_hours": 0.2402
+      }
+    },
+    {
+      "ticket_id": "CTL-448",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1654,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 129.46125,
+        "turns": 230,
+        "wall_hours": 0.4353
+      }
+    },
+    {
+      "ticket_id": "CTL-449",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1088,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 106.935193,
+        "turns": 211,
+        "wall_hours": 0.5224
+      }
+    },
+    {
+      "ticket_id": "CTL-450",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1399,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.54705,
+        "turns": 146,
+        "wall_hours": 0.3191
+      }
+    },
+    {
+      "ticket_id": "CTL-451",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1087,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 81.091951,
+        "turns": 196,
+        "wall_hours": 0.4123
+      }
+    },
+    {
+      "ticket_id": "CTL-452",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1430,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 126.399123,
+        "turns": 232,
+        "wall_hours": 0.6084
+      }
+    },
+    {
+      "ticket_id": "CTL-453",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1576,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 79.738237,
+        "turns": 166,
+        "wall_hours": 0.3649
+      }
+    },
+    {
+      "ticket_id": "CTL-454",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 131,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 46.549425,
+        "turns": 119,
+        "wall_hours": 0.257
+      }
+    },
+    {
+      "ticket_id": "CTL-455",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 206,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 65.730318,
+        "turns": 139,
+        "wall_hours": 0.3428
+      }
+    },
+    {
+      "ticket_id": "CTL-456",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 794,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 78.760469,
+        "turns": 149,
+        "wall_hours": 0.4108
+      }
+    },
+    {
+      "ticket_id": "CTL-457",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1161,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 57.316516,
+        "turns": 127,
+        "wall_hours": 0.3453
+      }
+    },
+    {
+      "ticket_id": "CTL-458",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1557,
+        "changed_files": 9,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 80.90921,
+        "turns": 164,
+        "wall_hours": 0.4126
+      }
+    },
+    {
+      "ticket_id": "CTL-459",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 633,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 59.766582,
+        "turns": 138,
+        "wall_hours": 0.2168
+      }
+    },
+    {
+      "ticket_id": "CTL-460",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1699,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 67.330609,
+        "turns": 165,
+        "wall_hours": 0.3203
+      }
+    },
+    {
+      "ticket_id": "CTL-461",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 13.484974,
+        "turns": 29,
+        "wall_hours": 0.0326
+      }
+    },
+    {
+      "ticket_id": "CTL-462",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 701,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 60.058895,
+        "turns": 137,
+        "wall_hours": 0.2902
+      }
+    },
+    {
+      "ticket_id": "CTL-463",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1179,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 86.889438,
+        "turns": 188,
+        "wall_hours": 0.5343
+      }
+    },
+    {
+      "ticket_id": "CTL-464",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 756,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 95.714054,
+        "turns": 147,
+        "wall_hours": 0.4626
+      }
+    },
+    {
+      "ticket_id": "CTL-465",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 927,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 107.149018,
+        "turns": 148,
+        "wall_hours": 0.295
+      }
+    },
+    {
+      "ticket_id": "CTL-466",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 16.682458,
+        "turns": 42,
+        "wall_hours": 0.0446
+      }
+    },
+    {
+      "ticket_id": "CTL-467",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 819,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 64.495008,
+        "turns": 163,
+        "wall_hours": 0.3537
+      }
+    },
+    {
+      "ticket_id": "CTL-468",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 953,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 62.050632,
+        "turns": 160,
+        "wall_hours": 0.4781
+      }
+    },
+    {
+      "ticket_id": "CTL-469",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1116,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 78.69648,
+        "turns": 163,
+        "wall_hours": 0.3486
+      }
+    },
+    {
+      "ticket_id": "CTL-470",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 22.170012,
+        "turns": 47,
+        "wall_hours": 0.0598
+      }
+    },
+    {
+      "ticket_id": "CTL-473",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 604,
+        "changed_files": 15,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 232.313975,
+        "turns": 651,
+        "wall_hours": 3.0562
+      }
+    },
+    {
+      "ticket_id": "CTL-474",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 715,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-476",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 307,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 105.539383,
+        "turns": 229,
+        "wall_hours": 0.5846
+      }
+    },
+    {
+      "ticket_id": "CTL-477",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 30,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 55.667967,
+        "turns": 132,
+        "wall_hours": 0.1985
+      }
+    },
+    {
+      "ticket_id": "CTL-478",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 81.662454,
+        "turns": 141,
+        "wall_hours": 0.4212
+      }
+    },
+    {
+      "ticket_id": "CTL-479",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 146,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 65.630463,
+        "turns": 150,
+        "wall_hours": 0.3291
+      }
+    },
+    {
+      "ticket_id": "CTL-480",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 85,
+        "changed_files": 9,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 81.189341,
+        "turns": 170,
+        "wall_hours": 0.5845
+      }
+    },
+    {
+      "ticket_id": "CTL-481",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 78,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 43.49396,
+        "turns": 96,
+        "wall_hours": 0.2532
+      }
+    },
+    {
+      "ticket_id": "CTL-482",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 91,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 61.144385,
+        "turns": 107,
+        "wall_hours": 0.1986
+      }
+    },
+    {
+      "ticket_id": "CTL-483",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 768,
+        "changed_files": 10,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 84.131064,
+        "turns": 202,
+        "wall_hours": 0.3983
+      }
+    },
+    {
+      "ticket_id": "CTL-484",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1203,
+        "changed_files": 18,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 170.491421,
+        "turns": 318,
+        "wall_hours": 0.9571
+      }
+    },
+    {
+      "ticket_id": "CTL-485",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 49,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 74.743634,
+        "turns": 141,
+        "wall_hours": 0.3075
+      }
+    },
+    {
+      "ticket_id": "CTL-486",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 127,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 70.290515,
+        "turns": 128,
+        "wall_hours": 0.3143
+      }
+    },
+    {
+      "ticket_id": "CTL-487",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 335,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-489",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1026,
+        "changed_files": 14,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 227.6526,
+        "turns": 573,
+        "wall_hours": 22.2437
+      }
+    },
+    {
+      "ticket_id": "CTL-490",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 232,
+        "changed_files": 17,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 56.085507,
+        "turns": 177,
+        "wall_hours": 0.6193
+      }
+    },
+    {
+      "ticket_id": "CTL-491",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1368,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 237.79256,
+        "turns": 649,
+        "wall_hours": 3.6952
+      }
+    },
+    {
+      "ticket_id": "CTL-492",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 171,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 136.494934,
+        "turns": 440,
+        "wall_hours": 4.5573
+      }
+    },
+    {
+      "ticket_id": "CTL-493",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1123,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 119.6075,
+        "turns": 366,
+        "wall_hours": 4.1087
+      }
+    },
+    {
+      "ticket_id": "CTL-494",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 318,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 123.420606,
+        "turns": 378,
+        "wall_hours": 2.6092
+      }
+    },
+    {
+      "ticket_id": "CTL-495",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 752,
+        "changed_files": 18,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 201.729763,
+        "turns": 560,
+        "wall_hours": 5.3251
+      }
+    },
+    {
+      "ticket_id": "CTL-496",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1542,
+        "changed_files": 18,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 235.670048,
+        "turns": 580,
+        "wall_hours": 5.3203
+      }
+    },
+    {
+      "ticket_id": "CTL-497",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 374,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 145.004616,
+        "turns": 414,
+        "wall_hours": 177.408
+      }
+    },
+    {
+      "ticket_id": "CTL-498",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 330,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 114.072154,
+        "turns": 355,
+        "wall_hours": 2.41
+      }
+    },
+    {
+      "ticket_id": "CTL-499",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 180,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 107.541355,
+        "turns": 359,
+        "wall_hours": 2.5005
+      }
+    },
+    {
+      "ticket_id": "CTL-507",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 125,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 144.870502,
+        "turns": 376,
+        "wall_hours": 1.7894
+      }
+    },
+    {
+      "ticket_id": "CTL-509",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 882,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 198.604422,
+        "turns": 592,
+        "wall_hours": 4.225
+      }
+    },
+    {
+      "ticket_id": "CTL-511",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 4232,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 241.015992,
+        "turns": 543,
+        "wall_hours": 1.9579
+      }
+    },
+    {
+      "ticket_id": "CTL-512",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 739,
+        "changed_files": 13,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 91.261344,
+        "turns": 315,
+        "wall_hours": 8.7303
+      }
+    },
+    {
+      "ticket_id": "CTL-513",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 312,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 140.408796,
+        "turns": 374,
+        "wall_hours": 1.683
+      }
+    },
+    {
+      "ticket_id": "CTL-528",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 600,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 200.633817,
+        "turns": 491,
+        "wall_hours": 2.3733
+      }
+    },
+    {
+      "ticket_id": "CTL-529",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 9602,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 355.445777,
+        "turns": 550,
+        "wall_hours": 15.1146
+      }
+    },
+    {
+      "ticket_id": "CTL-530",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1432,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 231.234992,
+        "turns": 530,
+        "wall_hours": 13.9801
+      }
+    },
+    {
+      "ticket_id": "CTL-531",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 786,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 203.132841,
+        "turns": 493,
+        "wall_hours": 2.1238
+      }
+    },
+    {
+      "ticket_id": "CTL-532",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 3896,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 162.472662,
+        "turns": 402,
+        "wall_hours": 1.9523
+      }
+    },
+    {
+      "ticket_id": "CTL-533",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 3302,
+        "changed_files": 14,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 208.97124,
+        "turns": 494,
+        "wall_hours": 2.4819
+      }
+    },
+    {
+      "ticket_id": "CTL-535",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 3650,
+        "changed_files": 20,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 285.863805,
+        "turns": 547,
+        "wall_hours": 2.6621
+      }
+    },
+    {
+      "ticket_id": "CTL-536",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1092,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 307.302535,
+        "turns": 657,
+        "wall_hours": 2.3438
+      }
+    },
+    {
+      "ticket_id": "CTL-539",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2404,
+        "changed_files": 10,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 201.614947,
+        "turns": 416,
+        "wall_hours": 1.8472
+      }
+    },
+    {
+      "ticket_id": "CTL-549",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 1.912272,
+        "turns": 40,
+        "wall_hours": 0.0689
+      }
+    },
+    {
+      "ticket_id": "CTL-554",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2235,
+        "changed_files": 13,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 327.701442,
+        "turns": 640,
+        "wall_hours": 2.2846
+      }
+    },
+    {
+      "ticket_id": "CTL-558",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1906,
+        "changed_files": 25,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 193.855284,
+        "turns": 422,
+        "wall_hours": 1.8014
+      }
+    },
+    {
+      "ticket_id": "CTL-564",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2926,
+        "changed_files": 14,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 272.081877,
+        "turns": 662,
+        "wall_hours": 1.6865
+      }
+    },
+    {
+      "ticket_id": "CTL-565",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1932,
+        "changed_files": 17,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 210.491457,
+        "turns": 480,
+        "wall_hours": 1.1567
+      }
+    },
+    {
+      "ticket_id": "CTL-566",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 146,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-567",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1470,
+        "changed_files": 10,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 137.68579,
+        "turns": 241,
+        "wall_hours": 0.4761
+      }
+    },
+    {
+      "ticket_id": "CTL-572",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 102,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 68.324921,
+        "turns": 159,
+        "wall_hours": 5.3648
+      }
+    },
+    {
+      "ticket_id": "CTL-573",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 312,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 110.736891,
+        "turns": 342,
+        "wall_hours": 8.8022
+      }
+    },
+    {
+      "ticket_id": "CTL-574",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1416,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-575",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 8,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-576",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 32,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-577",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 573,
+        "changed_files": 10,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 171.194828,
+        "turns": 239,
+        "wall_hours": 3.1524
+      }
+    },
+    {
+      "ticket_id": "CTL-578",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 848,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 136.917167,
+        "turns": 430,
+        "wall_hours": 8.923
+      }
+    },
+    {
+      "ticket_id": "CTL-579",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 178,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-582",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 3984,
+        "changed_files": 32,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-584",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 446,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-585",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1371,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 120.664619,
+        "turns": 410,
+        "wall_hours": 4.5595
+      }
+    },
+    {
+      "ticket_id": "CTL-586",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 364,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 89.046532,
+        "turns": 329,
+        "wall_hours": 8.5413
+      }
+    },
+    {
+      "ticket_id": "CTL-587",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 4302,
+        "changed_files": 14,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-588",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 216,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-589",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 86,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-596",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1328,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 247.735918,
+        "turns": 630,
+        "wall_hours": 9.0205
+      }
+    },
+    {
+      "ticket_id": "CTL-597",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 321,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 137.891502,
+        "turns": 422,
+        "wall_hours": 8.5062
+      }
+    },
+    {
+      "ticket_id": "CTL-598",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 98,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 98.442291,
+        "turns": 312,
+        "wall_hours": 19.7007
+      }
+    },
+    {
+      "ticket_id": "CTL-600",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 104.97408,
+        "turns": 344,
+        "wall_hours": 8.3089
+      }
+    },
+    {
+      "ticket_id": "CTL-601",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 78,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-602",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 576,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 87.069636,
+        "turns": 156,
+        "wall_hours": 8.8882
+      }
+    },
+    {
+      "ticket_id": "CTL-604",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1778,
+        "changed_files": 9,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 488.094683,
+        "turns": 1197,
+        "wall_hours": 22.2167
+      }
+    },
+    {
+      "ticket_id": "CTL-605",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 402,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 134.091154,
+        "turns": 346,
+        "wall_hours": 2.4577
+      }
+    },
+    {
+      "ticket_id": "CTL-606",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 366,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 325.385378,
+        "turns": 898,
+        "wall_hours": 22.206
+      }
+    },
+    {
+      "ticket_id": "CTL-607",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 632,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 241.455097,
+        "turns": 689,
+        "wall_hours": 31.0801
+      }
+    },
+    {
+      "ticket_id": "CTL-608",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 726,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 330.23131,
+        "turns": 827,
+        "wall_hours": 22.183
+      }
+    },
+    {
+      "ticket_id": "CTL-609",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 122.93298,
+        "turns": 294,
+        "wall_hours": 18.9645
+      }
+    },
+    {
+      "ticket_id": "CTL-610",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 750,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 264.182589,
+        "turns": 582,
+        "wall_hours": 22.1728
+      }
+    },
+    {
+      "ticket_id": "CTL-611",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1084,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 434.640681,
+        "turns": 1182,
+        "wall_hours": 38.4595
+      }
+    },
+    {
+      "ticket_id": "CTL-612",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 78.708714,
+        "turns": 259,
+        "wall_hours": 19.8052
+      }
+    },
+    {
+      "ticket_id": "CTL-613",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1096,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 306.110824,
+        "turns": 835,
+        "wall_hours": 20.7364
+      }
+    },
+    {
+      "ticket_id": "CTL-614",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 180,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 168.747083,
+        "turns": 587,
+        "wall_hours": 22.1497
+      }
+    },
+    {
+      "ticket_id": "CTL-615",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1359,
+        "changed_files": 15,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 277.41689,
+        "turns": 771,
+        "wall_hours": 22.1365
+      }
+    },
+    {
+      "ticket_id": "CTL-616",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 98.977275,
+        "turns": 308,
+        "wall_hours": 19.8973
+      }
+    },
+    {
+      "ticket_id": "CTL-617",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 174,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 158.128006,
+        "turns": 480,
+        "wall_hours": 22.1384
+      }
+    },
+    {
+      "ticket_id": "CTL-618",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 246,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 116.079358,
+        "turns": 347,
+        "wall_hours": 2.2466
+      }
+    },
+    {
+      "ticket_id": "CTL-619",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 236.981691,
+        "turns": 368,
+        "wall_hours": 2.7952
+      }
+    },
+    {
+      "ticket_id": "CTL-623",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 384,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 154.494904,
+        "turns": 394,
+        "wall_hours": 7.8364
+      }
+    },
+    {
+      "ticket_id": "CTL-624",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 611,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 182.218303,
+        "turns": 559,
+        "wall_hours": 2.4415
+      }
+    },
+    {
+      "ticket_id": "CTL-625",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 336,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 250.364315,
+        "turns": 606,
+        "wall_hours": 6.4549
+      }
+    },
+    {
+      "ticket_id": "CTL-628",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 30,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-632",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2612,
+        "changed_files": 13,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 175.634157,
+        "turns": 526,
+        "wall_hours": 3.23
+      }
+    },
+    {
+      "ticket_id": "CTL-633",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 797,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 189.454063,
+        "turns": 515,
+        "wall_hours": 2.9179
+      }
+    },
+    {
+      "ticket_id": "CTL-634",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1266,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 218.413648,
+        "turns": 547,
+        "wall_hours": 3.0401
+      }
+    },
+    {
+      "ticket_id": "CTL-635",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 204,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 309.029976,
+        "turns": 743,
+        "wall_hours": 22.7902
+      }
+    },
+    {
+      "ticket_id": "CTL-636",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 464,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 131.564189,
+        "turns": 389,
+        "wall_hours": 2.8843
+      }
+    },
+    {
+      "ticket_id": "CTL-637",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 687,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 139.53092,
+        "turns": 432,
+        "wall_hours": 0.9771
+      }
+    },
+    {
+      "ticket_id": "CTL-638",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1944,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 85.995287,
+        "turns": 173,
+        "wall_hours": 2.2218
+      }
+    },
+    {
+      "ticket_id": "CTL-640",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 283,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 335.7172,
+        "turns": 890,
+        "wall_hours": 8.4396
+      }
+    },
+    {
+      "ticket_id": "CTL-641",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 785,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 599.181355,
+        "turns": 1336,
+        "wall_hours": 8.4401
+      }
+    },
+    {
+      "ticket_id": "CTL-643",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1340,
+        "changed_files": 9,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 182.078839,
+        "turns": 546,
+        "wall_hours": 2.8103
+      }
+    },
+    {
+      "ticket_id": "CTL-649",
+      "title": "",
+      "tier": null,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 15108,
+        "changed_files": 51,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 1855.533115,
+        "turns": 2517,
+        "wall_hours": 41.7671
+      }
+    },
+    {
+      "ticket_id": "CTL-650",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2954,
+        "changed_files": 16,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 269.566689,
+        "turns": 654,
+        "wall_hours": 1.1989
+      }
+    },
+    {
+      "ticket_id": "CTL-653",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2265,
+        "changed_files": 17,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 322.757455,
+        "turns": 654,
+        "wall_hours": 2.4397
+      }
+    },
+    {
+      "ticket_id": "CTL-654",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1320,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 292.862253,
+        "turns": 565,
+        "wall_hours": 2.4373
+      }
+    },
+    {
+      "ticket_id": "CTL-655",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 526,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 201.499836,
+        "turns": 507,
+        "wall_hours": 2.4394
+      }
+    },
+    {
+      "ticket_id": "CTL-656",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 80,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 154.245283,
+        "turns": 299,
+        "wall_hours": 0.6372
+      }
+    },
+    {
+      "ticket_id": "CTL-657",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1892,
+        "changed_files": 12,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-658",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1334,
+        "changed_files": 9,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 338.520524,
+        "turns": 828,
+        "wall_hours": 1.6015
+      }
+    },
+    {
+      "ticket_id": "CTL-659",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 46.805469,
+        "turns": 118,
+        "wall_hours": 0.2732
+      }
+    },
+    {
+      "ticket_id": "CTL-660",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1644,
+        "changed_files": 9,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 336.745451,
+        "turns": 911,
+        "wall_hours": 5.6481
+      }
+    },
+    {
+      "ticket_id": "CTL-661",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1946,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 333.210313,
+        "turns": 907,
+        "wall_hours": 1.6782
+      }
+    },
+    {
+      "ticket_id": "CTL-662",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2078,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 392.250969,
+        "turns": 885,
+        "wall_hours": 1.8201
+      }
+    },
+    {
+      "ticket_id": "CTL-663",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 502,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 255.824832,
+        "turns": 666,
+        "wall_hours": 2.3386
+      }
+    },
+    {
+      "ticket_id": "CTL-664",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 799,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 240.439102,
+        "turns": 678,
+        "wall_hours": 1.1064
+      }
+    },
+    {
+      "ticket_id": "CTL-665",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 880,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 313.129666,
+        "turns": 848,
+        "wall_hours": 1.6132
+      }
+    },
+    {
+      "ticket_id": "CTL-666",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 534,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 163.504371,
+        "turns": 453,
+        "wall_hours": 0.8885
+      }
+    },
+    {
+      "ticket_id": "CTL-667",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1296,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 227.597511,
+        "turns": 542,
+        "wall_hours": 0.992
+      }
+    },
+    {
+      "ticket_id": "CTL-668",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 894,
+        "changed_files": 15,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-670",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 730,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 162.077721,
+        "turns": 426,
+        "wall_hours": 0.7459
+      }
+    },
+    {
+      "ticket_id": "CTL-671",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 966,
+        "changed_files": 17,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 375.419287,
+        "turns": 834,
+        "wall_hours": 10.9528
+      }
+    },
+    {
+      "ticket_id": "CTL-672",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 974,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-673",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1068,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 191.039346,
+        "turns": 564,
+        "wall_hours": 1.2709
+      }
+    },
+    {
+      "ticket_id": "CTL-674",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 290,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 136.261155,
+        "turns": 470,
+        "wall_hours": 0.9586
+      }
+    },
+    {
+      "ticket_id": "CTL-675",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 890,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 211.297303,
+        "turns": 607,
+        "wall_hours": 0.9973
+      }
+    },
+    {
+      "ticket_id": "CTL-676",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 891,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 126.516779,
+        "turns": 411,
+        "wall_hours": 1.6981
+      }
+    },
+    {
+      "ticket_id": "CTL-678",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1224,
+        "changed_files": 6,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 230.250654,
+        "turns": 718,
+        "wall_hours": 3.9005
+      }
+    },
+    {
+      "ticket_id": "CTL-679",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 824,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-680",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 86.995151,
+        "turns": 418,
+        "wall_hours": 1.2911
+      }
+    },
+    {
+      "ticket_id": "CTL-681",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1866,
+        "changed_files": 9,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 115.102846,
+        "turns": 588,
+        "wall_hours": 1.2502
+      }
+    },
+    {
+      "ticket_id": "CTL-682",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.797868,
+        "turns": 144,
+        "wall_hours": 0.2351
+      }
+    },
+    {
+      "ticket_id": "CTL-683",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 26.746874,
+        "turns": 132,
+        "wall_hours": 0.361
+      }
+    },
+    {
+      "ticket_id": "CTL-684",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2600,
+        "changed_files": 14,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 98.775071,
+        "turns": 559,
+        "wall_hours": 1.1923
+      }
+    },
+    {
+      "ticket_id": "CTL-685",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2456,
+        "changed_files": 12,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 101.866676,
+        "turns": 528,
+        "wall_hours": 0.8201
+      }
+    },
+    {
+      "ticket_id": "CTL-688",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 188,
+        "changed_files": 4,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 81.792204,
+        "turns": 423,
+        "wall_hours": 0.7902
+      }
+    },
+    {
+      "ticket_id": "CTL-689",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 456,
+        "changed_files": 3,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-690",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 534,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-692",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 30.232673,
+        "turns": 142,
+        "wall_hours": 0.5112
+      }
+    },
+    {
+      "ticket_id": "CTL-694",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1986,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 89.32958,
+        "turns": 459,
+        "wall_hours": 13.6001
+      }
+    },
+    {
+      "ticket_id": "CTL-695",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1122,
+        "changed_files": 8,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 720.709288,
+        "turns": 858,
+        "wall_hours": 14.5753
+      }
+    },
+    {
+      "ticket_id": "CTL-696",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 33.326122,
+        "turns": 282,
+        "wall_hours": 12.9916
+      }
+    },
+    {
+      "ticket_id": "CTL-701",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1188,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 76.547451,
+        "turns": 495,
+        "wall_hours": 1.0252
+      }
+    },
+    {
+      "ticket_id": "CTL-702",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 718,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 111.24954,
+        "turns": 488,
+        "wall_hours": 7.0339
+      }
+    },
+    {
+      "ticket_id": "CTL-703",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 45.481294,
+        "turns": 158,
+        "wall_hours": 0.4287
+      }
+    },
+    {
+      "ticket_id": "CTL-704",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 976,
+        "changed_files": 9,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 104.300672,
+        "turns": 513,
+        "wall_hours": 0.8949
+      }
+    },
+    {
+      "ticket_id": "CTL-705",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 3622,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 1253.509668,
+        "turns": 1389,
+        "wall_hours": 2.3856
+      }
+    },
+    {
+      "ticket_id": "CTL-706",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1280,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 113.049817,
+        "turns": 566,
+        "wall_hours": 1.179
+      }
+    },
+    {
+      "ticket_id": "CTL-707",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 3116,
+        "changed_files": 14,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 669.733874,
+        "turns": 839,
+        "wall_hours": 14.4291
+      }
+    },
+    {
+      "ticket_id": "CTL-709",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2420,
+        "changed_files": 7,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 105.406756,
+        "turns": 474,
+        "wall_hours": 0.9509
+      }
+    },
+    {
+      "ticket_id": "CTL-710",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2686,
+        "changed_files": 10,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 432.010488,
+        "turns": 354,
+        "wall_hours": 27.5446
+      }
+    },
+    {
+      "ticket_id": "CTL-711",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 352,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 227.826355,
+        "turns": 574,
+        "wall_hours": 21.2988
+      }
+    },
+    {
+      "ticket_id": "CTL-712",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 310,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 211.22251,
+        "turns": 533,
+        "wall_hours": 0.9671
+      }
+    },
+    {
+      "ticket_id": "CTL-713",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 940,
+        "changed_files": 5,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 166.39451,
+        "turns": 774,
+        "wall_hours": 14.1042
+      }
+    },
+    {
+      "ticket_id": "CTL-714",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 873,
+        "changed_files": 2,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 93.80001,
+        "turns": 471,
+        "wall_hours": 13.5528
+      }
+    },
+    {
+      "ticket_id": "CTL-715",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 24,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-718",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 17.538544,
+        "turns": 92,
+        "wall_hours": 0.2207
+      }
+    },
+    {
+      "ticket_id": "CTL-726",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 595,
+        "changed_files": 50,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 155.86295,
+        "turns": 1506,
+        "wall_hours": 13.4217
+      }
+    },
+    {
+      "ticket_id": "CTL-727",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 5089,
+        "changed_files": 15,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-728",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 0,
+        "turns": 741,
+        "wall_hours": 3.8214
+      }
+    },
+    {
+      "ticket_id": "CTL-729",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 0,
+        "turns": 561,
+        "wall_hours": 3.987
+      }
+    },
+    {
+      "ticket_id": "CTL-730",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1066,
+        "changed_files": 13,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-731",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1659,
+        "changed_files": 11,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 0,
+        "turns": 190,
+        "wall_hours": 2.6224
+      }
+    },
+    {
+      "ticket_id": "CTL-732",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 46,
+        "changed_files": 1,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-733",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 2686,
+        "changed_files": 20,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-735",
+      "title": "",
+      "tier": null,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1504,
+        "changed_files": 10,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-736",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 7408,
+        "changed_files": 26,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-737",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 0,
+        "turns": 0,
+        "wall_hours": 0.0109
+      }
+    },
+    {
+      "ticket_id": "CTL-739",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 0,
+        "turns": 3,
+        "wall_hours": 0.0512
+      }
+    },
+    {
+      "ticket_id": "CTL-740",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 0,
+        "turns": 1,
+        "wall_hours": 0.0298
+      }
+    },
+    {
+      "ticket_id": "CTL-741",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 0,
+        "turns": 3,
+        "wall_hours": 0.0521
+      }
+    },
+    {
+      "ticket_id": "CTL-742",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 1.820231,
+        "turns": 19,
+        "wall_hours": 0.0443
+      }
+    },
+    {
+      "ticket_id": "CTL-747",
+      "title": "",
+      "tier": null,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 2.573568,
+        "turns": 52,
+        "wall_hours": 0.0545
+      }
+    },
+    {
+      "ticket_id": "CTL-748",
+      "title": "",
+      "tier": null,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": 1146,
+        "changed_files": 32,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 105.234499,
+        "turns": 713,
+        "wall_hours": 3.1255
+      }
+    },
+    {
+      "ticket_id": "CTL-749",
+      "title": "",
+      "tier": null,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "reconstructed from CTL-746 actuals corpus",
+      "signals": {
+        "loc": null,
+        "changed_files": null,
+        "domains": [],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 2.008478,
+        "turns": 37,
+        "wall_hours": 0.0533
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-02T09:45:00Z -->
<!-- Last updated: 2026-06-02T09:45:00Z -->
<!-- PR: #1273 -->
<!-- Previous commits: e0ade74d5dc1195b3db8dbc5cda4440a7e7d7e6b,f5f017ac3c80b8b7c2d71826e9375fd37f44f861 -->

## Summary

Wires phase-triage to produce and persist a real reference-class complexity estimate (1/3/5/8/13) for every triaged ticket — replacing the old word-count heuristic. The estimate flows from the committed corpus through triage.json and lands on the Linear estimate field automatically when the scheduler advances the ticket from Triage → Research.

Four phases land together:

- **Phase 1**: `adapt-reference-corpus.ts` adapter that maps the flat CTL-746 corpus to the `entries[]` schema `loadCorpus()` accepts, plus `reference-class-corpus.json` (1 146 entries) committed as the canonical estimator corpus.
- **Phase 2**: `phase-triage` SKILL.md updated — Opus-mode step 2b runs `reference-class-lookup.ts` against the corpus, snaps to the nearest fibonacci point, and writes `estimate` into `triage.json`. The fenced bash body is unchanged so the CTL-558 e2e negative guard stays green.
- **Phase 3**: `applyEstimate({ ticket, estimate })` added to `linear-write.mjs`, mirroring `applyLabel`'s try/catch + `log.warn` + tagged-return shape. Input is validated against `ALLOWED_ESTIMATE_POINTS = {1,3,5,8,13}`; invalid values are rejected before any exec call (tolerate-failure semantics, never fails triage).
- **Phase 4**: `readTriageEstimate()` helper + `safeWrite(applyEstimate)` hooked into `schedulerTick`'s triage→research advance path, gated on `next === "research"` and a valid numeric points value. A missing or invalid estimate is a silent skip (Q4 requirement).

## Changes Made

### `plugins/pm/scripts/estimate/` (new files)

- `adapt-reference-corpus.ts` — pure `adaptCorpus()` transform: drops `_meta` + zero-point entries, renames `wall_time_hours → wall_hours`, lifts git signals, emits neutral defaults for absent fields. 90 lines.
- `reference-class-corpus.json` — 1 146 reference-class entries (577 KB) generated from `thoughts/shared/pm/analyses/reference-corpus.json`. Committed as the authoritative estimator corpus.
- `__tests__/adapt-reference-corpus.test.ts` — 6 unit tests covering transform correctness, field renaming, filtering, and neutral defaults.
- `__tests__/lookup-corpus-integration.test.ts` — 1 integration test verifying `loadCorpus()` accepts the adapted file without throwing.

### `plugins/dev/skills/phase-triage/SKILL.md`

- Added step 2b to the Opus-mode section: run `reference-class-lookup.ts`, parse `reference_class.points`, snap to 1/3/5/8/13, write `estimate` into `triage.json`. The existing fenced bash body that the CTL-558 e2e guard tests is not touched.

### `plugins/dev/scripts/execution-core/linear-write.mjs`

- `applyEstimate({ ticket, estimate, exec })` — new exported function mirroring `applyLabel` shape. Guards against non-fibonacci inputs, calls the Linear `issueUpdate` mutation, logs on failure, returns a tagged `{ok, error}` result. 32 lines.

### `plugins/dev/scripts/execution-core/linear-write.test.mjs`

- 7 new tests: happy path (all five valid point values), invalid value rejection, exec-failure toleration, missing-estimate early-exit.

### `plugins/dev/scripts/execution-core/scheduler.mjs`

- `readTriageEstimate(triageJsonPath)` — reads `triage.json`, returns numeric estimate or `null`.
- `safeWrite(applyEstimate)` call inserted in `schedulerTick` after `applyPhaseStatus` on the triage→research transition. Gated on `next === "research"` and a valid numeric value; invalid/absent estimate is a no-op. 26 lines.

### `plugins/dev/scripts/execution-core/scheduler.test.mjs`

- 5 new tests: estimate written on triage→research, skipped on other transitions, skipped on non-fibonacci value, skipped when triage.json absent, tolerated when `applyEstimate` throws.

## How to Verify

- [x] `bun test plugins/pm/scripts/estimate/__tests__/adapt-reference-corpus.test.ts` — 6 pass ✅
- [x] `bun test plugins/pm/scripts/estimate/__tests__/lookup-corpus-integration.test.ts` — 1 pass ✅
- [x] `bun test plugins/dev/scripts/execution-core/linear-write.test.mjs` — 42 pass (7 new) ✅
- [x] `bun test plugins/dev/scripts/execution-core/scheduler.test.mjs` — 299 pass (5 new) ✅
- [ ] `bash plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh` — 39/39 pass (CTL-558 guard intact — manual run required)
- [ ] Triage a real ticket end-to-end; confirm `triage.json` contains a numeric `estimate` and the Linear estimate field shows 1/3/5/8/13

## CI Status

All checks passing: Cloudflare Pages, audit-references, check-versions, docs-gate, validate.

## Related Issues

- Closes https://linear.app/coalesce-labs/issue/CTL-751
- Builds on CTL-746 (reference-class estimation tooling + corpus extractor, already on main)
- Feeds CTL-747 (per-phase effort / workflow escalation consumes `estimate` from triage.json)
- Supersedes CTL-497's word-count write-back approach
- Must not break CTL-558 e2e negative guard (verified: fenced bash body unchanged)
