### PR TITLE
feat(dev): auto-run compound learning per ticket + relocate stores to thoughts/shared/retros/ (CTL-831)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,9 @@ This workspace has no build process - it's markdown files and bash scripts.
 - `thoughts/shared/learnings/` — past problem→solution entries (grep by component/tags/problem_type).
   Search before implementing or debugging in a known area. Curated by `/catalyst-dev:ticket-compound`.
 - `thoughts/shared/CONCEPTS.md` — shared domain vocabulary (reclaim, revive-budget, orphan, signal ownership…).
+- `thoughts/shared/retros/` — the compound-loop outputs, written automatically at every merge
+  (CTL-831): `ticket/<date>.md` cross-ticket retros with watch-items (`/catalyst-dev:ticket-retro`);
+  `estimate/<YYYY-WW>-compound-log.md` per-PR estimation actuals (`/catalyst-dev:compound-estimate`).
 
 ## Commit Conventions
 

--- a/plugins/dev/scripts/__tests__/compound-log.test.sh
+++ b/plugins/dev/scripts/__tests__/compound-log.test.sh
@@ -2,7 +2,7 @@
 # Shell tests for compound-log helper (CTL-159).
 #
 # The /compound skill is a closing ritual at PR merge that writes a
-# compound-log entry to thoughts/shared/pm/metrics/YYYY-WW-compound-log.md.
+# compound-log entry to thoughts/shared/retros/estimate/YYYY-WW-compound-log.md.
 # This helper does the mechanical work: ISO-week routing, fail-loud field
 # validation, dedup, and append.
 #
@@ -68,7 +68,7 @@ EOF
 new_scratch_project() {
   local name="$1"
   local dir="${SCRATCH}/${name}"
-  mkdir -p "${dir}/thoughts/shared/pm/metrics"
+  mkdir -p "${dir}/thoughts/shared/retros/estimate"
   mkdir -p "${dir}/.catalyst"
   install_fakes "${dir}/bin"
   echo "$dir"
@@ -135,7 +135,7 @@ test_write_creates_file_with_header() {
     > "${SCRATCH}/out" 2>&1
   rc=$?
 
-  outfile="${proj}/thoughts/shared/pm/metrics/2026-W17-compound-log.md"
+  outfile="${proj}/thoughts/shared/retros/estimate/2026-W17-compound-log.md"
   if [ $rc -eq 0 ] && [ -f "$outfile" ] && \
      grep -q "^# Compound Log" "$outfile" && \
      grep -q "^### CTL-159 — #273" "$outfile" && \
@@ -164,7 +164,7 @@ test_write_appends_to_existing_file() {
     --estimate-actual 5 --cost-usd 2.00 \
     --what-worked "c" --what-surprised-me "d" > "${SCRATCH}/out" 2>&1
 
-  outfile="${proj}/thoughts/shared/pm/metrics/2026-W17-compound-log.md"
+  outfile="${proj}/thoughts/shared/retros/estimate/2026-W17-compound-log.md"
   count=$(grep -c "^### CTL-" "$outfile" 2>/dev/null || echo 0)
   if [ "$count" = "2" ]; then
     pass "write: appends second entry to existing file"
@@ -217,7 +217,7 @@ test_write_force_replaces_duplicate() {
     --force > "${SCRATCH}/out" 2>&1
   rc=$?
 
-  outfile="${proj}/thoughts/shared/pm/metrics/2026-W17-compound-log.md"
+  outfile="${proj}/thoughts/shared/retros/estimate/2026-W17-compound-log.md"
   count=$(grep -c "^### CTL-300" "$outfile" 2>/dev/null || echo 0)
   if [ $rc -eq 0 ] && [ "$count" = "1" ] && grep -q "cost_usd: 9.99" "$outfile"; then
     pass "write: --force replaces existing entry"
@@ -304,7 +304,7 @@ test_dry_run_does_not_write() {
     --dry-run > "${SCRATCH}/out" 2>&1
   rc=$?
 
-  outfile="${proj}/thoughts/shared/pm/metrics/2026-W17-compound-log.md"
+  outfile="${proj}/thoughts/shared/retros/estimate/2026-W17-compound-log.md"
   if [ $rc -eq 0 ] && [ ! -f "$outfile" ] && grep -q "CTL-600" "${SCRATCH}/out"; then
     pass "dry-run: prints entry, writes nothing"
   else
@@ -326,11 +326,11 @@ test_week_routing_uses_merged_at() {
     --estimate-actual 5 --cost-usd 1.00 \
     --what-worked "a" --what-surprised-me "b" > "${SCRATCH}/out" 2>&1
 
-  outfile="${proj}/thoughts/shared/pm/metrics/2026-W18-compound-log.md"
+  outfile="${proj}/thoughts/shared/retros/estimate/2026-W18-compound-log.md"
   if [ -f "$outfile" ]; then
     pass "week routing: uses mergedAt (2026-W18 file created)"
   else
-    fail "week routing: expected 2026-W18 file, got $(ls "${proj}/thoughts/shared/pm/metrics/" 2>&1)"
+    fail "week routing: expected 2026-W18 file, got $(ls "${proj}/thoughts/shared/retros/estimate/" 2>&1)"
   fi
   unset FAKE_GH_PR_JSON FAKE_LINEARIS_JSON
 }
@@ -348,7 +348,7 @@ test_wall_time_computed_from_pr() {
     --estimate-actual 5 --cost-usd 1.00 \
     --what-worked "a" --what-surprised-me "b" > "${SCRATCH}/out" 2>&1
 
-  outfile="${proj}/thoughts/shared/pm/metrics/2026-W17-compound-log.md"
+  outfile="${proj}/thoughts/shared/retros/estimate/2026-W17-compound-log.md"
   if grep -q "wall_time_hours: 3" "$outfile" 2>/dev/null; then
     pass "wall-time: computed from PR createdAt→mergedAt"
   else

--- a/plugins/dev/scripts/__tests__/ticket-retro-gather.test.sh
+++ b/plugins/dev/scripts/__tests__/ticket-retro-gather.test.sh
@@ -44,8 +44,8 @@ new_project() {
   local dir="${SCRATCH}/$1"
   mkdir -p "$dir/thoughts/shared/friction" \
            "$dir/thoughts/shared/learnings/architecture-patterns" \
-           "$dir/thoughts/shared/pm/metrics" \
-           "$dir/thoughts/shared/compound/retros"
+           "$dir/thoughts/shared/retros/estimate" \
+           "$dir/thoughts/shared/retros/ticket"
   echo "$dir"
 }
 
@@ -75,7 +75,7 @@ EOF
 
 write_compound_week() {
   local dir="$1"
-  cat > "$dir/thoughts/shared/pm/metrics/2026-W23-compound-log.md" <<'EOF'
+  cat > "$dir/thoughts/shared/retros/estimate/2026-W23-compound-log.md" <<'EOF'
 # Compound Log — 2026-W23
 
 One entry per merged PR. Fields follow the CTL-159 schema.
@@ -99,7 +99,7 @@ EOF
 
 write_prior_retro() {
   local dir="$1" date="$2"
-  cat > "$dir/thoughts/shared/compound/retros/${date}.md" <<'EOF'
+  cat > "$dir/thoughts/shared/retros/ticket/${date}.md" <<'EOF'
 ---
 date: RETRO_DATE
 type: retro
@@ -125,8 +125,8 @@ generated_by: ticket-retro
   source: CTL-628
 ```
 EOF
-  sed -i '' "s/RETRO_DATE/${date}/g" "$dir/thoughts/shared/compound/retros/${date}.md" 2>/dev/null \
-    || sed -i "s/RETRO_DATE/${date}/g" "$dir/thoughts/shared/compound/retros/${date}.md"
+  sed -i '' "s/RETRO_DATE/${date}/g" "$dir/thoughts/shared/retros/ticket/${date}.md" 2>/dev/null \
+    || sed -i "s/RETRO_DATE/${date}/g" "$dir/thoughts/shared/retros/ticket/${date}.md"
 }
 
 run_gather() {
@@ -243,6 +243,29 @@ EOF
   assert_eq "gh: churn carried" "100" "$(echo "$out" | jq '.merged_prs[0].additions')"
 }
 
+# ── Same-day re-run (CTL-831): floor + prior_retro skip TODAY's retro ───────
+# Retros run automatically at every merge, so several land per day. A re-run
+# must regenerate today's file cumulatively — anchoring on itself would give a
+# near-empty window and lose the day's earlier content.
+
+test_same_day_rerun_uses_previous_floor() {
+  local proj out today
+  proj=$(new_project sameday)
+  today=$(date -u +%Y-%m-%d)
+  write_prior_retro "$proj" "2026-06-03"
+  write_prior_retro "$proj" "$today"
+  write_friction "$proj" "CTL-40" "implement" "2026-06-05T10:00:00+0900" "in window"
+
+  out=$(run_gather "$proj")
+  assert_eq "same-day: floor skips today's retro" "2026-06-03" \
+    "$(echo "$out" | jq -r '.window.since')"
+  assert_eq "same-day: window source still last-retro" "last-retro" \
+    "$(echo "$out" | jq -r '.window.source')"
+  assert_eq "same-day: prior_retro is the pre-today one" "2026-06-03" \
+    "$(echo "$out" | jq -r '.prior_retro.date')"
+  assert_eq "same-day: in-window friction kept" "1" "$(echo "$out" | jq '.friction | length')"
+}
+
 # ── Run ──────────────────────────────────────────────────────────────────────
 
 test_empty_stores_degrade
@@ -250,6 +273,7 @@ test_last_retro_window_and_watch_items
 test_since_override_and_stores
 test_tickets_filter
 test_merged_prs_ticket_extraction
+test_same_day_rerun_uses_previous_floor
 
 echo "---"
 echo "summary: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/compound-log.sh
+++ b/plugins/dev/scripts/compound-log.sh
@@ -4,7 +4,7 @@
 # Closing ritual for the AI-native estimation feedback loop (CTL-159). At PR
 # merge, this helper writes a structured entry to:
 #
-#   <thoughts-dir>/shared/pm/metrics/<YYYY-WW>-compound-log.md
+#   <thoughts-dir>/shared/retros/estimate/<YYYY-WW>-compound-log.md
 #
 # One file per ISO week, one entry per merged PR. Fields follow the
 # CTL-159 schema: linear.key, pr_number, merged_at, estimate_at_start,
@@ -308,7 +308,7 @@ cmd_write() {
   # 7. Compute target week file from mergedAt (NOT today).
   local week outfile
   week=$(iso_week_of "$merged_at") || fatal "write: could not derive ISO week from mergedAt: $merged_at"
-  outfile="${thoughts_dir}/shared/pm/metrics/${week}-compound-log.md"
+  outfile="${thoughts_dir}/shared/retros/estimate/${week}-compound-log.md"
 
   # 8. Dry-run: print entry only.
   local entry
@@ -341,7 +341,7 @@ cmd_write() {
 
 # ─── subcommand: read (CTL-813) ─────────────────────────────────────────────
 #
-# Parse every <thoughts-dir>/shared/pm/metrics/*-compound-log.md and emit one
+# Parse every <thoughts-dir>/shared/retros/estimate/*-compound-log.md and emit one
 # JSON object per entry (JSON Lines). The yaml blocks are flat key: value
 # pairs written by render_entry, so an awk field-splitter is sufficient — the
 # only escaping in play is the \" that render_entry applies to free text.
@@ -359,7 +359,7 @@ cmd_read() {
     esac
   done
 
-  local metrics_dir="${thoughts_dir}/shared/pm/metrics"
+  local metrics_dir="${thoughts_dir}/shared/retros/estimate"
   [ -d "$metrics_dir" ] || return 0
 
   command -v jq >/dev/null 2>&1 || fatal "read: jq is required"

--- a/plugins/dev/scripts/ticket-retro/gather-retro.sh
+++ b/plugins/dev/scripts/ticket-retro/gather-retro.sh
@@ -54,19 +54,25 @@ done
 
 command -v jq >/dev/null 2>&1 || { echo "gather-retro: jq is required" >&2; exit 1; }
 
-[ -z "$RETROS_DIR" ] && RETROS_DIR="${THOUGHTS_DIR}/shared/compound/retros"
+[ -z "$RETROS_DIR" ] && RETROS_DIR="${THOUGHTS_DIR}/shared/retros/ticket"
 
 SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/gather-retro.XXXXXX")"
 trap 'rm -rf "$SCRATCH"' EXIT
 
 # ── Prior retro + window floor ───────────────────────────────────────────────
+# CTL-831: retros run automatically at EVERY merge now, so several can land on
+# one day. The "prior retro" is the most recent one STRICTLY BEFORE today
+# (UTC) — a same-day re-run reuses the same floor and REGENERATES today's
+# file cumulatively instead of anchoring on itself (near-empty window).
 
+TODAY_UTC="$(date -u +%Y-%m-%d)"
 PRIOR_RETRO=""
 if [ -d "$RETROS_DIR" ]; then
   for rf in "$RETROS_DIR"/*.md; do
     [ -e "$rf" ] || continue
     case "$(basename "$rf" .md)" in
       [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])
+        [ "$(basename "$rf" .md)" = "$TODAY_UTC" ] && continue
         if [ -z "$PRIOR_RETRO" ] || [ "$rf" \> "$PRIOR_RETRO" ]; then PRIOR_RETRO="$rf"; fi ;;
     esac
   done

--- a/plugins/dev/skills/compound-estimate/SKILL.md
+++ b/plugins/dev/skills/compound-estimate/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: compound-estimate
 description:
-  "Closing ritual for the AI-native estimation feedback loop. **ALWAYS use when** the user says
-  'compound-estimate', 'close the estimation loop', 'record actuals', 'compound-log', or wants to log post-merge
-  actuals for a shipped Linear ticket. Writes a structured entry (linear.key, pr_number, merged_at,
-  estimate_at_start, estimate_actual, cost_usd, wall_time_hours, what_worked, what_surprised_me)
-  to `thoughts/shared/pm/metrics/YYYY-WW-compound-log.md` — one file per ISO week, appends."
+  "Closing ritual for the AI-native estimation feedback loop. **ALWAYS use when** a ticket's PR
+  has just merged (runs automatically per ticket: merge-pr step 12b / phase-monitor-merge,
+  CTL-189/CTL-831), or when the user says 'compound-estimate', 'close the estimation loop',
+  'record actuals', 'compound-log', or wants to log post-merge actuals for a shipped Linear
+  ticket. Writes a structured entry (linear.key, pr_number, merged_at, estimate_at_start,
+  estimate_actual, cost_usd, wall_time_hours, what_worked, what_surprised_me)
+  to `thoughts/shared/retros/estimate/YYYY-WW-compound-log.md` — one file per ISO week, appends."
 disable-model-invocation: false
 allowed-tools: Bash(gh *), Bash(linearis *), Bash(jq *), Bash(git *), Bash(./plugins/dev/scripts/compound-log.sh *), Bash(plugins/dev/scripts/compound-log.sh *), Bash(./plugins/pm/scripts/estimate/refresh-corpus.sh *), Bash(plugins/pm/scripts/estimate/refresh-corpus.sh *), Read, Write
 version: 1.0.0
@@ -28,7 +30,7 @@ The skill delegates all mechanical work to `plugins/dev/scripts/compound-log.sh`
 
 ## Output
 
-Appends an entry to `thoughts/shared/pm/metrics/YYYY-WW-compound-log.md`, creating the weekly file with a header if it doesn't exist. Weeks are ISO-8601 and derived from the PR's `mergedAt` (not today's date).
+Appends an entry to `thoughts/shared/retros/estimate/YYYY-WW-compound-log.md`, creating the weekly file with a header if it doesn't exist. Weeks are ISO-8601 and derived from the PR's `mergedAt` (not today's date).
 
 ## Process
 

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -465,17 +465,22 @@ EOF
 humanlayer thoughts sync
 ```
 
-### 12b. Compound-estimate closing ritual (CTL-189 / CTL-813)
+### 12b. Compound closing ritual (CTL-189 / CTL-813 / CTL-831)
 
-Close the estimation loop for the just-merged ticket — invoke
-`/catalyst-dev:compound-estimate $ticket_id`. It prompts for the post-merge re-score
-(CTL-746 scale: XS=1 S=3 M=5 L=8 XL=13) plus two short reflections, appends the weekly
-compound-log entry, and offers a corpus refresh when the reference-class corpus is stale.
-That entry is what `refresh-corpus.sh` feeds back into `reference-class-corpus.json` as human
-ground truth — skipping it is how the loop falls open again.
+Two learning steps run for every merged ticket, in order:
 
-**Off the critical path**: if the user declines, the ticket was never estimated, or the skill
-errors, log one line and continue — never block the merge ritual on it.
+1. **Estimation actuals** — invoke `/catalyst-dev:compound-estimate $ticket_id`. It prompts for
+   the post-merge re-score (CTL-746 scale: XS=1 S=3 M=5 L=8 XL=13) plus two short reflections,
+   appends the weekly compound-log entry (`thoughts/shared/retros/estimate/`), and offers a
+   corpus refresh when the reference-class corpus is stale. That entry is what
+   `refresh-corpus.sh` feeds back into `reference-class-corpus.json` as human ground truth —
+   skipping it is how the loop falls open again.
+2. **Cross-ticket retro** — invoke `/catalyst-dev:ticket-retro` (no arguments). It regenerates
+   `thoughts/shared/retros/ticket/<today>.md` over the since-last-retro window (same-day re-runs
+   are cumulative) and refreshes the watch-items the morning briefing surfaces.
+
+**Off the critical path**: if the user declines, the ticket was never estimated, or either skill
+errors, log one line and continue — never block the merge ritual on them.
 
 ### 13. Detect Deployments and Report Success
 

--- a/plugins/dev/skills/morning-briefing/SKILL.md
+++ b/plugins/dev/skills/morning-briefing/SKILL.md
@@ -228,9 +228,9 @@ fi
 ```bash
 # ── Retro signals: open watch-items from the latest retro ────────────────────
 # Parse the machine contract (the fenced `yaml watch-items` block) from the
-# newest thoughts/shared/compound/retros/YYYY-MM-DD.md. Cap at 5 — the
+# newest thoughts/shared/retros/ticket/YYYY-MM-DD.md. Cap at 5 — the
 # briefing surfaces the watch list, the retro doc holds the detail.
-RETRO_DIR="thoughts/shared/compound/retros"
+RETRO_DIR="thoughts/shared/retros/ticket"
 : > "$SCRATCH/retro-signals.jsonl"
 LATEST_RETRO=""
 if [[ -d "$RETRO_DIR" ]]; then

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -290,6 +290,15 @@ Do NOT run the corpus refresh here (that is `compound-estimate` step 6 /
 operator cadence — a background phase worker must not mutate the committed
 corpus).
 
+4. **Run the cross-ticket retro (CTL-831 — the per-ticket learning step).** After
+   the compound-log entry (success OR skip), invoke `/catalyst-dev:ticket-retro`
+   with no arguments. It regenerates `thoughts/shared/retros/ticket/<today>.md`
+   over the since-last-retro window (same-day re-runs are cumulative by design)
+   and refreshes the watch-items the morning briefing surfaces — this is how the
+   system learns from every ticket it ships. Same contract as the entry above:
+   **best-effort, never blocks the End block** — on any retro failure, log one
+   line and continue.
+
 ## End block
 
 Mirror the merge outcome to Linear as a single comment (CTL-632). Best-effort

--- a/plugins/dev/skills/ticket-retro/SKILL.md
+++ b/plugins/dev/skills/ticket-retro/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: ticket-retro
 description:
-  "Cross-ticket retrospective VIEW (CTL-789 Loop C / CTL-814). **ALWAYS use when** the user says
-  'ticket retro', 'run a retro', 'retrospective', 'what did we learn lately', or 'how are the
-  estimates calibrating'. Synthesizes everything the compound loops captured since the last retro —
-  friction logs, learnings, compound-log calibration, catalyst.db / merged-PR actuals — into
-  thoughts/shared/compound/retros/<date>.md with a persisted watch-items block, and surfaces top
-  patterns in the morning briefing's Plan today."
-disable-model-invocation: true
+  "Cross-ticket retrospective VIEW (CTL-789 Loop C / CTL-814). **ALWAYS use when** a ticket's PR
+  has just merged (the workflow's compound closing step — runs automatically per ticket, CTL-831),
+  or when the user says 'ticket retro', 'run a retro', 'retrospective', 'what did we learn lately',
+  or 'how are the estimates calibrating'. Synthesizes everything the compound loops captured since
+  the last retro — friction logs, learnings, compound-log calibration, catalyst.db / merged-PR
+  actuals — into thoughts/shared/retros/ticket/<date>.md with a persisted watch-items block, and
+  surfaces top patterns in the morning briefing's Plan today."
 allowed-tools: Bash, Read, Write, Grep, Glob
 ---
 
@@ -17,9 +17,15 @@ Loop C of compound engineering: a human-readable reflection across a SET of tick
 **reads** what Loop B (friction logs, learnings) and Loop A (compound-log, estimation corpus)
 captured, then writes ONE artifact: the retro document.
 
+**Runs automatically per ticket (CTL-831):** `merge-pr` step 12b and `phase-monitor-merge` invoke
+this skill right after the compound-log entry lands, so the system learns from every ticket it
+ships without being asked. Best-effort in those contexts — a retro failure never blocks a merge
+or a phase. Several merges per day are normal: same-day re-runs REGENERATE today's file
+cumulatively (the gather floor skips today — see Step 3).
+
 **Hard contract — read-only VIEW:**
 
-- The ONLY thing this skill writes is `thoughts/shared/compound/retros/<YYYY-MM-DD>.md`.
+- The ONLY thing this skill writes is `thoughts/shared/retros/ticket/<YYYY-MM-DD>.md`.
 - It must NOT curate the learnings store, edit `thoughts/shared/CONCEPTS.md`, or touch ADRs —
   that is `ticket-compound`'s job (per-ticket curator). No Linear writes, no corpus writes.
 - Every input store degrades to `_none_` — empty stores are the normal early state, never an error.
@@ -34,7 +40,7 @@ captured, then writes ONE artifact: the retro document.
 
 Default scope is **since-last-retro, no time box** (solo-dev rhythm — design decision, plan
 line 114): the window floor is the date of the most recent retro in
-`thoughts/shared/compound/retros/`; the first retro ever falls back to 14 days.
+`thoughts/shared/retros/ticket/`; the first retro ever falls back to 14 days.
 
 ## Step 1: Gather (deterministic, read-only)
 
@@ -86,7 +92,10 @@ use it for the aggregate stats; treat db cost/hours as a bonus column where pres
 
 ## Step 3: Write the retro document
 
-Path: `thoughts/shared/compound/retros/<YYYY-MM-DD>.md` (today UTC). Template:
+Path: `thoughts/shared/retros/ticket/<YYYY-MM-DD>.md` (today UTC). **If today's file already
+exists, OVERWRITE it** — the gather floor deliberately skips today's retro (CTL-831), so a
+same-day re-run covers the same since-prior-retro window plus whatever just merged; today's file
+is always the cumulative day view, never a near-empty increment. Template:
 
 ```markdown
 ---
@@ -156,7 +165,7 @@ and `pattern` values double-quoted. `component` uses the learnings-store enum
 
 ```bash
 humanlayer thoughts sync 2>/dev/null || true
-echo "ticket-retro: wrote thoughts/shared/compound/retros/$(date -u +%Y-%m-%d).md"
+echo "ticket-retro: wrote thoughts/shared/retros/ticket/$(date -u +%Y-%m-%d).md"
 ```
 
 Report to the user: the retro path, top 3 recurring patterns, the calibration one-liner, and any


### PR DESCRIPTION
## Summary

Follow-up to #1400/#1410 (CTL-789 compound engineering): the learning loops now run **automatically for every ticket**, and their outputs live under one top-findable parent in the thoughts store.

## What changed

**Automatic per-ticket learning**
- `ticket-retro` is now **model-invokable** (dropped `disable-model-invocation: true`) so workflow agents can run it
- `phase-monitor-merge` invokes `/catalyst-dev:ticket-retro` right after its compound-log entry (best-effort, never blocks the End block)
- `merge-pr` step 12b becomes the two-step compound closing ritual: `/catalyst-dev:compound-estimate` then `/catalyst-dev:ticket-retro` (off the critical path)
- Both skills' descriptions now carry the auto-run trigger ("a ticket's PR has just merged")

**Same-day safety (new behavior + regression test)**
- Retros now land at every merge, so several per day is normal: `gather-retro.sh`'s window floor and prior-retro resolution **skip retros dated today (UTC)** — a same-day re-run regenerates today's file *cumulatively* over the same since-prior-retro window instead of anchoring on itself (near-empty window, broken watch-item recurrence)

**Store relocation** (shared parent, findable from the top of `thoughts/shared/`)
- `thoughts/shared/compound/retros/` → **`thoughts/shared/retros/ticket/`**
- `thoughts/shared/pm/metrics/*-compound-log.md` → **`thoughts/shared/retros/estimate/`** — `pm/metrics/` returns to the ~16 PM/discovery/pm-ops skills that use it for general PM metrics; compound-log was squatting there
- All writers/readers updated (`compound-log.sh`, `gather-retro.sh`, 5 SKILL.mds, tests); `CLAUDE.md` Knowledge Store gains the `retros/` pointer; live store files migrated + synced (`compound/pending/` ADR queue intentionally stays)

## Verification

4-lens adversarial workflow (paths / wiring / tests / adversarial diff review) — **all pass**: zero stale path refs repo-wide, frontmatter YAML-valid per plugin rules, no recursion path (ticket-retro is a read-only VIEW invoking no merge/phase skills), same-day floor empirically verified incl. watch-item recurrence reading the genuine prior retro. Suites: retro-gather **32/32** (incl. new same-day test), compound-log **19/19**, briefing **39/39**, estimate **45/45**, `audit-references --ci` exit 0.

Closes CTL-831. Part of CTL-789 (compound engineering); builds on #1400/#1410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)