### PR TITLE
feat(dev): add catalyst.dispatch_mode telemetry dimension (OTL-7)

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
@@ -464,6 +464,12 @@ phase_agent_dispatch_setup() {
 	cat >"${SCRATCH}/bin/phase-agent-dispatch" <<'EOF'
 #!/usr/bin/env bash
 echo "$@" >> "$PHASE_DISPATCH_LOG"
+# OTL-7: capture the dispatch-mode env so tests can assert the producer (the
+# /orchestrate wave) tagged this invocation and did NOT leak the daemon token.
+{
+  echo "CATALYST_DISPATCH_MODE=${CATALYST_DISPATCH_MODE:-}"
+  echo "CATALYST_EXECUTION_CORE=${CATALYST_EXECUTION_CORE:-}"
+} >> "${PHASE_DISPATCH_ENV_LOG:-/dev/null}"
 # Write the per-phase signal so the dispatcher's idempotency check sees it on
 # subsequent invocations — mirrors what the real helper does.
 ORCH_DIR=""; PHASE=""; TICKET=""
@@ -485,6 +491,9 @@ EOF
 	chmod +x "${SCRATCH}/bin/phase-agent-dispatch"
 	export PHASE_DISPATCH_LOG="${SCRATCH}/phase-dispatch.log"
 	: >"$PHASE_DISPATCH_LOG"
+	# OTL-7: separate log capturing the dispatch-mode env the stub was invoked with.
+	export PHASE_DISPATCH_ENV_LOG="${SCRATCH}/phase-dispatch-env.log"
+	: >"$PHASE_DISPATCH_ENV_LOG"
 	export CATALYST_PHASE_AGENT_DISPATCH="${SCRATCH}/bin/phase-agent-dispatch"
 }
 
@@ -634,6 +643,10 @@ RC=$?
 DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
 [ "$DISPATCHED" = "T-1" ] && pass "dispatched=[T-1] via phase-agents mode" || fail "dispatched=[T-1] via phase-agents mode" "got: $DISPATCHED"
 grep -q -- "--phase triage" "$PHASE_DISPATCH_LOG" && pass "default phase=triage when dispatchMode=phase-agents" || fail "default phase=triage when dispatchMode=phase-agents" "log: $(cat "$PHASE_DISPATCH_LOG")"
+# OTL-7: the /orchestrate wave is the authoritative producer of dispatch_mode=orchestrate.
+grep -q "^CATALYST_DISPATCH_MODE=orchestrate$" "$PHASE_DISPATCH_ENV_LOG" && pass "phase-agent-dispatch invoked with CATALYST_DISPATCH_MODE=orchestrate" || fail "CATALYST_DISPATCH_MODE=orchestrate set by /orchestrate wave" "env log: $(cat "$PHASE_DISPATCH_ENV_LOG")"
+# Non-leak contract: the orchestrate path must NOT carry the daemon fencing token.
+grep -q "^CATALYST_EXECUTION_CORE=1$" "$PHASE_DISPATCH_ENV_LOG" && fail "orchestrate wave must NOT set CATALYST_EXECUTION_CORE=1" "env log: $(cat "$PHASE_DISPATCH_ENV_LOG")" || pass "orchestrate wave does not leak CATALYST_EXECUTION_CORE (daemon/orchestrator non-leak)"
 [ ! -s "$CLAUDE_LOG" ] && pass "claude (legacy oneshot) not invoked in phase-agents mode" || fail "claude not invoked in phase-agents mode"
 # Queue should be drained
 W1_LEN=$(jq -r '.queue.wave1Pending | length' "${ORCH_DIR}/state.json")

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -131,6 +131,10 @@ fresh_env() {
 	export CLAUDE_STUB_LOG="${TEST_DIR}/claude-stub.log"
 	export CLAUDE_STUB_JOB_ID="f124220a"
 	unset CLAUDE_STUB_EXIT
+	# OTL-7: dispatch_mode is read from CATALYST_DISPATCH_MODE; keep tests hermetic
+	# against a developer shell that has it (or the CATALYST_EXECUTION_CORE fencing
+	# token) exported. Tests that exercise these set them inline per-invocation.
+	unset CATALYST_DISPATCH_MODE CATALYST_EXECUTION_CORE
 	export PATH="${STUB_DIR}:${PATH}"
 }
 
@@ -704,6 +708,63 @@ LOG=$(cat "$CLAUDE_STUB_LOG")
 assert_contains "$LOG" \
 	"OTEL_RESOURCE_ATTRIBUTES=linear.key=CTL-100,catalyst.orchestration=orch-test,task.type=phase-triage,catalyst.exec_context=phase-bg" \
 	"task.type appended even when projectKey absent (short form)"
+
+# OTL-7: catalyst.dispatch_mode — WHO dispatched this phase.
+# Pure explicit contract: each real dispatcher (execution-core/dispatch.mjs,
+# orchestrate-dispatch-next) exports CATALYST_DISPATCH_MODE; phase-agent-dispatch
+# whitelists it into OTEL_RESOURCE_ATTRIBUTES as catalyst.dispatch_mode. There is
+# NO env inference — absent or unrecognized → the attribute is OMITTED (honest
+# unknown), never guessed. Closes the gap where an execution-core phase-bg and an
+# /orchestrate phase-bg were indistinguishable (both task.type=phase-X + phase-bg).
+echo ""
+echo "Test 15d (OTL-7): CATALYST_DISPATCH_MODE=execution-core → catalyst.dispatch_mode=execution-core"
+fresh_env t15d
+rm -rf "${CONFIG_DIR}"
+(cd "${TEST_DIR}/proj" &&
+	CATALYST_DISPATCH_MODE=execution-core \
+		"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
+LOG=$(cat "$CLAUDE_STUB_LOG")
+assert_contains "$LOG" ",catalyst.dispatch_mode=execution-core" \
+	"execution-core dispatcher tags catalyst.dispatch_mode=execution-core"
+
+echo ""
+echo "Test 15e (OTL-7): CATALYST_DISPATCH_MODE=orchestrate → catalyst.dispatch_mode=orchestrate"
+fresh_env t15e
+rm -rf "${CONFIG_DIR}"
+(cd "${TEST_DIR}/proj" &&
+	CATALYST_DISPATCH_MODE=orchestrate \
+		"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
+LOG=$(cat "$CLAUDE_STUB_LOG")
+assert_contains "$LOG" ",catalyst.dispatch_mode=orchestrate" \
+	"orchestrate dispatcher tags catalyst.dispatch_mode=orchestrate"
+
+echo ""
+echo "Test 15f (OTL-7): absent CATALYST_DISPATCH_MODE omits the attr even with CATALYST_EXECUTION_CORE=1 (no inference)"
+fresh_env t15f
+rm -rf "${CONFIG_DIR}"
+# CATALYST_EXECUTION_CORE is the worktree-path fencing token, NOT a telemetry
+# signal — it must never be inferred into a dispatch_mode label.
+(cd "${TEST_DIR}/proj" &&
+	CATALYST_EXECUTION_CORE=1 \
+		"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
+LOG=$(cat "$CLAUDE_STUB_LOG")
+assert_not_contains "$LOG" "catalyst.dispatch_mode=" \
+	"absent CATALYST_DISPATCH_MODE omits the attribute (no inference from CATALYST_EXECUTION_CORE)"
+
+echo ""
+echo "Test 15g (OTL-7): invalid CATALYST_DISPATCH_MODE rejected by the closed-enum whitelist"
+fresh_env t15g
+rm -rf "${CONFIG_DIR}"
+(cd "${TEST_DIR}/proj" &&
+	CATALYST_DISPATCH_MODE=bogus-value \
+		"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
+LOG=$(cat "$CLAUDE_STUB_LOG")
+assert_not_contains "$LOG" "catalyst.dispatch_mode=" \
+	"invalid dispatch_mode is not injected as an arbitrary label (whitelist guard)"
 
 # ─── CTL-511: claude --bg launch failure → signal stalled + phase.*.failed ───
 # A launch failure must leave the signal at status="stalled" with NO

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -71,6 +71,12 @@ export function defaultRunPhaseAgent(
       CATALYST_PHASE: phase,
       CATALYST_TICKET: ticket,
       CATALYST_EXECUTION_CORE: "1",
+      // OTL-7 dispatch_mode telemetry: authoritative producer for the daemon-served
+      // pipeline. phase-agent-dispatch reads CATALYST_DISPATCH_MODE verbatim into
+      // OTEL_RESOURCE_ATTRIBUTES (catalyst.dispatch_mode) so phase-bg metrics
+      // distinguish daemon-dispatched (execution-core) from /orchestrate-dispatched
+      // (orchestrate) workers. Closed enum: execution-core | orchestrate | oneshot.
+      CATALYST_DISPATCH_MODE: "execution-core",
       ...extraEnv,
     },
   });

--- a/plugins/dev/scripts/execution-core/dispatch.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.test.mjs
@@ -336,6 +336,40 @@ describe("defaultRunPhaseAgent — handoffPath env injection (CTL-549)", () => {
   });
 });
 
+// OTL-7: the daemon is the authoritative producer of dispatch_mode=execution-core.
+// phase-agent-dispatch reads CATALYST_DISPATCH_MODE verbatim into
+// OTEL_RESOURCE_ATTRIBUTES (catalyst.dispatch_mode), so the spawned env must carry
+// it alongside the existing CATALYST_EXECUTION_CORE fencing token.
+describe("defaultRunPhaseAgent — dispatch_mode telemetry (OTL-7)", () => {
+  const spy = () => {
+    const calls = [];
+    const spawn = (bin, args, opts) => {
+      calls.push({ bin, args, opts });
+      return { status: 0, stdout: "ok", stderr: "" };
+    };
+    spawn.calls = calls;
+    return spawn;
+  };
+
+  test("sets CATALYST_DISPATCH_MODE=execution-core in the spawned env", () => {
+    const spawn = spy();
+    defaultRunPhaseAgent(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "implement", worktreePath: "/wt/CTL-1" },
+      { spawn },
+    );
+    expect(spawn.calls[0].opts.env.CATALYST_DISPATCH_MODE).toBe("execution-core");
+  });
+
+  test("keeps CATALYST_EXECUTION_CORE=1 alongside dispatch_mode", () => {
+    const spawn = spy();
+    defaultRunPhaseAgent(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "implement", worktreePath: "/wt/CTL-1" },
+      { spawn },
+    );
+    expect(spawn.calls[0].opts.env.CATALYST_EXECUTION_CORE).toBe("1");
+  });
+});
+
 // CTL-549: defaultDispatch forwards handoffPath to runPhaseAgent
 describe("defaultDispatch — handoffPath passthrough (CTL-549)", () => {
   const seams = (handoffPath) => {

--- a/plugins/dev/scripts/orchestrate-dispatch-next
+++ b/plugins/dev/scripts/orchestrate-dispatch-next
@@ -436,6 +436,7 @@ while IFS=$'\t' read -r W T; do
 			CATALYST_ORCHESTRATOR_DIR="$ORCH_DIR" \
 				CATALYST_ORCHESTRATOR_ID="$ORCH_ID" \
 				CATALYST_SESSION_ID="$SESSION_ID" \
+				CATALYST_DISPATCH_MODE="orchestrate" \
 				"$PHASE_DISPATCH_BIN" \
 				--phase "$PHASE" \
 				--ticket "$T" \

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -331,6 +331,22 @@ compose_otel_resource_attrs() {
 	# launch mode (phase-bg here vs catalyst.exec_context=interactive that
 	# catalyst-claude.sh stamps on the interactive orchestrator/dev sessions).
 	attrs="${attrs},catalyst.exec_context=phase-bg"
+	# OTL-7 dispatch_mode: WHO dispatched this phase — execution-core (daemon) vs
+	# orchestrate (/orchestrate wave). Closes the gap where both emitted
+	# task.type=phase-<P> + catalyst.exec_context=phase-bg and were indistinguishable.
+	# Pure explicit contract: each real dispatcher exports CATALYST_DISPATCH_MODE
+	# (execution-core/dispatch.mjs, orchestrate-dispatch-next). We do NOT infer from
+	# CATALYST_EXECUTION_CORE — an unknown caller that sets nothing yields an ABSENT
+	# label (honest unknown), never a guessed/wrong one. The value is whitelisted
+	# against the closed enum so a typo'd producer cannot inject an arbitrary
+	# Loki/Prometheus label. `oneshot` is reserved/forward-compat: /oneshot runs
+	# phases inline in an interactive session (already distinguishable via
+	# exec_context=interactive + task.type=oneshot), so it does not reach this path.
+	case "${CATALYST_DISPATCH_MODE:-}" in
+	execution-core | orchestrate | oneshot)
+		attrs="${attrs},catalyst.dispatch_mode=${CATALYST_DISPATCH_MODE}"
+		;;
+	esac
 	printf '%s\n' "$attrs"
 }
 


### PR DESCRIPTION
## What & why

Phase events from the **execution-core daemon** and from **/orchestrate** are currently indistinguishable — both emit `task.type=phase-<P>` + `catalyst.exec_context=phase-bg`. This adds a `catalyst.dispatch_mode` resource attribute so phase cost/token/tool metrics can be segmented by **who dispatched them**.

Emit side only — the consumer side (collector label `catalyst_dispatch_mode` + a `sum by(catalyst_dispatch_mode)` dashboard panel) ships separately in `coalesce-labs/catalyst-otel` (OTL-7).

## Design — pure explicit-var, no env inference

A multi-agent adversarial review (3 independent lenses: completeness, correctness, collision/naming) **rejected** the original "infer `execution-core` from `CATALYST_EXECUTION_CORE`" approach as fragile to env inheritance (an execution-core child that re-dispatches, or a future caller, could be silently mislabeled). The implemented design is therefore **purely explicit**:

| Site | Change |
|---|---|
| `execution-core/dispatch.mjs:73` | set `CATALYST_DISPATCH_MODE="execution-core"` in the spawned phase-agent env (sibling to the existing `CATALYST_EXECUTION_CORE:"1"`) |
| `orchestrate-dispatch-next:~436` | set `CATALYST_DISPATCH_MODE="orchestrate"` in the phase-agent-dispatch inline env prefix |
| `phase-agent-dispatch` `compose_otel_resource_attrs()` | read the var, validate against the closed enum `{execution-core\|orchestrate\|oneshot}`, append `catalyst.dispatch_mode` **only when valid** — else **omit** (honest unknown) |

Benefits: no inference ⇒ unknown callers are never mislabeled; the whitelist blocks a typo'd producer from injecting an arbitrary Loki/Prometheus label; and **every existing pinned OTEL-string test stays valid unchanged** (they set no `CATALYST_DISPATCH_MODE`, so nothing is appended).

## `oneshot` is reserved (decision for review)

`oneshot` is in the enum for forward-compat but **not actively emitted**: `/oneshot` runs phases inline in an interactive session, already distinguishable via `exec_context=interactive` + `task.type=oneshot`, so it never reaches the bg dispatch path. If you'd prefer to also stamp launcher sessions (a "cost by dispatch model across launchers" view), that's a clean follow-up — flagging for your call.

## Naming note (for review)

Telemetry attr `catalyst.dispatch_mode` / env `CATALYST_DISPATCH_MODE` (enum: execution-core\|orchestrate\|oneshot) is distinct from the pre-existing config `catalyst.orchestration.dispatchMode` (enum: phase-agents\|oneshot-legacy\|execution-core). Different casing/namespace; the attr name matches the OTL-7 handoff. Happy to rename (e.g. `launch_mode`) if you think the collision risk warrants it.

## Tests (all green locally — note: no CI job runs these suites)

- `phase-agent-dispatch.test.sh` (207 pass): execution-core/orchestrate tag the attr; absent var omits it **even with `CATALYST_EXECUTION_CORE=1`** (no inference); invalid value rejected by whitelist. `fresh_env` now unsets both vars for hermeticity.
- `dispatch.test.mjs` (34 pass): daemon spawn carries `CATALYST_DISPATCH_MODE=execution-core` alongside `CATALYST_EXECUTION_CORE=1`.
- `orchestrate-dispatch-next.test.sh` (140 pass): wave sets `dispatch_mode=orchestrate` and does **not** leak the daemon fencing token (non-leak contract).
- `shellcheck -S error` clean; `bash -n` / `node --check` clean; `audit-references --ci` exit 0.

Ref handoff `2026-06-06_07-14-58_catalyst-telemetry-dimensions-and-headless-emission.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)