### PR TITLE
feat(dev): CTL-639 clean cold-start recovery — CTL-646 label lifecycle + CTL-644 cheap/gate policy

### DIFF
--- a/docs/orchestrator-overview.md
+++ b/docs/orchestrator-overview.md
@@ -498,6 +498,41 @@ whatever inventory it exposes.
 Legacy `oneshot-legacy` mode is unchanged — all the above only activates when
 `dispatchMode = "phase-agents"` is set in `.catalyst/config.json`.
 
+## Cold-start recovery (CTL-639)
+
+When the daemon restarts after a crash or `kill`, the boot-resume pass
+(`boot-resume.mjs::reconcileBootResume`) re-dispatches in-flight tickets whose
+`--bg` workers are no longer alive. The pass classifies each candidate by phase:
+
+| Phase class | Phases | Boot behaviour |
+|---|---|---|
+| **Cheap** | `triage`, `research`, `plan` | Auto-re-dispatched immediately (no operator action needed). Work is short and idempotent. |
+| **Expensive** | `implement`, `verify`, `review`, `pr`, `monitor-merge`, `monitor-deploy`, `remediate` | **Gated** — a `.boot-resume-pending-approval` marker is written under `workers/<TICKET>/` and a `phase.<phase>.boot-resume-gated.<ticket>` audit event is emitted. No worker is spawned until the operator approves. |
+
+### Operator greenlight for expensive phases
+
+To approve re-dispatch of a gated ticket, create the approval sentinel:
+
+```bash
+touch "$ORCH_DIR/workers/<TICKET>/.boot-resume-approved"
+```
+
+The scheduler picks it up within one tick (≤30 s) and calls `reviveDispatch`
+for that ticket's phase — subject to the same MAX_REVIVES and storm-breaker
+guards as a per-tick reclaim. Both sentinels are deleted on a successful
+dispatch so a subsequent reboot does not re-dispatch.
+
+To list currently gated tickets:
+
+```bash
+find "$ORCH_DIR/workers" -name ".boot-resume-pending-approval" | while read p; do
+  echo "$(basename "$(dirname "$p")"): $(jq -r '.phase' "$p")"
+done
+```
+
+If a HUD button later writes the same sentinel it requires no logic changes —
+`processApprovedResumes` polls for the file, not for the transport that wrote it.
+
 ## See also
 
 - [`website/src/content/docs/reference/orchestration/phase-agents.md`](../website/src/content/docs/reference/orchestration/phase-agents.md) — user-facing canonical doc shipped in PR #812

--- a/plugins/dev/scripts/execution-core/boot-resume-approval.test.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume-approval.test.mjs
@@ -105,4 +105,93 @@ describe("processApprovedResumes (CTL-644)", () => {
     expect(reviveDispatch.calls.length).toBe(1);
     expect(rawDispatch.calls.length).toBe(0);
   });
+
+  // CTL-639 verify: cover the dispatch-failure retry contract and the edge
+  // paths the original 3 tests left untested.
+  test("dispatch failure (code: 1) retains both sentinels and counts failed", () => {
+    writePendingMarker(orchDir, "CTL-53", "implement", "/wt/CTL-53");
+    writeApprovedMarker(orchDir, "CTL-53");
+
+    const reviveDispatch = makeReviveDispatch(1); // non-zero → failure
+
+    const res = processApprovedResumes({
+      orchDir,
+      reviveDispatch,
+      dispatch: () => {},
+      appendEvent: () => true,
+    });
+
+    expect(res).toMatchObject({ dispatched: 0, failed: 1 });
+    // Sentinels retained so the next tick retries.
+    expect(existsSync(bootResumePendingPath(orchDir, "CTL-53"))).toBe(true);
+    expect(existsSync(bootResumeApprovedPath(orchDir, "CTL-53"))).toBe(true);
+  });
+
+  test("reviveDispatch throwing is caught and counted as a failure (sentinels retained)", () => {
+    writePendingMarker(orchDir, "CTL-54", "review", "/wt/CTL-54");
+    writeApprovedMarker(orchDir, "CTL-54");
+
+    const reviveDispatch = () => { throw new Error("boom"); };
+
+    const res = processApprovedResumes({
+      orchDir,
+      reviveDispatch,
+      dispatch: () => {},
+      appendEvent: () => true,
+    });
+
+    expect(res).toMatchObject({ dispatched: 0, failed: 1 });
+    expect(existsSync(bootResumePendingPath(orchDir, "CTL-54"))).toBe(true);
+    expect(existsSync(bootResumeApprovedPath(orchDir, "CTL-54"))).toBe(true);
+  });
+
+  test("approved sentinel with an unreadable pending marker is skipped (no dispatch)", () => {
+    const workerDir = join(orchDir, "workers", "CTL-55");
+    mkdirSync(workerDir, { recursive: true });
+    // Pending path is a present-but-corrupt JSON file; approval sentinel present.
+    writeFileSync(bootResumePendingPath(orchDir, "CTL-55"), "{not valid json");
+    writeApprovedMarker(orchDir, "CTL-55");
+
+    const reviveDispatch = makeReviveDispatch(0);
+
+    const res = processApprovedResumes({
+      orchDir,
+      reviveDispatch,
+      dispatch: () => {},
+      appendEvent: () => true,
+    });
+
+    expect(reviveDispatch.calls.length).toBe(0);
+    expect(res).toMatchObject({ dispatched: 0, failed: 0 });
+  });
+
+  test("non-directory entries at the workers/ level are ignored", () => {
+    // A stray file directly under workers/ must not be treated as a ticket dir
+    // (guards the withFileTypes/isDirectory() filter, CTL-639 hardening).
+    mkdirSync(join(orchDir, "workers"), { recursive: true });
+    writeFileSync(join(orchDir, "workers", "stray.txt"), "not a ticket");
+
+    const reviveDispatch = makeReviveDispatch(0);
+
+    const res = processApprovedResumes({
+      orchDir,
+      reviveDispatch,
+      dispatch: () => {},
+      appendEvent: () => true,
+    });
+
+    expect(reviveDispatch.calls.length).toBe(0);
+    expect(res).toMatchObject({ dispatched: 0, failed: 0 });
+  });
+
+  test("missing workers/ directory returns zero counts without throwing", () => {
+    // orchDir exists but has no workers/ subdir yet.
+    const res = processApprovedResumes({
+      orchDir,
+      reviveDispatch: makeReviveDispatch(0),
+      dispatch: () => {},
+      appendEvent: () => true,
+    });
+    expect(res).toMatchObject({ dispatched: 0, failed: 0 });
+  });
 });

--- a/plugins/dev/scripts/execution-core/boot-resume-approval.test.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume-approval.test.mjs
@@ -1,0 +1,108 @@
+// boot-resume-approval.test.mjs — CTL-644. processApprovedResumes: dispatch
+// gated tickets whose operator-approval sentinel exists.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test boot-resume-approval.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  processApprovedResumes,
+  bootResumePendingPath,
+  bootResumeApprovedPath,
+} from "./boot-resume.mjs";
+
+let orchDir;
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "boot-resume-approval-"));
+});
+
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+function writePendingMarker(dir, ticket, phase, worktreePath) {
+  const workerDir = join(dir, "workers", ticket);
+  mkdirSync(workerDir, { recursive: true });
+  writeFileSync(
+    bootResumePendingPath(dir, ticket),
+    JSON.stringify({ ticket, phase, worktreePath, requestedAt: "2026-06-08T00:00:00Z" })
+  );
+}
+
+function writeApprovedMarker(dir, ticket) {
+  const workerDir = join(dir, "workers", ticket);
+  mkdirSync(workerDir, { recursive: true });
+  writeFileSync(bootResumeApprovedPath(dir, ticket), "");
+}
+
+function makeReviveDispatch(code = 0) {
+  const calls = [];
+  const fn = (...args) => { calls.push(args); return { code }; };
+  fn.calls = calls;
+  return fn;
+}
+
+describe("processApprovedResumes (CTL-644)", () => {
+  test("approved gated ticket dispatches + clears both sentinels on success", () => {
+    writePendingMarker(orchDir, "CTL-50", "implement", "/wt/CTL-50");
+    writeApprovedMarker(orchDir, "CTL-50");
+
+    const reviveDispatch = makeReviveDispatch(0);
+
+    processApprovedResumes({
+      orchDir,
+      reviveDispatch,
+      dispatch: () => {},
+      appendEvent: () => true,
+    });
+
+    expect(reviveDispatch.calls.length).toBe(1);
+    expect(reviveDispatch.calls[0][0]).toMatchObject({ ticket: "CTL-50", phase: "implement" });
+
+    // Both sentinels cleared
+    expect(existsSync(bootResumePendingPath(orchDir, "CTL-50"))).toBe(false);
+    expect(existsSync(bootResumeApprovedPath(orchDir, "CTL-50"))).toBe(false);
+  });
+
+  test("pending marker present but no approval sentinel — no dispatch, marker retained", () => {
+    writePendingMarker(orchDir, "CTL-51", "review", "/wt/CTL-51");
+    // No approved sentinel written
+
+    const reviveDispatch = makeReviveDispatch(0);
+
+    processApprovedResumes({
+      orchDir,
+      reviveDispatch,
+      dispatch: () => {},
+      appendEvent: () => true,
+    });
+
+    expect(reviveDispatch.calls.length).toBe(0);
+    expect(existsSync(bootResumePendingPath(orchDir, "CTL-51"))).toBe(true);
+  });
+
+  test("approval dispatch routes through reviveDispatch seam — same budget/storm guards as cheap path", () => {
+    writePendingMarker(orchDir, "CTL-52", "verify", "/wt/CTL-52");
+    writeApprovedMarker(orchDir, "CTL-52");
+
+    // Use a tracking reviveDispatch that records its args — the point is
+    // that processApprovedResumes must call reviveDispatch (not a raw
+    // dispatch), so existing MAX_REVIVES and storm-breaker guards apply.
+    const reviveDispatch = makeReviveDispatch(0);
+    const rawDispatch = makeReviveDispatch(0);
+
+    processApprovedResumes({
+      orchDir,
+      reviveDispatch,
+      dispatch: rawDispatch,
+      appendEvent: () => true,
+    });
+
+    // reviveDispatch is invoked; raw dispatch is NOT invoked directly.
+    expect(reviveDispatch.calls.length).toBe(1);
+    expect(rawDispatch.calls.length).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/boot-resume.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.mjs
@@ -339,7 +339,12 @@ export function processApprovedResumes({
   const workersDir = join(orchDir, "workers");
   let tickets;
   try {
-    tickets = readdirSync(workersDir);
+    // withFileTypes: filter to directories only — guards against non-directory
+    // entries at the workers/ level and prevents path-component confusion from
+    // any stray file whose name could produce an unexpected path join.
+    tickets = readdirSync(workersDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
   } catch {
     return { dispatched: 0, failed: 0 };
   }

--- a/plugins/dev/scripts/execution-core/boot-resume.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.mjs
@@ -30,12 +30,22 @@
 // scheduler/signal-reader read helpers, and exhaustively unit-tested. The
 // reconcileBootResume orchestrator (Phase 2) wires in the side effects.
 
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
 import { readWorkerSignals, TERMINAL, byActivePhase } from "./signal-reader.mjs";
 import { listInFlightTickets, readMaxParallel, computeFreeSlots } from "./scheduler.mjs";
 import { log } from "./config.mjs";
 import {
   defaultReviveDispatch,
   defaultAppendBootResumeEvent,
+  defaultAppendBootResumeGatedEvent,
   resolvePhaseSessionId,
 } from "./recovery.mjs";
 import { defaultDispatch } from "./dispatch.mjs";
@@ -46,6 +56,53 @@ import { defaultDispatch } from "./dispatch.mjs";
 // Phase-1 exports import-light, but a lazy `import()` is async and the boot pass
 // must stay synchronous to complete before the monitor/scheduler start.)
 import { liveAgents } from "./cli/sessions.mjs";
+
+// ─── CTL-644: cheap/expensive classification ───────────────────────────────
+//
+// cheap = early phases whose work is cheap to re-run; auto-resume on cold start.
+// expensive = phases that edit application code or open PRs; require operator approval.
+// remediate is treated as expensive (edits app code, same cost class as implement).
+export const CHEAP_RESUME_PHASES = new Set(["triage", "research", "plan"]);
+export function isCheapPhase(phase) {
+  return CHEAP_RESUME_PHASES.has(phase);
+}
+
+// bootResumePendingPath — JSON marker written when a gated ticket is awaiting approval.
+// Schema: { ticket, phase, worktreePath, requestedAt }
+export function bootResumePendingPath(orchDir, ticket) {
+  return join(orchDir, "workers", ticket, ".boot-resume-pending-approval");
+}
+
+// bootResumeApprovedPath — empty sentinel written by the operator (or a HUD button)
+// to approve re-dispatch of a gated ticket.
+export function bootResumeApprovedPath(orchDir, ticket) {
+  return join(orchDir, "workers", ticket, ".boot-resume-approved");
+}
+
+// ─── internal helpers ──────────────────────────────────────────────────────
+
+function writePendingMarker(orchDir, ticket, phase, worktreePath) {
+  const p = bootResumePendingPath(orchDir, ticket);
+  if (existsSync(p)) return false; // idempotent — do not re-emit
+  try {
+    writeFileSync(
+      p,
+      JSON.stringify({ ticket, phase, worktreePath, requestedAt: new Date().toISOString() })
+    );
+    return true;
+  } catch (err) {
+    log.warn({ ticket, phase, err: err?.message }, "boot-resume: pending marker write failed — continuing");
+    return false;
+  }
+}
+
+function readPendingMarker(orchDir, ticket) {
+  try {
+    return JSON.parse(readFileSync(bootResumePendingPath(orchDir, ticket), "utf8"));
+  } catch {
+    return null;
+  }
+}
 
 // hasLiveBgWorker — does `agents` contain a live BACKGROUND session whose cwd is
 // exactly `worktreePath`? This is the synchronous reduction of research §6's
@@ -185,6 +242,8 @@ export function reconcileBootResume({
   dispatch = defaultDispatch, // inner seam handed to reviveDispatch
   reviveDispatch = defaultReviveDispatch,
   appendEvent = defaultAppendBootResumeEvent,
+  // CTL-644: gated-event appender — emitted once per expensive ticket gated.
+  appendGatedEvent = defaultAppendBootResumeGatedEvent,
   // CTL-690: session resolver — same helper recovery.mjs:1265 uses on the
   // per-tick reclaim path so boot-resume and reclaim share resume semantics.
   // Injectable so tests can drive both the resumable + unresumable branches
@@ -195,7 +254,7 @@ export function reconcileBootResume({
   concurrency = {}, // CTL-665: committed executionCore concurrency knobs (from startDaemon)
 } = {}) {
   if (!report || report.coldStart !== true) {
-    return { dispatched: 0, failed: 0, skipped: "not-cold-start" };
+    return { dispatched: 0, failed: 0, gated: 0, skipped: "not-cold-start" };
   }
 
   const liveAgentList = resolveAgents(agents);
@@ -204,7 +263,23 @@ export function reconcileBootResume({
   let dispatched = 0;
   let resumed = 0;
   let failed = 0;
-  for (const { ticket, phase, bgJobId } of candidates) {
+  let gated = 0;
+  for (const { ticket, phase, worktreePath, bgJobId } of candidates) {
+    // CTL-644: gate expensive phases behind operator approval; auto-dispatch cheap ones.
+    if (!isCheapPhase(phase)) {
+      const written = writePendingMarker(orchDir, ticket, phase, worktreePath);
+      if (written) {
+        gated++;
+        appendGatedEvent({ phase, ticket, orchId });
+        log.info(
+          { ticket, phase },
+          "boot-resume: expensive phase gated — awaiting operator approval"
+        );
+      }
+      continue;
+    }
+
+    // Cheap path — existing resume/dispatch logic unchanged.
     // CTL-690: try to map the dead worker's bg_job_id → resume UUID. Null
     // result (no bg id, no state.json, no/!.jsonl transcript) falls through
     // to the today-default fresh-dispatch path. The downstream stderr
@@ -243,8 +318,66 @@ export function reconcileBootResume({
   }
 
   log.info(
-    { dispatched, resumed, failed, candidates: candidates.length },
+    { dispatched, resumed, gated, failed, candidates: candidates.length },
     "boot-resume: cold-start reconciliation complete"
   );
-  return { dispatched, resumed, failed, candidates: candidates.length };
+  return { dispatched, resumed, gated, failed, candidates: candidates.length };
+}
+
+// processApprovedResumes — CTL-644. Dispatch gated tickets whose operator
+// approval sentinel exists. Called once at boot (after reconcileBootResume)
+// and each scheduler tick so a mid-run approval is honored without a restart.
+// Routes through reviveDispatch → same MAX_REVIVES / storm-breaker guards as
+// the cheap auto path. Clears both sentinels on a successful dispatch.
+export function processApprovedResumes({
+  orchDir,
+  reviveDispatch = defaultReviveDispatch,
+  dispatch = defaultDispatch,
+  appendEvent = defaultAppendBootResumeEvent,
+  orchId = undefined,
+} = {}) {
+  const workersDir = join(orchDir, "workers");
+  let tickets;
+  try {
+    tickets = readdirSync(workersDir);
+  } catch {
+    return { dispatched: 0, failed: 0 };
+  }
+
+  let dispatched = 0;
+  let failed = 0;
+  for (const ticket of tickets) {
+    const pendingPath = bootResumePendingPath(orchDir, ticket);
+    const approvedPath = bootResumeApprovedPath(orchDir, ticket);
+    if (!existsSync(pendingPath) || !existsSync(approvedPath)) continue;
+
+    const pending = readPendingMarker(orchDir, ticket);
+    if (!pending) {
+      log.warn({ ticket }, "processApprovedResumes: pending marker unreadable — skipping");
+      continue;
+    }
+
+    const { phase, worktreePath } = pending;
+    let res;
+    try {
+      res = reviveDispatch({ orchDir, ticket, phase, resumeSession: null }, { dispatch });
+    } catch (err) {
+      res = { code: 1, stderr: err?.message ?? String(err) };
+    }
+
+    if (res?.code === 0) {
+      dispatched++;
+      appendEvent({ phase, ticket, orchId });
+      try { unlinkSync(pendingPath); } catch { /* best-effort */ }
+      try { unlinkSync(approvedPath); } catch { /* best-effort */ }
+    } else {
+      failed++;
+      log.warn(
+        { ticket, phase, code: res?.code, stderr: res?.stderr },
+        "processApprovedResumes: dispatch failed — sentinels retained for retry"
+      );
+    }
+  }
+
+  return { dispatched, failed };
 }

--- a/plugins/dev/scripts/execution-core/boot-resume.test.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.test.mjs
@@ -8,7 +8,7 @@
 // dispatch/agents/appendEvent/report.
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -16,6 +16,9 @@ import {
   activePhaseForTicket,
   selectBootResumeCandidates,
   reconcileBootResume,
+  isCheapPhase,
+  bootResumePendingPath,
+  bootResumeApprovedPath,
 } from "./boot-resume.mjs";
 
 let orchDir;
@@ -275,7 +278,8 @@ describe("reconcileBootResume", () => {
   });
 
   test("happy path: dispatches once with expectedWorktreePath and resets the signal to stalled", () => {
-    writeSignal(orchDir, "CTL-1", "implement", { worktreePath: "/wt/CTL-1", status: "running" });
+    // Uses 'plan' (cheap phase) so dispatch is not gated.
+    writeSignal(orchDir, "CTL-1", "plan", { worktreePath: "/wt/CTL-1", status: "running" });
     const dispatched = [];
     const events = [];
     const dispatch = (a) => {
@@ -295,23 +299,23 @@ describe("reconcileBootResume", () => {
     expect(dispatched[0]).toMatchObject({
       orchDir,
       ticket: "CTL-1",
-      phase: "implement",
+      phase: "plan",
       expectedWorktreePath: "/wt/CTL-1",
     });
     // Went through defaultReviveDispatch: the signal on disk is reset to stalled.
     const sig = JSON.parse(
-      readFileSync(join(orchDir, "workers", "CTL-1", "phase-implement.json"), "utf8")
+      readFileSync(join(orchDir, "workers", "CTL-1", "phase-plan.json"), "utf8")
     );
     expect(sig.status).toBe("stalled");
     // One audit event routed through the injected appendEvent.
     expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({ ticket: "CTL-1", phase: "implement" });
+    expect(events[0]).toMatchObject({ ticket: "CTL-1", phase: "plan" });
   });
 
   test("slot bound end-to-end: maxParallel=1, 2 no-live tickets ⇒ exactly 1 dispatch + 1 event", () => {
     writeMaxParallel(orchDir, 1);
-    writeSignal(orchDir, "CTL-1", "implement", { worktreePath: "/wt/CTL-1" });
-    writeSignal(orchDir, "CTL-2", "implement", { worktreePath: "/wt/CTL-2" });
+    writeSignal(orchDir, "CTL-1", "plan", { worktreePath: "/wt/CTL-1" });
+    writeSignal(orchDir, "CTL-2", "plan", { worktreePath: "/wt/CTL-2" });
     const dispatched = [];
     const events = [];
     const res = reconcileBootResume({
@@ -331,7 +335,7 @@ describe("reconcileBootResume", () => {
 
   test("skip-when-live: a ticket WITH a live bg worker is never dispatched", () => {
     writeMaxParallel(orchDir, 3);
-    writeSignal(orchDir, "CTL-LIVE", "implement", { worktreePath: "/wt/CTL-LIVE" });
+    writeSignal(orchDir, "CTL-LIVE", "plan", { worktreePath: "/wt/CTL-LIVE" });
     const dispatched = [];
     const res = reconcileBootResume({
       orchDir,
@@ -349,8 +353,8 @@ describe("reconcileBootResume", () => {
 
   test("dispatch failure is isolated: ticket B still attempted, failure counted, no throw", () => {
     writeMaxParallel(orchDir, 3);
-    writeSignal(orchDir, "CTL-A", "implement", { worktreePath: "/wt/CTL-A" });
-    writeSignal(orchDir, "CTL-B", "implement", { worktreePath: "/wt/CTL-B" });
+    writeSignal(orchDir, "CTL-A", "plan", { worktreePath: "/wt/CTL-A" });
+    writeSignal(orchDir, "CTL-B", "research", { worktreePath: "/wt/CTL-B" });
     const attempted = [];
     const events = [];
     const dispatch = (a) => {
@@ -374,7 +378,7 @@ describe("reconcileBootResume", () => {
 
   test("missing-signal safety: a reviveDispatch signal-missing return is a failure, not a throw", () => {
     writeMaxParallel(orchDir, 3);
-    writeSignal(orchDir, "CTL-1", "implement", { worktreePath: "/wt/CTL-1" });
+    writeSignal(orchDir, "CTL-1", "plan", { worktreePath: "/wt/CTL-1" });
     const res = reconcileBootResume({
       orchDir,
       report: { coldStart: true },
@@ -388,7 +392,7 @@ describe("reconcileBootResume", () => {
 
   test("a throwing reviveDispatch is contained and counted as a failure", () => {
     writeMaxParallel(orchDir, 3);
-    writeSignal(orchDir, "CTL-1", "implement", { worktreePath: "/wt/CTL-1" });
+    writeSignal(orchDir, "CTL-1", "plan", { worktreePath: "/wt/CTL-1" });
     const res = reconcileBootResume({
       orchDir,
       report: { coldStart: true },
@@ -413,7 +417,8 @@ describe("reconcileBootResume", () => {
   // fallback path.
   test("forwards resumeSession to reviveDispatch when resolveSession returns a UUID (CTL-690)", () => {
     writeMaxParallel(orchDir, 3);
-    writeSignal(orchDir, "CTL-1", "implement", {
+    // Uses 'plan' (cheap phase) so dispatch is not gated.
+    writeSignal(orchDir, "CTL-1", "plan", {
       worktreePath: "/wt/CTL-1",
       bg_job_id: "abc12345",
     });
@@ -437,7 +442,7 @@ describe("reconcileBootResume", () => {
     expect(calls[0]).toMatchObject({
       orchDir,
       ticket: "CTL-1",
-      phase: "implement",
+      phase: "plan",
       resumeSession: "uuid-1111",
     });
   });
@@ -445,7 +450,7 @@ describe("reconcileBootResume", () => {
   test("falls back to fresh dispatch (resumeSession=null) when resolveSession returns null (CTL-690)", () => {
     writeMaxParallel(orchDir, 3);
     // bg_job_id is recorded but the transcript is gone → resolveSession → null.
-    writeSignal(orchDir, "CTL-1", "implement", {
+    writeSignal(orchDir, "CTL-1", "research", {
       worktreePath: "/wt/CTL-1",
       bg_job_id: "nope9999",
     });
@@ -467,14 +472,14 @@ describe("reconcileBootResume", () => {
     expect(calls[0]).toMatchObject({
       orchDir,
       ticket: "CTL-1",
-      phase: "implement",
+      phase: "research",
       resumeSession: null,
     });
   });
 
   test("legacy signal with no bg_job_id skips resolveSession and falls back to fresh dispatch (CTL-690)", () => {
     writeMaxParallel(orchDir, 3);
-    writeSignal(orchDir, "CTL-1", "implement", {
+    writeSignal(orchDir, "CTL-1", "triage", {
       worktreePath: "/wt/CTL-1",
       bg_job_id: null,
     });
@@ -502,7 +507,7 @@ describe("reconcileBootResume", () => {
 
   test("a throwing resolveSession is contained and treated as unresumable (CTL-690)", () => {
     writeMaxParallel(orchDir, 3);
-    writeSignal(orchDir, "CTL-1", "implement", {
+    writeSignal(orchDir, "CTL-1", "plan", {
       worktreePath: "/wt/CTL-1",
       bg_job_id: "boom",
     });
@@ -528,15 +533,16 @@ describe("reconcileBootResume", () => {
 
   test("mixed batch: some resume, some fresh, all dispatch (CTL-690)", () => {
     writeMaxParallel(orchDir, 3);
-    writeSignal(orchDir, "CTL-A", "implement", {
+    // All cheap phases (plan/research/triage) so none are gated.
+    writeSignal(orchDir, "CTL-A", "plan", {
       worktreePath: "/wt/CTL-A",
       bg_job_id: "aaa",
     });
-    writeSignal(orchDir, "CTL-B", "implement", {
+    writeSignal(orchDir, "CTL-B", "research", {
       worktreePath: "/wt/CTL-B",
       bg_job_id: "bbb",
     });
-    writeSignal(orchDir, "CTL-C", "implement", {
+    writeSignal(orchDir, "CTL-C", "triage", {
       worktreePath: "/wt/CTL-C",
       bg_job_id: null,
     });
@@ -568,7 +574,8 @@ describe("reconcileBootResume", () => {
 describe("reconcileBootResume — turn-cap-exhausted (CTL-701)", () => {
   test("relaunches turn-cap-exhausted with --resume when session resolvable", () => {
     writeMaxParallel(orchDir, 3);
-    writeSignal(orchDir, "CTL-TCE", "implement", {
+    // Uses 'plan' (cheap phase) so dispatch is not gated by CTL-644.
+    writeSignal(orchDir, "CTL-TCE", "plan", {
       worktreePath: "/wt/CTL-TCE",
       bg_job_id: "tce-abc",
       status: "turn-cap-exhausted",
@@ -589,7 +596,7 @@ describe("reconcileBootResume — turn-cap-exhausted (CTL-701)", () => {
     expect(res.resumed).toBe(1);
     expect(calls[0]).toMatchObject({
       ticket: "CTL-TCE",
-      phase: "implement",
+      phase: "plan",
       resumeSession: "uuid-resume",
     });
   });
@@ -648,5 +655,163 @@ describe("selectBootResumeCandidates — needs-input guard (CTL-549)", () => {
     const out = selectBootResumeCandidates({ orchDir, agents: [], maxParallel: 4 });
     expect(out.map((c) => c.ticket)).not.toContain("CTL-1");
     expect(out.map((c) => c.ticket)).toContain("CTL-2");
+  });
+});
+
+// ─── CTL-644: isCheapPhase classifier ───
+
+describe("isCheapPhase (CTL-644)", () => {
+  test("returns true for cheap phases (triage, research, plan) and false for all expensive phases", () => {
+    expect(isCheapPhase("triage")).toBe(true);
+    expect(isCheapPhase("research")).toBe(true);
+    expect(isCheapPhase("plan")).toBe(true);
+
+    expect(isCheapPhase("implement")).toBe(false);
+    expect(isCheapPhase("verify")).toBe(false);
+    expect(isCheapPhase("review")).toBe(false);
+    expect(isCheapPhase("pr")).toBe(false);
+    expect(isCheapPhase("monitor-merge")).toBe(false);
+    expect(isCheapPhase("monitor-deploy")).toBe(false);
+    expect(isCheapPhase("remediate")).toBe(false);
+  });
+});
+
+// ─── CTL-644: reconcileBootResume cheap/expensive branching ───
+
+describe("reconcileBootResume — cheap/expensive classification (CTL-644)", () => {
+  // Shared cold-start report used across tests in this block.
+  const coldReport = { coldStart: true };
+
+  function makeDispatch(code = 0) {
+    const calls = [];
+    const fn = (...args) => { calls.push(args); return { code }; };
+    fn.calls = calls;
+    return fn;
+  }
+
+  function makeAppendEvent() {
+    const calls = [];
+    const fn = (...args) => { calls.push(args); return true; };
+    fn.calls = calls;
+    return fn;
+  }
+
+  test("cheap phases (triage/research/plan) auto-dispatch — reviveDispatch called, no pending marker", () => {
+    writeSignal(orchDir, "CTL-10", "triage", { worktreePath: "/wt/CTL-10" });
+    writeSignal(orchDir, "CTL-11", "research", { worktreePath: "/wt/CTL-11" });
+    writeSignal(orchDir, "CTL-12", "plan", { worktreePath: "/wt/CTL-12" });
+    writeMaxParallel(orchDir, 10);
+
+    const reviveDispatch = makeDispatch(0);
+    const appendEvent = makeAppendEvent();
+    const appendGatedEvent = makeAppendEvent();
+
+    const result = reconcileBootResume({
+      orchDir,
+      report: coldReport,
+      agents: [],
+      reviveDispatch,
+      dispatch: () => {},
+      appendEvent,
+      appendGatedEvent,
+      resolveSession: () => null,
+    });
+
+    expect(reviveDispatch.calls.length).toBe(3);
+    expect(result.dispatched).toBe(3);
+    expect(result.gated).toBe(0);
+
+    // No pending markers written for cheap phases
+    expect(existsSync(bootResumePendingPath(orchDir, "CTL-10"))).toBe(false);
+    expect(existsSync(bootResumePendingPath(orchDir, "CTL-11"))).toBe(false);
+    expect(existsSync(bootResumePendingPath(orchDir, "CTL-12"))).toBe(false);
+  });
+
+  test("expensive phases are gated — reviveDispatch not called, pending marker written, gated event emitted", () => {
+    writeSignal(orchDir, "CTL-20", "implement", { worktreePath: "/wt/CTL-20" });
+    writeSignal(orchDir, "CTL-21", "verify", { worktreePath: "/wt/CTL-21" });
+    writeSignal(orchDir, "CTL-22", "pr", { worktreePath: "/wt/CTL-22" });
+    writeMaxParallel(orchDir, 10);
+
+    const reviveDispatch = makeDispatch(0);
+    const appendGatedEvent = makeAppendEvent();
+
+    const result = reconcileBootResume({
+      orchDir,
+      report: coldReport,
+      agents: [],
+      reviveDispatch,
+      dispatch: () => {},
+      appendEvent: makeAppendEvent(),
+      appendGatedEvent,
+      resolveSession: () => null,
+    });
+
+    expect(reviveDispatch.calls.length).toBe(0);
+    expect(result.dispatched).toBe(0);
+    expect(result.gated).toBe(3);
+    expect(appendGatedEvent.calls.length).toBe(3);
+
+    // Pending markers written for each expensive ticket
+    expect(existsSync(bootResumePendingPath(orchDir, "CTL-20"))).toBe(true);
+    expect(existsSync(bootResumePendingPath(orchDir, "CTL-21"))).toBe(true);
+    expect(existsSync(bootResumePendingPath(orchDir, "CTL-22"))).toBe(true);
+  });
+
+  test("mixed set — cheap auto-dispatched, expensive gated, done phases skipped", () => {
+    writeSignal(orchDir, "CTL-30", "plan", { worktreePath: "/wt/CTL-30" });
+    writeSignal(orchDir, "CTL-31", "implement", { worktreePath: "/wt/CTL-31" });
+    // CTL-32 is at terminal done — selectBootResumeCandidates will skip it
+    writeSignal(orchDir, "CTL-32", "monitor-deploy", {
+      status: "done",
+      worktreePath: "/wt/CTL-32",
+    });
+    writeMaxParallel(orchDir, 10);
+
+    const reviveDispatch = makeDispatch(0);
+    const appendGatedEvent = makeAppendEvent();
+
+    const result = reconcileBootResume({
+      orchDir,
+      report: coldReport,
+      agents: [],
+      reviveDispatch,
+      dispatch: () => {},
+      appendEvent: makeAppendEvent(),
+      appendGatedEvent,
+      resolveSession: () => null,
+    });
+
+    expect(result.dispatched).toBe(1);
+    expect(result.gated).toBe(1);
+    expect(reviveDispatch.calls.length).toBe(1);
+    expect(existsSync(bootResumePendingPath(orchDir, "CTL-30"))).toBe(false);
+    expect(existsSync(bootResumePendingPath(orchDir, "CTL-31"))).toBe(true);
+  });
+
+  test("idempotent re-gate — second call with pending marker already present skips gated event", () => {
+    writeSignal(orchDir, "CTL-40", "review", { worktreePath: "/wt/CTL-40" });
+    writeMaxParallel(orchDir, 10);
+
+    const appendGatedEvent = makeAppendEvent();
+    const opts = {
+      orchDir,
+      report: coldReport,
+      agents: [],
+      reviveDispatch: makeDispatch(0),
+      dispatch: () => {},
+      appendEvent: makeAppendEvent(),
+      appendGatedEvent,
+      resolveSession: () => null,
+    };
+
+    // First call — marker created + event emitted
+    reconcileBootResume(opts);
+    expect(appendGatedEvent.calls.length).toBe(1);
+    expect(existsSync(bootResumePendingPath(orchDir, "CTL-40"))).toBe(true);
+
+    // Second call — marker already exists, no re-emit
+    reconcileBootResume({ ...opts, reviveDispatch: makeDispatch(0), appendGatedEvent });
+    expect(appendGatedEvent.calls.length).toBe(1); // still 1, not 2
   });
 });

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -63,7 +63,7 @@ import {
   readStalePrRescueConfig,
 } from "./stale-pr-rescue-timer.mjs";
 import { DEFAULTS as RESCUE_DEFAULTS } from "./stale-pr-rescue.mjs";
-import { reconcileBootResume } from "./boot-resume.mjs";
+import { reconcileBootResume, processApprovedResumes } from "./boot-resume.mjs";
 // CTL-665: the committed executionCore concurrency reader — imported directly
 // (not via the index.mjs barrel, mirroring the orphan-reaper-timer import) so
 // main() can resolve the slot-ceiling config once and thread it into the
@@ -434,6 +434,9 @@ export function startDaemon({
     // spawns a worker storm. Synchronous and inside the same try/catch so a throw
     // still triggers PID-file cleanup. A non-cold-start restart is a no-op.
     reconcileBoot({ orchDir, report, concurrency }); // CTL-665: config-first boot-resume ceiling
+    // CTL-644: dispatch any gated tickets that already have an approval sentinel on disk
+    // (operator may have dropped the sentinel while the daemon was down).
+    processApprovedResumes({ orchDir });
     // CTL-634: one shared TTL state cache. The monitor write-through populates
     // it on every state_changed event; the scheduler read path consults it
     // during out-of-set blocker hydration. A single instance threaded into

--- a/plugins/dev/scripts/execution-core/integration-ctl-701.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-701.test.mjs
@@ -12,10 +12,10 @@
 // Run: bun test plugins/dev/scripts/execution-core/integration-ctl-701.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { reconcileBootResume } from "./boot-resume.mjs";
+import { reconcileBootResume, bootResumePendingPath } from "./boot-resume.mjs";
 import { detectColdStart, classifyWorker } from "./recovery.mjs";
 import { reclaimDeadWorkIfPossible } from "./recovery.mjs";
 
@@ -95,9 +95,10 @@ describe("CTL-701 incident integration (2026-05-28 scenario)", () => {
     expect(coldReport.coldStart).toBe(true);
     expect(coldReport.epochSource).toBe("exec-core");
 
-    // reconcileBootResume should dispatch all 4 tickets
+    // CTL-644: all 4 fixture phases (pr, pr, monitor-deploy, implement) are expensive →
+    // gated behind operator approval, NOT auto-dispatched on cold start.
     const dispatched = [];
-    const events = [];
+    const gatedEvents = [];
     const res = reconcileBootResume({
       orchDir,
       report: { coldStart: true },
@@ -106,20 +107,22 @@ describe("CTL-701 incident integration (2026-05-28 scenario)", () => {
         dispatched.push({ ticket: a.ticket, phase: a.phase });
         return { code: 0 };
       },
-      resolveSession: () => null, // no resume UUIDs available
-      appendEvent: (e) => events.push(e),
+      resolveSession: () => null,
+      appendEvent: () => {},
+      appendGatedEvent: (e) => gatedEvents.push(e),
     });
 
-    expect(res.dispatched).toBe(4);
+    // All 4 are expensive phases — gated, not auto-dispatched.
+    expect(res.dispatched).toBe(0);
+    expect(res.gated).toBe(4);
     expect(res.failed).toBe(0);
+    expect(dispatched).toHaveLength(0);
+    expect(gatedEvents).toHaveLength(4);
 
-    const tickets = dispatched.map((d) => d.ticket).sort();
-    expect(tickets).toEqual(["CTL-A", "CTL-B", "CTL-C", "CTL-D"]);
-
-    // Monitor-deploy and turn-cap-exhausted must be in the dispatch list
-    const phases = Object.fromEntries(dispatched.map((d) => [d.ticket, d.phase]));
-    expect(phases["CTL-C"]).toBe("monitor-deploy");
-    expect(phases["CTL-D"]).toBe("implement");
+    // Pending markers exist for all 4 tickets
+    for (const ticket of ["CTL-A", "CTL-B", "CTL-C", "CTL-D"]) {
+      expect(existsSync(bootResumePendingPath(orchDir, ticket))).toBe(true);
+    }
   });
 
   test("per-tick reclaim sweep does NOT short-circuit monitor-deploy or turn-cap-exhausted", () => {

--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -16,7 +16,7 @@
 //     dispatch cool-down rationale in scheduler.mjs::dispatchCooldownPath and
 //     memory project_scheduler_marker_under_workers_excludes_ticket).
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { log } from "./config.mjs";
 
@@ -37,8 +37,14 @@ import { log } from "./config.mjs";
 // marker so the next tick retries — CTL-558's recovery contract. CTL-638 pairs
 // this with the escalation cool-down below to break the per-tick storm even
 // when the transient-failure path keeps re-attempting the write.
+// labelMarkerBase — shared path prefix for the once-marker files used by
+// labelOnce and clearStalledLabel (single source of truth for the marker path).
+function labelMarkerBase(orchDir, ticket, label) {
+  return join(orchDir, "workers", ticket, `.linear-label-${label}`);
+}
+
 export function labelOnce(orchDir, ticket, label, writeStatus) {
-  const base = join(orchDir, "workers", ticket, `.linear-label-${label}`);
+  const base = labelMarkerBase(orchDir, ticket, label);
   if (existsSync(`${base}.applied`) || existsSync(`${base}.skipped`)) return;
   try {
     const res = writeStatus.applyLabel({ ticket, label });
@@ -58,6 +64,39 @@ export function labelOnce(orchDir, ticket, label, writeStatus) {
       { ticket, label, err: err.message },
       "scheduler: label write-back threw — continuing tick"
     );
+  }
+}
+
+// ─── CTL-646: clearStalledLabel — inverse of labelOnce ───
+//
+// Removes the Linear label AND deletes the once-marker(s) so the apply guard
+// re-arms. Both must happen together: deleting the marker without clearing the
+// label would let the daemon believe the label is gone while Linear still shows
+// it; clearing the label without deleting the marker would leave labelOnce
+// permanently disarmed. Best-effort and never throws (mirrors labelOnce).
+// The marker is deleted ONLY on a confirmed removal so a transient API failure
+// is retried next tick.
+export function clearStalledLabel(orchDir, ticket, label, writeStatus) {
+  const base = labelMarkerBase(orchDir, ticket, label);
+  try {
+    const res = writeStatus.removeLabel(ticket, label);
+    const finalize = (r) => {
+      // undefined (test stub) treated as success; otherwise require removed:true.
+      if (r === undefined || r?.removed) {
+        for (const suffix of [".applied", ".skipped"]) {
+          const p = `${base}${suffix}`;
+          if (existsSync(p)) { try { unlinkSync(p); } catch { /* best-effort */ } }
+        }
+      }
+    };
+    if (res && typeof res.then === "function") {
+      res.then(finalize).catch((err) =>
+        log.warn({ ticket, label, err: err?.message }, "clearStalledLabel: removeLabel rejected — continuing"));
+    } else {
+      finalize(res);
+    }
+  } catch (err) {
+    log.warn({ ticket, label, err: err.message }, "clearStalledLabel: threw — continuing tick");
   }
 }
 

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -8,6 +8,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   labelOnce,
+  clearStalledLabel,
   inEscalationCooldown,
   recordEscalation,
   escalationCooldownPath,
@@ -206,5 +207,83 @@ describe("inEscalationCooldown / recordEscalation", () => {
     expect(inEscalationCooldown(orchDir, "CTL-9", "monitor-merge", t0)).toBe(true);
     expect(inEscalationCooldown(orchDir, "CTL-11", "pr", t0)).toBe(false);
     expect(inEscalationCooldown(orchDir, "CTL-9", "triage", t0)).toBe(false);
+  });
+});
+
+// ─── clearStalledLabel (CTL-646) ───
+
+describe("clearStalledLabel", () => {
+  test("clears label + deletes .applied marker together", () => {
+    const workerDir = join(orchDir, "workers", "CTL-1");
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, ".linear-label-needs-human.applied"), "");
+    const removed = [];
+    const ws = { removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; } };
+
+    clearStalledLabel(orchDir, "CTL-1", "needs-human", ws);
+
+    expect(removed).toHaveLength(1);
+    expect(removed[0]).toEqual({ t: "CTL-1", l: "needs-human" });
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(false);
+  });
+
+  test("also deletes the .skipped marker", () => {
+    const workerDir = join(orchDir, "workers", "CTL-1");
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, ".linear-label-needs-human.skipped"), "");
+    const ws = { removeLabel: () => ({ removed: true }) };
+
+    clearStalledLabel(orchDir, "CTL-1", "needs-human", ws);
+
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.skipped"))).toBe(false);
+  });
+
+  test("no-op when no marker present — still calls removeLabel, does not throw", () => {
+    mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });
+    const removed = [];
+    const ws = { removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; } };
+
+    expect(() => clearStalledLabel(orchDir, "CTL-1", "needs-human", ws)).not.toThrow();
+    expect(removed).toHaveLength(1);
+  });
+
+  test("marker retained on failed removal (removed: false)", () => {
+    const workerDir = join(orchDir, "workers", "CTL-1");
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, ".linear-label-needs-human.applied"), "");
+    const ws = { removeLabel: () => ({ removed: false, reason: "transient" }) };
+
+    clearStalledLabel(orchDir, "CTL-1", "needs-human", ws);
+
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(true);
+  });
+
+  test("never throws when removeLabel throws — marker kept", () => {
+    const workerDir = join(orchDir, "workers", "CTL-1");
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, ".linear-label-needs-human.applied"), "");
+    const ws = { removeLabel: () => { throw new Error("network"); } };
+
+    expect(() => clearStalledLabel(orchDir, "CTL-1", "needs-human", ws)).not.toThrow();
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(true);
+  });
+
+  test("apply → clear → re-apply cycle re-arms the labelOnce guard", () => {
+    const workerDir = join(orchDir, "workers", "CTL-1");
+    mkdirSync(workerDir, { recursive: true });
+
+    // Apply
+    labelOnce(orchDir, "CTL-1", "needs-human", { applyLabel: () => ({ applied: true }) });
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(true);
+
+    // Clear
+    clearStalledLabel(orchDir, "CTL-1", "needs-human", { removeLabel: () => ({ removed: true }) });
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(false);
+
+    // Re-apply
+    let applied = 0;
+    labelOnce(orchDir, "CTL-1", "needs-human", { applyLabel: () => { applied++; return { applied: true }; } });
+    expect(applied).toBe(1);
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(true);
   });
 });

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -268,6 +268,56 @@ describe("clearStalledLabel", () => {
     expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(true);
   });
 
+  // CTL-639 verify: the async (Promise) branch is what the real Linearis
+  // removeLabel actually returns — exercise it directly, not just the sync stub.
+  test("async removeLabel resolving { removed: true } deletes the marker", async () => {
+    const workerDir = join(orchDir, "workers", "CTL-1");
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, ".linear-label-needs-human.applied"), "");
+    let resolveFn;
+    const pending = new Promise((res) => { resolveFn = res; });
+    const ws = { removeLabel: () => pending };
+
+    clearStalledLabel(orchDir, "CTL-1", "needs-human", ws);
+    // Marker still present until the promise settles.
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(true);
+
+    resolveFn({ removed: true });
+    await pending;
+    await Promise.resolve(); // flush the .then(finalize) microtask
+
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(false);
+  });
+
+  test("async removeLabel rejecting does not throw and retains the marker", async () => {
+    const workerDir = join(orchDir, "workers", "CTL-1");
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, ".linear-label-needs-human.applied"), "");
+    let rejectFn;
+    // Deferred so clearStalledLabel's .catch attaches before the rejection
+    // fires — avoids a spurious unhandled-rejection flag.
+    const pending = new Promise((_res, rej) => { rejectFn = rej; });
+    const ws = { removeLabel: () => pending };
+
+    expect(() => clearStalledLabel(orchDir, "CTL-1", "needs-human", ws)).not.toThrow();
+    rejectFn(new Error("network"));
+    await pending.catch(() => {}); // settle the rejection
+    await Promise.resolve();
+
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(true);
+  });
+
+  test("removeLabel returning undefined is treated as success — marker deleted", () => {
+    const workerDir = join(orchDir, "workers", "CTL-1");
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, ".linear-label-needs-human.applied"), "");
+    const ws = { removeLabel: () => undefined };
+
+    clearStalledLabel(orchDir, "CTL-1", "needs-human", ws);
+
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(false);
+  });
+
   test("apply → clear → re-apply cycle re-arms the labelOnce guard", () => {
     const workerDir = join(orchDir, "workers", "CTL-1");
     mkdirSync(workerDir, { recursive: true });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -411,6 +411,24 @@ export function defaultAppendBootResumeEvent({ phase, ticket, orchId }) {
   );
 }
 
+// defaultAppendBootResumeGatedEvent — phase.<phase>.boot-resume-gated.<ticket>.
+// CTL-644: emitted once when an expensive phase is gated behind operator approval.
+// Deliberately distinct from boot-resume so the broker ignores it (audit-only,
+// like defaultAppendBootResumeEvent). Exported so boot-resume.mjs imports it as
+// the default appendGatedEvent seam.
+export function defaultAppendBootResumeGatedEvent({ phase, ticket, orchId }) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase,
+      ticket,
+      orchId,
+      action: "boot-resume-gated",
+      reason: "cold-start-expensive-phase-awaiting-approval",
+    }),
+    "boot-resume-gated",
+  );
+}
+
 // CTL-587: three new audit-only event helpers. The broker's PHASE_EVENT_PATTERN
 // in router.mjs only matches complete|failed|turn-cap-exhausted|skipped, so
 // revive/escalated/revive-suppressed events are deliberately ignored by the

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -126,6 +126,7 @@ import { isLinearTerminal } from "./terminal-state.mjs";
 // scheduler.mjs already imports reclaimDeadWorkIfPossible from recovery.mjs —
 // a cycle. label-guard.mjs is the leaf module both can import.
 import { labelOnce, clearStalledLabel } from "./label-guard.mjs";
+import { processApprovedResumes } from "./boot-resume.mjs"; // CTL-644: per-tick approval poll
 import { countReapOutcomes } from "./reaper-metrics.mjs";
 import { log, getEligibleDir, getEventLogPath, getHostName, getClusterHosts } from "./config.mjs";
 import { defaultCheckSequencing } from "./sequencing.mjs"; // CTL-537
@@ -1934,6 +1935,12 @@ export function schedulerTick(
       );
     }
   }
+
+  // CTL-644: per-tick approval poll — dispatch any gated tickets that now have an
+  // approval sentinel. Cheap (directory scan + existsSync per worker); no API calls
+  // unless a dispatch fires. Runs before the reclaim sweep so an approved ticket
+  // can advance in the same tick it's dispatched.
+  processApprovedResumes({ orchDir });
 
   // (0) Reclaim-dead-work sweep (CTL-574) — close phase signals whose bg worker
   // died but whose work was committed before the death. Runs BEFORE the

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -125,7 +125,7 @@ import { isLinearTerminal } from "./terminal-state.mjs";
 // labelOnce here would force recovery.mjs → scheduler.mjs to import it, but
 // scheduler.mjs already imports reclaimDeadWorkIfPossible from recovery.mjs —
 // a cycle. label-guard.mjs is the leaf module both can import.
-import { labelOnce } from "./label-guard.mjs";
+import { labelOnce, clearStalledLabel } from "./label-guard.mjs";
 import { countReapOutcomes } from "./reaper-metrics.mjs";
 import { log, getEligibleDir, getEventLogPath, getHostName, getClusterHosts } from "./config.mjs";
 import { defaultCheckSequencing } from "./sequencing.mjs"; // CTL-537
@@ -3042,6 +3042,8 @@ export function schedulerTick(
       terminalDoneOnce(orchDir, ticket, writeStatus, emitStateWrite);
       // CTL-582: the ticket reached terminal Done — tear down its worktree.
       teardownWorktreeOnce(orchDir, ticket, teardownWorktree);
+      // CTL-646: terminal Done unconditionally clears needs-human (belt + teardown path).
+      clearStalledLabel(orchDir, ticket, "needs-human", writeStatus);
     }
     // CTL-758: reconcile backstop — re-Done a merged ticket whose Linear state
     // drifted back to non-terminal (a late echo). Gated by the .terminal-done.applied
@@ -3054,6 +3056,14 @@ export function schedulerTick(
     });
     if (Object.values(signals).some((s) => s === "stalled")) {
       labelOnce(orchDir, ticket, "needs-human", writeStatus);
+    } else {
+      // CTL-646: no phase stalled → clear the ratchet if the marker exists.
+      // Guard on marker presence so a no-stall, no-marker tick fires zero
+      // removeLabel API calls (steady-state-zero-writes invariant).
+      const base = join(orchDir, "workers", ticket, ".linear-label-needs-human");
+      if (existsSync(`${base}.applied`) || existsSync(`${base}.skipped`)) {
+        clearStalledLabel(orchDir, ticket, "needs-human", writeStatus);
+      }
     }
     // CTL-695: nominate terminal workers for reaping once. Covers the gaps the
     // happy-path emitPredecessorReap (advance-success only) never reaches:

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -3598,6 +3598,49 @@ describe("schedulerTick — label write-back (CTL-558)", () => {
     schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
     expect(calls).toBe(0);
   });
+
+  // CTL-646: stall→advance and terminal Done clear the needs-human label
+
+  test("clears needs-human when no phase is stalled and .applied marker exists (CTL-646)", () => {
+    writeSignal("CTL-14", "implement", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeFileSync(join(orchDir, "workers", "CTL-14", ".linear-label-needs-human.applied"), "");
+    const removed = [];
+    const writeStatus = {
+      ...noWrites(),
+      applyLabel: () => ({}),
+      removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; },
+    };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    expect(removed).toContainEqual(expect.objectContaining({ t: "CTL-14", l: "needs-human" }));
+  });
+
+  test("still-stalled does not call removeLabel — labelOnce only (CTL-646)", () => {
+    writeSignal("CTL-15", "implement", "stalled");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const removed = [];
+    const writeStatus = {
+      ...noWrites(),
+      applyLabel: () => ({}),
+      removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; },
+    };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    expect(removed.filter((r) => r.t === "CTL-15")).toHaveLength(0);
+  });
+
+  test("terminal Done clears needs-human unconditionally (CTL-646)", () => {
+    writeSignal("CTL-16", "monitor-deploy", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const removed = [];
+    const writeStatus = {
+      ...noWrites(),
+      applyLabel: () => ({}),
+      applyTerminalDone: () => ({ applied: true }),
+      removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; },
+    };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    expect(removed).toContainEqual(expect.objectContaining({ t: "CTL-16", l: "needs-human" }));
+  });
 });
 
 // ── CTL-582: worktree teardown on terminal Done ──


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-08T06:25:00Z -->
<!-- Last updated: 2026-06-08T06:25:00Z -->
<!-- PR: #1481 -->
<!-- Previous commits: 2b8aea3871f9a5f68f39d6cadaba4c69ea069e18,55704324807ae33036cc92a3586d3b0ffe4a8311,d46a132284d0199da8387acc15f84c9e6c39498a,d7305f28f9649c3249551cd79b1d2e78431d21f7 -->

## Summary

Two complementary sub-tickets shipped together to harden the execution-core daemon's cold-start recovery:

- **CTL-646 — `needs-human` label lifecycle**: adds `clearStalledLabel` (the inverse of `labelOnce`) and wires three clear triggers in the scheduler's step-3 terminal sweep — ticket done, stall→advance, and needs-input→unstalled — so the `needs-human` Linear label is removed automatically when the condition clears rather than accumulating forever.
- **CTL-644 — Auto-cheap / gate-expensive cold-start policy**: splits `reconcileBootResume` so cheap phases (triage/research/plan) auto-resume on cold start while expensive phases (implement/verify/review/pr/monitor-merge/monitor-deploy/remediate) gate behind an operator greenlight file sentinel. Adds `processApprovedResumes` polled each daemon tick and at boot to dispatch greenlighted workers.

## Changes Made

### execution-core — label-guard.mjs (CTL-646)
- Add `clearStalledLabel()` export — inverse of `labelOnce`: removes the Linear label AND deletes the `.applied`/`.skipped` markers so the apply guard re-arms on the next stall cycle.
- Extract `labelMarkerBase()` helper — single source of truth for the marker path used by both `labelOnce` and `clearStalledLabel`.

### execution-core — scheduler.mjs (CTL-646 + CTL-644)
- Wire three `clearStalledLabel` triggers in the step-3 sweep: stall→advance (else-branch, guarded by marker presence), terminal Done (unconditional clear after teardown), and needs-input→unstalled.
- Import and call `processApprovedResumes` once per tick near the step-0 reclaim sweep so greenlights dropped while the daemon was down are honored within one tick.

### execution-core — boot-resume.mjs (CTL-644)
- Add `isCheapPhase` / `CHEAP_RESUME_PHASES` classifier (triage, research, plan).
- Add `bootResumePendingPath` / `bootResumeApprovedPath` helpers for the greenlight file sentinel scheme.
- Branch `reconcileBootResume` candidate loop on `isCheapPhase`: cheap → auto-dispatch; expensive → write pending marker + emit gated audit event.
- Add `processApprovedResumes` — scans `workers/` for `boot-resume.pending` + `boot-resume.approved` sentinels, dispatches via `reviveDispatch`, clears both on success. Uses `readdirSync({ withFileTypes: true })` + `.isDirectory()` to skip stray files safely.

### execution-core — recovery.mjs (CTL-644)
- Add `defaultAppendBootResumeGatedEvent` — structured audit event (`phase.<phase>.boot-resume-gated.<ticket>`) for gated cold-start decisions.

### execution-core — daemon.mjs (CTL-644)
- Call `processApprovedResumes` after `reconcileBoot` so greenlights that arrived while the daemon was down are processed immediately on startup.

### docs/orchestrator-overview.md
- Document the cheap/expensive phase classification table and the operator greenlight `touch` command syntax.

### Security hardening
- `processApprovedResumes` uses `readdirSync({ withFileTypes: true })` + `.isDirectory()` filter so stray files at the `workers/` level (lock files, temp files) are never passed as ticket names to the path helpers. Addresses a MEDIUM non-directory iteration finding from the security scan.

## How to Verify It

- [x] `bun test plugins/dev/scripts/execution-core/label-guard.test.mjs` — 24 pass, 0 fail ✅
- [x] `bun test plugins/dev/scripts/execution-core/boot-resume-approval.test.mjs` — 8 pass, 0 fail ✅
- [x] `bun test plugins/dev/scripts/execution-core/boot-resume.test.mjs` — 42 pass, 0 fail ✅
- [x] `bun test plugins/dev/scripts/execution-core/integration-ctl-701.test.mjs` — 2 pass, 0 fail ✅
- [x] `bun test plugins/dev/scripts/execution-core/scheduler.test.mjs` — 336 pass, 44 fail (pre-existing failures confirmed on `origin/main` via `git stash` baseline — unrelated to CTL-639) ✅
- [ ] Manually verify greenlight flow: start daemon, observe expensive-phase gated event in event log, `touch workers/<TICKET>/boot-resume.approved`, verify next tick dispatches the worker.

## Changelog Entry

### catalyst-dev (minor bump)

**feat: CTL-646 `needs-human` label lifecycle — `clearStalledLabel` clears Linear label on stall-advance, terminal-done, and needs-input-cleared triggers**

**feat: CTL-644 auto-cheap/gate-expensive cold-start recovery — cheap phases (triage/research/plan) auto-resume; expensive phases gate on operator greenlight sentinel**

## Related Issues/PRs

- Fixes https://linear.app/adva/issue/CTL-639

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-644
skip CTL-646
