### PR TITLE
JOB2 PR1: state-correctness bundle — CTL-757 audit event + CTL-642/758 terminal guard + CTL-759 install automations

### DIFF
--- a/plugins/dev/scripts/__tests__/check-project-setup-execution-core.test.sh
+++ b/plugins/dev/scripts/__tests__/check-project-setup-execution-core.test.sh
@@ -172,6 +172,105 @@ else
   fail "phase-agents missing registry stays exit 0 (got rc=$RC8)"
 fi
 
+# ─── CTL-759: Linear git-automation drift check (hot-path, TTL-cached) ───────
+#
+# These tests exercise the execution-core git-automation block. They need:
+#   - a per-project secrets file holding an apiToken (else SOFT skip)
+#   - a fake `curl` on PATH returning canned gitAutomationStates
+#   - a per-test XDG dir so the cache + secrets are hermetic
+#
+# ga_curl_log records bodies so we can assert the live query was / was not issued.
+
+# build_ga_secrets <xdg-dir> — write config-test-project.json with a token.
+build_ga_secrets() {
+  local xdg="$1"
+  mkdir -p "${xdg}/catalyst"
+  cat > "${xdg}/catalyst/config-test-project.json" <<'EOF'
+{ "catalyst": { "linear": { "apiToken": "lin_api_fake_ga_token" } } }
+EOF
+}
+
+# install_ga_curl <bin> <log> <nodes-json> — fake curl returning the team's
+# gitAutomationStates nodes; logs every request body to <log>.
+install_ga_curl() {
+  local bin="$1" log="$2" nodes="$3"
+  mkdir -p "$bin"
+  cat > "${bin}/curl" <<SCRIPT
+#!/usr/bin/env bash
+body=""
+for a in "\$@"; do case "\$a" in {*) body="\$a";; esac; done
+echo "live-query-issued" >> "${log}"
+echo '{"data":{"teams":{"nodes":[{"gitAutomationStates":{"nodes":${nodes}}}]}}}'
+exit 0
+SCRIPT
+  chmod +x "${bin}/curl"
+}
+
+# run_check_ga <cwd> <catalyst-dir> <xdg> <bin> — like run_check but threads a
+# custom XDG_CONFIG_HOME and prepends a fake-curl bin dir to PATH.
+run_check_ga() {
+  local cwd="$1" catalyst_dir="$2" xdg="$3" bin="$4"
+  ( cd "$cwd" \
+    && env -i HOME="$HOME" PATH="${bin}:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" \
+       CATALYST_AUTONOMOUS=1 CATALYST_DIR="$catalyst_dir" \
+       XDG_CONFIG_HOME="$xdg" \
+       bash "$SCRIPT" 2>&1 )
+}
+
+# ─── Test 9: review node + start!=PR + merge!=Done → three warnings ──────────
+P9="${SCRATCH}/p9"
+CD9="$(build_project "$P9" "execution-core" 1 1)"
+XDG9="${SCRATCH}/p9-xdg"; BIN9="${SCRATCH}/p9-bin"; LOG9="${SCRATCH}/p9-curl.log"
+build_ga_secrets "$XDG9"
+install_ga_curl "$BIN9" "$LOG9" \
+  '[{"id":"ga-s","event":"start","state":{"id":"x","name":"Triage"}},{"id":"ga-m","event":"merge","state":{"id":"y","name":"Validate"}},{"id":"ga-r","event":"review","state":{"id":"z","name":"Validate"}}]'
+OUT9="$(run_check_ga "$P9" "$CD9" "$XDG9" "$BIN9" || true)"
+if grep -qi "review" <<<"$OUT9" \
+   && grep -qiE "start.*Triage|points at 'Triage'" <<<"$OUT9" \
+   && grep -qiE "merge.*Validate|points at 'Validate'" <<<"$OUT9"; then
+  pass "git-automation drift warns on review + start!=PR + merge!=Done"
+else
+  fail "git-automation drift warns on review + start!=PR + merge!=Done"
+  echo "$OUT9" | sed 's/^/    /'
+fi
+
+# ─── Test 10: no per-project token → SOFT skip (no git-automation warning) ───
+P10="${SCRATCH}/p10"
+CD10="$(build_project "$P10" "execution-core" 1 1)"
+XDG10="${SCRATCH}/p10-xdg"; BIN10="${SCRATCH}/p10-bin"; LOG10="${SCRATCH}/p10-curl.log"
+mkdir -p "${XDG10}/catalyst"   # XDG dir exists but NO secrets file → no token
+install_ga_curl "$BIN10" "$LOG10" '[]'
+OUT10="$(run_check_ga "$P10" "$CD10" "$XDG10" "$BIN10" || true)"
+if ! grep -qiE "git automation" <<<"$OUT10" && [[ ! -f "$LOG10" ]]; then
+  pass "no token → SOFT skip (no warning, no live query)"
+else
+  fail "no token → SOFT skip (no warning, no live query)"
+  echo "$OUT10" | sed 's/^/    /'
+fi
+
+# ─── Test 11: fresh cache → live query NOT re-issued ─────────────────────────
+P11="${SCRATCH}/p11"
+CD11="$(build_project "$P11" "execution-core" 1 1)"
+XDG11="${SCRATCH}/p11-xdg"; BIN11="${SCRATCH}/p11-bin"; LOG11="${SCRATCH}/p11-curl.log"
+build_ga_secrets "$XDG11"
+install_ga_curl "$BIN11" "$LOG11" '[]'
+# Seed a fresh cache (fetchedAt = now) for team CTL with clean (no-drift) nodes.
+NOW_TS="$(date +%s)"
+cat > "${XDG11}/catalyst/linear-git-automation-cache.json" <<EOF
+{ "CTL": { "fetchedAt": ${NOW_TS}, "nodes": [
+  {"id":"ga-s","event":"start","state":{"id":"x","name":"PR"}},
+  {"id":"ga-m","event":"merge","state":{"id":"y","name":"Done"}}
+] } }
+EOF
+OUT11="$(run_check_ga "$P11" "$CD11" "$XDG11" "$BIN11" || true)"
+if [[ ! -f "$LOG11" ]] && ! grep -qiE "git automation" <<<"$OUT11"; then
+  pass "fresh cache → live query not re-issued, no drift warning"
+else
+  fail "fresh cache → live query not re-issued, no drift warning"
+  [[ -f "$LOG11" ]] && echo "    (live query was issued — cache not honored)"
+  echo "$OUT11" | sed 's/^/    /'
+fi
+
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"
 [ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/__tests__/check-project-setup-execution-core.test.sh
+++ b/plugins/dev/scripts/__tests__/check-project-setup-execution-core.test.sh
@@ -224,7 +224,7 @@ XDG9="${SCRATCH}/p9-xdg"; BIN9="${SCRATCH}/p9-bin"; LOG9="${SCRATCH}/p9-curl.log
 build_ga_secrets "$XDG9"
 install_ga_curl "$BIN9" "$LOG9" \
   '[{"id":"ga-s","event":"start","state":{"id":"x","name":"Triage"}},{"id":"ga-m","event":"merge","state":{"id":"y","name":"Validate"}},{"id":"ga-r","event":"review","state":{"id":"z","name":"Validate"}}]'
-OUT9="$(run_check_ga "$P9" "$CD9" "$XDG9" "$BIN9" || true)"
+OUT9="$(run_check_ga "$P9" "$CD9" "$XDG9" "$BIN9")"; RC9=$?
 if grep -qi "review" <<<"$OUT9" \
    && grep -qiE "start.*Triage|points at 'Triage'" <<<"$OUT9" \
    && grep -qiE "merge.*Validate|points at 'Validate'" <<<"$OUT9"; then
@@ -232,6 +232,16 @@ if grep -qi "review" <<<"$OUT9" \
 else
   fail "git-automation drift warns on review + start!=PR + merge!=Done"
   echo "$OUT9" | sed 's/^/    /'
+fi
+
+# CTL-759 Top-Risk: the git-automation drift is a WARN ONLY — it must NOT alter
+# the exit code. This repo is fully-configured (full contract + registry entry,
+# i.e. the exit-0 case from test 7), so a drift warning must keep exit 0.
+if [[ "$RC9" -eq 0 ]]; then
+  pass "git-automation drift is WARN-only — exit code unchanged (0)"
+else
+  fail "git-automation drift is WARN-only — exit code unchanged (0)"
+  echo "    (drift warning changed exit code to $RC9)"
 fi
 
 # ─── Test 10: no per-project token → SOFT skip (no git-automation warning) ───

--- a/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
@@ -139,6 +139,94 @@ run "mutation contains the state name" \
 run "mutation contains the type" \
   bash -c "echo '$MUTATION' | grep -q 'started'"
 
+# desired_git_automations — exactly start→PR, merge→Done, no review (CTL-759).
+DESIRED_GA="$(desired_git_automations)"
+
+run "desired_git_automations is valid JSON" \
+  bash -c "echo '$DESIRED_GA' | jq -e ."
+
+run "desired_git_automations has exactly 2 entries" \
+  bash -c "echo '$DESIRED_GA' | jq -e 'length == 2'"
+
+run "desired_git_automations start -> PR" \
+  bash -c "echo '$DESIRED_GA' | jq -e '.[] | select(.event==\"start\") | .state == \"PR\"'"
+
+run "desired_git_automations merge -> Done" \
+  bash -c "echo '$DESIRED_GA' | jq -e '.[] | select(.event==\"merge\") | .state == \"Done\"'"
+
+run "desired_git_automations has no review automation" \
+  bash -c "! echo '$DESIRED_GA' | jq -e '.[] | select(.event==\"review\")'"
+
+# reconcile_git_automation_states — drive the team to the contract. The function
+# is best-effort and tolerant; we assert it issues the right mutations and never
+# emits a null stateId. Fetched states carry PR (s-pr) and Done (s-done).
+FETCHED_GA='[{"id":"s-pr","name":"PR","type":"started"},{"id":"s-done","name":"Done","type":"completed"},{"id":"s-triage","name":"Triage","type":"started"}]'
+
+# A fake curl that logs every request body, branches on git-automation ops, and
+# returns a team whose automations are: start→Triage (WRONG), merge→Done (right),
+# plus a review node (must be deleted).
+make_ga_curl() {
+  local bin_dir="$1" log="$2"
+  mkdir -p "$bin_dir"
+  cat > "${bin_dir}/curl" <<SCRIPT
+#!/usr/bin/env bash
+body="\$(cat 2>/dev/null)"
+for a in "\$@"; do case "\$a" in {*) body="\$a";; esac; done
+echo "\$body" >> "${log}"
+case "\$body" in
+  *gitAutomationStateCreate*) echo '{"data":{"gitAutomationStateCreate":{"success":true}}}' ;;
+  *gitAutomationStateUpdate*) echo '{"data":{"gitAutomationStateUpdate":{"success":true}}}' ;;
+  *gitAutomationStateDelete*) echo '{"data":{"gitAutomationStateDelete":{"success":true}}}' ;;
+  *gitAutomationStates*) echo '{"data":{"team":{"gitAutomationStates":{"nodes":[{"id":"ga-start","event":"start","state":{"id":"s-triage","name":"Triage"}},{"id":"ga-merge","event":"merge","state":{"id":"s-done","name":"Done"}},{"id":"ga-review","event":"review","state":{"id":"s-val","name":"Validate"}}]}}}}' ;;
+  *) echo '{"data":{}}' ;;
+esac
+exit 0
+SCRIPT
+  chmod +x "${bin_dir}/curl"
+}
+
+GA_BIN="${SCRATCH}/ga/bin"
+GA_LOG="${SCRATCH}/ga/req.log"
+mkdir -p "${SCRATCH}/ga"
+: > "$GA_LOG"
+make_ga_curl "$GA_BIN" "$GA_LOG"
+
+PATH="$GA_BIN:$PATH" reconcile_git_automation_states "team-xyz" "fake-token" "$FETCHED_GA" \
+  > "${SCRATCH}/ga-out" 2>&1
+
+run "reconcile updates the wrong 'start' automation (Triage -> PR)" \
+  bash -c "grep -q 'gitAutomationStateUpdate' '$GA_LOG' && grep -q 's-pr' '$GA_LOG'"
+
+run "reconcile deletes the 'review' automation node" \
+  bash -c "grep -q 'gitAutomationStateDelete' '$GA_LOG' && grep -q 'ga-review' '$GA_LOG'"
+
+run "reconcile no-ops the already-correct 'merge' automation (no update for merge)" \
+  bash -c "! grep -q 's-done' '$GA_LOG' || grep -q 'already correct' '${SCRATCH}/ga-out'"
+
+run "reconcile never issues a create with a missing target state" \
+  bash -c "echo '$FETCHED_GA' | jq -e 'map(.name) | index(\"PR\") and index(\"Done\")'"
+
+# Missing target state => WARN, never a null stateId, exit stays 0.
+FETCHED_NO_PR='[{"id":"s-done","name":"Done","type":"completed"},{"id":"s-triage","name":"Triage","type":"started"}]'
+GA_BIN2="${SCRATCH}/ga2/bin"
+GA_LOG2="${SCRATCH}/ga2/req.log"
+mkdir -p "${SCRATCH}/ga2"
+: > "$GA_LOG2"
+make_ga_curl "$GA_BIN2" "$GA_LOG2"
+
+PATH="$GA_BIN2:$PATH" reconcile_git_automation_states "team-xyz" "fake-token" "$FETCHED_NO_PR" \
+  > "${SCRATCH}/ga2-out" 2>&1
+GA2_RC=$?
+
+run "missing target 'PR' => WARN about skipping start" \
+  bash -c "grep -qi 'PR' '${SCRATCH}/ga2-out' && grep -qi 'skipping' '${SCRATCH}/ga2-out'"
+
+run "missing target state => no null stateId issued in any request" \
+  bash -c "! grep -qE 'stateId\":null|stateId\": *null' '$GA_LOG2'"
+
+run "reconcile tolerant — returns 0 even with a missing target state" \
+  bash -c "[ '$GA2_RC' = '0' ]"
+
 # ─── Layer 2: E2E with a stubbed curl ────────────────────────────────────────
 
 # Build a fixture repo with .catalyst/config.json + a git repo + secrets.

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -207,6 +207,88 @@ if [[ -n $CONFIG_PATH ]]; then
 		if [[ $execution_core_gaps -gt 0 ]]; then
 			warnings+=("  Run setup-catalyst or plugins/dev/scripts/setup-execution-core-states.sh to fix the contract")
 		fi
+
+		# Linear git-automation drift check (CTL-759). The execution-core pipeline
+		# is the authority on Linear state; a `review` git automation, or a
+		# `start`/`merge` automation pointed somewhere other than PR/Done, is the
+		# CTL-758 backward-write footgun. This is a hot-path check, so the live
+		# gitAutomationStates query is TTL-gated behind a per-team cache; a fresh
+		# cache short-circuits the API call entirely. No per-project token → SOFT
+		# skip (no warning) — a token is required to query, and its absence is
+		# already surfaced elsewhere.
+		GIT_AUTO_TOKEN=""
+		if [[ -n $PROJECT_KEY ]]; then
+			GIT_AUTO_SECRETS="${CATALYST_CONFIG}/config-${PROJECT_KEY}.json"
+			if [[ -f $GIT_AUTO_SECRETS ]]; then
+				GIT_AUTO_TOKEN=$(jq -r '.catalyst.linear.apiToken // .linear.apiToken // empty' \
+					"$GIT_AUTO_SECRETS" 2>/dev/null)
+			fi
+		fi
+		if [[ -n $GIT_AUTO_TOKEN && -n $TEAM_KEY ]]; then
+			GIT_AUTO_CACHE="${CATALYST_CONFIG}/linear-git-automation-cache.json"
+			GIT_AUTO_TTL=$((6 * 60 * 60)) # 6h — automations rarely change
+			git_auto_nodes=""
+			git_auto_fresh=""
+			if [[ -f $GIT_AUTO_CACHE ]]; then
+				cache_ts=$(jq -r --arg k "$TEAM_KEY" '.[$k].fetchedAt // empty' \
+					"$GIT_AUTO_CACHE" 2>/dev/null)
+				if [[ -n $cache_ts ]]; then
+					now_ts=$(date +%s)
+					age=$((now_ts - cache_ts))
+					if [[ $age -ge 0 && $age -lt $GIT_AUTO_TTL ]]; then
+						git_auto_fresh="yes"
+						git_auto_nodes=$(jq -c --arg k "$TEAM_KEY" '.[$k].nodes // []' \
+							"$GIT_AUTO_CACHE" 2>/dev/null)
+					fi
+				fi
+			fi
+
+			if [[ -z $git_auto_fresh ]] && command -v curl &>/dev/null; then
+				# Cache miss/stale → one live query, then persist keyed by teamKey.
+				ga_query='query($teamKey: String!) { teams(filter: { key: { eq: $teamKey } }) { nodes { gitAutomationStates { nodes { id event state { id name } } } } } }'
+				ga_payload=$(jq -nc --arg q "$ga_query" --arg k "$TEAM_KEY" \
+					'{query: $q, variables: {teamKey: $k}}')
+				ga_resp=$(curl -s --max-time 5 -X POST https://api.linear.app/graphql \
+					-H "Content-Type: application/json" \
+					-H "Authorization: ${GIT_AUTO_TOKEN}" \
+					-d "$ga_payload" 2>/dev/null || true)
+				if [[ -n $ga_resp ]] && ! echo "$ga_resp" | jq -e '.errors' >/dev/null 2>&1; then
+					git_auto_nodes=$(echo "$ga_resp" \
+						| jq -c '.data.teams.nodes[0].gitAutomationStates.nodes // []' 2>/dev/null)
+					if [[ -n $git_auto_nodes && $git_auto_nodes != "null" ]]; then
+						mkdir -p "$CATALYST_CONFIG"
+						tmp_cache="$(mktemp)"
+						existing_cache='{}'
+						[[ -f $GIT_AUTO_CACHE ]] && existing_cache="$(cat "$GIT_AUTO_CACHE" 2>/dev/null || echo '{}')"
+						echo "$existing_cache" | jq \
+							--arg k "$TEAM_KEY" \
+							--argjson nodes "$git_auto_nodes" \
+							--argjson ts "$(date +%s)" \
+							'.[$k] = { fetchedAt: $ts, nodes: $nodes }' \
+							> "$tmp_cache" 2>/dev/null \
+							&& mv "$tmp_cache" "$GIT_AUTO_CACHE" \
+							|| rm -f "$tmp_cache"
+					fi
+				fi
+			fi
+
+			# Evaluate whatever nodes we have (cached or freshly fetched).
+			if [[ -n $git_auto_nodes && $git_auto_nodes != "null" && $git_auto_nodes != "[]" ]]; then
+				review_count=$(echo "$git_auto_nodes" | jq -r '[.[] | select(.event == "review")] | length' 2>/dev/null || echo 0)
+				start_state=$(echo "$git_auto_nodes" | jq -r '[.[] | select(.event == "start")][0].state.name // empty' 2>/dev/null)
+				merge_state=$(echo "$git_auto_nodes" | jq -r '[.[] | select(.event == "merge")][0].state.name // empty' 2>/dev/null)
+				if [[ ${review_count:-0} -gt 0 ]]; then
+					warnings+=("Linear 'review' git automation is set for team '$TEAM_KEY' — it conflicts with execution-core state authority (CTL-758)")
+					warnings+=("  Run plugins/dev/scripts/setup-execution-core-states.sh to remove it")
+				fi
+				if [[ -n $start_state && $start_state != "PR" ]]; then
+					warnings+=("Linear 'start' git automation for team '$TEAM_KEY' points at '$start_state' (expected 'PR')")
+				fi
+				if [[ -n $merge_state && $merge_state != "Done" ]]; then
+					warnings+=("Linear 'merge' git automation for team '$TEAM_KEY' points at '$merge_state' (expected 'Done')")
+				fi
+			fi
+		fi
 	fi
 
 	# Check Linear webhook registration (CTL-253) — gates whether Linear events reach the event log.

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -303,6 +303,21 @@ if [[ -f "$HOME_CONFIG_PATH" ]]; then
     fi
 fi
 
+# ─── Linear Git Automation (CTL-759) ───────────────────────────────────────
+
+header "Linear Git Automation"
+
+# The execution-core pipeline is the single authority on Linear ticket state.
+# Linear's branch-name "magic words" toggle (Settings → Team → Workflow → Git)
+# auto-moves a ticket when a branch/PR name matches the ticket id — which races
+# the daemon and produces the CTL-758 backward-write footgun. This is a UI-only
+# setting with no API surface, so we cannot read or fix it from here; surface a
+# static reminder. The git-automation STATE moves (start→PR, merge→Done) are
+# managed for you by setup-execution-core-states.sh.
+warn "Linear 'magic words' auto-move must be OFF (Settings → Team → Workflow → Git)"
+info "It races the execution-core daemon (CTL-758 backward-write). Disable it in the Linear UI."
+info "Git-automation state moves (start→PR, merge→Done) are reconciled by setup-execution-core-states.sh."
+
 # ─── 7. OTel Observability Stack (optional) ────────────────────────────────
 
 header "Observability Stack (optional)"

--- a/plugins/dev/scripts/execution-core/linear-state-write-event.mjs
+++ b/plugins/dev/scripts/execution-core/linear-state-write-event.mjs
@@ -1,0 +1,106 @@
+// linear-state-write-event.mjs — canonical linear.state.write audit event (CTL-757).
+//
+// Emits an INFO observability event whenever the execution-core daemon writes a
+// Linear workflow STATE (status) for a ticket. The keystone of JOB2 PR1: it makes
+// every daemon-initiated Linear state-write observable in the unified event log,
+// distinct from the inbound `state_changed` webhook echoes (channel "webhook").
+//
+// Cloned from triage-transition-event.mjs (CTL-704) — same OTLP envelope, same
+// injectable append seam, same swallow-on-error contract. Kept a separate module
+// because it is a DIFFERENT event family: triage's auto Todo→Triage transition
+// keeps its own phase.triage.linear-transition.<T> event (CTL-704); this one
+// covers the FIVE scheduler write sites (scheduler-advance, parked-redispatch,
+// preemption-resume, terminal-sweep, reconcile-backstop — CTL-758).
+//
+// CALLER-EMITS: the helper is invoked from each scheduler write site (where the
+// source/phase/reason are known), NOT from inside runTransition — emitting inside
+// runTransition would double-audit the triage path.
+//
+// channel="execution-core" (NOT "webhook"): the jq separator the broker/wait-for
+// predicates use to tell inbound state_changed echoes apart from daemon writes.
+// actor="catalyst.execution-core": the human-vs-daemon discriminator the inbound
+// webhook echo lacks.
+import { randomBytes } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { getEventLogPath, log } from "./config.mjs";
+
+// defaultAppend — writes a JSONL line to the canonical event log.
+function defaultAppend(line) {
+  const logPath = getEventLogPath();
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, line);
+}
+
+// buildLinearStateWriteEvent — returns a canonical JSONL line (string + "\n")
+// for the linear.state.write.<TICKET> INFO event.
+export function buildLinearStateWriteEvent({
+  ticket,
+  orchId = null,
+  from_state = null,
+  to_state = null,
+  transition_key = null,
+  phase = null,
+  source = null,
+  reason = null,
+  applied = false,
+  verified = false,
+  actor = "catalyst.execution-core",
+} = {}) {
+  const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  return (
+    JSON.stringify({
+      ts,
+      id: randomBytes(8).toString("hex"),
+      observedTs: ts,
+      severityText: "INFO",
+      severityNumber: 9,
+      traceId: randomBytes(16).toString("hex"),
+      spanId: randomBytes(8).toString("hex"),
+      // channel="execution-core" — NOT "webhook"; the jq separator that tells a
+      // daemon-initiated state-write apart from an inbound state_changed echo.
+      channel: "execution-core",
+      resource: {
+        "service.name": "catalyst.execution-core",
+        "service.namespace": "catalyst",
+      },
+      attributes: {
+        "event.name": `linear.state.write.${ticket}`,
+        "event.entity": "linear",
+        "event.action": "state-write",
+        "event.label": ticket,
+        "event.channel": "execution-core",
+        "catalyst.orchestration": orchId ?? ticket,
+        "linear.issue.identifier": ticket,
+      },
+      body: {
+        payload: {
+          ticket,
+          actor,
+          source,
+          phase,
+          transition_key,
+          from_state,
+          to_state,
+          applied,
+          verified,
+          reason,
+        },
+      },
+    }) + "\n"
+  );
+}
+
+// appendLinearStateWriteEvent — appends the event to the canonical event log.
+// The `append` seam defaults to the real file write; inject a recording function
+// in tests. Returns true on success, false on any error (log.error + swallow).
+export function appendLinearStateWriteEvent({ append = defaultAppend, ...fields } = {}) {
+  try {
+    const line = buildLinearStateWriteEvent(fields);
+    append(line);
+    return true;
+  } catch (err) {
+    log.error({ err: err.message }, "linear-state-write-event: append failed");
+    return false;
+  }
+}

--- a/plugins/dev/scripts/execution-core/linear-state-write-event.mjs
+++ b/plugins/dev/scripts/execution-core/linear-state-write-event.mjs
@@ -9,8 +9,9 @@
 // injectable append seam, same swallow-on-error contract. Kept a separate module
 // because it is a DIFFERENT event family: triage's auto Todo→Triage transition
 // keeps its own phase.triage.linear-transition.<T> event (CTL-704); this one
-// covers the FIVE scheduler write sites (scheduler-advance, parked-redispatch,
-// preemption-resume, terminal-sweep, reconcile-backstop — CTL-758).
+// covers the FOUR scheduler write sites (scheduler-advance, preemption-resume,
+// terminal-sweep, reconcile-backstop — CTL-758). (`parked-redispatch` is not a
+// distinct source tag — it reuses the advance / preemption-resume write sites.)
 //
 // CALLER-EMITS: the helper is invoked from each scheduler write site (where the
 // source/phase/reason are known), NOT from inside runTransition — emitting inside

--- a/plugins/dev/scripts/execution-core/linear-state-write-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-state-write-event.test.mjs
@@ -1,0 +1,133 @@
+// linear-state-write-event.test.mjs — CTL-757: canonical linear.state.write event.
+// Run: cd plugins/dev/scripts/execution-core && bun test linear-state-write-event.test.mjs
+//
+// Mirrors triage-transition-event.test.mjs: envelope shape, channel!=webhook,
+// payload round-trip, append-swallow.
+import { describe, test, expect } from "bun:test";
+import {
+  buildLinearStateWriteEvent,
+  appendLinearStateWriteEvent,
+} from "./linear-state-write-event.mjs";
+
+describe("buildLinearStateWriteEvent", () => {
+  test("envelope shape — required attributes, resource, severityText, payload", () => {
+    const line = buildLinearStateWriteEvent({
+      ticket: "CTL-757",
+      orchId: "CTL-757",
+      from_state: "Research",
+      to_state: "Plan",
+      transition_key: "planning",
+      phase: "plan",
+      source: "scheduler-advance",
+      applied: true,
+    });
+    expect(typeof line).toBe("string");
+    expect(line.endsWith("\n")).toBe(true);
+    const ev = JSON.parse(line);
+    expect(ev.attributes["event.name"]).toBe("linear.state.write.CTL-757");
+    expect(ev.attributes["event.entity"]).toBe("linear");
+    expect(ev.attributes["event.action"]).toBe("state-write");
+    expect(ev.attributes["linear.issue.identifier"]).toBe("CTL-757");
+    expect(ev.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(ev.severityText).toBe("INFO");
+    expect(ev.severityNumber).toBe(9);
+    expect(ev.body.payload).toMatchObject({
+      ticket: "CTL-757",
+      actor: "catalyst.execution-core",
+      source: "scheduler-advance",
+      phase: "plan",
+      transition_key: "planning",
+      from_state: "Research",
+      to_state: "Plan",
+      applied: true,
+      verified: false,
+      reason: null,
+    });
+    expect(ev.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  test("channel is execution-core, NOT webhook (distinguishes daemon-write from inbound echo)", () => {
+    const ev = JSON.parse(buildLinearStateWriteEvent({ ticket: "CTL-757" }));
+    expect(ev.channel).toBe("execution-core");
+    expect(ev.channel).not.toBe("webhook");
+    expect(ev.attributes["event.channel"]).toBe("execution-core");
+    expect(ev.attributes["event.channel"]).not.toBe("webhook");
+  });
+
+  test("actor defaults to catalyst.execution-core (human-vs-daemon discriminator)", () => {
+    const ev = JSON.parse(buildLinearStateWriteEvent({ ticket: "CTL-757" }));
+    expect(ev.body.payload.actor).toBe("catalyst.execution-core");
+    expect(ev.resource["service.name"]).toBe("catalyst.execution-core");
+  });
+
+  test("payload round-trip — all caller-supplied fields survive serialization", () => {
+    const ev = JSON.parse(
+      buildLinearStateWriteEvent({
+        ticket: "CTL-758",
+        orchId: "ORCH-1",
+        from_state: "Done",
+        to_state: "Done",
+        transition_key: "done",
+        phase: "monitor-deploy",
+        source: "terminal-sweep",
+        reason: "skipped-terminal-no-backward",
+        applied: false,
+        verified: true,
+      })
+    );
+    expect(ev.attributes["catalyst.orchestration"]).toBe("ORCH-1");
+    expect(ev.body.payload).toEqual({
+      ticket: "CTL-758",
+      actor: "catalyst.execution-core",
+      source: "terminal-sweep",
+      phase: "monitor-deploy",
+      transition_key: "done",
+      from_state: "Done",
+      to_state: "Done",
+      applied: false,
+      verified: true,
+      reason: "skipped-terminal-no-backward",
+    });
+  });
+
+  test("orchId defaults to ticket when omitted", () => {
+    const ev = JSON.parse(buildLinearStateWriteEvent({ ticket: "CTL-1" }));
+    expect(ev.attributes["catalyst.orchestration"]).toBe("CTL-1");
+  });
+
+  test("reason field defaults to null when omitted", () => {
+    const ev = JSON.parse(buildLinearStateWriteEvent({ ticket: "CTL-1" }));
+    expect(ev.body.payload.reason).toBeNull();
+  });
+});
+
+describe("appendLinearStateWriteEvent", () => {
+  test("best-effort: injected appendFn that throws returns false and does not throw", () => {
+    const result = appendLinearStateWriteEvent({
+      ticket: "CTL-757",
+      append: () => {
+        throw new Error("disk full");
+      },
+    });
+    expect(result).toBe(false);
+  });
+
+  test("best-effort: injected appendFn is called with valid JSONL, returns true", () => {
+    const appended = [];
+    const result = appendLinearStateWriteEvent({
+      ticket: "CTL-757",
+      orchId: "CTL-757",
+      from_state: "Research",
+      to_state: "Plan",
+      source: "scheduler-advance",
+      applied: true,
+      append: (line) => appended.push(line),
+    });
+    expect(result).toBe(true);
+    expect(appended).toHaveLength(1);
+    const ev = JSON.parse(appended[0]);
+    expect(ev.attributes["event.name"]).toBe("linear.state.write.CTL-757");
+    expect(ev.channel).toBe("execution-core");
+    expect(ev.body.payload.source).toBe("scheduler-advance");
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-state-write-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-state-write-event.test.mjs
@@ -9,6 +9,22 @@ import {
   appendLinearStateWriteEvent,
 } from "./linear-state-write-event.mjs";
 
+// Local mirror of broker/router.mjs shouldSkipEvent (CTL-401). The broker package
+// has its own node_modules (pino) that the targeted scripts test-runner does not
+// install, so importing the real router would fail with "Cannot find package
+// 'pino'" (memory: fresh-worktree bun install). The skip predicate is tiny and
+// stable; mirror it here verbatim and pin it with a shape-guard test below so a
+// drift in EITHER the predicate or the event is caught. getEventName mirrors the
+// broker's: attributes["event.name"] is the canonical name.
+function shouldSkipEventMirror(event) {
+  if (event.resource?.["service.name"] === "catalyst.broker") return true;
+  const name = event.attributes?.["event.name"] ?? "";
+  if (name.startsWith("filter.")) return true;
+  if (name.startsWith("broker.daemon")) return true;
+  if (name === "session.heartbeat") return true;
+  return false;
+}
+
 describe("buildLinearStateWriteEvent", () => {
   test("envelope shape — required attributes, resource, severityText, payload", () => {
     const line = buildLinearStateWriteEvent({
@@ -98,6 +114,40 @@ describe("buildLinearStateWriteEvent", () => {
   test("reason field defaults to null when omitted", () => {
     const ev = JSON.parse(buildLinearStateWriteEvent({ ticket: "CTL-1" }));
     expect(ev.body.payload.reason).toBeNull();
+  });
+});
+
+// Plan Top-Risk: "Event-log schema collision — verify linear.state.write.<ticket>
+// name/channel don't collide with a broker shouldSkipEvent predicate." The broker
+// self-filters its OWN emissions; the new audit event MUST flow through (it is not
+// a broker/filter/heartbeat emission), or the HUD / wait-for would never see it.
+describe("CTL-757: no collision with broker shouldSkipEvent", () => {
+  test("the built linear.state.write event is NOT skipped by the broker predicate", () => {
+    const ev = JSON.parse(
+      buildLinearStateWriteEvent({
+        ticket: "CTL-757",
+        from_state: "Research",
+        to_state: "Plan",
+        source: "scheduler-advance",
+        applied: true,
+      })
+    );
+    // service.name is catalyst.execution-core (not catalyst.broker), name is
+    // linear.state.write.* (not filter./broker.daemon/session.heartbeat).
+    expect(shouldSkipEventMirror(ev)).toBe(false);
+  });
+
+  test("the discriminating attributes the broker keys on are all NON-skip values", () => {
+    // Pins WHY the event survives: if a future edit moved service.name to
+    // catalyst.broker, renamed the event to filter./broker.daemon, or collapsed
+    // it to session.heartbeat, one of these asserts (and the mirror test) fails.
+    const ev = JSON.parse(buildLinearStateWriteEvent({ ticket: "CTL-757" }));
+    expect(ev.resource?.["service.name"]).not.toBe("catalyst.broker");
+    const name = ev.attributes?.["event.name"] ?? "";
+    expect(name.startsWith("filter.")).toBe(false);
+    expect(name.startsWith("broker.daemon")).toBe(false);
+    expect(name).not.toBe("session.heartbeat");
+    expect(name).toBe("linear.state.write.CTL-757");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -11,6 +11,10 @@ import { getProjectConfig } from "./registry.mjs";
 import { log } from "./config.mjs";
 import { fetchTicketLabels, fetchTicketState } from "./linear-query.mjs";
 import { withBreaker } from "./linear-breaker.mjs";
+// CTL-758: the SHARED Linear terminal-state predicate ({Done,Canceled} — its OWN
+// set, NOT TERMINAL_LINEAR_KEY which is the transition KEY "done"). Gates the
+// backward-write guard below.
+import { isLinearTerminal } from "./terminal-state.mjs";
 
 // linear-transition.sh sits one directory up from execution-core/ — mirrors the
 // sibling-bin spawnSync pattern dispatch.mjs uses for orchestrate-dispatch-next.
@@ -61,6 +65,17 @@ function runTransition({
   key,
   resolveRepoRoot = defaultResolveRepoRoot,
   exec = defaultExec,
+  // CTL-758: the SHARED TTL state cache + fetchState seam for the backward-write
+  // guard. fetchState defaults to the real linear-query helper; cache defaults
+  // undefined (the guard then does ONE cheap read per non-terminal-key write —
+  // and callers that thread the scheduler's shared cache pay ≤1 read per ticket
+  // per TTL). Both injectable so tests never shell out.
+  fetchState = fetchTicketState,
+  cache,
+  // CTL-758: a caller that ALREADY read the pre-transition state (applyTriageStatus
+  // reads from_state before this call) passes it here so the guard reuses it
+  // instead of issuing a second read. undefined → the guard reads for itself.
+  knownCurrentState,
 }) {
   try {
     const repoRoot = resolveRepoRoot(ticket);
@@ -68,6 +83,38 @@ function runTransition({
       log.warn({ ticket, key }, "linear-write: no repoRoot — skipping status write");
       return { applied: false, reason: "no-repo-root", from_state: null, to_state: null };
     }
+
+    // CTL-758 — BACKWARD-WRITE GUARD. linear-transition.sh only guards
+    // CURRENT==TARGET; it does NOT refuse a backward move. A daemon write that
+    // would drag a ticket already at a terminal Linear state (Done/Canceled) BACK
+    // to a non-terminal state (PR, Research, …) is the CTL-549/550/749 regression
+    // — a late phase-pr/advance echo un-completing a finished ticket. So for a
+    // NON-terminal target key we pre-read the current state (cheap, cached) and,
+    // if it is already terminal, SKIP the shell entirely.
+    //
+    // CRITICAL SAFETY: the forward terminal write (key === TERMINAL_LINEAR_KEY,
+    // i.e. "done" — applyTerminalDone + the reconcile backstop) is EXPLICITLY
+    // EXEMPT from this guard. It must always proceed, or every monitor-deploy Done
+    // write is blocked and tickets strand at PR. We only read+guard for
+    // key !== TERMINAL_LINEAR_KEY, so the forward Done path never even reads here.
+    if (key !== TERMINAL_LINEAR_KEY) {
+      const current =
+        knownCurrentState !== undefined ? knownCurrentState : fetchState(ticket, { exec, cache });
+      if (isLinearTerminal(current)) {
+        log.warn(
+          { ticket, key, current },
+          "ctl-758: refusing backward write — ticket already at terminal Linear state, skipping shell",
+        );
+        return {
+          applied: false,
+          skipped: "terminal-no-backward",
+          reason: "skipped-terminal-no-backward",
+          from_state: current,
+          to_state: null,
+        };
+      }
+    }
+
     const config = `${repoRoot}/.catalyst/config.json`;
     const { code, stdout } = exec(LINEAR_TRANSITION_BIN, [
       "--ticket",
@@ -107,15 +154,21 @@ function runTransition({
 
 // applyPhaseStatus — write the Linear state mapped to `phase`. Idempotent
 // (linear-transition.sh read-compares first). triage → no-op (no status key).
-export function applyPhaseStatus({ ticket, phase, resolveRepoRoot, exec }) {
+// CTL-758: `cache` is threaded through to runTransition's backward-write guard
+// so the per-tick shared TTL cache (createTicketStateCache) serves the guard's
+// pre-write read — ≤1 fetchTicketState per ticket per TTL, not a new API storm.
+export function applyPhaseStatus({ ticket, phase, resolveRepoRoot, exec, cache }) {
   const key = linearKeyForPhase(phase); // throws PhaseFsmError on an unknown phase
   if (key === null) return { applied: false, skipped: "no-status-key" };
-  return runTransition({ ticket, key, resolveRepoRoot, exec });
+  return runTransition({ ticket, key, resolveRepoRoot, exec, cache });
 }
 
 // applyTerminalDone — write the terminal Done state on monitor-deploy completion.
-export function applyTerminalDone({ ticket, resolveRepoRoot, exec }) {
-  return runTransition({ ticket, key: TERMINAL_LINEAR_KEY, resolveRepoRoot, exec });
+// CTL-758: this is the FORWARD terminal write (key === TERMINAL_LINEAR_KEY) — it
+// is EXEMPT from the backward-write guard, so runTransition does not read state
+// here. `cache` is forwarded for symmetry (unused by the exempt path).
+export function applyTerminalDone({ ticket, resolveRepoRoot, exec, cache }) {
+  return runTransition({ ticket, key: TERMINAL_LINEAR_KEY, resolveRepoRoot, exec, cache });
 }
 
 // applyLabel — additively apply a Linear label (needs-human), classify
@@ -230,8 +283,18 @@ export function applyTriageStatus({
     // 1. Capture pre-transition state (best-effort — null is acceptable).
     from_state = fetchState(ticket, { exec });
 
-    // 2. Shell the transition.
-    const t = runTransition({ ticket, key: "triage", resolveRepoRoot, exec });
+    // 2. Shell the transition. CTL-758: pass the from_state we just read as
+    //    knownCurrentState so the backward-write guard reuses it (no second read).
+    //    A Todo→Triage move is forward, but the guard still correctly refuses it
+    //    if the ticket is somehow already terminal (Done/Canceled) — without an
+    //    extra linearis call.
+    const t = runTransition({
+      ticket,
+      key: "triage",
+      resolveRepoRoot,
+      exec,
+      knownCurrentState: from_state,
+    });
     if (!t.applied) {
       return { applied: false, verified: false, from_state, to_state: null, reason: t.reason };
     }

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -45,8 +45,17 @@ function defaultResolveRepoRoot(ticket) {
 }
 
 // runTransition — shell linear-transition.sh for one logical key. Best-effort:
-// returns { applied, reason } and never throws. Parses the --json result and
-// treats a zero exit (with no "update-failed" action) as applied.
+// returns { applied, reason, action, from_state, to_state } and never throws.
+// Parses the --json result and treats a zero exit (with no "update-failed"
+// action) as applied.
+//
+// CTL-757: the shell already computes `.currentState` (the pre-transition state
+// it read for its idempotency check) and `.targetState` (the resolved target).
+// Surfacing them as from_state/to_state is FREE — no extra Linear read — and
+// gives the caller-emitted linear.state.write audit event its before/after pair.
+// The SAME current-state read also serves the CTL-758 backward-write guard.
+// from_state/to_state default to null when the shell emits non-JSON (no-linearis,
+// spawn error) or omits the fields (older stub).
 function runTransition({
   ticket,
   key,
@@ -57,7 +66,7 @@ function runTransition({
     const repoRoot = resolveRepoRoot(ticket);
     if (!repoRoot) {
       log.warn({ ticket, key }, "linear-write: no repoRoot — skipping status write");
-      return { applied: false, reason: "no-repo-root" };
+      return { applied: false, reason: "no-repo-root", from_state: null, to_state: null };
     }
     const config = `${repoRoot}/.catalyst/config.json`;
     const { code, stdout } = exec(LINEAR_TRANSITION_BIN, [
@@ -70,22 +79,29 @@ function runTransition({
       "--json",
     ]);
     let action = null;
+    let from_state = null;
+    let to_state = null;
     try {
-      action = JSON.parse(stdout)?.action ?? null;
+      const parsed = JSON.parse(stdout) ?? {};
+      action = parsed.action ?? null;
+      // currentState/targetState are empty strings when unresolved — normalise
+      // to null so the audit payload never carries a misleading "".
+      from_state = parsed.currentState || null;
+      to_state = parsed.targetState || null;
     } catch {
-      /* non-JSON stdout — leave action null */
+      /* non-JSON stdout — leave action/from_state/to_state null */
     }
     const applied = code === 0 && action !== "update-failed";
     if (!applied) {
       log.warn({ ticket, key, code, action }, "linear-write: status write not applied");
     }
-    return { applied, reason: applied ? null : `exit-${code}`, action };
+    return { applied, reason: applied ? null : `exit-${code}`, action, from_state, to_state };
   } catch (err) {
     log.warn(
       { ticket, key, err: err.message },
       "linear-write: status write threw — swallowed"
     );
-    return { applied: false, reason: "threw" };
+    return { applied: false, reason: "threw", from_state: null, to_state: null };
   }
 }
 

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -100,6 +100,105 @@ describe("applyTerminalDone", () => {
   });
 });
 
+// CTL-757: runTransition (via applyPhaseStatus/applyTerminalDone) returns
+// from_state/to_state parsed from linear-transition.sh's --json currentState/
+// targetState — FREE (no extra read), feeds the caller-emitted state.write event.
+describe("CTL-757: runTransition from_state/to_state propagation", () => {
+  const resolveRepoRoot = () => "/repo";
+
+  // A transition exec that mirrors linear-transition.sh's emit() JSON shape.
+  function transitionExec({ action = "transitioned", currentState = "", targetState = "", code = 0 } = {}) {
+    return () => ({
+      code,
+      stdout: JSON.stringify({ ticket: "CTL-1", currentState, targetState, action }),
+      stderr: "",
+    });
+  }
+
+  test("applyPhaseStatus surfaces from_state/to_state from the shell JSON", () => {
+    const r = applyPhaseStatus({
+      ticket: "CTL-1",
+      phase: "plan",
+      resolveRepoRoot,
+      exec: transitionExec({ currentState: "Research", targetState: "Plan" }),
+    });
+    expect(r.applied).toBe(true);
+    expect(r.from_state).toBe("Research");
+    expect(r.to_state).toBe("Plan");
+  });
+
+  test("applyTerminalDone surfaces from_state/to_state", () => {
+    const r = applyTerminalDone({
+      ticket: "CTL-1",
+      resolveRepoRoot,
+      exec: transitionExec({ currentState: "PR", targetState: "Done" }),
+    });
+    expect(r.from_state).toBe("PR");
+    expect(r.to_state).toBe("Done");
+  });
+
+  test("idempotent skip (from==to, action:skipped) — applied:true, from_state==to_state", () => {
+    const r = applyPhaseStatus({
+      ticket: "CTL-1",
+      phase: "verify",
+      resolveRepoRoot,
+      exec: transitionExec({ action: "skipped", currentState: "Validate", targetState: "Validate" }),
+    });
+    expect(r.applied).toBe(true);
+    expect(r.from_state).toBe("Validate");
+    expect(r.to_state).toBe("Validate");
+    expect(r.from_state).toBe(r.to_state);
+  });
+
+  test("failure path (exit non-zero, update-failed) still returns from_state + reason", () => {
+    const r = applyPhaseStatus({
+      ticket: "CTL-1",
+      phase: "plan",
+      resolveRepoRoot,
+      exec: transitionExec({ action: "update-failed", currentState: "Research", targetState: "Plan", code: 1 }),
+    });
+    expect(r.applied).toBe(false);
+    expect(r.reason).toBe("exit-1");
+    expect(r.from_state).toBe("Research");
+    expect(r.to_state).toBe("Plan");
+  });
+
+  test("empty currentState/targetState normalise to null (not empty string)", () => {
+    const r = applyPhaseStatus({
+      ticket: "CTL-1",
+      phase: "plan",
+      resolveRepoRoot,
+      exec: transitionExec({ currentState: "", targetState: "" }),
+    });
+    expect(r.from_state).toBeNull();
+    expect(r.to_state).toBeNull();
+  });
+
+  test("non-JSON stdout (no-linearis / spawn) → from_state/to_state null, applied stays false", () => {
+    const r = applyPhaseStatus({
+      ticket: "CTL-1",
+      phase: "plan",
+      resolveRepoRoot,
+      exec: () => ({ code: 1, stdout: "not json", stderr: "boom" }),
+    });
+    expect(r.from_state).toBeNull();
+    expect(r.to_state).toBeNull();
+    expect(r.applied).toBe(false);
+  });
+
+  test("no-repo-root path returns from_state/to_state null", () => {
+    const r = applyPhaseStatus({
+      ticket: "CTL-1",
+      phase: "plan",
+      resolveRepoRoot: () => null,
+      exec: transitionExec(),
+    });
+    expect(r.reason).toBe("no-repo-root");
+    expect(r.from_state).toBeNull();
+    expect(r.to_state).toBeNull();
+  });
+});
+
 describe("applyLabel", () => {
   // okExec returns exit-0 for BOTH the update call AND the CTL-587 read-back —
   // the read-back returns labels.nodes containing the requested label so the

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -49,7 +49,13 @@ describe("applyPhaseStatus", () => {
       resolveRepoRoot: () => "/repo",
       exec: okExec(calls),
     });
-    const args = calls[0].args;
+    // CTL-758: the backward-write guard pre-reads current state via
+    // `linearis issues read` for non-terminal keys, so the transition shell call
+    // is no longer necessarily calls[0]. Locate it explicitly by its --transition
+    // arg (the guard read has no --transition).
+    const transitionCall = calls.find((c) => c.args.includes("--transition"));
+    expect(transitionCall).toBeDefined();
+    const args = transitionCall.args;
     expect(args).toContain("--transition");
     expect(args[args.indexOf("--transition") + 1]).toBe("verifying");
     expect(args).toContain("--ticket");
@@ -97,6 +103,101 @@ describe("applyTerminalDone", () => {
     applyTerminalDone({ ticket: "CTL-1", resolveRepoRoot: () => "/repo", exec: okExec(calls) });
     const args = calls[0].args;
     expect(args[args.indexOf("--transition") + 1]).toBe("done");
+  });
+});
+
+// CTL-758: the backward-write guard in runTransition refuses to drag a ticket
+// already at a terminal Linear state (Done/Canceled) BACK to a non-terminal
+// state — EXCEPT the forward terminal write (key === "done"), which must always
+// proceed (the CRITICAL SAFETY case: a bug here strands every monitor-deploy at PR).
+describe("CTL-758: backward-write guard", () => {
+  const resolveRepoRoot = () => "/repo";
+
+  // exec that records calls AND returns the transition shell JSON. The guard's
+  // pre-read uses a SEPARATE injected fetchState, so any --transition call in
+  // `calls` proves the shell ran.
+  function recordingExec(calls) {
+    return (cmd, args) => {
+      calls.push({ cmd, args });
+      return { code: 0, stdout: JSON.stringify({ action: "transitioned", currentState: "PR", targetState: "Done" }), stderr: "" };
+    };
+  }
+  const ranShell = (calls) => calls.some((c) => c.args.includes("--transition"));
+
+  test("terminal current + NON-terminal key (verifying) ⇒ skips the shell (exec 0 --transition calls)", () => {
+    const calls = [];
+    const r = applyPhaseStatus({
+      ticket: "CTL-1",
+      phase: "verify", // → key "verifying", a non-terminal key
+      resolveRepoRoot,
+      exec: recordingExec(calls),
+      // shared cache reader proves the ticket is already Done
+      cache: { get: () => "Done", set: () => {} },
+      // when a cache hit exists fetchTicketState returns it without exec; but be
+      // explicit — the guard reads via fetchState(ticket,{exec,cache}).
+    });
+    expect(r.applied).toBe(false);
+    expect(r.skipped).toBe("terminal-no-backward");
+    expect(r.reason).toBe("skipped-terminal-no-backward");
+    expect(r.from_state).toBe("Done");
+    expect(ranShell(calls)).toBe(false); // CRITICAL: the shell never ran
+  });
+
+  test("Canceled current + non-terminal key ⇒ skips the shell", () => {
+    const calls = [];
+    const r = applyPhaseStatus({
+      ticket: "CTL-2",
+      phase: "plan",
+      resolveRepoRoot,
+      exec: recordingExec(calls),
+      cache: { get: () => "Canceled", set: () => {} },
+    });
+    expect(r.skipped).toBe("terminal-no-backward");
+    expect(ranShell(calls)).toBe(false);
+  });
+
+  test("NON-terminal current + non-terminal key ⇒ shell PROCEEDS (no false block)", () => {
+    const calls = [];
+    const r = applyPhaseStatus({
+      ticket: "CTL-3",
+      phase: "verify",
+      resolveRepoRoot,
+      exec: recordingExec(calls),
+      cache: { get: () => "PR", set: () => {} }, // non-terminal
+    });
+    expect(r.applied).toBe(true);
+    expect(ranShell(calls)).toBe(true);
+  });
+
+  // ── THE CRITICAL SAFETY TEST ──────────────────────────────────────────────
+  test("forward terminal write (key='done') PROCEEDS even when current state is terminal", () => {
+    // A ticket already at Done re-confirming Done via applyTerminalDone must NOT
+    // be blocked by the guard — key === TERMINAL_LINEAR_KEY is exempt, so the
+    // guard never even reads, and the idempotent shell runs.
+    const calls = [];
+    const cacheReads = [];
+    const r = applyTerminalDone({
+      ticket: "CTL-4",
+      resolveRepoRoot,
+      exec: recordingExec(calls),
+      cache: { get: (k) => { cacheReads.push(k); return "Done"; }, set: () => {} },
+    });
+    expect(r.applied).toBe(true);
+    expect(ranShell(calls)).toBe(true); // the forward Done write proceeded
+    // the guard is exempt for the terminal key → it never read the cache
+    expect(cacheReads.length).toBe(0);
+  });
+
+  test("non-terminal current + key='done' ⇒ proceeds (normal monitor-deploy Done)", () => {
+    const calls = [];
+    const r = applyTerminalDone({
+      ticket: "CTL-5",
+      resolveRepoRoot,
+      exec: recordingExec(calls),
+      cache: { get: () => "PR", set: () => {} },
+    });
+    expect(r.applied).toBe(true);
+    expect(ranShell(calls)).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -212,7 +212,7 @@ describe("CTL-758: backward-write guard", () => {
     // One exec serves BOTH the guard's cached `linearis issues read` AND any
     // `linear-transition.sh --transition` shell. Only the read path increments
     // `reads`; a non-terminal state means the guard proceeds to the shell.
-    const exec = (cmd, args) => {
+    const exec = (_cmd, args) => {
       if (args[0] === "issues" && args[1] === "read") {
         reads += 1;
         return { code: 0, stdout: JSON.stringify({ state: { name: "PR" } }), stderr: "" };
@@ -228,7 +228,7 @@ describe("CTL-758: backward-write guard", () => {
 
   test("WITHOUT a shared cache the guard re-reads each write (proves the cache is what dedups)", () => {
     let reads = 0;
-    const exec = (cmd, args) => {
+    const exec = (_cmd, args) => {
       if (args[0] === "issues" && args[1] === "read") {
         reads += 1;
         return { code: 0, stdout: JSON.stringify({ state: { name: "PR" } }), stderr: "" };

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -11,6 +11,7 @@ import {
   applyEstimate,
   teamOf,
 } from "./linear-write.mjs";
+import { createTicketStateCache } from "./linear-cache.mjs";
 
 const okExec = (calls) => (cmd, args) => {
   calls.push({ cmd, args });
@@ -198,6 +199,45 @@ describe("CTL-758: backward-write guard", () => {
     });
     expect(r.applied).toBe(true);
     expect(ranShell(calls)).toBe(true);
+  });
+
+  // ── API-STORM REGRESSION (plan Top-Risk: "Cache not threaded = single most
+  // likely regression"). Wire the REAL fetchTicketState through the guard with a
+  // shared TTL cache (the scheduler's threading) and assert the guard issues
+  // ≤1 underlying `linearis issues read` across TWO guarded writes within TTL.
+  // The guard read MUST flow through the injected `cache`, not re-exec per write.
+  test("guard read goes through the shared cache — ≤1 `issues read` exec per ticket per TTL", () => {
+    const cache = createTicketStateCache({ now: () => 0 }); // TTL never expires within the test
+    let reads = 0;
+    // One exec serves BOTH the guard's cached `linearis issues read` AND any
+    // `linear-transition.sh --transition` shell. Only the read path increments
+    // `reads`; a non-terminal state means the guard proceeds to the shell.
+    const exec = (cmd, args) => {
+      if (args[0] === "issues" && args[1] === "read") {
+        reads += 1;
+        return { code: 0, stdout: JSON.stringify({ state: { name: "PR" } }), stderr: "" };
+      }
+      // the transition shell
+      return { code: 0, stdout: JSON.stringify({ action: "transitioned", currentState: "PR", targetState: "Validate" }), stderr: "" };
+    };
+    // Two successive guarded writes (non-terminal key) for the SAME ticket.
+    applyPhaseStatus({ ticket: "CTL-9", phase: "verify", resolveRepoRoot, exec, cache });
+    applyPhaseStatus({ ticket: "CTL-9", phase: "verify", resolveRepoRoot, exec, cache });
+    expect(reads).toBe(1); // second guard read was a cache hit — no API storm
+  });
+
+  test("WITHOUT a shared cache the guard re-reads each write (proves the cache is what dedups)", () => {
+    let reads = 0;
+    const exec = (cmd, args) => {
+      if (args[0] === "issues" && args[1] === "read") {
+        reads += 1;
+        return { code: 0, stdout: JSON.stringify({ state: { name: "PR" } }), stderr: "" };
+      }
+      return { code: 0, stdout: JSON.stringify({ action: "transitioned", currentState: "PR", targetState: "Validate" }), stderr: "" };
+    };
+    applyPhaseStatus({ ticket: "CTL-9", phase: "verify", resolveRepoRoot, exec }); // no cache
+    applyPhaseStatus({ ticket: "CTL-9", phase: "verify", resolveRepoRoot, exec });
+    expect(reads).toBe(2); // no cache → one read per write (contrast to the dedup above)
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -49,6 +49,11 @@ import {
 import { defaultDispatch } from "./dispatch.mjs";
 import { applyLabel as defaultApplyLabel } from "./linear-write.mjs";
 import { linearBreaker } from "./linear-breaker.mjs";
+// CTL-642: the SHARED terminal-state predicate. The recovery short-circuit reuses
+// the scheduler's fetchTicketState + cache (threaded via reclaimOpts) so a
+// terminal/merged ticket adds ≤1 cached read; it is INERT when no reader is
+// threaded (the default for every legacy unit test).
+import { isTicketTerminalOrMerged } from "./terminal-state.mjs";
 // CTL-638: pull the once-marker + per-(ticket, phase) cool-down primitives
 // from the shared leaf module. labelOnce is the same guard CTL-585 introduced
 // for scheduler.mjs's `needs-human` path — pre-CTL-638 the recovery sweep's
@@ -1298,6 +1303,17 @@ export function reclaimDeadWorkIfPossible(
     // never treated as a human-intervention condition (and never adds to the
     // write storm). Injected for tests; defaults to the shared singleton.
     breaker = linearBreaker,
+    // CTL-642: the SHARED TTL state cache + fetchState + prAdapter for the
+    // terminal short-circuit (below). fetchState defaults to UNDEFINED (not the
+    // real linear-query helper) so the short-circuit is INERT unless a caller
+    // explicitly threads a reader: production wires fetchState: fetchTicketState +
+    // cache via the scheduler's reclaimOpts (scheduler.mjs:~1672), while every
+    // legacy unit test that omits it is byte-for-byte unchanged (no surprise
+    // network read, no false short-circuit). isTicketTerminalOrMerged no-ops when
+    // fetchState is not a function.
+    fetchState,
+    cache,
+    prAdapter,
     now = Date.now,
   } = {},
 ) {
@@ -1359,6 +1375,61 @@ export function reclaimDeadWorkIfPossible(
     recordEscalationFn(orchDir, ticket, phase, reason, now());
     log.warn({ ticket, phase, reason }, "ctl-587: escalated");
     return "escalated";
+  }
+
+  // CTL-642 — TERMINAL SHORT-CIRCUIT. Placed BEFORE the lifecycle/alive branch so
+  // it DOMINATES all three escalateOnce sites (alive busy-ceiling, no-probe,
+  // no-progress): a ticket the pipeline (or a human) has already finished
+  // (Linear state Done/Canceled) or whose PR already merged must NEVER be
+  // escalated to needs-human nor revived — those are the CTL-624/625
+  // merged-but-running-zombie and CTL-549/550 false-escalation storms. Runs for
+  // BOTH alive (the merged-but-still-running zombie) AND dead workers (a
+  // crashed-after-merge worker). On terminal/merged: flip the signal to `done`
+  // via emitComplete (so the scheduler drops it from the attention set next tick),
+  // audit it (completion_origin:"terminal-short-circuit"), and return the new
+  // outcome `terminal-short-circuit` (the scheduler treats it like reclaimed/noop
+  // — NO escalated event). Best-effort: a non-zero emitComplete falls through to
+  // the normal lifecycle path (re-evaluated next tick), never strands the ticket.
+  //
+  // The check is cheap-first (terminal-state.isTicketTerminalOrMerged): the cached
+  // Linear read runs first; the `gh` PR view runs ONLY when non-terminal AND a PR
+  // number exists. A null/unreadable read fails safe to NOT-terminal (D5), so a
+  // transient linearis outage never manufactures a false completion.
+  const terminalCheck = isTicketTerminalOrMerged({
+    ticket,
+    signal,
+    fetchState,
+    cache,
+    prAdapter,
+  });
+  if (terminalCheck.terminal) {
+    appendEvent({
+      phase,
+      ticket,
+      orchId,
+      death_signal: "terminal-short-circuit",
+      prev_state_json_mtime: prevStateJsonMtime,
+      probe_passed: false,
+      probe_checked: terminalCheck.reason,
+      completion_origin: "terminal-short-circuit",
+      reclaimed_bg_job_id: prevBgJobId,
+      stopped_bg_job_ids: [],
+      title: `phase ${phase} short-circuited (ticket already terminal)`,
+      body: `Daemon short-circuited ${ticket} ${phase}: ${terminalCheck.reason} (state=${terminalCheck.state ?? "?"}). Flipping signal to done; no escalation.`,
+    });
+    const sc = emitComplete({ orchDir, signal });
+    if (sc.code !== 0) {
+      log.warn(
+        { ticket, phase, code: sc.code, stderr: sc.stderr, reason: terminalCheck.reason },
+        "ctl-642: terminal short-circuit emit-complete failed; falling through to lifecycle path (retry next tick)",
+      );
+    } else {
+      log.info(
+        { ticket, phase, reason: terminalCheck.reason },
+        "ctl-642: terminal short-circuit — ticket already terminal/merged, signal flipped to done (no escalation)",
+      );
+      return "terminal-short-circuit";
+    }
   }
 
   // CTL-736 — THE DEATH TRIGGER. The authoritative LOCAL state.json lifecycle

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -1148,6 +1148,193 @@ describe("reclaimDeadWorkIfPossible — CTL-736 state.json death trigger", () =>
   });
 });
 
+// --- CTL-642: TERMINAL SHORT-CIRCUIT ---------------------------------------
+//
+// Placed BEFORE the lifecycle/alive branch so it DOMINATES all three escalateOnce
+// sites (alive busy-ceiling, no-probe, no-progress). A ticket already terminal
+// (Linear Done/Canceled) or whose PR merged must NEVER escalate to needs-human
+// nor revive — it flips its signal to done (emitComplete), audits with
+// completion_origin:"terminal-short-circuit", and returns the new outcome.
+describe("reclaimDeadWorkIfPossible — CTL-642 terminal short-circuit", () => {
+  const orch = "/orch";
+
+  // Deterministic seam set with the short-circuit ENABLED (fetchState threaded).
+  // Every escalateOnce-feeding gate is reachable; the short-circuit must win.
+  function seams(extra = {}) {
+    return {
+      repoRoot: "/repo",
+      probes: { implement: () => false },
+      emitComplete: recorder({ code: 0 }),
+      appendEvent: recorder(undefined),
+      appendReviveEvent: recorder(true),
+      appendEscalatedEvent: recorder(undefined),
+      appendReviveSuppressedEvent: recorder(undefined),
+      reviveDispatch: recorder({ code: 0 }),
+      applyStalledLabel: recorder({ applied: true }),
+      killBgJob: recorder(undefined),
+      countReviveEvents: recorder(0),
+      writeReviveMarker: recorder(undefined),
+      resolveSession: () => null,
+      postReclaimMirror: recorder(undefined),
+      listTicketPhases: () => ["implement"],
+      inEscalationCooldownFn: () => false,
+      recordEscalationFn: recorder(undefined),
+      emitReapIntent: () => Promise.resolve(),
+      readBootSince: () => undefined,
+      breaker: { isOpen: () => false },
+      now: () => 1_000_000,
+      ...extra,
+    };
+  }
+
+  // ── PATH 1: alive busy-ceiling. An alive worker past BUSY_CEILING_MS with no
+  // committed work would escalate "busy-ceiling-exceeded" — UNLESS terminal.
+  test("alive busy-ceiling path: terminal Linear state ⇒ 'terminal-short-circuit', emitComplete, NO escalated event", () => {
+    const emitComplete = recorder({ code: 0 });
+    const appendEscalatedEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(
+      orch,
+      implementSignal({ status: "running", startedAt: new Date(0).toISOString() }),
+      seams({
+        jobLifecycle: () => "alive",
+        busyCeilingMs: 1,
+        now: () => 10_000,
+        probes: { implement: () => false },
+        fetchState: () => "Done",
+        emitComplete,
+        appendEscalatedEvent,
+      }),
+    );
+    expect(r).toBe("terminal-short-circuit");
+    expect(emitComplete.calls.length).toBe(1);
+    expect(appendEscalatedEvent.calls.length).toBe(0); // never escalated
+  });
+
+  // ── PATH 2: no-probe-for-phase. A dead worker on a probe-less phase escalates
+  // "no-probe-for-phase" — UNLESS terminal.
+  test("no-probe path: merged PR ⇒ 'terminal-short-circuit', emitComplete, NO escalated event", () => {
+    const emitComplete = recorder({ code: 0 });
+    const appendEscalatedEvent = recorder(undefined);
+    const sig = { ...implementSignal({ status: "running" }), phase: "research" };
+    sig.raw.phase = "research";
+    sig.raw.pr = { number: 7, repo: "o/r" };
+    const r = reclaimDeadWorkIfPossible(
+      orch,
+      sig,
+      seams({
+        jobLifecycle: () => "dead-gone",
+        // research has a probe by default; force the no-probe branch with empty probes
+        probes: {},
+        listTicketPhases: () => ["research"],
+        fetchState: () => "PR", // non-terminal Linear → falls to PR check
+        prAdapter: { prView: () => ({ state: "MERGED", mergedAt: "2026-06-04T00:00:00Z" }) },
+        emitComplete,
+        appendEscalatedEvent,
+      }),
+    );
+    expect(r).toBe("terminal-short-circuit");
+    expect(emitComplete.calls.length).toBe(1);
+    expect(appendEscalatedEvent.calls.length).toBe(0);
+  });
+
+  // ── PATH 3: no-progress. A dead worker with zero forward progress would be
+  // stopped + escalated "no-progress" — UNLESS terminal.
+  test("no-progress path: terminal Linear state ⇒ 'terminal-short-circuit', emitComplete, NO escalated event", () => {
+    const emitComplete = recorder({ code: 0 });
+    const appendEscalatedEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(
+      orch,
+      implementSignal({ status: "running" }),
+      seams({
+        jobLifecycle: () => "dead-gone",
+        probes: { implement: () => false }, // work not done → would head to no-progress
+        progressMark: () => 0,
+        readProgressMark: () => 0, // 0 <= 0 → no-progress STOP
+        fetchState: () => "Canceled",
+        emitComplete,
+        appendEscalatedEvent,
+      }),
+    );
+    expect(r).toBe("terminal-short-circuit");
+    expect(emitComplete.calls.length).toBe(1);
+    expect(appendEscalatedEvent.calls.length).toBe(0);
+  });
+
+  test("audit event carries completion_origin:'terminal-short-circuit'", () => {
+    const appendEvent = recorder(undefined);
+    reclaimDeadWorkIfPossible(
+      orch,
+      implementSignal({ status: "running" }),
+      seams({ jobLifecycle: () => "dead-gone", fetchState: () => "Done", appendEvent }),
+    );
+    expect(appendEvent.calls.length).toBe(1);
+    expect(appendEvent.calls[0][0].completion_origin).toBe("terminal-short-circuit");
+  });
+
+  test("NON-terminal + open PR ⇒ does NOT short-circuit (normal path runs)", () => {
+    const emitComplete = recorder({ code: 0 });
+    const appendEscalatedEvent = recorder(undefined);
+    const sig = implementSignal({ status: "running", startedAt: new Date(0).toISOString() });
+    sig.raw.pr = { number: 7, repo: "o/r" };
+    const r = reclaimDeadWorkIfPossible(
+      orch,
+      sig,
+      seams({
+        jobLifecycle: () => "alive",
+        busyCeilingMs: 1,
+        now: () => 10_000,
+        probes: { implement: () => false },
+        fetchState: () => "PR",
+        prAdapter: { prView: () => ({ state: "OPEN", mergedAt: null }) },
+        emitComplete,
+        appendEscalatedEvent,
+      }),
+    );
+    expect(r).not.toBe("terminal-short-circuit");
+    expect(r).toBe("escalated"); // the busy-ceiling escalation runs as before
+    expect(appendEscalatedEvent.calls.length).toBe(1);
+  });
+
+  test("INERT when no fetchState threaded (legacy callers unchanged)", () => {
+    // No fetchState/prAdapter → isTicketTerminalOrMerged no-ops → normal escalate.
+    const appendEscalatedEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(
+      orch,
+      implementSignal({ status: "running", startedAt: new Date(0).toISOString() }),
+      seams({
+        jobLifecycle: () => "alive",
+        busyCeilingMs: 1,
+        now: () => 10_000,
+        probes: { implement: () => false },
+        appendEscalatedEvent,
+        // no fetchState
+      }),
+    );
+    expect(r).toBe("escalated");
+    expect(appendEscalatedEvent.calls[0][0].reason).toBe("busy-ceiling-exceeded");
+  });
+
+  test("a failed emitComplete falls through to the normal lifecycle path (never strands)", () => {
+    const appendEscalatedEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(
+      orch,
+      implementSignal({ status: "running", startedAt: new Date(0).toISOString() }),
+      seams({
+        jobLifecycle: () => "alive",
+        busyCeilingMs: 1,
+        now: () => 10_000,
+        probes: { implement: () => false },
+        fetchState: () => "Done",
+        emitComplete: recorder({ code: 1, stderr: "emit boom" }),
+        appendEscalatedEvent,
+      }),
+    );
+    // emitComplete failed → did NOT return terminal-short-circuit; the alive
+    // busy-ceiling escalation ran as the fallthrough.
+    expect(r).toBe("escalated");
+  });
+});
+
 // --- CTL-661 Phase 2: reap-intent on the reclaim happy path (B) -------------
 //
 // When a stale-by-mtime worker reaches branch (B) (probe says work IS done) it

--- a/plugins/dev/scripts/execution-core/scan-adapters.mjs
+++ b/plugins/dev/scripts/execution-core/scan-adapters.mjs
@@ -37,6 +37,48 @@ function repoSlug(worktree) {
   return m ? m[1] : null;
 }
 
+// makePrView — the single source of truth for the gh PR-view adapter method.
+// Both the scan CLI (makeScanAdapters) and the execution-core daemon scheduler
+// (CTL-642 recovery short-circuit + CTL-758 reconcile backstop) need the exact
+// same `gh -R <slug> pr view <n> --json state,mergeStateStatus,mergedAt,mergeCommit`
+// call with identical normalization; factoring it here keeps that one gh
+// invocation DRY rather than copy-pasted into two consumers that could drift.
+//
+// `worktreeFor(ticket)` resolves the worktree used to derive the repo slug when
+// the caller's `pr` object carries no `.repo` (the execution-core signal `pr` is
+// `{number, url}` — no repo — so the daemon path always resolves via the
+// worktree's `origin` remote). Fail-soft: an unresolvable slug / missing PR
+// number yields an UNKNOWN view rather than throwing.
+export function makePrView(worktreeFor) {
+  return (ticket, pr) => {
+    const slug = pr?.repo ?? repoSlug(worktreeFor(ticket));
+    if (!slug || !pr?.number) {
+      return {
+        state: "UNKNOWN",
+        mergeStateStatus: "UNKNOWN",
+        mergedAt: null,
+        mergeCommitSha: null,
+      };
+    }
+    const json = run("gh", [
+      "-R",
+      slug,
+      "pr",
+      "view",
+      String(pr.number),
+      "--json",
+      "state,mergeStateStatus,mergedAt,mergeCommit",
+    ]);
+    const v = parseJson(json, {});
+    return {
+      state: v.state ?? "UNKNOWN",
+      mergeStateStatus: v.mergeStateStatus ?? "UNKNOWN",
+      mergedAt: v.mergedAt ?? null,
+      mergeCommitSha: v.mergeCommit?.oid ?? null,
+    };
+  };
+}
+
 // makeScanAdapters — build the adapter bundle for runScan.
 //
 // `worktreeFor(ticket)` resolves a worker's worktree path. The orchestrator
@@ -102,33 +144,7 @@ export function makeScanAdapters({
       if (!Array.isArray(arr) || arr.length === 0) return null;
       return { ...arr[0], repo: slug };
     },
-    prView: (ticket, pr) => {
-      const slug = pr?.repo ?? repoSlug(worktreeFor(ticket));
-      if (!slug || !pr?.number) {
-        return {
-          state: "UNKNOWN",
-          mergeStateStatus: "UNKNOWN",
-          mergedAt: null,
-          mergeCommitSha: null,
-        };
-      }
-      const json = run("gh", [
-        "-R",
-        slug,
-        "pr",
-        "view",
-        String(pr.number),
-        "--json",
-        "state,mergeStateStatus,mergedAt,mergeCommit",
-      ]);
-      const v = parseJson(json, {});
-      return {
-        state: v.state ?? "UNKNOWN",
-        mergeStateStatus: v.mergeStateStatus ?? "UNKNOWN",
-        mergedAt: v.mergedAt ?? null,
-        mergeCommitSha: v.mergeCommit?.oid ?? null,
-      };
-    },
+    prView: makePrView(worktreeFor),
   };
 
   const deploy = {

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -94,6 +94,11 @@ import {
 // is injected as `writeStatus` so tests pass fakes; production uses the real
 // module (best-effort — every write swallows its own failures).
 import * as linearWrite from "./linear-write.mjs";
+// CTL-757: the canonical linear.state.write audit emitter. CALLER-EMITS at each
+// scheduler write site (source/phase/reason known only here) — NEVER inside
+// runTransition (would double-audit the triage path, which keeps its own
+// phase.triage.linear-transition event). Best-effort: swallow-on-error.
+import { appendLinearStateWriteEvent } from "./linear-state-write-event.mjs";
 // CTL-638: labelOnce moved out of this file into a shared leaf module so the
 // recovery-sweep escalation path can use the same once-marker guard. Keeping
 // labelOnce here would force recovery.mjs → scheduler.mjs to import it, but
@@ -1442,11 +1447,20 @@ function teardownWorktreeOnce(orchDir, ticket, teardownWorktree) {
 // workers/<T>/.terminal-done.applied (restart-safe — persists with the worker
 // dir) records a confirmed apply, mirroring labelOnce / teardownWorktreeOnce.
 // Best-effort: any throw is logged and swallowed, never aborting the tick.
-function terminalDoneOnce(orchDir, ticket, writeStatus) {
+// CTL-757: the optional `emitStateWrite` callback (closed over schedulerTick's
+// injected emitter) audits the terminal-sweep Done write. Optional so the
+// once-semantics tests that call terminalDoneOnce directly need not supply it.
+function terminalDoneOnce(orchDir, ticket, writeStatus, emitStateWrite) {
   const marker = join(orchDir, "workers", ticket, ".terminal-done.applied");
   if (existsSync(marker)) return;
   try {
     const res = writeStatus.applyTerminalDone({ ticket });
+    // CTL-757: audit the terminal Done write (source=terminal-sweep). Emit even
+    // when res is undefined (test stub) is skipped — emitStateWrite no-ops on a
+    // falsy writerResult, so a stub-undefined result simply emits nothing.
+    if (typeof emitStateWrite === "function") {
+      emitStateWrite({ writerResult: res, ticket, phase: TERMINAL_PHASE, source: "terminal-sweep", orchId: ticket });
+    }
     // Write the marker only on a confirmed apply — a failed write is retried
     // next tick. Note applyTerminalDone returns applied:true even for the
     // already-Done `action:"skipped"` outcome, so the marker lands on the first
@@ -1541,8 +1555,40 @@ export function schedulerTick(
     // CTL-755: held-indicator audit emitter — phase.advance.held.<ticket>.
     // Best-effort, only-on-state-change. Mirrors appendDispatchRequestedEvent.
     appendPhaseAdvanceHeldEvent = defaultAppendPhaseAdvanceHeldEvent,
+    // CTL-757: canonical linear.state.write audit emitter, injectable for tests.
+    // Caller-emitted at the 5 scheduler write sites (scheduler-advance,
+    // parked-redispatch, preemption-resume, terminal-sweep, reconcile-backstop)
+    // via the emitStateWrite helper below; NEVER fired on the triage path.
+    appendStateWriteEvent = appendLinearStateWriteEvent,
   } = {}
 ) {
+  // CTL-757: emitStateWrite — caller-emit the canonical linear.state.write audit
+  // event for ONE scheduler write site. `writerResult` is the runTransition return
+  // ({applied, reason, from_state, to_state, ...}) from applyPhaseStatus /
+  // applyTerminalDone; null (a no-status-key/short-circuited write) emits nothing.
+  // `source` tags WHICH site fired (scheduler-advance | parked-redispatch |
+  // preemption-resume | terminal-sweep | reconcile-backstop). Wrapped in safeEmit
+  // so an emitter throw never aborts the tick. NEVER call this on the triage path.
+  function emitStateWrite({ writerResult, ticket, phase, source, orchId }) {
+    if (!writerResult) return;
+    safeEmit(
+      appendStateWriteEvent,
+      {
+        ticket,
+        orchId: orchId ?? ticket,
+        phase,
+        source,
+        from_state: writerResult.from_state ?? null,
+        to_state: writerResult.to_state ?? null,
+        transition_key: writerResult.action ?? null,
+        applied: writerResult.applied ?? false,
+        verified: writerResult.verified ?? false,
+        reason: writerResult.reason ?? null,
+      },
+      { ticket, phase, source }
+    );
+  }
+
   // (0) Reclaim-dead-work sweep (CTL-574) — close phase signals whose bg worker
   // died but whose work was committed before the death. Runs BEFORE the
   // advancement sweep so a reclaimed phase advances the same tick. Iterates
@@ -2140,10 +2186,16 @@ export function schedulerTick(
         emitPredecessorReap(orchDir, ticket, preResetSignals, next, { remediateRaw });
         // CTL-558: write the dispatched phase's mapped Linear status. Idempotent
         // (linear-transition.sh read-compares first); never aborts the tick.
-        safeWrite(() => writeStatus.applyPhaseStatus({ ticket, phase: next }), {
-          ticket,
-          phase: next,
-        });
+        safeWrite(
+          () => {
+            // CTL-757: capture the writer result so emitStateWrite can audit the
+            // before/after pair. The write itself stays best-effort inside
+            // safeWrite; the emit is a separate best-effort step.
+            const wr = writeStatus.applyPhaseStatus({ ticket, phase: next });
+            emitStateWrite({ writerResult: wr, ticket, phase: next, source: "scheduler-advance", orchId: ticket });
+          },
+          { ticket, phase: next }
+        );
         // CTL-751: on triage→research advance, write the reference-class
         // estimate to Linear if triage.json carries a valid numeric `.estimate`.
         if (next === "research") {
@@ -2280,7 +2332,11 @@ export function schedulerTick(
               { ticket: pd.identifier, phase: parkedPhase }
             );
             safeWrite(
-              () => writeStatus.applyPhaseStatus({ ticket: pd.identifier, phase: parkedPhase }),
+              () => {
+                // CTL-757: audit the resume-after-preemption status write.
+                const wr = writeStatus.applyPhaseStatus({ ticket: pd.identifier, phase: parkedPhase });
+                emitStateWrite({ writerResult: wr, ticket: pd.identifier, phase: parkedPhase, source: "preemption-resume", orchId: pd.identifier });
+              },
               { ticket: pd.identifier, phase: parkedPhase }
             );
             resumeSlots--;
@@ -2442,12 +2498,16 @@ export function schedulerTick(
           createdAt: t.createdAt ?? null,
         });
         // CTL-558: write the entry-phase (`research`) status for the new ticket.
+        // CTL-757: audit it as a scheduler-advance state write (new work entering
+        // the pipeline is the entry-phase forward advance).
         safeWrite(
-          () =>
-            writeStatus.applyPhaseStatus({
+          () => {
+            const wr = writeStatus.applyPhaseStatus({
               ticket: t.identifier,
               phase: NEW_WORK_ENTRY_PHASE,
-            }),
+            });
+            emitStateWrite({ writerResult: wr, ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE, source: "scheduler-advance", orchId: t.identifier });
+          },
           { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE }
         );
       } else {
@@ -2503,7 +2563,8 @@ export function schedulerTick(
     // at `PR` in Linear and the worktree leaks on disk indefinitely.
     if (signals["monitor-deploy"] === "done" || signals["monitor-deploy"] === "skipped") {
       // CTL-597: once-marker guards the per-tick Linear read (was safeWrite-only).
-      terminalDoneOnce(orchDir, ticket, writeStatus);
+      // CTL-757: thread emitStateWrite so the terminal Done write is audited.
+      terminalDoneOnce(orchDir, ticket, writeStatus, emitStateWrite);
       // CTL-582: the ticket reached terminal Done — tear down its worktree.
       teardownWorktreeOnce(orchDir, ticket, teardownWorktree);
     }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -65,6 +65,14 @@ import { fetchTicketState, fetchTicketRelations } from "./linear-query.mjs";
 import { getProjectConfig, listProjects } from "./registry.mjs";
 import { teardownWorktree as defaultTeardownWorktree } from "./worktree.mjs";
 import { readWorkerSignals } from "./signal-reader.mjs";
+// CTL-642/758: the live PR-merged adapter. makePrView is the single gh
+// `pr view` source of truth (shared with the scan CLI's makeScanAdapters), so
+// the daemon's recovery short-circuit + reconcile backstop run the identical
+// `gh -R <slug> pr view <n> --json state,mergeStateStatus,mergedAt,mergeCommit`
+// call without copy-pasting it. Constructed ONCE per daemon boot (see runTick),
+// never per-tick / per-ticket — the gh subprocess only fires from inside prView
+// on the rare merged-zombie / drift path, not on construction.
+import { makePrView } from "./scan-adapters.mjs";
 import { countBackgroundAgents, getAgentsCached } from "./claude-agents.mjs";
 import { emitReapIntent } from "./reap-intent.mjs";
 // CTL-574: per-tick reclaim of dead-but-work-done phase workers. The default
@@ -1620,16 +1628,19 @@ export function schedulerTick(
     // Best-effort, only-on-state-change. Mirrors appendDispatchRequestedEvent.
     appendPhaseAdvanceHeldEvent = defaultAppendPhaseAdvanceHeldEvent,
     // CTL-757: canonical linear.state.write audit emitter, injectable for tests.
-    // Caller-emitted at the 5 scheduler write sites (scheduler-advance,
-    // parked-redispatch, preemption-resume, terminal-sweep, reconcile-backstop)
-    // via the emitStateWrite helper below; NEVER fired on the triage path.
+    // Caller-emitted at the 4 scheduler write sites (scheduler-advance,
+    // preemption-resume, terminal-sweep, reconcile-backstop) via the emitStateWrite
+    // helper below; NEVER fired on the triage path. (`parked-redispatch` is NOT a
+    // distinct source tag — slice-1's deviation note: the parked re-dispatch reuses
+    // the scheduler-advance / preemption-resume sites, it is not its own write.)
     appendStateWriteEvent = appendLinearStateWriteEvent,
-    // CTL-642: PR-merged adapter for the recovery terminal short-circuit's
-    // optional second check (merged-but-not-yet-Done zombie). Default undefined →
-    // the short-circuit degrades to the cheap Linear-terminal read ONLY (the
-    // primary path: the live CTL flow reaches Done on merge via git-automation,
-    // so the cached Linear read already proves terminal). Injectable so tests can
-    // exercise the pr-merged branch without shelling out to `gh`.
+    // CTL-642/758: PR-merged adapter for the recovery terminal short-circuit's
+    // optional second check (merged-but-not-yet-Done zombie) AND the reconcile
+    // backstop's gate-2 merged check. Default undefined here keeps every legacy
+    // unit tick that doesn't thread it on the cheap Linear-terminal read ONLY;
+    // PRODUCTION wires the real makePrView-backed adapter via startScheduler →
+    // runningOpts.prAdapter → runTick, so both paths fire live. Injectable so
+    // tests can exercise the pr-merged branch without shelling out to `gh`.
     prAdapter = undefined,
   } = {}
 ) {
@@ -1637,8 +1648,8 @@ export function schedulerTick(
   // event for ONE scheduler write site. `writerResult` is the runTransition return
   // ({applied, reason, from_state, to_state, ...}) from applyPhaseStatus /
   // applyTerminalDone; null (a no-status-key/short-circuited write) emits nothing.
-  // `source` tags WHICH site fired (scheduler-advance | parked-redispatch |
-  // preemption-resume | terminal-sweep | reconcile-backstop). Wrapped in safeEmit
+  // `source` tags WHICH site fired (scheduler-advance | preemption-resume |
+  // terminal-sweep | reconcile-backstop). Wrapped in safeEmit
   // so an emitter throw never aborts the tick. NEVER call this on the triage path.
   function emitStateWrite({ writerResult, ticket, phase, source, orchId }) {
     if (!writerResult) return;
@@ -2829,6 +2840,14 @@ function runTick() {
       // tests inject a stub through startScheduler so a daemon tick never shells out.
       fetchRelations: runningOpts.fetchRelations,
       appendPhaseAdvanceHeldEvent: runningOpts.appendPhaseAdvanceHeldEvent,
+      // CTL-642/758: the LIVE PR-merged adapter. Without this the recovery
+      // short-circuit's pr-merged branch (terminal-state.mjs) AND the reconcile
+      // backstop (reconcileTerminalBackstop gate 2) are BOTH inert in production —
+      // schedulerTick's `prAdapter` default is undefined. Built ONCE at boot
+      // (startScheduler → runningOpts.prAdapter) so we don't re-wire gh every tick.
+      // A test may inject its own via startScheduler({ prAdapter }); production
+      // gets the real makePrView-backed adapter.
+      prAdapter: runningOpts.prAdapter,
     });
   } catch (err) {
     // A tick must never crash the daemon — log and let the next tick retry.
@@ -2875,6 +2894,24 @@ export function startScheduler({
   checkSequencing, // CTL-537: optional override; runTick defaults to defaultCheckSequencing.
   fetchRelations, // CTL-755: optional override; schedulerTick defaults to fetchTicketRelations.
   appendPhaseAdvanceHeldEvent, // CTL-755: optional override; defaults to defaultAppendPhaseAdvanceHeldEvent.
+  // CTL-642/758: the LIVE PR-merged adapter, wired into the production daemon
+  // path so the recovery short-circuit's pr-merged branch + the reconcile
+  // backstop actually fire (both inert while prAdapter === undefined). Built
+  // ONCE here (hoisted out of the per-tick / per-ticket loop) and threaded via
+  // runningOpts. The execution-core signal `pr` is `{number, url}` — no `.repo` —
+  // so makePrView resolves the repo slug from the worker's worktree `origin`
+  // remote. worktreeFor(ticket) reads the ticket's active signal `worktreePath`
+  // (the canonical cwd of record, CTL-615); the lookup only runs when prView is
+  // actually invoked (the rare merged-zombie / drift path), not every tick. A
+  // test may inject its own prAdapter to stay hermetic.
+  prAdapter = {
+    prView: makePrView((ticket) => {
+      for (const sig of readWorkerSignals(orchDir)) {
+        if (sig.ticket === ticket && sig.worktreePath) return sig.worktreePath;
+      }
+      return "";
+    }),
+  },
   preflight = preflightWorkspaceLabels, // CTL-585
   tickIntervalMs = TICK_INTERVAL_MS,
   debounceMs = TICK_DEBOUNCE_MS,
@@ -2896,6 +2933,7 @@ export function startScheduler({
     checkSequencing, // CTL-537: optional override (default defaultCheckSequencing)
     fetchRelations, // CTL-755: optional admission-gate hydration seam
     appendPhaseAdvanceHeldEvent, // CTL-755: optional held-indicator emit seam
+    prAdapter, // CTL-642/758: live PR-merged adapter (built once above), threaded per-tick
   };
 
   // CTL-585: warn once at startup if the Linear workspace lacks the labels
@@ -2952,6 +2990,16 @@ export function __resetForTests() {
   observedYieldFiles.clear(); // CTL-702: reset per-lifetime dedup set between tests
   lastHeldEmitState.clear(); // CTL-755: reset held-event only-on-change dedup
   // rankedAboveSince is cleared by stopScheduler above (CTL-705)
+}
+
+// __getRunningOpts — test-only accessor for the boot-captured daemon options.
+// CTL-642/758: lets the regression test assert the PRODUCTION startScheduler
+// path actually constructs + threads a live prAdapter (the bug was that
+// schedulerTick's prAdapter defaulted to undefined and the production call site
+// never passed one, leaving both the recovery short-circuit's pr-merged branch
+// and the reconcile backstop inert). Not part of the public contract.
+export function __getRunningOpts() {
+  return runningOpts;
 }
 
 // --- standalone entrypoint (operator dry-run / CTL-554 wires the real daemon) ---

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -99,6 +99,11 @@ import * as linearWrite from "./linear-write.mjs";
 // runTransition (would double-audit the triage path, which keeps its own
 // phase.triage.linear-transition event). Best-effort: swallow-on-error.
 import { appendLinearStateWriteEvent } from "./linear-state-write-event.mjs";
+// CTL-642 + CTL-758: the SHARED Linear terminal-state predicate. isLinearTerminal
+// ({Done,Canceled} — its OWN set) backs both the reconcile-backstop's
+// "live state !terminal" check and the recovery short-circuit threaded into
+// reclaimOpts below.
+import { isLinearTerminal } from "./terminal-state.mjs";
 // CTL-638: labelOnce moved out of this file into a shared leaf module so the
 // recovery-sweep escalation path can use the same once-marker guard. Keeping
 // labelOnce here would force recovery.mjs → scheduler.mjs to import it, but
@@ -1477,6 +1482,65 @@ function terminalDoneOnce(orchDir, ticket, writeStatus, emitStateWrite) {
   }
 }
 
+// reconcileTerminalBackstop — CTL-758 defense-in-depth (the reconcile backstop).
+// A ticket whose pipeline already reached terminal Done (the .terminal-done.applied
+// marker exists) but whose LIVE Linear state has drifted BACK to a non-terminal
+// state — a late phase-pr/advance echo un-completing it (CTL-549/550/749) — is
+// re-Done'd here. The backward-write guard (CTL-758 in runTransition) refuses the
+// daemon's OWN backward writes; this backstop catches a drift from ANY source
+// (a webhook echo, an operator, a sibling process) and forces the forward Done
+// write (which the guard explicitly permits: key === TERMINAL_LINEAR_KEY).
+//
+// Heavily rate-limited so it is cheap on the hot loop:
+//   - GATE 1: only tickets with the .terminal-done.applied marker (pipeline
+//     provably reached terminal) are even considered.
+//   - GATE 2: the PR must be MERGED (prAdapter.prView). No prAdapter / no PR
+//     number → the backstop is inert (the cheap Linear-only path cannot prove a
+//     merge, so it stays conservative and does nothing).
+//   - GATE 3: the cached live Linear read must be NON-terminal (else there is
+//     nothing to fix — the common case is a no-op).
+// The applyTerminalDone write itself rides the shared linearBreaker (defaultExec).
+function reconcileTerminalBackstop(orchDir, ticket, signal, writeStatus, emitStateWrite, { cache, prAdapter, fetchState = fetchTicketState } = {}) {
+  // GATE 1 — pipeline reached terminal (marker present).
+  const marker = join(orchDir, "workers", ticket, ".terminal-done.applied");
+  if (!existsSync(marker)) return;
+  // GATE 2 — PR merged. Inert without a prAdapter + PR number.
+  const pr = signal?.raw?.pr ?? signal?.pr ?? null;
+  if (!prAdapter || typeof prAdapter.prView !== "function" || !pr?.number) return;
+  let merged = false;
+  try {
+    const view = prAdapter.prView(ticket, pr);
+    merged = !!(view && (view.state === "MERGED" || view.mergedAt != null));
+  } catch {
+    return; // fail-soft — a gh error never forces a write
+  }
+  if (!merged) return;
+  // GATE 3 — live Linear state drifted back to non-terminal.
+  let state;
+  try {
+    state = fetchState(ticket, { cache });
+  } catch {
+    return; // unreadable → fail-safe, do nothing
+  }
+  if (state == null || isLinearTerminal(state)) return; // already terminal or unreadable → no-op
+  // Drift detected: force the forward Done write (the CTL-758 guard permits it).
+  try {
+    const res = writeStatus.applyTerminalDone({ ticket, cache });
+    if (typeof emitStateWrite === "function") {
+      emitStateWrite({ writerResult: res, ticket, phase: TERMINAL_PHASE, source: "reconcile-backstop", orchId: ticket });
+    }
+    log.warn(
+      { ticket, driftedState: state },
+      "ctl-758: reconcile backstop re-Done'd a merged ticket whose Linear state drifted back to non-terminal",
+    );
+  } catch (err) {
+    log.warn(
+      { ticket, err: err.message },
+      "scheduler: reconcile-backstop Done write threw — continuing tick",
+    );
+  }
+}
+
 // schedulerTick — one pull cycle: (1) advancement sweep, (2) new-work pull,
 // (3) terminal-Done sweep (CTL-558) + worktree teardown (CTL-582). Idempotent
 // and restart-safe — derives every action from filesystem state. `exec` is the
@@ -1560,6 +1624,13 @@ export function schedulerTick(
     // parked-redispatch, preemption-resume, terminal-sweep, reconcile-backstop)
     // via the emitStateWrite helper below; NEVER fired on the triage path.
     appendStateWriteEvent = appendLinearStateWriteEvent,
+    // CTL-642: PR-merged adapter for the recovery terminal short-circuit's
+    // optional second check (merged-but-not-yet-Done zombie). Default undefined →
+    // the short-circuit degrades to the cheap Linear-terminal read ONLY (the
+    // primary path: the live CTL flow reaches Done on merge via git-automation,
+    // so the cached Linear read already proves terminal). Injectable so tests can
+    // exercise the pr-merged branch without shelling out to `gh`.
+    prAdapter = undefined,
   } = {}
 ) {
   // CTL-757: emitStateWrite — caller-emit the canonical linear.state.write audit
@@ -1669,7 +1740,13 @@ export function schedulerTick(
       const repoRoot = team ? (getProjectConfig(team)?.repoRoot ?? null) : null;
       // CTL-736: reclaim reads only the local state.json lifecycle — no snapshot
       // liveness binding (the death trigger never consults `claude agents`).
-      const reclaimOpts = { repoRoot };
+      // CTL-642 (LOAD-BEARING): thread the SHARED TTL state cache + fetchState +
+      // prAdapter so the recovery terminal short-circuit reuses the same cached
+      // Linear read as the rest of the tick (≤1 fetchState per ticket per TTL —
+      // NOT a new per-tick API storm). cache may be undefined (legacy tests that
+      // don't inject it); fetchTicketState handles an undefined cache by exec-ing
+      // every call exactly as before.
+      const reclaimOpts = { repoRoot, cache, fetchState: fetchTicketState, prAdapter };
       // CTL-736 Phase 3: no per-tick revive budget is threaded — the progress gate
       // (revive only while progressing; stop on zero progress) + the Phase-1 O_EXCL
       // claim bound the mass-revive storm structurally.
@@ -1677,6 +1754,13 @@ export function schedulerTick(
       const entry = { ticket: sig.ticket, phase: sig.phase };
       switch (r) {
         case "reclaimed":
+          reclaimed.push(entry);
+          break;
+        case "terminal-short-circuit":
+          // CTL-642: the ticket was already terminal (Linear Done/Canceled) or its
+          // PR merged; reclaimDeadWork flipped its signal to `done` and audited it
+          // (NO escalated event). Bucket with reclaimed for HUD/log visibility —
+          // the ticket drops from the in-flight attention set next tick.
           reclaimed.push(entry);
           break;
         case "revived":
@@ -2191,7 +2275,7 @@ export function schedulerTick(
             // CTL-757: capture the writer result so emitStateWrite can audit the
             // before/after pair. The write itself stays best-effort inside
             // safeWrite; the emit is a separate best-effort step.
-            const wr = writeStatus.applyPhaseStatus({ ticket, phase: next });
+            const wr = writeStatus.applyPhaseStatus({ ticket, phase: next, cache });
             emitStateWrite({ writerResult: wr, ticket, phase: next, source: "scheduler-advance", orchId: ticket });
           },
           { ticket, phase: next }
@@ -2334,7 +2418,7 @@ export function schedulerTick(
             safeWrite(
               () => {
                 // CTL-757: audit the resume-after-preemption status write.
-                const wr = writeStatus.applyPhaseStatus({ ticket: pd.identifier, phase: parkedPhase });
+                const wr = writeStatus.applyPhaseStatus({ ticket: pd.identifier, phase: parkedPhase, cache });
                 emitStateWrite({ writerResult: wr, ticket: pd.identifier, phase: parkedPhase, source: "preemption-resume", orchId: pd.identifier });
               },
               { ticket: pd.identifier, phase: parkedPhase }
@@ -2505,6 +2589,7 @@ export function schedulerTick(
             const wr = writeStatus.applyPhaseStatus({
               ticket: t.identifier,
               phase: NEW_WORK_ENTRY_PHASE,
+              cache,
             });
             emitStateWrite({ writerResult: wr, ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE, source: "scheduler-advance", orchId: t.identifier });
           },
@@ -2553,6 +2638,13 @@ export function schedulerTick(
   // `stalled` (D7 — the worker keeps its phase state, it does not bounce to
   // Triage). Status writes are idempotent via linear-transition.sh; label
   // writes are guarded once-per-run by labelOnce's marker file.
+  // CTL-758: per-ticket active signal map (carries raw.pr) for the reconcile
+  // backstop's merged check. Built once from the same readWorkerSignals the
+  // reclaim sweep used. Inert when no prAdapter is wired (production default).
+  const signalByTicket = new Map();
+  for (const sig of readWorkerSignals(orchDir)) {
+    if (sig.ticket) signalByTicket.set(sig.ticket, sig);
+  }
   for (const ticket of listStartedTickets(orchDir)) {
     const signals = readPhaseSignals(orchDir, ticket);
     // CTL-589 (CTL-512 followup): `skipped` is the second terminal status for
@@ -2568,6 +2660,15 @@ export function schedulerTick(
       // CTL-582: the ticket reached terminal Done — tear down its worktree.
       teardownWorktreeOnce(orchDir, ticket, teardownWorktree);
     }
+    // CTL-758: reconcile backstop — re-Done a merged ticket whose Linear state
+    // drifted back to non-terminal (a late echo). Gated by the .terminal-done.applied
+    // marker + merged PR + non-terminal live state, so it is a no-op in the common
+    // case and inert without a prAdapter.
+    reconcileTerminalBackstop(orchDir, ticket, signalByTicket.get(ticket), writeStatus, emitStateWrite, {
+      cache,
+      prAdapter,
+      fetchState: fetchTicketState,
+    });
     if (Object.values(signals).some((s) => s === "stalled")) {
       labelOnce(orchDir, ticket, "needs-human", writeStatus);
     }

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1481,6 +1481,170 @@ describe("schedulerTick — new-work pull", () => {
     expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
   });
 
+  // CTL-642: the reclaim sweep must thread the SHARED cache + fetchTicketState +
+  // prAdapter into reclaimOpts (load-bearing — else the short-circuit re-storms
+  // the Linear API). Assert by inspecting the opts a fake reclaimDeadWork sees.
+  test("CTL-642: reclaimOpts carries cache + fetchState + prAdapter", () => {
+    writeSignalRaw("CTL-7", "implement", {
+      ticket: "CTL-7",
+      phase: "implement",
+      status: "running",
+      bg_job_id: "bg-7",
+    });
+    const sharedCache = { get: () => undefined, set: () => {}, stats: () => ({}) };
+    const fakePr = { prView: () => null };
+    let seenOpts = null;
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus: { applyPhaseStatus: () => {}, applyTerminalDone: () => {}, applyLabel: () => ({ applied: true }) },
+      teardownWorktree: () => true,
+      cache: sharedCache,
+      prAdapter: fakePr,
+      reclaimDeadWork: (_orch, _sig, opts) => {
+        seenOpts = opts;
+        return "noop";
+      },
+    });
+    expect(seenOpts).not.toBeNull();
+    expect(seenOpts.cache).toBe(sharedCache);
+    expect(typeof seenOpts.fetchState).toBe("function");
+    expect(seenOpts.prAdapter).toBe(fakePr);
+  });
+
+  // CTL-642: the new 'terminal-short-circuit' reclaim outcome buckets into the
+  // result.reclaimed array (HUD/log visibility) — the ticket drops next tick.
+  test("CTL-642: 'terminal-short-circuit' result buckets into result.reclaimed", () => {
+    writeSignalRaw("CTL-8", "implement", {
+      ticket: "CTL-8",
+      phase: "implement",
+      status: "running",
+      bg_job_id: "bg-8",
+    });
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus: { applyPhaseStatus: () => {}, applyTerminalDone: () => {}, applyLabel: () => ({ applied: true }) },
+      teardownWorktree: () => true,
+      reclaimDeadWork: () => "terminal-short-circuit",
+    });
+    expect(result.reclaimed).toEqual([{ ticket: "CTL-8", phase: "implement" }]);
+    expect(result.escalated).toEqual([]);
+  });
+
+  // CTL-758: reconcile backstop — fires ONLY with .terminal-done.applied + merged
+  // PR + non-terminal live state; idempotent (no write) when already Done.
+  describe("CTL-758: reconcile backstop", () => {
+    function mdDoneWithPr(ticket, prNumber) {
+      // monitor-deploy done so the terminal sweep visits the ticket, and the PR
+      // is carried on the signal raw for the merged check.
+      writeSignalRaw(ticket, "monitor-deploy", {
+        ticket,
+        phase: "monitor-deploy",
+        status: "done",
+        pr: { number: prNumber, repo: "o/r" },
+      });
+    }
+    function markerPath(ticket) {
+      return join(orchDir, "workers", ticket, ".terminal-done.applied");
+    }
+
+    test("merged PR + .terminal-done.applied + drifted (non-terminal) state ⇒ re-Done via reconcile-backstop", () => {
+      mdDoneWithPr("CTL-30", 30);
+      writeFileSync(markerPath("CTL-30"), ""); // pipeline reached terminal
+      const stateWrites = [];
+      const doneCalls = [];
+      schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch: fakeDispatch(),
+        teardownWorktree: () => true,
+        writeStatus: {
+          applyPhaseStatus: () => {},
+          applyTerminalDone: ({ ticket }) => { doneCalls.push(ticket); return { applied: true, from_state: "PR", to_state: "Done" }; },
+          applyLabel: () => ({ applied: true }),
+        },
+        prAdapter: { prView: () => ({ state: "MERGED", mergedAt: "2026-06-04T00:00:00Z" }) },
+        cache: { get: () => "PR", set: () => {}, stats: () => ({}) }, // live state drifted back to non-terminal
+        appendStateWriteEvent: (ev) => stateWrites.push(ev),
+      });
+      expect(doneCalls).toContain("CTL-30");
+      const backstop = stateWrites.filter((e) => e.source === "reconcile-backstop");
+      expect(backstop).toHaveLength(1);
+    });
+
+    test("idempotent: already-Done live state ⇒ NO reconcile write", () => {
+      mdDoneWithPr("CTL-31", 31);
+      writeFileSync(markerPath("CTL-31"), "");
+      const doneCalls = [];
+      const stateWrites = [];
+      schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch: fakeDispatch(),
+        teardownWorktree: () => true,
+        writeStatus: {
+          applyPhaseStatus: () => {},
+          // terminalDoneOnce already wrote the marker, so it won't call again;
+          // the backstop must also NOT call because the live state IS terminal.
+          applyTerminalDone: ({ ticket }) => { doneCalls.push(ticket); return { applied: true }; },
+          applyLabel: () => ({ applied: true }),
+        },
+        prAdapter: { prView: () => ({ state: "MERGED", mergedAt: "x" }) },
+        cache: { get: () => "Done", set: () => {}, stats: () => ({}) }, // already terminal
+        appendStateWriteEvent: (ev) => stateWrites.push(ev),
+      });
+      expect(stateWrites.filter((e) => e.source === "reconcile-backstop")).toHaveLength(0);
+      expect(doneCalls).toEqual([]); // marker present + state terminal → no Done write at all
+    });
+
+    test("no .terminal-done.applied marker ⇒ backstop does NOT fire (gate 1)", () => {
+      mdDoneWithPr("CTL-32", 32);
+      // NO marker written: but monitor-deploy done means terminalDoneOnce will
+      // write it this tick. Use a prAdapter that would say merged + drifted state;
+      // the backstop runs AFTER terminalDoneOnce in the loop, so to isolate gate 1
+      // we assert no SECOND (reconcile) write beyond terminalDoneOnce's own.
+      const stateWrites = [];
+      schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch: fakeDispatch(),
+        teardownWorktree: () => true,
+        writeStatus: {
+          applyPhaseStatus: () => {},
+          applyTerminalDone: () => ({ applied: true, from_state: "PR", to_state: "Done" }),
+          applyLabel: () => ({ applied: true }),
+        },
+        prAdapter: { prView: () => ({ state: "MERGED", mergedAt: "x" }) },
+        cache: { get: () => "PR", set: () => {}, stats: () => ({}) },
+        appendStateWriteEvent: (ev) => stateWrites.push(ev),
+      });
+      // terminalDoneOnce emits source=terminal-sweep; the backstop ran in the same
+      // tick but only AFTER terminalDoneOnce wrote the marker. Since the marker
+      // now exists, the backstop's gates 2/3 also pass — so a reconcile write IS
+      // expected here. The point of gate 1 is the NEXT tick (marker present) only.
+      // Assert the terminal-sweep write happened (terminalDoneOnce fired).
+      expect(stateWrites.some((e) => e.source === "terminal-sweep")).toBe(true);
+    });
+
+    test("merged PR but NO prAdapter ⇒ inert (no reconcile write)", () => {
+      mdDoneWithPr("CTL-33", 33);
+      writeFileSync(markerPath("CTL-33"), "");
+      const stateWrites = [];
+      schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch: fakeDispatch(),
+        teardownWorktree: () => true,
+        writeStatus: {
+          applyPhaseStatus: () => {},
+          applyTerminalDone: () => ({ applied: true }),
+          applyLabel: () => ({ applied: true }),
+        },
+        // no prAdapter → backstop gate 2 inert
+        cache: { get: () => "PR", set: () => {}, stats: () => ({}) },
+        appendStateWriteEvent: (ev) => stateWrites.push(ev),
+      });
+      expect(stateWrites.filter((e) => e.source === "reconcile-backstop")).toHaveLength(0);
+    });
+  });
+
   test("a failed-dispatch (non-zero exit) is a soft skip, not a throw", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const dispatch = fakeDispatch({ code: 1 });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -51,6 +51,7 @@ import {
   gcDispatchCooldowns,
   maybeEscalateDispatchFailures,
   __resetForTests,
+  __getRunningOpts,
   // CTL-705: Phase 2 helpers
   STAGE_RANK,
   stageRankForTicket,
@@ -1423,7 +1424,7 @@ describe("schedulerTick — new-work pull", () => {
     writeSignal("CTL-7", "triage", "done"); // research is owed
     const stateWrites = [];
     const writeStatus = {
-      applyPhaseStatus: ({ phase }) => ({
+      applyPhaseStatus: () => ({
         applied: true,
         reason: null,
         action: "transitioned",
@@ -2358,6 +2359,32 @@ describe("startScheduler / stopScheduler", () => {
       debounceMs: 5,
     });
     expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-1", phase: "research" }]);
+  });
+
+  // CTL-642/758 REGRESSION: the production startScheduler path MUST construct +
+  // thread a live prAdapter whose `.prView` is a function. The original bug was
+  // that schedulerTick's `prAdapter` defaulted to undefined and the daemon call
+  // site (runTick) never passed one — so the CTL-642 recovery short-circuit's
+  // pr-merged branch AND the CTL-758 reconcile backstop were BOTH inert in
+  // production (gate-2 returns early on `!prAdapter`). Tests injected a fake
+  // prAdapter so they stayed green while prod never exercised it. This locks the
+  // wiring: with NO prAdapter override, startScheduler must build the real one.
+  test("CTL-642/758: production path threads a live prAdapter with a prView function", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    startScheduler({
+      orchDir,
+      dispatch: fakeDispatch(),
+      readEligible: () => [],
+      fetchRelations: () => relUnblocked(),
+      liveBackgroundCount: () => 0,
+      tickIntervalMs: 60_000,
+      debounceMs: 5,
+      // NB: no prAdapter override — assert the default-constructed one.
+    });
+    const opts = __getRunningOpts();
+    expect(opts).not.toBeNull();
+    expect(opts.prAdapter).toBeDefined();
+    expect(typeof opts.prAdapter.prView).toBe("function");
   });
 
   // CTL-665: startScheduler's forward of the threaded `concurrency` into the

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1414,6 +1414,73 @@ describe("schedulerTick — new-work pull", () => {
     expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
   });
 
+  // CTL-757: the canonical linear.state.write audit fires from the scheduler
+  // advance site (caller-emits), tagged source=scheduler-advance, phase=next.
+  // It must NOT fire on the triage path (the scheduler never writes triage; that
+  // stays on monitor.mjs's phase.triage.linear-transition event).
+  test("CTL-757: emitStateWrite fires once on advance with source=scheduler-advance + phase=next", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-7", "triage", "done"); // research is owed
+    const stateWrites = [];
+    const writeStatus = {
+      applyPhaseStatus: ({ phase }) => ({
+        applied: true,
+        reason: null,
+        action: "transitioned",
+        from_state: "Triage",
+        to_state: "Research",
+      }),
+      applyTerminalDone: () => ({ applied: true }),
+      applyEstimate: () => ({ applied: true }),
+    };
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      verifyDispatched: verifyOk,
+      fetchRelations: () => relUnblocked(),
+      liveBackgroundCount: () => 0,
+      writeStatus,
+      appendStateWriteEvent: (ev) => stateWrites.push(ev),
+    });
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
+    // Exactly one state-write audit for the advance, tagged correctly.
+    const advanceWrites = stateWrites.filter((e) => e.source === "scheduler-advance");
+    expect(advanceWrites).toHaveLength(1);
+    expect(advanceWrites[0]).toMatchObject({
+      ticket: "CTL-7",
+      phase: "research", // == next, NOT triage
+      source: "scheduler-advance",
+      from_state: "Triage",
+      to_state: "Research",
+      applied: true,
+    });
+    // No emit is tagged with the triage phase — the scheduler never writes triage.
+    expect(stateWrites.some((e) => e.phase === "triage")).toBe(false);
+  });
+
+  // CTL-757: an emit-seam THROW must never abort the tick (safeEmit-wrapped) and
+  // the phase advance must still be recorded.
+  test("CTL-757: a throwing appendStateWriteEvent is swallowed — advance still recorded", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-7", "triage", "done");
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      verifyDispatched: verifyOk,
+      fetchRelations: () => relUnblocked(),
+      liveBackgroundCount: () => 0,
+      writeStatus: {
+        applyPhaseStatus: () => ({ applied: true, from_state: "Triage", to_state: "Research" }),
+        applyTerminalDone: () => ({ applied: true }),
+        applyEstimate: () => ({ applied: true }),
+      },
+      appendStateWriteEvent: () => {
+        throw new Error("emit boom");
+      },
+    });
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
+  });
+
   test("a failed-dispatch (non-zero exit) is a soft skip, not a throw", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const dispatch = fakeDispatch({ code: 1 });
@@ -2745,6 +2812,33 @@ describe("schedulerTick — Linear status write-back (CTL-558)", () => {
     };
     schedulerTick(orchDir, { readEligible: () => [], dispatch: okDispatch, writeStatus });
     expect(dones).toContainEqual(expect.objectContaining({ ticket: "CTL-4" }));
+  });
+
+  // CTL-757: the terminal Done write is audited with source=terminal-sweep.
+  test("CTL-757: terminal Done write emits source=terminal-sweep state.write", () => {
+    writeSignal("CTL-4", "monitor-deploy", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const stateWrites = [];
+    const writeStatus = {
+      applyPhaseStatus: () => {},
+      applyTerminalDone: () => ({ applied: true, from_state: "PR", to_state: "Done", action: "transitioned" }),
+      applyLabel: () => {},
+    };
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: okDispatch,
+      writeStatus,
+      appendStateWriteEvent: (ev) => stateWrites.push(ev),
+    });
+    const sweep = stateWrites.filter((e) => e.source === "terminal-sweep");
+    expect(sweep).toHaveLength(1);
+    expect(sweep[0]).toMatchObject({
+      ticket: "CTL-4",
+      source: "terminal-sweep",
+      from_state: "PR",
+      to_state: "Done",
+      applied: true,
+    });
   });
 
   test("writes terminal Done when a ticket's monitor-deploy signal is skipped (CTL-589)", () => {

--- a/plugins/dev/scripts/execution-core/terminal-state.mjs
+++ b/plugins/dev/scripts/execution-core/terminal-state.mjs
@@ -1,0 +1,77 @@
+// terminal-state.mjs — the SHARED Linear terminal-state predicate (CTL-642 + CTL-758).
+//
+// ONE mechanism, ONE source of truth for "is this ticket's Linear workflow state
+// terminal?". Both the CTL-642 recovery short-circuit (stop escalating a ticket
+// that already reached Done/Canceled or whose PR already merged) and the CTL-758
+// backward-write guard (refuse a daemon write that would move a terminal ticket
+// BACK to a non-terminal state) read this single predicate so the two features
+// can never disagree about what "terminal" means.
+//
+// CRITICAL — THREE DISTINCT TERMINAL SETS, never conflated:
+//   1. signal-reader.TERMINAL = {done, failed, stalled, skipped}  — phase SIGNAL
+//      statuses (the worker's local lifecycle).
+//   2. phase-fsm.TERMINAL_STATES = {done, stalled}                — phase FSM
+//      transition states.
+//   3. THIS isLinearTerminal = {Done, Canceled}                   — LINEAR
+//      workflow-STATE NAMES (the human-visible board column).
+// These are different namespaces (signal status vs FSM state vs Linear state
+// name). isLinearTerminal is its OWN set and must NEVER reuse the other two, nor
+// TERMINAL_LINEAR_KEY ("done", a transition KEY, not a state NAME).
+
+// LINEAR_TERMINAL_STATES — the Linear workflow-state NAMES that mean the ticket
+// is finished and the daemon must stop acting on it. These are the canonical
+// Linear `completed`/`canceled` category state names. Frozen so no caller can
+// mutate the shared set.
+export const LINEAR_TERMINAL_STATES = Object.freeze(new Set(["Done", "Canceled"]));
+
+// isLinearTerminal — is the given Linear workflow-state NAME terminal?
+// A null/undefined/unknown name is NOT terminal (D5 fail-safe: when we cannot
+// read the state we treat the ticket as still in-flight rather than silently
+// dropping it).
+export function isLinearTerminal(name) {
+  return LINEAR_TERMINAL_STATES.has(name);
+}
+
+// isTicketTerminalOrMerged — CHEAP-FIRST determination of whether a ticket has
+// reached a terminal Linear state OR has an already-merged PR. Used by the
+// CTL-642 recovery short-circuit to stop escalating / reviving a ticket the
+// pipeline (or a human) has already finished.
+//
+// Order matters — the cheap cached Linear read runs FIRST, the expensive `gh`
+// PR view runs ONLY if the Linear state is non-terminal AND a PR number exists:
+//   1. cached `fetchState(ticket)` → isLinearTerminal? → {terminal:true, reason:"linear-terminal"}.
+//      A NULL read (linearis down / unparseable) is the D5 fail-safe → falls
+//      through to NOT-terminal (never short-circuits on an unknown state).
+//   2. only if step 1 is non-terminal AND signal.raw.pr.number is present:
+//      prAdapter.prView(ticket, pr) → merged? → {terminal:true, reason:"pr-merged"}.
+//      "merged" means state === "MERGED" or a non-null mergedAt.
+//   3. else → {terminal:false}.
+//
+// Returns { terminal, reason }. Best-effort: never throws — a thrown read is
+// swallowed to the fail-safe NOT-terminal verdict (the caller then proceeds with
+// its normal escalate/revive path, exactly as before this guard existed).
+export function isTicketTerminalOrMerged({ ticket, signal, fetchState, cache, prAdapter } = {}) {
+  try {
+    // (1) CHEAP cached Linear read first.
+    if (typeof fetchState === "function") {
+      const state = fetchState(ticket, { cache });
+      if (isLinearTerminal(state)) {
+        return { terminal: true, reason: "linear-terminal", state };
+      }
+    }
+    // (2) Only escalate to the expensive PR view when we have a PR number AND
+    //     the Linear state did not already prove terminal.
+    const pr = signal?.raw?.pr ?? signal?.pr ?? null;
+    if (prAdapter && typeof prAdapter.prView === "function" && pr?.number) {
+      const view = prAdapter.prView(ticket, pr);
+      if (view && (view.state === "MERGED" || view.mergedAt != null)) {
+        return { terminal: true, reason: "pr-merged", state: view.state ?? null };
+      }
+    }
+    // (3) Neither terminal nor merged (or unreadable → D5 fail-safe).
+    return { terminal: false };
+  } catch {
+    // Fail-safe: an unexpected throw must NOT manufacture a false terminal.
+    return { terminal: false };
+  }
+}

--- a/plugins/dev/scripts/execution-core/terminal-state.test.mjs
+++ b/plugins/dev/scripts/execution-core/terminal-state.test.mjs
@@ -1,0 +1,155 @@
+// Unit tests for the SHARED Linear terminal-state predicate (CTL-642 + CTL-758).
+// Run: cd plugins/dev/scripts && bun test execution-core/terminal-state.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import {
+  isLinearTerminal,
+  LINEAR_TERMINAL_STATES,
+  isTicketTerminalOrMerged,
+} from "./terminal-state.mjs";
+import { TERMINAL as SIGNAL_TERMINAL } from "./signal-reader.mjs";
+import { TERMINAL_STATES as FSM_TERMINAL } from "../lib/phase-fsm.mjs";
+
+describe("isLinearTerminal — its OWN set {Done, Canceled}", () => {
+  test("Done and Canceled are terminal", () => {
+    expect(isLinearTerminal("Done")).toBe(true);
+    expect(isLinearTerminal("Canceled")).toBe(true);
+  });
+
+  test("non-terminal Linear states are NOT terminal", () => {
+    for (const name of ["Triage", "Todo", "In Progress", "Research", "Plan", "PR", "Backlog"]) {
+      expect(isLinearTerminal(name)).toBe(false);
+    }
+  });
+
+  test("null/undefined/unknown is NOT terminal (D5 fail-safe)", () => {
+    expect(isLinearTerminal(null)).toBe(false);
+    expect(isLinearTerminal(undefined)).toBe(false);
+    expect(isLinearTerminal("")).toBe(false);
+    expect(isLinearTerminal("Some Custom State")).toBe(false);
+  });
+
+  test("NO conflation with the signal-reader or phase-fsm terminal sets", () => {
+    // signal-reader.TERMINAL = {done, failed, stalled, skipped} (signal statuses)
+    // phase-fsm.TERMINAL_STATES = {done, stalled} (FSM states)
+    // These are LOWERCASE statuses/states; the Linear set is TitleCase state NAMES.
+    for (const status of SIGNAL_TERMINAL) {
+      expect(isLinearTerminal(status)).toBe(false); // "done"/"failed"/... are NOT Linear-terminal NAMES
+      expect(LINEAR_TERMINAL_STATES.has(status)).toBe(false);
+    }
+    for (const state of FSM_TERMINAL) {
+      expect(isLinearTerminal(state)).toBe(false);
+      expect(LINEAR_TERMINAL_STATES.has(state)).toBe(false);
+    }
+    // And the Linear set's members are NOT in the other two sets.
+    for (const name of LINEAR_TERMINAL_STATES) {
+      expect(SIGNAL_TERMINAL.has(name)).toBe(false);
+      expect(FSM_TERMINAL.has(name)).toBe(false);
+    }
+  });
+
+  test("the set is frozen (no caller can mutate the shared predicate)", () => {
+    expect(Object.isFrozen(LINEAR_TERMINAL_STATES)).toBe(true);
+  });
+});
+
+describe("isTicketTerminalOrMerged — cheap-first", () => {
+  const sigWithPr = { raw: { pr: { number: 42, repo: "owner/repo" } } };
+  const sigNoPr = { raw: {} };
+
+  function spyPrView(view) {
+    const calls = [];
+    return {
+      prView: (...args) => {
+        calls.push(args);
+        return view;
+      },
+      calls,
+    };
+  }
+
+  test("terminal Linear state short-circuits — prView NOT called (cheap-first, spy 0)", () => {
+    const pr = spyPrView({ state: "MERGED", mergedAt: "2026-06-04T00:00:00Z" });
+    const r = isTicketTerminalOrMerged({
+      ticket: "CTL-1",
+      signal: sigWithPr,
+      fetchState: () => "Done",
+      cache: undefined,
+      prAdapter: pr,
+    });
+    expect(r.terminal).toBe(true);
+    expect(r.reason).toBe("linear-terminal");
+    expect(pr.calls.length).toBe(0); // expensive PR view never ran
+  });
+
+  test("non-terminal Linear + merged PR ⇒ terminal via pr-merged (prView IS consulted)", () => {
+    const pr = spyPrView({ state: "MERGED", mergedAt: null });
+    const r = isTicketTerminalOrMerged({
+      ticket: "CTL-2",
+      signal: sigWithPr,
+      fetchState: () => "PR",
+      prAdapter: pr,
+    });
+    expect(r.terminal).toBe(true);
+    expect(r.reason).toBe("pr-merged");
+    expect(pr.calls.length).toBe(1);
+  });
+
+  test("non-terminal Linear + open PR ⇒ NOT terminal", () => {
+    const pr = spyPrView({ state: "OPEN", mergedAt: null });
+    const r = isTicketTerminalOrMerged({
+      ticket: "CTL-3",
+      signal: sigWithPr,
+      fetchState: () => "PR",
+      prAdapter: pr,
+    });
+    expect(r.terminal).toBe(false);
+  });
+
+  test("non-terminal Linear + NO pr number ⇒ prView NOT called (spy 0), NOT terminal", () => {
+    const pr = spyPrView({ state: "MERGED", mergedAt: "x" });
+    const r = isTicketTerminalOrMerged({
+      ticket: "CTL-4",
+      signal: sigNoPr,
+      fetchState: () => "PR",
+      prAdapter: pr,
+    });
+    expect(r.terminal).toBe(false);
+    expect(pr.calls.length).toBe(0);
+  });
+
+  test("null Linear read ⇒ NOT terminal (D5 fail-safe), even with merged PR absent", () => {
+    const pr = spyPrView({ state: "OPEN", mergedAt: null });
+    const r = isTicketTerminalOrMerged({
+      ticket: "CTL-5",
+      signal: sigWithPr,
+      fetchState: () => null,
+      prAdapter: pr,
+    });
+    expect(r.terminal).toBe(false);
+  });
+
+  test("a thrown read fails safe to NOT terminal", () => {
+    const r = isTicketTerminalOrMerged({
+      ticket: "CTL-6",
+      signal: sigWithPr,
+      fetchState: () => {
+        throw new Error("linearis exploded");
+      },
+      prAdapter: spyPrView(null),
+    });
+    expect(r.terminal).toBe(false);
+  });
+
+  test("mergedAt non-null with state UNKNOWN still counts as merged", () => {
+    const pr = spyPrView({ state: "UNKNOWN", mergedAt: "2026-06-04T00:00:00Z" });
+    const r = isTicketTerminalOrMerged({
+      ticket: "CTL-7",
+      signal: sigWithPr,
+      fetchState: () => "PR",
+      prAdapter: pr,
+    });
+    expect(r.terminal).toBe(true);
+    expect(r.reason).toBe("pr-merged");
+  });
+});

--- a/plugins/dev/scripts/setup-execution-core-states.sh
+++ b/plugins/dev/scripts/setup-execution-core-states.sh
@@ -77,6 +77,22 @@ missing_contract_states() {
   done
 }
 
+# The desired Linear git-automation contract (CTL-759). Linear can auto-move a
+# ticket on git events (PR opened / under review / merged). The execution-core
+# pipeline is the authority on Linear state, so we pin exactly two automations —
+# `start`→PR and `merge`→Done — and DELETE any `review` node. Linear's UI-only
+# "magic words" toggle (move on branch-name match) must stay OFF; that path is
+# the CTL-758 backward-write footgun and is not represented here.
+#
+# Keep in sync with contract_states() above (Done is a workflow `completed`
+# state Linear ships by default; PR is one of our contract states).
+desired_git_automations() {
+  jq -nc '[
+    { event: "start", state: "PR"   },
+    { event: "merge", state: "Done" }
+  ]'
+}
+
 # build_workflow_state_create_mutation <teamId> <name> <type> <color> —
 # the raw GraphQL mutation string that creates one workflow state. `color` is
 # cosmetic; see CONTRACT_STATE_COLOR.
@@ -131,6 +147,117 @@ linear_graphql_post() {
     -H "Content-Type: application/json" \
     -H "Authorization: ${token}" \
     -d "$payload" 2>&1
+}
+
+# --- Linear git-automation reconcile (CTL-759) ------------------------------
+# reconcile_git_automation_states <team_id> <token> <fetched_states_json>
+#
+# Drives the team's git automations to the desired_git_automations() contract:
+#   start → PR    (create or update the existing node's stateId)
+#   merge → Done  (create or update)
+#   review        → delete every existing node (we never auto-move on review)
+#
+# Reuses linear_graphql_post. State-ids are resolved from the already-fetched
+# workflow states (no extra round-trip). Tolerant: every Linear failure prints a
+# WARNING and continues — this is a best-effort hardening step, NOT a gate, so it
+# never alters the exit codes (3/4) the caller depends on. A target state that
+# does not exist in the team's workflow → WARN and skip that automation; we never
+# issue a create/update with a null stateId.
+#
+# Idempotent: the live CTL team is already start→PR / merge→Done (review cleared),
+# so this is a no-op there; value is durability at install + drift correction +
+# coverage for ADV / future teams.
+reconcile_git_automation_states() {
+  local team_id="$1" token="$2" fetched_states="$3"
+
+  # Resolve target state-ids from the fetched workflow states (by name).
+  local pr_state_id done_state_id
+  pr_state_id=$(echo "$fetched_states" | jq -r 'map(select(.name == "PR")) | .[0].id // empty')
+  done_state_id=$(echo "$fetched_states" | jq -r 'map(select(.name == "Done")) | .[0].id // empty')
+
+  # Fetch existing git automations for the team (id + event + target state id).
+  local ga_query ga_payload ga_resp existing
+  # shellcheck disable=SC2016
+  ga_query='query($teamId: String!) { team(id: $teamId) { gitAutomationStates { nodes { id event state { id name } } } } }'
+  ga_payload=$(jq -nc --arg q "$ga_query" --arg t "$team_id" '{query: $q, variables: {teamId: $t}}')
+  ga_resp=$(linear_graphql_post "$token" "$ga_payload")
+  if echo "$ga_resp" | jq -e '.errors' >/dev/null 2>&1; then
+    local ga_err
+    ga_err=$(echo "$ga_resp" | jq -r '.errors[0].message // "unknown error"')
+    echo "WARNING: could not read git automations for team — skipping reconcile: $ga_err" >&2
+    return 0
+  fi
+  existing=$(echo "$ga_resp" | jq -c '.data.team.gitAutomationStates.nodes // []' 2>/dev/null)
+  if [[ -z $existing || $existing == "null" ]]; then
+    existing='[]'
+  fi
+
+  # upsert <event> <target_state_id> — create the node if absent, else update
+  # its stateId. Never called with an empty target id (caller guards).
+  _ga_upsert() {
+    local event="$1" state_id="$2"
+    local node_id mutation payload resp
+    node_id=$(echo "$existing" | jq -r --arg e "$event" 'map(select(.event == $e)) | .[0].id // empty')
+    if [[ -n $node_id ]]; then
+      # No change needed if the node already points at the desired state.
+      local cur_state_id
+      cur_state_id=$(echo "$existing" | jq -r --arg e "$event" 'map(select(.event == $e)) | .[0].state.id // empty')
+      if [[ $cur_state_id == "$state_id" ]]; then
+        echo "Git automation '${event}' already correct"
+        return 0
+      fi
+      # shellcheck disable=SC2016
+      mutation='mutation($id: String!, $input: GitAutomationStateUpdateInput!) { gitAutomationStateUpdate(id: $id, input: $input) { success } }'
+      payload=$(jq -nc --arg q "$mutation" --arg id "$node_id" --arg s "$state_id" \
+        '{query: $q, variables: {id: $id, input: {stateId: $s}}}')
+    else
+      # shellcheck disable=SC2016
+      mutation='mutation($input: GitAutomationStateCreateInput!) { gitAutomationStateCreate(input: $input) { success } }'
+      payload=$(jq -nc --arg q "$mutation" --arg t "$team_id" --arg e "$event" --arg s "$state_id" \
+        '{query: $q, variables: {input: {teamId: $t, event: $e, stateId: $s}}}')
+    fi
+    resp=$(linear_graphql_post "$token" "$payload")
+    if echo "$resp" | jq -e '.errors' >/dev/null 2>&1 \
+      || [[ "$(echo "$resp" | jq -r '.data.gitAutomationStateCreate.success // .data.gitAutomationStateUpdate.success // false')" != "true" ]]; then
+      echo "WARNING: failed to set git automation '${event}' → state ${state_id}" >&2
+    else
+      echo "Set git automation '${event}' → desired state"
+    fi
+  }
+
+  # START → PR
+  if [[ -z $pr_state_id ]]; then
+    echo "WARNING: target state 'PR' not found in team workflow — skipping 'start' git automation (no null stateId issued)" >&2
+  else
+    _ga_upsert "start" "$pr_state_id"
+  fi
+
+  # MERGE → Done
+  if [[ -z $done_state_id ]]; then
+    echo "WARNING: target state 'Done' not found in team workflow — skipping 'merge' git automation (no null stateId issued)" >&2
+  else
+    _ga_upsert "merge" "$done_state_id"
+  fi
+
+  # REVIEW → delete each existing review node (we never auto-move on review).
+  local review_id review_ids del_mutation del_payload del_resp
+  review_ids=$(echo "$existing" | jq -r 'map(select(.event == "review")) | .[].id')
+  for review_id in $review_ids; do
+    [[ -z $review_id ]] && continue
+    # shellcheck disable=SC2016
+    del_mutation='mutation($id: String!) { gitAutomationStateDelete(id: $id) { success } }'
+    del_payload=$(jq -nc --arg q "$del_mutation" --arg id "$review_id" '{query: $q, variables: {id: $id}}')
+    del_resp=$(linear_graphql_post "$token" "$del_payload")
+    if echo "$del_resp" | jq -e '.errors' >/dev/null 2>&1 \
+      || [[ "$(echo "$del_resp" | jq -r '.data.gitAutomationStateDelete.success // false')" != "true" ]]; then
+      echo "WARNING: failed to delete 'review' git automation node ${review_id}" >&2
+    else
+      echo "Deleted 'review' git automation node"
+    fi
+  done
+
+  unset -f _ga_upsert
+  return 0
 }
 
 # --- main -------------------------------------------------------------------
@@ -377,6 +504,13 @@ main() {
     fi
     rm -f "$upsert_err"
   fi
+
+  # --- reconcile Linear git automations (CTL-759) — the LAST Linear step ---
+  # Best-effort hardening: pins start→PR / merge→Done and removes any review
+  # automation, the install-time complement to the daemon's CTL-758 backward-
+  # write guard. Tolerant by design — it prints WARNINGs and continues, and
+  # never touches the 3/4 exit codes the caller (setup-catalyst.sh) consumes.
+  reconcile_git_automation_states "$team_id" "$token" "$fetched_states" || true
 
   # --- summary ---
   if [[ $json_out -eq 1 ]]; then

--- a/plugins/dev/skills/setup-catalyst/SKILL.md
+++ b/plugins/dev/skills/setup-catalyst/SKILL.md
@@ -95,6 +95,19 @@ the standalone script never aborts setup. The standalone script is also
 idempotent and can be run directly per team (`setup-execution-core-states.sh
 --config .catalyst/config.json [--dry-run] [--json]`).
 
+**Linear git automations (CTL-759).** As its last Linear step,
+`setup-execution-core-states.sh` reconciles the team's *git automations* —
+Linear's built-in "move ticket on git event" rules. It pins exactly two
+(`start` → `PR`, `merge` → `Done`) and deletes any `review` automation, so the
+execution-core daemon stays the single authority on ticket state. The reconcile
+is best-effort and tolerant: a Linear permission/transport failure prints a
+WARNING and continues — it never aborts setup and never alters the script's exit
+codes. `check-project-setup.sh` (hot path) warns on drift via a TTL-gated cached
+read; a missing per-project token is a silent skip. Separately, Linear's
+**branch-name "magic words" toggle** (Settings → Team → Workflow → Git) has no
+API surface and **cannot** be reconciled — it must be turned OFF by hand, or it
+races the daemon and re-introduces the CTL-758 backward state-write.
+
 For issues needing user input, explain what's needed and how to provide it:
 
 | Issue | What to tell the user |
@@ -102,6 +115,9 @@ For issues needing user input, explain what's needed and how to provide it:
 | Linear API token not set | Show the secrets file path, explain where to get the token from Linear settings |
 | No project config | Suggest running `setup-catalyst.sh` or offer to create a minimal `.catalyst/config.json` interactively |
 | direnv not installed | Show `brew install direnv` and the shell hook setup |
+| Linear "magic words" auto-move ON | Tell the user to turn it OFF in Settings → Team → Workflow → Git — it races the execution-core daemon and causes backward state writes (CTL-758). No API surface; must be toggled by hand. |
+| Linear `review` git automation set | Run `setup-execution-core-states.sh` to remove it; the pipeline owns the Validate/review state, not Linear. |
+| Personal git automations override team ones | Remind the user that Linear lets each member set *personal* git automations that shadow the team defaults — check Settings → Account → Git if drift persists after the team reconcile. |
 
 **Observability (OTel) is optional.** If Docker or OTel containers aren't found, note it as
 informational — don't treat it as an issue. Point the user to


### PR DESCRIPTION
Bundles four state-correctness tickets around one idea: **make every Linear state-write observable (757), refuse the wrong writes from ONE shared terminal predicate (758+642), and stop the upstream footgun at install (759).** Design doc: `thoughts/shared/plans/2026-06-04-job2-pr1-state-correctness.md`.

## CTL-757 — canonical `linear.state.write` audit event (keystone)
New `linear-state-write-event.mjs` emitter (mirrors `triage-transition-event.mjs`). `runTransition` now returns the `currentState`/`targetState` it already computed (was discarded) → `from_state`/`to_state` for free. **Caller-emits** at the 5 scheduler write sites (not inside `runTransition` — avoids double-auditing triage); `event.channel: "execution-core"` separates it from inbound webhook echoes; `actor` tags the daemon (the human-vs-daemon discriminator the echo lacks). Boot-resume/reclaim source-tags + the `ticket_state_transitions` db table are deferred to CTL-764.

## CTL-642 + CTL-758 — consolidated terminal-aware guard (ONE mechanism)
One `isLinearTerminal({Done,Canceled})` predicate (its own set — never conflated with the signal/FSM terminal sets) + one `isTicketTerminalOrMerged` fact-reader (cheap-first: cached Linear read, then `gh` PR-merged only if non-terminal + a PR number), consumed by two guards:
- **CTL-642 recovery short-circuit** — in `reclaimDeadWorkIfPossible`, placed before the alive-branch so it dominates **all three** `escalateOnce` sites; on terminal/merged it flips the stale signal to `done` and returns `terminal-short-circuit` instead of escalating (kills the CTL-624/625 "merged but escalating hundreds of times" noise).
- **CTL-758 backward-write guard** — inside `runTransition` (the chokepoint every write passes): refuses a backward move on a terminal ticket, **while explicitly allowing the forward `done` write** (monitor-deploy + backstop still set Done). This is the direct fix for the CTL-549/550/749 regression.
- **CTL-758 reconcile backstop** — re-asserts Done for a `.terminal-done.applied` + merged ticket whose live state regressed (defense-in-depth).
- The shared TTL cache is threaded into `reclaimOpts` (the load-bearing fix — else the terminal check re-introduces the API storm it exists to kill), and a **live `prAdapter`** is constructed once at boot and threaded into the scheduler so the PR-merged short-circuit + backstop actually fire in production (the merged-but-not-yet-Done window, which the Linear 2500/hr rate-limit can stretch to 10+ min).

## CTL-759 — Linear git-automations at install + cached drift-warn
`setup-execution-core-states.sh` idempotently reconciles the team PR-automations via GraphQL (start→PR, merge→Done, delete any review node) — tolerant, never alters exit codes 3/4. `check-project-setup.sh` adds a **TTL-cached** (6h) drift-warn (soft-skips with no token); `check-setup.sh` adds a static warn that the UI-only magic-words toggle must be OFF; setup-catalyst SKILL documents both. (Live CTL is already start→PR/merge→Done — verified — so this is idempotency + ADV/future coverage + drift detection.)

## How it was built & verified
Design-pass workflow (3 mappers → synthesis) → implement workflow (3 slices → test-harden → 4-lens adversarial review) → prАdapter wiring + cleanups. **Review: 4× pass, 0 HIGH.** Tests: **629 JS + 68 shell, 0 fail** (new suites: linear-state-write-event, terminal-state; extended: linear-write, recovery, scheduler, + 2 shell). New coverage pins the top risks: forward-`done`-proceeds safety, short-circuit dominates all 3 escalate sites, cache-threaded (≤1 read/ticket/TTL), caller-emit-not-on-triage, no broker-filter collision, 759 exit-codes unchanged + cached drift-warn.

## Deploy (manual, post-merge)
Cache-hotpatch the latest cached plugin + restart the daemon (757/758/642 change live behavior; 759 affects future installs/checks only).