### PR TITLE
feat(dev): Gateway L1(c) — daemon read client over the durable descriptor store (CTL-823)

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -78,6 +78,7 @@ import { removeLabel as defaultRemoveLabel } from "./linear-write.mjs"; // CTL-5
 // no-ops (hermetic for direct-call unit tests); the REAL daemon arms them here
 // so the phantom worker-dir validity sweep is operative in production.
 import { classifyTicketResolution } from "./linear-query.mjs";
+import { createGatewayReader } from "./gateway-read.mjs";
 import { isBgJobAlive, refreshAgents } from "./claude-agents.mjs";
 
 const DEFAULT_MAX_PARALLEL = 3;
@@ -396,6 +397,9 @@ export function startDaemon({
     // during out-of-set blocker hydration. A single instance threaded into
     // both is what turns a write-through into a guaranteed next-tick hit.
     const cache = createTicketStateCache();
+    // CTL-823: readonly client over the broker's durable descriptor store
+    // (~/catalyst/filter-state.db). Fail-open — see gateway-read.mjs.
+    const gatewayReader = createGatewayReader();
     // CTL-565: the monitor needs orchDir to one-shot-dispatch the triage phase
     // agent on a →Triage transition. `dispatch` stays an injectable default
     // (dispatch.mjs) so the daemon's fakes-pass-through pattern still holds.
@@ -425,7 +429,20 @@ export function startDaemon({
       configPath,
       layer2Path,
       // CTL-671: arm the phantom worker-dir validity sweep + bg-liveness reader.
-      classifyResolution: classifyTicketResolution,
+      // CTL-823: the sweep's existence probe consults the durable broker
+      // descriptor store first (gateway-read.mjs) — a fresh not-removed
+      // descriptor short-circuits "exists" with ZERO subprocess/Linear cost;
+      // removed/absent/stale always fall through to the live read
+      // (fresh-before-quarantine). Fail-open: any store failure behaves
+      // exactly like the pre-gateway path.
+      // Spread order matters: the daemon's reader is AUTHORITATIVE — callers
+      // (the sweep passes { exec }) cannot accidentally drop it.
+      classifyResolution: (identifier, opts = {}) =>
+        classifyTicketResolution(identifier, { ...opts, gateway: gatewayReader }),
+      // CTL-823: thread the reader to the scheduler's internal fetchState
+      // injections (reclaim + terminal backstop) so the 60s state window is
+      // live in production, not just in unit tests.
+      gateway: gatewayReader,
       isBgJobAlive,
     }); // CTL-536 + CTL-634 + CTL-665 + CTL-671 + CTL-676 + CTL-678 — pull-loop scheduler (configPath + layer2Path enable per-tick Layer-1+Layer-2 re-read)
     // CTL-684: start the side-car auto-tuner AFTER the scheduler so the

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -1421,3 +1421,46 @@ describe("daemon wires onComment and onUpdate to monitorFn (CTL-549 + CTL-749)",
     expect(typeof capturedOpts?.onUpdate).toBe("function");
   });
 });
+
+// ─── CTL-823: gateway wiring (the slice's whole point — pin it) ──────────────
+
+describe("CTL-823 gateway wiring", () => {
+  test("injected classifyResolution serves a fresh store hit with ZERO live reads", async () => {
+    const { openBrokerStateDb, closeBrokerStateDb, upsertTicketDescriptor } = await import(
+      "../broker/broker-state.mjs"
+    );
+    // Seed the descriptor store at the path the daemon's default reader
+    // resolves (CATALYST_DIR/filter-state.db — pinned to this test's tmp dir).
+    openBrokerStateDb(join(catalystDir, "filter-state.db"));
+    upsertTicketDescriptor({ ticket: "CTL-GW", state: "Todo", uuid: "u-gw" });
+    closeBrokerStateDb();
+
+    let captured;
+    startDaemon({
+      recover: () => ({}),
+      reconcileBoot: () => {},
+      startMonitor: () => {},
+      startScheduler: (o) => {
+        captured = o;
+      },
+      watchRegistry: false,
+    });
+
+    // The reader is threaded for the scheduler's fetchState injections…
+    expect(captured.gateway).toBeTruthy();
+    // …and the classify wrapper serves the store WITHOUT touching linearis:
+    // an exec that would return a definitive not-found must never be reached.
+    const execCalls = [];
+    const exec = (...args) => {
+      execCalls.push(args);
+      return { code: 0, stdout: JSON.stringify({ error: "Issue not found" }) };
+    };
+    expect(captured.classifyResolution("CTL-GW", { exec })).toBe("exists");
+    expect(execCalls.length).toBe(0);
+
+    // Store MISS falls through to the live read (fail-open) — and the
+    // daemon's reader cannot be dropped by the caller's opts.
+    expect(captured.classifyResolution("CTL-MISSING", { exec })).toBe("not-found");
+    expect(execCalls.length).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/gateway-read.mjs
+++ b/plugins/dev/scripts/execution-core/gateway-read.mjs
@@ -1,0 +1,93 @@
+// gateway-read.mjs — CTL-823 (Gateway L1 child c): the daemon's READ client
+// for the broker-owned durable descriptor store (~/catalyst/filter-state.db,
+// schema CTL-821, populated by the CTL-822 webhook write-through).
+//
+// Deliberately NOT an HTTP client: the scheduler tick is synchronous, so an
+// HTTP hop would mean another per-call subprocess (the exact cost this slice
+// removes). SQLite WAL exists for this shape — the broker stays the single
+// WRITER, this module opens the same file strictly READONLY. The HTTP read
+// surface moves to child (d), where out-of-process workers actually need it.
+//
+// Fail-open contract: ANY failure (file absent, pre-CTL-821 schema, lock
+// contention, corrupt row) returns null — callers fall through to the live
+// linearis read exactly as before this module existed. The gateway is a safe
+// optimization, never the source of truth.
+import { Database } from "bun:sqlite";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+function defaultDbPath() {
+  return resolve(process.env.CATALYST_DIR ?? `${homedir()}/catalyst`, "filter-state.db");
+}
+
+// descriptorAgeMs — ms since the descriptor's last write; Infinity when the
+// timestamp is absent/unparseable so staleness checks fail safe (too old).
+export function descriptorAgeMs(descriptor, now = Date.now()) {
+  const ts = descriptor?.updatedAt;
+  if (!ts) return Infinity;
+  const t = Date.parse(ts);
+  return Number.isFinite(t) ? now - t : Infinity;
+}
+
+export function createGatewayReader({ dbPath = defaultDbPath() } = {}) {
+  let db = null;
+
+  const open = () => {
+    if (db) return db;
+    db = new Database(dbPath, { readonly: true });
+    // Readonly + WAL: writers never block readers, but a checkpoint can hold
+    // the lock briefly — wait a beat instead of failing the read.
+    db.run("PRAGMA busy_timeout = 250");
+    return db;
+  };
+
+  const dropHandle = () => {
+    try {
+      db?.close();
+    } catch {
+      /* already closed */
+    }
+    db = null;
+  };
+
+  const parse = (s) => {
+    if (s === null || s === undefined) return null;
+    try {
+      return JSON.parse(s);
+    } catch {
+      return null;
+    }
+  };
+
+  // getDescriptor — full descriptor row or null (absent row OR any failure).
+  // A pre-CTL-821 DB (legacy 4-column ticket_state) still resolves: SELECT *
+  // simply yields undefined for the missing columns → nulls.
+  const getDescriptor = (ticket) => {
+    if (!ticket) return null;
+    try {
+      const row = open().prepare(`SELECT * FROM ticket_state WHERE ticket = ?`).get(ticket);
+      if (!row) return null;
+      return {
+        ticket: row.ticket,
+        state: row.linear_state ?? null,
+        prNumber: row.pr_number ?? null,
+        relations: parse(row.relations),
+        labels: parse(row.labels),
+        priority: row.priority ?? null,
+        resolution: row.resolution ?? null,
+        assignee: row.assignee ?? null,
+        uuid: row.uuid ?? null,
+        removed: row.removed_at != null,
+        removedAt: row.removed_at ?? null,
+        updatedAt: row.updated_at ?? null,
+      };
+    } catch {
+      // Drop the handle so a later call re-opens fresh — the DB may be
+      // created/migrated by the broker between calls.
+      dropHandle();
+      return null;
+    }
+  };
+
+  return { getDescriptor, close: dropHandle };
+}

--- a/plugins/dev/scripts/execution-core/gateway-read.test.mjs
+++ b/plugins/dev/scripts/execution-core/gateway-read.test.mjs
@@ -1,0 +1,135 @@
+// Tests for gateway-read.mjs (CTL-823) — the daemon's readonly client over
+// the broker's durable descriptor store. The fixture DB is built with the
+// REAL broker module (cross-package import, test-setup only) so the schema
+// under test is the actual CTL-821 schema, not a hand-rolled imitation.
+// Run: bun test plugins/dev/scripts/execution-core/gateway-read.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  openBrokerStateDb,
+  closeBrokerStateDb,
+  upsertTicketDescriptor,
+  markTicketRemovedByUuid,
+} from "../broker/broker-state.mjs";
+import { createGatewayReader, descriptorAgeMs } from "./gateway-read.mjs";
+
+let tmpDir;
+let dbPath;
+let reader;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "gateway-read-test-"));
+  dbPath = join(tmpDir, "filter-state.db");
+});
+
+afterEach(() => {
+  reader?.close();
+  reader = null;
+  closeBrokerStateDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function seed() {
+  openBrokerStateDb(dbPath);
+  upsertTicketDescriptor({
+    ticket: "CTL-1",
+    state: "Todo",
+    priority: 2,
+    assignee: "user-1",
+    labels: ["feature"],
+    uuid: "u-1",
+  });
+}
+
+describe("createGatewayReader", () => {
+  test("reads a descriptor written by the broker (concurrent WAL reader)", () => {
+    seed(); // broker handle stays OPEN — proves reader works alongside the writer
+    reader = createGatewayReader({ dbPath });
+    const d = reader.getDescriptor("CTL-1");
+    expect(d.state).toBe("Todo");
+    expect(d.priority).toBe(2);
+    expect(d.assignee).toBe("user-1");
+    expect(d.labels).toEqual(["feature"]);
+    expect(d.uuid).toBe("u-1");
+    expect(d.removed).toBe(false);
+    expect(d.updatedAt).toBeTruthy();
+  });
+
+  test("sees the broker's removed flag", () => {
+    seed();
+    markTicketRemovedByUuid("u-1");
+    reader = createGatewayReader({ dbPath });
+    expect(reader.getDescriptor("CTL-1").removed).toBe(true);
+  });
+
+  test("absent row reads null (NOT a non-existence proof)", () => {
+    seed();
+    reader = createGatewayReader({ dbPath });
+    expect(reader.getDescriptor("CTL-404")).toBeNull();
+  });
+
+  test("missing DB file fails open with null, then recovers once created", () => {
+    reader = createGatewayReader({ dbPath });
+    expect(reader.getDescriptor("CTL-1")).toBeNull();
+    seed(); // broker creates + migrates the DB after the failed read
+    expect(reader.getDescriptor("CTL-1")?.state).toBe("Todo");
+  });
+
+  test("pre-CTL-821 legacy schema reads legacy fields, nulls for the rest", () => {
+    const legacy = new Database(dbPath, { create: true });
+    legacy.run(`
+      CREATE TABLE ticket_state (
+        ticket       TEXT PRIMARY KEY,
+        linear_state TEXT,
+        pr_number    INTEGER,
+        updated_at   TEXT NOT NULL
+      )
+    `);
+    legacy.run(`INSERT INTO ticket_state VALUES ('CTL-9', 'Done', 7, '2026-01-01T00:00:00Z')`);
+    legacy.close();
+    reader = createGatewayReader({ dbPath });
+    const d = reader.getDescriptor("CTL-9");
+    expect(d.state).toBe("Done");
+    expect(d.prNumber).toBe(7);
+    expect(d.uuid).toBeNull();
+    expect(d.removed).toBe(false);
+  });
+
+  test("empty/falsy ticket reads null without touching the DB", () => {
+    reader = createGatewayReader({ dbPath });
+    expect(reader.getDescriptor("")).toBeNull();
+    expect(reader.getDescriptor(null)).toBeNull();
+  });
+});
+
+describe("descriptorAgeMs", () => {
+  test("computes age from updatedAt", () => {
+    const now = Date.parse("2026-06-07T00:01:00Z");
+    expect(descriptorAgeMs({ updatedAt: "2026-06-07T00:00:00Z" }, now)).toBe(60_000);
+  });
+
+  test("absent or unparseable updatedAt is Infinity (fails safe as stale)", () => {
+    expect(descriptorAgeMs({})).toBe(Infinity);
+    expect(descriptorAgeMs(null)).toBe(Infinity);
+    expect(descriptorAgeMs({ updatedAt: "not a date" })).toBe(Infinity);
+  });
+});
+
+describe("handle recovery (dropHandle on query failure)", () => {
+  test("DB exists but lacks ticket_state → null; recovers after the broker migrates", () => {
+    // open-succeeded-then-query-threw path: an empty DB file opens fine but
+    // the SELECT throws. The catch MUST drop the handle so the next call
+    // re-opens and sees the broker's migration.
+    const empty = new Database(dbPath, { create: true });
+    empty.run(`CREATE TABLE unrelated (x INTEGER)`);
+    empty.close();
+    reader = createGatewayReader({ dbPath });
+    expect(reader.getDescriptor("CTL-1")).toBeNull();
+    seed(); // broker migrates the SAME file in place (ALTER/CREATE IF NOT EXISTS)
+    expect(reader.getDescriptor("CTL-1")?.state).toBe("Todo");
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -4,6 +4,7 @@
 // parses the JSON, normalizes the ticket list, and applies the priority-floor
 // post-filter that linearis cannot express server-side.
 
+import { descriptorAgeMs } from "./gateway-read.mjs";
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { withBreaker, linearBreaker, isRateLimitError } from "./linear-breaker.mjs";
@@ -113,10 +114,35 @@ function normalizeTicket(node) {
 // failed/unparseable read is NEVER cached so the D5 fail-safe re-reads next
 // tick. The param is opt-in — callers that omit it exec on every call exactly
 // as before.
-export function fetchTicketState(identifier, { exec = defaultExec, cache } = {}) {
+// ─── gateway read-path (CTL-823, Gateway L1 child c) ────────────────────────
+// The durable broker descriptor store (gateway-read.mjs) serves the hot read
+// paths. Freshness windows: EXISTENCE decays only via a missed remove webhook
+// (the reconcile backstop's gap), so the exists short-circuit tolerates
+// 10 min; STATE changes constantly, so it gets the same 60s the in-memory
+// cache uses. The store is a safe optimization, never the source of truth —
+// every destructive decision still pays a live read.
+const GATEWAY_EXISTS_FRESH_MS = 10 * 60_000;
+const GATEWAY_STATE_FRESH_MS = 60_000;
+
+export function fetchTicketState(
+  identifier,
+  { exec = defaultExec, cache, gateway, gatewayFreshMs = GATEWAY_STATE_FRESH_MS } = {}
+) {
   if (cache) {
     const cached = cache.get(identifier);
     if (cached !== undefined) return cached; // hit
+  }
+  if (gateway) {
+    const d = gateway.getDescriptor(identifier);
+    if (
+      d &&
+      !d.removed &&
+      d.state != null &&
+      descriptorAgeMs(d) <= gatewayFreshMs
+    ) {
+      if (cache) cache.set(identifier, d.state); // warm the in-memory tier too
+      return d.state;
+    }
   }
   const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
   if (code !== 0) return null; // fail-safe — not cached
@@ -356,7 +382,19 @@ export function fetchTicketLabels(identifier, { exec = defaultExec } = {}) {
 // discriminator is the BODY, not the exit code: a "not found" error string is
 // the definitive not-found; any other error body (auth/network/rate-limit) is
 // transient → unknown.
-export function classifyTicketResolution(identifier, { exec = defaultExec } = {}) {
+export function classifyTicketResolution(
+  identifier,
+  { exec = defaultExec, gateway, gatewayFreshMs = GATEWAY_EXISTS_FRESH_MS } = {}
+) {
+  // CTL-823: serve ONLY the cheap not-quarantine verdict from the durable
+  // store — a fresh, present, not-removed descriptor proves existence.
+  // removed/absent/stale NEVER short-circuit: quarantine is a destructive
+  // write, so those verdicts always pay a fresh live read
+  // (fresh-before-quarantine).
+  if (gateway) {
+    const d = gateway.getDescriptor(identifier);
+    if (d && !d.removed && descriptorAgeMs(d) <= gatewayFreshMs) return "exists";
+  }
   const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
   if (code !== 0) return "unknown"; // nonzero is ambiguous — NEVER not-found
   let node;

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -741,3 +741,120 @@ describe("classifyTicketResolution (CTL-671)", () => {
     expect(exec.calls[0]).toEqual({ cmd: "linearis", args: ["issues", "read", "CTL-9"] });
   });
 });
+
+// ─── gateway read-path (CTL-823) ─────────────────────────────────────────────
+
+function fakeGateway(descriptor) {
+  const calls = [];
+  return {
+    calls,
+    getDescriptor(ticket) {
+      calls.push(ticket);
+      return descriptor;
+    },
+  };
+}
+
+const FRESH = () => new Date().toISOString();
+const STALE = () => new Date(Date.now() - 11 * 60_000).toISOString();
+
+describe("classifyTicketResolution — gateway short-circuit (CTL-823)", () => {
+  test("fresh + present + not-removed → exists with ZERO live reads", () => {
+    const exec = fakeExec({ code: 0, stdout: "{}" });
+    const gateway = fakeGateway({ ticket: "CTL-1", removed: false, updatedAt: FRESH() });
+    expect(classifyTicketResolution("CTL-1", { exec, gateway })).toBe("exists");
+    expect(exec.calls.length).toBe(0);
+  });
+
+  test("removed descriptor NEVER short-circuits — exactly one live re-read (fresh-before-quarantine)", () => {
+    const exec = fakeExec({
+      code: 0,
+      stdout: JSON.stringify({ error: "Issue not found" }),
+    });
+    const gateway = fakeGateway({ ticket: "CTL-2", removed: true, updatedAt: FRESH() });
+    expect(classifyTicketResolution("CTL-2", { exec, gateway })).toBe("not-found");
+    expect(exec.calls.length).toBe(1); // the destructive verdict paid a live read
+  });
+
+  test("stale descriptor falls through to the live read", () => {
+    const exec = fakeExec({
+      code: 0,
+      stdout: JSON.stringify({ identifier: "CTL-3" }),
+    });
+    const gateway = fakeGateway({ ticket: "CTL-3", removed: false, updatedAt: STALE() });
+    expect(classifyTicketResolution("CTL-3", { exec, gateway })).toBe("exists");
+    expect(exec.calls.length).toBe(1);
+  });
+
+  test("gateway miss (null) falls through to the live read", () => {
+    const exec = fakeExec({ code: 0, stdout: JSON.stringify({ identifier: "CTL-4" }) });
+    const gateway = fakeGateway(null);
+    expect(classifyTicketResolution("CTL-4", { exec, gateway })).toBe("exists");
+    expect(exec.calls.length).toBe(1);
+  });
+
+  test("a gateway 'exists' hit can never quarantine: only the NOT-quarantine case is served", () => {
+    // mutation guard: if someone makes a removed/absent descriptor return
+    // "not-found" from the store, this test pins the contract that the store
+    // can short-circuit ONLY the exists verdict.
+    const exec = fakeExec({ code: 1, stdout: "" }); // live read unavailable
+    const gateway = fakeGateway({ ticket: "CTL-5", removed: true, updatedAt: FRESH() });
+    expect(classifyTicketResolution("CTL-5", { exec, gateway })).toBe("unknown");
+  });
+
+  test("no gateway param → behavior unchanged", () => {
+    const exec = fakeExec({ code: 0, stdout: JSON.stringify({ identifier: "CTL-6" }) });
+    expect(classifyTicketResolution("CTL-6", { exec })).toBe("exists");
+    expect(exec.calls.length).toBe(1);
+  });
+});
+
+describe("fetchTicketState — gateway read-path (CTL-823)", () => {
+  test("fresh descriptor state serves with zero live reads and warms the cache", () => {
+    const exec = fakeExec({ code: 0, stdout: "{}" });
+    const gateway = fakeGateway({ ticket: "CTL-7", state: "Todo", removed: false, updatedAt: FRESH() });
+    const cache = createTicketStateCache();
+    expect(fetchTicketState("CTL-7", { exec, gateway, cache })).toBe("Todo");
+    expect(exec.calls.length).toBe(0);
+    expect(cache.get("CTL-7")).toBe("Todo"); // in-memory cache warmed from the store
+  });
+
+  test("stale descriptor falls through to live read", () => {
+    const exec = fakeExec({
+      code: 0,
+      stdout: JSON.stringify({ state: { name: "PR" } }),
+    });
+    const gateway = fakeGateway({ ticket: "CTL-8", state: "Todo", removed: false, updatedAt: STALE() });
+    expect(fetchTicketState("CTL-8", { exec, gateway })).toBe("PR");
+    expect(exec.calls.length).toBe(1);
+  });
+
+  test("removed or stateless descriptor falls through to live read", () => {
+    const exec = fakeExec({ code: 0, stdout: JSON.stringify({ state: { name: "PR" } }) });
+    const gw1 = fakeGateway({ ticket: "CTL-9", state: "Todo", removed: true, updatedAt: FRESH() });
+    expect(fetchTicketState("CTL-9", { exec, gateway: gw1 })).toBe("PR");
+    const gw2 = fakeGateway({ ticket: "CTL-10", state: null, removed: false, updatedAt: FRESH() });
+    expect(fetchTicketState("CTL-10", { exec, gateway: gw2 })).toBe("PR");
+  });
+
+  test("in-memory cache hit still wins before the gateway is consulted", () => {
+    const gateway = fakeGateway({ ticket: "CTL-11", state: "Todo", removed: false, updatedAt: FRESH() });
+    const cache = createTicketStateCache();
+    cache.set("CTL-11", "Implement");
+    expect(fetchTicketState("CTL-11", { gateway, cache })).toBe("Implement");
+    expect(gateway.calls.length).toBe(0);
+  });
+});
+
+describe("fetchTicketState — gateway state-freshness boundary (CTL-823)", () => {
+  test("59s-old descriptor serves from the store; 61s falls through live", () => {
+    const at = (ms) => new Date(Date.now() - ms).toISOString();
+    const exec = fakeExec({ code: 0, stdout: JSON.stringify({ state: { name: "PR" } }) });
+    const fresh = fakeGateway({ ticket: "CTL-20", state: "Todo", removed: false, updatedAt: at(59_000) });
+    expect(fetchTicketState("CTL-20", { exec, gateway: fresh })).toBe("Todo");
+    expect(exec.calls.length).toBe(0);
+    const stale = fakeGateway({ ticket: "CTL-21", state: "Todo", removed: false, updatedAt: at(61_000) });
+    expect(fetchTicketState("CTL-21", { exec, gateway: stale })).toBe("PR");
+    expect(exec.calls.length).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1815,6 +1815,10 @@ export function schedulerTick(
     // production; sweep-specific tests inject their own stubs.
     classifyResolution = () => "unknown",
     isBgJobAlive = () => true,
+    // CTL-823: the daemon's durable-descriptor-store reader; threaded into the
+    // fetchState injections below. undefined in bare unit ticks (fail-open —
+    // fetchTicketState without gateway behaves exactly as before).
+    gateway = undefined,
     // CTL-671: runaway-alert seams. countTicketEvents reads the unified event
     // log (safe in tests — CATALYST_DIR is redirected), so it defaults to the
     // real scan; appendRunawayEvent writes the canonical alert. Both injectable
@@ -1990,7 +1994,7 @@ export function schedulerTick(
       const reclaimOpts = {
         repoRoot,
         cache,
-        fetchState: fetchTicketState,
+        fetchState: (id, o = {}) => fetchTicketState(id, { ...o, gateway }),
         prAdapter,
         // CTL-809 — thread the warm agents snapshot so the reclaim alive-branch can
         // cross-check a jobLifecycle-alive-but-process-gone ghost (getAgentsCached is
@@ -2958,7 +2962,7 @@ export function schedulerTick(
     reconcileTerminalBackstop(orchDir, ticket, signalByTicket.get(ticket), writeStatus, emitStateWrite, {
       cache,
       prAdapter,
-      fetchState: fetchTicketState,
+      fetchState: (id, o = {}) => fetchTicketState(id, { ...o, gateway }),
     });
     if (Object.values(signals).some((s) => s === "stalled")) {
       labelOnce(orchDir, ticket, "needs-human", writeStatus);


### PR DESCRIPTION
## Summary

Gateway L1 child (c) of the **CTL-792 4-layer re-plan** (parent CTL-820) — the slice that **kills the phantom-sweep linearis storm**, the last live Linear read cost on the tick.

- **`gateway-read.mjs`** — readonly `bun:sqlite` client over the live broker-owned `filter-state.db` (CTL-821 schema, CTL-822 webhook-fed). **Design deviation from the ticket, deliberately**: not HTTP — the scheduler tick is synchronous, so an HTTP hop would re-introduce a per-call subprocess (the exact cost being removed). WAL is built for this single-writer/concurrent-reader shape; the HTTP surface moves to child (d) where out-of-process workers need it. Fail-open everywhere.
- **`classifyTicketResolution {gateway}`** — only the cheap **not-quarantine** verdict short-circuits (fresh ≤10min + present + not-removed → `exists`, zero live reads). `removed`/absent/stale **never** short-circuit: quarantine is destructive, so those verdicts always pay a live read (**fresh-before-quarantine**). The store can only ever *add* `exists` verdicts — it cannot widen any false-quarantine window (3-lens verify confirmed the invariant).
- **`fetchTicketState {gateway}`** — 60s state window, warms the in-memory cache; threaded through `schedulerTick`'s new `{gateway}` opt into the reclaim + terminal-backstop injections (verify caught it would otherwise be prod-inert).
- **daemon wiring pinned by test**: a fresh store hit through the REAL `startDaemon` injection completes with **zero** exec calls; a miss falls through fail-open.

## Verify panel (3-lens adversarial): sound / sound / sound-with-changes — all findings addressed
- prod-inert `fetchTicketState` gateway → threaded through scheduler opts
- daemon wiring untested (could ship a no-op) → daemon-level pin added
- 60s window unpinned → 59s/61s boundary test
- dropHandle recovery unpinned → empty-DB-then-migrate recovery test
- duplicated freshness math → single source (`descriptorAgeMs`)
- spread order → daemon's reader pinned authoritative
- "zero reads" claim softened: zero for webhook-active tickets; idle tickets fall back to the pre-existing live read until child (e) lands

736 tests across touched modules green; suite baseline = 3 documented pre-existing fails only.

Closes the CTL-800 intent (folded per re-plan). Next: C3 — cache sync + broker/monitor/daemon restart + wedge-clear, then the board moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)