### PR TITLE
fix(dev): warm the liveness snapshot + tolerate in-tick aging so dispatch isn't held forever (CTL-792)

### DIFF
--- a/plugins/dev/scripts/execution-core/claude-agents.mjs
+++ b/plugins/dev/scripts/execution-core/claude-agents.mjs
@@ -108,11 +108,19 @@ export function cachedListClaudeAgents({
 //       isFresh so the scheduler can gate new-work dispatch on staleness.
 const LIVENESS_TIMEOUT_MS = Number(process.env.CATALYST_LIVENESS_TIMEOUT_MS) || 3_000;
 // Stale threshold for the non-blocking getter (and the scheduler's dispatch gate).
-// 2× the TTL: a snapshot older than this is "stale" and a background refresh is
-// kicked; the scheduler holds NEW-work dispatch while stale (fail-safe — never
-// over-spawn on an unknown/old count). Advancement of in-flight phases is
-// independent of this and continues regardless.
-const LIVENESS_STALE_MS = Number(process.env.CATALYST_LIVENESS_STALE_MS) || 2 * LIVENESS_TTL_MS;
+// A snapshot older than this is "stale" and the scheduler holds NEW-work dispatch
+// (fail-safe — never over-spawn on an unknown/old count). Advancement of in-flight
+// phases is independent of this and continues regardless.
+//
+// CTL-792: default ≥30s. The daemon's liveness warmer keeps the snapshot ~TTL-fresh
+// BETWEEN ticks, but a single SYNCHRONOUS scheduler tick can block the loop for tens
+// of seconds (the perf debt), during which no warmer can refresh — so the snapshot
+// ages WITHIN the tick. A 10s window held new-work forever on every such tick. 30s
+// tolerates that in-tick aging; it stays over-spawn-safe because the warmer (not this
+// threshold) drives refresh frequency, so the count is still ~TTL-accurate. The real
+// fix is a non-blocking tick (orchestrator redesign Stage 2).
+const LIVENESS_STALE_MS =
+  Number(process.env.CATALYST_LIVENESS_STALE_MS) || Math.max(30_000, 2 * LIVENESS_TTL_MS);
 // Backoff: below this many consecutive failures every stale read retries; at/above
 // it, suppress refresh for an exponential window (base × 2^over, capped).
 const LIVENESS_BACKOFF_AFTER = Number(process.env.CATALYST_LIVENESS_BACKOFF_AFTER) || 3;

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -78,7 +78,7 @@ import { removeLabel as defaultRemoveLabel } from "./linear-write.mjs"; // CTL-5
 // no-ops (hermetic for direct-call unit tests); the REAL daemon arms them here
 // so the phantom worker-dir validity sweep is operative in production.
 import { classifyTicketResolution } from "./linear-query.mjs";
-import { isBgJobAlive } from "./claude-agents.mjs";
+import { isBgJobAlive, refreshAgents } from "./claude-agents.mjs";
 
 const DEFAULT_MAX_PARALLEL = 3;
 
@@ -103,6 +103,11 @@ let _stopAutoTuner = null;
 let _eventWatcher = null;
 let _eventDebounceTimer = null;
 let _eventPollTimer = null; // CTL-769: poll-fallback drain (fs.watch debounce never fires on the continuously-appended log)
+// CTL-792: short-interval liveness-snapshot warmer. ~TTL/2 so the dispatch gate's
+// staleMs (2×TTL ≈ 10s) window always sees a fresh snapshot regardless of the
+// idle scheduler-tick cadence. Env-tunable.
+const LIVENESS_WARM_INTERVAL_MS = Number(process.env.CATALYST_LIVENESS_WARM_MS) || 4_000;
+let _livenessTimer = null;
 let _eventLogCursor = 0;
 // CTL-649: the trailing partial line carried across reads. _eventLogCursor is a
 // BYTE offset; consumeEventTail reads only NEW bytes via a file descriptor and
@@ -336,6 +341,26 @@ export function startDaemon({
   clearProgressMarks(orchDir);
   _stopMonitor = stopMonitorFn;
   _stopScheduler = stopSchedulerFn;
+
+  // CTL-792: keep the liveness snapshot warm so an idle tick cadence doesn't hold
+  // new-work dispatch forever on the staleMs gate. CTL-790 made the snapshot
+  // POPULATE, but it is refreshed only LAZILY (once per scheduler tick) — and an
+  // idle daemon ticks every ~15-30s while staleMs is short, so the snapshot is
+  // always stale by the next gate check. A dedicated short-interval refresh keeps
+  // _asyncSnap < staleMs old AND keeps the worker count ~TTL-accurate (over-spawn-
+  // safe). UNCONDITIONAL — core to dispatch, must NOT depend on the optionally-
+  // disabled reaper (its earlier placement inside startReaperAndTimer never ran).
+  // Fire-and-forget + single-flight; unref'd; torn down in stopDaemon.
+  _livenessTimer = setInterval(() => {
+    try {
+      Promise.resolve(refreshAgents()).catch((err) =>
+        log.warn({ err: err?.message }, "liveness warmer: refresh failed"),
+      );
+    } catch (err) {
+      log.warn({ err: err?.message }, "liveness warmer: threw");
+    }
+  }, LIVENESS_WARM_INTERVAL_MS);
+  _livenessTimer.unref?.();
 
   // CTL-586: write the PID file BEFORE the synchronous boot work
   // (recover/monitor/scheduler each trigger a blocking reconcile that fans
@@ -695,6 +720,10 @@ export function stopDaemon() {
   if (_eventPollTimer) {
     clearInterval(_eventPollTimer);
     _eventPollTimer = null;
+  }
+  if (_livenessTimer) {
+    clearInterval(_livenessTimer);
+    _livenessTimer = null;
   }
   if (_orphanTimer) {
     try {


### PR DESCRIPTION
Follow-up to CTL-790. The liveness wedge had three layers; CTL-790 fixed the first (snapshot never **populated**), this fixes the other two.

## Why dispatch was still held after CTL-790
The snapshot is refreshed only **lazily, once per scheduler tick**, then checked by the new-work gate (`getAgentsCached().isFresh`):
1. **Idle cadence** — an idle daemon ticks every ~15–30s (backstop) while `staleMs` was 10s, so the populated snapshot is always stale by the next gate check.
2. **In-tick aging** — a single **synchronous** tick can block the loop for tens of seconds (the perf debt: 168k-event reap scan + phantom sweep), aging the snapshot *within* the tick where no async refresh can run.

## Fix (two coupled changes)
- **Liveness warmer** (`daemon.mjs`): a dedicated ~4s timer (`CATALYST_LIVENESS_WARM_MS`) calling `refreshAgents()` to keep `_asyncSnap` warm *between* ticks. Placed on the **unconditional scheduler-start path** — not inside `startReaperAndTimer` (its first home), which the optionally-disabled reaper gates, so it **never fired**. unref'd; torn down in `stopDaemon`.
- **`staleMs` default → ≥30s** (`claude-agents.mjs`): tolerates the in-tick aging from a slow blocking tick. **Over-spawn-safe** — the *warmer* drives refresh frequency, so the count stays ~TTL-accurate; the larger window only widens the freshness tolerance.

## Live result
Gate-hold went from **every tick → ~45%** (the residual holds are slow ticks >30s). New-work dispatch resumed (**CTL Todo 10 → 6**). The residual holds + the dead-worker recovery backlog are the **perf debt / async-tick redesign** (Stage 1/2), not this gate.

132 daemon + claude-agents tests green; warmer 0 failures live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)