### PR TITLE
chore(dev): remove Conductor references — Catalyst owns its worktree location (CTL-788)

### DIFF
--- a/docs/schemas/catalyst-config.schema.json
+++ b/docs/schemas/catalyst-config.schema.json
@@ -120,7 +120,7 @@
                     "description": "A CSS color string (e.g. '#4A90E2', 'blue')."
                   },
                   "examples": [
-                    { "coalesce-labs/catalyst": "#4A90E2", "coalesce-labs/conductor": "#E24A4A" }
+                    { "coalesce-labs/catalyst": "#4A90E2", "coalesce-labs/adva": "#E24A4A" }
                   ]
                 }
               }

--- a/plugins/dev/direnv/lib/otel.sh
+++ b/plugins/dev/direnv/lib/otel.sh
@@ -85,15 +85,9 @@ use_otel_context() {
   local project="${1:-$(basename "$PWD")}"
   local attrs="project=${project},hostname=$(hostname -s)"
 
-  # Git branch: use $PWD (correct when .envrc is in the worktree dir itself).
-  # Fallback to CONDUCTOR_WORKSPACE_PATH for Conductor-launched sessions where
-  # direnv sets $PWD to the .envrc's parent dir, not the worktree.
-  local git_dir="${PWD}"
-  if [ -z "$(git -C "$git_dir" branch --show-current 2>/dev/null)" ] && [ -n "${CONDUCTOR_WORKSPACE_PATH:-}" ]; then
-    git_dir="$CONDUCTOR_WORKSPACE_PATH"
-  fi
+  # Git branch from $PWD (the .envrc lives in the worktree dir itself).
   local branch
-  branch=$(git -C "$git_dir" branch --show-current 2>/dev/null)
+  branch=$(git -C "${PWD}" branch --show-current 2>/dev/null)
   if [ -n "$branch" ]; then
     attrs="${attrs},branch=${branch}"
   fi

--- a/plugins/legacy/skills/orchestrate/SKILL.md
+++ b/plugins/legacy/skills/orchestrate/SKILL.md
@@ -359,7 +359,7 @@ With `worktreeDir: "~/catalyst/api"` explicitly configured:
 2. Copies `.claude/` directory (Claude Code native config, plugins, rules)
 3. Copies `.catalyst/` directory (Catalyst workflow config, if it exists)
 4. **Runs `catalyst.worktree.setup` commands from config** — dependency install, thoughts init,
-   permission grants, or any project-specific setup (like Conductor's `conductor.json` lifecycle
+   permission grants, or any project-specific setup (like a worktree-manager's lifecycle
    hooks)
 5. If no `catalyst.worktree.setup` configured, falls back to auto-detected setup: `make setup` or
    `bun/npm install`, then `humanlayer thoughts init` + `sync`

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -904,13 +904,13 @@ EOF
 setup_worktree_directory() {
 	print_header "Setting Up Worktree Directory"
 
-	# Check if we're already inside a worktree (e.g., Conductor-managed)
+	# Check if we're already inside a worktree (e.g., one your tooling manages)
 	local git_dir
 	git_dir=$(git rev-parse --git-dir 2>/dev/null || echo "")
 
 	if [ -f "$git_dir" ] 2>/dev/null || [[ $git_dir == *"/worktrees/"* ]]; then
 		print_success "Already running inside a git worktree"
-		echo "Worktree management is handled by your tooling (e.g., Conductor, /create-worktree)."
+		echo "Worktree management is handled by your tooling (e.g., /create-worktree)."
 		echo ""
 		echo "To create additional worktrees, use:"
 		echo "  /create-worktree PROJ-123 feature-name"

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -38,7 +38,7 @@
   }
 }
 
-/* ─── Changelog Styling (Conductor-inspired) ────────────────────────────────
+/* ─── Changelog Styling ──────────────────────────────────────────────────────
  *
  * DOM structure per version entry (from starlight-changelogs):
  *   <h2 id="slug"><a>6.34.0</a></h2>


### PR DESCRIPTION
## CTL-788 — remove Conductor references (Catalyst owns its worktree location)

Catalyst now has its own worktree location (`~/catalyst/wt/…`), so there should be **no dependency — fallback or otherwise — on Conductor**. The leftover `CONDUCTOR_WORKSPACE_PATH` fallback in `otel.sh` tripped an agent into creating a worktree under the Conductor path, so it was actively harmful.

### Changes
- **`plugins/dev/direnv/lib/otel.sh`** — drop the `CONDUCTOR_WORKSPACE_PATH` fallback `git_dir` (the only *functional* reference; used solely for OTel branch tagging). Branch tagging now reads `$PWD` directly. No test covered it; `lib-otel.test.sh` stays green (10/0).
- **`setup-catalyst.sh`** — drop "Conductor" from the worktree comment + user-facing echo.
- **`plugins/legacy/skills/orchestrate/SKILL.md`** — reword the `conductor.json` mention to a generic worktree-manager lifecycle-hooks example.
- **`docs/schemas/catalyst-config.schema.json`** — example repo `coalesce-labs/conductor` → `coalesce-labs/adva`.
- **`website/src/styles/custom.css`** — drop "(Conductor-inspired)" from the changelog-styling comment.

### Out of scope (by decision)
- `plugins/dev/CHANGELOG.md` — two historical release-note lines, release-please-managed and published to the website changelog; left intact to avoid rewriting release history.

### Verification
- `grep -ri conductor` on the branch returns only the 2 CHANGELOG lines.
- `bash -n` clean (otel.sh, setup-catalyst.sh); schema JSON valid; `lib-otel.test.sh` 10/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
