### PR TITLE
feat(dev): BFF6 board payload model/startedAt/pid/sess_id (CTL-888)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/board-phase-summary.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-phase-summary.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "bun:test";
 import { buildPhaseSummary, PHASE_ORDER } from "../lib/board-data.mjs";
 
-type Sig = { status: string; startedAt?: string; completedAt?: string } | null;
+type Sig = { status: string; startedAt?: string; completedAt?: string; model?: string } | null;
 
 const NOW = Date.parse("2026-06-02T10:00:00Z");
 
@@ -11,7 +11,7 @@ test("terminal phase uses completedAt - startedAt for duration", () => {
   const out = buildPhaseSummary(sigs, NOW);
   expect(out).toEqual([{
     phase: "triage", status: "done", durationMs: 112_000,
-    startedAt: "2026-06-02T09:28:09Z", completedAt: "2026-06-02T09:30:01Z",
+    startedAt: "2026-06-02T09:28:09Z", completedAt: "2026-06-02T09:30:01Z", model: null,
   }]);
 });
 
@@ -21,7 +21,7 @@ test("running (non-terminal, no completedAt) phase measures now - startedAt", ()
   const out = buildPhaseSummary(sigs, NOW);
   expect(out).toEqual([{
     phase: "plan", status: "running", durationMs: 60_000,
-    startedAt: "2026-06-02T09:59:00Z", completedAt: null,
+    startedAt: "2026-06-02T09:59:00Z", completedAt: null, model: null,
   }]);
 });
 
@@ -30,7 +30,7 @@ test("terminal phase WITHOUT completedAt yields null duration (not now-based)", 
   sigs[4] = { status: "failed", startedAt: "2026-06-02T09:00:00Z" }; // verify, terminal
   expect(buildPhaseSummary(sigs, NOW)).toEqual([{
     phase: "verify", status: "failed", durationMs: null,
-    startedAt: "2026-06-02T09:00:00Z", completedAt: null,
+    startedAt: "2026-06-02T09:00:00Z", completedAt: null, model: null,
   }]);
 });
 
@@ -54,7 +54,7 @@ test("unparseable completedAt yields null duration (not a now-anchored value)", 
   sigs[0] = { status: "done", startedAt: "2026-06-02T09:00:00Z", completedAt: "not-a-date" };
   expect(buildPhaseSummary(sigs, NOW)).toEqual([{
     phase: "triage", status: "done", durationMs: null,
-    startedAt: "2026-06-02T09:00:00Z", completedAt: null,
+    startedAt: "2026-06-02T09:00:00Z", completedAt: null, model: null,
   }]);
 });
 
@@ -67,7 +67,7 @@ test("completedAt earlier than startedAt yields null duration but raw timestamps
   sigs[0] = { status: "done", startedAt: "2026-06-02T09:30:00Z", completedAt: "2026-06-02T09:28:00Z" };
   expect(buildPhaseSummary(sigs, NOW)).toEqual([{
     phase: "triage", status: "done", durationMs: null,
-    startedAt: "2026-06-02T09:30:00Z", completedAt: "2026-06-02T09:28:00Z",
+    startedAt: "2026-06-02T09:30:00Z", completedAt: "2026-06-02T09:28:00Z", model: null,
   }]);
 });
 
@@ -83,6 +83,34 @@ test("startedAt and completedAt echoed verbatim from signal (raw string preserva
   const out = buildPhaseSummary(sigs, NOW);
   expect(out).toEqual([{
     phase: "research", status: "done", durationMs: 330_000,
-    startedAt: "2026-06-02T08:00:00Z", completedAt: "2026-06-02T08:05:30Z",
+    startedAt: "2026-06-02T08:00:00Z", completedAt: "2026-06-02T08:05:30Z", model: null,
   }]);
+});
+
+// ── BFF6 / CTL-888 P5: per-phase model on BoardPhaseTiming ──────────────────
+// sig.model is already read into deriveCurrentPhase's intermediate (:215/:217)
+// but was dropped at the buildPhaseSummary return. Surface it so the ticket
+// spine + gantt can render the per-phase model (◆sonnet/◆opus).
+test("BFF6: sig.model is surfaced onto BoardPhaseTiming.model", () => {
+  const sigs: Sig[] = PHASE_ORDER.map(() => null);
+  sigs[0] = { status: "done", startedAt: "2026-06-02T09:00:00Z", completedAt: "2026-06-02T09:01:00Z", model: "sonnet" };
+  sigs[3] = { status: "running", startedAt: "2026-06-02T09:59:00Z", model: "opus" }; // implement
+  const out = buildPhaseSummary(sigs, NOW);
+  expect(out).toEqual([
+    {
+      phase: "triage", status: "done", durationMs: 60_000,
+      startedAt: "2026-06-02T09:00:00Z", completedAt: "2026-06-02T09:01:00Z", model: "sonnet",
+    },
+    {
+      phase: "implement", status: "running", durationMs: 60_000,
+      startedAt: "2026-06-02T09:59:00Z", completedAt: null, model: "opus",
+    },
+  ]);
+});
+
+test("BFF6: a signal without a model yields model:null (no fabrication)", () => {
+  const sigs: Sig[] = PHASE_ORDER.map(() => null);
+  sigs[0] = { status: "done", startedAt: "2026-06-02T09:00:00Z", completedAt: "2026-06-02T09:01:00Z" };
+  const out = buildPhaseSummary(sigs, NOW);
+  expect(out[0]?.model).toBeNull();
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/read-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/read-model.test.ts
@@ -35,6 +35,9 @@ function worker(ticket: string): BoardWorker {
     runtimeMs: 0,
     costUSD: null,
     sessionId: "sess-1",
+    startedAt: null,
+    pid: null,
+    catalystSessionId: null,
   };
 }
 

--- a/plugins/dev/scripts/orch-monitor/board-data-worker-ids.test.ts
+++ b/plugins/dev/scripts/orch-monitor/board-data-worker-ids.test.ts
@@ -1,0 +1,125 @@
+// CTL-888 (BFF6) P6/P7: BoardWorker gains startedAt (epoch ms), pid, and the
+// catalyst sess_ id alongside the CC-UUID sessionId.
+//
+// assembleBoard() shells out to `claude agents --json` and reads a homedir DB
+// const, so it is not directly unit-testable. Following the convention in
+// board-data-phase-costs.test.ts, we exercise:
+//   • the CC-UUID → catalyst-sess_ join SQL (P7) against a temp DB, and
+//   • the worker field-derivation logic (P6 startedAt, P7 pid) on a synthetic
+//     `claude agents --json` agent record — asserting the exact null-vs-value
+//     normalization the board applies.
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { execFileSync } from "child_process";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+describe("BFF6 P7: CC-UUID → catalyst sess_ id join SQL", () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "board-worker-ids-"));
+    dbPath = join(tmpDir, "catalyst.db");
+    execFileSync("sqlite3", [
+      dbPath,
+      `
+      CREATE TABLE sessions (
+        session_id TEXT PRIMARY KEY,
+        ticket_key TEXT,
+        pid INTEGER,
+        claude_session_id TEXT
+      );
+      -- one worker with both ids
+      INSERT INTO sessions VALUES ('sess_abc_01','CTL-888',4242,'cc-uuid-1111');
+      -- a session that never recorded its CC-UUID (pre-CTL-374 / solo run)
+      INSERT INTO sessions VALUES ('sess_def_02','CTL-889',4243,NULL);
+      INSERT INTO sessions VALUES ('sess_ghi_03','CTL-890',4244,'');
+      `,
+    ]);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("maps a CC-UUID to its catalyst session_id and skips rows with no CC-UUID", () => {
+    const sql =
+      "SELECT claude_session_id, session_id FROM sessions " +
+      "WHERE claude_session_id IS NOT NULL AND claude_session_id <> '';";
+    const out = execFileSync("sqlite3", ["-separator", "\t", dbPath, sql], {
+      encoding: "utf8",
+    });
+    const map: Record<string, string> = {};
+    for (const line of out.trim().split("\n")) {
+      if (!line) continue;
+      const [ccUuid, sessId] = line.split("\t");
+      if (ccUuid && sessId) map[ccUuid] = sessId;
+    }
+    // the only row carrying a CC-UUID resolves to its catalyst sess_ id
+    expect(map["cc-uuid-1111"]).toBe("sess_abc_01");
+    // NULL / empty CC-UUID rows are excluded — no fabricated mapping
+    expect(Object.keys(map)).toEqual(["cc-uuid-1111"]);
+  });
+
+  it("an unknown CC-UUID has no mapping (catalystSessionId stays null)", () => {
+    const sql =
+      "SELECT claude_session_id, session_id FROM sessions " +
+      "WHERE claude_session_id IS NOT NULL AND claude_session_id <> '';";
+    const out = execFileSync("sqlite3", ["-separator", "\t", dbPath, sql], {
+      encoding: "utf8",
+    });
+    const map: Record<string, string> = {};
+    for (const line of out.trim().split("\n")) {
+      if (!line) continue;
+      const [ccUuid, sessId] = line.split("\t");
+      if (ccUuid && sessId) map[ccUuid] = sessId;
+    }
+    const catalystSessionId = map["cc-uuid-does-not-exist"] ?? null;
+    expect(catalystSessionId).toBeNull();
+  });
+});
+
+// P6 (startedAt) + P7 (pid) field normalization the worker assembly applies to a
+// `claude agents --json` agent record. The board persists numeric startedAt/pid
+// verbatim and collapses any non-number (absent field) to null.
+describe("BFF6 P6/P7: worker startedAt + pid field normalization", () => {
+  type Agent = { startedAt?: unknown; pid?: unknown; sessionId?: string };
+
+  // Mirrors the normalization in board-data.mjs assembleBoard worker map.
+  function deriveWorkerIds(a: Agent, catalystByUuid: Record<string, string>) {
+    return {
+      startedAt: typeof a.startedAt === "number" ? a.startedAt : null,
+      pid: typeof a.pid === "number" ? a.pid : null,
+      catalystSessionId: a.sessionId ? catalystByUuid[a.sessionId] ?? null : null,
+    };
+  }
+
+  it("persists numeric startedAt (epoch ms) and pid verbatim", () => {
+    const out = deriveWorkerIds(
+      { startedAt: 1780476726027, pid: 51612, sessionId: "cc-uuid-1111" },
+      { "cc-uuid-1111": "sess_abc_01" },
+    );
+    expect(out).toEqual({
+      startedAt: 1780476726027,
+      pid: 51612,
+      catalystSessionId: "sess_abc_01",
+    });
+  });
+
+  it("collapses absent startedAt / pid to null (no fabrication)", () => {
+    const out = deriveWorkerIds({ sessionId: "cc-uuid-2222" }, {});
+    expect(out).toEqual({ startedAt: null, pid: null, catalystSessionId: null });
+  });
+
+  it("surfaces BOTH id spaces: CC-UUID sessionId is independent of the catalyst sess_ id", () => {
+    const a: Agent = { startedAt: 1, pid: 2, sessionId: "cc-uuid-1111" };
+    const ids = deriveWorkerIds(a, { "cc-uuid-1111": "sess_abc_01" });
+    // CC-UUID (Prometheus/Loki claude-code key) and catalyst sess_ id
+    // (catalyst.session heartbeat key) are distinct, both present.
+    expect(a.sessionId).toBe("cc-uuid-1111");
+    expect(ids.catalystSessionId).toBe("sess_abc_01");
+    expect(a.sessionId).not.toBe(ids.catalystSessionId);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -18,7 +18,14 @@ export interface BoardWorker {
   team: string;
   runtimeMs: number | null;
   costUSD: number | null;
+  /** CC-UUID from `claude agents --json .sessionId` (Prometheus/Loki claude-code key). */
   sessionId: string;
+  /** CTL-888 (BFF6) P6: exact wall-clock start (epoch ms) for precise elapsed. */
+  startedAt: number | null;
+  /** CTL-888 (BFF6) P7: OS pid of the bg worker. */
+  pid: number | null;
+  /** CTL-888 (BFF6) P7: catalyst `sess_…` id (catalyst.session heartbeat key); null when unknown. */
+  catalystSessionId: string | null;
 }
 
 export interface BoardPhaseCost {
@@ -33,6 +40,8 @@ export interface BoardPhaseTiming {
   durationMs: number | null;
   startedAt: string | null;
   completedAt: string | null;
+  /** CTL-888 (BFF6) P5: per-phase model for the spine + gantt; null when absent. */
+  model: string | null;
 }
 
 export interface BoardCurrentPhase {

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -272,6 +272,11 @@ export function buildPhaseSummary(phaseSigs, now) {
         durationMs,
         startedAt: sig.startedAt ?? null,
         completedAt,
+        // CTL-888 (BFF6) P5: surface the per-phase model. sig.model is already
+        // read into deriveCurrentPhase's intermediate but was dropped here — the
+        // ticket spine + gantt render ◆sonnet/◆opus per node off this field.
+        // Normalize absent to null so consumers get a clean string-or-null signal.
+        model: sig.model ?? null,
       };
     })
     .filter(Boolean);
@@ -376,6 +381,34 @@ async function costByPhase() {
   return map;
 }
 
+// ── CC-UUID → catalyst sess_ id map (CTL-888 / BFF6 P7) ─────────────────────
+// Two disjoint id spaces ride the worker: the CC-UUID (`claude agents --json
+// .sessionId`, keys Prometheus/Loki claude-code streams) and the catalyst
+// `sess_…` id (keys the catalyst.session/phase-agent heartbeat streams). The
+// catalyst id lives only in catalyst.db `sessions.session_id`, joinable to the
+// CC-UUID we already hold via `sessions.claude_session_id`. Build the map once
+// so the worker assembly can surface BOTH ids. Fail-open: a missing db / column
+// yields an empty map and `catalystSessionId` stays null (never fabricated).
+async function catalystSessionByCcUuid() {
+  const map = {};
+  if (!(await exists(DB))) return map;
+  try {
+    const sql =
+      "SELECT claude_session_id, session_id FROM sessions " +
+      "WHERE claude_session_id IS NOT NULL AND claude_session_id <> '';";
+    const { stdout } = await execFileP("sqlite3", ["-separator", "\t", DB, sql], {
+      encoding: "utf8", timeout: 8000, maxBuffer: 8 * 1024 * 1024,
+    });
+    for (const line of stdout.trim().split("\n")) {
+      if (!line) continue;
+      const [ccUuid, sessId] = line.split("\t");
+      // Last write wins — a CC-UUID maps to a single catalyst session.
+      if (ccUuid && sessId) map[ccUuid] = sessId;
+    }
+  } catch { /* sqlite missing or pre-CTL-374 schema (no claude_session_id) */ }
+  return map;
+}
+
 // ── ranked eligible queue (mirrors scheduler-rank.mjs compareTickets) ───────
 const PRIORITY_RANK = (p) => (p && p >= 1 && p <= 4 ? p : 5); // 1=urgent..4=low, 0/none→5
 function compareQueued(a, b) {
@@ -434,8 +467,9 @@ async function readTicketArtifacts(id) {
 
 // ── main assembly ───────────────────────────────────────────────────────────
 export async function assembleBoard() {
-  const [agents, costs, phaseCostsByTicket, eligible, linfo, mp] = await Promise.all([
+  const [agents, costs, phaseCostsByTicket, eligible, linfo, mp, catalystSessByUuid] = await Promise.all([
     liveAgents(), costByTicket(), costByPhase(), loadEligible(), linearInfo(), maxParallel(),
+    catalystSessionByCcUuid(),
   ]);
   const eligibleIndex = Object.fromEntries(eligible.map((e) => [e.id, e]));
 
@@ -457,6 +491,17 @@ export async function assembleBoard() {
       status: a.status || "idle", activeState, working, lastActiveMs,
       repo: repoFor(p.ticket), team: teamFor(p.ticket),
       runtimeMs, costUSD: cost, sessionId: a.sessionId,
+      // CTL-888 (BFF6) P6: exact wall-clock start (epoch ms from `claude agents
+      // --json .startedAt`, the same value runtimeMs derives from) so the worker
+      // header can render precise elapsed instead of a floored runtimeMs.
+      startedAt: typeof a.startedAt === "number" ? a.startedAt : null,
+      // CTL-888 (BFF6) P7: the OS pid (read by `claude agents --json` but
+      // previously dropped) drives the worker-rail PID row.
+      pid: typeof a.pid === "number" ? a.pid : null,
+      // CTL-888 (BFF6) P7: the catalyst `sess_…` id alongside the CC-UUID
+      // sessionId — surfaces both id spaces (Loki catalyst.session heartbeat
+      // joins on this one). null when the db has no row for this CC-UUID.
+      catalystSessionId: catalystSessByUuid[a.sessionId] ?? null,
     };
   }));
   const inFlightTickets = new Map(workers.map((w) =>

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
@@ -19,7 +19,17 @@ export interface BoardWorker {
   team: string;
   runtimeMs: number | null;
   costUSD: number | null;
+  /** CC-UUID from `claude agents --json .sessionId` — keys the Prometheus
+   *  `claude_code_*` series and the Loki `claude-code` stream. */
   sessionId?: string;
+  /** CTL-888 (BFF6) P6: exact wall-clock start (epoch ms), for precise elapsed. */
+  startedAt?: number | null;
+  /** CTL-888 (BFF6) P7: OS pid of the bg worker — drives the worker-rail PID row. */
+  pid?: number | null;
+  /** CTL-888 (BFF6) P7: catalyst `sess_…` id (the second id space) — keys the
+   *  Loki `catalyst.session` heartbeat / `catalyst.phase-agent` lifecycle
+   *  streams. null when catalyst.db has no row for this CC-UUID. */
+  catalystSessionId?: string | null;
 }
 
 export interface BoardPhaseCost {
@@ -34,6 +44,9 @@ export interface BoardPhaseTiming {
   durationMs: number | null;
   startedAt: string | null;
   completedAt: string | null;
+  /** CTL-888 (BFF6) P5: per-phase model (◆sonnet/◆opus) for the spine + gantt.
+   *  null when the phase signal carried no model. */
+  model: string | null;
 }
 
 export interface BoardTicket {


### PR DESCRIPTION
## CTL-888 (BFF6) — Board payload: model / startedAt / pid / sess_id

Payload-only changes in `lib/board-data.mjs` that stop dropping read-then-discarded fields so the ticket/worker detail pages render real data instead of dimmed placeholders. This ticket is the **field PRODUCER**; DETAIL4 strictly consumes these in the spine/header UI — neither re-edits the `buildPhaseSummary` return (the ownership boundary the technical notes resolve). Host/team are explicitly **out of scope** (BFF10 owns per-entity host stamping).

### Gherkin scenarios → status

| Scenario | Status |
|---|---|
| **Per-phase model appears on the spine** — `BoardPhaseTiming.model` populated from `sig.model`; spine + gantt can render per-phase model | **satisfied** (P5: `sig.model ?? null` added to the `buildPhaseSummary` return + `BoardPhaseTiming` in both type files). UI rendering of the field is DETAIL4's consumption job. |
| **Worker header shows exact wall-clock elapsed** — `BoardWorker.startedAt` persisted from `claude agents --json .startedAt` | **satisfied** (P6: `startedAt: number \| null`, epoch ms — the same value `runtimeMs` derives from). |
| **Both id spaces are surfaced** — `BoardWorker` carries `sessionId` (CC-UUID) **and** `catalystSessionId` (catalyst `sess_` id), plus `pid` | **satisfied** (P7: `pid` un-dropped from the agent record; `catalystSessionId` joined from `catalyst.db sessions` via `claude_session_id`. CC-UUID keys Prometheus/Loki `claude-code`; catalyst `sess_` keys the `catalyst.session` heartbeat — both surfaced). |

### Single-node descope

None applicable — this ticket is pure board-payload field plumbing with no cluster/fence/multi-host/motion behavior. Nothing was single-node-descoped.

### Implementation notes
- **P5** `lib/board-data.mjs` `buildPhaseSummary` return: `model: sig.model ?? null`. `sig.model` was already read into `deriveCurrentPhase`'s intermediate but dropped at this return.
- **P6/P7** `assembleBoard` worker map: `startedAt`/`pid` persisted from the `claude agents --json` record with `typeof === "number"` normalization (absent → null, never fabricated); `catalystSessionId` resolved through a new fail-open `catalystSessionByCcUuid()` reader (missing db / pre-CTL-374 schema → empty map → null).
- Types updated in **both** `ui/src/board/types.ts` (UI subset, optional like `sessionId`) and `lib/board-data.d.mts` (server producer, required-with-null).

### Tests (TDD)
- Extended `__tests__/board-phase-summary.test.ts` — every existing assertion now includes `model`, plus 2 new cases (model surfaced; absent → null).
- New `board-data-worker-ids.test.ts` — the CC-UUID→`sess_` join SQL against a temp catalyst.db (NULL/empty CC-UUID rows excluded, unknown UUID → null) and `startedAt`/`pid` null-normalization on a synthetic agent record.
- Updated `__tests__/read-model.test.ts` `worker()` factory for the new required server fields.

### Validation
- `bunx tsc --noEmit` clean for the orch-monitor server package.
- ui package tsc: only the **pre-existing** `kpi-strip.tsx` `OrchestratorStats.abandoned` error (verified present on clean `main` with changes stashed) — zero new errors from this diff.
- `bun run build` (ui) succeeds.
- Targeted tests green (24 pass across board-phase-summary, read-model, board-data-worker-ids, board-data-phase-costs).
- No reward-hacking patterns (`as any` / `as unknown` / `@ts-ignore` / non-null `!` / `forEach(async`) in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)