### PR TITLE
fix(dev): CTL-623 residual — describe-pr sibling-ref prose + ci-describe-pr body_file fix

### DIFF
--- a/plugins/dev/skills/ci-describe-pr/SKILL.md
+++ b/plugins/dev/skills/ci-describe-pr/SKILL.md
@@ -82,8 +82,10 @@ handled mechanically by the guard block appended at write-back time (step 6).
 ### 6. Save and Update
 
 ```bash
+body_file="thoughts/shared/prs/${PR_NUMBER}_description.md"
+
 # Save to thoughts
-cat > "thoughts/shared/prs/${PR_NUMBER}_description.md" <<EOF
+cat > "$body_file" <<EOF
 [Generated description]
 EOF
 
@@ -110,7 +112,7 @@ humanlayer thoughts sync
 
 # Update PR on GitHub
 gh pr edit $PR_NUMBER --title "$new_title"
-gh pr edit $PR_NUMBER --body-file "thoughts/shared/prs/${PR_NUMBER}_description.md"
+gh pr edit $PR_NUMBER --body-file "$body_file"
 ```
 
 ### 7. Update Linear (if ticket found)

--- a/plugins/dev/skills/describe-pr/SKILL.md
+++ b/plugins/dev/skills/describe-pr/SKILL.md
@@ -225,8 +225,17 @@ If ticket found:
 ## Related Issues/PRs
 
 - Fixes https://linear.app/{workspace}/issue/{ticket}
-- Related to [any other linked issues]
+- Related to #NNN (reference sibling work by its **GitHub PR number**)
 ```
+
+**CTL-623 — sibling reference format (REQUIRED):** When referencing related/sibling
+work in prose, reference it by its **GitHub PR number (`#NNN`)**, never by a bare
+Linear token (`TEAM-NNN`) or a Linear issue URL. A bare sibling `TEAM-NNN` token in the
+body is auto-linked by Linear's GitHub integration and drags that sibling's workflow
+status (Done → Implement) on PR open/merge. Do **not** emit bare sibling Linear tokens
+in prose. The own ticket's `Fixes https://linear.app/...` line is correct and stays —
+that link/transition is intended. Sibling neutralization is handled mechanically by the
+guard block appended at write-back time (see below).
 
 Get Linear ticket details using the Linearis CLI (run `linearis issues usage` for read syntax).
 Extract title and description with jq. Use ticket title and description for context.


### PR DESCRIPTION
**Reduced to its residual after #1323 (CTL-633) landed.** CTL-633 was authored on top of CTL-623 and subsumed the helper (`lib/linear-pr-skip.sh`), the team-key allowlist, both test suites, and create-pr wiring — all already on main. This PR was reset to main and now carries only CTL-623's **two net-new deltas**:

1. `describe-pr/SKILL.md` (region 1) — the author-facing sibling-reference prose: `- Related to #NNN (by GitHub PR number)` + the 'sibling reference format (REQUIRED)' paragraph. CTL-633 left region 1 untouched.
2. `ci-describe-pr/SKILL.md` — **fixes a latent bug CTL-633 shipped**: its step-6 block referenced `$body_file` without ever defining it. Adds the `body_file=…` definition + path substitutions.

Diff is exactly these 2 files (+14/-3). Tests: linear-pr-skip 21/21, pr-body-sibling-skip 14/14. Independently verified: no CTL-633 regression, describe-pr region-2 bash block intact, body_file defined before use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)