### PR TITLE
fix(dev): CTL-766 persist real tailer offset in otel-forward checkpoint

### DIFF
--- a/plugins/dev/scripts/otel-forward/index.test.ts
+++ b/plugins/dev/scripts/otel-forward/index.test.ts
@@ -1,4 +1,32 @@
 import { describe, test, expect } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createTailer } from "./lib/tail.ts";
+import { readCheckpoint, writeCheckpoint } from "./lib/checkpoint.ts";
+
+describe("checkpoint persists real read offset (CTL-766)", () => {
+  test("a checkpoint written from tailer.currentOffset() resumes past the backlog", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ckoff-"));
+    const file = join(dir, "2026-05.jsonl");
+    const ckPath = join(dir, "otel-forward.checkpoint.json");
+    const line = JSON.stringify({ ts: "2026-05-08T00:00:01Z", attributes: { "event.name": "t" } }) + "\n";
+    writeFileSync(file, line);
+
+    const ac = new AbortController();
+    const tailer = createTailer({ filePath: file, offset: 0, onLine: () => {}, signal: ac.signal, pollMs: 10 });
+    await tailer.drain();
+    ac.abort();
+
+    // Mirror the production ckTimer write: persist the REAL position, not 0.
+    writeCheckpoint(ckPath, { path: tailer.currentPath(), offset: tailer.currentOffset() });
+
+    const ck = readCheckpoint(ckPath);
+    expect(ck?.offset).toBe(Buffer.byteLength(line, "utf8"));
+    expect(ck?.offset).not.toBe(0);
+    rmSync(dir, { recursive: true });
+  });
+});
 
 describe("daemon integration", () => {
   test("processLine skips legacy lines and counts canonical", async () => {

--- a/plugins/dev/scripts/otel-forward/index.ts
+++ b/plugins/dev/scripts/otel-forward/index.ts
@@ -77,7 +77,7 @@ if (import.meta.main) {
   const flushTimer = setInterval(flush, FLUSH_MS);
 
   const ckTimer = setInterval(() => {
-    writeCheckpoint(CHECKPOINT_PATH, { path: tailer.currentPath(), offset: 0 });
+    writeCheckpoint(CHECKPOINT_PATH, { path: tailer.currentPath(), offset: tailer.currentOffset() });
   }, 10_000);
 
   log.info(

--- a/plugins/dev/scripts/otel-forward/lib/tail.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/tail.test.ts
@@ -23,6 +23,42 @@ describe("createTailer", () => {
     rmSync(dir, { recursive: true });
   });
 
+  test("currentOffset advances to file size after draining appended lines", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "tail-"));
+    const file = join(dir, "2026-05.jsonl");
+    const line = JSON.stringify({ ts: "2026-05-08T00:00:01Z", attributes: { "event.name": "test" } }) + "\n";
+    writeFileSync(file, line);
+
+    const ac = new AbortController();
+    const tailer = createTailer({ filePath: file, offset: 0, onLine: () => {}, signal: ac.signal, pollMs: 10 });
+    expect(tailer.currentOffset()).toBe(0);
+    await tailer.drain();
+    ac.abort();
+
+    expect(tailer.currentOffset()).toBe(Buffer.byteLength(line, "utf8"));
+    rmSync(dir, { recursive: true });
+  });
+
+  test("resumes from a non-zero starting offset and only reads bytes after it", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "tail-"));
+    const file = join(dir, "2026-05.jsonl");
+    const first = JSON.stringify({ ts: "2026-05-08T00:00:00Z", attributes: { "event.name": "already-read" } }) + "\n";
+    const second = JSON.stringify({ ts: "2026-05-08T00:00:01Z", attributes: { "event.name": "new" } }) + "\n";
+    writeFileSync(file, first + second);
+
+    const emitted: string[] = [];
+    const ac = new AbortController();
+    const startOffset = Buffer.byteLength(first, "utf8");
+    const tailer = createTailer({ filePath: file, offset: startOffset, onLine: (l) => emitted.push(l), signal: ac.signal, pollMs: 10 });
+    await tailer.drain();
+    ac.abort();
+
+    expect(emitted.length).toBe(1);
+    expect(JSON.parse(emitted[0]).attributes["event.name"]).toBe("new");
+    expect(tailer.currentOffset()).toBe(Buffer.byteLength(first + second, "utf8"));
+    rmSync(dir, { recursive: true });
+  });
+
   test("handles month rollover by switching file path", async () => {
     const dir = mkdtempSync(join(tmpdir(), "tail-"));
     let callCount = 0;

--- a/plugins/dev/scripts/otel-forward/lib/tail.ts
+++ b/plugins/dev/scripts/otel-forward/lib/tail.ts
@@ -21,6 +21,7 @@ export interface Tailer {
   drain: () => Promise<void>;
   run: () => Promise<void>;
   currentPath: () => string;
+  currentOffset: () => number;
 }
 
 export function createTailer(opts: TailerOpts): Tailer {
@@ -68,5 +69,5 @@ export function createTailer(opts: TailerOpts): Tailer {
     }
   }
 
-  return { drain, run, currentPath: () => currentPath };
+  return { drain, run, currentPath: () => currentPath, currentOffset: () => offset };
 }


### PR DESCRIPTION
## Problem
`otel-forward` (the tailer that ships catalyst canonical events to the OTLP collector) wrote its resume checkpoint with a **hardcoded `offset: 0`** every 10s (`index.ts` ckTimer). So it could never resume — every restart re-read the entire ~34MB/114k-event backlog and flooded the collector. This blocked running the forwarder reliably (needed so `session.context` events with 5h/7d rate-limit attrs reach Loki/Grafana).

## Fix
- `lib/tail.ts`: add `currentOffset(): number` to the `Tailer` interface + return the live (advancing) `offset` from `createTailer`.
- `index.ts`: ckTimer now writes `offset: tailer.currentOffset()` so the checkpoint persists the real read position → restart resumes from there.

## Tests
TDD red→green: 3 new tests (currentOffset advances; checkpoint persists real offset; resume from non-zero offset reads only new bytes). **28 pass / 0 fail**, tsc clean on changed files (4 pre-existing tsc errors are in untouched files).

## Out of scope
Daemonize (auto-start wiring) is deferred to **CTL-696** — `catalyst-stack` is machine-local, not yet vendored in-repo. `catalyst-monitor.sh` already has `forward-start`/`forward-stop`; wiring is a one-liner once CTL-696 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)