### PR TITLE
fix(dev): CTL-777 reliable phase-worker signal flip via surviving settings.env channel (step 1)

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -1698,6 +1698,63 @@ SIGNAL_T55="${WORKER_DIR}/phase-triage.json"
 ATT_T55=$(jq -r '.attempt // empty' "$SIGNAL_T55" 2>/dev/null)
 assert_eq "1" "$ATT_T55" "signal file defaults attempt=1"
 
+# ─── CTL-777: settings.env also carries the 5 CATALYST_* context vars ────────
+# `claude --bg` drops the plain env prefix (DISPATCH_ENV), so the worker's
+# CATALYST_ORCHESTRATOR_DIR was empty and phase-agent-emit-complete's step-2
+# signal flip silently skipped — wedging the pipeline. The fix threads the same
+# 5 context vars into the surviving --settings.env channel.
+
+echo ""
+echo "Test 56 (CTL-777): .settings.env carries the 5 CATALYST_* context vars"
+fresh_env t56
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
+SETTINGS_JSON="$(settings_json_from_log)"
+SET_ODIR=$(echo "$SETTINGS_JSON" | jq -r '.env["CATALYST_ORCHESTRATOR_DIR"] // empty' 2>/dev/null)
+SET_OID=$(echo "$SETTINGS_JSON" | jq -r '.env["CATALYST_ORCHESTRATOR_ID"] // empty' 2>/dev/null)
+SET_PHASE=$(echo "$SETTINGS_JSON" | jq -r '.env["CATALYST_PHASE"] // empty' 2>/dev/null)
+SET_TICKET=$(echo "$SETTINGS_JSON" | jq -r '.env["CATALYST_TICKET"] // empty' 2>/dev/null)
+HAS_GEN=$(echo "$SETTINGS_JSON" | jq -r '.env | has("CATALYST_GENERATION")' 2>/dev/null)
+assert_eq "$ORCH_DIR" "$SET_ODIR" ".settings.env.CATALYST_ORCHESTRATOR_DIR equals --orch-dir"
+assert_eq "orch-test" "$SET_OID" ".settings.env.CATALYST_ORCHESTRATOR_ID equals --orch-id"
+assert_eq "triage" "$SET_PHASE" ".settings.env.CATALYST_PHASE equals the phase"
+assert_eq "CTL-100" "$SET_TICKET" ".settings.env.CATALYST_TICKET equals the ticket"
+assert_eq "true" "$HAS_GEN" ".settings.env carries CATALYST_GENERATION"
+
+echo ""
+echo "Test 57 (CTL-777): CTL-760 telemetry keys are unchanged and fail-open intact"
+# Reuse Test 56's SETTINGS_JSON.
+T57_TEL=$(echo "$SETTINGS_JSON" | jq -r '.env["CLAUDE_CODE_ENABLE_TELEMETRY"] // empty' 2>/dev/null)
+T57_MET=$(echo "$SETTINGS_JSON" | jq -r '.env["OTEL_METRICS_EXPORTER"] // empty' 2>/dev/null)
+T57_LOG=$(echo "$SETTINGS_JSON" | jq -r '.env["OTEL_LOGS_EXPORTER"] // empty' 2>/dev/null)
+T57_ATTR=$(echo "$SETTINGS_JSON" | jq -r '.env | has("OTEL_RESOURCE_ATTRIBUTES")' 2>/dev/null)
+assert_eq "1" "$T57_TEL" "CLAUDE_CODE_ENABLE_TELEMETRY still present and unchanged"
+assert_eq "otlp" "$T57_MET" "OTEL_METRICS_EXPORTER still present and unchanged"
+assert_eq "otlp" "$T57_LOG" "OTEL_LOGS_EXPORTER still present and unchanged"
+assert_eq "true" "$T57_ATTR" "OTEL_RESOURCE_ATTRIBUTES still composed alongside the context vars"
+T57_VALID=$(echo "$SETTINGS_JSON" | jq -e . >/dev/null 2>&1 && echo yes || echo no)
+assert_eq "yes" "$T57_VALID" "settings JSON remains valid with context vars added (fail-open intact)"
+
+echo ""
+echo "Test 58 (CTL-777): empty context var is OMITTED (no null key) while others stay"
+fresh_env t58
+# Run the composer directly with GENERATION empty but ORCH_DIR present so we can
+# assert the ==\"\" omission pattern holds for the new keys too.
+SETTINGS_T58=$(
+	ORCH_DIR="${ORCH_DIR}" ORCH_ID="orch-test" PHASE="triage" TICKET="CTL-100" \
+		GENERATION="" SCRIPT_DIR="${TEST_DIR}/bin" OTEL_RES_ATTRS="" \
+		bash -c '
+      source <(sed -n "/^compose_worker_settings_json()/,/^}/p" "'"$DISPATCH"'")
+      compose_worker_settings_json'
+)
+T58_HAS_GEN=$(echo "$SETTINGS_T58" | jq -r '.env | has("CATALYST_GENERATION")' 2>/dev/null)
+T58_HAS_ODIR=$(echo "$SETTINGS_T58" | jq -r '.env | has("CATALYST_ORCHESTRATOR_DIR")' 2>/dev/null)
+T58_VALID=$(echo "$SETTINGS_T58" | jq -e . >/dev/null 2>&1 && echo yes || echo no)
+assert_eq "false" "$T58_HAS_GEN" "empty CATALYST_GENERATION omitted (no null key)"
+assert_eq "true" "$T58_HAS_ODIR" "CATALYST_ORCHESTRATOR_DIR still present when set"
+assert_eq "yes" "$T58_VALID" "settings JSON valid with a context var omitted"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -478,6 +478,39 @@ LINE=$(read_event_line)
 assert_eq "2" "$(echo "$LINE" | jq -r '.attributes["phase.attempt"]')" "failed path: phase.attempt=2"
 assert_eq "1" "$(echo "$LINE" | jq -r '.attributes["phase.revive_count"]')" "failed path: revive_count=1"
 
+# ─── CTL-777: signal flip fires from --orch-dir even when the env var is dropped ─
+# `claude --bg` drops the plain env prefix, so a worker can run with
+# CATALYST_ORCHESTRATOR_DIR unset. The dispatch-side fix re-supplies ORCH_DIR via
+# settings.env, but emit-complete also already prefers an explicit --orch-dir over
+# the env var (belt-and-braces). These tests pin both halves: --orch-dir alone
+# flips the signal, and the unfixed failure mode (no env AND no --orch-dir) leaves
+# the signal untouched.
+
+echo ""
+echo "Test 29 (CTL-777): --orch-dir flips the signal to done even with env var unset"
+fresh_env t29
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"research"}' >"$SIGNAL"
+# Drop the env var to reproduce the dropped-prefix bg worker; supply --orch-dir.
+env -u CATALYST_ORCHESTRATOR_DIR "$EMIT_SCRIPT" \
+	--phase research --ticket CTL-100 --status complete \
+	--orch-dir "${TEST_DIR}/orch" >/dev/null 2>&1
+NEW_STATUS=$(jq -r '.status' "$SIGNAL" 2>/dev/null)
+HAS_COMPLETED=$(jq -r 'has("completedAt")' "$SIGNAL" 2>/dev/null)
+assert_eq "done" "$NEW_STATUS" "--orch-dir flips signal to done with env unset"
+assert_eq "true" "$HAS_COMPLETED" "--orch-dir path still stamps completedAt"
+
+echo ""
+echo "Test 30 (CTL-777): documents the fixed failure mode — no env AND no --orch-dir leaves signal running"
+fresh_env t30
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"research"}' >"$SIGNAL"
+# Neither the env var nor --orch-dir → ORCH_DIR empty → step-2 gate skips (the bug).
+env -u CATALYST_ORCHESTRATOR_DIR "$EMIT_SCRIPT" \
+	--phase research --ticket CTL-100 --status complete >/dev/null 2>&1
+STILL_RUNNING=$(jq -r '.status' "$SIGNAL" 2>/dev/null)
+assert_eq "running" "$STILL_RUNNING" "no env + no --orch-dir → signal NOT flipped (the wedge this fix avoids)"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -686,8 +686,16 @@ OTEL_RES_ATTRS="$(compose_otel_resource_attrs)"
 #
 # compose_worker_settings_json builds that settings object with `jq -nc` (never
 # hand-built JSON):
-#   { "env": { <telemetry toggles>, "OTEL_RESOURCE_ATTRIBUTES": "<attrs>" },
+#   { "env": { <telemetry toggles>, "OTEL_RESOURCE_ATTRIBUTES": "<attrs>",
+#              <CTL-777 context vars> },
 #     "statusLine": { "type": "command", "command": "<SCRIPT_DIR>/catalyst-statusline.sh" } }
+#
+# CTL-777: settings.env now ALSO carries the 5 CATALYST_* context vars
+# (CATALYST_ORCHESTRATOR_DIR / _ID / PHASE / TICKET / GENERATION) over this same
+# surviving --settings channel — DISPATCH_ENV below carries them too but on the
+# DROPPED plain env prefix, so without this the worker's CATALYST_ORCHESTRATOR_DIR
+# was empty and phase-agent-emit-complete's step-2 signal flip silently skipped,
+# wedging the pipeline. Riding settings.env makes it non-empty so the flip fires.
 #
 # Telemetry toggles are re-asserted from the dispatcher's own inherited env (the
 # same keys that enable telemetry in ~/.claude/settings.json's .env block),
@@ -699,6 +707,19 @@ OTEL_RES_ATTRS="$(compose_otel_resource_attrs)"
 # statusLine.command points at this repo's catalyst-statusline.sh — the entire
 # statusLine key is OMITTED (fail-open) when that file is absent. Always emits a
 # valid settings object; an empty OTEL_RES_ATTRS still yields valid JSON.
+#
+# ─── CTL-777: thread the 5 CATALYST_* context vars through settings.env ──────
+# The same --settings channel that carries the CTL-760 telemetry keys is the ONLY
+# lever that survives the `claude --bg` RPC (the plain env prefix in DISPATCH_ENV
+# below is DROPPED by the daemon). Previously CATALYST_ORCHESTRATOR_DIR rode only
+# that dropped prefix, so the worker saw it empty and phase-agent-emit-complete's
+# step-2 signal flip (hard-gated on CATALYST_ORCHESTRATOR_DIR) silently skipped →
+# the pipeline wedged on an idle zombie. We now also emit the 5 context vars
+# (CATALYST_ORCHESTRATOR_DIR / _ID / PHASE / TICKET / GENERATION) into settings.env
+# so they reach the worker via the surviving channel and the signal flip fires.
+# Telemetry keys stay first/unchanged; each context var is omitted when empty
+# (mirroring the optional-OTLP pattern) so the post-call `jq -e .` fail-open guard
+# still validates and an empty optional never becomes a null key.
 compose_worker_settings_json() {
 	local enable_telemetry metrics_exporter logs_exporter otlp_endpoint otlp_protocol
 	enable_telemetry="${CLAUDE_CODE_ENABLE_TELEMETRY:-1}"
@@ -706,6 +727,14 @@ compose_worker_settings_json() {
 	logs_exporter="${OTEL_LOGS_EXPORTER:-otlp}"
 	otlp_endpoint="${OTEL_EXPORTER_OTLP_ENDPOINT:-}"
 	otlp_protocol="${OTEL_EXPORTER_OTLP_PROTOCOL:-}"
+
+	# CTL-777: the same context values DISPATCH_ENV carries on the dropped env
+	# prefix — sourced from the dispatcher's own resolved vars.
+	local orch_dir="${ORCH_DIR:-}"
+	local orch_id="${ORCH_ID:-}"
+	local phase_val="${PHASE:-}"
+	local ticket_val="${TICKET:-}"
+	local generation_val="${GENERATION:-}"
 
 	local statusline_script="${SCRIPT_DIR}/catalyst-statusline.sh"
 
@@ -716,6 +745,11 @@ compose_worker_settings_json() {
 		--arg otlp_endpoint "$otlp_endpoint" \
 		--arg otlp_protocol "$otlp_protocol" \
 		--arg otel_attrs "$OTEL_RES_ATTRS" \
+		--arg orch_dir "$orch_dir" \
+		--arg orch_id "$orch_id" \
+		--arg phase "$phase_val" \
+		--arg ticket "$ticket_val" \
+		--arg generation "$generation_val" \
 		--arg statusline_cmd "$statusline_script" \
 		--argjson have_statusline "$([[ -f $statusline_script ]] && echo true || echo false)" \
 		'{
@@ -728,6 +762,11 @@ compose_worker_settings_json() {
          + (if $otlp_endpoint == "" then {} else { "OTEL_EXPORTER_OTLP_ENDPOINT": $otlp_endpoint } end)
          + (if $otlp_protocol == "" then {} else { "OTEL_EXPORTER_OTLP_PROTOCOL": $otlp_protocol } end)
          + (if $otel_attrs == "" then {} else { "OTEL_RESOURCE_ATTRIBUTES": $otel_attrs } end)
+         + (if $orch_dir == "" then {} else { "CATALYST_ORCHESTRATOR_DIR": $orch_dir } end)
+         + (if $orch_id == "" then {} else { "CATALYST_ORCHESTRATOR_ID": $orch_id } end)
+         + (if $phase == "" then {} else { "CATALYST_PHASE": $phase } end)
+         + (if $ticket == "" then {} else { "CATALYST_TICKET": $ticket } end)
+         + (if $generation == "" then {} else { "CATALYST_GENERATION": $generation } end)
        )
      }
      + (if $have_statusline


### PR DESCRIPTION
## CTL-777 step 1 — make the phase-worker signal flip survive the bg RPC

**Scope: step 1 only** of the event-sourced reactor (reliable signal-flip). Steps 2 (halt-on-complete) and 3 (daemon reactor self-heal) are deliberately out of scope and tracked separately on CTL-777.

### Root cause (confirmed on CTL-763 + OTL-3)
A phase worker emits `phase.<phase>.complete.<ticket>` to the event log, but the **signal file is never flipped to `status:"done"`** → the pipeline wedges and the worker idles for hours. `phase-agent-emit-complete` has two steps: (1) append the complete event — always runs; (2) flip the signal — **hard-gated on `CATALYST_ORCHESTRATOR_DIR`**. `claude --bg` is an RPC to the per-user daemon and the **plain env prefix (`DISPATCH_ENV`) is dropped**, so the worker saw `CATALYST_ORCHESTRATOR_DIR` empty → step 2 silently skipped.

### The fix
`compose_worker_settings_json` already builds the `--settings '{"env":{…}}'` object — the **only channel that crosses the `claude --bg` RPC** (the same one CTL-760 telemetry rides). This PR threads the 5 orchestrator-context vars (`CATALYST_ORCHESTRATOR_DIR / _ID / PHASE / TICKET / GENERATION`) into that surviving `settings.env` block via `jq --arg`, each **omitted-when-empty** (mirrors the optional-OTLP pattern), telemetry keys first/unchanged, post-call `jq -e .` fail-open guard intact.

`phase-agent-emit-complete` needed **no change** — it already accepts `--orch-dir` and prefers it over the env default; the same signal-flip gate now fires because `CATALYST_ORCHESTRATOR_DIR` reaches the worker.

### One genuine behavior change (please sign off)
`CATALYST_GENERATION` previously rode only the dropped prefix, so the **CTL-736 fence-check in emit-complete was silently inert on bg workers**. It now goes live. Verified safe: the dispatcher writes `signal.generation == GENERATION == CATALYST_GENERATION`, the fence only `exit 0`s when `mine < signal.generation` (a later dispatcher superseded this worker — exactly the duplicate-worker bow-out CTL-736 was designed for), and it fails-open on equal/non-numeric. This **completes** the CTL-736 fencing design rather than changing it.

### Tests
- `phase-agent-dispatch.test.sh`: **203 pass / 0 fail** — new Tests 56–58 assert the 5 vars land in the recorded `--settings.env` (exact value of `CATALYST_ORCHESTRATOR_DIR == --orch-dir`), telemetry keys unchanged, fail-open intact, empty var omitted.
- `phase-agent-emit-complete.test.sh`: **69 pass / 0 fail** — new Test 29 flips the signal via `--orch-dir` with the env var unset; Test 30 is the regression anchor (neither env nor `--orch-dir` leaves status `running` — the exact wedge this fixes).

### Verification
Adversarially reviewed by 3 independent lenses (correctness / regression / test-adequacy) + an independent verify pass — all **pass**, zero blockers, zero high findings.

### Deliberate follow-up (not in this PR)
The ticket's belt-and-braces also suggested each phase **End block** pass `--orch-dir` explicitly for a second independent channel. emit-complete already supports it, but the End blocks don't all pass it today — left as a follow-up since the primary `settings.env` channel is empirically proven (CTL-760). Notably the phase-research End block relies entirely on the settings.env var, so this dispatch fix is load-bearing for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
