### PR TITLE
feat(dev): Gateway L1(b) — webhook write-through with create/update/remove descriptor fold (CTL-822)

### DIFF
--- a/plugins/dev/scripts/broker/linear-descriptor-fold.test.mjs
+++ b/plugins/dev/scripts/broker/linear-descriptor-fold.test.mjs
@@ -1,0 +1,217 @@
+// Unit tests for the CTL-822 descriptor write-through (Gateway L1 child b).
+// Every linear.issue.* event must fold into the CTL-821 descriptor store —
+// and per the adversarial-verify finding, the fold MUST run on the LIVE path
+// (processEvent) with ZERO registered interests: it sits above the
+// `if (!interests.size) return` gate, mirroring the projectWorkerStateEvent
+// model, so the store stays current during idle periods. These tests drive
+// processEvent directly (not tryTicketLifecycleRoute) for exactly that reason.
+// Run: bun test plugins/dev/scripts/broker/linear-descriptor-fold.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  openBrokerStateDb,
+  closeBrokerStateDb,
+  getTicketDescriptor,
+  upsertTicketDescriptor,
+} from "./broker-state.mjs";
+import { processEvent } from "./router.mjs";
+import { clearInterests } from "./state.mjs";
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "descriptor-fold-test-"));
+  openBrokerStateDb(join(tmpDir, "test.db"));
+  // ZERO interests is the load-bearing case: the verify panel caught that a
+  // fold placed inside tryTicketLifecycleRoute was starved by processEvent's
+  // interests gate whenever the broker was idle.
+  clearInterests();
+});
+
+afterEach(() => {
+  closeBrokerStateDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// Legacy-flat envelope matching what the tailer hands processEvent: name via
+// `event`, payload via `detail` (canonical body.payload covered separately).
+function issueEvent(name, detail, ticket = detail.ticket) {
+  return {
+    event: name,
+    attributes: ticket ? { "linear.issue.identifier": ticket } : {},
+    detail,
+  };
+}
+
+describe("foldLinearIssueDescriptor via processEvent (zero interests — the live idle path)", () => {
+  test("issue.updated folds the full snapshot into the descriptor", () => {
+    processEvent(
+      issueEvent("linear.issue.updated", {
+        ticket: "CTL-1",
+        toState: "Todo",
+        toPriority: 2,
+        toAssigneeId: "user-1",
+        toLabels: ["feature", "broker"],
+        issueId: "uuid-1",
+      })
+    );
+    const d = getTicketDescriptor("CTL-1");
+    expect(d.state).toBe("Todo");
+    expect(d.priority).toBe(2);
+    expect(d.assignee).toBe("user-1");
+    expect(d.labels).toEqual(["feature", "broker"]);
+    expect(d.uuid).toBe("uuid-1");
+    expect(d.removed).toBe(false);
+  });
+
+  test("state_changed and created fold too (any linear.issue.* topic)", () => {
+    processEvent(
+      issueEvent("linear.issue.created", { ticket: "CTL-2", toState: "Backlog", issueId: "u-2" })
+    );
+    processEvent(issueEvent("linear.issue.state_changed", { ticket: "CTL-2", toState: "Todo" }));
+    const d = getTicketDescriptor("CTL-2");
+    expect(d.state).toBe("Todo");
+    expect(d.uuid).toBe("u-2"); // kept from the create (key-presence)
+  });
+
+  test("priority_changed topic folds too", () => {
+    processEvent(issueEvent("linear.issue.priority_changed", { ticket: "CTL-15", toPriority: 1 }));
+    expect(getTicketDescriptor("CTL-15").priority).toBe(1);
+  });
+
+  test("unassign IS cleared when the change is evidenced (assignee_changed)", () => {
+    upsertTicketDescriptor({ ticket: "CTL-3", assignee: "user-9", uuid: "u-3" });
+    processEvent(
+      issueEvent("linear.issue.assignee_changed", {
+        ticket: "CTL-3",
+        toAssigneeId: null,
+        updatedFromKeys: ["assigneeId"],
+      })
+    );
+    const d = getTicketDescriptor("CTL-3");
+    expect(d.assignee).toBeNull();
+    expect(d.uuid).toBe("u-3");
+  });
+
+  test("partial payload with toAssigneeId:null but NO change evidence keeps assignee", () => {
+    // Linear sends partial issue payloads (data.assignee omitted on an
+    // ASSIGNED issue) and the emitter always includes the key — a bare null
+    // must be treated as unknown, not an unassign.
+    upsertTicketDescriptor({ ticket: "CTL-13", assignee: "user-1" });
+    processEvent(
+      issueEvent("linear.issue.state_changed", {
+        ticket: "CTL-13",
+        toState: "PR",
+        toAssigneeId: null,
+        updatedFromKeys: ["stateId"],
+      })
+    );
+    expect(getTicketDescriptor("CTL-13").assignee).toBe("user-1");
+  });
+
+  test("create born-unassigned records the null assignee", () => {
+    processEvent(
+      issueEvent("linear.issue.created", {
+        action: "create",
+        ticket: "CTL-16",
+        toState: "Backlog",
+        toAssigneeId: null,
+        updatedFromKeys: [],
+      })
+    );
+    // stored row exists with explicit null assignee (not skipped)
+    const d = getTicketDescriptor("CTL-16");
+    expect(d.assignee).toBeNull();
+    expect(d.state).toBe("Backlog");
+  });
+
+  test("payload WITHOUT toAssigneeId key keeps the stored assignee", () => {
+    upsertTicketDescriptor({ ticket: "CTL-4", assignee: "user-9" });
+    processEvent(issueEvent("linear.issue.state_changed", { ticket: "CTL-4", toState: "PR" }));
+    expect(getTicketDescriptor("CTL-4").assignee).toBe("user-9");
+  });
+
+  test("toLabels [] is explicitly-empty (clears); toLabels null keeps", () => {
+    upsertTicketDescriptor({ ticket: "CTL-5", labels: ["bug"] });
+    processEvent(issueEvent("linear.issue.updated", { ticket: "CTL-5", toLabels: null }));
+    expect(getTicketDescriptor("CTL-5").labels).toEqual(["bug"]);
+    processEvent(issueEvent("linear.issue.updated", { ticket: "CTL-5", toLabels: [] }));
+    expect(getTicketDescriptor("CTL-5").labels).toEqual([]);
+  });
+
+  test("remove resolves by UUID alone (no identifier in payload)", () => {
+    processEvent(
+      issueEvent("linear.issue.created", { ticket: "CTL-6", toState: "Todo", issueId: "u-6" })
+    );
+    // remove carries ONLY the entityId — no ticket anywhere on the event
+    processEvent(issueEvent("linear.issue.removed", { issueId: "u-6" }, null));
+    const d = getTicketDescriptor("CTL-6");
+    expect(d.removed).toBe(true);
+    expect(d.removedAt).toBeTruthy();
+  });
+
+  test("remove prefers the UUID index over a stale identifier on the event", () => {
+    processEvent(
+      issueEvent("linear.issue.created", { ticket: "CTL-12", toState: "Todo", issueId: "u-12" })
+    );
+    // resolves u-12 → CTL-12 even though the event names a DIFFERENT ticket
+    processEvent(issueEvent("linear.issue.removed", { ticket: "CTL-99", issueId: "u-12" }));
+    expect(getTicketDescriptor("CTL-12").removed).toBe(true);
+    expect(getTicketDescriptor("CTL-99")).toBeNull();
+  });
+
+  test("remove with un-indexed UUID but a ticket falls back to identifier", () => {
+    processEvent(
+      issueEvent("linear.issue.removed", { ticket: "CTL-7", issueId: "never-indexed" })
+    );
+    const d = getTicketDescriptor("CTL-7");
+    expect(d.removed).toBe(true);
+    expect(d.uuid).toBe("never-indexed");
+  });
+
+  test("remove with neither UUID-hit nor ticket is a silent no-op (backstop's job)", () => {
+    expect(() =>
+      processEvent(issueEvent("linear.issue.removed", { issueId: "ghost" }, null))
+    ).not.toThrow();
+  });
+
+  test("a later issue event resurrects a removed ticket (unarchive)", () => {
+    processEvent(issueEvent("linear.issue.created", { ticket: "CTL-8", issueId: "u-8" }));
+    processEvent(issueEvent("linear.issue.removed", { issueId: "u-8" }, null));
+    expect(getTicketDescriptor("CTL-8").removed).toBe(true);
+    processEvent(issueEvent("linear.issue.updated", { ticket: "CTL-8", toState: "Backlog" }));
+    expect(getTicketDescriptor("CTL-8").removed).toBe(false);
+  });
+
+  test("linear.comment.* and non-ticket github events never touch the store", () => {
+    processEvent(issueEvent("linear.comment.created", { ticket: "CTL-9", body: "hi" }));
+    processEvent({ event: "github.pr.merged", detail: { title: "no ticket ref here" } });
+    expect(getTicketDescriptor("CTL-9")).toBeNull();
+  });
+
+  test("descriptor write failure never breaks event processing (closed DB)", () => {
+    closeBrokerStateDb();
+    expect(() =>
+      processEvent(issueEvent("linear.issue.updated", { ticket: "CTL-10", toState: "Todo" }))
+    ).not.toThrow();
+    openBrokerStateDb(join(tmpDir, "test.db")); // re-open so afterEach close is balanced
+  });
+
+  test("canonical envelope shape (body.payload + attributes event.name) folds the same", () => {
+    processEvent({
+      attributes: {
+        "event.name": "linear.issue.updated",
+        "linear.issue.identifier": "CTL-11",
+      },
+      body: {
+        payload: { ticket: "CTL-11", toState: "Implement", issueId: "u-11" },
+      },
+    });
+    const d = getTicketDescriptor("CTL-11");
+    expect(d.state).toBe("Implement");
+    expect(d.uuid).toBe("u-11");
+  });
+});

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -57,6 +57,8 @@ import {
   markAgentDone,
   getAgentsByTicket,
   upsertTicketState,
+  upsertTicketDescriptor,
+  markTicketRemovedByUuid,
   upsertWaitingSession,
   clearWaitingSession,
 } from "./broker-state.mjs";
@@ -888,6 +890,60 @@ const TICKET_LIFECYCLE_ALL_WAKE_ON = [
   "comment_added",
 ];
 
+// foldLinearIssueDescriptor — CTL-822 (Gateway L1 child b): write-through of
+// every linear.issue.* event into the durable descriptor store (CTL-821).
+// KEY-PRESENCE semantics deliberately: a webhook's issue data is a full
+// snapshot, so toAssigneeId:null means UNASSIGNED (clear), and toLabels []
+// means explicitly-empty while null means "labels absent from payload"
+// (unknown → keep). Every non-remove issue event proves existence, so it also
+// clears any stale removed flag (Linear unarchive arrives as `update`).
+// `remove` payloads carry ONLY the entityId UUID → resolve via the CTL-821
+// UUID→identifier index; an unresolvable remove with no identifier is left
+// for the reconcile backstop (child e).
+function foldLinearIssueDescriptor(name, detail, eventTicket) {
+  if (typeof name !== "string" || !name.startsWith("linear.issue.")) return;
+  try {
+    const uuid = detail.issueId ?? null;
+    if (name === "linear.issue.removed") {
+      if (uuid) {
+        const hit = markTicketRemovedByUuid(uuid);
+        if (!hit && eventTicket) {
+          upsertTicketDescriptor({ ticket: eventTicket, uuid, removed: true });
+        }
+      } else if (eventTicket) {
+        upsertTicketDescriptor({ ticket: eventTicket, removed: true });
+      }
+      return;
+    }
+    if (!eventTicket) return;
+    const descriptor = { ticket: eventTicket, removed: false };
+    if (detail.toState != null) descriptor.state = detail.toState;
+    if (detail.toPriority !== undefined && detail.toPriority !== null) {
+      descriptor.priority = detail.toPriority;
+    }
+    if ("toAssigneeId" in detail) {
+      const v = detail.toAssigneeId ?? null;
+      // Linear sends partial issue payloads (data.assignee can be omitted on
+      // an ASSIGNED issue), and the emitter always includes the key. So a
+      // null only CLEARS when the unassignment is evidenced: an assignee
+      // change topic/updatedFrom, or a create (born unassigned). Otherwise
+      // null is "unknown" → keep. Non-null always sets.
+      const changeEvidenced =
+        v !== null ||
+        name === "linear.issue.assignee_changed" ||
+        detail.action === "create" ||
+        (Array.isArray(detail.updatedFromKeys) && detail.updatedFromKeys.includes("assigneeId"));
+      if (changeEvidenced) descriptor.assignee = v;
+    }
+    if (detail.toLabels != null) descriptor.labels = detail.toLabels;
+    if (uuid) descriptor.uuid = uuid;
+    upsertTicketDescriptor(descriptor);
+  } catch {
+    /* DB not opened, or a UNIQUE-uuid violation from a buggy upstream — the
+       routing path must never die on a descriptor write */
+  }
+}
+
 export function tryTicketLifecycleRoute(event, interestsMap) {
   const matches = [];
   // CTL-357: read event name + payload via the canonical-aware helpers so
@@ -1631,6 +1687,23 @@ export function processEvent(event) {
   }
 
   if (shouldSkipEvent(event)) return;
+
+  // CTL-822: durable descriptor write-through. MUST run for every
+  // linear.issue.* event REGARDLESS of registered interests — webhooks arrive
+  // whether or not any orchestration is active, and the descriptor store is
+  // CTL-823's source of truth. Mirrors the projectWorkerStateEvent model
+  // (folds live ABOVE the `if (!interests.size) return` gate; the verify
+  // panel caught that placing this inside tryTicketLifecycleRoute silently
+  // starved the store during idle periods).
+  if (typeof name === "string" && name.startsWith("linear.issue.")) {
+    const foldDetail = getEventPayload(event);
+    const foldTicket =
+      event.attributes?.["linear.issue.identifier"] ??
+      foldDetail.ticket ??
+      foldDetail.identifier ??
+      null;
+    foldLinearIssueDescriptor(name, foldDetail, foldTicket);
+  }
 
   if (name === "heartbeat") {
     const sourceId = event.worker ?? event.session ?? event.orchestrator;

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
@@ -19,6 +19,26 @@ function issuePayload(overrides: Record<string, unknown> = {}): unknown {
 }
 
 describe("parseLinearWebhookEvent — Issue", () => {
+  it("extracts issueId from data.id (CTL-822 — all a remove carries)", () => {
+    const ev = parseLinearWebhookEvent("Issue", issuePayload());
+    expect(ev.kind).toBe("issue");
+    if (ev.kind !== "issue") return;
+    expect(ev.issueId).toBe("issue-uuid-1");
+  });
+
+  it("remove with ONLY data.id still yields issueId (no identifier)", () => {
+    const ev = parseLinearWebhookEvent("Issue", {
+      action: "remove",
+      type: "Issue",
+      data: { id: "removed-uuid-9" },
+    });
+    expect(ev.kind).toBe("issue");
+    if (ev.kind !== "issue") return;
+    expect(ev.topic).toBe("linear.issue.removed");
+    expect(ev.issueId).toBe("removed-uuid-9");
+    expect(ev.ticket).toBeNull();
+  });
+
   it("Issue create → linear.issue.created", () => {
     const ev = parseLinearWebhookEvent(
       "Issue",

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
@@ -400,6 +400,7 @@ describe("buildLinearEventLogEnvelope — description fields (CTL-749)", () => {
         teamKey: "CTL",
         data: {},
         updatedFromKeys: ["description"],
+        issueId: null,
         actorId: null,
         actorName: null,
         toState: null,
@@ -430,6 +431,7 @@ describe("buildLinearEventLogEnvelope — description fields (CTL-749)", () => {
         teamKey: "CTL",
         data: {},
         updatedFromKeys: [],
+        issueId: null,
         actorId: null,
         actorName: null,
         toState: null,
@@ -525,6 +527,7 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         teamKey: "CTL",
         data: {},
         updatedFromKeys: ["stateId"],
+        issueId: null,
         actorId: null,
         actorName: null,
         toState: null,
@@ -558,6 +561,7 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         teamKey: "CTL",
         data: {},
         updatedFromKeys: ["stateId"],
+        issueId: null,
         actorId: null,
         actorName: null,
         toState: "In Review",
@@ -587,6 +591,7 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         teamKey: "CTL",
         data: {},
         updatedFromKeys: ["stateId"],
+        issueId: null,
         actorId: null,
         actorName: null,
         toState: null,
@@ -616,6 +621,7 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         teamKey: "CTL",
         data: {},
         updatedFromKeys: [],
+        issueId: null,
         actorId: "actor-uuid-123",
         actorName: null,
         toState: null,
@@ -646,6 +652,7 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         teamKey: "CTL",
         data: {},
         updatedFromKeys: [],
+        issueId: null,
         actorId: null,
         actorName: null,
         toState: null,
@@ -675,6 +682,7 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         teamKey: "CTL",
         data: {},
         updatedFromKeys: ["stateId", "labelIds"],
+        issueId: null,
         actorId: null,
         actorName: null,
         toState: "Ready",
@@ -713,6 +721,7 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         teamKey: "CTL",
         data: {},
         updatedFromKeys: ["stateId"],
+        issueId: null,
         actorId: "actor-uuid-424",
         actorName: "Ryan",
         toState: "In Progress",
@@ -746,6 +755,7 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         teamKey: "CTL",
         data: {},
         updatedFromKeys: [],
+        issueId: null,
         actorId: null,
         actorName: null,
         toState: null,
@@ -841,6 +851,7 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         teamKey: "CTL",
         data: {},
         updatedFromKeys: ["stateId"],
+        issueId: null,
         actorId: null,
         actorName: null,
         toState: null,
@@ -871,6 +882,7 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         teamKey: "FOO",
         data: {},
         updatedFromKeys: [],
+        issueId: null,
         actorId: null,
         actorName: null,
         toState: null,
@@ -901,6 +913,7 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         teamKey: null,
         data: {},
         updatedFromKeys: [],
+        issueId: null,
         actorId: null,
         actorName: null,
         toState: null,
@@ -1033,6 +1046,7 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         teamKey: "CTL",
         data: {},
         updatedFromKeys: [],
+        issueId: null,
         actorId: null,
         actorName: null,
         toState: null,
@@ -1049,6 +1063,37 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
       TS
     );
     expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
+  });
+
+  it("issueId flows to attrs[linear.issue.id] and payload.issueId (CTL-822)", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "issue",
+        action: "remove",
+        topic: "linear.issue.removed",
+        ticket: null, // a real remove carries no identifier — only the UUID
+        teamKey: null,
+        data: { id: "entity-uuid-7" },
+        updatedFromKeys: [],
+        issueId: "entity-uuid-7",
+        actorId: null,
+        actorName: null,
+        toState: null,
+        toPriority: null,
+        toAssigneeId: null,
+        toAssigneeName: null,
+        toLabels: null,
+        toProject: null,
+        toProjectId: null,
+        previousFromValues: {},
+        description: null,
+        descriptionChanged: false,
+      },
+      TS
+    );
+    expect(env!.attributes["event.name"]).toBe("linear.issue.removed");
+    expect(env!.attributes["linear.issue.id"]).toBe("entity-uuid-7");
+    expect((env!.body.payload as { issueId: string | null }).issueId).toBe("entity-uuid-7");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
@@ -24,6 +24,12 @@ export type LinearWebhookEvent =
       teamKey: string | null;
       data: Record<string, unknown>;
       updatedFromKeys: string[];
+      /**
+       * Linear issue entityId UUID from data.id; null when absent. The
+       * `remove` action's payload carries ONLY this UUID (no identifier), so
+       * the Gateway's UUID→identifier index (CTL-821) is keyed off it. CTL-822.
+       */
+      issueId: string | null;
       /** Linear user UUID who triggered the action; null when absent. CTL-263. */
       actorId: string | null;
       /** Current state name from data.state.name; null when absent. CTL-424. */
@@ -198,6 +204,7 @@ function parseIssue(payload: Record<string, unknown>): LinearWebhookEvent {
     teamKey: teamKeyFromData(data),
     data,
     updatedFromKeys,
+    issueId: getOptStr(data, "id"), // CTL-822 — entityId UUID (all a `remove` carries)
     actorId,
     actorName,
     toState,

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
@@ -125,6 +125,7 @@ export function buildLinearEventLogEnvelope(
       if (event.ticket !== null) attrs["linear.issue.identifier"] = event.ticket;
       if (event.teamKey !== null) attrs["linear.team.key"] = event.teamKey;
       if (event.actorId !== null) attrs["linear.actor.id"] = event.actorId;
+      if (event.issueId !== null) attrs["linear.issue.id"] = event.issueId; // CTL-822
       const repo = lookupRepo(event.teamKey);
       if (repo !== undefined) attrs["vcs.repository.name"] = repo;
       return canonical({
@@ -140,6 +141,7 @@ export function buildLinearEventLogEnvelope(
           action: event.action,
           ticket: event.ticket,
           teamKey: event.teamKey,
+          issueId: event.issueId, // CTL-822 — the only key a `remove` payload carries
           updatedFromKeys: event.updatedFromKeys,
           actorId: event.actorId,
           actorName: event.actorName,


### PR DESCRIPTION
## Summary

Gateway L1 child (b) of the **CTL-792 4-layer re-plan** (parent CTL-820): every `linear.issue.*` webhook event now write-throughs into the CTL-821 durable descriptor store, and the Linear issue **entityId UUID rides the wire** so deletes are resolvable.

### orch-monitor half
- `parseIssue` extracts `issueId` from `data.id` (required field on the issue variant); the logged payload + `attrs["linear.issue.id"]` carry it. A `remove` webhook's payload carries ONLY this UUID — without it on the wire, deletes were unresolvable downstream.

### broker half
- `foldLinearIssueDescriptor` is invoked from **`processEvent`, above the `if (!interests.size) return` gate** (the `projectWorkerStateEvent` model) — the adversarial verify caught that placing it inside `tryTicketLifecycleRoute` silently starved the store whenever the broker had zero registered interests (exactly the idle periods webhooks keep arriving in). Tests drive the live `processEvent` path with `clearInterests()` to pin this.
- Key-presence fold: `toAssigneeId` **null only clears when the unassignment is evidenced** (assignee_changed topic / `updatedFromKeys` / create) — Linear sends partial payloads where `data.assignee` is omitted on an assigned issue, so a bare null is "unknown", not an unassign. `toLabels []` = explicitly empty, null = keep. Every non-remove issue event clears a stale removed flag (unarchive arrives as `update`).
- `remove` resolves **UUID-index-first** (pinned by test: a stale identifier on the event loses to the index), falls back to identifier, else leaves it for the reconcile backstop (child e). Fold failures never break routing.

## Verify panel findings consciously deferred (for child e / Gateway epic)
- **labels write-through is dead upstream**: Linear's update webhooks don't expand the labels relation, so `toLabels` is never a populated array in 2 months of real events — the labels column needs the reconcile backstop (child e) or parser enrichment.
- **resolution column** has no webhook writer — readers derive resolution from state/removed; child (e) owns it.
- **no out-of-order watermark** on descriptor upserts (broker tailer is forward-only in steady state; replay semantics to be handled with child e).

## Tests
16 broker fold tests (live-path zero-interests pin, snapshot fold, evidenced-unassign vs partial-payload keep, labels []/null, UUID-only remove + index-precedence + fallback, resurrect-on-unarchive, closed-DB resilience, canonical envelope) + parser/handler issueId coverage; 13 hand-built fixtures updated. Broker suite **395/395**, orch-monitor typecheck clean, lint 0 errors.

Unblocks CTL-823 (read API + daemon client, fresh-before-quarantine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)