### PR TITLE
feat(dev): CTL-761 emit revive/attempt count as OTEL dimensions on terminal phase events

### DIFF
--- a/plugins/dev/scripts/__tests__/canonical-event.test.sh
+++ b/plugins/dev/scripts/__tests__/canonical-event.test.sh
@@ -464,6 +464,24 @@ BAD_MATCH="$(printf '%s' "$BAD_PHASE_NAME" \
   | grep -cE '^phase\.([^.]+)\.(complete|failed)\.([A-Za-z][A-Za-z0-9_]*-[0-9]+)$' || true)"
 expect_eq "malformed phase event name does NOT match broker regex" "0" "$BAD_MATCH"
 
+# CTL-761: phase.attempt / phase.revive_count are typed int attributes
+LINE_ATT="$(build_canonical_line \
+  --ts "2026-06-05T00:00:00Z" --severity INFO \
+  --service catalyst.phase-agent --event-name "phase.implement.complete.CTL-761" \
+  --phase-attempt 2 --phase-revive-count 1)"
+ATT=$(echo "$LINE_ATT" | jq -r '.attributes["phase.attempt"]')
+RC=$(echo "$LINE_ATT" | jq -r '.attributes["phase.revive_count"]')
+expect_eq "build_canonical_line phase.attempt typed int" "2" "$ATT"
+expect_eq "build_canonical_line phase.revive_count typed int" "1" "$RC"
+TYPE=$(echo "$LINE_ATT" | jq -r '.attributes["phase.attempt"] | type')
+expect_eq "phase.attempt is a JSON number" "number" "$TYPE"
+
+LINE_BARE="$(build_canonical_line \
+  --ts "2026-06-05T00:00:00Z" --severity INFO \
+  --service catalyst.phase-agent --event-name "phase.implement.complete.CTL-761")"
+HAS=$(echo "$LINE_BARE" | jq -r '.attributes | has("phase.attempt")')
+expect_eq "phase.attempt omitted when flag absent" "false" "$HAS"
+
 echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES"
 exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -1675,6 +1675,30 @@ assert_eq \
 	"dry-run JSON settings.env carries the composed OTEL attrs"
 
 echo ""
+echo "Test 54 (CTL-761): --attempt is persisted to signal file"
+fresh_env t54
+rm -f "${WORKER_DIR}/phase-implement.json"
+mkdir -p "${TEST_DIR}/proj/thoughts/shared/plans"
+echo "# plan" >"${TEST_DIR}/proj/thoughts/shared/plans/2026-01-01-ctl-100.md"
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase implement --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		--attempt 4 >/dev/null 2>&1)
+SIGNAL_T54="${WORKER_DIR}/phase-implement.json"
+ATT_T54=$(jq -r '.attempt // empty' "$SIGNAL_T54" 2>/dev/null)
+assert_eq "4" "$ATT_T54" "signal file carries attempt=4"
+
+echo ""
+echo "Test 55 (CTL-761): default (no --attempt) → attempt=1 in signal file"
+fresh_env t55
+rm -f "${WORKER_DIR}/phase-triage.json"
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
+SIGNAL_T55="${WORKER_DIR}/phase-triage.json"
+ATT_T55=$(jq -r '.attempt // empty' "$SIGNAL_T55" 2>/dev/null)
+assert_eq "1" "$ATT_T55" "signal file defaults attempt=1"
+
+echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"
 if [[ $FAILURES -gt 0 ]]; then

--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -437,6 +437,48 @@ HAS_DURATION=$(echo "$LINE" | jq -r '.body.payload | has("duration_seconds")')
 assert_eq "false" "$HAS_DURATION" "duration_seconds omitted when startedAt/completedAt absent"
 
 echo ""
+echo "Test 25 (CTL-761): phase.attempt / phase.revive_count attributes from signal"
+fresh_env t25
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"implement","attempt":3}' >"$SIGNAL"
+"$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status complete >/dev/null 2>&1
+LINE=$(read_event_line)
+ATT=$(echo "$LINE" | jq -r '.attributes["phase.attempt"] // empty')
+RC=$(echo "$LINE" | jq -r '.attributes["phase.revive_count"] // empty')
+assert_eq "3" "$ATT" "attributes[\"phase.attempt\"] = 3 from signal"
+assert_eq "2" "$RC" "attributes[\"phase.revive_count\"] = attempt-1 = 2"
+
+echo ""
+echo "Test 26 (CTL-761): cold dispatch attempt=1 → revive_count=0"
+fresh_env t26
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-triage.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"triage","attempt":1}' >"$SIGNAL"
+"$EMIT_SCRIPT" --phase triage --ticket CTL-100 --status complete >/dev/null 2>&1
+LINE=$(read_event_line)
+assert_eq "1" "$(echo "$LINE" | jq -r '.attributes["phase.attempt"]')" "attempt=1"
+assert_eq "0" "$(echo "$LINE" | jq -r '.attributes["phase.revive_count"]')" "revive_count clamped to 0"
+
+echo ""
+echo "Test 27 (CTL-761): attributes omitted when signal lacks attempt"
+fresh_env t27
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"implement"}' >"$SIGNAL"
+"$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status complete >/dev/null 2>&1
+LINE=$(read_event_line)
+assert_eq "false" "$(echo "$LINE" | jq -r '.attributes | has("phase.attempt")')" "phase.attempt omitted"
+assert_eq "false" "$(echo "$LINE" | jq -r '.attributes | has("phase.revive_count")')" "phase.revive_count omitted"
+
+echo ""
+echo "Test 28 (CTL-761): failed status also carries attempt/revive_count"
+fresh_env t28
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"implement","attempt":2}' >"$SIGNAL"
+"$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status failed --reason "test_reason" >/dev/null 2>&1
+LINE=$(read_event_line)
+assert_eq "2" "$(echo "$LINE" | jq -r '.attributes["phase.attempt"]')" "failed path: phase.attempt=2"
+assert_eq "1" "$(echo "$LINE" | jq -r '.attributes["phase.revive_count"]')" "failed path: revive_count=1"
+
+echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"
 if [[ $FAILURES -gt 0 ]]; then

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -53,11 +53,12 @@ function defaultResolveProject(ticket) {
 // when null/undefined → today's fresh-start behaviour. `spawn` is injectable so
 // the unit test can assert the built arg array without a real spawn.
 export function defaultRunPhaseAgent(
-  { orchDir, ticket, phase, worktreePath, resumeSession, handoffPath },
+  { orchDir, ticket, phase, worktreePath, resumeSession, handoffPath, attempt },
   { spawn = spawnSync } = {},
 ) {
   const args = ["--phase", phase, "--ticket", ticket, "--orch-dir", orchDir, "--orch-id", ticket];
   if (resumeSession) args.push("--resume-session", resumeSession);
+  if (attempt != null) args.push("--attempt", String(attempt)); // CTL-761
   const extraEnv = {};
   if (handoffPath) extraEnv.CATALYST_HANDOFF_PATH = handoffPath;
   const res = spawn(PHASE_AGENT_DISPATCH_BIN, args, {
@@ -94,7 +95,7 @@ export function defaultRunPhaseAgent(
 // verbatim to runPhaseAgent so the spawned phase-agent-dispatch carries
 // `--resume-session`. Absent on every cold dispatch — only the revive path sets it.
 export function defaultDispatch(
-  { orchDir, ticket, phase, expectedWorktreePath, resumeSession, handoffPath },
+  { orchDir, ticket, phase, expectedWorktreePath, resumeSession, handoffPath, attempt },
   {
     resolveProject = defaultResolveProject,
     createWorktree = defaultCreateWorktree,
@@ -128,7 +129,7 @@ export function defaultDispatch(
       worktreePath: wt.worktreePath,
     };
   }
-  const res = runPhaseAgent({ orchDir, ticket, phase, worktreePath: wt.worktreePath, resumeSession, handoffPath });
+  const res = runPhaseAgent({ orchDir, ticket, phase, worktreePath: wt.worktreePath, resumeSession, handoffPath, attempt }); // CTL-761
   return { ...res, worktreePath: wt.worktreePath };
 }
 
@@ -138,10 +139,11 @@ export function defaultDispatch(
 // green because the key is not added when the value is falsy.
 export function dispatchTicket(
   orchDir, ticket, phase,
-  { dispatch = defaultDispatch, resumeSession, handoffPath } = {},
+  { dispatch = defaultDispatch, resumeSession, handoffPath, attempt } = {},
 ) {
   const args = { orchDir, ticket, phase };
   if (resumeSession) args.resumeSession = resumeSession;
   if (handoffPath) args.handoffPath = handoffPath;
+  if (attempt != null) args.attempt = attempt; // CTL-761
   return dispatch(args);
 }

--- a/plugins/dev/scripts/execution-core/dispatch.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.test.mjs
@@ -367,3 +367,84 @@ describe("defaultDispatch — handoffPath passthrough (CTL-549)", () => {
     expect(s.calls[0].handoffPath).toBeUndefined();
   });
 });
+
+// CTL-761: attempt thread-through (dispatch ordinal for revive observability)
+describe("defaultRunPhaseAgent — attempt arg (CTL-761)", () => {
+  const spy = () => {
+    const calls = [];
+    const spawn = (bin, args, opts) => {
+      calls.push({ bin, args, opts });
+      return { status: 0, stdout: "ok", stderr: "" };
+    };
+    spawn.calls = calls;
+    return spawn;
+  };
+
+  test("forwards --attempt to phase-agent-dispatch when provided", () => {
+    const spawn = spy();
+    defaultRunPhaseAgent(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "implement", worktreePath: "/wt/CTL-1", attempt: 2 },
+      { spawn },
+    );
+    const { args } = spawn.calls[0];
+    expect(args).toContain("--attempt");
+    expect(args[args.indexOf("--attempt") + 1]).toBe("2");
+  });
+
+  test("backward compat: no attempt → no --attempt flag (exact arg array)", () => {
+    const spawn = spy();
+    defaultRunPhaseAgent(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "implement", worktreePath: "/wt/CTL-1" },
+      { spawn },
+    );
+    const { args } = spawn.calls[0];
+    expect(args).not.toContain("--attempt");
+    expect(args).toEqual(["--phase", "implement", "--ticket", "CTL-1", "--orch-dir", "/ec", "--orch-id", "CTL-1"]);
+  });
+});
+
+describe("defaultDispatch — attempt passthrough (CTL-761)", () => {
+  const seams = () => {
+    const calls = [];
+    return {
+      resolveProject: () => ({ repoRoot: "/repo" }),
+      createWorktree: () => ({ code: 0, worktreePath: "/wt/CTL-1" }),
+      runPhaseAgent: (args) => { calls.push(args); return { code: 0 }; },
+      calls,
+    };
+  };
+
+  test("forwards attempt to runPhaseAgent when provided", () => {
+    const s = seams();
+    defaultDispatch(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "plan", attempt: 3 },
+      { resolveProject: s.resolveProject, createWorktree: s.createWorktree, runPhaseAgent: s.runPhaseAgent },
+    );
+    expect(s.calls[0].attempt).toBe(3);
+  });
+
+  test("attempt is undefined on a cold dispatch (no attempt)", () => {
+    const s = seams();
+    defaultDispatch(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "implement" },
+      { resolveProject: s.resolveProject, createWorktree: s.createWorktree, runPhaseAgent: s.runPhaseAgent },
+    );
+    expect(s.calls[0].attempt).toBeUndefined();
+  });
+});
+
+describe("dispatchTicket — attempt thread-through (CTL-761)", () => {
+  test("backward compat: no attempt → dispatch receives no attempt key", () => {
+    const calls = [];
+    const dispatch = (a) => { calls.push(a); return { code: 0 }; };
+    dispatchTicket("/orch", "CTL-1", "triage", { dispatch });
+    expect("attempt" in calls[0]).toBe(false);
+  });
+
+  test("forwards attempt to dispatch when provided", () => {
+    const calls = [];
+    const dispatch = (a) => { calls.push(a); return { code: 0 }; };
+    dispatchTicket("/orch", "CTL-1", "implement", { dispatch, attempt: 2 });
+    expect(calls[0].attempt).toBe(2);
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -781,7 +781,7 @@ export function defaultAppendAutotuneGaugeEvent({
 // outer `reviveDispatch` would otherwise leave the signal-reset logic — the
 // load-bearing half — uncovered).
 export function defaultReviveDispatch(
-  { orchDir, ticket, phase, resumeSession },
+  { orchDir, ticket, phase, resumeSession, attempt },
   {
     dispatch = defaultDispatch,
     // CTL-660: success-path lifecycle emitters, injectable for tests. Default
@@ -834,6 +834,7 @@ export function defaultReviveDispatch(
   // spawns `claude --bg --resume <uuid>`. Only present on the resume path; a
   // cold/unresumable revive omits it and falls through to a fresh dispatch.
   if (resumeSession) dispatchArgs.resumeSession = resumeSession;
+  if (attempt != null) dispatchArgs.attempt = attempt; // CTL-761
   // CTL-660: record the revive DECISION before the spawn (reason="revive"),
   // then the verified launch after a clean dispatch. Both best-effort — the
   // default emitters swallow IO errors (appendEnvelopeBestEffort); the revive
@@ -1823,7 +1824,10 @@ export function reclaimDeadWorkIfPossible(
     });
     return "revive-suppressed";
   }
-  const dispatchRes = reviveDispatch({ orchDir, ticket, phase, resumeSession });
+  // CTL-761: forward the DISPATCH ordinal (= revive ordinal + 1; cold=1, first
+  // revive=2) so the revived worker's terminal event carries phase.attempt /
+  // phase.revive_count. `attempt` here is the revive ordinal (priorRevives+1).
+  const dispatchRes = reviveDispatch({ orchDir, ticket, phase, resumeSession, attempt: attempt + 1 });
   if (dispatchRes.code === 0) {
     writeReviveMarker({ orchDir, ticket, attempt });
     log.info({ ticket, phase, attempt }, "ctl-587: revived");

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -1814,6 +1814,23 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     // resumeSession is null on the dispatch (the fresh-start path).
     expect(s.opts.reviveDispatch.calls[0][0].resumeSession).toBeNull();
   });
+
+  // CTL-761: attempt is the DISPATCH ordinal (revive ordinal + 1), so the
+  // revived worker's signal.attempt carries a value > 1 → revive_count > 0.
+  test("CTL-761: first revive (priorRevives=0) forwards attempt=2 (dispatch ordinal) to reviveDispatch", () => {
+    const s = setupReviveScenario({ reviveCount: 0 });
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(s.opts.reviveDispatch.calls.length).toBe(1);
+    // revive ordinal = 0+1=1; dispatch ordinal = 1+1=2
+    expect(s.opts.reviveDispatch.calls[0][0].attempt).toBe(2);
+  });
+
+  test("CTL-761: second revive (priorRevives=1) forwards attempt=3 to reviveDispatch", () => {
+    const s = setupReviveScenario({ reviveCount: 1 });
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    // revive ordinal = 1+1=2; dispatch ordinal = 2+1=3
+    expect(s.opts.reviveDispatch.calls[0][0].attempt).toBe(3);
+  });
 });
 
 // --- CTL-736 Phase 3: the progress gate (revive-while-progressing vs stop) -----
@@ -3374,5 +3391,48 @@ describe("reclaimDeadWorkIfPossible — CTL-755 dead-triage reclaim (gate is dow
     });
     expect(r).toBe("reclaimed");
     expect(emit.calls.length).toBe(1); // mid-pipeline reclaim proceeds
+  });
+});
+
+
+describe("defaultReviveDispatch — CTL-761 attempt passthrough", () => {
+  let orchDir;
+  let prevCatalystDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "ctl761-revdisp-"));
+    prevCatalystDir = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = orchDir;
+    mkdirSync(join(orchDir, "events"), { recursive: true });
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  function seed(ticket, phase, body) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify({ ticket, phase, ...body }));
+  }
+
+  test("attempt is forwarded to dispatch when set", () => {
+    seed("CTL-761A", "implement", { status: "running", bg_job_id: "bg-a" });
+    const dispatch = recorder({ code: 0 });
+    defaultReviveDispatch(
+      { orchDir, ticket: "CTL-761A", phase: "implement", attempt: 2 },
+      { dispatch },
+    );
+    expect(dispatch.calls[0][0].attempt).toBe(2);
+  });
+
+  test("attempt absent → dispatch called without the key", () => {
+    seed("CTL-761B", "implement", { status: "running", bg_job_id: "bg-b" });
+    const dispatch = recorder({ code: 0 });
+    defaultReviveDispatch(
+      { orchDir, ticket: "CTL-761B", phase: "implement" },
+      { dispatch },
+    );
+    expect("attempt" in dispatch.calls[0][0]).toBe(false);
   });
 });

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -159,6 +159,8 @@ synthesize_event_id() {
 #   --claude-ratelimit-7d-pct N    claude.ratelimit.seven_day_pct (integer, CTL-760)
 #   --claude-ratelimit-7d-opus-pct N    claude.ratelimit.seven_day_opus_pct (integer, CTL-763)
 #   --claude-ratelimit-7d-sonnet-pct N  claude.ratelimit.seven_day_sonnet_pct (integer, CTL-763)
+#   --phase-attempt N        phase.attempt (integer, CTL-761)
+#   --phase-revive-count N   phase.revive_count (integer, CTL-761)
 build_canonical_line() {
   local ts="" severity="" service="" event_name=""
   local trace_id="" span_id=""
@@ -175,6 +177,8 @@ build_canonical_line() {
   local claude_rl_5h="" claude_rl_7d=""
   # CTL-763: per-model 7d split.
   local claude_rl_7d_opus="" claude_rl_7d_sonnet=""
+  # CTL-761: dispatch attempt + revive count (typed int attributes).
+  local phase_attempt="" phase_revive_count=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -211,6 +215,8 @@ build_canonical_line() {
       --claude-ratelimit-7d-pct)        claude_rl_7d="$2"; shift 2 ;;
       --claude-ratelimit-7d-opus-pct)   claude_rl_7d_opus="$2"; shift 2 ;;
       --claude-ratelimit-7d-sonnet-pct) claude_rl_7d_sonnet="$2"; shift 2 ;;
+      --phase-attempt)       phase_attempt="$2"; shift 2 ;;
+      --phase-revive-count)  phase_revive_count="$2"; shift 2 ;;
       *) echo "build_canonical_line: unknown flag: $1" >&2; return 1 ;;
     esac
   done
@@ -273,6 +279,8 @@ build_canonical_line() {
     --arg claude_rl_7d "$claude_rl_7d" \
     --arg claude_rl_7d_opus "$claude_rl_7d_opus" \
     --arg claude_rl_7d_sonnet "$claude_rl_7d_sonnet" \
+    --arg phase_attempt "$phase_attempt" \
+    --arg phase_revive_count "$phase_revive_count" \
     '{
       ts: $ts,
       id: $id,
@@ -314,6 +322,8 @@ build_canonical_line() {
         + (if $claude_rl_7d == "" then {} else { "claude.ratelimit.seven_day_pct": ($claude_rl_7d | tonumber) } end)
         + (if $claude_rl_7d_opus   == "" then {} else { "claude.ratelimit.seven_day_opus_pct":   ($claude_rl_7d_opus   | tonumber) } end)
         + (if $claude_rl_7d_sonnet == "" then {} else { "claude.ratelimit.seven_day_sonnet_pct": ($claude_rl_7d_sonnet | tonumber) } end)
+        + (if $phase_attempt == "" then {} else { "phase.attempt": ($phase_attempt | tonumber) } end)
+        + (if $phase_revive_count == "" then {} else { "phase.revive_count": ($phase_revive_count | tonumber) } end)
       ),
       body: (
         (if $message == "" then {} else { message: $message } end)

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -595,9 +595,10 @@ jq -nc \
 	--arg ts "$TS" \
 	--arg wt "$WORKTREE_PATH_RESOLVED" \
 	--argjson generation "$GENERATION" \
+	--argjson attempt "$ATTEMPT" \
 	'{ticket: $ticket, phase: $phase, orchestrator: $orch, model: $model,
     turnCap: $turnCap, status: "dispatched", bg_job_id: null,
-    worktreePath: $wt, generation: $generation,
+    worktreePath: $wt, generation: $generation, attempt: $attempt,
     startedAt: $ts, updatedAt: $ts}' >"$SIGNAL_FILE" ||
 	die "failed to write signal file $SIGNAL_FILE"
 

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -236,6 +236,24 @@ if [[ -n $ORCH_DIR ]]; then
 	fi
 fi
 
+# CTL-761: read the dispatch attempt from the signal file and derive
+# revive_count = attempt - 1. Emitted as typed canonical attributes (not
+# body.payload, which otel-forward strips — otlp.ts:33) so Grafana/Loki can
+# query "what attempt completed this phase, and how many revives?"
+PHASE_ATTEMPT=""
+PHASE_REVIVE_COUNT=""
+if [[ -n $ORCH_DIR ]]; then
+	_ATT_SIGNAL="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+	if [[ -f $_ATT_SIGNAL ]] && command -v jq >/dev/null 2>&1; then
+		_ATTEMPT=$(jq -r '.attempt // empty' "$_ATT_SIGNAL" 2>/dev/null || echo "")
+		if [[ $_ATTEMPT =~ ^[0-9]+$ ]]; then
+			PHASE_ATTEMPT="$_ATTEMPT"
+			_RC=$((_ATTEMPT - 1)); [[ $_RC -lt 0 ]] && _RC=0
+			PHASE_REVIVE_COUNT="$_RC"
+		fi
+	fi
+fi
+
 # Payload mirrors what orchestrator monitors expect: phase, ticket, status,
 # optional failure_reason, optional handoff_path (CTL-484 turn-cap-exhausted),
 # optional duration_seconds (CTL-760). The broker's tryPhaseLifecycleRoute parser
@@ -270,6 +288,8 @@ LINE=$(build_canonical_line \
 	--catalyst-orchestration "$ORCH_ID" \
 	--message "Phase ${PHASE} ${STATUS} on ${TICKET}" \
 	--payload-json "$PAYLOAD" \
+	--phase-attempt "$PHASE_ATTEMPT" \
+	--phase-revive-count "$PHASE_REVIVE_COUNT" \
 	2>/dev/null) || warn "failed to build canonical event line"
 
 if [[ -n $LINE ]]; then


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-05T05:50:00Z -->
<!-- Last updated: 2026-06-05T05:50:00Z -->
<!-- PR: #1321 -->
<!-- Previous commits: bdbb2568 -->

## Summary

Adds `phase.attempt` and `phase.revive_count` as typed integer OTEL attributes on terminal phase events (`phase.<name>.complete.<ticket>` and `phase.<name>.failed.<ticket>`). Previously, knowing how many times a (ticket, phase) pair was revived required a post-hoc scan of `~/catalyst/events/*.jsonl`; after this change, the values are queryable directly in Grafana/Loki.

**How it works:**

1. `phase-agent-dispatch` accepts a new `--attempt` flag and writes `attempt` into the signal file.
2. `phase-agent-emit-complete` reads `signal.attempt`, derives `revive_count = attempt - 1`, and passes both to `build_canonical_line` as `--phase-attempt` / `--phase-revive-count`.
3. `build_canonical_line` in `canonical-event.sh` emits them as typed integers (via `tonumber`) in the `attributes` map — not in `body.payload`, which `otel-forward` strips at the OTLP boundary.
4. The dispatch ordinal flows through the call chain: `reclaimDeadWorkIfPossible → reviveDispatch → defaultDispatch → defaultRunPhaseAgent → phase-agent-dispatch --attempt N`, where `N = priorRevives + 1 + 1` (revive ordinal + 1 = dispatch ordinal).

## Changes Made

### Execution-core / dispatch (`dispatch.mjs`)

- `defaultRunPhaseAgent`, `defaultDispatch`, `dispatchTicket` each accept an optional `attempt` parameter and forward it to `phase-agent-dispatch` as `--attempt N`.
- Cold dispatches omit the flag (backward-compatible); only the revive path supplies it.

### Execution-core / recovery (`recovery.mjs`)

- `defaultReviveDispatch` accepts and forwards `attempt` to `defaultDispatch`.
- `reclaimDeadWorkIfPossible` computes `attempt: attempt + 1` (dispatch ordinal = revive ordinal + 1) and passes it to `reviveDispatch`.

### Shell scripts

- **`phase-agent-dispatch`**: parses `--attempt` flag, defaults to `1` when absent, writes `attempt` into the signal JSON.
- **`phase-agent-emit-complete`**: reads `signal.attempt`, derives `revive_count`, forwards both to `build_canonical_line`.
- **`canonical-event.sh` (`build_canonical_line`)**: adds `--phase-attempt` / `--phase-revive-count` flags; emits as `phase.attempt` / `phase.revive_count` typed integers in `attributes`.

## How to Verify It

- [x] `bun test plugins/dev/scripts/execution-core/dispatch.test.mjs` — 5 new tests covering attempt forwarding at every dispatch layer
- [x] `bun test plugins/dev/scripts/execution-core/recovery.test.mjs` — 4 new tests covering first and second revive forwarding, `defaultReviveDispatch` passthrough
- [x] `bash plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh` — tests 54-55: signal file carries `attempt=4` and defaults to `attempt=1`
- [x] `bash plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh` — tests 25-28: attribute values correct for attempt=3, cold dispatch, absent signal, failed path
- [x] `bash plugins/dev/scripts/__tests__/canonical-event.test.sh` — typed int verification and omit-when-absent
- [x] All verify gates passed: tests, lint (shellcheck 0 new findings), security, coverage, merge-conflict clean

## Acceptance Criteria

- [x] A Grafana/Loki query on `attributes["phase.attempt"]` and `attributes["phase.revive_count"]` returns values for (ticket, phase) terminal events.
- [x] No new high-cardinality resource labels introduced — values are small integers in `attributes`.
- [x] Tests cover emission on a simulated revive (recovery.test.mjs CTL-761 suite).

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-761
