### PR TITLE
fix(dev): CTL-883 keep bun:sqlite out of the Node-loaded vite.config import graph

### DIFF
--- a/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
@@ -34,6 +34,12 @@ const HOME = homedir();
 const DEFAULT_DB_PATH = join(HOME, "catalyst", "filter-state.db");
 const DEFAULT_ELIGIBLE_DIR = join(HOME, "catalyst", "execution-core", "eligible");
 
+// broker-state.mjs carries a top-level `import { Database } from "bun:sqlite"`.
+// We reach it ONLY through the lazy `import()` in readTicketStateById, but the
+// specifier MUST be computed (not a string literal) — see the long note there.
+// Kept as a module constant so the path lives in one place and reads cleanly.
+const BROKER_STATE_MODULE = ["..", "..", "broker", "broker-state.mjs"].join("/");
+
 // Normalize a stored ticket_state descriptor priority to the 0..4 Linear scale.
 // ticket_state stores it as an INTEGER (0 = no priority, 1 = urgent .. 4 = low);
 // a null/NaN means "cache has no priority for this ticket" → defer to eligible.
@@ -52,8 +58,22 @@ async function readTicketStateById(dbPath) {
     // orch-monitor server + vite middleware both run under Bun). Import lazily
     // so a non-Bun import of this module (e.g. a node-run tooling pass) fails
     // soft to {} instead of crashing at module load.
+    //
+    // CTL-883: the specifier is the COMPUTED `BROKER_STATE_MODULE` constant, NOT
+    // a string literal — and that is load-bearing, not stylistic. board-data.mjs
+    // (which statically imports this module) is itself statically imported by
+    // ui/vite.config.ts. When Vite loads that config it esbuild-bundles the
+    // config + its RELATIVE import graph, and esbuild follows relative dynamic
+    // imports too — but ONLY when the argument is a plain string literal. A
+    // literal `import("../../broker/broker-state.mjs")` would pull broker-state
+    // (and its top-level `bun:sqlite`) into the Node-evaluated config bundle,
+    // and Node throws ERR_UNSUPPORTED_ESM_URL_SCHEME on `bun:`, breaking
+    // `vite build` (the monitor's deploy path). A computed specifier stays an
+    // opaque runtime `import()` esbuild can't follow, so bun:sqlite never enters
+    // the config graph. Under Bun at runtime the string resolves identically.
+    // DO NOT inline this back to a literal.
     const [{ openBrokerStateDb, getAllTicketDescriptors }] = await Promise.all([
-      import("../../broker/broker-state.mjs"),
+      import(BROKER_STATE_MODULE),
     ]);
     openBrokerStateDb(dbPath);
     const byId = {};


### PR DESCRIPTION
## Root cause

The orch-monitor build runs `vite build`. Vite loads `plugins/dev/scripts/orch-monitor/ui/vite.config.ts` under **Node's ESM loader**. The static edge that broke the deploy:

```
ui/vite.config.ts
  → (static)  ../lib/board-data.mjs              import { assembleBoard }
    → (static)  ./linear-cache-reader.mjs        import { readLinearCache }
      → (lazy, but LITERAL) import("../../broker/broker-state.mjs")
        → (static) import { Database } from "bun:sqlite"   ← Node can't resolve `bun:`
```

PRs #1557 (CTL-881 FND1) + #1559 (CTL-883 BFF1) added the cache-backed read-model whose `linear-cache-reader.mjs` reaches the broker SQLite helpers (`broker/broker-state.mjs`, top-level `import { Database } from "bun:sqlite"`). That import was already *lazy* — but the specifier was a plain **string literal**.

Vite esbuild-bundles the config plus its **relative** import graph, and esbuild follows relative dynamic imports **when the argument is a string literal**. So the literal `import("../../broker/broker-state.mjs")` pulled `broker-state` (and its `bun:sqlite`) into the Node-evaluated config bundle, and Node threw:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: ... Received protocol 'bun:'
```

→ vite config load failed → `vite build` aborted → monitor never booted (:7400 dead).

Under `bunx`/bun the same build **succeeds** (bun resolves `bun:sqlite`), which is why local `bun run build` passed but the real deploy path failed.

## Fix

Make the dynamic-import specifier **computed** (a module constant built with `.join("/")`) instead of a string literal, so esbuild's config bundler can no longer statically follow it. `broker-state.mjs`/`bun:sqlite` never enters the Node-loaded config graph. Under Bun at runtime the string resolves to the identical relative path, so read-model behavior is unchanged.

This matches the established convention — the other `bun:sqlite` modules (`annotations.ts`, `archive-reader.ts`, `history-store.ts`, `session-store.ts`, `pr-cache.ts`) were simply never in `board-data.mjs`'s import graph. The fix keeps `bun:sqlite` out of that graph the same way.

One file changed (`lib/linear-cache-reader.mjs`), +21/-1, no build-artifact churn.

## Verification

- **BEFORE** (reproduced the failure): `node ./node_modules/vite/bin/vite.js build` → `ERR_UNSUPPORTED_ESM_URL_SCHEME` (protocol `'bun:'`).
- **AFTER**: `node ./node_modules/vite/bin/vite.js build` ✓ AND `bunx vite build` ✓ — both succeed, output lands in `../public` (`board.html` + `index.html` + assets).
- esbuild config-graph inputs no longer include `broker-state.mjs`; `bun:sqlite` absent from the config bundle.
- `bun test` `linear-cache-reader.test.ts` + `read-model.test.ts`: **14 pass / 0 fail**.
- Runtime under Bun: `readLinearCache` + `assembleBoard` work (computed import resolves correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)