### PR TITLE
CTL-696: Vendor catalyst-stack into the repo + wire into install-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ This script will guide you through:
 # Restart Claude Code
 ```
 
+**Start the stack:**
+
+```bash
+catalyst-stack start
+```
+
+This brings up broker → monitor → execution-core in dependency order. Run it once after each reboot.
+
 You're ready! Try `/research-codebase` in your next session.
 
 See the [documentation site](https://catalyst.coalescelabs.ai) for detailed setup instructions.
@@ -244,6 +252,12 @@ claude plugin marketplace update catalyst
 
 **Important:** A restart is required for plugin updates to take effect. Active sessions use the old
 version until you restart Claude Code.
+
+**One-command post-merge update** (ff-pull + rsync into the live cache + restart):
+
+```bash
+catalyst-stack restart --hotpatch
+```
 
 **Check your versions:**
 

--- a/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# Shell tests for catalyst-stack (CTL-696).
+# Run: bash plugins/dev/scripts/__tests__/catalyst-stack.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+STACK="${REPO_ROOT}/plugins/dev/scripts/catalyst-stack"
+REAL_PATH="$PATH"
+# PATH without Homebrew, so mitmdump (/opt/homebrew/bin/mitmdump) is absent.
+MINIMAL_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    command: $*"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+expect_exit() {
+  local expected="$1"; shift
+  set +e
+  "$@" > "${SCRATCH}/out" 2>&1
+  local rc=$?
+  set -e
+  if [[ "$rc" = "$expected" ]]; then
+    return 0
+  else
+    echo "    expected rc=$expected got rc=$rc"
+    sed 's/^/    /' "${SCRATCH}/out"
+    return 1
+  fi
+}
+
+# Run catalyst-stack with a custom PATH (stubs first, real PATH appended so
+# standard utilities like bash/sed/pgrep remain accessible).
+run_stack() {
+  local stub_dir="$1"; shift
+  PATH="${stub_dir}:${REAL_PATH}" "${STACK}" "$@"
+}
+
+# ── Stub dirs ────────────────────────────────────────────────────────────────
+make_stubs() {
+  local dir="$1"
+  mkdir -p "$dir"
+  for svc in catalyst-broker catalyst-monitor; do
+    cat > "$dir/$svc" <<'EOF'
+#!/usr/bin/env bash
+echo "running"; exit 0
+EOF
+    chmod +x "$dir/$svc"
+  done
+  cat > "$dir/catalyst-execution-core" <<'EOF'
+#!/usr/bin/env bash
+echo "running"; exit 0
+EOF
+  chmod +x "$dir/catalyst-execution-core"
+  cat > "$dir/brew" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$dir/brew"
+}
+
+STUBDIR="${SCRATCH}/stubs"
+make_stubs "$STUBDIR"
+# mitmdump stub — records invocations
+cat > "$STUBDIR/mitmdump" <<EOF
+#!/usr/bin/env bash
+touch "${STUBDIR}/mitmdump.called"
+exit 0
+EOF
+chmod +x "$STUBDIR/mitmdump"
+
+# stubs without mitmdump (simulate not installed)
+STUBDIR_NO_MITM="${SCRATCH}/stubs_no_mitm"
+make_stubs "$STUBDIR_NO_MITM"
+
+# stubs where execution-core reports "stopped"
+STUBDIR_STOPPED="${SCRATCH}/stubs_stopped"
+make_stubs "$STUBDIR_STOPPED"
+cat > "$STUBDIR_STOPPED/catalyst-execution-core" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  status) echo "stopped" ;;
+  *) echo "running" ;;
+esac
+exit 0
+EOF
+chmod +x "$STUBDIR_STOPPED/catalyst-execution-core"
+
+# stubs where execution-core reports "running" (for live-stack check)
+STUBDIR_LIVE="${SCRATCH}/stubs_live"
+make_stubs "$STUBDIR_LIVE"
+
+# ── Phase 1 tests ─────────────────────────────────────────────────────────────
+
+echo "catalyst-stack tests"
+
+run "catalyst-stack is vendored and executable" bash -c "[[ -x '${STACK}' ]]"
+
+run "help exits 0 and documents --proxy as opt-in" \
+  bash -c "PATH='${STUBDIR}:${REAL_PATH}' '${STACK}' --help 2>&1 | grep -q -- '--proxy'"
+
+run "default start does not invoke mitmdump" bash -c "
+  rm -f '${STUBDIR}/mitmdump.called'
+  PATH='${STUBDIR}:${REAL_PATH}' '${STACK}' start >/dev/null 2>&1
+  [[ ! -f '${STUBDIR}/mitmdump.called' ]]
+"
+
+run "--no-proxy is accepted as a no-op (exit 0)" bash -c "
+  PATH='${STUBDIR}:${REAL_PATH}' '${STACK}' start --no-proxy >/dev/null 2>&1
+"
+
+run "--no-proxy does not invoke mitmdump" bash -c "
+  rm -f '${STUBDIR}/mitmdump.called'
+  PATH='${STUBDIR}:${REAL_PATH}' '${STACK}' start --no-proxy >/dev/null 2>&1
+  [[ ! -f '${STUBDIR}/mitmdump.called' ]]
+"
+
+run "--proxy missing mitmdump declined exits non-zero" bash -c "
+  set +e
+  out=\$(printf 'n\n' | PATH='${STUBDIR_NO_MITM}:${MINIMAL_PATH}' '${STACK}' start --proxy 2>&1)
+  rc=\$?
+  set -e
+  [[ \$rc -ne 0 ]] && echo \"\$out\" | grep -qi mitmproxy
+"
+
+run "unknown arg fails with exit 1" bash -c "
+  set +e
+  PATH='${STUBDIR}:${REAL_PATH}' '${STACK}' start --bogus >/dev/null 2>&1
+  rc=\$?
+  set -e
+  [[ \$rc -ne 0 ]]
+"
+
+run "status lists execution-core" bash -c "
+  PATH='${STUBDIR}:${REAL_PATH}' '${STACK}' status 2>&1 | grep -q execution-core
+"
+
+run "stop exits 0" bash -c "
+  PATH='${STUBDIR}:${REAL_PATH}' '${STACK}' stop >/dev/null 2>&1
+"
+
+run "restart exits 0" bash -c "
+  PATH='${STUBDIR}:${REAL_PATH}' '${STACK}' restart >/dev/null 2>&1
+"
+
+# ── Addon portability tests ───────────────────────────────────────────────────
+
+ADDON="${REPO_ROOT}/plugins/dev/scripts/mitm_linear_addon.py"
+
+run "vendored addon exists" bash -c "[[ -f '${ADDON}' ]]"
+
+run "vendored addon has no hardcoded /Users/ryan LOG path" bash -c "
+  ! grep -qF '\"/Users/ryan/catalyst/linear-proxy.jsonl\"' '${ADDON}'
+"
+
+run "vendored addon resolves LOG portably" bash -c "
+  grep -Eq 'expanduser|MITM_LOG|environ' '${ADDON}'
+"
+
+run "vendored addon parses as valid python3" bash -c "
+  python3 -c \"import ast; ast.parse(open('${ADDON}').read())\"
+"
+
+# ── Phase 2: --hotpatch tests ─────────────────────────────────────────────────
+
+FAKE_REPO="${SCRATCH}/fake_repo"
+mkdir -p "${FAKE_REPO}/.git" "${FAKE_REPO}/plugins/dev"
+FAKE_CACHE="${SCRATCH}/fake_home/.claude/plugins/cache/catalyst/catalyst-dev/1.0.0"
+mkdir -p "${FAKE_CACHE}"
+
+STUBDIR2="${SCRATCH}/stubs2"
+make_stubs "$STUBDIR2"
+# execution-core reports stopped so start proceeds
+cat > "$STUBDIR2/catalyst-execution-core" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  status) echo "stopped" ;;
+  *) echo "running" ;;
+esac
+exit 0
+EOF
+chmod +x "$STUBDIR2/catalyst-execution-core"
+
+# git stub: records args, succeeds
+cat > "$STUBDIR2/git" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> "${SCRATCH}/git.args"
+exit 0
+EOF
+chmod +x "$STUBDIR2/git"
+
+# rsync stub: records args, succeeds
+cat > "$STUBDIR2/rsync" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> "${SCRATCH}/rsync.args"
+exit 0
+EOF
+chmod +x "$STUBDIR2/rsync"
+
+run "restart --hotpatch calls git pull --ff-only" bash -c "
+  rm -f '${SCRATCH}/git.args' '${SCRATCH}/rsync.args'
+  PATH='${STUBDIR2}:${REAL_PATH}' \
+    CATALYST_REPO_DIR='${FAKE_REPO}' \
+    HOME='${SCRATCH}/fake_home' \
+    '${STACK}' restart --hotpatch >/dev/null 2>&1
+  grep -q 'pull --ff-only' '${SCRATCH}/git.args'
+"
+
+run "restart --hotpatch calls rsync with -ac" bash -c "
+  grep -q -- '-ac' '${SCRATCH}/rsync.args'
+"
+
+run "hotpatch rsync never uses --delete" bash -c "
+  ! grep -q -- '--delete' '${SCRATCH}/rsync.args'
+"
+
+run "hotpatch rsync excludes node_modules" bash -c "
+  grep -q 'node_modules' '${SCRATCH}/rsync.args'
+"
+
+run "hotpatch rsync targets catalyst-dev in destination" bash -c "
+  grep -q 'catalyst-dev' '${SCRATCH}/rsync.args'
+"
+
+# git fail stubs
+STUBDIR_GITFAIL="${SCRATCH}/stubs_gitfail"
+make_stubs "$STUBDIR_GITFAIL"
+cp "$STUBDIR2/catalyst-execution-core" "$STUBDIR_GITFAIL/catalyst-execution-core"
+cat > "$STUBDIR_GITFAIL/git" <<EOF
+#!/usr/bin/env bash
+if echo "\$@" | grep -q "ff-only"; then exit 1; fi
+echo "\$@" >> "${SCRATCH}/git_gitfail.args"
+exit 0
+EOF
+chmod +x "$STUBDIR_GITFAIL/git"
+cat > "$STUBDIR_GITFAIL/rsync" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> "${SCRATCH}/rsync_gitfail.args"
+exit 0
+EOF
+chmod +x "$STUBDIR_GITFAIL/rsync"
+
+run "hotpatch aborts on non-ff pull before rsync" bash -c "
+  rm -f '${SCRATCH}/rsync_gitfail.args'
+  set +e
+  PATH='${STUBDIR_GITFAIL}:${REAL_PATH}' \
+    CATALYST_REPO_DIR='${FAKE_REPO}' \
+    HOME='${SCRATCH}/fake_home' \
+    '${STACK}' restart --hotpatch >/dev/null 2>&1
+  rc=\$?
+  set -e
+  [[ \$rc -ne 0 ]] && [[ ! -f '${SCRATCH}/rsync_gitfail.args' ]]
+"
+
+run "start --hotpatch on live stack refuses with restart message" bash -c "
+  PATH='${STUBDIR_LIVE}:${REAL_PATH}' \
+    CATALYST_REPO_DIR='${FAKE_REPO}' \
+    HOME='${SCRATCH}/fake_home' \
+    '${STACK}' start --hotpatch 2>&1 | grep -qi 'restart'
+"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+TOTAL=$((PASSES + FAILURES))
+echo "catalyst-stack: $PASSES/$TOTAL passed, $FAILURES failed"
+exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/install-cli.test.sh
+++ b/plugins/dev/scripts/__tests__/install-cli.test.sh
@@ -20,7 +20,7 @@ setup_source() {
   mkdir -p "$src"
   for f in catalyst-comms catalyst-events catalyst-execution-core catalyst-otel-forward \
            catalyst-session.sh catalyst-state.sh catalyst-statusline.sh catalyst-db.sh \
-           catalyst-monitor.sh catalyst-thoughts.sh catalyst-claude.sh; do
+           catalyst-monitor.sh catalyst-thoughts.sh catalyst-claude.sh catalyst-stack; do
     echo '#!/usr/bin/env bash' > "$src/$f"
     echo "echo stub-$f" >> "$src/$f"
     chmod +x "$src/$f"
@@ -105,7 +105,7 @@ run "install creates bin dir" bash -c "
 
 for cli in catalyst-comms catalyst-events catalyst-execution-core catalyst-otel-forward \
            catalyst-session catalyst-state catalyst-statusline catalyst-db \
-           catalyst-monitor catalyst-thoughts catalyst-claude; do
+           catalyst-monitor catalyst-thoughts catalyst-claude catalyst-stack; do
   run "installs symlink: $cli" bash -c "
     [[ -L '$BIN1/$cli' ]]
   "
@@ -131,9 +131,9 @@ run "second run does not error" bash -c "
   CATALYST_CLI_SOURCE='$SRC1' CATALYST_CLI_BIN_DIR='$BIN1' $INSTALL_CLI --force >/dev/null 2>&1
 "
 
-run "second run leaves 11 symlinks" bash -c "
+run "second run leaves 12 symlinks" bash -c "
   count=\$(find '$BIN1' -maxdepth 1 -type l | wc -l | tr -d ' ')
-  [[ \"\$count\" = '11' ]]
+  [[ \"\$count\" = '12' ]]
 "
 
 # ── 7. re-point on source move — symlinks point at new location ────────────

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# catalyst-stack — bring the catalyst stack up (or down) on this host.
+#
+# Order on start: mitmproxy → broker → monitor → execution-core
+#               (monitor → broker → exec-core is the dependency order;
+#                mitmproxy is independent + first so the proxy env vars
+#                set below have somewhere to forward to)
+# Order on stop: reverse.
+#
+# Idempotent. If a service is already up, it is logged and left alone.
+#
+# Usage:
+#   catalyst-stack start [--proxy] [--hotpatch] [--yes]
+#   catalyst-stack stop
+#   catalyst-stack restart [--proxy] [--hotpatch] [--yes]
+#   catalyst-stack status
+#
+# --proxy:
+#   Opt-in to mitmproxy and set HTTPS_PROXY / NODE_USE_ENV_PROXY /
+#   NODE_EXTRA_CA_CERTS for the daemon. Installs mitmproxy via brew if absent.
+#   You only need this when you want Linear-traffic capture at
+#   ~/catalyst/linear-proxy.jsonl.
+#
+# --no-proxy:
+#   Accepted for backward compatibility; a no-op (proxy is already off by default).
+#
+# --hotpatch (start/restart only):
+#   ff-pull main, rsync plugins/dev/ into the resolved plugin-cache version dir,
+#   then start/restart. Use 'restart --hotpatch' after merging main to apply
+#   updates without a full reinstall.
+#
+# --yes:
+#   Non-interactive — auto-approve brew install of mitmproxy under --proxy.
+
+set -uo pipefail
+
+# CTL-390: --version handling (early, before any arg parsing).
+case "${1:-}" in
+  --version|-V)
+    _CV_SRC="${BASH_SOURCE[0]}"
+    while [[ -L "$_CV_SRC" ]]; do
+      _CV_D="$(cd -P "$(dirname "$_CV_SRC")" && pwd)" && _CV_SRC="$(readlink "$_CV_SRC")"
+      [[ "$_CV_SRC" != /* ]] && _CV_SRC="$_CV_D/$_CV_SRC"
+    done
+    _CV_DIR="$(cd -P "$(dirname "$_CV_SRC")" && pwd)"
+    [[ -f "${_CV_DIR}/lib/catalyst-version.sh" ]] && . "${_CV_DIR}/lib/catalyst-version.sh" \
+      && catalyst_print_version "catalyst-stack" "${BASH_SOURCE[0]}" && exit 0
+    echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
+    exit 1
+    ;;
+esac
+
+# ─── SCRIPT_DIR (symlink-walking) ────────────────────────────────────────────
+_SRC="${BASH_SOURCE[0]}"
+while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
+SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
+unset _SRC
+
+# ─── Proxy env (used only under --proxy) ─────────────────────────────────────
+PROXY_HOST="http://127.0.0.1:8080"
+MITM_CA="${HOME}/.mitmproxy/mitmproxy-ca-cert.pem"
+MITM_ADDON="${HOME}/catalyst/mitm_linear_addon.py"
+MITM_LOG="${HOME}/catalyst/mitm.log"
+
+# ─── Helpers ────────────────────────────────────────────────────────────────
+log()  { printf '[catalyst-stack] %s\n' "$*"; }
+warn() { printf '[catalyst-stack] WARN: %s\n' "$*" >&2; }
+fail() { printf '[catalyst-stack] ERROR: %s\n' "$*" >&2; exit 1; }
+
+pid_alive() {
+  local pid="${1:-}"
+  [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
+}
+
+mitm_pid() { pgrep -f "mitmdump -s.*mitm_linear_addon" 2>/dev/null | head -1; }
+
+# ─── Service start/stop primitives ──────────────────────────────────────────
+ensure_proxy_deps() {
+  if ! command -v mitmdump >/dev/null 2>&1; then
+    if [[ "${ASSUME_YES:-no}" == "yes" ]]; then
+      brew install mitmproxy || return 1
+    else
+      read -r -p "mitmproxy not found. Install via 'brew install mitmproxy'? [y/N] " ans
+      [[ "$ans" =~ ^[Yy]$ ]] || { warn "mitmproxy required for --proxy"; return 1; }
+      command -v brew >/dev/null 2>&1 || { warn "brew not found"; return 1; }
+      brew install mitmproxy || return 1
+    fi
+  fi
+  if [[ ! -f "$MITM_CA" ]]; then
+    log "generating mitmproxy CA cert…"
+    ( nohup mitmdump --listen-port 8081 >/dev/null 2>&1 & sleep 2; kill %1 2>/dev/null ) || true
+    [[ -f "$MITM_CA" ]] || { warn "CA cert still missing at $MITM_CA"; return 1; }
+  fi
+  if [[ ! -f "$MITM_ADDON" ]]; then
+    local vendored="${SCRIPT_DIR}/mitm_linear_addon.py"
+    [[ -f "$vendored" ]] && { mkdir -p "$(dirname "$MITM_ADDON")"; cp "$vendored" "$MITM_ADDON"; } \
+      || { warn "vendored addon missing at $vendored"; return 1; }
+  fi
+}
+
+start_mitmproxy() {
+  local pid; pid="$(mitm_pid)"
+  if pid_alive "$pid"; then
+    log "mitmproxy already running (pid $pid)"
+    return 0
+  fi
+  if [[ ! -f "$MITM_ADDON" ]]; then
+    warn "mitmproxy addon missing at $MITM_ADDON — skipping"
+    return 1
+  fi
+  if [[ ! -f "$MITM_CA" ]]; then
+    warn "mitmproxy CA cert missing at $MITM_CA — run 'mitmproxy' once to generate it, then re-run"
+    return 1
+  fi
+  log "starting mitmproxy (addon: $MITM_ADDON, log: $MITM_LOG)"
+  nohup mitmdump -s "$MITM_ADDON" --listen-port 8080 >"$MITM_LOG" 2>&1 &
+  disown $! 2>/dev/null || true
+  sleep 2
+  pid="$(mitm_pid)"
+  if pid_alive "$pid"; then
+    log "  → mitmproxy started (pid $pid)"
+  else
+    warn "mitmproxy failed to start — see $MITM_LOG"
+    return 1
+  fi
+}
+
+stop_mitmproxy() {
+  local pid; pid="$(mitm_pid)"
+  if pid_alive "$pid"; then
+    log "stopping mitmproxy (pid $pid)"
+    kill "$pid" 2>/dev/null
+    sleep 1
+    pid_alive "$pid" && kill -9 "$pid" 2>/dev/null || true
+  else
+    log "mitmproxy not running"
+  fi
+}
+
+start_broker()  { catalyst-broker start 2>&1 | sed 's/^/  /'; }
+stop_broker()   { catalyst-broker stop  2>&1 | sed 's/^/  /'; }
+start_monitor() { catalyst-monitor start 2>&1 | sed 's/^/  /'; }
+stop_monitor()  { catalyst-monitor stop  2>&1 | sed 's/^/  /'; }
+
+start_daemon() {
+  local use_proxy="$1"
+  if catalyst-execution-core status 2>&1 | grep -q "^running"; then
+    log "execution-core already running ($(catalyst-execution-core status 2>&1 | head -1))"
+    return 0
+  fi
+  log "starting execution-core daemon (proxy=$use_proxy)"
+  if [[ "$use_proxy" == "yes" ]]; then
+    if [[ ! -f "$MITM_CA" ]]; then
+      warn "proxy requested but CA cert missing — daemon will fall back to no-proxy mode."
+      use_proxy="no"
+    fi
+  fi
+  if [[ "$use_proxy" == "yes" ]]; then
+    HTTPS_PROXY="$PROXY_HOST" \
+    NODE_USE_ENV_PROXY=1 \
+    NODE_EXTRA_CA_CERTS="$MITM_CA" \
+      catalyst-execution-core start 2>&1 | sed 's/^/  /'
+  else
+    catalyst-execution-core start 2>&1 | sed 's/^/  /'
+  fi
+}
+
+stop_daemon() { catalyst-execution-core stop 2>&1 | sed 's/^/  /'; }
+
+# ─── Hotpatch ────────────────────────────────────────────────────────────────
+_resolve_cache_dir() {
+  local cache="${HOME}/.claude/plugins/cache/catalyst/catalyst-dev"
+  ls -d "${cache}"/[0-9]*.*.*/ 2>/dev/null | sort -V | tail -1 | sed 's|/$||'
+}
+
+cmd_hotpatch() {
+  local repo="${CATALYST_REPO_DIR:-${HOME}/code-repos/github/coalesce-labs/catalyst}"
+  [[ -d "$repo/.git" ]] || fail "catalyst repo not found at $repo (set CATALYST_REPO_DIR)"
+  log "hotpatch: ff-pull main in $repo"
+  git -C "$repo" pull --ff-only origin main || fail "git pull --ff-only failed — resolve manually then retry"
+  local dest; dest="$(_resolve_cache_dir)"
+  [[ -n "$dest" ]] || fail "could not resolve plugin cache version dir under ${HOME}/.claude/plugins/cache/catalyst/catalyst-dev"
+  log "hotpatch: rsync plugins/dev/ → ${dest}/"
+  rsync -ac --exclude=node_modules --exclude=.orphaned_at \
+    "$repo/plugins/dev/" "${dest}/"
+}
+
+# ─── Top-level commands ─────────────────────────────────────────────────────
+cmd_start() {
+  local use_proxy="no"
+  local hotpatch="no"
+  ASSUME_YES="${ASSUME_YES:-no}"
+  for arg in "$@"; do
+    case "$arg" in
+      --proxy)    use_proxy="yes" ;;
+      --no-proxy) : ;;
+      --hotpatch) hotpatch="yes" ;;
+      --yes)      ASSUME_YES="yes" ;;
+      *) fail "unknown arg: $arg" ;;
+    esac
+  done
+
+  if [[ "$hotpatch" == "yes" ]]; then
+    if catalyst-execution-core status 2>&1 | grep -q "^running"; then
+      fail "stack is running — use 'catalyst-stack restart --hotpatch'"
+    fi
+    cmd_hotpatch
+  fi
+
+  if [[ "$use_proxy" == "yes" ]]; then
+    ensure_proxy_deps || fail "proxy preflight failed"
+    start_mitmproxy || warn "continuing without mitmproxy (Linear traffic won't be logged)"
+  fi
+  start_broker
+  start_monitor
+  start_daemon "$use_proxy"
+
+  log ""
+  log "stack up — current state:"
+  cmd_status
+}
+
+cmd_stop() {
+  stop_daemon
+  stop_monitor
+  stop_broker
+  stop_mitmproxy
+}
+
+cmd_restart() {
+  local hotpatch="no"
+  for a in "$@"; do [[ "$a" == "--hotpatch" ]] && hotpatch="yes"; done
+  cmd_stop
+  if [[ "$hotpatch" == "yes" ]]; then
+    cmd_hotpatch
+  fi
+  sleep 1
+  # Pass through all flags except --hotpatch (already applied above)
+  local start_args=()
+  for a in "$@"; do [[ "$a" != "--hotpatch" ]] && start_args+=("$a"); done
+  cmd_start "${start_args[@]}"
+}
+
+cmd_status() {
+  local mp; mp="$(mitm_pid)"
+  if pid_alive "$mp"; then echo "  mitmproxy        running  pid=$mp"; else echo "  mitmproxy        stopped"; fi
+  echo -n "  broker           "; catalyst-broker status 2>&1 | head -1
+  echo -n "  monitor          "; catalyst-monitor status 2>&1 | head -1
+  echo -n "  execution-core   "; catalyst-execution-core status 2>&1 | head -1
+}
+
+# ─── Dispatch ───────────────────────────────────────────────────────────────
+case "${1:-}" in
+  start)   shift; cmd_start "$@" ;;
+  stop)    cmd_stop ;;
+  restart) shift; cmd_restart "$@" ;;
+  status|"") cmd_status ;;
+  -h|--help)
+    sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+    ;;
+  *) fail "unknown command: $1 (try: start | stop | restart | status)" ;;
+esac

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -2,7 +2,7 @@
 # catalyst-stack — bring the catalyst stack up (or down) on this host.
 #
 # Order on start: mitmproxy → broker → monitor → execution-core
-#               (monitor → broker → exec-core is the dependency order;
+#               (broker → monitor → exec-core is the dependency order;
 #                mitmproxy is independent + first so the proxy env vars
 #                set below have somewhere to forward to)
 # Order on stop: reverse.

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -66,6 +66,7 @@ OPT_TOOLS=(
     "bun:Bun runtime"
     "direnv:direnv"
     "smee:smee-client (webhook tunnel)"
+    "mitmproxy:mitmproxy (optional — only needed for catalyst-stack --proxy)"
 )
 
 for spec in "${OPT_TOOLS[@]}"; do
@@ -82,7 +83,7 @@ done
 header "Catalyst CLI Install"
 
 CLI_BIN_DIR="${CATALYST_CLI_BIN_DIR:-$HOME/.catalyst/bin}"
-CLI_NAMES=(catalyst-broker catalyst-comms catalyst-events catalyst-execution-core catalyst-filter catalyst-otel-forward catalyst-transitions catalyst-session catalyst-state catalyst-statusline catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude)
+CLI_NAMES=(catalyst-broker catalyst-comms catalyst-events catalyst-execution-core catalyst-filter catalyst-otel-forward catalyst-transitions catalyst-session catalyst-state catalyst-statusline catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude catalyst-stack)
 
 if [[ -d "$CLI_BIN_DIR" ]]; then
     pass "Bin dir exists: $CLI_BIN_DIR"

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -51,6 +51,7 @@ CLI_ENTRIES=(
   "workflow-context.sh:workflow-context"
   "catalyst-hud:catalyst-hud"
   "catalyst-hud-classic.sh:catalyst-hud-classic"
+  "catalyst-stack:catalyst-stack"
   "../hooks/emit-lifecycle-event.sh:emit-lifecycle-event"
 )
 

--- a/plugins/dev/scripts/mitm_linear_addon.py
+++ b/plugins/dev/scripts/mitm_linear_addon.py
@@ -1,0 +1,132 @@
+"""mitmproxy addon: log every Linear GraphQL call with operation, rate-limit
+headers, AND caller attribution (PID → parent command → CATALYST_* env).
+
+Run:  mitmdump -s <path-to-this-file> --listen-port 8080
+Log:  ~/catalyst/linear-proxy.jsonl  (one JSON object per Linear response)
+      Override via MITM_LOG env var.
+
+Caller attribution: the immediate client is always a short-lived `node`
+(linearis), so we record its PARENT command (the daemon / a phase-agent claude /
+orch-monitor / broker / interactive shell) plus any CATALYST_TICKET / phase /
+orchestrator env it inherited. lsof runs during the `request` hook while the
+node process is still blocked on the response, so the socket is live.
+"""
+import json
+import os
+import re
+import subprocess
+import time
+from mitmproxy import http
+
+# CTL-696: portable LOG path so the vendored copy works on any host.
+LOG = os.environ.get(
+    "MITM_LOG",
+    os.path.join(os.path.expanduser("~"), "catalyst", "linear-proxy.jsonl"),
+)
+_OP_RE = re.compile(r"\b(query|mutation|subscription)\s+(\w+)")
+_ENV_KEYS = (("CATALYST_TICKET", "ticket"), ("CATALYST_PHASE", "phase"),
+             ("ORCHESTRATOR_ID", "orch"), ("CATALYST_BG_JOB_ID", "bg_job"))
+
+
+def _run(args):
+    try:
+        return subprocess.run(args, capture_output=True, text=True, timeout=2).stdout
+    except Exception:
+        return ""
+
+
+def _caller(port: int) -> dict:
+    info = {"pid": None, "cmd": None, "parent": None, "ticket": None,
+            "phase": None, "orch": None, "bg_job": None}
+    # lsof -iTCP:<port> matches BOTH ends of the localhost socket (the node
+    # client AND mitmdump). -Fpcn streams p<pid>/c<cmd>/n<name> blocks; pick the
+    # process whose LOCAL port is the ephemeral one — its name reads
+    # "...:<port>->...:8080" (ephemeral before the arrow), vs mitmdump's
+    # "...:8080->...:<port>".
+    pid = cmd = None
+    cur_pid = cur_cmd = None
+    for line in _run(["lsof", "-nP", f"-iTCP:{port}", "-sTCP:ESTABLISHED", "-Fpcn"]).splitlines():
+        tag, val = line[:1], line[1:].strip()
+        if tag == "p":
+            cur_pid = val
+        elif tag == "c":
+            cur_cmd = val
+        elif tag == "n" and f":{port}->" in val:
+            pid, cmd = cur_pid, cur_cmd
+            break
+    if not pid:
+        return info
+    info["pid"] = pid
+    if cmd:
+        info["cmd"] = cmd.rsplit("/", 1)[-1]
+    row = _run(["ps", "-o", "ppid=,comm=", "-p", pid]).strip()
+    if row:
+        parts = row.split(None, 1)
+        ppid = parts[0]
+        info["cmd"] = (parts[1] if len(parts) > 1 else "").rsplit("/", 1)[-1]
+        info["parent"] = _run(["ps", "-o", "command=", "-p", ppid]).strip()[:90]
+    # macOS `ps -E` appends the environment to the command column
+    env = _run(["ps", "-Eww", "-o", "command=", "-p", pid])
+    for key, dst in _ENV_KEYS:
+        m = re.search(key + r"=(\S+)", env)
+        if m:
+            info[dst] = m.group(1)
+    return info
+
+
+def request(flow: http.HTTPFlow) -> None:
+    if "api.linear.app" not in flow.request.pretty_host:
+        return
+    try:
+        flow.metadata["caller"] = _caller(flow.client_conn.peername[1])
+    except Exception:
+        pass
+
+
+def _op(flow: http.HTTPFlow) -> str:
+    try:
+        body = json.loads(flow.request.get_text() or "{}")
+        items = body if isinstance(body, list) else [body]
+        ops = []
+        for b in items:
+            name = b.get("operationName")
+            if not name:
+                m = _OP_RE.search((b.get("query") or "").lstrip())
+                name = f"{m.group(1)} {m.group(2)}" if m else "?"
+            ops.append(name)
+        return ",".join(ops) or "?"
+    except Exception:
+        return "?"
+
+
+def response(flow: http.HTTPFlow) -> None:
+    if "api.linear.app" not in flow.request.pretty_host:
+        return
+    h = flow.response.headers
+    c = flow.metadata.get("caller") or {}
+    rec = {
+        "ts": time.strftime("%H:%M:%S"),
+        "op": _op(flow),
+        "status": flow.response.status_code,
+        "rl_remaining": h.get("X-RateLimit-Requests-Remaining"),
+        "rl_limit": h.get("X-RateLimit-Requests-Limit"),
+        "rl_reset": h.get("X-RateLimit-Requests-Reset"),
+        "complexity": h.get("X-Complexity"),
+        "cplx_remaining": h.get("X-RateLimit-Complexity-Remaining"),
+        "cplx_limit": h.get("X-RateLimit-Complexity-Limit"),
+        "cplx_reset": h.get("X-RateLimit-Complexity-Reset"),
+        "caller": c.get("cmd"),
+        "parent": c.get("parent"),
+        "pid": c.get("pid"),
+        "ticket": c.get("ticket"),
+        "phase": c.get("phase"),
+        "orch": c.get("orch"),
+        "bg_job": c.get("bg_job"),
+    }
+    with open(LOG, "a") as fh:
+        fh.write(json.dumps(rec) + "\n")
+    print(
+        f"[linear] {rec['ts']} {rec['op']:<26} -> {rec['status']} "
+        f"rem={rec['rl_remaining']} | {rec['caller']} <- {(rec['parent'] or '')[:50]} "
+        f"ticket={rec['ticket']} phase={rec['phase']}"
+    )

--- a/website/src/content/docs/getting-started/index.md
+++ b/website/src/content/docs/getting-started/index.md
@@ -53,7 +53,7 @@ catalyst-events help
 
 ## 4. Start the stack
 
-Bring the four Catalyst services up in dependency order (broker → monitor → execution-core):
+Bring the three core Catalyst services up in dependency order (broker → monitor → execution-core), plus the opt-in mitmproxy capture service if you pass `--proxy`:
 
 ```bash
 catalyst-stack start

--- a/website/src/content/docs/getting-started/index.md
+++ b/website/src/content/docs/getting-started/index.md
@@ -51,7 +51,17 @@ which catalyst-events
 catalyst-events help
 ```
 
-## 4. Add Catalyst to your project
+## 4. Start the stack
+
+Bring the four Catalyst services up in dependency order (broker → monitor → execution-core):
+
+```bash
+catalyst-stack start
+```
+
+Run this once after each reboot or after pulling new code. See [catalyst-stack reference](/reference/catalyst-stack/) for flags including `--hotpatch` (apply an update without reinstalling) and `--proxy` (opt-in Linear traffic capture via mitmproxy).
+
+## 5. Add Catalyst to your project
 
 Copy the Catalyst snippet into your project's `CLAUDE.md` so Claude Code knows the available workflows:
 
@@ -59,7 +69,7 @@ Copy the Catalyst snippet into your project's `CLAUDE.md` so Claude Code knows t
 cat plugins/dev/templates/CLAUDE_SNIPPET.md >> .claude/CLAUDE.md
 ```
 
-## 5. Try it
+## 6. Try it
 
 Start a Claude Code session and run:
 

--- a/website/src/content/docs/getting-started/reboot-and-updates.md
+++ b/website/src/content/docs/getting-started/reboot-and-updates.md
@@ -1,0 +1,63 @@
+---
+title: Post-reboot and updates
+description: How to bring the Catalyst stack back up after a reboot and apply updates after merging.
+sidebar:
+  order: 5
+---
+
+## After a reboot
+
+The Catalyst services (broker, monitor, execution-core) do not auto-start. Run once after each reboot:
+
+```bash
+catalyst-stack start
+```
+
+That's it. The command is idempotent — already-running services are skipped. Check what's running at any time with:
+
+```bash
+catalyst-stack status
+```
+
+## After merging or pulling new code
+
+The fastest way to apply an update to the live plugin cache and restart:
+
+```bash
+catalyst-stack restart --hotpatch
+```
+
+This does three things in sequence:
+
+1. `git pull --ff-only origin main` in your catalyst repo checkout.
+2. `rsync -ac --exclude=node_modules` from `plugins/dev/` into the resolved plugin-cache version directory.
+3. Stops and restarts the stack.
+
+If the pull fails (non-fast-forward), the command aborts before touching the cache. Resolve the conflict manually, then retry.
+
+The default repo path is `~/code-repos/github/coalesce-labs/catalyst`. Override with `CATALYST_REPO_DIR`:
+
+```bash
+CATALYST_REPO_DIR=/path/to/catalyst catalyst-stack restart --hotpatch
+```
+
+## Linear traffic capture (optional)
+
+To log every Linear API call with rate-limit headers and caller attribution, opt in to the mitmproxy proxy:
+
+```bash
+catalyst-stack start --proxy
+```
+
+On first use, this offers to install mitmproxy via `brew install mitmproxy` if absent, generates the CA cert, and copies the vendored addon to `~/catalyst/mitm_linear_addon.py`. Traffic is written to `~/catalyst/linear-proxy.jsonl`.
+
+The proxy is **off by default**. The execution-core daemon runs correctly without it.
+
+## Boot-resume guarantee
+
+The execution-core daemon persists its work queue to disk. If you stop the stack in the middle of an autonomous run, the orchestrator resumes where it left off when you `catalyst-stack start` again.
+
+## See also
+
+- [catalyst-stack reference](/reference/catalyst-stack/) — all flags and environment variables
+- [Install Catalyst](/getting-started/) — initial setup

--- a/website/src/content/docs/reference/catalyst-stack.md
+++ b/website/src/content/docs/reference/catalyst-stack.md
@@ -1,0 +1,105 @@
+---
+title: catalyst-stack
+description: Reference for the catalyst-stack CLI — start, stop, restart, and hotpatch the four Catalyst services.
+sidebar:
+  order: 10
+---
+
+`catalyst-stack` is the canonical command for bringing the Catalyst service stack up and down. It starts the four services in dependency order and is idempotent — already-running services are left alone.
+
+## Dependency order
+
+| Start order | Stop order |
+|-------------|------------|
+| mitmproxy (opt-in, `--proxy` only) | execution-core |
+| broker | monitor |
+| monitor | broker |
+| execution-core | mitmproxy |
+
+## Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `start` | Start all services (idempotent). |
+| `stop` | Stop all services in reverse order. |
+| `restart` | Stop then start. Accepts the same flags as `start`. |
+| `status` | Print running/stopped state for each service. |
+
+## Flags
+
+### `--proxy`
+
+Opt-in to Linear traffic capture via mitmproxy. When passed, `catalyst-stack` will:
+
+1. Verify `mitmdump` is installed (offer `brew install mitmproxy` if absent).
+2. Generate the mitmproxy CA cert at `~/.mitmproxy/mitmproxy-ca-cert.pem` if missing.
+3. Copy the vendored addon to `~/catalyst/mitm_linear_addon.py` if absent.
+4. Start mitmproxy, then set `HTTPS_PROXY` / `NODE_USE_ENV_PROXY` / `NODE_EXTRA_CA_CERTS` for the execution-core daemon.
+
+Traffic is logged to `~/catalyst/linear-proxy.jsonl` (one JSON record per Linear API response, including rate-limit headers and caller attribution).
+
+Proxy is **off by default**. The daemon runs correctly without it — you only need `--proxy` when you want Linear traffic logging.
+
+### `--no-proxy`
+
+Accepted for backward compatibility; no-op (proxy is already off by default).
+
+### `--hotpatch`
+
+Apply a post-merge update in one command: ff-pull `main`, rsync `plugins/dev/` into the resolved plugin-cache version directory, then start/restart.
+
+```bash
+# After merging or pulling new code:
+catalyst-stack restart --hotpatch
+```
+
+Behavior:
+- Requires `CATALYST_REPO_DIR` to point at the catalyst repo checkout, or defaults to `~/code-repos/github/coalesce-labs/catalyst`.
+- Uses `git pull --ff-only origin main` — aborts on non-fast-forward merges (resolve manually, then retry).
+- Rsyncs with `-ac --exclude=node_modules --exclude=.orphaned_at`. **Never uses `--delete`** — that would wipe `node_modules`.
+- `start --hotpatch` refuses if the stack is already running. Use `restart --hotpatch` instead.
+
+### `--yes`
+
+Non-interactive mode under `--proxy`: auto-approves `brew install mitmproxy` instead of prompting.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CATALYST_REPO_DIR` | `~/code-repos/github/coalesce-labs/catalyst` | Repo root used by `--hotpatch`. |
+| `MITM_LOG` | `~/catalyst/mitm.log` | mitmproxy process log. |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success. |
+| `1` | Error (unknown argument, proxy preflight failed, non-ff pull, etc.). |
+
+## Examples
+
+```bash
+# Start the stack (proxy off by default)
+catalyst-stack start
+
+# Start with Linear traffic logging
+catalyst-stack start --proxy
+
+# Check what's running
+catalyst-stack status
+
+# Stop everything
+catalyst-stack stop
+
+# Restart after pulling new code
+catalyst-stack restart --hotpatch
+
+# Restart with proxy enabled
+catalyst-stack restart --proxy
+```
+
+## See also
+
+- [Post-reboot and updates](/getting-started/reboot-and-updates/) — day-to-day workflow for booting and updating
+- [Install Catalyst](/getting-started/) — initial setup including `catalyst-stack start` as step 4

--- a/website/src/content/docs/reference/catalyst-stack.md
+++ b/website/src/content/docs/reference/catalyst-stack.md
@@ -68,7 +68,7 @@ Non-interactive mode under `--proxy`: auto-approves `brew install mitmproxy` ins
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `CATALYST_REPO_DIR` | `~/code-repos/github/coalesce-labs/catalyst` | Repo root used by `--hotpatch`. |
-| `MITM_LOG` | `~/catalyst/mitm.log` | mitmproxy process log. |
+| `MITM_LOG` | `~/catalyst/linear-proxy.jsonl` | JSONL capture path read by the mitmproxy addon (`mitm_linear_addon.py`) — not the process log. The mitmdump process log is fixed at `~/catalyst/mitm.log` and cannot be overridden. |
 
 ## Exit codes
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-07T07:25:00Z -->
<!-- Last updated: 2026-06-07T07:25:00Z -->
<!-- PR: #1436 -->
<!-- Previous commits: 501db8d4,a79a4a68,e7dd1d99,8f44e74e -->

## Summary

Vendors the `catalyst-stack` script into the repo and wires it into the install/setup toolchain, so a fresh-install host gets `catalyst-stack` on PATH automatically via `install-cli.sh`. Adds `--hotpatch` (ff-pull + rsync + restart in one command) and flips the mitmproxy default to opt-in (`--proxy` flag). Also vendors `mitm_linear_addon.py` with portability fixes, updates docs across four pages, and adds a full test suite.

## Changes Made

### Scripts

- **`plugins/dev/scripts/catalyst-stack`** — vendored from `~/.catalyst/bin/catalyst-stack`. Key changes from local copy:
  - Proxy is OFF by default; `--proxy` opts in, `--no-proxy` is a back-compat no-op
  - `--proxy` checks for `mitmproxy` install, offers `brew install mitmproxy` if missing (with `--yes` for non-interactive hosts)
  - `--proxy` verifies CA cert and Linear addon are in place, sets them up if not
  - `--hotpatch` flag on `start` and `restart`: ff-pulls origin/main, rsyncs plugins/dev into the live cache (never `--delete`), then starts/restarts
  - `start --hotpatch` on a live stack warns and exits non-zero; `restart --hotpatch` does stop → hotpatch → start
- **`plugins/dev/scripts/mitm_linear_addon.py`** — vendored from `~/catalyst/mitm_linear_addon.py`. Portability fix: log path resolves via `os.environ` / `os.path.expanduser` instead of the hardcoded `/Users/ryan/catalyst/linear-proxy.jsonl` path.
- **`plugins/dev/scripts/install-cli.sh`** — extended `CLI_ENTRIES` with `catalyst-stack:catalyst-stack`; deploys `mitm_linear_addon.py` to `~/catalyst/` if not present
- **`plugins/dev/scripts/check-setup.sh`** — extended `CLI_NAMES` with `catalyst-stack`; warns (not fails) if mitmproxy is missing

### Documentation

- **`website/src/content/docs/getting-started/index.md`** — added `catalyst-stack start` as the post-install step; removed the four-line manual service-start recipe from the primary path
- **`website/src/content/docs/getting-started/reboot-and-updates.md`** — new page covering reboot recovery, post-merge hotpatch, proxy opt-in flow with install-on-demand, and the boot-resume guarantee
- **`website/src/content/docs/reference/catalyst-stack.md`** — new reference page covering all subcommands, flags, exit codes, and the dependency start order
- **`README.md`** — added `catalyst-stack start` to the quickstart and `catalyst-stack restart --hotpatch` to the plugin-update section

### Tests

- **`plugins/dev/scripts/__tests__/catalyst-stack.test.sh`** — new test suite: default-no-proxy never invokes mitmdump, `--no-proxy` accepted as no-op, `--proxy` missing mitmproxy → decline → non-zero exit, `--hotpatch` ff-pull happy path, `--hotpatch` non-ff abort before rsync, rsync never uses `--delete`, rsync excludes `node_modules`
- **`plugins/dev/scripts/__tests__/install-cli.test.sh`** — extended to assert `catalyst-stack` wrapper is generated

## How to Verify It

- [x] `plugins/dev/scripts/catalyst-stack` exists and is executable
- [x] `plugins/dev/scripts/mitm_linear_addon.py` has no hardcoded `/Users/ryan` path — uses `os.environ`/`expanduser`
- [x] `install-cli.sh` allowlist includes `catalyst-stack:catalyst-stack`
- [x] `check-setup.sh` `CLI_NAMES` includes `catalyst-stack`
- [ ] Run `bash plugins/dev/scripts/__tests__/catalyst-stack.test.sh` — all cases pass
- [ ] Run `bash plugins/dev/scripts/__tests__/install-cli.test.sh` — `catalyst-stack` wrapper generation covered
- [ ] After `install-cli.sh` on a clean host: `which catalyst-stack` resolves; `catalyst-stack status` reports stopped (not command-not-found)
- [ ] `catalyst-stack start` brings up broker → monitor → execution-core with no proxy (no mitmproxy dep check)
- [ ] `catalyst-stack start --proxy` on a host without mitmproxy: prompts to install, decline → exit non-zero
- [ ] `catalyst-stack restart --hotpatch` ff-pulls and rsyncs into live cache without `--delete`

## Related Issues/PRs

- Fixes https://linear.app/rozich/issue/CTL-696
