### PR TITLE
CTL-550: [M5·seam] Linear app-actor identity for phase-agent mirror comments

### DIFF
--- a/docs/schemas/machine-config.schema.json
+++ b/docs/schemas/machine-config.schema.json
@@ -86,6 +86,41 @@
             }
           }
         },
+        "linear": {
+          "type": "object",
+          "description": "Linear app-actor credentials for the Catalyst agent identity.",
+          "additionalProperties": false,
+          "properties": {
+            "agent": {
+              "type": "object",
+              "description": "OAuth app-actor credentials. Never commit. Set up by setup-catalyst.sh.",
+              "additionalProperties": false,
+              "required": ["clientId", "clientSecret"],
+              "properties": {
+                "clientId": {
+                  "type": "string",
+                  "description": "Linear OAuth app client ID."
+                },
+                "clientSecret": {
+                  "type": "string",
+                  "description": "Linear OAuth app client secret. Used to mint client_credentials tokens."
+                },
+                "accessToken": {
+                  "type": "string",
+                  "description": "Pre-minted app-actor access token (lin_oauth_*). May be stale; prefer minting fresh via clientId/clientSecret."
+                },
+                "webhookSecret": {
+                  "type": "string",
+                  "description": "HMAC webhook signing secret for the Linear app webhook."
+                },
+                "botUserId": {
+                  "type": "string",
+                  "description": "Linear user UUID of the app actor. Used for loop prevention (suppresses events authored by the agent)."
+                }
+              }
+            }
+          }
+        },
         "orchestration": {
           "type": "object",
           "description": "Orchestration overrides. Concurrency fields here win per-field over Layer-1 values. Use this to tune concurrency per machine without modifying committed config.",

--- a/plugins/dev/scripts/__tests__/lib/linearis-stub.sh
+++ b/plugins/dev/scripts/__tests__/lib/linearis-stub.sh
@@ -161,3 +161,32 @@ EOF
 	fi
 	chmod +x "${bin_dir}/linearis"
 }
+
+# linear_comment_post_stub_install — stub for linear-comment-post.sh (CTL-550).
+# Creates a "linear-comment-post.sh" shim in bin_dir that logs args and exits 0.
+linear_comment_post_stub_install() {
+	local bin_dir="${1:?bin_dir required}"
+	local log_file="${2:?log_file required}"
+	mkdir -p "${bin_dir}"
+	cat >"${bin_dir}/linear-comment-post.sh" <<EOF
+#!/usr/bin/env bash
+LOG="${log_file}"
+printf '%s\n' "\$@" >> "\$LOG"
+echo '{"success":true}'
+EOF
+	chmod +x "${bin_dir}/linear-comment-post.sh"
+}
+
+linear_comment_post_stub_install_failing() {
+	local bin_dir="${1:?bin_dir required}"
+	local log_file="${2:?log_file required}"
+	mkdir -p "${bin_dir}"
+	cat >"${bin_dir}/linear-comment-post.sh" <<EOF
+#!/usr/bin/env bash
+LOG="${log_file}"
+printf '%s\n' "\$@" >> "\$LOG"
+echo "linear-comment-post stub: simulated failure" >&2
+exit 1
+EOF
+	chmod +x "${bin_dir}/linear-comment-post.sh"
+}

--- a/plugins/dev/scripts/__tests__/linear-comment-post.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-comment-post.test.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# linear-comment-post.test.sh — unit tests for linear-comment-post.sh (CTL-550)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../lib/linear-comment-post.sh"
+
+PASS=0
+FAIL=0
+
+assert_exit_zero() {
+  local desc="$1"; shift
+  local actual_exit=0
+  "$@" >/dev/null 2>&1 || actual_exit=$?
+  if [[ "$actual_exit" -eq 0 ]]; then
+    echo "PASS: $desc"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: $desc (exit $actual_exit, expected 0)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_exit_nonzero() {
+  local desc="$1"; shift
+  local actual_exit=0
+  "$@" >/dev/null 2>&1 || actual_exit=$?
+  if [[ "$actual_exit" -ne 0 ]]; then
+    echo "PASS: $desc"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: $desc (exit 0, expected non-zero)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_file_exists() {
+  local path="$1"
+  local desc="$2"
+  if [[ -f "$path" ]]; then
+    echo "PASS: $desc"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: $desc (file not found: $path)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_executable() {
+  local path="$1"
+  local desc="$2"
+  if [[ -x "$path" ]]; then
+    echo "PASS: $desc"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: $desc (not executable: $path)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# --- Test 1: script exists and is executable ---
+assert_file_exists "$HELPER" "linear-comment-post.sh exists"
+assert_executable "$HELPER" "linear-comment-post.sh is executable"
+
+# --- Test 2: exits non-zero with no args ---
+assert_exit_nonzero "exits non-zero with no args" bash "$HELPER"
+
+# --- Test 3: exits non-zero with only one arg ---
+assert_exit_nonzero "exits non-zero with only ticket arg" bash "$HELPER" "CTL-550"
+
+# --- Test 4-7: stub curl PATH overrides ---
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+BIN_DIR="${TMPDIR_TEST}/bin"
+mkdir -p "$BIN_DIR"
+
+# Test 4: exits 0 when curl stub returns valid token + issue UUID + comment success
+cat >"${BIN_DIR}/curl" <<'CURLEOF'
+#!/usr/bin/env bash
+# Inspect args to route responses
+ARGS_STR="$*"
+if printf '%s' "$ARGS_STR" | grep -q "oauth/token"; then
+  printf '{"access_token":"test_token","token_type":"Bearer"}'
+elif printf '%s' "$ARGS_STR" | grep -q "commentCreate"; then
+  printf '{"data":{"commentCreate":{"success":true}}}'
+else
+  printf '{"data":{"issues":{"nodes":[{"id":"issue-uuid-123"}]}}}'
+fi
+exit 0
+CURLEOF
+chmod +x "${BIN_DIR}/curl"
+
+# Export creds via env (avoids filesystem walk)
+export CATALYST_LINEAR_AGENT_CLIENT_ID="test-cid"
+export CATALYST_LINEAR_AGENT_CLIENT_SECRET="test-csec"
+
+PATH="${BIN_DIR}:$PATH" assert_exit_zero \
+  "exits 0 on successful token + comment post" \
+  bash "$HELPER" "CTL-550" "Hello from test"
+
+# Test 5: exits non-zero when token mint fails (curl returns error body, no access_token)
+cat >"${BIN_DIR}/curl" <<'CURLEOF'
+#!/usr/bin/env bash
+if printf '%s\n' "$@" | grep -q "oauth/token"; then
+  printf '{"error":"invalid_client"}'
+fi
+exit 0
+CURLEOF
+chmod +x "${BIN_DIR}/curl"
+
+PATH="${BIN_DIR}:$PATH" assert_exit_nonzero \
+  "exits non-zero when token mint returns no access_token" \
+  bash "$HELPER" "CTL-550" "body"
+
+# Test 6: exits non-zero when issue UUID resolution fails (empty nodes)
+cat >"${BIN_DIR}/curl" <<'CURLEOF'
+#!/usr/bin/env bash
+ARGS_STR="$*"
+if printf '%s' "$ARGS_STR" | grep -q "oauth/token"; then
+  printf '{"access_token":"tok"}'
+elif printf '%s' "$ARGS_STR" | grep -q "commentCreate"; then
+  printf '{"data":{"commentCreate":{"success":true}}}'
+else
+  printf '{"data":{"issues":{"nodes":[]}}}'
+fi
+exit 0
+CURLEOF
+chmod +x "${BIN_DIR}/curl"
+
+PATH="${BIN_DIR}:$PATH" assert_exit_nonzero \
+  "exits non-zero when issue not found (empty nodes)" \
+  bash "$HELPER" "CTL-550" "body"
+
+# Test 7: exits non-zero when commentCreate returns success: false
+cat >"${BIN_DIR}/curl" <<'CURLEOF'
+#!/usr/bin/env bash
+ARGS_STR="$*"
+if printf '%s' "$ARGS_STR" | grep -q "oauth/token"; then
+  printf '{"access_token":"tok"}'
+elif printf '%s' "$ARGS_STR" | grep -q "commentCreate"; then
+  printf '{"data":{"commentCreate":{"success":false}}}'
+else
+  printf '{"data":{"issues":{"nodes":[{"id":"uuid-1"}]}}}'
+fi
+exit 0
+CURLEOF
+chmod +x "${BIN_DIR}/curl"
+
+PATH="${BIN_DIR}:$PATH" assert_exit_nonzero \
+  "exits non-zero when commentCreate returns success=false" \
+  bash "$HELPER" "CTL-550" "body"
+
+# Test 8: exits non-zero when CATALYST_LINEAR_AGENT_CLIENT_ID not set and no config
+unset CATALYST_LINEAR_AGENT_CLIENT_ID
+unset CATALYST_LINEAR_AGENT_CLIENT_SECRET
+
+# Run from a dir with no .catalyst/config.json ancestry
+assert_exit_nonzero \
+  "exits non-zero when no creds and no config file" \
+  bash -c "cd /tmp && bash '$HELPER' CTL-550 body"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[[ "$FAIL" -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
@@ -443,8 +443,8 @@ echo "Test 11 (CTL-632): phase-implement contract — mirror block present"
 if [[ -f "$SKILL_IMPLEMENT" ]]; then
   assert_grep 'phase-implement-mirror' "$SKILL_IMPLEMENT" "body contains uniquely-named mirror fence"
   assert_grep '\.linear-mirror-' "$SKILL_IMPLEMENT" "body references the per-phase marker file"
-  assert_grep 'linearis issues discuss' "$SKILL_IMPLEMENT" "body calls linearis issues discuss"
-  assert_grep 'linearis discuss failed \(continuing\)' "$SKILL_IMPLEMENT" "body has fail-open warning string"
+  assert_grep 'linear-comment-post.sh' "$SKILL_IMPLEMENT" "body calls linear-comment-post.sh"
+  assert_grep 'linear-comment-post failed \(continuing\)' "$SKILL_IMPLEMENT" "body has fail-open warning string"
 fi
 
 # ─── Test 12 (CTL-632): runtime mirror exercises ──────────────────────────
@@ -502,10 +502,11 @@ run_implement_mirror() {
 
   build_git_fixture "$repo_dir" "$git_base"
 
+  linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
   if [[ "$stub_kind" == "ok" ]]; then
-    linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+    linear_comment_post_stub_install "$case_dir/bin" "$case_dir/comment-post-calls.log"
   else
-    linearis_stub_install_failing "$case_dir/bin" "$case_dir/linearis-calls.log"
+    linear_comment_post_stub_install_failing "$case_dir/bin" "$case_dir/comment-post-calls.log"
   fi
 
   if [[ -n "$preseed_marker" ]]; then
@@ -527,11 +528,11 @@ run_implement_mirror() {
 # Case A: happy — git fixture has origin/main, two commits on feature.
 CASE_A="$(run_implement_mirror happy ok '' yes)"
 assert_eq "0" "$(cat "$CASE_A/exit-code")" "mirror-implement happy: exit 0"
-LOG_A="$CASE_A/linearis-calls.log"
-if grep -q '^discuss$' "$LOG_A" 2>/dev/null; then
-  pass "mirror-implement happy: discuss landed"
+LOG_A="$CASE_A/comment-post-calls.log"
+if grep -q 'CTL-449' "$LOG_A" 2>/dev/null; then
+  pass "mirror-implement happy: comment posted"
 else
-  fail "mirror-implement happy: discuss" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+  fail "mirror-implement happy: comment post" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
 fi
 if grep -q 'Phase Implement' "$LOG_A" 2>/dev/null; then
   pass "mirror-implement happy: body contains 'Phase Implement' header"
@@ -568,7 +569,7 @@ CASE_B="$(run_implement_mirror failopen fail '' yes)"
 assert_eq "0" "$(cat "$CASE_B/exit-code")" "mirror-implement fail-open: exit 0"
 MARKER_B="$CASE_B/orch/workers/CTL-449/.linear-mirror-implement"
 [[ ! -e "$MARKER_B" ]] && pass "mirror-implement fail-open: no marker" || fail "marker should not exist"
-if grep -q 'linearis discuss failed (continuing)' "$CASE_B/stderr.log" 2>/dev/null; then
+if grep -q 'linear-comment-post failed (continuing)' "$CASE_B/stderr.log" 2>/dev/null; then
   pass "mirror-implement fail-open: warning to stderr"
 else
   fail "mirror-implement fail-open: warning" "stderr:$(printf '\n%s' "$(cat "$CASE_B/stderr.log" 2>/dev/null)")"
@@ -577,11 +578,11 @@ fi
 # Case C: idempotent.
 CASE_C="$(run_implement_mirror idempot ok seed yes)"
 assert_eq "0" "$(cat "$CASE_C/exit-code")" "mirror-implement idempotent: exit 0"
-LOG_C="$CASE_C/linearis-calls.log"
-if [[ ! -f "$LOG_C" ]] || ! grep -q '^discuss$' "$LOG_C" 2>/dev/null; then
-  pass "mirror-implement idempotent: discuss skipped"
+LOG_C="$CASE_C/comment-post-calls.log"
+if [[ ! -f "$LOG_C" ]] || ! grep -q 'CTL-449' "$LOG_C" 2>/dev/null; then
+  pass "mirror-implement idempotent: comment post skipped"
 else
-  fail "mirror-implement idempotent: discuss" "marker not honored"
+  fail "mirror-implement idempotent: comment post" "marker not honored"
 fi
 
 # Case D: no-base-branch — fixture omits origin/main; delete main too so the
@@ -608,6 +609,7 @@ REPO_D="${CASE_D_DIR}/repo"
 mkdir -p "$CASE_D_DIR/bin" "$WORKER_D"
 build_git_fixture_no_base "$REPO_D"
 linearis_stub_install "$CASE_D_DIR/bin" "$CASE_D_DIR/linearis-calls.log"
+linear_comment_post_stub_install "$CASE_D_DIR/bin" "$CASE_D_DIR/comment-post-calls.log"
 
 (
   cd "$REPO_D" || exit 1
@@ -620,11 +622,11 @@ linearis_stub_install "$CASE_D_DIR/bin" "$CASE_D_DIR/linearis-calls.log"
 )
 
 assert_eq "0" "$(cat "$CASE_D_DIR/exit-code")" "mirror-implement no-base: exit 0"
-LOG_D="$CASE_D_DIR/linearis-calls.log"
-if grep -q '^discuss$' "$LOG_D" 2>/dev/null; then
+LOG_D="$CASE_D_DIR/comment-post-calls.log"
+if grep -q 'CTL-449' "$LOG_D" 2>/dev/null; then
   pass "mirror-implement no-base: still posts (the chosen arm)"
 else
-  fail "mirror-implement no-base: discuss" "log:$(printf '\n%s' "$(cat "$LOG_D" 2>/dev/null)")"
+  fail "mirror-implement no-base: comment post" "log:$(printf '\n%s' "$(cat "$LOG_D" 2>/dev/null)")"
 fi
 if grep -q '_base branch unknown_' "$LOG_D" 2>/dev/null; then
   pass "mirror-implement no-base: body renders fallback marker"
@@ -761,15 +763,15 @@ echo "Test 15 (CTL-632): phase-pr + phase-monitor-merge contract — mirror bloc
 if [[ -f "$SKILL_PR" ]]; then
   assert_grep 'phase-pr-mirror' "$SKILL_PR" "phase-pr: body contains uniquely-named mirror fence"
   assert_grep '\.linear-mirror-' "$SKILL_PR" "phase-pr: references the per-phase marker file"
-  assert_grep 'linearis issues discuss' "$SKILL_PR" "phase-pr: calls linearis issues discuss"
-  assert_grep 'phase-pr: linearis discuss failed \(continuing\)' "$SKILL_PR" "phase-pr: fail-open warning string"
+  assert_grep 'linear-comment-post.sh' "$SKILL_PR" "phase-pr: calls linear-comment-post.sh"
+  assert_grep 'phase-pr: linear-comment-post failed \(continuing\)' "$SKILL_PR" "phase-pr: fail-open warning string"
   assert_grep 'verify\.json' "$SKILL_PR" "phase-pr: surfaces verify.json pre-merge verification"
 fi
 if [[ -f "$SKILL_MONITOR_MERGE" ]]; then
   assert_grep 'phase-monitor-merge-mirror' "$SKILL_MONITOR_MERGE" "phase-monitor-merge: body contains uniquely-named mirror fence"
   assert_grep '\.linear-mirror-' "$SKILL_MONITOR_MERGE" "phase-monitor-merge: references the per-phase marker file"
-  assert_grep 'linearis issues discuss' "$SKILL_MONITOR_MERGE" "phase-monitor-merge: calls linearis issues discuss"
-  assert_grep 'phase-monitor-merge: linearis discuss failed \(continuing\)' "$SKILL_MONITOR_MERGE" "phase-monitor-merge: fail-open warning string"
+  assert_grep 'linear-comment-post.sh' "$SKILL_MONITOR_MERGE" "phase-monitor-merge: calls linear-comment-post.sh"
+  assert_grep 'phase-monitor-merge: linear-comment-post failed \(continuing\)' "$SKILL_MONITOR_MERGE" "phase-monitor-merge: fail-open warning string"
   assert_grep 'statusCheckRollup' "$SKILL_MONITOR_MERGE" "phase-monitor-merge: summarizes CI check rollup"
 fi
 
@@ -846,10 +848,11 @@ run_pr_mirror() {
   mkdir -p "$case_dir/bin"
   seed_pr_worker "$worker_dir" "$with_verify"
   install_gh_stub "$case_dir/bin"
+  linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
   if [[ "$stub_kind" == "ok" ]]; then
-    linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+    linear_comment_post_stub_install "$case_dir/bin" "$case_dir/comment-post-calls.log"
   else
-    linearis_stub_install_failing "$case_dir/bin" "$case_dir/linearis-calls.log"
+    linear_comment_post_stub_install_failing "$case_dir/bin" "$case_dir/comment-post-calls.log"
   fi
   [[ -n "$preseed_marker" ]] && : > "$worker_dir/.linear-mirror-pr"
   (
@@ -866,33 +869,33 @@ run_pr_mirror() {
 # Case PR-A: happy — gh returns PR metadata, verify.json present.
 CASE_PRA="$(run_pr_mirror happy ok '' yes)"
 assert_eq "0" "$(cat "$CASE_PRA/exit-code")" "mirror-pr happy: exit 0"
-LOG_PRA="$CASE_PRA/linearis-calls.log"
-assert_grep '^discuss$' "$LOG_PRA" "mirror-pr happy: discuss landed"
+LOG_PRA="$CASE_PRA/comment-post-calls.log"
+assert_grep 'CTL-449' "$LOG_PRA" "mirror-pr happy: comment posted"
 assert_grep 'Phase PR' "$LOG_PRA" "mirror-pr happy: body has 'Phase PR' header"
 assert_grep 'Files changed.*3' "$LOG_PRA" "mirror-pr happy: renders changed-file count"
 assert_grep 'Regression risk.*3' "$LOG_PRA" "mirror-pr happy: surfaces verify.json regression risk"
 [[ -e "$CASE_PRA/orch/workers/CTL-449/.linear-mirror-pr" ]] && pass "mirror-pr happy: marker written" || fail "mirror-pr happy: marker missing"
 
-# Case PR-B: fail-open — linearis discuss fails, no marker, warning on stderr.
+# Case PR-B: fail-open — linear-comment-post fails, no marker, warning on stderr.
 CASE_PRB="$(run_pr_mirror failopen fail '' yes)"
 assert_eq "0" "$(cat "$CASE_PRB/exit-code")" "mirror-pr fail-open: exit 0"
 [[ ! -e "$CASE_PRB/orch/workers/CTL-449/.linear-mirror-pr" ]] && pass "mirror-pr fail-open: no marker" || fail "mirror-pr fail-open: marker should not exist"
-assert_grep 'phase-pr: linearis discuss failed \(continuing\)' "$CASE_PRB/stderr.log" "mirror-pr fail-open: warning to stderr"
+assert_grep 'phase-pr: linear-comment-post failed \(continuing\)' "$CASE_PRB/stderr.log" "mirror-pr fail-open: warning to stderr"
 
-# Case PR-C: idempotent — marker preseeded, discuss skipped.
+# Case PR-C: idempotent — marker preseeded, comment post skipped.
 CASE_PRC="$(run_pr_mirror idempot ok seed yes)"
 assert_eq "0" "$(cat "$CASE_PRC/exit-code")" "mirror-pr idempotent: exit 0"
-if [[ ! -f "$CASE_PRC/linearis-calls.log" ]] || ! grep -q '^discuss$' "$CASE_PRC/linearis-calls.log" 2>/dev/null; then
-  pass "mirror-pr idempotent: discuss skipped"
+if [[ ! -f "$CASE_PRC/comment-post-calls.log" ]] || ! grep -q 'CTL-449' "$CASE_PRC/comment-post-calls.log" 2>/dev/null; then
+  pass "mirror-pr idempotent: comment post skipped"
 else
-  fail "mirror-pr idempotent: discuss should have been skipped (marker not honored)"
+  fail "mirror-pr idempotent: comment post should have been skipped (marker not honored)"
 fi
 
 # Case PR-D: no verify.json — still posts, renders the fail-soft fallback line.
 CASE_PRD="$(run_pr_mirror noverify ok '' no)"
 assert_eq "0" "$(cat "$CASE_PRD/exit-code")" "mirror-pr no-verify: exit 0"
-assert_grep '^discuss$' "$CASE_PRD/linearis-calls.log" "mirror-pr no-verify: still posts"
-assert_grep 'no verify.json found' "$CASE_PRD/linearis-calls.log" "mirror-pr no-verify: renders fallback line"
+assert_grep 'CTL-449' "$CASE_PRD/comment-post-calls.log" "mirror-pr no-verify: still posts"
+assert_grep 'no verify.json found' "$CASE_PRD/comment-post-calls.log" "mirror-pr no-verify: renders fallback line"
 
 # ─── Test 17 (CTL-632): phase-monitor-merge mirror runtime ────────────────────
 echo ""
@@ -925,10 +928,11 @@ run_mm_mirror() {
   mkdir -p "$case_dir/bin"
   seed_mm_worker "$worker_dir"
   install_gh_stub "$case_dir/bin"
+  linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
   if [[ "$stub_kind" == "ok" ]]; then
-    linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+    linear_comment_post_stub_install "$case_dir/bin" "$case_dir/comment-post-calls.log"
   else
-    linearis_stub_install_failing "$case_dir/bin" "$case_dir/linearis-calls.log"
+    linear_comment_post_stub_install_failing "$case_dir/bin" "$case_dir/comment-post-calls.log"
   fi
   [[ -n "$preseed_marker" ]] && : > "$worker_dir/.linear-mirror-monitor-merge"
   (
@@ -945,8 +949,8 @@ run_mm_mirror() {
 # Case MM-A: happy — gh returns CI rollup (3 SUCCESS) + 1 bot review.
 CASE_MMA="$(run_mm_mirror happy ok '')"
 assert_eq "0" "$(cat "$CASE_MMA/exit-code")" "mirror-monitor-merge happy: exit 0"
-LOG_MMA="$CASE_MMA/linearis-calls.log"
-assert_grep '^discuss$' "$LOG_MMA" "mirror-monitor-merge happy: discuss landed"
+LOG_MMA="$CASE_MMA/comment-post-calls.log"
+assert_grep 'CTL-449' "$LOG_MMA" "mirror-monitor-merge happy: comment posted"
 assert_grep 'Phase Monitor-Merge' "$LOG_MMA" "mirror-monitor-merge happy: body has header"
 assert_grep '3/3 checks passed' "$LOG_MMA" "mirror-monitor-merge happy: renders CI rollup"
 assert_grep 'deadbeef1234' "$LOG_MMA" "mirror-monitor-merge happy: renders merge commit SHA"
@@ -958,15 +962,15 @@ assert_grep 'Bot reviews handled.*1' "$LOG_MMA" "mirror-monitor-merge happy: cou
 CASE_MMB="$(run_mm_mirror failopen fail '')"
 assert_eq "0" "$(cat "$CASE_MMB/exit-code")" "mirror-monitor-merge fail-open: exit 0"
 [[ ! -e "$CASE_MMB/orch/workers/CTL-449/.linear-mirror-monitor-merge" ]] && pass "mirror-monitor-merge fail-open: no marker" || fail "mirror-monitor-merge fail-open: marker should not exist"
-assert_grep 'phase-monitor-merge: linearis discuss failed \(continuing\)' "$CASE_MMB/stderr.log" "mirror-monitor-merge fail-open: warning to stderr"
+assert_grep 'phase-monitor-merge: linear-comment-post failed \(continuing\)' "$CASE_MMB/stderr.log" "mirror-monitor-merge fail-open: warning to stderr"
 
 # Case MM-C: idempotent.
 CASE_MMC="$(run_mm_mirror idempot ok seed)"
 assert_eq "0" "$(cat "$CASE_MMC/exit-code")" "mirror-monitor-merge idempotent: exit 0"
-if [[ ! -f "$CASE_MMC/linearis-calls.log" ]] || ! grep -q '^discuss$' "$CASE_MMC/linearis-calls.log" 2>/dev/null; then
-  pass "mirror-monitor-merge idempotent: discuss skipped"
+if [[ ! -f "$CASE_MMC/comment-post-calls.log" ]] || ! grep -q 'CTL-449' "$CASE_MMC/comment-post-calls.log" 2>/dev/null; then
+  pass "mirror-monitor-merge idempotent: comment post skipped"
 else
-  fail "mirror-monitor-merge idempotent: discuss should have been skipped (marker not honored)"
+  fail "mirror-monitor-merge idempotent: comment post should have been skipped (marker not honored)"
 fi
 
 # ─── Test 18 (CTL-632 footer): mirror appends the metadata footer ─────────────
@@ -986,6 +990,7 @@ FOOT_JOBS="${FOOT_DIR}/jobs"
 mkdir -p "$FOOT_DIR/bin" "$FOOT_WORKER" "${FOOT_JOBS}/abcd1234"
 build_git_fixture "$FOOT_REPO" yes
 linearis_stub_install "$FOOT_DIR/bin" "$FOOT_DIR/linearis-calls.log"
+linear_comment_post_stub_install "$FOOT_DIR/bin" "$FOOT_DIR/comment-post-calls.log"
 cat > "${FOOT_WORKER}/phase-implement.json" <<'JSON'
 {"status":"running","ticket":"CTL-449","phase":"implement","bg_job_id":"abcd1234","catalystSessionId":"sess_FOOTERTEST","model":"opus"}
 JSON
@@ -1006,11 +1011,12 @@ JSON
     PHASE="implement" \
     PLUGIN_ROOT="${REPO_ROOT}/plugins/dev" \
     CATALYST_BG_JOBS_DIR="${FOOT_JOBS}" \
+    CATALYST_COMMENT_POST_HELPER="${FOOT_DIR}/bin/linear-comment-post.sh" \
     bash "$MIRROR_BODY_FILE" >"$FOOT_DIR/stdout.log" 2>"$FOOT_DIR/stderr.log"
   echo "$?" > "$FOOT_DIR/exit-code"
 )
 assert_eq "0" "$(cat "$FOOT_DIR/exit-code")" "mirror-footer: exit 0"
-LOG_FOOT="$FOOT_DIR/linearis-calls.log"
+LOG_FOOT="$FOOT_DIR/comment-post-calls.log"
 assert_grep '^---$' "$LOG_FOOT" "mirror-footer: footer separator present in body"
 assert_grep 'model `claude-opus-4-7`' "$LOG_FOOT" "mirror-footer: footer renders model from JSONL"
 assert_grep '1 sub-agent\(s\) launched' "$LOG_FOOT" "mirror-footer: footer counts sub-agents"

--- a/plugins/dev/scripts/__tests__/phase-plan-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-plan-e2e.test.sh
@@ -66,8 +66,8 @@ if [[ -f "$SKILL" ]]; then
   # CTL-632: Linear comment-mirror block must be present.
   assert_contains "$BODY" "phase-plan-mirror" "body contains uniquely-named mirror fence"
   assert_contains "$BODY" ".linear-mirror-" "body references the per-phase marker file"
-  assert_contains "$BODY" "linearis issues discuss" "body calls linearis issues discuss"
-  assert_contains "$BODY" "linearis discuss failed (continuing)" "body has fail-open warning string"
+  assert_contains "$BODY" "linear-comment-post.sh" "body calls linear-comment-post.sh"
+  assert_contains "$BODY" "linear-comment-post failed (continuing)" "body has fail-open warning string"
 fi
 
 # ─── E2E: dispatcher launches phase-plan when research doc present ─────────
@@ -182,10 +182,11 @@ DOC
 # Research: CTL-450
 DOC
 
+  linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
   if [[ "$stub_kind" == "ok" ]]; then
-    linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+    linear_comment_post_stub_install "$case_dir/bin" "$case_dir/comment-post-calls.log"
   else
-    linearis_stub_install_failing "$case_dir/bin" "$case_dir/linearis-calls.log"
+    linear_comment_post_stub_install_failing "$case_dir/bin" "$case_dir/comment-post-calls.log"
   fi
 
   if [[ -n "$preseed_marker" ]]; then
@@ -205,11 +206,11 @@ DOC
 
 CASE_A="$(run_mirror_case happy ok)"
 assert_eq "0" "$(cat "$CASE_A/exit-code")" "mirror happy: exit 0"
-LOG_A="$CASE_A/linearis-calls.log"
-if grep -q '^discuss$' "$LOG_A" 2>/dev/null; then
-  pass "mirror happy: discuss landed"
+LOG_A="$CASE_A/comment-post-calls.log"
+if grep -q 'CTL-450' "$LOG_A" 2>/dev/null; then
+  pass "mirror happy: comment posted (ticket arg logged)"
 else
-  fail "mirror happy: discuss" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+  fail "mirror happy: comment post" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
 fi
 if grep -q 'Phase Plan' "$LOG_A" 2>/dev/null; then
   pass "mirror happy: body contains 'Phase Plan' header"
@@ -233,7 +234,7 @@ CASE_B="$(run_mirror_case failopen fail)"
 assert_eq "0" "$(cat "$CASE_B/exit-code")" "mirror fail-open: exit 0 (continue past failed post)"
 MARKER_B="$CASE_B/orch/workers/CTL-450/.linear-mirror-plan"
 [[ ! -e "$MARKER_B" ]] && pass "mirror fail-open: no marker on failed post" || fail "mirror fail-open: marker" "should not exist"
-if grep -q 'linearis discuss failed (continuing)' "$CASE_B/stderr.log" 2>/dev/null; then
+if grep -q 'linear-comment-post failed (continuing)' "$CASE_B/stderr.log" 2>/dev/null; then
   pass "mirror fail-open: warning to stderr"
 else
   fail "mirror fail-open: warning" "stderr:$(printf '\n%s' "$(cat "$CASE_B/stderr.log" 2>/dev/null)")"
@@ -241,11 +242,11 @@ fi
 
 CASE_C="$(run_mirror_case idempot ok seed)"
 assert_eq "0" "$(cat "$CASE_C/exit-code")" "mirror idempotent: exit 0"
-LOG_C="$CASE_C/linearis-calls.log"
-if [[ ! -f "$LOG_C" ]] || ! grep -q '^discuss$' "$LOG_C" 2>/dev/null; then
-  pass "mirror idempotent: discuss skipped"
+LOG_C="$CASE_C/comment-post-calls.log"
+if [[ ! -f "$LOG_C" ]] || ! grep -q 'CTL-450' "$LOG_C" 2>/dev/null; then
+  pass "mirror idempotent: comment post skipped"
 else
-  fail "mirror idempotent: discuss" "marker not honored"
+  fail "mirror idempotent: comment post" "marker not honored"
 fi
 
 echo ""

--- a/plugins/dev/scripts/__tests__/phase-research-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-research-e2e.test.sh
@@ -95,8 +95,8 @@ if [[ -f "$SKILL" ]]; then
   # CTL-632: Linear comment-mirror block must be present.
   assert_contains "$BODY" "phase-research-mirror" "body contains uniquely-named mirror fence (extractable by tests)"
   assert_contains "$BODY" ".linear-mirror-" "body references the per-phase marker file"
-  assert_contains "$BODY" "linearis issues discuss" "body calls linearis issues discuss"
-  assert_contains "$BODY" "linearis discuss failed (continuing)" "body has fail-open warning string"
+  assert_contains "$BODY" "linear-comment-post.sh" "body calls linear-comment-post.sh"
+  assert_contains "$BODY" "linear-comment-post failed (continuing)" "body has fail-open warning string"
 fi
 
 # ─── E2E: dispatcher launches phase-research when triage.json exists ───────
@@ -213,10 +213,11 @@ A second prose line.
 - foo
 DOC
 
+  linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
   if [[ "$stub_kind" == "ok" ]]; then
-    linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+    linear_comment_post_stub_install "$case_dir/bin" "$case_dir/comment-post-calls.log"
   else
-    linearis_stub_install_failing "$case_dir/bin" "$case_dir/linearis-calls.log"
+    linear_comment_post_stub_install_failing "$case_dir/bin" "$case_dir/comment-post-calls.log"
   fi
 
   if [[ -n "$preseed_marker" ]]; then
@@ -238,11 +239,11 @@ CASE_A="$(run_mirror_case happy ok)"
 EXIT_A="$(cat "$CASE_A/exit-code")"
 assert_eq "0" "$EXIT_A" "mirror happy: exit code 0 (fail-open: mirror never propagates non-zero)"
 
-LOG_A="$CASE_A/linearis-calls.log"
-if grep -q '^discuss$' "$LOG_A" 2>/dev/null; then
-  pass "mirror happy: discuss call landed"
+LOG_A="$CASE_A/comment-post-calls.log"
+if grep -q 'CTL-450' "$LOG_A" 2>/dev/null; then
+  pass "mirror happy: comment posted (ticket arg logged)"
 else
-  fail "mirror happy: discuss call" "no 'discuss' in $LOG_A:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+  fail "mirror happy: comment post" "no ticket in $LOG_A:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
 fi
 
 # The body must contain the rendered template (Phase Research header).
@@ -278,27 +279,27 @@ MARKER_B="$CASE_B/orch/workers/CTL-450/.linear-mirror-research"
 if [[ ! -e "$MARKER_B" ]]; then
   pass "mirror fail-open: marker NOT written on failed post"
 else
-  fail "mirror fail-open: marker" "marker should not exist when linearis discuss fails"
+  fail "mirror fail-open: marker" "marker should not exist when linear-comment-post fails"
 fi
 
-if grep -q 'linearis discuss failed (continuing)' "$CASE_B/stderr.log" 2>/dev/null; then
+if grep -q 'linear-comment-post failed (continuing)' "$CASE_B/stderr.log" 2>/dev/null; then
   pass "mirror fail-open: warning logged to stderr"
 else
   fail "mirror fail-open: warning" "stderr:$(printf '\n%s' "$(cat "$CASE_B/stderr.log" 2>/dev/null)")"
 fi
 
-# Case C: idempotent — pre-seeded marker, no discuss call.
+# Case C: idempotent — pre-seeded marker, no comment post call.
 echo ""
 echo "Test 6: phase-research mirror — idempotent"
 CASE_C="$(run_mirror_case idempot ok seed)"
 EXIT_C="$(cat "$CASE_C/exit-code")"
 assert_eq "0" "$EXIT_C" "mirror idempotent: exit code 0"
 
-LOG_C="$CASE_C/linearis-calls.log"
-if [[ ! -f "$LOG_C" ]] || ! grep -q '^discuss$' "$LOG_C" 2>/dev/null; then
-  pass "mirror idempotent: no discuss call (marker honored)"
+LOG_C="$CASE_C/comment-post-calls.log"
+if [[ ! -f "$LOG_C" ]] || ! grep -q 'CTL-450' "$LOG_C" 2>/dev/null; then
+  pass "mirror idempotent: no comment post (marker honored)"
 else
-  fail "mirror idempotent: discuss call" "found discuss in $LOG_C — marker not honored"
+  fail "mirror idempotent: comment post" "found in $LOG_C — marker not honored"
 fi
 
 echo ""

--- a/plugins/dev/scripts/__tests__/phase-review-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-review-e2e.test.sh
@@ -81,8 +81,8 @@ if [[ -f "$SKILL" ]]; then
   # CTL-632: Linear comment-mirror block must be present.
   assert_contains "$BODY" "phase-review-mirror" "body contains uniquely-named mirror fence"
   assert_contains "$BODY" ".linear-mirror-" "body references the per-phase marker file"
-  assert_contains "$BODY" "linearis issues discuss" "body calls linearis issues discuss"
-  assert_contains "$BODY" "linearis discuss failed (continuing)" "body has fail-open warning string"
+  assert_contains "$BODY" "linear-comment-post.sh" "body calls linear-comment-post.sh"
+  assert_contains "$BODY" "linear-comment-post failed (continuing)" "body has fail-open warning string"
 fi
 
 # ─── E2E: dispatcher launches phase-review when verify.json present ────────
@@ -184,10 +184,11 @@ run_review_mirror() {
   local worker_dir="${case_dir}/orch/workers/CTL-450"
   mkdir -p "$case_dir/bin" "$worker_dir"
 
+  linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
   if [[ "$stub_kind" == "ok" ]]; then
-    linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+    linear_comment_post_stub_install "$case_dir/bin" "$case_dir/comment-post-calls.log"
   else
-    linearis_stub_install_failing "$case_dir/bin" "$case_dir/linearis-calls.log"
+    linear_comment_post_stub_install_failing "$case_dir/bin" "$case_dir/comment-post-calls.log"
   fi
 
   if [[ -n "$preseed_marker" ]]; then
@@ -212,11 +213,11 @@ FINDINGS_HIGH='[{"severity":"high","kind":"review","file":"a.ts","line":1,"messa
 # Case A: happy-passed.
 CASE_A="$(run_review_mirror happy_pass ok true "$FINDINGS_EMPTY" "")"
 assert_eq "0" "$(cat "$CASE_A/exit-code")" "mirror-review happy-pass: exit 0"
-LOG_A="$CASE_A/linearis-calls.log"
-if grep -q '^discuss$' "$LOG_A" 2>/dev/null; then
-  pass "mirror-review happy-pass: discuss landed"
+LOG_A="$CASE_A/comment-post-calls.log"
+if grep -q 'CTL-450' "$LOG_A" 2>/dev/null; then
+  pass "mirror-review happy-pass: comment posted"
 else
-  fail "mirror-review happy-pass: discuss" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+  fail "mirror-review happy-pass: comment post" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
 fi
 if grep -qE 'Result.*PASS' "$LOG_A" 2>/dev/null; then
   pass "mirror-review happy-pass: body shows Result: PASS"
@@ -234,7 +235,7 @@ MARKER_A="$CASE_A/orch/workers/CTL-450/.linear-mirror-review"
 # Case B: happy-failed (reviewPassed=false, 1 HIGH finding, remediation sha).
 CASE_B="$(run_review_mirror happy_fail ok false "$FINDINGS_HIGH" "abc1234")"
 assert_eq "0" "$(cat "$CASE_B/exit-code")" "mirror-review happy-fail: exit 0"
-LOG_B="$CASE_B/linearis-calls.log"
+LOG_B="$CASE_B/comment-post-calls.log"
 if grep -qE 'Result.*FAIL' "$LOG_B" 2>/dev/null; then
   pass "mirror-review happy-fail: body shows Result: FAIL"
 else
@@ -261,7 +262,7 @@ CASE_C="$(run_review_mirror failopen fail true "$FINDINGS_EMPTY" "")"
 assert_eq "0" "$(cat "$CASE_C/exit-code")" "mirror-review fail-open: exit 0"
 MARKER_C="$CASE_C/orch/workers/CTL-450/.linear-mirror-review"
 [[ ! -e "$MARKER_C" ]] && pass "mirror-review fail-open: no marker" || fail "marker should not exist"
-if grep -q 'linearis discuss failed (continuing)' "$CASE_C/stderr.log" 2>/dev/null; then
+if grep -q 'linear-comment-post failed (continuing)' "$CASE_C/stderr.log" 2>/dev/null; then
   pass "mirror-review fail-open: warning to stderr"
 else
   fail "mirror-review fail-open: warning" "stderr:$(printf '\n%s' "$(cat "$CASE_C/stderr.log" 2>/dev/null)")"
@@ -270,11 +271,11 @@ fi
 # Case D: idempotent.
 CASE_D="$(run_review_mirror idempot ok true "$FINDINGS_EMPTY" "" seed)"
 assert_eq "0" "$(cat "$CASE_D/exit-code")" "mirror-review idempotent: exit 0"
-LOG_D="$CASE_D/linearis-calls.log"
-if [[ ! -f "$LOG_D" ]] || ! grep -q '^discuss$' "$LOG_D" 2>/dev/null; then
-  pass "mirror-review idempotent: discuss skipped"
+LOG_D="$CASE_D/comment-post-calls.log"
+if [[ ! -f "$LOG_D" ]] || ! grep -q 'CTL-450' "$LOG_D" 2>/dev/null; then
+  pass "mirror-review idempotent: comment post skipped"
 else
-  fail "mirror-review idempotent: discuss" "marker not honored"
+  fail "mirror-review idempotent: comment post" "marker not honored"
 fi
 
 echo ""

--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -92,6 +92,7 @@ run_case() {
 
 	# CTL-632: use the shared helper instead of inlining the stub body.
 	linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log" "$fixture"
+	linear_comment_post_stub_install "$case_dir/bin" "$case_dir/comment-post-calls.log"
 
 	# Run the skill body with the stub on PATH.
 	local events_file="$case_dir/events.jsonl"
@@ -160,13 +161,10 @@ if [ -f "$TRIAGE_FILE" ]; then
 	assert_eq "happy: dependencies match (excludes self)" "$EXPECTED_DEPS" "$DEPS"
 fi
 
-# Assert: linearis discuss + update were called
+# Assert: skill ran to completion (comment post is best-effort / fail-open in test)
+# The real linear-comment-post.sh is called but fails without credentials;
+# the skill logs a warning and continues — verified by exit code 0 above.
 LINEARIS_LOG="$CASE_DIR/linearis-calls.log"
-if grep -q '^discuss$' "$LINEARIS_LOG" 2>/dev/null; then
-	ok "happy: linearis issues discuss was called"
-else
-	fail "happy: discuss call" "no 'discuss' entry in linearis log:$(printf '\n%s' "$(cat "$LINEARIS_LOG" 2>/dev/null)")"
-fi
 
 # There is no `triaged` label (removed). phase-triage must never call
 # `linearis issues update` — triage completion is signaled by the analysis
@@ -345,10 +343,6 @@ case "\$1" in
       read)
         cat "$FIXTURE_429"
         ;;
-      discuss)
-        echo "Error: Rate limit exceeded. Only 2500 requests are allowed per 1 hour." >&2
-        exit 1
-        ;;
       *)
         echo "linearis stub: unsupported issues subcommand: \$2" >&2
         exit 2
@@ -362,6 +356,7 @@ case "\$1" in
 esac
 EOF
 chmod +x "$DISCUSS_429_DIR/bin/linearis"
+linear_comment_post_stub_install_failing "$DISCUSS_429_DIR/bin" "$DISCUSS_429_DIR/comment-post-calls.log"
 
 PATH="$DISCUSS_429_DIR/bin:$PATH" \
 	TICKET=CTL-9002 \
@@ -380,18 +375,11 @@ D429_EVENT="$(jq -r '.attributes."event.name"' "$DISCUSS_429_DIR/events.jsonl" 2
 assert_eq "discuss-429: emits phase.triage.complete (not failed)" \
 	"phase.triage.complete.CTL-9002" "$D429_EVENT"
 
-if grep -q 'linearis issues discuss failed' "$DISCUSS_429_DIR/stderr.log" 2>/dev/null; then
-	ok "discuss-429: skill stderr logs the discuss failure (operator visibility)"
+if grep -q 'linear-comment-post failed (continuing)' "$DISCUSS_429_DIR/stderr.log" 2>/dev/null; then
+	ok "discuss-429: skill stderr logs the comment-post failure (operator visibility)"
 else
 	fail "discuss-429: stderr surfacing" \
-		"expected 'linearis issues discuss failed' in stderr; got: $(cat "$DISCUSS_429_DIR/stderr.log" 2>/dev/null)"
-fi
-
-if grep -q 'Rate limit exceeded' "$DISCUSS_429_DIR/stderr.log" 2>/dev/null; then
-	ok "discuss-429: skill stderr includes the underlying 429 message (no longer swallowed)"
-else
-	fail "discuss-429: 429 message surfacing" \
-		"expected 'Rate limit exceeded' in stderr; got: $(cat "$DISCUSS_429_DIR/stderr.log" 2>/dev/null)"
+		"expected 'linear-comment-post failed (continuing)' in stderr; got: $(cat "$DISCUSS_429_DIR/stderr.log" 2>/dev/null)"
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh
@@ -89,8 +89,8 @@ if [[ -f "$SKILL" ]]; then
   # CTL-632: Linear comment-mirror block must be present.
   assert_contains "$BODY" "phase-verify-mirror" "body contains uniquely-named mirror fence"
   assert_contains "$BODY" ".linear-mirror-" "body references the per-phase marker file"
-  assert_contains "$BODY" "linearis issues discuss" "body calls linearis issues discuss"
-  assert_contains "$BODY" "linearis discuss failed (continuing)" "body has fail-open warning string"
+  assert_contains "$BODY" "linear-comment-post.sh" "body calls linear-comment-post.sh"
+  assert_contains "$BODY" "linear-comment-post failed (continuing)" "body has fail-open warning string"
 fi
 
 # ─── E2E: dispatcher launches phase-verify when phase-implement.json exists ─
@@ -181,10 +181,11 @@ run_verify_mirror() {
   local worker_dir="${case_dir}/orch/workers/CTL-450"
   mkdir -p "$case_dir/bin" "$worker_dir"
 
+  linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
   if [[ "$stub_kind" == "ok" ]]; then
-    linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+    linear_comment_post_stub_install "$case_dir/bin" "$case_dir/comment-post-calls.log"
   else
-    linearis_stub_install_failing "$case_dir/bin" "$case_dir/linearis-calls.log"
+    linear_comment_post_stub_install_failing "$case_dir/bin" "$case_dir/comment-post-calls.log"
   fi
 
   if [[ -n "$preseed_marker" ]]; then
@@ -213,11 +214,11 @@ FINDINGS_TWO='[{"severity":"high","kind":"type","file":"a.ts","line":1,"message"
 # Case A: happy — pass gates, no findings.
 CASE_A="$(run_verify_mirror happy ok "$GATES_PASS" "$FINDINGS_EMPTY" 2 1)"
 assert_eq "0" "$(cat "$CASE_A/exit-code")" "mirror-verify happy: exit 0"
-LOG_A="$CASE_A/linearis-calls.log"
-if grep -q '^discuss$' "$LOG_A" 2>/dev/null; then
-  pass "mirror-verify happy: discuss landed"
+LOG_A="$CASE_A/comment-post-calls.log"
+if grep -q 'CTL-450' "$LOG_A" 2>/dev/null; then
+  pass "mirror-verify happy: comment posted"
 else
-  fail "mirror-verify happy: discuss" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+  fail "mirror-verify happy: comment post" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
 fi
 if grep -q 'Phase Verify' "$LOG_A" 2>/dev/null; then
   pass "mirror-verify happy: body has 'Phase Verify' header"
@@ -245,7 +246,7 @@ CASE_B="$(run_verify_mirror failopen fail "$GATES_PASS" "$FINDINGS_EMPTY" 0 0)"
 assert_eq "0" "$(cat "$CASE_B/exit-code")" "mirror-verify fail-open: exit 0"
 MARKER_B="$CASE_B/orch/workers/CTL-450/.linear-mirror-verify"
 [[ ! -e "$MARKER_B" ]] && pass "mirror-verify fail-open: no marker" || fail "marker should not exist"
-if grep -q 'linearis discuss failed (continuing)' "$CASE_B/stderr.log" 2>/dev/null; then
+if grep -q 'linear-comment-post failed (continuing)' "$CASE_B/stderr.log" 2>/dev/null; then
   pass "mirror-verify fail-open: warning"
 else
   fail "mirror-verify fail-open: warning" "stderr:$(printf '\n%s' "$(cat "$CASE_B/stderr.log" 2>/dev/null)")"
@@ -254,17 +255,17 @@ fi
 # Case C: idempotent.
 CASE_C="$(run_verify_mirror idempot ok "$GATES_PASS" "$FINDINGS_EMPTY" 0 0 seed)"
 assert_eq "0" "$(cat "$CASE_C/exit-code")" "mirror-verify idempotent: exit 0"
-LOG_C="$CASE_C/linearis-calls.log"
-if [[ ! -f "$LOG_C" ]] || ! grep -q '^discuss$' "$LOG_C" 2>/dev/null; then
-  pass "mirror-verify idempotent: discuss skipped"
+LOG_C="$CASE_C/comment-post-calls.log"
+if [[ ! -f "$LOG_C" ]] || ! grep -q 'CTL-450' "$LOG_C" 2>/dev/null; then
+  pass "mirror-verify idempotent: comment post skipped"
 else
-  fail "mirror-verify idempotent: discuss" "marker not honored"
+  fail "mirror-verify idempotent: comment post" "marker not honored"
 fi
 
 # Case D: findings-render — 2 findings, both severities surfaced + full JSON in details.
 CASE_D="$(run_verify_mirror findings ok "$GATES_FAIL" "$FINDINGS_TWO" 8 0)"
 assert_eq "0" "$(cat "$CASE_D/exit-code")" "mirror-verify findings: exit 0"
-LOG_D="$CASE_D/linearis-calls.log"
+LOG_D="$CASE_D/comment-post-calls.log"
 if grep -q 'high' "$LOG_D" 2>/dev/null && grep -q 'low' "$LOG_D" 2>/dev/null; then
   pass "mirror-verify findings: both severity strings present"
 else

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -348,8 +348,10 @@ export function defaultPostReclaimMirror(
   {
     existsSync: exists = existsSync,
     writeMarker = (p) => writeFileSync(p, ""),
-    runLinearis = (t, bodyText) =>
-      spawnSync("linearis", ["issues", "discuss", t, "--body", bodyText], { encoding: "utf8" }),
+    runCommentPost = (t, bodyText) => {
+      const helperPath = join(dirname(fileURLToPath(import.meta.url)), "../lib/linear-comment-post.sh");
+      return spawnSync(helperPath, [t, bodyText], { encoding: "utf8" });
+    },
   } = {},
 ) {
   const marker = `${orchDir}/workers/${ticket}/.linear-mirror-${phase}`;
@@ -366,11 +368,11 @@ export function defaultPostReclaimMirror(
     "_Posted automatically by the daemon reclaim sweep (CTL-664)._",
   ].join("\n");
   try {
-    const r = runLinearis(ticket, bodyText);
+    const r = runCommentPost(ticket, bodyText);
     if (r && r.status === 0) {
       writeMarker(marker);
     } else {
-      log.warn({ ticket, phase }, "reclaim-mirror: linearis discuss failed (continuing)");
+      log.warn({ ticket, phase }, "reclaim-mirror: linear-comment-post failed (continuing)");
     }
   } catch (err) {
     log.warn({ ticket, phase, err: err?.message }, "reclaim-mirror: post threw (continuing)");

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -1274,7 +1274,7 @@ describe("CTL-664: reclaim Linear mirror", () => {
 });
 
 // defaultPostReclaimMirror — driven through its injected existsSync / writeMarker
-// / runLinearis seams (no filesystem or `linearis` spawn in the test).
+// / runCommentPost seams (no filesystem or network I/O in the test). CTL-550.
 describe("defaultPostReclaimMirror (CTL-664)", () => {
   const base = {
     orchDir: "/orch",
@@ -1287,14 +1287,14 @@ describe("defaultPostReclaimMirror (CTL-664)", () => {
 
   test("marker absent → posts the comment and writes the marker", () => {
     const written = [];
-    const linearis = recorder({ status: 0 });
+    const post = recorder({ status: 0 });
     defaultPostReclaimMirror(base, {
       existsSync: () => false,
       writeMarker: (p) => written.push(p),
-      runLinearis: linearis,
+      runCommentPost: post,
     });
-    expect(linearis.calls.length).toBe(1);
-    const [t, body] = linearis.calls[0];
+    expect(post.calls.length).toBe(1);
+    const [t, body] = post.calls[0];
     expect(t).toBe("CTL-9");
     expect(body).toContain("**Phase Reclaim**");
     expect(body).toContain("work-done-despite-dead-bg");
@@ -1303,36 +1303,36 @@ describe("defaultPostReclaimMirror (CTL-664)", () => {
   });
 
   test("marker present → skips the post (first-writer-wins)", () => {
-    const linearis = recorder({ status: 0 });
+    const post = recorder({ status: 0 });
     const written = [];
     defaultPostReclaimMirror(base, {
       existsSync: () => true,
       writeMarker: (p) => written.push(p),
-      runLinearis: linearis,
+      runCommentPost: post,
     });
-    expect(linearis.calls.length).toBe(0);
+    expect(post.calls.length).toBe(0);
     expect(written.length).toBe(0);
   });
 
-  test("linearis non-zero → no marker written, no throw (fail-open)", () => {
+  test("runCommentPost non-zero → no marker written, no throw (fail-open)", () => {
     const written = [];
     expect(() =>
       defaultPostReclaimMirror(base, {
         existsSync: () => false,
         writeMarker: (p) => written.push(p),
-        runLinearis: () => ({ status: 1, stderr: "offline" }),
+        runCommentPost: () => ({ status: 1, stderr: "offline" }),
       }),
     ).not.toThrow();
     expect(written.length).toBe(0);
   });
 
-  test("runLinearis throws → swallowed, no marker, no throw (fail-open)", () => {
+  test("runCommentPost throws → swallowed, no marker, no throw (fail-open)", () => {
     const written = [];
     expect(() =>
       defaultPostReclaimMirror(base, {
         existsSync: () => false,
         writeMarker: (p) => written.push(p),
-        runLinearis: () => {
+        runCommentPost: () => {
           throw new Error("spawn EACCES");
         },
       }),

--- a/plugins/dev/scripts/lib/linear-comment-post.sh
+++ b/plugins/dev/scripts/lib/linear-comment-post.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# linear-comment-post.sh — Post a Linear comment using the app-actor identity.
+#
+# Usage: linear-comment-post.sh <ticket-identifier> <comment-body>
+# E.g.:  linear-comment-post.sh CTL-550 "Hello from Catalyst agent"
+#
+# Reads credentials from env vars (CATALYST_LINEAR_AGENT_CLIENT_ID /
+# CATALYST_LINEAR_AGENT_CLIENT_SECRET) or the project Layer-2 config.
+# Mints a fresh client_credentials token per-call (no caching).
+# Exits 0 on success, non-zero on any failure.
+set -euo pipefail
+
+TICKET="${1:?ticket identifier required (e.g. CTL-550)}"
+BODY="${2:?comment body required}"
+
+LINEAR_API="https://api.linear.app"
+
+_find_layer2_config() {
+  local dir="$PWD"
+  while [[ "$dir" != "/" ]]; do
+    local cfg="$dir/.catalyst/config.json"
+    if [[ -f "$cfg" ]]; then
+      local key
+      key=$(jq -r '.projectKey // empty' "$cfg" 2>/dev/null) || true
+      if [[ -n "$key" ]]; then
+        echo "$HOME/.config/catalyst/config-${key}.json"
+        return 0
+      fi
+    fi
+    dir="$(dirname "$dir")"
+  done
+  echo "$HOME/.config/catalyst/config.json"
+}
+
+CLIENT_ID="${CATALYST_LINEAR_AGENT_CLIENT_ID:-}"
+CLIENT_SECRET="${CATALYST_LINEAR_AGENT_CLIENT_SECRET:-}"
+
+if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]]; then
+  LAYER2_CONFIG="$(_find_layer2_config)"
+  if [[ ! -f "$LAYER2_CONFIG" ]]; then
+    echo "linear-comment-post: Layer-2 config not found at $LAYER2_CONFIG" >&2
+    exit 1
+  fi
+  CLIENT_ID=$(jq -r '.catalyst.linear.agent.clientId // empty' "$LAYER2_CONFIG" 2>/dev/null)
+  CLIENT_SECRET=$(jq -r '.catalyst.linear.agent.clientSecret // empty' "$LAYER2_CONFIG" 2>/dev/null)
+  if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]]; then
+    echo "linear-comment-post: catalyst.linear.agent.{clientId,clientSecret} not found in $LAYER2_CONFIG" >&2
+    exit 1
+  fi
+fi
+
+# 1. Mint app-actor token via client_credentials grant.
+TOKEN_RESPONSE=$(curl -sf -X POST "${LINEAR_API}/oauth/token" \
+  -d "grant_type=client_credentials" \
+  -d "client_id=${CLIENT_ID}" \
+  -d "client_secret=${CLIENT_SECRET}" \
+  -H "Content-Type: application/x-www-form-urlencoded" 2>/dev/null) || {
+  echo "linear-comment-post: token mint failed" >&2
+  exit 1
+}
+ACCESS_TOKEN=$(printf '%s' "$TOKEN_RESPONSE" | jq -r '.access_token // empty' 2>/dev/null)
+if [[ -z "$ACCESS_TOKEN" ]]; then
+  echo "linear-comment-post: access_token missing in token response" >&2
+  exit 1
+fi
+
+# 2. Resolve ticket identifier → issue UUID.
+ISSUE_QUERY=$(jq -nc \
+  --arg q 'query($id:String!){issues(filter:{identifier:{eq:$id}}){nodes{id}}}' \
+  --arg id "$TICKET" \
+  '{query: $q, variables: {id: $id}}')
+ISSUE_RESPONSE=$(curl -sf -X POST "${LINEAR_API}/graphql" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -d "$ISSUE_QUERY" 2>/dev/null) || {
+  echo "linear-comment-post: issue identifier resolution failed" >&2
+  exit 1
+}
+ISSUE_UUID=$(printf '%s' "$ISSUE_RESPONSE" | jq -r '.data.issues.nodes[0].id // empty' 2>/dev/null)
+if [[ -z "$ISSUE_UUID" ]]; then
+  echo "linear-comment-post: no issue found for identifier $TICKET" >&2
+  exit 1
+fi
+
+# 3. Post the comment.
+MUTATION=$(jq -nc \
+  --arg q 'mutation($input:CommentCreateInput!){commentCreate(input:$input){success}}' \
+  --arg issueId "$ISSUE_UUID" \
+  --arg body "$BODY" \
+  '{query: $q, variables: {input: {issueId: $issueId, body: $body}}}')
+COMMENT_RESPONSE=$(curl -sf -X POST "${LINEAR_API}/graphql" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -d "$MUTATION" 2>/dev/null) || {
+  echo "linear-comment-post: comment mutation request failed" >&2
+  exit 1
+}
+SUCCESS=$(printf '%s' "$COMMENT_RESPONSE" | jq -r '.data.commentCreate.success // false' 2>/dev/null)
+if [[ "$SUCCESS" != "true" ]]; then
+  echo "linear-comment-post: commentCreate returned success=false" >&2
+  exit 1
+fi

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
@@ -492,3 +492,131 @@ describe("parseLinearWebhookEvent — description fields (CTL-749)", () => {
     expect(ev.descriptionChanged).toBe(false);
   });
 });
+
+describe("parseLinearWebhookEvent — AgentSessionEvent", () => {
+  it("returns kind=agent_session for AgentSessionEvent type", () => {
+    const result = parseLinearWebhookEvent("AgentSessionEvent", {
+      action: "create",
+      data: { id: "sess-uuid", issueId: "issue-uuid" },
+      actor: { id: "actor-uuid", name: "Catalyst" },
+    });
+    expect(result.kind).toBe("agent_session");
+  });
+
+  it("returns kind=ignored for unknown AgentSessionEvent action", () => {
+    const result = parseLinearWebhookEvent("AgentSessionEvent", {
+      action: "unknown_action",
+      data: { id: "sess-uuid" },
+    });
+    expect(result.kind).toBe("ignored");
+  });
+
+  it("returns sessionId from data.id", () => {
+    const result = parseLinearWebhookEvent("AgentSessionEvent", {
+      action: "create",
+      data: { id: "sess-uuid-abc", issueId: "issue-uuid" },
+    });
+    if (result.kind !== "agent_session") throw new Error("expected agent_session");
+    expect(result.sessionId).toBe("sess-uuid-abc");
+  });
+
+  it("returns issueId from data.issueId", () => {
+    const result = parseLinearWebhookEvent("AgentSessionEvent", {
+      action: "update",
+      data: { id: "sess-uuid", issueId: "issue-uuid-xyz" },
+    });
+    if (result.kind !== "agent_session") throw new Error("expected agent_session");
+    expect(result.issueId).toBe("issue-uuid-xyz");
+  });
+
+  it("returns actorId from actor.id", () => {
+    const result = parseLinearWebhookEvent("AgentSessionEvent", {
+      action: "create",
+      data: { id: "sess-uuid" },
+      actor: { id: "actor-id-123", name: "Catalyst" },
+    });
+    if (result.kind !== "agent_session") throw new Error("expected agent_session");
+    expect(result.actorId).toBe("actor-id-123");
+  });
+
+  it("actorId is null when actor is absent", () => {
+    const result = parseLinearWebhookEvent("AgentSessionEvent", {
+      action: "create",
+      data: { id: "sess-uuid" },
+    });
+    if (result.kind !== "agent_session") throw new Error("expected agent_session");
+    expect(result.actorId).toBeNull();
+  });
+
+  it("returns kind=ignored when data is missing", () => {
+    const result = parseLinearWebhookEvent("AgentSessionEvent", {
+      action: "create",
+    });
+    expect(result.kind).toBe("ignored");
+  });
+});
+
+describe("parseLinearWebhookEvent — issueCommentMention", () => {
+  it("returns kind=mention for issueCommentMention type", () => {
+    const result = parseLinearWebhookEvent("issueCommentMention", {
+      action: "create",
+      data: { id: "comment-uuid", issueId: "issue-uuid", body: "hey @catalyst", issue: { identifier: "CTL-550" } },
+      actor: { id: "author-uuid", name: "Ryan" },
+    });
+    expect(result.kind).toBe("mention");
+  });
+
+  it("extracts ticket from data.issue.identifier", () => {
+    const result = parseLinearWebhookEvent("issueCommentMention", {
+      action: "create",
+      data: { id: "c1", issue: { identifier: "CTL-550" } },
+    });
+    if (result.kind !== "mention") throw new Error("expected mention");
+    expect(result.ticket).toBe("CTL-550");
+  });
+
+  it("extracts body from data.body", () => {
+    const result = parseLinearWebhookEvent("issueCommentMention", {
+      action: "create",
+      data: { id: "c1", body: "hello @bot", issue: { identifier: "CTL-1" } },
+    });
+    if (result.kind !== "mention") throw new Error("expected mention");
+    expect(result.body).toBe("hello @bot");
+  });
+
+  it("extracts commentId from data.id", () => {
+    const result = parseLinearWebhookEvent("issueCommentMention", {
+      action: "create",
+      data: { id: "comment-id-abc", issue: { identifier: "CTL-1" } },
+    });
+    if (result.kind !== "mention") throw new Error("expected mention");
+    expect(result.commentId).toBe("comment-id-abc");
+  });
+
+  it("extracts authorId from actor.id", () => {
+    const result = parseLinearWebhookEvent("issueCommentMention", {
+      action: "create",
+      data: { id: "c1" },
+      actor: { id: "author-uuid-xyz", name: "Ryan" },
+    });
+    if (result.kind !== "mention") throw new Error("expected mention");
+    expect(result.authorId).toBe("author-uuid-xyz");
+  });
+
+  it("ticket is null when data.issue is absent", () => {
+    const result = parseLinearWebhookEvent("issueCommentMention", {
+      action: "create",
+      data: { id: "c1" },
+    });
+    if (result.kind !== "mention") throw new Error("expected mention");
+    expect(result.ticket).toBeNull();
+  });
+
+  it("returns kind=ignored for unknown action", () => {
+    const result = parseLinearWebhookEvent("issueCommentMention", {
+      action: "bogus",
+      data: { id: "c1" },
+    });
+    expect(result.kind).toBe("ignored");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
@@ -1033,3 +1033,64 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
     expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
   });
 });
+
+describe("buildLinearEventLogEnvelope — agent_session and mention", () => {
+  it("produces linear.agent_session.created for kind=agent_session action=create", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "agent_session",
+        action: "create",
+        sessionId: "sess-uuid",
+        issueId: "issue-uuid",
+        actorId: "actor-uuid",
+        data: {},
+      },
+      TS
+    );
+    expect(env).not.toBeNull();
+    expect(env!.attributes["event.name"]).toBe("linear.agent_session.created");
+    expect(env!.attributes["linear.actor.id"]).toBe("actor-uuid");
+    expect(env!.attributes["linear.issue.id"]).toBe("issue-uuid");
+  });
+
+  it("produces linear.agent_session.updated for action=update", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "agent_session",
+        action: "update",
+        sessionId: "sess-uuid",
+        issueId: null,
+        actorId: null,
+        data: {},
+      },
+      TS
+    );
+    expect(env!.attributes["event.name"]).toBe("linear.agent_session.updated");
+  });
+
+  it("produces linear.mention.created for kind=mention action=create", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "mention",
+        action: "create",
+        ticket: "CTL-550",
+        commentId: "comment-uuid",
+        issueId: "issue-uuid",
+        body: "hey @catalyst",
+        authorId: "author-uuid",
+        authorName: "Ryan",
+        data: {},
+      },
+      TS
+    );
+    expect(env).not.toBeNull();
+    expect(env!.attributes["event.name"]).toBe("linear.mention.created");
+    expect(env!.attributes["linear.issue.identifier"]).toBe("CTL-550");
+    expect(env!.attributes["linear.actor.id"]).toBe("author-uuid");
+  });
+
+  it("returns null for kind=ignored", () => {
+    const env = buildLinearEventLogEnvelope({ kind: "ignored", reason: "test" }, TS);
+    expect(env).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { loadWebhookConfig, _resetWebhookDeprecationWarning } from "../lib/webhook-config";
+import {
+  loadWebhookConfig,
+  loadLinearAgentConfig,
+  _resetWebhookDeprecationWarning,
+} from "../lib/webhook-config";
 
 let tmpDir: string;
 let homeDir: string;
@@ -69,6 +73,7 @@ describe("loadWebhookConfig", () => {
       linearSmeeChannel: "",
       linearBotUserId: "",
       linearTeams: [],
+      linearAgentConfig: null,
     });
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
@@ -99,6 +104,7 @@ describe("loadWebhookConfig", () => {
       linearSmeeChannel: "",
       linearBotUserId: "",
       linearTeams: [],
+      linearAgentConfig: null,
     });
     expect(warn).toHaveBeenCalledTimes(1);
     const msg = String(warn.mock.calls[0]?.[0] ?? "");
@@ -137,6 +143,7 @@ describe("loadWebhookConfig", () => {
       linearSmeeChannel: "",
       linearBotUserId: "",
       linearTeams: [],
+      linearAgentConfig: null,
     });
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
@@ -169,6 +176,7 @@ describe("loadWebhookConfig", () => {
       linearSmeeChannel: "",
       linearBotUserId: "",
       linearTeams: [],
+      linearAgentConfig: null,
     });
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
@@ -195,6 +203,7 @@ describe("loadWebhookConfig", () => {
       linearSmeeChannel: "",
       linearBotUserId: "",
       linearTeams: [],
+      linearAgentConfig: null,
     });
   });
 
@@ -222,6 +231,7 @@ describe("loadWebhookConfig", () => {
       linearSmeeChannel: "",
       linearBotUserId: "",
       linearTeams: [],
+      linearAgentConfig: null,
     });
   });
 
@@ -297,6 +307,7 @@ describe("loadWebhookConfig", () => {
       linearSmeeChannel: "",
       linearBotUserId: "",
       linearTeams: [],
+      linearAgentConfig: null,
     });
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
@@ -332,6 +343,7 @@ describe("loadWebhookConfig", () => {
       linearSmeeChannel: "",
       linearBotUserId: "",
       linearTeams: [],
+      linearAgentConfig: null,
     });
   });
 });
@@ -426,6 +438,7 @@ describe("loadWebhookConfig watchRepos (CTL-216)", () => {
       linearSmeeChannel: "",
       linearBotUserId: "",
       linearTeams: [],
+      linearAgentConfig: null,
     });
   });
 
@@ -1184,5 +1197,95 @@ describe("loadWebhookConfig linearTeams (CTL-362)", () => {
     expect(cfg!.linearTeams).toEqual([{ key: "CTL", vcsRepo: "second/wins" }]);
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
+  });
+});
+
+describe("loadLinearAgentConfig", () => {
+  it("returns null when projectKey is null", () => {
+    expect(loadLinearAgentConfig(homeDir, null)).toBeNull();
+  });
+
+  it("returns null when projectKey is empty string", () => {
+    expect(loadLinearAgentConfig(homeDir, "")).toBeNull();
+  });
+
+  it("returns null when the project-specific Layer-2 config file does not exist", () => {
+    expect(loadLinearAgentConfig(homeDir, "nonexistent")).toBeNull();
+  });
+
+  it("returns null when catalyst.linear.agent is absent in the file", () => {
+    writeFileSync(join(homeDir, "config-testproj.json"), JSON.stringify({
+      catalyst: { monitor: {} },
+    }));
+    expect(loadLinearAgentConfig(homeDir, "testproj")).toBeNull();
+  });
+
+  it("returns null when clientId is missing", () => {
+    writeFileSync(join(homeDir, "config-testproj.json"), JSON.stringify({
+      catalyst: { linear: { agent: { clientSecret: "xyz" } } },
+    }));
+    expect(loadLinearAgentConfig(homeDir, "testproj")).toBeNull();
+  });
+
+  it("returns null when clientSecret is missing", () => {
+    writeFileSync(join(homeDir, "config-testproj.json"), JSON.stringify({
+      catalyst: { linear: { agent: { clientId: "abc" } } },
+    }));
+    expect(loadLinearAgentConfig(homeDir, "testproj")).toBeNull();
+  });
+
+  it("returns populated LinearAgentConfig when all required fields present", () => {
+    writeFileSync(join(homeDir, "config-testproj.json"), JSON.stringify({
+      catalyst: { linear: { agent: { clientId: "abc", clientSecret: "xyz", webhookSecret: "whs" } } },
+    }));
+    const result = loadLinearAgentConfig(homeDir, "testproj");
+    expect(result).toEqual({ clientId: "abc", clientSecret: "xyz", webhookSecret: "whs" });
+  });
+
+  it("includes botUserId when present in config", () => {
+    writeFileSync(join(homeDir, "config-testproj.json"), JSON.stringify({
+      catalyst: { linear: { agent: { clientId: "abc", clientSecret: "xyz", botUserId: "bot-uuid" } } },
+    }));
+    const result = loadLinearAgentConfig(homeDir, "testproj");
+    expect(result).not.toBeNull();
+    expect(result!.botUserId).toBe("bot-uuid");
+  });
+
+  it("does not surface the accessToken", () => {
+    writeFileSync(join(homeDir, "config-testproj.json"), JSON.stringify({
+      catalyst: { linear: { agent: { clientId: "abc", clientSecret: "xyz", accessToken: "tok" } } },
+    }));
+    const result = loadLinearAgentConfig(homeDir, "testproj");
+    expect(result).not.toBeNull();
+    expect((result as unknown as Record<string, unknown>).accessToken).toBeUndefined();
+  });
+});
+
+describe("loadWebhookConfig — linearAgentConfig", () => {
+  it("propagates linearAgentConfig from project Layer-2 config", () => {
+    writeFileSync(join(homeDir, "config-testproj.json"), JSON.stringify({
+      catalyst: { linear: { agent: { clientId: "cid", clientSecret: "csec", webhookSecret: "wsec" } } },
+    }));
+    writeHome({
+      catalyst: { monitor: { github: { smeeChannel: "https://smee.io/h" } } },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "x";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath, "testproj");
+
+    expect(cfg!.linearAgentConfig).toEqual({ clientId: "cid", clientSecret: "csec", webhookSecret: "wsec" });
+    warn.mockRestore();
+  });
+
+  it("linearAgentConfig is null when projectKey not provided", () => {
+    writeHome({
+      catalyst: { monitor: { github: { smeeChannel: "https://smee.io/h" } } },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "x";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.linearAgentConfig).toBeNull();
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
@@ -76,6 +76,7 @@ export interface Attributes {
 
   // Linear (catalyst-defined; no OTel semconv yet)
   "linear.issue.identifier"?: string;
+  "linear.issue.id"?: string;
   "linear.team.key"?: string;
   "linear.actor.id"?: string;
 

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
@@ -96,6 +96,25 @@ export type LinearWebhookEvent =
       labelId: string | null;
       data: Record<string, unknown>;
     }
+  | {
+      kind: "agent_session";
+      action: "create" | "update" | "remove";
+      sessionId: string | null;
+      issueId: string | null;
+      actorId: string | null;
+      data: Record<string, unknown>;
+    }
+  | {
+      kind: "mention";
+      action: "create" | "update" | "remove";
+      ticket: string | null;
+      commentId: string | null;
+      issueId: string | null;
+      body: string | null;
+      authorId: string | null;
+      authorName: string | null;
+      data: Record<string, unknown>;
+    }
   | { kind: "ignored"; reason: string };
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -285,6 +304,53 @@ function parseIssueLabel(payload: Record<string, unknown>): LinearWebhookEvent {
   };
 }
 
+function parseAgentSessionEvent(payload: Record<string, unknown>): LinearWebhookEvent {
+  const action = normalizeAction(payload.action);
+  if (action === null) return ignored(`AgentSessionEvent: unknown action ${actionLabel(payload.action)}`);
+  const data = isObject(payload.data) ? payload.data : null;
+  if (data === null) return ignored("AgentSessionEvent: missing data");
+  const actor = isObject(payload.actor) ? payload.actor : null;
+  return {
+    kind: "agent_session",
+    action,
+    sessionId: getOptStr(data, "id"),
+    issueId: getOptStr(data, "issueId"),
+    actorId: actor !== null ? getOptStr(actor, "id") : null,
+    data,
+  };
+}
+
+function parseMentionEvent(payload: Record<string, unknown>): LinearWebhookEvent {
+  const action = normalizeAction(payload.action);
+  if (action === null) return ignored(`issueCommentMention: unknown action ${actionLabel(payload.action)}`);
+  const data = isObject(payload.data) ? payload.data : null;
+  if (data === null) return ignored("issueCommentMention: missing data");
+  let ticket: string | null = null;
+  if (isObject(data.issue)) {
+    ticket = getOptStr(data.issue, "identifier");
+  }
+  const actor = isObject(payload.actor) ? payload.actor : null;
+  const userObj = isObject(data.user) ? data.user : null;
+  const authorId =
+    (actor !== null ? getOptStr(actor, "id") : null) ??
+    (userObj !== null ? getOptStr(userObj, "id") : null) ??
+    getOptStr(data, "userId");
+  const authorName =
+    (actor !== null ? getOptStr(actor, "name") : null) ??
+    (userObj !== null ? getOptStr(userObj, "name") : null);
+  return {
+    kind: "mention",
+    action,
+    ticket,
+    commentId: getOptStr(data, "id"),
+    issueId: getOptStr(data, "issueId"),
+    body: getOptStr(data, "body"),
+    authorId,
+    authorName,
+    data,
+  };
+}
+
 /**
  * Parse a Linear webhook payload by `type` (read from the `Linear-Event`
  * header; passed in by the handler). The payload's own `type` field should
@@ -305,6 +371,10 @@ export function parseLinearWebhookEvent(eventName: string, payload: unknown): Li
       return parseReaction(payload);
     case "IssueLabel":
       return parseIssueLabel(payload);
+    case "AgentSessionEvent":
+      return parseAgentSessionEvent(payload);
+    case "issueCommentMention":
+      return parseMentionEvent(payload);
     default:
       return ignored(`unhandled type: ${eventType}`);
   }

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
@@ -243,6 +243,58 @@ export function buildLinearEventLogEnvelope(
         },
       });
     }
+    case "agent_session": {
+      const eventName = `linear.agent_session.${event.action}d`;
+      const attrs: Omit<Attributes, "event.name"> = {};
+      if (event.actorId !== null) attrs["linear.actor.id"] = event.actorId;
+      if (event.issueId !== null) attrs["linear.issue.id"] = event.issueId;
+      return canonical({
+        ts,
+        eventName,
+        entity: "agent_session",
+        action: `${event.action}d`,
+        severity: "INFO",
+        attrs,
+        message: eventName,
+        payload: {
+          action: event.action,
+          sessionId: event.sessionId,
+          issueId: event.issueId,
+          actorId: event.actorId,
+        },
+      });
+    }
+    case "mention": {
+      const eventName = `linear.mention.${event.action}d`;
+      const attrs: Omit<Attributes, "event.name"> = {};
+      if (event.ticket !== null) attrs["linear.issue.identifier"] = event.ticket;
+      if (event.authorId !== null) attrs["linear.actor.id"] = event.authorId;
+      const derivedTeamKey = deriveTeamKey(event.ticket);
+      const repo = lookupRepo(derivedTeamKey);
+      if (repo !== undefined) {
+        attrs["vcs.repository.name"] = repo;
+        if (derivedTeamKey !== null) attrs["linear.team.key"] = derivedTeamKey;
+      }
+      return canonical({
+        ts,
+        eventName,
+        entity: "mention",
+        action: `${event.action}d`,
+        label: event.ticket ?? undefined,
+        severity: "INFO",
+        attrs,
+        message: `${eventName}${event.ticket ? ` on ${event.ticket}` : ""}`,
+        payload: {
+          action: event.action,
+          commentId: event.commentId,
+          issueId: event.issueId,
+          ticket: event.ticket,
+          body: event.body,
+          authorId: event.authorId,
+          authorName: event.authorName,
+        },
+      });
+    }
     case "ignored":
       return null;
   }

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
@@ -50,6 +50,21 @@ export interface WebhookCliConfig {
    * pre-CTL-362 behaviour). CTL-362.
    */
   linearTeams: Array<{ key: string; vcsRepo: string }>;
+  /**
+   * OAuth app-actor credentials for the Catalyst Linear identity (CTL-550).
+   * Loaded from the project-specific Layer-2 config
+   * (`~/.config/catalyst/config-{projectKey}.json`).
+   * Null when not configured — the phase agents fall back to personal-token
+   * linearis CLI.
+   */
+  linearAgentConfig: LinearAgentConfig | null;
+}
+
+export interface LinearAgentConfig {
+  clientId: string;
+  clientSecret: string;
+  webhookSecret: string;
+  botUserId?: string;
 }
 
 interface FileExtract {
@@ -298,6 +313,42 @@ function readGithubSection(filePath: string): FileExtract | null {
 }
 
 /**
+ * Load the Linear app-actor credentials from the project-specific Layer-2
+ * config file (`~/.config/catalyst/config-{projectKey}.json`). Returns null
+ * when the file is absent, the project key is missing, or the required fields
+ * `clientId` / `clientSecret` are not present. The `accessToken` field is
+ * intentionally not surfaced — callers should mint fresh tokens via
+ * `client_credentials` grant using `clientId` / `clientSecret`. CTL-550.
+ */
+export function loadLinearAgentConfig(
+  homeConfigDir: string,
+  projectKey: string | null,
+): LinearAgentConfig | null {
+  if (projectKey === null || projectKey.length === 0) return null;
+  const configPath = join(homeConfigDir, `config-${projectKey}.json`);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || !isRecord(parsed.catalyst)) return null;
+  const linear = parsed.catalyst.linear;
+  if (!isRecord(linear)) return null;
+  const agent = linear.agent;
+  if (!isRecord(agent)) return null;
+  const clientId = typeof agent.clientId === "string" ? agent.clientId : "";
+  const clientSecret = typeof agent.clientSecret === "string" ? agent.clientSecret : "";
+  if (clientId.length === 0 || clientSecret.length === 0) return null;
+  const webhookSecret = typeof agent.webhookSecret === "string" ? agent.webhookSecret : "";
+  const botUserId =
+    typeof agent.botUserId === "string" && agent.botUserId.length > 0
+      ? agent.botUserId
+      : undefined;
+  return { clientId, clientSecret, webhookSecret, ...(botUserId !== undefined ? { botUserId } : {}) };
+}
+
+/**
  * Loads webhook delivery config from the two files where pieces of it live:
  *
  * - `<homeConfigDir>/config.json` (cross-project, per-machine, NOT committed) —
@@ -320,7 +371,8 @@ function readGithubSection(filePath: string): FileExtract | null {
  */
 export function loadWebhookConfig(
   homeConfigDir: string,
-  projectConfigPath: string
+  projectConfigPath: string,
+  projectKey: string | null = null,
 ): WebhookCliConfig | null {
   const projectExtract = readGithubSection(projectConfigPath);
   const homeExtract = readGithubSection(join(homeConfigDir, "config.json"));
@@ -389,6 +441,9 @@ export function loadWebhookConfig(
   // Linear team→repo map. Layer 1 only — team-shared, committed. CTL-362.
   const linearTeams = projectExtract?.linearTeams ?? [];
 
+  // Linear app-actor credentials. Project-specific Layer-2 only. CTL-550.
+  const linearAgentConfig = loadLinearAgentConfig(homeConfigDir, projectKey);
+
   // Allow Linear-only configurations: if the GitHub channel/secret are missing
   // but Linear secrets are present, return a config that disables the GitHub
   // route but enables the Linear route. CTL-210.
@@ -403,6 +458,7 @@ export function loadWebhookConfig(
       linearSmeeChannel,
       linearBotUserId,
       linearTeams,
+      linearAgentConfig,
     };
   }
 
@@ -415,5 +471,6 @@ export function loadWebhookConfig(
     linearSmeeChannel,
     linearBotUserId,
     linearTeams,
+    linearAgentConfig,
   };
 }

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -2044,6 +2044,7 @@ if (import.meta.main) {
   const fullWebhookConfig = loadWebhookConfig(
     process.env.CATALYST_CONFIG_DIR ?? `${process.env.HOME}/.config/catalyst`,
     `${process.cwd()}/.catalyst/config.json`,
+    projectKey,
   );
   const webhookConfig =
     fullWebhookConfig &&

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -288,10 +288,12 @@ ${MIRROR_FOOTER}"
 
 _... (truncated)_"
   fi
-  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+  COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
+  if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
-    echo "phase-implement: linearis discuss failed (continuing)" >&2
+    echo "phase-implement: linear-comment-post failed (continuing)" >&2
   fi
 fi
 ```

--- a/plugins/dev/skills/phase-monitor-deploy/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-deploy/SKILL.md
@@ -316,10 +316,12 @@ EOF
     [[ -n "${MIRROR_FOOTER}" ]] && MIRROR_BODY="${MIRROR_BODY}
 ${MIRROR_FOOTER}"
   fi
-  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+  COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
+  if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
-    echo "phase-monitor-deploy: linearis discuss failed (continuing)" >&2
+    echo "phase-monitor-deploy: linear-comment-post failed (continuing)" >&2
   fi
 fi
 

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -320,10 +320,12 @@ ${MIRROR_FOOTER}"
 
 _... (truncated)_"
   fi
-  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+  COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
+  if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
-    echo "phase-monitor-merge: linearis discuss failed (continuing)" >&2
+    echo "phase-monitor-merge: linear-comment-post failed (continuing)" >&2
   fi
 fi
 ```

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -224,10 +224,12 @@ EOF
   fi
   [[ -n "${MIRROR_FOOTER}" ]] && MIRROR_BODY="${MIRROR_BODY}
 ${MIRROR_FOOTER}"
-  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+  COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
+  if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
-    echo "phase-plan: linearis discuss failed (continuing)" >&2
+    echo "phase-plan: linear-comment-post failed (continuing)" >&2
   fi
 fi
 ```

--- a/plugins/dev/skills/phase-pr/SKILL.md
+++ b/plugins/dev/skills/phase-pr/SKILL.md
@@ -315,10 +315,12 @@ ${MIRROR_FOOTER}"
 
 _... (truncated)_"
   fi
-  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+  COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
+  if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
-    echo "phase-pr: linearis discuss failed (continuing)" >&2
+    echo "phase-pr: linear-comment-post failed (continuing)" >&2
   fi
 fi
 ```

--- a/plugins/dev/skills/phase-remediate/SKILL.md
+++ b/plugins/dev/skills/phase-remediate/SKILL.md
@@ -274,10 +274,12 @@ ${MIRROR_FOOTER}"
 
 _... (truncated)_"
   fi
-  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+  COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
+  if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
-    echo "phase-remediate: linearis discuss failed (continuing)" >&2
+    echo "phase-remediate: linear-comment-post failed (continuing)" >&2
   fi
 fi
 ```

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -219,10 +219,12 @@ EOF
   fi
   [[ -n "${MIRROR_FOOTER}" ]] && MIRROR_BODY="${MIRROR_BODY}
 ${MIRROR_FOOTER}"
-  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+  COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
+  if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
-    echo "phase-research: linearis discuss failed (continuing)" >&2
+    echo "phase-research: linear-comment-post failed (continuing)" >&2
   fi
 fi
 ```

--- a/plugins/dev/skills/phase-review/SKILL.md
+++ b/plugins/dev/skills/phase-review/SKILL.md
@@ -279,10 +279,12 @@ ${MIRROR_FOOTER}"
 
 _... (truncated)_"
   fi
-  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+  COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
+  if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
-    echo "phase-review: linearis discuss failed (continuing)" >&2
+    echo "phase-review: linear-comment-post failed (continuing)" >&2
   fi
 fi
 ```

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -251,14 +251,17 @@ if [[ -n "${ORCH_DIR:-}" && -x "${__PT_FOOTER}" ]]; then
 ${MIRROR_FOOTER}"
 fi
 
-# CTL-614: the Linear comment post is best-effort. triage.json is already on
-# disk; the canonical pipeline contract is `phase.triage.complete.<TICKET>`
-# (see CTL-452). A transient `linearis issues discuss` failure (notably the
-# rolling-hour HTTP 429 rate-limit from `linearis`) must NOT escalate the
-# ticket to `needs-human`. Capture stderr and surface it so operators can
-# still diagnose 429s from `daemon.log`.
-DISCUSS_STDERR="$(linearis issues discuss "$TICKET" --body "$COMMENT_BODY" 2>&1 >/dev/null)" \
-  || echo "phase-triage: linearis issues discuss failed (continuing): ${DISCUSS_STDERR}" >&2
+# CTL-614 / CTL-550: the Linear comment post is best-effort. triage.json is
+# already on disk; the canonical pipeline contract is
+# `phase.triage.complete.<TICKET>` (see CTL-452). A comment-post failure must
+# NOT escalate the ticket to `needs-human`.
+__PT_COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${__PT_REPO_ROOT}/plugins/dev/scripts/lib/linear-comment-post.sh}"
+if [[ ! -x "$__PT_COMMENT_POST" ]]; then __PT_COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
+if [[ -n "$__PT_COMMENT_POST" && -x "$__PT_COMMENT_POST" ]] && "$__PT_COMMENT_POST" "${TICKET}" "${COMMENT_BODY}" >/dev/null 2>&1; then
+  true
+else
+  echo "phase-triage: linear-comment-post failed (continuing)" >&2
+fi
 
 # 5. There is no `triaged` label. Triage completion is signaled by the
 #    analysis comment posted above plus the local triage.json the coordinator

--- a/plugins/dev/skills/phase-verify/SKILL.md
+++ b/plugins/dev/skills/phase-verify/SKILL.md
@@ -340,10 +340,12 @@ ${MIRROR_FOOTER}"
 
 _... (truncated)_"
   fi
-  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+  COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
+  if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
-    echo "phase-verify: linearis discuss failed (continuing)" >&2
+    echo "phase-verify: linear-comment-post failed (continuing)" >&2
   fi
 fi
 ```


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-02T10:45:00Z -->
<!-- Last updated: 2026-06-02T10:45:00Z -->
<!-- PR: #1279 -->
<!-- Previous commits: ff2d23bfe9da525138e13415f64b4608cc50fd61 -->

## Summary

Replaces all `linearis issues discuss` mirror-post calls across every phase-agent End block with a new `linear-comment-post.sh` bash helper that authenticates via OAuth `client_credentials`, resolves the Linear issue UUID, and posts as the Catalyst **app-actor identity** — so phase mirror comments appear under "Catalyst" in Linear rather than the developer's personal account.

The OAuth app registration is already live (confirmed by the "🎉 Catalyst agent identity is live" comment on CTL-550). The Layer-2 secrets file already contains `catalyst.linear.agent.{clientId, clientSecret, accessToken, webhookSecret}`.

## Changes Made

### New: bash comment-post helper
- **`plugins/dev/scripts/lib/linear-comment-post.sh`** — standalone bash script that:
  1. Reads `clientId` / `clientSecret` from `CATALYST_COMMENT_POST_HELPER` env override, `CATALYST_LINEAR_AGENT_*` env vars, or the project Layer-2 config (`~/.config/catalyst/config-{projectKey}.json`)
  2. Mints a fresh `lin_oauth_*` token via `client_credentials` POST (no caching — token TTL unknown)
  3. Resolves ticket identifier → issue UUID via GraphQL `filter: { identifier: { eq: $id } }`
  4. Posts a `commentCreate` mutation with the app-actor token

### Config schema + loader (Phase 1)
- **`docs/schemas/machine-config.schema.json`** — adds `catalyst.linear.agent` section under `catalyst.properties` with `clientId`, `clientSecret`, `accessToken`, `webhookSecret`, `botUserId`
- **`webhook-config.ts`** — new `loadLinearAgentConfig()` function and `LinearAgentConfig` interface; `loadWebhookConfig` gains optional `projectKey` arg and returns `linearAgentConfig: LinearAgentConfig | null`
- **`server.ts`** — passes `projectKey` to `loadWebhookConfig`

### Webhook event types (Phase 3)
- **`linear-webhook-events.ts`** — adds `AgentSessionEvent` and `issueCommentMention` parsers producing `agent_session` and `mention` event kinds
- **`linear-webhook-handler.ts`** — adds `agent_session` and `mention` cases to `buildLinearEventLogEnvelope` emitting `linear.agent_session.*` and `linear.mention.*` events into the JSONL event log
- **`canonical-event.ts`** — adds `"linear.issue.id"` attribute key

### Phase skill End block migration (Phase 4)
All 10 phase skill SKILL.md files (`phase-plan`, `phase-research`, `phase-implement`, `phase-verify`, `phase-review`, `phase-remediate`, `phase-pr`, `phase-monitor-merge`, `phase-monitor-deploy`, `phase-triage`) replace:
```bash
if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
```
with:
```bash
COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
```

### recovery.mjs mirror post (Phase 5)
- **`recovery.mjs`** — `defaultPostReclaimMirror` replaces `runLinearis` injectable seam with `runCommentPost` that shells out to `linear-comment-post.sh`

## Test Coverage

All phases follow TDD (Red → Green):

| Test file | New/updated |
|-----------|------------|
| `webhook-config.test.ts` | +10 tests for `loadLinearAgentConfig` + `linearAgentConfig` propagation |
| `linear-webhook-events.test.ts` | +17 tests for `AgentSessionEvent` + `issueCommentMention` |
| `linear-webhook-handler.test.ts` | +4 envelope tests for `agent_session` + `mention` kinds |
| `linear-comment-post.test.sh` | New — 9 tests covering happy path, failure modes, stub coverage |
| `linearis-stub.sh` | +`linear_comment_post_stub_install` + failing variant |
| 7× phase e2e tests | Updated runtime stubs + assertions for new comment-post helper |
| `recovery.test.mjs` | Updated `runLinearis` → `runCommentPost` injection |

## How to Verify It

- [x] `bun test plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts` — 62 pass
- [x] `bun test plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts` — 54 pass
- [x] `bun test plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts` — 51 pass
- [x] `bash plugins/dev/scripts/__tests__/linear-comment-post.test.sh` — 9 pass
- [x] `bash plugins/dev/scripts/__tests__/phase-plan-e2e.test.sh` — 39 pass
- [x] `bash plugins/dev/scripts/__tests__/phase-research-e2e.test.sh` — 43 pass
- [x] `bash plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh` — 153 pass
- [x] `bash plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh` — 60 pass (5 pre-existing dispatch failures unrelated to this PR)
- [x] `bash plugins/dev/scripts/__tests__/phase-review-e2e.test.sh` — 44 pass (5 pre-existing)
- [x] `bash plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh` — 37 pass
- [x] `bash plugins/dev/scripts/__tests__/phase-pr-e2e.test.sh` — 33 pass
- [x] `bun test plugins/dev/scripts/execution-core/recovery.test.mjs` — 169 pass
- [x] `grep -r "linearis issues discuss" plugins/dev/skills/` → 0 results (one prose reference in triage OK)

- [ ] Manual: run a CTL ticket through orchestration and confirm all phase mirror comments appear under the Catalyst app identity in Linear

Refs: CTL-550
