### PR TITLE
feat(dev): CTL-859 cluster claim/fence library + HRW ownership

### DIFF
--- a/plugins/dev/scripts/execution-core/cluster-claim.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+// cluster-claim.mjs — cross-host CLAIM + FENCE record, stored as a single Linear
+// ATTACHMENT per ticket (CTL-859, PR2 of the distributed-coordination epic).
+//
+// DORMANT: this module is the verified mechanism + the read-back CAS + the
+// fencing predicate as a tested library. No caller is wired in yet — CTL-850
+// (HRW ownership + Linear-CAS claim wiring) consumes it next. Keeping it pure
+// and self-contained makes it PR-order-independent: the only externalities are
+// the GraphQL `post` seam (injectable) and the Linear API token in the env.
+//
+// ─── The storage mechanism (VERIFIED via live Linear API probe, 2026-06-08) ──
+// Linear has no custom fields and labels can't model a counter, so the claim +
+// fence + owner-name record is ONE Linear attachment per ticket:
+//
+//   attachmentCreate(input:{
+//     issueId, title:"catalyst-meta", url:"catalyst://fence/<TICKET>",
+//     metadata:{ owner_host, catalyst_generation, phase, claimed_at }
+//   })
+//
+//   • attachmentCreate with the SAME url is an UPSERT — it returns the same
+//     attachment id with new metadata. (attachmentUpdate requires `title` and
+//     does NOT accept `metadata`, so create is the only upsert path.)
+//   • The write produces ZERO issue.history entries → invisible to the human
+//     activity feed (no notification spam).
+//   • READ via issue.attachments and pick the node whose url starts with
+//     `catalyst://fence/`.
+//
+// Linear has no native compare-and-swap, so claimTicket is a SOFT-CAS: write the
+// claim, then read it back and confirm the owner+generation we just wrote are
+// what's on the ticket. A concurrent host that wrote last wins the read-back; we
+// lose and back off. Single-writer discipline (the owning host) + the read-back
+// staleness signal is what makes a small trusted fleet safe without consensus.
+
+// FENCE_URL_PREFIX — the synthetic attachment url that namespaces our record.
+// One attachment per ticket; the full url is `${FENCE_URL_PREFIX}<TICKET>`.
+const FENCE_URL_PREFIX = "catalyst://fence/";
+
+// FENCE_ATTACHMENT_TITLE — the human-facing title on the attachment. Constant so
+// the record is always recognisable in the (rare) case a human inspects it.
+const FENCE_ATTACHMENT_TITLE = "catalyst-meta";
+
+// LINEAR_GRAPHQL_ENDPOINT — same endpoint linear-query.mjs posts to.
+const LINEAR_GRAPHQL_ENDPOINT = "https://api.linear.app/graphql";
+
+// fenceUrl — the per-ticket attachment url. The unique key Linear upserts on.
+export function fenceUrl(ticket) {
+  return `${FENCE_URL_PREFIX}${ticket}`;
+}
+
+// authHeader — Linear's documented auth contract, mirrored from
+// linear-query.mjs::authHeader (kept local so this lib has no cross-module
+// import and stays PR-order-independent). An OAuth access token (`lin_oauth_…`,
+// the daemon's app-actor token) is sent `Bearer <token>`; a personal API key
+// (`lin_api_…`) is sent raw.
+export function authHeader(token = "") {
+  return /^lin_oauth/i.test(token) ? `Bearer ${token}` : token;
+}
+
+// defaultPost — the production GraphQL POST. One fetch to the Linear endpoint
+// with the env token (LINEAR_API_TOKEN / LINEAR_API_KEY — the same vars the
+// daemon exports for linear-query.mjs). Returns the parsed `data` object, or
+// throws on a transport error, non-2xx status, or a GraphQL errors[] body so
+// the caller's try/catch fails safe. Injectable via the `post` option on every
+// public function so tests never touch the network.
+async function defaultPost(query, variables) {
+  const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
+  const res = await fetch(LINEAR_GRAPHQL_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: authHeader(token),
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) {
+    throw new Error(`linear graphql http ${res.status}`);
+  }
+  const json = await res.json();
+  if (json?.errors) {
+    throw new Error(`linear graphql errors: ${JSON.stringify(json.errors)}`);
+  }
+  return json?.data ?? {};
+}
+
+// ─── identifier → issue UUID ─────────────────────────────────────────────────
+
+const RESOLVE_ISSUE_QUERY = `query ResolveIssueId($id: String!) {
+  issues(filter: { identifier: { eq: $id } }) { nodes { id } }
+}`;
+
+// resolveIssueId — a ticket identifier (e.g. "CTL-842") → its issue UUID, or
+// null when no issue matches. Mirrors lib/linear-comment-post.sh's resolution
+// (issues filter on identifier.eq). attachmentCreate needs the UUID, not the
+// identifier. Exported for unit coverage + reuse.
+export async function resolveIssueId(ticket, { post = defaultPost } = {}) {
+  const data = await post(RESOLVE_ISSUE_QUERY, { id: ticket });
+  return data?.issues?.nodes?.[0]?.id ?? null;
+}
+
+// ─── read ────────────────────────────────────────────────────────────────────
+
+const READ_ATTACHMENTS_QUERY = `query ReadFence($id: String!) {
+  issue(id: $id) { attachments { nodes { id url metadata } } }
+}`;
+
+// parseClaimMetadata — normalise an attachment's metadata into the flat claim
+// record callers consume. `catalyst_generation` is coerced to a Number; a
+// missing/unparseable generation becomes null so isFenceCurrent never reads a
+// stale string as a match. Exported for unit coverage.
+export function parseClaimMetadata(metadata) {
+  const m = metadata ?? {};
+  const genRaw = m.catalyst_generation;
+  const generation = Number(genRaw);
+  return {
+    owner_host: m.owner_host ?? null,
+    generation: Number.isFinite(generation) ? generation : null,
+    phase: m.phase ?? null,
+    claimed_at: m.claimed_at ?? null,
+  };
+}
+
+// readClaim — the current claim/fence record for a ticket, or null when no
+// catalyst://fence/ attachment exists. Reads issue.attachments and picks the
+// node whose url starts with the fence prefix (defensive: the issue may carry
+// unrelated attachments — PRs, designs). The `id`/`issueId` args double as the
+// issue UUID when the caller already resolved it; a bare identifier is resolved
+// transparently is NOT done here (Linear's `issue(id:)` accepts an identifier
+// like "CTL-842" directly), so we pass `ticket` straight through.
+export async function readClaim(ticket, { post = defaultPost } = {}) {
+  const data = await post(READ_ATTACHMENTS_QUERY, { id: ticket });
+  const nodes = data?.issue?.attachments?.nodes ?? [];
+  const node = nodes.find((n) => typeof n?.url === "string" && n.url.startsWith(FENCE_URL_PREFIX));
+  if (!node) return null;
+  return parseClaimMetadata(node.metadata);
+}
+
+// ─── write / upsert ──────────────────────────────────────────────────────────
+
+const WRITE_ATTACHMENT_MUTATION = `mutation UpsertFence($input: AttachmentCreateInput!) {
+  attachmentCreate(input: $input) { success attachment { id url metadata } }
+}`;
+
+// writeClaim — upsert the claim/fence attachment for a ticket. Always uses
+// attachmentCreate (the VERIFIED upsert path — the same url returns the same
+// attachment id with new metadata; attachmentUpdate cannot take metadata).
+// Sets claimed_at to now. Resolves the issue UUID first (attachmentCreate needs
+// issueId). Returns the parsed claim record written (the metadata we sent),
+// throwing on a resolution miss or a success:false response so callers fail safe.
+//
+// metadata is written with the VERIFIED key names: owner_host,
+// catalyst_generation, phase, claimed_at. catalyst_generation is a Number on the
+// wire; Linear's metadata JSON round-trips it.
+export async function writeClaim(ticket, { owner_host, generation, phase }, { post = defaultPost } = {}) {
+  const issueId = await resolveIssueId(ticket, { post });
+  if (!issueId) {
+    throw new Error(`cluster-claim: no issue found for identifier ${ticket}`);
+  }
+  const claimed_at = new Date().toISOString();
+  const metadata = {
+    owner_host,
+    catalyst_generation: generation,
+    phase,
+    claimed_at,
+  };
+  const data = await post(WRITE_ATTACHMENT_MUTATION, {
+    input: {
+      issueId,
+      title: FENCE_ATTACHMENT_TITLE,
+      url: fenceUrl(ticket),
+      metadata,
+    },
+  });
+  if (!data?.attachmentCreate?.success) {
+    throw new Error(`cluster-claim: attachmentCreate returned success=false for ${ticket}`);
+  }
+  return parseClaimMetadata(metadata);
+}
+
+// ─── soft-CAS claim ──────────────────────────────────────────────────────────
+
+// claimTicket — the soft compare-and-set that is the actual cross-host mutex.
+//   1. read the current claim → currentGen = current?.generation ?? 0
+//   2. nextGen = currentGen + 1 (1 when nothing is held; a takeover bumps past
+//      the dead owner's generation — the monotonic FENCING TOKEN)
+//   3. writeClaim with owner_host = hostName, generation = nextGen
+//   4. read it BACK and declare won iff the readback shows OUR owner AND OUR
+//      generation. A concurrent host that wrote last shows a different owner (or
+//      a higher generation) → won:false → back off.
+//
+// hostName is a PARAMETER (this lib never imports config — that keeps it pure
+// and PR-order-independent; the caller threads in catalyst.host.name).
+// Returns { won, generation } where generation is the gen we attempted to claim.
+export async function claimTicket(ticket, hostName, phase, { post = defaultPost } = {}) {
+  const current = await readClaim(ticket, { post });
+  const nextGen = (current?.generation ?? 0) + 1;
+  await writeClaim(ticket, { owner_host: hostName, generation: nextGen, phase }, { post });
+  const readback = await readClaim(ticket, { post });
+  const won = readback?.owner_host === hostName && readback?.generation === nextGen;
+  return { won, generation: nextGen };
+}
+
+// ─── fencing predicate ───────────────────────────────────────────────────────
+
+// isFenceCurrent — the cross-host fencing check a worker calls BEFORE any
+// side-effect (PR push, comment, Linear transition). true ⇒ the ticket's current
+// claim generation still equals the generation this worker holds → proceed.
+// false ⇒ a takeover bumped the generation past us (we're a stale zombie) →
+// abort the side-effect. A missing claim (null) yields false — there is nothing
+// authorising our generation, so the conservative answer is "not current".
+export async function isFenceCurrent(ticket, generation, { post = defaultPost } = {}) {
+  const current = await readClaim(ticket, { post });
+  return current?.generation === generation;
+}

--- a/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
@@ -1,0 +1,303 @@
+// cluster-claim.test.mjs — the cross-host CLAIM/FENCE attachment library
+// (CTL-859 PR2). Every test injects a fake GraphQL `post` so nothing touches
+// the network: the fake models a single in-memory Linear attachment per ticket,
+// upserting on the verified `catalyst://fence/<TICKET>` url exactly as the live
+// API does (attachmentCreate with the same url returns the same node with new
+// metadata), so claimTicket's read→write→read-back soft-CAS exercises real
+// semantics.
+import { describe, it, expect } from "bun:test";
+
+import {
+  fenceUrl,
+  authHeader,
+  parseClaimMetadata,
+  resolveIssueId,
+  readClaim,
+  writeClaim,
+  claimTicket,
+  isFenceCurrent,
+} from "./cluster-claim.mjs";
+
+// makeFakeLinear — an in-memory Linear that honours the three operations
+// cluster-claim issues: identifier→id resolution, attachment read, and the
+// upsert-on-url attachmentCreate. State is a Map<ticket, metadata>. Returns
+// { post, store, calls } so a test can pre-seed a claim, inspect the post log,
+// or read the resulting metadata directly.
+function makeFakeLinear({ seed = {}, missingIssues = new Set() } = {}) {
+  // store: ticket → the single fence attachment metadata object (or absent).
+  const store = new Map(Object.entries(seed));
+  const calls = [];
+
+  async function post(query, variables) {
+    calls.push({ query, variables });
+
+    if (query.includes("ResolveIssueId")) {
+      const id = variables.id;
+      if (missingIssues.has(id)) return { issues: { nodes: [] } };
+      return { issues: { nodes: [{ id: `uuid-${id}` }] } };
+    }
+
+    if (query.includes("ReadFence")) {
+      // issue(id:) is called with the IDENTIFIER (Linear accepts it directly).
+      const ticket = variables.id;
+      const metadata = store.get(ticket);
+      const nodes = [];
+      // an unrelated attachment is always present to prove the url-prefix filter.
+      nodes.push({ id: "att-pr", url: "https://github.com/x/y/pull/1", metadata: {} });
+      if (metadata) {
+        nodes.push({ id: `att-fence-${ticket}`, url: fenceUrl(ticket), metadata });
+      }
+      return { issue: { attachments: { nodes } } };
+    }
+
+    if (query.includes("UpsertFence")) {
+      const { issueId, url, metadata } = variables.input;
+      // recover the ticket from the fence url (catalyst://fence/<TICKET>).
+      const ticket = url.replace("catalyst://fence/", "");
+      // verify the resolver was used (issueId is the uuid- form).
+      expect(issueId).toBe(`uuid-${ticket}`);
+      store.set(ticket, metadata); // upsert-on-url
+      return {
+        attachmentCreate: { success: true, attachment: { id: `att-fence-${ticket}`, url, metadata } },
+      };
+    }
+
+    throw new Error(`unexpected query: ${query}`);
+  }
+
+  return { post, store, calls };
+}
+
+describe("authHeader — Linear auth contract", () => {
+  it("OAuth app-actor token is sent Bearer", () => {
+    expect(authHeader("lin_oauth_abc")).toBe("Bearer lin_oauth_abc");
+  });
+  it("personal API key is sent raw", () => {
+    expect(authHeader("lin_api_abc")).toBe("lin_api_abc");
+  });
+  it("empty token yields empty header (raw)", () => {
+    expect(authHeader()).toBe("");
+  });
+});
+
+describe("fenceUrl — the per-ticket upsert key", () => {
+  it("namespaces the synthetic url with the verified prefix", () => {
+    expect(fenceUrl("CTL-842")).toBe("catalyst://fence/CTL-842");
+  });
+});
+
+describe("parseClaimMetadata — normalisation", () => {
+  it("coerces catalyst_generation to a Number", () => {
+    const c = parseClaimMetadata({
+      owner_host: "mini",
+      catalyst_generation: "3",
+      phase: "implement",
+      claimed_at: "2026-06-08T00:00:00.000Z",
+    });
+    expect(c).toEqual({
+      owner_host: "mini",
+      generation: 3,
+      phase: "implement",
+      claimed_at: "2026-06-08T00:00:00.000Z",
+    });
+  });
+  it("missing/unparseable generation becomes null", () => {
+    expect(parseClaimMetadata({ owner_host: "mini" }).generation).toBeNull();
+    expect(parseClaimMetadata({ catalyst_generation: "nope" }).generation).toBeNull();
+  });
+  it("empty metadata yields an all-null record", () => {
+    expect(parseClaimMetadata(undefined)).toEqual({
+      owner_host: null,
+      generation: null,
+      phase: null,
+      claimed_at: null,
+    });
+  });
+});
+
+describe("resolveIssueId — identifier → UUID", () => {
+  it("returns the issue UUID for a known identifier", async () => {
+    const { post } = makeFakeLinear();
+    expect(await resolveIssueId("CTL-842", { post })).toBe("uuid-CTL-842");
+  });
+  it("returns null when no issue matches", async () => {
+    const { post } = makeFakeLinear({ missingIssues: new Set(["CTL-999"]) });
+    expect(await resolveIssueId("CTL-999", { post })).toBeNull();
+  });
+});
+
+describe("readClaim — parse the fence attachment", () => {
+  it("returns null when no fence attachment exists (ignores unrelated ones)", async () => {
+    const { post } = makeFakeLinear();
+    expect(await readClaim("CTL-842", { post })).toBeNull();
+  });
+
+  it("picks the catalyst://fence/ node and parses its metadata", async () => {
+    const { post } = makeFakeLinear({
+      seed: {
+        "CTL-842": {
+          owner_host: "mac-studio",
+          catalyst_generation: 7,
+          phase: "verify",
+          claimed_at: "2026-06-08T01:00:00.000Z",
+        },
+      },
+    });
+    expect(await readClaim("CTL-842", { post })).toEqual({
+      owner_host: "mac-studio",
+      generation: 7,
+      phase: "verify",
+      claimed_at: "2026-06-08T01:00:00.000Z",
+    });
+  });
+});
+
+describe("writeClaim — upsert the attachment", () => {
+  it("resolves the issue id and upserts metadata with a fresh claimed_at", async () => {
+    const { post, store, calls } = makeFakeLinear();
+    const before = Date.now();
+    const written = await writeClaim(
+      "CTL-842",
+      { owner_host: "mini", generation: 1, phase: "triage" },
+      { post },
+    );
+    expect(written.owner_host).toBe("mini");
+    expect(written.generation).toBe(1);
+    expect(written.phase).toBe("triage");
+    // claimed_at is set to ~now (ISO timestamp).
+    const ts = Date.parse(written.claimed_at);
+    expect(ts).toBeGreaterThanOrEqual(before);
+    // the resolver ran before the mutation.
+    expect(calls[0].query).toContain("ResolveIssueId");
+    expect(calls[1].query).toContain("UpsertFence");
+    // metadata landed in the store under the verified key names.
+    expect(store.get("CTL-842").catalyst_generation).toBe(1);
+    expect(store.get("CTL-842").owner_host).toBe("mini");
+  });
+
+  it("upserts on the same url — a second write replaces metadata (one record)", async () => {
+    const { post, store } = makeFakeLinear();
+    await writeClaim("CTL-842", { owner_host: "mini", generation: 1, phase: "triage" }, { post });
+    await writeClaim("CTL-842", { owner_host: "mac-studio", generation: 2, phase: "plan" }, { post });
+    // single record, latest metadata.
+    expect(store.size).toBe(1);
+    expect(store.get("CTL-842").owner_host).toBe("mac-studio");
+    expect(store.get("CTL-842").catalyst_generation).toBe(2);
+  });
+
+  it("throws when the identifier resolves to no issue", async () => {
+    const { post } = makeFakeLinear({ missingIssues: new Set(["CTL-999"]) });
+    await expect(
+      writeClaim("CTL-999", { owner_host: "mini", generation: 1, phase: "triage" }, { post }),
+    ).rejects.toThrow(/no issue found/);
+  });
+});
+
+describe("claimTicket — soft-CAS via read-back", () => {
+  it("first claim on an unheld ticket: generation 1, won", async () => {
+    const { post } = makeFakeLinear();
+    const res = await claimTicket("CTL-842", "mini", "triage", { post });
+    expect(res).toEqual({ won: true, generation: 1 });
+  });
+
+  it("increments generation past the current holder (takeover bump)", async () => {
+    const { post } = makeFakeLinear({
+      seed: {
+        "CTL-842": {
+          owner_host: "dead-host",
+          catalyst_generation: 4,
+          phase: "implement",
+          claimed_at: "2026-06-08T00:00:00.000Z",
+        },
+      },
+    });
+    const res = await claimTicket("CTL-842", "mini", "implement", { post });
+    expect(res).toEqual({ won: true, generation: 5 });
+  });
+
+  it("read-back shows a DIFFERENT owner → won:false (a concurrent host wrote last)", async () => {
+    // A poster whose read-back always reports a rival owner at our generation,
+    // modelling a concurrent host that won the serialized write race.
+    let writes = 0;
+    async function post(query, variables) {
+      if (query.includes("ResolveIssueId")) return { issues: { nodes: [{ id: "uuid-CTL-842" }] } };
+      if (query.includes("UpsertFence")) {
+        writes += 1;
+        return { attachmentCreate: { success: true, attachment: {} } };
+      }
+      if (query.includes("ReadFence")) {
+        // pre-write read: unheld; post-write read-back: a RIVAL owns our gen.
+        const metadata =
+          writes === 0
+            ? null
+            : { owner_host: "rival", catalyst_generation: 1, phase: "triage", claimed_at: "x" };
+        const nodes = metadata
+          ? [{ id: "f", url: fenceUrl("CTL-842"), metadata }]
+          : [];
+        return { issue: { attachments: { nodes } } };
+      }
+      throw new Error("unexpected");
+    }
+    const res = await claimTicket("CTL-842", "mini", "triage", { post });
+    expect(res.generation).toBe(1);
+    expect(res.won).toBe(false);
+  });
+
+  it("read-back shows a HIGHER generation → won:false (we were leapfrogged)", async () => {
+    let writes = 0;
+    async function post(query, variables) {
+      if (query.includes("ResolveIssueId")) return { issues: { nodes: [{ id: "uuid-CTL-842" }] } };
+      if (query.includes("UpsertFence")) {
+        writes += 1;
+        return { attachmentCreate: { success: true, attachment: {} } };
+      }
+      if (query.includes("ReadFence")) {
+        const metadata =
+          writes === 0
+            ? null
+            : { owner_host: "mini", catalyst_generation: 9, phase: "triage", claimed_at: "x" };
+        const nodes = metadata ? [{ id: "f", url: fenceUrl("CTL-842"), metadata }] : [];
+        return { issue: { attachments: { nodes } } };
+      }
+      throw new Error("unexpected");
+    }
+    const res = await claimTicket("CTL-842", "mini", "triage", { post });
+    expect(res.generation).toBe(1);
+    expect(res.won).toBe(false);
+  });
+
+  it("two SEQUENTIAL claims against the shared fake: second bumps generation and wins", async () => {
+    // The fake serializes writes (single in-memory record), modelling Linear's
+    // per-issue atomic write. Sequential claims read each other's writes.
+    const { post } = makeFakeLinear();
+    const a = await claimTicket("CTL-842", "mini", "triage", { post });
+    const b = await claimTicket("CTL-842", "mac-studio", "triage", { post });
+    expect(a).toEqual({ won: true, generation: 1 });
+    expect(b).toEqual({ won: true, generation: 2 });
+  });
+});
+
+describe("isFenceCurrent — the pre-side-effect fencing check", () => {
+  it("true when the ticket's current generation equals ours", async () => {
+    const { post } = makeFakeLinear({
+      seed: {
+        "CTL-842": { owner_host: "mini", catalyst_generation: 3, phase: "pr", claimed_at: "x" },
+      },
+    });
+    expect(await isFenceCurrent("CTL-842", 3, { post })).toBe(true);
+  });
+
+  it("false when a takeover bumped the generation past ours (stale zombie)", async () => {
+    const { post } = makeFakeLinear({
+      seed: {
+        "CTL-842": { owner_host: "other", catalyst_generation: 5, phase: "pr", claimed_at: "x" },
+      },
+    });
+    expect(await isFenceCurrent("CTL-842", 3, { post })).toBe(false);
+  });
+
+  it("false when there is no claim at all (nothing authorises our generation)", async () => {
+    const { post } = makeFakeLinear();
+    expect(await isFenceCurrent("CTL-842", 1, { post })).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/hrw.mjs
+++ b/plugins/dev/scripts/execution-core/hrw.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// hrw.mjs — Highest-Random-Weight (rendezvous) hashing for cross-host ticket
+// ownership (CTL-859, PR2 of the distributed-coordination epic).
+//
+// DORMANT: pure, deterministic ownership math with no caller yet. CTL-850 wires
+// it into the eligible-query filter so each daemon considers ONLY its own
+// tickets — which kills ~80% of cross-host races for free (only one host even
+// looks at a given ticket) and dissolves the smee webhook fan-out (every host
+// receives every webhook but acts only on tickets it owns).
+//
+// HRW property set (why rendezvous, not modulo):
+//   • deterministic — same (ticket, host-set) → same owner on every host, no
+//     coordination needed to agree.
+//   • balanced — sha1 spreads tickets roughly uniformly across hosts.
+//   • minimal churn — adding/removing ONE host re-homes only that host's ~1/N
+//     of tickets; every other ticket→owner mapping is undisturbed. (Modulo would
+//     reshuffle nearly everything when N changes.)
+
+import { createHash } from "node:crypto";
+
+// score — the rendezvous weight for one (ticketId, host) pair. A stable sha1 of
+// `ticketId + '|' + host`, with a numeric slice of the digest taken as the
+// score. Using the first 12 hex chars (48 bits) gives a wide, collision-resistant
+// score space that fits safely in a JS double (≤2^53). Deterministic across hosts
+// and runs (sha1 is content-addressed, no salt). The '|' separator prevents
+// boundary ambiguity (e.g. "CTL-1" + "2" vs "CTL-12" + "" hashing alike).
+function score(ticketId, host) {
+  const digest = createHash("sha1").update(`${ticketId}|${host}`).digest("hex");
+  // 12 hex chars = 48 bits; Number.parseInt base-16 of a 12-char slice stays
+  // well under Number.MAX_SAFE_INTEGER (2^53), so comparisons are exact.
+  return Number.parseInt(digest.slice(0, 12), 16);
+}
+
+// ownerForTicket — the HRW owner of a ticket: argmax_host score(ticket, host)
+// over the host roster. Deterministic. Ties (astronomically unlikely with a
+// 48-bit score) break on the lexicographically smaller host name so every host
+// still agrees. Returns null for an empty/absent roster (no owner can exist).
+export function ownerForTicket(ticketId, hosts) {
+  if (!Array.isArray(hosts) || hosts.length === 0) return null;
+  let best = null;
+  let bestScore = -1;
+  for (const host of hosts) {
+    const s = score(ticketId, host);
+    if (s > bestScore || (s === bestScore && best !== null && host < best)) {
+      bestScore = s;
+      best = host;
+    }
+  }
+  return best;
+}
+
+// ownedBy — does `hostName` own `ticketId` under the current roster? The
+// predicate each daemon applies to its eligible set: keep a ticket iff
+// ownerForTicket(...) === my host name. False when the roster is empty (no owner).
+export function ownedBy(ticketId, hosts, hostName) {
+  return ownerForTicket(ticketId, hosts) === hostName;
+}

--- a/plugins/dev/scripts/execution-core/hrw.test.mjs
+++ b/plugins/dev/scripts/execution-core/hrw.test.mjs
@@ -1,0 +1,125 @@
+// hrw.test.mjs — Highest-Random-Weight (rendezvous) ownership (CTL-859 PR2).
+// Pure deterministic hashing: determinism, single-host degeneracy, distribution
+// sanity, and the minimal-churn property that makes HRW the right choice for a
+// small fleet (removing a non-owner host never moves a ticket's owner).
+import { describe, it, expect } from "bun:test";
+
+import { ownerForTicket, ownedBy } from "./hrw.mjs";
+
+const HOSTS = ["mini", "mac-studio", "macbook"];
+
+describe("ownerForTicket — determinism", () => {
+  it("same (ticket, host-set) → same owner every time", () => {
+    const a = ownerForTicket("CTL-842", HOSTS);
+    const b = ownerForTicket("CTL-842", HOSTS);
+    expect(a).toBe(b);
+    expect(HOSTS).toContain(a);
+  });
+
+  it("host order in the roster does not change the owner", () => {
+    const owner = ownerForTicket("CTL-842", HOSTS);
+    const reversed = ownerForTicket("CTL-842", [...HOSTS].reverse());
+    expect(reversed).toBe(owner);
+  });
+});
+
+describe("ownerForTicket — single host & empty roster", () => {
+  it("a single-host roster always owns every ticket", () => {
+    for (const t of ["CTL-1", "CTL-842", "ADV-77", "CTL-999"]) {
+      expect(ownerForTicket(t, ["only-host"])).toBe("only-host");
+    }
+  });
+
+  it("an empty roster has no owner (null)", () => {
+    expect(ownerForTicket("CTL-842", [])).toBeNull();
+    expect(ownerForTicket("CTL-842", undefined)).toBeNull();
+  });
+});
+
+describe("ownerForTicket — distribution sanity", () => {
+  it("different tickets map across more than one host", () => {
+    const owners = new Set();
+    for (let i = 0; i < 300; i += 1) {
+      owners.add(ownerForTicket(`CTL-${i}`, HOSTS));
+    }
+    // sha1 spread should cover the whole roster over 300 tickets.
+    expect(owners.size).toBe(HOSTS.length);
+  });
+
+  it("roughly balanced — no host owns more than ~60% of a large sample", () => {
+    const counts = Object.fromEntries(HOSTS.map((h) => [h, 0]));
+    const N = 900;
+    for (let i = 0; i < N; i += 1) {
+      counts[ownerForTicket(`CTL-${i}`, HOSTS)] += 1;
+    }
+    for (const h of HOSTS) {
+      expect(counts[h]).toBeGreaterThan(0);
+      expect(counts[h] / N).toBeLessThan(0.6); // far from a degenerate skew
+    }
+  });
+});
+
+describe("ownerForTicket — minimal churn (the HRW property)", () => {
+  it("removing a NON-owner host never changes a ticket's owner", () => {
+    for (let i = 0; i < 200; i += 1) {
+      const ticket = `CTL-${i}`;
+      const owner = ownerForTicket(ticket, HOSTS);
+      // drop a host that is NOT the owner.
+      const nonOwner = HOSTS.find((h) => h !== owner);
+      const reduced = HOSTS.filter((h) => h !== nonOwner);
+      expect(ownerForTicket(ticket, reduced)).toBe(owner);
+    }
+  });
+
+  it("removing the OWNER re-homes ONLY that host's tickets; others undisturbed", () => {
+    const victim = "mac-studio";
+    const reduced = HOSTS.filter((h) => h !== victim);
+    let movedCount = 0;
+    for (let i = 0; i < 300; i += 1) {
+      const ticket = `CTL-${i}`;
+      const before = ownerForTicket(ticket, HOSTS);
+      const after = ownerForTicket(ticket, reduced);
+      if (before === victim) {
+        // its tickets must re-home to a surviving host.
+        movedCount += 1;
+        expect(reduced).toContain(after);
+      } else {
+        // everyone else's mapping is untouched — the minimal-churn guarantee.
+        expect(after).toBe(before);
+      }
+    }
+    expect(movedCount).toBeGreaterThan(0); // the victim actually owned some
+  });
+
+  it("adding a host only steals a fraction; the rest keep their owner", () => {
+    const grown = [...HOSTS, "new-host"];
+    let stolen = 0;
+    let kept = 0;
+    for (let i = 0; i < 300; i += 1) {
+      const ticket = `CTL-${i}`;
+      const before = ownerForTicket(ticket, HOSTS);
+      const after = ownerForTicket(ticket, grown);
+      if (after === "new-host") stolen += 1;
+      else {
+        expect(after).toBe(before); // unchanged owners are exactly preserved
+        kept += 1;
+      }
+    }
+    expect(kept).toBeGreaterThan(stolen); // most tickets keep their owner
+  });
+});
+
+describe("ownedBy — the per-daemon eligibility predicate", () => {
+  it("true exactly for the HRW owner", () => {
+    const ticket = "CTL-842";
+    const owner = ownerForTicket(ticket, HOSTS);
+    expect(ownedBy(ticket, HOSTS, owner)).toBe(true);
+    for (const other of HOSTS.filter((h) => h !== owner)) {
+      expect(ownedBy(ticket, HOSTS, other)).toBe(false);
+    }
+  });
+
+  it("false on an empty roster (no owner)", () => {
+    expect(ownedBy("CTL-842", [], "mini")).toBe(false);
+  });
+});


### PR DESCRIPTION
## CTL-859 — Cluster claim/fence library + HRW ownership (PR2 of the distributed-coordination epic)

PR2 of the distributed-orchestrator-coordination epic. Two **NEW, fully-tested, DORMANT** modules — **additive only**, **no caller wired in yet** (CTL-850 consumes them next), **zero changes to existing dispatch/claim code**.

Design spec: `thoughts/shared/research/2026-06-08-distributed-orchestrator-coordination-design.md` (the four-primitive stack: named-host identity → HRW pre-assignment → Linear-CAS claim → fencing token).

### The verified mechanism (live Linear API probe, 2026-06-08)

The cross-host claim + fence + owner record is a **single Linear ATTACHMENT per ticket** (Linear has no custom fields, and labels can't model a counter):

```
attachmentCreate(input:{
  issueId, title:"catalyst-meta", url:"catalyst://fence/<TICKET>",
  metadata:{ owner_host, catalyst_generation, phase, claimed_at }
})
```

- **WRITE/UPSERT** via `attachmentCreate` with the **same `url`** — the verified upsert path: returns the same attachment id with new metadata. (`attachmentUpdate` requires `title` and does **not** accept `metadata`, so create is the only upsert path.)
- **READ** via `issue.attachments` and pick the node whose `url` starts with `catalyst://fence/`.
- Produces **zero `issue.history` entries** → invisible to the human activity feed (no notification spam).

### `cluster-claim.mjs`
- `readClaim(ticket)` → `{owner_host, generation, phase, claimed_at}` | `null`
- `writeClaim(ticket, {owner_host, generation, phase})` → upserts the attachment, sets `claimed_at`=now
- `claimTicket(ticket, hostName, phase)` → **soft-CAS** (Linear has no native compare-and-swap): read current → `nextGen = (current?.generation ?? 0) + 1` → write → **read back** → `won` iff readback shows our owner **and** our generation. A concurrent host that wrote last wins the read-back; we lose and back off. Returns `{won, generation}`.
- `isFenceCurrent(ticket, generation)` → the pre-side-effect fencing check a worker calls before any PR push / comment / transition — true iff the ticket's current claim generation still equals the generation it holds (a stale zombie is rejected).
- `hostName` is a **parameter** (the lib never imports config — keeps it pure and PR-order-independent). The GraphQL POST is an **injectable `post` seam** so tests never touch the network. Auth mirrors `linear-query.mjs` (`LINEAR_API_TOKEN` / app-actor `Bearer`).

### `hrw.mjs`
- `ownerForTicket(ticketId, hosts)` → rendezvous/HRW: `argmax_host sha1(ticketId + '|' + host)`. Pure, deterministic.
- `ownedBy(ticketId, hosts, hostName)` → `ownerForTicket === hostName` — the per-daemon eligibility predicate. Minimal churn: removing a non-owner host never re-homes a ticket.

### Tests
- `cluster-claim.test.mjs` — generation increment, upsert-on-url, read-back **won/lost** soft-CAS (rival owner → `won:false`; leapfrogged generation → `won:false`), fence comparison; in-memory fake Linear injected via the `post` seam.
- `hrw.test.mjs` — determinism, single-host degeneracy, distribution sanity, and the minimal-churn property.
- **33 new tests, all pass** (`cd plugins/dev/scripts/execution-core && bun test cluster-claim.test.mjs hrw.test.mjs`). Neighbor `claim.test.mjs` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)