### PR TITLE
fix(dev): catalyst-agent skips unlabeled usage samples + normalizes hostname (CTL-812)

### DIFF
--- a/plugins/dev/scripts/catalyst-agent/emit.mjs
+++ b/plugins/dev/scripts/catalyst-agent/emit.mjs
@@ -24,6 +24,16 @@ import { mkdirSync, appendFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { randomBytes } from "node:crypto";
 import { hostname } from "node:os";
+
+// shortHostname — os.hostname() with the macOS-appended ".local" suffix
+// stripped, matching the hostname Claude Code's native OTel emits
+// ("Ryans-MacBook-Pro-2", not "Ryans-MacBook-Pro-2.local") — so the
+// dashboard's hostname labels, template variable, and filters see exactly ONE
+// identity per machine (CTL-812 multi-host finding).
+export function shortHostname() {
+  return hostname().replace(/\.local$/, "");
+}
+
 import { getEventLogPath, log } from "./config.mjs";
 
 /**
@@ -70,7 +80,7 @@ export function buildAgentEnvelope(name, { entity, label, attrs = {}, payload = 
     resource: {
       "service.name": "catalyst.agent",
       "service.namespace": "catalyst",
-      hostname: hostname(),
+      hostname: shortHostname(),
     },
     body: { payload },
     attributes,

--- a/plugins/dev/scripts/catalyst-agent/emit.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/emit.test.mjs
@@ -41,7 +41,7 @@ describe("buildAgentEnvelope — resource + severity (contract)", () => {
     const env = buildAgentEnvelope("host.metrics.sampled", hostSpec());
     expect(env.resource["service.name"]).toBe("catalyst.agent");
     expect(env.resource["service.namespace"]).toBe("catalyst");
-    expect(env.resource.hostname).toBe(hostname());
+    expect(env.resource.hostname).toBe(hostname().replace(/\.local$/, ""));
   });
 
   test("severity is INFO / 9", () => {
@@ -419,5 +419,22 @@ describe("drainPending", () => {
   test("an empty / non-array argument is a no-op (never throws)", async () => {
     await expect(drainPending([])).resolves.toBeUndefined();
     await expect(drainPending(undefined)).resolves.toBeUndefined();
+  });
+});
+
+// ─── shortHostname (CTL-812 multi-host) ──────────────────────────────────────
+import { shortHostname } from "./emit.mjs";
+import { hostname as osHostname } from "node:os";
+
+describe("shortHostname", () => {
+  test("never carries the macOS .local suffix (matches Claude Code's native hostname)", () => {
+    expect(shortHostname().endsWith(".local")).toBe(false);
+    expect(shortHostname()).toBe(osHostname().replace(/\.local$/, ""));
+  });
+
+  test("envelope resource hostname uses the normalized form", () => {
+    const env = buildAgentEnvelope("host.metrics.sampled", { entity: "host", label: "x", attrs: {}, payload: {} });
+    expect(env.resource.hostname).toBe(shortHostname());
+    expect(env.resource.hostname.endsWith(".local")).toBe(false);
   });
 });

--- a/plugins/dev/scripts/catalyst-agent/host.mjs
+++ b/plugins/dev/scripts/catalyst-agent/host.mjs
@@ -24,7 +24,8 @@
 
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { cpus, loadavg, totalmem, freemem, hostname } from "node:os";
+import { cpus, loadavg, totalmem, freemem } from "node:os";
+import { shortHostname } from "./emit.mjs";
 import { buildAgentEnvelope, emitEnvelope } from "./emit.mjs";
 import { readAgentConfig, log } from "./config.mjs";
 
@@ -242,7 +243,7 @@ function defaultReadLoad() {
  * @param {Function} [opts.readLoad] → number (load1) | null
  * @param {Function} [opts.emit]     (name, spec, opts) → emit the envelope
  * @param {Function} [opts.now]      injectable ISO-timestamp fn (passed to emit)
- * @param {string}   [opts.label]    event.label override (defaults to hostname())
+ * @param {string}   [opts.label]    event.label override (defaults to shortHostname())
  * @returns {Promise<object>} the emitted envelope (also useful for assertions)
  */
 export async function sampleHost({
@@ -252,7 +253,7 @@ export async function sampleHost({
   readLoad = defaultReadLoad,
   emit = defaultEmit,
   now,
-  label = hostname(),
+  label = shortHostname(),
 } = {}) {
   // Read every probe defensively — one throwing probe must not sink the others
   // or the whole event. `await` is a no-op on a sync return value.

--- a/plugins/dev/scripts/catalyst-agent/host.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/host.test.mjs
@@ -50,7 +50,7 @@ describe("sampleHost — emits one host.metrics.sampled per contract", () => {
     expect(calls.length).toBe(1);
     expect(calls[0].name).toBe(HOST_EVENT_SAMPLED);
     expect(calls[0].spec.entity).toBe("host");
-    expect(calls[0].spec.label).toBe(hostname());
+    expect(calls[0].spec.label).toBe(hostname().replace(/\.local$/, ""));
   });
 
   test("a custom label overrides the hostname default", async () => {

--- a/plugins/dev/scripts/catalyst-agent/processes.mjs
+++ b/plugins/dev/scripts/catalyst-agent/processes.mjs
@@ -37,7 +37,8 @@
 import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
 import { join, basename } from "node:path";
-import { homedir, hostname } from "node:os";
+import { homedir } from "node:os";
+import { shortHostname } from "./emit.mjs";
 import { buildAgentEnvelope, emitEnvelope, drainPending } from "./emit.mjs";
 import { readAgentConfig, log } from "./config.mjs";
 
@@ -262,7 +263,7 @@ export async function sampleProcesses({
     workerMap = new Map();
   }
 
-  const host = hostname();
+  const host = shortHostname();
   const top = rankTopN(rows, topN);
   const envelopes = [];
   // OTLP POST promises returned by emit, drained before we resolve so the

--- a/plugins/dev/scripts/catalyst-agent/processes.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/processes.test.mjs
@@ -390,7 +390,7 @@ describe("sampleProcesses", () => {
       expect(e.attributes["event.name"]).toBe(PROCESS_EVENT_SAMPLED);
       expect(e.attributes["event.entity"]).toBe("host");
       expect(e.attributes["event.action"]).toBe("process.sampled");
-      expect(e.attributes["event.label"]).toBe(hostname());
+      expect(e.attributes["event.label"]).toBe(hostname().replace(/\.local$/, ""));
       expect(e.resource["service.name"]).toBe("catalyst.agent");
       expect(e.ts).toBe(FIXED_NOW);
     }

--- a/plugins/dev/scripts/catalyst-agent/usage.mjs
+++ b/plugins/dev/scripts/catalyst-agent/usage.mjs
@@ -115,12 +115,30 @@ export async function defaultFetchUsage(token, { userAgent, fetchImpl = fetch } 
   }
 }
 
+// parseOtelEmail — pull user.email from the comma-separated
+// OTEL_RESOURCE_ATTRIBUTES key=value list (the CTL-787 poller's fallback).
+// Only meaningful for the ACTIVE account — the ambient identity belongs to
+// whoever is logged in, never to a swapped-out backup. Returns null when absent.
+export function parseOtelEmail(env = process.env) {
+  const attrs = env.OTEL_RESOURCE_ATTRIBUTES;
+  if (!attrs) return null;
+  for (const pair of attrs.split(",")) {
+    const idx = pair.indexOf("=");
+    if (idx === -1) continue;
+    if (pair.slice(0, idx).trim() === "user.email") {
+      const value = pair.slice(idx + 1).trim();
+      return value || null;
+    }
+  }
+  return null;
+}
+
 // defaultResolveEmail — GET /api/oauth/profile to resolve .account.email plus
 // .organization.rate_limit_tier / .organization.subscription_status. Returns
 // { email, rateLimitTier, subscriptionType } (any field may be null) or null
 // when no email could be resolved. NEVER throws. Mirrors the execution-core
-// poller, minus the OTEL_RESOURCE_ATTRIBUTES env fallback (the standalone
-// multi-account agent has no single ambient email to fall back to).
+// poller; the OTEL_RESOURCE_ATTRIBUTES env fallback is applied by tickUsage
+// for the active account only.
 export async function defaultResolveEmail(token, { userAgent, fetchImpl = fetch } = {}) {
   try {
     const res = await fetchImpl(PROFILE_ENDPOINT, {
@@ -236,6 +254,23 @@ export async function tickUsage({
           rateLimitTier: resolved.rateLimitTier ?? null,
           subscriptionType: resolved.subscriptionType ?? null,
         };
+      }
+
+      // No email ⇒ no emit (CTL-812 live finding): the profile call can 429
+      // under poller contention, and an account.ratelimit.sampled without
+      // account.email renders as a GHOST ROW in the per-account scoreboard —
+      // an account-keyed sample is unusable without its key. The active
+      // account first falls back to OTEL_RESOURCE_ATTRIBUTES user.email (the
+      // CTL-787 poller's ambient identity; backups have no ambient identity).
+      // Skipping BEFORE fetchUsage also spares the rate-limited endpoint a
+      // call we could not attribute anyway; the next run re-resolves.
+      if (!email && account?.source === "active") email = parseOtelEmail();
+      if (!email) {
+        log.warn(
+          { source: account?.source },
+          "usage: account email unresolvable; skipping account this run",
+        );
+        continue;
       }
 
       const { status, body } = await fetchUsage(token, { userAgent });

--- a/plugins/dev/scripts/catalyst-agent/usage.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/usage.test.mjs
@@ -286,12 +286,14 @@ describe("tickUsage — email resolution", () => {
     expect(resolveCalls.map((c) => c.token).sort()).toEqual([TOKEN_A, TOKEN_B].sort());
   });
 
-  test("a null-resolving profile still emits with email null + label 'unknown'", async () => {
+  test("a null-resolving profile skips the account — no unlabeled emit (CTL-812 ghost-row fix)", async () => {
+    // Pre-fix this emitted with email=null / label "unknown", which rendered
+    // as a blank Account row in the per-account scoreboard. Account-keyed
+    // samples are unusable without their key, so the account is skipped.
+    delete process.env.OTEL_RESOURCE_ATTRIBUTES;
     const { promise, emitted } = harness({ resolveEmail: async () => null });
     await promise;
-    expect(emitted.length).toBe(1);
-    expect(emitted[0].spec.attrs["account.email"]).toBe(null);
-    expect(emitted[0].spec.label).toBe("unknown");
+    expect(emitted.length).toBe(0);
   });
 
   test("an account with no token is skipped (no resolve, no fetch, no emit)", async () => {
@@ -474,5 +476,75 @@ describe("tickUsage — secrets hygiene", () => {
     expect(all).not.toContain(SECRET);
     // Sanity: the branches DID log (so the assertion above is meaningful).
     expect(all).toContain("usage:");
+  });
+});
+
+// ─── email unresolvable ⇒ skip (CTL-812 ghost-row fix) ───────────────────────
+import { parseOtelEmail } from "./usage.mjs";
+
+describe("tickUsage — unresolvable email skips the account", () => {
+  const ACCOUNT = { source: "backup", token: "tok-backup-FAKE" };
+
+  test("null resolveEmail → no usage fetch, no emit (ghost-row prevention)", async () => {
+    const emitted = [];
+    const fetchCalls = [];
+    delete process.env.OTEL_RESOURCE_ATTRIBUTES;
+    const n = await tickUsage({
+      accounts: [ACCOUNT],
+      resolveEmail: async () => null,
+      fetchUsage: async (...a) => {
+        fetchCalls.push(a);
+        return { status: 200, body: usageBody() };
+      },
+      emit: (name, spec) => emitted.push({ name, spec }),
+    });
+    expect(n).toBe(0);
+    expect(emitted.length).toBe(0);
+    expect(fetchCalls.length).toBe(0); // skipped BEFORE burning a rate-limited call
+  });
+
+  test("active account falls back to OTEL_RESOURCE_ATTRIBUTES user.email", async () => {
+    const emitted = [];
+    process.env.OTEL_RESOURCE_ATTRIBUTES = "project=x,user.email=env@example.com,branch=main";
+    try {
+      const n = await tickUsage({
+        accounts: [{ source: "active", token: "tok-active-FAKE" }],
+        resolveEmail: async () => null,
+        fetchUsage: async () => ({ status: 200, body: usageBody() }),
+        emit: (name, spec) => emitted.push({ name, spec }),
+      });
+      expect(n).toBe(1);
+      expect(emitted[0].spec.attrs["account.email"]).toBe("env@example.com");
+    } finally {
+      delete process.env.OTEL_RESOURCE_ATTRIBUTES;
+    }
+  });
+
+  test("backup account does NOT use the ambient env fallback", async () => {
+    const emitted = [];
+    process.env.OTEL_RESOURCE_ATTRIBUTES = "user.email=env@example.com";
+    try {
+      const n = await tickUsage({
+        accounts: [ACCOUNT],
+        resolveEmail: async () => null,
+        fetchUsage: async () => ({ status: 200, body: usageBody() }),
+        emit: (name, spec) => emitted.push({ name, spec }),
+      });
+      expect(n).toBe(0);
+      expect(emitted.length).toBe(0);
+    } finally {
+      delete process.env.OTEL_RESOURCE_ATTRIBUTES;
+    }
+  });
+});
+
+describe("parseOtelEmail", () => {
+  test("extracts user.email from the k=v list", () => {
+    expect(parseOtelEmail({ OTEL_RESOURCE_ATTRIBUTES: "a=b,user.email=x@y.z" })).toBe("x@y.z");
+  });
+  test("absent var / absent key / empty value → null", () => {
+    expect(parseOtelEmail({})).toBe(null);
+    expect(parseOtelEmail({ OTEL_RESOURCE_ATTRIBUTES: "a=b" })).toBe(null);
+    expect(parseOtelEmail({ OTEL_RESOURCE_ATTRIBUTES: "user.email=" })).toBe(null);
   });
 });


### PR DESCRIPTION
Live multi-host findings: (1) a 429'd profile lookup produced an `account.ratelimit.sampled` with no `account.email` → **ghost blank row** in the scoreboard; now falls back to `OTEL_RESOURCE_ATTRIBUTES user.email` (active account) and otherwise **skips before** burning a usage call. (2) `os.hostname()` returns `X.local` on macOS but Claude Code emits `X` — same machine, two identities; new `shortHostname()` normalizes all agent host labels. 205 tests pass (12 new/updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)