### PR TITLE
CTL-862: Wire HRW ownership + claim into monitor dispatchTriage + daemon boot-log

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -39,7 +39,10 @@ import {
   readWaitWatcherConfig,
   readMemorySamplerConfig,
   readRatelimitPollerConfig,
+  getHostName,      // CTL-862
+  getClusterHosts,  // CTL-862
 } from "./config.mjs";
+import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
 import { startWaitWatcher as realStartWaitWatcher } from "./wait-watcher.mjs";
 import { startMemorySampler as realStartMemorySampler } from "./memory-sampler.mjs";
 import { startRatelimitPoller as realStartRatelimitPoller } from "./ratelimit-poller.mjs";
@@ -77,6 +80,7 @@ import {
   readExecutionCoreConcurrency,
   readExecutionCoreConcurrencyLayer2,
   mergeExecutionCoreConcurrency,
+  readAllEligibleTickets, // CTL-862: boot-log ownership count
 } from "./scheduler.mjs";
 import { writeBootMarker, clearProgressMarks } from "./recovery.mjs"; // CTL-655: window the revive budget to this run; CTL-736: reset progress high-water
 import { startAutoTuner } from "./autotune.mjs"; // CTL-684: side-car maxParallel auto-tuner
@@ -376,9 +380,18 @@ export function startDaemon({
   // CTL-854: injectable for the boot empty-registry health check. Tests inject
   // a deterministic fake; production uses the real registry reader.
   listProjects: listProjectsFn = realListProjects,
+  // CTL-862: injectable seams for the ownership boot-log. Tests inject a fixed
+  // roster and eligible list; production resolves them from the real modules.
+  readAllEligible = readAllEligibleTickets,
+  bootHosts = undefined,
+  bootHostName = undefined,
 } = {}) {
   const orchDir = getExecutionCoreDir();
   ensureState(orchDir);
+  // CTL-862: write the resolved config path back into the env so downstream
+  // callers (getClusterHosts → getCatalystRepoDir) resolve the right repo
+  // regardless of the daemon's cwd. ||= preserves any launcher-provided value.
+  if (configPath) process.env.CATALYST_CONFIG_FILE ||= configPath;
   // CTL-655: record this daemon process's start time so the first scheduler
   // tick's reclaimDeadWorkIfPossible can window the per-ticket revive budget to
   // the current run (a clean restart resets a budget burned by a prior storm).
@@ -586,7 +599,15 @@ export function startDaemon({
     log.warn({ err }, "execution-core daemon: registry health check failed (continuing)");
   }
 
-  log.info({ orchDir }, "execution-core daemon started");
+  // CTL-862: report HRW ownership at boot for multi-host observability.
+  const bootRoster = bootHosts ?? getClusterHosts();
+  const bootSelf = bootHostName ?? getHostName();
+  const bootEligible = readAllEligible();
+  const bootOwns = bootEligible.filter((t) => ownedBy(t.identifier, bootRoster, bootSelf)).length;
+  log.info(
+    { orchDir, host: bootSelf, owns: bootOwns, eligible: bootEligible.length, roster: bootRoster },
+    "execution-core daemon started"
+  );
 }
 
 // startReaperAndTimer — wire the Reaper (CTL-649 Phase 4) and the periodic

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -1539,3 +1539,92 @@ describe("readLinearBotWriteId (CTL-781)", () => {
     expect(() => readLinearBotWriteId(bad, bad)).not.toThrow();
   });
 });
+
+// ── CTL-862: daemon.mjs — CATALYST_CONFIG_FILE propagation + ownership boot-log ──
+//
+// Two independent daemon edits: propagate the resolved config path into process.env
+// so getClusterHosts() resolves the right repo regardless of cwd, and replace the
+// bare boot-log line with one reporting owned-vs-eligible ticket counts.
+describe("CTL-862 — daemon CATALYST_CONFIG_FILE propagation", () => {
+  const baseOpts = () => ({
+    recover: () => ({}),
+    reconcileBoot: () => {},
+    startMonitor: () => {},
+    startScheduler: () => {},
+    stopMonitor: () => {},
+    stopScheduler: () => {},
+    reconcile: () => {},
+    startAutoTuner: () => () => {},
+    watchRegistry: false,
+    listProjects: () => [],
+  });
+
+  test("propagates configPath into CATALYST_CONFIG_FILE when unset (CTL-862)", () => {
+    const prev = process.env.CATALYST_CONFIG_FILE;
+    delete process.env.CATALYST_CONFIG_FILE;
+    const fakeConfigPath = join(catalystDir, "fake-config.json");
+    try {
+      startDaemon({ ...baseOpts(), configPath: fakeConfigPath });
+      expect(process.env.CATALYST_CONFIG_FILE).toBe(fakeConfigPath);
+    } finally {
+      if (prev === undefined) delete process.env.CATALYST_CONFIG_FILE;
+      else process.env.CATALYST_CONFIG_FILE = prev;
+    }
+  });
+
+  test("does NOT overwrite CATALYST_CONFIG_FILE already set (||= semantics, CTL-862)", () => {
+    const prev = process.env.CATALYST_CONFIG_FILE;
+    const preExisting = "/pre-set/catalyst/config.json";
+    process.env.CATALYST_CONFIG_FILE = preExisting;
+    try {
+      startDaemon({ ...baseOpts(), configPath: "/new/config.json" });
+      expect(process.env.CATALYST_CONFIG_FILE).toBe(preExisting);
+    } finally {
+      if (prev === undefined) delete process.env.CATALYST_CONFIG_FILE;
+      else process.env.CATALYST_CONFIG_FILE = prev;
+    }
+  });
+});
+
+describe("CTL-862 — daemon boot-log ownership context", () => {
+  const baseOpts = () => ({
+    recover: () => ({}),
+    reconcileBoot: () => {},
+    startMonitor: () => {},
+    startScheduler: () => {},
+    stopMonitor: () => {},
+    stopScheduler: () => {},
+    reconcile: () => {},
+    startAutoTuner: () => () => {},
+    watchRegistry: false,
+    listProjects: () => [],
+  });
+
+  test("boot log carries host/owns/eligible/roster fields (CTL-862)", () => {
+    const infoSpy = spyOn(log, "info");
+    const ROSTER = ["mini", "mac-studio"];
+    const SELF = "mini";
+    const eligible = [{ identifier: "ENG-1" }, { identifier: "ENG-2" }];
+    try {
+      startDaemon({
+        ...baseOpts(),
+        readAllEligible: () => eligible,
+        bootHosts: ROSTER,
+        bootHostName: SELF,
+      });
+      const bootCall = infoSpy.mock.calls.find(
+        (c) => typeof c[1] === "string" && c[1].includes("daemon started")
+      );
+      expect(bootCall).toBeDefined();
+      const obj = bootCall[0];
+      expect(obj.host).toBe(SELF);
+      expect(Array.isArray(obj.roster)).toBe(true);
+      expect(obj.eligible).toBe(eligible.length);
+      expect(typeof obj.owns).toBe("number");
+      expect(obj.owns).toBeGreaterThanOrEqual(0);
+      expect(obj.owns).toBeLessThanOrEqual(eligible.length);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+});

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -33,7 +33,11 @@ import {
   EVENT_DEBOUNCE_MS,
   TAILER_POLL_INTERVAL_MS,
   log,
+  getHostName,      // CTL-862
+  getClusterHosts,  // CTL-862
 } from "./config.mjs";
+import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
+import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS
 import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry.mjs";
 import { runEligibleQuery, fetchTicketAssignee, isAssigneeClaimable } from "./linear-query.mjs";
 import { setProjectEligible, removeTicket, dropProject, getEligibleSet, upsertTicket } from "./eligible-set.mjs";
@@ -333,6 +337,10 @@ export function handleStateChangedEvent(
     gateway,
     fetchAssignee = fetchTicketAssignee,
     applyAssignee = defaultApplyAssignee,
+    // CTL-862: cross-host coordination seams.
+    hosts = undefined,
+    hostName = undefined,
+    claimDispatch = claimDispatchSync,
   } = {}
 ) {
   const parsed = parseStateChangedEvent(event);
@@ -371,6 +379,7 @@ export function handleStateChangedEvent(
           gateway,
           fetchAssignee,
           applyAssignee,
+          hosts, hostName, claimDispatch, // CTL-862
         });
       }
     } else if (!parsed.toState || parsed.toState === query.status) {
@@ -422,6 +431,7 @@ export function handleStateChangedEvent(
           gateway,
           fetchAssignee,
           applyAssignee,
+          hosts, hostName, claimDispatch, // CTL-862
         });
       } else {
         log.debug(
@@ -498,9 +508,25 @@ function dispatchTriage(identifier, {
   gateway,
   fetchAssignee = fetchTicketAssignee,
   applyAssignee = defaultApplyAssignee,
+  // CTL-862: cross-host coordination seams (left undefined → single-host fallback).
+  hosts = undefined,
+  hostName = undefined,
+  claimDispatch = claimDispatchSync,
 }) {
   if (!orchDir) {
     log.warn({ identifier }, "→Triage seen but monitor has no orchDir — skipping dispatch");
+    return false;
+  }
+  // CTL-862: HRW ownership filter. Resolve roster/self lazily per call so hot
+  // roster reloads need no restart. Single-host roster → ownedBy is identity.
+  const roster = hosts ?? getClusterHosts();
+  const self = hostName ?? getHostName();
+  const multiHost = roster.length > 1;
+  if (!ownedBy(identifier, roster, self)) {
+    log.debug(
+      { identifier, self, roster },
+      "ctl-862: ticket not owned by this host under HRW — skipping triage dispatch"
+    );
     return false;
   }
   if (budget && budget.remaining <= 0) {
@@ -520,6 +546,18 @@ function dispatchTriage(identifier, {
       log.info(
         { identifier, known: a.known, assignee: a.known ? (a.assignee ?? null) : undefined },
         "monitor: triage dispatch skipped — respect-assignment (CTL-781)"
+      );
+      return false;
+    }
+  }
+  // CTL-862: cross-host claim soft-CAS immediately before the spawn. Skipped on
+  // single-host (no Linear write). A lost claim is NOT a failure — defer cleanly.
+  if (multiHost) {
+    const claim = claimDispatch({ ticket: identifier, hostName: self, phase: "triage" });
+    if (!claim.won) {
+      log.debug(
+        { identifier, self },
+        "ctl-862: lost cross-host claim — another host owns this triage dispatch, deferring"
       );
       return false;
     }
@@ -594,6 +632,10 @@ export function sweepMissingTriage({
   gateway,
   fetchAssignee = fetchTicketAssignee,
   applyAssignee = defaultApplyAssignee,
+  // CTL-862: cross-host coordination seams.
+  hosts = undefined,
+  hostName = undefined,
+  claimDispatch = claimDispatchSync,
 } = {}) {
   if (!orchDir) {
     log.debug("sweepMissingTriage: no orchDir wired — skipping triage sweep");
@@ -617,6 +659,7 @@ export function sweepMissingTriage({
         gateway,
         fetchAssignee,
         applyAssignee,
+        hosts, hostName, claimDispatch, // CTL-862
       });
     }
   }

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -6,6 +6,7 @@
 // per-repo enrollment records are gone.
 
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { ownerForTicket } from "./hrw.mjs"; // CTL-862: HRW owner computation for ownership-filter tests
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, appendFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -1816,5 +1817,125 @@ describe("sweepMissingTriage — CTL-781 threading", () => {
     } finally {
       rmSync(orchDir, { recursive: true, force: true });
     }
+  });
+});
+
+// ── CTL-862: HRW ownership filter + claim-on-dispatch (monitor dispatchTriage) ──
+//
+// Mirrors scheduler.test.mjs:7092-7206 but drives dispatchTriage through the
+// exported handleStateChangedEvent (→Triage branch) and sweepMissingTriage,
+// since dispatchTriage is not exported. The entry phase asserted in the claim
+// payload is "triage" (not "research" as in the scheduler). Safe-by-construction:
+// a single-host roster is an exact no-op until a 2nd host joins.
+describe("CTL-862 — HRW ownership + claim-on-dispatch (monitor dispatchTriage)", () => {
+  const ROSTER = ["mini", "mac-studio"];
+  const TICKET = "ENG-1";
+  const OWNER = ownerForTicket(TICKET, ROSTER);
+  const OTHER = ROSTER.find((h) => h !== OWNER);
+
+  const triageEvent = () => ({
+    event: "linear.issue.state_changed",
+    detail: { ticket: TICKET, teamKey: "ENG", toState: "Triage" },
+  });
+
+  const recordClaim = (verdict) => {
+    const calls = [];
+    const fn = (arg) => { calls.push(arg); return verdict; };
+    fn.calls = calls;
+    return fn;
+  };
+
+  const fakeOrchDir = "/fake-orch-862";
+
+  test("single-host roster is an exact no-op: claim NEVER attempted, dispatch proceeds", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const claimDispatch = recordClaim({ won: false, generation: null });
+    handleStateChangedEvent(triageEvent(), {
+      dispatch,
+      orchDir: fakeOrchDir,
+      hosts: ["solo"],
+      hostName: "solo",
+      claimDispatch,
+      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      appendEvent: () => {},
+    });
+    expect(claimDispatch.calls).toHaveLength(0);
+    expect(dispatch).toHaveBeenCalledWith({ orchDir: fakeOrchDir, ticket: TICKET, phase: "triage" });
+  });
+
+  test("multi-host: a ticket OWNED by this host is dispatched + claim ran with phase 'triage'", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const claimDispatch = recordClaim({ won: true, generation: 1 });
+    handleStateChangedEvent(triageEvent(), {
+      dispatch,
+      orchDir: fakeOrchDir,
+      hosts: ROSTER,
+      hostName: OWNER,
+      claimDispatch,
+      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      appendEvent: () => {},
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(claimDispatch.calls).toHaveLength(1);
+    expect(claimDispatch.calls[0]).toEqual({ ticket: TICKET, hostName: OWNER, phase: "triage" });
+  });
+
+  test("multi-host: a ticket owned by ANOTHER host is filtered — no claim, no dispatch", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const claimDispatch = recordClaim({ won: true, generation: 1 });
+    handleStateChangedEvent(triageEvent(), {
+      dispatch,
+      orchDir: fakeOrchDir,
+      hosts: ROSTER,
+      hostName: OTHER,
+      claimDispatch,
+      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      appendEvent: () => {},
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(claimDispatch.calls).toHaveLength(0);
+  });
+
+  test("multi-host: a LOST claim defers — no dispatch, no triage status write", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const claimDispatch = recordClaim({ won: false, generation: 2 });
+    const applyTriageStatus = mock(() => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }));
+    handleStateChangedEvent(triageEvent(), {
+      dispatch,
+      orchDir: fakeOrchDir,
+      hosts: ROSTER,
+      hostName: OWNER,
+      claimDispatch,
+      applyTriageStatus,
+      appendEvent: () => {},
+    });
+    expect(claimDispatch.calls).toHaveLength(1);
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(applyTriageStatus).not.toHaveBeenCalled();
+  });
+
+  test("sweepMissingTriage path: OWNED ticket is dispatched + claim ran with phase 'triage'", () => {
+    enroll("ENG", { status: "Ready" });
+    setProjectEligible("ENG", [{ identifier: TICKET, state: "Todo", priority: 1, project: null }]);
+    const dispatch = mock(() => ({ code: 0 }));
+    const claimDispatch = recordClaim({ won: true, generation: 1 });
+    sweepMissingTriage({
+      orchDir: fakeOrchDir,
+      dispatch,
+      hosts: ROSTER,
+      hostName: OWNER,
+      claimDispatch,
+      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      appendEvent: () => {},
+      readMaxParallelFn: () => 5,
+      liveBackgroundCount: () => 0,
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(claimDispatch.calls).toHaveLength(1);
+    expect(claimDispatch.calls[0]).toMatchObject({ ticket: TICKET, phase: "triage" });
   });
 });


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-08T16:39:00Z -->
<!-- Last updated: 2026-06-08T16:39:00Z -->
<!-- PR: #1496 -->
<!-- Previous commits: 2f0a48c42049645a17714127ac1dd374879b9cbe -->

## Summary

Part 2 of 2 of the CTL-850 HRW ownership cutover. Part 1 shipped in PR #1473 (scheduler new-work dispatch path + claim libraries). This PR wires the same HRW ownership filter and soft-CAS claim gate into the **second dispatch entry point** (`dispatchTriage` in `monitor.mjs`) and adds multi-host observability to the daemon boot log.

**Safety invariant preserved:** exact no-op when `.catalyst/hosts.json` has a single host — the `multiHost` guard keeps both the HRW filter and the claim gate off on the live single-host mini.

## Changes Made

### `monitor.mjs` — `dispatchTriage` HRW + claim gate

- Added `hosts`, `hostName`, `claimDispatch` option-bag seams to `dispatchTriage` (fail-open defaults via `getClusterHosts()` / `getHostName()`), mirroring the scheduler pattern from PR #1473.
- After the orchDir guard: `if (!ownedBy(identifier, roster, self)) return;` — one HRW filter covers all three callers (handles the smee fan-out where every host receives every webhook).
- Immediately before `dispatchTicket`: soft-CAS claim gate (`claimDispatchSync`) that returns without error if the claim is lost (another host won — reconsidered next tick).
- Threaded the new seams down through `handleStateChangedEvent` (Triage branch and Ready branch) and `sweepMissingTriage` so all callers go through the single gate.

### `daemon.mjs` — config propagation + ownership boot log

- `process.env.CATALYST_CONFIG_FILE ||= configPath` in `startDaemon()` — propagates the resolved config path so `getClusterHosts()` resolves the right repo regardless of the daemon's `cwd` (the launcher does not export this env var today).
- Replaced the bare `"execution-core daemon started"` log line with one reporting `{ host, owns, eligible, roster }` so operators can confirm correct ownership distribution at startup without a separate query.

### Tests (8 new)

**`monitor.test.mjs`** — 5 dispatchTriage ownership/claim cases:
1. Single-host no-op: roster `['solo']` → claim never attempted, triage dispatched normally.
2. Owned + won: `hostName` = HRW winner → dispatched + claim called with `{ticket, hostName, phase:'triage'}`.
3. Foreign: `hostName` = non-owner → NOT dispatched, claim never reached.
4. Lost claim: owner + `claimDispatch→{won:false}` → NOT dispatched.
5. `sweepMissingTriage` path: seams threaded correctly through the sweep caller.

**`daemon.test.mjs`** — 3 daemon tests:
1. `CATALYST_CONFIG_FILE` propagated when unset.
2. `CATALYST_CONFIG_FILE` NOT overwritten when already set (`||=` semantics).
3. Boot log carries `host`, `owns`, `eligible`, `roster` fields with correct types.

## How to Verify It

- [x] Tests pass: `bun test plugins/dev/scripts/execution-core/monitor.test.mjs daemon.test.mjs` ✅ (120/120 monitor, all 3 daemon CTL-862 blocks pass)
- [x] Full suite: 2344 pass / 5 fail — all 5 pre-existing timing flakes in files not touched by this diff ✅
- [x] TypeScript: N/A — execution-core is plain `.mjs` ✅
- [ ] Regression: start daemon on single-host machine and confirm boot log shows `owns=1` or `0`, not a crash
- [ ] Integration: if a 2-host `.catalyst/hosts.json` is configured, only the HRW-owning host dispatches triage for any given ticket

## Related Issues/PRs

- Fixes https://linear.app/getadva/issue/CTL-862
- Continues work from #1473 (CTL-850 Part 1 — scheduler path)

## Changelog Entry

```
feat(dev): wire HRW ownership + claim into monitor.mjs dispatchTriage + daemon.mjs boot-log (CTL-862)

The second dispatch entry point (monitor's Todo→Triage path) now participates in the
cross-host HRW ownership filter and soft-CAS claim gate, completing the CTL-850 behavioral
cutover. On single-host deployments the gate is a no-op. The daemon boot log now reports
owned/eligible/roster counts for multi-host observability.
```

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-850
