### PR TITLE
fix(dev): CTL-846 liveness-gate proxy env at daemon launch + harden docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -353,6 +353,13 @@ export NODE_EXTRA_CA_CERTS=$HOME/.mitmproxy/mitmproxy-ca-cert.pem
 catalyst-execution-core restart
 ```
 
+> **Do not `source` `execution-core.env` in an interactive shell or shell profile.** It is sourced
+> by `catalyst-execution-core start` for the daemon only. Sourcing it in your terminal pins
+> `HTTP(S)_PROXY` onto every process you launch (including interactive `claude`); when mitmproxy is
+> down, those calls fail with `connection refused`. Always apply changes with
+> `catalyst-execution-core restart`. The daemon liveness-gates the proxy and degrades to direct mode
+> if mitmproxy is unreachable (CTL-846); an interactive shell gets no such protection.
+
 **Why `NODE_USE_ENV_PROXY=1` is required.** Node 20+/24+ native `fetch` (undici) **ignores**
 `HTTPS_PROXY`/`HTTP_PROXY` unless `NODE_USE_ENV_PROXY=1` is also set. Omit it and the daemon's
 Linear calls bypass the proxy entirely while looking perfectly healthy — the audit silently captures

--- a/plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh
@@ -23,10 +23,12 @@ fail() {
 setup() {
 	SCRATCH=$(mktemp -d)
 	export CATALYST_DIR="$SCRATCH"
-	# fake daemon: write the PID file it is handed, then sleep so kill-0 sees it.
+	export DAEMON_ENV_DUMP="$SCRATCH/daemon-env.dump"
+	# fake daemon: dump env for proxy-gating assertions, write PID file, then sleep.
 	FAKE="$SCRATCH/fake-daemon.sh"
 	cat >"$FAKE" <<'EOF'
 #!/usr/bin/env bash
+env > "${DAEMON_ENV_DUMP:?}"
 while [ $# -gt 0 ]; do [ "$1" = "--pid-file" ] && echo $$ > "$2"; shift; done
 sleep 30
 EOF
@@ -39,7 +41,17 @@ teardown() {
 	"$SCRIPT" stop >/dev/null 2>&1 || true
 	pkill -f "fake-daemon.sh" 2>/dev/null || true
 	rm -rf "$SCRATCH"
-	unset CATALYST_DIR EXECUTION_CORE_DAEMON_SCRIPT EXECUTION_CORE_RUNTIME
+	unset CATALYST_DIR EXECUTION_CORE_DAEMON_SCRIPT EXECUTION_CORE_RUNTIME \
+	      DAEMON_ENV_DUMP CATALYST_EXECUTION_CORE_ENV
+}
+
+# Return a localhost TCP port with no current listener (best-effort).
+_free_port() {
+	local p
+	for p in 49231 49233 49237 49241 49243; do
+		if ! (echo >"/dev/tcp/127.0.0.1/$p") 2>/dev/null; then echo "$p"; return; fi
+	done
+	echo 49251
 }
 
 # ─── Test cases ───────────────────────────────────────────────────────────────
@@ -142,6 +154,63 @@ GOT="$(cat "$ENVDUMP" 2>/dev/null)"
 if ! echo "$GOT" | grep -q 'linear.key='; then pass "daemon env has no linear.key"; else fail "daemon env has no linear.key" "got=$GOT"; fi
 if echo "$GOT" | grep -q 'catalyst.role=execution-core-daemon'; then pass "daemon env carries neutral identity"; else fail "daemon env carries neutral identity" "got=$GOT"; fi
 unset OTEL_RESOURCE_ATTRIBUTES
+teardown
+
+echo "test 7 (CTL-846): dead proxy in execution-core.env is stripped before daemon launch"
+setup
+DEAD_PORT=$(_free_port)
+ENVF="$SCRATCH/execution-core.env"
+printf 'export HTTPS_PROXY=http://127.0.0.1:%s\n' "$DEAD_PORT" >  "$ENVF"
+printf 'export HTTP_PROXY=http://127.0.0.1:%s\n'  "$DEAD_PORT" >> "$ENVF"
+printf 'export NODE_USE_ENV_PROXY=1\n'                          >> "$ENVF"
+export CATALYST_EXECUTION_CORE_ENV="$ENVF"
+WARN=$("$SCRIPT" start 2>&1 >/dev/null)
+if ! grep -q 'HTTPS_PROXY=' "$DAEMON_ENV_DUMP" \
+   && ! grep -q 'NODE_USE_ENV_PROXY=' "$DAEMON_ENV_DUMP"; then
+	pass "dead proxy vars stripped from daemon env"
+else
+	fail "dead proxy vars stripped from daemon env" "$(grep -E 'PROXY' "$DAEMON_ENV_DUMP" || true)"
+fi
+if printf '%s' "$WARN" | grep -qi 'proxy.*not listening\|degrad'; then
+	pass "warns when proxy is down"
+else
+	fail "warns when proxy is down" "stderr: $WARN"
+fi
+teardown
+
+echo "test 8 (CTL-846): live proxy is preserved into daemon env"
+if ! command -v nc >/dev/null 2>&1; then
+	echo "SKIP: test 8 requires nc (not found on PATH)"
+else
+	setup
+	LIVE_PORT=$(_free_port)
+	( nc -l 127.0.0.1 "$LIVE_PORT" >/dev/null 2>&1 & echo $! > "$SCRATCH/listener.pid" )
+	sleep 0.3
+	ENVF="$SCRATCH/execution-core.env"
+	printf 'export HTTPS_PROXY=http://127.0.0.1:%s\n' "$LIVE_PORT" > "$ENVF"
+	printf 'export NODE_USE_ENV_PROXY=1\n'                        >> "$ENVF"
+	export CATALYST_EXECUTION_CORE_ENV="$ENVF"
+	"$SCRIPT" start >/dev/null 2>&1
+	if grep -q "HTTPS_PROXY=http://127.0.0.1:$LIVE_PORT" "$DAEMON_ENV_DUMP"; then
+		pass "live proxy preserved into daemon env"
+	else
+		fail "live proxy preserved into daemon env" "$(grep -E 'PROXY' "$DAEMON_ENV_DUMP" || true)"
+	fi
+	kill "$(cat "$SCRATCH/listener.pid" 2>/dev/null)" 2>/dev/null || true
+	teardown
+fi
+
+echo "test 9 (CTL-846): no proxy vars set → launch unaffected, no warning"
+setup
+ENVF="$SCRATCH/execution-core.env"
+printf 'export LINEAR_STATE_CACHE_TTL_MS=180000\n' > "$ENVF"
+export CATALYST_EXECUTION_CORE_ENV="$ENVF"
+WARN=$("$SCRIPT" start 2>&1 >/dev/null)
+if printf '%s' "$WARN" | grep -qi 'proxy.*not listening'; then
+	fail "no spurious proxy warning when no proxy configured" "$WARN"
+else
+	pass "no spurious proxy warning when no proxy configured"
+fi
 teardown
 
 echo ""

--- a/plugins/dev/scripts/__tests__/execution-core-proxy-docs.test.sh
+++ b/plugins/dev/scripts/__tests__/execution-core-proxy-docs.test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# CTL-846: assert docs + template warn against sourcing execution-core.env interactively.
+# Run: bash plugins/dev/scripts/__tests__/execution-core-proxy-docs.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+TEMPLATE="${REPO_ROOT}/plugins/dev/templates/execution-core.env.example"
+CONFIG_DOC="${REPO_ROOT}/docs/configuration.md"
+
+FAILURES=0; PASSES=0
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; }
+
+grep -qi 'do not[^\n]*source\|never[^\n]*source\|not.*interactive shell' "$TEMPLATE" \
+  && pass "template warns against interactive sourcing" \
+  || fail "template warns against interactive sourcing"
+
+grep -qi 'interactive shell' "$CONFIG_DOC" \
+  && pass "configuration.md warns against interactive sourcing" \
+  || fail "configuration.md warns against interactive sourcing"
+
+echo ""; echo "Results: $PASSES passed, $FAILURES failed"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -86,6 +86,16 @@ _neutralize_otel_attrs() {
 	printf '%s' "$out"
 }
 
+# CTL-846: is host:port accepting TCP connections? bash /dev/tcp first, nc fallback.
+# Used to gate mitmproxy proxy vars so a down proxy degrades to direct mode instead of
+# breaking every daemon/worker API call with "connection refused".
+_proxy_listening() {
+	local host="$1" port="$2"
+	(echo >"/dev/tcp/${host}/${port}") 2>/dev/null && return 0
+	command -v nc >/dev/null 2>&1 && nc -z -w 1 "$host" "$port" 2>/dev/null && return 0
+	return 1
+}
+
 cmd_start() {
 	if read_pid >/dev/null 2>&1; then
 		echo "catalyst-execution-core already running (pid $(read_pid))"
@@ -112,6 +122,21 @@ cmd_start() {
 	local _daemon_env="${CATALYST_EXECUTION_CORE_ENV:-${HOME}/.config/catalyst/execution-core.env}"
 	# shellcheck disable=SC1090
 	[[ -f "$_daemon_env" ]] && source "$_daemon_env"
+	# CTL-846: if proxy vars were sourced (here or via catalyst-stack --proxy's inline prefix —
+	# both converge on this process) but the proxy endpoint is not listening, strip them and warn
+	# so the daemon starts in direct mode instead of failing every API call with connection refused.
+	local _proxy_url _hp _phost _pport
+	_proxy_url="${HTTPS_PROXY:-${HTTP_PROXY:-}}"
+	if [[ -n "$_proxy_url" ]]; then
+		_hp="${_proxy_url#*://}"; _hp="${_hp%%/*}"
+		_phost="${_hp%%:*}"; _pport="${_hp##*:}"
+		[[ "$_pport" == "$_phost" ]] && _pport=80
+		if ! _proxy_listening "$_phost" "$_pport"; then
+			echo "catalyst-execution-core: WARNING proxy ${_phost}:${_pport} not listening — starting daemon in direct mode (proxy vars stripped)" >&2
+			unset HTTPS_PROXY HTTP_PROXY NODE_USE_ENV_PROXY
+		fi
+		unset _proxy_url _hp _phost _pport
+	fi
 	# CTL-785: authenticate the daemon's Linear calls as the Catalyst Orchestrator app-actor
 	# (its own 5000/hr OAuth bucket — isolated from the personal token it would otherwise pin).
 	# Mint a fresh client_credentials token from the creds in the global config. --noproxy keeps

--- a/plugins/dev/templates/execution-core.env.example
+++ b/plugins/dev/templates/execution-core.env.example
@@ -15,6 +15,13 @@
 #
 # ─── Optional: route daemon Linear/gh traffic through a local mitmproxy audit ──
 #
+# WARNING: this file is sourced by `catalyst-execution-core start` for the DAEMON only.
+# Do NOT `source` it in an interactive shell or shell profile — the HTTP(S)_PROXY exports
+# would then pin every process you launch (including interactive `claude`) to mitmproxy, and
+# all API calls break with "connection refused" whenever mitmproxy is down. Apply changes with
+# `catalyst-execution-core restart` instead. (The daemon liveness-gates these vars; your shell
+# does not.)  See CTL-846.
+#
 # The daemon's Linear/GitHub calls go out over Node's native fetch (undici). To
 # observe/record them, run a local mitmproxy and point the daemon at it. This is
 # OPT-IN — leave it all commented out to keep direct connections.


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-07T20:19:30Z -->
<!-- Last updated: 2026-06-07T20:19:30Z -->
<!-- PR: #1459 -->
<!-- Previous commits: 5391aa917da6b3a5ea860a965eb1023842ddf0c7 -->

## Summary

Fixes a proxy-scope leak where `execution-core.env` exports (`HTTP(S)_PROXY`, `NODE_USE_ENV_PROXY`) escaped daemon scope and broke all API calls in interactive Claude sessions whenever mitmproxy was down. The daemon now liveness-gates the proxy endpoint before inheriting those vars, degrading to direct mode rather than hard-failing. Phase 2 locks the correct usage pattern into the env template and docs via a new grep-based doc-shape test.

**Root cause:** `catalyst-execution-core start` sourced `execution-core.env` into its own process, but since the daemon inherits the shell environment, any vars already in the shell (from direnv, `source ~/.config/catalyst/execution-core.env`, or `catalyst-stack --proxy`'s inline prefix) had already contaminated interactive sessions pointing at a dead proxy.

## Changes Made

### Core Fix — `plugins/dev/scripts/catalyst-execution-core`

- Added `_proxy_listening()` helper: tries `bash /dev/tcp` first, falls back to `nc -z -w 1`
- Called immediately after `source "$_daemon_env"` in `cmd_start()`: if `HTTPS_PROXY`/`HTTP_PROXY` is set but the endpoint is unreachable, `unset HTTPS_PROXY HTTP_PROXY NODE_USE_ENV_PROXY` and emit a warning to stderr
- Both injection paths (env file + `catalyst-stack --proxy` inline prefix) converge in this single function, so no second gate is needed elsewhere

### Tests — `plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh`

- **Test 7**: dead proxy port → vars stripped from daemon env, warning emitted
- **Test 8**: live proxy port (`nc -l` listener) → `HTTPS_PROXY` preserved into daemon env
- **Test 9**: no proxy vars in env file → daemon starts cleanly, no spurious warning

### New Test — `plugins/dev/scripts/__tests__/execution-core-proxy-docs.test.sh`

Grep-based doc-shape test asserting that both `execution-core.env.example` and `docs/configuration.md` contain the "do not source interactively" warning. Guards against future edits that remove the caution text.

### Docs — `docs/configuration.md`

Added a callout block under the proxy configuration section warning against sourcing `execution-core.env` in an interactive shell or shell profile, explaining that `catalyst-execution-core restart` is the correct way to apply changes.

### Template — `plugins/dev/templates/execution-core.env.example`

Added a `WARNING:` block at the top of the mitmproxy proxy section explaining the daemon-only scope, the failure mode when proxy is down, and the correct usage pattern.

## How to Verify It

- [x] `bash plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh` — tests 7, 8, 9 pass ✅
- [x] `bash plugins/dev/scripts/__tests__/execution-core-proxy-docs.test.sh` — both grep assertions pass ✅
- [x] CI: `audit-references` pass ✅
- [x] CI: `check-versions` pass ✅
- [x] CI: `docs-gate` pass ✅
- [x] CI: `validate` pass ✅
- [ ] Manual: start daemon with proxy pointing at a dead port, confirm `catalyst-execution-core start` logs warning and daemon calls succeed (direct mode)
- [ ] Manual: start daemon with `mitmproxy` running, confirm proxy traffic appears in the mitmproxy UI

## Related Issues / PRs

- Fixes https://linear.app/l/issue/CTL-846
