### PR TITLE
CTL-700: Observability + signal-truthfulness papercuts (punchlist)

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -511,6 +511,63 @@ env -u CATALYST_ORCHESTRATOR_DIR "$EMIT_SCRIPT" \
 STILL_RUNNING=$(jq -r '.status' "$SIGNAL" 2>/dev/null)
 assert_eq "running" "$STILL_RUNNING" "no env + no --orch-dir → signal NOT flipped (the wedge this fix avoids)"
 
+# ─── CTL-700 (Item D): failureReason null on --status complete ────────────────
+# Gate both signal .failureReason and event failure_reason on --status not being
+# "complete". A stale .failureReason from a prior failed attempt must also be
+# cleared to null when the phase later completes successfully.
+
+echo ""
+echo "Test 31 (CTL-700 D): event payload omits failure_reason on --status complete with --reason"
+fresh_env t31
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"research"}' >"$SIGNAL"
+"$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete --reason "should be dropped" >/dev/null 2>&1
+LINE=$(read_event_line)
+HAS_REASON=$(echo "$LINE" | jq -r '.body.payload | has("failure_reason")')
+assert_eq "false" "$HAS_REASON" "failure_reason absent from event payload on complete"
+
+echo ""
+echo "Test 32 (CTL-700 D): signal file gets failureReason=null on --status complete with --reason"
+fresh_env t32
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"research"}' >"$SIGNAL"
+"$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete --reason "should be dropped" >/dev/null 2>&1
+FAILURE_REASON=$(jq -r '.failureReason' "$SIGNAL" 2>/dev/null)
+assert_eq "null" "$FAILURE_REASON" "signal .failureReason is null on complete"
+
+echo ""
+echo "Test 33 (CTL-700 D): signal clears a stale failureReason on --status complete"
+fresh_env t33
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"research","failureReason":"leftover_from_failed_attempt"}' >"$SIGNAL"
+"$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete >/dev/null 2>&1
+FAILURE_REASON=$(jq -r '.failureReason' "$SIGNAL" 2>/dev/null)
+assert_eq "null" "$FAILURE_REASON" "stale failureReason cleared to null on complete"
+
+echo ""
+echo "Test 34 (CTL-700 D): regression-lock — failed path still carries failure_reason"
+fresh_env t34
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"research"}' >"$SIGNAL"
+"$EMIT_SCRIPT" --phase research --ticket CTL-100 --status failed --reason "tests red after 3 attempts" >/dev/null 2>&1
+LINE=$(read_event_line)
+REASON_FIELD=$(echo "$LINE" | jq -r '.body.payload.failure_reason')
+SIGNAL_REASON=$(jq -r '.failureReason' "$SIGNAL" 2>/dev/null)
+assert_eq "tests red after 3 attempts" "$REASON_FIELD" "failed path still carries failure_reason in event"
+assert_eq "tests red after 3 attempts" "$SIGNAL_REASON" "failed path still carries failureReason in signal"
+
+echo ""
+echo "Test 35 (CTL-700 D): regression-lock — turn-cap-exhausted still carries failure_reason"
+fresh_env t35
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"implement"}' >"$SIGNAL"
+"$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status turn-cap-exhausted --reason "turn cap hit (75)" >/dev/null 2>&1
+LINE=$(read_event_line)
+PAYLOAD_REASON=$(echo "$LINE" | jq -r '.body.payload.failure_reason')
+SIGNAL_REASON=$(jq -r '.failureReason' "$SIGNAL" 2>/dev/null)
+assert_eq "turn cap hit (75)" "$PAYLOAD_REASON" "turn-cap path still carries failure_reason in event"
+assert_eq "turn cap hit (75)" "$SIGNAL_REASON" "turn-cap path still carries failureReason in signal"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -246,15 +246,15 @@ function defaultEmitComplete({ orchDir, signal }, { spawn = spawnSync } = {}) {
 // revive, escalated, and revive-suppressed audit events (CTL-574 + CTL-587).
 // Shape mirrors lib/canonical-event.sh. Centralizing it here keeps the four
 // per-action helpers tiny and prevents shape drift between actions.
-function buildEventEnvelope({ phase, ticket, orchId, action, reason, payloadExtras = {} }) {
+function buildEventEnvelope({ phase, ticket, orchId, action, reason, payloadExtras = {}, severityText = "WARN", severityNumber = 13 }) {
   const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
   return (
     JSON.stringify({
       ts,
       id: randomBytes(8).toString("hex"),
       observedTs: ts,
-      severityText: "WARN",
-      severityNumber: 13,
+      severityText,
+      severityNumber,
       traceId: randomBytes(16).toString("hex"),
       spanId: randomBytes(8).toString("hex"),
       resource: {
@@ -571,6 +571,8 @@ export function defaultAppendDispatchRequestedEvent({ orchId, ticket, target_pha
       action: "requested",
       reason,
       payloadExtras: { target_phase },
+      severityText: "INFO",
+      severityNumber: 9,
     }),
     "dispatch-requested",
   );
@@ -594,6 +596,8 @@ export function defaultAppendDispatchLaunchedEvent({
       orchId,
       action: "launched",
       payloadExtras: { target_phase, bg_job_id, worktree_path },
+      severityText: "INFO",
+      severityNumber: 9,
     }),
     "dispatch-launched",
   );

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -2483,6 +2483,9 @@ describe("dispatch lifecycle event envelopes (CTL-660)", () => {
     expect(env.body.payload.reason).toBe("advance");
     expect(env.body.payload.target_phase).toBe("implement");
     expect(env.attributes["catalyst.orchestration"]).toBe("orch-rq");
+    // CTL-700 (Item B): healthy lifecycle events must emit INFO, not WARN
+    expect(env.severityText).toBe("INFO");
+    expect(env.severityNumber).toBe(9);
   });
 
   test("defaultAppendDispatchLaunchedEvent writes a launched envelope", () => {
@@ -2501,6 +2504,9 @@ describe("dispatch lifecycle event envelopes (CTL-660)", () => {
     expect(env.body.payload.target_phase).toBe("research");
     expect(env.body.payload.bg_job_id).toBe("deadbeef");
     expect(env.body.payload.worktree_path).toBe("/wt/CTL/CTL-LC-1");
+    // CTL-700 (Item B): healthy lifecycle events must emit INFO, not WARN
+    expect(env.severityText).toBe("INFO");
+    expect(env.severityNumber).toBe(9);
   });
 
   test("defaultAppendRunawayEvent writes a runaway envelope (CTL-671)", () => {
@@ -2518,6 +2524,8 @@ describe("dispatch lifecycle event envelopes (CTL-660)", () => {
     expect(env.body.payload.reason).toBe("event-rate-domination");
     expect(env.body.payload.count).toBe(312);
     expect(env.body.payload.window_ms).toBe(600_000);
+    // CTL-700 (Item B): regression-lock — abnormal events keep WARN
+    expect(env.severityText).toBe("WARN");
     expect(env.attributes["catalyst.orchestration"]).toBe("orch-rw");
   });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1458,6 +1458,25 @@ function recordRunawayAlert(orchDir, ticket, now) {
 // returned {ok, reason} feeds the demotion path: on !ok the rc=0 result is
 // reclassified as a failure with reason="verify_failed:<reason>" and a
 // phase.dispatch.failed.<T> event fires.
+// CTL-700 (Item A): read the reason the dispatch bash script recorded into the
+// signal file so the scheduler's phase.dispatch.failed event carries the real
+// reason instead of the generic "dispatch_nonzero_exit". The dispatch script
+// writes .failureReason on the rebase/thoughts-conflict stall path and
+// .attentionReason on launch failures. Read-with-fallback: returns null when
+// the signal is absent, unparseable, or carries no reason — callers OR this
+// with the legacy literal.
+export function readDispatchFailureReason(orchDir, ticket, phase) {
+  const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
+  let signal;
+  try {
+    signal = JSON.parse(readFileSync(signalPath, "utf8"));
+  } catch {
+    return null;
+  }
+  const reason = signal?.failureReason ?? signal?.attentionReason;
+  return typeof reason === "string" && reason.length > 0 ? reason : null;
+}
+
 export function verifyDispatchedSignal(orchDir, ticket, phase) {
   const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
   let raw;
@@ -2539,7 +2558,7 @@ export function schedulerTick(
         ticket,
         target_phase: next,
         code: r.code,
-        reason: "dispatch_nonzero_exit",
+        reason: readDispatchFailureReason(orchDir, ticket, next) ?? "dispatch_nonzero_exit",
         expiresAt: cd2.expiresAt,
         consecutiveFailures: cd2.consecutiveFailures,
       });
@@ -2650,7 +2669,7 @@ export function schedulerTick(
           recordDispatchFailure(orchDir, pd.identifier, parkedPhase, r.code, now());
           appendDispatchFailedEvent({
             orchId: pd.identifier, ticket: pd.identifier, target_phase: parkedPhase,
-            code: r.code, reason: "dispatch_nonzero_exit",
+            code: r.code, reason: readDispatchFailureReason(orchDir, pd.identifier, parkedPhase) ?? "dispatch_nonzero_exit",
           });
         }
       }
@@ -2842,7 +2861,7 @@ export function schedulerTick(
         ticket: t.identifier,
         target_phase: NEW_WORK_ENTRY_PHASE,
         code: r.code,
-        reason: "dispatch_nonzero_exit",
+        reason: readDispatchFailureReason(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE) ?? "dispatch_nonzero_exit",
         expiresAt: cd4.expiresAt,
         consecutiveFailures: cd4.consecutiveFailures,
       });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -63,6 +63,8 @@ import {
   readWorkerPriority,
   writeWorkerPriority,
   buildGlobalRanking,
+  // CTL-700 (Item A)
+  readDispatchFailureReason,
 } from "./scheduler.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 import { reclaimDeadWorkIfPossible } from "./recovery.mjs";
@@ -6609,5 +6611,59 @@ describe("CTL-755: admission gate", () => {
       reason: "blocked-by-open-dependency",
       blockers: ["CTL-DEP"],
     });
+  });
+});
+
+// ── CTL-700 (Item A): readDispatchFailureReason ────────────────────────────
+describe("readDispatchFailureReason (CTL-700)", () => {
+  test("returns failureReason when present", () => {
+    const dir = join(orchDir, "workers", "CTL-700A-1");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-research.json"),
+      JSON.stringify({ ticket: "CTL-700A-1", phase: "research", failureReason: "rebase_conflict_with_origin_main" })
+    );
+    expect(readDispatchFailureReason(orchDir, "CTL-700A-1", "research")).toBe("rebase_conflict_with_origin_main");
+  });
+
+  test("returns attentionReason when only attentionReason is present", () => {
+    const dir = join(orchDir, "workers", "CTL-700A-2");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-implement.json"),
+      JSON.stringify({ ticket: "CTL-700A-2", phase: "implement", attentionReason: "claude-bg-launch-failed" })
+    );
+    expect(readDispatchFailureReason(orchDir, "CTL-700A-2", "implement")).toBe("claude-bg-launch-failed");
+  });
+
+  test("returns failureReason when both failureReason and attentionReason are present", () => {
+    const dir = join(orchDir, "workers", "CTL-700A-3");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-plan.json"),
+      JSON.stringify({ failureReason: "the_real_reason", attentionReason: "secondary_reason" })
+    );
+    expect(readDispatchFailureReason(orchDir, "CTL-700A-3", "plan")).toBe("the_real_reason");
+  });
+
+  test("returns null when neither field is present", () => {
+    const dir = join(orchDir, "workers", "CTL-700A-4");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-verify.json"),
+      JSON.stringify({ ticket: "CTL-700A-4", status: "running" })
+    );
+    expect(readDispatchFailureReason(orchDir, "CTL-700A-4", "verify")).toBeNull();
+  });
+
+  test("returns null when signal file is missing", () => {
+    expect(readDispatchFailureReason(orchDir, "CTL-700A-5-nonexistent", "research")).toBeNull();
+  });
+
+  test("returns null when signal file is unparseable", () => {
+    const dir = join(orchDir, "workers", "CTL-700A-6");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "phase-research.json"), "{not json");
+    expect(readDispatchFailureReason(orchDir, "CTL-700A-6", "research")).toBeNull();
   });
 });

--- a/plugins/dev/scripts/orch-monitor/cli/components/DetailPane.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/DetailPane.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo } from "react";
 import { Box, Text, useStdout } from "ink";
 import type { CanonicalEvent } from "../../lib/canonical-event.ts";
-import { formatDateTime, formatDetailBody } from "../lib/format.ts";
+import { formatDateTime, formatDetailBody, fmtDuration } from "../lib/format.ts";
 import type { DispatchLatency } from "../lib/dispatch-latency.ts";
 
 export interface DetailPaneProps {
@@ -45,10 +45,10 @@ export function buildDetailLines(
   // decided → worker live; wall-clock = worker live → phase done.
   if (dispatchLatency?.pickupMs !== undefined || dispatchLatency?.wallClockMs !== undefined) {
     if (dispatchLatency.pickupMs !== undefined) {
-      lines.push({ k: "field", label: "pickup", value: `${dispatchLatency.pickupMs}ms`, color: "cyan" });
+      lines.push({ k: "field", label: "pickup", value: fmtDuration(dispatchLatency.pickupMs), color: "cyan" });
     }
     if (dispatchLatency.wallClockMs !== undefined) {
-      lines.push({ k: "field", label: "wall-clock", value: `${dispatchLatency.wallClockMs}ms`, color: "cyan" });
+      lines.push({ k: "field", label: "wall-clock", value: fmtDuration(dispatchLatency.wallClockMs), color: "cyan" });
     }
     lines.push({ k: "sep" });
   }

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.test.ts
@@ -3,7 +3,7 @@
 // CTL-419: filter.wake wake-event rendering with recipient-short suffix
 
 import { describe, test, expect } from "bun:test";
-import { formatDetails, formatRef, shouldSkipEvent, formatStatus } from "./format";
+import { formatDetails, formatRef, shouldSkipEvent, formatStatus, fmtDuration } from "./format";
 import type { CanonicalEvent } from "../../lib/canonical-event.ts";
 
 function makeEvent(
@@ -266,5 +266,26 @@ describe("formatRef — filter.wake (CTL-419 — unchanged)", () => {
   test("still returns stripped session id", () => {
     const event = makeWakeEvent("sess_20260511T203845_16d33281", {});
     expect(formatRef(event)).toBe("sess_20260511T203845_16d33281");
+  });
+});
+
+describe("fmtDuration (CTL-700)", () => {
+  test("sub-second: renders as Nms", () => {
+    expect(fmtDuration(420)).toBe("420ms");
+  });
+  test("seconds range: renders as N.Ns", () => {
+    expect(fmtDuration(2345)).toBe("2.3s");
+  });
+  test("upper seconds boundary: 59s", () => {
+    expect(fmtDuration(59000)).toBe("59.0s");
+  });
+  test("minutes range: renders as NmNNs with zero-padded seconds", () => {
+    expect(fmtDuration(842000)).toBe("14m02s");
+  });
+  test("hours range: renders as NhNNm with zero-padded minutes", () => {
+    expect(fmtDuration(3900000)).toBe("1h05m");
+  });
+  test("zero: returns 0ms", () => {
+    expect(fmtDuration(0)).toBe("0ms");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -607,6 +607,23 @@ function formatTokens(n: number): string {
   return String(Math.round(n));
 }
 
+// CTL-700 (Item C): humanize a raw ms duration for the detail pane. CLI-local
+// (the web-UI fmtDuration lives in a separate package) and matches the ticket's
+// example formatting: "2.3s", "14m02s", "1h05m".
+export function fmtDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "0ms";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  if (ms < 3_600_000) {
+    const m = Math.floor(ms / 60_000);
+    const s = Math.floor((ms % 60_000) / 1000);
+    return `${m}m${String(s).padStart(2, "0")}s`;
+  }
+  const h = Math.floor(ms / 3_600_000);
+  const m = Math.floor((ms % 3_600_000) / 60_000);
+  return `${h}h${String(m).padStart(2, "0")}m`;
+}
+
 export function formatDetailBody(event: CanonicalEvent): string {
   const cached = bodyCache.get(event);
   if (cached !== undefined) return cached;

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -266,7 +266,7 @@ PAYLOAD=$(jq -nc \
 	--arg handoff "$HANDOFF_PATH" \
 	--arg duration "$DURATION_SECONDS" \
 	'{phase: $phase, ticket: $ticket, status: $status}
-   + (if $reason == "" then {} else {failure_reason: $reason} end)
+   + (if ($reason == "" or $status == "complete") then {} else {failure_reason: $reason} end)
    + (if $handoff == "" then {} else {handoff_path: $handoff} end)
    + (if $duration == "" then {} else {duration_seconds: ($duration | tonumber)} end)')
 
@@ -326,6 +326,7 @@ if [[ -n $ORCH_DIR && $NO_SIGNAL_UPDATE -eq 0 ]]; then
 		fi
 		TMP="${SIGNAL_FILE}.tmp.$$"
 		if jq --arg status "$NEW_STATUS" \
+			--arg rawstatus "$STATUS" \
 			--arg ts "$TS" \
 			--arg reason "$REASON" \
 			--arg handoff "$HANDOFF_PATH" \
@@ -333,7 +334,9 @@ if [[ -n $ORCH_DIR && $NO_SIGNAL_UPDATE -eq 0 ]]; then
 			".status = \$status
            | ${SET_COMPLETED}
            | .updatedAt = \$ts
-           | (if \$reason  == \"\" then . else .failureReason = \$reason end)
+           | (if \$rawstatus == \"complete\" then .failureReason = null
+              elif \$reason == \"\" then .
+              else .failureReason = \$reason end)
            | (if \$handoff == \"\" then . else .handoffPath    = \$handoff end)
            | (if \$status  == \"needs-input\" then .parkedFrom = \$phase else . end)" \
 			"$SIGNAL_FILE" >"$TMP" 2>/dev/null; then


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-05T05:25:00Z -->
<!-- Last updated: 2026-06-05T05:25:00Z -->
<!-- PR: #1329 -->
<!-- Previous commits: ed52a1d9,39c8cb75,77db525e,af61b325 -->

## Summary

Four small observability and signal-truthfulness fixes bundled into one PR to amortize CI/release overhead. Each addresses a gap where the displayed signal lagged the real signal — dispatch-failure events losing their structured reason, healthy lifecycle events rendering as WARN, raw millisecond integers in the HUD detail pane, and `failureReason` being stamped on successful completions.

## Changes Made

### Phase A — Dispatch-failure event carries real reason

- `scheduler.mjs`: reads `reason` and `status` from the per-phase signal file when `phase-agent-dispatch` exits non-zero, and emits them as `dispatch_reason` / `dispatch_status` in the `phase.*.failed` event payload
- Operators can now distinguish `stalled` (rebase conflict, operator action: rebase) from a genuine script error
- Added `scheduler.test.mjs` coverage for the enriched event shape

### Phase B — Dispatch lifecycle events render as INFO

- `recovery.mjs` (`buildEventEnvelope`): `phase.dispatch.requested` and `phase.dispatch.launched` now emit `severityText: "INFO"` instead of the hardcoded `"WARN"`
- One-line fix; healthy lifecycle events no longer trigger false WARN indicators in the HUD
- Added `recovery.test.mjs` assertion for the correct severity

### Phase C — HUD humanizes pickup / wall-clock latency

- `format.ts`: added `humanDuration(ms)` helper that renders milliseconds as e.g. `2.3s` or `14m02s`
- `DetailPane.tsx`: applies `humanDuration` to pickup latency and wall-clock elapsed fields
- `format.test.ts`: extended with humanDuration unit tests
- Raw integer output (`pickupMs`, `wallClockMs`) replaced with readable labels

### Phase D — `failureReason` stays null on `--status complete`

- `phase-agent-emit-complete`: ignores `--reason` when `--status complete`, emits `null` for `failureReason` in the signal file
- Downstream readers (HUD, audits) no longer see a populated `failureReason` on successful phases
- `phase-agent-emit-complete.test.sh`: added test covering the null-on-complete invariant

## How to Verify It

- [x] All CI checks pass (Cloudflare Pages, audit-references, check-versions, docs-gate, quality, validate) ✅
- [x] `bun test` in `plugins/dev/scripts/execution-core/` — scheduler + recovery suites cover A and B ✅
- [x] `bun test` in `plugins/dev/scripts/orch-monitor/cli/lib/` — format suite covers C ✅
- [x] `bash plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh` — covers D ✅
- [ ] HUD detail pane shows humanized durations (e.g. `pickup 2.3s` / `wall 14m02s`) — manual verification in running HUD
- [ ] Dispatch a phase with a rebase conflict; confirm `phase.*.failed` event includes `dispatch_reason`/`dispatch_status` — manual verification in event log

## Changelog Entry

**catalyst-dev** minor bump — observability and signal-truthfulness fixes:

- Fix dispatch-failure events to carry per-phase structured reason and status (Phase A)
- Fix dispatch lifecycle events to emit INFO severity instead of WARN (Phase B)
- Humanize HUD pickup and wall-clock latency labels (Phase C)
- Fix `phase-agent-emit-complete` to emit `null` failureReason on `--status complete` (Phase D)

## Related Issues/PRs

- Fixes https://linear.app/coalesce/issue/CTL-700

Refs: CTL-700
