### PR TITLE
fix(dev): repair removeLabel (linearis rejects --label-mode remove) + hermetic test guard

### DIFF
--- a/plugins/dev/scripts/execution-core/.gitignore
+++ b/plugins/dev/scripts/execution-core/.gitignore
@@ -1,1 +1,6 @@
 node_modules/
+
+# Transient leak ledger rewritten on every `bun test` run by test-setup.mjs.
+# The fake-bin/* scripts, bunfig.toml and test-setup.mjs ARE tracked; only this
+# per-run recording is not.
+__tests__/.fake-bin-invocations.log

--- a/plugins/dev/scripts/execution-core/__tests__/fake-bin/claude
+++ b/plugins/dev/scripts/execution-core/__tests__/fake-bin/claude
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Fake `claude` for hermetic execution-core tests — intercepts `claude agents
+# --json` (liveBackgroundCount / countBackgroundAgents) so tests never shell the
+# real CLI. Records the invocation; returns an empty agents list. No network.
+printf 'claude %s\n' "$*" >>"${CATALYST_FAKE_BIN_LOG:-/dev/null}" 2>/dev/null
+case "$*" in
+  *agents*) echo '[]' ;;
+  *) echo '' ;;
+esac
+exit 0

--- a/plugins/dev/scripts/execution-core/__tests__/fake-bin/gh
+++ b/plugins/dev/scripts/execution-core/__tests__/fake-bin/gh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Fake `gh` for hermetic execution-core tests — intercepts every GitHub-CLI call
+# (pr view / api pulls / issue / auth status) so a test that reaches a default
+# `gh` exec seam never floods the real GitHub API. Records the invocation and
+# returns benign, shape-valid output. NEVER touches the network. Installed on
+# PATH by test-setup.mjs alongside the fake `linearis`/`claude`. A non-empty
+# `gh ...` line in .fake-bin-invocations.log after a run is the leak surface: a
+# test reached the default gh seam instead of injecting a runGh/run stub.
+printf 'gh %s\n' "$*" >>"${CATALYST_FAKE_BIN_LOG:-/dev/null}" 2>/dev/null
+
+# `gh ... pr view`           → an empty-ish PR view object (state/mergeStateStatus
+#                              null; the probes treat that as "not yet merged").
+# `gh api ...`               → empty JSON object ({}.state/{}.merged are undefined,
+#                              which ghPullRest/pr probes read as "unknown/false").
+# `gh ... pr ...` (list etc) → empty JSON array.
+# `gh issue ...`             → empty JSON array.
+# `gh auth status`           → success, no body.
+# anything else              → empty JSON object, exit 0.
+case "$*" in
+  *"pr view"*) echo '{"state":null,"mergeStateStatus":null,"mergedAt":null,"mergeCommit":null}' ;;
+  *"api "*|*" api "*) echo '{}' ;;
+  *"pr "*|*"pr") echo '[]' ;;
+  *"issue"*) echo '[]' ;;
+  *"auth status"*) ;;
+  *) echo '{}' ;;
+esac
+exit 0

--- a/plugins/dev/scripts/execution-core/__tests__/fake-bin/linearis
+++ b/plugins/dev/scripts/execution-core/__tests__/fake-bin/linearis
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Fake `linearis` for hermetic execution-core tests. Records the invocation and
+# returns benign, shape-valid empty JSON. NEVER touches the network. Installed on
+# PATH by test-setup.mjs so even child-shell calls (linear-transition.sh's bare
+# `linearis`) are intercepted. A non-empty .fake-bin-invocations.log after a run
+# is the leak surface: a test reached a default exec seam instead of injecting a stub.
+printf 'linearis %s\n' "$*" >>"${CATALYST_FAKE_BIN_LOG:-/dev/null}" 2>/dev/null
+case "$1 $2" in
+  "issues list" | "labels list" | "comments list") echo '{"nodes":[]}' ;;
+  "issues read") echo '{}' ;;
+  "issues update") echo '{}' ;;
+  *) echo '{}' ;;
+esac
+exit 0

--- a/plugins/dev/scripts/execution-core/bunfig.toml
+++ b/plugins/dev/scripts/execution-core/bunfig.toml
@@ -1,0 +1,4 @@
+[test]
+# CTL test-leak guard: load the hermetic-Linear preload before any *.test.mjs so
+# no test can reach real Linear (api.linear.app) or `claude`. See test-setup.mjs.
+preload = ["./test-setup.mjs"]

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -236,25 +236,54 @@ export function applyLabel({ ticket, label, exec = defaultExec }) {
   }
 }
 
-// removeLabel — remove a single label from a ticket via linearis --label-mode
-// remove (CTL-549). Counterpart to applyLabel; used by handleCommentWake to
-// clear needs-human/question when re-dispatching a parked worker. No read-back
-// (remove is idempotent for absent labels). Returns { removed: true } on
-// success, { removed: false, reason } on failure. Never throws.
-export async function removeLabel(ticket, label, { exec = defaultExec } = {}) {
+// removeLabel — remove a single label from a ticket while preserving its OTHER
+// labels (CTL-549). Counterpart to applyLabel; used by handleCommentWake to
+// clear needs-human/question when re-dispatching a parked worker.
+//
+// linearis 2026.4.9 has NO single-label-remove primitive: `--label-mode` only
+// accepts `add` or `overwrite` (the old `remove` value is REJECTED with
+// "--label-mode must be either 'add' or 'overwrite'"), and `--clear-labels`
+// drops ALL labels. So the only way to remove one label without clobbering the
+// rest is read-modify-write: read the current label set, filter out the target,
+// and overwrite with the remainder (or --clear-labels when nothing remains).
+// This keeps the write inside linearis and preserves the issue's other labels.
+//
+// Idempotent: if the label is already absent we return { removed: true } without
+// a write. A failed read (fetchLabels returns non-array) is { removed: false,
+// reason: 'transient' } so the caller retries. Mirrors applyLabel's shape for
+// logging + failure classification. Never throws.
+export async function removeLabel(
+  ticket,
+  label,
+  { exec = defaultExec, fetchLabels = fetchTicketLabels } = {}
+) {
   try {
-    const res = exec("linearis", [
-      "issues",
-      "update",
-      ticket,
-      "--labels",
-      label,
-      "--label-mode",
-      "remove",
-    ]);
+    const current = fetchLabels(ticket, { exec });
+    if (!Array.isArray(current)) {
+      // Read failed (linearis non-zero / non-JSON) — cannot safely overwrite
+      // without knowing the current set, so retry next tick.
+      log.warn({ ticket, label, reason: "transient" }, "removeLabel: read failed");
+      return { removed: false, reason: "transient" };
+    }
+    if (!current.includes(label)) {
+      // Idempotent: the label is already gone, no write needed.
+      return { removed: true };
+    }
+    const remaining = current.filter((l) => l !== label);
+    const res = remaining.length
+      ? exec("linearis", [
+          "issues",
+          "update",
+          ticket,
+          "--labels",
+          remaining.join(","),
+          "--label-mode",
+          "overwrite",
+        ])
+      : exec("linearis", ["issues", "update", ticket, "--clear-labels"]);
     if ((res.code ?? res.status ?? 0) !== 0) {
       const reason = classifyLabelFailure(res.stderr ?? "");
-      log.warn({ ticket, label, reason }, "removeLabel: failed");
+      log.warn({ ticket, label, reason, stderr: res.stderr }, "removeLabel: write failed");
       return { removed: false, reason };
     }
     return { removed: true };

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -547,35 +547,83 @@ describe("applyTriageStatus", () => {
   });
 });
 
-// CTL-549: removeLabel — remove a single label via linearis --label-mode remove
+// CTL-549: removeLabel — remove a single label without clobbering the others.
+// linearis 2026.4.9 has no single-label-remove primitive (`--label-mode` only
+// accepts add|overwrite; `remove` is REJECTED), so removeLabel read-modify-writes:
+// fetch the current label set, filter out the target, overwrite with the
+// remainder (or --clear-labels when the remainder is empty).
 describe("removeLabel (CTL-549)", () => {
-  test("shells linearis issues update with --label-mode remove", async () => {
+  test("reads current labels then overwrites with the remainder (preserves others)", async () => {
     const cmds = [];
     const exec = (cmd, args) => { cmds.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
-    await removeLabel("CTL-1", "needs-human/question", { exec });
-    expect(cmds).toHaveLength(1);
-    expect(cmds[0].args).toContain("--label-mode");
-    expect(cmds[0].args).toContain("remove");
-    expect(cmds[0].args).toContain("needs-human/question");
-    expect(cmds[0].args).toContain("CTL-1");
-  });
-
-  test("returns { removed: true } on exit 0", async () => {
-    const exec = () => ({ code: 0, stdout: "", stderr: "" });
-    const result = await removeLabel("CTL-1", "needs-human/question", { exec });
+    // ticket has ['blocked','orchestrator']; remove 'blocked' → overwrite with 'orchestrator'
+    const fetchLabels = () => ["blocked", "orchestrator"];
+    const result = await removeLabel("CTL-1", "blocked", { exec, fetchLabels });
     expect(result.removed).toBe(true);
+    expect(cmds).toHaveLength(1);
+    const args = cmds[0].args;
+    expect(args.slice(0, 3)).toEqual(["issues", "update", "CTL-1"]);
+    expect(args).toContain("--labels");
+    expect(args[args.indexOf("--labels") + 1]).toBe("orchestrator");
+    expect(args).toContain("--label-mode");
+    expect(args[args.indexOf("--label-mode") + 1]).toBe("overwrite");
+    // the rejected `remove` value must never be emitted anymore
+    expect(args).not.toContain("remove");
   });
 
-  test("returns { removed: false, reason } on non-zero exit", async () => {
+  test("multiple remaining labels are joined into a single --labels arg", async () => {
+    const cmds = [];
+    const exec = (cmd, args) => { cmds.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const fetchLabels = () => ["needs-human/question", "orchestrator", "bug"];
+    const result = await removeLabel("CTL-1", "needs-human/question", { exec, fetchLabels });
+    expect(result.removed).toBe(true);
+    const args = cmds[0].args;
+    expect(args[args.indexOf("--labels") + 1]).toBe("orchestrator,bug");
+    expect(args[args.indexOf("--label-mode") + 1]).toBe("overwrite");
+  });
+
+  test("idempotent — label already absent: returns removed:true with NO write", async () => {
+    const cmds = [];
+    const exec = (cmd, args) => { cmds.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const fetchLabels = () => ["orchestrator", "bug"]; // target 'blocked' not present
+    const result = await removeLabel("CTL-1", "blocked", { exec, fetchLabels });
+    expect(result.removed).toBe(true);
+    expect(cmds).toHaveLength(0); // no overwrite issued
+  });
+
+  test("empty remaining set → --clear-labels (not an empty --labels overwrite)", async () => {
+    const cmds = [];
+    const exec = (cmd, args) => { cmds.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const fetchLabels = () => ["needs-human/question"]; // the only label is the one removed
+    const result = await removeLabel("CTL-1", "needs-human/question", { exec, fetchLabels });
+    expect(result.removed).toBe(true);
+    expect(cmds).toHaveLength(1);
+    expect(cmds[0].args).toEqual(["issues", "update", "CTL-1", "--clear-labels"]);
+    expect(cmds[0].args).not.toContain("--labels");
+  });
+
+  test("read failure (fetchLabels returns null) → removed:false, reason:transient, no write", async () => {
+    const cmds = [];
+    const exec = (cmd, args) => { cmds.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const fetchLabels = () => null; // linearis read failed
+    const result = await removeLabel("CTL-1", "needs-human/question", { exec, fetchLabels });
+    expect(result.removed).toBe(false);
+    expect(result.reason).toBe("transient");
+    expect(cmds).toHaveLength(0);
+  });
+
+  test("returns { removed: false, reason } on non-zero overwrite exit", async () => {
     const exec = () => ({ code: 1, stdout: "", stderr: "not found" });
-    const result = await removeLabel("CTL-1", "needs-human/question", { exec });
+    const fetchLabels = () => ["needs-human/question", "orchestrator"];
+    const result = await removeLabel("CTL-1", "needs-human/question", { exec, fetchLabels });
     expect(result.removed).toBe(false);
     expect(result.reason).toBeTruthy();
   });
 
   test("returns { removed: false, reason: 'transient' } on thrown exec", async () => {
     const exec = () => { throw new Error("spawn failed"); };
-    const result = await removeLabel("CTL-1", "needs-human/question", { exec });
+    const fetchLabels = () => ["needs-human/question", "orchestrator"];
+    const result = await removeLabel("CTL-1", "needs-human/question", { exec, fetchLabels });
     expect(result.removed).toBe(false);
     expect(result.reason).toBe("transient");
   });

--- a/plugins/dev/scripts/execution-core/test-setup.mjs
+++ b/plugins/dev/scripts/execution-core/test-setup.mjs
@@ -1,0 +1,48 @@
+// test-setup.mjs — bun [test].preload (loaded once before every *.test.mjs in
+// this package). Makes the execution-core suite HERMETIC against Linear:
+//
+// The leak (proxy audit: 868 real Linear calls + real `issues update --status`
+// WRITES from `bun test`) comes from FIVE default exec seams, one of which is a
+// CHILD SHELL — linear-write.mjs → ../linear-transition.sh → bare `linearis`.
+// An in-process JS mock cannot reach that bash process, so the guard MUST be at
+// the env/PATH level: child processes inherit process.env (modified PATH + the
+// deleted tokens) through spawnSync, so every `linearis`/`claude` invocation —
+// JS spawnSync OR child shell — resolves to the fake binaries in __tests__/fake-bin
+// and never touches the network.
+//
+// The SAME leak class exists for GitHub: production code shells `gh` (work-done
+// probes, scheduler PR-merged adapter, scan-adapters, worktrees) so a test that
+// reaches a default `gh` exec seam would flood the real GitHub API. The fake
+// `gh` on PATH + the unset GITHUB_TOKEN/GH_TOKEN close that the same way.
+//
+// Three layers, defence in depth:
+//   1. PATH-shim: front PATH with fake `linearis`/`claude`/`gh` (records + benign JSON).
+//   2. Token unset: even if a real binary is somehow reached, no creds → no write.
+//   3. CATALYST_TEST flag: a tripwire other guards/tests can assert on.
+import { join } from "node:path";
+import { writeFileSync } from "node:fs";
+
+const fakeBin = join(import.meta.dir, "__tests__", "fake-bin");
+process.env.PATH = `${fakeBin}:${process.env.PATH ?? ""}`;
+
+// Belt: a real linearis reached despite the shim writes nothing without creds.
+delete process.env.LINEAR_API_TOKEN;
+delete process.env.LINEAR_API_KEY;
+
+// Same belt for GitHub: a real `gh` reached despite the shim has no creds →
+// it can only error, never mutate a real PR/issue or flood the GitHub API.
+delete process.env.GITHUB_TOKEN;
+delete process.env.GH_TOKEN;
+
+// Tripwire flag (clear attribution for any in-JS guard or assertion).
+process.env.CATALYST_TEST = "1";
+
+// Where the fake binaries record every invocation (the leak surface). Cleared
+// once per `bun test` run so the log reflects exactly this run's leaks.
+const log = join(import.meta.dir, "__tests__", ".fake-bin-invocations.log");
+process.env.CATALYST_FAKE_BIN_LOG = log;
+try {
+  writeFileSync(log, "");
+} catch {
+  // best-effort — a missing __tests__ dir just means no log this run
+}


### PR DESCRIPTION
## What & why

**Fix 1 — `removeLabel` was broken (caused the Linear-quota storm).** It shelled
`linearis issues update --labels X --label-mode remove`, but **linearis 2026.4.9 rejects `remove`**
(only `add|overwrite|--clear-labels` exist). So the daemon could *apply* held labels but never
*clear* them → `convergeHeldLabel` re-fired the failing remove **every tick** = the label-write storm
that pinned the 2500/hr quota and tripped the breaker. Fix is **read-modify-write**: read current
labels, drop the target, `--label-mode overwrite` the remainder (`--clear-labels` when empty).
Idempotent when absent; **transient with no destructive write** on read-failure or open breaker.

**Fix 2 — hermetic test guard (no test can flood Linear *or* GitHub).** A mitmproxy audit found
**868 real Linear calls — including `issues update --status` WRITES — leaking from `bun test`** across
5 default exec seams (one a child shell). A `bunfig.toml [test].preload` fronts `PATH` with fake
`linearis`/`claude`/`gh` and unsets `LINEAR_*`/`GITHUB_*` tokens, so **no test — present or future,
passing or failing — reaches a real API**.

## Validation
- `removeLabel` exercised against **real Linear** (CTL-773): one label removed, others preserved,
  durable (independent GraphQL cross-check), idempotent on re-remove, scratch ticket restored.
- Full execution-core suite: **1785 pass / 1 fail** (the 1 is pre-existing & unrelated —
  `cli/sessions.test.mjs:71`, unmodified vs HEAD). **0 new proxy rows**; leak ledger = 0 linearis / 0 gh.
- Adversarial review: **ship (93%)**, `daemonRestartSafe: true`, 0 must-fix. Storm root-cause confirmed
  unblocked (removed → next tick sees label gone → zero writes → converges). No production code changed
  for tests.

Hotpatched into the running daemon (10.6.0 cache) + restarted: **0 label-write failures, 0 circuit
events** — storm gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
