### PR TITLE
CTL-781: Catalyst self-assigns tickets it claims from To Do (visible ownership)

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -147,6 +147,30 @@ export function readLinearBotUserIds(layer1Path, layer2Path) {
   return ids;
 }
 
+// readLinearBotWriteId — the SINGLE bot UUID the daemon writes as assignee on
+// claim (CTL-781): the orchestrator app-actor identity, preferred from Layer-2,
+// falling back to the legacy Layer-1 monitor botUserId. Null = self-assign
+// disabled (the respect-assignment predicate still runs off the Set). Never throws.
+export function readLinearBotWriteId(layer1Path, layer2Path) {
+  // Prefer Layer-2: catalyst.linear.bot.orchestrator.botUserId.
+  if (layer2Path) {
+    try {
+      const p = JSON.parse(readFileSync(layer2Path, "utf8"));
+      const id = p?.catalyst?.linear?.bot?.orchestrator?.botUserId;
+      if (typeof id === "string" && id.length > 0) return id;
+    } catch { /* ignore */ }
+  }
+  // Fallback: Layer-1 catalyst.monitor.linear.botUserId.
+  if (layer1Path) {
+    try {
+      const p = JSON.parse(readFileSync(layer1Path, "utf8"));
+      const id = p?.catalyst?.monitor?.linear?.botUserId;
+      if (typeof id === "string" && id.length > 0) return id;
+    } catch { /* ignore */ }
+  }
+  return null;
+}
+
 // _isBotId — returns true when actorId is in the bot-ids set or (for backward
 // compat with tests that pass a plain string) equals the string directly.
 // Centralises the "is this the bot?" check used in the three self-echo guards.
@@ -408,17 +432,21 @@ export function startDaemon({
     // suppress self-echo from BOTH the worker app-actor AND the orchestrator
     // app-actor. Returns a Set<string> — empty = no filter (fail-open).
     const linearBotUserIds = readLinearBotUserIds(configPath, layer2Path);
+    const linearBotWriteId = readLinearBotWriteId(configPath, layer2Path); // CTL-781
     const commentInboxWriter = createCommentInboxWriter(orchDir, linearBotUserIds);
     monitorFn({
       orchDir,
       cache,
       concurrency, // CTL-716: slot-gate uses the same ceiling as the scheduler
+      botUserIds: linearBotUserIds, // CTL-781: respect-assignment gate
+      botWriteId: linearBotWriteId, // CTL-781: self-assign on claim
+      gateway: gatewayReader, // CTL-781: gateway-first assignee reads
       onComment: (parsed) => {
         commentInboxWriter(parsed); // CTL-749: write to inbox.jsonl for in-flight workers
         handleCommentWake(parsed, { orchDir, dispatch: dispatchTicket, removeLabel: defaultRemoveLabel, botUserId: linearBotUserIds }); // CTL-549 + CTL-756: re-dispatch parked tickets; botUserId suppresses self-echo
       },
       onUpdate: createUpdateInboxWriter(orchDir, linearBotUserIds), // CTL-749
-    }); // CTL-535 + CTL-565 + CTL-634 + CTL-549 + CTL-749 + CTL-716
+    }); // CTL-535 + CTL-565 + CTL-634 + CTL-549 + CTL-749 + CTL-716 + CTL-781
     // CTL-558: the scheduler writes Linear status via its default `writeStatus`
     // (linear-write.mjs) on every committed phase transition — no daemon wiring
     // needed; production uses the real module, tests inject fakes.
@@ -428,6 +456,8 @@ export function startDaemon({
       concurrency,
       configPath,
       layer2Path,
+      botUserIds: linearBotUserIds, // CTL-781: respect-assignment gate
+      botWriteId: linearBotWriteId, // CTL-781: self-assign on claim
       // CTL-671: arm the phantom worker-dir validity sweep + bg-liveness reader.
       // CTL-823: the sweep's existence probe consults the durable broker
       // descriptor store first (gateway-read.mjs) — a fresh not-removed

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -31,6 +31,7 @@ import {
   createCommentInboxWriter,
   createUpdateInboxWriter,
   readLinearBotUserIds,
+  readLinearBotWriteId,
   _isBotId,
 } from "./daemon.mjs";
 import { getEventLogPath } from "./config.mjs";
@@ -1462,5 +1463,38 @@ describe("CTL-823 gateway wiring", () => {
     // daemon's reader cannot be dropped by the caller's opts.
     expect(captured.classifyResolution("CTL-MISSING", { exec })).toBe("not-found");
     expect(execCalls.length).toBe(1);
+  });
+});
+
+// readLinearBotWriteId — resolves the SINGLE bot UUID to write as assignee (CTL-781).
+describe("readLinearBotWriteId (CTL-781)", () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), "bot-write-id-test-")); });
+  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  test("returns catalyst.linear.bot.orchestrator.botUserId from Layer-2 when present", () => {
+    const layer2 = join(tmpDir, "config.json");
+    writeFileSync(layer2, JSON.stringify({
+      catalyst: { linear: { bot: { orchestrator: { botUserId: "orch-uuid-1" } } } }
+    }));
+    expect(readLinearBotWriteId(null, layer2)).toBe("orch-uuid-1");
+  });
+
+  test("falls back to Layer-1 catalyst.monitor.linear.botUserId when Layer-2 absent", () => {
+    const layer1 = join(tmpDir, "layer1.json");
+    writeFileSync(layer1, JSON.stringify({
+      catalyst: { monitor: { linear: { botUserId: "legacy-uuid-1" } } }
+    }));
+    expect(readLinearBotWriteId(layer1, null)).toBe("legacy-uuid-1");
+  });
+
+  test("returns null when neither layer configures an ID (self-assign disabled)", () => {
+    expect(readLinearBotWriteId("/nonexistent/l1.json", "/nonexistent/l2.json")).toBeNull();
+  });
+
+  test("never throws on unreadable/malformed files", () => {
+    const bad = join(tmpDir, "bad.json");
+    writeFileSync(bad, "not-json{{");
+    expect(() => readLinearBotWriteId(bad, bad)).not.toThrow();
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -413,6 +413,37 @@ export function classifyTicketResolution(
   return id ? "exists" : "not-found";
 }
 
+// fetchTicketAssignee — the CTL-781 respect-assignment read: the ticket's
+// current assignee UUID (or null = unassigned), gateway-first so the hot
+// new-work predicate is rate-free, live `linearis issues read` on a miss.
+// Tri-state return so callers can distinguish "known unassigned" from
+// "couldn't read": { known: true, assignee: string|null } | { known: false }.
+// A not-removed descriptor is trusted regardless of age (the assignment gate
+// is rate-free by design; a stale miss is corrected by the future Reconciler).
+export function fetchTicketAssignee(identifier, { exec = defaultExec, gateway } = {}) {
+  if (gateway) {
+    const d = gateway.getDescriptor(identifier);
+    if (d && !d.removed) return { known: true, assignee: d.assignee ?? null };
+  }
+  const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
+  if (code !== 0) return { known: false };
+  try {
+    const node = JSON.parse(stdout);
+    return { known: true, assignee: node?.assignee?.id ?? null };
+  } catch {
+    return { known: false };
+  }
+}
+
+// isAssigneeClaimable — the CTL-781 rule-set predicate: a ticket is the
+// daemon's to claim iff assignee ∈ {null, bot}. Pure; shared by the scheduler
+// new-work pull, the monitor triage one-shot, and (future) the CTL-780
+// staleness sweep.
+export function isAssigneeClaimable(assignee, botUserIds) {
+  if (assignee == null) return true;
+  return botUserIds instanceof Set && botUserIds.has(assignee);
+}
+
 // runEligibleQuery — run the query, parse + normalize, apply the priority
 // floor. A non-zero linearis exit THROWS (never a silent []): a silent empty
 // would let one failed poll flatten a project's eligible set to zero. The

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -13,6 +13,8 @@ import {
   buildBatchCurlArgs,
   isBatchRateLimited,
   classifyTicketResolution,
+  fetchTicketAssignee,
+  isAssigneeClaimable,
 } from "./linear-query.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 
@@ -856,5 +858,91 @@ describe("fetchTicketState — gateway state-freshness boundary (CTL-823)", () =
     const stale = fakeGateway({ ticket: "CTL-21", state: "Todo", removed: false, updatedAt: at(61_000) });
     expect(fetchTicketState("CTL-21", { exec, gateway: stale })).toBe("PR");
     expect(exec.calls.length).toBe(1);
+  });
+});
+
+// ─── CTL-781: fetchTicketAssignee + isAssigneeClaimable ─────────────────────
+
+describe("fetchTicketAssignee (CTL-781)", () => {
+  const BOT = "ff78d890-7906-4c22-b2f5-020bd150c790";
+
+  test("gateway descriptor present + !removed → {known:true, assignee:<uuid>}, zero exec", () => {
+    const exec = fakeExec({ code: 0, stdout: "{}" });
+    const gateway = fakeGateway({ ticket: "CTL-1", assignee: BOT, removed: false, updatedAt: FRESH() });
+    const r = fetchTicketAssignee("CTL-1", { exec, gateway });
+    expect(r).toEqual({ known: true, assignee: BOT });
+    expect(exec.calls.length).toBe(0);
+  });
+
+  test("gateway descriptor present with assignee null → {known:true, assignee:null}, zero exec", () => {
+    const exec = fakeExec({ code: 0, stdout: "{}" });
+    const gateway = fakeGateway({ ticket: "CTL-2", assignee: null, removed: false, updatedAt: FRESH() });
+    const r = fetchTicketAssignee("CTL-2", { exec, gateway });
+    expect(r).toEqual({ known: true, assignee: null });
+    expect(exec.calls.length).toBe(0);
+  });
+
+  test("gateway descriptor removed → falls through to live read", () => {
+    const exec = fakeExec({ code: 0, stdout: JSON.stringify({ assignee: { id: BOT } }) });
+    const gateway = fakeGateway({ ticket: "CTL-3", assignee: BOT, removed: true, updatedAt: FRESH() });
+    const r = fetchTicketAssignee("CTL-3", { exec, gateway });
+    expect(r).toEqual({ known: true, assignee: BOT });
+    expect(exec.calls.length).toBe(1);
+  });
+
+  test("gateway absent/miss (getDescriptor null) → live read parses assignee.id", () => {
+    const exec = fakeExec({ code: 0, stdout: JSON.stringify({ assignee: { id: BOT } }) });
+    const gateway = fakeGateway(null);
+    const r = fetchTicketAssignee("CTL-4", { exec, gateway });
+    expect(r).toEqual({ known: true, assignee: BOT });
+    expect(exec.calls.length).toBe(1);
+  });
+
+  test("live read: top-level assignee null → {known:true, assignee:null}", () => {
+    const exec = fakeExec({ code: 0, stdout: JSON.stringify({ assignee: null }) });
+    const r = fetchTicketAssignee("CTL-5", { exec });
+    expect(r).toEqual({ known: true, assignee: null });
+  });
+
+  test("live read non-zero exit → {known:false}", () => {
+    const exec = fakeExec({ code: 1, stdout: "", stderr: "fail" });
+    const r = fetchTicketAssignee("CTL-6", { exec });
+    expect(r).toEqual({ known: false });
+  });
+
+  test("live read unparseable stdout → {known:false}", () => {
+    const exec = fakeExec({ code: 0, stdout: "not-json" });
+    const r = fetchTicketAssignee("CTL-7", { exec });
+    expect(r).toEqual({ known: false });
+  });
+
+  test("no gateway param at all → straight to live read", () => {
+    const exec = fakeExec({ code: 0, stdout: JSON.stringify({ assignee: { id: BOT } }) });
+    const r = fetchTicketAssignee("CTL-8", { exec });
+    expect(r).toEqual({ known: true, assignee: BOT });
+    expect(exec.calls.length).toBe(1);
+  });
+});
+
+describe("isAssigneeClaimable (CTL-781)", () => {
+  const BOT = "ff78d890-7906-4c22-b2f5-020bd150c790";
+
+  test("null assignee → claimable regardless of botUserIds", () => {
+    expect(isAssigneeClaimable(null, new Set([BOT]))).toBe(true);
+    expect(isAssigneeClaimable(null, new Set())).toBe(true);
+    expect(isAssigneeClaimable(null, undefined)).toBe(true);
+  });
+
+  test("assignee in botUserIds Set → claimable", () => {
+    expect(isAssigneeClaimable(BOT, new Set([BOT]))).toBe(true);
+  });
+
+  test("assignee NOT in botUserIds Set → NOT claimable", () => {
+    expect(isAssigneeClaimable("human-uuid", new Set([BOT]))).toBe(false);
+  });
+
+  test("empty botUserIds Set + non-null assignee → NOT claimable", () => {
+    expect(isAssigneeClaimable(BOT, new Set())).toBe(false);
+    expect(isAssigneeClaimable("human-uuid", new Set())).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -418,6 +418,48 @@ export function applyEstimate({ ticket, estimate, exec = defaultExec, fetchLabel
   }
 }
 
+// applyAssignee — write the Catalyst bot as the Linear assignee on a claimed
+// ticket (CTL-781). Mirrors applyLabel: try/catch, log.warn, tagged
+// {applied, reason} return, CTL-587-style read-back so applied:true means a
+// follow-up read confirmed the assignee landed. Never throws.
+// reason values: null | "invalid-user" | "transient" | "verify-failed".
+export function applyAssignee({ ticket, userId, exec = defaultExec }) {
+  if (typeof userId !== "string" || userId.length === 0) {
+    return { applied: false, reason: "invalid-user" };
+  }
+  try {
+    const writeRes = exec("linearis", ["issues", "update", ticket, "--assignee", userId]);
+    if (writeRes.code !== 0) {
+      log.warn(
+        { ticket, userId, code: writeRes.code, stderr: writeRes.stderr },
+        "linear-write: assignee write failed (exit non-zero)"
+      );
+      return { applied: false, reason: "transient" };
+    }
+    const readRes = exec("linearis", ["issues", "read", ticket]);
+    let actual = null;
+    try {
+      actual = JSON.parse(readRes.stdout ?? "")?.assignee?.id ?? null;
+    } catch {
+      /* unparseable read-back — falls through to verify-failed */
+    }
+    if (readRes.code !== 0 || actual !== userId) {
+      log.warn(
+        { ticket, userId, readback: actual },
+        "linear-write: assignee write exit-0 but read-back mismatch (silent-success gap)"
+      );
+      return { applied: false, reason: "verify-failed" };
+    }
+    return { applied: true, reason: null };
+  } catch (err) {
+    log.warn(
+      { ticket, userId, reason: "transient", err: err.message },
+      "linear-write: assignee write threw — swallowed"
+    );
+    return { applied: false, reason: "transient" };
+  }
+}
+
 // applyBlockedByRelation — additively write a durable blocked-by edge
 // (CTL-537). Best-effort, never throws; mirrors applyLabel but without a
 // read-back: a blocked-by relation is durable (research:140) and the seam

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -9,6 +9,7 @@ import {
   removeLabel,
   applyBlockedByRelation,
   applyEstimate,
+  applyAssignee,
   teamOf,
 } from "./linear-write.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
@@ -814,5 +815,95 @@ describe("applyEstimate", () => {
     expect(r.skipped).toBe("human-estimate");
     expect(calls).toHaveLength(1);
     expect(calls[0].args.slice(0, 2)).toEqual(["issues", "read"]);
+  });
+});
+
+describe("applyAssignee (CTL-781)", () => {
+  const BOT = "ff78d890-7906-4c22-b2f5-020bd150c790";
+
+  function makeOkExec(calls) {
+    return (cmd, args) => {
+      calls.push({ cmd, args });
+      if (args[0] === "issues" && args[1] === "update") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "issues" && args[1] === "read") {
+        return { code: 0, stdout: JSON.stringify({ assignee: { id: BOT } }), stderr: "" };
+      }
+      return { code: 127, stdout: "", stderr: "unexpected" };
+    };
+  }
+
+  test("shells linearis issues update --assignee <uuid>", () => {
+    const calls = [];
+    applyAssignee({ ticket: "CTL-1", userId: BOT, exec: makeOkExec(calls) });
+    expect(calls[0].args.slice(0, 3)).toEqual(["issues", "update", "CTL-1"]);
+    expect(calls[0].args).toContain("--assignee");
+    expect(calls[0].args[calls[0].args.indexOf("--assignee") + 1]).toBe(BOT);
+  });
+
+  test("write exit-0 AND read-back assignee.id matches → applied:true, reason:null", () => {
+    const calls = [];
+    const r = applyAssignee({ ticket: "CTL-1", userId: BOT, exec: makeOkExec(calls) });
+    expect(r).toEqual({ applied: true, reason: null });
+    expect(calls[0].args.slice(0, 2)).toEqual(["issues", "update"]);
+    expect(calls[1].args.slice(0, 2)).toEqual(["issues", "read"]);
+  });
+
+  test("write exits non-zero → applied:false, reason:'transient', no read-back exec", () => {
+    const calls = [];
+    const exec = (cmd, args) => {
+      calls.push({ cmd, args });
+      return { code: 1, stdout: "", stderr: "update-failed" };
+    };
+    const r = applyAssignee({ ticket: "CTL-1", userId: BOT, exec });
+    expect(r).toEqual({ applied: false, reason: "transient" });
+    expect(calls).toHaveLength(1);
+  });
+
+  test("write exit-0 BUT read-back assignee null → applied:false, reason:'verify-failed'", () => {
+    const exec = (_cmd, args) => {
+      if (args[1] === "update") return { code: 0, stdout: "", stderr: "" };
+      if (args[1] === "read") return { code: 0, stdout: JSON.stringify({ assignee: null }), stderr: "" };
+      return { code: 127 };
+    };
+    const r = applyAssignee({ ticket: "CTL-1", userId: BOT, exec });
+    expect(r).toEqual({ applied: false, reason: "verify-failed" });
+  });
+
+  test("write exit-0 BUT read-back assignee.id differs → applied:false, reason:'verify-failed'", () => {
+    const exec = (_cmd, args) => {
+      if (args[1] === "update") return { code: 0, stdout: "", stderr: "" };
+      if (args[1] === "read") return { code: 0, stdout: JSON.stringify({ assignee: { id: "other-uuid" } }), stderr: "" };
+      return { code: 127 };
+    };
+    const r = applyAssignee({ ticket: "CTL-1", userId: BOT, exec });
+    expect(r).toEqual({ applied: false, reason: "verify-failed" });
+  });
+
+  test("read-back unparseable stdout → applied:false, reason:'verify-failed'", () => {
+    const exec = (_cmd, args) => {
+      if (args[1] === "update") return { code: 0, stdout: "", stderr: "" };
+      if (args[1] === "read") return { code: 0, stdout: "not-json", stderr: "" };
+      return { code: 127 };
+    };
+    const r = applyAssignee({ ticket: "CTL-1", userId: BOT, exec });
+    expect(r).toEqual({ applied: false, reason: "verify-failed" });
+  });
+
+  test("never throws — a thrown exec is caught, applied:false reason:'transient'", () => {
+    const exec = () => { throw new Error("exec died"); };
+    expect(() => applyAssignee({ ticket: "CTL-1", userId: BOT, exec })).not.toThrow();
+    const r = applyAssignee({ ticket: "CTL-1", userId: BOT, exec });
+    expect(r).toEqual({ applied: false, reason: "transient" });
+  });
+
+  test("missing userId → applied:false, reason:'invalid-user', zero exec calls", () => {
+    const calls = [];
+    const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0 }; };
+    expect(applyAssignee({ ticket: "CTL-1", userId: "", exec })).toEqual({ applied: false, reason: "invalid-user" });
+    expect(applyAssignee({ ticket: "CTL-1", userId: null, exec })).toEqual({ applied: false, reason: "invalid-user" });
+    expect(applyAssignee({ ticket: "CTL-1", exec })).toEqual({ applied: false, reason: "invalid-user" });
+    expect(calls).toHaveLength(0);
   });
 });

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -35,12 +35,12 @@ import {
   log,
 } from "./config.mjs";
 import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry.mjs";
-import { runEligibleQuery } from "./linear-query.mjs";
+import { runEligibleQuery, fetchTicketAssignee, isAssigneeClaimable } from "./linear-query.mjs";
 import { setProjectEligible, removeTicket, dropProject, getEligibleSet, upsertTicket } from "./eligible-set.mjs";
 import { loadCursor, saveCursor, resolveStartOffset } from "./event-cursor.mjs";
 import { dispatchTicket } from "./dispatch.mjs";
 import { abortWorker as defaultAbortWorker } from "./abort-worker.mjs";
-import { applyTriageStatus as defaultApplyTriageStatus } from "./linear-write.mjs";
+import { applyTriageStatus as defaultApplyTriageStatus, applyAssignee as defaultApplyAssignee } from "./linear-write.mjs";
 import { appendTriageTransitionEvent as defaultAppendEvent } from "./triage-transition-event.mjs";
 import { countBackgroundAgents, resetLivenessCache } from "./claude-agents.mjs";
 import { readMaxParallel, computeFreeSlots } from "./scheduler.mjs";
@@ -306,6 +306,12 @@ export function handleStateChangedEvent(
     readMaxParallelFn = readMaxParallel,
     liveBackgroundCount = () => countBackgroundAgents(),
     triageBudget,
+    // CTL-781: respect-assignment + self-assign seams.
+    botUserIds,
+    botWriteId,
+    gateway,
+    fetchAssignee = fetchTicketAssignee,
+    applyAssignee = defaultApplyAssignee,
   } = {}
 ) {
   const parsed = parseStateChangedEvent(event);
@@ -339,6 +345,11 @@ export function handleStateChangedEvent(
           appendEvent,
           orchId: parsed.identifier,
           budget, // CTL-716
+          botUserIds,
+          botWriteId,
+          gateway,
+          fetchAssignee,
+          applyAssignee,
         });
       }
     } else if (!parsed.toState || parsed.toState === query.status) {
@@ -385,6 +396,11 @@ export function handleStateChangedEvent(
           appendEvent,
           orchId: parsed.identifier,
           budget, // CTL-716
+          botUserIds,
+          botWriteId,
+          gateway,
+          fetchAssignee,
+          applyAssignee,
         });
       } else {
         log.debug(
@@ -455,6 +471,12 @@ function dispatchTriage(identifier, {
   appendEvent = defaultAppendEvent,
   orchId,
   budget,
+  // CTL-781: respect-assignment + self-assign seams.
+  botUserIds,
+  botWriteId,
+  gateway,
+  fetchAssignee = fetchTicketAssignee,
+  applyAssignee = defaultApplyAssignee,
 }) {
   if (!orchDir) {
     log.warn({ identifier }, "→Triage seen but monitor has no orchDir — skipping dispatch");
@@ -466,6 +488,20 @@ function dispatchTriage(identifier, {
       "monitor: triage dispatch deferred — no free slots (maxParallel); sweepMissingTriage will retry (CTL-716)"
     );
     return false;
+  }
+  // CTL-781: respect-assignment gate — a →Triage/→Todo ticket assigned to a
+  // non-bot is a human's; never claim it. Gateway-first, live read on miss;
+  // unknown holds (sweepMissingTriage retries next reconcile). Empty/absent
+  // botUserIds disables the gate (CTL-749 fail-open convention).
+  if (botUserIds instanceof Set && botUserIds.size > 0) {
+    const a = fetchAssignee(identifier, { gateway });
+    if (!a.known || !isAssigneeClaimable(a.assignee, botUserIds)) {
+      log.info(
+        { identifier, known: a.known, assignee: a.known ? (a.assignee ?? null) : undefined },
+        "monitor: triage dispatch skipped — respect-assignment (CTL-781)"
+      );
+      return false;
+    }
   }
   const r = dispatchTicket(orchDir, identifier, "triage", { dispatch });
   if (r.code !== 0) {
@@ -489,6 +525,14 @@ function dispatchTriage(identifier, {
     applied: res.applied,
     reason: res.reason,
   });
+  // CTL-781: self-assign the bot on claim — best-effort, never blocks triage.
+  if (botWriteId) {
+    try {
+      applyAssignee({ ticket: identifier, userId: botWriteId });
+    } catch (err) {
+      log.warn({ identifier, err: err.message }, "monitor: self-assign threw — continuing");
+    }
+  }
   return true;
 }
 
@@ -523,6 +567,12 @@ export function sweepMissingTriage({
   concurrency = {},
   readMaxParallelFn = readMaxParallel,
   liveBackgroundCount = () => countBackgroundAgents(),
+  // CTL-781: respect-assignment + self-assign seams.
+  botUserIds,
+  botWriteId,
+  gateway,
+  fetchAssignee = fetchTicketAssignee,
+  applyAssignee = defaultApplyAssignee,
 } = {}) {
   if (!orchDir) {
     log.debug("sweepMissingTriage: no orchDir wired — skipping triage sweep");
@@ -541,6 +591,11 @@ export function sweepMissingTriage({
         appendEvent,
         orchId: t.identifier,
         budget,
+        botUserIds,
+        botWriteId,
+        gateway,
+        fetchAssignee,
+        applyAssignee,
       });
     }
   }
@@ -719,6 +774,10 @@ export function startMonitor({
   concurrency = {},
   readMaxParallelFn,
   liveBackgroundCount,
+  // CTL-781: respect-assignment + self-assign seams.
+  botUserIds,
+  botWriteId,
+  gateway,
 } = {}) {
   // CTL-565: orchDir + dispatch + abortWorker are stored in tailerOpts so the
   // tailer-driven readNewEvents → handleStateChangedEvent path can one-shot-
@@ -726,9 +785,9 @@ export function startMonitor({
   // undefined, handleStateChangedEvent falls back to its real default.
   // CTL-634: cache rides in tailerOpts too so the tailer's write-through path
   // populates the same instance the scheduler reads.
-  tailerOpts = { exec, debounceMs, orchDir, dispatch, abortWorker, cache, onComment, onUpdate, concurrency, readMaxParallelFn, liveBackgroundCount };
+  tailerOpts = { exec, debounceMs, orchDir, dispatch, abortWorker, cache, onComment, onUpdate, concurrency, readMaxParallelFn, liveBackgroundCount, botUserIds, botWriteId, gateway };
   reconcileAll({ exec });
-  sweepMissingTriage({ orchDir, dispatch, concurrency, readMaxParallelFn, liveBackgroundCount }); // CTL-711: triage pre-existing eligible tickets
+  sweepMissingTriage({ orchDir, dispatch, concurrency, readMaxParallelFn, liveBackgroundCount, botUserIds, botWriteId, gateway }); // CTL-711: triage pre-existing eligible tickets
   if (resumeFromCursor) {
     seedTailerFromCursor();
     // CTL-731 Phase 00: drain the cursor→EOF downtime gap FOLD-ONLY. Pre-CTL-731
@@ -754,7 +813,7 @@ export function startMonitor({
   }
   reconcileTimer = setInterval(() => {
     reconcileAll({ exec });
-    sweepMissingTriage({ orchDir, dispatch, concurrency, readMaxParallelFn, liveBackgroundCount }); // CTL-711 + CTL-716: catch tickets that appeared between webhooks
+    sweepMissingTriage({ orchDir, dispatch, concurrency, readMaxParallelFn, liveBackgroundCount, botUserIds, botWriteId, gateway }); // CTL-711 + CTL-716: catch tickets that appeared between webhooks
   }, reconcileIntervalMs);
 }
 

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -1509,3 +1509,151 @@ describe("handleIssueUpdatedEvent — onUpdate seam (CTL-749)", () => {
     stopMonitor();
   });
 });
+
+// ── CTL-781: respect-assignment + self-assign in dispatchTriage + sweep ──────
+
+describe("dispatchTriage — CTL-781 respect-assignment + self-assign", () => {
+  const BOT = "ff78d890-7906-4c22-b2f5-020bd150c790";
+  const HUMAN = "11111111-1111-1111-1111-111111111111";
+  const orchDir = "/orch-781";
+
+  function toTriageEvent(ticket) {
+    return {
+      event: "linear.issue.state_changed",
+      detail: { ticket, teamKey: "ENG", toState: "Triage" },
+    };
+  }
+
+  test("→Triage for a human-assigned ticket → NO dispatch, budget not decremented", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const applyAssignee = mock(() => ({ applied: true, reason: null }));
+    const fetchAssignee = () => ({ known: true, assignee: HUMAN });
+    handleStateChangedEvent(toTriageEvent("ENG-H1"), {
+      dispatch,
+      orchDir,
+      botUserIds: new Set([BOT]),
+      botWriteId: BOT,
+      fetchAssignee,
+      applyAssignee,
+      triageBudget: { remaining: 5 },
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(applyAssignee).not.toHaveBeenCalled();
+  });
+
+  test("→Triage for an unassigned ticket → dispatch fires AND applyAssignee called with botWriteId", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const applyTriageStatus = mock(() => ({ applied: true, verified: true, from_state: "Todo", to_state: "Triage", reason: null }));
+    const appendEvent = mock(() => {});
+    const applyAssignee = mock(() => ({ applied: true, reason: null }));
+    const fetchAssignee = () => ({ known: true, assignee: null });
+    handleStateChangedEvent(toTriageEvent("ENG-N1"), {
+      dispatch,
+      orchDir,
+      applyTriageStatus,
+      appendEvent,
+      botUserIds: new Set([BOT]),
+      botWriteId: BOT,
+      fetchAssignee,
+      applyAssignee,
+      triageBudget: { remaining: 5 },
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(applyAssignee).toHaveBeenCalledTimes(1);
+    expect(applyAssignee.mock.calls[0][0]).toMatchObject({ ticket: "ENG-N1", userId: BOT });
+  });
+
+  test("→Triage for a bot-assigned ticket → dispatch fires (re-claim of own ticket OK)", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const fetchAssignee = () => ({ known: true, assignee: BOT });
+    handleStateChangedEvent(toTriageEvent("ENG-B1"), {
+      dispatch,
+      orchDir,
+      botUserIds: new Set([BOT]),
+      fetchAssignee,
+      triageBudget: { remaining: 5 },
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  test("assignee unknown (no gateway, live read fails) → dispatch SKIPPED this event (sweep retries)", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const fetchAssignee = () => ({ known: false });
+    handleStateChangedEvent(toTriageEvent("ENG-U1"), {
+      dispatch,
+      orchDir,
+      botUserIds: new Set([BOT]),
+      fetchAssignee,
+      triageBudget: { remaining: 5 },
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  test("no botUserIds threaded → gate skipped, dispatches as today (all existing tests unchanged)", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const fetchAssignee = mock(() => ({ known: true, assignee: HUMAN }));
+    handleStateChangedEvent(toTriageEvent("ENG-ND1"), {
+      dispatch,
+      orchDir,
+      fetchAssignee,
+      triageBudget: { remaining: 5 },
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(fetchAssignee).not.toHaveBeenCalled();
+  });
+
+  test("applyAssignee absent/failing → dispatch still completes, applyTriageStatus + appendEvent unaffected", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const applyTriageStatus = mock(() => ({ applied: true, verified: true, from_state: "Todo", to_state: "Triage", reason: null }));
+    const appendEvent = mock(() => {});
+    const applyAssignee = mock(() => ({ applied: false, reason: "transient" }));
+    const fetchAssignee = () => ({ known: true, assignee: null });
+    handleStateChangedEvent(toTriageEvent("ENG-FA1"), {
+      dispatch,
+      orchDir,
+      applyTriageStatus,
+      appendEvent,
+      botUserIds: new Set([BOT]),
+      botWriteId: BOT,
+      fetchAssignee,
+      applyAssignee,
+      triageBudget: { remaining: 5 },
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(applyTriageStatus).toHaveBeenCalledTimes(1);
+    expect(appendEvent).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("sweepMissingTriage — CTL-781 threading", () => {
+  const BOT = "ff78d890-7906-4c22-b2f5-020bd150c790";
+  const HUMAN = "11111111-1111-1111-1111-111111111111";
+
+  test("sweep passes botUserIds/botWriteId/gateway through to dispatchTriage (human-assigned eligible ticket skipped)", () => {
+    enroll("ENG", { status: "Ready" });
+    setProjectEligible("ENG", [{ identifier: "ENG-SW1", state: "Todo", priority: 2, project: null }]);
+    const orchDir = mkdtempSync(join(tmpdir(), "sw-orch-"));
+    try {
+      const dispatch = mock(() => ({ code: 0 }));
+      const fetchAssignee = mock(() => ({ known: true, assignee: HUMAN }));
+      sweepMissingTriage({
+        orchDir,
+        dispatch,
+        botUserIds: new Set([BOT]),
+        fetchAssignee,
+        readMaxParallelFn: () => 5,
+        liveBackgroundCount: () => 0,
+      });
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(fetchAssignee).toHaveBeenCalledWith("ENG-SW1", expect.anything());
+    } finally {
+      rmSync(orchDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -61,7 +61,7 @@ import { readVerifyVerdict } from "./work-done-probes.mjs";
 import { countRemediateCycles, countTicketEventsInWindow } from "./event-scan.mjs";
 import { rankTickets, compareTickets } from "./scheduler-rank.mjs";
 import { defaultDispatch, dispatchTicket, teamOf } from "./dispatch.mjs";
-import { fetchTicketState, fetchTicketsBatch, classifyTicketResolution } from "./linear-query.mjs";
+import { fetchTicketState, fetchTicketsBatch, classifyTicketResolution, fetchTicketAssignee, isAssigneeClaimable } from "./linear-query.mjs";
 import { getProjectConfig, listProjects } from "./registry.mjs";
 // CTL-791: the terminal-Done sweep removes a worktree ONLY through the evidence
 // gate (GitHub-merged + clean + no-live-session + orchestrator-provenance,
@@ -1819,6 +1819,15 @@ export function schedulerTick(
     // fetchState injections below. undefined in bare unit ticks (fail-open —
     // fetchTicketState without gateway behaves exactly as before).
     gateway = undefined,
+    // CTL-781: respect-assignment + self-assign. botUserIds is the Set of known
+    // bot UUIDs (predicate membership); botWriteId is the single orchestrator
+    // UUID written as assignee on claim. undefined / empty Set → the gate and
+    // the write are both skipped (fail-open, CTL-749 convention) — every
+    // existing test and unconfigured install behaves byte-for-byte as before.
+    botUserIds = undefined,
+    botWriteId = undefined,
+    // CTL-781: injectable assignee read so tests never shell out.
+    fetchAssignee = fetchTicketAssignee,
     // CTL-671: runaway-alert seams. countTicketEvents reads the unified event
     // log (safe in tests — CATALYST_DIR is redirected), so it defaults to the
     // real scan; appendRunawayEvent writes the canonical alert. Both injectable
@@ -2836,6 +2845,25 @@ export function schedulerTick(
     // CTL-671: circuit breaker — stop re-dispatching a new-work ticket that has
     // failed its entry-phase dispatch THRESHOLD times in a row.
     if (maybeTripCircuitBreaker(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE)) continue;
+    // CTL-781: respect-assignment gate — claim only assignee ∈ {null, bot}.
+    // Gateway-first (rate-free); live read only on a miss. An unreadable
+    // assignee HOLDS the candidate this tick (fail-safe) — it is not a dispatch
+    // failure, so no cooldown marker and no failure event. Empty/absent
+    // botUserIds disables the gate (CTL-749 fail-open convention).
+    if (botUserIds instanceof Set && botUserIds.size > 0) {
+      const a = fetchAssignee(t.identifier, { gateway, exec });
+      if (!a.known) {
+        log.debug({ ticket: t.identifier }, "ctl-781: assignee unreadable — holding candidate this tick");
+        continue;
+      }
+      if (!isAssigneeClaimable(a.assignee, botUserIds)) {
+        log.debug(
+          { ticket: t.identifier, assignee: a.assignee },
+          "ctl-781: candidate assigned to a non-bot — skipping (respect-assignment)"
+        );
+        continue;
+      }
+    }
     // CTL-660: record the new-work dispatch DECISION before the spawn.
     safeEmit(
       appendDispatchRequestedEvent,
@@ -2888,6 +2916,15 @@ export function schedulerTick(
           },
           { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE }
         );
+        // CTL-781: self-assign the Catalyst bot so the claim is visible in
+        // Linear. Best-effort (safeWrite) — an assignment failure never blocks
+        // the pipeline; the read-back inside applyAssignee logs the gap.
+        if (botWriteId) {
+          safeWrite(
+            () => writeStatus.applyAssignee?.({ ticket: t.identifier, userId: botWriteId }),
+            { ticket: t.identifier, phase: "assignment" }
+          );
+        }
       } else {
         const cd3 = recordDispatchFailure(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, 0, now());
         if (cd3.consecutiveFailures >= getMaxDispatchRetries()) escalateDispatchExhausted(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE); // CTL-712 terminal stop
@@ -3158,6 +3195,9 @@ function runTick() {
       // + the standalone main() pass the real impls to arm the sweep.
       classifyResolution: runningOpts.classifyResolution,
       isBgJobAlive: runningOpts.isBgJobAlive,
+      // CTL-781: respect-assignment + self-assign seams (undefined = gate off).
+      botUserIds: runningOpts.botUserIds,
+      botWriteId: runningOpts.botWriteId,
     });
   } catch (err) {
     // A tick must never crash the daemon — log and let the next tick retry.
@@ -3228,6 +3268,9 @@ export function startScheduler({
   // real daemon (startDaemon) and the standalone main() pass the real impls.
   classifyResolution,
   isBgJobAlive,
+  // CTL-781: respect-assignment + self-assign. Undefined → gate off (fail-open).
+  botUserIds,
+  botWriteId,
   tickIntervalMs = TICK_INTERVAL_MS,
   debounceMs = TICK_DEBOUNCE_MS,
 } = {}) {
@@ -3251,6 +3294,8 @@ export function startScheduler({
     prAdapter, // CTL-642/758: live PR-merged adapter (built once above), threaded per-tick
     classifyResolution, // CTL-671: optional phantom-sweep Linear-probe seam
     isBgJobAlive, // CTL-671: optional phantom-sweep bg-liveness seam
+    botUserIds, // CTL-781: respect-assignment predicate membership set
+    botWriteId, // CTL-781: orchestrator bot UUID to write as assignee on claim
   };
 
   // CTL-585: warn once at startup if the Linear workspace lacks the labels

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -6700,3 +6700,216 @@ describe("readDispatchFailureReason (CTL-700)", () => {
     expect(readDispatchFailureReason(orchDir, "CTL-700A-6", "research")).toBeNull();
   });
 });
+
+// ── CTL-781: respect-assignment + self-assign in schedulerTick new-work pull ──
+
+describe("schedulerTick — CTL-781 respect-assignment + self-assign", () => {
+  const BOT = "ff78d890-7906-4c22-b2f5-020bd150c790";
+  const HUMAN = "11111111-1111-1111-1111-111111111111";
+
+  function candidateTicket(id) {
+    return {
+      identifier: id,
+      priority: 2,
+      createdAt: "x",
+      state: "Todo",
+      relations: { nodes: [] },
+      inverseRelations: { nodes: [] },
+    };
+  }
+
+  function gatewayStub(assigneeByTicket) {
+    return { getDescriptor: (id) => ({ assignee: assigneeByTicket[id] ?? null, removed: false }) };
+  }
+
+  beforeEach(() => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 5 }));
+  });
+
+  test("human-assigned candidate is SKIPPED — no dispatch, no cooldown marker, no dispatch.requested event", () => {
+    const dispatch = fakeDispatch();
+    const gateway = gatewayStub({ "CTL-H1": HUMAN });
+    schedulerTick(orchDir, {
+      readEligible: () => [candidateTicket("CTL-H1")],
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      botUserIds: new Set([BOT]),
+      gateway,
+    });
+    expect(dispatch.calls).toHaveLength(0);
+    expect(existsSync(join(orchDir, ".dispatch-cooldowns", "CTL-H1", "research"))).toBe(false);
+  });
+
+  test("null-assignee candidate dispatches AND applyAssignee is called with botWriteId after verify", () => {
+    const dispatch = fakeDispatch();
+    const assigneeCalls = [];
+    const writeStatus = {
+      applyPhaseStatus: () => ({ applied: true, reason: null }),
+      applyTerminalDone: () => {},
+      applyLabel: () => {},
+      applyAssignee: (a) => { assigneeCalls.push(a); return { applied: true, reason: null }; },
+    };
+    const gateway = gatewayStub({ "CTL-N1": null });
+    schedulerTick(orchDir, {
+      readEligible: () => [candidateTicket("CTL-N1")],
+      dispatch,
+      writeStatus,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      botUserIds: new Set([BOT]),
+      botWriteId: BOT,
+      gateway,
+    });
+    expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-N1"]);
+    expect(assigneeCalls).toHaveLength(1);
+    expect(assigneeCalls[0]).toMatchObject({ ticket: "CTL-N1", userId: BOT });
+  });
+
+  test("bot-assigned candidate (assignee in botUserIds) dispatches normally", () => {
+    const dispatch = fakeDispatch();
+    const gateway = gatewayStub({ "CTL-B1": BOT });
+    schedulerTick(orchDir, {
+      readEligible: () => [candidateTicket("CTL-B1")],
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      botUserIds: new Set([BOT]),
+      gateway,
+    });
+    expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-B1"]);
+  });
+
+  test("gateway miss → falls through to live read (exec seam); human assignee from live read skips", () => {
+    const dispatch = fakeDispatch();
+    const execCalls = [];
+    const exec = (cmd, args) => {
+      execCalls.push(args);
+      return { code: 0, stdout: JSON.stringify({ assignee: { id: HUMAN } }), stderr: "" };
+    };
+    const gateway = { getDescriptor: () => null };
+    schedulerTick(orchDir, {
+      readEligible: () => [candidateTicket("CTL-M1")],
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      botUserIds: new Set([BOT]),
+      gateway,
+      fetchAssignee: (id, opts) => {
+        execCalls.push(["fetchAssignee", id]);
+        return { known: true, assignee: HUMAN };
+      },
+    });
+    expect(dispatch.calls).toHaveLength(0);
+    expect(execCalls.some((c) => c[0] === "fetchAssignee")).toBe(true);
+  });
+
+  test("assignee unknown (live read fails) → candidate held this tick (no dispatch), NOT a recorded failure", () => {
+    const dispatch = fakeDispatch();
+    schedulerTick(orchDir, {
+      readEligible: () => [candidateTicket("CTL-U1")],
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      botUserIds: new Set([BOT]),
+      gateway: { getDescriptor: () => null },
+      fetchAssignee: () => ({ known: false }),
+    });
+    expect(dispatch.calls).toHaveLength(0);
+    expect(existsSync(join(orchDir, ".dispatch-cooldowns", "CTL-U1", "research"))).toBe(false);
+  });
+
+  test("no botUserIds threaded (undefined) → predicate skipped entirely, no assignee reads, dispatches as today", () => {
+    const dispatch = fakeDispatch();
+    const fetchAssigneeCalls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [candidateTicket("CTL-ND1")],
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchAssignee: (id) => { fetchAssigneeCalls.push(id); return { known: true, assignee: HUMAN }; },
+    });
+    expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-ND1"]);
+    expect(fetchAssigneeCalls).toHaveLength(0);
+  });
+
+  test("empty botUserIds Set → predicate skipped (CTL-749 fail-open convention)", () => {
+    const dispatch = fakeDispatch();
+    const fetchAssigneeCalls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [candidateTicket("CTL-E1")],
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      botUserIds: new Set(),
+      fetchAssignee: (id) => { fetchAssigneeCalls.push(id); return { known: true, assignee: HUMAN }; },
+    });
+    expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-E1"]);
+    expect(fetchAssigneeCalls).toHaveLength(0);
+  });
+
+  test("botWriteId absent → dispatch proceeds, NO applyAssignee call (predicate may still gate)", () => {
+    const dispatch = fakeDispatch();
+    const assigneeCalls = [];
+    const writeStatus = {
+      applyPhaseStatus: () => ({ applied: true, reason: null }),
+      applyTerminalDone: () => {},
+      applyLabel: () => {},
+      applyAssignee: (a) => { assigneeCalls.push(a); return { applied: true, reason: null }; },
+    };
+    const gateway = gatewayStub({ "CTL-WI1": null });
+    schedulerTick(orchDir, {
+      readEligible: () => [candidateTicket("CTL-WI1")],
+      dispatch,
+      writeStatus,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      botUserIds: new Set([BOT]),
+      gateway,
+    });
+    expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-WI1"]);
+    expect(assigneeCalls).toHaveLength(0);
+  });
+
+  test("applyAssignee failure (applied:false) does not fail the dispatch — ticket still advances", () => {
+    const dispatch = fakeDispatch();
+    const writeStatus = {
+      applyPhaseStatus: () => ({ applied: true, reason: null }),
+      applyTerminalDone: () => {},
+      applyLabel: () => {},
+      applyAssignee: () => ({ applied: false, reason: "transient" }),
+    };
+    const gateway = gatewayStub({ "CTL-AF1": null });
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [candidateTicket("CTL-AF1")],
+      dispatch,
+      writeStatus,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      botUserIds: new Set([BOT]),
+      botWriteId: BOT,
+      gateway,
+    });
+    expect(r.dispatched).toContain("CTL-AF1");
+  });
+
+  test("writeStatus stub WITHOUT applyAssignee (legacy test shape) → no throw", () => {
+    const dispatch = fakeDispatch();
+    const writeStatus = {
+      applyPhaseStatus: () => ({ applied: true, reason: null }),
+      applyTerminalDone: () => {},
+      applyLabel: () => {},
+    };
+    const gateway = gatewayStub({ "CTL-LS1": null });
+    expect(() => schedulerTick(orchDir, {
+      readEligible: () => [candidateTicket("CTL-LS1")],
+      dispatch,
+      writeStatus,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      botUserIds: new Set([BOT]),
+      botWriteId: BOT,
+      gateway,
+    })).not.toThrow();
+  });
+});


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-07T02:20:00Z -->
<!-- Last updated: 2026-06-07T02:20:00Z -->
<!-- PR: #1420 -->
<!-- Previous commits: b754a2b3cbbed5633ce6911e427a325ce30580b6,eeb9618407094fbf5801a40e56b5cf68e3559abf,c6a527302118bb28b62a57d7e572d061c9303d2e,a20eafde109d958978f4e3acdfa4d54acf7cc8f9 -->

## Summary

Implements **visible ownership**: when the Catalyst daemon claims a ticket from To Do, it now self-assigns the Catalyst bot as the Linear assignee so in-flight work is immediately identifiable without inspecting disk or signal files. Complementarily, the scheduler and monitor respect pre-existing assignment — tickets already assigned to a human (or another bot) are skipped rather than claimed.

- Adds `applyAssignee` to `linear-write.mjs`: write bot as Linear assignee with read-back verification (mirrors the `applyLabel` pattern, fail-open, tagged `{applied, reason}` return)
- Adds `fetchTicketAssignee` and `isAssigneeClaimable` to `linear-query.mjs`: gateway-first tri-state reads so the hot new-work predicate is rate-free; live `linearis issues read` only on a cache miss
- Wires a **respect-assignment gate** into `schedulerTick` and `dispatchTriage`/`sweepMissingTriage`: human-assigned tickets are skipped; unknown-assignee tickets are held (no cooldown) until the next tick; unassigned or bot-assigned tickets proceed as before
- On successful dispatch the daemon **self-assigns** the Catalyst bot via `applyAssignee` (fail-open)
- Adds `readLinearBotWriteId` to `daemon.mjs` and threads `botUserIds`/`botWriteId`/`gateway` into both `startMonitor` and `startScheduler`
- All gating is **fail-open**: absent or empty `botUserIds` disables the gate entirely — no assignee reads, no self-assign writes (CTL-749 convention)

## Changes Made

### `plugins/dev/scripts/execution-core/linear-write.mjs`

- Added `applyAssignee({ ticket, userId, exec })`: writes the bot as Linear assignee via `linearis issues update --assignee`, then reads back with `linearis issues read` to confirm the field landed (CTL-587 silent-success gap). Returns `{ applied: false, reason: "invalid-user" | "transient" | "verify-failed" }` on any failure path; never throws. 42 lines added.

### `plugins/dev/scripts/execution-core/linear-query.mjs`

- Added `fetchTicketAssignee(identifier, { exec, gateway })`: tri-state `{ known: true, assignee: string|null }` or `{ known: false }`. Consults the broker gateway descriptor first (rate-free); falls through to live `linearis issues read` on a cache miss or removed descriptor.
- Added `isAssigneeClaimable(assignee, botUserIds)`: pure predicate — claimable iff `assignee == null` (unassigned) or `assignee` is in the `botUserIds` Set. Shared by scheduler, monitor, and the future CTL-780 staleness sweep.

### `plugins/dev/scripts/execution-core/scheduler.mjs`

- `schedulerTick`: before dispatching a ticket, gates on `isAssigneeClaimable` (gateway-first via `fetchTicketAssignee`). Skips humans permanently; holds unknowns (no cooldown) for the next tick. On successful dispatch, calls `applyAssignee` fail-open.
- `startScheduler`: accepts `botUserIds`, `botWriteId` params; passes them into each tick. 46 lines added, 1 line modified.

### `plugins/dev/scripts/execution-core/monitor.mjs`

- `dispatchTriage` / `sweepMissingTriage`: same respect-assignment gate as the scheduler — skip humans, hold unknowns, self-assign on claim.
- `startMonitor`: accepts `botUserIds`, `botWriteId`, `gateway` params and threads them into the dispatch path. 64 lines added, 5 lines modified.

### `plugins/dev/scripts/execution-core/daemon.mjs`

- Added `readLinearBotWriteId(layer1Path, layer2Path)`: resolves the single bot UUID to write as assignee. Prefers `catalyst.linear.bot.orchestrator.botUserId` from Layer-2; falls back to `catalyst.monitor.linear.botUserId` from Layer-1. Null = self-assign disabled.
- `startDaemon`: reads `linearBotWriteId`, passes `botUserIds`/`botWriteId`/`gateway` into both `monitorFn` and `schedulerFn` calls. 31 lines added, 1 line modified.

### Tests

- `linear-write.test.mjs` — 8 new tests for `applyAssignee`: correct linearis args, exit-non-zero path, read-back mismatch, never-throws, and invalid userId guard.
- `linear-query.test.mjs` — 12 new tests for `fetchTicketAssignee` (gateway hit, removed→live-fallback, parse failure, null assignee semantics) and `isAssigneeClaimable` (null claimable regardless of Set, bot in Set claimable, human not claimable, empty Set).
- `scheduler.test.mjs` — 10 new integration tests covering the full respect-assignment × self-assign matrix in `schedulerTick`.
- `monitor.test.mjs` — 7 new tests covering the same gate in `dispatchTriage` and `startMonitor` wiring.
- `daemon.test.mjs` — 4 new tests for `readLinearBotWriteId`: Layer-2 preferred, Layer-1 fallback, null when neither set, never-throws on malformed files.

## How to Verify It

- [x] All CI checks pass (Cloudflare Pages, audit-references, check-versions, docs-gate, validate) ✅
- [ ] `bun test plugins/dev/scripts/execution-core/linear-write.test.mjs` — 8 new tests pass (72 total)
- [ ] `bun test plugins/dev/scripts/execution-core/linear-query.test.mjs` — 12 new tests pass (92 total)
- [ ] `bun test plugins/dev/scripts/execution-core/scheduler.test.mjs` — 10 new tests pass (372 total)
- [ ] `bun test plugins/dev/scripts/execution-core/monitor.test.mjs` — 7 new tests pass
- [ ] `bun test plugins/dev/scripts/execution-core/daemon.test.mjs` — 4 new tests pass (86 total)
- [ ] Full suite: 2034 pass / 4 fail (all 4 pre-existing, unrelated to this diff)
- [ ] With `botUserIds` configured, start a new ticket from To Do; confirm the Catalyst bot appears as assignee in Linear within the dispatch tick
- [ ] With `botUserIds` configured, manually assign a ticket to a human; confirm the daemon does not claim or re-assign it

## Changelog Entry

**feat(dev):** execution-core now self-assigns the Catalyst bot on ticket claim and skips human/unknown-bot-assigned tickets. Adds `applyAssignee` (linear-write), `fetchTicketAssignee` + `isAssigneeClaimable` (linear-query), and `readLinearBotWriteId` (daemon); wires gateway-first respect-assignment gate into both scheduler and monitor dispatch paths. All gating fail-open when `botUserIds` is absent.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-781

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-587
skip CTL-749
skip CTL-780
