### PR TITLE
fix(dev): relocate CONCEPTS.md to thoughts/shared/ so it syncs (CTL-789 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ This workspace has no build process - it's markdown files and bash scripts.
 
 - `thoughts/shared/learnings/` — past problem→solution entries (grep by component/tags/problem_type).
   Search before implementing or debugging in a known area. Curated by `/catalyst-dev:ticket-compound`.
-- `thoughts/CONCEPTS.md` — shared domain vocabulary (reclaim, revive-budget, orphan, signal ownership…).
+- `thoughts/shared/CONCEPTS.md` — shared domain vocabulary (reclaim, revive-budget, orphan, signal ownership…).
 
 ## Commit Conventions
 

--- a/plugins/dev/scripts/__tests__/ticket-compound-shape.test.sh
+++ b/plugins/dev/scripts/__tests__/ticket-compound-shape.test.sh
@@ -45,16 +45,16 @@ done
 # 4. Seed thoughts artifacts (gitignored + humanlayer-synced — only present where the
 #    thoughts store is seeded). Guarded so this stays a pure repo-structure test that also
 #    passes in a bare checkout / CI; skips-with-note otherwise. CONCEPTS.md is the vocabulary
-#    seed whose canonical synced path is a CTL-811 follow-up (currently top-level, unsynced).
+#    seed, now in the synced shared store (thoughts/shared/CONCEPTS.md).
 SEED="$ROOT/thoughts/shared/learnings/architecture-patterns/friction-capture-container.md"
 if [ -d "$ROOT/thoughts/shared/learnings" ]; then
   assert "seed learnings entry exists" "test -f '$SEED'"
   assert "validate-learnings.sh exits 0 on the seed entry" \
     "bash '$VALIDATOR' '$SEED' >/dev/null 2>&1"
-  if [ -f "$ROOT/thoughts/CONCEPTS.md" ]; then
-    assert "thoughts/CONCEPTS.md exists" "test -f '$ROOT/thoughts/CONCEPTS.md'"
+  if [ -f "$ROOT/thoughts/shared/CONCEPTS.md" ]; then
+    assert "thoughts/shared/CONCEPTS.md exists" "test -f '$ROOT/thoughts/shared/CONCEPTS.md'"
   else
-    echo "skip: thoughts/CONCEPTS.md not seeded here (CTL-811 follow-up: move under thoughts/shared/ to sync)"
+    echo "skip: thoughts/shared/CONCEPTS.md not seeded in this checkout"
   fi
 else
   echo "skip: thoughts store not seeded in this checkout — skipping seed-entry + CONCEPTS assertions"

--- a/plugins/dev/skills/ticket-compound/SKILL.md
+++ b/plugins/dev/skills/ticket-compound/SKILL.md
@@ -4,7 +4,7 @@ description:
   Compound-engineering capture + curation for a finished ticket — the engineering feedback loop.
   Harvests the Friction sections that phase agents left in their artifacts plus the git diff, writes a
   structured entry to the shared learnings store (thoughts/shared/learnings/), prunes/amends stale
-  notes there autonomously, captures new domain vocabulary to thoughts/CONCEPTS.md, and PROPOSES (for
+  notes there autonomously, captures new domain vocabulary to thoughts/shared/CONCEPTS.md, and PROPOSES (for
   human approval) any ADR change. Non-blocking — runs after a ticket ships or fails, never on the
   critical path. Use when the user says "compound this ticket", "capture learnings", "what did we
   learn", or run as /catalyst-dev:ticket-compound <TICKET> [mode:headless].
@@ -21,7 +21,7 @@ Read `reference.md` (this dir) for the learnings-store schema before writing any
 
 **Two authority levels (hard rule):**
 - **Autonomous** — write/append/update/delete in `thoughts/shared/learnings/` and
-  `thoughts/CONCEPTS.md`, and prune stale notes in `thoughts/shared/{research,plans}/`.
+  `thoughts/shared/CONCEPTS.md`, and prune stale notes in `thoughts/shared/{research,plans}/`.
 - **Propose only (APPROVE-gated)** — any change to `docs/adrs.md`. Never edit an ADR directly; queue
   it for the morning ritual to approve.
 
@@ -96,7 +96,7 @@ unambiguous cases; mark the rest `status: stale` + `stale_reason`.
 
 ## Step 5 — Vocabulary → CONCEPTS.md (autonomous)
 
-Scan the diff + friction for Catalyst domain terms not yet in `thoughts/CONCEPTS.md` (e.g. "reclaim",
+Scan the diff + friction for Catalyst domain terms not yet in `thoughts/shared/CONCEPTS.md` (e.g. "reclaim",
 "revive-budget", "orphan", "signal ownership"). Append concise definitions. Create the file if absent.
 
 ## Step 6 — ADR changes → PROPOSE, never apply

--- a/plugins/dev/skills/ticket-compound/reference.md
+++ b/plugins/dev/skills/ticket-compound/reference.md
@@ -64,7 +64,7 @@ unquoted `#` is silently truncated as a comment and unquoted `: ` is parsed as a
 - **Standing rule that every agent must always follow** → propose an **ADR** change (`docs/adrs.md`,
   `@import`ed into CLAUDE.md). APPROVE-gated.
 - **Shared domain vocabulary** (what "reclaim", "revive-budget", "orphan", "signal ownership" mean)
-  → `thoughts/CONCEPTS.md`. Autonomous.
+  → `thoughts/shared/CONCEPTS.md`. Autonomous.
 - **A specific problem→solution pair** → a learnings entry here. Autonomous.
 
 CLAUDE.md itself only ever gets a *pointer* to the store (the "discoverability check"), never the


### PR DESCRIPTION
## CONCEPTS.md durability fix (follow-up to CTL-811 / CTL-789 Slice 1)

`thoughts/CONCEPTS.md` at the **top level is not humanlayer-synced** — only `thoughts/shared/`, `thoughts/<user>/`, and `thoughts/global/` sync. So the shared domain-vocabulary file was effectively machine-local and would be lost whenever its worktree was cleaned (which is exactly what stranded the seeded copy). A cross-agent shared file must live under the synced subtree.

### Change
- `ticket-compound` SKILL.md (Step 5 + authority levels + description) and `reference.md`: write/curate **`thoughts/shared/CONCEPTS.md`**.
- `CLAUDE.md` Knowledge Store pointer → `thoughts/shared/CONCEPTS.md`.
- `ticket-compound-shape.test.sh`: asserts `thoughts/shared/CONCEPTS.md` (still guarded to stay a pure repo-structure test in bare checkouts).
- The seeded `CONCEPTS.md` content is now in the synced shared store (preserved + pushed).

Closes the last `thoughts/`-durability gap from Slice 1. Relates CTL-789, CTL-811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)