### PR TITLE
CTL-671: Guard + monitor runaway phase-dispatch loops (phantom/non-resolving tickets)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -276,6 +276,37 @@ The rebase is otherwise unchanged from CTL-667:
   (`.catalyst/config.json`, `.trunk/*`) is stashed across the rebase.
 - **Transient fetch failure → proceed un-rebased.** A flaky `git fetch` (rc=1) is non-fatal.
 
+### Runaway-loop guards (CTL-671)
+
+`schedulerTick` is hardened against runaway phase-dispatch/reclaim loops on phantom or
+non-resolving tickets — the failure mode where the phantom **CTL-9** (a ticket that does not exist
+in Linear) spammed ~24,560 `phase.*` events over three days, 92% of them per-tick
+`work-done-probe` reclaim storms. Three additive defenses, smallest blast radius first:
+
+- **Pass 0a — phantom worker-dir validity sweep.** Runs *before* the reclaim sweep. Quarantines a
+  `workers/<ticket>/` dir to terminal `stalled` (`stalledReason:"phantom-ticket"`) only when **all
+  three** hold: the ticket is definitively **not-found** in Linear, it is **not in the eligible
+  set**, and it has **no live bg worker**. The conjunction (plus the 3-valued
+  `classifyTicketResolution`, which maps a transient outage to `unknown`, never `not-found`)
+  guarantees a Linear outage can never quarantine a healthy, resolvable, in-flight ticket. This is
+  the path that actually sustained CTL-9 — cut on the first tick that sees it.
+  `classifyTicketResolution`/`isBgJobAlive` are safe no-ops by default in `schedulerTick` and armed
+  with the real impls by the daemon's `runTick`, so a bare unit tick never shells out.
+- **Dispatch circuit breaker.** The CTL-624 cool-down marker now carries a `consecutiveFailures`
+  counter; after `SCHEDULER_CIRCUIT_BREAKER_THRESHOLD` (default 8) consecutive failed dispatches
+  with no forward progress the ticket is quarantined to `stalled`
+  (`stalledReason:"dispatch-circuit-breaker"`). A successful dispatch clears the marker and resets
+  the counter, so a healthy ticket can never trip it. This is the **Linear-independent backstop**.
+- **Runaway-rate alert (observability only).** When a single ticket's `phase.*.<ticket>` event rate
+  crosses `SCHEDULER_RUNAWAY_THRESHOLD` (default 50) within `SCHEDULER_RUNAWAY_WINDOW_MS` (default
+  10 min), the scheduler emits exactly one `phase.dispatch.runaway.<ticket>` event per window
+  (once-per-window marker under `orchDir/.runaway-alerts/`). It surfaces a dominating ticket in the
+  HUD with an attention glyph but does **not** itself quarantine — enforcement stays with the sweep
+  + circuit breaker.
+
+Enforcement reuses the existing mechanism: a `stalled` signal makes `isTicketInFlight` drop the
+ticket and the terminal sweep applies `needs-human` via `labelOnce`.
+
 ### Unified data-flow
 
 The same event log is the cross-process backbone for every observation surface:

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -72,6 +72,11 @@ import { writeBootMarker, clearProgressMarks } from "./recovery.mjs"; // CTL-655
 import { startAutoTuner } from "./autotune.mjs"; // CTL-684: side-car maxParallel auto-tuner
 import { dispatchTicket } from "./dispatch.mjs"; // CTL-549: comment-wake re-dispatch
 import { removeLabel as defaultRemoveLabel } from "./linear-write.mjs"; // CTL-549: clear needs-human/question on resume
+// CTL-671: the real phantom-sweep seams. startScheduler defaults them to safe
+// no-ops (hermetic for direct-call unit tests); the REAL daemon arms them here
+// so the phantom worker-dir validity sweep is operative in production.
+import { classifyTicketResolution } from "./linear-query.mjs";
+import { isBgJobAlive } from "./claude-agents.mjs";
 
 const DEFAULT_MAX_PARALLEL = 3;
 
@@ -351,7 +356,16 @@ export function startDaemon({
     // CTL-558: the scheduler writes Linear status via its default `writeStatus`
     // (linear-write.mjs) on every committed phase transition — no daemon wiring
     // needed; production uses the real module, tests inject fakes.
-    schedulerFn({ orchDir, cache, concurrency, configPath, layer2Path }); // CTL-536 + CTL-634 + CTL-665 + CTL-676 + CTL-678 — pull-loop scheduler (configPath + layer2Path enable per-tick Layer-1+Layer-2 re-read)
+    schedulerFn({
+      orchDir,
+      cache,
+      concurrency,
+      configPath,
+      layer2Path,
+      // CTL-671: arm the phantom worker-dir validity sweep + bg-liveness reader.
+      classifyResolution: classifyTicketResolution,
+      isBgJobAlive,
+    }); // CTL-536 + CTL-634 + CTL-665 + CTL-671 + CTL-676 + CTL-678 — pull-loop scheduler (configPath + layer2Path enable per-tick Layer-1+Layer-2 re-read)
     // CTL-684: start the side-car auto-tuner AFTER the scheduler so the
     // scheduler's first tick runs with the operator's current Layer-2 value
     // before any auto-tune adjustments. configPath + layer2Path are threaded

--- a/plugins/dev/scripts/execution-core/event-scan.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.mjs
@@ -176,3 +176,34 @@ export function countDistinctRevivingTickets({
 export function __resetEventScanIndexForTest() {
   _index.clear();
 }
+
+// countTicketEventsInWindow — CTL-671. Total phase.*.<ticket> envelopes within
+// `windowMs` of now(). The runaway-loop signal: a healthy ticket emits a
+// handful of events per phase; a phantom probe-storm emits hundreds. Counts ALL
+// actions (the CTL-9 storm was 92% non-failed work-done probes), unlike a
+// dispatch-failure-only counter which would have missed it. Matches on the
+// canonical event name `phase.<phase>.<action>.<ticket>` via a leading-dot
+// suffix so "CTL-9" never matches "CTL-90". now: () => number matches the
+// recovery.mjs clock-injection convention.
+export function countTicketEventsInWindow({
+  ticket,
+  windowMs,
+  now = Date.now,
+  path = getEventLogPath(),
+} = {}) {
+  if (!ticket) throw new Error("countTicketEventsInWindow: ticket required");
+  if (!windowMs) throw new Error("countTicketEventsInWindow: windowMs required");
+  const cutoff = now() - windowMs;
+  const suffix = `.${ticket}`;
+  let n = 0;
+  for (const line of readLinesSync(path)) {
+    const ev = safeParse(line);
+    if (!ev) continue;
+    const name = ev?.attributes?.["event.name"];
+    if (typeof name !== "string" || !name.startsWith("phase.") || !name.endsWith(suffix)) continue;
+    const tsMs = Date.parse(ev?.ts || "");
+    if (!Number.isFinite(tsMs) || tsMs < cutoff) continue;
+    n++;
+  }
+  return n;
+}

--- a/plugins/dev/scripts/execution-core/event-scan.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.mjs
@@ -196,14 +196,22 @@ export function countTicketEventsInWindow({
   const cutoff = now() - windowMs;
   const suffix = `.${ticket}`;
   let n = 0;
-  for (const line of readLinesSync(path)) {
-    const ev = safeParse(line);
-    if (!ev) continue;
-    const name = ev?.attributes?.["event.name"];
-    if (typeof name !== "string" || !name.startsWith("phase.") || !name.endsWith(suffix)) continue;
-    const tsMs = Date.parse(ev?.ts || "");
-    if (!Number.isFinite(tsMs) || tsMs < cutoff) continue;
-    n++;
-  }
+  // CTL-671 (rebased onto CTL-673): the runaway counter must see ALL
+  // `phase.*.<ticket>` envelopes, not just the revive/remediate families the
+  // retained `_index` keeps — so it cannot reuse refreshIndex. Use the same
+  // bounded `scanEventsChunked` primitive directly (fixed-size chunks, never the
+  // pre-CTL-673 whole-file readFileSync) for a memory-safe full scan.
+  scanEventsChunked({
+    path,
+    fromOffset: 0,
+    leftover: "",
+    onEvent: (ev) => {
+      const name = ev?.attributes?.["event.name"];
+      if (typeof name !== "string" || !name.startsWith("phase.") || !name.endsWith(suffix)) return;
+      const tsMs = Date.parse(ev?.ts || "");
+      if (!Number.isFinite(tsMs) || tsMs < cutoff) return;
+      n++;
+    },
+  });
   return n;
 }

--- a/plugins/dev/scripts/execution-core/event-scan.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.test.mjs
@@ -17,6 +17,7 @@ import {
   countDistinctRevivingTickets,
   countRemediateCycles,
   __resetEventScanIndexForTest,
+  countTicketEventsInWindow,
 } from "./event-scan.mjs";
 
 // makeEvent — minimal envelope mirroring buildEventEnvelope in recovery.mjs.
@@ -313,5 +314,71 @@ describe("incremental index (CTL-673)", () => {
     expect(
       countDistinctRevivingTickets({ windowMs: 10 * 60 * 1000, now: at("2026-05-27T00:15:00Z"), path }),
     ).toBe(1); // A aged out of the window
+  });
+});
+
+// ─── CTL-671 Phase 4: countTicketEventsInWindow — per-ticket event-rate ───
+// Total phase.*.<ticket> envelopes in a rolling window. Counts ALL actions
+// (the CTL-9 storm was 92% non-failed work-done probes), unlike a
+// dispatch-failure-only counter — the runaway-loop domination signal.
+
+describe("countTicketEventsInWindow (CTL-671)", () => {
+  test("counts all phase.*.<ticket> events in window regardless of action", () => {
+    const now = 10_000_000;
+    const recent = new Date(now - 1000).toISOString();
+    const { path } = tempLog([
+      makeEvent({ phase: "pr", action: "work-done-probe", ticket: "CTL-9", ts: recent }),
+      makeEvent({ phase: "implement", action: "failed", ticket: "CTL-9", ts: recent }),
+      makeEvent({ phase: "research", action: "complete", ticket: "CTL-100", ts: recent }), // other ticket
+    ]);
+    expect(
+      countTicketEventsInWindow({ ticket: "CTL-9", windowMs: 60_000, now: () => now, path })
+    ).toBe(2);
+  });
+
+  test("excludes events older than the window", () => {
+    const now = 10_000_000;
+    const old = new Date(now - 10 * 60_000).toISOString();
+    const { path } = tempLog([
+      makeEvent({ phase: "pr", action: "work-done-probe", ticket: "CTL-9", ts: old }),
+    ]);
+    expect(
+      countTicketEventsInWindow({ ticket: "CTL-9", windowMs: 60_000, now: () => now, path })
+    ).toBe(0);
+  });
+
+  test("does NOT match a ticket that is a prefix of another (suffix boundary)", () => {
+    const now = 10_000_000;
+    const recent = new Date(now - 1000).toISOString();
+    const { path } = tempLog([
+      makeEvent({ phase: "pr", action: "probe", ticket: "CTL-90", ts: recent }), // CTL-90 ≠ CTL-9
+      makeEvent({ phase: "pr", action: "probe", ticket: "CTL-9", ts: recent }), // match
+    ]);
+    expect(
+      countTicketEventsInWindow({ ticket: "CTL-9", windowMs: 60_000, now: () => now, path })
+    ).toBe(1);
+  });
+
+  test("ignores events with unparseable ts", () => {
+    const now = 10_000_000;
+    const recent = new Date(now - 1000).toISOString();
+    const { path } = tempLog([
+      makeEvent({ phase: "pr", action: "probe", ticket: "CTL-9", ts: "not-a-date" }),
+      makeEvent({ phase: "pr", action: "probe", ticket: "CTL-9", ts: recent }),
+    ]);
+    expect(
+      countTicketEventsInWindow({ ticket: "CTL-9", windowMs: 60_000, now: () => now, path })
+    ).toBe(1);
+  });
+
+  test("missing log → 0", () => {
+    expect(
+      countTicketEventsInWindow({ ticket: "CTL-9", windowMs: 60_000, now: () => 1, path: "/nope" })
+    ).toBe(0);
+  });
+
+  test("throws when ticket or windowMs is missing", () => {
+    expect(() => countTicketEventsInWindow({ windowMs: 60_000 })).toThrow();
+    expect(() => countTicketEventsInWindow({ ticket: "CTL-9" })).toThrow();
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -174,6 +174,43 @@ export function fetchTicketLabels(identifier, { exec = defaultExec } = {}) {
   }
 }
 
+// classifyTicketResolution — CTL-671 3-valued phantom probe. Distinguishes a
+// DEFINITIVELY non-existent ticket (clean exit 0, empty/null node) from a
+// TRANSIENT failure (nonzero exit: auth/network/rate-limit/not-found — all
+// indistinguishable). Only "not-found" may trigger quarantine; "unknown" is the
+// fail-safe that re-checks next tick. Sibling to fetchTicketState, which
+// conflates both as null (line ~86) — existing callers are unchanged.
+//
+// SAFETY: the only path to "not-found" is a DEFINITIVE missing-ticket signal.
+// Everything ambiguous (nonzero exit, unparseable, or a non-"not found" error
+// body) returns "unknown" so a Linear outage never quarantines a real ticket.
+//
+// OBSERVED CONTRACT (CTL-671, verified against the real CLI 2026-05-27):
+// `linearis issues read CTL-9` for a MISSING ticket exits **0** (not nonzero!)
+// with body `{"error": "Issue with identifier \"CTL-9\" not found"}`. A real
+// ticket exits 0 with `{"identifier": "...", "id": "...", ...}`. So the
+// discriminator is the BODY, not the exit code: a "not found" error string is
+// the definitive not-found; any other error body (auth/network/rate-limit) is
+// transient → unknown.
+export function classifyTicketResolution(identifier, { exec = defaultExec } = {}) {
+  const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
+  if (code !== 0) return "unknown"; // nonzero is ambiguous — NEVER not-found
+  let node;
+  try {
+    node = JSON.parse(stdout);
+  } catch {
+    return "unknown"; // unparseable — fail safe, re-check next tick
+  }
+  if (node == null) return "not-found";
+  // The real missing-ticket shape: exit 0 + { error: "...not found" }. Only a
+  // "not found" error is definitive; any other error body is transient.
+  if (typeof node.error === "string") {
+    return /not\s*found/i.test(node.error) ? "not-found" : "unknown";
+  }
+  const id = node?.identifier ?? node?.id ?? null;
+  return id ? "exists" : "not-found";
+}
+
 // runEligibleQuery — run the query, parse + normalize, apply the priority
 // floor. A non-zero linearis exit THROWS (never a silent []): a silent empty
 // would let one failed poll flatten a project's eligible set to zero. The

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -8,6 +8,7 @@ import {
   fetchTicketState,
   fetchTicketLabels,
   fetchTicketRelations,
+  classifyTicketResolution,
 } from "./linear-query.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 
@@ -459,5 +460,77 @@ describe("fetchTicketRelations (CTL-755)", () => {
       fetchTicketRelations("CTL-1", { exec });
       expect(calls).toBe(2);
     });
+  });
+});
+
+// ── CTL-671 Phase 2: 3-valued phantom-resolution classifier ──
+describe("classifyTicketResolution (CTL-671)", () => {
+  test("resolvable ticket → exists", () => {
+    const exec = fakeExec({
+      code: 0,
+      stdout: JSON.stringify({ identifier: "CTL-100", state: { name: "Ready" } }),
+    });
+    expect(classifyTicketResolution("CTL-100", { exec })).toBe("exists");
+  });
+
+  test("clean empty result → not-found", () => {
+    // linearis exits 0 with a null node for a missing ticket
+    const exec = fakeExec({ code: 0, stdout: "null" });
+    expect(classifyTicketResolution("CTL-9", { exec })).toBe("not-found");
+  });
+
+  test("clean empty object → not-found (no identifier/id/state)", () => {
+    const exec = fakeExec({ code: 0, stdout: "{}" });
+    expect(classifyTicketResolution("CTL-9", { exec })).toBe("not-found");
+  });
+
+  test("REAL linearis missing-ticket shape (exit 0 + error body) → not-found", () => {
+    // Observed contract: `linearis issues read CTL-9` exits 0 with this body.
+    const exec = fakeExec({
+      code: 0,
+      stdout: JSON.stringify({ error: 'Issue with identifier "CTL-9" not found' }),
+    });
+    expect(classifyTicketResolution("CTL-9", { exec })).toBe("not-found");
+  });
+
+  test("exit-0 error body that is NOT 'not found' → unknown (auth/transient — fail safe)", () => {
+    // A non-not-found error body must never quarantine a real ticket.
+    const exec = fakeExec({ code: 0, stdout: JSON.stringify({ error: "Authentication required" }) });
+    expect(classifyTicketResolution("CTL-100", { exec })).toBe("unknown");
+  });
+
+  test("REAL linearis resolvable shape (exit 0 + identifier/id) → exists", () => {
+    const exec = fakeExec({
+      code: 0,
+      stdout: JSON.stringify({
+        id: "36fced03-bb1e-45b4-be96-234aaab39040",
+        identifier: "CTL-671",
+        title: "Guard + monitor runaway phase-dispatch loops",
+      }),
+    });
+    expect(classifyTicketResolution("CTL-671", { exec })).toBe("exists");
+  });
+
+  test("explicit not-found stderr with nonzero exit → unknown (NOT not-found — fail safe)", () => {
+    // A nonzero exit is ambiguous (auth/network/not-found all exit nonzero);
+    // never quarantine on it. This is the load-bearing safety assertion.
+    const exec = fakeExec({ code: 1, stderr: "linearis: issue CTL-9 not found" });
+    expect(classifyTicketResolution("CTL-9", { exec })).toBe("unknown");
+  });
+
+  test("auth/network failure → unknown (never quarantines a real ticket)", () => {
+    const exec = fakeExec({ code: 1, stderr: "auth failed" });
+    expect(classifyTicketResolution("CTL-100", { exec })).toBe("unknown");
+  });
+
+  test("unparseable stdout → unknown", () => {
+    const exec = fakeExec({ code: 0, stdout: "not json" });
+    expect(classifyTicketResolution("CTL-100", { exec })).toBe("unknown");
+  });
+
+  test("reads via `linearis issues read <identifier>`", () => {
+    const exec = fakeExec({ code: 0, stdout: "null" });
+    classifyTicketResolution("CTL-9", { exec });
+    expect(exec.calls[0]).toEqual({ cmd: "linearis", args: ["issues", "read", "CTL-9"] });
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -525,6 +525,28 @@ export function defaultAppendDispatchFailedEvent({
   );
 }
 
+// CTL-671: runaway-loop alert event. Fires once-per-window from schedulerTick
+// when a single ticket's per-ticket event rate dominates the unified log
+// (>= SCHEDULER_RUNAWAY_THRESHOLD events in SCHEDULER_RUNAWAY_WINDOW_MS). This
+// is OBSERVABILITY ONLY — it does not itself quarantine (the phantom sweep +
+// circuit breaker handle enforcement); a real but noisy ticket gets surfaced,
+// not killed. Routes via the broker's PHASE_EVENT_PATTERN as
+// phase.dispatch.runaway.<TICKET> (phase slot "dispatch", action "runaway").
+// Best-effort, mirroring every other audit emitter.
+export function defaultAppendRunawayEvent({ ticket, orchId, count, window_ms }) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase: "dispatch",
+      ticket,
+      orchId,
+      action: "runaway",
+      reason: "event-rate-domination",
+      payloadExtras: { count, window_ms },
+    }),
+    "runaway",
+  );
+}
+
 // CTL-660: success-path dispatch lifecycle events — the complement to
 // defaultAppendDispatchFailedEvent. The daemon already emits on the dispatch
 // FAILURE path (above) and on phase COMPLETION, but nothing when it DECIDES to

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -29,6 +29,7 @@ import {
   defaultAppendAutotuneGaugeEvent,
   defaultAppendPreemptedEvent,
   defaultAppendResumedAfterPreemptionEvent,
+  defaultAppendRunawayEvent,
   readBootEpoch,
   readDaemonEpoch,
   defaultReadRuntimeEpoch,
@@ -2500,6 +2501,24 @@ describe("dispatch lifecycle event envelopes (CTL-660)", () => {
     expect(env.body.payload.target_phase).toBe("research");
     expect(env.body.payload.bg_job_id).toBe("deadbeef");
     expect(env.body.payload.worktree_path).toBe("/wt/CTL/CTL-LC-1");
+  });
+
+  test("defaultAppendRunawayEvent writes a runaway envelope (CTL-671)", () => {
+    const ok = defaultAppendRunawayEvent({
+      ticket: "CTL-9",
+      orchId: "orch-rw",
+      count: 312,
+      window_ms: 600_000,
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["event.name"]).toBe("phase.dispatch.runaway.CTL-9");
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(env.body.payload.status).toBe("runaway");
+    expect(env.body.payload.reason).toBe("event-rate-domination");
+    expect(env.body.payload.count).toBe(312);
+    expect(env.body.payload.window_ms).toBe(600_000);
+    expect(env.attributes["catalyst.orchestration"]).toBe("orch-rw");
   });
 
   test("both helpers are fail-open: return false when the log dir is unwriteable", () => {

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -58,7 +58,7 @@ export { STAGE_RANK, NON_PREEMPTABLE_PHASES };
 // budget) live here. deriveAdvancement stays pure — the impure reads happen in
 // the sweep and are injected, so the router itself is unit-testable.
 import { readVerifyVerdict } from "./work-done-probes.mjs";
-import { countRemediateCycles } from "./event-scan.mjs";
+import { countRemediateCycles, countTicketEventsInWindow } from "./event-scan.mjs";
 import { rankTickets, compareTickets } from "./scheduler-rank.mjs";
 import { defaultDispatch, dispatchTicket, teamOf } from "./dispatch.mjs";
 import { fetchTicketState, fetchTicketRelations, classifyTicketResolution } from "./linear-query.mjs";
@@ -101,6 +101,7 @@ import {
   defaultAppendCooldownGcEvent,
   defaultAppendCooldownEscalatedEvent,
   defaultAppendPhaseAdvanceHeldEvent,
+  defaultAppendRunawayEvent,
 } from "./recovery.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
@@ -1420,6 +1421,35 @@ function maybeQuarantinePhantom(orchDir, ticket, phase, opts = {}) {
   return writeTerminalStalled(orchDir, ticket, phase, "phantom-ticket", {}, opts);
 }
 
+// CTL-671: once-per-window guard for the runaway alert, mirroring the dispatch
+// cool-down marker (timestamp + time-based window). Lives under
+// orchDir/.runaway-alerts/<ticket>.json so it never manufactures a worker dir
+// (same reasoning as the .dispatch-cooldowns placement, CTL-624). Best-effort.
+function runawayAlertPath(orchDir, ticket) {
+  return join(orchDir, ".runaway-alerts", `${ticket}.json`);
+}
+
+function inRunawayCooldown(orchDir, ticket, now) {
+  let alertedAt;
+  try {
+    alertedAt = JSON.parse(readFileSync(runawayAlertPath(orchDir, ticket), "utf8"))?.alertedAt;
+  } catch {
+    return false; // absent / malformed → not in cool-down
+  }
+  if (typeof alertedAt !== "number") return false;
+  return now - alertedAt < RUNAWAY_WINDOW_MS;
+}
+
+function recordRunawayAlert(orchDir, ticket, now) {
+  const dir = join(orchDir, ".runaway-alerts");
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(runawayAlertPath(orchDir, ticket), JSON.stringify({ ticket, alertedAt: now }));
+  } catch (err) {
+    log.warn({ ticket, err: err.message }, "scheduler: runaway-alert marker write failed — continuing");
+  }
+}
+
 // CTL-611: post-dispatch verifier. A dispatch is only really successful if
 // workers/<T>/phase-<P>.json was written with a non-empty bg_job_id and a
 // runnable status. A --dry-run leak (no signal at all) or a mark_launch_failed
@@ -1752,6 +1782,12 @@ export function schedulerTick(
     // production; sweep-specific tests inject their own stubs.
     classifyResolution = () => "unknown",
     isBgJobAlive = () => true,
+    // CTL-671: runaway-alert seams. countTicketEvents reads the unified event
+    // log (safe in tests — CATALYST_DIR is redirected), so it defaults to the
+    // real scan; appendRunawayEvent writes the canonical alert. Both injectable
+    // for hermetic unit assertions.
+    countTicketEvents = countTicketEventsInWindow,
+    appendRunawayEvent = defaultAppendRunawayEvent,
   } = {}
 ) {
   // CTL-757: emitStateWrite — caller-emit the canonical linear.state.write audit
@@ -1800,6 +1836,25 @@ export function schedulerTick(
   for (const sig of readWorkerSignals(orchDir)) {
     if (!sig.ticket) continue;
     if (!isTicketInFlight(readPhaseSignals(orchDir, sig.ticket))) continue; // skip terminal — no probe
+
+    // CTL-671 runaway-rate alert — OBSERVABILITY ONLY (does not quarantine, so
+    // it covers noisy-but-real tickets too and runs before the phantom gates).
+    // Fires once per RUNAWAY_WINDOW_MS via the .runaway-alerts/<ticket> marker.
+    const evCount = countTicketEvents({ ticket: sig.ticket, windowMs: RUNAWAY_WINDOW_MS, now });
+    if (evCount >= RUNAWAY_THRESHOLD && !inRunawayCooldown(orchDir, sig.ticket, now())) {
+      appendRunawayEvent({
+        ticket: sig.ticket,
+        orchId: sig.raw?.orchestrator ?? sig.ticket,
+        count: evCount,
+        window_ms: RUNAWAY_WINDOW_MS,
+      });
+      recordRunawayAlert(orchDir, sig.ticket, now());
+      log.warn(
+        { ticket: sig.ticket, count: evCount, window_ms: RUNAWAY_WINDOW_MS },
+        "scheduler: ticket event-rate domination — emitted phase.dispatch.runaway (CTL-671)"
+      );
+    }
+
     if (eligibleIds.has(sig.ticket)) continue; // (a) eligible → real ticket
     const bgId = sig.liveness?.kind === "bg" ? sig.liveness.value : null;
     if (isBgJobAlive(bgId)) continue; // (c) live worker → cheap check before the Linear call
@@ -2916,6 +2971,16 @@ const getMaxDispatchRetries = () => Number(process.env.SCHEDULER_MAX_DISPATCH_RE
 // resets the counter, so a healthy ticket can never trip it.
 export const CIRCUIT_BREAKER_THRESHOLD =
   Number(process.env.SCHEDULER_CIRCUIT_BREAKER_THRESHOLD) || 8;
+
+// CTL-671: per-ticket event-rate domination alert. When a single ticket emits
+// >= RUNAWAY_THRESHOLD phase.*.<ticket> events within RUNAWAY_WINDOW_MS, the
+// scheduler fires ONE phase.dispatch.runaway.<ticket> event per window
+// (observability only — enforcement is the phantom sweep + circuit breaker).
+// CTL-9's storm was ~24,560 events over 3 days; 50-in-10min is a conservative
+// floor far above any healthy ticket's per-window rate.
+export const RUNAWAY_THRESHOLD = Number(process.env.SCHEDULER_RUNAWAY_THRESHOLD) || 50;
+export const RUNAWAY_WINDOW_MS =
+  Number(process.env.SCHEDULER_RUNAWAY_WINDOW_MS) || 10 * 60 * 1000;
 
 // --- daemon module state ---
 let tickTimer = null;

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -3076,11 +3076,13 @@ function runTick() {
       // A test may inject its own via startScheduler({ prAdapter }); production
       // gets the real makePrView-backed adapter.
       prAdapter: runningOpts.prAdapter,
-      // CTL-671: arm the phantom worker-dir validity sweep with the real Linear
-      // probe + bg-liveness reader (schedulerTick's defaults are safe no-ops).
-      // ?? lets a daemon test inject hermetic stubs via runningOpts.
-      classifyResolution: runningOpts.classifyResolution ?? classifyTicketResolution,
-      isBgJobAlive: runningOpts.isBgJobAlive ?? defaultIsBgJobAlive,
+      // CTL-671: phantom-sweep seams threaded from startScheduler. Undefined for
+      // a direct startScheduler caller that did not opt in (unit tests) →
+      // schedulerTick's SAFE no-op defaults apply, so a bare daemon tick never
+      // shells out to linearis / `claude agents`. The real daemon (startDaemon)
+      // + the standalone main() pass the real impls to arm the sweep.
+      classifyResolution: runningOpts.classifyResolution,
+      isBgJobAlive: runningOpts.isBgJobAlive,
     });
   } catch (err) {
     // A tick must never crash the daemon — log and let the next tick retry.
@@ -3146,8 +3148,9 @@ export function startScheduler({
     }),
   },
   preflight = preflightWorkspaceLabels, // CTL-585
-  // CTL-671: phantom-sweep seams — undefined here falls back to the real impls
-  // in runTick; a daemon test can inject hermetic stubs.
+  // CTL-671: phantom-sweep seams. Undefined → schedulerTick's safe no-op
+  // defaults (hermetic for unit tests that call startScheduler directly). The
+  // real daemon (startDaemon) and the standalone main() pass the real impls.
   classifyResolution,
   isBgJobAlive,
   tickIntervalMs = TICK_INTERVAL_MS,
@@ -3250,7 +3253,14 @@ function main() {
     process.exit(1);
   }
   log.info({ orchDir }, "execution-core scheduler starting");
-  startScheduler({ orchDir });
+  // CTL-671: arm the phantom worker-dir validity sweep + bg-liveness reader with
+  // the real impls (startScheduler defaults them to safe no-ops for hermetic
+  // unit tests). This standalone dry-run mirrors the real daemon's behavior.
+  startScheduler({
+    orchDir,
+    classifyResolution: classifyTicketResolution,
+    isBgJobAlive: defaultIsBgJobAlive,
+  });
   const shutdown = (sig) => {
     log.info({ sig }, "execution-core scheduler shutting down");
     stopScheduler();

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -61,7 +61,7 @@ import { readVerifyVerdict } from "./work-done-probes.mjs";
 import { countRemediateCycles } from "./event-scan.mjs";
 import { rankTickets, compareTickets } from "./scheduler-rank.mjs";
 import { defaultDispatch, dispatchTicket, teamOf } from "./dispatch.mjs";
-import { fetchTicketState, fetchTicketRelations } from "./linear-query.mjs";
+import { fetchTicketState, fetchTicketRelations, classifyTicketResolution } from "./linear-query.mjs";
 import { getProjectConfig, listProjects } from "./registry.mjs";
 import { teardownWorktree as defaultTeardownWorktree } from "./worktree.mjs";
 import { readWorkerSignals } from "./signal-reader.mjs";
@@ -73,7 +73,11 @@ import { readWorkerSignals } from "./signal-reader.mjs";
 // never per-tick / per-ticket — the gh subprocess only fires from inside prView
 // on the rare merged-zombie / drift path, not on construction.
 import { makePrView } from "./scan-adapters.mjs";
-import { countBackgroundAgents, getAgentsCached } from "./claude-agents.mjs";
+import {
+  countBackgroundAgents,
+  getAgentsCached,
+  isBgJobAlive as defaultIsBgJobAlive,
+} from "./claude-agents.mjs";
 import { emitReapIntent } from "./reap-intent.mjs";
 // CTL-574: per-tick reclaim of dead-but-work-done phase workers. The default
 // is the real recovery-module function; tests inject a fake. See
@@ -1406,6 +1410,16 @@ export function maybeTripCircuitBreaker(orchDir, ticket, phase, opts = {}) {
   return true;
 }
 
+// CTL-671: quarantine a phantom worker dir to terminal `stalled`. Thin wrapper
+// over writeTerminalStalled with reason "phantom-ticket". The phantom sweep
+// (schedulerTick Pass 0a) only calls this after the full conjunction — Linear
+// not-found AND not-eligible AND no live bg job — so a Linear outage (unknown)
+// or a real in-flight ticket is never quarantined. Returns true when the signal
+// is (or was already) stalled, false when there was no signal to stall.
+function maybeQuarantinePhantom(orchDir, ticket, phase, opts = {}) {
+  return writeTerminalStalled(orchDir, ticket, phase, "phantom-ticket", {}, opts);
+}
+
 // CTL-611: post-dispatch verifier. A dispatch is only really successful if
 // workers/<T>/phase-<P>.json was written with a non-empty bg_job_id and a
 // runnable status. A --dry-run leak (no signal at all) or a mark_launch_failed
@@ -1728,6 +1742,16 @@ export function schedulerTick(
     // runningOpts.prAdapter → runTick, so both paths fire live. Injectable so
     // tests can exercise the pr-merged branch without shelling out to `gh`.
     prAdapter = undefined,
+    // CTL-671: phantom worker-dir validity sweep seams. classifyResolution is
+    // the 3-valued Linear probe (exists|not-found|unknown); isBgJobAlive maps a
+    // dead worker's bg_job_id to a live `claude agents` session. The DEFAULTS
+    // here are deliberately SAFE no-ops (resolution always "unknown", liveness
+    // always alive) so a bare unit tick never shells out to linearis /
+    // `claude agents` and never quarantines. The daemon (runTick) injects the
+    // real classifyTicketResolution + isBgJobAlive to arm the sweep in
+    // production; sweep-specific tests inject their own stubs.
+    classifyResolution = () => "unknown",
+    isBgJobAlive = () => true,
   } = {}
 ) {
   // CTL-757: emitStateWrite — caller-emit the canonical linear.state.write audit
@@ -1755,6 +1779,38 @@ export function schedulerTick(
       },
       { ticket, phase, source }
     );
+  }
+
+  // CTL-671: compute the eligible set ONCE per tick. Consumed by the phantom
+  // validity sweep (Pass 0a, below) and the new-work pull (Pass 2). readEligible
+  // is the test injection seam; production reads all per-project eligible
+  // projections (written exclusively from a live `linearis issues list`).
+  const eligible = readEligible ? readEligible() : readAllEligibleTickets();
+  const eligibleIds = new Set(eligible.map((t) => t.identifier));
+
+  // (0a) CTL-671 phantom/orphan validity sweep — quarantine a worker dir whose
+  // ticket is definitively non-existent in Linear, NOT in the eligible set, and
+  // has NO live bg worker. The conjunction of all three is required so a Linear
+  // outage (unknown resolution) or a real in-flight ticket is never touched.
+  // Runs BEFORE the reclaim sweep so the per-tick probe-storm path that
+  // sustained phantom CTL-9 (24,560 events) is cut on the first tick that sees
+  // it, instead of looping forever. Cheap checks (eligible membership, then
+  // bg-liveness) gate the Linear call, so a healthy fleet pays nothing.
+  const quarantinedPhantoms = [];
+  for (const sig of readWorkerSignals(orchDir)) {
+    if (!sig.ticket) continue;
+    if (!isTicketInFlight(readPhaseSignals(orchDir, sig.ticket))) continue; // skip terminal — no probe
+    if (eligibleIds.has(sig.ticket)) continue; // (a) eligible → real ticket
+    const bgId = sig.liveness?.kind === "bg" ? sig.liveness.value : null;
+    if (isBgJobAlive(bgId)) continue; // (c) live worker → cheap check before the Linear call
+    if (classifyResolution(sig.ticket, { exec }) !== "not-found") continue; // (b) definitive only
+    if (maybeQuarantinePhantom(orchDir, sig.ticket, sig.phase)) {
+      quarantinedPhantoms.push({ ticket: sig.ticket, phase: sig.phase });
+      log.warn(
+        { ticket: sig.ticket, phase: sig.phase },
+        "scheduler: quarantined phantom worker dir (not-found + not-eligible + dead bg) — CTL-671"
+      );
+    }
   }
 
   // (0) Reclaim-dead-work sweep (CTL-574) — close phase signals whose bg worker
@@ -1911,9 +1967,10 @@ export function schedulerTick(
     }
   }
 
-  // CTL-705: hoist eligible read here so both the preemption sweep (0.5) and
-  // the new-work pull (2) share a single read per tick.
-  const eligible = readEligible ? readEligible() : readAllEligibleTickets();
+  // CTL-705: the eligible read is hoisted to the top of the tick (see the CTL-671
+  // phantom-sweep block above) so the preemption sweep (0.5), the new-work pull
+  // (2), and the phantom sweep (0a) all share a single read per tick. `eligible`
+  // is already in scope here.
 
   // CTL-705: hoist the worker-slot ceiling + live background count to a SINGLE
   // read per tick, shared by the preemption sweep (0.5), the resume sweep (1.5),
@@ -2547,7 +2604,8 @@ export function schedulerTick(
 
   // (2) New-work pull — fill free slots with top-ranked ready tickets. D5:
   // hydrate the live state of every out-of-set blocker first so a Ready ticket
-  // blocked by a non-terminal out-of-set ticket is held back.
+  // blocked by a non-terminal out-of-set ticket is held back. `eligible` was
+  // computed once at the top of the tick (CTL-671) and is reused here.
   // CTL-705: `eligible` is hoisted above sweep 0.5 — used by buildGlobalRanking there.
   const blockerStates = hydrateOutOfSetBlockers(eligible, { exec, cache });
   // CTL-634: surface the cache hit-rate once per tick. Log-line-only matches
@@ -2797,8 +2855,8 @@ export function schedulerTick(
   // (4) Cooldown GC sweep (CTL-713) — reap expired markers for tickets that
   // have left the eligible set so .dispatch-cooldowns/ self-cleans instead of
   // accumulating orphans. Runs last: GC must not influence this tick's dispatch
-  // decisions.
-  const eligibleIds = new Set(eligible.map((t) => t.identifier));
+  // decisions. `eligibleIds` is computed once at the top of the tick (CTL-671
+  // phantom-sweep block) and is already in scope here.
   for (const { ticket, phase } of gcDispatchCooldowns(orchDir, eligibleIds, now())) {
     appendCooldownGcEvent({ ticket, orchId: ticket, target_phase: phase });
   }
@@ -2809,6 +2867,7 @@ export function schedulerTick(
     reviveSuppressed,
     noProgressStopped,
     escalated,
+    quarantinedPhantoms, // CTL-671 — phantom worker dirs stalled this tick
     advanced,
     dispatched,
     freeSlots,
@@ -2952,6 +3011,11 @@ function runTick() {
       // A test may inject its own via startScheduler({ prAdapter }); production
       // gets the real makePrView-backed adapter.
       prAdapter: runningOpts.prAdapter,
+      // CTL-671: arm the phantom worker-dir validity sweep with the real Linear
+      // probe + bg-liveness reader (schedulerTick's defaults are safe no-ops).
+      // ?? lets a daemon test inject hermetic stubs via runningOpts.
+      classifyResolution: runningOpts.classifyResolution ?? classifyTicketResolution,
+      isBgJobAlive: runningOpts.isBgJobAlive ?? defaultIsBgJobAlive,
     });
   } catch (err) {
     // A tick must never crash the daemon — log and let the next tick retry.
@@ -3017,6 +3081,10 @@ export function startScheduler({
     }),
   },
   preflight = preflightWorkspaceLabels, // CTL-585
+  // CTL-671: phantom-sweep seams — undefined here falls back to the real impls
+  // in runTick; a daemon test can inject hermetic stubs.
+  classifyResolution,
+  isBgJobAlive,
   tickIntervalMs = TICK_INTERVAL_MS,
   debounceMs = TICK_DEBOUNCE_MS,
 } = {}) {
@@ -3038,6 +3106,8 @@ export function startScheduler({
     fetchRelations, // CTL-755: optional admission-gate hydration seam
     appendPhaseAdvanceHeldEvent, // CTL-755: optional held-indicator emit seam
     prAdapter, // CTL-642/758: live PR-merged adapter (built once above), threaded per-tick
+    classifyResolution, // CTL-671: optional phantom-sweep Linear-probe seam
+    isBgJobAlive, // CTL-671: optional phantom-sweep bg-liveness seam
   };
 
   // CTL-585: warn once at startup if the Linear workspace lacks the labels

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1195,31 +1195,38 @@ export function dispatchCooldownPath(orchDir, ticket, phase) {
   return join(orchDir, ".dispatch-cooldowns", `${ticket}-${phase}.json`);
 }
 
-export function inDispatchCooldown(orchDir, ticket, phase, now) {
-  const p = dispatchCooldownPath(orchDir, ticket, phase);
-  let marker;
+// CTL-671: single reader for the cool-down marker, shared by inDispatchCooldown,
+// recordDispatchFailure, and maybeTripCircuitBreaker (avoids three copies of the
+// try/parse). Returns the parsed marker object, or null when absent/malformed.
+function readCooldownMarker(orchDir, ticket, phase) {
   try {
-    marker = JSON.parse(readFileSync(p, "utf8"));
+    return JSON.parse(readFileSync(dispatchCooldownPath(orchDir, ticket, phase), "utf8"));
   } catch {
-    return false; // absent / malformed → no cool-down
+    return null; // absent / malformed → treat as no marker
   }
-  if (typeof marker?.expiresAt === "number") return now < marker.expiresAt;
+}
+
+export function inDispatchCooldown(orchDir, ticket, phase, now) {
+  const marker = readCooldownMarker(orchDir, ticket, phase);
+  if (!marker) return false; // absent / malformed → no cool-down
+  if (typeof marker.expiresAt === "number") return now < marker.expiresAt;
   // Legacy CTL-624 marker (failedAt only): preserve old behavior.
-  if (typeof marker?.failedAt === "number") return now - marker.failedAt < DISPATCH_COOLDOWN_MS;
+  if (typeof marker.failedAt === "number") return now - marker.failedAt < DISPATCH_COOLDOWN_MS;
   return false;
 }
 
+// CTL-671: extends the CTL-624 marker with a `consecutiveFailures` counter
+// (read-modify-write, preserving every existing field — phase/code/failedAt). A
+// pre-CTL-671 marker without the counter reads as 0 (the `?? 0` default) and
+// self-upgrades on this write. clearDispatchCooldown rmSync's the whole marker,
+// so a successful dispatch resets the counter for free.
 export function recordDispatchFailure(orchDir, ticket, phase, code, now) {
   const dir = join(orchDir, ".dispatch-cooldowns");
   const path = dispatchCooldownPath(orchDir, ticket, phase);
+  const prev = readCooldownMarker(orchDir, ticket, phase);
   let consecutiveFailures = 1;
-  try {
-    const prev = JSON.parse(readFileSync(path, "utf8"));
-    if (prev?.code === code && typeof prev.consecutiveFailures === "number") {
-      consecutiveFailures = prev.consecutiveFailures + 1;
-    }
-  } catch {
-    // absent / malformed / legacy-without-counter → start at 1
+  if (prev?.code === code && typeof prev.consecutiveFailures === "number") {
+    consecutiveFailures = prev.consecutiveFailures + 1;
   }
   const ttl = PERMANENT_FAILURE_CODES.has(code)
     ? DISPATCH_PERMANENT_COOLDOWN_MS
@@ -1333,6 +1340,69 @@ export function escalateDispatchExhausted(
     return false;
   }
   clearDispatchCooldown(orchDir, ticket, phase); // marker no longer needed; stalled signal is the stop
+  return true;
+}
+
+// CTL-671: shared terminal-`stalled` writer for the dispatch circuit breaker
+// (Phase 1) and the phantom worker-dir sweep (Phase 3). Writes status:"stalled"
+// + stalledReason onto an EXISTING phase signal in place (every other field
+// preserved), so isTicketInFlight() drops the ticket and the terminal sweep
+// applies `needs-human`. Idempotent (a signal already stalled is a no-op).
+// Best-effort: a missing/unreadable signal returns false (nothing to stall) —
+// the caller decides whether that still counts as "handled". Mirrors the shape
+// of maybeEscalateRemediateExhausted's in-place write.
+function writeTerminalStalled(
+  orchDir,
+  ticket,
+  phase,
+  reason,
+  extra = {},
+  { readFile = readFileSync, writeFile = writeFileSync } = {}
+) {
+  const p = join(orchDir, "workers", ticket, `phase-${phase}.json`);
+  let cur;
+  try {
+    cur = JSON.parse(readFile(p, "utf8"));
+  } catch {
+    return false; // no signal to stall
+  }
+  if (cur.status === "stalled") return true; // idempotent
+  try {
+    writeFile(
+      p,
+      JSON.stringify({
+        ...cur,
+        ...extra,
+        status: "stalled",
+        stalledReason: reason,
+        updatedAt: new Date().toISOString(),
+      })
+    );
+  } catch {
+    return false; // best-effort — could not persist the stall
+  }
+  return true;
+}
+
+// CTL-671: trip the per-ticket dispatch circuit breaker. When the cool-down
+// marker's consecutiveFailures >= CIRCUIT_BREAKER_THRESHOLD, write terminal
+// `stalled` onto the ticket's phase signal (via writeTerminalStalled) so
+// isTicketInFlight() drops it and the terminal sweep applies `needs-human`.
+// Returns true at/above threshold REGARDLESS of whether a signal existed to
+// stall — a refused dispatch never wrote a target-phase signal, but the caller
+// must still stop re-dispatching. Below threshold (or no marker) → false.
+// Idempotent. Best-effort.
+export function maybeTripCircuitBreaker(orchDir, ticket, phase, opts = {}) {
+  const n = readCooldownMarker(orchDir, ticket, phase)?.consecutiveFailures ?? 0;
+  if (n < CIRCUIT_BREAKER_THRESHOLD) return false;
+  writeTerminalStalled(
+    orchDir,
+    ticket,
+    phase,
+    "dispatch-circuit-breaker",
+    { consecutiveFailures: n },
+    opts
+  );
   return true;
 }
 
@@ -2255,6 +2325,9 @@ export function schedulerTick(
     // for the triage→research edge; non-research edges skip the guard.
     if (next === NEW_WORK_ENTRY_PHASE && signals.triage === "done" && !admittedThisTick.has(ticket)) continue;
     if (inDispatchCooldown(orchDir, ticket, next, now())) continue; // CTL-624: throttle refused re-dispatch
+    // CTL-671: circuit breaker — once consecutiveFailures has crossed the
+    // threshold, quarantine to terminal `stalled` and stop re-dispatching.
+    if (maybeTripCircuitBreaker(orchDir, ticket, next)) continue;
     // CTL-660: record the dispatch DECISION before the spawn. Best-effort.
     safeEmit(
       appendDispatchRequestedEvent,
@@ -2324,6 +2397,7 @@ export function schedulerTick(
         // see the drop.
         const cd1 = recordDispatchFailure(orchDir, ticket, next, 0, now());
         if (cd1.consecutiveFailures >= getMaxDispatchRetries()) escalateDispatchExhausted(orchDir, ticket, next); // CTL-712 terminal stop
+        maybeTripCircuitBreaker(orchDir, ticket, next); // CTL-671: trip same tick if at threshold
         appendDispatchFailedEvent({
           orchId: ticket,
           ticket,
@@ -2345,6 +2419,7 @@ export function schedulerTick(
     } else {
       const cd2 = recordDispatchFailure(orchDir, ticket, next, r.code, now()); // CTL-624: arm the cool-down window
       if (cd2.consecutiveFailures >= getMaxDispatchRetries()) escalateDispatchExhausted(orchDir, ticket, next); // CTL-712 terminal stop
+      maybeTripCircuitBreaker(orchDir, ticket, next); // CTL-671: trip same tick if at threshold
       // CTL-611 Gap 2: surface the silent drop as an event so the broker /
       // HUD / operator can react. Best-effort; failure is logged inside.
       appendDispatchFailedEvent({
@@ -2570,6 +2645,9 @@ export function schedulerTick(
       if (verdict?.verdict === "hold") continue; // soft conflict — no cooldown marker
       // "go" → fall through to existing dispatch
     }
+    // CTL-671: circuit breaker — stop re-dispatching a new-work ticket that has
+    // failed its entry-phase dispatch THRESHOLD times in a row.
+    if (maybeTripCircuitBreaker(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE)) continue;
     // CTL-660: record the new-work dispatch DECISION before the spawn.
     safeEmit(
       appendDispatchRequestedEvent,
@@ -2625,6 +2703,7 @@ export function schedulerTick(
       } else {
         const cd3 = recordDispatchFailure(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, 0, now());
         if (cd3.consecutiveFailures >= getMaxDispatchRetries()) escalateDispatchExhausted(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE); // CTL-712 terminal stop
+        maybeTripCircuitBreaker(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE); // CTL-671
         appendDispatchFailedEvent({
           orchId: t.identifier,
           ticket: t.identifier,
@@ -2643,6 +2722,7 @@ export function schedulerTick(
     } else {
       const cd4 = recordDispatchFailure(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, r.code, now()); // CTL-624: arm the cool-down window
       if (cd4.consecutiveFailures >= getMaxDispatchRetries()) escalateDispatchExhausted(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE); // CTL-712 terminal stop
+      maybeTripCircuitBreaker(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE); // CTL-671
       // CTL-611: Gap 2 entry-phase silent-drop event.
       appendDispatchFailedEvent({
         orchId: t.identifier,
@@ -2769,6 +2849,14 @@ const DISPATCH_FAILURE_ESCALATION_THRESHOLD =
 // writes the stalled signal that terminally stops the loop; the CTL-713 label
 // escalation at DISPATCH_FAILURE_ESCALATION_THRESHOLD (3) fires earlier as a flag.
 const getMaxDispatchRetries = () => Number(process.env.SCHEDULER_MAX_DISPATCH_RETRIES) || 5;
+
+// CTL-671: consecutive failed dispatches (no forward progress) before the ticket
+// is quarantined to terminal `stalled` by the dispatch circuit breaker.
+// Conservative default — well above any legitimate transient (rebase race,
+// momentary launch failure). A successful dispatch (clearDispatchCooldown)
+// resets the counter, so a healthy ticket can never trip it.
+export const CIRCUIT_BREAKER_THRESHOLD =
+  Number(process.env.SCHEDULER_CIRCUIT_BREAKER_THRESHOLD) || 8;
 
 // --- daemon module state ---
 let tickTimer = null;

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -50,6 +50,8 @@ import {
   escalateDispatchExhausted,
   maybeTripCircuitBreaker,
   CIRCUIT_BREAKER_THRESHOLD,
+  RUNAWAY_THRESHOLD,
+  RUNAWAY_WINDOW_MS,
   verifyDispatchedSignal,
   gcDispatchCooldowns,
   maybeEscalateDispatchFailures,
@@ -1250,6 +1252,88 @@ describe("phantom worker-dir validity sweep (CTL-671)", () => {
       isBgJobAlive: () => false,
     });
     expect(result.quarantinedPhantoms).toEqual([{ ticket: "CTL-9", phase: "implement" }]);
+  });
+});
+
+// ── CTL-671 Phase 4: runaway event-rate domination alert ──
+describe("runaway event-rate alert (CTL-671)", () => {
+  test("emits exactly one runaway event per window when a ticket dominates", () => {
+    writeSignal("CTL-9", "implement", "running");
+    const runawayCalls = [];
+    const opts = {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      liveBackgroundCount: () => 0,
+      isBgJobAlive: () => true, // isolate the alert from phantom quarantine
+      countTicketEvents: () => RUNAWAY_THRESHOLD, // at threshold → fires
+      appendRunawayEvent: (arg) => {
+        runawayCalls.push(arg);
+        return true;
+      },
+      now: () => 1_000_000,
+    };
+    schedulerTick(orchDir, opts);
+    expect(runawayCalls).toHaveLength(1);
+    expect(runawayCalls[0]).toMatchObject({
+      ticket: "CTL-9",
+      count: RUNAWAY_THRESHOLD,
+      window_ms: RUNAWAY_WINDOW_MS,
+    });
+
+    // Second tick within the same window → suppressed by the once-per-window marker.
+    schedulerTick(orchDir, opts);
+    expect(runawayCalls).toHaveLength(1);
+
+    // A tick past the window → fires again.
+    schedulerTick(orchDir, { ...opts, now: () => 1_000_000 + RUNAWAY_WINDOW_MS + 1 });
+    expect(runawayCalls).toHaveLength(2);
+  });
+
+  test("does NOT emit below threshold", () => {
+    writeSignal("CTL-9", "implement", "running");
+    const runawayCalls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      liveBackgroundCount: () => 0,
+      isBgJobAlive: () => true,
+      countTicketEvents: () => RUNAWAY_THRESHOLD - 1, // below threshold
+      appendRunawayEvent: (arg) => {
+        runawayCalls.push(arg);
+        return true;
+      },
+      now: () => 1_000_000,
+    });
+    expect(runawayCalls).toHaveLength(0);
+  });
+
+  test("alerts a noisy ticket even when it is eligible (real but runaway)", () => {
+    // The alert is observability, not enforcement — it must fire before the
+    // eligible short-circuit so a real, eligible, noisy ticket is still surfaced.
+    writeSignal("CTL-100", "implement", "running");
+    const runawayCalls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [
+        {
+          identifier: "CTL-100",
+          priority: 1,
+          state: "Todo",
+          relations: { nodes: [] },
+          inverseRelations: { nodes: [] },
+        },
+      ],
+      dispatch: () => ({ code: 0 }),
+      liveBackgroundCount: () => 0,
+      isBgJobAlive: () => true,
+      countTicketEvents: () => RUNAWAY_THRESHOLD + 5,
+      appendRunawayEvent: (arg) => {
+        runawayCalls.push(arg);
+        return true;
+      },
+      now: () => 2_000_000,
+    });
+    expect(runawayCalls).toHaveLength(1);
+    expect(runawayCalls[0].ticket).toBe("CTL-100");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -48,6 +48,8 @@ import {
   clearDispatchCooldown,
   dispatchCooldownPath,
   escalateDispatchExhausted,
+  maybeTripCircuitBreaker,
+  CIRCUIT_BREAKER_THRESHOLD,
   verifyDispatchedSignal,
   gcDispatchCooldowns,
   maybeEscalateDispatchFailures,
@@ -1009,6 +1011,112 @@ describe("dispatch cool-down escalation", () => {
       });
     }
     expect(applied).toContainEqual({ ticket: "CTL-7", label: "needs-human" });
+  });
+});
+
+// ── CTL-671 Phase 1: per-ticket dispatch-failure circuit breaker ──
+describe("dispatch circuit breaker (CTL-671)", () => {
+  test("recordDispatchFailure increments consecutiveFailures and preserves CTL-624 fields", () => {
+    const t = "CTL-9",
+      phase = "research";
+    recordDispatchFailure(orchDir, t, phase, 1, 1000);
+    recordDispatchFailure(orchDir, t, phase, 1, 2000);
+    const m = JSON.parse(readFileSync(dispatchCooldownPath(orchDir, t, phase), "utf8"));
+    expect(m.failedAt).toBe(2000); // CTL-624 field preserved (latest)
+    expect(m.phase).toBe(phase); // CTL-624 field preserved
+    expect(m.code).toBe(1); // CTL-624 field preserved
+    expect(m.consecutiveFailures).toBe(2); // new counter
+  });
+
+  test("clearDispatchCooldown resets the counter (success heals)", () => {
+    recordDispatchFailure(orchDir, "CTL-9", "research", 1, 1000);
+    clearDispatchCooldown(orchDir, "CTL-9", "research");
+    // marker gone → fresh failure starts at 1
+    recordDispatchFailure(orchDir, "CTL-9", "research", 1, 3000);
+    const m = JSON.parse(readFileSync(dispatchCooldownPath(orchDir, "CTL-9", "research"), "utf8"));
+    expect(m.consecutiveFailures).toBe(1);
+  });
+
+  test("a pre-CTL-671 marker without consecutiveFailures self-upgrades from 0", () => {
+    // A legacy CTL-624 marker (no counter field) reads as 0, so the first new
+    // failure writes consecutiveFailures: 1 (the `?? 0` default — Migration Notes).
+    mkdirSync(join(orchDir, ".dispatch-cooldowns"), { recursive: true });
+    writeFileSync(
+      dispatchCooldownPath(orchDir, "CTL-9", "research"),
+      JSON.stringify({ phase: "research", code: 2, failedAt: 500 })
+    );
+    recordDispatchFailure(orchDir, "CTL-9", "research", 2, 1000);
+    const m = JSON.parse(readFileSync(dispatchCooldownPath(orchDir, "CTL-9", "research"), "utf8"));
+    expect(m.consecutiveFailures).toBe(1);
+  });
+
+  test("maybeTripCircuitBreaker writes terminal stalled at threshold, idempotently", () => {
+    const t = "CTL-9",
+      phase = "research";
+    writeSignal(t, phase, "running");
+    for (let i = 1; i <= CIRCUIT_BREAKER_THRESHOLD; i++)
+      recordDispatchFailure(orchDir, t, phase, 1, i * 1000);
+    expect(maybeTripCircuitBreaker(orchDir, t, phase)).toBe(true);
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", t, `phase-${phase}.json`), "utf8")
+    );
+    expect(sig.status).toBe("stalled");
+    expect(sig.stalledReason).toBe("dispatch-circuit-breaker");
+    expect(sig.consecutiveFailures).toBe(CIRCUIT_BREAKER_THRESHOLD);
+    expect(maybeTripCircuitBreaker(orchDir, t, phase)).toBe(true); // idempotent (already stalled)
+  });
+
+  test("below threshold does NOT trip", () => {
+    writeSignal("CTL-9", "research", "running");
+    recordDispatchFailure(orchDir, "CTL-9", "research", 1, 1000);
+    expect(maybeTripCircuitBreaker(orchDir, "CTL-9", "research")).toBe(false);
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", "CTL-9", "phase-research.json"), "utf8")
+    );
+    expect(sig.status).toBe("running"); // untouched
+  });
+
+  test("no marker → does NOT trip (absent counter)", () => {
+    expect(maybeTripCircuitBreaker(orchDir, "CTL-9", "research")).toBe(false);
+  });
+
+  test("at threshold with no signal still reports tripped so the caller skips dispatch", () => {
+    // Refused-dispatch case: the target phase signal was never written. The
+    // breaker has nothing to stall but must still return true so the caller
+    // stops re-dispatching.
+    const t = "CTL-9",
+      phase = "plan";
+    for (let i = 1; i <= CIRCUIT_BREAKER_THRESHOLD; i++)
+      recordDispatchFailure(orchDir, t, phase, 2, i * 1000);
+    expect(maybeTripCircuitBreaker(orchDir, t, phase)).toBe(true);
+    expect(existsSync(join(orchDir, "workers", t, `phase-${phase}.json`))).toBe(false);
+  });
+
+  test("schedulerTick stops dispatching after THRESHOLD consecutive failures", () => {
+    writeSignal("CTL-9", "research", "done"); // in-flight; advancement → plan
+    const dispatch = fakeDispatch({ code: 2 }); // every dispatch refused
+    // Each tick is past the 60 s cool-down window so a fresh failure records.
+    for (let i = 0; i < CIRCUIT_BREAKER_THRESHOLD; i++) {
+      schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch,
+        now: () => (i + 1) * 70_000,
+        liveBackgroundCount: () => 0,
+      });
+    }
+    expect(dispatch.calls).toHaveLength(CIRCUIT_BREAKER_THRESHOLD);
+    const m = JSON.parse(
+      readFileSync(dispatchCooldownPath(orchDir, "CTL-9", "plan"), "utf8")
+    );
+    expect(m.consecutiveFailures).toBe(CIRCUIT_BREAKER_THRESHOLD);
+    // One more tick past the window: the top-of-loop breaker guard suppresses it.
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      now: () => (CIRCUIT_BREAKER_THRESHOLD + 2) * 70_000,
+      liveBackgroundCount: () => 0,
+    });
+    expect(dispatch.calls).toHaveLength(CIRCUIT_BREAKER_THRESHOLD); // no growth — breaker held
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1093,30 +1093,163 @@ describe("dispatch circuit breaker (CTL-671)", () => {
   });
 
   test("schedulerTick stops dispatching after THRESHOLD consecutive failures", () => {
-    writeSignal("CTL-9", "research", "done"); // in-flight; advancement → plan
-    const dispatch = fakeDispatch({ code: 2 }); // every dispatch refused
-    // Each tick is past the 60 s cool-down window so a fresh failure records.
-    for (let i = 0; i < CIRCUIT_BREAKER_THRESHOLD; i++) {
+    // Rebase note (CTL-671 onto CTL-712/CTL-713): two sibling mechanisms now
+    // co-exist on the advancement path — the CTL-712 max-dispatch-retries
+    // terminal stop (escalateDispatchExhausted at getMaxDispatchRetries()=5) and
+    // CTL-671's own circuit breaker (CIRCUIT_BREAKER_THRESHOLD=8). To isolate the
+    // CTL-671 breaker (the subject under test) we lift the CTL-712 ceiling above
+    // the breaker threshold so the breaker is the gate that fires. We also use a
+    // TRANSIENT failure code (1): CTL-712 classifies code 2 as a PERMANENT failure
+    // (PERMANENT_FAILURE_CODES) with a 30-min cooldown, which would suppress the
+    // re-dispatch retries this test relies on.
+    const prevMax = process.env.SCHEDULER_MAX_DISPATCH_RETRIES;
+    process.env.SCHEDULER_MAX_DISPATCH_RETRIES = String(CIRCUIT_BREAKER_THRESHOLD + 5);
+    try {
+      writeSignal("CTL-9", "research", "done"); // in-flight; advancement → plan
+      const dispatch = fakeDispatch({ code: 1 }); // every dispatch refused (transient)
+      // Each tick is past the 60 s cool-down window so a fresh failure records.
+      for (let i = 0; i < CIRCUIT_BREAKER_THRESHOLD; i++) {
+        schedulerTick(orchDir, {
+          readEligible: () => [],
+          dispatch,
+          now: () => (i + 1) * 70_000,
+          liveBackgroundCount: () => 0,
+        });
+      }
+      expect(dispatch.calls).toHaveLength(CIRCUIT_BREAKER_THRESHOLD);
+      const m = JSON.parse(
+        readFileSync(dispatchCooldownPath(orchDir, "CTL-9", "plan"), "utf8")
+      );
+      expect(m.consecutiveFailures).toBe(CIRCUIT_BREAKER_THRESHOLD);
+      // One more tick past the window: the top-of-loop breaker guard suppresses it.
       schedulerTick(orchDir, {
         readEligible: () => [],
         dispatch,
-        now: () => (i + 1) * 70_000,
+        now: () => (CIRCUIT_BREAKER_THRESHOLD + 2) * 70_000,
         liveBackgroundCount: () => 0,
       });
+      expect(dispatch.calls).toHaveLength(CIRCUIT_BREAKER_THRESHOLD); // no growth — breaker held
+    } finally {
+      if (prevMax === undefined) delete process.env.SCHEDULER_MAX_DISPATCH_RETRIES;
+      else process.env.SCHEDULER_MAX_DISPATCH_RETRIES = prevMax;
     }
-    expect(dispatch.calls).toHaveLength(CIRCUIT_BREAKER_THRESHOLD);
-    const m = JSON.parse(
-      readFileSync(dispatchCooldownPath(orchDir, "CTL-9", "plan"), "utf8")
-    );
-    expect(m.consecutiveFailures).toBe(CIRCUIT_BREAKER_THRESHOLD);
-    // One more tick past the window: the top-of-loop breaker guard suppresses it.
+  });
+});
+
+// ── CTL-671 Phase 3: phantom/orphan worker-dir validity sweep ──
+describe("phantom worker-dir validity sweep (CTL-671)", () => {
+  // The sweep's seams are injected directly (classifyResolution returns the
+  // 3-valued result; classifyTicketResolution's parsing is covered in
+  // linear-query.test.mjs). schedulerTick's defaults are safe no-ops, so the
+  // sweep only acts here because we arm it.
+  const resolveTo = (verdict) => () => verdict;
+  const eligibleFull = (id) => ({
+    identifier: id,
+    priority: 1,
+    state: "Todo",
+    relations: { nodes: [] },
+    inverseRelations: { nodes: [] },
+  });
+
+  test("quarantines a not-found + not-eligible + dead worker dir", () => {
+    writeSignal("CTL-9", "implement", "running");
     schedulerTick(orchDir, {
       readEligible: () => [],
-      dispatch,
-      now: () => (CIRCUIT_BREAKER_THRESHOLD + 2) * 70_000,
+      dispatch: () => ({ code: 0 }),
       liveBackgroundCount: () => 0,
+      classifyResolution: resolveTo("not-found"),
+      isBgJobAlive: () => false,
     });
-    expect(dispatch.calls).toHaveLength(CIRCUIT_BREAKER_THRESHOLD); // no growth — breaker held
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", "CTL-9", "phase-implement.json"), "utf8")
+    );
+    expect(sig.status).toBe("stalled");
+    expect(sig.stalledReason).toBe("phantom-ticket");
+  });
+
+  test("does NOT quarantine when Linear resolution is unknown (outage safety)", () => {
+    writeSignal("CTL-100", "implement", "running");
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      liveBackgroundCount: () => 0,
+      classifyResolution: resolveTo("unknown"), // transient outage
+      isBgJobAlive: () => false,
+    });
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", "CTL-100", "phase-implement.json"), "utf8")
+    );
+    expect(sig.status).toBe("running"); // untouched
+  });
+
+  test("does NOT quarantine a ticket present in the eligible set", () => {
+    writeSignal("CTL-100", "implement", "running");
+    let classifyCalls = 0;
+    schedulerTick(orchDir, {
+      readEligible: () => [eligibleFull("CTL-100")], // eligible → real ticket
+      dispatch: () => ({ code: 0 }),
+      liveBackgroundCount: () => 0,
+      classifyResolution: () => {
+        classifyCalls++;
+        return "not-found";
+      },
+      isBgJobAlive: () => false,
+    });
+    expect(
+      JSON.parse(
+        readFileSync(join(orchDir, "workers", "CTL-100", "phase-implement.json"), "utf8")
+      ).status
+    ).toBe("running");
+    expect(classifyCalls).toBe(0); // eligible short-circuits before the Linear probe
+  });
+
+  test("does NOT quarantine a not-found ticket whose bg job is still alive", () => {
+    writeSignal("CTL-9", "implement", "running");
+    let classifyCalls = 0;
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      liveBackgroundCount: () => 0,
+      classifyResolution: () => {
+        classifyCalls++;
+        return "not-found";
+      },
+      isBgJobAlive: () => true, // live worker → never touched
+    });
+    expect(
+      JSON.parse(
+        readFileSync(join(orchDir, "workers", "CTL-9", "phase-implement.json"), "utf8")
+      ).status
+    ).toBe("running");
+    expect(classifyCalls).toBe(0); // bg-liveness short-circuits before the Linear probe
+  });
+
+  test("skips already-terminal signals (idempotent / no rework, never probes Linear)", () => {
+    writeSignal("CTL-9", "implement", "stalled");
+    let classifyCalls = 0;
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      liveBackgroundCount: () => 0,
+      classifyResolution: () => {
+        classifyCalls++;
+        return "not-found";
+      },
+      isBgJobAlive: () => false,
+    });
+    expect(classifyCalls).toBe(0); // never probes a terminal ticket
+  });
+
+  test("returns the quarantined phantoms list for the daemon log / HUD", () => {
+    writeSignal("CTL-9", "implement", "running");
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      liveBackgroundCount: () => 0,
+      classifyResolution: resolveTo("not-found"),
+      isBgJobAlive: () => false,
+    });
+    expect(result.quarantinedPhantoms).toEqual([{ ticket: "CTL-9", phase: "implement" }]);
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/cli/components/WorkerList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/WorkerList.tsx
@@ -116,6 +116,9 @@ export function WorkerList({
               </Box>
               <Box flexGrow={1}>
                 <Text dimColor={!selected} inverse={selected}>{worktree}</Text>
+                {w.stalledReason && (
+                  <Text color="yellow" inverse={selected}>{` ⚠ ${w.stalledReason}`}</Text>
+                )}
               </Box>
             </Box>
             {ws && selected && (

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useHudMetrics.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useHudMetrics.test.ts
@@ -15,6 +15,7 @@ function worker(overrides: Partial<WorkerSignal>): WorkerSignal {
     workerName: "o-1-X-1",
     label: null,
     status: "researching",
+    stalledReason: null,
     phase: 1,
     phaseName: null,
     phaseTimestamps: {},

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.test.ts
@@ -3,7 +3,7 @@
 // CTL-419: filter.wake wake-event rendering with recipient-short suffix
 
 import { describe, test, expect } from "bun:test";
-import { formatDetails, formatRef } from "./format";
+import { formatDetails, formatRef, shouldSkipEvent, formatStatus } from "./format";
 import type { CanonicalEvent } from "../../lib/canonical-event.ts";
 
 function makeEvent(
@@ -175,6 +175,24 @@ describe("formatDetails — session.phase (CTL-418)", () => {
   test("falls back to generic when no payload.to", () => {
     const ev = makeEvent("session.phase", {}, undefined, "session.phase");
     expect(formatDetails(ev)).toBe("session.phase");
+  });
+});
+
+describe("phase.dispatch.runaway — CTL-671 runaway alert", () => {
+  const runaway = (count = 312, windowMs = 600_000) =>
+    makeEvent("phase.dispatch.runaway.CTL-9", {}, { count, window_ms: windowMs });
+
+  test("is NOT skipped by the HUD filter (operator-critical)", () => {
+    expect(shouldSkipEvent(runaway())).toBe(false);
+  });
+
+  test("renders count + window in DETAILS", () => {
+    expect(formatDetails(runaway(312, 600_000))).toBe("runaway: 312 events in 10min");
+  });
+
+  test("WARN severity drives the attention glyph", () => {
+    const ev = { ...runaway(), severityText: "WARN" } as ReturnType<typeof runaway>;
+    expect(formatStatus(ev)).toBe("! ");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -535,6 +535,21 @@ export function formatDetails(event: CanonicalEvent): string {
     detailsCache.set(event, sanitized);
     return sanitized;
   }
+  // CTL-671: runaway event-rate alert — render the dominating count + window so
+  // an operator sees the severity of the storm at a glance (it is an
+  // attention/WARN row via severityText, surfaced by formatStatus's "!").
+  if (name?.startsWith("phase.dispatch.runaway.")) {
+    const p = payload as Record<string, unknown> | undefined;
+    const count = typeof p?.["count"] === "number" ? p["count"] : "?";
+    const windowMs = typeof p?.["window_ms"] === "number" ? p["window_ms"] : 0;
+    const windowMin = windowMs ? Math.round(windowMs / 60_000) : 0;
+    const out = sanitize(
+      `runaway: ${count} events in ${windowMin}min`,
+      "oneline"
+    );
+    detailsCache.set(event, out);
+    return out;
+  }
   const msg = event.body?.message ?? "";
   let raw = msg;
   if (payload && typeof payload === "object") {

--- a/plugins/dev/scripts/orch-monitor/cli/lib/worker-signals-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/worker-signals-reader.test.ts
@@ -234,6 +234,32 @@ describe("readWorkerSignals (per-phase layout)", () => {
     expect(row.status).toBe("running"); // per-phase status wins
   });
 
+  test("per-phase: surfaces stalledReason from a quarantined phase signal (CTL-671)", () => {
+    const dir = join(tmp, "orch-pa", "workers", "CTL-9");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-implement.json"),
+      JSON.stringify({
+        ticket: "CTL-9",
+        phase: "implement",
+        orchestrator: "orch-pa",
+        status: "stalled",
+        stalledReason: "phantom-ticket",
+        updatedAt: new Date(NOW - 5_000).toISOString(),
+      }),
+    );
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(1);
+    expect(out[0].status).toBe("stalled");
+    expect(out[0].stalledReason).toBe("phantom-ticket");
+  });
+
+  test("per-phase: stalledReason is null for a healthy running phase", () => {
+    setupPerPhaseOrch(tmp, "orch-pa", "T-100", [{ phase: "implement" }]);
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out[0].stalledReason).toBeNull();
+  });
+
   test("per-phase directory with no phase-*.json is skipped silently", () => {
     setupOrch(tmp, "orch-pa", [makeSignal({ ticket: "T-flat", workerName: "orch-pa-T-flat" })]);
     mkdirSync(join(tmp, "orch-pa", "workers", "T-empty"), { recursive: true });

--- a/plugins/dev/scripts/orch-monitor/cli/lib/worker-signals-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/worker-signals-reader.ts
@@ -24,6 +24,10 @@ export interface WorkerSignal {
   workerName: string;
   label: string | null;
   status: string;
+  // CTL-671: why a worker is `stalled` — "phantom-ticket" (quarantined by the
+  // validity sweep), "dispatch-circuit-breaker", or "remediate-cycle-cap-exhausted".
+  // Null when not stalled. Surfaced on the worker row so an operator sees the cause.
+  stalledReason: string | null;
   phase: number | null;
   // Per-phase mode current phase name (e.g. "implement", "monitor-merge"). Null for legacy
   // oneshot-legacy workers that only carry the integer `phase`.
@@ -99,6 +103,7 @@ function parseSignal(raw: unknown): WorkerSignal | null {
     workerName,
     label: asString(r.label),
     status,
+    stalledReason: asString(r.stalledReason),
     phase: asNumber(r.phase),
     phaseName: asString(r.phaseName),
     phaseTimestamps: parsePhaseTimestamps(r.phaseTimestamps),
@@ -121,6 +126,7 @@ interface PerPhaseOverlay {
   orchestrator: string;
   phaseName: string;
   status: string;
+  stalledReason: string | null;
   updatedAt: string | null;
 }
 
@@ -137,7 +143,14 @@ function parsePerPhaseFile(raw: unknown): PerPhaseOverlay | null {
   const phaseName = asString(r.phase);
   const status = asString(r.status);
   if (!ticket || !orchestrator || !phaseName || !status) return null;
-  return { ticket, orchestrator, phaseName, status, updatedAt: asString(r.updatedAt) };
+  return {
+    ticket,
+    orchestrator,
+    phaseName,
+    status,
+    stalledReason: asString(r.stalledReason),
+    updatedAt: asString(r.updatedAt),
+  };
 }
 
 function scanPerPhaseDir(perPhaseDir: string): PerPhaseOverlay | null {
@@ -180,6 +193,7 @@ function synthesizeFromOverlay(overlay: PerPhaseOverlay): WorkerSignal {
     workerName: `${overlay.orchestrator}-${overlay.ticket}`,
     label: null,
     status: overlay.status,
+    stalledReason: overlay.stalledReason,
     phase: null,
     phaseName: overlay.phaseName,
     phaseTimestamps: {},
@@ -250,6 +264,7 @@ function scanOrchestratorWorkersDir(workersDir: string): WorkerSignal[] {
     if (existing) {
       existing.phaseName = overlay.phaseName;
       existing.status = overlay.status;
+      existing.stalledReason = overlay.stalledReason ?? existing.stalledReason;
       if (overlay.updatedAt) {
         existing.updatedAt = overlay.updatedAt;
         existing.lastHeartbeat = overlay.updatedAt;

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -119,3 +119,13 @@ For hands-off merging, set your `main` branch to require pull requests, require 
 ## More settings
 
 Catalyst reads many more keys — for the event broker, the Monitor dashboard, webhooks, deploy checks, and worktree setup. The setup script writes them, and `plugins/dev/templates/config.template.json` lists them all. You only need the keys above to get started.
+
+### Runaway-dispatch guards (CTL-671)
+
+The execution-core scheduler protects itself against a single ticket dominating the dispatch loop. These knobs are env vars on the `catalyst-execution-core` process:
+
+- `SCHEDULER_CIRCUIT_BREAKER_THRESHOLD` (default `8`) — consecutive failed dispatches (no forward progress) before a ticket is quarantined to terminal `stalled` + `needs-human`. A successful dispatch resets the counter, so a healthy ticket can never trip it.
+- `SCHEDULER_RUNAWAY_THRESHOLD` (default `50`) — per-ticket `phase.*.<ticket>` event count within `SCHEDULER_RUNAWAY_WINDOW_MS` that fires one `phase.dispatch.runaway.<ticket>` alert. Observability only — it surfaces a dominating ticket without quarantining it.
+- `SCHEDULER_RUNAWAY_WINDOW_MS` (default `600000`, 10 min) — rolling window for the runaway-rate alert and its once-per-window suppression marker.
+
+The **phantom worker-dir validity sweep** quarantines a `workers/<ticket>/` dir only when all three hold: the ticket is definitively **not-found** in Linear (a clean exit-0 not-found body — a nonzero exit or transient outage classifies as `unknown` and is never quarantined), it is **not in the eligible set**, and it has **no live bg worker**. This conjunction guarantees a transient Linear outage can never quarantine a healthy, resolvable, in-flight ticket. `SCHEDULER_CIRCUIT_BREAKER_THRESHOLD` is the Linear-independent backstop; the runaway knobs are observability only.


### PR DESCRIPTION
## CTL-671 — Guard + monitor runaway phase-dispatch loops (phantom/non-resolving tickets)

Rescue of stalled-before-PR work. Implementation and verify were already complete on `origin/CTL-671`; the branch stalled ~68 commits behind `origin/main` before a PR was opened. This PR rebases that work cleanly onto current `origin/main`, resolves the conflicts, and ships it.

### What it does

Closes the gap that let a phantom ticket (CTL-9 — not in Linear) drive a 24,560-event runaway failed-dispatch loop with no circuit-breaker and no alert. Six commits:

1. **Per-ticket dispatch-failure circuit breaker** — quarantines a ticket to terminal `stalled` + `needs-human` after `SCHEDULER_CIRCUIT_BREAKER_THRESHOLD` (default 8) consecutive failed dispatches. A successful dispatch resets the counter.
2. **3-valued Linear ticket-resolution classifier** — `exists | not-found | unknown`, fail-safe (a nonzero exit / transient outage classifies as `unknown` and never quarantines).
3. **Phantom/orphan worker-dir validity sweep** — quarantines a `workers/<ticket>/` dir only when all three hold: definitively not-found in Linear, not in the eligible set, and no live bg worker.
4. **Per-ticket runaway event-rate alert** — fires one `phase.dispatch.runaway.<ticket>` observability event when a ticket exceeds `SCHEDULER_RUNAWAY_THRESHOLD` events in `SCHEDULER_RUNAWAY_WINDOW_MS`.
5. **HUD surface + config docs** for the runaway guards.
6. **Refactor**: arm the phantom-sweep seams at the daemon entry (not `runTick`), so a bare `startScheduler` unit tick stays hermetic.

### Rebase notes (additive conflict resolution)

Rebased onto `origin/main`; all conflicts resolved additively (kept both this branch's work and the sibling changes that landed while it was stalled):

- **scheduler.mjs** — merged the circuit breaker + phantom sweep alongside the sibling CTL-712 max-dispatch-retries terminal stop, CTL-713 cooldown GC/escalation, CTL-755 admission gate, CTL-731 staleness gate, and CTL-642/758 PR-merged adapter. The CTL-671 circuit breaker now co-exists with CTL-712 as defense-in-depth.
- **linear-query.test.mjs / scheduler.test.mjs** — kept both sibling test suites (CTL-755 `fetchTicketRelations`, CTL-713 GC/escalation) and the CTL-671 suites.
- **event-scan.mjs** — `countTicketEventsInWindow` was rebased onto CTL-673's bounded-memory rework: it now uses the `scanEventsChunked` primitive instead of the removed `readLinesSync` whole-file scan.
- **daemon.mjs** — armed the phantom-sweep seams at the daemon entry alongside the sibling autotuner / comment-wake wiring.
- **configuration.md** — preserved main's restructured doc and added a concise runaway-guard knobs section.
- The CTL-671 circuit-breaker integration test was adapted to isolate the breaker from CTL-712's now-tighter `PERMANENT_FAILURE_CODES` + max-retries semantics (transient code + raised retry ceiling).

### Tests

Green. The suites this ticket touches all pass:

- `scheduler.test.mjs` — 355 pass
- `linear-query.test.mjs` — 49 pass
- `event-scan.test.mjs` — 31 pass
- Together (scheduler + linear-query + event-scan): 435 pass / 0 fail

(A documented cross-suite fs.watch / module-singleton flake produces sporadic `reclaimDeadWorkIfPossible` failures only when 7 execution-core suites share a single `bun test` process; recovery.mjs logic is untouched by this branch and recovery.test.mjs passes 185/185 in isolation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
