### PR TITLE
fix(dev): CTL-752 neutralize frozen-daemon workflow_id leak + doc join queries

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-session-claude.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-session-claude.test.sh
@@ -230,6 +230,37 @@ STORED_TURNS="$(sqlite3 "$CATALYST_DB_FILE" \
   "SELECT num_turns FROM session_metrics WHERE session_id = '${SID_TURNS}';")"
 expect_eq "metric --turns writes num_turns to DB" "12" "$STORED_TURNS"
 
+# ─── 14. CTL-752: workflow_id resolution (frozen-daemon leak guard) ──────────
+
+# (a) A leaked daemon session id passed as --workflow is overridden by ORCH_ID.
+WF_SID="$(CATALYST_ORCHESTRATOR_ID=CTL-752 bash "$SESSION_SCRIPT" start \
+          --skill phase-plan --ticket CTL-752 \
+          --workflow "sess_20260528T202656_16651cb1")"
+WF_DB="$(sqlite3 "$CATALYST_DB_FILE" \
+  "SELECT workflow_id FROM sessions WHERE session_id = '$WF_SID';")"
+expect_eq "leaked sess_* --workflow overridden by CATALYST_ORCHESTRATOR_ID" \
+  "CTL-752" "$WF_DB"
+
+# (b) An explicit, non-sess_* workflow id is preserved (legacy oneshot parent).
+WF_SID2="$(CATALYST_ORCHESTRATOR_ID=CTL-752 bash "$SESSION_SCRIPT" start \
+           --skill oneshot --ticket CTL-752 --workflow "wf-legacy-parent")"
+WF_DB2="$(sqlite3 "$CATALYST_DB_FILE" \
+  "SELECT workflow_id FROM sessions WHERE session_id = '$WF_SID2';")"
+expect_eq "explicit non-sess_* workflow id preserved" "wf-legacy-parent" "$WF_DB2"
+
+# (c) Empty --workflow with ORCH_ID set populates workflow_id from ORCH_ID.
+WF_SID3="$(CATALYST_ORCHESTRATOR_ID=CTL-752 bash "$SESSION_SCRIPT" start \
+           --skill phase-research --ticket CTL-752 --workflow "")"
+WF_DB3="$(sqlite3 "$CATALYST_DB_FILE" \
+  "SELECT workflow_id FROM sessions WHERE session_id = '$WF_SID3';")"
+expect_eq "empty --workflow falls back to CATALYST_ORCHESTRATOR_ID" "CTL-752" "$WF_DB3"
+
+# (d) No ORCH_ID + no --workflow → workflow_id stays empty (interactive, no regression).
+WF_SID4="$(env -u CATALYST_ORCHESTRATOR_ID bash "$SESSION_SCRIPT" start --skill manual)"
+WF_DB4="$(sqlite3 "$CATALYST_DB_FILE" \
+  "SELECT COALESCE(workflow_id,'') FROM sessions WHERE session_id = '$WF_SID4';")"
+expect_eq "no orch id + no workflow stays empty (no regression)" "" "$WF_DB4"
+
 echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES"
 exit "$FAILURES"

--- a/plugins/dev/scripts/catalyst-session.sh
+++ b/plugins/dev/scripts/catalyst-session.sh
@@ -261,6 +261,16 @@ cmd_start() {
   # Flag wins over env (caller has direct knowledge).
   [[ -z "$claude_session_id" ]] && claude_session_id="${CLAUDE_CODE_SESSION_ID:-}"
 
+  # CTL-752: resolve the orchestration-run grouping key for workflow_id.
+  # A bg phase worker has no real parent session, but the daemon's frozen
+  # CATALYST_SESSION_ID leaks across the `claude --bg` boundary (CTL-635) and
+  # the phase preludes pass it as --workflow, polluting workflow_id with a stale
+  # sess_* daemon id. Prefer the orchestrator id (the true run id; == ticket
+  # under execution-core) when --workflow is empty or is a leaked session id.
+  if [[ -z "$workflow" || "$workflow" == sess_* ]]; then
+    workflow="${CATALYST_ORCHESTRATOR_ID:-$workflow}"
+  fi
+
   # Generate a sortable, reasonably-unique session id without forking uuidgen
   # (uuidgen fork ~10ms, which we want to keep for the callers, not ourselves).
   local stamp rand sid

--- a/website/src/content/docs/reference/catalyst-session.md
+++ b/website/src/content/docs/reference/catalyst-session.md
@@ -96,6 +96,56 @@ export CATALYST_SESSION_ID
 Skills wrap this in an `if [[ -x "$SESSION_SCRIPT" ]]` guard so they degrade gracefully when the
 script is unavailable (e.g., in CI environments without the dev plugin installed).
 
+## Token / cost attribution join
+
+Each phase worker session stores `claude_session_id` (the Claude Code session UUID), `ticket_key`,
+`skill_name` (used as the phase label), and `workflow_id` (the orchestration-run id, typically the
+ticket key under execution-core). This makes it possible to attribute Claude Code's native OTEL
+token counters back to a Linear ticket and pipeline phase without relying on per-job
+`OTEL_RESOURCE_ATTRIBUTES` — which are dropped at the `claude --bg` daemon boundary (see CTL-635).
+
+This is the interim path that sidesteps the CTL-635 `--bg` resource-attribute drop. See also the
+[research doc](../../../../thoughts/shared/research/2026-06-02-ctl-752.md) for a full analysis.
+
+### Per-phase cost/tokens for one ticket
+
+Works today against `~/catalyst/catalyst.db`:
+
+```sql
+SELECT s.ticket_key, s.skill_name AS phase, s.claude_session_id,
+       sm.cost_usd, sm.input_tokens, sm.output_tokens, sm.cache_read_tokens
+FROM sessions s
+LEFT JOIN session_metrics sm ON sm.session_id = s.session_id
+WHERE s.ticket_key = 'CTL-752'
+ORDER BY s.started_at;
+```
+
+### All phases of one orchestration run
+
+Enabled by the `workflow_id` fix (CTL-752): phase workers now store the orchestrator id (e.g. the
+ticket key under execution-core) in `workflow_id` instead of a leaked daemon `sess_*` value.
+
+```sql
+SELECT skill_name AS phase, claude_session_id, status
+FROM sessions WHERE workflow_id = 'CTL-752' ORDER BY started_at;
+```
+
+Under execution-core `workflow_id` equals `ticket_key` for single-ticket runs. The `workflow_id`
+column becomes meaningful for multi-ticket runs where the orchestrator id differs from the ticket.
+
+### Join to Claude Code OTEL metrics
+
+When the Claude Code OTEL exporter is enabled (currently opt-in / disabled by default), native
+token counters are keyed by `session.id`:
+
+```
+claude_code_cost_usage_USD_total{session_id="<claude_session_id>"}
+```
+
+Match `claude_session_id` from the DB query above to `session_id` in the OTEL metric labels to
+correlate cost metrics with ticket + phase data. See CTL-635 and the
+[`catalyst-otel-forward`](/observability/forwarder/) docs for the current forwarding topology.
+
 ## Related
 
 - [Agent Communication (catalyst-comms)](./catalyst-comms/) — sibling CLI for cross-agent messaging


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-02T00:00:00Z -->
<!-- Last updated: 2026-06-02T00:00:00Z -->
<!-- PR: #1274 -->
<!-- Previous commits: 2d6f2f2623e66cbd0be91522e4ad7cb4c071e090,4d128fd580226fec112a57cd27f509503f30f927 -->

## Summary

Two-phase fix for phase-worker session attribution in the `catalyst.db` sessions table.

- **Phase 1** — Fix `workflow_id` pollution in `catalyst-session.sh cmd_start`: when `--workflow` is empty or contains a leaked daemon `sess_*` value (a frozen `CATALYST_SESSION_ID` that crosses the `claude --bg` boundary), override it with `CATALYST_ORCHESTRATOR_ID`. Phase workers now store the true orchestration-run id in `workflow_id` instead of a stale daemon session id.
- **Phase 2** — Document the `claude_session_id → ticket + phase` join queries in `website/src/content/docs/reference/catalyst-session.md`, including the `workflow_id`-grouped all-phases query that becomes meaningful after Phase 1's fix.

Phase 3 (cosmetic prelude cleanup across 8 SKILL.md files) deferred — zero behavioral change after the centralized fix in Phase 1.

## What changed

### `plugins/dev/scripts/catalyst-session.sh`

Added a 10-line resolution block in `cmd_start` that applies after `--workflow` is parsed and before the session id is generated. Logic:

- If `--workflow` is absent or is a `sess_*` string, replace with `$CATALYST_ORCHESTRATOR_ID` (when set).
- If `--workflow` is an explicit non-`sess_*` value (e.g., a legacy oneshot parent id), preserve it unchanged.
- If neither is set (interactive run, no orchestrator), `workflow_id` stays empty — no regression for existing callers.

### `plugins/dev/scripts/__tests__/catalyst-session-claude.test.sh`

Four new test cases (section 14, CTL-752) covering all four resolution branches:

1. Leaked `sess_*` value overridden by `CATALYST_ORCHESTRATOR_ID`
2. Explicit non-`sess_*` workflow id preserved
3. Empty `--workflow` falls back to `CATALYST_ORCHESTRATOR_ID`
4. No `CATALYST_ORCHESTRATOR_ID` + no `--workflow` → empty (no regression)

### `website/src/content/docs/reference/catalyst-session.md`

New "Token / cost attribution join" section documenting:

- The per-phase cost/tokens query joining `sessions` + `session_metrics` by `ticket_key`
- The all-phases-of-one-run query using `workflow_id` (enabled by Phase 1)
- How to correlate `claude_session_id` from the DB to OTEL `session.id` metric labels

## How to verify

- [x] `bash plugins/dev/scripts/__tests__/catalyst-session-claude.test.sh` — 36/36 pass (4 new CTL-752 assertions) ✅
- [x] `bash plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh` — 53/53 pass (regression) ✅
- [x] CI checks all pass (audit-references, check-versions, docs-gate, validate, Cloudflare Pages) ✅
- [ ] After merge: `sqlite3 ~/catalyst/catalyst.db "SELECT skill_name, workflow_id FROM sessions WHERE ticket_key='CTL-752'"` shows `workflow_id = CTL-752`, not `sess_*`

## Related issues

- Refs: https://linear.app/coalesce-labs/issue/CTL-752
- Context: CTL-635 (the `--bg` env scrub that made the daemon identity honest but left `workflow_id` polluted)
