### PR TITLE
fix(dev): CTL-772 platform-aware available memory — stop autotuner false-clamping to 1 on macOS

### DIFF
--- a/plugins/dev/scripts/execution-core/autotune-decision.test.mjs
+++ b/plugins/dev/scripts/execution-core/autotune-decision.test.mjs
@@ -5,12 +5,167 @@
 
 import { describe, test, expect } from "bun:test";
 import {
+  availableMemPct,
   sampleSystem,
   pushSample,
   detectTrend,
   memGuard,
   decideMaxParallel,
 } from "./autotune.mjs";
+
+// A realistic darwin vm_stat body — header carries the page size, every data
+// line carries a TRAILING PERIOD (verified live). The label spellings match the
+// macOS output exactly: "Pages free/inactive/speculative/purgeable".
+function makeVmStat({ pageSize = 16384, free = 100, inactive = 200, speculative = 50, purgeable = 150 } = {}) {
+  return [
+    `Mach Virtual Memory Statistics: (page size of ${pageSize} bytes)`,
+    `Pages free:                               ${free}.`,
+    `Pages active:                           1509896.`,
+    `Pages inactive:                         ${inactive}.`,
+    `Pages speculative:                         ${speculative}.`,
+    `Pages throttled:                              0.`,
+    `Pages wired down:                        431514.`,
+    `Pages purgeable:                          ${purgeable}.`,
+  ].join("\n");
+}
+
+// --- availableMemPct (CTL-772) ----------------------------------------------
+
+describe("availableMemPct", () => {
+  test("darwin: sums free+inactive+speculative+purgeable pages × pageSize / total", () => {
+    const total = 10e9;
+    const pct = availableMemPct({
+      freemem: () => 1, // must be IGNORED on the darwin parse path
+      totalmem: () => total,
+      platform: "darwin",
+      execSync: () => makeVmStat({ pageSize: 16384, free: 100, inactive: 200, speculative: 50, purgeable: 150 }),
+    });
+    const expected = Math.round(((100 + 200 + 50 + 150) * 16384 / total) * 1000) / 10;
+    expect(pct).toBe(expected);
+  });
+
+  test("non-darwin: returns freemem/totalmem pct identical to the old formula", () => {
+    const pct = availableMemPct({
+      freemem: () => 2e9,
+      totalmem: () => 10e9,
+      platform: "linux",
+      execSync: () => { throw new Error("should not be called on linux"); },
+    });
+    expect(pct).toBe(20);
+  });
+
+  test("darwin + execSync throws → falls back to freemem pct, no throw", () => {
+    let pct;
+    expect(() => {
+      pct = availableMemPct({
+        freemem: () => 2e9,
+        totalmem: () => 10e9,
+        platform: "darwin",
+        execSync: () => { throw new Error("spawn EAGAIN"); },
+      });
+    }).not.toThrow();
+    expect(pct).toBe(20);
+  });
+
+  test("darwin + unparseable output (no page size / no Pages lines) → fallback to freemem pct, no throw", () => {
+    let pct;
+    expect(() => {
+      pct = availableMemPct({
+        freemem: () => 3e9,
+        totalmem: () => 10e9,
+        platform: "darwin",
+        execSync: () => "garbage output with no recognizable fields",
+      });
+    }).not.toThrow();
+    expect(pct).toBe(30);
+  });
+
+  test("darwin: tolerates trailing periods (parses the digits, not the period)", () => {
+    const total = 16384 * 1000; // makes the math clean: 400 pages → 40%
+    const pct = availableMemPct({
+      freemem: () => 1,
+      totalmem: () => total,
+      platform: "darwin",
+      execSync: () => makeVmStat({ pageSize: 16384, free: 100, inactive: 100, speculative: 100, purgeable: 100 }),
+    });
+    expect(pct).toBe(40);
+  });
+
+  test("darwin: missing Pages line counts as 0 (defensive, not an error)", () => {
+    const out = [
+      "Mach Virtual Memory Statistics: (page size of 16384 bytes)",
+      "Pages free:                               100.",
+      // no inactive/speculative/purgeable lines
+    ].join("\n");
+    const total = 16384 * 1000;
+    const pct = availableMemPct({
+      freemem: () => 999,
+      totalmem: () => total,
+      platform: "darwin",
+      execSync: () => out,
+    });
+    // only free=100 counts → 100/1000 = 10%
+    expect(pct).toBe(10);
+  });
+});
+
+// --- sampleSystem darwin integration (CTL-772) ------------------------------
+
+describe("sampleSystem (darwin vm_stat seam)", () => {
+  test("platform:darwin + stubbed execSync → memFreePct from availableMemPct, load/core from their seams", () => {
+    const total = 10e9;
+    const s = sampleSystem({
+      loadavg: () => [2.5, 3.0, 3.5],
+      freemem: () => 1, // ignored on darwin parse path
+      totalmem: () => total,
+      cpus: () => Array(12),
+      platform: "darwin",
+      execSync: () => makeVmStat({ pageSize: 16384, free: 100, inactive: 200, speculative: 50, purgeable: 150 }),
+    });
+    const expectedMem = Math.round(((100 + 200 + 50 + 150) * 16384 / total) * 1000) / 10;
+    expect(s.memFreePct).toBe(expectedMem);
+    expect(s.load1).toBe(2.5);
+    expect(s.load5).toBe(3.0);
+    expect(s.load15).toBe(3.5);
+    expect(s.coreCount).toBe(12);
+  });
+
+  test("keep-green default: NO platform/execSync seam + injected freemem/totalmem → freemem-derived memFreePct (holds even on a darwin host)", () => {
+    const s = sampleSystem({
+      loadavg: () => [0, 0, 0],
+      freemem: () => 2e9,
+      totalmem: () => 10e9,
+      cpus: () => Array(4),
+    });
+    expect(s.memFreePct).toBe(20);
+  });
+
+  test("mem-critical still fires under genuine darwin pressure (tiny available pages)", () => {
+    const total = 10e9;
+    // tiny page counts → availBytes ≪ total → availableMemPct < criticalPct (5)
+    const s = sampleSystem({
+      loadavg: () => [1, 1, 1],
+      freemem: () => total, // freemem would say "100% free" — proves the darwin path overrides it
+      totalmem: () => total,
+      cpus: () => Array(8),
+      platform: "darwin",
+      execSync: () => makeVmStat({ pageSize: 16384, free: 1, inactive: 1, speculative: 1, purgeable: 1 }),
+    });
+    expect(s.memFreePct).toBeLessThan(5);
+
+    const window = [s, s, s];
+    const { next, reason } = decideMaxParallel({
+      window,
+      concurrency: { maxParallel: 10, minParallel: 2, maxParallelCeiling: 20 },
+      minSamples: 3,
+      loadSafeFactor: 4,
+      criticalPct: 5,
+      warnPct: 20,
+    });
+    expect(reason).toBe("mem-critical");
+    expect(next).toBe(2); // minParallel
+  });
+});
 
 // --- sampleSystem -----------------------------------------------------------
 

--- a/plugins/dev/scripts/execution-core/autotune.mjs
+++ b/plugins/dev/scripts/execution-core/autotune.mjs
@@ -11,8 +11,10 @@ import {
   freemem as osFreemem,
   totalmem as osTotalmem,
   cpus as osCpus,
+  platform as osPlatform,
 } from "node:os";
 import { readFileSync, writeFileSync, renameSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { clampToBounds } from "./scheduler.mjs";
 import {
   readExecutionCoreConcurrency,
@@ -39,18 +41,81 @@ import {
 
 // --- Pure decision helpers --------------------------------------------------
 
+// defaultVmStatExec — production seam for the darwin `vm_stat` shell-out. Uses
+// execFileSync (the established child-process primitive in this dir:
+// memory-sampler.mjs / claude-agents.mjs) so there is no shell parsing.
+const defaultVmStatExec = () => execFileSync("vm_stat", [], { encoding: "utf8" });
+
+// availableMemPct — CTL-772: platform-aware "available memory" percentage.
+//
+// The bug: on darwin os.freemem() reports only the truly-free page count and
+// EXCLUDES inactive/speculative/purgeable pages that the kernel reclaims on
+// demand. That made memFreePct read ~0.5% on a host with tens of GB actually
+// available, tripping mem-critical and pinning maxParallel at the floor.
+//
+// Fix: on darwin parse `vm_stat` and sum free + inactive + speculative +
+// purgeable pages × page-size, divided by totalmem(). On any platform other
+// than darwin — or on ANY parse/exec error — fall back to the original
+// freemem()/totalmem() formula (byte-identical to the old sampleSystem code),
+// so a parse failure is strictly no-worse than today and the seam-injected
+// freemem/totalmem still drive the value everywhere except real darwin.
+//
+// Pure + total: never rethrows. All OS access is via the injected seams.
+export function availableMemPct({
+  freemem = osFreemem,
+  totalmem = osTotalmem,
+  platform = "linux",
+  execSync = defaultVmStatExec,
+} = {}) {
+  const fallback = () => Math.round((freemem() / totalmem()) * 1000) / 10;
+
+  if (platform !== "darwin") return fallback();
+
+  try {
+    const out = execSync("vm_stat");
+    const ps = Number(out.match(/page size of (\d+) bytes/)?.[1]);
+    if (!Number.isFinite(ps) || ps <= 0) throw new Error("vm_stat: bad page size");
+
+    // vm_stat values carry a TRAILING PERIOD ("Pages free:   17612."), so the
+    // regex captures the digits then a literal `.`. A missing line → 0
+    // (defensive, not an error).
+    const pages = (label) => {
+      const m = out.match(new RegExp("Pages " + label + ":\\s+(\\d+)\\."));
+      return m ? Number(m[1]) : 0;
+    };
+    const free = pages("free");
+    const inactive = pages("inactive");
+    const speculative = pages("speculative");
+    const purgeable = pages("purgeable");
+
+    const total = totalmem();
+    const availBytes = (free + inactive + speculative + purgeable) * ps;
+    const pct = Math.round((availBytes / total) * 1000) / 10;
+    if (!Number.isFinite(pct)) throw new Error("vm_stat: non-finite pct");
+    return pct;
+  } catch {
+    return fallback();
+  }
+}
+
 // sampleSystem — capture current load + memory snapshot from seam-injected OS
 // functions. Returns {load1, load5, load15, memFreePct, coreCount}.
+//
+// CTL-772: memFreePct now delegates to availableMemPct so darwin reports
+// reclaimable memory. `platform`/`execSync` are seams; platform defaults to
+// "linux" (the freemem path) so callers/tests that inject only freemem/totalmem
+// keep the original behavior even when bun test runs on a darwin host. Only
+// startAutoTuner injects the real process.platform + real vm_stat.
 export function sampleSystem({
   loadavg = osLoadavg,
   freemem = osFreemem,
   totalmem = osTotalmem,
   cpus = osCpus,
+  platform = "linux",
+  execSync = defaultVmStatExec,
 } = {}) {
   const [load1, load5, load15] = loadavg();
-  const free = freemem();
-  const total = totalmem();
-  const memFreePct = Math.round((free / total) * 1000) / 10;
+  const memFreePct = availableMemPct({ freemem, totalmem, platform, execSync });
   const coreCount = cpus().length;
   return { load1, load5, load15, memFreePct, coreCount };
 }
@@ -255,6 +320,12 @@ export function autoTuneTick(state, seams) {
     freemem,
     totalmem,
     cpus,
+    // CTL-772: platform defaults to "linux" at this seam boundary so existing
+    // tests that build seams by hand (injecting only freemem/totalmem) take the
+    // freemem path and stay green even on a darwin CI/dev host. Only
+    // startAutoTuner's real wiring passes process.platform + real vm_stat.
+    platform = "linux",
+    execSync,
     readConcurrency,
     readLayer1Concurrency,  // CTL-750: optional seam for Layer-1 committed maxParallel
     readLayer2Concurrency,  // CTL-770: optional seam for Layer-2 host targetParallel
@@ -279,7 +350,7 @@ export function autoTuneTick(state, seams) {
       state.window = [];
     }
 
-    const sample = sampleSystem({ loadavg, freemem, totalmem, cpus });
+    const sample = sampleSystem({ loadavg, freemem, totalmem, cpus, platform, execSync });
     state.window = pushSample(state.window, sample, state.windowSamples);
 
     const concurrency = readConcurrency();
@@ -390,6 +461,10 @@ export function startAutoTuner({
   freemem = osFreemem,
   totalmem = osTotalmem,
   cpus = osCpus,
+  // CTL-772: the REAL daemon path uses the host platform + real vm_stat so
+  // darwin reports reclaimable (available) memory instead of os.freemem().
+  platform = osPlatform(),
+  execSync = defaultVmStatExec,
   appendSampledEvent = defaultAppendParallelismSampledEvent,
   appendAdjustedEvent = defaultAppendParallelismAdjustedEvent,
   appendGaugeEvent = defaultAppendAutotuneGaugeEvent,  // CTL-771
@@ -411,6 +486,8 @@ export function startAutoTuner({
     freemem,
     totalmem,
     cpus,
+    platform,   // CTL-772: host platform (process.platform via os.platform())
+    execSync,   // CTL-772: real vm_stat shell-out
     readConcurrency: () =>
       mergeExecutionCoreConcurrency(
         readExecutionCoreConcurrency(configPath),


### PR DESCRIPTION
The autotuner clamped `maxParallel` to `minParallel` (1) on **every tick** on macOS, regardless of real load/memory — the dominant driver of the stuck-at-1 chased through CTL-769 (reaper leak), CTL-770 (trend-gate), and #1308 (idle-bail).

## Root cause
`sampleSystem` derived `memFreePct` from `os.freemem()`, which on darwin reports only truly-free pages and **excludes reclaimable inactive/speculative/purgeable pages**. Live on this 68.7 GB host: `memory_pressure` → **75% free**, but `os.freemem()/totalmem()` → **~3%** < 5% `criticalPct` → `memGuard` returns "critical" → clamp to 1. The CTL-771 gauges surfaced it (`reason: mem-critical` at idle).

## Fix
New `availableMemPct({freemem, totalmem, platform, execSync})`:
- **darwin** → parse `vm_stat`, sum `free + inactive + speculative + purgeable` pages × page-size ÷ `totalmem()`.
- **else / any exec or parse error** → fall back to `freemem()/totalmem()` (byte-identical to the old formula). Never throws in the tick path.

Wiring keeps existing freemem/totalmem-injecting tests green **without editing them**: `availableMemPct`/`sampleSystem`/`autoTuneTick` default `platform` to `"linux"` (freemem path) at their seam boundaries, so tests keep the old behavior even on a darwin CI host. Only `startAutoTuner` injects the real `process.platform` + real `vm_stat`, so the live daemon on macOS gets the corrected reading.

## Safety
- `memGuard` thresholds + `decideMaxParallel` unchanged — **mem-critical still fires** under genuinely-low available memory (a test stubs low `vm_stat` pages and asserts the clamp).
- Non-darwin behavior identical.

## Test plan
- `autotune-decision` + `autotune-lifecycle`: **81 pass / 0 fail**.
- New tests pin: darwin stubbed-`vm_stat` → expected %; non-darwin → freemem path; exec-throws/garbage → fallback (no throw); mem-critical-under-pressure.
- Mutation-verified: reverting the darwin branch to always-freemem turns **5 tests red**.

Once merged + hotpatched, the autotuner sees ~75% available on macOS → converges to the `targetParallel` setpoint (CTL-770) instead of clamping to 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)