### PR TITLE
CTL-755: admission-control the triage→research promotion (deps + priority + capacity)

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -107,6 +107,52 @@ export function fetchTicketState(identifier, { exec = defaultExec, cache } = {})
   }
 }
 
+// fetchTicketRelations — the CTL-755 admission gate's single-read hydration of
+// one triaged-waiting candidate: its live workflow state, dependency edges,
+// priority, and labels, all parsed from ONE `linearis issues read <id>`. The
+// returned descriptor mirrors normalizeTicket (above) so the same
+// buildDependencyEdges / analyzeDependencyGraph / computeReadySet consume it:
+//   { state, relations, inverseRelations, priority, labels }
+// - state: node.state.name (or a flat string `state`), or null when absent.
+// - relations / inverseRelations: default { nodes: [] } so the graph builder
+//   reads `.nodes` unconditionally. VERIFIED (ADV-1277): the single-ticket read
+//   returns populated relations.nodes (blocks→ADV-1280) and inverseRelations.nodes
+//   (blocks←ADV-1276, i.e. the blocked-by edge the dependency graph reads).
+// - priority: node.priority ?? null (0 "No priority" is preserved, NOT coerced
+//   to null — distinct from normalizeTicket's eligible-set 0 default, because
+//   the admission ranking treats an explicit 0 differently from "unknown").
+// - labels: node.labels.nodes[].name (or []), so STEP A can diff the held
+//   indicator (blocked/waiting) without a second read.
+// Returns null on a non-zero exit or unparseable stdout — the STEP-A caller
+// fails SAFE (treats the candidate as held / non-terminal) just like the D5
+// fetchTicketState contract.
+//
+// CTL-634 cache sharing: the opt-in `cache` is the SAME createTicketStateCache
+// fetchTicketState uses. We populate it with the string `state` only, so a
+// subsequent fetchTicketState(id, { cache }) is a hit. relations/priority/labels
+// are returned UNCACHED (one read per call): the cache stores a single value per
+// key and is string-state-typed, so writing a relations object under the same
+// key would corrupt fetchTicketState's reads. Within a single STEP-A tick this
+// costs nothing — the relations come from the same read that populates state.
+export function fetchTicketRelations(identifier, { exec = defaultExec, cache } = {}) {
+  const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
+  if (code !== 0) return null; // fail-safe — not cached
+  try {
+    const node = JSON.parse(stdout);
+    const state = node?.state?.name ?? node?.state ?? null;
+    if (cache && state != null) cache.set(identifier, state); // share with fetchTicketState
+    return {
+      state,
+      relations: node?.relations ?? { nodes: [] },
+      inverseRelations: node?.inverseRelations ?? { nodes: [] },
+      priority: typeof node?.priority === "number" ? node.priority : null,
+      labels: node?.labels?.nodes?.map((n) => n.name) ?? [],
+    };
+  } catch {
+    return null; // unparseable — not cached
+  }
+}
+
 // fetchTicketLabels — current label-name list for one ticket, or null on any
 // failure. CTL-587: used by linear-write.mjs::applyLabel for the
 // verify-write-landed step that closes the silent-success gap in linearis

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -118,9 +118,12 @@ export function fetchTicketState(identifier, { exec = defaultExec, cache } = {})
 //   reads `.nodes` unconditionally. VERIFIED (ADV-1277): the single-ticket read
 //   returns populated relations.nodes (blocks→ADV-1280) and inverseRelations.nodes
 //   (blocks←ADV-1276, i.e. the blocked-by edge the dependency graph reads).
-// - priority: node.priority ?? null (0 "No priority" is preserved, NOT coerced
-//   to null — distinct from normalizeTicket's eligible-set 0 default, because
-//   the admission ranking treats an explicit 0 differently from "unknown").
+// - priority: node.priority when numeric, else null. An explicit 0 ("No priority")
+//   is kept as 0 (fidelity to the source), NOT coerced to null. Note 0 and null
+//   rank IDENTICALLY — scheduler-rank.priorityRank floors any non-1..4 value to
+//   band 5 — so this distinction does not affect selection; it only differs from
+//   normalizeTicket's eligible-set default (missing → 0) by recording a missing
+//   priority as "unknown" (null) rather than "lowest" (0).
 // - labels: node.labels.nodes[].name (or []), so STEP A can diff the held
 //   indicator (blocked/waiting) without a second read.
 // Returns null on a non-zero exit or unparseable stdout — the STEP-A caller

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -7,6 +7,7 @@ import {
   runEligibleQuery,
   fetchTicketState,
   fetchTicketLabels,
+  fetchTicketRelations,
 } from "./linear-query.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 
@@ -310,5 +311,153 @@ describe("fetchTicketState — cache (CTL-634)", () => {
     fetchTicketState("CTL-1", { exec });
     fetchTicketState("CTL-1", { exec });
     expect(calls).toBe(2);
+  });
+});
+
+// CTL-755 — fetchTicketRelations is the admission gate's single-read hydration
+// of a triaged-waiting candidate: state + relations + inverseRelations +
+// priority + labels in one `linearis issues read <id>`. The descriptor it
+// returns mirrors normalizeTicket so buildDependencyEdges / computeReadySet
+// consume it unchanged. VERIFIED payload (ADV-1277): relations.nodes carry a
+// `blocks` edge, inverseRelations.nodes carry a `blocks` edge from the blocker,
+// priority is a number, labels.nodes[].name carries the label list.
+describe("fetchTicketRelations (CTL-755)", () => {
+  // The verified ADV-1277 shape: a blocks→ADV-1280 relation, an inverse
+  // blocks←ADV-1276 (i.e. ADV-1276 blocks this ticket → a blocked-by edge),
+  // priority 2, plus labels.
+  function adv1277Json() {
+    return JSON.stringify({
+      identifier: "ADV-1277",
+      state: { name: "Triage" },
+      priority: 2,
+      relations: {
+        nodes: [{ type: "blocks", relatedIssue: { identifier: "ADV-1280" } }],
+      },
+      inverseRelations: {
+        nodes: [{ type: "blocks", issue: { identifier: "ADV-1276" } }],
+      },
+      labels: { nodes: [{ name: "feature" }, { name: "orchestrator" }] },
+    });
+  }
+
+  test("runs `linearis issues read <id>` and returns the full descriptor", () => {
+    const calls = [];
+    const exec = (cmd, args) => {
+      calls.push({ cmd, args });
+      return { code: 0, stdout: adv1277Json(), stderr: "" };
+    };
+    const rel = fetchTicketRelations("ADV-1277", { exec });
+    expect(calls[0].cmd).toBe("linearis");
+    expect(calls[0].args).toEqual(["issues", "read", "ADV-1277"]);
+    expect(rel).toEqual({
+      state: "Triage",
+      relations: { nodes: [{ type: "blocks", relatedIssue: { identifier: "ADV-1280" } }] },
+      inverseRelations: { nodes: [{ type: "blocks", issue: { identifier: "ADV-1276" } }] },
+      priority: 2,
+      labels: ["feature", "orchestrator"],
+    });
+  });
+
+  test("parses a blocked-by edge out of inverseRelations.nodes", () => {
+    const exec = () => ({ code: 0, stdout: adv1277Json(), stderr: "" });
+    const rel = fetchTicketRelations("ADV-1277", { exec });
+    // The inverse `blocks` edge means ADV-1276 blocks ADV-1277 — the blocked-by
+    // relationship the dependency graph reads from inverseRelations.
+    expect(rel.inverseRelations.nodes).toHaveLength(1);
+    expect(rel.inverseRelations.nodes[0].type).toBe("blocks");
+    expect(rel.inverseRelations.nodes[0].issue.identifier).toBe("ADV-1276");
+  });
+
+  test("defaults relations / inverseRelations to { nodes: [] } when absent", () => {
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({ identifier: "CTL-9", state: { name: "Triage" } }),
+      stderr: "",
+    });
+    const rel = fetchTicketRelations("CTL-9", { exec });
+    expect(rel.relations).toEqual({ nodes: [] });
+    expect(rel.inverseRelations).toEqual({ nodes: [] });
+  });
+
+  test("defaults priority to null and labels to [] when absent", () => {
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({ identifier: "CTL-9", state: { name: "Triage" } }),
+      stderr: "",
+    });
+    const rel = fetchTicketRelations("CTL-9", { exec });
+    expect(rel.priority).toBeNull();
+    expect(rel.labels).toEqual([]);
+  });
+
+  test("priority 0 (No priority) is preserved, not coerced to null", () => {
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({ identifier: "CTL-9", state: { name: "Triage" }, priority: 0 }),
+      stderr: "",
+    });
+    expect(fetchTicketRelations("CTL-9", { exec }).priority).toBe(0);
+  });
+
+  test("accepts a flat string `state` field too", () => {
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({ identifier: "CTL-9", state: "Done" }),
+      stderr: "",
+    });
+    expect(fetchTicketRelations("CTL-9", { exec }).state).toBe("Done");
+  });
+
+  test("returns null on a non-zero linearis exit (caller fails safe → held)", () => {
+    const exec = () => ({ code: 1, stdout: "", stderr: "not found" });
+    expect(fetchTicketRelations("CTL-9", { exec })).toBeNull();
+  });
+
+  test("returns null on unparseable stdout", () => {
+    const exec = () => ({ code: 0, stdout: "not json at all", stderr: "" });
+    expect(fetchTicketRelations("CTL-9", { exec })).toBeNull();
+  });
+
+  // The shared cache contract: fetchTicketRelations populates the SAME state
+  // cache fetchTicketState reads (string state keyed by identifier), so a
+  // subsequent fetchTicketState hits it without a second read. Relations /
+  // priority / labels are returned uncached (one read per call) — caching them
+  // under the same key would corrupt fetchTicketState's string-typed reads.
+  describe("shared state cache", () => {
+    test("populates the shared cache so fetchTicketState serves a hit (no second exec)", () => {
+      const cache = createTicketStateCache({ now: () => 0 });
+      let calls = 0;
+      const exec = () => {
+        calls += 1;
+        return { code: 0, stdout: JSON.stringify({ state: { name: "Done" } }), stderr: "" };
+      };
+      expect(fetchTicketRelations("CTL-1", { exec, cache }).state).toBe("Done");
+      // fetchTicketState now reads the state populated by fetchTicketRelations.
+      expect(fetchTicketState("CTL-1", { exec, cache })).toBe("Done");
+      expect(calls).toBe(1); // second read was a cache hit on the shared state
+    });
+
+    test("does NOT cache a failed read (null) — re-execs next call (fail-safe)", () => {
+      const cache = createTicketStateCache({ now: () => 0 });
+      let calls = 0;
+      const exec = () => {
+        calls += 1;
+        return { code: 1, stdout: "", stderr: "boom" };
+      };
+      expect(fetchTicketRelations("CTL-1", { exec, cache })).toBeNull();
+      expect(fetchTicketRelations("CTL-1", { exec, cache })).toBeNull();
+      expect(calls).toBe(2); // null never cached → both calls hit exec
+    });
+
+    test("without a cache, every call execs (relations are always read fresh)", () => {
+      let calls = 0;
+      const exec = () => {
+        calls += 1;
+        return { code: 0, stdout: JSON.stringify({ state: { name: "Triage" } }), stderr: "" };
+      };
+      fetchTicketRelations("CTL-1", { exec });
+      fetchTicketRelations("CTL-1", { exec });
+      expect(calls).toBe(2);
+    });
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -608,6 +608,32 @@ export function defaultAppendResumedAfterPreemptionEvent({ orchId, ticket, phase
   );
 }
 
+// CTL-755: triage→research admission-hold event — phase.advance.held.<ticket>.
+// Emitted by the scheduler's STEP-A admission gate when a triage-complete ticket
+// is NOT promoted to research this tick. `reason` distinguishes the two hold
+// classes:
+//   "blocked-by-open-dependency"     — ≥1 blocked_by dependency is non-terminal
+//                                       (the candidate is not in readyIds).
+//   "awaiting-capacity-or-priority"  — deps satisfied (in readyIds) but the
+//                                       candidate lost the priority/capacity
+//                                       selection this tick.
+// `blockers` carries the unmet blocker identifiers (empty for the capacity case).
+// Best-effort, never throws — mirrors defaultAppendDispatchRequestedEvent. The
+// scheduler emits it only-on-state-change to bound log volume.
+export function defaultAppendPhaseAdvanceHeldEvent({ orchId, ticket, reason, blockers }) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase: "advance",
+      ticket,
+      orchId,
+      action: "held",
+      reason,
+      payloadExtras: { blockers: blockers ?? [] },
+    }),
+    "advance-held",
+  );
+}
+
 // CTL-713: cooldown GC event — phase.scheduler.cooldown-gc.<ticket>.
 // Emitted once per reaped cooldown marker so GC activity is queryable from the
 // unified event log.

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -1186,6 +1186,11 @@ function defaultWriteProgressMark(orchDir, ticket, phase, value) {
 //                         flipped the signal, session ended.
 //   'reclaim-failed'      reclaim-eligible + work IS done BUT emit-complete exited
 //                         non-zero. Signal NOT mutated (atomic rename); retries.
+//   'reclaim-held'        CTL-755 — a dead `triage` worker whose work IS done but
+//                         whose ticket is NOT admitted by the gate (deps/priority/
+//                         capacity). Non-mutating: triage.json preserved, signal
+//                         NOT flipped, no reap-intent, no emitComplete. Next tick's
+//                         STEP A re-evaluates. ONLY `phase === "triage"`.
 //   'revived'             reclaim-eligible + probe says work NOT done + progress
 //                         ADVANCED since the last attempt. Signal reset to
 //                         'stalled', defaultDispatch invoked (bumps the fencing
@@ -1298,6 +1303,17 @@ export function reclaimDeadWorkIfPossible(
     // never treated as a human-intervention condition (and never adds to the
     // write storm). Injected for tests; defaults to the shared singleton.
     breaker = linearBreaker,
+    // CTL-755 STEP D — admission predicate for a dead-but-work-done `triage`
+    // worker. The reclaim sweep runs ABOVE the schedulerTick admission compute
+    // (it cannot see `admittedThisTick`), so the default is hold-safe: never
+    // bypass the gate. A dead triage worker whose work IS done is only reclaimed
+    // (branch B → emitComplete flips the signal to research-owed) when the
+    // ticket has been ADMITTED; otherwise it stays at triage:done with its
+    // signal un-flipped so next tick's STEP A re-evaluates deps/priority/
+    // capacity. Mid-pipeline reclaims are NEVER gated (they hold a live slot and
+    // must complete). Production wires the real predicate; with the default
+    // false a triage reclaim always holds.
+    isAdmitted = () => false,
     now = Date.now,
   } = {},
 ) {
@@ -1459,6 +1475,19 @@ export function reclaimDeadWorkIfPossible(
   //     can locate their artifact; implementProbe ignores the extra key.
   const probe = probes[phase];
   if (probe({ ticket, repoRoot, orchDir })) {
+    // CTL-755 STEP D — admission gate for a dead-but-work-done `triage` worker.
+    // Reclaiming a triage worker via emitComplete flips its signal to
+    // research-owed, which the advancement sweep would then free-promote —
+    // bypassing the admission gate (deps/priority/capacity) the live promotion
+    // path enforces. Hold instead: leave triage.json on disk and the signal
+    // UN-flipped (return BEFORE the reap-intent / appendEvent / emitComplete so
+    // nothing mutates), so next tick's STEP A re-evaluates the gate for this
+    // ticket. Only `triage` is gated — a mid-pipeline dead worker holds a live
+    // slot and must be reclaimed to free it.
+    if (phase === "triage" && !isAdmitted({ ticket })) {
+      log.debug({ ticket, phase }, "reclaim-dead-work: triage held by admission gate (un-admitted)");
+      return "reclaim-held";
+    }
     // CTL-661 hole #3: a worker reaching branch (B) is reclaim-eligible, so it
     // is either `absent` (nothing live to stop) or `idle`-confirmed (between
     // turns → safe to stop). Emit a fire-and-forget reap-intent BEFORE

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -1186,11 +1186,6 @@ function defaultWriteProgressMark(orchDir, ticket, phase, value) {
 //                         flipped the signal, session ended.
 //   'reclaim-failed'      reclaim-eligible + work IS done BUT emit-complete exited
 //                         non-zero. Signal NOT mutated (atomic rename); retries.
-//   'reclaim-held'        CTL-755 — a dead `triage` worker whose work IS done but
-//                         whose ticket is NOT admitted by the gate (deps/priority/
-//                         capacity). Non-mutating: triage.json preserved, signal
-//                         NOT flipped, no reap-intent, no emitComplete. Next tick's
-//                         STEP A re-evaluates. ONLY `phase === "triage"`.
 //   'revived'             reclaim-eligible + probe says work NOT done + progress
 //                         ADVANCED since the last attempt. Signal reset to
 //                         'stalled', defaultDispatch invoked (bumps the fencing
@@ -1303,17 +1298,6 @@ export function reclaimDeadWorkIfPossible(
     // never treated as a human-intervention condition (and never adds to the
     // write storm). Injected for tests; defaults to the shared singleton.
     breaker = linearBreaker,
-    // CTL-755 STEP D — admission predicate for a dead-but-work-done `triage`
-    // worker. The reclaim sweep runs ABOVE the schedulerTick admission compute
-    // (it cannot see `admittedThisTick`), so the default is hold-safe: never
-    // bypass the gate. A dead triage worker whose work IS done is only reclaimed
-    // (branch B → emitComplete flips the signal to research-owed) when the
-    // ticket has been ADMITTED; otherwise it stays at triage:done with its
-    // signal un-flipped so next tick's STEP A re-evaluates deps/priority/
-    // capacity. Mid-pipeline reclaims are NEVER gated (they hold a live slot and
-    // must complete). Production wires the real predicate; with the default
-    // false a triage reclaim always holds.
-    isAdmitted = () => false,
     now = Date.now,
   } = {},
 ) {
@@ -1475,19 +1459,21 @@ export function reclaimDeadWorkIfPossible(
   //     can locate their artifact; implementProbe ignores the extra key.
   const probe = probes[phase];
   if (probe({ ticket, repoRoot, orchDir })) {
-    // CTL-755 STEP D — admission gate for a dead-but-work-done `triage` worker.
-    // Reclaiming a triage worker via emitComplete flips its signal to
-    // research-owed, which the advancement sweep would then free-promote —
-    // bypassing the admission gate (deps/priority/capacity) the live promotion
-    // path enforces. Hold instead: leave triage.json on disk and the signal
-    // UN-flipped (return BEFORE the reap-intent / appendEvent / emitComplete so
-    // nothing mutates), so next tick's STEP A re-evaluates the gate for this
-    // ticket. Only `triage` is gated — a mid-pipeline dead worker holds a live
-    // slot and must be reclaimed to free it.
-    if (phase === "triage" && !isAdmitted({ ticket })) {
-      log.debug({ ticket, phase }, "reclaim-dead-work: triage held by admission gate (un-admitted)");
-      return "reclaim-held";
-    }
+    // CTL-755 STEP D (CORRECTED): a dead-but-work-done `triage` worker is
+    // reclaimed normally — emitComplete flips its signal to `triage:done`. This
+    // does NOT bypass the admission gate: the gate lives DOWNSTREAM at the
+    // scheduler's STEP-B advancement guard (scheduler.mjs:2096), which holds the
+    // triage→research promotion for ANY `triage:done` worker not in
+    // `admittedThisTick` — regardless of HOW the signal reached `done` (live
+    // complete, reclaim, or post-boot). The earlier non-mutating `reclaim-held`
+    // outcome STRANDED such a worker: a dead triage worker only reaches branch B
+    // with a NON-terminal signal (a `done` signal short-circuits to `noop` at the
+    // `klass === "terminal"` gate above), so holding it left the signal at
+    // `running`, and STEP A's `s.triage === "done"` pool requirement then skipped
+    // it forever. Flipping to `done` lands it exactly where STEP A expects it, so
+    // the gate re-evaluates deps/priority/capacity next tick (and STEP B holds the
+    // research dispatch until admitted). No phase is special-cased here.
+    //
     // CTL-661 hole #3: a worker reaching branch (B) is reclaim-eligible, so it
     // is either `absent` (nothing live to stop) or `idle`-confirmed (between
     // turns → safe to stop). Emit a fire-and-forget reap-intent BEFORE

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -3072,16 +3072,25 @@ describe("reclaimDeadWorkIfPossible — needs-input guard (CTL-549)", () => {
   });
 });
 
-// CTL-755 STEP D — reclaim hold-safe. A dead-but-work-done `triage` worker must
-// NOT be reclaimed (which would flip its signal to research-owed and bypass the
-// admission gate) unless the ticket has been admitted. The reclaim sweep cannot
-// see `admittedThisTick`, so isAdmitted defaults to () => false (hold-safe).
-// Only `triage` is gated — a mid-pipeline dead worker holds a live slot and must
-// be reclaimed.
-describe("reclaimDeadWorkIfPossible — CTL-755 reclaim-held (admission gate)", () => {
+// CTL-755 STEP D (CORRECTED) — a dead-but-work-done `triage` worker is reclaimed
+// NORMALLY (emitComplete flips its signal to `triage:done`), exactly like any
+// other phase. The admission gate is NOT enforced inside reclaim — it lives
+// DOWNSTREAM at the scheduler's STEP-B advancement guard, which holds the
+// triage→research promotion for any `triage:done` worker not in
+// `admittedThisTick`. The earlier `reclaim-held` non-mutating outcome was a bug:
+// a dead triage worker only reaches branch B with a NON-terminal signal (a `done`
+// signal short-circuits to `noop` at the terminal gate), so holding it left the
+// signal at `running` and the scheduler's STEP-A triaged-waiting pool (which keys
+// on `triage === "done"`) skipped it FOREVER — the ticket stranded. Flipping the
+// signal to `done` lands it exactly where STEP A expects, so the gate
+// re-evaluates next tick (see scheduler.test.mjs "STEP D integration").
+describe("reclaimDeadWorkIfPossible — CTL-755 dead-triage reclaim (gate is downstream)", () => {
   const orch = "/orch";
 
-  // A dead (job dir gone) triage signal whose triage probe passes (work done).
+  // A dead (job dir gone) triage signal whose triage probe passes (work done) but
+  // whose status never reached `done` (it died mid-flight as `running`). This is
+  // the exact class the reclaim branch-B path recovers — and the class the old
+  // `reclaim-held` early-return stranded.
   function triageSignal({ ticket = "CTL-7" } = {}) {
     return {
       ticket,
@@ -3099,78 +3108,55 @@ describe("reclaimDeadWorkIfPossible — CTL-755 reclaim-held (admission gate)", 
     };
   }
 
-  test("dead triage + work done + un-admitted (default isAdmitted=false) → 'reclaim-held', NO emit, NO append, NO reap", () => {
+  test("dead triage + work done → 'reclaimed', emit FIRES (signal flips to done; the gate is enforced downstream in the scheduler, not here)", () => {
     const probe = recorder(true); // triage.json present → work done
     const emit = recorder({ code: 0 });
     const appendEvent = recorder(undefined);
-    const emitReapIntent = recorder(Promise.resolve());
-    const postReclaimMirror = recorder(undefined);
     const r = reclaimDeadWorkIfPossible(orch, triageSignal(), {
       statJob: () => null, // dead-gone → reclaim-eligible
       probes: { triage: probe },
       emitComplete: emit,
       appendEvent,
-      emitReapIntent,
-      postReclaimMirror,
-      // isAdmitted omitted → defaults to () => false (hold-safe).
-      now: () => 1_000,
-    });
-    expect(r).toBe("reclaim-held");
-    expect(probe.calls.length).toBe(1); // branch B was entered (probe ran)
-    // Non-mutating: the guard returns BEFORE emit / append / reap.
-    expect(emit.calls.length).toBe(0);
-    expect(appendEvent.calls.length).toBe(0);
-    expect(emitReapIntent.calls.length).toBe(0);
-    expect(postReclaimMirror.calls.length).toBe(0);
-  });
-
-  test("dead triage + work done + ADMITTED (isAdmitted=()=>true) → 'reclaimed', emit fires (branch B proceeds)", () => {
-    const probe = recorder(true);
-    const emit = recorder({ code: 0 });
-    const appendEvent = recorder(undefined);
-    const r = reclaimDeadWorkIfPossible(orch, triageSignal(), {
-      statJob: () => null,
-      probes: { triage: probe },
-      emitComplete: emit,
-      appendEvent,
       postReclaimMirror: () => {}, // keep hermetic
-      isAdmitted: () => true,
       now: () => 1_000,
     });
     expect(r).toBe("reclaimed");
+    expect(probe.calls.length).toBe(1); // branch B was entered (probe ran)
+    // The reclaim flips the signal to done so the scheduler's STEP A picks it up —
+    // STEP B then holds the triage→research promotion until the ticket is admitted.
     expect(emit.calls.length).toBe(1);
     expect(appendEvent.calls.length).toBe(1);
   });
 
-  test("isAdmitted receives the ticket so the predicate can decide per-ticket", () => {
-    const seen = [];
-    reclaimDeadWorkIfPossible(orch, triageSignal({ ticket: "CTL-42" }), {
+  test("triage reclaim emits the reap-intent for the dead bg job (no longer suppressed by a hold)", () => {
+    const emitReapIntent = recorder(Promise.resolve());
+    reclaimDeadWorkIfPossible(orch, triageSignal(), {
       statJob: () => null,
       probes: { triage: recorder(true) },
       emitComplete: recorder({ code: 0 }),
       appendEvent: recorder(undefined),
-      isAdmitted: (arg) => { seen.push(arg); return false; },
+      emitReapIntent,
+      postReclaimMirror: () => {},
       now: () => 1_000,
     });
-    expect(seen).toEqual([{ ticket: "CTL-42" }]);
+    // The dead worker's lingering session is reaped (the old `reclaim-held`
+    // non-mutating return skipped this, leaking the bg session).
+    expect(emitReapIntent.calls.length).toBe(1);
   });
 
-  test("a NON-triage dead worker (implement) with work done still reclaims (branch B), gate not applied", () => {
+  test("a NON-triage dead worker (implement) with work done reclaims identically (no phase special-casing)", () => {
     const probe = recorder(true);
     const emit = recorder({ code: 0 });
     const appendEvent = recorder(undefined);
-    const isAdmitted = recorder(false); // would HOLD if consulted — must NOT be
     const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
       statJob: () => null,
       probes: { implement: probe },
       emitComplete: emit,
       appendEvent,
       postReclaimMirror: () => {},
-      isAdmitted,
       now: () => 1_000,
     });
     expect(r).toBe("reclaimed");
     expect(emit.calls.length).toBe(1); // mid-pipeline reclaim proceeds
-    expect(isAdmitted.calls.length).toBe(0); // gate only consulted for triage
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -3071,3 +3071,106 @@ describe("reclaimDeadWorkIfPossible — needs-input guard (CTL-549)", () => {
     expect(dispatched).toHaveLength(0);
   });
 });
+
+// CTL-755 STEP D — reclaim hold-safe. A dead-but-work-done `triage` worker must
+// NOT be reclaimed (which would flip its signal to research-owed and bypass the
+// admission gate) unless the ticket has been admitted. The reclaim sweep cannot
+// see `admittedThisTick`, so isAdmitted defaults to () => false (hold-safe).
+// Only `triage` is gated — a mid-pipeline dead worker holds a live slot and must
+// be reclaimed.
+describe("reclaimDeadWorkIfPossible — CTL-755 reclaim-held (admission gate)", () => {
+  const orch = "/orch";
+
+  // A dead (job dir gone) triage signal whose triage probe passes (work done).
+  function triageSignal({ ticket = "CTL-7" } = {}) {
+    return {
+      ticket,
+      phase: "triage",
+      status: "running",
+      liveness: { kind: "bg", value: "job-x" },
+      signalPath: `/x/${ticket}/phase-triage.json`,
+      raw: {
+        ticket,
+        phase: "triage",
+        orchestrator: ticket,
+        status: "running",
+        bg_job_id: "job-x",
+      },
+    };
+  }
+
+  test("dead triage + work done + un-admitted (default isAdmitted=false) → 'reclaim-held', NO emit, NO append, NO reap", () => {
+    const probe = recorder(true); // triage.json present → work done
+    const emit = recorder({ code: 0 });
+    const appendEvent = recorder(undefined);
+    const emitReapIntent = recorder(Promise.resolve());
+    const postReclaimMirror = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, triageSignal(), {
+      statJob: () => null, // dead-gone → reclaim-eligible
+      probes: { triage: probe },
+      emitComplete: emit,
+      appendEvent,
+      emitReapIntent,
+      postReclaimMirror,
+      // isAdmitted omitted → defaults to () => false (hold-safe).
+      now: () => 1_000,
+    });
+    expect(r).toBe("reclaim-held");
+    expect(probe.calls.length).toBe(1); // branch B was entered (probe ran)
+    // Non-mutating: the guard returns BEFORE emit / append / reap.
+    expect(emit.calls.length).toBe(0);
+    expect(appendEvent.calls.length).toBe(0);
+    expect(emitReapIntent.calls.length).toBe(0);
+    expect(postReclaimMirror.calls.length).toBe(0);
+  });
+
+  test("dead triage + work done + ADMITTED (isAdmitted=()=>true) → 'reclaimed', emit fires (branch B proceeds)", () => {
+    const probe = recorder(true);
+    const emit = recorder({ code: 0 });
+    const appendEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, triageSignal(), {
+      statJob: () => null,
+      probes: { triage: probe },
+      emitComplete: emit,
+      appendEvent,
+      postReclaimMirror: () => {}, // keep hermetic
+      isAdmitted: () => true,
+      now: () => 1_000,
+    });
+    expect(r).toBe("reclaimed");
+    expect(emit.calls.length).toBe(1);
+    expect(appendEvent.calls.length).toBe(1);
+  });
+
+  test("isAdmitted receives the ticket so the predicate can decide per-ticket", () => {
+    const seen = [];
+    reclaimDeadWorkIfPossible(orch, triageSignal({ ticket: "CTL-42" }), {
+      statJob: () => null,
+      probes: { triage: recorder(true) },
+      emitComplete: recorder({ code: 0 }),
+      appendEvent: recorder(undefined),
+      isAdmitted: (arg) => { seen.push(arg); return false; },
+      now: () => 1_000,
+    });
+    expect(seen).toEqual([{ ticket: "CTL-42" }]);
+  });
+
+  test("a NON-triage dead worker (implement) with work done still reclaims (branch B), gate not applied", () => {
+    const probe = recorder(true);
+    const emit = recorder({ code: 0 });
+    const appendEvent = recorder(undefined);
+    const isAdmitted = recorder(false); // would HOLD if consulted — must NOT be
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
+      statJob: () => null,
+      probes: { implement: probe },
+      emitComplete: emit,
+      appendEvent,
+      postReclaimMirror: () => {},
+      isAdmitted,
+      now: () => 1_000,
+    });
+    expect(r).toBe("reclaimed");
+    expect(emit.calls.length).toBe(1); // mid-pipeline reclaim proceeds
+    expect(isAdmitted.calls.length).toBe(0); // gate only consulted for triage
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1662,14 +1662,6 @@ export function schedulerTick(
           // (rather than silently invisible in `default`).
           noProgressStopped.push(entry);
           break;
-        case "reclaim-held":
-          // CTL-755 STEP D: a dead-but-work-done `triage` worker held by the
-          // admission gate (un-admitted). Non-mutating — triage.json + signal are
-          // untouched, so next tick's STEP A re-evaluates the gate. Invisible by
-          // design (it is a steady-state hold, not a failure), bucketed like
-          // reclaim-failed; no log line so a long-held blocked ticket does not
-          // re-emit per-tick reclaim noise.
-          break;
         default:
           // noop | reclaim-failed → invisible.
           // CTL-606: superseded-noop also buckets here — a dead predecessor signal

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -165,6 +165,44 @@ function readTriageEstimate(orchDir, ticket) {
   }
 }
 
+// CTL-755 STEP E — a TEAM-NNN identifier (the shape phase-triage scrapes from
+// the ticket body). Used to drop prose-only tokens before resolving a dependency
+// against Linear. Mirrors the skill's scrape regex (phase-triage/SKILL.md:167).
+const TICKET_REF_RE = /^[A-Z][A-Z0-9_]*-[0-9]+$/;
+
+// readTriageDependencies — read workers/<T>/triage.json `.dependencies` and
+// return the candidate dependency IDENTIFIERS (TEAM-NNN strings) the scheduler
+// should validate + persist as durable blocked_by edges. The skill stays
+// read-only (CTL-497/CTL-558): it scrapes the ids; the scheduler resolves +
+// writes. Tolerant of BOTH shapes so a future skill enrichment is forward-
+// compatible without a scheduler change:
+//   - flat strings:        ["CTL-100", "PROSE-1"]            (current skill)
+//   - rich descriptors:    [{ id: "CTL-100", exists: true }] (richer shape)
+// Tokens that are not a valid TEAM-NNN identifier, the candidate itself
+// (self-ref), or empty are dropped here; the per-blocker Linear-state validation
+// (resolvable + non-terminal) + cycle-check happen at the STEP-E call site.
+// Returns a de-duplicated array; never throws.
+function readTriageDependencies(orchDir, ticket) {
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(join(orchDir, "workers", ticket, "triage.json"), "utf8"));
+  } catch {
+    return [];
+  }
+  const deps = Array.isArray(raw?.dependencies) ? raw.dependencies : [];
+  const out = [];
+  const seen = new Set();
+  for (const d of deps) {
+    const id = typeof d === "string" ? d : typeof d?.id === "string" ? d.id : null;
+    if (!id || !TICKET_REF_RE.test(id)) continue; // prose-only / malformed → drop
+    if (id === ticket) continue; // self-ref → drop
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
 // Missing or unreadable → {priority: 5, createdAt: null} (safe lowest-band
 // default). Never throws.
 export function readWorkerPriority(orchDir, ticket) {
@@ -1624,6 +1662,14 @@ export function schedulerTick(
           // (rather than silently invisible in `default`).
           noProgressStopped.push(entry);
           break;
+        case "reclaim-held":
+          // CTL-755 STEP D: a dead-but-work-done `triage` worker held by the
+          // admission gate (un-admitted). Non-mutating — triage.json + signal are
+          // untouched, so next tick's STEP A re-evaluates the gate. Invisible by
+          // design (it is a steady-state hold, not a failure), bucketed like
+          // reclaim-failed; no log line so a long-held blocked ticket does not
+          // re-emit per-tick reclaim noise.
+          break;
         default:
           // noop | reclaim-failed → invisible.
           // CTL-606: superseded-noop also buckets here — a dead predecessor signal
@@ -1813,6 +1859,78 @@ export function schedulerTick(
         } else {
           // Admitted (or no longer held) → reset so a future re-hold re-emits.
           lastHeldEmitState.delete(ticket);
+        }
+      }
+
+      // (STEP E) CTL-755 dep PERSISTENCE — scheduler-side (CTL-497/CTL-558: the
+      // phase-triage skill stays READ-ONLY; the durable `blocked_by` write lives
+      // here, never in the skill). For each triaged-waiting candidate, read its
+      // triage.json `.dependencies`, VALIDATE each scraped TEAM-NNN token like
+      // the CTL-537 sequencing block (resolve via fetchTicketState — drop
+      // unresolvable / prose-only / self-refs; keep only real NON-TERMINAL
+      // blockers; skip a token that would close a cycle with the candidate), and
+      // for each surviving (candidate, blocker) NOT already in the candidate's
+      // FRESH relations (idempotent — a steady-state tick writes nothing), write
+      // the durable edge via the same applyBlockedByRelation seam CTL-537 uses.
+      // This is what makes the admission gate (STEP A) durable: the next tick's
+      // analyzeDependencyGraph reads the persisted edge from Linear.
+      const descriptorByTicket = new Map(
+        waitingDescriptors.map((d) => [d.identifier, d]),
+      );
+      for (const candidate of triagedWaiting) {
+        // Cycle members are owned by needs-human; do not also write deps for them.
+        if (cycleMembers.has(candidate)) continue;
+        const depIds = readTriageDependencies(orchDir, candidate);
+        if (depIds.length === 0) continue;
+
+        const desc = descriptorByTicket.get(candidate);
+        // Already-durable blocked_by blockers for THIS candidate, read from its
+        // FRESH inverseRelations ({type:"blocks", issue:<blocker>} ⇒ blocker
+        // blocks candidate). The idempotency guard: skip writing an edge we can
+        // already see on Linear.
+        const existingBlockers = new Set();
+        for (const node of desc?.inverseRelations?.nodes ?? []) {
+          if (node?.type === "blocks" && node?.issue?.identifier) {
+            existingBlockers.add(node.issue.identifier);
+          }
+        }
+        // CTL-537 cycle guard (Open-Q4 lightweight form): the candidate's own
+        // OUTGOING `blocks` edges name tickets it already blocks. A new
+        // blocked_by edge naming one of those would close a 2-node cycle, so
+        // skip it. (The broader admission graph's detectCycles already escalated
+        // any in-set cycle to needs-human above; this catches the candidate→dep
+        // back-edge for an out-of-set dep before we persist it.)
+        const candidateBlocks = new Set();
+        for (const node of desc?.relations?.nodes ?? []) {
+          if (node?.type === "blocks" && node?.relatedIssue?.identifier) {
+            candidateBlocks.add(node.relatedIssue.identifier);
+          }
+        }
+
+        for (const dep of depIds) {
+          if (existingBlockers.has(dep)) continue; // idempotent — edge already durable
+          if (candidateBlocks.has(dep)) {
+            // Persisting blocked_by(candidate ← dep) while candidate already
+            // blocks dep would close a cycle. Drop it (do not deadlock).
+            log.warn(
+              { candidate, dep },
+              "ctl-755 step-e: skipping dependency that would close a cycle",
+            );
+            continue;
+          }
+          // Resolve the dep's live Linear state. A null read (404 / unparseable /
+          // prose-only token that is not a real ticket) is dropped — we never
+          // persist an edge to a ticket we cannot resolve. A TERMINAL dep
+          // (Done/Canceled) is a no-op blocker, so do not write a durable edge
+          // for it (it would never hold the gate and only adds Linear noise).
+          const depState = fetchTicketState(dep, { exec, cache });
+          if (depState == null) continue; // unresolvable → drop
+          if (ADMISSION_TERMINAL_STATES.has(depState)) continue; // terminal → no durable edge
+
+          safeWrite(
+            () => writeStatus.applyBlockedByRelation({ ticket: candidate, blockedBy: dep }),
+            { ticket: candidate, phase: "triage-deps" },
+          );
         }
       }
     }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -30,6 +30,7 @@ import {
   analyzeDependencyGraph,
   referencedBlockerIds,
   buildDependencyEdges,
+  DEFAULT_TERMINAL_STATUSES,
 } from "../lib/dependency-graph.mjs";
 // PHASES is still imported for deriveAdvancement; CTL-565 note: PHASES[0]
 // ("triage") is intentionally NO LONGER the new-work entry phase — new work
@@ -1090,9 +1091,10 @@ export const HELD_LABEL_WAITING = "waiting";
 const HELD_LABELS = [HELD_LABEL_BLOCKED, HELD_LABEL_WAITING];
 
 // Terminal Linear states a blocker can be in (a blocker in one of these does NOT
-// hold its dependent). Mirrors lib/dependency-graph.mjs DEFAULT_TERMINAL_STATUSES
-// (not exported there); admissionPool uses the default terminal set.
-const ADMISSION_TERMINAL_STATES = new Set(["Done", "Canceled"]);
+// hold its dependent). Single source of truth: lib/dependency-graph.mjs
+// DEFAULT_TERMINAL_STATUSES (the same set computeReadySet applies to admissionPool),
+// imported so the held-classification + the readiness partition cannot drift apart.
+const ADMISSION_TERMINAL_STATES = new Set(DEFAULT_TERMINAL_STATUSES);
 
 // unmetBlockersFor — the non-terminal blocked_by blocker identifiers for ONE
 // candidate, over the combined admission edge set. An in-set blocker is unmet
@@ -1827,8 +1829,17 @@ export function schedulerTick(
         let blockers = [];
         if (!readyIds.has(ticket)) {
           desired = HELD_LABEL_BLOCKED;
-          reason = "blocked-by-open-dependency";
-          blockers = unmetBlockersFor(ticket, edges, poolById, admissionBlockerStates);
+          if (readFailedTickets.has(ticket)) {
+            // A null relations read forced this ticket out of readyIds (fail-safe
+            // hold). The dependency picture is UNKNOWN, not a confirmed open dep —
+            // emit a distinct reason so the audit log can't conflate a hydration
+            // failure with a genuine zero-or-more open-dependency hold.
+            reason = "dependency-state-unknown";
+            blockers = [];
+          } else {
+            reason = "blocked-by-open-dependency";
+            blockers = unmetBlockersFor(ticket, edges, poolById, admissionBlockerStates);
+          }
         } else if (!admittedThisTick.has(ticket)) {
           desired = HELD_LABEL_WAITING;
           reason = "awaiting-capacity-or-priority";
@@ -2197,7 +2208,11 @@ export function schedulerTick(
   // pull (so a preempted ticket reclaims its slot ahead of brand-new work).
   let resumedCount = 0;
   {
-    let resumeSlots = computeFreeSlots(maxParallel, liveCount);
+    // CTL-755: subtract promotedCount so a triage→research promotion (STEP B, this
+    // tick, before this sweep) and a resume cannot both claim the same free slot.
+    // Symmetric to STEP C's sweep-2 subtraction — the same double-fill class CTL-705
+    // closed for resume-vs-new-work, now also closed for promotion-vs-resume.
+    let resumeSlots = Math.max(0, computeFreeSlots(maxParallel, liveCount) - promotedCount);
     if (resumeSlots > 0) {
       // Collect parked tickets: in-flight tickets with status === PREEMPTED_STATUS.
       const parkedDescriptors = [];

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -26,7 +26,11 @@ import {
 } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join, dirname, basename } from "node:path";
-import { analyzeDependencyGraph, referencedBlockerIds } from "../lib/dependency-graph.mjs";
+import {
+  analyzeDependencyGraph,
+  referencedBlockerIds,
+  buildDependencyEdges,
+} from "../lib/dependency-graph.mjs";
 // PHASES is still imported for deriveAdvancement; CTL-565 note: PHASES[0]
 // ("triage") is intentionally NO LONGER the new-work entry phase — new work
 // enters at NEW_WORK_ENTRY_PHASE ("research"), see schedulerTick.
@@ -56,7 +60,7 @@ import { readVerifyVerdict } from "./work-done-probes.mjs";
 import { countRemediateCycles } from "./event-scan.mjs";
 import { rankTickets, compareTickets } from "./scheduler-rank.mjs";
 import { defaultDispatch, dispatchTicket, teamOf } from "./dispatch.mjs";
-import { fetchTicketState } from "./linear-query.mjs";
+import { fetchTicketState, fetchTicketRelations } from "./linear-query.mjs";
 import { getProjectConfig, listProjects } from "./registry.mjs";
 import { teardownWorktree as defaultTeardownWorktree } from "./worktree.mjs";
 import { readWorkerSignals } from "./signal-reader.mjs";
@@ -83,6 +87,7 @@ import {
   resolvePhaseSessionId as defaultResolveSession,
   defaultAppendCooldownGcEvent,
   defaultAppendCooldownEscalatedEvent,
+  defaultAppendPhaseAdvanceHeldEvent,
 } from "./recovery.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
@@ -1030,6 +1035,75 @@ function safeEmit(fn, arg, ctx) {
 // import block at the top of this file). The shared module also hosts the
 // per-(ticket, phase) escalation cool-down used by the recovery sweep.
 
+// ─── CTL-755: admission-gate held-indicator labels ───
+//
+// A triage-complete ticket held back from the research promotion carries ONE of
+// two dynamic labels so the hold is unmistakable on the orch-monitor board:
+//   • "blocked" — ≥1 blocked_by dependency is non-terminal (not in readyIds).
+//   • "waiting" — deps satisfied (in readyIds) but lost the priority/capacity
+//                 selection this tick.
+// These are converged ON A DIFF against the ticket's CURRENT labels via
+// applyLabel/removeLabel (NOT labelOnce — labelOnce is apply-once-forever,
+// reserved for needs-human/cycle members). A candidate that becomes admitted
+// gets BOTH labels removed (clear-on-pickup). The two label names live here so
+// the diff logic and any board reader share one source of truth.
+export const HELD_LABEL_BLOCKED = "blocked";
+export const HELD_LABEL_WAITING = "waiting";
+const HELD_LABELS = [HELD_LABEL_BLOCKED, HELD_LABEL_WAITING];
+
+// Terminal Linear states a blocker can be in (a blocker in one of these does NOT
+// hold its dependent). Mirrors lib/dependency-graph.mjs DEFAULT_TERMINAL_STATUSES
+// (not exported there); admissionPool uses the default terminal set.
+const ADMISSION_TERMINAL_STATES = new Set(["Done", "Canceled"]);
+
+// unmetBlockersFor — the non-terminal blocked_by blocker identifiers for ONE
+// candidate, over the combined admission edge set. An in-set blocker is unmet
+// unless its descriptor state is terminal; an out-of-set blocker is unmet when
+// its hydrated state (blockerStates) is non-terminal (a failed/absent hydration
+// is the non-terminal UNFETCHED sentinel → unmet, failing safe). Used to fill
+// the phase.advance.held event's `blockers` array. Pure.
+function unmetBlockersFor(candidateId, edges, poolById, blockerStates) {
+  const unmet = [];
+  for (const { from, to } of edges ?? []) {
+    if (to !== candidateId) continue;
+    const inSet = poolById.get(from);
+    if (inSet) {
+      if (!ADMISSION_TERMINAL_STATES.has(inSet?.state?.name)) unmet.push(from);
+    } else if (from in (blockerStates ?? {})) {
+      if (!ADMISSION_TERMINAL_STATES.has(blockerStates[from])) unmet.push(from);
+    }
+    // else: unknown out-of-set blocker, no hydrated state → non-blocking (legacy).
+  }
+  return unmet;
+}
+
+// convergeHeldLabel — apply/remove the held-indicator labels (blocked/waiting)
+// on a DIFF so a steady-state held tick makes ZERO Linear writes (CTL-755
+// ADDENDUM). `current` is the ticket's fresh label set (from fetchRelations);
+// `desired` is one of HELD_LABEL_BLOCKED | HELD_LABEL_WAITING | null. Writes are
+// best-effort via safeWrite — applyLabel adds, removeLabel removes. Returns the
+// number of write calls issued (0 == idempotent no-op) so tests can pin the
+// steady-state-zero-writes invariant. removeLabel is async (linear-write.mjs:175)
+// but called fire-and-forget inside safeWrite — the write still happens and its
+// own try/catch swallows any failure, matching the best-effort convention.
+function convergeHeldLabel(ticket, current, desired, writeStatus) {
+  const have = new Set(current ?? []);
+  let writes = 0;
+  // Remove any held label that is present but not desired.
+  for (const label of HELD_LABELS) {
+    if (label !== desired && have.has(label)) {
+      safeWrite(() => writeStatus.removeLabel(ticket, label), { ticket, phase: "admission" });
+      writes++;
+    }
+  }
+  // Apply the desired label if it is not already present.
+  if (desired && !have.has(desired)) {
+    safeWrite(() => writeStatus.applyLabel({ ticket, label: desired }), { ticket, phase: "admission" });
+    writes++;
+  }
+  return writes;
+}
+
 // CTL-624: dispatch cool-down marker. Conceptually mirrors the labelOnce
 // once-marker (workers/<T>/.linear-label-*), but with two deliberate
 // differences: (1) the marker carries a timestamp and the guard is time-based —
@@ -1419,6 +1493,14 @@ export function schedulerTick(
     // entirely (byte-for-byte legacy dispatch for every test that doesn't inject
     // it). Production wires defaultCheckSequencing via runTick/startScheduler.
     checkSequencing = undefined,
+    // CTL-755: admission-gate hydration seam — fetches one triaged-waiting
+    // candidate's live state + relations + priority + labels in a single
+    // `linearis issues read`. Defaults to the real linear-query helper; tests
+    // inject a stub keyed by identifier so a STEP-A tick never shells out.
+    fetchRelations = fetchTicketRelations,
+    // CTL-755: held-indicator audit emitter — phase.advance.held.<ticket>.
+    // Best-effort, only-on-state-change. Mirrors appendDispatchRequestedEvent.
+    appendPhaseAdvanceHeldEvent = defaultAppendPhaseAdvanceHeldEvent,
   } = {}
 ) {
   // (0) Reclaim-dead-work sweep (CTL-574) — close phase signals whose bg worker
@@ -1578,6 +1660,164 @@ export function schedulerTick(
   const maxParallel = readMaxParallel(orchDir, concurrency);
   const liveCount = liveBackgroundCount();
 
+  // (STEP A) CTL-755 admission-control compute — gate the triage→research
+  // promotion by deps + priority + capacity. PURE-COMPUTE + labelOnce escalation
+  // only: no dispatch, no signal mutation. Produces `admittedThisTick` (the set
+  // of triaged-waiting tickets allowed to advance to research this tick) which
+  // the advancement sweep (STEP B) consumes as a predicate. Runs after the
+  // liveCount hoist (so the promotion budget reflects the live slot count) and
+  // before the preemption sweep (so it is independent of the dispatch sweeps).
+  let promotedCount = 0;
+  let admittedThisTick = new Set();
+  {
+    // A.1 — the triaged-waiting pool: exactly the set sweep 1 would free-promote
+    // this tick (triage:done, no research signal, not parked). Covers live
+    // triage-complete, reclaim branch-B emitComplete, AND post-boot — all
+    // converge on triage:done / no-research.
+    const triagedWaiting = [];
+    for (const ticket of listInFlightTickets(orchDir)) {
+      const s = readPhaseSignals(orchDir, ticket);
+      if (s.triage !== "done") continue;
+      if ("research" in s) continue;
+      if (Object.values(s).some((v) => v === PREEMPTED_STATUS)) continue;
+      triagedWaiting.push(ticket);
+    }
+
+    // A.2 — early-exit when nothing is waiting. Zero Linear cost in the common
+    // path (no fetchRelations, no hydration, no label diff).
+    if (triagedWaiting.length > 0) {
+      // A.3 — hydrate each candidate's live state + relations + priority + labels
+      // FRESH via one `linearis issues read` (fetchRelations, shared cache). A
+      // read failure (rel === null) is tracked so the candidate fails SAFE —
+      // it is forced out of readyIds below (A.4), never silently promoted on an
+      // unknown dependency picture. Build pseudo-issue descriptors in the
+      // buildDependencyEdges shape (state re-nested into {name} — fetchRelations
+      // returns a flat string).
+      const waitingDescriptors = [];
+      const labelsByTicket = new Map(); // ticket → current Linear label set
+      const readFailedTickets = new Set(); // fail-safe: null read → held
+      for (const ticket of triagedWaiting) {
+        const rel = fetchRelations(ticket, { exec, cache });
+        const { priority, createdAt } = readWorkerPriority(orchDir, ticket);
+        if (rel === null) readFailedTickets.add(ticket);
+        // null rel → fail-safe: non-terminal sentinel state, no edges, no labels.
+        const stateName = rel?.state ?? UNFETCHED_BLOCKER_STATE;
+        labelsByTicket.set(ticket, rel?.labels ?? []);
+        waitingDescriptors.push({
+          identifier: ticket,
+          // Prefer the live Linear priority; fall back to the persisted worker
+          // priority when the read failed or carried no priority.
+          priority: typeof rel?.priority === "number" ? rel.priority : priority,
+          createdAt,
+          state: { name: stateName },
+          relations: rel?.relations ?? { nodes: [] },
+          inverseRelations: rel?.inverseRelations ?? { nodes: [] },
+        });
+      }
+
+      // A.4 — combined dep analysis over candidates + eligible new work. Hydrates
+      // BOTH pools' out-of-set blockers once (closes the D5 fail-open gap). The
+      // candidates are not in `eligible`, so they cannot leak into sweep-2
+      // selection — sweep 2 keeps its own computation over `eligible` unchanged.
+      const admissionPool = [...eligible, ...waitingDescriptors];
+      const admissionBlockerStates = hydrateOutOfSetBlockers(admissionPool, { exec, cache });
+      const graph = analyzeDependencyGraph(admissionPool, {
+        blockerStates: admissionBlockerStates,
+      });
+      const readyIds = new Set(graph.ready);
+      // Fail-safe: a candidate whose fresh read FAILED has an unknown dependency
+      // picture (empty edges from a null read would otherwise read as "ready") —
+      // hold it (drop from readyIds → classified "blocked"). Retries next tick.
+      for (const ticket of readFailedTickets) readyIds.delete(ticket);
+
+      // A.5 — cycle escalation: a triaged-waiting ticket in a dependency cycle
+      // can never become ready, so flag it needs-human (labelOnce, apply-once).
+      const cycleMembers = new Set();
+      for (const anomaly of graph.anomalies) {
+        for (const member of anomaly.members) {
+          if (triagedWaiting.includes(member)) {
+            cycleMembers.add(member);
+            labelOnce(orchDir, member, "needs-human", writeStatus);
+          }
+        }
+      }
+
+      // A.6 — priority + capacity selection over the COMBINED ready pool. Triaged
+      // candidates compete fairly with brand-new ready work for the shared
+      // free-slot ceiling. Empty exclude is correct (candidates have no research
+      // signal yet). Brand-new eligible tickets in the slice are NOT acted on
+      // here — they flow through sweep 2; their presence only makes the triaged
+      // candidates compete fairly.
+      const freeSlotsForPromotion = livenessIsFresh()
+        ? Math.max(0, computeFreeSlots(maxParallel, liveCount))
+        : 0;
+      const readyCandidates = rankTickets(
+        admissionPool.filter((t) => readyIds.has(t.identifier)),
+      );
+      const admittedSlice = selectDispatchablePerProject(
+        readyCandidates,
+        new Set(),
+        freeSlotsForPromotion,
+        { perProject: concurrency?.perProject, inFlight: inFlightTickets },
+      );
+      admittedThisTick = new Set(
+        admittedSlice
+          .filter((t) => triagedWaiting.includes(t.identifier))
+          .map((t) => t.identifier),
+      );
+
+      // A.7 — held-indicator convergence (CTL-755 ADDENDUM). For each candidate,
+      // compute the desired held label and converge ON A DIFF (steady-state tick
+      // = zero writes). Emit phase.advance.held only-on-state-change.
+      const edges = buildDependencyEdges(admissionPool, {
+        externalIds: Object.keys(admissionBlockerStates),
+      });
+      const poolById = new Map(
+        admissionPool.filter((t) => t?.identifier).map((t) => [t.identifier, t]),
+      );
+      for (const ticket of triagedWaiting) {
+        if (cycleMembers.has(ticket)) {
+          // Cycle member → owned by needs-human (labelOnce above). Clear any
+          // stale held label so it doesn't double-signal, and drop its held
+          // emit-state so a future non-cycle hold re-emits.
+          convergeHeldLabel(ticket, labelsByTicket.get(ticket), null, writeStatus);
+          lastHeldEmitState.delete(ticket);
+          continue;
+        }
+        let desired = null;
+        let reason = null;
+        let blockers = [];
+        if (!readyIds.has(ticket)) {
+          desired = HELD_LABEL_BLOCKED;
+          reason = "blocked-by-open-dependency";
+          blockers = unmetBlockersFor(ticket, edges, poolById, admissionBlockerStates);
+        } else if (!admittedThisTick.has(ticket)) {
+          desired = HELD_LABEL_WAITING;
+          reason = "awaiting-capacity-or-priority";
+        }
+        // else: admitted → desired null → clear-on-pickup (both labels removed).
+
+        convergeHeldLabel(ticket, labelsByTicket.get(ticket), desired, writeStatus);
+
+        if (desired) {
+          // Only-on-state-change emission: skip if the same held class already
+          // emitted for this ticket since it was last cleared/admitted.
+          if (lastHeldEmitState.get(ticket) !== desired) {
+            lastHeldEmitState.set(ticket, desired);
+            safeEmit(
+              appendPhaseAdvanceHeldEvent,
+              { orchId: ticket, ticket, reason, blockers },
+              { ticket, phase: "advance" },
+            );
+          }
+        } else {
+          // Admitted (or no longer held) → reset so a future re-hold re-emits.
+          lastHeldEmitState.delete(ticket);
+        }
+      }
+    }
+  }
+
   // (0.5) Preemption sweep — if slots are saturated AND the top-ranked queued
   // ticket out-ranks the lowest-ranked preemptable in-flight worker, stop that
   // worker and park it for resume when a slot frees. Safety guards prevent
@@ -1729,6 +1969,13 @@ export function schedulerTick(
       remediateCycleCount: cycleCount,
     });
     if (!next) continue;
+    // (STEP B) CTL-755 admission gate — hold the triage→research promotion unless
+    // STEP A admitted this ticket (deps terminal + won priority/capacity). Soft
+    // hold: no dispatch → applyPhaseStatus(research)/applyEstimate never fire, the
+    // ticket stays at Linear "Triage" (no cooldown, auto-retries next tick). Keyed
+    // on `next === NEW_WORK_ENTRY_PHASE` which deriveAdvancement returns UNIQUELY
+    // for the triage→research edge; non-research edges skip the guard.
+    if (next === NEW_WORK_ENTRY_PHASE && signals.triage === "done" && !admittedThisTick.has(ticket)) continue;
     if (inDispatchCooldown(orchDir, ticket, next, now())) continue; // CTL-624: throttle refused re-dispatch
     // CTL-660: record the dispatch DECISION before the spawn. Best-effort.
     safeEmit(
@@ -1760,6 +2007,11 @@ export function schedulerTick(
           { ticket, phase: next }
         );
         advanced.push({ ticket, phase: next });
+        // CTL-755: a verified triage→research promotion consumed a slot this tick.
+        // liveCount was read at the top of the tick (before this dispatch), so the
+        // promotion has not yet incremented it — STEP C subtracts promotedCount
+        // from sweep-2 freeSlots to stop over-admitting into the just-taken slots.
+        if (next === NEW_WORK_ENTRY_PHASE) promotedCount++;
         // CTL-657 / CTL-661: stop the predecessor worker now that its successor
         // is live. resolveReapPredecessor reads the PRE-reset signals so the
         // verify⇄remediate detour edges name the correct just-finished worker;
@@ -1958,12 +2210,16 @@ export function schedulerTick(
   // independent of freeSlots and already ran, so the pipeline keeps moving; only
   // NEW admissions pause until the read recovers. Fresh (the default) → no change.
   const livenessFresh = livenessIsFresh();
+  // CTL-755: also subtract promotedCount — the triage→research promotions STEP B
+  // dispatched this tick took slots that liveCount (read before STEP B) does not
+  // yet reflect, so without this term sweep 2 over-admits into them (the same
+  // double-fill class CTL-705's resumedCount term fixed; one symmetric extra term).
   const freeSlots = livenessFresh
-    ? Math.max(0, computeFreeSlots(maxParallel, inFlightCount) - resumedCount)
+    ? Math.max(0, computeFreeSlots(maxParallel, inFlightCount) - resumedCount - promotedCount)
     : 0;
   if (!livenessFresh) {
     log.warn(
-      { maxParallel, inFlightCount, resumedCount },
+      { maxParallel, inFlightCount, resumedCount, promotedCount },
       "scheduler: liveness snapshot stale/cold — holding new-work dispatch (CTL-731)",
     );
   }
@@ -2211,6 +2467,13 @@ let runningOpts = null;
 // one event. Cleared only on daemon restart (via __resetForTests in tests).
 const observedYieldFiles = new Set();
 
+// CTL-755: last-emitted held-state per ticket, so the phase.advance.held event
+// fires only-on-state-change (not every tick a candidate stays held) — bounding
+// log volume on a long-blocked ticket. Keyed by ticket → "blocked"|"waiting".
+// An admitted/cleared ticket is deleted so a future re-hold re-emits. Cleared on
+// daemon restart (via __resetForTests).
+const lastHeldEmitState = new Map();
+
 function runTick() {
   try {
     // CTL-676 + CTL-678: hot-reload the concurrency knobs by re-reading the
@@ -2274,6 +2537,11 @@ function runTick() {
       // CTL-537: production defaults to defaultCheckSequencing; tests inject via
       // startScheduler({ checkSequencing }) or directly into schedulerTick.
       checkSequencing: runningOpts.checkSequencing ?? defaultCheckSequencing,
+      // CTL-755: admission-gate seams. Undefined here keeps schedulerTick's
+      // production defaults (fetchTicketRelations / defaultAppendPhaseAdvanceHeldEvent);
+      // tests inject a stub through startScheduler so a daemon tick never shells out.
+      fetchRelations: runningOpts.fetchRelations,
+      appendPhaseAdvanceHeldEvent: runningOpts.appendPhaseAdvanceHeldEvent,
     });
   } catch (err) {
     // A tick must never crash the daemon — log and let the next tick retry.
@@ -2318,6 +2586,8 @@ export function startScheduler({
   // exec / writeStatus / teardownWorktree seams on schedulerTick.
   livenessIsFresh, // CTL-731: optional override; runTick defaults to getAgentsCached().isFresh.
   checkSequencing, // CTL-537: optional override; runTick defaults to defaultCheckSequencing.
+  fetchRelations, // CTL-755: optional override; schedulerTick defaults to fetchTicketRelations.
+  appendPhaseAdvanceHeldEvent, // CTL-755: optional override; defaults to defaultAppendPhaseAdvanceHeldEvent.
   preflight = preflightWorkspaceLabels, // CTL-585
   tickIntervalMs = TICK_INTERVAL_MS,
   debounceMs = TICK_DEBOUNCE_MS,
@@ -2337,6 +2607,8 @@ export function startScheduler({
     liveBackgroundCount, // CTL-676: test seam
     livenessIsFresh, // CTL-731: optional override (default getAgentsCached().isFresh)
     checkSequencing, // CTL-537: optional override (default defaultCheckSequencing)
+    fetchRelations, // CTL-755: optional admission-gate hydration seam
+    appendPhaseAdvanceHeldEvent, // CTL-755: optional held-indicator emit seam
   };
 
   // CTL-585: warn once at startup if the Linear workspace lacks the labels
@@ -2391,6 +2663,7 @@ export function stopScheduler() {
 export function __resetForTests() {
   stopScheduler();
   observedYieldFiles.clear(); // CTL-702: reset per-lifetime dedup set between tests
+  lastHeldEmitState.clear(); // CTL-755: reset held-event only-on-change dedup
   // rankedAboveSince is cleared by stopScheduler above (CTL-705)
 }
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -663,6 +663,38 @@ function fakeDispatch({ code = 0 } = {}) {
 // schedulerTick to opt out of demotion for non-CTL-611 tests.
 const verifyOk = () => ({ ok: true });
 
+// ── CTL-755: admission-gate fetchRelations stub helpers ──
+//
+// relUnblocked — a fetchTicketRelations return for a candidate with NO open
+// dependency (non-terminal "Triage" state, no relations, given priority/labels).
+// STEP A admits it whenever a promotion slot is free. relBlockedBy — adds a
+// blocked_by inverseRelations edge (type:"blocks", issue:<blocker>) so the dep
+// graph holds the candidate until the blocker hydrates terminal.
+function relUnblocked({ priority = 2, labels = [], state = "Triage" } = {}) {
+  return {
+    state,
+    relations: { nodes: [] },
+    inverseRelations: { nodes: [] },
+    priority,
+    labels,
+  };
+}
+function relBlockedBy(blockerId, { priority = 2, labels = [], state = "Triage" } = {}) {
+  return {
+    state,
+    relations: { nodes: [] },
+    // inverseRelations {type:"blocks", issue:<blocker>} means <blocker> BLOCKS this
+    // ticket — the blocked_by edge buildDependencyEdges reads (node.issue.identifier).
+    inverseRelations: { nodes: [{ type: "blocks", issue: { identifier: blockerId } }] },
+    priority,
+    labels,
+  };
+}
+// A fetchRelations dispatcher keyed by ticket id, falling back to relUnblocked.
+function relMap(map) {
+  return (id) => map[id] ?? relUnblocked();
+}
+
 // ── CTL-624: per-(ticket,phase) dispatch cool-down helpers ──
 describe("dispatch cool-down helpers", () => {
   test("no marker → not in cool-down", () => {
@@ -1372,6 +1404,10 @@ describe("schedulerTick — new-work pull", () => {
       readEligible: () => [],
       dispatch,
       verifyDispatched: verifyOk, // CTL-611: bypass dispatch verifier
+      // CTL-755: the triage→research promotion is now admission-gated. Stub
+      // fetchRelations (unblocked) + a free slot so the gate admits CTL-7.
+      fetchRelations: () => relUnblocked(),
+      liveBackgroundCount: () => 0,
     });
     expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "research" }]);
     expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
@@ -1417,6 +1453,10 @@ describe("schedulerTick — new-work pull", () => {
       dispatch,
       verifyDispatched: verifyOk, // CTL-611: bypass dispatch verifier
       liveBackgroundCount: () => 0,
+      // CTL-755: admission-gate seam — CTL-7 (triaged-waiting) is unblocked, so
+      // it is admitted and promoted; STEP C subtracts promotedCount so the new
+      // CTL-X still gets the remaining free slot (the double-fill invariant).
+      fetchRelations: () => relUnblocked(),
     });
     expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
     expect(r.dispatched).toEqual(["CTL-X"]);
@@ -1456,9 +1496,13 @@ describe("schedulerTick — new-work pull", () => {
     expect(r.dispatched).toEqual([]);
   });
 
-  test("a stale liveness snapshot still advances in-flight phases (advancement is count-independent)", () => {
+  test("a stale liveness snapshot still advances MID-pipeline phases (advancement is count-independent)", () => {
+    // CTL-755: the triage→research edge is now capacity-gated (held under
+    // staleness — see the dedicated staleness-holds-promotion test below). But a
+    // MID-pipeline advance (research:done → plan) is still count-independent and
+    // must fire under a stale snapshot, exactly as before.
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
-    writeSignal("CTL-7", "triage", "done"); // should advance to research
+    writeSignal("CTL-7", "research", "done"); // should advance to plan
     const dispatch = fakeDispatch();
     const eligible = [
       {
@@ -1477,8 +1521,8 @@ describe("schedulerTick — new-work pull", () => {
       liveBackgroundCount: () => 0,
       livenessIsFresh: () => false, // stale → new-work held, advancement unaffected
     });
-    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
-    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "research" }]);
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "plan" }]);
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "plan" }]);
     expect(r.dispatched).toEqual([]); // CTL-X held by the staleness gate
   });
 
@@ -2073,6 +2117,11 @@ describe("startScheduler / stopScheduler", () => {
       orchDir,
       dispatch,
       readEligible: () => [],
+      // CTL-755: the triage→research promotion is admission-gated. Stub
+      // fetchRelations (unblocked + non-terminal state) and provide a free slot
+      // so the gate admits CTL-1 and the advancement sweep dispatches research.
+      fetchRelations: () => relUnblocked(),
+      liveBackgroundCount: () => 0,
       tickIntervalMs: 60_000,
       debounceMs: 5,
     });
@@ -2098,6 +2147,9 @@ describe("startScheduler / stopScheduler", () => {
       orchDir,
       dispatch,
       readEligible: () => [],
+      // CTL-755: admission-gate seam + free slot so the promotion fires.
+      fetchRelations: () => relUnblocked(),
+      liveBackgroundCount: () => 0,
       tickIntervalMs: 20,
       debounceMs: 5,
     });
@@ -2117,6 +2169,9 @@ describe("startScheduler / stopScheduler", () => {
       orchDir,
       dispatch,
       readEligible: () => [],
+      // CTL-755: admission-gate seam + free slot so the promotion fires.
+      fetchRelations: () => relUnblocked(),
+      liveBackgroundCount: () => 0,
       tickIntervalMs: 60_000,
       debounceMs: 10,
     });
@@ -5043,9 +5098,15 @@ describe("CTL-751: applyEstimate write-back on triage→research advance", () =>
       applyPhaseStatus: () => {},
       applyTerminalDone: () => {},
       applyLabel: () => {},
+      removeLabel: () => {},
       applyEstimate: (a) => { estimateCalls.push(a); return { applied: true, reason: null }; },
     };
   }
+
+  // CTL-755: the estimate write-back rides the triage→research advance, which is
+  // now admission-gated — stub fetchRelations (unblocked) + a free slot so the
+  // promotion fires and the applyEstimate code path is reached.
+  const admit = { fetchRelations: () => relUnblocked(), liveBackgroundCount: () => 0 };
 
   test("triage.json with estimate:5 → applyEstimate called once with {ticket, estimate:5}", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
@@ -5057,6 +5118,7 @@ describe("CTL-751: applyEstimate write-back on triage→research advance", () =>
       dispatch: okDispatch,
       writeStatus: makeWriteStatus(calls),
       verifyDispatched: verifyOk,
+      ...admit,
     });
     expect(calls).toHaveLength(1);
     expect(calls[0]).toEqual({ ticket: "CTL-1", estimate: 5 });
@@ -5072,6 +5134,7 @@ describe("CTL-751: applyEstimate write-back on triage→research advance", () =>
       dispatch: okDispatch,
       writeStatus: makeWriteStatus(calls),
       verifyDispatched: verifyOk,
+      ...admit,
     });
     expect(calls).toHaveLength(0);
   });
@@ -5086,6 +5149,7 @@ describe("CTL-751: applyEstimate write-back on triage→research advance", () =>
       dispatch: okDispatch,
       writeStatus: makeWriteStatus(calls),
       verifyDispatched: verifyOk,
+      ...admit,
     });
     expect(calls).toHaveLength(0);
   });
@@ -5113,6 +5177,7 @@ describe("CTL-751: applyEstimate write-back on triage→research advance", () =>
       applyPhaseStatus: () => {},
       applyTerminalDone: () => {},
       applyLabel: () => {},
+      removeLabel: () => {},
       applyEstimate: () => { throw new Error("Linear exploded"); },
     };
     expect(() =>
@@ -5121,7 +5186,338 @@ describe("CTL-751: applyEstimate write-back on triage→research advance", () =>
         dispatch: okDispatch,
         writeStatus,
         verifyDispatched: verifyOk,
+        ...admit,
       })
     ).not.toThrow();
+  });
+});
+
+// ── CTL-755: admission-control gate (STEP A/B/C) ──
+//
+// The triage→research promotion is admission-controlled by deps + priority +
+// capacity. A triaged-waiting ticket is dispatched to research ONLY when its
+// blockers are all terminal AND it wins the priority/capacity selection this
+// tick. Held tickets carry a dynamic blocked/waiting label (cleared on pickup).
+describe("CTL-755: admission gate", () => {
+  afterEach(() => __resetForTests());
+
+  // A writeStatus spy that records label add/remove + estimate + phase-status.
+  function labelSpy() {
+    const applied = [];
+    const removed = [];
+    const phaseStatus = [];
+    const ws = {
+      applyPhaseStatus: (a) => phaseStatus.push(a),
+      applyTerminalDone: () => {},
+      applyEstimate: () => ({ applied: true }),
+      applyLabel: (a) => { applied.push(a); return { applied: true, reason: null }; },
+      removeLabel: (ticket, label) => { removed.push({ ticket, label }); return { removed: true }; },
+    };
+    return { ws, applied, removed, phaseStatus };
+  }
+
+  // A held-event spy.
+  function heldSpy() {
+    const events = [];
+    return { fn: (e) => events.push(e), events };
+  }
+
+  // An exec stub that answers `linearis issues read <id>` with a state name,
+  // keyed by identifier. Used to hydrate out-of-set blocker states (the D5 path
+  // STEP A reuses). Unknown ids → code 0 with a non-terminal placeholder.
+  function execWithStates(stateById) {
+    return (_cmd, args) => {
+      const id = args?.[2];
+      const name = stateById[id] ?? "Triage";
+      return { code: 0, stdout: JSON.stringify({ state: { name } }), stderr: "" };
+    };
+  }
+
+  test("dep hold: a blocked triaged ticket is NOT dispatched, no Research write, 'blocked' label applied", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws, applied, removed, phaseStatus } = labelSpy();
+    const held = heldSpy();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      // CTL-7 is blocked by an out-of-set blocker that is still In Progress.
+      fetchRelations: () => relBlockedBy("CTL-DEP"),
+      exec: execWithStates({ "CTL-DEP": "In Progress" }),
+      appendPhaseAdvanceHeldEvent: held.fn,
+    });
+    expect(dispatch.calls).toEqual([]); // no research dispatch
+    expect(r.advanced).toEqual([]);
+    // No phase-status write for research (the soft hold never reaches it).
+    expect(phaseStatus.some((p) => p.phase === "research")).toBe(false);
+    // The "blocked" held label is applied.
+    expect(applied).toContainEqual({ ticket: "CTL-7", label: "blocked" });
+    expect(removed).toEqual([]);
+    // The held event carries the dep reason + unmet blocker id.
+    expect(held.events).toHaveLength(1);
+    expect(held.events[0]).toMatchObject({
+      ticket: "CTL-7",
+      reason: "blocked-by-open-dependency",
+      blockers: ["CTL-DEP"],
+    });
+  });
+
+  test("auto-promote: when the blocker flips terminal, 'blocked' is removed and research dispatches", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws, applied, removed } = labelSpy();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      // CTL-7's blocker carries the "blocked" label already; now it is Done.
+      fetchRelations: () => relBlockedBy("CTL-DEP", { labels: ["blocked"] }),
+      exec: execWithStates({ "CTL-DEP": "Done" }),
+    });
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "research" }]);
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
+    // Clear-on-pickup: the stale "blocked" label is removed, none applied.
+    expect(removed).toContainEqual({ ticket: "CTL-7", label: "blocked" });
+    expect(applied).toEqual([]);
+  });
+
+  test("capacity hold-then-promote: 'waiting' while full, promoted + label cleared when a slot frees", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-7", "triage", "done"); // unblocked but no free slot
+
+    // Tick 1: a live worker fills the only slot → CTL-7 is ready but un-admitted.
+    const d1 = fakeDispatch();
+    const s1 = labelSpy();
+    const h1 = heldSpy();
+    const r1 = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: d1,
+      writeStatus: s1.ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 1, // saturated
+      fetchRelations: () => relUnblocked(),
+      appendPhaseAdvanceHeldEvent: h1.fn,
+    });
+    expect(d1.calls).toEqual([]); // no promotion
+    expect(r1.advanced).toEqual([]);
+    expect(s1.applied).toContainEqual({ ticket: "CTL-7", label: "waiting" });
+    expect(h1.events[0]).toMatchObject({
+      ticket: "CTL-7",
+      reason: "awaiting-capacity-or-priority",
+      blockers: [],
+    });
+
+    // Tick 2: the slot frees → CTL-7 is admitted, promoted, and "waiting" cleared.
+    const d2 = fakeDispatch();
+    const s2 = labelSpy();
+    const r2 = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: d2,
+      writeStatus: s2.ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0, // slot freed
+      fetchRelations: () => relUnblocked({ labels: ["waiting"] }),
+    });
+    expect(d2.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "research" }]);
+    expect(r2.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
+    expect(s2.removed).toContainEqual({ ticket: "CTL-7", label: "waiting" });
+  });
+
+  test("promotion clears BOTH held labels (clear-on-pickup regression anchor)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws, applied, removed } = labelSpy();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      // Both stale labels present (defensive — should never co-exist, but the
+      // converge must clear both on pickup).
+      fetchRelations: () => relUnblocked({ labels: ["blocked", "waiting"] }),
+    });
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "research" }]);
+    expect(removed).toContainEqual({ ticket: "CTL-7", label: "blocked" });
+    expect(removed).toContainEqual({ ticket: "CTL-7", label: "waiting" });
+    expect(applied).toEqual([]);
+  });
+
+  test("steady-state held tick makes ZERO applyLabel/removeLabel calls (idempotent)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws, applied, removed } = labelSpy();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      // Already correctly labeled "blocked" (blocker still open) → no diff.
+      fetchRelations: () => relBlockedBy("CTL-DEP", { labels: ["blocked"] }),
+      exec: execWithStates({ "CTL-DEP": "In Progress" }),
+    });
+    expect(dispatch.calls).toEqual([]);
+    expect(applied).toEqual([]); // already labeled → no apply
+    expect(removed).toEqual([]); // nothing to remove
+  });
+
+  test("steady-state held tick re-emits NO held event (only-on-state-change)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    const dispatch = fakeDispatch();
+    const held = heldSpy();
+    const common = {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: labelSpy().ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchRelations: () => relBlockedBy("CTL-DEP", { labels: ["blocked"] }),
+      exec: execWithStates({ "CTL-DEP": "In Progress" }),
+      appendPhaseAdvanceHeldEvent: held.fn,
+    };
+    schedulerTick(orchDir, common);
+    schedulerTick(orchDir, common);
+    // Two held ticks, but the held class did not change → exactly one emit.
+    expect(held.events).toHaveLength(1);
+  });
+
+  test("circular dep among triaged tickets → labelOnce(needs-human), no throw, no deadlock", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-A", "triage", "done");
+    writeSignal("CTL-B", "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws, applied } = labelSpy();
+    // CTL-A blocked_by CTL-B and CTL-B blocked_by CTL-A → 2-node cycle.
+    const fr = relMap({
+      "CTL-A": relBlockedBy("CTL-B"),
+      "CTL-B": relBlockedBy("CTL-A"),
+    });
+    let r;
+    expect(() => {
+      r = schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch,
+        writeStatus: ws,
+        verifyDispatched: verifyOk,
+        liveBackgroundCount: () => 0,
+        fetchRelations: fr,
+      });
+    }).not.toThrow();
+    expect(dispatch.calls).toEqual([]); // neither member promotes
+    expect(r.advanced).toEqual([]);
+    // Both cycle members are flagged needs-human (labelOnce).
+    expect(applied).toContainEqual({ ticket: "CTL-A", label: "needs-human" });
+    expect(applied).toContainEqual({ ticket: "CTL-B", label: "needs-human" });
+  });
+
+  test("double-fill guard: maxParallel 2, one triaged + one new-work → exactly 2 dispatches (not 3)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done"); // triaged-waiting, promotes to research
+    const dispatch = fakeDispatch();
+    const eligible = [
+      { identifier: "CTL-X", priority: 1, createdAt: "x", state: "Todo", relations: { nodes: [] }, inverseRelations: { nodes: [] } },
+    ];
+    const r = schedulerTick(orchDir, {
+      readEligible: () => eligible,
+      dispatch,
+      writeStatus: labelSpy().ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchRelations: () => relUnblocked(),
+    });
+    // STEP B promotes CTL-7 (+promotedCount); STEP C subtracts it so sweep 2 has
+    // exactly 1 remaining slot for CTL-X — 2 total dispatches, not 3.
+    expect(dispatch.calls).toHaveLength(2);
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
+    expect(r.dispatched).toEqual(["CTL-X"]);
+  });
+
+  test("double-fill guard, 1 slot: a higher-priority NEW ticket wins over a lower-priority triaged candidate", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-7", "triage", "done"); // priority 3 (lower)
+    const dispatch = fakeDispatch();
+    // CTL-X is brand-new ready work at priority 1 (more urgent).
+    const eligible = [
+      { identifier: "CTL-X", priority: 1, createdAt: "x", state: "Todo", relations: { nodes: [] }, inverseRelations: { nodes: [] } },
+    ];
+    const { ws, applied } = labelSpy();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => eligible,
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchRelations: () => relUnblocked({ priority: 3 }),
+    });
+    // The single slot goes to the higher-priority new work; CTL-7 is held
+    // "waiting" (ready, lost the selection), not promoted.
+    expect(r.advanced).toEqual([]);
+    expect(r.dispatched).toEqual(["CTL-X"]);
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-X", phase: "research" }]);
+    expect(applied).toContainEqual({ ticket: "CTL-7", label: "waiting" });
+  });
+
+  test("staleness gate (livenessIsFresh=false) holds the triage→research promotion", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 3 }));
+    writeSignal("CTL-7", "triage", "done"); // unblocked, slots available on paper
+    const dispatch = fakeDispatch();
+    const { ws, applied } = labelSpy();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0, // would show 3 free slots
+      livenessIsFresh: () => false, // but the snapshot is stale → hold
+      fetchRelations: () => relUnblocked(),
+    });
+    expect(dispatch.calls).toEqual([]); // promotion held
+    expect(r.advanced).toEqual([]);
+    // Deps are satisfied (in readyIds) but the promotion budget is 0 → "waiting".
+    expect(applied).toContainEqual({ ticket: "CTL-7", label: "waiting" });
+  });
+
+  test("early-exit: zero triaged-waiting tickets → fetchRelations never called (zero Linear cost)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "research", "running"); // in-flight but NOT triaged-waiting
+    let fetchCalls = 0;
+    const dispatch = fakeDispatch();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: labelSpy().ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchRelations: () => { fetchCalls++; return relUnblocked(); },
+    });
+    expect(fetchCalls).toBe(0); // STEP A early-exited
+  });
+
+  test("read-failure (fetchRelations → null) fails SAFE: the candidate is held", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws } = labelSpy();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchRelations: () => null, // read failed → non-terminal sentinel → held
+    });
+    expect(dispatch.calls).toEqual([]);
+    expect(r.advanced).toEqual([]);
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5520,4 +5520,141 @@ describe("CTL-755: admission gate", () => {
     expect(dispatch.calls).toEqual([]);
     expect(r.advanced).toEqual([]);
   });
+
+  // ── STEP E: dep persistence (scheduler-side) ──
+  //
+  // A writeStatus spy that ALSO records applyBlockedByRelation (the durable
+  // blocked_by write STEP E issues). Mirrors labelSpy but exposes `relations`.
+  function depSpy() {
+    const relations = [];
+    const applied = [];
+    const ws = {
+      applyPhaseStatus: () => {},
+      applyTerminalDone: () => {},
+      applyEstimate: () => ({ applied: true }),
+      applyLabel: (a) => { applied.push(a); return { applied: true, reason: null }; },
+      removeLabel: () => ({ removed: true }),
+      applyBlockedByRelation: (a) => { relations.push(a); return { applied: true, reason: null }; },
+    };
+    return { ws, relations, applied };
+  }
+
+  // Write workers/<T>/triage.json with a `.dependencies` array (the flat-string
+  // shape the phase-triage skill scrapes). The worker dir already exists from
+  // writeSignal.
+  function writeTriageDeps(ticket, dependencies) {
+    writeFileSync(
+      join(orchDir, "workers", ticket, "triage.json"),
+      JSON.stringify({ ticket, classification: "feature", dependencies }),
+    );
+  }
+
+  // An exec stub: `linearis issues read <id>` → keyed state, or code!==0 for
+  // ids in `unresolvable` (so fetchTicketState returns null and STEP E drops it).
+  function execStates(stateById, unresolvable = new Set()) {
+    return (_cmd, args) => {
+      const id = args?.[2];
+      if (unresolvable.has(id)) return { code: 1, stdout: "", stderr: "not found" };
+      const name = stateById[id] ?? "Triage";
+      return { code: 0, stdout: JSON.stringify({ state: { name } }), stderr: "" };
+    };
+  }
+
+  test("dep persistence: a resolvable non-terminal dep is written, a prose-only/unresolvable token is dropped", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    // CTL-100 resolves (non-terminal); PROSE-1 is a TEAM-NNN-shaped token that
+    // does not resolve to a real ticket → dropped.
+    writeTriageDeps("CTL-7", ["CTL-100", "PROSE-1"]);
+    const dispatch = fakeDispatch();
+    const { ws, relations } = depSpy();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      // CTL-7 has NO existing relations (so the dep write is not idempotently
+      // skipped); the dep states are resolved via exec below.
+      fetchRelations: () => relUnblocked(),
+      exec: execStates({ "CTL-100": "In Progress" }, new Set(["PROSE-1"])),
+    });
+    // Exactly one durable edge: CTL-7 blocked_by CTL-100. PROSE-1 dropped.
+    expect(relations).toEqual([{ ticket: "CTL-7", blockedBy: "CTL-100" }]);
+  });
+
+  test("dep persistence is idempotent: a dep already in the candidate's relations → zero writes", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    writeTriageDeps("CTL-7", ["CTL-100"]);
+    const dispatch = fakeDispatch();
+    const { ws, relations } = depSpy();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      // CTL-7's FRESH relations already carry blocked_by CTL-100 (durable edge
+      // exists) → STEP E must NOT re-write it. (CTL-100 In Progress also holds
+      // the gate, but the persistence path is what we pin here.)
+      fetchRelations: () => relBlockedBy("CTL-100"),
+      exec: execStates({ "CTL-100": "In Progress" }),
+    });
+    expect(relations).toEqual([]); // idempotent — nothing written
+  });
+
+  test("dep persistence: a TERMINAL dep is NOT written (no durable edge for a Done blocker)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    writeTriageDeps("CTL-7", ["CTL-100"]);
+    const dispatch = fakeDispatch();
+    const { ws, relations } = depSpy();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchRelations: () => relUnblocked(),
+      exec: execStates({ "CTL-100": "Done" }), // terminal → no durable edge
+    });
+    expect(relations).toEqual([]);
+  });
+
+  test("dep persistence: a self-ref dependency token is dropped", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    writeTriageDeps("CTL-7", ["CTL-7", "CTL-100"]); // CTL-7 is self → dropped
+    const dispatch = fakeDispatch();
+    const { ws, relations } = depSpy();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchRelations: () => relUnblocked(),
+      exec: execStates({ "CTL-100": "In Progress" }),
+    });
+    expect(relations).toEqual([{ ticket: "CTL-7", blockedBy: "CTL-100" }]);
+  });
+
+  test("dep persistence tolerates the rich {id} descriptor shape (forward-compat)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    writeTriageDeps("CTL-7", [{ id: "CTL-100", exists: true, blockerState: "In Progress" }]);
+    const dispatch = fakeDispatch();
+    const { ws, relations } = depSpy();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchRelations: () => relUnblocked(),
+      exec: execStates({ "CTL-100": "In Progress" }),
+    });
+    expect(relations).toEqual([{ ticket: "CTL-7", blockedBy: "CTL-100" }]);
+  });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5501,7 +5501,7 @@ describe("CTL-755: admission gate", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 6 }));
     for (const t of ["CTL-L1", "CTL-L2", "CTL-L3"]) writeSignal(t, "triage", "done");
     const dispatch = fakeDispatch();
-    const { ws, applied, removed } = labelSpy();
+    const { ws, applied } = labelSpy();
     const fr = relMap({
       "CTL-L1": relBlockedBy("CTL-FOUND"),
       "CTL-L2": relBlockedBy("CTL-FOUND"),
@@ -5543,6 +5543,80 @@ describe("CTL-755: admission gate", () => {
     expect(dispatch.calls).toHaveLength(2);
     expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
     expect(r.dispatched).toEqual(["CTL-X"]);
+  });
+
+  test("double-fill guard, promotion↔resume: one free slot is claimed by the triage→research promotion OR the resume sweep, never both (CTL-755 fix #1)", () => {
+    // ONE tick, ONE free global slot, contended by TWO sweeps:
+    //  - STEP B: a triaged-waiting candidate (CTL-7) eligible for triage→research.
+    //  - sweep 1.5: a parked/preempted ticket (CTL-Park) eligible for resume.
+    // maxParallel 2 with liveBackgroundCount 1 → computeFreeSlots == 1 (the live
+    // count models the one running sibling that holds the second slot; the parked
+    // ticket's bg worker was killed at preemption, so it is NOT live-counted).
+    //
+    // Fix #1 subtracts promotedCount from the resume sweep's slot budget:
+    //   resumeSlots = max(0, computeFreeSlots(2, 1) - promotedCount) = max(0, 1 - 1) = 0
+    // so once STEP B promotes CTL-7 the resume sweep sees ZERO slots and bows out.
+    // WITHOUT fix #1 the resume sweep would read resumeSlots = computeFreeSlots(2,1)
+    // = 1 and ALSO dispatch CTL-Park into the same single slot — two NEW dispatches
+    // into one free slot (over-admission past maxParallel). This test would then
+    // see dispatch.calls length 2 and fail the single-slot assertion below.
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    // Triaged-waiting candidate — promotes via STEP B (unblocked, free slot).
+    writeSignal("CTL-7", "triage", "done");
+    // Parked/preempted candidate — a phase-research signal in the "preempted"
+    // status on its parkedFrom phase, with a (killed) bg_job_id, plus a persisted
+    // priority so the resume sweep's rankTickets has a descriptor to rank. This is
+    // the exact shape seedPreempted writes for the resume-after-preemption tests.
+    writeSignalRaw("CTL-Park", "research", {
+      ticket: "CTL-Park",
+      phase: "research",
+      status: "preempted",
+      parkedFrom: "research",
+      bg_job_id: "dead-bg-from-preemption",
+      attentionReason: "preempted-by-priority",
+    });
+    writeWorkerPriority(orchDir, "CTL-Park", { priority: 2, createdAt: "2026-05-01T00:00:00Z" });
+
+    // A dispatch that writes a runnable "dispatched" signal so BOTH the promotion's
+    // and (were it to fire) the resume sweep's verifyDispatched + signal reset would
+    // succeed — i.e. nothing other than fix #1 suppresses a second dispatch.
+    const calls = [];
+    const dispatch = (args) => {
+      calls.push(args);
+      const dir = join(orchDir, "workers", args.ticket);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, `phase-${args.phase}.json`),
+        JSON.stringify({ ticket: args.ticket, phase: args.phase, status: "dispatched", bg_job_id: "new-bg" }),
+      );
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    dispatch.calls = calls;
+
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [], // no brand-new work — isolate promotion vs resume
+      dispatch,
+      writeStatus: labelSpy().ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 1, // 1 live sibling → computeFreeSlots(2,1) == 1
+      reclaimDeadWork: () => "noop", // CTL-690: never revive the parked signal
+      resolveSession: () => "uuid-park", // the resume sweep would resume-with-session
+      appendResumedAfterPreemptionEvent: () => {}, // capture-free; presence proves reachability
+      fetchRelations: () => relUnblocked(), // CTL-7's deps are satisfied → admitted
+    });
+
+    // Exactly ONE new dispatch consumed the single free slot. Fix #1 makes the
+    // promotion win and the resume sweep stand down (promotedCount drained the
+    // resume budget to zero); the parked ticket is NOT re-dispatched this tick.
+    expect(dispatch.calls).toHaveLength(1);
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
+    expect(dispatch.calls[0]).toMatchObject({ ticket: "CTL-7", phase: "research" });
+    expect(dispatch.calls.find((c) => c.ticket === "CTL-Park")).toBeUndefined();
+    // The parked signal stays parked (the resume sweep never reset it to "stalled").
+    const parkSig = JSON.parse(
+      readFileSync(join(orchDir, "workers", "CTL-Park", "phase-research.json"), "utf8"),
+    );
+    expect(parkSig.status).toBe("preempted");
   });
 
   test("double-fill guard, 1 slot: a higher-priority NEW ticket wins over a lower-priority triaged candidate", () => {
@@ -5621,6 +5695,44 @@ describe("CTL-755: admission gate", () => {
     });
     expect(dispatch.calls).toEqual([]);
     expect(r.advanced).toEqual([]);
+  });
+
+  test("read-failure held event carries the DISTINCT 'dependency-state-unknown' reason with empty blockers (CTL-755 fix #2)", () => {
+    // Same fail-safe path as above, but pinning the held-event CLASSIFICATION. A
+    // null relations read forces CTL-7 out of readyIds (A.4), so STEP A.7 classifies
+    // it as "blocked". Fix #2: because readFailedTickets.has(CTL-7), the emitted
+    // phase.advance.held reason is "dependency-state-unknown" (a hydration failure,
+    // NOT a confirmed open dependency) and blockers is []. WITHOUT fix #2 the same
+    // branch would fall through to reason "blocked-by-open-dependency" with blockers
+    // = unmetBlockersFor(...) — which, on a null read with no edges, is [] but with
+    // the WRONG reason, conflating a read failure with a genuine dependency hold.
+    // The reason assertion below would then fail.
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws } = labelSpy();
+    const held = heldSpy();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchRelations: () => null, // read failed → fail-safe hold
+      appendPhaseAdvanceHeldEvent: held.fn,
+    });
+    expect(dispatch.calls).toEqual([]);
+    expect(r.advanced).toEqual([]);
+    expect(held.events).toHaveLength(1);
+    expect(held.events[0]).toMatchObject({
+      ticket: "CTL-7",
+      reason: "dependency-state-unknown",
+    });
+    // blockers must be EXACTLY [] (deep-equal), distinguishing a read-failure hold
+    // from a genuine open-dependency hold that names its unmet blocker ids.
+    expect(held.events[0].blockers).toEqual([]);
+    // And it must NOT carry the genuine-open-dependency reason.
+    expect(held.events[0].reason).not.toBe("blocked-by-open-dependency");
   });
 
   // ── STEP E: dep persistence (scheduler-side) ──
@@ -5812,7 +5924,7 @@ describe("CTL-755: admission gate", () => {
       liveness: { kind: "bg", value: "job-dead-7" },
     });
     const dispatch = fakeDispatch();
-    const { ws, removed } = labelSpy();
+    const { ws } = labelSpy();
     const r = schedulerTick(orchDir, {
       readEligible: () => [],
       dispatch,

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5421,6 +5421,107 @@ describe("CTL-755: admission gate", () => {
     expect(applied).toContainEqual({ ticket: "CTL-B", label: "needs-human" });
   });
 
+  test("triaged-blocks-triaged chain: the unblocked foundation promotes; the dependent is held 'blocked'", () => {
+    // CTL-A (foundation, no blocker) blocks CTL-B (dependent). Both are
+    // triaged-waiting in the SAME tick, so both land in admissionPool. The dep
+    // graph sees A→B with A non-terminal ("Triage") → B is NOT ready, A IS.
+    // Per design open-question #5: the chain must promote A and HOLD B, never
+    // promote B while its sibling blocker is still non-terminal.
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 3 }));
+    writeSignal("CTL-A", "triage", "done");
+    writeSignal("CTL-B", "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws, applied } = labelSpy();
+    const held = heldSpy();
+    // CTL-B is blocked_by CTL-A; CTL-A has no blocker. Both resolve in-set
+    // (they ARE the admissionPool descriptors), so no exec hydration needed.
+    const fr = relMap({
+      "CTL-A": relUnblocked(),
+      "CTL-B": relBlockedBy("CTL-A"),
+    });
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0, // 3 free slots — capacity is NOT the gate here
+      fetchRelations: fr,
+      appendPhaseAdvanceHeldEvent: held.fn,
+    });
+    // Only the foundation promotes; the dependent never reaches research.
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-A", phase: "research" }]);
+    expect(r.advanced).toEqual([{ ticket: "CTL-A", phase: "research" }]);
+    // CTL-B is held "blocked" (its in-set blocker CTL-A is still non-terminal),
+    // and the held event names CTL-A as the unmet blocker.
+    expect(applied).toContainEqual({ ticket: "CTL-B", label: "blocked" });
+    expect(applied).not.toContainEqual({ ticket: "CTL-A", label: "blocked" });
+    expect(applied).not.toContainEqual({ ticket: "CTL-A", label: "waiting" });
+    const bHeld = held.events.find((e) => e.ticket === "CTL-B");
+    expect(bHeld).toMatchObject({ reason: "blocked-by-open-dependency", blockers: ["CTL-A"] });
+  });
+
+  test("epic fan-out: while the foundation is non-terminal NO dependent leaves triage→research", () => {
+    // FOUND blocks three leaves L1/L2/L3 (the classic epic shape: one foundation
+    // ticket, three dependent features). All four are triaged-waiting this tick.
+    // FOUND is non-terminal → every leaf is held "blocked", none promotes; only
+    // FOUND (the root, ready) advances even though there are slots for all four.
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 6 }));
+    for (const t of ["CTL-FOUND", "CTL-L1", "CTL-L2", "CTL-L3"]) writeSignal(t, "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws, applied } = labelSpy();
+    const fr = relMap({
+      "CTL-FOUND": relUnblocked(),
+      "CTL-L1": relBlockedBy("CTL-FOUND"),
+      "CTL-L2": relBlockedBy("CTL-FOUND"),
+      "CTL-L3": relBlockedBy("CTL-FOUND"),
+    });
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0, // 6 free slots — capacity is NOT the gate
+      fetchRelations: fr,
+    });
+    // Exactly one promotion: the foundation. No leaf reaches research while its
+    // blocker is non-terminal — even with ample capacity.
+    expect(r.advanced).toEqual([{ ticket: "CTL-FOUND", phase: "research" }]);
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-FOUND", phase: "research" }]);
+    for (const leaf of ["CTL-L1", "CTL-L2", "CTL-L3"]) {
+      expect(applied).toContainEqual({ ticket: leaf, label: "blocked" });
+    }
+  });
+
+  test("epic fan-out: once the foundation is terminal (out-of-set Done) the leaves become ready", () => {
+    // Same fan-out, but the foundation has already finished — it is NOT in the
+    // triaged-waiting pool (no worker dir), so it is an OUT-OF-SET blocker
+    // hydrated via exec. A terminal (Done) out-of-set blocker no longer blocks →
+    // all three leaves are ready and (with capacity) promote.
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 6 }));
+    for (const t of ["CTL-L1", "CTL-L2", "CTL-L3"]) writeSignal(t, "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws, applied, removed } = labelSpy();
+    const fr = relMap({
+      "CTL-L1": relBlockedBy("CTL-FOUND"),
+      "CTL-L2": relBlockedBy("CTL-FOUND"),
+      "CTL-L3": relBlockedBy("CTL-FOUND"),
+    });
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchRelations: fr,
+      // CTL-FOUND is out-of-set; hydrate it Done so it no longer blocks.
+      exec: execWithStates({ "CTL-FOUND": "Done" }),
+    });
+    const promoted = r.advanced.map((a) => a.ticket).sort();
+    expect(promoted).toEqual(["CTL-L1", "CTL-L2", "CTL-L3"]);
+    // None held "blocked" once the foundation is terminal.
+    expect(applied.filter((a) => a.label === "blocked")).toEqual([]);
+  });
+
   test("double-fill guard: maxParallel 2, one triaged + one new-work → exactly 2 dispatches (not 3)", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
     writeSignal("CTL-7", "triage", "done"); // triaged-waiting, promotes to research

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -59,6 +59,7 @@ import {
   buildGlobalRanking,
 } from "./scheduler.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
+import { reclaimDeadWorkIfPossible } from "./recovery.mjs";
 import { REMEDIATE_CYCLE_CAP } from "../lib/phase-fsm.mjs";
 
 let orchDir;
@@ -5757,5 +5758,110 @@ describe("CTL-755: admission gate", () => {
       exec: execStates({ "CTL-100": "In Progress" }),
     });
     expect(relations).toEqual([{ ticket: "CTL-7", blockedBy: "CTL-100" }]);
+  });
+
+  // ── STEP D integration: dead-triage reclaim → STEP A re-eval → promotion ──
+  //
+  // The isolated recovery tests pin reclaim behaviour but never prove a reclaimed
+  // triage worker later ADVANCES. This integration test drives a real
+  // reclaimDeadWorkIfPossible (production wiring — scheduler.mjs:1624 passes only
+  // { repoRoot }) through a single schedulerTick and asserts the worker does NOT
+  // strand: the reclaim sweep flips the dead triage worker's signal to `done`,
+  // STEP A re-evaluates it as a triaged-waiting candidate, and STEP B promotes it
+  // (unblocked + free slot). The gate is enforced DOWNSTREAM at STEP B (which holds
+  // any triage:done worker not admitted), so flipping the signal to `done` never
+  // bypasses admission control. (Regression anchor for the CTL-755 strand bug where
+  // the now-removed `reclaim-held` early-return left the signal at `running`, which
+  // STEP A's `triage === "done"` pool then skipped forever.)
+
+  // A production-faithful reclaimDeadWork: the real reclaimDeadWorkIfPossible with
+  // the triage probe forced true (triage.json present → work done), a dead-gone
+  // statJob, and an emitComplete that flips the ON-DISK signal to `done` (what the
+  // real phase-agent-emit-complete --status complete does). The options bag matches
+  // production (no special-casing) — there is no admission predicate inside reclaim.
+  function prodTriageReclaim(orchDirArg) {
+    return (od, sig) =>
+      reclaimDeadWorkIfPossible(od, sig, {
+        statJob: () => null, // dead-gone → reclaim-eligible
+        probes: { triage: () => true, ...EMPTY_NONTRIAGE_PROBES },
+        emitComplete: ({ orchDir: o, signal }) => {
+          // Mirror the real closer: flip phase-<phase>.json.status → done.
+          const p = join(o ?? orchDirArg, "workers", signal.ticket, `phase-${signal.phase}.json`);
+          const cur = JSON.parse(readFileSync(p, "utf8"));
+          writeFileSync(p, JSON.stringify({ ...cur, status: "done" }));
+          return { code: 0 };
+        },
+        appendEvent: () => {},
+        postReclaimMirror: () => {},
+      });
+  }
+  // Probes for the non-triage phases the reclaim sweep may also see — never true
+  // here (no other dead workers), but keeps the probe bag total.
+  const EMPTY_NONTRIAGE_PROBES = { implement: () => false, research: () => false, plan: () => false };
+
+  test("STEP D integration: a dead triage:running worker (work done) is NOT stranded — reclaim flips it to done, STEP A re-evals, STEP B promotes (unblocked + free slot)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    // A dead triage worker whose signal never reached `done` (it died mid-flight
+    // with status running) but whose triage.json IS on disk (probe passes). This
+    // is the exact class the reclaim branch-B path exists to recover.
+    writeSignalRaw("CTL-7", "triage", {
+      ticket: "CTL-7",
+      phase: "triage",
+      status: "running",
+      bg_job_id: "job-dead-7",
+      liveness: { kind: "bg", value: "job-dead-7" },
+    });
+    const dispatch = fakeDispatch();
+    const { ws, removed } = labelSpy();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0, // a free slot
+      reclaimDeadWork: prodTriageReclaim(orchDir),
+      fetchRelations: () => relUnblocked(), // deps satisfied
+    });
+    // The reclaim sweep flipped the signal to done (no longer stranded at running).
+    expect(readPhaseSignals(orchDir, "CTL-7").triage).toBe("done");
+    // STEP A re-evaluated it as triaged-waiting and STEP B promoted it to research.
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "research" }]);
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
+  });
+
+  test("STEP D integration: a dead triage:running worker held by deps does NOT strand — reclaim flips to done, STEP A holds it 'blocked' (gate enforced downstream)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignalRaw("CTL-7", "triage", {
+      ticket: "CTL-7",
+      phase: "triage",
+      status: "running",
+      bg_job_id: "job-dead-7",
+      liveness: { kind: "bg", value: "job-dead-7" },
+    });
+    const dispatch = fakeDispatch();
+    const { ws, applied } = labelSpy();
+    const held = heldSpy();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      reclaimDeadWork: prodTriageReclaim(orchDir),
+      // CTL-7 is blocked by an out-of-set blocker still In Progress.
+      fetchRelations: () => relBlockedBy("CTL-DEP"),
+      exec: execWithStates({ "CTL-DEP": "In Progress" }),
+      appendPhaseAdvanceHeldEvent: held.fn,
+    });
+    // Signal still flipped to done (reclaim ran) — but research is HELD by the gate.
+    expect(readPhaseSignals(orchDir, "CTL-7").triage).toBe("done");
+    expect(dispatch.calls).toEqual([]); // STEP B held the research promotion
+    expect(r.advanced).toEqual([]);
+    expect(applied).toContainEqual({ ticket: "CTL-7", label: "blocked" });
+    expect(held.events[0]).toMatchObject({
+      ticket: "CTL-7",
+      reason: "blocked-by-open-dependency",
+      blockers: ["CTL-DEP"],
+    });
   });
 });

--- a/plugins/dev/scripts/lib/dependency-graph.mjs
+++ b/plugins/dev/scripts/lib/dependency-graph.mjs
@@ -10,7 +10,7 @@
 
 // Statuses treated as finished. A finished issue never blocks a dependent and
 // never appears in the ready/blocked sets. Override via options.terminalStatuses.
-const DEFAULT_TERMINAL_STATUSES = ["Done", "Canceled"];
+export const DEFAULT_TERMINAL_STATUSES = ["Done", "Canceled"];
 
 // buildDependencyEdges — normalize Linear relations into canonical directed
 // edges (CTL-530). An edge is kept when both endpoints are in-set, OR (CTL-565

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-held-indicator.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-held-indicator.test.ts
@@ -1,0 +1,108 @@
+// board-held-indicator.test.ts — CTL-755 SLICE 4 (board surfacing).
+//
+// The admission-control gate (scheduler STEP A) holds a triaged-waiting ticket
+// before the triage→research promotion and tags it with a Linear label:
+//   • `blocked` — ≥1 non-terminal blocked_by dependency.
+//   • `waiting` — deps satisfied, but it lost the priority/capacity selection.
+// This board slice reads those labels (already returned by the cached
+// `linearis issues list` call) and renders a distinct held chip so an operator
+// sees at a glance the ticket is HELD, not silently mid-triage.
+//
+// This file pins:
+//   1. heldFor() label-classification (pure data-layer helper).
+//   2. The held label constants do NOT drift across the three copies:
+//      scheduler.mjs (daemon writer) ⇄ board-data.mjs (reader) ⇄ Board.tsx (UI).
+//   3. Board.tsx actually wires the held indicator into the ticket card.
+
+import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { heldFor, HELD_LABEL_BLOCKED, HELD_LABEL_WAITING } from "../lib/board-data.mjs";
+
+// Source of truth: the daemon-side label writer (execution-core/scheduler.mjs).
+// We read it as TEXT rather than import it — the scheduler is a large daemon
+// module with no .d.mts, so importing it under the typechecked test package
+// would trip TS7016. This mirrors how board-phase-drift.test.ts reads Board.tsx
+// as text. We extract the two `export const HELD_LABEL_* = "…"` literals.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCHED_SRC = readFileSync(
+  join(HERE, "..", "..", "execution-core", "scheduler.mjs"),
+  "utf8",
+);
+function schedLabel(name: string): string {
+  // eslint-disable-next-line security/detect-non-literal-regexp
+  const m = new RegExp(`export\\s+const\\s+${name}\\s*=\\s*"([^"]+)"`).exec(SCHED_SRC);
+  if (!m) throw new Error(`board-held-indicator: could not locate \`export const ${name}\` in scheduler.mjs`);
+  return m[1];
+}
+const SCHED_BLOCKED = schedLabel("HELD_LABEL_BLOCKED");
+const SCHED_WAITING = schedLabel("HELD_LABEL_WAITING");
+
+// ── 1. heldFor() classification ──────────────────────────────────────────────
+test("heldFor → 'blocked' when the blocked label is present", () => {
+  expect(heldFor(["blocked"])).toBe("blocked");
+  expect(heldFor(["feature", "orchestrator", "blocked"])).toBe("blocked");
+});
+
+test("heldFor → 'waiting' when only the waiting label is present", () => {
+  expect(heldFor(["waiting"])).toBe("waiting");
+  expect(heldFor(["chore", "waiting"])).toBe("waiting");
+});
+
+test("heldFor → 'blocked' wins when both labels are somehow present (more severe)", () => {
+  expect(heldFor(["waiting", "blocked"])).toBe("blocked");
+  expect(heldFor(["blocked", "waiting"])).toBe("blocked");
+});
+
+test("heldFor → null for a ticket with no held label", () => {
+  expect(heldFor(["feature", "orchestrator"])).toBeNull();
+  expect(heldFor([])).toBeNull();
+});
+
+test("heldFor → null for missing / non-array input (graceful)", () => {
+  expect(heldFor(undefined)).toBeNull();
+  expect(heldFor(null)).toBeNull();
+  // A bare (non-array) string is NOT a label set → not held (no throw).
+  expect(heldFor("blocked")).toBeNull();
+});
+
+// ── 2. cross-copy drift guard ────────────────────────────────────────────────
+test("board-data held labels equal scheduler.mjs source of truth (no drift)", () => {
+  if (HELD_LABEL_BLOCKED !== SCHED_BLOCKED || HELD_LABEL_WAITING !== SCHED_WAITING) {
+    throw new Error(
+      `DRIFT: lib/board-data.mjs held labels diverged from execution-core/scheduler.mjs.\n` +
+        `  scheduler:  blocked=${JSON.stringify(SCHED_BLOCKED)} waiting=${JSON.stringify(SCHED_WAITING)}\n` +
+        `  board-data: blocked=${JSON.stringify(HELD_LABEL_BLOCKED)} waiting=${JSON.stringify(HELD_LABEL_WAITING)}\n` +
+        `The daemon writes these labels and the board reads them — they must match. ` +
+        `scheduler.mjs is the source of truth.`,
+    );
+  }
+  expect(HELD_LABEL_BLOCKED).toBe(SCHED_BLOCKED);
+  expect(HELD_LABEL_WAITING).toBe(SCHED_WAITING);
+});
+
+// ── Board.tsx text extraction (cannot import — pulls React + "@/…" aliases) ───
+const BOARD_TSX = readFileSync(join(HERE, "..", "ui", "src", "board", "Board.tsx"), "utf8");
+
+test("Board.tsx held label constants equal scheduler.mjs source of truth (no drift)", () => {
+  const grab = (name: string) => {
+    // eslint-disable-next-line security/detect-non-literal-regexp
+    const m = new RegExp(`const\\s+${name}\\s*=\\s*"([^"]+)"`).exec(BOARD_TSX);
+    if (!m) throw new Error(`board-held-indicator: could not locate \`const ${name}\` in Board.tsx`);
+    return m[1];
+  };
+  expect(grab("HELD_LABEL_BLOCKED")).toBe(SCHED_BLOCKED);
+  expect(grab("HELD_LABEL_WAITING")).toBe(SCHED_WAITING);
+});
+
+// ── 3. Board.tsx renders the held indicator ──────────────────────────────────
+test("Board.tsx defines a HeldBadge and wires it from the ticket's held field", () => {
+  expect(BOARD_TSX).toContain("function HeldBadge");
+  // The chip is rendered in TicketCard from t.held (+ t.blockers).
+  expect(BOARD_TSX).toContain("<HeldBadge held={t.held} blockers={t.blockers} />");
+  // It distinguishes blocked vs waiting with the pause glyph.
+  expect(BOARD_TSX).toContain("⏸ blocked");
+  expect(BOARD_TSX).toContain("⏸ waiting");
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -66,6 +66,10 @@ export interface BoardTicket {
   phaseSummary: BoardPhaseTiming[];
   pr: number | null;
   updatedAt: string;
+  /** CTL-755 held indicator from the ticket's Linear labels. */
+  held: "blocked" | "waiting" | null;
+  /** Dependency ids a `blocked` hold is waiting on (from triage.json). */
+  blockers: string[];
 }
 
 export interface BoardQueueItem {
@@ -103,6 +107,9 @@ export interface BoardPayload {
 export const PHASE_ORDER: string[];
 export const PHASE_TO_LINEAR: Record<string, string>;
 export const TERMINAL: Set<string>;
+export const HELD_LABEL_BLOCKED: string;
+export const HELD_LABEL_WAITING: string;
+export function heldFor(labels: unknown): "blocked" | "waiting" | null;
 export function buildPhaseSummary(phaseSigs: unknown[], now: number): BoardPhaseTiming[];
 export function deriveCurrentPhase(phaseSigs: unknown[]): BoardCurrentPhase;
 export function assembleBoard(): Promise<BoardPayload>;

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -42,6 +42,30 @@ export const TERMINAL = new Set([
   "done", "failed", "stalled", "skipped", "signal_corrupt", "superseded", "canceled",
 ]);
 
+// CTL-755 held-indicator labels (admission-control gate). A triaged-waiting
+// ticket the scheduler holds before the triage→research promotion carries one of
+// these Linear labels: `blocked` (≥1 non-terminal blocked_by dependency) or
+// `waiting` (deps satisfied but it lost the priority/capacity selection this
+// tick). The scheduler converges them ON A DIFF (apply/remove) and clears BOTH
+// on pickup. These two strings MUST stay in lock-step with
+// execution-core/scheduler.mjs HELD_LABEL_BLOCKED / HELD_LABEL_WAITING — the
+// board-held-indicator drift guard asserts that, so the board reads the same
+// label the daemon writes (we copy the literals rather than import the whole
+// scheduler module into the lightweight board data layer).
+export const HELD_LABEL_BLOCKED = "blocked";
+export const HELD_LABEL_WAITING = "waiting";
+
+// heldFor — classify a ticket's held state from its Linear label set. `blocked`
+// wins over `waiting` when both are somehow present (it is the more severe hold;
+// steady-state convergence only ever leaves one applied). Returns "blocked" |
+// "waiting" | null. Pure + exported so it is unit-testable.
+export function heldFor(labels) {
+  const set = new Set(Array.isArray(labels) ? labels : []);
+  if (set.has(HELD_LABEL_BLOCKED)) return HELD_LABEL_BLOCKED;
+  if (set.has(HELD_LABEL_WAITING)) return HELD_LABEL_WAITING;
+  return null;
+}
+
 // phase → Linear workflow state (board columns for the Tickets/Linear lens).
 export const PHASE_TO_LINEAR = {
   triage: "Research", research: "Research", plan: "Plan", implement: "Implement",
@@ -222,6 +246,14 @@ function ticketTitle(ticket, triage, eligibleIndex) {
   return ticket;
 }
 const ticketType = (triage) => triage?.classification || triage?.type || "task";
+// CTL-755: the scraped dependency ids triage recorded (flat string[] or rich
+// [{id}] — readTriageDependencies in the scheduler tolerates both, so we do too).
+// Surfaced as the held card's `blockers` so a `blocked` chip can name WHAT it is
+// waiting on, without the board taking on a second (event-log) data source.
+const ticketBlockers = (triage) =>
+  (Array.isArray(triage?.dependencies) ? triage.dependencies : [])
+    .map((d) => (typeof d === "string" ? d : d?.id))
+    .filter(Boolean);
 // triage's coarse size estimate (xs/small/medium/large/xl) — present once a
 // ticket has been triaged; the closest thing to a Linear estimate for CTL.
 const ticketScope = (triage) => triage?.estimated_scope || null;
@@ -252,6 +284,10 @@ async function linearInfo() {
           priority: typeof n.priority === "number" ? n.priority : 0,
           estimate: n.estimate ?? null,
           project: n.project?.name || (typeof n.project === "string" ? n.project : null),
+          // CTL-755: label names for the held indicator (blocked/waiting). The
+          // same cached list call already returns labels.nodes[].name, so this
+          // costs zero extra Linear traffic.
+          labels: (n.labels?.nodes ?? []).map((l) => l?.name).filter(Boolean),
         };
       }
     } catch { /* linearis unavailable — leave this team unenriched */ }
@@ -420,6 +456,12 @@ export async function assembleBoard() {
       priority: linfo[id]?.priority ?? 0,
       estimate: linfo[id]?.estimate ?? null, scope: ticketScope(triage),
       project: linfo[id]?.project ?? null,
+      // CTL-755 held indicator: "blocked" | "waiting" | null, read from the
+      // ticket's Linear labels (the scheduler's admission gate writes them).
+      // `blockers` names the dependencies a `blocked` hold is waiting on (only
+      // meaningful when held === "blocked"); empty otherwise.
+      held: heldFor(linfo[id]?.labels),
+      blockers: ticketBlockers(triage),
       costUSD: costs[id]?.costUSD ?? null, tokens: costs[id]?.tokens ?? null,
       turns: phaseCostsByTicket[id]
         ? Object.values(phaseCostsByTicket[id]).reduce((s, p) => s + p.turns, 0)

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
@@ -51,6 +51,12 @@ const WORKER_COLS = [
 // terminal status added there cannot silently render here as a live phase
 // (CTL-754).
 const TERMINAL_STATUSES = ["done", "failed", "stalled", "skipped", "signal_corrupt", "superseded", "canceled"];
+// CTL-755 held-indicator label names. MUST stay in lock-step with
+// execution-core/scheduler.mjs HELD_LABEL_BLOCKED / HELD_LABEL_WAITING (and the
+// board-data.mjs copies) — the board-held-indicator drift guard asserts all
+// three agree, so the badge below reads exactly the label the daemon writes.
+const HELD_LABEL_BLOCKED = "blocked";
+const HELD_LABEL_WAITING = "waiting";
 
 type ColorBy = "phase" | "status" | "repo" | "type";
 const TYPE_C: Record<string, string> = {
@@ -191,6 +197,31 @@ function StatusBadge({ status }: { status: string }) {
   if (!m) return null;
   return <span style={{ fontFamily: C.mono, fontSize: 10, padding: "1.5px 7px", borderRadius: 6, color: m.fg, background: m.bg, whiteSpace: "nowrap" }}>{m.label}</span>;
 }
+// CTL-755: held indicator. A triaged-waiting ticket the admission gate is
+// holding before the triage→research promotion carries a `blocked` or `waiting`
+// Linear label. We render a distinct amber "⏸" chip so an operator sees at a
+// glance the ticket is HELD on a dependency (blocked, names the blocker ids) vs
+// merely awaiting capacity/priority (waiting) — NOT silently mid-triage.
+function HeldBadge({ held, blockers }: { held: "blocked" | "waiting" | null | undefined; blockers?: string[] }) {
+  if (held !== HELD_LABEL_BLOCKED && held !== HELD_LABEL_WAITING) return null;
+  const isBlocked = held === HELD_LABEL_BLOCKED;
+  const fg = isBlocked ? "#f4a8a8" : "#f4dc8a";
+  const bg = isBlocked ? "rgba(239,93,93,0.14)" : "rgba(234,188,59,0.14)";
+  const ids = (blockers ?? []).filter(Boolean);
+  const label = isBlocked
+    ? `⏸ blocked${ids.length ? `: ${ids.join(", ")}` : ""}`
+    : "⏸ waiting";
+  const tip = isBlocked
+    ? ids.length
+      ? `Held — blocked on open dependency: ${ids.join(", ")}`
+      : "Held — blocked on an open dependency"
+    : "Held — deps satisfied, awaiting capacity or priority";
+  return (
+    <Tooltip><TooltipTrigger asChild>
+      <span style={{ fontFamily: C.mono, fontSize: 10, padding: "1.5px 7px", borderRadius: 6, color: fg, background: bg, whiteSpace: "nowrap", maxWidth: 180, overflow: "hidden", textOverflow: "ellipsis", display: "inline-block" }}>{label}</span>
+    </TooltipTrigger><TooltipContent style={{ fontFamily: C.mono, fontSize: 11 }}>{tip}</TooltipContent></Tooltip>
+  );
+}
 function Cost({ v }: { v: number | null }) {
   return <span style={{ fontFamily: C.mono, fontVariantNumeric: "tabular-nums", fontSize: 10.5, color: v == null ? C.fgDim : C.fgMuted }}>{v == null ? "—" : `$${v.toFixed(2)}`}</span>;
 }
@@ -231,6 +262,7 @@ function TicketCard({ t, colorBy, onSelect }: { t: Ticket; colorBy: ColorBy; onS
       <TitleText text={t.title} />
       <div style={{ display: "flex", alignItems: "center", gap: 7, flexWrap: "wrap" }}>
         <PhasePill phase={t.phase} />
+        <HeldBadge held={t.held} blockers={t.blockers} />
         <StatusBadge status={t.status} />
         <ScopeChip scope={t.scope} estimate={t.estimate} />
         {t.project && <Badge variant="outline" style={{ fontSize: 10, color: C.fgDim }}>{t.project}</Badge>}

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
@@ -60,6 +60,11 @@ export interface BoardTicket {
   pr: number | null;
   updatedAt: string;
   subSteps?: WorkflowSubStep[];
+  /** CTL-755 held indicator from the ticket's Linear labels: the admission gate
+   *  holds a triaged-waiting ticket before the triage→research promotion. */
+  held?: "blocked" | "waiting" | null;
+  /** Dependency ids a `blocked` hold is waiting on (only meaningful when held === "blocked"). */
+  blockers?: string[];
 }
 
 export interface WorkflowSubStep {

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -302,6 +302,37 @@ then skips the Linear estimate write for this ticket (Q4 design decision: no SCO
 fallback for the Linear estimate field). The bash body intentionally does **not** write `estimate`
 (CTL-558 guard).
 
+**2c. Validate the scraped dependencies — READ-ONLY (CTL-755).** The bash body's `2d` step scrapes
+every `TEAM-NNN` token from the body into a flat `dependencies` array but does NOT verify any of them
+resolve to a real ticket. When running in Opus mode, enrich each scraped id using **read-only**
+`linearis issues read <id>` so the richer shape carries existence + the blocker's current state:
+
+```jsonc
+"dependencies": [
+  { "id": "CTL-447", "exists": true,  "blockerState": "In Progress" },
+  { "id": "CTL-9999", "exists": false, "blockerState": null }
+]
+```
+
+For each id, run `linearis issues read <id>` (the same read the bash body already uses for the
+ticket itself). On a successful read, set `exists: true` and `blockerState` to the ticket's
+`state.name`; on a non-zero exit / unparseable output (a prose token that merely matched the
+`TEAM-NNN` regex but is not a real ticket), set `exists: false`, `blockerState: null`. Re-write
+`triage.json` with the enriched `dependencies`. This is purely advisory metadata — the durable
+ordering edge is written **scheduler-side** (see the hard constraint below), so a missing/extra
+entry here can never deadlock the pipeline.
+
+**Hard constraint — the skill makes ZERO Linear writes for dependencies.** Do NOT call
+`linearis issues update ... --blocked-by` (or any `linearis issues update`) from this skill. The
+admission gate's durable `blocked_by` persistence lives in the execution-core scheduler (CTL-755
+STEP E, `scheduler.mjs` — it reads `triage.json.dependencies`, re-validates each token via
+`fetchTicketState`, drops unresolvable/terminal/cycle-closing tokens, and writes the durable edge
+with `applyBlockedByRelation`). Keeping the write scheduler-side preserves the CTL-497/CTL-558
+contract — the phase-triage e2e negative guard (`phase-triage-e2e.test.sh:172`) fails the build if
+this skill ever emits a `linearis issues update` call. `linearis issues read` is read-only and is
+fine. Because STEP E tolerates BOTH the flat-string and the rich `{id}` shapes, emitting the rich
+shape here is forward-compatible and changes nothing scheduler-side.
+
 3. If the refined fields differ materially, post a follow-up `linearis issues discuss` comment
    marking the refinement.
 


### PR DESCRIPTION
## What & why

Fixes **CTL-755**: the execution-core daemon did not respect dependency ordering — dependents advanced through the pipeline before their blockers were Done (observed on the ADV-1274 epic, where a ticket transitively blocked by a still-untriaged foundation reached Validate).

Root cause: the dependency gate was wired in **one place only** — the new-work pull. Once the monitor dispatched triage (ungated) and created a worker dir, the **advancement sweep** free-promoted the ticket `triage → research` from signal files alone, consulting neither dependencies, priority, nor capacity.

## Operator-clarified semantics (broader than the original ticket)

Triage is **universal intake** (always runs — it's how dependencies are even identified). The `triage → research` promotion is now **admission-controlled exactly like new work**: a triaged ticket waits until **(1) all dependencies are terminal, (2) it's selected by the priority algorithm, and (3) a slot is free**. Implemented by **reusing the existing new-work-pull primitives** (`hydrateOutOfSetBlockers`, `analyzeDependencyGraph`/`computeReadySet`+D5, `rankTickets`, `selectDispatchablePerProject`, `computeFreeSlots`) — no new admission logic invented.

## How it works (gate-in-place)

- **STEP A** (per-tick, above the advancement sweep): build the `triagedWaiting` pool from worker dirs (triage `done`, no research signal), hydrate each candidate's live Linear state/relations/priority/labels via a new `fetchTicketRelations`, run them through the shared dep+rank+slot selection → `admittedThisTick`. Early-exits (zero Linear cost) when no ticket is waiting.
- **STEP B**: one gate line on the `triage → research` edge — `if (next === NEW_WORK_ENTRY_PHASE && signals.triage === "done" && !admittedThisTick.has(ticket)) continue;`. Every other advancement edge stays free. Held tickets get **no** premature Research/estimate write; they auto-promote the moment they're unblocked + selected.
- **STEP C**: `promotedCount` is subtracted from both the resume-sweep and new-work freeSlots (symmetric to CTL-705's `resumedCount`) so a promotion can't double-fill a slot.
- **Held indicator** (operator-requested, distinguishes the two cases): two Linear **labels**, `blocked` (≥1 non-terminal dependency) and `waiting` (deps satisfied, lost priority/capacity selection), converged **on-diff** via `applyLabel`/`removeLabel` (not `labelOnce`) and **cleared on pickup**. Plus a `phase.advance.held.<ticket>` event and an orch-monitor board badge. No new Linear workflow state (keeps the state machine JOB 2 is hardening untouched).
- **Cycle deps** → `needs-human` (no silent deadlock). **Reclaim** of a dead triage worker reclaims normally; the downstream STEP-B gate (not reclaim) owns admission, so a reclaimed-but-blocked ticket is held, never stranded.
- **Triage dep persistence** (STEP E, scheduler-side per CTL-497): validated `blocked_by` edges are written durably so the gate consumes them; the phase-triage skill stays read-only (CTL-558 negative guard intact).

## How it was built & verified

Design pass (9-agent workflow: map → 3 independent designs → adversarial synthesis) → implement workflow (4 slices → test-harden → 4-lens adversarial review → remediation) → residual fixes → **final independent adversarial review: SHIP**.

- **Tests:** dependency-graph 48, scheduler 323, recovery 172, linear-query 39, board-held-indicator 8 — **590 pass, 0 fail** (targeted suites; baselines were 48/299/169). New coverage: epic fan-out, triaged-blocks-triaged chain, D5 fail-safe, double-fill guards (promotion↔new-work **and** promotion↔resume), capacity hold→promote, circular→needs-human, staleness-holds, reclaim no-strand, clear-on-pickup, idempotent steady-state, dep persistence.
- **1 HIGH found & fixed** in review (an early reclaim-held design would have permanently stranded a dead triage worker — removed; gate is downstream). 1 MEDIUM (promotion↔resume double-fill) + LOWs (dedup terminal-state set, distinct read-fail reason, comment fix) all addressed.
- **CTL-706 preserved:** the fragile sweep-2 `computeReadyTickets` input and `selectDispatchablePerProject` exclude arg are byte-for-byte unchanged.

## ⚠️ Setup needed before the gate runs live

Create two issue labels in **CTL** and **ADV** teams: `blocked` and `waiting` (`linearis` can't create labels → GraphQL `issueLabelCreate`). I'll do this as part of the cache-hotpatch + daemon-resume step after merge.

Design doc: `thoughts/shared/plans/2026-06-03-ctl-755-admission-control-gate.md`.