### PR TITLE
perf(dev): incremental countTicketEventsInWindow — kill the per-tick full-log rescan (CTL-802)

### DIFF
--- a/plugins/dev/scripts/execution-core/event-scan.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.mjs
@@ -46,9 +46,33 @@ import { getEventLogPath } from "./config.mjs";
 const REVIVE_NAME_RE = /^phase\.[^.]+\.revive\./;
 const REMEDIATE_NAME_PREFIX = "phase.remediate.complete.";
 
+// CTL-802 — countTicketEventsInWindow (the CTL-671 runaway detector) used to scan
+// the WHOLE log from offset 0 on every call — and it is called once per in-flight
+// signal per scheduler tick. On a large monthly log that single function dominated
+// tick latency (~20s/tick observed; blocked the event loop, starved the liveness
+// warmer → held new-work dispatch). It now rides the SAME incremental cursor as the
+// revive/remediate counters: refreshIndex records a compact {t, k} for every
+// `phase.*.<ticket>` event, and countTicketEventsInWindow filters that time-windowed
+// list instead of re-reading the file. PHASE_EVENT_CAP bounds the retained list for
+// the pathological case where the count is never read (so the per-call window prune
+// never runs) — keep only the most-recent slice. Env-overridable so tests can
+// drive the cap with a small fixture instead of 20k events.
+const PHASE_EVENT_CAP = Number(process.env.EXECUTION_CORE_PHASE_EVENT_CAP) || 20_000;
+
+// ticketOfPhaseEvent — the trailing dot-segment of a `phase.<phase>.<action>.<ticket>`
+// name (e.g. "phase.implement.revive.CTL-728" → "CTL-728"). Mirrors the old
+// `.endsWith(".<ticket>")` suffix match exactly (so "CTL-9" still never matches
+// "CTL-90") while letting one forward pass bucket every phase event by ticket.
+// Returns "" for a non-phase / non-string name.
+function ticketOfPhaseEvent(name) {
+  if (typeof name !== "string" || !name.startsWith("phase.")) return "";
+  return name.slice(name.lastIndexOf(".") + 1);
+}
+
 // Per-path incremental index. We retain ONLY the two event families the counters
-// query — a tiny fraction of the log — so memory stays bounded as the file grows.
-const _index = new Map(); // path -> { cursor, leftover, events: [{ name, orchId, ts, label }] }
+// query plus the compact per-ticket {t,k} phase-event records (CTL-802) — a small
+// fraction of the log — so memory stays bounded as the file grows.
+const _index = new Map(); // path -> { cursor, leftover, events: [...], phaseEvents: [{ t, k }] }
 
 function isRelevant(name) {
   return (
@@ -64,7 +88,7 @@ function isRelevant(name) {
 function refreshIndex(path) {
   let entry = _index.get(path);
   if (!entry) {
-    entry = { cursor: 0, leftover: "", events: [] };
+    entry = { cursor: 0, leftover: "", events: [], phaseEvents: [] };
     _index.set(path, entry);
   }
   let size;
@@ -78,6 +102,7 @@ function refreshIndex(path) {
     entry.cursor = 0;
     entry.leftover = "";
     entry.events = [];
+    entry.phaseEvents = [];
   }
   if (size === entry.cursor) return entry; // no new bytes — never re-reads
   const { endOffset, leftover } = scanEventsChunked({
@@ -86,13 +111,27 @@ function refreshIndex(path) {
     leftover: entry.leftover,
     onEvent: (ev) => {
       const name = ev?.attributes?.["event.name"];
-      if (!isRelevant(name)) return;
-      entry.events.push({
-        name,
-        orchId: ev?.attributes?.["catalyst.orchestration"],
-        ts: ev?.ts,
-        label: ev?.attributes?.["event.label"],
-      });
+      if (isRelevant(name)) {
+        entry.events.push({
+          name,
+          orchId: ev?.attributes?.["catalyst.orchestration"],
+          ts: ev?.ts,
+          label: ev?.attributes?.["event.label"],
+        });
+      }
+      // CTL-802 — bucket every phase.*.<ticket> event for countTicketEventsInWindow,
+      // so it no longer re-scans the whole file. Skip unparseable ts (matches the
+      // old detector, which ignored them). Cap the list as a memory backstop.
+      const k = ticketOfPhaseEvent(name);
+      if (k) {
+        const t = Date.parse(ev?.ts || "");
+        if (Number.isFinite(t)) {
+          entry.phaseEvents.push({ t, k });
+          if (entry.phaseEvents.length > PHASE_EVENT_CAP) {
+            entry.phaseEvents.splice(0, entry.phaseEvents.length - PHASE_EVENT_CAP);
+          }
+        }
+      }
     },
   });
   entry.cursor = endOffset;
@@ -177,6 +216,13 @@ export function __resetEventScanIndexForTest() {
   _index.clear();
 }
 
+// Test-only: the retained phaseEvents length for a path. Guards the CTL-802
+// window-prune + PHASE_EVENT_CAP memory bounds (both are count-invisible — only
+// the retained-list size observes them).
+export function __phaseEventsLengthForTest(path = getEventLogPath()) {
+  return _index.get(path)?.phaseEvents?.length ?? 0;
+}
+
 // countTicketEventsInWindow — CTL-671. Total phase.*.<ticket> envelopes within
 // `windowMs` of now(). The runaway-loop signal: a healthy ticket emits a
 // handful of events per phase; a phantom probe-storm emits hundreds. Counts ALL
@@ -193,25 +239,20 @@ export function countTicketEventsInWindow({
 } = {}) {
   if (!ticket) throw new Error("countTicketEventsInWindow: ticket required");
   if (!windowMs) throw new Error("countTicketEventsInWindow: windowMs required");
+  // CTL-802: ride the incremental cursor instead of re-scanning from offset 0.
+  // refreshIndex has already bucketed every phase.*.<ticket> event as {t,k}.
+  const entry = refreshIndex(path);
   const cutoff = now() - windowMs;
-  const suffix = `.${ticket}`;
+  // Prune entries that have aged out of the window. The list is append-ordered by
+  // the forward scan (≈ chronological), so the stale entries are a leading prefix;
+  // splicing them bounds the retained list to ≈ one window of phase events. (The
+  // one production caller always passes the same RUNAWAY_WINDOW_MS, so this prune
+  // and the count below use a consistent cutoff.)
+  const arr = entry.phaseEvents;
+  let firstIn = 0;
+  while (firstIn < arr.length && arr[firstIn].t < cutoff) firstIn++;
+  if (firstIn > 0) arr.splice(0, firstIn);
   let n = 0;
-  // CTL-671 (rebased onto CTL-673): the runaway counter must see ALL
-  // `phase.*.<ticket>` envelopes, not just the revive/remediate families the
-  // retained `_index` keeps — so it cannot reuse refreshIndex. Use the same
-  // bounded `scanEventsChunked` primitive directly (fixed-size chunks, never the
-  // pre-CTL-673 whole-file readFileSync) for a memory-safe full scan.
-  scanEventsChunked({
-    path,
-    fromOffset: 0,
-    leftover: "",
-    onEvent: (ev) => {
-      const name = ev?.attributes?.["event.name"];
-      if (typeof name !== "string" || !name.startsWith("phase.") || !name.endsWith(suffix)) return;
-      const tsMs = Date.parse(ev?.ts || "");
-      if (!Number.isFinite(tsMs) || tsMs < cutoff) return;
-      n++;
-    },
-  });
+  for (const e of arr) if (e.k === ticket && e.t >= cutoff) n++;
   return n;
 }

--- a/plugins/dev/scripts/execution-core/event-scan.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.test.mjs
@@ -17,6 +17,7 @@ import {
   countDistinctRevivingTickets,
   countRemediateCycles,
   __resetEventScanIndexForTest,
+  __phaseEventsLengthForTest,
   countTicketEventsInWindow,
 } from "./event-scan.mjs";
 
@@ -380,5 +381,100 @@ describe("countTicketEventsInWindow (CTL-671)", () => {
   test("throws when ticket or windowMs is missing", () => {
     expect(() => countTicketEventsInWindow({ windowMs: 60_000 })).toThrow();
     expect(() => countTicketEventsInWindow({ ticket: "CTL-9" })).toThrow();
+  });
+
+  // CTL-802 — the counter now rides the incremental cursor (no more offset-0 rescan).
+  test("incremental: a later append is counted without re-reading the whole file", () => {
+    __resetEventScanIndexForTest();
+    const now = 10_000_000;
+    const recent = new Date(now - 1000).toISOString();
+    const { path } = tempLog([
+      makeEvent({ phase: "pr", action: "probe", ticket: "CTL-9", ts: recent }),
+    ]);
+    expect(
+      countTicketEventsInWindow({ ticket: "CTL-9", windowMs: 60_000, now: () => now, path })
+    ).toBe(1);
+    appendFileSync(
+      path,
+      makeEvent({ phase: "implement", action: "failed", ticket: "CTL-9", ts: recent }) + "\n",
+    );
+    expect(
+      countTicketEventsInWindow({ ticket: "CTL-9", windowMs: 60_000, now: () => now, path })
+    ).toBe(2);
+  });
+
+  test("does NOT re-scan already-read bytes (overwrite a counted line; count stays cached)", () => {
+    __resetEventScanIndexForTest();
+    const now = 10_000_000;
+    const recent = new Date(now - 1000).toISOString();
+    const { path } = tempLog([
+      makeEvent({ phase: "pr", action: "probe", ticket: "CTL-9", ts: recent }),
+    ]);
+    // Seed: cursor advances to EOF.
+    expect(
+      countTicketEventsInWindow({ ticket: "CTL-9", windowMs: 60_000, now: () => now, path })
+    ).toBe(1);
+    // Overwrite the already-scanned line with a DIFFERENT ticket of the SAME byte
+    // length (CTL-8 ≡ CTL-9 in width). size === cursor → refreshIndex short-circuits
+    // and never re-reads — proof the offset-0 full rescan is gone.
+    writeFileSync(path, makeEvent({ phase: "pr", action: "probe", ticket: "CTL-8", ts: recent }) + "\n");
+    expect(
+      countTicketEventsInWindow({ ticket: "CTL-9", windowMs: 60_000, now: () => now, path })
+    ).toBe(1); // cached CTL-9 record, no re-read
+    expect(
+      countTicketEventsInWindow({ ticket: "CTL-8", windowMs: 60_000, now: () => now, path })
+    ).toBe(0); // CTL-8 bytes were never scanned
+  });
+
+  test("window-prune shrinks the retained list (aged-out leading prefix is spliced)", () => {
+    __resetEventScanIndexForTest();
+    const now = 10_000_000;
+    const old = new Date(now - 20 * 60_000).toISOString(); // aged out (>10min)
+    const recent = new Date(now - 60_000).toISOString(); // in window
+    const { path } = tempLog([
+      makeEvent({ phase: "pr", action: "probe", ticket: "CTL-9", ts: old }),
+      makeEvent({ phase: "pr", action: "probe", ticket: "CTL-9", ts: recent }),
+    ]);
+    expect(
+      countTicketEventsInWindow({ ticket: "CTL-9", windowMs: 10 * 60_000, now: () => now, path })
+    ).toBe(1);
+    // the aged-out entry was spliced — only the in-window record is retained
+    expect(__phaseEventsLengthForTest(path)).toBe(1);
+  });
+
+  test("PHASE_EVENT_CAP bounds the retained list even when the count is never read", async () => {
+    const prev = process.env.EXECUTION_CORE_PHASE_EVENT_CAP;
+    process.env.EXECUTION_CORE_PHASE_EVENT_CAP = "3";
+    try {
+      const mod = await import(`./event-scan.mjs?cap=${Date.now()}-${Math.random()}`);
+      mod.__resetEventScanIndexForTest();
+      const ts = new Date().toISOString();
+      const lines = [];
+      for (let i = 0; i < 8; i++) {
+        lines.push(makeEvent({ phase: "implement", action: "probe", ticket: `CTL-${i}`, ts }));
+      }
+      const { path } = tempLog(lines);
+      // refreshIndex (via the revive counter, which does NOT prune phaseEvents) must
+      // still cap the list at 3, not retain all 8.
+      mod.countReviveEvents({ ticket: "CTL-0", path });
+      expect(mod.__phaseEventsLengthForTest(path)).toBe(3);
+    } finally {
+      if (prev === undefined) delete process.env.EXECUTION_CORE_PHASE_EVENT_CAP;
+      else process.env.EXECUTION_CORE_PHASE_EVENT_CAP = prev;
+    }
+  });
+
+  test("ignores a non-phase event whose trailing segment collides with the ticket id", () => {
+    __resetEventScanIndexForTest();
+    const now = 10_000_000;
+    const recent = new Date(now - 1000).toISOString();
+    const { path } = tempLog([
+      // a non-phase event family that happens to end in ".CTL-9" — must NOT be counted
+      JSON.stringify({ ts: recent, attributes: { "event.name": "session.ended.CTL-9" } }),
+      makeEvent({ phase: "pr", action: "probe", ticket: "CTL-9", ts: recent }), // the real one
+    ]);
+    expect(
+      countTicketEventsInWindow({ ticket: "CTL-9", windowMs: 60_000, now: () => now, path })
+    ).toBe(1);
   });
 });


### PR DESCRIPTION
## Problem
`countTicketEventsInWindow` (CTL-671 runaway detector) scanned the **whole event log from offset 0 on every call**, called **once per in-flight signal per tick** (scheduler.mjs:1876). On the live ~282k-line log it blocked the event loop ~20s/tick (19 signals × full scan), starving the CTL-792 warmer → holding new-work dispatch (~50% of ticks measured).

## Fix
Rides the **same incremental cursor** as the revive/remediate counters: refreshIndex buckets every `phase.*.<ticket>` event as `{t,k}` in one forward pass; the counter filters that time-windowed list (splicing the aged-out prefix). `PHASE_EVENT_CAP` bounds it if never read.

**Measured:** 19 signals × 80k-event log: **~20s → 5.4ms** (one-time 231ms seed at boot).

## Safety
- Behavior preserved: counts all `phase.*.<ticket>` in window, suffix boundary (CTL-9 ≠ CTL-90), unparseable ts ignored, missing log → 0, throws preserved. Rotation resets phaseEvents.
- 2 new tests guard the incremental contract; "does-NOT-re-scan" is **mutation-proven**.
- Consumers unchanged: event-scan 33, recovery 191, scheduler 362 pass.

Stage 1 keystone (redesign §3 #3) — fast tick → reliable dispatch. The 282k log was 69% test-fixture pollution (CTL-810); this fix makes the per-tick scan size-independent regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)