### PR TITLE
feat(dev): account-level rate-limit usage poller (CTL-787)

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -196,6 +196,20 @@ export function readMemorySamplerConfig() {
   };
 }
 
+// CTL-787 — account-level Claude rate-limit usage poller. Re-reads from
+// process.env on every call so tests can manipulate env vars freely (mirrors
+// readMemorySamplerConfig). The poller floors intervalMs at 180s internally;
+// the default cadence here is ~5 min.
+export function readRatelimitPollerConfig() {
+  return {
+    enabled: process.env.CATALYST_RATELIMIT_POLLER !== "0",
+    intervalMs: Number(process.env.EXECUTION_CORE_RATELIMIT_POLL_INTERVAL_MS) || 300000,
+    usageEndpoint:
+      process.env.EXECUTION_CORE_RATELIMIT_USAGE_ENDPOINT ||
+      "https://api.anthropic.com/api/oauth/usage",
+  };
+}
+
 // --- Auto-tuner (CTL-684) ---
 // Sample cadence — how often the auto-tuner polls load + memory.
 export const AUTOTUNE_SAMPLE_INTERVAL_MS =

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -11,6 +11,7 @@ import {
   readWaitWatcherConfig,
   EVENT_DEBOUNCE_MS,
   readMemorySamplerConfig,
+  readRatelimitPollerConfig,
   AUTOTUNE_SAMPLE_INTERVAL_MS,
   AUTOTUNE_WINDOW_SAMPLES,
   AUTOTUNE_TREND_MIN_SAMPLES,
@@ -118,6 +119,63 @@ describe("readMemorySamplerConfig (CTL-685)", () => {
   test("zero interval falls back to 30000", () => {
     process.env.EXECUTION_CORE_MEMORY_SAMPLE_INTERVAL_MS = "0";
     expect(readMemorySamplerConfig().intervalMs).toBe(30_000);
+  });
+});
+
+// CTL-787: rate-limit poller config knob tests.
+const RL_ENVS = [
+  "CATALYST_RATELIMIT_POLLER",
+  "EXECUTION_CORE_RATELIMIT_POLL_INTERVAL_MS",
+  "EXECUTION_CORE_RATELIMIT_USAGE_ENDPOINT",
+];
+let savedRlEnvs = {};
+
+describe("readRatelimitPollerConfig (CTL-787)", () => {
+  beforeEach(() => {
+    for (const k of RL_ENVS) {
+      savedRlEnvs[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of RL_ENVS) {
+      if (savedRlEnvs[k] === undefined) delete process.env[k];
+      else process.env[k] = savedRlEnvs[k];
+    }
+    savedRlEnvs = {};
+  });
+
+  test("returns defaults when env is unset", () => {
+    const cfg = readRatelimitPollerConfig();
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.intervalMs).toBe(300000);
+    expect(cfg.usageEndpoint).toBe("https://api.anthropic.com/api/oauth/usage");
+  });
+
+  test("CATALYST_RATELIMIT_POLLER=0 disables the poller", () => {
+    process.env.CATALYST_RATELIMIT_POLLER = "0";
+    expect(readRatelimitPollerConfig().enabled).toBe(false);
+  });
+
+  test("any non-zero CATALYST_RATELIMIT_POLLER keeps it enabled", () => {
+    process.env.CATALYST_RATELIMIT_POLLER = "1";
+    expect(readRatelimitPollerConfig().enabled).toBe(true);
+  });
+
+  test("numeric interval override parses correctly", () => {
+    process.env.EXECUTION_CORE_RATELIMIT_POLL_INTERVAL_MS = "600000";
+    expect(readRatelimitPollerConfig().intervalMs).toBe(600000);
+  });
+
+  test("non-numeric interval falls back to 300000", () => {
+    process.env.EXECUTION_CORE_RATELIMIT_POLL_INTERVAL_MS = "nope";
+    expect(readRatelimitPollerConfig().intervalMs).toBe(300000);
+  });
+
+  test("custom usage endpoint override is honored", () => {
+    process.env.EXECUTION_CORE_RATELIMIT_USAGE_ENDPOINT = "https://example/usage";
+    expect(readRatelimitPollerConfig().usageEndpoint).toBe("https://example/usage");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -37,9 +37,11 @@ import {
   TAILER_POLL_INTERVAL_MS,
   readWaitWatcherConfig,
   readMemorySamplerConfig,
+  readRatelimitPollerConfig,
 } from "./config.mjs";
 import { startWaitWatcher as realStartWaitWatcher } from "./wait-watcher.mjs";
 import { startMemorySampler as realStartMemorySampler } from "./memory-sampler.mjs";
+import { startRatelimitPoller as realStartRatelimitPoller } from "./ratelimit-poller.mjs";
 import {
   recoverStartup,
   startMonitor,
@@ -94,6 +96,8 @@ let _refreshTimer = null;
 let _waitWatcher = null;
 // CTL-685: per-worker memory sampler handle.
 let _memorySampler = null;
+// CTL-787: account-level rate-limit usage poller handle.
+let _ratelimitPoller = null;
 // CTL-684: auto-tuner stop handle.
 let _stopAutoTuner = null;
 let _eventWatcher = null;
@@ -294,6 +298,11 @@ export function startDaemon({
   // knob (default-on, CATALYST_MEMORY_SAMPLER=0 disables) like the wait-watcher.
   startMemorySampler = realStartMemorySampler,
   enableMemorySampler = readMemorySamplerConfig().enabled,
+  // CTL-787: account-level rate-limit usage poller. Injectable for tests; gated
+  // by a config knob (default-on, CATALYST_RATELIMIT_POLLER=0 disables) like the
+  // memory sampler.
+  startRatelimitPoller = realStartRatelimitPoller,
+  enableRatelimitPoller = readRatelimitPollerConfig().enabled,
   // CTL-665: committed executionCore concurrency knobs resolved in main() from
   // .catalyst/config.json. Threaded into both the scheduler new-work pull and the
   // boot-resume ceiling. Empty {} (the test default) keeps the legacy state.json path.
@@ -442,6 +451,12 @@ export function startDaemon({
     // a throw triggers PID-file cleanup via stopDaemon.
     if (enableMemorySampler) {
       _memorySampler = startMemorySampler();
+    }
+
+    // CTL-787: start the account-level rate-limit usage poller. Inside the same
+    // try/catch so a throw triggers PID-file cleanup via stopDaemon.
+    if (enableRatelimitPoller) {
+      _ratelimitPoller = startRatelimitPoller();
     }
   } catch (err) {
     stopDaemon();
@@ -715,6 +730,15 @@ export function stopDaemon() {
       log.warn({ err: err?.message }, "stopDaemon: memory-sampler stop failed");
     }
     _memorySampler = null;
+  }
+  // CTL-787: stop the account-level rate-limit usage poller.
+  if (_ratelimitPoller) {
+    try {
+      _ratelimitPoller.stop();
+    } catch (err) {
+      log.warn({ err: err?.message }, "stopDaemon: ratelimit-poller stop failed");
+    }
+    _ratelimitPoller = null;
   }
   // CTL-684: stop the auto-tuner.
   if (_stopAutoTuner) {

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -510,6 +510,61 @@ describe("startDaemon", () => {
     expect(() => stopDaemon()).not.toThrow();
     expect(stopped).toBe(1);
   });
+
+  // CTL-787: the account-level rate-limit poller is started from startDaemon
+  // (default-on), gated by enableRatelimitPoller, and stopped in stopDaemon —
+  // mirroring the CTL-685 memory-sampler wiring.
+  test("starts the ratelimit-poller when enabled (CTL-787)", () => {
+    let started = 0;
+    startDaemon({
+      recover: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+      startRatelimitPoller: () => {
+        started++;
+        return { stop: () => {} };
+      },
+      enableRatelimitPoller: true,
+    });
+    expect(started).toBe(1);
+  });
+
+  test("skips the ratelimit-poller when disabled (CTL-787)", () => {
+    let started = 0;
+    startDaemon({
+      recover: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+      startRatelimitPoller: () => {
+        started++;
+        return { stop: () => {} };
+      },
+      enableRatelimitPoller: false,
+    });
+    expect(started).toBe(0);
+  });
+
+  test("stopDaemon stops the ratelimit-poller and swallows a throwing stop() (CTL-787)", () => {
+    let stopped = 0;
+    startDaemon({
+      recover: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+      startRatelimitPoller: () => ({
+        stop: () => {
+          stopped++;
+          throw new Error("simulated poller stop failure");
+        },
+      }),
+      enableRatelimitPoller: true,
+    });
+    // Must not throw even though stop() throws
+    expect(() => stopDaemon()).not.toThrow();
+    expect(stopped).toBe(1);
+  });
 });
 
 // CTL-678 — main()-side resolver: pre-merge Layer-1 (committed seed) under

--- a/plugins/dev/scripts/execution-core/ratelimit-event.mjs
+++ b/plugins/dev/scripts/execution-core/ratelimit-event.mjs
@@ -1,0 +1,116 @@
+// ratelimit-event.mjs — CTL-787. Account-level Claude rate-limit usage event
+// builder + best-effort appender. Mirrors memory-event.mjs's shape (OTel
+// envelope, appendFileSync, never throws) so orch-monitor/HUD parsers treat
+// these events identically.
+//
+// One event name:
+//   account.ratelimit.sampled — INFO, emitted every poll tick with the live
+//   account-level utilization snapshot from GET /api/oauth/usage.
+//
+// CRITICAL DIFFERENCE FROM memory-event: the numeric/string values are placed
+// as LOG-RECORD attributes in DOT form (account.email, ratelimit.five_hour_pct,
+// …) so the catalyst-otel collector can rename dot→underscore and Loki promotes
+// them to labels — exactly how OTL-2 panels 50/51 consume them. A body.payload
+// mirror of the same fields is kept for human readability.
+
+import { mkdirSync, appendFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getEventLogPath, log } from "./config.mjs";
+
+export const RATELIMIT_EVENT_SAMPLED = "account.ratelimit.sampled";
+
+/**
+ * buildRatelimitEnvelope — assemble the canonical OTel envelope for an account
+ * rate-limit event. Pure (modulo random ids + timestamp); no I/O.
+ *
+ * @param {string} name   RATELIMIT_EVENT_SAMPLED
+ * @param {object} payload
+ * @param {object} [opts]
+ * @param {Function} [opts.now]  injectable timestamp fn (returns ISO string)
+ * @returns {object} the envelope object
+ */
+export function buildRatelimitEnvelope(name, payload = {}, { now } = {}) {
+  const ts = now ? now() : new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const severityText = "INFO";
+  const severityNumber = 9;
+  const {
+    email = null,
+    fiveHourPct = null,
+    sevenDayPct = null,
+    fiveHourResetsAt = null,
+    sevenDayResetsAt = null,
+    opusPct = null,
+    sonnetPct = null,
+    subscriptionType = null,
+    rateLimitTier = null,
+  } = payload;
+  const action = name.replace(/^account\./, "");
+
+  // Only include a DOT-form attribute when its value is non-null/defined so the
+  // collector never promotes an empty label.
+  const attributes = {
+    "event.name": name,
+    "event.entity": "account",
+    "event.action": action,
+    "event.label": email ?? "unknown",
+  };
+  const put = (key, value) => {
+    if (value !== null && value !== undefined) attributes[key] = value;
+  };
+  put("account.email", email);
+  put("ratelimit.five_hour_pct", fiveHourPct);
+  put("ratelimit.seven_day_pct", sevenDayPct);
+  put("ratelimit.five_hour_resets_at", fiveHourResetsAt);
+  put("ratelimit.seven_day_resets_at", sevenDayResetsAt);
+  put("ratelimit.seven_day_opus_pct", opusPct);
+  put("ratelimit.seven_day_sonnet_pct", sonnetPct);
+  put("subscription.type", subscriptionType);
+  put("rate_limit.tier", rateLimitTier);
+
+  return {
+    ts,
+    id: randomBytes(8).toString("hex"),
+    observedTs: ts,
+    severityText,
+    severityNumber,
+    traceId: randomBytes(16).toString("hex"),
+    spanId: randomBytes(8).toString("hex"),
+    resource: {
+      "service.name": "catalyst.execution-core",
+      "service.namespace": "catalyst",
+    },
+    attributes,
+    body: {
+      payload: {
+        email,
+        fiveHourPct,
+        sevenDayPct,
+        fiveHourResetsAt,
+        sevenDayResetsAt,
+        opusPct,
+        sonnetPct,
+        subscriptionType,
+        rateLimitTier,
+      },
+    },
+  };
+}
+
+/**
+ * emitRatelimitEvent — build + append one envelope line to the event log.
+ * Returns true on success, false on any failure (best-effort; never throws).
+ * `logPath` is injectable for tests; `now` is an optional injectable timestamp
+ * fn forwarded into buildRatelimitEnvelope (defaults to real time).
+ */
+export function emitRatelimitEvent(name, payload, { logPath = getEventLogPath(), now } = {}) {
+  const line = `${JSON.stringify(buildRatelimitEnvelope(name, payload, { now }))}\n`;
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, line);
+    return true;
+  } catch (err) {
+    log.warn({ err: err?.message, name }, "ratelimit-event: event append failed");
+    return false;
+  }
+}

--- a/plugins/dev/scripts/execution-core/ratelimit-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/ratelimit-event.test.mjs
@@ -1,0 +1,158 @@
+// ratelimit-event.test.mjs — CTL-787. OTel account rate-limit event builder +
+// best-effort appender. buildRatelimitEnvelope is asserted without touching the
+// FS; emitRatelimitEvent is exercised against a temp event log.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test ratelimit-event.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildRatelimitEnvelope,
+  emitRatelimitEvent,
+  RATELIMIT_EVENT_SAMPLED,
+} from "./ratelimit-event.mjs";
+
+const basePayload = {
+  email: "ryan@rozich.com",
+  fiveHourPct: 42,
+  sevenDayPct: 17,
+  fiveHourResetsAt: "2026-06-06T18:00:00Z",
+  sevenDayResetsAt: "2026-06-13T00:00:00Z",
+  opusPct: 12,
+  sonnetPct: 5,
+  subscriptionType: "active",
+  rateLimitTier: "default_claude_max_20x",
+};
+
+describe("buildRatelimitEnvelope", () => {
+  test("resource/service fields and severity INFO/9", () => {
+    const env = buildRatelimitEnvelope(RATELIMIT_EVENT_SAMPLED, basePayload);
+    expect(env.severityText).toBe("INFO");
+    expect(env.severityNumber).toBe(9);
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(env.resource["service.namespace"]).toBe("catalyst");
+  });
+
+  test("event.* identity attributes", () => {
+    const env = buildRatelimitEnvelope(RATELIMIT_EVENT_SAMPLED, basePayload);
+    expect(env.attributes["event.name"]).toBe("account.ratelimit.sampled");
+    expect(env.attributes["event.entity"]).toBe("account");
+    expect(env.attributes["event.action"]).toBe("ratelimit.sampled");
+    expect(env.attributes["event.label"]).toBe("ryan@rozich.com");
+  });
+
+  test("DOT-form attributes present with correct values", () => {
+    const env = buildRatelimitEnvelope(RATELIMIT_EVENT_SAMPLED, basePayload);
+    const a = env.attributes;
+    expect(a["account.email"]).toBe("ryan@rozich.com");
+    expect(a["ratelimit.five_hour_pct"]).toBe(42);
+    expect(a["ratelimit.seven_day_pct"]).toBe(17);
+    expect(a["ratelimit.five_hour_resets_at"]).toBe("2026-06-06T18:00:00Z");
+    expect(a["ratelimit.seven_day_resets_at"]).toBe("2026-06-13T00:00:00Z");
+    expect(a["ratelimit.seven_day_opus_pct"]).toBe(12);
+    expect(a["ratelimit.seven_day_sonnet_pct"]).toBe(5);
+    expect(a["subscription.type"]).toBe("active");
+    expect(a["rate_limit.tier"]).toBe("default_claude_max_20x");
+  });
+
+  test("zero utilization is preserved (not dropped as falsy)", () => {
+    const env = buildRatelimitEnvelope(RATELIMIT_EVENT_SAMPLED, {
+      email: "ryan@rozich.com",
+      fiveHourPct: 0,
+      sevenDayPct: 0,
+    });
+    expect(env.attributes["ratelimit.five_hour_pct"]).toBe(0);
+    expect(env.attributes["ratelimit.seven_day_pct"]).toBe(0);
+  });
+
+  test("absent keys are omitted when null", () => {
+    const env = buildRatelimitEnvelope(RATELIMIT_EVENT_SAMPLED, {
+      email: "ryan@rozich.com",
+      fiveHourPct: 42,
+    });
+    const a = env.attributes;
+    expect("ratelimit.seven_day_pct" in a).toBe(false);
+    expect("ratelimit.five_hour_resets_at" in a).toBe(false);
+    expect("ratelimit.seven_day_opus_pct" in a).toBe(false);
+    expect("ratelimit.seven_day_sonnet_pct" in a).toBe(false);
+    expect("subscription.type" in a).toBe(false);
+    expect("rate_limit.tier" in a).toBe(false);
+  });
+
+  test("event.label falls back to 'unknown' when email absent", () => {
+    const env = buildRatelimitEnvelope(RATELIMIT_EVENT_SAMPLED, { fiveHourPct: 1 });
+    expect(env.attributes["event.label"]).toBe("unknown");
+    expect("account.email" in env.attributes).toBe(false);
+  });
+
+  test("body.payload mirrors the same fields for human readability", () => {
+    const env = buildRatelimitEnvelope(RATELIMIT_EVENT_SAMPLED, basePayload);
+    expect(env.body.payload).toMatchObject({
+      email: "ryan@rozich.com",
+      fiveHourPct: 42,
+      sevenDayPct: 17,
+      fiveHourResetsAt: "2026-06-06T18:00:00Z",
+      sevenDayResetsAt: "2026-06-13T00:00:00Z",
+      opusPct: 12,
+      sonnetPct: 5,
+      subscriptionType: "active",
+      rateLimitTier: "default_claude_max_20x",
+    });
+  });
+
+  test("ts is a Z-suffixed timestamp with no millisecond fraction", () => {
+    const env = buildRatelimitEnvelope(RATELIMIT_EVENT_SAMPLED, basePayload);
+    expect(env.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  test("injectable now() overrides timestamp", () => {
+    const fixed = "2026-06-06T12:00:00Z";
+    const env = buildRatelimitEnvelope(RATELIMIT_EVENT_SAMPLED, basePayload, {
+      now: () => fixed,
+    });
+    expect(env.ts).toBe(fixed);
+    expect(env.observedTs).toBe(fixed);
+  });
+
+  test("envelope has id, traceId, spanId random hex fields", () => {
+    const env = buildRatelimitEnvelope(RATELIMIT_EVENT_SAMPLED, basePayload);
+    expect(env.id).toMatch(/^[0-9a-f]{16}$/);
+    expect(env.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(env.spanId).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+describe("emitRatelimitEvent", () => {
+  test("appends exactly one valid JSON line and returns true", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl787-re-"));
+    const logPath = join(dir, "2026-06.jsonl");
+    const ok = emitRatelimitEvent(RATELIMIT_EVENT_SAMPLED, basePayload, { logPath });
+    expect(ok).toBe(true);
+    const lines = readFileSync(logPath, "utf8").trim().split("\n");
+    expect(lines.length).toBe(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.attributes["event.name"]).toBe(RATELIMIT_EVENT_SAMPLED);
+    expect(parsed.attributes["account.email"]).toBe("ryan@rozich.com");
+    expect(parsed.body.payload.opusPct).toBe(12);
+  });
+
+  test("creates the parent directory when missing (never throws)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl787-re-"));
+    const logPath = join(dir, "nested", "deep", "2026-06.jsonl");
+    expect(emitRatelimitEvent(RATELIMIT_EVENT_SAMPLED, basePayload, { logPath })).toBe(true);
+    const lines = readFileSync(logPath, "utf8").trim().split("\n");
+    expect(lines.length).toBe(1);
+  });
+
+  test("returns false and does not throw for an unwritable logPath", () => {
+    // Passing a directory as the logPath makes appendFileSync throw EISDIR.
+    const dir = mkdtempSync(join(tmpdir(), "ctl787-re-bad-"));
+    let result;
+    expect(() => {
+      result = emitRatelimitEvent(RATELIMIT_EVENT_SAMPLED, basePayload, { logPath: dir });
+    }).not.toThrow();
+    expect(result).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/ratelimit-poller.mjs
+++ b/plugins/dev/scripts/execution-core/ratelimit-poller.mjs
@@ -1,0 +1,276 @@
+// ratelimit-poller.mjs — CTL-787. Account-level Claude rate-limit usage poller.
+//
+// Every ~5 min (floor 180s) it reads the local OAuth access token, calls
+// GET https://api.anthropic.com/api/oauth/usage with the validated 3-header
+// shape, and emits one account.ratelimit.sampled event carrying the live
+// 5h / 7d utilization (plus per-model 7d opus + sonnet) for the account. The
+// account email is resolved ONCE (via GET /api/oauth/profile, falling back to
+// OTEL_RESOURCE_ATTRIBUTES) and cached on the poller instance.
+//
+// On HTTP 429 it backs off by skipping ticks (multiplier grows 1→2→4×, so the
+// inter-attempt gap grows 2→3→5× intervalMs, capped so the gap stays <=15 min)
+// and resets to no-skip on the next success.
+//
+// Secrets hygiene: the OAuth token is read into a variable and used without
+// ever being logged or echoed. NEVER print it.
+//
+// All side effects (readToken, fetchUsage, resolveEmail, emit, clock) are
+// injected so tick() is fully unit-testable with no real network or keychain.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { readRatelimitPollerConfig, log } from "./config.mjs";
+import { emitRatelimitEvent, RATELIMIT_EVENT_SAMPLED } from "./ratelimit-event.mjs";
+
+const PROFILE_ENDPOINT = "https://api.anthropic.com/api/oauth/profile";
+const OAUTH_BETA = "oauth-2025-04-20";
+// The hard floor and the absolute backoff ceiling, per the locked CTL-787 spec.
+const INTERVAL_FLOOR_MS = 180000;
+const BACKOFF_CAP_MS = 15 * 60_000;
+
+function realClock() {
+  return {
+    setInterval: (fn, ms) => setInterval(fn, ms),
+    clearInterval: (handle) => clearInterval(handle),
+  };
+}
+
+// defaultReadToken — resolve the local OAuth access token. macOS reads the
+// Keychain generic password; other platforms read ~/.claude/.credentials.json.
+// Both paths parse the same JSON blob and pull .claudeAiOauth.accessToken.
+// Returns null on ANY error — never throws, never logs the token.
+function defaultReadToken() {
+  try {
+    let raw;
+    if (process.platform === "darwin") {
+      raw = execFileSync(
+        "security",
+        ["find-generic-password", "-s", "Claude Code-credentials", "-w"],
+        { encoding: "utf8" },
+      );
+    } else {
+      raw = readFileSync(resolve(homedir(), ".claude", ".credentials.json"), "utf8");
+    }
+    const token = JSON.parse(raw)?.claudeAiOauth?.accessToken;
+    return token || null;
+  } catch {
+    return null;
+  }
+}
+
+// getUserAgent — REQUIRED header. A wrong/missing UA triggers an instant
+// persistent 429. Built from the locally-installed claude version; computed
+// once at startup. Falls back to "claude-code/unknown".
+function getUserAgent() {
+  try {
+    const out = execFileSync("claude", ["--version"], { encoding: "utf8" });
+    const token = String(out).trim().split(/\s+/)[0];
+    return `claude-code/${token || "unknown"}`;
+  } catch {
+    return "claude-code/unknown";
+  }
+}
+
+function authHeaders(token, userAgent) {
+  return {
+    Authorization: `Bearer ${token}`,
+    "anthropic-beta": OAUTH_BETA,
+    "User-Agent": userAgent,
+  };
+}
+
+// pctOf — normalize a usage bucket to its numeric utilization. The live usage
+// endpoint returns each bucket (five_hour, seven_day, seven_day_opus,
+// seven_day_sonnet) as an object { utilization, resets_at }; older docs showed
+// the per-model buckets as bare numbers. Accept either shape, null when absent.
+// (Validated 2026-06-06: seven_day_sonnet came back as an object, so emitting it
+// raw produced "[object Object]" in Loki — this guards against that.)
+function pctOf(bucket) {
+  if (bucket == null) return null;
+  if (typeof bucket === "object") return bucket.utilization ?? null;
+  return bucket;
+}
+
+// defaultFetchUsage — GET the usage endpoint with the 3 required headers.
+// Returns { status, body } where body is parsed JSON when status===200, else
+// null. NEVER throws (a network error returns { status: 0, body: null }).
+async function defaultFetchUsage(token, { endpoint, userAgent }) {
+  try {
+    const res = await fetch(endpoint, {
+      method: "GET",
+      headers: authHeaders(token, userAgent),
+    });
+    const status = res.status;
+    const body = status === 200 ? await res.json() : null;
+    return { status, body };
+  } catch {
+    return { status: 0, body: null };
+  }
+}
+
+// parseOtelEmail — pull user.email from the comma-separated
+// OTEL_RESOURCE_ATTRIBUTES key=value list. Returns null when absent.
+function parseOtelEmail() {
+  const attrs = process.env.OTEL_RESOURCE_ATTRIBUTES;
+  if (!attrs) return null;
+  for (const pair of attrs.split(",")) {
+    const idx = pair.indexOf("=");
+    if (idx === -1) continue;
+    const key = pair.slice(0, idx).trim();
+    if (key === "user.email") {
+      const value = pair.slice(idx + 1).trim();
+      return value || null;
+    }
+  }
+  return null;
+}
+
+// defaultResolveEmail — GET /api/oauth/profile to resolve .account.email and
+// harvest .organization.rate_limit_tier / .organization.subscription_status
+// when present. On failure, parse user.email from OTEL_RESOURCE_ATTRIBUTES.
+// Returns { email, rateLimitTier, subscriptionType } (any field may be null);
+// returns null only when NO email could be resolved at all. NEVER throws.
+async function defaultResolveEmail(token, { userAgent }) {
+  try {
+    const res = await fetch(PROFILE_ENDPOINT, {
+      method: "GET",
+      headers: authHeaders(token, userAgent),
+    });
+    if (res.status === 200) {
+      const body = await res.json();
+      const email = body?.account?.email ?? null;
+      const rateLimitTier = body?.organization?.rate_limit_tier ?? null;
+      const subscriptionType = body?.organization?.subscription_status ?? null;
+      if (email) return { email, rateLimitTier, subscriptionType };
+    }
+  } catch {
+    /* fall through to the env fallback */
+  }
+  const fallbackEmail = parseOtelEmail();
+  if (fallbackEmail) {
+    return { email: fallbackEmail, rateLimitTier: null, subscriptionType: null };
+  }
+  return null;
+}
+
+/**
+ * startRatelimitPoller — start the periodic account rate-limit poll. Returns
+ * { stop, tick }. All I/O is injected so tick() is testable with zero real
+ * network or keychain access.
+ *
+ * @param {object} opts
+ * @param {object}   [opts.clock=realClock()]                fake-clock seam
+ * @param {object}   [opts.config=readRatelimitPollerConfig()] cadence + endpoint
+ * @param {Function} [opts.readToken=defaultReadToken]       OAuth token reader (sync, returns string|null)
+ * @param {Function} [opts.fetchUsage=defaultFetchUsage]     usage GET ({status,body})
+ * @param {Function} [opts.resolveEmail=defaultResolveEmail] one-shot email resolver
+ * @param {Function} [opts.emit=emitRatelimitEvent]          event emitter
+ * @param {Function} [opts.now]                              injectable envelope timestamp fn (forwarded to emit; defaults to real time)
+ */
+export function startRatelimitPoller({
+  clock = realClock(),
+  config = readRatelimitPollerConfig(),
+  readToken = defaultReadToken,
+  fetchUsage = defaultFetchUsage,
+  resolveEmail = defaultResolveEmail,
+  emit = emitRatelimitEvent,
+  now = undefined,
+} = {}) {
+  const userAgent = getUserAgent();
+  const intervalMs = Math.max(INTERVAL_FLOOR_MS, config.intervalMs);
+  // Cap the backoff multiplier so the inter-attempt GAP stays <= BACKOFF_CAP_MS.
+  // N skipped ticks before the next real attempt yield a gap of (N+1)*intervalMs,
+  // so the cap on N is floor(BACKOFF_CAP_MS / intervalMs) - 1 (e.g. 5 min interval
+  // → maxMultiplier 2 → max gap (2+1)*5 = 15 min; 3 min interval → maxMultiplier 4
+  // → max gap (4+1)*3 = 15 min). At least 1.
+  const maxMultiplier = Math.max(1, Math.floor(BACKOFF_CAP_MS / intervalMs) - 1);
+
+  // Account email is resolved lazily on the first successful token read and
+  // cached for the life of the poller. orgMeta carries the profile-harvested
+  // tier/subscription so they ride on every emit.
+  let cachedEmail = null;
+  let orgMeta = { rateLimitTier: null, subscriptionType: null };
+  let emailResolved = false; // guard so a null-resolving profile is not retried every tick
+  let backoffMultiplier = 1; // 1 = no backoff; grows on 429
+  let skipCounter = 0; // ticks to skip before the next real attempt
+
+  async function tick() {
+    try {
+      if (skipCounter > 0) {
+        skipCounter--;
+        return;
+      }
+
+      const token = readToken();
+      if (!token) {
+        log.warn("ratelimit-poller: no OAuth token available; skipping tick");
+        return;
+      }
+
+      // Resolve the account email ONCE; reuse the cached value thereafter.
+      if (!emailResolved) {
+        const resolved = await resolveEmail(token, { userAgent });
+        emailResolved = true;
+        if (resolved) {
+          cachedEmail = resolved.email ?? null;
+          orgMeta = {
+            rateLimitTier: resolved.rateLimitTier ?? null,
+            subscriptionType: resolved.subscriptionType ?? null,
+          };
+        }
+      }
+
+      const { status, body } = await fetchUsage(token, {
+        endpoint: config.usageEndpoint,
+        userAgent,
+      });
+
+      if (status === 429) {
+        // Backoff: skip the next (multiplier) intervals, then grow the
+        // multiplier (capped). Reset only on a 200.
+        skipCounter = backoffMultiplier;
+        backoffMultiplier = Math.min(backoffMultiplier * 2, maxMultiplier);
+        log.warn(
+          { nextSkips: skipCounter },
+          "ratelimit-poller: 429 from usage endpoint; backing off",
+        );
+        return;
+      }
+
+      if (status !== 200 || !body) {
+        log.warn({ status }, "ratelimit-poller: non-200 usage response; skipping emit");
+        return;
+      }
+
+      // Success — reset backoff.
+      backoffMultiplier = 1;
+      skipCounter = 0;
+
+      const fiveHour = body.five_hour ?? {};
+      const sevenDay = body.seven_day ?? {};
+      emit(
+        RATELIMIT_EVENT_SAMPLED,
+        {
+          email: cachedEmail,
+          fiveHourPct: pctOf(body.five_hour),
+          sevenDayPct: pctOf(body.seven_day),
+          fiveHourResetsAt: fiveHour.resets_at ?? null,
+          sevenDayResetsAt: sevenDay.resets_at ?? null,
+          opusPct: pctOf(body.seven_day_opus),
+          sonnetPct: pctOf(body.seven_day_sonnet),
+          subscriptionType: orgMeta.subscriptionType,
+          rateLimitTier: orgMeta.rateLimitTier,
+        },
+        { now },
+      );
+    } catch (err) {
+      log.warn({ err: err?.message }, "ratelimit-poller: tick failed");
+    }
+  }
+
+  const handle = clock.setInterval(tick, intervalMs);
+  if (typeof handle?.unref === "function") handle.unref();
+  return { stop: () => clock.clearInterval(handle), tick };
+}

--- a/plugins/dev/scripts/execution-core/ratelimit-poller.test.mjs
+++ b/plugins/dev/scripts/execution-core/ratelimit-poller.test.mjs
@@ -1,0 +1,364 @@
+// ratelimit-poller.test.mjs — CTL-787. The account rate-limit poller core:
+// 200-body parse + emit, 429 backoff/skip, success backoff reset, missing-token
+// no-op, non-200/null-body no-op, one-shot cached email, file-fallback token
+// read, and stop(). All dependencies injected; tick() awaited directly — no
+// real timer, no real network, no real keychain.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test ratelimit-poller.test.mjs
+
+import { test, expect, describe } from "bun:test";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startRatelimitPoller } from "./ratelimit-poller.mjs";
+import { RATELIMIT_EVENT_SAMPLED, emitRatelimitEvent } from "./ratelimit-event.mjs";
+
+// Recording fake clock — setInterval returns a stable handle; tests drive
+// w.tick() directly.
+function recordingClock() {
+  const handle = { id: Symbol("interval") };
+  let cleared = false;
+  return {
+    setInterval: () => handle,
+    clearInterval: (h) => {
+      if (h === handle) cleared = true;
+    },
+    handle,
+    wasCleared: () => cleared,
+  };
+}
+
+// A representative live 200 body (validated shape from GET /api/oauth/usage on
+// 2026-06-06). The per-model 7d buckets come back as OBJECTS { utilization,
+// resets_at }, same as five_hour/seven_day — NOT bare numbers — so the poller
+// must normalize them to the numeric utilization (see pctOf).
+function usageBody(overrides = {}) {
+  return {
+    five_hour: { utilization: 42, resets_at: "2026-06-06T18:00:00Z" },
+    seven_day: { utilization: 17, resets_at: "2026-06-13T00:00:00Z" },
+    seven_day_opus: { utilization: 12, resets_at: "2026-06-13T00:00:00Z" },
+    seven_day_sonnet: { utilization: 5, resets_at: "2026-06-13T00:00:00Z" },
+    ...overrides,
+  };
+}
+
+const TOKEN = "sk-oauth-FAKE-TOKEN-never-logged";
+const EMAIL = "ryan@rozich.com";
+
+// Build a test harness. All seams injected; defaults to a healthy 200 path.
+function harness({
+  readToken = () => TOKEN,
+  fetchUsage = async () => ({ status: 200, body: usageBody() }),
+  resolveEmail = async () => ({
+    email: EMAIL,
+    rateLimitTier: "default_claude_max_20x",
+    subscriptionType: "active",
+  }),
+  config = { enabled: true, intervalMs: 300000, usageEndpoint: "https://example/usage" },
+} = {}) {
+  const emitted = [];
+  const fetchCalls = [];
+  const resolveCalls = [];
+  const clock = recordingClock();
+  const w = startRatelimitPoller({
+    clock,
+    config,
+    readToken,
+    fetchUsage: async (token, opts) => {
+      fetchCalls.push({ token, opts });
+      return fetchUsage(token, opts);
+    },
+    resolveEmail: async (token, opts) => {
+      resolveCalls.push({ token, opts });
+      return resolveEmail(token, opts);
+    },
+    emit: (name, payload) => emitted.push({ name, payload }),
+  });
+  return { w, emitted, fetchCalls, resolveCalls, clock };
+}
+
+// ─── 200 parse + emit ────────────────────────────────────────────────────────
+
+describe("tick — 200 body", () => {
+  test("parses a 200 body and emits one account.ratelimit.sampled with all fields", async () => {
+    const { w, emitted } = harness();
+    await w.tick();
+    expect(emitted.length).toBe(1);
+    const { name, payload } = emitted[0];
+    expect(name).toBe(RATELIMIT_EVENT_SAMPLED);
+    expect(payload.email).toBe(EMAIL);
+    expect(payload.fiveHourPct).toBe(42);
+    expect(payload.sevenDayPct).toBe(17);
+    expect(payload.fiveHourResetsAt).toBe("2026-06-06T18:00:00Z");
+    expect(payload.sevenDayResetsAt).toBe("2026-06-13T00:00:00Z");
+    expect(payload.opusPct).toBe(12);
+    expect(payload.sonnetPct).toBe(5);
+    expect(payload.subscriptionType).toBe("active");
+    expect(payload.rateLimitTier).toBe("default_claude_max_20x");
+  });
+
+  test("zero utilization is carried through (not dropped)", async () => {
+    const { w, emitted } = harness({
+      fetchUsage: async () => ({
+        status: 200,
+        body: usageBody({
+          five_hour: { utilization: 0, resets_at: "x" },
+          seven_day: { utilization: 0, resets_at: "y" },
+        }),
+      }),
+    });
+    await w.tick();
+    expect(emitted[0].payload.fiveHourPct).toBe(0);
+    expect(emitted[0].payload.sevenDayPct).toBe(0);
+  });
+
+  test("per-model 7d buckets are normalized to numbers (object shape) — guards the [object Object] bug", async () => {
+    const { w, emitted } = harness();
+    await w.tick();
+    const { payload } = emitted[0];
+    // The live API returns objects; pctOf must extract the numeric utilization,
+    // never the whole object (which would stringify to "[object Object]" in Loki).
+    expect(payload.opusPct).toBe(12);
+    expect(payload.sonnetPct).toBe(5);
+    expect(typeof payload.opusPct).toBe("number");
+    expect(typeof payload.sonnetPct).toBe("number");
+  });
+
+  test("per-model 7d buckets also accept bare-number shape (back-compat)", async () => {
+    const { w, emitted } = harness({
+      fetchUsage: async () => ({
+        status: 200,
+        body: usageBody({ seven_day_opus: 9, seven_day_sonnet: 3 }),
+      }),
+    });
+    await w.tick();
+    expect(emitted[0].payload.opusPct).toBe(9);
+    expect(emitted[0].payload.sonnetPct).toBe(3);
+  });
+
+  test("absent per-model 7d buckets emit null (omitted downstream)", async () => {
+    const { w, emitted } = harness({
+      fetchUsage: async () => ({
+        status: 200,
+        body: usageBody({ seven_day_opus: undefined, seven_day_sonnet: undefined }),
+      }),
+    });
+    await w.tick();
+    expect(emitted[0].payload.opusPct).toBeNull();
+    expect(emitted[0].payload.sonnetPct).toBeNull();
+  });
+});
+
+// ─── 429 backoff ─────────────────────────────────────────────────────────────
+
+describe("tick — 429 backoff", () => {
+  test("429 emits nothing and the next tick is skipped", async () => {
+    let status = 429;
+    const { w, emitted, fetchCalls } = harness({
+      fetchUsage: async () => ({ status, body: null }),
+    });
+
+    await w.tick(); // 429 — no emit, sets skipCounter=1
+    expect(emitted.length).toBe(0);
+    expect(fetchCalls.length).toBe(1);
+
+    await w.tick(); // skipped — fetch not called again
+    expect(fetchCalls.length).toBe(1);
+    expect(emitted.length).toBe(0);
+  });
+
+  test("success after 429 resets backoff (no further skips)", async () => {
+    let status = 429;
+    const { w, emitted, fetchCalls } = harness({
+      fetchUsage: async () => (status === 429 ? { status: 429, body: null } : { status: 200, body: usageBody() }),
+    });
+
+    await w.tick(); // 429 → skipCounter=1
+    await w.tick(); // skipped
+    status = 200;
+    await w.tick(); // real attempt → 200, emit, reset backoff
+    expect(emitted.length).toBe(1);
+    const fetchesSoFar = fetchCalls.length;
+
+    await w.tick(); // not skipped anymore (backoff reset) → emits again
+    expect(emitted.length).toBe(2);
+    expect(fetchCalls.length).toBe(fetchesSoFar + 1);
+  });
+
+  // CTL-787 reviewer FIX 1: the skip loop consumes skipCounter ticks BEFORE the
+  // next real attempt, so N skips ⇒ an inter-attempt gap of (N+1)*intervalMs.
+  // Capping the skip COUNT at floor(CAP/interval) overshoots the 15-min cap;
+  // the GAP must be capped instead. Drive sustained 429s and assert the gap
+  // between consecutive real fetch attempts never exceeds BACKOFF_CAP_MS — for
+  // BOTH the 5-min default cadence and the 180s interval floor.
+  const BACKOFF_CAP_MS = 15 * 60_000;
+
+  async function maxObservedGapMs(intervalMs) {
+    // Always-429: every real attempt grows the backoff toward the cap.
+    const { w, fetchCalls } = harness({
+      fetchUsage: async () => ({ status: 429, body: null }),
+      config: { enabled: true, intervalMs, usageEndpoint: "https://example/usage" },
+    });
+    let maxSkipRun = 0; // most skipped ticks observed before any real attempt
+    let skipsSinceLastFetch = 0;
+    let lastFetchCount = 0;
+    // Many ticks so the backoff saturates at maxMultiplier and we observe the
+    // steady-state skip run repeatedly.
+    for (let i = 0; i < 200; i++) {
+      await w.tick();
+      if (fetchCalls.length > lastFetchCount) {
+        // A real attempt fired this tick — close out the preceding skip run.
+        if (skipsSinceLastFetch > maxSkipRun) maxSkipRun = skipsSinceLastFetch;
+        skipsSinceLastFetch = 0;
+        lastFetchCount = fetchCalls.length;
+      } else {
+        // A skipped tick (skipCounter consumed; no fetch).
+        skipsSinceLastFetch++;
+      }
+    }
+    // gap between two consecutive real attempts = (skips + 1) * intervalMs.
+    return (maxSkipRun + 1) * intervalMs;
+  }
+
+  test("backoff never lets the inter-attempt gap exceed BACKOFF_CAP_MS — 5-min default", async () => {
+    const gap = await maxObservedGapMs(300000);
+    expect(gap).toBeLessThanOrEqual(BACKOFF_CAP_MS);
+    expect(gap).toBe(15 * 60_000); // (2+1)*5min — saturates exactly at the cap
+  });
+
+  test("backoff never lets the inter-attempt gap exceed BACKOFF_CAP_MS — 180s floor", async () => {
+    const gap = await maxObservedGapMs(180000);
+    expect(gap).toBeLessThanOrEqual(BACKOFF_CAP_MS);
+    expect(gap).toBe(15 * 60_000); // (4+1)*3min — saturates exactly at the cap
+  });
+});
+
+// ─── missing token ───────────────────────────────────────────────────────────
+
+test("missing token → no throw, no emit, no fetch", async () => {
+  const { w, emitted, fetchCalls } = harness({ readToken: () => null });
+  await expect(w.tick()).resolves.toBeUndefined();
+  expect(emitted.length).toBe(0);
+  expect(fetchCalls.length).toBe(0);
+});
+
+// ─── non-200 / null body ─────────────────────────────────────────────────────
+
+test("non-200 status → no throw, no emit", async () => {
+  const { w, emitted } = harness({ fetchUsage: async () => ({ status: 500, body: null }) });
+  await expect(w.tick()).resolves.toBeUndefined();
+  expect(emitted.length).toBe(0);
+});
+
+test("200 with null body → no throw, no emit", async () => {
+  const { w, emitted } = harness({ fetchUsage: async () => ({ status: 200, body: null }) });
+  await w.tick();
+  expect(emitted.length).toBe(0);
+});
+
+test("network error (status 0) → no throw, no emit", async () => {
+  const { w, emitted } = harness({ fetchUsage: async () => ({ status: 0, body: null }) });
+  await w.tick();
+  expect(emitted.length).toBe(0);
+});
+
+// ─── email resolved once + cached ────────────────────────────────────────────
+
+test("email is resolved exactly once and cached across ticks", async () => {
+  const { w, emitted, resolveCalls } = harness();
+  await w.tick();
+  await w.tick();
+  await w.tick();
+  expect(resolveCalls.length).toBe(1);
+  expect(emitted.every((e) => e.payload.email === EMAIL)).toBe(true);
+});
+
+test("a null-resolving profile is not retried every tick (email stays null)", async () => {
+  const { w, emitted, resolveCalls } = harness({ resolveEmail: async () => null });
+  await w.tick();
+  await w.tick();
+  expect(resolveCalls.length).toBe(1);
+  expect(emitted[0].payload.email).toBe(null);
+});
+
+// ─── token file fallback (non-darwin path) ───────────────────────────────────
+
+test("injected readToken reading a credentials file returns the accessToken", async () => {
+  // Simulate the non-darwin file-fallback branch without touching the keychain:
+  // an injected readToken that parses a real ~/.claude/.credentials.json shape.
+  const dir = mkdtempSync(join(tmpdir(), "ctl787-cred-"));
+  const credPath = join(dir, ".credentials.json");
+  writeFileSync(
+    credPath,
+    JSON.stringify({ claudeAiOauth: { accessToken: "file-token-abc" } }),
+  );
+  const fileReadToken = () => {
+    try {
+      const raw = require("node:fs").readFileSync(credPath, "utf8");
+      return JSON.parse(raw)?.claudeAiOauth?.accessToken || null;
+    } catch {
+      return null;
+    }
+  };
+  const { w, fetchCalls } = harness({ readToken: fileReadToken });
+  await w.tick();
+  expect(fetchCalls.length).toBe(1);
+  expect(fetchCalls[0].token).toBe("file-token-abc");
+});
+
+// ─── transient resilience ────────────────────────────────────────────────────
+
+test("a throwing fetchUsage does not crash tick and emits nothing", async () => {
+  const { w, emitted } = harness({
+    fetchUsage: async () => {
+      throw new Error("boom");
+    },
+  });
+  await expect(w.tick()).resolves.toBeUndefined();
+  expect(emitted.length).toBe(0);
+});
+
+// ─── injected now() controls the emitted envelope ts (CTL-787 FIX 3) ─────────
+
+test("an injected now() controls the emitted envelope's ts", async () => {
+  // Use the REAL emitRatelimitEvent writing to a temp logPath so the assertion
+  // proves now is threaded end-to-end: startRatelimitPoller → emit → logPath +
+  // now → buildRatelimitEnvelope.ts. (The default harness emit seam discards the
+  // opts arg, so it cannot observe now; this drives the production emit instead.)
+  const dir = mkdtempSync(join(tmpdir(), "ctl787-now-"));
+  const logPath = join(dir, "events.jsonl");
+  const FIXED_TS = "2025-01-02T03:04:05Z";
+  const clock = recordingClock();
+  const w = startRatelimitPoller({
+    clock,
+    config: { enabled: true, intervalMs: 300000, usageEndpoint: "https://example/usage" },
+    readToken: () => TOKEN,
+    fetchUsage: async () => ({ status: 200, body: usageBody() }),
+    resolveEmail: async () => ({ email: EMAIL, rateLimitTier: null, subscriptionType: null }),
+    // Real emitter, redirected to a temp file via logPath; now is threaded through.
+    emit: (name, payload, opts) => emitRatelimitEvent(name, payload, { ...opts, logPath }),
+    now: () => FIXED_TS,
+  });
+  await w.tick();
+  const line = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean).pop();
+  const envelope = JSON.parse(line);
+  expect(envelope.ts).toBe(FIXED_TS);
+  expect(envelope.observedTs).toBe(FIXED_TS);
+});
+
+// ─── stop() ──────────────────────────────────────────────────────────────────
+
+test("stop() calls clock.clearInterval with the registered handle", () => {
+  const clock = recordingClock();
+  const w = startRatelimitPoller({
+    clock,
+    config: { enabled: true, intervalMs: 300000, usageEndpoint: "https://x/usage" },
+    readToken: () => null,
+    fetchUsage: async () => ({ status: 0, body: null }),
+    resolveEmail: async () => null,
+    emit: () => {},
+  });
+  expect(clock.wasCleared()).toBe(false);
+  w.stop();
+  expect(clock.wasCleared()).toBe(true);
+});


### PR DESCRIPTION
## CTL-787 — account-level Claude rate-limit usage poller (emit side)

Adds a periodic **execution-core daemon task** that fetches the Claude.ai 5h/7d subscription usage % from the OAuth usage endpoint and emits them as an account-level telemetry event labeled by account email. Mirrors the CTL-685 memory-sampler pattern line-for-line and the OTL-7 emit-in-catalyst / label+panel-in-catalyst-otel split.

### What & why
Rate-limit 5h/7d % are account-global Claude.ai subscription limits, surfaced by Claude Code only to the interactive statusLine — absent from native OTel telemetry, hook inputs, and the transcript JSONL. The OAuth usage endpoint (`GET /api/oauth/usage`) is the only standalone source. This supersedes the original per-session `session.context` framing (rate limits are account-global, not session-local) — see the CTL-787 discussion.

### Changes (`plugins/dev/scripts/execution-core/`)
- **`ratelimit-poller.mjs`** (new) — `startRatelimitPoller({ clock, config, readToken, fetchUsage, resolveEmail, emit, now })` → `{ stop, tick }`. Reads the OAuth token from the macOS Keychain (`security find-generic-password -s "Claude Code-credentials" -w`, `~/.claude/.credentials.json` fallback on Linux) and **never logs it**. GETs the usage endpoint with the 3 required headers (UA `claude-code/<ver>` — a wrong/missing UA → instant persistent 429). Resolves the account email **once** via `GET /api/oauth/profile` (`.account.email`), falling back to `OTEL_RESOURCE_ATTRIBUTES` `user.email`, then caches it. 180 s floor, ~5-min cadence, exponential 429 skip-tick backoff with the inter-attempt gap capped at 15 min (reset on a 200). All I/O is injected, so `tick()` is fully unit-testable with zero real network/keychain.
- **`ratelimit-event.mjs`** (new) — `buildRatelimitEnvelope` / `emitRatelimitEvent`. Event `account.ratelimit.sampled` (`event.entity=account`, `event.label=<email>`, resource `service.name=catalyst.execution-core`). Carries log-record attributes in **dot form** (`account.email`, `ratelimit.five_hour_pct`, `ratelimit.seven_day_pct`, `ratelimit.five_hour_resets_at`, `ratelimit.seven_day_resets_at`, `ratelimit.seven_day_opus_pct`, `ratelimit.seven_day_sonnet_pct`, `subscription.type`, `rate_limit.tier`) so the catalyst-otel collector can rename them to Loki labels. Best-effort `appendFileSync`, never throws.
- **`config.mjs`** — `readRatelimitPollerConfig()` (`CATALYST_RATELIMIT_POLLER=0` disables; `EXECUTION_CORE_RATELIMIT_POLL_INTERVAL_MS` default `300000`; endpoint override).
- **`daemon.mjs`** — wired symmetric with the memory sampler (import alias, `_ratelimitPoller` handle, injected `startRatelimitPoller`/`enableRatelimitPoller` params, gated startup inside the try, swallowing shutdown).
- **Tests** — `ratelimit-poller.test.mjs`, `ratelimit-event.test.mjs`, plus daemon start/skip/stop wiring-parity tests and config tests.

### Validation (local — note: no CI job runs the `.mjs`/`.sh` suites)
- `bun test` poller + event + config + daemon → **133 pass / 0 fail**
- `node --check` clean on all sources
- `plugins/meta/scripts/audit-references.sh --ci` → 0 critical

### Companion
catalyst-otel CTL-787 adds the collector label rename + the "Account Rate-Limit Usage (5h/7d) by account" dashboard panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
