### PR TITLE
chore(dev): remove release-as 11.0.0 override (post-release cleanup)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
   "packages": {
     "plugins/dev": {
       "release-type": "simple",
-      "release-as": "11.0.0",
       "component": "catalyst-dev",
       "package-name": "catalyst-dev",
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
Removes the `release-as: 11.0.0` pin added to force the CTL-726 breaking release. **catalyst-dev-v11.0.0 is now cut**, so future releases must compute from the 11.0.0 base normally (leaving the pin would make release-please re-propose 11.0.0 and fail on the existing tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)