### PR TITLE
feat(dev): Gateway L1(a) — full-descriptor ticket_state schema + UUID→identifier index (CTL-821)

### DIFF
--- a/plugins/dev/scripts/broker/broker-state.mjs
+++ b/plugins/dev/scripts/broker/broker-state.mjs
@@ -97,6 +97,32 @@ export function openBrokerStateDb(dbPath = DEFAULT_DB_PATH) {
       updated_at   TEXT NOT NULL
     )
   `);
+  // CTL-821 (Gateway L1 child a): grow ticket_state into the full Linear-truth
+  // descriptor — additive ALTERs in try/catch (the CTL-402 pattern), so an
+  // existing live filter-state.db migrates in place with zero data loss and a
+  // re-open is a no-op. `removed_at` is the removed flag (null = present);
+  // `uuid` carries the Linear entityId so a `remove` webhook (whose payload
+  // has ONLY the UUID, never the CTL-123 identifier) can be resolved.
+  for (const col of [
+    "relations TEXT",
+    "labels TEXT",
+    "priority INTEGER",
+    "resolution TEXT",
+    "assignee TEXT",
+    "uuid TEXT",
+    "removed_at TEXT",
+  ]) {
+    try {
+      db.run(`ALTER TABLE ticket_state ADD COLUMN ${col}`);
+    } catch {
+      /* already exists */
+    }
+  }
+  db.run(`
+    CREATE INDEX IF NOT EXISTS idx_ticket_state_uuid
+      ON ticket_state(uuid)
+      WHERE uuid IS NOT NULL
+  `);
 
   // CTL-403: waiting_sessions tracks active wait-for loops so the watchdog can
   // distinguish 'silently dead' (no heartbeat AND no active wait) from
@@ -458,6 +484,120 @@ export function getTicketState(ticket) {
     prNumber: row.pr_number,
     updatedAt: row.updated_at,
   };
+}
+
+// ─── ticket descriptor helpers (CTL-821, Gateway L1 child a) ─────────────────
+
+// upsertTicketDescriptor — COALESCE-sticky like upsertTicketState: an absent
+// field never regresses what a previous (possibly richer) webhook wrote.
+// relations/labels are stored as JSON text (mirrors how fetchTicketRelations
+// hydrates its store). `removed` is tri-state: true stamps removed_at (sticky
+// on the first stamp), false clears it (Linear archive→unarchive arrives as
+// `update`), undefined leaves it untouched.
+export function upsertTicketDescriptor({
+  ticket,
+  state,
+  prNumber,
+  relations,
+  labels,
+  priority,
+  resolution,
+  assignee,
+  uuid,
+  removed,
+}) {
+  if (!ticket) return;
+  const json = (v) => (v === undefined || v === null ? null : JSON.stringify(v));
+  ensure().run(
+    `INSERT INTO ticket_state
+       (ticket, linear_state, pr_number, relations, labels, priority, resolution, assignee, uuid, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(ticket) DO UPDATE SET
+       linear_state = COALESCE(excluded.linear_state, linear_state),
+       pr_number    = COALESCE(excluded.pr_number, pr_number),
+       relations    = COALESCE(excluded.relations, relations),
+       labels       = COALESCE(excluded.labels, labels),
+       priority     = COALESCE(excluded.priority, priority),
+       resolution   = COALESCE(excluded.resolution, resolution),
+       assignee     = COALESCE(excluded.assignee, assignee),
+       uuid         = COALESCE(excluded.uuid, uuid),
+       updated_at   = excluded.updated_at`,
+    [
+      ticket,
+      state ?? null,
+      prNumber ?? null,
+      json(relations),
+      json(labels),
+      priority ?? null,
+      resolution ?? null,
+      assignee ?? null,
+      uuid ?? null,
+      nowIso(),
+    ]
+  );
+  if (removed === true) {
+    ensure().run(`UPDATE ticket_state SET removed_at = COALESCE(removed_at, ?) WHERE ticket = ?`, [
+      nowIso(),
+      ticket,
+    ]);
+  } else if (removed === false) {
+    ensure().run(`UPDATE ticket_state SET removed_at = NULL WHERE ticket = ?`, [ticket]);
+  }
+}
+
+function rowToTicketDescriptor(row) {
+  const parse = (s) => {
+    if (s === null || s === undefined) return null;
+    try {
+      return JSON.parse(s);
+    } catch {
+      return null;
+    }
+  };
+  return {
+    ticket: row.ticket,
+    state: row.linear_state,
+    prNumber: row.pr_number,
+    relations: parse(row.relations),
+    labels: parse(row.labels),
+    priority: row.priority ?? null,
+    resolution: row.resolution ?? null,
+    assignee: row.assignee ?? null,
+    uuid: row.uuid ?? null,
+    removed: row.removed_at != null,
+    removedAt: row.removed_at ?? null,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function getTicketDescriptor(ticket) {
+  const row = ensure().prepare(`SELECT * FROM ticket_state WHERE ticket = ?`).get(ticket);
+  return row ? rowToTicketDescriptor(row) : null;
+}
+
+// getTicketDescriptorByUuid — the UUID→identifier index lookup. Linear's
+// `remove` webhook payload carries only the entityId UUID; this resolves it to
+// the descriptor row populated by earlier create/update webhooks.
+export function getTicketDescriptorByUuid(uuid) {
+  if (!uuid) return null;
+  const row = ensure().prepare(`SELECT * FROM ticket_state WHERE uuid = ?`).get(uuid);
+  return row ? rowToTicketDescriptor(row) : null;
+}
+
+// markTicketRemovedByUuid — the `remove`-webhook write path: resolve the UUID,
+// stamp removed_at (sticky — a duplicate remove keeps the first timestamp).
+// Returns the resolved identifier, or null when the UUID was never indexed
+// (the reconcile backstop, child e, owns that gap).
+export function markTicketRemovedByUuid(uuid) {
+  if (!uuid) return null;
+  const row = ensure().prepare(`SELECT ticket FROM ticket_state WHERE uuid = ?`).get(uuid);
+  if (!row) return null;
+  const ts = nowIso();
+  ensure().run(
+    `UPDATE ticket_state SET removed_at = COALESCE(removed_at, ?), updated_at = ? WHERE ticket = ?`,
+    [ts, ts, row.ticket]
+  );
+  return { ticket: row.ticket };
 }
 
 // ─── worker_state helpers (CTL-532) ──────────────────────────────────────────

--- a/plugins/dev/scripts/broker/broker-state.mjs
+++ b/plugins/dev/scripts/broker/broker-state.mjs
@@ -31,6 +31,9 @@ export function openBrokerStateDb(dbPath = DEFAULT_DB_PATH) {
   mkdirSync(dirname(dbPath), { recursive: true });
   db = new Database(dbPath, { create: true });
   db.run("PRAGMA journal_mode=WAL");
+  // CTL-821: don't fail instantly on transient WAL contention (live broker +
+  // orch-monitor + test drivers can hold handles on the same file).
+  db.run("PRAGMA busy_timeout = 5000");
 
   // Legacy filter_state table (CTL-284) — still needed for PR↔deploy correlation.
   db.run(`
@@ -118,8 +121,13 @@ export function openBrokerStateDb(dbPath = DEFAULT_DB_PATH) {
       /* already exists */
     }
   }
+  // UNIQUE so a buggy upstream writing one entityId onto two identifiers fails
+  // loud instead of silently shadowing a row in the remove-webhook resolution.
+  // Drop-then-create migrates any interim non-unique version of this index;
+  // ticket_state is small (hundreds of rows) so the per-boot rebuild is ~ms.
+  db.run(`DROP INDEX IF EXISTS idx_ticket_state_uuid`);
   db.run(`
-    CREATE INDEX IF NOT EXISTS idx_ticket_state_uuid
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_ticket_state_uuid
       ON ticket_state(uuid)
       WHERE uuid IS NOT NULL
   `);
@@ -488,61 +496,78 @@ export function getTicketState(ticket) {
 
 // ─── ticket descriptor helpers (CTL-821, Gateway L1 child a) ─────────────────
 
-// upsertTicketDescriptor — COALESCE-sticky like upsertTicketState: an absent
-// field never regresses what a previous (possibly richer) webhook wrote.
-// relations/labels are stored as JSON text (mirrors how fetchTicketRelations
-// hydrates its store). `removed` is tri-state: true stamps removed_at (sticky
-// on the first stamp), false clears it (Linear archive→unarchive arrives as
-// `update`), undefined leaves it untouched.
-export function upsertTicketDescriptor({
-  ticket,
-  state,
-  prNumber,
-  relations,
-  labels,
-  priority,
-  resolution,
-  assignee,
-  uuid,
-  removed,
-}) {
+// Descriptor field → column map. Internal constant — the dynamic SQL below
+// only ever interpolates these fixed column names, never caller input.
+const DESCRIPTOR_COLUMNS = {
+  state: "linear_state",
+  prNumber: "pr_number",
+  relations: "relations",
+  labels: "labels",
+  priority: "priority",
+  resolution: "resolution",
+  assignee: "assignee",
+  uuid: "uuid",
+};
+
+// upsertTicketDescriptor — KEY-PRESENCE semantics (not COALESCE): a field
+// ABSENT from the input keeps its stored value; a field present with an
+// explicit null CLEARS it. This is load-bearing for the Assignment layer —
+// a Linear unassign webhook carries assignee:null and MUST be expressible
+// (back-off-when-human-assignee-removed keys off it). Webhook write-through
+// callers should pass exactly the fields the webhook carried.
+//
+// relations/labels must be arrays/objects (stored as JSON text); passing a
+// pre-stringified JSON string throws — silent double-encoding would hand
+// child (b) a string where readers expect an array.
+//
+// `removed` is tri-state: true stamps removed_at (sticky — the FIRST removal
+// timestamp survives duplicates), false clears it (Linear archive→unarchive
+// arrives as `update`), undefined leaves it untouched. The whole upsert runs
+// in one transaction so concurrent WAL readers (orch-monitor, the child-c
+// read API) never observe the row between the insert and the removed stamp.
+export function upsertTicketDescriptor(input = {}) {
+  const { ticket, removed } = input;
   if (!ticket) return;
-  const json = (v) => (v === undefined || v === null ? null : JSON.stringify(v));
-  ensure().run(
-    `INSERT INTO ticket_state
-       (ticket, linear_state, pr_number, relations, labels, priority, resolution, assignee, uuid, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(ticket) DO UPDATE SET
-       linear_state = COALESCE(excluded.linear_state, linear_state),
-       pr_number    = COALESCE(excluded.pr_number, pr_number),
-       relations    = COALESCE(excluded.relations, relations),
-       labels       = COALESCE(excluded.labels, labels),
-       priority     = COALESCE(excluded.priority, priority),
-       resolution   = COALESCE(excluded.resolution, resolution),
-       assignee     = COALESCE(excluded.assignee, assignee),
-       uuid         = COALESCE(excluded.uuid, uuid),
-       updated_at   = excluded.updated_at`,
-    [
-      ticket,
-      state ?? null,
-      prNumber ?? null,
-      json(relations),
-      json(labels),
-      priority ?? null,
-      resolution ?? null,
-      assignee ?? null,
-      uuid ?? null,
-      nowIso(),
-    ]
-  );
-  if (removed === true) {
-    ensure().run(`UPDATE ticket_state SET removed_at = COALESCE(removed_at, ?) WHERE ticket = ?`, [
-      nowIso(),
-      ticket,
-    ]);
-  } else if (removed === false) {
-    ensure().run(`UPDATE ticket_state SET removed_at = NULL WHERE ticket = ?`, [ticket]);
+  const cols = [];
+  const vals = [];
+  for (const [field, col] of Object.entries(DESCRIPTOR_COLUMNS)) {
+    if (!(field in input) || input[field] === undefined) continue; // absent → keep
+    let v = input[field];
+    if ((field === "relations" || field === "labels") && v !== null) {
+      if (typeof v === "string") {
+        throw new TypeError(
+          `upsertTicketDescriptor: ${field} must be an array/object, not a pre-stringified JSON string`
+        );
+      }
+      v = JSON.stringify(v);
+    }
+    cols.push(col);
+    vals.push(v);
   }
+  const d = ensure();
+  const ts = nowIso();
+  d.transaction(() => {
+    const insertCols = ["ticket", ...cols, "updated_at"];
+    const placeholders = insertCols.map(() => "?").join(", ");
+    const setClauses = [
+      ...cols.map((c) => `${c} = excluded.${c}`),
+      "updated_at = excluded.updated_at",
+    ];
+    d.run(
+      `INSERT INTO ticket_state (${insertCols.join(", ")})
+       VALUES (${placeholders})
+       ON CONFLICT(ticket) DO UPDATE SET ${setClauses.join(", ")}`,
+      [ticket, ...vals, ts]
+    );
+    if (removed === true) {
+      d.run(`UPDATE ticket_state SET removed_at = COALESCE(removed_at, ?) WHERE ticket = ?`, [
+        ts,
+        ticket,
+      ]);
+    } else if (removed === false) {
+      d.run(`UPDATE ticket_state SET removed_at = NULL WHERE ticket = ?`, [ticket]);
+    }
+  })();
 }
 
 function rowToTicketDescriptor(row) {

--- a/plugins/dev/scripts/broker/ticket-descriptor.test.mjs
+++ b/plugins/dev/scripts/broker/ticket-descriptor.test.mjs
@@ -1,0 +1,191 @@
+// Unit tests for the CTL-821 Gateway descriptor schema (L1 child a).
+// ticket_state grows from the 4-column routing index to the full descriptor
+// {state, relations, labels, priority, resolution, assignee, uuid, updated_at}
+// + a removed flag, via the CTL-402 additive-ALTER pattern, plus the
+// UUID→identifier index that Linear's `remove` webhook payload requires
+// (it carries only the entityId UUID, never the CTL-123 identifier).
+// Run: bun test plugins/dev/scripts/broker/ticket-descriptor.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  openBrokerStateDb,
+  closeBrokerStateDb,
+  upsertTicketState,
+  getTicketState,
+  upsertTicketDescriptor,
+  getTicketDescriptor,
+  getTicketDescriptorByUuid,
+  markTicketRemovedByUuid,
+} from "./broker-state.mjs";
+
+let tmpDir;
+let dbPath;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "ticket-descriptor-test-"));
+  dbPath = join(tmpDir, "test.db");
+  openBrokerStateDb(dbPath);
+});
+
+afterEach(() => {
+  closeBrokerStateDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const FULL = {
+  ticket: "CTL-821",
+  state: "Backlog",
+  prNumber: 1400,
+  relations: [{ type: "blocks", id: "CTL-780" }],
+  labels: ["feature", "broker"],
+  priority: 2,
+  resolution: "exists",
+  assignee: "ff78d890-7906-4c22-b2f5-020bd150c790",
+  uuid: "11111111-2222-3333-4444-555555555555",
+};
+
+// ─── descriptor round-trip ───────────────────────────────────────────────────
+
+describe("upsertTicketDescriptor / getTicketDescriptor", () => {
+  test("full descriptor round-trips, removed defaults false", () => {
+    upsertTicketDescriptor(FULL);
+    const d = getTicketDescriptor("CTL-821");
+    expect(d.ticket).toBe("CTL-821");
+    expect(d.state).toBe("Backlog");
+    expect(d.prNumber).toBe(1400);
+    expect(d.relations).toEqual([{ type: "blocks", id: "CTL-780" }]);
+    expect(d.labels).toEqual(["feature", "broker"]);
+    expect(d.priority).toBe(2);
+    expect(d.resolution).toBe("exists");
+    expect(d.assignee).toBe(FULL.assignee);
+    expect(d.uuid).toBe(FULL.uuid);
+    expect(d.removed).toBe(false);
+    expect(d.removedAt).toBeNull();
+    expect(d.updatedAt).toBeTruthy();
+  });
+
+  test("partial upsert is COALESCE-sticky — absent fields survive", () => {
+    upsertTicketDescriptor(FULL);
+    upsertTicketDescriptor({ ticket: "CTL-821", state: "Todo" });
+    const d = getTicketDescriptor("CTL-821");
+    expect(d.state).toBe("Todo");
+    expect(d.labels).toEqual(["feature", "broker"]);
+    expect(d.assignee).toBe(FULL.assignee);
+    expect(d.uuid).toBe(FULL.uuid);
+    expect(d.priority).toBe(2);
+  });
+
+  test("unknown ticket reads null", () => {
+    expect(getTicketDescriptor("CTL-0")).toBeNull();
+  });
+});
+
+// ─── UUID → identifier index ─────────────────────────────────────────────────
+
+describe("getTicketDescriptorByUuid", () => {
+  test("resolves a descriptor row by its Linear entityId UUID", () => {
+    upsertTicketDescriptor(FULL);
+    const d = getTicketDescriptorByUuid(FULL.uuid);
+    expect(d?.ticket).toBe("CTL-821");
+  });
+
+  test("unknown uuid resolves null", () => {
+    expect(getTicketDescriptorByUuid("dead-beef")).toBeNull();
+  });
+});
+
+// ─── removed flag lifecycle ──────────────────────────────────────────────────
+
+describe("markTicketRemovedByUuid", () => {
+  test("flags the row removed and returns the resolved identifier", () => {
+    upsertTicketDescriptor(FULL);
+    const res = markTicketRemovedByUuid(FULL.uuid);
+    expect(res).toEqual({ ticket: "CTL-821" });
+    const d = getTicketDescriptor("CTL-821");
+    expect(d.removed).toBe(true);
+    expect(d.removedAt).toBeTruthy();
+  });
+
+  test("unknown uuid is a null no-op", () => {
+    expect(markTicketRemovedByUuid("not-there")).toBeNull();
+  });
+
+  test("a later upsert with removed:false resurrects (archive→unarchive)", () => {
+    upsertTicketDescriptor(FULL);
+    markTicketRemovedByUuid(FULL.uuid);
+    upsertTicketDescriptor({ ticket: "CTL-821", removed: false });
+    const d = getTicketDescriptor("CTL-821");
+    expect(d.removed).toBe(false);
+    expect(d.removedAt).toBeNull();
+  });
+
+  test("upsert without removed never clears an existing removed flag", () => {
+    upsertTicketDescriptor(FULL);
+    markTicketRemovedByUuid(FULL.uuid);
+    upsertTicketDescriptor({ ticket: "CTL-821", state: "Canceled" });
+    expect(getTicketDescriptor("CTL-821").removed).toBe(true);
+  });
+});
+
+// ─── additive migration on an existing legacy DB ─────────────────────────────
+
+describe("schema migration", () => {
+  test("ALTER-on-existing-DB preserves legacy rows; descriptor fields default null", () => {
+    closeBrokerStateDb();
+    rmSync(dbPath, { force: true });
+    // Hand-create a LEGACY 4-column ticket_state with one row, as a pre-CTL-821
+    // filter-state.db would have it.
+    const legacy = new Database(dbPath, { create: true });
+    legacy.run(`
+      CREATE TABLE ticket_state (
+        ticket       TEXT PRIMARY KEY,
+        linear_state TEXT,
+        pr_number    INTEGER,
+        updated_at   TEXT NOT NULL
+      )
+    `);
+    legacy.run(`INSERT INTO ticket_state VALUES ('CTL-100', 'Done', 999, '2026-01-01T00:00:00Z')`);
+    legacy.close();
+
+    openBrokerStateDb(dbPath);
+    const d = getTicketDescriptor("CTL-100");
+    expect(d.state).toBe("Done");
+    expect(d.prNumber).toBe(999);
+    expect(d.relations).toBeNull();
+    expect(d.labels).toBeNull();
+    expect(d.assignee).toBeNull();
+    expect(d.uuid).toBeNull();
+    expect(d.removed).toBe(false);
+    // and the migrated row accepts descriptor writes
+    upsertTicketDescriptor({ ticket: "CTL-100", uuid: "u-100", labels: ["bug"] });
+    expect(getTicketDescriptorByUuid("u-100")?.ticket).toBe("CTL-100");
+  });
+
+  test("re-opening an already-migrated DB is a no-op (idempotent ALTERs)", () => {
+    upsertTicketDescriptor(FULL);
+    closeBrokerStateDb();
+    openBrokerStateDb(dbPath);
+    expect(getTicketDescriptor("CTL-821").uuid).toBe(FULL.uuid);
+  });
+});
+
+// ─── legacy API interop ──────────────────────────────────────────────────────
+
+describe("legacy ticket_state API interop", () => {
+  test("upsertTicketState still works and never clobbers descriptor fields", () => {
+    upsertTicketDescriptor(FULL);
+    upsertTicketState({ ticket: "CTL-821", linearState: "PR", prNumber: 1401 });
+    const d = getTicketDescriptor("CTL-821");
+    expect(d.state).toBe("PR");
+    expect(d.prNumber).toBe(1401);
+    expect(d.labels).toEqual(["feature", "broker"]);
+    expect(d.uuid).toBe(FULL.uuid);
+    const legacyView = getTicketState("CTL-821");
+    expect(legacyView.linearState).toBe("PR");
+    expect(legacyView.prNumber).toBe(1401);
+  });
+});

--- a/plugins/dev/scripts/broker/ticket-descriptor.test.mjs
+++ b/plugins/dev/scripts/broker/ticket-descriptor.test.mjs
@@ -68,7 +68,7 @@ describe("upsertTicketDescriptor / getTicketDescriptor", () => {
     expect(d.updatedAt).toBeTruthy();
   });
 
-  test("partial upsert is COALESCE-sticky — absent fields survive", () => {
+  test("key-presence: absent fields survive a partial upsert", () => {
     upsertTicketDescriptor(FULL);
     upsertTicketDescriptor({ ticket: "CTL-821", state: "Todo" });
     const d = getTicketDescriptor("CTL-821");
@@ -79,8 +79,40 @@ describe("upsertTicketDescriptor / getTicketDescriptor", () => {
     expect(d.priority).toBe(2);
   });
 
+  test("key-presence: explicit null CLEARS a field (Linear unassign webhook)", () => {
+    upsertTicketDescriptor(FULL);
+    upsertTicketDescriptor({ ticket: "CTL-821", assignee: null });
+    const d = getTicketDescriptor("CTL-821");
+    expect(d.assignee).toBeNull();
+    // siblings untouched
+    expect(d.uuid).toBe(FULL.uuid);
+    expect(d.labels).toEqual(["feature", "broker"]);
+  });
+
+  test("priority can go back to 0 (Linear no-priority) and to null", () => {
+    upsertTicketDescriptor(FULL);
+    upsertTicketDescriptor({ ticket: "CTL-821", priority: 0 });
+    expect(getTicketDescriptor("CTL-821").priority).toBe(0);
+    upsertTicketDescriptor({ ticket: "CTL-821", priority: null });
+    expect(getTicketDescriptor("CTL-821").priority).toBeNull();
+  });
+
+  test("pre-stringified JSON for relations/labels throws loud", () => {
+    expect(() =>
+      upsertTicketDescriptor({ ticket: "CTL-821", relations: '[{"type":"blocks"}]' })
+    ).toThrow(TypeError);
+    expect(() => upsertTicketDescriptor({ ticket: "CTL-821", labels: '["bug"]' })).toThrow(
+      TypeError
+    );
+  });
+
   test("unknown ticket reads null", () => {
     expect(getTicketDescriptor("CTL-0")).toBeNull();
+  });
+
+  test("duplicate uuid on a second ticket fails loud (UNIQUE index)", () => {
+    upsertTicketDescriptor(FULL);
+    expect(() => upsertTicketDescriptor({ ticket: "CTL-999", uuid: FULL.uuid })).toThrow();
   });
 });
 
@@ -95,6 +127,11 @@ describe("getTicketDescriptorByUuid", () => {
 
   test("unknown uuid resolves null", () => {
     expect(getTicketDescriptorByUuid("dead-beef")).toBeNull();
+  });
+
+  test("matches uuid only — a ticket IDENTIFIER does not resolve", () => {
+    upsertTicketDescriptor(FULL);
+    expect(getTicketDescriptorByUuid("CTL-821")).toBeNull();
   });
 });
 
@@ -128,6 +165,23 @@ describe("markTicketRemovedByUuid", () => {
     markTicketRemovedByUuid(FULL.uuid);
     upsertTicketDescriptor({ ticket: "CTL-821", state: "Canceled" });
     expect(getTicketDescriptor("CTL-821").removed).toBe(true);
+  });
+
+  test("removed_at is sticky — a duplicate removal keeps the FIRST timestamp", () => {
+    upsertTicketDescriptor(FULL);
+    markTicketRemovedByUuid(FULL.uuid);
+    const first = getTicketDescriptor("CTL-821").removedAt;
+    Bun.sleepSync(5); // ensure a later wall-clock would differ if overwritten
+    markTicketRemovedByUuid(FULL.uuid);
+    upsertTicketDescriptor({ ticket: "CTL-821", removed: true });
+    expect(getTicketDescriptor("CTL-821").removedAt).toBe(first);
+  });
+
+  test("insert-then-remove path: brand-new row with removed:true lands removed", () => {
+    upsertTicketDescriptor({ ticket: "CTL-NEW", uuid: "u-new", removed: true });
+    const d = getTicketDescriptor("CTL-NEW");
+    expect(d.removed).toBe(true);
+    expect(d.removedAt).toBeTruthy();
   });
 });
 
@@ -170,6 +224,51 @@ describe("schema migration", () => {
     closeBrokerStateDb();
     openBrokerStateDb(dbPath);
     expect(getTicketDescriptor("CTL-821").uuid).toBe(FULL.uuid);
+  });
+
+  test("PARTIALLY-migrated DB (aborted earlier boot) self-heals on open", () => {
+    closeBrokerStateDb();
+    rmSync(dbPath, { force: true });
+    // Legacy 4 columns plus a SUBSET of the new ones — as if a prior boot's
+    // ALTER loop died midway. The next open must add only the missing columns.
+    const partial = new Database(dbPath, { create: true });
+    partial.run(`
+      CREATE TABLE ticket_state (
+        ticket       TEXT PRIMARY KEY,
+        linear_state TEXT,
+        pr_number    INTEGER,
+        updated_at   TEXT NOT NULL,
+        relations    TEXT,
+        labels       TEXT,
+        priority     INTEGER
+      )
+    `);
+    partial.run(
+      `INSERT INTO ticket_state (ticket, linear_state, pr_number, updated_at, labels)
+       VALUES ('CTL-200', 'Todo', NULL, '2026-01-01T00:00:00Z', '["bug"]')`
+    );
+    partial.close();
+
+    openBrokerStateDb(dbPath);
+    const d = getTicketDescriptor("CTL-200");
+    expect(d.state).toBe("Todo");
+    expect(d.labels).toEqual(["bug"]);
+    expect(d.assignee).toBeNull();
+    expect(d.removed).toBe(false);
+    upsertTicketDescriptor({ ticket: "CTL-200", uuid: "u-200", assignee: "bot" });
+    expect(getTicketDescriptorByUuid("u-200")?.assignee).toBe("bot");
+  });
+
+  test("corrupt JSON in a descriptor column reads null, never throws", () => {
+    upsertTicketDescriptor(FULL);
+    closeBrokerStateDb();
+    const raw = new Database(dbPath);
+    raw.run(`UPDATE ticket_state SET relations = '{not json' WHERE ticket = 'CTL-821'`);
+    raw.close();
+    openBrokerStateDb(dbPath);
+    const d = getTicketDescriptor("CTL-821");
+    expect(d.relations).toBeNull();
+    expect(d.labels).toEqual(["feature", "broker"]);
   });
 });
 


### PR DESCRIPTION
## Summary

First build slice of the **CTL-792 4-layer re-plan** (Gateway parent CTL-820): grows the broker's durable webhook-fed `ticket_state` (in the live `filter-state.db`) from the 4-column routing index into the Gateway's full Linear-truth descriptor — `{state, relations, labels, priority, resolution, assignee, uuid, updated_at}` + a `removed_at` flag — via additive `ALTER TABLE` in try/catch (the CTL-402 pattern). Zero data loss on a live DB; re-open is a no-op; partially-migrated DBs (aborted boot) self-heal.

## API (legacy `upsertTicketState`/`getTicketState` untouched)

- `upsertTicketDescriptor` — **key-presence semantics**: absent field = keep, explicit `null` = clear (a Linear *unassign* webhook is expressible — load-bearing for the Assignment layer's back-off rule). relations/labels stored as JSON text; pre-stringified strings throw loud. Tri-state `removed` (true = sticky first-timestamp stamp, false = archive→unarchive clear, undefined = keep), all in one transaction.
- `getTicketDescriptor` / `getTicketDescriptorByUuid` — the **UUID→identifier index** Linear's `remove` webhook requires (its payload carries only the entityId UUID). Index is UNIQUE — duplicate entityId writes fail loud.
- `markTicketRemovedByUuid` — the remove-webhook write path (consumed by child b, CTL-822).

## Verification

- TDD: 21 tests — round-trip, key-presence keep/clear, priority 0/null, loud JSON guard, uuid lookup + identifier-negative, duplicate-uuid throw, removed lifecycle (sticky/resurrect/never-implicit-clear/new-row), legacy-DB ALTER migration, partial-migration self-heal, idempotent re-open, corrupt-JSON null read, legacy-API interop. Full broker suite **379/379**.
- 3-lens adversarial verify workflow: the flagged MAJOR (COALESCE couldn't express field-clears) + all four hardening minors are fixed in the second commit. Verified safe against the live DB shape (additive only; ~ms index rebuild on a hundreds-of-rows table).

Part of CTL-820 (Gateway epic). Next slice: CTL-823 (localhost read API + daemon client, fresh-before-quarantine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)