### PR TITLE
fix(dev): otel-forward floats as doubleValue + agent OTLP body = event name (CTL-812)

### DIFF
--- a/plugins/dev/scripts/catalyst-agent/emit.mjs
+++ b/plugins/dev/scripts/catalyst-agent/emit.mjs
@@ -122,8 +122,14 @@ function otlpAttributes(obj) {
 
 // envelopeToLogRecord — map one catalyst-agent envelope to an OTLP logRecord.
 // timeUnixNano is derived from the envelope ts (ms → ns); severity carries
-// through as INFO/9; the dot-form attributes become OTLP attributes and the
-// body.payload rides as a stringValue body for human readability.
+// through as INFO/9; the dot-form attributes become OTLP attributes.
+//
+// CTL-812 BODY CONVENTION: the body is the bare event name — exactly what
+// otel-forward emits for the same envelope (body.message ?? event.name). The
+// catalyst-otel dashboards match events with LogQL line filters
+// (|= "host.metrics.sampled"), so the direct-OTLP path must produce the same
+// line or every panel silently misses Approach-B events. The high-cardinality
+// body.payload mirror stays local to the event log on purpose.
 function envelopeToLogRecord(envelope) {
   const ms = Date.parse(envelope.ts);
   const timeUnixNano = String((Number.isFinite(ms) ? ms : Date.now()) * 1_000_000);
@@ -132,7 +138,7 @@ function envelopeToLogRecord(envelope) {
     observedTimeUnixNano: timeUnixNano,
     severityNumber: 9,
     severityText: "INFO",
-    body: { stringValue: JSON.stringify(envelope.body?.payload ?? {}) },
+    body: { stringValue: envelope.attributes?.["event.name"] ?? "" },
     attributes: otlpAttributes(envelope.attributes ?? {}),
   };
 }

--- a/plugins/dev/scripts/catalyst-agent/emit.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/emit.test.mjs
@@ -197,8 +197,10 @@ describe("sendOtlp — mapping correctness with injected fetch", () => {
     expect(rec.severityText).toBe("INFO");
     // timeUnixNano = ms-since-epoch * 1e6, as a string.
     expect(rec.timeUnixNano).toBe(String(Date.parse("2026-06-06T12:00:00Z") * 1_000_000));
-    // body is the JSON-stringified payload.
-    expect(JSON.parse(rec.body.stringValue)).toEqual({ sampledFrom: "test" });
+    // body is the bare event name — the otel-forward convention, so the
+    // dashboards' LogQL line filters (|= "host.metrics.sampled") match the
+    // direct-OTLP path exactly like the event-log path (CTL-812).
+    expect(rec.body.stringValue).toBe("host.metrics.sampled");
   });
 
   test("every number → doubleValue (one type per key); strings → stringValue", async () => {

--- a/plugins/dev/scripts/otel-forward/lib/destinations/otlp.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/destinations/otlp.test.ts
@@ -66,12 +66,37 @@ describe("buildOtlpPayload", () => {
     expect(evName?.value?.stringValue).toBe("session.heartbeat");
   });
 
-  test("maps numeric attributes to intValue", () => {
+  test("maps integer attributes to intValue", () => {
     const event: CanonicalEvent = { ...SAMPLE_EVENT, attributes: { "event.name": "test", "vcs.pr.number": 42 } };
     const payload = buildOtlpPayload([event]) as any;
     const attrs = payload.resourceLogs[0].scopeLogs[0].logRecords[0].attributes;
     const prNum = attrs.find((a: any) => a.key === "vcs.pr.number");
     expect(prNum?.value?.intValue).toBe(42);
+  });
+
+  test("maps fractional attributes to doubleValue, never intValue (CTL-812)", () => {
+    // The collector's OTLP/JSON decoder rejects a float inside intValue
+    // ("assertInteger: can not decode float as int" → HTTP 400) and the whole
+    // batch dead-letters. catalyst-agent metrics (host.cpu_pct, ratelimit
+    // paces) are fractional, so they MUST ride as doubleValue.
+    const event: CanonicalEvent = {
+      ...SAMPLE_EVENT,
+      attributes: {
+        "event.name": "host.metrics.sampled",
+        "host.cpu_pct": 30.3,
+        "host.load1": 6.02,
+        "ratelimit.seven_day_pace": -0.344,
+      },
+    };
+    const payload = buildOtlpPayload([event]) as any;
+    const attrs = payload.resourceLogs[0].scopeLogs[0].logRecords[0].attributes;
+    const get = (k: string) => attrs.find((a: any) => a.key === k)?.value;
+    expect(get("host.cpu_pct")).toEqual({ doubleValue: 30.3 });
+    expect(get("host.load1")).toEqual({ doubleValue: 6.02 });
+    expect(get("ratelimit.seven_day_pace")).toEqual({ doubleValue: -0.344 });
+    for (const k of ["host.cpu_pct", "host.load1", "ratelimit.seven_day_pace"]) {
+      expect(get(k)?.intValue).toBeUndefined();
+    }
   });
 
   test("maps event.id to OTLP logRecordUid (CTL-344)", () => {

--- a/plugins/dev/scripts/otel-forward/lib/destinations/otlp.ts
+++ b/plugins/dev/scripts/otel-forward/lib/destinations/otlp.ts
@@ -5,12 +5,20 @@ import { log } from "../logger.ts";
 
 const destLog = log.child({ destination: "otlp" });
 
-interface OtlpAttr { key: string; value: { stringValue?: string; intValue?: number } }
+interface OtlpAttr { key: string; value: { stringValue?: string; intValue?: number; doubleValue?: number } }
 
+// CTL-812: fractional numbers MUST map to doubleValue. The collector's OTLP/JSON
+// decoder hard-rejects a float inside intValue ("assertInteger: can not decode
+// float as int" → HTTP 400), and one bad attribute 400s the ENTIRE batch — the
+// catalyst-agent's float metrics (host.cpu_pct, ratelimit.*_pace, …) wedged every
+// batch they rode in into the DLQ this way. Integers keep intValue so existing
+// integer-valued labels are byte-for-byte unchanged in Loki.
 function toAttrArray(obj: Record<string, unknown>): OtlpAttr[] {
   return Object.entries(obj).map(([key, val]) =>
     typeof val === "number"
-      ? { key, value: { intValue: val } }
+      ? Number.isInteger(val)
+        ? { key, value: { intValue: val } }
+        : { key, value: { doubleValue: val } }
       : { key, value: { stringValue: String(val ?? "") } }
   );
 }


### PR DESCRIPTION
## Summary

Two pipeline-breaking mismatches found during CTL-812 live end-to-end verification (events emitted by the new `catalyst-agent` never reached Loki):

1. **otel-forward: floats encoded as `intValue`** — the collector's OTLP/JSON decoder hard-rejects a float inside `intValue` (`assertInteger: can not decode float as int` → HTTP 400, reproduced live), and one bad attribute 400s the **entire batch**. The agent's fractional metrics (`host.cpu_pct`, `host.load1`, `ratelimit.*_pace`) wedged every batch into a permanently-cycling DLQ. Fix: `Number.isInteger ? intValue : doubleValue` — integer labels stay byte-for-byte identical in Loki.

2. **catalyst-agent direct-OTLP body convention** — `emit.mjs` set the log body to the JSON payload, but dashboards match events with LogQL line filters (`|= "host.metrics.sampled"`) against otel-forward's convention (bare event name). Approach-B events landed but were invisible to every panel. Body is now the bare event name on both paths.

## Test evidence
- `otel-forward`: 29 pass / 0 fail (new regression test: fractional → doubleValue, never intValue)
- `catalyst-agent`: 193 pass / 0 fail (body assertion updated to the event-name convention)

Refs CTL-812

🤖 Generated with [Claude Code](https://claude.com/claude-code)