### PR TITLE
fix(dev): CTL-745 gate synthetic done on terminal pipeline state

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/board-current-phase.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-current-phase.test.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "bun:test";
+import { deriveCurrentPhase, PHASE_ORDER } from "../lib/board-data.mjs";
+
+type Sig = {
+  status: string;
+  model?: string | null;
+  startedAt?: string;
+  updatedAt?: string;
+} | null;
+
+const sigs = () => PHASE_ORDER.map(() => null) as Sig[];
+const idx = (phase: string) => PHASE_ORDER.indexOf(phase);
+
+// ── THE BUG (CTL-745) ──────────────────────────────────────────────────────
+test("verify done + no downstream signals → stays at verify, NOT synthetic done", () => {
+  const s = sigs();
+  s[idx("verify")] = { status: "done", startedAt: "2026-06-03T08:00:00Z", updatedAt: "2026-06-03T08:05:00Z" };
+  const cur = deriveCurrentPhase(s);
+  expect(cur.phase).toBe("verify");
+  expect(cur.status).toBe("done");
+});
+
+test("implement done + verify absent → stays at implement (mid-pipeline gap)", () => {
+  const s = sigs();
+  s[idx("triage")] = { status: "done" };
+  s[idx("research")] = { status: "done" };
+  s[idx("plan")] = { status: "done" };
+  s[idx("implement")] = { status: "done", startedAt: "2026-06-03T08:00:00Z" };
+  expect(deriveCurrentPhase(s).phase).toBe("implement");
+});
+
+// ── GENUINE COMPLETION ─────────────────────────────────────────────────────
+test("final phase (monitor-deploy) terminal → synthetic done", () => {
+  const s = sigs();
+  for (const p of PHASE_ORDER) s[idx(p)] = { status: "done" };
+  const cur = deriveCurrentPhase(s);
+  expect(cur.phase).toBe("done");
+  expect(cur.status).toBe("done");
+});
+
+test("monitor-deploy skipped (final phase, terminal) → still done", () => {
+  const s = sigs();
+  for (const p of PHASE_ORDER) s[idx(p)] = { status: "done" };
+  s[idx("monitor-deploy")] = { status: "skipped" };
+  expect(deriveCurrentPhase(s).phase).toBe("done");
+});
+
+// ── NON-TERMINAL (RUNNING) ─────────────────────────────────────────────────
+test("running phase returns immediately with its real status", () => {
+  const s = sigs();
+  s[idx("triage")] = { status: "done" };
+  s[idx("research")] = { status: "running", startedAt: "2026-06-03T08:00:00Z" };
+  const cur = deriveCurrentPhase(s);
+  expect(cur.phase).toBe("research");
+  expect(cur.status).toBe("running");
+});
+
+// ── FAILED / STALLED SURFACE AT THEIR OWN PHASE ────────────────────────────
+test("failed mid-pipeline phase surfaces at that phase (not done)", () => {
+  const s = sigs();
+  s[idx("triage")] = { status: "done" };
+  s[idx("implement")] = { status: "failed", startedAt: "2026-06-03T08:00:00Z" };
+  const cur = deriveCurrentPhase(s);
+  expect(cur.phase).toBe("implement");
+  expect(cur.status).toBe("failed");
+});
+
+test("stalled phase surfaces at that phase", () => {
+  const s = sigs();
+  s[idx("verify")] = { status: "stalled" };
+  expect(deriveCurrentPhase(s)).toMatchObject({ phase: "verify", status: "stalled" });
+});
+
+// ── DEGENERATE: NO SIGNALS AT ALL ──────────────────────────────────────────
+test("no phase signal files at all → first column, never Done", () => {
+  const cur = deriveCurrentPhase(sigs());
+  expect(cur.phase).toBe(PHASE_ORDER[0]); // "triage" → maps to Research, not Done
+  expect(cur.status).not.toBe("done");
+});
+
+// ── METADATA PASSED THROUGH ────────────────────────────────────────────────
+test("carries model/startedAt/updatedAt from the surfaced phase", () => {
+  const s = sigs();
+  s[idx("verify")] = { status: "done", model: "opus", startedAt: "2026-06-03T08:00:00Z", updatedAt: "2026-06-03T08:05:00Z" };
+  const cur = deriveCurrentPhase(s);
+  expect(cur.model).toBe("opus");
+  expect(cur.startedAt).toBe("2026-06-03T08:00:00Z");
+  expect(cur.updatedAt).toBe("2026-06-03T08:05:00Z");
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -33,6 +33,14 @@ export interface BoardPhaseTiming {
   durationMs: number | null;
 }
 
+export interface BoardCurrentPhase {
+  phase: string;
+  status: string;
+  model: string | null;
+  startedAt?: string;
+  updatedAt?: string;
+}
+
 export interface BoardTicket {
   id: string;
   title: string;
@@ -96,4 +104,5 @@ export const PHASE_ORDER: string[];
 export const PHASE_TO_LINEAR: Record<string, string>;
 export const TERMINAL: Set<string>;
 export function buildPhaseSummary(phaseSigs: unknown[], now: number): BoardPhaseTiming[];
+export function deriveCurrentPhase(phaseSigs: unknown[]): BoardCurrentPhase;
 export function assembleBoard(): Promise<BoardPayload>;

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -141,8 +141,10 @@ async function deriveActiveState(ticket, phase, ageMs) {
 
 // ── derive a ticket's current phase + status from its signal files ──────────
 // Takes the pre-read phase signals (PHASE_ORDER-aligned) to avoid re-reading.
-function deriveCurrentPhase(phaseSigs) {
+// Exported (like buildPhaseSummary) so it is unit-testable (CTL-745).
+export function deriveCurrentPhase(phaseSigs) {
   let lastTerminal = null;
+  let lastTerminalIndex = -1;
   for (let i = 0; i < PHASE_ORDER.length; i++) {
     const sig = phaseSigs[i];
     if (!sig) continue;
@@ -152,11 +154,24 @@ function deriveCurrentPhase(phaseSigs) {
       return { phase, status, model: sig.model || null, startedAt: sig.startedAt, updatedAt: sig.updatedAt };
     }
     lastTerminal = { phase, status, model: sig.model || null, startedAt: sig.startedAt, updatedAt: sig.updatedAt };
+    lastTerminalIndex = i;
   }
-  // all phases terminal → if the last one failed/stalled surface that, else done
-  if (lastTerminal && (lastTerminal.status === "failed" || lastTerminal.status === "stalled"))
-    return lastTerminal;
-  return { phase: "done", status: "done", model: lastTerminal?.model || null };
+  // No phase has written a signal file yet → pre-pipeline. Surface the first
+  // column (Research), never Done (CTL-745).
+  if (!lastTerminal) return { phase: PHASE_ORDER[0], status: "unknown", model: null };
+  // A failed/stalled phase always surfaces at its own column, wherever it sits.
+  if (lastTerminal.status === "failed" || lastTerminal.status === "stalled") return lastTerminal;
+  // CTL-745: the pipeline is genuinely "done" ONLY when its FINAL phase
+  // (monitor-deploy) has reached a terminal status. The loop skips absent signal
+  // files (`if (!sig) continue`), so reaching the end with a terminal mid-pipeline
+  // phase (e.g. verify.done) does NOT mean the pipeline finished — the next
+  // phase's signal file simply hasn't been written yet. Synthesizing "done" here
+  // jumped the card to the Done column while the ticket was still at Validate.
+  // Surface the real last phase instead so the column matches true progress.
+  if (lastTerminalIndex === PHASE_ORDER.length - 1) {
+    return { phase: "done", status: "done", model: lastTerminal.model };
+  }
+  return lastTerminal;
 }
 
 // CTL-754: per-phase timing for the board progression strip. Pure + exported so


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-03T09:15:00Z -->
<!-- Last updated: 2026-06-03T09:15:00Z -->
<!-- PR: #1287 -->
<!-- Previous commits: 709ee1e821e22bcb1cab29f8cd521bc957d81189 -->

## Summary

Fixes a board display bug where the Catalyst monitor **Tickets** view incorrectly showed tickets in the **Done** column while they were still mid-pipeline (e.g., at Verify/Validate). The root cause was `deriveCurrentPhase()` synthesizing a `done` result whenever every *present* phase signal was terminal — without checking whether the *final* phase (monitor-deploy) had actually been reached. A ticket at Verify with no downstream signals would jump straight to Done.

The fix gates synthetic done on the final phase (monitor-deploy) having reached a terminal status, and correctly returns the last real phase for any earlier stopping point. Also fixes the all-absent (no signals yet) degenerate case to return the first pipeline column instead of Done.

## Changes Made

### `plugins/dev/scripts/orch-monitor/lib/board-data.mjs`

- **`deriveCurrentPhase()`: gate synthetic done on final phase** — Only synthesize `{ phase: "done" }` when `lastTerminalIndex === PHASE_ORDER.length - 1` (i.e., monitor-deploy is terminal). Previously the loop would exhaust all *present* signals and unconditionally return done, skipping absent downstream files.
- **Fix degenerate case** — When no phase signal files exist at all, return the first pipeline column (`PHASE_ORDER[0]`) with status `"unknown"` instead of `done`.
- **Export `deriveCurrentPhase`** — mirrors `buildPhaseSummary`'s existing export pattern so the function is unit-testable without mocking.
- **Track `lastTerminalIndex`** — new loop variable to know whether the last terminal phase is the final one.

### `plugins/dev/scripts/orch-monitor/__tests__/board-current-phase.test.ts` *(new)*

Behavior table covering the corrected logic:
- **The bug (CTL-745)**: verify done + no downstream signals → stays at verify, NOT synthetic done
- **Mid-pipeline gap**: implement done + verify absent → stays at implement
- **Genuine completion**: final phase (monitor-deploy) terminal → synthetic done
- **Skipped final phase**: monitor-deploy skipped (still terminal) → done
- **Running phase**: returns immediately with real status
- **Failed mid-pipeline**: surfaces at its own phase, not done
- **Stalled phase**: surfaces at that phase
- **No signals at all**: returns first column, never Done
- **Metadata passthrough**: model/startedAt/updatedAt carried from surfaced phase

## How to Verify It

- [x] `bun test plugins/dev/scripts/orch-monitor/__tests__/board-current-phase.test.ts` — all 8 tests pass ✅
- [ ] Open the monitor board while a ticket is at Verify — confirm it shows Verify column, not Done
- [ ] Let a ticket reach monitor-deploy terminal — confirm it shows Done

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-745
