### PR TITLE
feat(dev): portable daemon env / proxy-audit template + prerequisite checks

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -307,6 +307,77 @@ active.
 
 ---
 
+## Execution-core Daemon Env (`~/.config/catalyst/execution-core.env`)
+
+**Template:** [`plugins/dev/templates/execution-core.env.example`](../plugins/dev/templates/execution-core.env.example)
+
+### Purpose
+
+A **machine-local, never-committed** shell env file that the execution-core daemon sources on
+start. `catalyst-execution-core start` runs `[[ -f "$file" ]] && source "$file"` immediately before
+it launches the daemon, so every variable the file exports is inherited by the daemon process and
+by every phase-agent bg job it dispatches. `restart` re-sources it (it calls `stop` then `start`),
+so edits take effect on the next restart — **not** live.
+
+The path defaults to `~/.config/catalyst/execution-core.env` and can be overridden with the
+`CATALYST_EXECUTION_CORE_ENV` environment variable. This file is **entirely opt-in**: an absent file
+is a complete no-op, which is the common case. Because the values are machine-specific (proxy port,
+local CA path), setup never writes it for you — copy the committed example template and edit it by
+hand.
+
+### Options
+
+| Variable | Purpose |
+|----------|---------|
+| `HTTPS_PROXY` / `HTTP_PROXY` | Route the daemon's outbound Linear/GitHub HTTP(S) traffic through a local proxy (e.g. `http://127.0.0.1:8080`). |
+| `NODE_USE_ENV_PROXY` | Set to `1` to make Node's native `fetch`/undici honor the `*_PROXY` vars. **Required whenever you set a proxy** — see rationale below. |
+| `NODE_EXTRA_CA_CERTS` | Absolute path to a CA cert to trust (e.g. `$HOME/.mitmproxy/mitmproxy-ca-cert.pem`) so a MITM proxy's intercepted TLS validates. |
+| `LINEAR_STATE_CACHE_TTL_MS` | Widen the daemon's in-process Linear workflow-state cache window (milliseconds) to cut per-ticket read volume. Independent of the proxy. |
+
+### Proxy audit (opt-in)
+
+The daemon's Linear/GitHub calls go out over Node's native fetch. To observe or record them, run a
+local [mitmproxy](https://mitmproxy.org/) and point the daemon at it:
+
+```bash
+# 1. Start the proxy (its CA is created on first run at ~/.mitmproxy/mitmproxy-ca-cert.pem)
+mitmdump -s "$HOME/catalyst/mitm_linear_addon.py" --listen-port 8080
+
+# 2. In ~/.config/catalyst/execution-core.env:
+export NODE_USE_ENV_PROXY=1
+export HTTPS_PROXY=http://127.0.0.1:8080
+export HTTP_PROXY=http://127.0.0.1:8080
+export NODE_EXTRA_CA_CERTS=$HOME/.mitmproxy/mitmproxy-ca-cert.pem
+
+# 3. Apply it
+catalyst-execution-core restart
+```
+
+**Why `NODE_USE_ENV_PROXY=1` is required.** Node 20+/24+ native `fetch` (undici) **ignores**
+`HTTPS_PROXY`/`HTTP_PROXY` unless `NODE_USE_ENV_PROXY=1` is also set. Omit it and the daemon's
+Linear calls bypass the proxy entirely while looking perfectly healthy — the audit silently captures
+nothing.
+
+### Health check
+
+A misconfigured proxy silently breaks the daemon's Linear connectivity on a fresh or changed
+machine, which is otherwise hard to debug. `check-setup.sh` (and `/catalyst-dev:setup-catalyst`)
+therefore verify the setup whenever the env file configures a proxy, and warn loudly + actionably on
+each failure mode:
+
+- the proxy host:port is **not listening** → start `mitmdump` or unset the proxy vars;
+- `NODE_EXTRA_CA_CERTS` points at a **missing file** → fix the path or re-run mitmproxy to
+  regenerate its CA;
+- `*_PROXY` is set but `NODE_USE_ENV_PROXY=1` is **missing** → Node fetch will ignore the proxy and
+  calls bypass the audit silently.
+
+When no env file exists (or it sets no proxy) the check is a no-op and reports nothing but an
+informational pointer to the example template. `check-project-setup.sh` (the hot-path workflow gate)
+carries only the highest-impact `NODE_USE_ENV_PROXY` silent-bypass warning; the full port/CA
+diagnostics live in `check-setup.sh`.
+
+---
+
 ## Registry (`~/catalyst/execution-core/registry.json`)
 
 **Schema:** [`docs/schemas/registry.schema.json`](./schemas/registry.schema.json)

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -323,6 +323,34 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# 4c. Execution-core daemon env proxy sanity (CTL proxy-audit automation).
+#     The daemon sources a machine-local env file on start (catalyst-execution-core
+#     cmd_start). It is OPT-IN; an absent file is a no-op and the common case. The
+#     ONE silent-failure we surface in this hot path is: a proxy is configured but
+#     NODE_USE_ENV_PROXY=1 is missing — Node fetch then IGNORES the proxy, so the
+#     daemon's Linear/gh calls bypass the audit with nothing visibly broken. Full
+#     port/CA diagnostics live in check-setup.sh; here we keep it cheap (read the
+#     file in a subshell, no network) and warn only.
+DAEMON_ENV_FILE="${CATALYST_EXECUTION_CORE_ENV:-$CATALYST_CONFIG/execution-core.env}"
+if [[ -f "$DAEMON_ENV_FILE" ]]; then
+	daemon_env_vals=$(
+		set +euo pipefail
+		set -a
+		# shellcheck disable=SC1090
+		. "$DAEMON_ENV_FILE" 2>/dev/null
+		set +a
+		printf 'PROXY=%s\nUSE_ENV_PROXY=%s\n' \
+			"${HTTPS_PROXY:-${HTTP_PROXY:-}}" "${NODE_USE_ENV_PROXY:-}"
+	)
+	de_proxy=$(printf '%s\n' "$daemon_env_vals" | sed -n 's/^PROXY=//p')
+	de_use_env_proxy=$(printf '%s\n' "$daemon_env_vals" | sed -n 's/^USE_ENV_PROXY=//p')
+	if [[ -n $de_proxy && $de_use_env_proxy != "1" ]]; then
+		warnings+=("Proxy vars set in $DAEMON_ENV_FILE but NODE_USE_ENV_PROXY=1 missing — Node fetch IGNORES the proxy (daemon Linear/gh calls bypass the audit silently)")
+		warnings+=("  Add to $DAEMON_ENV_FILE: export NODE_USE_ENV_PROXY=1 — then: catalyst-execution-core restart")
+		warnings+=("  Full proxy health (port listening, CA cert): bash plugins/dev/scripts/check-setup.sh")
+	fi
+fi
+
 # 5. Check orch-monitor daemon liveness
 #    Event-driven skills (orchestrate Phase 4, oneshot Phase 5, merge-pr Phase 6) depend on
 #    the daemon to surface webhook events. Without it, catalyst-events wait-for falls back

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -465,6 +465,114 @@ else
     fi
 fi
 
+# ─── 7c. Execution-core Daemon Env / Proxy Audit (optional) ────────────────
+
+header "Execution-core Daemon Env / Proxy Audit (optional)"
+
+# The execution-core daemon sources a machine-local env file on `start`/`restart`
+# (catalyst-execution-core cmd_start). It is OPT-IN: an absent file is a no-op,
+# and is the common case. When it IS present and configures a proxy (routing the
+# daemon's Linear/gh fetch traffic through a local mitmproxy audit), a broken
+# proxy silently breaks the daemon's Linear connectivity on a fresh/changed
+# machine — hard to debug. So: surface the file, and when a proxy is configured,
+# verify it actually works.
+DAEMON_ENV_FILE="${CATALYST_EXECUTION_CORE_ENV:-$CATALYST_CONFIG/execution-core.env}"
+DAEMON_ENV_EXAMPLE="plugins/dev/templates/execution-core.env.example"
+if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -f "${CLAUDE_PLUGIN_ROOT}/templates/execution-core.env.example" ]]; then
+    DAEMON_ENV_EXAMPLE="${CLAUDE_PLUGIN_ROOT}/templates/execution-core.env.example"
+fi
+
+if [[ ! -f "$DAEMON_ENV_FILE" ]]; then
+    # Absent file = intended default; not a problem. Surface it for discoverability.
+    info "No daemon env at $DAEMON_ENV_FILE (optional) — used for proxy/CA tuning"
+    info "To enable: copy $DAEMON_ENV_EXAMPLE there, uncomment what you need, then catalyst-execution-core restart"
+else
+    pass "Daemon env present: $DAEMON_ENV_FILE"
+
+    # Read the file's exports in an isolated subshell so we don't pollute this
+    # script's own environment, then pipe the values back as a single line.
+    # (set -a exports everything the file assigns; the subshell is discarded.)
+    daemon_env_vals=$(
+        set +euo pipefail
+        set -a
+        # shellcheck disable=SC1090
+        . "$DAEMON_ENV_FILE" 2>/dev/null
+        set +a
+        printf 'HTTPS_PROXY=%s\nHTTP_PROXY=%s\nNODE_USE_ENV_PROXY=%s\nNODE_EXTRA_CA_CERTS=%s\n' \
+            "${HTTPS_PROXY:-}" "${HTTP_PROXY:-}" "${NODE_USE_ENV_PROXY:-}" "${NODE_EXTRA_CA_CERTS:-}"
+    )
+    de_https_proxy=$(printf '%s\n' "$daemon_env_vals" | sed -n 's/^HTTPS_PROXY=//p')
+    de_http_proxy=$(printf '%s\n' "$daemon_env_vals" | sed -n 's/^HTTP_PROXY=//p')
+    de_use_env_proxy=$(printf '%s\n' "$daemon_env_vals" | sed -n 's/^NODE_USE_ENV_PROXY=//p')
+    de_ca_certs=$(printf '%s\n' "$daemon_env_vals" | sed -n 's/^NODE_EXTRA_CA_CERTS=//p')
+
+    de_proxy="$de_https_proxy"
+    [[ -z "$de_proxy" ]] && de_proxy="$de_http_proxy"
+
+    if [[ -z "$de_proxy" ]]; then
+        # File exists but configures no proxy — nothing to verify. Still report the
+        # CA-cert path if one is set on its own (rare, but check it anyway).
+        info "No proxy configured in $DAEMON_ENV_FILE — skipping proxy health check"
+        if [[ -n "$de_ca_certs" && ! -f "$de_ca_certs" ]]; then
+            warn "NODE_EXTRA_CA_CERTS in $DAEMON_ENV_FILE points at a missing file: $de_ca_certs"
+            info "Fix the path or re-run mitmproxy to regenerate its CA at \$HOME/.mitmproxy/mitmproxy-ca-cert.pem"
+        fi
+    else
+        # Parse host:port from the proxy URL with pure parameter expansion:
+        # strip scheme, strip optional userinfo, strip any path/query.
+        de_hostport="${de_proxy#*://}"   # drop scheme://
+        de_hostport="${de_hostport##*@}" # drop user:pass@
+        de_hostport="${de_hostport%%/*}" # drop /path
+        de_proxy_host="${de_hostport%:*}"
+        de_proxy_port="${de_hostport##*:}"
+        [[ "$de_proxy_host" == "$de_hostport" ]] && de_proxy_host="127.0.0.1" # no colon → default host
+        [[ "$de_proxy_port" == "$de_hostport" ]] && de_proxy_port="" # no colon → no port
+
+        # (a) Is the proxy port actually listening? Probe with bash /dev/tcp (same
+        #     idiom as the OTel/monitor checks above); fall back to `nc -z` if a
+        #     port couldn't be parsed or /dev/tcp is unavailable.
+        if [[ -z "$de_proxy_port" ]]; then
+            warn "Could not parse a port from proxy '$de_proxy' in $DAEMON_ENV_FILE — cannot probe liveness"
+        else
+            proxy_listening=""
+            if (echo >/dev/tcp/"$de_proxy_host"/"$de_proxy_port") 2>/dev/null; then
+                proxy_listening="yes"
+            elif command -v nc &>/dev/null && nc -z -w 1 "$de_proxy_host" "$de_proxy_port" 2>/dev/null; then
+                proxy_listening="yes"
+            fi
+            if [[ -n "$proxy_listening" ]]; then
+                pass "Proxy reachable ($de_proxy_host:$de_proxy_port)"
+            else
+                warn "Daemon is set to route Linear/gh through $de_proxy_host:$de_proxy_port but nothing is LISTENING there"
+                info "Start the proxy: mitmdump -s \"\$HOME/catalyst/mitm_linear_addon.py\" --listen-port $de_proxy_port"
+                info "…or unset HTTPS_PROXY/HTTP_PROXY in $DAEMON_ENV_FILE to go direct"
+            fi
+        fi
+
+        # (b) NODE_EXTRA_CA_CERTS must point at an existing file or MITM'd Linear
+        #     TLS will fail cert validation.
+        if [[ -z "$de_ca_certs" ]]; then
+            warn "Proxy is set in $DAEMON_ENV_FILE but NODE_EXTRA_CA_CERTS is not — MITM'd Linear TLS will fail cert validation"
+            info "Add: export NODE_EXTRA_CA_CERTS=\$HOME/.mitmproxy/mitmproxy-ca-cert.pem"
+        elif [[ ! -f "$de_ca_certs" ]]; then
+            warn "MITM CA cert not found at $de_ca_certs — Linear TLS will fail"
+            info "Fix the path in $DAEMON_ENV_FILE, or re-run mitmproxy to regenerate its CA"
+        else
+            pass "MITM CA cert present ($de_ca_certs)"
+        fi
+
+        # (c) *_PROXY set but NODE_USE_ENV_PROXY unset → Node fetch SILENTLY ignores
+        #     the proxy. This is the highest-value catch: calls bypass the audit and
+        #     nothing visibly breaks.
+        if [[ "$de_use_env_proxy" != "1" ]]; then
+            warn "Proxy vars are set but NODE_USE_ENV_PROXY=1 is missing from $DAEMON_ENV_FILE — Node fetch will IGNORE the proxy (Linear calls bypass the audit silently)"
+            info "Add: export NODE_USE_ENV_PROXY=1"
+        else
+            pass "NODE_USE_ENV_PROXY=1 (Node fetch will honor the proxy)"
+        fi
+    fi
+fi
+
 # ─── 8. direnv ──────────────────────────────────────────────────────────────
 
 header "direnv"

--- a/plugins/dev/skills/setup-catalyst/SKILL.md
+++ b/plugins/dev/skills/setup-catalyst/SKILL.md
@@ -146,6 +146,31 @@ read; a missing per-project token is a silent skip. Separately, Linear's
 API surface and **cannot** be reconciled — it must be turned OFF by hand, or it
 races the daemon and re-introduces the CTL-758 backward state-write.
 
+**Execution-core daemon env / proxy audit (machine-local, opt-in).**
+`catalyst-execution-core start` sources a machine-local env file —
+`~/.config/catalyst/execution-core.env` (override with `CATALYST_EXECUTION_CORE_ENV`)
+— right before it launches the daemon, so every var it exports is inherited by the
+daemon and every phase-agent bg job. An **absent file is a complete no-op** and is
+the common case; this is **not** auto-fixable because the values (proxy port, MITM
+CA path) are machine-specific. The committed template
+`plugins/dev/templates/execution-core.env.example` documents every option. The two
+uses are (1) routing the daemon's Linear/gh fetch traffic through a local mitmproxy
+audit and (2) widening the Linear state-cache TTL (`LINEAR_STATE_CACHE_TTL_MS`).
+
+The risk this guards against: a proxy that is configured but quietly broken silently
+kills the daemon's Linear connectivity on a fresh or changed machine, with nothing
+obvious to debug. So when the env file sets a proxy, `check-setup.sh` verifies it and
+warns **loudly + actionably** on each failure mode — (a) the proxy port is not
+listening, (b) `NODE_EXTRA_CA_CERTS` points at a missing file, or (c) `NODE_USE_ENV_PROXY=1`
+is missing. The `NODE_USE_ENV_PROXY` flag matters because Node 20+/24+ native fetch
+(undici) **ignores** `HTTPS_PROXY`/`HTTP_PROXY` without it — so the daemon's calls
+would bypass the audit entirely while looking perfectly healthy. `check-project-setup.sh`
+(the hot-path gate) carries only that one silent-bypass warning; full port/CA
+diagnostics live in `check-setup.sh`. Treat any of these as **needs-user-input** — relay
+the specific warning and fix, never write a machine path on the user's behalf, and
+remind them to `catalyst-execution-core restart` after editing (the daemon re-sources
+the file only on start/restart).
+
 For issues needing user input, explain what's needed and how to provide it:
 
 | Issue | What to tell the user |
@@ -156,6 +181,8 @@ For issues needing user input, explain what's needed and how to provide it:
 | Linear "magic words" auto-move ON | Tell the user to turn it OFF in Settings → Team → Workflow → Git — it races the execution-core daemon and causes backward state writes (CTL-758). No API surface; must be toggled by hand. |
 | Linear `review` git automation set | Run `setup-execution-core-states.sh` to remove it; the pipeline owns the Validate/review state, not Linear. |
 | Personal git automations override team ones | Remind the user that Linear lets each member set *personal* git automations that shadow the team defaults — check Settings → Account → Git if drift persists after the team reconcile. |
+| Proxy audit / daemon env wanted | Copy `plugins/dev/templates/execution-core.env.example` to `~/.config/catalyst/execution-core.env`, uncomment the vars you need (proxy + CA + `NODE_USE_ENV_PROXY=1`, and/or `LINEAR_STATE_CACHE_TTL_MS`), then `catalyst-execution-core restart`. **Needs user input, not auto-fix** — the proxy port and CA path are machine-specific. Never write machine paths for the user. |
+| Daemon env proxy configured but broken | The check reports the exact failure: port not listening (start `mitmdump … --listen-port <port>` or unset the proxy), `NODE_EXTRA_CA_CERTS` missing (fix the path / re-run mitmproxy to regenerate its CA), or `NODE_USE_ENV_PROXY=1` missing (add it — without it Node fetch silently bypasses the audit). Relay the specific warning + fix; restart the daemon after. |
 
 **Observability (OTel) is optional.** If Docker or OTel containers aren't found, note it as
 informational — don't treat it as an issue. Point the user to

--- a/plugins/dev/templates/execution-core.env.example
+++ b/plugins/dev/templates/execution-core.env.example
@@ -1,0 +1,45 @@
+# Catalyst execution-core daemon env (EXAMPLE / TEMPLATE)
+#
+# Copy to ~/.config/catalyst/execution-core.env and uncomment the lines you need.
+# (Override the path with CATALYST_EXECUTION_CORE_ENV if you keep it elsewhere.)
+#
+# This file is MACHINE-LOCAL and is NEVER committed. The committed copy you are
+# reading (execution-core.env.example) is the template only — it sets nothing.
+#
+# `catalyst-execution-core start` sources the real file (if present) right before
+# it launches the daemon, so every var below is inherited by the daemon process
+# and by every phase-agent bg job it dispatches. An ABSENT file is a complete
+# no-op — nothing here is required. Re-source on each `catalyst-execution-core
+# restart`. Validate your setup any time with `check-setup.sh` (it warns loudly
+# if the proxy is configured but broken).
+#
+# ─── Optional: route daemon Linear/gh traffic through a local mitmproxy audit ──
+#
+# The daemon's Linear/GitHub calls go out over Node's native fetch (undici). To
+# observe/record them, run a local mitmproxy and point the daemon at it. This is
+# OPT-IN — leave it all commented out to keep direct connections.
+#
+#   Start the proxy first, e.g.:
+#     mitmdump -s "$HOME/catalyst/mitm_linear_addon.py" --listen-port 8080
+#   (the addon logs to ~/catalyst/linear-proxy.jsonl; mitmproxy's CA is created
+#    on first run at ~/.mitmproxy/mitmproxy-ca-cert.pem)
+#
+# 1. Tell Node's fetch/undici to honor the *_PROXY vars. REQUIRED whenever you
+#    set a proxy below — Node 20+/24+ IGNORES *_PROXY without it, so the daemon
+#    would silently bypass the audit and you'd never know.
+# export NODE_USE_ENV_PROXY=1
+#
+# 2. Point HTTP(S) traffic at the local proxy. Match the --listen-port above.
+# export HTTPS_PROXY=http://127.0.0.1:8080
+# export HTTP_PROXY=http://127.0.0.1:8080
+#
+# 3. Trust the proxy's MITM TLS cert so the intercepted Linear HTTPS doesn't fail
+#    cert validation. Use YOUR home path — do not hardcode another machine's.
+# export NODE_EXTRA_CA_CERTS=$HOME/.mitmproxy/mitmproxy-ca-cert.pem
+#
+# ─── Optional: tune the in-process Linear state-cache TTL ──────────────────────
+#
+# Widen the daemon's Linear workflow-state cache window (milliseconds) to cut
+# per-ticket read volume. Default is the daemon's built-in TTL; raise it to make
+# the daemon re-read Linear states less often. Unrelated to the proxy.
+# export LINEAR_STATE_CACHE_TTL_MS=180000


### PR DESCRIPTION
Makes the machine-local daemon env / proxy-audit setup (runtime sourcing landed in #1341) **discoverable and self-diagnosing**, so it can't become a silent "works on my machine" trap.

**Adds (all opt-in; complete no-op when no env file / no proxy is configured):**
- **`execution-core.env.example`** — committed template, `$HOME` placeholders, documents every option.
- **`check-setup.sh` health check** — when a proxy IS configured, warns **loudly + actionably** on each failure mode, naming the file + fix: port not listening · CA file missing · `NODE_USE_ENV_PROXY` missing (the silent-bypass that Node fetch ignores `*_PROXY` without).
- **`check-project-setup.sh`** hot-path guard for the silent-bypass case.
- **docs + setup-catalyst skill** — the env file, the opt-in mitmproxy workflow, the `NODE_USE_ENV_PROXY` rationale.

**Verified** (all four states): absent/no-proxy → silent · broken → 3 clear warnings · healthy → silent · `bash -n` + shellcheck clean · **no committed machine paths**. Review verdict: ship, 0 must-fix.

Follow-up (pre-existing, not in this diff): `docs/configuration.md:401` has a hardcoded `/Users/ryan` path from an earlier commit — worth fixing separately given the machine-path-hygiene goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)