### PR TITLE
feat(dev): read Linear bot creds + self-echo botUserIds from global config.linear.bot.{worker,orchestrator} (back-compat)

### DIFF
--- a/plugins/dev/scripts/__tests__/linear-comment-post.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-comment-post.test.sh
@@ -160,6 +160,47 @@ assert_exit_nonzero \
   "exits non-zero when no creds and no config file" \
   bash -c "cd /tmp && bash '$HELPER' CTL-550 body"
 
+# Reinstate the success curl stub for the file-resolution back-compat tests.
+cat >"${BIN_DIR}/curl" <<'CURLEOF'
+#!/usr/bin/env bash
+ARGS_STR="$*"
+if printf '%s' "$ARGS_STR" | grep -q "oauth/token"; then
+  printf '{"access_token":"test_token","token_type":"Bearer"}'
+elif printf '%s' "$ARGS_STR" | grep -q "commentCreate"; then
+  printf '{"data":{"commentCreate":{"success":true}}}'
+else
+  printf '{"data":{"issues":{"nodes":[{"id":"issue-uuid-123"}]}}}'
+fi
+exit 0
+CURLEOF
+chmod +x "${BIN_DIR}/curl"
+
+# Test 9 (CTL-749 back-compat): NEW global path
+# ~/.config/catalyst/config.json → catalyst.linear.bot.worker.{clientId,clientSecret}.
+# No env creds, no per-team file — must resolve from the global bot.worker key.
+NEW_HOME="${TMPDIR_TEST}/home-new"
+mkdir -p "${NEW_HOME}/.config/catalyst" "${NEW_HOME}/work"
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":{"clientId":"new-cid","clientSecret":"new-csec"}}}}}' \
+  >"${NEW_HOME}/.config/catalyst/config.json"
+PATH="${BIN_DIR}:$PATH" assert_exit_zero \
+  "resolves NEW global catalyst.linear.bot.worker.{clientId,clientSecret}" \
+  env HOME="${NEW_HOME}" bash -c "cd '${NEW_HOME}/work' && bash '$HELPER' CTL-550 body"
+
+# Test 10 (CTL-749 back-compat): OLD per-team fallback
+# config-<key>.json → catalyst.linear.agent.* resolved via nested .catalyst.projectKey,
+# with the global config carrying only the orchestrator placeholder (no bot.worker).
+OLD_HOME="${TMPDIR_TEST}/home-old"
+mkdir -p "${OLD_HOME}/.config/catalyst" "${OLD_HOME}/repo/.catalyst"
+printf '%s' '{"catalyst":{"linear":{"bot":{"orchestrator":{"clientId":"orch-only"}}}}}' \
+  >"${OLD_HOME}/.config/catalyst/config.json"
+printf '%s' '{"catalyst":{"linear":{"agent":{"clientId":"old-cid","clientSecret":"old-csec"}}}}' \
+  >"${OLD_HOME}/.config/catalyst/config-catalyst-workspace.json"
+printf '%s' '{"catalyst":{"projectKey":"catalyst-workspace"}}' \
+  >"${OLD_HOME}/repo/.catalyst/config.json"
+PATH="${BIN_DIR}:$PATH" assert_exit_zero \
+  "falls back to OLD per-team catalyst.linear.agent.* via nested projectKey" \
+  env HOME="${OLD_HOME}" bash -c "cd '${OLD_HOME}/repo' && bash '$HELPER' CTL-550 body"
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [[ "$FAIL" -eq 0 ]]

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -302,15 +302,17 @@ if [[ -n $CONFIG_PATH ]]; then
 		fi
 	fi
 
-	# CTL-749: botUserId is the Linear app-actor user UUID — read from the project's
-	# Layer-1 config ($CONFIG_PATH), the SAME place the execution-core daemon
-	# (daemon.mjs readLinearBotUserId) and orch-monitor's webhook handler read it.
-	# Without it, execution-core comms can't filter the agent's own mirror
-	# comments/updates and treats them as human input (false "human replied" signal).
+	# CTL-749: bot user IDs — daemon now reads a SET from two sources:
+	#   NEW: ~/.config/catalyst/config.json  catalyst.linear.bot.{worker,orchestrator}.botUserId
+	#   OLD: .catalyst/config.json           catalyst.monitor.linear.botUserId (Layer-1, back-compat)
+	_GLOBAL_CFG="$HOME/.config/catalyst/config.json"
+	BOT_WORKER_ID=$(jq -r '.catalyst.linear.bot.worker.botUserId // empty' "$_GLOBAL_CFG" 2>/dev/null)
+	BOT_ORCH_ID=$(jq -r '.catalyst.linear.bot.orchestrator.botUserId // empty' "$_GLOBAL_CFG" 2>/dev/null)
 	BOT_USER_ID=$(jq -r '.catalyst.monitor.linear.botUserId // empty' "$CONFIG_PATH" 2>/dev/null)
-	if [[ -z $BOT_USER_ID ]]; then
-		warnings+=("Missing catalyst.monitor.linear.botUserId in $CONFIG_PATH — execution-core comms won't filter bot self-echo (the agent's own Linear comments look like human replies)")
-		warnings+=("  Set it: query the Catalyst app-actor viewer.id (app token from ~/.config/catalyst/config-<projectKey>.json catalyst.linear.agent.accessToken) and write catalyst.monitor.linear.botUserId; see /catalyst-dev:setup-catalyst")
+	if [[ -z $BOT_WORKER_ID && -z $BOT_ORCH_ID && -z $BOT_USER_ID ]]; then
+		warnings+=("No Linear bot user IDs configured — execution-core comms won't filter bot self-echo (the agent's own Linear comments look like human replies)")
+		warnings+=("  NEW: set catalyst.linear.bot.worker.botUserId in ~/.config/catalyst/config.json")
+		warnings+=("  OLD fallback: set catalyst.monitor.linear.botUserId in $CONFIG_PATH; see /catalyst-dev:setup-catalyst")
 	fi
 
 	# Warn if config is still only in .claude/ (deprecated location)

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -318,17 +318,26 @@ warn "Linear 'magic words' auto-move must be OFF (Settings → Team → Workflow
 info "It races the execution-core daemon (CTL-758 backward-write). Disable it in the Linear UI."
 info "Git-automation state moves (start→PR, merge→Done) are reconciled by setup-execution-core-states.sh."
 
-# botUserId (CTL-749) is the Linear app-actor user UUID. It is read from the
-# project's Layer-1 .catalyst/config.json ($CONFIG_PATH) — the SAME place the
-# execution-core daemon and orch-monitor read it — NOT the Layer-2 home config.
+# botUserId (CTL-749) — the execution-core daemon now reads a SET from two sources:
+#   NEW: ~/.config/catalyst/config.json  catalyst.linear.bot.{worker,orchestrator}.botUserId
+#   OLD: .catalyst/config.json           catalyst.monitor.linear.botUserId (back-compat)
+# Check both; pass if either is set.
+_GLOBAL_WORKER_BOT=$(jq -r '.catalyst.linear.bot.worker.botUserId // empty' "${CATALYST_CONFIG}/config.json" 2>/dev/null)
+_GLOBAL_ORCH_BOT=$(jq -r '.catalyst.linear.bot.orchestrator.botUserId // empty' "${CATALYST_CONFIG}/config.json" 2>/dev/null)
+_LAYER1_BOT=""
 if [[ -n "$CONFIG_PATH" && -f "$CONFIG_PATH" ]]; then
-    bot_id=$(jq -r '.catalyst.monitor.linear.botUserId // empty' "$CONFIG_PATH" 2>/dev/null)
-    if [[ -z "$bot_id" ]]; then
-        warn "catalyst.monitor.linear.botUserId missing in $CONFIG_PATH — execution-core comms won't filter bot self-echo (the agent's own Linear comments look like human replies)"
-        info "Set it: query the Catalyst app-actor viewer.id (app token in ~/.config/catalyst/config-\${projectKey}.json → catalyst.linear.agent.accessToken) and write catalyst.monitor.linear.botUserId; see /catalyst-dev:setup-catalyst"
-    else
-        pass "Linear app-actor identity: ${bot_id:0:8}…"
-    fi
+    _LAYER1_BOT=$(jq -r '.catalyst.monitor.linear.botUserId // empty' "$CONFIG_PATH" 2>/dev/null)
+fi
+if [[ -n "$_GLOBAL_WORKER_BOT" || -n "$_GLOBAL_ORCH_BOT" || -n "$_LAYER1_BOT" ]]; then
+    _bot_ids=""
+    [[ -n "$_GLOBAL_WORKER_BOT" ]] && _bot_ids="${_GLOBAL_WORKER_BOT:0:8}… (worker)"
+    [[ -n "$_GLOBAL_ORCH_BOT" ]] && _bot_ids="${_bot_ids:+$_bot_ids, }${_GLOBAL_ORCH_BOT:0:8}… (orchestrator)"
+    [[ -n "$_LAYER1_BOT" ]] && _bot_ids="${_bot_ids:+$_bot_ids, }${_LAYER1_BOT:0:8}… (layer-1 legacy)"
+    pass "Linear app-actor identity: $_bot_ids"
+else
+    warn "No Linear bot user IDs configured — execution-core comms won't filter bot self-echo"
+    info "NEW: set catalyst.linear.bot.worker.botUserId in ~/.config/catalyst/config.json"
+    info "OLD fallback: set catalyst.monitor.linear.botUserId in .catalyst/config.json; see /catalyst-dev:setup-catalyst"
 fi
 
 # ─── 7. OTel Observability Stack (optional) ────────────────────────────────

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -106,29 +106,55 @@ let _eventLogCursor = 0;
 // half-written line at read time) is parsed exactly once, never truncated.
 let _eventLogLeftover = "";
 
-// readLinearBotUserId — read catalyst.monitor.linear.botUserId from Layer 1
-// config (.catalyst/config.json). Returns "" when absent/unreadable so callers
-// can treat it as "no filter". Never throws. CTL-749.
-function readLinearBotUserId(configPath) {
-  if (!configPath) return "";
-  try {
-    const parsed = JSON.parse(readFileSync(configPath, "utf8"));
-    const uid = parsed?.catalyst?.monitor?.linear?.botUserId;
-    return typeof uid === "string" && uid.length > 0 ? uid : "";
-  } catch {
-    return "";
+// readLinearBotUserIds — collect all known Linear bot user UUIDs from both
+// config layers so the self-echo guard covers every app-actor identity:
+//   1. NEW:  ~/.config/catalyst/config.json  catalyst.linear.bot.worker.botUserId
+//   2. NEW:  ~/.config/catalyst/config.json  catalyst.linear.bot.orchestrator.botUserId
+//   3. OLD:  .catalyst/config.json           catalyst.monitor.linear.botUserId  (Layer-1)
+// Returns a Set<string>. Empty set = no filter (fail-open). Never throws. CTL-749.
+export function readLinearBotUserIds(layer1Path, layer2Path) {
+  const ids = new Set();
+  function addFromPath(path, extractor) {
+    if (!path) return;
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf8"));
+      extractor(parsed, ids);
+    } catch { /* ignore unreadable / malformed files */ }
   }
+  // NEW global path: both worker and orchestrator bot identities (Layer 2).
+  addFromPath(layer2Path, (p, s) => {
+    const bot = p?.catalyst?.linear?.bot;
+    if (typeof bot?.worker?.botUserId === "string" && bot.worker.botUserId.length > 0)
+      s.add(bot.worker.botUserId);
+    if (typeof bot?.orchestrator?.botUserId === "string" && bot.orchestrator.botUserId.length > 0)
+      s.add(bot.orchestrator.botUserId);
+  });
+  // OLD Layer-1 path: catalyst.monitor.linear.botUserId (back-compat). CTL-749.
+  addFromPath(layer1Path, (p, s) => {
+    const uid = p?.catalyst?.monitor?.linear?.botUserId;
+    if (typeof uid === "string" && uid.length > 0) s.add(uid);
+  });
+  return ids;
+}
+
+// _isBotId — returns true when actorId is in the bot-ids set or (for backward
+// compat with tests that pass a plain string) equals the string directly.
+// Centralises the "is this the bot?" check used in the three self-echo guards.
+export function _isBotId(botUserId, actorId) {
+  if (!botUserId || !actorId) return false;
+  if (botUserId instanceof Set) return botUserId.has(actorId);
+  return botUserId === actorId;
 }
 
 // createCommentInboxWriter — factory for a per-daemon onComment subscriber.
 // Appends a JSONL entry to ORCH_DIR/workers/<ticket>/inbox.jsonl when the
 // ticket is in-flight (workers/ dir exists). Filters bot self-echo via
-// botUserId. Exported for testing. CTL-749.
+// botUserId (string or Set<string>). Exported for testing. CTL-749.
 export function createCommentInboxWriter(orchDir, botUserId) {
   return function writeCommentToInbox(parsed) {
     const ticket = parsed.ticket ?? parsed.identifier ?? null;
     if (!ticket) return;
-    if (botUserId && parsed.authorId === botUserId) return;
+    if (_isBotId(botUserId, parsed.authorId)) return;
     const workerDir = join(orchDir, "workers", ticket);
     if (!existsSync(workerDir)) return;
     const entry = JSON.stringify({
@@ -152,7 +178,7 @@ export function createUpdateInboxWriter(orchDir, botUserId) {
     if (!parsed.descriptionChanged) return;
     const ticket = parsed.ticket ?? parsed.identifier ?? null;
     if (!ticket) return;
-    if (botUserId && parsed.actorId === botUserId) return;
+    if (_isBotId(botUserId, parsed.actorId)) return;
     const workerDir = join(orchDir, "workers", ticket);
     if (!existsSync(workerDir)) return;
     const entry = JSON.stringify({
@@ -196,8 +222,8 @@ export async function handleCommentWake(
   // CTL-756: self-echo guard — never re-dispatch on the bot's own comment
   // (e.g. the parking-question comment the parked worker just posted as the
   // Catalyst app actor). Fail-open when botUserId is unset. Mirrors the inbox
-  // writers' guard (daemon.mjs:124 / :148).
-  if (botUserId && parsed.authorId === botUserId) return;
+  // writers' guard. botUserId accepts a string or Set<string>.
+  if (_isBotId(botUserId, parsed.authorId)) return;
 
   const workerDir = join(orchDir, "workers", ticket);
   let signalFiles;
@@ -339,19 +365,21 @@ export function startDaemon({
     // CTL-565: the monitor needs orchDir to one-shot-dispatch the triage phase
     // agent on a →Triage transition. `dispatch` stays an injectable default
     // (dispatch.mjs) so the daemon's fakes-pass-through pattern still holds.
-    // CTL-749: resolve the bot user ID from .catalyst/config.json so the inbox
-    // writers can filter out self-echo comments (the bot posting mirror comments).
-    const linearBotUserId = readLinearBotUserId(configPath);
-    const commentInboxWriter = createCommentInboxWriter(orchDir, linearBotUserId);
+    // CTL-749: resolve bot user IDs from both config layers (Layer-1 old path +
+    // Layer-2 new global path) so inbox writers and the comment-wake guard
+    // suppress self-echo from BOTH the worker app-actor AND the orchestrator
+    // app-actor. Returns a Set<string> — empty = no filter (fail-open).
+    const linearBotUserIds = readLinearBotUserIds(configPath, layer2Path);
+    const commentInboxWriter = createCommentInboxWriter(orchDir, linearBotUserIds);
     monitorFn({
       orchDir,
       cache,
       concurrency, // CTL-716: slot-gate uses the same ceiling as the scheduler
       onComment: (parsed) => {
         commentInboxWriter(parsed); // CTL-749: write to inbox.jsonl for in-flight workers
-        handleCommentWake(parsed, { orchDir, dispatch: dispatchTicket, removeLabel: defaultRemoveLabel, botUserId: linearBotUserId }); // CTL-549 + CTL-756: re-dispatch parked tickets; botUserId suppresses self-echo
+        handleCommentWake(parsed, { orchDir, dispatch: dispatchTicket, removeLabel: defaultRemoveLabel, botUserId: linearBotUserIds }); // CTL-549 + CTL-756: re-dispatch parked tickets; botUserId suppresses self-echo
       },
-      onUpdate: createUpdateInboxWriter(orchDir, linearBotUserId), // CTL-749
+      onUpdate: createUpdateInboxWriter(orchDir, linearBotUserIds), // CTL-749
     }); // CTL-535 + CTL-565 + CTL-634 + CTL-549 + CTL-749 + CTL-716
     // CTL-558: the scheduler writes Linear status via its default `writeStatus`
     // (linear-write.mjs) on every committed phase transition — no daemon wiring

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -30,6 +30,8 @@ import {
   __getEventPollTimerForTest,
   createCommentInboxWriter,
   createUpdateInboxWriter,
+  readLinearBotUserIds,
+  _isBotId,
 } from "./daemon.mjs";
 import { getEventLogPath } from "./config.mjs";
 import { upsertProjectEntry } from "./registry.mjs";
@@ -1173,6 +1175,178 @@ describe("inbox writer — createUpdateInboxWriter (CTL-749)", () => {
     const writer = createUpdateInboxWriter(tmpDir, "bot-id");
     writer({ ticket, description: "bot edit", descriptionChanged: true, actorId: "bot-id", actorName: "Bot" });
     expect(existsSync(join(tmpDir, "workers", ticket, "inbox.jsonl"))).toBe(false);
+  });
+});
+
+// readLinearBotUserIds — collects bot UUIDs from Layer-2 new path + Layer-1 back-compat
+describe("readLinearBotUserIds", () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), "bot-ids-test-")); });
+  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  test("returns empty set when both paths are absent", () => {
+    const ids = readLinearBotUserIds("/nonexistent/layer1.json", "/nonexistent/layer2.json");
+    expect(ids.size).toBe(0);
+  });
+
+  test("reads worker botUserId from Layer-2 new global path", () => {
+    const layer2 = join(tmpDir, "config.json");
+    writeFileSync(layer2, JSON.stringify({
+      catalyst: { linear: { bot: { worker: { botUserId: "worker-uuid-1" } } } }
+    }));
+    const ids = readLinearBotUserIds(null, layer2);
+    expect(ids.has("worker-uuid-1")).toBe(true);
+    expect(ids.size).toBe(1);
+  });
+
+  test("reads orchestrator botUserId from Layer-2 new global path", () => {
+    const layer2 = join(tmpDir, "config.json");
+    writeFileSync(layer2, JSON.stringify({
+      catalyst: { linear: { bot: { orchestrator: { botUserId: "orch-uuid-1" } } } }
+    }));
+    const ids = readLinearBotUserIds(null, layer2);
+    expect(ids.has("orch-uuid-1")).toBe(true);
+    expect(ids.size).toBe(1);
+  });
+
+  test("reads both worker and orchestrator botUserIds from Layer-2", () => {
+    const layer2 = join(tmpDir, "config.json");
+    writeFileSync(layer2, JSON.stringify({
+      catalyst: {
+        linear: {
+          bot: {
+            worker: { botUserId: "worker-uuid" },
+            orchestrator: { botUserId: "orch-uuid" },
+          },
+        },
+      },
+    }));
+    const ids = readLinearBotUserIds(null, layer2);
+    expect(ids.has("worker-uuid")).toBe(true);
+    expect(ids.has("orch-uuid")).toBe(true);
+    expect(ids.size).toBe(2);
+  });
+
+  test("reads Layer-1 back-compat path (catalyst.monitor.linear.botUserId)", () => {
+    const layer1 = join(tmpDir, "layer1.json");
+    writeFileSync(layer1, JSON.stringify({
+      catalyst: { monitor: { linear: { botUserId: "legacy-uuid" } } }
+    }));
+    const ids = readLinearBotUserIds(layer1, null);
+    expect(ids.has("legacy-uuid")).toBe(true);
+    expect(ids.size).toBe(1);
+  });
+
+  test("merges IDs from both layers; deduplicates when same UUID appears in both", () => {
+    const layer1 = join(tmpDir, "layer1.json");
+    const layer2 = join(tmpDir, "config.json");
+    writeFileSync(layer1, JSON.stringify({
+      catalyst: { monitor: { linear: { botUserId: "shared-uuid" } } }
+    }));
+    writeFileSync(layer2, JSON.stringify({
+      catalyst: {
+        linear: {
+          bot: {
+            worker: { botUserId: "shared-uuid" },  // same as layer-1 — should dedup
+            orchestrator: { botUserId: "orch-uuid" },
+          },
+        },
+      },
+    }));
+    const ids = readLinearBotUserIds(layer1, layer2);
+    expect(ids.has("shared-uuid")).toBe(true);
+    expect(ids.has("orch-uuid")).toBe(true);
+    expect(ids.size).toBe(2); // not 3 — deduped
+  });
+
+  test("returns empty set when layer2 has no bot section", () => {
+    const layer2 = join(tmpDir, "config.json");
+    writeFileSync(layer2, JSON.stringify({ catalyst: { linear: {} } }));
+    const ids = readLinearBotUserIds(null, layer2);
+    expect(ids.size).toBe(0);
+  });
+});
+
+// _isBotId — normalises string vs Set so guard callers are consistent
+describe("_isBotId", () => {
+  test("returns false when botUserId is empty string", () => {
+    expect(_isBotId("", "some-id")).toBe(false);
+  });
+  test("returns false when actorId is absent", () => {
+    expect(_isBotId("bot-id", null)).toBe(false);
+    expect(_isBotId("bot-id", undefined)).toBe(false);
+    expect(_isBotId("bot-id", "")).toBe(false);
+  });
+  test("matches a plain string botUserId", () => {
+    expect(_isBotId("bot-id", "bot-id")).toBe(true);
+    expect(_isBotId("bot-id", "human-id")).toBe(false);
+  });
+  test("matches any member of a Set botUserId", () => {
+    const ids = new Set(["worker-id", "orch-id"]);
+    expect(_isBotId(ids, "worker-id")).toBe(true);
+    expect(_isBotId(ids, "orch-id")).toBe(true);
+    expect(_isBotId(ids, "human-id")).toBe(false);
+  });
+  test("returns false for an empty Set", () => {
+    expect(_isBotId(new Set(), "some-id")).toBe(false);
+  });
+});
+
+// inbox writers with Set botUserId
+describe("createCommentInboxWriter — Set<string> botUserId", () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), "inbox-set-test-")); });
+  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  test("skips write when authorId is in the bot Set (worker id)", () => {
+    const ticket = "CTL-99";
+    mkdirSync(join(tmpDir, "workers", ticket), { recursive: true });
+    const ids = new Set(["worker-id", "orch-id"]);
+    const writer = createCommentInboxWriter(tmpDir, ids);
+    writer({ ticket, commentId: "c1", body: "bot mirror", authorId: "worker-id" });
+    expect(existsSync(join(tmpDir, "workers", ticket, "inbox.jsonl"))).toBe(false);
+  });
+
+  test("skips write when authorId is in the bot Set (orchestrator id)", () => {
+    const ticket = "CTL-99";
+    mkdirSync(join(tmpDir, "workers", ticket), { recursive: true });
+    const ids = new Set(["worker-id", "orch-id"]);
+    const writer = createCommentInboxWriter(tmpDir, ids);
+    writer({ ticket, commentId: "c2", body: "orch comment", authorId: "orch-id" });
+    expect(existsSync(join(tmpDir, "workers", ticket, "inbox.jsonl"))).toBe(false);
+  });
+
+  test("writes when authorId is NOT in the bot Set (human reply)", () => {
+    const ticket = "CTL-99";
+    mkdirSync(join(tmpDir, "workers", ticket), { recursive: true });
+    const ids = new Set(["worker-id", "orch-id"]);
+    const writer = createCommentInboxWriter(tmpDir, ids);
+    writer({ ticket, commentId: "c3", body: "human reply", authorId: "human-id" });
+    expect(existsSync(join(tmpDir, "workers", ticket, "inbox.jsonl"))).toBe(true);
+  });
+});
+
+describe("createUpdateInboxWriter — Set<string> botUserId", () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), "update-set-test-")); });
+  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  test("skips write when actorId is in the bot Set", () => {
+    const ticket = "CTL-99";
+    mkdirSync(join(tmpDir, "workers", ticket), { recursive: true });
+    const ids = new Set(["worker-id", "orch-id"]);
+    const writer = createUpdateInboxWriter(tmpDir, ids);
+    writer({ ticket, description: "updated", descriptionChanged: true, actorId: "orch-id" });
+    expect(existsSync(join(tmpDir, "workers", ticket, "inbox.jsonl"))).toBe(false);
+  });
+
+  test("writes when actorId is NOT in the bot Set", () => {
+    const ticket = "CTL-99";
+    mkdirSync(join(tmpDir, "workers", ticket), { recursive: true });
+    const ids = new Set(["worker-id", "orch-id"]);
+    const writer = createUpdateInboxWriter(tmpDir, ids);
+    writer({ ticket, description: "updated", descriptionChanged: true, actorId: "human-id" });
+    expect(existsSync(join(tmpDir, "workers", ticket, "inbox.jsonl"))).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/lib/linear-comment-post.sh
+++ b/plugins/dev/scripts/lib/linear-comment-post.sh
@@ -15,13 +15,18 @@ BODY="${2:?comment body required}"
 
 LINEAR_API="https://api.linear.app"
 
+# _find_layer2_config — resolve the OLD per-team Layer-2 file
+# (~/.config/catalyst/config-<key>.json) by walking up for .catalyst/config.json
+# and reading the project key. The key lives at `.catalyst.projectKey` (nested);
+# a bare top-level `.projectKey` is also honored for any legacy layout. Falls
+# back to the GLOBAL ~/.config/catalyst/config.json when no key is found.
 _find_layer2_config() {
   local dir="$PWD"
   while [[ "$dir" != "/" ]]; do
     local cfg="$dir/.catalyst/config.json"
     if [[ -f "$cfg" ]]; then
       local key
-      key=$(jq -r '.projectKey // empty' "$cfg" 2>/dev/null) || true
+      key=$(jq -r '.catalyst.projectKey // .projectKey // empty' "$cfg" 2>/dev/null) || true
       if [[ -n "$key" ]]; then
         echo "$HOME/.config/catalyst/config-${key}.json"
         return 0
@@ -36,15 +41,34 @@ CLIENT_ID="${CATALYST_LINEAR_AGENT_CLIENT_ID:-}"
 CLIENT_SECRET="${CATALYST_LINEAR_AGENT_CLIENT_SECRET:-}"
 
 if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]]; then
+  GLOBAL_CONFIG="$HOME/.config/catalyst/config.json"
   LAYER2_CONFIG="$(_find_layer2_config)"
-  if [[ ! -f "$LAYER2_CONFIG" ]]; then
-    echo "linear-comment-post: Layer-2 config not found at $LAYER2_CONFIG" >&2
-    exit 1
+
+  # 1. NEW global path (~/.config/catalyst/config.json):
+  #    catalyst.linear.bot.worker.{clientId,clientSecret}
+  if [[ -f "$GLOBAL_CONFIG" ]]; then
+    CLIENT_ID=$(jq -r '.catalyst.linear.bot.worker.clientId // empty' "$GLOBAL_CONFIG" 2>/dev/null)
+    CLIENT_SECRET=$(jq -r '.catalyst.linear.bot.worker.clientSecret // empty' "$GLOBAL_CONFIG" 2>/dev/null)
   fi
-  CLIENT_ID=$(jq -r '.catalyst.linear.agent.clientId // empty' "$LAYER2_CONFIG" 2>/dev/null)
-  CLIENT_SECRET=$(jq -r '.catalyst.linear.agent.clientSecret // empty' "$LAYER2_CONFIG" 2>/dev/null)
+
+  # 2. OLD per-team path fallback (config-<key>.json, resolved above):
+  #    catalyst.linear.agent.{clientId,clientSecret}. During the transition the
+  #    worker creds may still live in the per-team file under the legacy key.
+  if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]] && [[ -f "$LAYER2_CONFIG" ]]; then
+    CLIENT_ID=$(jq -r '.catalyst.linear.agent.clientId // empty' "$LAYER2_CONFIG" 2>/dev/null)
+    CLIENT_SECRET=$(jq -r '.catalyst.linear.agent.clientSecret // empty' "$LAYER2_CONFIG" 2>/dev/null)
+  fi
+
+  # 3. OLD global path fallback: legacy catalyst.linear.agent.* in the global
+  #    config.json (covers a global-only legacy layout when no per-team file
+  #    exists or the resolver already pointed at config.json).
+  if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]] && [[ -f "$GLOBAL_CONFIG" ]]; then
+    CLIENT_ID=$(jq -r '.catalyst.linear.agent.clientId // empty' "$GLOBAL_CONFIG" 2>/dev/null)
+    CLIENT_SECRET=$(jq -r '.catalyst.linear.agent.clientSecret // empty' "$GLOBAL_CONFIG" 2>/dev/null)
+  fi
+
   if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]]; then
-    echo "linear-comment-post: catalyst.linear.agent.{clientId,clientSecret} not found in $LAYER2_CONFIG" >&2
+    echo "linear-comment-post: catalyst.linear.bot.worker.{clientId,clientSecret} (global) or legacy catalyst.linear.agent.* (per-team $LAYER2_CONFIG / global $GLOBAL_CONFIG) not found" >&2
     exit 1
   fi
 fi

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
@@ -323,7 +323,7 @@ describe("createLinearWebhookHandler", () => {
     const handler = createLinearWebhookHandler({
       linearSecrets: [{ key: "test", secret: SECRET }],
       eventLog,
-      botUserId: "bot-uuid-123",
+      botUserIds: new Set(["bot-uuid-123"]),
     });
     const botPayload = {
       action: "update",
@@ -337,11 +337,29 @@ describe("createLinearWebhookHandler", () => {
     expect(eventLog.appends.length).toBe(0);
   });
 
-  it("non-bot actor writes normally even when botUserId is configured", async () => {
+  it("suppresses issue event from orchestrator bot (second id in Set)", async () => {
     const handler = createLinearWebhookHandler({
       linearSecrets: [{ key: "test", secret: SECRET }],
       eventLog,
-      botUserId: "bot-uuid-123",
+      botUserIds: new Set(["worker-uuid", "orch-uuid"]),
+    });
+    const orchPayload = {
+      action: "update",
+      type: "Issue",
+      actor: { id: "orch-uuid", name: "Catalyst Orchestrator" },
+      data: { id: "i1", identifier: "CTL-263", team: { key: "CTL" } },
+      updatedFrom: { stateId: "old" },
+    };
+    const res = await handler.handle(makeReq(orchPayload));
+    expect(res.status).toBe(200);
+    expect(eventLog.appends.length).toBe(0);
+  });
+
+  it("non-bot actor writes normally even when botUserIds is configured", async () => {
+    const handler = createLinearWebhookHandler({
+      linearSecrets: [{ key: "test", secret: SECRET }],
+      eventLog,
+      botUserIds: new Set(["bot-uuid-123"]),
     });
     const humanPayload = {
       action: "update",
@@ -358,7 +376,7 @@ describe("createLinearWebhookHandler", () => {
     const handler = createLinearWebhookHandler({
       linearSecrets: [{ key: "test", secret: SECRET }],
       eventLog,
-      botUserId: "bot-uuid-123",
+      botUserIds: new Set(["bot-uuid-123"]),
     });
     const commentPayload = {
       action: "create",
@@ -483,7 +501,7 @@ describe("buildLinearEventLogEnvelope — comment fields (CTL-681)", () => {
     const handler = createLinearWebhookHandler({
       linearSecrets: [{ key: "test", secret: SECRET }],
       eventLog: eventLog2,
-      botUserId: "bot-uuid-123",
+      botUserIds: new Set(["bot-uuid-123"]),
     });
     const botComment = {
       action: "create",

--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
@@ -71,7 +71,7 @@ describe("loadWebhookConfig", () => {
       watchRepos: [],
       linearSecrets: [],
       linearSmeeChannel: "",
-      linearBotUserId: "",
+      linearBotUserIds: new Set(),
       linearTeams: [],
       linearAgentConfig: null,
     });
@@ -102,7 +102,7 @@ describe("loadWebhookConfig", () => {
       watchRepos: [],
       linearSecrets: [],
       linearSmeeChannel: "",
-      linearBotUserId: "",
+      linearBotUserIds: new Set(),
       linearTeams: [],
       linearAgentConfig: null,
     });
@@ -141,7 +141,7 @@ describe("loadWebhookConfig", () => {
       watchRepos: [],
       linearSecrets: [],
       linearSmeeChannel: "",
-      linearBotUserId: "",
+      linearBotUserIds: new Set(),
       linearTeams: [],
       linearAgentConfig: null,
     });
@@ -174,7 +174,7 @@ describe("loadWebhookConfig", () => {
       watchRepos: [],
       linearSecrets: [],
       linearSmeeChannel: "",
-      linearBotUserId: "",
+      linearBotUserIds: new Set(),
       linearTeams: [],
       linearAgentConfig: null,
     });
@@ -201,7 +201,7 @@ describe("loadWebhookConfig", () => {
       watchRepos: [],
       linearSecrets: [],
       linearSmeeChannel: "",
-      linearBotUserId: "",
+      linearBotUserIds: new Set(),
       linearTeams: [],
       linearAgentConfig: null,
     });
@@ -229,7 +229,7 @@ describe("loadWebhookConfig", () => {
       watchRepos: [],
       linearSecrets: [],
       linearSmeeChannel: "",
-      linearBotUserId: "",
+      linearBotUserIds: new Set(),
       linearTeams: [],
       linearAgentConfig: null,
     });
@@ -305,7 +305,7 @@ describe("loadWebhookConfig", () => {
       watchRepos: [],
       linearSecrets: [],
       linearSmeeChannel: "",
-      linearBotUserId: "",
+      linearBotUserIds: new Set(),
       linearTeams: [],
       linearAgentConfig: null,
     });
@@ -341,7 +341,7 @@ describe("loadWebhookConfig", () => {
       watchRepos: [],
       linearSecrets: [],
       linearSmeeChannel: "",
-      linearBotUserId: "",
+      linearBotUserIds: new Set(),
       linearTeams: [],
       linearAgentConfig: null,
     });
@@ -436,7 +436,7 @@ describe("loadWebhookConfig watchRepos (CTL-216)", () => {
       watchRepos: ["a/b"],
       linearSecrets: [],
       linearSmeeChannel: "",
-      linearBotUserId: "",
+      linearBotUserIds: new Set(),
       linearTeams: [],
       linearAgentConfig: null,
     });
@@ -822,8 +822,8 @@ describe("loadWebhookConfig — linearSmeeChannel (CTL-242)", () => {
     expect(cfg!.linearSmeeChannel).toBe("https://smee.io/linear-only");
   });
 
-  // CTL-263: linearBotUserId
-  it("reads catalyst.monitor.linear.botUserId from Layer 1 into linearBotUserId", () => {
+  // CTL-263: linearBotUserIds (Set)
+  it("reads catalyst.monitor.linear.botUserId from Layer 1 into linearBotUserIds", () => {
     writeHome({
       catalyst: {
         monitor: {
@@ -850,10 +850,11 @@ describe("loadWebhookConfig — linearSmeeChannel (CTL-242)", () => {
     const cfg = loadWebhookConfig(homeDir, projectConfigPath);
 
     expect(cfg).not.toBeNull();
-    expect(cfg!.linearBotUserId).toBe("bot-linear-uuid-abc");
+    expect(cfg!.linearBotUserIds.has("bot-linear-uuid-abc")).toBe(true);
+    expect(cfg!.linearBotUserIds.size).toBe(1);
   });
 
-  it("linearBotUserId is empty string when not configured", () => {
+  it("linearBotUserIds is empty set when not configured", () => {
     writeHome({
       catalyst: {
         monitor: {
@@ -877,7 +878,107 @@ describe("loadWebhookConfig — linearSmeeChannel (CTL-242)", () => {
     const cfg = loadWebhookConfig(homeDir, projectConfigPath);
 
     expect(cfg).not.toBeNull();
-    expect(cfg!.linearBotUserId).toBe("");
+    expect(cfg!.linearBotUserIds.size).toBe(0);
+  });
+
+  it("reads worker botUserId from Layer-2 global config.json (new path)", () => {
+    // Write worker botUserId to the new global path in homeDir/config.json
+    writeHome({
+      catalyst: {
+        linear: {
+          bot: {
+            worker: { botUserId: "worker-bot-uuid" },
+          },
+        },
+        monitor: {
+          linear: {
+            workspace: { webhookId: "linear-webhook-123" },
+          },
+        },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: { webhookSecretEnv: "CATALYST_LINEAR_WEBHOOK_SECRET" },
+        },
+      },
+    });
+    process.env.CATALYST_LINEAR_WEBHOOK_SECRET = "linear-secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).not.toBeNull();
+    expect(cfg!.linearBotUserIds.has("worker-bot-uuid")).toBe(true);
+    expect(cfg!.linearBotUserIds.size).toBe(1);
+  });
+
+  it("reads orchestrator botUserId from Layer-2 global config.json (new path)", () => {
+    writeHome({
+      catalyst: {
+        linear: {
+          bot: {
+            orchestrator: { botUserId: "orch-bot-uuid" },
+          },
+        },
+        monitor: {
+          linear: {
+            workspace: { webhookId: "linear-webhook-123" },
+          },
+        },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: { webhookSecretEnv: "CATALYST_LINEAR_WEBHOOK_SECRET" },
+        },
+      },
+    });
+    process.env.CATALYST_LINEAR_WEBHOOK_SECRET = "linear-secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).not.toBeNull();
+    expect(cfg!.linearBotUserIds.has("orch-bot-uuid")).toBe(true);
+    expect(cfg!.linearBotUserIds.size).toBe(1);
+  });
+
+  it("collects worker + orchestrator + Layer-1 botUserIds into a unified set", () => {
+    writeHome({
+      catalyst: {
+        linear: {
+          bot: {
+            worker: { botUserId: "worker-uuid" },
+            orchestrator: { botUserId: "orch-uuid" },
+          },
+        },
+        monitor: {
+          linear: {
+            workspace: { webhookId: "linear-webhook-123" },
+          },
+        },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: {
+            webhookSecretEnv: "CATALYST_LINEAR_WEBHOOK_SECRET",
+            botUserId: "legacy-uuid",
+          },
+        },
+      },
+    });
+    process.env.CATALYST_LINEAR_WEBHOOK_SECRET = "linear-secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).not.toBeNull();
+    expect(cfg!.linearBotUserIds.has("worker-uuid")).toBe(true);
+    expect(cfg!.linearBotUserIds.has("orch-uuid")).toBe(true);
+    expect(cfg!.linearBotUserIds.has("legacy-uuid")).toBe(true);
+    expect(cfg!.linearBotUserIds.size).toBe(3);
   });
 });
 
@@ -1213,10 +1314,11 @@ describe("loadLinearAgentConfig", () => {
     expect(loadLinearAgentConfig(homeDir, "nonexistent")).toBeNull();
   });
 
-  it("returns null when catalyst.linear.agent is absent in the file", () => {
+  it("returns null when neither global bot.worker nor per-team agent section present", () => {
     writeFileSync(join(homeDir, "config-testproj.json"), JSON.stringify({
       catalyst: { monitor: {} },
     }));
+    // no config.json at all in homeDir either
     expect(loadLinearAgentConfig(homeDir, "testproj")).toBeNull();
   });
 
@@ -1258,6 +1360,48 @@ describe("loadLinearAgentConfig", () => {
     const result = loadLinearAgentConfig(homeDir, "testproj");
     expect(result).not.toBeNull();
     expect((result as unknown as Record<string, unknown>).accessToken).toBeUndefined();
+  });
+
+  // New global path tests
+  it("reads from global config.json catalyst.linear.bot.worker (new path) when present", () => {
+    writeFileSync(join(homeDir, "config.json"), JSON.stringify({
+      catalyst: { linear: { bot: { worker: { clientId: "gid", clientSecret: "gsec", webhookSecret: "gwhs" } } } },
+    }));
+    const result = loadLinearAgentConfig(homeDir, "testproj");
+    expect(result).not.toBeNull();
+    expect(result!.clientId).toBe("gid");
+    expect(result!.clientSecret).toBe("gsec");
+    expect(result!.webhookSecret).toBe("gwhs");
+  });
+
+  it("new global path wins over old per-team path when both present", () => {
+    writeFileSync(join(homeDir, "config.json"), JSON.stringify({
+      catalyst: { linear: { bot: { worker: { clientId: "global-id", clientSecret: "global-sec" } } } },
+    }));
+    writeFileSync(join(homeDir, "config-testproj.json"), JSON.stringify({
+      catalyst: { linear: { agent: { clientId: "per-team-id", clientSecret: "per-team-sec" } } },
+    }));
+    const result = loadLinearAgentConfig(homeDir, "testproj");
+    expect(result!.clientId).toBe("global-id"); // new global wins
+  });
+
+  it("falls back to per-team path when global config.json has no bot.worker section", () => {
+    writeFileSync(join(homeDir, "config.json"), JSON.stringify({
+      catalyst: { monitor: {} }, // no catalyst.linear.bot.worker
+    }));
+    writeFileSync(join(homeDir, "config-testproj.json"), JSON.stringify({
+      catalyst: { linear: { agent: { clientId: "fallback-id", clientSecret: "fallback-sec" } } },
+    }));
+    const result = loadLinearAgentConfig(homeDir, "testproj");
+    expect(result!.clientId).toBe("fallback-id"); // old path used as fallback
+  });
+
+  it("reads botUserId from global bot.worker path", () => {
+    writeFileSync(join(homeDir, "config.json"), JSON.stringify({
+      catalyst: { linear: { bot: { worker: { clientId: "gid", clientSecret: "gsec", botUserId: "global-bot-id" } } } },
+    }));
+    const result = loadLinearAgentConfig(homeDir, "testproj");
+    expect(result!.botUserId).toBe("global-bot-id");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
@@ -37,11 +37,12 @@ export interface LinearWebhookHandlerDeps {
    */
   onAccept?: (event: LinearWebhookEvent) => void | Promise<void>;
   /**
-   * Linear user UUID for the catalyst bot. Issue events where the actor matches
-   * this value are suppressed before reaching the event log (loop prevention).
-   * Empty or absent = no suppression.
+   * Linear bot user UUIDs for loop prevention. Issue events where the actor
+   * matches any ID in the set are suppressed before reaching the event log.
+   * Accepts either a ReadonlySet<string> (new) or a plain string (legacy, for
+   * callers that haven't migrated yet). Absent / empty = no suppression.
    */
-  botUserId?: string;
+  botUserIds?: ReadonlySet<string> | string;
   /** Cap for the in-memory delivery-ID dedup set. Default 1000. */
   idempotencyMax?: number;
   logger?: LinearWebhookLogger;
@@ -371,13 +372,16 @@ export function createLinearWebhookHandler(deps: LinearWebhookHandlerDeps): Line
 
     const event = parseLinearWebhookEvent(eventName, payload);
 
-    // Bot-skip: suppress issue events authored by the catalyst bot to prevent
-    // write loops.
+    // Bot-skip: suppress issue events authored by any known catalyst bot actor
+    // to prevent write loops. botUserIds accepts ReadonlySet<string> or string.
+    const _isBotActor = (ids: ReadonlySet<string> | string | undefined, id: string | null): boolean => {
+      if (!ids || !id) return false;
+      if (typeof ids === "string") return ids === id;
+      return ids.has(id);
+    };
     if (
       event.kind === "issue" &&
-      deps.botUserId &&
-      deps.botUserId.length > 0 &&
-      event.actorId === deps.botUserId
+      _isBotActor(deps.botUserIds, event.actorId)
     ) {
       logger.info?.(
         `[linear-webhook] suppressed bot-authored issue event for ${event.ticket ?? "unknown"}`

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
@@ -34,12 +34,15 @@ export interface WebhookCliConfig {
    */
   linearSmeeChannel: string;
   /**
-   * Linear user UUID for the catalyst bot. Issue events where the actor matches
-   * this ID are suppressed before reaching the event log (loop prevention). CTL-263.
-   * Read from `catalyst.monitor.linear.botUserId` in Layer 1 (project config).
-   * Empty string when not configured — no suppression.
+   * Linear bot user UUIDs for loop prevention. Suppresses issue events where the
+   * actor matches any ID in the set before they reach the event log. CTL-263.
+   * Collected from:
+   *   1. NEW: `~/.config/catalyst/config.json` catalyst.linear.bot.worker.botUserId
+   *   2. NEW: `~/.config/catalyst/config.json` catalyst.linear.bot.orchestrator.botUserId
+   *   3. OLD: `.catalyst/config.json`           catalyst.monitor.linear.botUserId
+   * Empty set when not configured — no suppression.
    */
-  linearBotUserId: string;
+  linearBotUserIds: ReadonlySet<string>;
   /**
    * Optional team→repo mapping read from `catalyst.monitor.linear.teams[]` in
    * Layer 1 (project config). Each entry is `{ key, vcsRepo }` where `key` is
@@ -76,7 +79,7 @@ interface FileExtract {
   /** smee.io channel URL for Linear, from Layer 2 only (per-machine). CTL-242. */
   linearSmeeChannel: string | null;
   /** Linear bot user UUID for loop prevention, from Layer 1 (project). CTL-263. */
-  linearBotUserId: string | null;
+  linearBotUserId: string | null; // single string; assembled into a Set in loadWebhookConfig
   /** Linear team→repo map from Layer 1 (project). CTL-362. */
   linearTeams: Array<{ key: string; vcsRepo: string }>;
 }
@@ -313,39 +316,62 @@ function readGithubSection(filePath: string): FileExtract | null {
 }
 
 /**
- * Load the Linear app-actor credentials from the project-specific Layer-2
- * config file (`~/.config/catalyst/config-{projectKey}.json`). Returns null
- * when the file is absent, the project key is missing, or the required fields
- * `clientId` / `clientSecret` are not present. The `accessToken` field is
- * intentionally not surfaced — callers should mint fresh tokens via
- * `client_credentials` grant using `clientId` / `clientSecret`. CTL-550.
+ * Load the Linear app-actor (worker) credentials. Reads from two locations with
+ * the NEW global path taking precedence over the OLD per-team path:
+ *
+ *   NEW (global):   `~/.config/catalyst/config.json`
+ *                   catalyst.linear.bot.worker.{clientId,clientSecret,webhookSecret,botUserId}
+ *   OLD (per-team): `~/.config/catalyst/config-{projectKey}.json`
+ *                   catalyst.linear.agent.{clientId,clientSecret,webhookSecret,botUserId}
+ *
+ * Returns null when neither location has the required `clientId` / `clientSecret`.
+ * The `accessToken` field is intentionally not surfaced — callers mint fresh tokens
+ * via `client_credentials` grant. CTL-550.
  */
 export function loadLinearAgentConfig(
   homeConfigDir: string,
   projectKey: string | null,
 ): LinearAgentConfig | null {
-  if (projectKey === null || projectKey.length === 0) return null;
-  const configPath = join(homeConfigDir, `config-${projectKey}.json`);
-  let parsed: unknown;
+  // Helper: extract agent cred fields from a parsed config object under the given
+  // path (either catalyst.linear.bot.worker or catalyst.linear.agent).
+  function extractCreds(
+    parsed: unknown,
+    path: string[],
+  ): LinearAgentConfig | null {
+    let cur: unknown = parsed;
+    for (const key of path) {
+      if (!isRecord(cur)) return null;
+      cur = (cur as Record<string, unknown>)[key];
+    }
+    if (!isRecord(cur)) return null;
+    const clientId = typeof cur.clientId === "string" ? cur.clientId : "";
+    const clientSecret = typeof cur.clientSecret === "string" ? cur.clientSecret : "";
+    if (clientId.length === 0 || clientSecret.length === 0) return null;
+    const webhookSecret = typeof cur.webhookSecret === "string" ? cur.webhookSecret : "";
+    const botUserId =
+      typeof cur.botUserId === "string" && cur.botUserId.length > 0
+        ? cur.botUserId
+        : undefined;
+    return { clientId, clientSecret, webhookSecret, ...(botUserId !== undefined ? { botUserId } : {}) };
+  }
+
+  // 1. NEW: try global config.json → catalyst.linear.bot.worker
+  const globalConfigPath = join(homeConfigDir, "config.json");
   try {
-    parsed = JSON.parse(readFileSync(configPath, "utf8"));
+    const globalParsed = JSON.parse(readFileSync(globalConfigPath, "utf8"));
+    const result = extractCreds(globalParsed, ["catalyst", "linear", "bot", "worker"]);
+    if (result !== null) return result;
+  } catch { /* absent / malformed — fall through */ }
+
+  // 2. OLD: try per-team config-{projectKey}.json → catalyst.linear.agent
+  if (projectKey === null || projectKey.length === 0) return null;
+  const perTeamConfigPath = join(homeConfigDir, `config-${projectKey}.json`);
+  try {
+    const perTeamParsed = JSON.parse(readFileSync(perTeamConfigPath, "utf8"));
+    return extractCreds(perTeamParsed, ["catalyst", "linear", "agent"]);
   } catch {
     return null;
   }
-  if (!isRecord(parsed) || !isRecord(parsed.catalyst)) return null;
-  const linear = parsed.catalyst.linear;
-  if (!isRecord(linear)) return null;
-  const agent = linear.agent;
-  if (!isRecord(agent)) return null;
-  const clientId = typeof agent.clientId === "string" ? agent.clientId : "";
-  const clientSecret = typeof agent.clientSecret === "string" ? agent.clientSecret : "";
-  if (clientId.length === 0 || clientSecret.length === 0) return null;
-  const webhookSecret = typeof agent.webhookSecret === "string" ? agent.webhookSecret : "";
-  const botUserId =
-    typeof agent.botUserId === "string" && agent.botUserId.length > 0
-      ? agent.botUserId
-      : undefined;
-  return { clientId, clientSecret, webhookSecret, ...(botUserId !== undefined ? { botUserId } : {}) };
 }
 
 /**
@@ -435,8 +461,30 @@ export function loadWebhookConfig(
       ? linearSmeeChannelOverride
       : (fileLinearSmeeChannel ?? "");
 
-  // Linear bot user UUID for loop prevention. Layer 1 only (project/team setting). CTL-263.
-  const linearBotUserId = projectExtract?.linearBotUserId ?? "";
+  // Collect all known Linear bot user UUIDs for loop prevention. CTL-263.
+  // NEW: Layer-2 global config.json carries worker + orchestrator botUserIds.
+  // OLD: Layer-1 project config carries catalyst.monitor.linear.botUserId (back-compat).
+  const linearBotUserIds = new Set<string>();
+  try {
+    const globalParsed = JSON.parse(readFileSync(join(homeConfigDir, "config.json"), "utf8")) as unknown;
+    if (isRecord(globalParsed) && isRecord(globalParsed.catalyst)) {
+      const bot = (globalParsed.catalyst as Record<string, unknown>).linear;
+      if (isRecord(bot) && isRecord((bot as Record<string, unknown>).bot)) {
+        const botSection = (bot as Record<string, unknown>).bot as Record<string, unknown>;
+        if (isRecord(botSection.worker) && typeof (botSection.worker as Record<string, unknown>).botUserId === "string") {
+          const id = (botSection.worker as Record<string, unknown>).botUserId as string;
+          if (id.length > 0) linearBotUserIds.add(id);
+        }
+        if (isRecord(botSection.orchestrator) && typeof (botSection.orchestrator as Record<string, unknown>).botUserId === "string") {
+          const id = (botSection.orchestrator as Record<string, unknown>).botUserId as string;
+          if (id.length > 0) linearBotUserIds.add(id);
+        }
+      }
+    }
+  } catch { /* absent / malformed — continue to Layer-1 fallback */ }
+  // OLD Layer-1 back-compat: catalyst.monitor.linear.botUserId.
+  const layer1BotUserId = projectExtract?.linearBotUserId ?? "";
+  if (layer1BotUserId.length > 0) linearBotUserIds.add(layer1BotUserId);
 
   // Linear team→repo map. Layer 1 only — team-shared, committed. CTL-362.
   const linearTeams = projectExtract?.linearTeams ?? [];
@@ -456,7 +504,7 @@ export function loadWebhookConfig(
       watchRepos,
       linearSecrets,
       linearSmeeChannel,
-      linearBotUserId,
+      linearBotUserIds,
       linearTeams,
       linearAgentConfig,
     };
@@ -469,7 +517,7 @@ export function loadWebhookConfig(
     watchRepos,
     linearSecrets,
     linearSmeeChannel,
-    linearBotUserId,
+    linearBotUserIds,
     linearTeams,
     linearAgentConfig,
   };

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -207,8 +207,8 @@ export interface CreateServerOptions {
     linearSecrets: Array<{ key: string; secret: string }>;
     /** smee.io channel URL for Linear delivery. Empty = no tunnel. CTL-242. */
     smeeChannel?: string;
-    /** Linear bot user UUID for loop prevention. CTL-263. */
-    botUserId?: string;
+    /** Linear bot user UUIDs for loop prevention (set of worker + orchestrator app-actor UUIDs). CTL-263. */
+    botUserIds?: ReadonlySet<string>;
     /** Linear team→repo map (CTL-362). When set, the handler stamps
      * `attributes["vcs.repository.name"]` on issue/comment/cycle envelopes for
      * teams that appear here so the HUD's REPO column populates for Linear
@@ -707,7 +707,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     });
     linearWebhookHandler = createLinearWebhookHandler({
       linearSecrets: linearWebhookConfig?.linearSecrets ?? [],
-      botUserId: linearWebhookConfig?.botUserId,
+      botUserIds: linearWebhookConfig?.botUserIds,
       linearTeams: linearWebhookConfig?.linearTeams ?? [],
       eventLog: linearEventLog,
       emit: (type, data) => emit(type, data),
@@ -2064,7 +2064,7 @@ if (import.meta.main) {
       ? {
           linearSecrets: fullWebhookConfig.linearSecrets,
           smeeChannel: fullWebhookConfig.linearSmeeChannel,
-          botUserId: fullWebhookConfig.linearBotUserId || undefined,
+          botUserIds: fullWebhookConfig.linearBotUserIds.size > 0 ? fullWebhookConfig.linearBotUserIds : undefined,
           linearTeams: fullWebhookConfig.linearTeams,
         }
       : null;

--- a/plugins/dev/scripts/setup-execution-core-states.sh
+++ b/plugins/dev/scripts/setup-execution-core-states.sh
@@ -439,19 +439,22 @@ main() {
   fi
 
   # --- check the Linear app-actor identity (CTL-749) ---
-  # The execution-core daemon reads catalyst.monitor.linear.botUserId at startup
-  # to filter the agent's OWN mirror comments/description-updates out of each
-  # worker's inbox.jsonl (self-echo / write-loop guard). Without it set, the
-  # agent's comments are written back as if a human replied, and bot-authored
-  # issue events feed back into the event log as loops. This is a prerequisite,
-  # not a hard failure here — warn and continue.
-  local bot_id
-  bot_id=$(jq -r '.catalyst.monitor.linear.botUserId // empty' "$config" 2>/dev/null)
-  if [[ -z $bot_id ]]; then
-    echo "WARNING: catalyst.monitor.linear.botUserId not set in $config" >&2
-    echo "  execution-core needs it for CTL-749 self-echo filtering of the agent's own" >&2
-    echo "  Linear comments/updates. Obtain it by querying viewer.id with the app-actor" >&2
-    echo "  token from ~/.config/catalyst/config-${project_key}.json, then set it here." >&2
+  # The execution-core daemon reads a SET of bot user UUIDs at startup:
+  #   NEW: ~/.config/catalyst/config.json  catalyst.linear.bot.worker.botUserId
+  #        ~/.config/catalyst/config.json  catalyst.linear.bot.orchestrator.botUserId
+  #   OLD: .catalyst/config.json           catalyst.monitor.linear.botUserId (back-compat)
+  # Without at least one set, the agent's OWN comments/updates are not filtered
+  # out of inbox.jsonl and are treated as human input (false "human replied").
+  # This is a prerequisite, not a hard failure here — warn and continue.
+  local _global_cfg="$HOME/.config/catalyst/config.json"
+  local _bot_worker _bot_orch _bot_layer1
+  _bot_worker=$(jq -r '.catalyst.linear.bot.worker.botUserId // empty' "$_global_cfg" 2>/dev/null)
+  _bot_orch=$(jq -r '.catalyst.linear.bot.orchestrator.botUserId // empty' "$_global_cfg" 2>/dev/null)
+  _bot_layer1=$(jq -r '.catalyst.monitor.linear.botUserId // empty' "$config" 2>/dev/null)
+  if [[ -z $_bot_worker && -z $_bot_orch && -z $_bot_layer1 ]]; then
+    echo "WARNING: No Linear bot user IDs configured — CTL-749 self-echo guard is inactive" >&2
+    echo "  NEW: set catalyst.linear.bot.worker.botUserId in ~/.config/catalyst/config.json" >&2
+    echo "  OLD fallback: set catalyst.monitor.linear.botUserId in $config" >&2
   fi
 
   # --- write the execution-core stateMap (atomic tmp + mv) ---

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -88,18 +88,33 @@ For `execution-core` mode, the number of workers comes from a separate committed
 
 In `execution-core` mode, the daemon reads a central registry at `~/catalyst/execution-core/registry.json`. Each project there has an `eligibleQuery` that says which tickets are ready — for example, `status: "Ready"`. The setup tool `setup-execution-core-states.sh` writes this for you; you don't edit it by hand. That mode also needs six Linear states to exist — `Ready`, `Research`, `Plan`, `Implement`, `Validate`, and `PR` — which the same tool creates.
 
-## Linear app-actor identity (`catalyst.monitor.linear.botUserId`)
+## Linear app-actor identity (`catalyst.linear.bot.{worker,orchestrator}.botUserId`)
 
-You must set `catalyst.monitor.linear.botUserId` for the Linear app-actor comms channel — i.e. when the daemon mirrors phase-agent output to Linear and wakes on human replies (the "Linear for Agents" identity that posts comments **as Catalyst**). It's the Linear user UUID of that app actor. This lives in the committed `.catalyst/config.json` — not the secrets file — because the value isn't secret (it appears on every comment the app posts), but it is workspace-specific.
+Catalyst posts to Linear as a Linear OAuth **app actor** — the "Linear for Agents" identity that comments **as Catalyst**. Linear OAuth apps are account-level (one app serves every team), so the bot identity and OAuth credentials now live in the **global** `~/.config/catalyst/config.json` under `catalyst.linear.bot`, split into two app actors:
+
+- `catalyst.linear.bot.worker` — the worker app that posts phase-agent mirror comments and mints tokens via `client_credentials`.
+- `catalyst.linear.bot.orchestrator` — the orchestrator app that posts run-level updates.
+
+Each carries a `botUserId` (the Linear user UUID of that app actor). The daemon and orch-monitor read **both** `botUserId`s into a single set so the self-echo / loop-prevention guard suppresses comments and issue events from **either** app actor. These UUIDs aren't secret (they appear on every comment the app posts), but they are account-specific.
 
 ```json
 {
   "catalyst": {
-    "monitor": {
-      "linear": {
-        "teams": ["ACME"],
-        "webhookSecretEnv": "CATALYST_LINEAR_WEBHOOK_SECRET",
-        "botUserId": null
+    "linear": {
+      "bot": {
+        "worker": {
+          "clientId": "...",
+          "clientSecret": "...",
+          "webhookSecret": "...",
+          "accessToken": "...",
+          "botUserId": null
+        },
+        "orchestrator": {
+          "clientId": "...",
+          "clientSecret": "...",
+          "accessToken": "...",
+          "botUserId": null
+        }
       }
     }
   }
@@ -108,30 +123,41 @@ You must set `catalyst.monitor.linear.botUserId` for the Linear app-actor comms 
 
 | Key | What it does |
 | --- | --- |
-| `catalyst.monitor.linear.botUserId` | Linear user UUID of the Catalyst app actor. Required for the Linear app-actor comms channel — when the daemon mirrors phase-agent output to Linear and wakes on human replies; leave `null` otherwise |
+| `catalyst.linear.bot.worker.botUserId` | Linear user UUID of the worker app actor. Suppresses self-echo on the worker's own mirror comments / description updates |
+| `catalyst.linear.bot.orchestrator.botUserId` | Linear user UUID of the orchestrator app actor. Suppresses self-echo on orchestrator-posted updates |
+| `catalyst.linear.bot.worker.{clientId,clientSecret,webhookSecret,accessToken}` | OAuth app-actor credentials for the worker identity. Secrets — keep in the un-committed global config |
+
+### Back-compat (transition period)
+
+Every reader prefers the new global path and falls back to the old location, so a running daemon or webhook receiver keeps working whether the value has been migrated yet:
+
+- **Bot IDs:** `catalyst.linear.bot.{worker,orchestrator}.botUserId` (global) → fall back to `catalyst.monitor.linear.botUserId` (per-repo `.catalyst/config.json`, the legacy single-actor location).
+- **Worker OAuth creds:** `catalyst.linear.bot.worker.{clientId,clientSecret}` (global) → fall back to `catalyst.linear.agent.{clientId,clientSecret}` (per-team `~/.config/catalyst/config-{projectKey}.json`, the legacy location).
+
+The legacy keys remain readable, so you can migrate the values at any time without coordinating a restart.
 
 ### Why it's required
 
-Catalyst's app identity lets it post comments as the app, and a human reply on a ticket can wake a parked worker. To make that work, the system must tell the agent's **own** comments and description updates apart from a human's. Without `botUserId` loaded, it can't:
+Catalyst's app identity lets it post comments as the app, and a human reply on a ticket can wake a parked worker. To make that work, the system must tell the agent's **own** comments and description updates apart from a human's. Without a `botUserId` loaded:
 
 - The agent's own mirror comments get written into the worker inbox as if a human had replied — noise, and a false "human replied" signal.
 - Bot-authored issue events feed back into the event log as write loops.
 
-So `botUserId` is the self-echo and loop-prevention guard for the whole Linear-for-Agents channel. Set it for any workspace that uses the app-actor comms.
+So the `botUserId` set is the self-echo and loop-prevention guard for the whole Linear-for-Agents channel. Set at least the worker `botUserId` for any workspace that uses the app-actor comms.
 
 ### How to obtain it
 
-Query `viewer.id` with the app-actor token. The app OAuth credentials live in the secrets file under `catalyst.linear.agent`:
+Query `viewer.id` with each app-actor token. The app OAuth credentials live in the global secrets file under `catalyst.linear.bot.{worker,orchestrator}` (legacy: `catalyst.linear.agent` in the per-team file):
 
 ```bash
-TOKEN=$(jq -r '.catalyst.linear.agent.accessToken' ~/.config/catalyst/config-{projectKey}.json)
+TOKEN=$(jq -r '.catalyst.linear.bot.worker.accessToken // .catalyst.linear.agent.accessToken' ~/.config/catalyst/config.json)
 BOT_ID=$(curl -s -X POST https://api.linear.app/graphql \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"query":"query{viewer{id name}}"}' | jq -r .data.viewer.id)
 ```
 
-Write `$BOT_ID` into `.catalyst/config.json` under `catalyst.monitor.linear.botUserId`, then restart both readers — they only load it at startup:
+Write `$BOT_ID` into `~/.config/catalyst/config.json` under `catalyst.linear.bot.worker.botUserId` (repeat for the orchestrator actor), then restart both readers — they only load it at startup:
 
 ```bash
 catalyst-monitor stop && catalyst-monitor start


### PR DESCRIPTION
Linear OAuth apps are **account-level** (one app, all teams), so the worker + orchestrator app-actor creds and bot identities belong in the **global** `~/.config/catalyst/config.json` under `catalyst.linear.bot.{worker,orchestrator}` — not the per-team config.

Every runtime reader now resolves the **NEW global path first, falling back to the OLD location**, so the values can migrate **without breaking running workers/webhooks**:
- creds → `catalyst.linear.bot.worker.*` then fallback `catalyst.linear.agent.*`
- self-echo botUserId → a **Set** of `catalyst.linear.bot.{worker,orchestrator}.botUserId` then fallback `catalyst.monitor.linear.botUserId` — the guard now suppresses **both** app-actors.

**Verified:** review `ship`, `safeToMergeBeforeValueMigration: true`, 0 must-fix. All cases green incl. the must-pass **OLD-only fallback** (running worker mid-migration). Tests: 11 linear-comment-post + 78 daemon + 121 orch-monitor, `tsc` clean. **No secret values moved** (code-only). Bonus: fixed a latent `.projectKey` → `.catalyst.projectKey` resolution bug.

Code-first, values-last by design — nothing breaks at any step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)