### PR TITLE
fix(dev): CTL-693 suppress pre-push hooks on automated phase-agent pushes

### DIFF
--- a/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
@@ -226,10 +226,28 @@ install_git_stub_push_fail() {
   cat > "${bin_dir}/git" <<STUB
 #!/usr/bin/env bash
 LOG="${log_file}"
-printf '%s\n' "git \$@" >> "\$LOG"
-if [[ "\$1" == "push" ]]; then
-  echo "git push failed (stub)" >&2; exit 1
-fi
+printf '%s\n' "git \$*" >> "\$LOG"
+for arg in "\$@"; do
+  if [[ "\$arg" == "push" ]]; then
+    echo "git push failed (stub)" >&2; exit 1
+  fi
+done
+exec "${real_git}" "\$@"
+STUB
+  chmod +x "${bin_dir}/git"
+}
+
+# install_git_stub_logging <bin_dir> <log_file>
+# Logs every git invocation as `git $*` (one line), then exec's real git.
+install_git_stub_logging() {
+  local bin_dir="$1" log_file="$2"
+  local real_git
+  real_git="$(command -v git)"
+  mkdir -p "$bin_dir"
+  cat > "${bin_dir}/git" <<STUB
+#!/usr/bin/env bash
+LOG="${log_file}"
+printf '%s\n' "git \$*" >> "\$LOG"
 exec "${real_git}" "\$@"
 STUB
   chmod +x "${bin_dir}/git"
@@ -315,6 +333,57 @@ if grep -q "push.*failed\|failed.*continuing" "${P1C_LOG}.stderr" 2>/dev/null; t
 else
   fail "1c: warning to stderr — got: $(cat "${P1C_LOG}.stderr" 2>/dev/null)"
 fi
+
+# 1d: no-upstream push carries core.hooksPath=/dev/null
+echo "1d: no-upstream push carries core.hooksPath=/dev/null"
+new_fixture p1d
+P1D_BIN="${SCRATCH}/p1d-bin"; P1D_LOG="${SCRATCH}/p1d.log"
+install_git_stub_logging "$P1D_BIN" "$P1D_LOG"
+(
+  cd "$WORK"
+  PATH="${P1D_BIN}:${PATH}"
+  source "$DRAFT_PR_LIB"
+  draft_pr_push >/dev/null 2>&1
+) || true
+if grep -E 'push .*-u origin HEAD' "$P1D_LOG" 2>/dev/null | grep -q 'core\.hooksPath=/dev/null'; then
+  pass "1d: no-upstream push suppresses local pre-push hooks"
+else
+  fail "1d: no-upstream push must include core.hooksPath=/dev/null — log: $(cat "$P1D_LOG" 2>/dev/null)"
+fi
+
+# 1e: upstream-set push carries core.hooksPath=/dev/null
+echo "1e: upstream-set push carries core.hooksPath=/dev/null"
+new_fixture p1e
+(cd "$WORK" && git push -u origin HEAD --quiet)
+P1E_BIN="${SCRATCH}/p1e-bin"; P1E_LOG="${SCRATCH}/p1e.log"
+install_git_stub_logging "$P1E_BIN" "$P1E_LOG"
+(
+  cd "$WORK"
+  PATH="${P1E_BIN}:${PATH}"
+  source "$DRAFT_PR_LIB"
+  draft_pr_push >/dev/null 2>&1
+) || true
+if grep -q 'core\.hooksPath=/dev/null' "$P1E_LOG" 2>/dev/null; then
+  pass "1e: upstream push suppresses local pre-push hooks"
+else
+  fail "1e: upstream push must include core.hooksPath=/dev/null — log: $(cat "$P1E_LOG" 2>/dev/null)"
+fi
+
+# 1f: blocking pre-push hook → draft_pr_push still returns 0
+echo "1f: blocking pre-push hook → draft_pr_push still returns 0"
+new_fixture p1f
+mkdir -p "${WORK}/.localhooks"
+printf '#!/usr/bin/env bash\nexit 1\n' > "${WORK}/.localhooks/pre-push"
+chmod +x "${WORK}/.localhooks/pre-push"
+git -C "$WORK" config core.hooksPath "${WORK}/.localhooks"
+(
+  cd "$WORK"
+  source "$DRAFT_PR_LIB"
+  set +e
+  draft_pr_push >/dev/null 2>&1
+  echo "$?" > "${SCRATCH}/p1f.exit"
+) || true
+assert_eq "0" "$(cat "${SCRATCH}/p1f.exit" 2>/dev/null)" "1f: draft_pr_push succeeds despite blocking pre-push hook"
 
 # ─── Suite 2: draft_pr_ensure ─────────────────────────────────────────────────
 echo ""

--- a/plugins/dev/scripts/lib/draft-pr.sh
+++ b/plugins/dev/scripts/lib/draft-pr.sh
@@ -24,12 +24,19 @@ _draft_pr_default_base() {
 }
 
 # draft_pr_push — idempotent push of current branch to origin. Fail-open.
+# CTL-693: suppress local pre-push hooks (trunk trufflehog/fmt/tests) on the
+# automated phase-agent push path — CI on origin/main already runs those gates.
+# Per-invocation `-c core.hooksPath=/dev/null` only; never mutates persistent
+# config and never affects human-interactive pushes. NOT `--no-verify` (prohibited
+# by rebase-prompt.md / phase-review).
 draft_pr_push() {
   command -v git >/dev/null 2>&1 || { _draft_pr_warn "git unavailable"; return 1; }
   if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
-    git push 2>/dev/null || { _draft_pr_warn "git push failed (continuing)"; return 1; }
+    git -c core.hooksPath=/dev/null push 2>/dev/null \
+      || { _draft_pr_warn "git push failed (continuing)"; return 1; }
   else
-    git push -u origin HEAD 2>/dev/null || { _draft_pr_warn "git push -u failed (continuing)"; return 1; }
+    git -c core.hooksPath=/dev/null push -u origin HEAD 2>/dev/null \
+      || { _draft_pr_warn "git push -u failed (continuing)"; return 1; }
   fi
 }
 

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -133,7 +133,7 @@ Key elements that MUST be preserved:
    |----------|--------|
    | clean    | proceed to merge step |
    | blocked  | resolve via `/catalyst-dev:review-comments` (bot threads) or run an inline CI fix-up commit (up to 3 attempts); 4th attempt → `stalled` |
-   | behind   | `git fetch && git rebase origin/<base> && git push --force-with-lease` |
+   | behind   | `git fetch && git rebase origin/<base> && git -c core.hooksPath=/dev/null push --force-with-lease` |
    | dirty    | merge conflicts — emit `failed` with reason "merge conflicts (DIRTY)" |
    | unknown/unstable | continue waiting for the next event |
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-05T05:22:00Z -->
<!-- Last updated: 2026-06-05T05:22:00Z -->
<!-- PR: #1328 -->
<!-- Previous commits: a44e29357f6913037348b2d63bb74fe12bcae700 -->

## Summary

Suppresses locally-installed pre-push hooks (trunk trufflehog, fmt, tests) on automated phase-agent `git push` invocations by adding `-c core.hooksPath=/dev/null` per-call. CI on `origin/main` already runs all the same gates; firing them again in every concurrent worktree during phase-pr dispatches caused RSS + CPU spikes (load avg 125–160 observed 2026-05-28). Interactive developer pushes are unaffected.

- **`draft_pr_push()`** — both the no-upstream (`push -u origin HEAD`) and upstream-set (`push`) paths now carry `-c core.hooksPath=/dev/null`; never mutates persistent git config; never uses `--no-verify` (prohibited).
- **`phase-monitor-merge` force-push** — the `git push --force-with-lease` in the BEHIND rebase table updated to match.
- **Tests (TDD)** — 3 new cases (1d/1e/1f) in `draft-pr.test.sh` using a new `install_git_stub_logging` helper; `install_git_stub_push_fail` fixed to detect `push` anywhere in `$@` now that `-c` precedes the verb. 37 pass, 0 fail.

## Changes Made

### `plugins/dev/scripts/lib/draft-pr.sh` (+9/-2)

- `draft_pr_push()` — added `-c core.hooksPath=/dev/null` to both `git push` paths (no-upstream and upstream-set).
- Clarifying comment explains the rationale: duplicate CI gates, never `--no-verify`, no persistent config mutation.

### `plugins/dev/scripts/lib/__tests__/draft-pr.test.sh` (+73/-4)

- `install_git_stub_push_fail` fixed: changed `if [[ "$1" == "push" ]]` → loop over `$@` so `-c` prefix doesn't prevent fail detection; added `exec real_git` fallthrough so the stub can actually push the fixture repo.
- New helper `install_git_stub_logging`: logs every git invocation (`git $*`) then `exec`s real git — lets tests inspect the exact flags passed without mocking git's behavior.
- Case **1d**: no-upstream path — asserts `git push -u origin HEAD` line in log contains `core.hooksPath=/dev/null`.
- Case **1e**: upstream-set path — asserts any logged push line contains `core.hooksPath=/dev/null`.
- Case **1f**: blocking pre-push hook installed via `git config core.hooksPath` — asserts `draft_pr_push` exits 0 (hook suppressed).

### `plugins/dev/skills/phase-monitor-merge/SKILL.md` (+1/-1)

- BEHIND-row push command updated to `git -c core.hooksPath=/dev/null push --force-with-lease` for consistency.

## How to Verify It

- [x] `bash plugins/dev/scripts/lib/__tests__/draft-pr.test.sh` — 37/37 pass ✅
- [ ] Observe a phase-pr dispatch in the wild: no trunk test/fmt spikes in concurrent worktrees during push

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-693
