### PR TITLE
feat(dev): CTL-880 wire gherkin-ticket standard into ticket-creation skills

### DIFF
--- a/plugins/dev/skills/linear/SKILL.md
+++ b/plugins/dev/skills/linear/SKILL.md
@@ -14,6 +14,15 @@ version: 1.0.0
 You are tasked with managing Linear tickets, including creating tickets from thoughts documents,
 updating existing tickets, and following a structured workflow using the Linearis CLI.
 
+## REQUIRED: ticket format gate
+
+**Before creating ANY ticket, apply the `/catalyst-dev:gherkin-ticket` standard.** Every ticket must
+open with a scannable use-case — an outcome-first title (`<actor> should <outcome> [so that
+<benefit>]`, no internal-mechanism jargon, no `[Component]` prefix) and a body that leads with a
+plain-English use case followed by tiered Gherkin (`Given/When/Then`) acceptance criteria. This is a
+hard gate: do not draft a title or description without first consulting that skill. Component goes in
+a Linear label, not the title.
+
 ## Prerequisites Check
 
 First, verify that Linearis CLI is installed and configured:
@@ -177,23 +186,25 @@ When referencing thoughts documents, always provide GitHub links:
    - If it mentions other thoughts documents, quickly check them
    - Look for any existing Linear tickets mentioned
 
-4. **Draft the ticket summary:** Present a draft to the user:
+4. **Draft the ticket summary** following the `/catalyst-dev:gherkin-ticket` standard. Present a
+   draft to the user:
 
    ```
    ## Draft Linear Ticket
 
-   **Title**: [Clear, action-oriented title]
+   **Title**: [outcome-first use-case sentence — <actor> should <outcome> [so that <benefit>];
+   no mechanism/file/symbol names, no [Component] prefix]
 
    **Description**:
-   [2-3 sentence summary of the problem/goal]
+   [short plain-English use case — who benefits and why — so a reader who didn't write it gets oriented]
 
-   ## Key Details
-   - [Bullet points of important details from thoughts]
-   - [Technical decisions or constraints]
-   - [Any specific requirements]
+   [Gherkin acceptance criteria in a ```gherkin fenced block, at the right tier:
+    A = features/bugs (full Given/When/Then), B = bugs (Then states correct behavior + # CURRENTLY:),
+    C = pure chores (Context/Motivation/Outcome prose)]
 
-   ## Implementation Notes (if applicable)
-   [Any specific technical approach or steps outlined]
+   ## Technical notes
+   - [implementation detail, technical decisions, constraints — preserved, but BELOW the use case]
+   - [any specific requirements]
 
    ## References
    - Source: `thoughts/[path]` ([View on GitHub](converted URL))

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -23,6 +23,17 @@ The skill is dispatched in two modes:
 
 Both modes produce the same `triage.json` shape and emit the same canonical phase event.
 
+## Use-case conformance (Opus mode)
+
+When refining the analysis, also assess whether the ticket meets the `/catalyst-dev:gherkin-ticket`
+standard: an outcome-first title (not a mechanism/file/symbol name) and a body that opens with a
+plain-English use case followed by tiered Gherkin acceptance criteria. If it does **not** conform,
+add one line to the triage analysis comment flagging it — e.g. *"⚠️ Ticket does not lead with a
+use-case (per gherkin-ticket); consider rewriting the title/opening for scannability."* This surfaces
+non-conformant tickets for the operator without auto-rewriting them — triage is a documentarian, so
+**do not** edit the ticket's title or description here; flag only. (The deterministic bash body and
+`triage.json` schema are unchanged.)
+
 ## /goal
 
 ```

--- a/plugins/pm-ops/skills/create-tickets/SKILL.md
+++ b/plugins/pm-ops/skills/create-tickets/SKILL.md
@@ -8,6 +8,12 @@ disable-model-invocation: false
 
 Generate engineering tickets from PRDs, feature specs, or task lists. Supports direct creation via Linear MCP or formatted text output.
 
+> **REQUIRED: every generated ticket must follow the `/catalyst-dev:gherkin-ticket` standard.**
+> Outcome-first title (`<actor> should <outcome> [so that <benefit>]`, no internal-mechanism jargon,
+> component as a *label* not a title prefix) + a body that opens with a plain-English use case
+> followed by tiered Gherkin acceptance criteria. The legacy `[Component] Action:` title format below
+> is superseded — see the updated Title Format and Ticket Body sections.
+
 ## Quick Start
 
 1. Point me to the source: PRD, feature spec, meeting action items, or describe the work
@@ -66,38 +72,36 @@ Read the source document and identify:
 
 For each ticket, generate:
 
-**Title Format:**
+**Title Format** (per `/catalyst-dev:gherkin-ticket` — outcome-first, no `[Component]` prefix):
 
 ```
-[Component] Action: Brief description
+<actor> should <outcome> [when <condition>] [so that <benefit>]
 ```
 
-Examples:
+The actor is whoever benefits (a user, an operator, the API, the scheduler). The component goes in a
+Linear **label**, not the title. Examples:
 
-- `[API] Add endpoint for user preferences`
-- `[Frontend] Build preference selection UI`
-- `[DB] Create user_preferences table`
+- `Users should be able to save and reload their preferences so settings persist across sessions`
+- `The preferences API should reject an unknown user with a 404 rather than a 500`
+- `Operators should see a preference-selection screen so they can configure defaults without code`
 
-**Ticket Body:**
+**Ticket Body** (use case first, then tiered Gherkin, then technical detail):
 
 ```markdown
-## Context
+[Short plain-English use case — who benefits and why — so a reader who didn't write it gets oriented.]
 
-[Link to PRD or parent epic]
+​```gherkin
+Scenario: <one specific behavior>
+  Given <minimum starting state>
+  When <the single action>
+  Then <observable outcome>
+​```
+(Tier A = features/bugs full scenarios; Tier B = bugs, `Then` states correct behavior + `# CURRENTLY:`;
+Tier C = pure chores, Context/Motivation/Outcome prose instead of a vacuous scenario.)
 
-## Objective
+## Technical notes
 
-[What this ticket accomplishes]
-
-## Acceptance Criteria
-
-- [ ] Specific outcome 1
-- [ ] Specific outcome 2
-- [ ] Specific outcome 3
-
-## Technical Notes
-
-[API contracts, data schemas, edge cases]
+[API contracts, data schemas, edge cases — preserved, but BELOW the use case]
 
 ## Dependencies
 
@@ -373,8 +377,8 @@ Priority: Medium
 
 ## Common Mistakes to Avoid
 
-❌ Vague titles: "Fix preferences"
-✅ Specific titles: "[API] Fix: Preferences endpoint returns 500 on missing user"
+❌ Mechanism/vague titles: "Fix preferences" / "[API] Fix preferences endpoint"
+✅ Outcome titles: "The preferences API should return 404 (not 500) when the user doesn't exist"
 
 ❌ No acceptance criteria
 ✅ Clear checklist of outcomes
@@ -450,7 +454,8 @@ When the PM uses `/create-tickets`, I automatically:
 
 Before delivering tickets, verify:
 
-- [ ] **Every ticket has a clear, specific title** -- "[Component] Action: Description" format, no vague titles like "Fix stuff"
+- [ ] **Every ticket has an outcome-first title** -- per `/catalyst-dev:gherkin-ticket` (`<actor> should <outcome>`), no `[Component]` prefix, no internal-mechanism jargon, no vague titles like "Fix stuff"
+- [ ] **Every ticket body opens with a use case + tiered Gherkin** -- plain-English context first, then `Given/When/Then` acceptance criteria
 - [ ] **Every ticket has testable acceptance criteria** -- At least 2-3 checkboxes that define "done"
 - [ ] **Every ticket has an effort estimate** -- T-shirt size (XS/S/M/L/XL) assigned to each
 - [ ] **XL tickets flagged for splitting** -- Any ticket estimated at 1-2 weeks has a suggested breakdown


### PR DESCRIPTION
## What

Wires the **`gherkin-ticket`** standard (CTL-877, shipped v12.2.0) into the ticket-creation paths so new tickets are born conformant and the backlog can't regress to cryptic, mechanism-first titles.

CTL-880. Follows the just-completed rewrite of all 83 active CTL tickets to this standard.

## Changes

- **`linear` (hard gate)** — adds a "REQUIRED: ticket format gate" before any creation: apply `/catalyst-dev:gherkin-ticket` first. Draft template now produces an outcome-first title + use-case opener + tiered Gherkin body (technical detail moved under `## Technical notes`).
- **`create-tickets` (pm-ops, hard gate)** — supersedes the legacy `[Component] Action:` title format with outcome titles (component → Linear label); body template leads with a use case + `Given/When/Then`; self-check and examples updated.
- **`phase-triage` (reference + flag, no code change)** — Opus-mode prose only: assess use-case conformance and flag non-conformant tickets in the triage comment. Deliberately does **not** touch the deterministic bash body or `triage.json` schema, and **never auto-rewrites** (triage stays a documentarian).

## Scope notes

- `linear` + `create-tickets` are the real creation gates; `phase-triage` is an analysis path, so it only flags.
- Out of scope: triage classification/estimation logic, auto-rewriting during triage, the `~/.claude/skills/` global mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)