### PR TITLE
fix(dev): CTL-869 detect proxy env leak into interactive shells (CTL-846 regression class)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -361,6 +361,13 @@ catalyst-execution-core restart
 > down, those calls fail with `connection refused`. Always apply changes with
 > `catalyst-execution-core restart`. The daemon liveness-gates the proxy and degrades to direct mode
 > if mitmproxy is unreachable (CTL-846); an interactive shell gets no such protection.
+>
+> Concretely: never add a line like `source ~/.config/catalyst/execution-core.env` to `~/.zshrc`,
+> `~/.zshenv`, `~/.zprofile`, `~/.bashrc`, `~/.bash_profile`, or `~/.profile`, and never `export
+> HTTPS_PROXY=…` from those files. `check-setup.sh` has a **Proxy Leak Into Interactive Shells**
+> section (CTL-869) that scans these profiles plus the live shell env, fails if it finds such a leak,
+> and prints the exact line to delete. If you already have one, remove it and open a fresh terminal —
+> the daemon still routes through the proxy because it sources the file itself at launch.
 
 **Why `NODE_USE_ENV_PROXY=1` is required.** Node 20+/24+ native `fetch` (undici) **ignores**
 `HTTPS_PROXY`/`HTTP_PROXY` unless `NODE_USE_ENV_PROXY=1` is also set. Omit it and the daemon's

--- a/plugins/dev/scripts/__tests__/check-setup-proxy-leak.test.sh
+++ b/plugins/dev/scripts/__tests__/check-setup-proxy-leak.test.sh
@@ -158,6 +158,30 @@ OUT5="$(
 )"
 assert_grep "live proxy in shell flagged" "$OUT5" "HTTP(S)_PROXY is set in THIS shell"
 
+# ─── Test 7: live shell has a NON-catalyst (e.g. corporate) proxy → no hard fail
+# A developer behind a legitimate corporate proxy must NOT get a false-positive
+# hard failure (which would flip the whole health check non-zero) nor an untrue
+# "routes through mitmproxy" claim. check (c) must only hard-fail when the live
+# proxy matches the catalyst mitmproxy (de_proxy / the conventional :8080
+# host:port); an unrelated proxy gets an informational note only. (CTL-869)
+P7="${SCRATCH}/p7"; H7="${SCRATCH}/h7"
+make_project "$P7"; make_home "$H7"
+echo 'export EDITOR=vim' > "${H7}/.zshrc"
+OUT7="$(
+  cd "$P7" \
+  && env -i HOME="$H7" PATH="$PATH" \
+     XDG_CONFIG_HOME="${H7}/.config" CATALYST_AUTONOMOUS=1 \
+     HTTPS_PROXY="http://corp-proxy.example.com:3128" \
+     bash "$SCRIPT" 2>&1 || true
+)"
+# It MUST NOT hard-fail check (c) on the non-catalyst proxy...
+assert_not_grep "non-catalyst proxy not hard-failed" "$OUT7" "HTTP(S)_PROXY is set in THIS shell"
+# ...and MUST NOT make the untrue "routes through mitmproxy" claim about it.
+assert_not_grep "no false mitmproxy claim for corp proxy" "$OUT7" "route through the catalyst mitmproxy"
+# It still surfaces the proxy as an informational note (so a down catalyst proxy
+# under a non-default address is not silently ignored).
+assert_grep "non-catalyst proxy noted informationally" "$OUT7" "A proxy is set in this shell"
+
 # ─── Test 6: profile sources env file but daemon env file absent → no set -u crash
 # de_proxy is only populated in check-setup.sh's section 7c when the daemon env
 # file exists; the leak section must still run (and detect the source line)

--- a/plugins/dev/scripts/__tests__/check-setup-proxy-leak.test.sh
+++ b/plugins/dev/scripts/__tests__/check-setup-proxy-leak.test.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Tests for the check-setup.sh interactive-shell proxy-leak detection (CTL-869,
+# CTL-846 regression class).
+#
+# The mitmproxy HTTP(S)_PROXY in execution-core.env is meant to be DAEMON-launch-
+# scoped only (catalyst-execution-core sources it right before nohup'ing the
+# daemon). If a shell profile sources that env file — or exports HTTP(S)_PROXY
+# directly — the proxy leaks into every interactive shell and fresh terminals get
+# "connection refused" when mitmproxy is down. check-setup.sh must DETECT that
+# leak and print the exact one-line removal.
+#
+# Strategy: point HOME at a scratch dir so we fully control the shell profiles the
+# check reads, and point XDG_CONFIG_HOME at a scratch dir holding a fixture
+# execution-core.env. env -i gives a clean (no live proxy) base environment.
+#
+# Run: bash plugins/dev/scripts/__tests__/check-setup-proxy-leak.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SCRIPT="${REPO_ROOT}/plugins/dev/scripts/check-setup.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+assert_grep() {
+  local label="$1" output="$2" pattern="$3"
+  if grep -qF -- "$pattern" <<<"$output"; then
+    PASSES=$((PASSES + 1)); echo "  PASS: $label"
+  else
+    FAILURES=$((FAILURES + 1)); echo "  FAIL: $label"
+    echo "    expected substring: $pattern"
+    echo "    actual output (proxy-leak section):"
+    echo "$output" | grep -iA2 -E 'proxy leak|interactive shell' | head -20 | sed 's/^/      /'
+  fi
+}
+
+assert_not_grep() {
+  local label="$1" output="$2" pattern="$3"
+  if grep -qF -- "$pattern" <<<"$output"; then
+    FAILURES=$((FAILURES + 1)); echo "  FAIL: $label (unexpected pattern found)"
+    echo "    unexpected substring: $pattern"
+  else
+    PASSES=$((PASSES + 1)); echo "  PASS: $label"
+  fi
+}
+
+# make_home <home-dir> — minimal HOME with a daemon env file that configures the
+# proxy (so de_proxy is populated for the "leaks ... into all terminals" message)
+# and a global config.json so check-setup.sh's earlier jq reads don't trip set -e.
+make_home() {
+  local home="$1"
+  mkdir -p "${home}/.config/catalyst"
+  cat > "${home}/.config/catalyst/execution-core.env" <<'EOF'
+export NODE_USE_ENV_PROXY=1
+export HTTPS_PROXY=http://127.0.0.1:8080
+export HTTP_PROXY=http://127.0.0.1:8080
+export NODE_EXTRA_CA_CERTS=/nonexistent/ca.pem
+EOF
+  # check-setup.sh runs `jq ... "$CATALYST_CONFIG/config.json"` under set -e in
+  # its Linear-Git-Automation section; an absent file makes jq exit non-zero and
+  # aborts the script BEFORE the proxy-leak section. A minimal valid JSON keeps it
+  # going to section 7d (the section under test).
+  echo '{"catalyst":{}}' > "${home}/.config/catalyst/config.json"
+}
+
+# make_project <dir> — minimal .catalyst/config.json so check-setup.sh runs.
+make_project() {
+  local dir="$1"
+  mkdir -p "${dir}/.catalyst"
+  cat > "${dir}/.catalyst/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "test",
+    "project": { "ticketPrefix": "TST" },
+    "linear": { "teamKey": "TST", "stateMap": { "research": "Research" } }
+  }
+}
+EOF
+  mkdir -p "${dir}/thoughts/shared/research" "${dir}/thoughts/shared/plans" \
+    "${dir}/thoughts/shared/handoffs" "${dir}/thoughts/shared/prs" \
+    "${dir}/thoughts/shared/reports"
+}
+
+# run_script <project-dir> <home-dir> — run check-setup.sh with a controlled HOME
+# (its shell profiles + daemon env) and a clean env (env -i → no live proxy
+# inherited). The PATH is inherited from the caller so docker/curl/jq resolve as
+# they do on a real machine; only HOME + XDG point at the scratch fixture.
+run_script() {
+  local cwd="$1" home="$2"
+  ( cd "$cwd" \
+    && env -i HOME="$home" PATH="$PATH" \
+       XDG_CONFIG_HOME="${home}/.config" CATALYST_AUTONOMOUS=1 \
+       bash "$SCRIPT" 2>&1 || true )
+}
+
+echo "check-setup.sh interactive-shell proxy-leak tests (CTL-869)"
+
+# ─── Test 1: clean profiles → pass, no leak reported ─────────────────────────
+P1="${SCRATCH}/p1"; H1="${SCRATCH}/h1"
+make_project "$P1"; make_home "$H1"
+cat > "${H1}/.zshrc" <<'EOF'
+# clean profile, no proxy, no daemon-env source
+export EDITOR=vim
+EOF
+OUT1="$(run_script "$P1" "$H1")"
+assert_grep "clean profile passes leak check" "$OUT1" "No proxy leak into interactive shells"
+assert_not_grep "clean profile has no fail" "$OUT1" "sources the DAEMON-only env file"
+
+# ─── Test 2: .zshrc sources execution-core.env → leak detected + removal shown ─
+P2="${SCRATCH}/p2"; H2="${SCRATCH}/h2"
+make_project "$P2"; make_home "$H2"
+cat > "${H2}/.zshrc" <<EOF
+export EDITOR=vim
+source "\$HOME/.config/catalyst/execution-core.env"
+EOF
+OUT2="$(run_script "$P2" "$H2")"
+assert_grep "source-of-daemon-env detected" "$OUT2" "sources the DAEMON-only env file into every interactive shell"
+assert_grep "removal instruction shown" "$OUT2" "REMOVE this line from"
+assert_grep "regression-class named" "$OUT2" "CTL-846 regression class"
+assert_not_grep "not reported clean" "$OUT2" "No proxy leak into interactive shells"
+
+# ─── Test 3: commented-out source line → NOT flagged ─────────────────────────
+P3="${SCRATCH}/p3"; H3="${SCRATCH}/h3"
+make_project "$P3"; make_home "$H3"
+cat > "${H3}/.zshrc" <<EOF
+# source "\$HOME/.config/catalyst/execution-core.env"   # disabled, daemon does it
+export EDITOR=vim
+EOF
+OUT3="$(run_script "$P3" "$H3")"
+assert_grep "commented source passes" "$OUT3" "No proxy leak into interactive shells"
+assert_not_grep "commented source not flagged" "$OUT3" "sources the DAEMON-only env file"
+
+# ─── Test 4: profile exports HTTPS_PROXY directly → leak detected ─────────────
+P4="${SCRATCH}/p4"; H4="${SCRATCH}/h4"
+make_project "$P4"; make_home "$H4"
+cat > "${H4}/.zshenv" <<'EOF'
+export HTTPS_PROXY=http://127.0.0.1:8080
+EOF
+echo 'export EDITOR=vim' > "${H4}/.zshrc"
+OUT4="$(run_script "$P4" "$H4")"
+assert_grep "direct proxy export detected" "$OUT4" "exports a proxy var into every interactive shell"
+assert_grep "direct export removal shown" "$OUT4" "REMOVE:"
+
+# ─── Test 5: live shell already has the proxy set → flagged ───────────────────
+P5="${SCRATCH}/p5"; H5="${SCRATCH}/h5"
+make_project "$P5"; make_home "$H5"
+echo 'export EDITOR=vim' > "${H5}/.zshrc"
+OUT5="$(
+  cd "$P5" \
+  && env -i HOME="$H5" PATH="$PATH" \
+     XDG_CONFIG_HOME="${H5}/.config" CATALYST_AUTONOMOUS=1 \
+     HTTPS_PROXY="http://127.0.0.1:8080" \
+     bash "$SCRIPT" 2>&1 || true
+)"
+assert_grep "live proxy in shell flagged" "$OUT5" "HTTP(S)_PROXY is set in THIS shell"
+
+# ─── Test 6: profile sources env file but daemon env file absent → no set -u crash
+# de_proxy is only populated in check-setup.sh's section 7c when the daemon env
+# file exists; the leak section must still run (and detect the source line)
+# without tripping `set -u` when it is absent.
+P6="${SCRATCH}/p6"; H6="${SCRATCH}/h6"
+make_project "$P6"
+mkdir -p "${H6}/.config/catalyst"
+# Global config.json present (so the earlier jq read doesn't abort), but NO
+# execution-core.env file.
+echo '{"catalyst":{}}' > "${H6}/.config/catalyst/config.json"
+cat > "${H6}/.zshrc" <<EOF
+source "\$HOME/.config/catalyst/execution-core.env"
+EOF
+OUT6="$(run_script "$P6" "$H6")"
+assert_grep "absent-env source still detected" "$OUT6" "sources the DAEMON-only env file"
+assert_not_grep "no set -u unbound-var crash" "$OUT6" "unbound variable"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASSES passed, $FAILURES failed"
+[[ $FAILURES -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -661,14 +661,38 @@ for prof in "${PROFILE_CANDIDATES[@]}"; do
     fi
 done
 
-# (c) Live check: this very (interactive) shell already has the proxy set. If so,
-#     SOMETHING in the login chain leaked it — surface it even if the grep above
-#     missed the source (e.g. an indirect include or a Warp/IDE launch config).
+# (c) Live check: this very (interactive) shell already has a proxy set. This is
+#     only a *leak* worth hard-failing on if the proxy is the catalyst mitmproxy
+#     audit proxy (matching the daemon env's de_proxy, or the conventional
+#     mitmproxy host:port) — a developer behind a legitimate corporate proxy
+#     (HTTPS_PROXY=http://corp-proxy:…) must NOT get a false-positive failure
+#     (and an untrue "routes through mitmproxy" claim) that flips the whole
+#     health check non-zero. So: fail only on a confirmed mitmproxy match,
+#     otherwise emit an informational note. (CTL-869)
 live_proxy="${HTTPS_PROXY:-${HTTP_PROXY:-}}"
 if [[ -n "$live_proxy" ]]; then
-    leak_found="yes"
-    fail "HTTP(S)_PROXY is set in THIS shell ($live_proxy) — interactive processes (incl. claude) route through mitmproxy"
-    info "If mitmproxy is down, every API call here fails with 'connection refused'. Find and remove the export/source from your shell profile (see above), then open a fresh terminal."
+    # de_proxy is the daemon env's configured proxy when the env file exists; it
+    # is the literal placeholder "(the daemon proxy)" otherwise (set at line ~620
+    # under set -u). Treat the live proxy as the catalyst mitmproxy when it equals
+    # that real de_proxy, or when it points at the conventional mitmproxy host:port
+    # (127.0.0.1:8080 / localhost:8080), the default this repo's tooling uses.
+    is_catalyst_proxy=""
+    if [[ "$de_proxy" != "(the daemon proxy)" && "$live_proxy" == "$de_proxy" ]]; then
+        is_catalyst_proxy="yes"
+    elif [[ "$live_proxy" == *"127.0.0.1:8080"* || "$live_proxy" == *"localhost:8080"* ]]; then
+        is_catalyst_proxy="yes"
+    fi
+
+    if [[ -n "$is_catalyst_proxy" ]]; then
+        leak_found="yes"
+        fail "HTTP(S)_PROXY is set in THIS shell ($live_proxy) — interactive processes (incl. claude) route through the catalyst mitmproxy"
+        info "If mitmproxy is down, every API call here fails with 'connection refused'. Find and remove the export/source from your shell profile (see above), then open a fresh terminal."
+    else
+        # An unrelated proxy (e.g. a corporate HTTP proxy). Do NOT hard-fail the
+        # whole health check on it; just note it in case it is in fact a down
+        # catalyst audit proxy under a non-default address.
+        info "A proxy is set in this shell ($live_proxy) — if it is the catalyst mitmproxy audit proxy and it is down, interactive claude calls will fail with connection refused. If it is an unrelated (e.g. corporate) proxy, this is fine."
+    fi
 fi
 
 if [[ -z "$leak_found" ]]; then

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -600,6 +600,81 @@ else
     fi
 fi
 
+# ─── 7d. Proxy leak into interactive shells (CTL-869, CTL-846 regression class) ──
+#
+# The mitmproxy HTTP(S)_PROXY in execution-core.env is DAEMON-launch-scoped only:
+# catalyst-execution-core cmd_start sources the file right before nohup'ing the
+# daemon, so the proxy lives only in the daemon's process tree. If instead a shell
+# profile (~/.zshrc, ~/.zshenv, ~/.zprofile, ~/.bashrc, ~/.bash_profile, ~/.profile)
+# `source`s execution-core.env — or exports HTTP(S)_PROXY directly — the proxy
+# leaks into EVERY interactive shell. A fresh terminal then routes all traffic
+# (including interactive `claude`) through mitmproxy, and when the proxy is down
+# every API call dies with "connection refused". This check catches that leak and
+# prints the exact one-line removal. No repo script writes such a line — it is
+# always a hand-edit — so the fix is to delete it from the profile, never to widen
+# the daemon env's reach.
+header "Proxy Leak Into Interactive Shells (CTL-869)"
+
+# de_proxy is set in section 7c only when the daemon env file exists; default it
+# here so the messages below are safe under `set -u` when the file is absent.
+de_proxy="${de_proxy:-(the daemon proxy)}"
+leak_found=""
+# (a) Any profile that sources the daemon env file directly leaks every export in
+#     it (proxy + CA) into interactive shells. The grep ignores commented lines.
+PROFILE_CANDIDATES=(
+    "$HOME/.zshenv"
+    "$HOME/.zprofile"
+    "$HOME/.zshrc"
+    "$HOME/.bash_profile"
+    "$HOME/.bashrc"
+    "$HOME/.profile"
+)
+for prof in "${PROFILE_CANDIDATES[@]}"; do
+    [[ -f "$prof" ]] || continue
+    # Match a non-comment line that sources execution-core.env (with or without
+    # the `source`/`.` builtin spelled out, quoted or not).
+    if grep -nE '^[[:space:]]*(source|\.)[[:space:]]+.*execution-core\.env' "$prof" 2>/dev/null \
+        | grep -vE '^[0-9]+:[[:space:]]*#' >/dev/null; then
+        leak_found="yes"
+        leak_line=$(grep -nE '^[[:space:]]*(source|\.)[[:space:]]+.*execution-core\.env' "$prof" 2>/dev/null \
+            | grep -vE '^[0-9]+:[[:space:]]*#' | head -1)
+        fail "$prof sources the DAEMON-only env file into every interactive shell (line ${leak_line%%:*})"
+        info "This leaks HTTP(S)_PROXY=$de_proxy into all terminals — fresh shells get 'connection refused' when mitmproxy is down (CTL-846 regression class)"
+        info "REMOVE this line from $prof:"
+        info "    ${leak_line#*:}"
+        info "The daemon already sources this file itself at launch (catalyst-execution-core cmd_start) — the proxy stays daemon-scoped without it."
+    fi
+done
+
+# (b) A profile may also export HTTP(S)_PROXY directly (not via the env file).
+#     Flag any non-comment proxy export in a profile.
+for prof in "${PROFILE_CANDIDATES[@]}"; do
+    [[ -f "$prof" ]] || continue
+    if grep -nE '^[[:space:]]*export[[:space:]]+(HTTPS?_PROXY|ALL_PROXY)=' "$prof" 2>/dev/null \
+        | grep -vE '^[0-9]+:[[:space:]]*#' >/dev/null; then
+        leak_found="yes"
+        leak_line=$(grep -nE '^[[:space:]]*export[[:space:]]+(HTTPS?_PROXY|ALL_PROXY)=' "$prof" 2>/dev/null \
+            | grep -vE '^[0-9]+:[[:space:]]*#' | head -1)
+        fail "$prof exports a proxy var into every interactive shell (line ${leak_line%%:*})"
+        info "REMOVE: ${leak_line#*:}"
+        info "Proxy belongs ONLY in the daemon launch env (execution-core.env, sourced by catalyst-execution-core at start), never in a shell profile."
+    fi
+done
+
+# (c) Live check: this very (interactive) shell already has the proxy set. If so,
+#     SOMETHING in the login chain leaked it — surface it even if the grep above
+#     missed the source (e.g. an indirect include or a Warp/IDE launch config).
+live_proxy="${HTTPS_PROXY:-${HTTP_PROXY:-}}"
+if [[ -n "$live_proxy" ]]; then
+    leak_found="yes"
+    fail "HTTP(S)_PROXY is set in THIS shell ($live_proxy) — interactive processes (incl. claude) route through mitmproxy"
+    info "If mitmproxy is down, every API call here fails with 'connection refused'. Find and remove the export/source from your shell profile (see above), then open a fresh terminal."
+fi
+
+if [[ -z "$leak_found" ]]; then
+    pass "No proxy leak into interactive shells (proxy stays daemon-launch-scoped)"
+fi
+
 # ─── 8. direnv ──────────────────────────────────────────────────────────────
 
 header "direnv"

--- a/plugins/dev/templates/execution-core.env.example
+++ b/plugins/dev/templates/execution-core.env.example
@@ -16,11 +16,14 @@
 # ─── Optional: route daemon Linear/gh traffic through a local mitmproxy audit ──
 #
 # WARNING: this file is sourced by `catalyst-execution-core start` for the DAEMON only.
-# Do NOT `source` it in an interactive shell or shell profile — the HTTP(S)_PROXY exports
-# would then pin every process you launch (including interactive `claude`) to mitmproxy, and
-# all API calls break with "connection refused" whenever mitmproxy is down. Apply changes with
+# Do NOT `source` it in an interactive shell or shell profile — specifically, NEVER add a
+# line like `source ~/.config/catalyst/execution-core.env` to ~/.zshrc / ~/.zshenv /
+# ~/.zprofile / ~/.bashrc / ~/.bash_profile / ~/.profile. The HTTP(S)_PROXY exports would
+# then pin every process you launch (including interactive `claude`) to mitmproxy, and all
+# API calls break with "connection refused" whenever mitmproxy is down. Apply changes with
 # `catalyst-execution-core restart` instead. (The daemon liveness-gates these vars; your shell
-# does not.)  See CTL-846.
+# does not.) `check-setup.sh` detects this leak and prints the exact line to remove. See
+# CTL-846 / CTL-869.
 #
 # The daemon's Linear/GitHub calls go out over Node's native fetch (undici). To
 # observe/record them, run a local mitmproxy and point the daemon at it. This is


### PR DESCRIPTION
## Problem

The mitmproxy Linear-audit `HTTP(S)_PROXY` is meant to be **daemon-launch-scoped only**, but it was leaking into **all interactive shells** — a fresh terminal routed every request (including interactive `claude`) through mitmproxy and got `connection refused` whenever the proxy was down. This is the CTL-846 regression class.

## Root cause hunt

The repo scripts are already correct:
- `catalyst-stack --proxy` sets `HTTPS_PROXY / NODE_USE_ENV_PROXY / NODE_EXTRA_CA_CERTS` as an **inline prefix** on the `catalyst-execution-core start` invocation only (not a profile export).
- `catalyst-execution-core` sources `~/.config/catalyst/execution-core.env` **only inside `cmd_start`**, right before `nohup`'ing the daemon — so the proxy lives only in the daemon's process tree.
- The launchd plist (`com.catalyst.agent.plist`) sets only `PATH` + `HOME`, no proxy.
- `install-cli.sh` appends only a **PATH bootstrap** to the shell profile, never a proxy/source line.

The actual live leak is **machine-local**: a hand-added line in `~/.zshrc` does
`source "$HOME/.config/catalyst/execution-core.env"`, which pulls the daemon-only `export HTTPS_PROXY=…` into every interactive shell. No repo script produces this line — it is always a manual edit.

## Fix (repo-side hardening — correct for all installs)

Since the leak can only be a hand-edit, the durable repo fix is **detection + guidance**:

- **`check-setup.sh`** gains a new section **"Proxy Leak Into Interactive Shells (CTL-869)"** that:
  - scans `~/.zshrc`, `~/.zshenv`, `~/.zprofile`, `~/.bashrc`, `~/.bash_profile`, `~/.profile` for a non-commented `source … execution-core.env` line **or** a direct `export HTTP(S)_PROXY=` / `ALL_PROXY=`,
  - checks the **live shell env** for an already-set proxy,
  - **fails loudly** and prints the exact line + file to remove, noting the daemon still routes through the proxy because it sources the file itself at launch.
- **`execution-core.env.example`** and **`docs/configuration.md`** warnings now name the specific `source ~/.config/catalyst/execution-core.env` anti-pattern and point at the new check.
- **New regression test** `check-setup-proxy-leak.test.sh` (13 assertions): clean profile passes; a source line is detected with the removal shown; commented lines are ignored; a direct proxy export is detected; a live in-shell proxy is flagged; and the section is `set -u`-safe when the daemon env file is absent.

## Machine-local removal the user should apply

The live leak on this machine is **`~/.zshrc` line 378**:

```
source "$HOME/.config/catalyst/execution-core.env"
```

**Delete that one line and open a fresh terminal.** The daemon keeps auditing Linear through the proxy because `catalyst-execution-core start` sources the file itself at launch. (`check-setup.sh` now reports this exact line.)

## Acceptance

- Fresh terminal: no `HTTP(S)_PROXY` in `env` once the `~/.zshrc` line is removed → Claude Code connects.
- Daemon still audits Linear via the proxy (unchanged — `cmd_start` still sources the env file).
- `check-setup.sh` against this machine correctly flags `~/.zshrc:378` with the removal instruction.

## Tests

- `check-setup-proxy-leak.test.sh`: 13 passed, 0 failed (new)
- `execution-core-proxy-docs.test.sh` (CTL-846): 2 passed
- `check-setup-orchestrator-app.test.sh` (CTL-785): 7 passed
- `catalyst-execution-core.test.sh`: 23 passed
- `catalyst-stack.test.sh`: 21 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)