### PR TITLE
feat(dev): catalyst-agent — standalone host telemetry + multi-account Claude usage agent (CTL-812)

### DIFF
--- a/plugins/dev/scripts/catalyst-agent/README.md
+++ b/plugins/dev/scripts/catalyst-agent/README.md
@@ -62,7 +62,17 @@ launchd re-launches it each tick.
 ## Emit
 
 - **eventlog** (Approach A) — append each envelope as one JSONL line to
-  `~/catalyst/events/<YYYY-MM UTC>.jsonl`.
+  `~/catalyst/events/<YYYY-MM UTC>.jsonl` (synchronous `appendFileSync`).
 - **otlp** (Approach B) — POST OTLP/HTTP JSON logs to
-  `<CATALYST_AGENT_OTLP_ENDPOINT>/v1/logs`.
+  `<CATALYST_AGENT_OTLP_ENDPOINT>/v1/logs`. The POST is **awaited before the tick
+  returns**, so `--once` never exits with a request still in flight (numbers are
+  emitted as `doubleValue` for a stable per-key OTLP type).
 - **both** — do both.
+
+## Notes
+
+- **Process parsing is cross-platform.** `processes.mjs` parses `ps` per platform:
+  macOS renders the `comm` column at a fixed 16-char width (and truncates deep
+  paths), so the command name is healed from the full `argv[0]` in the `args`
+  column; Linux renders `comm` at its natural width. A rewritten `argv[0]`
+  (a login shell's `-zsh`) still defers to `comm`.

--- a/plugins/dev/scripts/catalyst-agent/README.md
+++ b/plugins/dev/scripts/catalyst-agent/README.md
@@ -1,0 +1,68 @@
+# catalyst-agent (CTL-812)
+
+A self-contained, standalone host-telemetry agent. It samples three domains on a
+launchd `StartInterval` tick and emits OTel log envelopes (same shape as
+execution-core events) so the catalyst-otel collector / Loki dashboards pick them
+up uniformly.
+
+- **Zero npm deps** — `node:*` builtins only; runs unchanged under `node>=18`
+  and `bun`.
+- **Does not import from execution-core** — it is a separate process with its own
+  config, envelope builder, and emit transports.
+
+## Domains
+
+| event.name                  | entity  | toggle (env)             |
+| --------------------------- | ------- | ------------------------ |
+| `account.ratelimit.sampled` | account | `CATALYST_AGENT_USAGE`   |
+| `host.metrics.sampled`      | host    | `CATALYST_AGENT_HOST`    |
+| `host.process.sampled`      | host    | `CATALYST_AGENT_PROCESS` |
+
+Each toggle defaults **on**; set it to `0` to disable that domain.
+
+Each tick runs the enabled domains in order (usage → host → processes). The
+sampler modules (`usage.mjs` + `accounts.mjs`, `host.mjs`, `processes.mjs`) are
+imported lazily and adapted to a uniform `runOnce(config)`; a domain that throws
+is isolated so it never stops the others.
+
+## Run
+
+```sh
+node catalyst-agent.mjs --once      # one tick of each enabled domain, then exit 0
+node catalyst-agent.mjs --loop      # run continuously on the configured interval
+node catalyst-agent.mjs --install   # print launchd install instructions
+node catalyst-agent.mjs --help      # usage
+
+bun test                            # run the unit suite
+```
+
+### launchd (macOS)
+
+```sh
+./install.sh                        # idempotent: substitute tokens, copy plist, (re)load
+```
+
+The plist runs the agent with `--once` every `StartInterval` (default 300s);
+launchd re-launches it each tick.
+
+## Env knobs
+
+| Variable                      | Default                       | Meaning                                            |
+| ----------------------------- | ----------------------------- | -------------------------------------------------- |
+| `CATALYST_AGENT_EMIT`         | `eventlog`                    | `eventlog` \| `otlp` \| `both`                     |
+| `CATALYST_AGENT_OTLP_ENDPOINT`| _none_                        | base URL; `/v1/logs` is appended on POST           |
+| `CATALYST_AGENT_OTLP_HEADERS` | _none_                        | extra OTLP headers, `k=v,k=v`                       |
+| `CATALYST_AGENT_INTERVAL_MS`  | `300000` (floor `180000`)     | tick cadence                                       |
+| `CATALYST_AGENT_TOP_N`        | `10`                          | top-N processes by RSS (`host.process.sampled`)    |
+| `CATALYST_AGENT_USAGE`        | on                            | `0` disables the account rate-limit domain         |
+| `CATALYST_AGENT_HOST`         | on                            | `0` disables the host.metrics domain               |
+| `CATALYST_AGENT_PROCESS`      | on                            | `0` disables the host.process domain               |
+| `CATALYST_DIR`                | `~/catalyst`                  | event-log root (`<dir>/events/<YYYY-MM>.jsonl`)    |
+
+## Emit
+
+- **eventlog** (Approach A) — append each envelope as one JSONL line to
+  `~/catalyst/events/<YYYY-MM UTC>.jsonl`.
+- **otlp** (Approach B) — POST OTLP/HTTP JSON logs to
+  `<CATALYST_AGENT_OTLP_ENDPOINT>/v1/logs`.
+- **both** — do both.

--- a/plugins/dev/scripts/catalyst-agent/accounts.mjs
+++ b/plugins/dev/scripts/catalyst-agent/accounts.mjs
@@ -1,0 +1,187 @@
+// accounts.mjs — CTL-812 Domain 1. Enumerate the Claude accounts the agent
+// should sample rate-limit usage for: the locally-active account plus any
+// claude-swap backups.
+//
+// On most hosts there is exactly ONE account — the active one read from the
+// macOS Keychain (or ~/.claude/.credentials.json on other platforms). When the
+// operator uses claude-swap (cswap), each swapped-out account is persisted as a
+// JSON file under ~/.claude-swap-backup/credentials/ with the same
+// { claudeAiOauth: { accessToken, refreshToken } } shape. Those backup tokens
+// can be STALE, so each is refreshed via the platform OAuth token endpoint
+// before use; an account whose refresh fails is dropped from the run.
+//
+// SELF-CONTAINED: zero npm deps, node:* builtins only; runs under node>=18 and
+// bun. The standalone agent does NOT import from execution-core.
+//
+// SECRETS HYGIENE (hard rule): OAuth access/refresh tokens are read into local
+// variables and used without ever being logged, echoed, or placed in an error
+// message. The refresh-failure warning carries the FILE name only — never the
+// token. NEVER print a token.
+//
+// All side effects (readActiveToken, listBackups, refreshToken) are injected so
+// enumerateAccounts() is fully unit-testable with no real keychain, filesystem,
+// or network.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { log } from "./config.mjs";
+
+// The platform OAuth token endpoint + the public client id, per the locked
+// CTL-812 spec. A swapped-out backup token is refreshed (read-only — the
+// refreshed token is used in-memory for this run and NEVER written back).
+const TOKEN_ENDPOINT = "https://platform.claude.com/v1/oauth/token";
+const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+
+// The claude-swap backup credentials directory. Each entry is one JSON file
+// carrying the same { claudeAiOauth } shape as the live credentials.
+function backupCredentialsDir() {
+  return resolve(homedir(), ".claude-swap-backup", "credentials");
+}
+
+// defaultReadActiveToken — resolve the locally-active OAuth access token. On
+// macOS this reads the Keychain generic password; other platforms read
+// ~/.claude/.credentials.json. Both paths parse the same JSON blob and pull
+// .claudeAiOauth.accessToken. Returns null on ANY error — never throws, never
+// logs the token. (Copied verbatim in spirit from
+// execution-core/ratelimit-poller.mjs's defaultReadToken so the standalone
+// agent stays dependency-free.)
+export function defaultReadActiveToken() {
+  try {
+    let raw;
+    if (process.platform === "darwin") {
+      raw = execFileSync(
+        "security",
+        ["find-generic-password", "-s", "Claude Code-credentials", "-w"],
+        { encoding: "utf8" },
+      );
+    } else {
+      raw = readFileSync(resolve(homedir(), ".claude", ".credentials.json"), "utf8");
+    }
+    const token = JSON.parse(raw)?.claudeAiOauth?.accessToken;
+    return token || null;
+  } catch {
+    return null;
+  }
+}
+
+// defaultListBackups — enumerate the claude-swap backup credential files,
+// returning [{ file, token, refreshToken }] for each parseable JSON entry. A
+// missing directory (the common single-account case) or an unreadable/garbled
+// file yields an empty list / skips that entry — never throws, never logs a
+// token. `file` is the BASENAME only (low-cardinality, no path leakage in logs).
+export function defaultListBackups(dir = backupCredentialsDir()) {
+  let names;
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return []; // dir absent → single-account host
+  }
+  const out = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    try {
+      const raw = readFileSync(resolve(dir, name), "utf8");
+      const oauth = JSON.parse(raw)?.claudeAiOauth;
+      const token = oauth?.accessToken ?? null;
+      const refreshToken = oauth?.refreshToken ?? null;
+      out.push({ file: name, token, refreshToken });
+    } catch {
+      // Unreadable / non-JSON backup file — skip it silently (no token to leak).
+    }
+  }
+  return out;
+}
+
+// defaultRefreshToken — POST a refresh_token grant to the platform OAuth
+// endpoint and return the fresh access token, or null on ANY failure. The
+// refreshed token is used in-memory for this run only; it is NEVER written back
+// to disk (read-only v1). NEVER throws, NEVER logs the token. `fetchImpl` is
+// injectable for tests.
+export async function defaultRefreshToken(refreshToken, { fetchImpl = fetch } = {}) {
+  if (!refreshToken) return null;
+  try {
+    const res = await fetchImpl(TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: OAUTH_CLIENT_ID,
+      }),
+    });
+    if (res?.status !== 200) return null;
+    const body = await res.json();
+    // The fresh token may live under .access_token (OAuth) or, defensively,
+    // the nested .claudeAiOauth.accessToken shape.
+    const token = body?.access_token ?? body?.claudeAiOauth?.accessToken ?? null;
+    return token || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * enumerateAccounts — resolve every account the agent should sample this run.
+ * Returns an array of { source, token, file? }:
+ *   - the active account first (source:'active'), when a token is available
+ *   - then one entry per claude-swap backup (source:'backup', file:<basename>)
+ *     whose stale token refreshed successfully
+ * A backup whose refresh fails is dropped with a warning that carries the FILE
+ * name only — never the token. NEVER throws.
+ *
+ * All seams are injected so the function is fully unit-testable with no real
+ * keychain, filesystem, or network.
+ *
+ * @param {object}   [opts]
+ * @param {Function} [opts.readActiveToken=defaultReadActiveToken] sync; returns string|null
+ * @param {Function} [opts.listBackups=defaultListBackups]         sync; returns [{file,token,refreshToken}]
+ * @param {Function} [opts.refreshToken=defaultRefreshToken]       async (refreshToken) → string|null
+ * @returns {Promise<Array<{source:'active'|'backup', token:string, file?:string}>>}
+ */
+export async function enumerateAccounts({
+  readActiveToken = defaultReadActiveToken,
+  listBackups = defaultListBackups,
+  refreshToken = defaultRefreshToken,
+} = {}) {
+  const accounts = [];
+
+  // 1. The active account (keychain / credentials file). Listed first.
+  let activeToken = null;
+  try {
+    activeToken = readActiveToken();
+  } catch {
+    activeToken = null;
+  }
+  if (activeToken) {
+    accounts.push({ source: "active", token: activeToken });
+  } else {
+    log.warn("accounts: no active OAuth token available");
+  }
+
+  // 2. The claude-swap backups. Each stale token is refreshed before use; a
+  //    refresh failure drops the account (the run still proceeds for the rest).
+  let backups = [];
+  try {
+    backups = listBackups() ?? [];
+  } catch {
+    backups = []; // unreadable backup dir → active-only
+  }
+  for (const backup of backups) {
+    let fresh = null;
+    try {
+      fresh = await refreshToken(backup.refreshToken, { file: backup.file });
+    } catch {
+      fresh = null;
+    }
+    if (!fresh) {
+      // Warn with the FILE name ONLY — the token is never included.
+      log.warn({ file: backup.file }, "accounts: backup token refresh failed; skipping account");
+      continue;
+    }
+    accounts.push({ source: "backup", token: fresh, file: backup.file });
+  }
+
+  return accounts;
+}

--- a/plugins/dev/scripts/catalyst-agent/accounts.mjs
+++ b/plugins/dev/scripts/catalyst-agent/accounts.mjs
@@ -171,7 +171,11 @@ export async function enumerateAccounts({
   for (const backup of backups) {
     let fresh = null;
     try {
-      fresh = await refreshToken(backup.refreshToken, { file: backup.file });
+      // Pass ONLY the refresh token: defaultRefreshToken's 2nd arg is { fetchImpl }
+      // (the file name is not one of its params). An earlier version passed
+      // { file } here, which defaultRefreshToken silently ignored — harmless but
+      // misleading (CTL-812 review). The file is used only for the warning below.
+      fresh = await refreshToken(backup.refreshToken);
     } catch {
       fresh = null;
     }

--- a/plugins/dev/scripts/catalyst-agent/accounts.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/accounts.test.mjs
@@ -1,0 +1,275 @@
+// accounts.test.mjs — CTL-812 Domain 1. enumerateAccounts(): active-first
+// ordering, empty-backup-dir fallback to active-only, backup token refresh,
+// refresh-failure-drops-the-account (silent-but-logged WITHOUT the token), and
+// the real defaultListBackups against fake on-disk dir contents. All seams
+// injected; no real keychain, network, or (except the listBackups suite) FS.
+//
+// SECRETS HYGIENE: every fixture token is obviously fake.
+//
+// Run: cd plugins/dev/scripts/catalyst-agent && bun test accounts.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  enumerateAccounts,
+  defaultListBackups,
+  defaultRefreshToken,
+} from "./accounts.mjs";
+
+const ACTIVE_TOKEN = "FAKE-active-access-token-never-logged";
+
+// ─── active account ──────────────────────────────────────────────────────────
+
+describe("enumerateAccounts — active account", () => {
+  test("returns the active account first with source:'active' and no file", async () => {
+    const accounts = await enumerateAccounts({
+      readActiveToken: () => ACTIVE_TOKEN,
+      listBackups: () => [],
+    });
+    expect(accounts).toEqual([{ source: "active", token: ACTIVE_TOKEN }]);
+  });
+
+  test("no active token + no backups → empty list (no throw)", async () => {
+    const accounts = await enumerateAccounts({
+      readActiveToken: () => null,
+      listBackups: () => [],
+    });
+    expect(accounts).toEqual([]);
+  });
+
+  test("a throwing readActiveToken is swallowed; falls through to backups", async () => {
+    const accounts = await enumerateAccounts({
+      readActiveToken: () => {
+        throw new Error("keychain locked");
+      },
+      listBackups: () => [{ file: "a.json", token: "stale-a", refreshToken: "rt-a" }],
+      refreshToken: async () => "FAKE-fresh-a",
+    });
+    expect(accounts).toEqual([{ source: "backup", token: "FAKE-fresh-a", file: "a.json" }]);
+  });
+});
+
+// ─── empty-dir fallback ──────────────────────────────────────────────────────
+
+describe("enumerateAccounts — empty-dir fallback", () => {
+  test("empty backup dir → active-only (the common single-account host)", async () => {
+    const accounts = await enumerateAccounts({
+      readActiveToken: () => ACTIVE_TOKEN,
+      listBackups: () => [], // dir absent / empty
+      refreshToken: async () => {
+        throw new Error("refresh should never be called when there are no backups");
+      },
+    });
+    expect(accounts).toEqual([{ source: "active", token: ACTIVE_TOKEN }]);
+  });
+
+  test("a throwing listBackups is swallowed → active-only", async () => {
+    const accounts = await enumerateAccounts({
+      readActiveToken: () => ACTIVE_TOKEN,
+      listBackups: () => {
+        throw new Error("EACCES");
+      },
+    });
+    expect(accounts).toEqual([{ source: "active", token: ACTIVE_TOKEN }]);
+  });
+});
+
+// ─── backups: refresh + ordering ─────────────────────────────────────────────
+
+describe("enumerateAccounts — backups", () => {
+  test("each backup is refreshed and appended after the active account, in order", async () => {
+    const seenRefresh = [];
+    const accounts = await enumerateAccounts({
+      readActiveToken: () => ACTIVE_TOKEN,
+      listBackups: () => [
+        { file: "alice.json", token: "stale-alice", refreshToken: "rt-alice" },
+        { file: "bob.json", token: "stale-bob", refreshToken: "rt-bob" },
+      ],
+      refreshToken: async (rt) => {
+        seenRefresh.push(rt);
+        return `FAKE-fresh-${rt}`;
+      },
+    });
+    expect(accounts).toEqual([
+      { source: "active", token: ACTIVE_TOKEN },
+      { source: "backup", token: "FAKE-fresh-rt-alice", file: "alice.json" },
+      { source: "backup", token: "FAKE-fresh-rt-bob", file: "bob.json" },
+    ]);
+    // The refresh seam is invoked with each backup's refresh token.
+    expect(seenRefresh).toEqual(["rt-alice", "rt-bob"]);
+  });
+
+  test("backups can be returned with no active account (backup-only host)", async () => {
+    const accounts = await enumerateAccounts({
+      readActiveToken: () => null,
+      listBackups: () => [{ file: "alice.json", token: "stale", refreshToken: "rt" }],
+      refreshToken: async () => "FAKE-fresh",
+    });
+    expect(accounts).toEqual([{ source: "backup", token: "FAKE-fresh", file: "alice.json" }]);
+  });
+});
+
+// ─── refresh failure drops the account (silent-but-logged, no token) ──────────
+
+describe("enumerateAccounts — refresh failure", () => {
+  test("a backup whose refresh returns null is dropped; siblings survive", async () => {
+    const accounts = await enumerateAccounts({
+      readActiveToken: () => ACTIVE_TOKEN,
+      listBackups: () => [
+        { file: "good.json", token: "stale-good", refreshToken: "rt-good" },
+        { file: "expired.json", token: "stale-bad", refreshToken: "rt-bad" },
+      ],
+      refreshToken: async (rt) => (rt === "rt-bad" ? null : "FAKE-fresh-good"),
+    });
+    expect(accounts).toEqual([
+      { source: "active", token: ACTIVE_TOKEN },
+      { source: "backup", token: "FAKE-fresh-good", file: "good.json" },
+    ]);
+    // The expired backup is absent — dropped, not crashed.
+    expect(accounts.some((a) => a.file === "expired.json")).toBe(false);
+  });
+
+  test("a throwing refreshToken drops only that account (no throw)", async () => {
+    const accounts = await enumerateAccounts({
+      readActiveToken: () => null,
+      listBackups: () => [
+        { file: "boom.json", token: "stale", refreshToken: "rt-boom" },
+        { file: "ok.json", token: "stale", refreshToken: "rt-ok" },
+      ],
+      refreshToken: async (rt) => {
+        if (rt === "rt-boom") throw new Error("network down");
+        return "FAKE-fresh-ok";
+      },
+    });
+    expect(accounts).toEqual([{ source: "backup", token: "FAKE-fresh-ok", file: "ok.json" }]);
+  });
+
+  test("the refresh-failure warning never carries a token (secrets hygiene)", async () => {
+    // Capture stderr/stdout: the console-shim logger writes there. The fake
+    // tokens must never appear in any line the agent emits on a refresh failure.
+    const SECRET_RT = "FAKE-SECRET-refresh-token-MUST-NOT-LEAK";
+    const writes = [];
+    const origOut = process.stdout.write.bind(process.stdout);
+    const origErr = process.stderr.write.bind(process.stderr);
+    process.stdout.write = (chunk, ...rest) => {
+      writes.push(String(chunk));
+      return origOut(chunk, ...rest);
+    };
+    process.stderr.write = (chunk, ...rest) => {
+      writes.push(String(chunk));
+      return origErr(chunk, ...rest);
+    };
+    try {
+      await enumerateAccounts({
+        readActiveToken: () => null,
+        listBackups: () => [{ file: "leak.json", token: "FAKE-SECRET-access", refreshToken: SECRET_RT }],
+        refreshToken: async () => null, // force the failure path
+      });
+    } finally {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+    }
+    const all = writes.join("");
+    expect(all).not.toContain(SECRET_RT);
+    expect(all).not.toContain("FAKE-SECRET-access");
+    // But the file name IS allowed in the warning (low-cardinality, no secret).
+    expect(all).toContain("leak.json");
+  });
+});
+
+// ─── defaultListBackups against real fake-dir contents ───────────────────────
+
+describe("defaultListBackups — fake on-disk dir contents", () => {
+  test("parses each .json credential file into {file, token, refreshToken}", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl812-swap-"));
+    writeFileSync(
+      join(dir, "alice.json"),
+      JSON.stringify({ claudeAiOauth: { accessToken: "FAKE-a-access", refreshToken: "FAKE-a-rt" } }),
+    );
+    writeFileSync(
+      join(dir, "bob.json"),
+      JSON.stringify({ claudeAiOauth: { accessToken: "FAKE-b-access", refreshToken: "FAKE-b-rt" } }),
+    );
+    const backups = defaultListBackups(dir).sort((a, b) => a.file.localeCompare(b.file));
+    expect(backups).toEqual([
+      { file: "alice.json", token: "FAKE-a-access", refreshToken: "FAKE-a-rt" },
+      { file: "bob.json", token: "FAKE-b-access", refreshToken: "FAKE-b-rt" },
+    ]);
+  });
+
+  test("a missing directory yields [] (single-account host)", () => {
+    const missing = join(tmpdir(), "ctl812-does-not-exist-" + Math.random().toString(36).slice(2));
+    expect(defaultListBackups(missing)).toEqual([]);
+  });
+
+  test("non-.json files and garbled JSON are skipped silently", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl812-swap-mixed-"));
+    writeFileSync(join(dir, "good.json"), JSON.stringify({ claudeAiOauth: { accessToken: "FAKE-ok", refreshToken: "FAKE-rt" } }));
+    writeFileSync(join(dir, "notes.txt"), "ignore me");
+    writeFileSync(join(dir, "garbled.json"), "{not valid json");
+    const backups = defaultListBackups(dir);
+    expect(backups).toEqual([{ file: "good.json", token: "FAKE-ok", refreshToken: "FAKE-rt" }]);
+  });
+
+  test("a credential file without claudeAiOauth yields null token/refreshToken (still listed)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl812-swap-empty-"));
+    writeFileSync(join(dir, "empty.json"), JSON.stringify({ somethingElse: true }));
+    expect(defaultListBackups(dir)).toEqual([{ file: "empty.json", token: null, refreshToken: null }]);
+  });
+});
+
+// ─── defaultRefreshToken with injected fetch ─────────────────────────────────
+
+describe("defaultRefreshToken — injected fetch", () => {
+  test("a 200 with access_token returns the fresh token", async () => {
+    const fetchImpl = async () => ({ status: 200, json: async () => ({ access_token: "FAKE-fresh-200" }) });
+    expect(await defaultRefreshToken("FAKE-rt", { fetchImpl })).toBe("FAKE-fresh-200");
+  });
+
+  test("a 200 with the nested claudeAiOauth shape is also accepted", async () => {
+    const fetchImpl = async () => ({
+      status: 200,
+      json: async () => ({ claudeAiOauth: { accessToken: "FAKE-nested" } }),
+    });
+    expect(await defaultRefreshToken("FAKE-rt", { fetchImpl })).toBe("FAKE-nested");
+  });
+
+  test("a null refresh token short-circuits to null without calling fetch", async () => {
+    let called = false;
+    const fetchImpl = async () => {
+      called = true;
+      return { status: 200, json: async () => ({}) };
+    };
+    expect(await defaultRefreshToken(null, { fetchImpl })).toBe(null);
+    expect(called).toBe(false);
+  });
+
+  test("a non-200 status returns null (never throws)", async () => {
+    const fetchImpl = async () => ({ status: 400, json: async () => ({}) });
+    expect(await defaultRefreshToken("FAKE-rt", { fetchImpl })).toBe(null);
+  });
+
+  test("a throwing fetch returns null (never throws)", async () => {
+    const fetchImpl = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    await expect(defaultRefreshToken("FAKE-rt", { fetchImpl })).resolves.toBe(null);
+  });
+
+  test("the POST body carries grant_type/refresh_token/client_id; never logs the token", async () => {
+    let captured = null;
+    const fetchImpl = async (url, init) => {
+      captured = { url, init };
+      return { status: 200, json: async () => ({ access_token: "FAKE-fresh" }) };
+    };
+    await defaultRefreshToken("FAKE-rt-secret", { fetchImpl });
+    expect(captured.url).toBe("https://platform.claude.com/v1/oauth/token");
+    expect(captured.init.method).toBe("POST");
+    const body = JSON.parse(captured.init.body);
+    expect(body.grant_type).toBe("refresh_token");
+    expect(body.refresh_token).toBe("FAKE-rt-secret");
+    expect(body.client_id).toBe("9d1c250a-e61b-44d9-88ed-5944d1962f5e");
+  });
+});

--- a/plugins/dev/scripts/catalyst-agent/accounts.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/accounts.test.mjs
@@ -273,3 +273,62 @@ describe("defaultRefreshToken — injected fetch", () => {
     expect(body.client_id).toBe("9d1c250a-e61b-44d9-88ed-5944d1962f5e");
   });
 });
+
+// ─── enumerateAccounts × the REAL defaultRefreshToken (arg-shape) ─────────────
+
+describe("enumerateAccounts — real defaultRefreshToken integration (no injected refresh)", () => {
+  // CTL-812 review: enumerateAccounts used to call refreshToken(rt, { file }) but
+  // defaultRefreshToken's 2nd arg is { fetchImpl } — the { file } was silently
+  // ignored. These tests drive enumerateAccounts through the REAL defaultRefreshToken
+  // (NOT an injected stub), monkeypatching globalThis.fetch so no real network is
+  // touched, proving the default refresh seam actually works end to end via
+  // enumerateAccounts and that the (now corrected) call shape refreshes backups.
+  test("a backup is refreshed through the real defaultRefreshToken (fetch monkeypatched)", async () => {
+    const realFetch = globalThis.fetch;
+    const calls = [];
+    globalThis.fetch = async (url, init) => {
+      calls.push({ url, init });
+      return { status: 200, json: async () => ({ access_token: "FAKE-fresh-from-real-refresh" }) };
+    };
+    try {
+      const accounts = await enumerateAccounts({
+        readActiveToken: () => null,
+        listBackups: () => [{ file: "swap.json", token: "FAKE-stale", refreshToken: "FAKE-rt-real" }],
+        // refreshToken intentionally OMITTED → exercises the real defaultRefreshToken.
+      });
+      expect(accounts).toEqual([
+        { source: "backup", token: "FAKE-fresh-from-real-refresh", file: "swap.json" },
+      ]);
+      // The real refresh seam actually hit the token endpoint with the backup's rt.
+      expect(calls.length).toBe(1);
+      expect(calls[0].url).toBe("https://platform.claude.com/v1/oauth/token");
+      expect(JSON.parse(calls[0].init.body).refresh_token).toBe("FAKE-rt-real");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("a real-refresh failure (non-200) drops the backup; no token leaks in the warning", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({ status: 401, json: async () => ({}) });
+    const writes = [];
+    const origErr = process.stderr.write.bind(process.stderr);
+    const origOut = process.stdout.write.bind(process.stdout);
+    process.stderr.write = (c, ...r) => { writes.push(String(c)); return origErr(c, ...r); };
+    process.stdout.write = (c, ...r) => { writes.push(String(c)); return origOut(c, ...r); };
+    try {
+      const accounts = await enumerateAccounts({
+        readActiveToken: () => null,
+        listBackups: () => [{ file: "expired.json", token: "FAKE-stale", refreshToken: "FAKE-SECRET-rt" }],
+      });
+      expect(accounts).toEqual([]); // refresh failed → dropped
+    } finally {
+      process.stderr.write = origErr;
+      process.stdout.write = origOut;
+      globalThis.fetch = realFetch;
+    }
+    const all = writes.join("");
+    expect(all).not.toContain("FAKE-SECRET-rt");
+    expect(all).toContain("expired.json"); // file name IS allowed in the warning
+  });
+});

--- a/plugins/dev/scripts/catalyst-agent/catalyst-agent.mjs
+++ b/plugins/dev/scripts/catalyst-agent/catalyst-agent.mjs
@@ -22,7 +22,7 @@
 // touch no real network, ps, or keychain.
 
 import { readAgentConfig, log } from "./config.mjs";
-import { makeBuilderEmit } from "./emit.mjs";
+import { makeBuilderEmit, drainPending } from "./emit.mjs";
 
 const HELP = `catalyst-agent — standalone host telemetry agent (CTL-812)
 
@@ -114,20 +114,30 @@ export async function runDomain({ name, importer, config }) {
 // richer, fully-injectable APIs, so each importer adapts that API to runOnce and
 // wires the config-aware emit seam (makeBuilderEmit → emit per CATALYST_AGENT_EMIT).
 //
+// `pending` is the shared array every OTLP POST promise is collected into; runOnce
+// drains it AFTER all domains have ticked so a `--once` / launchd run never exits
+// while a POST is still in flight (CTL-812 review — emit is not fire-and-forget).
+// In the default eventlog mode nothing is pushed (appendFileSync is synchronous).
+//
 // Resolved relative to this module via import.meta.url so the agent can launch
 // from any cwd. The dynamic import is still lazy: a domain whose module fails to
 // load is skipped by runDomain instead of crashing the whole agent.
-function defaultImporters() {
+//
+// Exported so a test can drive the REAL enumerate→tick→emit / sampleHost /
+// sampleProcesses composition (the production --once wiring) end to end, not just
+// injected stubs (CTL-812 review).
+export function defaultImporters(pending = []) {
   return {
     // Domain 1 — account.ratelimit.sampled. Enumerate every account (active +
     // refreshed swap backups), then sample usage for each, emitting one event per
-    // account. emit is the builder-style (name, spec, {now}) seam tickUsage wants.
+    // account. emit is the builder-style (name, spec, {now}) seam tickUsage wants;
+    // it pushes each OTLP POST promise into `pending` for the drain.
     usage: () =>
       import(new URL("./usage.mjs", import.meta.url).href).then((usage) =>
         import(new URL("./accounts.mjs", import.meta.url).href).then((accounts) => ({
           runOnce: async (config) => {
             const enumerated = await accounts.enumerateAccounts();
-            await usage.tickUsage({ accounts: enumerated, emit: makeBuilderEmit(config) });
+            await usage.tickUsage({ accounts: enumerated, emit: makeBuilderEmit(config, { pending }) });
           },
         })),
       ),
@@ -135,85 +145,137 @@ function defaultImporters() {
     host: () =>
       import(new URL("./host.mjs", import.meta.url).href).then((host) => ({
         runOnce: async (config) => {
-          await host.sampleHost({ emit: makeBuilderEmit(config) });
+          await host.sampleHost({ emit: makeBuilderEmit(config, { pending }) });
         },
       })),
     // Domain 3 — host.process.sampled. One event per top-N process by RSS.
-    // sampleProcesses takes the envelope-style emit (already-built envelope), so
-    // it routes through emitEnvelope via its own default — we pass topN from config.
+    // sampleProcesses takes the envelope-style emit (already-built envelope) and
+    // routes it through emitEnvelope via its own default; it drains its OWN OTLP
+    // POSTs internally (it is async), so there is nothing to collect here — we
+    // just pass topN from config and await it.
     process: () =>
       import(new URL("./processes.mjs", import.meta.url).href).then((processes) => ({
-        runOnce: (config) => {
-          processes.sampleProcesses({ topN: config.topN });
+        runOnce: async (config) => {
+          await processes.sampleProcesses({ topN: config.topN });
         },
       })),
   };
 }
 
 /**
- * runOnce — run one tick of each ENABLED domain. Returns the per-domain outcome
- * map. `config` and `importers` are injectable for tests.
+ * runOnce — run one tick of each ENABLED domain, then DRAIN any in-flight OTLP
+ * POSTs before returning, so the `--once` / launchd caller can exit without
+ * dropping telemetry (CTL-812 review). Returns the per-domain outcome map.
+ * `config` and `importers` are injectable for tests; when `importers` is
+ * injected the caller owns its own emit/drain semantics, so the internal drain
+ * is a no-op (its `pending` stays empty).
  */
-export async function runOnce({ config = readAgentConfig(), importers = defaultImporters() } = {}) {
+export async function runOnce({ config = readAgentConfig(), importers } = {}) {
+  const pending = [];
+  const useImporters = importers ?? defaultImporters(pending);
   const results = {};
   if (config.usageEnabled) {
-    results.usage = await runDomain({ name: "usage", importer: importers.usage, config });
+    results.usage = await runDomain({ name: "usage", importer: useImporters.usage, config });
   }
   if (config.hostEnabled) {
-    results.host = await runDomain({ name: "host", importer: importers.host, config });
+    results.host = await runDomain({ name: "host", importer: useImporters.host, config });
   }
   if (config.processEnabled) {
-    results.process = await runDomain({ name: "process", importer: importers.process, config });
+    results.process = await runDomain({ name: "process", importer: useImporters.process, config });
   }
+  // Await every OTLP POST kicked off this tick before resolving — the load-
+  // bearing fix for the --once telemetry-drop. No-op in eventlog mode / when a
+  // test injects its own importers (pending stays empty).
+  await drainPending(pending);
   return results;
 }
 
 // --- CLI ---
-// Exported so a test can assert flag dispatch without spawning a process.
-export async function main(argv = process.argv.slice(2)) {
+/**
+ * main — parse the flag and dispatch. Exported (and fully seam-injected) so a
+ * test can assert the flag-dispatch ladder, the --once exit code, AND the --loop
+ * lifecycle WITHOUT spawning a process or blocking forever.
+ *
+ * Exit codes (the launchd contract): --help/--install/--once → 0, --loop runs
+ * until a signal (the direct entrypoint never resolves it; on SIGINT/SIGTERM the
+ * stop() handler exits 0 directly), an unknown flag → 2.
+ *
+ * `deps` are injectable seams; the defaults are the production wiring:
+ * @param {string[]} [argv]
+ * @param {object}   [deps]
+ * @param {Function} [deps.runOnceImpl=runOnce]   the per-tick runner
+ * @param {Function} [deps.setIntervalImpl=setInterval]   timer factory (returns a handle)
+ * @param {Function} [deps.clearIntervalImpl=clearInterval]
+ * @param {Function} [deps.onSignal]   (name, handler) registrar; defaults to process.on
+ * @param {Function} [deps.waitForStop]  () => Promise that resolves when the loop should end;
+ *                                        default never resolves (process-lifetime loop)
+ * @param {Function} [deps.write]   (stream, text) writer; defaults to the real streams
+ */
+export async function main(argv = process.argv.slice(2), deps = {}) {
+  const {
+    runOnceImpl = runOnce,
+    setIntervalImpl = setInterval,
+    clearIntervalImpl = clearInterval,
+    onSignal = (name, handler) => process.on(name, handler),
+    // Default: a promise that never resolves so the loop runs for the life of the
+    // process (the only exit is the signal handler calling process.exit). A test
+    // injects a resolvable one to drive a finite number of ticks.
+    waitForStop = () => new Promise(() => {}),
+    write = (stream, text) => stream.write(text),
+  } = deps;
+
   const flag = argv.find((a) => a.startsWith("--")) ?? "--help";
 
   if (flag === "--help" || flag === "-h") {
-    process.stdout.write(HELP);
+    write(process.stdout, HELP);
     return 0;
   }
   if (flag === "--install") {
-    process.stdout.write(INSTALL);
+    write(process.stdout, INSTALL);
     return 0;
   }
   if (flag === "--once") {
-    await runOnce();
+    await runOnceImpl();
     return 0;
   }
   if (flag === "--loop") {
     const config = readAgentConfig();
     log.info({ intervalMs: config.intervalMs }, "catalyst-agent: starting loop");
-    // Fire one tick immediately, then on the interval. unref() so a bare `node
-    // catalyst-agent.mjs --loop` does not, by itself, keep the event loop alive
-    // (launchd uses --once instead); the SIGINT/SIGTERM handlers below are what
-    // keep the process running and give it a clean stop.
-    await runOnce({ config });
-    const handle = setInterval(() => {
-      runOnce({ config }).catch((err) =>
+    // Fire one tick immediately, then keep ticking on the interval. The interval
+    // is deliberately NOT unref()'d: a ref'd timer is what holds the event loop
+    // open so the process actually loops (Node signal listeners and an unref'd
+    // timer do NOT keep the loop alive — an earlier version unref'd this handle
+    // AND resolved main() with `return 0`, so `main().then(process.exit)` killed
+    // the process right after the first tick, CTL-812 review). launchd uses
+    // --once instead, so this long-lived mode is the interactive/manual path.
+    await runOnceImpl({ config });
+    const handle = setIntervalImpl(() => {
+      runOnceImpl({ config }).catch((err) =>
         log.warn({ err: err?.message }, "catalyst-agent: loop tick failed"),
       );
     }, config.intervalMs);
-    if (typeof handle?.unref === "function") handle.unref();
-    // Clean stop on a termination signal: clear the interval and exit 0 so the
-    // loop never leaves a dangling timer (and a launchd KeepAlive restart is a
-    // clean handoff, not a kill -9).
+    // Clean stop on a termination signal: clear the interval (releasing the ref
+    // keeping the loop alive) and exit 0 so the loop never leaves a dangling
+    // timer (and a launchd KeepAlive restart is a clean handoff, not a kill -9).
     const stop = (signal) => {
       log.info({ signal }, "catalyst-agent: stopping loop");
-      clearInterval(handle);
+      clearIntervalImpl(handle);
       process.exit(0);
     };
-    process.on("SIGINT", () => stop("SIGINT"));
-    process.on("SIGTERM", () => stop("SIGTERM"));
+    onSignal("SIGINT", () => stop("SIGINT"));
+    onSignal("SIGTERM", () => stop("SIGTERM"));
+    // Block here until waitForStop resolves. In production it never resolves (the
+    // loop runs on the ref'd interval until a signal exits the process), so
+    // main()'s caller never reaches `process.exit(code)` and the loop survives.
+    // A test injects a resolvable waitForStop to end deterministically and clears
+    // the interval itself so no timer leaks past the test.
+    await waitForStop();
+    clearIntervalImpl(handle);
     return 0;
   }
 
-  process.stderr.write(`catalyst-agent: unknown flag "${flag}"\n\n`);
-  process.stdout.write(HELP);
+  write(process.stderr, `catalyst-agent: unknown flag "${flag}"\n\n`);
+  write(process.stdout, HELP);
   return 2;
 }
 

--- a/plugins/dev/scripts/catalyst-agent/catalyst-agent.mjs
+++ b/plugins/dev/scripts/catalyst-agent/catalyst-agent.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+// catalyst-agent.mjs — CTL-812. Standalone host-telemetry agent entrypoint.
+//
+// A SELF-CONTAINED process (zero npm deps, node:* builtins only; runs under both
+// node>=18 and bun) that, once per launchd StartInterval tick, samples three
+// domains and emits OTel envelopes via the configured transport:
+//   1. account.ratelimit.sampled  (CATALYST_AGENT_USAGE)
+//   2. host.metrics.sampled       (CATALYST_AGENT_HOST)
+//   3. host.process.sampled       (CATALYST_AGENT_PROCESS, one event per top-N proc)
+//
+// Modes:
+//   --once     run one tick of each enabled domain, then exit 0 (launchd path)
+//   --loop     run on an internal setInterval at config.intervalMs
+//   --install  print the launchd install instructions
+//   --help     usage
+//
+// The three per-domain samplers live in sibling modules (usage.mjs + accounts.mjs,
+// host.mjs, processes.mjs) and are imported LAZILY through `importers` — each one
+// adapted to a uniform `{ runOnce(config) }` shape. The lazy import means a
+// missing / unparseable domain module is logged and skipped, never a crash, and
+// it keeps `importers` injectable so tests drive runDomain/runOnce with stubs and
+// touch no real network, ps, or keychain.
+
+import { readAgentConfig, log } from "./config.mjs";
+import { makeBuilderEmit } from "./emit.mjs";
+
+const HELP = `catalyst-agent — standalone host telemetry agent (CTL-812)
+
+Usage:
+  catalyst-agent.mjs --once       Run one tick of each enabled domain, then exit
+  catalyst-agent.mjs --loop       Run continuously on the configured interval
+  catalyst-agent.mjs --install    Print launchd install instructions
+  catalyst-agent.mjs --help       Show this help
+
+Domains (each emits OTel envelopes; toggle with env, default on):
+  account.ratelimit.sampled   CATALYST_AGENT_USAGE=0    to disable
+  host.metrics.sampled        CATALYST_AGENT_HOST=0     to disable
+  host.process.sampled        CATALYST_AGENT_PROCESS=0  to disable
+
+Emit (CATALYST_AGENT_EMIT, default eventlog):
+  eventlog   append JSONL to ~/catalyst/events/<YYYY-MM>.jsonl
+  otlp       POST OTLP/HTTP JSON logs to <CATALYST_AGENT_OTLP_ENDPOINT>/v1/logs
+  both       do both
+
+Other env knobs:
+  CATALYST_AGENT_INTERVAL_MS  tick cadence (default 300000, floor 180000)
+  CATALYST_AGENT_TOP_N        top-N processes by RSS (default 10)
+  CATALYST_AGENT_OTLP_HEADERS extra OTLP headers, "k=v,k=v"
+  CATALYST_DIR                override the catalyst dir (event-log root)
+`;
+
+const INSTALL = `catalyst-agent launchd install (macOS)
+
+  1. Copy the plist into LaunchAgents:
+       cp com.catalyst.agent.plist ~/Library/LaunchAgents/com.catalyst.agent.plist
+     (or run ./install.sh from this directory — it does this idempotently)
+
+  2. Edit the copied plist: replace REPLACE_WITH_NODE with the absolute path to
+     your node binary (e.g. $(which node)) and REPLACE_WITH_AGENT with the
+     absolute path to catalyst-agent.mjs.
+
+  3. Load it:
+       launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.catalyst.agent.plist
+
+  4. Verify:
+       launchctl list | grep com.catalyst.agent
+       tail -f ~/catalyst/catalyst-agent.log
+
+  To stop/unload:
+       launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.catalyst.agent.plist
+`;
+
+/**
+ * runDomain — lazily import a domain sampler module and invoke its tick. The
+ * import + tick are both wrapped so a domain whose module fails to load OR whose
+ * tick throws is skipped with a warning instead of crashing the whole agent —
+ * this is the per-domain failure isolation: one domain throwing never stops the
+ * others.
+ *
+ * Each (adapted) sampler module exports `runOnce(config)`. `importer` is
+ * injectable for tests so a test can supply a stub module without a real file on
+ * disk and without any real network / ps / keychain I/O.
+ *
+ * @param {object} spec
+ * @param {string}   spec.name      human label for logs
+ * @param {Function} spec.importer  async () => module (lazy import)
+ * @param {object}   spec.config    the resolved agent config
+ * @returns {Promise<boolean>} true if the domain ran, false if skipped/failed
+ */
+export async function runDomain({ name, importer, config }) {
+  let mod;
+  try {
+    mod = await importer();
+  } catch (err) {
+    log.warn({ domain: name, err: err?.message }, "catalyst-agent: sampler module unavailable; skipping");
+    return false;
+  }
+  if (!mod || typeof mod.runOnce !== "function") {
+    log.warn({ domain: name }, "catalyst-agent: sampler has no runOnce(); skipping");
+    return false;
+  }
+  try {
+    await mod.runOnce(config);
+    return true;
+  } catch (err) {
+    log.warn({ domain: name, err: err?.message }, "catalyst-agent: sampler tick failed");
+    return false;
+  }
+}
+
+// Default lazy importers for the three domain samplers. Each returns a module
+// shaped { runOnce(config) } so runDomain() can drive them uniformly; the real
+// sampler modules (usage.mjs/accounts.mjs, host.mjs, processes.mjs) expose
+// richer, fully-injectable APIs, so each importer adapts that API to runOnce and
+// wires the config-aware emit seam (makeBuilderEmit → emit per CATALYST_AGENT_EMIT).
+//
+// Resolved relative to this module via import.meta.url so the agent can launch
+// from any cwd. The dynamic import is still lazy: a domain whose module fails to
+// load is skipped by runDomain instead of crashing the whole agent.
+function defaultImporters() {
+  return {
+    // Domain 1 — account.ratelimit.sampled. Enumerate every account (active +
+    // refreshed swap backups), then sample usage for each, emitting one event per
+    // account. emit is the builder-style (name, spec, {now}) seam tickUsage wants.
+    usage: () =>
+      import(new URL("./usage.mjs", import.meta.url).href).then((usage) =>
+        import(new URL("./accounts.mjs", import.meta.url).href).then((accounts) => ({
+          runOnce: async (config) => {
+            const enumerated = await accounts.enumerateAccounts();
+            await usage.tickUsage({ accounts: enumerated, emit: makeBuilderEmit(config) });
+          },
+        })),
+      ),
+    // Domain 2 — host.metrics.sampled. One event per tick.
+    host: () =>
+      import(new URL("./host.mjs", import.meta.url).href).then((host) => ({
+        runOnce: async (config) => {
+          await host.sampleHost({ emit: makeBuilderEmit(config) });
+        },
+      })),
+    // Domain 3 — host.process.sampled. One event per top-N process by RSS.
+    // sampleProcesses takes the envelope-style emit (already-built envelope), so
+    // it routes through emitEnvelope via its own default — we pass topN from config.
+    process: () =>
+      import(new URL("./processes.mjs", import.meta.url).href).then((processes) => ({
+        runOnce: (config) => {
+          processes.sampleProcesses({ topN: config.topN });
+        },
+      })),
+  };
+}
+
+/**
+ * runOnce — run one tick of each ENABLED domain. Returns the per-domain outcome
+ * map. `config` and `importers` are injectable for tests.
+ */
+export async function runOnce({ config = readAgentConfig(), importers = defaultImporters() } = {}) {
+  const results = {};
+  if (config.usageEnabled) {
+    results.usage = await runDomain({ name: "usage", importer: importers.usage, config });
+  }
+  if (config.hostEnabled) {
+    results.host = await runDomain({ name: "host", importer: importers.host, config });
+  }
+  if (config.processEnabled) {
+    results.process = await runDomain({ name: "process", importer: importers.process, config });
+  }
+  return results;
+}
+
+// --- CLI ---
+// Exported so a test can assert flag dispatch without spawning a process.
+export async function main(argv = process.argv.slice(2)) {
+  const flag = argv.find((a) => a.startsWith("--")) ?? "--help";
+
+  if (flag === "--help" || flag === "-h") {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (flag === "--install") {
+    process.stdout.write(INSTALL);
+    return 0;
+  }
+  if (flag === "--once") {
+    await runOnce();
+    return 0;
+  }
+  if (flag === "--loop") {
+    const config = readAgentConfig();
+    log.info({ intervalMs: config.intervalMs }, "catalyst-agent: starting loop");
+    // Fire one tick immediately, then on the interval. unref() so a bare `node
+    // catalyst-agent.mjs --loop` does not, by itself, keep the event loop alive
+    // (launchd uses --once instead); the SIGINT/SIGTERM handlers below are what
+    // keep the process running and give it a clean stop.
+    await runOnce({ config });
+    const handle = setInterval(() => {
+      runOnce({ config }).catch((err) =>
+        log.warn({ err: err?.message }, "catalyst-agent: loop tick failed"),
+      );
+    }, config.intervalMs);
+    if (typeof handle?.unref === "function") handle.unref();
+    // Clean stop on a termination signal: clear the interval and exit 0 so the
+    // loop never leaves a dangling timer (and a launchd KeepAlive restart is a
+    // clean handoff, not a kill -9).
+    const stop = (signal) => {
+      log.info({ signal }, "catalyst-agent: stopping loop");
+      clearInterval(handle);
+      process.exit(0);
+    };
+    process.on("SIGINT", () => stop("SIGINT"));
+    process.on("SIGTERM", () => stop("SIGTERM"));
+    return 0;
+  }
+
+  process.stderr.write(`catalyst-agent: unknown flag "${flag}"\n\n`);
+  process.stdout.write(HELP);
+  return 2;
+}
+
+// Only run when invoked directly (not when imported by a test). The
+// import.meta.url vs process.argv[1] guard works under both node and bun.
+const invokedPath = process.argv[1] ? new URL(`file://${process.argv[1]}`).href : "";
+if (invokedPath && import.meta.url === invokedPath) {
+  main().then((code) => process.exit(code));
+}

--- a/plugins/dev/scripts/catalyst-agent/catalyst-agent.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/catalyst-agent.test.mjs
@@ -1,0 +1,84 @@
+// catalyst-agent.test.mjs — CTL-812. Entrypoint wiring: runDomain's graceful
+// skip when a sampler module is missing / malformed, and runOnce honoring the
+// per-domain enable flags. All importers are injected so no real sampler files
+// (which do not exist at the scaffold stage) are touched.
+//
+// Run: cd plugins/dev/scripts/catalyst-agent && bun test catalyst-agent.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { runDomain, runOnce } from "./catalyst-agent.mjs";
+
+const ALL_ON = {
+  usageEnabled: true,
+  hostEnabled: true,
+  processEnabled: true,
+  emit: "eventlog",
+  intervalMs: 300000,
+  topN: 10,
+};
+
+describe("runDomain", () => {
+  test("invokes runOnce(config) and returns true when the module is present", async () => {
+    let seen = null;
+    const importer = async () => ({ runOnce: (cfg) => { seen = cfg; } });
+    const ok = await runDomain({ name: "usage", importer, config: { tag: "cfg" } });
+    expect(ok).toBe(true);
+    expect(seen).toEqual({ tag: "cfg" });
+  });
+
+  test("returns false (no throw) when the import rejects — the scaffold case", async () => {
+    const importer = async () => {
+      throw new Error("Cannot find module './usage-sampler.mjs'");
+    };
+    await expect(runDomain({ name: "usage", importer, config: {} })).resolves.toBe(false);
+  });
+
+  test("returns false when the module lacks a runOnce export", async () => {
+    const importer = async () => ({ notRunOnce: () => {} });
+    await expect(runDomain({ name: "host", importer, config: {} })).resolves.toBe(false);
+  });
+
+  test("returns false (no throw) when the sampler tick throws", async () => {
+    const importer = async () => ({ runOnce: () => { throw new Error("boom"); } });
+    await expect(runDomain({ name: "process", importer, config: {} })).resolves.toBe(false);
+  });
+});
+
+describe("runOnce", () => {
+  test("runs every enabled domain once", async () => {
+    const ran = [];
+    const importers = {
+      usage: async () => ({ runOnce: () => ran.push("usage") }),
+      host: async () => ({ runOnce: () => ran.push("host") }),
+      process: async () => ({ runOnce: () => ran.push("process") }),
+    };
+    const results = await runOnce({ config: ALL_ON, importers });
+    expect(ran.sort()).toEqual(["host", "process", "usage"]);
+    expect(results).toEqual({ usage: true, host: true, process: true });
+  });
+
+  test("skips disabled domains", async () => {
+    const ran = [];
+    const importers = {
+      usage: async () => ({ runOnce: () => ran.push("usage") }),
+      host: async () => ({ runOnce: () => ran.push("host") }),
+      process: async () => ({ runOnce: () => ran.push("process") }),
+    };
+    const config = { ...ALL_ON, hostEnabled: false, processEnabled: false };
+    const results = await runOnce({ config, importers });
+    expect(ran).toEqual(["usage"]);
+    expect(results).toEqual({ usage: true });
+  });
+
+  test("a missing sampler module does not abort sibling domains", async () => {
+    const ran = [];
+    const importers = {
+      usage: async () => { throw new Error("missing"); },
+      host: async () => ({ runOnce: () => ran.push("host") }),
+      process: async () => ({ runOnce: () => ran.push("process") }),
+    };
+    const results = await runOnce({ config: ALL_ON, importers });
+    expect(ran.sort()).toEqual(["host", "process"]);
+    expect(results).toEqual({ usage: false, host: true, process: true });
+  });
+});

--- a/plugins/dev/scripts/catalyst-agent/catalyst-agent.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/catalyst-agent.test.mjs
@@ -6,7 +6,11 @@
 // Run: cd plugins/dev/scripts/catalyst-agent && bun test catalyst-agent.test.mjs
 
 import { describe, test, expect } from "bun:test";
-import { runDomain, runOnce } from "./catalyst-agent.mjs";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runDomain, runOnce, main, defaultImporters } from "./catalyst-agent.mjs";
+import { readAgentConfig } from "./config.mjs";
 
 const ALL_ON = {
   usageEnabled: true,
@@ -80,5 +84,321 @@ describe("runOnce", () => {
     const results = await runOnce({ config: ALL_ON, importers });
     expect(ran.sort()).toEqual(["host", "process"]);
     expect(results).toEqual({ usage: false, host: true, process: true });
+  });
+
+  test("runOnce awaits in-flight OTLP POSTs before resolving (CTL-812: no drop)", async () => {
+    // A domain whose runOnce kicks off a slow async emit. runOnce must not resolve
+    // until that async work settles — otherwise --once would exit (and a real
+    // process.exit would kill an in-flight OTLP POST). Here the domain's runOnce is
+    // itself async and awaited, which is the contract runDomain relies on.
+    let settled = false;
+    const importers = {
+      usage: async () => ({
+        runOnce: async () => {
+          await new Promise((r) => setTimeout(r, 5));
+          settled = true;
+        },
+      }),
+      host: async () => ({ runOnce: () => {} }),
+      process: async () => ({ runOnce: () => {} }),
+    };
+    await runOnce({ config: ALL_ON, importers });
+    expect(settled).toBe(true);
+  });
+});
+
+// ─── main() flag dispatch + exit codes (CTL-812 review: was untested) ──────────
+
+describe("main — flag dispatch & exit codes", () => {
+  // A capturing write seam so help/usage text never hits the real streams and we
+  // can assert WHICH stream each branch wrote to.
+  function captureWrites() {
+    const out = [];
+    const err = [];
+    const write = (stream, text) => {
+      (stream === process.stderr ? err : out).push(text);
+    };
+    return { out, err, write };
+  }
+
+  test("--help returns 0 and writes usage to stdout", async () => {
+    const { out, err, write } = captureWrites();
+    const code = await main(["--help"], { write });
+    expect(code).toBe(0);
+    expect(out.join("")).toContain("catalyst-agent");
+    expect(err.join("")).toBe("");
+  });
+
+  test("-h is an alias for --help (returns 0)", async () => {
+    const { write } = captureWrites();
+    expect(await main(["-h"], { write })).toBe(0);
+  });
+
+  test("no flag defaults to --help (returns 0)", async () => {
+    const { out, write } = captureWrites();
+    expect(await main([], { write })).toBe(0);
+    expect(out.join("")).toContain("Usage:");
+  });
+
+  test("--install returns 0 and writes the launchd instructions to stdout", async () => {
+    const { out, write } = captureWrites();
+    expect(await main(["--install"], { write })).toBe(0);
+    expect(out.join("")).toContain("launchd");
+  });
+
+  test("--once dispatches to the (injected) runOnce and returns 0", async () => {
+    let called = 0;
+    const { write } = captureWrites();
+    const code = await main(["--once"], { write, runOnceImpl: async () => { called++; } });
+    expect(code).toBe(0);
+    expect(called).toBe(1);
+  });
+
+  test("--once awaits runOnce before returning (no early resolve)", async () => {
+    // If main() did not await, `done` would still be false when it returns.
+    let done = false;
+    const { write } = captureWrites();
+    await main(["--once"], {
+      write,
+      runOnceImpl: async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        done = true;
+      },
+    });
+    expect(done).toBe(true);
+  });
+
+  test("an unknown flag returns 2 and writes the error to stderr", async () => {
+    const { out, err, write } = captureWrites();
+    const code = await main(["--frobnicate"], { write });
+    expect(code).toBe(2);
+    expect(err.join("")).toContain('unknown flag "--frobnicate"');
+    // …and still prints help to stdout so the operator sees the valid flags.
+    expect(out.join("")).toContain("Usage:");
+  });
+});
+
+// ─── main --loop lifecycle (CTL-812 review: the loop silently exited) ──────────
+
+describe("main — --loop lifecycle", () => {
+  test("fires the immediate tick AND keeps ticking on the interval (does NOT exit after one)", async () => {
+    // The bug: the interval was unref'd and main() resolved `return 0`, so under
+    // the real entrypoint `main().then(process.exit)` the process exited 0 right
+    // after the first tick — exactly ZERO interval ticks ran. Here we inject a
+    // synchronous setInterval seam that fires the registered callback N times, and
+    // a resolvable waitForStop, and assert runOnce ran MORE than once (immediate +
+    // interval ticks) — i.e. the loop actually loops.
+    let ticks = 0;
+    let intervalCb = null;
+    let cleared = false;
+    let stopResolve;
+    const stopPromise = new Promise((r) => { stopResolve = r; });
+
+    const code = await main(["--loop"], {
+      runOnceImpl: async () => { ticks++; },
+      // Capture the interval callback instead of scheduling a real timer.
+      setIntervalImpl: (cb) => { intervalCb = cb; return { __fake: true }; },
+      clearIntervalImpl: () => { cleared = true; },
+      onSignal: () => {}, // do not touch real process signal handlers
+      // Drive three interval ticks, then resolve the loop.
+      waitForStop: async () => {
+        await intervalCb(); // tick 2
+        await intervalCb(); // tick 3
+        await intervalCb(); // tick 4
+        return stopResolveAndWait();
+      },
+    });
+
+    function stopResolveAndWait() {
+      stopResolve();
+      return stopPromise;
+    }
+
+    expect(code).toBe(0);
+    // 1 immediate tick + 3 interval ticks = 4 — proving the loop loops, not exits.
+    expect(ticks).toBe(4);
+    expect(intervalCb).toBeInstanceOf(Function);
+    // The interval is cleared on stop so no timer leaks.
+    expect(cleared).toBe(true);
+  });
+
+  test("registers SIGINT and SIGTERM handlers", async () => {
+    const signals = [];
+    let stopResolve;
+    const stop = new Promise((r) => { stopResolve = r; });
+    await main(["--loop"], {
+      runOnceImpl: async () => {},
+      setIntervalImpl: () => ({}),
+      clearIntervalImpl: () => {},
+      onSignal: (name) => signals.push(name),
+      waitForStop: () => { stopResolve(); return stop; },
+    });
+    expect(signals.sort()).toEqual(["SIGINT", "SIGTERM"]);
+  });
+
+  test("the interval callback swallows a runOnce rejection (loop survives a bad tick)", async () => {
+    // The interval body is `runOnce().catch(...)`; a rejected tick must NOT throw
+    // out of the interval callback (which would crash the loop) and must NOT leave
+    // an unhandled rejection. The callback is sync (returns undefined) and handles
+    // the rejection internally, so calling it must not throw synchronously, and a
+    // microtask flush must not surface an unhandled rejection.
+    let intervalCb = null;
+    let stopResolve;
+    const stop = new Promise((r) => { stopResolve = r; });
+    let firstTick = true;
+    let unhandled = null;
+    const onUnhandled = (err) => { unhandled = err; };
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      await main(["--loop"], {
+        runOnceImpl: async () => {
+          if (firstTick) { firstTick = false; return; } // immediate tick OK
+          throw new Error("tick boom"); // interval ticks reject
+        },
+        setIntervalImpl: (cb) => { intervalCb = cb; return {}; },
+        clearIntervalImpl: () => {},
+        onSignal: () => {},
+        waitForStop: async () => {
+          // Calling the interval callback must not throw despite runOnce rejecting.
+          expect(() => intervalCb()).not.toThrow();
+          // Let the internal .catch() settle, then assert no unhandled rejection.
+          await new Promise((r) => setTimeout(r, 5));
+          stopResolve();
+          return stop;
+        },
+      });
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+    expect(intervalCb).toBeInstanceOf(Function);
+    expect(unhandled).toBeNull();
+  });
+});
+
+// ─── defaultImporters / makeBuilderEmit — the REAL --once wiring (finding 9) ───
+
+describe("defaultImporters — real sampler composition (event-log emit)", () => {
+  const ENVS = ["CATALYST_DIR", "CATALYST_AGENT_EMIT", "CATALYST_AGENT_USAGE", "CATALYST_AGENT_HOST", "CATALYST_AGENT_PROCESS"];
+  let saved = {};
+  function setEnv(env) {
+    for (const k of ENVS) { saved[k] = process.env[k]; delete process.env[k]; }
+    Object.assign(process.env, env);
+  }
+  function restoreEnv() {
+    for (const k of ENVS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    saved = {};
+  }
+
+  function eventLogFor(dir) {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    return join(dir, "events", `${ym}.jsonl`);
+  }
+
+  test("the process importer runs the REAL sampleProcesses → writes host.process.sampled to the event log", async () => {
+    // Exercises the actual defaultImporters().process.runOnce composition against
+    // the real ps + real emit (eventlog mode), proving sampleProcesses({topN}) is
+    // wired with the right signature and the emit reaches the monthly log. ps is
+    // fast and never-throws, so this is deterministic enough on macOS CI.
+    const dir = mkdtempSync(join(tmpdir(), "ctl812-wire-"));
+    setEnv({ CATALYST_DIR: dir, CATALYST_AGENT_EMIT: "eventlog" });
+    try {
+      const importers = defaultImporters();
+      const mod = await importers.process();
+      await mod.runOnce(readAgentConfig());
+      const logPath = eventLogFor(dir);
+      expect(existsSync(logPath)).toBe(true);
+      const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
+      expect(lines.length).toBeGreaterThan(0);
+      const first = JSON.parse(lines[0]);
+      expect(first.attributes["event.name"]).toBe("host.process.sampled");
+      expect(first.resource["service.name"]).toBe("catalyst.agent");
+    } finally {
+      restoreEnv();
+    }
+  });
+
+  test("the host importer runs the REAL sampleHost → makeBuilderEmit → host.metrics.sampled (eventlog)", async () => {
+    // Exercises defaultImporters().host.runOnce → sampleHost({ emit:
+    // makeBuilderEmit(config) }) end to end against the real host probes (no
+    // network), proving the makeBuilderEmit (name, spec, opts) seam matches the
+    // sampler's expected emit signature and the contract envelope reaches the log.
+    const dir = mkdtempSync(join(tmpdir(), "ctl812-wire-host-"));
+    setEnv({ CATALYST_DIR: dir, CATALYST_AGENT_EMIT: "eventlog" });
+    try {
+      const importers = defaultImporters();
+      const mod = await importers.host();
+      await mod.runOnce(readAgentConfig());
+      const logPath = eventLogFor(dir);
+      expect(existsSync(logPath)).toBe(true);
+      const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
+      // Exactly one host.metrics.sampled event per host tick.
+      expect(lines.length).toBe(1);
+      const env = JSON.parse(lines[0]);
+      expect(env.attributes["event.name"]).toBe("host.metrics.sampled");
+      expect(env.attributes["event.entity"]).toBe("host");
+      expect(env.resource["service.name"]).toBe("catalyst.agent");
+    } finally {
+      restoreEnv();
+    }
+  });
+
+  test("OTLP mode: runOnce awaits the in-flight POST before resolving (CTL-812 drop fix, end to end)", async () => {
+    // The load-bearing --once fix proven through the REAL path: emit=otlp, only the
+    // host domain enabled (no other network), and globalThis.fetch monkeypatched to
+    // a slow POST. After runOnce() resolves the POST MUST have finished — the bug
+    // was process.exit() killing an abandoned fire-and-forget POST. We assert the
+    // POST both STARTED and FINISHED by the time runOnce resolved.
+    const dir = mkdtempSync(join(tmpdir(), "ctl812-otlp-"));
+    setEnv({
+      CATALYST_DIR: dir,
+      CATALYST_AGENT_EMIT: "otlp",
+      CATALYST_AGENT_USAGE: "0", // no keychain/usage network
+      CATALYST_AGENT_PROCESS: "0", // host only
+    });
+    process.env.CATALYST_AGENT_OTLP_ENDPOINT = "http://127.0.0.1:4318";
+    const realFetch = globalThis.fetch;
+    let started = false;
+    let finished = false;
+    globalThis.fetch = async (url) => {
+      started = true;
+      await new Promise((r) => setTimeout(r, 40));
+      finished = true;
+      return { status: 200 };
+    };
+    try {
+      // Real runOnce with the real defaultImporters + real makeBuilderEmit drain.
+      const results = await runOnce();
+      expect(results.host).toBe(true);
+      expect(started).toBe(true);
+      // The decisive assertion: the POST completed before runOnce returned, so a
+      // subsequent process.exit(0) (the --once entrypoint) would NOT drop it.
+      expect(finished).toBe(true);
+    } finally {
+      globalThis.fetch = realFetch;
+      delete process.env.CATALYST_AGENT_OTLP_ENDPOINT;
+      restoreEnv();
+    }
+  });
+
+  test("every importer resolves to a module with an async runOnce (lazy import + adapter shape)", async () => {
+    // Structural wiring check for ALL three domains, with NO network: the usage
+    // importer's runOnce would hit the live keychain + usage API if executed on a
+    // dev host, so we deliberately do NOT call it here — we assert the lazy import
+    // resolves and yields the uniform { runOnce } adapter (the import.meta.url path
+    // + two-level .then chain for usage). The deep enumerate→tick→emit and
+    // sampleHost/sampleProcesses signatures are validated by the host & process
+    // event-log tests above and by the per-module unit suites.
+    const importers = defaultImporters();
+    for (const key of ["usage", "host", "process"]) {
+      const mod = await importers[key]();
+      expect(typeof mod.runOnce).toBe("function");
+      // Each adapter's runOnce is async (returns a promise) so runOnce/runDomain
+      // can await it (the load-bearing property for the OTLP drain).
+      expect(mod.runOnce.constructor.name).toBe("AsyncFunction");
+    }
   });
 });

--- a/plugins/dev/scripts/catalyst-agent/com.catalyst.agent.plist
+++ b/plugins/dev/scripts/catalyst-agent/com.catalyst.agent.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  LaunchAgent template for catalyst-agent (macOS) — CTL-812.
+
+  This is a TEMPLATE. install.sh substitutes the two REPLACE_WITH_* tokens for
+  the real absolute paths before copying it into ~/Library/LaunchAgents/. Run
+  `node catalyst-agent.mjs --install` for the manual instructions.
+
+  StartInterval (seconds) drives the launchd-side cadence. The agent itself runs
+  with --once: launchd re-launches it every interval, the process samples each
+  enabled domain once, then exits 0. Keep StartInterval >= the agent's
+  CATALYST_AGENT_INTERVAL_MS floor (180s) so we never hammer the usage endpoint.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.catalyst.agent</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>REPLACE_WITH_NODE</string>
+    <string>REPLACE_WITH_AGENT</string>
+    <string>--once</string>
+  </array>
+
+  <key>StartInterval</key>
+  <integer>300</integer>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>REPLACE_WITH_HOME/catalyst/catalyst-agent.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>REPLACE_WITH_HOME/catalyst/catalyst-agent.log</string>
+</dict>
+</plist>

--- a/plugins/dev/scripts/catalyst-agent/config.mjs
+++ b/plugins/dev/scripts/catalyst-agent/config.mjs
@@ -1,0 +1,140 @@
+// config.mjs — catalyst-agent configuration: logger, path resolvers, and the
+// per-call env reader for emit mode / OTLP target / cadence / domain toggles.
+// Zero internal deps (leaf module) and zero npm deps — node:* builtins only, so
+// the file runs unchanged under both node>=18 and bun. Mirrors
+// execution-core/config.mjs (CTL-578 pino-with-console-shim, CTL-787 per-call
+// env readers) but is SELF-CONTAINED: the standalone agent never imports from
+// execution-core.
+//
+// CTL-812: the catalyst-agent is a host-level telemetry daemon launched by
+// launchd (StartInterval). Path resolvers re-read CATALYST_DIR per call so tests
+// redirect by setting the env var; the launchd process pins a stable value.
+
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+// --- Logger (mirrors execution-core CTL-578) ---
+// Pino is the daemon's runtime logger. The standalone agent ships with no
+// node_modules, so `pino` is virtually always unresolvable here — wrap the
+// import in try/catch and substitute a console-shim with the same
+// pino-compatible surface so the agent degrades gracefully instead of aborting
+// at module-load.
+let log;
+try {
+  const { default: pino } = await import("pino");
+  log = pino({
+    name: "catalyst-agent",
+    level: process.env.LOG_LEVEL ?? "info",
+  });
+} catch (err) {
+  const emit = (level) => (...args) => {
+    // pino-style: log.info(obj, msg) OR log.info(msg). Console-shim flattens.
+    const stream =
+      level === "error" || level === "fatal" ? process.stderr : process.stdout;
+    stream.write(
+      `[catalyst-agent:${level}] ${args
+        .map((a) => (typeof a === "string" ? a : JSON.stringify(a)))
+        .join(" ")}\n`,
+    );
+  };
+  log = {
+    info: emit("info"),
+    warn: emit("warn"),
+    error: emit("error"),
+    debug: emit("debug"),
+    fatal: emit("fatal"),
+    trace: emit("trace"),
+    child: () => log,
+  };
+  process.stderr.write(
+    `[catalyst-agent] WARN: pino unavailable (${err?.message ?? err}); using console shim\n`,
+  );
+}
+export { log };
+
+// --- Paths ---
+// Re-resolved per call so tests can redirect by setting CATALYST_DIR;
+// production launches pin a stable value.
+function catalystDir() {
+  return process.env.CATALYST_DIR ?? `${homedir()}/catalyst`;
+}
+
+// The unified monthly event log (Approach A emit target). UTC month to match
+// the writer convention shared with execution-core/orch-monitor — the tailer
+// resolves the same path or it would follow the wrong file. Own copy: the
+// standalone agent does not import execution-core's getEventLogPath.
+export function getEventLogPath() {
+  const now = new Date();
+  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  return resolve(catalystDir(), "events", `${ym}.jsonl`);
+}
+
+// --- Cadence floor ---
+// The launchd StartInterval and --loop cadence are both driven by intervalMs.
+// 3 min is the hard floor (matches the rate-limit poller floor) so a misset env
+// can never hammer the usage endpoint into a persistent 429.
+const INTERVAL_FLOOR_MS = 180000;
+const INTERVAL_DEFAULT_MS = 300000;
+
+// --- Agent config (CTL-812) ---
+// Re-reads from process.env on every call so tests can manipulate env vars
+// freely (mirrors execution-core's readMemorySamplerConfig / readRatelimitPollerConfig).
+//
+// Knobs:
+//   CATALYST_AGENT_EMIT            eventlog | otlp | both   (default eventlog)
+//   CATALYST_AGENT_OTLP_ENDPOINT   base URL; /v1/logs is appended on POST
+//   CATALYST_AGENT_OTLP_HEADERS    "k=v,k=v" extra headers for the OTLP POST
+//   CATALYST_AGENT_INTERVAL_MS     tick cadence (default 300000, floor 180000)
+//   CATALYST_AGENT_TOP_N           top-N processes by RSS (default 10, floor 1)
+//   CATALYST_AGENT_USAGE           account rate-limit domain on/off (default on)
+//   CATALYST_AGENT_HOST            host.metrics domain on/off (default on)
+//   CATALYST_AGENT_PROCESS         host.process domain on/off (default on)
+export function readAgentConfig() {
+  const emit = normalizeEmitMode(process.env.CATALYST_AGENT_EMIT);
+
+  const rawInterval = Number(process.env.CATALYST_AGENT_INTERVAL_MS);
+  const intervalMs = Math.max(
+    INTERVAL_FLOOR_MS,
+    Number.isFinite(rawInterval) && rawInterval > 0 ? rawInterval : INTERVAL_DEFAULT_MS,
+  );
+
+  const rawTopN = Number(process.env.CATALYST_AGENT_TOP_N);
+  const topN = Math.max(1, Number.isFinite(rawTopN) && rawTopN > 0 ? Math.floor(rawTopN) : 10);
+
+  return {
+    emit,
+    otlpEndpoint: process.env.CATALYST_AGENT_OTLP_ENDPOINT || null,
+    otlpHeaders: parseHeaders(process.env.CATALYST_AGENT_OTLP_HEADERS),
+    intervalMs,
+    topN,
+    // Per-domain toggles default ON; "0" is the explicit opt-out (mirrors the
+    // execution-core CATALYST_* kill-switch convention).
+    usageEnabled: process.env.CATALYST_AGENT_USAGE !== "0",
+    hostEnabled: process.env.CATALYST_AGENT_HOST !== "0",
+    processEnabled: process.env.CATALYST_AGENT_PROCESS !== "0",
+  };
+}
+
+// normalizeEmitMode — clamp the emit knob to one of the three valid modes.
+// Anything unrecognized (including unset) falls back to "eventlog" so a typo
+// never silently drops telemetry to nowhere.
+function normalizeEmitMode(raw) {
+  const v = String(raw ?? "").toLowerCase();
+  return v === "otlp" || v === "both" ? v : "eventlog";
+}
+
+// parseHeaders — split a "k=v,k=v" list into an object. Empty/missing → {}.
+// Tolerant of stray whitespace; a pair without "=" is skipped. Values may
+// themselves contain "=" (only the first is the separator), e.g. base64 tokens.
+function parseHeaders(raw) {
+  const out = {};
+  if (!raw) return out;
+  for (const pair of String(raw).split(",")) {
+    const idx = pair.indexOf("=");
+    if (idx === -1) continue;
+    const key = pair.slice(0, idx).trim();
+    const value = pair.slice(idx + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}

--- a/plugins/dev/scripts/catalyst-agent/config.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/config.test.mjs
@@ -1,0 +1,181 @@
+// config.test.mjs — CTL-812. catalyst-agent config: readAgentConfig() defaults +
+// overrides (emit mode, OTLP endpoint/headers, interval floor, topN floor, per-
+// domain toggles) and getEventLogPath() with the CATALYST_DIR override.
+// All env is saved/restored so the suite is order-independent.
+//
+// Run: cd plugins/dev/scripts/catalyst-agent && bun test config.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { readAgentConfig, getEventLogPath } from "./config.mjs";
+
+const ENVS = [
+  "CATALYST_AGENT_EMIT",
+  "CATALYST_AGENT_OTLP_ENDPOINT",
+  "CATALYST_AGENT_OTLP_HEADERS",
+  "CATALYST_AGENT_INTERVAL_MS",
+  "CATALYST_AGENT_TOP_N",
+  "CATALYST_AGENT_USAGE",
+  "CATALYST_AGENT_HOST",
+  "CATALYST_AGENT_PROCESS",
+  "CATALYST_DIR",
+];
+let saved = {};
+
+beforeEach(() => {
+  for (const k of ENVS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of ENVS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  saved = {};
+});
+
+describe("readAgentConfig — defaults", () => {
+  test("returns the documented defaults when env is unset", () => {
+    const cfg = readAgentConfig();
+    expect(cfg.emit).toBe("eventlog");
+    expect(cfg.otlpEndpoint).toBe(null);
+    expect(cfg.otlpHeaders).toEqual({});
+    expect(cfg.intervalMs).toBe(300000);
+    expect(cfg.topN).toBe(10);
+    expect(cfg.usageEnabled).toBe(true);
+    expect(cfg.hostEnabled).toBe(true);
+    expect(cfg.processEnabled).toBe(true);
+  });
+});
+
+describe("readAgentConfig — emit mode", () => {
+  test("otlp and both are honored (case-insensitive)", () => {
+    process.env.CATALYST_AGENT_EMIT = "otlp";
+    expect(readAgentConfig().emit).toBe("otlp");
+    process.env.CATALYST_AGENT_EMIT = "BOTH";
+    expect(readAgentConfig().emit).toBe("both");
+  });
+
+  test("an unrecognized mode falls back to eventlog", () => {
+    process.env.CATALYST_AGENT_EMIT = "carrier-pigeon";
+    expect(readAgentConfig().emit).toBe("eventlog");
+  });
+});
+
+describe("readAgentConfig — interval floor", () => {
+  test("a value above the floor is honored", () => {
+    process.env.CATALYST_AGENT_INTERVAL_MS = "600000";
+    expect(readAgentConfig().intervalMs).toBe(600000);
+  });
+
+  test("a value below the 180000 floor is clamped up", () => {
+    process.env.CATALYST_AGENT_INTERVAL_MS = "1000";
+    expect(readAgentConfig().intervalMs).toBe(180000);
+  });
+
+  test("a non-numeric interval falls back to the 300000 default", () => {
+    process.env.CATALYST_AGENT_INTERVAL_MS = "soon";
+    expect(readAgentConfig().intervalMs).toBe(300000);
+  });
+
+  test("zero falls back to the default (then is above the floor)", () => {
+    process.env.CATALYST_AGENT_INTERVAL_MS = "0";
+    expect(readAgentConfig().intervalMs).toBe(300000);
+  });
+});
+
+describe("readAgentConfig — topN floor", () => {
+  test("a positive value is honored (floored to an integer)", () => {
+    process.env.CATALYST_AGENT_TOP_N = "25";
+    expect(readAgentConfig().topN).toBe(25);
+    process.env.CATALYST_AGENT_TOP_N = "7.9";
+    expect(readAgentConfig().topN).toBe(7);
+  });
+
+  test("zero / negative / non-numeric clamp to at least 1", () => {
+    process.env.CATALYST_AGENT_TOP_N = "0";
+    expect(readAgentConfig().topN).toBe(10); // 0 → default 10
+    process.env.CATALYST_AGENT_TOP_N = "-5";
+    expect(readAgentConfig().topN).toBe(10); // negative → default 10
+    process.env.CATALYST_AGENT_TOP_N = "lots";
+    expect(readAgentConfig().topN).toBe(10); // non-numeric → default 10
+  });
+});
+
+describe("readAgentConfig — OTLP endpoint + headers", () => {
+  test("endpoint passes through; empty string is null", () => {
+    process.env.CATALYST_AGENT_OTLP_ENDPOINT = "http://localhost:4318";
+    expect(readAgentConfig().otlpEndpoint).toBe("http://localhost:4318");
+    process.env.CATALYST_AGENT_OTLP_ENDPOINT = "";
+    expect(readAgentConfig().otlpEndpoint).toBe(null);
+  });
+
+  test("headers parse from a k=v,k=v list (whitespace-tolerant)", () => {
+    process.env.CATALYST_AGENT_OTLP_HEADERS = "x-api-key=abc, x-tenant = t1 ";
+    expect(readAgentConfig().otlpHeaders).toEqual({ "x-api-key": "abc", "x-tenant": "t1" });
+  });
+
+  test("a value containing '=' keeps everything after the first '='", () => {
+    process.env.CATALYST_AGENT_OTLP_HEADERS = "authorization=Basic dXNlcjpwYXNz==";
+    expect(readAgentConfig().otlpHeaders).toEqual({ authorization: "Basic dXNlcjpwYXNz==" });
+  });
+
+  test("a malformed pair (no '=') is skipped", () => {
+    process.env.CATALYST_AGENT_OTLP_HEADERS = "good=1,broken,also=2";
+    expect(readAgentConfig().otlpHeaders).toEqual({ good: "1", also: "2" });
+  });
+});
+
+describe("readAgentConfig — domain toggles", () => {
+  test("CATALYST_AGENT_USAGE=0 disables usage only", () => {
+    process.env.CATALYST_AGENT_USAGE = "0";
+    const cfg = readAgentConfig();
+    expect(cfg.usageEnabled).toBe(false);
+    expect(cfg.hostEnabled).toBe(true);
+    expect(cfg.processEnabled).toBe(true);
+  });
+
+  test("CATALYST_AGENT_HOST=0 disables host only", () => {
+    process.env.CATALYST_AGENT_HOST = "0";
+    const cfg = readAgentConfig();
+    expect(cfg.hostEnabled).toBe(false);
+    expect(cfg.usageEnabled).toBe(true);
+    expect(cfg.processEnabled).toBe(true);
+  });
+
+  test("CATALYST_AGENT_PROCESS=0 disables process only", () => {
+    process.env.CATALYST_AGENT_PROCESS = "0";
+    const cfg = readAgentConfig();
+    expect(cfg.processEnabled).toBe(false);
+    expect(cfg.usageEnabled).toBe(true);
+    expect(cfg.hostEnabled).toBe(true);
+  });
+
+  test("any non-zero value keeps a domain enabled", () => {
+    process.env.CATALYST_AGENT_USAGE = "1";
+    process.env.CATALYST_AGENT_HOST = "true";
+    expect(readAgentConfig().usageEnabled).toBe(true);
+    expect(readAgentConfig().hostEnabled).toBe(true);
+  });
+});
+
+describe("getEventLogPath", () => {
+  test("defaults under ~/catalyst/events with a UTC YYYY-MM file", () => {
+    const p = getEventLogPath();
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    expect(p).toBe(resolve(homedir(), "catalyst", "events", `${ym}.jsonl`));
+  });
+
+  test("CATALYST_DIR overrides the root", () => {
+    process.env.CATALYST_DIR = "/tmp/ctl812-fake-catalyst";
+    const p = getEventLogPath();
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    expect(p).toBe(resolve("/tmp/ctl812-fake-catalyst", "events", `${ym}.jsonl`));
+  });
+});

--- a/plugins/dev/scripts/catalyst-agent/emit.mjs
+++ b/plugins/dev/scripts/catalyst-agent/emit.mjs
@@ -95,14 +95,23 @@ export function emitEventLog(envelope, { logPath = getEventLogPath() } = {}) {
 }
 
 // otlpAnyValue — map a JS scalar to an OTLP AnyValue. Booleans before numbers
-// (typeof true === "boolean"); integers use intValue, other numbers doubleValue;
-// everything else stringifies. Null/undefined never reach here (filtered by the
-// put() pattern upstream) but are coerced to an empty string defensively.
+// (typeof true === "boolean"); everything else stringifies. Null/undefined never
+// reach here (filtered by the put() pattern upstream) but are coerced to an empty
+// string defensively.
+//
+// NUMERIC TYPE CHOICE (CTL-812 review): every number maps to doubleValue, never
+// intValue. The samplers round metrics to 1-3 decimals, so the SAME attribute key
+// (e.g. host.cpu_pct) would otherwise oscillate between intValue (when it rounds
+// to a whole number like 50) and doubleValue (50.5) across ticks — an int/double
+// type oscillation per key that strict OTLP consumers can reject. doubleValue is
+// a valid representation for every JS number (an integer-valued double is still a
+// number to Loki / the catalyst-otel collector), so pinning one type per key is
+// the safe, deterministic choice. (The sibling otel-forward collector forces
+// intValue even for fractional values, which is technically invalid OTLP; we go
+// the other, always-valid way.)
 function otlpAnyValue(value) {
   if (typeof value === "boolean") return { boolValue: value };
-  if (typeof value === "number") {
-    return Number.isInteger(value) ? { intValue: value } : { doubleValue: value };
-  }
+  if (typeof value === "number") return { doubleValue: value };
   return { stringValue: value == null ? "" : String(value) };
 }
 
@@ -181,24 +190,34 @@ export async function sendOtlp(envelopes, { endpoint, headers = {}, fetchImpl = 
  * emitEnvelope — route ONE already-built envelope through the transport(s) that
  * the resolved config selects. The single emit seam every domain sampler shares:
  *   eventlog → append a JSONL line to the monthly event log (Approach A)
- *   otlp     → POST it to <endpoint>/v1/logs (Approach B), fire-and-forget
+ *   otlp     → POST it to <endpoint>/v1/logs (Approach B)
  *   both     → do both
  * Best-effort: each transport is itself never-throw, and a rejected OTLP POST is
- * swallowed so a flaky collector never disrupts the tick. Returns nothing.
+ * swallowed so a flaky collector never disrupts the tick.
+ *
+ * RETURNS the pending OTLP POST promise (or null when no POST was issued) so the
+ * caller can AWAIT it before the process exits. This is load-bearing for the
+ * primary `--once` / launchd path: emit is not fire-and-forget — if the caller
+ * exited without awaiting, an in-flight POST would be killed by process.exit()
+ * and the telemetry dropped on every tick (CTL-812 review). The promise itself
+ * already swallows rejections (resolves to true/false), so awaiting it is safe.
  *
  * @param {object} envelope  a buildAgentEnvelope() result
  * @param {object} config    a readAgentConfig() result (emit/otlpEndpoint/otlpHeaders)
+ * @returns {Promise<boolean>|null} the OTLP POST promise, or null for eventlog-only
  */
 export function emitEnvelope(envelope, config) {
   if (config?.emit === "eventlog" || config?.emit === "both") {
     emitEventLog(envelope);
   }
   if (config?.emit === "otlp" || config?.emit === "both") {
-    // Fire-and-forget: the OTLP POST is async and best-effort.
-    Promise.resolve(
+    // sendOtlp is itself never-throw (resolves true/false), but guard the
+    // .catch defensively so a synchronous throw could never escape either.
+    return Promise.resolve(
       sendOtlp([envelope], { endpoint: config.otlpEndpoint, headers: config.otlpHeaders }),
-    ).catch(() => {});
+    ).catch(() => false);
   }
+  return null;
 }
 
 /**
@@ -207,13 +226,37 @@ export function emitEnvelope(envelope, config) {
  * It builds the envelope from (name, spec, {now}) and routes it through the
  * configured transport(s), returning the envelope so the caller can inspect it.
  *
- * @param {object} config  a readAgentConfig() result
+ * The pending OTLP POST promise (if any) is collected into `pending` so the
+ * caller can drain it before exiting — see drainPending(). Without this, the
+ * `--once` path would exit while POSTs are still in flight (CTL-812 review).
+ *
+ * @param {object}   config           a readAgentConfig() result
+ * @param {object}   [opts]
+ * @param {Array}    [opts.pending]    array the emit pushes each OTLP promise into
  * @returns {(name: string, spec: object, opts?: {now?: Function}) => object}
  */
-export function makeBuilderEmit(config) {
+export function makeBuilderEmit(config, { pending } = {}) {
   return (name, spec, opts) => {
     const envelope = buildAgentEnvelope(name, spec, opts);
-    emitEnvelope(envelope, config);
+    const posted = emitEnvelope(envelope, config);
+    if (posted && Array.isArray(pending)) pending.push(posted);
     return envelope;
   };
+}
+
+/**
+ * drainPending — await every collected OTLP POST promise so an in-flight POST is
+ * never abandoned by process.exit() in the `--once` path. Each promise already
+ * resolves (never rejects) to true/false, so Promise.allSettled is belt-and-
+ * braces. Returns nothing; NEVER throws.
+ *
+ * @param {Array<Promise<*>>} [pending]
+ */
+export async function drainPending(pending) {
+  if (!Array.isArray(pending) || pending.length === 0) return;
+  try {
+    await Promise.allSettled(pending);
+  } catch {
+    /* never throw — drain is best-effort */
+  }
 }

--- a/plugins/dev/scripts/catalyst-agent/emit.mjs
+++ b/plugins/dev/scripts/catalyst-agent/emit.mjs
@@ -1,0 +1,219 @@
+// emit.mjs — catalyst-agent telemetry envelope builder + the two emit
+// transports. Mirrors execution-core/ratelimit-event.mjs's envelope shape (OTel
+// log record: ts/id/observedTs/severityText INFO/severityNumber 9/traceId/
+// spanId/resource/attributes/body.payload) so orch-monitor / catalyst-otel
+// parsers treat agent events identically to execution-core events.
+//
+// SELF-CONTAINED: zero npm deps, node:* builtins only; runs under node>=18 and
+// bun. The standalone agent does NOT import from execution-core.
+//
+// Two transports, both best-effort and NEVER-throw:
+//   emitEventLog(envelope) — Approach A: append the envelope as one JSONL line
+//     to ~/catalyst/events/<YYYY-MM UTC>.jsonl (logPath injectable for tests).
+//   sendOtlp(envelopes)    — Approach B: POST OTLP/HTTP JSON logs to
+//     <endpoint>/v1/logs, mapping each envelope to an OTLP logRecord.
+//
+// CRITICAL (telemetry contract): numeric/string value attributes are placed as
+// LOG-RECORD attributes in DOT form (e.g. host.cpu_pct, ratelimit.five_hour_pct)
+// so the catalyst-otel collector renames dot→underscore and Loki promotes them
+// to labels. A body.payload mirror keeps the high-cardinality / human-readable
+// fields. An attribute is included ONLY when its value is non-null/defined (the
+// put() pattern) so the collector never promotes an empty label.
+
+import { mkdirSync, appendFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { hostname } from "node:os";
+import { getEventLogPath, log } from "./config.mjs";
+
+/**
+ * buildAgentEnvelope — assemble the canonical OTel envelope for a catalyst-agent
+ * event. Pure (modulo random ids + timestamp); no I/O.
+ *
+ * @param {string} name  e.g. "account.ratelimit.sampled", "host.metrics.sampled"
+ * @param {object} spec
+ * @param {string}  spec.entity   event.entity — "account" | "host" | …
+ * @param {string} [spec.label]   event.label  — defaults to "unknown"
+ * @param {object} [spec.attrs]   dot-form value attributes; null/undefined entries are dropped
+ * @param {object} [spec.payload] body.payload mirror (kept verbatim, may hold high-cardinality fields)
+ * @param {object} [opts]
+ * @param {Function} [opts.now]   injectable timestamp fn (returns ISO string)
+ * @returns {object} the envelope object
+ */
+export function buildAgentEnvelope(name, { entity, label, attrs = {}, payload = {} } = {}, { now } = {}) {
+  const ts = now ? now() : new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  // event.action is the name with its leading "<entity>." segment stripped,
+  // matching ratelimit-event's `name.replace(/^account\./, "")` convention.
+  const action = entity ? name.replace(new RegExp(`^${entity}\\.`), "") : name;
+
+  const attributes = {
+    "event.name": name,
+    "event.entity": entity,
+    "event.action": action,
+    "event.label": label ?? "unknown",
+  };
+  // Only include a value attribute when it is non-null/defined so the collector
+  // never promotes an empty label (and zero is preserved, not dropped as falsy).
+  const put = (key, value) => {
+    if (value !== null && value !== undefined) attributes[key] = value;
+  };
+  for (const [key, value] of Object.entries(attrs)) put(key, value);
+
+  return {
+    ts,
+    id: randomBytes(8).toString("hex"),
+    observedTs: ts,
+    severityText: "INFO",
+    severityNumber: 9,
+    traceId: randomBytes(16).toString("hex"),
+    spanId: randomBytes(8).toString("hex"),
+    resource: {
+      "service.name": "catalyst.agent",
+      "service.namespace": "catalyst",
+      hostname: hostname(),
+    },
+    body: { payload },
+    attributes,
+  };
+}
+
+/**
+ * emitEventLog — append one envelope as a JSONL line to the unified event log.
+ * Best-effort: returns true on success, false on any failure; NEVER throws.
+ * `logPath` is injectable for tests (defaults to the current monthly log).
+ */
+export function emitEventLog(envelope, { logPath = getEventLogPath() } = {}) {
+  const line = `${JSON.stringify(envelope)}\n`;
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, line);
+    return true;
+  } catch (err) {
+    log.warn({ err: err?.message }, "emit: event-log append failed");
+    return false;
+  }
+}
+
+// otlpAnyValue — map a JS scalar to an OTLP AnyValue. Booleans before numbers
+// (typeof true === "boolean"); integers use intValue, other numbers doubleValue;
+// everything else stringifies. Null/undefined never reach here (filtered by the
+// put() pattern upstream) but are coerced to an empty string defensively.
+function otlpAnyValue(value) {
+  if (typeof value === "boolean") return { boolValue: value };
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? { intValue: value } : { doubleValue: value };
+  }
+  return { stringValue: value == null ? "" : String(value) };
+}
+
+// otlpAttributes — map a flat { key: scalar } object to the OTLP KeyValue[] shape.
+function otlpAttributes(obj) {
+  return Object.entries(obj).map(([key, value]) => ({ key, value: otlpAnyValue(value) }));
+}
+
+// envelopeToLogRecord — map one catalyst-agent envelope to an OTLP logRecord.
+// timeUnixNano is derived from the envelope ts (ms → ns); severity carries
+// through as INFO/9; the dot-form attributes become OTLP attributes and the
+// body.payload rides as a stringValue body for human readability.
+function envelopeToLogRecord(envelope) {
+  const ms = Date.parse(envelope.ts);
+  const timeUnixNano = String((Number.isFinite(ms) ? ms : Date.now()) * 1_000_000);
+  return {
+    timeUnixNano,
+    observedTimeUnixNano: timeUnixNano,
+    severityNumber: 9,
+    severityText: "INFO",
+    body: { stringValue: JSON.stringify(envelope.body?.payload ?? {}) },
+    attributes: otlpAttributes(envelope.attributes ?? {}),
+  };
+}
+
+/**
+ * sendOtlp — POST a batch of envelopes to <endpoint>/v1/logs as OTLP/HTTP JSON
+ * logs. All envelopes share one resource (they originate from this host), so
+ * they are grouped into a single resourceLogs entry. Best-effort: resolves to
+ * true on a 2xx response, false on any non-2xx or network error; NEVER throws.
+ *
+ * @param {object[]} envelopes
+ * @param {object}  opts
+ * @param {string}  opts.endpoint        base URL; "/v1/logs" is appended
+ * @param {object} [opts.headers={}]     extra request headers (k=v map)
+ * @param {Function} [opts.fetchImpl=fetch] injectable fetch for tests
+ * @returns {Promise<boolean>}
+ */
+export async function sendOtlp(envelopes, { endpoint, headers = {}, fetchImpl = fetch } = {}) {
+  if (!endpoint || !Array.isArray(envelopes) || envelopes.length === 0) return false;
+  // Strip any trailing slash so "<endpoint>/" and "<endpoint>" both yield one /v1/logs.
+  const url = `${endpoint.replace(/\/+$/, "")}/v1/logs`;
+
+  // The resource is identical across this host's envelopes; take it from the first.
+  const resourceAttrs = otlpAttributes(envelopes[0].resource ?? {});
+  const body = {
+    resourceLogs: [
+      {
+        resource: { attributes: resourceAttrs },
+        scopeLogs: [
+          {
+            scope: { name: "catalyst-agent" },
+            logRecords: envelopes.map(envelopeToLogRecord),
+          },
+        ],
+      },
+    ],
+  };
+
+  try {
+    const res = await fetchImpl(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    });
+    const ok = res?.status >= 200 && res?.status < 300;
+    if (!ok) log.warn({ status: res?.status }, "emit: OTLP POST non-2xx");
+    return ok;
+  } catch (err) {
+    log.warn({ err: err?.message }, "emit: OTLP POST failed");
+    return false;
+  }
+}
+
+/**
+ * emitEnvelope — route ONE already-built envelope through the transport(s) that
+ * the resolved config selects. The single emit seam every domain sampler shares:
+ *   eventlog → append a JSONL line to the monthly event log (Approach A)
+ *   otlp     → POST it to <endpoint>/v1/logs (Approach B), fire-and-forget
+ *   both     → do both
+ * Best-effort: each transport is itself never-throw, and a rejected OTLP POST is
+ * swallowed so a flaky collector never disrupts the tick. Returns nothing.
+ *
+ * @param {object} envelope  a buildAgentEnvelope() result
+ * @param {object} config    a readAgentConfig() result (emit/otlpEndpoint/otlpHeaders)
+ */
+export function emitEnvelope(envelope, config) {
+  if (config?.emit === "eventlog" || config?.emit === "both") {
+    emitEventLog(envelope);
+  }
+  if (config?.emit === "otlp" || config?.emit === "both") {
+    // Fire-and-forget: the OTLP POST is async and best-effort.
+    Promise.resolve(
+      sendOtlp([envelope], { endpoint: config.otlpEndpoint, headers: config.otlpHeaders }),
+    ).catch(() => {});
+  }
+}
+
+/**
+ * makeBuilderEmit — adapt the config-aware emitEnvelope() to the (name, spec,
+ * opts) "builder-style" emit signature that the host and usage samplers expect.
+ * It builds the envelope from (name, spec, {now}) and routes it through the
+ * configured transport(s), returning the envelope so the caller can inspect it.
+ *
+ * @param {object} config  a readAgentConfig() result
+ * @returns {(name: string, spec: object, opts?: {now?: Function}) => object}
+ */
+export function makeBuilderEmit(config) {
+  return (name, spec, opts) => {
+    const envelope = buildAgentEnvelope(name, spec, opts);
+    emitEnvelope(envelope, config);
+    return envelope;
+  };
+}

--- a/plugins/dev/scripts/catalyst-agent/emit.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/emit.test.mjs
@@ -1,0 +1,245 @@
+// emit.test.mjs — CTL-812. catalyst-agent envelope builder + the two emit
+// transports. buildAgentEnvelope is asserted against the telemetry contract
+// without touching the FS; emitEventLog appends to a temp log; sendOtlp is
+// exercised with an injected fetch (URL, headers, body structure, value types,
+// never-throw on network error).
+//
+// Run: cd plugins/dev/scripts/catalyst-agent && bun test emit.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir, hostname } from "node:os";
+import { join } from "node:path";
+import { buildAgentEnvelope, emitEventLog, sendOtlp } from "./emit.mjs";
+
+// A representative host.metrics spec exercising int + float + string attrs.
+function hostSpec() {
+  return {
+    entity: "host",
+    label: hostname(),
+    attrs: {
+      "host.cpu_pct": 12.5, // float → doubleValue
+      "host.cpu_count": 10, // int → intValue
+      "host.load1": 2.0, // integer-valued float → intValue (Number.isInteger(2.0))
+      "host.mem_used_mb": 8192,
+    },
+    payload: { sampledFrom: "test" },
+  };
+}
+
+describe("buildAgentEnvelope — resource + severity (contract)", () => {
+  test("resource carries catalyst.agent / catalyst / hostname", () => {
+    const env = buildAgentEnvelope("host.metrics.sampled", hostSpec());
+    expect(env.resource["service.name"]).toBe("catalyst.agent");
+    expect(env.resource["service.namespace"]).toBe("catalyst");
+    expect(env.resource.hostname).toBe(hostname());
+  });
+
+  test("severity is INFO / 9", () => {
+    const env = buildAgentEnvelope("host.metrics.sampled", hostSpec());
+    expect(env.severityText).toBe("INFO");
+    expect(env.severityNumber).toBe(9);
+  });
+
+  test("id / traceId / spanId are random hex of the expected widths", () => {
+    const env = buildAgentEnvelope("host.metrics.sampled", hostSpec());
+    expect(env.id).toMatch(/^[0-9a-f]{16}$/);
+    expect(env.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(env.spanId).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("ts is Z-suffixed with no millisecond fraction; injectable now() overrides", () => {
+    const env = buildAgentEnvelope("host.metrics.sampled", hostSpec());
+    expect(env.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    const fixed = "2026-06-06T12:00:00Z";
+    const env2 = buildAgentEnvelope("host.metrics.sampled", hostSpec(), { now: () => fixed });
+    expect(env2.ts).toBe(fixed);
+    expect(env2.observedTs).toBe(fixed);
+  });
+});
+
+describe("buildAgentEnvelope — event.* identity (contract)", () => {
+  test("event.name / entity / action / label are always present", () => {
+    const env = buildAgentEnvelope("host.metrics.sampled", hostSpec());
+    const a = env.attributes;
+    expect(a["event.name"]).toBe("host.metrics.sampled");
+    expect(a["event.entity"]).toBe("host");
+    expect(a["event.action"]).toBe("metrics.sampled"); // entity prefix stripped
+    expect(a["event.label"]).toBe(hostname());
+  });
+
+  test("action strips only the leading <entity>. segment", () => {
+    const env = buildAgentEnvelope("account.ratelimit.sampled", { entity: "account", label: "x" });
+    expect(env.attributes["event.action"]).toBe("ratelimit.sampled");
+  });
+
+  test("event.label falls back to 'unknown' when label absent", () => {
+    const env = buildAgentEnvelope("host.process.sampled", { entity: "host" });
+    expect(env.attributes["event.label"]).toBe("unknown");
+  });
+});
+
+describe("buildAgentEnvelope — attrs only when non-null (put pattern)", () => {
+  test("null and undefined attrs are dropped; zero is preserved", () => {
+    const env = buildAgentEnvelope("host.metrics.sampled", {
+      entity: "host",
+      label: "h",
+      attrs: {
+        "host.cpu_pct": 0, // preserved (not dropped as falsy)
+        "host.load1": null, // dropped
+        "host.mem_used_mb": undefined, // dropped
+        "host.disk_used_pct": 51.2, // kept
+      },
+    });
+    const a = env.attributes;
+    expect(a["host.cpu_pct"]).toBe(0);
+    expect("host.load1" in a).toBe(false);
+    expect("host.mem_used_mb" in a).toBe(false);
+    expect(a["host.disk_used_pct"]).toBe(51.2);
+  });
+
+  test("body.payload is mirrored verbatim", () => {
+    const env = buildAgentEnvelope("host.process.sampled", {
+      entity: "host",
+      label: "h",
+      attrs: { "process.command": "node" },
+      payload: { pid: 1234, ppid: 1, args: "node x.mjs --once" },
+    });
+    expect(env.body.payload).toEqual({ pid: 1234, ppid: 1, args: "node x.mjs --once" });
+  });
+});
+
+describe("emitEventLog", () => {
+  test("appends exactly one valid JSON line and returns true", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl812-el-"));
+    const logPath = join(dir, "2026-06.jsonl");
+    const env = buildAgentEnvelope("host.metrics.sampled", hostSpec());
+    expect(emitEventLog(env, { logPath })).toBe(true);
+    const lines = readFileSync(logPath, "utf8").trim().split("\n");
+    expect(lines.length).toBe(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.attributes["event.name"]).toBe("host.metrics.sampled");
+    expect(parsed.resource["service.name"]).toBe("catalyst.agent");
+  });
+
+  test("creates the parent directory when missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl812-el-"));
+    const logPath = join(dir, "nested", "deep", "2026-06.jsonl");
+    const env = buildAgentEnvelope("host.metrics.sampled", hostSpec());
+    expect(emitEventLog(env, { logPath })).toBe(true);
+    expect(readFileSync(logPath, "utf8").trim().split("\n").length).toBe(1);
+  });
+
+  test("returns false and does not throw for an unwritable logPath", () => {
+    // Passing a directory as the logPath makes appendFileSync throw EISDIR.
+    const dir = mkdtempSync(join(tmpdir(), "ctl812-el-bad-"));
+    const env = buildAgentEnvelope("host.metrics.sampled", hostSpec());
+    let result;
+    expect(() => {
+      result = emitEventLog(env, { logPath: dir });
+    }).not.toThrow();
+    expect(result).toBe(false);
+  });
+});
+
+describe("sendOtlp — mapping correctness with injected fetch", () => {
+  function captureFetch(status = 200) {
+    const calls = [];
+    const fetchImpl = async (url, init) => {
+      calls.push({ url, init });
+      return { status };
+    };
+    return { calls, fetchImpl };
+  }
+
+  test("POSTs to <endpoint>/v1/logs with merged headers and a JSON body", async () => {
+    const { calls, fetchImpl } = captureFetch(200);
+    const env = buildAgentEnvelope("host.metrics.sampled", hostSpec());
+    const ok = await sendOtlp([env], {
+      endpoint: "http://localhost:4318/",
+      headers: { "x-api-key": "k" },
+      fetchImpl,
+    });
+    expect(ok).toBe(true);
+    expect(calls.length).toBe(1);
+    // Trailing slash on endpoint is collapsed to a single /v1/logs.
+    expect(calls[0].url).toBe("http://localhost:4318/v1/logs");
+    expect(calls[0].init.method).toBe("POST");
+    expect(calls[0].init.headers["Content-Type"]).toBe("application/json");
+    expect(calls[0].init.headers["x-api-key"]).toBe("k");
+  });
+
+  test("body maps the envelope to OTLP resourceLogs/scopeLogs/logRecords", async () => {
+    const { calls, fetchImpl } = captureFetch(200);
+    const env = buildAgentEnvelope("host.metrics.sampled", hostSpec(), {
+      now: () => "2026-06-06T12:00:00Z",
+    });
+    await sendOtlp([env], { endpoint: "http://x:4318", fetchImpl });
+    const body = JSON.parse(calls[0].init.body);
+
+    const rl = body.resourceLogs[0];
+    // resource attributes carry through as KeyValue[].
+    const resKeys = Object.fromEntries(rl.resource.attributes.map((kv) => [kv.key, kv.value]));
+    expect(resKeys["service.name"]).toEqual({ stringValue: "catalyst.agent" });
+    expect(resKeys["service.namespace"]).toEqual({ stringValue: "catalyst" });
+
+    const rec = rl.scopeLogs[0].logRecords[0];
+    expect(rec.severityNumber).toBe(9);
+    expect(rec.severityText).toBe("INFO");
+    // timeUnixNano = ms-since-epoch * 1e6, as a string.
+    expect(rec.timeUnixNano).toBe(String(Date.parse("2026-06-06T12:00:00Z") * 1_000_000));
+    // body is the JSON-stringified payload.
+    expect(JSON.parse(rec.body.stringValue)).toEqual({ sampledFrom: "test" });
+  });
+
+  test("attribute value types: int → intValue, float → doubleValue, string → stringValue", async () => {
+    const { calls, fetchImpl } = captureFetch(200);
+    const env = buildAgentEnvelope("host.process.sampled", {
+      entity: "host",
+      label: "h",
+      attrs: {
+        "process.command": "node", // string
+        "process.cpu_pct": 12.5, // float → doubleValue
+        "process.rss_mb": 512, // int → intValue
+      },
+    });
+    await sendOtlp([env], { endpoint: "http://x:4318", fetchImpl });
+    const rec = JSON.parse(calls[0].init.body).resourceLogs[0].scopeLogs[0].logRecords[0];
+    const attrs = Object.fromEntries(rec.attributes.map((kv) => [kv.key, kv.value]));
+    expect(attrs["process.command"]).toEqual({ stringValue: "node" });
+    expect(attrs["process.cpu_pct"]).toEqual({ doubleValue: 12.5 });
+    expect(attrs["process.rss_mb"]).toEqual({ intValue: 512 });
+    expect(attrs["event.name"]).toEqual({ stringValue: "host.process.sampled" });
+  });
+
+  test("batches multiple envelopes into one resourceLogs entry", async () => {
+    const { calls, fetchImpl } = captureFetch(200);
+    const a = buildAgentEnvelope("host.process.sampled", { entity: "host", label: "h", attrs: { "process.command": "node" } });
+    const b = buildAgentEnvelope("host.process.sampled", { entity: "host", label: "h", attrs: { "process.command": "bun" } });
+    await sendOtlp([a, b], { endpoint: "http://x:4318", fetchImpl });
+    const records = JSON.parse(calls[0].init.body).resourceLogs[0].scopeLogs[0].logRecords;
+    expect(records.length).toBe(2);
+  });
+
+  test("a non-2xx status returns false (never throws)", async () => {
+    const { fetchImpl } = captureFetch(500);
+    const env = buildAgentEnvelope("host.metrics.sampled", hostSpec());
+    await expect(sendOtlp([env], { endpoint: "http://x:4318", fetchImpl })).resolves.toBe(false);
+  });
+
+  test("a throwing fetch returns false (never throws)", async () => {
+    const env = buildAgentEnvelope("host.metrics.sampled", hostSpec());
+    const fetchImpl = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    await expect(sendOtlp([env], { endpoint: "http://x:4318", fetchImpl })).resolves.toBe(false);
+  });
+
+  test("no endpoint or empty batch returns false without calling fetch", async () => {
+    const { calls, fetchImpl } = captureFetch(200);
+    const env = buildAgentEnvelope("host.metrics.sampled", hostSpec());
+    expect(await sendOtlp([env], { endpoint: "", fetchImpl })).toBe(false);
+    expect(await sendOtlp([], { endpoint: "http://x:4318", fetchImpl })).toBe(false);
+    expect(calls.length).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/catalyst-agent/emit.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/emit.test.mjs
@@ -6,21 +6,30 @@
 //
 // Run: cd plugins/dev/scripts/catalyst-agent && bun test emit.test.mjs
 
-import { describe, test, expect } from "bun:test";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir, hostname } from "node:os";
 import { join } from "node:path";
-import { buildAgentEnvelope, emitEventLog, sendOtlp } from "./emit.mjs";
+import {
+  buildAgentEnvelope,
+  emitEventLog,
+  sendOtlp,
+  emitEnvelope,
+  makeBuilderEmit,
+  drainPending,
+} from "./emit.mjs";
 
-// A representative host.metrics spec exercising int + float + string attrs.
+// A representative host.metrics spec exercising number + string attrs. Every
+// number maps to doubleValue (CTL-812 review: one OTLP type per attribute key,
+// no int/double oscillation when a metric happens to round to a whole number).
 function hostSpec() {
   return {
     entity: "host",
     label: hostname(),
     attrs: {
-      "host.cpu_pct": 12.5, // float → doubleValue
-      "host.cpu_count": 10, // int → intValue
-      "host.load1": 2.0, // integer-valued float → intValue (Number.isInteger(2.0))
+      "host.cpu_pct": 12.5, // fractional → doubleValue
+      "host.cpu_count": 10, // whole number → STILL doubleValue (pinned type)
+      "host.load1": 2.0, // integer-valued → doubleValue
       "host.mem_used_mb": 8192,
     },
     payload: { sampledFrom: "test" },
@@ -192,15 +201,19 @@ describe("sendOtlp — mapping correctness with injected fetch", () => {
     expect(JSON.parse(rec.body.stringValue)).toEqual({ sampledFrom: "test" });
   });
 
-  test("attribute value types: int → intValue, float → doubleValue, string → stringValue", async () => {
+  test("every number → doubleValue (one type per key); strings → stringValue", async () => {
+    // CTL-812 review: a metric that rounds to a whole number (process.rss_mb 512)
+    // must NOT switch to intValue — the same attribute key would then carry
+    // intValue on one tick and doubleValue on another, an int/double oscillation
+    // that strict OTLP consumers reject. doubleValue is valid for every number.
     const { calls, fetchImpl } = captureFetch(200);
     const env = buildAgentEnvelope("host.process.sampled", {
       entity: "host",
       label: "h",
       attrs: {
         "process.command": "node", // string
-        "process.cpu_pct": 12.5, // float → doubleValue
-        "process.rss_mb": 512, // int → intValue
+        "process.cpu_pct": 12.5, // fractional → doubleValue
+        "process.rss_mb": 512, // whole number → STILL doubleValue
       },
     });
     await sendOtlp([env], { endpoint: "http://x:4318", fetchImpl });
@@ -208,7 +221,7 @@ describe("sendOtlp — mapping correctness with injected fetch", () => {
     const attrs = Object.fromEntries(rec.attributes.map((kv) => [kv.key, kv.value]));
     expect(attrs["process.command"]).toEqual({ stringValue: "node" });
     expect(attrs["process.cpu_pct"]).toEqual({ doubleValue: 12.5 });
-    expect(attrs["process.rss_mb"]).toEqual({ intValue: 512 });
+    expect(attrs["process.rss_mb"]).toEqual({ doubleValue: 512 });
     expect(attrs["event.name"]).toEqual({ stringValue: "host.process.sampled" });
   });
 
@@ -241,5 +254,168 @@ describe("sendOtlp — mapping correctness with injected fetch", () => {
     expect(await sendOtlp([env], { endpoint: "", fetchImpl })).toBe(false);
     expect(await sendOtlp([], { endpoint: "http://x:4318", fetchImpl })).toBe(false);
     expect(calls.length).toBe(0);
+  });
+});
+
+// ─── emitEnvelope — the mode router (CTL-812 review: was never exercised) ──────
+
+describe("emitEnvelope — eventlog | otlp | both router", () => {
+  // emitEnvelope routes by config.emit through the REAL transports: emitEventLog
+  // (CATALYST_DIR-relative monthly log) and sendOtlp (globalThis.fetch). We point
+  // CATALYST_DIR at a temp dir and monkeypatch fetch so both transports are real
+  // but isolated. Env + fetch are saved/restored so the suite is order-independent.
+  let dir;
+  let realFetch;
+  let posts;
+  const savedCatalystDir = { v: undefined };
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ctl812-router-"));
+    savedCatalystDir.v = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = dir;
+    realFetch = globalThis.fetch;
+    posts = [];
+    globalThis.fetch = async (url, init) => {
+      posts.push({ url, init });
+      return { status: 200 };
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    if (savedCatalystDir.v === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = savedCatalystDir.v;
+  });
+
+  function monthlyLog() {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    return join(dir, "events", `${ym}.jsonl`);
+  }
+  function env() {
+    return buildAgentEnvelope("host.metrics.sampled", hostSpec());
+  }
+  const cfg = (emit) => ({ emit, otlpEndpoint: "http://127.0.0.1:4318", otlpHeaders: {} });
+
+  test("eventlog mode writes the log and issues NO POST; returns null", async () => {
+    const ret = emitEnvelope(env(), cfg("eventlog"));
+    expect(ret).toBeNull(); // no OTLP promise to await
+    expect(existsSync(monthlyLog())).toBe(true);
+    expect(readFileSync(monthlyLog(), "utf8").trim().split("\n").length).toBe(1);
+    expect(posts.length).toBe(0);
+  });
+
+  test("otlp mode POSTs and does NOT write the log; returns an awaitable promise", async () => {
+    const ret = emitEnvelope(env(), cfg("otlp"));
+    expect(ret).not.toBeNull();
+    expect(typeof ret.then).toBe("function");
+    await ret; // drain the POST
+    expect(posts.length).toBe(1);
+    expect(posts[0].url).toBe("http://127.0.0.1:4318/v1/logs");
+    expect(existsSync(monthlyLog())).toBe(false);
+  });
+
+  test("both mode writes the log AND POSTs (returns the POST promise)", async () => {
+    const ret = emitEnvelope(env(), cfg("both"));
+    expect(ret).not.toBeNull();
+    await ret;
+    expect(existsSync(monthlyLog())).toBe(true);
+    expect(posts.length).toBe(1);
+  });
+
+  test("an unrecognized / missing emit mode does nothing (no log, no POST)", async () => {
+    expect(emitEnvelope(env(), { emit: "carrier-pigeon" })).toBeNull();
+    expect(emitEnvelope(env(), undefined)).toBeNull();
+    expect(existsSync(monthlyLog())).toBe(false);
+    expect(posts.length).toBe(0);
+  });
+
+  test("otlp mode never throws even when fetch rejects (returns false)", async () => {
+    globalThis.fetch = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    const ret = emitEnvelope(env(), cfg("otlp"));
+    await expect(ret).resolves.toBe(false);
+  });
+});
+
+// ─── makeBuilderEmit — adapter + pending collection (was never referenced) ────
+
+describe("makeBuilderEmit", () => {
+  let realFetch;
+  let posts;
+  let savedDir;
+  let dir;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ctl812-builder-"));
+    savedDir = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = dir;
+    realFetch = globalThis.fetch;
+    posts = [];
+    globalThis.fetch = async (url, init) => {
+      posts.push({ url, init });
+      return { status: 200 };
+    };
+  });
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    if (savedDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = savedDir;
+  });
+
+  const cfg = (emit) => ({ emit, otlpEndpoint: "http://127.0.0.1:4318", otlpHeaders: {} });
+
+  test("builds the envelope from (name, spec, opts) and returns it", () => {
+    const emit = makeBuilderEmit(cfg("eventlog"));
+    const fixed = "2026-06-06T12:00:00Z";
+    const e = emit(
+      "host.metrics.sampled",
+      { entity: "host", label: "h", attrs: { "host.cpu_pct": 12.5 } },
+      { now: () => fixed },
+    );
+    expect(e.attributes["event.name"]).toBe("host.metrics.sampled");
+    expect(e.attributes["host.cpu_pct"]).toBe(12.5);
+    expect(e.ts).toBe(fixed); // opts.now forwarded into the envelope
+  });
+
+  test("collects the OTLP POST promise into `pending` so the caller can drain it", async () => {
+    const pending = [];
+    const emit = makeBuilderEmit(cfg("otlp"), { pending });
+    emit("host.metrics.sampled", { entity: "host", label: "h", attrs: { "host.cpu_pct": 1 } });
+    expect(pending.length).toBe(1);
+    expect(typeof pending[0].then).toBe("function");
+    await drainPending(pending);
+    expect(posts.length).toBe(1);
+  });
+
+  test("eventlog mode pushes nothing into `pending` (synchronous transport)", () => {
+    const pending = [];
+    const emit = makeBuilderEmit(cfg("eventlog"), { pending });
+    emit("host.metrics.sampled", { entity: "host", label: "h", attrs: { "host.cpu_pct": 1 } });
+    expect(pending.length).toBe(0);
+  });
+});
+
+// ─── drainPending — best-effort await of collected OTLP POSTs ─────────────────
+
+describe("drainPending", () => {
+  test("awaits every pending promise before resolving", async () => {
+    let settled = 0;
+    const pending = [0, 0, 0].map(
+      () => new Promise((r) => setTimeout(() => { settled++; r(true); }, 5)),
+    );
+    await drainPending(pending);
+    expect(settled).toBe(3);
+  });
+
+  test("a rejected pending promise does not make drainPending throw", async () => {
+    const pending = [Promise.reject(new Error("boom")), Promise.resolve(true)];
+    await expect(drainPending(pending)).resolves.toBeUndefined();
+  });
+
+  test("an empty / non-array argument is a no-op (never throws)", async () => {
+    await expect(drainPending([])).resolves.toBeUndefined();
+    await expect(drainPending(undefined)).resolves.toBeUndefined();
   });
 });

--- a/plugins/dev/scripts/catalyst-agent/host.mjs
+++ b/plugins/dev/scripts/catalyst-agent/host.mjs
@@ -1,0 +1,296 @@
+// host.mjs — CTL-812 Domain 2. The host.metrics sampler.
+//
+// sampleHost() reads four host probes (cpu, mem, disk, load) and emits exactly
+// ONE host.metrics.sampled envelope per the telemetry contract. Each probe is
+// an injected seam (readCpu / readMem / readDisk / readLoad) so tick() is fully
+// unit-testable with no real /proc, df, vm_stat, or two-sample sleep. The
+// defaults cover macOS + Linux and NEVER throw — a failed probe returns null and
+// the corresponding attribute is simply omitted (the put() pattern in
+// buildAgentEnvelope), so the event still emits with whatever is available.
+//
+// SELF-CONTAINED: zero npm deps, node:* builtins only; runs under node>=18 and
+// bun. The standalone agent does NOT import from execution-core.
+//
+// Contract attrs (host.metrics.sampled, entity=host, event.label=hostname):
+//   host.cpu_pct       1 decimal, clamped 0..100
+//   host.cpu_count     integer (os.cpus().length)
+//   host.load1         os.loadavg()[0], 2 decimals
+//   host.mem_used_mb   integer
+//   host.mem_total_mb  integer
+//   host.mem_used_pct  1 decimal, clamped 0..100
+//   host.disk_used_gb  1 decimal
+//   host.disk_total_gb 1 decimal
+//   host.disk_used_pct 1 decimal, clamped 0..100
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { cpus, loadavg, totalmem, freemem, hostname } from "node:os";
+import { buildAgentEnvelope, emitEnvelope } from "./emit.mjs";
+import { readAgentConfig, log } from "./config.mjs";
+
+export const HOST_EVENT_SAMPLED = "host.metrics.sampled";
+
+const BYTES_PER_MB = 1024 * 1024;
+const KB_PER_GB = 1024 * 1024; // KB → GB (df reports 1024-byte blocks)
+// Default two-sample window for the CPU-busy delta. 500ms gives a stable read
+// without meaningfully delaying a once-every-5-min launchd tick. Injectable.
+const DEFAULT_CPU_WINDOW_MS = 500;
+
+// --- rounding / clamping helpers (pure) ---
+
+// round1 / round2 — round to 1 / 2 decimals, passing null/non-finite through so
+// a missing probe stays null (and is dropped by the put() pattern downstream).
+function round1(n) {
+  return n == null || !Number.isFinite(n) ? null : Math.round(n * 10) / 10;
+}
+function round2(n) {
+  return n == null || !Number.isFinite(n) ? null : Math.round(n * 100) / 100;
+}
+function roundInt(n) {
+  return n == null || !Number.isFinite(n) ? null : Math.round(n);
+}
+// clampPct — clamp a percentage into [0, 100]; null/non-finite passes through.
+function clampPct(n) {
+  if (n == null || !Number.isFinite(n)) return null;
+  return Math.min(100, Math.max(0, n));
+}
+
+// --- sleep seam (await-able, no foreground `sleep` shell) ---
+function realSleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// --- default probe: CPU ---
+// cpuTimesTotals — sum the per-core { idle, total } from an os.cpus() snapshot.
+// Pure so the two-sample delta can be unit-tested without a real clock.
+export function cpuTimesTotals(snapshot) {
+  let idle = 0;
+  let total = 0;
+  for (const c of snapshot ?? []) {
+    const t = c?.times ?? {};
+    idle += t.idle ?? 0;
+    total += (t.user ?? 0) + (t.nice ?? 0) + (t.sys ?? 0) + (t.idle ?? 0) + (t.irq ?? 0);
+  }
+  return { idle, total };
+}
+
+// cpuBusyPctFromDeltas — busy% = 100 * (1 - Δidle/Δtotal) from two totals.
+// Returns null when Δtotal <= 0 (no elapsed ticks → undefined utilization).
+export function cpuBusyPctFromDeltas(a, b) {
+  const dTotal = b.total - a.total;
+  const dIdle = b.idle - a.idle;
+  if (!(dTotal > 0)) return null;
+  return clampPct(100 * (1 - dIdle / dTotal));
+}
+
+// defaultReadCpu — two-sample os.cpus() busy% over sampleWindowMs (cross-platform).
+// On Linux a /proc/stat delta is marginally cheaper, but the os.cpus() delta is
+// portable and already accurate, so it is the single default path. Never throws.
+//
+// `snapshot` and `sleep` are injectable so the default reader itself is testable
+// without a real delay.
+async function defaultReadCpu({
+  sampleWindowMs = DEFAULT_CPU_WINDOW_MS,
+  snapshot = cpus,
+  sleep = realSleep,
+} = {}) {
+  try {
+    const a = cpuTimesTotals(snapshot());
+    await sleep(sampleWindowMs);
+    const b = cpuTimesTotals(snapshot());
+    return { cpuPct: cpuBusyPctFromDeltas(a, b), cpuCount: snapshot().length };
+  } catch {
+    return { cpuPct: null, cpuCount: null };
+  }
+}
+
+// --- default probe: memory ---
+// PAGE-SIZE / "used" choice (macOS): os.freemem() on Darwin reports only the
+// truly free list and counts the large inactive/compressible pool as "used",
+// which wildly overstates pressure. We instead derive used from vm_stat's
+// active + wired + compressed pages (the genuinely resident, non-reclaimable
+// working set) × page size — the same definition Activity Monitor's "Memory
+// Used" approximates. os.totalmem() is the denominator. If vm_stat is
+// unavailable or unparseable we fall back to os.totalmem()/freemem().
+
+// parseVmStat — parse `vm_stat` output into { pageSize, pages:{...} }. The header
+// line "page size of N bytes" gives the page size; each "Key: N." line yields a
+// page count. Returns null if the page size cannot be found. Pure / never throws.
+export function parseVmStat(text) {
+  if (!text) return null;
+  const sizeMatch = /page size of (\d+) bytes/.exec(text);
+  if (!sizeMatch) return null;
+  const pageSize = Number(sizeMatch[1]);
+  const pages = {};
+  for (const line of String(text).split("\n")) {
+    const m = /^(.*?):\s+(\d+)\.?\s*$/.exec(line);
+    if (m) pages[m[1].trim().toLowerCase()] = Number(m[2]);
+  }
+  return { pageSize, pages };
+}
+
+// memUsedBytesFromVmStat — used = (active + wired down + occupied by compressor)
+// × pageSize. Returns null if any required bucket is missing.
+export function memUsedBytesFromVmStat(parsed) {
+  if (!parsed) return null;
+  const p = parsed.pages;
+  const active = p["pages active"];
+  const wired = p["pages wired down"];
+  const compressed = p["pages occupied by compressor"];
+  if (active == null || wired == null || compressed == null) return null;
+  return (active + wired + compressed) * parsed.pageSize;
+}
+
+// defaultReadMem — { usedMb, totalMb }. macOS prefers the vm_stat-based used
+// (documented above) with an os.* fallback; Linux/other uses os.totalmem -
+// os.freemem directly. Never throws.
+function defaultReadMem({
+  vmStat = () => execFileSync("vm_stat", { encoding: "utf8" }),
+} = {}) {
+  try {
+    const totalBytes = totalmem();
+    let usedBytes = null;
+    if (process.platform === "darwin") {
+      try {
+        usedBytes = memUsedBytesFromVmStat(parseVmStat(vmStat()));
+      } catch {
+        usedBytes = null;
+      }
+    }
+    // Fallback (non-darwin, or vm_stat unavailable): total - free.
+    if (usedBytes == null) usedBytes = totalBytes - freemem();
+    return { usedMb: usedBytes / BYTES_PER_MB, totalMb: totalBytes / BYTES_PER_MB };
+  } catch {
+    return { usedMb: null, totalMb: null };
+  }
+}
+
+// --- default probe: disk ---
+// parseDfRoot — parse `df -k /` output → { usedKb, totalKb }. macOS df adds inode
+// columns (iused ifree %iused) after Capacity and a two-word "Mounted on" header,
+// so we index from the START of the data row: field[1]=1024-blocks (total),
+// field[2]=Used. Linux `df -k /` is [fs, 1K-blocks, used, avail, use%, mount] —
+// the same positions. A device path with embedded spaces is not expected for /.
+// Returns null if the row cannot be parsed. Pure / never throws.
+export function parseDfRoot(text) {
+  if (!text) return null;
+  const lines = String(text).trim().split("\n");
+  if (lines.length < 2) return null;
+  // Last non-empty line is the data row (header is first).
+  const row = lines[lines.length - 1].trim().split(/\s+/);
+  const totalKb = Number(row[1]);
+  const usedKb = Number(row[2]);
+  if (!Number.isFinite(totalKb) || !Number.isFinite(usedKb)) return null;
+  return { usedKb, totalKb };
+}
+
+// defaultReadDisk — { usedGb, totalGb } for the root filesystem via `df -k /`.
+// Never throws.
+function defaultReadDisk({
+  df = () => execFileSync("df", ["-k", "/"], { encoding: "utf8" }),
+} = {}) {
+  try {
+    const parsed = parseDfRoot(df());
+    if (!parsed) return { usedGb: null, totalGb: null };
+    return { usedGb: parsed.usedKb / KB_PER_GB, totalGb: parsed.totalKb / KB_PER_GB };
+  } catch {
+    return { usedGb: null, totalGb: null };
+  }
+}
+
+// --- default probe: load ---
+// defaultReadLoad — 1-minute load average. os.loadavg() returns [0,0,0] on
+// platforms without load tracking (e.g. some Windows), which is a legitimate 0
+// here. Never throws.
+function defaultReadLoad() {
+  try {
+    return loadavg()[0];
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * sampleHost — read the four host probes and emit ONE host.metrics.sampled
+ * envelope. Every probe is injected (defaults provided) so the function is fully
+ * unit-testable with no real I/O. A probe that fails / returns null simply omits
+ * its attribute(s); the event still emits with whatever is available.
+ *
+ * @param {object}  [opts]
+ * @param {Function} [opts.readCpu]  async/ sync → { cpuPct, cpuCount }
+ * @param {Function} [opts.readMem]  → { usedMb, totalMb }
+ * @param {Function} [opts.readDisk] → { usedGb, totalGb }
+ * @param {Function} [opts.readLoad] → number (load1) | null
+ * @param {Function} [opts.emit]     (name, spec, opts) → emit the envelope
+ * @param {Function} [opts.now]      injectable ISO-timestamp fn (passed to emit)
+ * @param {string}   [opts.label]    event.label override (defaults to hostname())
+ * @returns {Promise<object>} the emitted envelope (also useful for assertions)
+ */
+export async function sampleHost({
+  readCpu = defaultReadCpu,
+  readMem = defaultReadMem,
+  readDisk = defaultReadDisk,
+  readLoad = defaultReadLoad,
+  emit = defaultEmit,
+  now,
+  label = hostname(),
+} = {}) {
+  // Read every probe defensively — one throwing probe must not sink the others
+  // or the whole event. `await` is a no-op on a sync return value.
+  const cpu = (await safe(() => readCpu())) ?? {};
+  const mem = (await safe(() => readMem())) ?? {};
+  const disk = (await safe(() => readDisk())) ?? {};
+  const load1 = await safe(() => readLoad());
+
+  // mem_used_pct / disk_used_pct are derived only when both numerator and a
+  // positive denominator are present (avoid 0/0 → NaN and div-by-zero).
+  const memUsedPct =
+    isPos(mem.totalMb) && mem.usedMb != null ? (mem.usedMb / mem.totalMb) * 100 : null;
+  const diskUsedPct =
+    isPos(disk.totalGb) && disk.usedGb != null ? (disk.usedGb / disk.totalGb) * 100 : null;
+
+  const attrs = {
+    "host.cpu_pct": round1(clampPct(cpu.cpuPct)),
+    "host.cpu_count": roundInt(cpu.cpuCount),
+    "host.load1": round2(load1),
+    "host.mem_used_mb": roundInt(mem.usedMb),
+    "host.mem_total_mb": roundInt(mem.totalMb),
+    "host.mem_used_pct": round1(clampPct(memUsedPct)),
+    "host.disk_used_gb": round1(disk.usedGb),
+    "host.disk_total_gb": round1(disk.totalGb),
+    "host.disk_used_pct": round1(clampPct(diskUsedPct)),
+  };
+
+  return emit(HOST_EVENT_SAMPLED, { entity: "host", label, attrs }, { now });
+}
+
+// defaultEmit — build the envelope and route it through the configured
+// transport(s) (eventlog / otlp / both) via the shared emitEnvelope() helper.
+// Kept as the sampler's default so a bare sampleHost() call writes telemetry;
+// tests inject a capturing emit instead. Never throws, and returns the envelope
+// so the caller can inspect it.
+function defaultEmit(name, spec, opts) {
+  const envelope = buildAgentEnvelope(name, spec, opts);
+  try {
+    emitEnvelope(envelope, readAgentConfig());
+  } catch (err) {
+    log.warn({ err: err?.message }, "host: emit failed");
+  }
+  return envelope;
+}
+
+// isPos — true only for a finite number strictly greater than 0.
+function isPos(n) {
+  return typeof n === "number" && Number.isFinite(n) && n > 0;
+}
+
+// safe — run fn, swallowing any throw to undefined. Awaits the result so both
+// sync and async (Promise-returning) probes are handled uniformly; a rejected
+// promise is also swallowed.
+async function safe(fn) {
+  try {
+    return await fn();
+  } catch {
+    return undefined;
+  }
+}

--- a/plugins/dev/scripts/catalyst-agent/host.mjs
+++ b/plugins/dev/scripts/catalyst-agent/host.mjs
@@ -261,18 +261,24 @@ export async function sampleHost({
     "host.disk_used_pct": round1(clampPct(diskUsedPct)),
   };
 
-  return emit(HOST_EVENT_SAMPLED, { entity: "host", label, attrs }, { now });
+  // `await` normalizes both emit seams: the default async defaultEmit (which
+  // awaits its own OTLP POST) and the sync makeBuilderEmit (which returns the
+  // envelope synchronously and routes the POST into runOnce's drain).
+  return await emit(HOST_EVENT_SAMPLED, { entity: "host", label, attrs }, { now });
 }
 
 // defaultEmit — build the envelope and route it through the configured
 // transport(s) (eventlog / otlp / both) via the shared emitEnvelope() helper.
 // Kept as the sampler's default so a bare sampleHost() call writes telemetry;
 // tests inject a capturing emit instead. Never throws, and returns the envelope
-// so the caller can inspect it.
-function defaultEmit(name, spec, opts) {
+// so the caller can inspect it. The OTLP POST promise (otlp/both mode) is awaited
+// here so a bare sampleHost() never resolves with a request still in flight; in
+// the --once importer path the emit seam is makeBuilderEmit instead (which routes
+// the POST into runOnce's drain), so this default is the bare-call safety net.
+async function defaultEmit(name, spec, opts) {
   const envelope = buildAgentEnvelope(name, spec, opts);
   try {
-    emitEnvelope(envelope, readAgentConfig());
+    await emitEnvelope(envelope, readAgentConfig());
   } catch (err) {
     log.warn({ err: err?.message }, "host: emit failed");
   }

--- a/plugins/dev/scripts/catalyst-agent/host.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/host.test.mjs
@@ -1,0 +1,300 @@
+// host.test.mjs — CTL-812 Domain 2. The host.metrics sampler.
+//
+// sampleHost is exercised purely through injected seams (readCpu / readMem /
+// readDisk / readLoad / emit) so there is no real /proc, df, vm_stat, or sleep.
+// Covers: exact contract attrs, partial-probe failure still emits, pct bounds
+// clamped 0..100, rounding (pct 1dp, mb int, gb 1dp, load1 2dp), the put()
+// pattern (null probe → attr omitted), and the pure parse helpers against real
+// `df -k /` and `vm_stat` output captured on macOS.
+//
+// Run: cd plugins/dev/scripts/catalyst-agent && bun test host.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { hostname } from "node:os";
+import {
+  sampleHost,
+  HOST_EVENT_SAMPLED,
+  parseDfRoot,
+  parseVmStat,
+  memUsedBytesFromVmStat,
+  cpuTimesTotals,
+  cpuBusyPctFromDeltas,
+} from "./host.mjs";
+
+// captureEmit — an injected emit that records (name, spec, opts) and returns a
+// minimal envelope-like object so sampleHost's return value is still inspectable.
+function captureEmit() {
+  const calls = [];
+  const emit = (name, spec, opts) => {
+    calls.push({ name, spec, opts });
+    return { name, attributes: { "event.name": name, ...spec.attrs } };
+  };
+  return { calls, emit };
+}
+
+// A full set of healthy probe seams (round-number values so rounding is obvious).
+function healthyProbes(overrides = {}) {
+  return {
+    readCpu: () => ({ cpuPct: 12.34, cpuCount: 10 }),
+    readMem: () => ({ usedMb: 8192.6, totalMb: 16384 }),
+    readDisk: () => ({ usedGb: 120.45, totalGb: 500 }),
+    readLoad: () => 2.345,
+    ...overrides,
+  };
+}
+
+describe("sampleHost — emits one host.metrics.sampled per contract", () => {
+  test("emits exactly one event with entity=host and label=hostname", async () => {
+    const { calls, emit } = captureEmit();
+    await sampleHost({ ...healthyProbes(), emit });
+    expect(calls.length).toBe(1);
+    expect(calls[0].name).toBe(HOST_EVENT_SAMPLED);
+    expect(calls[0].spec.entity).toBe("host");
+    expect(calls[0].spec.label).toBe(hostname());
+  });
+
+  test("a custom label overrides the hostname default", async () => {
+    const { calls, emit } = captureEmit();
+    await sampleHost({ ...healthyProbes(), emit, label: "fixture-host" });
+    expect(calls[0].spec.label).toBe("fixture-host");
+  });
+
+  test("now is threaded through to emit", async () => {
+    const { calls, emit } = captureEmit();
+    const now = () => "2026-06-07T00:00:00Z";
+    await sampleHost({ ...healthyProbes(), emit, now });
+    expect(calls[0].opts.now).toBe(now);
+  });
+
+  test("carries every contract attr with correct rounding", async () => {
+    const { calls, emit } = captureEmit();
+    await sampleHost({ ...healthyProbes(), emit });
+    const a = calls[0].spec.attrs;
+    expect(a["host.cpu_pct"]).toBe(12.3); // 1 decimal
+    expect(a["host.cpu_count"]).toBe(10); // int
+    expect(a["host.load1"]).toBe(2.35); // 2 decimals
+    expect(a["host.mem_used_mb"]).toBe(8193); // int (8192.6 → 8193)
+    expect(a["host.mem_total_mb"]).toBe(16384); // int
+    expect(a["host.mem_used_pct"]).toBe(50.0); // 8192.6/16384*100 → 50.0
+    expect(a["host.disk_used_gb"]).toBe(120.5); // 1 decimal (120.45 → 120.5)
+    expect(a["host.disk_total_gb"]).toBe(500.0); // 1 decimal
+    expect(a["host.disk_used_pct"]).toBe(24.1); // 120.45/500*100 = 24.09 → 24.1
+  });
+});
+
+describe("sampleHost — partial-probe failure still emits", () => {
+  test("a throwing probe omits its attrs; the event still emits with the rest", async () => {
+    const { calls, emit } = captureEmit();
+    await sampleHost({
+      ...healthyProbes({
+        readDisk: () => {
+          throw new Error("df not found");
+        },
+      }),
+      emit,
+    });
+    expect(calls.length).toBe(1);
+    const a = calls[0].spec.attrs;
+    // disk probe threw → all three disk attrs are null (dropped downstream).
+    expect(a["host.disk_used_gb"]).toBe(null);
+    expect(a["host.disk_total_gb"]).toBe(null);
+    expect(a["host.disk_used_pct"]).toBe(null);
+    // the others are unaffected.
+    expect(a["host.cpu_pct"]).toBe(12.3);
+    expect(a["host.mem_used_mb"]).toBe(8193);
+  });
+
+  test("a null-returning probe omits only its attrs", async () => {
+    const { calls, emit } = captureEmit();
+    await sampleHost({
+      ...healthyProbes({ readCpu: () => ({ cpuPct: null, cpuCount: null }) }),
+      emit,
+    });
+    const a = calls[0].spec.attrs;
+    expect(a["host.cpu_pct"]).toBe(null);
+    expect(a["host.cpu_count"]).toBe(null);
+    expect(a["host.load1"]).toBe(2.35); // still present
+  });
+
+  test("a rejected async probe is swallowed and the event still emits", async () => {
+    const { calls, emit } = captureEmit();
+    await sampleHost({
+      ...healthyProbes({ readMem: async () => Promise.reject(new Error("boom")) }),
+      emit,
+    });
+    expect(calls.length).toBe(1);
+    const a = calls[0].spec.attrs;
+    expect(a["host.mem_used_mb"]).toBe(null);
+    expect(a["host.mem_total_mb"]).toBe(null);
+    expect(a["host.mem_used_pct"]).toBe(null);
+  });
+
+  test("an async probe value is awaited (not emitted as a Promise)", async () => {
+    const { calls, emit } = captureEmit();
+    await sampleHost({
+      ...healthyProbes({ readCpu: async () => ({ cpuPct: 50, cpuCount: 8 }) }),
+      emit,
+    });
+    expect(calls[0].spec.attrs["host.cpu_pct"]).toBe(50);
+    expect(calls[0].spec.attrs["host.cpu_count"]).toBe(8);
+  });
+
+  test("all probes failing still emits an event (all value attrs null)", async () => {
+    const { calls, emit } = captureEmit();
+    const boom = () => {
+      throw new Error("nope");
+    };
+    await sampleHost({ readCpu: boom, readMem: boom, readDisk: boom, readLoad: boom, emit });
+    expect(calls.length).toBe(1);
+    const a = calls[0].spec.attrs;
+    for (const k of Object.keys(a)) expect(a[k]).toBe(null);
+  });
+});
+
+describe("sampleHost — pct bounds clamped to 0..100", () => {
+  test("cpu_pct above 100 is clamped to 100", async () => {
+    const { calls, emit } = captureEmit();
+    await sampleHost({ ...healthyProbes({ readCpu: () => ({ cpuPct: 150, cpuCount: 4 }) }), emit });
+    expect(calls[0].spec.attrs["host.cpu_pct"]).toBe(100);
+  });
+
+  test("cpu_pct below 0 is clamped to 0", async () => {
+    const { calls, emit } = captureEmit();
+    await sampleHost({ ...healthyProbes({ readCpu: () => ({ cpuPct: -5, cpuCount: 4 }) }), emit });
+    expect(calls[0].spec.attrs["host.cpu_pct"]).toBe(0);
+  });
+
+  test("derived mem_used_pct over 100 (used > total) is clamped to 100", async () => {
+    const { calls, emit } = captureEmit();
+    await sampleHost({
+      ...healthyProbes({ readMem: () => ({ usedMb: 20000, totalMb: 16384 }) }),
+      emit,
+    });
+    expect(calls[0].spec.attrs["host.mem_used_pct"]).toBe(100);
+  });
+
+  test("a zero/absent denominator yields a null pct (no div-by-zero / NaN)", async () => {
+    const { calls, emit } = captureEmit();
+    await sampleHost({
+      ...healthyProbes({
+        readMem: () => ({ usedMb: 100, totalMb: 0 }),
+        readDisk: () => ({ usedGb: 5, totalGb: null }),
+      }),
+      emit,
+    });
+    expect(calls[0].spec.attrs["host.mem_used_pct"]).toBe(null);
+    expect(calls[0].spec.attrs["host.disk_used_pct"]).toBe(null);
+  });
+});
+
+describe("parseDfRoot — real `df -k /` fixtures", () => {
+  // Captured on macOS (note the inode columns iused/ifree/%iused after Capacity).
+  const MACOS = `Filesystem     1024-blocks      Used Available Capacity iused      ifree %iused  Mounted on
+/dev/disk3s1s1   971350180  16324544 186926344     9%  458116 1869263440    0%   /`;
+
+  // Linux `df -k /` shape (no inode columns).
+  const LINUX = `Filesystem     1K-blocks     Used Available Use% Mounted on
+/dev/nvme0n1p2 102400000 51200000  46137344  53% /`;
+
+  test("parses the macOS row by leading column position (total, used)", () => {
+    expect(parseDfRoot(MACOS)).toEqual({ totalKb: 971350180, usedKb: 16324544 });
+  });
+
+  test("parses the Linux row identically (same leading positions)", () => {
+    expect(parseDfRoot(LINUX)).toEqual({ totalKb: 102400000, usedKb: 51200000 });
+  });
+
+  test("returns null for empty / header-only / unparseable input", () => {
+    expect(parseDfRoot("")).toBe(null);
+    expect(parseDfRoot("Filesystem 1024-blocks Used Available Capacity Mounted on")).toBe(null);
+    expect(parseDfRoot("garbage line with no numbers here\nstill garbage")).toBe(null);
+  });
+
+  test("the parsed macOS fixture converts to the expected GB (1 decimal)", async () => {
+    const { calls, emit } = captureEmit();
+    // Wire the real macOS df through the default disk path's parser via a custom
+    // readDisk that mirrors defaultReadDisk's KB→GB math (1024*1024 KB per GB).
+    const parsed = parseDfRoot(MACOS);
+    const KB_PER_GB = 1024 * 1024;
+    await sampleHost({
+      ...healthyProbes({
+        readDisk: () => ({ usedGb: parsed.usedKb / KB_PER_GB, totalGb: parsed.totalKb / KB_PER_GB }),
+      }),
+      emit,
+    });
+    const a = calls[0].spec.attrs;
+    expect(a["host.disk_total_gb"]).toBe(926.4); // 971350180/1048576 = 926.36 → 926.4
+    expect(a["host.disk_used_gb"]).toBe(15.6); // 16324544/1048576 = 15.57 → 15.6
+    expect(a["host.disk_used_pct"]).toBe(1.7); // 16324544/971350180*100 = 1.68 → 1.7
+  });
+});
+
+describe("parseVmStat / memUsedBytesFromVmStat — real macOS vm_stat fixture", () => {
+  // Captured on macOS (page size 16384). Trimmed to the buckets we use plus a
+  // couple of others to prove the line parser is tolerant of extra rows.
+  const VM_STAT = `Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                              112322.
+Pages active:                           1116505.
+Pages inactive:                         1108757.
+Pages speculative:                         6674.
+Pages wired down:                        453208.
+Pages purgeable:                          20353.
+Pages occupied by compressor:           1339877.
+File-backed pages:                       739653.`;
+
+  test("parseVmStat extracts the page size and the named page counts", () => {
+    const parsed = parseVmStat(VM_STAT);
+    expect(parsed.pageSize).toBe(16384);
+    expect(parsed.pages["pages active"]).toBe(1116505);
+    expect(parsed.pages["pages wired down"]).toBe(453208);
+    expect(parsed.pages["pages occupied by compressor"]).toBe(1339877);
+  });
+
+  test("memUsedBytesFromVmStat = (active + wired + compressed) * pageSize", () => {
+    const parsed = parseVmStat(VM_STAT);
+    const expected = (1116505 + 453208 + 1339877) * 16384;
+    expect(memUsedBytesFromVmStat(parsed)).toBe(expected);
+  });
+
+  test("parseVmStat returns null when the page size header is absent", () => {
+    expect(parseVmStat("Pages active: 100.")).toBe(null);
+    expect(parseVmStat("")).toBe(null);
+  });
+
+  test("memUsedBytesFromVmStat returns null when a required bucket is missing", () => {
+    const parsed = parseVmStat(`Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages active:                           1000.`); // no wired / compressor
+    expect(memUsedBytesFromVmStat(parsed)).toBe(null);
+    expect(memUsedBytesFromVmStat(null)).toBe(null);
+  });
+});
+
+describe("cpu two-sample delta helpers (pure)", () => {
+  const snap = (idle, user, sys) => [{ times: { idle, user, sys, nice: 0, irq: 0 } }];
+
+  test("cpuTimesTotals sums idle and total across cores", () => {
+    const totals = cpuTimesTotals([
+      { times: { idle: 10, user: 5, sys: 3, nice: 1, irq: 1 } },
+      { times: { idle: 20, user: 4, sys: 2, nice: 0, irq: 0 } },
+    ]);
+    expect(totals.idle).toBe(30);
+    expect(totals.total).toBe(10 + 5 + 3 + 1 + 1 + 20 + 4 + 2);
+  });
+
+  test("cpuBusyPctFromDeltas: 50% busy when half the delta-ticks are non-idle", () => {
+    const a = cpuTimesTotals(snap(100, 0, 0)); // idle 100, total 100
+    const b = cpuTimesTotals(snap(150, 25, 25)); // idle 150, total 200 → Δidle 50, Δtotal 100
+    expect(cpuBusyPctFromDeltas(a, b)).toBe(50);
+  });
+
+  test("cpuBusyPctFromDeltas returns null when no time elapsed (Δtotal <= 0)", () => {
+    const a = cpuTimesTotals(snap(100, 0, 0));
+    expect(cpuBusyPctFromDeltas(a, a)).toBe(null);
+  });
+
+  test("cpuBusyPctFromDeltas clamps a fully-busy window to 100", () => {
+    const a = cpuTimesTotals(snap(100, 0, 0));
+    const b = cpuTimesTotals(snap(100, 50, 50)); // Δidle 0, Δtotal 100 → 100%
+    expect(cpuBusyPctFromDeltas(a, b)).toBe(100);
+  });
+});

--- a/plugins/dev/scripts/catalyst-agent/install.sh
+++ b/plugins/dev/scripts/catalyst-agent/install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# install.sh — CTL-812. Idempotently install the catalyst-agent launchd
+# LaunchAgent on macOS: substitute the template tokens, copy the plist into
+# ~/Library/LaunchAgents/, then (re)load it via launchctl.
+#
+# Re-running is safe: an already-loaded agent is booted out before being
+# re-bootstrapped, so the latest plist always wins.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE="${SCRIPT_DIR}/com.catalyst.agent.plist"
+AGENT="${SCRIPT_DIR}/catalyst-agent.mjs"
+LABEL="com.catalyst.agent"
+DEST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+
+NODE_BIN="$(command -v node || true)"
+if [ -z "${NODE_BIN}" ]; then
+  echo "install.sh: node not found on PATH — install node>=18 first" >&2
+  exit 1
+fi
+if [ ! -f "${TEMPLATE}" ]; then
+  echo "install.sh: plist template not found at ${TEMPLATE}" >&2
+  exit 1
+fi
+
+mkdir -p "${HOME}/Library/LaunchAgents" "${HOME}/catalyst"
+
+# Substitute the template tokens into the destination plist. Using a temp file
+# then mv keeps the install atomic.
+TMP="$(mktemp)"
+sed \
+  -e "s|REPLACE_WITH_NODE|${NODE_BIN}|g" \
+  -e "s|REPLACE_WITH_AGENT|${AGENT}|g" \
+  -e "s|REPLACE_WITH_HOME|${HOME}|g" \
+  "${TEMPLATE}" > "${TMP}"
+mv "${TMP}" "${DEST}"
+echo "install.sh: wrote ${DEST}"
+
+# Reload idempotently: bootout any existing instance (ignore failure when not
+# loaded), then bootstrap the fresh plist.
+DOMAIN="gui/$(id -u)"
+launchctl bootout "${DOMAIN}/${LABEL}" 2>/dev/null || true
+launchctl bootstrap "${DOMAIN}" "${DEST}"
+echo "install.sh: loaded ${LABEL} into ${DOMAIN}"
+echo "install.sh: verify with 'launchctl list | grep ${LABEL}'"

--- a/plugins/dev/scripts/catalyst-agent/processes.mjs
+++ b/plugins/dev/scripts/catalyst-agent/processes.mjs
@@ -11,9 +11,18 @@
 // execution-core/cli/sessions.mjs's parsePsSnapshot + signal-reader.mjs's
 // defensive JSON read) so this file has no cross-package coupling.
 //
+// PS PARSING IS CROSS-PLATFORM (CTL-812 review). The `comm` column is rendered
+// differently per OS: macOS clamps it to a fixed 16-char, space-padded width (and
+// truncates deep paths, e.g. /usr/libexec/logd → /usr/libexec/log); Linux renders
+// comm at its natural width with a single space before args. splitCommArgs handles
+// both (keyed on process.platform, injectable), and deriveCommand heals a
+// macOS-truncated comm from the full argv[0] carried in the args column while
+// still deferring to comm when argv[0] was rewritten (a login shell's `-zsh`).
+//
 // CONTRACT (host.process.sampled, entity=host, ONE event per top-N process):
 //   attributes (dot-form, low-cardinality):
-//     process.command  basename(comm) lowercased
+//     process.command  basename of the executable, lowercased (healed from argv[0]
+//                      when comm was truncated; see deriveCommand)
 //     process.cpu_pct  pcpu (percent-of-one-core; may exceed 100)
 //     process.rss_mb   resident set size in MB (ps reports KB)
 //     process.ticket?  only when the process (or an ancestor) maps to a worker
@@ -29,7 +38,7 @@ import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
 import { join, basename } from "node:path";
 import { homedir, hostname } from "node:os";
-import { buildAgentEnvelope, emitEnvelope } from "./emit.mjs";
+import { buildAgentEnvelope, emitEnvelope, drainPending } from "./emit.mjs";
 import { readAgentConfig, log } from "./config.mjs";
 
 export const PROCESS_EVENT_SAMPLED = "host.process.sampled";
@@ -47,22 +56,87 @@ const COMM_COLUMN_WIDTH = 16;
 const LEADING_FIELDS = /^\s*(\d+)\s+(\d+)\s+([\d.]+)\s+(\d+)\s+(.*)$/;
 
 /**
+ * splitCommArgs — split the variable tail (everything after the 4 numeric ps
+ * fields) into { comm, args }. Cross-platform (CTL-812 review): the fixed 16-char
+ * comm column is a macOS-only rendering; Linux `ps -o comm=,args=` renders comm at
+ * its NATURAL width with a single space before args.
+ *
+ *   darwin → comm occupies a fixed COMM_COLUMN_WIDTH (16) space-padded column,
+ *            then args runs to EOL. A line shorter than the column (a comm-only
+ *            line, no args spec matched) is all comm. Slicing at 16 is correct.
+ *   other  → comm is the FIRST whitespace-delimited token (its natural width);
+ *            args is the remainder after the single separating space. comm has no
+ *            embedded spaces (it is one executable path token), so this is exact.
+ *
+ * `platform` is injectable so both renderings are unit-testable on one host.
+ * Pure; never throws.
+ *
+ * @param {string} tail
+ * @param {string} [platform]  defaults to process.platform
+ * @returns {{comm: string, args: string}}
+ */
+export function splitCommArgs(tail, platform = process.platform) {
+  if (platform === "darwin") {
+    // Fixed-width comm column (space-padded to 16) then args to EOL.
+    const comm = tail.slice(0, COMM_COLUMN_WIDTH).trim();
+    const args = tail.slice(COMM_COLUMN_WIDTH).trim();
+    return { comm, args };
+  }
+  // Linux / other: comm is the first token (natural width); args is the rest.
+  const idx = tail.indexOf(" ");
+  if (idx === -1) return { comm: tail.trim(), args: "" };
+  return { comm: tail.slice(0, idx).trim(), args: tail.slice(idx + 1).trim() };
+}
+
+/**
+ * deriveCommand — pick the low-cardinality command name (basename, lowercased)
+ * from comm + the full args column. CTL-812 review:
+ *   - macOS truncates the comm column to 16 chars, so a deep path is cut BEFORE
+ *     basename is taken (`/usr/libexec/logd` → `/usr/libexec/log` → `log`, losing
+ *     the trailing 'd'; `/System/Library/PrivateFrameworks/…` → `/System/Library/`
+ *     → `library`). The args column carries the FULL, untruncated argv[0] path, so
+ *     when comm is a prefix of argv[0] we know comm was truncated and basename of
+ *     argv[0] is the correct, complete command name.
+ *   - BUT argv[0] is sometimes rewritten and is NOT the executable path: a login
+ *     shell's argv[0] is `-zsh` while comm is `/bin/zsh`. There comm is the
+ *     authority and basename(comm) → `zsh` is right. The "comm is a prefix of
+ *     argv[0]" guard rejects the rewritten case (`/bin/zsh` is not a prefix of
+ *     `-zsh`), so comm wins exactly when it should.
+ *
+ * Pure; returns null only when nothing usable is present.
+ *
+ * @param {string} comm   the (possibly truncated) comm value
+ * @param {string} args   the full command line (argv[0] … is its head)
+ * @returns {string|null}
+ */
+export function deriveCommand(comm, args) {
+  const argv0 = (args || "").split(/\s+/)[0] || "";
+  // comm truncated (macOS deep path): argv0 is the full path that comm prefixes.
+  if (comm && argv0 && argv0.startsWith(comm) && argv0.length > comm.length) {
+    return basename(argv0).toLowerCase() || null;
+  }
+  // Otherwise comm is authoritative (covers the rewritten-argv0 login-shell case).
+  return basename(comm).toLowerCase() || null;
+}
+
+/**
  * parsePsLines — parse `ps -axo pid=,ppid=,pcpu=,rss=,comm=,args=` output into
  * row objects. Pure; never throws on a malformed line (it is skipped).
  *
- * The tail after the 4 numeric fields is `comm`(fixed-width, space-padded) + a
- * separator + `args`(full, may contain spaces). `command` is `basename(comm)`
- * lowercased per the telemetry contract: comm is the executable path, so its
- * basename is the low-cardinality command name (e.g. `node`, `claude`, `zsh`)
- * — and it is the right source even when argv[0] is rewritten (a login shell's
- * argv[0] is `-zsh`, whose basename is the misleading `-zsh`; comm stays
- * `/bin/zsh`). `args` is the full command line, kept for the body.payload only.
- * When there is no args column (a comm-only line) the whole tail is comm.
+ * The tail after the 4 numeric fields is `comm` + a separator + `args` (full, may
+ * contain spaces); see splitCommArgs for the per-platform column layout. The
+ * `command` is the basename (lowercased) of the executable, derived by
+ * deriveCommand so a macOS-truncated comm is healed from the full argv[0] in args
+ * while a rewritten argv[0] (`-zsh`) still defers to comm. `args` is the full
+ * command line, kept for body.payload only. A comm-only line (no args) keeps the
+ * whole tail as comm.
  *
- * @param {string[]} lines  raw ps lines (a trailing blank line is fine)
+ * @param {string[]} lines      raw ps lines (a trailing blank line is fine)
+ * @param {object}  [opts]
+ * @param {string}  [opts.platform]  comm-column rendering; defaults to process.platform
  * @returns {{pid:number, ppid:number, cpu_pct:number, rss_kb:number, command:string, args:string}[]}
  */
-export function parsePsLines(lines = []) {
+export function parsePsLines(lines = [], { platform = process.platform } = {}) {
   const rows = [];
   for (const raw of lines) {
     if (typeof raw !== "string") continue;
@@ -78,14 +152,11 @@ export function parsePsLines(lines = []) {
     if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
 
     const tail = m[5];
-    // comm occupies the first COMM_COLUMN_WIDTH chars (space-padded); args is
-    // the remainder. When the line is shorter than the column (no args column at
-    // all, e.g. a comm-only line) the whole tail is comm and args is "".
-    const comm = tail.slice(0, COMM_COLUMN_WIDTH).trim();
-    const args = tail.slice(COMM_COLUMN_WIDTH).trim();
+    const { comm, args } = splitCommArgs(tail, platform);
 
-    // basename(comm) lowercased — the contract's low-cardinality command name.
-    const command = basename(comm).toLowerCase() || null;
+    // The contract's low-cardinality command name (basename, lowercased),
+    // healed from argv[0] when comm was truncated (see deriveCommand).
+    const command = deriveCommand(comm, args);
 
     rows.push({
       pid,
@@ -147,26 +218,35 @@ export function attributeRow(row, byPid, workerMap) {
  * attribute each to a worker, and emit one host.process.sampled per ranked row.
  * Returns the array of envelopes emitted (handy for tests / callers).
  *
+ * ASYNC so the OTLP transport can be drained before resolving: the default emit
+ * returns the pending OTLP POST promise per envelope, and sampleProcesses awaits
+ * all of them before returning. Without this drain the `--once` / launchd path
+ * would exit while POSTs are still in flight, dropping telemetry every tick
+ * (CTL-812 review). The eventlog transport is synchronous (appendFileSync), so
+ * eventlog-mode ticks resolve with nothing to await.
+ *
  * All seams injected; defaults run the real ps / filesystem / emit.
  *
  * @param {object} [opts]
  * @param {Function} [opts.psLines=defaultPsLines]            () => string[]
  * @param {Function} [opts.readWorkerMap=defaultReadWorkerMap] () => Map<pid,{ticket,phase,bg_job_id}>
  * @param {number}   [opts.topN]                              default from config (10)
- * @param {Function} [opts.emit=defaultEmit]                  (envelope) => void
+ * @param {Function} [opts.emit=defaultEmit]                  (envelope) => Promise|void; a returned promise is drained
  * @param {Function} [opts.now]                               injectable ISO-timestamp fn
- * @returns {object[]} the emitted envelopes
+ * @param {string}   [opts.platform]                          ps comm-column rendering (defaults to process.platform)
+ * @returns {Promise<object[]>} the emitted envelopes (after the OTLP drain)
  */
-export function sampleProcesses({
+export async function sampleProcesses({
   psLines = defaultPsLines,
   readWorkerMap = defaultReadWorkerMap,
   topN = readAgentConfig().topN,
   emit = defaultEmit,
   now,
+  platform = process.platform,
 } = {}) {
   let rows;
   try {
-    rows = parsePsLines(psLines());
+    rows = parsePsLines(psLines(), { platform });
   } catch (err) {
     log.warn({ err: err?.message }, "processes: ps snapshot failed");
     return [];
@@ -185,6 +265,9 @@ export function sampleProcesses({
   const host = hostname();
   const top = rankTopN(rows, topN);
   const envelopes = [];
+  // OTLP POST promises returned by emit, drained before we resolve so the
+  // --once path never exits with a request still in flight (CTL-812 review).
+  const pending = [];
 
   for (const row of top) {
     const worker = attributeRow(row, byPid, workerMap);
@@ -214,12 +297,17 @@ export function sampleProcesses({
     );
     envelopes.push(envelope);
     try {
-      emit(envelope);
+      // emit may return a pending OTLP POST promise (otlp/both mode); collect it
+      // so it is drained below rather than abandoned on process.exit().
+      const posted = emit(envelope);
+      if (posted && typeof posted.then === "function") pending.push(posted);
     } catch (err) {
       log.warn({ err: err?.message }, "processes: emit failed");
     }
   }
 
+  // Drain any in-flight OTLP POSTs before resolving (no-op in eventlog mode).
+  await drainPending(pending);
   return envelopes;
 }
 
@@ -301,7 +389,9 @@ export function defaultReadWorkerMap(root = join(catalystDir(), "execution-core"
 }
 
 // defaultEmit — route one envelope through the configured transport(s) via the
-// shared emitEnvelope() helper (eventlog / otlp / both). Best-effort; never throws.
+// shared emitEnvelope() helper (eventlog / otlp / both). Returns the pending OTLP
+// POST promise (or null) so sampleProcesses can drain it before resolving in the
+// --once path. Best-effort; never throws.
 function defaultEmit(envelope) {
-  emitEnvelope(envelope, readAgentConfig());
+  return emitEnvelope(envelope, readAgentConfig());
 }

--- a/plugins/dev/scripts/catalyst-agent/processes.mjs
+++ b/plugins/dev/scripts/catalyst-agent/processes.mjs
@@ -1,0 +1,307 @@
+// processes.mjs — catalyst-agent Domain 3: process attribution (CTL-812).
+//
+// Once per tick, snapshot every process (`ps -axo pid=,ppid=,pcpu=,rss=,comm=,
+// args=`), rank the top-N by RSS, attribute each to a Catalyst worker (ticket /
+// phase) by joining against the execution-core worker-signal files, and emit one
+// host.process.sampled envelope per ranked process per the telemetry contract.
+//
+// SELF-CONTAINED: zero npm deps, node:* builtins only; runs under both node>=18
+// and bun. The standalone agent does NOT import from execution-core — the
+// ps-parse, worker-map scan, and ancestry walk are re-implemented here (mirroring
+// execution-core/cli/sessions.mjs's parsePsSnapshot + signal-reader.mjs's
+// defensive JSON read) so this file has no cross-package coupling.
+//
+// CONTRACT (host.process.sampled, entity=host, ONE event per top-N process):
+//   attributes (dot-form, low-cardinality):
+//     process.command  basename(comm) lowercased
+//     process.cpu_pct  pcpu (percent-of-one-core; may exceed 100)
+//     process.rss_mb   resident set size in MB (ps reports KB)
+//     process.ticket?  only when the process (or an ancestor) maps to a worker
+//     process.phase?   ditto
+//   body.payload (high-cardinality — kept OUT of attributes to protect label
+//   cardinality): pid, ppid, args (full command line), bg_job_id.
+//   event.label = hostname.
+//
+// All I/O is injected (psLines, readWorkerMap, emit, now) so sampleProcesses is
+// fully unit-testable with no real ps, no real filesystem, no real clock.
+
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, basename } from "node:path";
+import { homedir, hostname } from "node:os";
+import { buildAgentEnvelope, emitEnvelope } from "./emit.mjs";
+import { readAgentConfig, log } from "./config.mjs";
+
+export const PROCESS_EVENT_SAMPLED = "host.process.sampled";
+
+// macOS `ps` renders the intermediate `comm` column at a FIXED width, space-
+// padded, when a later column (`args`) follows it. 16 is that documented width
+// (`/System/Library/` etc. clamp to exactly 16 chars). The trailing `args`
+// column is the full, untruncated command line and runs to end-of-line — which
+// is why `args=` MUST be last in the ps spec: it is the only field allowed to
+// contain spaces past the fixed columns.
+const COMM_COLUMN_WIDTH = 16;
+
+// The 4 leading numeric fields (pid ppid pcpu rss) are whitespace-free, so a
+// single regex peels them off; group 5 is the variable tail (comm + args).
+const LEADING_FIELDS = /^\s*(\d+)\s+(\d+)\s+([\d.]+)\s+(\d+)\s+(.*)$/;
+
+/**
+ * parsePsLines — parse `ps -axo pid=,ppid=,pcpu=,rss=,comm=,args=` output into
+ * row objects. Pure; never throws on a malformed line (it is skipped).
+ *
+ * The tail after the 4 numeric fields is `comm`(fixed-width, space-padded) + a
+ * separator + `args`(full, may contain spaces). `command` is `basename(comm)`
+ * lowercased per the telemetry contract: comm is the executable path, so its
+ * basename is the low-cardinality command name (e.g. `node`, `claude`, `zsh`)
+ * — and it is the right source even when argv[0] is rewritten (a login shell's
+ * argv[0] is `-zsh`, whose basename is the misleading `-zsh`; comm stays
+ * `/bin/zsh`). `args` is the full command line, kept for the body.payload only.
+ * When there is no args column (a comm-only line) the whole tail is comm.
+ *
+ * @param {string[]} lines  raw ps lines (a trailing blank line is fine)
+ * @returns {{pid:number, ppid:number, cpu_pct:number, rss_kb:number, command:string, args:string}[]}
+ */
+export function parsePsLines(lines = []) {
+  const rows = [];
+  for (const raw of lines) {
+    if (typeof raw !== "string") continue;
+    const line = raw.replace(/\s+$/, ""); // rstrip only — leading pad is significant for the fields regex
+    if (!line.trim()) continue;
+    const m = LEADING_FIELDS.exec(line);
+    if (!m) continue;
+
+    const pid = Number(m[1]);
+    const ppid = Number(m[2]);
+    const cpu_pct = Number(m[3]);
+    const rss_kb = Number(m[4]);
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
+
+    const tail = m[5];
+    // comm occupies the first COMM_COLUMN_WIDTH chars (space-padded); args is
+    // the remainder. When the line is shorter than the column (no args column at
+    // all, e.g. a comm-only line) the whole tail is comm and args is "".
+    const comm = tail.slice(0, COMM_COLUMN_WIDTH).trim();
+    const args = tail.slice(COMM_COLUMN_WIDTH).trim();
+
+    // basename(comm) lowercased — the contract's low-cardinality command name.
+    const command = basename(comm).toLowerCase() || null;
+
+    rows.push({
+      pid,
+      ppid,
+      cpu_pct: Number.isFinite(cpu_pct) ? cpu_pct : null,
+      rss_kb: Number.isFinite(rss_kb) ? rss_kb : null,
+      command,
+      args: args || comm, // payload-only; keep the fullest command line we have
+    });
+  }
+  return rows;
+}
+
+/**
+ * rankTopN — return the N rows with the largest RSS, descending. Ties broken by
+ * CPU descending (a busy process is the more interesting one to surface). Pure.
+ *
+ * @param {object[]} rows  parsed ps rows
+ * @param {number} topN    how many to keep (already floored to >= 1 by config)
+ */
+export function rankTopN(rows, topN) {
+  const n = Math.max(1, Math.floor(Number(topN) || 1));
+  return [...rows]
+    .sort((a, b) => {
+      const rssDelta = (b.rss_kb ?? 0) - (a.rss_kb ?? 0);
+      if (rssDelta !== 0) return rssDelta;
+      return (b.cpu_pct ?? 0) - (a.cpu_pct ?? 0);
+    })
+    .slice(0, n);
+}
+
+/**
+ * attributeRow — resolve a row's owning worker by walking the ppid chain: the
+ * row itself, then its parent, grandparent, … up to MAX_CHAIN hops. A `claude
+ * --bg` worker spawns node / claude / MCP children whose PIDs are NOT in the
+ * worker map; walking ancestors lets those descendants inherit the worker's
+ * ticket/phase. Returns the matched worker entry ({ticket, phase, bg_job_id})
+ * or null. Pure given `byPid` (pid→row) and `workerMap` (pid→entry).
+ */
+const MAX_CHAIN = 20;
+export function attributeRow(row, byPid, workerMap) {
+  let pid = row?.pid;
+  const seen = new Set();
+  for (let hops = 0; hops < MAX_CHAIN; hops++) {
+    if (pid == null || seen.has(pid)) break; // null parent or a cycle → stop
+    seen.add(pid);
+    const hit = workerMap.get(pid);
+    if (hit) return hit;
+    const parent = byPid.get(pid);
+    if (!parent) break;
+    pid = parent.ppid;
+    if (pid === 0) break; // reached init/launchd — no worker above here
+  }
+  return null;
+}
+
+/**
+ * sampleProcesses — Domain 3 tick. Snapshot processes, rank top-N by RSS,
+ * attribute each to a worker, and emit one host.process.sampled per ranked row.
+ * Returns the array of envelopes emitted (handy for tests / callers).
+ *
+ * All seams injected; defaults run the real ps / filesystem / emit.
+ *
+ * @param {object} [opts]
+ * @param {Function} [opts.psLines=defaultPsLines]            () => string[]
+ * @param {Function} [opts.readWorkerMap=defaultReadWorkerMap] () => Map<pid,{ticket,phase,bg_job_id}>
+ * @param {number}   [opts.topN]                              default from config (10)
+ * @param {Function} [opts.emit=defaultEmit]                  (envelope) => void
+ * @param {Function} [opts.now]                               injectable ISO-timestamp fn
+ * @returns {object[]} the emitted envelopes
+ */
+export function sampleProcesses({
+  psLines = defaultPsLines,
+  readWorkerMap = defaultReadWorkerMap,
+  topN = readAgentConfig().topN,
+  emit = defaultEmit,
+  now,
+} = {}) {
+  let rows;
+  try {
+    rows = parsePsLines(psLines());
+  } catch (err) {
+    log.warn({ err: err?.message }, "processes: ps snapshot failed");
+    return [];
+  }
+
+  // pid→row index for the ancestry walk, and the (defensive, never-throw) worker map.
+  const byPid = new Map(rows.map((r) => [r.pid, r]));
+  let workerMap;
+  try {
+    workerMap = readWorkerMap() ?? new Map();
+  } catch (err) {
+    log.warn({ err: err?.message }, "processes: worker map read failed");
+    workerMap = new Map();
+  }
+
+  const host = hostname();
+  const top = rankTopN(rows, topN);
+  const envelopes = [];
+
+  for (const row of top) {
+    const worker = attributeRow(row, byPid, workerMap);
+    const envelope = buildAgentEnvelope(
+      PROCESS_EVENT_SAMPLED,
+      {
+        entity: "host",
+        label: host,
+        // Dot-form value attributes; ticket/phase included ONLY when matched
+        // (the put() pattern in buildAgentEnvelope drops null/undefined).
+        attrs: {
+          "process.command": row.command,
+          "process.cpu_pct": row.cpu_pct,
+          "process.rss_mb": row.rss_kb == null ? null : Math.round(row.rss_kb / 1024),
+          "process.ticket": worker?.ticket ?? null,
+          "process.phase": worker?.phase ?? null,
+        },
+        // High-cardinality fields stay in the payload, never as labels.
+        payload: {
+          pid: row.pid,
+          ppid: row.ppid,
+          args: row.args,
+          bg_job_id: worker?.bg_job_id ?? null,
+        },
+      },
+      { now },
+    );
+    envelopes.push(envelope);
+    try {
+      emit(envelope);
+    } catch (err) {
+      log.warn({ err: err?.message }, "processes: emit failed");
+    }
+  }
+
+  return envelopes;
+}
+
+// --- Defaults (the real-I/O seams; replaced wholesale in tests) ---
+
+// defaultPsLines — the real process snapshot. `args=` is LAST because it is the
+// only field permitted to contain spaces (see parsePsLines). Best-effort: any
+// ps failure yields [] so the tick degrades to "no processes" instead of
+// throwing.
+function defaultPsLines() {
+  try {
+    const out = execFileSync("ps", ["-axo", "pid=,ppid=,pcpu=,rss=,comm=,args="], {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024, // generous: a busy host can have thousands of procs
+    });
+    return out.split("\n");
+  } catch (err) {
+    log.warn({ err: err?.message }, "processes: ps exec failed");
+    return [];
+  }
+}
+
+// catalystDir — own copy (the standalone agent does not import execution-core).
+// CATALYST_DIR override is honored so tests redirect the worker-map scan.
+function catalystDir() {
+  return process.env.CATALYST_DIR ?? `${homedir()}/catalyst`;
+}
+
+/**
+ * defaultReadWorkerMap — scan ${CATALYST_DIR}/execution-core/workers/<TICKET>/
+ * for JSON signal files and build a pid→{ticket, phase, bg_job_id} map. The
+ * execution-core worker signals carry pid (flat oneshot) and/or bg_job_id +
+ * phase (nested phase-agent); only signals with a numeric `pid` join here (the
+ * ps snapshot is keyed by pid). Fully defensive: a missing workers dir, an
+ * unreadable subdir, or a malformed JSON file is skipped — NEVER throws.
+ *
+ * @param {string} [root]  override the workers root (defaults under CATALYST_DIR)
+ * @returns {Map<number, {ticket:?string, phase:?string, bg_job_id:?string}>}
+ */
+export function defaultReadWorkerMap(root = join(catalystDir(), "execution-core", "workers")) {
+  const map = new Map();
+  let tickets;
+  try {
+    tickets = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return map; // no workers dir yet → empty map → everything unattributed
+  }
+
+  for (const entry of tickets) {
+    if (!entry.isDirectory()) continue;
+    const dir = join(root, entry.name);
+    let files;
+    try {
+      files = readdirSync(dir);
+    } catch {
+      continue; // unreadable subdir → skip
+    }
+    for (const name of files) {
+      if (!name.endsWith(".json")) continue;
+      let raw;
+      try {
+        raw = JSON.parse(readFileSync(join(dir, name), "utf8"));
+      } catch {
+        continue; // malformed signal → skip (defensive parse)
+      }
+      const pid = Number(raw?.pid);
+      if (!Number.isInteger(pid) || pid <= 0) continue; // only pid-bearing signals join
+      // First writer wins per pid; a later signal for the same pid does not
+      // clobber an earlier mapping (signals for one worker are consistent).
+      if (map.has(pid)) continue;
+      map.set(pid, {
+        ticket: raw.ticket ?? entry.name ?? null,
+        phase: raw.phase == null ? null : String(raw.phase),
+        bg_job_id: raw.bg_job_id ?? null,
+      });
+    }
+  }
+  return map;
+}
+
+// defaultEmit — route one envelope through the configured transport(s) via the
+// shared emitEnvelope() helper (eventlog / otlp / both). Best-effort; never throws.
+function defaultEmit(envelope) {
+  emitEnvelope(envelope, readAgentConfig());
+}

--- a/plugins/dev/scripts/catalyst-agent/processes.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/processes.test.mjs
@@ -1,0 +1,449 @@
+// processes.test.mjs — CTL-812 Domain 3 (process attribution). Exercises the
+// ps-line parser (incl. the args-with-spaces / fixed-width-comm case), top-N
+// ranking + tie-break, the worker-map join both directly and via an ancestor
+// ppid chain, the missing-workers-dir → all-unattributed path, and the emitted
+// host.process.sampled envelope shape against the telemetry contract.
+//
+// All I/O is injected: psLines / readWorkerMap / emit / now are fakes, so no
+// real ps, no real filesystem (except the defaultReadWorkerMap test, which uses
+// a temp CATALYST_DIR), and no real clock.
+//
+// Run: cd plugins/dev/scripts/catalyst-agent && bun test processes.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir, hostname } from "node:os";
+import { join } from "node:path";
+import {
+  parsePsLines,
+  rankTopN,
+  attributeRow,
+  sampleProcesses,
+  defaultReadWorkerMap,
+  PROCESS_EVENT_SAMPLED,
+} from "./processes.mjs";
+
+const FIXED_NOW = "2026-06-07T12:00:00Z";
+
+// A recording emit seam — collects the envelopes the sampler hands it.
+function recordingEmit() {
+  const envelopes = [];
+  return { emit: (e) => envelopes.push(e), envelopes };
+}
+
+// ─── ps parsing ──────────────────────────────────────────────────────────────
+
+// macOS clamps the intermediate `comm` column to exactly 16 chars, space-padded,
+// then a single separator, then the full `args` column to EOL. psRow builds a
+// line in that exact layout so fixtures match real `ps -axo …,comm=,args=`
+// output without hand-counting spaces. `comm` is padded/clamped to 16; `args` is
+// appended verbatim (and may contain spaces — the whole point of args= LAST).
+function psRow({ pid, ppid, cpu, rss, comm, args }) {
+  const commCol = comm.padEnd(16, " ").slice(0, 16);
+  const tail = args === undefined ? commCol.trimEnd() : `${commCol} ${args}`;
+  return `${pid} ${ppid} ${cpu} ${rss} ${tail}`;
+}
+
+describe("parsePsLines", () => {
+  test("parses the 4 numeric leading fields, comm column, and full args", () => {
+    const line = psRow({
+      pid: 4321,
+      ppid: 4000,
+      cpu: 12.5,
+      rss: 524288,
+      comm: "/bin/node", // short enough to survive the 16-char column clamp
+      args: "/usr/local/bin/node server.mjs --port 8080",
+    });
+    const [row] = parsePsLines([line]);
+    expect(row.pid).toBe(4321);
+    expect(row.ppid).toBe(4000);
+    expect(row.cpu_pct).toBe(12.5);
+    expect(row.rss_kb).toBe(524288);
+    // command = basename(comm) lowercased.
+    expect(row.command).toBe("node");
+    // args (payload-only) is the full command line, spaces and flags intact.
+    expect(row.args).toBe("/usr/local/bin/node server.mjs --port 8080");
+  });
+
+  test("args-with-spaces: flags and a path with a space survive verbatim", () => {
+    const line = psRow({
+      pid: 900,
+      ppid: 1,
+      cpu: 0.0,
+      rss: 10240,
+      comm: "/Applications/Foo Bar.app/Contents/MacOS/Foo",
+      args: '/Applications/Foo Bar.app/Contents/MacOS/Foo --flag "a b c"',
+    });
+    const [row] = parsePsLines([line]);
+    expect(row.pid).toBe(900);
+    // basename of the 16-char-clamped comm "/Applications/Fo" → "fo".
+    expect(row.command).toBe("fo");
+    // args is the full untruncated command line, spaces and quotes intact.
+    expect(row.args).toBe('/Applications/Foo Bar.app/Contents/MacOS/Foo --flag "a b c"');
+  });
+
+  test("lowercases the command basename", () => {
+    const line = psRow({
+      pid: 10,
+      ppid: 1,
+      cpu: 0.0,
+      rss: 2048,
+      comm: "/opt/Claude/CLI", // 15 chars, fits the column un-truncated
+      args: "/opt/Claude/CLI --serve",
+    });
+    const [row] = parsePsLines([line]);
+    expect(row.command).toBe("cli");
+  });
+
+  test("documents the 16-char comm-column clamp: a long comm path truncates", () => {
+    // macOS clamps the intermediate comm column to 16 chars, so a long
+    // executable path basename can be cut. This is an accepted ps limitation;
+    // the test pins the behavior so it is intentional, not a surprise.
+    const line = psRow({
+      pid: 33,
+      ppid: 1,
+      cpu: 0.0,
+      rss: 2048,
+      comm: "/usr/local/bin/node", // 19 chars → clamped to "/usr/local/bin/n"
+      args: "/usr/local/bin/node x.mjs",
+    });
+    const [row] = parsePsLines([line]);
+    expect(row.command).toBe("n");
+    // …but the full, untruncated command line is preserved in args (payload).
+    expect(row.args).toBe("/usr/local/bin/node x.mjs");
+  });
+
+  test("login-shell argv[0] (-zsh) does NOT mislead command: comm wins", () => {
+    // Real macOS: a login shell's args is `-zsh` but comm is `/bin/zsh`.
+    const line = psRow({ pid: 77, ppid: 1, cpu: 0.1, rss: 4096, comm: "/bin/zsh", args: "-zsh" });
+    const [row] = parsePsLines([line]);
+    expect(row.command).toBe("zsh");
+  });
+
+  test("skips blank lines and malformed (non-numeric leading) lines", () => {
+    const good = psRow({ pid: 88, ppid: 1, cpu: 0.0, rss: 4096, comm: "/bin/bash", args: "bash" });
+    const rows = parsePsLines(["", "   ", "not a ps line at all", good, "\t"]);
+    expect(rows.length).toBe(1);
+    expect(rows[0].pid).toBe(88);
+    expect(rows[0].command).toBe("bash");
+  });
+
+  test("handles a comm-only line (no args column)", () => {
+    // No args field: the whole tail is the (sub-16-char) comm.
+    const [row] = parsePsLines([psRow({ pid: 5, ppid: 1, cpu: 0.0, rss: 1024, comm: "bun" })]);
+    expect(row.pid).toBe(5);
+    expect(row.command).toBe("bun");
+    expect(row.args).toBe("bun");
+  });
+
+  test("ignores non-string entries", () => {
+    expect(parsePsLines([null, undefined, 123]).length).toBe(0);
+  });
+});
+
+// ─── ranking ─────────────────────────────────────────────────────────────────
+
+describe("rankTopN", () => {
+  function rowsForRank() {
+    return [
+      { pid: 1, rss_kb: 100, cpu_pct: 1 },
+      { pid: 2, rss_kb: 900, cpu_pct: 5 },
+      { pid: 3, rss_kb: 500, cpu_pct: 2 },
+      { pid: 4, rss_kb: 500, cpu_pct: 9 }, // ties pid 3 on RSS; higher CPU wins the tie
+      { pid: 5, rss_kb: 50, cpu_pct: 0 },
+    ];
+  }
+
+  test("returns the N largest by RSS, descending", () => {
+    const top = rankTopN(rowsForRank(), 3);
+    expect(top.map((r) => r.pid)).toEqual([2, 4, 3]);
+  });
+
+  test("breaks RSS ties by CPU descending", () => {
+    const top = rankTopN(rowsForRank(), 5);
+    // pid 4 (cpu 9) precedes pid 3 (cpu 2) despite equal RSS.
+    const idx4 = top.findIndex((r) => r.pid === 4);
+    const idx3 = top.findIndex((r) => r.pid === 3);
+    expect(idx4).toBeLessThan(idx3);
+  });
+
+  test("does not mutate the input array", () => {
+    const rows = rowsForRank();
+    const before = rows.map((r) => r.pid);
+    rankTopN(rows, 2);
+    expect(rows.map((r) => r.pid)).toEqual(before);
+  });
+
+  test("floors topN to at least 1", () => {
+    expect(rankTopN(rowsForRank(), 0).length).toBe(1);
+    expect(rankTopN(rowsForRank(), -5).length).toBe(1);
+  });
+});
+
+// ─── attribution (ppid chain) ──────────────────────────────────────────────────
+
+describe("attributeRow", () => {
+  // worker → node → claude tree: only the top worker pid is in the worker map.
+  function tree() {
+    const rows = [
+      { pid: 100, ppid: 1 }, // the worker root
+      { pid: 200, ppid: 100 }, // node child
+      { pid: 300, ppid: 200 }, // claude grandchild
+      { pid: 999, ppid: 1 }, // unrelated process
+    ];
+    const byPid = new Map(rows.map((r) => [r.pid, r]));
+    const workerMap = new Map([[100, { ticket: "CTL-700", phase: "implement", bg_job_id: "abc" }]]);
+    return { byPid, workerMap };
+  }
+
+  test("direct match: the process pid is in the worker map", () => {
+    const { byPid, workerMap } = tree();
+    expect(attributeRow({ pid: 100, ppid: 1 }, byPid, workerMap).ticket).toBe("CTL-700");
+  });
+
+  test("via-ancestor match: a grandchild inherits the worker through the ppid chain", () => {
+    const { byPid, workerMap } = tree();
+    const hit = attributeRow({ pid: 300, ppid: 200 }, byPid, workerMap);
+    expect(hit).not.toBeNull();
+    expect(hit.ticket).toBe("CTL-700");
+    expect(hit.phase).toBe("implement");
+  });
+
+  test("unrelated process resolves to null", () => {
+    const { byPid, workerMap } = tree();
+    expect(attributeRow({ pid: 999, ppid: 1 }, byPid, workerMap)).toBeNull();
+  });
+
+  test("stops at the chain cap and tolerates cycles without looping forever", () => {
+    // A pathological ppid cycle: 1→2→1. attributeRow must terminate.
+    const byPid = new Map([
+      [1, { pid: 1, ppid: 2 }],
+      [2, { pid: 2, ppid: 1 }],
+    ]);
+    const workerMap = new Map(); // no match anywhere
+    expect(attributeRow({ pid: 1, ppid: 2 }, byPid, workerMap)).toBeNull();
+  });
+});
+
+// ─── sampleProcesses (end to end with injected seams) ───────────────────────────
+
+describe("sampleProcesses", () => {
+  // A small ps snapshot: a worker root (1000), its node+claude descendants, a
+  // big unrelated process, and a tiny one that should fall outside top-N. comm
+  // paths are kept short so basename survives the 16-char comm-column clamp.
+  function psSnapshot() {
+    return [
+      psRow({ pid: 1000, ppid: 1, cpu: 3.0, rss: 800000, comm: "/bin/node", args: "/bin/node worker.mjs CTL-555" }),
+      psRow({ pid: 1100, ppid: 1000, cpu: 10.0, rss: 600000, comm: "/bin/node", args: "/bin/node mcp-server.mjs" }),
+      psRow({ pid: 1200, ppid: 1100, cpu: 25.5, rss: 900000, comm: "/bin/claude", args: "/opt/claude/claude --bg --resume" }),
+      psRow({ pid: 2000, ppid: 1, cpu: 0.5, rss: 950000, comm: "/bin/Chrome", args: "/Applications/Chrome.app/Contents/MacOS/Chrome --type=gpu" }),
+      psRow({ pid: 50, ppid: 1, cpu: 0.0, rss: 1024, comm: "/usr/sbin/cupsd", args: "/usr/sbin/cupsd -l" }),
+    ];
+  }
+
+  // Worker map: only the worker ROOT pid (1000) is known; descendants attribute
+  // via the ppid chain.
+  function workerMap() {
+    return new Map([[1000, { ticket: "CTL-555", phase: "implement", bg_job_id: "job-9" }]]);
+  }
+
+  test("emits one host.process.sampled envelope per top-N row", () => {
+    const { emit, envelopes } = recordingEmit();
+    const out = sampleProcesses({
+      psLines: psSnapshot,
+      readWorkerMap: workerMap,
+      topN: 3,
+      emit,
+      now: () => FIXED_NOW,
+    });
+    expect(out.length).toBe(3);
+    expect(envelopes.length).toBe(3);
+    for (const e of envelopes) {
+      expect(e.attributes["event.name"]).toBe(PROCESS_EVENT_SAMPLED);
+      expect(e.attributes["event.entity"]).toBe("host");
+      expect(e.attributes["event.action"]).toBe("process.sampled");
+      expect(e.attributes["event.label"]).toBe(hostname());
+      expect(e.resource["service.name"]).toBe("catalyst.agent");
+      expect(e.ts).toBe(FIXED_NOW);
+    }
+  });
+
+  test("top-N is by RSS desc: chrome(950k) > claude(900k) > worker-root(800k)", () => {
+    const { emit, envelopes } = recordingEmit();
+    sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 3, emit });
+    const pids = envelopes.map((e) => e.body.payload.pid);
+    expect(pids).toEqual([2000, 1200, 1000]);
+  });
+
+  test("contract: attributes carry command/cpu/rss; payload carries pid/ppid/args/bg_job_id", () => {
+    const { emit, envelopes } = recordingEmit();
+    sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 5, emit });
+    const claude = envelopes.find((e) => e.body.payload.pid === 1200);
+    // dot-form value attributes
+    expect(claude.attributes["process.command"]).toBe("claude");
+    expect(claude.attributes["process.cpu_pct"]).toBe(25.5);
+    expect(claude.attributes["process.rss_mb"]).toBe(Math.round(900000 / 1024));
+    // high-cardinality fields live ONLY in the payload, never as attributes
+    expect("pid" in claude.attributes).toBe(false);
+    expect("args" in claude.attributes).toBe(false);
+    expect(claude.body.payload.pid).toBe(1200);
+    expect(claude.body.payload.ppid).toBe(1100);
+    expect(claude.body.payload.args).toBe("/opt/claude/claude --bg --resume");
+  });
+
+  test("direct attribution: the worker root row gets ticket/phase/bg_job_id", () => {
+    const { emit, envelopes } = recordingEmit();
+    sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 5, emit });
+    const root = envelopes.find((e) => e.body.payload.pid === 1000);
+    expect(root.attributes["process.ticket"]).toBe("CTL-555");
+    expect(root.attributes["process.phase"]).toBe("implement");
+    expect(root.body.payload.bg_job_id).toBe("job-9");
+  });
+
+  test("via-ancestor attribution: the claude grandchild inherits the worker's ticket", () => {
+    const { emit, envelopes } = recordingEmit();
+    sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 5, emit });
+    const claude = envelopes.find((e) => e.body.payload.pid === 1200);
+    expect(claude.attributes["process.ticket"]).toBe("CTL-555");
+    expect(claude.attributes["process.phase"]).toBe("implement");
+    expect(claude.body.payload.bg_job_id).toBe("job-9");
+  });
+
+  test("unattributed process omits ticket/phase attrs and has null bg_job_id", () => {
+    const { emit, envelopes } = recordingEmit();
+    sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 5, emit });
+    const chrome = envelopes.find((e) => e.body.payload.pid === 2000);
+    expect("process.ticket" in chrome.attributes).toBe(false);
+    expect("process.phase" in chrome.attributes).toBe(false);
+    expect(chrome.body.payload.bg_job_id).toBeNull();
+  });
+
+  test("missing workers dir → empty map → every process unattributed", () => {
+    const { emit, envelopes } = recordingEmit();
+    sampleProcesses({
+      psLines: psSnapshot,
+      readWorkerMap: () => new Map(), // simulate no workers dir
+      topN: 5,
+      emit,
+    });
+    for (const e of envelopes) {
+      expect("process.ticket" in e.attributes).toBe(false);
+      expect("process.phase" in e.attributes).toBe(false);
+      expect(e.body.payload.bg_job_id).toBeNull();
+    }
+  });
+
+  test("a throwing psLines seam degrades to [] (never throws)", () => {
+    let out;
+    expect(() => {
+      out = sampleProcesses({
+        psLines: () => {
+          throw new Error("ps exploded");
+        },
+        readWorkerMap: () => new Map(),
+        emit: () => {},
+      });
+    }).not.toThrow();
+    expect(out).toEqual([]);
+  });
+
+  test("a throwing readWorkerMap seam degrades to all-unattributed (never throws)", () => {
+    const { emit, envelopes } = recordingEmit();
+    expect(() => {
+      sampleProcesses({
+        psLines: psSnapshot,
+        readWorkerMap: () => {
+          throw new Error("fs exploded");
+        },
+        topN: 2,
+        emit,
+      });
+    }).not.toThrow();
+    expect(envelopes.length).toBe(2);
+    for (const e of envelopes) expect("process.ticket" in e.attributes).toBe(false);
+  });
+
+  test("a throwing emit does not abort the tick (best-effort per row)", () => {
+    let calls = 0;
+    const out = sampleProcesses({
+      psLines: psSnapshot,
+      readWorkerMap: workerMap,
+      topN: 3,
+      emit: () => {
+        calls++;
+        throw new Error("emit boom");
+      },
+      now: () => FIXED_NOW,
+    });
+    // All 3 envelopes were built and emit was attempted for each.
+    expect(out.length).toBe(3);
+    expect(calls).toBe(3);
+  });
+});
+
+// ─── defaultReadWorkerMap (real filesystem via a temp CATALYST_DIR) ──────────────
+
+describe("defaultReadWorkerMap", () => {
+  function makeWorkersRoot() {
+    const dir = mkdtempSync(join(tmpdir(), "ctl812-proc-"));
+    return join(dir, "execution-core", "workers");
+  }
+
+  function writeSignal(root, ticket, file, obj) {
+    const d = join(root, ticket);
+    mkdirSync(d, { recursive: true });
+    writeFileSync(join(d, file), JSON.stringify(obj));
+  }
+
+  test("builds pid→{ticket,phase,bg_job_id} from pid-bearing signals", () => {
+    const root = makeWorkersRoot();
+    writeSignal(root, "CTL-100", "phase-implement.json", {
+      ticket: "CTL-100",
+      phase: "implement",
+      pid: 4242,
+      bg_job_id: "bg-1",
+    });
+    const map = defaultReadWorkerMap(root);
+    expect(map.get(4242)).toEqual({ ticket: "CTL-100", phase: "implement", bg_job_id: "bg-1" });
+  });
+
+  test("skips signals without a numeric pid (bg-only nested phase signals)", () => {
+    const root = makeWorkersRoot();
+    // The common on-disk shape: a phase signal with bg_job_id but no pid.
+    writeSignal(root, "CTL-200", "phase-triage.json", {
+      ticket: "CTL-200",
+      phase: "triage",
+      bg_job_id: "bg-2",
+    });
+    expect(defaultReadWorkerMap(root).size).toBe(0);
+  });
+
+  test("tolerates malformed JSON and unreadable entries (never throws)", () => {
+    const root = makeWorkersRoot();
+    const d = join(root, "CTL-300");
+    mkdirSync(d, { recursive: true });
+    writeFileSync(join(d, "phase-implement.json"), "{ not valid json");
+    writeSignal(root, "CTL-301", "phase-implement.json", { ticket: "CTL-301", pid: 5151 });
+    let map;
+    expect(() => {
+      map = defaultReadWorkerMap(root);
+    }).not.toThrow();
+    // The good signal still joins; the malformed one is silently skipped.
+    expect(map.get(5151).ticket).toBe("CTL-301");
+    expect(map.size).toBe(1);
+  });
+
+  test("missing workers dir returns an empty map (no throw)", () => {
+    const map = defaultReadWorkerMap(join(tmpdir(), "ctl812-does-not-exist-xyz", "workers"));
+    expect(map.size).toBe(0);
+  });
+
+  test("first writer wins per pid (a duplicate pid does not clobber)", () => {
+    const root = makeWorkersRoot();
+    writeSignal(root, "CTL-400", "a.json", { ticket: "CTL-400", phase: "p1", pid: 7000 });
+    writeSignal(root, "CTL-400", "b.json", { ticket: "CTL-400", phase: "p2", pid: 7000 });
+    const map = defaultReadWorkerMap(root);
+    expect(map.size).toBe(1);
+    expect(map.get(7000).ticket).toBe("CTL-400");
+  });
+});

--- a/plugins/dev/scripts/catalyst-agent/processes.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/processes.test.mjs
@@ -16,6 +16,8 @@ import { tmpdir, hostname } from "node:os";
 import { join } from "node:path";
 import {
   parsePsLines,
+  splitCommArgs,
+  deriveCommand,
   rankTopN,
   attributeRow,
   sampleProcesses,
@@ -54,7 +56,7 @@ describe("parsePsLines", () => {
       comm: "/bin/node", // short enough to survive the 16-char column clamp
       args: "/usr/local/bin/node server.mjs --port 8080",
     });
-    const [row] = parsePsLines([line]);
+    const [row] = parsePsLines([line], { platform: "darwin" });
     expect(row.pid).toBe(4321);
     expect(row.ppid).toBe(4000);
     expect(row.cpu_pct).toBe(12.5);
@@ -74,10 +76,13 @@ describe("parsePsLines", () => {
       comm: "/Applications/Foo Bar.app/Contents/MacOS/Foo",
       args: '/Applications/Foo Bar.app/Contents/MacOS/Foo --flag "a b c"',
     });
-    const [row] = parsePsLines([line]);
+    const [row] = parsePsLines([line], { platform: "darwin" });
     expect(row.pid).toBe(900);
-    // basename of the 16-char-clamped comm "/Applications/Fo" → "fo".
-    expect(row.command).toBe("fo");
+    // The macOS comm column is clamped to 16 ("/Applications/Fo"). deriveCommand
+    // heals it from argv[0] in args: comm is a prefix of the first args token
+    // "/Applications/Foo", so basename(argv[0]) → "foo" (better than the clamped
+    // "fo"; argv[0] itself stops at the embedded space, but the basename is right).
+    expect(row.command).toBe("foo");
     // args is the full untruncated command line, spaces and quotes intact.
     expect(row.args).toBe('/Applications/Foo Bar.app/Contents/MacOS/Foo --flag "a b c"');
   });
@@ -91,38 +96,82 @@ describe("parsePsLines", () => {
       comm: "/opt/Claude/CLI", // 15 chars, fits the column un-truncated
       args: "/opt/Claude/CLI --serve",
     });
-    const [row] = parsePsLines([line]);
+    const [row] = parsePsLines([line], { platform: "darwin" });
     expect(row.command).toBe("cli");
   });
 
-  test("documents the 16-char comm-column clamp: a long comm path truncates", () => {
-    // macOS clamps the intermediate comm column to 16 chars, so a long
-    // executable path basename can be cut. This is an accepted ps limitation;
-    // the test pins the behavior so it is intentional, not a surprise.
+  test("macOS 16-char comm clamp is HEALED from argv[0] in args (CTL-812 fix)", () => {
+    // macOS clamps the comm column to 16 chars ("/usr/local/bin/node" → the
+    // truncated "/usr/local/bin/n"), which would yield the misleading command
+    // "n". deriveCommand recovers the real command from the full argv[0] in the
+    // args column: comm is a prefix of "/usr/local/bin/node", so basename(argv[0])
+    // → "node". (Pre-fix this asserted "n"; the review flagged the truncation.)
     const line = psRow({
       pid: 33,
       ppid: 1,
       cpu: 0.0,
       rss: 2048,
-      comm: "/usr/local/bin/node", // 19 chars → clamped to "/usr/local/bin/n"
+      comm: "/usr/local/bin/node", // 19 chars → comm column clamped to "/usr/local/bin/n"
       args: "/usr/local/bin/node x.mjs",
     });
-    const [row] = parsePsLines([line]);
-    expect(row.command).toBe("n");
-    // …but the full, untruncated command line is preserved in args (payload).
+    const [row] = parsePsLines([line], { platform: "darwin" });
+    expect(row.command).toBe("node");
+    // …and the full, untruncated command line is preserved in args (payload).
     expect(row.args).toBe("/usr/local/bin/node x.mjs");
+  });
+
+  test("macOS deep-path comm (logd, framework) heals to the real command", () => {
+    // The exact cases the CTL-812 review reproduced against real `ps` output:
+    //   /usr/libexec/logd → comm clamped to "/usr/libexec/log" → would give "log"
+    //   /System/Library/PrivateFrameworks/… → "/System/Library/" → would give "library"
+    // deriveCommand heals both from the full argv[0] in args.
+    const logd = psRow({
+      pid: 343, ppid: 1, cpu: 0.7, rss: 44192,
+      comm: "/usr/libexec/logd", // clamps to "/usr/libexec/log"
+      args: "/usr/libexec/logd",
+    });
+    const framework = psRow({
+      pid: 598, ppid: 1, cpu: 0.0, rss: 15296,
+      comm: "/System/Library/PrivateFrameworks/ModelCatalogRuntime.framework/Versions/A/modelcatalogd",
+      args: "/System/Library/PrivateFrameworks/ModelCatalogRuntime.framework/Versions/A/modelcatalogd",
+    });
+    const [a] = parsePsLines([logd], { platform: "darwin" });
+    const [b] = parsePsLines([framework], { platform: "darwin" });
+    expect(a.command).toBe("logd"); // not the truncated "log"
+    expect(b.command).toBe("modelcatalogd"); // not the truncated "library"
+  });
+
+  test("Linux comm column is natural-width (not 16-padded) — parsed correctly", () => {
+    // CTL-812 review: Linux `ps -o comm=,args=` does NOT fixed-pad comm to 16; it
+    // renders comm at its natural width with a single space before args. The
+    // darwin 16-char slice would split mid-token here. With platform:"linux" the
+    // first whitespace token is comm and the remainder is args.
+    //
+    // A SHORT comm (< 16): the macOS slice would absorb the leading args into
+    // comm; the linux split keeps them separate.
+    const shortComm = "1234 1 3.1 524288 node /usr/bin/node server.mjs --port 8080";
+    const [row] = parsePsLines([shortComm], { platform: "linux" });
+    expect(row.pid).toBe(1234);
+    expect(row.command).toBe("node");
+    expect(row.args).toBe("/usr/bin/node server.mjs --port 8080");
+
+    // A LONG comm (> 16) is NOT truncated on Linux: comm renders in full.
+    const longComm = "55 1 0.0 2048 systemd-resolved /lib/systemd/systemd-resolved";
+    const [row2] = parsePsLines([longComm], { platform: "linux" });
+    expect(row2.command).toBe("systemd-resolved");
+    expect(row2.args).toBe("/lib/systemd/systemd-resolved");
   });
 
   test("login-shell argv[0] (-zsh) does NOT mislead command: comm wins", () => {
     // Real macOS: a login shell's args is `-zsh` but comm is `/bin/zsh`.
     const line = psRow({ pid: 77, ppid: 1, cpu: 0.1, rss: 4096, comm: "/bin/zsh", args: "-zsh" });
-    const [row] = parsePsLines([line]);
+    const [row] = parsePsLines([line], { platform: "darwin" });
     expect(row.command).toBe("zsh");
   });
 
   test("skips blank lines and malformed (non-numeric leading) lines", () => {
     const good = psRow({ pid: 88, ppid: 1, cpu: 0.0, rss: 4096, comm: "/bin/bash", args: "bash" });
-    const rows = parsePsLines(["", "   ", "not a ps line at all", good, "\t"]);
+    const rows = parsePsLines(["", "   ", "not a ps line at all", good, "\t"], { platform: "darwin" });
     expect(rows.length).toBe(1);
     expect(rows[0].pid).toBe(88);
     expect(rows[0].command).toBe("bash");
@@ -130,7 +179,9 @@ describe("parsePsLines", () => {
 
   test("handles a comm-only line (no args column)", () => {
     // No args field: the whole tail is the (sub-16-char) comm.
-    const [row] = parsePsLines([psRow({ pid: 5, ppid: 1, cpu: 0.0, rss: 1024, comm: "bun" })]);
+    const [row] = parsePsLines([psRow({ pid: 5, ppid: 1, cpu: 0.0, rss: 1024, comm: "bun" })], {
+      platform: "darwin",
+    });
     expect(row.pid).toBe(5);
     expect(row.command).toBe("bun");
     expect(row.args).toBe("bun");
@@ -138,6 +189,77 @@ describe("parsePsLines", () => {
 
   test("ignores non-string entries", () => {
     expect(parsePsLines([null, undefined, 123]).length).toBe(0);
+  });
+});
+
+// ─── splitCommArgs (per-platform comm column) ──────────────────────────────────
+
+describe("splitCommArgs", () => {
+  test("darwin: fixed 16-char space-padded comm column, args to EOL", () => {
+    // "node" padded to 16, a space, then args. The 16-slice peels comm cleanly.
+    const tail = "node            /usr/bin/node x.mjs --port 8080";
+    expect(splitCommArgs(tail, "darwin")).toEqual({
+      comm: "node",
+      args: "/usr/bin/node x.mjs --port 8080",
+    });
+  });
+
+  test("darwin: a comm-only tail shorter than the column has empty args", () => {
+    expect(splitCommArgs("bun", "darwin")).toEqual({ comm: "bun", args: "" });
+  });
+
+  test("linux: comm is the first whitespace token (natural width), args is the rest", () => {
+    // No 16-padding: a SHORT comm would absorb args under the darwin slice; the
+    // linux split keeps them separate.
+    expect(splitCommArgs("node /usr/bin/node x.mjs", "linux")).toEqual({
+      comm: "node",
+      args: "/usr/bin/node x.mjs",
+    });
+    // A LONG comm (> 16) is NOT truncated on linux.
+    expect(splitCommArgs("systemd-resolved /lib/systemd/systemd-resolved", "linux")).toEqual({
+      comm: "systemd-resolved",
+      args: "/lib/systemd/systemd-resolved",
+    });
+  });
+
+  test("linux: a comm-only tail (no space) has empty args", () => {
+    expect(splitCommArgs("bun", "linux")).toEqual({ comm: "bun", args: "" });
+  });
+});
+
+// ─── deriveCommand (heal macOS truncation, defer to comm on rewritten argv0) ──
+
+describe("deriveCommand", () => {
+  test("comm is authoritative when it is NOT a truncated prefix of argv[0] (login shell)", () => {
+    // comm "/bin/zsh", argv0 "-zsh" — argv0 was rewritten; comm wins → "zsh".
+    expect(deriveCommand("/bin/zsh", "-zsh")).toBe("zsh");
+  });
+
+  test("heals a truncated comm from the full argv[0] (logd, framework)", () => {
+    // macOS clamps comm to 16; argv[0] in args carries the full path.
+    expect(deriveCommand("/usr/libexec/log", "/usr/libexec/logd")).toBe("logd");
+    expect(
+      deriveCommand(
+        "/System/Library/",
+        "/System/Library/PrivateFrameworks/ModelCatalogRuntime.framework/Versions/A/modelcatalogd",
+      ),
+    ).toBe("modelcatalogd");
+  });
+
+  test("comm wins when it equals argv[0] (no truncation to heal)", () => {
+    expect(deriveCommand("/opt/Claude/CLI", "/opt/Claude/CLI --serve")).toBe("cli");
+  });
+
+  test("comm wins when there is no args column at all", () => {
+    expect(deriveCommand("/bin/bash", "")).toBe("bash");
+  });
+
+  test("lowercases the result", () => {
+    expect(deriveCommand("/bin/ZSH", "-zsh")).toBe("zsh");
+  });
+
+  test("empty comm + empty args → null", () => {
+    expect(deriveCommand("", "")).toBeNull();
   });
 });
 
@@ -247,14 +369,20 @@ describe("sampleProcesses", () => {
     return new Map([[1000, { ticket: "CTL-555", phase: "implement", bg_job_id: "job-9" }]]);
   }
 
-  test("emits one host.process.sampled envelope per top-N row", () => {
+  // sampleProcesses is async (it drains in-flight OTLP POSTs before resolving),
+  // so every call is awaited. platform:"darwin" pins the macOS-shaped psRow
+  // fixtures so the suite is host-independent (it would mis-split on a Linux CI).
+  const DARWIN = { platform: "darwin" };
+
+  test("emits one host.process.sampled envelope per top-N row", async () => {
     const { emit, envelopes } = recordingEmit();
-    const out = sampleProcesses({
+    const out = await sampleProcesses({
       psLines: psSnapshot,
       readWorkerMap: workerMap,
       topN: 3,
       emit,
       now: () => FIXED_NOW,
+      ...DARWIN,
     });
     expect(out.length).toBe(3);
     expect(envelopes.length).toBe(3);
@@ -268,16 +396,16 @@ describe("sampleProcesses", () => {
     }
   });
 
-  test("top-N is by RSS desc: chrome(950k) > claude(900k) > worker-root(800k)", () => {
+  test("top-N is by RSS desc: chrome(950k) > claude(900k) > worker-root(800k)", async () => {
     const { emit, envelopes } = recordingEmit();
-    sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 3, emit });
+    await sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 3, emit, ...DARWIN });
     const pids = envelopes.map((e) => e.body.payload.pid);
     expect(pids).toEqual([2000, 1200, 1000]);
   });
 
-  test("contract: attributes carry command/cpu/rss; payload carries pid/ppid/args/bg_job_id", () => {
+  test("contract: attributes carry command/cpu/rss; payload carries pid/ppid/args/bg_job_id", async () => {
     const { emit, envelopes } = recordingEmit();
-    sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 5, emit });
+    await sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 5, emit, ...DARWIN });
     const claude = envelopes.find((e) => e.body.payload.pid === 1200);
     // dot-form value attributes
     expect(claude.attributes["process.command"]).toBe("claude");
@@ -291,40 +419,41 @@ describe("sampleProcesses", () => {
     expect(claude.body.payload.args).toBe("/opt/claude/claude --bg --resume");
   });
 
-  test("direct attribution: the worker root row gets ticket/phase/bg_job_id", () => {
+  test("direct attribution: the worker root row gets ticket/phase/bg_job_id", async () => {
     const { emit, envelopes } = recordingEmit();
-    sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 5, emit });
+    await sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 5, emit, ...DARWIN });
     const root = envelopes.find((e) => e.body.payload.pid === 1000);
     expect(root.attributes["process.ticket"]).toBe("CTL-555");
     expect(root.attributes["process.phase"]).toBe("implement");
     expect(root.body.payload.bg_job_id).toBe("job-9");
   });
 
-  test("via-ancestor attribution: the claude grandchild inherits the worker's ticket", () => {
+  test("via-ancestor attribution: the claude grandchild inherits the worker's ticket", async () => {
     const { emit, envelopes } = recordingEmit();
-    sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 5, emit });
+    await sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 5, emit, ...DARWIN });
     const claude = envelopes.find((e) => e.body.payload.pid === 1200);
     expect(claude.attributes["process.ticket"]).toBe("CTL-555");
     expect(claude.attributes["process.phase"]).toBe("implement");
     expect(claude.body.payload.bg_job_id).toBe("job-9");
   });
 
-  test("unattributed process omits ticket/phase attrs and has null bg_job_id", () => {
+  test("unattributed process omits ticket/phase attrs and has null bg_job_id", async () => {
     const { emit, envelopes } = recordingEmit();
-    sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 5, emit });
+    await sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 5, emit, ...DARWIN });
     const chrome = envelopes.find((e) => e.body.payload.pid === 2000);
     expect("process.ticket" in chrome.attributes).toBe(false);
     expect("process.phase" in chrome.attributes).toBe(false);
     expect(chrome.body.payload.bg_job_id).toBeNull();
   });
 
-  test("missing workers dir → empty map → every process unattributed", () => {
+  test("missing workers dir → empty map → every process unattributed", async () => {
     const { emit, envelopes } = recordingEmit();
-    sampleProcesses({
+    await sampleProcesses({
       psLines: psSnapshot,
       readWorkerMap: () => new Map(), // simulate no workers dir
       topN: 5,
       emit,
+      ...DARWIN,
     });
     for (const e of envelopes) {
       expect("process.ticket" in e.attributes).toBe(false);
@@ -333,39 +462,49 @@ describe("sampleProcesses", () => {
     }
   });
 
-  test("a throwing psLines seam degrades to [] (never throws)", () => {
+  test("a throwing psLines seam degrades to [] (never throws)", async () => {
     let out;
-    expect(() => {
-      out = sampleProcesses({
+    let threw = false;
+    try {
+      out = await sampleProcesses({
         psLines: () => {
           throw new Error("ps exploded");
         },
         readWorkerMap: () => new Map(),
         emit: () => {},
+        ...DARWIN,
       });
-    }).not.toThrow();
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
     expect(out).toEqual([]);
   });
 
-  test("a throwing readWorkerMap seam degrades to all-unattributed (never throws)", () => {
+  test("a throwing readWorkerMap seam degrades to all-unattributed (never throws)", async () => {
     const { emit, envelopes } = recordingEmit();
-    expect(() => {
-      sampleProcesses({
+    let threw = false;
+    try {
+      await sampleProcesses({
         psLines: psSnapshot,
         readWorkerMap: () => {
           throw new Error("fs exploded");
         },
         topN: 2,
         emit,
+        ...DARWIN,
       });
-    }).not.toThrow();
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
     expect(envelopes.length).toBe(2);
     for (const e of envelopes) expect("process.ticket" in e.attributes).toBe(false);
   });
 
-  test("a throwing emit does not abort the tick (best-effort per row)", () => {
+  test("a throwing emit does not abort the tick (best-effort per row)", async () => {
     let calls = 0;
-    const out = sampleProcesses({
+    const out = await sampleProcesses({
       psLines: psSnapshot,
       readWorkerMap: workerMap,
       topN: 3,
@@ -374,10 +513,32 @@ describe("sampleProcesses", () => {
         throw new Error("emit boom");
       },
       now: () => FIXED_NOW,
+      ...DARWIN,
     });
     // All 3 envelopes were built and emit was attempted for each.
     expect(out.length).toBe(3);
     expect(calls).toBe(3);
+  });
+
+  test("drains in-flight OTLP POSTs before resolving (CTL-812: no abandoned POST)", async () => {
+    // The emit seam returns a slow promise (an OTLP POST). sampleProcesses must
+    // await it before resolving — otherwise the --once path would exit with the
+    // POST still in flight. We assert every returned promise has settled by the
+    // time sampleProcesses resolves.
+    let settled = 0;
+    const slowEmit = () =>
+      new Promise((resolve) => setTimeout(() => { settled++; resolve(true); }, 5));
+    const out = await sampleProcesses({
+      psLines: psSnapshot,
+      readWorkerMap: workerMap,
+      topN: 3,
+      emit: slowEmit,
+      now: () => FIXED_NOW,
+      ...DARWIN,
+    });
+    expect(out.length).toBe(3);
+    // All 3 slow POSTs completed before the tick resolved (not abandoned).
+    expect(settled).toBe(3);
   });
 });
 

--- a/plugins/dev/scripts/catalyst-agent/usage.mjs
+++ b/plugins/dev/scripts/catalyst-agent/usage.mjs
@@ -1,0 +1,289 @@
+// usage.mjs — CTL-812 Domain 1. Per-account Claude rate-limit usage sampler.
+//
+// Given the accounts enumerated for this run (active + refreshed swap backups),
+// tickUsage() resolves each account's email/tier ONCE, GETs
+// https://api.anthropic.com/api/oauth/usage, normalizes the five_hour /
+// seven_day / per-model 7d buckets, computes a forward-looking burn PACE for the
+// 5h and 7d windows, and emits one account.ratelimit.sampled envelope per
+// account via the injected emit. On HTTP 429 from any account it stops sampling
+// the REMAINING accounts this run (a shared limiter — the usage endpoint is
+// rate-limited per source IP / token, so continuing would compound the throttle)
+// and emits nothing for the throttled or skipped accounts.
+//
+// The agent is stateless between runs (launchd --once relaunches the process),
+// so the email/tier cache lives only for the duration of THIS tickUsage() call.
+//
+// SELF-CONTAINED: zero npm deps, node:* builtins only; runs under node>=18 and
+// bun. The standalone agent does NOT import from execution-core.
+//
+// SECRETS HYGIENE (hard rule): the OAuth token is passed into fetchUsage /
+// resolveEmail and used without ever being logged or echoed. NEVER print it.
+//
+// All side effects (fetchUsage, resolveEmail, emit, now) are injected so
+// tickUsage() is fully unit-testable with no real network.
+
+import { execFileSync } from "node:child_process";
+import { log } from "./config.mjs";
+
+const USAGE_ENDPOINT = "https://api.anthropic.com/api/oauth/usage";
+const PROFILE_ENDPOINT = "https://api.anthropic.com/api/oauth/profile";
+const OAUTH_BETA = "oauth-2025-04-20";
+
+// Rolling-window widths used for the pace calculation. 5h and 7d in ms.
+const FIVE_HOUR_MS = 5 * 3600_000;
+const SEVEN_DAY_MS = 7 * 86_400_000;
+
+export const RATELIMIT_EVENT_SAMPLED = "account.ratelimit.sampled";
+
+// pctOf — normalize a usage bucket to its numeric utilization. The live usage
+// endpoint returns each bucket (five_hour, seven_day, seven_day_opus,
+// seven_day_sonnet) as an object { utilization, resets_at }; older docs showed
+// the per-model buckets as bare numbers. Accept either shape; null when absent
+// (an absent bucket means NO usage → null, never coerced to 0). Mirrors
+// execution-core/ratelimit-poller.mjs's pctOf to guard the "[object Object]" bug.
+export function pctOf(bucket) {
+  if (bucket == null) return null;
+  if (typeof bucket === "object") return bucket.utilization ?? null;
+  return bucket;
+}
+
+// getUserAgent — REQUIRED usage/profile header. A wrong/missing UA triggers an
+// instant persistent 429. Built from the locally-installed claude version;
+// computed once per run. Falls back to "claude-code/unknown". Mirrors the
+// execution-core poller idiom.
+export function getUserAgent() {
+  try {
+    const out = execFileSync("claude", ["--version"], { encoding: "utf8" });
+    const token = String(out).trim().split(/\s+/)[0];
+    return `claude-code/${token || "unknown"}`;
+  } catch {
+    return "claude-code/unknown";
+  }
+}
+
+function authHeaders(token, userAgent) {
+  return {
+    Authorization: `Bearer ${token}`,
+    "anthropic-beta": OAUTH_BETA,
+    "User-Agent": userAgent,
+  };
+}
+
+/**
+ * computePace — forward-looking burn pace for one rolling window. Positive means
+ * the account is consuming its quota FASTER than wall-clock (on track to exhaust
+ * before the window resets); negative means it is comfortably under pace.
+ *
+ *   elapsed = (nowMs − (resetsAt − windowMs)) / windowMs   // fraction of window elapsed
+ *   pace    = utilization/100 − elapsed                    // usage fraction minus time fraction
+ *
+ * Rounded to 3 decimals. Returns null when utilization or resetsAt is missing
+ * (or resetsAt is unparseable) — pace is undefined without both. Pure; no I/O.
+ *
+ * @param {number|null} utilization  bucket utilization as a percent (0..100)
+ * @param {string|null} resetsAtIso  ISO timestamp the window resets (window end)
+ * @param {number}      windowMs     window width (FIVE_HOUR_MS | SEVEN_DAY_MS)
+ * @param {number}      nowMs        current epoch ms
+ * @returns {number|null}
+ */
+export function computePace(utilization, resetsAtIso, windowMs, nowMs) {
+  if (utilization == null || resetsAtIso == null) return null;
+  const resetsMs = Date.parse(resetsAtIso);
+  if (!Number.isFinite(resetsMs)) return null;
+  const windowStart = resetsMs - windowMs;
+  const elapsed = (nowMs - windowStart) / windowMs;
+  const pace = utilization / 100 - elapsed;
+  // Round to 3 decimals (round-half-up via Math.round on the scaled value).
+  return Math.round(pace * 1000) / 1000;
+}
+
+// defaultFetchUsage — GET the usage endpoint with the 3 required headers.
+// Returns { status, body } where body is parsed JSON when status===200, else
+// null. NEVER throws (a network error returns { status: 0, body: null }).
+// Mirrors execution-core/ratelimit-poller.mjs.
+export async function defaultFetchUsage(token, { userAgent, fetchImpl = fetch } = {}) {
+  try {
+    const res = await fetchImpl(USAGE_ENDPOINT, {
+      method: "GET",
+      headers: authHeaders(token, userAgent),
+    });
+    const status = res.status;
+    const body = status === 200 ? await res.json() : null;
+    return { status, body };
+  } catch {
+    return { status: 0, body: null };
+  }
+}
+
+// defaultResolveEmail — GET /api/oauth/profile to resolve .account.email plus
+// .organization.rate_limit_tier / .organization.subscription_status. Returns
+// { email, rateLimitTier, subscriptionType } (any field may be null) or null
+// when no email could be resolved. NEVER throws. Mirrors the execution-core
+// poller, minus the OTEL_RESOURCE_ATTRIBUTES env fallback (the standalone
+// multi-account agent has no single ambient email to fall back to).
+export async function defaultResolveEmail(token, { userAgent, fetchImpl = fetch } = {}) {
+  try {
+    const res = await fetchImpl(PROFILE_ENDPOINT, {
+      method: "GET",
+      headers: authHeaders(token, userAgent),
+    });
+    if (res.status === 200) {
+      const body = await res.json();
+      const email = body?.account?.email ?? null;
+      const rateLimitTier = body?.organization?.rate_limit_tier ?? null;
+      const subscriptionType = body?.organization?.subscription_status ?? null;
+      if (email) return { email, rateLimitTier, subscriptionType };
+    }
+  } catch {
+    /* never throw */
+  }
+  return null;
+}
+
+// buildSampledSpec — assemble the account.ratelimit.sampled envelope spec
+// (entity / label / dot-form attrs / body.payload mirror) per the CTL-812
+// telemetry contract. Pure. Attrs are placed in DOT form; the emit layer's
+// put() pattern drops any null/undefined entry so the collector never promotes
+// an empty label (and zero utilization is preserved, not dropped as falsy).
+export function buildSampledSpec({
+  email,
+  fiveHourPct,
+  sevenDayPct,
+  fiveHourResetsAt,
+  sevenDayResetsAt,
+  opusPct,
+  sonnetPct,
+  subscriptionType,
+  rateLimitTier,
+  fiveHourPace,
+  sevenDayPace,
+}) {
+  return {
+    entity: "account",
+    label: email ?? "unknown",
+    attrs: {
+      "account.email": email,
+      "ratelimit.five_hour_pct": fiveHourPct,
+      "ratelimit.seven_day_pct": sevenDayPct,
+      "ratelimit.five_hour_resets_at": fiveHourResetsAt,
+      "ratelimit.seven_day_resets_at": sevenDayResetsAt,
+      "ratelimit.seven_day_opus_pct": opusPct,
+      "ratelimit.seven_day_sonnet_pct": sonnetPct,
+      "subscription.type": subscriptionType,
+      "rate_limit.tier": rateLimitTier,
+      // NEW (CTL-812): forward-looking burn pace per window.
+      "ratelimit.five_hour_pace": fiveHourPace,
+      "ratelimit.seven_day_pace": sevenDayPace,
+    },
+    payload: {
+      email,
+      fiveHourPct,
+      sevenDayPct,
+      fiveHourResetsAt,
+      sevenDayResetsAt,
+      opusPct,
+      sonnetPct,
+      subscriptionType,
+      rateLimitTier,
+      fiveHourPace,
+      sevenDayPace,
+    },
+  };
+}
+
+/**
+ * tickUsage — sample rate-limit usage for every account this run, emitting one
+ * account.ratelimit.sampled per account. On a 429 from any account it stops the
+ * remaining accounts (shared limiter) and emits nothing further. Returns the
+ * count of accounts emitted. NEVER throws.
+ *
+ * @param {object}   opts
+ * @param {Array<{source:string, token:string, file?:string}>} opts.accounts
+ * @param {Function} [opts.fetchUsage=defaultFetchUsage]     usage GET ({status,body})
+ * @param {Function} [opts.resolveEmail=defaultResolveEmail] one-shot email/tier resolver
+ * @param {Function} opts.emit                                (name, spec, {now}) → void
+ * @param {Function} [opts.now]                               () → epoch ms (defaults to Date.now)
+ * @param {Function} [opts.nowIso]                            () → ISO string for the envelope ts (forwarded to emit)
+ * @returns {Promise<number>} number of accounts emitted
+ */
+export async function tickUsage({
+  accounts = [],
+  fetchUsage = defaultFetchUsage,
+  resolveEmail = defaultResolveEmail,
+  emit,
+  now = () => Date.now(),
+  nowIso = undefined,
+} = {}) {
+  const userAgent = getUserAgent();
+  let emittedCount = 0;
+
+  for (const account of accounts) {
+    try {
+      const token = account?.token;
+      if (!token) {
+        log.warn({ source: account?.source }, "usage: account has no token; skipping");
+        continue;
+      }
+
+      // Resolve email/tier ONCE per account this run. The agent is stateless
+      // between runs, so there is no cross-run cache to consult.
+      let email = null;
+      let orgMeta = { rateLimitTier: null, subscriptionType: null };
+      const resolved = await resolveEmail(token, { userAgent });
+      if (resolved) {
+        email = resolved.email ?? null;
+        orgMeta = {
+          rateLimitTier: resolved.rateLimitTier ?? null,
+          subscriptionType: resolved.subscriptionType ?? null,
+        };
+      }
+
+      const { status, body } = await fetchUsage(token, { userAgent });
+
+      if (status === 429) {
+        // Shared limiter: the usage endpoint throttled us. Continuing would
+        // compound the throttle for the remaining accounts, so stop the run
+        // here and emit nothing further.
+        log.warn(
+          { source: account?.source },
+          "usage: 429 from usage endpoint; stopping remaining accounts this run",
+        );
+        break;
+      }
+
+      if (status !== 200 || !body) {
+        log.warn({ status, source: account?.source }, "usage: non-200 usage response; skipping emit");
+        continue;
+      }
+
+      const fiveHour = body.five_hour ?? {};
+      const sevenDay = body.seven_day ?? {};
+      const fiveHourPct = pctOf(body.five_hour);
+      const sevenDayPct = pctOf(body.seven_day);
+      const fiveHourResetsAt = fiveHour.resets_at ?? null;
+      const sevenDayResetsAt = sevenDay.resets_at ?? null;
+      const nowMs = now();
+
+      const spec = buildSampledSpec({
+        email,
+        fiveHourPct,
+        sevenDayPct,
+        fiveHourResetsAt,
+        sevenDayResetsAt,
+        opusPct: pctOf(body.seven_day_opus),
+        sonnetPct: pctOf(body.seven_day_sonnet),
+        subscriptionType: orgMeta.subscriptionType,
+        rateLimitTier: orgMeta.rateLimitTier,
+        fiveHourPace: computePace(fiveHourPct, fiveHourResetsAt, FIVE_HOUR_MS, nowMs),
+        sevenDayPace: computePace(sevenDayPct, sevenDayResetsAt, SEVEN_DAY_MS, nowMs),
+      });
+
+      emit(RATELIMIT_EVENT_SAMPLED, spec, { now: nowIso });
+      emittedCount++;
+    } catch (err) {
+      log.warn({ err: err?.message, source: account?.source }, "usage: account tick failed");
+    }
+  }
+
+  return emittedCount;
+}

--- a/plugins/dev/scripts/catalyst-agent/usage.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/usage.test.mjs
@@ -416,3 +416,63 @@ describe("tickUsage — non-200 / resilience", () => {
     expect(emitted.length).toBe(0);
   });
 });
+
+// ─── secrets hygiene (hard rule): the usage domain never logs a token ─────────
+
+describe("tickUsage — secrets hygiene", () => {
+  test("no log line on any branch (429 / non-200 / throw) ever carries the token", async () => {
+    // The usage domain handles live OAuth access tokens. Capture every stdout/
+    // stderr write (the console-shim logger target) across the throttle, non-200,
+    // and throwing-fetch branches and assert the obviously-fake token never leaks
+    // into any log payload — a regression guard mirroring accounts.test.mjs.
+    const SECRET = "FAKE-SECRET-usage-token-MUST-NOT-LEAK";
+    const writes = [];
+    const origOut = process.stdout.write.bind(process.stdout);
+    const origErr = process.stderr.write.bind(process.stderr);
+    process.stdout.write = (chunk, ...rest) => {
+      writes.push(String(chunk));
+      return origOut(chunk, ...rest);
+    };
+    process.stderr.write = (chunk, ...rest) => {
+      writes.push(String(chunk));
+      return origErr(chunk, ...rest);
+    };
+    try {
+      // 429 branch (logs "stopping remaining accounts").
+      await tickUsage({
+        accounts: [{ source: "active", token: SECRET }],
+        fetchUsage: async () => ({ status: 429, body: null }),
+        resolveEmail: async () => null,
+        emit: () => {},
+      });
+      // non-200 branch (logs "non-200 usage response").
+      await tickUsage({
+        accounts: [{ source: "active", token: SECRET }],
+        fetchUsage: async () => ({ status: 500, body: null }),
+        resolveEmail: async () => null,
+        emit: () => {},
+      });
+      // throwing-fetch branch (logs "account tick failed").
+      await tickUsage({
+        accounts: [{ source: "active", token: SECRET }],
+        fetchUsage: async () => {
+          throw new Error("network down");
+        },
+        resolveEmail: async () => null,
+        emit: () => {},
+      });
+      // no-token branch (logs "account has no token").
+      await tickUsage({
+        accounts: [{ source: "backup", token: null, file: "x.json" }],
+        emit: () => {},
+      });
+    } finally {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+    }
+    const all = writes.join("");
+    expect(all).not.toContain(SECRET);
+    // Sanity: the branches DID log (so the assertion above is meaningful).
+    expect(all).toContain("usage:");
+  });
+});

--- a/plugins/dev/scripts/catalyst-agent/usage.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/usage.test.mjs
@@ -1,0 +1,418 @@
+// usage.test.mjs — CTL-812 Domain 1. tickUsage(): per-account emit of
+// account.ratelimit.sampled with the full contract field set (incl. the NEW
+// five_hour/seven_day pace), exact pace math against the locked fixtures, the
+// object/bare/absent bucket shapes, zero-utilization carried through, email/tier
+// resolved once per account, and a 429 stopping the REMAINING accounts this run
+// (shared limiter). Plus computePace() unit cases. All seams injected; no real
+// network. tickUsage()/computePace() are pure given their fakes.
+//
+// SECRETS HYGIENE: every fixture token is obviously fake.
+//
+// Run: cd plugins/dev/scripts/catalyst-agent && bun test usage.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { computePace, pctOf, tickUsage, RATELIMIT_EVENT_SAMPLED } from "./usage.mjs";
+
+const FIVE_HOUR_MS = 5 * 3600_000;
+const SEVEN_DAY_MS = 7 * 86_400_000;
+
+const TOKEN_A = "FAKE-token-account-a-never-logged";
+const TOKEN_B = "FAKE-token-account-b-never-logged";
+
+// A representative live 200 body (validated shape from GET /api/oauth/usage).
+function usageBody(overrides = {}) {
+  return {
+    five_hour: { utilization: 42, resets_at: "2026-06-06T18:00:00Z" },
+    seven_day: { utilization: 17, resets_at: "2026-06-13T00:00:00Z" },
+    seven_day_opus: { utilization: 12, resets_at: "2026-06-13T00:00:00Z" },
+    seven_day_sonnet: { utilization: 5, resets_at: "2026-06-13T00:00:00Z" },
+    ...overrides,
+  };
+}
+
+// Build a tickUsage harness: records every emit; defaults to one healthy
+// active account on the 200 path.
+function harness({
+  accounts = [{ source: "active", token: TOKEN_A }],
+  fetchUsage = async () => ({ status: 200, body: usageBody() }),
+  resolveEmail = async () => ({
+    email: "ryan@rozich.com",
+    rateLimitTier: "default_claude_max_20x",
+    subscriptionType: "active",
+  }),
+  now = () => Date.parse("2026-06-06T12:00:00Z"),
+  nowIso = undefined,
+} = {}) {
+  const emitted = [];
+  const fetchCalls = [];
+  const resolveCalls = [];
+  const promise = tickUsage({
+    accounts,
+    fetchUsage: async (token, opts) => {
+      fetchCalls.push({ token, opts });
+      return fetchUsage(token, opts);
+    },
+    resolveEmail: async (token, opts) => {
+      resolveCalls.push({ token, opts });
+      return resolveEmail(token, opts);
+    },
+    emit: (name, spec, opts) => emitted.push({ name, spec, opts }),
+    now,
+    nowIso,
+  });
+  return { promise, emitted, fetchCalls, resolveCalls };
+}
+
+// ─── computePace — pure unit (the locked fixtures) ───────────────────────────
+
+describe("computePace — locked fixtures", () => {
+  test("5h window, 1h elapsed, 8% used → -0.12", () => {
+    // window started 11:00, resets_at = 16:00 (start + 5h); now = 12:00 (1h in).
+    const nowMs = Date.parse("2026-06-06T12:00:00Z");
+    const resetsAt = "2026-06-06T16:00:00Z";
+    expect(computePace(8, resetsAt, FIVE_HOUR_MS, nowMs)).toBe(-0.12);
+  });
+
+  test("7d window, day 1 (1d elapsed), 30% used → +0.157", () => {
+    // window started 06-06, resets_at = 06-13 (start + 7d); now = 06-07 (1d in).
+    const nowMs = Date.parse("2026-06-07T00:00:00Z");
+    const resetsAt = "2026-06-13T00:00:00Z";
+    expect(computePace(30, resetsAt, SEVEN_DAY_MS, nowMs)).toBe(0.157);
+  });
+
+  test("on-pace exactly → 0 (50% used at the 5h midpoint)", () => {
+    const nowMs = Date.parse("2026-06-06T13:30:00Z"); // 2.5h into a 5h window
+    const resetsAt = "2026-06-06T16:00:00Z"; // started 11:00
+    expect(computePace(50, resetsAt, FIVE_HOUR_MS, nowMs)).toBe(0);
+  });
+
+  test("null utilization or null resetsAt → null", () => {
+    const nowMs = Date.parse("2026-06-06T12:00:00Z");
+    expect(computePace(null, "2026-06-06T16:00:00Z", FIVE_HOUR_MS, nowMs)).toBe(null);
+    expect(computePace(8, null, FIVE_HOUR_MS, nowMs)).toBe(null);
+  });
+
+  test("an unparseable resetsAt → null", () => {
+    const nowMs = Date.parse("2026-06-06T12:00:00Z");
+    expect(computePace(8, "not-a-date", FIVE_HOUR_MS, nowMs)).toBe(null);
+  });
+
+  test("zero utilization computes a (negative) pace, not null", () => {
+    const nowMs = Date.parse("2026-06-06T12:00:00Z"); // 1h into 5h window
+    const resetsAt = "2026-06-06T16:00:00Z";
+    expect(computePace(0, resetsAt, FIVE_HOUR_MS, nowMs)).toBe(-0.2);
+  });
+
+  test("result is rounded to exactly 3 decimals", () => {
+    // 7d, 1d elapsed (1/7 = 0.142857…), 0% used → -0.142857… → -0.143.
+    const nowMs = Date.parse("2026-06-07T00:00:00Z");
+    const resetsAt = "2026-06-13T00:00:00Z";
+    expect(computePace(0, resetsAt, SEVEN_DAY_MS, nowMs)).toBe(-0.143);
+  });
+});
+
+// ─── pctOf — bucket shapes ───────────────────────────────────────────────────
+
+describe("pctOf — bucket shapes", () => {
+  test("object bucket → its utilization", () => {
+    expect(pctOf({ utilization: 42, resets_at: "x" })).toBe(42);
+  });
+  test("bare-number bucket → the number (back-compat)", () => {
+    expect(pctOf(9)).toBe(9);
+  });
+  test("absent bucket (null/undefined) → null, not 0", () => {
+    expect(pctOf(null)).toBe(null);
+    expect(pctOf(undefined)).toBe(null);
+  });
+  test("object bucket with no utilization → null", () => {
+    expect(pctOf({ resets_at: "x" })).toBe(null);
+  });
+  test("zero utilization is carried (not coerced to null)", () => {
+    expect(pctOf({ utilization: 0, resets_at: "x" })).toBe(0);
+  });
+});
+
+// ─── tickUsage — 200 emit with the full contract ─────────────────────────────
+
+describe("tickUsage — 200 emit (contract)", () => {
+  test("emits one account.ratelimit.sampled with every contract attr incl. pace", async () => {
+    // resets_at picked so the pace math is checkable: 5h window started 11:00
+    // (resets 16:00), now 12:00 → 1h in → elapsed 0.2; 42% → pace 0.42-0.2=0.22.
+    // 7d window started 06-06 (resets 06-13), now 06-06T12:00 → 0.5d in →
+    // elapsed 0.5/7 = 0.0714…; 17% → pace 0.17-0.0714 = 0.0986 → 0.099.
+    const { promise, emitted } = harness({
+      fetchUsage: async () => ({
+        status: 200,
+        body: usageBody({
+          five_hour: { utilization: 42, resets_at: "2026-06-06T16:00:00Z" },
+          seven_day: { utilization: 17, resets_at: "2026-06-13T00:00:00Z" },
+        }),
+      }),
+      now: () => Date.parse("2026-06-06T12:00:00Z"),
+    });
+    const count = await promise;
+    expect(count).toBe(1);
+    expect(emitted.length).toBe(1);
+
+    const { name, spec } = emitted[0];
+    expect(name).toBe(RATELIMIT_EVENT_SAMPLED);
+    expect(spec.entity).toBe("account");
+    expect(spec.label).toBe("ryan@rozich.com");
+
+    const a = spec.attrs;
+    expect(a["account.email"]).toBe("ryan@rozich.com");
+    expect(a["ratelimit.five_hour_pct"]).toBe(42);
+    expect(a["ratelimit.seven_day_pct"]).toBe(17);
+    expect(a["ratelimit.five_hour_resets_at"]).toBe("2026-06-06T16:00:00Z");
+    expect(a["ratelimit.seven_day_resets_at"]).toBe("2026-06-13T00:00:00Z");
+    expect(a["ratelimit.seven_day_opus_pct"]).toBe(12);
+    expect(a["ratelimit.seven_day_sonnet_pct"]).toBe(5);
+    expect(a["subscription.type"]).toBe("active");
+    expect(a["rate_limit.tier"]).toBe("default_claude_max_20x");
+    // NEW pace attrs:
+    expect(a["ratelimit.five_hour_pace"]).toBe(0.22); // 0.42 - 0.20
+    expect(a["ratelimit.seven_day_pace"]).toBe(0.099); // 0.17 - 0.5/7
+  });
+
+  test("body.payload mirrors the same fields (incl. pace) for human readability", async () => {
+    const { promise, emitted } = harness({
+      fetchUsage: async () => ({
+        status: 200,
+        body: usageBody({
+          five_hour: { utilization: 42, resets_at: "2026-06-06T16:00:00Z" },
+          seven_day: { utilization: 17, resets_at: "2026-06-13T00:00:00Z" },
+        }),
+      }),
+      now: () => Date.parse("2026-06-06T12:00:00Z"),
+    });
+    await promise;
+    const p = emitted[0].spec.payload;
+    expect(p.email).toBe("ryan@rozich.com");
+    expect(p.fiveHourPct).toBe(42);
+    expect(p.fiveHourPace).toBe(0.22);
+    expect(p.sevenDayPace).toBe(0.099);
+  });
+
+  test("nowIso is forwarded to emit as opts.now (envelope ts seam)", async () => {
+    const { promise, emitted } = harness({ nowIso: () => "2026-06-06T12:00:00Z" });
+    await promise;
+    expect(typeof emitted[0].opts.now).toBe("function");
+    expect(emitted[0].opts.now()).toBe("2026-06-06T12:00:00Z");
+  });
+});
+
+// ─── tickUsage — bucket shapes + zero utilization ────────────────────────────
+
+describe("tickUsage — bucket shapes", () => {
+  test("per-model 7d objects are normalized to numbers (guards [object Object])", async () => {
+    const { promise, emitted } = harness();
+    await promise;
+    const a = emitted[0].spec.attrs;
+    expect(a["ratelimit.seven_day_opus_pct"]).toBe(12);
+    expect(a["ratelimit.seven_day_sonnet_pct"]).toBe(5);
+    expect(typeof a["ratelimit.seven_day_opus_pct"]).toBe("number");
+  });
+
+  test("bare-number per-model buckets are accepted (back-compat)", async () => {
+    const { promise, emitted } = harness({
+      fetchUsage: async () => ({ status: 200, body: usageBody({ seven_day_opus: 9, seven_day_sonnet: 3 }) }),
+    });
+    await promise;
+    const a = emitted[0].spec.attrs;
+    expect(a["ratelimit.seven_day_opus_pct"]).toBe(9);
+    expect(a["ratelimit.seven_day_sonnet_pct"]).toBe(3);
+  });
+
+  test("absent per-model buckets emit null (dropped downstream by the put() pattern)", async () => {
+    const { promise, emitted } = harness({
+      fetchUsage: async () => ({ status: 200, body: usageBody({ seven_day_opus: undefined, seven_day_sonnet: undefined }) }),
+    });
+    await promise;
+    const a = emitted[0].spec.attrs;
+    expect(a["ratelimit.seven_day_opus_pct"]).toBe(null);
+    expect(a["ratelimit.seven_day_sonnet_pct"]).toBe(null);
+  });
+
+  test("zero utilization is carried through (not dropped); pace still computed", async () => {
+    const { promise, emitted } = harness({
+      fetchUsage: async () => ({
+        status: 200,
+        body: usageBody({
+          five_hour: { utilization: 0, resets_at: "2026-06-06T16:00:00Z" },
+          seven_day: { utilization: 0, resets_at: "2026-06-13T00:00:00Z" },
+        }),
+      }),
+      now: () => Date.parse("2026-06-06T12:00:00Z"),
+    });
+    await promise;
+    const a = emitted[0].spec.attrs;
+    expect(a["ratelimit.five_hour_pct"]).toBe(0);
+    expect(a["ratelimit.seven_day_pct"]).toBe(0);
+    expect(a["ratelimit.five_hour_pace"]).toBe(-0.2); // 0 - 1h/5h
+  });
+
+  test("missing resets_at → pace null (but pct still emitted)", async () => {
+    const { promise, emitted } = harness({
+      fetchUsage: async () => ({
+        status: 200,
+        body: usageBody({
+          five_hour: { utilization: 42 }, // no resets_at
+          seven_day: { utilization: 17 },
+        }),
+      }),
+    });
+    await promise;
+    const a = emitted[0].spec.attrs;
+    expect(a["ratelimit.five_hour_pct"]).toBe(42);
+    expect(a["ratelimit.five_hour_pace"]).toBe(null);
+    expect(a["ratelimit.seven_day_pace"]).toBe(null);
+  });
+});
+
+// ─── tickUsage — email/tier resolved once per account ────────────────────────
+
+describe("tickUsage — email resolution", () => {
+  test("email/tier are resolved exactly once per account", async () => {
+    const { promise, resolveCalls, fetchCalls } = harness({
+      accounts: [
+        { source: "active", token: TOKEN_A },
+        { source: "backup", token: TOKEN_B, file: "b.json" },
+      ],
+    });
+    await promise;
+    // One resolve + one fetch per account.
+    expect(resolveCalls.length).toBe(2);
+    expect(fetchCalls.length).toBe(2);
+    expect(resolveCalls.map((c) => c.token).sort()).toEqual([TOKEN_A, TOKEN_B].sort());
+  });
+
+  test("a null-resolving profile still emits with email null + label 'unknown'", async () => {
+    const { promise, emitted } = harness({ resolveEmail: async () => null });
+    await promise;
+    expect(emitted.length).toBe(1);
+    expect(emitted[0].spec.attrs["account.email"]).toBe(null);
+    expect(emitted[0].spec.label).toBe("unknown");
+  });
+
+  test("an account with no token is skipped (no resolve, no fetch, no emit)", async () => {
+    const { promise, emitted, fetchCalls, resolveCalls } = harness({
+      accounts: [{ source: "backup", token: null, file: "x.json" }],
+    });
+    const count = await promise;
+    expect(count).toBe(0);
+    expect(emitted.length).toBe(0);
+    expect(fetchCalls.length).toBe(0);
+    expect(resolveCalls.length).toBe(0);
+  });
+});
+
+// ─── tickUsage — multi-account + 429 shared limiter ──────────────────────────
+
+describe("tickUsage — multiple accounts", () => {
+  test("emits one event per healthy account, in order", async () => {
+    const { promise, emitted } = harness({
+      accounts: [
+        { source: "active", token: TOKEN_A },
+        { source: "backup", token: TOKEN_B, file: "b.json" },
+      ],
+      resolveEmail: async (token) =>
+        token === TOKEN_A
+          ? { email: "a@x.com", rateLimitTier: "t1", subscriptionType: "active" }
+          : { email: "b@x.com", rateLimitTier: "t2", subscriptionType: "active" },
+    });
+    const count = await promise;
+    expect(count).toBe(2);
+    expect(emitted.map((e) => e.spec.attrs["account.email"])).toEqual(["a@x.com", "b@x.com"]);
+  });
+
+  test("a 429 on the FIRST account stops the run — no emit for it or later accounts", async () => {
+    const fetchTokens = [];
+    const { promise, emitted } = harness({
+      accounts: [
+        { source: "active", token: TOKEN_A },
+        { source: "backup", token: TOKEN_B, file: "b.json" },
+      ],
+      fetchUsage: async (token) => {
+        fetchTokens.push(token);
+        return { status: 429, body: null };
+      },
+    });
+    const count = await promise;
+    expect(count).toBe(0);
+    expect(emitted.length).toBe(0);
+    // The shared limiter stops the loop: account B is never even fetched.
+    expect(fetchTokens).toEqual([TOKEN_A]);
+  });
+
+  test("a 429 on the SECOND account keeps the first emit, skips the rest", async () => {
+    const fetchTokens = [];
+    const { promise, emitted } = harness({
+      accounts: [
+        { source: "active", token: TOKEN_A },
+        { source: "backup", token: TOKEN_B, file: "b.json" },
+        { source: "backup", token: "FAKE-token-c", file: "c.json" },
+      ],
+      fetchUsage: async (token) => {
+        fetchTokens.push(token);
+        return token === TOKEN_A ? { status: 200, body: usageBody() } : { status: 429, body: null };
+      },
+    });
+    const count = await promise;
+    expect(count).toBe(1); // only A emitted
+    expect(emitted.length).toBe(1);
+    // A fetched + B fetched (429 → break); C never fetched.
+    expect(fetchTokens).toEqual([TOKEN_A, TOKEN_B]);
+  });
+});
+
+// ─── tickUsage — non-200 / null body / resilience ────────────────────────────
+
+describe("tickUsage — non-200 / resilience", () => {
+  test("a non-200 (non-429) skips that account's emit but continues to the next", async () => {
+    const { promise, emitted } = harness({
+      accounts: [
+        { source: "active", token: TOKEN_A },
+        { source: "backup", token: TOKEN_B, file: "b.json" },
+      ],
+      fetchUsage: async (token) =>
+        token === TOKEN_A ? { status: 500, body: null } : { status: 200, body: usageBody() },
+    });
+    const count = await promise;
+    expect(count).toBe(1); // only B emitted; A's 500 is skipped, not a stop
+    expect(emitted.length).toBe(1);
+  });
+
+  test("a 200 with null body emits nothing but does not stop the run", async () => {
+    const { promise, emitted } = harness({
+      accounts: [
+        { source: "active", token: TOKEN_A },
+        { source: "backup", token: TOKEN_B, file: "b.json" },
+      ],
+      fetchUsage: async (token) =>
+        token === TOKEN_A ? { status: 200, body: null } : { status: 200, body: usageBody() },
+    });
+    expect(await promise).toBe(1);
+    expect(emitted.length).toBe(1);
+  });
+
+  test("a throwing fetchUsage for one account does not crash the run", async () => {
+    const { promise, emitted } = harness({
+      accounts: [
+        { source: "active", token: TOKEN_A },
+        { source: "backup", token: TOKEN_B, file: "b.json" },
+      ],
+      fetchUsage: async (token) => {
+        if (token === TOKEN_A) throw new Error("boom");
+        return { status: 200, body: usageBody() };
+      },
+    });
+    await expect(promise).resolves.toBe(1);
+    expect(emitted.length).toBe(1);
+  });
+
+  test("an empty accounts list emits nothing and returns 0", async () => {
+    const { promise, emitted } = harness({ accounts: [] });
+    expect(await promise).toBe(0);
+    expect(emitted.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

A new **standalone host-telemetry agent** lives at `plugins/dev/scripts/catalyst-agent/`. It is a self-contained process — **zero npm deps** (`node:*` builtins only, runs unchanged under `node>=18` and `bun`) that **does not import from execution-core**. Each launchd `StartInterval` tick samples three domains and emits OTel log envelopes whose shape matches execution-core events, so the catalyst-otel collector / Loki dashboards pick them up uniformly. Domains are imported lazily and run with per-domain failure isolation (one domain throwing never stops the others).

### The 3 domains

| `event.name`                  | entity  | what it samples                                                                                                  | toggle (env)             |
| ----------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------ |
| `account.ratelimit.sampled`   | account | Per-account Claude rate-limit usage — **multi-account**: the locally-active account (Keychain / `~/.claude/.credentials.json`) **plus** every `claude-swap` backup (refreshed in-memory). One event per account; 5h/7d/per-model buckets + a forward-looking burn pace. On HTTP 429 it stops the remaining accounts this run. | `CATALYST_AGENT_USAGE`   |
| `host.metrics.sampled`        | host    | One event/tick — cpu / mem / disk / load probes (macOS + Linux); a failed probe drops just that attribute.       | `CATALYST_AGENT_HOST`    |
| `host.process.sampled`        | host    | One event per top-N process by RSS; each attributed to a Catalyst worker (ticket/phase) by joining the execution-core worker-signal files. Cross-platform `ps` parsing (macOS 16-char `comm` healing vs Linux natural width). | `CATALYST_AGENT_PROCESS` |

Each toggle defaults **on**; set it to `0` to opt out (mirrors the execution-core `CATALYST_*` kill-switch convention). Secrets hygiene is a hard rule throughout: OAuth tokens are read into locals and never logged, echoed, or placed in an error message.

### Approach A / B emit modes

Selected by `CATALYST_AGENT_EMIT` (default `eventlog`); a typo falls back to `eventlog` so telemetry is never silently dropped to nowhere:

- **Approach A — `eventlog`**: append each envelope as one JSONL line to `~/catalyst/events/<YYYY-MM UTC>.jsonl` (synchronous `appendFileSync`; same path convention as execution-core / orch-monitor).
- **Approach B — `otlp`**: POST OTLP/HTTP JSON logs to `<CATALYST_AGENT_OTLP_ENDPOINT>/v1/logs`. The POST is **awaited before the `--once` tick returns** (`drainPending`), so a launchd run never exits with a request still in flight. Numbers emit as `doubleValue` for a stable per-key OTLP type (avoids int/double oscillation across ticks).
- **`both`**: do both.

Value attributes are placed as dot-form log-record attributes (e.g. `host.cpu_pct`, `ratelimit.five_hour_pct`) so the collector renames dot→underscore and Loki promotes them to labels; a `body.payload` mirror carries the high-cardinality / human fields. An attribute is included only when non-null (the `put()` pattern) so the collector never promotes an empty label.

### Env knobs

| Variable                       | Default                   | Meaning                                          |
| ------------------------------ | ------------------------- | ------------------------------------------------ |
| `CATALYST_AGENT_EMIT`          | `eventlog`                | `eventlog` \| `otlp` \| `both`                   |
| `CATALYST_AGENT_OTLP_ENDPOINT` | _none_                    | base URL; `/v1/logs` is appended on POST         |
| `CATALYST_AGENT_OTLP_HEADERS`  | _none_                    | extra OTLP headers, `k=v,k=v`                    |
| `CATALYST_AGENT_INTERVAL_MS`   | `300000` (floor `180000`) | tick cadence (3-min floor matches the usage-poll floor so a misset env can't hammer the endpoint into a persistent 429) |
| `CATALYST_AGENT_TOP_N`         | `10`                      | top-N processes by RSS (`host.process.sampled`)  |
| `CATALYST_AGENT_USAGE`         | on                        | `0` disables the account rate-limit domain        |
| `CATALYST_AGENT_HOST`          | on                        | `0` disables the host.metrics domain              |
| `CATALYST_AGENT_PROCESS`       | on                        | `0` disables the host.process domain              |
| `CATALYST_DIR`                 | `~/catalyst`              | event-log root (`<dir>/events/<YYYY-MM>.jsonl`)   |

CLI: `--once` (one tick of each enabled domain, exit 0 — the launchd path), `--loop` (continuous on the configured interval — interactive/manual), `--install` (print launchd instructions), `--help`. A `com.catalyst.agent.plist` + idempotent `install.sh` are included for the launchd `--once` path.

## Test evidence

**`bun test` — 193 pass / 0 fail, 471 `expect()` calls, across 7 files (~2.7s).**

```
 193 pass
 0 fail
 471 expect() calls
Ran 193 tests across 7 files. [2.66s]
```

(The warnings in test output are the deliberately-exercised failure paths — 429 stop, non-200 skip, refresh failure, ps/fs/emit exceptions, EISDIR append failure, ECONNREFUSED — asserting the never-throw / per-domain-isolation guarantees.)

**Smoke (`--once`, isolated `CATALYST_DIR`, host + process domains):**
- `--help` → exit `0`; `--once` → exit `0`.
- pino-unavailable warning confirmed the console-shim graceful-degradation path (zero npm deps).
- Wrote **11 envelopes** to `events/2026-06.jsonl`: `1 × host.metrics.sampled` + `10 × host.process.sampled` (top-N=10).
- Envelope shape verified: `ts,id,observedTs,severityText,severityNumber,traceId,spanId,resource,body,attributes` with dot-form attributes, e.g. `host.cpu_pct`, `host.cpu_count`, `host.load1`, `host.mem_used_pct`, `host.disk_used_pct`, and `event.{name,entity,action,label}`.

Self-containment confirmed: no `import` from execution-core (only docstring/comment references explaining the mirrored shapes).

## Migration note

The existing daemon side-cars (the execution-core memory sampler, the CTL-787 account rate-limit poller, etc.) **keep running unchanged during migration** — this PR is purely additive (17 new files, no edits to existing code) and does not retire or alter any current sampler. Retirement of the now-redundant side-cars is intentionally deferred to a **follow-up child ticket** so the cutover is observable (run both, compare, then retire) rather than a flag-day swap.

Refs CTL-812

🤖 Generated with [Claude Code](https://claude.com/claude-code)
