### PR TITLE
fix(dev): CTL-841 self-heal missing wt/ dir in catalyst-monitor start

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-monitor-bootstrap.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-monitor-bootstrap.test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# CTL-841: catalyst-monitor `start` must NOT hard-fail when ~/catalyst/wt is missing.
+#
+# A missing wt/ dir is a fresh-host normal, not a fatal error — a daemon start
+# script should mkdir -p its own runtime dirs and start, rather than dead-end a
+# headless-host operator at an interactive Claude skill. bootstrap() previously
+# pushed "Worktree directory missing" onto its fatal-errors list and returned 1,
+# which aborted cmd_start BEFORE its own `mkdir -p "$CATALYST_DIR/wt"` could run —
+# proving the auto-create was always intended but unreachable.
+#
+# These tests source catalyst-monitor.sh and call bootstrap() directly against a
+# throwaway CATALYST_DIR. MONITOR_SERVER_SCRIPT is pointed at a stub file whose
+# sibling node_modules/ exists, so the orch-monitor install/build block is skipped
+# (the test stays hermetic and fast).
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+MONITOR_SH="${REPO_ROOT}/plugins/dev/scripts/catalyst-monitor.sh"
+
+FAILURES=0
+PASSES=0
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+if [[ ! -f "$MONITOR_SH" ]]; then
+  echo "FATAL: catalyst-monitor.sh missing: $MONITOR_SH" >&2
+  exit 1
+fi
+
+# Build a hermetic sandbox: a CATALYST_DIR and a stub server-script dir whose
+# node_modules/ already exists (so bootstrap skips the bun install/build block).
+# Echoes the sandbox root on stdout.
+make_sandbox() {
+  local root
+  root="$(mktemp -d)"
+  mkdir -p "$root/srv/node_modules"
+  : > "$root/srv/server.ts"
+  echo "$root"
+}
+
+echo "Test: bootstrap self-heals a missing wt/ dir and succeeds"
+ROOT="$(make_sandbox)"
+mkdir -p "$ROOT/catalyst" # CATALYST_DIR exists, but wt/ does NOT
+RESULT="$(
+  CATALYST_DIR="$ROOT/catalyst" MONITOR_SERVER_SCRIPT="$ROOT/srv/server.ts" \
+  bash -c '
+    source "'"$MONITOR_SH"'" url >/dev/null 2>&1
+    bootstrap >/dev/null 2>&1; rc=$?
+    echo "rc=$rc wt=$([ -d "$CATALYST_DIR/wt" ] && echo yes || echo no)"
+  '
+)"
+[[ "$RESULT" == *"rc=0"* ]] && pass "bootstrap returns 0 when wt/ is absent" \
+  || fail "bootstrap should return 0 when wt/ is absent (got: $RESULT)"
+[[ "$RESULT" == *"wt=yes"* ]] && pass "bootstrap creates \$CATALYST_DIR/wt when absent" \
+  || fail "bootstrap should create \$CATALYST_DIR/wt (got: $RESULT)"
+rm -rf "$ROOT"
+
+echo ""
+echo "Test: bootstrap stays idempotent when wt/ already exists"
+ROOT="$(make_sandbox)"
+mkdir -p "$ROOT/catalyst/wt" # both CATALYST_DIR and wt/ already present
+RESULT="$(
+  CATALYST_DIR="$ROOT/catalyst" MONITOR_SERVER_SCRIPT="$ROOT/srv/server.ts" \
+  bash -c '
+    source "'"$MONITOR_SH"'" url >/dev/null 2>&1
+    bootstrap >/dev/null 2>&1; rc=$?
+    echo "rc=$rc wt=$([ -d "$CATALYST_DIR/wt" ] && echo yes || echo no)"
+  '
+)"
+[[ "$RESULT" == *"rc=0"* && "$RESULT" == *"wt=yes"* ]] \
+  && pass "bootstrap returns 0 and leaves an existing wt/ in place" \
+  || fail "bootstrap should be idempotent when wt/ exists (got: $RESULT)"
+rm -rf "$ROOT"
+
+echo ""
+echo "Test: a missing CATALYST_DIR itself stays genuinely fatal"
+ROOT="$(make_sandbox)" # NOTE: $ROOT/catalyst intentionally NOT created
+OUT="$(
+  CATALYST_DIR="$ROOT/catalyst" MONITOR_SERVER_SCRIPT="$ROOT/srv/server.ts" \
+  bash -c '
+    source "'"$MONITOR_SH"'" url >/dev/null 2>&1
+    out=$(bootstrap 2>&1); rc=$?
+    echo "rc=$rc dir=$([ -d "$CATALYST_DIR" ] && echo yes || echo no) wt=$([ -d "$CATALYST_DIR/wt" ] && echo yes || echo no)"
+    echo "$out"
+  '
+)"
+[[ "$OUT" == *"rc=1"* ]] && pass "bootstrap still returns 1 when CATALYST_DIR is missing" \
+  || fail "missing CATALYST_DIR must stay fatal (got: $OUT)"
+[[ "$OUT" == *"Catalyst directory missing"* ]] \
+  && pass "bootstrap still reports the missing-CATALYST_DIR error" \
+  || fail "missing-CATALYST_DIR error message should persist (got: $OUT)"
+# The wt self-heal must NOT manufacture a runtime dir under a missing parent.
+[[ "$OUT" == *"dir=no"* && "$OUT" == *"wt=no"* ]] \
+  && pass "wt self-heal does not run when CATALYST_DIR is absent" \
+  || fail "wt self-heal must not create dirs under a missing CATALYST_DIR (got: $OUT)"
+rm -rf "$ROOT"
+
+echo ""
+echo "Test: the self-heal mkdir replaced the hard-fail (source-level guard)"
+if grep -q 'Worktree directory missing' "$MONITOR_SH"; then
+  fail "catalyst-monitor.sh still hard-fails on missing wt/ ('Worktree directory missing' present)"
+else
+  pass "catalyst-monitor.sh no longer hard-fails on missing wt/"
+fi
+if grep -q 'mkdir -p "$CATALYST_DIR/wt"' "$MONITOR_SH"; then
+  pass "catalyst-monitor.sh mkdir -p's its wt/ runtime dir"
+else
+  fail "catalyst-monitor.sh should mkdir -p \$CATALYST_DIR/wt"
+fi
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "catalyst-monitor-bootstrap: ${PASSES} passed, ${FAILURES} failed"
+if [[ $FAILURES -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -165,8 +165,13 @@ bootstrap() {
     errors+=("Catalyst directory missing: $CATALYST_DIR — run /catalyst-foundry:setup-catalyst first")
   fi
 
-  if [[ ! -d "$CATALYST_DIR/wt" ]]; then
-    errors+=("Worktree directory missing: $CATALYST_DIR/wt/ — run /catalyst-foundry:setup-catalyst first")
+  # CTL-841: a missing wt/ dir is a fresh-host normal, not a fatal error. A daemon
+  # start script should mkdir -p its own runtime dirs and start, rather than dead-end
+  # a headless-host operator at an interactive Claude skill. Self-heal instead of
+  # hard-failing. (cmd_start also runs `mkdir -p "$CATALYST_DIR/wt"`, but bootstrap's
+  # `return 1` made that line unreachable — proving the auto-create was always intended.)
+  if [[ ! -d "$CATALYST_DIR/wt" ]] && [[ -d "$CATALYST_DIR" ]]; then
+    mkdir -p "$CATALYST_DIR/wt" 2>/dev/null || true
   fi
 
   if [[ ${#errors[@]} -gt 0 ]]; then


### PR DESCRIPTION
## Summary

`catalyst-monitor start` hard-failed on a fresh host when `~/catalyst/wt` was missing:

```
Cannot start monitor:
  • Worktree directory missing: ~/catalyst/wt/ — run /catalyst-foundry:setup-catalyst first
```

`bootstrap()` (in `plugins/dev/scripts/catalyst-monitor.sh`) pushed the missing `wt/` onto its fatal-errors list and `return 1`'d, which aborted `cmd_start`'s `bootstrap || return 1` **before** its own `mkdir -p "$CATALYST_DIR/wt"` (a few lines later) could ever run — leaving that auto-create line permanently unreachable, which itself proves the auto-create was always intended.

A missing `wt/` dir is a fresh-host normal, not a fatal error. A daemon start script should `mkdir -p` its own runtime dirs and start, rather than dead-end a headless-host operator at an interactive Claude skill (CTL-841).

## Change

- `bootstrap()` now self-heals a missing `$CATALYST_DIR/wt` via `mkdir -p` instead of hard-failing.
- The self-heal is guarded on `$CATALYST_DIR` itself existing, so a genuinely-missing `CATALYST_DIR` stays fatal (no runtime dir manufactured under a missing parent) — only the missing-`wt`-dir case self-heals. All other preconditions (bun, sqlite3, server.ts, CATALYST_DIR) remain fatal.

## Test

New `plugins/dev/scripts/__tests__/catalyst-monitor-bootstrap.test.sh` (8 assertions, hermetic — stubs the server-script dir so the orch-monitor install/build is skipped):

- `bootstrap` returns 0 **and** creates `$CATALYST_DIR/wt` when it is absent
- idempotent when `wt/` already exists
- a missing `CATALYST_DIR` stays fatal (rc=1, error preserved, no dir created)
- source-level guard: the old "Worktree directory missing" hard-fail is gone and the `mkdir -p` is present

```
catalyst-monitor-bootstrap: 8 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)