### PR TITLE
feat(dev): ticket-retro — cross-ticket retrospective view + briefing Plan-today callout (CTL-814)

### DIFF
--- a/plugins/dev/scripts/__tests__/morning-briefing-skill.test.sh
+++ b/plugins/dev/scripts/__tests__/morning-briefing-skill.test.sh
@@ -157,6 +157,44 @@ test_render_no_data_placeholder() {
   fi
 }
 
+# ─── Test: render.sh Plan today carries the Retro signals sub-section ───────
+# CTL-814: .today.retro_signals (latest ticket-retro watch-items) renders as a
+# fourth Plan-today sub-section; absent/empty input degrades to _no data_.
+test_render_retro_signals() {
+  echo "test: render.sh renders Plan today → Retro signals"
+  local fixture="$SCRATCH/fixture-retro.json"
+  cat > "$fixture" <<'JSON'
+{
+  "date": "2026-06-07",
+  "decisions": [],
+  "today": {
+    "linear_in_progress": [],
+    "calendar": [],
+    "followups": [],
+    "retro_signals": [
+      {"title": "watch: signal file missing artifact path on re-walk"},
+      {"title": "watch: stale plugin cache serving old skill bodies"}
+    ]
+  }
+}
+JSON
+  local out="$SCRATCH/render-retro.md"
+  bash "$MB_DIR/render.sh" --input "$fixture" --output "$out" >/dev/null
+  local content
+  content=$(cat "$out")
+  assert_grep "Retro signals sub-section present" "### Retro signals" "$content"
+  assert_grep "watch-item rendered" "- watch: signal file missing artifact path on re-walk" "$content"
+
+  # Empty retro_signals (and legacy inputs without the key) degrade to _no data_.
+  local fixture2="$SCRATCH/fixture-retro-empty.json"
+  echo '{"date":"2026-06-07","decisions":[],"today":{"linear_in_progress":[],"calendar":[],"followups":[]}}' > "$fixture2"
+  local out2="$SCRATCH/render-retro-empty.md"
+  bash "$MB_DIR/render.sh" --input "$fixture2" --output "$out2" >/dev/null
+  local section
+  section=$(awk '/^### Retro signals/{f=1; next} /^##/{f=0} f' "$out2")
+  assert_grep "empty retro_signals degrades to _no data_" "_no data_" "$section"
+}
+
 # ─── Test: output-path.sh default ───────────────────────────────────────────
 test_output_path_default() {
   echo "test: output-path.sh --date prints thoughts/briefings/<date>.md"
@@ -298,6 +336,7 @@ test_schema_exists
 test_render_produces_4_sections
 test_render_writes_decisions_block
 test_render_no_data_placeholder
+test_render_retro_signals
 test_output_path_default
 test_output_path_dry_run
 test_output_path_default_date

--- a/plugins/dev/scripts/__tests__/ticket-retro-gather.test.sh
+++ b/plugins/dev/scripts/__tests__/ticket-retro-gather.test.sh
@@ -213,12 +213,43 @@ test_tickets_filter() {
     "$(echo "$out" | jq -r '.window.source')"
 }
 
+# ── merged_prs via fake gh: ticket extraction + version-string exclusion ────
+
+test_merged_prs_ticket_extraction() {
+  local proj out
+  proj=$(new_project ghfake)
+  mkdir -p "$proj/bin"
+  cat > "$proj/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+cat <<'JSON'
+[
+  {"number": 10, "title": "feat(dev): real ticket work (CTL-99)", "headRefName": "ryan/ctl-99-thing",
+   "mergedAt": "2026-06-06T10:00:00Z", "additions": 100, "deletions": 20},
+  {"number": 11, "title": "docs(dev): refresh linearis skill to v2026.4.9", "headRefName": "docs/linearis-v2026-4-9",
+   "mergedAt": "2026-06-06T11:00:00Z", "additions": 50, "deletions": 5},
+  {"number": 12, "title": "old PR outside window (CTL-1)", "headRefName": "ctl-1-old",
+   "mergedAt": "2026-01-01T00:00:00Z", "additions": 9, "deletions": 9}
+]
+JSON
+EOF
+  chmod +x "$proj/bin/gh"
+
+  out=$(cd "$proj" && PATH="$proj/bin:$PATH" bash "$GATHER" \
+    --thoughts-dir "$proj/thoughts" --db /nonexistent --since 2026-06-01)
+  assert_eq "gh: one PR matched (version string + out-of-window excluded)" "1" \
+    "$(echo "$out" | jq '.merged_prs | length')"
+  assert_eq "gh: ticket uppercased from branch" "CTL-99" \
+    "$(echo "$out" | jq -r '.merged_prs[0].ticket')"
+  assert_eq "gh: churn carried" "100" "$(echo "$out" | jq '.merged_prs[0].additions')"
+}
+
 # ── Run ──────────────────────────────────────────────────────────────────────
 
 test_empty_stores_degrade
 test_last_retro_window_and_watch_items
 test_since_override_and_stores
 test_tickets_filter
+test_merged_prs_ticket_extraction
 
 echo "---"
 echo "summary: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/ticket-retro-gather.test.sh
+++ b/plugins/dev/scripts/__tests__/ticket-retro-gather.test.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# Tests for gather-retro.sh — the deterministic read side of ticket-retro (CTL-814).
+#
+# The retro is a read-only VIEW over what Loops A/B captured. These tests build
+# fixture stores (friction logs, learnings, compound-log weeks, a prior retro
+# with watch-items) and assert the gathered JSON: window resolution
+# (since-last-retro default, --since, --tickets), record filtering, watch-item
+# parsing, and the all-stores-empty degradation contract.
+#
+# Run: bash plugins/dev/scripts/__tests__/ticket-retro-gather.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+GATHER="${REPO_ROOT}/plugins/dev/scripts/ticket-retro/gather-retro.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() {
+  FAILURES=$((FAILURES+1))
+  echo "  FAIL: $1"
+  [ -n "${2:-}" ] && echo "    detail: $2"
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then pass "$label"; else fail "$label" "expected=$expected actual=$actual"; fi
+}
+
+if [ ! -x "$GATHER" ]; then
+  echo "ERROR: $GATHER not present or not executable"
+  echo "summary: 0 passed, 1 failed"
+  exit 1
+fi
+
+# ── Fixture builder ──────────────────────────────────────────────────────────
+
+new_project() {
+  local dir="${SCRATCH}/$1"
+  mkdir -p "$dir/thoughts/shared/friction" \
+           "$dir/thoughts/shared/learnings/architecture-patterns" \
+           "$dir/thoughts/shared/pm/metrics" \
+           "$dir/thoughts/shared/compound/retros"
+  echo "$dir"
+}
+
+write_friction() {
+  local dir="$1" ticket="$2" phase="$3" ts="$4" line="$5"
+  cat >> "$dir/thoughts/shared/friction/${ticket}.md" <<EOF
+## ${phase} · ${ticket} · ${ts}
+- **Backtracks / redone work:** ${line}
+EOF
+}
+
+write_learning() {
+  local dir="$1" slug="$2" title="$3" component="$4"
+  cat > "$dir/thoughts/shared/learnings/architecture-patterns/${slug}.md" <<EOF
+---
+title: "${title}"
+date: 2026-06-06
+category: architecture-patterns
+problem_type: workflow_issue
+component: ${component}
+severity: medium
+---
+
+Body.
+EOF
+}
+
+write_compound_week() {
+  local dir="$1"
+  cat > "$dir/thoughts/shared/pm/metrics/2026-W23-compound-log.md" <<'EOF'
+# Compound Log — 2026-W23
+
+One entry per merged PR. Fields follow the CTL-159 schema.
+
+### CTL-50 — #900 — 2026-06-04T12:00:00Z
+
+```yaml
+linear_key: CTL-50
+pr_number: 900
+merged_at: 2026-06-04T12:00:00Z
+estimate_at_start: 3
+estimate_actual: 5
+cost_usd: 4.20
+wall_time_hours: 2.0
+what_worked: "plan held"
+what_surprised_me: "ci flake"
+```
+
+EOF
+}
+
+write_prior_retro() {
+  local dir="$1" date="$2"
+  cat > "$dir/thoughts/shared/compound/retros/${date}.md" <<'EOF'
+---
+date: RETRO_DATE
+type: retro
+generated_by: ticket-retro
+---
+
+# Ticket Retro — RETRO_DATE
+
+## Recurring friction patterns
+
+- **signal file missing artifact path** (2 records)
+
+## Watch items
+
+```yaml watch-items
+- pattern: "signal file missing artifact path on re-walk"
+  component: phase-agent
+  first_seen: 2026-06-01
+  source: CTL-696
+- pattern: "stale plugin cache serving old skill bodies"
+  component: cli
+  first_seen: 2026-06-01
+  source: CTL-628
+```
+EOF
+  sed -i '' "s/RETRO_DATE/${date}/g" "$dir/thoughts/shared/compound/retros/${date}.md" 2>/dev/null \
+    || sed -i "s/RETRO_DATE/${date}/g" "$dir/thoughts/shared/compound/retros/${date}.md"
+}
+
+run_gather() {
+  local dir="$1"; shift
+  (cd "$dir" && bash "$GATHER" --thoughts-dir "$dir/thoughts" --no-github --db /nonexistent "$@")
+}
+
+echo "ticket-retro gather tests"
+echo "---"
+
+# ── All stores empty → zeroed JSON, exit 0 ───────────────────────────────────
+
+test_empty_stores_degrade() {
+  local proj out rc
+  proj=$(new_project empty)
+  out=$(run_gather "$proj")
+  rc=$?
+  assert_eq "empty: exit 0" "0" "$rc"
+  assert_eq "empty: friction []" "0" "$(echo "$out" | jq '.friction | length')"
+  assert_eq "empty: learnings []" "0" "$(echo "$out" | jq '.learnings | length')"
+  assert_eq "empty: merged_prs []" "0" "$(echo "$out" | jq '.merged_prs | length')"
+  assert_eq "empty: db_stats []" "0" "$(echo "$out" | jq '.db_stats | length')"
+  assert_eq "empty: prior_retro null" "null" "$(echo "$out" | jq '.prior_retro')"
+  assert_eq "empty: window source default" "default-14d" "$(echo "$out" | jq -r '.window.source')"
+  assert_eq "empty: calibration entries 0" "0" "$(echo "$out" | jq '.calibration.entries // 0')"
+}
+
+# ── since-last-retro window + watch-items parse ──────────────────────────────
+
+test_last_retro_window_and_watch_items() {
+  local proj out
+  proj=$(new_project lastretro)
+  write_prior_retro "$proj" "2026-06-03"
+  # one friction record BEFORE the retro date (excluded), one after (included)
+  write_friction "$proj" "CTL-10" "research" "2026-06-02T10:00:00+0900" "old record"
+  write_friction "$proj" "CTL-11" "implement" "2026-06-05T10:00:00+0900" "new record"
+
+  out=$(run_gather "$proj")
+  assert_eq "last-retro: window source" "last-retro" "$(echo "$out" | jq -r '.window.source')"
+  assert_eq "last-retro: window since" "2026-06-03" "$(echo "$out" | jq -r '.window.since')"
+  assert_eq "last-retro: only post-floor friction kept" "1" "$(echo "$out" | jq '.friction | length')"
+  assert_eq "last-retro: kept the right record" "CTL-11" "$(echo "$out" | jq -r '.friction[0].ticket')"
+  assert_eq "last-retro: 2 watch items parsed" "2" "$(echo "$out" | jq '.prior_retro.watch_items | length')"
+  assert_eq "last-retro: watch item pattern" "signal file missing artifact path on re-walk" \
+    "$(echo "$out" | jq -r '.prior_retro.watch_items[0].pattern')"
+  assert_eq "last-retro: watch item component" "phase-agent" \
+    "$(echo "$out" | jq -r '.prior_retro.watch_items[0].component')"
+  assert_eq "last-retro: watch item source" "CTL-628" \
+    "$(echo "$out" | jq -r '.prior_retro.watch_items[1].source')"
+}
+
+# ── --since override + learnings + calibration ───────────────────────────────
+
+test_since_override_and_stores() {
+  local proj out
+  proj=$(new_project since)
+  write_friction "$proj" "CTL-20" "verify" "2026-06-05T10:00:00+0900" "flaky suite"
+  write_learning "$proj" "some-learning" "Phase env can leak sibling ticket" "phase-agent"
+  write_compound_week "$proj"
+
+  out=$(run_gather "$proj" --since 2026-06-01)
+  assert_eq "since: window source" "--since" "$(echo "$out" | jq -r '.window.source')"
+  assert_eq "since: friction kept" "1" "$(echo "$out" | jq '.friction | length')"
+  assert_eq "since: learning title" "Phase env can leak sibling ticket" \
+    "$(echo "$out" | jq -r '.learnings[0].title')"
+  assert_eq "since: learning component" "phase-agent" "$(echo "$out" | jq -r '.learnings[0].component')"
+  assert_eq "since: calibration entries" "1" "$(echo "$out" | jq '.calibration.entries')"
+  assert_eq "since: calibration actual for CTL-50" "5" \
+    "$(echo "$out" | jq '.calibration.tickets["CTL-50"].estimate_actual')"
+}
+
+# ── --tickets filter ─────────────────────────────────────────────────────────
+
+test_tickets_filter() {
+  local proj out
+  proj=$(new_project tickets)
+  write_friction "$proj" "CTL-30" "plan" "2026-06-05T10:00:00+0900" "kept"
+  write_friction "$proj" "CTL-31" "plan" "2026-06-05T11:00:00+0900" "filtered out"
+
+  out=$(run_gather "$proj" --tickets ctl-30)
+  assert_eq "tickets: filter keeps only CTL-30" "1" "$(echo "$out" | jq '.friction | length')"
+  assert_eq "tickets: kept ticket" "CTL-30" "$(echo "$out" | jq -r '.friction[0].ticket')"
+  assert_eq "tickets: window drops to all-time" "--tickets (all time)" \
+    "$(echo "$out" | jq -r '.window.source')"
+}
+
+# ── Run ──────────────────────────────────────────────────────────────────────
+
+test_empty_stores_degrade
+test_last_retro_window_and_watch_items
+test_since_override_and_stores
+test_tickets_filter
+
+echo "---"
+echo "summary: ${PASSES} passed, ${FAILURES} failed"
+exit $([ "$FAILURES" -eq 0 ] && echo 0 || echo 1)

--- a/plugins/dev/scripts/morning-briefing/render.sh
+++ b/plugins/dev/scripts/morning-briefing/render.sh
@@ -19,7 +19,8 @@
 #   "today": {
 #     "linear_in_progress": [{"id":"CTL-200","title":"..."}, ...],
 #     "calendar":           [{"title":"...","start":"..."}, ...],
-#     "followups":          [{"source":"granola","action":"..."}, ...]
+#     "followups":          [{"source":"granola","action":"..."}, ...],
+#     "retro_signals":      [{"title":"watch: ..."}, ...]
 #   },
 #   "suggested_runs": [{"id":"CTL-300","title":"...","priority":"High"}, ...]
 # }
@@ -139,6 +140,8 @@ render_section() {
   render_section '.today.linear_in_progress' 'Linear in-progress' | sed 's/^## /### /'
   render_section '.today.calendar'           'Calendar today'     | sed 's/^## /### /'
   render_section '.today.followups'          'Follow-ups'         | sed 's/^## /### /'
+  # CTL-814: latest ticket-retro's top recurring patterns + open watch-items.
+  render_section '.today.retro_signals'      'Retro signals'      | sed 's/^## /### /'
 
   echo "## Suggest orchestrator runs"
   echo

--- a/plugins/dev/scripts/ticket-retro/gather-retro.sh
+++ b/plugins/dev/scripts/ticket-retro/gather-retro.sh
@@ -155,8 +155,9 @@ while i < len(lines):
     if epoch <= floor:
         continue
     # Strip the bullet's bold field label ("**Backtracks / redone work:** …")
-    # so pattern clustering sees the substance, not the template.
-    one = re.sub(r'^\*\*[^*]+:\*\*\s*', '', one)
+    # so pattern clustering sees the substance, not the template. The leading
+    # "**" is already gone (lstrip above), so match label-text up to ":**".
+    one = re.sub(r'^[^:*]{1,60}:\*\*\s*', '', one)
     print(json.dumps({"ticket": ticket, "phase": phase, "ts": ts,
                       "line": re.sub(r'\s+', ' ', one)}))
 PY
@@ -200,7 +201,9 @@ if [ "$NO_GITHUB" -eq 0 ] && command -v gh >/dev/null 2>&1; then
       [ .[]
         | select(.mergedAt > $since)
         | . + {ticket: (try ((.headRefName + " " + .title)
-                             | capture("(?<t>[A-Za-z][A-Za-z0-9]*-[0-9]+)"; "i").t
+                             # Letters-only team prefix — "v2026-4"-style version
+                             # strings must NOT read as tickets (dogfood finding).
+                             | capture("(?<t>\\b[A-Za-z]+-[0-9]+)\\b"; "i").t
                              | ascii_upcase)
                         catch null)}
         | select(.ticket != null)

--- a/plugins/dev/scripts/ticket-retro/gather-retro.sh
+++ b/plugins/dev/scripts/ticket-retro/gather-retro.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# gather-retro.sh — deterministic read side of /catalyst-dev:ticket-retro (CTL-814).
+#
+# Collects everything the cross-ticket retro VIEW reads into ONE JSON document
+# on stdout. READ-ONLY by contract: this script writes nothing anywhere. Every
+# section degrades to empty/null — an absent store, missing CLI, or empty
+# window never fails the run (mirrors morning-briefing Step 3b resilience).
+#
+# Usage:
+#   gather-retro.sh [--thoughts-dir <path>] [--since YYYY-MM-DD]
+#                   [--tickets CTL-1,CTL-2] [--db <path>]
+#                   [--retros-dir <path>] [--no-github]
+#
+# Window resolution (the since-last-retro default, plan line 114):
+#   --since wins; else the DATE of the most recent <retros-dir>/YYYY-MM-DD.md
+#   (records strictly AFTER that date's midnight UTC); else 14 days back.
+#   --tickets without --since drops the floor to 0 (explicit scope = all time).
+#
+# Output shape:
+# {
+#   "window":      {"since": "YYYY-MM-DD", "floor_epoch": N, "source": "..."},
+#   "prior_retro": {"path","date","watch_items":[{pattern,component,first_seen,source}]} | null,
+#   "friction":    [{"ticket","phase","ts","line"}],            # '## <phase> · <TICKET> · <ISO>' contract
+#   "learnings":   [{"title","component","problem_type","path"}],
+#   "calibration": {…compound-log.sh aggregate…},               # {} when store empty/helper absent
+#   "merged_prs":  [{"ticket","pr","title","merged_at","additions","deletions"}],
+#   "db_stats":    [{"ticket_key","sessions","cost_usd","hours"}]   # sparse by design
+# }
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOUND_LOG="${SCRIPT_DIR}/../compound-log.sh"
+
+THOUGHTS_DIR="./thoughts"
+SINCE=""
+TICKETS=""
+DB="${HOME}/catalyst/catalyst.db"
+RETROS_DIR=""
+NO_GITHUB=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --thoughts-dir) THOUGHTS_DIR="$2"; shift 2 ;;
+    --since)        SINCE="$2"; shift 2 ;;
+    --tickets)      TICKETS="$2"; shift 2 ;;
+    --db)           DB="$2"; shift 2 ;;
+    --retros-dir)   RETROS_DIR="$2"; shift 2 ;;
+    --no-github)    NO_GITHUB=1; shift ;;
+    -h|--help)      sed -n '2,28p' "$0" | sed 's|^# \{0,1\}||'; exit 0 ;;
+    *) echo "gather-retro: unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || { echo "gather-retro: jq is required" >&2; exit 1; }
+
+[ -z "$RETROS_DIR" ] && RETROS_DIR="${THOUGHTS_DIR}/shared/compound/retros"
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/gather-retro.XXXXXX")"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# ── Prior retro + window floor ───────────────────────────────────────────────
+
+PRIOR_RETRO=""
+if [ -d "$RETROS_DIR" ]; then
+  for rf in "$RETROS_DIR"/*.md; do
+    [ -e "$rf" ] || continue
+    case "$(basename "$rf" .md)" in
+      [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])
+        if [ -z "$PRIOR_RETRO" ] || [ "$rf" \> "$PRIOR_RETRO" ]; then PRIOR_RETRO="$rf"; fi ;;
+    esac
+  done
+fi
+
+WINDOW_SOURCE=""
+if [ -n "$SINCE" ]; then
+  WINDOW_DATE="$SINCE"; WINDOW_SOURCE="--since"
+elif [ -n "$TICKETS" ]; then
+  WINDOW_DATE="1970-01-01"; WINDOW_SOURCE="--tickets (all time)"
+elif [ -n "$PRIOR_RETRO" ]; then
+  WINDOW_DATE="$(basename "$PRIOR_RETRO" .md)"; WINDOW_SOURCE="last-retro"
+else
+  # First retro ever: 14 days back. GNU date first, then BSD (macOS).
+  WINDOW_DATE="$(date -u -d '14 days ago' +%Y-%m-%d 2>/dev/null \
+    || date -j -u -v-14d +%Y-%m-%d 2>/dev/null || echo 1970-01-01)"
+  WINDOW_SOURCE="default-14d"
+fi
+WINDOW_EPOCH=$(date -u -d "${WINDOW_DATE}T00:00:00Z" +%s 2>/dev/null \
+  || date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "${WINDOW_DATE}T00:00:00Z" +%s 2>/dev/null || echo 0)
+
+jq -nc --arg since "$WINDOW_DATE" --arg src "$WINDOW_SOURCE" --argjson floor "$WINDOW_EPOCH" \
+  '{since: $since, floor_epoch: $floor, source: $src}' > "$SCRATCH/window.json"
+
+# ── Prior retro watch-items (the only stateful contract, CTL-814) ───────────
+# Parsed from the fenced block:   ```yaml watch-items … ```
+# Items:  - pattern: "…"\n  component: …\n  first_seen: …\n  source: …
+
+if [ -n "$PRIOR_RETRO" ]; then
+  awk '
+    /^```yaml watch-items/ { f = 1; next }
+    f && /^```/            { f = 0; next }
+    f && /^- pattern:/ {
+      if (started) printf "%s\t%s\t%s\t%s\n", p, c, fs, s
+      started = 1; c = ""; fs = ""; s = ""
+      p = $0; sub(/^- pattern:[ ]*/, "", p); gsub(/^"|"$/, "", p)
+      next
+    }
+    f && /^[ ]+component:/  { c = $0;  sub(/^[ ]+component:[ ]*/,  "", c);  next }
+    f && /^[ ]+first_seen:/ { fs = $0; sub(/^[ ]+first_seen:[ ]*/, "", fs); next }
+    f && /^[ ]+source:/     { s = $0;  sub(/^[ ]+source:[ ]*/,     "", s);  next }
+    END { if (started) printf "%s\t%s\t%s\t%s\n", p, c, fs, s }
+  ' "$PRIOR_RETRO" \
+  | jq -R -c 'split("\t") | {pattern: .[0], component: .[1], first_seen: .[2], source: .[3]}' \
+  > "$SCRATCH/watch-items.jsonl" || : > "$SCRATCH/watch-items.jsonl"
+
+  jq -sc --arg path "$PRIOR_RETRO" --arg date "$(basename "$PRIOR_RETRO" .md)" \
+    '{path: $path, date: $date, watch_items: .}' "$SCRATCH/watch-items.jsonl" \
+    > "$SCRATCH/prior-retro.json"
+else
+  echo 'null' > "$SCRATCH/prior-retro.json"
+fi
+
+# ── Friction records after the floor ─────────────────────────────────────────
+# Same header contract the morning briefing parses (Step 3b):
+#   ## <phase> · <TICKET> · <ISO-8601 timestamp>
+
+: > "$SCRATCH/friction.jsonl"
+FRICTION_DIR="${THOUGHTS_DIR}/shared/friction"
+if [ -d "$FRICTION_DIR" ] && command -v python3 >/dev/null 2>&1; then
+  for ff in "$FRICTION_DIR"/*.md; do
+    [ -e "$ff" ] || continue
+    python3 - "$ff" "$WINDOW_EPOCH" >> "$SCRATCH/friction.jsonl" <<'PY'
+import sys, re, json, datetime
+path, floor = sys.argv[1], int(sys.argv[2])
+hdr = re.compile(r'^##\s+(?P<phase>[^·]+?)\s+·\s+(?P<ticket>[^·]+?)\s+·\s+(?P<ts>\S+)\s*$')
+lines = open(path, encoding='utf-8', errors='replace').read().splitlines()
+i = 0
+while i < len(lines):
+    m = hdr.match(lines[i])
+    if not m:
+        i += 1; continue
+    phase, ticket, ts = m.group('phase').strip(), m.group('ticket').strip(), m.group('ts').strip()
+    one = ""
+    j = i + 1
+    while j < len(lines) and not hdr.match(lines[j]):
+        t = lines[j].strip().lstrip('-* ').strip()
+        if t and t.rstrip('.').lower() != "none":
+            one = t; break
+        j += 1
+    i = j
+    try:
+        epoch = int(datetime.datetime.fromisoformat(ts).timestamp())
+    except ValueError:
+        continue
+    if epoch <= floor:
+        continue
+    # Strip the bullet's bold field label ("**Backtracks / redone work:** …")
+    # so pattern clustering sees the substance, not the template.
+    one = re.sub(r'^\*\*[^*]+:\*\*\s*', '', one)
+    print(json.dumps({"ticket": ticket, "phase": phase, "ts": ts,
+                      "line": re.sub(r'\s+', ' ', one)}))
+PY
+  done
+fi
+
+# ── Learnings entries modified after the floor ───────────────────────────────
+
+: > "$SCRATCH/learnings.jsonl"
+LEARN_DIR="${THOUGHTS_DIR}/shared/learnings"
+if [ -d "$LEARN_DIR" ]; then
+  find "$LEARN_DIR" -type f -name '*.md' 2>/dev/null | while IFS= read -r lf; do
+    [ -n "$lf" ] || continue
+    mt=$(date -u -r "$lf" +%s 2>/dev/null || stat -c %Y "$lf" 2>/dev/null || echo 0)
+    [ "$mt" -gt "$WINDOW_EPOCH" ] || continue
+    title=$(grep -m1 '^title:' "$lf" 2>/dev/null | sed -E 's/^title:[[:space:]]*//; s/^"//; s/"$//')
+    [ -z "$title" ] && title="$(basename "$lf" .md)"
+    comp=$(grep -m1 '^component:' "$lf" 2>/dev/null | sed -E 's/^component:[[:space:]]*//')
+    ptype=$(grep -m1 '^problem_type:' "$lf" 2>/dev/null | sed -E 's/^problem_type:[[:space:]]*//')
+    jq -nc --arg t "$title" --arg c "${comp:-}" --arg p "${ptype:-}" --arg path "$lf" \
+      '{title: $t, component: $c, problem_type: $p, path: $path}' >> "$SCRATCH/learnings.jsonl"
+  done
+fi
+
+# ── Estimation calibration (compound-log aggregate, CTL-813) ─────────────────
+
+if [ -x "$COMPOUND_LOG" ]; then
+  "$COMPOUND_LOG" aggregate --thoughts-dir "$THOUGHTS_DIR" > "$SCRATCH/calibration.json" 2>/dev/null \
+    || echo '{}' > "$SCRATCH/calibration.json"
+else
+  echo '{}' > "$SCRATCH/calibration.json"
+fi
+
+# ── Merged PRs in the window ("what we did") ─────────────────────────────────
+
+echo '[]' > "$SCRATCH/merged-prs.json"
+if [ "$NO_GITHUB" -eq 0 ] && command -v gh >/dev/null 2>&1; then
+  gh pr list --state merged --limit 200 \
+    --json number,title,headRefName,mergedAt,additions,deletions 2>/dev/null \
+  | jq -c --arg since "${WINDOW_DATE}T00:00:00Z" '
+      [ .[]
+        | select(.mergedAt > $since)
+        | . + {ticket: (try ((.headRefName + " " + .title)
+                             | capture("(?<t>[A-Za-z][A-Za-z0-9]*-[0-9]+)"; "i").t
+                             | ascii_upcase)
+                        catch null)}
+        | select(.ticket != null)
+        | {ticket, pr: .number, title, merged_at: .mergedAt, additions, deletions}
+      ]' > "$SCRATCH/merged-prs.json" 2>/dev/null \
+  || echo '[]' > "$SCRATCH/merged-prs.json"
+fi
+
+# ── catalyst.db aggregate stats (sparse cross-check) ─────────────────────────
+
+echo '[]' > "$SCRATCH/db-stats.json"
+if [ -f "$DB" ] && command -v sqlite3 >/dev/null 2>&1; then
+  sqlite3 -json "$DB" "
+    SELECT s.ticket_key AS ticket_key,
+           COUNT(*) AS sessions,
+           ROUND(SUM(m.cost_usd), 2) AS cost_usd,
+           ROUND(SUM(m.duration_ms) / 3600000.0, 2) AS hours
+    FROM sessions s JOIN session_metrics m ON s.session_id = m.session_id
+    WHERE s.ticket_key IS NOT NULL AND s.ticket_key != ''
+    GROUP BY s.ticket_key;" > "$SCRATCH/db-stats.json" 2>/dev/null \
+  || echo '[]' > "$SCRATCH/db-stats.json"
+  [ -s "$SCRATCH/db-stats.json" ] || echo '[]' > "$SCRATCH/db-stats.json"
+fi
+
+# ── Optional --tickets filter ────────────────────────────────────────────────
+
+TICKETS_JSON='null'
+if [ -n "$TICKETS" ]; then
+  TICKETS_JSON=$(printf '%s' "$TICKETS" | jq -R -c 'split(",") | map(ascii_upcase | gsub("^\\s+|\\s+$"; ""))')
+fi
+
+# ── Assemble ─────────────────────────────────────────────────────────────────
+
+jq -n \
+  --slurpfile window "$SCRATCH/window.json" \
+  --slurpfile prior "$SCRATCH/prior-retro.json" \
+  --slurpfile cal "$SCRATCH/calibration.json" \
+  --slurpfile prs "$SCRATCH/merged-prs.json" \
+  --slurpfile db "$SCRATCH/db-stats.json" \
+  --argjson tickets "$TICKETS_JSON" \
+  '
+  ($tickets) as $tk
+  | {
+      window: $window[0],
+      prior_retro: $prior[0],
+      friction: $ARGS.positional[0],
+      learnings: $ARGS.positional[1],
+      calibration: $cal[0],
+      merged_prs: $prs[0],
+      db_stats: $db[0]
+    }
+  | if $tk != null then
+      .friction   |= map(select(.ticket | ascii_upcase as $u | $tk | index($u)))
+    | .merged_prs |= map(select(.ticket | ascii_upcase as $u | $tk | index($u)))
+    | .db_stats   |= map(select(.ticket_key | ascii_upcase as $u | $tk | index($u)))
+    else . end
+  ' \
+  --jsonargs \
+  "$(jq -sc '.' "$SCRATCH/friction.jsonl")" \
+  "$(jq -sc '.' "$SCRATCH/learnings.jsonl")"

--- a/plugins/dev/skills/morning-briefing/SKILL.md
+++ b/plugins/dev/skills/morning-briefing/SKILL.md
@@ -221,11 +221,37 @@ fi
 - Today's calendar — already gathered in Step 2, reuse `$SCRATCH/calendar.json`
 - Follow-ups — extract action items from the prior day's Granola notes (`$SCRATCH/granola.json`)
   via a Claude-side synthesis pass
+- **Retro signals (CTL-814)** — the most recent `/catalyst-dev:ticket-retro` artifact's open
+  watch-items, rendered as a `Plan today → Retro signals` sub-section. Degrades to an empty
+  array (`_no data_`) when no retro has ever run.
 
 ```bash
-cat > "$SCRATCH/today.json" <<JSON
-{"today": {"linear_in_progress": [], "calendar": [], "followups": []}}
-JSON
+# ── Retro signals: open watch-items from the latest retro ────────────────────
+# Parse the machine contract (the fenced `yaml watch-items` block) from the
+# newest thoughts/shared/compound/retros/YYYY-MM-DD.md. Cap at 5 — the
+# briefing surfaces the watch list, the retro doc holds the detail.
+RETRO_DIR="thoughts/shared/compound/retros"
+: > "$SCRATCH/retro-signals.jsonl"
+LATEST_RETRO=""
+if [[ -d "$RETRO_DIR" ]]; then
+  for rf in "$RETRO_DIR"/*.md; do
+    [[ -e "$rf" ]] || continue
+    [[ "$(basename "$rf" .md)" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || continue
+    [[ -z "$LATEST_RETRO" || "$rf" > "$LATEST_RETRO" ]] && LATEST_RETRO="$rf"
+  done
+fi
+if [[ -n "$LATEST_RETRO" ]]; then
+  awk '/^```yaml watch-items/{f=1; next} f && /^```/{f=0} f && /^- pattern:/ {
+         sub(/^- pattern:[ ]*/, ""); gsub(/^"|"$/, ""); print
+       }' "$LATEST_RETRO" | head -5 \
+    | while IFS= read -r wi; do
+        jq -nc --arg t "watch: $wi" '{title: $t}' >> "$SCRATCH/retro-signals.jsonl"
+      done
+fi
+
+jq -nc --slurpfile rs <(jq -sc '.' "$SCRATCH/retro-signals.jsonl") \
+  '{today: {linear_in_progress: [], calendar: [], followups: [],
+            retro_signals: ($rs[0] // [])}}' > "$SCRATCH/today.json"
 ```
 
 ## Step 5: Suggest orchestrator runs
@@ -362,8 +388,10 @@ The rendered markdown has YAML frontmatter validated against
 `generated_by`, `decisions`; optional `output_status` block populated by Step 7).
 Six `## ...` sections follow: the four `render.sh` owns (Review yesterday, Surface decisions,
 Plan today, Suggest orchestrator runs) plus the two compound digests appended in Step 6b
-(Friction since last briefing, Learnings since last briefing). Empty render sources render
-`_no data_`; empty compound stores render `_none_`. Neither path fails the run.
+(Friction since last briefing, Learnings since last briefing). Plan today carries a
+`### Retro signals` sub-section (CTL-814) surfacing the latest `ticket-retro` watch-items.
+Empty render sources render `_no data_`; empty compound stores render `_none_`. Neither path
+fails the run.
 
 Pending compound-engineering ADR proposals (`thoughts/shared/compound/pending/*.md`) surface as
 `decisions:` entries (`type: judgment_call`, carrying a `pending:` path) so `briefing-followup`'s

--- a/plugins/dev/skills/ticket-retro/SKILL.md
+++ b/plugins/dev/skills/ticket-retro/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: ticket-retro
+description:
+  "Cross-ticket retrospective VIEW (CTL-789 Loop C / CTL-814). **ALWAYS use when** the user says
+  'ticket retro', 'run a retro', 'retrospective', 'what did we learn lately', or 'how are the
+  estimates calibrating'. Synthesizes everything the compound loops captured since the last retro —
+  friction logs, learnings, compound-log calibration, catalyst.db / merged-PR actuals — into
+  thoughts/shared/compound/retros/<date>.md with a persisted watch-items block, and surfaces top
+  patterns in the morning briefing's Plan today."
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write, Grep, Glob
+---
+
+# Ticket Retro — the cross-ticket compound view
+
+Loop C of compound engineering: a human-readable reflection across a SET of tickets. It mostly
+**reads** what Loop B (friction logs, learnings) and Loop A (compound-log, estimation corpus)
+captured, then writes ONE artifact: the retro document.
+
+**Hard contract — read-only VIEW:**
+
+- The ONLY thing this skill writes is `thoughts/shared/compound/retros/<YYYY-MM-DD>.md`.
+- It must NOT curate the learnings store, edit `thoughts/shared/CONCEPTS.md`, or touch ADRs —
+  that is `ticket-compound`'s job (per-ticket curator). No Linear writes, no corpus writes.
+- Every input store degrades to `_none_` — empty stores are the normal early state, never an error.
+
+## Invocation
+
+```
+/catalyst-dev:ticket-retro                      # since-last-retro (default scope)
+/catalyst-dev:ticket-retro --since 2026-06-01   # explicit window floor
+/catalyst-dev:ticket-retro --tickets CTL-1,CTL-2  # explicit ticket set (all time)
+```
+
+Default scope is **since-last-retro, no time box** (solo-dev rhythm — design decision, plan
+line 114): the window floor is the date of the most recent retro in
+`thoughts/shared/compound/retros/`; the first retro ever falls back to 14 days.
+
+## Step 1: Gather (deterministic, read-only)
+
+All reads go through the gather helper — one JSON document, every section degrades to empty:
+
+```bash
+GATHER="${CLAUDE_PLUGIN_ROOT:-plugins/dev}/scripts/ticket-retro/gather-retro.sh"
+RETRO_JSON=$(mktemp)
+bash "$GATHER" --thoughts-dir thoughts "$@" > "$RETRO_JSON"
+jq '{window, prior_retro: (.prior_retro != null), friction: (.friction|length),
+     learnings: (.learnings|length), calibration: (.calibration.entries // 0),
+     merged_prs: (.merged_prs|length), db_stats: (.db_stats|length)}' "$RETRO_JSON"
+```
+
+What it returns (see the script header for the full shape):
+
+| Key | Source | Degrades to |
+|---|---|---|
+| `window` | latest `retros/YYYY-MM-DD.md` / `--since` / `--tickets` | 14-day default |
+| `prior_retro.watch_items` | the previous retro's fenced `yaml watch-items` block | `null` |
+| `friction[]` | `thoughts/shared/friction/*.md` (`## <phase> · <TICKET> · <ISO-8601>` records after the floor) | `[]` |
+| `learnings[]` | `thoughts/shared/learnings/**` frontmatter, mtime after the floor | `[]` |
+| `calibration` | `compound-log.sh aggregate` (estimate_at_start vs estimate_actual) | `{}` |
+| `merged_prs[]` | `gh pr list --state merged` in-window, ticket id from branch/title | `[]` |
+| `db_stats[]` | `~/catalyst/catalyst.db` sessions⋈session_metrics per ticket (SPARSE — see note) | `[]` |
+
+**Actuals note:** `db_stats` covers only orchestrator-run tickets with metrics rows (historically
+~13 of 333). `merged_prs[].additions/deletions` (diff churn) is the universal actuals fallback —
+use it for the aggregate stats; treat db cost/hours as a bonus column where present.
+
+## Step 2: Synthesize (your judgment — this is the LLM half)
+
+1. **What we did** — group `merged_prs` by ticket; one line each. Failed/abandoned tickets that
+   show up in friction but not in `merged_prs` belong here too (often highest-signal).
+2. **Recurring friction patterns** — cluster `friction[].line` entries that describe the same
+   underlying problem (same component, same failure shape — NOT necessarily same wording). A
+   pattern needs **≥2 records** (across tickets or phases). One-off frictions are listed only if
+   severe. For each pattern: a name, the supporting records (`ticket·phase`), and one sentence of
+   synthesis.
+3. **Watch-item recurrence** — for each `prior_retro.watch_items[]` pattern, check whether this
+   window's friction/learnings show it again. Verdict per item: `recurred` (cite evidence),
+   `quiet` (no sighting), or `resolved` (a learning/ADR/fix landed that addresses it — cite it).
+4. **Estimation calibration** — from `calibration`: count/exact/mean-signed-delta/median-abs-delta
+   plus a per-ticket start→actual table. When `calibration.entries == 0`, render `_none_` and note
+   the sink fills at merge (`merge-pr` 12b / `phase-monitor-merge`).
+5. **Next watch items** — carry forward unresolved prior items (keep their `first_seen`) and add
+   new patterns from (2) worth tracking. Cap at ~7 — a watch list longer than that is a backlog,
+   not a watch list.
+
+## Step 3: Write the retro document
+
+Path: `thoughts/shared/compound/retros/<YYYY-MM-DD>.md` (today UTC). Template:
+
+```markdown
+---
+date: <YYYY-MM-DD>
+type: retro
+generated_by: ticket-retro
+window_since: <window.since>
+window_source: <window.source>
+tickets_shipped: <N>
+---
+
+# Ticket Retro — <YYYY-MM-DD>
+
+Window: <window.since> → today (<window.source>)
+
+## What we did
+
+- `CTL-x` title — #PR (+adds/−dels)
+- …                                      (_none_ when empty)
+
+## Aggregate stats
+
+| Metric | Value |
+|---|---|
+| Tickets shipped | N |
+| Diff churn (LOC) | +A / −D |
+| Sessions / cost / hours (catalyst.db, sparse) | N / $C / H |
+
+## Recurring friction patterns
+
+- **<pattern name>** (N records: CTL-a·research, CTL-b·implement) — one-sentence synthesis.
+- …                                      (_none_ when empty)
+
+## What we learned
+
+- [component] title — `path`             (_none_ when empty)
+
+## Estimation calibration
+
+entries: N · exact: N · mean signed delta: +X.X · median |delta|: X
+
+| Ticket | start | actual | Δ |
+|---|---|---|---|
+…                                        (_none_ when empty)
+
+## Watch items from last retro
+
+- ✅ resolved / 🔁 recurred / 💤 quiet — <pattern> (evidence)
+…                                        (_no prior retro_ on the first run)
+
+## Watch items
+
+```yaml watch-items
+- pattern: "<short greppable description>"
+  component: <orchestrator|phase-agent|broker|monitor|cli|ci|worktree|linear|execution-core|estimation|website|plugins>
+  first_seen: <YYYY-MM-DD of when it first appeared — preserve across retros>
+  source: <TICKET the clearest record came from>
+```
+```
+
+**The watch-items block is the only stateful contract.** The next retro and the morning briefing
+both machine-parse it: keep the exact fence info string `yaml watch-items`, the exact four keys,
+and `pattern` values double-quoted. `component` uses the learnings-store enum
+(`ticket-compound/reference.md`).
+
+## Step 4: Sync + report
+
+```bash
+humanlayer thoughts sync 2>/dev/null || true
+echo "ticket-retro: wrote thoughts/shared/compound/retros/$(date -u +%Y-%m-%d).md"
+```
+
+Report to the user: the retro path, top 3 recurring patterns, the calibration one-liner, and any
+recurred watch-items. The next morning briefing surfaces the watch-items automatically
+(`Plan today → Retro signals`).
+
+## Relationship to the other compound skills
+
+| Skill | Owns | Scope |
+|---|---|---|
+| `ticket-compound` | learnings / CONCEPTS / ADR proposals (writes) | one ticket |
+| `compound-estimate` | estimation numbers → compound-log (writes) | one PR |
+| **`ticket-retro`** | the cross-ticket VIEW (reads both, writes only its retro doc) | a window of tickets |


### PR DESCRIPTION
## Summary

**CTL-789 Slice 3 (PR2c) — Loop C.** A genuinely new skill: the cross-ticket retrospective **VIEW** over everything the compound loops capture. It mostly *reads* what Loop B (friction logs, learnings) and Loop A (compound-log, estimation corpus — closed in #1400) produce, and writes exactly one artifact: the retro document.

## What changed

- **`/catalyst-dev:ticket-retro`** (catalyst-dev — NOT foundry, per the CTL-811 lesson). Default scope **since-last-retro** (solo-dev rhythm, design line 114); `--since` / `--tickets` overrides. Hard read-only contract: must NOT curate learnings/CONCEPTS/ADRs (that's `ticket-compound`); every store degrades to `_none_`.
- **`gather-retro.sh`** — the deterministic read side, ONE JSON doc: window-floor resolution, the cross-phase friction-header parser (same `## <phase> · <TICKET> · <ISO-8601>` contract as the briefing), learnings frontmatter scan, `compound-log.sh aggregate` calibration (the #1400 consumer), `gh` merged-PRs (diff churn = the universal actuals; `catalyst.db` is the sparse bonus — 0/32 window tickets had metrics rows), and the prior retro's watch-items.
- **Watch-items schema** — the retro's only stateful contract: a fenced ` ```yaml watch-items ` block (`pattern`/`component`/`first_seen`/`source`) that the NEXT retro checks for recurrence (recurred/quiet/resolved) and the morning briefing machine-parses.
- **Briefing callout** — `render.sh` gains a fourth Plan-today sub-section `### Retro signals` from `.today.retro_signals`; morning-briefing Step 4 gathers the latest retro's open watch-items (cap 5). Body-only — the closed `decisions[].type` enum and frontmatter schema are untouched (`validate-frontmatter` green).
- **Dogfooded for real**: the first retro (`thoughts/shared/compound/retros/2026-06-07.md`, 32 tickets / 34 PRs / +29.9k/−14.5k) is live in the thoughts store and its watch-items render in the briefing end-to-end. Dogfood findings fixed in-flight: friction label-strip, and version strings (`v2026-4-9`) no longer parse as ticket ids (letters-only team prefix + fake-gh regression test).
- Stale `catalyst-foundry` refs fixed opportunistically in the thoughts store (CONCEPTS.md, friction-capture-container.md, design-doc line 50) — synced, not part of this diff.

## Tests

- `ticket-retro-gather.test.sh` — 28 fixture-driven asserts: window resolution (last-retro / `--since` / `--tickets`), watch-item parsing, record filtering, version-string exclusion, and the all-stores-empty degradation contract.
- `morning-briefing-skill.test.sh` — +3 asserts for the Retro signals sub-section (populated + `_no data_` degradation); full suite 39/39.
- `compound-log` 19/19 (consumer sanity), `audit-references --ci` exit 0.

Closes CTL-814. Part of CTL-789 (Compound Engineering, Loop C). Builds on #1400 (Loop A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)