### PR TITLE
fix(dev): catalyst-agent disk probe reads the APFS Data volume on macOS (CTL-812)

### DIFF
--- a/plugins/dev/scripts/catalyst-agent/host.mjs
+++ b/plugins/dev/scripts/catalyst-agent/host.mjs
@@ -184,15 +184,34 @@ export function parseDfRoot(text) {
   return { usedKb, totalKb };
 }
 
-// defaultReadDisk — { usedGb, totalGb } for the root filesystem via `df -k /`.
-// Never throws.
-function defaultReadDisk({
-  df = () => execFileSync("df", ["-k", "/"], { encoding: "utf8" }),
+// defaultReadDisk — { usedGb, totalGb } for the data filesystem via `df -k`.
+//
+// CTL-812 VOLUME CHOICE: on macOS, `/` is the SEALED APFS SYSTEM SNAPSHOT — a
+// few GB of OS image on a ~1TB container, so `df -k /` reads ~1-2% "used" while
+// the machine is actually 75%+ full. User data lives on the Data volume
+// (`/System/Volumes/Data`), which shares the container and reports the real
+// usage. Probe the Data volume on darwin (falling back to `/` when it's absent,
+// e.g. non-APFS or a future layout change); Linux keeps `/`.
+// Never throws. Exported for the volume-selection tests (df + platform injectable).
+export function defaultReadDisk({
+  df = (path) => execFileSync("df", ["-k", path], { encoding: "utf8" }),
+  platform = process.platform,
 } = {}) {
-  try {
-    const parsed = parseDfRoot(df());
-    if (!parsed) return { usedGb: null, totalGb: null };
+  const probe = (path) => {
+    const parsed = parseDfRoot(df(path));
+    if (!parsed) return null;
     return { usedGb: parsed.usedKb / KB_PER_GB, totalGb: parsed.totalKb / KB_PER_GB };
+  };
+  try {
+    if (platform === "darwin") {
+      try {
+        const data = probe("/System/Volumes/Data");
+        if (data) return data;
+      } catch {
+        /* Data volume missing/unreadable — fall through to the root probe */
+      }
+    }
+    return probe("/") ?? { usedGb: null, totalGb: null };
   } catch {
     return { usedGb: null, totalGb: null };
   }

--- a/plugins/dev/scripts/catalyst-agent/host.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/host.test.mjs
@@ -298,3 +298,61 @@ describe("cpu two-sample delta helpers (pure)", () => {
     expect(cpuBusyPctFromDeltas(a, b)).toBe(100);
   });
 });
+
+// ─── defaultReadDisk — volume selection (CTL-812 disk fix) ──────────────────
+// On macOS `/` is the sealed APFS system snapshot (~1-2% used on a full disk);
+// the real usage lives on /System/Volumes/Data. These pin the platform branch.
+import { defaultReadDisk } from "./host.mjs";
+
+const DF_DATA = `Filesystem    1024-blocks      Used  Available Capacity iused ifree %iused  Mounted on
+/dev/disk3s5    971350180 741536048  188252552    80% 4168860 1882525520    0%   /System/Volumes/Data`;
+const DF_ROOT = `Filesystem    1024-blocks     Used  Available Capacity iused ifree %iused  Mounted on
+/dev/disk3s1s1  971350180 16325024  188252552     8%  356810 1882525520    0%   /`;
+
+describe("defaultReadDisk — volume selection", () => {
+  test("darwin probes /System/Volumes/Data (the real data volume, not the sealed snapshot)", () => {
+    const calls = [];
+    const df = (path) => {
+      calls.push(path);
+      return path === "/System/Volumes/Data" ? DF_DATA : DF_ROOT;
+    };
+    const disk = defaultReadDisk({ df, platform: "darwin" });
+    expect(calls).toEqual(["/System/Volumes/Data"]);
+    // 741536048 KB used of 971350180 KB ≈ 707.2 / 926.4 GB — ~76% used, not ~1.7%.
+    expect(disk.usedGb).toBeCloseTo(741536048 / (1024 * 1024), 1);
+    expect(disk.totalGb).toBeCloseTo(971350180 / (1024 * 1024), 1);
+  });
+
+  test("darwin falls back to / when the Data volume probe throws", () => {
+    const calls = [];
+    const df = (path) => {
+      calls.push(path);
+      if (path === "/System/Volumes/Data") throw new Error("ENOENT");
+      return DF_ROOT;
+    };
+    const disk = defaultReadDisk({ df, platform: "darwin" });
+    expect(calls).toEqual(["/System/Volumes/Data", "/"]);
+    expect(disk.totalGb).toBeCloseTo(971350180 / (1024 * 1024), 1);
+  });
+
+  test("darwin falls back to / when the Data volume output is unparseable", () => {
+    const df = (path) => (path === "/System/Volumes/Data" ? "garbage" : DF_ROOT);
+    const disk = defaultReadDisk({ df, platform: "darwin" });
+    expect(disk.usedGb).toBeCloseTo(16325024 / (1024 * 1024), 1);
+  });
+
+  test("linux probes / directly (single df call)", () => {
+    const calls = [];
+    const df = (path) => {
+      calls.push(path);
+      return DF_ROOT;
+    };
+    defaultReadDisk({ df, platform: "linux" });
+    expect(calls).toEqual(["/"]);
+  });
+
+  test("every probe failing returns nulls, never throws", () => {
+    const disk = defaultReadDisk({ df: () => { throw new Error("boom"); }, platform: "darwin" });
+    expect(disk).toEqual({ usedGb: null, totalGb: null });
+  });
+});


### PR DESCRIPTION
`df -k /` on macOS reads the **sealed APFS system snapshot** (16GB of OS image on a 1TB container) → the host disk gauge showed **1.7% used** on a machine that's actually **~76% full**. The probe now reads `/System/Volumes/Data` on darwin (fallback to `/`), Linux unchanged. 5 new volume-selection tests; 198 total pass. Verified live: 707.2/926.4 GB = 76.3%, matching the OS storage UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)