### PR TITLE
chore(meta): register OTL->catalyst-otel in monitor config

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -42,6 +42,10 @@
           {
             "key": "ADV",
             "vcsRepo": "coalesce-labs/adva"
+          },
+          {
+            "key": "OTL",
+            "vcsRepo": "coalesce-labs/catalyst-otel"
           }
         ]
       }


### PR DESCRIPTION
Adds the OTL team → coalesce-labs/catalyst-otel mapping to monitor.linear.teams so the catalyst monitor correlates OTL events. Mirrors the existing CTL/ADV entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)