### PR TITLE
fix(dev): CTL-867 escalate persistent per-team reconcile failure to a visible event

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -72,6 +72,20 @@ export function getEligibleDir() {
   return resolve(getExecutionCoreDir(), "eligible");
 }
 
+// CTL-867 — per-team reconcile-health dir. Holds <team>.json health markers
+// ({ team, lastSuccessTs, consecutiveFailures, alerting, updatedAt }) the
+// monitor writes on every reconcile and the orch-monitor /api/snapshot reads to
+// surface each team's "last successful eligible refresh age". This is a SEPARATE
+// marker from the eligible projection's content-keyed `updatedAt`: a healthy
+// reconcile of an unchanged eligible set skips the projection write entirely
+// (eligible-set.mjs skip-when-unchanged), so the projection timestamp can look
+// fresh while no poll has actually succeeded in hours. The health marker is
+// rewritten every reconcile regardless, so its lastSuccessTs is the truthful
+// staleness signal.
+export function getReconcileHealthDir() {
+  return resolve(getExecutionCoreDir(), "reconcile-health");
+}
+
 // The durable event-log tailer cursor — monitor.mjs persists its byte offset
 // here so a daemon restart resumes the fast path instead of re-seeding at EOF.
 export function getCursorPath() {
@@ -191,6 +205,21 @@ export const HEARTBEAT_INTERVAL_MS =
 // The periodic reconcile poll — the missed-webhook correctness backstop.
 export const RECONCILE_INTERVAL_MS =
   Number(process.env.EXECUTION_CORE_RECONCILE_INTERVAL_MS) || 10 * 60_000;
+
+// CTL-867 — per-team reconcile-health escalation threshold. A team's
+// eligibleQuery can error every poll (e.g. its status references a removed
+// Linear state → `linearis issues list --team X --status Ready` exits 1). The
+// catch in reconcileProject preserves the prior eligible set and logs, which
+// is correct, but a *persistent* failure freezes that team's eligible
+// projection stale for hours while the daemon looks healthy — invisible
+// starvation. After this many CONSECUTIVE failures the monitor escalates beyond
+// the buried log.error to a canonical `monitor.reconcile.failing.<TEAM>` event
+// the orch-monitor dashboard surfaces. A recovering query clears the alert and
+// resets the counter. Default 3 (≈30 min of a 10-min reconcile) so a single
+// transient linearis hiccup never alerts, but a removed-state misconfig does.
+// Env-overridable for tuning/tests.
+export const RECONCILE_FAILURE_ALERT_THRESHOLD =
+  Number(process.env.EXECUTION_CORE_RECONCILE_FAILURE_ALERT_THRESHOLD) || 3;
 
 // Debounce window: state_changed events that enter the eligible state coalesce
 // into one reconcile poll per affected project per burst.

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -44,6 +44,11 @@ import { applyTriageStatus as defaultApplyTriageStatus, applyAssignee as default
 import { appendTriageTransitionEvent as defaultAppendEvent } from "./triage-transition-event.mjs";
 import { countBackgroundAgents, resetLivenessCache } from "./claude-agents.mjs";
 import { readMaxParallel, computeFreeSlots } from "./scheduler.mjs";
+import {
+  recordReconcileSuccess,
+  recordReconcileFailure,
+  __resetReconcileHealthForTests,
+} from "./reconcile-health.mjs";
 
 // DRAG_OUT_STATES — the Linear workflow states that signal "stop work on this
 // ticket". The monitor classifies these as a kill: remove the ticket from the
@@ -209,7 +214,16 @@ const knownProjects = new Set();
 // edit is picked up without a daemon restart. A failed poll THROWS inside
 // runEligibleQuery; we log and return, preserving the prior eligible set
 // rather than flattening it to empty.
-export function reconcileProject(team, { exec } = {}) {
+//
+// CTL-867: a PERSISTENT per-team poll failure (e.g. the team's status references
+// a removed Linear state, so `linearis issues list --team X --status Ready`
+// exits 1 every tick) is no longer ONLY a buried log.error. Each call records
+// the per-team reconcile outcome (recordReconcileSuccess / recordReconcileFailure);
+// after N consecutive failures the health tracker escalates a canonical
+// `monitor.reconcile.failing.<TEAM>` event onto the unified event log so the
+// orch-monitor dashboard surfaces the silently-starving team, and a recovering
+// poll clears the alert. `appendHealthEvent` is an injectable test seam.
+export function reconcileProject(team, { exec, appendHealthEvent } = {}) {
   const entry = getProjectConfig(team);
   if (!entry) {
     log.warn({ team }, "reconcile: no registry entry for team — skipping");
@@ -221,8 +235,15 @@ export function reconcileProject(team, { exec } = {}) {
     tickets = runEligibleQuery(query, { exec });
   } catch (err) {
     log.error({ team, err: err.message }, "reconcile poll failed — preserving prior eligible set");
+    // CTL-867: escalate persistent failures beyond the buried log line.
+    recordReconcileFailure(team, err.message, appendHealthEvent ? { appendEvent: appendHealthEvent } : {});
     return;
   }
+  // CTL-867: the poll succeeded — reset the failure streak, refresh the
+  // last-successful-refresh marker, and clear any standing alert. Recorded
+  // BEFORE the projection write so a successful poll counts as a recovery even
+  // if the (rare) projection write below fails.
+  recordReconcileSuccess(team, appendHealthEvent ? { appendEvent: appendHealthEvent } : {});
   try {
     setProjectEligible(team, tickets, { source: "reconcile", query });
   } catch (err) {
@@ -242,10 +263,10 @@ export function reconcileProject(team, { exec } = {}) {
 // reconcileAll — full reconcile of every registered team (the missed-webhook
 // backstop). Re-reads registry.json each call so a team added to the registry
 // is picked up and one removed is dropped within one tick.
-export function reconcileAll({ exec } = {}) {
+export function reconcileAll({ exec, appendHealthEvent } = {}) {
   const projects = listProjects();
   const seen = new Set(projects.map((p) => p.team));
-  for (const p of projects) reconcileProject(p.team, { exec });
+  for (const p of projects) reconcileProject(p.team, { exec, appendHealthEvent });
   for (const stale of knownProjects) {
     if (!seen.has(stale)) {
       dropProject(stale);
@@ -852,4 +873,5 @@ export function __resetForTests() {
   leftoverBuf = "";
   tailerOpts = {};
   resetLivenessCache();
+  __resetReconcileHealthForTests(); // CTL-867: clear per-team reconcile-health map
 }

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -33,6 +33,8 @@ import { fetchTicketState } from "./linear-query.mjs";
 import {
   getReconcileHealth,
   readReconcileHealthMarkers,
+  recordReconcileFailure,
+  __resetReconcileHealthForTests,
 } from "./reconcile-health.mjs";
 
 let catalystDir;
@@ -310,6 +312,51 @@ describe("reconcileProject — CTL-867 reconcile-health escalation", () => {
     expect(failed.ENG.alerting).toBe(true);
     expect(failed.ENG.consecutiveFailures).toBe(3);
     expect(failed.ENG.lastSuccessTs).toBe(priorTs); // unchanged — eligible set is frozen stale
+  });
+
+  // CTL-867 cross-restart fix: the in-memory health map is empty on every process
+  // start. Without rehydration, the first post-restart failure for a team that has
+  // been failing for hours would seed a FRESH entry and writeHealthMarker would
+  // OVERWRITE the truthful disk marker — resetting consecutiveFailures to 1,
+  // dropping the real lastSuccessTs to null, and clearing the alerting latch. That
+  // is the exact starvation scenario CTL-867 targets, so it must survive a restart.
+  test("a daemon restart rehydrates per-team health from the disk marker (preserves lastSuccessTs + alerting, increments the failure count)", () => {
+    enroll("ENG", { status: "Ready" });
+    const appendHealthEvent = () => {};
+    const throwingExec = () => ({ code: 1, stdout: "", stderr: "removed-state: Ready" });
+
+    // Establish a truthful marker: one success (stamps a real lastSuccessTs), then
+    // drive past the threshold so the team is alerting with N consecutive failures.
+    reconcileProject("ENG", { exec: execReturning({ ENG: [node("ENG-1")] }), appendHealthEvent });
+    const staleSuccessTs = readReconcileHealthMarkers().ENG.lastSuccessTs;
+    expect(staleSuccessTs).toBeTruthy();
+    for (let i = 0; i < 3; i++) reconcileProject("ENG", { exec: throwingExec, appendHealthEvent });
+
+    const beforeRestart = readReconcileHealthMarkers().ENG;
+    expect(beforeRestart.alerting).toBe(true);
+    expect(beforeRestart.consecutiveFailures).toBe(3);
+    expect(beforeRestart.lastSuccessTs).toBe(staleSuccessTs);
+
+    // Simulate a daemon RESTART: the in-memory map is cleared, but the disk marker
+    // (the durable starvation truth) persists in the per-test reconcile-health dir.
+    __resetReconcileHealthForTests();
+    expect(getReconcileHealth("ENG")).toBeNull(); // confirm the in-memory map is empty
+
+    // ONE more failure after the restart. The seed must come from the disk marker,
+    // not fresh defaults — so the count increments to N+1, lastSuccessTs is the
+    // preserved stale timestamp (NOT null), and the alerting latch stays set.
+    recordReconcileFailure("ENG", "removed-state: Ready");
+
+    const afterRestart = readReconcileHealthMarkers().ENG;
+    expect(afterRestart.consecutiveFailures).toBe(4); // N+1, not reset to 1
+    expect(afterRestart.lastSuccessTs).toBe(staleSuccessTs); // preserved, not nulled
+    expect(afterRestart.alerting).toBe(true); // latch survives the restart
+
+    // The in-memory entry now mirrors the rehydrated-then-incremented state.
+    const inMem = getReconcileHealth("ENG");
+    expect(inMem.consecutiveFailures).toBe(4);
+    expect(inMem.lastSuccessTs).toBe(staleSuccessTs);
+    expect(inMem.alerting).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -30,6 +30,10 @@ import { setProjectEligible, getEligibleSet, dropProject } from "./eligible-set.
 import { loadCursor, saveCursor } from "./event-cursor.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 import { fetchTicketState } from "./linear-query.mjs";
+import {
+  getReconcileHealth,
+  readReconcileHealthMarkers,
+} from "./reconcile-health.mjs";
 
 let catalystDir;
 let prevCatalystDir;
@@ -196,6 +200,116 @@ describe("reconcileProject", () => {
     writeFileSync(join(projDir, "sentinel"), "x");
     expect(() => reconcileProject("ENG", { exec })).not.toThrow();
     rmSync(projDir, { recursive: true, force: true });
+  });
+});
+
+// --- CTL-867: per-team reconcile-health escalation --------------------------
+//
+// A team whose eligibleQuery errors every poll (e.g. its status references a
+// removed Linear state) freezes its eligible projection stale for hours while
+// the daemon looks healthy — invisible starvation. reconcileProject now records
+// per-team reconcile health and, after N consecutive failures, escalates a
+// canonical monitor.reconcile.failing.<TEAM> event onto the unified event log;
+// a recovering poll clears the alert.
+
+describe("reconcileProject — CTL-867 reconcile-health escalation", () => {
+  const throwingExec = () => ({ code: 1, stdout: "", stderr: "removed-state: Ready" });
+
+  test("a reconcile that throws N consecutive times emits the failing alert exactly once", () => {
+    enroll("ENG", { status: "Ready" });
+    const events = [];
+    const appendHealthEvent = (e) => events.push(e);
+
+    // First two failures: under the default threshold (3) → no alert yet.
+    reconcileProject("ENG", { exec: throwingExec, appendHealthEvent });
+    reconcileProject("ENG", { exec: throwingExec, appendHealthEvent });
+    expect(events).toHaveLength(0);
+    expect(getReconcileHealth("ENG").consecutiveFailures).toBe(2);
+    expect(getReconcileHealth("ENG").alerting).toBe(false);
+
+    // Third consecutive failure crosses the threshold → exactly one alert.
+    reconcileProject("ENG", { exec: throwingExec, appendHealthEvent });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ team: "ENG", action: "failing", consecutiveFailures: 3 });
+    expect(getReconcileHealth("ENG").alerting).toBe(true);
+
+    // Further failures do NOT re-fire the alert (latched until recovery).
+    reconcileProject("ENG", { exec: throwingExec, appendHealthEvent });
+    reconcileProject("ENG", { exec: throwingExec, appendHealthEvent });
+    expect(events).toHaveLength(1);
+    expect(getReconcileHealth("ENG").consecutiveFailures).toBe(5);
+  });
+
+  test("a recovering query clears the alert and resets the counter (emits a recovery event)", () => {
+    enroll("ENG", { status: "Ready" });
+    const events = [];
+    const appendHealthEvent = (e) => events.push(e);
+
+    // Drive past the threshold so the team is alerting.
+    for (let i = 0; i < 3; i++) reconcileProject("ENG", { exec: throwingExec, appendHealthEvent });
+    expect(getReconcileHealth("ENG").alerting).toBe(true);
+    expect(events).toHaveLength(1);
+
+    // A successful poll: counter resets, alert clears, recovery event fires.
+    const goodExec = execReturning({ ENG: [node("ENG-1")] });
+    reconcileProject("ENG", { exec: goodExec, appendHealthEvent });
+    const health = getReconcileHealth("ENG");
+    expect(health.consecutiveFailures).toBe(0);
+    expect(health.alerting).toBe(false);
+    expect(health.lastSuccessTs).toBeTruthy();
+    expect(events).toHaveLength(2);
+    expect(events[1]).toMatchObject({ team: "ENG", action: "recovered" });
+    // The successful poll also rebuilt the eligible set (no longer frozen stale).
+    expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-1"]);
+  });
+
+  test("a single transient failure under the threshold never alerts; recovery emits nothing", () => {
+    enroll("ENG", { status: "Ready" });
+    const events = [];
+    const appendHealthEvent = (e) => events.push(e);
+
+    reconcileProject("ENG", { exec: throwingExec, appendHealthEvent }); // 1 failure
+    const goodExec = execReturning({ ENG: [node("ENG-1")] });
+    reconcileProject("ENG", { exec: goodExec, appendHealthEvent }); // recovers before alert
+
+    // No alert was ever raised, so the recovery must NOT emit a spurious clear.
+    expect(events).toHaveLength(0);
+    expect(getReconcileHealth("ENG").consecutiveFailures).toBe(0);
+    expect(getReconcileHealth("ENG").alerting).toBe(false);
+  });
+
+  test("a new streak after a recovery re-alerts (alert is per-streak, not once-ever)", () => {
+    enroll("ENG", { status: "Ready" });
+    const events = [];
+    const appendHealthEvent = (e) => events.push(e);
+
+    for (let i = 0; i < 3; i++) reconcileProject("ENG", { exec: throwingExec, appendHealthEvent });
+    reconcileProject("ENG", { exec: execReturning({ ENG: [node("ENG-1")] }), appendHealthEvent });
+    // failing(1) + recovered(1) so far.
+    expect(events.filter((e) => e.action === "failing")).toHaveLength(1);
+
+    for (let i = 0; i < 3; i++) reconcileProject("ENG", { exec: throwingExec, appendHealthEvent });
+    expect(events.filter((e) => e.action === "failing")).toHaveLength(2);
+  });
+
+  test("each call persists a per-team health marker the orch-monitor server reads", () => {
+    enroll("ENG", { status: "Ready" });
+    const appendHealthEvent = () => {};
+    reconcileProject("ENG", { exec: execReturning({ ENG: [node("ENG-1")] }), appendHealthEvent });
+
+    const markers = readReconcileHealthMarkers();
+    expect(markers.ENG).toBeDefined();
+    expect(markers.ENG.lastSuccessTs).toBeTruthy();
+    expect(markers.ENG.alerting).toBe(false);
+    expect(markers.ENG.consecutiveFailures).toBe(0);
+
+    // After persistent failures the marker reflects the alert + frozen lastSuccessTs.
+    const priorTs = markers.ENG.lastSuccessTs;
+    for (let i = 0; i < 3; i++) reconcileProject("ENG", { exec: throwingExec, appendHealthEvent });
+    const failed = readReconcileHealthMarkers();
+    expect(failed.ENG.alerting).toBe(true);
+    expect(failed.ENG.consecutiveFailures).toBe(3);
+    expect(failed.ENG.lastSuccessTs).toBe(priorTs); // unchanged — eligible set is frozen stale
   });
 });
 

--- a/plugins/dev/scripts/execution-core/reconcile-health-event.mjs
+++ b/plugins/dev/scripts/execution-core/reconcile-health-event.mjs
@@ -1,0 +1,102 @@
+// reconcile-health-event.mjs — canonical monitor.reconcile.{failing,recovered}
+// events (CTL-867).
+//
+// When a team's eligibleQuery errors every reconcile poll (e.g. its status
+// references a removed Linear state → `linearis issues list --team X --status
+// Ready` exits 1), reconcileProject's catch preserves the prior eligible set
+// and logs — correct, but a *persistent* failure freezes that team's eligible
+// projection stale for hours while the daemon looks healthy. No new Todo tickets
+// become eligible; the whole team starves invisibly.
+//
+// These events ESCALATE that buried log.error onto the unified event log so the
+// orch-monitor dashboard surfaces the failing team:
+//   monitor.reconcile.failing.<TEAM>    — WARN, after N consecutive failures
+//   monitor.reconcile.recovered.<TEAM>  — INFO, when a poll succeeds after an alert
+//
+// Shape mirrors triage-transition-event.mjs / memory-event.mjs (OTel envelope,
+// appendFileSync, never throws) so the dashboard/HUD parsers treat these events
+// identically to every other canonical execution-core emission.
+import { randomBytes } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { getEventLogPath, log } from "./config.mjs";
+import { hostName, hostId } from "./lib/host-identity.mjs";
+
+export const RECONCILE_FAILING_ACTION = "failing";
+export const RECONCILE_RECOVERED_ACTION = "recovered";
+
+// defaultAppend — writes a JSONL line to the canonical event log.
+function defaultAppend(line) {
+  const logPath = getEventLogPath();
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, line);
+}
+
+// buildReconcileHealthEvent — returns a canonical JSONL line (string + "\n") for
+// the monitor.reconcile.<action>.<TEAM> event. `action` is "failing" (WARN) or
+// "recovered" (INFO). The team is the event's entity label — there is no Linear
+// issue identifier for a team-wide reconcile failure, so the attributes carry
+// `team` rather than `linear.issue.identifier`.
+export function buildReconcileHealthEvent({
+  team,
+  action,
+  consecutiveFailures = null,
+  lastSuccessTs = null,
+  staleMs = null,
+  reason = null,
+} = {}) {
+  const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const failing = action === RECONCILE_FAILING_ACTION;
+  return (
+    JSON.stringify({
+      ts,
+      id: randomBytes(8).toString("hex"),
+      observedTs: ts,
+      severityText: failing ? "WARN" : "INFO",
+      severityNumber: failing ? 13 : 9,
+      traceId: randomBytes(16).toString("hex"),
+      spanId: randomBytes(8).toString("hex"),
+      resource: {
+        "service.name": "catalyst.execution-core",
+        "service.namespace": "catalyst",
+        "host.name": hostName(),
+        "host.id": hostId(),
+      },
+      attributes: {
+        "event.name": `monitor.reconcile.${action}.${team}`,
+        "event.entity": "monitor",
+        "event.action": `reconcile.${action}`,
+        "event.label": team,
+        "catalyst.team": team,
+      },
+      body: {
+        payload: {
+          team,
+          action,
+          consecutiveFailures,
+          lastSuccessTs,
+          staleMs,
+          reason,
+        },
+      },
+    }) + "\n"
+  );
+}
+
+// appendReconcileHealthEvent — append the event to the canonical event log. The
+// `append` seam defaults to the real file write; inject a recording function in
+// tests. Returns true on success, false on any error (log.error + swallow) so a
+// failed append never crashes the reconcile timer.
+export function appendReconcileHealthEvent({ append = defaultAppend, ...fields } = {}) {
+  try {
+    const line = buildReconcileHealthEvent(fields);
+    append(line);
+    return true;
+  } catch (err) {
+    log.error(
+      { err: err.message, team: fields.team, action: fields.action },
+      "reconcile-health-event: append failed",
+    );
+    return false;
+  }
+}

--- a/plugins/dev/scripts/execution-core/reconcile-health-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/reconcile-health-event.test.mjs
@@ -1,0 +1,91 @@
+// reconcile-health-event.test.mjs — CTL-867: canonical
+// monitor.reconcile.{failing,recovered} events.
+// Run: cd plugins/dev/scripts/execution-core && bun test reconcile-health-event.test.mjs
+import { describe, test, expect } from "bun:test";
+import {
+  buildReconcileHealthEvent,
+  appendReconcileHealthEvent,
+  RECONCILE_FAILING_ACTION,
+  RECONCILE_RECOVERED_ACTION,
+} from "./reconcile-health-event.mjs";
+
+describe("buildReconcileHealthEvent", () => {
+  test("failing envelope — WARN, team-keyed name, payload carries failure context", () => {
+    const line = buildReconcileHealthEvent({
+      team: "CTL",
+      action: RECONCILE_FAILING_ACTION,
+      consecutiveFailures: 3,
+      lastSuccessTs: "2026-06-08T10:00:00Z",
+      staleMs: 1800000,
+      reason: "removed-state: Ready",
+    });
+    expect(typeof line).toBe("string");
+    expect(line.endsWith("\n")).toBe(true);
+    const ev = JSON.parse(line);
+    expect(ev.attributes["event.name"]).toBe("monitor.reconcile.failing.CTL");
+    expect(ev.attributes["event.entity"]).toBe("monitor");
+    expect(ev.attributes["event.action"]).toBe("reconcile.failing");
+    expect(ev.attributes["event.label"]).toBe("CTL");
+    expect(ev.attributes["catalyst.team"]).toBe("CTL");
+    // A team-wide failure has no Linear issue identifier.
+    expect(ev.attributes["linear.issue.identifier"]).toBeUndefined();
+    expect(ev.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(ev.severityText).toBe("WARN");
+    expect(ev.severityNumber).toBe(13);
+    expect(ev.body.payload).toMatchObject({
+      team: "CTL",
+      action: "failing",
+      consecutiveFailures: 3,
+      lastSuccessTs: "2026-06-08T10:00:00Z",
+      staleMs: 1800000,
+      reason: "removed-state: Ready",
+    });
+    expect(ev.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  test("recovered envelope — INFO severity", () => {
+    const ev = JSON.parse(
+      buildReconcileHealthEvent({ team: "CTL", action: RECONCILE_RECOVERED_ACTION }),
+    );
+    expect(ev.attributes["event.name"]).toBe("monitor.reconcile.recovered.CTL");
+    expect(ev.attributes["event.action"]).toBe("reconcile.recovered");
+    expect(ev.severityText).toBe("INFO");
+    expect(ev.severityNumber).toBe(9);
+  });
+
+  test("optional payload fields default to null when omitted", () => {
+    const ev = JSON.parse(buildReconcileHealthEvent({ team: "CTL", action: "failing" }));
+    expect(ev.body.payload.consecutiveFailures).toBeNull();
+    expect(ev.body.payload.lastSuccessTs).toBeNull();
+    expect(ev.body.payload.staleMs).toBeNull();
+    expect(ev.body.payload.reason).toBeNull();
+  });
+});
+
+describe("appendReconcileHealthEvent", () => {
+  test("best-effort: injected appendFn that throws returns false and does not throw", () => {
+    const result = appendReconcileHealthEvent({
+      team: "CTL",
+      action: "failing",
+      append: () => {
+        throw new Error("disk full");
+      },
+    });
+    expect(result).toBe(false);
+  });
+
+  test("best-effort: injected appendFn receives valid JSONL, returns true", () => {
+    const appended = [];
+    const result = appendReconcileHealthEvent({
+      team: "CTL",
+      action: "failing",
+      consecutiveFailures: 4,
+      append: (line) => appended.push(line),
+    });
+    expect(result).toBe(true);
+    expect(appended).toHaveLength(1);
+    const ev = JSON.parse(appended[0]);
+    expect(ev.attributes["event.name"]).toBe("monitor.reconcile.failing.CTL");
+    expect(ev.body.payload.consecutiveFailures).toBe(4);
+  });
+});

--- a/plugins/dev/scripts/execution-core/reconcile-health.mjs
+++ b/plugins/dev/scripts/execution-core/reconcile-health.mjs
@@ -1,0 +1,188 @@
+// reconcile-health.mjs — per-team reconcile-health tracking + escalation (CTL-867).
+//
+// The bug: when a team's eligibleQuery errors every reconcile poll (e.g. its
+// status references a removed Linear state → `linearis issues list --team X
+// --status Ready` exits 1), reconcileProject's catch preserves the prior
+// eligible set and logs `reconcile poll failed — preserving prior eligible set`.
+// That is correct for a transient blip, but a PERSISTENT failure freezes the
+// team's eligible projection stale for hours: no new Todo tickets ever become
+// eligible, the daemon looks healthy, and the whole team starves invisibly.
+//
+// This module is the visibility fix. It tracks per-team reconcile health on the
+// monitor (consecutive-failure count + last-successful-refresh timestamp),
+// escalates a canonical `monitor.reconcile.failing.<TEAM>` event to the unified
+// event log after N consecutive failures (so the orch-monitor dashboard surfaces
+// the failing team), and clears the alert (emitting `monitor.reconcile.recovered
+// .<TEAM>`) when a poll succeeds again. It also persists a per-team health marker
+// file the orch-monitor server reads to render each team's "last successful
+// eligible refresh age".
+
+import { writeFileSync, readFileSync, renameSync, mkdirSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import {
+  getReconcileHealthDir,
+  RECONCILE_FAILURE_ALERT_THRESHOLD,
+  log,
+} from "./config.mjs";
+import {
+  appendReconcileHealthEvent as defaultAppendEvent,
+  RECONCILE_FAILING_ACTION,
+  RECONCILE_RECOVERED_ACTION,
+} from "./reconcile-health-event.mjs";
+
+// team -> { consecutiveFailures, lastSuccessTs, alerting }
+const health = new Map();
+
+function healthPath(team) {
+  return join(getReconcileHealthDir(), `${team}.json`);
+}
+
+// writeHealthMarker — atomically persist a team's health marker. Best-effort: a
+// disk fault must never crash the reconcile timer, so a write failure is logged
+// and swallowed (the in-memory state remains authoritative; the next reconcile
+// retries the marker write).
+function writeHealthMarker(team, state) {
+  const body = JSON.stringify(
+    {
+      team,
+      lastSuccessTs: state.lastSuccessTs,
+      consecutiveFailures: state.consecutiveFailures,
+      alerting: state.alerting,
+      updatedAt: new Date().toISOString(),
+    },
+    null,
+    2,
+  );
+  try {
+    mkdirSync(getReconcileHealthDir(), { recursive: true });
+    const file = healthPath(team);
+    const tmp = `${file}.tmp`;
+    writeFileSync(tmp, body);
+    renameSync(tmp, file);
+  } catch (err) {
+    log.warn({ team, err: err.message }, "reconcile-health: marker write failed");
+  }
+}
+
+function ensureEntry(team) {
+  let entry = health.get(team);
+  if (!entry) {
+    entry = { consecutiveFailures: 0, lastSuccessTs: null, alerting: false };
+    health.set(team, entry);
+  }
+  return entry;
+}
+
+// recordReconcileSuccess — a reconcile poll succeeded for `team`. Resets the
+// consecutive-failure counter, stamps lastSuccessTs, and — if the team was
+// alerting — emits a recovery event and clears the alert. Best-effort throughout;
+// the `appendEvent`/`now` seams are injectable for tests.
+export function recordReconcileSuccess(
+  team,
+  { appendEvent = defaultAppendEvent, now = () => new Date().toISOString() } = {},
+) {
+  const entry = ensureEntry(team);
+  const wasAlerting = entry.alerting;
+  const priorFailures = entry.consecutiveFailures;
+  entry.consecutiveFailures = 0;
+  entry.lastSuccessTs = now();
+  entry.alerting = false;
+  if (wasAlerting) {
+    log.info(
+      { team, priorFailures },
+      "reconcile-health: team recovered — eligible set refreshing again (CTL-867)",
+    );
+    appendEvent({
+      team,
+      action: RECONCILE_RECOVERED_ACTION,
+      consecutiveFailures: 0,
+      lastSuccessTs: entry.lastSuccessTs,
+      reason: "reconcile-poll-succeeded",
+    });
+  }
+  writeHealthMarker(team, entry);
+}
+
+// recordReconcileFailure — a reconcile poll threw for `team`. Increments the
+// consecutive-failure counter; once it crosses RECONCILE_FAILURE_ALERT_THRESHOLD
+// (and the team is not already alerting), escalates a single
+// monitor.reconcile.failing.<TEAM> event so the failure surfaces on the
+// dashboard instead of staying buried in a log.error. The alert is emitted ONCE
+// per failing streak (the `alerting` latch) — a recovery clears it. Best-effort;
+// `appendEvent`/`threshold` seams are injectable for tests.
+export function recordReconcileFailure(
+  team,
+  reason,
+  {
+    appendEvent = defaultAppendEvent,
+    threshold = RECONCILE_FAILURE_ALERT_THRESHOLD,
+  } = {},
+) {
+  const entry = ensureEntry(team);
+  entry.consecutiveFailures += 1;
+  const staleMs = entry.lastSuccessTs
+    ? Date.now() - Date.parse(entry.lastSuccessTs)
+    : null;
+  if (entry.consecutiveFailures >= threshold && !entry.alerting) {
+    entry.alerting = true;
+    log.error(
+      { team, consecutiveFailures: entry.consecutiveFailures, lastSuccessTs: entry.lastSuccessTs },
+      "reconcile-health: team reconcile failing persistently — escalating monitor.reconcile.failing (CTL-867)",
+    );
+    appendEvent({
+      team,
+      action: RECONCILE_FAILING_ACTION,
+      consecutiveFailures: entry.consecutiveFailures,
+      lastSuccessTs: entry.lastSuccessTs,
+      staleMs,
+      reason: reason ?? "reconcile-poll-failed",
+    });
+  }
+  writeHealthMarker(team, entry);
+}
+
+// getReconcileHealth — a copy of a team's in-memory health state, or null when
+// the team has never been reconciled this process. Test/inspection helper.
+export function getReconcileHealth(team) {
+  const entry = health.get(team);
+  return entry ? { ...entry } : null;
+}
+
+// readReconcileHealthMarkers — read every persisted per-team health marker as a
+// { [team]: marker } map. Used by the orch-monitor server to surface per-team
+// "last successful eligible refresh age" in /api/snapshot. Never throws: a
+// missing dir, an unreadable/malformed marker, or an absent field yields an
+// empty/partial map. `dir` is injectable for tests.
+export function readReconcileHealthMarkers({ dir = getReconcileHealthDir() } = {}) {
+  const out = {};
+  let files;
+  try {
+    files = readdirSync(dir);
+  } catch {
+    return out; // dir absent — no team has been reconciled yet
+  }
+  for (const f of files) {
+    if (!f.endsWith(".json") || f.endsWith(".tmp")) continue;
+    const team = f.slice(0, -".json".length);
+    try {
+      const parsed = JSON.parse(readFileSync(join(dir, f), "utf8"));
+      out[team] = {
+        team,
+        lastSuccessTs: parsed.lastSuccessTs ?? null,
+        consecutiveFailures:
+          typeof parsed.consecutiveFailures === "number" ? parsed.consecutiveFailures : 0,
+        alerting: parsed.alerting === true,
+        updatedAt: parsed.updatedAt ?? null,
+      };
+    } catch {
+      // unreadable / malformed marker — skip this team, keep the rest
+    }
+  }
+  return out;
+}
+
+// __resetReconcileHealthForTests — clear the in-memory health map between tests.
+// Not part of the public contract.
+export function __resetReconcileHealthForTests() {
+  health.clear();
+}

--- a/plugins/dev/scripts/execution-core/reconcile-health.mjs
+++ b/plugins/dev/scripts/execution-core/reconcile-health.mjs
@@ -64,13 +64,50 @@ function writeHealthMarker(team, state) {
   }
 }
 
+// ensureEntry — return the in-memory health entry for `team`, creating it lazily.
+//
+// CTL-867 cross-restart fix: the in-memory `health` Map is empty on every process
+// start, so the first call after a daemon restart would otherwise seed a FRESH
+// {consecutiveFailures:0, lastSuccessTs:null, alerting:false}. For a team that has
+// been failing for hours, the very next failure would then writeHealthMarker over
+// the truthful disk marker — resetting consecutiveFailures to 1, dropping the real
+// lastSuccessTs to null, and clearing the alerting latch. That defeats the exact
+// cross-restart starvation scenario this module targets. So on first touch we
+// HYDRATE the seed from the persisted per-team marker; only an absent/malformed
+// marker falls back to fresh defaults.
 function ensureEntry(team) {
   let entry = health.get(team);
   if (!entry) {
-    entry = { consecutiveFailures: 0, lastSuccessTs: null, alerting: false };
+    entry = hydrateEntry(team) ?? {
+      consecutiveFailures: 0,
+      lastSuccessTs: null,
+      alerting: false,
+    };
     health.set(team, entry);
   }
   return entry;
+}
+
+// hydrateEntry — read a team's persisted health marker and project it into a
+// fresh in-memory entry, preserving consecutiveFailures / lastSuccessTs / alerting
+// across a process restart. Returns null when the marker is absent or unreadable
+// (caller falls back to fresh defaults). Never throws — a disk fault must never
+// crash the reconcile timer. Reuses readReconcileHealthMarkers' parse/coercion so
+// the hydrated shape matches the marker schema exactly.
+function hydrateEntry(team) {
+  try {
+    const markers = readReconcileHealthMarkers();
+    const marker = markers[team];
+    if (!marker) return null;
+    return {
+      consecutiveFailures:
+        typeof marker.consecutiveFailures === "number" ? marker.consecutiveFailures : 0,
+      lastSuccessTs: marker.lastSuccessTs ?? null,
+      alerting: marker.alerting === true,
+    };
+  } catch {
+    return null; // best-effort: any read/parse fault → fresh defaults
+  }
 }
 
 // recordReconcileSuccess — a reconcile poll succeeded for `team`. Resets the

--- a/plugins/dev/scripts/orch-monitor/lib/reconcile-health-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/reconcile-health-reader.test.ts
@@ -1,0 +1,91 @@
+// reconcile-health-reader.test.ts — CTL-867: reads the execution-core per-team
+// reconcile-health markers so /api/snapshot can surface each team's "last
+// successful eligible refresh age".
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { readReconcileHealth } from "./reconcile-health-reader.ts";
+
+let catalystDir: string;
+
+beforeEach(() => {
+  catalystDir = mkdtempSync(join(tmpdir(), "recon-health-"));
+});
+
+afterEach(() => {
+  rmSync(catalystDir, { recursive: true, force: true });
+});
+
+function writeMarker(team: string, marker: Record<string, unknown>) {
+  const dir = join(catalystDir, "execution-core", "reconcile-health");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${team}.json`), JSON.stringify(marker));
+}
+
+describe("readReconcileHealth", () => {
+  test("missing dir → empty map (never throws)", () => {
+    expect(readReconcileHealth(catalystDir)).toEqual({});
+  });
+
+  test("computes ageMs from lastSuccessTs against injected now", () => {
+    writeMarker("ENG", {
+      team: "ENG",
+      lastSuccessTs: "2026-06-08T10:00:00Z",
+      consecutiveFailures: 0,
+      alerting: false,
+      updatedAt: "2026-06-08T10:00:00Z",
+    });
+    const now = () => Date.parse("2026-06-08T10:05:00Z");
+    const health = readReconcileHealth(catalystDir, { now });
+    expect(health.ENG).toBeDefined();
+    expect(health.ENG.ageMs).toBe(5 * 60_000);
+    expect(health.ENG.alerting).toBe(false);
+    expect(health.ENG.consecutiveFailures).toBe(0);
+  });
+
+  test("surfaces a starving team — alerting true, consecutiveFailures set, frozen lastSuccessTs", () => {
+    writeMarker("CTL", {
+      team: "CTL",
+      lastSuccessTs: "2026-06-08T08:00:00Z",
+      consecutiveFailures: 12,
+      alerting: true,
+      updatedAt: "2026-06-08T10:00:00Z",
+    });
+    const now = () => Date.parse("2026-06-08T10:00:00Z");
+    const health = readReconcileHealth(catalystDir, { now });
+    expect(health.CTL.alerting).toBe(true);
+    expect(health.CTL.consecutiveFailures).toBe(12);
+    expect(health.CTL.ageMs).toBe(2 * 60 * 60_000); // 2h stale
+  });
+
+  test("null lastSuccessTs → ageMs null (never refreshed)", () => {
+    writeMarker("NEW", { team: "NEW", lastSuccessTs: null, consecutiveFailures: 1, alerting: false });
+    const health = readReconcileHealth(catalystDir);
+    expect(health.NEW.lastSuccessTs).toBeNull();
+    expect(health.NEW.ageMs).toBeNull();
+  });
+
+  test("malformed marker is skipped; valid siblings still read", () => {
+    writeMarker("GOOD", {
+      team: "GOOD",
+      lastSuccessTs: "2026-06-08T10:00:00Z",
+      consecutiveFailures: 0,
+      alerting: false,
+    });
+    const dir = join(catalystDir, "execution-core", "reconcile-health");
+    writeFileSync(join(dir, "BAD.json"), "{ not json");
+    const health = readReconcileHealth(catalystDir);
+    expect(health.GOOD).toBeDefined();
+    expect(health.BAD).toBeUndefined();
+  });
+
+  test("ignores .tmp files and non-json entries", () => {
+    const dir = join(catalystDir, "execution-core", "reconcile-health");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "ENG.json.tmp"), "{}");
+    writeFileSync(join(dir, "README"), "ignore me");
+    expect(readReconcileHealth(catalystDir)).toEqual({});
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/reconcile-health-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/reconcile-health-reader.ts
@@ -1,0 +1,85 @@
+// reconcile-health-reader.ts — read the execution-core per-team reconcile-health
+// markers so /api/snapshot can surface each team's "last successful eligible
+// refresh age" (CTL-867).
+//
+// The execution-core monitor writes one marker per team at
+//   ${CATALYST_DIR}/execution-core/reconcile-health/<team>.json
+// on every reconcile (success or failure). The marker's `lastSuccessTs` is the
+// truthful staleness signal — unlike the eligible projection's content-keyed
+// `updatedAt`, which is skipped when the eligible set is unchanged, so it can
+// look fresh while no poll has actually succeeded in hours. A team whose
+// `alerting` flag is set has crossed the consecutive-failure threshold and is
+// silently starving (its eligible projection is frozen stale).
+//
+// This reader never throws: a missing dir, an unreadable/malformed marker, or an
+// absent field degrades to an empty/partial result so the dashboard stays up.
+
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+
+export interface TeamReconcileHealth {
+  team: string;
+  /** ISO timestamp of the last successful eligible-set refresh, or null. */
+  lastSuccessTs: string | null;
+  /** Milliseconds since the last successful refresh, or null when never succeeded. */
+  ageMs: number | null;
+  /** Consecutive reconcile-poll failures for this team. */
+  consecutiveFailures: number;
+  /** True once the consecutive-failure threshold is crossed — the team is starving. */
+  alerting: boolean;
+  /** ISO timestamp the marker was last written (every reconcile). */
+  updatedAt: string | null;
+}
+
+function asString(x: unknown): string | null {
+  return typeof x === "string" && x.length > 0 ? x : null;
+}
+
+function asNumber(x: unknown, fallback: number): number {
+  return typeof x === "number" && Number.isFinite(x) ? x : fallback;
+}
+
+/**
+ * readReconcileHealth — read every per-team reconcile-health marker under
+ * `${catalystDir}/execution-core/reconcile-health/`. Returns a map keyed by team.
+ * `now` is injectable for deterministic age computation in tests.
+ */
+export function readReconcileHealth(
+  catalystDir: string,
+  { now = Date.now }: { now?: () => number } = {},
+): Record<string, TeamReconcileHealth> {
+  const out: Record<string, TeamReconcileHealth> = {};
+  const dir = join(catalystDir, "execution-core", "reconcile-health");
+  let files: string[];
+  try {
+    files = readdirSync(dir);
+  } catch {
+    return out; // dir absent — no team has been reconciled yet
+  }
+  for (const f of files) {
+    if (!f.endsWith(".json") || f.endsWith(".tmp")) continue;
+    const team = f.slice(0, -".json".length);
+    const file = join(dir, f);
+    try {
+      statSync(file); // skip phantom dirents
+      const parsed = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>;
+      const lastSuccessTs = asString(parsed.lastSuccessTs);
+      let ageMs: number | null = null;
+      if (lastSuccessTs) {
+        const t = Date.parse(lastSuccessTs);
+        if (Number.isFinite(t)) ageMs = Math.max(0, now() - t);
+      }
+      out[team] = {
+        team,
+        lastSuccessTs,
+        ageMs,
+        consecutiveFailures: asNumber(parsed.consecutiveFailures, 0),
+        alerting: parsed.alerting === true,
+        updatedAt: asString(parsed.updatedAt),
+      };
+    } catch {
+      // unreadable / malformed marker — skip this team, keep the rest
+    }
+  }
+  return out;
+}

--- a/plugins/dev/scripts/orch-monitor/lib/state-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/state-reader.ts
@@ -168,6 +168,29 @@ export interface MonitorSnapshot {
    * single-host consumers ignore it.
    */
   hostName?: string;
+  /**
+   * CTL-867: per-team reconcile health, keyed by Linear team. Surfaces each
+   * team's "last successful eligible refresh age" (lastSuccessTs/ageMs) plus the
+   * consecutive-failure count and the `alerting` flag the execution-core monitor
+   * sets once a team's eligibleQuery has failed persistently (its eligible set is
+   * frozen stale — silent starvation). Optional/additive: populated by server.ts
+   * from the execution-core reconcile-health markers; absent on snapshots built
+   * by consumers that do not read them.
+   */
+  reconcileHealth?: Record<string, TeamReconcileHealth>;
+}
+
+/**
+ * CTL-867 — per-team reconcile-health view surfaced in the snapshot. Mirrors the
+ * marker the execution-core monitor writes; see lib/reconcile-health-reader.ts.
+ */
+export interface TeamReconcileHealth {
+  team: string;
+  lastSuccessTs: string | null;
+  ageMs: number | null;
+  consecutiveFailures: number;
+  alerting: boolean;
+  updatedAt: string | null;
 }
 
 export interface BuildSnapshotOptions {

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -10,6 +10,7 @@ import {
   type SessionState,
 } from "./lib/state-reader";
 import { readSessionStore } from "./lib/session-store";
+import { readReconcileHealth } from "./lib/reconcile-health-reader"; // CTL-867
 import type { BoardPayload } from "./lib/board-data.mjs";
 import { createBoardSnapshotManager } from "./lib/board-snapshot.mjs";
 import { queryHistory, queryStats, compareSessions } from "./lib/history-store";
@@ -768,6 +769,15 @@ export function createServer(opts: CreateServerOptions): BunServer {
         () => collectTicketKeys(buildSnapshot(wtDir, buildOpts)),
         linearRefreshMs,
       );
+    }
+    // CTL-867: surface per-team reconcile health (last successful eligible
+    // refresh age + the `alerting` flag) so the dashboard can show a team whose
+    // eligibleQuery is failing persistently — its eligible set frozen stale,
+    // silently starving. Best-effort: the reader never throws (missing dir →
+    // empty map). Omitted entirely when no team has a marker yet.
+    const reconcileHealth = readReconcileHealth(CATALYST_DIR);
+    if (Object.keys(reconcileHealth).length > 0) {
+      snap.reconcileHealth = reconcileHealth;
     }
     return snap;
   }


### PR DESCRIPTION
## Problem (CTL-867)

`plugins/dev/scripts/execution-core/monitor.mjs` `reconcileProject` — when a team's `eligibleQuery` errors every poll (e.g. its `status` references a removed Linear state, so `linearis issues list --team X --status Ready` exits 1), the `catch` logged a single buried `reconcile poll failed — preserving prior eligible set` and silently continued.

Preserving the prior set is correct for a transient blip. But a **persistent** failure froze that team's eligible projection stale for hours: no new `Todo` tickets became eligible, the daemon looked healthy, and the whole team starved **invisibly**.

## Fix

1. **Per-team reconcile-health tracking** — new `reconcile-health.mjs` keeps a consecutive-failure count + last-successful-refresh timestamp per team on the monitor, and persists a per-team marker at `~/catalyst/execution-core/reconcile-health/<team>.json` on every reconcile (success or failure).

2. **Escalation** — after `RECONCILE_FAILURE_ALERT_THRESHOLD` (default 3, env-overridable) consecutive failures, the monitor emits a canonical `monitor.reconcile.failing.<TEAM>` (WARN) event onto the unified event log so the orch-monitor dashboard surfaces the starving team. A recovering poll resets the counter, clears the alert, and emits `monitor.reconcile.recovered.<TEAM>` (INFO). The alert is **latched per-streak** — emitted once per failing run, re-armed after a recovery. Envelope shape (`reconcile-health-event.mjs`) mirrors the established `triage-transition-event.mjs` / `memory-event.mjs` canonical-event pattern.

3. **Dashboard visibility** — `/api/snapshot` (orch-monitor `server.ts`) now carries per-team `reconcileHealth` (`lastSuccessTs` / `ageMs` / `consecutiveFailures` / `alerting`) via new `lib/reconcile-health-reader.ts`. The health marker is the truthful staleness signal: the eligible projection's own content-keyed `updatedAt` is **skipped when the set is unchanged**, so it can look fresh while no poll has actually succeeded in hours.

## Tests

- `execution-core/monitor.test.mjs` — escalation after N consecutive throws (alert exactly once), recovery clears + resets the counter, a sub-threshold transient failure never alerts, a new streak re-alerts after recovery, and the per-team marker is persisted.
- `execution-core/reconcile-health-event.test.mjs` — failing/recovered envelope round-trip (WARN/INFO, team-keyed name, payload).
- `orch-monitor/lib/reconcile-health-reader.test.ts` — age computation, starving-team surfacing, malformed-marker skip, `.tmp`/non-json ignored.

`bun test plugins/dev/scripts/execution-core/monitor.test.mjs` → 113 pass, 1 fail. The 1 failure is the **pre-existing** CTL-716 burst-budget timeout (confirmed failing on clean `main`, unrelated to this change). orch-monitor suite: all reconcile-health-reader tests pass; the only intermittent suite failures (session-store SQLite, SSE board-snapshot) are pre-existing flakes confirmed on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)