### PR TITLE
feat(dev): document and enforce the Linear app-actor botUserId requirement

### DIFF
--- a/.claude/config.template.json
+++ b/.claude/config.template.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
-  "$comment": "Catalyst Configuration Template - Copy to config.json and fill in values. Secrets go in ~/.config/catalyst/config-{projectKey}.json",
+  "$comment": "Catalyst Configuration Template - Copy to config.json and fill in values. Secrets (including the Linear app-actor OAuth creds) go in ~/.config/catalyst/config-{projectKey}.json; monitor.linear.botUserId is NOT a secret and stays here in Layer 1.",
   "catalyst": {
     "projectKey": "my-project",
     "repository": {
@@ -59,7 +59,9 @@
         "repoColors": {}
       },
       "linear": {
-        "webhookSecretEnv": "CATALYST_LINEAR_WEBHOOK_SECRET"
+        "$comment": "botUserId is the Linear USER UUID of the Catalyst app-actor (CTL-550). Required for the Linear app-actor comms channel — i.e. when the execution-core daemon mirrors phase-agent output to Linear and wakes on human replies (CTL-550 / CTL-549 / CTL-749). It lets execution-core and orch-monitor tell the agent's own mirror comments/issue events apart from a human's (loop / self-echo prevention). To obtain: TOKEN=$(jq -r '.catalyst.linear.agent.accessToken' ~/.config/catalyst/config-{projectKey}.json) && curl -s -X POST https://api.linear.app/graphql -H \"Authorization: Bearer $TOKEN\" -H \"Content-Type: application/json\" -d '{\"query\":\"query{viewer{id name}}\"}' | jq -r .data.viewer.id — then restart the monitor and execution-core daemon (both read botUserId only at startup).",
+        "webhookSecretEnv": "CATALYST_LINEAR_WEBHOOK_SECRET",
+        "botUserId": null
       }
     },
     "filter": {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -347,6 +347,19 @@ plus an `fs.watch` byte-cursor to drive `claude stop` / `git worktree remove` / 
 and broker registry) without coordinating with one another. The broker and the reaper are each
 both a reader and a writer of the same file.
 
+### Linear app-actor self-echo guard (`botUserId`)
+
+When the execution-core daemon mirrors phase-agent output to Linear and wakes on human replies,
+it must tell its **own** Linear comments and updates (posted as the Catalyst app-actor) apart
+from a human's. `catalyst.monitor.linear.botUserId` — the app-actor user UUID, read from the
+project's Layer-1 `.catalyst/config.json` at the flat path `catalyst.monitor.linear.botUserId`
+— is that discriminator. The daemon's `createCommentInboxWriter` / `createUpdateInboxWriter`
+(`daemon.mjs`) and orch-monitor's Linear webhook handler both skip events authored by
+`botUserId`, so the agent's mirror comments don't land in the worker `inbox.jsonl` as a false
+"human replied" signal and bot-authored issue events don't feed back as write loops. Without it
+the system can't distinguish the two, so it is the self-echo / loop-prevention guard for the
+Linear channel. See `docs/configuration.md` for how to obtain and set the value.
+
 ### `shouldSkipEvent` self-filter
 
 Because the broker both **reads** and **writes** the same JSONL log, it would otherwise re-ingest

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,6 +90,56 @@ cp plugins/dev/templates/config.template.json .catalyst/config.json
 All `stateMap` values must exactly match the state names in your Linear team. The daemon uses
 these to transition tickets as phases complete.
 
+#### Linear Webhook Bot Identity
+
+```jsonc
+{
+  "catalyst": {
+    "monitor": {
+      "linear": {
+        "botUserId": null               // Linear user UUID of the Catalyst app-actor
+      }
+    }
+  }
+}
+```
+
+`monitor.linear.botUserId` is the Linear user UUID of the Catalyst app-actor — the "Linear for
+Agents" app user that posts comments **as the app**. It is the self-echo / loop-prevention guard
+for the whole Linear app-actor comms channel:
+
+- The orch-monitor server uses it to suppress bot-authored issue events so the app's own writes
+  don't feed back into the event log as write loops.
+- The execution-core daemon uses it to filter the agent's own mirror comments and
+  description-updates out of each worker's `inbox.jsonl`, so a human reply on a ticket is the
+  only thing that wakes a parked worker (not the agent's own echo).
+
+**When to set it:** required for the Linear app-actor comms channel — i.e. when the execution-core
+daemon mirrors phase-agent output to Linear and wakes on human replies (CTL-550 / CTL-549 /
+CTL-749). Without it, the system cannot tell the agent's own comments apart from a human's. The
+value is not secret (it appears on every comment the app posts) but it **is workspace-specific**,
+so the committed config ships `null` and each operator fills in their own.
+
+**How to obtain it:** query `viewer.id` with the app-actor token. The app OAuth credentials live
+in the per-project Layer-2 file (`~/.config/catalyst/config-<projectKey>.json` →
+`catalyst.linear.agent.{clientId,clientSecret,accessToken}`). Using the stored access token:
+
+```bash
+TOKEN=$(jq -r '.catalyst.linear.agent.accessToken' ~/.config/catalyst/config-<projectKey>.json)
+BOT_ID=$(curl -s -X POST https://api.linear.app/graphql \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"query{viewer{id name}}"}' | jq -r .data.viewer.id)
+```
+
+Write `$BOT_ID` into `.catalyst/config.json` → `catalyst.monitor.linear.botUserId`, then restart
+both readers (they read `botUserId` only at startup):
+
+```bash
+catalyst-monitor stop && catalyst-monitor start
+catalyst-execution-core restart
+```
+
 #### Orchestration
 
 ```jsonc

--- a/docs/orchestrator-overview.md
+++ b/docs/orchestrator-overview.md
@@ -120,6 +120,15 @@ completion advances the ticket to `research` normally. This makes "Ready" a
 valid manual entry point: the system transparently runs the missing triage
 instead of dead-locking the research prior-artifact gate. (CTL-625)
 
+**Linear app-actor self-echo guard.** `catalyst.monitor.linear.botUserId` (Layer-1
+`.catalyst/config.json`, the Linear user UUID of the Catalyst app-actor) is the
+self-echo guard the daemon uses to tell the agent's *own* mirror comments from a
+human reply, so bot-authored issue events don't feed back as a false "human
+replied" signal or a write loop. Required for the Linear app-actor comms channel —
+i.e. when the daemon mirrors phase-agent output to Linear and wakes on human
+replies (CTL-550 / CTL-549 / CTL-749). Set it via `/catalyst-dev:setup-catalyst`;
+distributed templates ship `null`.
+
 ## The 9-phase pipeline (phase-agents mode)
 
 Canonical sequence is defined in `plugins/dev/scripts/orchestrate-phase-advance`

--- a/docs/schemas/catalyst-config.schema.json
+++ b/docs/schemas/catalyst-config.schema.json
@@ -148,6 +148,12 @@
                       }
                     }
                   }
+                },
+                "botUserId": {
+                  "type": ["string", "null"],
+                  "format": "uuid",
+                  "description": "Linear user UUID of the Catalyst app-actor (the 'Linear for Agents' app user, installed via CTL-550). Used by orch-monitor and the execution-core daemon to suppress bot self-echo comments/updates and bot-authored issue events, preventing write loops (CTL-749). Required for the Linear app-actor comms channel — i.e. when the execution-core daemon mirrors phase-agent output to Linear and wakes on human replies (CTL-550 / CTL-549 / CTL-749); omitting it makes the system treat the agent's own comments as human input. Obtain it from the app-actor access token's viewer.id (NOT a personal/admin token): query{viewer{id}}. This value is workspace-specific — set it only in the local .catalyst/config.json, not in committed templates (use null + a placeholder there). Default null disables suppression.",
+                  "examples": ["00000000-0000-0000-0000-000000000000", null]
                 }
               }
             }

--- a/docs/schemas/machine-config.schema.json
+++ b/docs/schemas/machine-config.schema.json
@@ -115,7 +115,7 @@
                 },
                 "botUserId": {
                   "type": "string",
-                  "description": "Linear user UUID of the app actor. Used for loop prevention (suppresses events authored by the agent)."
+                  "description": "Linear user UUID of the app-actor. NOT USED in machine config (this field is for reference only; the operational botUserId is read from Layer 1 catalyst.monitor.linear.botUserId). Kept here for backwards compatibility / documentation of the app-actor identity."
                 }
               }
             }

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -302,6 +302,17 @@ if [[ -n $CONFIG_PATH ]]; then
 		fi
 	fi
 
+	# CTL-749: botUserId is the Linear app-actor user UUID — read from the project's
+	# Layer-1 config ($CONFIG_PATH), the SAME place the execution-core daemon
+	# (daemon.mjs readLinearBotUserId) and orch-monitor's webhook handler read it.
+	# Without it, execution-core comms can't filter the agent's own mirror
+	# comments/updates and treats them as human input (false "human replied" signal).
+	BOT_USER_ID=$(jq -r '.catalyst.monitor.linear.botUserId // empty' "$CONFIG_PATH" 2>/dev/null)
+	if [[ -z $BOT_USER_ID ]]; then
+		warnings+=("Missing catalyst.monitor.linear.botUserId in $CONFIG_PATH — execution-core comms won't filter bot self-echo (the agent's own Linear comments look like human replies)")
+		warnings+=("  Set it: query the Catalyst app-actor viewer.id (app token from ~/.config/catalyst/config-<projectKey>.json catalyst.linear.agent.accessToken) and write catalyst.monitor.linear.botUserId; see /catalyst-dev:setup-catalyst")
+	fi
+
 	# Warn if config is still only in .claude/ (deprecated location)
 	if [[ $CONFIG_PATH == ".claude/config.json" && ! -f ".catalyst/config.json" ]]; then
 		warnings+=("config.json is in .claude/ (deprecated) — move to .catalyst/config.json")

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -318,6 +318,19 @@ warn "Linear 'magic words' auto-move must be OFF (Settings → Team → Workflow
 info "It races the execution-core daemon (CTL-758 backward-write). Disable it in the Linear UI."
 info "Git-automation state moves (start→PR, merge→Done) are reconciled by setup-execution-core-states.sh."
 
+# botUserId (CTL-749) is the Linear app-actor user UUID. It is read from the
+# project's Layer-1 .catalyst/config.json ($CONFIG_PATH) — the SAME place the
+# execution-core daemon and orch-monitor read it — NOT the Layer-2 home config.
+if [[ -n "$CONFIG_PATH" && -f "$CONFIG_PATH" ]]; then
+    bot_id=$(jq -r '.catalyst.monitor.linear.botUserId // empty' "$CONFIG_PATH" 2>/dev/null)
+    if [[ -z "$bot_id" ]]; then
+        warn "catalyst.monitor.linear.botUserId missing in $CONFIG_PATH — execution-core comms won't filter bot self-echo (the agent's own Linear comments look like human replies)"
+        info "Set it: query the Catalyst app-actor viewer.id (app token in ~/.config/catalyst/config-\${projectKey}.json → catalyst.linear.agent.accessToken) and write catalyst.monitor.linear.botUserId; see /catalyst-dev:setup-catalyst"
+    else
+        pass "Linear app-actor identity: ${bot_id:0:8}…"
+    fi
+fi
+
 # ─── 7. OTel Observability Stack (optional) ────────────────────────────────
 
 header "Observability Stack (optional)"

--- a/plugins/dev/scripts/setup-execution-core-states.sh
+++ b/plugins/dev/scripts/setup-execution-core-states.sh
@@ -438,6 +438,22 @@ main() {
     echo "Missing states: $missing" >&2
   fi
 
+  # --- check the Linear app-actor identity (CTL-749) ---
+  # The execution-core daemon reads catalyst.monitor.linear.botUserId at startup
+  # to filter the agent's OWN mirror comments/description-updates out of each
+  # worker's inbox.jsonl (self-echo / write-loop guard). Without it set, the
+  # agent's comments are written back as if a human replied, and bot-authored
+  # issue events feed back into the event log as loops. This is a prerequisite,
+  # not a hard failure here — warn and continue.
+  local bot_id
+  bot_id=$(jq -r '.catalyst.monitor.linear.botUserId // empty' "$config" 2>/dev/null)
+  if [[ -z $bot_id ]]; then
+    echo "WARNING: catalyst.monitor.linear.botUserId not set in $config" >&2
+    echo "  execution-core needs it for CTL-749 self-echo filtering of the agent's own" >&2
+    echo "  Linear comments/updates. Obtain it by querying viewer.id with the app-actor" >&2
+    echo "  token from ~/.config/catalyst/config-${project_key}.json, then set it here." >&2
+  fi
+
   # --- write the execution-core stateMap (atomic tmp + mv) ---
   jq --argjson stateMap "$state_map" '.catalyst.linear.stateMap = $stateMap' \
     "$config" > "${config}.tmp" && mv "${config}.tmp" "$config"

--- a/plugins/dev/scripts/setup-linear-webhook.sh
+++ b/plugins/dev/scripts/setup-linear-webhook.sh
@@ -538,6 +538,21 @@ chmod 600 "$SECRET_FILE"
 # Write the Layer 2 registration record (CTL-238).
 write_linear_record "$REGISTER_KEY" "$WEBHOOK_ID" "$WEBHOOK_URL" "$RESOURCE_TYPES_JSON"
 
+# CTL-749 reminder (NOT set here): the Linear app-actor identity
+# `catalyst.monitor.linear.botUserId` — read from the project's Layer-1
+# `.catalyst/config.json` by the execution-core daemon (daemon.mjs
+# readLinearBotUserId) and orch-monitor's Linear webhook handler — must be the
+# Catalyst **app-actor** user UUID so the agent's OWN comments/issue-events are
+# filtered (self-echo / write-loop guard; without it a human reply can't be told
+# apart from the agent's mirror comments). This script authenticates with the
+# personal/admin Linear token for webhook CRUD, whose `viewer.id` is the HUMAN
+# operator — writing that as botUserId would wrongly suppress real human replies.
+# Obtain it with the app-actor token (Layer-2 catalyst.linear.agent.accessToken)
+# via `query{viewer{id}}`, write it to .catalyst/config.json ->
+# catalyst.monitor.linear.botUserId, then restart the monitor + daemon. See
+# /catalyst-dev:setup-catalyst or docs/configuration.md "Linear Webhook Bot Identity".
+echo "NOTE: set catalyst.monitor.linear.botUserId (the app-actor viewer.id, NOT this admin token's) in .catalyst/config.json — see /catalyst-dev:setup-catalyst. Not written here." >&2
+
 cat <<EOF
 Created Linear webhook $WEBHOOK_ID for $WEBHOOK_URL
   Resource types: $(printf '%s, ' "${RESOURCE_TYPES[@]}" | sed 's/, $//')

--- a/plugins/dev/skills/setup-catalyst/SKILL.md
+++ b/plugins/dev/skills/setup-catalyst/SKILL.md
@@ -81,6 +81,44 @@ a unified diff and asks for confirmation before merging. Concretely:
 6. If the user declines, leave `.catalyst/config.json` untouched. The drift warning continues to
    appear on subsequent workflow invocations, providing passive nagging until resolved.
 
+**Linear bot user ID (CTL-550 / CTL-749 / CTL-549).** `catalyst.monitor.linear.botUserId` is the
+Linear user UUID of the Catalyst app-actor — the "Linear for Agents" app identity that posts
+comments *as the app* (installed by CTL-550). It is **required for the Linear app-actor comms
+channel** — i.e. when the execution-core daemon mirrors phase-agent output to Linear and wakes on
+human replies (CTL-550 / CTL-549 / CTL-749). It is the self-echo / loop-prevention guard for the
+whole bidirectional channel. CTL-749 / CTL-549 built a channel where a human reply on a ticket
+wakes a parked worker; without `botUserId` loaded, the system cannot tell the agent's *own*
+comments and description-updates apart from a human's, so (a) the agent's own mirror comments get
+written into the worker `inbox.jsonl` as if they were human input (noise / false "human replied"
+signals), and (b) bot-authored issue events feed back into the event log as write loops. The
+orch-monitor's Linear webhook handler suppresses bot-authored issue events using this value, and
+the execution-core daemon uses it to filter the agent's self-echo from each worker's inbox.
+
+This value is **workspace-specific** and is NOT shipped in the committed template
+(`config.template.json` keeps it `null`). It is not secret — it appears on every comment the app
+posts — but it must be obtained per workspace and written into Layer 1
+`.catalyst/config.json → catalyst.monitor.linear.botUserId` (alongside the other `monitor.linear`
+keys such as `teams` and `webhookSecretEnv`). To obtain it, query `viewer.id` with the app-actor
+token (the app OAuth credentials live in Layer 2
+`~/.config/catalyst/config-<projectKey>.json → catalyst.linear.agent.{clientId,clientSecret,accessToken}`):
+
+```bash
+TOKEN=$(jq -r '.catalyst.linear.agent.accessToken' ~/.config/catalyst/config-<projectKey>.json)
+BOT_ID=$(curl -s -X POST https://api.linear.app/graphql \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"query{viewer{id name}}"}' | jq -r .data.viewer.id)
+```
+
+(Alternatively, mint a fresh app token via `grant_type=client_credentials` with `actor=app` and
+`scope="app:mentionable,app:assignable"` at `POST https://api.linear.app/oauth/token`, then run the
+same `viewer{id}` query.) Write `$BOT_ID` into
+`.catalyst/config.json → catalyst.monitor.linear.botUserId`. Both the monitor and the daemon read
+`botUserId` **only at startup**, so after setting it you must restart them:
+`catalyst-monitor stop && catalyst-monitor start`, then `catalyst-execution-core restart`. This is
+a needs-user-input step (it requires the app-actor credentials), not an auto-fix — never write the
+value for the user without confirming it came from their own app-actor token.
+
 **Execution-core state contract (CTL-564).** When a repo's
 `catalyst.orchestration.dispatchMode` is `execution-core`, `setup-catalyst.sh`
 runs an extra step — `setup_execution_core_states` — right after the Linear

--- a/plugins/dev/templates/config.template.json
+++ b/plugins/dev/templates/config.template.json
@@ -45,6 +45,12 @@
       "_comment": "Semantic event routing via Groq. Set GROQ_API_KEY env var to enable.",
       "groqModel": "llama-3.1-8b-instant"
     },
+    "monitor": {
+      "linear": {
+        "_comment": "Linear app-actor identity for loop prevention (CTL-550/549/749). botUserId is the Linear user UUID of the installed Catalyst Linear app — it is the self-echo guard that keeps the agent's own mirror comments/issue events out of the worker inbox and event log. Required for the Linear app-actor comms channel — i.e. when the execution-core daemon mirrors phase-agent output to Linear and wakes on human replies (CTL-550 / CTL-549 / CTL-749). Not secret, but workspace-specific — keep null in committed templates and set it in your local .catalyst/config.json. Obtain via: TOKEN=$(jq -r '.catalyst.linear.agent.accessToken' ~/.config/catalyst/config-{projectKey}.json) && curl -s -X POST https://api.linear.app/graphql -H \"Authorization: Bearer $TOKEN\" -H \"Content-Type: application/json\" -d '{\"query\":\"query{viewer{id}}\"}' | jq -r .data.viewer.id — then restart the monitor and execution-core (both read it only at startup).",
+        "botUserId": null
+      }
+    },
     "orchestration": {
       "_comment": "Worker dispatch mode. 'phase-agents' (default) dispatches the 9-phase pipeline on claude --bg; 'oneshot-legacy' keeps the pre-CTL-452 single-shot oneshot worker on claude -p.",
       "dispatchMode": "phase-agents",

--- a/plugins/legacy/skills/orchestrate/SKILL.md
+++ b/plugins/legacy/skills/orchestrate/SKILL.md
@@ -257,6 +257,26 @@ ALLOW_SELF_REPORTED=$(jq -r '.catalyst.orchestration.allowSelfReportedCompletion
 DISPATCH_MODE=$(jq -r '.catalyst.orchestration.dispatchMode // "oneshot-legacy"' "$CONFIG_FILE" 2>/dev/null)
 ```
 
+**Linear App-Actor Identity (CTL-550, CTL-749)**
+
+`catalyst.monitor.linear.botUserId` is **required for the Linear app-actor comms channel — i.e.
+when the execution-core daemon mirrors phase-agent output to Linear and wakes on human replies
+(CTL-550 / CTL-549 / CTL-749)**. It must be set **before** the daemon starts. The daemon reads it
+from the project's Layer-1 committed config at the flat path
+`<project>/.catalyst/config.json` → `catalyst.monitor.linear.botUserId` (not the Layer-2 home
+config, not a team-keyed sub-object). This is the Linear user UUID of the Catalyst app-actor (the
+"Linear for Agents" app user) — workspace-specific, and `null` in the committed config template.
+See `/catalyst-dev:setup-catalyst` for how to obtain it (query `viewer.id` with the app-actor
+token). (The execution-core daemon is the pull-based runner of the phase-agent pipeline; it is not
+a `dispatchMode` enum value — those are `phase-agents` and `oneshot-legacy`.)
+
+The daemon reads `botUserId` only at startup and uses it to filter the agent's own mirror activity
+out of the bidirectional Linear comms channel (CTL-749/CTL-549): it suppresses bot-authored comments
+and description updates so they are not written into `workers/<ticket>/inbox.jsonl` as input. Without
+it, the daemon cannot tell the agent's own comments/updates apart from a human's, so every mirror
+comment lands in the worker inbox as a false "human replied" signal (noise / write loops). It is
+the self-echo / loop-prevention guard.
+
 **Create ALL worktrees using `create-worktree.sh`** — both orchestrator and workers go through the
 same script so they all get `.claude/`, `.catalyst/`, dependency install, thoughts init, and custom
 hooks:

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -88,6 +88,56 @@ For `execution-core` mode, the number of workers comes from a separate committed
 
 In `execution-core` mode, the daemon reads a central registry at `~/catalyst/execution-core/registry.json`. Each project there has an `eligibleQuery` that says which tickets are ready — for example, `status: "Ready"`. The setup tool `setup-execution-core-states.sh` writes this for you; you don't edit it by hand. That mode also needs six Linear states to exist — `Ready`, `Research`, `Plan`, `Implement`, `Validate`, and `PR` — which the same tool creates.
 
+## Linear app-actor identity (`catalyst.monitor.linear.botUserId`)
+
+You must set `catalyst.monitor.linear.botUserId` for the Linear app-actor comms channel — i.e. when the daemon mirrors phase-agent output to Linear and wakes on human replies (the "Linear for Agents" identity that posts comments **as Catalyst**). It's the Linear user UUID of that app actor. This lives in the committed `.catalyst/config.json` — not the secrets file — because the value isn't secret (it appears on every comment the app posts), but it is workspace-specific.
+
+```json
+{
+  "catalyst": {
+    "monitor": {
+      "linear": {
+        "teams": ["ACME"],
+        "webhookSecretEnv": "CATALYST_LINEAR_WEBHOOK_SECRET",
+        "botUserId": null
+      }
+    }
+  }
+}
+```
+
+| Key | What it does |
+| --- | --- |
+| `catalyst.monitor.linear.botUserId` | Linear user UUID of the Catalyst app actor. Required for the Linear app-actor comms channel — when the daemon mirrors phase-agent output to Linear and wakes on human replies; leave `null` otherwise |
+
+### Why it's required
+
+Catalyst's app identity lets it post comments as the app, and a human reply on a ticket can wake a parked worker. To make that work, the system must tell the agent's **own** comments and description updates apart from a human's. Without `botUserId` loaded, it can't:
+
+- The agent's own mirror comments get written into the worker inbox as if a human had replied — noise, and a false "human replied" signal.
+- Bot-authored issue events feed back into the event log as write loops.
+
+So `botUserId` is the self-echo and loop-prevention guard for the whole Linear-for-Agents channel. Set it for any workspace that uses the app-actor comms.
+
+### How to obtain it
+
+Query `viewer.id` with the app-actor token. The app OAuth credentials live in the secrets file under `catalyst.linear.agent`:
+
+```bash
+TOKEN=$(jq -r '.catalyst.linear.agent.accessToken' ~/.config/catalyst/config-{projectKey}.json)
+BOT_ID=$(curl -s -X POST https://api.linear.app/graphql \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"query{viewer{id name}}"}' | jq -r .data.viewer.id)
+```
+
+Write `$BOT_ID` into `.catalyst/config.json` under `catalyst.monitor.linear.botUserId`, then restart both readers — they only load it at startup:
+
+```bash
+catalyst-monitor stop && catalyst-monitor start
+catalyst-execution-core restart
+```
+
 ## Secrets config (`~/.config/catalyst/config-{projectKey}.json`)
 
 Never commit this. One file per project, linked by `projectKey`. It holds API keys.


### PR DESCRIPTION
## What

Makes every setup/doc surface reflect the **`catalyst.monitor.linear.botUserId`** requirement — the self-echo / loop-prevention guard for the Linear app-actor comms channel (CTL-550 / CTL-549 / CTL-749). It was consumed by code (daemon + orch-monitor) but missing from every template, schema, skill, doc, and setup script, so a fresh install silently ran without it.

## Why it matters

`botUserId` is the Linear user UUID of the Catalyst **app-actor**. The execution-core daemon (`createCommentInboxWriter` / `createUpdateInboxWriter`) and orch-monitor's Linear webhook handler read it from the **Layer-1** `.catalyst/config.json` to tell the agent's own mirror comments/issue-events apart from a human reply. Without it: the agent's comments get written to the worker inbox as a false "human replied" signal, and bot-authored issue events feed back as write loops.

## Changes (14 files)

- **Docs** — `docs/configuration.md` + website `reference/configuration.md` (full bot-identity reference: what / why / how-to / restart); `docs/schemas/catalyst-config.schema.json` (new `botUserId` property) + `machine-config.schema.json` (Layer-2 reference note); `docs/architecture.md` + `docs/orchestrator-overview.md` (note the guard in the comms data flow).
- **Templates** — `config.template.json` + `.claude/config.template.json` ship `botUserId: null` + documented guidance.
- **Skills** — `setup-catalyst` (obtain recipe) + `orchestrate` (requirement) SKILL.md.
- **Setup scripts** — `check-setup.sh` + `check-project-setup.sh` warn when unset (read **Layer-1**, matching the daemon); `setup-execution-core-states.sh` keeps its Layer-1 prereq warning; `setup-linear-webhook.sh` no longer mis-writes `botUserId` via the webhook **admin** token (whose `viewer.id` is the human operator, not the app — which would have made the filter suppress real human replies).

## Canonical contract (consistent across all surfaces)

- **Read/write location:** Layer-1 `<project>/.catalyst/config.json → catalyst.monitor.linear.botUserId` (flat).
- **Value:** the **app-actor** `viewer.id` (NOT a personal/admin token).
- **Creds:** Layer-2 `~/.config/catalyst/config-<projectKey>.json → catalyst.linear.agent.*`.

## Safety

- No secrets committed. The real workspace UUID stays only in the operator's local `.catalyst/config.json` (deliberately **not** in this PR); committed templates ship `null`.
- Setup scripts validated with `bash -n`; all edited JSON parses.

## Follow-up

The wake path (`handleCommentWake`) still lacks the `botUserId` guard, so setting it doesn't fully close the self-wake loop — tracked as a code fix in **CTL-756**.

Refs: CTL-550, CTL-549, CTL-749.