### PR TITLE
CTL-762: Add --resource-attr passthrough to emit-otel-event.sh and emit-otel-metric.sh

### DIFF
--- a/plugins/dev/scripts/__tests__/emit-otel-event.test.sh
+++ b/plugins/dev/scripts/__tests__/emit-otel-event.test.sh
@@ -444,6 +444,12 @@ BODY_17=$(cat "$SCRATCH/body17" 2>/dev/null || echo "{}")
 BOGUS_CNT="$(echo "$BODY_17" | jq -r '[.resourceLogs[0].resource.attributes[]? | select(.key=="bogus")] | length')"
 assert_eq "0" "$BOGUS_CNT" "malformed --resource-attr: bogus key not present"
 
+# ─── Test 18: --help output includes --resource-attr ────────────────────────
+echo ""
+echo "--- Test 18: --help output documents --resource-attr ---"
+HELP_OUT=$("$EMIT_SCRIPT" --help 2>&1 || true)
+assert_contains "$HELP_OUT" "--resource-attr" "--help output includes --resource-attr"
+
 # ─── Summary ────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/emit-otel-event.test.sh
+++ b/plugins/dev/scripts/__tests__/emit-otel-event.test.sh
@@ -311,6 +311,139 @@ PHASE_ATTR=$(echo "$BODY_11" | jq -r '
   | select(.key == "phase") | .value.stringValue // ""')
 assert_eq "research" "$PHASE_ATTR" "--phase adds phase attribute to log record"
 
+# ─── Test 12: --resource-attr string lands in resource attrs ────────────────
+echo ""
+echo "--- Test 12: --resource-attr string lands in resource attributes ---"
+STUB_DIR_12="$SCRATCH/stub12"
+setup_curl_stub "$STUB_DIR_12"
+export PATH="$STUB_DIR_12:$PATH"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://x:4317"
+export CURL_STUB_ARGS="$SCRATCH/args12"
+export CURL_STUB_BODY="$SCRATCH/body12"
+
+"$EMIT_SCRIPT" \
+  --event "claude_code.session.outcome" \
+  --outcome success \
+  --session-id s1 \
+  --resource-attr "project=catalyst" \
+  >/dev/null 2>&1
+
+BODY_12=$(cat "$SCRATCH/body12" 2>/dev/null || echo "{}")
+assert_eq "catalyst" \
+  "$(echo "$BODY_12" | jq -r '.resourceLogs[0].resource.attributes[] | select(.key=="project") | .value.stringValue')" \
+  "--resource-attr project=catalyst in resource attributes"
+
+# ─── Test 13: multiple --resource-attr repeats ──────────────────────────────
+echo ""
+echo "--- Test 13: multiple --resource-attr repeats ---"
+STUB_DIR_13="$SCRATCH/stub13"
+setup_curl_stub "$STUB_DIR_13"
+export PATH="$STUB_DIR_13:$PATH"
+export CURL_STUB_ARGS="$SCRATCH/args13"
+export CURL_STUB_BODY="$SCRATCH/body13"
+
+"$EMIT_SCRIPT" \
+  --event "claude_code.session.outcome" \
+  --outcome success \
+  --session-id s1 \
+  --resource-attr "project=catalyst" \
+  --resource-attr "env=staging" \
+  >/dev/null 2>&1
+
+BODY_13=$(cat "$SCRATCH/body13" 2>/dev/null || echo "{}")
+assert_eq "catalyst" \
+  "$(echo "$BODY_13" | jq -r '.resourceLogs[0].resource.attributes[] | select(.key=="project") | .value.stringValue')" \
+  "multiple --resource-attr: project=catalyst present"
+assert_eq "staging" \
+  "$(echo "$BODY_13" | jq -r '.resourceLogs[0].resource.attributes[] | select(.key=="env") | .value.stringValue')" \
+  "multiple --resource-attr: env=staging present"
+
+# ─── Test 14: integer --resource-attr → intValue ────────────────────────────
+echo ""
+echo "--- Test 14: integer --resource-attr emits intValue ---"
+STUB_DIR_14="$SCRATCH/stub14"
+setup_curl_stub "$STUB_DIR_14"
+export PATH="$STUB_DIR_14:$PATH"
+export CURL_STUB_ARGS="$SCRATCH/args14"
+export CURL_STUB_BODY="$SCRATCH/body14"
+
+"$EMIT_SCRIPT" \
+  --event "claude_code.session.outcome" \
+  --outcome success \
+  --session-id s1 \
+  --resource-attr "revive_count=3" \
+  >/dev/null 2>&1
+
+BODY_14=$(cat "$SCRATCH/body14" 2>/dev/null || echo "{}")
+assert_eq "3" \
+  "$(echo "$BODY_14" | jq -r '.resourceLogs[0].resource.attributes[] | select(.key=="revive_count") | .value.intValue')" \
+  "integer --resource-attr: intValue==3"
+assert_eq "null" \
+  "$(echo "$BODY_14" | jq -r '.resourceLogs[0].resource.attributes[] | select(.key=="revive_count") | .value.stringValue // "null"')" \
+  "integer --resource-attr: stringValue is absent"
+
+# ─── Test 15: integer --attr → intValue (shared helper) ─────────────────────
+echo ""
+echo "--- Test 15: integer --attr emits intValue via shared helper ---"
+STUB_DIR_15="$SCRATCH/stub15"
+setup_curl_stub "$STUB_DIR_15"
+export PATH="$STUB_DIR_15:$PATH"
+export CURL_STUB_ARGS="$SCRATCH/args15"
+export CURL_STUB_BODY="$SCRATCH/body15"
+
+"$EMIT_SCRIPT" \
+  --event "claude_code.session.outcome" \
+  --outcome success \
+  --session-id s1 \
+  --attr "attempt=2" \
+  >/dev/null 2>&1
+
+BODY_15=$(cat "$SCRATCH/body15" 2>/dev/null || echo "{}")
+assert_eq "2" \
+  "$(echo "$BODY_15" | jq -r '.resourceLogs[0].scopeLogs[0].logRecords[0].attributes[] | select(.key=="attempt") | .value.intValue')" \
+  "integer --attr: intValue==2"
+
+# ─── Test 16: omitting --resource-attr leaves resource array byte-identical ──
+echo ""
+echo "--- Test 16: omitting --resource-attr yields byte-identical resource array ---"
+STUB_DIR_16="$SCRATCH/stub16"
+setup_curl_stub "$STUB_DIR_16"
+export PATH="$STUB_DIR_16:$PATH"
+export CURL_STUB_ARGS="$SCRATCH/args16"
+export CURL_STUB_BODY="$SCRATCH/body16"
+
+"$EMIT_SCRIPT" \
+  --event "claude_code.session.outcome" \
+  --outcome success \
+  --session-id s1 \
+  >/dev/null 2>&1
+
+BODY_16=$(cat "$SCRATCH/body16" 2>/dev/null || echo "{}")
+EXPECTED_RES='[{"key":"service.name","value":{"stringValue":"claude-code"}}]'
+ACTUAL_RES="$(echo "$BODY_16" | jq -c '.resourceLogs[0].resource.attributes')"
+assert_eq "$EXPECTED_RES" "$ACTUAL_RES" "omitting --resource-attr: resource array is byte-identical"
+
+# ─── Test 17: malformed --resource-attr (no =) is skipped ───────────────────
+echo ""
+echo "--- Test 17: malformed --resource-attr (no =) is skipped ---"
+STUB_DIR_17="$SCRATCH/stub17"
+setup_curl_stub "$STUB_DIR_17"
+export PATH="$STUB_DIR_17:$PATH"
+export CURL_STUB_ARGS="$SCRATCH/args17"
+export CURL_STUB_BODY="$SCRATCH/body17"
+
+"$EMIT_SCRIPT" \
+  --event "claude_code.session.outcome" \
+  --outcome success \
+  --session-id s1 \
+  --resource-attr "bogus" \
+  >/dev/null 2>&1
+EXIT_CODE_17=$?
+assert_eq "0" "$EXIT_CODE_17" "malformed --resource-attr: exit 0"
+BODY_17=$(cat "$SCRATCH/body17" 2>/dev/null || echo "{}")
+BOGUS_CNT="$(echo "$BODY_17" | jq -r '[.resourceLogs[0].resource.attributes[]? | select(.key=="bogus")] | length')"
+assert_eq "0" "$BOGUS_CNT" "malformed --resource-attr: bogus key not present"
+
 # ─── Summary ────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/emit-otel-metric.test.sh
+++ b/plugins/dev/scripts/__tests__/emit-otel-metric.test.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Tests for emit-otel-metric.sh — the OTLP/HTTP metric emitter used by
+# catalyst-session.sh to flush per-session counters.
+#
+# Approach: stub `curl` on PATH, capture the URL + JSON payload from stdin
+# (script uses `printf '%s' "$PAYLOAD" | curl ... --data @-`), then assert
+# both. Silent-failure paths assert exit 0 regardless of curl stub exit code.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+EMIT_SCRIPT="${REPO_ROOT}/plugins/dev/scripts/emit-otel-metric.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t emit-otel-metric-test-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label — expected '$expected', got '$actual'"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$label"
+  else
+    fail "$label — '$needle' not found in '$haystack'"
+  fi
+}
+
+# ─── curl stub ──────────────────────────────────────────────────────────────
+# Records args to $CURL_STUB_ARGS and payload (from stdin via --data @-)
+# to $CURL_STUB_BODY. Exits with $CURL_STUB_EXIT (default 0).
+setup_curl_stub() {
+  local stub_dir="$1"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/curl" <<'STUB'
+#!/usr/bin/env bash
+ARGS_FILE="${CURL_STUB_ARGS:-/tmp/curl-stub.args}"
+BODY_FILE="${CURL_STUB_BODY:-/tmp/curl-stub.body}"
+printf '%s\n' "$@" > "$ARGS_FILE"
+
+# Extract body from -d / --data / --data @- (stdin).
+body=""
+prev=""
+for a in "$@"; do
+  if [[ "$prev" == "-d" || "$prev" == "--data" || "$prev" == "--data-raw" ]]; then
+    body="$a"
+    break
+  fi
+  prev="$a"
+done
+# @- means read from stdin; @<file> means read from that file.
+if [[ "$body" == @* ]]; then
+  body=$(cat "${body:1}")
+fi
+printf '%s' "$body" > "$BODY_FILE"
+exit "${CURL_STUB_EXIT:-0}"
+STUB
+  chmod +x "$stub_dir/curl"
+}
+
+if [[ ! -x "$EMIT_SCRIPT" ]]; then
+  echo "FATAL: emit-otel-metric.sh not found or not executable at $EMIT_SCRIPT" >&2
+  exit 1
+fi
+
+# ─── Test 1: baseline payload structure ─────────────────────────────────────
+echo ""
+echo "--- Test 1: baseline OTLP metric payload structure ---"
+STUB_DIR_1="$SCRATCH/stub1"
+setup_curl_stub "$STUB_DIR_1"
+export PATH="$STUB_DIR_1:$PATH"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://collector.example:4317"
+export CURL_STUB_ARGS="$SCRATCH/args1"
+export CURL_STUB_BODY="$SCRATCH/body1"
+unset CURL_STUB_EXIT
+
+"$EMIT_SCRIPT" iteration_count \
+  --kind plan \
+  --count 5 \
+  --linear-key CTL-1 \
+  >/dev/null 2>&1
+EXIT_CODE=$?
+
+assert_eq "0" "$EXIT_CODE" "exit 0 on success"
+[[ -f "$SCRATCH/body1" ]] && pass "curl stub received a body" || fail "no body captured"
+
+BODY_1=$(cat "$SCRATCH/body1" 2>/dev/null || echo "")
+if echo "$BODY_1" | jq -e '.resourceMetrics[0].scopeMetrics[0].metrics[0]' >/dev/null 2>&1; then
+  pass "payload has valid OTLP metric structure"
+else
+  fail "payload is not valid OTLP metric shape: $BODY_1"
+fi
+
+assert_eq "iteration_count" \
+  "$(echo "$BODY_1" | jq -r '.resourceMetrics[0].scopeMetrics[0].metrics[0].name')" \
+  "metric name is iteration_count"
+
+assert_eq "claude-code" \
+  "$(echo "$BODY_1" | jq -r '.resourceMetrics[0].resource.attributes[] | select(.key=="service.name") | .value.stringValue')" \
+  "service.name=claude-code in resource attributes"
+
+assert_eq "plan" \
+  "$(echo "$BODY_1" | jq -r '.resourceMetrics[0].scopeMetrics[0].metrics[0].sum.dataPoints[0].attributes[] | select(.key=="kind") | .value.stringValue')" \
+  "kind=plan in data point attributes"
+
+assert_eq "5" \
+  "$(echo "$BODY_1" | jq -r '.resourceMetrics[0].scopeMetrics[0].metrics[0].sum.dataPoints[0].asInt')" \
+  "asInt==5"
+
+# ─── Test 2: --linear-key → resource attribute (regression guard) ────────────
+echo ""
+echo "--- Test 2: --linear-key sets resource attribute ---"
+STUB_DIR_2="$SCRATCH/stub2"
+setup_curl_stub "$STUB_DIR_2"
+export PATH="$STUB_DIR_2:$PATH"
+export CURL_STUB_ARGS="$SCRATCH/args2"
+export CURL_STUB_BODY="$SCRATCH/body2"
+
+"$EMIT_SCRIPT" iteration_count \
+  --kind plan \
+  --count 1 \
+  --linear-key CTL-1 \
+  >/dev/null 2>&1
+
+BODY_2=$(cat "$SCRATCH/body2")
+assert_eq "CTL-1" \
+  "$(echo "$BODY_2" | jq -r '.resourceMetrics[0].resource.attributes[] | select(.key=="linear.key") | .value.stringValue')" \
+  "linear.key==CTL-1 in resource attributes"
+
+# ─── Test 3: omitting --resource-attr is byte-identical ─────────────────────
+echo ""
+echo "--- Test 3: omitting --resource-attr yields byte-identical resource array ---"
+STUB_DIR_3="$SCRATCH/stub3"
+setup_curl_stub "$STUB_DIR_3"
+export PATH="$STUB_DIR_3:$PATH"
+export CURL_STUB_ARGS="$SCRATCH/args3"
+export CURL_STUB_BODY="$SCRATCH/body3"
+
+"$EMIT_SCRIPT" iteration_count \
+  --kind fix \
+  --count 2 \
+  --linear-key CTL-1 \
+  >/dev/null 2>&1
+
+BODY_3=$(cat "$SCRATCH/body3")
+EXPECTED_RES_3='[{"key":"service.name","value":{"stringValue":"claude-code"}},{"key":"linear.key","value":{"stringValue":"CTL-1"}}]'
+ACTUAL_RES_3="$(echo "$BODY_3" | jq -c '.resourceMetrics[0].resource.attributes')"
+assert_eq "$EXPECTED_RES_3" "$ACTUAL_RES_3" "omitting --resource-attr: resource array is byte-identical"
+
+# ─── Test 4: --resource-attr string appended after existing entries ──────────
+echo ""
+echo "--- Test 4: --resource-attr string appended after existing entries ---"
+STUB_DIR_4="$SCRATCH/stub4"
+setup_curl_stub "$STUB_DIR_4"
+export PATH="$STUB_DIR_4:$PATH"
+export CURL_STUB_ARGS="$SCRATCH/args4"
+export CURL_STUB_BODY="$SCRATCH/body4"
+
+"$EMIT_SCRIPT" iteration_count \
+  --kind plan \
+  --count 1 \
+  --linear-key CTL-1 \
+  --resource-attr "project=catalyst" \
+  >/dev/null 2>&1
+
+BODY_4=$(cat "$SCRATCH/body4")
+assert_eq "catalyst" \
+  "$(echo "$BODY_4" | jq -r '.resourceMetrics[0].resource.attributes[] | select(.key=="project") | .value.stringValue')" \
+  "--resource-attr project=catalyst present"
+
+# ─── Test 5: integer --resource-attr → intValue ─────────────────────────────
+echo ""
+echo "--- Test 5: integer --resource-attr emits intValue ---"
+STUB_DIR_5="$SCRATCH/stub5"
+setup_curl_stub "$STUB_DIR_5"
+export PATH="$STUB_DIR_5:$PATH"
+export CURL_STUB_ARGS="$SCRATCH/args5"
+export CURL_STUB_BODY="$SCRATCH/body5"
+
+"$EMIT_SCRIPT" iteration_count \
+  --kind plan \
+  --count 1 \
+  --linear-key CTL-1 \
+  --resource-attr "revive_count=4" \
+  >/dev/null 2>&1
+
+BODY_5=$(cat "$SCRATCH/body5")
+assert_eq "4" \
+  "$(echo "$BODY_5" | jq -r '.resourceMetrics[0].resource.attributes[] | select(.key=="revive_count") | .value.intValue')" \
+  "integer --resource-attr: intValue==4"
+assert_eq "null" \
+  "$(echo "$BODY_5" | jq -r '.resourceMetrics[0].resource.attributes[] | select(.key=="revive_count") | .value.stringValue // "null"')" \
+  "integer --resource-attr: stringValue is absent"
+
+# ─── Test 6: silent no-op when OTEL_EXPORTER_OTLP_ENDPOINT unset ────────────
+echo ""
+echo "--- Test 6: silent no-op when endpoint unset ---"
+STUB_DIR_6="$SCRATCH/stub6"
+setup_curl_stub "$STUB_DIR_6"
+export PATH="$STUB_DIR_6:$PATH"
+unset OTEL_EXPORTER_OTLP_ENDPOINT
+export CURL_STUB_ARGS="$SCRATCH/args6"
+export CURL_STUB_BODY="$SCRATCH/body6"
+rm -f "$SCRATCH/args6" "$SCRATCH/body6"
+export CURL_STUB_EXIT=99
+
+"$EMIT_SCRIPT" iteration_count --kind plan --count 1 >/dev/null 2>&1
+EXIT_CODE_6=$?
+assert_eq "0" "$EXIT_CODE_6" "exit 0 when endpoint unset"
+if [[ ! -f "$SCRATCH/args6" ]]; then
+  pass "curl not invoked when endpoint unset"
+else
+  fail "curl was invoked — stub args captured: $(cat "$SCRATCH/args6")"
+fi
+unset CURL_STUB_EXIT
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://collector.example:4317"
+
+# ─── Test 7: unknown flag is silent no-op ───────────────────────────────────
+echo ""
+echo "--- Test 7: unknown flag is silent no-op (die_silent contract) ---"
+STUB_DIR_7="$SCRATCH/stub7"
+setup_curl_stub "$STUB_DIR_7"
+export PATH="$STUB_DIR_7:$PATH"
+export CURL_STUB_ARGS="$SCRATCH/args7"
+export CURL_STUB_BODY="$SCRATCH/body7"
+rm -f "$SCRATCH/args7" "$SCRATCH/body7"
+
+"$EMIT_SCRIPT" iteration_count --kind plan --count 1 --bogus x >/dev/null 2>&1
+EXIT_CODE_7=$?
+assert_eq "0" "$EXIT_CODE_7" "unknown flag: exit 0 (silent no-op)"
+if [[ ! -f "$SCRATCH/args7" ]]; then
+  pass "unknown flag: curl not invoked"
+else
+  fail "unknown flag: curl was unexpectedly invoked"
+fi
+
+# ─── Summary ────────────────────────────────────────────────────────────────
+echo ""
+echo "─────────────────────────────────────"
+echo "  Passed: $PASSES"
+echo "  Failed: $FAILURES"
+echo "─────────────────────────────────────"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/emit-otel-event.sh
+++ b/plugins/dev/scripts/emit-otel-event.sh
@@ -11,8 +11,11 @@
 # Usage:
 #   emit-otel-event.sh --event <name> --outcome <enum> --session-id <id>
 #                      [--reason <text>] [--linear-key <key>] [--attr k=v ...]
+#                      [--resource-attr k=v ...]
 #
 # --outcome must be one of: success, fail, timeout, abandoned.
+# --resource-attr appends into the OTLP resource attributes array. Integer
+# values (^-?[0-9]+$) are emitted as intValue; all others as stringValue.
 #
 # Transport: OTLP/HTTP (port 4318) to OTEL_EXPORTER_OTLP_ENDPOINT. When that
 # env var is unset or the POST fails, we exit 0 silently — the caller is a

--- a/plugins/dev/scripts/emit-otel-event.sh
+++ b/plugins/dev/scripts/emit-otel-event.sh
@@ -32,6 +32,17 @@ is_valid_outcome() {
 
 die() { echo "error: $*" >&2; exit 1; }
 
+# Append one k=v into a JSON attr array on stdin, choosing intValue for
+# integer-looking values (matches otel-forward otlp.ts), stringValue otherwise.
+append_attr_json() {  # args: <key> <val>; reads array on stdin, writes on stdout
+  local k="$1" v="$2"
+  if [[ "$v" =~ ^-?[0-9]+$ ]]; then
+    jq -c --arg k "$k" --argjson n "$v" '. + [{key:$k,value:{intValue:$n}}]'
+  else
+    jq -c --arg k "$k" --arg v "$v" '. + [{key:$k,value:{stringValue:$v}}]'
+  fi
+}
+
 # ─── Parse args ─────────────────────────────────────────────────────────────
 
 EVENT=""
@@ -41,18 +52,20 @@ REASON=""
 LINEAR_KEY=""
 PHASE=""
 EXTRA_ATTRS=()
+RES_EXTRA_ATTRS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --event)       EVENT="$2"; shift 2 ;;
-    --outcome)     OUTCOME="$2"; shift 2 ;;
-    --session-id)  SESSION_ID="$2"; shift 2 ;;
-    --reason)      REASON="$2"; shift 2 ;;
-    --linear-key)  LINEAR_KEY="$2"; shift 2 ;;
-    --phase)       PHASE="$2"; shift 2 ;;
-    --attr)        EXTRA_ATTRS+=("$2"); shift 2 ;;
-    -h|--help)     grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
-    *)             die "unknown flag: $1" ;;
+    --event)          EVENT="$2"; shift 2 ;;
+    --outcome)        OUTCOME="$2"; shift 2 ;;
+    --session-id)     SESSION_ID="$2"; shift 2 ;;
+    --reason)         REASON="$2"; shift 2 ;;
+    --linear-key)     LINEAR_KEY="$2"; shift 2 ;;
+    --phase)          PHASE="$2"; shift 2 ;;
+    --attr)           EXTRA_ATTRS+=("$2"); shift 2 ;;
+    --resource-attr)  RES_EXTRA_ATTRS+=("$2"); shift 2 ;;
+    -h|--help)        grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *)                die "unknown flag: $1" ;;
   esac
 done
 
@@ -98,6 +111,12 @@ if [[ -n "$LINEAR_KEY" ]]; then
   RES_ATTRS_JSON=$(echo "$RES_ATTRS_JSON" \
     | jq -c --arg k "$LINEAR_KEY" '. + [{key:"linear.key",value:{stringValue:$k}}]')
 fi
+for kv in "${RES_EXTRA_ATTRS[@]:-}"; do
+  [[ -n "$kv" ]] || continue
+  key="${kv%%=*}"; val="${kv#*=}"
+  [[ -n "$key" && "$key" != "$kv" ]] || continue
+  RES_ATTRS_JSON=$(printf '%s' "$RES_ATTRS_JSON" | append_attr_json "$key" "$val")
+done
 
 # Build log record attributes.
 LOG_ATTRS_JSON=$(jq -nc \
@@ -118,12 +137,11 @@ if [[ -n "$PHASE" ]]; then
     | jq -c --arg p "$PHASE" '. + [{key:"phase",value:{stringValue:$p}}]')
 fi
 
-for kv in "${EXTRA_ATTRS[@]}"; do
-  key="${kv%%=*}"
-  val="${kv#*=}"
+for kv in "${EXTRA_ATTRS[@]:-}"; do
+  [[ -n "$kv" ]] || continue
+  key="${kv%%=*}"; val="${kv#*=}"
   [[ -n "$key" && "$key" != "$kv" ]] || continue
-  LOG_ATTRS_JSON=$(echo "$LOG_ATTRS_JSON" \
-    | jq -c --arg k "$key" --arg v "$val" '. + [{key:$k,value:{stringValue:$v}}]')
+  LOG_ATTRS_JSON=$(printf '%s' "$LOG_ATTRS_JSON" | append_attr_json "$key" "$val")
 done
 
 PAYLOAD=$(jq -nc \

--- a/plugins/dev/scripts/emit-otel-metric.sh
+++ b/plugins/dev/scripts/emit-otel-metric.sh
@@ -30,6 +30,17 @@ set -uo pipefail
 
 die_silent() { exit 0; }  # explicit shorthand for "fail silently"
 
+# Append one k=v into a JSON attr array on stdin, choosing intValue for
+# integer-looking values (matches otel-forward otlp.ts), stringValue otherwise.
+append_attr_json() {  # args: <key> <val>; reads array on stdin, writes on stdout
+  local k="$1" v="$2"
+  if [[ "$v" =~ ^-?[0-9]+$ ]]; then
+    jq -c --arg k "$k" --argjson n "$v" '. + [{key:$k,value:{intValue:$n}}]'
+  else
+    jq -c --arg k "$k" --arg v "$v" '. + [{key:$k,value:{stringValue:$v}}]'
+  fi
+}
+
 # ─── Parse args ─────────────────────────────────────────────────────────────
 
 METRIC_NAME="${1:-}"
@@ -42,15 +53,17 @@ LINEAR_KEY=""
 START_NS=""
 SCOPE="catalyst.session"
 PHASE=""
+RES_EXTRA_ATTRS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --kind)       KIND="$2";       shift 2 ;;
-    --count)      COUNT="$2";      shift 2 ;;
-    --linear-key) LINEAR_KEY="$2"; shift 2 ;;
-    --start-ns)   START_NS="$2";   shift 2 ;;
-    --scope)      SCOPE="$2";      shift 2 ;;
-    --phase)      PHASE="$2";      shift 2 ;;
+    --kind)          KIND="$2";              shift 2 ;;
+    --count)         COUNT="$2";             shift 2 ;;
+    --linear-key)    LINEAR_KEY="$2";        shift 2 ;;
+    --start-ns)      START_NS="$2";          shift 2 ;;
+    --scope)         SCOPE="$2";             shift 2 ;;
+    --phase)         PHASE="$2";             shift 2 ;;
+    --resource-attr) RES_EXTRA_ATTRS+=("$2"); shift 2 ;;
     *) die_silent ;;  # unknown flag — silent noop, we're on the session-end hot path
   esac
 done
@@ -83,28 +96,35 @@ NOW_NS="$(date -u +%s)000000000"
 
 SERVICE_NAME="${OTEL_SERVICE_NAME:-claude-code}"
 
+# Build resource attributes via step-append (preserves today's exact order).
+RES_ATTRS_JSON=$(jq -nc --arg svc "$SERVICE_NAME" '[{key:"service.name",value:{stringValue:$svc}}]')
+if [[ -n "$LINEAR_KEY" ]]; then
+  RES_ATTRS_JSON=$(printf '%s' "$RES_ATTRS_JSON" \
+    | jq -c --arg k "$LINEAR_KEY" '. + [{key:"linear.key",value:{stringValue:$k}}]')
+fi
+for kv in "${RES_EXTRA_ATTRS[@]:-}"; do
+  [[ -n "$kv" ]] || continue
+  key="${kv%%=*}"; val="${kv#*=}"
+  [[ -n "$key" && "$key" != "$kv" ]] || continue
+  RES_ATTRS_JSON=$(printf '%s' "$RES_ATTRS_JSON" | append_attr_json "$key" "$val")
+done
+
 # Emit the OTLP/HTTP payload. Uses `jq -n` with --arg so caller-supplied
 # values can never break the JSON structure.
 PAYLOAD=$(jq -nc \
-  --arg metric     "$METRIC_NAME" \
-  --arg scope      "$SCOPE" \
-  --arg service    "$SERVICE_NAME" \
-  --arg kind       "$KIND" \
-  --arg linear_key "$LINEAR_KEY" \
-  --arg count      "$COUNT" \
-  --arg start_ns   "$START_NS" \
-  --arg now_ns     "$NOW_NS" \
-  --arg phase      "$PHASE" \
+  --arg metric       "$METRIC_NAME" \
+  --arg scope        "$SCOPE" \
+  --argjson res_attrs "$RES_ATTRS_JSON" \
+  --arg kind         "$KIND" \
+  --arg count        "$COUNT" \
+  --arg start_ns     "$START_NS" \
+  --arg now_ns       "$NOW_NS" \
+  --arg phase        "$PHASE" \
   '{
     resourceLogs: null,
     resourceMetrics: [{
       resource: {
-        attributes: [
-          {key: "service.name", value: {stringValue: $service}},
-          (if $linear_key == "" then empty else
-            {key: "linear.key", value: {stringValue: $linear_key}}
-          end)
-        ]
+        attributes: $res_attrs
       },
       scopeMetrics: [{
         scope: {name: $scope},

--- a/plugins/dev/scripts/emit-otel-metric.sh
+++ b/plugins/dev/scripts/emit-otel-metric.sh
@@ -12,7 +12,11 @@
 #     --count <int> \
 #     --linear-key <KEY> \
 #     [--start-ns <unix-ns>] \
-#     [--scope <scope-name>]
+#     [--scope <scope-name>] \
+#     [--resource-attr k=v ...]
+#
+# --resource-attr appends into the OTLP resource attributes array. Integer
+# values (^-?[0-9]+$) are emitted as intValue; all others as stringValue.
 #
 # Emits a single counter data point tagged {kind, linear.key}. The metric
 # aggregation temporality is CUMULATIVE and isMonotonic=true, matching the


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-05T05:15:00Z -->
<!-- Last updated: 2026-06-05T05:15:00Z -->
<!-- PR: #1330 -->
<!-- Previous commits: fcf51b72,5a7af801,8bc2fce4 -->

## Summary

Adds a repeatable `--resource-attr k=v` flag to both `emit-otel-event.sh` and `emit-otel-metric.sh`, allowing callers to attach arbitrary key/value pairs to the OTLP resource attributes block alongside the existing `service.name` and `linear.key` entries. Also introduces type inference for numeric values: integer-looking strings (matching `^-?[0-9]+$`) emit as `intValue` rather than `stringValue`, consistent with how `otel-forward`'s `otlp.ts:10-16` already handles them.

**Why this matters:** The canonical-event OTEL path already supports arbitrary resource attributes; the standalone emitters did not. After this change, metrics and events can be tagged with `project`, `catalyst.orchestration`, `service.namespace`, `service.version`, or any per-worker dimension without bespoke caller logic.

**Backward compatibility:** Omitting `--resource-attr` leaves the resource attributes array byte-identical to the previous output.

## Changes Made

### `plugins/dev/scripts/emit-otel-event.sh` (+35 / -14)

- Replaces the inline `jq` expression that built the resource attributes array with a `step-append` pattern using a new `append_attr_json` shell helper.
- `append_attr_json <key> <value>` applies the shared int-vs-string inference: if `$value` matches `^-?[0-9]+$`, emits `{"key":…,"value":{"intValue":…}}`; otherwise emits `{"key":…,"value":{"stringValue":…}}`.
- Applies the same helper to the existing `--attr` loop, so integer `--attr` values now also emit `intValue` (previously all `--attr` values were forced to `stringValue`).
- Adds the `--resource-attr` argument to the `while` / `case` parser; repeatable, accumulates into `RESOURCE_ATTRS_JSON` via the helper.
- Updates the `Usage:` block to document `--resource-attr k=v`.

### `plugins/dev/scripts/emit-otel-metric.sh` (+46 / -22)

- Same `append_attr_json` helper and step-append refactor for the resource block (previously an inline `jq` expression on lines 95–108).
- Adds the `--resource-attr` argument parser and accumulator.
- Updates the `Contract:` block to document the new flag and int-inference behavior.

### `plugins/dev/scripts/__tests__/emit-otel-event.test.sh` (+139 / -0)

Adds Tests 12–18 covering:

| # | What is tested |
|---|---|
| 12 | `--resource-attr project=catalyst` lands in `resource.attributes` as `stringValue` |
| 13 | Multiple `--resource-attr` repeats all appear in `resource.attributes` |
| 14 | Integer `--resource-attr revive_count=3` emits as `intValue`, no `stringValue` |
| 15 | Integer `--attr attempt=2` now emits as `intValue` via shared helper |
| 16 | Omitting `--resource-attr` yields byte-identical `resource.attributes` array |
| 17 | Malformed `--resource-attr bogus` (no `=`) is silently skipped, exit 0 |
| 18 | `--help` output contains `--resource-attr` |

### `plugins/dev/scripts/__tests__/emit-otel-metric.test.sh` (+255 / -0, new file)

New test suite for `emit-otel-metric.sh` with 16 tests, including:

- Baseline payload shape (metric name, service.name, linear.key)
- `--linear-key` regression guard (still appends after the resource-attr refactor)
- Byte-identical invariant when `--resource-attr` is omitted
- `--resource-attr` string and integer (`intValue`) cases
- No-endpoint no-op and `die_silent` contract

## How to Verify It

- [x] `bash plugins/dev/scripts/__tests__/emit-otel-event.test.sh` — all 33 tests pass (including new 12–18)
- [x] `bash plugins/dev/scripts/__tests__/emit-otel-metric.test.sh` — all 16 tests pass
- [x] Backward-compat assertion: Test 16 (event) and the byte-identical test in the metric suite both pass
- [ ] Manual spot-check: run `emit-otel-event.sh --help` and confirm `--resource-attr` appears in output

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-762
