### PR TITLE
fix(dev): CTL-770 reach idle convergence — autotuner no longer bails at bgCount===0

### DIFF
--- a/plugins/dev/scripts/execution-core/autotune-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/autotune-lifecycle.test.mjs
@@ -38,19 +38,53 @@ describe("autoTuneTick", () => {
     };
   }
 
-  test("when liveBackgroundCount() === 0 → no sampled event, no write, window reset", () => {
-    const state = makeState({ window: [{ load1: 1, load5: 2, load15: 3, memFreePct: 50, coreCount: 4 }] });
+  // CTL-770 fix-up: idle (bgCount===0) no longer bails. The trend window is
+  // reset (no workers ⇒ no meaningful trend) but the tick falls through to
+  // sample → gauge → setpoint seed/hold. With NO setpoint configured it still
+  // makes no write (insufficient-samples hold), but it DOES sample + can emit a
+  // gauge — observability no longer goes dark at idle.
+  test("when liveBackgroundCount() === 0 with no setpoint → samples + gauge but no write (window holds one fresh sample)", () => {
+    const state = makeState({ window: [{ load1: 9, load5: 9, load15: 9, memFreePct: 50, coreCount: 4 }] });
     const sampledCalls = [];
     const writeCalls = [];
+    const gaugeCalls = [];
     const seams = makeSeams({
       liveBackgroundCount: () => 0,
       appendSampledEvent: (args) => { sampledCalls.push(args); return true; },
       writeLayer2: (v) => { writeCalls.push(v); return true; },
+      appendGaugeEvent: (args) => { gaugeCalls.push(args); return true; },
     });
     autoTuneTick(state, seams);
-    expect(sampledCalls).toHaveLength(0);
-    expect(writeCalls).toHaveLength(0);
-    expect(state.window).toHaveLength(0); // reset
+    expect(sampledCalls).toHaveLength(1);        // samples even at idle now
+    expect(gaugeCalls).toHaveLength(1);          // gauge emits at idle now
+    expect(gaugeCalls[0].runningWorkers).toBe(0);
+    expect(writeCalls).toHaveLength(0);          // no setpoint → no change
+    expect(state.window).toHaveLength(1);        // reset, then one fresh sample
+  });
+
+  // CTL-770 fix-up regression pin: idle + a host setpoint above the current
+  // floor MUST seed to the setpoint. With the pre-fix early `return` this wrote
+  // nothing and the autotuner stayed stuck at the floor at idle (the live bug).
+  test("when liveBackgroundCount() === 0 AND setpoint > current → seeds to setpoint + emits gauge", () => {
+    const state = makeState({ window: [] });
+    const writeCalls = [];
+    const gaugeCalls = [];
+    const seams = makeSeams({
+      liveBackgroundCount: () => 0,
+      loadavg: () => [1, 1, 1],                  // safe/idle load
+      freemem: () => 8e9,
+      totalmem: () => 10e9,                       // 80% free → mem ok
+      cpus: () => Array(8),                       // coreCount 8 → core-bound min(6, 6) = 6
+      readConcurrency: () => ({ maxParallel: 1, minParallel: 1, maxParallelCeiling: 40 }),
+      readLayer2Concurrency: () => ({ targetParallel: 6 }), // host override setpoint
+      writeLayer2: (v) => { writeCalls.push(v); return true; },
+      appendGaugeEvent: (args) => { gaugeCalls.push(args); return true; },
+    });
+    autoTuneTick(state, seams);
+    expect(writeCalls).toEqual([6]);             // seeded to the setpoint
+    expect(gaugeCalls).toHaveLength(1);
+    expect(gaugeCalls[0].maxParallelTarget).toBe(6);
+    expect(gaugeCalls[0].runningWorkers).toBe(0);
   });
 
   test("when active → exactly one appendSampledEvent with correct fields", () => {

--- a/plugins/dev/scripts/execution-core/autotune.mjs
+++ b/plugins/dev/scripts/execution-core/autotune.mjs
@@ -267,8 +267,16 @@ export function autoTuneTick(state, seams) {
   try {
     const bgCount = liveBackgroundCount();
     if (bgCount === 0) {
+      // CTL-770 fix-up: idle (zero live workers) is exactly when capacity should
+      // sit AT the setpoint so the scheduler can dispatch a full wave the moment
+      // work arrives. The original `return` here left the autotuner inert at
+      // idle — effective maxParallel stayed pinned at whatever floor it was last
+      // shed to (the stuck-at-1 observed live) and the CTL-771 gauges went dark.
+      // Reset the trend window (no workers ⇒ no meaningful load trend) but fall
+      // through so the sample → gauge → cold-start-seed/hold-at-setpoint path
+      // still runs (decideMaxParallel's <minSamples seed handles the fresh
+      // single-sample window).
       state.window = [];
-      return;
     }
 
     const sample = sampleSystem({ loadavg, freemem, totalmem, cpus });


### PR DESCRIPTION
Follow-up to **CTL-770** (#1307). The setpoint convergence + CTL-771 gauges were **unreachable at idle**: `autoTuneTick` returned early when `liveBackgroundCount() === 0` (`state.window = []; return;`), so on an idle host — the exact state where the autotuner should pre-seed capacity to the setpoint — it never sampled, never called `decideMaxParallel` (where cold-start-seed / converge-to-setpoint live), and never emitted a gauge.

Discovered live: after #1307 merged + hotpatch + restart, effective maxParallel stayed at 1 with **zero** `autotune-gauge` events. Root cause was this early return (the merged unit tests bypassed it — `decideMaxParallel` is tested directly and the lifecycle tests stubbed a non-zero worker count).

## Fix
At `bgCount === 0`, still reset the trend window (no workers ⇒ no meaningful trend) but **fall through** to sample → gauge → setpoint. `decideMaxParallel`'s `<minSamples` cold-start-seed handles the fresh single-sample window: with a setpoint above current it seeds to the (core-bounded) setpoint; with no setpoint it holds. Capacity is just a ceiling — at idle nothing dispatches until eligible work exists, so seeding is safe.

## Tests
- Rewrote the `bgCount===0` lifecycle test to the new behavior (samples + emits gauge, no write without a setpoint, window holds one fresh sample).
- Added a regression pin: idle + host setpoint above current → `writeLayer2(6)` + gauge — **goes red if the early return is restored** (verified).
- 72 pass / 0 fail.

Note: separately confirmed the live Layer-2 file the daemon reads is `~/.config/catalyst/config.json` (CTL-678 machine-canonical), where the per-host `targetParallel` override belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)