### PR TITLE
feat(dev): BFF11 broker fence projection into cache (CTL-923)

### DIFF
--- a/plugins/dev/scripts/broker/broker-state.d.mts
+++ b/plugins/dev/scripts/broker/broker-state.d.mts
@@ -22,6 +22,12 @@ export interface TicketDescriptor {
   uuid: string | null;
   removed: boolean;
   removedAt: string | null;
+  /** CTL-923 (BFF11): fence projection + held-since, from the durable cache. */
+  ownerHost: string | null;
+  generation: number | null;
+  fencePhase: string | null;
+  claimedAt: string | null;
+  heldSince: string | null;
   updatedAt: string;
 }
 
@@ -56,3 +62,23 @@ export function getTicketDescriptorByUuid(uuid: string): TicketDescriptor | null
 
 /** Stamp a descriptor removed by UUID; returns the resolved identifier or null. */
 export function markTicketRemovedByUuid(uuid: string): { ticket: string } | null;
+
+export interface UpsertTicketFenceInput {
+  ticket: string;
+  ownerHost?: string | null;
+  generation?: number | null;
+  phase?: string | null;
+  claimedAt?: string | null;
+}
+
+/** CTL-923 (BFF11): key-presence projection of the cluster-claim fence
+ *  attachment metadata into ticket_state (absent field = keep, explicit
+ *  null = clear). */
+export function upsertTicketFence(input: UpsertTicketFenceInput): void;
+
+/** CTL-923 (BFF11): stamp the held-label applied-at timestamp (sticky — the
+ *  first observed hold start survives duplicate webhooks; missing = now). */
+export function setTicketHeldSince(ticket: string, heldSince?: string | null): void;
+
+/** CTL-923 (BFF11): clear held_since when the held labels leave the ticket. */
+export function clearTicketHeldSince(ticket: string): void;

--- a/plugins/dev/scripts/broker/broker-state.mjs
+++ b/plugins/dev/scripts/broker/broker-state.mjs
@@ -106,6 +106,14 @@ export function openBrokerStateDb(dbPath = DEFAULT_DB_PATH) {
   // re-open is a no-op. `removed_at` is the removed flag (null = present);
   // `uuid` carries the Linear entityId so a `remove` webhook (whose payload
   // has ONLY the UUID, never the CTL-123 identifier) can be resolved.
+  // CTL-923 (BFF11): project the cluster-claim fence attachment
+  // (catalyst://fence/<TICKET> metadata owner_host/catalyst_generation/phase/
+  // claimed_at — cluster-claim.mjs) into ticket_state so the read-model groups
+  // by node and shows hold duration from the DURABLE cache, never a live
+  // per-request attachment fetch (which BFF1 forbids). `held_since` carries the
+  // applied-at of the held labels (blocked/waiting) so the duration feature —
+  // punted by HOME3/DETAIL2/BFF7 with no owner — resolves here. Same additive
+  // try/catch ALTER, so a live filter-state.db migrates in place, null-valued.
   for (const col of [
     "relations TEXT",
     "labels TEXT",
@@ -114,6 +122,11 @@ export function openBrokerStateDb(dbPath = DEFAULT_DB_PATH) {
     "assignee TEXT",
     "uuid TEXT",
     "removed_at TEXT",
+    "owner_host TEXT",
+    "catalyst_generation INTEGER",
+    "fence_phase TEXT",
+    "claimed_at TEXT",
+    "held_since TEXT",
   ]) {
     try {
       db.run(`ALTER TABLE ticket_state ADD COLUMN ${col}`);
@@ -121,6 +134,14 @@ export function openBrokerStateDb(dbPath = DEFAULT_DB_PATH) {
       /* already exists */
     }
   }
+  // Node-grouping read path: the read-model bulk-reads ticket_state and groups
+  // by owner_host. The partial index keeps that grouping scan off a full table
+  // walk once the fleet is multi-node (single-node: trivially small, free).
+  db.run(`
+    CREATE INDEX IF NOT EXISTS idx_ticket_state_owner_host
+      ON ticket_state(owner_host)
+      WHERE owner_host IS NOT NULL
+  `);
   // UNIQUE so a buggy upstream writing one entityId onto two identifiers fails
   // loud instead of silently shadowing a row in the remove-webhook resolution.
   // Drop-then-create migrates any interim non-unique version of this index;
@@ -591,6 +612,15 @@ function rowToTicketDescriptor(row) {
     uuid: row.uuid ?? null,
     removed: row.removed_at != null,
     removedAt: row.removed_at ?? null,
+    // CTL-923 (BFF11): fence projection + held-since, surfaced so the
+    // read-model groups by ownerHost and renders a real hold duration straight
+    // from the durable cache. All null when no fence attachment / held label
+    // has been observed — consumers render the field dim, never fabricated.
+    ownerHost: row.owner_host ?? null,
+    generation: row.catalyst_generation ?? null,
+    fencePhase: row.fence_phase ?? null,
+    claimedAt: row.claimed_at ?? null,
+    heldSince: row.held_since ?? null,
     updatedAt: row.updated_at,
   };
 }
@@ -636,6 +666,81 @@ export function markTicketRemovedByUuid(uuid) {
     [ts, ts, row.ticket]
   );
   return { ticket: row.ticket };
+}
+
+// ─── fence projection + held-since helpers (CTL-923, BFF11) ──────────────────
+
+// Fence field → column map. Internal constant — the dynamic SQL below only ever
+// interpolates these fixed column names, never caller input (mirrors the
+// DESCRIPTOR_COLUMNS guard above).
+const FENCE_COLUMNS = {
+  ownerHost: "owner_host",
+  generation: "catalyst_generation",
+  phase: "fence_phase",
+  claimedAt: "claimed_at",
+};
+
+// upsertTicketFence — project the cluster-claim fence attachment metadata
+// (owner_host, catalyst_generation, phase, claimed_at) into ticket_state. Same
+// KEY-PRESENCE semantics as upsertTicketDescriptor: a field ABSENT from the
+// input keeps its stored value; a field present with an explicit null CLEARS it
+// — so a takeover that drops the owner (or a release) is expressible. The row is
+// created if absent so a fence can land before any other webhook for the ticket.
+// Webhook write-through callers should pass exactly the fields the fence carried.
+export function upsertTicketFence(input = {}) {
+  const { ticket } = input;
+  if (!ticket) return;
+  const cols = [];
+  const vals = [];
+  for (const [field, col] of Object.entries(FENCE_COLUMNS)) {
+    if (!(field in input) || input[field] === undefined) continue; // absent → keep
+    cols.push(col);
+    vals.push(input[field]);
+  }
+  if (cols.length === 0) return; // nothing to project
+  const insertCols = ["ticket", ...cols, "updated_at"];
+  const placeholders = insertCols.map(() => "?").join(", ");
+  const setClauses = [
+    ...cols.map((c) => `${c} = excluded.${c}`),
+    "updated_at = excluded.updated_at",
+  ];
+  ensure().run(
+    `INSERT INTO ticket_state (${insertCols.join(", ")})
+     VALUES (${placeholders})
+     ON CONFLICT(ticket) DO UPDATE SET ${setClauses.join(", ")}`,
+    [ticket, ...vals, nowIso()]
+  );
+}
+
+// setTicketHeldSince — stamp the held-label applied-at timestamp. STICKY: the
+// FIRST observed held timestamp survives duplicate held-label webhooks (the
+// duration must measure from when the hold STARTED, not the latest webhook). A
+// missing `heldSince` falls back to now() — the moment the broker first observed
+// the held label. The row is created if absent. Idempotent: re-applying the held
+// label while held_since is already set is a no-op on the timestamp.
+export function setTicketHeldSince(ticket, heldSince) {
+  if (!ticket) return;
+  const ts = heldSince ?? nowIso();
+  ensure().run(
+    `INSERT INTO ticket_state (ticket, held_since, updated_at)
+     VALUES (?, ?, ?)
+     ON CONFLICT(ticket) DO UPDATE SET
+       held_since = COALESCE(ticket_state.held_since, excluded.held_since),
+       updated_at = excluded.updated_at`,
+    [ticket, ts, nowIso()]
+  );
+}
+
+// clearTicketHeldSince — null the held-since timestamp when the held labels
+// leave the ticket (pickup/unblock clears BOTH blocked/waiting labels). The next
+// hold re-stamps a fresh start via setTicketHeldSince. No-op when the row is
+// absent or already clear.
+export function clearTicketHeldSince(ticket) {
+  if (!ticket) return;
+  ensure().run(
+    `UPDATE ticket_state SET held_since = NULL, updated_at = ? WHERE ticket = ?`,
+    [nowIso(), ticket]
+  );
 }
 
 // ─── worker_state helpers (CTL-532) ──────────────────────────────────────────

--- a/plugins/dev/scripts/broker/fence-held-fold.test.mjs
+++ b/plugins/dev/scripts/broker/fence-held-fold.test.mjs
@@ -1,0 +1,231 @@
+// Unit tests for the CTL-923 (BFF11) fence + held-since write-through in
+// foldLinearIssueDescriptor. Like the CTL-822 descriptor fold, this projection
+// runs on the LIVE processEvent path with ZERO registered interests (above the
+// `if (!interests.size) return` gate) so the durable cache stays current during
+// idle periods. These tests drive processEvent directly for exactly that reason.
+// Run: bun test plugins/dev/scripts/broker/fence-held-fold.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  openBrokerStateDb,
+  closeBrokerStateDb,
+  getTicketDescriptor,
+} from "./broker-state.mjs";
+import { processEvent } from "./router.mjs";
+import { clearInterests } from "./state.mjs";
+import { heldFor } from "../orch-monitor/lib/board-data.mjs";
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "fence-held-fold-test-"));
+  openBrokerStateDb(join(tmpDir, "test.db"));
+  clearInterests(); // ZERO interests is the load-bearing idle path
+});
+
+afterEach(() => {
+  closeBrokerStateDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function issueEvent(name, detail, ticket = detail.ticket) {
+  return {
+    event: name,
+    attributes: ticket ? { "linear.issue.identifier": ticket } : {},
+    detail,
+  };
+}
+
+// ─── Scenario: Fence metadata lands in the durable cache ─────────────────────
+
+describe("fence projection via processEvent", () => {
+  test("a fence-bearing issue event projects owner_host/generation/phase/claimed_at", () => {
+    processEvent(
+      issueEvent("linear.issue.updated", {
+        ticket: "CTL-845",
+        toState: "Implement",
+        toFence: {
+          owner_host: "mac-mini",
+          catalyst_generation: 3,
+          phase: "implement",
+          claimed_at: "2026-06-08T10:00:00.000Z",
+        },
+      })
+    );
+    const d = getTicketDescriptor("CTL-845");
+    expect(d.ownerHost).toBe("mac-mini");
+    expect(d.generation).toBe(3);
+    expect(d.fencePhase).toBe("implement");
+    expect(d.claimedAt).toBe("2026-06-08T10:00:00.000Z");
+    // the descriptor fold still ran alongside the fence fold
+    expect(d.state).toBe("Implement");
+  });
+
+  test("the wire generation string coerces to a Number", () => {
+    processEvent(
+      issueEvent("linear.issue.updated", {
+        ticket: "CTL-846",
+        toFence: { owner_host: "mac-mini", catalyst_generation: "5" },
+      })
+    );
+    expect(getTicketDescriptor("CTL-846").generation).toBe(5);
+  });
+
+  test("the camelCase `fence` alias also projects", () => {
+    processEvent(
+      issueEvent("linear.issue.updated", {
+        ticket: "CTL-847",
+        fence: { ownerHost: "mac-studio", generation: 2, claimedAt: "2026-06-08T01:00:00Z" },
+      })
+    );
+    const d = getTicketDescriptor("CTL-847");
+    expect(d.ownerHost).toBe("mac-studio");
+    expect(d.generation).toBe(2);
+    expect(d.claimedAt).toBe("2026-06-08T01:00:00Z");
+  });
+
+  test("a null fence clears the projection (release / takeover dropping owner)", () => {
+    processEvent(
+      issueEvent("linear.issue.updated", {
+        ticket: "CTL-848",
+        toFence: { owner_host: "mac-mini", catalyst_generation: 1 },
+      })
+    );
+    expect(getTicketDescriptor("CTL-848").ownerHost).toBe("mac-mini");
+    processEvent(issueEvent("linear.issue.updated", { ticket: "CTL-848", toFence: null }));
+    expect(getTicketDescriptor("CTL-848").ownerHost).toBeNull();
+    expect(getTicketDescriptor("CTL-848").generation).toBeNull();
+  });
+
+  test("an event with no fence key leaves the stored fence untouched", () => {
+    processEvent(
+      issueEvent("linear.issue.updated", {
+        ticket: "CTL-849",
+        toFence: { owner_host: "mac-mini", catalyst_generation: 7 },
+      })
+    );
+    processEvent(issueEvent("linear.issue.state_changed", { ticket: "CTL-849", toState: "PR" }));
+    const d = getTicketDescriptor("CTL-849");
+    expect(d.ownerHost).toBe("mac-mini"); // unknown → keep
+    expect(d.generation).toBe(7);
+    expect(d.state).toBe("PR");
+  });
+});
+
+// ─── Scenario: Held-since timestamp is captured ──────────────────────────────
+
+describe("held-since capture via processEvent", () => {
+  test("a blocked label stamps held_since", () => {
+    processEvent(
+      issueEvent("linear.issue.updated", {
+        ticket: "CTL-850",
+        toLabels: ["blocked"],
+        heldSince: "2026-06-08T09:00:00.000Z",
+      })
+    );
+    expect(getTicketDescriptor("CTL-850").heldSince).toBe("2026-06-08T09:00:00.000Z");
+  });
+
+  test("a waiting label stamps held_since too", () => {
+    processEvent(issueEvent("linear.issue.updated", { ticket: "CTL-851", toLabels: ["waiting"] }));
+    expect(getTicketDescriptor("CTL-851").heldSince).toBeTruthy();
+  });
+
+  test("held_since is sticky across duplicate held webhooks", () => {
+    processEvent(
+      issueEvent("linear.issue.updated", {
+        ticket: "CTL-852",
+        toLabels: ["blocked"],
+        heldSince: "2026-06-08T09:00:00.000Z",
+      })
+    );
+    processEvent(
+      issueEvent("linear.issue.updated", {
+        ticket: "CTL-852",
+        toLabels: ["blocked", "feature"],
+        heldSince: "2026-06-08T11:00:00.000Z",
+      })
+    );
+    expect(getTicketDescriptor("CTL-852").heldSince).toBe("2026-06-08T09:00:00.000Z");
+  });
+
+  test("losing the held labels clears held_since (pickup/unblock)", () => {
+    processEvent(
+      issueEvent("linear.issue.updated", {
+        ticket: "CTL-853",
+        toLabels: ["blocked"],
+        heldSince: "2026-06-08T09:00:00.000Z",
+      })
+    );
+    expect(getTicketDescriptor("CTL-853").heldSince).toBeTruthy();
+    processEvent(issueEvent("linear.issue.updated", { ticket: "CTL-853", toLabels: ["feature"] }));
+    expect(getTicketDescriptor("CTL-853").heldSince).toBeNull();
+  });
+
+  test("an explicitly empty label set clears held_since", () => {
+    processEvent(issueEvent("linear.issue.updated", { ticket: "CTL-854", toLabels: ["waiting"] }));
+    expect(getTicketDescriptor("CTL-854").heldSince).toBeTruthy();
+    processEvent(issueEvent("linear.issue.updated", { ticket: "CTL-854", toLabels: [] }));
+    expect(getTicketDescriptor("CTL-854").heldSince).toBeNull();
+  });
+
+  test("toLabels null (labels absent from payload) leaves held_since alone", () => {
+    processEvent(
+      issueEvent("linear.issue.updated", {
+        ticket: "CTL-855",
+        toLabels: ["blocked"],
+        heldSince: "2026-06-08T09:00:00.000Z",
+      })
+    );
+    processEvent(issueEvent("linear.issue.state_changed", { ticket: "CTL-855", toState: "PR" }));
+    expect(getTicketDescriptor("CTL-855").heldSince).toBe("2026-06-08T09:00:00.000Z");
+  });
+});
+
+// ─── Scenario: Absent data is honest ─────────────────────────────────────────
+
+describe("absent data is honest", () => {
+  test("a non-fence, non-held issue event leaves both null", () => {
+    processEvent(
+      issueEvent("linear.issue.updated", { ticket: "CTL-860", toState: "Todo", toLabels: ["feature"] })
+    );
+    const d = getTicketDescriptor("CTL-860");
+    expect(d.ownerHost).toBeNull();
+    expect(d.heldSince).toBeNull();
+  });
+
+  test("fence/held fold failure never breaks event processing (closed DB)", () => {
+    closeBrokerStateDb();
+    expect(() =>
+      processEvent(
+        issueEvent("linear.issue.updated", {
+          ticket: "CTL-861",
+          toFence: { owner_host: "mac-mini", catalyst_generation: 1 },
+          toLabels: ["blocked"],
+        })
+      )
+    ).not.toThrow();
+    openBrokerStateDb(join(tmpDir, "test.db")); // re-open so afterEach close is balanced
+  });
+});
+
+// ─── drift guard: broker held literals match the board's ─────────────────────
+
+describe("held-label literals stay in lock-step with the board", () => {
+  test("the broker stamps held_since for exactly the labels heldFor classifies", () => {
+    // board-data heldFor is the read side; the broker fold is the write side —
+    // both must agree on which labels mean "held" or the duration is mis-stamped.
+    for (const label of ["blocked", "waiting"]) {
+      expect(heldFor([label])).toBe(label);
+    }
+    processEvent(issueEvent("linear.issue.updated", { ticket: "CTL-870", toLabels: ["blocked"] }));
+    expect(getTicketDescriptor("CTL-870").heldSince).toBeTruthy();
+    // a label heldFor does NOT classify must not stamp
+    expect(heldFor(["feature"])).toBeNull();
+    processEvent(issueEvent("linear.issue.updated", { ticket: "CTL-871", toLabels: ["feature"] }));
+    expect(getTicketDescriptor("CTL-871").heldSince).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -59,6 +59,9 @@ import {
   upsertTicketState,
   upsertTicketDescriptor,
   markTicketRemovedByUuid,
+  upsertTicketFence,
+  setTicketHeldSince,
+  clearTicketHeldSince,
   upsertWaitingSession,
   clearWaitingSession,
 } from "./broker-state.mjs";
@@ -894,6 +897,17 @@ const TICKET_LIFECYCLE_ALL_WAKE_ON = [
   "comment_added",
 ];
 
+// CTL-923 (BFF11): held-indicator labels, the same literals the scheduler
+// applies (execution-core/scheduler.mjs HELD_LABEL_BLOCKED / HELD_LABEL_WAITING)
+// and the board reads (orch-monitor/lib/board-data.mjs heldFor). When either
+// label enters a ticket's set the broker stamps held_since so the read-model can
+// render a real hold duration from the durable cache. Copied (not imported) so
+// the lightweight broker fold takes no scheduler/board dependency — kept in
+// lock-step by the unit test that asserts these match board-data's literals.
+const HELD_LABELS = ["blocked", "waiting"];
+const isHeld = (labels) =>
+  Array.isArray(labels) && labels.some((l) => HELD_LABELS.includes(l));
+
 // foldLinearIssueDescriptor — CTL-822 (Gateway L1 child b): write-through of
 // every linear.issue.* event into the durable descriptor store (CTL-821).
 // KEY-PRESENCE semantics deliberately: a webhook's issue data is a full
@@ -942,10 +956,64 @@ function foldLinearIssueDescriptor(name, detail, eventTicket) {
     if (detail.toLabels != null) descriptor.labels = detail.toLabels;
     if (uuid) descriptor.uuid = uuid;
     upsertTicketDescriptor(descriptor);
+
+    // CTL-923 (BFF11): held_since capture. The label-set snapshot drives the
+    // held-duration clock — when blocked/waiting enters the set we stamp the
+    // applied-at (sticky: first hold start survives), when it leaves we clear.
+    // `detail.heldSince` lets an emitter thread an exact applied-at; otherwise
+    // setTicketHeldSince falls back to now (first observation). A null toLabels
+    // (labels absent from the payload) is "unknown" → leave held_since alone.
+    if (detail.toLabels != null) {
+      if (isHeld(detail.toLabels)) {
+        setTicketHeldSince(eventTicket, detail.heldSince ?? null);
+      } else {
+        clearTicketHeldSince(eventTicket);
+      }
+    }
+
+    // CTL-923 (BFF11): fence projection. cluster-claim.mjs records the
+    // catalyst://fence/<TICKET> attachment (owner_host/catalyst_generation/
+    // phase/claimed_at); when an event carries that metadata under `toFence`
+    // (key-presence, same convention as toLabels/toState) we project it into
+    // ticket_state so the read-model groups by node from the durable cache
+    // rather than a forbidden live attachment fetch. Key-presence: prefer the
+    // `toFence` key when present (even an explicit null, which CLEARS), else the
+    // `fence` alias; absent from both → undefined → leave the projection alone.
+    const fence = "toFence" in detail ? detail.toFence : detail.fence;
+    foldFenceMetadata(eventTicket, fence);
   } catch {
     /* DB not opened, or a UNIQUE-uuid violation from a buggy upstream — the
        routing path must never die on a descriptor write */
   }
+}
+
+// foldFenceMetadata — project a fence-attachment metadata object (the shape
+// cluster-claim.mjs::parseClaimMetadata produces: owner_host, generation, phase,
+// claimed_at) into ticket_state. Accepts both the wire key (catalyst_generation)
+// and the parsed key (generation). A null `fence` clears the projection (a
+// release/takeover that drops the owner); undefined leaves it untouched.
+function foldFenceMetadata(ticket, fence) {
+  if (!ticket || fence === undefined) return;
+  if (fence === null) {
+    upsertTicketFence({
+      ticket,
+      ownerHost: null,
+      generation: null,
+      phase: null,
+      claimedAt: null,
+    });
+    return;
+  }
+  if (typeof fence !== "object") return;
+  const genRaw = fence.generation ?? fence.catalyst_generation;
+  const generation = genRaw == null ? null : Number(genRaw);
+  upsertTicketFence({
+    ticket,
+    ownerHost: fence.owner_host ?? fence.ownerHost ?? null,
+    generation: Number.isFinite(generation) ? generation : null,
+    phase: fence.phase ?? null,
+    claimedAt: fence.claimed_at ?? fence.claimedAt ?? null,
+  });
 }
 
 export function tryTicketLifecycleRoute(event, interestsMap) {

--- a/plugins/dev/scripts/broker/ticket-fence.test.mjs
+++ b/plugins/dev/scripts/broker/ticket-fence.test.mjs
@@ -1,0 +1,237 @@
+// Unit tests for the CTL-923 (BFF11) fence projection + held-since columns on
+// ticket_state. The broker projects the cluster-claim catalyst://fence/<TICKET>
+// attachment metadata (owner_host/catalyst_generation/phase/claimed_at) and the
+// held-label applied-at timestamp into the durable cache so the read-model
+// groups by node and renders a real hold duration WITHOUT a live Linear hit.
+// Run: bun test plugins/dev/scripts/broker/ticket-fence.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  openBrokerStateDb,
+  closeBrokerStateDb,
+  upsertTicketDescriptor,
+  getTicketDescriptor,
+  getAllTicketDescriptors,
+  upsertTicketFence,
+  setTicketHeldSince,
+  clearTicketHeldSince,
+} from "./broker-state.mjs";
+
+let tmpDir;
+let dbPath;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "ticket-fence-test-"));
+  dbPath = join(tmpDir, "test.db");
+  openBrokerStateDb(dbPath);
+});
+
+afterEach(() => {
+  closeBrokerStateDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const FENCE = {
+  ticket: "CTL-845",
+  ownerHost: "mac-mini",
+  generation: 3,
+  phase: "implement",
+  claimedAt: "2026-06-08T10:00:00.000Z",
+};
+
+// ─── fence projection ────────────────────────────────────────────────────────
+
+describe("upsertTicketFence / getTicketDescriptor (Scenario: Fence metadata lands in the cache)", () => {
+  test("full fence metadata round-trips onto the descriptor", () => {
+    upsertTicketFence(FENCE);
+    const d = getTicketDescriptor("CTL-845");
+    expect(d.ownerHost).toBe("mac-mini");
+    expect(d.generation).toBe(3);
+    expect(d.fencePhase).toBe("implement");
+    expect(d.claimedAt).toBe("2026-06-08T10:00:00.000Z");
+  });
+
+  test("a brand-new row is created if no descriptor exists yet", () => {
+    // The fence can land before any other webhook for the ticket.
+    expect(getTicketDescriptor("CTL-845")).toBeNull();
+    upsertTicketFence(FENCE);
+    const d = getTicketDescriptor("CTL-845");
+    expect(d.ticket).toBe("CTL-845");
+    expect(d.ownerHost).toBe("mac-mini");
+    // descriptor fields it did not set stay null (honest absence)
+    expect(d.state).toBeNull();
+    expect(d.labels).toBeNull();
+  });
+
+  test("fence projection never clobbers existing descriptor fields", () => {
+    upsertTicketDescriptor({ ticket: "CTL-845", state: "Implement", labels: ["feature"] });
+    upsertTicketFence(FENCE);
+    const d = getTicketDescriptor("CTL-845");
+    expect(d.state).toBe("Implement");
+    expect(d.labels).toEqual(["feature"]);
+    expect(d.ownerHost).toBe("mac-mini");
+    expect(d.generation).toBe(3);
+  });
+
+  test("key-presence: absent fields survive a partial fence upsert", () => {
+    upsertTicketFence(FENCE);
+    upsertTicketFence({ ticket: "CTL-845", generation: 4 });
+    const d = getTicketDescriptor("CTL-845");
+    expect(d.generation).toBe(4); // bumped
+    expect(d.ownerHost).toBe("mac-mini"); // kept
+    expect(d.fencePhase).toBe("implement"); // kept
+  });
+
+  test("explicit null CLEARS a fence field (release / takeover dropping the owner)", () => {
+    upsertTicketFence(FENCE);
+    upsertTicketFence({ ticket: "CTL-845", ownerHost: null, generation: null });
+    const d = getTicketDescriptor("CTL-845");
+    expect(d.ownerHost).toBeNull();
+    expect(d.generation).toBeNull();
+    expect(d.fencePhase).toBe("implement"); // untouched sibling
+  });
+
+  test("a takeover bumps the generation past the dead owner", () => {
+    upsertTicketFence({ ...FENCE, ownerHost: "mac-mini", generation: 3 });
+    upsertTicketFence({ ticket: "CTL-845", ownerHost: "mac-studio", generation: 4 });
+    const d = getTicketDescriptor("CTL-845");
+    expect(d.ownerHost).toBe("mac-studio");
+    expect(d.generation).toBe(4);
+  });
+
+  test("upsert with no fence fields and no ticket is a safe no-op", () => {
+    expect(() => upsertTicketFence({})).not.toThrow();
+    expect(() => upsertTicketFence({ ticket: "CTL-845" })).not.toThrow();
+    expect(getTicketDescriptor("CTL-845")).toBeNull();
+  });
+
+  test("bulk read carries ownerHost for node-grouping", () => {
+    upsertTicketFence({ ticket: "CTL-1", ownerHost: "mac-mini", generation: 1 });
+    upsertTicketFence({ ticket: "CTL-2", ownerHost: "mac-studio", generation: 1 });
+    upsertTicketDescriptor({ ticket: "CTL-3", state: "Todo" }); // no fence
+    const all = getAllTicketDescriptors();
+    const byId = Object.fromEntries(all.map((d) => [d.ticket, d]));
+    expect(byId["CTL-1"].ownerHost).toBe("mac-mini");
+    expect(byId["CTL-2"].ownerHost).toBe("mac-studio");
+    expect(byId["CTL-3"].ownerHost).toBeNull(); // honest null, never fabricated
+  });
+});
+
+// ─── held-since capture ──────────────────────────────────────────────────────
+
+describe("setTicketHeldSince / clearTicketHeldSince (Scenario: Held-since timestamp is captured)", () => {
+  test("stamps the supplied applied-at timestamp", () => {
+    setTicketHeldSince("CTL-845", "2026-06-08T09:00:00.000Z");
+    expect(getTicketDescriptor("CTL-845").heldSince).toBe("2026-06-08T09:00:00.000Z");
+  });
+
+  test("falls back to now() when no timestamp is supplied", () => {
+    const before = new Date().toISOString();
+    setTicketHeldSince("CTL-845");
+    const hs = getTicketDescriptor("CTL-845").heldSince;
+    expect(hs).toBeTruthy();
+    expect(hs >= before).toBe(true);
+  });
+
+  test("held_since is STICKY — a duplicate hold keeps the FIRST timestamp", () => {
+    setTicketHeldSince("CTL-845", "2026-06-08T09:00:00.000Z");
+    Bun.sleepSync(5);
+    setTicketHeldSince("CTL-845", "2026-06-08T11:00:00.000Z");
+    // first hold start survives so the duration measures from the real start
+    expect(getTicketDescriptor("CTL-845").heldSince).toBe("2026-06-08T09:00:00.000Z");
+  });
+
+  test("clear nulls held_since; the next hold re-stamps fresh", () => {
+    setTicketHeldSince("CTL-845", "2026-06-08T09:00:00.000Z");
+    clearTicketHeldSince("CTL-845");
+    expect(getTicketDescriptor("CTL-845").heldSince).toBeNull();
+    setTicketHeldSince("CTL-845", "2026-06-08T12:00:00.000Z");
+    expect(getTicketDescriptor("CTL-845").heldSince).toBe("2026-06-08T12:00:00.000Z");
+  });
+
+  test("held_since never clobbers descriptor or fence fields", () => {
+    upsertTicketFence(FENCE);
+    upsertTicketDescriptor({ ticket: "CTL-845", labels: ["blocked"] });
+    setTicketHeldSince("CTL-845", "2026-06-08T09:00:00.000Z");
+    const d = getTicketDescriptor("CTL-845");
+    expect(d.heldSince).toBe("2026-06-08T09:00:00.000Z");
+    expect(d.ownerHost).toBe("mac-mini");
+    expect(d.labels).toEqual(["blocked"]);
+  });
+
+  test("clear on an absent / already-clear row is a safe no-op", () => {
+    expect(() => clearTicketHeldSince("CTL-ghost")).not.toThrow();
+    expect(getTicketDescriptor("CTL-ghost")).toBeNull();
+  });
+
+  test("a held-since-only stamp creates the row with null everything else", () => {
+    setTicketHeldSince("CTL-NEW", "2026-06-08T09:00:00.000Z");
+    const d = getTicketDescriptor("CTL-NEW");
+    expect(d.heldSince).toBe("2026-06-08T09:00:00.000Z");
+    expect(d.ownerHost).toBeNull();
+    expect(d.state).toBeNull();
+  });
+});
+
+// ─── Scenario: Absent data is honest ─────────────────────────────────────────
+
+describe("Scenario: Absent data is honest", () => {
+  test("a plain descriptor with no fence/held label has null fence + held fields", () => {
+    upsertTicketDescriptor({ ticket: "CTL-300", state: "Todo", labels: ["feature"] });
+    const d = getTicketDescriptor("CTL-300");
+    expect(d.ownerHost).toBeNull();
+    expect(d.generation).toBeNull();
+    expect(d.fencePhase).toBeNull();
+    expect(d.claimedAt).toBeNull();
+    expect(d.heldSince).toBeNull();
+  });
+});
+
+// ─── additive migration ──────────────────────────────────────────────────────
+
+describe("schema migration (additive ALTERs, CTL-821 pattern)", () => {
+  test("legacy DB without fence columns migrates in place, fields default null", () => {
+    closeBrokerStateDb();
+    rmSync(dbPath, { force: true });
+    const legacy = new Database(dbPath, { create: true });
+    legacy.run(`
+      CREATE TABLE ticket_state (
+        ticket       TEXT PRIMARY KEY,
+        linear_state TEXT,
+        pr_number    INTEGER,
+        updated_at   TEXT NOT NULL,
+        labels       TEXT
+      )
+    `);
+    legacy.run(
+      `INSERT INTO ticket_state (ticket, linear_state, pr_number, updated_at, labels)
+       VALUES ('CTL-100', 'Implement', NULL, '2026-01-01T00:00:00Z', '["feature"]')`
+    );
+    legacy.close();
+
+    openBrokerStateDb(dbPath);
+    const d = getTicketDescriptor("CTL-100");
+    expect(d.state).toBe("Implement");
+    expect(d.labels).toEqual(["feature"]);
+    expect(d.ownerHost).toBeNull();
+    expect(d.generation).toBeNull();
+    expect(d.heldSince).toBeNull();
+    // and the migrated row accepts fence + held writes
+    upsertTicketFence({ ticket: "CTL-100", ownerHost: "mac-mini", generation: 2 });
+    setTicketHeldSince("CTL-100", "2026-06-08T09:00:00.000Z");
+    const after = getTicketDescriptor("CTL-100");
+    expect(after.ownerHost).toBe("mac-mini");
+    expect(after.heldSince).toBe("2026-06-08T09:00:00.000Z");
+  });
+
+  test("re-opening an already-migrated DB is idempotent", () => {
+    upsertTicketFence(FENCE);
+    closeBrokerStateDb();
+    openBrokerStateDb(dbPath);
+    expect(getTicketDescriptor("CTL-845").ownerHost).toBe("mac-mini");
+  });
+});


### PR DESCRIPTION
## Summary

Extends the broker to project each ticket's cluster-claim **fence attachment** metadata (`owner_host`, `catalyst_generation`, `phase`, `claimed_at`) and the **held-label applied-at** timestamp into the durable `filter-state.db` `ticket_state` cache. This gives the redesign read-model a durable node-grouping key and a real hold-duration source so it can group by node and render hold duration **without a live Linear attachment fetch** (which BFF1 forbids).

BFF2 assumed `owner_host` was "already in filter-state.db via broker" — verified FALSE (no fence/owner column existed). This ticket creates that durable source, and closes the `held-since` NEEDS-PLUMBING punt that HOME3/DETAIL2/BFF7 all declared with no owner.

## Changes (all under `plugins/dev/scripts/broker/`)

- **`broker-state.mjs`** — additive ALTERs (the CTL-821 try/catch pattern) add `owner_host`, `catalyst_generation`, `fence_phase`, `claimed_at`, `held_since` to `ticket_state` + a partial `owner_host` index for the node-grouping scan. New helpers:
  - `upsertTicketFence({ ticket, ownerHost, generation, phase, claimedAt })` — key-presence (absent = keep, explicit null = clear), so a release/takeover is expressible; creates the row if absent.
  - `setTicketHeldSince(ticket, heldSince?)` — sticky: the first observed hold start survives duplicate held-label webhooks (missing timestamp = now).
  - `clearTicketHeldSince(ticket)` — nulls `held_since` when the held labels leave.
  - `rowToTicketDescriptor` now surfaces `ownerHost`, `generation`, `fencePhase`, `claimedAt`, `heldSince` — all null when unobserved.
- **`router.mjs`** — `foldLinearIssueDescriptor` projects a payload-carried fence object (`toFence`/`fence`, key-presence) via `upsertTicketFence`, and stamps/clears `held_since` from the `blocked`/`waiting` label set. Runs on the LIVE `processEvent` idle path (zero interests), mirroring the CTL-822 descriptor write-through. Held literals kept in lock-step with `board-data.heldFor` via a drift-guard test.
- **`broker-state.d.mts`** — declares the new descriptor fields + helper signatures for the TS read-model consumers.

## Gherkin acceptance scenarios

| Scenario | Status | Notes |
|---|---|---|
| **Fence metadata lands in the durable cache** | ✅ satisfied | `ticket_state` gains `owner_host`/`catalyst_generation`/`fence_phase`/`claimed_at`; bulk read (`getAllTicketDescriptors`) surfaces `ownerHost` for grouping. The read-model now resolves node-grouping from this durable column with **no live attachment fetch** (the consumer-side grouping UI is BFF2/BFF10; this ticket is the durable source they depend on). |
| **Held-since timestamp is captured** | ✅ satisfied | A `blocked`/`waiting` label stamps `held_since` (sticky from the real hold start); losing the held labels clears it. Surfaced on the descriptor so the read-model serves it. |
| **Absent data is honest** | ✅ satisfied | A ticket with no fence attachment / no held label reads `ownerHost`/`heldSince` (and all fence fields) as `null` — never fabricated. Verified by `ticket-fence.test.mjs` and `fence-held-fold.test.mjs`. |

## Single-node MVP descope

The fence projection is **host-identity-agnostic** — it stores whatever `owner_host` the metadata carries. On a single host it records that one host's name with zero added latency and **no multi-node anchors** (CTL-863/864/865 et al. not built; their contracts are satisfied by the identity behavior). No N>1 cross-node transport is introduced here.

## Tests

New (TDD): `plugins/dev/scripts/broker/ticket-fence.test.mjs` (helper/schema/migration coverage) and `plugins/dev/scripts/broker/fence-held-fold.test.mjs` (live `processEvent` fold + board drift-guard). Both green; adjacent existing suites (`ticket-descriptor`, `linear-descriptor-fold`, `broker-state`) unchanged and green — 91 pass / 0 fail.

```
bun test ticket-fence.test.mjs fence-held-fold.test.mjs ticket-descriptor.test.mjs \
  linear-descriptor-fold.test.mjs broker-state.test.mjs
→ 91 pass, 0 fail
```

`bunx tsc --noEmit` on the orch-monitor package: identical output to clean origin/main (the 2 pre-existing `marked`/`dompurify` UI-dep errors are unrelated; my change adds zero new errors). The broker is plain `.mjs` (no tsconfig).

Note: `gc-startup.test.mjs` has 2-3 pre-existing failures on clean origin/main (unrelated to this diff — gc/liveness pruning, not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)