### PR TITLE
fix(catalyst-agent): add PATH to launchd plist so usage domain works

### DIFF
--- a/plugins/dev/scripts/catalyst-agent/com.catalyst.agent.plist
+++ b/plugins/dev/scripts/catalyst-agent/com.catalyst.agent.plist
@@ -4,8 +4,8 @@
 <!--
   LaunchAgent template for catalyst-agent (macOS) — CTL-812.
 
-  This is a TEMPLATE. install.sh substitutes the two REPLACE_WITH_* tokens for
-  the real absolute paths before copying it into ~/Library/LaunchAgents/. Run
+  This is a TEMPLATE. install.sh substitutes the REPLACE_WITH_* tokens for
+  real values before copying it into ~/Library/LaunchAgents/. Run
   `node catalyst-agent.mjs --install` for the manual instructions.
 
   StartInterval (seconds) drives the launchd-side cadence. The agent itself runs
@@ -27,6 +27,14 @@
 
   <key>StartInterval</key>
   <integer>300</integer>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>REPLACE_WITH_PATH</string>
+    <key>HOME</key>
+    <string>REPLACE_WITH_HOME</string>
+  </dict>
 
   <key>RunAtLoad</key>
   <true/>

--- a/plugins/dev/scripts/catalyst-agent/install.sh
+++ b/plugins/dev/scripts/catalyst-agent/install.sh
@@ -29,10 +29,15 @@ mkdir -p "${HOME}/Library/LaunchAgents" "${HOME}/catalyst"
 # Substitute the template tokens into the destination plist. Using a temp file
 # then mv keeps the install atomic.
 TMP="$(mktemp)"
+# Capture the current PATH so the launchd agent can find `claude`, `node`, etc.
+# that live outside /usr/bin:/bin:/usr/sbin:/sbin (the launchd default).
+INSTALL_PATH="${PATH}"
+
 sed \
   -e "s|REPLACE_WITH_NODE|${NODE_BIN}|g" \
   -e "s|REPLACE_WITH_AGENT|${AGENT}|g" \
   -e "s|REPLACE_WITH_HOME|${HOME}|g" \
+  -e "s|REPLACE_WITH_PATH|${INSTALL_PATH}|g" \
   "${TEMPLATE}" > "${TMP}"
 mv "${TMP}" "${DEST}"
 echo "install.sh: wrote ${DEST}"


### PR DESCRIPTION
## Problem
launchd gives agents a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). The catalyst-agent's usage domain calls `claude --version` to build the required User-Agent header, but `claude` lives at `~/.local/bin/claude` — not on launchd's PATH. This caused:

1. `getUserAgent()` → ENOENT → fallback to `claude-code/unknown`
2. Profile endpoint rejects/429s the degraded UA → `resolveEmail()` returns null
3. `parseOtelEmail()` fallback also null (no `OTEL_RESOURCE_ATTRIBUTES` in launchd env)
4. No email → usage domain skips every account every run

Host and process domains were unaffected (2,373 events in June). Usage domain was silently dead.

## Fix
- Add `EnvironmentVariables` dict to the plist template with `REPLACE_WITH_PATH` and `REPLACE_WITH_HOME` tokens
- `install.sh` now captures the installer's live `PATH` at install time so the agent inherits it under launchd

## Verification
After reinstalling, the first launchd run emitted a valid `account.ratelimit.sampled` event with email and usage data. The `account email unresolvable` log spam is gone.

## Other hosts
`git pull && ./install.sh` on any other host will pick up the fix.

Co-Authored-By: Oz <oz-agent@warp.dev>