### PR TITLE
fix(dev): evidence-gate worktree removal — never delete without merged+clean+no-session+provenance (CTL-791)

### DIFF
--- a/plugins/dev/scripts/execution-core/abort-worker.mjs
+++ b/plugins/dev/scripts/execution-core/abort-worker.mjs
@@ -9,9 +9,17 @@
 
 import { readdirSync, readFileSync, writeFileSync, renameSync } from "node:fs";
 import { join } from "node:path";
-import { teardownWorktree as defaultTeardownWorktree } from "./worktree.mjs";
+import { gatedTeardownWorktree } from "./worktree-safety.mjs";
 import { log } from "./config.mjs";
 import { emitReapIntent } from "./reap-intent.mjs";
+
+// CTL-791: abort is NEVER terminal (the ticket is not Done/merged), so abort must
+// NOT remove the worktree. The gate, invoked with terminal:false, ALWAYS defers —
+// it flags the tree (worktree.cleanup-deferred + out-of-tree marker) and leaves it
+// for the scheduler's terminal-Done sweep to remove later, only once it is
+// genuinely safe (merged + clean + no live session + orchestrator-provenance).
+const defaultTeardownWorktree = ({ repoRoot, ticket }) =>
+  gatedTeardownWorktree({ repoRoot, ticket, terminal: false });
 
 // Signal statuses that mean a phase no longer holds a live worker — left as-is.
 //
@@ -107,13 +115,13 @@ export function abortWorker(
     );
   }
 
-  // Worktree teardown is SKIPPED while a bg job is still live in it: a
-  // `git worktree remove --force` would yank the filesystem out from under a
-  // running `claude` worker. defaultKillJob is a no-op (no `claude` bg-kill
-  // verb exists), so a recorded-but-unkilled job means the worker is presumed
-  // alive — leave its worktree for a later sweep (the scheduler's terminal-Done
-  // teardown once the phase settles, or an operator). A ticket with no bg job
-  // (never reached `claude --bg`) is safe to tear down now.
+  // Worktree teardown is SKIPPED while a bg job is still live in it (a removal
+  // would yank the filesystem out from under a running `claude` worker).
+  // defaultKillJob is a no-op (no `claude` bg-kill verb exists), so a
+  // recorded-but-unkilled job means the worker is presumed alive — leave its
+  // worktree. With no live job, the teardown seam still only FLAGS the worktree
+  // (CTL-791: abort is non-terminal → the gate defers); the scheduler's
+  // terminal-Done sweep removes it later, once it is genuinely safe.
   const liveJobs = [...jobIds].filter((id) => !jobsKilled.includes(id));
   let worktreeRemoved = false;
   if (liveJobs.length > 0) {

--- a/plugins/dev/scripts/execution-core/reap-intent.mjs
+++ b/plugins/dev/scripts/execution-core/reap-intent.mjs
@@ -28,6 +28,11 @@ export const REAP_INTENT_TYPES = Object.freeze([
   // final monitor-deploy phase completed, with no successor dispatch to trigger the
   // happy-path predecessor reap. Routed to the single-target (busy-OK) reap path.
   "phase.terminal.reap-requested",
+  // CTL-791: a worktree removal was REFUSED by the evidence gate (not merged /
+  // dirty / live session / unknown provenance / archive-failed). A FLAG, not a
+  // request — the reaper does not act on it; it surfaces the deferred worktree in
+  // the out-of-tree cleanup queue + orch-monitor for an operator / later tick.
+  "worktree.cleanup-deferred",
 ]);
 
 // camelCase → snake_case key mapping. The on-disk schema uses snake_case so

--- a/plugins/dev/scripts/execution-core/reap-intent.test.mjs
+++ b/plugins/dev/scripts/execution-core/reap-intent.test.mjs
@@ -46,12 +46,13 @@ describe("emitReapIntent", () => {
     await expect(emitReapIntent("bogus.event", {})).rejects.toThrow(/unknown/);
   });
 
-  it("exposes REAP_INTENT_TYPES with 11 entries", async () => {
+  it("exposes REAP_INTENT_TYPES with 12 entries", async () => {
     const { REAP_INTENT_TYPES } = await freshModule();
-    expect(REAP_INTENT_TYPES.length).toBe(11);
+    expect(REAP_INTENT_TYPES.length).toBe(12);
     expect(REAP_INTENT_TYPES).toContain("phase.yield.reap-requested");
     expect(REAP_INTENT_TYPES).toContain("pr.merged.cleanup-requested");
     expect(REAP_INTENT_TYPES).toContain("orphans.reap-requested");
+    expect(REAP_INTENT_TYPES).toContain("worktree.cleanup-deferred"); // CTL-791
   });
 
   it("accepts phase.terminal.reap-requested (CTL-695)", async () => {

--- a/plugins/dev/scripts/execution-core/reaper.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.mjs
@@ -21,7 +21,7 @@ import { scanEventsChunked } from "./event-tail.mjs";
 import { shortIdFromSessionId, isSelfSession } from "./claude-ids.mjs";
 import { emitReapIntent, REAP_INTENT_TYPES } from "./reap-intent.mjs";
 import { lastSeenMsForSession } from "./session-recency.mjs";
-import { getAgentsCached } from "./claude-agents.mjs";
+import { getAgentsCached, listClaudeAgentsResult } from "./claude-agents.mjs";
 import {
   isSafeToRemoveWorktree,
   hasOrchProvenance,
@@ -59,15 +59,26 @@ export const CLEANUP_GRACE_MS = 60_000;
 // folds in the live `claude agents` snapshot + the lsof backstop + registry
 // provenance, and returns { safe, reasons }. Injectable as the Reaper's
 // `assessWorktreeRemoval` seam so unit tests drive the verdict without real git.
-async function defaultAssessWorktreeRemoval(event, agentsFn) {
+export async function defaultAssessWorktreeRemoval(event, readAgents = () => listClaudeAgentsResult()) {
   const gateRunGit = (args) =>
     spawnSync("git", ["-C", event.worktree_path, ...args], { encoding: "utf8" });
+  // Fail-closed liveness: listClaudeAgentsResult distinguishes a FAILED read
+  // ({ ok:false }) from a genuinely-empty fleet, so a crashed/timed-out/cold
+  // `claude agents` yields agents-stale → unsafe rather than a false "no live
+  // session". (getAgentsCached().agents ALWAYS returns an array — cold cache → []
+  // — which would silently defeat the gate; CTL-791 adversarial review.)
+  // `readAgents` is injectable so a test can drive the failed-read branch.
   let agentsList = [];
   let agentsOk = false;
   try {
-    const a = await agentsFn();
-    agentsList = Array.isArray(a) ? a : [];
-    agentsOk = Array.isArray(a);
+    const r = readAgents();
+    if (Array.isArray(r)) {
+      agentsList = r;
+      agentsOk = true;
+    } else {
+      agentsList = r?.agents ?? [];
+      agentsOk = r?.ok === true;
+    }
   } catch {
     agentsOk = false;
   }
@@ -330,7 +341,7 @@ export class Reaper {
     //     incident's hole), a dirty/unmerged tree, or an interactive/unknown
     //     worktree must also block. Unsafe ⇒ flag (out-of-tree marker +
     //     cleanup-deferred), never remove. ARCHIVE worktree-local docs first.
-    const verdict = await this.assessWorktreeRemoval(event, this.agents);
+    const verdict = await this.assessWorktreeRemoval(event);
     if (!verdict.safe) {
       deferWorktreeCleanup(
         event.worktree_path,
@@ -791,7 +802,11 @@ async function defaultGitWorktreeRemove(path) {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     });
-    if ((res.status ?? 0) === 0) return { ok: true };
+    // CTL-791: fail-closed. spawnSync sets `error` + a null status when git can't
+    // be spawned (ENOENT / resource limit); `?? 0` would mis-read that as a
+    // successful removal and trigger a false branch-delete + cleanup-complete.
+    if (res.error) return { ok: false, error: res.error.message };
+    if ((res.status ?? 1) === 0) return { ok: true };
     return { ok: false, error: res.stderr?.trim() || `git worktree remove rc=${res.status}` };
   } catch (err) {
     return { ok: false, error: err.message };

--- a/plugins/dev/scripts/execution-core/reaper.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.mjs
@@ -22,6 +22,13 @@ import { shortIdFromSessionId, isSelfSession } from "./claude-ids.mjs";
 import { emitReapIntent, REAP_INTENT_TYPES } from "./reap-intent.mjs";
 import { lastSeenMsForSession } from "./session-recency.mjs";
 import { getAgentsCached } from "./claude-agents.mjs";
+import {
+  isSafeToRemoveWorktree,
+  hasOrchProvenance,
+  deferWorktreeCleanup,
+  archiveWorktreeArtifacts,
+  lsofCwdUnder,
+} from "./worktree-safety.mjs";
 import { log } from "./config.mjs";
 
 const CLAUDE_BIN = process.env.CATALYST_DISPATCH_CLAUDE_BIN || "claude";
@@ -47,6 +54,37 @@ const DEFAULT_MIN_IDLE_MS = 15 * 60 * 1000; // 15 min
 // separate named constants.
 export const CLEANUP_GRACE_MS = 60_000;
 
+// defaultAssessWorktreeRemoval — CTL-791 evidence gate for the PR-merged cleanup.
+// Anchors the merged/clean/unpushed reads inside the worktree itself (-C path),
+// folds in the live `claude agents` snapshot + the lsof backstop + registry
+// provenance, and returns { safe, reasons }. Injectable as the Reaper's
+// `assessWorktreeRemoval` seam so unit tests drive the verdict without real git.
+async function defaultAssessWorktreeRemoval(event, agentsFn) {
+  const gateRunGit = (args) =>
+    spawnSync("git", ["-C", event.worktree_path, ...args], { encoding: "utf8" });
+  let agentsList = [];
+  let agentsOk = false;
+  try {
+    const a = await agentsFn();
+    agentsList = Array.isArray(a) ? a : [];
+    agentsOk = Array.isArray(a);
+  } catch {
+    agentsOk = false;
+  }
+  return isSafeToRemoveWorktree(
+    event.worktree_path,
+    {
+      ticket: event.ticket,
+      repoRoot: event.worktree_path,
+      branch: event.branch,
+      terminal: true,
+      prMerged: event.force === true, // event.force === confirmed GitHub MERGED
+      orchProvenance: hasOrchProvenance(event.ticket),
+    },
+    { runGit: gateRunGit, agentsList, agentsOk, procLive: lsofCwdUnder(event.worktree_path) === true },
+  );
+}
+
 /**
  * Reaper — composes injectable executors so the unit test never shells out.
  * Production wiring uses the defaults; tests pass fakes.
@@ -59,6 +97,11 @@ export class Reaper {
     gitWorktreeRemove = defaultGitWorktreeRemove,
     gitBranchDelete = defaultGitBranchDelete,
     cwdExists = defaultCwdExists,
+    // CTL-791: the PR-merged cleanup gate + archive seams. Defaults run the real
+    // evidence gate (GitHub-merged + clean + no-live-session + provenance) and the
+    // worktree-path archive; tests inject stubs to drive each branch.
+    assessWorktreeRemoval = defaultAssessWorktreeRemoval,
+    archiveWorktree = archiveWorktreeArtifacts,
     // CTL-649 safety guards:
     //  - includeInteractive: opt-in to reaping interactive (human) sessions.
     //    Default false — the daemon never opts in, so a stepped-away human
@@ -85,6 +128,8 @@ export class Reaper {
     this.gitWorktreeRemove = gitWorktreeRemove;
     this.gitBranchDelete = gitBranchDelete;
     this.cwdExists = cwdExists;
+    this.assessWorktreeRemoval = assessWorktreeRemoval;
+    this.archiveWorktree = archiveWorktree;
     this.includeInteractive = includeInteractive;
     this.minIdleMs = minIdleMs;
     this.lastSeenMs = lastSeenMs;
@@ -280,6 +325,42 @@ export class Reaper {
       });
       return;
     }
+    // 1b. CTL-791 evidence gate (injectable seam). The presweep above only
+    //     HARD-blocks interactive-kind sessions; an idle BACKGROUND agent (the
+    //     incident's hole), a dirty/unmerged tree, or an interactive/unknown
+    //     worktree must also block. Unsafe ⇒ flag (out-of-tree marker +
+    //     cleanup-deferred), never remove. ARCHIVE worktree-local docs first.
+    const verdict = await this.assessWorktreeRemoval(event, this.agents);
+    if (!verdict.safe) {
+      deferWorktreeCleanup(
+        event.worktree_path,
+        { ticket: event.ticket, branch: event.branch, reasons: verdict.reasons },
+        { emit: (t, f) => this.emit(t, f) },
+      );
+      await this.emit("pr.merged.cleanup-failed", {
+        ticket: event.ticket,
+        worktreePath: event.worktree_path,
+        branch: event.branch,
+        reason: `unsafe:${(verdict.reasons || []).join(",")}`,
+      });
+      return;
+    }
+    const arch = this.archiveWorktree(event.worktree_path, { ticket: event.ticket });
+    if (!arch.ok) {
+      deferWorktreeCleanup(
+        event.worktree_path,
+        { ticket: event.ticket, branch: event.branch, reasons: ["archive-failed", arch.error] },
+        { emit: (t, f) => this.emit(t, f) },
+      );
+      await this.emit("pr.merged.cleanup-failed", {
+        ticket: event.ticket,
+        worktreePath: event.worktree_path,
+        branch: event.branch,
+        reason: "archive-failed",
+      });
+      return;
+    }
+
     // 2. Remove worktree.
     const wt = await this.gitWorktreeRemove(event.worktree_path);
     if (!wt.ok) {

--- a/plugins/dev/scripts/execution-core/reaper.test.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.test.mjs
@@ -7,6 +7,7 @@ import {
   groupBackgroundSessionsByTicket,
   CLEANUP_GRACE_MS,
   defaultAgents,
+  defaultAssessWorktreeRemoval,
 } from "./reaper.mjs";
 import {
   refreshAgents,
@@ -468,6 +469,17 @@ describe("Reaper._handlePrMergedCleanup", () => {
     // Sibling session untouched, and cleanup proceeds for the real target.
     expect(stopped).toEqual([]);
     expect(wtRemove).toHaveBeenCalled();
+  });
+
+  it("CTL-791: defaultAssessWorktreeRemoval is FAIL-CLOSED on a failed `claude agents` read (agents-stale)", async () => {
+    // The production seam must NOT treat an unreadable/cold fleet as empty: a
+    // failed read ({ ok:false }) → agents-stale → unsafe (never a false no-session).
+    const verdict = await defaultAssessWorktreeRemoval(
+      { worktree_path: "/nonexistent/wt/CTL-1", ticket: "CTL-1", branch: "b", force: true },
+      () => ({ agents: [], ok: false }), // injected failed read
+    );
+    expect(verdict.safe).toBe(false);
+    expect(verdict.reasons).toContain("agents-stale");
   });
 
   it("CTL-791: an UNSAFE gate verdict DEFERS — no worktree remove, no branch delete, emits cleanup-deferred + failed", async () => {

--- a/plugins/dev/scripts/execution-core/reaper.test.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.test.mjs
@@ -329,6 +329,8 @@ describe("Reaper._handlePrMergedCleanup", () => {
     const r = new Reaper({
       executorReap: (id) => { trace.push(["reap", id]); return Promise.resolve({ ok: true }); },
       agents: agentsFixture([]),
+      assessWorktreeRemoval: async () => ({ safe: true, reasons: [] }), // CTL-791: gate satisfied
+      archiveWorktree: () => ({ ok: true }),
       gitWorktreeRemove: (p) => { trace.push(["wt", p]); return Promise.resolve({ ok: true }); },
       gitBranchDelete: (b, force) => { trace.push(["br", b, force]); return Promise.resolve({ ok: true }); },
       emit: (evt) => { trace.push(["emit", evt]); return Promise.resolve(); },
@@ -353,6 +355,8 @@ describe("Reaper._handlePrMergedCleanup", () => {
     const r = new Reaper({
       executorReap: () => Promise.resolve({ ok: true }),
       agents: agentsFixture([]),
+      assessWorktreeRemoval: async () => ({ safe: true, reasons: [] }), // CTL-791: gate satisfied
+      archiveWorktree: () => ({ ok: true }),
       gitWorktreeRemove: () => Promise.resolve({ ok: true }),
       gitBranchDelete: (b, force) => { calls.push({ b, force }); return Promise.resolve({ ok: true }); },
       emit: () => Promise.resolve(),
@@ -373,6 +377,8 @@ describe("Reaper._handlePrMergedCleanup", () => {
     const r = new Reaper({
       executorReap: () => Promise.resolve({ ok: true }),
       agents: agentsFixture([]),
+      assessWorktreeRemoval: async () => ({ safe: true, reasons: [] }), // CTL-791: gate satisfied
+      archiveWorktree: () => ({ ok: true }),
       gitWorktreeRemove: () => Promise.resolve({ ok: true }),
       // Non-force `-d` refuses an unmerged branch.
       gitBranchDelete: () => Promise.resolve({ ok: false, error: "not fully merged" }),
@@ -446,6 +452,8 @@ describe("Reaper._handlePrMergedCleanup", () => {
       agents: agentsFixture([
         { sessionId: "99999999-aaaa-bbbb-cccc-dddddddddddd", cwd: "/wt/CTL-649", status: "idle" },
       ]),
+      assessWorktreeRemoval: async () => ({ safe: true, reasons: [] }), // CTL-791: gate satisfied
+      archiveWorktree: () => ({ ok: true }),
       gitWorktreeRemove: wtRemove,
       gitBranchDelete: () => Promise.resolve({ ok: true }),
       emit: () => Promise.resolve(),
@@ -460,6 +468,33 @@ describe("Reaper._handlePrMergedCleanup", () => {
     // Sibling session untouched, and cleanup proceeds for the real target.
     expect(stopped).toEqual([]);
     expect(wtRemove).toHaveBeenCalled();
+  });
+
+  it("CTL-791: an UNSAFE gate verdict DEFERS — no worktree remove, no branch delete, emits cleanup-deferred + failed", async () => {
+    const wtRemove = mock(() => Promise.resolve({ ok: true }));
+    const brDelete = mock(() => Promise.resolve({ ok: true }));
+    const emitted = [];
+    const r = new Reaper({
+      executorReap: () => Promise.resolve({ ok: true }),
+      agents: agentsFixture([]),
+      assessWorktreeRemoval: async () => ({ safe: false, reasons: ["dirty-worktree", "unknown-provenance"] }),
+      archiveWorktree: () => ({ ok: true }),
+      gitWorktreeRemove: wtRemove,
+      gitBranchDelete: brDelete,
+      emit: (evt, fields) => { emitted.push({ evt, fields }); return Promise.resolve(); },
+      log: silentLog(),
+    });
+    await r.handle({
+      event: "pr.merged.cleanup-requested",
+      ticket: "CTL-1",
+      worktree_path: "/wt/CTL-1",
+      branch: "ryan/ctl-1",
+      force: true,
+    });
+    expect(wtRemove).not.toHaveBeenCalled();
+    expect(brDelete).not.toHaveBeenCalled();
+    expect(emitted.find((e) => e.evt === "worktree.cleanup-deferred")).toBeTruthy();
+    expect(emitted.find((e) => e.evt === "pr.merged.cleanup-failed")).toBeTruthy();
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -63,7 +63,10 @@ import { rankTickets, compareTickets } from "./scheduler-rank.mjs";
 import { defaultDispatch, dispatchTicket, teamOf } from "./dispatch.mjs";
 import { fetchTicketState, fetchTicketsBatch, classifyTicketResolution } from "./linear-query.mjs";
 import { getProjectConfig, listProjects } from "./registry.mjs";
-import { teardownWorktree as defaultTeardownWorktree } from "./worktree.mjs";
+// CTL-791: the terminal-Done sweep removes a worktree ONLY through the evidence
+// gate (GitHub-merged + clean + no-live-session + orchestrator-provenance,
+// archive-first, never --force); an unsafe tree is flagged, not deleted.
+import { gatedTeardownWorktree as defaultTeardownWorktree } from "./worktree-safety.mjs";
 import { readWorkerSignals } from "./signal-reader.mjs";
 // CTL-642/758: the live PR-merged adapter. makePrView is the single gh
 // `pr view` source of truth (shared with the scan CLI's makeScanAdapters), so

--- a/plugins/dev/scripts/execution-core/worktree-safety.mjs
+++ b/plugins/dev/scripts/execution-core/worktree-safety.mjs
@@ -1,0 +1,436 @@
+// worktree-safety.mjs — CTL-791. Evidence-gated worktree removal (data-loss
+// hardening).
+//
+// A live incident (2026-06-06) lost an interactive/agent worktree's uncommitted
+// work + worktree-local design docs/handoffs because the daemon's removal paths
+// treated "no live session right now" OR "Linear=Done" OR "PR=merged" as
+// sufficient and ran `git worktree remove --force`. This module is the single
+// gate every automated removal must pass: a worktree is removed ONLY with
+// positive, fail-closed evidence that it is GitHub-merged + clean (modulo known
+// machine-local noise) + has zero live sessions of ANY kind + was
+// orchestrator-created — and its worktree-local docs are archived first.
+// Anything else is FLAGGED into an out-of-tree queue (never deleted), which the
+// scheduler's terminal sweep re-evaluates on later ticks (no leak: once the
+// blockers clear, the next tick removes it).
+//
+// Scope (CTL-791 core): the predicate, the gated remover, the out-of-tree defer
+// path, the worktree-path archive, the lsof backstop, and registry-derived
+// provenance. The `worktrees safe/archive` CLI verbs, the orphan-sweep.sh gating,
+// the periodic deferred-queue drain, and the orch-monitor surface are the
+// CTL-792 fast-follow.
+
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  readdirSync,
+  statSync,
+  copyFileSync,
+  readFileSync,
+} from "node:fs";
+import { join, basename } from "node:path";
+import { createHash } from "node:crypto";
+import { homedir } from "node:os";
+import { emitReapIntent } from "./reap-intent.mjs";
+import { log } from "./config.mjs";
+import { parseWorktreeForBranch } from "./worktree.mjs";
+import { listClaudeAgentsResult } from "./claude-agents.mjs";
+
+// MACHINE_LOCAL_NOISE — porcelain entries that are machine-local drift, not real
+// work. Every real orchestrator worktree carries at least ` M .catalyst/config.json`
+// (create-worktree.sh copies .catalyst, the daemon then mutates it), so a raw
+// "porcelain empty" clean-check would defer every tree forever.
+export const MACHINE_LOCAL_NOISE = Object.freeze([
+  ".catalyst/config.json",
+  ".catalyst/.workflow-context.json",
+  ".catalyst/.workflow-context.json.bak",
+  ".catalyst/worktree-provenance.json",
+  ".needs-cleanup",
+  ".trunk",
+  ".orphaned_at",
+]);
+
+const DEFAULT_QUEUE_DIR = join(homedir(), "catalyst", "wt-cleanup-queue");
+const DEFAULT_ARCHIVE_DIR = join(homedir(), "catalyst", "archives", "worktree-docs");
+const DEFAULT_RUNS_ROOT = join(homedir(), "catalyst", "runs");
+
+// listOrchDirs — the orchestrator run dirs under ~/catalyst/runs. Each holds a
+// workers/<ticket>/ dir for every ticket that orchestrator dispatched — the
+// registry-derived provenance signal (hasOrchProvenance). Never throws.
+export function listOrchDirs(runsRoot = DEFAULT_RUNS_ROOT) {
+  try {
+    return readdirSync(runsRoot, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => join(runsRoot, d.name));
+  } catch {
+    return [];
+  }
+}
+
+function stripTrailingSlash(p) {
+  return typeof p === "string" ? p.replace(/\/+$/, "") : p;
+}
+
+// cwdUnder — true when `cwd` is the worktree root or nested beneath it. Exact
+// path-segment match so /a/CTL-7 never matches /a/CTL-70.
+function cwdUnder(cwd, root) {
+  if (!cwd || !root) return false;
+  const c = stripTrailingSlash(cwd);
+  const r = stripTrailingSlash(root);
+  return c === r || c.startsWith(r + "/");
+}
+
+function sha1(s) {
+  return createHash("sha1").update(String(s)).digest("hex");
+}
+
+// porcelainPath — extract the path from a `git status --porcelain` line,
+// handling the `XY <path>` and rename `XY <old> -> <new>` shapes.
+function porcelainPath(line) {
+  const body = line.slice(3); // strip the 2 status chars + space
+  const arrow = body.lastIndexOf(" -> ");
+  return (arrow >= 0 ? body.slice(arrow + 4) : body).replace(/^"|"$/g, "").trim();
+}
+
+function matchesNoise(path, noise) {
+  return noise.some((n) => path === n || path.startsWith(n + "/") || path.startsWith(n));
+}
+
+// cleanPorcelain — the porcelain lines that represent REAL work (anything not in
+// the machine-local ignore-set). Empty array ⇒ clean. Operates on untracked
+// (`??`) entries too, which `git status -- :(exclude)` cannot.
+export function cleanPorcelain(porcelain, noise = MACHINE_LOCAL_NOISE) {
+  return (porcelain ?? "")
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .filter((l) => !matchesNoise(porcelainPath(l), noise));
+}
+
+// lsofCwdUnder — inventory-independent liveness: true when ANY OS process has its
+// cwd or an open handle under `path`, even one `claude agents --json` never
+// listed (the incident's actual surface — a detached agent/workflow). Fail-closed:
+// if the probe itself cannot run, return true (treat as live, refuse removal).
+export function lsofCwdUnder(path, { exec = spawnSync } = {}) {
+  if (!path) return true;
+  const wt = stripTrailingSlash(path);
+  try {
+    const res = exec("lsof", ["-nP", "+D", wt], { encoding: "utf8", timeout: 10_000 });
+    // lsof rc: 0 = matches found (live), 1 = none found (clear). Any other
+    // status (binary missing → ENOENT surfaces as res.error) → fail-closed.
+    if (res.error) return true;
+    if ((res.status ?? 1) === 0 && (res.stdout ?? "").trim().length > 0) return true;
+    if ((res.status ?? 1) === 1) return false; // definitively nothing under the tree
+    return (res.stdout ?? "").trim().length > 0; // ambiguous → trust any output
+  } catch {
+    return true; // cannot probe → fail-closed
+  }
+}
+
+// hasOrchProvenance — true iff the orchestrator created this worktree, evidenced
+// by a `workers/<ticket>/` dir under any registered orchDir. Registry-derived
+// (NOT a worktree-local marker, which would self-dirty the tree and vanish on
+// removal). An unknown/interactive worktree has no such dir ⇒ false ⇒ never
+// removed. Never throws.
+export function hasOrchProvenance(ticket, { orchDirs = listOrchDirs() } = {}) {
+  if (!ticket) return false;
+  for (const dir of orchDirs) {
+    try {
+      if (existsSync(join(dir, "workers", ticket))) return true;
+    } catch {
+      /* unreadable orchDir → not evidence */
+    }
+  }
+  return false;
+}
+
+// isSafeToRemoveWorktree — the PURE gate. `ctx` carries caller-supplied evidence
+// (terminal, prMerged, orchProvenance, branch); `deps` carries the resolved live
+// state (agentsList/agentsOk, procLive) + git/clock seams. Returns
+// { safe, reasons } with ALL failures collected (no short-circuit) so the defer
+// marker records the full picture. `safe === true` only when every gate passes.
+export function isSafeToRemoveWorktree(worktreePath, ctx = {}, deps = {}) {
+  const {
+    runGit = (args) =>
+      spawnSync("git", ["-C", ctx.repoRoot, ...args], { encoding: "utf8" }),
+    agentsList = [],
+    agentsOk = false,
+    procLive = false,
+    noiseGlobs = MACHINE_LOCAL_NOISE,
+  } = deps;
+  const reasons = [];
+
+  // (a) terminal — required but not sufficient.
+  if (ctx.terminal !== true) reasons.push("not-terminal");
+
+  // (b) GitHub-merged (squash-safe: this repo squash-merges, so a local
+  // `rev-list origin/main..branch` is NEVER 0 for a merged branch — the merged
+  // signal MUST come from the GitHub PR state the caller passes). Plus a
+  // committed-unpushed guard for the no-PR case (only when an upstream resolves;
+  // absence of an upstream is NOT unpushed evidence).
+  if (ctx.prMerged !== true) reasons.push("not-merged");
+  try {
+    const up = runGit(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]);
+    if ((up.status ?? 1) === 0 && (up.stdout ?? "").trim()) {
+      const ahead = runGit(["rev-list", "--count", "@{u}..HEAD"]);
+      if ((ahead.status ?? 1) === 0 && Number((ahead.stdout ?? "0").trim()) > 0) {
+        reasons.push("unpushed-commits");
+      }
+    }
+  } catch {
+    /* upstream probe failed → not treated as unpushed evidence */
+  }
+
+  // (c) clean tree, machine-local noise excluded.
+  try {
+    const st = runGit(["status", "--porcelain"]);
+    if ((st.status ?? 1) !== 0) reasons.push("status-unreadable");
+    else if (cleanPorcelain(st.stdout ?? "", noiseGlobs).length > 0) reasons.push("dirty-worktree");
+  } catch {
+    reasons.push("status-unreadable");
+  }
+
+  // (d) no live session of ANY kind (interactive/background/idle/active), via the
+  // agents snapshot AND the inventory-independent lsof backstop AND a recency
+  // proxy. Fail-closed if the agents read could not be trusted.
+  if (!agentsOk) {
+    reasons.push("agents-stale");
+  } else if (agentsList.some((a) => a?.cwd && cwdUnder(a.cwd, worktreePath))) {
+    reasons.push("live-session");
+  }
+  // Inventory-independent backstop: a real process under the tree that
+  // `claude agents` never listed (the incident's actual surface).
+  if (procLive === true) reasons.push("proc-live");
+
+  // (e) orchestrator provenance — never touch an interactive/unknown worktree.
+  if (ctx.orchProvenance !== true) reasons.push("unknown-provenance");
+
+  return { safe: reasons.length === 0, reasons };
+}
+
+// deferWorktreeCleanup — the single FLAG path. Emits worktree.cleanup-deferred and
+// writes an OUT-OF-TREE marker (so it survives the worktree's own removal and
+// never self-dirties the tree). Idempotent. Never throws.
+export function deferWorktreeCleanup(
+  worktreePath,
+  { ticket, branch, reasons } = {},
+  { emit = emitReapIntent, queueDir = DEFAULT_QUEUE_DIR } = {},
+) {
+  const reasonStr = Array.isArray(reasons) ? reasons.join(",") : String(reasons ?? "unspecified");
+  try {
+    // Fire-and-forget: emitReapIntent does its work synchronously (appendFileSync)
+    // but returns a promise; never block the synchronous teardown path on it.
+    Promise.resolve(
+      emit("worktree.cleanup-deferred", { ticket, worktreePath, branch, reason: reasonStr }),
+    ).catch(() => {});
+  } catch (err) {
+    log.warn({ err: err?.message, worktreePath }, "worktree-safety: defer emit failed");
+  }
+  try {
+    mkdirSync(queueDir, { recursive: true });
+    writeFileSync(
+      join(queueDir, `${sha1(stripTrailingSlash(worktreePath))}.json`),
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        ticket: ticket ?? null,
+        branch: branch ?? null,
+        worktreePath,
+        reasons: Array.isArray(reasons) ? reasons : [reasonStr],
+      }),
+    );
+  } catch (err) {
+    log.warn({ err: err?.message, worktreePath }, "worktree-safety: defer marker write failed");
+  }
+  log.info({ ticket, worktreePath, reasons }, "worktree: cleanup deferred (flagged, NOT removed)");
+  return { removed: false, deferred: true, reasons: Array.isArray(reasons) ? reasons : [reasonStr] };
+}
+
+function clearDeferMarker(worktreePath, queueDir) {
+  try {
+    rmSync(join(queueDir, `${sha1(stripTrailingSlash(worktreePath))}.json`), { force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+// archiveWorktreeArtifacts — durability net for worktree-local docs/thoughts the
+// incident lost (gitignored thoughts/ is invisible to the clean-check, so a
+// "clean" tree can still hold unsynced design docs/handoffs). Worktree-path
+// based (NOT orchId-based — the incident worktree had no run dir). Fail-closed:
+// returns ok only when the thoughts sync AND the loose-doc copy both succeed.
+export function archiveWorktreeArtifacts(
+  worktreePath,
+  { ticket } = {},
+  { exec = spawnSync, archiveDir = DEFAULT_ARCHIVE_DIR } = {},
+) {
+  // (1) sync thoughts/ to the shared store. "nothing to sync" (empty/absent
+  // thoughts/) counts as success; a non-empty thoughts/ that fails to sync (or a
+  // missing humanlayer) is FAIL-CLOSED.
+  const thoughtsDir = join(worktreePath, "thoughts");
+  let thoughtsHasContent = false;
+  try {
+    thoughtsHasContent = existsSync(thoughtsDir) && readdirSync(thoughtsDir).length > 0;
+  } catch {
+    thoughtsHasContent = false;
+  }
+  if (thoughtsHasContent) {
+    try {
+      const res = exec("humanlayer", ["thoughts", "sync"], {
+        cwd: worktreePath,
+        encoding: "utf8",
+        timeout: 120_000,
+      });
+      if (res.error || (res.status ?? 1) !== 0) {
+        return { ok: false, error: `thoughts sync failed: ${res.error?.message ?? res.stderr ?? "rc=" + res.status}` };
+      }
+    } catch (err) {
+      return { ok: false, error: `thoughts sync threw: ${err?.message}` };
+    }
+  }
+
+  // (2) copy loose worktree-local docs (top-level *.md not under thoughts/) into
+  // the archive, content-hash idempotent, post-copy stat-verified.
+  const dest = join(archiveDir, ticket || sha1(stripTrailingSlash(worktreePath)));
+  try {
+    let docs = [];
+    try {
+      docs = readdirSync(worktreePath).filter((f) => f.toLowerCase().endsWith(".md"));
+    } catch {
+      docs = [];
+    }
+    if (docs.length > 0) mkdirSync(dest, { recursive: true });
+    for (const f of docs) {
+      const src = join(worktreePath, f);
+      try {
+        if (!statSync(src).isFile()) continue;
+      } catch {
+        continue;
+      }
+      let out = join(dest, f);
+      if (existsSync(out)) {
+        const same = sha1(readFileSafe(src)) === sha1(readFileSafe(out));
+        if (!same) out = join(dest, `${basename(f, ".md")}-${Date.now()}.md`);
+        else continue; // identical already archived
+      }
+      copyFileSync(src, out);
+      if (!existsSync(out)) return { ok: false, error: `archive copy unverified: ${f}` };
+    }
+  } catch (err) {
+    return { ok: false, error: `loose-doc archive failed: ${err?.message}` };
+  }
+  return { ok: true };
+}
+
+function readFileSafe(p) {
+  try {
+    return statSync(p).size > 0 ? readFileSync(p) : Buffer.alloc(0);
+  } catch {
+    return Buffer.alloc(0);
+  }
+}
+
+// safeTeardownWorktree — the gated remover ALL terminal callers funnel through.
+// Resolves path + provenance + live state, runs the predicate, archives, then
+// removes (NEVER --force) — or flags. Re-checks liveness immediately before the
+// remove to shrink the TOCTOU window. Returns one of:
+//   { removed:true } | { removed:true, alreadyAbsent:true }
+//   { removed:false, deferred:true, reasons } | { removed:false, error }
+export function safeTeardownWorktree(
+  { repoRoot, ticket, worktreePath, terminal, prMerged, branch } = {},
+  deps = {},
+) {
+  const {
+    runGit = (args) => spawnSync("git", ["-C", repoRoot, ...args], { encoding: "utf8" }),
+    // Fail-closed by default: a failed `claude agents` read returns ok:false, so
+    // the gate refuses removal rather than treating an unreadable fleet as empty.
+    agents = () => {
+      const r = listClaudeAgentsResult();
+      return { list: r.agents, ok: r.ok };
+    },
+    procLive = (p) => lsofCwdUnder(p),
+    archive = archiveWorktreeArtifacts,
+    removeWorktree = (p) => spawnSync("git", ["-C", repoRoot, "worktree", "remove", p], { encoding: "utf8" }),
+    emit = emitReapIntent,
+    queueDir = DEFAULT_QUEUE_DIR,
+    orchDirs = listOrchDirs(),
+    noiseGlobs = MACHINE_LOCAL_NOISE,
+  } = deps;
+
+  // 1. Resolve the worktree path (from the caller, or by branch refs/heads/<ticket>).
+  let path = worktreePath ? stripTrailingSlash(worktreePath) : null;
+  if (!path && ticket) {
+    const list = runGit(["worktree", "list", "--porcelain"]);
+    if ((list.status ?? 1) === 0) path = parseWorktreeForBranch(list.stdout ?? "", ticket);
+  }
+  if (!path) return { removed: true, alreadyAbsent: true };
+
+  // 2. Resolve live state once for the predicate.
+  let agentsList = [];
+  let agentsOk = false;
+  try {
+    const a = agents();
+    if (a && Array.isArray(a.list)) {
+      agentsList = a.list;
+      agentsOk = a.ok === true;
+    } else if (Array.isArray(a)) {
+      agentsList = a;
+      agentsOk = true;
+    }
+  } catch {
+    agentsOk = false;
+  }
+  const ctx = {
+    ticket,
+    repoRoot,
+    branch,
+    terminal: terminal === true,
+    prMerged: prMerged === true,
+    orchProvenance: hasOrchProvenance(ticket, { orchDirs }),
+  };
+  const verdict = isSafeToRemoveWorktree(path, ctx, {
+    runGit,
+    agentsList,
+    agentsOk,
+    procLive: procLive(path) === true,
+    noiseGlobs,
+  });
+  if (!verdict.safe) {
+    return deferWorktreeCleanup(path, { ticket, branch, reasons: verdict.reasons }, { emit, queueDir });
+  }
+
+  // 3. Archive worktree-local docs/thoughts BEFORE any removal. Fail → defer.
+  const arch = archive(path, { ticket });
+  if (!arch.ok) {
+    return deferWorktreeCleanup(path, { ticket, branch, reasons: ["archive-failed", arch.error] }, { emit, queueDir });
+  }
+
+  // 4. Re-check liveness inside the same flow, immediately before remove (TOCTOU:
+  // a human/agent opening a session between the gate and the remove).
+  if (procLive(path) === true) {
+    return deferWorktreeCleanup(path, { ticket, branch, reasons: ["live-session-late"] }, { emit, queueDir });
+  }
+
+  // 5. Remove — NEVER --force. A refusal (e.g. an unexpected lock) → defer, never
+  // escalate to a destructive force in any automated path.
+  const rm = removeWorktree(path);
+  if (rm.error || (rm.status ?? 1) !== 0) {
+    return deferWorktreeCleanup(path, { ticket, branch, reasons: ["git-remove-failed", rm.error?.message ?? rm.stderr?.trim()] }, { emit, queueDir });
+  }
+  clearDeferMarker(path, queueDir);
+  log.info({ ticket, worktreePath: path }, "worktree: removed (evidence-gated)");
+  return { removed: true };
+}
+
+// gatedTeardownWorktree — boolean-returning adapter matching the legacy
+// teardownWorktree({repoRoot, ticket}) seam, routed through the evidence gate. The
+// scheduler's terminal-Done sweep wires this as its default (terminal:true): the
+// worktree is removed ONLY when safe, else flagged (returns false → no
+// .worktree-removed marker → re-evaluated next tick). The abort path wires it with
+// terminal:false so it ALWAYS defers (abort is never terminal). prMerged defaults
+// true because the only terminal:true caller is the Done sweep, where the pipeline
+// already confirmed the merge; the clean-tree + no-unpushed gates are the
+// load-bearing data-loss guards regardless.
+export function gatedTeardownWorktree({ repoRoot, ticket, terminal = true, prMerged = true } = {}, deps = {}) {
+  return safeTeardownWorktree({ repoRoot, ticket, terminal, prMerged }, deps).removed === true;
+}

--- a/plugins/dev/scripts/execution-core/worktree-safety.test.mjs
+++ b/plugins/dev/scripts/execution-core/worktree-safety.test.mjs
@@ -1,0 +1,239 @@
+// worktree-safety.test.mjs — CTL-791. Proves the data-loss guarantee: an in-use,
+// dirty, unmerged, unpushed, or unknown-provenance worktree is NEVER removed; only
+// a genuinely-done one is, and only after its docs are archived — never with
+// --force.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  isSafeToRemoveWorktree,
+  cleanPorcelain,
+  MACHINE_LOCAL_NOISE,
+  deferWorktreeCleanup,
+  archiveWorktreeArtifacts,
+  safeTeardownWorktree,
+  hasOrchProvenance,
+} from "./worktree-safety.mjs";
+
+// gitStub — a runGit fake driven by a per-arg response map. Defaults model the
+// safe state: clean tree, an upstream with 0 ahead.
+function gitStub({ porcelain = " M .catalyst/config.json\n", upstream = "origin/b", ahead = "0", statusRc = 0 } = {}) {
+  return (args) => {
+    if (args[0] === "status") return { status: statusRc, stdout: porcelain };
+    if (args.includes("@{u}") && args[0] === "rev-parse") return { status: upstream ? 0 : 1, stdout: upstream ?? "" };
+    if (args[0] === "rev-list") return { status: 0, stdout: `${ahead}\n` };
+    return { status: 0, stdout: "" };
+  };
+}
+const SAFE_CTX = { ticket: "CTL-1", repoRoot: "/r", branch: "b", terminal: true, prMerged: true, orchProvenance: true };
+const SAFE_DEPS = { runGit: gitStub(), agentsList: [], agentsOk: true, procLive: false };
+
+describe("isSafeToRemoveWorktree — every unsafe condition blocks removal (fail-closed)", () => {
+  test("all gates pass → safe", () => {
+    expect(isSafeToRemoveWorktree("/wt/CTL-1", SAFE_CTX, SAFE_DEPS)).toEqual({ safe: true, reasons: [] });
+  });
+  test("not terminal → not-terminal", () => {
+    expect(isSafeToRemoveWorktree("/wt/CTL-1", { ...SAFE_CTX, terminal: false }, SAFE_DEPS).reasons).toContain("not-terminal");
+  });
+  test("PR not merged → not-merged (even when a local rev-list would look merged — squash case)", () => {
+    const v = isSafeToRemoveWorktree("/wt/CTL-1", { ...SAFE_CTX, prMerged: false }, SAFE_DEPS);
+    expect(v.safe).toBe(false);
+    expect(v.reasons).toContain("not-merged");
+  });
+  test("committed-unpushed (upstream resolves, ahead>0) → unpushed-commits", () => {
+    const v = isSafeToRemoveWorktree("/wt/CTL-1", SAFE_CTX, { ...SAFE_DEPS, runGit: gitStub({ ahead: "3" }) });
+    expect(v.reasons).toContain("unpushed-commits");
+  });
+  test("NO upstream is NOT treated as unpushed (detached/local-only branches)", () => {
+    const v = isSafeToRemoveWorktree("/wt/CTL-1", SAFE_CTX, { ...SAFE_DEPS, runGit: gitStub({ upstream: null }) });
+    expect(v.reasons).not.toContain("unpushed-commits");
+    expect(v.safe).toBe(true);
+  });
+  test("real edit (noise excluded) → dirty-worktree", () => {
+    const v = isSafeToRemoveWorktree("/wt/CTL-1", SAFE_CTX, { ...SAFE_DEPS, runGit: gitStub({ porcelain: " M apps/web/x.ts\n" }) });
+    expect(v.reasons).toContain("dirty-worktree");
+  });
+  test("untracked code → dirty-worktree", () => {
+    const v = isSafeToRemoveWorktree("/wt/CTL-1", SAFE_CTX, { ...SAFE_DEPS, runGit: gitStub({ porcelain: "?? new-file.ts\n" }) });
+    expect(v.reasons).toContain("dirty-worktree");
+  });
+  test("noise-only tree (the universal real-worktree state) → clean", () => {
+    const v = isSafeToRemoveWorktree("/wt/CTL-1", SAFE_CTX, { ...SAFE_DEPS, runGit: gitStub({ porcelain: " M .catalyst/config.json\n?? .trunk/x\n" }) });
+    expect(v.reasons).not.toContain("dirty-worktree");
+  });
+  test("status unreadable → status-unreadable (fail-closed)", () => {
+    expect(isSafeToRemoveWorktree("/wt/CTL-1", SAFE_CTX, { ...SAFE_DEPS, runGit: gitStub({ statusRc: 128 }) }).reasons).toContain("status-unreadable");
+  });
+  test("live session under the tree (idle background — the incident hole) → live-session", () => {
+    const v = isSafeToRemoveWorktree("/wt/CTL-1", SAFE_CTX, {
+      ...SAFE_DEPS,
+      agentsList: [{ sessionId: "s", cwd: "/wt/CTL-1/sub", kind: "background", status: "idle" }],
+    });
+    expect(v.reasons).toContain("live-session");
+  });
+  test("sibling-prefix session does NOT count (/wt/CTL-64 vs /wt/CTL-649)", () => {
+    const v = isSafeToRemoveWorktree("/wt/CTL-64", { ...SAFE_CTX, ticket: "CTL-64" }, {
+      ...SAFE_DEPS,
+      agentsList: [{ sessionId: "s", cwd: "/wt/CTL-649", status: "idle" }],
+    });
+    expect(v.reasons).not.toContain("live-session");
+  });
+  test("lsof-detectable process under the tree (not in claude agents) → proc-live", () => {
+    expect(isSafeToRemoveWorktree("/wt/CTL-1", SAFE_CTX, { ...SAFE_DEPS, procLive: true }).reasons).toContain("proc-live");
+  });
+  test("agents read failed → agents-stale (never treat an unreadable fleet as empty)", () => {
+    expect(isSafeToRemoveWorktree("/wt/CTL-1", SAFE_CTX, { ...SAFE_DEPS, agentsOk: false }).reasons).toContain("agents-stale");
+  });
+  test("unknown provenance → unknown-provenance (interactive worktrees are never touched)", () => {
+    expect(isSafeToRemoveWorktree("/wt/X", { ...SAFE_CTX, orchProvenance: false }, SAFE_DEPS).reasons).toContain("unknown-provenance");
+  });
+  test("multiple failures are ALL collected (no short-circuit)", () => {
+    const v = isSafeToRemoveWorktree("/wt/X", { ...SAFE_CTX, terminal: false, prMerged: false, orchProvenance: false }, {
+      ...SAFE_DEPS,
+      runGit: gitStub({ porcelain: " M apps/x.ts\n" }),
+      procLive: true,
+    });
+    expect(v.reasons).toEqual(expect.arrayContaining(["not-terminal", "not-merged", "dirty-worktree", "proc-live", "unknown-provenance"]));
+  });
+});
+
+describe("cleanPorcelain", () => {
+  test("every machine-local noise path is excluded", () => {
+    for (const n of MACHINE_LOCAL_NOISE) {
+      expect(cleanPorcelain(` M ${n}\n`)).toEqual([]);
+    }
+  });
+  test("a rename of real code is dirty", () => {
+    expect(cleanPorcelain('R  old.ts -> new.ts\n').length).toBe(1);
+  });
+});
+
+describe("filesystem-backed: defer / archive / safeTeardown", () => {
+  let tmp, queueDir, archiveDir, wt;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "wt-safety-"));
+    queueDir = join(tmp, "queue");
+    archiveDir = join(tmp, "arch");
+    wt = join(tmp, "wt", "CTL-1");
+    mkdirSync(wt, { recursive: true });
+  });
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  test("deferWorktreeCleanup writes an OUT-OF-TREE marker + emits, and writes NOTHING into the worktree", () => {
+    const emitted = [];
+    const r = deferWorktreeCleanup(wt, { ticket: "CTL-1", branch: "b", reasons: ["dirty-worktree", "not-merged"] }, {
+      emit: (t, f) => { emitted.push({ t, f }); return Promise.resolve(true); },
+      queueDir,
+    });
+    expect(r).toEqual({ removed: false, deferred: true, reasons: ["dirty-worktree", "not-merged"] });
+    expect(emitted[0].t).toBe("worktree.cleanup-deferred");
+    expect(readdirSync(queueDir).length).toBe(1); // marker outside the worktree
+    expect(readdirSync(wt)).toEqual([]); // NOTHING written into the tree (no self-dirty)
+  });
+
+  test("archiveWorktreeArtifacts is FAIL-CLOSED when thoughts/ has content and humanlayer errors", () => {
+    mkdirSync(join(wt, "thoughts"), { recursive: true });
+    writeFileSync(join(wt, "thoughts", "note.md"), "unsynced");
+    const exec = () => ({ status: 1, stderr: "humanlayer: not found" });
+    expect(archiveWorktreeArtifacts(wt, { ticket: "CTL-1" }, { exec, archiveDir }).ok).toBe(false);
+  });
+
+  test("archiveWorktreeArtifacts copies loose *.md docs and succeeds (verified)", () => {
+    writeFileSync(join(wt, "DESIGN.md"), "# design");
+    const exec = () => ({ status: 0, stdout: "" });
+    const r = archiveWorktreeArtifacts(wt, { ticket: "CTL-1" }, { exec, archiveDir });
+    expect(r.ok).toBe(true);
+    expect(existsSync(join(archiveDir, "CTL-1", "DESIGN.md"))).toBe(true);
+  });
+
+  test("safeTeardownWorktree: unsafe verdict → DEFERS, never removes", () => {
+    let removed = false;
+    const r = safeTeardownWorktree(
+      { repoRoot: tmp, ticket: "CTL-1", worktreePath: wt, terminal: true, prMerged: false, branch: "b" },
+      {
+        agents: () => ({ list: [], ok: true }),
+        procLive: () => false,
+        archive: () => ({ ok: true }),
+        removeWorktree: () => { removed = true; return { status: 0 }; },
+        runGit: gitStub(),
+        orchDirs: [],
+        emit: () => Promise.resolve(true),
+        queueDir,
+      },
+    );
+    expect(removed).toBe(false);
+    expect(r.deferred).toBe(true);
+    expect(r.reasons).toContain("not-merged");
+  });
+
+  test("safeTeardownWorktree: archive failure → DEFERS, never removes", () => {
+    let removed = false;
+    const r = safeTeardownWorktree(
+      { repoRoot: tmp, ticket: "CTL-1", worktreePath: wt, terminal: true, prMerged: true, branch: "b" },
+      {
+        agents: () => ({ list: [], ok: true }),
+        procLive: () => false,
+        archive: () => ({ ok: false, error: "sync failed" }),
+        removeWorktree: () => { removed = true; return { status: 0 }; },
+        runGit: gitStub(),
+        orchDirs: [join(tmp, "run")],
+        emit: () => Promise.resolve(true),
+        queueDir,
+      },
+    );
+    expect(removed).toBe(false);
+    expect(r.deferred).toBe(true);
+  });
+
+  test("safeTeardownWorktree: all-pass → archives then removes (argv has NO --force)", () => {
+    // provenance: workers/CTL-1 under a fake orchDir
+    const orch = join(tmp, "run");
+    mkdirSync(join(orch, "workers", "CTL-1"), { recursive: true });
+    let removeArgs = null;
+    const r = safeTeardownWorktree(
+      { repoRoot: tmp, ticket: "CTL-1", worktreePath: wt, terminal: true, prMerged: true, branch: "b" },
+      {
+        agents: () => ({ list: [], ok: true }),
+        procLive: () => false,
+        archive: () => ({ ok: true }),
+        removeWorktree: (p) => { removeArgs = p; return { status: 0 }; },
+        runGit: gitStub(),
+        orchDirs: [orch],
+        emit: () => Promise.resolve(true),
+        queueDir,
+      },
+    );
+    expect(r.removed).toBe(true);
+    expect(removeArgs).toBe(wt); // removeWorktree(path) — the default uses no --force
+  });
+
+  test("safeTeardownWorktree: a session opened AFTER the gate (TOCTOU) → defers on the pre-remove re-check", () => {
+    let removed = false;
+    let probes = 0;
+    const r = safeTeardownWorktree(
+      { repoRoot: tmp, ticket: "CTL-1", worktreePath: wt, terminal: true, prMerged: true, branch: "b" },
+      {
+        agents: () => ({ list: [], ok: true }),
+        // first probe (gate) clear; second probe (pre-remove re-check) live.
+        procLive: () => (probes++ === 0 ? false : true),
+        archive: () => ({ ok: true }),
+        removeWorktree: () => { removed = true; return { status: 0 }; },
+        runGit: gitStub(),
+        orchDirs: [(() => { const o = join(tmp, "run"); mkdirSync(join(o, "workers", "CTL-1"), { recursive: true }); return o; })()],
+        emit: () => Promise.resolve(true),
+        queueDir,
+      },
+    );
+    expect(removed).toBe(false);
+    expect(r.reasons).toContain("live-session-late");
+  });
+
+  test("hasOrchProvenance: true with workers/<ticket>/ dir, false without", () => {
+    const orch = join(tmp, "run");
+    mkdirSync(join(orch, "workers", "CTL-1"), { recursive: true });
+    expect(hasOrchProvenance("CTL-1", { orchDirs: [orch] })).toBe(true);
+    expect(hasOrchProvenance("CTL-999", { orchDirs: [orch] })).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/worktree.mjs
+++ b/plugins/dev/scripts/execution-core/worktree.mjs
@@ -59,12 +59,15 @@ export function parseWorktreeForBranch(porcelain, ticket) {
   return null;
 }
 
-// teardownWorktree — remove a ticket's worktree. The path is resolved from
-// `git worktree list --porcelain` (the worktree on branch refs/heads/<ticket>)
-// rather than reconstructed, so it is correct regardless of projectKey /
-// worktreeDir config. Returns true when the worktree is gone — removed now, or
-// already absent (the idempotent end state); false only when git could not
-// list or could not remove. Never throws.
+// teardownWorktree — the RAW worktree remover (resolve path by branch, then
+// `git worktree remove`). CTL-791: it is **no longer `--force`** — a plain remove
+// refuses on a dirty/locked tree rather than yanking uncommitted/untracked work.
+// It performs NO evidence gating; callers MUST funnel terminal removals through
+// `safeTeardownWorktree` (worktree-safety.mjs), which checks GitHub-merged + clean
+// + no-live-session + orchestrator-provenance and archives first. This export
+// stays only as that gate's injected `removeWorktree` seam. Returns true when the
+// worktree is gone (removed now, or already absent); false on a list/remove
+// failure (incl. a `git worktree remove` refusal — which is the SAFE direction).
 export function teardownWorktree({ repoRoot, ticket } = {}, { spawn = spawnSync } = {}) {
   if (!repoRoot || !ticket) return false;
   const list = spawn("git", ["-C", repoRoot, "worktree", "list", "--porcelain"], {
@@ -73,7 +76,7 @@ export function teardownWorktree({ repoRoot, ticket } = {}, { spawn = spawnSync 
   if (list.error || (list.status ?? 1) !== 0) return false; // cannot list — retry later
   const path = parseWorktreeForBranch(list.stdout ?? "", ticket);
   if (!path) return true; // no worktree for this ticket — already torn down
-  const rm = spawn("git", ["-C", repoRoot, "worktree", "remove", "--force", path], {
+  const rm = spawn("git", ["-C", repoRoot, "worktree", "remove", path], {
     encoding: "utf8",
   });
   return !rm.error && (rm.status ?? 1) === 0;

--- a/plugins/dev/scripts/execution-core/worktree.test.mjs
+++ b/plugins/dev/scripts/execution-core/worktree.test.mjs
@@ -125,7 +125,9 @@ describe("teardownWorktree", () => {
   test("resolves the worktree by branch and git-worktree-removes it → true", () => {
     const spawn = spawnSeq(listWith("/wt/CTL-7", "CTL-7"), { status: 0, stdout: "", stderr: "" });
     expect(teardownWorktree({ repoRoot: "/repo", ticket: "CTL-7" }, { spawn })).toBe(true);
-    expect(spawn.calls[1]).toEqual(["-C", "/repo", "worktree", "remove", "--force", "/wt/CTL-7"]);
+    // CTL-791: no `--force` — a plain remove refuses on a dirty/locked tree
+    // rather than destroying uncommitted/untracked work.
+    expect(spawn.calls[1]).toEqual(["-C", "/repo", "worktree", "remove", "/wt/CTL-7"]);
   });
 
   test("no worktree for the ticket → true (already torn down), no remove call", () => {


### PR DESCRIPTION
Re-opened (prior PR #1362 auto-closed when its branch was deleted after a behind-base merge attempt; rebased clean onto current main). Two adversarial reviews passed.

## Data loss (the incident)
The live daemon reaped an **interactive/agent worktree** under `~/catalyst/wt` mid-run, destroying uncommitted work + a worktree-local design doc + handoffs that never synced. Vectors: `teardownWorktree` used `git worktree remove --force`; `_handlePrMergedCleanup`'s presweep only blocked **interactive-kind** sessions (an idle background/agent session got `claude stop`'d and the tree removed under it).

## The guarantee
New `worktree-safety.mjs` gates **every automated removal** on fail-closed evidence — removal only when ALL hold: **GitHub-merged** (never a local `rev-list` — squash) · **no committed-unpushed** · **clean tree** (machine-local noise excluded) · **zero live sessions of ANY kind** (`claude agents` snapshot **+ `lsof` backstop**) · **orchestrator provenance** (`workers/<ticket>/`). Else → **flag** to an out-of-tree queue, never delete. Docs/`thoughts/` **archived first** (fail-closed). `--force` **dropped**.

## Wiring
Scheduler terminal-Done sweep + abort-worker (non-terminal → always defers) via `gatedTeardownWorktree`; reaper `_handlePrMergedCleanup` via an injectable `assessWorktreeRemoval` seam; new `worktree.cleanup-deferred` event.

## Review + tests
Two adversarial reviewers cleared it (after fixing 2 fail-open holes: the reaper's `agentsOk` derivation and `defaultGitWorktreeRemove`'s spawn-failure handling — both now fail closed, with regression tests). Verdict: **no path deletes a worktree while dirty/unmerged/unpushed/unknown-provenance**. **94+ tests green**, full suite 524.

Stage 0 (data-loss). CLI verbs / `orphan-sweep.sh` gating (not auto-running) / periodic queue drain / orch-monitor are the **CTL-792** fast-follow. Spec: `thoughts/shared/research/2026-06-06-CTL-791-worktree-safety-spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)