### PR TITLE
feat(dev): FND1 deep-linkable routes (TanStack Router) (CTL-881)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/route-search.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/route-search.test.ts
@@ -1,0 +1,99 @@
+// route-search.test.ts — units for the typed search-param contract of the
+// detail routes (CTL-881 / FND1). These encode the FND1 Gherkin acceptance
+// scenarios "List-context survives a refresh or paste" and "A degraded
+// deep-link with no context still works" against the PURE validator
+// (ui/src/board/route-search.ts) — no React/router needed (same pattern as
+// board-client.test.ts which units board-logic.ts directly).
+import { describe, it, expect } from "bun:test";
+import {
+  validateDetailSearch,
+  FROM_VALUES,
+  LENS_VALUES,
+  type DetailSearch,
+} from "../ui/src/board/route-search";
+
+describe("validateDetailSearch — typed contract (CTL-881)", () => {
+  // Gherkin: "List-context survives a refresh or paste" — the full URL
+  // /ticket/CTL-845?from=board&lens=linear&col=Implement&cursor=4 parses to all
+  // four typed fields (from in board|stuck|recent, lens in linear|phase, col a
+  // string, cursor a number).
+  it("parses a full board-origin context with the right types", () => {
+    const s = validateDetailSearch({ from: "board", lens: "linear", col: "Implement", cursor: 4 });
+    expect(s).toEqual({ from: "board", lens: "linear", col: "Implement", cursor: 4 });
+    expect(typeof s.cursor).toBe("number");
+  });
+
+  it("accepts cursor as a numeric string (hand-pasted URL form)", () => {
+    const s = validateDetailSearch({ from: "stuck", lens: "phase", col: "implement", cursor: "7" });
+    expect(s).toEqual({ from: "stuck", lens: "phase", col: "implement", cursor: 7 });
+  });
+
+  it("accepts every legal from value", () => {
+    for (const from of FROM_VALUES) {
+      expect(validateDetailSearch({ from }).from).toBe(from);
+    }
+  });
+
+  it("accepts every legal lens value", () => {
+    for (const lens of LENS_VALUES) {
+      expect(validateDetailSearch({ lens }).lens).toBe(lens);
+    }
+  });
+
+  it("treats col as an opaque string (any column name survives)", () => {
+    expect(validateDetailSearch({ col: "Some Custom Column" }).col).toBe("Some Custom Column");
+  });
+});
+
+describe("validateDetailSearch — safe-defaults / never-throws (CTL-881)", () => {
+  // Gherkin: "unknown or malformed search params fall back to safe defaults
+  // rather than throwing".
+  it("drops an unknown from to undefined instead of throwing", () => {
+    expect(validateDetailSearch({ from: "outerspace" })).toEqual({});
+  });
+
+  it("drops an unknown lens to undefined", () => {
+    expect(validateDetailSearch({ lens: "kanban" })).toEqual({});
+  });
+
+  it("drops a non-string col (numbers/objects) to undefined", () => {
+    expect(validateDetailSearch({ col: 42 })).toEqual({});
+    expect(validateDetailSearch({ col: { x: 1 } })).toEqual({});
+  });
+
+  it("drops a non-numeric / malformed cursor to undefined", () => {
+    expect(validateDetailSearch({ cursor: "abc" })).toEqual({});
+    expect(validateDetailSearch({ cursor: NaN }).cursor).toBeUndefined();
+    expect(validateDetailSearch({ cursor: Infinity }).cursor).toBeUndefined();
+    expect(validateDetailSearch({ cursor: -1 }).cursor).toBeUndefined();
+    expect(validateDetailSearch({ cursor: 2.5 }).cursor).toBeUndefined();
+  });
+
+  it("keeps the valid fields while dropping the malformed ones (partial URL)", () => {
+    // col valid, cursor garbage, from valid, lens garbage → keep from+col only.
+    const s = validateDetailSearch({ from: "recent", lens: "???", col: "PR", cursor: "x" });
+    expect(s).toEqual({ from: "recent", col: "PR" });
+  });
+
+  it("never throws on hostile / non-object input", () => {
+    const inputs: unknown[] = [null, undefined, "raw-string", 123, [], true];
+    for (const input of inputs) {
+      expect(() => validateDetailSearch(input)).not.toThrow();
+      expect(validateDetailSearch(input)).toEqual({});
+    }
+  });
+});
+
+describe("validateDetailSearch — cold-link / degraded deep-link (CTL-881)", () => {
+  // Gherkin: "A degraded deep-link with no context still works" — an empty
+  // search object yields all-undefined context (a cold-link). FND2 adds pager
+  // support for this case; FND1 only guarantees the contract parses cleanly.
+  it("an empty search object is a valid cold-link (all fields absent)", () => {
+    const s: DetailSearch = validateDetailSearch({});
+    expect(s).toEqual({});
+    expect(s.from).toBeUndefined();
+    expect(s.lens).toBeUndefined();
+    expect(s.col).toBeUndefined();
+    expect(s.cursor).toBeUndefined();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/bun.lock
+++ b/plugins/dev/scripts/orch-monitor/ui/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
+        "@tanstack/react-router": "^1.170.15",
         "@uidotdev/usehooks": "^2.4.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -354,6 +355,16 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.2", "", { "dependencies": { "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "tailwindcss": "4.2.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w=="],
 
+    "@tanstack/history": ["@tanstack/history@1.162.0", "", {}, "sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA=="],
+
+    "@tanstack/react-router": ["@tanstack/react-router@1.170.15", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.13", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-GawYz7HEjj8rTUUDoT/SemDEVm63pZUO+2mOcXHY9Jl3EwMS5gFBnPu/2UvcrwRm1jN1k79fokc0d4aFmrLatg=="],
+
+    "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
+
+    "@tanstack/router-core": ["@tanstack/router-core@1.171.13", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA=="],
+
+    "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
+
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -394,6 +405,8 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "date-fns": ["date-fns@4.4.0", "", {}, "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="],
@@ -423,6 +436,8 @@
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "isbot": ["isbot@5.1.42", "", {}, "sha512-/SXsVh7KpPRISrD4ffrGSxnTLlUBzEQUfWIusaJPrpJ93FW1P0YEZri5vAUkFsA0m2HRUhQRQadk2wJ+EeKowQ=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
@@ -499,6 +514,10 @@
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
+
+    "seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/plugins/dev/scripts/orch-monitor/ui/package.json
+++ b/plugins/dev/scripts/orch-monitor/ui/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
+    "@tanstack/react-router": "^1.170.15",
     "@uidotdev/usehooks": "^2.4.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/main.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/main.tsx
@@ -1,10 +1,9 @@
-import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "../app.css";
-import { Board } from "./Board";
+// CTL-881 / FND1: the board is no longer mounted route-less. main.tsx now mounts
+// the TanStack Router (AppRouter wraps RouterProvider in StrictMode); the `/`
+// route renders the existing <Board /> unchanged, and /ticket/$id + /worker/$id
+// become first-class deep-linkable locations. #board-root is kept exactly.
+import { AppRouter } from "./router";
 
-createRoot(document.getElementById("board-root")!).render(
-  <StrictMode>
-    <Board />
-  </StrictMode>,
-);
+createRoot(document.getElementById("board-root")!).render(<AppRouter />);

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/route-search.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/route-search.ts
@@ -1,0 +1,95 @@
+// route-search.ts — the typed search-param contract for the detail routes
+// (CTL-881 / FND1). This is the load-bearing piece every later redesign ticket
+// binds to: the breadcrumb, list-context, pager, and j/k walk are all
+// reconstructed from `?from&lens&col&cursor` on the URL alone (detail design
+// §3.1 — "URL = location, store = cursor").
+//
+// PURE module — deliberately React-/router-free so it can be unit-tested under
+// `bun test` directly (same pattern as board-logic.ts). `router.tsx` wires
+// `validateDetailSearch` into TanStack Router's `validateSearch`; nothing here
+// imports the router.
+//
+// Hard contract (mirrors the param names detail design §3.1 mandates):
+//   from   ∈ board | stuck | recent      (which list the operator came from)
+//   lens   ∈ linear | phase               (which board lens that list was under)
+//   col    : string                       (the column within that lens)
+//   cursor : number                       (0-based index into the resolved list)
+//
+// Robustness requirement (Gherkin "List-context survives a refresh or paste" +
+// "unknown or malformed search params fall back to safe defaults rather than
+// throwing"): validation NEVER throws — every field independently falls back to
+// `undefined` (a cold-link, no context) when absent or malformed, so a pasted
+// or hand-edited URL can never crash the route resolver.
+
+/** Which list the operator navigated from. */
+export const FROM_VALUES = ["board", "stuck", "recent"] as const;
+export type DetailFrom = (typeof FROM_VALUES)[number];
+
+/** Which board lens that originating list was rendered under. */
+export const LENS_VALUES = ["linear", "phase"] as const;
+export type DetailLens = (typeof LENS_VALUES)[number];
+
+/**
+ * The typed search params shared by `/ticket/$id` and `/worker/$id`.
+ * Every field is optional: a degraded deep-link (a pasted bare URL) carries
+ * none of them and is a valid "cold-link" — see the FND1 Gherkin
+ * "A degraded deep-link with no context still works". Pager support for the
+ * cold-link case is added by FND2; FND1 only guarantees the contract parses.
+ */
+export interface DetailSearch {
+  from?: DetailFrom;
+  lens?: DetailLens;
+  col?: string;
+  cursor?: number;
+}
+
+function isDetailFrom(value: unknown): value is DetailFrom {
+  return typeof value === "string" && (FROM_VALUES as readonly string[]).includes(value);
+}
+
+function isDetailLens(value: unknown): value is DetailLens {
+  return typeof value === "string" && (LENS_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * Coerce a raw search value to a finite non-negative integer cursor, or
+ * `undefined` if it is absent/malformed. Accepts the numeric form TanStack's
+ * default search parser produces (a `number`) as well as a bare string (e.g.
+ * hand-pasted `?cursor=4`). Rejects NaN/Infinity, negatives, and non-integers
+ * — a cursor is an index into the resolved list, so anything else is unsafe.
+ */
+function coerceCursor(value: unknown): number | undefined {
+  let n: number;
+  if (typeof value === "number") {
+    n = value;
+  } else if (typeof value === "string" && value.trim() !== "") {
+    n = Number(value);
+  } else {
+    return undefined;
+  }
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) return undefined;
+  return n;
+}
+
+/**
+ * Validate raw URL search params into the typed `DetailSearch` contract.
+ *
+ * Total + non-throwing: any input (including `null`, a string, or an object
+ * with garbage values) yields a valid `DetailSearch`; unknown/malformed fields
+ * are dropped to `undefined` rather than raising. This is exactly TanStack
+ * Router's `validateSearch` shape `(raw) => DetailSearch`, and the Gherkin
+ * acceptance criterion for "unknown or malformed search params fall back to
+ * safe defaults rather than throwing".
+ */
+export function validateDetailSearch(raw: unknown): DetailSearch {
+  const record: Record<string, unknown> =
+    typeof raw === "object" && raw !== null ? (raw as Record<string, unknown>) : {};
+
+  const out: DetailSearch = {};
+  if (isDetailFrom(record.from)) out.from = record.from;
+  if (isDetailLens(record.lens)) out.lens = record.lens;
+  if (typeof record.col === "string" && record.col !== "") out.col = record.col;
+  const cursor = coerceCursor(record.cursor);
+  if (cursor !== undefined) out.cursor = cursor;
+  return out;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/router.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/router.tsx
@@ -1,0 +1,109 @@
+// router.tsx — the orch-monitor app-wide routing skeleton (CTL-881 / FND1).
+//
+// The board was a route-less React tree: main.tsx mounted <Board /> directly,
+// so nothing was deep-linkable and a refresh/paste could not reconstruct where
+// you were. This adopts @tanstack/react-router (greenfield — the redesign's
+// whole detail-page spine sits on it) and defines three routes:
+//
+//   /              → the existing <Board /> (mounted unchanged; the SharedWorker
+//                    board stream in board-client.ts is untouched — routing wraps
+//                    the tree, it never touches data flow).
+//   /ticket/$id    → typed `id` param + typed `?from&lens&col&cursor` search;
+//                    renders a placeholder detail container (body filled later by
+//                    the DETAIL stream — out of scope for FND1).
+//   /worker/$id    → same shape; `id` is e.g. "CTL-845:2" (a colon is legal
+//                    inside a single path segment, so the run-id resolves whole).
+//
+// Detail-page bodies, the Sidebar nav frame (SHELL stream), and the jotai store
+// are explicitly NOT in this ticket — this is purely the routing skeleton and
+// the typed search-param contract (route-search.ts) everything else binds to.
+import { StrictMode } from "react";
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { Board } from "./Board";
+import { validateDetailSearch } from "./route-search";
+
+// Root route: holds the <Outlet> the matched child renders into. No chrome yet
+// (the Sidebar/SHELL frame is a later ticket) — the root is a bare passthrough
+// so `/` paints exactly today's board with no visual regression.
+const rootRoute = createRootRoute({
+  component: () => <Outlet />,
+});
+
+// `/` — the existing board, mounted unchanged.
+const boardRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  component: Board,
+});
+
+// `/ticket/$id` — typed id param + typed search contract. Body is a placeholder
+// container the DETAIL stream fills in a later ticket; for FND1 the route just
+// has to resolve, expose the typed param, and parse the search params safely.
+const ticketRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/ticket/$id",
+  validateSearch: validateDetailSearch,
+  component: TicketDetailPlaceholder,
+});
+
+// `/worker/$id` — single-run page. Same typed param + search contract.
+const workerRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/worker/$id",
+  validateSearch: validateDetailSearch,
+  component: WorkerDetailPlaceholder,
+});
+
+function TicketDetailPlaceholder() {
+  const { id } = ticketRoute.useParams();
+  return (
+    <div data-detail-kind="ticket" data-detail-id={id} style={PLACEHOLDER_STYLE}>
+      ticket {id}
+    </div>
+  );
+}
+
+function WorkerDetailPlaceholder() {
+  const { id } = workerRoute.useParams();
+  return (
+    <div data-detail-kind="worker" data-detail-id={id} style={PLACEHOLDER_STYLE}>
+      worker {id}
+    </div>
+  );
+}
+
+// Minimal, theme-neutral placeholder so the route renders something while the
+// real detail body is out of scope (filled by the DETAIL stream later).
+const PLACEHOLDER_STYLE = {
+  padding: "24px",
+  color: "#8b93a1",
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+} as const;
+
+const routeTree = rootRoute.addChildren([boardRoute, ticketRoute, workerRoute]);
+
+export const router = createRouter({ routeTree });
+
+// Register the router instance type so `Link`, `useParams`, `useSearch`, etc.
+// are fully typed app-wide against this exact route tree (standard TanStack
+// type-registration pattern).
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}
+
+/** Wrap the whole app in the router. Mounted by main.tsx inside #board-root. */
+export function AppRouter() {
+  return (
+    <StrictMode>
+      <RouterProvider router={router} />
+    </StrictMode>
+  );
+}


### PR DESCRIPTION
## CTL-881 / FND1 — Deep-linkable routes (TanStack Router)

Adopts `@tanstack/react-router` on the previously route-less orch-monitor board (`board/main.tsx` mounted `<Board />` directly, no router). The board now lives at `/`, and `/ticket/$id` + `/worker/$id` become first-class deep-linkable locations with a typed `?from&lens&col&cursor` search-param contract that every later redesign ticket binds to. This is purely the routing skeleton + typed search contract — no detail-page bodies, no Sidebar nav, no jotai store.

### Files
- `ui/package.json` / `ui/bun.lock` — add `@tanstack/react-router@^1.170.15`.
- `ui/src/board/route-search.ts` (new) — pure, React-/router-free typed search-param validator (`validateDetailSearch`, `DetailSearch`). Total + never-throws; unknown/malformed params fall back to `undefined`.
- `ui/src/board/router.tsx` (new) — route tree (`/` → `<Board/>` unchanged, `/ticket/$id`, `/worker/$id`), `validateSearch` wired to `validateDetailSearch`, typed `Register` augmentation, `AppRouter` (StrictMode + `RouterProvider`).
- `ui/src/board/main.tsx` — mounts `<AppRouter/>` into `#board-root` (kept), replacing the direct `<Board/>` mount.
- `__tests__/route-search.test.ts` (new) — 12 cases encoding the Gherkin scenarios against the pure validator.

The board transport (`board-client.ts`, `/api/board/stream` SSE + SharedWorker) is **untouched** — routing wraps the tree, it does not touch data flow.

### Gherkin scenario mapping

| Scenario | Status |
|---|---|
| The board still renders at the root route (`<Board/>` unchanged, SharedWorker stream unchanged) | **satisfied** — `/` route renders `Board` directly; `board-client.ts` untouched; root route is a bare `<Outlet>` passthrough (no chrome), so no visual regression. |
| A ticket page has its own URL (`/ticket/CTL-845` → typed `id`, placeholder detail container) | **satisfied** — typed `$id` param via `ticketRoute.useParams()`, renders a placeholder container (body owned by the DETAIL stream, out of scope). |
| A worker page has its own URL (`/worker/CTL-845:2` → typed `id = "CTL-845:2"`) | **satisfied** — colon is legal inside one path segment, so the run-id resolves whole. |
| List-context survives a refresh or paste (`?from=board&lens=linear&col=Implement&cursor=4` → typed; unknown/malformed → safe defaults, no throw) | **satisfied** — `validateDetailSearch` types `from∈board\|stuck\|recent`, `lens∈linear\|phase`, `col:string`, `cursor:number`; every field independently falls back to `undefined` on absent/malformed input; never throws (tested against null/string/number/array/garbage values). |
| A degraded deep-link with no context still works (`/ticket/CTL-845` with no search → resolves; absent `from/lens/col/cursor` = cold-link) | **satisfied** — empty search yields all-`undefined` (a valid cold-link). Pager support for the cold-link case is **explicitly deferred to FND2** per the scenario text. |

### Single-node descope
N/A — this ticket has no cluster/fence/multi-host behavior. No scenarios descoped.

### Validation
- `bunx tsc --noEmit` (ui package): the three touched files are clean. The only remaining error is a pre-existing `kpi-strip.tsx` `OrchestratorStats.abandoned` mismatch on `origin/main` (untouched by this PR).
- `bun test __tests__/route-search.test.ts` — 12 pass / 0 fail. Plus `board-client.test.ts` + `board-phase-drift.test.ts` green (no board-area regression).
- `bun run build` in `ui/` succeeds (board entry bundles with the router). Build artifacts under `public/` are intentionally not committed (deploy pipeline regenerates them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)