### PR TITLE
feat(dev): CTL-775 demand-driven autotuner — saturation-gated up, Claude-attributed down

### DIFF
--- a/plugins/dev/scripts/execution-core/autotune-decision.test.mjs
+++ b/plugins/dev/scripts/execution-core/autotune-decision.test.mjs
@@ -11,7 +11,9 @@ import {
   detectTrend,
   memGuard,
   decideMaxParallel,
+  claudeResourceShare,
 } from "./autotune.mjs";
+import { parsePsSnapshotWithCpu } from "./cli/sessions.mjs";
 
 // A realistic darwin vm_stat body — header carries the page size, every data
 // line carries a TRAILING PERIOD (verified live). The label spellings match the
@@ -358,6 +360,101 @@ describe("memGuard", () => {
   });
 });
 
+// --- claudeResourceShare (CTL-775) ------------------------------------------
+
+describe("claudeResourceShare", () => {
+  // A two-worker fleet. Each worker tree: root + one child. Tree RSS ~560MB,
+  // tree pcpu ~120% (over one core, decaying-average semantics).
+  function makeSnapshot() {
+    // 560MB ≈ 573440 KB per tree → split root 400000 / child 173440.
+    return parsePsSnapshotWithCpu([
+      "100 1 80.0 400000", // worker A root
+      "101 100 40.0 173440", // worker A child
+      "200 1 90.0 400000", // worker B root
+      "201 200 30.0 173440", // worker B child
+    ]);
+  }
+  const agents = [
+    { kind: "background", pid: 100, sessionId: "a" },
+    { kind: "background", pid: 200, sessionId: "b" },
+  ];
+  const totalmem = 68.7e9; // ~68.7 GB host
+  const coreCount = 16;
+
+  test("sums two background worker trees into whole-host cpu/mem percent", () => {
+    const { claudeCpuPct, claudeMemPct } = claudeResourceShare({
+      listAgents: () => agents,
+      psSnapshot: makeSnapshot(),
+      totalmem,
+      coreCount,
+    });
+    const rssKbSum = (400000 + 173440) * 2;
+    const cpuSum = 120 + 120;
+    expect(claudeMemPct).toBe(Math.round(((rssKbSum * 1024) / totalmem) * 100 * 10) / 10);
+    expect(claudeCpuPct).toBe(Math.round((cpuSum / (coreCount * 100)) * 100 * 10) / 10);
+  });
+
+  test("filters out non-background agents and pid-less agents", () => {
+    const mixed = [
+      { kind: "background", pid: 100, sessionId: "a" },
+      { kind: "interactive", pid: 200, sessionId: "human" }, // excluded
+      { kind: "background", sessionId: "nopid" }, // excluded (no pid)
+    ];
+    const { claudeCpuPct, claudeMemPct } = claudeResourceShare({
+      listAgents: () => mixed,
+      psSnapshot: makeSnapshot(),
+      totalmem,
+      coreCount,
+    });
+    // Only worker A counted: tree rss 573440 KB, tree cpu 120%.
+    expect(claudeMemPct).toBe(Math.round(((573440 * 1024) / totalmem) * 100 * 10) / 10);
+    expect(claudeCpuPct).toBe(Math.round((120 / (coreCount * 100)) * 100 * 10) / 10);
+  });
+
+  test("no live agents → {0,0} (full headroom)", () => {
+    const r = claudeResourceShare({
+      listAgents: () => [],
+      psSnapshot: makeSnapshot(),
+      totalmem,
+      coreCount,
+    });
+    expect(r).toEqual({ claudeCpuPct: 0, claudeMemPct: 0 });
+  });
+
+  test("totalmem=0 → memPct 0 (no divide-by-zero)", () => {
+    const r = claudeResourceShare({
+      listAgents: () => agents,
+      psSnapshot: makeSnapshot(),
+      totalmem: 0,
+      coreCount,
+    });
+    expect(r.claudeMemPct).toBe(0);
+  });
+
+  test("coreCount=0 → cpuPct 0 (no divide-by-zero)", () => {
+    const r = claudeResourceShare({
+      listAgents: () => agents,
+      psSnapshot: makeSnapshot(),
+      totalmem,
+      coreCount: 0,
+    });
+    expect(r.claudeCpuPct).toBe(0);
+  });
+
+  test("a throwing listAgents → {0,0}, never throws (fail-low)", () => {
+    let r;
+    expect(() => {
+      r = claudeResourceShare({
+        listAgents: () => { throw new Error("claude agents failed"); },
+        psSnapshot: makeSnapshot(),
+        totalmem,
+        coreCount,
+      });
+    }).not.toThrow();
+    expect(r).toEqual({ claudeCpuPct: 0, claudeMemPct: 0 });
+  });
+});
+
 // --- decideMaxParallel ------------------------------------------------------
 
 describe("decideMaxParallel", () => {
@@ -633,6 +730,246 @@ describe("decideMaxParallel", () => {
       const result = decideMaxParallel({ window: w, concurrency: atFloor, setpoint: 6, ...base });
       expect(result.next).toBe(1);
       expect(result.reason).toBe("mem-critical");
+    });
+  });
+
+  // --- CTL-775: Claude-attributable resource control law ---------------------
+
+  describe("Claude-attribution control law (CTL-775)", () => {
+    // Flat-idle window: trend==="none", load well below the safe line.
+    // coreCount=4, loadSafeFactor=2 → threshold=8.
+    const flatIdle = makeWindow([[1.2, 1.2, 1.3], [1.2, 1.3, 1.2], [1.3, 1.2, 1.2]], 50);
+
+    test("law rule 1: SCALE-UP when saturated + our-headroom + mem ok + below ceiling", () => {
+      // current=10, running=10 (no free slots), claude share low → +1.
+      const result = decideMaxParallel({
+        window: flatIdle,
+        concurrency,
+        runningWorkers: 10,
+        claudeCpuPct: 30,
+        claudeMemPct: 20,
+        ...base,
+      });
+      expect(result.next).toBe(11);
+      expect(result.reason).toBe("saturated-scale-up");
+    });
+
+    test("law rule 1: scale-up bounded at the ceiling (current=ceiling → no growth)", () => {
+      const atCeiling = { maxParallel: 20, minParallel: 2, maxParallelCeiling: 20 };
+      const result = decideMaxParallel({
+        window: flatIdle,
+        concurrency: atCeiling,
+        runningWorkers: 20,
+        claudeCpuPct: 30,
+        claudeMemPct: 20,
+        ...base,
+      });
+      expect(result.next).toBe(20); // current<ceiling false → not scale-up; holds
+      expect(result.reason).not.toBe("saturated-scale-up");
+    });
+
+    test("ROOT CAUSE PIN: NOT saturated + full headroom → never +1 above current", () => {
+      // current=10, running=2 (free slots) → must NOT grow. With setpoint absent
+      // it falls through to hold; with setpoint it would drift down — either way
+      // never +1.
+      const result = decideMaxParallel({
+        window: flatIdle,
+        concurrency,
+        runningWorkers: 2,
+        claudeCpuPct: 10,
+        claudeMemPct: 10,
+        ...base,
+      });
+      expect(result.next).toBeLessThanOrEqual(10);
+      expect(result.reason).not.toBe("saturated-scale-up");
+    });
+
+    test("law rule 2: claudeCpuPct >= high-water → claude-resource-shed (×0.75)", () => {
+      const result = decideMaxParallel({
+        window: flatIdle,
+        concurrency,
+        runningWorkers: 10,
+        claudeCpuPct: 80, // >= 75 high-water
+        claudeMemPct: 20,
+        ...base,
+      });
+      expect(result.next).toBe(Math.floor(10 * 0.75)); // 7
+      expect(result.reason).toBe("claude-resource-shed");
+    });
+
+    test("law rule 2: claudeMemPct >= high-water → shed; floored at minParallel", () => {
+      const tight = { maxParallel: 2, minParallel: 2, maxParallelCeiling: 20 };
+      const result = decideMaxParallel({
+        window: flatIdle,
+        concurrency: tight,
+        runningWorkers: 2,
+        claudeCpuPct: 10,
+        claudeMemPct: 90, // mem at limit
+        ...base,
+      });
+      expect(result.next).toBe(2); // floor(2*0.75)=1 → clamped up to minParallel
+      expect(result.reason).toBe("claude-resource-shed");
+    });
+
+    test("law rule 3: host warn (sub-critical) + LOW claude share → host-pressure-not-ours-hold", () => {
+      // mem 10% → warn (critical=5, warn=20). Claude share low → another process.
+      const w = makeWindow([[1.2, 1.2, 1.3], [1.2, 1.3, 1.2], [1.3, 1.2, 1.2]], 10);
+      const result = decideMaxParallel({
+        window: w,
+        concurrency,
+        runningWorkers: 5,
+        claudeCpuPct: 15,
+        claudeMemPct: 12,
+        ...base,
+      });
+      expect(result.next).toBe(10); // HOLD, does not shed
+      expect(result.reason).toBe("host-pressure-not-ours-hold");
+    });
+
+    test("law rule 3 (CPU axis): host load UP-trend + LOW claude share → hold, NOT trend-up shed", () => {
+      // Strictly-increasing host load (trend "up"), mem healthy, but Claude's
+      // attributable share is low → a non-Claude CPU spike. Must HOLD, not shed
+      // our workers to make room for the other process (the gap the CTL-775
+      // review caught: trend-up shed previously fired above attribution).
+      const up = makeWindow([[10, 8, 6], [12, 9, 7], [15, 11, 8]], 50);
+      const result = decideMaxParallel({
+        window: up,
+        concurrency,
+        runningWorkers: 5,
+        claudeCpuPct: 12,
+        claudeMemPct: 10,
+        ...base,
+      });
+      expect(result.next).toBe(10); // HOLD, not floor(10*0.75)
+      expect(result.reason).toBe("host-pressure-not-ours-hold");
+    });
+
+    test("law rule 3 (CPU axis): host UP-trend with attribution UNKNOWN still sheds (back-compat)", () => {
+      const up = makeWindow([[10, 8, 6], [12, 9, 7], [15, 11, 8]], 50);
+      const result = decideMaxParallel({
+        window: up,
+        concurrency,
+        runningWorkers: 5,
+        // no claudeCpuPct/claudeMemPct → attribution unknown → coarse safety shed
+        ...base,
+      });
+      expect(result.next).toBe(Math.floor(10 * 0.75)); // 7
+      expect(result.reason).toBe("trend-up");
+    });
+
+    test("law rule 4: mem-critical still wins even with LOW claude share (OOM safety)", () => {
+      const w = makeWindow([[1, 2, 4]], 2); // 2% < critical
+      const result = decideMaxParallel({
+        window: w,
+        concurrency,
+        runningWorkers: 5,
+        claudeCpuPct: 1,
+        claudeMemPct: 1,
+        ...base,
+      });
+      expect(result.next).toBe(2); // minParallel — attribution does NOT rescue
+      expect(result.reason).toBe("mem-critical");
+    });
+
+    test("law rule 5: DRIFT-DOWN — the live 16-with-2 case → -1/tick, floors at setpoint", () => {
+      let cur = 16;
+      const reasons = [];
+      for (let i = 0; i < 15; i++) {
+        const r = decideMaxParallel({
+          window: flatIdle,
+          concurrency: { maxParallel: cur, minParallel: 1, maxParallelCeiling: 20 },
+          runningWorkers: 2, // not saturated (2 < cur)
+          setpoint: 6,
+          claudeCpuPct: 20,
+          claudeMemPct: 20,
+          ...base,
+        });
+        reasons.push(r.reason);
+        cur = r.next;
+      }
+      // First step: 16 → 15 with drift reason.
+      expect(reasons[0]).toBe("drift-to-setpoint");
+      // Floors at the setpoint, then holds (no undershoot, no thrash).
+      expect(cur).toBe(6);
+      expect(reasons[reasons.length - 1]).toBe("at-setpoint");
+    });
+
+    test("law rule 5: converge-UP still wins below setpoint regardless of saturation (9b > 9c)", () => {
+      const atFloor = { maxParallel: 1, minParallel: 1, maxParallelCeiling: 20 };
+      const result = decideMaxParallel({
+        window: flatIdle,
+        concurrency: atFloor,
+        runningWorkers: 0, // not saturated, but current < setpoint
+        setpoint: 6,
+        claudeCpuPct: 10,
+        claudeMemPct: 10,
+        ...base,
+      });
+      expect(result.next).toBe(6);
+      expect(result.reason).toBe("converge-to-setpoint");
+    });
+
+    test("deadband: current === setpoint holds at-setpoint, no -1 oscillation across two decides", () => {
+      const atTarget = { maxParallel: 6, minParallel: 1, maxParallelCeiling: 20 };
+      const args = {
+        window: flatIdle,
+        concurrency: atTarget,
+        runningWorkers: 2,
+        setpoint: 6,
+        claudeCpuPct: 20,
+        claudeMemPct: 20,
+        ...base,
+      };
+      const r1 = decideMaxParallel(args);
+      const r2 = decideMaxParallel(args);
+      expect(r1.next).toBe(6);
+      expect(r1.reason).toBe("at-setpoint");
+      expect(r2.next).toBe(6);
+      expect(r2.reason).toBe("at-setpoint");
+    });
+
+    test("drift never drops the ceiling below running workers", () => {
+      // current=10, runningWorkers=8, setpoint=6 → drift floors at 8, not 6/9.
+      const result = decideMaxParallel({
+        window: flatIdle,
+        concurrency: { maxParallel: 10, minParallel: 1, maxParallelCeiling: 20 },
+        runningWorkers: 8,
+        setpoint: 6,
+        claudeCpuPct: 20,
+        claudeMemPct: 20,
+        ...base,
+      });
+      expect(result.next).toBe(9); // current-1=9, still >= running 8
+      expect(result.reason).toBe("drift-to-setpoint");
+    });
+
+    test("back-compat: runningWorkers null/omitted ⇒ saturated → legacy trend-down growth still fires", () => {
+      const down = makeWindow([[2, 4, 6], [1, 3, 5], [1, 2, 4]], 50);
+      const result = decideMaxParallel({ window: down, concurrency, ...base }); // no runningWorkers
+      expect(result.next).toBe(11);
+      expect(result.reason).toBe("trend-down");
+    });
+
+    test("back-compat: runningWorkers null ⇒ recovery-to-layer1 still fires", () => {
+      const down = makeWindow([[2, 4, 6], [1, 3, 5], [1, 2, 4]], 50);
+      const atFloor = { maxParallel: 1, minParallel: 1, maxParallelCeiling: 20 };
+      const result = decideMaxParallel({ window: down, concurrency: atFloor, layer1Max: 4, ...base });
+      expect(result.next).toBe(4);
+      expect(result.reason).toBe("recovery-to-layer1");
+    });
+
+    test("attribution unavailable (pcts null) degrades to CTL-770 setpoint behavior", () => {
+      // current=16, running=2, setpoint=6, NO attribution → still drifts down
+      // (drift needs only setpoint + not-saturated, both supplied by runningWorkers).
+      const result = decideMaxParallel({
+        window: flatIdle,
+        concurrency: { maxParallel: 16, minParallel: 1, maxParallelCeiling: 20 },
+        runningWorkers: 2,
+        setpoint: 6,
+        ...base,
+      });
+      expect(result.next).toBe(15);
+      expect(result.reason).toBe("drift-to-setpoint");
     });
   });
 });

--- a/plugins/dev/scripts/execution-core/autotune-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/autotune-lifecycle.test.mjs
@@ -350,6 +350,112 @@ describe("autoTuneTick", () => {
     });
     expect(() => autoTuneTick(state, seams)).not.toThrow();
   });
+
+  // --- CTL-775: attribution seam wiring + the live 16-with-2 fix --------------
+
+  // A flat-idle 2-sample window the seam's 3rd flat sample completes; loadSafe.
+  function flatIdleWindow() {
+    return [
+      { load1: 0.5, load5: 0.5, load15: 0.5, memFreePct: 50, coreCount: 8 },
+      { load1: 0.5, load5: 0.5, load15: 0.5, memFreePct: 50, coreCount: 8 },
+    ];
+  }
+
+  test("attribution seams present → claudeCpuPct/memPct computed and threaded into the gauge", () => {
+    const state = makeState({ window: flatIdleWindow(), loadSafeFactor: 2 });
+    const gaugeCalls = [];
+    const seams = makeSeams({
+      liveBackgroundCount: () => 2,
+      loadavg: () => [0.5, 0.5, 0.5],
+      freemem: () => 8e9,
+      totalmem: () => 68.7e9,
+      cpus: () => Array(16),
+      readConcurrency: () => ({ maxParallel: 10, minParallel: 1, maxParallelCeiling: 20 }),
+      listAgents: () => [
+        { kind: "background", pid: 100, sessionId: "a" },
+        { kind: "background", pid: 200, sessionId: "b" },
+      ],
+      psLinesWithCpu: () => [
+        "100 1 80.0 400000",
+        "101 100 40.0 173440",
+        "200 1 90.0 400000",
+        "201 200 30.0 173440",
+      ],
+      appendGaugeEvent: (args) => { gaugeCalls.push(args); return true; },
+    });
+    autoTuneTick(state, seams);
+    expect(gaugeCalls).toHaveLength(1);
+    expect(typeof gaugeCalls[0].claudeCpuPct).toBe("number");
+    expect(typeof gaugeCalls[0].claudeMemPct).toBe("number");
+    expect(gaugeCalls[0].claudeCpuPct).toBeGreaterThan(0);
+    expect(gaugeCalls[0].claudeMemPct).toBeGreaterThan(0);
+  });
+
+  test("attribution seams ABSENT → claudeCpuPct/memPct null, no throw, degrades to setpoint behavior", () => {
+    const state = makeState({ window: flatIdleWindow(), loadSafeFactor: 2 });
+    const gaugeCalls = [];
+    const seams = makeSeams({
+      liveBackgroundCount: () => 2,
+      loadavg: () => [0.5, 0.5, 0.5],
+      freemem: () => 8e9,
+      totalmem: () => 16e9,
+      cpus: () => Array(8),
+      readConcurrency: () => ({ maxParallel: 10, minParallel: 1, maxParallelCeiling: 20 }),
+      // no listAgents / psLinesWithCpu
+      appendGaugeEvent: (args) => { gaugeCalls.push(args); return true; },
+    });
+    expect(() => autoTuneTick(state, seams)).not.toThrow();
+    expect(gaugeCalls[0].claudeCpuPct).toBeNull();
+    expect(gaugeCalls[0].claudeMemPct).toBeNull();
+  });
+
+  test("LIVE 16-with-2 integration: current=16, running=2, setpoint=6 → writeLayer2(15) drift", () => {
+    const state = makeState({ window: flatIdleWindow(), loadSafeFactor: 2 });
+    const writes = [];
+    const seams = makeSeams({
+      liveBackgroundCount: () => 2,
+      loadavg: () => [0.5, 0.5, 0.5],
+      freemem: () => 8e9,
+      totalmem: () => 16e9, // 50% ok
+      cpus: () => Array(8), // core-bound setpoint: min(6, 8-2)=6
+      readConcurrency: () => ({ maxParallel: 16, minParallel: 1, maxParallelCeiling: 20 }),
+      readLayer2Concurrency: () => ({ targetParallel: 6 }),
+      listAgents: () => [
+        { kind: "background", pid: 100, sessionId: "a" },
+        { kind: "background", pid: 200, sessionId: "b" },
+      ],
+      psLinesWithCpu: () => [
+        "100 1 10.0 100000",
+        "200 1 10.0 100000",
+      ],
+      writeLayer2: (v) => { writes.push(v); return true; },
+    });
+    autoTuneTick(state, seams);
+    expect(writes).toEqual([15]); // 16 → 15 drift-to-setpoint
+  });
+
+  test("a throwing psLinesWithCpu seam does not propagate; attribution falls back to null", () => {
+    const state = makeState({ window: flatIdleWindow(), loadSafeFactor: 2 });
+    const gaugeCalls = [];
+    const writes = [];
+    const seams = makeSeams({
+      liveBackgroundCount: () => 2,
+      loadavg: () => [0.5, 0.5, 0.5],
+      freemem: () => 8e9,
+      totalmem: () => 16e9,
+      cpus: () => Array(8),
+      readConcurrency: () => ({ maxParallel: 16, minParallel: 1, maxParallelCeiling: 20 }),
+      readLayer2Concurrency: () => ({ targetParallel: 6 }),
+      listAgents: () => [{ kind: "background", pid: 100, sessionId: "a" }],
+      psLinesWithCpu: () => { throw new Error("ps timed out"); },
+      appendGaugeEvent: (args) => { gaugeCalls.push(args); return true; },
+      writeLayer2: (v) => { writes.push(v); return true; },
+    });
+    expect(() => autoTuneTick(state, seams)).not.toThrow();
+    expect(gaugeCalls[0].claudeCpuPct).toBeNull();
+    // Drift/setpoint path still runs (running=2, setpoint=6, current=16) → 15.
+    expect(writes).toEqual([15]);
+  });
 });
 
 // --- startAutoTuner / stopAutoTuner lifecycle --------------------------------

--- a/plugins/dev/scripts/execution-core/autotune.mjs
+++ b/plugins/dev/scripts/execution-core/autotune.mjs
@@ -22,7 +22,8 @@ import {
   mergeExecutionCoreConcurrency,
   resolveTargetSetpoint,
 } from "./scheduler.mjs";
-import { countBackgroundAgents } from "./claude-agents.mjs";
+import { countBackgroundAgents, getAgentsCached } from "./claude-agents.mjs";
+import { parsePsSnapshotWithCpu, rssTotalForPid, cpuTotalForPid } from "./cli/sessions.mjs";
 import {
   defaultAppendParallelismSampledEvent,
   defaultAppendParallelismAdjustedEvent,
@@ -36,6 +37,11 @@ import {
   AUTOTUNE_MEM_CRITICAL_PCT,
   AUTOTUNE_MEM_WARN_PCT,
   AUTOTUNE_ENABLED,
+  AUTOTUNE_CLAUDE_RESOURCE_HIGH_WATER_PCT,
+  AUTOTUNE_ATTRIBUTION_DEADBAND_PCT,
+  AUTOTUNE_SCALE_UP_STEP,
+  AUTOTUNE_DRIFT_DOWN_STEP,
+  AUTOTUNE_CLAUDE_SHED_FACTOR,
   log,
 } from "./config.mjs";
 
@@ -45,6 +51,63 @@ import {
 // execFileSync (the established child-process primitive in this dir:
 // memory-sampler.mjs / claude-agents.mjs) so there is no shell parsing.
 const defaultVmStatExec = () => execFileSync("vm_stat", [], { encoding: "utf8" });
+
+// round1 — one-decimal rounding, matching availableMemPct's formula.
+const round1 = (x) => Math.round(x * 10) / 10;
+
+// defaultPsLinesWithCpu — CTL-775 production seam for the 4-column ps snapshot
+// that drives Claude-attribution. Mirrors memory-sampler.mjs's defaultPsLines
+// but adds the pcpu column: `ps -axo pid=,ppid=,pcpu=,rss=`. One shell-out per
+// autotune tick (~30s cadence) — cheap. Returns [] on any failure (fail-low).
+export function defaultPsLinesWithCpu() {
+  try {
+    const out = execFileSync("ps", ["-axo", "pid=,ppid=,pcpu=,rss="], { encoding: "utf8" });
+    return out.split("\n");
+  } catch {
+    return [];
+  }
+}
+
+// claudeResourceShare — CTL-775. Sum the RSS + pcpu of every live background
+// `claude` worker tree and express each as a percent of the whole host. This is
+// the ATTRIBUTION signal that lets the control law distinguish "WE are saturating
+// the host" (shed) from "another process is, our share is low" (hold).
+//
+// Fully seam-injected, pure, and TOTAL (never throws): on ANY error it returns
+// { claudeCpuPct: 0, claudeMemPct: 0 } — FAIL-LOW. Fail-low is the safe direction
+// because 0% reads as "we have headroom / we are not the cause", so attribution
+// can never falsely shed work nor falsely block a scale-up; the rule-4 near-OOM
+// clamp is independent of attribution and still fires regardless.
+//
+//   listAgents()  — array of `claude agents --json` records.
+//   psSnapshot    — a parsePsSnapshotWithCpu result ({selfRss, selfCpu, children}).
+//   totalmem      — host bytes.
+//   coreCount     — os.cpus().length.
+export function claudeResourceShare({ listAgents, psSnapshot, totalmem, coreCount } = {}) {
+  try {
+    // Mirror memory-sampler.mjs:113 — only kind==="background" agents with a pid.
+    const liveBgAgents = (listAgents?.() ?? []).filter(
+      (a) => a?.kind === "background" && a.pid,
+    );
+    let rssKbSum = 0;
+    let cpuSum = 0;
+    for (const a of liveBgAgents) {
+      rssKbSum += rssTotalForPid(psSnapshot, a.pid);
+      cpuSum += cpuTotalForPid(psSnapshot, a.pid);
+    }
+    const total = typeof totalmem === "function" ? totalmem() : totalmem;
+    // rss is KB → ×1024 to bytes.
+    const claudeMemPct = total > 0 ? round1(((rssKbSum * 1024) / total) * 100) : 0;
+    // pcpu is %-of-one-core; normalize the tree sum to whole-host percent.
+    const claudeCpuPct = coreCount > 0 ? round1((cpuSum / (coreCount * 100)) * 100) : 0;
+    if (!Number.isFinite(claudeCpuPct) || !Number.isFinite(claudeMemPct)) {
+      return { claudeCpuPct: 0, claudeMemPct: 0 };
+    }
+    return { claudeCpuPct, claudeMemPct };
+  } catch {
+    return { claudeCpuPct: 0, claudeMemPct: 0 };
+  }
+}
 
 // availableMemPct — CTL-772: platform-aware "available memory" percentage.
 //
@@ -176,6 +239,36 @@ export function memGuard(memFreePct, { criticalPct, warnPct }) {
 // is one obvious knob.
 const SETPOINT_DEADBAND = 0;
 
+// CTL-775 named constants for the Claude-attributable resource control law.
+// All env-overridable via config.mjs (EXECUTION_CORE_AUTOTUNE_*).
+const CLAUDE_RESOURCE_HIGH_WATER_PCT = AUTOTUNE_CLAUDE_RESOURCE_HIGH_WATER_PCT; // shed/scale-up gate
+const ATTRIBUTION_DEADBAND_PCT = AUTOTUNE_ATTRIBUTION_DEADBAND_PCT;             // hysteresis
+const SCALE_UP_STEP = AUTOTUNE_SCALE_UP_STEP;                                   // +1/tick saturated growth
+const DRIFT_DOWN_STEP = AUTOTUNE_DRIFT_DOWN_STEP;                               // -1/tick over-provisioned drift
+const CLAUDE_SHED_FACTOR = AUTOTUNE_CLAUDE_SHED_FACTOR;                         // ×0.75 shed
+
+// decideMaxParallel — CTL-775 control law. Branch precedence is top→bottom,
+// first match wins. Integrates the CTL-770/772 setpoint+OOM behavior with the
+// new Claude-attribution gates:
+//   1. host near-OOM        → clamp(minParallel)            [hard safety floor]
+//   2. <minSamples          → cold-start-seed / hold
+//   3. host trend-up        → coarse-load shed (kept above attribution)
+//   4. claude at limit      → claude-resource-shed          [law rule 2]
+//   5. host warn, not us    → host-pressure-not-ours-hold   [law rule 3]
+//   6. saturated + headroom → saturated-scale-up            [law rule 1]
+//   7. host trend-down      → CTL-750 recovery (saturation-gated)
+//   8. host flat-high       → hold
+//   9. setpoint converge/drift                              [law rule 5]
+//  10. fallback             → hold
+//
+// New params (all default to a back-compat-safe value):
+//   runningWorkers  — live bg worker count; null ⇒ unknown ⇒ treated as
+//                     saturated so legacy CTL-750 trend-down growth still fires
+//                     for direct unit callers that don't supply it.
+//   claudeCpuPct /
+//   claudeMemPct    — Claude-attributable host share; null ⇒ attribution
+//                     unavailable ⇒ the attribution gates (4,5,6) are skipped and
+//                     the function degrades to CTL-770/772 setpoint+drift behavior.
 export function decideMaxParallel({
   window,
   concurrency,
@@ -183,11 +276,30 @@ export function decideMaxParallel({
   loadSafeFactor,
   criticalPct,
   warnPct,
-  layer1Max = null,   // CTL-750: Layer-1 committed maxParallel for fast recovery target
-  setpoint = null,    // CTL-770: core-bounded seek-to target (host-over-repo); null → convergence no-ops
+  layer1Max = null,         // CTL-750: Layer-1 committed maxParallel for fast recovery target
+  setpoint = null,          // CTL-770: core-bounded seek-to target; null → convergence no-ops
+  runningWorkers = null,    // CTL-775: live bg worker count; null ⇒ unknown ⇒ saturated (back-compat)
+  claudeCpuPct = null,      // CTL-775: Claude-attributable host CPU %; null ⇒ attribution unavailable
+  claudeMemPct = null,      // CTL-775: Claude-attributable host MEM %; null ⇒ attribution unavailable
 }) {
   const { maxParallel: current, minParallel, maxParallelCeiling } = concurrency;
   const clamp = (v) => clampToBounds(v, { minParallel, maxParallelCeiling });
+
+  // Attribution-derived helpers. attribution-known ⇒ at least one pct supplied.
+  const attributionKnown = claudeCpuPct != null || claudeMemPct != null;
+  const claudeAtLimit =
+    (claudeCpuPct != null && claudeCpuPct >= CLAUDE_RESOURCE_HIGH_WATER_PCT) ||
+    (claudeMemPct != null && claudeMemPct >= CLAUDE_RESOURCE_HIGH_WATER_PCT);
+  const headroomLine = CLAUDE_RESOURCE_HIGH_WATER_PCT - ATTRIBUTION_DEADBAND_PCT;
+  const claudeHasHeadroom =
+    attributionKnown &&
+    (claudeCpuPct == null || claudeCpuPct < headroomLine) &&
+    (claudeMemPct == null || claudeMemPct < headroomLine);
+  // No-free-slots. runningWorkers==null ⇒ unknown demand ⇒ assume saturated so
+  // legacy CTL-750 trend-down recovery (which has no runningWorkers concept)
+  // keeps firing for direct unit callers. autoTuneTick ALWAYS supplies bgCount,
+  // so null only happens in hand-built unit calls. Documented in risks.
+  const saturated = runningWorkers == null || runningWorkers >= current;
 
   if (window.length === 0) {
     // CTL-770: truly-empty window has no sample to judge mem/load — keep the
@@ -199,16 +311,14 @@ export function decideMaxParallel({
   const latest = window[window.length - 1];
   const mem = memGuard(latest.memFreePct, { criticalPct, warnPct });
 
-  // mem-critical overrides everything — act even without a full window.
+  // RULE 1 — mem-critical hard floor. Runs before ALL attribution so the host
+  // near-OOM clamp fires regardless of whose load it is.
   if (mem === "critical") {
     return { next: clamp(minParallel), reason: "mem-critical" };
   }
 
+  // RULE 2 — cold-start seed / insufficient-samples (CTL-770).
   if (window.length < minSamples) {
-    // CTL-770 cold-start seed: a short window plus a mem-ok sample and a
-    // setpoint above the current floor → jump straight to the (core-bounded)
-    // target instead of idling at the persisted floor. mem-critical already
-    // won above; we only seed when mem is not critical (ok or warn).
     if (setpoint !== null && current < setpoint) {
       return { next: clamp(setpoint), reason: "cold-start-seed" };
     }
@@ -221,12 +331,49 @@ export function decideMaxParallel({
     loadSafeFactor,
   });
 
-  // trend-up shed and mem-critical (above) always win over the setpoint logic.
-  if (trend === "up") {
+  // RULE 3 — host-load trend-up shed (CTL-684), now ONLY a coarse backstop when
+  // attribution is UNKNOWN (old/unwired callers, or a ps snapshot we couldn't
+  // read). When attribution IS known, a host up-trend must NOT blindly shed our
+  // workers (CTL-775 law rule 3) — defer to the claude-at-limit shed (RULE 4)
+  // and the not-ours hold (RULE 5), so a non-Claude CPU spike holds, not sheds.
+  if (trend === "up" && !attributionKnown) {
     return { next: clamp(Math.max(minParallel, Math.floor(current * 0.75))), reason: "trend-up" };
   }
 
-  if (trend === "down") {
+  // RULE 4 — CLAUDE-DRIVEN SHED (law rule 2). Only fires when WE are the cause:
+  // a current sample whose Claude-attributable cpu OR mem is at/over the
+  // high-water. Stateless v1 (no per-sample share-history threaded), so the
+  // "approaching + rising" sub-clause is intentionally omitted.
+  if (claudeAtLimit) {
+    return {
+      next: clamp(Math.max(minParallel, Math.floor(current * CLAUDE_SHED_FACTOR))),
+      reason: "claude-resource-shed",
+    };
+  }
+
+  // RULE 5 — NON-CLAUDE PRESSURE HOLD (law rule 3). Host is pressured — either a
+  // sub-critical mem-warn OR a load up-trend — but our attributable share is low
+  // → another process is the cause. Shedding wouldn't help our throughput, and
+  // growing would pour onto an already-busy host. HOLD. Requires attribution
+  // KNOWN so the no-attribution mem-warn tests still reach rule 7's mem-warn
+  // semantics (different reason string); the up-trend coarse shed for the
+  // no-attribution case already returned in RULE 3.
+  if (attributionKnown && !claudeAtLimit && (mem === "warn" || trend === "up")) {
+    return { next: clamp(current), reason: "host-pressure-not-ours-hold" };
+  }
+
+  // RULE 6 — SATURATED SCALE-UP (law rule 1). The ONLY path that grows ABOVE the
+  // setpoint. Requires no-free-slots AND our-own-headroom AND mem ok. Bounded by
+  // the ceiling via clamp. Kills the "16 ceiling with 2 running" ramp: not
+  // saturated → never reached.
+  if (saturated && claudeHasHeadroom && mem === "ok" && current < maxParallelCeiling) {
+    return { next: clamp(current + SCALE_UP_STEP), reason: "saturated-scale-up" };
+  }
+
+  // RULE 7 — host trend-down recovery (CTL-750), now SATURATION-GATED so it
+  // never grows on demand-free falling load. NOT saturated → fall through to the
+  // setpoint logic.
+  if (trend === "down" && saturated) {
     if (mem === "warn") {
       // CTL-750: allow slow recovery from absolute floor even under mem-warn.
       if (current <= minParallel) return { next: clamp(current + 1), reason: "mem-warn-recovery" };
@@ -239,32 +386,36 @@ export function decideMaxParallel({
     return { next: clamp(current + 1), reason: "trend-down" };
   }
 
+  // RULE 8 — host flat-high coarse-load hold (CTL-684).
   if (trend === "flat-high") {
     return { next: clamp(current), reason: "flat-high" };
   }
 
-  // CTL-770 idle/headroom convergence — generalizes CTL-750's recovery (which
-  // only fired for trend==="down") to the flat-idle trend==="none" case. When
-  // there is real headroom (mem ok + load below the ~75% safe line) and the
-  // current value is below the setpoint, ramp toward the (already core-bounded)
-  // target so a stuck-at-floor host converges in a bounded number of ticks.
+  // RULE 9 — setpoint converge (CTL-770) + drift-down (CTL-775 law rule 5).
   if (setpoint !== null && mem === "ok") {
     const threshold = latest.coreCount * loadSafeFactor;
     const loadSafe = latest.load1 < threshold;
     if (loadSafe) {
-      // Hold within the deadband first so a value already at/near the setpoint
-      // does not ping-pong (BEFORE the converge-up branch).
+      // 9a — hold within the deadband (BEFORE converge/drift so a value at the
+      // setpoint never ping-pongs).
       if (Math.abs(current - setpoint) <= SETPOINT_DEADBAND) {
         return { next: clamp(current), reason: "at-setpoint" };
       }
+      // 9b — converge UP to the baseline (always; first-wave headroom).
       if (current < setpoint - SETPOINT_DEADBAND) {
-        // Direct jump (mirrors CTL-750's recovery-to-layer1 semantics); clamp
-        // guarantees no overshoot past the ceiling or the setpoint.
         return { next: clamp(Math.min(setpoint, maxParallelCeiling)), reason: "converge-to-setpoint" };
+      }
+      // 9c — DRIFT DOWN to the baseline when over-provisioned and NOT saturated.
+      // Floored at setpoint so it never undershoots, and never below
+      // runningWorkers so the lowered ceiling can't drop under in-flight work.
+      if (current > setpoint + SETPOINT_DEADBAND && !saturated) {
+        const floor = Math.max(setpoint, runningWorkers ?? setpoint);
+        return { next: clamp(Math.max(floor, current - DRIFT_DOWN_STEP)), reason: "drift-to-setpoint" };
       }
     }
   }
 
+  // RULE 10 — final fallback hold.
   return { next: clamp(current), reason: "hold" };
 }
 
@@ -329,6 +480,8 @@ export function autoTuneTick(state, seams) {
     readConcurrency,
     readLayer1Concurrency,  // CTL-750: optional seam for Layer-1 committed maxParallel
     readLayer2Concurrency,  // CTL-770: optional seam for Layer-2 host targetParallel
+    listAgents,             // CTL-775: optional seam for Claude attribution; default undefined
+    psLinesWithCpu,         // CTL-775: optional seam — () => string[] for the 4-col ps snapshot
     writeLayer2,
     appendSampledEvent,
     appendAdjustedEvent,
@@ -385,6 +538,28 @@ export function autoTuneTick(state, seams) {
             },
           );
 
+    // CTL-775: Claude-attributable resource share. Guarded behind both seams so
+    // the existing hand-built test seams (which inject neither) no-op cleanly:
+    // null pcts → decideMaxParallel's attribution gates are SKIPPED and the
+    // function degrades to the CTL-770/772 setpoint+drift behavior. Any throw
+    // (a hung ps, a malformed snapshot) is swallowed → null → same fail-low path.
+    let claudeCpuPct = null;
+    let claudeMemPct = null;
+    if (listAgents && psLinesWithCpu) {
+      try {
+        const snap = parsePsSnapshotWithCpu(psLinesWithCpu());
+        ({ claudeCpuPct, claudeMemPct } = claudeResourceShare({
+          listAgents,
+          psSnapshot: snap,
+          totalmem: totalmem(),
+          coreCount: sample.coreCount,
+        }));
+      } catch {
+        claudeCpuPct = null;
+        claudeMemPct = null;
+      }
+    }
+
     try {
       appendSampledEvent({
         label: "execution-core",
@@ -404,8 +579,11 @@ export function autoTuneTick(state, seams) {
       loadSafeFactor: state.loadSafeFactor,
       criticalPct: state.criticalPct,
       warnPct: state.warnPct,
-      layer1Max,  // CTL-750
-      setpoint,   // CTL-770
+      layer1Max,                  // CTL-750
+      setpoint,                   // CTL-770
+      runningWorkers: bgCount,    // CTL-775: live worker count is the saturation signal
+      claudeCpuPct,               // CTL-775: Claude-attributable host CPU %
+      claudeMemPct,               // CTL-775: Claude-attributable host MEM %
     });
 
     // CTL-771: emit the setpoint gauge EVERY tick (unconditional, unlike the
@@ -422,6 +600,8 @@ export function autoTuneTick(state, seams) {
         load1: sample.load1,
         loadPerCore: coreCount ? sample.load1 / coreCount : sample.load1,
         memFreePct: sample.memFreePct,
+        claudeCpuPct,  // CTL-775: additive — dashboard visibility into attribution
+        claudeMemPct,  // CTL-775
         reason,
       });
     } catch {}
@@ -498,6 +678,11 @@ export function startAutoTuner({
     // CTL-770: Layer-2 host file — carries the NEW targetParallel key (the
     // autotuner's seek-to setpoint), separate from maxParallel.
     readLayer2Concurrency: () => readExecutionCoreConcurrencyLayer2(layer2Path),
+    // CTL-775: Claude-attribution seams. listAgents reads the SAME warm,
+    // non-blocking snapshot memory-sampler uses (getAgentsCached) — never a sync
+    // spawn on the loop. psLinesWithCpu shells out the 4-col ps once per tick.
+    listAgents: () => getAgentsCached().agents,
+    psLinesWithCpu: defaultPsLinesWithCpu,
     writeLayer2: (next) => writeLayer2MaxParallel(layer2Path, next),
     appendSampledEvent,
     appendAdjustedEvent,

--- a/plugins/dev/scripts/execution-core/cli/sessions.mjs
+++ b/plugins/dev/scripts/execution-core/cli/sessions.mjs
@@ -131,6 +131,68 @@ export function rssTotalForPid(snapshot, pid) {
   return total;
 }
 
+/**
+ * parsePsSnapshotWithCpu — CTL-775 sibling of parsePsSnapshot for the 4-column
+ * `ps -axo pid=,ppid=,pcpu=,rss=` snapshot. It MUST be a separate function:
+ * parsePsSnapshot reads parts[2]=rss from the 3-column layout, and its two live
+ * callers (memory-sampler.mjs, sessions.mjs buildRows) still feed it 3 columns —
+ * extending it in place would shift rss to parts[3] and silently mis-read RSS.
+ *
+ * Returns `{ selfRss, selfCpu, children }` where:
+ *   selfRss[pid] = Number(parts[3])   — RSS in KB (4th column)
+ *   selfCpu[pid] = Number(parts[2])   — pcpu, percent-of-one-core (can exceed 100)
+ * The `{selfRss, children}` shape is a superset of what rssTotalForPid needs, so
+ * this one 4-column snapshot drives BOTH rssTotalForPid and cpuTotalForPid.
+ */
+export function parsePsSnapshotWithCpu(lines) {
+  const selfRss = new Map();
+  const selfCpu = new Map();
+  const children = new Map();
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    const parts = line.split(/\s+/);
+    if (parts.length < 4) continue;
+    const pid = Number(parts[0]);
+    const ppid = Number(parts[1]);
+    const pcpu = Number(parts[2]);
+    const rss = Number(parts[3]);
+    if (
+      !Number.isFinite(pid) ||
+      !Number.isFinite(ppid) ||
+      !Number.isFinite(pcpu) ||
+      !Number.isFinite(rss)
+    )
+      continue;
+    selfRss.set(pid, rss);
+    selfCpu.set(pid, pcpu);
+    if (!children.has(ppid)) children.set(ppid, []);
+    children.get(ppid).push(pid);
+  }
+  return { selfRss, selfCpu, children };
+}
+
+/**
+ * cpuTotalForPid — self pcpu plus the pcpu of every descendant (DFS). Mirrors
+ * rssTotalForPid's tree-walk but sums selfCpu. The snapshot MUST be a
+ * parsePsSnapshotWithCpu result (carries selfCpu). Returns 0 for an unknown pid.
+ */
+export function cpuTotalForPid(snapshot, pid) {
+  const { selfCpu, children } = snapshot;
+  if (!selfCpu || !selfCpu.has(pid)) return 0;
+  let total = 0;
+  const stack = [pid];
+  const seen = new Set();
+  while (stack.length) {
+    const p = stack.pop();
+    if (seen.has(p)) continue;
+    seen.add(p);
+    total += selfCpu.get(p) ?? 0;
+    for (const c of children.get(p) ?? []) stack.push(c);
+  }
+  return total;
+}
+
 // ─── Pure: name parsing ──────────────────────────────────────────────────────
 
 /**

--- a/plugins/dev/scripts/execution-core/cli/sessions.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/sessions.test.mjs
@@ -13,7 +13,9 @@ import {
   classifyRow,
   applyDuplicates,
   parsePsSnapshot,
+  parsePsSnapshotWithCpu,
   rssTotalForPid,
+  cpuTotalForPid,
   parseSessionName,
   buildRows,
   buildLiveSessionsByWorktree,
@@ -126,6 +128,54 @@ describe("RSS attribution (single ps snapshot, ancestor walk)", () => {
   it("tolerates blank/malformed lines", () => {
     const s = parsePsSnapshot(["", "  ", "100 1 1000", "garbage line here"]);
     expect(rssTotalForPid(s, 100)).toBe(1000);
+  });
+});
+
+// CTL-775: 4-column attribution snapshot (pid ppid pcpu rss). MUST be a sibling
+// of parsePsSnapshot so the 3-column callers never mis-read rss.
+describe("CPU+RSS attribution (parsePsSnapshotWithCpu / cpuTotalForPid) — CTL-775", () => {
+  const withCpu = parsePsSnapshotWithCpu([
+    "100   1 50.0 102400", // PID PPID PCPU RSS-KB  (root)
+    "200 100 30.0  51200", // child of 100
+    "300 200 10.0  30720", // grandchild via 200
+    "201 100  5.0  20480", // child of 100
+  ]);
+
+  it("reads pcpu from col 3 and rss from col 4 (NOT mis-read)", () => {
+    expect(withCpu.selfCpu.get(100)).toBe(50.0);
+    expect(withCpu.selfRss.get(100)).toBe(102400); // rss is the 4th column
+    expect(withCpu.selfCpu.get(200)).toBe(30.0);
+    expect(withCpu.selfRss.get(200)).toBe(51200);
+  });
+
+  it("skips lines with fewer than 4 parts", () => {
+    const s = parsePsSnapshotWithCpu(["100 1 50.0", "200 100 30.0 51200"]);
+    expect(s.selfRss.has(100)).toBe(false); // only 3 parts → skipped
+    expect(s.selfRss.get(200)).toBe(51200);
+  });
+
+  it("skips non-finite values", () => {
+    const s = parsePsSnapshotWithCpu(["abc 1 50.0 1000", "200 100 xx 51200", "300 200 10.0 yy"]);
+    expect(s.selfRss.size).toBe(0);
+  });
+
+  it("cpuTotalForPid sums self + all descendants (DFS)", () => {
+    expect(cpuTotalForPid(withCpu, 100)).toBeCloseTo(50 + 30 + 10 + 5, 5);
+  });
+
+  it("cpuTotalForPid sums a subtree from a non-root pid", () => {
+    expect(cpuTotalForPid(withCpu, 200)).toBeCloseTo(30 + 10, 5);
+  });
+
+  it("cpuTotalForPid returns 0 for an unknown pid", () => {
+    expect(cpuTotalForPid(withCpu, 999)).toBe(0);
+  });
+
+  it("rssTotalForPid still correct on a 4-column snapshot (one snapshot drives BOTH totals)", () => {
+    // Guards against a future column-order regression: the WithCpu snapshot's
+    // {selfRss, children} must remain a valid input to rssTotalForPid.
+    expect(rssTotalForPid(withCpu, 100)).toBe(102400 + 51200 + 30720 + 20480);
+    expect(rssTotalForPid(withCpu, 200)).toBe(51200 + 30720);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -224,3 +224,26 @@ export const AUTOTUNE_MEM_WARN_PCT =
 
 // Kill-switch: EXECUTION_CORE_AUTOTUNE=0 disables all sampling and Layer-2 writes.
 export const AUTOTUNE_ENABLED = process.env.EXECUTION_CORE_AUTOTUNE !== "0";
+
+// --- Claude-attributable resource control law (CTL-775) ---
+// High-water mark for Claude-attributable cpu/mem (% of whole host). Above this
+// → shed; below it (minus deadband) → we have headroom to scale up.
+export const AUTOTUNE_CLAUDE_RESOURCE_HIGH_WATER_PCT =
+  Number(process.env.EXECUTION_CORE_AUTOTUNE_CLAUDE_HIGH_WATER_PCT) || 75;
+
+// Hysteresis around the high-water so a sample straddling the line doesn't flap
+// between scale-up and shed.
+export const AUTOTUNE_ATTRIBUTION_DEADBAND_PCT =
+  Number(process.env.EXECUTION_CORE_AUTOTUNE_ATTRIBUTION_DEADBAND_PCT) || 5;
+
+// Step sizes for the saturation-gated scale-up and the over-provisioned
+// drift-down toward the setpoint.
+export const AUTOTUNE_SCALE_UP_STEP =
+  Number(process.env.EXECUTION_CORE_AUTOTUNE_SCALE_UP_STEP) || 1;
+export const AUTOTUNE_DRIFT_DOWN_STEP =
+  Number(process.env.EXECUTION_CORE_AUTOTUNE_DRIFT_DOWN_STEP) || 1;
+
+// Multiplicative shed factor applied when Claude-attributable resources hit the
+// high-water (reuses the legacy ×0.75 trend-up shed factor).
+export const AUTOTUNE_CLAUDE_SHED_FACTOR =
+  Number(process.env.EXECUTION_CORE_AUTOTUNE_CLAUDE_SHED_FACTOR) || 0.75;


### PR DESCRIPTION
Fixes the autotuner ratcheting maxParallel to 16 with only 2 workers in flight — it grew from host LOAD trend, ignoring slot utilization and *whose* load it was.

## Control law (operator-specified)
- **Up** only when saturated (`runningWorkers >= current`) AND Claude's own cpu+mem share has headroom (<75%) AND host not near-OOM.
- **Down** when Claude-attributable cpu/mem is at the high-water (we're the cause).
- **Hold** when host is pressured but Claude's share is low — another process is the cause; shedding only yields the machine to it. **Both mem-warn and load-up-trend honored.**
- **OOM safety** (CTL-772 available-mem) still clamps regardless of attribution.
- **Setpoint** stays the idle baseline; grow above only under saturation+headroom; **drift down** to it when over-provisioned + idle (the live 16-with-2 → 6).

## Attribution
Reuses CTL-685's per-worker process-tree RSS; adds `parsePsSnapshotWithCpu` + `cpuTotalForPid` (one `ps -axo pid=,ppid=,pcpu=,rss=` per tick) → sums Claude cpu%/mem% over live bg-agent process trees. `claudeResourceShare` **fails low** (→0%) on any ps error, so it never falsely sheds or blocks scale-up; the OOM clamp is independent.

## Review-caught fix (control-correctness lens)
The adversarial review found the host `trend-up` shed sat **above** attribution and would shed for a **non-Claude CPU spike** — violating the HOLD law on the CPU axis (it was only wired for mem-warn). **Fixed:** the coarse trend-up shed now fires only when attribution is *unknown* (back-compat / ps-failure backstop); with attribution known, a host up-trend + low Claude share **HOLDS** (rule 5 widened to mem-warn OR trend-up). Pinned by a test that goes red if either gate reverts; the attribution-unknown path still sheds (back-compat).

## Test plan
- `autotune-decision` + `autotune-lifecycle`: **107 pass / 0 fail** (incl. the 5 acceptance cases + the CPU-axis HOLD + OOM-safety + drift-down).
- The 1 failing `cli/sessions.test.mjs > classifyRow` is **pre-existing** (identical on origin/main, classifyRow untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)