### PR TITLE
feat(dev): CTL-783 draft-PR-early: implement opens draft on first commit; phase-pr flips ready

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -276,6 +276,45 @@ The rebase is otherwise unchanged from CTL-667:
   (`.catalyst/config.json`, `.trunk/*`) is stashed across the rebase.
 - **Transient fetch failure → proceed un-rebased.** A flaky `git fetch` (rc=1) is non-fatal.
 
+### PR as the durable work record (CTL-783)
+
+During an orchestrated implement phase the draft PR is the **off-disk record of active work**,
+visible in GitHub and survives daemon restarts:
+
+| Signal | Meaning |
+|--------|---------|
+| Branch exists, no PR | Worker not yet past first commit |
+| Draft PR open | Implementing (phase-implement in progress) |
+| PR ready (not draft) | In review (phase-pr promoted it) |
+| PR merged | Done |
+
+**Branch naming**: branches come from Linear's `branchName` field (`ryan/<ticket>-slug`); the
+daemon's `create-worktree.sh` never overrides this.
+
+**PR title convention**: `<type>(<scope>): <ticket> ...` (e.g.
+`feat(dev): CTL-783 draft-PR-early first-commit open`). Both `draft_pr_ensure` and
+`create-pr/SKILL.md` Step 7 route through `draft_pr_title` (in
+`plugins/dev/scripts/lib/draft-pr.sh`) which injects the ticket after the conventional prefix
+without fabricating type or scope.
+
+**Lifecycle**:
+
+1. `implement-plan/SKILL.md` runs the `implement-plan-draft-pr-early` fence after **each**
+   plan-phase commit — `draft_pr_push` + `draft_pr_ensure` (idempotent). First call opens the
+   draft PR; later calls just push. Interactive `/implement-plan` runs are gated out by
+   `[[ -n "${CATALYST_PHASE:-}" ]]`.
+2. `phase-implement/SKILL.md` End block runs the `phase-implement-draft-pr` fence as the
+   **idempotent backstop** after all phases complete; this is also the **sole writer** of
+   `.draftPr={number,url,isDraft}` into the phase signal file.
+3. `phase-pr/SKILL.md` calls `draft_pr_promote` to flip the draft PR to ready instead of
+   creating a new PR (avoids the `create-pr` interactive "PR already exists" hang).
+
+**Config**: `orchestration.draftPr.enabled` (default `true`) — set `false` to create the PR
+only at the pr phase (End-block backstop still runs; `draft_pr_push` becomes the only push).
+
+**Deferred**: letting the scheduler read `.draftPr` draft-state as a secondary advancement
+signal (currently phase advancement is driven by signal `status === "done"` only).
+
 ### Runaway-loop guards (CTL-671)
 
 `schedulerTick` is hardened against runaway phase-dispatch/reclaim loops on phantom or

--- a/plugins/dev/scripts/__tests__/create-pr-title.test.sh
+++ b/plugins/dev/scripts/__tests__/create-pr-title.test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Tests for create-pr/SKILL.md title derivation + docs presence (CTL-783 Phase 3 & 4).
+# Run: bash plugins/dev/scripts/__tests__/create-pr-title.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILL_CREATE_PR="${REPO_ROOT}/plugins/dev/skills/create-pr/SKILL.md"
+CONFIG_DOC="${REPO_ROOT}/website/src/content/docs/reference/configuration.md"
+ARCH_DOC="${REPO_ROOT}/docs/architecture.md"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+
+assert_grep() {
+  local pattern="$1" file="$2" label="$3"
+  if grep -qE "$pattern" "$file" 2>/dev/null; then pass "$label"
+  else fail "$label — pattern '$pattern' not found in $(basename "$file")"; fi
+}
+
+assert_not_grep() {
+  local pattern="$1" file="$2" label="$3"
+  if ! grep -qE "$pattern" "$file" 2>/dev/null; then pass "$label"
+  else fail "$label — pattern '$pattern' unexpectedly found in $(basename "$file")"; fi
+}
+
+echo "=== create-pr-title + docs presence tests (CTL-783) ==="
+
+# ─── A. Step 7 sources lib/draft-pr.sh (or references draft_pr_title) ────────
+echo ""
+echo "A: create-pr/SKILL.md Step 7 uses draft_pr_title"
+assert_grep 'draft_pr_title|draft-pr\.sh' "$SKILL_CREATE_PR" \
+  "A: Step 7 references draft_pr_title or sources draft-pr.sh"
+
+# ─── B. Step 7 derives subject from git log --no-merges ────────────────────
+echo ""
+echo "B: Step 7 derives title from commit subject (git log --no-merges)"
+assert_grep 'git log.*--no-merges' "$SKILL_CREATE_PR" \
+  "B: Step 7 uses git log --no-merges for commit-first title"
+
+# ─── C. Branch-derived fallback retained ───────────────────────────────────
+echo ""
+echo "C: branch-derived kebab→spaces fallback retained"
+assert_grep "tr '-' ' '" "$SKILL_CREATE_PR" \
+  "C: kebab-to-spaces branch fallback still present"
+
+# ─── D. Documents the convention string in prose ───────────────────────────
+echo ""
+echo "D: create-pr/SKILL.md documents the <type>(<scope>): <ticket> convention"
+assert_grep '<type>\(<scope>\).*<ticket>|type.*scope.*ticket|conventional.*ticket|ticket.*convention' "$SKILL_CREATE_PR" \
+  "D: Step 7 prose documents the PR title convention"
+
+# ─── E. website/src/content/docs/reference/configuration.md documents draftPr.enabled
+echo ""
+echo "E: configuration.md documents orchestration.draftPr.enabled"
+assert_grep 'draftPr\.enabled|draftPr' "$CONFIG_DOC" \
+  "E: configuration.md mentions orchestration.draftPr.enabled"
+
+# ─── F. docs/architecture.md contains a work record / draft-PR-early section ─
+echo ""
+echo "F: docs/architecture.md contains draft-PR-early / work record section"
+assert_grep 'draft.*PR.*work record|work record.*draft PR|implement-plan-draft-pr-early|draft_pr_promote|draft.*implementing|ready.*in review' "$ARCH_DOC" \
+  "F: architecture.md documents the PR-as-work-record convention"
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "─────────────────────────────────────────────"
+echo "create-pr-title: ${PASSES} passed, ${FAILURES} failed"
+echo "─────────────────────────────────────────────"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/draft-pr-lib.test.sh
+++ b/plugins/dev/scripts/__tests__/draft-pr-lib.test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Wrapper so run-tests.sh's scripts/__tests__ glob discovers the lib suite (CTL-783).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "${SCRIPT_DIR}/../lib/__tests__/draft-pr.test.sh"

--- a/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
@@ -1299,6 +1299,182 @@ GHSTUB
   fi
 fi
 
+# ─── Test 24 (CTL-783): implement-plan early draft-pr fence contract ──────────
+SKILL_IMPLEMENT_PLAN="${REPO_ROOT}/plugins/dev/skills/implement-plan/SKILL.md"
+echo ""
+echo "Test 24 (CTL-783): implement-plan early draft-pr fence contract"
+if [[ -f "$SKILL_IMPLEMENT_PLAN" ]]; then
+  # A. fence present + uniquely named
+  assert_grep '```bash implement-plan-draft-pr-early' "$SKILL_IMPLEMENT_PLAN" \
+    "Test 24A: implement-plan-draft-pr-early fence present and uniquely named"
+  # B. sources lib/draft-pr.sh
+  assert_grep 'draft-pr\.sh' "$SKILL_IMPLEMENT_PLAN" \
+    "Test 24B: fence sources lib/draft-pr.sh"
+  # C. gated on CATALYST_PHASE being set
+  EARLY_FENCE_BODY="${SCRATCH}/t24-early-fence.sh"
+  awk '
+    /^```bash implement-plan-draft-pr-early$/ {grab=1; next}
+    grab && /^```[ \t]*$/ {grab=0}
+    grab {print}
+  ' "$SKILL_IMPLEMENT_PLAN" > "$EARLY_FENCE_BODY"
+  if [[ -s "$EARLY_FENCE_BODY" ]]; then
+    pass "Test 24: implement-plan-draft-pr-early fence extractable"
+    assert_grep 'CATALYST_PHASE' "$EARLY_FENCE_BODY" \
+      "Test 24C: fence is gated on CATALYST_PHASE (interactive runs unaffected)"
+    # D. gated on draft_pr_enabled
+    assert_grep 'draft_pr_enabled' "$EARLY_FENCE_BODY" \
+      "Test 24D: fence gates on draft_pr_enabled (config knob)"
+    # E. calls draft_pr_push AND draft_pr_ensure
+    assert_grep 'draft_pr_push' "$EARLY_FENCE_BODY" \
+      "Test 24E: fence calls draft_pr_push"
+    assert_grep 'draft_pr_ensure' "$EARLY_FENCE_BODY" \
+      "Test 24E: fence calls draft_pr_ensure"
+    # F. fail-open: no bare exit 1
+    if grep -qE '^\s*exit 1' "$EARLY_FENCE_BODY" 2>/dev/null; then
+      fail "Test 24F: fence must not contain bare 'exit 1' (fail-open required)"
+    else
+      pass "Test 24F: fence is fail-open (no bare exit 1)"
+    fi
+    # G. does NOT call phase-agent-emit-complete
+    if grep -q 'emit-complete' "$EARLY_FENCE_BODY" 2>/dev/null; then
+      fail "Test 24G: fence must not call emit-complete (phase wiring concern)"
+    else
+      pass "Test 24G: fence does not call emit-complete"
+    fi
+    # H. does NOT write .draftPr (signal writes belong to phase-implement End block)
+    if grep -q '\.draftPr' "$EARLY_FENCE_BODY" 2>/dev/null; then
+      fail "Test 24H: fence must not write .draftPr (signal writes belong to phase-implement End block)"
+    else
+      pass "Test 24H: fence does not write .draftPr (correct separation)"
+    fi
+    # I. runtime: extract + run fence with CATALYST_PHASE=implement, no-PR stub → gh pr create called once;
+    #    re-run with existing-PR stub → no second create.
+    T24_DIR="${SCRATCH}/t24-runtime"
+    mkdir -p "$T24_DIR"
+    T24_REPO="${T24_DIR}/repo"
+    T24_BARE="${T24_DIR}/repo-bare.git"
+    T24_BIN="${T24_DIR}/bin"
+    T24_GH_LOG="${T24_DIR}/gh.log"
+    T24_PLUGIN="${T24_DIR}/plugin"
+    mkdir -p "${T24_PLUGIN}/scripts/lib"
+    cp "${REPO_ROOT}/plugins/dev/scripts/lib/draft-pr.sh" "${T24_PLUGIN}/scripts/lib/draft-pr.sh"
+    git init --quiet "$T24_BARE" --bare -b main
+    git clone --quiet "$T24_BARE" "$T24_REPO"
+    (
+      cd "$T24_REPO"
+      git config user.email "test@example.com"
+      git config user.name "Test"
+      echo "base" > base.txt
+      git add base.txt
+      git commit --quiet -m "base"
+      git push --quiet origin main
+      git checkout --quiet -b feature
+      echo "work" > work.txt
+      git add work.txt
+      git commit --quiet -m "feat(dev): CTL-783 add draft pr early"
+      git push --quiet -u origin HEAD
+    ) 2>/dev/null
+    mkdir -p "$T24_BIN"
+    cat > "${T24_BIN}/gh" <<GHSTUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" >> "${T24_GH_LOG}"
+if [[ "\$1" == "pr" && "\$2" == "view" ]]; then exit 1; fi
+if [[ "\$1" == "pr" && "\$2" == "create" ]]; then
+  echo "https://github.com/test/repo/pull/42"; exit 0
+fi
+if [[ "\$1" == "repo" && "\$2" == "view" ]]; then
+  echo '{"defaultBranchRef":{"name":"main"}}'; exit 0
+fi
+exit 0
+GHSTUB
+    chmod +x "${T24_BIN}/gh"
+    (
+      cd "$T24_REPO"
+      PATH="${T24_BIN}:${PATH}" \
+        CLAUDE_PLUGIN_ROOT="${T24_PLUGIN}" \
+        CATALYST_PHASE=implement \
+        CATALYST_TICKET=CTL-783 \
+        bash "$EARLY_FENCE_BODY" >"${T24_DIR}/stdout1.log" 2>"${T24_DIR}/stderr1.log"
+      echo "$?" > "${T24_DIR}/exit1"
+    ) || true
+    assert_eq "0" "$(cat "${T24_DIR}/exit1" 2>/dev/null)" "Test 24I: fence exits 0 (enabled + commits)"
+    if grep -q 'create' "${T24_GH_LOG}" 2>/dev/null; then
+      pass "Test 24I: gh pr create called on first run"
+    else
+      fail "Test 24I: gh pr create should be called — log: $(cat "${T24_GH_LOG}" 2>/dev/null)"
+    fi
+    # Re-run with existing-PR stub: assert NO second create
+    T24_BIN2="${T24_DIR}/bin2"
+    T24_GH_LOG2="${T24_DIR}/gh2.log"
+    mkdir -p "$T24_BIN2"
+    cat > "${T24_BIN2}/gh" <<GHSTUB2
+#!/usr/bin/env bash
+printf '%s\n' "\$@" >> "${T24_GH_LOG2}"
+if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
+  printf '{"number":42,"url":"https://github.com/test/repo/pull/42","isDraft":true}\n'; exit 0
+fi
+if [[ "\$1" == "pr" && "\$2" == "create" ]]; then
+  echo "gh stub: create unexpectedly called" >&2; exit 1
+fi
+exit 0
+GHSTUB2
+    chmod +x "${T24_BIN2}/gh"
+    (
+      cd "$T24_REPO"
+      PATH="${T24_BIN2}:${PATH}" \
+        CLAUDE_PLUGIN_ROOT="${T24_PLUGIN}" \
+        CATALYST_PHASE=implement \
+        CATALYST_TICKET=CTL-783 \
+        bash "$EARLY_FENCE_BODY" >"${T24_DIR}/stdout2.log" 2>"${T24_DIR}/stderr2.log"
+      echo "$?" > "${T24_DIR}/exit2"
+    ) || true
+    assert_eq "0" "$(cat "${T24_DIR}/exit2" 2>/dev/null)" "Test 24I: fence exits 0 on idempotent run"
+    if grep -q 'create' "${T24_GH_LOG2}" 2>/dev/null; then
+      fail "Test 24I: gh pr create must NOT be called on idempotent run — log: $(cat "${T24_GH_LOG2}" 2>/dev/null)"
+    else
+      pass "Test 24I: gh pr create NOT called (idempotent)"
+    fi
+    # J. runtime gate: CATALYST_PHASE unset → gh log empty (no push, no create)
+    T24_GH_LOG3="${T24_DIR}/gh3.log"
+    T24_BIN3="${T24_DIR}/bin3"
+    mkdir -p "$T24_BIN3"
+    cat > "${T24_BIN3}/gh" <<GHSTUB3
+#!/usr/bin/env bash
+printf '%s\n' "\$@" >> "${T24_GH_LOG3}"; exit 0
+GHSTUB3
+    chmod +x "${T24_BIN3}/gh"
+    (
+      cd "$T24_REPO"
+      PATH="${T24_BIN3}:${PATH}" \
+        CLAUDE_PLUGIN_ROOT="${T24_PLUGIN}" \
+        CATALYST_PHASE="" \
+        bash "$EARLY_FENCE_BODY" >"${T24_DIR}/stdout3.log" 2>"${T24_DIR}/stderr3.log"
+      echo "$?" > "${T24_DIR}/exit3"
+    ) || true
+    assert_eq "0" "$(cat "${T24_DIR}/exit3" 2>/dev/null)" "Test 24J: fence exits 0 when CATALYST_PHASE unset"
+    if [[ -s "${T24_GH_LOG3}" ]]; then
+      fail "Test 24J: gh must NOT be called when CATALYST_PHASE unset — log: $(cat "${T24_GH_LOG3}" 2>/dev/null)"
+    else
+      pass "Test 24J: gh NOT called when CATALYST_PHASE unset (interactive mode)"
+    fi
+  else
+    fail "Test 24: implement-plan-draft-pr-early fence not extractable (not yet implemented)"
+  fi
+else
+  fail "Test 24: implement-plan/SKILL.md not found"
+fi
+
+# Test 24 extension: phase-implement prose mentions implement-plan opens draft PR early
+echo ""
+echo "Test 24 ext: phase-implement prose mentions early draft PR from implement-plan (backstop note)"
+if [[ -f "$SKILL_IMPLEMENT" ]]; then
+  if grep -q 'implement-plan-draft-pr-early\|backstop' "$SKILL_IMPLEMENT" 2>/dev/null; then
+    pass "Test 24 ext: phase-implement references implement-plan-draft-pr-early or backstop"
+  else
+    fail "Test 24 ext: phase-implement should mention implement-plan-draft-pr-early or call End-block fence a backstop"
+  fi
+fi
+
 # ─── Summary ────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
@@ -608,6 +608,87 @@ printf '{"catalyst":{"orchestration":{"draftPr":{"enabled":true}}}}\n' > "$P4D_C
 P4D_OUT="$(CATALYST_CONFIG_PATH="$P4D_CONFIG" draft_pr_enabled 2>/dev/null)"
 assert_eq "true" "$P4D_OUT" "4d: explicit true → enabled=true"
 
+# ─── Suite 5: draft_pr_title (CTL-783) ───────────────────────────────────────
+echo ""
+echo "Suite 5: draft_pr_title"
+
+# Source once for all Suite 5 tests.
+source "$DRAFT_PR_LIB"
+
+# 5a: conventional subject without ticket → ticket injected after the prefix colon
+echo "5a: conventional subject without ticket → ticket injected"
+P5A_OUT="$(draft_pr_title "CTL-783" "feat(dev): add early draft open" 2>/dev/null)"
+assert_eq "feat(dev): CTL-783 add early draft open" "$P5A_OUT" "5a: ticket injected after prefix"
+
+# 5b: subject already contains ticket → unchanged
+echo "5b: subject already contains ticket → unchanged"
+P5B_OUT="$(draft_pr_title "CTL-783" "feat(dev): CTL-783 add early draft open" 2>/dev/null)"
+assert_eq "feat(dev): CTL-783 add early draft open" "$P5B_OUT" "5b: unchanged when ticket already present"
+
+# 5c: bang variant preserved
+echo "5c: bang variant preserved"
+P5C_OUT="$(draft_pr_title "CTL-783" "feat(dev)!: break things" 2>/dev/null)"
+assert_eq "feat(dev)!: CTL-783 break things" "$P5C_OUT" "5c: bang variant preserved"
+
+# 5d: scopeless conventional subject
+echo "5d: scopeless conventional subject"
+P5D_OUT="$(draft_pr_title "CTL-783" "fix: a bug" 2>/dev/null)"
+assert_eq "fix: CTL-783 a bug" "$P5D_OUT" "5d: scopeless prefix → ticket injected"
+
+# 5e: non-conventional subject → "<ticket>: <subject>"
+echo "5e: non-conventional subject → ticket: subject"
+P5E_OUT="$(draft_pr_title "CTL-783" "add early draft open" 2>/dev/null)"
+assert_eq "CTL-783: add early draft open" "$P5E_OUT" "5e: non-conventional → ticket: subject"
+
+# 5f: empty ticket → subject unchanged
+echo "5f: empty ticket → subject unchanged"
+P5F_OUT="$(draft_pr_title "" "feat(dev): add X" 2>/dev/null)"
+assert_eq "feat(dev): add X" "$P5F_OUT" "5f: empty ticket → subject unchanged"
+
+# 5g: empty subject → echoes ticket
+echo "5g: empty subject → echoes ticket"
+P5G_OUT="$(draft_pr_title "CTL-783" "" 2>/dev/null)"
+assert_eq "CTL-783" "$P5G_OUT" "5g: empty subject → echoes ticket"
+
+# 5h: zsh-safe — draft_pr_title accessible under zsh
+echo "5h: zsh-safe — draft_pr_title accessible under zsh"
+ZSH5H="$(zsh -c "source '${DRAFT_PR_LIB}' && type draft_pr_title" 2>&1)"
+if echo "$ZSH5H" | grep -qE 'not found|error|Error'; then
+  fail "5h: draft_pr_title not accessible under zsh — got: $ZSH5H"
+else
+  pass "5h: draft_pr_title accessible under zsh"
+fi
+
+# Extend Suite 0 zsh check to include draft_pr_title
+ZSH_CHECK5="$(zsh -c "source '${DRAFT_PR_LIB}' && type draft_pr_title && draft_pr_title 'CTL-783' 'feat(dev): add X'" 2>&1)"
+if echo "$ZSH_CHECK5" | grep -q 'feat(dev): CTL-783 add X'; then
+  pass "5h: draft_pr_title produces correct output under zsh"
+else
+  fail "5h: draft_pr_title zsh output — got: $ZSH_CHECK5"
+fi
+
+# Suite 2 extension: draft_pr_ensure routes through draft_pr_title
+echo ""
+echo "Suite 2 (ext): draft_pr_ensure uses draft_pr_title for --title argument"
+new_fixture p2ext
+(cd "$WORK" && git push -u origin HEAD --quiet)
+P2EXT_BIN="${SCRATCH}/p2ext-bin"
+P2EXT_LOG="${SCRATCH}/p2ext.log"
+install_gh_stub_no_pr "$P2EXT_BIN" "$P2EXT_LOG"
+(
+  cd "$WORK"
+  PATH="${P2EXT_BIN}:${PATH}"
+  source "$DRAFT_PR_LIB"
+  draft_pr_ensure "main" "CTL-709" 2>/dev/null
+) || true
+# The gh stub logs all args one-per-line; find --title then check the following line
+TITLE_LINE="$(awk '/^--title$/{found=1; next} found{print; exit}' "$P2EXT_LOG" 2>/dev/null || true)"
+if [[ "$TITLE_LINE" == "feat: CTL-709 work commit" ]]; then
+  pass "Suite 2 ext: draft_pr_ensure routes through draft_pr_title (got: $TITLE_LINE)"
+else
+  fail "Suite 2 ext: draft_pr_ensure --title should be 'feat: CTL-709 work commit', got: '$TITLE_LINE'"
+fi
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
@@ -650,6 +650,16 @@ echo "5g: empty subject → echoes ticket"
 P5G_OUT="$(draft_pr_title "CTL-783" "" 2>/dev/null)"
 assert_eq "CTL-783" "$P5G_OUT" "5g: empty subject → echoes ticket"
 
+# 5i: multiple colons in subject → split on FIRST colon only (pins design decision)
+echo "5i: multiple colons → split on first colon only"
+P5I_OUT="$(draft_pr_title "CTL-783" "chore: a: b: c" 2>/dev/null)"
+assert_eq "chore: CTL-783 a: b: c" "$P5I_OUT" "5i: multi-colon subject splits on first colon"
+
+# 5j: uppercase type prefix is NOT conventional → falls through to "<ticket>: <subject>"
+echo "5j: uppercase type prefix → non-conventional fallback"
+P5J_OUT="$(draft_pr_title "CTL-783" "Feat(dev): uppercase type" 2>/dev/null)"
+assert_eq "CTL-783: Feat(dev): uppercase type" "$P5J_OUT" "5j: uppercase prefix treated as non-conventional"
+
 # 5h: zsh-safe — draft_pr_title accessible under zsh
 echo "5h: zsh-safe — draft_pr_title accessible under zsh"
 ZSH5H="$(zsh -c "source '${DRAFT_PR_LIB}' && type draft_pr_title" 2>&1)"

--- a/plugins/dev/scripts/lib/draft-pr.sh
+++ b/plugins/dev/scripts/lib/draft-pr.sh
@@ -40,6 +40,26 @@ draft_pr_push() {
   fi
 }
 
+# draft_pr_title TICKET SUBJECT — normalize a PR title to the work-record
+# convention `<type>(<scope>): <ticket> ...` (CTL-783). Never fabricates
+# type/scope; injects TICKET when absent. Pure function, safe under zsh.
+draft_pr_title() {
+  local ticket="${1:-}" subject="${2:-}"
+  [[ -z "$subject" ]] && { printf '%s\n' "$ticket"; return 0; }
+  [[ -z "$ticket" ]] && { printf '%s\n' "$subject"; return 0; }
+  case "$subject" in
+    *"$ticket"*) printf '%s\n' "$subject"; return 0 ;;
+  esac
+  if printf '%s' "$subject" | grep -qE '^[a-z]+(\([a-z0-9-]+\))?!?: '; then
+    local prefix rest
+    prefix="${subject%%: *}"
+    rest="${subject#*: }"
+    printf '%s: %s %s\n' "$prefix" "$ticket" "$rest"
+  else
+    printf '%s: %s\n' "$ticket" "$subject"
+  fi
+}
+
 # draft_pr_ensure BASE TICKET — ensure a PR exists for the current branch.
 # Echoes "<number>\t<url>\t<isDraft>". No-op if a PR already exists.
 # Falls back to a non-draft PR if --draft is rejected. Fail-open.
@@ -70,7 +90,8 @@ draft_pr_ensure() {
   if [[ -z "$commit_subj" ]]; then
     commit_subj="$(git log --no-merges --format='%s' --max-count=1 HEAD 2>/dev/null || true)"
   fi
-  title="${commit_subj:-${ticket:-${branch}}}"
+  title="$(draft_pr_title "${ticket}" "${commit_subj}")"
+  [[ -z "$title" ]] && title="${ticket:-${branch}}"
 
   # Build PR body: commit list + "Refs: TICKET" — no Claude attribution.
   local commit_list

--- a/plugins/dev/skills/create-pr/SKILL.md
+++ b/plugins/dev/skills/create-pr/SKILL.md
@@ -121,26 +121,27 @@ fi
 
 ### 7. Generate PR title from branch and ticket
 
+PR titles follow `<type>(<scope>): <ticket> ...` so active work is identifiable from GitHub
+alone. Prefer the first commit subject (it carries type/scope per commit conventions); inject
+the ticket via `draft_pr_title`. Branch-derived title remains the no-commit fallback.
+
 ```bash
-# Branch format examples:
-# - ENG-123-implement-pr-lifecycle → "ENG-123: implement pr lifecycle"
-# - feature-add-validation → "add validation"
-
-# Extract description from branch name
-if [[ "$ticket" ]]; then
-    # Remove ticket prefix from branch
-    desc=$(echo "$branch" | sed "s/^$ticket-//")
-    # Convert kebab-case to spaces
-    desc=$(echo "$desc" | tr '-' ' ')
-    # Capitalize first word
-    desc="$(tr '[:lower:]' '[:upper:]' <<< ${desc:0:1})${desc:1}"
-
-    title="$ticket: $desc"
+# CTL-783: PR titles follow `<type>(<scope>): <ticket> ...` convention.
+# Prefer first commit subject; branch-derived title is the no-commit fallback.
+source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/draft-pr.sh"
+commit_subj=$(git log --no-merges --format='%s' "origin/${base}..HEAD" 2>/dev/null | tail -1)
+if [[ -n "$commit_subj" ]]; then
+    title="$(draft_pr_title "$ticket" "$commit_subj")"
 else
-    # No ticket in branch
-    desc=$(echo "$branch" | tr '-' ' ')
-    desc="$(tr '[:lower:]' '[:upper:]' <<< ${desc:0:1})${desc:1}"
-    title="$desc"
+    # Branch-derived fallback (no commits or base unreachable)
+    if [[ "$ticket" ]]; then
+        desc=$(echo "$branch" | sed "s/^$ticket-//")
+        desc=$(echo "$desc" | tr '-' ' ')
+        title="$ticket: $desc"
+    else
+        desc=$(echo "$branch" | tr '-' ' ')
+        title="$desc"
+    fi
 fi
 ```
 

--- a/plugins/dev/skills/implement-plan/SKILL.md
+++ b/plugins/dev/skills/implement-plan/SKILL.md
@@ -144,6 +144,24 @@ If you encounter a mismatch:
 - Update your progress in both the plan and your todos
 - Check off completed items in the plan file itself using Edit
 - **Check context usage** - monitor token consumption
+- **Push + ensure the draft PR (phase-agent mode)** — In phase-agent mode the draft PR opens
+  at the first phase commit (see the `implement-plan-draft-pr-early` fence); interactive
+  `/catalyst-dev:implement-plan` runs skip this automatically via the CATALYST_PHASE gate.
+
+```bash implement-plan-draft-pr-early
+# CTL-783: make the PR the durable off-disk work record from the FIRST commit.
+# Run after EVERY plan-phase commit: first run opens the draft PR, later runs
+# just push (draft_pr_ensure is idempotent). Interactive runs (no
+# CATALYST_PHASE) skip — no surprise pushes. Fail-open: never blocks the phase.
+if [[ -n "${CATALYST_PHASE:-}" && -r "${CLAUDE_PLUGIN_ROOT}/scripts/lib/draft-pr.sh" ]]; then
+  # shellcheck source=/dev/null
+  source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/draft-pr.sh"
+  if [[ "$(draft_pr_enabled)" == "true" ]]; then
+    draft_pr_push || true
+    draft_pr_ensure "main" "${TICKET_ID:-${CATALYST_TICKET:-}}" >/dev/null 2>&1 || true
+  fi
+fi
+```
 
 Don't let verification interrupt your flow - batch full suite runs at natural stopping points. But
 always run the specific tests you wrote during each Red → Green cycle.

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -332,12 +332,12 @@ else
 fi
 ```
 
-CTL-709: push the branch and open a draft PR now that commits exist (past the empty-branch gate).
-The draft is fail-open — a push or PR failure prints a warning but does **not** block `--status
-complete`. Phase-pr detects and promotes the draft instead of creating a new PR (avoiding the
-`create-pr` interactive "PR already exists" hang). Gated on `draftPr.enabled` (default `true`)
-so it can be disabled with one config key. Writes `.draftPr={number,url,isDraft}` into the signal
-file so downstream phases can see the PR number without querying GitHub.
+CTL-783: The canonical `implement-plan` skill opens the draft PR at the **first** plan-phase
+commit via the `implement-plan-draft-pr-early` fence (idempotent — later commits just push).
+This End-block fence is the **idempotent backstop**: it fires after all phases complete and is
+the sole writer of `.draftPr` into the signal file. Gated on `draftPr.enabled` (default `true`)
+so it can be disabled with one config key. Phase-pr detects and promotes the draft instead of
+creating a new PR (avoiding the `create-pr` interactive "PR already exists" hang).
 
 ```bash phase-implement-draft-pr
 # CTL-709: open a draft PR + push as soon as we have commits, so CI runs during

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -81,6 +81,7 @@ The `orchestration.dispatchMode` key picks how Catalyst runs each ticket:
 | `orchestration.worktreeDir` | `~/catalyst/wt/<projectKey>` | Where worktrees are created |
 | `orchestration.phaseAgents.models[phase]` | `opus` | Model per step (`opus`, `sonnet`, or `haiku`). Phases: `triage`, `research`, `plan`, `implement`, `verify`, `review`, `pr`, `monitor-merge`, `monitor-deploy` |
 | `orchestration.phaseAgents.turnCaps[phase]` | per-phase | Max Claude turns per step |
+| `orchestration.draftPr.enabled` | `true` | Open a draft PR at the first implement commit; phase-pr flips it ready. Set `false` to create the PR only at the pr phase. |
 
 For `execution-core` mode, the number of workers comes from a separate committed block, `orchestration.executionCore.maxParallel` (default `4`). One daemon runs per machine and serves all your projects.
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-07T01:40:00Z -->
<!-- Last updated: 2026-06-07T01:40:00Z -->
<!-- PR: #1419 -->
<!-- Previous commits: ce68ecdb2529645b9550f89bfdd05276a6f1804f,a707ba1a2e568a93ca667e9ce47da2321326613b,68acf7cf1f5f93712007b46f7109cac223078e54,cee1896f2444f32b39f5dc0f97a04bd8bfc3da03 -->

## Summary

Makes the PR itself the durable, off-disk work record for active implementation. Previously the only trace of in-flight work was local disk (worktrees + signal files). Now:

- `phase-implement` opens a draft PR on its **first commit** and keeps pushing subsequent commits to it — the PR is visible in GitHub from the moment implementation begins
- `phase-pr` **promotes the draft to ready** (`gh pr ready`) rather than creating a fresh PR — the implement→review boundary is a state flip, not a new artifact
- PR titles follow `<type>(<scope>): <ticket> ...` via a new `draft_pr_title()` helper, so active work is identifiable from GitHub alone without inspecting disk

## Changes Made

### `plugins/dev/scripts/lib/draft-pr.sh`

- Added `draft_pr_title(ticket, subject)` — normalizes a commit subject to the `<type>(<scope>): <ticket> ...` work-record convention. Injects the ticket after the conventional prefix when absent; falls back to `<ticket>: <subject>` for non-conventional subjects. Pure function, zsh-safe.
- Wired `draft_pr_title` into `draft_pr_ensure` so all auto-opened draft PRs carry the ticket in the title from the first commit.

### `plugins/dev/skills/implement-plan/SKILL.md`

- Added `implement-plan-draft-pr-early` fence: runs after every plan-phase commit, gated on `CATALYST_PHASE` (interactive runs skip it), idempotent via `draft_pr_ensure`, fail-open.

### `plugins/dev/skills/phase-implement/SKILL.md`

- Updated End-block fence description: the End block is now the idempotent backstop and sole writer of the `.draftPr` signal, not the primary draft-PR creator.

### `plugins/dev/skills/create-pr/SKILL.md`

- Step 7 now derives the PR title via `draft_pr_title` using the first commit subject, with a branch-derived fallback for zero-commit branches.

### `docs/architecture.md`

- Added "PR as the durable work record (CTL-783)" subsection: branch naming, title convention, lifecycle (implement-plan early fence → phase-implement End-block backstop → phase-pr promote), config knob, and stretch goal.

### `website/src/content/docs/reference/configuration.md`

- Added `orchestration.draftPr.enabled` to the configuration reference table.

### Tests

- `plugins/dev/scripts/lib/__tests__/draft-pr.test.sh` — Suite 5 (5a–5h): `draft_pr_title` unit tests (ticket injection, idempotency, bang variant, scopeless, non-conventional, empty args, zsh-safe). Suite 2 extension: verifies `draft_pr_ensure` routes through `draft_pr_title`.
- `plugins/dev/scripts/__tests__/draft-pr-lib.test.sh` — thin wrapper so `run-tests.sh`'s glob discovers the lib suite.
- `plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh` — Test 24 (A–J): fence presence, gate contracts (CATALYST_PHASE guard, idempotency, fail-open), and runtime behavior.
- `plugins/dev/scripts/__tests__/create-pr-title.test.sh` — asserts the title convention, `git log` derivation, branch fallback, and docs presence.

## How to Verify It

- [x] All CI checks pass (Cloudflare Pages, audit-references, check-versions, docs-gate, validate) ✅
- [ ] `bun test plugins/dev/scripts/lib/__tests__/draft-pr.test.sh` — Suite 5 passes
- [ ] `bun test plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh` — Test 24 passes
- [ ] `bun test plugins/dev/scripts/__tests__/create-pr-title.test.sh` — title convention assertions pass
- [ ] Start a ticket through phase-implement; confirm a draft PR appears after the first commit with title matching `<type>(<scope>): <ticket> ...`
- [ ] Run phase-pr on the same ticket; confirm it promotes the draft to ready rather than creating a second PR

## Changelog Entry

**feat(dev):** phase-implement now opens a draft PR on its first commit using `draft_pr_title`-normalized titles; phase-pr promotes draft→ready. PR title convention `<type>(<scope>): <ticket> ...` applied consistently. Adds `orchestration.draftPr.enabled` config knob.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-783
