### PR TITLE
fix(dev): defer CTL-731 liveness deadline verdict so a completed read survives loop starvation (CTL-790)

### DIFF
--- a/plugins/dev/scripts/execution-core/claude-agents.mjs
+++ b/plugins/dev/scripts/execution-core/claude-agents.mjs
@@ -133,47 +133,89 @@ function backoffWindowMs(failures) {
 }
 
 // defaultExecFileAsync — the production async reader: execFile wrapped as a
-// promise, bound to an AbortSignal so the timeout path can kill the child.
+// promise, bound to an AbortSignal so the timeout path can kill the child. The
+// returned promise carries a `.child` reference (the ChildProcess) so the
+// deadline (refreshAgents) can ask whether the child has ACTUALLY exited rather
+// than discarding a completed-but-late read as a timeout (CTL-790). Any injected
+// execFileAsync may omit `.child`; the deadline tolerates its absence.
 function defaultExecFileAsync(bin, args, opts = {}) {
-  return new Promise((resolve, reject) => {
-    execFile(bin, args, { encoding: "utf8", ...opts }, (err, stdout) => {
+  let child;
+  const promise = new Promise((resolve, reject) => {
+    child = execFile(bin, args, { encoding: "utf8", ...opts }, (err, stdout) => {
       if (err) reject(err);
       else resolve(stdout);
     });
   });
+  promise.child = child;
+  return promise;
 }
 
 // refreshAgents — perform ONE async, timed, single-flight `claude agents --json`
 // read and update the shared snapshot. Returns the resolved agents array (or the
 // last-good / [] on failure); never rejects. Concurrent callers join the same
 // in-flight promise (anti-stampede). Injectable seams: execFileAsync (the async
-// reader), now (clock), timeoutMs, setTimer/clearTimer (the deadline timer).
+// reader), now (clock), timeoutMs, setTimer/clearTimer (the deadline timer),
+// deferDecision (the phase-deferral primitive — setImmediate in production).
+//
+// CTL-790 — the deadline must NOT race the read with a bare reject-timer. The
+// scheduler tick is synchronous and blocks the Node event loop for many seconds;
+// libuv runs the TIMERS phase BEFORE the POLL phase, so an overdue deadline timer
+// fires before an already-COMPLETED read is delivered, and a `Promise.race` would
+// discard that good snapshot as a "timeout" — the bug that wedged new-work
+// dispatch forever (isFresh never went true). Instead the deadline DEFERS its
+// verdict one phase via `deferDecision` (setImmediate → the CHECK phase, which
+// runs AFTER poll): a read that finished during the block has had its result
+// delivered and `settled` is set, so it wins. Only a child that is GENUINELY
+// still running (exitCode/signalCode both null) — or an injected fake with no
+// `.child` — is aborted and treated as a timeout. This shrinks the discard
+// window to a child mid-flush; the async-tick refactor (CTL roadmap Stage 2)
+// closes it entirely by never blocking the loop > timeoutMs.
 export function refreshAgents({
   execFileAsync = defaultExecFileAsync,
   now = Date.now,
   timeoutMs = LIVENESS_TIMEOUT_MS,
   setTimer = setTimeout,
   clearTimer = clearTimeout,
+  deferDecision = setImmediate,
 } = {}) {
   if (_inflight) return _inflight; // (c) join the in-flight read
   const controller = new AbortController();
   let timer = null;
+  let settled = false; // (b) set the instant the read resolves/rejects
   const run = (async () => {
     try {
-      const out = await Promise.race([
-        // (a) async read, bound to the abort signal for (b).
-        execFileAsync(CLAUDE_BIN, ["agents", "--json"], {
-          encoding: "utf8",
-          signal: controller.signal,
-        }),
-        // (b) deadline: abort the child and reject so we fall back to last-good.
-        new Promise((_, reject) => {
-          timer = setTimer(() => {
-            controller.abort();
-            reject(new Error("claude agents --json timed out"));
-          }, timeoutMs);
-        }),
-      ]);
+      // (a) async read, bound to the abort signal for (b). `.child` (when the
+      // reader exposes it) is the authoritative "has it exited?" signal.
+      const readP = execFileAsync(CLAUDE_BIN, ["agents", "--json"], {
+        encoding: "utf8",
+        signal: controller.signal,
+      });
+      const out = await new Promise((resolve, reject) => {
+        readP.then(
+          (o) => {
+            settled = true;
+            resolve(o);
+          },
+          (e) => {
+            settled = true;
+            reject(e);
+          },
+        );
+        // (b) deadline: defer the verdict past the poll phase so a completed read
+        // wins; abort + reject only a child that is genuinely still running.
+        timer = setTimer(() => {
+          deferDecision(() => {
+            if (settled) return; // read already completed — honor it
+            const child = readP.child;
+            if (!child || (child.exitCode === null && child.signalCode === null)) {
+              controller.abort();
+              reject(new Error("claude agents --json timed out"));
+            }
+            // else: child has exited; its read callback is imminent in poll —
+            // do nothing and let `readP` settle the outer promise.
+          });
+        }, timeoutMs);
+      });
       const parsed = JSON.parse(out);
       if (!Array.isArray(parsed)) throw new Error("claude agents --json: non-array JSON");
       _asyncSnap = { ts: now(), agents: parsed };

--- a/plugins/dev/scripts/execution-core/claude-agents.test.mjs
+++ b/plugins/dev/scripts/execution-core/claude-agents.test.mjs
@@ -4,6 +4,7 @@
 // seams) so nothing shells out to the real `claude`.
 
 import { describe, test, expect, beforeEach } from "bun:test";
+import { execFile } from "node:child_process";
 import {
   listClaudeAgents,
   listClaudeAgentsResult,
@@ -381,6 +382,108 @@ describe("refreshAgents + getAgentsCached (Phase 00 hardened liveness read)", ()
     });
     timeoutCb();
     expect(await p).toEqual([]);
+  });
+
+  test("(b/CTL-790) a read that COMPLETES before the deferred deadline verdict is HONORED, not discarded", async () => {
+    // The production stall in miniature: the deadline fires, but the read already
+    // settled (child exited). The deferred verdict must keep the good snapshot
+    // rather than discard it as a timeout (the bug that wedged dispatch forever).
+    let resolveRead = null;
+    const child = { exitCode: null, signalCode: null };
+    const reader = () => {
+      const pr = new Promise((res) => {
+        resolveRead = res;
+      });
+      pr.child = child;
+      return pr;
+    };
+    let timeoutCb = null;
+    let deferredCb = null;
+    const p = refreshAgents({
+      execFileAsync: reader,
+      now: () => 1000,
+      timeoutMs: 3000,
+      setTimer: (cb) => {
+        timeoutCb = cb;
+        return 1;
+      },
+      clearTimer: () => {},
+      deferDecision: (cb) => {
+        deferredCb = cb;
+      },
+    });
+    // Read completes (child exits) BEFORE the deferred verdict runs.
+    child.exitCode = 0;
+    resolveRead(JSON.stringify(agents));
+    await Promise.resolve(); // let the read's .then mark `settled`
+    timeoutCb(); // deadline fires → schedules the deferred verdict
+    deferredCb(); // verdict runs AFTER the read settled → must no-op
+    expect(await p).toEqual(agents); // NOT discarded
+    const snap = getAgentsCached({ now: () => 1000 });
+    expect(snap.populated).toBe(true);
+    expect(snap.isFresh).toBe(true);
+  });
+
+  test("(b/CTL-790) a GENUINELY-running read (child not exited) IS aborted at the deadline", async () => {
+    await refreshAgents({ execFileAsync: async () => JSON.stringify(agents), now: () => 1000 });
+    const child = { exitCode: null, signalCode: null }; // still running
+    let capturedSignal = null;
+    const hanging = (_bin, _args, opts) => {
+      capturedSignal = opts.signal;
+      const pr = new Promise(() => {}); // never resolves
+      pr.child = child;
+      return pr;
+    };
+    let timeoutCb = null;
+    const p = refreshAgents({
+      execFileAsync: hanging,
+      now: () => 5000,
+      timeoutMs: 3000,
+      setTimer: (cb) => {
+        timeoutCb = cb;
+        return 1;
+      },
+      clearTimer: () => {},
+      deferDecision: (cb) => cb(), // run the verdict synchronously
+    });
+    timeoutCb();
+    const result = await p;
+    expect(capturedSignal?.aborted).toBe(true); // still running → aborted, not leaked
+    expect(result).toEqual(agents); // served last-good
+  });
+
+  test("(b/CTL-790) INTEGRATION: a real read completing during a synchronous loop-block survives (libuv timers-before-poll)", async () => {
+    // The exact production trap: a real subprocess finishes in ms, but a
+    // synchronous scheduler tick busy-blocks the event loop > timeoutMs. The old
+    // `Promise.race` discarded the completed read as a timeout; the deferred
+    // verdict keeps it.
+    const sample = [
+      { sessionId: "aaaaaaaa-bbbb-cccc-dddd-000000000001", status: "idle", kind: "background" },
+    ];
+    const realReader = (_bin, _args, opts) => {
+      let child;
+      const pr = new Promise((res, rej) => {
+        child = execFile(
+          "sh",
+          ["-c", `printf '%s' '${JSON.stringify(sample)}'`],
+          opts,
+          (err, stdout) => (err ? rej(err) : res(stdout)),
+        );
+      });
+      pr.child = child;
+      return pr;
+    };
+    const p = refreshAgents({ execFileAsync: realReader, timeoutMs: 100, now: () => 1000 });
+    const end = Date.now() + 300; // block the loop > timeoutMs while the child finishes
+    while (Date.now() < end) {
+      /* busy-wait: starve the event loop, exactly like the synchronous tick */
+    }
+    await p;
+    const snap = getAgentsCached({ now: () => 1000 });
+    expect(snap.populated).toBe(true);
+    expect(snap.isFresh).toBe(true);
+    expect(snap.agents.length).toBe(1);
+    expect(countBackgroundAgents({ now: () => 1000 })).toBe(1);
   });
 
   test("(d) backoff: after the failure threshold, getAgentsCached does NOT fire a new refresh until the window elapses", async () => {


### PR DESCRIPTION
## Problem
The execution-core daemon held **all** new-work dispatch — every tick logged `scheduler: liveness snapshot stale/cold — holding new-work dispatch (CTL-731)` (inFlightCount 0, tickets queued). **Not** Linear rate-limiting (orchestrator OAuth bucket was 4999/5000).

## Root cause (confirmed live, daemon pid 84647, + standalone repro)
The synchronous scheduler tick blocks the Node event loop ~14–18s. `refreshAgents` raced the async `claude agents --json` read against a 3s reject-timer. **libuv runs the timers phase before the poll phase**, so under a >3s block the overdue timeout fires *before* the already-completed read is delivered — discarding the good snapshot as a "timeout". `_asyncSnap` never populates → `isFresh` perpetually false → dispatch held forever. Survives restarts (the tick is structurally long); refresh failures were silently swallowed.

## Fix
The deadline now **defers its verdict via `setImmediate`** (check phase, runs after poll) so a read that completed during the block wins; only a child that is **genuinely still running** (`exitCode`/`signalCode` both null) — or an injected fake with no `.child` — is aborted. `defaultExecFileAsync` exposes `.child` as the authoritative exit signal.

This **shrinks** the discard window (a child mid-flush is the residue); the Stage-2 async-tick refactor closes the class entirely by never blocking the loop > `timeoutMs`.

## Tests
- Two deterministic unit tests covering **both** branches (completed-read-wins; genuinely-running-aborts).
- A **real-subprocess loop-block integration test** that reproduces the exact trap (busy-wait > `timeoutMs` while a real child completes) — would fail on the old `Promise.race`.
- Green locally: claude-agents **51**, scheduler **362**, recovery **185**, work-done-probes.

Stage 0a of the execution-core redesign (`thoughts/shared/research/2026-06-06-execution-core-redesign.md` §2). Ships alone (one-function, bisectable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)