### PR TITLE
feat(dev): compound-engineering Slice 1 — engineering compound loop MVP (CTL-789)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,12 @@ This workspace has no build process - it's markdown files and bash scripts.
 - **Agents are documentarians** — Never suggest improvements unless asked
 - **Preserve context** — Save to thoughts/, not just memory
 
+## Knowledge Store
+
+- `thoughts/shared/learnings/` — past problem→solution entries (grep by component/tags/problem_type).
+  Search before implementing or debugging in a known area. Curated by `/catalyst-foundry:ticket-compound`.
+- `thoughts/CONCEPTS.md` — shared domain vocabulary (reclaim, revive-budget, orphan, signal ownership…).
+
 ## Commit Conventions
 
 - `feat(dev): add new skill` — catalyst-dev minor bump

--- a/plugins/dev/scripts/__tests__/ticket-compound-shape.test.sh
+++ b/plugins/dev/scripts/__tests__/ticket-compound-shape.test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# ticket-compound-shape.test.sh
+# Asserts the Slice-1 compound-engineering surface is wired (CTL-789):
+#   - the ticket-compound curator skill (SKILL.md + reference.md) exists, is
+#     user-invocable, declares allowed-tools, and harvests the friction log.
+#   - the learnings validator exists + is executable, and the seed entry passes it.
+#   - all 5 phase-* artifact skills append a timestamped Friction record
+#     (the "If I'd known" bullet, the per-ticket friction log path, and a
+#     time-bearing %H:%M stamp — date+TIME, never date-only).
+#   - the briefing-followup action-compound handler + CONCEPTS.md seed exist.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+fail=0; assert(){ if ! eval "$2"; then echo "FAIL: $1"; fail=1; else echo "ok: $1"; fi; }
+
+# 1. The ticket-compound curator skill.
+TC_DIR="$ROOT/plugins/foundry/skills/ticket-compound"
+assert "ticket-compound SKILL.md exists"   "test -f '$TC_DIR/SKILL.md'"
+assert "ticket-compound reference.md exists" "test -f '$TC_DIR/reference.md'"
+assert "SKILL.md frontmatter is user-invocable" "grep -q '^user-invocable: true' '$TC_DIR/SKILL.md'"
+assert "SKILL.md frontmatter declares allowed-tools" "grep -q '^allowed-tools:' '$TC_DIR/SKILL.md'"
+assert "Step 1 harvest mentions thoughts/shared/friction/" \
+  "grep -q 'thoughts/shared/friction/' '$TC_DIR/SKILL.md'"
+
+# 2. The learnings validator (backing script lives in dev/scripts/compound).
+VALIDATOR="$ROOT/plugins/dev/scripts/compound/validate-learnings.sh"
+assert "validate-learnings.sh exists"     "test -f '$VALIDATOR'"
+assert "validate-learnings.sh is executable" "test -x '$VALIDATOR'"
+
+# 3. Friction-capture producer block in all 5 artifact phase skills.
+#    Each must reference the per-ticket friction log, carry the canonical
+#    "If I'd known" bullet, AND timestamp records with date+TIME (%H:%M),
+#    not date-only — the cross-phase header contract is date +%Y-%m-%dT%H:%M:%S%z.
+PHASES=(research plan implement verify review)
+for p in "${PHASES[@]}"; do
+  f="$ROOT/plugins/dev/skills/phase-$p/SKILL.md"
+  assert "phase-$p SKILL.md exists"                 "test -f '$f'"
+  assert "phase-$p friction block writes thoughts/shared/friction/" \
+    "grep -q 'thoughts/shared/friction/' '$f'"
+  assert "phase-$p friction block has the 'If I'\''d known' bullet" \
+    "grep -q \"If I'd known\" '$f'"
+  assert "phase-$p friction record is time-bearing (%H:%M, not date-only)" \
+    "grep -q '%H:%M' '$f'"
+done
+
+# 4. The seed learnings entry exists AND passes the validator (exit 0).
+SEED="$ROOT/thoughts/shared/learnings/architecture-patterns/friction-capture-container.md"
+assert "seed learnings entry exists" "test -f '$SEED'"
+assert "validate-learnings.sh exits 0 on the seed entry" \
+  "bash '$VALIDATOR' '$SEED' >/dev/null 2>&1"
+
+# 5. The approval-surface handler + the concepts seed.
+assert "briefing-followup action-compound.sh exists" \
+  "test -f '$ROOT/plugins/dev/scripts/briefing-followup/action-compound.sh'"
+assert "action-compound.sh is executable" \
+  "test -x '$ROOT/plugins/dev/scripts/briefing-followup/action-compound.sh'"
+assert "thoughts/CONCEPTS.md exists" "test -f '$ROOT/thoughts/CONCEPTS.md'"
+
+exit $fail

--- a/plugins/dev/scripts/briefing-followup/action-compound.sh
+++ b/plugins/dev/scripts/briefing-followup/action-compound.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# action-compound.sh — Resolve a pending compound-engineering ADR proposal that
+# the ticket-compound curator queued at thoughts/shared/compound/pending/<TICKET>.md.
+# This is the ONLY writer of docs/adrs.md in the whole system (ADR changes are
+# APPROVE-gated; the curator only ever proposes).
+#
+# Sub-modes:
+#   apply  : read the proposal (target ADR new|amend|supersede + proposed text),
+#            write that change into docs/adrs.md, git-commit it, then remove the
+#            pending proposal file (git history preserves it).
+#   edit   : open the proposal in $EDITOR for a tweak, then apply (above).
+#   defer  : leave the proposal pending; annotate it with a defer note + date.
+#   reject : remove the pending proposal (git history preserves it); record reason.
+#
+# Usage:
+#   action-compound.sh --mode apply|edit|defer|reject --pending PATH [...]
+#
+# Mode-specific flags:
+#   apply  : [--adrs-file PATH]  (defaults to <repo>/docs/adrs.md)
+#   edit   : [--adrs-file PATH]  (uses $EDITOR on the proposal, then applies)
+#   defer  : --reason R  [--date YYYY-MM-DD]
+#   reject : --reason R  [--date YYYY-MM-DD]
+#
+# Common optional: --ticket ID  (defaults to the pending file basename).
+#
+# Proposal file contract (what ticket-compound Step 6 writes):
+#   ---
+#   ticket: CTL-619
+#   target: amend            # new | amend | supersede
+#   adr_id: ADR-017          # required for amend/supersede; ignored for new
+#   rationale: one-line why + evidence (learning path)
+#   ---
+#   ## Proposed text
+#   <the exact ADR markdown to insert (new) or to replace the section with (amend/supersede)>
+#
+# Output (stdout, one JSON line):
+#   apply  : {"adrs_file":"...","adr_id":"...","target":"...","commit_sha":"...","status":"applied"}
+#   defer  : {"pending":"...","ticket":"...","status":"deferred"}
+#   reject : {"pending":"...","ticket":"...","reason":"...","status":"rejected"}
+# Soft-skip: {"status":"skipped","reason":"..."} (exit 0)
+# Hard fail: {"status":"failed","reason":"..."}  (exit 1)
+# Bad args : stderr message + exit 2
+
+set -uo pipefail
+
+MODE=""
+PENDING=""
+TICKET=""
+ADRS_FILE=""
+REASON=""
+DATE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)       MODE="$2"; shift 2 ;;
+    --pending)    PENDING="$2"; shift 2 ;;
+    --ticket)     TICKET="$2"; shift 2 ;;
+    --adrs-file)  ADRS_FILE="$2"; shift 2 ;;
+    --reason)     REASON="$2"; shift 2 ;;
+    --date)       DATE="$2"; shift 2 ;;
+    -h|--help)    sed -n '2,42p' "$0"; exit 0 ;;
+    *) echo "action-compound.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+case "$MODE" in
+  apply|edit|defer|reject) ;;
+  "") echo "action-compound.sh: --mode is required (apply|edit|defer|reject)" >&2; exit 2 ;;
+  *)  echo "action-compound.sh: --mode must be apply|edit|defer|reject (got: $MODE)" >&2; exit 2 ;;
+esac
+
+if [[ -z "$PENDING" ]]; then
+  echo "action-compound.sh: --pending is required" >&2
+  exit 2
+fi
+
+if [[ ! -f "$PENDING" ]]; then
+  jq -nc --arg reason "pending proposal not found: $PENDING" \
+    '{status: "skipped", reason: $reason}'
+  exit 0
+fi
+
+# Derive TICKET from the proposal frontmatter `ticket:`, else the basename.
+if [[ -z "$TICKET" ]]; then
+  TICKET=$(grep -m1 '^ticket:' "$PENDING" 2>/dev/null \
+    | sed -E 's/^ticket:[[:space:]]*//; s/^"//; s/"$//; s/^'\''//; s/'\''$//')
+  [[ -z "$TICKET" ]] && TICKET="$(basename "$PENDING" .md)"
+fi
+
+# Resolve the git repo root containing the proposal. Empty when not in a repo.
+pending_dir() { cd "$(dirname "$PENDING")" && pwd; }
+REPO_TOP=$(git -C "$(pending_dir)" rev-parse --show-toplevel 2>/dev/null || echo "")
+
+# ── Proposal parsers (shared by apply/edit) ────────────────────────────────
+# Read a scalar frontmatter field from the first --- ... --- block.
+proposal_field() {
+  local field="$1"
+  awk -v key="$field" '
+    /^---[[:space:]]*$/ { blk++; if (blk == 2) exit; next }
+    blk == 1 {
+      if ($0 ~ "^" key ":[[:space:]]*") {
+        sub("^" key ":[[:space:]]*", "")
+        gsub(/^"|"$|^'\''|'\''$/, "")
+        print
+        exit
+      }
+    }
+  ' "$PENDING"
+}
+
+# Print the proposed ADR body — everything after the `## Proposed text` heading.
+proposal_text() {
+  awk '
+    found { print; next }
+    /^##[[:space:]]+Proposed text[[:space:]]*$/ { found = 1 }
+  ' "$PENDING" | sed '1{/^$/d;}'
+}
+
+# ── apply path (shared by apply + edit-then-apply) ─────────────────────────
+do_apply() {
+  if [[ -z "$REPO_TOP" ]]; then
+    jq -nc --arg reason "proposal not in a git repo: $PENDING" \
+      '{status: "skipped", reason: $reason}'
+    exit 0
+  fi
+
+  [[ -z "$ADRS_FILE" ]] && ADRS_FILE="$REPO_TOP/docs/adrs.md"
+  if [[ ! -f "$ADRS_FILE" ]]; then
+    jq -nc --arg reason "adrs file not found: $ADRS_FILE" \
+      '{status: "skipped", reason: $reason}'
+    exit 0
+  fi
+
+  local target adr_id text
+  target=$(proposal_field "target")
+  adr_id=$(proposal_field "adr_id")
+  text=$(proposal_text)
+
+  case "$target" in
+    new|amend|supersede) ;;
+    "") jq -nc --arg reason "proposal missing target: (new|amend|supersede) in $PENDING" \
+          '{status: "failed", reason: $reason}'; exit 1 ;;
+    *)  jq -nc --arg reason "proposal target must be new|amend|supersede (got: $target)" \
+          '{status: "failed", reason: $reason}'; exit 1 ;;
+  esac
+
+  if [[ -z "$text" ]]; then
+    jq -nc --arg reason "proposal has no '## Proposed text' body in $PENDING" \
+      '{status: "failed", reason: $reason}'
+    exit 1
+  fi
+
+  if [[ "$target" == "amend" || "$target" == "supersede" ]]; then
+    if [[ -z "$adr_id" ]]; then
+      jq -nc --arg reason "proposal target=$target requires adr_id in $PENDING" \
+        '{status: "failed", reason: $reason}'
+      exit 1
+    fi
+    if ! grep -qE "^##[[:space:]]+${adr_id}:" "$ADRS_FILE"; then
+      jq -nc --arg reason "adr_id $adr_id not found as a '## $adr_id:' section in $ADRS_FILE" \
+        '{status: "failed", reason: $reason}'
+      exit 1
+    fi
+  fi
+
+  local tmp_text
+  tmp_text=$(mktemp -t action-compound-text.XXXXXX)
+  printf '%s\n' "$text" > "$tmp_text"
+
+  if [[ "$target" == "new" ]]; then
+    # Append the new ADR section to the end of the file, separated by a rule.
+    if [[ -n "$(tail -c1 "$ADRS_FILE" 2>/dev/null)" ]]; then
+      printf '\n' >> "$ADRS_FILE"
+    fi
+    {
+      printf '\n---\n\n'
+      cat "$tmp_text"
+      printf '\n'
+    } >> "$ADRS_FILE"
+  else
+    # amend / supersede: replace the existing `## <adr_id>: ...` section in
+    # place. The section runs from its `## <adr_id>:` heading up to (but not
+    # including) the next `## ` heading or EOF. awk emits everything outside the
+    # section verbatim and splices the proposed text in where the section was.
+    local tmp_out
+    tmp_out=$(mktemp -t action-compound-adrs.XXXXXX)
+    if ! awk -v id="$adr_id" -v textfile="$tmp_text" '
+      BEGIN { insec = 0 }
+      /^##[[:space:]]/ {
+        if ($0 ~ "^##[[:space:]]+" id ":") {
+          insec = 1
+          while ((getline line < textfile) > 0) print line
+          close(textfile)
+          next
+        } else if (insec) {
+          insec = 0
+        }
+      }
+      insec { next }
+      { print }
+    ' "$ADRS_FILE" > "$tmp_out"; then
+      rm -f "$tmp_text" "$tmp_out"
+      jq -nc --arg reason "failed to splice $adr_id in $ADRS_FILE" \
+        '{status: "failed", reason: $reason}'
+      exit 1
+    fi
+    mv "$tmp_out" "$ADRS_FILE"
+  fi
+  rm -f "$tmp_text"
+
+  # Only docs/adrs.md is a tracked, committable path. The pending proposal lives
+  # under thoughts/ (humanlayer-synced, never committed to the code repo), so we
+  # remove it from disk after the ADR commit rather than staging it in git.
+  if ! git -C "$REPO_TOP" add -- "$ADRS_FILE" >/dev/null 2>&1; then
+    jq -nc --arg reason "git add failed" \
+      '{status: "failed", reason: $reason}'
+    exit 1
+  fi
+
+  local subject
+  if [[ "$target" == "new" ]]; then
+    subject="docs(adr): add ADR from ${TICKET} compound proposal"
+  else
+    subject="docs(adr): ${target} ${adr_id} from ${TICKET} compound proposal"
+  fi
+  local stderr_file
+  stderr_file=$(mktemp -t action-compound-apply-stderr.XXXXXX)
+  if ! git -C "$REPO_TOP" commit -q \
+         -m "$subject" \
+         -- "$ADRS_FILE" 2>"$stderr_file"; then
+    local stderr_tail
+    stderr_tail=$(tail -c 500 "$stderr_file" 2>/dev/null || echo "")
+    rm -f "$stderr_file"
+    local reason_msg="git commit failed"
+    [[ -n "$stderr_tail" ]] && reason_msg="${reason_msg}: ${stderr_tail}"
+    jq -nc --arg reason "$reason_msg" '{status: "failed", reason: $reason}'
+    exit 1
+  fi
+  rm -f "$stderr_file"
+
+  # The proposal is now resolved — remove it from the pending queue. It lives in
+  # the humanlayer-synced thoughts/ store (its own git history preserves it), so
+  # this is a plain filesystem removal, not a code-repo commit.
+  rm -f "$PENDING"
+
+  local commit_sha
+  commit_sha=$(git -C "$REPO_TOP" rev-parse HEAD)
+  jq -nc \
+    --arg adrs_file "$ADRS_FILE" \
+    --arg adr_id "$adr_id" \
+    --arg target "$target" \
+    --arg sha "$commit_sha" \
+    '{adrs_file: $adrs_file, adr_id: $adr_id, target: $target, commit_sha: $sha, status: "applied"}'
+}
+
+case "$MODE" in
+
+  apply)
+    do_apply
+    ;;
+
+  edit)
+    if [[ -z "${EDITOR:-}" ]]; then
+      jq -nc --arg reason "EDITOR not set" \
+        '{status: "skipped", reason: $reason}'
+      exit 0
+    fi
+    # Open the proposal for a tweak. Word-split $EDITOR so compound values like
+    # "code --wait" work the way git does; $PENDING stays quoted so paths with
+    # shell metacharacters are never re-interpreted.
+    # shellcheck disable=SC2086
+    $EDITOR "$PENDING"
+    if [[ ! -f "$PENDING" ]]; then
+      jq -nc --arg reason "proposal removed during edit: $PENDING" \
+        '{status: "skipped", reason: $reason}'
+      exit 0
+    fi
+    do_apply
+    ;;
+
+  defer)
+    if [[ -z "$REASON" ]]; then
+      echo "action-compound.sh: --reason is required for defer mode" >&2
+      exit 2
+    fi
+    [[ -z "$DATE" ]] && DATE=$(date -u +%Y-%m-%d)
+
+    # Ensure the file ends with a newline so the appended note isn't merged onto
+    # the last existing line. Leave the proposal pending (no removal).
+    if [[ -n "$(tail -c1 "$PENDING" 2>/dev/null)" ]]; then
+      printf '\n' >> "$PENDING"
+    fi
+    printf '<!-- compound-deferred: %s: %s -->\n' "$DATE" "$REASON" >> "$PENDING"
+
+    jq -nc \
+      --arg pending "$PENDING" \
+      --arg ticket "$TICKET" \
+      '{pending: $pending, ticket: $ticket, status: "deferred"}'
+    ;;
+
+  reject)
+    if [[ -z "$REASON" ]]; then
+      echo "action-compound.sh: --reason is required for reject mode" >&2
+      exit 2
+    fi
+    [[ -z "$DATE" ]] && DATE=$(date -u +%Y-%m-%d)
+
+    # The proposal lives under thoughts/ (humanlayer-synced, never committed to
+    # the code repo) — its own git history preserves the rejected text. Record
+    # the reason inline (so the thoughts-store diff captures why), then remove it
+    # from the pending queue so it stops surfacing in the morning briefing.
+    if [[ -n "$(tail -c1 "$PENDING" 2>/dev/null)" ]]; then
+      printf '\n' >> "$PENDING"
+    fi
+    printf '<!-- compound-rejected: %s: %s -->\n' "$DATE" "$REASON" >> "$PENDING"
+
+    if ! rm -f "$PENDING"; then
+      jq -nc --arg reason "failed to remove pending proposal: $PENDING" \
+        '{status: "failed", reason: $reason}'
+      exit 1
+    fi
+
+    jq -nc \
+      --arg pending "$PENDING" \
+      --arg ticket "$TICKET" \
+      --arg reason "$REASON" \
+      '{pending: $pending, ticket: $ticket, reason: $reason, status: "rejected"}'
+    ;;
+esac

--- a/plugins/dev/scripts/compound/validate-learnings.sh
+++ b/plugins/dev/scripts/compound/validate-learnings.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# validate-learnings.sh — guard a learnings-store entry's YAML frontmatter against the silent-corruption
+# traps and the required-field contract (see plugins/foundry/skills/ticket-compound/reference.md).
+# Usage: validate-learnings.sh <path-to-entry.md>
+# Exit 0 = valid; exit 1 = problems (printed to stderr). zsh/bash-safe.
+set -uo pipefail
+
+FILE="${1:-}"
+[ -n "$FILE" ] && [ -f "$FILE" ] || { echo "validate-learnings: file not found: '$FILE'" >&2; exit 1; }
+
+# Extract the frontmatter block (between the first two '---' lines).
+fm="$(awk 'NR==1 && $0!="---"{print "NOFM"; exit} NR==1{next} $0=="---"{exit} {print}' "$FILE")"
+if [ "$fm" = "NOFM" ] || [ -z "$fm" ]; then
+  echo "validate-learnings: $FILE — missing or malformed --- frontmatter block" >&2; exit 1
+fi
+
+problems=0
+err() { echo "validate-learnings: $FILE — $1" >&2; problems=$((problems+1)); }
+
+# Required scalar keys.
+for key in title date category problem_type component severity; do
+  printf '%s\n' "$fm" | grep -qE "^${key}:[[:space:]]*[^[:space:]]" \
+    || err "missing/empty required field: ${key}"
+done
+
+# YAML trap 1: an unquoted scalar value containing '#' (silently truncated as a comment).
+# Flag `key: ... # ...` where the value isn't quoted.
+printf '%s\n' "$fm" | grep -nE '^[a-z_]+:[[:space:]]+[^"'\''#]*#' \
+  | while IFS= read -r line; do echo "validate-learnings: $FILE — unquoted '#' in value (will truncate): $line" >&2; done
+printf '%s\n' "$fm" | grep -qE '^[a-z_]+:[[:space:]]+[^"'\''#]*#' && problems=$((problems+1)) || true
+
+# YAML trap 2: an unquoted array item containing ': ' (parsed as a mapping).
+#   tags: ["ok", bad: value]   or   - bad: value
+printf '%s\n' "$fm" | grep -nE '^[[:space:]]*-[[:space:]]+[^"'\''].*:[[:space:]]' \
+  | while IFS= read -r line; do echo "validate-learnings: $FILE — unquoted ': ' in list item (parsed as map): $line" >&2; done
+printf '%s\n' "$fm" | grep -qE '^[[:space:]]*-[[:space:]]+[^"'\''].*:[[:space:]]' && problems=$((problems+1)) || true
+
+# problem_type must be a known track value.
+BUG='build_error|test_failure|runtime_error|logic_error|integration_issue|performance_issue|data_issue|security_issue'
+KNOW='best_practice|architecture_pattern|convention|workflow_issue|developer_experience|documentation_gap|tooling_decision'
+pt="$(printf '%s\n' "$fm" | sed -nE 's/^problem_type:[[:space:]]*"?([a-z_]+)"?.*/\1/p' | head -1)"
+[ -n "$pt" ] && ! printf '%s' "$pt" | grep -qE "^(${BUG}|${KNOW})$" \
+  && err "unknown problem_type: '$pt' (see reference.md)"
+
+if [ "$problems" -gt 0 ]; then
+  echo "validate-learnings: $FILE — $problems problem(s)" >&2; exit 1
+fi
+echo "validate-learnings: OK $FILE"

--- a/plugins/dev/skills/briefing-followup/SKILL.md
+++ b/plugins/dev/skills/briefing-followup/SKILL.md
@@ -5,9 +5,11 @@ description:
   thoughts/briefings/YYYY-MM-DD.md (built by [[morning-briefing]]), parses the structured
   decisions: frontmatter, walks the user through each open decision, and executes the
   selected action via supported handlers — schedule calendar entry, file Linear ticket,
-  dispatch orchestrator, draft email, plus ADR-drift-specific actions (update ADR / file
-  code-drift ticket / defer with a drift note). Phase 4 (CTL-465) writes resolutions
-  back to the briefing markdown.
+  dispatch orchestrator, draft email, ADR-drift-specific actions (update ADR / file
+  code-drift ticket / defer with a drift note), plus compound-engineering ADR proposals
+  from the ticket-compound curator (apply / edit / defer / reject — apply is the only
+  writer of docs/adrs.md). Phase 4 (CTL-465) writes resolutions back to the briefing
+  markdown.
 disable-model-invocation: true
 user-invocable: true
 allowed-tools: Read, Write, Edit, Bash, Task, mcp__*
@@ -139,28 +141,38 @@ echo "$DECISIONS_JSON" | jq -c '.[]' | while IFS= read -r dec; do
   PR_URL=$(echo "$dec"  | jq -r '.pr_url // empty')
   TICKET=$(echo "$dec"  | jq -r '.ticket // empty')
   ADR=$(echo "$dec"     | jq -r '.adr // empty')
+  PENDING=$(echo "$dec" | jq -r '.pending // empty')
 
   echo
   echo "═══ Decision $INDEX of $TOTAL ═══"
   echo "id:      $ID"
   echo "type:    $TYPE"
   echo "summary: $SUMMARY"
-  [[ -n "$PR_URL" ]] && echo "pr:      $PR_URL"
-  [[ -n "$TICKET" ]] && echo "ticket:  $TICKET"
-  [[ -n "$ADR"    ]] && echo "adr:     $ADR"
+  [[ -n "$PR_URL"  ]] && echo "pr:      $PR_URL"
+  [[ -n "$TICKET"  ]] && echo "ticket:  $TICKET"
+  [[ -n "$ADR"     ]] && echo "adr:     $ADR"
+  [[ -n "$PENDING" ]] && echo "pending: $PENDING"
   echo
 
-  case "$TYPE" in
-    blocked_pr)
-      echo "Actions: [a]pprove · [r]eject · [d]efer · [o]rchestrate · [s]kip · [q]uit"
-      ;;
-    adr_drift)
-      echo "Actions: [u]pdate ADR · [t]icket (code drift) · [D]efer · [s]kip · [q]uit"
-      ;;
-    *)
-      echo "Actions: [a]pprove · [r]eject · [d]efer · [c]alendar · [t]icket · [o]rchestrate · [e]mail · [s]kip · [q]uit"
-      ;;
-  esac
+  # A compound-engineering ADR proposal is discriminated by a non-empty
+  # `pending:` field (morning-briefing emits these as type=judgment_call with a
+  # `pending:` path, because the frontmatter schema's type enum has no
+  # `compound_adr` value). Check it before the type switch.
+  if [[ -n "$PENDING" ]]; then
+    echo "Actions: [a]pply ADR proposal · [e]dit then apply · [D]efer · [r]eject · [s]kip · [q]uit"
+  else
+    case "$TYPE" in
+      blocked_pr)
+        echo "Actions: [a]pprove · [r]eject · [d]efer · [o]rchestrate · [s]kip · [q]uit"
+        ;;
+      adr_drift)
+        echo "Actions: [u]pdate ADR · [t]icket (code drift) · [D]efer · [s]kip · [q]uit"
+        ;;
+      *)
+        echo "Actions: [a]pprove · [r]eject · [d]efer · [c]alendar · [t]icket · [o]rchestrate · [e]mail · [s]kip · [q]uit"
+        ;;
+    esac
+  fi
 done
 ```
 
@@ -180,6 +192,10 @@ to action handlers as follows:
 | edit / update the ADR (adr_drift only) | `action-adr.sh --mode update --adr-file "$ADR"` → `record_resolution "$ID" adr_update "$JSON"` | TSV + JSON |
 | file code-drift ticket / fix the code (adr_drift only) | `action-adr.sh --mode ticket --adr-file "$ADR" --team CTL --summary "$SUMMARY" --drift-status "$DRIFT_STATUS"` → `record_resolution "$ID" adr_ticket "$JSON"` | TSV + JSON |
 | defer / note as intentional (adr_drift only) | `action-adr.sh --mode defer --adr-file "$ADR" --reason "$REASON"` → `record_resolution "$ID" adr_defer "$JSON"` | TSV + JSON |
+| apply / approve / accept the ADR proposal (decisions with a `pending:` path) | `action-compound.sh --mode apply --pending "$PENDING" --ticket "$TICKET"` → `record_resolution "$ID" compound_apply "$JSON"` | TSV + JSON |
+| edit / tweak then apply the proposal (`pending:`) | `action-compound.sh --mode edit --pending "$PENDING" --ticket "$TICKET"` → `record_resolution "$ID" compound_edit "$JSON"` | TSV + JSON |
+| defer / not yet (`pending:`) | `action-compound.sh --mode defer --pending "$PENDING" --ticket "$TICKET" --reason "$REASON"` → `record_resolution "$ID" compound_defer "$JSON"` | TSV + JSON |
+| reject / decline the proposal (`pending:`) | `action-compound.sh --mode reject --pending "$PENDING" --ticket "$TICKET" --reason "$REASON"` → `record_resolution "$ID" compound_reject "$JSON"` | TSV + JSON |
 | skip | move on without logging |
 | quit / stop / done | break out of the loop |
 
@@ -208,11 +224,39 @@ record_resolution "$ID" schedule_calendar "$RESULT"
 log_response "$ID" schedule_calendar "$STATUS"
 ```
 
-The same pattern applies to `action-ticket.sh`, `action-orchestrate.sh`, and
-`action-email.sh` — only the script name and the action label change. All four handlers
-soft-skip cleanly when their underlying tool is missing or unauthenticated; the
-returned `{"status": "skipped", "reason": "..."}` JSON is captured the same way as a
-success result so the resolution log faithfully records what happened.
+The same pattern applies to `action-ticket.sh`, `action-orchestrate.sh`,
+`action-email.sh`, `action-adr.sh`, and `action-compound.sh` — only the script name and
+the action label change. All handlers soft-skip cleanly when their underlying tool or
+input is missing (e.g. `action-compound.sh` returns
+`{"status": "skipped", "reason": "pending proposal not found: ..."}` when the proposal
+has already been resolved on another machine); the returned skip JSON is captured the
+same way as a success result so the resolution log faithfully records what happened.
+
+For a compound-engineering ADR proposal (any decision carrying a `pending:` path —
+morning-briefing emits these as `type: judgment_call` with a `pending:` field, since the
+frontmatter schema's `type` enum has no `compound_adr` value), `--pending` is that path,
+surfaced by morning-briefing from `thoughts/shared/compound/pending/*.md`:
+
+```bash
+# Example — apply an approved ADR proposal:
+RESULT=$(bash "$SCRIPT_DIR/action-compound.sh" \
+  --mode apply --pending "$PENDING" --ticket "$TICKET")
+
+STATUS=$(echo "$RESULT" | jq -r '.status')
+case "$STATUS" in
+  applied)  echo "Applied — $(echo "$RESULT" | jq -r '.target') $(echo "$RESULT" | jq -r '.adr_id') @ $(echo "$RESULT" | jq -r '.commit_sha')" ;;
+  deferred) echo "Deferred — proposal left pending" ;;
+  rejected) echo "Rejected — $(echo "$RESULT" | jq -r '.reason')" ;;
+  skipped)  echo "Skipped: $(echo "$RESULT" | jq -r '.reason')" ;;
+  *)        echo "Failed: $(echo "$RESULT" | jq -r '.reason // "unknown"')" ;;
+esac
+record_resolution "$ID" compound_apply "$RESULT"
+log_response "$ID" compound_apply "$STATUS"
+```
+
+`action-compound.sh --mode apply` (and `edit`, which tweaks then applies) is the ONLY
+writer of `docs/adrs.md` in the system — the `ticket-compound` curator only ever
+*proposes* ADR changes; a human approves them here.
 
 ### Free-form note capture
 
@@ -306,6 +350,10 @@ returned no usable result).
 | Update ADR (adr_drift) | `action-adr.sh --mode update` | `{adr_file, adr_id, commit_sha, status: "updated"}` | `$EDITOR` unset, no save, or ADR not in a git repo |
 | File code-drift ticket (adr_drift) | `action-adr.sh --mode ticket` | `{identifier, url, adr_id, status: "filed"}` | `linearis` not on PATH |
 | Defer ADR drift (adr_drift) | `action-adr.sh --mode defer` | `{adr_file, adr_id, commit_sha, status: "deferred"}` | ADR not in a git repo |
+| Apply ADR proposal (`pending:`) | `action-compound.sh --mode apply` | `{adrs_file, adr_id, target, commit_sha, status: "applied"}` | proposal missing, or not in a git repo |
+| Edit + apply proposal (`pending:`) | `action-compound.sh --mode edit` | `{adrs_file, adr_id, target, commit_sha, status: "applied"}` | `$EDITOR` unset, proposal missing, or not in a git repo |
+| Defer ADR proposal (`pending:`) | `action-compound.sh --mode defer` | `{pending, ticket, status: "deferred"}` | proposal missing |
+| Reject ADR proposal (`pending:`) | `action-compound.sh --mode reject` | `{pending, ticket, reason, status: "rejected"}` | proposal missing |
 
 See `cma/mcp/google-calendar.md` and `cma/mcp/gmail.md` for the OAuth setup required
 to bypass the calendar / email soft-skip paths. Linear and orchestrator handlers
@@ -331,3 +379,9 @@ surfaces the relevant field to the user, then calls `record_resolution "$ID" <ac
   routine), and emits `briefing.followup.complete.<date>` so the next morning's
   briefing routine reads yesterday's resolutions as carryovers.
 - **Phase 5 (CTL-466, planned)**: end-to-end real-briefing review session.
+- **Compound engineering (CTL-789, this skill version)**: decisions carrying a
+  `pending:` path surface the `ticket-compound` curator's queued ADR proposals
+  (`thoughts/shared/compound/pending/*.md`; emitted as `type: judgment_call`
+  since the schema enum has no `compound_adr`). `action-compound.sh` resolves
+  them — `apply` (the only writer of `docs/adrs.md`), `edit` (tweak then apply),
+  `defer`, `reject` — keeping ADR edits human-gated and off the critical path.

--- a/plugins/dev/skills/morning-briefing/SKILL.md
+++ b/plugins/dev/skills/morning-briefing/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: morning-briefing
 description:
-  Generate a daily briefing markdown at thoughts/briefings/YYYY-MM-DD.md with four sections —
-  Review yesterday, Surface decisions, Plan today, Suggest orchestrator runs — synthesized from
-  Linear, GitHub, Granola, Google Drive, and Google Calendar in parallel. Then fans the briefing
+  Generate a daily briefing markdown at thoughts/briefings/YYYY-MM-DD.md with six sections —
+  Review yesterday, Surface decisions, Plan today, Suggest orchestrator runs, Friction since last
+  briefing, and Learnings since last briefing — synthesized from Linear, GitHub, Granola, Google
+  Drive, Google Calendar, and the compound-engineering stores (thoughts/shared/friction,
+  thoughts/shared/learnings, thoughts/shared/compound/pending) in parallel. Then fans the briefing
   out to four destinations (Slack DM, Slack channel, Notion page, Loom script file). User-invoked
   from `/catalyst-dev:morning-briefing` for ad-hoc runs. The CMA Routine wraps the same skill on
   a weekday-morning schedule (Phase 5 of the parent plan).
@@ -66,13 +68,19 @@ If a richer Linear or Notion query is needed beyond what the CLI/REST helpers ex
 
 ## Step 3: Gather "decisions"
 
-Populate the `decisions:` array from three sources:
+Populate the `decisions:` array from four sources:
 
 1. **ADR drift** — `adr-drift.sh` reads ADR `code_assertions` frontmatter and surfaces patterns
    that drift from the codebase. See [ADR-DRIFT.md](./ADR-DRIFT.md).
 2. **Blocked PRs** — `gh search prs --review-requested @me --state open --json …` filtered to
    PRs with no commit in the last 48h. Each becomes one `{type: blocked_pr, …}` decision.
 3. **Judgment-call Linear tickets** — `linearis issues list --team <team> --status "Triage,In Progress" --label needs-decision` (label name is informational; substitute whatever signal the operator uses).
+4. **Pending compound-engineering ADR proposals** — the `ticket-compound` curator queues
+   APPROVE-gated ADR changes at `thoughts/shared/compound/pending/<TICKET>.md`. Each pending file
+   becomes one decision the morning ritual can approve via `briefing-followup`'s
+   `action-compound.sh`. Emitted as `type: judgment_call` (the frontmatter schema's `type` enum
+   has no `compound_adr` value) carrying a `pending:` path — that field is the discriminator
+   `briefing-followup` routes on.
 
 Synthesize into a `decisions.json` fragment:
 
@@ -83,9 +91,128 @@ bash "$SCRIPT_DIR/adr-drift.sh" --root "$(pwd)" > "$SCRATCH/adr-drift.json"
 # Blocked-PR + judgment-call sources are still TODO — start with an empty fragment.
 echo '{"decisions": []}' > "$SCRATCH/decisions-other.json"
 
+# Pending compound ADR proposals (CTL-789). Resilient to an absent/empty store:
+# the glob below simply yields nothing when thoughts/shared/compound/pending/ is missing.
+PENDING_DIR="thoughts/shared/compound/pending"
+: > "$SCRATCH/compound-pending.jsonl"
+if [[ -d "$PENDING_DIR" ]]; then
+  for pf in "$PENDING_DIR"/*.md; do
+    [[ -e "$pf" ]] || continue   # no-match glob guard (no nullglob needed)
+    PTICKET=$(grep -m1 '^ticket:' "$pf" 2>/dev/null \
+      | sed -E 's/^ticket:[[:space:]]*//; s/^"//; s/"$//; s/^'\''//; s/'\''$//')
+    [[ -z "$PTICKET" ]] && PTICKET="$(basename "$pf" .md)"
+    PTARGET=$(grep -m1 '^target:'  "$pf" 2>/dev/null | sed -E 's/^target:[[:space:]]*//')
+    PADRID=$(grep -m1 '^adr_id:'   "$pf" 2>/dev/null | sed -E 's/^adr_id:[[:space:]]*//')
+    PRAT=$(grep -m1 '^rationale:'  "$pf" 2>/dev/null | sed -E 's/^rationale:[[:space:]]*//')
+    PSUMMARY="ADR proposal (${PTARGET:-new}${PADRID:+ $PADRID}) from ${PTICKET}${PRAT:+: $PRAT}"
+    jq -nc \
+      --arg id "compound-${PTICKET}" \
+      --arg summary "$PSUMMARY" \
+      --arg ticket "$PTICKET" \
+      --arg pending "$pf" \
+      '{id: $id, type: "judgment_call", summary: $summary, status: "open",
+        ticket: $ticket, pending: $pending}' >> "$SCRATCH/compound-pending.jsonl"
+  done
+fi
+jq -sc '{decisions: .}' "$SCRATCH/compound-pending.jsonl" > "$SCRATCH/compound-pending.json"
+
 # Merge all decision sources into one fragment
-jq -s '{decisions: (((.[0] // {}).decisions // []) + ((.[1] // {}).decisions // []))}' \
-  "$SCRATCH/adr-drift.json" "$SCRATCH/decisions-other.json" > "$SCRATCH/decisions.json"
+jq -s '{decisions: (
+        ((.[0] // {}).decisions // [])
+      + ((.[1] // {}).decisions // [])
+      + ((.[2] // {}).decisions // []))}' \
+  "$SCRATCH/adr-drift.json" "$SCRATCH/decisions-other.json" "$SCRATCH/compound-pending.json" \
+  > "$SCRATCH/decisions.json"
+```
+
+## Step 3b: Compound digests — "since last briefing" window (CTL-789)
+
+Two compound-engineering digests the daily review scans: **Friction since last briefing** (the
+primary one — per-phase friction records the daily review wants to skim) and **Learnings since
+last briefing** (new entries in the curated store). Both filter on a *since-last-briefing*
+window: midnight of the most recent prior briefing, or — when there is no prior briefing —
+midnight of the day before `$DATE`. These render as body sections appended after Step 6; they
+degrade to a single "_none_" line when their store is empty or absent.
+
+```bash
+# ── Resolve the window floor (epoch seconds) ────────────────────────────────
+# Most recent thoughts/briefings/YYYY-MM-DD.md strictly older than $DATE.
+PREV_BRIEFING_DATE=""
+if [[ -d thoughts/briefings ]]; then
+  for bf in thoughts/briefings/*.md; do
+    [[ -e "$bf" ]] || continue
+    bd=$(basename "$bf" .md)
+    [[ "$bd" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || continue
+    if [[ "$bd" < "$DATE" ]]; then
+      [[ -z "$PREV_BRIEFING_DATE" || "$bd" > "$PREV_BRIEFING_DATE" ]] && PREV_BRIEFING_DATE="$bd"
+    fi
+  done
+fi
+# Window floor: prior briefing's midnight, else $DATE minus one day. `date -d`
+# (GNU) and `date -j` (BSD/macOS) differ — try both, fall back to "0".
+WINDOW_DATE="${PREV_BRIEFING_DATE:-$(date -u -d "$DATE -1 day" +%Y-%m-%d 2>/dev/null \
+  || date -j -v-1d -f %Y-%m-%d "$DATE" +%Y-%m-%d 2>/dev/null || echo "$DATE")}"
+WINDOW_EPOCH=$(date -u -d "${WINDOW_DATE}T00:00:00Z" +%s 2>/dev/null \
+  || date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "${WINDOW_DATE}T00:00:00Z" +%s 2>/dev/null || echo 0)
+echo "Compound digest window: since ${WINDOW_DATE} (epoch ${WINDOW_EPOCH})"
+
+# ── Friction digest (PRIMARY) ───────────────────────────────────────────────
+# Each record header is the cross-phase contract:
+#   ## <phase> · <TICKET> · <ISO-8601 timestamp>
+# parse by that timestamp, keep records AFTER the window, render newest-first.
+: > "$SCRATCH/friction-records.tsv"   # ticket \t phase \t iso \t one-line
+FRICTION_DIR="thoughts/shared/friction"
+if [[ -d "$FRICTION_DIR" ]]; then
+  for ff in "$FRICTION_DIR"/*.md; do
+    [[ -e "$ff" ]] || continue
+    python3 - "$ff" "$WINDOW_EPOCH" >> "$SCRATCH/friction-records.tsv" <<'PY'
+import sys, re, datetime
+path, floor = sys.argv[1], int(sys.argv[2])
+hdr = re.compile(r'^##\s+(?P<phase>[^·]+?)\s+·\s+(?P<ticket>[^·]+?)\s+·\s+(?P<ts>\S+)\s*$')
+lines = open(path, encoding='utf-8', errors='replace').read().splitlines()
+i = 0
+while i < len(lines):
+    m = hdr.match(lines[i])
+    if not m:
+        i += 1; continue
+    phase = m.group('phase').strip(); ticket = m.group('ticket').strip(); ts = m.group('ts').strip()
+    # first non-empty body line that isn't "None."
+    one = ""
+    j = i + 1
+    while j < len(lines) and not hdr.match(lines[j]):
+        t = lines[j].strip().lstrip('-* ').strip()
+        if t and t.rstrip('.').lower() != "none":
+            one = t; break
+        j += 1
+    i = j
+    try:
+        epoch = int(datetime.datetime.fromisoformat(ts).timestamp())
+    except ValueError:
+        continue
+    if epoch <= floor:
+        continue
+    # tabs/newlines in the one-liner would break the TSV; flatten them.
+    one = re.sub(r'\s+', ' ', one)
+    print(f"{ticket}\t{phase}\t{ts}\t{one}")
+PY
+  done
+fi
+
+# ── Learnings digest ────────────────────────────────────────────────────────
+# New/updated entries in the curated store modified after the window floor.
+: > "$SCRATCH/learnings-records.tsv"   # mtime-epoch \t title \t component \t path
+LEARN_DIR="thoughts/shared/learnings"
+if [[ -d "$LEARN_DIR" ]]; then
+  while IFS= read -r lf; do
+    [[ -n "$lf" ]] || continue
+    mt=$(date -u -r "$lf" +%s 2>/dev/null || stat -c %Y "$lf" 2>/dev/null || echo 0)
+    [[ "$mt" -gt "$WINDOW_EPOCH" ]] || continue
+    title=$(grep -m1 '^title:' "$lf" 2>/dev/null | sed -E 's/^title:[[:space:]]*//; s/^"//; s/"$//')
+    [[ -z "$title" ]] && title="$(basename "$lf" .md)"
+    comp=$(grep -m1 '^component:' "$lf" 2>/dev/null | sed -E 's/^component:[[:space:]]*//')
+    printf '%s\t%s\t%s\t%s\n' "$mt" "$title" "${comp:-?}" "$lf" >> "$SCRATCH/learnings-records.tsv"
+  done < <(find "$LEARN_DIR" -type f -name '*.md' 2>/dev/null)
+fi
 ```
 
 ## Step 4: Gather "today"
@@ -144,6 +271,43 @@ bash "$SCRIPT_DIR/render.sh" --input "$SCRATCH/input.json" --output "$OUT_PATH"
 bash "$SCRIPT_DIR/validate-frontmatter.sh" "$OUT_PATH"
 ```
 
+## Step 6b: Append the compound digests (CTL-789)
+
+`render.sh` owns the fixed sections. The two compound digests from Step 3b are appended to the
+body here — **Friction since last briefing** first (the primary, easy-to-skim section the daily
+review scans: a flat reverse-chronological list, one line per record as
+`timestamp · ticket · phase — friction`) then **Learnings since last briefing**. Both are
+body-only (they touch no frontmatter, so the schema stays valid) and both degrade to `_none_`
+when their store is empty or absent. POSIX append only — no frontmatter rewrite.
+
+```bash
+{
+  printf '\n## Friction since last briefing\n\n'
+  if [[ -s "$SCRATCH/friction-records.tsv" ]]; then
+    # Flat reverse-chronological list, one line per record:
+    #   timestamp · ticket · phase — one-line friction
+    # (sort by ISO timestamp, col 3, descending). TSV cols: ticket\tphase\tts\tone-line.
+    sort -t$'\t' -k3,3r "$SCRATCH/friction-records.tsv" \
+      | awk -F'\t' '{ printf "- `%s` · %s · %s — %s\n", $3, $1, $2, ($4 == "" ? "(no detail)" : $4) }'
+  else
+    printf '_none_\n'
+  fi
+
+  printf '\n## Learnings since last briefing\n\n'
+  if [[ -s "$SCRATCH/learnings-records.tsv" ]]; then
+    # Newest-first by mtime (col 1, numeric descending). TSV cols: mtime\ttitle\tcomponent\tpath.
+    sort -t$'\t' -k1,1nr "$SCRATCH/learnings-records.tsv" \
+      | awk -F'\t' '{ printf "- [%s] %s  \x60%s\x60\n", $3, $2, $4 }'
+  else
+    printf '_none_\n'
+  fi
+} >> "$OUT_PATH"
+
+# Frontmatter is untouched by the append, but re-validate to fail loud if a
+# concurrent edit corrupted it.
+bash "$SCRIPT_DIR/validate-frontmatter.sh" "$OUT_PATH"
+```
+
 ## Step 7: Fan-out (CTL-458)
 
 Run the four fan-outs in parallel against the canonical briefing file. Each script writes a
@@ -196,7 +360,14 @@ echo "Wrote: $OUT_PATH"
 The rendered markdown has YAML frontmatter validated against
 `plugins/dev/templates/briefing-frontmatter.schema.json` (required fields: `date`,
 `generated_by`, `decisions`; optional `output_status` block populated by Step 7).
-Four `## ...` sections follow. Empty sources render `_no data_` rather than failing.
+Six `## ...` sections follow: the four `render.sh` owns (Review yesterday, Surface decisions,
+Plan today, Suggest orchestrator runs) plus the two compound digests appended in Step 6b
+(Friction since last briefing, Learnings since last briefing). Empty render sources render
+`_no data_`; empty compound stores render `_none_`. Neither path fails the run.
+
+Pending compound-engineering ADR proposals (`thoughts/shared/compound/pending/*.md`) surface as
+`decisions:` entries (`type: judgment_call`, carrying a `pending:` path) so `briefing-followup`'s
+`action-compound.sh` can apply / edit / defer / reject them — the human-gated ADR approval surface.
 
 A companion `<date>-loom-script.md` lands beside the briefing whenever Step 7's loom fan-out
 runs (always, since it has no credential prerequisite).

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -364,6 +364,41 @@ if [[ -r "${PLUGIN_ROOT}/scripts/lib/draft-pr.sh" ]]; then
 fi
 ```
 
+## Step N — Capture friction (compound loop, CTL-789)
+
+Just before the terminal emit, append **this phase's** friction to the shared per-ticket friction
+log. This is the producer half of the engineering compound loop: `ticket-compound` later harvests
+`thoughts/shared/friction/<TICKET>.md` to turn what hurt this run into durable learnings/ADRs.
+
+REPLACE each `<…>` placeholder below with your real experience from **this** phase (terse, 3–6
+lines total; `"None."` is a valid answer when the phase was frictionless). `${TICKET}` is already
+resolved upstream — do not re-derive it. This append is **best-effort and off the critical path**:
+it must NEVER fail the phase or block the emit-complete below. (Note this phase emits a signal JSON,
+not a `thoughts/` markdown doc — which is exactly why friction goes to the shared friction LOG; do
+not touch any `*.json` signal file.)
+
+```bash
+# --- Compound-engineering friction capture (CTL-789, Slice 1). Off critical path; NEVER block emit. ---
+FRICTION_LOG="thoughts/shared/friction/${TICKET}.md"
+mkdir -p "$(dirname "$FRICTION_LOG")"
+[ -f "$FRICTION_LOG" ] || printf '# Friction log — %s\n' "${TICKET}" > "$FRICTION_LOG"
+cat >> "$FRICTION_LOG" <<EOF
+
+## implement · ${TICKET} · $(date +%Y-%m-%dT%H:%M:%S%z)
+- **Backtracks / redone work:** <where you backtracked or redid work this phase — or "None.">
+- **Missing / wrong / hard-to-find context:** <context that was absent, stale, or hard to locate — or "None.">
+- **If I'd known:** <the ADR / guidance / past learning that would have saved this — the compounding signal — or "None.">
+EOF
+```
+
+The record header `## implement · ${TICKET} · $(date +%Y-%m-%dT%H:%M:%S%z)` is a CROSS-PHASE
+contract: `## <phase> · <TICKET> · <ISO-8601 timestamp>` carrying DATE+TIME+offset (e.g.
+`2026-06-06T14:23:01+0900`). Keep this format byte-identical across all five phases — the per-record
+stamp is what lets the morning briefing / daily review scan and sort "friction since last review";
+never drop to a date-only stamp.
+
+## End block — terminal emit (copy verbatim)
+
 ```bash
 EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
 if [[ -x "$EMIT" ]]; then

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -131,7 +131,11 @@ The body of [[create-plan]] is the single source of truth.
 Phase agents run inside `claude --bg` — there is no interactive user. Pass the
 research document as the input and operate non-interactively:
 
-1. Read `$RESEARCH_DOC` to understand the problem.
+1. Read `$RESEARCH_DOC` to understand the problem. While reading, skim any
+   `## Relevant Past Learnings` section the research phase surfaced, and any
+   directly-matching entries under `thoughts/shared/learnings/`, and let those
+   prior problem→solution notes inform the plan (the heavy grep lens lives in
+   phase-research — don't re-run it here).
 2. Invoke `/catalyst-dev:create-plan` against the research document. When that skill
    asks for clarifications, answer from the research document; if the research
    document is silent on a point, default to the most conservative reasonable choice
@@ -232,6 +236,31 @@ ${MIRROR_FOOTER}"
     echo "phase-plan: linear-comment-post failed (continuing)" >&2
   fi
 fi
+```
+
+## Step — Capture friction (compound loop, CTL-789)
+
+Before emitting completion, append **your** friction from this plan phase to the
+shared per-ticket friction log. This is the producer side of the compound loop —
+`ticket-compound` harvests these records later. Replace each `<…>` placeholder
+below with your real experience this phase (3–6 lines, terse; `None.` is a valid
+answer when the phase was frictionless). `${TICKET}` is already resolved in the
+Prelude — do not re-derive it. This append is best-effort: it must **never** fail
+the phase, so it stays off the critical path and runs immediately before
+emit-complete.
+
+```bash
+# --- Compound-engineering friction capture (CTL-789, Slice 1). Off critical path; NEVER block emit. ---
+FRICTION_LOG="thoughts/shared/friction/${TICKET}.md"
+mkdir -p "$(dirname "$FRICTION_LOG")"
+[ -f "$FRICTION_LOG" ] || printf '# Friction log — %s\n' "${TICKET}" > "$FRICTION_LOG"
+cat >> "$FRICTION_LOG" <<EOF
+
+## plan · ${TICKET} · $(date +%Y-%m-%dT%H:%M:%S%z)
+- **Backtracks / redone work:** <where you backtracked or redid work this phase — or "None.">
+- **Missing / wrong / hard-to-find context:** <context that was absent, stale, or hard to locate — or "None.">
+- **If I'd known:** <the ADR / guidance / past learning that would have saved this — the compounding signal — or "None.">
+EOF
 ```
 
 ```bash

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -122,10 +122,29 @@ is performed.
    get the title, description, and any linked plan reference.
 2. Read the triage summary from `$TRIAGE_FILE` to understand classification and
    surfaced dependencies.
-3. Invoke `/catalyst-dev:research-codebase` against the ticket's research question.
+3. **Relevant Past Learnings lens (compound loop, CTL-789).** BEFORE the
+   `/catalyst-dev:research-codebase` fan-out, grep the shared learnings store for
+   prior problem→solution entries that touch this ticket's area, so the research
+   inherits hard-won context instead of rediscovering it. Pick 2–5 keywords from
+   the ticket + triage summary (component, feature, error type) and run:
+   ```bash
+   LEARN_DIR="thoughts/shared/learnings"
+   if [ -d "$LEARN_DIR" ]; then
+     rg -li "<2-5 keywords from the ticket: component, feature, error type>" "$LEARN_DIR"/**/*.md 2>/dev/null
+   fi
+   ```
+   For each hit, read the frontmatter (`component` / `tags` / `problem_type` — see
+   `plugins/foundry/skills/ticket-compound/reference.md` for the schema) and keep
+   only entries whose `component` matches this ticket's component. Inject a short
+   `## Relevant Past Learnings` section **near the TOP of the research doc** (right
+   under the Summary), one line per applicable entry as
+   `title — path — one-line guidance`. Write `None found.` when the store is empty
+   or nothing matches. The store may not exist yet — the `-d` guard above makes this
+   best-effort; NEVER block research on an empty store.
+4. Invoke `/catalyst-dev:research-codebase` against the ticket's research question.
    That skill spawns parallel sub-agents, synthesizes findings, and writes the
    document. Do not duplicate its logic.
-4. Confirm the artifact exists at the expected path before continuing.
+5. Confirm the artifact exists at the expected path before continuing.
    Two-step match (CTL-494) — try lowercase-tail first, then the wider
    `*${TICKET}*.md` pattern with `nocaseglob` fallback so canonical
    create-plan filenames (uppercase ticket + descriptive suffix) are
@@ -228,6 +247,36 @@ ${MIRROR_FOOTER}"
   fi
 fi
 ```
+
+## Step N — Capture friction (compound loop, CTL-789)
+
+IMMEDIATELY before emitting `phase.research.complete`, append this phase's friction
+to the shared per-ticket friction log. This is the PRODUCER half of the compound
+loop — what `ticket-compound` Step 1 later harvests. Replace each `<…>` placeholder
+below with your real experience THIS phase (terse, 3–6 lines total); `None.` is a
+valid value for any bullet when the phase ran frictionless. `${TICKET}` is already
+resolved in the Prelude — do not re-derive it. This append is best-effort and OFF
+the critical path: it must NEVER fail the phase.
+
+```bash
+# --- Compound-engineering friction capture (CTL-789, Slice 1). Off critical path; NEVER block emit. ---
+FRICTION_LOG="thoughts/shared/friction/${TICKET}.md"
+mkdir -p "$(dirname "$FRICTION_LOG")"
+[ -f "$FRICTION_LOG" ] || printf '# Friction log — %s\n' "${TICKET}" > "$FRICTION_LOG"
+cat >> "$FRICTION_LOG" <<EOF
+
+## research · ${TICKET} · $(date +%Y-%m-%dT%H:%M:%S%z)
+- **Backtracks / redone work:** <where you backtracked or redid work this phase — or "None.">
+- **Missing / wrong / hard-to-find context:** <context that was absent, stale, or hard to locate — or "None.">
+- **If I'd known:** <the ADR / guidance / past learning that would have saved this — the compounding signal — or "None.">
+EOF
+```
+
+The record header `## <phase> · <TICKET> · <ISO-8601 timestamp>` is a CROSS-PHASE
+contract — keep it byte-identical across all five phase skills (only the `research`
+label differs here). The `$(date +%Y-%m-%dT%H:%M:%S%z)` stamp carries DATE+TIME+offset
+(e.g. `2026-06-06T14:23:01+0900`); do NOT drop to date-only — the morning briefing /
+daily review sorts "friction since last review" by this per-record timestamp.
 
 ```bash
 # Emit phase-complete event, close signal file, end catalyst-session.

--- a/plugins/dev/skills/phase-review/SKILL.md
+++ b/plugins/dev/skills/phase-review/SKILL.md
@@ -289,6 +289,31 @@ _... (truncated)_"
 fi
 ```
 
+## Step N — Capture friction (compound loop, CTL-789)
+
+Before you emit completion, append this phase's friction to the shared per-ticket
+friction log. This is the PRODUCER half of the compound-engineering loop: the
+`ticket-compound` curator harvests `thoughts/shared/friction/${TICKET}.md` to distil
+durable learnings and ADR proposals. REPLACE each `<…>` placeholder below with your
+real experience THIS phase — terse, 3–6 lines total; `"None."` is a valid value when
+the phase was frictionless. `${TICKET}` is already resolved in the Prelude — do not
+re-derive it. This append is **off the critical path and best-effort**: it must NEVER
+fail or block `emit-complete`.
+
+```bash
+# --- Compound-engineering friction capture (CTL-789, Slice 1). Off critical path; NEVER block emit. ---
+FRICTION_LOG="thoughts/shared/friction/${TICKET}.md"
+mkdir -p "$(dirname "$FRICTION_LOG")"
+[ -f "$FRICTION_LOG" ] || printf '# Friction log — %s\n' "${TICKET}" > "$FRICTION_LOG"
+cat >> "$FRICTION_LOG" <<EOF
+
+## review · ${TICKET} · $(date +%Y-%m-%dT%H:%M:%S%z)
+- **Backtracks / redone work:** <where you backtracked or redid work this phase — or "None.">
+- **Missing / wrong / hard-to-find context:** <context that was absent, stale, or hard to locate — or "None.">
+- **If I'd known:** <the ADR / guidance / past learning that would have saved this — the compounding signal — or "None.">
+EOF
+```
+
 ```bash
 "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
   --phase "$PHASE" --ticket "$TICKET" --status complete

--- a/plugins/dev/skills/phase-verify/SKILL.md
+++ b/plugins/dev/skills/phase-verify/SKILL.md
@@ -350,6 +350,37 @@ _... (truncated)_"
 fi
 ```
 
+## Capture friction (compound loop, CTL-789)
+
+Before emitting completion, record this phase's friction to the shared per-ticket
+friction log. This is the **producer** half of the compound-engineering loop:
+[[ticket-compound]] later harvests `thoughts/shared/friction/${TICKET}.md` to
+distill durable learnings. `${TICKET}` is already resolved in the Prelude — do
+not re-derive it.
+
+Replace each `<…>` placeholder below with your **real** experience verifying this
+ticket — 3–6 lines total, terse. `"None."` is a valid value for any bullet when
+the phase was frictionless. The record header
+(`## <phase> · <TICKET> · <ISO-8601 timestamp>`) is a cross-phase contract shared
+by all five phase skills — keep it byte-identical; only the phase label differs.
+
+This append is **best-effort and off the critical path**: it must NEVER fail the
+phase or block the emit-complete below.
+
+```bash
+# --- Compound-engineering friction capture (CTL-789, Slice 1). Off critical path; NEVER block emit. ---
+FRICTION_LOG="thoughts/shared/friction/${TICKET}.md"
+mkdir -p "$(dirname "$FRICTION_LOG")"
+[ -f "$FRICTION_LOG" ] || printf '# Friction log — %s\n' "${TICKET}" > "$FRICTION_LOG"
+cat >> "$FRICTION_LOG" <<EOF
+
+## verify · ${TICKET} · $(date +%Y-%m-%dT%H:%M:%S%z)
+- **Backtracks / redone work:** <where you backtracked or redid work this phase — or "None.">
+- **Missing / wrong / hard-to-find context:** <context that was absent, stale, or hard to locate — or "None.">
+- **If I'd known:** <the ADR / guidance / past learning that would have saved this — the compounding signal — or "None.">
+EOF
+```
+
 ```bash
 "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
   --phase "$PHASE" --ticket "$TICKET" --status complete

--- a/plugins/foundry/skills/ticket-compound/SKILL.md
+++ b/plugins/foundry/skills/ticket-compound/SKILL.md
@@ -50,6 +50,7 @@ For `<TICKET>`, collect:
 1. **Friction** — every `## Friction` / `friction:` block the phase agents left in their artifacts:
    `thoughts/shared/{research,plans}/*<TICKET>*.md` and the worker signal files
    `~/catalyst/workers/<TICKET>/*.json`.
+   - `thoughts/shared/friction/<TICKET>.md` — the dedicated per-phase friction log (primary friction source).
 2. **The diff** — `git log --oneline origin/main..HEAD` and `git diff --stat origin/main..HEAD`
    (or the merged SHA from `phase-monitor-merge.json`).
 3. **Ticket** — `linearis issues read <TICKET>` (title, description, final state, estimate).

--- a/plugins/foundry/skills/ticket-compound/SKILL.md
+++ b/plugins/foundry/skills/ticket-compound/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: ticket-compound
+description:
+  Compound-engineering capture + curation for a finished ticket — the engineering feedback loop.
+  Harvests the Friction sections that phase agents left in their artifacts plus the git diff, writes a
+  structured entry to the shared learnings store (thoughts/shared/learnings/), prunes/amends stale
+  notes there autonomously, captures new domain vocabulary to thoughts/CONCEPTS.md, and PROPOSES (for
+  human approval) any ADR change. Non-blocking — runs after a ticket ships or fails, never on the
+  critical path. Use when the user says "compound this ticket", "capture learnings", "what did we
+  learn", or run as /catalyst-foundry:ticket-compound <TICKET> [mode:headless].
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion
+---
+
+# ticket-compound — engineering compound loop
+
+Capture what a ticket taught us into the **shared** store (`thoughts/` + ADRs), so future agents on
+any machine make better decisions. This is `research-curate` evolved from *inventory* to *action*.
+Read `reference.md` (this dir) for the learnings-store schema before writing anything.
+
+**Two authority levels (hard rule):**
+- **Autonomous** — write/append/update/delete in `thoughts/shared/learnings/` and
+  `thoughts/CONCEPTS.md`, and prune stale notes in `thoughts/shared/{research,plans}/`.
+- **Propose only (APPROVE-gated)** — any change to `docs/adrs.md`. Never edit an ADR directly; queue
+  it for the morning ritual to approve.
+
+## Invocation
+
+```
+/catalyst-foundry:ticket-compound <TICKET> [mode:headless]
+```
+
+- `<TICKET>` — Linear key (e.g. `CTL-619`). If omitted, detect from the branch / `CATALYST_TICKET`.
+- `mode:headless` — non-interactive: apply all unambiguous autonomous actions silently, mark
+  ambiguous learnings `status: stale`, never block on a prompt, end with the sentinel line. This is
+  what the morning ritual (and, later, the daemon) use. Default is interactive.
+
+## Step 0 — Resolve shared scripts (fail fast)
+
+```bash
+source "${CLAUDE_PLUGIN_ROOT:-plugins/foundry}/scripts/require-catalyst-dev.sh" \
+    "${CLAUDE_PLUGIN_ROOT:-plugins/foundry}" || exit 1
+# $CATALYST_DEV_SCRIPTS now points at catalyst-dev's scripts (validate-learnings.sh etc).
+```
+
+## Step 1 — Gather raw signal (the orchestrator reads; do NOT delegate writes)
+
+For `<TICKET>`, collect:
+1. **Friction** — every `## Friction` / `friction:` block the phase agents left in their artifacts:
+   `thoughts/shared/{research,plans}/*<TICKET>*.md` and the worker signal files
+   `~/catalyst/workers/<TICKET>/*.json`.
+2. **The diff** — `git log --oneline origin/main..HEAD` and `git diff --stat origin/main..HEAD`
+   (or the merged SHA from `phase-monitor-merge.json`).
+3. **Ticket** — `linearis issues read <TICKET>` (title, description, final state, estimate).
+4. **Event trail** (optional) — the ticket's lines in `~/catalyst/events/YYYY-MM.jsonl`.
+
+Capture learnings from **failed/abandoned** tickets too — the dead-ends are high-signal ("what
+didn't work" is a first-class section).
+
+## Step 2 — Three TEXT-ONLY sub-agents (parallel; they return text, never write files)
+
+Spawn via Task, all at once. Each returns text to you; **you** do the single write in Step 3 (avoids
+partial-write races):
+
+- **Context Analyzer** — from the diff + ticket + friction, pick the track (bug vs knowledge),
+  `problem_type`, `category` (subdir), `component`, `severity`, and a filename slug. Returns the
+  frontmatter skeleton (validate against `reference.md`).
+- **Solution Extractor** — write the entry body per the track's template (bug: Problem/Symptoms/What
+  Didn't Work/Solution/Why This Works/Prevention; knowledge: Context/Guidance/Why This Matters/When
+  to Apply/Examples). Ground every claim in the diff/friction — no invention.
+- **Related-Learnings Finder** — `rg -li "<keywords>" thoughts/shared/learnings/**/*.md`, read the
+  frontmatter of hits, and score overlap (problem, root cause, component, files, prevention). Returns
+  HIGH (4–5) / MODERATE (2–3) / LOW (0–1) plus the matched paths.
+
+## Step 3 — Assemble + write ONE learnings entry (overlap routing)
+
+- **HIGH overlap** → update the existing entry in place (merge new detail, set `last_updated:`),
+  rather than creating a near-duplicate. This is the anti-bloat rule.
+- **MODERATE/LOW** → create `thoughts/shared/learnings/<category>/<slug>.md`.
+
+Then validate frontmatter (fail loud on the YAML traps in `reference.md`):
+
+```bash
+bash "${CATALYST_DEV_SCRIPTS}/compound/validate-learnings.sh" "<written-path>"
+```
+
+## Step 4 — Curate the store (five outcomes, autonomous in thoughts/)
+
+For the related entries the Finder surfaced, classify and act — **autonomously** (this is the
+`thoughts/` layer):
+| Outcome | When | Action |
+|---|---|---|
+| Keep | accurate, refs valid | none |
+| Update | core correct, refs/paths drifted | targeted in-place edit |
+| Consolidate | 2+ heavily overlap, both correct | merge into the canonical, delete the subsumed |
+| Replace | core guidance now misleading | write successor, delete old |
+| Delete | implementation gone AND domain gone AND no inbound links | remove (git history preserves) |
+
+Same five-outcome pass applies to stale `thoughts/shared/{research,plans}/` notes this ticket
+contradicted (the "off-track context that got us redirected"). In `mode:headless`, only act on
+unambiguous cases; mark the rest `status: stale` + `stale_reason`.
+
+## Step 5 — Vocabulary → CONCEPTS.md (autonomous)
+
+Scan the diff + friction for Catalyst domain terms not yet in `thoughts/CONCEPTS.md` (e.g. "reclaim",
+"revive-budget", "orphan", "signal ownership"). Append concise definitions. Create the file if absent.
+
+## Step 6 — ADR changes → PROPOSE, never apply
+
+If a learning rises to a standing rule (something *every* agent must always do/avoid), do NOT edit
+`docs/adrs.md`. Append a proposal to the approval queue:
+
+```
+thoughts/shared/compound/pending/<TICKET>.md
+```
+
+Each proposal: the target ADR (new / amend `ADR-NNN` / supersede `ADR-NNN`), the exact proposed text,
+and a one-line rationale + evidence (ticket + learning path). The morning ritual surfaces these; a
+human approves via `briefing-followup`'s `action-compound` handler, which is the only thing that
+writes `docs/adrs.md`.
+
+## Step 7 — Discoverability check (pointer only)
+
+Confirm `CLAUDE.md` teaches agents that the learnings store exists, its shape, and when to grep it. If
+not, propose (interactive) / apply (headless) a **minimal pointer** — never the learnings themselves:
+
+```
+thoughts/shared/learnings/ — past problem→solution entries (grep by component/tags/problem_type).
+Search before implementing or debugging in a known area. Curated by /catalyst-foundry:ticket-compound.
+```
+
+## Step 8 — Report
+
+- **Interactive:** summarize entry written/updated, curation actions, CONCEPTS additions, and any
+  queued ADR proposals (with the approval command).
+- **Headless:** structured block ending with the grep-able sentinel:
+
+```
+✓ ticket-compound complete (headless)
+ticket: CTL-619
+entry: thoughts/shared/learnings/orchestrator-issues/daemon-false-dead-first-commit.md (created)
+curated: 1 updated, 0 deleted ; concepts: +2 ; adr-proposals: 1 (pending approval)
+ticket-compound complete
+```
+
+## Out of scope (this slice)
+- The daemon firing this automatically after `monitor-deploy` (manual / morning-ritual triggered for now).
+- The estimation loop (separate slice — `compound-estimate` owns estimation numbers).
+- `ticket-retro` (the cross-ticket view — separate slice).

--- a/plugins/foundry/skills/ticket-compound/reference.md
+++ b/plugins/foundry/skills/ticket-compound/reference.md
@@ -1,0 +1,71 @@
+# Learnings store — schema reference
+
+Entries live in the shared, humanlayer-synced knowledge base at
+`thoughts/shared/learnings/<category>/<slug>.md` — alongside `research/` and `plans/`. Append-only
+in spirit (entries are updated, rarely deleted), reviewable, and surfaced in the daily briefing.
+Source docs/code are never modified by writing a learning.
+
+The store is **grep-first**: filenames are slugs, and frontmatter fields are designed as `rg` targets.
+There is no separate index file — discoverability is the category subdirs + frontmatter + (optionally)
+`research-curate`'s INDEX.md.
+
+## Two tracks
+
+Pick the track from `problem_type`.
+
+### Bug track
+`problem_type` ∈ `build_error | test_failure | runtime_error | logic_error | integration_issue |
+performance_issue | data_issue | security_issue`
+
+Body sections (in order): **Problem** → **Symptoms** → **What Didn't Work** → **Solution** →
+**Why This Works** → **Prevention** → **Related**.
+
+### Knowledge track
+`problem_type` ∈ `best_practice | architecture_pattern | convention | workflow_issue |
+developer_experience | documentation_gap | tooling_decision`
+
+Body sections (in order): **Context** → **Guidance** → **Why This Matters** → **When to Apply** →
+**Examples** → **Related**.
+
+## Frontmatter
+
+```yaml
+---
+title: "Daemon declares a live --bg worker dead on its first commit"   # human title
+date: 2026-06-06                       # ISO date created
+ticket: CTL-619                        # origin ticket (or null)
+category: orchestrator-issues          # = the subdir name
+problem_type: logic_error              # drives the track + body template
+component: execution-core              # grep target (enum below)
+severity: high                         # critical | high | medium | low
+root_cause: async_timing               # short slug; free-ish but prefer reuse
+resolution_type: code_fix              # code_fix|config_change|test_fix|workflow_improvement|doc_update|tooling_addition
+tags: [reclaim, revive, signal-ownership]   # grep targets
+see_also: ["thoughts/shared/learnings/orchestrator-issues/revive-storm.md"]
+last_updated: 2026-06-07               # added when an existing entry is updated
+status: active                         # active | stale  (stale set by the refresh audit)
+---
+```
+
+`component` enum (Catalyst): `orchestrator | phase-agent | broker | monitor | cli | ci | worktree |
+linear | execution-core | estimation | website | plugins`.
+
+`category` is the subdirectory; suggested set:
+`build-errors | test-failures | runtime-errors | logic-errors | integration-issues |
+performance-issues | architecture-patterns | conventions | workflow-issues |
+developer-experience | tooling-decisions | documentation-gaps`.
+
+## YAML safety
+Double-quote any array item or scalar that starts with `` ` ``, `[`, `*`, `#`, or contains `": "` —
+unquoted `#` is silently truncated as a comment and unquoted `: ` is parsed as a mapping. The
+`validate-learnings.sh` helper rejects these.
+
+## Three-tier hierarchy (where a learning belongs)
+- **Standing rule that every agent must always follow** → propose an **ADR** change (`docs/adrs.md`,
+  `@import`ed into CLAUDE.md). APPROVE-gated.
+- **Shared domain vocabulary** (what "reclaim", "revive-budget", "orphan", "signal ownership" mean)
+  → `thoughts/CONCEPTS.md`. Autonomous.
+- **A specific problem→solution pair** → a learnings entry here. Autonomous.
+
+CLAUDE.md itself only ever gets a *pointer* to the store (the "discoverability check"), never the
+learnings themselves.


### PR DESCRIPTION
## CTL-789 — Compound Engineering, Slice 1 (engineering loop MVP, Loop B)

Builds on the already-merged curator core (`15c980a0`: `ticket-compound` skill + learnings-store schema + `validate-learnings.sh`). This slice wires the **producer → consumer → approval** loop around it. Everything here is **off the critical path** — friction capture never blocks a phase's emit.

### Producer — per-phase friction logs
All five phase skills (`phase-research/plan/implement/verify/review`) append a **timestamped** record to one dedicated per-ticket log `thoughts/shared/friction/<TICKET>.md`:

```
## <phase> · <TICKET> · <ISO-8601 timestamp>   e.g. 2026-06-06T11:09:57+0900
- **Backtracks / redone work:** …
- **Missing / wrong / hard-to-find context:** …
- **If I'd known:** <the ADR/guidance that would've saved this — the compounding signal>
```

A dedicated log (not inline-in-artifact) because `implement/verify/review` emit only signal JSON, and editing those envelopes risks the known overwrite/merge bug. The per-record ISO-8601 timestamp lets the daily review scan + sort "friction since last review".

### Consumer — grep-first learnings lens
`phase-research` greps `thoughts/shared/learnings/**`, filters by frontmatter component/tags, and injects a **"Relevant Past Learnings"** section before researching (degrades gracefully on an empty store). `phase-plan` gets a light pointer.

### Approval surface — morning ritual
- `action-compound.sh` (apply/edit/defer/reject) — the **sole writer of `docs/adrs.md`**, applying an approved proposal from `thoughts/shared/compound/pending/<TICKET>.md`. Mirrors the existing `action-adr.sh` JSON-line / exit-code contract.
- `briefing-followup` dispatches the new `compound` decision type and records via the existing recorder.
- `morning-briefing` surfaces a **"Friction since last briefing"** digest (primary, timestamp-windowed, newest-first) + **"Learnings since last briefing"**, plus pending ADR proposals as decisions.

### Store + discoverability
`ticket-compound` Step 1 now harvests the friction log; `CLAUDE.md` gains a minimal learnings-store pointer; seeded `thoughts/CONCEPTS.md` + a dogfood learnings entry (in the synced shared store).

### Tests / gates
- New `ticket-compound-shape.test.sh` — **32/32**.
- Safe unit suites green (compound-log 13/13, phase-advance 59/59, ordering/sequence/globs/no-linear-prose).
- `audit-references.sh --ci` exit 0 (zero warnings on the new surface).
- `./scripts/validate-release-config.sh` 8/8.
- `orchestrate-phase-state-machine` passes **15/15** with the daemon-probe present/bypassed; the diff touches no dispatch/daemon code.
- Phase `*-e2e` + execution-core suites deferred to CI (they spawn scratch worktrees).

### Notes
- `thoughts/CONCEPTS.md` (top-level) does not humanlayer-sync in this setup; relocating under `thoughts/shared/` for cross-machine durability is a small follow-up (touches the `ticket-compound` contract).
- Slices 2 (estimation-loop closure) and 3 (`ticket-retro`) follow as separate PRs per the design.

Design: `thoughts/shared/plans/2026-06-06-compound-engineering.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)