### PR TITLE
test(dev): CTL-847 — regression-lock catalyst-stack fresh-install contract

### DIFF
--- a/plugins/dev/scripts/__tests__/install-cli.test.sh
+++ b/plugins/dev/scripts/__tests__/install-cli.test.sh
@@ -115,6 +115,23 @@ for cli in catalyst-comms catalyst-events catalyst-execution-core catalyst-otel-
   "
 done
 
+# ── CTL-847: catalyst-stack fresh-install contract — installed link is runnable ─
+# Replace the stub with the real catalyst-stack + its lib dependency so --version
+# exercises the genuine version path (catalyst-stack:38-51). The symlink
+# $BIN1/catalyst-stack already points to $SRC1/catalyst-stack — no reinstall needed.
+cp "$REPO_ROOT/plugins/dev/scripts/catalyst-stack" "$SRC1/catalyst-stack"
+mkdir -p "$SRC1/lib"
+cp "$REPO_ROOT/plugins/dev/scripts/lib/catalyst-version.sh" "$SRC1/lib/catalyst-version.sh"
+
+run "catalyst-stack installed entry is executable" bash -c "
+  [[ -x '$BIN1/catalyst-stack' ]]
+"
+
+run "catalyst-stack installed entry invokes end-to-end (--version)" bash -c "
+  out=\$('$BIN1/catalyst-stack' --version 2>&1) || { echo \"exit nonzero: \$out\"; exit 1; }
+  [[ -n \"\$out\" ]]
+"
+
 # ── 4. .sh suffix stripped on link name ─────────────────────────────────────
 run "catalyst-session points at catalyst-session.sh" bash -c "
   target=\$(readlink '$BIN1/catalyst-session')


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-07T20:47:00Z -->
<!-- Last updated: 2026-06-07T20:47:00Z -->
<!-- PR: #1460 -->
<!-- Previous commits: 5e3c00c27db0849a96803ec7062a87778cabcbb6 -->

## Summary

- Adds two end-to-end regression tests to `install-cli.test.sh` that verify the installed `catalyst-stack` link is executable and invocable via `--version`
- Closes the coverage gap identified by research: symlink creation was tested, but invocability through the installed link was not
- Guarding power proven: removing `catalyst-stack` from `CLI_ENTRIES` causes both assertions to fail

## Changes Made

### Test Changes

- `plugins/dev/scripts/__tests__/install-cli.test.sh` (+17 lines)
  - Copies the real `catalyst-stack` script and its `lib/catalyst-version.sh` dependency into the sandbox (replacing the stub) so `--version` exercises the genuine version path
  - Asserts `~/.catalyst/bin/catalyst-stack` is executable
  - Asserts invoking it end-to-end via `--version` exits zero and produces non-empty output
  - Test count: 67 → 69 (2 new assertions)

## How to Verify It

- [x] `bash plugins/dev/scripts/__tests__/install-cli.test.sh` — 69/69 passed (incl. 2 new catalyst-stack contract assertions)
- [x] `bash plugins/dev/scripts/__tests__/catalyst-stack.test.sh` — unaffected (20/21 pre-existing)
- [x] Temporarily removing `"catalyst-stack:catalyst-stack"` from `CLI_ENTRIES` causes both new assertions to fail — guarding power confirmed
- [x] Restoring the entry → 69/69 green
- [x] CI: audit-references ✅ · check-versions ✅ · docs-gate ✅ · validate ✅ · Cloudflare Pages ✅

## Pre-merge Verification

| Gate | Status |
|------|--------|
| Tests | ✅ pass — install-cli.test.sh 69/69 |
| Security | ✅ pass — test-only diff; no secrets introduced |
| Code review | ✅ pass — well-formed test; guarding power verified |
| Coverage | ✅ pass — adds coverage for installed-link invocability |
| Silent failure | ✅ pass — explicit `|| { echo; exit 1; }` error propagation |
| Typecheck | — skip (bash-only repo) |
| Lint | — skip (shellcheck not in env) |
| Regression risk | 0 / 10 |

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-847
