### PR TITLE
refactor(dev): CTL-826 extract shared dispatchAndVerify() from 3 scheduler sweeps

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1965,6 +1965,149 @@ export function schedulerTick(
     );
   }
 
+  // ─── CTL-826: dispatchAndVerify — the shared dispatch→verify core ───
+  //
+  // Collapses the ~240 lines of identical "decide → dispatch → verify the worker
+  // landed → on success clear-cooldown + re-read signal + emit launched / on
+  // failure run the cool-down + circuit-breaker + escalation ladder" skeleton that
+  // recurred VERBATIM across the three scheduler dispatch sweeps:
+  //   • Pass 1   advancement          (advance dispatch)
+  //   • Pass 1.5 resume-after-preempt (reduced failure ladder)
+  //   • Pass 2   new-work pull        (entry-phase dispatch)
+  //
+  // PURE REFACTOR — zero behavior change. It owns ONLY the byte-identical core
+  // (steps 1–4 of the ticket). Every per-site DIVERGENCE stays at the call site,
+  // driven off the returned `{ ok, code, reason, signal }`:
+  //   • success follow-ups (advanced.push / promotedCount++ / emitPredecessorReap /
+  //     applyPhaseStatus+emitStateWrite / applyEstimate / writeWorkerPriority /
+  //     applyAssignee / appendResumedAfterPreemptionEvent / rankedAboveSince.delete /
+  //     resumeSlots--/resumedCount++ / dispatched.push)
+  //   • Pass 1's CTL-695 emitPredecessorReap on the FAILURE branches
+  //
+  // Ordering is preserved exactly: the requested-emit fires first, then the
+  // optional `preDispatch` hook (Pass 1.5's signal reset-to-stalled, which may
+  // abort the iteration), then dispatchTicket → verifyDispatched. The launched
+  // re-read returns the signal so the caller need not re-read it.
+  //
+  // `fullFailureLadder` selects the failure handling: Pass 1 & 2 run the full
+  // ladder (recordDispatchFailure → escalateDispatchExhausted at the retry ceiling
+  // → maybeTripCircuitBreaker → appendDispatchFailedEvent with expiresAt +
+  // consecutiveFailures → maybeEscalateDispatchFailures); Pass 1.5 keeps its
+  // deliberately reduced ladder (recordDispatchFailure → appendDispatchFailedEvent
+  // WITHOUT the counter/cooldown-escalation fields) by passing false.
+  //
+  // Returns: { ok, code, reason, signal } on a real dispatch attempt, or
+  // { aborted: true } when preDispatch vetoed the iteration (caller `continue`s).
+  function dispatchAndVerify(
+    orchDir,
+    ticket,
+    phase,
+    {
+      dispatch,
+      resumeSession, // optional; dispatchTicket only adds the key when truthy
+      requestedReason, // reason field for the dispatch-requested event
+      preDispatch, // optional () => boolean; a false return aborts (→ { aborted: true })
+      fullFailureLadder = true, // Pass 1.5 passes false for its reduced ladder
+      failLogMsg, // optional log.warn message for the rc!=0 branch (omit → no log)
+      failLogIncludePhase = true, // Pass 2's original rc!=0 log omits the phase field
+    }
+  ) {
+    // CTL-660: record the dispatch DECISION before the spawn. Best-effort.
+    safeEmit(
+      appendDispatchRequestedEvent,
+      { orchId: ticket, ticket, target_phase: phase, reason: requestedReason },
+      { ticket, phase }
+    );
+    // Pass 1.5: reset the parked signal to "stalled" before dispatch; a false
+    // return (reset write failed) aborts so the caller can `continue`.
+    if (preDispatch && preDispatch() === false) return { aborted: true };
+
+    const r = dispatchTicket(orchDir, ticket, phase, { dispatch, resumeSession });
+    if (r.code === 0) {
+      // CTL-611: verify the dispatch actually produced a live worker before
+      // declaring success. A --dry-run leak / mark_launch_failed half-write
+      // returns rc=0 with no usable signal; !ok demotes to failure.
+      const v = verifyDispatched(orchDir, ticket, phase);
+      if (v.ok) {
+        clearDispatchCooldown(orchDir, ticket, phase); // CTL-624: success clears any prior cool-down
+        // CTL-660: record the VERIFIED launch. Re-read the signal for the
+        // bg_job_id + worktreePath the launched worker wrote.
+        const signal = readPhaseSignalRaw(orchDir, ticket, phase);
+        safeEmit(
+          appendDispatchLaunchedEvent,
+          {
+            orchId: ticket,
+            ticket,
+            target_phase: phase,
+            bg_job_id: signal?.bg_job_id,
+            worktree_path: signal?.worktreePath,
+          },
+          { ticket, phase }
+        );
+        return { ok: true, code: 0, reason: null, signal };
+      }
+      // CTL-611 Gap 1 demotion: rc=0 but no live bg job. Same on-disk effects as
+      // a real rc!=0 failure so the broker / HUD / operator can see the drop.
+      const reason = `verify_failed:${v.reason}`;
+      const cd = recordDispatchFailure(orchDir, ticket, phase, 0, now());
+      if (fullFailureLadder) {
+        if (cd.consecutiveFailures >= getMaxDispatchRetries()) escalateDispatchExhausted(orchDir, ticket, phase); // CTL-712 terminal stop
+        maybeTripCircuitBreaker(orchDir, ticket, phase); // CTL-671: trip same tick if at threshold
+        appendDispatchFailedEvent({
+          orchId: ticket,
+          ticket,
+          target_phase: phase,
+          code: 0,
+          reason,
+          expiresAt: cd.expiresAt,
+          consecutiveFailures: cd.consecutiveFailures,
+        });
+        maybeEscalateDispatchFailures(orchDir, cd, { writeStatus, appendEvent: appendCooldownEscalatedEvent });
+        log.warn({ ticket, phase, verifyReason: v.reason }, "scheduler: dispatched signal verification failed");
+      } else {
+        appendDispatchFailedEvent({
+          orchId: ticket,
+          ticket,
+          target_phase: phase,
+          code: 0,
+          reason,
+        });
+      }
+      return { ok: false, code: 0, reason, signal: null };
+    }
+
+    // rc != 0 — real dispatch failure.
+    const reason = readDispatchFailureReason(orchDir, ticket, phase) ?? "dispatch_nonzero_exit";
+    const cd = recordDispatchFailure(orchDir, ticket, phase, r.code, now()); // CTL-624: arm the cool-down window
+    if (fullFailureLadder) {
+      if (cd.consecutiveFailures >= getMaxDispatchRetries()) escalateDispatchExhausted(orchDir, ticket, phase); // CTL-712 terminal stop
+      maybeTripCircuitBreaker(orchDir, ticket, phase); // CTL-671: trip same tick if at threshold
+      // CTL-611 Gap 2: surface the silent drop as an event.
+      appendDispatchFailedEvent({
+        orchId: ticket,
+        ticket,
+        target_phase: phase,
+        code: r.code,
+        reason,
+        expiresAt: cd.expiresAt,
+        consecutiveFailures: cd.consecutiveFailures,
+      });
+      maybeEscalateDispatchFailures(orchDir, cd, { writeStatus, appendEvent: appendCooldownEscalatedEvent });
+      if (failLogMsg) {
+        log.warn(failLogIncludePhase ? { ticket, phase, code: r.code } : { ticket, code: r.code }, failLogMsg);
+      }
+    } else {
+      appendDispatchFailedEvent({
+        orchId: ticket,
+        ticket,
+        target_phase: phase,
+        code: r.code,
+        reason,
+      });
+    }
+    return { ok: false, code: r.code, reason, signal: null };
+  }
+
   // CTL-671: compute the eligible set ONCE per tick. Consumed by the phantom
   // validity sweep (Pass 0a, below) and the new-work pull (Pass 2). readEligible
   // is the test injection seam; production reads all per-project eligible
@@ -2628,113 +2771,52 @@ export function schedulerTick(
     // CTL-671: circuit breaker — once consecutiveFailures has crossed the
     // threshold, quarantine to terminal `stalled` and stop re-dispatching.
     if (maybeTripCircuitBreaker(orchDir, ticket, next)) continue;
-    // CTL-660: record the dispatch DECISION before the spawn. Best-effort.
-    safeEmit(
-      appendDispatchRequestedEvent,
-      { orchId: ticket, ticket, target_phase: next, reason: "advance" },
-      { ticket, phase: next }
-    );
-    const r = dispatchTicket(orchDir, ticket, next, { dispatch });
-    if (r.code === 0) {
-      // CTL-611: verify the dispatch actually produced a live worker before
-      // declaring success. A --dry-run leak / mark_launch_failed half-write
-      // returns rc=0 with no usable signal, which used to silently leave the
-      // pipeline wedged. !ok demotes to failure (cool-down + event).
-      const v = verifyDispatched(orchDir, ticket, next);
-      if (v.ok) {
-        clearDispatchCooldown(orchDir, ticket, next); // CTL-624: success clears any prior cool-down
-        // CTL-660: record the VERIFIED launch. Re-read the signal for the
-        // bg_job_id + worktreePath the launched worker wrote.
-        const sig = readPhaseSignalRaw(orchDir, ticket, next);
-        safeEmit(
-          appendDispatchLaunchedEvent,
-          {
-            orchId: ticket,
+    // CTL-826: the dispatch→verify core is shared (requested-emit, dispatch,
+    // verify, success cooldown-clear + launched-emit, full failure ladder). The
+    // advance-specific follow-ups stay here, keyed off the returned result.
+    const dv = dispatchAndVerify(orchDir, ticket, next, {
+      dispatch,
+      requestedReason: "advance",
+      failLogMsg: "scheduler: advance dispatch failed",
+    });
+    if (dv.ok) {
+      advanced.push({ ticket, phase: next });
+      // CTL-755: a verified triage→research promotion consumed a slot this tick.
+      // liveCount was read at the top of the tick (before this dispatch), so the
+      // promotion has not yet incremented it — STEP C subtracts promotedCount
+      // from sweep-2 freeSlots to stop over-admitting into the just-taken slots.
+      if (next === NEW_WORK_ENTRY_PHASE) promotedCount++;
+      // CTL-657 / CTL-661: stop the predecessor worker now that its successor
+      // is live. resolveReapPredecessor reads the PRE-reset signals so the
+      // verify⇄remediate detour edges name the correct just-finished worker;
+      // remediateRaw supplies the bg_job_id the reset already deleted.
+      emitPredecessorReap(orchDir, ticket, preResetSignals, next, { remediateRaw });
+      // CTL-558: write the dispatched phase's mapped Linear status. Idempotent
+      // (linear-transition.sh read-compares first); never aborts the tick.
+      safeWrite(
+        () => {
+          // CTL-757: capture the writer result so emitStateWrite can audit the
+          // before/after pair. The write itself stays best-effort inside
+          // safeWrite; the emit is a separate best-effort step.
+          const wr = writeStatus.applyPhaseStatus({ ticket, phase: next, cache });
+          emitStateWrite({ writerResult: wr, ticket, phase: next, source: "scheduler-advance", orchId: ticket });
+        },
+        { ticket, phase: next }
+      );
+      // CTL-751: on triage→research advance, write the reference-class
+      // estimate to Linear if triage.json carries a valid numeric `.estimate`.
+      if (next === "research") {
+        const est = readTriageEstimate(orchDir, ticket);
+        if (est !== null) {
+          safeWrite(() => writeStatus.applyEstimate({ ticket, estimate: est }), {
             ticket,
-            target_phase: next,
-            bg_job_id: sig?.bg_job_id,
-            worktree_path: sig?.worktreePath,
-          },
-          { ticket, phase: next }
-        );
-        advanced.push({ ticket, phase: next });
-        // CTL-755: a verified triage→research promotion consumed a slot this tick.
-        // liveCount was read at the top of the tick (before this dispatch), so the
-        // promotion has not yet incremented it — STEP C subtracts promotedCount
-        // from sweep-2 freeSlots to stop over-admitting into the just-taken slots.
-        if (next === NEW_WORK_ENTRY_PHASE) promotedCount++;
-        // CTL-657 / CTL-661: stop the predecessor worker now that its successor
-        // is live. resolveReapPredecessor reads the PRE-reset signals so the
-        // verify⇄remediate detour edges name the correct just-finished worker;
-        // remediateRaw supplies the bg_job_id the reset already deleted.
-        emitPredecessorReap(orchDir, ticket, preResetSignals, next, { remediateRaw });
-        // CTL-558: write the dispatched phase's mapped Linear status. Idempotent
-        // (linear-transition.sh read-compares first); never aborts the tick.
-        safeWrite(
-          () => {
-            // CTL-757: capture the writer result so emitStateWrite can audit the
-            // before/after pair. The write itself stays best-effort inside
-            // safeWrite; the emit is a separate best-effort step.
-            const wr = writeStatus.applyPhaseStatus({ ticket, phase: next, cache });
-            emitStateWrite({ writerResult: wr, ticket, phase: next, source: "scheduler-advance", orchId: ticket });
-          },
-          { ticket, phase: next }
-        );
-        // CTL-751: on triage→research advance, write the reference-class
-        // estimate to Linear if triage.json carries a valid numeric `.estimate`.
-        if (next === "research") {
-          const est = readTriageEstimate(orchDir, ticket);
-          if (est !== null) {
-            safeWrite(() => writeStatus.applyEstimate({ ticket, estimate: est }), {
-              ticket,
-              phase: next,
-            });
-          }
+            phase: next,
+          });
         }
-      } else {
-        // CTL-611 Gap 1 demotion: rc=0 but no live bg job. Same on-disk
-        // effects as a real rc!=0 failure so the broker / HUD / operator can
-        // see the drop.
-        const cd1 = recordDispatchFailure(orchDir, ticket, next, 0, now());
-        if (cd1.consecutiveFailures >= getMaxDispatchRetries()) escalateDispatchExhausted(orchDir, ticket, next); // CTL-712 terminal stop
-        maybeTripCircuitBreaker(orchDir, ticket, next); // CTL-671: trip same tick if at threshold
-        appendDispatchFailedEvent({
-          orchId: ticket,
-          ticket,
-          target_phase: next,
-          code: 0,
-          reason: `verify_failed:${v.reason}`,
-          expiresAt: cd1.expiresAt,
-          consecutiveFailures: cd1.consecutiveFailures,
-        });
-        maybeEscalateDispatchFailures(orchDir, cd1, { writeStatus, appendEvent: appendCooldownEscalatedEvent });
-        log.warn(
-          { ticket, phase: next, verifyReason: v.reason },
-          "scheduler: dispatched signal verification failed"
-        );
-        // CTL-695: reap the just-finished predecessor even though its successor
-        // did not come up — the failed dispatch leaves the predecessor alive.
-        emitPredecessorReap(orchDir, ticket, preResetSignals, next, { remediateRaw });
       }
     } else {
-      const cd2 = recordDispatchFailure(orchDir, ticket, next, r.code, now()); // CTL-624: arm the cool-down window
-      if (cd2.consecutiveFailures >= getMaxDispatchRetries()) escalateDispatchExhausted(orchDir, ticket, next); // CTL-712 terminal stop
-      maybeTripCircuitBreaker(orchDir, ticket, next); // CTL-671: trip same tick if at threshold
-      // CTL-611 Gap 2: surface the silent drop as an event so the broker /
-      // HUD / operator can react. Best-effort; failure is logged inside.
-      appendDispatchFailedEvent({
-        orchId: ticket,
-        ticket,
-        target_phase: next,
-        code: r.code,
-        reason: readDispatchFailureReason(orchDir, ticket, next) ?? "dispatch_nonzero_exit",
-        expiresAt: cd2.expiresAt,
-        consecutiveFailures: cd2.consecutiveFailures,
-      });
-      maybeEscalateDispatchFailures(orchDir, cd2, { writeStatus, appendEvent: appendCooldownEscalatedEvent });
-      log.warn({ ticket, phase: next, code: r.code }, "scheduler: advance dispatch failed");
-      // CTL-695: reap the just-finished predecessor even though its successor
-      // did not come up — the failed dispatch leaves the predecessor alive.
+      // CTL-695: reap the just-finished predecessor even though its successor did
+      // not come up — the failed dispatch (verify-failed OR rc!=0) leaves it alive.
       emitPredecessorReap(orchDir, ticket, preResetSignals, next, { remediateRaw });
     }
   }
@@ -2777,69 +2859,55 @@ export function schedulerTick(
         const bgJobId = signalRaw?.bg_job_id;
 
         const resumeSession = resolveSession(bgJobId) ?? undefined;
-        safeEmit(
-          appendDispatchRequestedEvent,
-          { orchId: pd.identifier, ticket: pd.identifier, target_phase: parkedPhase, reason: "resume-after-preemption" },
-          { ticket: pd.identifier, phase: parkedPhase }
-        );
 
-        // Reset the signal to "stalled" so phase-agent-dispatch's idempotency
-        // guard does not block re-dispatch (mirrors defaultReviveDispatch).
-        const signalPath = join(orchDir, "workers", pd.identifier, `phase-${parkedPhase}.json`);
-        try {
-          const tmp = `${signalPath}.tmp.${process.pid}`;
-          writeFileSync(tmp, JSON.stringify({
-            ...(signalRaw ?? {}),
-            status: "stalled",
-            attentionReason: "resume-after-preemption",
-            updatedAt: new Date(now()).toISOString().replace(/\.\d{3}Z$/, "Z"),
-          }));
-          renameSync(tmp, signalPath);
-        } catch (err) {
-          log.warn({ ticket: pd.identifier, phase: parkedPhase, err: err.message }, "scheduler: resume signal reset failed");
-          continue;
-        }
-
-        const r = dispatchTicket(orchDir, pd.identifier, parkedPhase, { dispatch, resumeSession });
-        if (r.code === 0) {
-          const v = verifyDispatched(orchDir, pd.identifier, parkedPhase);
-          if (v.ok) {
-            clearDispatchCooldown(orchDir, pd.identifier, parkedPhase);
-            rankedAboveSince.delete(`${pd.identifier}:${pd.identifier}`); // clear any stale hysteresis
-            const sig2 = readPhaseSignalRaw(orchDir, pd.identifier, parkedPhase);
-            safeEmit(
-              appendDispatchLaunchedEvent,
-              { orchId: pd.identifier, ticket: pd.identifier, target_phase: parkedPhase, bg_job_id: sig2?.bg_job_id, worktree_path: sig2?.worktreePath },
-              { ticket: pd.identifier, phase: parkedPhase }
-            );
-            safeEmit(
-              appendResumedAfterPreemptionEvent,
-              { orchId: pd.identifier, ticket: pd.identifier, phase: parkedPhase, resumeSession: resumeSession ?? null },
-              { ticket: pd.identifier, phase: parkedPhase }
-            );
-            safeWrite(
-              () => {
-                // CTL-757: audit the resume-after-preemption status write.
-                const wr = writeStatus.applyPhaseStatus({ ticket: pd.identifier, phase: parkedPhase, cache });
-                emitStateWrite({ writerResult: wr, ticket: pd.identifier, phase: parkedPhase, source: "preemption-resume", orchId: pd.identifier });
-              },
-              { ticket: pd.identifier, phase: parkedPhase }
-            );
-            resumeSlots--;
-            resumedCount++;
-          } else {
-            recordDispatchFailure(orchDir, pd.identifier, parkedPhase, 0, now());
-            appendDispatchFailedEvent({
-              orchId: pd.identifier, ticket: pd.identifier, target_phase: parkedPhase,
-              code: 0, reason: `verify_failed:${v.reason}`,
-            });
-          }
-        } else {
-          recordDispatchFailure(orchDir, pd.identifier, parkedPhase, r.code, now());
-          appendDispatchFailedEvent({
-            orchId: pd.identifier, ticket: pd.identifier, target_phase: parkedPhase,
-            code: r.code, reason: readDispatchFailureReason(orchDir, pd.identifier, parkedPhase) ?? "dispatch_nonzero_exit",
-          });
+        // CTL-826: shared dispatch→verify core, with the RESUME divergences kept
+        // here. preDispatch performs the signal reset-to-stalled BEFORE dispatch
+        // (returning false on a failed reset aborts → `continue`); the reduced
+        // failure ladder (fullFailureLadder:false) preserves this sweep's lighter
+        // failure handling (no escalation/circuit-breaker/cooldown-escalation).
+        const dv = dispatchAndVerify(orchDir, pd.identifier, parkedPhase, {
+          dispatch,
+          resumeSession,
+          requestedReason: "resume-after-preemption",
+          fullFailureLadder: false,
+          preDispatch: () => {
+            // Reset the signal to "stalled" so phase-agent-dispatch's idempotency
+            // guard does not block re-dispatch (mirrors defaultReviveDispatch).
+            const signalPath = join(orchDir, "workers", pd.identifier, `phase-${parkedPhase}.json`);
+            try {
+              const tmp = `${signalPath}.tmp.${process.pid}`;
+              writeFileSync(tmp, JSON.stringify({
+                ...(signalRaw ?? {}),
+                status: "stalled",
+                attentionReason: "resume-after-preemption",
+                updatedAt: new Date(now()).toISOString().replace(/\.\d{3}Z$/, "Z"),
+              }));
+              renameSync(tmp, signalPath);
+            } catch (err) {
+              log.warn({ ticket: pd.identifier, phase: parkedPhase, err: err.message }, "scheduler: resume signal reset failed");
+              return false;
+            }
+            return true;
+          },
+        });
+        if (dv.aborted) continue; // reset write failed — skip this parked ticket
+        if (dv.ok) {
+          rankedAboveSince.delete(`${pd.identifier}:${pd.identifier}`); // clear any stale hysteresis
+          safeEmit(
+            appendResumedAfterPreemptionEvent,
+            { orchId: pd.identifier, ticket: pd.identifier, phase: parkedPhase, resumeSession: resumeSession ?? null },
+            { ticket: pd.identifier, phase: parkedPhase }
+          );
+          safeWrite(
+            () => {
+              // CTL-757: audit the resume-after-preemption status write.
+              const wr = writeStatus.applyPhaseStatus({ ticket: pd.identifier, phase: parkedPhase, cache });
+              emitStateWrite({ writerResult: wr, ticket: pd.identifier, phase: parkedPhase, source: "preemption-resume", orchId: pd.identifier });
+            },
+            { ticket: pd.identifier, phase: parkedPhase }
+          );
+          resumeSlots--;
+          resumedCount++;
         }
       }
     }
@@ -3002,102 +3070,47 @@ export function schedulerTick(
         continue;
       }
     }
-    // CTL-660: record the new-work dispatch DECISION before the spawn.
-    safeEmit(
-      appendDispatchRequestedEvent,
-      {
-        orchId: t.identifier,
-        ticket: t.identifier,
-        target_phase: NEW_WORK_ENTRY_PHASE,
-        reason: "new-work",
-      },
-      { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE }
-    );
-    const r = dispatchTicket(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, { dispatch });
-    if (r.code === 0) {
-      // CTL-611: same Gap 1 verifier as the advancement sweep — a rc=0
-      // without a live successor signal must be demoted.
-      const v = verifyDispatched(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE);
-      if (v.ok) {
-        clearDispatchCooldown(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE); // CTL-624: success clears any prior cool-down
-        // CTL-660: record the VERIFIED launch for the new ticket's entry phase.
-        const sig = readPhaseSignalRaw(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE);
-        safeEmit(
-          appendDispatchLaunchedEvent,
-          {
-            orchId: t.identifier,
+    // CTL-826: shared dispatch→verify core (requested-emit "new-work", dispatch,
+    // verify, success cooldown-clear + launched-emit, full failure ladder). The
+    // new-work-specific success follow-ups stay here. Pass 2's original rc!=0 log
+    // omits the phase field (failLogIncludePhase:false) to stay byte-identical.
+    const dv = dispatchAndVerify(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, {
+      dispatch,
+      requestedReason: "new-work",
+      failLogMsg: "scheduler: dispatch failed",
+      failLogIncludePhase: false,
+    });
+    if (dv.ok) {
+      dispatched.push(t.identifier);
+      // CTL-705: persist priority + createdAt for the global rank, so
+      // preemption decisions need no per-tick Linear API calls.
+      writeWorkerPriority(orchDir, t.identifier, {
+        priority: t.priority,
+        createdAt: t.createdAt ?? null,
+      });
+      // CTL-558: write the entry-phase (`research`) status for the new ticket.
+      // CTL-757: audit it as a scheduler-advance state write (new work entering
+      // the pipeline is the entry-phase forward advance).
+      safeWrite(
+        () => {
+          const wr = writeStatus.applyPhaseStatus({
             ticket: t.identifier,
-            target_phase: NEW_WORK_ENTRY_PHASE,
-            bg_job_id: sig?.bg_job_id,
-            worktree_path: sig?.worktreePath,
-          },
-          { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE }
-        );
-        dispatched.push(t.identifier);
-        // CTL-705: persist priority + createdAt for the global rank, so
-        // preemption decisions need no per-tick Linear API calls.
-        writeWorkerPriority(orchDir, t.identifier, {
-          priority: t.priority,
-          createdAt: t.createdAt ?? null,
-        });
-        // CTL-558: write the entry-phase (`research`) status for the new ticket.
-        // CTL-757: audit it as a scheduler-advance state write (new work entering
-        // the pipeline is the entry-phase forward advance).
+            phase: NEW_WORK_ENTRY_PHASE,
+            cache,
+          });
+          emitStateWrite({ writerResult: wr, ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE, source: "scheduler-advance", orchId: t.identifier });
+        },
+        { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE }
+      );
+      // CTL-781: self-assign the Catalyst bot so the claim is visible in
+      // Linear. Best-effort (safeWrite) — an assignment failure never blocks
+      // the pipeline; the read-back inside applyAssignee logs the gap.
+      if (botWriteId) {
         safeWrite(
-          () => {
-            const wr = writeStatus.applyPhaseStatus({
-              ticket: t.identifier,
-              phase: NEW_WORK_ENTRY_PHASE,
-              cache,
-            });
-            emitStateWrite({ writerResult: wr, ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE, source: "scheduler-advance", orchId: t.identifier });
-          },
-          { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE }
-        );
-        // CTL-781: self-assign the Catalyst bot so the claim is visible in
-        // Linear. Best-effort (safeWrite) — an assignment failure never blocks
-        // the pipeline; the read-back inside applyAssignee logs the gap.
-        if (botWriteId) {
-          safeWrite(
-            () => writeStatus.applyAssignee?.({ ticket: t.identifier, userId: botWriteId }),
-            { ticket: t.identifier, phase: "assignment" }
-          );
-        }
-      } else {
-        const cd3 = recordDispatchFailure(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, 0, now());
-        if (cd3.consecutiveFailures >= getMaxDispatchRetries()) escalateDispatchExhausted(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE); // CTL-712 terminal stop
-        maybeTripCircuitBreaker(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE); // CTL-671
-        appendDispatchFailedEvent({
-          orchId: t.identifier,
-          ticket: t.identifier,
-          target_phase: NEW_WORK_ENTRY_PHASE,
-          code: 0,
-          reason: `verify_failed:${v.reason}`,
-          expiresAt: cd3.expiresAt,
-          consecutiveFailures: cd3.consecutiveFailures,
-        });
-        maybeEscalateDispatchFailures(orchDir, cd3, { writeStatus, appendEvent: appendCooldownEscalatedEvent });
-        log.warn(
-          { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE, verifyReason: v.reason },
-          "scheduler: dispatched signal verification failed"
+          () => writeStatus.applyAssignee?.({ ticket: t.identifier, userId: botWriteId }),
+          { ticket: t.identifier, phase: "assignment" }
         );
       }
-    } else {
-      const cd4 = recordDispatchFailure(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, r.code, now()); // CTL-624: arm the cool-down window
-      if (cd4.consecutiveFailures >= getMaxDispatchRetries()) escalateDispatchExhausted(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE); // CTL-712 terminal stop
-      maybeTripCircuitBreaker(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE); // CTL-671
-      // CTL-611: Gap 2 entry-phase silent-drop event.
-      appendDispatchFailedEvent({
-        orchId: t.identifier,
-        ticket: t.identifier,
-        target_phase: NEW_WORK_ENTRY_PHASE,
-        code: r.code,
-        reason: readDispatchFailureReason(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE) ?? "dispatch_nonzero_exit",
-        expiresAt: cd4.expiresAt,
-        consecutiveFailures: cd4.consecutiveFailures,
-      });
-      maybeEscalateDispatchFailures(orchDir, cd4, { writeStatus, appendEvent: appendCooldownEscalatedEvent });
-      log.warn({ ticket: t.identifier, code: r.code }, "scheduler: dispatch failed");
     }
   }
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -7293,3 +7293,187 @@ describe("CTL-834 — convergeHeldLabel apply cool-down", () => {
     expect(ws.applyLabel.calls).toHaveLength(2);
   });
 });
+
+// ── CTL-826: dispatchAndVerify shared dispatch→verify core ────────────────
+//
+// dispatchAndVerify is a closure inside schedulerTick (it needs the per-tick
+// safeEmit/safeWrite/emitStateWrite + injected emitters), so it is exercised
+// through the public schedulerTick API. This block pins the three-branch
+// contract the helper now owns for ALL THREE sweeps it deduplicated, and —
+// critically — the FULL-vs-REDUCED failure-ladder divergence that drove the
+// `fullFailureLadder` parameter (advance + new-work run the full ladder with
+// escalation/circuit-breaker; resume-after-preemption keeps its reduced one).
+describe("dispatchAndVerify shared core (CTL-826)", () => {
+  // A dispatch fake that writes a runnable signal so the default
+  // verifyDispatchedSignal returns ok AND the launched re-read sees bg fields.
+  function dispatchWritesSignal({ bgJobId = "bg-826", worktreePath = "/wt/826" } = {}) {
+    const calls = [];
+    const fn = ({ orchDir: od, ticket, phase }) => {
+      calls.push({ ticket, phase });
+      const dir = join(od, "workers", ticket);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, `phase-${phase}.json`),
+        JSON.stringify({ ticket, phase, status: "running", bg_job_id: bgJobId, worktreePath })
+      );
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    fn.calls = calls;
+    return fn;
+  }
+
+  function seedPreempted(ticket, phase, bgJobId, priority) {
+    writeSignalRaw(ticket, phase, {
+      ticket, phase, status: "preempted", parkedFrom: phase, bg_job_id: bgJobId,
+      attentionReason: "preempted-by-priority",
+    });
+    writeWorkerPriority(orchDir, ticket, { priority, createdAt: "2026-05-01T00:00:00Z" });
+  }
+
+  function spy() {
+    const calls = [];
+    const fn = (arg) => { calls.push(arg); return true; };
+    fn.calls = calls;
+    return fn;
+  }
+
+  // ─── Branch 1: v.ok success ───
+  test("v.ok branch: clears cooldown, re-reads the signal, emits launched with bg fields, returns ok", () => {
+    writeSignal("CTL-826A", "research", "done"); // FSM owes plan
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    // Pre-arm a cooldown marker (failedAt=1 → expiresAt=60_001) so we can prove
+    // the success path clears it. The tick runs at now=70_000, PAST the 60s
+    // window, so inDispatchCooldown does not suppress the dispatch.
+    recordDispatchFailure(orchDir, "CTL-826A", "plan", 1, 1);
+    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-826A", "plan"))).toBe(true);
+
+    const dispatch = dispatchWritesSignal({ bgJobId: "live-a", worktreePath: "/wt/CTL-826A" });
+    const launched = spy();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      now: () => 70_000,
+      appendDispatchLaunchedEvent: launched,
+    });
+
+    expect(r.advanced).toContainEqual({ ticket: "CTL-826A", phase: "plan" });
+    // Success clears any prior cool-down (CTL-624).
+    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-826A", "plan"))).toBe(false);
+    // launched carries the re-read signal's bg_job_id + worktree_path.
+    expect(launched.calls).toHaveLength(1);
+    expect(launched.calls[0]).toMatchObject({
+      ticket: "CTL-826A", target_phase: "plan", bg_job_id: "live-a", worktree_path: "/wt/CTL-826A",
+    });
+    // No failure event on the success branch.
+    expect(dispatchFailedEvents("CTL-826A")).toHaveLength(0);
+  });
+
+  // ─── Branch 2: verify-failed (rc=0, no live signal) ───
+  test("verify-failed branch (full ladder): demotes rc=0+no-signal to failure with consecutiveFailures", () => {
+    writeSignal("CTL-826B", "research", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 }); // rc=0 but writes NO signal → verifier !ok
+
+    const r = schedulerTick(orchDir, { readEligible: () => [], dispatch, now: () => 1_000 });
+
+    expect(r.advanced ?? []).not.toContainEqual({ ticket: "CTL-826B", phase: "plan" });
+    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-826B", "plan"))).toBe(true);
+    const events = dispatchFailedEvents("CTL-826B");
+    expect(events).toHaveLength(1);
+    expect(events[0].body.payload).toMatchObject({ target_phase: "plan", code: 0, consecutiveFailures: 1 });
+    expect(events[0].body.payload.reason).toMatch(/^verify_failed:/);
+  });
+
+  // ─── Branch 3: rc!=0 (real dispatch failure) ───
+  test("rc!=0 branch (full ladder): arms cooldown + emits failure with dispatch_nonzero_exit + counter", () => {
+    writeSignal("CTL-826C", "research", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 1 });
+
+    schedulerTick(orchDir, { readEligible: () => [], dispatch, now: () => 1_000 });
+
+    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-826C", "plan"))).toBe(true);
+    const events = dispatchFailedEvents("CTL-826C");
+    expect(events).toHaveLength(1);
+    expect(events[0].body.payload).toMatchObject({
+      target_phase: "plan", code: 1, reason: "dispatch_nonzero_exit", consecutiveFailures: 1,
+    });
+  });
+
+  // ─── Reduced ladder: resume-after-preemption keeps the lighter failure path ───
+  test("reduced ladder (resume sweep): failed event omits consecutiveFailures/expiresAt; no escalation at the ceiling", () => {
+    seedPreempted("CTL-826D", "research", "bg-826d", 2);
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const dispatch = fakeDispatch({ code: 1 }); // resume re-dispatch fails
+
+    // Drive far past getMaxDispatchRetries() (default 5) so the FULL ladder
+    // WOULD have escalateDispatchExhausted-stalled the signal by now. The reduced
+    // ladder must NOT: the signal stays "preempted" and never carries the counter.
+    for (let i = 0; i < 7; i++) {
+      // re-seed each tick: the reduced ladder's reset-to-stalled mutates the signal,
+      // and a stalled signal would drop out of the parked set on the next tick.
+      seedPreempted("CTL-826D", "research", "bg-826d", 2);
+      schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch,
+        now: () => 1_000 + i, // distinct clock so a new cooldown marker can arm
+        liveBackgroundCount: () => 1, // 1 free slot → resume sweep fires
+        reclaimDeadWork: () => "noop",
+        resolveSession: () => null,
+      });
+    }
+
+    const events = dispatchFailedEvents("CTL-826D");
+    expect(events.length).toBeGreaterThan(0);
+    // Reduced ladder: the failed event is the lighter shape — NO counter/expiry.
+    for (const e of events) {
+      expect(e.body.payload).toMatchObject({ target_phase: "research", code: 1 });
+      expect(e.body.payload.consecutiveFailures).toBeUndefined();
+      expect(e.body.payload.expiresAt).toBeUndefined();
+    }
+    // No needs-human escalation marker (full ladder's escalateDispatchExhausted
+    // would have written a `stalled` signal; the reduced ladder never does).
+    const sig = JSON.parse(readFileSync(
+      join(orchDir, "workers", "CTL-826D", "phase-research.json"), "utf8"
+    ));
+    expect(sig.stalledReason).toBeUndefined();
+  });
+
+  // ─── preDispatch abort: a failed signal reset short-circuits with no dispatch ───
+  test("resume preDispatch abort: a parked ticket with no worker dir still drives the reset path", () => {
+    // The resume sweep's preDispatch writes the reset signal; the dispatch fake
+    // then writes the runnable signal. With resolveSession→null and verifyOk, a
+    // verified resume advances and emits the resumed-after-preemption event,
+    // proving the requested→preDispatch(reset)→dispatch ordering is preserved.
+    seedPreempted("CTL-826E", "research", "bg-826e", 2);
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const calls = [];
+    const dispatch = ({ orchDir: od, ticket, phase }) => {
+      // Capture the signal state AT dispatch time — preDispatch must have reset it
+      // to "stalled" before this fake runs (ordering guarantee).
+      const pre = JSON.parse(readFileSync(join(od, "workers", ticket, `phase-${phase}.json`), "utf8"));
+      calls.push({ ticket, phase, preStatus: pre.status });
+      const dir = join(od, "workers", ticket);
+      writeFileSync(join(dir, `phase-${phase}.json`),
+        JSON.stringify({ ticket, phase, status: "running", bg_job_id: "resumed-bg" }));
+      return { code: 0 };
+    };
+    const resumed = spy();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      now: () => 1_000,
+      liveBackgroundCount: () => 1,
+      reclaimDeadWork: () => "noop",
+      resolveSession: () => null,
+      appendResumedAfterPreemptionEvent: resumed,
+      verifyDispatched: verifyOk,
+    });
+
+    expect(calls).toHaveLength(1);
+    // Ordering: requested → preDispatch reset-to-stalled → dispatchTicket.
+    expect(calls[0]).toMatchObject({ ticket: "CTL-826E", phase: "research", preStatus: "stalled" });
+    expect(resumed.calls).toHaveLength(1);
+    expect(resumed.calls[0].ticket).toBe("CTL-826E");
+  });
+});


### PR DESCRIPTION
## Summary

**Reconciler Phase A** (CTL-826) — pure mechanical extraction, zero behavior change.

Collapses the ~240 duplicated lines of "dispatch → verify the worker landed → on success clear-cooldown + re-read signal + emit launched / on failure run the cool-down + circuit-breaker + escalation ladder" skeleton that recurred **verbatim** across the three scheduler dispatch sweeps in `plugins/dev/scripts/execution-core/scheduler.mjs` into one shared `dispatchAndVerify()` helper:

| Sweep | Path | Failure ladder |
|-------|------|----------------|
| Pass 1 | advancement | full |
| Pass 1.5 | resume-after-preemption | reduced |
| Pass 2 | new-work pull | full |

## What the helper owns vs. what stays at the call sites

The helper owns **only** the byte-identical core (steps 1–4 of the ticket): the dispatch-requested emit, `dispatchTicket`, `verifyDispatched`, and on success `clearDispatchCooldown` + signal re-read + launched emit / on failure the cool-down + circuit-breaker + escalation ladder. It returns `{ ok, code, reason, signal }` (or `{ aborted: true }` when the `preDispatch` hook vetoes) so each call site keeps its own **divergences**:

- **advance**: `emitPredecessorReap` (success + both failure branches), CTL-751 triage→research `applyEstimate`, CTL-755 `promotedCount++`
- **resume**: the pre-dispatch signal reset-to-stalled (via the `preDispatch` hook), `appendResumedAfterPreemptionEvent`, `rankedAboveSince.delete`, `resumeSlots--`/`resumedCount++`
- **new-work**: `writeWorkerPriority`, `applyAssignee`, `dispatched.push`

## Behavior-preservation guarantees

- The **full-vs-reduced failure ladder** divergence is parameterized via `fullFailureLadder` (advance/new-work escalate + trip the breaker + carry `consecutiveFailures`/`expiresAt`; resume keeps its lighter path).
- The per-site `rc!=0` `log.warn` payloads are reproduced exactly via `failLogMsg`/`failLogIncludePhase` (Pass 2's original log omits the `phase` field).
- Ordering preserved exactly: requested-emit → optional `preDispatch` (resume's reset) → `dispatchTicket` → `verifyDispatched`.
- `dispatchTicket` only adds `resumeSession` to args when truthy, so always threading it is byte-identical for the two sweeps that don't use it.

## Tests

- `scheduler.test.mjs`: **399 pass / 0 fail** (394 pre-existing + 5 new). The existing CTL-611 / CTL-660 / resume-sweep suites already exercise every branch the helper now owns and stay green unchanged — they are the equivalence guard.
- New focused `dispatchAndVerify shared core (CTL-826)` describe block (5 tests): the three branches (v.ok success with launched bg fields + cooldown clear / verify-failed demotion / rc!=0), the reduced-ladder divergence (no escalation past the retry ceiling, lighter event shape), and the requested→preDispatch(reset)→dispatch ordering.
- `recovery.test.mjs` 203 pass, `daemon.test.mjs` 91 pass, plus dispatch/integration/rank/perproject/sequencing/reaper suites all green.
- The intermittent `integration.test.mjs` "AC5 — kill mid-run + restart" failure is a **pre-existing** real-process spawn/timing flake (reproduced identically on clean `origin/main`), not introduced here.

## Why now

Low-risk, high-leverage precondition: **CTL-807** (async tick) reshapes how/when these passes run and **CTL-808** merges them into one classifier — both far safer against a single tested `dispatchAndVerify` than three hand-maintained copies. Blocks CTL-807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)