### PR TITLE
fix(dev): ghost-breaker — reclaim jobLifecycle-alive-but-FRESH-agents-absent workers (CTL-809)

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -141,6 +141,17 @@ export const STALE_WORKER_CUTOFF_MS =
 export const BUSY_CEILING_MS =
   Number(process.env.EXECUTION_CORE_BUSY_CEILING_MS) || 6 * 60 * 60_000;
 
+// CTL-809 — ghost-breaker just-dispatched grace. The reclaim alive-branch
+// cross-checks the FRESH `claude agents` snapshot to catch a jobLifecycle-alive
+// worker whose process is actually gone (CC 2.x never flips a crashed/wedged
+// --bg worker's local state.json terminal, so jobLifecycle reports it alive
+// forever). A worker younger than this may simply not have registered in
+// `claude agents` yet, so its absence is NOT proof of death — only reclaim on
+// absence once past this window. Comfortably exceeds observed `claude --bg`
+// registration latency + one warmer interval. Env-overridable.
+export const GHOST_GRACE_MS =
+  Number(process.env.EXECUTION_CORE_GHOST_GRACE_MS) || 90_000;
+
 // CTL-735 — revival age ceiling (KEPT in CTL-736). `isTicketInFlight` treats any
 // ticket with a non-terminal signal as in-flight, so a worker that crashed at
 // `running` and never flipped terminal stays swept forever. A reclaim-eligible

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -31,13 +31,14 @@ import {
   log,
   BUSY_CEILING_MS,
   REVIVE_MAX_AGE_MS,
+  GHOST_GRACE_MS,
 } from "./config.mjs";
 import { phaseIndex, isKnownPhase } from "../lib/phase-fsm.mjs";
 import { readWorkerSignals, TERMINAL, listDispatchedPhases } from "./signal-reader.mjs";
 import { reconcileAll } from "./monitor.mjs";
 import { listProjects } from "./registry.mjs";
 import { emitReapIntent as emitReapIntentDefault } from "./reap-intent.mjs";
-import { claudeStop } from "./claude-agents.mjs";
+import { claudeStop, getAgentsCached, agentForShortId } from "./claude-agents.mjs";
 import { shortIdFromSessionId } from "./claude-ids.mjs";
 import { loadCursor, resolveStartOffset } from "./event-cursor.mjs";
 import {
@@ -1339,6 +1340,15 @@ export function reclaimDeadWorkIfPossible(
     // eventually-consistent `claude agents` snapshot reader (livenessForBgJob),
     // which is no longer consulted by the reclaim/death path at all.
     jobLifecycle: jobLifecycleFn = jobLifecycle,
+    // CTL-809 — GHOST BREAKER seams. agentsSnapshot returns the FRESH `claude
+    // agents` snapshot {agents,isFresh,ageMs}; production reads the warm
+    // getAgentsCached, tests inject a fake. ghostGraceMs is the just-dispatched
+    // grace window. Consulted ONLY to break the jobLifecycle-alive-but-process-gone
+    // tie in the alive branch below, strictly gated on isFresh (CTL-731/657-safe)
+    // and on a worker older than ghostGraceMs (no false-reclaim of a not-yet-
+    // registered fresh spawn — CTL-662-safe; a busy fan-out worker stays LISTED).
+    agentsSnapshot = getAgentsCached,
+    ghostGraceMs = GHOST_GRACE_MS,
     // CTL-735 — revival age ceiling. An absent/idle, work-not-done worker whose
     // signal has not been touched in this long is an abandoned historical dir,
     // not a fresh crash: treated as inert (no revive, no escalate). Injectable for
@@ -1535,8 +1545,47 @@ export function reclaimDeadWorkIfPossible(
         return escalateOnce("busy-ceiling-exceeded", 0);
       }
     }
-    log.info({ ticket, phase, prevBgJobId }, "ctl-736: alive worker — reclaim suppressed");
-    return "alive-suppressed";
+    // CTL-809 — GHOST BREAKER. jobLifecycle reads ONLY the local state.json, which
+    // on CC 2.x is never rewritten terminal for a crashed/wedged --bg worker — so a
+    // corpse stuck at state:"working" (e.g. wedged on the bypass-permissions startup
+    // dialog) reads "alive" forever and is suppressed every tick. Cross-check the
+    // now-reliable (CTL-790/792) `claude agents` snapshot: a worker ABSENT from a
+    // FRESH snapshot, past the just-dispatched grace window, is genuinely gone — so
+    // fall through to the reclaim-eligible path below instead of suppressing forever.
+    //   • CTL-662-safe: a busy in-process sub-agent fan-out worker is STILL LISTED in
+    //     `claude agents` (active/idle), never absent → never reclaimed here.
+    //   • CTL-731/657-safe: STRICTLY gated on snap.isFresh — a stale/cold snapshot
+    //     skips the cross-check and suppresses exactly as before (no cold storm).
+    //   • just-spawned-safe: ghostGraceMs gate (reusing startedAtMs parsed above)
+    //     keeps a worker that has not yet registered in `claude agents` from being
+    //     false-reclaimed.
+    let ghostAbsent = false;
+    if (Number.isFinite(startedAtMs) && now() - startedAtMs > ghostGraceMs) {
+      let shortId = null;
+      if (prevBgJobId) {
+        try {
+          shortId = shortIdFromSessionId(prevBgJobId);
+        } catch {
+          shortId = null; // malformed bg_job_id → unresolvable → suppress (no throw)
+        }
+      }
+      if (shortId) {
+        const snap = agentsSnapshot();
+        if (snap?.isFresh && agentForShortId(shortId, snap.agents) === null) {
+          ghostAbsent = true;
+          log.warn(
+            { ticket, phase, prevBgJobId, snapshotAgeMs: snap.ageMs },
+            "ctl-809: jobLifecycle-alive but ABSENT from fresh claude-agents snapshot — treating as dead (ghost breaker)",
+          );
+        }
+      }
+    }
+    if (!ghostAbsent) {
+      log.info({ ticket, phase, prevBgJobId }, "ctl-736: alive worker — reclaim suppressed");
+      return "alive-suppressed";
+    }
+    // ghostAbsent → fall through to the dead-eligible reclaim path below (supersede
+    // guard → no-probe escalate (A) / probe-done reclaim (B) / revive).
   }
 
   // ── dead-terminal | dead-gone share the reclaim-eligible path below.

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -843,6 +843,142 @@ describe("reclaimDeadWorkIfPossible", () => {
     expect(emit.calls.length).toBe(0);
   });
 
+  // CTL-809 — GHOST BREAKER. jobLifecycle reports a crashed/wedged --bg worker
+  // "alive" forever (CC 2.x never flips its state.json terminal). The alive branch
+  // cross-checks a FRESH `claude agents` snapshot: absent-from-fresh + past grace =
+  // genuinely dead → fall through to reclaim. Strictly gated to preserve CTL-662
+  // (busy fan-out stays listed) and CTL-731/657 (stale snapshot never reclaims).
+  const GHOST_GRACE = 60_000;
+  const STARTED = "2026-06-06T00:00:00Z";
+  const STARTED_MS = Date.parse(STARTED);
+
+  test("CTL-809: alive worker ABSENT from a FRESH snapshot, past grace, work done → ghost-breaker reclaims", () => {
+    const probe = recorder(true);
+    const emit = recorder({ code: 0 });
+    const appendEvent = recorder(undefined);
+    const sig = implementSignal({ bgJobId: "807b77bd", startedAt: STARTED });
+    const r = reclaimDeadWorkIfPossible(orch, sig, {
+      statJob: () => ({ exists: true, state: "working" }), // jobLifecycle → alive
+      probes: { implement: probe },
+      emitComplete: emit,
+      appendEvent,
+      postReclaimMirror: () => {}, // hermetic — no linearis spawn
+      // FRESH snapshot, our worker absent (only an unrelated agent present)
+      agentsSnapshot: () => ({
+        agents: [{ sessionId: "deadbeef-1111-2222-3333-444444444444" }],
+        isFresh: true,
+        ageMs: 1_000,
+      }),
+      ghostGraceMs: GHOST_GRACE,
+      now: () => STARTED_MS + 5 * 60_000, // > grace, < busy ceiling
+    });
+    expect(r).toBe("reclaimed");
+    expect(probe.calls.length).toBe(1);
+    expect(emit.calls.length).toBe(1);
+  });
+
+  test("CTL-809: alive worker PRESENT in a FRESH snapshot (busy fan-out) → still alive-suppressed (CTL-662)", () => {
+    const emit = recorder({ code: 0 });
+    const sig = implementSignal({ bgJobId: "807b77bd", startedAt: STARTED });
+    const r = reclaimDeadWorkIfPossible(orch, sig, {
+      statJob: () => ({ exists: true, state: "working" }),
+      probes: { implement: recorder(true) },
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+      // our worker's shortId IS in the fresh snapshot → busy, not a ghost
+      agentsSnapshot: () => ({
+        agents: [{ sessionId: "807b77bd-0000-0000-0000-000000000000" }],
+        isFresh: true,
+        ageMs: 1_000,
+      }),
+      ghostGraceMs: GHOST_GRACE,
+      now: () => STARTED_MS + 5 * 60_000,
+    });
+    expect(r).toBe("alive-suppressed");
+    expect(emit.calls.length).toBe(0);
+  });
+
+  test("CTL-809: alive worker absent but snapshot STALE/cold → still alive-suppressed (CTL-731/657, no cold storm)", () => {
+    const emit = recorder({ code: 0 });
+    const sig = implementSignal({ bgJobId: "807b77bd", startedAt: STARTED });
+    const r = reclaimDeadWorkIfPossible(orch, sig, {
+      statJob: () => ({ exists: true, state: "working" }),
+      probes: { implement: recorder(true) },
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+      agentsSnapshot: () => ({ agents: [], isFresh: false, ageMs: Infinity }), // cold
+      ghostGraceMs: GHOST_GRACE,
+      now: () => STARTED_MS + 5 * 60_000,
+    });
+    expect(r).toBe("alive-suppressed");
+    expect(emit.calls.length).toBe(0);
+  });
+
+  test("CTL-809: alive worker absent from a FRESH snapshot but WITHIN grace → suppress (just-spawned-safe)", () => {
+    const emit = recorder({ code: 0 });
+    let snapCalls = 0;
+    const sig = implementSignal({ bgJobId: "807b77bd", startedAt: STARTED });
+    const r = reclaimDeadWorkIfPossible(orch, sig, {
+      statJob: () => ({ exists: true, state: "working" }),
+      probes: { implement: recorder(true) },
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+      agentsSnapshot: () => {
+        snapCalls++;
+        return { agents: [], isFresh: true, ageMs: 1 };
+      },
+      ghostGraceMs: GHOST_GRACE,
+      now: () => STARTED_MS + 30_000, // 30s < 60s grace
+    });
+    expect(r).toBe("alive-suppressed");
+    expect(snapCalls).toBe(0); // within grace → snapshot never consulted
+    expect(emit.calls.length).toBe(0);
+  });
+
+  test("CTL-809: alive worker PAST busy-ceiling with work done but PRESENT in a fresh snapshot → still suppressed (busy-ceiling × ghost-breaker)", () => {
+    // The dangerous intersection: past busy-ceiling with workDone:true skips the
+    // escalation and reaches the ghost-breaker. A worker still LISTED in a fresh
+    // snapshot is a live busy worker and must NEVER be reclaimed (CTL-662).
+    const emit = recorder({ code: 0 });
+    const sig = implementSignal({ bgJobId: "807b77bd", startedAt: STARTED });
+    const r = reclaimDeadWorkIfPossible(orch, sig, {
+      statJob: () => ({ exists: true, state: "working" }),
+      probes: { implement: recorder(true) }, // workDone → skips busy-ceiling escalate
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+      agentsSnapshot: () => ({
+        agents: [{ sessionId: "807b77bd-0000-0000-0000-000000000000" }], // PRESENT
+        isFresh: true,
+        ageMs: 1_000,
+      }),
+      ghostGraceMs: GHOST_GRACE,
+      busyCeilingMs: 1, // tiny → now() is far past it
+      now: () => STARTED_MS + 5 * 60_000,
+    });
+    expect(r).toBe("alive-suppressed");
+    expect(emit.calls.length).toBe(0);
+  });
+
+  test("CTL-809: malformed bg_job_id → ghost-breaker suppresses without throwing (snapshot not consulted)", () => {
+    const emit = recorder({ code: 0 });
+    let snapCalls = 0;
+    const sig = implementSignal({ bgJobId: "zzzzzzzz", startedAt: STARTED });
+    const r = reclaimDeadWorkIfPossible(orch, sig, {
+      statJob: () => ({ exists: true, state: "working" }),
+      probes: { implement: recorder(true) },
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+      agentsSnapshot: () => {
+        snapCalls++;
+        return { agents: [], isFresh: true, ageMs: 1 };
+      },
+      ghostGraceMs: GHOST_GRACE,
+      now: () => STARTED_MS + 5 * 60_000,
+    });
+    expect(r).toBe("alive-suppressed"); // shortIdFromSessionId throws → caught → suppress
+    expect(snapCalls).toBe(0);
+  });
+
   test("'noop' for an unknown signal (no bg_job_id)", () => {
     const sig = implementSignal();
     sig.liveness = { kind: "bg", value: null };

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1987,7 +1987,16 @@ export function schedulerTick(
       // NOT a new per-tick API storm). cache may be undefined (legacy tests that
       // don't inject it); fetchTicketState handles an undefined cache by exec-ing
       // every call exactly as before.
-      const reclaimOpts = { repoRoot, cache, fetchState: fetchTicketState, prAdapter };
+      const reclaimOpts = {
+        repoRoot,
+        cache,
+        fetchState: fetchTicketState,
+        prAdapter,
+        // CTL-809 — thread the warm agents snapshot so the reclaim alive-branch can
+        // cross-check a jobLifecycle-alive-but-process-gone ghost (getAgentsCached is
+        // already imported at scheduler.mjs:81).
+        agentsSnapshot: getAgentsCached,
+      };
       // CTL-736 Phase 3: no per-tick revive budget is threaded — the progress gate
       // (revive only while progressing; stop on zero progress) + the Phase-1 O_EXCL
       // claim bound the mass-revive storm structurally.


### PR DESCRIPTION
## Problem

On CC 2.x a crashed/wedged `claude --bg` worker's local `~/.claude/jobs/<id>/state.json` is **never** rewritten to a terminal state — so `jobLifecycle()` (recovery.mjs) reports it `"alive"` forever and the reclaim sweep returns `"alive-suppressed"` every tick, **forever**. Live evidence: 11 ghost workers (6 research: CTL-663/696/703/767/783/OTL-7 + 5 triage: CTL-794–798) sitting at `status:running` with dead `bg_job_id`s absent from `claude agents`, 3600+ "reclaim suppressed" lines, 0 reclaims. CTL-736 deliberately removed the `claude agents` snapshot from the reclaim path because it was unreliable then — the exact defect CTL-790/792 just fixed.

## Fix

In the `lifecycle === "alive"` branch, before suppressing, cross-check the **FRESH** `getAgentsCached()` snapshot: a worker ABSENT from a fresh snapshot, past a just-dispatched grace window, is genuinely gone → fall through to the existing reclaim-eligible path.

```
reclaim iff  snap.isFresh === true
        AND  agentForShortId(shortIdFromSessionId(prevBgJobId), snap.agents) === null
        AND  now() - Date.parse(startedAt) > GHOST_GRACE_MS
```

All four adversarial-review fixes folded in:
1. **GHOST_GRACE_MS** (90s default) startedAt gate — reuses the busy-ceiling's parsed `startedAtMs`; a not-yet-registered fresh spawn is never false-reclaimed.
2. **staleMs floor** is on origin/main (CTL-792) → the `isFresh` gate is not inert.
3. **Exception-safe** shortId derivation (try/catch → null → suppress, no throw).
4. **Explicit-branch control flow** — the alive-block brace is retained; only the `absentFromFresh` path falls through (never a present/past-ceiling worker).

## Invariants (adversarially verified, 3 lenses, zero blockers)

- **CTL-662** — a busy in-process fan-out worker stays LISTED in `claude agents` → non-null → never reclaimed.
- **CTL-731/657** — strict `snap?.isFresh` gate → a stale/cold snapshot never reclaims (no cold-storm).
- **just-spawned** — within-grace → snapshot not even consulted.

## Tests

recovery 191 pass (+6), scheduler 362 pass. All 6 ghost-breaker tests are **mutation-guarded** (incl. the busy-ceiling × ghost-breaker × present intersection and the malformed-id no-throw path).

Design: `thoughts/shared/research/2026-06-06-execution-core-redesign.md` §2/§5 + the ghost-worker root-cause workflow. Follow-ups (separate tickets): bypass-permissions post-spawn liveness probe (the ghost *root* prevention) and a state.json-driven reaper for wedged job-dir cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)