### PR TITLE
feat(dev): CTL-760 per-worker OpenTelemetry for the background-worker execution model

### DIFF
--- a/plugins/dev/scripts/__tests__/canonical-event.test.sh
+++ b/plugins/dev/scripts/__tests__/canonical-event.test.sh
@@ -324,6 +324,27 @@ expect_eq "build_canonical_line claude.turn" "126" "$CLAUDE_TURN"
 CLAUDE_TURN_TYPE="$(echo "$CLAUDE_LINE" | jq -r '.attributes."claude.turn" | type')"
 expect_eq "build_canonical_line claude.turn is number" "number" "$CLAUDE_TURN_TYPE"
 
+# CTL-760: rate-limit 5h/7d used-percentages emitted as NUMERIC typed attributes.
+RL_LINE="$(build_canonical_line \
+  --ts "2026-06-03T00:00:00.000Z" \
+  --severity INFO \
+  --service "catalyst.session" \
+  --event-name "session.context" \
+  --claude-ratelimit-5h-pct 26 \
+  --claude-ratelimit-7d-pct 15)"
+
+RL_5H="$(echo "$RL_LINE" | jq -r '.attributes."claude.ratelimit.five_hour_pct"')"
+expect_eq "build_canonical_line claude.ratelimit.five_hour_pct" "26" "$RL_5H"
+
+RL_5H_TYPE="$(echo "$RL_LINE" | jq -r '.attributes."claude.ratelimit.five_hour_pct" | type')"
+expect_eq "build_canonical_line claude.ratelimit.five_hour_pct is number" "number" "$RL_5H_TYPE"
+
+RL_7D="$(echo "$RL_LINE" | jq -r '.attributes."claude.ratelimit.seven_day_pct"')"
+expect_eq "build_canonical_line claude.ratelimit.seven_day_pct" "15" "$RL_7D"
+
+RL_7D_TYPE="$(echo "$RL_LINE" | jq -r '.attributes."claude.ratelimit.seven_day_pct" | type')"
+expect_eq "build_canonical_line claude.ratelimit.seven_day_pct is number" "number" "$RL_7D_TYPE"
+
 # When claude.* flags are NOT passed, the attribute keys must be absent.
 BARE_LINE="$(build_canonical_line \
   --ts "2026-05-13T00:00:00.000Z" \
@@ -345,6 +366,13 @@ expect_eq "no --claude-context-tokens → key absent" "false" "$HAS_TOKENS"
 
 HAS_TURN="$(echo "$BARE_LINE" | jq '.attributes | has("claude.turn")')"
 expect_eq "no --claude-turn → key absent" "false" "$HAS_TURN"
+
+# CTL-760: rate-limit attrs absent when flags not passed.
+HAS_RL5H="$(echo "$BARE_LINE" | jq '.attributes | has("claude.ratelimit.five_hour_pct")')"
+expect_eq "no --claude-ratelimit-5h-pct → key absent" "false" "$HAS_RL5H"
+
+HAS_RL7D="$(echo "$BARE_LINE" | jq '.attributes | has("claude.ratelimit.seven_day_pct")')"
+expect_eq "no --claude-ratelimit-7d-pct → key absent" "false" "$HAS_RL7D"
 
 # Cost MUST NOT be a typed attribute (PII gate — OTLP forwarder strips body.payload only).
 HAS_COST_ATTR="$(echo "$CLAUDE_LINE" | jq '.attributes | has("claude.cost.usd")')"

--- a/plugins/dev/scripts/__tests__/catalyst-claude-task-type.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-claude-task-type.test.sh
@@ -99,6 +99,16 @@ else
   fail "task.type=interactive" "OUT: $OUT"
 fi
 
+# ─── Test 2b (CTL-760): catalyst.exec_context=interactive in OTEL attrs
+echo ""
+echo "Test 2b: catalyst.exec_context=interactive appended to OTEL attrs"
+OUT=$(run_wrapper t2b "/catalyst-dev:create-plan")
+if [[ "$OUT" == *"catalyst.exec_context=interactive"* ]]; then
+  pass "catalyst.exec_context=interactive present in OTEL_RESOURCE_ATTRIBUTES"
+else
+  fail "catalyst.exec_context=interactive" "OUT: $OUT"
+fi
+
 # ─── Test 3: --skill flag wins over leading slash
 echo ""
 echo "Test 3: --skill flag is the SKILL source"
@@ -120,8 +130,12 @@ OUT=$(
 )
 # Extract just the OTEL line (between --OTEL-- and --END-- markers).
 OTEL_LINE=$(printf '%s\n' "$OUT" | awk '/^--OTEL--$/{flag=1; next} /^--END--$/{flag=0} flag')
-if [[ "$OTEL_LINE" == "task.type=preset" ]]; then
-  pass "parent shell's task.type=preset preserved exactly"
+# CTL-760: the parent's task.type value must still win (first-writer-wins), and
+# task.type must appear exactly once. The exec_context append is additive and
+# orthogonal, so the line may now also carry catalyst.exec_context=interactive.
+TASK_TYPE_COUNT=$(printf '%s' "$OTEL_LINE" | grep -oE 'task\.type=' | wc -l | tr -d ' ')
+if [[ "$OTEL_LINE" == *"task.type=preset"* && "$TASK_TYPE_COUNT" == "1" ]]; then
+  pass "parent shell's task.type=preset preserved (task.type appears once)"
 else
   fail "parent shell's task.type=preset preserved" "OTEL line: '$OTEL_LINE'"
 fi

--- a/plugins/dev/scripts/__tests__/catalyst-session-claude.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-session-claude.test.sh
@@ -124,6 +124,48 @@ expect_eq "cost is NOT a typed attribute" "false" "$CTX_COST_ATTR_PRESENT"
 CTX_MAX_PAYLOAD="$(printf '%s' "$CTX_LINE" | jq -r '.body.payload.context_max')"
 expect_eq "context_max lives in body.payload" "1000000" "$CTX_MAX_PAYLOAD"
 
+# ─── 5b. CTL-760: rate-limit 5h/7d percentages + resets + resource.linear.key ─
+# Start a session bound to a ticket so the session.context resource block
+# carries linear.key (the per-worker join key for Grafana panels).
+SID_RL="$(bash "$SESSION_SCRIPT" start --skill phase-implement \
+            --ticket CTL-760 --claude-session-id "uuid-rl-1")"
+
+bash "$SESSION_SCRIPT" emit-context "$SID_RL" \
+  --context-pct 30 --turn 7 --model "claude-opus-4-7" \
+  --ratelimit-5h-pct 26 --ratelimit-7d-pct 15 \
+  --ratelimit-5h-reset "2026-06-03T05:00:00Z" \
+  --ratelimit-7d-reset "2026-06-10T00:00:00Z" >/dev/null
+
+RL_LINE="$(grep '"session.context"' "$EF" | grep "$SID_RL" | tail -n 1)"
+expect_not_empty "session.context event recorded for rate-limit test" "$RL_LINE"
+
+RL_5H="$(printf '%s' "$RL_LINE" | jq -r '.attributes."claude.ratelimit.five_hour_pct"')"
+expect_eq "session.context claude.ratelimit.five_hour_pct" "26" "$RL_5H"
+
+RL_5H_TYPE="$(printf '%s' "$RL_LINE" | jq -r '.attributes."claude.ratelimit.five_hour_pct" | type')"
+expect_eq "five_hour_pct is a number" "number" "$RL_5H_TYPE"
+
+RL_7D="$(printf '%s' "$RL_LINE" | jq -r '.attributes."claude.ratelimit.seven_day_pct"')"
+expect_eq "session.context claude.ratelimit.seven_day_pct" "15" "$RL_7D"
+
+RL_7D_TYPE="$(printf '%s' "$RL_LINE" | jq -r '.attributes."claude.ratelimit.seven_day_pct" | type')"
+expect_eq "seven_day_pct is a number" "number" "$RL_7D_TYPE"
+
+# Reset timestamps travel in body.payload only (informational, no label cardinality).
+RL_5H_RESET="$(printf '%s' "$RL_LINE" | jq -r '.body.payload.ratelimit_5h_reset')"
+expect_eq "5h reset in body.payload" "2026-06-03T05:00:00Z" "$RL_5H_RESET"
+
+RL_7D_RESET="$(printf '%s' "$RL_LINE" | jq -r '.body.payload.ratelimit_7d_reset')"
+expect_eq "7d reset in body.payload" "2026-06-10T00:00:00Z" "$RL_7D_RESET"
+
+# Resets MUST NOT be typed attributes (avoid label cardinality explosion).
+RL_5H_RESET_ATTR="$(printf '%s' "$RL_LINE" | jq -r '.attributes | has("claude.ratelimit.five_hour_reset")')"
+expect_eq "5h reset is NOT a typed attribute" "false" "$RL_5H_RESET_ATTR"
+
+# CTL-760: per-worker linear.key lands in the resource block.
+RL_LINEAR_KEY="$(printf '%s' "$RL_LINE" | jq -r '.resource."linear.key" // ""')"
+expect_eq "session.context resource.linear.key populated from ticket" "CTL-760" "$RL_LINEAR_KEY"
+
 # ─── 6. No threshold crossing below 70 — only session.context emitted ──────
 SID_BELOW="$(bash "$SESSION_SCRIPT" start --skill below70 \
               --claude-session-id "uuid-below")"

--- a/plugins/dev/scripts/__tests__/catalyst-statusline.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-statusline.test.sh
@@ -128,6 +128,48 @@ if [[ -n "$CTX_LINE" ]]; then
   expect_eq "wrapper-emitted cost in body.payload" "23.02" "$COST"
 fi
 
+# ─── 3b. CTL-760: rate-limit 5h/7d % forwarded to catalyst-session.sh ───────
+# Stub catalyst-session.sh via CATALYST_SESSION_BIN to capture the argv the
+# wrapper forwards. The stub records its args and exits 0 so the foreground
+# render path is unaffected.
+RL_CAPTURE="$SCRATCH/rl-emit-args.log"
+RL_SESSION_STUB="$MOCK_BIN_DIR/mock-session-rl.sh"
+cat > "$RL_SESSION_STUB" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$RL_CAPTURE"
+exit 0
+STUB
+chmod +x "$RL_SESSION_STUB"
+
+# Build an input that carries the rate_limits block Claude Code's statusLine
+# payload provides (proven from ccstatusline's input schema).
+RL_STATUS_JSON='{
+  "session_id": "claude-uuid-aaaa",
+  "model": {"id": "claude-opus-4-7"},
+  "context_window": {"used_percentage": 24, "current_usage": 245000},
+  "rate_limits": {
+    "five_hour":  {"used_percentage": 26, "resets_at": "2026-06-03T05:00:00Z"},
+    "seven_day":  {"used_percentage": 15, "resets_at": "2026-06-10T00:00:00Z"}
+  }
+}'
+
+CATALYST_SESSION_BIN="$RL_SESSION_STUB" \
+  bash "$WRAPPER" >/dev/null 2>&1 <<<"$RL_STATUS_JSON"
+
+# Wait for the background emit to land.
+RL_WAITED=0
+while (( RL_WAITED < 20 )); do
+  [[ -f "$RL_CAPTURE" ]] && break
+  sleep 0.25
+  RL_WAITED=$((RL_WAITED + 1))
+done
+
+RL_ARGS="$(cat "$RL_CAPTURE" 2>/dev/null | tr '\n' ' ')"
+expect_contains "wrapper forwards --ratelimit-5h-pct 26 to catalyst-session.sh" "$RL_ARGS" "--ratelimit-5h-pct 26"
+expect_contains "wrapper forwards --ratelimit-7d-pct 15 to catalyst-session.sh" "$RL_ARGS" "--ratelimit-7d-pct 15"
+expect_contains "wrapper forwards --ratelimit-5h-reset to catalyst-session.sh" "$RL_ARGS" "--ratelimit-5h-reset 2026-06-03T05:00:00Z"
+expect_contains "wrapper forwards --ratelimit-7d-reset to catalyst-session.sh" "$RL_ARGS" "--ratelimit-7d-reset 2026-06-10T00:00:00Z"
+
 # ─── 4. Resilience: even if emit fails, wrapper still renders ───────────────
 # Point the session script at a bogus path so emit silently fails.
 export CATALYST_SESSION_BIN="/does/not/exist-$$"

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -644,7 +644,7 @@ DRY=$(cd "${TEST_DIR}/proj" &&
 	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run 2>/dev/null)
 OTEL_ENTRY=$(echo "$DRY" | jq -r '.env[] | select(startswith("OTEL_RESOURCE_ATTRIBUTES="))')
 assert_eq \
-	"OTEL_RESOURCE_ATTRIBUTES=project=test-proj,linear.key=CTL-100,catalyst.orchestration=orch-test,branch=orch-test-CTL-100,task.type=phase-triage" \
+	"OTEL_RESOURCE_ATTRIBUTES=project=test-proj,linear.key=CTL-100,catalyst.orchestration=orch-test,branch=orch-test-CTL-100,task.type=phase-triage,catalyst.exec_context=phase-bg" \
 	"$OTEL_ENTRY" \
 	"dry-run JSON env array carries the composed OTEL attribute string"
 
@@ -669,6 +669,11 @@ touch "${TEST_DIR}/proj/thoughts/shared/plans/2026-05-18-ctl-100.md"
 LOG=$(cat "$CLAUDE_STUB_LOG")
 assert_contains "$LOG" ",task.type=phase-implement" \
 	"task.type=phase-implement appended with projectKey present"
+
+# CTL-760: catalyst.exec_context=phase-bg rides the OTEL attrs so every bg
+# phase metric slices by launch mode (phase-bg vs interactive).
+assert_contains "$LOG" ",catalyst.exec_context=phase-bg" \
+	"catalyst.exec_context=phase-bg appended to OTEL_RESOURCE_ATTRIBUTES"
 
 # Case B: phase value flows through verbatim — monitor-deploy (the longest, hyphenated).
 fresh_env t15b
@@ -697,7 +702,7 @@ rm -rf "${CONFIG_DIR}"
 		>/dev/null 2>&1)
 LOG=$(cat "$CLAUDE_STUB_LOG")
 assert_contains "$LOG" \
-	"OTEL_RESOURCE_ATTRIBUTES=linear.key=CTL-100,catalyst.orchestration=orch-test,task.type=phase-triage" \
+	"OTEL_RESOURCE_ATTRIBUTES=linear.key=CTL-100,catalyst.orchestration=orch-test,task.type=phase-triage,catalyst.exec_context=phase-bg" \
 	"task.type appended even when projectKey absent (short form)"
 
 # ─── CTL-511: claude --bg launch failure → signal stalled + phase.*.failed ───
@@ -1574,7 +1579,7 @@ assert_contains "$LOG" "--settings" "spawn argv carries --settings"
 SETTINGS_JSON="$(settings_json_from_log)"
 SET_OTEL=$(echo "$SETTINGS_JSON" | jq -r '.env["OTEL_RESOURCE_ATTRIBUTES"] // empty' 2>/dev/null)
 assert_eq \
-	"project=test-proj,linear.key=CTL-100,catalyst.orchestration=orch-test,branch=orch-test-CTL-100,task.type=phase-triage" \
+	"project=test-proj,linear.key=CTL-100,catalyst.orchestration=orch-test,branch=orch-test-CTL-100,task.type=phase-triage,catalyst.exec_context=phase-bg" \
 	"$SET_OTEL" \
 	".settings.env.OTEL_RESOURCE_ATTRIBUTES equals the composed attrs"
 
@@ -1665,7 +1670,7 @@ HAS_SETTINGS=$(echo "$DRY" | jq -r 'has("settings")' 2>/dev/null)
 assert_eq "true" "$HAS_SETTINGS" "dry-run JSON has a settings field"
 DRY_OTEL=$(echo "$DRY" | jq -r '.settings.env["OTEL_RESOURCE_ATTRIBUTES"] // empty' 2>/dev/null)
 assert_eq \
-	"project=test-proj,linear.key=CTL-100,catalyst.orchestration=orch-test,branch=orch-test-CTL-100,task.type=phase-triage" \
+	"project=test-proj,linear.key=CTL-100,catalyst.orchestration=orch-test,branch=orch-test-CTL-100,task.type=phase-triage,catalyst.exec_context=phase-bg" \
 	"$DRY_OTEL" \
 	"dry-run JSON settings.env carries the composed OTEL attrs"
 

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -1532,6 +1532,143 @@ else
 	pass "un-pointed verify: no --effort flag"
 fi
 
+# ─── CTL-760: per-worker --settings env injection ───────────────────────────
+# `claude --bg` is an RPC to the per-user daemon, so the worker inherits the
+# daemon's FROZEN env and per-worker OTEL_RESOURCE_ATTRIBUTES is lost. The only
+# lever that crosses the RPC is `claude --bg --settings '{"env":{...}}'`, which
+# MERGES with ~/.claude/settings.json. The dispatcher composes that settings
+# JSON (telemetry toggles + per-worker OTEL_RESOURCE_ATTRIBUTES + a statusLine
+# command) and threads it into every spawn.
+#
+# The stub claude logs all argv under --ARGS-- (one token per line), so we can
+# grep the line after `--settings` to recover the composed JSON and assert on it
+# with jq. Telemetry toggles are re-asserted from the dispatcher's inherited env,
+# so the tests export them before invoking.
+
+# settings_json_from_log → echoes the JSON token logged right after `--settings`
+# in $CLAUDE_STUB_LOG (the argv section logs one token per line).
+settings_json_from_log() {
+	grep -A1 -- '^--settings$' "$CLAUDE_STUB_LOG" | sed -n '2p'
+}
+
+echo ""
+echo "Test 48 (CTL-760): spawn carries --settings with per-worker OTEL_RESOURCE_ATTRIBUTES in .env"
+fresh_env t48
+cat >"${CONFIG_DIR}/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "test-proj"
+  }
+}
+EOF
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://otel.example:4317"
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
+LOG=$(cat "$CLAUDE_STUB_LOG")
+assert_contains "$LOG" "--settings" "spawn argv carries --settings"
+SETTINGS_JSON="$(settings_json_from_log)"
+SET_OTEL=$(echo "$SETTINGS_JSON" | jq -r '.env["OTEL_RESOURCE_ATTRIBUTES"] // empty' 2>/dev/null)
+assert_eq \
+	"project=test-proj,linear.key=CTL-100,catalyst.orchestration=orch-test,branch=orch-test-CTL-100,task.type=phase-triage" \
+	"$SET_OTEL" \
+	".settings.env.OTEL_RESOURCE_ATTRIBUTES equals the composed attrs"
+
+echo ""
+echo "Test 49 (CTL-760): .settings.env carries the telemetry toggles from the dispatcher env"
+# Reuse the exports from Test 48 (still in the environment).
+SET_TELEMETRY=$(echo "$SETTINGS_JSON" | jq -r '.env["CLAUDE_CODE_ENABLE_TELEMETRY"] // empty' 2>/dev/null)
+SET_METRICS=$(echo "$SETTINGS_JSON" | jq -r '.env["OTEL_METRICS_EXPORTER"] // empty' 2>/dev/null)
+SET_LOGS=$(echo "$SETTINGS_JSON" | jq -r '.env["OTEL_LOGS_EXPORTER"] // empty' 2>/dev/null)
+SET_ENDPOINT=$(echo "$SETTINGS_JSON" | jq -r '.env["OTEL_EXPORTER_OTLP_ENDPOINT"] // empty' 2>/dev/null)
+SET_PROTOCOL=$(echo "$SETTINGS_JSON" | jq -r '.env["OTEL_EXPORTER_OTLP_PROTOCOL"] // empty' 2>/dev/null)
+assert_eq "1" "$SET_TELEMETRY" ".settings.env.CLAUDE_CODE_ENABLE_TELEMETRY = 1"
+assert_eq "otlp" "$SET_METRICS" ".settings.env.OTEL_METRICS_EXPORTER = otlp"
+assert_eq "otlp" "$SET_LOGS" ".settings.env.OTEL_LOGS_EXPORTER = otlp"
+assert_eq "http://otel.example:4317" "$SET_ENDPOINT" ".settings.env.OTEL_EXPORTER_OTLP_ENDPOINT carried when set"
+assert_eq "grpc" "$SET_PROTOCOL" ".settings.env.OTEL_EXPORTER_OTLP_PROTOCOL carried when set"
+unset CLAUDE_CODE_ENABLE_TELEMETRY OTEL_METRICS_EXPORTER OTEL_LOGS_EXPORTER \
+	OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_PROTOCOL
+
+echo ""
+echo "Test 50 (CTL-760): unset optional endpoint/protocol are OMITTED from .settings.env (no null keys)"
+fresh_env t50
+cat >"${CONFIG_DIR}/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "test-proj"
+  }
+}
+EOF
+# Explicitly clear the optional OTLP keys so the dispatcher must omit them.
+unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_PROTOCOL
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
+SETTINGS_JSON="$(settings_json_from_log)"
+HAS_ENDPOINT=$(echo "$SETTINGS_JSON" | jq -r '.env | has("OTEL_EXPORTER_OTLP_ENDPOINT")' 2>/dev/null)
+HAS_PROTOCOL=$(echo "$SETTINGS_JSON" | jq -r '.env | has("OTEL_EXPORTER_OTLP_PROTOCOL")' 2>/dev/null)
+assert_eq "false" "$HAS_ENDPOINT" "unset OTEL_EXPORTER_OTLP_ENDPOINT omitted from .settings.env"
+assert_eq "false" "$HAS_PROTOCOL" "unset OTEL_EXPORTER_OTLP_PROTOCOL omitted from .settings.env"
+# Settings is still valid JSON even with the optional keys absent.
+IS_VALID=$(echo "$SETTINGS_JSON" | jq -e . >/dev/null 2>&1 && echo yes || echo no)
+assert_eq "yes" "$IS_VALID" "settings JSON remains valid with optional keys omitted"
+
+echo ""
+echo "Test 51 (CTL-760): --settings COEXISTS with --effort / --append-system-prompt (levers branch)"
+fresh_env t51
+mkdir -p "${TEST_DIR}/proj/thoughts/shared/research"
+touch "${TEST_DIR}/proj/thoughts/shared/research/2026-05-30-ctl-100.md"
+printf '%s\n' '{"estimated_scope":"large","classification":"feature"}' >"${WORKER_DIR}/triage.json"
+(cd "${TEST_DIR}/proj" && "$DISPATCH" --phase plan --ticket CTL-100 \
+	--orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1)
+LOG=$(cat "$CLAUDE_STUB_LOG")
+assert_contains "$LOG" "--settings" "levers branch: --settings present"
+assert_contains "$LOG" "--effort" "levers branch: --effort present"
+assert_contains "$LOG" "--append-system-prompt" "levers branch: --append-system-prompt present"
+SETTINGS_JSON="$(settings_json_from_log)"
+LEVERS_OTEL=$(echo "$SETTINGS_JSON" | jq -r '.env["OTEL_RESOURCE_ATTRIBUTES"] // empty' 2>/dev/null)
+assert_contains "$LEVERS_OTEL" "task.type=phase-plan" "levers branch: settings still carries the composed OTEL attrs"
+
+echo ""
+echo "Test 52 (CTL-760): .settings.statusLine.command ends with catalyst-statusline.sh when present"
+fresh_env t52
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
+SETTINGS_JSON="$(settings_json_from_log)"
+SL_CMD=$(echo "$SETTINGS_JSON" | jq -r '.statusLine.command // empty' 2>/dev/null)
+SL_TYPE=$(echo "$SETTINGS_JSON" | jq -r '.statusLine.type // empty' 2>/dev/null)
+case "$SL_CMD" in
+*/catalyst-statusline.sh) pass ".settings.statusLine.command ends with catalyst-statusline.sh" ;;
+*) fail ".settings.statusLine.command ends with catalyst-statusline.sh — got '$SL_CMD'" ;;
+esac
+assert_eq "command" "$SL_TYPE" ".settings.statusLine.type = command"
+
+echo ""
+echo "Test 53 (CTL-760): --dry-run JSON includes the composed settings field"
+fresh_env t53
+cat >"${CONFIG_DIR}/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "test-proj"
+  }
+}
+EOF
+DRY=$(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run 2>/dev/null)
+HAS_SETTINGS=$(echo "$DRY" | jq -r 'has("settings")' 2>/dev/null)
+assert_eq "true" "$HAS_SETTINGS" "dry-run JSON has a settings field"
+DRY_OTEL=$(echo "$DRY" | jq -r '.settings.env["OTEL_RESOURCE_ATTRIBUTES"] // empty' 2>/dev/null)
+assert_eq \
+	"project=test-proj,linear.key=CTL-100,catalyst.orchestration=orch-test,branch=orch-test-CTL-100,task.type=phase-triage" \
+	"$DRY_OTEL" \
+	"dry-run JSON settings.env carries the composed OTEL attrs"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -375,6 +375,67 @@ fresh_env t21
 "$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status parked 2>/dev/null
 assert_eq "1" "$?" "invalid status parked: exits 1"
 
+# ─── CTL-760: canonical resource block (project / linear.key / catalyst.orchestration)
+# build_canonical_line supports a resource block (lib/canonical-event.sh) but the
+# emit call previously only passed --linear-ticket, leaving the resource block's
+# project / linear.key / catalyst.orchestration unset on the worker's terminal
+# event. CTL-760 threads --project / --linear-key / --catalyst-orchestration so the
+# completion event carries the same orchestration context the worker's metrics do,
+# plus a duration_seconds payload field when the signal has both startedAt and
+# completedAt.
+
+echo ""
+echo "Test 22 (CTL-760): completion event carries the resource block (project / linear.key / catalyst.orchestration)"
+fresh_env t22
+# Provide a .catalyst/config.json with a projectKey the script can resolve, and
+# run from that directory so the ancestor-config lookup finds it.
+PROJ_DIR="${TEST_DIR}/proj"
+mkdir -p "${PROJ_DIR}/.catalyst"
+cat >"${PROJ_DIR}/.catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "projectKey": "test-proj"
+  }
+}
+EOF
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-triage.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"triage"}' >"$SIGNAL"
+(cd "$PROJ_DIR" &&
+	CATALYST_ORCHESTRATOR_ID=CTL-100 "$EMIT_SCRIPT" --phase triage --ticket CTL-100 \
+		--status complete --orch-id CTL-100 >/dev/null 2>&1)
+LINE=$(read_event_line)
+if [[ -z $LINE ]]; then
+	fail "Test 22: no event line emitted"
+else
+	RES_PROJECT=$(echo "$LINE" | jq -r '.resource["project"] // empty')
+	RES_LINEAR=$(echo "$LINE" | jq -r '.resource["linear.key"] // empty')
+	RES_ORCH=$(echo "$LINE" | jq -r '.resource["catalyst.orchestration"] // empty')
+	assert_eq "test-proj" "$RES_PROJECT" "resource.project resolved from config projectKey"
+	assert_eq "CTL-100" "$RES_LINEAR" "resource[\"linear.key\"] = ticket"
+	assert_eq "CTL-100" "$RES_ORCH" "resource[\"catalyst.orchestration\"] = orch id"
+fi
+
+echo ""
+echo "Test 23 (CTL-760): duration_seconds payload computed from startedAt/completedAt"
+fresh_env t23
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+# startedAt 90s before completedAt → duration_seconds should be 90.
+echo '{"status":"running","ticket":"CTL-100","phase":"implement","startedAt":"2026-06-04T00:00:00Z","completedAt":"2026-06-04T00:01:30Z"}' >"$SIGNAL"
+"$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status complete >/dev/null 2>&1
+LINE=$(read_event_line)
+DURATION=$(echo "$LINE" | jq -r '.body.payload.duration_seconds // empty')
+assert_eq "90" "$DURATION" "body.payload.duration_seconds = 90 (completedAt - startedAt)"
+
+echo ""
+echo "Test 24 (CTL-760): duration_seconds omitted when signal lacks timestamps"
+fresh_env t24
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"implement"}' >"$SIGNAL"
+"$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status complete >/dev/null 2>&1
+LINE=$(read_event_line)
+HAS_DURATION=$(echo "$LINE" | jq -r '.body.payload | has("duration_seconds")')
+assert_eq "false" "$HAS_DURATION" "duration_seconds omitted when startedAt/completedAt absent"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/catalyst-claude.sh
+++ b/plugins/dev/scripts/catalyst-claude.sh
@@ -134,6 +134,16 @@ fi
 . "${SCRIPT_DIR}/lib/task-type.sh"
 __catalyst_append_task_type "$SKILL"
 
+# CTL-760: launch-mode dimension. The phase-agent dispatcher stamps
+# catalyst.exec_context=phase-bg on bg workers; catalyst-claude.sh stamps
+# =interactive here so Grafana can split native Claude-Code cost/metrics by
+# launch mode. Append using the same OTEL_RESOURCE_ATTRIBUTES idiom as
+# task.type above; first-writer-wins so a parent shell's value is preserved.
+if [[ "${OTEL_RESOURCE_ATTRIBUTES:-}" != *"catalyst.exec_context="* ]]; then
+  OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES:+${OTEL_RESOURCE_ATTRIBUTES},}catalyst.exec_context=interactive"
+  export OTEL_RESOURCE_ATTRIBUTES
+fi
+
 # ─── Start session ────────────────────────────────────────────────────────────
 
 SESSION_ARGS=(--skill "$SKILL" --cwd "$WORKTREE_PATH")

--- a/plugins/dev/scripts/catalyst-session.sh
+++ b/plugins/dev/scripts/catalyst-session.sh
@@ -666,6 +666,10 @@ cmd_emit_context() {
   shift
 
   local pct="" tokens="" ctx_max="" turn="" model="" cost="" effort=""
+  # CTL-760: Claude Code's statusLine payload carries a rate_limits block. The
+  # 5h/7d used-percentages are the "5h: 26%" / "7d: 15%" the user sees; the
+  # resets_at timestamps are informational (body-only, no label cardinality).
+  local rl5h="" rl7d="" rl5h_reset="" rl7d_reset=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --context-pct)    pct="$2"; shift 2 ;;
@@ -675,6 +679,10 @@ cmd_emit_context() {
       --model)          model="$2"; shift 2 ;;
       --cost-usd)       cost="$2"; shift 2 ;;
       --effort)         effort="$2"; shift 2 ;;
+      --ratelimit-5h-pct)    rl5h="$2"; shift 2 ;;
+      --ratelimit-7d-pct)    rl7d="$2"; shift 2 ;;
+      --ratelimit-5h-reset)  rl5h_reset="$2"; shift 2 ;;
+      --ratelimit-7d-reset)  rl7d_reset="$2"; shift 2 ;;
       *) echo "error: unknown flag for emit-context: $1" >&2; return 1 ;;
     esac
   done
@@ -706,13 +714,21 @@ cmd_emit_context() {
     --argjson cost "${cost:-null}" \
     --arg model "$model" \
     --arg effort "$effort" \
+    --argjson rl5h "${rl5h:-null}" \
+    --argjson rl7d "${rl7d:-null}" \
+    --arg rl5h_reset "$rl5h_reset" \
+    --arg rl7d_reset "$rl7d_reset" \
     '{context_pct: $pct,
       context_tokens: (if $tokens == null then null else $tokens end),
       context_max: (if $context_max == null then null else $context_max end),
       turn: (if $turn == null then null else $turn end),
       model: (if $model == "" then null else $model end),
       cost_usd: (if $cost == null then null else $cost end),
-      effort: (if $effort == "" then null else $effort end)}')
+      effort: (if $effort == "" then null else $effort end),
+      ratelimit_5h_pct: (if $rl5h == null then null else $rl5h end),
+      ratelimit_7d_pct: (if $rl7d == null then null else $rl7d end),
+      ratelimit_5h_reset: (if $rl5h_reset == "" then null else $rl5h_reset end),
+      ratelimit_7d_reset: (if $rl7d_reset == "" then null else $rl7d_reset end)}')
 
   # Build claude.* extra args for typed attributes
   local extra_args=()
@@ -721,6 +737,9 @@ cmd_emit_context() {
   [[ -n "$pct" ]] && extra_args+=(--claude-context-used-pct "$pct")
   [[ -n "$tokens" ]] && extra_args+=(--claude-context-tokens "$tokens")
   [[ -n "$turn" ]] && extra_args+=(--claude-turn "$turn")
+  # CTL-760: rate-limit % as typed attributes (numeric). Resets stay body-only.
+  [[ -n "$rl5h" ]] && extra_args+=(--claude-ratelimit-5h-pct "$rl5h")
+  [[ -n "$rl7d" ]] && extra_args+=(--claude-ratelimit-7d-pct "$rl7d")
 
   # Workflow/ticket lookup for trace/span derivation.
   local trow workflow ticket
@@ -745,6 +764,7 @@ cmd_emit_context() {
     --trace-id "$trace_id" \
     --span-id "$span_id" \
     --session "$sid" \
+    ${ticket:+--linear-key "$ticket"} \
     "${extra_args[@]}" \
     --payload-json "$payload" 2>/dev/null)" || return 1
   canonical_jsonl_append "$EVENTS_DIR" "$ctx_line"
@@ -771,6 +791,7 @@ cmd_emit_context() {
         --trace-id "$trace_id" \
         --span-id "$span_id" \
         --session "$sid" \
+        ${ticket:+--linear-key "$ticket"} \
         "${extra_args[@]}" \
         --message "context crossed ${CATALYST_CTX_THRESHOLD}%: ${prev_pct} → ${pct}" \
         --payload-json "$att_payload" 2>/dev/null)" || true

--- a/plugins/dev/scripts/catalyst-statusline.sh
+++ b/plugins/dev/scripts/catalyst-statusline.sh
@@ -68,6 +68,16 @@ fi
   MODEL="$(printf '%s' "$INPUT" | jq -r '.model.id // .model // empty' 2>/dev/null)"
   EFFORT="$(printf '%s' "$INPUT" | jq -r '.effort.level // empty' 2>/dev/null)"
 
+  # CTL-760: Claude Code's statusLine payload carries a rate_limits block. The
+  # five_hour/seven_day used_percentage are the "5h: 26%" / "7d: 15%" the user
+  # sees; the resets_at timestamps are informational. Flowing them through
+  # emit-context adds fields to the EXISTING session.context event (no new
+  # event count).
+  RL5H="$(printf '%s' "$INPUT" | jq -r '.rate_limits.five_hour.used_percentage // empty' 2>/dev/null)"
+  RL7D="$(printf '%s' "$INPUT" | jq -r '.rate_limits.seven_day.used_percentage // empty' 2>/dev/null)"
+  RL5H_RESET="$(printf '%s' "$INPUT" | jq -r '.rate_limits.five_hour.resets_at // empty' 2>/dev/null)"
+  RL7D_RESET="$(printf '%s' "$INPUT" | jq -r '.rate_limits.seven_day.resets_at // empty' 2>/dev/null)"
+
   # Without a percentage there's nothing meaningful to emit — bail.
   [[ -n "$PCT" ]] || exit 0
 
@@ -78,6 +88,10 @@ fi
   [[ -n "$MODEL" ]]  && ARGS+=(--model "$MODEL")
   [[ -n "$COST" ]]   && ARGS+=(--cost-usd "$COST")
   [[ -n "$EFFORT" ]] && ARGS+=(--effort "$EFFORT")
+  [[ -n "$RL5H" ]]       && ARGS+=(--ratelimit-5h-pct "$RL5H")
+  [[ -n "$RL7D" ]]       && ARGS+=(--ratelimit-7d-pct "$RL7D")
+  [[ -n "$RL5H_RESET" ]] && ARGS+=(--ratelimit-5h-reset "$RL5H_RESET")
+  [[ -n "$RL7D_RESET" ]] && ARGS+=(--ratelimit-7d-reset "$RL7D_RESET")
 
   bash "$SESSION_BIN" "${ARGS[@]}" >/dev/null 2>&1 || true
 ) </dev/null >/dev/null 2>&1 &

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -155,6 +155,8 @@ synthesize_event_id() {
 #   --claude-context-used-pct N    claude.context.used_pct (integer)
 #   --claude-context-tokens N      claude.context.tokens (integer)
 #   --claude-turn N                claude.turn (integer)
+#   --claude-ratelimit-5h-pct N    claude.ratelimit.five_hour_pct (integer, CTL-760)
+#   --claude-ratelimit-7d-pct N    claude.ratelimit.seven_day_pct (integer, CTL-760)
 build_canonical_line() {
   local ts="" severity="" service="" event_name=""
   local trace_id="" span_id=""
@@ -167,6 +169,8 @@ build_canonical_line() {
   local project="" linear_key="" cat_orch=""
   local claude_session_id="" claude_model=""
   local claude_context_used_pct="" claude_context_tokens="" claude_turn=""
+  # CTL-760: rate-limit 5h/7d used-percentages (numeric typed attributes).
+  local claude_rl_5h="" claude_rl_7d=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -199,6 +203,8 @@ build_canonical_line() {
       --claude-context-used-pct)   claude_context_used_pct="$2"; shift 2 ;;
       --claude-context-tokens)     claude_context_tokens="$2"; shift 2 ;;
       --claude-turn)               claude_turn="$2"; shift 2 ;;
+      --claude-ratelimit-5h-pct)   claude_rl_5h="$2"; shift 2 ;;
+      --claude-ratelimit-7d-pct)   claude_rl_7d="$2"; shift 2 ;;
       *) echo "build_canonical_line: unknown flag: $1" >&2; return 1 ;;
     esac
   done
@@ -257,6 +263,8 @@ build_canonical_line() {
     --arg claude_context_used_pct "$claude_context_used_pct" \
     --arg claude_context_tokens "$claude_context_tokens" \
     --arg claude_turn "$claude_turn" \
+    --arg claude_rl_5h "$claude_rl_5h" \
+    --arg claude_rl_7d "$claude_rl_7d" \
     '{
       ts: $ts,
       id: $id,
@@ -294,6 +302,8 @@ build_canonical_line() {
         + (if $claude_context_used_pct == "" then {} else { "claude.context.used_pct": ($claude_context_used_pct | tonumber) } end)
         + (if $claude_context_tokens == "" then {} else { "claude.context.tokens": ($claude_context_tokens | tonumber) } end)
         + (if $claude_turn == "" then {} else { "claude.turn": ($claude_turn | tonumber) } end)
+        + (if $claude_rl_5h == "" then {} else { "claude.ratelimit.five_hour_pct": ($claude_rl_5h | tonumber) } end)
+        + (if $claude_rl_7d == "" then {} else { "claude.ratelimit.seven_day_pct": ($claude_rl_7d | tonumber) } end)
       ),
       body: (
         (if $message == "" then {} else { message: $message } end)

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -326,6 +326,11 @@ compose_otel_resource_attrs() {
 		attrs="linear.key=${TICKET},catalyst.orchestration=${ORCH_ID}"
 	fi
 	attrs="${attrs},task.type=phase-${PHASE}"
+	# CTL-760: launch-mode dimension. Rides OTEL_RES_ATTRS → the --settings env →
+	# the worker's native Claude-Code metrics, so every bg phase metric slices by
+	# launch mode (phase-bg here vs catalyst.exec_context=interactive that
+	# catalyst-claude.sh stamps on the interactive orchestrator/dev sessions).
+	attrs="${attrs},catalyst.exec_context=phase-bg"
 	printf '%s\n' "$attrs"
 }
 

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -669,6 +669,71 @@ PROMPT="/catalyst-dev:phase-${PHASE} ${TICKET} --orch-dir ${ORCH_DIR}"
 # direnv produces for the interactive orchestrator.
 OTEL_RES_ATTRS="$(compose_otel_resource_attrs)"
 
+# ─── CTL-760: per-worker --settings env injection ───────────────────────────
+#
+# `claude --bg` is an RPC to the per-user daemon, so the spawned worker inherits
+# the DAEMON's frozen env — the per-worker OTEL_RESOURCE_ATTRIBUTES we set in
+# DISPATCH_ENV below never reaches it, and the worker emits Claude-Code
+# metrics/logs with empty linear_key / branch / project labels. The only lever
+# that crosses the RPC is `claude --bg --settings '{"env":{...}}'`, which MERGES
+# with ~/.claude/settings.json (it does not replace it) — verified empirically.
+#
+# compose_worker_settings_json builds that settings object with `jq -nc` (never
+# hand-built JSON):
+#   { "env": { <telemetry toggles>, "OTEL_RESOURCE_ATTRIBUTES": "<attrs>" },
+#     "statusLine": { "type": "command", "command": "<SCRIPT_DIR>/catalyst-statusline.sh" } }
+#
+# Telemetry toggles are re-asserted from the dispatcher's own inherited env (the
+# same keys that enable telemetry in ~/.claude/settings.json's .env block),
+# defaulting CLAUDE_CODE_ENABLE_TELEMETRY=1 / OTEL_METRICS_EXPORTER=otlp /
+# OTEL_LOGS_EXPORTER=otlp. OTEL_EXPORTER_OTLP_ENDPOINT and
+# OTEL_EXPORTER_OTLP_PROTOCOL are included ONLY when non-empty (absent optionals
+# are omitted, never written as null/empty keys).
+#
+# statusLine.command points at this repo's catalyst-statusline.sh — the entire
+# statusLine key is OMITTED (fail-open) when that file is absent. Always emits a
+# valid settings object; an empty OTEL_RES_ATTRS still yields valid JSON.
+compose_worker_settings_json() {
+	local enable_telemetry metrics_exporter logs_exporter otlp_endpoint otlp_protocol
+	enable_telemetry="${CLAUDE_CODE_ENABLE_TELEMETRY:-1}"
+	metrics_exporter="${OTEL_METRICS_EXPORTER:-otlp}"
+	logs_exporter="${OTEL_LOGS_EXPORTER:-otlp}"
+	otlp_endpoint="${OTEL_EXPORTER_OTLP_ENDPOINT:-}"
+	otlp_protocol="${OTEL_EXPORTER_OTLP_PROTOCOL:-}"
+
+	local statusline_script="${SCRIPT_DIR}/catalyst-statusline.sh"
+
+	jq -nc \
+		--arg enable_telemetry "$enable_telemetry" \
+		--arg metrics_exporter "$metrics_exporter" \
+		--arg logs_exporter "$logs_exporter" \
+		--arg otlp_endpoint "$otlp_endpoint" \
+		--arg otlp_protocol "$otlp_protocol" \
+		--arg otel_attrs "$OTEL_RES_ATTRS" \
+		--arg statusline_cmd "$statusline_script" \
+		--argjson have_statusline "$([[ -f $statusline_script ]] && echo true || echo false)" \
+		'{
+       env: (
+         {
+           "CLAUDE_CODE_ENABLE_TELEMETRY": $enable_telemetry,
+           "OTEL_METRICS_EXPORTER": $metrics_exporter,
+           "OTEL_LOGS_EXPORTER": $logs_exporter
+         }
+         + (if $otlp_endpoint == "" then {} else { "OTEL_EXPORTER_OTLP_ENDPOINT": $otlp_endpoint } end)
+         + (if $otlp_protocol == "" then {} else { "OTEL_EXPORTER_OTLP_PROTOCOL": $otlp_protocol } end)
+         + (if $otel_attrs == "" then {} else { "OTEL_RESOURCE_ATTRIBUTES": $otel_attrs } end)
+       )
+     }
+     + (if $have_statusline
+        then { statusLine: { type: "command", command: $statusline_cmd } }
+        else {} end)'
+}
+WORKER_SETTINGS_JSON="$(compose_worker_settings_json)"
+# Fail-open: never let a malformed settings string reach the spawn or dry-run.
+if ! printf '%s' "$WORKER_SETTINGS_JSON" | jq -e . >/dev/null 2>&1; then
+	WORKER_SETTINGS_JSON='{}'
+fi
+
 DISPATCH_ENV=(
 	"CATALYST_ORCHESTRATOR_DIR=${ORCH_DIR}"
 	"CATALYST_ORCHESTRATOR_ID=${ORCH_ID}"
@@ -707,11 +772,12 @@ if [[ $DRY_RUN -eq 1 ]]; then
 		--argjson attempt "$ATTEMPT" \
 		--arg resumeSession "$RESUME_SESSION" \
 		--argjson env "$(printf '%s\n' "${DISPATCH_ENV[@]}" | jq -R . | jq -s .)" \
+		--argjson settings "$(printf '%s' "$WORKER_SETTINGS_JSON" | jq -e . >/dev/null 2>&1 && printf '%s' "$WORKER_SETTINGS_JSON" || echo '{}')" \
 		'{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
       bg_job_id: null, prompt: $prompt, signalFile: $signal,
       sessionName: $sessionName, attempt: $attempt,
       resumeSession: (if $resumeSession == "" then null else $resumeSession end),
-      env: $env, status: "dispatched", dryRun: true}'
+      env: $env, settings: $settings, status: "dispatched", dryRun: true}'
 	exit 0
 fi
 
@@ -837,18 +903,23 @@ spawn_claude_bg() {
 	# CTL descriptor v1.1: thread the resolved per-step levers. ADDITIVE +
 	# fail-open — when WORKER_EFFORT and APPEND_SYSTEM_PROMPT are both empty the
 	# launch is byte-identical to today (no --effort / --append-system-prompt).
+	# CTL-760: --settings carries the per-worker telemetry env + statusLine across
+	# the `claude --bg` daemon RPC (the DISPATCH_ENV prefix is kept belt-and-braces
+	# but is lost to the frozen daemon env on the far side). Threaded immediately
+	# after --model in BOTH branches so every spawn site (fresh, resume,
+	# resume-fallback) inherits it.
 	if [[ -n "$WORKER_EFFORT" || -n "$APPEND_SYSTEM_PROMPT" ]]; then
 		local _levers=()
 		[[ -n "$WORKER_EFFORT" ]] && _levers+=(--effort "$WORKER_EFFORT")
 		[[ -n "$APPEND_SYSTEM_PROMPT" ]] && _levers+=(--append-system-prompt "$APPEND_SYSTEM_PROMPT")
 		env "${DISPATCH_ENV[@]}" \
 			"$CLAUDE_BIN" --bg --name "$SESSION_NAME" --dangerously-skip-permissions \
-			--model "$MODEL" "${_levers[@]}" "$@" \
+			--model "$MODEL" --settings "$WORKER_SETTINGS_JSON" "${_levers[@]}" "$@" \
 			>"$BG_OUT" 2>"$BG_ERR" </dev/null
 	else
 		env "${DISPATCH_ENV[@]}" \
 			"$CLAUDE_BIN" --bg --name "$SESSION_NAME" --dangerously-skip-permissions \
-			--model "$MODEL" "$@" \
+			--model "$MODEL" --settings "$WORKER_SETTINGS_JSON" "$@" \
 			>"$BG_OUT" 2>"$BG_ERR" </dev/null
 	fi
 }

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -149,6 +149,30 @@ if [[ $PHASE == *.* ]]; then
 	die "invalid --phase: $PHASE (dots are reserved for event name parsing)"
 fi
 
+# ─── CTL-760: resolve the project key for the canonical resource block ───────
+#
+# build_canonical_line (lib/canonical-event.sh) supports a resource block with
+# project / linear.key / catalyst.orchestration, but the emit call below only
+# passed --linear-ticket — leaving project / linear.key / catalyst.orchestration
+# unset on the worker's terminal phase event (the metrics carry them via the
+# worker's OTEL_RESOURCE_ATTRIBUTES, but the event log did not). Resolve the
+# project key from the nearest-ancestor .catalyst/config.json so the completion
+# event mirrors that context. Fail-open to empty — the resource keys are each
+# omitted when their resolved value is empty (canonical-event.sh:274-276).
+resolve_project_key() {
+	command -v jq >/dev/null 2>&1 || return 0
+	local dir
+	dir="$(pwd)"
+	while [[ $dir != "/" ]]; do
+		if [[ -f "${dir}/.catalyst/config.json" ]]; then
+			jq -r '.catalyst.projectKey // empty' "${dir}/.catalyst/config.json" 2>/dev/null || true
+			return 0
+		fi
+		dir="$(dirname "$dir")"
+	done
+}
+PROJECT_KEY="$(resolve_project_key)"
+
 # ─── 0. CTL-736 Phase 1: fencing check (stale generation bows out) ───────────
 #
 # A worker carries its dispatch generation in CATALYST_GENERATION. If the phase
@@ -186,19 +210,47 @@ SEVERITY=$([[ $STATUS == "complete" || $STATUS == "skipped" ]] && echo INFO || e
 TRACE_ID=$(derive_trace_id "$ORCH_ID" "$SESSION_ID")
 SPAN_ID=$(derive_span_id "$TICKET" "$SESSION_ID")
 
+# CTL-760: compute duration_seconds (integer) from the signal file's startedAt /
+# completedAt when BOTH are present. Body-payload field, NOT a resource attr.
+# completedAt is written by this script's signal mutation below; on a fresh
+# `complete` it isn't on disk yet, so we derive "now" as the completion instant
+# and measure against the existing startedAt. If startedAt is absent, omit it.
+DURATION_SECONDS=""
+if [[ -n $ORCH_DIR ]]; then
+	_DUR_SIGNAL="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+	if [[ -f $_DUR_SIGNAL ]] && command -v jq >/dev/null 2>&1; then
+		_STARTED_AT=$(jq -r '.startedAt // empty' "$_DUR_SIGNAL" 2>/dev/null || echo "")
+		_COMPLETED_AT=$(jq -r '.completedAt // empty' "$_DUR_SIGNAL" 2>/dev/null || echo "")
+		# Fall back to this emit's TS as the completion instant when the signal
+		# has a startedAt but not yet a completedAt (the common success path).
+		[[ -z $_COMPLETED_AT ]] && _COMPLETED_AT="$TS"
+		if [[ -n $_STARTED_AT && -n $_COMPLETED_AT ]]; then
+			_S_EPOCH=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$_STARTED_AT" +%s 2>/dev/null ||
+				date -u -d "$_STARTED_AT" +%s 2>/dev/null || echo "")
+			_C_EPOCH=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$_COMPLETED_AT" +%s 2>/dev/null ||
+				date -u -d "$_COMPLETED_AT" +%s 2>/dev/null || echo "")
+			if [[ $_S_EPOCH =~ ^[0-9]+$ && $_C_EPOCH =~ ^[0-9]+$ && $_C_EPOCH -ge $_S_EPOCH ]]; then
+				DURATION_SECONDS=$((_C_EPOCH - _S_EPOCH))
+			fi
+		fi
+	fi
+fi
+
 # Payload mirrors what orchestrator monitors expect: phase, ticket, status,
-# optional failure_reason, optional handoff_path (CTL-484 turn-cap-exhausted).
-# The broker's tryPhaseLifecycleRoute parser reads only event.name + ticket,
-# so payload extras don't change routing.
+# optional failure_reason, optional handoff_path (CTL-484 turn-cap-exhausted),
+# optional duration_seconds (CTL-760). The broker's tryPhaseLifecycleRoute parser
+# reads only event.name + ticket, so payload extras don't change routing.
 PAYLOAD=$(jq -nc \
 	--arg phase "$PHASE" \
 	--arg ticket "$TICKET" \
 	--arg status "$STATUS" \
 	--arg reason "$REASON" \
 	--arg handoff "$HANDOFF_PATH" \
+	--arg duration "$DURATION_SECONDS" \
 	'{phase: $phase, ticket: $ticket, status: $status}
    + (if $reason == "" then {} else {failure_reason: $reason} end)
-   + (if $handoff == "" then {} else {handoff_path: $handoff} end)')
+   + (if $handoff == "" then {} else {handoff_path: $handoff} end)
+   + (if $duration == "" then {} else {duration_seconds: ($duration | tonumber)} end)')
 
 LINE=$(build_canonical_line \
 	--ts "$TS" \
@@ -213,6 +265,9 @@ LINE=$(build_canonical_line \
 	--worker "$TICKET" \
 	--session "$SESSION_ID" \
 	--linear-ticket "$TICKET" \
+	--project "$PROJECT_KEY" \
+	--linear-key "$TICKET" \
+	--catalyst-orchestration "$ORCH_ID" \
 	--message "Phase ${PHASE} ${STATUS} on ${TICKET}" \
 	--payload-json "$PAYLOAD" \
 	2>/dev/null) || warn "failed to build canonical event line"


### PR DESCRIPTION
## CTL-760 — Per-worker OpenTelemetry for the background-worker execution model

Makes the new execution model (background `claude --bg` phase workers + event-based execution-core + configurable workflows) **fully observable per-worker** in Grafana/Dash0/Honeycomb.

### Root cause

`phase-agent-dispatch` spawned workers via `env "${DISPATCH_ENV[@]}" claude --bg …`. `claude --bg` is an RPC to the per-user daemon, so the worker inherits the **daemon's frozen env** — the per-worker `OTEL_RESOURCE_ATTRIBUTES` never reached it. Result: **zero `task_type=phase-*` series have ever existed** in Prometheus; bg cost/token metrics were untagged or mis-attributed to whatever ticket the daemon booted under.

The only lever that crosses the RPC is `claude --bg --settings '{"env":{…}}'` (empirically proven; `--settings` **merges** with `~/.claude/settings.json`, it does not replace).

### What changed (4 commits)

1. **`--settings` injection** (`phase-agent-dispatch`): new `compose_worker_settings_json()` builds `{env:{telemetry toggles, OTEL_RESOURCE_ATTRIBUTES}, statusLine:{command: catalyst-statusline.sh}}` via `jq -nc`, threaded into **all** spawn paths (fresh/resume/resume-fallback) through `spawn_claude_bg`. Fail-open; keeps the `env` prefix belt-and-braces.
2. **Canonical resource block** (`phase-agent-emit-complete`): passes `--project/--linear-key/--catalyst-orchestration` + `duration_seconds` so `phase.<PHASE>.<STATUS>.<TICKET>` events carry per-worker resource attrs (previously only `service.*`).
3. **`catalyst.exec_context`** dimension: `phase-bg` stamped at dispatch, `interactive` stamped by `catalyst-claude.sh` — every native metric now slices by launch mode.
4. **5h/7d rate-limit %**: `catalyst-statusline.sh` → `catalyst-session.sh emit-context` → `lib/canonical-event.sh` flows `.rate_limits.{five_hour,seven_day}.used_percentage` from the statusLine payload as numeric `claude.ratelimit.*_pct` attributes on the existing `session.context` event (no new event count). Resets stay body-only (cardinality). Also adds `--linear-key` so those events are per-worker tagged.

> The 5h/7d data lives in the Claude Code statusLine **payload** (confirmed against ccstatusline's input schema) — the original audit's "refuted" verdict only checked API response headers and missed this surface.

### Tests — 380 passing, TDD red-first (no new shellcheck)

| suite | result |
|---|---|
| phase-agent-dispatch | 188 ✓ |
| phase-agent-emit-complete | 58 ✓ |
| catalyst-statusline | 16 ✓ |
| catalyst-session-claude | 45 ✓ |
| canonical-event | 68 ✓ |
| catalyst-claude-task-type | 5 ✓ |

(Full `run-tests.sh` aggregate intentionally not used as a gate — it is RED on clean main from unrelated suites and regenerates tracked orch-monitor TSX.)

### Known empirical question (to validate post-deploy)

Whether a headless `--bg` worker actually **invokes** the injected statusLine command is unverified — statuslines are normally a TUI feature. The injection is **fail-open** (harmless if it never fires). The deterministic wins (native-metric resource tagging #1, canonical resource block #2, exec_context #3) do not depend on it; the statusLine-derived dynamic metrics (#4 context/turn/cost/5h-7d) do. This will be confirmed by reading Prometheus/Loki after restart.

### Relationships

- Delivers what **CTL-635** deferred as "Option D — external/unavailable."
- Upstream of **CTL-697** (local collector multi-backend fan-out): this PR makes workers emit *correctly-tagged* signal; CTL-697 fans it to Grafana/Dash0/Honeycomb.
- Follow-ups: CTL-761 (revive/dup count), CTL-762 (`emit-otel-*.sh --resource-attr`), CTL-763 (rate-limit extras).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
