### PR TITLE
fix(dev): CTL-731 residual — default eligibleQuery to Todo + Release-As 11.0.0

### DIFF
--- a/plugins/dev/scripts/execution-core/registry.mjs
+++ b/plugins/dev/scripts/execution-core/registry.mjs
@@ -64,12 +64,13 @@ export function getProjectConfig(team) {
 // monitor + linear-query layer needs. The entry's `team` lives at the top level
 // (the eligibleQuery object never carries it); this is the single place it is
 // merged in and the per-field defaults are applied. `status` defaults to the
-// execution-core contract state "Ready"; `triageStatus` to "Triage" (CTL-565).
+// start state "Todo" (CTL-731: "Ready" was removed from Linear 2026-06-02, so
+// the old "Ready" default was a latent trap); `triageStatus` to "Triage" (CTL-565).
 export function resolveEligibleQuery(entry) {
   const eq = entry?.eligibleQuery ?? {};
   return {
     team: entry?.team ?? null,
-    status: eq.status ?? "Ready",
+    status: eq.status ?? "Todo",
     triageStatus: eq.triageStatus ?? "Triage",
     project: eq.project ?? null,
     label: eq.label ?? null,

--- a/plugins/dev/scripts/execution-core/registry.test.mjs
+++ b/plugins/dev/scripts/execution-core/registry.test.mjs
@@ -187,7 +187,7 @@ describe("resolveEligibleQuery", () => {
   test("merges the entry's team and applies defaults for an absent eligibleQuery", () => {
     expect(resolveEligibleQuery({ team: "CTL", repoRoot: "/r" })).toEqual({
       team: "CTL",
-      status: "Ready",
+      status: "Todo",
       triageStatus: "Triage",
       project: null,
       label: null,
@@ -201,8 +201,8 @@ describe("resolveEligibleQuery", () => {
     expect(q.status).toBe("Ready");
   });
 
-  test("status defaults to Ready (the execution-core contract state) when absent", () => {
-    expect(resolveEligibleQuery({ team: "CTL", eligibleQuery: {} }).status).toBe("Ready");
+  test("status defaults to Todo (the start state; Ready removed 2026-06-02) when absent", () => {
+    expect(resolveEligibleQuery({ team: "CTL", eligibleQuery: {} }).status).toBe("Todo");
   });
 
   test("triageStatus defaults to Triage but an explicit value is preserved", () => {
@@ -230,7 +230,7 @@ describe("resolveEligibleQuery", () => {
   test("a non-object eligibleQuery (hand-edited registry) degrades to defaults", () => {
     expect(resolveEligibleQuery({ team: "CTL", eligibleQuery: "garbage" })).toEqual({
       team: "CTL",
-      status: "Ready",
+      status: "Todo",
       triageStatus: "Triage",
       project: null,
       label: null,


### PR DESCRIPTION
Last unshipped slice of **CTL-731** + the **release trigger for 11.0.0**.

**The fix:** `resolveEligibleQuery` (registry.mjs) defaulted `status` to `"Ready"`, but Ready was removed from Linear 2026-06-02 — `Todo` is the start state. The old default was a latent trap (benign today only because the CTL eligibleQuery sets status explicitly). Updated the default + the 3 default-asserting tests. registry 26/26, daemon 61/61, monitor 102/102 (individually; the combined-run flake is the known pre-existing fs.watch cross-suite issue).

**Why CTL-731 is otherwise done:** re-scope confirmed the dispatch storm is fully handled on main — Phase 00/0 de-starvation (#1225/#1226) + monitor-owned triage + CTL-755 admission gate + CTL-671 guards. Phases 1-3 (triage-as-entry-phase) were *superseded* by the research-entry + monitor-triage architecture. This registry default was the only residual.

**`Release-As: 11.0.0`** in the commit footer forces release-please to cut catalyst-dev at **11.0.0** (major), reflecting the CTL-726 catalyst-legacy skill relocation (user-facing breaking change). Auto-clears after this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)