### PR TITLE
feat(dev): CTL-784 batch per-tick Linear reads into one filtered query

### DIFF
--- a/plugins/dev/scripts/execution-core/__tests__/fake-bin/curl
+++ b/plugins/dev/scripts/execution-core/__tests__/fake-bin/curl
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Fake `curl` for hermetic execution-core tests (CTL-784). The ONLY production
+# curl in this package is linear-query.mjs defaultBatchExec (the batched
+# GraphQL read). This records the invocation and returns a benign, shape-valid
+# EMPTY result in the exact form `curl -w "\n%{http_code}"` produces: the
+# response body, a newline, then the HTTP status with NO trailing newline. So a
+# test that reaches the default batch exec (a missed fetchBatch injection) gets
+# an empty node set → every id is absent → the admission gate fails SAFE (holds)
+# and the assertion fails loudly, instead of hitting api.linear.app. A non-empty
+# `curl ...` line in .fake-bin-invocations.log is the leak surface.
+printf 'curl %s\n' "$*" >>"${CATALYST_FAKE_BIN_LOG:-/dev/null}" 2>/dev/null
+printf '%s\n200' '{"data":{"issues":{"nodes":[]}}}'
+exit 0

--- a/plugins/dev/scripts/execution-core/linear-cache.mjs
+++ b/plugins/dev/scripts/execution-core/linear-cache.mjs
@@ -1,4 +1,4 @@
-// linear-cache.mjs — in-process TTL cache for single-ticket Linear state reads
+// linear-cache.mjs — in-process TTL cache for single-ticket Linear reads
 // (CTL-634 Tier 1). One instance is created by startDaemon and shared by the
 // scheduler's out-of-set blocker hydration (read path) and the monitor's
 // state_changed handler (write-through). Cuts `linearis issues read` calls the
@@ -9,14 +9,37 @@
 // null/undefined value — a failed `linearis issues read` must stay un-cached so
 // the D5 fail-safe sentinel (UNFETCHED_BLOCKER_STATE) is never poisoned and a
 // recovered blocker is re-read promptly.
+//
+// CTL-784: two stores in one instance.
+//   1. `entries` — string STATE keyed by identifier (the original CTL-634 cache).
+//      Written-through by the monitor on every state_changed; read by
+//      fetchTicketState. The `get`/`set`/`invalidate`/`stats` contract is
+//      UNCHANGED — `set` stores only a string and has no side effect on the
+//      relations store, so a setRelations() priming a state never trips an
+//      invalidation, and the monitor write-through stays byte-for-byte.
+//   2. `relationsEntries` — the FULL relation descriptor
+//      ({ state, relations, inverseRelations, priority, labels }) keyed by
+//      identifier, with its own TTL. This is the read-through store
+//      fetchTicketsBatch / fetchTicketRelations populate and consult so the
+//      admission pool's per-tick relation reads collapse to one batched query
+//      per TTL window. getRelations OVERLAYS the freshest state from `entries`
+//      (the monitor keeps it current) onto the cached descriptor, so a cached
+//      edge set is returned with up-to-date state even when only the state
+//      changed — edges (rarely-changing) carry the ≤TTL staleness, state does
+//      not. Storing the descriptor in a SEPARATE map is required: writing an
+//      object under an `entries` key would return an object to fetchTicketState's
+//      string-typed terminal-state checks and silently corrupt them.
 
 // Default 60 s TTL; env-overridable to match the SCHEDULER_*_MS env idiom.
 const DEFAULT_TTL_MS = Number(process.env.LINEAR_STATE_CACHE_TTL_MS) || 60_000;
 
 export function createTicketStateCache({ now = Date.now, ttlMs = DEFAULT_TTL_MS } = {}) {
   const entries = new Map(); // identifier -> { state, expiresAt }
+  const relationsEntries = new Map(); // identifier -> { desc, expiresAt } (CTL-784)
   let hits = 0;
   let misses = 0;
+  let relHits = 0;
+  let relMisses = 0;
 
   function get(identifier) {
     const entry = entries.get(identifier);
@@ -35,8 +58,39 @@ export function createTicketStateCache({ now = Date.now, ttlMs = DEFAULT_TTL_MS 
     entries.set(identifier, { state, expiresAt: now() + ttlMs });
   }
 
+  // getRelations — CTL-784 read-through for the full relation descriptor. TTL is
+  // governed by the relations entry (the edges); the state field is OVERLAID
+  // from the live state cache when present (the monitor write-through keeps it
+  // fresh) so a cached descriptor never returns a stale state. Returns undefined
+  // on a cold/expired miss so fetchTicketsBatch treats it as a fetch.
+  function getRelations(identifier) {
+    const entry = relationsEntries.get(identifier);
+    if (entry && entry.expiresAt > now()) {
+      relHits += 1;
+      const stateEntry = entries.get(identifier);
+      const freshState =
+        stateEntry && stateEntry.expiresAt > now() ? stateEntry.state : entry.desc.state;
+      return { ...entry.desc, state: freshState };
+    }
+    if (entry) relationsEntries.delete(identifier); // expired — drop eagerly
+    relMisses += 1;
+    return undefined;
+  }
+
+  // setRelations — CTL-784. Store the full descriptor (edges + state + priority +
+  // labels) AND prime the string-state cache via set() so a subsequent
+  // fetchTicketState(id, { cache }) is a hit. set() has no side effect on
+  // relationsEntries, so priming the state never evicts the descriptor we just
+  // wrote. A null descriptor is never cached (fail-safe, mirrors set()).
+  function setRelations(identifier, desc) {
+    if (desc == null) return;
+    relationsEntries.set(identifier, { desc, expiresAt: now() + ttlMs });
+    set(identifier, desc.state); // prime state (set() null-guards desc.state)
+  }
+
   function invalidate(identifier) {
     entries.delete(identifier);
+    relationsEntries.delete(identifier);
   }
 
   function stats() {
@@ -44,5 +98,13 @@ export function createTicketStateCache({ now = Date.now, ttlMs = DEFAULT_TTL_MS 
     return { hits, misses, hitRate: total === 0 ? 0 : hits / total };
   }
 
-  return { get, set, invalidate, stats };
+  // relationsStats — CTL-784 per-tick observability for the relation read-through
+  // store, kept separate from stats() so the CTL-634 stats() contract (and its
+  // tests) stay byte-identical.
+  function relationsStats() {
+    const total = relHits + relMisses;
+    return { hits: relHits, misses: relMisses, hitRate: total === 0 ? 0 : relHits / total };
+  }
+
+  return { get, set, getRelations, setRelations, invalidate, stats, relationsStats };
 }

--- a/plugins/dev/scripts/execution-core/linear-cache.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-cache.test.mjs
@@ -82,3 +82,98 @@ describe("createTicketStateCache", () => {
     expect(c.stats().hitRate).toBe(0);
   });
 });
+
+// CTL-784 — the relations read-through store (getRelations / setRelations) lives
+// in a SEPARATE map from the string-state store, with its own TTL. The state
+// store (get/set/stats) contract above is unchanged by these.
+describe("createTicketStateCache — relations store (CTL-784)", () => {
+  const desc = (state, extra = {}) => ({
+    state,
+    relations: { nodes: [] },
+    inverseRelations: { nodes: [] },
+    priority: 2,
+    labels: [],
+    ...extra,
+  });
+
+  it("returns undefined on a cold relations miss", () => {
+    const c = createTicketStateCache({ now: () => 0 });
+    expect(c.getRelations("CTL-1")).toBeUndefined();
+  });
+
+  it("returns a set descriptor within the TTL window", () => {
+    let t = 0;
+    const c = createTicketStateCache({ now: () => t, ttlMs: 60_000 });
+    c.setRelations("CTL-1", desc("Triage", { priority: 3 }));
+    t = 59_000;
+    const got = c.getRelations("CTL-1");
+    expect(got.state).toBe("Triage");
+    expect(got.priority).toBe(3);
+    expect(got.relations).toEqual({ nodes: [] });
+  });
+
+  it("expires a descriptor past the TTL window (returns undefined)", () => {
+    let t = 0;
+    const c = createTicketStateCache({ now: () => t, ttlMs: 60_000 });
+    c.setRelations("CTL-1", desc("Triage"));
+    t = 60_001;
+    expect(c.getRelations("CTL-1")).toBeUndefined();
+  });
+
+  it("setRelations primes the state cache so fetchTicketState-style get() hits", () => {
+    const c = createTicketStateCache({ now: () => 0 });
+    c.setRelations("CTL-1", desc("Done"));
+    expect(c.get("CTL-1")).toBe("Done"); // state store primed
+  });
+
+  it("getRelations overlays the freshest state from the state cache (write-through wins)", () => {
+    let t = 0;
+    const c = createTicketStateCache({ now: () => t, ttlMs: 60_000 });
+    c.setRelations("CTL-1", desc("Triage"));
+    // monitor write-through updates the STATE on a state_changed event
+    c.set("CTL-1", "In Progress");
+    const got = c.getRelations("CTL-1");
+    expect(got.state).toBe("In Progress"); // overlaid, not the stale "Triage"
+    expect(got.relations).toEqual({ nodes: [] }); // edges still from the descriptor
+  });
+
+  it("getRelations falls back to the descriptor state when the state entry expired", () => {
+    let t = 0;
+    const c = createTicketStateCache({ now: () => t, ttlMs: 60_000 });
+    c.setRelations("CTL-1", desc("Triage"));
+    // advance past the state TTL but the relations entry was re-set later
+    t = 30_000;
+    c.setRelations("CTL-1", desc("Backlog"));
+    t = 30_000 + 59_000; // state entry (set at 30_000) still fresh here
+    expect(c.getRelations("CTL-1").state).toBe("Backlog");
+  });
+
+  it("never stores a null descriptor (fail-safe)", () => {
+    const c = createTicketStateCache({ now: () => 0 });
+    c.setRelations("CTL-1", null);
+    c.setRelations("CTL-2", undefined);
+    expect(c.getRelations("CTL-1")).toBeUndefined();
+    expect(c.getRelations("CTL-2")).toBeUndefined();
+  });
+
+  it("invalidate drops BOTH the state and relations entries", () => {
+    const c = createTicketStateCache({ now: () => 0 });
+    c.setRelations("CTL-1", desc("Done"));
+    c.invalidate("CTL-1");
+    expect(c.getRelations("CTL-1")).toBeUndefined();
+    expect(c.get("CTL-1")).toBeUndefined();
+  });
+
+  it("relationsStats counts relation hits/misses separately from stats()", () => {
+    const c = createTicketStateCache({ now: () => 0 });
+    c.getRelations("CTL-1"); // rel miss
+    c.setRelations("CTL-1", desc("Done"));
+    c.getRelations("CTL-1"); // rel hit
+    const rs = c.relationsStats();
+    expect(rs.hits).toBe(1);
+    expect(rs.misses).toBe(1);
+    expect(rs.hitRate).toBeCloseTo(1 / 2, 5);
+    // state-store stats untouched by relation lookups (only the setRelations prime)
+    expect(c.stats().hits).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -5,11 +5,34 @@
 // post-filter that linearis cannot express server-side.
 
 import { spawnSync } from "node:child_process";
-import { withBreaker } from "./linear-breaker.mjs";
+import { existsSync } from "node:fs";
+import { withBreaker, linearBreaker, isRateLimitError } from "./linear-breaker.mjs";
 
 // linearis caps a single page; 200 comfortably covers a project's pickable
 // set without pagination (the reconcile poll runs every 10 min anyway).
 const DEFAULT_LIMIT = 200;
+
+// CTL-784: batched multi-issue read. The Linear GraphQL endpoint, the named
+// operation (so the proxy audit can tell a batch read apart from the per-ticket
+// `GetIssueByIdentifier` storm), and the chunk ceiling (Linear caps a page at
+// 250; one identifier yields ≤1 issue so 250 ids fit one page). The projection
+// is a structural match for normalizeRelations / the dependency-graph consumers:
+// state{name}, labels{nodes{name}}, relations{nodes{type relatedIssue{identifier}}},
+// inverseRelations{nodes{type issue{identifier}}}.
+const LINEAR_GRAPHQL_ENDPOINT = "https://api.linear.app/graphql";
+const BATCH_CHUNK_SIZE = 250;
+const BATCH_QUERY = `query CtlBatchTickets($ids: [ID!]) {
+  issues(filter: { id: { in: $ids } }, first: ${BATCH_CHUNK_SIZE}) {
+    nodes {
+      identifier
+      priority
+      state { name }
+      labels(first: 50) { nodes { name } }
+      relations(first: 100) { nodes { type relatedIssue { identifier } } }
+      inverseRelations(first: 100) { nodes { type issue { identifier } } }
+    }
+  }
+}`;
 
 // buildLinearisArgs — argv for `linearis issues list`. `--status` requires
 // `--team` (linearis/SKILL.md), so a null team is unsatisfiable and throws.
@@ -130,30 +153,171 @@ export function fetchTicketState(identifier, { exec = defaultExec, cache } = {})
 // fails SAFE (treats the candidate as held / non-terminal) just like the D5
 // fetchTicketState contract.
 //
-// CTL-634 cache sharing: the opt-in `cache` is the SAME createTicketStateCache
-// fetchTicketState uses. We populate it with the string `state` only, so a
-// subsequent fetchTicketState(id, { cache }) is a hit. relations/priority/labels
-// are returned UNCACHED (one read per call): the cache stores a single value per
-// key and is string-state-typed, so writing a relations object under the same
-// key would corrupt fetchTicketState's reads. Within a single STEP-A tick this
-// costs nothing — the relations come from the same read that populates state.
+// CTL-784 read-through: the opt-in `cache` is the SAME createTicketStateCache
+// fetchTicketState uses, now with a relations store (getRelations/setRelations).
+// fetchTicketRelations READS that store first (the gap the CTL-784 handoff
+// identified: the old code WROTE the state cache but never read relations, so
+// the admission pool re-read every tick regardless of TTL). A relations hit
+// returns the cached descriptor (state overlaid fresh from the monitor
+// write-through) with NO exec. The miss path is the live `linearis issues read`,
+// which then populates BOTH the relations store and (via setRelations priming)
+// the string-state store, so a subsequent fetchTicketState(id, { cache }) hits.
 export function fetchTicketRelations(identifier, { exec = defaultExec, cache } = {}) {
+  if (cache) {
+    const hit = cache.getRelations?.(identifier);
+    if (hit !== undefined) return hit; // read-through hit — no exec
+  }
   const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
   if (code !== 0) return null; // fail-safe — not cached
   try {
-    const node = JSON.parse(stdout);
-    const state = node?.state?.name ?? node?.state ?? null;
-    if (cache && state != null) cache.set(identifier, state); // share with fetchTicketState
-    return {
-      state,
-      relations: node?.relations ?? { nodes: [] },
-      inverseRelations: node?.inverseRelations ?? { nodes: [] },
-      priority: typeof node?.priority === "number" ? node.priority : null,
-      labels: node?.labels?.nodes?.map((n) => n.name) ?? [],
-    };
+    const desc = normalizeRelations(JSON.parse(stdout));
+    if (cache && desc.state != null) cache.setRelations?.(identifier, desc); // read-through + prime state
+    return desc;
   } catch {
     return null; // unparseable — not cached
   }
+}
+
+// normalizeRelations — flatten one issue node (from `linearis issues read` OR
+// the batched GraphQL query — both return the same nested shape) into the
+// descriptor the admission gate consumes: { state, relations, inverseRelations,
+// priority, labels }. NOTE: deliberately does NOT include `identifier` so the
+// shape stays byte-identical to the legacy fetchTicketRelations return (callers
+// and tests rely on it); fetchTicketsBatch keys its Map on node.identifier
+// separately. A missing priority normalizes to null ("unknown"), matching
+// fetchTicketRelations (NOT normalizeTicket's eligible-set default of 0).
+function normalizeRelations(node) {
+  return {
+    state: node?.state?.name ?? node?.state ?? null,
+    relations: node?.relations ?? { nodes: [] },
+    inverseRelations: node?.inverseRelations ?? { nodes: [] },
+    priority: typeof node?.priority === "number" ? node.priority : null,
+    labels: node?.labels?.nodes?.map((n) => n.name) ?? [],
+  };
+}
+
+// authHeader — CTL-784. Linear's documented contract: an OAuth access token
+// (the daemon's app-actor token, minted client_credentials, prefix `lin_oauth_`)
+// is sent `Authorization: Bearer <token>` — matching lib/linear-comment-post.sh
+// which posts as the SAME app-actor; a personal API key (`lin_api_`) is sent raw.
+// (Empirically Linear accepts an OAuth token both ways, but Bearer is the
+// contract + future-proof, and personal keys must stay raw — Bearer may be
+// rejected for them.) Exported for unit coverage of the otherwise prod-only path.
+export function authHeader(token = "") {
+  return /^lin_oauth/i.test(token) ? `Bearer ${token}` : token;
+}
+
+// isBatchRateLimited — a GraphQL errors[] signals a rate/complexity limit either
+// via extensions.code === "RATELIMITED" (Linear's complexity/soft limit, served
+// HTTP 400 not 429) OR a rate-limit message. Either must open the CTL-679 breaker
+// so the larger batch payload backs off instead of re-firing every tick.
+// Exported for unit coverage.
+export function isBatchRateLimited(errors) {
+  return (errors ?? []).some(
+    (e) => e?.extensions?.code === "RATELIMITED" || isRateLimitError(e?.message),
+  );
+}
+
+// buildBatchCurlArgs — CTL-784. The curl argv + stdin payload for ONE batched
+// GraphQL POST. Exported so the auth scheme, `--cacert` gating, and projection
+// are unit-tested (the live spawn path is otherwise prod-only). `--cacert` is
+// added only when NODE_EXTRA_CA_CERTS points at a real file (the mitmproxy audit:
+// curl then trusts the MITM CA and the inherited HTTPS_PROXY routes the call so
+// it is captured as `query CtlBatchTickets`); production (no proxy) goes direct.
+export function buildBatchCurlArgs(ids, { token = "", ca } = {}) {
+  const payload = JSON.stringify({ query: BATCH_QUERY, variables: { ids } });
+  const caArgs = ca && existsSync(ca) ? ["--cacert", ca] : [];
+  const args = [
+    "-sS",
+    "--max-time",
+    "30",
+    ...caArgs,
+    "-X",
+    "POST",
+    LINEAR_GRAPHQL_ENDPOINT,
+    "-H",
+    `Authorization: ${authHeader(token)}`,
+    "-H",
+    "Content-Type: application/json",
+    "-w",
+    "\n%{http_code}",
+    "--data",
+    "@-", // read the payload from stdin (no argv length limit / shell escaping)
+  ];
+  return { args, payload };
+}
+
+// defaultBatchExec — CTL-784. ONE synchronous GraphQL POST (via curl, to keep
+// the scheduler tick synchronous — making the tick async would break the
+// no-overlapping-tick invariant) returning the issues nodes array, or null on
+// any failure (caller fails safe). Integrated with the SAME process-wide circuit
+// breaker as the per-ticket reads: an open breaker short-circuits without
+// spawning; a 429 (HTTP) or a RATELIMITED GraphQL error body opens it; a clean
+// response closes it. Auth uses LINEAR_API_TOKEN/LINEAR_API_KEY (the daemon
+// exports the orchestrator app-actor token, CTL-785).
+function defaultBatchExec(ids) {
+  if (linearBreaker.isOpen()) return null; // circuit-open → skip, no spawn
+  const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
+  const { args, payload } = buildBatchCurlArgs(ids, { token, ca: process.env.NODE_EXTRA_CA_CERTS });
+  const res = spawnSync("curl", args, { input: payload, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+  if (res.status !== 0) return null; // curl/network failure — fail-safe, no breaker change
+  const out = res.stdout ?? "";
+  const nl = out.lastIndexOf("\n");
+  const httpCode = Number(out.slice(nl + 1).trim());
+  const body = out.slice(0, Math.max(0, nl));
+  if (httpCode === 429) {
+    linearBreaker.recordRateLimited();
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null; // unparseable — fail-safe
+  }
+  if (parsed?.errors) {
+    if (isBatchRateLimited(parsed.errors)) linearBreaker.recordRateLimited();
+    return null; // GraphQL-level error (incl. auth / RATELIMITED) — fail-safe
+  }
+  linearBreaker.recordSuccess();
+  return parsed?.data?.issues?.nodes ?? [];
+}
+
+// fetchTicketsBatch — CTL-784 THE root fix. Resolve the relation descriptors for
+// a SET of identifiers in ONE request instead of N per-ticket reads. Returns a
+// Map<identifier, descriptor> (descriptor = normalizeRelations shape). Cache-
+// first: identifiers already in the relations read-through store are served from
+// cache; only the MISSES are fetched, chunked at ≤250. An identifier that the
+// query does not return (not-found / dropped) is ABSENT from the Map so the
+// caller fails safe (treats it as held / unfetched), exactly like a null
+// fetchTicketRelations. `exec` is the injection seam (defaults to the curl
+// batch exec); tests inject a fake `(ids) => nodes[]` so no test shells out.
+export function fetchTicketsBatch(identifiers, { exec = defaultBatchExec, cache } = {}) {
+  const ids = [...new Set((identifiers ?? []).filter(Boolean))];
+  const result = new Map();
+  if (ids.length === 0) return result;
+
+  const misses = [];
+  for (const id of ids) {
+    const hit = cache?.getRelations?.(id);
+    if (hit !== undefined) result.set(id, hit);
+    else misses.push(id);
+  }
+
+  for (let i = 0; i < misses.length; i += BATCH_CHUNK_SIZE) {
+    const chunk = misses.slice(i, i + BATCH_CHUNK_SIZE);
+    const nodes = exec(chunk);
+    if (nodes == null) continue; // batch failed → those ids stay absent (fail-safe)
+    for (const node of nodes) {
+      const id = node?.identifier;
+      if (!id) continue;
+      const desc = normalizeRelations(node);
+      result.set(id, desc);
+      if (cache && desc.state != null) cache.setRelations?.(id, desc);
+    }
+    // ids in the chunk not returned by the query stay absent → fail-safe hold.
+  }
+  return result;
 }
 
 // fetchTicketLabels — current label-name list for one ticket, or null on any

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -8,6 +8,10 @@ import {
   fetchTicketState,
   fetchTicketLabels,
   fetchTicketRelations,
+  fetchTicketsBatch,
+  authHeader,
+  buildBatchCurlArgs,
+  isBatchRateLimited,
   classifyTicketResolution,
 } from "./linear-query.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
@@ -460,6 +464,209 @@ describe("fetchTicketRelations (CTL-755)", () => {
       fetchTicketRelations("CTL-1", { exec });
       expect(calls).toBe(2);
     });
+
+    // CTL-784: read-through. A second fetchTicketRelations WITH a cache hits the
+    // relations store and does NOT exec again (the gap the handoff fixed).
+    test("with a cache, a second call is a read-through hit (no second exec)", () => {
+      const cache = createTicketStateCache({ now: () => 0 });
+      let calls = 0;
+      const exec = () => {
+        calls += 1;
+        return {
+          code: 0,
+          stdout: JSON.stringify({ state: { name: "Triage" }, priority: 2 }),
+          stderr: "",
+        };
+      };
+      expect(fetchTicketRelations("CTL-1", { exec, cache }).state).toBe("Triage");
+      expect(fetchTicketRelations("CTL-1", { exec, cache }).state).toBe("Triage");
+      expect(calls).toBe(1); // second call served from the relations read-through store
+    });
+  });
+});
+
+// CTL-784 — fetchTicketsBatch collapses N per-ticket reads into ONE request. The
+// `exec` seam is injected as `(ids) => nodes[]` so no test shells out to curl.
+describe("fetchTicketsBatch (CTL-784)", () => {
+  // A node in the batched GraphQL shape (same nested shape `linearis issues read`
+  // returns): state{name}, labels{nodes{name}}, relations{nodes{...}}.
+  const node = (identifier, { state = "Triage", priority = 2, labels = [], blockedBy } = {}) => ({
+    identifier,
+    priority,
+    state: { name: state },
+    labels: { nodes: labels.map((name) => ({ name })) },
+    relations: { nodes: [] },
+    inverseRelations: blockedBy
+      ? { nodes: [{ type: "blocks", issue: { identifier: blockedBy } }] }
+      : { nodes: [] },
+  });
+
+  test("resolves a set of identifiers in ONE exec call, keyed by identifier", () => {
+    let calls = 0;
+    const exec = (ids) => {
+      calls += 1;
+      return ids.map((id) => node(id, { state: "Done" }));
+    };
+    const map = fetchTicketsBatch(["CTL-1", "CTL-2", "CTL-3"], { exec });
+    expect(calls).toBe(1); // ONE request for all three
+    expect([...map.keys()].sort()).toEqual(["CTL-1", "CTL-2", "CTL-3"]);
+    expect(map.get("CTL-2").state).toBe("Done");
+  });
+
+  test("normalizes each node to the fetchTicketRelations shape (no identifier key)", () => {
+    const exec = (ids) =>
+      ids.map((id) => node(id, { state: "In Progress", priority: 1, labels: ["blocked"], blockedBy: "CTL-9" }));
+    const desc = fetchTicketsBatch(["CTL-1"], { exec }).get("CTL-1");
+    expect(desc).toEqual({
+      state: "In Progress",
+      relations: { nodes: [] },
+      inverseRelations: { nodes: [{ type: "blocks", issue: { identifier: "CTL-9" } }] },
+      priority: 1,
+      labels: ["blocked"],
+    });
+    expect("identifier" in desc).toBe(false); // shape parity with fetchTicketRelations
+  });
+
+  test("dedupes identifiers before the exec", () => {
+    let received = null;
+    const exec = (ids) => {
+      received = ids;
+      return ids.map((id) => node(id));
+    };
+    fetchTicketsBatch(["CTL-1", "CTL-1", "CTL-2"], { exec });
+    expect(received.sort()).toEqual(["CTL-1", "CTL-2"]); // deduped
+  });
+
+  test("chunks >250 identifiers into multiple exec calls", () => {
+    const ids = Array.from({ length: 600 }, (_, i) => `CTL-${i + 1}`);
+    const chunkSizes = [];
+    const exec = (chunk) => {
+      chunkSizes.push(chunk.length);
+      return chunk.map((id) => node(id));
+    };
+    const map = fetchTicketsBatch(ids, { exec });
+    expect(chunkSizes).toEqual([250, 250, 100]);
+    expect(map.size).toBe(600);
+  });
+
+  test("an identifier the query does not return is ABSENT (fail-safe hold)", () => {
+    // exec returns only CTL-1; CTL-MISSING (not-found) is dropped by the query.
+    const exec = () => [node("CTL-1")];
+    const map = fetchTicketsBatch(["CTL-1", "CTL-MISSING"], { exec });
+    expect(map.has("CTL-1")).toBe(true);
+    expect(map.has("CTL-MISSING")).toBe(false); // absent → caller fails safe
+  });
+
+  test("a failed batch (exec returns null) leaves all ids absent (fail-safe)", () => {
+    const exec = () => null; // breaker open / network / 429
+    const map = fetchTicketsBatch(["CTL-1", "CTL-2"], { exec });
+    expect(map.size).toBe(0);
+  });
+
+  test("cache-first: cached ids are served from cache, only misses are fetched", () => {
+    const cache = createTicketStateCache({ now: () => 0 });
+    cache.setRelations("CTL-CACHED", {
+      state: "Backlog",
+      relations: { nodes: [] },
+      inverseRelations: { nodes: [] },
+      priority: 2,
+      labels: [],
+    });
+    let received = null;
+    const exec = (ids) => {
+      received = ids;
+      return ids.map((id) => node(id, { state: "Done" }));
+    };
+    const map = fetchTicketsBatch(["CTL-CACHED", "CTL-FRESH"], { exec, cache });
+    expect(received).toEqual(["CTL-FRESH"]); // only the miss was fetched
+    expect(map.get("CTL-CACHED").state).toBe("Backlog"); // served from cache
+    expect(map.get("CTL-FRESH").state).toBe("Done");
+  });
+
+  test("populates the cache (relations + primed state) on a fetched miss", () => {
+    const cache = createTicketStateCache({ now: () => 0 });
+    const exec = (ids) => ids.map((id) => node(id, { state: "Done" }));
+    fetchTicketsBatch(["CTL-1"], { exec, cache });
+    expect(fetchTicketState("CTL-1", { cache, exec: () => ({ code: 1, stdout: "", stderr: "" }) })).toBe(
+      "Done",
+    ); // state primed → hit, never reaches the failing exec
+    expect(cache.getRelations("CTL-1").state).toBe("Done"); // relations cached
+  });
+
+  test("no exec for an empty / all-cached id set", () => {
+    let calls = 0;
+    const exec = () => {
+      calls += 1;
+      return [];
+    };
+    expect(fetchTicketsBatch([], { exec }).size).toBe(0);
+    expect(fetchTicketsBatch(null, { exec }).size).toBe(0);
+    expect(calls).toBe(0);
+  });
+});
+
+// CTL-784 — the curl-path internals (auth scheme, --cacert gating, RATELIMITED
+// detection) are otherwise only exercised in production (every fetchTicketsBatch
+// test injects a fake exec). These pin them deterministically.
+describe("authHeader (CTL-784)", () => {
+  test("OAuth access token (lin_oauth_) → Bearer scheme", () => {
+    expect(authHeader("lin_oauth_abc123")).toBe("Bearer lin_oauth_abc123");
+  });
+  test("personal API key (lin_api_) → raw (no Bearer)", () => {
+    expect(authHeader("lin_api_xyz")).toBe("lin_api_xyz");
+  });
+  test("empty token → raw empty (no crash)", () => {
+    expect(authHeader("")).toBe("");
+    expect(authHeader()).toBe("");
+  });
+});
+
+describe("buildBatchCurlArgs (CTL-784)", () => {
+  const argFor = (args, flag) => args[args.indexOf(flag) + 1];
+
+  test("posts the named CtlBatchTickets query with the ids as variables, via stdin", () => {
+    const { args, payload } = buildBatchCurlArgs(["CTL-1", "CTL-2"], { token: "lin_api_x" });
+    expect(args).toContain("--data");
+    expect(argFor(args, "--data")).toBe("@-"); // payload via stdin, not argv
+    expect(args[args.indexOf("-X") + 1]).toBe("POST");
+    expect(args).toContain("https://api.linear.app/graphql");
+    const body = JSON.parse(payload);
+    expect(body.query).toContain("query CtlBatchTickets");
+    expect(body.variables).toEqual({ ids: ["CTL-1", "CTL-2"] });
+  });
+
+  test("an OAuth token is sent as Bearer in the Authorization header", () => {
+    const { args } = buildBatchCurlArgs(["CTL-1"], { token: "lin_oauth_tok" });
+    expect(argFor(args, "-H")).toBe("Authorization: Bearer lin_oauth_tok");
+  });
+
+  test("a personal token is sent raw in the Authorization header", () => {
+    const { args } = buildBatchCurlArgs(["CTL-1"], { token: "lin_api_tok" });
+    expect(argFor(args, "-H")).toBe("Authorization: lin_api_tok");
+  });
+
+  test("--cacert is added only when the CA file exists (audit proxy), else omitted", () => {
+    const withCa = buildBatchCurlArgs(["CTL-1"], { token: "t", ca: "/etc/hosts" }).args; // exists
+    expect(withCa).toContain("--cacert");
+    expect(argFor(withCa, "--cacert")).toBe("/etc/hosts");
+    const noCa = buildBatchCurlArgs(["CTL-1"], { token: "t", ca: "/no/such/ca.pem" }).args;
+    expect(noCa).not.toContain("--cacert");
+    const undef = buildBatchCurlArgs(["CTL-1"], { token: "t" }).args;
+    expect(undef).not.toContain("--cacert");
+  });
+});
+
+describe("isBatchRateLimited (CTL-784)", () => {
+  test("detects extensions.code === RATELIMITED (Linear soft/complexity limit, HTTP 400)", () => {
+    expect(isBatchRateLimited([{ message: "Something", extensions: { code: "RATELIMITED" } }])).toBe(true);
+  });
+  test("detects a 'rate limit exceeded' message", () => {
+    expect(isBatchRateLimited([{ message: "Rate limit exceeded. Only 5000 requests…" }])).toBe(true);
+  });
+  test("a non-rate-limit GraphQL error is NOT treated as rate-limited", () => {
+    expect(isBatchRateLimited([{ message: "Authentication required", extensions: { code: "AUTHENTICATION_ERROR" } }])).toBe(false);
+    expect(isBatchRateLimited([])).toBe(false);
+    expect(isBatchRateLimited(undefined)).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -61,7 +61,7 @@ import { readVerifyVerdict } from "./work-done-probes.mjs";
 import { countRemediateCycles, countTicketEventsInWindow } from "./event-scan.mjs";
 import { rankTickets, compareTickets } from "./scheduler-rank.mjs";
 import { defaultDispatch, dispatchTicket, teamOf } from "./dispatch.mjs";
-import { fetchTicketState, fetchTicketRelations, classifyTicketResolution } from "./linear-query.mjs";
+import { fetchTicketState, fetchTicketsBatch, classifyTicketResolution } from "./linear-query.mjs";
 import { getProjectConfig, listProjects } from "./registry.mjs";
 import { teardownWorktree as defaultTeardownWorktree } from "./worktree.mjs";
 import { readWorkerSignals } from "./signal-reader.mjs";
@@ -753,20 +753,29 @@ const UNFETCHED_BLOCKER_STATE = "__unfetched__";
 // live Linear state once, and return a { identifier: stateName } map. A failed
 // fetch yields the non-terminal UNFETCHED_BLOCKER_STATE sentinel so the
 // dependent is held back — failing safe. CTL-565 D5.
-// CTL-634: the opt-in `cache` is threaded into each fetchState call so the
-// same out-of-set blocker is read at most once per TTL window across ticks.
-// Absent the cache, every tick re-reads (the pre-CTL-634 behavior).
+// CTL-634: the opt-in `cache` is threaded so the same out-of-set blocker is read
+// at most once per TTL window across ticks. CTL-784: the per-blocker reads are
+// now collapsed into ONE batched query (fetchBatch, the SAME cache-first
+// fetchTicketsBatch the admission gate uses) — externalBlockers resolve in a
+// single request, cache-first, instead of one `linearis issues read` each. A
+// blocker the batch does not return (read failure / not-found) is ABSENT from
+// the map → the UNFETCHED_BLOCKER_STATE sentinel, failing safe exactly as the
+// per-id null read did. Absent a cache, each tick re-batches (one request).
 export function hydrateOutOfSetBlockers(
   eligibleTickets,
-  { exec, fetchState = fetchTicketState, cache } = {}
+  { fetchBatch = fetchTicketsBatch, cache } = {}
 ) {
   const list = eligibleTickets ?? [];
   const inSet = new Set(list.map((t) => t?.identifier).filter(Boolean));
   const externalBlockers = referencedBlockerIds(list).filter((id) => !inSet.has(id));
   const blockerStates = {};
+  if (externalBlockers.length === 0) return blockerStates;
+  // fetchBatch (production: fetchTicketsBatch) owns its own batch exec (the curl
+  // GraphQL POST) — do NOT thread the scheduler's linearis `exec` here (wrong shape).
+  const batch = fetchBatch(externalBlockers, { cache });
   for (const id of externalBlockers) {
-    const state = fetchState(id, { exec, cache });
-    blockerStates[id] = state ?? UNFETCHED_BLOCKER_STATE; // non-terminal → fails safe
+    const desc = batch.get(id);
+    blockerStates[id] = desc?.state ?? UNFETCHED_BLOCKER_STATE; // miss → non-terminal, fails safe
   }
   return blockerStates;
 }
@@ -1768,11 +1777,13 @@ export function schedulerTick(
     // entirely (byte-for-byte legacy dispatch for every test that doesn't inject
     // it). Production wires defaultCheckSequencing via runTick/startScheduler.
     checkSequencing = undefined,
-    // CTL-755: admission-gate hydration seam — fetches one triaged-waiting
-    // candidate's live state + relations + priority + labels in a single
-    // `linearis issues read`. Defaults to the real linear-query helper; tests
-    // inject a stub keyed by identifier so a STEP-A tick never shells out.
-    fetchRelations = fetchTicketRelations,
+    // CTL-755/784: admission-gate hydration seam — resolves the live state +
+    // relations + priority + labels for a SET of tickets in ONE batched,
+    // cache-first request (fetchTicketsBatch → Map<id, descriptor>). Used by
+    // STEP A.3 (triaged-waiting candidates), STEP E (deps), and threaded into
+    // both hydrateOutOfSetBlockers calls. Defaults to the real batch helper;
+    // tests inject a stub `(ids) => Map<id, descriptor>` so a tick never shells out.
+    fetchBatch = fetchTicketsBatch,
     // CTL-755: held-indicator audit emitter — phase.advance.held.<ticket>.
     // Best-effort, only-on-state-change. Mirrors appendDispatchRequestedEvent.
     appendPhaseAdvanceHeldEvent = defaultAppendPhaseAdvanceHeldEvent,
@@ -2082,23 +2093,25 @@ export function schedulerTick(
     }
 
     // A.2 — early-exit when nothing is waiting. Zero Linear cost in the common
-    // path (no fetchRelations, no hydration, no label diff).
+    // path (no fetch, no hydration, no label diff).
     if (triagedWaiting.length > 0) {
-      // A.3 — hydrate each candidate's live state + relations + priority + labels
-      // FRESH via one `linearis issues read` (fetchRelations, shared cache). A
-      // read failure (rel === null) is tracked so the candidate fails SAFE —
-      // it is forced out of readyIds below (A.4), never silently promoted on an
-      // unknown dependency picture. Build pseudo-issue descriptors in the
-      // buildDependencyEdges shape (state re-nested into {name} — fetchRelations
-      // returns a flat string).
+      // A.3 — hydrate every candidate's live state + relations + priority +
+      // labels FRESH in ONE batched, cache-first request (CTL-784 — was one
+      // `linearis issues read` per candidate every tick). A candidate the batch
+      // does not return (read failure / not-found) is ABSENT from the map → it
+      // fails SAFE: tracked in readFailedTickets and forced out of readyIds below
+      // (A.4), never silently promoted on an unknown dependency picture. Build
+      // pseudo-issue descriptors in the buildDependencyEdges shape (state
+      // re-nested into {name} — the descriptor carries a flat string state).
+      const relByTicket = fetchBatch(triagedWaiting, { cache });
       const waitingDescriptors = [];
       const labelsByTicket = new Map(); // ticket → current Linear label set
-      const readFailedTickets = new Set(); // fail-safe: null read → held
+      const readFailedTickets = new Set(); // fail-safe: missing read → held
       for (const ticket of triagedWaiting) {
-        const rel = fetchRelations(ticket, { exec, cache });
+        const rel = relByTicket.get(ticket) ?? null;
         const { priority, createdAt } = readWorkerPriority(orchDir, ticket);
         if (rel === null) readFailedTickets.add(ticket);
-        // null rel → fail-safe: non-terminal sentinel state, no edges, no labels.
+        // missing rel → fail-safe: non-terminal sentinel state, no edges, no labels.
         const stateName = rel?.state ?? UNFETCHED_BLOCKER_STATE;
         labelsByTicket.set(ticket, rel?.labels ?? []);
         waitingDescriptors.push({
@@ -2114,11 +2127,11 @@ export function schedulerTick(
       }
 
       // A.4 — combined dep analysis over candidates + eligible new work. Hydrates
-      // BOTH pools' out-of-set blockers once (closes the D5 fail-open gap). The
-      // candidates are not in `eligible`, so they cannot leak into sweep-2
-      // selection — sweep 2 keeps its own computation over `eligible` unchanged.
+      // BOTH pools' out-of-set blockers in one batched request (closes the D5
+      // fail-open gap). The candidates are not in `eligible`, so they cannot leak
+      // into sweep-2 selection — sweep 2 keeps its own computation over `eligible`.
       const admissionPool = [...eligible, ...waitingDescriptors];
-      const admissionBlockerStates = hydrateOutOfSetBlockers(admissionPool, { exec, cache });
+      const admissionBlockerStates = hydrateOutOfSetBlockers(admissionPool, { cache, fetchBatch });
       const graph = analyzeDependencyGraph(admissionPool, {
         blockerStates: admissionBlockerStates,
       });
@@ -2238,11 +2251,25 @@ export function schedulerTick(
       const descriptorByTicket = new Map(
         waitingDescriptors.map((d) => [d.identifier, d]),
       );
+      // CTL-784: pre-collect every (non-cycle) candidate's triage.json deps and
+      // resolve their live Linear states in ONE batched, cache-first request —
+      // was one fetchTicketState per dep per candidate. The per-dep loop below
+      // reads state from this map; a dep the batch does not return (404 /
+      // unresolvable / prose-only token) is ABSENT → dropped, exactly like the
+      // prior null fetchTicketState. Most deps are already warm from A.3/A.4.
+      const depIdsByCandidate = new Map();
+      const allDepIds = new Set();
       for (const candidate of triagedWaiting) {
-        // Cycle members are owned by needs-human; do not also write deps for them.
-        if (cycleMembers.has(candidate)) continue;
+        if (cycleMembers.has(candidate)) continue; // owned by needs-human
         const depIds = readTriageDependencies(orchDir, candidate);
         if (depIds.length === 0) continue;
+        depIdsByCandidate.set(candidate, depIds);
+        for (const dep of depIds) allDepIds.add(dep);
+      }
+      const depBatch = fetchBatch([...allDepIds], { cache });
+      for (const candidate of triagedWaiting) {
+        const depIds = depIdsByCandidate.get(candidate);
+        if (!depIds) continue; // cycle member or no deps
 
         const desc = descriptorByTicket.get(candidate);
         // Already-durable blocked_by blockers for THIS candidate, read from its
@@ -2279,12 +2306,13 @@ export function schedulerTick(
             );
             continue;
           }
-          // Resolve the dep's live Linear state. A null read (404 / unparseable /
-          // prose-only token that is not a real ticket) is dropped — we never
-          // persist an edge to a ticket we cannot resolve. A TERMINAL dep
-          // (Done/Canceled) is a no-op blocker, so do not write a durable edge
-          // for it (it would never hold the gate and only adds Linear noise).
-          const depState = fetchTicketState(dep, { exec, cache });
+          // Resolve the dep's live Linear state from the batch (CTL-784). An
+          // absent dep (404 / unparseable / prose-only token that is not a real
+          // ticket) is dropped — we never persist an edge to a ticket we cannot
+          // resolve. A TERMINAL dep (Done/Canceled) is a no-op blocker, so do
+          // not write a durable edge for it (it would never hold the gate and
+          // only adds Linear noise).
+          const depState = depBatch.get(dep)?.state ?? null;
           if (depState == null) continue; // unresolvable → drop
           if (ADMISSION_TERMINAL_STATES.has(depState)) continue; // terminal → no durable edge
 
@@ -2292,6 +2320,14 @@ export function schedulerTick(
             () => writeStatus.applyBlockedByRelation({ ticket: candidate, blockedBy: dep }),
             { ticket: candidate, phase: "triage-deps" },
           );
+          // CTL-784: we just wrote a NEW durable blocked_by edge for this
+          // candidate. Its cached relations descriptor (read this tick by A.3)
+          // does NOT carry the edge, so without invalidation a freed-slot tick
+          // within the TTL window would serve the stale no-edge descriptor and
+          // OVER-PROMOTE the candidate past its open blocker. Drop the cache
+          // entry so the next tick re-reads fresh and the gate holds. (The OLD
+          // per-tick fresh read had no such window.)
+          cache?.invalidate?.(candidate);
         }
       }
     }
@@ -2681,11 +2717,15 @@ export function schedulerTick(
   // blocked by a non-terminal out-of-set ticket is held back. `eligible` was
   // computed once at the top of the tick (CTL-671) and is reused here.
   // CTL-705: `eligible` is hoisted above sweep 0.5 — used by buildGlobalRanking there.
-  const blockerStates = hydrateOutOfSetBlockers(eligible, { exec, cache });
+  const blockerStates = hydrateOutOfSetBlockers(eligible, { cache, fetchBatch });
   // CTL-634: surface the cache hit-rate once per tick. Log-line-only matches
   // the daemon's pino-only observability convention (schedulerTick's return
   // object is discarded by runTick, so a metric must be logged, not returned).
-  if (cache) log.info(cache.stats(), "scheduler: cache stats");
+  if (cache) {
+    log.info(cache.stats(), "scheduler: cache stats");
+    // CTL-784: surface the relation read-through hit-rate too (separate store).
+    if (cache.relationsStats) log.info(cache.relationsStats(), "scheduler: relations cache stats");
+  }
   // CTL-695: per-tick reaper telemetry — otel-forward ships this pino line as a
   // gauge (same log-line-only convention as cache.stats / per-project slots).
   log.info(countReapOutcomes(), "scheduler: reap stats");
@@ -3082,10 +3122,10 @@ function runTick() {
       // CTL-537: production defaults to defaultCheckSequencing; tests inject via
       // startScheduler({ checkSequencing }) or directly into schedulerTick.
       checkSequencing: runningOpts.checkSequencing ?? defaultCheckSequencing,
-      // CTL-755: admission-gate seams. Undefined here keeps schedulerTick's
-      // production defaults (fetchTicketRelations / defaultAppendPhaseAdvanceHeldEvent);
+      // CTL-755/784: admission-gate seams. Undefined here keeps schedulerTick's
+      // production defaults (fetchTicketsBatch / defaultAppendPhaseAdvanceHeldEvent);
       // tests inject a stub through startScheduler so a daemon tick never shells out.
-      fetchRelations: runningOpts.fetchRelations,
+      fetchBatch: runningOpts.fetchBatch,
       appendPhaseAdvanceHeldEvent: runningOpts.appendPhaseAdvanceHeldEvent,
       // CTL-642/758: the LIVE PR-merged adapter. Without this the recovery
       // short-circuit's pr-merged branch (terminal-state.mjs) AND the reconcile
@@ -3146,7 +3186,7 @@ export function startScheduler({
   // exec / writeStatus / teardownWorktree seams on schedulerTick.
   livenessIsFresh, // CTL-731: optional override; runTick defaults to getAgentsCached().isFresh.
   checkSequencing, // CTL-537: optional override; runTick defaults to defaultCheckSequencing.
-  fetchRelations, // CTL-755: optional override; schedulerTick defaults to fetchTicketRelations.
+  fetchBatch, // CTL-755/784: optional override; schedulerTick defaults to fetchTicketsBatch.
   appendPhaseAdvanceHeldEvent, // CTL-755: optional override; defaults to defaultAppendPhaseAdvanceHeldEvent.
   // CTL-642/758: the LIVE PR-merged adapter, wired into the production daemon
   // path so the recovery short-circuit's pr-merged branch + the reconcile
@@ -3190,7 +3230,7 @@ export function startScheduler({
     liveBackgroundCount, // CTL-676: test seam
     livenessIsFresh, // CTL-731: optional override (default getAgentsCached().isFresh)
     checkSequencing, // CTL-537: optional override (default defaultCheckSequencing)
-    fetchRelations, // CTL-755: optional admission-gate hydration seam
+    fetchBatch, // CTL-755/784: optional admission-gate batch hydration seam
     appendPhaseAdvanceHeldEvent, // CTL-755: optional held-indicator emit seam
     prAdapter, // CTL-642/758: live PR-merged adapter (built once above), threaded per-tick
     classifyResolution, // CTL-671: optional phantom-sweep Linear-probe seam

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -67,6 +67,7 @@ import {
   readDispatchFailureReason,
 } from "./scheduler.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
+import { fetchTicketsBatch } from "./linear-query.mjs"; // CTL-784: cache-reuse tests drive the real batch
 import { reclaimDeadWorkIfPossible } from "./recovery.mjs";
 import { REMEDIATE_CYCLE_CAP } from "../lib/phase-fsm.mjs";
 
@@ -722,9 +723,46 @@ function relBlockedBy(blockerId, { priority = 2, labels = [], state = "Triage" }
     labels,
   };
 }
-// A fetchRelations dispatcher keyed by ticket id, falling back to relUnblocked.
+// A per-id descriptor dispatcher keyed by ticket id, falling back to relUnblocked.
 function relMap(map) {
   return (id) => map[id] ?? relUnblocked();
+}
+
+// CTL-784: the admission gate now hydrates via a single batched seam
+// (fetchBatch: (ids) => Map<id, descriptor>) instead of per-ticket fetchRelations
+// / per-blocker fetchTicketState. These helpers build that seam from the same
+// per-id descriptor fakes (relUnblocked / relBlockedBy / relMap).
+
+// mkBatch — wrap a per-id descriptor source (a function or an {id: desc} object)
+// into a fetchBatch. A source returning null/undefined for an id OMITS it from
+// the Map, mirroring fetchTicketsBatch dropping a failed/not-found id (the
+// admission gate then fails safe — treats it as held / unfetched).
+function mkBatch(source) {
+  const fn = typeof source === "function" ? source : (id) => source[id];
+  return (ids) => {
+    const m = new Map();
+    for (const id of ids) {
+      const d = fn(id);
+      if (d != null) m.set(id, d);
+    }
+    return m;
+  };
+}
+
+// descOf — a state-only descriptor (the hydrate / STEP-E shape: blocker/dep
+// lookups only consult .state). Replaces the old execWithStates/execStates
+// linearis-exec stubs that returned `{ state: { name } }` per `issues read`.
+function descOf(state) {
+  return { state, relations: { nodes: [] }, inverseRelations: { nodes: [] }, priority: null, labels: [] };
+}
+
+// batchWith — a fetchBatch that returns `candidateDesc` for the triaged-waiting
+// candidate(s) and a state-only descriptor for each out-of-set blocker / dep in
+// `stateById`. Replaces the old paired injection
+// `fetchRelations: () => <candidateDesc>` + `exec: execWithStates(stateById)`.
+function batchWith(candidateSource, stateById = {}) {
+  const candFn = typeof candidateSource === "function" ? candidateSource : () => candidateSource;
+  return mkBatch((id) => (id in stateById ? descOf(stateById[id]) : candFn(id)));
 }
 
 // ── CTL-624: per-(ticket,phase) dispatch cool-down helpers ──
@@ -1759,7 +1797,7 @@ describe("schedulerTick — new-work pull", () => {
       verifyDispatched: verifyOk, // CTL-611: bypass dispatch verifier
       // CTL-755: the triage→research promotion is now admission-gated. Stub
       // fetchRelations (unblocked) + a free slot so the gate admits CTL-7.
-      fetchRelations: () => relUnblocked(),
+      fetchBatch: mkBatch(() => relUnblocked()),
       liveBackgroundCount: () => 0,
     });
     expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "research" }]);
@@ -1789,7 +1827,7 @@ describe("schedulerTick — new-work pull", () => {
       readEligible: () => [],
       dispatch: fakeDispatch(),
       verifyDispatched: verifyOk,
-      fetchRelations: () => relUnblocked(),
+      fetchBatch: mkBatch(() => relUnblocked()),
       liveBackgroundCount: () => 0,
       writeStatus,
       appendStateWriteEvent: (ev) => stateWrites.push(ev),
@@ -1819,7 +1857,7 @@ describe("schedulerTick — new-work pull", () => {
       readEligible: () => [],
       dispatch: fakeDispatch(),
       verifyDispatched: verifyOk,
-      fetchRelations: () => relUnblocked(),
+      fetchBatch: mkBatch(() => relUnblocked()),
       liveBackgroundCount: () => 0,
       writeStatus: {
         applyPhaseStatus: () => ({ applied: true, from_state: "Triage", to_state: "Research" }),
@@ -2040,7 +2078,7 @@ describe("schedulerTick — new-work pull", () => {
       // CTL-755: admission-gate seam — CTL-7 (triaged-waiting) is unblocked, so
       // it is admitted and promoted; STEP C subtracts promotedCount so the new
       // CTL-X still gets the remaining free slot (the double-fill invariant).
-      fetchRelations: () => relUnblocked(),
+      fetchBatch: mkBatch(() => relUnblocked()),
     });
     expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
     expect(r.dispatched).toEqual(["CTL-X"]);
@@ -2540,43 +2578,38 @@ describe("hydrateOutOfSetBlockers / D5 readiness", () => {
     inverseRelations: { nodes: [] },
   });
 
-  test("fetches each unique out-of-set blocker once (deduped)", () => {
-    const fetched = [];
-    const exec = (_cmd, args) => {
-      fetched.push(args[2]);
-      return { code: 0, stdout: JSON.stringify({ state: { name: "Backlog" } }), stderr: "" };
+  test("batches the unique out-of-set blockers in one fetchBatch call (deduped)", () => {
+    const fetchedChunks = [];
+    const fetchBatch = (ids) => {
+      fetchedChunks.push(ids);
+      return new Map(ids.map((id) => [id, descOf("Backlog")]));
     };
     const map = hydrateOutOfSetBlockers(
       [blkTk("CTL-1", { blockedBy: "CTL-99" }), blkTk("CTL-2", { blockedBy: "CTL-99" })],
-      { exec }
+      { fetchBatch }
     );
-    expect(fetched).toEqual(["CTL-99"]); // deduped — one fetch
+    expect(fetchedChunks).toEqual([["CTL-99"]]); // deduped — one batched fetch
     expect(map).toEqual({ "CTL-99": "Backlog" });
   });
 
   test("an in-set blocker is not fetched (only out-of-set blockers hydrate)", () => {
-    const fetched = [];
-    const exec = (_cmd, args) => {
-      fetched.push(args[2]);
-      return { code: 0, stdout: JSON.stringify({ state: { name: "Backlog" } }), stderr: "" };
+    let called = false;
+    const fetchBatch = (ids) => {
+      called = true;
+      return new Map(ids.map((id) => [id, descOf("Backlog")]));
     };
     // CTL-2 is in the eligible set, so the CTL-1→CTL-2 edge is in-set.
-    hydrateOutOfSetBlockers([blkTk("CTL-1", { blockedBy: "CTL-2" }), blkTk("CTL-2")], { exec });
-    expect(fetched).toEqual([]);
+    hydrateOutOfSetBlockers([blkTk("CTL-1", { blockedBy: "CTL-2" }), blkTk("CTL-2")], { fetchBatch });
+    expect(called).toBe(false); // no external blockers → no batch
   });
 
   test("a Ready ticket blocked by a Backlog out-of-set blocker is not dispatched", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const dispatch = fakeDispatch({ code: 0 });
-    const exec = () => ({
-      code: 0,
-      stdout: JSON.stringify({ state: { name: "Backlog" } }),
-      stderr: "",
-    });
     schedulerTick(orchDir, {
       readEligible: () => [blkTk("CTL-1", { blockedBy: "CTL-99" })],
       dispatch,
-      exec,
+      fetchBatch: mkBatch({ "CTL-99": descOf("Backlog") }),
     });
     expect(dispatch.calls).toHaveLength(0);
   });
@@ -2584,15 +2617,10 @@ describe("hydrateOutOfSetBlockers / D5 readiness", () => {
   test("a Ready ticket blocked by a Done out-of-set blocker IS dispatched", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const dispatch = fakeDispatch({ code: 0 });
-    const exec = () => ({
-      code: 0,
-      stdout: JSON.stringify({ state: { name: "Done" } }),
-      stderr: "",
-    });
     schedulerTick(orchDir, {
       readEligible: () => [blkTk("CTL-1", { blockedBy: "CTL-99" })],
       dispatch,
-      exec,
+      fetchBatch: mkBatch({ "CTL-99": descOf("Done") }),
       liveBackgroundCount: () => 0,
     });
     expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-1"]);
@@ -2601,11 +2629,10 @@ describe("hydrateOutOfSetBlockers / D5 readiness", () => {
   test("a failed blocker fetch fails safe — the dependent is held back, not dispatched", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const dispatch = fakeDispatch({ code: 0 });
-    const exec = () => ({ code: 1, stdout: "", stderr: "boom" });
     schedulerTick(orchDir, {
       readEligible: () => [blkTk("CTL-1", { blockedBy: "CTL-99" })],
       dispatch,
-      exec,
+      fetchBatch: () => new Map(), // batch failure → CTL-99 absent → UNFETCHED → held
     });
     expect(dispatch.calls).toHaveLength(0);
   });
@@ -2625,29 +2652,33 @@ describe("hydrateOutOfSetBlockers — cache reuse (CTL-634)", () => {
     inverseRelations: { nodes: [] },
   });
 
+  // These drive the REAL fetchTicketsBatch (so the read-through cache is exercised)
+  // with an injected BATCH exec `(ids) => nodes[]`.
   test("reads an out-of-set blocker once across two hydrations within TTL", () => {
     const cache = createTicketStateCache({ now: () => 0, ttlMs: 60_000 });
     const fetched = [];
-    const exec = (_cmd, args) => {
-      fetched.push(args[2]);
-      return { code: 0, stdout: JSON.stringify({ state: { name: "Backlog" } }), stderr: "" };
+    const batchExec = (ids) => {
+      fetched.push(...ids);
+      return ids.map((id) => ({ identifier: id, state: { name: "Backlog" } }));
     };
+    const fetchBatch = (ids, opts) => fetchTicketsBatch(ids, { ...opts, exec: batchExec });
     const eligible = [blkTk("CTL-1", "CTL-99")];
-    hydrateOutOfSetBlockers(eligible, { exec, cache });
-    hydrateOutOfSetBlockers(eligible, { exec, cache });
-    expect(fetched).toEqual(["CTL-99"]); // one read, second hydration is a hit
+    hydrateOutOfSetBlockers(eligible, { fetchBatch, cache });
+    hydrateOutOfSetBlockers(eligible, { fetchBatch, cache });
+    expect(fetched).toEqual(["CTL-99"]); // one read, second hydration is a cache hit
   });
 
   test("preserves the fail-safe: a failed fetch is the sentinel AND is not cached", () => {
     const cache = createTicketStateCache({ now: () => 0 });
     let calls = 0;
-    const exec = () => {
+    const batchExec = () => {
       calls += 1;
-      return { code: 1, stdout: "", stderr: "" };
+      return null; // batch failure
     };
+    const fetchBatch = (ids, opts) => fetchTicketsBatch(ids, { ...opts, exec: batchExec });
     const eligible = [blkTk("CTL-1", "CTL-99")];
-    const a = hydrateOutOfSetBlockers(eligible, { exec, cache });
-    const b = hydrateOutOfSetBlockers(eligible, { exec, cache });
+    const a = hydrateOutOfSetBlockers(eligible, { fetchBatch, cache });
+    const b = hydrateOutOfSetBlockers(eligible, { fetchBatch, cache });
     expect(a["CTL-99"]).toBe("__unfetched__");
     expect(b["CTL-99"]).toBe("__unfetched__");
     expect(calls).toBe(2); // never cached the failure
@@ -2672,19 +2703,21 @@ describe("schedulerTick — cache stats (CTL-634)", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const cache = createTicketStateCache({ now: () => 0 });
     const dispatch = fakeDispatch({ code: 0 });
-    const exec = () => ({
-      code: 0,
-      stdout: JSON.stringify({ state: { name: "Backlog" } }),
-      stderr: "",
-    });
+    // CTL-784: hydrate now reads through the RELATIONS store, so the activity
+    // shows up in relationsStats() (the per-tick metric the scheduler also logs).
+    const fetchBatch = (ids, opts) =>
+      fetchTicketsBatch(ids, {
+        ...opts,
+        exec: (cs) => cs.map((id) => ({ identifier: id, state: { name: "Backlog" } })),
+      });
     schedulerTick(orchDir, {
       readEligible: () => [blkTk("CTL-1", "CTL-99")],
       dispatch,
-      exec,
+      fetchBatch,
       cache,
     });
-    const s = cache.stats();
-    expect(s.misses + s.hits).toBeGreaterThan(0); // the hydrate read went through the cache
+    const s = cache.relationsStats();
+    expect(s.misses + s.hits).toBeGreaterThan(0); // the hydrate read went through the relations cache
   });
 });
 
@@ -2704,7 +2737,7 @@ describe("startScheduler / stopScheduler", () => {
       // CTL-755: the triage→research promotion is admission-gated. Stub
       // fetchRelations (unblocked + non-terminal state) and provide a free slot
       // so the gate admits CTL-1 and the advancement sweep dispatches research.
-      fetchRelations: () => relUnblocked(),
+      fetchBatch: mkBatch(() => relUnblocked()),
       liveBackgroundCount: () => 0,
       tickIntervalMs: 60_000,
       debounceMs: 5,
@@ -2726,7 +2759,7 @@ describe("startScheduler / stopScheduler", () => {
       orchDir,
       dispatch: fakeDispatch(),
       readEligible: () => [],
-      fetchRelations: () => relUnblocked(),
+      fetchBatch: mkBatch(() => relUnblocked()),
       liveBackgroundCount: () => 0,
       tickIntervalMs: 60_000,
       debounceMs: 5,
@@ -2758,7 +2791,7 @@ describe("startScheduler / stopScheduler", () => {
       dispatch,
       readEligible: () => [],
       // CTL-755: admission-gate seam + free slot so the promotion fires.
-      fetchRelations: () => relUnblocked(),
+      fetchBatch: mkBatch(() => relUnblocked()),
       liveBackgroundCount: () => 0,
       tickIntervalMs: 20,
       debounceMs: 5,
@@ -2780,7 +2813,7 @@ describe("startScheduler / stopScheduler", () => {
       dispatch,
       readEligible: () => [],
       // CTL-755: admission-gate seam + free slot so the promotion fires.
-      fetchRelations: () => relUnblocked(),
+      fetchBatch: mkBatch(() => relUnblocked()),
       liveBackgroundCount: () => 0,
       tickIntervalMs: 60_000,
       debounceMs: 10,
@@ -5743,7 +5776,7 @@ describe("CTL-751: applyEstimate write-back on triage→research advance", () =>
   // CTL-755: the estimate write-back rides the triage→research advance, which is
   // now admission-gated — stub fetchRelations (unblocked) + a free slot so the
   // promotion fires and the applyEstimate code path is reached.
-  const admit = { fetchRelations: () => relUnblocked(), liveBackgroundCount: () => 0 };
+  const admit = { fetchBatch: mkBatch(() => relUnblocked()), liveBackgroundCount: () => 0 };
 
   test("triage.json with estimate:5 → applyEstimate called once with {ticket, estimate:5}", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
@@ -5859,17 +5892,6 @@ describe("CTL-755: admission gate", () => {
     return { fn: (e) => events.push(e), events };
   }
 
-  // An exec stub that answers `linearis issues read <id>` with a state name,
-  // keyed by identifier. Used to hydrate out-of-set blocker states (the D5 path
-  // STEP A reuses). Unknown ids → code 0 with a non-terminal placeholder.
-  function execWithStates(stateById) {
-    return (_cmd, args) => {
-      const id = args?.[2];
-      const name = stateById[id] ?? "Triage";
-      return { code: 0, stdout: JSON.stringify({ state: { name } }), stderr: "" };
-    };
-  }
-
   test("dep hold: a blocked triaged ticket is NOT dispatched, no Research write, 'blocked' label applied", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
     writeSignal("CTL-7", "triage", "done");
@@ -5883,8 +5905,7 @@ describe("CTL-755: admission gate", () => {
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
       // CTL-7 is blocked by an out-of-set blocker that is still In Progress.
-      fetchRelations: () => relBlockedBy("CTL-DEP"),
-      exec: execWithStates({ "CTL-DEP": "In Progress" }),
+      fetchBatch: batchWith(() => relBlockedBy("CTL-DEP"), { "CTL-DEP": "In Progress" }),
       appendPhaseAdvanceHeldEvent: held.fn,
     });
     expect(dispatch.calls).toEqual([]); // no research dispatch
@@ -5915,8 +5936,7 @@ describe("CTL-755: admission gate", () => {
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
       // CTL-7's blocker carries the "blocked" label already; now it is Done.
-      fetchRelations: () => relBlockedBy("CTL-DEP", { labels: ["blocked"] }),
-      exec: execWithStates({ "CTL-DEP": "Done" }),
+      fetchBatch: batchWith(() => relBlockedBy("CTL-DEP", { labels: ["blocked"] }), { "CTL-DEP": "Done" }),
     });
     expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "research" }]);
     expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
@@ -5939,7 +5959,7 @@ describe("CTL-755: admission gate", () => {
       writeStatus: s1.ws,
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 1, // saturated
-      fetchRelations: () => relUnblocked(),
+      fetchBatch: mkBatch(() => relUnblocked()),
       appendPhaseAdvanceHeldEvent: h1.fn,
     });
     expect(d1.calls).toEqual([]); // no promotion
@@ -5960,7 +5980,7 @@ describe("CTL-755: admission gate", () => {
       writeStatus: s2.ws,
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0, // slot freed
-      fetchRelations: () => relUnblocked({ labels: ["waiting"] }),
+      fetchBatch: mkBatch(() => relUnblocked({ labels: ["waiting"] })),
     });
     expect(d2.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "research" }]);
     expect(r2.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
@@ -5980,7 +6000,7 @@ describe("CTL-755: admission gate", () => {
       liveBackgroundCount: () => 0,
       // Both stale labels present (defensive — should never co-exist, but the
       // converge must clear both on pickup).
-      fetchRelations: () => relUnblocked({ labels: ["blocked", "waiting"] }),
+      fetchBatch: mkBatch(() => relUnblocked({ labels: ["blocked", "waiting"] })),
     });
     expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "research" }]);
     expect(removed).toContainEqual({ ticket: "CTL-7", label: "blocked" });
@@ -6000,8 +6020,7 @@ describe("CTL-755: admission gate", () => {
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
       // Already correctly labeled "blocked" (blocker still open) → no diff.
-      fetchRelations: () => relBlockedBy("CTL-DEP", { labels: ["blocked"] }),
-      exec: execWithStates({ "CTL-DEP": "In Progress" }),
+      fetchBatch: batchWith(() => relBlockedBy("CTL-DEP", { labels: ["blocked"] }), { "CTL-DEP": "In Progress" }),
     });
     expect(dispatch.calls).toEqual([]);
     expect(applied).toEqual([]); // already labeled → no apply
@@ -6019,8 +6038,7 @@ describe("CTL-755: admission gate", () => {
       writeStatus: labelSpy().ws,
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
-      fetchRelations: () => relBlockedBy("CTL-DEP", { labels: ["blocked"] }),
-      exec: execWithStates({ "CTL-DEP": "In Progress" }),
+      fetchBatch: batchWith(() => relBlockedBy("CTL-DEP", { labels: ["blocked"] }), { "CTL-DEP": "In Progress" }),
       appendPhaseAdvanceHeldEvent: held.fn,
     };
     schedulerTick(orchDir, common);
@@ -6048,7 +6066,7 @@ describe("CTL-755: admission gate", () => {
         writeStatus: ws,
         verifyDispatched: verifyOk,
         liveBackgroundCount: () => 0,
-        fetchRelations: fr,
+        fetchBatch: mkBatch(fr),
       });
     }).not.toThrow();
     expect(dispatch.calls).toEqual([]); // neither member promotes
@@ -6082,7 +6100,7 @@ describe("CTL-755: admission gate", () => {
       writeStatus: ws,
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0, // 3 free slots — capacity is NOT the gate here
-      fetchRelations: fr,
+      fetchBatch: mkBatch(fr),
       appendPhaseAdvanceHeldEvent: held.fn,
     });
     // Only the foundation promotes; the dependent never reaches research.
@@ -6118,7 +6136,7 @@ describe("CTL-755: admission gate", () => {
       writeStatus: ws,
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0, // 6 free slots — capacity is NOT the gate
-      fetchRelations: fr,
+      fetchBatch: mkBatch(fr),
     });
     // Exactly one promotion: the foundation. No leaf reaches research while its
     // blocker is non-terminal — even with ample capacity.
@@ -6149,9 +6167,8 @@ describe("CTL-755: admission gate", () => {
       writeStatus: ws,
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
-      fetchRelations: fr,
       // CTL-FOUND is out-of-set; hydrate it Done so it no longer blocks.
-      exec: execWithStates({ "CTL-FOUND": "Done" }),
+      fetchBatch: batchWith(fr, { "CTL-FOUND": "Done" }),
     });
     const promoted = r.advanced.map((a) => a.ticket).sort();
     expect(promoted).toEqual(["CTL-L1", "CTL-L2", "CTL-L3"]);
@@ -6172,7 +6189,7 @@ describe("CTL-755: admission gate", () => {
       writeStatus: labelSpy().ws,
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
-      fetchRelations: () => relUnblocked(),
+      fetchBatch: mkBatch(() => relUnblocked()),
     });
     // STEP B promotes CTL-7 (+promotedCount); STEP C subtracts it so sweep 2 has
     // exactly 1 remaining slot for CTL-X — 2 total dispatches, not 3.
@@ -6238,7 +6255,7 @@ describe("CTL-755: admission gate", () => {
       reclaimDeadWork: () => "noop", // CTL-690: never revive the parked signal
       resolveSession: () => "uuid-park", // the resume sweep would resume-with-session
       appendResumedAfterPreemptionEvent: () => {}, // capture-free; presence proves reachability
-      fetchRelations: () => relUnblocked(), // CTL-7's deps are satisfied → admitted
+      fetchBatch: mkBatch(() => relUnblocked()), // CTL-7's deps are satisfied → admitted
     });
 
     // Exactly ONE new dispatch consumed the single free slot. Fix #1 makes the
@@ -6270,7 +6287,7 @@ describe("CTL-755: admission gate", () => {
       writeStatus: ws,
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
-      fetchRelations: () => relUnblocked({ priority: 3 }),
+      fetchBatch: mkBatch(() => relUnblocked({ priority: 3 })),
     });
     // The single slot goes to the higher-priority new work; CTL-7 is held
     // "waiting" (ready, lost the selection), not promoted.
@@ -6292,7 +6309,7 @@ describe("CTL-755: admission gate", () => {
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0, // would show 3 free slots
       livenessIsFresh: () => false, // but the snapshot is stale → hold
-      fetchRelations: () => relUnblocked(),
+      fetchBatch: mkBatch(() => relUnblocked()),
     });
     expect(dispatch.calls).toEqual([]); // promotion held
     expect(r.advanced).toEqual([]);
@@ -6300,7 +6317,7 @@ describe("CTL-755: admission gate", () => {
     expect(applied).toContainEqual({ ticket: "CTL-7", label: "waiting" });
   });
 
-  test("early-exit: zero triaged-waiting tickets → fetchRelations never called (zero Linear cost)", () => {
+  test("early-exit: zero triaged-waiting tickets → fetchBatch never called (zero Linear cost)", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
     writeSignal("CTL-7", "research", "running"); // in-flight but NOT triaged-waiting
     let fetchCalls = 0;
@@ -6311,9 +6328,9 @@ describe("CTL-755: admission gate", () => {
       writeStatus: labelSpy().ws,
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
-      fetchRelations: () => { fetchCalls++; return relUnblocked(); },
+      fetchBatch: (ids) => { fetchCalls++; return mkBatch(() => relUnblocked())(ids); },
     });
-    expect(fetchCalls).toBe(0); // STEP A early-exited
+    expect(fetchCalls).toBe(0); // STEP A early-exited (and no eligible out-of-set blockers)
   });
 
   test("read-failure (fetchRelations → null) fails SAFE: the candidate is held", () => {
@@ -6327,7 +6344,7 @@ describe("CTL-755: admission gate", () => {
       writeStatus: ws,
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
-      fetchRelations: () => null, // read failed → non-terminal sentinel → held
+      fetchBatch: mkBatch(() => null), // read failed → non-terminal sentinel → held
     });
     expect(dispatch.calls).toEqual([]);
     expect(r.advanced).toEqual([]);
@@ -6354,7 +6371,7 @@ describe("CTL-755: admission gate", () => {
       writeStatus: ws,
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
-      fetchRelations: () => null, // read failed → fail-safe hold
+      fetchBatch: mkBatch(() => null), // read failed → fail-safe hold
       appendPhaseAdvanceHeldEvent: held.fn,
     });
     expect(dispatch.calls).toEqual([]);
@@ -6399,17 +6416,6 @@ describe("CTL-755: admission gate", () => {
     );
   }
 
-  // An exec stub: `linearis issues read <id>` → keyed state, or code!==0 for
-  // ids in `unresolvable` (so fetchTicketState returns null and STEP E drops it).
-  function execStates(stateById, unresolvable = new Set()) {
-    return (_cmd, args) => {
-      const id = args?.[2];
-      if (unresolvable.has(id)) return { code: 1, stdout: "", stderr: "not found" };
-      const name = stateById[id] ?? "Triage";
-      return { code: 0, stdout: JSON.stringify({ state: { name } }), stderr: "" };
-    };
-  }
-
   test("dep persistence: a resolvable non-terminal dep is written, a prose-only/unresolvable token is dropped", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
     writeSignal("CTL-7", "triage", "done");
@@ -6426,8 +6432,7 @@ describe("CTL-755: admission gate", () => {
       liveBackgroundCount: () => 0,
       // CTL-7 has NO existing relations (so the dep write is not idempotently
       // skipped); the dep states are resolved via exec below.
-      fetchRelations: () => relUnblocked(),
-      exec: execStates({ "CTL-100": "In Progress" }, new Set(["PROSE-1"])),
+      fetchBatch: mkBatch({ "CTL-7": relUnblocked(), "CTL-100": descOf("In Progress") }),
     });
     // Exactly one durable edge: CTL-7 blocked_by CTL-100. PROSE-1 dropped.
     expect(relations).toEqual([{ ticket: "CTL-7", blockedBy: "CTL-100" }]);
@@ -6448,8 +6453,7 @@ describe("CTL-755: admission gate", () => {
       // CTL-7's FRESH relations already carry blocked_by CTL-100 (durable edge
       // exists) → STEP E must NOT re-write it. (CTL-100 In Progress also holds
       // the gate, but the persistence path is what we pin here.)
-      fetchRelations: () => relBlockedBy("CTL-100"),
-      exec: execStates({ "CTL-100": "In Progress" }),
+      fetchBatch: mkBatch({ "CTL-7": relBlockedBy("CTL-100"), "CTL-100": descOf("In Progress") }),
     });
     expect(relations).toEqual([]); // idempotent — nothing written
   });
@@ -6466,8 +6470,7 @@ describe("CTL-755: admission gate", () => {
       writeStatus: ws,
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
-      fetchRelations: () => relUnblocked(),
-      exec: execStates({ "CTL-100": "Done" }), // terminal → no durable edge
+      fetchBatch: mkBatch({ "CTL-7": relUnblocked(), "CTL-100": descOf("Done") }), // terminal → no durable edge
     });
     expect(relations).toEqual([]);
   });
@@ -6484,8 +6487,7 @@ describe("CTL-755: admission gate", () => {
       writeStatus: ws,
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
-      fetchRelations: () => relUnblocked(),
-      exec: execStates({ "CTL-100": "In Progress" }),
+      fetchBatch: mkBatch({ "CTL-7": relUnblocked(), "CTL-100": descOf("In Progress") }),
     });
     expect(relations).toEqual([{ ticket: "CTL-7", blockedBy: "CTL-100" }]);
   });
@@ -6502,10 +6504,42 @@ describe("CTL-755: admission gate", () => {
       writeStatus: ws,
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
-      fetchRelations: () => relUnblocked(),
-      exec: execStates({ "CTL-100": "In Progress" }),
+      fetchBatch: mkBatch({ "CTL-7": relUnblocked(), "CTL-100": descOf("In Progress") }),
     });
     expect(relations).toEqual([{ ticket: "CTL-7", blockedBy: "CTL-100" }]);
+  });
+
+  test("CTL-784: writing a durable edge INVALIDATES the candidate's relations cache (no ≤TTL over-promotion)", () => {
+    // After STEP E writes a new blocked_by edge, the candidate's relations
+    // descriptor cached THIS tick (by A.3) is stale (no edge). Invalidating it
+    // forces the next tick to re-read fresh and surface the blocker — closing the
+    // over-promotion window the old fresh-every-tick read never had.
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    writeTriageDeps("CTL-7", ["CTL-100"]);
+    const dispatch = fakeDispatch();
+    const { ws, relations } = depSpy();
+    const invalidated = [];
+    const cache = {
+      get: () => undefined,
+      set: () => {},
+      getRelations: () => undefined,
+      setRelations: () => {},
+      invalidate: (id) => invalidated.push(id),
+      stats: () => ({}),
+      relationsStats: () => ({}),
+    };
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      cache,
+      fetchBatch: mkBatch({ "CTL-7": relUnblocked(), "CTL-100": descOf("In Progress") }),
+    });
+    expect(relations).toEqual([{ ticket: "CTL-7", blockedBy: "CTL-100" }]); // edge written
+    expect(invalidated).toContain("CTL-7"); // candidate cache dropped → next tick re-reads fresh
   });
 
   // ── STEP D integration: dead-triage reclaim → STEP A re-eval → promotion ──
@@ -6568,7 +6602,7 @@ describe("CTL-755: admission gate", () => {
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0, // a free slot
       reclaimDeadWork: prodTriageReclaim(orchDir),
-      fetchRelations: () => relUnblocked(), // deps satisfied
+      fetchBatch: mkBatch(() => relUnblocked()), // deps satisfied
     });
     // The reclaim sweep flipped the signal to done (no longer stranded at running).
     expect(readPhaseSignals(orchDir, "CTL-7").triage).toBe("done");
@@ -6597,8 +6631,7 @@ describe("CTL-755: admission gate", () => {
       liveBackgroundCount: () => 0,
       reclaimDeadWork: prodTriageReclaim(orchDir),
       // CTL-7 is blocked by an out-of-set blocker still In Progress.
-      fetchRelations: () => relBlockedBy("CTL-DEP"),
-      exec: execWithStates({ "CTL-DEP": "In Progress" }),
+      fetchBatch: batchWith(() => relBlockedBy("CTL-DEP"), { "CTL-DEP": "In Progress" }),
       appendPhaseAdvanceHeldEvent: held.fn,
     });
     // Signal still flipped to done (reclaim ran) — but research is HELD by the gate.


### PR DESCRIPTION
## CTL-784 — batch per-tick Linear reads into one filtered query

### Problem
The execution-core daemon's dominant Linear cost is **single-ticket reads** (`linearis issues read` → `query GetIssueByIdentifier`) — **~82% of all captured Linear traffic** (`~/catalyst/linear-proxy.jsonl`), running **~51–74/min ≈ 3,000–4,400/hr** and scaling **linearly with in-flight work**. The scheduler tick fires on a 30s timer + a ~2s debounce of every unified-event-log append, so under fleet activity it ticks ~30×/min, and each tick reads ticket state/relations **one ticket at a time** at four unconditional sites (admission STEP A.3, both `hydrateOutOfSetBlockers`, STEP-E dep persistence). The CTL-634 TTL cache didn't help the admission pool because `fetchTicketRelations` **wrote but never read** the cache (so the `LINEAR_STATE_CACHE_TTL_MS` bump was a no-op).

This is the textbook **N+1 read problem** against a request-count quota; the canonical fix is **batching**. (Full analysis, prior art, and ruled-out alternatives — ETag/conditional, webhook/CDC — in `thoughts/shared/research/2026-06-06-CTL-784-daemon-linear-read-amplification.md`.)

### Change
- **`linear-cache.mjs`** — add a relations read-through store (`getRelations`/`setRelations`/`relationsStats`) in a **separate map**; `getRelations` overlays the freshest state from the monitor write-through (edges carry ≤TTL staleness, state stays fresh). The CTL-634 `get`/`set`/`invalidate`/`stats` string contract is **unchanged**.
- **`linear-query.mjs`** — add `fetchTicketsBatch` (cache-first, chunk ≤250, one **synchronous** `curl` GraphQL POST so the tick stays non-async, integrated with the CTL-679 breaker; `Bearer` for OAuth tokens, raw for personal keys; `--cacert` for the mitmproxy audit; `RATELIMITED`/`extensions.code` detection) + make `fetchTicketRelations` read-through. `authHeader`/`buildBatchCurlArgs`/`isBatchRateLimited` exported for unit coverage.
- **`scheduler.mjs`** — one `fetchBatch` seam replaces the per-ticket loops at all four sites; STEP-E invalidates the candidate's relations cache after a durable `blocked_by` edge write so a freed-slot tick within the TTL can't over-promote past the new edge.
- **hermetic fake `curl`** on the test PATH so no test reaches the network.

### Acceptance
- [x] Per-tick `GetIssueByIdentifier` collapses to one batched `query CtlBatchTickets` — **verified live (read-only): N tickets → 1 request** on the orchestrator bucket.
- [x] Admission readiness/held classification unchanged (semantic-equivalence preserved; fail-safe: an absent id is held, never promoted).
- [x] Steady-state request rate comfortably under quota (cache-first batch ≈ a few requests / TTL window vs the old `N × ticks/min`).

### Tests & verification
- `linear-cache` / `linear-query` / `scheduler` suites: **449 pass / 0 fail**; full execution-core suite green (only pre-existing flaky/unrelated failures); **zero curl/linearis network leaks**.
- Adversarial multi-agent review run on the diff; all 6 confirmed findings fixed (auth scheme, ≤TTL over-promotion, soft rate-limit detection, curl-path coverage, sub-connection bounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
