### PR TITLE
fix(dev): CTL-834 cool-down held-label converger + classify exclusive-group label conflicts

### DIFF
--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -28,10 +28,13 @@ import { log } from "./config.mjs";
 // record terminal outcomes:
 //
 //   .applied — applyLabel returned applied:true. Happy path.
-//   .skipped — applyLabel returned reason:"missing-label". The workspace lacks
-//              the label; retrying inside this daemon's lifetime would just
-//              storm the Linear API (CTL-585). An operator creates the label
-//              in the Linear UI and deletes this marker to re-arm the apply.
+//   .skipped — applyLabel returned an UNRECOVERABLE reason ("missing-label": the
+//              workspace lacks the label; "exclusive-conflict" (CTL-834): the
+//              label's exclusive-group sibling is already on the ticket). Either
+//              way the add can never land this run, so retrying every tick would
+//              just storm the Linear API (CTL-585). An operator fixes the cause
+//              (create the label / clear the sibling) and deletes this marker to
+//              re-arm the apply.
 //
 // Transient failures (reason:"rate-limited", "transient", undefined) write no
 // marker so the next tick retries — CTL-558's recovery contract. CTL-638 pairs
@@ -43,6 +46,12 @@ function labelMarkerBase(orchDir, ticket, label) {
   return join(orchDir, "workers", ticket, `.linear-label-${label}`);
 }
 
+// UNRECOVERABLE_LABEL_REASONS — applyLabel reasons that can never land this
+// daemon lifetime (CTL-834); labelOnce writes its .skipped marker for these to
+// stop the per-tick retry storm. "missing-label": the workspace lacks the label;
+// "exclusive-conflict": the label's exclusive-group sibling is already present.
+const UNRECOVERABLE_LABEL_REASONS = new Set(["missing-label", "exclusive-conflict"]);
+
 export function labelOnce(orchDir, ticket, label, writeStatus) {
   const base = labelMarkerBase(orchDir, ticket, label);
   if (existsSync(`${base}.applied`) || existsSync(`${base}.skipped`)) return;
@@ -52,11 +61,11 @@ export function labelOnce(orchDir, ticket, label, writeStatus) {
     // the once-semantics stay testable without a real result.
     if (res === undefined || res?.applied) {
       writeFileSync(`${base}.applied`, "");
-    } else if (res?.reason === "missing-label") {
+    } else if (UNRECOVERABLE_LABEL_REASONS.has(res?.reason)) {
       writeFileSync(`${base}.skipped`, "");
       log.warn(
-        { ticket, label },
-        "scheduler: label missing in workspace — skipping retries for this run"
+        { ticket, label, reason: res.reason },
+        "scheduler: label unrecoverable (missing / exclusive-conflict) — skipping retries for this run"
       );
     }
   } catch (err) {

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -74,6 +74,34 @@ describe("labelOnce", () => {
     );
   });
 
+  test("CTL-834: exclusive-conflict reason → writes .skipped marker (no retry storm)", () => {
+    const ws = { applyLabel: recorder({ applied: false, reason: "exclusive-conflict" }) };
+    mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });
+
+    labelOnce(orchDir, "CTL-1", "needs-human", ws);
+
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".linear-label-needs-human.skipped"))).toBe(
+      true
+    );
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".linear-label-needs-human.applied"))).toBe(
+      false
+    );
+  });
+
+  test("transient reason → NO marker (retries next tick)", () => {
+    const ws = { applyLabel: recorder({ applied: false, reason: "transient" }) };
+    mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });
+
+    labelOnce(orchDir, "CTL-1", "needs-human", ws);
+
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".linear-label-needs-human.skipped"))).toBe(
+      false
+    );
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".linear-label-needs-human.applied"))).toBe(
+      false
+    );
+  });
+
   test("rate-limited (any non-applied, non-missing-label) → no marker, next tick retries", () => {
     const ws = { applyLabel: recorder({ applied: false, reason: "rate-limited" }) };
     mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -194,14 +194,19 @@ export function applyTerminalDone({ ticket, resolveRepoRoot, exec, cache }) {
 //                     Unrecoverable inside one daemon lifetime — callers
 //                     (scheduler.labelOnce) write a .skipped marker and do not
 //                     retry it this run.
+//   "exclusive-conflict" — CTL-834: the label is in an exclusive group whose
+//                     sibling is already on the ticket. Unrecoverable while the
+//                     sibling is present — callers back off (labelOnce writes
+//                     .skipped; convergeHeldLabel arms a cool-down).
 //   "rate-limited"  — Linear write rate-cap hit; retry next tick.
 //   "verify-failed" — write exited 0 but the read-back is missing the label
 //                     (the silent-success case) OR the read-back exec failed;
 //                     retry next tick.
 //   "transient"     — every other failure (network, spawn error, unknown
 //                     stderr, exec threw); retry next tick.
-// All reasons except "missing-label" are retryable next tick: labelOnce only
-// writes its .applied marker when applied: true, so a failure naturally retries.
+// Unrecoverable reasons ("missing-label", "exclusive-conflict") are NOT retried;
+// every other reason is retryable next tick (labelOnce only writes its .applied
+// marker when applied: true, so a failure naturally retries).
 export function applyLabel({ ticket, label, exec = defaultExec }) {
   try {
     const writeRes = exec("linearis", [
@@ -500,10 +505,17 @@ export function applyBlockedByRelation({ ticket, blockedBy, exec = defaultExec }
 //     stops the per-tick retry storm. (Observed on ADV tickets when the daemon
 //     orchestrates a team whose labels share names with the resolver's default
 //     team but have different UUIDs.)
-function classifyLabelFailure(stderr) {
+//   - "not exclusive child" (CTL-834): the label belongs to an EXCLUSIVE Linear
+//     label group and a SIBLING from that group is already on the ticket, so the
+//     add can never land while the sibling is present. Its own unrecoverable
+//     reason ("exclusive-conflict") so callers back off instead of re-issuing it
+//     every ~22s tick (observed: 218 fails / 44 min on the held-label converger —
+//     CTL-838 blocked↔needs-human, ADV-1295 blocked↔waiting).
+export function classifyLabelFailure(stderr) {
   const s = String(stderr ?? "");
   if (s.includes("not found")) return "missing-label";
   if (s.includes("incorrect team")) return "missing-label";
+  if (s.includes("not exclusive")) return "exclusive-conflict";
   if (s.includes("Rate limit")) return "rate-limited";
   return "transient";
 }

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -11,6 +11,7 @@ import {
   applyEstimate,
   applyAssignee,
   teamOf,
+  classifyLabelFailure,
 } from "./linear-write.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 
@@ -470,6 +471,35 @@ describe("applyLabel", () => {
     };
     const r = applyLabel({ ticket: "CTL-1", label: "triaged", exec });
     expect(r).toEqual({ applied: false, reason: "transient" });
+  });
+  test("CTL-834: an exclusive-group conflict stderr → reason:'exclusive-conflict'", () => {
+    // The held-label converger adds `blocked` while `needs-human`/`waiting`
+    // (same exclusive group) is present — Linear rejects with this exact form.
+    const exec = () => ({
+      code: 1,
+      stdout: "",
+      stderr:
+        "GraphQL request failed: LabelIds not exclusive child labels - blocked is in an exclusive group already represented.",
+    });
+    const r = applyLabel({ ticket: "CTL-838", label: "blocked", exec });
+    expect(r).toEqual({ applied: false, reason: "exclusive-conflict" });
+  });
+});
+
+// CTL-834: classifyLabelFailure — stderr → tagged reason. Exported so the new
+// exclusive-conflict mapping (and the existing unrecoverable cases) are pinned
+// directly, independent of applyLabel's read-back wrapper.
+describe("classifyLabelFailure (CTL-834)", () => {
+  test("'not exclusive child' → 'exclusive-conflict'", () => {
+    expect(classifyLabelFailure("LabelIds not exclusive child labels")).toBe("exclusive-conflict");
+    expect(classifyLabelFailure("... not exclusive ...")).toBe("exclusive-conflict");
+  });
+  test("existing mappings are unchanged", () => {
+    expect(classifyLabelFailure('Label "x" not found')).toBe("missing-label");
+    expect(classifyLabelFailure("LabelIds for incorrect team")).toBe("missing-label");
+    expect(classifyLabelFailure("Rate limit exceeded")).toBe("rate-limited");
+    expect(classifyLabelFailure("anything else")).toBe("transient");
+    expect(classifyLabelFailure(undefined)).toBe("transient");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1174,13 +1174,27 @@ function unmetBlockersFor(candidateId, edges, poolById, blockerStates) {
 // convergeHeldLabel — apply/remove the held-indicator labels (blocked/waiting)
 // on a DIFF so a steady-state held tick makes ZERO Linear writes (CTL-755
 // ADDENDUM). `current` is the ticket's fresh label set (from fetchRelations);
-// `desired` is one of HELD_LABEL_BLOCKED | HELD_LABEL_WAITING | null. Writes are
-// best-effort via safeWrite — applyLabel adds, removeLabel removes. Returns the
-// number of write calls issued (0 == idempotent no-op) so tests can pin the
-// steady-state-zero-writes invariant. removeLabel is async (linear-write.mjs:175)
-// but called fire-and-forget inside safeWrite — the write still happens and its
-// own try/catch swallows any failure, matching the best-effort convention.
-function convergeHeldLabel(ticket, current, desired, writeStatus) {
+// `desired` is one of HELD_LABEL_BLOCKED | HELD_LABEL_WAITING | null.
+//
+// CTL-834: the apply is COOL-DOWN-GATED. The prior version re-issued the
+// remove+apply every ~22s tick; when the apply failed UNRECOVERABLY (the desired
+// label is in an exclusive Linear group whose sibling is already on the ticket —
+// "not exclusive child"), the label never landed, the diff was never satisfied,
+// and the write re-fired forever (observed: 218 fails / 44 min, burning the
+// Linear write quota — CTL-838 blocked↔needs-human, ADV-1295 blocked↔waiting).
+// Now: if a recent apply of `desired` failed unrecoverably, inLabelCooldown
+// short-circuits the whole convergence until LABEL_COOLDOWN_MS elapses
+// (time-boxed, so it self-heals once the conflict clears — mirrors the CTL-624
+// dispatch cool-down). The apply's {applied, reason} is captured directly (NOT
+// via the result-discarding safeWrite) so the cool-down can arm. Returns the
+// number of write calls issued (0 == idempotent no-op OR cooled-down). `orchDir`/
+// `now` are optional so legacy callers / bare unit ticks keep the prior
+// best-effort-every-tick behavior (the cool-down simply never arms).
+export function convergeHeldLabel(ticket, current, desired, writeStatus, { orchDir, now = Date.now } = {}) {
+  // CTL-834: back off if a recent apply of `desired` failed unrecoverably.
+  if (orchDir && desired && inLabelCooldown(orchDir, ticket, desired, now())) {
+    return 0;
+  }
   const have = new Set(current ?? []);
   let writes = 0;
   // Remove any held label that is present but not desired.
@@ -1190,12 +1204,53 @@ function convergeHeldLabel(ticket, current, desired, writeStatus) {
       writes++;
     }
   }
-  // Apply the desired label if it is not already present.
+  // Apply the desired label if it is not already present. Capture the result so
+  // an unrecoverable failure arms the cool-down (applyLabel is sync + never
+  // throws, returning {applied, reason}; a throw from a test fake is swallowed).
   if (desired && !have.has(desired)) {
-    safeWrite(() => writeStatus.applyLabel({ ticket, label: desired }), { ticket, phase: "admission" });
+    let res;
+    try {
+      res = writeStatus.applyLabel({ ticket, label: desired });
+    } catch (err) {
+      log.warn({ ticket, label: desired, err: err.message }, "convergeHeldLabel: applyLabel threw — continuing tick");
+    }
     writes++;
+    if (orchDir && res && res.applied === false && UNRECOVERABLE_LABEL_REASONS.has(res.reason)) {
+      recordLabelCooldown(orchDir, ticket, desired, now());
+      log.warn(
+        { ticket, label: desired, reason: res.reason },
+        "ctl-834: held-label apply unrecoverable — backing off (cool-down)"
+      );
+    }
   }
   return writes;
+}
+
+// UNRECOVERABLE_LABEL_REASONS — applyLabel reasons that can never land this
+// daemon lifetime, so convergeHeldLabel arms a cool-down instead of re-issuing
+// the write every tick (CTL-834). Mirrors label-guard.labelOnce's .skipped set.
+const UNRECOVERABLE_LABEL_REASONS = new Set(["missing-label", "exclusive-conflict"]);
+
+// CTL-834 held-label apply cool-down — the same time-boxed-marker shape as the
+// CTL-624 dispatch cool-down: a per-(ticket,label) JSON marker carrying failedAt,
+// kept OUTSIDE workers/<T>/ so it survives worker-dir GC (see dispatchCooldownPath
+// + memory project_scheduler_marker_under_workers_excludes_ticket). The window
+// self-heals so an exclusive conflict that later clears lets the label re-apply.
+export function labelCooldownPath(orchDir, ticket, label) {
+  return join(orchDir, ".label-cooldowns", `${ticket}-${label}.json`);
+}
+function inLabelCooldown(orchDir, ticket, label, now) {
+  try {
+    const marker = JSON.parse(readFileSync(labelCooldownPath(orchDir, ticket, label), "utf8"));
+    return typeof marker.failedAt === "number" && now - marker.failedAt < LABEL_COOLDOWN_MS;
+  } catch {
+    return false;
+  }
+}
+function recordLabelCooldown(orchDir, ticket, label, now) {
+  const p = labelCooldownPath(orchDir, ticket, label);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, JSON.stringify({ failedAt: now }));
 }
 
 // CTL-624: dispatch cool-down marker. Conceptually mirrors the labelOnce
@@ -2244,7 +2299,7 @@ export function schedulerTick(
           // Cycle member → owned by needs-human (labelOnce above). Clear any
           // stale held label so it doesn't double-signal, and drop its held
           // emit-state so a future non-cycle hold re-emits.
-          convergeHeldLabel(ticket, labelsByTicket.get(ticket), null, writeStatus);
+          convergeHeldLabel(ticket, labelsByTicket.get(ticket), null, writeStatus, { orchDir, now });
           lastHeldEmitState.delete(ticket);
           continue;
         }
@@ -2270,7 +2325,7 @@ export function schedulerTick(
         }
         // else: admitted → desired null → clear-on-pickup (both labels removed).
 
-        convergeHeldLabel(ticket, labelsByTicket.get(ticket), desired, writeStatus);
+        convergeHeldLabel(ticket, labelsByTicket.get(ticket), desired, writeStatus, { orchDir, now });
 
         if (desired) {
           // Only-on-state-change emission: skip if the same held class already
@@ -3126,6 +3181,9 @@ const TICK_DEBOUNCE_MS = Number(process.env.SCHEDULER_DEBOUNCE_MS) || 2_000;
 // (ticket,phase) to one attempt per window. Time-based (not a permanent
 // .skipped marker like labelOnce) so it self-heals once the artifact appears.
 const DISPATCH_COOLDOWN_MS = Number(process.env.SCHEDULER_DISPATCH_COOLDOWN_MS) || 60_000;
+// CTL-834: held-label apply cool-down window (convergeHeldLabel). Same default as
+// the dispatch cool-down; overridable for tests / quieter quota budgets.
+const LABEL_COOLDOWN_MS = Number(process.env.SCHEDULER_LABEL_COOLDOWN_MS) || 60_000;
 // CTL-713: permanent-failure cooldown. code=2 (prior_artifact_missing,
 // phase-agent-dispatch exit 2) is a structural refusal — back it off longer than
 // the 60s transient window. GC reaps the marker once the ticket leaves the eligible set.

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -65,6 +65,9 @@ import {
   buildGlobalRanking,
   // CTL-700 (Item A)
   readDispatchFailureReason,
+  // CTL-834: held-label apply cool-down
+  convergeHeldLabel,
+  labelCooldownPath,
 } from "./scheduler.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 import { fetchTicketsBatch } from "./linear-query.mjs"; // CTL-784: cache-reuse tests drive the real batch
@@ -7203,5 +7206,94 @@ describe("CTL-850 — HRW ownership + claim-on-dispatch (schedulerTick new-work)
     // A lost claim is NOT a dispatch failure, so NO cooldown marker is written
     // (the ticket is simply reconsidered next tick).
     expect(existsSync(dispatchCooldownPath(orchDir, TICKET, "research"))).toBe(false);
+  });
+});
+
+// ── CTL-834: convergeHeldLabel held-label apply cool-down ──
+//
+// The held-label converger re-issued applyLabel(blocked/waiting) every ~22s tick.
+// When the apply failed UNRECOVERABLY (the desired label's exclusive-group
+// sibling is already on the ticket — "not exclusive child"), the label never
+// landed, the diff was never satisfied, and the write re-fired forever (the storm:
+// 218 fails / 44 min, burning the Linear write quota). These pin the time-boxed
+// cool-down that backs the apply off after such a failure (and self-heals).
+describe("CTL-834 — convergeHeldLabel apply cool-down", () => {
+  // makeWs — a writeStatus fake whose applyLabel returns a fixed result and
+  // records calls; removeLabel records calls (fire-and-forget).
+  const makeWs = (applyResult) => {
+    const applyLabel = (...a) => {
+      applyLabel.calls.push(a);
+      return applyResult;
+    };
+    applyLabel.calls = [];
+    const removeLabel = (...a) => {
+      removeLabel.calls.push(a);
+    };
+    removeLabel.calls = [];
+    return { applyLabel, removeLabel };
+  };
+  const cd = (ticket, label) => existsSync(labelCooldownPath(orchDir, ticket, label));
+
+  test("happy path: apply succeeds → 1 write, NO cool-down marker", () => {
+    const ws = makeWs({ applied: true, reason: null });
+    const writes = convergeHeldLabel("CTL-1", [], "blocked", ws, { orchDir, now: () => 1000 });
+    expect(writes).toBe(1);
+    expect(ws.applyLabel.calls).toHaveLength(1);
+    expect(cd("CTL-1", "blocked")).toBe(false);
+  });
+
+  test("unrecoverable apply (exclusive-conflict) → arms the cool-down marker", () => {
+    const ws = makeWs({ applied: false, reason: "exclusive-conflict" });
+    const writes = convergeHeldLabel("CTL-1", [], "blocked", ws, { orchDir, now: () => 1000 });
+    expect(writes).toBe(1);
+    expect(ws.applyLabel.calls).toHaveLength(1);
+    expect(cd("CTL-1", "blocked")).toBe(true);
+  });
+
+  test("WITHIN the window: apply is SUPPRESSED (0 writes, applyLabel not re-called)", () => {
+    const ws = makeWs({ applied: false, reason: "exclusive-conflict" });
+    convergeHeldLabel("CTL-1", [], "blocked", ws, { orchDir, now: () => 1000 }); // arms cooldown
+    const writes = convergeHeldLabel("CTL-1", [], "blocked", ws, { orchDir, now: () => 1000 + 30_000 });
+    expect(writes).toBe(0);
+    expect(ws.applyLabel.calls).toHaveLength(1); // NOT re-attempted this tick
+  });
+
+  test("AFTER the window: apply retries (self-heals)", () => {
+    const ws = makeWs({ applied: false, reason: "exclusive-conflict" });
+    convergeHeldLabel("CTL-1", [], "blocked", ws, { orchDir, now: () => 1000 }); // arms cooldown
+    const writes = convergeHeldLabel("CTL-1", [], "blocked", ws, { orchDir, now: () => 1000 + 61_000 });
+    expect(writes).toBe(1);
+    expect(ws.applyLabel.calls).toHaveLength(2); // re-attempted past the window
+  });
+
+  test("transient apply failure → NO cool-down (retries next tick)", () => {
+    const ws = makeWs({ applied: false, reason: "transient" });
+    convergeHeldLabel("CTL-1", [], "blocked", ws, { orchDir, now: () => 1000 });
+    expect(cd("CTL-1", "blocked")).toBe(false);
+    const writes = convergeHeldLabel("CTL-1", [], "blocked", ws, { orchDir, now: () => 1000 + 30_000 });
+    expect(writes).toBe(1); // not suppressed
+    expect(ws.applyLabel.calls).toHaveLength(2);
+  });
+
+  test("steady-state (label already present) → 0 writes (zero-write invariant intact)", () => {
+    const ws = makeWs({ applied: true });
+    const writes = convergeHeldLabel("CTL-1", ["blocked"], "blocked", ws, { orchDir, now: () => 1000 });
+    expect(writes).toBe(0);
+    expect(ws.applyLabel.calls).toHaveLength(0);
+  });
+
+  test("desired=null with a stale held label → removes it (cool-down path not taken)", () => {
+    const ws = makeWs({ applied: true });
+    const writes = convergeHeldLabel("CTL-1", ["waiting"], null, ws, { orchDir, now: () => 1000 });
+    expect(writes).toBe(1);
+    expect(ws.removeLabel.calls).toHaveLength(1);
+    expect(ws.applyLabel.calls).toHaveLength(0);
+  });
+
+  test("no orchDir (legacy caller) → cool-down never arms, byte-for-byte prior behavior", () => {
+    const ws = makeWs({ applied: false, reason: "exclusive-conflict" });
+    convergeHeldLabel("CTL-1", [], "blocked", ws, {}); // no orchDir
+    convergeHeldLabel("CTL-1", [], "blocked", ws, {}); // attempted again — no suppression
+    expect(ws.applyLabel.calls).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## What
Stops the **live label-write storm** on the mini. The held-label converger
(`scheduler.mjs convergeHeldLabel`) re-issues `applyLabel(blocked|waiting)` every
~22s tick on a diff; when the apply fails with an **exclusive-group conflict**
("not exclusive child" — the desired label's exclusive sibling is already on the
ticket), the label never lands, the diff is never satisfied, and the write
**re-fires forever**. Observed live: **218 failed label writes in 44 min** on
CTL-838 (`blocked`↔`needs-human`) + ADV-1295 (`blocked`↔`waiting`), burning the
Linear 2500/hr write quota and risking collateral throttling of legit writes.

## Changes
- **`linear-write.mjs`** — `classifyLabelFailure` tags `"not exclusive child"` as
  its own unrecoverable reason `"exclusive-conflict"` (was silently `"transient"`
  = retryable). Exported for direct testing.
- **`label-guard.mjs`** — `labelOnce` writes `.skipped` on `exclusive-conflict`
  too (symmetric with `missing-label`).
- **`scheduler.mjs`** — `convergeHeldLabel` is now **cool-down-gated**: it captures
  the apply result directly (not via the result-discarding `safeWrite`) and, on an
  unrecoverable reason, arms a time-boxed per-`(ticket,label)` marker (mirrors the
  CTL-624 dispatch cool-down; kept outside `workers/<T>/` so it survives GC).
  While fresh, the whole convergence short-circuits → a permanent conflict is
  attempted **at most once per `LABEL_COOLDOWN_MS` (default 60s)** instead of every
  tick, and **self-heals** when the conflict clears. `orchDir`/`now` are optional,
  so bare unit ticks keep the prior best-effort behavior.

## Scope / follow-ups
This stops the *retry storm* (the quota burn). The underlying exclusive-group
*config* (blocked/waiting/needs-human sharing one exclusive Linear group) + the
cross-team `removeLabel` "incorrect team" deadlock are noted for a follow-up; the
cool-down bounds the damage regardless of the precise conflict cause.

## Tests
477 pass / 0 fail across the 3 touched suites (+13 new): classifyLabelFailure
mapping, labelOnce exclusive-conflict→.skipped, and the converger cool-down
(arm / suppress-within-window / retry-after-window / transient-not-cooled /
steady-state-zero-writes / legacy-no-orchDir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)