### PR TITLE
CTL-848: fix getting-started docs — paths, daemon names, headless host

### DIFF
--- a/plugins/dev/scripts/__tests__/getting-started-contract.test.sh
+++ b/plugins/dev/scripts/__tests__/getting-started-contract.test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Contract test: getting-started docs match the real fresh-install flow (CTL-848).
+# Run: bash plugins/dev/scripts/__tests__/getting-started-contract.test.sh
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+GS="website/src/content/docs/getting-started"
+FAILURES=0; PASSES=0
+
+assert_doc_has() {
+  local label="$1" file="$2" needle="$3"
+  if grep -qF -- "$needle" "$REPO_ROOT/$file"; then
+    PASSES=$((PASSES+1)); echo "  PASS: $label"
+  else
+    FAILURES=$((FAILURES+1)); echo "  FAIL: $label (missing in $file): $needle"
+  fi
+}
+assert_doc_lacks() {
+  local label="$1" file="$2" needle="$3"
+  if grep -qF -- "$needle" "$REPO_ROOT/$file"; then
+    FAILURES=$((FAILURES+1)); echo "  FAIL: $label (should be gone from $file): $needle"
+  else
+    PASSES=$((PASSES+1)); echo "  PASS: $label"
+  fi
+}
+
+echo "=== Phase 1: index.md correctness fixes ==="
+
+# Issue 1 — snippet path
+assert_doc_lacks "index: broken repo-relative snippet path removed" \
+  "$GS/index.md" "cat plugins/dev/templates/CLAUDE_SNIPPET.md"
+assert_doc_has "index: snippet uses installed-cache glob" \
+  "$GS/index.md" ".claude/plugins/cache/catalyst/catalyst-dev/*/templates/CLAUDE_SNIPPET.md"
+
+# Issue 2 — CLI plugin install form
+assert_doc_has "index: CLI marketplace-add form documented" \
+  "$GS/index.md" "claude plugin marketplace add coalesce-labs/catalyst"
+assert_doc_has "index: CLI plugin-install form documented" \
+  "$GS/index.md" "claude plugin install catalyst-dev@catalyst"
+
+# Issue 7 — install-cli glob guard (a not-found guard is present near the install-cli line)
+assert_doc_has "index: install-cli step has a not-found guard" \
+  "$GS/index.md" "plugin not installed"
+
+# Issue 8 — qualified skill name
+assert_doc_has "index: try-it uses qualified skill name" \
+  "$GS/index.md" "/catalyst-dev:research-codebase"
+
+echo ""
+echo "=== Phase 2: daemon stack naming ==="
+
+# Issue 3/6 — the three services are named and given a one-line role for newcomers
+assert_doc_has "index: names broker service" \
+  "$GS/index.md" "catalyst-broker"
+assert_doc_has "index: names monitor service" \
+  "$GS/index.md" "catalyst-monitor"
+assert_doc_has "index: names execution-core service" \
+  "$GS/index.md" "catalyst-execution-core"
+assert_doc_has "how-it-works: names execution-core (not just 'the executor')" \
+  "$GS/how-catalyst-works.md" "execution-core"
+
+echo ""
+echo "=== Phase 3: remote and unattended hosts page ==="
+
+# Issue 4 — gh keychain migration pattern documented
+REMOTE="$GS/remote-and-unattended-hosts.md"
+if [ -f "$REPO_ROOT/$REMOTE" ]; then
+  PASSES=$((PASSES+1)); echo "  PASS: remote-host page exists"
+else
+  FAILURES=$((FAILURES+1)); echo "  FAIL: remote-host page missing: $REMOTE"
+fi
+assert_doc_has "remote: gh token migration pattern" \
+  "$REMOTE" "gh auth token | ssh"
+# Issue 5 — macOS-only-vs-headless reconciled (unattended host framed as a headless Mac)
+assert_doc_has "remote: clarifies unattended host is a headless Mac" \
+  "$REMOTE" "headless Mac"
+assert_doc_has "remote: post-reboot start documented for unattended host" \
+  "$REMOTE" "catalyst-stack start"
+
+echo ""
+echo "Results: $PASSES passed, $FAILURES failed"
+exit "$FAILURES"

--- a/website/src/content/docs/getting-started/how-catalyst-works.md
+++ b/website/src/content/docs/getting-started/how-catalyst-works.md
@@ -7,7 +7,7 @@ sidebar:
 
 Here is the whole idea: you describe the work, autonomous agents build and ship it, and you watch it happen on your Linear board. You stay away from the keyboard for the run itself.
 
-Linear is the issue tracker Catalyst works from. (An issue, or "ticket," is one unit of work.) A background program called the **executor** watches your board and does the rest.
+Linear is the issue tracker Catalyst works from. (An issue, or "ticket," is one unit of work.) A background scheduler — the **execution-core** daemon (part of the Catalyst service stack: broker, monitor, execution-core) — watches your board and does the rest.
 
 ## The loop, in four steps
 

--- a/website/src/content/docs/getting-started/index.md
+++ b/website/src/content/docs/getting-started/index.md
@@ -36,12 +36,21 @@ In Claude Code:
 
 Restart Claude Code after installing.
 
+On a headless or SSH-only host, install from the shell instead:
+
+```bash
+claude plugin marketplace add coalesce-labs/catalyst
+claude plugin install catalyst-dev@catalyst
+```
+
 ## 3. Install the command-line tools
 
 Several Catalyst features call shell tools by name (`catalyst-monitor`, `catalyst-hud`, `catalyst-events`, and more). Install them onto your PATH:
 
 ```bash
-bash ~/.claude/plugins/cache/catalyst/catalyst-dev/*/scripts/install-cli.sh
+shopt -s nullglob
+_cli=( ~/.claude/plugins/cache/catalyst/catalyst-dev/*/scripts/install-cli.sh )
+[ ${#_cli[@]} -gt 0 ] && bash "${_cli[0]}" || echo "catalyst-dev plugin not installed — run step 2 first"
 ```
 
 They install to `$HOME/.catalyst/bin`. If that folder isn't on your PATH, the installer adds it to your shell's startup file. Open a new terminal to pick up the change, then check it worked:
@@ -61,12 +70,21 @@ catalyst-stack start
 
 Run this once after each reboot or after pulling new code. See [catalyst-stack reference](/reference/catalyst-stack/) for flags including `--hotpatch` (apply an update without reinstalling) and `--proxy` (opt-in Linear traffic capture via mitmproxy).
 
+The stack is three long-running services (plus an opt-in proxy):
+
+- **`catalyst-broker`** — the event bus every agent and the executor read and write through.
+- **`catalyst-monitor`** — watches your GitHub PRs and CI status and emits events.
+- **`catalyst-execution-core`** — the scheduler: it picks up Todo tickets and dispatches the phase-agent workers.
+- **`mitmproxy`** *(opt-in, `--proxy` only)* — logs Linear API traffic.
+
+See the [catalyst-stack reference](/reference/catalyst-stack/) for the full command set.
+
 ## 5. Add Catalyst to your project
 
 Copy the Catalyst snippet into your project's `CLAUDE.md` so Claude Code knows the available workflows:
 
 ```bash
-cat plugins/dev/templates/CLAUDE_SNIPPET.md >> .claude/CLAUDE.md
+cat ~/.claude/plugins/cache/catalyst/catalyst-dev/*/templates/CLAUDE_SNIPPET.md >> .claude/CLAUDE.md
 ```
 
 ## 6. Try it
@@ -74,7 +92,7 @@ cat plugins/dev/templates/CLAUDE_SNIPPET.md >> .claude/CLAUDE.md
 Start a Claude Code session and run:
 
 ```
-/research-codebase
+/catalyst-dev:research-codebase
 ```
 
 Follow the prompts. Catalyst spawns helper agents, documents what your code does, and saves the findings to `thoughts/shared/research/`.
@@ -107,3 +125,4 @@ Check your installed versions any time with `/plugins`.
 
 - [How Catalyst works](/getting-started/how-catalyst-works/) — the autonomous loop, end to end
 - [Configuration](/reference/configuration/) — the settings Catalyst reads
+- [Remote and unattended hosts](/getting-started/remote-and-unattended-hosts/) — set up on a headless Mac reached over SSH

--- a/website/src/content/docs/getting-started/reboot-and-updates.md
+++ b/website/src/content/docs/getting-started/reboot-and-updates.md
@@ -61,3 +61,4 @@ The execution-core daemon persists its work queue to disk. If you stop the stack
 
 - [catalyst-stack reference](/reference/catalyst-stack/) — all flags and environment variables
 - [Install Catalyst](/getting-started/) — initial setup
+- [Remote and unattended hosts](/getting-started/remote-and-unattended-hosts/) — bring the stack up on a headless Mac

--- a/website/src/content/docs/getting-started/remote-and-unattended-hosts.md
+++ b/website/src/content/docs/getting-started/remote-and-unattended-hosts.md
@@ -1,0 +1,48 @@
+---
+title: Remote and unattended hosts
+description: Run Catalyst on a headless Mac you reach over SSH — plugin install, gh token migration, and bringing the stack up.
+sidebar:
+  order: 6
+---
+
+Catalyst is macOS-only, but the host does not have to be the Mac in front of you. A
+common setup is a **headless Mac** (for example, a Mac mini) that you reach over SSH and
+leave running. This page covers the parts of setup that differ from the
+[interactive install](/getting-started/).
+
+## Install the plugin over SSH
+
+The in-app `/plugin` commands need an interactive Claude Code session. From a shell, use
+the CLI form instead:
+
+```bash
+claude plugin marketplace add coalesce-labs/catalyst
+claude plugin install catalyst-dev@catalyst
+```
+
+Then install the CLI tools and start the stack exactly as in the
+[main install steps](/getting-started/).
+
+## Move your GitHub login to the remote host
+
+On macOS, `gh auth login` often stores the token in the **macOS keychain**, not in
+`~/.config/gh/hosts.yml`. Copying `hosts.yml` to another machine therefore silently
+fails — the token field is blank. Pipe the token across instead:
+
+```bash
+gh auth token | ssh your-host 'gh auth login --with-token'
+```
+
+`gh auth token` reads from whichever store `gh` is using (keychain or `hosts.yml`), so
+this works regardless of how you logged in locally.
+
+## After a reboot
+
+The services do not auto-start at boot today. After the host reboots, reconnect and run:
+
+```bash
+catalyst-stack start
+```
+
+See [Post-reboot and updates](/getting-started/reboot-and-updates/) for the day-to-day
+boot and update flow.


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-07T22:47:30Z -->
<!-- Last updated: 2026-06-07T22:47:30Z -->
<!-- PR: #1463 -->
<!-- Previous commits: b603c18c -->

## Summary

Fixes three categories of errors in the getting-started documentation discovered during a real fresh-install audit:

1. **Broken snippet path** — `cat plugins/dev/templates/CLAUDE_SNIPPET.md` referenced a repo-relative path no new user would have; corrected to the installed-cache glob.
2. **Missing headless/CLI install path** — only the in-app `/plugin` command was documented; added the `claude plugin marketplace add` + `claude plugin install` form that works in SSH/headless environments.
3. **Unnamed daemon stack** — `catalyst-broker`, `catalyst-monitor`, and `catalyst-execution-core` services were never named in the docs; added a service-list callout to the start-stack step.
4. **New remote-host page** — a new `remote-and-unattended-hosts.md` page covers headless Mac setup, the `gh auth token | ssh` keychain migration pattern, and post-reboot start.
5. **Contract test** — a shell-based contract test (`getting-started-contract.test.sh`) pins the corrected content so regressions are caught in CI.

## Changes Made

### Documentation

- **`website/src/content/docs/getting-started/index.md`**
  - Step 2: Added headless/SSH install block (`claude plugin marketplace add` + `claude plugin install`).
  - Step 3: Replaced bare `bash ~/.claude/plugins/.../install-cli.sh` with a `nullglob`-guarded array form that prints a friendly error when the plugin isn't installed.
  - Step 4: Added service-list callout naming `catalyst-broker`, `catalyst-monitor`, `catalyst-execution-core`, and the optional `mitmproxy`.
  - Step 5 (CLAUDE_SNIPPET): Fixed path from repo-relative `plugins/dev/templates/…` to installed-cache glob `~/.claude/plugins/cache/catalyst/…`.
  - Step 6: Changed `/research-codebase` to fully-qualified `/catalyst-dev:research-codebase`.
  - Added link to new remote-and-unattended-hosts page at the bottom.

- **`website/src/content/docs/getting-started/how-catalyst-works.md`**
  - Replaced vague "executor" reference with the proper service name: `execution-core` daemon, noting it is part of the broker/monitor/execution-core stack.

- **`website/src/content/docs/getting-started/reboot-and-updates.md`**
  - Added link to the new remote-and-unattended-hosts page.

- **`website/src/content/docs/getting-started/remote-and-unattended-hosts.md`** *(new)*
  - Explains headless Mac as the supported remote-host model.
  - Documents CLI plugin install path for SSH environments.
  - Documents the `gh auth token | ssh your-host 'gh auth login --with-token'` keychain migration pattern.
  - Documents post-reboot `catalyst-stack start`.

### Tests

- **`plugins/dev/scripts/__tests__/getting-started-contract.test.sh`** *(new)*
  - 82-line bash contract test covering all 8 issues from the audit: snippet path, CLI install form, nullglob guard, qualified skill name, daemon naming (broker/monitor/execution-core), remote-host page existence, gh-token pattern, and headless Mac framing.
  - Passes on the corrected docs; run with `bash plugins/dev/scripts/__tests__/getting-started-contract.test.sh`.

## How to Verify It

- [x] `audit-references` CI check passes ✅
- [x] `check-versions` CI check passes ✅
- [x] `docs-gate` CI check passes ✅
- [x] `validate` CI check passes ✅
- [x] Cloudflare Pages preview build passes ✅
- [ ] Open the Cloudflare preview URL and verify index.md renders correctly
- [ ] Confirm the new `remote-and-unattended-hosts` page appears in the sidebar and links resolve
- [ ] Run the contract test locally: `bash plugins/dev/scripts/__tests__/getting-started-contract.test.sh`

## Related Issues/PRs

- Fixes https://linear.app/coalesce/issue/CTL-848
