### PR TITLE
fix(dev): CTL-838 stop inferring dependencies from prose — link them, triage analyzes for missed ones

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -156,9 +156,12 @@ if [ -f "$TRIAGE_FILE" ]; then
 	fi
 
 	DEPS="$(jq -c '.dependencies' "$TRIAGE_FILE")"
-	# Expect CTL-447 and CTL-448, but NOT CTL-9999 (self).
-	EXPECTED_DEPS='["CTL-447","CTL-448"]'
-	assert_eq "happy: dependencies match (excludes self)" "$EXPECTED_DEPS" "$DEPS"
+	# CTL-838: the bash body does NOT scrape ticket ids from prose. "See CTL-447 and
+	# CTL-448 for prior art" is a mention, not a dependency — deterministic deps are
+	# always []. Real prerequisites come from author-set blocker links + the Opus
+	# semantic pass, neither of which the bash fallback performs.
+	EXPECTED_DEPS='[]'
+	assert_eq "happy: dependencies are empty (CTL-838: no prose scraping)" "$EXPECTED_DEPS" "$DEPS"
 fi
 
 # Assert: skill ran to completion (comment post is best-effort / fail-open in test)
@@ -434,32 +437,32 @@ if [ -f "$TRIAGE_SUBST" ]; then
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Case: CTL-878 — the parent epic is NEVER scraped into dependencies. A Linear
-# parent/child hierarchy link is not a blocker; emitting it makes the scheduler
-# persist `child blocked_by parent-epic`, deadlocking the child against an epic
-# that is never worked. The parent id is in the ticket JSON, so 2d excludes it.
+# Case: CTL-838 — the deterministic body NEVER scrapes ticket ids from prose. A
+# description dense with mentions (parent epic, "depends on", sibling ids) must
+# still yield an empty dependency list. Real prerequisites are author-set blocker
+# links + the Opus semantic pass — never a regex over what's written in the body.
 
-FIXTURE_PARENT="$TMPROOT/fixture-parent.json"
-cat >"$FIXTURE_PARENT" <<'EOF'
+FIXTURE_MENTIONS="$TMPROOT/fixture-mentions.json"
+cat >"$FIXTURE_MENTIONS" <<'EOF'
 {
   "identifier": "CTL-863",
   "title": "Implement takeover/healing for a downed daemon node",
-  "description": "Part of the CTL-859 multi-host epic. Depends on CTL-850 (HRW claim). When a node dies, the survivor must resume from the draft PR.",
+  "description": "Part of the CTL-859 multi-host epic. Depends on CTL-850 (HRW claim). See CTL-718 for prior art and OTL-4 for the dashboard. When a node dies, the survivor must resume from the draft PR.",
   "parent": { "identifier": "CTL-859" },
   "labels": {"nodes": []}
 }
 EOF
 
-CASE_DIR_PARENT="$(run_case parent "$FIXTURE_PARENT" CTL-863)"
-assert_eq "ctl878-parent: exit code 0" 0 "$(cat "$CASE_DIR_PARENT/exit-code")"
-TRIAGE_PARENT="$CASE_DIR_PARENT/worker/triage.json"
-assert_file_exists "ctl878-parent: triage.json created" "$TRIAGE_PARENT"
-if [ -f "$TRIAGE_PARENT" ]; then
-	DEPS_PARENT="$(jq -c '.dependencies' "$TRIAGE_PARENT")"
-	# CTL-859 is the parent epic → excluded. CTL-850 is a real sibling dep → kept.
-	# CTL-863 is self → excluded.
-	EXPECTED_DEPS_PARENT='["CTL-850"]'
-	assert_eq "ctl878-parent: parent epic excluded, sibling dep kept" "$EXPECTED_DEPS_PARENT" "$DEPS_PARENT"
+CASE_DIR_MENTIONS="$(run_case mentions "$FIXTURE_MENTIONS" CTL-863)"
+assert_eq "ctl838-noscrape: exit code 0" 0 "$(cat "$CASE_DIR_MENTIONS/exit-code")"
+TRIAGE_MENTIONS="$CASE_DIR_MENTIONS/worker/triage.json"
+assert_file_exists "ctl838-noscrape: triage.json created" "$TRIAGE_MENTIONS"
+if [ -f "$TRIAGE_MENTIONS" ]; then
+	DEPS_MENTIONS="$(jq -c '.dependencies' "$TRIAGE_MENTIONS")"
+	# Five ticket ids appear in the prose (CTL-859 parent, CTL-850 "depends on",
+	# CTL-718/OTL-4 mentions, CTL-863 self) — NONE become dependencies.
+	EXPECTED_DEPS_MENTIONS='[]'
+	assert_eq "ctl838-noscrape: prose mentions are NOT scraped into dependencies" "$EXPECTED_DEPS_MENTIONS" "$DEPS_MENTIONS"
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -32,6 +32,7 @@ import {
   buildDependencyEdges,
   DEFAULT_TERMINAL_STATUSES,
 } from "../lib/dependency-graph.mjs";
+// teamOf (CTL-838 cross-team guard) is imported from ./dispatch.mjs below.
 // PHASES is still imported for deriveAdvancement; CTL-565 note: PHASES[0]
 // ("triage") is intentionally NO LONGER the new-work entry phase — new work
 // enters at NEW_WORK_ENTRY_PHASE ("research"), see schedulerTick.
@@ -2615,6 +2616,17 @@ export function schedulerTick(
             log.warn(
               { candidate, dep },
               "ctl-878 step-e: skipping dependency that is the candidate's parent epic",
+            );
+            continue;
+          }
+          if (teamOf(dep) !== teamOf(candidate)) {
+            // CTL-838: the dep is in a DIFFERENT team. This daemon orchestrates one
+            // team and cannot work another team's ticket to terminal, so a
+            // cross-team blocked_by edge can only deadlock the candidate. Never
+            // persist it (the read-layer buildDependencyEdges drop is the backstop).
+            log.warn(
+              { candidate, dep, candidateTeam: teamOf(candidate), depTeam: teamOf(dep) },
+              "ctl-838 step-e: skipping cross-team dependency (daemon cannot work it)",
             );
             continue;
           }

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -6603,6 +6603,31 @@ describe("CTL-755: admission gate", () => {
     expect(relations).toEqual([{ ticket: "CTL-7", blockedBy: "CTL-100" }]);
   });
 
+  test("CTL-838: a CROSS-TEAM dep is NOT persisted (daemon can't work it)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-7", "triage", "done");
+    // ADV-9 is a different team; OTL-2 too. Both non-terminal — absent the CTL-838
+    // guard STEP E would persist them and deadlock CTL-7 against work this daemon
+    // can never run. CTL-100 (same team, non-terminal) IS persisted.
+    writeTriageDeps("CTL-7", ["ADV-9", "OTL-2", "CTL-100"]);
+    const dispatch = fakeDispatch();
+    const { ws, relations } = depSpy();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchBatch: mkBatch({
+        "CTL-7": relUnblocked(),
+        "ADV-9": descOf("In Progress"),
+        "OTL-2": descOf("Implement"),
+        "CTL-100": descOf("In Progress"),
+      }),
+    });
+    expect(relations).toEqual([{ ticket: "CTL-7", blockedBy: "CTL-100" }]);
+  });
+
   test("CTL-784: writing a durable edge INVALIDATES the candidate's relations cache (no ≤TTL over-promotion)", () => {
     // After STEP E writes a new blocked_by edge, the candidate's relations
     // descriptor cached THIS tick (by A.3) is stale (no edge). Invalidating it

--- a/plugins/dev/scripts/lib/dependency-graph.mjs
+++ b/plugins/dev/scripts/lib/dependency-graph.mjs
@@ -12,6 +12,15 @@
 // never appears in the ready/blocked sets. Override via options.terminalStatuses.
 export const DEFAULT_TERMINAL_STATUSES = ["Done", "Canceled"];
 
+// teamOf — the Linear team key from an issue identifier (the prefix before the
+// first `-`): "CTL-863" → "CTL", "OTL-4" → "OTL". Used by the CTL-838 cross-team
+// edge drop. A malformed/empty id yields "" (never matches a real team key).
+export function teamOf(id) {
+  if (typeof id !== "string") return "";
+  const i = id.indexOf("-");
+  return i === -1 ? id : id.slice(0, i);
+}
+
 // buildDependencyEdges — normalize Linear relations into canonical directed
 // edges (CTL-530). An edge is kept when both endpoints are in-set, OR (CTL-565
 // D5) when `to` is in-set and `from` is a declared external blocker — so an
@@ -28,6 +37,15 @@ export const DEFAULT_TERMINAL_STATUSES = ["Done", "Canceled"];
 // that edge deadlocks the child forever. Each in-set issue carries `parent` (the
 // epic identifier, threaded from linearis) so the drop also fires when the parent
 // is an out-of-set externalId — exactly the deadlock case (CTL-859→863, CTL-718→722).
+//
+// CTL-838: a `blocks` edge that crosses TEAMS is DROPPED. The team is the
+// identifier prefix (CTL-863 → "CTL", OTL-4 → "OTL"). A single daemon orchestrates
+// one team's backlog and cannot work another team's tickets, so a cross-team
+// blocker can never reach a terminal state from the daemon's side — it can only
+// deadlock the dependent forever. Such edges were created by the now-removed
+// prose scrape (a foreign id mentioned in the body, e.g. OTL-4 → CTL-838); a
+// genuine cross-team prerequisite, if one ever exists, is handled out-of-band by
+// a human, not by the daemon's auto-sequencing.
 //
 // options.externalIds — out-of-set blocker identifiers (D5) that remain valid
 // edge endpoints on the `from` side.
@@ -51,6 +69,7 @@ export function buildDependencyEdges(issues, { externalIds } = {}) {
     if (!inSet.has(to)) return;
     if (!inSet.has(from) && !ext.has(from)) return;
     if (parentOf.get(to) === from) return; // CTL-878: parent→child is hierarchy, not a dependency
+    if (teamOf(from) !== teamOf(to)) return; // CTL-838: cross-team blocker can't be worked by this daemon → only deadlocks
     const key = `${from} ${to}`;
     if (seen.has(key)) return; // dedup symmetric relations/inverseRelations
     seen.add(key);

--- a/plugins/dev/scripts/lib/dependency-graph.test.mjs
+++ b/plugins/dev/scripts/lib/dependency-graph.test.mjs
@@ -9,6 +9,7 @@ import {
   detectCycles,
   analyzeDependencyGraph,
   referencedBlockerIds,
+  teamOf,
 } from "./dependency-graph.mjs";
 
 // issue(id, state, relations[], inverseRelations[]) — terse fixture builder.
@@ -178,6 +179,44 @@ describe("buildDependencyEdges", () => {
       issue("CTL-2", "Todo"),
     ];
     expect(buildDependencyEdges(issues)).toEqual([{ from: "CTL-1", to: "CTL-2" }]);
+  });
+
+  // CTL-838: a cross-team blocker (different identifier prefix) is dropped — the
+  // daemon orchestrates one team and can't work another's ticket to terminal, so
+  // the edge can only deadlock. The blocker is out-of-set, so declare it external
+  // to prove the drop is the CROSS-TEAM rule, not the out-of-set rule.
+  test("CTL-838: a cross-team blocks edge is dropped even when declared as an externalId", () => {
+    const issues = [
+      {
+        identifier: "CTL-838",
+        state: { name: "Todo" },
+        relations: { nodes: [] },
+        inverseRelations: { nodes: [inv("blocks", "OTL-4")] },
+      },
+    ];
+    expect(buildDependencyEdges(issues, { externalIds: ["OTL-4"] })).toEqual([]);
+  });
+
+  test("CTL-838: a same-team edge is unaffected by the cross-team guard", () => {
+    const issues = [
+      issue("CTL-1", "Backlog", [rel("blocks", "CTL-2")]),
+      issue("CTL-2", "Todo"),
+    ];
+    expect(buildDependencyEdges(issues)).toEqual([{ from: "CTL-1", to: "CTL-2" }]);
+  });
+});
+
+describe("teamOf (CTL-838)", () => {
+  test("extracts the team prefix from an identifier", () => {
+    expect(teamOf("CTL-863")).toBe("CTL");
+    expect(teamOf("OTL-4")).toBe("OTL");
+    expect(teamOf("ADV-1278")).toBe("ADV");
+  });
+  test("degrades safely on malformed input", () => {
+    expect(teamOf("")).toBe("");
+    expect(teamOf(null)).toBe("");
+    expect(teamOf(undefined)).toBe("");
+    expect(teamOf("NODASH")).toBe("NODASH");
   });
 });
 
@@ -544,6 +583,23 @@ describe("analyzeDependencyGraph", () => {
     expect(result.ready).toEqual(["CTL-863"]);
     expect(result.blocked).toEqual([]);
     expect(result.anomalies).toEqual([]);
+  });
+
+  // CTL-838 end-to-end: a ticket whose only blocker is a non-terminal CROSS-TEAM
+  // ticket (e.g. CTL-838 ⟵ OTL-4[Implement]) must be ready — the daemon can't work
+  // OTL-4, so honoring the edge would deadlock CTL-838 forever.
+  test("CTL-838: a ticket blocked only by a non-terminal cross-team blocker is ready, not blocked", () => {
+    const issues = [
+      {
+        identifier: "CTL-838",
+        state: { name: "Todo" },
+        relations: { nodes: [] },
+        inverseRelations: { nodes: [inv("blocks", "OTL-4")] },
+      },
+    ];
+    const result = analyzeDependencyGraph(issues, { blockerStates: { "OTL-4": "Implement" } });
+    expect(result.ready).toEqual(["CTL-838"]);
+    expect(result.blocked).toEqual([]);
   });
 });
 

--- a/plugins/dev/skills/gherkin-ticket/SKILL.md
+++ b/plugins/dev/skills/gherkin-ticket/SKILL.md
@@ -265,6 +265,35 @@ Body:
 - [ ] Bug `Then` describes the CORRECT behavior; `# CURRENTLY:` documents the break.
 - [ ] No vacuous chore scenarios (`Then the code is cleaner`).
 
+Dependencies:
+- [ ] Real prerequisites are set as formal Linear **blocker links**, not narrated in prose.
+- [ ] No "depends on TEAM-123" / "after TEAM-456" sentences in the body expecting something to read them.
+
+---
+
+## Dependencies — link them, don't narrate them
+
+If you know that other work **must finish before this ticket can start**, record it as a first-class
+Linear `blocked_by` **link** at authoring time — you know the prerequisites better than any later
+pass will. **Catalyst does NOT infer dependencies from prose** (CTL-838): writing "depends on
+CTL-123" or "see CTL-456" in the description does nothing — it is not scraped into a blocker, and it
+should not be (a mention is not a dependency).
+
+```bash
+# After the ticket exists, link each genuine prerequisite (see /catalyst-dev:linearis for syntax):
+linearis issues update <NEW-TICKET> --blocked-by <PREREQ-TICKET>
+```
+
+Rules of thumb:
+- Link only **true** prerequisites — work that must reach Done/Canceled first. A shared topic,
+  prior-art reference, or "related" ticket is **not** a blocker.
+- Never link across teams for auto-sequencing (a `CTL` ticket on an `OTL`/`ADV` ticket): the
+  execution-core daemon only works its own team, so a cross-team blocker just deadlocks. Coordinate
+  cross-team work out-of-band.
+- A blocker you miss is fine — `/catalyst-dev:phase-triage` does a semantic second pass over the
+  backlog and can add genuine ones it finds. But a **false** blocker you add stalls real work, so
+  when in doubt, leave it out.
+
 ---
 
 ## Per-project criteria (override hook)

--- a/plugins/dev/skills/linear/SKILL.md
+++ b/plugins/dev/skills/linear/SKILL.md
@@ -234,7 +234,21 @@ When referencing thoughts documents, always provide GitHub links:
    Linearis creates issues in the team's default backlog state. To set specific status or assignee,
    create first then update. Capture the created issue ID from the JSON output with jq.
 
-7. **Post-creation actions:**
+7. **Link genuine prerequisites as formal blockers (CTL-838):** If you know of work that must
+   finish before this ticket can start, set it as a Linear `blocked_by` **link** now — do NOT rely
+   on mentioning the id in the description (Catalyst does not infer dependencies from prose; a
+   mention is not a dependency). See `/catalyst-dev:linearis` for syntax:
+
+   ```bash
+   linearis issues update <NEW-TICKET> --blocked-by <PREREQ-TICKET>
+   ```
+
+   Link only TRUE prerequisites (must reach Done/Canceled first). Do NOT link across teams for
+   auto-sequencing — the daemon only works its own team, so a cross-team blocker only deadlocks.
+   Missing a blocker is fine (phase-triage does a semantic second pass); a FALSE blocker stalls real
+   work, so when in doubt leave it out.
+
+8. **Post-creation actions:**
    - Show the created ticket URL
    - Ask if user wants to:
      - Add a comment with additional implementation details

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phase-triage
-description: Phase agent that triages a Linear ticket — expands acronyms, classifies (feature/bug/docs/refactor/chore), identifies dependencies, estimates scope, writes triage.json, and posts a triage analysis comment to Linear. Triage completion is signaled by that comment plus the local triage.json — there is no `triaged` label. Emits phase.triage.complete.<TICKET> on success and phase.triage.failed.<TICKET> on error. Dispatched by the phase-agent orchestrator (CTL-452) via slash command — `user-invocable: true` so the dispatcher's `claude --bg "/catalyst-dev:phase-triage ..."` resolves.
+description: Phase agent that triages a Linear ticket — expands acronyms, classifies (feature/bug/docs/refactor/chore), identifies genuine blockers (a semantic second-pass over the backlog — NOT a prose scrape; CTL-838), estimates scope, writes triage.json, and posts a triage analysis comment to Linear. Triage completion is signaled by that comment plus the local triage.json — there is no `triaged` label. Emits phase.triage.complete.<TICKET> on success and phase.triage.failed.<TICKET> on error. Dispatched by the phase-agent orchestrator (CTL-452) via slash command — `user-invocable: true` so the dispatcher's `claude --bg "/catalyst-dev:phase-triage ..."` resolves.
 user-invocable: true
 disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
 allowed-tools: Bash, Read, Write, Grep
@@ -172,22 +172,21 @@ ACRONYMS_EXPANDED="$(jq -nc --arg t "$COMBINED" '
   | map({acronym: .a, expansion: .e})
 ')"
 
-# 2d. Dependencies — other CTL-style identifiers referenced in body, excluding self.
-#     Match any TEAM-NNN pattern; dedupe; exclude the ticket itself AND its parent
-#     epic. A Linear parent/child hierarchy link is NOT a dependency: emitting the
-#     parent epic here makes the scheduler (CTL-755 STEP E) persist `child blocked_by
-#     parent-epic`, which deadlocks the child against a tracking epic that is never
-#     worked (CTL-878). The parent identifier is already in the ticket JSON, so the
-#     exclusion costs no extra Linear read. PARENT_TICKET is empty when the ticket
-#     has no parent, in which case the second grep pattern collapses to the self
-#     exclusion (a harmless no-op).
-PARENT_TICKET="$(jq -r '.parent.identifier // .parent // empty' "$TICKET_JSON_FILE" 2>/dev/null)"
-DEPENDENCIES="$(printf '%s\n' "$COMBINED" \
-  | grep -oE '[A-Z][A-Z0-9_]*-[0-9]+' 2>/dev/null \
-  | sort -u \
-  | grep -v -x -e "$TICKET" -e "${PARENT_TICKET:-$TICKET}" \
-  | jq -R . | jq -sc .)"
-DEPENDENCIES="${DEPENDENCIES:-[]}"
+# 2d. Dependencies — DELIBERATELY EMPTY in the deterministic path (CTL-838).
+#     Catalyst does NOT infer dependencies from prose. The old behavior scraped
+#     every TEAM-NNN token out of the title+description and the scheduler (CTL-755
+#     STEP E) persisted each as a durable `blocked_by` edge — turning prior-art
+#     mentions, incident examples, "see also" references and cross-team ids into
+#     FALSE blockers that deadlocked tickets against work they do not depend on.
+#     Real prerequisites are first-class, captured two ways, NEVER by scraping:
+#       1. The ticket AUTHOR sets formal Linear `blocked_by` LINKS at creation time
+#          (see the gherkin-ticket / linear / create-tickets skills). Those are
+#          already durable Linear relations the scheduler honors directly.
+#       2. An Opus-mode triage pass acts as a SECOND PAIR OF EYES — it examines the
+#          backlog and records only GENUINE missed blockers (see "2c" below).
+#     The bash fallback therefore emits an empty list (safe: no false blocks). It
+#     must never reintroduce a regex over mentioned ids.
+DEPENDENCIES="[]"
 
 # 2e. Summary — first paragraph of prose, trimmed.
 #     Skip leading markdown headers (^#+\s+) and bullet markers (^[-*+]\s+) so a
@@ -330,36 +329,46 @@ then skips the Linear estimate write for this ticket (Q4 design decision: no SCO
 fallback for the Linear estimate field). The bash body intentionally does **not** write `estimate`
 (CTL-558 guard).
 
-**2c. Validate the scraped dependencies — READ-ONLY (CTL-755).** The bash body's `2d` step scrapes
-every `TEAM-NNN` token from the body into a flat `dependencies` array but does NOT verify any of them
-resolve to a real ticket. When running in Opus mode, enrich each scraped id using **read-only**
-`linearis issues read <id>` so the richer shape carries existence + the blocker's current state:
+**2c. Identify genuine blockers — semantic second-pass, READ-ONLY (CTL-838).** Catalyst does **not**
+parse or infer dependencies from the description text. The bash body writes an empty `dependencies`
+list by design (CTL-838 killed the old `2d` regex scrape). Real prerequisites come from two places,
+and your job here is the second one:
+
+1. **Formal author links (primary).** The agent that authored the ticket records its real
+   prerequisites as Linear `blocked_by` LINKS at creation time (the gherkin-ticket / linear /
+   create-tickets skills now instruct this). Those are already durable Linear relations and the
+   admission gate honors them directly from the live graph — triage does **not** need to re-derive
+   or re-emit them.
+
+2. **Triage as a SECOND PAIR OF EYES (your job).** You are NOT a parser. Do **not** add a dependency
+   because an id appears in the prose. Instead: read the ticket's intent, then **examine the relevant
+   backlog** — `linearis issues list` for the ticket's team / area (and `linearis issues read <id>`
+   to confirm a candidate) — and judge whether any in-flight or planned work is a **true
+   prerequisite the author may have missed**: work that must reach a terminal state before this
+   ticket can sensibly start (a shared interface not yet built, a migration that must land first,
+   an explicit "must follow" sequencing). Record **only** blockers you can justify, in the rich
+   shape with a `reason`:
 
 ```jsonc
 "dependencies": [
-  { "id": "CTL-447", "exists": true,  "blockerState": "In Progress" },
-  { "id": "CTL-9999", "exists": false, "blockerState": null }
+  { "id": "CTL-123", "exists": true, "blockerState": "Implement", "reason": "defines the API this ticket consumes" }
 ]
 ```
 
-For each id, run `linearis issues read <id>` (the same read the bash body already uses for the
-ticket itself). On a successful read, set `exists: true` and `blockerState` to the ticket's
-`state.name`; on a non-zero exit / unparseable output (a prose token that merely matched the
-`TEAM-NNN` regex but is not a real ticket), set `exists: false`, `blockerState: null`. Re-write
-`triage.json` with the enriched `dependencies`. This is purely advisory metadata — the durable
-ordering edge is written **scheduler-side** (see the hard constraint below), so a missing/extra
-entry here can never deadlock the pipeline.
+   If you find no genuine missed blocker, leave `dependencies` as the empty list the bash body wrote.
+   A mention is not a dependency; a shared topic is not a dependency; "see also / prior art /
+   regression of / example" is not a dependency. When in doubt, leave it out — a false blocker
+   deadlocks real work, a missed one is caught on the next pass.
 
 **Hard constraint — the skill makes ZERO Linear writes for dependencies.** Do NOT call
 `linearis issues update ... --blocked-by` (or any `linearis issues update`) from this skill. The
 admission gate's durable `blocked_by` persistence lives in the execution-core scheduler (CTL-755
-STEP E, `scheduler.mjs` — it reads `triage.json.dependencies`, re-validates each token via
-`fetchTicketState`, drops unresolvable/terminal/cycle-closing tokens, and writes the durable edge
-with `applyBlockedByRelation`). Keeping the write scheduler-side preserves the CTL-497/CTL-558
-contract — the phase-triage e2e negative guard (`phase-triage-e2e.test.sh:172`) fails the build if
-this skill ever emits a `linearis issues update` call. `linearis issues read` is read-only and is
-fine. Because STEP E tolerates BOTH the flat-string and the rich `{id}` shapes, emitting the rich
-shape here is forward-compatible and changes nothing scheduler-side.
+STEP E, `scheduler.mjs` — it reads `triage.json.dependencies`, re-validates each id via
+`fetchTicketState`, and drops unresolvable / terminal / cycle-closing / **parent-epic (CTL-878)** /
+**cross-team (CTL-838)** ids before writing the durable edge with `applyBlockedByRelation`). Keeping
+the write scheduler-side preserves the CTL-497/CTL-558 contract — the phase-triage e2e negative guard
+fails the build if this skill ever emits a `linearis issues update` call. `linearis issues read` is
+read-only and is fine. STEP E tolerates BOTH the flat-string and the rich `{id}` shapes.
 
 3. If the refined fields differ materially, post a follow-up `linearis issues discuss` comment
    marking the refinement.

--- a/plugins/pm-ops/skills/create-tickets/SKILL.md
+++ b/plugins/pm-ops/skills/create-tickets/SKILL.md
@@ -105,6 +105,9 @@ Tier C = pure chores, Context/Motivation/Outcome prose instead of a vacuous scen
 
 ## Dependencies
 
+<!-- Documentation only. A real prerequisite MUST also be set as a formal Linear
+     blocked_by LINK (see Bulk Creation step 5) — Catalyst does not infer
+     dependencies from this prose (CTL-838). -->
 - Blocked by: [Other ticket]
 - Blocks: [Other ticket]
 
@@ -148,7 +151,12 @@ When creating 5+ tickets:
 2. **Group by component** (Frontend, Backend, Data, etc.)
 3. **Order by dependency** (foundation tickets first)
 4. **Add estimates** (if PM provides sizing)
-5. **Link tickets** (blockers, related work)
+5. **Link tickets as formal Linear blockers** — `linearis issues update <ticket> --blocked-by <prereq>`
+   for each TRUE prerequisite (see `/catalyst-dev:linearis`). Set real `blocked_by` LINKS; do NOT
+   rely on naming the dependency in the description. **Catalyst does not infer dependencies from
+   prose (CTL-838)** — a "Blocked by: X" line in the body is documentation only and is never turned
+   into a blocker. Link only genuine must-finish-first work; never link across teams for
+   auto-sequencing (the daemon only works its own team, so a cross-team blocker deadlocks).
 
 ## Effort Estimation Framework
 


### PR DESCRIPTION
## Problem

phase-triage's `2d` step regex-scraped **every** `TEAM-NNN` token from a ticket's title+description into `triage.json .dependencies`, and the scheduler (CTL-755 STEP E) persisted each as a durable Linear `blocked_by` edge. Prior-art mentions, incident examples, "see also" references, and **cross-team ids** all became **false blockers** that deadlocked tickets against work they don't depend on. CTL-838 itself was blocked by 8 tickets it merely *names as examples of over-scraping*. (CTL-878 fixed the narrow parent-epic subset; this is the general class.)

## Design — dependencies are first-class, never inferred from prose

| Layer | Change |
|---|---|
| **Source** | **Kill the `2d` regex scrape.** The deterministic bash path emits `dependencies: []` (safe — no false blocks). |
| **Triage** | The Opus pass is repurposed from "validate scraped deps" → a **semantic second-pass**: read the ticket, examine the backlog, record only **genuine** missed blockers (with a `reason`). Never a regex over mentioned ids. |
| **Authoring** | `gherkin-ticket`, `linear`, and `pm-ops create-tickets` skills now instruct the author to set formal Linear `blocked_by` **links** at creation time for real prerequisites — and explicitly *not* to rely on prose. |
| **Scheduler guard** (defense-in-depth) | STEP E and `buildDependencyEdges` now **drop a `blocked_by` edge that crosses teams** (blocker prefix ≠ candidate prefix). A single daemon works one team and can't take a foreign ticket to terminal, so a cross-team blocker only ever deadlocks. New `teamOf()` export + read-layer drop mirroring the CTL-878 parent guard; STEP E reuses `dispatch.mjs` `teamOf`. |

## Scope / follow-up

This does **not** delete the already-durable over-scrape edges on existing tickets — that's a one-time operator **sweep after re-triage** (the edges regenerate from stale `triage.json` until each ticket is re-triaged under the new logic). The cross-team guard *does* neutralize cross-team edges (e.g. OTL-4 → CTL-774/838) at read time immediately on deploy.

## Tests

- `dependency-graph`: cross-team edge dropped (in-set + out-of-set), same-team kept, `teamOf` unit, end-to-end ready-not-blocked.
- `scheduler` STEP-E: cross-team dep not persisted; same-team still persisted (CTL-878 parent tests still green).
- `phase-triage` e2e: **flipped** — prose mentions (incl. parent, "depends on", cross-team) are NOT scraped (`dependencies: []`).

Zero new regressions vs baseline (full scheduler suite 352 pass / 50 env-fail, same baseline). Mirrors the merged CTL-878 playbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)