### PR TITLE
fix(dev): CTL-835 add scope to linear-comment-post OAuth mint (invalid_scope)

### DIFF
--- a/plugins/dev/scripts/__tests__/linear-comment-post.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-comment-post.test.sh
@@ -201,6 +201,69 @@ PATH="${BIN_DIR}:$PATH" assert_exit_zero \
   "falls back to OLD per-team catalyst.linear.agent.* via nested projectKey" \
   env HOME="${OLD_HOME}" bash -c "cd '${OLD_HOME}/repo' && bash '$HELPER' CTL-550 body"
 
+# Test 11 (CTL-835): the oauth/token mint request carries the scope param.
+# Without an explicit scope Linear rejects the mint with 400 invalid_scope and
+# the mirror fails open — the comment silently never posts. Stub curl records
+# the args it received for the oauth/token call so we can assert scope is present.
+export CATALYST_LINEAR_AGENT_CLIENT_ID="test-cid"
+export CATALYST_LINEAR_AGENT_CLIENT_SECRET="test-csec"
+
+SCOPE_CAPTURE="${TMPDIR_TEST}/token-args.txt"
+cat >"${BIN_DIR}/curl" <<CURLEOF
+#!/usr/bin/env bash
+ARGS_STR="\$*"
+if printf '%s' "\$ARGS_STR" | grep -q "oauth/token"; then
+  printf '%s\n' "\$ARGS_STR" >"${SCOPE_CAPTURE}"
+  printf '{"access_token":"test_token","token_type":"Bearer"}'
+elif printf '%s' "\$ARGS_STR" | grep -q "commentCreate"; then
+  printf '{"data":{"commentCreate":{"success":true}}}'
+else
+  printf '{"data":{"issues":{"nodes":[{"id":"issue-uuid-123"}]}}}'
+fi
+exit 0
+CURLEOF
+chmod +x "${BIN_DIR}/curl"
+
+PATH="${BIN_DIR}:$PATH" bash "$HELPER" "CTL-550" "body" >/dev/null 2>&1 || true
+if grep -q "scope=read,write,comments:create" "${SCOPE_CAPTURE}" 2>/dev/null; then
+  echo "PASS: oauth/token mint request includes scope=read,write,comments:create"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: oauth/token mint request missing scope (got: $(cat "${SCOPE_CAPTURE}" 2>/dev/null))"
+  FAIL=$((FAIL+1))
+fi
+
+# Test 12 (CTL-835): a 400 invalid_scope mint emits EXACTLY ONE diagnostic line,
+# and that line carries the real cause (invalid_scope) — no longer silent.
+cat >"${BIN_DIR}/curl" <<'CURLEOF'
+#!/usr/bin/env bash
+ARGS_STR="$*"
+if printf '%s' "$ARGS_STR" | grep -q "oauth/token"; then
+  # Emulate `curl -w '\n%{http_code}'`: body + newline + status. -f is NOT used
+  # by the helper, so the body is returned even on a 400.
+  printf '{"error":"invalid_scope","error_description":"missing scope"}\n400'
+fi
+exit 0
+CURLEOF
+chmod +x "${BIN_DIR}/curl"
+
+STDERR_OUT="$(PATH="${BIN_DIR}:$PATH" bash "$HELPER" "CTL-550" "body" 2>&1 1>/dev/null || true)"
+DIAG_LINES="$(printf '%s' "$STDERR_OUT" | grep -c .)"
+if [[ "$DIAG_LINES" -eq 1 ]]; then
+  echo "PASS: invalid_scope mint emits exactly one diagnostic line"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: invalid_scope mint emitted ${DIAG_LINES} diagnostic line(s), expected 1 (out: ${STDERR_OUT})"
+  FAIL=$((FAIL+1))
+fi
+if printf '%s' "$STDERR_OUT" | grep -q "invalid_scope"; then
+  echo "PASS: diagnostic surfaces the invalid_scope cause"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: diagnostic did not surface invalid_scope (out: ${STDERR_OUT})"
+  FAIL=$((FAIL+1))
+fi
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [[ "$FAIL" -eq 0 ]]

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -410,7 +410,18 @@ export function defaultPostReclaimMirror(
     if (r && r.status === 0) {
       writeMarker(marker);
     } else {
-      log.warn({ ticket, phase }, "reclaim-mirror: linear-comment-post failed (continuing)");
+      // Surface the helper's own diagnostic (e.g. the CTL-835 token-mint HTTP
+      // status / invalid_scope) instead of swallowing it, so a credential or
+      // scope failure is no longer silent. Still fail-open (no throw).
+      const detail = String(r?.stderr ?? "")
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .pop();
+      log.warn(
+        { ticket, phase, status: r?.status, detail },
+        "reclaim-mirror: linear-comment-post failed (continuing)",
+      );
     }
   } catch (err) {
     log.warn({ ticket, phase, err: err?.message }, "reclaim-mirror: post threw (continuing)");

--- a/plugins/dev/scripts/lib/linear-comment-post.sh
+++ b/plugins/dev/scripts/lib/linear-comment-post.sh
@@ -15,6 +15,14 @@ BODY="${2:?comment body required}"
 
 LINEAR_API="https://api.linear.app"
 
+# Scope for the client_credentials app-actor mint. `comments:create` is REQUIRED
+# for the commentCreate mutation below; `read` covers the issue-identifier
+# resolution query. Without an explicit scope Linear rejects the mint with
+# `400 invalid_scope` (CTL-835), so the mirror would fail open and the comment
+# would silently never post. This matches the canonical mints in
+# execution-core/linear-remint.mjs (MINT_SCOPE) and catalyst-execution-core.
+MINT_SCOPE="read,write,comments:create"
+
 # _find_layer2_config — resolve the OLD per-team Layer-2 file
 # (~/.config/catalyst/config-<key>.json) by walking up for .catalyst/config.json
 # and reading the project key. The key lives at `.catalyst.projectKey` (nested);
@@ -74,17 +82,26 @@ if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]]; then
 fi
 
 # 1. Mint app-actor token via client_credentials grant.
-TOKEN_RESPONSE=$(curl -sf -X POST "${LINEAR_API}/oauth/token" \
+#    Capture the body + HTTP status WITHOUT -f so a 400 (e.g. invalid_scope)
+#    surfaces the real error JSON instead of being discarded — the single
+#    diagnostic line below then carries the actual cause (CTL-835).
+TOKEN_HTTP=$(curl -s -w '\n%{http_code}' -X POST "${LINEAR_API}/oauth/token" \
   -d "grant_type=client_credentials" \
   -d "client_id=${CLIENT_ID}" \
   -d "client_secret=${CLIENT_SECRET}" \
+  -d "scope=${MINT_SCOPE}" \
   -H "Content-Type: application/x-www-form-urlencoded" 2>/dev/null) || {
-  echo "linear-comment-post: token mint failed" >&2
+  echo "linear-comment-post: token mint request failed (curl error)" >&2
   exit 1
 }
+TOKEN_CODE="${TOKEN_HTTP##*$'\n'}"
+TOKEN_RESPONSE="${TOKEN_HTTP%$'\n'*}"
 ACCESS_TOKEN=$(printf '%s' "$TOKEN_RESPONSE" | jq -r '.access_token // empty' 2>/dev/null)
 if [[ -z "$ACCESS_TOKEN" ]]; then
-  echo "linear-comment-post: access_token missing in token response" >&2
+  # One clear diagnostic carrying the HTTP status + Linear's error/description so
+  # invalid_scope (and any future mint rejection) is no longer silent.
+  ERR_DETAIL=$(printf '%s' "$TOKEN_RESPONSE" | jq -r '[.error, .error_description] | map(select(. != null and . != "")) | join(": ") // empty' 2>/dev/null)
+  echo "linear-comment-post: token mint failed (HTTP ${TOKEN_CODE:-?}${ERR_DETAIL:+; }${ERR_DETAIL}) — comment NOT posted" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Problem

`plugins/dev/scripts/lib/linear-comment-post.sh` minted its `client_credentials` app-actor token **without a `scope` param**, so Linear returned `400 invalid_scope`. Because the mint used `curl -sf` (which discards the response body on 4xx), the failure showed only a generic `token mint failed` line, and the phase-mirror caller logged the now-infamous:

```
reclaim-mirror: linear-comment-post failed (continuing)
```

Net effect: phase-mirror comments **silently never posted**.

## Root cause / evidence

Two independent, working app-actor mints in this repo both pass an explicit scope:

- `plugins/dev/scripts/execution-core/linear-remint.mjs` → `const MINT_SCOPE = "read,write,comments:create";`
- `plugins/dev/scripts/catalyst-execution-core` (daemon startup mint) → `-d 'scope=read,write,comments:create'`

`comments:create` is required for the `commentCreate` mutation; `read` covers the issue-identifier resolution query. Neither working path uses an `actor` param, so none was added here. (The `actor=app` + `app:mentionable,app:assignable` scope in `foundry/setup-catalyst` is a different, identity-only `viewer{id}` flow.)

## Fix

- Add `scope=read,write,comments:create` to the token mint.
- Drop `-f` and capture body + HTTP status via `curl -w '\n%{http_code}'` so a mint rejection surfaces Linear's real `error` / `error_description` in **exactly one** diagnostic line — e.g. `token mint failed (HTTP 400; invalid_scope: ...) — comment NOT posted` — instead of a generic, causeless message.
- `recovery.mjs` reclaim-mirror now includes the helper's stderr detail + exit status in its single fail-open warn line, so the cause is no longer swallowed by the caller either.

## Tests

Extended `plugins/dev/scripts/__tests__/linear-comment-post.test.sh`:
- the `oauth/token` request carries `scope=read,write,comments:create`
- a `400 invalid_scope` mint emits **exactly one** diagnostic line
- that line surfaces the `invalid_scope` cause

```
bash plugins/dev/scripts/__tests__/linear-comment-post.test.sh   → 14 passed, 0 failed
bun test execution-core/recovery.test.mjs                        → 203 pass, 0 fail
bun test execution-core/linear-remint.test.mjs                   → 46 pass, 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)