### PR TITLE
fix(dev): CTL-756 self-echo guard for handleCommentWake

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -182,10 +182,15 @@ function ensureState(orchDir) {
 // and skipped, never fatal.
 export async function handleCommentWake(
   parsed,
-  { orchDir, dispatch, removeLabel },
+  { orchDir, dispatch, removeLabel, botUserId },
 ) {
   const { ticket } = parsed ?? {};
   if (!ticket) return;
+  // CTL-756: self-echo guard — never re-dispatch on the bot's own comment
+  // (e.g. the parking-question comment the parked worker just posted as the
+  // Catalyst app actor). Fail-open when botUserId is unset. Mirrors the inbox
+  // writers' guard (daemon.mjs:124 / :148).
+  if (botUserId && parsed.authorId === botUserId) return;
 
   const workerDir = join(orchDir, "workers", ticket);
   let signalFiles;
@@ -330,7 +335,7 @@ export function startDaemon({
       cache,
       onComment: (parsed) => {
         commentInboxWriter(parsed); // CTL-749: write to inbox.jsonl for in-flight workers
-        handleCommentWake(parsed, { orchDir, dispatch: dispatchTicket, removeLabel: defaultRemoveLabel }); // CTL-549: re-dispatch parked tickets
+        handleCommentWake(parsed, { orchDir, dispatch: dispatchTicket, removeLabel: defaultRemoveLabel, botUserId: linearBotUserId }); // CTL-549 + CTL-756: re-dispatch parked tickets; botUserId suppresses self-echo
       },
       onUpdate: createUpdateInboxWriter(orchDir, linearBotUserId), // CTL-749
     }); // CTL-535 + CTL-565 + CTL-634 + CTL-549 + CTL-749

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -908,6 +908,50 @@ describe("handleCommentWake (CTL-549)", () => {
     );
     expect(dispatched).toHaveLength(0);
   });
+
+  test("no-ops (self-echo) when comment authorId matches botUserId", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "CTL-1", "implement", {
+      status: "needs-input",
+      parkedFrom: "implement",
+      handoffPath: "/path/handoff.md",
+    });
+    const dispatched = [];
+    const removed = [];
+    await handleCommentWake(
+      { ticket: "CTL-1", commentId: "c1", body: "I am the bot", authorId: "bot-user-id" },
+      {
+        orchDir: orch,
+        dispatch: (dir, ticket, phase, opts) => { dispatched.push({ ticket, phase, opts }); return { code: 0 }; },
+        removeLabel: async (t, l) => { removed.push({ ticket: t, label: l }); },
+        botUserId: "bot-user-id",
+      },
+    );
+    expect(dispatched).toHaveLength(0); // self-echo suppressed: no re-dispatch
+    expect(removed).toHaveLength(0);    // and the human-attention label is preserved
+  });
+
+  test("re-dispatches when comment authorId does NOT match botUserId (human reply)", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "CTL-1", "implement", {
+      status: "needs-input",
+      parkedFrom: "implement",
+      handoffPath: "/path/handoff.md",
+    });
+    const dispatched = [];
+    await handleCommentWake(
+      { ticket: "CTL-1", commentId: "c2", body: "Here is the answer", authorId: "human-user-id" },
+      {
+        orchDir: orch,
+        dispatch: (dir, ticket, phase, opts) => { dispatched.push({ ticket, phase, opts }); return { code: 0 }; },
+        removeLabel: async () => {},
+        botUserId: "bot-user-id",
+      },
+    );
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].ticket).toBe("CTL-1");
+    expect(dispatched[0].phase).toBe("implement");
+  });
 });
 
 // CTL-749: inbox writer factory functions


### PR DESCRIPTION

## Summary

- Adds a `botUserId` parameter to `handleCommentWake` and an early-return self-echo guard so bot-authored comments (e.g. the parking-question mirror post) never re-dispatch a parked worker
- Threads the already-resolved `linearBotUserId` through the `onComment` wiring site in `startDaemon`, mirroring the existing inbox-writer guard
- Covers both the suppression path (bot-authored → 0 dispatches, label preserved) and the wake path (human-authored → 1 dispatch) with two new unit tests; all 5 pre-existing `handleCommentWake` tests still pass

## Problem

`handleCommentWake` was wired into the daemon's `onComment` callback WITHOUT a `botUserId` self-echo guard. When a worker parks for human clarification it (a) posts a question comment as the Catalyst app actor, then (b) sets `status=needs-input`. The webhook for the agent's own question then fired `handleCommentWake`, which stripped the `needs-human/question` label and re-dispatched the just-parked worker — a spurious self-wake.

The inbox writers (`createCommentInboxWriter`, `createUpdateInboxWriter`) already guarded self-echo via `if (botUserId && parsed.authorId === botUserId) return;`. The wake path had no equivalent guard.

## Changes Made

### `plugins/dev/scripts/execution-core/daemon.mjs` (+7 / -2)

- `handleCommentWake`: added `botUserId` to the destructured options; added early-return self-echo guard (fail-open when `botUserId` is unset, preserving backward compatibility with all pre-existing call sites that don't pass the param)
- `startDaemon` → `onComment` wiring: passes `botUserId: linearBotUserId` into `handleCommentWake`

### `plugins/dev/scripts/execution-core/daemon.test.mjs` (+44 / -0)

- New test: bot-authored comment → `dispatched.length === 0`, `removed.length === 0` (label preserved)
- New test: human-authored comment (different `authorId`) → `dispatched.length === 1` (wake preserved)

## How to Verify It

- [x] `bun test daemon.test.mjs` — 58/58 pass (was 56/56 before this PR)
- [x] `bun test` (full execution-core suite) — 1610/1611 pass; 1 pre-existing flaky failure unrelated to this diff
- [x] New self-echo test: bot-authored comment → 0 dispatches, 0 removeLabel calls
- [x] New human-reply test: human-authored comment → 1 dispatch
- [x] 5 pre-existing `handleCommentWake` tests pass (fail-open `botUserId && ...` guard preserves all legacy call sites)

## Changelog Entry

```
fix(dev): CTL-756 self-echo guard for handleCommentWake

Thread linearBotUserId into the onComment wake path so bot-authored comments
(e.g. parking-question mirror posts) never re-dispatch a parked worker.
Mirrors the inbox writers' existing guard. +2 unit tests.
```

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-756
- Related: CTL-549 (clarification wake), CTL-550 (app-actor botUserId), CTL-749 (inbox writers self-echo guard)