### PR TITLE
fix(dev): CTL-769 give the execution-core reaper a poll-fallback drain

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -34,6 +34,7 @@ import {
   getEventLogPath,
   log,
   EVENT_DEBOUNCE_MS,
+  TAILER_POLL_INTERVAL_MS,
   readWaitWatcherConfig,
   readMemorySamplerConfig,
 } from "./config.mjs";
@@ -92,6 +93,7 @@ let _memorySampler = null;
 let _stopAutoTuner = null;
 let _eventWatcher = null;
 let _eventDebounceTimer = null;
+let _eventPollTimer = null; // CTL-769: poll-fallback drain (fs.watch debounce never fires on the continuously-appended log)
 let _eventLogCursor = 0;
 // CTL-649: the trailing partial line carried across reads. _eventLogCursor is a
 // BYTE offset; consumeEventTail reads only NEW bytes via a file descriptor and
@@ -240,10 +242,16 @@ export function startDaemon({
   reconcile = reconcileAll,
   watchRegistry = true,
   debounceMs = EVENT_DEBOUNCE_MS,
+  // CTL-769: reaper poll-fallback interval. Injectable so tests can drive the
+  // reap-intent drain deterministically; defaults to TAILER_POLL_INTERVAL_MS.
+  pollMs = TAILER_POLL_INTERVAL_MS,
   pidFile = null,
   // CTL-649: reaper + orphan-sweep timer. Disable via env knob for tests
   // that only exercise monitor + scheduler.
   enableReaper = process.env.EXECUTION_CORE_DISABLE_REAPER !== "1",
+  // CTL-769: reaper factory seam — defaults to the real Reaper; injectable so
+  // tests can spy on reap dispatch driven by the poll fallback.
+  makeReaper = (opts) => new Reaper(opts),
   orphanReaperConfig = null,
   // CTL-707: worktree refresh timer config (catalyst.orchestration.worktreeRefresh).
   worktreeRefreshConfig = null,
@@ -379,7 +387,7 @@ export function startDaemon({
     }
 
     if (enableReaper) {
-      startReaperAndTimer({ orphanReaperConfig, worktreeRefreshConfig, debounceMs, orchDir });
+      startReaperAndTimer({ orphanReaperConfig, worktreeRefreshConfig, debounceMs, pollMs, orchDir, makeReaper });
     }
 
     // CTL-650: start the push-based session wait-state watcher. Inside the same
@@ -409,7 +417,20 @@ export function startDaemon({
 //
 // Boot replay is best-effort: if it throws, log and continue with live
 // consumption only.
-function startReaperAndTimer({ orphanReaperConfig, worktreeRefreshConfig, debounceMs, orchDir }) {
+function startReaperAndTimer({
+  orphanReaperConfig,
+  worktreeRefreshConfig,
+  debounceMs,
+  orchDir,
+  // CTL-769: poll-fallback interval. Defaults to TAILER_POLL_INTERVAL_MS
+  // (env-tunable via EXECUTION_CORE_TAILER_POLL_MS); injectable so tests can
+  // drive the drain on a tiny interval deterministically.
+  pollMs = TAILER_POLL_INTERVAL_MS,
+  // CTL-769: reaper factory seam. Defaults to the real Reaper; injectable so a
+  // test can observe that the poll-fallback timer (not an fs.watch event)
+  // dispatched a reap-requested line into reaper.handle().
+  makeReaper = (opts) => new Reaper(opts),
+}) {
   const eventLogPath = getEventLogPath();
   // CTL-649: the periodic sweep honors the configured recency floor
   // (minIdleSeconds, default 900s). includeInteractive stays at its safe
@@ -417,7 +438,7 @@ function startReaperAndTimer({ orphanReaperConfig, worktreeRefreshConfig, deboun
   // CTL-661: bind the per-ticket reconciler's canonical-owner reader to this
   // daemon's orchDir so the sweep resolves the authoritative active-phase
   // bg_job_id (falling back to newest-by-last_seen when no signal is found).
-  _reaper = new Reaper({
+  _reaper = makeReaper({
     minIdleMs: (orphanReaperConfig?.minIdleSeconds ?? 900) * 1000,
     readActivePhaseSignal: (ticket) => defaultReadActivePhaseSignal(orchDir, ticket),
   });
@@ -450,6 +471,16 @@ function startReaperAndTimer({ orphanReaperConfig, worktreeRefreshConfig, deboun
     });
   } catch (err) {
     log.error({ err }, "reaper: event-log watch failed — relying on boot replay only");
+  }
+
+  // CTL-769: fs.watch + debounce is perpetually reset by the continuously-
+  // appended unified event log, so consumeEventTail only fires during >5s idle
+  // gaps — the reaper starves exactly when workers are busy and predecessors
+  // accumulate. Mirror the new-work tailer's poll fallback (monitor.mjs:684-685,
+  // CTL-711): a cheap, idempotent, cursor-based poll drains reap-intents in ~2s
+  // instead of waiting up to the 600s reconcile sweep.
+  if (pollMs > 0) {
+    _eventPollTimer = setInterval(() => consumeEventTail(), pollMs);
   }
 
   const cfg = orphanReaperConfig ?? {};
@@ -488,6 +519,14 @@ export function __resetEventTailCursorForTest(cursor = 0, leftover = "") {
 // __getEventTailLeftoverForTest — inspect the carried partial line. Test-only.
 export function __getEventTailLeftoverForTest() {
   return _eventLogLeftover;
+}
+
+// __getEventPollTimerForTest — inspect the CTL-769 poll-fallback interval handle
+// so a test can pin its teardown directly (non-null while running, null after
+// stopDaemon) instead of inferring it from drain side-effects, which the
+// `_reaper = null` guard in stopDaemon would otherwise mask. Test-only.
+export function __getEventPollTimerForTest() {
+  return _eventPollTimer;
 }
 
 // consumeEventTail — read the NEW BYTES appended to the event log since the
@@ -595,6 +634,10 @@ export function stopDaemon() {
   if (_eventDebounceTimer) {
     clearTimeout(_eventDebounceTimer);
     _eventDebounceTimer = null;
+  }
+  if (_eventPollTimer) {
+    clearInterval(_eventPollTimer);
+    _eventPollTimer = null;
   }
   if (_orphanTimer) {
     try {

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -27,9 +27,11 @@ import {
   handleCommentWake,
   __resetEventTailCursorForTest,
   __getEventTailLeftoverForTest,
+  __getEventPollTimerForTest,
   createCommentInboxWriter,
   createUpdateInboxWriter,
 } from "./daemon.mjs";
+import { getEventLogPath } from "./config.mjs";
 import { upsertProjectEntry } from "./registry.mjs";
 
 // CATALYST_DIR temp-dir harness — identical shape to enrollment.test.mjs:14-19.
@@ -720,6 +722,118 @@ describe("consumeEventTail (byte-offset + partial-line tail)", () => {
       consumeEventTail({ path: join(dir, "does-not-exist.jsonl"), reaper })
     ).not.toThrow();
     expect(handled).toHaveLength(0);
+  });
+});
+
+// CTL-769: the reaper must drain reap-intents via a setInterval POLL fallback,
+// not solely via fs.watch + debounce. On the continuously-appended unified
+// event log the debounce is perpetually reset, so consumeEventTail only ever
+// fired during >5s idle gaps and the reaper starved exactly when workers were
+// busy (~101k reap-requested vs ~216 reap-complete live). Mirrors the sibling
+// new-work tailer's poll fallback (monitor.mjs:684-685 / TAILER_POLL_INTERVAL_MS).
+describe("startReaperAndTimer — poll fallback drains reap-intents (CTL-769)", () => {
+  test("a reap-requested line appended after boot is drained by the poll, NOT fs.watch", async () => {
+    const handled = [];
+    // Fake reaper: record every dispatched event. .handle returns a resolved
+    // promise so the production .catch(...) chain is exercised without throwing
+    // and without any `claude` shell-out.
+    const fakeReaper = {
+      handle: (event) => {
+        handled.push(event);
+        return Promise.resolve();
+      },
+      // bootReplay runs once at startReaperAndTimer; no-op for the test.
+      bootReplay: () => Promise.resolve(),
+    };
+
+    startDaemon({
+      recover: () => {},
+      reconcileBoot: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      // No registry watcher — isolate the reaper event-log path.
+      watchRegistry: false,
+      enableReaper: true,
+      makeReaper: () => fakeReaper,
+      // Tiny poll so the drain is fast and deterministic.
+      pollMs: 10,
+      // A huge debounce makes the fs.watch path (if it ever fires) schedule a
+      // consumeEventTail far beyond this test's deadline — so any drain we
+      // observe within ~2s must have come from the poll interval, not fs.watch.
+      debounceMs: 600_000,
+    });
+
+    // Append a reap-requested line to the REAL event log path the daemon polls.
+    // startReaperAndTimer set the cursor to the current tail (0 here, since the
+    // file does not exist yet), so this newly-appended line is "new" bytes.
+    const logPath = getEventLogPath();
+    mkdirSync(dirname(logPath), { recursive: true });
+    const reapLine =
+      JSON.stringify({ event: "phase.yield.reap-requested", bg_job_id: "poll-abc" }) + "\n";
+    appendFileSync(logPath, reapLine);
+
+    // Poll-wait (deadline loop) until the reaper handles it — proving the
+    // setInterval drained the tail without any fs.watch event.
+    const deadline = Date.now() + 3000;
+    while (handled.length === 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    const reaps = handled.filter((e) => e.event === "phase.yield.reap-requested");
+    expect(reaps).toHaveLength(1);
+    expect(reaps[0].bg_job_id).toBe("poll-abc");
+  });
+
+  test("stopDaemon clears the poll interval — no further drains after stop", async () => {
+    const handled = [];
+    const fakeReaper = {
+      handle: (event) => {
+        handled.push(event);
+        return Promise.resolve();
+      },
+      bootReplay: () => Promise.resolve(),
+    };
+
+    startDaemon({
+      recover: () => {},
+      reconcileBoot: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+      enableReaper: true,
+      makeReaper: () => fakeReaper,
+      pollMs: 10,
+      debounceMs: 600_000,
+    });
+
+    const logPath = getEventLogPath();
+    mkdirSync(dirname(logPath), { recursive: true });
+
+    // The poll interval is live after boot. Assert the handle DIRECTLY so this
+    // test pins stopDaemon's clearInterval — a behavioral "0 drains after stop"
+    // check alone is masked by stopDaemon also nulling _reaper (consumeEventTail
+    // short-circuits on a null reaper), so a leaked, un-cleared interval would
+    // no-op and the behavioral assertion would still pass. Removing the
+    // clearInterval block from stopDaemon must make THIS test red.
+    expect(__getEventPollTimerForTest()).not.toBeNull();
+
+    // Stop the daemon BEFORE appending — the interval must be cleared so the
+    // newly-appended line is never drained.
+    stopDaemon();
+
+    // The handle is cleared (the real teardown pin, independent of the reaper).
+    expect(__getEventPollTimerForTest()).toBeNull();
+
+    appendFileSync(
+      logPath,
+      JSON.stringify({ event: "phase.yield.reap-requested", bg_job_id: "after-stop" }) + "\n"
+    );
+
+    // Belt-and-suspenders: give the (now-cleared) interval ample wall-clock time
+    // to misfire and confirm no drain occurs.
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(handled.filter((e) => e.event === "phase.yield.reap-requested")).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## What

Closes CTL-769. Layer A: give the execution-core reaper the same poll-fallback drain the new-work tailer already has.

## Why

The reaper's only live-drain path (`consumeEventTail`) was wired solely to `watch(eventsDir)` + a `setTimeout` debounce (`daemon.mjs`). On the **continuously-appended** unified event log the debounce is perpetually reset by ongoing dispatch/heartbeat/state writes, so `consumeEventTail` only fired during >5s idle gaps — the reaper drained when **idle** and starved exactly when workers were **busy** and predecessors accumulated. Undrained reap-intents then sat until the 600s reconcile sweep.

**Live proof:** ~101k `reap-requested` vs ~216 `reap-complete`. Leaked predecessor workers inflate `liveCount` → `freeSlots=0` → the whole `maxParallel` queue starves (the "7 in Triage" pile-up, OTL-2's 3 concurrent live workers).

This is the **consumer half of CTL-657 left unfinished**: the NEW-WORK tailer already got the identical poll fallback (`monitor.mjs:684-685`, CTL-711, comment *"fs.watch is unreliable for cross-process appends"*) — it was never extended to the reaper.

## What changed (Layer A only)

- `startReaperAndTimer`: `setInterval(() => consumeEventTail(), TAILER_POLL_INTERVAL_MS)` alongside the existing watch+debounce.
- `stopDaemon`: tears the interval down (`clearInterval` + null).
- Minimal `pollMs`/`makeReaper` seams (defaulting to production behavior) to make the poll path deterministically testable.
- Two tests that **pin both production lines** (each goes red when its line is reverted):
  1. a reap-requested line appended after boot is drained by the poll, **not** fs.watch (proven by a 600s debounce that rules out the watch path);
  2. `stopDaemon` clears the interval — asserts the **timer handle directly** via a test-only inspector, so it pins `clearInterval` rather than being masked by the `_reaper = null` guard.

`consumeEventTail` is cursor-based, cheap (reads only new bytes), idempotent — safe on a fixed interval. Drains reap-intents in ~2s instead of up to 600s.

## Out of scope (follow-ups)

- **Does NOT** touch slot accounting (`computeFreeSlots`/`liveCount`/`countBackgroundAgents`) — counting leaked processes is the intended fail-safe. *Fix the leak, not the count.*
- **Layer B** (stop-before-advance in `recordWorkerTransition`) → CTL-764.
- Secondary hardening (reaper.mjs fresh-snapshot re-verify, terminal-reap flood) → follow-ups.

## Test plan

- `bun test plugins/dev/scripts/execution-core/daemon.test.mjs` → 61 pass, 0 fail
- Collateral `reaper.test.mjs` + `scheduler.test.mjs` → 384 pass, 0 fail
- Adversarially verified: reverting each production line turns the corresponding test red.

Delivered via a dynamic Workflow (implement → independent verify → 3-lens adversarial review, 3/3 pass; the one medium finding — test 2 not pinning teardown — is fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)