### PR TITLE
docs(meta): morning-briefing routine prose — surface the compound sections (CTL-836)

### DIFF
--- a/cma/routines/morning-briefing/agent.yaml
+++ b/cma/routines/morning-briefing/agent.yaml
@@ -37,6 +37,14 @@ system: |
     `THOUGHTS_WRITABLE_BRANCH=routines/briefings` in its env block. The base
     agent's §1a clones the writable tree and the routine end-of-life block
     commits + pushes. See [`cma/decisions/2026-05-17-briefing-write-back.md`](../../decisions/2026-05-17-briefing-write-back.md).
+  - **Compound surfaces (CTL-789 / CTL-814 / CTL-831).** The skill's briefing
+    includes the compound-engineering sections: friction + learnings digests
+    ("since last briefing") and the `Plan today → Retro signals` sub-section
+    (open watch-items parsed from the latest
+    `thoughts/shared/retros/ticket/<date>.md`). These READ from the thoughts
+    clone (`thoughts/shared/{friction,learnings,retros}/`) — read-only, no
+    extra write-back, and every store degrades to `_none_`/`_no data_` when
+    empty. Do not skip them on an empty store.
   - **Carryovers from yesterday's briefing (CTL-465).** Before running the
     `morning-briefing` skill, check whether `thoughts/briefings/<yesterday>.md`
     exists on the writable clone (the `routines/briefings` branch). If it

--- a/cma/routines/morning-briefing/routine.yaml
+++ b/cma/routines/morning-briefing/routine.yaml
@@ -48,10 +48,15 @@ prompt: |
     1. Resolve target date and output path.
     2. Gather sources (Linear, GitHub, Granola, Drive, Calendar) in parallel.
     3. Compute decisions (ADR drift via CTL-459's adr-drift.sh, blocked PRs,
-       judgment-call tickets).
-    4. Render `thoughts/briefings/<date>.md` with validated YAML frontmatter.
-    5. Fan-out to Slack DM, Slack channel, Notion, and a Loom script file.
-    6. End the session.
+       judgment-call tickets, pending compound ADR proposals) plus the
+       compound digests — friction + learnings since last briefing (CTL-789).
+    4. Gather "today" incl. retro signals: the latest ticket-retro's open
+       watch-items from thoughts/shared/retros/ticket/ (CTL-814 / CTL-831).
+    5. Render `thoughts/briefings/<date>.md` with validated YAML frontmatter
+       ("Plan today" carries the Retro signals sub-section), then append the
+       Friction / Learnings digest body sections.
+    6. Fan-out to Slack DM, Slack channel, Notion, and a Loom script file.
+    7. End the session.
 
   Write-back is handled by the base agent's startup ritual:
     - §1a clones the thoughts repo writable at `/workspace/thoughts-writable/`
@@ -64,6 +69,10 @@ prompt: |
   Success criteria:
     - `thoughts/briefings/<YYYY-MM-DD>.md` exists in the writable clone.
     - The frontmatter validates (the skill calls validate-frontmatter.sh).
+    - "Plan today" includes the Retro signals sub-section (open watch-items
+      from the latest thoughts/shared/retros/ticket/ retro; `_no data_` when
+      none) and the body carries the two compound digests ("Friction since
+      last briefing", "Learnings since last briefing"; `_none_` when empty).
     - Push to `routines/briefings` succeeds.
     - The `output_status` block on the briefing markdown reflects each
       destination's outcome (skipped, sent, or failed — never silent).


### PR DESCRIPTION
## Summary

Prep for CTL-836 (activate the morning-briefing CMA Routine). The committed routine wiring (CTL-460) predates the compound-engineering work — its prompt summary and success criteria didn't mention the sections the briefing now produces.

## What changed

- `routine.yaml` prompt: step list now includes the compound digests gather (CTL-789) and the "today" retro-signals gather from `thoughts/shared/retros/ticket/` (CTL-814/CTL-831); success criteria now require **Plan today → Retro signals** + the two Friction/Learnings digest sections (with their `_no data_`/`_none_` degradations)
- `agent.yaml` extension: new **Compound surfaces** bullet — read-only reads from `thoughts/shared/{friction,learnings,retros}/`, no extra write-back, never skip on empty stores

No behavioral change — `SKILL.md` remains the authoritative body the routine executes. Routine config test 7/7; both YAMLs parse.

Part of CTL-836 (registration + first-run acceptance remains — needs interactive `ant` auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)