### PR TITLE
feat(dev): CTL-770 setpoint-seeking autotuner + CTL-771 autotune OTel gauges

### DIFF
--- a/plugins/dev/scripts/execution-core/autotune-decision.test.mjs
+++ b/plugins/dev/scripts/execution-core/autotune-decision.test.mjs
@@ -373,10 +373,111 @@ describe("decideMaxParallel", () => {
       { w: makeWindow([[10, 8, 6], [12, 9, 7], [15, 11, 8]]), label: "trend-up" },
       { w: makeWindow([[2, 4, 6], [1, 3, 5], [1, 2, 4]], 50), label: "trend-down" },
     ];
-    for (const { w, label } of cases) {
+    for (const { w } of cases) {
       const { next } = decideMaxParallel({ window: w, concurrency, ...base });
       expect(next).toBeGreaterThanOrEqual(concurrency.minParallel);
       expect(next).toBeLessThanOrEqual(concurrency.maxParallelCeiling);
     }
+  });
+
+  // --- CTL-770: setpoint-seeking convergence ---------------------------------
+
+  describe("setpoint convergence (CTL-770)", () => {
+    // A flat-idle window: trend==="none" (no strict up/down), load well below
+    // the cores×factor safe line. coreCount=4, loadSafeFactor=2 → threshold=8.
+    const flatIdle = makeWindow([[1.2, 1.2, 1.3], [1.2, 1.3, 1.2], [1.3, 1.2, 1.2]], 50);
+
+    test("flat-idle + mem-ok + setpoint + current<setpoint → converge-to-setpoint", () => {
+      // current=1 below setpoint=6. This is exactly the case that returns 'hold'
+      // today when setpoint is omitted.
+      const atFloor = { maxParallel: 1, minParallel: 1, maxParallelCeiling: 20 };
+      const result = decideMaxParallel({ window: flatIdle, concurrency: atFloor, setpoint: 6, ...base });
+      expect(result.next).toBe(6);
+      expect(result.reason).toBe("converge-to-setpoint");
+    });
+
+    test("without setpoint, the same flat-idle window still holds (no regression)", () => {
+      const atFloor = { maxParallel: 1, minParallel: 1, maxParallelCeiling: 20 };
+      const result = decideMaxParallel({ window: flatIdle, concurrency: atFloor, ...base });
+      expect(result.next).toBe(1);
+      expect(result.reason).toBe("hold");
+    });
+
+    test("cold-start seed: window < minSamples + mem-ok + setpoint + current<setpoint", () => {
+      // Only 1 flat-low sample → fewer than minSamples=3. Seeds to the target.
+      const oneSample = makeWindow([[1.2, 1.2, 1.3]], 50);
+      const atFloor = { maxParallel: 1, minParallel: 1, maxParallelCeiling: 20 };
+      const result = decideMaxParallel({ window: oneSample, concurrency: atFloor, setpoint: 6, ...base });
+      expect(result.next).toBe(6);
+      expect(result.reason).toBe("cold-start-seed");
+    });
+
+    test("cold-start seed does NOT fire when current already >= setpoint", () => {
+      const oneSample = makeWindow([[1.2, 1.2, 1.3]], 50);
+      const atTarget = { maxParallel: 6, minParallel: 1, maxParallelCeiling: 20 };
+      const result = decideMaxParallel({ window: oneSample, concurrency: atTarget, setpoint: 6, ...base });
+      expect(result.next).toBe(6);
+      expect(result.reason).toBe("insufficient-samples");
+    });
+
+    test("empty window keeps insufficient-samples even with a setpoint (one tick delay)", () => {
+      const atFloor = { maxParallel: 1, minParallel: 1, maxParallelCeiling: 20 };
+      const result = decideMaxParallel({ window: [], concurrency: atFloor, setpoint: 6, ...base });
+      expect(result.next).toBe(1);
+      expect(result.reason).toBe("insufficient-samples");
+    });
+
+    test("deadband: current === setpoint, flat-idle → at-setpoint, no change, stable across ticks", () => {
+      const atTarget = { maxParallel: 6, minParallel: 1, maxParallelCeiling: 20 };
+      const r1 = decideMaxParallel({ window: flatIdle, concurrency: atTarget, setpoint: 6, ...base });
+      expect(r1.next).toBe(6);
+      expect(r1.reason).toBe("at-setpoint");
+      // Re-decide with the same inputs → identical, no ±1 oscillation.
+      const r2 = decideMaxParallel({ window: flatIdle, concurrency: atTarget, setpoint: 6, ...base });
+      expect(r2.next).toBe(6);
+      expect(r2.reason).toBe("at-setpoint");
+    });
+
+    test("never overshoots: setpoint=6, current=5 converge → next<=6 (never 7)", () => {
+      const justBelow = { maxParallel: 5, minParallel: 1, maxParallelCeiling: 20 };
+      const result = decideMaxParallel({ window: flatIdle, concurrency: justBelow, setpoint: 6, ...base });
+      expect(result.next).toBe(6);
+      expect(result.next).toBeLessThanOrEqual(6);
+      expect(result.reason).toBe("converge-to-setpoint");
+    });
+
+    test("converge clamped to ceiling when setpoint exceeds it", () => {
+      const tight = { maxParallel: 1, minParallel: 1, maxParallelCeiling: 4 };
+      const result = decideMaxParallel({ window: flatIdle, concurrency: tight, setpoint: 6, ...base });
+      expect(result.next).toBe(4); // ceiling clamps the jump
+      expect(result.reason).toBe("converge-to-setpoint");
+    });
+
+    test("no convergence when load is NOT safe (load1 >= cores×factor) even below setpoint", () => {
+      // cores=4, factor=2 → threshold=8; load1=9 not safe. Flat-high pattern.
+      const flatHigh = makeWindow([[9, 9, 7], [9, 9, 11], [9, 10, 8]], 50);
+      const atFloor = { maxParallel: 1, minParallel: 1, maxParallelCeiling: 20 };
+      const result = decideMaxParallel({ window: flatHigh, concurrency: atFloor, setpoint: 6, ...base });
+      // flat-high fires (both load1,load5 > threshold) → hold, NOT converge.
+      expect(result.reason).toBe("flat-high");
+      expect(result.next).toBe(1);
+    });
+
+    test("no-regression: trend-up still sheds even below the setpoint", () => {
+      // current=10 above-floor, strict up-trend, setpoint=6 → must still shed,
+      // never converge upward toward the setpoint.
+      const up = makeWindow([[10, 8, 6], [12, 9, 7], [15, 11, 8]], 50);
+      const result = decideMaxParallel({ window: up, concurrency, setpoint: 6, ...base });
+      expect(result.next).toBe(Math.floor(10 * 0.75)); // 7
+      expect(result.reason).toBe("trend-up");
+    });
+
+    test("no-regression: mem-critical still clamps to minParallel even with a setpoint", () => {
+      const w = makeWindow([[1, 2, 4]], 2); // 2% free < critical
+      const atFloor = { maxParallel: 1, minParallel: 1, maxParallelCeiling: 20 };
+      const result = decideMaxParallel({ window: w, concurrency: atFloor, setpoint: 6, ...base });
+      expect(result.next).toBe(1);
+      expect(result.reason).toBe("mem-critical");
+    });
   });
 });

--- a/plugins/dev/scripts/execution-core/autotune-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/autotune-lifecycle.test.mjs
@@ -170,6 +170,152 @@ describe("autoTuneTick", () => {
     expect(decisions).toHaveLength(1);
     expect(decisions[0]).toBe(4); // jumped to layer1Max, not 2
   });
+
+  // --- CTL-770: setpoint resolution + plumbing -------------------------------
+
+  test("autoTuneTick resolves setpoint from Layer-2 targetParallel and passes it to decideMaxParallel", () => {
+    // Flat-idle, mem-ok, current=1, cores=8 → with setpoint=6 the converge
+    // branch fires and writeLayer2 is called with the core-bounded setpoint.
+    const flatIdle = [
+      { load1: 1.2, load5: 1.2, load15: 1.3, memFreePct: 50, coreCount: 8 },
+      { load1: 1.2, load5: 1.3, load15: 1.2, memFreePct: 50, coreCount: 8 },
+    ];
+    const state = makeState({ window: flatIdle, loadSafeFactor: 2 });
+    const writes = [];
+    const seams = makeSeams({
+      loadavg: () => [1.3, 1.2, 1.2], // 3rd flat sample
+      freemem: () => 8e9,
+      totalmem: () => 16e9, // 50% ok
+      cpus: () => Array(8),
+      readConcurrency: () => ({ maxParallel: 1, minParallel: 1, maxParallelCeiling: 20 }),
+      readLayer1Concurrency: () => ({ maxParallel: 4, minParallel: 1, maxParallelCeiling: 20 }),
+      readLayer2Concurrency: () => ({ targetParallel: 6 }),
+      writeLayer2: (v) => { writes.push(v); return true; },
+    });
+    autoTuneTick(state, seams);
+    // cores=8 → core-bound max(1, 8-2)=6, min(6,6)=6 → setpoint=6 → converge to 6.
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toBe(6);
+  });
+
+  test("setpoint is core-bounded: low-core box caps the target", () => {
+    // cores=4 → max(minParallel, 4-2)=2; target=6 bounded to 2.
+    const flatIdle = [
+      { load1: 0.5, load5: 0.5, load15: 0.5, memFreePct: 50, coreCount: 4 },
+      { load1: 0.5, load5: 0.5, load15: 0.5, memFreePct: 50, coreCount: 4 },
+    ];
+    const state = makeState({ window: flatIdle, loadSafeFactor: 2 });
+    const writes = [];
+    const seams = makeSeams({
+      loadavg: () => [0.5, 0.5, 0.5],
+      freemem: () => 8e9,
+      totalmem: () => 16e9,
+      cpus: () => Array(4),
+      readConcurrency: () => ({ maxParallel: 1, minParallel: 1, maxParallelCeiling: 20 }),
+      readLayer2Concurrency: () => ({ targetParallel: 6 }),
+      writeLayer2: (v) => { writes.push(v); return true; },
+    });
+    autoTuneTick(state, seams);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toBe(2); // core-bounded to 2
+  });
+
+  test("fail-safe: readLayer2Concurrency absent → setpoint resolves from Layer-1 maxParallel, no throw", () => {
+    const flatIdle = [
+      { load1: 1.2, load5: 1.2, load15: 1.3, memFreePct: 50, coreCount: 8 },
+      { load1: 1.2, load5: 1.3, load15: 1.2, memFreePct: 50, coreCount: 8 },
+    ];
+    const state = makeState({ window: flatIdle, loadSafeFactor: 2 });
+    const writes = [];
+    const seams = makeSeams({
+      loadavg: () => [1.3, 1.2, 1.2],
+      freemem: () => 8e9,
+      totalmem: () => 16e9,
+      cpus: () => Array(8),
+      readConcurrency: () => ({ maxParallel: 1, minParallel: 1, maxParallelCeiling: 20 }),
+      readLayer1Concurrency: () => ({ maxParallel: 4, minParallel: 1, maxParallelCeiling: 20 }),
+      // readLayer2Concurrency intentionally absent
+      writeLayer2: (v) => { writes.push(v); return true; },
+    });
+    expect(() => autoTuneTick(state, seams)).not.toThrow();
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toBe(4); // setpoint resolved from Layer-1 maxParallel=4
+  });
+
+  test("fail-safe: a throwing readLayer2Concurrency does not propagate (falls back to Layer-1)", () => {
+    const flatIdle = [
+      { load1: 1.2, load5: 1.2, load15: 1.3, memFreePct: 50, coreCount: 8 },
+      { load1: 1.2, load5: 1.3, load15: 1.2, memFreePct: 50, coreCount: 8 },
+    ];
+    const state = makeState({ window: flatIdle, loadSafeFactor: 2 });
+    const writes = [];
+    const seams = makeSeams({
+      loadavg: () => [1.3, 1.2, 1.2],
+      freemem: () => 8e9,
+      totalmem: () => 16e9,
+      cpus: () => Array(8),
+      readConcurrency: () => ({ maxParallel: 1, minParallel: 1, maxParallelCeiling: 20 }),
+      readLayer1Concurrency: () => ({ maxParallel: 4, minParallel: 1, maxParallelCeiling: 20 }),
+      readLayer2Concurrency: () => { throw new Error("malformed host file"); },
+      writeLayer2: (v) => { writes.push(v); return true; },
+    });
+    expect(() => autoTuneTick(state, seams)).not.toThrow();
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toBe(4);
+  });
+
+  // --- CTL-771: per-tick gauge emit ------------------------------------------
+
+  test("autoTuneTick calls appendGaugeEvent every tick with effective+target+workers+load+mem+reason", () => {
+    // next===current (hold) — the gauge must still fire (unconditional).
+    const state = makeState({ window: [{ load1: 5, load5: 5, load15: 5, memFreePct: 50, coreCount: 4 }] });
+    const gaugeCalls = [];
+    const seams = makeSeams({
+      liveBackgroundCount: () => 3,
+      loadavg: () => [4, 4, 4],
+      freemem: () => 8e9,
+      totalmem: () => 16e9,
+      cpus: () => Array(8),
+      readConcurrency: () => ({ maxParallel: 10, minParallel: 2, maxParallelCeiling: 20 }),
+      readLayer2Concurrency: () => ({ targetParallel: 6 }),
+      appendGaugeEvent: (args) => { gaugeCalls.push(args); return true; },
+    });
+    autoTuneTick(state, seams);
+    expect(gaugeCalls).toHaveLength(1);
+    const g = gaugeCalls[0];
+    expect(g.maxParallelEffective).toBe(10);
+    expect(g.maxParallelTarget).toBe(6);   // core-bounded (8-2=6, min(6,6)=6)
+    expect(g.runningWorkers).toBe(3);      // === bgCount
+    expect(g.load1).toBe(4);
+    expect(g.loadPerCore).toBeCloseTo(4 / 8, 5);
+    expect(g.memFreePct).toBe(50);
+    expect(typeof g.reason).toBe("string");
+  });
+
+  test("appendGaugeEvent fires even when the autotuner changes maxParallel (one per tick)", () => {
+    const upSamples = [
+      { load1: 10, load5: 8, load15: 6, memFreePct: 50, coreCount: 4 },
+      { load1: 12, load5: 9, load15: 7, memFreePct: 50, coreCount: 4 },
+    ];
+    const state = makeState({ window: upSamples });
+    const gaugeCalls = [];
+    const seams = makeSeams({
+      loadavg: () => [15, 11, 8], // completes trend-up → change
+      readConcurrency: () => ({ maxParallel: 10, minParallel: 2, maxParallelCeiling: 20 }),
+      appendGaugeEvent: (args) => { gaugeCalls.push(args); return true; },
+    });
+    autoTuneTick(state, seams);
+    expect(gaugeCalls).toHaveLength(1);
+    expect(gaugeCalls[0].reason).toBe("trend-up");
+  });
+
+  test("a throwing appendGaugeEvent does not propagate out of autoTuneTick", () => {
+    const state = makeState();
+    const seams = makeSeams({
+      appendGaugeEvent: () => { throw new Error("io error"); },
+    });
+    expect(() => autoTuneTick(state, seams)).not.toThrow();
+  });
 });
 
 // --- startAutoTuner / stopAutoTuner lifecycle --------------------------------
@@ -177,7 +323,7 @@ describe("autoTuneTick", () => {
 describe("startAutoTuner / stopAutoTuner", () => {
   test("startAutoTuner calls setIntervalFn once with the configured interval and returns a stop handle", () => {
     const intervals = [];
-    const setIntervalFn = (fn, ms) => { intervals.push(ms); return "timer-handle"; };
+    const setIntervalFn = (_fn, ms) => { intervals.push(ms); return "timer-handle"; };
     const clearIntervalFn = () => {};
     const stop = startAutoTuner({
       configPath: null,
@@ -195,7 +341,7 @@ describe("startAutoTuner / stopAutoTuner", () => {
 
   test("stopAutoTuner calls clearIntervalFn with the stored handle", () => {
     const cleared = [];
-    const setIntervalFn = (fn, ms) => "my-timer";
+    const setIntervalFn = (_fn, _ms) => "my-timer";
     const clearIntervalFn = (h) => cleared.push(h);
     startAutoTuner({
       configPath: null,

--- a/plugins/dev/scripts/execution-core/autotune.mjs
+++ b/plugins/dev/scripts/execution-core/autotune.mjs
@@ -18,11 +18,13 @@ import {
   readExecutionCoreConcurrency,
   readExecutionCoreConcurrencyLayer2,
   mergeExecutionCoreConcurrency,
+  resolveTargetSetpoint,
 } from "./scheduler.mjs";
 import { countBackgroundAgents } from "./claude-agents.mjs";
 import {
   defaultAppendParallelismSampledEvent,
   defaultAppendParallelismAdjustedEvent,
+  defaultAppendAutotuneGaugeEvent,
 } from "./recovery.mjs";
 import {
   AUTOTUNE_SAMPLE_INTERVAL_MS,
@@ -103,6 +105,12 @@ export function memGuard(memFreePct, { criticalPct, warnPct }) {
 
 // decideMaxParallel — apply the decision matrix and return {next, reason}.
 // Every result is clamped to [minParallel, maxParallelCeiling].
+// CTL-770: hysteresis band around the setpoint. With 0 the at-setpoint hold
+// fires only on exact equality; the converge branch (current < setpoint) and
+// shed branches still bound oscillation. Kept a named constant so the deadband
+// is one obvious knob.
+const SETPOINT_DEADBAND = 0;
+
 export function decideMaxParallel({
   window,
   concurrency,
@@ -111,11 +119,15 @@ export function decideMaxParallel({
   criticalPct,
   warnPct,
   layer1Max = null,   // CTL-750: Layer-1 committed maxParallel for fast recovery target
+  setpoint = null,    // CTL-770: core-bounded seek-to target (host-over-repo); null → convergence no-ops
 }) {
   const { maxParallel: current, minParallel, maxParallelCeiling } = concurrency;
   const clamp = (v) => clampToBounds(v, { minParallel, maxParallelCeiling });
 
   if (window.length === 0) {
+    // CTL-770: truly-empty window has no sample to judge mem/load — keep the
+    // conservative insufficient-samples hold (one tick of delay before the
+    // cold-start seed can fire on the first tick with a sample).
     return { next: clamp(current), reason: "insufficient-samples" };
   }
 
@@ -128,6 +140,13 @@ export function decideMaxParallel({
   }
 
   if (window.length < minSamples) {
+    // CTL-770 cold-start seed: a short window plus a mem-ok sample and a
+    // setpoint above the current floor → jump straight to the (core-bounded)
+    // target instead of idling at the persisted floor. mem-critical already
+    // won above; we only seed when mem is not critical (ok or warn).
+    if (setpoint !== null && current < setpoint) {
+      return { next: clamp(setpoint), reason: "cold-start-seed" };
+    }
     return { next: clamp(current), reason: "insufficient-samples" };
   }
 
@@ -137,6 +156,7 @@ export function decideMaxParallel({
     loadSafeFactor,
   });
 
+  // trend-up shed and mem-critical (above) always win over the setpoint logic.
   if (trend === "up") {
     return { next: clamp(Math.max(minParallel, Math.floor(current * 0.75))), reason: "trend-up" };
   }
@@ -156,6 +176,28 @@ export function decideMaxParallel({
 
   if (trend === "flat-high") {
     return { next: clamp(current), reason: "flat-high" };
+  }
+
+  // CTL-770 idle/headroom convergence — generalizes CTL-750's recovery (which
+  // only fired for trend==="down") to the flat-idle trend==="none" case. When
+  // there is real headroom (mem ok + load below the ~75% safe line) and the
+  // current value is below the setpoint, ramp toward the (already core-bounded)
+  // target so a stuck-at-floor host converges in a bounded number of ticks.
+  if (setpoint !== null && mem === "ok") {
+    const threshold = latest.coreCount * loadSafeFactor;
+    const loadSafe = latest.load1 < threshold;
+    if (loadSafe) {
+      // Hold within the deadband first so a value already at/near the setpoint
+      // does not ping-pong (BEFORE the converge-up branch).
+      if (Math.abs(current - setpoint) <= SETPOINT_DEADBAND) {
+        return { next: clamp(current), reason: "at-setpoint" };
+      }
+      if (current < setpoint - SETPOINT_DEADBAND) {
+        // Direct jump (mirrors CTL-750's recovery-to-layer1 semantics); clamp
+        // guarantees no overshoot past the ceiling or the setpoint.
+        return { next: clamp(Math.min(setpoint, maxParallelCeiling)), reason: "converge-to-setpoint" };
+      }
+    }
   }
 
   return { next: clamp(current), reason: "hold" };
@@ -215,9 +257,11 @@ export function autoTuneTick(state, seams) {
     cpus,
     readConcurrency,
     readLayer1Concurrency,  // CTL-750: optional seam for Layer-1 committed maxParallel
+    readLayer2Concurrency,  // CTL-770: optional seam for Layer-2 host targetParallel
     writeLayer2,
     appendSampledEvent,
     appendAdjustedEvent,
+    appendGaugeEvent,       // CTL-771: per-tick setpoint gauge emitter
   } = seams;
 
   try {
@@ -239,6 +283,29 @@ export function autoTuneTick(state, seams) {
       ? layer1.maxParallel
       : null;
 
+    // CTL-770: resolve the seek-to setpoint with host-over-repo layering, then
+    // core-bound it. Fail-safe: a missing/throwing Layer-2 seam → setpoint
+    // resolves from Layer-1 maxParallel; neither set → resolveTargetSetpoint
+    // returns undefined → setpoint=null → convergence/seed branches no-op.
+    let layer2 = {};
+    try {
+      layer2 = readLayer2Concurrency?.() ?? {};
+    } catch {
+      layer2 = {};
+    }
+    const rawTarget = resolveTargetSetpoint(layer1 ?? {}, layer2 ?? {});
+    const coreCount = sample.coreCount;
+    const setpoint =
+      rawTarget == null
+        ? null
+        : clampToBounds(
+            Math.min(rawTarget, Math.max(concurrency.minParallel ?? 1, coreCount - 2)),
+            {
+              minParallel: concurrency.minParallel ?? 1,
+              maxParallelCeiling: concurrency.maxParallelCeiling ?? rawTarget,
+            },
+          );
+
     try {
       appendSampledEvent({
         label: "execution-core",
@@ -259,7 +326,26 @@ export function autoTuneTick(state, seams) {
       criticalPct: state.criticalPct,
       warnPct: state.warnPct,
       layer1Max,  // CTL-750
+      setpoint,   // CTL-770
     });
+
+    // CTL-771: emit the setpoint gauge EVERY tick (unconditional, unlike the
+    // change-gated parallelism-adjusted event) so the OTel dashboard renders
+    // effective/target/load/mem continuously. Best-effort; mirrors the
+    // appendSampledEvent try/catch above. running_workers reuses bgCount — no
+    // extra `claude agents` shell-out.
+    try {
+      appendGaugeEvent?.({
+        label: "execution-core",
+        maxParallelEffective: current,
+        maxParallelTarget: setpoint,
+        runningWorkers: bgCount,
+        load1: sample.load1,
+        loadPerCore: coreCount ? sample.load1 / coreCount : sample.load1,
+        memFreePct: sample.memFreePct,
+        reason,
+      });
+    } catch {}
 
     if (next !== current) {
       try {
@@ -298,6 +384,7 @@ export function startAutoTuner({
   cpus = osCpus,
   appendSampledEvent = defaultAppendParallelismSampledEvent,
   appendAdjustedEvent = defaultAppendParallelismAdjustedEvent,
+  appendGaugeEvent = defaultAppendAutotuneGaugeEvent,  // CTL-771
 } = {}) {
   if (!enabled) return () => {};
 
@@ -323,9 +410,13 @@ export function startAutoTuner({
       ),
     // CTL-750: Layer-1 only (no Layer-2 merge) — the committed operator target.
     readLayer1Concurrency: () => readExecutionCoreConcurrency(configPath),
+    // CTL-770: Layer-2 host file — carries the NEW targetParallel key (the
+    // autotuner's seek-to setpoint), separate from maxParallel.
+    readLayer2Concurrency: () => readExecutionCoreConcurrencyLayer2(layer2Path),
     writeLayer2: (next) => writeLayer2MaxParallel(layer2Path, next),
     appendSampledEvent,
     appendAdjustedEvent,
+    appendGaugeEvent,  // CTL-771
   };
 
   _timer = setIntervalFn(() => autoTuneTick(_state, seams), sampleIntervalMs);

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -724,6 +724,46 @@ export function defaultAppendParallelismAdjustedEvent({
   );
 }
 
+// CTL-770/CTL-771: auto-tuner setpoint gauge event —
+// phase.scheduler.autotune-gauge.<label>. Emitted UNCONDITIONALLY once per tick
+// (unlike parallelism-adjusted, which is write-on-change) so the OTel dashboard
+// renders the effective/target/load/mem gauges every sample interval. Mirrors
+// defaultAppendParallelismSampledEvent's transport: a CanonicalEvent envelope
+// appended best-effort to the unified event log, which otel-forward tails and
+// translates to OTLP. The metric VALUES live as flat scalars inside body.payload
+// (via the payloadExtras seam), exactly as the parallelism-sampled precedent
+// does. Best-effort — never throws (appendEnvelopeBestEffort).
+export function defaultAppendAutotuneGaugeEvent({
+  label = "execution-core",
+  maxParallelEffective,
+  maxParallelTarget,
+  runningWorkers,
+  load1,
+  loadPerCore,
+  memFreePct,
+  reason,
+}) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase: "scheduler",
+      ticket: label,
+      orchId: label,
+      action: "autotune-gauge",
+      reason,
+      payloadExtras: {
+        max_parallel_effective: maxParallelEffective,
+        max_parallel_target: maxParallelTarget,
+        running_workers: runningWorkers,
+        load1,
+        load_per_core: loadPerCore,
+        mem_free_pct: memFreePct,
+        decision_reason: reason,
+      },
+    }),
+    "autotune-gauge",
+  );
+}
+
 // CTL-587 default seams — all overridable for tests, all best-effort for prod.
 
 // defaultReviveDispatch — reset the signal to status: "stalled" first (to bypass

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -26,6 +26,7 @@ import {
   defaultAppendYieldFileSkipEvent,
   defaultAppendParallelismSampledEvent,
   defaultAppendParallelismAdjustedEvent,
+  defaultAppendAutotuneGaugeEvent,
   defaultAppendPreemptedEvent,
   defaultAppendResumedAfterPreemptionEvent,
   readBootEpoch,
@@ -2508,6 +2509,34 @@ describe("dispatch lifecycle event envelopes (CTL-660)", () => {
         worktree_path: "/x",
       }),
     ).toBe(false);
+  });
+
+  // CTL-771: autotune-gauge envelope round-trip. The metric values live as flat
+  // scalars in body.payload so otel-forward processLine keeps the line (it has
+  // truthy .attributes) and toAttrArray maps the numbers as the OTLP precedent.
+  test("defaultAppendAutotuneGaugeEvent writes a gauge envelope", () => {
+    const ok = defaultAppendAutotuneGaugeEvent({
+      label: "execution-core",
+      maxParallelEffective: 4,
+      maxParallelTarget: 6,
+      runningWorkers: 3,
+      load1: 2.4,
+      loadPerCore: 0.3,
+      memFreePct: 42.5,
+      reason: "converge-to-setpoint",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["event.name"]).toBe("phase.scheduler.autotune-gauge.execution-core");
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(env.body.payload.status).toBe("autotune-gauge");
+    expect(env.body.payload.max_parallel_effective).toBe(4);
+    expect(env.body.payload.max_parallel_target).toBe(6);
+    expect(env.body.payload.running_workers).toBe(3);
+    expect(env.body.payload.load1).toBe(2.4);
+    expect(env.body.payload.load_per_core).toBe(0.3);
+    expect(env.body.payload.mem_free_pct).toBe(42.5);
+    expect(env.body.payload.decision_reason).toBe("converge-to-setpoint");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -478,6 +478,22 @@ export function mergeExecutionCoreConcurrency(layer1 = {}, layer2 = {}) {
   return validatePerProjectBudgets(merged);
 }
 
+// resolveTargetSetpoint — CTL-770: resolve the autotuner's seek-to TARGET with
+// host-over-repo layering. The HOST Layer-2 file may carry a NEW key
+// `catalyst.orchestration.executionCore.targetParallel` (distinct from
+// `maxParallel`, which the autotuner clobbers every tick as its live runtime
+// mirror — reusing it for the target would be overwritten). When the host key is
+// a positive integer it wins; otherwise fall back to Layer-1's committed
+// `maxParallel`. Returns `undefined` when neither is set → the caller's
+// convergence branches no-op (backward-compatible). Positive-int guard mirrors
+// mergeExecutionCoreConcurrency (:463-465) so a malformed host value never zeroes
+// the setpoint. The caller is responsible for core-bounding the result.
+export function resolveTargetSetpoint(layer1 = {}, layer2 = {}) {
+  const t = layer2?.targetParallel;
+  if (Number.isInteger(t) && t > 0) return t;
+  return layer1?.maxParallel;
+}
+
 // validatePerProjectBudgets — clamps over-subscribed reserves so
 // sum(reserve) ≤ maxParallel, warns once per distinct config (CTL-706).
 // Never throws; returns input unchanged when perProject is absent/empty.

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -23,6 +23,7 @@ import {
   readExecutionCoreConcurrency,
   readExecutionCoreConcurrencyLayer2,
   mergeExecutionCoreConcurrency,
+  resolveTargetSetpoint,
   DEFAULT_MAX_PARALLEL,
   computeFreeSlots,
   predecessorPhaseOf,
@@ -384,6 +385,29 @@ describe("mergeExecutionCoreConcurrency (CTL-678)", () => {
       maxParallelCeiling: 10,
       eligibleQuery: { status: "Ready" },
     });
+  });
+});
+
+describe("resolveTargetSetpoint (CTL-770)", () => {
+  test("host targetParallel present (positive int) → returns it", () => {
+    expect(resolveTargetSetpoint({ maxParallel: 4 }, { targetParallel: 6 })).toBe(6);
+  });
+  test("host absent → falls back to repo maxParallel", () => {
+    expect(resolveTargetSetpoint({ maxParallel: 4 }, {})).toBe(4);
+    expect(resolveTargetSetpoint({ maxParallel: 4 })).toBe(4);
+  });
+  test("both absent → undefined (caller no-ops convergence)", () => {
+    expect(resolveTargetSetpoint({}, {})).toBeUndefined();
+    expect(resolveTargetSetpoint()).toBeUndefined();
+  });
+  test("non-positive / non-integer host targetParallel falls back to repo maxParallel", () => {
+    expect(resolveTargetSetpoint({ maxParallel: 4 }, { targetParallel: 0 })).toBe(4);
+    expect(resolveTargetSetpoint({ maxParallel: 4 }, { targetParallel: -1 })).toBe(4);
+    expect(resolveTargetSetpoint({ maxParallel: 4 }, { targetParallel: 2.5 })).toBe(4);
+    expect(resolveTargetSetpoint({ maxParallel: 4 }, { targetParallel: "6" })).toBe(4);
+  });
+  test("host targetParallel wins even when repo maxParallel also set", () => {
+    expect(resolveTargetSetpoint({ maxParallel: 4 }, { targetParallel: 8 })).toBe(8);
   });
 });
 


### PR DESCRIPTION
Delivers **CTL-770** (autotuner stuck at maxParallel=1) + **CTL-771** (autotune OTel gauges) via a dynamic Workflow (design → implement → independent verify → 3-lens adversarial review, 3/3 pass, 9/9 checks).

## CTL-770 — converge to a host-configurable setpoint

After CTL-769 fixed the reaper leak that *drove* maxParallel down, the autotuner stayed pinned at 1 on an idle box. `decideMaxParallel` only ramped up inside the `trend === "down"` branch, but `detectTrend` returns `"down"` only for strictly decreasing load — a flat-idle host yields `"none"` → `hold` → no path back up.

- **Setpoint resolves host-over-repo:** `host.targetParallel ?? repo.maxParallel`, core-bounded by `min(target, max(minParallel, coreCount-2))`.
- **Config layering (the important bit):** the repo `.catalyst/config.json` keeps a conservative committed default (`maxParallel=4`, **unchanged** — host-agnostic). The per-host override is a **new key `targetParallel`** in the uncommitted `~/.config/catalyst/config-{projectKey}.json` — deliberately separate from the autotuner's live `maxParallel` mirror so it isn't clobbered each tick. **No host-specific number is committed in this PR.**
- **Idle/headroom convergence:** mem-ok + load safe + `current < setpoint` → ramp toward the setpoint regardless of strict trend (generalizes CTL-750's recovery to the `trend "none"` case).
- **Cold-start seeding** to the setpoint instead of the persisted floor.
- **Deadband hold** before converge-up; converge is `clamp(min(setpoint, ceiling))` — **no overshoot**.
- Preserved: mem-critical clamp, trend-up shed, flat-high hold, CTL-750 recovery. Fail-safe: missing/throwing setpoint seam → `null` → no-op (legacy behavior).

## CTL-771 — autotune OTel gauges

Emits per-tick `catalyst_execution_core_*` signals (effective+target maxParallel, running_workers, load1/load_per_core, mem_free_pct, decision_reason) via the **event-log envelope transport** otel-forward actually ships (`appendEnvelopeBestEffort` → tail EVENTS_DIR → OTLP `/v1/logs`) — the same path the existing parallelism-sampled event uses. `running_workers` reuses the already-computed `bgCount` (no new `claude agents` shell-out). Silent no-op when the collector is down. Dashboard panel tracked in **OTL-4**.

## Test plan
- Changed-file suites (`autotune-decision`, `autotune-lifecycle`, `recovery`, `scheduler`): **589 pass / 0 fail**.
- New tests pin: idle convergence (`trend "none"`), cold-start seed, deadband hold, host-over-repo resolution both ways, gauge emission, and no-regression shedding.
- `.catalyst/config.json` confirmed untouched; repo default stays 4.
- The one verify-run failure (`startDaemon > reconciles when the registry changes`) is the known pre-existing fs.watch-debounce flake — green 61/0 ×3 in isolation, not in the diff path.

Slot accounting untouched (counting leaked processes is the intended fail-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)