### PR TITLE
feat(pm): close the estimation feedback loop — recurring corpus refresh from real actuals (CTL-813)

### DIFF
--- a/plugins/dev/scripts/__tests__/compound-log.test.sh
+++ b/plugins/dev/scripts/__tests__/compound-log.test.sh
@@ -357,6 +357,134 @@ test_wall_time_computed_from_pr() {
   unset FAKE_GH_PR_JSON FAKE_LINEARIS_JSON
 }
 
+# ─── read / aggregate (CTL-813: the consumer side of the loop) ─────────────
+#
+# Until CTL-813 the compound-log was a write-only sink (subcommands: iso-week,
+# write). `read` emits every entry as JSON Lines; `aggregate` reduces them to
+# a per-ticket latest map + calibration stats for the corpus-refresh join.
+
+# Seed two entries across two tickets via the public write path.
+seed_two_entries() {
+  local proj="$1"
+  export FAKE_GH_PR_JSON='{"number":900,"createdAt":"2026-04-24T09:00:00Z","mergedAt":"2026-04-24T12:00:00Z","state":"MERGED"}'
+  export FAKE_LINEARIS_JSON='{"identifier":"CTL-900","estimate":3}'
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-900 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 5 --cost-usd 1.50 \
+    --what-worked "tests first" --what-surprised-me "nothing" >/dev/null 2>&1
+
+  export FAKE_GH_PR_JSON='{"number":901,"createdAt":"2026-04-27T09:00:00Z","mergedAt":"2026-04-27T12:00:00Z","state":"MERGED"}'
+  export FAKE_LINEARIS_JSON='{"identifier":"CTL-901","estimate":8}'
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-901 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 8 --cost-usd 4.25 \
+    --what-worked "plan held" --what-surprised-me "ci flake" >/dev/null 2>&1
+  unset FAKE_GH_PR_JSON FAKE_LINEARIS_JSON
+}
+
+test_read_empty_store_exits_zero() {
+  proj=$(new_scratch_project read_empty)
+  out=$("$COMPOUND" read --thoughts-dir "${proj}/thoughts" 2>&1)
+  rc=$?
+  if [ $rc -eq 0 ] && [ -z "$out" ]; then
+    pass "read: empty store → exit 0, no output"
+  else
+    fail "read: empty store should be silent success (rc=$rc)" "$out"
+  fi
+}
+
+test_read_emits_json_lines() {
+  proj=$(new_scratch_project read_jsonl)
+  seed_two_entries "$proj"
+
+  "$COMPOUND" read --thoughts-dir "${proj}/thoughts" > "${SCRATCH}/out" 2>&1
+  rc=$?
+  lines=$(wc -l < "${SCRATCH}/out" | tr -d ' ')
+  keys=$(jq -r '.linear_key' "${SCRATCH}/out" 2>/dev/null | sort | paste -sd, -)
+  actual900=$(jq -r 'select(.linear_key=="CTL-900") | .estimate_actual' "${SCRATCH}/out" 2>/dev/null)
+  week900=$(jq -r 'select(.linear_key=="CTL-900") | .week' "${SCRATCH}/out" 2>/dev/null)
+  if [ $rc -eq 0 ] && [ "$lines" = "2" ] && [ "$keys" = "CTL-900,CTL-901" ] \
+     && [ "$actual900" = "5" ] && [ "$week900" = "2026-W17" ]; then
+    pass "read: emits one parseable JSON line per entry with typed fields"
+  else
+    fail "read: bad output (rc=$rc lines=$lines keys=$keys actual=$actual900 week=$week900)"
+  fi
+}
+
+test_read_week_filter() {
+  proj=$(new_scratch_project read_week)
+  seed_two_entries "$proj"   # CTL-900 → W17, CTL-901 → W18
+
+  out=$("$COMPOUND" read --thoughts-dir "${proj}/thoughts" --week 2026-W18 2>&1)
+  key=$(echo "$out" | jq -r '.linear_key' 2>/dev/null)
+  n=$(echo "$out" | grep -c '^{')
+  if [ "$n" = "1" ] && [ "$key" = "CTL-901" ]; then
+    pass "read: --week filters to one weekly file"
+  else
+    fail "read: --week filter wrong (n=$n key=$key)" "$out"
+  fi
+}
+
+test_read_roundtrips_quoted_text() {
+  proj=$(new_scratch_project read_quotes)
+  export FAKE_GH_PR_JSON='{"number":910,"createdAt":"2026-04-24T09:00:00Z","mergedAt":"2026-04-24T12:00:00Z","state":"MERGED"}'
+  export FAKE_LINEARIS_JSON='{"identifier":"CTL-910","estimate":3}'
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-910 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 3 --cost-usd 1.00 \
+    --what-worked 'said "quoted" thing' --what-surprised-me "b" >/dev/null 2>&1
+  unset FAKE_GH_PR_JSON FAKE_LINEARIS_JSON
+
+  ww=$("$COMPOUND" read --thoughts-dir "${proj}/thoughts" 2>/dev/null | jq -r '.what_worked')
+  if [ "$ww" = 'said "quoted" thing' ]; then
+    pass "read: quoted free text round-trips through YAML escaping"
+  else
+    fail "read: quote round-trip broken, got: $ww"
+  fi
+}
+
+test_aggregate_empty_store() {
+  proj=$(new_scratch_project agg_empty)
+  out=$("$COMPOUND" aggregate --thoughts-dir "${proj}/thoughts" 2>&1)
+  rc=$?
+  entries=$(echo "$out" | jq -r '.entries' 2>/dev/null)
+  cal=$(echo "$out" | jq -r '.calibration.count' 2>/dev/null)
+  if [ $rc -eq 0 ] && [ "$entries" = "0" ] && [ "$cal" = "0" ]; then
+    pass "aggregate: empty store → zeroed JSON, exit 0"
+  else
+    fail "aggregate: empty store wrong (rc=$rc entries=$entries cal=$cal)" "$out"
+  fi
+}
+
+test_aggregate_latest_per_ticket_and_calibration() {
+  proj=$(new_scratch_project agg_latest)
+  seed_two_entries "$proj"
+  # Second entry for CTL-900 with a LATER merged_at and a different actual —
+  # aggregate must pick this one for tickets["CTL-900"].
+  export FAKE_GH_PR_JSON='{"number":902,"createdAt":"2026-04-28T09:00:00Z","mergedAt":"2026-04-28T12:00:00Z","state":"MERGED"}'
+  export FAKE_LINEARIS_JSON='{"identifier":"CTL-900","estimate":3}'
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-900 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 8 --cost-usd 2.00 \
+    --what-worked "redo" --what-surprised-me "scope grew" >/dev/null 2>&1
+  unset FAKE_GH_PR_JSON FAKE_LINEARIS_JSON
+
+  out=$("$COMPOUND" aggregate --thoughts-dir "${proj}/thoughts" 2>&1)
+  entries=$(echo "$out" | jq -r '.entries')
+  latest900=$(echo "$out" | jq -r '.tickets["CTL-900"].estimate_actual')
+  cal_count=$(echo "$out" | jq -r '.calibration.count')
+  cal_exact=$(echo "$out" | jq -r '.calibration.exact')
+  # deltas: 900a: 5-3=2, 901: 8-8=0, 900b: 8-3=5 → mean 7/3 ≈ 2.33, exact 1
+  mean=$(echo "$out" | jq -r '.calibration.mean_signed_delta')
+  mean_ok=$(echo "$out" | jq -r '.calibration.mean_signed_delta > 2.3 and .calibration.mean_signed_delta < 2.4')
+  if [ "$entries" = "3" ] && [ "$latest900" = "8" ] && [ "$cal_count" = "3" ] \
+     && [ "$cal_exact" = "1" ] && [ "$mean_ok" = "true" ]; then
+    pass "aggregate: latest-per-ticket map + calibration stats"
+  else
+    fail "aggregate: wrong (entries=$entries latest900=$latest900 count=$cal_count exact=$cal_exact mean=$mean)" "$out"
+  fi
+}
+
 # ─── Run all test_* functions ───────────────────────────────────────────────
 
 for t in $(declare -F | awk '/^declare -f test_/{print $3}'); do

--- a/plugins/dev/scripts/compound-log.sh
+++ b/plugins/dev/scripts/compound-log.sh
@@ -14,6 +14,19 @@
 #   iso-week <iso-timestamp>
 #       Print YYYY-WW for the given UTC timestamp. Exits non-zero on bad input.
 #
+#   read [--thoughts-dir <path>] [--week <YYYY-WW>]
+#       Emit every compound-log entry as JSON Lines (one object per entry):
+#       week, linear_key, pr_number, merged_at, estimate_at_start,
+#       estimate_actual, cost_usd, wall_time_hours, what_worked,
+#       what_surprised_me. Empty/absent store → no output, exit 0 (CTL-813:
+#       consumers fail open).
+#
+#   aggregate [--thoughts-dir <path>]
+#       Reduce all entries to a single JSON object for the corpus-refresh
+#       join: { entries, tickets: {<KEY>: <latest entry by merged_at>},
+#       calibration: { count, exact, mean_signed_delta, median_abs_delta } }.
+#       median_abs_delta is the lower median. Empty store → zeroed object.
+#
 #   write <ticket-id> [options]
 #       Append an entry for <ticket-id>. Options:
 #         --pr <number>               PR number (default: gh pr view on branch)
@@ -326,14 +339,137 @@ cmd_write() {
   echo "entry: ${ticket} — #${pr} — ${merged_at}"
 }
 
+# ─── subcommand: read (CTL-813) ─────────────────────────────────────────────
+#
+# Parse every <thoughts-dir>/shared/pm/metrics/*-compound-log.md and emit one
+# JSON object per entry (JSON Lines). The yaml blocks are flat key: value
+# pairs written by render_entry, so an awk field-splitter is sufficient — the
+# only escaping in play is the \" that render_entry applies to free text.
+# Empty/absent store is SILENT SUCCESS: consumers (refresh-corpus join,
+# ticket-retro) fail open on an empty log.
+
+cmd_read() {
+  local thoughts_dir="./thoughts"
+  local week_filter=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --thoughts-dir) thoughts_dir="$2"; shift 2 ;;
+      --week)         week_filter="$2"; shift 2 ;;
+      *) fatal "read: unknown flag: $1" ;;
+    esac
+  done
+
+  local metrics_dir="${thoughts_dir}/shared/pm/metrics"
+  [ -d "$metrics_dir" ] || return 0
+
+  command -v jq >/dev/null 2>&1 || fatal "read: jq is required"
+
+  local f base week
+  for f in "$metrics_dir"/*-compound-log.md; do
+    [ -e "$f" ] || continue   # nullglob-safe: literal pattern when no match
+    base="$(basename "$f")"
+    week="${base%-compound-log.md}"
+    if [ -n "$week_filter" ] && [ "$week" != "$week_filter" ]; then
+      continue
+    fi
+    # awk → one TAB-separated record per yaml block (tabs in text mapped to
+    # spaces; outer quotes stripped; \" unescaped), then jq types the fields.
+    awk -v week="$week" '
+      function val(line,   v) {
+        v = line
+        sub(/^[a-z_]+:[ ]*/, "", v)
+        gsub(/\t/, " ", v)
+        return v
+      }
+      function unquote(v) {
+        if (v ~ /^".*"$/) { v = substr(v, 2, length(v) - 2); gsub(/\\"/, "\"", v) }
+        return v
+      }
+      /^```yaml$/ { in_yaml = 1; lk=pr=ma=es=ea=cu=wh=ww=ws=""; next }
+      /^```$/ {
+        if (in_yaml && lk != "") {
+          printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", \
+            week, lk, pr, ma, es, ea, cu, wh, ww, ws
+        }
+        in_yaml = 0; next
+      }
+      in_yaml && /^linear_key:/        { lk = val($0) }
+      in_yaml && /^pr_number:/         { pr = val($0) }
+      in_yaml && /^merged_at:/         { ma = val($0) }
+      in_yaml && /^estimate_at_start:/ { es = val($0) }
+      in_yaml && /^estimate_actual:/   { ea = val($0) }
+      in_yaml && /^cost_usd:/          { cu = val($0) }
+      in_yaml && /^wall_time_hours:/   { wh = val($0) }
+      in_yaml && /^what_worked:/       { ww = unquote(val($0)) }
+      in_yaml && /^what_surprised_me:/ { ws = unquote(val($0)) }
+    ' "$f" | jq -R -c 'split("\t") | {
+        week: .[0],
+        linear_key: .[1],
+        pr_number: (.[2] | tonumber? // null),
+        merged_at: .[3],
+        estimate_at_start: (.[4] | tonumber? // null),
+        estimate_actual: (.[5] | tonumber? // null),
+        cost_usd: (.[6] | tonumber? // null),
+        wall_time_hours: (.[7] | tonumber? // null),
+        what_worked: .[8],
+        what_surprised_me: .[9]
+      }'
+  done
+}
+
+# ─── subcommand: aggregate (CTL-813) ────────────────────────────────────────
+#
+# Reduce the read stream to the shape the corpus-refresh join consumes:
+# per-ticket LATEST entry (by merged_at — a re-merged follow-up PR supersedes
+# the first re-score) + calibration stats over ALL entries.
+
+cmd_aggregate() {
+  local thoughts_dir="./thoughts"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --thoughts-dir) thoughts_dir="$2"; shift 2 ;;
+      *) fatal "aggregate: unknown flag: $1" ;;
+    esac
+  done
+
+  command -v jq >/dev/null 2>&1 || fatal "aggregate: jq is required"
+
+  cmd_read --thoughts-dir "$thoughts_dir" | jq -s '
+    {
+      entries: length,
+      tickets: (
+        group_by(.linear_key)
+        | map({ key: .[0].linear_key, value: (sort_by(.merged_at) | last) })
+        | from_entries
+      ),
+      calibration: (
+        [ .[] | select(.estimate_at_start != null and .estimate_actual != null) ] as $c
+        | ($c | map(.estimate_actual - .estimate_at_start)) as $d
+        | {
+            count: ($c | length),
+            exact: ([ $d[] | select(. == 0) ] | length),
+            mean_signed_delta:
+              (if ($d | length) > 0 then (($d | add) / ($d | length)) else null end),
+            median_abs_delta:
+              (if ($d | length) > 0
+               then (($d | map(if . < 0 then -. else . end) | sort) as $a
+                     | $a[(($a | length - 1) / 2) | floor])
+               else null end)
+          }
+      )
+    }'
+}
+
 # ─── main ───────────────────────────────────────────────────────────────────
 
 usage() {
-  sed -n '2,35p' "$0" | sed 's|^# \{0,1\}||'
+  sed -n '2,50p' "$0" | sed 's|^# \{0,1\}||'
 }
 
 case "${1:-}" in
   iso-week)  shift; cmd_iso_week "$@" ;;
+  read)      shift; cmd_read "$@" ;;
+  aggregate) shift; cmd_aggregate "$@" ;;
   write)     shift; cmd_write "$@" ;;
   -h|--help|help|"") usage ;;
   *) fatal "unknown subcommand: ${1}" ;;

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -358,15 +358,48 @@ export function applyTriageStatus({
 // applyEstimate; anything else is rejected without calling linearis.
 const ALLOWED_ESTIMATE_POINTS = new Set([1, 3, 5, 8, 13]);
 
+// HUMAN_ESTIMATE_LABEL — tickets carrying this label have a hand-set estimate
+// that machine write-backs must never clobber (estimation-methodology.md §6b).
+// Same label score-tickets.ts --check-labels honors (its HUMAN_LABEL const).
+const HUMAN_ESTIMATE_LABEL = "estimate-source:human";
+
 // applyEstimate — write a numeric estimate to a ticket's Linear estimate field
 // (CTL-751). Best-effort, never throws; mirrors applyLabel shape (try/catch,
 // log.warn, tagged return). No read-back (the estimate field is not subject to
 // the label silent-success gap; a verifying read-back can be added as follow-up).
-export function applyEstimate({ ticket, estimate, exec = defaultExec }) {
+//
+// CTL-813 — estimate-source:human guard. Pre-reads the ticket's labels and
+// SKIPS the write when HUMAN_ESTIMATE_LABEL is present, honoring the
+// methodology contract that human estimates are never machine-overwritten.
+// FAIL-OPEN on an unreadable label set (null / throw): proceeding matches the
+// score-tickets --check-labels precedent ("label check failed; proceeding
+// without filter") — the scheduler's estimate write is one-shot (fires once on
+// the triage→research advance), so failing closed would silently drop it
+// forever on any transient read hiccup.
+export function applyEstimate({ ticket, estimate, exec = defaultExec, fetchLabels = fetchTicketLabels }) {
   if (!ALLOWED_ESTIMATE_POINTS.has(estimate)) {
     return { applied: false, reason: "invalid-estimate" };
   }
   try {
+    let labels = null;
+    try {
+      labels = fetchLabels(ticket, { exec });
+    } catch {
+      /* fail-open — treated as unreadable below */
+    }
+    if (Array.isArray(labels) && labels.includes(HUMAN_ESTIMATE_LABEL)) {
+      log.info(
+        { ticket, estimate, label: HUMAN_ESTIMATE_LABEL },
+        "linear-write: estimate write skipped — ticket carries a human estimate"
+      );
+      return { applied: false, skipped: "human-estimate", reason: "skipped-human-estimate" };
+    }
+    if (!Array.isArray(labels)) {
+      log.warn(
+        { ticket, estimate },
+        "linear-write: estimate label pre-read failed — proceeding without human-estimate guard (fail-open)"
+      );
+    }
     const res = exec("linearis", ["issues", "update", ticket, "--estimate", String(estimate)]);
     if (res.code !== 0) {
       log.warn(

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -672,10 +672,12 @@ describe("applyBlockedByRelation", () => {
 });
 
 describe("applyEstimate", () => {
+  // CTL-813: fetchLabels is injected in call-counting tests so the
+  // estimate-source:human pre-read doesn't go through the counted exec.
   test("valid estimate, exec returns code:0 → applied:true, correct args", () => {
     const calls = [];
     const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
-    const r = applyEstimate({ ticket: "CTL-1", estimate: 5, exec });
+    const r = applyEstimate({ ticket: "CTL-1", estimate: 5, exec, fetchLabels: () => [] });
     expect(r).toEqual({ applied: true, reason: null });
     expect(calls).toHaveLength(1);
     expect(calls[0].cmd).toBe("linearis");
@@ -726,9 +728,91 @@ describe("applyEstimate", () => {
     for (const est of [1, 3, 5, 8, 13]) {
       const calls = [];
       const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
-      const r = applyEstimate({ ticket: "CTL-1", estimate: est, exec });
+      const r = applyEstimate({ ticket: "CTL-1", estimate: est, exec, fetchLabels: () => [] });
       expect(r.applied).toBe(true);
       expect(calls[0].args).toContain(String(est));
     }
+  });
+
+  // ── CTL-813: estimate-source:human guard ─────────────────────────────────
+  // estimation-methodology.md §6b promises human estimates are never clobbered
+  // (the contract score-tickets --check-labels already honors). applyEstimate
+  // pre-reads the label set and skips the write when the label is present.
+
+  test("ticket labeled estimate-source:human → skipped, update never called", () => {
+    const calls = [];
+    const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const r = applyEstimate({
+      ticket: "CTL-1",
+      estimate: 5,
+      exec,
+      fetchLabels: () => ["feature", "estimate-source:human"],
+    });
+    expect(r.applied).toBe(false);
+    expect(r.skipped).toBe("human-estimate");
+    expect(r.reason).toBe("skipped-human-estimate");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("ticket with other labels but not the human label → write proceeds", () => {
+    const calls = [];
+    const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const r = applyEstimate({
+      ticket: "CTL-1",
+      estimate: 5,
+      exec,
+      fetchLabels: () => ["feature", "estimation"],
+    });
+    expect(r).toEqual({ applied: true, reason: null });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toEqual(["issues", "update", "CTL-1", "--estimate", "5"]);
+  });
+
+  test("label pre-read fails (null) → FAIL-OPEN: write proceeds", () => {
+    // Matches the score-tickets --check-labels precedent: a failed label check
+    // warns and proceeds without the filter. The scheduler's estimate write is
+    // one-shot (triage→research advance) — failing closed would silently drop
+    // it forever on any transient read hiccup.
+    const calls = [];
+    const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const r = applyEstimate({ ticket: "CTL-1", estimate: 5, exec, fetchLabels: () => null });
+    expect(r).toEqual({ applied: true, reason: null });
+    expect(calls).toHaveLength(1);
+  });
+
+  test("label pre-read throws → FAIL-OPEN: write proceeds, nothing thrown", () => {
+    const calls = [];
+    const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const r = applyEstimate({
+      ticket: "CTL-1",
+      estimate: 5,
+      exec,
+      fetchLabels: () => { throw new Error("label boom"); },
+    });
+    expect(r).toEqual({ applied: true, reason: null });
+    expect(calls).toHaveLength(1);
+  });
+
+  test("default fetchLabels wiring: linearis read returns human label via exec → skipped", () => {
+    // No injected fetchLabels — the real fetchTicketLabels path runs through
+    // the injected exec: first call is the `issues read`, and on seeing the
+    // human label no update call follows.
+    const calls = [];
+    const exec = (cmd, args) => {
+      calls.push({ cmd, args });
+      if (args[0] === "issues" && args[1] === "read") {
+        return {
+          code: 0,
+          stdout: JSON.stringify({ labels: { nodes: [{ name: "estimate-source:human" }] } }),
+          stderr: "",
+        };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    const r = applyEstimate({ ticket: "CTL-1", estimate: 5, exec });
+    expect(r.applied).toBe(false);
+    expect(r.skipped).toBe("human-estimate");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args.slice(0, 2)).toEqual(["issues", "read"]);
   });
 });

--- a/plugins/dev/skills/compound-estimate/SKILL.md
+++ b/plugins/dev/skills/compound-estimate/SKILL.md
@@ -7,7 +7,7 @@ description:
   estimate_at_start, estimate_actual, cost_usd, wall_time_hours, what_worked, what_surprised_me)
   to `thoughts/shared/pm/metrics/YYYY-WW-compound-log.md` — one file per ISO week, appends."
 disable-model-invocation: false
-allowed-tools: Bash(gh *), Bash(linearis *), Bash(jq *), Bash(git *), Bash(./plugins/dev/scripts/compound-log.sh *), Bash(plugins/dev/scripts/compound-log.sh *), Read, Write
+allowed-tools: Bash(gh *), Bash(linearis *), Bash(jq *), Bash(git *), Bash(./plugins/dev/scripts/compound-log.sh *), Bash(plugins/dev/scripts/compound-log.sh *), Bash(./plugins/pm/scripts/estimate/refresh-corpus.sh *), Bash(plugins/pm/scripts/estimate/refresh-corpus.sh *), Read, Write
 version: 1.0.0
 ---
 
@@ -62,7 +62,7 @@ fi
 
 Prompt the user interactively (one at a time). Keep the prompts short and concrete; the estimate re-scoring is the calibration signal, so do not skip it.
 
-- **estimate_actual** — re-score the ticket on the same T-shirt scale used at ticket creation (XS=1, S=2, M=3, L=5, XL=8). Ask: "After shipping, what T-shirt would you set this ticket to? (XS/S/M/L/XL or integer 1/2/3/5/8)"
+- **estimate_actual** — re-score the ticket on the CTL-746 T-shirt → points scale (XS=1, S=3, M=5, L=8, XL=13 — the same Fibonacci mirror `phase-triage` writes to `Issue.estimate`). Ask: "After shipping, what T-shirt would you set this ticket to? (XS/S/M/L/XL or integer 1/3/5/8/13)". Off-scale integers are accepted by the helper but the corpus-refresh override ignores them — stick to the scale.
 - **what_worked** — ask: "What worked? (one or two sentences)"
 - **what_surprised_me** — ask: "What surprised you? (one or two sentences — this is the highest-signal calibration input)"
 
@@ -86,6 +86,32 @@ The helper resolves the rest:
 ### 5. Report back
 
 On success, the helper prints the target file and a one-line summary. Show that to the user.
+
+### 6. Opportunistic corpus refresh (CTL-813 — off the critical path)
+
+After a successful write, check whether the committed reference-class corpus is stale and offer to
+refresh it. **Best-effort: a refresh failure never fails the ritual.**
+
+```bash
+CORPUS="plugins/pm/scripts/estimate/reference-class-corpus.json"
+STALE=$(jq -r '
+  (.generated_at // "1970-01-01T00:00:00Z")
+  | sub("\\.[0-9]+"; "")
+  | (try fromdateiso8601 catch 0)
+  | (now - .) > 604800
+' "$CORPUS" 2>/dev/null || echo "false")
+```
+
+If `STALE` is `true` (corpus older than 7 days), tell the user and offer to run the refresh:
+
+```bash
+plugins/pm/scripts/estimate/refresh-corpus.sh
+```
+
+It re-runs Extract → Collect → Score and merges fresh entries over the committed corpus (your
+just-written `estimate_actual` flows in as the human ground-truth override). The refresh leaves the
+corpus change in the working tree — show the user the summary line and let them commit/PR it (or
+re-run with `--commit`). If the user declines or the refresh fails, log and move on.
 
 On failure, surface the helper's error verbatim. The helper fails loud with actionable messages — don't paraphrase them. Common causes and fixes:
 
@@ -118,7 +144,10 @@ plugins/dev/scripts/compound-log.sh write <ticket> [options]
 
 ## Schema of a written entry
 
-Each entry is a level-3 heading with a fenced YAML block (parseable by the forthcoming `/pm:weekly-cycle-review` aggregator):
+Each entry is a level-3 heading with a fenced YAML block. Machine consumers (CTL-813): read them
+back with `plugins/dev/scripts/compound-log.sh read` (JSON Lines) or `… aggregate` (per-ticket
+latest + calibration stats) — `refresh-corpus.sh` joins `estimate_actual` into the reference-class
+corpus as the human ground-truth override.
 
 ```markdown
 ### CTL-159 — #273 — 2026-04-24T18:32:10Z
@@ -127,8 +156,8 @@ Each entry is a level-3 heading with a fenced YAML block (parseable by the forth
 linear_key: CTL-159
 pr_number: 273
 merged_at: 2026-04-24T18:32:10Z
-estimate_at_start: 3     # team scale: 3 → M
-estimate_actual: 5       # team scale: 5 → L
+estimate_at_start: 3     # CTL-746 scale: 3 → S
+estimate_actual: 5       # CTL-746 scale: 5 → M
 cost_usd: 2.47
 wall_time_hours: 3.2
 what_worked: "Tests-first TDD kept the helper script testable."
@@ -154,5 +183,8 @@ Covers ISO-week derivation, happy-path writes, append-idempotence, dedup + `--fo
 
 - Spec: `thoughts/shared/research/2026-04-24-CTL-159-compound-closing-ritual.md`
 - Plan: `thoughts/shared/plans/2026-04-24-CTL-159-compound-closing-ritual.md`
-- Unblocks: CTL-189 (auto-invoke from `merge-pr` / `/catalyst-legacy:oneshot` Phase 5)
-- Consumer (future): `/pm:weekly-cycle-review` reads all `YYYY-WW-compound-log.md` files and joins to Linear cycle data for the retrospective
+- Auto-invoked (CTL-189/CTL-813): interactively from `merge-pr` step 12b; autonomously
+  (agent-authored re-score) from `phase-monitor-merge` after the merge lands
+- Consumers (CTL-813): `compound-log.sh read`/`aggregate` → `refresh-corpus.sh` feeds
+  `estimate_actual` into `reference-class-corpus.json`; `/catalyst-dev:ticket-retro` reads the
+  weekly files for the estimation-calibration summary

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -465,6 +465,18 @@ EOF
 humanlayer thoughts sync
 ```
 
+### 12b. Compound-estimate closing ritual (CTL-189 / CTL-813)
+
+Close the estimation loop for the just-merged ticket — invoke
+`/catalyst-dev:compound-estimate $ticket_id`. It prompts for the post-merge re-score
+(CTL-746 scale: XS=1 S=3 M=5 L=8 XL=13) plus two short reflections, appends the weekly
+compound-log entry, and offers a corpus refresh when the reference-class corpus is stale.
+That entry is what `refresh-corpus.sh` feeds back into `reference-class-corpus.json` as human
+ground truth — skipping it is how the loop falls open again.
+
+**Off the critical path**: if the user declines, the ticket was never estimated, or the skill
+errors, log one line and continue — never block the merge ritual on it.
+
 ### 13. Detect Deployments and Report Success
 
 After branch cleanup, check if the merge triggered any deployment workflows:

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -238,7 +238,57 @@ fi
 
 Deployment verification (`skipDeployVerification=false`) is **not** in this
 phase's scope — that is `phase-monitor-deploy` (plan §Initiative 1 Phase 5).
-This skill exits cleanly the moment the merge + Linear transition land.
+This skill exits cleanly the moment the merge + Linear transition land (the
+compound-log entry below is best-effort and never extends the phase on failure).
+
+## Compound-log closing entry (CTL-813 — off the critical path)
+
+After the merge + Linear transition land, write the ticket's compound-log entry
+so the estimation loop's sink fills autonomously (the unbuilt CTL-189 — in
+`merge-pr` a human answers these prompts; here YOU author them). **Best-effort:
+on ANY failure log one line and continue to the End block — never fail or
+block the phase on this.**
+
+1. **Re-score from the merged diff** (CTL-746 structural bands → points
+   XS=1 S=3 M=5 L=8 XL=13; LOC = additions+deletions: `<50→1, <200→3, <800→5,
+   <2000→8, else 13`):
+
+```bash
+LOC=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.additions + .deletions' 2>/dev/null || echo "")
+if   [[ -z "$LOC" ]];      then POINTS=""
+elif [[ "$LOC" -lt 50 ]];  then POINTS=1
+elif [[ "$LOC" -lt 200 ]]; then POINTS=3
+elif [[ "$LOC" -lt 800 ]]; then POINTS=5
+elif [[ "$LOC" -lt 2000 ]]; then POINTS=8
+else POINTS=13; fi
+```
+
+   Adjust ±1 step with judgment (e.g. heavy rework you personally resolved —
+   CI fix-up loops, rebases — justifies a bump). Skip the whole section when
+   `POINTS` is empty.
+
+2. **Author the two reflections yourself** — you just walked this PR through
+   merge, so you have the ground truth: `what_worked` (1-2 sentences) and
+   `what_surprised_me` (1-2 sentences; the BEHIND-rebase treadmill, bot review
+   threads, or flaky CI you resolved are exactly this signal).
+
+3. **Write the entry.** The helper resolves `estimate_at_start`/cost/wall from
+   its defaults; on a missing default, retry once with explicit overrides; on a
+   duplicate (re-walked phase), the "already exists" failure IS the skip path:
+
+```bash
+CL="${PLUGIN_ROOT}/scripts/compound-log.sh"
+"$CL" write "$TICKET" --pr "$PR_NUMBER" --estimate-actual "$POINTS" \
+  --what-worked "$WHAT_WORKED" --what-surprised-me "$WHAT_SURPRISED" 2>/dev/null \
+|| "$CL" write "$TICKET" --pr "$PR_NUMBER" --estimate-actual "$POINTS" \
+  --what-worked "$WHAT_WORKED" --what-surprised-me "$WHAT_SURPRISED" \
+  --cost-usd 0 --estimate-start 0 \
+|| echo "phase-monitor-merge: compound-log entry skipped (non-fatal)" >&2
+```
+
+Do NOT run the corpus refresh here (that is `compound-estimate` step 6 /
+operator cadence — a background phase worker must not mutate the committed
+corpus).
 
 ## End block
 

--- a/plugins/pm/docs/estimation-methodology.md
+++ b/plugins/pm/docs/estimation-methodology.md
@@ -2,7 +2,7 @@
 
 This document describes the **reusable, calibrated estimation pipeline** ported from the proven
 Adva pipeline (ADV-424 / ADV-458 / ADV-426) into the Catalyst PM plugin. It covers the data
-sources, the three pipeline stages, the calibrated heuristic table, the T-shirt → story-point
+sources, the pipeline stages, the calibrated heuristic table, the T-shirt → story-point
 mapping, the calibration approach, and how the orchestrator's `phase-triage` agent and the
 execution-core scheduler should consume the output.
 
@@ -11,7 +11,9 @@ The scripts live in [`plugins/pm/scripts/estimate/`](../scripts/estimate/):
 | Stage | Script | Role |
 |---|---|---|
 | **Extract** | `extract-actuals-from-transcripts.ts` | Stream session transcripts → per-ticket actuals CSV (cost, turns, wall-hours) |
+| **Collect** | `collect-ticket-signals.ts` | CTL-813: join Linear Done tickets ⋈ merged PRs (LOC/files/domains/flags) ⋈ actuals CSV ⋈ compound-log re-scores → the Score input CSV |
 | **Score** | `score-tickets.ts` | Apply the calibrated heuristic → T-shirt + points + confidence + rationale, emit a corpus JSON |
+| **Refresh** | `refresh-corpus.sh` | CTL-813: recurring orchestration Extract→Collect→Score, then MERGE fresh entries over the committed corpus (see §5.5) |
 | **Lookup** | `reference-class-lookup.ts` | Read-side k-NN: nearest closed tickets by signal similarity + their actuals distribution |
 
 This methodology is the **runtime calibration anchor**; the on-ticket data contract it feeds is the
@@ -188,8 +190,28 @@ corpus entry carries both the T-shirt and the point value.
    medians — the §3 AI-native bands.
 4. Bands are sanity-checked against the structural votes: a well-calibrated table has the actuals
    votes agreeing with the structural votes on most Tier-1 tickets (high-confidence rows).
-5. Re-run periodically as the corpus grows; the geometric-midpoint rule makes re-derivation
-   mechanical. Human-labelled tickets (`estimate-source:human`) are excluded via `--check-labels`.
+5. **Re-run mechanism (CTL-813 — this closes the loop).** `refresh-corpus.sh` is the recurring
+   producer; `adapt-reference-corpus.ts` is bootstrap-only (the historical CTL-746 `/tmp` dict —
+   its entries carry no titles/signals, so the lookup's title/domain/flag similarity components
+   are inert against them until refreshed):
+
+   ```bash
+   plugins/pm/scripts/estimate/refresh-corpus.sh           # Extract → Collect → Score → merge
+   plugins/pm/scripts/estimate/refresh-corpus.sh --dry-run # preview the old→new summary
+   ```
+
+   - **Merge semantics**: fresh entries REPLACE same-ticket entries; entries not re-scored
+     (e.g. cross-repo ADV anchors whose PRs aren't in this repo) are RETAINED; `generated_at`
+     advances and the entry count never shrinks (guarded; `--force` to override).
+   - **Human ground truth**: the Collect step joins `compound-log.sh aggregate` — a ticket's
+     post-merge `estimate_actual` re-score overrides the voted score (`confidence: high`,
+     rationale annotated) and anchors the Tier-4 NN pool.
+   - **Cadence**: opportunistic — `compound-estimate` step 6 offers a refresh whenever the
+     committed corpus is >7 days old; run it manually (or via a scheduled routine) otherwise.
+     The compound-log sink fills at every merge: interactively via `merge-pr` step 12b, and
+     autonomously (agent-authored re-score) via `phase-monitor-merge`.
+   - Human-labelled tickets (`estimate-source:human`) are excluded via `--check-labels` (on by
+     default in the refresh).
 
 ---
 
@@ -215,7 +237,10 @@ scheduler, NOT in the phase-triage skill**. The scheduler picks up the proposed 
 
 - **OVERWRITE semantics**: the scheduler write **overwrites** the existing machine estimate (the
   estimate is derived, not hand-tuned), **except** when the ticket carries `estimate-source:human` —
-  human estimates are never clobbered (same guard as `score-tickets --check-labels`).
+  human estimates are never clobbered (same guard as `score-tickets --check-labels`). Enforced
+  since CTL-813 in `linear-write.mjs applyEstimate()`: it pre-reads the ticket's labels and skips
+  with `{skipped: "human-estimate"}`; an unreadable label set fails OPEN (matching the
+  `score-tickets --check-labels` precedent), since the scheduler's write is one-shot.
 - Putting the write in the scheduler (not the skill) preserves the CTL-497 negative guard in the
   execution-core e2e test and keeps the skill a pure read-only proposer.
 

--- a/plugins/pm/scripts/estimate/__tests__/collect-ticket-signals.test.ts
+++ b/plugins/pm/scripts/estimate/__tests__/collect-ticket-signals.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildSignalRows,
+  domainOf,
+  domainsFromPaths,
+  hoursBetween,
+  indexPrsByTicket,
+  parseActualsCsv,
+  parseCompoundAggregate,
+  structuralFlags,
+  ticketIdFromPr,
+  toCsv,
+  type LinearTicket,
+  type MergedPr,
+} from "../collect-ticket-signals";
+import { parseCsv } from "../score-tickets";
+
+// -- fixtures -----------------------------------------------------------------
+
+function pr(over: Partial<MergedPr> = {}): MergedPr {
+  return {
+    number: 100,
+    title: "feat(dev): something (CTL-100)",
+    headRefName: "ryan/ctl-100-something",
+    createdAt: "2026-06-01T00:00:00Z",
+    mergedAt: "2026-06-01T06:00:00Z",
+    additions: 120,
+    deletions: 30,
+    changedFiles: 4,
+    files: [
+      { path: "plugins/dev/scripts/foo.mjs", additions: 100, deletions: 20 },
+      { path: "plugins/pm/docs/bar.md", additions: 20, deletions: 10 },
+    ],
+    ...over,
+  };
+}
+
+function ticket(over: Partial<LinearTicket> = {}): LinearTicket {
+  return {
+    identifier: "CTL-100",
+    title: "something",
+    state: "Done",
+    priority: 2,
+    project: "",
+    created_at: "2026-05-30T00:00:00Z",
+    updated_at: "2026-06-01T07:00:00Z",
+    estimate: 3,
+    ...over,
+  };
+}
+
+// -- ticketIdFromPr -------------------------------------------------------------
+
+describe("ticketIdFromPr", () => {
+  test("extracts from lowercase branch name", () => {
+    expect(ticketIdFromPr(pr({ headRefName: "ryan/ctl-813-loop", title: "x" }), ["CTL"])).toBe(
+      "CTL-813",
+    );
+  });
+
+  test("extracts from uppercase branch name", () => {
+    expect(ticketIdFromPr(pr({ headRefName: "CTL-42", title: "x" }), ["CTL"])).toBe("CTL-42");
+  });
+
+  test("falls back to PR title when branch has no id", () => {
+    expect(
+      ticketIdFromPr(pr({ headRefName: "fix/concepts-shared-sync", title: "fix: x (CTL-789)" }), [
+        "CTL",
+      ]),
+    ).toBe("CTL-789");
+  });
+
+  test("non-matching team is ignored", () => {
+    expect(ticketIdFromPr(pr({ headRefName: "adv-12-foo", title: "ADV-12" }), ["CTL"])).toBeNull();
+  });
+
+  test("multiple teams accepted", () => {
+    expect(ticketIdFromPr(pr({ headRefName: "adv-12-foo", title: "" }), ["CTL", "ADV"])).toBe(
+      "ADV-12",
+    );
+  });
+
+  test("branch id wins over a different title id", () => {
+    expect(
+      ticketIdFromPr(pr({ headRefName: "ryan/ctl-1-a", title: "dup of (CTL-2)" }), ["CTL"]),
+    ).toBe("CTL-1");
+  });
+});
+
+// -- domains + flags --------------------------------------------------------------
+
+describe("domainOf / domainsFromPaths", () => {
+  test("plugins keep two segments", () => {
+    expect(domainOf("plugins/dev/scripts/foo.mjs")).toBe("plugins/dev");
+  });
+
+  test("non-plugins use first segment", () => {
+    expect(domainOf("website/src/pages/index.astro")).toBe("website");
+    expect(domainOf("CLAUDE.md")).toBe("CLAUDE.md");
+  });
+
+  test("domainsFromPaths dedupes and sorts", () => {
+    expect(
+      domainsFromPaths([
+        "website/a.ts",
+        "plugins/dev/x.mjs",
+        "plugins/dev/y.mjs",
+        "plugins/pm/z.ts",
+      ]),
+    ).toEqual(["plugins/dev", "plugins/pm", "website"]);
+  });
+});
+
+describe("structuralFlags", () => {
+  test("migration path sets has_migration", () => {
+    expect(structuralFlags(["db/migrations/001.sql"]).has_migration).toBe(true);
+  });
+
+  test("website path is frontend, not backend", () => {
+    const f = structuralFlags(["website/src/x.ts"]);
+    expect(f.has_frontend).toBe(true);
+    expect(f.has_backend).toBe(false);
+  });
+
+  test(".mjs script is backend", () => {
+    const f = structuralFlags(["plugins/dev/scripts/execution-core/scheduler.mjs"]);
+    expect(f.has_backend).toBe(true);
+    expect(f.has_frontend).toBe(false);
+  });
+
+  test(".tsx is frontend even outside website/", () => {
+    expect(structuralFlags(["plugins/dev/scripts/orch-monitor/src/App.tsx"]).has_frontend).toBe(
+      true,
+    );
+  });
+
+  test("markdown-only change has no flags", () => {
+    const f = structuralFlags(["docs/adrs.md"]);
+    expect(f).toEqual({ has_migration: false, has_frontend: false, has_backend: false });
+  });
+});
+
+// -- parsers ---------------------------------------------------------------------
+
+describe("parseActualsCsv", () => {
+  const csv = [
+    `"ticket_id","session_count","otel_cost_usd","otel_input_tokens","otel_output_tokens","otel_turns","otel_wall_time_hours","otel_tool_success_rate","models","branches"`,
+    `"CTL-100","2","12.3456","1000","2000","42","1.5000","","claude-opus-4-7","ryan/ctl-100"`,
+  ].join("\n");
+
+  test("maps ticket to otel columns", () => {
+    const m = parseActualsCsv(csv);
+    expect(m.get("CTL-100")).toEqual({
+      otel_cost_usd: "12.3456",
+      otel_input_tokens: "1000",
+      otel_output_tokens: "2000",
+      otel_turns: "42",
+      otel_wall_time_hours: "1.5000",
+      otel_tool_success_rate: "",
+    });
+  });
+
+  test("empty content yields empty map", () => {
+    expect(parseActualsCsv("").size).toBe(0);
+  });
+});
+
+describe("parseCompoundAggregate", () => {
+  test("extracts numeric estimate_actual per ticket", () => {
+    const m = parseCompoundAggregate(
+      JSON.stringify({
+        entries: 2,
+        tickets: {
+          "CTL-1": { estimate_actual: 5 },
+          "CTL-2": { estimate_actual: null },
+        },
+      }),
+    );
+    expect(m.get("CTL-1")).toBe(5);
+    expect(m.has("CTL-2")).toBe(false);
+  });
+
+  test("malformed JSON yields empty map (fail-open)", () => {
+    expect(parseCompoundAggregate("not json").size).toBe(0);
+  });
+
+  test("missing tickets key yields empty map", () => {
+    expect(parseCompoundAggregate("{}").size).toBe(0);
+  });
+});
+
+describe("hoursBetween", () => {
+  test("6 hours", () => {
+    expect(hoursBetween("2026-06-01T00:00:00Z", "2026-06-01T06:00:00Z")).toBe(6);
+  });
+  test("bad input → null", () => {
+    expect(hoursBetween("nope", "2026-06-01T06:00:00Z")).toBeNull();
+  });
+});
+
+// -- indexPrsByTicket --------------------------------------------------------------
+
+describe("indexPrsByTicket", () => {
+  test("first (latest-merged) PR wins per ticket", () => {
+    const newer = pr({ number: 2, mergedAt: "2026-06-02T00:00:00Z" });
+    const older = pr({ number: 1, mergedAt: "2026-06-01T00:00:00Z" });
+    const map = indexPrsByTicket([newer, older], ["CTL"]); // gh emits newest first
+    expect(map.get("CTL-100")?.number).toBe(2);
+  });
+});
+
+// -- buildSignalRows + toCsv ---------------------------------------------------------
+
+describe("buildSignalRows", () => {
+  const actuals = parseActualsCsv(
+    [
+      `"ticket_id","session_count","otel_cost_usd","otel_input_tokens","otel_output_tokens","otel_turns","otel_wall_time_hours","otel_tool_success_rate","models","branches"`,
+      `"CTL-100","1","42.0000","10","20","33","2.0000","","m","b"`,
+      `"CTL-200","1","9.9900","5","6","12","0.5000","","m","b"`,
+    ].join("\n"),
+  );
+
+  test("full join: PR + actuals + human re-score", () => {
+    const rows = buildSignalRows(
+      [ticket()],
+      new Map([["CTL-100", pr()]]),
+      actuals,
+      new Map([["CTL-100", 5]]),
+    );
+    expect(rows).toHaveLength(1);
+    const r = rows[0];
+    expect(r.ticket_id).toBe("CTL-100");
+    expect(r.pr_number).toBe("100");
+    expect(r.additions).toBe("120");
+    expect(r.closed_at).toBe("2026-06-01T06:00:00Z"); // PR mergedAt, not updated_at
+    expect(r.hours_to_merge).toBe("6.00");
+    expect(r.otel_cost_usd).toBe("42.0000");
+    expect(r.domains_touched).toBe("plugins/dev|plugins/pm");
+    expect(r.has_backend).toBe("true");
+    expect(r.has_frontend).toBe("false");
+    expect(r.human_actual_points).toBe("5");
+  });
+
+  test("actuals-only ticket kept with updated_at as closed_at", () => {
+    const rows = buildSignalRows(
+      [ticket({ identifier: "CTL-200", title: "no pr matched" })],
+      new Map(),
+      actuals,
+      new Map(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].pr_number).toBe("");
+    expect(rows[0].closed_at).toBe("2026-06-01T07:00:00Z");
+    expect(rows[0].otel_cost_usd).toBe("9.9900");
+    expect(rows[0].has_backend).toBe(""); // no paths → flags unknown, not false
+  });
+
+  test("ticket with neither PR nor actuals is dropped", () => {
+    const rows = buildSignalRows(
+      [ticket({ identifier: "CTL-300" })],
+      new Map(),
+      new Map(),
+      new Map(),
+    );
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe("toCsv", () => {
+  test("round-trips through score-tickets parseCsv with extra column intact", () => {
+    const rows = buildSignalRows(
+      [ticket({ title: 'has "quotes", commas' })],
+      new Map([["CTL-100", pr()]]),
+      new Map(),
+      new Map([["CTL-100", 8]]),
+    );
+    const parsed = parseCsv(toCsv(rows));
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].ticket_id).toBe("CTL-100");
+    expect(parsed[0].title).toBe('has "quotes", commas');
+    expect(
+      (parsed[0] as unknown as Record<string, string>).human_actual_points,
+    ).toBe("8");
+  });
+});

--- a/plugins/pm/scripts/estimate/__tests__/refresh-corpus-integration.test.ts
+++ b/plugins/pm/scripts/estimate/__tests__/refresh-corpus-integration.test.ts
@@ -1,0 +1,200 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+/**
+ * CTL-813 loop-reopen regression gate.
+ *
+ * The estimator's backward path was DEAD from CTL-751 until CTL-813: the
+ * committed corpus had a single one-shot commit and nothing regenerated it.
+ * This test runs the real refresh-corpus.sh (offline, via the --signals
+ * seam) and fails if the loop re-opens:
+ *
+ *   - generated_at must ADVANCE on refresh
+ *   - entry count must GROW when new actuals appear
+ *   - fresh entries must REPLACE stale same-ticket entries (full signals)
+ *   - entries not re-scored (cross-repo anchors) must be RETAINED
+ *   - the compound-log human re-score must survive into the corpus
+ *
+ * The pre-existing lookup-corpus-integration.test.ts only proves the corpus
+ * stays LOADABLE — it cannot detect a frozen corpus.
+ */
+
+const SCRIPT = resolve(import.meta.dir, "../refresh-corpus.sh");
+
+const CSV_HEADER =
+  '"ticket_id","title","state","closed_at","current_estimate","pr_number","additions","deletions","changed_files","domains_touched","has_migration","has_frontend","has_backend","otel_cost_usd","otel_turns","otel_wall_time_hours","human_actual_points"';
+
+// CTL-9001: LOC=400→M, files=6→M, domains=1→S → mode M; human override 8 → L.
+const ROW_9001 =
+  '"CTL-9001","wire refresh corpus orchestration","Done","2026-06-05T10:00:00Z","5","1401","300","100","6","plugins/pm","false","false","true","","","","8"';
+// CTL-9002: LOC=45→XS, files=1→XS → XS (points 1). Replaces a STALE old entry.
+const ROW_9002 =
+  '"CTL-9002","fix broker bug","Done","2026-06-05T11:00:00Z","3","1402","40","5","1","plugins/dev","false","false","true","","","",""';
+// CTL-9003: appears only in the v2 fixture — the growth probe.
+const ROW_9003 =
+  '"CTL-9003","add monitor panel","Done","2026-06-06T09:00:00Z","","1403","150","20","3","plugins/dev","false","true","true","","","",""';
+
+const OLD_CORPUS = {
+  generated_at: "2020-01-01T00:00:00.000Z",
+  schema: "catalyst.estimation.corpus.v1",
+  count: 2,
+  entries: [
+    {
+      // Stale CTL-751-bootstrap-shaped entry: degraded signals, wrong points.
+      ticket_id: "CTL-9002",
+      title: "",
+      tier: null,
+      tshirt: "M",
+      points: 5,
+      confidence: "low",
+      rationale: "reconstructed from CTL-746 actuals corpus",
+      signals: {
+        loc: null,
+        changed_files: null,
+        domains: [],
+        has_migration: false,
+        has_frontend: false,
+        has_backend: false,
+      },
+      actuals: { cost_usd: 12.5, turns: 80, wall_hours: 1.2 },
+    },
+    {
+      // Cross-repo anchor (its PRs live in another repo) — must be retained.
+      ticket_id: "ADV-1",
+      title: "",
+      tier: null,
+      tshirt: "S",
+      points: 3,
+      confidence: "low",
+      rationale: "reconstructed from CTL-746 actuals corpus",
+      signals: {
+        loc: 120,
+        changed_files: 4,
+        domains: [],
+        has_migration: false,
+        has_frontend: false,
+        has_backend: false,
+      },
+      actuals: { cost_usd: 30.1, turns: 150, wall_hours: 0.9 },
+    },
+  ],
+};
+
+let dir: string;
+
+function runRefresh(args: string[]): { code: number; stdout: string; stderr: string } {
+  const proc = Bun.spawnSync(["bash", SCRIPT, ...args], { cwd: dir });
+  return {
+    code: proc.exitCode,
+    stdout: proc.stdout.toString(),
+    stderr: proc.stderr.toString(),
+  };
+}
+
+function readCorpus(path: string): {
+  generated_at: string;
+  count: number;
+  entries: Array<{
+    ticket_id: string;
+    title: string;
+    points: number;
+    confidence: string;
+    rationale: string;
+    signals: { loc: number | null; domains: string[] };
+  }>;
+} {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "refresh-corpus-test-"));
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("refresh-corpus.sh (offline via --signals seam)", () => {
+  test("refresh advances generated_at, replaces stale entries, retains anchors, honors human re-score", () => {
+    const signals = join(dir, "signals-v1.csv");
+    const corpus = join(dir, "corpus.json");
+    writeFileSync(signals, [CSV_HEADER, ROW_9001, ROW_9002].join("\n") + "\n");
+    writeFileSync(corpus, JSON.stringify(OLD_CORPUS, null, 2));
+
+    const r = runRefresh(["--signals", signals, "--corpus", corpus, "--no-check-labels"]);
+    expect(r.code).toBe(0);
+
+    const c = readCorpus(corpus);
+    // generated_at advanced past the frozen bootstrap timestamp.
+    expect(c.generated_at > OLD_CORPUS.generated_at).toBe(true);
+    // 2 fresh + 1 retained anchor.
+    expect(c.count).toBe(3);
+    expect(c.entries.map((e) => e.ticket_id).sort()).toEqual(["ADV-1", "CTL-9001", "CTL-9002"]);
+
+    // Fresh CTL-9002 REPLACED the stale degraded entry: full signals now.
+    const e9002 = c.entries.find((e) => e.ticket_id === "CTL-9002");
+    expect(e9002?.title).toBe("fix broker bug");
+    expect(e9002?.points).toBe(1); // XS from LOC=45/files=1, not the stale 5
+    expect(e9002?.signals.loc).toBe(45);
+    expect(e9002?.signals.domains).toEqual(["plugins/dev"]);
+
+    // Human re-score override survives into the corpus.
+    const e9001 = c.entries.find((e) => e.ticket_id === "CTL-9001");
+    expect(e9001?.points).toBe(8);
+    expect(e9001?.confidence).toBe("high");
+    expect(e9001?.rationale).toContain("human re-score override");
+
+    // Cross-repo anchor retained untouched.
+    const adv = c.entries.find((e) => e.ticket_id === "ADV-1");
+    expect(adv?.points).toBe(3);
+  });
+
+  test("entry count GROWS when new actuals appear (the loop-reopen probe)", () => {
+    const signals = join(dir, "signals-v2.csv");
+    const corpus = join(dir, "corpus.json"); // continues from the previous test
+    writeFileSync(signals, [CSV_HEADER, ROW_9001, ROW_9002, ROW_9003].join("\n") + "\n");
+
+    const before = readCorpus(corpus);
+    const r = runRefresh(["--signals", signals, "--corpus", corpus, "--no-check-labels"]);
+    expect(r.code).toBe(0);
+
+    const after = readCorpus(corpus);
+    expect(after.count).toBe(before.count + 1);
+    expect(after.entries.some((e) => e.ticket_id === "CTL-9003")).toBe(true);
+    expect(after.generated_at > before.generated_at).toBe(true);
+  });
+
+  test("--dry-run leaves the corpus byte-identical", () => {
+    const signals = join(dir, "signals-v1.csv");
+    const corpus = join(dir, "corpus.json");
+    const before = readFileSync(corpus, "utf8");
+
+    const r = runRefresh(["--signals", signals, "--corpus", corpus, "--no-check-labels", "--dry-run"]);
+    expect(r.code).toBe(0);
+    expect(readFileSync(corpus, "utf8")).toBe(before);
+  });
+
+  test("missing/empty signals CSV fails loud", () => {
+    const corpus = join(dir, "corpus.json");
+    const r = runRefresh([
+      "--signals",
+      join(dir, "does-not-exist.csv"),
+      "--corpus",
+      corpus,
+      "--no-check-labels",
+    ]);
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toContain("signals CSV");
+  });
+
+  test("bootstrapping with no existing corpus file works", () => {
+    const signals = join(dir, "signals-v1.csv");
+    const corpus = join(dir, "fresh-start.json");
+    const r = runRefresh(["--signals", signals, "--corpus", corpus, "--no-check-labels"]);
+    expect(r.code).toBe(0);
+    const c = readCorpus(corpus);
+    expect(c.count).toBe(2);
+  });
+});

--- a/plugins/pm/scripts/estimate/__tests__/score-tickets-human-override.test.ts
+++ b/plugins/pm/scripts/estimate/__tests__/score-tickets-human-override.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import {
+  applyHumanOverride,
+  buildCorpusEntry,
+  humanOverridePoints,
+  parseCsv,
+  scoreRow,
+  type SignalRow,
+} from "../score-tickets";
+
+// CTL-813: the compound-log human re-score (`human_actual_points` column from
+// collect-ticket-signals) overrides the voted score — a post-merge human
+// ground truth beats any heuristic vote, so the corpus entry should carry it.
+
+function row(over: Partial<SignalRow> = {}): SignalRow {
+  return {
+    ticket_id: "CTL-1",
+    title: "a medium ticket",
+    state: "Done",
+    priority: "2",
+    project: "",
+    created_at: "2026-06-01T00:00:00Z",
+    closed_at: "2026-06-02T00:00:00Z",
+    current_estimate: "3",
+    pr_number: "10",
+    additions: "100",
+    deletions: "50",
+    changed_files: "3",
+    commits: "",
+    review_comments: "",
+    ci_runs: "",
+    hours_to_merge: "4.0",
+    had_force_push: "",
+    otel_cost_usd: "",
+    otel_input_tokens: "",
+    otel_output_tokens: "",
+    otel_turns: "",
+    otel_wall_time_hours: "",
+    otel_tool_success_rate: "",
+    domains_touched: "plugins/dev",
+    has_migration: "false",
+    has_frontend: "false",
+    has_backend: "true",
+    ...over,
+  };
+}
+
+describe("humanOverridePoints", () => {
+  test("valid fib points parse", () => {
+    for (const v of ["1", "3", "5", "8", "13"]) {
+      expect(humanOverridePoints(row({ human_actual_points: v }))).toBe(Number(v));
+    }
+  });
+
+  test("non-fib, non-numeric, and absent values → null", () => {
+    expect(humanOverridePoints(row({ human_actual_points: "4" }))).toBeNull();
+    expect(humanOverridePoints(row({ human_actual_points: "x" }))).toBeNull();
+    expect(humanOverridePoints(row({ human_actual_points: "" }))).toBeNull();
+    expect(humanOverridePoints(row())).toBeNull();
+  });
+});
+
+describe("applyHumanOverride", () => {
+  test("override rewrites tshirt/points/confidence and annotates rationale", () => {
+    const r = row({ human_actual_points: "8" });
+    const scored = applyHumanOverride(scoreRow(r, 2, []), r);
+    expect(scored.points).toBe(8);
+    expect(scored.proposed_tshirt).toBe("L");
+    expect(scored.confidence).toBe("high");
+    expect(scored.reasoning).toContain("human re-score override");
+  });
+
+  test("no column → scored result unchanged", () => {
+    const r = row();
+    const base = scoreRow(r, 2, []);
+    expect(applyHumanOverride(base, r)).toEqual(base);
+  });
+
+  test("invalid value → scored result unchanged", () => {
+    const r = row({ human_actual_points: "4" });
+    const base = scoreRow(r, 2, []);
+    expect(applyHumanOverride(base, r)).toEqual(base);
+  });
+
+  test("corpus entry carries the overridden points", () => {
+    const r = row({ human_actual_points: "13" });
+    const entry = buildCorpusEntry(r, applyHumanOverride(scoreRow(r, 2, []), r));
+    expect(entry.points).toBe(13);
+    expect(entry.tshirt).toBe("XL");
+    expect(entry.confidence).toBe("high");
+  });
+});
+
+describe("parseCsv carries the extra column", () => {
+  test("human_actual_points survives CSV parsing", () => {
+    const csv = [
+      `"ticket_id","title","state","closed_at","pr_number","additions","deletions","changed_files","human_actual_points"`,
+      `"CTL-9","t","Done","2026-06-01T00:00:00Z","1","10","5","2","5"`,
+    ].join("\n");
+    const rows = parseCsv(csv);
+    expect(rows[0].human_actual_points).toBe("5");
+  });
+});

--- a/plugins/pm/scripts/estimate/collect-ticket-signals.ts
+++ b/plugins/pm/scripts/estimate/collect-ticket-signals.ts
@@ -1,0 +1,474 @@
+#!/usr/bin/env bun
+/**
+ * Collect per-ticket SIGNALS into the score-tickets input CSV (CTL-813).
+ *
+ * This is the missing JOIN step of the corpus-refresh write side:
+ *
+ *   Extract (extract-actuals-from-transcripts.ts)
+ *        ↘ actuals.csv (otel_* columns)
+ *   Linear (linearis issues list --status Done)   ──┐
+ *   GitHub (gh pr list --state merged + files[])  ──┼→ Collect (this script) → signals.csv → Score
+ *   compound-log (compound-log.sh aggregate)      ──┘
+ *
+ * Output columns are score-tickets.ts SignalRow plus `human_actual_points`
+ * (the per-ticket post-merge human re-score from the compound-log — the
+ * ground-truth override Score honors when present).
+ *
+ * v1 limitations (documented, not silent):
+ *   - commits / review_comments / ci_runs / had_force_push are emitted EMPTY.
+ *     Filling them needs per-PR timeline API calls (an API storm); Score
+ *     simply casts no vote / skips the modifier for empty columns. Entries
+ *     are still strictly richer than the CTL-751 bootstrap corpus (which had
+ *     NO structural signals at all).
+ *   - Only PRs in the CURRENT repo are matched (gh pr list runs in cwd), so
+ *     run it from the repo whose team you pass. Cross-repo teams (e.g. ADV
+ *     anchors in the committed corpus) are preserved by refresh-corpus.sh's
+ *     merge step, not re-collected here.
+ *
+ * Usage:
+ *   bun collect-ticket-signals.ts --team CTL --out signals.csv \
+ *     [--actuals actuals.csv] [--compound-log aggregate.json] \
+ *     [--limit 250] [--pr-limit 1000] [--dry-run] [--verbose]
+ *
+ * Dependency-light: bun + node builtins; shells to `linearis` and `gh`.
+ */
+
+import { mkdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { splitCsvLine } from "./score-tickets";
+
+// -- Types --------------------------------------------------------------------
+
+export interface LinearTicket {
+  identifier: string;
+  title: string;
+  state: string;
+  priority: number | null;
+  project: string;
+  created_at: string;
+  updated_at: string;
+  estimate: number | null;
+}
+
+export interface PrFile {
+  path: string;
+  additions: number;
+  deletions: number;
+}
+
+export interface MergedPr {
+  number: number;
+  title: string;
+  headRefName: string;
+  createdAt: string;
+  mergedAt: string;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  files: PrFile[];
+}
+
+export interface ActualsRow {
+  otel_cost_usd: string;
+  otel_input_tokens: string;
+  otel_output_tokens: string;
+  otel_turns: string;
+  otel_wall_time_hours: string;
+  otel_tool_success_rate: string;
+}
+
+/** One output row — SignalRow columns + the human re-score override. */
+export type OutputRow = Record<(typeof OUTPUT_HEADERS)[number], string>;
+
+export const OUTPUT_HEADERS = [
+  "ticket_id",
+  "title",
+  "state",
+  "priority",
+  "project",
+  "created_at",
+  "closed_at",
+  "current_estimate",
+  "pr_number",
+  "additions",
+  "deletions",
+  "changed_files",
+  "commits",
+  "review_comments",
+  "ci_runs",
+  "hours_to_merge",
+  "had_force_push",
+  "otel_cost_usd",
+  "otel_input_tokens",
+  "otel_output_tokens",
+  "otel_turns",
+  "otel_wall_time_hours",
+  "otel_tool_success_rate",
+  "domains_touched",
+  "has_migration",
+  "has_frontend",
+  "has_backend",
+  "human_actual_points",
+] as const;
+
+// -- Ticket-id extraction -------------------------------------------------------
+
+/**
+ * Extract a ticket id for the given teams from a merged PR. Branch name wins
+ * (orchestrator branches embed the id: `ryan/ctl-813-...`, `CTL-813`); the PR
+ * title is the fallback (`feat(dev): ... (CTL-813)`). Case-insensitive;
+ * returns the UPPERCASED id or null.
+ */
+export function ticketIdFromPr(
+  pr: Pick<MergedPr, "headRefName" | "title">,
+  teams: string[],
+): string | null {
+  const pattern = new RegExp(`\\b(${teams.join("|")})-(\\d+)\\b`, "i");
+  for (const source of [pr.headRefName, pr.title]) {
+    const m = pattern.exec(source ?? "");
+    if (m) return `${m[1].toUpperCase()}-${m[2]}`;
+  }
+  return null;
+}
+
+// -- Domain + structural-flag heuristics ----------------------------------------
+
+/**
+ * Top-level domain of a repo path. `plugins/<name>` keeps two segments (the
+ * plugin is the unit of distribution); everything else is the first segment.
+ * Matches the methodology's "distinct pkgs" intent (estimation-methodology §1b).
+ */
+export function domainOf(path: string): string {
+  const parts = path.split("/");
+  if (parts[0] === "plugins" && parts.length > 1) return `plugins/${parts[1]}`;
+  return parts[0];
+}
+
+export function domainsFromPaths(paths: string[]): string[] {
+  return [...new Set(paths.map(domainOf))].sort();
+}
+
+const FRONTEND_RE = /^website\/|\/orch-monitor\/src\/|\.(tsx|css)$/;
+const BACKEND_RE = /\.(mjs|ts|sh)$/;
+
+/**
+ * Structural flags for the Score floors/modifiers. Catalyst-tuned:
+ * frontend = website/ or the orch-monitor SPA or .tsx/.css; backend = script
+ * code (.mjs/.ts/.sh) that is not a frontend path. has_migration keys off the
+ * path containing "migration" (rare in this repo, kept for schema parity).
+ */
+export function structuralFlags(paths: string[]): {
+  has_migration: boolean;
+  has_frontend: boolean;
+  has_backend: boolean;
+} {
+  let has_migration = false;
+  let has_frontend = false;
+  let has_backend = false;
+  for (const p of paths) {
+    if (/migration/i.test(p)) has_migration = true;
+    if (FRONTEND_RE.test(p)) has_frontend = true;
+    else if (BACKEND_RE.test(p)) has_backend = true;
+  }
+  return { has_migration, has_frontend, has_backend };
+}
+
+// -- Actuals CSV parsing ---------------------------------------------------------
+
+/** Parse the Extract step's actuals CSV into a ticket_id → otel columns map. */
+export function parseActualsCsv(content: string): Map<string, ActualsRow> {
+  const map = new Map<string, ActualsRow>();
+  const lines = content.trim().split("\n");
+  if (lines.length < 2) return map;
+  const headers = splitCsvLine(lines[0]).map((h) => h.trim());
+  for (let i = 1; i < lines.length; i++) {
+    if (!lines[i].trim()) continue;
+    const values = splitCsvLine(lines[i]);
+    const row: Record<string, string> = {};
+    for (let j = 0; j < headers.length; j++) row[headers[j]] = values[j] ?? "";
+    if (!row.ticket_id) continue;
+    map.set(row.ticket_id.toUpperCase(), {
+      otel_cost_usd: row.otel_cost_usd ?? "",
+      otel_input_tokens: row.otel_input_tokens ?? "",
+      otel_output_tokens: row.otel_output_tokens ?? "",
+      otel_turns: row.otel_turns ?? "",
+      otel_wall_time_hours: row.otel_wall_time_hours ?? "",
+      otel_tool_success_rate: row.otel_tool_success_rate ?? "",
+    });
+  }
+  return map;
+}
+
+// -- Compound-log aggregate parsing ----------------------------------------------
+
+/**
+ * ticket_id → estimate_actual from `compound-log.sh aggregate` output.
+ * Anything non-numeric is dropped; Score re-validates against the allowed
+ * points scale.
+ */
+export function parseCompoundAggregate(json: string): Map<string, number> {
+  const map = new Map<string, number>();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return map;
+  }
+  const tickets = (parsed as { tickets?: Record<string, { estimate_actual?: unknown }> })
+    ?.tickets;
+  if (!tickets || typeof tickets !== "object") return map;
+  for (const [key, entry] of Object.entries(tickets)) {
+    const v = entry?.estimate_actual;
+    if (typeof v === "number" && Number.isFinite(v)) map.set(key.toUpperCase(), v);
+  }
+  return map;
+}
+
+// -- Join -------------------------------------------------------------------------
+
+export function hoursBetween(fromIso: string, toIso: string): number | null {
+  const t0 = Date.parse(fromIso);
+  const t1 = Date.parse(toIso);
+  if (!Number.isFinite(t0) || !Number.isFinite(t1)) return null;
+  return (t1 - t0) / 3_600_000;
+}
+
+/**
+ * Join Linear tickets with their merged PR, transcript actuals, and the
+ * compound-log human re-score into score-tickets input rows.
+ *
+ * closed_at: linearis never populates completedAt, so the merged PR's
+ * mergedAt is the closed timestamp; tickets without a matched PR fall back
+ * to updated_at (every input ticket is Done by query). Tickets with NEITHER
+ * a PR nor actuals are dropped — they would score as signal-less default-M
+ * noise (Tier 3 with zero votes).
+ */
+export function buildSignalRows(
+  tickets: LinearTicket[],
+  prsByTicket: Map<string, MergedPr>,
+  actuals: Map<string, ActualsRow>,
+  humanActuals: Map<string, number>,
+  opts: { verbose?: boolean } = {},
+): OutputRow[] {
+  const rows: OutputRow[] = [];
+  for (const t of tickets) {
+    const id = t.identifier.toUpperCase();
+    const pr = prsByTicket.get(id) ?? null;
+    const act = actuals.get(id) ?? null;
+    if (!pr && !act) {
+      if (opts.verbose) console.log(`  [collect] ${id}: no PR + no actuals — dropped`);
+      continue;
+    }
+    const paths = pr ? pr.files.map((f) => f.path) : [];
+    const flags = structuralFlags(paths);
+    const human = humanActuals.get(id);
+    const hours =
+      pr && pr.createdAt && pr.mergedAt ? hoursBetween(pr.createdAt, pr.mergedAt) : null;
+    rows.push({
+      ticket_id: id,
+      title: t.title ?? "",
+      state: t.state ?? "",
+      priority: t.priority != null ? String(t.priority) : "",
+      project: t.project ?? "",
+      created_at: t.created_at ?? "",
+      closed_at: pr?.mergedAt || t.updated_at || "",
+      current_estimate: t.estimate != null ? String(t.estimate) : "",
+      pr_number: pr ? String(pr.number) : "",
+      additions: pr ? String(pr.additions) : "",
+      deletions: pr ? String(pr.deletions) : "",
+      changed_files: pr ? String(pr.changedFiles) : "",
+      commits: "",
+      review_comments: "",
+      ci_runs: "",
+      hours_to_merge: hours != null ? hours.toFixed(2) : "",
+      had_force_push: "",
+      otel_cost_usd: act?.otel_cost_usd ?? "",
+      otel_input_tokens: act?.otel_input_tokens ?? "",
+      otel_output_tokens: act?.otel_output_tokens ?? "",
+      otel_turns: act?.otel_turns ?? "",
+      otel_wall_time_hours: act?.otel_wall_time_hours ?? "",
+      otel_tool_success_rate: act?.otel_tool_success_rate ?? "",
+      domains_touched: domainsFromPaths(paths).join("|"),
+      has_migration: paths.length ? String(flags.has_migration) : "",
+      has_frontend: paths.length ? String(flags.has_frontend) : "",
+      has_backend: paths.length ? String(flags.has_backend) : "",
+      human_actual_points: human != null ? String(human) : "",
+    });
+  }
+  return rows;
+}
+
+// -- CSV output ---------------------------------------------------------------------
+
+function csvQuote(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+export function toCsv(rows: OutputRow[]): string {
+  const header = OUTPUT_HEADERS.map(csvQuote).join(",");
+  const lines = rows.map((r) => OUTPUT_HEADERS.map((h) => csvQuote(r[h])).join(","));
+  return [header, ...lines].join("\n") + "\n";
+}
+
+// -- External fetchers (CLI shells; injectable in tests via the pure join) ----------
+
+async function run(cmd: string[]): Promise<string> {
+  const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe", stdin: "ignore" });
+  const code = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  if (code !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`${cmd[0]} ${cmd[1] ?? ""} failed (exit ${code}): ${stderr.slice(0, 400)}`);
+  }
+  return stdout;
+}
+
+export async function fetchDoneTickets(team: string, limit: number): Promise<LinearTicket[]> {
+  const out = await run([
+    "linearis",
+    "issues",
+    "list",
+    "--team",
+    team,
+    "--status",
+    "Done",
+    "--limit",
+    String(limit),
+  ]);
+  const parsed = JSON.parse(out) as {
+    nodes: Array<{
+      identifier: string;
+      title?: string;
+      state?: { name?: string };
+      priority?: number;
+      project?: { name?: string } | null;
+      createdAt?: string;
+      updatedAt?: string;
+      estimate?: number | null;
+    }>;
+  };
+  return (parsed.nodes ?? []).map((n) => ({
+    identifier: n.identifier,
+    title: n.title ?? "",
+    state: n.state?.name ?? "Done",
+    priority: typeof n.priority === "number" ? n.priority : null,
+    project: n.project?.name ?? "",
+    created_at: n.createdAt ?? "",
+    updated_at: n.updatedAt ?? "",
+    estimate: typeof n.estimate === "number" ? n.estimate : null,
+  }));
+}
+
+export async function fetchMergedPrs(limit: number): Promise<MergedPr[]> {
+  const out = await run([
+    "gh",
+    "pr",
+    "list",
+    "--state",
+    "merged",
+    "--limit",
+    String(limit),
+    "--json",
+    "number,title,headRefName,createdAt,mergedAt,additions,deletions,changedFiles,files",
+  ]);
+  return JSON.parse(out) as MergedPr[];
+}
+
+/** First PR per ticket by mergedAt DESC order of gh output → latest merge wins. */
+export function indexPrsByTicket(prs: MergedPr[], teams: string[]): Map<string, MergedPr> {
+  const map = new Map<string, MergedPr>();
+  for (const pr of prs) {
+    const id = ticketIdFromPr(pr, teams);
+    if (id && !map.has(id)) map.set(id, pr);
+  }
+  return map;
+}
+
+// -- CLI ------------------------------------------------------------------------------
+
+interface CliOpts {
+  team: string;
+  out: string | null;
+  actuals: string | null;
+  compoundLog: string | null;
+  limit: number;
+  prLimit: number;
+  dryRun: boolean;
+  verbose: boolean;
+}
+
+function parseArgs(argv: string[]): CliOpts {
+  const args = argv.slice(2);
+  const getFlag = (flag: string): string | null => {
+    const i = args.indexOf(flag);
+    return i !== -1 && i + 1 < args.length ? args[i + 1] : null;
+  };
+  return {
+    team: getFlag("--team") ?? "CTL",
+    out: getFlag("--out"),
+    actuals: getFlag("--actuals"),
+    compoundLog: getFlag("--compound-log"),
+    limit: Number.parseInt(getFlag("--limit") ?? "250", 10),
+    prLimit: Number.parseInt(getFlag("--pr-limit") ?? "1000", 10),
+    dryRun: args.includes("--dry-run"),
+    verbose: args.includes("--verbose"),
+  };
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv);
+  console.log(`[collect] team=${opts.team} limit=${opts.limit} pr-limit=${opts.prLimit}`);
+
+  const tickets = await fetchDoneTickets(opts.team, opts.limit);
+  console.log(`[collect] ${tickets.length} Done ticket(s) from Linear`);
+
+  const prs = await fetchMergedPrs(opts.prLimit);
+  const prsByTicket = indexPrsByTicket(prs, [opts.team]);
+  console.log(`[collect] ${prs.length} merged PR(s) → ${prsByTicket.size} ticket-matched`);
+
+  let actuals = new Map<string, ActualsRow>();
+  if (opts.actuals) {
+    try {
+      actuals = parseActualsCsv(readFileSync(resolve(opts.actuals), "utf8"));
+      console.log(`[collect] ${actuals.size} actuals row(s) from ${opts.actuals}`);
+    } catch (err) {
+      console.warn(`[collect] actuals unreadable (${(err as Error).message}) — proceeding without`);
+    }
+  }
+
+  let human = new Map<string, number>();
+  if (opts.compoundLog) {
+    try {
+      human = parseCompoundAggregate(readFileSync(resolve(opts.compoundLog), "utf8"));
+      console.log(`[collect] ${human.size} human re-score(s) from compound-log`);
+    } catch (err) {
+      console.warn(
+        `[collect] compound-log unreadable (${(err as Error).message}) — proceeding without`,
+      );
+    }
+  }
+
+  const rows = buildSignalRows(tickets, prsByTicket, actuals, human, {
+    verbose: opts.verbose,
+  });
+  const csv = toCsv(rows);
+  console.log(`[collect] ${rows.length} signal row(s) built (${tickets.length - rows.length} dropped: no PR + no actuals)`);
+
+  if (opts.dryRun || !opts.out) {
+    console.log(`[collect] --dry-run / no --out: skipping write`);
+    console.log(csv.split("\n").slice(0, 5).join("\n"));
+    return;
+  }
+
+  const outPath = resolve(opts.out);
+  mkdirSync(dirname(outPath), { recursive: true });
+  await Bun.write(outPath, csv);
+  console.log(`[collect] wrote ${rows.length} rows → ${outPath}`);
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/plugins/pm/scripts/estimate/reference-class-corpus.json
+++ b/plugins/pm/scripts/estimate/reference-class-corpus.json
@@ -1,8 +1,4824 @@
 {
-  "generated_at": "2026-06-02",
+  "generated_at": "2026-06-06T23:22:00.931Z",
   "schema": "catalyst.estimation.corpus.v1",
-  "count": 1146,
   "entries": [
+    {
+      "ticket_id": "CTL-789",
+      "title": "Compound Engineering: engineering + estimation feedback loops (epic)",
+      "tier": 2,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "LOC=18→XS, files=4→S, domains=2→M",
+      "signals": {
+        "loc": 18,
+        "changed_files": 4,
+        "domains": [
+          "CLAUDE.md",
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-787",
+      "title": "Headless session.context emission for claude --bg phase agents",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "LOC=1065→L, files=8→M, domains=1→S",
+      "signals": {
+        "loc": 1065,
+        "changed_files": 8,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-811",
+      "title": "Move ticket-compound from catalyst-foundry to catalyst-dev (core plugin)",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=47→XS, files=6→M, domains=2→M",
+      "signals": {
+        "loc": 47,
+        "changed_files": 6,
+        "domains": [
+          "CLAUDE.md",
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-802",
+      "title": "Shared incremental-event-counter primitive",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=193→S, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 193,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 0,
+        "turns": 0,
+        "wall_hours": 0
+      }
+    },
+    {
+      "ticket_id": "CTL-793",
+      "title": "reaper-metrics: counters-not-rows (bound the 168k-event memory leak + per-tick scan)",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=126→S, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 126,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 0,
+        "turns": 0,
+        "wall_hours": 0
+      }
+    },
+    {
+      "ticket_id": "CTL-809",
+      "title": "fix(dev): reclaim jobLifecycle-alive-but-FRESH-agents-absent ghost workers (CC 2.x state.json never flips terminal)",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=213→M, files=4→S, domains=1→S",
+      "signals": {
+        "loc": 213,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 0,
+        "turns": 0,
+        "wall_hours": 0
+      }
+    },
+    {
+      "ticket_id": "CTL-792",
+      "title": "Periodic liveness refresh: keep the snapshot warm so idle tick cadence doesn't hold dispatch on the staleMs gate (CTL-790 follow-up)",
+      "tier": 2,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "medium",
+      "rationale": "LOC=49→XS, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 49,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-791",
+      "title": "Reaper worktree-safety: require positive done-evidence, never --force, protect interactive/unknown worktrees, flag instead of delete",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "LOC=882→L, files=10→M, domains=1→S",
+      "signals": {
+        "loc": 882,
+        "changed_files": 10,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-790",
+      "title": "Fix CTL-731 liveness deadline race: setImmediate-deferred verdict + child.exitCode check",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=181→S, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 181,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-731",
+      "title": "Triage-entry dispatch storm: make triage the scheduler entry phase + graceful predecessor kick-back",
+      "tier": 1,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "medium",
+      "rationale": "LOC=13→XS, files=2→XS, domains=1→S, turns=190→S, wall=45.66h→XL",
+      "signals": {
+        "loc": 13,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 0,
+        "turns": 190,
+        "wall_hours": 45.6574
+      }
+    },
+    {
+      "ticket_id": "CTL-788",
+      "title": "Remove Conductor (CONDUCTOR_WORKSPACE_PATH) references — Catalyst owns its worktree location",
+      "tier": 2,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "low",
+      "rationale": "LOC=20→XS, files=5→S, domains=5→XL; FE+BE→floor-M; 3+-dirs(+1)",
+      "signals": {
+        "loc": 20,
+        "changed_files": 5,
+        "domains": [
+          "docs",
+          "plugins/dev",
+          "plugins/legacy",
+          "setup-catalyst.sh",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-786",
+      "title": "Plugin reorg: catalyst-foundry plugin + legacy topology fix + compound-estimate rename",
+      "tier": 2,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "medium",
+      "rationale": "LOC=1730→L, files=57→XL, domains=9→XL; 3+-dirs(+1)",
+      "signals": {
+        "loc": 1730,
+        "changed_files": 57,
+        "domains": [
+          ".claude-plugin",
+          ".release-please-manifest.json",
+          "CLAUDE.md",
+          "cma",
+          "docs",
+          "plugins/dev",
+          "plugins/foundry",
+          "plugins/legacy",
+          "release-please-config.json"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-784",
+      "title": "execution-core: batch per-ticket Linear reads into one filtered query per tick",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "LOC=968→L, files=7→M, domains=1→S",
+      "signals": {
+        "loc": 968,
+        "changed_files": 7,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-777",
+      "title": "Event-sourced phase-lifecycle reactor: workers emit+exit, daemon derives signal-flip/advance/stop (fixes zombie + orphan deadlock)",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=131→S, files=3→S, domains=1→S, cost=$9.22→XS, turns=151→S, wall=1.26h→M",
+      "signals": {
+        "loc": 131,
+        "changed_files": 3,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 9.2244,
+        "turns": 151,
+        "wall_hours": 1.2575
+      }
+    },
+    {
+      "ticket_id": "CTL-693",
+      "title": "Phase-pr workers should suppress local trunk pre-push hooks",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=90→S, files=3→S, domains=1→S, cost=$78.81→S, turns=573→L, wall=1.46h→M",
+      "signals": {
+        "loc": 90,
+        "changed_files": 3,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 78.8079,
+        "turns": 573,
+        "wall_hours": 1.4573
+      }
+    },
+    {
+      "ticket_id": "CTL-726",
+      "title": "Create catalyst-legacy plugin — deprecate oneshot/orchestrate/wave skills from catalyst-dev",
+      "tier": 1,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "medium",
+      "rationale": "LOC=1→XS, files=1→XS, domains=1→S, cost=$128.58→M, turns=1573→XL, wall=124.76h→XL",
+      "signals": {
+        "loc": 1,
+        "changed_files": 1,
+        "domains": [
+          "release-please-config.json"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 128.5772,
+        "turns": 1573,
+        "wall_hours": 124.7585
+      }
+    },
+    {
+      "ticket_id": "CTL-762",
+      "title": "Harden emit-otel-metric.sh / emit-otel-event.sh resource blocks with --resource-attr passthrough",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=511→M, files=4→S, domains=1→S, cost=$77.21→S, turns=464→L, wall=0.83h→M",
+      "signals": {
+        "loc": 511,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 77.2083,
+        "turns": 464,
+        "wall_hours": 0.8346
+      }
+    },
+    {
+      "ticket_id": "CTL-700",
+      "title": "Observability + signal-truthfulness papercuts (punchlist)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=209→M, files=9→M, domains=1→S, cost=$107.43→M, turns=820→XL, wall=1.06h→M",
+      "signals": {
+        "loc": 209,
+        "changed_files": 9,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 107.4298,
+        "turns": 820,
+        "wall_hours": 1.0567
+      }
+    },
+    {
+      "ticket_id": "CTL-623",
+      "title": "orchestrate: sibling Linear tickets dragged Done→Implement — branch names + describe-pr emit sibling IDs that Linear auto-links",
+      "tier": 1,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "medium",
+      "rationale": "LOC=17→XS, files=2→XS, domains=1→S, cost=$155.56→L, turns=756→XL, wall=8.40h→L",
+      "signals": {
+        "loc": 17,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 155.5581,
+        "turns": 756,
+        "wall_hours": 8.405
+      }
+    },
+    {
+      "ticket_id": "CTL-633",
+      "title": "linear-pr-skip.sh:69 over-matches WORD-NUMBER patterns — fabricates fake Linear tokens from UTF-8 / OAUTH-2 / dates / shas in PR bodies",
+      "tier": 1,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "high",
+      "rationale": "LOC=1066→L, files=11→M, domains=1→S, cost=$177.67→L, turns=662→XL, wall=5.38h→L",
+      "signals": {
+        "loc": 1066,
+        "changed_files": 11,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 177.6686,
+        "turns": 662,
+        "wall_hours": 5.379
+      }
+    },
+    {
+      "ticket_id": "CTL-671",
+      "title": "Guard + monitor runaway phase-dispatch loops (phantom/non-resolving tickets) — CTL-9 spammed 24k failed-dispatch events",
+      "tier": 1,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "high",
+      "rationale": "LOC=1002→L, files=17→L, domains=3→L, cost=$375.60→XL, turns=1614→XL, wall=3.08h→M; 3+-dirs(+1)",
+      "signals": {
+        "loc": 1002,
+        "changed_files": 17,
+        "domains": [
+          "docs",
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 375.6033,
+        "turns": 1614,
+        "wall_hours": 3.077
+      }
+    },
+    {
+      "ticket_id": "CTL-775",
+      "title": "execution-core autotuner ramps maxParallel up without demand — gate upward tuning on saturation + drift down to setpoint",
+      "tier": 1,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "high",
+      "rationale": "LOC=807→L, files=6→M, domains=1→S, cost=$1.79→XS, turns=50→XS, wall=0.06h→XS",
+      "signals": {
+        "loc": 807,
+        "changed_files": 6,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 1.791,
+        "turns": 50,
+        "wall_hours": 0.0626
+      }
+    },
+    {
+      "ticket_id": "CTL-761",
+      "title": "Emit revive/duplicate count and attempt number as observability dimensions",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=276→M, files=10→M, domains=1→S, cost=$111.11→M, turns=626→XL, wall=1.05h→M",
+      "signals": {
+        "loc": 276,
+        "changed_files": 10,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 111.1146,
+        "turns": 626,
+        "wall_hours": 1.0472
+      }
+    },
+    {
+      "ticket_id": "CTL-734",
+      "title": "Ticket-detail drill-in: kibo-ui Gantt of per-phase worker spans",
+      "tier": 1,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "high",
+      "rationale": "LOC=2631→XL, files=35→XL, domains=1→S, cost=$119.86→M, turns=695→XL, wall=1.04h→M",
+      "signals": {
+        "loc": 2631,
+        "changed_files": 35,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 119.862,
+        "turns": 695,
+        "wall_hours": 1.0412
+      }
+    },
+    {
+      "ticket_id": "CTL-763",
+      "title": "Rate-limit window extras (per-model 7d split, usage-API fallback, org aggregate) — primary 5h/7d delivered by CTL-760",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=138→S, files=6→M, domains=1→S, cost=$77.27→S, turns=608→L, wall=0.83h→M",
+      "signals": {
+        "loc": 138,
+        "changed_files": 6,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 77.2749,
+        "turns": 608,
+        "wall_hours": 0.8279
+      }
+    },
+    {
+      "ticket_id": "CTL-684",
+      "title": "Auto-tune maxParallel from system load + memory trends (active-only sampler with trend detection)",
+      "tier": 1,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "high",
+      "rationale": "LOC=1300→L, files=14→M, domains=3→L, cost=$101.59→M, turns=756→XL, wall=1.50h→M; 3+-dirs(+1)",
+      "signals": {
+        "loc": 1300,
+        "changed_files": 14,
+        "domains": [
+          ".catalyst",
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 101.5943,
+        "turns": 756,
+        "wall_hours": 1.496
+      }
+    },
+    {
+      "ticket_id": "CTL-772",
+      "title": "execution-core autotuner clamps to 1 on macOS — os.freemem() undercounts available memory → false mem-critical every tick",
+      "tier": 2,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "LOC=240→M, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 240,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-685",
+      "title": "Per-worker memory monitoring + OOM-kill (memsw RSS+swap, warn at 1.5GB, kill at 4GB sustained)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=1228→L, files=12→M, domains=1→S, cost=$102.83→M, turns=592→L, wall=0.88h→M",
+      "signals": {
+        "loc": 1228,
+        "changed_files": 12,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 102.8345,
+        "turns": 592,
+        "wall_hours": 0.8794
+      }
+    },
+    {
+      "ticket_id": "CTL-770",
+      "title": "execution-core autotuner: converge to a committed setpoint (~6) — fix flat-idle no-ramp-up + cold-start seeding",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=54→S, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 54,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-769",
+      "title": "execution-core reaper never drains reap-intents (fs.watch+debounce, no poll fallback) → leaks predecessor workers + starves the queue",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=163→S, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 163,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-600",
+      "title": "Tracer bullet: verify execution-core thin slice end-to-end (no implementation needed)",
+      "tier": 1,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "medium",
+      "rationale": "LOC=1→XS, files=1→XS, domains=1→S, cost=$87.17→M, turns=344→M, wall=0.38h→S",
+      "signals": {
+        "loc": 1,
+        "changed_files": 1,
+        "domains": [
+          "docs"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 87.1732,
+        "turns": 344,
+        "wall_hours": 0.3769
+      }
+    },
+    {
+      "ticket_id": "CTL-666",
+      "title": "Aggregate true cost + token totals per phase (incl. sub-agent sessions) for the Linear mirror footer",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=267→M, files=4→S, domains=1→S, cost=$143.94→M, turns=615→L, wall=1.10h→M",
+      "signals": {
+        "loc": 267,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 143.941,
+        "turns": 615,
+        "wall_hours": 1.099
+      }
+    },
+    {
+      "ticket_id": "CTL-608",
+      "title": "phase-implement sub-agents commit to nested worktrees; work stranded off the ticket branch",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=363→M, files=4→S, domains=1→S, cost=$288.54→XL, turns=1079→XL, wall=5.10h→L",
+      "signals": {
+        "loc": 363,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 288.5363,
+        "turns": 1079,
+        "wall_hours": 5.1003
+      }
+    },
+    {
+      "ticket_id": "CTL-662",
+      "title": "Reclaim must key on absence from claude-agents, not time-in-state — long sub-worker waits look idle/quiet (CTL-661 follow-up)",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=1039→L, files=5→S, domains=1→S, cost=$342.36→XL, turns=1008→XL, wall=2.04h→M",
+      "signals": {
+        "loc": 1039,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 342.364,
+        "turns": 1008,
+        "wall_hours": 2.0437
+      }
+    },
+    {
+      "ticket_id": "CTL-596",
+      "title": "orchestrate-verify.sh rewrite — diff-aware, test-discovery-aware, post-merge-aware",
+      "tier": 1,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "medium",
+      "rationale": "LOC=440→M, files=2→XS, domains=1→S, cost=$243.68→L, turns=905→XL, wall=10.20h→L",
+      "signals": {
+        "loc": 440,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 243.6787,
+        "turns": 905,
+        "wall_hours": 10.2048
+      }
+    },
+    {
+      "ticket_id": "CTL-611",
+      "title": "orchestrate-phase-advance can silently drop the next-phase dispatch (ticket hangs)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=542→M, files=7→M, domains=1→S, cost=$397.42→XL, turns=1352→XL, wall=7.00h→L",
+      "signals": {
+        "loc": 542,
+        "changed_files": 7,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 397.4239,
+        "turns": 1352,
+        "wall_hours": 6.9987
+      }
+    },
+    {
+      "ticket_id": "CTL-675",
+      "title": "catalyst-execution-core tidy fails silently outside a git repo — worktrees/branches git calls inherit process cwd",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=445→M, files=11→M, domains=2→M, cost=$184.05→L, turns=679→XL, wall=1.06h→M",
+      "signals": {
+        "loc": 445,
+        "changed_files": 11,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 184.0507,
+        "turns": 679,
+        "wall_hours": 1.0575
+      }
+    },
+    {
+      "ticket_id": "CTL-607",
+      "title": "orchestrate-revive re-dispatches reaped predecessor phases (spawns duplicate agents in one worktree)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=316→M, files=6→M, domains=1→S, cost=$209.42→L, turns=989→XL, wall=5.08h→L",
+      "signals": {
+        "loc": 316,
+        "changed_files": 6,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 209.4231,
+        "turns": 989,
+        "wall_hours": 5.0774
+      }
+    },
+    {
+      "ticket_id": "CTL-634",
+      "title": "execution-core daemon: cache `linearis issues read` results to reduce Linear rate-limit exposure (per-tick reads burn ~600/hr per in-flight ticket)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=633→M, files=11→M, domains=1→S, cost=$191.27→L, turns=767→XL, wall=1.60h→M",
+      "signals": {
+        "loc": 633,
+        "changed_files": 11,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 191.2671,
+        "turns": 767,
+        "wall_hours": 1.5961
+      }
+    },
+    {
+      "ticket_id": "CTL-654",
+      "title": "Daemon boot-resume: re-dispatch in-flight tickets that have no live worker",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=653→M, files=7→M, domains=1→S, cost=$258.30→XL, turns=1003→XL, wall=2.79h→M",
+      "signals": {
+        "loc": 653,
+        "changed_files": 7,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 258.2993,
+        "turns": 1003,
+        "wall_hours": 2.7878
+      }
+    },
+    {
+      "ticket_id": "CTL-613",
+      "title": "orchestrate-revive turn-cap continuation branch doesn't fire in phase-agents mode (handoff unused, ticket hangs)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=548→M, files=5→S, domains=2→M, cost=$270.25→XL, turns=873→XL, wall=5.18h→L",
+      "signals": {
+        "loc": 548,
+        "changed_files": 5,
+        "domains": [
+          "docs",
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 270.2547,
+        "turns": 873,
+        "wall_hours": 5.1826
+      }
+    },
+    {
+      "ticket_id": "CTL-624",
+      "title": "execution-core scheduler: tight retry loop on `prior_artifact_missing` dispatch failure (no backoff, no failed-signal marker)",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=197→S, files=2→XS, domains=1→S, cost=$164.63→L, turns=679→XL, wall=2.11h→M",
+      "signals": {
+        "loc": 197,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 164.625,
+        "turns": 679,
+        "wall_hours": 2.1123
+      }
+    },
+    {
+      "ticket_id": "CTL-640",
+      "title": "Cold-start detection signal + recovery gate (kern.boottime vs job-dir mtimes)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=283→M, files=2→XS, domains=1→S, cost=$289.34→XL, turns=1056→XL, wall=2.57h→M",
+      "signals": {
+        "loc": 283,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 289.3365,
+        "turns": 1056,
+        "wall_hours": 2.5654
+      }
+    },
+    {
+      "ticket_id": "CTL-614",
+      "title": "phase-triage treats a transient Linear 429 rate-limit on 'issues discuss' as a FATAL triage failure",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=90→S, files=2→XS, domains=1→S, cost=$151.90→L, turns=1013→XL, wall=5.57h→L",
+      "signals": {
+        "loc": 90,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 151.904,
+        "turns": 1013,
+        "wall_hours": 5.5689
+      }
+    },
+    {
+      "ticket_id": "CTL-637",
+      "title": "direnv `use_otel_context` concat-without-dedup appends every cd's project= / hostname= attrs, producing OTEL_RESOURCE_ATTRIBUTES with duplicate keys",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=343→M, files=4→S, domains=2→M, cost=$119.49→M, turns=445→L, wall=1.68h→M",
+      "signals": {
+        "loc": 343,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 119.4943,
+        "turns": 445,
+        "wall_hours": 1.6844
+      }
+    },
+    {
+      "ticket_id": "CTL-632",
+      "title": "phase agents (research / plan / implement / verify / review) should mirror their output to Linear as a comment — only phase-triage currently does",
+      "tier": 1,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "high",
+      "rationale": "LOC=1306→L, files=13→M, domains=1→S, cost=$156.86→L, turns=588→L, wall=1.93h→M",
+      "signals": {
+        "loc": 1306,
+        "changed_files": 13,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 156.858,
+        "turns": 588,
+        "wall_hours": 1.9326
+      }
+    },
+    {
+      "ticket_id": "CTL-625",
+      "title": "execution-core: moving a ticket to Ready should not infinite-loop when triage.json is missing — Ready-without-triage is an undefined-but-natural user action",
+      "tier": 1,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "high",
+      "rationale": "LOC=112→S, files=4→S, domains=3→L, cost=$211.34→L, turns=774→XL, wall=19.54h→L; 3+-dirs(+1)",
+      "signals": {
+        "loc": 112,
+        "changed_files": 4,
+        "domains": [
+          "docs",
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 211.3428,
+        "turns": 774,
+        "wall_hours": 19.5379
+      }
+    },
+    {
+      "ticket_id": "CTL-635",
+      "title": "OTEL env propagation severed at the claude --bg daemon boundary — phase-agent metrics mis-tagged with daemon's spawn-context (linear.key=ADV-1039, project=adva) regardless of actual ticket",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=102→S, files=2→XS, domains=1→S, cost=$257.57→XL, turns=906→XL, wall=3.45h→M",
+      "signals": {
+        "loc": 102,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 257.5731,
+        "turns": 906,
+        "wall_hours": 3.4512
+      }
+    },
+    {
+      "ticket_id": "CTL-674",
+      "title": "sessions/tidy audit CLI scans ~/catalyst/runs not the execution-core dir → all live workers mis-classified UNKNOWN",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=145→S, files=2→XS, domains=1→S, cost=$134.26→M, turns=566→L, wall=1.06h→M",
+      "signals": {
+        "loc": 145,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 134.257,
+        "turns": 566,
+        "wall_hours": 1.0649
+      }
+    },
+    {
+      "ticket_id": "CTL-670",
+      "title": "Speed up CI: skip Cloudflare Pages build for non-docs PRs",
+      "tier": 1,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "medium",
+      "rationale": "LOC=365→M, files=5→S, domains=5→XL, cost=$142.57→M, turns=474→L, wall=0.75h→S; FE+BE→floor-M; 3+-dirs(+1)",
+      "signals": {
+        "loc": 365,
+        "changed_files": 5,
+        "domains": [
+          ".github",
+          "docs",
+          "plugins/dev",
+          "scripts",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 142.5699,
+        "turns": 474,
+        "wall_hours": 0.7549
+      }
+    },
+    {
+      "ticket_id": "CTL-665",
+      "title": "Externalize maxParallel to committed config + bounds (enables bump to 10, gated on leak fix live)",
+      "tier": 1,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "high",
+      "rationale": "LOC=440→M, files=11→M, domains=3→L, cost=$276.57→XL, turns=907→XL, wall=1.65h→M; 3+-dirs(+1)",
+      "signals": {
+        "loc": 440,
+        "changed_files": 11,
+        "domains": [
+          ".catalyst",
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 276.5737,
+        "turns": 907,
+        "wall_hours": 1.6514
+      }
+    },
+    {
+      "ticket_id": "CTL-667",
+      "title": "Each build phase rebases its worktree on origin/main before starting (surface merge conflicts early)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=648→M, files=8→M, domains=2→M, cost=$208.43→L, turns=800→XL, wall=1.27h→M",
+      "signals": {
+        "loc": 648,
+        "changed_files": 8,
+        "domains": [
+          "docs",
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 208.4312,
+        "turns": 800,
+        "wall_hours": 1.2712
+      }
+    },
+    {
+      "ticket_id": "CTL-658",
+      "title": "Daemon revive/reclaim should claude --bg --resume the dead worker session, not fresh re-dispatch (restart re-walk hazard)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=667→M, files=9→M, domains=1→S, cost=$296.28→XL, turns=926→XL, wall=1.81h→M",
+      "signals": {
+        "loc": 667,
+        "changed_files": 9,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 296.2769,
+        "turns": 926,
+        "wall_hours": 1.8108
+      }
+    },
+    {
+      "ticket_id": "CTL-664",
+      "title": "Reclaim observability: post a Linear mirror comment + enrich the reclaim event",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=381→M, files=4→S, domains=1→S, cost=$227.35→L, turns=936→XL, wall=1.43h→M",
+      "signals": {
+        "loc": 381,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 227.3536,
+        "turns": 936,
+        "wall_hours": 1.4283
+      }
+    },
+    {
+      "ticket_id": "CTL-661",
+      "title": "execution-core leaks live phase workers: reclaim false-declares busy workers dead + no reap on remediate cycle (enforce one-worker-per-ticket)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=970→L, files=11→M, domains=1→S, cost=$303.74→XL, turns=954→XL, wall=1.94h→M",
+      "signals": {
+        "loc": 970,
+        "changed_files": 11,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 303.7389,
+        "turns": 954,
+        "wall_hours": 1.94
+      }
+    },
+    {
+      "ticket_id": "CTL-660",
+      "title": "catalyst-hud: surface daemon pickup→dispatch latency (emit dispatch-lifecycle events)",
+      "tier": 1,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "medium",
+      "rationale": "LOC=822→L, files=9→M, domains=1→S, cost=$308.57→XL, turns=1112→XL, wall=6.52h→L",
+      "signals": {
+        "loc": 822,
+        "changed_files": 9,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 308.5685,
+        "turns": 1112,
+        "wall_hours": 6.5161
+      }
+    },
+    {
+      "ticket_id": "CTL-618",
+      "title": "phase-emit-complete.sh breaks under zsh (BASH_SOURCE unset, 'status' read-only)",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=123→S, files=3→S, domains=1→S, cost=$98.57→M, turns=347→M, wall=1.08h→M",
+      "signals": {
+        "loc": 123,
+        "changed_files": 3,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 98.5677,
+        "turns": 347,
+        "wall_hours": 1.0823
+      }
+    },
+    {
+      "ticket_id": "CTL-585",
+      "title": "Execution-core daemon retries applying missing 'triaged' label to every triaged ticket — Label not found",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=457→M, files=5→S, domains=1→S, cost=$104.35→M, turns=419→L, wall=0.95h→M",
+      "signals": {
+        "loc": 457,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 104.3459,
+        "turns": 419,
+        "wall_hours": 0.9493
+      }
+    },
+    {
+      "ticket_id": "CTL-597",
+      "title": "applyTerminalDone has no once-marker — every tick re-writes Linear Done for already-terminal tickets (retry-storm root cause)",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=107→S, files=2→XS, domains=1→S, cost=$122.03→M, turns=470→L, wall=0.69h→S",
+      "signals": {
+        "loc": 107,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 122.0279,
+        "turns": 470,
+        "wall_hours": 0.6873
+      }
+    },
+    {
+      "ticket_id": "CTL-378",
+      "title": "orchestrate skill should auto-resolve review threads when worker dies between fix-push and merge",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=796→M, files=3→S, domains=1→S, cost=$236.32→L, turns=820→XL, wall=27.01h→XL",
+      "signals": {
+        "loc": 796,
+        "changed_files": 3,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 236.3198,
+        "turns": 820,
+        "wall_hours": 27.0134
+      }
+    },
+    {
+      "ticket_id": "CTL-655",
+      "title": "Recovery: reset/window the revive budget on daemon restart (one more shot per restart)",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=263→M, files=5→S, domains=1→S, cost=$172.96→L, turns=656→XL, wall=1.90h→M",
+      "signals": {
+        "loc": 263,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 172.9561,
+        "turns": 656,
+        "wall_hours": 1.9029
+      }
+    },
+    {
+      "ticket_id": "CTL-636",
+      "title": "canonical event resource block hardcodes {service.name, service.namespace, service.version} — never carries project / linear.key, so Loki forwarding loses ticket+project context",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=232→M, files=5→S, domains=1→S, cost=$115.84→M, turns=581→L, wall=0.88h→M",
+      "signals": {
+        "loc": 232,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 115.8435,
+        "turns": 581,
+        "wall_hours": 0.8842
+      }
+    },
+    {
+      "ticket_id": "CTL-617",
+      "title": "Double-dispatch: standalone rebase worker (CTL-232) co-dispatched with phase-monitor-merge (CTL-449) on same PR",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=87→S, files=2→XS, domains=1→S, cost=$141.74→M, turns=984→XL, wall=6.01h→L",
+      "signals": {
+        "loc": 87,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 141.7427,
+        "turns": 984,
+        "wall_hours": 6.0072
+      }
+    },
+    {
+      "ticket_id": "CTL-610",
+      "title": "phase-agent heartbeat update is unreliable — state-json-stale stalls hit ~50% of phase workers",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=375→M, files=4→S, domains=1→S, cost=$222.00→L, turns=691→XL, wall=2.50h→M",
+      "signals": {
+        "loc": 375,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 222.0013,
+        "turns": 691,
+        "wall_hours": 2.5043
+      }
+    },
+    {
+      "ticket_id": "CTL-604",
+      "title": "Phase agent dying mid-turn on 'socket connection closed' leaves pipeline silently stalled; revive misclassifies it as pid-dead",
+      "tier": 1,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "medium",
+      "rationale": "LOC=889→L, files=9→M, domains=1→S, cost=$454.74→XL, turns=1536→XL, wall=5.98h→L",
+      "signals": {
+        "loc": 889,
+        "changed_files": 9,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 454.7403,
+        "turns": 1536,
+        "wall_hours": 5.9798
+      }
+    },
+    {
+      "ticket_id": "CTL-605",
+      "title": "orchestrate-dispatch-next phase fork drains PENDING herestring (CTL-334 redux) + RUNNING undercount in phase mode",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=201→M, files=3→S, domains=1→S, cost=$118.71→M, turns=387→L, wall=1.01h→M",
+      "signals": {
+        "loc": 201,
+        "changed_files": 3,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 118.7056,
+        "turns": 387,
+        "wall_hours": 1.0058
+      }
+    },
+    {
+      "ticket_id": "CTL-656",
+      "title": "Goal-driven phases: add /goal to triage+monitor-deploy, deploy-fail remediation, generalize fail→previous-phase routing",
+      "tier": 1,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "medium",
+      "rationale": "LOC=40→XS, files=2→XS, domains=1→S, cost=$135.96→M, turns=585→L, wall=2.01h→M",
+      "signals": {
+        "loc": 40,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 135.9633,
+        "turns": 585,
+        "wall_hours": 2.0108
+      }
+    },
+    {
+      "ticket_id": "CTL-615",
+      "title": "CTL-509 false-stall redispatch put TWO live phase-implement workers on one worktree (ADV-1134)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=630→M, files=14→M, domains=1→S, cost=$263.22→XL, turns=1992→XL, wall=7.49h→L",
+      "signals": {
+        "loc": 630,
+        "changed_files": 14,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 263.2205,
+        "turns": 1992,
+        "wall_hours": 7.4884
+      }
+    },
+    {
+      "ticket_id": "CTL-606",
+      "title": "Predecessor reaping emits phase.<oldphase>.failed.<TICKET> that mimics a real failure",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=183→S, files=7→M, domains=1→S, cost=$288.94→XL, turns=1062→XL, wall=4.58h→L",
+      "signals": {
+        "loc": 183,
+        "changed_files": 7,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 288.9359,
+        "turns": 1062,
+        "wall_hours": 4.5767
+      }
+    },
+    {
+      "ticket_id": "CTL-673",
+      "title": "execution-core daemon re-reads the full event log per scheduler tick — incremental/byte-offset scan to bound RSS",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=534→M, files=7→M, domains=1→S, cost=$187.21→L, turns=774→XL, wall=1.44h→M",
+      "signals": {
+        "loc": 534,
+        "changed_files": 7,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 187.2114,
+        "turns": 774,
+        "wall_hours": 1.4415
+      }
+    },
+    {
+      "ticket_id": "CTL-653",
+      "title": "Remediate phase: autonomous verify→remediate loop (cap 3) instead of stalling to needs-human",
+      "tier": 1,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "high",
+      "rationale": "LOC=1129→L, files=17→L, domains=3→L, cost=$290.17→XL, turns=980→XL, wall=2.70h→M; 3+-dirs(+1)",
+      "signals": {
+        "loc": 1129,
+        "changed_files": 17,
+        "domains": [
+          ".catalyst",
+          "docs",
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 290.1686,
+        "turns": 980,
+        "wall_hours": 2.698
+      }
+    },
+    {
+      "ticket_id": "CTL-641",
+      "title": "Per-phase work-done probes (extend WORK_DONE_PROBES beyond implement)",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=518→M, files=5→S, domains=1→S, cost=$516.19→XL, turns=1425→XL, wall=3.61h→M",
+      "signals": {
+        "loc": 518,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 516.1928,
+        "turns": 1425,
+        "wall_hours": 3.6066
+      }
+    },
+    {
+      "ticket_id": "CTL-766",
+      "title": "otel-forward daemon: daemonize + fix checkpoint offset:0 backlog-flood (collector transform moved to OTL)",
+      "tier": 1,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "high",
+      "rationale": "LOC=69→S, files=4→S, domains=1→S, cost=$1.17→XS, turns=27→XS, wall=0.04h→XS",
+      "signals": {
+        "loc": 69,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 1.1707,
+        "turns": 27,
+        "wall_hours": 0.042
+      }
+    },
+    {
+      "ticket_id": "CTL-750",
+      "title": "Daemon: maxParallel resolves 4→1 + 5 workers dispatched past the cap + cold-liveness vs running-signal disconnect",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=123→S, files=4→S, domains=1→S, cost=$68.82→S, turns=498→L, wall=0.89h→M",
+      "signals": {
+        "loc": 123,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 68.8159,
+        "turns": 498,
+        "wall_hours": 0.8865
+      }
+    },
+    {
+      "ticket_id": "CTL-710",
+      "title": "Config schema formalization + schema-evolution bug audit",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=1343→L, files=10→M, domains=2→M, cost=$336.06→XL, turns=354→M, wall=182.43h→XL",
+      "signals": {
+        "loc": 1343,
+        "changed_files": 10,
+        "domains": [
+          "docs",
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 336.0599,
+        "turns": 354,
+        "wall_hours": 182.4326
+      }
+    },
+    {
+      "ticket_id": "CTL-716",
+      "title": "Webhook-triggered triage dispatch bypasses maxParallel slot check",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=343→M, files=4→S, domains=1→S, cost=$245.41→XL, turns=1038→XL, wall=2.20h→M",
+      "signals": {
+        "loc": 343,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 245.4122,
+        "turns": 1038,
+        "wall_hours": 2.1984
+      }
+    },
+    {
+      "ticket_id": "CTL-657",
+      "title": "Stop leaking bg workers: reaper never runs `claude stop` — make `claude agents` the source of truth for liveness, termination & concurrency",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=756→M, files=8→M, domains=1→S",
+      "signals": {
+        "loc": 756,
+        "changed_files": 8,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-760",
+      "title": "Per-worker OTEL tagging via --settings injection + statusLine + canonical resource block",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=539→M, files=12→M, domains=1→S",
+      "signals": {
+        "loc": 539,
+        "changed_files": 12,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-757",
+      "title": "Emit canonical linear.state.write audit event on every Linear state transition (writer attribution + from→to)",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "LOC=2158→XL, files=17→L, domains=1→S",
+      "signals": {
+        "loc": 2158,
+        "changed_files": 17,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-745",
+      "title": "Monitor Tickets view shows Done while Linear state is Validate (conflates bg-worker job-state with ticket state)",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=123→S, files=3→S, domains=1→S, cost=$104.81→M, turns=592→L, wall=0.90h→M",
+      "signals": {
+        "loc": 123,
+        "changed_files": 3,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 104.8107,
+        "turns": 592,
+        "wall_hours": 0.9034
+      }
+    },
+    {
+      "ticket_id": "CTL-755",
+      "title": "execution-core scheduler not gating blocked tickets — dependents advance past blockers",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "LOC=1823→L, files=13→M, domains=1→S; FE+BE→floor-M",
+      "signals": {
+        "loc": 1823,
+        "changed_files": 13,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-736",
+      "title": "Retire the revive-storm guard stack: state.json death-trigger + fencing claim + progress probe",
+      "tier": 2,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "medium",
+      "rationale": "LOC=41→XS, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 41,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-756",
+      "title": "fix(dev): handleCommentWake self-wakes parked workers on the agent's own comment (no botUserId guard)",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=53→S, files=2→XS, domains=1→S, cost=$97.31→M, turns=590→L, wall=0.89h→M",
+      "signals": {
+        "loc": 53,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 97.3085,
+        "turns": 590,
+        "wall_hours": 0.891
+      }
+    },
+    {
+      "ticket_id": "CTL-754",
+      "title": "Board: per-phase progression strip + per-ticket timeline (data already on disk in phase-*.json)",
+      "tier": 1,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "high",
+      "rationale": "LOC=903→L, files=29→L, domains=1→S, cost=$159.14→L, turns=864→XL, wall=1.24h→M",
+      "signals": {
+        "loc": 903,
+        "changed_files": 29,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 159.1445,
+        "turns": 864,
+        "wall_hours": 1.2413
+      }
+    },
+    {
+      "ticket_id": "CTL-753",
+      "title": "Surface dynamic-workflow sub-steps per ticket: emit workflow.substep.* events + board drill-down",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=714→M, files=13→M, domains=1→S, cost=$120.74→M, turns=828→XL, wall=1.19h→M",
+      "signals": {
+        "loc": 714,
+        "changed_files": 13,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 120.7442,
+        "turns": 828,
+        "wall_hours": 1.1874
+      }
+    },
+    {
+      "ticket_id": "CTL-752",
+      "title": "Phase-agent OTEL token attribution: register a catalyst-session per phase worker so subagent/workflow tokens join to ticket+phase",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=91→S, files=3→S, domains=2→M, cost=$86.57→M, turns=499→L, wall=0.79h→S; FE+BE→floor-M",
+      "signals": {
+        "loc": 91,
+        "changed_files": 3,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 86.5659,
+        "turns": 499,
+        "wall_hours": 0.7901
+      }
+    },
+    {
+      "ticket_id": "CTL-751",
+      "title": "Wire phase-triage to produce + write a real reference-class estimate (deliver: every triaged ticket gets a 1/3/5/8/13 estimate)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=25685→XL, files=9→M, domains=2→M, cost=$112.70→M, turns=883→XL, wall=6.63h→L",
+      "signals": {
+        "loc": 25685,
+        "changed_files": 9,
+        "domains": [
+          "plugins/dev",
+          "plugins/pm"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 112.7028,
+        "turns": 883,
+        "wall_hours": 6.6331
+      }
+    },
+    {
+      "ticket_id": "CTL-746",
+      "title": "Real complexity estimate in triage: port the ADV AI-native estimator, build the CTL corpus, write points to Linear",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=2255→XL, files=4→S, domains=1→S",
+      "signals": {
+        "loc": 2255,
+        "changed_files": 4,
+        "domains": [
+          "plugins/pm"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-747",
+      "title": "Per-phase effort + dynamic-workflow execution driven by ticket points",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=195→S, files=5→S, domains=1→S, cost=$92.36→M, turns=559→L, wall=1.62h→M",
+      "signals": {
+        "loc": 195,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 92.3599,
+        "turns": 559,
+        "wall_hours": 1.6203
+      }
+    },
+    {
+      "ticket_id": "CTL-537",
+      "title": "[M4·scheduler] Sequencing and dependency-detection seam",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=694→M, files=6→M, domains=1→S, cost=$153.68→L, turns=789→XL, wall=4.70h→L",
+      "signals": {
+        "loc": 694,
+        "changed_files": 6,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 153.6811,
+        "turns": 789,
+        "wall_hours": 4.6984
+      }
+    },
+    {
+      "ticket_id": "CTL-668",
+      "title": "Linear comment trail: PR/monitor/deploy phase mirrors + run-metadata footer",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=894→L, files=15→M, domains=2→M",
+      "signals": {
+        "loc": 894,
+        "changed_files": 15,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-628",
+      "title": "install-cli.sh + check-setup.sh: missing catalyst-execution-core, catalyst-otel-forward, catalyst-statusline, catalyst-transitions from CLI allowlist",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=15→XS, files=3→S, domains=1→S",
+      "signals": {
+        "loc": 15,
+        "changed_files": 3,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-715",
+      "title": "scheduler.test.mjs: 8 tests broken on machines with active bg workers after CTL-705",
+      "tier": 2,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "medium",
+      "rationale": "LOC=12→XS, files=1→XS, domains=1→S",
+      "signals": {
+        "loc": 12,
+        "changed_files": 1,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-690",
+      "title": "boot-resume should pass --resume-session for true session continuation",
+      "tier": 2,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "LOC=267→M, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 267,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-689",
+      "title": "URGENT: switch phase-implement workers (and sub-agents) from Opus → Sonnet to use the separate Sonnet token budget",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=166→S, files=3→S, domains=2→M",
+      "signals": {
+        "loc": 166,
+        "changed_files": 3,
+        "domains": [
+          ".catalyst",
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-679",
+      "title": "Add rate-limit backoff / circuit breaker to execution-core Linear calls",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=412→M, files=11→M, domains=1→S",
+      "signals": {
+        "loc": 412,
+        "changed_files": 11,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-672",
+      "title": "Unify broker watchdog liveness on `claude agents` (single-host); retire session.heartbeat from the event log",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=487→M, files=6→M, domains=1→S",
+      "signals": {
+        "loc": 487,
+        "changed_files": 6,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-735",
+      "title": "Bound the reclaim/revive path: de-starvation unmasked a revive storm (CTL-731 follow-up)",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=523→M, files=5→S, domains=1→S",
+      "signals": {
+        "loc": 523,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-733",
+      "title": "Board real-time data layer: single server-side snapshot + SSE push (retire per-tab polling)",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=701→M, files=11→M, domains=1→S",
+      "signals": {
+        "loc": 701,
+        "changed_files": 11,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-732",
+      "title": "Workers tab: toggle columns between pipeline stage and worker status",
+      "tier": 2,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "medium",
+      "rationale": "LOC=23→XS, files=1→XS, domains=1→S",
+      "signals": {
+        "loc": 23,
+        "changed_files": 1,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-730",
+      "title": "Serve the Worker Board from the monitor (server.ts) + retire the old dashboard",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=533→M, files=13→M, domains=1→S",
+      "signals": {
+        "loc": 533,
+        "changed_files": 13,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-678",
+      "title": "Relocate execution-core concurrency knobs to machine-canonical config layer",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=528→M, files=6→M, domains=2→M, cost=$200.54→L, turns=895→XL, wall=3.58h→M",
+      "signals": {
+        "loc": 528,
+        "changed_files": 6,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 200.5401,
+        "turns": 895,
+        "wall_hours": 3.5831
+      }
+    },
+    {
+      "ticket_id": "CTL-688",
+      "title": "Rename bg phase-agent sessions: '<TICKET> <PHASE>' instead of 'o-<TICKET>:<TICKET>:<PHASE>:1'",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=94→S, files=4→S, domains=1→S, cost=$79.38→M, turns=576→L, wall=0.92h→M",
+      "signals": {
+        "loc": 94,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 79.3779,
+        "turns": 576,
+        "wall_hours": 0.9213
+      }
+    },
+    {
+      "ticket_id": "CTL-695",
+      "title": "Fix the broken phase-agent reaper (CTL-657 followup)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=373→M, files=8→M, domains=1→S, cost=$565.55→XL, turns=1152→XL, wall=1.91h→M",
+      "signals": {
+        "loc": 373,
+        "changed_files": 8,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 565.546,
+        "turns": 1152,
+        "wall_hours": 1.912
+      }
+    },
+    {
+      "ticket_id": "CTL-701",
+      "title": "Cold-restart reclaim sweep misses monitor-deploy + turn-cap-exhausted phases",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=594→M, files=7→M, domains=1→S, cost=$65.22→S, turns=495→L, wall=0.97h→M",
+      "signals": {
+        "loc": 594,
+        "changed_files": 7,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 65.2185,
+        "turns": 495,
+        "wall_hours": 0.9669
+      }
+    },
+    {
+      "ticket_id": "CTL-705",
+      "title": "Global priority+stage sort across queue+in-flight with preemption",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=1686→L, files=11→M, domains=2→M, cost=$965.32→XL, turns=1429→XL, wall=2.36h→M",
+      "signals": {
+        "loc": 1686,
+        "changed_files": 11,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 965.3185,
+        "turns": 1429,
+        "wall_hours": 2.3558
+      }
+    },
+    {
+      "ticket_id": "CTL-706",
+      "title": "Per-project resource budgets (maxParallel per project + reserves)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=640→M, files=5→S, domains=2→M, cost=$112.84→M, turns=798→XL, wall=1.38h→M",
+      "signals": {
+        "loc": 640,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 112.8437,
+        "turns": 798,
+        "wall_hours": 1.3831
+      }
+    },
+    {
+      "ticket_id": "CTL-707",
+      "title": "Multi-layer stale-base auto-rebase",
+      "tier": 1,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "high",
+      "rationale": "LOC=1556→L, files=14→M, domains=4→XL, cost=$566.83→XL, turns=1104→XL, wall=2.08h→M; 3+-dirs(+1)",
+      "signals": {
+        "loc": 1556,
+        "changed_files": 14,
+        "domains": [
+          ".catalyst",
+          "docs",
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 566.8347,
+        "turns": 1104,
+        "wall_hours": 2.081
+      }
+    },
+    {
+      "ticket_id": "CTL-711",
+      "title": "Startup reconcile misses pre-existing Todo tickets without triage.json",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=176→S, files=2→XS, domains=1→S, cost=$198.32→L, turns=638→XL, wall=1.07h→M",
+      "signals": {
+        "loc": 176,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 198.3177,
+        "turns": 638,
+        "wall_hours": 1.0724
+      }
+    },
+    {
+      "ticket_id": "CTL-712",
+      "title": "Infinite dispatch retry storm for manually-rescued phases",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=155→S, files=2→XS, domains=1→S, cost=$179.09→L, turns=656→XL, wall=1.01h→M",
+      "signals": {
+        "loc": 155,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 179.09,
+        "turns": 656,
+        "wall_hours": 1.0115
+      }
+    },
+    {
+      "ticket_id": "CTL-713",
+      "title": "Dispatch cooldowns have no TTL — accumulate forever and require manual cleanup",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=376→M, files=5→S, domains=2→M, cost=$161.48→L, turns=974→XL, wall=1.83h→M",
+      "signals": {
+        "loc": 376,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 161.4796,
+        "turns": 974,
+        "wall_hours": 1.8273
+      }
+    },
+    {
+      "ticket_id": "CTL-676",
+      "title": "Hot-reload execution-core concurrency knobs from config (no daemon restart)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=359→M, files=5→S, domains=2→M, cost=$112.40→M, turns=558→L, wall=1.38h→M",
+      "signals": {
+        "loc": 359,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 112.403,
+        "turns": 558,
+        "wall_hours": 1.3801
+      }
+    },
+    {
+      "ticket_id": "CTL-681",
+      "title": "Daemon: first-class handlers for linear.issue.updated and linear.comment.created (event-sourcing step 3)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=656→M, files=8→M, domains=1→S, cost=$111.19→M, turns=741→XL, wall=1.37h→M",
+      "signals": {
+        "loc": 656,
+        "changed_files": 8,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 111.1854,
+        "turns": 741,
+        "wall_hours": 1.3681
+      }
+    },
+    {
+      "ticket_id": "CTL-694",
+      "title": "Periodic orphan process + worktree sweep for unattended hosts",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=993→L, files=5→S, domains=2→M, cost=$90.37→M, turns=635→XL, wall=1.38h→M",
+      "signals": {
+        "loc": 993,
+        "changed_files": 5,
+        "domains": [
+          "docs",
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 90.3692,
+        "turns": 635,
+        "wall_hours": 1.3843
+      }
+    },
+    {
+      "ticket_id": "CTL-702",
+      "title": "Scheduler tick fails on phase-X-yield-*.json files (silent multi-hour outage risk)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=359→M, files=7→M, domains=2→M, cost=$93.74→M, turns=604→L, wall=1.53h→M",
+      "signals": {
+        "loc": 359,
+        "changed_files": 7,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 93.7359,
+        "turns": 604,
+        "wall_hours": 1.5258
+      }
+    },
+    {
+      "ticket_id": "CTL-704",
+      "title": "Verify Todo→Triage auto-transition on first phase dispatch + telemetry",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=488→M, files=9→M, domains=2→M, cost=$100.64→M, turns=686→XL, wall=1.06h→M",
+      "signals": {
+        "loc": 488,
+        "changed_files": 9,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 100.6355,
+        "turns": 686,
+        "wall_hours": 1.0562
+      }
+    },
+    {
+      "ticket_id": "CTL-709",
+      "title": "Open PR on first commit + push-frequently policy for phase agents",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=1210→L, files=7→M, domains=2→M, cost=$93.05→M, turns=607→L, wall=1.05h→M",
+      "signals": {
+        "loc": 1210,
+        "changed_files": 7,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 93.0457,
+        "turns": 607,
+        "wall_hours": 1.055
+      }
+    },
+    {
+      "ticket_id": "CTL-714",
+      "title": "phase-pr must detect already-merged branch and skip gracefully",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=291→M, files=2→XS, domains=1→S, cost=$87.24→M, turns=495→L, wall=0.75h→S",
+      "signals": {
+        "loc": 291,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 87.2445,
+        "turns": 495,
+        "wall_hours": 0.7519
+      }
+    },
+    {
+      "ticket_id": "CTL-748",
+      "title": "Disable per-phase turn caps; track tokens/$/turns instead (no hard bounds)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=573→M, files=32→XL, domains=1→S, cost=$113.96→M, turns=913→XL, wall=3.31h→M",
+      "signals": {
+        "loc": 573,
+        "changed_files": 32,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": true,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 113.9594,
+        "turns": 913,
+        "wall_hours": 3.3054
+      }
+    },
+    {
+      "ticket_id": "CTL-643",
+      "title": "Startup reconcile-and-GC (prune leaked broker interests + drop terminal tickets)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=670→M, files=9→M, domains=1→S, cost=$162.43→L, turns=796→XL, wall=2.34h→M",
+      "signals": {
+        "loc": 670,
+        "changed_files": 9,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 162.4328,
+        "turns": 796,
+        "wall_hours": 2.3428
+      }
+    },
+    {
+      "ticket_id": "CTL-650",
+      "title": "Daemon: detect when an agent is waiting on the user → emit event → consumer alerts",
+      "tier": 1,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "medium",
+      "rationale": "LOC=1477→L, files=16→L, domains=1→S, cost=$258.54→XL, turns=928→XL, wall=1.52h→M",
+      "signals": {
+        "loc": 1477,
+        "changed_files": 16,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 258.5404,
+        "turns": 928,
+        "wall_hours": 1.5219
+      }
+    },
+    {
+      "ticket_id": "CTL-573",
+      "title": "create-worktree.sh branches off stale local main; orchestrator workers start on outdated base",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=156→S, files=3→S, domains=1→S, cost=$96.14→M, turns=474→L, wall=1.49h→M",
+      "signals": {
+        "loc": 156,
+        "changed_files": 3,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 96.1435,
+        "turns": 474,
+        "wall_hours": 1.4902
+      }
+    },
+    {
+      "ticket_id": "CTL-53",
+      "title": "Preview deployment links in monitor",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=848→L, files=9→M, domains=2→M",
+      "signals": {
+        "loc": 848,
+        "changed_files": 9,
+        "domains": [
+          ".claude",
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-43",
+      "title": "Session labeling & naming system",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=275→M, files=12→M, domains=1→S",
+      "signals": {
+        "loc": 275,
+        "changed_files": 12,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-82",
+      "title": "Fix catalyst-claude.sh to exec claude for Warp terminal integration",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=73→S, files=1→XS, domains=1→S",
+      "signals": {
+        "loc": 73,
+        "changed_files": 1,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-74",
+      "title": "Sidebar grouping: group by repo/cwd",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "LOC=1190→L, files=11→M, domains=1→S; FE+BE→floor-M",
+      "signals": {
+        "loc": 1190,
+        "changed_files": 11,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-64",
+      "title": "Orchestrate skill Phase 4: auto-dispatch fixup on BLOCKED",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=757→M, files=4→S, domains=1→S",
+      "signals": {
+        "loc": 757,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-601",
+      "title": "Linear state flicker: implement-plan SKILL writes inProgress un-gated, regresses ticket from PR → Implement under phase-agents (CTL-558 follow-up)",
+      "tier": 2,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "medium",
+      "rationale": "LOC=39→XS, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 39,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-59",
+      "title": "orchestrate: consolidate per-orchestrator state into ~/catalyst/ (decouple from worktrees)",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=578→M, files=12→M, domains=1→S",
+      "signals": {
+        "loc": 578,
+        "changed_files": 12,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-584",
+      "title": "Execution-core monitor aborts own workers — daemon-written →Research/Plan/Implement/Validate/PR misread as drag-out kills",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=223→M, files=3→S, domains=1→S",
+      "signals": {
+        "loc": 223,
+        "changed_files": 3,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-576",
+      "title": "Apply execution-core Linear-state contract to CTL (config stateMap + stateIds migration)",
+      "tier": 2,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "medium",
+      "rationale": "LOC=32→XS, files=1→XS, domains=1→S",
+      "signals": {
+        "loc": 32,
+        "changed_files": 1,
+        "domains": [
+          ".catalyst"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-564",
+      "title": "[M4·scheduler] Execution-core Linear-state contract in setup tooling",
+      "tier": 1,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "high",
+      "rationale": "LOC=946→L, files=25→L, domains=1→S, cost=$1253.27→XL, turns=3994→XL, wall=26.63h→XL",
+      "signals": {
+        "loc": 946,
+        "changed_files": 25,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 1253.2731,
+        "turns": 3994,
+        "wall_hours": 26.6286
+      }
+    },
+    {
+      "ticket_id": "CTL-535",
+      "title": "[M4·scheduler] Linear Todo-state monitor",
+      "tier": 1,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "high",
+      "rationale": "LOC=1893→L, files=20→L, domains=3→L, cost=$304.97→XL, turns=904→XL, wall=2.34h→M; 3+-dirs(+1)",
+      "signals": {
+        "loc": 1893,
+        "changed_files": 20,
+        "domains": [
+          ".catalyst",
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 304.9702,
+        "turns": 904,
+        "wall_hours": 2.3423
+      }
+    },
+    {
+      "ticket_id": "CTL-529",
+      "title": "[M2·foundation] Refactor broker into the execution-core process skeleton + router module",
+      "tier": 1,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "high",
+      "rationale": "LOC=4693→XL, files=7→M, domains=1→S, cost=$376.48→XL, turns=1052→XL, wall=15.98h→L",
+      "signals": {
+        "loc": 4693,
+        "changed_files": 7,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 376.4837,
+        "turns": 1052,
+        "wall_hours": 15.9833
+      }
+    },
+    {
+      "ticket_id": "CTL-51",
+      "title": "Unified workspace/repo grouping view",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=381→M, files=6→M, domains=1→S",
+      "signals": {
+        "loc": 381,
+        "changed_files": 6,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-50",
+      "title": "SSE event architecture for multiple frontends",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=557→M, files=8→M, domains=1→S",
+      "signals": {
+        "loc": 557,
+        "changed_files": 8,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-487",
+      "title": "Orchestrator monitor loop is not invoking orchestrate-roll-usage.sh (CTL-455 fix is dead code in practice)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=335→M, files=4→S, domains=2→M, cost=$80.82→M, turns=226→M, wall=1.44h→M",
+      "signals": {
+        "loc": 335,
+        "changed_files": 4,
+        "domains": [
+          ".catalyst",
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 80.8178,
+        "turns": 226,
+        "wall_hours": 1.4382
+      }
+    },
+    {
+      "ticket_id": "CTL-476",
+      "title": "catalyst-hud: surface per-phase signal files for phase-agents mode workers",
+      "tier": 1,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "high",
+      "rationale": "LOC=1203→L, files=18→L, domains=2→M, cost=$912.87→XL, turns=2460→XL, wall=8.16h→L",
+      "signals": {
+        "loc": 1203,
+        "changed_files": 18,
+        "domains": [
+          "docs",
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 912.8733,
+        "turns": 2460,
+        "wall_hours": 8.1619
+      }
+    },
+    {
+      "ticket_id": "CTL-467",
+      "title": "Phase 1: research-curate skill — inventory + staleness + INDEX.md",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=819→L, files=6→M, domains=1→S, cost=$57.21→S, turns=163→S, wall=0.35h→S",
+      "signals": {
+        "loc": 819,
+        "changed_files": 6,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 57.2077,
+        "turns": 163,
+        "wall_hours": 0.3509
+      }
+    },
+    {
+      "ticket_id": "CTL-46",
+      "title": "Monitor: OTel-powered metrics panels",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=572→M, files=3→S, domains=1→S",
+      "signals": {
+        "loc": 572,
+        "changed_files": 3,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-454",
+      "title": "Follow-up: Add intermediate Linear states (Researching/Verifying/Reviewing) for phase-agent observability",
+      "tier": 1,
+      "tshirt": "L",
+      "points": 8,
+      "confidence": "high",
+      "rationale": "LOC=131→S, files=5→S, domains=3→L, cost=$41.38→S, turns=119→XS, wall=0.25h→XS; FE+BE→floor-M; 3+-dirs(+1)",
+      "signals": {
+        "loc": 131,
+        "changed_files": 5,
+        "domains": [
+          ".catalyst",
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 41.3778,
+        "turns": 119,
+        "wall_hours": 0.2533
+      }
+    },
+    {
+      "ticket_id": "CTL-449",
+      "title": "Phase 3: Implement phase-implement + phase-pr + phase-monitor-merge (MVP)",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=1088→L, files=6→M, domains=1→S, cost=$106.18→M, turns=273→M, wall=0.59h→S",
+      "signals": {
+        "loc": 1088,
+        "changed_files": 6,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 106.1821,
+        "turns": 273,
+        "wall_hours": 0.5862
+      }
+    },
+    {
+      "ticket_id": "CTL-40",
+      "title": "Monitor: SQLite reader and unified data source",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "LOC=874→L, files=9→M, domains=1→S",
+      "signals": {
+        "loc": 874,
+        "changed_files": 9,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-394",
+      "title": "HUD: user-configurable column display and order (with great defaults)",
+      "tier": 2,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "medium",
+      "rationale": "LOC=12→XS, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 12,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-383",
+      "title": "HUD: truncate long orchestrator IDs in ORCH column",
+      "tier": 1,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "high",
+      "rationale": "LOC=848→L, files=8→M, domains=1→S, cost=$1059.73→XL, turns=4899→XL, wall=66.48h→XL",
+      "signals": {
+        "loc": 848,
+        "changed_files": 8,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 1059.7273,
+        "turns": 4899,
+        "wall_hours": 66.4794
+      }
+    },
+    {
+      "ticket_id": "CTL-36",
+      "title": "Session data model & SQLite store",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "low",
+      "rationale": "LOC=862→L, files=4→S, domains=2→M; has-migration→floor-M",
+      "signals": {
+        "loc": 862,
+        "changed_files": 4,
+        "domains": [
+          "docs",
+          "plugins/dev"
+        ],
+        "has_migration": true,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-353",
+      "title": "HUD: Nerd Font detection + 1-cell in-progress glyph (CTL-351 follow-up)",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=371→M, files=6→M, domains=1→S",
+      "signals": {
+        "loc": 371,
+        "changed_files": 6,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-340",
+      "title": "fix(dev): broker suppresses all prose-matched wake events when source is canonical (id field missing)",
+      "tier": 1,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "high",
+      "rationale": "LOC=196→S, files=2→XS, domains=1→S, cost=$46.41→S, turns=124→XS, wall=0.14h→XS",
+      "signals": {
+        "loc": 196,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 46.4108,
+        "turns": 124,
+        "wall_hours": 0.1376
+      }
+    },
+    {
+      "ticket_id": "CTL-331",
+      "title": "fix(dev): broker/index.mjs writes filter.wake events in legacy shape — HUD drops them all",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=390→M, files=5→S, domains=1→S, cost=$78.36→S, turns=183→S, wall=0.55h→S",
+      "signals": {
+        "loc": 390,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 78.3612,
+        "turns": 183,
+        "wall_hours": 0.5547
+      }
+    },
+    {
+      "ticket_id": "CTL-323",
+      "title": "Update all documentation for the 4-plugin catalyst-pm split",
+      "tier": 1,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "high",
+      "rationale": "LOC=116→S, files=4→S, domains=2→M, cost=$4.25→XS, turns=127→XS, wall=0.15h→XS",
+      "signals": {
+        "loc": 116,
+        "changed_files": 4,
+        "domains": [
+          "README.md",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 4.2546,
+        "turns": 127,
+        "wall_hours": 0.1522
+      }
+    },
+    {
+      "ticket_id": "CTL-30",
+      "title": "Orchestrate: document & codify fix-up worker + follow-up ticket patterns",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "LOC=1006→L, files=14→M, domains=1→S",
+      "signals": {
+        "loc": 1006,
+        "changed_files": 14,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-271",
+      "title": "fix(dev): catalyst-filter daemon should read groq.apiKey from config.json when GROQ_API_KEY env var is not set",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=61→S, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 61,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-266",
+      "title": "feat(dev): event-schema reference doc — derive from TypeScript types so agents don't guess field names",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=592→M, files=4→S, domains=1→S",
+      "signals": {
+        "loc": 592,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-202",
+      "title": "Monitor mockup refresh — solo worker Kanban, PR icons, filters, orch worker board, todos prominence",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=78→S, files=1→XS, domains=1→S",
+      "signals": {
+        "loc": 78,
+        "changed_files": 1,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-178",
+      "title": "feat(meta): docs site drawn lockup + brand page light-dark rework",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=3118→XL, files=15→M, domains=2→M",
+      "signals": {
+        "loc": 3118,
+        "changed_files": 15,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-165",
+      "title": "Worker comms prompt guidance — message budgets, mandatory escalation, severity",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=119→S, files=3→S, domains=1→S",
+      "signals": {
+        "loc": 119,
+        "changed_files": 3,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-91",
+      "title": "Polish CTL-90 fix: init-or-repair should auto-fix profile drift, suggested-fix message is wrong",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=132→S, files=4→S, domains=1→S",
+      "signals": {
+        "loc": 132,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-80",
+      "title": "Oneshot workers must poll until PR actually merges before exiting",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=409→M, files=7→M, domains=2→M",
+      "signals": {
+        "loc": 409,
+        "changed_files": 7,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-73",
+      "title": "Session detail drawer",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "LOC=1380→L, files=15→M, domains=1→S",
+      "signals": {
+        "loc": 1380,
+        "changed_files": 15,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-638",
+      "title": "execution-core: recovery.mjs::defaultApplyStalledLabel bypasses labelOnce — 'no probe for phase' escalation re-fires needs-human label write on every tick (CTL-587 regression)",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=648→M, files=5→S, domains=1→S, cost=$72.93→S, turns=173→S, wall=1.76h→M",
+      "signals": {
+        "loc": 648,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 72.9294,
+        "turns": 173,
+        "wall_hours": 1.765
+      }
+    },
+    {
+      "ticket_id": "CTL-63",
+      "title": "Port revive-worker.sh session-resume pattern into orchestrator Phase 4",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=579→M, files=3→S, domains=1→S",
+      "signals": {
+        "loc": 579,
+        "changed_files": 3,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-589",
+      "title": "Execution-core scheduler terminal-Done sweep must accept monitor-deploy=skipped (CTL-512 followup)",
+      "tier": 2,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "medium",
+      "rationale": "LOC=43→XS, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 43,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-582",
+      "title": "Complete the execution-core daemon dispatch path — worktree provisioning + registry-driven enrollment (D4)",
+      "tier": 2,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "medium",
+      "rationale": "LOC=1981→L, files=32→XL, domains=3→L; 3+-dirs(+1)",
+      "signals": {
+        "loc": 1981,
+        "changed_files": 32,
+        "domains": [
+          "docs",
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-575",
+      "title": "setup-execution-core-states.sh: Linear GraphQL query uses non-existent workflowStates field",
+      "tier": 2,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "medium",
+      "rationale": "LOC=8→XS, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 8,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-533",
+      "title": "[M3·primitive] Deterministic per-event scan module",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=1643→L, files=14→M, domains=1→S, cost=$250.60→XL, turns=887→XL, wall=2.17h→M",
+      "signals": {
+        "loc": 1643,
+        "changed_files": 14,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 250.6024,
+        "turns": 887,
+        "wall_hours": 2.1716
+      }
+    },
+    {
+      "ticket_id": "CTL-528",
+      "title": "[M2·foundation] Aggregate test runner for shell + bun suites",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=283→M, files=4→S, domains=2→M, cost=$222.41→L, turns=916→XL, wall=1.82h→M",
+      "signals": {
+        "loc": 283,
+        "changed_files": 4,
+        "domains": [
+          "Makefile",
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 222.412,
+        "turns": 916,
+        "wall_hours": 1.8216
+      }
+    },
+    {
+      "ticket_id": "CTL-474",
+      "title": "Docs currency pass after phase-agent architecture ship (CTL-447 → CTL-470)",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=171→S, files=1→XS, domains=1→S",
+      "signals": {
+        "loc": 171,
+        "changed_files": 1,
+        "domains": [
+          "docs"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-465",
+      "title": "Phase 4: Resolution-notes write-back to briefing markdown",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=927→L, files=5→S, domains=2→M, cost=$86.19→M, turns=148→S, wall=0.29h→XS",
+      "signals": {
+        "loc": 927,
+        "changed_files": 5,
+        "domains": [
+          "cma",
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 86.1878,
+        "turns": 148,
+        "wall_hours": 0.2931
+      }
+    },
+    {
+      "ticket_id": "CTL-459",
+      "title": "Phase 4: ADR-drift detector",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=633→M, files=4→S, domains=1→S, cost=$50.45→S, turns=138→S, wall=0.21h→XS",
+      "signals": {
+        "loc": 633,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 50.4491,
+        "turns": 138,
+        "wall_hours": 0.2145
+      }
+    },
+    {
+      "ticket_id": "CTL-453",
+      "title": "Phase 7: End-to-end real-ticket run + cost measurement + docs",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=1576→L, files=5→S, domains=2→M, cost=$71.18→S, turns=252→M, wall=0.45h→S",
+      "signals": {
+        "loc": 1576,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 71.1794,
+        "turns": 252,
+        "wall_hours": 0.4503
+      }
+    },
+    {
+      "ticket_id": "CTL-448",
+      "title": "Phase 2: Build phase-agent skill scaffold + dispatch helper",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=1654→L, files=11→M, domains=2→M, cost=$112.09→M, turns=230→M, wall=0.43h→S",
+      "signals": {
+        "loc": 1654,
+        "changed_files": 11,
+        "domains": [
+          "cma",
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 112.0924,
+        "turns": 230,
+        "wall_hours": 0.431
+      }
+    },
+    {
+      "ticket_id": "CTL-41",
+      "title": "Monitor: single-session detail view",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=811→L, files=5→S, domains=1→S",
+      "signals": {
+        "loc": 811,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-37",
+      "title": "Session lifecycle CLI (catalyst-session)",
+      "tier": 2,
+      "tshirt": "XS",
+      "points": 1,
+      "confidence": "low",
+      "rationale": "LOC=881→L, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 881,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-359",
+      "title": "broker: tryDeterministicRoute has same canonical-envelope read bug as tryTicketLifecycleRoute did pre-CTL-357",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "high",
+      "rationale": "LOC=96→S, files=2→XS, domains=1→S, cost=$42.25→S, turns=145→S, wall=5.52h→L",
+      "signals": {
+        "loc": 96,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 42.2521,
+        "turns": 145,
+        "wall_hours": 5.5203
+      }
+    },
+    {
+      "ticket_id": "CTL-352",
+      "title": "broker interests integrity + empty-state observability",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=1047→L, files=7→M, domains=2→M, cost=$385.41→XL, turns=983→XL, wall=2.03h→M",
+      "signals": {
+        "loc": 1047,
+        "changed_files": 7,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 385.4131,
+        "turns": 983,
+        "wall_hours": 2.0346
+      }
+    },
+    {
+      "ticket_id": "CTL-346",
+      "title": "fix(dev): broker re-ingests its own filter.wake/broker.daemon emissions, causing wake feedback loop across orchestrators",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=128→S, files=2→XS, domains=1→S, cost=$150.61→L, turns=404→L, wall=1.65h→M",
+      "signals": {
+        "loc": 128,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 150.6143,
+        "turns": 404,
+        "wall_hours": 1.6501
+      }
+    },
+    {
+      "ticket_id": "CTL-339",
+      "title": "fix(dev): install-cli.sh should install shims to ~/.catalyst/bin (not ~/.local/bin) and own PATH setup",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=478→M, files=3→S, domains=2→M, cost=$251.59→XL, turns=455→L, wall=9.54h→L",
+      "signals": {
+        "loc": 478,
+        "changed_files": 3,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 251.5903,
+        "turns": 455,
+        "wall_hours": 9.5428
+      }
+    },
+    {
+      "ticket_id": "CTL-330",
+      "title": "fix(dev): catalyst-hud — improve comms event display in table rows",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=125→S, files=2→XS, domains=1→S, cost=$133.43→M, turns=296→M, wall=0.86h→M",
+      "signals": {
+        "loc": 125,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 133.4291,
+        "turns": 296,
+        "wall_hours": 0.8648
+      }
+    },
+    {
+      "ticket_id": "CTL-322",
+      "title": "Shrink catalyst-pm to 12 strategy/PRD skills (drop 3, verify after sibling migrations)",
+      "tier": 1,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=5637→XL, files=18→L, domains=3→L, cost=$6.02→XS, turns=133→S, wall=0.23h→XS; 3+-dirs(+1)",
+      "signals": {
+        "loc": 5637,
+        "changed_files": 18,
+        "domains": [
+          "plugins/dev",
+          "plugins/pm",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": 6.022,
+        "turns": 133,
+        "wall_hours": 0.2341
+      }
+    },
+    {
+      "ticket_id": "CTL-31",
+      "title": "Orchestrate: orchestrator-owned poll-until-MERGED (workers exit early)",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=413→M, files=5→S, domains=1→S",
+      "signals": {
+        "loc": 413,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-299",
+      "title": "[CMA] Generalize base agent for multi-project use (Catalyst, Adva)",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "LOC=820→L, files=6→M, domains=1→S",
+      "signals": {
+        "loc": 820,
+        "changed_files": 6,
+        "domains": [
+          "cma"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-270",
+      "title": "fix(dev): event filter bugs — Codex reviews silently dropped, oneshot review wake broken",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=30→XS, files=4→S, domains=1→S",
+      "signals": {
+        "loc": 30,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-26",
+      "title": "refactor: migrate workflow state from .claude/ to .catalyst/ and fix currentTicket bug",
+      "tier": 2,
+      "tshirt": "XL",
+      "points": 13,
+      "confidence": "high",
+      "rationale": "LOC=6239→XL, files=56→XL, domains=13→XL; 3+-dirs(+1)",
+      "signals": {
+        "loc": 6239,
+        "changed_files": 56,
+        "domains": [
+          ".catalyst",
+          ".claude",
+          ".gitignore",
+          "CLAUDE.md",
+          "Makefile",
+          "artifacts",
+          "docs",
+          "plugins/dev",
+          "plugins/meta",
+          "plugins/pm",
+          "scripts",
+          "setup-catalyst.sh",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-24",
+      "title": "ensure that Workflow Context ( `.claude/.workflow-context.json` ) is created and used properly",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=773→M, files=5→S, domains=2→M",
+      "signals": {
+        "loc": 773,
+        "changed_files": 5,
+        "domains": [
+          "Makefile",
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-200",
+      "title": "feat(meta): produce wordmark + lockup SVGs in Space Grotesk Medium",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=217→M, files=12→M, domains=2→M",
+      "signals": {
+        "loc": 217,
+        "changed_files": 12,
+        "domains": [
+          "assets",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-192",
+      "title": "feat: session state tracking + crash-resilient restart",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=294→M, files=4→S, domains=1→S",
+      "signals": {
+        "loc": 294,
+        "changed_files": 4,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-176",
+      "title": "catalyst skills: auto-file improvement tickets as completion checklist (orchestrate, oneshot, workers)",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=513→M, files=9→M, domains=2→M",
+      "signals": {
+        "loc": 513,
+        "changed_files": 9,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-90",
+      "title": "setup-catalyst silently masks broken thoughts symlinks by mkdir-ing thoughts/shared",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=686→M, files=5→S, domains=1→S",
+      "signals": {
+        "loc": 686,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-78",
+      "title": "AI-enhanced release notes with migration instructions",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=353→M, files=3→S, domains=2→M",
+      "signals": {
+        "loc": 353,
+        "changed_files": 3,
+        "domains": [
+          ".github",
+          "scripts"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-72",
+      "title": "Session time filter controls in sidebar",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=261→M, files=5→S, domains=1→S; FE+BE→floor-M",
+      "signals": {
+        "loc": 261,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-60",
+      "title": "feat: catalyst-comms — file-based agent communication channels",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=991→L, files=3→S, domains=1→S",
+      "signals": {
+        "loc": 991,
+        "changed_files": 3,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-588",
+      "title": "Execution-core reclaim trigger too narrow: bg job dir persists after worker exit (CTL-574 follow-up)",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "medium",
+      "rationale": "LOC=108→S, files=2→XS, domains=1→S",
+      "signals": {
+        "loc": 108,
+        "changed_files": 2,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-58",
+      "title": "orchestrate: remove HumanLayer dispatcher, go claude-only for worker dispatch",
+      "tier": 2,
+      "tshirt": "S",
+      "points": 3,
+      "confidence": "low",
+      "rationale": "LOC=1014→L, files=5→S, domains=2→M",
+      "signals": {
+        "loc": 1014,
+        "changed_files": 5,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": false
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-574",
+      "title": "phase-implement flagged failed (state-json-stale) despite all work committed — missed terminal emit",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=708→M, files=6→M, domains=1→S",
+      "signals": {
+        "loc": 708,
+        "changed_files": 6,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
+    {
+      "ticket_id": "CTL-554",
+      "title": "[M7·cutover] Third dispatchMode value: execution-core",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "high",
+      "rationale": "LOC=2162→XL, files=13→M, domains=2→M, cost=$352.19→XL, turns=1151→XL, wall=1.92h→M",
+      "signals": {
+        "loc": 2162,
+        "changed_files": 13,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 352.1881,
+        "turns": 1151,
+        "wall_hours": 1.9169
+      }
+    },
+    {
+      "ticket_id": "CTL-532",
+      "title": "[M3·primitive] Event-sourced worker-state projection",
+      "tier": 1,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=1828→L, files=6→M, domains=1→S, cost=$271.42→XL, turns=1059→XL, wall=1.86h→M",
+      "signals": {
+        "loc": 1828,
+        "changed_files": 6,
+        "domains": [
+          "plugins/dev"
+        ],
+        "has_migration": false,
+        "has_frontend": false,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": 271.4247,
+        "turns": 1059,
+        "wall_hours": 1.8568
+      }
+    },
+    {
+      "ticket_id": "CTL-52",
+      "title": "AI-powered status overview",
+      "tier": 2,
+      "tshirt": "M",
+      "points": 5,
+      "confidence": "medium",
+      "rationale": "LOC=1096→L, files=8→M, domains=2→M",
+      "signals": {
+        "loc": 1096,
+        "changed_files": 8,
+        "domains": [
+          "plugins/dev",
+          "website"
+        ],
+        "has_migration": false,
+        "has_frontend": true,
+        "has_backend": true
+      },
+      "actuals": {
+        "cost_usd": null,
+        "turns": null,
+        "wall_hours": null
+      }
+    },
     {
       "ticket_id": "ADV-87",
       "title": "",
@@ -14172,50 +18988,6 @@
       }
     },
     {
-      "ticket_id": "CTL-30",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1006,
-        "changed_files": 14,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 49.627545,
-        "turns": 138,
-        "wall_hours": 0.2706
-      }
-    },
-    {
-      "ticket_id": "CTL-31",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 413,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 41.619327,
-        "turns": 140,
-        "wall_hours": 0.2709
-      }
-    },
-    {
       "ticket_id": "CTL-32",
       "title": "",
       "tier": null,
@@ -14257,50 +19029,6 @@
         "cost_usd": null,
         "turns": null,
         "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-36",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 862,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 52.728687,
-        "turns": 139,
-        "wall_hours": 0.4969
-      }
-    },
-    {
-      "ticket_id": "CTL-37",
-      "title": "",
-      "tier": null,
-      "tshirt": "XS",
-      "points": 1,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 881,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 29.358411,
-        "turns": 85,
-        "wall_hours": 0.2218
       }
     },
     {
@@ -14348,50 +19076,6 @@
       }
     },
     {
-      "ticket_id": "CTL-40",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 874,
-        "changed_files": 9,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 44.121912,
-        "turns": 159,
-        "wall_hours": 0.2543
-      }
-    },
-    {
-      "ticket_id": "CTL-41",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": null,
-        "changed_files": null,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 111.052778,
-        "turns": 367,
-        "wall_hours": 2.2826
-      }
-    },
-    {
       "ticket_id": "CTL-42",
       "title": "",
       "tier": null,
@@ -14411,28 +19095,6 @@
         "cost_usd": 74.602592,
         "turns": 267,
         "wall_hours": 0.5263
-      }
-    },
-    {
-      "ticket_id": "CTL-43",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": null,
-        "changed_files": null,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 79.265689,
-        "turns": 305,
-        "wall_hours": 2.0746
       }
     },
     {
@@ -14477,28 +19139,6 @@
         "cost_usd": 63.933367,
         "turns": 217,
         "wall_hours": 1.8699
-      }
-    },
-    {
-      "ticket_id": "CTL-46",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": null,
-        "changed_files": null,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 86.94868,
-        "turns": 362,
-        "wall_hours": 0.6522
       }
     },
     {
@@ -14568,94 +19208,6 @@
       }
     },
     {
-      "ticket_id": "CTL-50",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": null,
-        "changed_files": null,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 65.737706,
-        "turns": 254,
-        "wall_hours": 0.6589
-      }
-    },
-    {
-      "ticket_id": "CTL-51",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": null,
-        "changed_files": null,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 78.144475,
-        "turns": 338,
-        "wall_hours": 0.5905
-      }
-    },
-    {
-      "ticket_id": "CTL-52",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": null,
-        "changed_files": null,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 89.347464,
-        "turns": 389,
-        "wall_hours": 2.367
-      }
-    },
-    {
-      "ticket_id": "CTL-53",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": null,
-        "changed_files": null,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 97.815096,
-        "turns": 376,
-        "wall_hours": 0.4843
-      }
-    },
-    {
       "ticket_id": "CTL-54",
       "title": "",
       "tier": null,
@@ -14675,72 +19227,6 @@
         "cost_usd": 62.792724,
         "turns": 221,
         "wall_hours": 0.4131
-      }
-    },
-    {
-      "ticket_id": "CTL-58",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1014,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 51.225056,
-        "turns": 137,
-        "wall_hours": 0.2361
-      }
-    },
-    {
-      "ticket_id": "CTL-59",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 578,
-        "changed_files": 12,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 86.903292,
-        "turns": 253,
-        "wall_hours": 0.4219
-      }
-    },
-    {
-      "ticket_id": "CTL-60",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 991,
-        "changed_files": 3,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 51.901554,
-        "turns": 168,
-        "wall_hours": 0.4724
       }
     },
     {
@@ -14766,50 +19252,6 @@
       }
     },
     {
-      "ticket_id": "CTL-63",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 579,
-        "changed_files": 3,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 51.756298,
-        "turns": 139,
-        "wall_hours": 0.2262
-      }
-    },
-    {
-      "ticket_id": "CTL-64",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 757,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 38.67604,
-        "turns": 153,
-        "wall_hours": 1.2947
-      }
-    },
-    {
       "ticket_id": "CTL-69",
       "title": "",
       "tier": null,
@@ -14829,72 +19271,6 @@
         "cost_usd": 45.545065,
         "turns": 145,
         "wall_hours": 0.2194
-      }
-    },
-    {
-      "ticket_id": "CTL-72",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": null,
-        "changed_files": null,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 40.015873,
-        "turns": 193,
-        "wall_hours": 0.2774
-      }
-    },
-    {
-      "ticket_id": "CTL-73",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": null,
-        "changed_files": null,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 40.987971,
-        "turns": 166,
-        "wall_hours": 0.2786
-      }
-    },
-    {
-      "ticket_id": "CTL-74",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": null,
-        "changed_files": null,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 41.030871,
-        "turns": 179,
-        "wall_hours": 0.2949
       }
     },
     {
@@ -14964,50 +19340,6 @@
       }
     },
     {
-      "ticket_id": "CTL-78",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": null,
-        "changed_files": null,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 29.831249,
-        "turns": 137,
-        "wall_hours": 0.2762
-      }
-    },
-    {
-      "ticket_id": "CTL-80",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": null,
-        "changed_files": null,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 34.307998,
-        "turns": 123,
-        "wall_hours": 0.2559
-      }
-    },
-    {
       "ticket_id": "CTL-86",
       "title": "",
       "tier": null,
@@ -15071,50 +19403,6 @@
         "cost_usd": 36.229331,
         "turns": 113,
         "wall_hours": 0.1937
-      }
-    },
-    {
-      "ticket_id": "CTL-90",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 686,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 57.401397,
-        "turns": 152,
-        "wall_hours": 1.0631
-      }
-    },
-    {
-      "ticket_id": "CTL-91",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 132,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 39.970446,
-        "turns": 94,
-        "wall_hours": 21.1224
       }
     },
     {
@@ -16240,28 +20528,6 @@
       }
     },
     {
-      "ticket_id": "CTL-165",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 119,
-        "changed_files": 3,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 57.170902,
-        "turns": 104,
-        "wall_hours": 39.4771
-      }
-    },
-    {
       "ticket_id": "CTL-166",
       "title": "",
       "tier": null,
@@ -16394,50 +20660,6 @@
       }
     },
     {
-      "ticket_id": "CTL-176",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 513,
-        "changed_files": 9,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 56.908451,
-        "turns": 142,
-        "wall_hours": 0.3283
-      }
-    },
-    {
-      "ticket_id": "CTL-178",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 3196,
-        "changed_files": 15,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 123.191806,
-        "turns": 337,
-        "wall_hours": 1.4395
-      }
-    },
-    {
       "ticket_id": "CTL-182",
       "title": "",
       "tier": null,
@@ -16523,28 +20745,6 @@
         "cost_usd": 34.021476,
         "turns": 74,
         "wall_hours": 0.0828
-      }
-    },
-    {
-      "ticket_id": "CTL-192",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 294,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 39.050262,
-        "turns": 159,
-        "wall_hours": 0.4331
       }
     },
     {
@@ -16636,28 +20836,6 @@
       }
     },
     {
-      "ticket_id": "CTL-200",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 217,
-        "changed_files": 12,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 44.72983,
-        "turns": 157,
-        "wall_hours": 67.5322
-      }
-    },
-    {
       "ticket_id": "CTL-201",
       "title": "",
       "tier": null,
@@ -16677,28 +20855,6 @@
         "cost_usd": null,
         "turns": null,
         "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-202",
-      "title": "",
-      "tier": null,
-      "tshirt": "XL",
-      "points": 13,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 3349,
-        "changed_files": 8,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 38.141107,
-        "turns": 687,
-        "wall_hours": 118.1902
       }
     },
     {
@@ -17846,28 +22002,6 @@
       }
     },
     {
-      "ticket_id": "CTL-266",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": null,
-        "changed_files": null,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 9.740382,
-        "turns": 185,
-        "wall_hours": 2.9314
-      }
-    },
-    {
       "ticket_id": "CTL-267",
       "title": "",
       "tier": null,
@@ -17931,50 +22065,6 @@
         "cost_usd": 117.775413,
         "turns": 197,
         "wall_hours": 0.4845
-      }
-    },
-    {
-      "ticket_id": "CTL-270",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 30,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 84.762017,
-        "turns": 170,
-        "wall_hours": 2.6922
-      }
-    },
-    {
-      "ticket_id": "CTL-271",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": null,
-        "changed_files": null,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 10.064718,
-        "turns": 187,
-        "wall_hours": 18.7433
       }
     },
     {
@@ -18305,28 +22395,6 @@
         "cost_usd": 297.329697,
         "turns": 478,
         "wall_hours": 188.6385
-      }
-    },
-    {
-      "ticket_id": "CTL-299",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 820,
-        "changed_files": 6,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
       }
     },
     {
@@ -18704,50 +22772,6 @@
       }
     },
     {
-      "ticket_id": "CTL-322",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 5637,
-        "changed_files": 18,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 6.740963,
-        "turns": 133,
-        "wall_hours": 0.2375
-      }
-    },
-    {
-      "ticket_id": "CTL-323",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 116,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 4.3422,
-        "turns": 88,
-        "wall_hours": 0.1282
-      }
-    },
-    {
       "ticket_id": "CTL-324",
       "title": "",
       "tier": null,
@@ -18833,50 +22857,6 @@
         "cost_usd": 56.508077,
         "turns": 147,
         "wall_hours": 0.3452
-      }
-    },
-    {
-      "ticket_id": "CTL-330",
-      "title": "",
-      "tier": null,
-      "tshirt": "XS",
-      "points": 1,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 125,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 65.521047,
-        "turns": 127,
-        "wall_hours": 0.2001
-      }
-    },
-    {
-      "ticket_id": "CTL-331",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 390,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 93.171047,
-        "turns": 183,
-        "wall_hours": 0.624
       }
     },
     {
@@ -18968,50 +22948,6 @@
       }
     },
     {
-      "ticket_id": "CTL-339",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 478,
-        "changed_files": 3,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 107.826626,
-        "turns": 147,
-        "wall_hours": 5.7808
-      }
-    },
-    {
-      "ticket_id": "CTL-340",
-      "title": "",
-      "tier": null,
-      "tshirt": "XS",
-      "points": 1,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 196,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 57.609938,
-        "turns": 124,
-        "wall_hours": 0.1421
-      }
-    },
-    {
       "ticket_id": "CTL-341",
       "title": "",
       "tier": null,
@@ -19097,28 +23033,6 @@
         "cost_usd": 132.617253,
         "turns": 271,
         "wall_hours": 0.5583
-      }
-    },
-    {
-      "ticket_id": "CTL-346",
-      "title": "",
-      "tier": null,
-      "tshirt": "XS",
-      "points": 1,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 77,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 50.100774,
-        "turns": 109,
-        "wall_hours": 0.1424
       }
     },
     {
@@ -19210,50 +23124,6 @@
       }
     },
     {
-      "ticket_id": "CTL-352",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 667,
-        "changed_files": 6,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 85.393496,
-        "turns": 206,
-        "wall_hours": 0.3951
-      }
-    },
-    {
-      "ticket_id": "CTL-353",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 371,
-        "changed_files": 6,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
       "ticket_id": "CTL-354",
       "title": "",
       "tier": null,
@@ -19339,28 +23209,6 @@
         "cost_usd": null,
         "turns": null,
         "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-359",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 96,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 50.474393,
-        "turns": 145,
-        "wall_hours": 5.5423
       }
     },
     {
@@ -19694,28 +23542,6 @@
       }
     },
     {
-      "ticket_id": "CTL-378",
-      "title": "",
-      "tier": null,
-      "tshirt": "L",
-      "points": 8,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 2427,
-        "changed_files": 3,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 260.654487,
-        "turns": 527,
-        "wall_hours": 18.8953
-      }
-    },
-    {
       "ticket_id": "CTL-380",
       "title": "",
       "tier": null,
@@ -19757,28 +23583,6 @@
         "cost_usd": 156.828082,
         "turns": 376,
         "wall_hours": 1.8279
-      }
-    },
-    {
-      "ticket_id": "CTL-383",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 131,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 73.046148,
-        "turns": 186,
-        "wall_hours": 0.5332
       }
     },
     {
@@ -19999,28 +23803,6 @@
         "cost_usd": 8.883797,
         "turns": 199,
         "wall_hours": 22.0957
-      }
-    },
-    {
-      "ticket_id": "CTL-394",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 860,
-        "changed_files": 8,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 17.45141,
-        "turns": 296,
-        "wall_hours": 21.2096
       }
     },
     {
@@ -20970,50 +24752,6 @@
       }
     },
     {
-      "ticket_id": "CTL-448",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1654,
-        "changed_files": 11,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 129.46125,
-        "turns": 230,
-        "wall_hours": 0.4353
-      }
-    },
-    {
-      "ticket_id": "CTL-449",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1088,
-        "changed_files": 6,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 106.935193,
-        "turns": 211,
-        "wall_hours": 0.5224
-      }
-    },
-    {
       "ticket_id": "CTL-450",
       "title": "",
       "tier": null,
@@ -21077,50 +24815,6 @@
         "cost_usd": 126.399123,
         "turns": 232,
         "wall_hours": 0.6084
-      }
-    },
-    {
-      "ticket_id": "CTL-453",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1576,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 79.738237,
-        "turns": 166,
-        "wall_hours": 0.3649
-      }
-    },
-    {
-      "ticket_id": "CTL-454",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 131,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 46.549425,
-        "turns": 119,
-        "wall_hours": 0.257
       }
     },
     {
@@ -21209,28 +24903,6 @@
         "cost_usd": 80.90921,
         "turns": 164,
         "wall_hours": 0.4126
-      }
-    },
-    {
-      "ticket_id": "CTL-459",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 633,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 59.766582,
-        "turns": 138,
-        "wall_hours": 0.2168
       }
     },
     {
@@ -21344,28 +25016,6 @@
       }
     },
     {
-      "ticket_id": "CTL-465",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 927,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 107.149018,
-        "turns": 148,
-        "wall_hours": 0.295
-      }
-    },
-    {
       "ticket_id": "CTL-466",
       "title": "",
       "tier": null,
@@ -21385,28 +25035,6 @@
         "cost_usd": 16.682458,
         "turns": 42,
         "wall_hours": 0.0446
-      }
-    },
-    {
-      "ticket_id": "CTL-467",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 819,
-        "changed_files": 6,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 64.495008,
-        "turns": 163,
-        "wall_hours": 0.3537
       }
     },
     {
@@ -21495,50 +25123,6 @@
         "cost_usd": 232.313975,
         "turns": 651,
         "wall_hours": 3.0562
-      }
-    },
-    {
-      "ticket_id": "CTL-474",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 715,
-        "changed_files": 8,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-476",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 307,
-        "changed_files": 7,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 105.539383,
-        "turns": 229,
-        "wall_hours": 0.5846
       }
     },
     {
@@ -21759,28 +25343,6 @@
         "cost_usd": 70.290515,
         "turns": 128,
         "wall_hours": 0.3143
-      }
-    },
-    {
-      "ticket_id": "CTL-487",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 335,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
       }
     },
     {
@@ -22136,50 +25698,6 @@
       }
     },
     {
-      "ticket_id": "CTL-528",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 600,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 200.633817,
-        "turns": 491,
-        "wall_hours": 2.3733
-      }
-    },
-    {
-      "ticket_id": "CTL-529",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 9602,
-        "changed_files": 7,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 355.445777,
-        "turns": 550,
-        "wall_hours": 15.1146
-      }
-    },
-    {
       "ticket_id": "CTL-530",
       "title": "",
       "tier": null,
@@ -22221,72 +25739,6 @@
         "cost_usd": 203.132841,
         "turns": 493,
         "wall_hours": 2.1238
-      }
-    },
-    {
-      "ticket_id": "CTL-532",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 3896,
-        "changed_files": 6,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 162.472662,
-        "turns": 402,
-        "wall_hours": 1.9523
-      }
-    },
-    {
-      "ticket_id": "CTL-533",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 3302,
-        "changed_files": 14,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 208.97124,
-        "turns": 494,
-        "wall_hours": 2.4819
-      }
-    },
-    {
-      "ticket_id": "CTL-535",
-      "title": "",
-      "tier": null,
-      "tshirt": "L",
-      "points": 8,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 3650,
-        "changed_files": 20,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 285.863805,
-        "turns": 547,
-        "wall_hours": 2.6621
       }
     },
     {
@@ -22356,28 +25808,6 @@
       }
     },
     {
-      "ticket_id": "CTL-554",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 2235,
-        "changed_files": 13,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 327.701442,
-        "turns": 640,
-        "wall_hours": 2.2846
-      }
-    },
-    {
       "ticket_id": "CTL-558",
       "title": "",
       "tier": null,
@@ -22397,28 +25827,6 @@
         "cost_usd": 193.855284,
         "turns": 422,
         "wall_hours": 1.8014
-      }
-    },
-    {
-      "ticket_id": "CTL-564",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 2926,
-        "changed_files": 14,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 272.081877,
-        "turns": 662,
-        "wall_hours": 1.6865
       }
     },
     {
@@ -22510,94 +25918,6 @@
       }
     },
     {
-      "ticket_id": "CTL-573",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 312,
-        "changed_files": 3,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 110.736891,
-        "turns": 342,
-        "wall_hours": 8.8022
-      }
-    },
-    {
-      "ticket_id": "CTL-574",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1416,
-        "changed_files": 6,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-575",
-      "title": "",
-      "tier": null,
-      "tshirt": "XS",
-      "points": 1,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 8,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-576",
-      "title": "",
-      "tier": null,
-      "tshirt": "XS",
-      "points": 1,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 32,
-        "changed_files": 1,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
       "ticket_id": "CTL-577",
       "title": "",
       "tier": null,
@@ -22664,72 +25984,6 @@
       }
     },
     {
-      "ticket_id": "CTL-582",
-      "title": "",
-      "tier": null,
-      "tshirt": "XL",
-      "points": 13,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 3984,
-        "changed_files": 32,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-584",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 446,
-        "changed_files": 3,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-585",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1371,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 120.664619,
-        "turns": 410,
-        "wall_hours": 4.5595
-      }
-    },
-    {
       "ticket_id": "CTL-586",
       "title": "",
       "tier": null,
@@ -22774,94 +26028,6 @@
       }
     },
     {
-      "ticket_id": "CTL-588",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 216,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-589",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 86,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-596",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1328,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 247.735918,
-        "turns": 630,
-        "wall_hours": 9.0205
-      }
-    },
-    {
-      "ticket_id": "CTL-597",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 321,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 137.891502,
-        "turns": 422,
-        "wall_hours": 8.5062
-      }
-    },
-    {
       "ticket_id": "CTL-598",
       "title": "",
       "tier": null,
@@ -22881,50 +26047,6 @@
         "cost_usd": 98.442291,
         "turns": 312,
         "wall_hours": 19.7007
-      }
-    },
-    {
-      "ticket_id": "CTL-600",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 2,
-        "changed_files": 1,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 104.97408,
-        "turns": 344,
-        "wall_hours": 8.3089
-      }
-    },
-    {
-      "ticket_id": "CTL-601",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 78,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
       }
     },
     {
@@ -22950,116 +26072,6 @@
       }
     },
     {
-      "ticket_id": "CTL-604",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1778,
-        "changed_files": 9,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 488.094683,
-        "turns": 1197,
-        "wall_hours": 22.2167
-      }
-    },
-    {
-      "ticket_id": "CTL-605",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 402,
-        "changed_files": 3,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 134.091154,
-        "turns": 346,
-        "wall_hours": 2.4577
-      }
-    },
-    {
-      "ticket_id": "CTL-606",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 366,
-        "changed_files": 7,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 325.385378,
-        "turns": 898,
-        "wall_hours": 22.206
-      }
-    },
-    {
-      "ticket_id": "CTL-607",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 632,
-        "changed_files": 6,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 241.455097,
-        "turns": 689,
-        "wall_hours": 31.0801
-      }
-    },
-    {
-      "ticket_id": "CTL-608",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 726,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 330.23131,
-        "turns": 827,
-        "wall_hours": 22.183
-      }
-    },
-    {
       "ticket_id": "CTL-609",
       "title": "",
       "tier": null,
@@ -23079,50 +26091,6 @@
         "cost_usd": 122.93298,
         "turns": 294,
         "wall_hours": 18.9645
-      }
-    },
-    {
-      "ticket_id": "CTL-610",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 750,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 264.182589,
-        "turns": 582,
-        "wall_hours": 22.1728
-      }
-    },
-    {
-      "ticket_id": "CTL-611",
-      "title": "",
-      "tier": null,
-      "tshirt": "L",
-      "points": 8,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1084,
-        "changed_files": 7,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 434.640681,
-        "turns": 1182,
-        "wall_hours": 38.4595
       }
     },
     {
@@ -23148,72 +26116,6 @@
       }
     },
     {
-      "ticket_id": "CTL-613",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1096,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 306.110824,
-        "turns": 835,
-        "wall_hours": 20.7364
-      }
-    },
-    {
-      "ticket_id": "CTL-614",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 180,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 168.747083,
-        "turns": 587,
-        "wall_hours": 22.1497
-      }
-    },
-    {
-      "ticket_id": "CTL-615",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1359,
-        "changed_files": 15,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 277.41689,
-        "turns": 771,
-        "wall_hours": 22.1365
-      }
-    },
-    {
       "ticket_id": "CTL-616",
       "title": "",
       "tier": null,
@@ -23233,50 +26135,6 @@
         "cost_usd": 98.977275,
         "turns": 308,
         "wall_hours": 19.8973
-      }
-    },
-    {
-      "ticket_id": "CTL-617",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 174,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 158.128006,
-        "turns": 480,
-        "wall_hours": 22.1384
-      }
-    },
-    {
-      "ticket_id": "CTL-618",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 246,
-        "changed_files": 3,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 116.079358,
-        "turns": 347,
-        "wall_hours": 2.2466
       }
     },
     {
@@ -23302,314 +26160,6 @@
       }
     },
     {
-      "ticket_id": "CTL-623",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 384,
-        "changed_files": 6,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 154.494904,
-        "turns": 394,
-        "wall_hours": 7.8364
-      }
-    },
-    {
-      "ticket_id": "CTL-624",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 611,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 182.218303,
-        "turns": 559,
-        "wall_hours": 2.4415
-      }
-    },
-    {
-      "ticket_id": "CTL-625",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 336,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 250.364315,
-        "turns": 606,
-        "wall_hours": 6.4549
-      }
-    },
-    {
-      "ticket_id": "CTL-628",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 30,
-        "changed_files": 3,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-632",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 2612,
-        "changed_files": 13,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 175.634157,
-        "turns": 526,
-        "wall_hours": 3.23
-      }
-    },
-    {
-      "ticket_id": "CTL-633",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 797,
-        "changed_files": 11,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 189.454063,
-        "turns": 515,
-        "wall_hours": 2.9179
-      }
-    },
-    {
-      "ticket_id": "CTL-634",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1266,
-        "changed_files": 11,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 218.413648,
-        "turns": 547,
-        "wall_hours": 3.0401
-      }
-    },
-    {
-      "ticket_id": "CTL-635",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 204,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 309.029976,
-        "turns": 743,
-        "wall_hours": 22.7902
-      }
-    },
-    {
-      "ticket_id": "CTL-636",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 464,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 131.564189,
-        "turns": 389,
-        "wall_hours": 2.8843
-      }
-    },
-    {
-      "ticket_id": "CTL-637",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 687,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 139.53092,
-        "turns": 432,
-        "wall_hours": 0.9771
-      }
-    },
-    {
-      "ticket_id": "CTL-638",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1944,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 85.995287,
-        "turns": 173,
-        "wall_hours": 2.2218
-      }
-    },
-    {
-      "ticket_id": "CTL-640",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 283,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 335.7172,
-        "turns": 890,
-        "wall_hours": 8.4396
-      }
-    },
-    {
-      "ticket_id": "CTL-641",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 785,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 599.181355,
-        "turns": 1336,
-        "wall_hours": 8.4401
-      }
-    },
-    {
-      "ticket_id": "CTL-643",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1340,
-        "changed_files": 9,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 182.078839,
-        "turns": 546,
-        "wall_hours": 2.8103
-      }
-    },
-    {
       "ticket_id": "CTL-649",
       "title": "",
       "tier": null,
@@ -23629,160 +26179,6 @@
         "cost_usd": 1855.533115,
         "turns": 2517,
         "wall_hours": 41.7671
-      }
-    },
-    {
-      "ticket_id": "CTL-650",
-      "title": "",
-      "tier": null,
-      "tshirt": "L",
-      "points": 8,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 2954,
-        "changed_files": 16,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 269.566689,
-        "turns": 654,
-        "wall_hours": 1.1989
-      }
-    },
-    {
-      "ticket_id": "CTL-653",
-      "title": "",
-      "tier": null,
-      "tshirt": "L",
-      "points": 8,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 2265,
-        "changed_files": 17,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 322.757455,
-        "turns": 654,
-        "wall_hours": 2.4397
-      }
-    },
-    {
-      "ticket_id": "CTL-654",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1320,
-        "changed_files": 7,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 292.862253,
-        "turns": 565,
-        "wall_hours": 2.4373
-      }
-    },
-    {
-      "ticket_id": "CTL-655",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 526,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 201.499836,
-        "turns": 507,
-        "wall_hours": 2.4394
-      }
-    },
-    {
-      "ticket_id": "CTL-656",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 80,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 154.245283,
-        "turns": 299,
-        "wall_hours": 0.6372
-      }
-    },
-    {
-      "ticket_id": "CTL-657",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1892,
-        "changed_files": 12,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-658",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1334,
-        "changed_files": 9,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 338.520524,
-        "turns": 828,
-        "wall_hours": 1.6015
       }
     },
     {
@@ -23808,72 +26204,6 @@
       }
     },
     {
-      "ticket_id": "CTL-660",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1644,
-        "changed_files": 9,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 336.745451,
-        "turns": 911,
-        "wall_hours": 5.6481
-      }
-    },
-    {
-      "ticket_id": "CTL-661",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1946,
-        "changed_files": 11,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 333.210313,
-        "turns": 907,
-        "wall_hours": 1.6782
-      }
-    },
-    {
-      "ticket_id": "CTL-662",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 2078,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 392.250969,
-        "turns": 885,
-        "wall_hours": 1.8201
-      }
-    },
-    {
       "ticket_id": "CTL-663",
       "title": "",
       "tier": null,
@@ -23896,314 +26226,6 @@
       }
     },
     {
-      "ticket_id": "CTL-664",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 799,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 240.439102,
-        "turns": 678,
-        "wall_hours": 1.1064
-      }
-    },
-    {
-      "ticket_id": "CTL-665",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 880,
-        "changed_files": 11,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 313.129666,
-        "turns": 848,
-        "wall_hours": 1.6132
-      }
-    },
-    {
-      "ticket_id": "CTL-666",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 534,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 163.504371,
-        "turns": 453,
-        "wall_hours": 0.8885
-      }
-    },
-    {
-      "ticket_id": "CTL-667",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1296,
-        "changed_files": 8,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 227.597511,
-        "turns": 542,
-        "wall_hours": 0.992
-      }
-    },
-    {
-      "ticket_id": "CTL-668",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 894,
-        "changed_files": 15,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-670",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 730,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 162.077721,
-        "turns": 426,
-        "wall_hours": 0.7459
-      }
-    },
-    {
-      "ticket_id": "CTL-671",
-      "title": "",
-      "tier": null,
-      "tshirt": "L",
-      "points": 8,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 966,
-        "changed_files": 17,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 375.419287,
-        "turns": 834,
-        "wall_hours": 10.9528
-      }
-    },
-    {
-      "ticket_id": "CTL-672",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 974,
-        "changed_files": 6,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-673",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1068,
-        "changed_files": 7,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 191.039346,
-        "turns": 564,
-        "wall_hours": 1.2709
-      }
-    },
-    {
-      "ticket_id": "CTL-674",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 290,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 136.261155,
-        "turns": 470,
-        "wall_hours": 0.9586
-      }
-    },
-    {
-      "ticket_id": "CTL-675",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 890,
-        "changed_files": 11,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 211.297303,
-        "turns": 607,
-        "wall_hours": 0.9973
-      }
-    },
-    {
-      "ticket_id": "CTL-676",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 891,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 126.516779,
-        "turns": 411,
-        "wall_hours": 1.6981
-      }
-    },
-    {
-      "ticket_id": "CTL-678",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1224,
-        "changed_files": 6,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 230.250654,
-        "turns": 718,
-        "wall_hours": 3.9005
-      }
-    },
-    {
-      "ticket_id": "CTL-679",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 824,
-        "changed_files": 11,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
       "ticket_id": "CTL-680",
       "title": "",
       "tier": null,
@@ -24223,28 +26245,6 @@
         "cost_usd": 86.995151,
         "turns": 418,
         "wall_hours": 1.2911
-      }
-    },
-    {
-      "ticket_id": "CTL-681",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1866,
-        "changed_files": 9,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 115.102846,
-        "turns": 588,
-        "wall_hours": 1.2502
       }
     },
     {
@@ -24292,116 +26292,6 @@
       }
     },
     {
-      "ticket_id": "CTL-684",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 2600,
-        "changed_files": 14,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 98.775071,
-        "turns": 559,
-        "wall_hours": 1.1923
-      }
-    },
-    {
-      "ticket_id": "CTL-685",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 2456,
-        "changed_files": 12,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 101.866676,
-        "turns": 528,
-        "wall_hours": 0.8201
-      }
-    },
-    {
-      "ticket_id": "CTL-688",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 188,
-        "changed_files": 4,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 81.792204,
-        "turns": 423,
-        "wall_hours": 0.7902
-      }
-    },
-    {
-      "ticket_id": "CTL-689",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 456,
-        "changed_files": 3,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-690",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 534,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
       "ticket_id": "CTL-692",
       "title": "",
       "tier": null,
@@ -24421,50 +26311,6 @@
         "cost_usd": 30.232673,
         "turns": 142,
         "wall_hours": 0.5112
-      }
-    },
-    {
-      "ticket_id": "CTL-694",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1986,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 89.32958,
-        "turns": 459,
-        "wall_hours": 13.6001
-      }
-    },
-    {
-      "ticket_id": "CTL-695",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1122,
-        "changed_files": 8,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 720.709288,
-        "turns": 858,
-        "wall_hours": 14.5753
       }
     },
     {
@@ -24490,50 +26336,6 @@
       }
     },
     {
-      "ticket_id": "CTL-701",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1188,
-        "changed_files": 7,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 76.547451,
-        "turns": 495,
-        "wall_hours": 1.0252
-      }
-    },
-    {
-      "ticket_id": "CTL-702",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 718,
-        "changed_files": 7,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 111.24954,
-        "turns": 488,
-        "wall_hours": 7.0339
-      }
-    },
-    {
       "ticket_id": "CTL-703",
       "title": "",
       "tier": null,
@@ -24556,248 +26358,6 @@
       }
     },
     {
-      "ticket_id": "CTL-704",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 976,
-        "changed_files": 9,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 104.300672,
-        "turns": 513,
-        "wall_hours": 0.8949
-      }
-    },
-    {
-      "ticket_id": "CTL-705",
-      "title": "",
-      "tier": null,
-      "tshirt": "L",
-      "points": 8,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 3622,
-        "changed_files": 11,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 1253.509668,
-        "turns": 1389,
-        "wall_hours": 2.3856
-      }
-    },
-    {
-      "ticket_id": "CTL-706",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1280,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 113.049817,
-        "turns": 566,
-        "wall_hours": 1.179
-      }
-    },
-    {
-      "ticket_id": "CTL-707",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 3116,
-        "changed_files": 14,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 669.733874,
-        "turns": 839,
-        "wall_hours": 14.4291
-      }
-    },
-    {
-      "ticket_id": "CTL-709",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 2420,
-        "changed_files": 7,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 105.406756,
-        "turns": 474,
-        "wall_hours": 0.9509
-      }
-    },
-    {
-      "ticket_id": "CTL-710",
-      "title": "",
-      "tier": null,
-      "tshirt": "L",
-      "points": 8,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 2686,
-        "changed_files": 10,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 432.010488,
-        "turns": 354,
-        "wall_hours": 27.5446
-      }
-    },
-    {
-      "ticket_id": "CTL-711",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 352,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 227.826355,
-        "turns": 574,
-        "wall_hours": 21.2988
-      }
-    },
-    {
-      "ticket_id": "CTL-712",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 310,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 211.22251,
-        "turns": 533,
-        "wall_hours": 0.9671
-      }
-    },
-    {
-      "ticket_id": "CTL-713",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 940,
-        "changed_files": 5,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 166.39451,
-        "turns": 774,
-        "wall_hours": 14.1042
-      }
-    },
-    {
-      "ticket_id": "CTL-714",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 873,
-        "changed_files": 2,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 93.80001,
-        "turns": 471,
-        "wall_hours": 13.5528
-      }
-    },
-    {
-      "ticket_id": "CTL-715",
-      "title": "",
-      "tier": null,
-      "tshirt": "XS",
-      "points": 1,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 24,
-        "changed_files": 1,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
       "ticket_id": "CTL-718",
       "title": "",
       "tier": null,
@@ -24817,28 +26377,6 @@
         "cost_usd": 17.538544,
         "turns": 92,
         "wall_hours": 0.2207
-      }
-    },
-    {
-      "ticket_id": "CTL-726",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 595,
-        "changed_files": 50,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 155.86295,
-        "turns": 1506,
-        "wall_hours": 13.4217
       }
     },
     {
@@ -24905,138 +26443,6 @@
         "cost_usd": 0,
         "turns": 561,
         "wall_hours": 3.987
-      }
-    },
-    {
-      "ticket_id": "CTL-730",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1066,
-        "changed_files": 13,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-731",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1659,
-        "changed_files": 11,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 0,
-        "turns": 190,
-        "wall_hours": 2.6224
-      }
-    },
-    {
-      "ticket_id": "CTL-732",
-      "title": "",
-      "tier": null,
-      "tshirt": "XS",
-      "points": 1,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 46,
-        "changed_files": 1,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-733",
-      "title": "",
-      "tier": null,
-      "tshirt": "L",
-      "points": 8,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 2686,
-        "changed_files": 20,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-735",
-      "title": "",
-      "tier": null,
-      "tshirt": "M",
-      "points": 5,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1504,
-        "changed_files": 10,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
-      }
-    },
-    {
-      "ticket_id": "CTL-736",
-      "title": "",
-      "tier": null,
-      "tshirt": "L",
-      "points": 8,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 7408,
-        "changed_files": 26,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": null,
-        "turns": null,
-        "wall_hours": null
       }
     },
     {
@@ -25150,50 +26556,6 @@
       }
     },
     {
-      "ticket_id": "CTL-747",
-      "title": "",
-      "tier": null,
-      "tshirt": "S",
-      "points": 3,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": null,
-        "changed_files": null,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 2.573568,
-        "turns": 52,
-        "wall_hours": 0.0545
-      }
-    },
-    {
-      "ticket_id": "CTL-748",
-      "title": "",
-      "tier": null,
-      "tshirt": "L",
-      "points": 8,
-      "confidence": "low",
-      "rationale": "reconstructed from CTL-746 actuals corpus",
-      "signals": {
-        "loc": 1146,
-        "changed_files": 32,
-        "domains": [],
-        "has_migration": false,
-        "has_frontend": false,
-        "has_backend": false
-      },
-      "actuals": {
-        "cost_usd": 105.234499,
-        "turns": 713,
-        "wall_hours": 3.1255
-      }
-    },
-    {
       "ticket_id": "CTL-749",
       "title": "",
       "tier": null,
@@ -25215,5 +26577,6 @@
         "wall_hours": 0.0533
       }
     }
-  ]
+  ],
+  "count": 1186
 }

--- a/plugins/pm/scripts/estimate/refresh-corpus.sh
+++ b/plugins/pm/scripts/estimate/refresh-corpus.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# refresh-corpus.sh — re-run the corpus WRITE SIDE from real actuals (CTL-813).
+#
+# Closes the estimation feedback loop: until CTL-813 the committed read-side
+# corpus (reference-class-corpus.json) was a frozen one-shot bootstrap
+# (CTL-751) produced by the lossy adapt-reference-corpus.ts path (title=''
+# / tier=null / empty signals). This script makes score-tickets.ts the
+# RECURRING producer:
+#
+#   1. Extract    bun extract-actuals-from-transcripts.ts  → actuals.csv
+#   2. Aggregate  compound-log.sh aggregate                → human re-scores
+#   3. Collect    bun collect-ticket-signals.ts            → signals.csv
+#   4. Score      bun score-tickets.ts --check-labels      → fresh corpus
+#   5. Merge      fresh entries REPLACE same-ticket old entries; old entries
+#                 not re-scored are RETAINED (e.g. the ADV bootstrap anchors
+#                 whose PRs live in another repo). generated_at advances.
+#   6. Commit     (--commit) git add + commit the corpus.
+#
+# adapt-reference-corpus.ts stays bootstrap-only (the historical /tmp dict).
+#
+# Usage:
+#   refresh-corpus.sh [--team CTL] [--corpus <path>] [--thoughts-dir <path>]
+#                     [--actuals <csv>]   # skip Extract, use this CSV
+#                     [--signals <csv>]   # skip Extract+Collect, use this CSV
+#                     [--limit N] [--pr-limit N] [--no-check-labels]
+#                     [--dry-run] [--commit] [--force] [--keep-workdir]
+#
+# Offline test seam: --signals makes steps 1-3 no-ops, so the integration
+# test exercises Score+Merge with zero network (no linearis/gh/transcripts).
+#
+# Exit codes: 0 success; 1 validation/step failure (fails loud).
+
+set -uo pipefail
+
+err()   { echo "error: $*" >&2; }
+fatal() { err "$*"; exit 1; }
+note()  { echo "[refresh-corpus] $*"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+COMPOUND_LOG="${REPO_ROOT}/plugins/dev/scripts/compound-log.sh"
+
+TEAM="CTL"
+CORPUS="${SCRIPT_DIR}/reference-class-corpus.json"
+THOUGHTS_DIR="${REPO_ROOT}/thoughts"
+ACTUALS=""
+SIGNALS=""
+LIMIT="250"
+PR_LIMIT="1000"
+CHECK_LABELS=1
+DRY_RUN=0
+DO_COMMIT=0
+FORCE=0
+KEEP_WORKDIR=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --team)            TEAM="$2"; shift 2 ;;
+    --corpus)          CORPUS="$2"; shift 2 ;;
+    --thoughts-dir)    THOUGHTS_DIR="$2"; shift 2 ;;
+    --actuals)         ACTUALS="$2"; shift 2 ;;
+    --signals)         SIGNALS="$2"; shift 2 ;;
+    --limit)           LIMIT="$2"; shift 2 ;;
+    --pr-limit)        PR_LIMIT="$2"; shift 2 ;;
+    --no-check-labels) CHECK_LABELS=0; shift ;;
+    --dry-run)         DRY_RUN=1; shift ;;
+    --commit)          DO_COMMIT=1; shift ;;
+    --force)           FORCE=1; shift ;;
+    --keep-workdir)    KEEP_WORKDIR=1; shift ;;
+    -h|--help)         sed -n '2,33p' "$0" | sed 's|^# \{0,1\}||'; exit 0 ;;
+    *) fatal "unknown flag: $1" ;;
+  esac
+done
+
+command -v jq  >/dev/null 2>&1 || fatal "jq is required"
+command -v bun >/dev/null 2>&1 || fatal "bun is required"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/refresh-corpus.XXXXXX")"
+cleanup() { [ "$KEEP_WORKDIR" -eq 1 ] || rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+[ "$KEEP_WORKDIR" -eq 1 ] && note "workdir: $WORKDIR (kept)"
+
+# ── 1-3. Build the signals CSV (unless injected) ────────────────────────────
+
+if [ -z "$SIGNALS" ]; then
+  if [ -z "$ACTUALS" ]; then
+    ACTUALS="${WORKDIR}/actuals.csv"
+    note "extract: harvesting transcript actuals (team=${TEAM})"
+    bun "${SCRIPT_DIR}/extract-actuals-from-transcripts.ts" \
+      --team "$TEAM" --apply --out "$ACTUALS" \
+      || fatal "extract step failed"
+  else
+    note "extract: skipped (--actuals ${ACTUALS})"
+  fi
+
+  COMPOUND_JSON="${WORKDIR}/compound-aggregate.json"
+  if [ -x "$COMPOUND_LOG" ]; then
+    # Best-effort: an empty/absent compound-log store aggregates to a zeroed
+    # object and the collector simply emits no human column values.
+    "$COMPOUND_LOG" aggregate --thoughts-dir "$THOUGHTS_DIR" > "$COMPOUND_JSON" 2>/dev/null \
+      || { note "compound-log aggregate failed — proceeding without human re-scores"; echo '{}' > "$COMPOUND_JSON"; }
+    note "compound-log: $(jq -r '.entries // 0' "$COMPOUND_JSON") entr(ies), $(jq -r '.tickets // {} | length' "$COMPOUND_JSON") ticket(s)"
+  else
+    echo '{}' > "$COMPOUND_JSON"
+    note "compound-log helper not found — proceeding without human re-scores"
+  fi
+
+  SIGNALS="${WORKDIR}/signals.csv"
+  note "collect: joining Linear + merged PRs + actuals + compound-log"
+  bun "${SCRIPT_DIR}/collect-ticket-signals.ts" \
+    --team "$TEAM" --limit "$LIMIT" --pr-limit "$PR_LIMIT" \
+    --actuals "$ACTUALS" --compound-log "$COMPOUND_JSON" \
+    --out "$SIGNALS" \
+    || fatal "collect step failed"
+else
+  note "extract+collect: skipped (--signals ${SIGNALS})"
+fi
+
+[ -s "$SIGNALS" ] || fatal "signals CSV is missing/empty: $SIGNALS"
+
+# ── 4. Score → fresh corpus ─────────────────────────────────────────────────
+
+FRESH="${WORKDIR}/fresh-corpus.json"
+SCORE_ARGS=(--in "$SIGNALS" --out "${WORKDIR}/estimates.md" --json "$FRESH" --team "$TEAM")
+[ "$CHECK_LABELS" -eq 1 ] && SCORE_ARGS+=(--check-labels)
+note "score: voting calibrated heuristic (check-labels=$([ "$CHECK_LABELS" -eq 1 ] && echo on || echo off))"
+bun "${SCRIPT_DIR}/score-tickets.ts" "${SCORE_ARGS[@]}" || fatal "score step failed"
+
+FRESH_COUNT=$(jq -r '.entries | length' "$FRESH" 2>/dev/null) || fatal "fresh corpus unparseable: $FRESH"
+if [ "$FRESH_COUNT" -eq 0 ] && [ "$FORCE" -eq 0 ]; then
+  fatal "fresh corpus has 0 entries — nothing to refresh (pass --force to write anyway)"
+fi
+
+# ── 5. Merge fresh over old ─────────────────────────────────────────────────
+
+if [ -f "$CORPUS" ]; then
+  OLD_COUNT=$(jq -r '.entries | length' "$CORPUS" 2>/dev/null) || OLD_COUNT=0
+  OLD_GENERATED=$(jq -r '.generated_at // "unknown"' "$CORPUS" 2>/dev/null)
+else
+  OLD_COUNT=0
+  OLD_GENERATED="none"
+  echo '{"generated_at":null,"schema":"catalyst.estimation.corpus.v1","count":0,"entries":[]}' > "${WORKDIR}/empty.json"
+  CORPUS_INPUT="${WORKDIR}/empty.json"
+fi
+
+MERGED="${WORKDIR}/merged-corpus.json"
+jq -s '
+  (.[0].entries | map({key: .ticket_id, value: true}) | from_entries) as $fresh_ids
+  | {
+      generated_at: .[0].generated_at,
+      schema: .[0].schema,
+      entries: (
+        .[0].entries
+        + (.[1].entries | map(select($fresh_ids[.ticket_id] | not)))
+      )
+    }
+  | .count = (.entries | length)
+' "$FRESH" "${CORPUS_INPUT:-$CORPUS}" > "$MERGED" || fatal "merge step failed"
+
+MERGED_COUNT=$(jq -r '.count' "$MERGED")
+RETAINED=$(( MERGED_COUNT - FRESH_COUNT ))
+NEW_GENERATED=$(jq -r '.generated_at' "$MERGED")
+
+note "summary: old=${OLD_COUNT} fresh=${FRESH_COUNT} retained=${RETAINED} merged=${MERGED_COUNT}"
+note "generated_at: ${OLD_GENERATED} → ${NEW_GENERATED}"
+
+if [ "$MERGED_COUNT" -lt "$OLD_COUNT" ] && [ "$FORCE" -eq 0 ]; then
+  fatal "merged corpus (${MERGED_COUNT}) is SMALLER than the old one (${OLD_COUNT}) — refusing (pass --force to override)"
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  note "--dry-run: corpus not written (${CORPUS})"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$CORPUS")"
+cp "$MERGED" "$CORPUS" || fatal "could not write corpus: $CORPUS"
+note "wrote ${MERGED_COUNT} entries → ${CORPUS}"
+
+# ── 6. Optional commit ──────────────────────────────────────────────────────
+
+if [ "$DO_COMMIT" -eq 1 ]; then
+  git -C "$(dirname "$CORPUS")" add "$CORPUS" \
+    && git -C "$(dirname "$CORPUS")" commit -m "chore(pm): refresh reference-class corpus (${FRESH_COUNT} fresh, ${MERGED_COUNT} total)" \
+    || fatal "git commit failed"
+  note "committed corpus refresh"
+fi

--- a/plugins/pm/scripts/estimate/score-tickets.ts
+++ b/plugins/pm/scripts/estimate/score-tickets.ts
@@ -84,6 +84,13 @@ export interface SignalRow {
   has_migration: string;
   has_frontend: string;
   has_backend: string;
+  /**
+   * CTL-813: optional post-merge human re-score (story points) from the
+   * compound-log (`collect-ticket-signals.ts` joins it in). When present and
+   * a valid point value, it OVERRIDES the voted score — human ground truth
+   * beats the heuristic. Absent on older CSVs.
+   */
+  human_actual_points?: string;
 }
 
 export interface ScoredRow {
@@ -599,6 +606,48 @@ export function scoreRow(
   };
 }
 
+// -- Human re-score override (CTL-813) ----------------------------------------
+
+/** Reverse of TSHIRT_POINTS — points value → T-shirt. */
+export const POINTS_TSHIRT: Record<number, TShirt> = {
+  1: "XS",
+  3: "S",
+  5: "M",
+  8: "L",
+  13: "XL",
+};
+
+/**
+ * Parse the row's `human_actual_points` column. Returns the points value when
+ * it is one of the allowed scale values {1,3,5,8,13}, else null (invalid
+ * values are reported by the caller, never silently coerced).
+ */
+export function humanOverridePoints(row: SignalRow): number | null {
+  const raw = row.human_actual_points ?? "";
+  if (raw === "") return null;
+  const pts = Number.parseInt(raw, 10);
+  return POINTS_TSHIRT[pts] ? pts : null;
+}
+
+/**
+ * Apply the compound-log human re-score as a final override: the post-merge
+ * human ground truth beats any heuristic vote, so the corpus entry should
+ * anchor on it. Confidence becomes "high" and the rationale is annotated so
+ * provenance survives into the corpus. No-op when the column is absent or
+ * invalid (the caller warns on invalid).
+ */
+export function applyHumanOverride(scored: ScoredRow, row: SignalRow): ScoredRow {
+  const pts = humanOverridePoints(row);
+  if (pts === null) return scored;
+  return {
+    ...scored,
+    proposed_tshirt: POINTS_TSHIRT[pts],
+    points: pts,
+    confidence: "high",
+    reasoning: `${scored.reasoning}; human re-score override (compound-log)`,
+  };
+}
+
 // -- Corpus entry builder ----------------------------------------------------
 
 function numOrNull(s: string): number | null {
@@ -863,7 +912,10 @@ async function main(): Promise<void> {
   for (const { row, tier } of tieredRows) {
     if (tier !== 4) {
       const { tshirt } = scoreClosedTicket(row, tier);
-      closedPool.push({ row, tshirt, tier });
+      // CTL-813: a human re-score anchors the NN pool too — neighbors should
+      // vote with ground truth, not the heuristic it corrects.
+      const humanPts = humanOverridePoints(row);
+      closedPool.push({ row, tshirt: humanPts !== null ? POINTS_TSHIRT[humanPts] : tshirt, tier });
     }
   }
 
@@ -873,8 +925,19 @@ async function main(): Promise<void> {
     );
   }
 
+  // CTL-813: warn (don't silently drop) when a human re-score is present but
+  // not on the points scale — the override only honors {1,3,5,8,13}.
+  for (const { row } of tieredRows) {
+    const raw = row.human_actual_points ?? "";
+    if (raw !== "" && humanOverridePoints(row) === null) {
+      console.warn(
+        `[score] ${row.ticket_id}: human_actual_points=${raw} not in {1,3,5,8,13} — override ignored`,
+      );
+    }
+  }
+
   const scored = tieredRows.map(({ row, tier }) =>
-    scoreRow(row, tier, closedPool),
+    applyHumanOverride(scoreRow(row, tier, closedPool), row),
   );
   const corpus = tieredRows.map(({ row }, i) =>
     buildCorpusEntry(row, scored[i]),


### PR DESCRIPTION
## Summary

**CTL-789 Slice 2 (PR2b).** The estimator's forward path has been live since CTL-751 (triage → reference-class lookup → Linear estimate write), but the backward path was **dead at every seam**: the committed corpus was a frozen one-shot bootstrap (single commit, every entry `title:""`/`tier:null`/empty signals), `extract-actuals`/`score-tickets` were invoked nowhere, and the compound-log was a write-only sink with zero readers. This PR makes the corpus self-refresh from real actuals.

## What changed

**The loop, seam by seam:**

- **`compound-log.sh read` / `aggregate`** — the sink becomes a source. JSON-Lines reader + per-ticket latest-by-`merged_at` map with calibration stats (count/exact/mean-signed-delta/median-abs-delta). Empty store = silent success (consumers fail open).
- **`collect-ticket-signals.ts` (new)** — the missing JOIN: Linear Done tickets ⋈ merged PRs incl. `files[]` (one `gh pr list` call, no per-ticket API storm) ⋈ transcript actuals CSV ⋈ compound-log human re-scores → the Score input CSV (+ new `human_actual_points` column).
- **`score-tickets.ts`** — honors `human_actual_points` as a final override: post-merge human ground truth rewrites tshirt/points (`confidence: high`, rationale annotated) and anchors the Tier-4 NN pool. Off-scale values warn and are ignored.
- **`refresh-corpus.sh` (new)** — recurring orchestration: Extract → aggregate → Collect → Score (`--check-labels` on) → **merge**: fresh entries replace same-ticket stale ones, un-re-scored entries (cross-repo ADV bootstrap anchors) are retained, `generated_at` advances, shrink/zero-fresh guarded. `--signals`/`--actuals` seams make it testable offline. `adapt-reference-corpus.ts` is retired to bootstrap-only.
- **`linear-write.mjs applyEstimate()`** — adds the missing `estimate-source:human` guard the methodology promised at §6b (latent clobber bug). Fails open on an unreadable label set (the `score-tickets --check-labels` precedent; the scheduler's write is one-shot).
- **Cadence (the unbuilt CTL-189)** — `merge-pr` step 12b invokes `/catalyst-dev:compound-estimate` interactively; `phase-monitor-merge` writes an agent-authored entry (LOC-band re-score of the merged diff + self-authored reflections) off the critical path; `compound-estimate` step 6 offers a corpus refresh when the corpus is >7 days stale. Also fixes `compound-estimate`'s stale pre-CTL-746 points scale (S=2→3, M=3→5, L=5→8, XL=8→13).
- **Corpus refreshed for real** — first output of the closed loop: 197 fresh full-signal entries (titles/domains/flags now feed the lookup's 0.35/0.20/0.10 similarity weights), 989 anchors retained, 1186 total. The corpus's second commit ever.

## Tests

- `refresh-corpus-integration.test.ts` — the **loop-reopen regression gate**: fails if `generated_at` stops advancing, count stops growing on new actuals, stale entries survive, anchors drop, or the human re-score doesn't reach the corpus (the pre-existing lookup test only proves loadability — it can't detect a frozen corpus). Offline via the `--signals` seam.
- `applyEstimate` guard tests (skip/fail-open/default-wiring), collector unit tests (26), human-override tests, `compound-log` read/aggregate shell tests.
- Full sweep green: estimate 45/45 · compound-log 19/19 · linear-write+scheduler 426/426 · `audit-references --ci` exit 0.
- Live end-to-end dry-run verified: 219 tickets extracted, 250 Done ⋈ 752 PRs → 197 signal rows (Tier1=120).

Closes CTL-813. Part of CTL-789 (Compound Engineering, Loop A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)