### PR TITLE
fix(dev): fold reaper-metrics into O(1) counters, drop the unbounded events[] (CTL-793)

### DIFF
--- a/plugins/dev/scripts/execution-core/reaper-metrics.mjs
+++ b/plugins/dev/scripts/execution-core/reaper-metrics.mjs
@@ -1,20 +1,28 @@
-// reaper-metrics.mjs — incremental reap-outcome counter (CTL-695 Phase 2).
+// reaper-metrics.mjs — incremental reap-outcome counter (CTL-695 Phase 2; CTL-793 counters-not-rows).
 //
 // Reads the unified event log's flat reap-family lines (event field ending in
 // .reap-requested / .reap-complete / .reap-failed) and returns per-tick counters
 // that otel-forward ships as a pino gauge. Mirrors event-scan.mjs's per-path
 // incremental byte cursor + scanEventsChunked for bounded memory.
 //
+// CTL-793: the index folds each reap event into three running counters as it is
+// scanned, instead of retaining every event in an unbounded `events[]` array that
+// countReapOutcomes re-iterated every tick (the ~170k-entry leak that blocked the
+// scheduler event loop ~20s/tick). Memory is now O(1) per active month and
+// countReapOutcomes is O(1). The first call still seeds the counters with a single
+// cursor-0 scan of the month's log, so the absolute totals are continuous with the
+// pre-CTL-793 array-based gauge (no per-boot discontinuity). The cross-month evict
+// (redesign §3 finding #4) drops the prior month's entry on rotation so the Map
+// can never accumulate across months.
+//
 // Reap echoes use FLAT `ev.event` (not attributes["event.name"]) — a distinct
-// shape from OTLP-wrapped session events. Production 2026-05.jsonl: 8936
-// reap-requested, 498 reap-complete, 0 reap-failed — the gap is observable but
-// uninstrumented without this module.
+// shape from OTLP-wrapped session events.
 
 import { statSync } from "node:fs";
 import { scanEventsChunked } from "./event-tail.mjs";
 import { getEventLogPath } from "./config.mjs";
 
-const _index = new Map(); // path → { cursor, leftover, events: [{event, ts}] }
+const _index = new Map(); // path → { cursor, leftover, staleSeen, staleReaped, reapFailures }
 
 function isReapEvent(name) {
   return (
@@ -25,10 +33,19 @@ function isReapEvent(name) {
   );
 }
 
+function newEntry() {
+  return { cursor: 0, leftover: "", staleSeen: 0, staleReaped: 0, reapFailures: 0 };
+}
+
 function refreshIndex(path) {
+  // Cross-month evict (redesign §3 finding #4): keep only the active path's entry
+  // so the Map can never accumulate prior months across log rotation.
+  for (const key of _index.keys()) {
+    if (key !== path) _index.delete(key);
+  }
   let entry = _index.get(path);
   if (!entry) {
-    entry = { cursor: 0, leftover: "", events: [] };
+    entry = newEntry();
     _index.set(path, entry);
   }
   let size;
@@ -38,10 +55,12 @@ function refreshIndex(path) {
     return entry; // missing log → cold start
   }
   if (size < entry.cursor) {
-    // Rotated or truncated — drop stale state.
+    // Rotated or truncated — drop stale state, counters included.
     entry.cursor = 0;
     entry.leftover = "";
-    entry.events = [];
+    entry.staleSeen = 0;
+    entry.staleReaped = 0;
+    entry.reapFailures = 0;
   }
   if (size === entry.cursor) return entry; // no new bytes
   const { endOffset, leftover } = scanEventsChunked({
@@ -51,7 +70,10 @@ function refreshIndex(path) {
     onEvent: (ev) => {
       const name = ev?.event;
       if (!isReapEvent(name)) return;
-      entry.events.push({ event: name, ts: ev?.ts });
+      // Fold into running counters — no per-event retention (CTL-793).
+      if (name.endsWith(".reap-requested")) entry.staleSeen++;
+      else if (name.endsWith(".reap-complete")) entry.staleReaped++;
+      else if (name.endsWith(".reap-failed")) entry.reapFailures++;
     },
   });
   entry.cursor = endOffset;
@@ -61,22 +83,23 @@ function refreshIndex(path) {
 
 /**
  * Count reap outcomes from the event log at `path` (defaults to the current
- * month's log). Optional `since` ISO timestamp excludes earlier events.
- * Returns { staleSeen, staleReaped, reapFailures }.
+ * month's log). Returns { staleSeen, staleReaped, reapFailures } in O(1): the
+ * counters are folded incrementally as the log is scanned (CTL-793), so this is
+ * a constant-time read after the first cursor-0 seed scan. The pre-CTL-793 `since`
+ * window param is dropped — the sole production caller (scheduler reap-stats log)
+ * never passed it, and folded counters can't be retroactively windowed.
  */
-export function countReapOutcomes({ since, path = getEventLogPath() } = {}) {
-  let staleSeen = 0;
-  let staleReaped = 0;
-  let reapFailures = 0;
-  for (const ev of refreshIndex(path).events) {
-    if (since && ev.ts && ev.ts < since) continue;
-    if (ev.event.endsWith(".reap-requested")) staleSeen++;
-    else if (ev.event.endsWith(".reap-complete")) staleReaped++;
-    else if (ev.event.endsWith(".reap-failed")) reapFailures++;
-  }
+export function countReapOutcomes({ path = getEventLogPath() } = {}) {
+  const { staleSeen, staleReaped, reapFailures } = refreshIndex(path);
   return { staleSeen, staleReaped, reapFailures };
 }
 
 export function __resetReaperMetricsIndexForTest() {
   _index.clear();
+}
+
+// Test-only: the live index size. Guards the cross-month evict (finding #4) —
+// the Map must stay bounded (≤1 active month) across log rotation.
+export function __reaperMetricsIndexSizeForTest() {
+  return _index.size;
 }

--- a/plugins/dev/scripts/execution-core/reaper-metrics.test.mjs
+++ b/plugins/dev/scripts/execution-core/reaper-metrics.test.mjs
@@ -1,7 +1,8 @@
 // reaper-metrics.test.mjs — unit tests for the incremental reap-outcome counter
-// (CTL-695 Phase 2). Run: cd plugins/dev/scripts/execution-core && bun test reaper-metrics.test.mjs
+// (CTL-695 Phase 2; CTL-793 counters-not-rows).
+// Run: cd plugins/dev/scripts/execution-core && bun test reaper-metrics.test.mjs
 import { describe, test, expect, beforeEach } from "bun:test";
-import { mkdtempSync, mkdirSync, appendFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, appendFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -26,14 +27,13 @@ beforeEach(async () => {
 });
 
 async function freshMetrics() {
-  const { countReapOutcomes, __resetReaperMetricsIndexForTest } = await import(
-    `./reaper-metrics.mjs?cb=${Date.now()}-${Math.random()}`
-  );
+  const { countReapOutcomes, __resetReaperMetricsIndexForTest, __reaperMetricsIndexSizeForTest } =
+    await import(`./reaper-metrics.mjs?cb=${Date.now()}-${Math.random()}`);
   __resetReaperMetricsIndexForTest();
-  return { countReapOutcomes };
+  return { countReapOutcomes, __reaperMetricsIndexSizeForTest };
 }
 
-describe("countReapOutcomes", () => {
+describe("countReapOutcomes (folded counters, CTL-793)", () => {
   test("counts reap-requested, reap-complete, reap-failed by family", async () => {
     const { countReapOutcomes } = await freshMetrics();
     appendFlat({ event: "phase.predecessor.reap-requested", bg_job_id: "a" });
@@ -57,22 +57,55 @@ describe("countReapOutcomes", () => {
     expect(m).toEqual({ staleSeen: 0, staleReaped: 0, reapFailures: 0 });
   });
 
-  test("since filter excludes older events", async () => {
+  test("first call seeds counters from a full cursor-0 scan (continuity, no per-boot discontinuity)", async () => {
+    // The folded counters must equal the absolute totals over the whole log on
+    // the first read — the gauge stays continuous with the pre-CTL-793 array sum.
     const { countReapOutcomes } = await freshMetrics();
-    appendFlat({ ts: "2026-05-01T00:00:00Z", event: "phase.predecessor.reap-complete" });
-    appendFlat({ ts: "2026-05-28T00:00:00Z", event: "phase.predecessor.reap-complete" });
-    const m = countReapOutcomes({ path: logPath, since: "2026-05-15T00:00:00Z" });
-    expect(m.staleReaped).toBe(1);
+    for (let i = 0; i < 50; i++) {
+      appendFlat({ event: "phase.terminal.reap-requested", bg_job_id: `b${i}` });
+    }
+    appendFlat({ event: "phase.terminal.reap-complete", bg_job_id: "done" });
+    const m = countReapOutcomes({ path: logPath });
+    expect(m).toEqual({ staleSeen: 50, staleReaped: 1, reapFailures: 0 });
   });
 
-  test("incremental: second call on the same path reads only new bytes", async () => {
+  test("incremental: folded counters accumulate across calls, reading only new bytes", async () => {
     const { countReapOutcomes } = await freshMetrics();
     appendFlat({ event: "phase.predecessor.reap-requested", bg_job_id: "x" });
     const first = countReapOutcomes({ path: logPath });
     expect(first.staleSeen).toBe(1);
-    // Append a second event and call again — should see 2 total, not 1.
+    // Append a second event and call again — should fold to 2 total, not re-scan.
     appendFlat({ event: "phase.terminal.reap-requested", bg_job_id: "y" });
     const second = countReapOutcomes({ path: logPath });
     expect(second.staleSeen).toBe(2);
+  });
+
+  test("cross-month evict: a new month's log drops the prior month's entry (bounded Map, finding #4)", async () => {
+    // Switching the active path (month rollover) must evict the prior entry so the
+    // index can never accumulate prior months — the whole point of CTL-793 §3 #4.
+    const { countReapOutcomes, __reaperMetricsIndexSizeForTest } = await freshMetrics();
+    const dir = mkdtempSync(join(tmpdir(), "reap-evict-"));
+    mkdirSync(join(dir, "events"), { recursive: true });
+    const may = join(dir, "events", "2026-05.jsonl");
+    const jun = join(dir, "events", "2026-06.jsonl");
+    writeFileSync(may, JSON.stringify({ event: "phase.terminal.reap-requested" }) + "\n");
+    writeFileSync(jun, JSON.stringify({ event: "phase.terminal.reap-complete" }) + "\n");
+    expect(countReapOutcomes({ path: may })).toEqual({ staleSeen: 1, staleReaped: 0, reapFailures: 0 });
+    // June must NOT inherit May's totals…
+    expect(countReapOutcomes({ path: jun })).toEqual({ staleSeen: 0, staleReaped: 1, reapFailures: 0 });
+    // …and May's entry must be evicted so the Map stays bounded across months.
+    expect(__reaperMetricsIndexSizeForTest()).toBe(1);
+  });
+
+  test("rotation/truncation resets the folded counters (size < cursor)", async () => {
+    // A new/rotated month must not inherit the prior month's running totals.
+    const { countReapOutcomes } = await freshMetrics();
+    appendFlat({ event: "phase.terminal.reap-requested" });
+    appendFlat({ event: "phase.terminal.reap-requested" });
+    expect(countReapOutcomes({ path: logPath }).staleSeen).toBe(2);
+    // Truncate the log to a strictly smaller size → triggers the reset path.
+    writeFileSync(logPath, JSON.stringify({ event: "phase.terminal.reap-complete" }) + "\n");
+    const m = countReapOutcomes({ path: logPath });
+    expect(m).toEqual({ staleSeen: 0, staleReaped: 1, reapFailures: 0 });
   });
 });


### PR DESCRIPTION
## What

`reaper-metrics.mjs` retained **every** reap-family event in an unbounded in-memory `events[]` (~170k entries on the live daemon), and `countReapOutcomes` re-iterated the whole array **every scheduler tick**. This blocked the Node event loop ~20s/tick (measured: 18–56s gaps between `reap stats` lines, one 214s outlier), which starved the CTL-792 4s liveness warmer and aged the snapshot past `staleMs` → `isFresh:false` ~99% of ticks → **new-work dispatch held forever** (the live production stall).

## Change

- Fold each reap line into three running counters `{staleSeen, staleReaped, reapFailures}` as it is scanned. Memory is now O(1) per active month; `countReapOutcomes` is O(1).
- First call still seeds from a full cursor-0 scan → the otel gauge stays **continuous** with the pre-CTL-793 array sum (no per-boot discontinuity).
- Cross-month evict drops the prior month's entry on log rotation so the index can never grow.
- Drop the prod-unused `since` param (sole caller `scheduler.mjs:2734` passes no args).

## Why it's safe

- Sole consumer is `scheduler.mjs:2734` `log.info(countReapOutcomes(), "scheduler: reap stats")` — return shape **unchanged**. otel-forward reads the pino log line, not module internals.
- Adversarially verified across 3 independent lenses (correctness/continuity, consumer-compat/leak-actually-fixed, test-quality) — verdict **sound**, zero blockers.
- Tests: 7 pass. The cross-month evict is **mutation-guarded** (disabling the evict loop turns the new test red).

## Roadmap

Stage 0b/1 of the execution-core redesign (`thoughts/shared/research/2026-06-06-execution-core-redesign.md` §3 findings #1, #4). The keystone for unblocking dispatch: a fast tick keeps the liveness snapshot fresh so the daemon stops holding new work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)