### PR TITLE
CTL-633: fix linear-pr-skip token fabrication — mode-aware branch/body scanning + team-key allowlist

### DIFF
--- a/plugins/dev/scripts/__tests__/linear-pr-skip-zsh.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-pr-skip-zsh.test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# CTL-633 phase-review regression: linear-pr-skip.sh must work when SOURCED
+# under zsh, because the Catalyst Bash tool runs /bin/zsh — that is the real
+# production runtime for the create-pr/describe-pr/ci-describe-pr producers.
+#
+# The original helper resolved its sibling-lib dir via ${BASH_SOURCE[0]} (unset
+# in zsh ⇒ collapsed to CWD ⇒ team-keys lib never sourced) and guarded the
+# filter with `declare -F` (returns SUCCESS for an absent function in zsh ⇒
+# called a missing command ⇒ the whole pipe emitted EMPTY output with exit 0).
+# Net effect: the sibling-skip guard was SILENTLY nullified under zsh while all
+# bash-shebang suites stayed green. This suite exercises the helper through
+# `zsh -c` so the harness catches that class of regression.
+#
+# The harness itself runs under bash (run-tests.sh invokes via `bash "$f"`); the
+# assertions shell out to zsh to test the runtime shell.
+#
+# Run: bash plugins/dev/scripts/__tests__/linear-pr-skip-zsh.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../lib/linear-pr-skip.sh"
+# Mirror the producers: they source via "${CLAUDE_PLUGIN_ROOT}/scripts/lib/...".
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+FAILURES=0
+PASSES=0
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	[ $# -ge 2 ] && echo "    $2"
+}
+
+if ! command -v zsh >/dev/null 2>&1; then
+	echo "zsh not available — skipping zsh runtime regression suite (no-op)."
+	echo "PASSES=0 FAILURES=0"
+	exit 0
+fi
+
+# Run a snippet under zsh from an UNRELATED cwd (/tmp) so a BASH_SOURCE-relative
+# resolver would collapse to /tmp — the exact failure geometry of finding #1.
+run_zsh() {
+	local plugin_root="$1" snippet="$2"
+	if [[ -n "$plugin_root" ]]; then
+		zsh -c "cd /tmp; export CLAUDE_PLUGIN_ROOT='$plugin_root'; source '$HELPER'; $snippet" 2>&1
+	else
+		zsh -c "cd /tmp; unset CLAUDE_PLUGIN_ROOT; source '$HELPER'; $snippet" 2>&1
+	fi
+}
+
+# Sandbox the team-key cache so a real workstation's allowlist can't skew us.
+TK_SANDBOX="$(mktemp -d)"
+mkdir -p "$TK_SANDBOX/catalyst"
+export XDG_CONFIG_HOME="$TK_SANDBOX"
+trap 'rm -rf "$TK_SANDBOX"' EXIT
+
+# ─── Case 1: branch mode under zsh (CLAUDE_PLUGIN_ROOT anchor) ─────────────────
+echo "Test: branch mode emits sibling skips when sourced under zsh"
+out="$(run_zsh "$PLUGIN_ROOT" \
+	'linear_sibling_skip_block_from_branch ADV-1155 "o-adv-1155-1156-1157-ADV-1155"')"
+if grep -q '^skip ADV-1156$' <<<"$out" \
+	&& grep -q '^skip ADV-1157$' <<<"$out" \
+	&& ! grep -q '^skip ADV-1155$' <<<"$out" \
+	&& ! grep -qi 'command not found' <<<"$out"; then
+	pass "zsh branch mode: skip ADV-1156/1157 emitted (own excluded), no command-not-found"
+else
+	fail "zsh branch mode emits sibling skips" "got: $out"
+fi
+
+# ─── Case 2: body mode under zsh ──────────────────────────────────────────────
+echo "Test: body mode emits canonical token when sourced under zsh"
+out="$(run_zsh "$PLUGIN_ROOT" \
+	'linear_sibling_skip_block_from_body CTL-633 "see ENG-50, released 2026-05-25, oauth2 utf8 abc123"')"
+if grep -q '^skip ENG-50$' <<<"$out" \
+	&& ! grep -q '^skip UTF-' <<<"$out" \
+	&& ! grep -q '^skip OAUTH-' <<<"$out" \
+	&& ! grep -qi 'command not found' <<<"$out"; then
+	pass "zsh body mode: canonical ENG-50 emitted, prose did not fabricate"
+else
+	fail "zsh body mode emits canonical token" "got: $out"
+fi
+
+# ─── Case 3: allowlist filter actually applies under zsh ──────────────────────
+# With CLAUDE_PLUGIN_ROOT set, the team-keys lib IS sourced, so a populated
+# allowlist must drop a non-allowlisted prefix (proves the filter ran, not the
+# fail-open passthrough).
+echo "Test: populated allowlist filters under zsh (lib was sourced)"
+printf '{"keys":["ADV"]}\n' >"$TK_SANDBOX/catalyst/linear-team-keys.json"
+out="$(run_zsh "$PLUGIN_ROOT" \
+	'linear_sibling_skip_block_from_body CTL-633 "see ENG-50 and ADV-200"')"
+if grep -q '^skip ADV-200$' <<<"$out" && ! grep -q '^skip ENG-50$' <<<"$out"; then
+	pass "zsh: allowlist applied (ADV-200 kept, ENG-50 dropped) — lib was sourced"
+else
+	fail "zsh: allowlist applied" "got: $out"
+fi
+rm -f "$TK_SANDBOX/catalyst/linear-team-keys.json"
+
+# ─── Case 4: fail-open path under zsh (no CLAUDE_PLUGIN_ROOT) ──────────────────
+# The lib cannot be resolved (no anchor), so the filter must fall back to `cat`
+# rather than dropping all output. This is the `command -v` guard's job.
+echo "Test: fail-open passthrough under zsh when lib cannot be resolved"
+out="$(run_zsh "" \
+	'linear_sibling_skip_block_from_branch ADV-1155 "o-adv-1155-1156-1157-ADV-1155"')"
+if grep -q '^skip ADV-1156$' <<<"$out" \
+	&& grep -q '^skip ADV-1157$' <<<"$out" \
+	&& ! grep -qi 'command not found' <<<"$out"; then
+	pass "zsh fail-open: skips still emitted via cat fallback, no command-not-found"
+else
+	fail "zsh fail-open passthrough emits skips" "got: $out"
+fi
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "─────────────────────────────────────────"
+echo "PASSES=$PASSES FAILURES=$FAILURES"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/linear-pr-skip.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-pr-skip.test.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# CTL-623: unit tests for the linear-pr-skip sibling-guard helper.
+# The helper emits Linear `skip <ID>` guard lines for every foreign ticket
+# token found in the supplied text (branch name, PR body, …), so Linear's
+# GitHub integration does not auto-link sibling tickets and drag their status.
+# Run: bash plugins/dev/scripts/__tests__/linear-pr-skip.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../lib/linear-pr-skip.sh"
+
+FAILURES=0
+PASSES=0
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	[ $# -ge 2 ] && echo "    $2"
+}
+
+if [[ ! -f "$HELPER" ]]; then
+	fail "helper exists at lib/linear-pr-skip.sh"
+	echo ""
+	echo "PASSES=$PASSES FAILURES=$FAILURES"
+	exit 1
+fi
+# shellcheck source=/dev/null
+source "$HELPER"
+
+# ─── Case A: multi-ticket phase-agents/legacy branch → siblings, own excluded ──
+echo "▶ Case A: multi-ticket branch emits siblings, excludes own"
+out=$(linear_sibling_skip_block "ADV-1155" "o-adv-1155-1156-1157-ADV-1155")
+if grep -q "skip ADV-1156" <<<"$out" && grep -q "skip ADV-1157" <<<"$out" &&
+	! grep -q "skip ADV-1155" <<<"$out"; then
+	pass "A: siblings ADV-1156/ADV-1157 present, own ADV-1155 excluded"
+else
+	fail "A: siblings present and own excluded" "got: $out"
+fi
+
+# ─── Case B: single-ticket branch (own only) → empty output (no-op) ────────────
+echo "▶ Case B: single-ticket branch is a no-op"
+out=$(linear_sibling_skip_block "CTL-623" "CTL-623")
+if [[ -z "$out" ]]; then
+	pass "B: empty output for own-ticket-only branch"
+else
+	fail "B: empty output for own-ticket-only branch" "got: $out"
+fi
+
+# ─── Case C: dedup — same sibling repeated in branch + body emits once ─────────
+echo "▶ Case C: dedup repeated sibling across args"
+out=$(linear_sibling_skip_block "ADV-1155" "o-adv-1155-1156-ADV-1155" "builds on ADV-1156")
+count=$(grep -c "skip ADV-1156" <<<"$out")
+if [[ "$count" -eq 1 ]]; then
+	pass "C: ADV-1156 emitted exactly once"
+else
+	fail "C: ADV-1156 emitted exactly once" "count=$count out: $out"
+fi
+
+# ─── Case D: case normalization — lowercase branch tokens → canonical UPPER ────
+echo "▶ Case D: lowercase tokens normalize to uppercase"
+out=$(linear_sibling_skip_block "ADV-1155" "o-adv-1155-1156-1157-ADV-1155")
+if grep -q "skip ADV-1156" <<<"$out" && ! grep -q "skip adv-1156" <<<"$out"; then
+	pass "D: lowercase adv-1156 normalized to ADV-1156"
+else
+	fail "D: lowercase adv-1156 normalized to ADV-1156" "got: $out"
+fi
+
+# ─── Case E: mixed-team slug → both foreign teams captured ─────────────────────
+echo "▶ Case E: mixed-team slug captures foreign team"
+out=$(linear_sibling_skip_block "ADV-1155" "o-adv-1155-ctl-200-ADV-1155")
+if grep -q "skip CTL-200" <<<"$out" && ! grep -q "skip ADV-1155" <<<"$out"; then
+	pass "E: foreign CTL-200 captured, own ADV-1155 excluded"
+else
+	fail "E: foreign CTL-200 captured, own ADV-1155 excluded" "got: $out"
+fi
+
+# ─── Case F: guard block carries the HTML comment marker ───────────────────────
+echo "▶ Case F: output begins with the HTML comment guard marker"
+out=$(linear_sibling_skip_block "ADV-1155" "o-adv-1155-1156-1157-ADV-1155")
+first_line=$(head -1 <<<"$out")
+if [[ "$first_line" == "<!-- Linear automation guard"* ]]; then
+	pass "F: output begins with '<!-- Linear automation guard'"
+else
+	fail "F: output begins with '<!-- Linear automation guard'" "first line: $first_line"
+fi
+
+# ─── Case G: GitHub PR-number prose (#NNN) must NOT fabricate skip tokens ───────
+# The plan's Phase-2 contract references siblings by GitHub PR number (#NNN),
+# never bare Linear tokens. Bare numbers separated from words by whitespace/'#'
+# must not be reattributed to a fake team prefix.
+echo "▶ Case G: '#NNN' PR-number prose produces no skip lines"
+out=$(linear_sibling_skip_block "CTL-623" "CTL-623" "see PR #890 and #892")
+if [[ -z "$out" ]]; then
+	pass "G: '#890 / #892' prose is a no-op"
+else
+	fail "G: '#890 / #892' prose is a no-op" "got: $out"
+fi
+
+# ─── Case H: explicit foreign TEAM-NNN token in body prose is still captured ───
+echo "▶ Case H: explicit foreign token in prose is captured"
+out=$(linear_sibling_skip_block "CTL-623" "CTL-623" "relates to ENG-50")
+if grep -q "skip ENG-50" <<<"$out"; then
+	pass "H: explicit ENG-50 captured from prose"
+else
+	fail "H: explicit ENG-50 captured from prose" "got: $out"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CTL-633: scope-split adversarial cases (I–T). Tests the new
+# linear_foreign_tokens_from_branch / _from_body and their wrapper
+# linear_sibling_skip_block_from_branch / _from_body APIs. Cases A–H above
+# remain unchanged — they exercise the back-compat default-branch-mode shim.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Sandbox helper: every body-mode case that touches the allowlist needs its
+# own XDG_CONFIG_HOME so the real ~/.config/catalyst/linear-team-keys.json
+# (which may exist on a real workstation) cannot poison results.
+TK_SANDBOX="$(mktemp -d)"
+mkdir -p "$TK_SANDBOX/catalyst"
+export XDG_CONFIG_HOME="$TK_SANDBOX"
+trap 'chmod -R u+rw "$TK_SANDBOX" 2>/dev/null; rm -rf "$TK_SANDBOX"' EXIT
+
+# ─── Case I: descriptive branch slug → only canonical token, no fabrication ───
+echo "▶ Case I: descriptive branch slug does not fabricate"
+out=$(linear_foreign_tokens_from_branch "CTL-623-migrate-oauth2-and-utf8-support")
+if [[ "$out" == "CTL-623" ]]; then
+	pass "I: only CTL-623 emitted (no OAUTH-2, no UTF-8)"
+else
+	fail "I: only CTL-623 emitted" "got: $out"
+fi
+
+# ─── Case N: single-digit real ticket in branch slug preserved ───────────────
+echo "▶ Case N: single-digit real ticket preserved"
+out=$(linear_foreign_tokens_from_branch "CTL-7-fix")
+if [[ "$out" == "CTL-7" ]]; then
+	pass "N: CTL-7 preserved (no [0-9]{2,} digit-floor regression)"
+else
+	fail "N: CTL-7 preserved" "got: $out"
+fi
+
+# ─── Case O: canonical orch slug → siblings via wrapper ──────────────────────
+echo "▶ Case O: orch slug emits siblings via _from_branch wrapper"
+out=$(linear_sibling_skip_block_from_branch "ADV-1155" "o-adv-1155-1156-1157-ADV-1155")
+if grep -q '^skip ADV-1156$' <<<"$out" && grep -q '^skip ADV-1157$' <<<"$out" \
+		&& ! grep -q '^skip ADV-1155$' <<<"$out"; then
+	pass "O: siblings ADV-1156/1157, own excluded"
+else
+	fail "O: siblings + own excluded" "got: $out"
+fi
+
+# ─── Case J: prose alpha+num collisions → blocked by allowlist ───────────────
+echo "▶ Case J: UTF-8/HTTP-2 in prose blocked when not in allowlist"
+printf '{"keys":["CTL","ADV"]}\n' > "$TK_SANDBOX/catalyst/linear-team-keys.json"
+out=$(linear_foreign_tokens_from_body "this implements UTF-8 and HTTP-2 encoding")
+if [[ -z "$out" ]]; then
+	pass "J: UTF/HTTP filtered out of canonical-shaped body tokens"
+else
+	fail "J: UTF/HTTP filtered" "got: $out"
+fi
+rm -f "$TK_SANDBOX/catalyst/linear-team-keys.json"
+
+# ─── Case K: date in prose → no fabrication (canonical regex never matches) ──
+echo "▶ Case K: dashed date prose does not fabricate"
+out=$(linear_foreign_tokens_from_body "Released 2026-05-25")
+if [[ -z "$out" ]]; then
+	pass "K: no RELEASED-25 fabrication from prose"
+else
+	fail "K: no RELEASED-25 fabrication" "got: $out"
+fi
+
+# ─── Case L: pseudo-tokens abc123 / def456 → no fabrication ──────────────────
+echo "▶ Case L: abc123 / def456 pseudo-tokens do not fabricate"
+out=$(linear_foreign_tokens_from_body "abc123 def456 cleanup")
+if [[ -z "$out" ]]; then
+	pass "L: pseudo-tokens not captured"
+else
+	fail "L: pseudo-tokens not captured" "got: $out"
+fi
+
+# ─── Case M: API-v2 collision worst-case → no V-2 emission ───────────────────
+echo "▶ Case M: API-v2 prose does not emit V-2"
+out=$(linear_foreign_tokens_from_body "fixes API-v2 regression")
+if [[ -z "$out" ]]; then
+	pass "M: lowercase v2 breaks the canonical shape"
+else
+	fail "M: V-2 not fabricated" "got: $out"
+fi
+
+# ─── Case P: explicit canonical TEAM-NNN captured iff team in allowlist ──────
+echo "▶ Case P: explicit canonical body token allowlisted → captured"
+printf '{"keys":["ENG","CTL"]}\n' > "$TK_SANDBOX/catalyst/linear-team-keys.json"
+out=$(linear_foreign_tokens_from_body "see also ENG-50 for context")
+if [[ "$out" == "ENG-50" ]]; then
+	pass "P: ENG-50 captured from prose when ENG is allowlisted"
+else
+	fail "P: ENG-50 captured (allowlisted)" "got: $out"
+fi
+rm -f "$TK_SANDBOX/catalyst/linear-team-keys.json"
+
+# ─── Case P2: no cache → fail-open passthrough (backward-compat with Case H) ─
+echo "▶ Case P2: no cache → fail-open canonical capture preserved"
+rm -f "$TK_SANDBOX/catalyst/linear-team-keys.json"
+out=$(linear_foreign_tokens_from_body "see also ENG-50 for context")
+if [[ "$out" == "ENG-50" ]]; then
+	pass "P2: ENG-50 still captured with no cache (fail-open)"
+else
+	fail "P2: ENG-50 captured with no cache" "got: $out"
+fi
+
+# ─── Case Q: OAUTH-2 canonical-shape prose filtered when not allowlisted ─────
+echo "▶ Case Q: OAUTH-2 in prose filtered when OAUTH not allowlisted"
+printf '{"keys":["CTL"]}\n' > "$TK_SANDBOX/catalyst/linear-team-keys.json"
+out=$(linear_foreign_tokens_from_body "OAUTH-2 isn't a real ticket")
+if [[ -z "$out" ]]; then
+	pass "Q: OAUTH-2 dropped by allowlist"
+else
+	fail "Q: OAUTH-2 dropped" "got: $out"
+fi
+rm -f "$TK_SANDBOX/catalyst/linear-team-keys.json"
+
+# ─── Case R: date with trailing word in prose → no fabrication ───────────────
+echo "▶ Case R: 'shipped 2026-05-25-final' produces no tokens"
+out=$(linear_foreign_tokens_from_body "shipped 2026-05-25-final")
+if [[ -z "$out" ]]; then
+	pass "R: no fabrication from date+trailing-word"
+else
+	fail "R: no fabrication" "got: $out"
+fi
+
+# ─── Case S: malformed cache fails open silently ─────────────────────────────
+echo "▶ Case S: malformed cache fails open"
+printf 'not json\n' > "$TK_SANDBOX/catalyst/linear-team-keys.json"
+out=$(linear_foreign_tokens_from_body "see also ENG-50")
+if [[ "$out" == "ENG-50" ]]; then
+	pass "S: malformed cache → fail open (ENG-50 captured)"
+else
+	fail "S: malformed cache fails open" "got: $out"
+fi
+rm -f "$TK_SANDBOX/catalyst/linear-team-keys.json"
+
+# ─── Case T: branch-mode also filtered through allowlist (defense in depth) ──
+echo "▶ Case T: branch-mode allowlist filters non-team segments"
+printf '{"keys":["CTL"]}\n' > "$TK_SANDBOX/catalyst/linear-team-keys.json"
+out=$(linear_foreign_tokens_from_branch "o-utf-8-9-CTL-200")
+if ! grep -q '^UTF-' <<<"$out" && grep -q '^CTL-200$' <<<"$out"; then
+	pass "T: branch-mode UTF-* dropped, CTL-200 retained"
+else
+	fail "T: branch-mode allowlist filter" "got: $out"
+fi
+rm -f "$TK_SANDBOX/catalyst/linear-team-keys.json"
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "─────────────────────────────────────────"
+echo "PASSES=$PASSES FAILURES=$FAILURES"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/linear-team-keys-docs.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-team-keys-docs.test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# CTL-633: doc-invariant tests. Cheap grep-only assertions on the helper
+# header and the linearis SKILL.md so the next-developer-touching-this can
+# discover the two-mode design and the cache-refresh one-liner.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+FAILURES=0
+PASSES=0
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+echo "Test: linearis SKILL.md mentions the linear-team-keys cache file"
+if grep -q 'linear-team-keys.json' "$REPO_ROOT/plugins/dev/skills/linearis/SKILL.md"; then
+	pass "linearis SKILL.md references linear-team-keys.json"
+else
+	fail "linearis SKILL.md references linear-team-keys.json"
+fi
+
+echo "Test: linear-pr-skip.sh header documents both modes"
+HELPER="$REPO_ROOT/plugins/dev/scripts/lib/linear-pr-skip.sh"
+if grep -q 'linear_foreign_tokens_from_branch' "$HELPER" \
+		&& grep -q 'linear_foreign_tokens_from_body' "$HELPER"; then
+	pass "linear-pr-skip.sh documents both _from_branch and _from_body"
+else
+	fail "linear-pr-skip.sh documents both modes"
+fi
+
+echo "Test: linear-team-keys.sh header documents the manual refresh one-liner"
+TK="$REPO_ROOT/plugins/dev/scripts/lib/linear-team-keys.sh"
+if grep -q 'linearis teams list --json' "$TK"; then
+	pass "linear-team-keys.sh documents refresh via linearis"
+else
+	fail "linear-team-keys.sh documents refresh via linearis"
+fi
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "─────────────────────────────────────────"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/linear-team-keys.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-team-keys.test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# CTL-633: unit tests for the linear-team-keys allowlist loader/filter helper.
+# Each test runs in a temp XDG_CONFIG_HOME so the real ~/.config is untouched.
+# Run: bash plugins/dev/scripts/__tests__/linear-team-keys.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../lib/linear-team-keys.sh"
+
+FAILURES=0
+PASSES=0
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+if [[ ! -f "$HELPER" ]]; then
+	fail "helper exists at lib/linear-team-keys.sh"
+	echo ""
+	echo "PASSES=$PASSES FAILURES=$FAILURES"
+	exit 1
+fi
+# shellcheck source=/dev/null
+source "$HELPER"
+
+# Each case sets up a fresh sandbox.
+sandbox() {
+	local d
+	d="$(mktemp -d)"
+	mkdir -p "$d/catalyst"
+	printf '%s' "$d"
+}
+
+# ─── Case 1: missing cache → empty load, fail-open ────────────────────────────
+echo "▶ Case 1: missing cache returns empty"
+HOME_TMP="$(sandbox)"
+out=$(XDG_CONFIG_HOME="$HOME_TMP" linear_team_keys_load 2>/dev/null)
+if [[ -z "$out" ]]; then
+	pass "1: missing cache → empty"
+else
+	fail "1: missing cache → empty" "got: $out"
+fi
+rm -rf "$HOME_TMP"
+
+# ─── Case 2: well-formed cache returns sorted keys ────────────────────────────
+echo "▶ Case 2: well-formed cache returns sorted keys"
+HOME_TMP="$(sandbox)"
+printf '{"keys":["ENG","ADV","CTL"],"fetched_at":"2026-05-25T00:00:00Z"}\n' \
+	> "$HOME_TMP/catalyst/linear-team-keys.json"
+out=$(XDG_CONFIG_HOME="$HOME_TMP" linear_team_keys_load 2>/dev/null)
+expected=$'ADV\nCTL\nENG'
+if [[ "$out" == "$expected" ]]; then
+	pass "2: keys sorted ADV/CTL/ENG"
+else
+	fail "2: keys sorted ADV/CTL/ENG" "got: $out"
+fi
+rm -rf "$HOME_TMP"
+
+# ─── Case 3: empty cache → empty load ─────────────────────────────────────────
+echo "▶ Case 3: empty keys array returns empty"
+HOME_TMP="$(sandbox)"
+printf '{"keys":[]}\n' > "$HOME_TMP/catalyst/linear-team-keys.json"
+out=$(XDG_CONFIG_HOME="$HOME_TMP" linear_team_keys_load 2>/dev/null)
+if [[ -z "$out" ]]; then
+	pass "3: empty keys → empty"
+else
+	fail "3: empty keys → empty" "got: $out"
+fi
+rm -rf "$HOME_TMP"
+
+# ─── Case 4: malformed JSON → empty, no fatal stderr ──────────────────────────
+echo "▶ Case 4: malformed cache fails open silently"
+HOME_TMP="$(sandbox)"
+printf 'not json\n' > "$HOME_TMP/catalyst/linear-team-keys.json"
+err=$(XDG_CONFIG_HOME="$HOME_TMP" linear_team_keys_load 2>&1 >/dev/null)
+out=$(XDG_CONFIG_HOME="$HOME_TMP" linear_team_keys_load 2>/dev/null)
+if [[ -z "$out" && -z "$err" ]]; then
+	pass "4: malformed → empty stdout, empty stderr"
+else
+	fail "4: malformed → empty (stdout+stderr)" "stdout=$out stderr=$err"
+fi
+rm -rf "$HOME_TMP"
+
+# ─── Case 5: unreadable cache → empty (fail-open) ─────────────────────────────
+echo "▶ Case 5: unreadable cache fails open"
+HOME_TMP="$(sandbox)"
+printf '{"keys":["X"]}\n' > "$HOME_TMP/catalyst/linear-team-keys.json"
+chmod 000 "$HOME_TMP/catalyst/linear-team-keys.json"
+out=$(XDG_CONFIG_HOME="$HOME_TMP" linear_team_keys_load 2>/dev/null)
+chmod 644 "$HOME_TMP/catalyst/linear-team-keys.json" 2>/dev/null || true
+if [[ -z "$out" ]]; then
+	pass "5: unreadable → empty"
+else
+	fail "5: unreadable → empty" "got: $out"
+fi
+rm -rf "$HOME_TMP"
+
+# ─── Case 6: filter with empty allowlist is passthrough ───────────────────────
+echo "▶ Case 6: filter passthrough on empty allowlist"
+HOME_TMP="$(sandbox)"
+out=$(printf 'CTL-1\nENG-2\nADV-3\n' \
+	| XDG_CONFIG_HOME="$HOME_TMP" linear_team_keys_filter)
+expected=$'CTL-1\nENG-2\nADV-3'
+if [[ "$out" == "$expected" ]]; then
+	pass "6: passthrough on empty allowlist"
+else
+	fail "6: passthrough on empty allowlist" "got: $out"
+fi
+rm -rf "$HOME_TMP"
+
+# ─── Case 7: filter with populated allowlist drops non-members ────────────────
+echo "▶ Case 7: filter drops non-allowlist tokens"
+HOME_TMP="$(sandbox)"
+printf '{"keys":["CTL","ENG"]}\n' > "$HOME_TMP/catalyst/linear-team-keys.json"
+out=$(printf 'CTL-1\nENG-2\nADV-3\nOAUTH-2\n' \
+	| XDG_CONFIG_HOME="$HOME_TMP" linear_team_keys_filter)
+expected=$'CTL-1\nENG-2'
+if [[ "$out" == "$expected" ]]; then
+	pass "7: only CTL/ENG retained"
+else
+	fail "7: only CTL/ENG retained" "got: $out"
+fi
+rm -rf "$HOME_TMP"
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "─────────────────────────────────────────"
+echo "PASSES=$PASSES FAILURES=$FAILURES"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/pr-body-sibling-skip.test.sh
+++ b/plugins/dev/scripts/__tests__/pr-body-sibling-skip.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# CTL-623: contract + integration tests for wiring the linear-pr-skip guard into
+# the three PR-body producers (create-pr, describe-pr, ci-describe-pr).
+#
+#   1. Prose-contract tests (grep-based, mirroring
+#      phase-skill-no-linear-prose.test.sh): each SKILL.md must reference the
+#      helper and carry the sibling-format rule (reference siblings by GitHub PR
+#      number #NNN, never bare Linear tokens). describe-pr must keep the own
+#      Fixes URL.
+#   2. Assembled-body integration tests: source the helper, simulate the
+#      create-pr body assembly against a multi-ticket branch (guard block + own
+#      Refs present) and a single-ticket branch (no skip line).
+#
+# Run: bash plugins/dev/scripts/__tests__/pr-body-sibling-skip.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILLS_DIR="${REPO_ROOT}/plugins/dev/skills"
+HELPER="${SCRIPT_DIR}/../lib/linear-pr-skip.sh"
+
+FAILURES=0
+PASSES=0
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	[ $# -ge 2 ] && echo "    $2"
+}
+
+# ─── 1. Prose-contract tests ───────────────────────────────────────────────────
+echo "Test: all three PR-body producers reference the helper + carry the format rule"
+for skill in create-pr describe-pr ci-describe-pr; do
+	f="${SKILLS_DIR}/${skill}/SKILL.md"
+	if [[ ! -f "$f" ]]; then
+		fail "${skill}/SKILL.md exists"
+		continue
+	fi
+
+	# (a) references the helper script
+	if grep -q 'linear-pr-skip\.sh' "$f"; then
+		pass "${skill}: references linear-pr-skip.sh"
+	else
+		fail "${skill}: references linear-pr-skip.sh"
+	fi
+
+	# (b) carries the sibling-format rule: mentions skip/ignore AND references the
+	#     #NNN PR-number convention / "do not ... bare" instruction.
+	if grep -qiE 'skip|ignore' "$f" &&
+		grep -qiE 'PR number|#NNN|do not.*bare|never.*bare' "$f"; then
+		pass "${skill}: carries the sibling-format rule (#NNN, no bare tokens)"
+	else
+		fail "${skill}: carries the sibling-format rule (#NNN, no bare tokens)"
+	fi
+done
+
+# (c) describe-pr keeps the own-ticket Fixes URL
+echo "Test: describe-pr keeps the own-ticket Fixes URL"
+DP="${SKILLS_DIR}/describe-pr/SKILL.md"
+if grep -q 'Fixes https://linear.app' "$DP"; then
+	pass "describe-pr keeps 'Fixes https://linear.app' (own-ticket link intended)"
+else
+	fail "describe-pr keeps 'Fixes https://linear.app' (own-ticket link intended)"
+fi
+
+# ─── 2. Assembled-body integration tests ───────────────────────────────────────
+if [[ ! -f "$HELPER" ]]; then
+	fail "helper exists for integration tests"
+	echo ""
+	echo "PASSES=$PASSES FAILURES=$FAILURES"
+	exit 1
+fi
+# shellcheck source=/dev/null
+source "$HELPER"
+
+# Mirror the create-pr transient-body assembly (Refs + guard block).
+assemble_body() {
+	local ticket="$1" branch="$2"
+	local body="## Changes
+
+abc123 some commit
+
+Refs: $ticket"
+	local skip_block
+	skip_block="$(linear_sibling_skip_block "$ticket" "$branch")"
+	[[ -n "$skip_block" ]] && body="$body
+
+$skip_block"
+	printf '%s' "$body"
+}
+
+echo "Test: multi-ticket branch body carries guard block + own Refs"
+body="$(assemble_body "ADV-1155" "o-adv-1155-1156-1157-ADV-1155")"
+if grep -q '^Refs: ADV-1155$' <<<"$body" &&
+	grep -q '<!-- Linear automation guard' <<<"$body" &&
+	grep -q '^skip ADV-1156$' <<<"$body" &&
+	grep -q '^skip ADV-1157$' <<<"$body" &&
+	! grep -q '^skip ADV-1155$' <<<"$body"; then
+	pass "multi-ticket: Refs + guard block (skip ADV-1156/1157, own excluded)"
+else
+	fail "multi-ticket: Refs + guard block present" "body: $body"
+fi
+
+echo "Test: single-ticket branch body has NO skip line (no-op preserved)"
+body="$(assemble_body "CTL-623" "CTL-623-add-helper")"
+if grep -q '^Refs: CTL-623$' <<<"$body" && ! grep -q 'skip ' <<<"$body" &&
+	! grep -q 'Linear automation guard' <<<"$body"; then
+	pass "single-ticket: Refs present, no skip line, no guard block"
+else
+	fail "single-ticket: no skip line" "body: $body"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CTL-633: scope-split integration tests. Producers must call the mode-aware
+# wrappers (branch ⇒ awk segmenter, body ⇒ canonical-only regex) so adversarial
+# body prose can never fabricate `skip TEAM-NNN` lines.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Sandbox the team-key cache for these cases — without a clean XDG_CONFIG_HOME
+# a real workstation's allowlist would skew results.
+TK_SANDBOX_INT="$(mktemp -d)"
+mkdir -p "$TK_SANDBOX_INT/catalyst"
+export XDG_CONFIG_HOME="$TK_SANDBOX_INT"
+trap 'chmod -R u+rw "$TK_SANDBOX_INT" 2>/dev/null; rm -rf "$TK_SANDBOX_INT"' EXIT
+
+# ─── Case I-int: describe-pr-shaped branch+body invocation ────────────────────
+# Allowlist contains only ADV so canonical-shape UTF-8 / OAUTH-2 from body
+# prose are filtered out by Layer 2 (team-key allowlist).
+echo "Test: describe-pr-shaped branch+body invocation (no body fabrication)"
+printf '{"keys":["ADV","CTL"]}\n' > "$TK_SANDBOX_INT/catalyst/linear-team-keys.json"
+branch="o-adv-1155-1156-1157-ADV-1155"
+body=$'## Summary\n\nFixes UTF-8 handling and the OAUTH-2 flow.\n\nSee ENG-50 for context.'
+out=$( {
+	linear_sibling_skip_block_from_branch "ADV-1155" "$branch"
+	linear_sibling_skip_block_from_body   "ADV-1155" "$body"
+} )
+if grep -q '^skip ADV-1156$' <<<"$out" \
+		&& grep -q '^skip ADV-1157$' <<<"$out" \
+		&& ! grep -q '^skip UTF-' <<<"$out" \
+		&& ! grep -q '^skip OAUTH-' <<<"$out"; then
+	pass "I-int: real siblings emitted, body-prose fabrication blocked"
+else
+	fail "I-int: branch siblings + no body fabrication" "got: $out"
+fi
+rm -f "$TK_SANDBOX_INT/catalyst/linear-team-keys.json"
+
+# ─── Case II-int: create-pr-shaped branch-only invocation ─────────────────────
+echo "Test: create-pr-shaped branch-only descriptive slug emits no skip lines"
+out=$(linear_sibling_skip_block_from_branch "CTL-633" "CTL-633-migrate-oauth2-and-utf8-support")
+if [[ -z "$out" ]]; then
+	pass "II-int: descriptive own-ticket slug → empty skip block"
+else
+	fail "II-int: empty skip block for descriptive own slug" "got: $out"
+fi
+
+# ─── Case III-int: producer SKILL.md files reference the new API ──────────────
+echo "Test: describe-pr and ci-describe-pr call both _from_branch and _from_body"
+for skill in describe-pr ci-describe-pr; do
+	f="${SKILLS_DIR}/${skill}/SKILL.md"
+	if grep -q 'linear_sibling_skip_block_from_branch' "$f" \
+			&& grep -q 'linear_sibling_skip_block_from_body' "$f"; then
+		pass "${skill}: invokes both _from_branch and _from_body"
+	else
+		fail "${skill}: invokes both _from_branch and _from_body"
+	fi
+done
+
+echo "Test: create-pr calls only _from_branch (transient initial body has no PR body to scan)"
+CP="${SKILLS_DIR}/create-pr/SKILL.md"
+if grep -q 'linear_sibling_skip_block_from_branch' "$CP" \
+		&& ! grep -q 'linear_sibling_skip_block_from_body' "$CP"; then
+	pass "create-pr: branch-only invocation (body mode intentionally absent)"
+else
+	fail "create-pr: branch-only invocation" \
+		"$(grep -n 'linear_sibling_skip_block' "$CP" | head -3)"
+fi
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "─────────────────────────────────────────"
+echo "PASSES=$PASSES FAILURES=$FAILURES"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/lib/linear-pr-skip.sh
+++ b/plugins/dev/scripts/lib/linear-pr-skip.sh
@@ -37,15 +37,37 @@
 
 # Source the team-key allowlist helper. Fail-open if the file is missing
 # (defensive — both helpers ship together via CTL-633).
-_pr_skip_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#
+# Dir resolution must work under BOTH bash and zsh. The Catalyst Bash tool runs
+# zsh, where ${BASH_SOURCE[0]} is unset — so a BASH_SOURCE-only resolver
+# collapsed to the CWD and silently failed to source the sibling lib (CTL-633
+# phase-review finding #1). The producers (create-pr/describe-pr/ci-describe-pr)
+# all source us via "${CLAUDE_PLUGIN_ROOT}/scripts/lib/linear-pr-skip.sh", so
+# CLAUDE_PLUGIN_ROOT is the reliable anchor in the real runtime; fall back to
+# BASH_SOURCE for `bash linear-pr-skip.sh` direct exec and bash sourcers.
+if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" \
+	&& -r "${CLAUDE_PLUGIN_ROOT}/scripts/lib/linear-team-keys.sh" ]]; then
+	_pr_skip_dir="${CLAUDE_PLUGIN_ROOT}/scripts/lib"
+elif [[ -n "${BASH_SOURCE:-}" ]]; then
+	_pr_skip_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+	_pr_skip_dir=""
+fi
 # shellcheck source=/dev/null
-[[ -r "$_pr_skip_dir/linear-team-keys.sh" ]] \
+[[ -n "$_pr_skip_dir" && -r "$_pr_skip_dir/linear-team-keys.sh" ]] \
 	&& source "$_pr_skip_dir/linear-team-keys.sh"
 
 # Pipe stdin through linear_team_keys_filter if it's defined; passthrough
 # otherwise (handles the "team-keys helper not sourced" edge case).
+#
+# Use `command -v`, NOT `declare -F`: under zsh `declare -F <name>` returns
+# success for an ABSENT function, so the guard wrongly called the missing
+# filter (`command not found`) and dropped ALL output with exit 0 — silently
+# nullifying the sibling-skip guard (CTL-633 phase-review finding #1). `command
+# -v` correctly reports absence under both bash and zsh, so fail-open `cat`
+# actually triggers. (`type -t` would be a bash-only builtin — broken in zsh.)
 _pr_skip_filter() {
-	if declare -F linear_team_keys_filter >/dev/null 2>&1; then
+	if command -v linear_team_keys_filter >/dev/null 2>&1; then
 		linear_team_keys_filter
 	else
 		cat

--- a/plugins/dev/scripts/lib/linear-pr-skip.sh
+++ b/plugins/dev/scripts/lib/linear-pr-skip.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# linear-pr-skip — emit Linear "skip <ID>" guard lines for every foreign ticket
+# token found in branch or body text, so Linear's GitHub integration does NOT
+# auto-link sibling tickets and drag their workflow status.
+# CTL-623 introduced the helper; CTL-633 split it into two scope-bounded modes
+# to stop body-mode prose ("Released 2026-05-25", "fixes UTF-8 handling",
+# "OAUTH-2 cleanup", "abc123 commit") from fabricating fake foreign tokens.
+#
+# Two-mode design:
+#   linear_foreign_tokens_from_branch <branch> [<branch> …]
+#     Keeps the original awk segmenter: walks the slug char-by-char and
+#     recovers same-prefix sibling numbers under the most-recent team prefix
+#     (the orchestrator-built `o-adv-1155-1156-1157-ADV-1155` shape produced
+#     by setup-orchestrator.sh::build_orch_name). This is the ONLY legitimate
+#     bare-number-recovery source in the repo. Output piped through the
+#     team-key allowlist filter for defense in depth.
+#
+#   linear_foreign_tokens_from_body <body> [<body> …]
+#     Canonical-only extraction via `grep -oE '\b[A-Z]+-[0-9]+\b'`. NO prefix
+#     recovery, NO mixed-alpha emission. Prose, dates (2026-05-25), SHAs
+#     (075e1ff5), lowercase pseudo-tokens (oauth2/utf8/abc123/api-v2), and
+#     dashed-date prose cannot fabricate. Canonical body tokens (`see ENG-50`)
+#     are still captured and ALSO filtered through the team-key allowlist —
+#     the allowlist is fail-open on missing/empty cache so fresh installs
+#     behave like today.
+#
+# Wrappers emit the HTML-comment guard + `skip <TOKEN>` block per mode:
+#   linear_sibling_skip_block_from_branch <own> <branch>
+#   linear_sibling_skip_block_from_body   <own> <body>
+#
+# Back-compat: linear_sibling_skip_block / linear_foreign_tokens default to
+# branch mode (the original primary use case — orchestrator slug recovery).
+#
+# Direct exec stays branch-mode (`linear-pr-skip.sh <own> <branch>` works).
+#
+# Team-key allowlist: see linear-team-keys.sh (sibling lib in this dir).
+
+# Source the team-key allowlist helper. Fail-open if the file is missing
+# (defensive — both helpers ship together via CTL-633).
+_pr_skip_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+[[ -r "$_pr_skip_dir/linear-team-keys.sh" ]] \
+	&& source "$_pr_skip_dir/linear-team-keys.sh"
+
+# Pipe stdin through linear_team_keys_filter if it's defined; passthrough
+# otherwise (handles the "team-keys helper not sourced" edge case).
+_pr_skip_filter() {
+	if declare -F linear_team_keys_filter >/dev/null 2>&1; then
+		linear_team_keys_filter
+	else
+		cat
+	fi
+}
+
+# Extract canonical UPPER-cased TEAM-NNN tokens from a branch slug, recovering
+# bare sibling numbers under the most-recent prefix. Prints one token per line,
+# de-duplicated and sorted. Network-free, deterministic.
+linear_foreign_tokens_from_branch() {
+	printf '%s\n' "$@" |
+		awk '
+			{
+				# Walk the string char-by-char, accumulating runs of alphanumerics
+				# into segments and remembering the single separator char that
+				# preceded each segment. A pure-alpha segment sets the running team
+				# prefix; a bare number inherits that prefix ONLY when joined to the
+				# prior segment by a single "-" (the same-prefix orch-slug shape
+				# "adv-1155-1156-1157" — never across whitespace or "#", so prose
+				# like "PR #890" cannot fabricate a token). CTL-633: mixed
+				# alpha+num segments ("oauth2", "utf8") used to split into
+				# "OAUTH-2" / "UTF-8" — that was the documented fabrication site.
+				# Now we drop both the emit and the prefix update for mixed-alpha
+				# tokens; legitimate orch slugs (build_orch_name) always hyphenate
+				# alpha and digit, so this loses no real signal.
+				line = $0
+				prefix = ""
+				seg = ""
+				seg_sep = ""
+				next_sep = ""
+				L = length(line)
+				for (i = 1; i <= L + 1; i++) {
+					c = (i <= L) ? substr(line, i, 1) : ""
+					if (c ~ /[A-Za-z0-9]/) {
+						if (seg == "") seg_sep = next_sep
+						seg = seg c
+						continue
+					}
+					if (seg != "") {
+						if (seg ~ /^[A-Za-z]+$/) {
+							prefix = toupper(seg)
+						} else if (seg ~ /^[0-9]+$/) {
+							if (prefix != "" && seg_sep == "-") print prefix "-" seg
+						}
+						# Mixed alpha+num (oauth2, utf8, abc123) is intentionally
+						# ignored: it was the CTL-623 fabrication site that
+						# CTL-633 closes.
+						seg = ""
+						next_sep = ""
+					}
+					next_sep = c
+				}
+			}
+		' |
+		grep -E '^[A-Z]+-[0-9]+$' |
+		sort -u |
+		_pr_skip_filter
+}
+
+# Extract canonical UPPER-cased TEAM-NNN tokens from PR body prose. No prefix
+# recovery, no mixed-alpha emission. \b[A-Z]+-[0-9]+\b requires an UPPER-case
+# alpha prefix glued by exactly one hyphen to a pure-digit tail at word
+# boundaries — dates, lowercase prose, SHAs, abc123-style pseudo-tokens, and
+# API-v2-style mixed-case collisions can never match. Output also filtered
+# through the team-key allowlist (fail-open).
+linear_foreign_tokens_from_body() {
+	printf '%s\n' "$@" |
+		grep -oE '\b[A-Z]+-[0-9]+\b' |
+		sort -u |
+		_pr_skip_filter
+}
+
+# Private: render the HTML-comment guard + `skip <TOKEN>` block for a list of
+# tokens (one per line on stdin). Drops the own ticket (case-insensitive).
+_pr_skip_emit_block() {
+	local own_uc="$1"
+	local tokens
+	tokens=$(grep -vxF "$own_uc" || true)
+	[[ -z "$tokens" ]] && return 0
+	printf '<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->\n'
+	while IFS= read -r t; do printf 'skip %s\n' "$t"; done <<<"$tokens"
+}
+
+linear_sibling_skip_block_from_branch() {
+	local own="${1:?own ticket required}"
+	shift
+	local own_uc
+	own_uc="$(printf '%s' "$own" | tr '[:lower:]' '[:upper:]')"
+	linear_foreign_tokens_from_branch "$@" | _pr_skip_emit_block "$own_uc"
+}
+
+linear_sibling_skip_block_from_body() {
+	local own="${1:?own ticket required}"
+	shift
+	local own_uc
+	own_uc="$(printf '%s' "$own" | tr '[:lower:]' '[:upper:]')"
+	linear_foreign_tokens_from_body "$@" | _pr_skip_emit_block "$own_uc"
+}
+
+# Back-compat alias — defaults to branch mode (the original primary use case).
+# Any existing caller (e.g. third-party scripts that sourced the helper before
+# CTL-633's split) keeps its current semantics for branch-shaped inputs. The
+# producers (create-pr, describe-pr, ci-describe-pr) call the mode-specific
+# wrappers explicitly so body-mode inputs go through canonical-only extraction.
+linear_sibling_skip_block() {
+	linear_sibling_skip_block_from_branch "$@"
+}
+
+# Back-compat alias for any external sourcer that called the old extractor.
+linear_foreign_tokens() {
+	linear_foreign_tokens_from_branch "$@"
+}
+
+# Direct-execution entrypoint — preserves branch-mode behavior.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	linear_sibling_skip_block "$@"
+fi

--- a/plugins/dev/scripts/lib/linear-team-keys.sh
+++ b/plugins/dev/scripts/lib/linear-team-keys.sh
@@ -19,11 +19,17 @@ linear_team_keys_cache_path() {
 
 # Print the cached allowlist, one key per line, sorted+deduped. Empty output
 # means "no allowlist available — fail open".
+# NB: the local is named cache_path, NOT path. Under zsh `path` is a special
+# array tied to $PATH; `local path; path=<file>` would clobber PATH to the
+# cache-file path for the rest of the function, making `sort`/`jq` resolve to
+# "command not found" so the loader always failed open under zsh (CTL-633
+# phase-review finding #1, zsh-runtime class). Bash treats `path` as ordinary,
+# which is why the bash test suites never caught this.
 linear_team_keys_load() {
-	local path
-	path="$(linear_team_keys_cache_path)"
-	[[ -r "$path" ]] || return 0
-	jq -r '.keys[]? // empty' "$path" 2>/dev/null | sort -u
+	local cache_path
+	cache_path="$(linear_team_keys_cache_path)"
+	[[ -r "$cache_path" ]] || return 0
+	jq -r '.keys[]? // empty' "$cache_path" 2>/dev/null | sort -u
 }
 
 # Filter stdin tokens (TEAM-NNN, one per line) through the allowlist. Empty

--- a/plugins/dev/scripts/lib/linear-team-keys.sh
+++ b/plugins/dev/scripts/lib/linear-team-keys.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# linear-team-keys — read-only loader for the cached Linear team-key allowlist.
+# CTL-633. Network-free, fail-open: an empty / missing / malformed / unreadable
+# cache means "no filtering" so the helper continues to behave like today on
+# fresh installs.
+#
+# Cache location: ${XDG_CONFIG_HOME:-$HOME/.config}/catalyst/linear-team-keys.json
+# Cache shape:    {"keys": ["ADV", "CTL", "ENG", ...], "fetched_at": "ISO-8601"}
+# Refresh (manual, run by the operator — see plugins/dev/skills/linearis/SKILL.md):
+#   mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/catalyst"
+#   linearis teams list --json |
+#     jq '{keys:[.nodes[].key]|sort, fetched_at:(now|todate)}' \
+#     > "${XDG_CONFIG_HOME:-$HOME/.config}/catalyst/linear-team-keys.json"
+
+linear_team_keys_cache_path() {
+	printf '%s/catalyst/linear-team-keys.json' \
+		"${XDG_CONFIG_HOME:-$HOME/.config}"
+}
+
+# Print the cached allowlist, one key per line, sorted+deduped. Empty output
+# means "no allowlist available — fail open".
+linear_team_keys_load() {
+	local path
+	path="$(linear_team_keys_cache_path)"
+	[[ -r "$path" ]] || return 0
+	jq -r '.keys[]? // empty' "$path" 2>/dev/null | sort -u
+}
+
+# Filter stdin tokens (TEAM-NNN, one per line) through the allowlist. Empty
+# allowlist ⇒ passthrough. Otherwise drops tokens whose TEAM prefix is not in
+# the allowlist (exact case-sensitive UPPER-case match on the prefix).
+linear_team_keys_filter() {
+	local allowlist
+	allowlist="$(linear_team_keys_load)"
+	if [[ -z "$allowlist" ]]; then
+		cat
+		return 0
+	fi
+	# Use a comma-joined keylist for awk -v so we don't depend on BSD/GNU awk
+	# accepting embedded newlines in command-line string literals (BSD does not).
+	local keys_csv
+	keys_csv="$(printf '%s' "$allowlist" | tr '\n' ',')"
+	awk -v keys="$keys_csv" '
+		BEGIN { n = split(keys, k, ","); for (i=1;i<=n;i++) if (k[i] != "") a[k[i]] = 1 }
+		{
+			p = $0; sub(/-[0-9]+$/, "", p)
+			if (p in a) print
+		}
+	'
+}

--- a/plugins/dev/skills/ci-describe-pr/SKILL.md
+++ b/plugins/dev/skills/ci-describe-pr/SKILL.md
@@ -71,6 +71,14 @@ Analyze all commits and changes. Generate a complete PR description following th
 
 **CRITICAL: NO Claude attribution** — remove any "Generated with Claude" or "Co-Authored-By" lines.
 
+**CTL-623 — sibling reference format (REQUIRED):** When referencing related/sibling
+work in prose, reference it by its **GitHub PR number (`#NNN`)**, never by a bare Linear
+token (`TEAM-NNN`) or a Linear issue URL. A bare sibling `TEAM-NNN` token is auto-linked
+by Linear's GitHub integration and drags that sibling's workflow status (Done → Implement)
+on PR open/merge. Do **not** emit bare sibling Linear tokens in prose. The own ticket's
+`Fixes https://linear.app/...` line is correct and stays. Sibling neutralization is
+handled mechanically by the guard block appended at write-back time (step 6).
+
 ### 6. Save and Update
 
 ```bash
@@ -78,6 +86,24 @@ Analyze all commits and changes. Generate a complete PR description following th
 cat > "thoughts/shared/prs/${PR_NUMBER}_description.md" <<EOF
 [Generated description]
 EOF
+
+# CTL-623: append a Linear automation guard block so sibling tickets embedded in
+# the branch name or pulled into the body are NOT auto-linked and dragged backward
+# in status when this PR opens/merges. Scans the branch AND the assembled body;
+# no-op for single-ticket PRs. See https://linear.app/docs/github (skip/ignore
+# negative magic word).
+# CTL-633: branch and body are scanned in DIFFERENT modes — the branch goes
+# through the awk segmenter (legitimate sibling-number recovery); the body
+# uses canonical-only regex so prose, dashed dates, and SHAs cannot fabricate
+# fake `skip TEAM-NNN` lines. Stays non-interactive — no cache refresh prompt.
+# shellcheck source=/dev/null
+source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/linear-pr-skip.sh"
+body="$(cat "$body_file")"
+skip_block="$( {
+    linear_sibling_skip_block_from_branch "$ticket" "$branch"
+    linear_sibling_skip_block_from_body   "$ticket" "$body"
+} | awk '/^skip /{if(!seen[$0]++) print; next} {if(!h){print; h=1}}' )"
+[[ -n "$skip_block" ]] && printf '\n%s\n' "$skip_block" >>"$body_file"
 
 # Sync thoughts
 humanlayer thoughts sync

--- a/plugins/dev/skills/create-pr/SKILL.md
+++ b/plugins/dev/skills/create-pr/SKILL.md
@@ -185,6 +185,24 @@ if [[ "$ticket" ]]; then
 Refs: $ticket"
 fi
 
+# CTL-623: prevent Linear from auto-linking sibling tickets embedded in the
+# branch name (multi-ticket orchestrator runs build branches like
+# `o-adv-1155-1156-1157-ADV-1155`) and dragging their workflow status when this
+# PR opens. The skip/ignore negative magic word fully unlinks siblings even when
+# the branch still carries their IDs (https://linear.app/docs/github). No-op for
+# single-ticket branches. Linking can fire on PR-open, BEFORE /describe-pr runs,
+# so the guard block must be present in this transient initial body too.
+# CTL-633: create-pr scans the BRANCH only — the transient body is assembled
+# from commit messages, not user prose, so no body-mode scan is needed (and
+# adding one risks fabricating from commit subjects). Call _from_branch
+# explicitly to opt into the new mode-aware API.
+# shellcheck source=/dev/null
+source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/linear-pr-skip.sh"
+skip_block="$(linear_sibling_skip_block_from_branch "$ticket" "$branch")"
+[[ -n "$skip_block" ]] && body="$body
+
+$skip_block"
+
 # Create PR (author will be the git user)
 gh pr create --title "$title" --body "$body" --base "$base"
 ```

--- a/plugins/dev/skills/describe-pr/SKILL.md
+++ b/plugins/dev/skills/describe-pr/SKILL.md
@@ -342,6 +342,28 @@ gh pr edit $pr_number --title "$new_title"
 **Update body:**
 
 ```bash
+body_file="thoughts/shared/prs/${pr_number}_description.md"
+
+# CTL-623: append a Linear automation guard block so sibling tickets embedded in
+# the branch name or pulled into the body (Linear relations/description) are NOT
+# auto-linked and dragged backward in status when this PR opens/merges. Scans the
+# branch AND the assembled body; no-op for single-ticket PRs. See
+# https://linear.app/docs/github (skip/ignore negative magic word).
+# CTL-633: branch and body are scanned in DIFFERENT modes — the branch goes
+# through the awk segmenter (legitimate sibling-number recovery from
+# build_orch_name slugs); the body goes through a canonical-only regex
+# (\b[A-Z]+-[0-9]+\b) so prose like "Released 2026-05-25", "UTF-8", and
+# "abc123" cannot fabricate fake `skip TEAM-NNN` lines. Both modes are also
+# filtered through the optional team-key allowlist for defense in depth.
+# shellcheck source=/dev/null
+source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/linear-pr-skip.sh"
+body="$(cat "$body_file")"
+skip_block="$( {
+    linear_sibling_skip_block_from_branch "$ticket" "$branch"
+    linear_sibling_skip_block_from_body   "$ticket" "$body"
+} | awk '/^skip /{if(!seen[$0]++) print; next} {if(!h){print; h=1}}' )"
+[[ -n "$skip_block" ]] && printf '\n%s\n' "$skip_block" >>"$body_file"
+
 # Ensure no Claude attribution in the description file
 gh pr edit $pr_number --body-file "thoughts/shared/prs/${pr_number}_description.md"
 ```

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -260,6 +260,26 @@ plugins/dev/scripts/resolve-linear-ids.sh
 plugins/dev/scripts/linear-transition.sh --ticket ENG-123 --transition done
 ```
 
+### Team-key allowlist cache (CTL-633)
+
+The PR-body guard `lib/linear-pr-skip.sh` optionally filters its output
+through a cached snapshot of workspace team keys at
+`${XDG_CONFIG_HOME:-$HOME/.config}/catalyst/linear-team-keys.json`. The
+cache is **manual** and **fail-open** — when the file is missing, empty,
+malformed, or unreadable, the helper does no filtering (fresh installs
+behave like today). Populate / refresh it with:
+
+```bash
+mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/catalyst"
+linearis teams list --json |
+  jq '{keys:[.nodes[].key]|sort, fetched_at:(now|todate)}' \
+  > "${XDG_CONFIG_HOME:-$HOME/.config}/catalyst/linear-team-keys.json"
+```
+
+Re-run after onboarding a new Linear team. The helper is invoked inside
+non-interactive `gh pr create` / `gh pr edit` paths — no automatic
+refresh is wired in.
+
 ## Important Rules
 
 1. **--status NOT --state**: Always `--status` for issue updates (`--state` was removed in v2025.12.2)


### PR DESCRIPTION
## Summary

Fixes the over-matching `WORD-NUMBER` regex in `linear-pr-skip.sh` that fabricated fake Linear tokens (e.g. `UTF-8`, `OAUTH-2`, `RELEASED-25`, `ABC-123`) from prose, dates, and short SHAs in PR bodies — which could cause `describe-pr`/`ci-describe-pr` to UN-link unrelated tickets, the exact inverse of the bug CTL-623 was filed to fix.

Resolves the real/descriptive-token ambiguity by design change rather than regex tightening (which would break the legitimate single-digit `CTL-7` sibling):

- **Phase 1** — `linear-team-keys.sh`: team-key allowlist loader (only treat tokens whose prefix matches a known workspace team as Linear tokens; fails open when the cache is absent/malformed).
- **Phase 2** — split `linear-pr-skip.sh` into two explicit modes: `_from_branch` (awk segmenter, legitimate sibling-number recovery from orchestrator `build_orch_name` slugs) and `_from_body` (canonical-only `\b[A-Z]+-[0-9]+\b` regex so prose/dates/SHAs cannot fabricate tokens). Both filtered through the optional allowlist for defense in depth.
- **Phase 3** — rewire the PR-body producers (`create-pr` scans branch only; `describe-pr` and `ci-describe-pr` scan branch + body in their respective modes), plus the sibling-reference-format prose rule.
- **Phase 4** — docs: two-mode design + team-key cache + manual refresh one-liner.
- zsh-safety remediations so the helper sources cleanly under the zsh Bash tool.

## Test plan

All five touched shell suites pass at HEAD (49 assertions, 0 failures):

- `plugins/dev/scripts/__tests__/linear-pr-skip.test.sh` — 21 pass
- `plugins/dev/scripts/__tests__/linear-pr-skip-zsh.test.sh` — 4 pass
- `plugins/dev/scripts/__tests__/linear-team-keys.test.sh` — 7 pass
- `plugins/dev/scripts/__tests__/linear-team-keys-docs.test.sh` — 3 pass
- `plugins/dev/scripts/__tests__/pr-body-sibling-skip.test.sh` — 14 pass

Adversarial fixtures cover descriptive slugs, prose `WORD-NUMBER` patterns, dates, SHAs; the real single-digit `CTL-7` sibling is still correctly skipped.

## Rescue note

This is a **rescue of stalled-before-PR work**: the implement/test/docs/verify/review phases completed locally but the `pr` phase escalated and never pushed — the branch was local-only and ~131 commits behind. It has been **rebased onto current origin/main** with conflicts resolved additively; tests are green.

Because CTL-633 was built on top of **CTL-623** (which introduced `linear-pr-skip.sh`) and CTL-623 was never merged to `main`, this PR bundles the CTL-623 foundation it depends on (the `linear-pr-skip.sh` base file + sibling-format prose). The net diff is purely additive (no deletions).

Fixes https://linear.app/coalesce-labs/issue/CTL-633
