### PR TITLE
fix(dev): CTL-874 preflight queries workspace-scoped labels (not --team)

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1585,64 +1585,82 @@ export function verifyDispatchedSignal(orchDir, ticket, phase) {
   return { ok: true };
 }
 
-// REQUIRED_WORKSPACE_LABELS — the flat labels the CTL-558 coordinator sweep
-// writes. Must pre-exist in the Linear workspace; linearis has no
-// `labels create`. CTL-585's preflight warns once at daemon start if it
-// is missing, so an operator sees the contract gap before the per-tick label
-// sweep starts (and so the missing-label short-circuit in labelOnce does not
-// surprise a fresh operator).
-const REQUIRED_WORKSPACE_LABELS = ["needs-human"];
+// REQUIRED_WORKSPACE_LABELS — the worker-status labels the daemon's escalation
+// + admission-hold sweeps write. ALL THREE are WORKSPACE-scoped (team:null)
+// members of the `worker-status` exclusive group (CTL-764) and must pre-exist;
+// linearis has no `labels create`. CTL-585's preflight warns once at daemon
+// start if one is missing, so an operator sees the contract gap before the
+// per-tick label sweep starts (and so the missing-label short-circuit in
+// labelOnce / convergeHeldLabel does not surprise a fresh operator).
+//
+//   • needs-human — the escalation label (labelOnce, scheduler/recovery).
+//   • blocked / waiting — HELD_LABEL_BLOCKED / HELD_LABEL_WAITING, applied by
+//     convergeHeldLabel for admission-hold indicators (CTL-874: the pre-CTL-874
+//     set listed only needs-human, so a missing held label went undetected).
+const REQUIRED_WORKSPACE_LABELS = ["needs-human", HELD_LABEL_BLOCKED, HELD_LABEL_WAITING];
 
-// preflightWorkspaceLabels — best-effort daemon-start check. For each team,
-// list the team's labels and warn once per missing expected label. `exec`
-// defaults to a spawnSync wrapper that normalises the result shape; `log`
-// defaults to the module logger. Never throws — a broken linearis (missing
-// binary, network outage) logs a single info line and returns.
+// preflightWorkspaceLabels — best-effort daemon-start check. CTL-874: the
+// required labels are WORKSPACE-scoped (team:null), so the pre-CTL-874
+// `linearis labels list --team <team>` per-team query NEVER returned them and
+// the preflight warned "missing required label" on EVERY boot for EVERY team
+// even though the labels existed (and the runtime apply path, which lists
+// without --team, applied them fine). The fix lists WORKSPACE-scoped labels
+// ONCE via `--scope workspace` and warns per missing label (team-independent).
+// `teams` is retained only as a "is any team configured?" gate so an
+// unconfigured daemon stays a no-op. `exec` defaults to a spawnSync wrapper
+// that normalises the result shape; `log` defaults to the module logger. Never
+// throws — a broken linearis (missing binary, network outage) logs a single
+// info line and returns.
 export function preflightWorkspaceLabels({
   teams,
   exec = defaultPreflightExec,
   log: logger = log,
 } = {}) {
   if (!Array.isArray(teams) || teams.length === 0) return;
-  for (const team of teams) {
+  try {
+    const { code, stdout, stderr } = exec("linearis", [
+      "labels",
+      "list",
+      "--scope",
+      "workspace",
+      "--limit",
+      "250",
+    ]);
+    if (code !== 0) {
+      logger.info(
+        { code, stderr },
+        "scheduler: workspace-label preflight skipped — linearis labels list failed"
+      );
+      return;
+    }
+    // linearis labels list emits JSON ({nodes: [{name, ...}, ...]}) — match
+    // the parsing used in linear-query.mjs:100-106. A non-JSON stdout is
+    // treated as a soft preflight skip, not a throw.
+    let names = [];
     try {
-      const { code, stdout, stderr } = exec("linearis", ["labels", "list", "--team", team]);
-      if (code !== 0) {
-        logger.info(
-          { team, code, stderr },
-          "scheduler: workspace-label preflight skipped — linearis labels list failed"
-        );
-        continue;
-      }
-      // linearis labels list emits JSON ({nodes: [{name, ...}, ...]}) — match
-      // the parsing used in linear-query.mjs:100-106. A non-JSON stdout is
-      // treated as a soft preflight skip, not a throw.
-      let names = [];
-      try {
-        const parsed = JSON.parse(String(stdout || "{}"));
-        names = (parsed?.nodes ?? []).map((n) => n?.name).filter(Boolean);
-      } catch (err) {
-        logger.info(
-          { team, err: err.message },
-          "scheduler: workspace-label preflight skipped — linearis stdout is not JSON"
-        );
-        continue;
-      }
-      const present = new Set(names);
-      for (const label of REQUIRED_WORKSPACE_LABELS) {
-        if (!present.has(label)) {
-          logger.warn(
-            { team, label },
-            "scheduler: Linear workspace is missing required label — create it in the Linear UI; the label sweep will skip this label for this run"
-          );
-        }
-      }
+      const parsed = JSON.parse(String(stdout || "{}"));
+      names = (parsed?.nodes ?? []).map((n) => n?.name).filter(Boolean);
     } catch (err) {
       logger.info(
-        { team, err: err.message },
-        "scheduler: workspace-label preflight threw — swallowed"
+        { err: err.message },
+        "scheduler: workspace-label preflight skipped — linearis stdout is not JSON"
       );
+      return;
     }
+    const present = new Set(names);
+    for (const label of REQUIRED_WORKSPACE_LABELS) {
+      if (!present.has(label)) {
+        logger.warn(
+          { label },
+          "scheduler: Linear workspace is missing required label — create it in the Linear UI; the label sweep will skip this label for this run"
+        );
+      }
+    }
+  } catch (err) {
+    logger.info(
+      { err: err.message },
+      "scheduler: workspace-label preflight threw — swallowed"
+    );
   }
 }
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -4172,37 +4172,36 @@ function recorder(returnValue) {
 
 // ── CTL-585: daemon-start preflight for missing workspace labels ──
 
-describe("preflightWorkspaceLabels (CTL-585)", () => {
-  test("warns once per missing label per team", () => {
+describe("preflightWorkspaceLabels (CTL-585, CTL-874)", () => {
+  test("CTL-874: queries WORKSPACE scope once (not --team) and warns per missing required label", () => {
     const warnings = [];
+    const execCalls = [];
     const fakeLog = {
       warn: (obj, msg) => warnings.push({ obj, msg }),
       info: () => {},
       error: () => {},
     };
+    // Workspace has needs-human but is MISSING blocked + waiting.
     const exec = (cmd, args) => {
+      execCalls.push({ cmd, args });
       expect(cmd).toBe("linearis");
-      expect(args.slice(0, 3)).toEqual(["labels", "list", "--team"]);
-      const team = args[3];
-      // linearis labels list emits JSON ({nodes:[{name,...},...]}).
-      // CTL is missing the expected label; ENG has it.
-      const nodes =
-        team === "CTL"
-          ? [{ name: "orchestrate" }, { name: "enhancement" }]
-          : [{ name: "needs-human" }, { name: "bug" }];
-      return { code: 0, stdout: JSON.stringify({ nodes }), stderr: "" };
+      expect(args.slice(0, 4)).toEqual(["labels", "list", "--scope", "workspace"]);
+      return {
+        code: 0,
+        stdout: JSON.stringify({ nodes: [{ name: "needs-human" }, { name: "bug" }] }),
+        stderr: "",
+      };
     };
-    preflightWorkspaceLabels({
-      teams: ["CTL", "ENG"],
-      exec,
-      log: fakeLog,
-    });
-    const ctlWarns = warnings.filter(
-      (w) => w.obj?.team === "CTL" && w.msg.includes("missing required label")
-    );
-    expect(ctlWarns.map((w) => w.obj.label).sort()).toEqual(["needs-human"]);
-    const engWarns = warnings.filter((w) => w.obj?.team === "ENG");
-    expect(engWarns).toHaveLength(0);
+    preflightWorkspaceLabels({ teams: ["CTL", "ENG"], exec, log: fakeLog });
+    // Exactly ONE workspace-scoped query regardless of team count (no per-team --team).
+    expect(execCalls).toHaveLength(1);
+    expect(execCalls[0].args).not.toContain("--team");
+    // Warns for the two missing required labels (blocked, waiting), team-independent.
+    const missing = warnings
+      .filter((w) => w.msg.includes("missing required label"))
+      .map((w) => w.obj.label)
+      .sort();
+    expect(missing).toEqual(["blocked", "waiting"]);
   });
 
   test("does not throw on a linearis spawn failure", () => {
@@ -4219,9 +4218,11 @@ describe("preflightWorkspaceLabels (CTL-585)", () => {
     expect(() => preflightWorkspaceLabels({ teams: ["CTL"], exec, log: fakeLog })).not.toThrow();
   });
 
-  test("real JSON shape with both labels present produces zero warnings", () => {
-    // Regression: an early draft split stdout on newlines, which produced
-    // false-positive warnings against the real JSON output every daemon start.
+  test("CTL-874: all three worker-status labels present produces zero warnings", () => {
+    // Regression: the pre-CTL-874 preflight used --team, which never returns
+    // workspace-scoped labels, so it warned on EVERY boot even when the labels
+    // existed. With --scope workspace and the full required set present, the
+    // boot is silent.
     const warnings = [];
     const fakeLog = {
       warn: (obj, msg) => warnings.push({ obj, msg }),
@@ -4232,8 +4233,10 @@ describe("preflightWorkspaceLabels (CTL-585)", () => {
       code: 0,
       stdout: JSON.stringify({
         nodes: [
-          { name: "triaged", color: "#000" },
+          { name: "worker-status", color: "#000" },
           { name: "needs-human", color: "#fff" },
+          { name: "blocked" },
+          { name: "waiting" },
           { name: "bug" },
         ],
       }),


### PR DESCRIPTION
## Summary
The execution-core daemon logged `scheduler: Linear workspace is missing required label needs-human — create it in the Linear UI` on **every boot for every team** (ADV/OTL/CTL) — a false alarm. The required labels actually exist.

Verified live (2026-06-08): `needs-human`, `blocked`, `waiting` all exist at **workspace level** (team:null) as children of the workspace exclusive group `worker-status`. No case-variant duplicates.

## Root cause
`preflightWorkspaceLabels` (scheduler.mjs) listed labels per-team via `linearis labels list --team <team>`. `--team` returns **only team-scoped** labels and excludes workspace-scoped ones, so the preflight never saw the required labels for any team. (The runtime apply path lists *without* `--team`, so it applies them fine — only the preflight was wrong, making the warning pure noise.)

Secondary: `REQUIRED_WORKSPACE_LABELS` listed only `needs-human`, omitting the held-indicator labels `blocked`/`waiting` that `convergeHeldLabel` requires — so even a correct preflight wouldn't catch a missing held label.

## Fix
- List workspace-scoped labels **once** via `linearis labels list --scope workspace` (not per-team `--team`); warn per missing label, team-independent.
- Extend `REQUIRED_WORKSPACE_LABELS` to `[needs-human, blocked, waiting]`.
- `teams` is retained only as an "is any team configured?" gate so an unconfigured daemon stays a no-op.

## Tests
- Updated the CTL-585 preflight suite: asserts the `--scope workspace` arg shape, a single query regardless of team count, no `--team`, and the full 3-label required set.
- Full `scheduler.test.mjs` suite: 394 pass / 0 fail (the one transient failure observed was the unrelated CTL-671 circuit-breaker timing test — flaky, documented; passes on re-run).

## Scope / out of scope
This is the narrow correctness slice. The larger follow-up — **setup-time ensure + cache** of the worker-status group + members (mirroring the `workflowStateCreate` + `linear-state-ids.json` state-ID pipeline with `issueLabelCreate` + a label-ID cache, plus a `check-setup.sh` assertion) — is **not** in this PR. Today the labels exist (created manually at some point); a fresh workspace would have working state setup but missing labels and silently-failing escalations. Tracks under CTL-764 / CTL-856.

Linear: CTL-874

🤖 Generated with [Claude Code](https://claude.com/claude-code)