### PR TITLE
CTL-785: execution-core: token re-mint on mid-run 401 + setup prereq check

### DIFF
--- a/plugins/dev/scripts/__tests__/check-setup-orchestrator-app.test.sh
+++ b/plugins/dev/scripts/__tests__/check-setup-orchestrator-app.test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Tests for the check-setup.sh orchestrator Linear app credential check (CTL-785).
+# Verifies that check-setup.sh reports pass/warn correctly for configured,
+# partial, and absent orchestrator app credentials — and that the secret never
+# appears in output.
+#
+# Run: bash plugins/dev/scripts/__tests__/check-setup-orchestrator-app.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SCRIPT="${REPO_ROOT}/plugins/dev/scripts/check-setup.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+FIXTURE_SECRET="super-secret-value-$$"
+
+assert_grep() {
+  local label="$1" output="$2" pattern="$3"
+  if grep -qF -- "$pattern" <<<"$output"; then
+    PASSES=$((PASSES + 1))
+    echo "  PASS: $label"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $label"
+    echo "    expected substring: $pattern"
+    echo "    actual output (truncated):"
+    echo "$output" | head -20 | sed 's/^/      /'
+  fi
+}
+
+assert_not_grep() {
+  local label="$1" output="$2" pattern="$3"
+  if grep -qF -- "$pattern" <<<"$output"; then
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $label (unexpected pattern found)"
+    echo "    unexpected substring: $pattern"
+  else
+    PASSES=$((PASSES + 1))
+    echo "  PASS: $label"
+  fi
+}
+
+# make_xdg <dir> <clientId> <clientSecret>
+# Writes a minimal ~/.config/catalyst/config.json fixture under <dir>/catalyst/config.json.
+# Pass empty strings to omit a field entirely.
+make_xdg() {
+  local dir="$1" client_id="$2" client_secret="$3"
+  local cfg_dir="${dir}/catalyst"
+  mkdir -p "$cfg_dir"
+
+  local orch_block
+  if [[ -n "$client_id" && -n "$client_secret" ]]; then
+    orch_block="{\"clientId\":\"${client_id}\",\"clientSecret\":\"${client_secret}\"}"
+  elif [[ -n "$client_id" ]]; then
+    orch_block="{\"clientId\":\"${client_id}\"}"
+  elif [[ -n "$client_secret" ]]; then
+    orch_block="{\"clientSecret\":\"${client_secret}\"}"
+  else
+    orch_block="{}"
+  fi
+
+  cat > "${cfg_dir}/config.json" <<EOF
+{
+  "catalyst": {
+    "linear": {
+      "bot": {
+        "orchestrator": ${orch_block}
+      }
+    }
+  }
+}
+EOF
+}
+
+# make_project <dir> — minimal .catalyst/config.json so check-setup.sh can run
+make_project() {
+  local dir="$1"
+  mkdir -p "${dir}/.catalyst"
+  cat > "${dir}/.catalyst/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "test",
+    "project": { "ticketPrefix": "TST" },
+    "linear": { "teamKey": "TST", "stateMap": { "research": "Research" } }
+  }
+}
+EOF
+  mkdir -p "${dir}/thoughts/shared/research" "${dir}/thoughts/shared/plans" \
+    "${dir}/thoughts/shared/handoffs" "${dir}/thoughts/shared/prs" \
+    "${dir}/thoughts/shared/reports"
+}
+
+# run_script <project-dir> <xdg-dir>
+run_script() {
+  local cwd="$1" xdg_dir="$2"
+  ( cd "$cwd" \
+    && env -i HOME="$HOME" PATH="/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" \
+       XDG_CONFIG_HOME="$xdg_dir" CATALYST_AUTONOMOUS=1 \
+       bash "$SCRIPT" 2>&1 || true )
+}
+
+echo "check-setup.sh orchestrator app credential tests (CTL-785)"
+
+# ─── Test 1: both clientId + clientSecret configured → pass ──────────────────
+P1="${SCRATCH}/p1" X1="${SCRATCH}/x1"
+make_project "$P1"
+make_xdg "$X1" "my-client-id-123" "$FIXTURE_SECRET"
+OUT1="$(run_script "$P1" "$X1")"
+
+assert_grep "configured creds pass" "$OUT1" "Orchestrator Linear app credentials configured"
+assert_not_grep "secret not printed" "$OUT1" "$FIXTURE_SECRET"
+
+# ─── Test 2: clientId only (partial) → warn ───────────────────────────────────
+P2="${SCRATCH}/p2" X2="${SCRATCH}/x2"
+make_project "$P2"
+make_xdg "$X2" "my-client-id-456" ""
+OUT2="$(run_script "$P2" "$X2")"
+
+assert_grep "partial creds warn" "$OUT2" "Orchestrator Linear app credentials incomplete"
+
+# ─── Test 3: clientSecret only (partial) → warn ──────────────────────────────
+P3="${SCRATCH}/p3" X3="${SCRATCH}/x3"
+make_project "$P3"
+make_xdg "$X3" "" "$FIXTURE_SECRET"
+OUT3="$(run_script "$P3" "$X3")"
+
+assert_grep "partial creds (secret only) warn" "$OUT3" "Orchestrator Linear app credentials incomplete"
+assert_not_grep "secret not printed (partial case)" "$OUT3" "$FIXTURE_SECRET"
+
+# ─── Test 4: neither configured → warn + fallback explanation ────────────────
+P4="${SCRATCH}/p4" X4="${SCRATCH}/x4"
+make_project "$P4"
+make_xdg "$X4" "" ""
+OUT4="$(run_script "$P4" "$X4")"
+
+assert_grep "absent warn" "$OUT4" "Orchestrator Linear app not configured"
+assert_grep "fallback explanation" "$OUT4" "daemon will fall back to the personal LINEAR_API_TOKEN"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASSES passed, $FAILURES failed"
+[[ $FAILURES -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -341,6 +341,21 @@ else
     info "OLD fallback: set catalyst.monitor.linear.botUserId in .catalyst/config.json; see /catalyst-foundry:setup-catalyst"
 fi
 
+# Orchestrator Linear OAuth app (CTL-785) — the daemon mints its app-actor token
+# from these creds at start; absent/partial creds silently fall back to the
+# personal LINEAR_API_TOKEN (re-pinning the shared 2,500/hr bucket).
+_ORCH_CID=$(jq -r '.catalyst.linear.bot.orchestrator.clientId // empty' "${CATALYST_CONFIG}/config.json" 2>/dev/null)
+_ORCH_CSEC=$(jq -r '.catalyst.linear.bot.orchestrator.clientSecret // empty' "${CATALYST_CONFIG}/config.json" 2>/dev/null)
+if [[ -n "$_ORCH_CID" && -n "$_ORCH_CSEC" ]]; then
+    pass "Orchestrator Linear app credentials configured (clientId ${_ORCH_CID:0:8}…)"
+elif [[ -n "$_ORCH_CID" || -n "$_ORCH_CSEC" ]]; then
+    warn "Orchestrator Linear app credentials incomplete — need BOTH clientId and clientSecret"
+    info "Set catalyst.linear.bot.orchestrator.{clientId,clientSecret} in ${CATALYST_CONFIG}/config.json"
+else
+    warn "Orchestrator Linear app not configured — daemon will fall back to the personal LINEAR_API_TOKEN (CTL-785)"
+    info "Create a 'Catalyst Orchestrator' OAuth app in Linear, then set catalyst.linear.bot.orchestrator.{clientId,clientSecret} in ${CATALYST_CONFIG}/config.json"
+fi
+
 # ─── 7. OTel Observability Stack (optional) ────────────────────────────────
 
 header "Observability Stack (optional)"

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -8,6 +8,7 @@ import { descriptorAgeMs } from "./gateway-read.mjs";
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { withBreaker, linearBreaker, isRateLimitError } from "./linear-breaker.mjs";
+import { withAuthRemint, linearReminter, isBatchAuthError } from "./linear-remint.mjs";
 
 // linearis caps a single page; 200 comfortably covers a project's pickable
 // set without pagination (the reconcile poll runs every 10 min anyway).
@@ -75,8 +76,10 @@ function rawExec(cmd, args) {
 // defaultExec — rawExec behind the CTL-679 process-wide rate-limit breaker. The
 // eligible poll and per-ticket reads short-circuit without spawning linearis
 // while the breaker is open. Shared singleton with linear-write.mjs so a 429 on
-// the write path also pauses reads (and vice-versa).
-const defaultExec = withBreaker(rawExec);
+// the write path also pauses reads (and vice-versa). CTL-785: withAuthRemint
+// interposes under the breaker — an open breaker still short-circuits before any
+// spawn (including the remint retry).
+const defaultExec = withBreaker(withAuthRemint(rawExec));
 
 // normalizeTicket — flatten linearis's nested shape into a stable record.
 // `state` and `project` arrive as `{ name }` objects from the Linear API;
@@ -238,6 +241,10 @@ export function authHeader(token = "") {
 // HTTP 400 not 429) OR a rate-limit message. Either must open the CTL-679 breaker
 // so the larger batch payload backs off instead of re-firing every tick.
 // Exported for unit coverage.
+// CTL-785: isBatchAuthError is imported from linear-remint.mjs and re-exported
+// here so callers that already depend on linear-query.mjs can access it without
+// a direct dependency on linear-remint.mjs.
+export { isBatchAuthError } from "./linear-remint.mjs";
 export function isBatchRateLimited(errors) {
   return (errors ?? []).some(
     (e) => e?.extensions?.code === "RATELIMITED" || isRateLimitError(e?.message),
@@ -273,6 +280,40 @@ export function buildBatchCurlArgs(ids, { token = "", ca } = {}) {
   return { args, payload };
 }
 
+// runBatchOnce — executes ONE curl GraphQL POST and classifies the result.
+// Returns { nodes, auth, ratelimit, curlFailed }. Never throws. Internal to
+// defaultBatchExec; extracted so the auth-retry path can call it a second time.
+function runBatchOnce(ids) {
+  const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
+  const { args, payload } = buildBatchCurlArgs(ids, { token, ca: process.env.NODE_EXTRA_CA_CERTS });
+  const res = spawnSync("curl", args, { input: payload, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+  if (res.status !== 0) {
+    return { nodes: null, auth: false, ratelimit: false, curlFailed: true };
+  }
+  const out = res.stdout ?? "";
+  const nl = out.lastIndexOf("\n");
+  const httpCode = Number(out.slice(nl + 1).trim());
+  const body = out.slice(0, Math.max(0, nl));
+  if (httpCode === 401) {
+    return { nodes: null, auth: true, ratelimit: false, curlFailed: false };
+  }
+  if (httpCode === 429) {
+    return { nodes: null, auth: false, ratelimit: true, curlFailed: false };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return { nodes: null, auth: false, ratelimit: false, curlFailed: false };
+  }
+  if (parsed?.errors) {
+    const auth = isBatchAuthError(parsed.errors);
+    const ratelimit = !auth && isBatchRateLimited(parsed.errors);
+    return { nodes: null, auth, ratelimit, curlFailed: false };
+  }
+  return { nodes: parsed?.data?.issues?.nodes ?? [], auth: false, ratelimit: false, curlFailed: false };
+}
+
 // defaultBatchExec — CTL-784. ONE synchronous GraphQL POST (via curl, to keep
 // the scheduler tick synchronous — making the tick async would break the
 // no-overlapping-tick invariant) returning the issues nodes array, or null on
@@ -281,32 +322,16 @@ export function buildBatchCurlArgs(ids, { token = "", ca } = {}) {
 // spawning; a 429 (HTTP) or a RATELIMITED GraphQL error body opens it; a clean
 // response closes it. Auth uses LINEAR_API_TOKEN/LINEAR_API_KEY (the daemon
 // exports the orchestrator app-actor token, CTL-785).
+// CTL-785: an expired app-actor token serves 401 (HTTP) or AUTHENTICATION_ERROR
+// (GraphQL, HTTP 400). One remint attempt + one retry; cooldown bounds storms.
 function defaultBatchExec(ids) {
   if (linearBreaker.isOpen()) return null; // circuit-open → skip, no spawn
-  const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
-  const { args, payload } = buildBatchCurlArgs(ids, { token, ca: process.env.NODE_EXTRA_CA_CERTS });
-  const res = spawnSync("curl", args, { input: payload, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
-  if (res.status !== 0) return null; // curl/network failure — fail-safe, no breaker change
-  const out = res.stdout ?? "";
-  const nl = out.lastIndexOf("\n");
-  const httpCode = Number(out.slice(nl + 1).trim());
-  const body = out.slice(0, Math.max(0, nl));
-  if (httpCode === 429) {
-    linearBreaker.recordRateLimited();
-    return null;
-  }
-  let parsed;
-  try {
-    parsed = JSON.parse(body);
-  } catch {
-    return null; // unparseable — fail-safe
-  }
-  if (parsed?.errors) {
-    if (isBatchRateLimited(parsed.errors)) linearBreaker.recordRateLimited();
-    return null; // GraphQL-level error (incl. auth / RATELIMITED) — fail-safe
-  }
+  let r = runBatchOnce(ids);
+  if (r.auth && linearReminter.attempt()) r = runBatchOnce(ids);
+  if (r.ratelimit) { linearBreaker.recordRateLimited(); return null; }
+  if (r.nodes == null) return null; // auth-after-retry, curlFailed, or unparseable
   linearBreaker.recordSuccess();
-  return parsed?.data?.issues?.nodes ?? [];
+  return r.nodes;
 }
 
 // fetchTicketsBatch — CTL-784 THE root fix. Resolve the relation descriptors for

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -672,6 +672,19 @@ describe("isBatchRateLimited (CTL-784)", () => {
   });
 });
 
+// ── CTL-785: isBatchAuthError re-export contract ──
+// linear-query.mjs re-exports isBatchAuthError from linear-remint.mjs so
+// callers already depending on this module need no direct linear-remint
+// import. Pin the re-export so an accidental removal fails a test.
+describe("isBatchAuthError re-export (CTL-785)", () => {
+  test("is importable from linear-query.mjs and detects AUTHENTICATION_ERROR", async () => {
+    const { isBatchAuthError } = await import("./linear-query.mjs");
+    expect(typeof isBatchAuthError).toBe("function");
+    expect(isBatchAuthError([{ extensions: { code: "AUTHENTICATION_ERROR" } }])).toBe(true);
+    expect(isBatchAuthError([{ extensions: { code: "RATELIMITED" } }])).toBe(false);
+  });
+});
+
 // ── CTL-671 Phase 2: 3-valued phantom-resolution classifier ──
 describe("classifyTicketResolution (CTL-671)", () => {
   test("resolvable ticket → exists", () => {

--- a/plugins/dev/scripts/execution-core/linear-remint.mjs
+++ b/plugins/dev/scripts/execution-core/linear-remint.mjs
@@ -1,0 +1,155 @@
+// linear-remint.mjs — CTL-785 follow-up: re-mint the Catalyst Orchestrator
+// app-actor token on a mid-run 401. The startup mint (catalyst-execution-core
+// cmd_start) runs ONCE; a daemon crossing the OAuth expiry boundary would
+// otherwise fail every Linear call until restarted. Secrets hygiene: the
+// clientSecret/token are read into variables and never logged (house style:
+// ratelimit-poller.mjs).
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { log } from "./config.mjs";
+
+const OAUTH_ENDPOINT = "https://api.linear.app/oauth/token";
+const MINT_SCOPE = "read,write,comments:create";
+const DEFAULT_COOLDOWN_MS = 60_000;
+
+// isAuthError — Linear auth failures as surfaced on linearis stderr. Matched
+// loosely (message wording unverified against a live expired token; the
+// GraphQL contract is errors[].extensions.code === "AUTHENTICATION_ERROR"
+// with "Authentication required" messages; the oauth layer can serve 401).
+// Deliberately does NOT overlap isRateLimitError.
+export function isAuthError(stderr) {
+  return /authentication[ _-]?(required|error)|unauthorized|\b401\b/i.test(
+    String(stderr ?? ""),
+  );
+}
+
+// isBatchAuthError — GraphQL errors[] auth shape (sibling of isBatchRateLimited).
+export function isBatchAuthError(errors) {
+  return (errors ?? []).some(
+    (e) => e?.extensions?.code === "AUTHENTICATION_ERROR" || isAuthError(e?.message),
+  );
+}
+
+// defaultLayer2Path — mirrors daemon.mjs boot resolution (env override for tests).
+function defaultLayer2Path() {
+  return (
+    process.env.CATALYST_LAYER2_CONFIG_FILE ||
+    resolve(homedir(), ".config", "catalyst", "config.json")
+  );
+}
+
+export function readOrchestratorCreds(layer2Path = defaultLayer2Path()) {
+  try {
+    const parsed = JSON.parse(readFileSync(layer2Path, "utf8"));
+    const o = parsed?.catalyst?.linear?.bot?.orchestrator;
+    if (
+      typeof o?.clientId === "string" &&
+      o.clientId &&
+      typeof o?.clientSecret === "string" &&
+      o.clientSecret
+    ) {
+      return { clientId: o.clientId, clientSecret: o.clientSecret };
+    }
+  } catch {
+    /* unreadable/malformed → null (fail-open) */
+  }
+  return null;
+}
+
+// buildMintCurlArgs — argv + form payload for the client_credentials mint.
+// Mirrors the bash startup mint: --noproxy '*' keeps it off the audit MITM.
+// Secret travels via --data @- (stdin), never argv. Exported for unit coverage.
+export function buildMintCurlArgs({ clientId, clientSecret }) {
+  const payload = new URLSearchParams({
+    grant_type: "client_credentials",
+    client_id: clientId,
+    client_secret: clientSecret,
+    scope: MINT_SCOPE,
+  }).toString();
+  return {
+    args: [
+      "-sS",
+      "--max-time",
+      "30",
+      "--noproxy",
+      "*",
+      "-X",
+      "POST",
+      OAUTH_ENDPOINT,
+      "--data",
+      "@-",
+    ],
+    payload,
+  };
+}
+
+export function parseMintResponse({ code, stdout }) {
+  if (code !== 0) return null;
+  try {
+    return JSON.parse(stdout)?.access_token || null;
+  } catch {
+    return null;
+  }
+}
+
+// defaultMint — synchronous (the scheduler tick is sync; see defaultBatchExec).
+function defaultMint(creds) {
+  const { args, payload } = buildMintCurlArgs(creds);
+  const res = spawnSync("curl", args, { input: payload, encoding: "utf8" });
+  return parseMintResponse({ code: res.status ?? 1, stdout: res.stdout ?? "" });
+}
+
+function defaultApplyToken(token) {
+  process.env.LINEAR_API_TOKEN = token;
+  process.env.LINEAR_API_KEY = token;
+}
+
+// createReminter — cooldown-guarded re-mint. attempt() returns true iff a new
+// token was minted AND applied. At most one mint per cooldown window regardless
+// of outcome (storm guard for revoked creds); recovers automatically once the
+// cooldown elapses. No creds configured → permanent no-op (fail-open: the
+// daemon keeps whatever token it has).
+export function createReminter({
+  readCreds = readOrchestratorCreds,
+  mint = defaultMint,
+  applyToken = defaultApplyToken,
+  cooldownMs = DEFAULT_COOLDOWN_MS,
+  logger = log,
+} = {}) {
+  let lastAttempt = -Infinity;
+  return {
+    attempt(now = Date.now()) {
+      if (now - lastAttempt < cooldownMs) return false;
+      lastAttempt = now;
+      const creds = readCreds();
+      if (!creds) return false;
+      const token = mint(creds);
+      if (!token) {
+        logger.warn({}, "ctl-785: orchestrator token re-mint FAILED — keeping current token");
+        return false;
+      }
+      applyToken(token);
+      logger.info({}, "ctl-785: orchestrator token re-minted after auth error");
+      return true;
+    },
+  };
+}
+
+// Process-wide singleton (same pattern as linearBreaker).
+export const linearReminter = createReminter();
+
+// withAuthRemint — wrap a raw exec: on an auth-error failure, attempt ONE
+// re-mint; if a fresh token was applied, retry the call once (the spawned
+// child inherits the updated process.env). Composes UNDER withBreaker so an
+// open breaker still short-circuits before any spawn.
+export function withAuthRemint(rawExec, { reminter = linearReminter, now = Date.now } = {}) {
+  return (cmd, args) => {
+    const res = rawExec(cmd, args);
+    if (res.code !== 0 && isAuthError(res.stderr) && reminter.attempt(now())) {
+      return rawExec(cmd, args);
+    }
+    return res;
+  };
+}

--- a/plugins/dev/scripts/execution-core/linear-remint.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-remint.test.mjs
@@ -1,0 +1,393 @@
+// linear-remint.test.mjs — CTL-785: in-process token re-mint on mid-run 401.
+// Run: cd plugins/dev/scripts/execution-core && bun test linear-remint.test.mjs
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { writeFileSync, unlinkSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  isAuthError,
+  isBatchAuthError,
+  readOrchestratorCreds,
+  buildMintCurlArgs,
+  parseMintResponse,
+  createReminter,
+  withAuthRemint,
+} from "./linear-remint.mjs";
+import { createLinearBreaker, withBreaker } from "./linear-breaker.mjs";
+
+const silentLogger = { warn() {}, info() {}, error() {} };
+
+// ── isAuthError ───────────────────────────────────────────────────────────────
+
+describe("isAuthError", () => {
+  test("matches 'Authentication required'", () =>
+    expect(isAuthError("Authentication required, not authenticated")).toBe(true));
+  test("matches AUTHENTICATION_ERROR code text", () =>
+    expect(isAuthError("error: AUTHENTICATION_ERROR")).toBe(true));
+  test("matches HTTP 401", () =>
+    expect(isAuthError("HTTP 401")).toBe(true));
+  test("matches 401 standalone", () =>
+    expect(isAuthError("401")).toBe(true));
+  test("matches Unauthorized", () =>
+    expect(isAuthError("Unauthorized")).toBe(true));
+  test("does NOT match rate-limit errors", () =>
+    expect(isAuthError("Rate limit exceeded")).toBe(false));
+  test("does NOT match generic errors", () =>
+    expect(isAuthError("network timeout")).toBe(false));
+  test("does NOT match empty string", () =>
+    expect(isAuthError("")).toBe(false));
+  test("does NOT match null", () =>
+    expect(isAuthError(null)).toBe(false));
+  test("does NOT match undefined", () =>
+    expect(isAuthError(undefined)).toBe(false));
+});
+
+// ── isBatchAuthError ──────────────────────────────────────────────────────────
+
+describe("isBatchAuthError", () => {
+  test("true on extensions.code AUTHENTICATION_ERROR", () =>
+    expect(isBatchAuthError([{ extensions: { code: "AUTHENTICATION_ERROR" } }])).toBe(true));
+  test("true on auth message", () =>
+    expect(isBatchAuthError([{ message: "Authentication required" }])).toBe(true));
+  test("false on RATELIMITED", () =>
+    expect(isBatchAuthError([{ extensions: { code: "RATELIMITED" } }])).toBe(false));
+  test("false on empty array", () =>
+    expect(isBatchAuthError([])).toBe(false));
+  test("false on undefined", () =>
+    expect(isBatchAuthError(undefined)).toBe(false));
+});
+
+// ── readOrchestratorCreds ─────────────────────────────────────────────────────
+
+describe("readOrchestratorCreds", () => {
+  let scratch;
+  beforeEach(() => {
+    scratch = join(tmpdir(), `remint-test-${Math.floor(Math.random() * 1e9)}`);
+    mkdirSync(scratch, { recursive: true });
+  });
+  afterEach(() => {
+    try { unlinkSync(join(scratch, "config.json")); } catch { /* ok */ }
+  });
+
+  function writeCfg(obj) {
+    writeFileSync(join(scratch, "config.json"), JSON.stringify(obj));
+    return join(scratch, "config.json");
+  }
+
+  test("reads clientId+clientSecret from the correct path", () => {
+    const p = writeCfg({
+      catalyst: { linear: { bot: { orchestrator: {
+        clientId: "my-client-id",
+        clientSecret: "my-secret",
+      } } } },
+    });
+    expect(readOrchestratorCreds(p)).toEqual({ clientId: "my-client-id", clientSecret: "my-secret" });
+  });
+
+  test("null when file missing", () => {
+    expect(readOrchestratorCreds(join(scratch, "nonexistent.json"))).toBeNull();
+  });
+
+  test("null when JSON is malformed", () => {
+    writeFileSync(join(scratch, "config.json"), "not-json");
+    expect(readOrchestratorCreds(join(scratch, "config.json"))).toBeNull();
+  });
+
+  test("null when clientId is absent", () => {
+    const p = writeCfg({ catalyst: { linear: { bot: { orchestrator: { clientSecret: "s" } } } } });
+    expect(readOrchestratorCreds(p)).toBeNull();
+  });
+
+  test("null when clientSecret is absent", () => {
+    const p = writeCfg({ catalyst: { linear: { bot: { orchestrator: { clientId: "c" } } } } });
+    expect(readOrchestratorCreds(p)).toBeNull();
+  });
+
+  test("null when clientId is empty string", () => {
+    const p = writeCfg({ catalyst: { linear: { bot: { orchestrator: { clientId: "", clientSecret: "s" } } } } });
+    expect(readOrchestratorCreds(p)).toBeNull();
+  });
+
+  test("null when clientSecret is empty string", () => {
+    const p = writeCfg({ catalyst: { linear: { bot: { orchestrator: { clientId: "c", clientSecret: "" } } } } });
+    expect(readOrchestratorCreds(p)).toBeNull();
+  });
+
+  test("null when orchestrator key is entirely absent", () => {
+    const p = writeCfg({ catalyst: { linear: { bot: {} } } });
+    expect(readOrchestratorCreds(p)).toBeNull();
+  });
+});
+
+// ── buildMintCurlArgs ─────────────────────────────────────────────────────────
+
+describe("buildMintCurlArgs", () => {
+  test("uses --noproxy '*' and POSTs to the oauth token endpoint", () => {
+    const { args } = buildMintCurlArgs({ clientId: "c", clientSecret: "s" });
+    expect(args).toContain("--noproxy");
+    expect(args[args.indexOf("--noproxy") + 1]).toBe("*");
+    expect(args).toContain("-X");
+    expect(args[args.indexOf("-X") + 1]).toBe("POST");
+    expect(args).toContain("https://api.linear.app/oauth/token");
+  });
+
+  test("reads payload from stdin (--data @-), secret NOT in argv", () => {
+    const { args, payload } = buildMintCurlArgs({ clientId: "cid", clientSecret: "verysecret" });
+    expect(args).toContain("--data");
+    expect(args[args.indexOf("--data") + 1]).toBe("@-");
+    // secret must not appear in argv
+    expect(args.join(" ")).not.toContain("verysecret");
+    // but does appear in payload (sent via stdin)
+    expect(payload).toContain("verysecret");
+  });
+
+  test("payload includes client_credentials grant and correct scope", () => {
+    const { payload } = buildMintCurlArgs({ clientId: "c", clientSecret: "s" });
+    expect(payload).toContain("grant_type=client_credentials");
+    expect(payload).toContain("read%2Cwrite%2Ccomments%3Acreate");
+  });
+
+  test("sets --max-time", () => {
+    const { args } = buildMintCurlArgs({ clientId: "c", clientSecret: "s" });
+    expect(args).toContain("--max-time");
+  });
+});
+
+// ── parseMintResponse ─────────────────────────────────────────────────────────
+
+describe("parseMintResponse", () => {
+  test("returns access_token on success", () =>
+    expect(parseMintResponse({ code: 0, stdout: JSON.stringify({ access_token: "tok123" }) })).toBe("tok123"));
+  test("null on non-zero exit code", () =>
+    expect(parseMintResponse({ code: 1, stdout: JSON.stringify({ access_token: "tok" }) })).toBeNull());
+  test("null on unparseable body", () =>
+    expect(parseMintResponse({ code: 0, stdout: "not-json" })).toBeNull());
+  test("null when access_token missing from body", () =>
+    expect(parseMintResponse({ code: 0, stdout: JSON.stringify({ error: "invalid_client" }) })).toBeNull());
+  test("null on empty body", () =>
+    expect(parseMintResponse({ code: 0, stdout: "" })).toBeNull());
+});
+
+// ── createReminter ────────────────────────────────────────────────────────────
+
+describe("createReminter", () => {
+  test("attempt() with no creds → false, mint never called", () => {
+    const mintCalls = [];
+    const r = createReminter({
+      logger: silentLogger,
+      readCreds: () => null,
+      mint: (c) => { mintCalls.push(c); return "tok"; },
+    });
+    expect(r.attempt(0)).toBe(false);
+    expect(mintCalls).toHaveLength(0);
+  });
+
+  test("attempt() mints, calls applyToken, returns true", () => {
+    const applied = [];
+    const r = createReminter({
+      logger: silentLogger,
+      readCreds: () => ({ clientId: "c", clientSecret: "s" }),
+      mint: () => "fresh-token",
+      applyToken: (t) => applied.push(t),
+    });
+    expect(r.attempt(0)).toBe(true);
+    expect(applied).toEqual(["fresh-token"]);
+  });
+
+  test("cooldown: second attempt within cooldownMs → false, mint called ONCE", () => {
+    let mintCount = 0;
+    const r = createReminter({
+      logger: silentLogger,
+      cooldownMs: 60_000,
+      readCreds: () => ({ clientId: "c", clientSecret: "s" }),
+      mint: () => { mintCount++; return "tok"; },
+      applyToken: () => {},
+    });
+    r.attempt(0);
+    expect(r.attempt(59_999)).toBe(false);
+    expect(mintCount).toBe(1);
+  });
+
+  test("cooldown applies even to failed mints (storm guard)", () => {
+    let mintCount = 0;
+    const r = createReminter({
+      logger: silentLogger,
+      cooldownMs: 60_000,
+      readCreds: () => ({ clientId: "c", clientSecret: "s" }),
+      mint: () => { mintCount++; return null; }, // mint fails
+      applyToken: () => {},
+    });
+    r.attempt(0); // fails (null token), but lastAttempt set
+    expect(r.attempt(59_999)).toBe(false); // still in cooldown
+    expect(mintCount).toBe(1);
+  });
+
+  test("after cooldown elapses, attempt() mints again", () => {
+    let mintCount = 0;
+    const r = createReminter({
+      logger: silentLogger,
+      cooldownMs: 60_000,
+      readCreds: () => ({ clientId: "c", clientSecret: "s" }),
+      mint: () => { mintCount++; return "tok"; },
+      applyToken: () => {},
+    });
+    r.attempt(0);
+    r.attempt(60_000); // exactly at cooldown boundary → allowed
+    expect(mintCount).toBe(2);
+  });
+
+  test("default applyToken sets process.env.LINEAR_API_TOKEN and LINEAR_API_KEY", () => {
+    const saved = { key: process.env.LINEAR_API_TOKEN, key2: process.env.LINEAR_API_KEY };
+    try {
+      delete process.env.LINEAR_API_TOKEN;
+      delete process.env.LINEAR_API_KEY;
+      const r = createReminter({
+        logger: silentLogger,
+        cooldownMs: 0,
+        readCreds: () => ({ clientId: "c", clientSecret: "s" }),
+        mint: () => "new-tok",
+        // use default applyToken by not passing it
+      });
+      r.attempt(0);
+      expect(process.env.LINEAR_API_TOKEN).toBe("new-tok");
+      expect(process.env.LINEAR_API_KEY).toBe("new-tok");
+    } finally {
+      if (saved.key !== undefined) process.env.LINEAR_API_TOKEN = saved.key;
+      else delete process.env.LINEAR_API_TOKEN;
+      if (saved.key2 !== undefined) process.env.LINEAR_API_KEY = saved.key2;
+      else delete process.env.LINEAR_API_KEY;
+    }
+  });
+
+  test("mint returns null → attempt returns false", () => {
+    const r = createReminter({
+      logger: silentLogger,
+      readCreds: () => ({ clientId: "c", clientSecret: "s" }),
+      mint: () => null,
+      applyToken: () => {},
+    });
+    expect(r.attempt(0)).toBe(false);
+  });
+});
+
+// ── withAuthRemint ────────────────────────────────────────────────────────────
+
+describe("withAuthRemint", () => {
+  function makeReminter(willSucceed = true) {
+    let attempts = 0;
+    return {
+      attempt() { attempts++; return willSucceed; },
+      get attempts() { return attempts; },
+    };
+  }
+
+  test("clean call passes through untouched, reminter not consulted", () => {
+    const reminter = makeReminter();
+    const calls = [];
+    const raw = (cmd, args) => { calls.push([cmd, args]); return { code: 0, stdout: "ok", stderr: "" }; };
+    const exec = withAuthRemint(raw, { reminter, now: () => 0 });
+    const r = exec("linearis", ["issues", "list"]);
+    expect(r.code).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(reminter.attempts).toBe(0);
+  });
+
+  test("non-auth failure passes through without remint", () => {
+    const reminter = makeReminter();
+    const calls = [];
+    const raw = () => { calls.push(1); return { code: 1, stdout: "", stderr: "Rate limit exceeded" }; };
+    const exec = withAuthRemint(raw, { reminter, now: () => 0 });
+    const r = exec("linearis", ["x"]);
+    expect(r.code).toBe(1);
+    expect(calls).toHaveLength(1);
+    expect(reminter.attempts).toBe(0);
+  });
+
+  test("auth failure → reminter.attempt() true → raw exec retried ONCE, retry result returned", () => {
+    const reminter = makeReminter(true); // mint succeeds
+    let callN = 0;
+    const raw = () => {
+      callN++;
+      // first call: auth error; retry: success
+      return callN === 1
+        ? { code: 1, stdout: "", stderr: "Unauthorized" }
+        : { code: 0, stdout: "retry-ok", stderr: "" };
+    };
+    const exec = withAuthRemint(raw, { reminter, now: () => 0 });
+    const r = exec("linearis", ["x"]);
+    expect(r.stdout).toBe("retry-ok");
+    expect(callN).toBe(2); // spawned twice
+    expect(reminter.attempts).toBe(1);
+  });
+
+  test("auth failure → attempt() false (no creds/cooldown) → original result returned, single spawn", () => {
+    const reminter = makeReminter(false); // mint fails / in cooldown
+    let callN = 0;
+    const raw = () => { callN++; return { code: 1, stdout: "", stderr: "AUTHENTICATION_ERROR" }; };
+    const exec = withAuthRemint(raw, { reminter, now: () => 0 });
+    const r = exec("linearis", ["x"]);
+    expect(r.code).toBe(1);
+    expect(callN).toBe(1); // NOT retried
+    expect(reminter.attempts).toBe(1); // attempt WAS consulted
+  });
+
+  test("retry also failing returns the retry result without a third spawn", () => {
+    const reminter = makeReminter(true);
+    let callN = 0;
+    const raw = () => {
+      callN++;
+      // both calls return auth error
+      return { code: 1, stdout: "", stderr: "Unauthorized" };
+    };
+    const exec = withAuthRemint(raw, { reminter, now: () => 0 });
+    const r = exec("linearis", ["x"]);
+    expect(r.code).toBe(1);
+    expect(callN).toBe(2); // original + one retry only
+  });
+});
+
+// ── breaker + remint composition ──────────────────────────────────────────────
+
+describe("breaker + remint composition", () => {
+  test("withBreaker(withAuthRemint(raw)): open breaker short-circuits — raw NEVER spawned, reminter NOT consulted", () => {
+    const breaker = createLinearBreaker({ logger: silentLogger, baseCooldownMs: 1000 });
+    let spawnCount = 0;
+    const reminter = { attempt() { throw new Error("reminter should not be called"); } };
+    const raw = () => { spawnCount++; return { code: 0, stdout: "", stderr: "" }; };
+    // open the breaker
+    breaker.recordRateLimited(0);
+    const exec = withBreaker(withAuthRemint(raw, { reminter }), { breaker, now: () => 500 });
+    const r = exec("linearis", ["x"]);
+    expect(r.stderr).toBe("circuit-open");
+    expect(spawnCount).toBe(0);
+  });
+
+  test("auth-fail → remint → retry-success: breaker records success", () => {
+    const breaker = createLinearBreaker({ logger: silentLogger });
+    let callN = 0;
+    const applied = [];
+    const reminter = createReminter({
+      logger: silentLogger,
+      readCreds: () => ({ clientId: "c", clientSecret: "s" }),
+      mint: () => "new-tok",
+      applyToken: (t) => applied.push(t),
+      cooldownMs: 0,
+    });
+    const raw = () => {
+      callN++;
+      return callN === 1
+        ? { code: 1, stdout: "", stderr: "Unauthorized" }
+        : { code: 0, stdout: "ok", stderr: "" };
+    };
+    let clock = 0;
+    const exec = withBreaker(withAuthRemint(raw, { reminter, now: () => clock }), {
+      breaker,
+      now: () => clock,
+    });
+    const r = exec("linearis", ["x"]);
+    expect(r.code).toBe(0);
+    expect(callN).toBe(2);
+    expect(applied).toEqual(["new-tok"]);
+    expect(breaker.isOpen(0)).toBe(false); // success closed the path
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -11,6 +11,7 @@ import { getProjectConfig } from "./registry.mjs";
 import { log } from "./config.mjs";
 import { fetchTicketLabels, fetchTicketState } from "./linear-query.mjs";
 import { withBreaker } from "./linear-breaker.mjs";
+import { withAuthRemint } from "./linear-remint.mjs";
 // CTL-758: the SHARED Linear terminal-state predicate ({Done,Canceled} — its OWN
 // set, NOT TERMINAL_LINEAR_KEY which is the transition KEY "done"). Gates the
 // backward-write guard below.
@@ -34,7 +35,9 @@ function rawExec(cmd, args) {
 // the status-write path (which shells linear-transition.sh, itself a Linear
 // read+write) short-circuits without spawning while the breaker is open. Shared
 // singleton with linear-query.mjs: one 429 on any path pauses every path.
-const defaultExec = withBreaker(rawExec);
+// CTL-785: withAuthRemint interposes under the breaker — an open breaker still
+// short-circuits before any spawn (including the remint retry).
+const defaultExec = withBreaker(withAuthRemint(rawExec));
 
 // teamOf — the Linear team key is the identifier prefix: "CTL-558" → "CTL".
 export function teamOf(ticket) {


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-07T08:15:00Z -->
<!-- Last updated: 2026-06-07T08:15:00Z -->
<!-- PR: #1435 -->
<!-- Previous commits: 117d4f5af805bbd457ee7e127a7adb6fc53a0de0 -->

## Summary

Isolates the execution-core daemon's Linear API budget onto a dedicated **Catalyst Orchestrator** OAuth app token — preventing the daemon's heavy admission-pool reads (~2,160/hr) from starving interactive work on the shared personal token. Also adds a `check-setup.sh` prerequisite gate that warns (not fails) when the orchestrator app credentials are absent or partial.

- **`linear-remint.mjs`** (new): auth-error detection (`isAuthError`/`isBatchAuthError`), Layer-2 cred reader (`readOrchestratorCreds`), mint plumbing (`buildMintCurlArgs`/`parseMintResponse`), and `createReminter`/`withAuthRemint` — cooldown-guarded wrapper that detects a 401/auth error on a linearis exec, re-mints the orchestrator app-actor token in-process, and retries once
- **`linear-query.mjs`**: compose `withAuthRemint` under `withBreaker` on the linearis exec path; extract `runBatchOnce` and add 401/AUTHENTICATION_ERROR retry branch to `defaultBatchExec`; re-export `isBatchAuthError`
- **`linear-write.mjs`**: compose `withAuthRemint` under `withBreaker` on the status-write exec path
- **`check-setup.sh`**: add orchestrator app credential check — `pass` when both `clientId + clientSecret` configured, `warn` (not `fail`) when absent or partial; secret never printed

## Changes Made

### Execution-core

- New `linear-remint.mjs` module: full token re-mint lifecycle for mid-run 401s on the orchestrator app token
- `linear-query.mjs`: `withAuthRemint` composed into exec path; `runBatchOnce` extracted; 401/AUTHENTICATION_ERROR retry in `defaultBatchExec`; `isBatchAuthError` re-exported for consumers
- `linear-write.mjs`: `withAuthRemint` composed into status-write exec path

### Setup / Prerequisites

- `check-setup.sh`: orchestrator app credential gate — warns when `clientId`/`clientSecret` absent or partial; never prints the secret value

### Tests

- `linear-remint.test.mjs`: 46 tests covering auth-error detection, cred reader, mint plumbing, and remint wrapper (cooldown, retry, passthrough)
- `__tests__/check-setup-orchestrator-app.test.sh`: 7 shell tests covering pass/warn/absent cases and secret-not-printed invariant

## How to Verify It

- [x] `bun test linear-remint.test.mjs` — 46 pass, 0 fail ✅
- [x] `bun test` in `execution-core/` — 2081 pass (4 pre-existing flaky failures unrelated to this diff) ✅
- [x] `bash plugins/dev/scripts/__tests__/check-setup-orchestrator-app.test.sh` — 7 pass, 0 fail ✅
- [x] CI: audit-references, check-versions, docs-gate, validate — all pass ✅
- [ ] `bash plugins/dev/scripts/check-setup.sh` shows `✅ Orchestrator Linear app credentials configured` (manual, requires real credentials)
- [ ] Daemon authenticates as Catalyst Orchestrator app-actor (verified from `x-ratelimit-*` headers — daemon token vs personal token decrement independently)

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-785

## Changelog Entry

### catalyst-dev

**feat**: execution-core: token re-mint on mid-run 401 + orchestrator app credential check

- Add `linear-remint.mjs` — cooldown-guarded auth-error detector and token re-minter for the orchestrator app-actor token
- Compose `withAuthRemint` into `linear-query.mjs` and `linear-write.mjs` exec paths
- Add orchestrator app credential prerequisite check to `check-setup.sh` (warn-not-fail when absent)
- 53 new tests (46 unit + 7 shell)
