### PR TITLE
fix(dev): hermetic CATALYST_DIR preload — tests can't pollute the real event log (CTL-810)

### DIFF
--- a/plugins/dev/scripts/execution-core/test-setup.mjs
+++ b/plugins/dev/scripts/execution-core/test-setup.mjs
@@ -20,10 +20,25 @@
 //   2. Token unset: even if a real binary is somehow reached, no creds → no write.
 //   3. CATALYST_TEST flag: a tripwire other guards/tests can assert on.
 import { join } from "node:path";
-import { writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 const fakeBin = join(import.meta.dir, "__tests__", "fake-bin");
 process.env.PATH = `${fakeBin}:${process.env.PATH ?? ""}`;
+
+// CTL-810: pin CATALYST_DIR to a fresh per-run temp dir so no test — and no
+// code under test reaching a default appendEvent/emitReapIntent seam (e.g.
+// recovery.test.mjs reclaim branches that never injected the emit seam) — can
+// append to the REAL ~/catalyst/events/YYYY-MM.jsonl. 69% of the prod event
+// log (194,544 lines) was CTL-9/bg-9 fixture pollution before this guard.
+// Tests that want their own scratch still set CATALYST_DIR themselves; the
+// common save/restore pattern now restores to this hermetic default instead
+// of falling back to the real ~/catalyst. CATALYST_HERMETIC_DIR is the stable
+// record of the pin (asserted by test-setup.test.mjs) — sibling tests mutate
+// CATALYST_DIR mid-suite, but nothing may touch the record.
+const hermeticDir = mkdtempSync(join(tmpdir(), "catalyst-hermetic-"));
+process.env.CATALYST_DIR = hermeticDir;
+process.env.CATALYST_HERMETIC_DIR = hermeticDir;
 
 // Belt: a real linearis reached despite the shim writes nothing without creds.
 delete process.env.LINEAR_API_TOKEN;

--- a/plugins/dev/scripts/execution-core/test-setup.test.mjs
+++ b/plugins/dev/scripts/execution-core/test-setup.test.mjs
@@ -1,0 +1,80 @@
+// test-setup.test.mjs — CTL-810 suite-hermeticity tripwire.
+//
+// The preload (test-setup.mjs, wired via bunfig [test].preload) must pin
+// CATALYST_DIR to a fresh per-run temp dir BEFORE any test module loads, so a
+// test (or code under test reaching a default appendEvent/emitReapIntent seam,
+// e.g. recovery.test.mjs reclaim branches B/C) can never append to the REAL
+// ~/catalyst/events/YYYY-MM.jsonl. Evidence: 194,544 of 282,627 prod log lines
+// (69%) were CTL-9/bg-9 test-fixture pollution on 2026-06-06.
+//
+// Asserts key off CATALYST_HERMETIC_DIR — the preload's stable record of the
+// pinned value — because sibling test files legitimately overwrite and restore
+// CATALYST_DIR mid-suite; the record is the invariant, the live var is not.
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve, sep } from "node:path";
+
+import { getEventLogPath } from "./config.mjs";
+import { emitReapIntent, REAP_INTENT_TYPES } from "./reap-intent.mjs";
+
+const realCatalystDir = resolve(homedir(), "catalyst");
+
+describe("CTL-810: hermetic CATALYST_DIR preload", () => {
+  test("preload pinned CATALYST_DIR to a per-run temp dir and recorded it", () => {
+    const pinned = process.env.CATALYST_HERMETIC_DIR;
+    expect(pinned).toBeDefined();
+    // mkdtempSync names the dir with our prefix — guards against the pin being
+    // repointed somewhere meaningful (like the real ~/catalyst).
+    expect(pinned).toContain("catalyst-hermetic-");
+    // It must live under the OS temp root, never under the real ~/catalyst.
+    expect(resolve(pinned).startsWith(realCatalystDir + sep)).toBe(false);
+    expect(resolve(pinned)).not.toBe(realCatalystDir);
+    expect(resolve(pinned).includes(`${sep}T${sep}`) || resolve(pinned).startsWith(resolve(tmpdir()))).toBe(true);
+    // The dir actually exists, so path resolution inside code under test works.
+    expect(existsSync(pinned)).toBe(true);
+  });
+
+  test("CATALYST_DIR is never the real ~/catalyst when this file runs", () => {
+    // Bun runs every *.test.mjs in ONE shared process with a shared env, and
+    // sibling files legitimately repoint CATALYST_DIR to their own scratch
+    // (some without restoring). So equality-to-the-pin can't be asserted here;
+    // the load-bearing invariant is weaker but real: CATALYST_DIR must NEVER
+    // be unset back to (or repointed at) the ~/catalyst fallback — the preload
+    // seeded it, and the save/restore pattern restores the seed, not undefined.
+    expect(process.env.CATALYST_DIR).toBeDefined();
+    expect(resolve(process.env.CATALYST_DIR)).not.toBe(realCatalystDir);
+    expect(resolve(process.env.CATALYST_DIR).startsWith(realCatalystDir + sep)).toBe(false);
+  });
+
+  test("getEventLogPath() resolves outside the real ~/catalyst", () => {
+    const p = resolve(getEventLogPath());
+    expect(p.startsWith(realCatalystDir + sep)).toBe(false);
+  });
+
+  test("functional: the polluter seam writes under the hermetic dir end-to-end", async () => {
+    // The exact seam that polluted the prod log (emitReapIntent → default
+    // getEventLogPath → mkdir + append) must land its line under the pinned
+    // hermetic dir. Pin CATALYST_DIR back to the recorded value for the
+    // duration (a sibling may have repointed it), emit a uniquely-marked
+    // intent, and read the line back from the hermetic events file.
+    const pinned = process.env.CATALYST_HERMETIC_DIR;
+    const prev = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = pinned;
+    try {
+      const marker = `tripwire-${process.pid}`;
+      const ok = await emitReapIntent(REAP_INTENT_TYPES[0], {
+        ticket: "CTL-810-TRIPWIRE",
+        bgJobId: marker,
+      });
+      expect(ok).toBe(true);
+      const eventsDir = join(pinned, "events");
+      const lines = readdirSync(eventsDir)
+        .map((f) => readFileSync(join(eventsDir, f), "utf8"))
+        .join("");
+      expect(lines).toContain(marker);
+    } finally {
+      process.env.CATALYST_DIR = prev;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The execution-core bun suite wrote reap-intent/event envelopes to the **real** `~/catalyst/events/YYYY-MM.jsonl` whenever code under test reached a default `appendEvent`/`emitReapIntent` seam without `CATALYST_DIR` set (notably `recovery.test.mjs` reclaim branches B/C). Evidence from 2026-06-06: **194,544 of 282,627 prod log lines (69%) were CTL-9/bg-9 test-fixture pollution** — it bloated the prod log (the tick-latency root CTL-802 had to mitigate), corrupted reaper-metrics/event-scan counts, and meant every `bun test` silently mutated orchestrator runtime state.

## Fix (ticket option 1 — preload)

- `test-setup.mjs` (already the bunfig `[test].preload` for Linear/GitHub hermeticity) now pins `CATALYST_DIR` to a fresh `mkdtempSync(catalyst-hermetic-*)` **before any test module loads**, and records the pin in `CATALYST_HERMETIC_DIR`.
- Tests that set their own scratch still override; the common save/restore pattern now restores to the hermetic default instead of falling back to the real `~/catalyst`.
- `test-setup.test.mjs` is the mutation-guarded tripwire: pin recorded + under the OS temp root + never `~/catalyst` + exists; `getEventLogPath()` resolves outside the real dir; **functional end-to-end check** — `emitReapIntent` through the default seam lands its marker line under the hermetic dir.

## Verification

- Full suite: 1970 tests / 66 files — **zero fixture-marker lines** (`CTL-9|bg-9|job-x`) appended to the real event log (delta during the run was ambient broker webhook traffic only).
- 3-lens adversarial verify workflow (correctness / invariants-memory / test-quality): **sound, sound, sound-with-changes** — the flagged major (test-2 name overclaimed vs. bun's shared-process env leakage between sibling files) and the missing functional assert are fixed in this diff. Mutation tests confirmed: reverting the pin or repointing it at the real `~/catalyst` fails all tripwire tests.
- 3 pre-existing failures on main, untouched by this env-only diff: `monitor.test.mjs` CTL-716 burst-budget (timing), `integration-ctl-587` storm repro (timing), `cli/sessions.test.mjs` expects `turn-cap-exhausted` ∈ `TERMINAL` but `signal-reader.mjs:34` lacks it (code/test mismatch — follow-up candidate).

Closes CTL-810. Pairs with CTL-806 (CI execution-core test job must run hermetically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)