### PR TITLE
chore(dev): force catalyst-dev 11.0.0 release (CTL-726 breaking change)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
   "packages": {
     "plugins/dev": {
       "release-type": "simple",
+      "release-as": "11.0.0",
       "component": "catalyst-dev",
       "package-name": "catalyst-dev",
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
Pins `release-as: 11.0.0` for catalyst-dev in release-please-config.json so the pending release PR (#1312) cuts **11.0.0** instead of the auto-computed 10.7.0. The CTL-726 catalyst-legacy skill relocation is a user-facing breaking change.

(The `Release-As` commit-footer attempt on #1331 was mangled by the squash-merge into markdown prose, so release-please didn't recognize it — hence this explicit config pin. **Will be removed in a follow-up PR** once #1312 cuts 11.0.0, so future releases compute normally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)