### PR TITLE
feat(dev): CTL-850 wire HRW ownership + Linear-CAS claim into new-work dispatch

### DIFF
--- a/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// cluster-claim-sync.mjs — a SYNCHRONOUS bridge over the async cluster-claim CLI
+// (CTL-850, the behavioral-cutover PR).
+//
+// Why this exists: the execution-core dispatch paths (scheduler.mjs schedulerTick,
+// monitor.mjs dispatchTriage) are synchronous, and their existing daemon-side
+// Linear writes already go through synchronous spawnSync shell wrappers
+// (linear-write.mjs → linear-transition.sh). The cross-host claim, by contrast,
+// is async (fetch-based, in cluster-claim.mjs). Rather than make the whole tick
+// async (which would churn the 292KB scheduler/monitor test suites and the
+// setInterval/setTimeout drivers), we drive the claim through spawnSync of
+// `node cluster-claim.mjs claim …` here — the same sync-subprocess convention the
+// daemon already uses for Linear writes, and it reuses the verified, tested lib.
+//
+// FAIL-CLOSED contract: ANY failure — spawn error, timeout, non-zero exit, or
+// unparseable stdout — is reported as { won: false }. The caller then does NOT
+// dispatch this tick and reconsiders next tick. A transient Linear hiccup must
+// never cause a double-dispatch; deferring is always safe (the HRW pre-filter
+// already guarantees only the owning host even reaches the claim).
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+// CLUSTER_CLAIM_CLI — absolute path to the claim CLI, resolved relative to this
+// module so it works regardless of the daemon's cwd.
+const CLUSTER_CLAIM_CLI = fileURLToPath(new URL("./cluster-claim.mjs", import.meta.url));
+
+// CLAIM_TIMEOUT_MS — hard cap on the claim subprocess. The soft-CAS is up to four
+// sequential Linear round-trips (read → resolve → write → read-back); 15s is
+// generous for a healthy API and bounds a hung call so a stuck claim can't wedge
+// a tick. Overridable for tests / slow networks.
+const CLAIM_TIMEOUT_MS = Number(process.env.EXECUTION_CORE_CLAIM_TIMEOUT_MS) || 15_000;
+
+// claimDispatchSync — soft-CAS claim `ticket` for `hostName` at `phase`,
+// synchronously. Returns { won, generation }. won:false on any failure
+// (fail-closed). `spawn`/`nodeBin`/`cli`/`env`/`timeout` are injectable so the
+// unit tests never spawn a real process.
+export function claimDispatchSync(
+  { ticket, hostName, phase },
+  {
+    spawn = spawnSync,
+    nodeBin = process.execPath,
+    cli = CLUSTER_CLAIM_CLI,
+    env = process.env,
+    timeout = CLAIM_TIMEOUT_MS,
+  } = {},
+) {
+  try {
+    const res = spawn(nodeBin, [cli, "claim", ticket, hostName, phase], {
+      encoding: "utf8",
+      env,
+      timeout,
+    });
+    if (!res || res.status !== 0 || typeof res.stdout !== "string") {
+      return { won: false, generation: null };
+    }
+    // The CLI prints exactly one JSON line; take the last non-empty line defensively.
+    const line = res.stdout.trim().split("\n").filter(Boolean).pop();
+    const parsed = JSON.parse(line);
+    return {
+      won: parsed?.won === true,
+      generation: Number.isFinite(parsed?.generation) ? parsed.generation : null,
+    };
+  } catch {
+    return { won: false, generation: null };
+  }
+}

--- a/plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs
@@ -1,0 +1,89 @@
+// cluster-claim-sync.test.mjs — the synchronous spawnSync bridge over the
+// cluster-claim CLI (CTL-850). Every test injects a fake `spawn` so nothing
+// actually forks a process; the focus is argv construction + stdout parsing +
+// the FAIL-CLOSED contract (won:false on any failure).
+import { describe, it, expect } from "bun:test";
+
+import { claimDispatchSync } from "./cluster-claim-sync.mjs";
+
+describe("claimDispatchSync — argv + parsing", () => {
+  it("builds the right argv: node <cli> claim <ticket> <host> <phase>", () => {
+    let captured;
+    const spawn = (bin, args) => {
+      captured = { bin, args };
+      return { status: 0, stdout: JSON.stringify({ won: true, generation: 1 }) + "\n" };
+    };
+    claimDispatchSync(
+      { ticket: "CTL-7", hostName: "mac-studio", phase: "triage" },
+      { spawn, nodeBin: "/usr/bin/node", cli: "/x/cluster-claim.mjs" },
+    );
+    expect(captured.bin).toBe("/usr/bin/node");
+    expect(captured.args).toEqual([
+      "/x/cluster-claim.mjs",
+      "claim",
+      "CTL-7",
+      "mac-studio",
+      "triage",
+    ]);
+  });
+
+  it("parses {won, generation} from the CLI stdout on exit 0", () => {
+    const spawn = () => ({ status: 0, stdout: JSON.stringify({ won: true, generation: 3 }) + "\n" });
+    expect(claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn })).toEqual({
+      won: true,
+      generation: 3,
+    });
+  });
+
+  it("won:false from stdout is preserved (a lost soft-CAS, not an error)", () => {
+    const spawn = () => ({ status: 0, stdout: JSON.stringify({ won: false, generation: 2 }) + "\n" });
+    expect(claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn })).toEqual({
+      won: false,
+      generation: 2,
+    });
+  });
+});
+
+describe("claimDispatchSync — FAIL-CLOSED on every failure mode", () => {
+  it("non-zero exit → won:false", () => {
+    const spawn = () => ({ status: 1, stdout: "" });
+    expect(claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn })).toEqual({
+      won: false,
+      generation: null,
+    });
+  });
+
+  it("unparseable stdout → won:false", () => {
+    const spawn = () => ({ status: 0, stdout: "not json at all" });
+    expect(claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn })).toEqual({
+      won: false,
+      generation: null,
+    });
+  });
+
+  it("timeout / spawn error (status null) → won:false", () => {
+    const spawn = () => ({ status: null, error: new Error("ETIMEDOUT"), stdout: null });
+    expect(claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn })).toEqual({
+      won: false,
+      generation: null,
+    });
+  });
+
+  it("spawn throws → won:false (never propagates)", () => {
+    const spawn = () => {
+      throw new Error("EACCES");
+    };
+    expect(claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn })).toEqual({
+      won: false,
+      generation: null,
+    });
+  });
+
+  it("missing/garbage generation in stdout → generation null but won honoured", () => {
+    const spawn = () => ({ status: 0, stdout: JSON.stringify({ won: true }) + "\n" });
+    expect(claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn })).toEqual({
+      won: true,
+      generation: null,
+    });
+  });
+});

--- a/plugins/dev/scripts/execution-core/cluster-claim.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.mjs
@@ -211,3 +211,66 @@ export async function isFenceCurrent(ticket, generation, { post = defaultPost } 
   const current = await readClaim(ticket, { post });
   return current?.generation === generation;
 }
+
+// ─── CLI ─────────────────────────────────────────────────────────────────────
+// A thin argv shim so the SYNCHRONOUS daemon (scheduler.mjs / monitor.mjs) can
+// drive these async claim/fence functions through spawnSync — the same
+// sync-subprocess convention the daemon already uses for its Linear writes
+// (linear-write.mjs shells linear-transition.sh). cluster-claim-sync.mjs is the
+// in-process wrapper that spawnSync's `node cluster-claim.mjs <cmd> …`.
+//
+// runCli is exported (with an injectable `post`) so the CLI surface is unit
+// tested without the network; the main-guard below calls it with the real post.
+//
+//   claim <ticket> <host> <phase>  → stdout JSON {won, generation}; exit 0 iff
+//                                    the soft-CAS ran (read `won` from stdout —
+//                                    a non-zero exit means the operation threw,
+//                                    which the wrapper treats as won:false).
+//   fence-check <ticket> <gen>     → stdout JSON {current}; exit 0 when current,
+//                                    FENCE_STALE_EXIT (10) when stale — mirrors
+//                                    claim.mjs's host-local fence-check contract.
+const FENCE_STALE_EXIT = 10;
+
+export async function runCli(argv, { post = defaultPost } = {}) {
+  const [cmd, ...rest] = argv;
+  switch (cmd) {
+    case "claim": {
+      const [ticket, hostName, phase] = rest;
+      const res = await claimTicket(ticket, hostName, phase, { post });
+      process.stdout.write(JSON.stringify(res) + "\n");
+      return 0;
+    }
+    case "fence-check": {
+      const [ticket, gen] = rest;
+      const current = await isFenceCurrent(ticket, Number(gen), { post });
+      process.stdout.write(JSON.stringify({ current }) + "\n");
+      return current ? 0 : FENCE_STALE_EXIT;
+    }
+    default:
+      process.stderr.write(
+        `cluster-claim.mjs: unknown subcommand: ${cmd ?? "(none)"}\n` +
+          "usage: cluster-claim.mjs <claim <ticket> <host> <phase> | fence-check <ticket> <gen>>\n",
+      );
+      return 1;
+  }
+}
+
+// isMain — true when run as `node cluster-claim.mjs …`, false when imported.
+// Uses the suffix check (not bun-only import.meta.main) so the CLI fires under
+// the daemon's node runtime, mirroring claim.mjs::isMain.
+function isMain() {
+  return (
+    process.argv[1] &&
+    (process.argv[1].endsWith("/cluster-claim.mjs") ||
+      process.argv[1].endsWith("cluster-claim.mjs"))
+  );
+}
+
+if (isMain()) {
+  runCli(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(`cluster-claim.mjs: ${err?.message ?? err}\n`);
+      process.exit(1);
+    });
+}

--- a/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
@@ -16,7 +16,26 @@ import {
   writeClaim,
   claimTicket,
   isFenceCurrent,
+  runCli,
 } from "./cluster-claim.mjs";
+
+// captureStdout — run an async fn with process.stdout.write trapped, returning
+// the concatenated output. The CLI writes its JSON result to stdout (the channel
+// the spawnSync wrapper parses), so the tests assert on captured stdout.
+async function captureStdout(fn) {
+  const chunks = [];
+  const orig = process.stdout.write;
+  process.stdout.write = (s) => {
+    chunks.push(typeof s === "string" ? s : s.toString());
+    return true;
+  };
+  try {
+    const code = await fn();
+    return { code, out: chunks.join("") };
+  } finally {
+    process.stdout.write = orig;
+  }
+}
 
 // makeFakeLinear — an in-memory Linear that honours the three operations
 // cluster-claim issues: identifier→id resolution, attachment read, and the
@@ -187,9 +206,13 @@ describe("writeClaim — upsert the attachment", () => {
 
   it("throws when the identifier resolves to no issue", async () => {
     const { post } = makeFakeLinear({ missingIssues: new Set(["CTL-999"]) });
-    await expect(
-      writeClaim("CTL-999", { owner_host: "mini", generation: 1, phase: "triage" }, { post }),
-    ).rejects.toThrow(/no issue found/);
+    let err;
+    try {
+      await writeClaim("CTL-999", { owner_host: "mini", generation: 1, phase: "triage" }, { post });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.message).toMatch(/no issue found/);
   });
 });
 
@@ -219,7 +242,7 @@ describe("claimTicket — soft-CAS via read-back", () => {
     // A poster whose read-back always reports a rival owner at our generation,
     // modelling a concurrent host that won the serialized write race.
     let writes = 0;
-    async function post(query, variables) {
+    async function post(query) {
       if (query.includes("ResolveIssueId")) return { issues: { nodes: [{ id: "uuid-CTL-842" }] } };
       if (query.includes("UpsertFence")) {
         writes += 1;
@@ -245,7 +268,7 @@ describe("claimTicket — soft-CAS via read-back", () => {
 
   it("read-back shows a HIGHER generation → won:false (we were leapfrogged)", async () => {
     let writes = 0;
-    async function post(query, variables) {
+    async function post(query) {
       if (query.includes("ResolveIssueId")) return { issues: { nodes: [{ id: "uuid-CTL-842" }] } };
       if (query.includes("UpsertFence")) {
         writes += 1;
@@ -299,5 +322,72 @@ describe("isFenceCurrent — the pre-side-effect fencing check", () => {
   it("false when there is no claim at all (nothing authorises our generation)", async () => {
     const { post } = makeFakeLinear();
     expect(await isFenceCurrent("CTL-842", 1, { post })).toBe(false);
+  });
+});
+
+describe("runCli — the spawnSync CLI surface (CTL-850)", () => {
+  it("claim: prints {won, generation} JSON and exits 0", async () => {
+    const { post } = makeFakeLinear();
+    const { code, out } = await captureStdout(() =>
+      runCli(["claim", "CTL-842", "mini", "triage"], { post }),
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(out)).toEqual({ won: true, generation: 1 });
+  });
+
+  it("claim: a LOST read-back still exits 0 with won:false in stdout (wrapper reads `won`)", async () => {
+    // A rival owns our generation on the read-back → soft-CAS reports won:false,
+    // but the OPERATION succeeded, so the CLI exit stays 0; the sync wrapper
+    // decides not-to-dispatch from the `won:false` it parses out of stdout.
+    let writes = 0;
+    async function post(query) {
+      if (query.includes("ResolveIssueId")) return { issues: { nodes: [{ id: "uuid-CTL-842" }] } };
+      if (query.includes("UpsertFence")) {
+        writes += 1;
+        return { attachmentCreate: { success: true, attachment: {} } };
+      }
+      if (query.includes("ReadFence")) {
+        const metadata =
+          writes === 0
+            ? null
+            : { owner_host: "rival", catalyst_generation: 1, phase: "triage", claimed_at: "x" };
+        const nodes = metadata ? [{ id: "f", url: fenceUrl("CTL-842"), metadata }] : [];
+        return { issue: { attachments: { nodes } } };
+      }
+      throw new Error("unexpected");
+    }
+    const { code, out } = await captureStdout(() =>
+      runCli(["claim", "CTL-842", "mini", "triage"], { post }),
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(out)).toEqual({ won: false, generation: 1 });
+  });
+
+  it("fence-check: exits 0 and prints {current:true} when the generation matches", async () => {
+    const { post } = makeFakeLinear({
+      seed: {
+        "CTL-842": { owner_host: "mini", catalyst_generation: 3, phase: "pr", claimed_at: "x" },
+      },
+    });
+    const { code, out } = await captureStdout(() =>
+      runCli(["fence-check", "CTL-842", "3"], { post }),
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(out)).toEqual({ current: true });
+  });
+
+  it("fence-check: exits 10 (FENCE_STALE_EXIT) and prints {current:false} when stale/missing", async () => {
+    const { post } = makeFakeLinear(); // no claim at all
+    const { code, out } = await captureStdout(() =>
+      runCli(["fence-check", "CTL-842", "3"], { post }),
+    );
+    expect(code).toBe(10);
+    expect(JSON.parse(out)).toEqual({ current: false });
+  });
+
+  it("unknown subcommand: exits 1", async () => {
+    const { post } = makeFakeLinear();
+    const { code } = await captureStdout(() => runCli(["bogus"], { post }));
+    expect(code).toBe(1);
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -127,8 +127,10 @@ import { isLinearTerminal } from "./terminal-state.mjs";
 // a cycle. label-guard.mjs is the leaf module both can import.
 import { labelOnce } from "./label-guard.mjs";
 import { countReapOutcomes } from "./reaper-metrics.mjs";
-import { log, getEligibleDir, getEventLogPath } from "./config.mjs";
+import { log, getEligibleDir, getEventLogPath, getHostName, getClusterHosts } from "./config.mjs";
 import { defaultCheckSequencing } from "./sequencing.mjs"; // CTL-537
+import { ownedBy } from "./hrw.mjs"; // CTL-850: HRW ownership filter
+import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-850: cross-host claim soft-CAS
 
 // The last pipeline phase — its `done` signal means the whole pipeline
 // finished. `done` is otherwise phase-dependent: a `triage: done` signal still
@@ -1834,8 +1836,27 @@ export function schedulerTick(
     // for hermetic unit assertions.
     countTicketEvents = countTicketEventsInWindow,
     appendRunawayEvent = defaultAppendRunawayEvent,
+    // CTL-850: cross-host coordination seams. `hosts` is the cluster roster and
+    // `hostName` this host's coordination name; left undefined they resolve to
+    // the real getClusterHosts()/getHostName() (a single-host fallback when
+    // .catalyst/hosts.json is absent), so every existing single-host install +
+    // bare unit tick is unaffected. `claimDispatch` is the synchronous soft-CAS
+    // claim seam — a spawnSync bridge over cluster-claim.mjs — invoked ONLY when
+    // the roster has >1 host. Tests inject a fixed roster + a recorder to drive
+    // the multi-host HRW-filter and claim-lost paths without touching Linear.
+    hosts = undefined,
+    hostName = undefined,
+    claimDispatch = claimDispatchSync,
   } = {}
 ) {
+  // CTL-850: resolve this host + the cluster roster ONCE per tick (cheap
+  // readFileSync; a per-tick read lets `hosts.json` edits take effect without a
+  // daemon restart). multiHost gates the Linear-touching claim: a single-host
+  // roster makes the HRW filter an identity AND skips the claim entirely, so the
+  // coordination wiring is an exact no-op until a 2nd host joins the roster.
+  const roster = hosts ?? getClusterHosts();
+  const self = hostName ?? getHostName();
+  const multiHost = roster.length > 1;
   // CTL-757: emitStateWrite — caller-emit the canonical linear.state.write audit
   // event for ONE scheduler write site. `writerResult` is the runTransition return
   // ({applied, reason, from_state, to_state, ...}) from applyPhaseStatus /
@@ -2754,7 +2775,15 @@ export function schedulerTick(
   // CTL-695: per-tick reaper telemetry — otel-forward ships this pino line as a
   // gauge (same log-line-only convention as cache.stats / per-project slots).
   log.info(countReapOutcomes(), "scheduler: reap stats");
-  const ready = computeReadyTickets(eligible, { blockerStates });
+  // CTL-850: HRW ownership filter — keep only the tickets THIS host owns under
+  // the cluster roster so freeSlots + per-project caps compute over owned work
+  // only. Applied to `ready` (NOT the raw `eligible`, whose `eligibleIds` drives
+  // the phantom-quarantine sweep above — narrowing that would mis-quarantine a
+  // sibling host's worker dirs). Identity filter for a single-host roster
+  // (ownedBy is always true), so this is an exact no-op until a 2nd host joins.
+  const ready = computeReadyTickets(eligible, { blockerStates }).filter((t) =>
+    ownedBy(t.identifier, roster, self),
+  );
   // CTL-657: the in-flight count is the live `background` claude-agents count,
   // not listInFlightTickets(orchDir).size. A worker that leaked (signal terminal
   // but process alive) still consumes a slot; a duplicate spawn is counted.
@@ -2860,6 +2889,28 @@ export function schedulerTick(
         log.debug(
           { ticket: t.identifier, assignee: a.assignee },
           "ctl-781: candidate assigned to a non-bot — skipping (respect-assignment)"
+        );
+        continue;
+      }
+    }
+    // CTL-850: claim-on-dispatch — the cross-host soft-CAS mutex, the actual
+    // serializer behind the HRW pre-filter. Runs ONLY when the roster has >1 host
+    // (a single-host install never touches Linear here). A LOST claim means
+    // another host won the read-back — NOT a dispatch failure, so `continue` with
+    // NO cooldown/failure marker and the ticket is simply reconsidered next tick.
+    // Fail-closed: claimDispatch returns won:false on any error (never
+    // double-dispatch on a transient Linear hiccup). Placed before the
+    // dispatch-requested emit so a lost claim never emits a phantom "requested".
+    if (multiHost) {
+      const claim = claimDispatch({
+        ticket: t.identifier,
+        hostName: self,
+        phase: NEW_WORK_ENTRY_PHASE,
+      });
+      if (!claim.won) {
+        log.debug(
+          { ticket: t.identifier, host: self },
+          "ctl-850: lost cross-host claim — another host owns this dispatch, deferring"
         );
         continue;
       }

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -70,6 +70,7 @@ import { createTicketStateCache } from "./linear-cache.mjs";
 import { fetchTicketsBatch } from "./linear-query.mjs"; // CTL-784: cache-reuse tests drive the real batch
 import { reclaimDeadWorkIfPossible } from "./recovery.mjs";
 import { WORK_DONE_PROBES } from "./work-done-probes.mjs";
+import { ownerForTicket } from "./hrw.mjs"; // CTL-850: HRW owner computation for the ownership-filter tests
 import { REMEDIATE_CYCLE_CAP } from "../lib/phase-fsm.mjs";
 
 let orchDir;
@@ -7043,5 +7044,121 @@ Final polish, documentation, and code cleanup.
     // No next-phase dispatch fired (implement wasn't declared complete).
     const verifyDispatches = dispatch.calls.filter((args) => args[0]?.phase === "verify");
     expect(verifyDispatches.length).toBe(0);
+  });
+});
+
+// ── CTL-850: HRW ownership filter + claim-on-dispatch (new-work path) ──
+//
+// These exercise the cross-host coordination wiring in schedulerTick. The
+// foundation is safe-by-construction: a single-host roster makes the HRW filter
+// an identity (ownedBy always true) AND gates off the claim, so the wiring is an
+// exact no-op until a 2nd host joins .catalyst/hosts.json. Every test injects a
+// fixed roster + a claimDispatch recorder so nothing touches Linear.
+describe("CTL-850 — HRW ownership + claim-on-dispatch (schedulerTick new-work)", () => {
+  const ROSTER = ["mini", "mac-studio"];
+  const TICKET = "CTL-850";
+  // Compute the deterministic HRW owner of the fixture under the 2-host roster.
+  const OWNER = ownerForTicket(TICKET, ROSTER);
+  const OTHER = ROSTER.find((h) => h !== OWNER);
+
+  const eligibleOne = (id = TICKET) => [
+    {
+      identifier: id,
+      priority: 1,
+      createdAt: "x",
+      state: "Todo",
+      relations: { nodes: [] },
+      inverseRelations: { nodes: [] },
+    },
+  ];
+
+  // recordClaim — a claimDispatch seam that records every call and returns a
+  // fixed verdict, so a test asserts both WHETHER the claim ran and with WHAT.
+  const recordClaim = (verdict) => {
+    const calls = [];
+    const fn = (arg) => {
+      calls.push(arg);
+      return verdict;
+    };
+    fn.calls = calls;
+    return fn;
+  };
+
+  test("single-host roster is an exact no-op: claim is NEVER attempted, dispatch proceeds", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    const claimDispatch = recordClaim({ won: false, generation: null }); // would block IF called
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne(),
+      dispatch,
+      hosts: ["solo"],
+      hostName: "solo",
+      claimDispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+    });
+    expect(claimDispatch.calls).toHaveLength(0); // multiHost gate skipped the claim
+    expect(dispatch.calls).toHaveLength(1); // HRW identity → dispatched
+    expect(dispatch.calls[0]).toMatchObject({ ticket: TICKET, phase: "research" });
+  });
+
+  test("multi-host: a ticket OWNED by this host is dispatched (HRW keeps it)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    const claimDispatch = recordClaim({ won: true, generation: 1 });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne(),
+      dispatch,
+      hosts: ROSTER,
+      hostName: OWNER,
+      claimDispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+    });
+    expect(dispatch.calls).toHaveLength(1);
+    // The claim ran with this host + the entry phase before the spawn.
+    expect(claimDispatch.calls).toHaveLength(1);
+    expect(claimDispatch.calls[0]).toEqual({ ticket: TICKET, hostName: OWNER, phase: "research" });
+  });
+
+  test("multi-host: a ticket owned by ANOTHER host is filtered out — no claim, no dispatch", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    const claimDispatch = recordClaim({ won: true, generation: 1 });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne(),
+      dispatch,
+      hosts: ROSTER,
+      hostName: OTHER, // not the HRW owner
+      claimDispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+    });
+    expect(dispatch.calls).toHaveLength(0); // HRW excluded it before the loop
+    expect(claimDispatch.calls).toHaveLength(0); // never reached the claim
+  });
+
+  test("multi-host: a LOST claim defers WITHOUT a cooldown marker (reconsidered next tick)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    const claimDispatch = recordClaim({ won: false, generation: 2 }); // another host won
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne(),
+      dispatch,
+      hosts: ROSTER,
+      hostName: OWNER,
+      claimDispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+    });
+    expect(claimDispatch.calls).toHaveLength(1); // the claim was attempted
+    expect(dispatch.calls).toHaveLength(0); // but lost → not dispatched
+    // A lost claim is NOT a dispatch failure, so NO cooldown marker is written
+    // (the ticket is simply reconsidered next tick).
+    expect(existsSync(dispatchCooldownPath(orchDir, TICKET, "research"))).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Behavioral cutover **part 1 of 2** — the **scheduler new-work dispatch path**. Each execution-core daemon now dispatches only the tickets it **owns** under the committed cluster roster (HRW rendezvous hashing) and **claims** a ticket via a cross-host soft-CAS before spawning a worker.

**Safe-by-construction: an exact no-op while `.catalyst/hosts.json` has a single host.** `ownedBy` is trivially true (identity filter) and the claim is gated off entirely, so today's single-host mini behaves byte-for-byte as before. The cutover flips on by editing `hosts.json` to add a 2nd host. Dissolves the new-work half of the smee fan-out (CTL-851).

Design: `thoughts/shared/research/2026-06-08-distributed-orchestrator-coordination-design.md`. Foundation libs (hrw/cluster-claim/heartbeat, PR #1469/#1470) were merged + dormant; this is their first dispatch-path consumer.

## Changes

- **`cluster-claim.mjs`** — add testable `runCli(argv,{post})` + node main-guard so the async claim/fence lib can be driven from the **synchronous** daemon via `spawnSync` (the same sync-subprocess convention `linear-write.mjs` already uses for Linear writes). Pure exports untouched. Folds in the 3 lint nits flagged on `cluster-claim.test.mjs`.
- **`cluster-claim-sync.mjs`** (new) — `claimDispatchSync`, a synchronous `spawnSync` bridge over the CLI. **Fail-closed**: any spawn error / timeout / non-zero exit / unparseable stdout → `{won:false}` (defer this tick, never double-dispatch).
- **`scheduler.mjs`** — HRW filter on `ready` (deliberately **not** the raw `eligible`, whose `eligibleIds` drives the phantom-quarantine sweep); claim-on-dispatch immediately before the spawn, gated on a >1-host roster; a lost claim → `continue` with **no** cooldown/failure marker. Roster + host name resolved once per tick (allows `hosts.json` hot-reload without a daemon restart).

## Async/sync bridge

`claimTicket`/`isFenceCurrent` are async (fetch); `schedulerTick` is sync and its existing Linear writes are `spawnSync` shell wrappers. Rather than make the tick async (292KB test-suite churn + interval-driver risk), the claim runs through `spawnSync` of the new CLI — idiomatic for this codebase, and only ever spawned when the roster has >1 host.

## Scope / deferrals (tracked)

- **Fence enforcement** (`isFenceCurrent` guards before side-effects) is deferred to the **takeover/healing** ticket — without takeover nothing bumps the generation, so the guard is vacuous *and untestable* until then. This PR **establishes** the fence token (the claim writes `catalyst_generation`).
- **CTL-850 remainder** (filed separately, Todo): the `monitor.mjs` `dispatchTriage` entry point (2nd dispatch path) + `daemon.mjs` boot observability log + `CATALYST_CONFIG_FILE` export.
- **Worker-side fencing** (in-skill git push / Linear mirror) — separate follow-on (needs `CATALYST_CLUSTER_GENERATION` plumbed into the worker env).

## Tests

468 pass / 0 fail across the 6 touched execution-core suites. 4 new scheduler tests assert: single-host **no-op** (claim never attempted, dispatch proceeds), owned-ticket dispatch, foreign-ticket skip (HRW), and lost-claim defer (no cooldown). `runCli` + `claimDispatchSync` fully covered incl. every fail-closed mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)