### PR TITLE
feat(dev): monitor board — add Todo + Triage columns + surface queued tickets (CTL-767)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/board-todo-column.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-todo-column.test.ts
@@ -1,0 +1,82 @@
+// board-todo-column.test.ts — CTL-767 regression guard.
+// Locks the Triage and Todo columns into the data layer + UI, and verifies
+// that synthesizeQueuedTicket() produces the right shape for eligible-queue
+// board cards.
+import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { PHASE_TO_LINEAR } from "../lib/board-data.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const boardSrc = readFileSync(join(HERE, "..", "ui", "src", "board", "Board.tsx"), "utf8");
+
+// ── Requirement A: triage phase maps to "Triage", not "Research" ─────────────
+test("PHASE_TO_LINEAR maps triage phase to 'Triage' column (not 'Research')", () => {
+  expect(PHASE_TO_LINEAR.triage).toBe("Triage");
+});
+
+// ── Requirement B: PHASE_TO_LINEAR has queued → "Todo" for eligible synthesis ─
+test("PHASE_TO_LINEAR has queued → 'Todo' for eligible queue synthesis", () => {
+  expect((PHASE_TO_LINEAR as Record<string, string>).queued).toBe("Todo");
+});
+
+// ── Requirement C: Board.tsx LINEAR_COLS includes Triage and Todo columns ─────
+test("Board.tsx LINEAR_COLS includes 'Triage' column key", () => {
+  // Extract the LINEAR_COLS initializer and check it contains the Triage key
+  const re = /const\s+LINEAR_COLS\b[^=]*=\s*\[[\s\S]*?\];/;
+  const m = re.exec(boardSrc);
+  expect(m).not.toBeNull();
+  expect(m![0]).toContain('"Triage"');
+});
+
+test("Board.tsx LINEAR_COLS includes 'Todo' column key", () => {
+  const re = /const\s+LINEAR_COLS\b[^=]*=\s*\[[\s\S]*?\];/;
+  const m = re.exec(boardSrc);
+  expect(m).not.toBeNull();
+  expect(m![0]).toContain('"Todo"');
+});
+
+// ── Requirement D: synthesizeQueuedTicket shape ───────────────────────────────
+test("synthesizeQueuedTicket produces a BoardTicket-compatible object with linearState 'Todo'", async () => {
+  const mod = await import("../lib/board-data.mjs");
+  const fn = (mod as Record<string, unknown>).synthesizeQueuedTicket as ((e: unknown, linfo: unknown) => Record<string, unknown>) | undefined;
+  if (!fn) throw new Error("synthesizeQueuedTicket is not exported from board-data.mjs");
+
+  const eligible = {
+    id: "CTL-900", title: "Test ticket", priority: 2,
+    createdAt: "2026-06-07T00:00:00Z", state: "Todo", repo: "catalyst", team: "CTL",
+  };
+  const linfo: Record<string, { priority?: number; estimate?: number | null; project?: string | null; labels?: string[] }> = {
+    "CTL-900": { priority: 2, estimate: 3, project: null, labels: ["feature"] },
+  };
+
+  const t = fn(eligible, linfo);
+
+  expect(t.id).toBe("CTL-900");
+  expect(t.phase).toBe("queued");
+  expect(t.linearState).toBe("Todo");
+  expect(t.status).toBe("queued");
+  expect(t.working).toBe(false);
+  expect(t.workerStatus).toBeNull();
+  expect(t.activeState).toBeNull();
+  expect(t.phaseSummary).toEqual([]);
+  expect(t.priority).toBe(2);
+  expect(t.estimate).toBe(3);
+  expect(t.held).toBeNull();
+});
+
+test("synthesizeQueuedTicket surfaces held state from linfo labels", async () => {
+  const mod = await import("../lib/board-data.mjs");
+  const fn = (mod as Record<string, unknown>).synthesizeQueuedTicket as ((e: unknown, linfo: unknown) => Record<string, unknown>) | undefined;
+  if (!fn) throw new Error("synthesizeQueuedTicket not exported");
+
+  const eligible = {
+    id: "CTL-901", title: "Blocked ticket", priority: 1,
+    createdAt: "2026-06-07T00:00:00Z", state: "Todo", repo: "catalyst", team: "CTL",
+  };
+  const linfo = { "CTL-901": { priority: 1, estimate: null, project: null, labels: ["blocked"] } };
+
+  const t = fn(eligible, linfo);
+  expect(t.held).toBe("blocked");
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-todo-column.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-todo-column.test.ts
@@ -18,7 +18,7 @@ test("PHASE_TO_LINEAR maps triage phase to 'Triage' column (not 'Research')", ()
 
 // ── Requirement B: PHASE_TO_LINEAR has queued → "Todo" for eligible synthesis ─
 test("PHASE_TO_LINEAR has queued → 'Todo' for eligible queue synthesis", () => {
-  expect((PHASE_TO_LINEAR as Record<string, string>).queued).toBe("Todo");
+  expect(PHASE_TO_LINEAR.queued).toBe("Todo");
 });
 
 // ── Requirement C: Board.tsx LINEAR_COLS includes Triage and Todo columns ─────

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -68,10 +68,46 @@ export function heldFor(labels) {
 
 // phase → Linear workflow state (board columns for the Tickets/Linear lens).
 export const PHASE_TO_LINEAR = {
-  triage: "Research", research: "Research", plan: "Plan", implement: "Implement",
+  triage: "Triage", research: "Research", plan: "Plan", implement: "Implement",
   verify: "Validate", review: "Validate", pr: "PR", "monitor-merge": "PR",
   "monitor-deploy": "Done", done: "Done",
+  queued: "Todo",  // synthetic phase for eligible-queue board cards (CTL-767)
 };
+
+// synthesizeQueuedTicket — build a thin BoardTicket from an eligible queue entry
+// so it renders in the "Todo" Kanban column (CTL-767). All agent/cost/phase-summary
+// fields default to null / empty since there is no worker dir for these tickets.
+export function synthesizeQueuedTicket(e, linfo) {
+  const li = linfo[e.id] ?? {};
+  return {
+    id: e.id,
+    title: e.title || e.id,
+    type: "task",
+    repo: e.repo || repoFor(e.id),
+    team: e.team || teamFor(e.id),
+    phase: "queued",
+    status: "queued",
+    model: null,
+    linearState: PHASE_TO_LINEAR.queued,
+    workerStatus: null,
+    activeState: null,
+    working: false,
+    lastActiveMs: null,
+    priority: li.priority ?? e.priority ?? 0,
+    estimate: li.estimate ?? null,
+    scope: null,
+    project: li.project ?? null,
+    costUSD: null,
+    tokens: null,
+    turns: null,
+    phaseCosts: null,
+    phaseSummary: [],
+    pr: null,
+    updatedAt: e.createdAt || new Date(0).toISOString(),
+    held: heldFor(li.labels),
+    blockers: [],
+  };
+}
 
 // team/prefix → repo swim-lane label
 const TEAM_REPO = { CTL: "catalyst", ADV: "adva" };
@@ -496,11 +532,13 @@ export async function assembleBoard() {
     .filter((t) => t.workerStatus === null && t.status === "done")
     .sort(byRecent)
     .slice(0, 12);
-  tickets = [...liveTickets, ...moving, ...recentDone];
+  // eligible queue tickets → thin Todo-column board cards (CTL-767)
+  const notInFlight = eligible.filter((e) => !ticketIds.has(e.id));
+  const queuedTickets = notInFlight.map((e) => synthesizeQueuedTicket(e, linfo));
+  tickets = [...liveTickets, ...moving, ...recentDone, ...queuedTickets];
 
-  // priority queue: eligible (not yet in-flight), globally ranked
-  const queue = await Promise.all(eligible
-    .filter((e) => !ticketIds.has(e.id))
+  // priority queue: eligible (not yet in-flight), globally ranked (Queue tab)
+  const queue = await Promise.all(notInFlight
     .sort(compareQueued)
     .map(async (e, i) => {
       const { triage } = await readTicketArtifacts(e.id);

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
@@ -341,7 +341,7 @@ export function loadLinearAgentConfig(
     let cur: unknown = parsed;
     for (const key of path) {
       if (!isRecord(cur)) return null;
-      cur = (cur as Record<string, unknown>)[key];
+      cur = cur[key];
     }
     if (!isRecord(cur)) return null;
     const clientId = typeof cur.clientId === "string" ? cur.clientId : "";
@@ -358,7 +358,7 @@ export function loadLinearAgentConfig(
   // 1. NEW: try global config.json → catalyst.linear.bot.worker
   const globalConfigPath = join(homeConfigDir, "config.json");
   try {
-    const globalParsed = JSON.parse(readFileSync(globalConfigPath, "utf8"));
+    const globalParsed: unknown = JSON.parse(readFileSync(globalConfigPath, "utf8"));
     const result = extractCreds(globalParsed, ["catalyst", "linear", "bot", "worker"]);
     if (result !== null) return result;
   } catch { /* absent / malformed — fall through */ }
@@ -367,7 +367,7 @@ export function loadLinearAgentConfig(
   if (projectKey === null || projectKey.length === 0) return null;
   const perTeamConfigPath = join(homeConfigDir, `config-${projectKey}.json`);
   try {
-    const perTeamParsed = JSON.parse(readFileSync(perTeamConfigPath, "utf8"));
+    const perTeamParsed: unknown = JSON.parse(readFileSync(perTeamConfigPath, "utf8"));
     return extractCreds(perTeamParsed, ["catalyst", "linear", "agent"]);
   } catch {
     return null;
@@ -466,17 +466,17 @@ export function loadWebhookConfig(
   // OLD: Layer-1 project config carries catalyst.monitor.linear.botUserId (back-compat).
   const linearBotUserIds = new Set<string>();
   try {
-    const globalParsed = JSON.parse(readFileSync(join(homeConfigDir, "config.json"), "utf8")) as unknown;
+    const globalParsed: unknown = JSON.parse(readFileSync(join(homeConfigDir, "config.json"), "utf8"));
     if (isRecord(globalParsed) && isRecord(globalParsed.catalyst)) {
-      const bot = (globalParsed.catalyst as Record<string, unknown>).linear;
-      if (isRecord(bot) && isRecord((bot as Record<string, unknown>).bot)) {
-        const botSection = (bot as Record<string, unknown>).bot as Record<string, unknown>;
-        if (isRecord(botSection.worker) && typeof (botSection.worker as Record<string, unknown>).botUserId === "string") {
-          const id = (botSection.worker as Record<string, unknown>).botUserId as string;
+      const bot = globalParsed.catalyst.linear;
+      if (isRecord(bot) && isRecord(bot.bot)) {
+        const botSection = bot.bot;
+        if (isRecord(botSection.worker) && typeof botSection.worker.botUserId === "string") {
+          const id = botSection.worker.botUserId;
           if (id.length > 0) linearBotUserIds.add(id);
         }
-        if (isRecord(botSection.orchestrator) && typeof (botSection.orchestrator as Record<string, unknown>).botUserId === "string") {
-          const id = (botSection.orchestrator as Record<string, unknown>).botUserId as string;
+        if (isRecord(botSection.orchestrator) && typeof botSection.orchestrator.botUserId === "string") {
+          const id = botSection.orchestrator.botUserId;
           if (id.length > 0) linearBotUserIds.add(id);
         }
       }

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
@@ -32,8 +32,9 @@ const PHASE_C: Record<string, string> = {
   "monitor-merge": "#4ea1ff", "monitor-deploy": "#39d07a", merge: "#4ea1ff", deploy: "#39d07a", done: "#6b7280",
 };
 const LINEAR_COLS = [
-  { key: "Research", c: "#3b82f6" }, { key: "Plan", c: "#a855f7" }, { key: "Implement", c: "#10b981" },
-  { key: "Validate", c: "#f59e0b" }, { key: "PR", c: "#14b8a6" }, { key: "Done", c: "#6b7280" },
+  { key: "Todo",     c: "#94a3b8" }, { key: "Triage",   c: "#64748b" },
+  { key: "Research", c: "#3b82f6" }, { key: "Plan",     c: "#a855f7" }, { key: "Implement", c: "#10b981" },
+  { key: "Validate", c: "#f59e0b" }, { key: "PR",       c: "#14b8a6" }, { key: "Done",      c: "#6b7280" },
 ];
 const PHASE_COLS = [
   { key: "triage", label: "Triage", c: "#64748b" }, { key: "research", label: "Research", c: "#3b82f6" },


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-07T00:00:00Z -->
<!-- Last updated: 2026-06-07T00:00:00Z -->
<!-- PR: #1411 -->
<!-- Previous commits: COMMIT_SHA_PLACEHOLDER -->

## Summary

Fixes two visibility gaps in the orch-monitor board's "Linear state" lens:

1. **Triage-phase tickets** were bucketed into the Research column because `PHASE_TO_LINEAR` mapped `triage → "Research"`. They now render in a dedicated **Triage** column.
2. **Todo-state tickets** (eligible queue, waiting for dispatch) were invisible on the Kanban board — only visible in the Queue tab. They now render in a new **Todo** column via thin synthesized `BoardTicket` entries.

The admission-control hold-state surface (`⏸ blocked` / `⏸ waiting` chips) was already implemented (CTL-755) and required no changes.

## Changes Made

### Data layer (`board-data.mjs`)

- `PHASE_TO_LINEAR`: `triage` → `"Triage"` (was `"Research"`); added `queued → "Todo"` (extra key, allowed by the Requirement 4 superset rule in the drift guard)
- New exported `synthesizeQueuedTicket(e, linfo)` helper — builds a thin `BoardTicket` from an eligible queue entry with `phase: "queued"`, `linearState: "Todo"`, and null/empty fillers for agent/cost/phase-summary fields. Propagates `held` state from `linfo` labels.
- `assembleBoard()`: eligible items not in `ticketIds` are now synthesized into a fourth `queuedTickets` bucket appended after `liveTickets / moving / recentDone`. The `notInFlight` variable is shared between ticket synthesis and the Queue tab's `queue` array (eliminates the duplicate `.filter()` call).

### UI (`Board.tsx`)

- `LINEAR_COLS`: added `{ key: "Todo", c: "#94a3b8" }` and `{ key: "Triage", c: "#64748b" }` at the front, before Research. Both colors match existing `PHASE_C` token for `triage` (`#64748b`) and a lighter slate for Todo (`#94a3b8`).

### Tests (`__tests__/board-todo-column.test.ts`)

New regression guard with 6 assertions:
- Requirement A: `PHASE_TO_LINEAR.triage === "Triage"` (not "Research")
- Requirement B: `PHASE_TO_LINEAR.queued === "Todo"`
- Requirements C: `LINEAR_COLS` contains both `"Todo"` and `"Triage"` keys
- Requirements D: `synthesizeQueuedTicket()` shape — correct `phase`, `linearState`, `status`, `working`, `activeState`, `phaseSummary`, `priority`, `estimate`, `held` propagation

## How to Verify It

### Automated

- [x] `bun test __tests__/board-todo-column.test.ts` — 6 tests pass ✅
- [x] `bun test __tests__/board-phase-drift.test.ts` — all 7 drift-guard assertions pass (including Requirement 6: `PHASE_TO_LINEAR` value-space === `LINEAR_COLS` keys) ✅
- [x] `bun test __tests__/board-held-indicator.test.ts` — unchanged, 9 tests pass ✅
- [x] `bun test __tests__/board-*` — 52/52 pass across all board test files ✅

### Manual

- [ ] Start `catalyst-monitor` and open board at `localhost:7400`
- [ ] Switch to "Linear state" lens — confirm 8 columns visible: Todo, Triage, Research, Plan, Implement, Validate, PR, Done
- [ ] Dispatch a ticket — confirm it appears in Triage column while triage phase runs (not Research)
- [ ] Confirm eligible queue tickets (Todo linear state) appear in the Todo column on the Kanban board
- [ ] Confirm the Queue tab still shows the same ranked list (no regression)
- [ ] A held eligible ticket shows `⏸ blocked` or `⏸ waiting` chip in the Todo column

## What We're NOT Doing

- Not changing `PHASE_COLS` (pipeline lens already has a Triage column)
- Not modifying the hold-state implementation (already done, CTL-755)
- Not touching `board-phase-drift.test.ts` — the existing drift guard naturally enforces the new consistency constraint

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-767
