### PR TITLE
CTL-763: Add per-model 7d rate-limit split to OTEL telemetry pipeline

### DIFF
--- a/plugins/dev/scripts/__tests__/canonical-event.test.sh
+++ b/plugins/dev/scripts/__tests__/canonical-event.test.sh
@@ -331,7 +331,9 @@ RL_LINE="$(build_canonical_line \
   --service "catalyst.session" \
   --event-name "session.context" \
   --claude-ratelimit-5h-pct 26 \
-  --claude-ratelimit-7d-pct 15)"
+  --claude-ratelimit-7d-pct 15 \
+  --claude-ratelimit-7d-opus-pct 12 \
+  --claude-ratelimit-7d-sonnet-pct 9)"
 
 RL_5H="$(echo "$RL_LINE" | jq -r '.attributes."claude.ratelimit.five_hour_pct"')"
 expect_eq "build_canonical_line claude.ratelimit.five_hour_pct" "26" "$RL_5H"
@@ -344,6 +346,17 @@ expect_eq "build_canonical_line claude.ratelimit.seven_day_pct" "15" "$RL_7D"
 
 RL_7D_TYPE="$(echo "$RL_LINE" | jq -r '.attributes."claude.ratelimit.seven_day_pct" | type')"
 expect_eq "build_canonical_line claude.ratelimit.seven_day_pct is number" "number" "$RL_7D_TYPE"
+
+# CTL-763: per-model 7d split — opus + sonnet typed numeric attributes.
+RL_OPUS="$(echo "$RL_LINE" | jq -r '.attributes."claude.ratelimit.seven_day_opus_pct"')"
+expect_eq "build_canonical_line claude.ratelimit.seven_day_opus_pct" "12" "$RL_OPUS"
+RL_OPUS_TYPE="$(echo "$RL_LINE" | jq -r '.attributes."claude.ratelimit.seven_day_opus_pct" | type')"
+expect_eq "build_canonical_line seven_day_opus_pct is number" "number" "$RL_OPUS_TYPE"
+
+RL_SONNET="$(echo "$RL_LINE" | jq -r '.attributes."claude.ratelimit.seven_day_sonnet_pct"')"
+expect_eq "build_canonical_line claude.ratelimit.seven_day_sonnet_pct" "9" "$RL_SONNET"
+RL_SONNET_TYPE="$(echo "$RL_LINE" | jq -r '.attributes."claude.ratelimit.seven_day_sonnet_pct" | type')"
+expect_eq "build_canonical_line seven_day_sonnet_pct is number" "number" "$RL_SONNET_TYPE"
 
 # When claude.* flags are NOT passed, the attribute keys must be absent.
 BARE_LINE="$(build_canonical_line \
@@ -373,6 +386,12 @@ expect_eq "no --claude-ratelimit-5h-pct → key absent" "false" "$HAS_RL5H"
 
 HAS_RL7D="$(echo "$BARE_LINE" | jq '.attributes | has("claude.ratelimit.seven_day_pct")')"
 expect_eq "no --claude-ratelimit-7d-pct → key absent" "false" "$HAS_RL7D"
+
+# CTL-763: per-model attrs absent when flags not passed.
+HAS_RL_OPUS="$(echo "$BARE_LINE" | jq '.attributes | has("claude.ratelimit.seven_day_opus_pct")')"
+expect_eq "no --claude-ratelimit-7d-opus-pct → key absent" "false" "$HAS_RL_OPUS"
+HAS_RL_SONNET="$(echo "$BARE_LINE" | jq '.attributes | has("claude.ratelimit.seven_day_sonnet_pct")')"
+expect_eq "no --claude-ratelimit-7d-sonnet-pct → key absent" "false" "$HAS_RL_SONNET"
 
 # Cost MUST NOT be a typed attribute (PII gate — OTLP forwarder strips body.payload only).
 HAS_COST_ATTR="$(echo "$CLAUDE_LINE" | jq '.attributes | has("claude.cost.usd")')"

--- a/plugins/dev/scripts/__tests__/catalyst-session-claude.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-session-claude.test.sh
@@ -134,7 +134,10 @@ bash "$SESSION_SCRIPT" emit-context "$SID_RL" \
   --context-pct 30 --turn 7 --model "claude-opus-4-7" \
   --ratelimit-5h-pct 26 --ratelimit-7d-pct 15 \
   --ratelimit-5h-reset "2026-06-03T05:00:00Z" \
-  --ratelimit-7d-reset "2026-06-10T00:00:00Z" >/dev/null
+  --ratelimit-7d-reset "2026-06-10T00:00:00Z" \
+  --ratelimit-7d-opus-pct 12 --ratelimit-7d-sonnet-pct 9 \
+  --ratelimit-7d-opus-reset "2026-06-10T00:00:00Z" \
+  --ratelimit-7d-sonnet-reset "2026-06-10T00:00:00Z" >/dev/null
 
 RL_LINE="$(grep '"session.context"' "$EF" | grep "$SID_RL" | tail -n 1)"
 expect_not_empty "session.context event recorded for rate-limit test" "$RL_LINE"
@@ -161,6 +164,24 @@ expect_eq "7d reset in body.payload" "2026-06-10T00:00:00Z" "$RL_7D_RESET"
 # Resets MUST NOT be typed attributes (avoid label cardinality explosion).
 RL_5H_RESET_ATTR="$(printf '%s' "$RL_LINE" | jq -r '.attributes | has("claude.ratelimit.five_hour_reset")')"
 expect_eq "5h reset is NOT a typed attribute" "false" "$RL_5H_RESET_ATTR"
+
+# CTL-763: per-model 7d split.
+OPUS_ATTR="$(printf '%s' "$RL_LINE" | jq -r '.attributes."claude.ratelimit.seven_day_opus_pct"')"
+expect_eq "emit-context seven_day_opus_pct typed attr" "12" "$OPUS_ATTR"
+SONNET_ATTR="$(printf '%s' "$RL_LINE" | jq -r '.attributes."claude.ratelimit.seven_day_sonnet_pct"')"
+expect_eq "emit-context seven_day_sonnet_pct typed attr" "9" "$SONNET_ATTR"
+
+OPUS_BODY="$(printf '%s' "$RL_LINE" | jq -r '.body.payload.ratelimit_7d_opus_pct')"
+expect_eq "emit-context ratelimit_7d_opus_pct in body" "12" "$OPUS_BODY"
+OPUS_RESET="$(printf '%s' "$RL_LINE" | jq -r '.body.payload.ratelimit_7d_opus_reset')"
+expect_eq "emit-context ratelimit_7d_opus_reset in body" "2026-06-10T00:00:00Z" "$OPUS_RESET"
+SONNET_BODY="$(printf '%s' "$RL_LINE" | jq -r '.body.payload.ratelimit_7d_sonnet_pct')"
+expect_eq "emit-context ratelimit_7d_sonnet_pct in body" "9" "$SONNET_BODY"
+SONNET_RESET="$(printf '%s' "$RL_LINE" | jq -r '.body.payload.ratelimit_7d_sonnet_reset')"
+expect_eq "emit-context ratelimit_7d_sonnet_reset in body" "2026-06-10T00:00:00Z" "$SONNET_RESET"
+
+HAS_OPUS_RESET_ATTR="$(printf '%s' "$RL_LINE" | jq '.attributes | has("claude.ratelimit.seven_day_opus_reset")')"
+expect_eq "opus reset is body-only, not a typed attr" "false" "$HAS_OPUS_RESET_ATTR"
 
 # CTL-760: per-worker linear.key lands in the resource block.
 RL_LINEAR_KEY="$(printf '%s' "$RL_LINE" | jq -r '.resource."linear.key" // ""')"

--- a/plugins/dev/scripts/__tests__/catalyst-statusline.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-statusline.test.sh
@@ -148,8 +148,10 @@ RL_STATUS_JSON='{
   "model": {"id": "claude-opus-4-7"},
   "context_window": {"used_percentage": 24, "current_usage": 245000},
   "rate_limits": {
-    "five_hour":  {"used_percentage": 26, "resets_at": "2026-06-03T05:00:00Z"},
-    "seven_day":  {"used_percentage": 15, "resets_at": "2026-06-10T00:00:00Z"}
+    "five_hour":    {"used_percentage": 26, "resets_at": "2026-06-03T05:00:00Z"},
+    "seven_day":    {"used_percentage": 15, "resets_at": "2026-06-10T00:00:00Z"},
+    "seven_day_opus":   {"used_percentage": 12, "resets_at": "2026-06-10T00:00:00Z"},
+    "seven_day_sonnet": {"used_percentage": 9,  "resets_at": "2026-06-10T00:00:00Z"}
   }
 }'
 
@@ -169,6 +171,43 @@ expect_contains "wrapper forwards --ratelimit-5h-pct 26 to catalyst-session.sh" 
 expect_contains "wrapper forwards --ratelimit-7d-pct 15 to catalyst-session.sh" "$RL_ARGS" "--ratelimit-7d-pct 15"
 expect_contains "wrapper forwards --ratelimit-5h-reset to catalyst-session.sh" "$RL_ARGS" "--ratelimit-5h-reset 2026-06-03T05:00:00Z"
 expect_contains "wrapper forwards --ratelimit-7d-reset to catalyst-session.sh" "$RL_ARGS" "--ratelimit-7d-reset 2026-06-10T00:00:00Z"
+# CTL-763: per-model 7d split forwarded flags.
+expect_contains "wrapper forwards --ratelimit-7d-opus-pct 12" "$RL_ARGS" "--ratelimit-7d-opus-pct 12"
+expect_contains "wrapper forwards --ratelimit-7d-sonnet-pct 9" "$RL_ARGS" "--ratelimit-7d-sonnet-pct 9"
+expect_contains "wrapper forwards --ratelimit-7d-opus-reset" "$RL_ARGS" "--ratelimit-7d-opus-reset 2026-06-10T00:00:00Z"
+expect_contains "wrapper forwards --ratelimit-7d-sonnet-reset" "$RL_ARGS" "--ratelimit-7d-sonnet-reset 2026-06-10T00:00:00Z"
+
+# CTL-763: negative path — when per-model fields are absent, no per-model flags emitted.
+RL_CAPTURE_BASELINE="$TMPDIR/rl-capture-baseline-$$"
+RL_SESSION_STUB_BASELINE="$TMPDIR/rl-stub-baseline-$$.sh"
+cat >"$RL_SESSION_STUB_BASELINE" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$RL_CAPTURE_BASELINE"
+exit 0
+STUB
+chmod +x "$RL_SESSION_STUB_BASELINE"
+RL_STATUS_BASELINE='{
+  "session_id": "claude-uuid-baseline",
+  "model": {"id": "claude-opus-4-7"},
+  "context_window": {"used_percentage": 24, "current_usage": 245000},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 26, "resets_at": "2026-06-03T05:00:00Z"},
+    "seven_day": {"used_percentage": 15, "resets_at": "2026-06-10T00:00:00Z"}
+  }
+}'
+CATALYST_SESSION_BIN="$RL_SESSION_STUB_BASELINE" \
+  bash "$WRAPPER" >/dev/null 2>&1 <<<"$RL_STATUS_BASELINE"
+RL_WAITED_B=0
+while (( RL_WAITED_B < 20 )); do
+  [[ -f "$RL_CAPTURE_BASELINE" ]] && break
+  sleep 0.25
+  RL_WAITED_B=$((RL_WAITED_B + 1))
+done
+RL_ARGS_BASELINE="$(cat "$RL_CAPTURE_BASELINE" 2>/dev/null | tr '\n' ' ')"
+case "$RL_ARGS_BASELINE" in
+  *--ratelimit-7d-opus-pct*) fail "no per-model field → no opus flag" "flag present unexpectedly" ;;
+  *) ok "no per-model field → no opus flag" ;;
+esac
 
 # ─── 4. Resilience: even if emit fails, wrapper still renders ───────────────
 # Point the session script at a bogus path so emit silently fails.

--- a/plugins/dev/scripts/catalyst-session.sh
+++ b/plugins/dev/scripts/catalyst-session.sh
@@ -670,6 +670,8 @@ cmd_emit_context() {
   # 5h/7d used-percentages are the "5h: 26%" / "7d: 15%" the user sees; the
   # resets_at timestamps are informational (body-only, no label cardinality).
   local rl5h="" rl7d="" rl5h_reset="" rl7d_reset=""
+  # CTL-763: per-model 7d split.
+  local rl7d_opus="" rl7d_sonnet="" rl7d_opus_reset="" rl7d_sonnet_reset=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --context-pct)    pct="$2"; shift 2 ;;
@@ -679,10 +681,14 @@ cmd_emit_context() {
       --model)          model="$2"; shift 2 ;;
       --cost-usd)       cost="$2"; shift 2 ;;
       --effort)         effort="$2"; shift 2 ;;
-      --ratelimit-5h-pct)    rl5h="$2"; shift 2 ;;
-      --ratelimit-7d-pct)    rl7d="$2"; shift 2 ;;
-      --ratelimit-5h-reset)  rl5h_reset="$2"; shift 2 ;;
-      --ratelimit-7d-reset)  rl7d_reset="$2"; shift 2 ;;
+      --ratelimit-5h-pct)        rl5h="$2"; shift 2 ;;
+      --ratelimit-7d-pct)        rl7d="$2"; shift 2 ;;
+      --ratelimit-5h-reset)      rl5h_reset="$2"; shift 2 ;;
+      --ratelimit-7d-reset)      rl7d_reset="$2"; shift 2 ;;
+      --ratelimit-7d-opus-pct)   rl7d_opus="$2"; shift 2 ;;
+      --ratelimit-7d-sonnet-pct) rl7d_sonnet="$2"; shift 2 ;;
+      --ratelimit-7d-opus-reset) rl7d_opus_reset="$2"; shift 2 ;;
+      --ratelimit-7d-sonnet-reset) rl7d_sonnet_reset="$2"; shift 2 ;;
       *) echo "error: unknown flag for emit-context: $1" >&2; return 1 ;;
     esac
   done
@@ -718,6 +724,10 @@ cmd_emit_context() {
     --argjson rl7d "${rl7d:-null}" \
     --arg rl5h_reset "$rl5h_reset" \
     --arg rl7d_reset "$rl7d_reset" \
+    --argjson rl7d_opus "${rl7d_opus:-null}" \
+    --argjson rl7d_sonnet "${rl7d_sonnet:-null}" \
+    --arg rl7d_opus_reset "$rl7d_opus_reset" \
+    --arg rl7d_sonnet_reset "$rl7d_sonnet_reset" \
     '{context_pct: $pct,
       context_tokens: (if $tokens == null then null else $tokens end),
       context_max: (if $context_max == null then null else $context_max end),
@@ -728,7 +738,11 @@ cmd_emit_context() {
       ratelimit_5h_pct: (if $rl5h == null then null else $rl5h end),
       ratelimit_7d_pct: (if $rl7d == null then null else $rl7d end),
       ratelimit_5h_reset: (if $rl5h_reset == "" then null else $rl5h_reset end),
-      ratelimit_7d_reset: (if $rl7d_reset == "" then null else $rl7d_reset end)}')
+      ratelimit_7d_reset: (if $rl7d_reset == "" then null else $rl7d_reset end),
+      ratelimit_7d_opus_pct: (if $rl7d_opus == null then null else $rl7d_opus end),
+      ratelimit_7d_sonnet_pct: (if $rl7d_sonnet == null then null else $rl7d_sonnet end),
+      ratelimit_7d_opus_reset: (if $rl7d_opus_reset == "" then null else $rl7d_opus_reset end),
+      ratelimit_7d_sonnet_reset: (if $rl7d_sonnet_reset == "" then null else $rl7d_sonnet_reset end)}')
 
   # Build claude.* extra args for typed attributes
   local extra_args=()
@@ -740,6 +754,9 @@ cmd_emit_context() {
   # CTL-760: rate-limit % as typed attributes (numeric). Resets stay body-only.
   [[ -n "$rl5h" ]] && extra_args+=(--claude-ratelimit-5h-pct "$rl5h")
   [[ -n "$rl7d" ]] && extra_args+=(--claude-ratelimit-7d-pct "$rl7d")
+  # CTL-763: per-model 7d split. Resets stay body-only.
+  [[ -n "$rl7d_opus" ]]   && extra_args+=(--claude-ratelimit-7d-opus-pct "$rl7d_opus")
+  [[ -n "$rl7d_sonnet" ]] && extra_args+=(--claude-ratelimit-7d-sonnet-pct "$rl7d_sonnet")
 
   # Workflow/ticket lookup for trace/span derivation.
   local trow workflow ticket

--- a/plugins/dev/scripts/catalyst-statusline.sh
+++ b/plugins/dev/scripts/catalyst-statusline.sh
@@ -77,6 +77,11 @@ fi
   RL7D="$(printf '%s' "$INPUT" | jq -r '.rate_limits.seven_day.used_percentage // empty' 2>/dev/null)"
   RL5H_RESET="$(printf '%s' "$INPUT" | jq -r '.rate_limits.five_hour.resets_at // empty' 2>/dev/null)"
   RL7D_RESET="$(printf '%s' "$INPUT" | jq -r '.rate_limits.seven_day.resets_at // empty' 2>/dev/null)"
+  # CTL-763: per-model 7d split (seven_day_opus / seven_day_sonnet).
+  RL7D_OPUS="$(printf '%s' "$INPUT" | jq -r '.rate_limits.seven_day_opus.used_percentage // empty' 2>/dev/null)"
+  RL7D_SONNET="$(printf '%s' "$INPUT" | jq -r '.rate_limits.seven_day_sonnet.used_percentage // empty' 2>/dev/null)"
+  RL7D_OPUS_RESET="$(printf '%s' "$INPUT" | jq -r '.rate_limits.seven_day_opus.resets_at // empty' 2>/dev/null)"
+  RL7D_SONNET_RESET="$(printf '%s' "$INPUT" | jq -r '.rate_limits.seven_day_sonnet.resets_at // empty' 2>/dev/null)"
 
   # Without a percentage there's nothing meaningful to emit — bail.
   [[ -n "$PCT" ]] || exit 0
@@ -92,6 +97,11 @@ fi
   [[ -n "$RL7D" ]]       && ARGS+=(--ratelimit-7d-pct "$RL7D")
   [[ -n "$RL5H_RESET" ]] && ARGS+=(--ratelimit-5h-reset "$RL5H_RESET")
   [[ -n "$RL7D_RESET" ]] && ARGS+=(--ratelimit-7d-reset "$RL7D_RESET")
+  # CTL-763: per-model 7d split.
+  [[ -n "$RL7D_OPUS" ]]        && ARGS+=(--ratelimit-7d-opus-pct "$RL7D_OPUS")
+  [[ -n "$RL7D_SONNET" ]]      && ARGS+=(--ratelimit-7d-sonnet-pct "$RL7D_SONNET")
+  [[ -n "$RL7D_OPUS_RESET" ]]  && ARGS+=(--ratelimit-7d-opus-reset "$RL7D_OPUS_RESET")
+  [[ -n "$RL7D_SONNET_RESET" ]] && ARGS+=(--ratelimit-7d-sonnet-reset "$RL7D_SONNET_RESET")
 
   bash "$SESSION_BIN" "${ARGS[@]}" >/dev/null 2>&1 || true
 ) </dev/null >/dev/null 2>&1 &

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -157,6 +157,8 @@ synthesize_event_id() {
 #   --claude-turn N                claude.turn (integer)
 #   --claude-ratelimit-5h-pct N    claude.ratelimit.five_hour_pct (integer, CTL-760)
 #   --claude-ratelimit-7d-pct N    claude.ratelimit.seven_day_pct (integer, CTL-760)
+#   --claude-ratelimit-7d-opus-pct N    claude.ratelimit.seven_day_opus_pct (integer, CTL-763)
+#   --claude-ratelimit-7d-sonnet-pct N  claude.ratelimit.seven_day_sonnet_pct (integer, CTL-763)
 build_canonical_line() {
   local ts="" severity="" service="" event_name=""
   local trace_id="" span_id=""
@@ -171,6 +173,8 @@ build_canonical_line() {
   local claude_context_used_pct="" claude_context_tokens="" claude_turn=""
   # CTL-760: rate-limit 5h/7d used-percentages (numeric typed attributes).
   local claude_rl_5h="" claude_rl_7d=""
+  # CTL-763: per-model 7d split.
+  local claude_rl_7d_opus="" claude_rl_7d_sonnet=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -203,8 +207,10 @@ build_canonical_line() {
       --claude-context-used-pct)   claude_context_used_pct="$2"; shift 2 ;;
       --claude-context-tokens)     claude_context_tokens="$2"; shift 2 ;;
       --claude-turn)               claude_turn="$2"; shift 2 ;;
-      --claude-ratelimit-5h-pct)   claude_rl_5h="$2"; shift 2 ;;
-      --claude-ratelimit-7d-pct)   claude_rl_7d="$2"; shift 2 ;;
+      --claude-ratelimit-5h-pct)        claude_rl_5h="$2"; shift 2 ;;
+      --claude-ratelimit-7d-pct)        claude_rl_7d="$2"; shift 2 ;;
+      --claude-ratelimit-7d-opus-pct)   claude_rl_7d_opus="$2"; shift 2 ;;
+      --claude-ratelimit-7d-sonnet-pct) claude_rl_7d_sonnet="$2"; shift 2 ;;
       *) echo "build_canonical_line: unknown flag: $1" >&2; return 1 ;;
     esac
   done
@@ -265,6 +271,8 @@ build_canonical_line() {
     --arg claude_turn "$claude_turn" \
     --arg claude_rl_5h "$claude_rl_5h" \
     --arg claude_rl_7d "$claude_rl_7d" \
+    --arg claude_rl_7d_opus "$claude_rl_7d_opus" \
+    --arg claude_rl_7d_sonnet "$claude_rl_7d_sonnet" \
     '{
       ts: $ts,
       id: $id,
@@ -304,6 +312,8 @@ build_canonical_line() {
         + (if $claude_turn == "" then {} else { "claude.turn": ($claude_turn | tonumber) } end)
         + (if $claude_rl_5h == "" then {} else { "claude.ratelimit.five_hour_pct": ($claude_rl_5h | tonumber) } end)
         + (if $claude_rl_7d == "" then {} else { "claude.ratelimit.seven_day_pct": ($claude_rl_7d | tonumber) } end)
+        + (if $claude_rl_7d_opus   == "" then {} else { "claude.ratelimit.seven_day_opus_pct":   ($claude_rl_7d_opus   | tonumber) } end)
+        + (if $claude_rl_7d_sonnet == "" then {} else { "claude.ratelimit.seven_day_sonnet_pct": ($claude_rl_7d_sonnet | tonumber) } end)
       ),
       body: (
         (if $message == "" then {} else { message: $message } end)


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-04T14:45:00Z -->
<!-- Last updated: 2026-06-04T14:45:00Z -->
<!-- PR: #1320 -->
<!-- Previous commits: af442de4e20732fd56d7ad6c2fa966f5d053842c,a95224cdfbdb0e8e41570d285c9f1cf2832ce248,d8d68ec9d6de23fa673fbec22abc20623b1c2eb0 -->

## Summary

Adds per-model 7-day rate-limit fields (`seven_day_opus` / `seven_day_sonnet`) as separate OTEL
series through the full telemetry pipeline: statusLine stdin extraction → `emit-context` flags →
`build_canonical_line` typed attributes. The account-level `seven_day` aggregate already landed in
CTL-760; this ticket delivers the per-model split for capacity planning granularity.

## Changes Made

### OTEL canonical-event builder (`lib/canonical-event.sh`)

- Added `--claude-ratelimit-7d-opus-pct` and `--claude-ratelimit-7d-sonnet-pct` flags to
  `build_canonical_line`
- Both emit as **typed numeric** OTEL attributes (`claude.ratelimit.seven_day_opus_pct`,
  `claude.ratelimit.seven_day_sonnet_pct`) — absent when flags are not passed (no-cardinality
  guarantee)
- Same pattern as the existing `--claude-ratelimit-7d-pct` / `five_hour_pct` attributes

### `emit-context` command (`catalyst-session.sh`)

- Added `--ratelimit-7d-opus-pct`, `--ratelimit-7d-sonnet-pct`, `--ratelimit-7d-opus-reset`,
  `--ratelimit-7d-sonnet-reset` flags
- Percentages forwarded to `build_canonical_line` as typed numeric OTEL attributes
- All four fields written to `body.payload` for raw access
- Reset timestamps are body-only (not typed attributes — matches the existing 5h/7d reset
  convention; avoids label cardinality)

### `catalyst-statusline.sh` wrapper

- Extracts `rate_limits.seven_day_opus.{used_percentage,resets_at}` and
  `rate_limits.seven_day_sonnet.{used_percentage,resets_at}` from the Claude Code statusLine stdin
  payload (the same `rate_limits` object that already carries `five_hour` and `seven_day`)
- Conditionally forwards all four flags to `catalyst-session.sh emit-context`
- Safe no-op when fields are absent (statusLine payload without per-model fields)

### Tests

- **`canonical-event.test.sh`**: 8 new assertions — typed-numeric presence (opus + sonnet), absent
  when flags omitted (both models)
- **`catalyst-session-claude.test.sh`**: 8 new assertions — typed attributes + body.payload values
  for both models, reset fields body-only, reset NOT a typed attribute
- **`catalyst-statusline.test.sh`**: 5 new assertions — forwarded flags (pct + reset for both
  models), negative path (no per-model fields → no per-model flags emitted)

## How to Verify It

- [x] `bash plugins/dev/scripts/__tests__/canonical-event.test.sh` — Total: 74, Passed: 74 ✅
- [x] `bash plugins/dev/scripts/__tests__/catalyst-statusline.test.sh` — Total: 21, Passed: 21 ✅
- [x] `bash plugins/dev/scripts/__tests__/catalyst-session-claude.test.sh` — Total: 52, Passed: 52 ✅

## Changelog Entry

`feat(dev)`: Add per-model 7d rate-limit split (`seven_day_opus_pct`, `seven_day_sonnet_pct`) as
typed OTEL attributes through the full telemetry pipeline — statusLine extraction, emit-context
flags, and build_canonical_line attributes.

## Related Issues

- Implements scope item 1 of https://linear.app/rozich/issue/CTL-763
- Builds on top of https://linear.app/rozich/issue/CTL-760 (account-level 5h/7d landed there)
