### PR TITLE
fix(dev): CTL-878 stop self-inflicted epic→child dependency deadlock

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -434,6 +434,35 @@ if [ -f "$TRIAGE_SUBST" ]; then
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Case: CTL-878 — the parent epic is NEVER scraped into dependencies. A Linear
+# parent/child hierarchy link is not a blocker; emitting it makes the scheduler
+# persist `child blocked_by parent-epic`, deadlocking the child against an epic
+# that is never worked. The parent id is in the ticket JSON, so 2d excludes it.
+
+FIXTURE_PARENT="$TMPROOT/fixture-parent.json"
+cat >"$FIXTURE_PARENT" <<'EOF'
+{
+  "identifier": "CTL-863",
+  "title": "Implement takeover/healing for a downed daemon node",
+  "description": "Part of the CTL-859 multi-host epic. Depends on CTL-850 (HRW claim). When a node dies, the survivor must resume from the draft PR.",
+  "parent": { "identifier": "CTL-859" },
+  "labels": {"nodes": []}
+}
+EOF
+
+CASE_DIR_PARENT="$(run_case parent "$FIXTURE_PARENT" CTL-863)"
+assert_eq "ctl878-parent: exit code 0" 0 "$(cat "$CASE_DIR_PARENT/exit-code")"
+TRIAGE_PARENT="$CASE_DIR_PARENT/worker/triage.json"
+assert_file_exists "ctl878-parent: triage.json created" "$TRIAGE_PARENT"
+if [ -f "$TRIAGE_PARENT" ]; then
+	DEPS_PARENT="$(jq -c '.dependencies' "$TRIAGE_PARENT")"
+	# CTL-859 is the parent epic → excluded. CTL-850 is a real sibling dep → kept.
+	# CTL-863 is self → excluded.
+	EXPECTED_DEPS_PARENT='["CTL-850"]'
+	assert_eq "ctl878-parent: parent epic excluded, sibling dep kept" "$EXPECTED_DEPS_PARENT" "$DEPS_PARENT"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Summary
 
 echo

--- a/plugins/dev/scripts/execution-core/eligible-set.mjs
+++ b/plugins/dev/scripts/execution-core/eligible-set.mjs
@@ -28,14 +28,21 @@ function byIdentifier(a, b) {
   return String(a.identifier).localeCompare(String(b.identifier));
 }
 
-// Stable content signature - identifiers + states + priorities only. The
+// Stable content signature - identifiers + states + priorities + parent. The
 // projection's updatedAt timestamp always differs between writes, so the
 // skip-when-unchanged check compares ticket content, never the serialized
 // body. JSON.stringify of the tuple list is collision-proof (its escaping
 // disambiguates any separator that could appear inside a field).
+//
+// CTL-878: `parent` is part of the signature so a parent-only delta forces a
+// rewrite. The dependency graph drops a `blocks` edge from a ticket's parent
+// epic, which needs `parent` ON the projected descriptor. Without parent in the
+// key, a pre-fix projection (no parent field) written by an older daemon would
+// survive across a deploy whenever the project's identifier/state/priority set
+// is steady — leaving the parent-epic edge un-dropped and the child deadlocked.
 function contentKey(tickets) {
   return JSON.stringify(
-    tickets.map((t) => [t.identifier, t.state, t.priority]),
+    tickets.map((t) => [t.identifier, t.state, t.priority, t.parent ?? null]),
   );
 }
 

--- a/plugins/dev/scripts/execution-core/eligible-set.test.mjs
+++ b/plugins/dev/scripts/execution-core/eligible-set.test.mjs
@@ -123,6 +123,26 @@ describe("setProjectEligible", () => {
     );
     expect(statSync(projFile("alpha")).mtimeMs).toBeGreaterThan(mtime1);
   });
+
+  test("CTL-878: a parent-only delta DOES rewrite the file (parent is in the content key)", async () => {
+    // A pre-fix projection lacks `parent`; the post-fix reconcile supplies it.
+    // Without parent in contentKey the rewrite is skipped and the read-layer
+    // parent-epic drop silently no-ops for steady-state eligible children.
+    setProjectEligible("alpha", [{ identifier: "A-1", state: "Todo", priority: 1 }], {
+      source: "reconcile",
+      query: {},
+    });
+    const mtime1 = statSync(projFile("alpha")).mtimeMs;
+    await sleep(15);
+    setProjectEligible(
+      "alpha",
+      [{ identifier: "A-1", state: "Todo", priority: 1, parent: "A-9" }],
+      { source: "reconcile", query: {} },
+    );
+    expect(statSync(projFile("alpha")).mtimeMs).toBeGreaterThan(mtime1);
+    const doc = JSON.parse(readFileSync(projFile("alpha"), "utf8"));
+    expect(doc.tickets[0].parent).toBe("A-9"); // parent persisted to disk
+  });
 });
 
 describe("removeTicket", () => {

--- a/plugins/dev/scripts/execution-core/linear-cache.mjs
+++ b/plugins/dev/scripts/execution-core/linear-cache.mjs
@@ -18,7 +18,7 @@
 //      relations store, so a setRelations() priming a state never trips an
 //      invalidation, and the monitor write-through stays byte-for-byte.
 //   2. `relationsEntries` — the FULL relation descriptor
-//      ({ state, relations, inverseRelations, priority, labels }) keyed by
+//      ({ state, parent, relations, inverseRelations, priority, labels }) keyed by
 //      identifier, with its own TTL. This is the read-through store
 //      fetchTicketsBatch / fetchTicketRelations populate and consult so the
 //      admission pool's per-tick relation reads collapse to one batched query

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -29,6 +29,7 @@ const BATCH_QUERY = `query CtlBatchTickets($ids: [ID!]) {
       identifier
       priority
       state { name }
+      parent { identifier }
       labels(first: 50) { nodes { name } }
       relations(first: 100) { nodes { type relatedIssue { identifier } } }
       inverseRelations(first: 100) { nodes { type issue { identifier } } }
@@ -100,6 +101,11 @@ function normalizeTicket(node) {
     project: node.project?.name ?? node.project ?? null,
     updatedAt: node.updatedAt ?? null,
     createdAt: node.createdAt ?? null,
+    // CTL-878: the parent epic identifier (or null). buildDependencyEdges drops a
+    // `blocks` edge whose source is the target's parent — a Linear parent/child
+    // hierarchy link is NOT a dependency, so a never-worked tracking epic must not
+    // deadlock its own children. `linearis issues list` emits `parent { identifier }`.
+    parent: node.parent?.identifier ?? node.parent ?? null,
     relations: node.relations ?? { nodes: [] },
     inverseRelations: node.inverseRelations ?? { nodes: [] },
   };
@@ -160,11 +166,11 @@ export function fetchTicketState(
 }
 
 // fetchTicketRelations — the CTL-755 admission gate's single-read hydration of
-// one triaged-waiting candidate: its live workflow state, dependency edges,
-// priority, and labels, all parsed from ONE `linearis issues read <id>`. The
+// one triaged-waiting candidate: its live workflow state, parent epic, dependency
+// edges, priority, and labels, all parsed from ONE `linearis issues read <id>`. The
 // returned descriptor mirrors normalizeTicket (above) so the same
 // buildDependencyEdges / analyzeDependencyGraph / computeReadySet consume it:
-//   { state, relations, inverseRelations, priority, labels }
+//   { state, parent, relations, inverseRelations, priority, labels }
 // - state: node.state.name (or a flat string `state`), or null when absent.
 // - relations / inverseRelations: default { nodes: [] } so the graph builder
 //   reads `.nodes` unconditionally. VERIFIED (ADV-1277): the single-ticket read
@@ -209,15 +215,21 @@ export function fetchTicketRelations(identifier, { exec = defaultExec, cache } =
 
 // normalizeRelations — flatten one issue node (from `linearis issues read` OR
 // the batched GraphQL query — both return the same nested shape) into the
-// descriptor the admission gate consumes: { state, relations, inverseRelations,
-// priority, labels }. NOTE: deliberately does NOT include `identifier` so the
-// shape stays byte-identical to the legacy fetchTicketRelations return (callers
-// and tests rely on it); fetchTicketsBatch keys its Map on node.identifier
-// separately. A missing priority normalizes to null ("unknown"), matching
-// fetchTicketRelations (NOT normalizeTicket's eligible-set default of 0).
+// descriptor the admission gate consumes: { state, parent, relations,
+// inverseRelations, priority, labels }. NOTE: deliberately does NOT include
+// `identifier` so fetchTicketRelations and fetchTicketsBatch stay the SAME shape
+// (callers and tests rely on it); fetchTicketsBatch keys its Map on
+// node.identifier separately. A missing priority normalizes to null ("unknown"),
+// matching fetchTicketRelations (NOT normalizeTicket's eligible-set default of 0).
 function normalizeRelations(node) {
   return {
     state: node?.state?.name ?? node?.state ?? null,
+    // CTL-878: parent epic identifier (or null). Carried so the admission gate's
+    // buildDependencyEdges can drop a parent→child `blocks` edge AND STEP E can
+    // skip persisting a child→parent blocked_by (a parent/child hierarchy link is
+    // not a dependency). Both `linearis issues read` and the batch GraphQL query
+    // emit `parent { identifier }`.
+    parent: node?.parent?.identifier ?? node?.parent ?? null,
     relations: node?.relations ?? { nodes: [] },
     inverseRelations: node?.inverseRelations ?? { nodes: [] },
     priority: typeof node?.priority === "number" ? node.priority : null,

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -185,6 +185,24 @@ describe("runEligibleQuery", () => {
     expect(t.relations).toEqual(relations);
     expect(t.inverseRelations).toEqual({ nodes: [] });
   });
+
+  // CTL-878: the eligible/Pass-2 path carries the parent epic id so
+  // buildDependencyEdges can drop a parent→child blocks edge for a Todo child.
+  test("CTL-878: captures the parent epic identifier (nested) for an eligible ticket", () => {
+    const exec = fakeExec({
+      stdout: ticketsJson([
+        { identifier: "CTL-863", state: { name: "Todo" }, parent: { identifier: "CTL-859" } },
+      ]),
+    });
+    expect(runEligibleQuery(query, { exec })[0].parent).toBe("CTL-859");
+  });
+
+  test("CTL-878: parent is null when an eligible ticket has no parent (never undefined)", () => {
+    const exec = fakeExec({
+      stdout: ticketsJson([{ identifier: "CTL-1", state: { name: "Todo" } }]),
+    });
+    expect(runEligibleQuery(query, { exec })[0].parent).toBeNull();
+  });
 });
 
 // CTL-565 D5 — fetchTicketState wraps `linearis issues read <id>` to hydrate
@@ -358,11 +376,25 @@ describe("fetchTicketRelations (CTL-755)", () => {
     expect(calls[0].args).toEqual(["issues", "read", "ADV-1277"]);
     expect(rel).toEqual({
       state: "Triage",
+      parent: null, // CTL-878: ADV-1277 has no parent → null
       relations: { nodes: [{ type: "blocks", relatedIssue: { identifier: "ADV-1280" } }] },
       inverseRelations: { nodes: [{ type: "blocks", issue: { identifier: "ADV-1276" } }] },
       priority: 2,
       labels: ["feature", "orchestrator"],
     });
+  });
+
+  test("CTL-878: carries the parent epic identifier when `linearis issues read` emits it", () => {
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({
+        identifier: "CTL-863",
+        state: { name: "Todo" },
+        parent: { identifier: "CTL-859" },
+      }),
+      stderr: "",
+    });
+    expect(fetchTicketRelations("CTL-863", { exec }).parent).toBe("CTL-859");
   });
 
   test("parses a blocked-by edge out of inverseRelations.nodes", () => {
@@ -492,10 +524,11 @@ describe("fetchTicketRelations (CTL-755)", () => {
 describe("fetchTicketsBatch (CTL-784)", () => {
   // A node in the batched GraphQL shape (same nested shape `linearis issues read`
   // returns): state{name}, labels{nodes{name}}, relations{nodes{...}}.
-  const node = (identifier, { state = "Triage", priority = 2, labels = [], blockedBy } = {}) => ({
+  const node = (identifier, { state = "Triage", priority = 2, labels = [], blockedBy, parent } = {}) => ({
     identifier,
     priority,
     state: { name: state },
+    ...(parent ? { parent: { identifier: parent } } : {}),
     labels: { nodes: labels.map((name) => ({ name })) },
     relations: { nodes: [] },
     inverseRelations: blockedBy
@@ -521,12 +554,19 @@ describe("fetchTicketsBatch (CTL-784)", () => {
     const desc = fetchTicketsBatch(["CTL-1"], { exec }).get("CTL-1");
     expect(desc).toEqual({
       state: "In Progress",
+      parent: null, // CTL-878: no parent on this node → null
       relations: { nodes: [] },
       inverseRelations: { nodes: [{ type: "blocks", issue: { identifier: "CTL-9" } }] },
       priority: 1,
       labels: ["blocked"],
     });
     expect("identifier" in desc).toBe(false); // shape parity with fetchTicketRelations
+  });
+
+  test("CTL-878: carries the parent epic identifier from a batched node", () => {
+    const exec = (ids) => ids.map((id) => node(id, { parent: "CTL-859" }));
+    const desc = fetchTicketsBatch(["CTL-863"], { exec }).get("CTL-863");
+    expect(desc.parent).toBe("CTL-859");
   });
 
   test("dedupes identifiers before the exec", () => {

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2415,6 +2415,12 @@ export function schedulerTick(
           priority: typeof rel?.priority === "number" ? rel.priority : priority,
           createdAt,
           state: { name: stateName },
+          // CTL-878: carry the parent epic id so buildDependencyEdges (A.7) drops a
+          // parent→child blocks edge AND STEP E skips persisting child blocked_by
+          // parent. This literal cherry-picks fields (it does NOT spread `rel`), so
+          // parent MUST be copied explicitly or the parent-deadlock guard no-ops for
+          // the very triaged-waiting path that holds the epic's children.
+          parent: rel?.parent ?? null,
           relations: rel?.relations ?? { nodes: [] },
           inverseRelations: rel?.inverseRelations ?? { nodes: [] },
         });
@@ -2566,6 +2572,17 @@ export function schedulerTick(
         if (!depIds) continue; // cycle member or no deps
 
         const desc = descriptorByTicket.get(candidate);
+        // CTL-878: the candidate's parent epic. A parent/child hierarchy link is
+        // NOT a dependency — persisting `child blocked_by parent-epic` deadlocks
+        // the child (a tracking epic is never worked → never terminal → the gate
+        // never clears). Triage scrapes the parent id out of the child's body, so
+        // skip the durable write below when a dep IS the parent. This guards only
+        // NEW edges: an ALREADY-durable parent edge is short-circuited earlier by
+        // the existingBlockers idempotency check and is left in Linear — harmless,
+        // because the read-layer buildDependencyEdges drop (the load-bearing fix)
+        // neutralizes it at read time regardless; a one-time operator edge delete
+        // clears the residual UI noise.
+        const candidateParent = desc?.parent ?? null;
         // Already-durable blocked_by blockers for THIS candidate, read from its
         // FRESH inverseRelations ({type:"blocks", issue:<blocker>} ⇒ blocker
         // blocks candidate). The idempotency guard: skip writing an edge we can
@@ -2591,6 +2608,16 @@ export function schedulerTick(
 
         for (const dep of depIds) {
           if (existingBlockers.has(dep)) continue; // idempotent — edge already durable
+          if (dep === candidateParent) {
+            // CTL-878: the dep is the candidate's parent epic. Never persist a
+            // child→parent-epic blocked_by edge — it is a hierarchy link mis-scraped
+            // as a dependency and would deadlock the child against a never-worked epic.
+            log.warn(
+              { candidate, dep },
+              "ctl-878 step-e: skipping dependency that is the candidate's parent epic",
+            );
+            continue;
+          }
           if (candidateBlocks.has(dep)) {
             // Persisting blocked_by(candidate ← dep) while candidate already
             // blocks dep would close a cycle. Drop it (do not deadlock).

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -6557,6 +6557,52 @@ describe("CTL-755: admission gate", () => {
     expect(relations).toEqual([{ ticket: "CTL-7", blockedBy: "CTL-100" }]);
   });
 
+  test("CTL-878: a dep that is the candidate's PARENT epic is NOT persisted", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    // CTL-859 is CTL-7's parent epic, scraped into triage.json deps. It is
+    // non-terminal (Backlog) and not already a durable edge — so absent the
+    // CTL-878 guard STEP E would persist CTL-7 blocked_by CTL-859 (the deadlock).
+    writeTriageDeps("CTL-7", ["CTL-859"]);
+    const dispatch = fakeDispatch();
+    const { ws, relations } = depSpy();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      // CTL-7's descriptor carries parent === CTL-859; CTL-859 hydrates Backlog.
+      fetchBatch: mkBatch({
+        "CTL-7": { ...relUnblocked(), parent: "CTL-859" },
+        "CTL-859": descOf("Backlog"),
+      }),
+    });
+    expect(relations).toEqual([]); // parent epic never persisted as a blocker
+  });
+
+  test("CTL-878: the parent skip is parent-specific — a non-parent non-terminal dep is still persisted", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    // CTL-859 is the parent (skipped); CTL-100 is a real sibling dep (persisted).
+    writeTriageDeps("CTL-7", ["CTL-859", "CTL-100"]);
+    const dispatch = fakeDispatch();
+    const { ws, relations } = depSpy();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchBatch: mkBatch({
+        "CTL-7": { ...relUnblocked(), parent: "CTL-859" },
+        "CTL-859": descOf("Backlog"),
+        "CTL-100": descOf("In Progress"),
+      }),
+    });
+    expect(relations).toEqual([{ ticket: "CTL-7", blockedBy: "CTL-100" }]);
+  });
+
   test("CTL-784: writing a durable edge INVALIDATES the candidate's relations cache (no ≤TTL over-promotion)", () => {
     // After STEP E writes a new blocked_by edge, the candidate's relations
     // descriptor cached THIS tick (by A.3) is stale (no edge). Invalidating it

--- a/plugins/dev/scripts/lib/dependency-graph.mjs
+++ b/plugins/dev/scripts/lib/dependency-graph.mjs
@@ -20,12 +20,27 @@ export const DEFAULT_TERMINAL_STATUSES = ["Done", "Canceled"];
 // `linearis` emits only `blocks`; the API-native `blocked_by` form is also
 // accepted for forward-compat.
 //
+// CTL-878: a `blocks` edge whose source is the target's PARENT epic is DROPPED.
+// A Linear parent/child hierarchy link is not a dependency, but triage scrapes a
+// child's body for ticket refs and the scheduler (CTL-755 STEP E) was persisting
+// `child blocked_by parent-epic` durably. Because a tracking epic is never worked
+// (it never reaches a terminal state and the daemon's eligible query is Todo-only),
+// that edge deadlocks the child forever. Each in-set issue carries `parent` (the
+// epic identifier, threaded from linearis) so the drop also fires when the parent
+// is an out-of-set externalId — exactly the deadlock case (CTL-859→863, CTL-718→722).
+//
 // options.externalIds — out-of-set blocker identifiers (D5) that remain valid
 // edge endpoints on the `from` side.
 export function buildDependencyEdges(issues, { externalIds } = {}) {
   const list = issues ?? [];
   const inSet = new Set(list.map((i) => i?.identifier).filter(Boolean));
   const ext = externalIds instanceof Set ? externalIds : new Set(externalIds ?? []);
+  // CTL-878: child identifier → its parent epic identifier, for the parent-edge
+  // drop below. Built from the in-set issues' `parent` field (normalized to a
+  // string id upstream); a missing parent leaves the child absent from the map.
+  const parentOf = new Map(
+    list.filter((i) => i?.identifier && i?.parent).map((i) => [i.identifier, i.parent]),
+  );
   const seen = new Set();
   const edges = [];
 
@@ -35,6 +50,7 @@ export function buildDependencyEdges(issues, { externalIds } = {}) {
     // declared external blocker. A genuinely out-of-set edge is dropped.
     if (!inSet.has(to)) return;
     if (!inSet.has(from) && !ext.has(from)) return;
+    if (parentOf.get(to) === from) return; // CTL-878: parent→child is hierarchy, not a dependency
     const key = `${from} ${to}`;
     if (seen.has(key)) return; // dedup symmetric relations/inverseRelations
     seen.add(key);

--- a/plugins/dev/scripts/lib/dependency-graph.test.mjs
+++ b/plugins/dev/scripts/lib/dependency-graph.test.mjs
@@ -98,6 +98,54 @@ describe("buildDependencyEdges", () => {
       issues: [{ identifier: "CTL-1", state: { name: "Backlog" } }],
       expected: [],
     },
+    {
+      // CTL-878: a child's blocks edge from its own parent epic is hierarchy, not
+      // a dependency — dropped so a never-worked tracking epic can't deadlock it.
+      name: "CTL-878: a `blocks` edge from the target's parent epic is dropped",
+      issues: [
+        {
+          identifier: "CTL-863",
+          state: { name: "Todo" },
+          parent: "CTL-859",
+          relations: { nodes: [] },
+          inverseRelations: { nodes: [inv("blocks", "CTL-859")] },
+        },
+        issue("CTL-859", "Backlog"),
+      ],
+      expected: [],
+    },
+    {
+      // CTL-878: only the PARENT edge is dropped — a real sibling dependency on the
+      // same child survives (mirrors CTL-866: parent CTL-859 + sibling CTL-863).
+      name: "CTL-878: parent edge dropped, sibling dependency edge kept",
+      issues: [
+        {
+          identifier: "CTL-866",
+          state: { name: "Todo" },
+          parent: "CTL-859",
+          relations: { nodes: [] },
+          inverseRelations: { nodes: [inv("blocks", "CTL-859"), inv("blocks", "CTL-863")] },
+        },
+        issue("CTL-863", "Todo"),
+        issue("CTL-859", "Backlog"),
+      ],
+      expected: [{ from: "CTL-863", to: "CTL-866" }],
+    },
+    {
+      // CTL-878: the drop must also fire when the parent epic is genuinely a child
+      // of a sibling (forward `blocks` direction, parent declared on the child).
+      name: "CTL-878: parent edge dropped via forward `blocks` from the parent node",
+      issues: [
+        {
+          identifier: "CTL-859",
+          state: { name: "Backlog" },
+          relations: { nodes: [rel("blocks", "CTL-863")] },
+          inverseRelations: { nodes: [] },
+        },
+        { identifier: "CTL-863", state: { name: "Todo" }, parent: "CTL-859" },
+      ],
+      expected: [],
+    },
   ];
 
   for (const c of cases) {
@@ -105,6 +153,32 @@ describe("buildDependencyEdges", () => {
       expect(sortEdges(buildDependencyEdges(c.issues))).toEqual(sortEdges(c.expected));
     });
   }
+
+  // CTL-878: the deadlock case is an OUT-OF-SET parent epic — the child is in the
+  // eligible/admission pool but the epic (Backlog, never dispatched) is hydrated
+  // only as an externalId. Without the parent guard the externalId rule keeps the
+  // edge; with it the edge is dropped because the child carries parent === epic.
+  test("CTL-878: parent-epic edge dropped even when the parent is an out-of-set externalId", () => {
+    const issues = [
+      {
+        identifier: "CTL-722",
+        state: { name: "Todo" },
+        parent: "CTL-718",
+        relations: { nodes: [] },
+        inverseRelations: { nodes: [inv("blocks", "CTL-718")] },
+      },
+    ];
+    // CTL-718 is out-of-set but declared as an external blocker (D5 hydration).
+    expect(buildDependencyEdges(issues, { externalIds: ["CTL-718"] })).toEqual([]);
+  });
+
+  test("CTL-878: an issue with no parent field is unaffected (backward compat)", () => {
+    const issues = [
+      issue("CTL-1", "Backlog", [rel("blocks", "CTL-2")]),
+      issue("CTL-2", "Todo"),
+    ];
+    expect(buildDependencyEdges(issues)).toEqual([{ from: "CTL-1", to: "CTL-2" }]);
+  });
 });
 
 describe("computeReadySet", () => {
@@ -451,6 +525,25 @@ describe("analyzeDependencyGraph", () => {
   test("acyclic graph → no anomalies", () => {
     const issues = [issue("CTL-1", "Backlog", [rel("blocks", "CTL-2")]), issue("CTL-2", "Backlog")];
     expect(analyzeDependencyGraph(issues).anomalies).toEqual([]);
+  });
+
+  // CTL-878 end-to-end: a Todo child whose ONLY blocker is its Backlog parent epic
+  // (an out-of-set, non-terminal blocker) must be READY, not blocked. This is the
+  // exact production deadlock (CTL-859→863, CTL-718→722) the parent guard fixes.
+  test("CTL-878: a child blocked only by its non-terminal parent epic is ready, not blocked", () => {
+    const issues = [
+      {
+        identifier: "CTL-863",
+        state: { name: "Todo" },
+        parent: "CTL-859",
+        relations: { nodes: [] },
+        inverseRelations: { nodes: [inv("blocks", "CTL-859")] },
+      },
+    ];
+    const result = analyzeDependencyGraph(issues, { blockerStates: { "CTL-859": "Backlog" } });
+    expect(result.ready).toEqual(["CTL-863"]);
+    expect(result.blocked).toEqual([]);
+    expect(result.anomalies).toEqual([]);
   });
 });
 

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -173,11 +173,19 @@ ACRONYMS_EXPANDED="$(jq -nc --arg t "$COMBINED" '
 ')"
 
 # 2d. Dependencies — other CTL-style identifiers referenced in body, excluding self.
-#     Match any TEAM-NNN pattern; dedupe; exclude the ticket itself.
+#     Match any TEAM-NNN pattern; dedupe; exclude the ticket itself AND its parent
+#     epic. A Linear parent/child hierarchy link is NOT a dependency: emitting the
+#     parent epic here makes the scheduler (CTL-755 STEP E) persist `child blocked_by
+#     parent-epic`, which deadlocks the child against a tracking epic that is never
+#     worked (CTL-878). The parent identifier is already in the ticket JSON, so the
+#     exclusion costs no extra Linear read. PARENT_TICKET is empty when the ticket
+#     has no parent, in which case the second grep pattern collapses to the self
+#     exclusion (a harmless no-op).
+PARENT_TICKET="$(jq -r '.parent.identifier // .parent // empty' "$TICKET_JSON_FILE" 2>/dev/null)"
 DEPENDENCIES="$(printf '%s\n' "$COMBINED" \
   | grep -oE '[A-Z][A-Z0-9_]*-[0-9]+' 2>/dev/null \
   | sort -u \
-  | grep -v -x "$TICKET" \
+  | grep -v -x -e "$TICKET" -e "${PARENT_TICKET:-$TICKET}" \
   | jq -R . | jq -sc .)"
 DEPENDENCIES="${DEPENDENCIES:-[]}"
 


### PR DESCRIPTION
## Problem

The execution-core daemon was **deadlocking its own children**. `phase-triage` scrapes every `TEAM-NNN` token from a child ticket's body into `triage.json .dependencies` — including the child's **parent epic** — and the scheduler (CTL-755 STEP E) persists each as a durable Linear `child blocked_by parent-epic` relation. A tracking epic sits in Backlog forever (never worked — the eligible query is Todo-only), so `computeReadySet` marks the child **permanently blocked**.

Symptom on the mini: broker/monitor/execution-core healthy, `FREE SLOTS 6 / IN FLIGHT 0`, ~10 eligible Todo tickets, but `promotedCount: 0` — nothing dispatches. Deleting the bad edges didn't stick: STEP E re-created them on the next ~30s tick (faster than the 60s relation-cache TTL could even surface the deletion — confirmed *not* a caching artifact).

## Root cause (verified against live Linear + the mini)

Two `applyBlockedByRelation` call sites exist; only **STEP E** (`scheduler.mjs`, reading `triage.json` deps) is the re-creator. The CTL-537 sequencing gate is already guarded (`validDeps` requires the blocker be in-flight; an epic never is). Live proof: the 8 bad edges were written in a 6-second programmatic batch, `parent{identifier}` was absent from the GraphQL projection, and `linearis` does emit `parent` on both `issues read` and `issues list`.

## Fix (defense in depth)

| Layer | Change |
|---|---|
| **Read** (load-bearing) | `buildDependencyEdges` drops a `blocks` edge whose source is the target's parent epic — neutralizes *existing* durable edges at read time, so the deadlock clears with **no deletion required** |
| **Write** | STEP E skips `applyBlockedByRelation` when a dep IS the candidate's parent — stops new durable edges |
| **Source** | phase-triage `2d` scrape excludes the parent id (already in the ticket JSON; no extra Linear read) |
| **Threading** | `parent{identifier}` added to the batch projection + carried through `normalizeTicket`, `normalizeRelations`, and the STEP A `waitingDescriptors` literal. `eligible-set` `contentKey` now includes `parent` so a parent-only delta forces a projection rewrite (else a stale pre-fix projection survives a deploy and the read-layer drop silently no-ops) |

## Scope

Frees the genuine epic-children (CTL-722, CTL-863/864/865). **Does not** address the broader over-scrape (prose mentions / cross-team `OTL-*` refs persisted as hard deps) — that is **CTL-838**.

## Tests

- `dependency-graph`: in-set + out-of-set parent drop, sibling-dep kept, end-to-end `analyzeDependencyGraph` ready-not-blocked, backward-compat (no `parent` field)
- `scheduler` STEP-E: parent skip + parent-specificity (non-parent dep still persisted)
- `linear-query`: `parent` threaded through `fetchTicketRelations` / `fetchTicketsBatch` / `runEligibleQuery`
- `eligible-set`: `contentKey` parent delta forces rewrite
- `phase-triage` e2e: parent epic excluded, sibling dep kept

Zero regressions vs baseline across all 8 touched suites (pre-existing scheduler/monitor flakes are environmental, baseline-confirmed). Went through a 3-lens adversarial review + per-finding verification; the contentKey gap was caught by that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)