### PR TITLE
feat(dev): BFF4 phase runs as run entities + verbatim signal (CTL-886)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/ticket-runs-endpoints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ticket-runs-endpoints.test.ts
@@ -1,0 +1,74 @@
+// CTL-886 (BFF4): HTTP route-plumbing tests for the run→worker identity
+// endpoints. Validates the server.ts wiring — param validation (400), the JSON
+// content type, the empty-history shape for a ticket with no worker dir, and the
+// 404 for a phase with no signal. The assembly LOGIC itself (run-entity mapping,
+// PR derivation, cost join, verbatim read) is covered exhaustively by the
+// injectable unit tests in ticket-runs.test.ts; these tests prove the routes are
+// mounted, matched, and guarded.
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+let tmpDir: string;
+
+// A ticket id that definitively has no worker dir on this machine, so the route's
+// behavior is deterministic regardless of host state.
+const ABSENT_TICKET = "ZZZ-999999";
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "ticket-runs-endpoints-"));
+  const wtDir = join(tmpDir, "wt");
+  mkdirSync(wtDir, { recursive: true });
+  server = createServer({ port: 0, wtDir, startWatcher: false });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  void server?.stop(true);
+  if (tmpDir) {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+describe("GET /api/ticket-runs/:id (CTL-886)", () => {
+  it("returns 200 + JSON with the empty-history shape for a ticket with no worker dir", async () => {
+    const res = await fetch(`${baseUrl}/api/ticket-runs/${ABSENT_TICKET}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = (await res.json()) as { ticket: string; runs: unknown[] };
+    expect(body.ticket).toBe(ABSENT_TICKET);
+    expect(body.runs).toEqual([]);
+  });
+
+  it("rejects a malformed ticket id with 400 (no path traversal / arbitrary read)", async () => {
+    expect((await fetch(`${baseUrl}/api/ticket-runs/not-a-ticket`)).status).toBe(400);
+    expect((await fetch(`${baseUrl}/api/ticket-runs/CTL`)).status).toBe(400);
+    // an encoded traversal attempt never reaches the filesystem
+    expect((await fetch(`${baseUrl}/api/ticket-runs/..%2F..%2Fetc`)).status).toBe(400);
+  });
+});
+
+describe("GET /api/ec-worker/:ticket/:phase (CTL-886)", () => {
+  it("returns 404 when the phase has no signal on disk for that ticket", async () => {
+    const res = await fetch(`${baseUrl}/api/ec-worker/${ABSENT_TICKET}/implement`);
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects a malformed ticket id with 400", async () => {
+    expect((await fetch(`${baseUrl}/api/ec-worker/nope/implement`)).status).toBe(400);
+  });
+
+  it("rejects a malformed phase name with 400 (no traversal via the phase segment)", async () => {
+    // uppercase / digits / dots are not valid phase segments
+    expect((await fetch(`${baseUrl}/api/ec-worker/${ABSENT_TICKET}/Implement`)).status).toBe(400);
+    expect((await fetch(`${baseUrl}/api/ec-worker/${ABSENT_TICKET}/..%2Ftriage`)).status).toBe(400);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/ticket-runs.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ticket-runs.test.ts
@@ -1,0 +1,338 @@
+// CTL-886 (BFF4): unit tests for the run→worker identity layer. Encodes the
+// ticket's Gherkin acceptance scenarios against real on-disk fixtures (temp
+// worker dirs + a temp catalyst.db) — no live API, no network.
+//
+//   • "A ticket's full run history is queryable" — one run per phase signal;
+//      finished runs (no live BoardWorker) included; each carries model,
+//      bg_job_id, attempt, generation, status, startedAt/completedAt,
+//      host{name,id}, and pr{} when present.
+//   • "Per-phase PR and deploy detail come free from the signals" — PR + DEPLOY
+//      derived from phase-pr / phase-monitor-merge / phase-monitor-deploy; no
+//      live GitHub call.
+//   • "One run signal is served verbatim" — the raw phase-<phase>.json contents,
+//      untransformed.
+//   • "Cost/tokens/turns are joined, not invented" — cost comes from the
+//      catalyst.db join, null when no telemetry row (never a fabricated 0).
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { execFileSync } from "child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  assembleTicketRuns,
+  readPhaseSignalVerbatim,
+  toRunEntity,
+} from "../lib/ticket-runs.mjs";
+import { hostName, hostId } from "../lib/canonical-event-shared";
+
+let root: string;
+let workersDir: string;
+let dbPath: string;
+
+function writeSignal(ticket: string, phase: string, body: Record<string, unknown>) {
+  const dir = join(workersDir, ticket);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify(body));
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "ticket-runs-"));
+  workersDir = join(root, "workers");
+  mkdirSync(workersDir, { recursive: true });
+  dbPath = join(root, "catalyst.db");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("assembleTicketRuns — full run history (CTL-886)", () => {
+  it("returns one run entity per phase signal, in PHASE_ORDER", async () => {
+    writeSignal("CTL-845", "triage", { ticket: "CTL-845", phase: "triage", status: "done" });
+    writeSignal("CTL-845", "research", { ticket: "CTL-845", phase: "research", status: "done" });
+    writeSignal("CTL-845", "plan", { ticket: "CTL-845", phase: "plan", status: "done" });
+    writeSignal("CTL-845", "implement", { ticket: "CTL-845", phase: "implement", status: "done" });
+
+    const { ticket, runs } = await assembleTicketRuns("CTL-845", { workersDir, dbPath });
+    expect(ticket).toBe("CTL-845");
+    expect(runs.map((r) => r.phase)).toEqual(["triage", "research", "plan", "implement"]);
+  });
+
+  it("each run carries model, bg_job_id, attempt, generation, status, timestamps, host{name,id}", async () => {
+    writeSignal("CTL-845", "implement", {
+      ticket: "CTL-845",
+      phase: "implement",
+      status: "done",
+      model: "sonnet",
+      bg_job_id: "7238ca37",
+      attempt: 2,
+      generation: 1,
+      startedAt: "2026-06-07T07:59:10Z",
+      completedAt: "2026-06-07T08:22:23Z",
+      host: { name: "mini-1", id: "deadbeefdeadbeef" },
+    });
+    const { runs } = await assembleTicketRuns("CTL-845", { workersDir, dbPath });
+    const run = runs[0];
+    expect(run.model).toBe("sonnet");
+    expect(run.bg_job_id).toBe("7238ca37");
+    expect(run.attempt).toBe(2);
+    expect(run.generation).toBe(1);
+    expect(run.status).toBe("done");
+    expect(run.startedAt).toBe("2026-06-07T07:59:10Z");
+    expect(run.completedAt).toBe("2026-06-07T08:22:23Z");
+    expect(run.host).toEqual({ name: "mini-1", id: "deadbeefdeadbeef" });
+    // durationMs derived from start/complete
+    expect(run.durationMs).toBe(
+      Date.parse("2026-06-07T08:22:23Z") - Date.parse("2026-06-07T07:59:10Z"),
+    );
+  });
+
+  it("INCLUDES finished runs (no live BoardWorker) — reads signals, not the live-agent list", async () => {
+    // A phase that finished long ago: terminal status, completedAt set, no live
+    // agent anywhere. It MUST still surface as a run record.
+    writeSignal("CTL-845", "verify", {
+      ticket: "CTL-845",
+      phase: "verify",
+      status: "done",
+      startedAt: "2026-06-01T00:00:00Z",
+      completedAt: "2026-06-01T00:05:00Z",
+    });
+    const { runs } = await assembleTicketRuns("CTL-845", { workersDir, dbPath });
+    expect(runs).toHaveLength(1);
+    expect(runs[0].phase).toBe("verify");
+    expect(runs[0].status).toBe("done");
+  });
+
+  it("single-host identity NO-OP: signal without host defaults to this host's identity", async () => {
+    // Older signals predate CTL-852 host attribution — the single-node MVP
+    // defaults to THIS host (exact identity no-op), never invents a phantom host.
+    writeSignal("CTL-845", "plan", { ticket: "CTL-845", phase: "plan", status: "done" });
+    const { runs } = await assembleTicketRuns("CTL-845", { workersDir, dbPath });
+    expect(runs[0].host).toEqual({ name: hostName(), id: hostId() });
+  });
+
+  it("returns an empty run list (not a throw) when the ticket has no worker dir", async () => {
+    const { ticket, runs } = await assembleTicketRuns("CTL-999", { workersDir, dbPath });
+    expect(ticket).toBe("CTL-999");
+    expect(runs).toEqual([]);
+  });
+
+  it("skips phases with no signal file (only present signals become runs)", async () => {
+    writeSignal("CTL-845", "triage", { ticket: "CTL-845", phase: "triage", status: "done" });
+    writeSignal("CTL-845", "pr", { ticket: "CTL-845", phase: "pr", status: "done" });
+    const { runs } = await assembleTicketRuns("CTL-845", { workersDir, dbPath });
+    expect(runs.map((r) => r.phase)).toEqual(["triage", "pr"]);
+  });
+});
+
+describe("assembleTicketRuns — PR + deploy detail rides free from the signals (CTL-886)", () => {
+  it("derives PR detail from phase-pr.json (pr.{number,url}) verbatim", async () => {
+    writeSignal("CTL-845", "pr", {
+      ticket: "CTL-845",
+      phase: "pr",
+      status: "done",
+      pr: { number: 1434, url: "https://github.com/coalesce-labs/catalyst/pull/1434" },
+    });
+    const { runs } = await assembleTicketRuns("CTL-845", { workersDir, dbPath });
+    expect(runs[0].pr).toEqual({
+      number: 1434,
+      url: "https://github.com/coalesce-labs/catalyst/pull/1434",
+    });
+  });
+
+  it("derives full merge detail from phase-monitor-merge.json (mergedAt, ciStatus, mergeCommitSha)", async () => {
+    writeSignal("CTL-845", "monitor-merge", {
+      ticket: "CTL-845",
+      phase: "monitor-merge",
+      status: "done",
+      pr: {
+        number: 1434,
+        mergedAt: "2026-06-07T06:36:48Z",
+        ciStatus: "merged",
+        mergeCommitSha: "0098e484eb27fe7e78459b528ad56e32bf4618b2",
+      },
+    });
+    const { runs } = await assembleTicketRuns("CTL-845", { workersDir, dbPath });
+    expect(runs[0].pr).toEqual({
+      number: 1434,
+      mergedAt: "2026-06-07T06:36:48Z",
+      ciStatus: "merged",
+      mergeCommitSha: "0098e484eb27fe7e78459b528ad56e32bf4618b2",
+    });
+  });
+
+  it("surfaces the early draft-PR floor from phase-implement.json (draftPr.{number,url,isDraft})", async () => {
+    writeSignal("CTL-845", "implement", {
+      ticket: "CTL-845",
+      phase: "implement",
+      status: "done",
+      draftPr: { number: 1028, url: "https://example/pull/1028", isDraft: true },
+    });
+    const { runs } = await assembleTicketRuns("CTL-845", { workersDir, dbPath });
+    expect(runs[0].pr).toEqual({ number: 1028, url: "https://example/pull/1028", isDraft: true });
+  });
+
+  it("the DEPLOY card data is derived from phase-monitor-deploy.json", async () => {
+    writeSignal("CTL-845", "monitor-deploy", {
+      ticket: "CTL-845",
+      phase: "monitor-deploy",
+      status: "done",
+      pr: { number: 1434, mergeCommitSha: "abc123" },
+    });
+    const { runs } = await assembleTicketRuns("CTL-845", { workersDir, dbPath });
+    const deploy = runs.find((r) => r.phase === "monitor-deploy");
+    expect(deploy).toBeDefined();
+    expect(deploy?.pr).toEqual({ number: 1434, mergeCommitSha: "abc123" });
+  });
+
+  it("a phase with no PR shape carries pr:null (no empty stub)", async () => {
+    writeSignal("CTL-845", "research", { ticket: "CTL-845", phase: "research", status: "done" });
+    const { runs } = await assembleTicketRuns("CTL-845", { workersDir, dbPath });
+    expect(runs[0].pr).toBeNull();
+  });
+});
+
+describe("assembleTicketRuns — cost is JOINED, not invented (CTL-886)", () => {
+  function seedDb() {
+    execFileSync("sqlite3", [
+      dbPath,
+      `
+      CREATE TABLE sessions (
+        session_id TEXT PRIMARY KEY,
+        ticket_key TEXT,
+        skill_name TEXT
+      );
+      CREATE TABLE session_metrics (
+        session_id TEXT PRIMARY KEY,
+        cost_usd REAL DEFAULT 0,
+        input_tokens INTEGER DEFAULT 0,
+        output_tokens INTEGER DEFAULT 0,
+        num_turns INTEGER DEFAULT 0
+      );
+      INSERT INTO sessions VALUES ('s1','CTL-845','phase-implement');
+      INSERT INTO session_metrics VALUES ('s1',0.50,2000,1000,42);
+      `,
+    ]);
+  }
+
+  it("per-run cost comes from the catalyst.db join, never the signal", async () => {
+    seedDb();
+    // The signal itself carries NO cost — only identity/timestamp/status.
+    writeSignal("CTL-845", "implement", {
+      ticket: "CTL-845",
+      phase: "implement",
+      status: "done",
+    });
+    const { runs } = await assembleTicketRuns("CTL-845", { workersDir, dbPath });
+    expect(runs[0].cost).toEqual({ costUSD: 0.5, tokens: 3000, turns: 42 });
+  });
+
+  it("a run with no telemetry row gets cost:null (no fabricated zero)", async () => {
+    seedDb(); // db has a row for implement only
+    writeSignal("CTL-845", "research", { ticket: "CTL-845", phase: "research", status: "done" });
+    const { runs } = await assembleTicketRuns("CTL-845", { workersDir, dbPath });
+    expect(runs[0].cost).toBeNull();
+  });
+
+  it("cost stays null when the catalyst.db is absent entirely", async () => {
+    // dbPath points at a non-existent file — no join, no throw, no fabrication.
+    writeSignal("CTL-845", "implement", { ticket: "CTL-845", phase: "implement", status: "done" });
+    const { runs } = await assembleTicketRuns("CTL-845", {
+      workersDir,
+      dbPath: join(root, "does-not-exist.db"),
+    });
+    expect(runs[0].cost).toBeNull();
+  });
+});
+
+describe("readPhaseSignalVerbatim — one signal served verbatim (CTL-886)", () => {
+  it("returns the raw phase-<phase>.json contents untransformed", async () => {
+    const body = {
+      ticket: "CTL-845",
+      phase: "implement",
+      orchestrator: "CTL-845",
+      model: "sonnet",
+      turnCap: 75,
+      status: "done",
+      bg_job_id: "7238ca37",
+      generation: 1,
+      attempt: 1,
+      startedAt: "2026-06-07T07:59:10Z",
+      completedAt: "2026-06-07T08:22:23Z",
+      host: { name: "mini-1", id: "deadbeefdeadbeef" },
+      pr: { number: 1028, url: "https://example/pull/1028" },
+    };
+    writeSignal("CTL-845", "implement", body);
+    const signal = await readPhaseSignalVerbatim("CTL-845", "implement", { workersDir });
+    // Byte-for-byte the same object the agent wrote — nothing added/dropped.
+    expect(signal).toEqual(body);
+  });
+
+  it("returns null when the phase has no signal on disk", async () => {
+    const signal = await readPhaseSignalVerbatim("CTL-845", "implement", { workersDir });
+    expect(signal).toBeNull();
+  });
+
+  it("returns null for a phase name outside the canonical pipeline (no path traversal)", async () => {
+    writeSignal("CTL-845", "implement", { ticket: "CTL-845", phase: "implement", status: "done" });
+    // an unknown / malicious phase string is rejected before any file read
+    expect(await readPhaseSignalVerbatim("CTL-845", "../triage", { workersDir })).toBeNull();
+    expect(await readPhaseSignalVerbatim("CTL-845", "bogus", { workersDir })).toBeNull();
+  });
+});
+
+describe("toRunEntity — field mapping (CTL-886)", () => {
+  it("maps a verbatim signal to a run entity and joins the supplied cost row", () => {
+    const run = toRunEntity(
+      "implement",
+      {
+        ticket: "CTL-845",
+        phase: "implement",
+        status: "done",
+        model: "opus",
+        bg_job_id: "abc",
+        attempt: 1,
+        generation: 2,
+        orchestrator: "CTL-845",
+        startedAt: "2026-06-07T00:00:00Z",
+        completedAt: "2026-06-07T00:10:00Z",
+        updatedAt: "2026-06-07T00:10:00Z",
+        worktreePath: "/wt/CTL-845",
+        catalystSessionId: "sess_xyz",
+        host: { name: "h", id: "abcd000000000000" },
+        pr: { number: 7 },
+      },
+      { costUSD: 1.23, tokens: 100, turns: 9 },
+    );
+    expect(run).toEqual({
+      ticket: "CTL-845",
+      phase: "implement",
+      status: "done",
+      model: "opus",
+      bg_job_id: "abc",
+      attempt: 1,
+      generation: 2,
+      orchestrator: "CTL-845",
+      startedAt: "2026-06-07T00:00:00Z",
+      completedAt: "2026-06-07T00:10:00Z",
+      updatedAt: "2026-06-07T00:10:00Z",
+      durationMs: 600000,
+      host: { name: "h", id: "abcd000000000000" },
+      worktreePath: "/wt/CTL-845",
+      sessionId: "sess_xyz",
+      pr: { number: 7 },
+      cost: { costUSD: 1.23, tokens: 100, turns: 9 },
+    });
+  });
+
+  it("collapses a clock-skewed (end < start) duration to null, not a negative", () => {
+    const run = toRunEntity("verify", {
+      ticket: "CTL-1",
+      phase: "verify",
+      status: "done",
+      startedAt: "2026-06-07T00:10:00Z",
+      completedAt: "2026-06-07T00:00:00Z",
+    });
+    expect(run.durationMs).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/ticket-runs.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/ticket-runs.d.mts
@@ -1,0 +1,74 @@
+// Type declarations for ticket-runs.mjs (CTL-886, BFF4) — the run→worker
+// identity layer. Lets the typechecked TS server (server.ts) import
+// assembleTicketRuns / readPhaseSignalVerbatim without a TS7016 implicit-any
+// error. Keep in sync with the objects assembled in ticket-runs.mjs.
+
+/** Host attribution for a run (single-host identity no-op default — CTL-886). */
+export interface RunHost {
+  name: string;
+  id: string;
+}
+
+/** Per-run cost, JOINED from catalyst.db (never fabricated onto the signal). */
+export interface RunCost {
+  costUSD: number;
+  tokens: number;
+  turns: number;
+}
+
+/**
+ * One phase-agent execution surfaced as a RUN entity. Identity + timestamp
+ * fields are carried straight through from the phase-<phase>.json signal; `host`
+ * is resolved (signal value or single-host default); `pr` is the signal's own
+ * verbatim PR shape (null when the phase carries none); `cost` is the joined
+ * telemetry row or null.
+ */
+export interface TicketRun {
+  ticket: string | null;
+  phase: string;
+  status: string;
+  model: string | null;
+  bg_job_id: string | null;
+  attempt: number | null;
+  generation: number | null;
+  orchestrator: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  updatedAt: string | null;
+  durationMs: number | null;
+  host: RunHost;
+  worktreePath: string | null;
+  sessionId: string | null;
+  /** Verbatim PR shape from the signal (phase-pr / monitor-merge / deploy / draftPr). */
+  pr: Record<string, unknown> | null;
+  /** Joined per-phase cost from catalyst.db, or null when no telemetry row. */
+  cost: RunCost | null;
+}
+
+/** A ticket's full run history — one run per phase-*.json signal on disk. */
+export interface TicketRuns {
+  ticket: string;
+  runs: TicketRun[];
+}
+
+export interface TicketRunsOptions {
+  workersDir?: string;
+  dbPath?: string;
+}
+
+export function toRunEntity(
+  phase: string,
+  sig: Record<string, unknown>,
+  costRow?: RunCost,
+): TicketRun;
+
+export function assembleTicketRuns(
+  ticket: string,
+  options?: TicketRunsOptions,
+): Promise<TicketRuns>;
+
+export function readPhaseSignalVerbatim(
+  ticket: string,
+  phase: string,
+  options?: { workersDir?: string },
+): Promise<Record<string, unknown> | null>;

--- a/plugins/dev/scripts/orch-monitor/lib/ticket-runs.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/ticket-runs.mjs
@@ -1,0 +1,225 @@
+// ticket-runs.mjs — surface every phase-agent execution as a real RUN entity
+// (CTL-886, BFF4 — the design's named keystone P2 + its companion P3).
+//
+// The structural gap this closes: BoardPayload carries `phaseSummary`
+// (per-phase timing, NO worker identity — board-data.d.mts BoardPhaseTiming) and
+// `BoardWorker` (board-data.mjs liveAgents → `kind==="background"` only, i.e.
+// LIVE bg agents). A phase that finished 2h ago has a `phase-*.json` signal on
+// disk but NO BoardWorker. The RUNS rail, per-phase PR detail, the DEPLOY card,
+// finished-run worker pages, and the finished-run peek all need a run→worker
+// identity that does not exist today.
+//
+// This module reads every
+//   ~/catalyst/execution-core/workers/<TICKET>/phase-*.json
+// signal as a queryable RUN RECORD (model, bg_job_id, attempt, generation,
+// status, startedAt/completedAt, host{name,id}, pr{} when present). FINISHED runs
+// (no live BoardWorker) are included, not just live ones — that is the whole
+// point. A companion entry serves ONE phase signal VERBATIM for the worker
+// header / timestamps / SIGNAL panel.
+//
+// READ-ONLY, durable-cache-only: pure file reads of resident signals + a single
+// grouped catalyst.db join for per-phase cost. NO live Linear / GitHub call is
+// ever made per request — PR + deploy detail ride free off the signals the
+// phase-pr / phase-monitor-merge / phase-monitor-deploy agents already wrote.
+//
+// Cost/tokens/turns are JOINED, never invented onto the signal: phase signals
+// carry no cost field (verified), so per-run cost comes from the telemetry /
+// catalyst.db join (board-data.mjs::costByPhase). A run with no telemetry row
+// gets `cost: null`, never a fabricated zero stamped on the signal.
+
+import { execFile } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { PHASE_ORDER } from "./board-data.mjs";
+import { hostName, hostId } from "./canonical-event-shared.ts";
+
+const execFileP = promisify(execFile);
+
+const HOME = homedir();
+const DEFAULT_WORKERS_DIR = join(HOME, "catalyst", "execution-core", "workers");
+const DEFAULT_DB = join(HOME, "catalyst", "catalyst.db");
+
+async function readJSON(path) {
+  try {
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function exists(p) {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Single-host identity NO-OP default (CTL-886 single-node MVP). Newer signals
+// carry `host:{name,id}` (CTL-852 phase-agent-dispatch); older on-disk signals
+// predate it. When the signal omits host, default to THIS host's identity via the
+// shared host-identity algorithm (canonical-event-shared.ts hostName/hostId,
+// byte-identical to lib/host-identity.sh + execution-core/lib/host-identity.mjs).
+// For a single-host deployment this is an exact identity no-op — every run is
+// attributed to the one node, zero added latency. A real multi-node fan-in
+// (BFF3) is out of scope; this keeps the RUNS rail node-aware (consistent with
+// BFF2) without inventing a host the signal never recorded.
+function resolveHost(sig) {
+  const h = sig && typeof sig === "object" ? sig.host : null;
+  if (h && typeof h === "object" && typeof h.name === "string" && h.name) {
+    return { name: h.name, id: typeof h.id === "string" && h.id ? h.id : hostId({ override: h.name }) };
+  }
+  const name = hostName();
+  return { name, id: hostId() };
+}
+
+// Derive this run's PR detail from its OWN signal, verbatim. The phase agents
+// already wrote everything the UI needs:
+//   • phase-pr.json          → pr.{number,url}
+//   • phase-implement.json    → draftPr.{number,url,isDraft}  (early PR floor)
+//   • phase-monitor-merge.json → pr.{number,mergedAt,ciStatus,mergeCommitSha}
+//   • phase-monitor-deploy.json → pr/deploy detail for the DEPLOY card
+// No GitHub call — the signal IS the source. Returns null when the phase carries
+// no PR shape (most phases don't), so the UI can hide the PR cell rather than
+// render an empty stub.
+function prFromSignal(sig) {
+  if (!sig || typeof sig !== "object") return null;
+  if (sig.pr && typeof sig.pr === "object" && sig.pr.number != null) return sig.pr;
+  if (sig.draftPr && typeof sig.draftPr === "object" && sig.draftPr.number != null) {
+    return sig.draftPr;
+  }
+  return null;
+}
+
+function finiteDate(s) {
+  if (typeof s !== "string" || !s) return null;
+  const t = Date.parse(s);
+  return Number.isFinite(t) ? t : null;
+}
+
+// durationMs for a run — completedAt − startedAt when both parse and the result
+// is non-negative; null otherwise (mirrors buildPhaseSummary's "unknown" rather
+// than laundering a clock-skewed negative as a clean zero). A run still in flight
+// (no completedAt) yields null here — the live elapsed clock is the UI's job off
+// the live BoardWorker, not a now-anchored runaway baked into a run record.
+function runDurationMs(sig) {
+  const start = finiteDate(sig?.startedAt);
+  const end = finiteDate(sig?.completedAt);
+  if (start == null || end == null) return null;
+  return end >= start ? end - start : null;
+}
+
+// ── per-phase cost join (catalyst.db / telemetry) ───────────────────────────
+// Grouped query lifted from board-data.mjs::costByPhase — sessions ⋈
+// session_metrics, scoped to ONE ticket's `phase-%` skills. Returns
+// { [phase]: {costUSD, tokens, turns} } or {} when the db is absent / has no
+// rows. This is the ONLY place cost enters a run record; signals never carry it.
+async function costByPhaseForTicket(ticket, dbPath) {
+  const map = {};
+  if (!ticket || !(await exists(dbPath))) return map;
+  try {
+    // Bind the ticket as a NAMED sqlite parameter (@t) rather than interpolating
+    // it into the SQL — no injection surface regardless of the ticket string.
+    // (`.param set` only supports named params, not positional `?`.)
+    const sql =
+      "SELECT s.skill_name, ROUND(COALESCE(SUM(m.cost_usd),0),4), " +
+      "COALESCE(SUM(m.input_tokens+m.output_tokens),0), COALESCE(SUM(m.num_turns),0) " +
+      "FROM sessions s JOIN session_metrics m ON m.session_id=s.session_id " +
+      "WHERE s.ticket_key=@t AND s.skill_name LIKE 'phase-%' " +
+      "GROUP BY s.skill_name;";
+    const { stdout } = await execFileP(
+      "sqlite3",
+      ["-separator", "\t", "-cmd", `.param set @t ${JSON.stringify(ticket)}`, dbPath, sql],
+      { encoding: "utf8", timeout: 8000, maxBuffer: 8 * 1024 * 1024 },
+    );
+    for (const line of stdout.trim().split("\n")) {
+      if (!line) continue;
+      const [skill, cost, tokens, turns] = line.split("\t");
+      const phase = skill.replace(/^phase-/, "");
+      map[phase] = {
+        costUSD: Number(cost) || 0,
+        tokens: Number(tokens) || 0,
+        turns: Number(turns) || 0,
+      };
+    }
+  } catch {
+    /* sqlite missing or schema pre-migration — cost stays null per run */
+  }
+  return map;
+}
+
+// Build ONE run entity from a phase signal. `costRow` is the joined telemetry for
+// this phase (or undefined → cost:null, never a fabricated 0). Carries the signal
+// identity fields straight through (model, bg_job_id, attempt, generation,
+// status, timestamps, orchestrator, worktreePath, sessionId), the resolved host,
+// the verbatim PR shape, and the joined cost.
+export function toRunEntity(phase, sig, costRow) {
+  return {
+    ticket: typeof sig.ticket === "string" ? sig.ticket : null,
+    phase,
+    status: typeof sig.status === "string" ? sig.status : "unknown",
+    model: typeof sig.model === "string" ? sig.model : null,
+    bg_job_id: sig.bg_job_id ?? null,
+    attempt: typeof sig.attempt === "number" ? sig.attempt : null,
+    generation: typeof sig.generation === "number" ? sig.generation : null,
+    orchestrator: typeof sig.orchestrator === "string" ? sig.orchestrator : null,
+    startedAt: typeof sig.startedAt === "string" ? sig.startedAt : null,
+    completedAt: typeof sig.completedAt === "string" ? sig.completedAt : null,
+    updatedAt: typeof sig.updatedAt === "string" ? sig.updatedAt : null,
+    durationMs: runDurationMs(sig),
+    host: resolveHost(sig),
+    worktreePath: typeof sig.worktreePath === "string" ? sig.worktreePath : null,
+    sessionId:
+      typeof sig.catalystSessionId === "string"
+        ? sig.catalystSessionId
+        : typeof sig.sessionId === "string"
+          ? sig.sessionId
+          : null,
+    pr: prFromSignal(sig),
+    // Joined, never invented: undefined telemetry row → null (no fabricated 0).
+    cost: costRow ?? null,
+  };
+}
+
+// ── keystone: a ticket's full run history ───────────────────────────────────
+// assembleTicketRuns(ticket) — one run entity per phase-*.json signal under the
+// ticket's worker dir, in canonical PHASE_ORDER. Finished runs (no live
+// BoardWorker) are included by construction — we read the signal files, not the
+// live-agent list. Each run carries the joined per-phase cost. No live API.
+export async function assembleTicketRuns(
+  ticket,
+  { workersDir = DEFAULT_WORKERS_DIR, dbPath = DEFAULT_DB } = {},
+) {
+  const dir = join(workersDir, ticket);
+  if (!(await exists(dir))) return { ticket, runs: [] };
+  const [sigs, costByPhase] = await Promise.all([
+    Promise.all(
+      PHASE_ORDER.map((p) => readJSON(join(dir, `phase-${p}.json`)).then((s) => [p, s])),
+    ),
+    costByPhaseForTicket(ticket, dbPath),
+  ]);
+  const runs = [];
+  for (const [phase, sig] of sigs) {
+    if (!sig || typeof sig !== "object") continue;
+    runs.push(toRunEntity(phase, sig, costByPhase[phase]));
+  }
+  return { ticket, runs };
+}
+
+// ── companion P3: one run signal served VERBATIM ────────────────────────────
+// readPhaseSignalVerbatim(ticket, phase) — the raw phase-<phase>.json contents,
+// parsed but UNTRANSFORMED (model, bg_job_id, generation, status, timestamps,
+// host, pr — exactly as the agent wrote them). Powers the worker header,
+// PHASE TIMESTAMPS, and the SIGNAL panel. Returns null when the phase has no
+// signal (so the route can 404 instead of serving an empty object).
+export async function readPhaseSignalVerbatim(
+  ticket,
+  phase,
+  { workersDir = DEFAULT_WORKERS_DIR } = {},
+) {
+  if (!ticket || !phase || !PHASE_ORDER.includes(phase)) return null;
+  return readJSON(join(workersDir, ticket, `phase-${phase}.json`));
+}

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -13,6 +13,14 @@ import { readSessionStore } from "./lib/session-store";
 import { readReconcileHealth } from "./lib/reconcile-health-reader"; // CTL-867
 import type { BoardPayload } from "./lib/board-data.mjs";
 import { createBoardSnapshotManager } from "./lib/board-snapshot.mjs";
+// CTL-886 (BFF4): run→worker identity — surface every phase-*.json signal as a
+// queryable run entity (/api/ticket-runs/<id>) + serve one signal verbatim
+// (/api/ec-worker/<ticket>/<phase>). Pure file-reads of resident signals — no
+// live Linear/GitHub call per request.
+import {
+  assembleTicketRuns,
+  readPhaseSignalVerbatim,
+} from "./lib/ticket-runs.mjs";
 import { queryHistory, queryStats, compareSessions } from "./lib/history-store";
 import {
   listArchivedOrchestrators,
@@ -1814,6 +1822,56 @@ export function createServer(opts: CreateServerOptions): BunServer {
             eventCount24h: stats.eventCount24h,
             eventCount24hByRepo: stats.eventCount24hByRepo,
           });
+        }
+
+        // CTL-886 (BFF4) keystone P2: a ticket's full run history. One run entity
+        // per phase-*.json signal under ~/catalyst/execution-core/workers/<id>/
+        // (model, bg_job_id, attempt, generation, status, timestamps, host{},
+        // pr{} when present). FINISHED runs (no live BoardWorker) included by
+        // construction — we read the on-disk signals, not the live-agent list.
+        // Per-phase cost is JOINED from catalyst.db, never invented onto the
+        // signal. Pure file reads — no live Linear/GitHub call.
+        const ticketRunsMatch = url.pathname.match(/^\/api\/ticket-runs\/([^/]+)$/);
+        if (ticketRunsMatch) {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(ticketRunsMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          return Response.json(await assembleTicketRuns(ticket));
+        }
+
+        // CTL-886 (BFF4) companion P3: one phase signal served VERBATIM — the raw
+        // phase-<phase>.json contents (model, bg_job_id, generation, status,
+        // timestamps, host, pr) untransformed, for the worker header / PHASE
+        // TIMESTAMPS / SIGNAL panel. 404 when the phase has no signal on disk.
+        const ecWorkerMatch = url.pathname.match(
+          /^\/api\/ec-worker\/([^/]+)\/([^/]+)$/,
+        );
+        if (ecWorkerMatch) {
+          let ticket: string;
+          let phase: string;
+          try {
+            ticket = decodeURIComponent(ecWorkerMatch[1]);
+            phase = decodeURIComponent(ecWorkerMatch[2]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            !/^[A-Za-z]+-\d+$/.test(ticket) ||
+            !/^[a-z][a-z-]*$/.test(phase)
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const signal = await readPhaseSignalVerbatim(ticket, phase);
+          if (!signal) {
+            return new Response("Not Found", { status: 404 });
+          }
+          return Response.json(signal);
         }
 
         if (url.pathname === "/api/board") {


### PR DESCRIPTION
## What

Surfaces every `~/catalyst/execution-core/workers/<TICKET>/phase-*.json` signal as a queryable **run→worker identity** — the design's named keystone (P2) plus its companion (P3). Closes the structural gap where `BoardPayload` carries `phaseSummary` (per-phase timing, no worker identity) and `BoardWorker` (live bg agents only), so a phase that finished hours ago has a signal on disk but **no run record**.

### New module — `lib/ticket-runs.mjs` (+ `.d.mts`)
- `assembleTicketRuns(ticket)` — one run entity per phase signal, in `PHASE_ORDER`, each carrying `model, bg_job_id, attempt, generation, status, startedAt/completedAt, durationMs, host{name,id}, orchestrator, worktreePath, sessionId, pr{}, cost`. Finished runs (no live `BoardWorker`) are included **by construction** — it reads the on-disk signals, not the live-agent list.
- `readPhaseSignalVerbatim(ticket, phase)` — one signal served untransformed.

### Two routes mounted on `server.ts` (pure file reads — no live Linear/GitHub per request)
- `GET /api/ticket-runs/<id>`
- `GET /api/ec-worker/<ticket>/<phase>`

PR + DEPLOY detail ride **free** off the signals the phase agents already wrote (`phase-pr` → `pr.{number,url}`, `phase-monitor-merge` → `pr.{number,mergedAt,ciStatus,mergeCommitSha}`, `phase-monitor-deploy` → DEPLOY card, `phase-implement.draftPr` → early floor). Cost/tokens/turns are **joined** from `catalyst.db` (the `board-data` `costByPhase` pattern, ticket bound as a named sqlite param), `null` when no telemetry row — never fabricated onto the signal.

## Gherkin scenarios

| Scenario | Status |
| --- | --- |
| **A ticket's full run history is queryable** — one run per phase signal; each carries model/bg_job_id/attempt/generation/status/timestamps/host{name,id}/pr{} when present; **finished runs included, not just live ones** | ✅ satisfied |
| **Per-phase PR and deploy detail come free from the signals** — PR detail + DEPLOY data derived from `phase-pr`/`phase-monitor-merge`/`phase-monitor-deploy`; **no live GitHub call** per request | ✅ satisfied |
| **One run signal is served verbatim** — `GET /api/ec-worker/<t>/<phase>` returns the `phase-<phase>.json` contents byte-for-byte | ✅ satisfied |
| **Cost/tokens/turns are joined, not invented** — per-run cost comes from the `catalyst.db` telemetry join; `null` (never a fabricated 0) when absent | ✅ satisfied |

## Single-node descope (operator constraint)

Per the single-node MVP, `host{name,id}` is taken from the signal when present (CTL-852 `phase-agent-dispatch` stamps it) and otherwise **defaults to this host's identity** via the shared `canonical-event-shared` `hostName`/`hostId` algorithm — an exact **identity no-op** for a single-host deployment, keeping the RUNS rail node-aware (consistent with BFF2) at zero added latency. The multi-node cross-host fan-in (BFF3) is **descoped**; there is no N>1 host-discovery path here.

## Tests (run locally — repo CI has no unit-test gate)

- `__tests__/ticket-runs.test.ts` — 19 tests, injectable `workersDir`/`dbPath` (no network), encoding all 4 Gherkin scenarios + single-host default + clock-skew duration collapse + cost-join-vs-null.
- `__tests__/ticket-runs-endpoints.test.ts` — 5 tests, route plumbing via `createServer`: empty-history 200 shape, 400 on malformed ticket/phase (no path traversal), 404 on a phase with no signal.

```
bun test __tests__/ticket-runs.test.ts __tests__/ticket-runs-endpoints.test.ts   # 24 pass / 0 fail
bunx tsc --noEmit                                                                  # clean (orch-monitor root)
```

(The pre-existing `ui/kpi-strip.tsx` + `ui/briefings.ts` tsc errors are unmodified on `origin/main` and untouched by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)