### PR TITLE
feat(dev): FND2 resolveList() + jotai nav store (CTL-882)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/list-order.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/list-order.test.ts
@@ -1,0 +1,239 @@
+// list-order.test.ts — units for the P1 keystone correctness item (CTL-882 /
+// FND2): the SINGLE ordering source shared by the board, the detail-page pager
+// (`N / total`), and the j/k walk. These encode the FND2 Gherkin acceptance
+// scenarios against the PURE module ui/src/board/list-order.ts — no React /
+// jotai / router needed (same pattern as route-search.test.ts / board-client
+// .test.ts, which unit the pure ui/src/board helpers directly).
+//
+// The whole point of the extraction is that the board renders through
+// `resolveList` and the shell walks through `resolveList`, so the on-screen card
+// order can never silently drift from the pager/j-k order. The "byte-for-byte
+// identical to today's order" scenarios below lock that in by reproducing the
+// two prior inline orderings (Board.tsx:362 ticket filter, Board.tsx:441-442
+// worker rank-sort) and asserting `resolveList` matches them exactly.
+import { describe, it, expect } from "bun:test";
+import {
+  resolveList,
+  resolveListIds,
+  filterTickets,
+  sortWorkers,
+  rankWorker,
+} from "../ui/src/board/list-order";
+import type {
+  BoardPayload,
+  BoardTicket,
+  BoardWorker,
+  BoardActiveState,
+} from "../ui/src/board/types";
+
+// ── minimal fixtures (only the fields the orderings read) ───────────────────
+function mkTicket(id: string, over: Partial<BoardTicket> = {}): BoardTicket {
+  return {
+    id,
+    title: id,
+    type: "feature",
+    repo: "catalyst",
+    team: "CTL",
+    phase: "implement",
+    status: "active",
+    model: null,
+    linearState: "Implement",
+    workerStatus: null,
+    activeState: null,
+    working: false,
+    lastActiveMs: null,
+    priority: 2,
+    estimate: null,
+    scope: null,
+    project: null,
+    costUSD: null,
+    tokens: null,
+    turns: null,
+    phaseCosts: null,
+    phaseSummary: [],
+    pr: null,
+    updatedAt: "",
+    ...over,
+  };
+}
+
+function mkWorker(
+  name: string,
+  activeState: BoardActiveState,
+  runtimeMs: number | null,
+  over: Partial<BoardWorker> = {},
+): BoardWorker {
+  return {
+    name,
+    ticket: name,
+    tickets: [name],
+    phase: "implement",
+    status: "working",
+    activeState,
+    working: activeState === "active",
+    lastActiveMs: null,
+    repo: "catalyst",
+    team: "CTL",
+    runtimeMs,
+    costUSD: null,
+    ...over,
+  };
+}
+
+function mkPayload(over: Partial<BoardPayload> = {}): BoardPayload {
+  return {
+    generatedAt: "",
+    config: { maxParallel: 0, inFlight: 0, freeSlots: 0, active: 0, working: 0, stuck: 0 },
+    repos: [],
+    workers: [],
+    tickets: [],
+    queue: [],
+    ...over,
+  };
+}
+
+// The literal prior inline orderings, kept verbatim so the tests assert against
+// the OLD behaviour rather than re-implementing the new one.
+function legacyTicketFilter(
+  tickets: BoardTicket[],
+  lens: "linear" | "phase",
+  col: string,
+): BoardTicket[] {
+  return lens === "linear"
+    ? tickets.filter((t) => t.linearState === col)
+    : tickets.filter((t) => t.phase === col);
+}
+function legacyWorkerSort(workers: BoardWorker[]): BoardWorker[] {
+  const isActive = (s: BoardActiveState) => s === "active";
+  const rank = (w: BoardWorker) => (isActive(w.activeState) ? 0 : w.activeState === "stuck" ? 2 : 1);
+  return [...workers].sort((a, b) => rank(a) - rank(b) || (b.runtimeMs ?? 0) - (a.runtimeMs ?? 0));
+}
+
+describe("resolveList — ticket columns (the board renders through resolveList)", () => {
+  // Gherkin: "The board renders through resolveList" — TicketBoard builds a
+  // Linear column for col="Implement" by calling
+  // resolveList(payload, {kind:"ticket", lens:"linear", col:"Implement"}); the
+  // rendered card order is byte-for-byte identical to today's (filter on
+  // linearState, payload array order preserved).
+  const tickets = [
+    mkTicket("CTL-845", { linearState: "Implement", phase: "implement" }),
+    mkTicket("CTL-831", { linearState: "PR", phase: "pr" }),
+    mkTicket("CTL-877", { linearState: "Implement", phase: "verify" }),
+    mkTicket("CTL-878", { linearState: "Research", phase: "research" }),
+    mkTicket("CTL-880", { linearState: "Implement", phase: "implement" }),
+  ];
+  const payload = mkPayload({ tickets });
+
+  it("filters a Linear column on linearState, payload array order preserved", () => {
+    const got = resolveList(payload, { kind: "ticket", lens: "linear", col: "Implement" });
+    expect(got.map((t) => (t as BoardTicket).id)).toEqual(["CTL-845", "CTL-877", "CTL-880"]);
+  });
+
+  it("is byte-for-byte identical to the prior inline linear filter (Board.tsx:362)", () => {
+    const got = resolveList(payload, { kind: "ticket", lens: "linear", col: "Implement" });
+    expect(got).toEqual(legacyTicketFilter(tickets, "linear", "Implement"));
+  });
+
+  it("filters a phase column on phase when lens === 'phase'", () => {
+    const got = resolveList(payload, { kind: "ticket", lens: "phase", col: "implement" });
+    expect(got.map((t) => (t as BoardTicket).id)).toEqual(["CTL-845", "CTL-880"]);
+    expect(got).toEqual(legacyTicketFilter(tickets, "phase", "implement"));
+  });
+
+  it("defaults to the linear lens when lens is omitted", () => {
+    const got = resolveList(payload, { kind: "ticket", col: "Implement" });
+    expect(got).toEqual(legacyTicketFilter(tickets, "linear", "Implement"));
+  });
+
+  it("resolves an empty list (never throws) for a cold-link with no column", () => {
+    expect(resolveList(payload, { kind: "ticket", lens: "linear", col: undefined })).toEqual([]);
+    expect(filterTickets(tickets, "linear", undefined)).toEqual([]);
+  });
+
+  it("does not mutate the payload's ticket array", () => {
+    const snapshot = tickets.map((t) => t.id);
+    resolveList(payload, { kind: "ticket", lens: "linear", col: "Implement" });
+    expect(tickets.map((t) => t.id)).toEqual(snapshot);
+  });
+});
+
+describe("resolveList — worker queue (rank-sort preserved through the same fn)", () => {
+  // Gherkin: "Worker rank-sort is preserved through the same function" — when
+  // resolveList is called with {kind:"worker"} it returns workers ordered by
+  // rank(active=0, stuck=2, else=1) then runtimeMs descending, matching the
+  // existing inline sort at Board.tsx:441-442.
+  const workers = [
+    mkWorker("w-stuck", "stuck", 5000),
+    mkWorker("w-active-short", "active", 1000),
+    mkWorker("w-idle", null, 9000),
+    mkWorker("w-active-long", "active", 8000),
+    mkWorker("w-stuck-long", "stuck", 9999),
+  ];
+  const payload = mkPayload({ workers });
+
+  it("orders by rank then runtimeMs desc", () => {
+    const got = resolveList(payload, { kind: "worker" }) as BoardWorker[];
+    expect(got.map((w) => w.name)).toEqual([
+      "w-active-long", // active, 8000
+      "w-active-short", // active, 1000
+      "w-idle", // else, 9000
+      "w-stuck-long", // stuck, 9999
+      "w-stuck", // stuck, 5000
+    ]);
+  });
+
+  it("is byte-for-byte identical to the prior inline sort (Board.tsx:441-442)", () => {
+    const got = resolveList(payload, { kind: "worker" });
+    expect(got).toEqual(legacyWorkerSort(workers));
+  });
+
+  it("rankWorker matches active=0 / stuck=2 / else=1", () => {
+    expect(rankWorker(mkWorker("a", "active", 0))).toBe(0);
+    expect(rankWorker(mkWorker("b", null, 0))).toBe(1);
+    expect(rankWorker(mkWorker("c", "stuck", 0))).toBe(2);
+  });
+
+  it("treats a null runtimeMs as 0 in the tie-break", () => {
+    const ws = [mkWorker("nullrt", "active", null), mkWorker("hasrt", "active", 10)];
+    expect(sortWorkers(ws).map((w) => w.name)).toEqual(["hasrt", "nullrt"]);
+  });
+
+  it("does not mutate the payload's worker array", () => {
+    const snapshot = workers.map((w) => w.name);
+    sortWorkers(workers);
+    expect(workers.map((w) => w.name)).toEqual(snapshot);
+  });
+});
+
+describe("resolveListIds — the id list the pager + j/k bind to", () => {
+  // Gherkin: "The pager and the board agree (the correctness contract)" — the
+  // shell resolves the list via resolveList with the SAME ctx, so indexOf($id)+1
+  // and the list length equal what the operator counted on the board.
+  it("ticket ids equal the resolved column's ids, in order", () => {
+    const tickets = [
+      mkTicket("CTL-845", { linearState: "Implement" }),
+      mkTicket("CTL-877", { linearState: "Implement" }),
+      mkTicket("CTL-880", { linearState: "Implement" }),
+    ];
+    const payload = mkPayload({ tickets });
+    const ctx = { kind: "ticket" as const, lens: "linear" as const, col: "Implement" };
+    const ids = resolveListIds(payload, ctx);
+    expect(ids).toEqual(["CTL-845", "CTL-877", "CTL-880"]);
+    // The correctness contract: indexOf+1 / length the operator counted.
+    expect(ids.indexOf("CTL-877") + 1).toBe(2);
+    expect(ids.length).toBe(3);
+    // And the ids are exactly resolveList(...).map(id) — one source.
+    const list = resolveList(payload, ctx) as BoardTicket[];
+    expect(list.map((t) => t.id)).toEqual(ids);
+  });
+
+  it("worker ids are BoardWorker.name in the rank-sorted order", () => {
+    const workers = [
+      mkWorker("w-stuck", "stuck", 1),
+      mkWorker("w-active", "active", 1),
+    ];
+    const payload = mkPayload({ workers });
+    const ids = resolveListIds(payload, { kind: "worker" });
+    expect(ids).toEqual(["w-active", "w-stuck"]);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/recents.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/recents.test.ts
@@ -1,0 +1,82 @@
+// recents.test.ts — units for the recency-merge behind the ⌘K RECENT group +
+// `recentlyViewedAtom` persistence (CTL-882 / FND2). Tests the PURE helper
+// ui/src/board/recents.ts (jotai-free), so they run in the main `bun test`
+// suite without a jotai / localStorage runtime — the atom wiring in nav-store.ts
+// calls this exact helper, so the persisted list can't drift from these units.
+//
+// Encodes the FND2 Gherkin "Recently-viewed survives a reload": visit CTL-845
+// then CTL-831 then reload → recentlyViewedAtom still lists CTL-831 and CTL-845
+// in recency order. atomWithStorage handles the literal localStorage round-trip
+// (asserted from the ui module graph in nav-store.test.ts); what makes the
+// reload *correct* is that `pushRecent` keeps the list most-recent-first and
+// de-duped, which is what these units lock in.
+import { describe, it, expect } from "bun:test";
+import { pushRecent, RECENTLY_VIEWED_CAP, RECENTLY_VIEWED_KEY } from "../ui/src/board/recents";
+
+describe("pushRecent — recency-order merge (CTL-882)", () => {
+  it("seeds an empty list with the first visit", () => {
+    expect(pushRecent([], "CTL-845")).toEqual(["CTL-845"]);
+  });
+
+  it("puts the most-recent visit at the front", () => {
+    // visit CTL-845 then CTL-831 → ["CTL-831", "CTL-845"] (recency order).
+    const afterFirst = pushRecent([], "CTL-845");
+    const afterSecond = pushRecent(afterFirst, "CTL-831");
+    expect(afterSecond).toEqual(["CTL-831", "CTL-845"]);
+  });
+
+  it("re-visiting an id moves it to the front without duplicating", () => {
+    const list = pushRecent(pushRecent([], "CTL-845"), "CTL-831"); // [831, 845]
+    const revisit = pushRecent(list, "CTL-845");
+    expect(revisit).toEqual(["CTL-845", "CTL-831"]);
+    // exactly one occurrence of each id.
+    expect(revisit.filter((x) => x === "CTL-845")).toHaveLength(1);
+  });
+
+  it("ignores an empty id so a cold-link never pollutes recents", () => {
+    const list = ["CTL-845"];
+    expect(pushRecent(list, "")).toEqual(["CTL-845"]);
+  });
+
+  it("caps the list at the cap, dropping the oldest", () => {
+    let list: string[] = [];
+    for (let i = 0; i < RECENTLY_VIEWED_CAP + 5; i++) list = pushRecent(list, `CTL-${i}`);
+    expect(list).toHaveLength(RECENTLY_VIEWED_CAP);
+    // newest first, oldest dropped.
+    expect(list[0]).toBe(`CTL-${RECENTLY_VIEWED_CAP + 4}`);
+    expect(list).not.toContain("CTL-0");
+  });
+
+  it("respects an explicit small cap", () => {
+    const list = pushRecent(pushRecent(pushRecent([], "a"), "b"), "c");
+    expect(pushRecent(list, "d", 2)).toEqual(["d", "c"]);
+  });
+
+  it("never mutates the input list", () => {
+    const orig = ["CTL-845"];
+    const copy = [...orig];
+    pushRecent(orig, "CTL-831");
+    expect(orig).toEqual(copy);
+  });
+
+  it("exposes a stable, namespaced storage key", () => {
+    expect(RECENTLY_VIEWED_KEY).toBe("catalyst.recentlyViewed");
+  });
+});
+
+// The "survives a reload" simulation in pure form: persist the merged list (what
+// atomWithStorage writes to localStorage), then re-derive it on the next load —
+// the order must hold. The real localStorage round-trip is covered by
+// nav-store.test.ts in the ui module graph.
+describe("pushRecent — survives a (simulated) reload (CTL-882)", () => {
+  it("the persisted list is already in recency order on reload", () => {
+    // session 1: visit CTL-845 then CTL-831.
+    let persisted = pushRecent([], "CTL-845");
+    persisted = pushRecent(persisted, "CTL-831");
+    const serialized = JSON.stringify(persisted); // what localStorage holds
+
+    // reload: atomWithStorage reads the same bytes back.
+    const rehydrated: string[] = JSON.parse(serialized);
+    expect(rehydrated).toEqual(["CTL-831", "CTL-845"]);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/tsconfig.json
+++ b/plugins/dev/scripts/orch-monitor/tsconfig.json
@@ -11,7 +11,10 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": {
+      "@/*": ["./ui/src/*"]
+    }
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["ui"]

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
@@ -9,6 +9,11 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { fmtDuration } from "../lib/formatters";
 // ── types + transport (hoisted to ./types + ./board-client for CTL-733 PR-2b) ─
 import { connectBoard } from "./board-client";
+// ── single ordering source (CTL-882 / FND2) ──────────────────────────────────
+// The board renders ticket columns + the worker queue through resolveList so the
+// detail-page pager (N/total) and the j/k walk read the SAME order. See
+// list-order.ts — the P1 keystone correctness item.
+import { resolveList, sortWorkers } from "./list-order";
 import type {
   BoardPayload,
   BoardWorker as Worker,
@@ -46,6 +51,16 @@ const PHASE_COLS = [
 const WORKER_COLS = [
   { key: "active", label: "Active", c: LIVE }, { key: "stuck", label: "Stuck", c: C.red },
 ];
+// Stub payload used to route a ticket column through resolveList (CTL-882) when
+// the caller only holds a (repo-/search-filtered) ticket array: resolveList's
+// ticket branch reads `.tickets` only, so the other fields are inert.
+const EMPTY_BOARD_PAYLOAD: Omit<BoardPayload, "tickets"> = {
+  generatedAt: "",
+  config: { maxParallel: 0, inFlight: 0, freeSlots: 0, active: 0, working: 0, stuck: 0 },
+  repos: [],
+  workers: [],
+  queue: [],
+};
 // Phase statuses that mean a phase is no longer running. MUST stay in lock-step
 // with the TERMINAL set in lib/board-data.mjs (the data-layer source of truth) —
 // board-phase-drift.test.ts asserts this array equals [...TERMINAL] so a new
@@ -359,7 +374,13 @@ function TicketBoard({ tickets, lens, colorBy, fill, onSelect }: { tickets: Tick
   return (
     <BoardScroll fill={fill}>
       {cols.map((c: any) => {
-        const items = lens === "linear" ? tickets.filter((t) => t.linearState === c.key) : tickets.filter((t) => t.phase === c.key);
+        // Render through resolveList (CTL-882 / FND2) so the on-screen column
+        // order is the SAME list the detail-page pager + j/k walk derive. The
+        // ticket branch is a pure column filter (linearState | phase), payload
+        // array order preserved — byte-for-byte identical to the prior inline
+        // `tickets.filter(...)`. `tickets` here is already the repo-/search-
+        // filtered subset; resolveList only reads `.tickets` for kind:"ticket".
+        const items = resolveList({ ...EMPTY_BOARD_PAYLOAD, tickets }, { kind: "ticket", lens, col: c.key });
         const live = items.filter((t) => t.activeState === "active").length;
         return (
           <Column key={c.key} label={c.label || c.key} color={c.c} count={items.length} live={live}>
@@ -438,8 +459,10 @@ const ellip = { overflow: "hidden" as const, textOverflow: "ellipsis" as const, 
 function QueueView({ data }: { data: BoardPayload }) {
   const { config, queue, workers, tickets } = data;
   const infoById: Record<string, Ticket> = Object.fromEntries(tickets.map((t) => [t.id, t]));
-  const rank = (w: Worker) => (isActive(w.activeState) ? 0 : w.activeState === "stuck" ? 2 : 1);
-  const inflight = [...workers].sort((a, b) => rank(a) - rank(b) || (b.runtimeMs ?? 0) - (a.runtimeMs ?? 0));
+  // Order through the SHARED comparator (CTL-882 / FND2): rank(active=0, stuck=2,
+  // else=1) then runtimeMs desc — the same order the worker pager + j/k walk
+  // resolve via resolveList({kind:"worker"}). Byte-for-byte the prior inline sort.
+  const inflight = sortWorkers(workers);
   return (
     <div className="cat-scroll" style={{ overflowY: "auto", height: "calc(100vh - 104px)", padding: "2px 16px 24px" }}>
       <div style={{ maxWidth: 1040 }}>

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/list-order.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/list-order.ts
@@ -1,0 +1,141 @@
+// list-order.ts — THE single ordering source for the board, the detail-page
+// pager (`N / total`), and the j/k walk (CTL-882 / FND2). This is the P1
+// keystone correctness item from detail design §3.1 / §6:
+//
+//   > the board's sort is an inline `.sort()` with a local `rank()` closure
+//   > (Board.tsx:442, not exported). The pager `N/total` and `j/k` MUST consume
+//   > the *same* comparator + column filter or the on-screen order silently
+//   > drifts from the walk order. Extract `board/list-order.ts` →
+//   > `resolveList(payload, ctx)`, imported by both `Board.tsx` and the shell.
+//
+// PURE module — deliberately React-/jotai-/router-free (it imports only the
+// hoisted board *types*) so the orch-monitor `bun test` suite can unit-test it
+// directly from outside the `ui/` module graph, the same way board-logic.ts is
+// unit-tested by board-client.test.ts. The board view (Board.tsx) and the
+// detail shell both call `resolveList`; because they share this one function,
+// `indexOf($id)+1` on the shell's resolved list can never disagree with the
+// card order the operator counted on the board.
+
+import type {
+  BoardActiveState,
+  BoardPayload,
+  BoardTicket,
+  BoardWorker,
+} from "./types";
+
+/** Which list the operator is walking — a ticket column or the worker queue. */
+export type ListKind = "ticket" | "worker";
+
+/** Which board lens a ticket list was rendered under (mirrors route-search). */
+export type ListLens = "linear" | "phase";
+
+/**
+ * The context that selects + orders a list. Mirrors the typed search params
+ * (`route-search.ts`) the detail shell reconstructs from the URL:
+ *   - `kind:"ticket"` + `lens` + `col` → one board column (filter, no re-sort).
+ *   - `kind:"worker"` → the in-flight worker queue (rank-sorted).
+ */
+export type ListContext =
+  | { kind: "ticket"; lens?: ListLens; col?: string }
+  | { kind: "worker"; lens?: ListLens; col?: string };
+
+// ── worker ordering (lifted verbatim from Board.tsx:441-442) ────────────────
+// `isActive` is the same predicate Board.tsx defines at line 67. Kept local so
+// this module stays import-free apart from the shared types.
+const isActive = (s: BoardActiveState): boolean => s === "active";
+
+/**
+ * The worker rank used by the in-flight queue: active (in-loop) first, then
+ * everything else, then stuck last. Byte-for-byte the closure from
+ * `Board.tsx:441` — `active?0 : stuck?2 : 1`.
+ */
+export function rankWorker(w: BoardWorker): number {
+  return isActive(w.activeState) ? 0 : w.activeState === "stuck" ? 2 : 1;
+}
+
+/**
+ * Order workers exactly as the in-flight queue does today: by `rankWorker`
+ * ascending, ties broken by `runtimeMs` descending (longest-running first).
+ * This is the literal comparator from `Board.tsx:442`:
+ *   `[...workers].sort((a,b)=> rank(a)-rank(b) || (b.runtimeMs ?? 0)-(a.runtimeMs ?? 0))`
+ * Returns a new array — never mutates the resident payload.
+ */
+export function sortWorkers(workers: readonly BoardWorker[]): BoardWorker[] {
+  return [...workers].sort(
+    (a, b) => rankWorker(a) - rankWorker(b) || (b.runtimeMs ?? 0) - (a.runtimeMs ?? 0),
+  );
+}
+
+// ── ticket ordering (lifted verbatim from Board.tsx:362) ────────────────────
+/**
+ * Select the tickets in one board column. The board has NO explicit `.sort()`
+ * on tickets — order is the payload array order within the column filter
+ * (`Board.tsx:362`). Reproduce that exactly (filter, no re-sort) or card order
+ * drifts from the pager. A `col` of `undefined`/`""` selects nothing (a
+ * cold-link with no column context resolves to an empty list, never a throw).
+ */
+export function filterTickets(
+  tickets: readonly BoardTicket[],
+  lens: ListLens,
+  col: string | undefined,
+): BoardTicket[] {
+  if (!col) return [];
+  return lens === "linear"
+    ? tickets.filter((t) => t.linearState === col)
+    : tickets.filter((t) => t.phase === col);
+}
+
+/**
+ * Resolve the ordered list for a board column (tickets) or the in-flight queue
+ * (workers) from the resident `BoardPayload` and the navigation context.
+ *
+ * The board renders through this and the detail shell walks through this, so
+ * `resolveList(payload, ctx).map(e => e.id…)` is the single source of truth for
+ * pager `N / total` and the j/k order on BOTH pages.
+ *
+ *   - `kind:"ticket"`: `filterTickets` — column filter on `linearState`
+ *     (lens "linear", the default) or `phase` (lens "phase"), payload array
+ *     order preserved, NO re-sort.
+ *   - `kind:"worker"`: `sortWorkers` — rank(active=0, stuck=2, else=1) then
+ *     `runtimeMs` descending.
+ *
+ * Never mutates `payload`; never throws on missing/unknown context.
+ *
+ * Overloaded on the `kind` discriminant so callers that pass a literal
+ * `kind:"ticket"` / `kind:"worker"` get the precise element type back with no
+ * cast; the general `ListContext` signature keeps the union for a dynamic ctx.
+ */
+export function resolveList(
+  payload: BoardPayload,
+  ctx: { kind: "ticket"; lens?: ListLens; col?: string },
+): BoardTicket[];
+export function resolveList(
+  payload: BoardPayload,
+  ctx: { kind: "worker"; lens?: ListLens; col?: string },
+): BoardWorker[];
+export function resolveList(
+  payload: BoardPayload,
+  ctx: ListContext,
+): BoardTicket[] | BoardWorker[];
+export function resolveList(
+  payload: BoardPayload,
+  ctx: ListContext,
+): BoardTicket[] | BoardWorker[] {
+  if (ctx.kind === "worker") {
+    return sortWorkers(payload.workers);
+  }
+  return filterTickets(payload.tickets, ctx.lens ?? "linear", ctx.col);
+}
+
+/**
+ * The ordered id list for a context — the exact thing the pager and j/k walk
+ * bind to (`listContextAtom.ids`). For tickets this is `BoardTicket.id`; for
+ * workers it is `BoardWorker.name` (the worker board keys cards by `w.name`,
+ * `Board.tsx:387`, and the worker route is `/worker/$id`).
+ */
+export function resolveListIds(payload: BoardPayload, ctx: ListContext): string[] {
+  if (ctx.kind === "worker") {
+    return sortWorkers(payload.workers).map((w) => w.name);
+  }
+  return filterTickets(payload.tickets, ctx.lens ?? "linear", ctx.col).map((t) => t.id);
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/nav-store.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/nav-store.test.ts
@@ -1,0 +1,137 @@
+// nav-store.test.ts — units for the jotai nav store (CTL-882 / FND2): the
+// list-context / peek / palette atoms + the persisted recentlyViewedAtom.
+//
+// This file imports jotai (`atom`, `createStore`) and `jotai/utils`
+// (`atomWithStorage`), which resolve from THIS module's own `ui/node_modules`.
+// Run it from the ui package:  `cd ui && bun test src/board/nav-store.test.ts`.
+// The main orch-monitor `bun test` does not load jotai, so the jotai-free
+// recency logic is also covered there via __tests__/recents.test.ts; this file
+// proves the atom wiring + the real localStorage round-trip behind
+// `recentlyViewedAtom` (the "survives a reload" Gherkin, end-to-end).
+import { describe, it, expect, beforeEach } from "bun:test";
+import { createStore } from "jotai";
+import {
+  listContextAtom,
+  EMPTY_LIST_CONTEXT,
+  peekAtom,
+  PEEK_CLOSED,
+  paletteOpenAtom,
+  recentlyViewedAtom,
+  recordRecentAtom,
+  RECENTLY_VIEWED_KEY,
+} from "./nav-store";
+
+// Minimal in-memory localStorage so atomWithStorage's default storage — which
+// reads `window.localStorage` (jotai createJSONStorage, verified in
+// node_modules/jotai/vanilla/utils.js:421) — has a backing store under bun
+// (there is no `window` in bun's runtime). `Storage` + `addEventListener` are
+// shimmed too because jotai's default storage feature-detects them for its
+// cross-tab `storage`-event subscriber.
+class MemStorage {
+  private m = new Map<string, string>();
+  getItem(k: string) { return this.m.has(k) ? this.m.get(k)! : null; }
+  setItem(k: string, v: string) { this.m.set(k, v); }
+  removeItem(k: string) { this.m.delete(k); }
+  clear() { this.m.clear(); }
+  key(i: number) { return [...this.m.keys()][i] ?? null; }
+  get length() { return this.m.size; }
+}
+
+function installWindowStorage(): MemStorage {
+  const mem = new MemStorage();
+  const win = {
+    localStorage: mem,
+    Storage: MemStorage,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+  (globalThis as unknown as { window: unknown }).window = win;
+  return mem;
+}
+
+beforeEach(() => {
+  // Fresh, isolated storage per test (jotai's default storage reads it lazily).
+  installWindowStorage();
+});
+
+describe("nav-store — list context / peek / palette atoms", () => {
+  it("listContextAtom starts at the empty cold-link context", () => {
+    const store = createStore();
+    expect(store.get(listContextAtom)).toEqual(EMPTY_LIST_CONTEXT);
+    expect(store.get(listContextAtom).ids).toEqual([]);
+  });
+
+  it("listContextAtom holds {ids, kind, lens, col} when the shell resolves a list", () => {
+    const store = createStore();
+    store.set(listContextAtom, {
+      ids: ["CTL-845", "CTL-877", "CTL-880"],
+      kind: "ticket",
+      lens: "linear",
+      col: "Implement",
+    });
+    const ctx = store.get(listContextAtom);
+    expect(ctx.ids).toEqual(["CTL-845", "CTL-877", "CTL-880"]);
+    expect(ctx.kind).toBe("ticket");
+    expect(ctx.lens).toBe("linear");
+    expect(ctx.col).toBe("Implement");
+  });
+
+  it("peekAtom starts closed and round-trips a neighbour preview", () => {
+    const store = createStore();
+    expect(store.get(peekAtom)).toEqual(PEEK_CLOSED);
+    store.set(peekAtom, { open: true, leftId: "CTL-845", onId: "CTL-877", nextId: "CTL-880" });
+    expect(store.get(peekAtom)).toEqual({
+      open: true, leftId: "CTL-845", onId: "CTL-877", nextId: "CTL-880",
+    });
+  });
+
+  it("paletteOpenAtom toggles", () => {
+    const store = createStore();
+    expect(store.get(paletteOpenAtom)).toBe(false);
+    store.set(paletteOpenAtom, true);
+    expect(store.get(paletteOpenAtom)).toBe(true);
+  });
+});
+
+describe("nav-store — recentlyViewedAtom persistence (survives a reload)", () => {
+  it("records visits most-recent-first via recordRecentAtom", () => {
+    const store = createStore();
+    store.set(recordRecentAtom, "CTL-845");
+    store.set(recordRecentAtom, "CTL-831");
+    expect(store.get(recentlyViewedAtom)).toEqual(["CTL-831", "CTL-845"]);
+  });
+
+  it("de-dupes a re-visit to the front", () => {
+    const store = createStore();
+    store.set(recordRecentAtom, "CTL-845");
+    store.set(recordRecentAtom, "CTL-831");
+    store.set(recordRecentAtom, "CTL-845");
+    expect(store.get(recentlyViewedAtom)).toEqual(["CTL-845", "CTL-831"]);
+  });
+
+  it("persists to localStorage and rehydrates in recency order after a reload", () => {
+    // session 1: visit CTL-845 then CTL-831. atomWithStorage only writes through
+    // to localStorage while the atom is mounted, so subscribe first (this is
+    // what React's <Provider>/useAtom does in the real app).
+    const store1 = createStore();
+    const unsub = store1.sub(recentlyViewedAtom, () => {});
+    store1.set(recordRecentAtom, "CTL-845");
+    store1.set(recordRecentAtom, "CTL-831");
+
+    // it actually wrote to our backing window.localStorage under the key.
+    const raw = (globalThis as unknown as { window: { localStorage: Storage } }).window.localStorage.getItem(
+      RECENTLY_VIEWED_KEY,
+    );
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!)).toEqual(["CTL-831", "CTL-845"]);
+    unsub();
+
+    // reload: a brand-new store reading the SAME localStorage sees the list.
+    // atomWithStorage hydrates from storage on mount (subscribe), exactly as the
+    // React app does when the component first renders.
+    const store2 = createStore();
+    const unsub2 = store2.sub(recentlyViewedAtom, () => {});
+    expect(store2.get(recentlyViewedAtom)).toEqual(["CTL-831", "CTL-845"]);
+    unsub2();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/nav-store.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/nav-store.ts
@@ -1,0 +1,98 @@
+// nav-store.ts — the jotai navigation store for the detail-page chrome
+// (CTL-882 / FND2). The URL owns *location* (route + typed search params, see
+// route-search.ts); this store owns the *ephemeral cursor* — list-context,
+// peek overlay, ⌘K palette open-state — plus the one persisted bit:
+// recently-viewed (detail design §3.1 / §6 P11).
+//
+//   listContextAtom   {ids, kind, lens, col}   — the resolved walk list
+//   peekAtom          {open, leftId, onId, nextId}
+//   paletteOpenAtom   boolean
+//   recentlyViewedAtom string[] (atomWithStorage → localStorage, P11)
+//
+// jotai is already in-grain (the kibo-ui gantt is the only other consumer,
+// `components/kibo-ui/gantt/index.tsx:28`). This ticket stands up the atoms ONLY
+// — the shell chrome, the peek/palette UI, and the pager that READ these atoms
+// are owned by the SHELL/DETAIL streams (boundary stated in the ticket).
+//
+// The recency-merge logic is factored into the PURE `pushRecent` helper so the
+// orch-monitor `bun test` suite can unit-test the "CTL-845 then CTL-831 then
+// reload → recency order" Gherkin without a jotai/localStorage runtime; the
+// atom setter just calls it.
+
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+import type { ListKind, ListLens } from "./list-order";
+import { pushRecent, RECENTLY_VIEWED_KEY } from "./recents";
+
+// Re-export the recents constants/helper so consumers of the store have one
+// import surface; the testable logic itself lives in the jotai-free recents.ts.
+export { pushRecent, RECENTLY_VIEWED_KEY, RECENTLY_VIEWED_CAP } from "./recents";
+
+// ── list context (the resolved walk list) ───────────────────────────────────
+/**
+ * The list the operator is walking, resolved once (via `resolveList`) from the
+ * resident payload + the typed search params, and read by the pager (`N /
+ * total`), the j/k handler, and peek (prev/next). `ids` is the ordered id list
+ * — `BoardTicket.id` for tickets, `BoardWorker.name` for workers.
+ *
+ * Cold-link (a pasted bare URL with no `?from`): `ids` is `[]` until the board
+ * stream rehydrates, at which point the shell resets this atom and the pager
+ * silently lights up (detail design §3.3 "Cold-link").
+ */
+export interface ListContextState {
+  ids: string[];
+  kind: ListKind;
+  lens?: ListLens;
+  col?: string;
+}
+
+/** The empty / cold-link context: no list resolved yet. */
+export const EMPTY_LIST_CONTEXT: ListContextState = { ids: [], kind: "ticket" };
+
+export const listContextAtom = atom<ListContextState>(EMPTY_LIST_CONTEXT);
+
+// ── peek overlay ────────────────────────────────────────────────────────────
+/**
+ * The blue-framed peek overlay state (detail design §3.3 "Peek"). `onId` is the
+ * entity currently centred; `leftId`/`nextId` are its neighbours in
+ * `listContextAtom.ids` (null at the list ends). The shell sets `open` while
+ * j/k is held or a chevron is hovered.
+ */
+export interface PeekState {
+  open: boolean;
+  leftId: string | null;
+  onId: string | null;
+  nextId: string | null;
+}
+
+/** Closed peek with no anchored entity. */
+export const PEEK_CLOSED: PeekState = { open: false, leftId: null, onId: null, nextId: null };
+
+export const peekAtom = atom<PeekState>(PEEK_CLOSED);
+
+// ── ⌘K palette ──────────────────────────────────────────────────────────────
+/** Whether the ⌘K command palette is open. The shell saves/restores focus
+ *  around the toggle (detail design §3.4); this atom is just the boolean. */
+export const paletteOpenAtom = atom<boolean>(false);
+
+// ── recently-viewed (persisted) ─────────────────────────────────────────────
+// The localStorage key, the cap, and the `pushRecent` recency-merge live in the
+// jotai-free `recents.ts` (re-exported above) so the recency Gherkin is unit-
+// testable in the main `bun test` suite without a jotai runtime.
+
+/**
+ * The recently-viewed ids, most-recent-first, persisted to localStorage via
+ * `atomWithStorage` so the ⌘K RECENT group survives a reload (detail design §6
+ * P11). Write through `recordRecentAtom` (below) rather than setting this
+ * directly, so the de-dupe + cap invariants always hold.
+ */
+export const recentlyViewedAtom = atomWithStorage<string[]>(RECENTLY_VIEWED_KEY, []);
+
+/**
+ * Write-only atom: record a freshly-viewed `id` into `recentlyViewedAtom`,
+ * applying the `pushRecent` recency-merge (move-to-front, de-dupe, cap). The
+ * shell calls `set(recordRecentAtom, id)` on every detail LAND.
+ */
+export const recordRecentAtom = atom(null, (get, set, id: string) => {
+  set(recentlyViewedAtom, pushRecent(get(recentlyViewedAtom), id));
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/recents.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/recents.ts
@@ -1,0 +1,35 @@
+// recents.ts — the PURE recency-merge for the ⌘K RECENT group (CTL-882 / FND2).
+// Split out of nav-store.ts (which imports jotai) so the orch-monitor `bun test`
+// suite can unit-test the "CTL-845 then CTL-831 then reload → recency order"
+// Gherkin directly, with no jotai / localStorage runtime in the import graph
+// (the same dependency-free-so-it's-testable discipline as board-logic.ts).
+// nav-store.ts's `recentlyViewedAtom` setter and `recordRecentAtom` both call
+// `pushRecent`, so the persisted list and these units can never drift.
+
+/** How many ids the ⌘K RECENT group keeps. */
+export const RECENTLY_VIEWED_CAP = 20;
+
+/** localStorage key for the persisted recents (used by `recentlyViewedAtom`). */
+export const RECENTLY_VIEWED_KEY = "catalyst.recentlyViewed";
+
+/**
+ * Push `id` onto the front of the recents list, most-recent-first, de-duped,
+ * capped at `cap`:
+ *
+ *   visit CTL-845 → ["CTL-845"]
+ *   visit CTL-831 → ["CTL-831", "CTL-845"]    (most recent first)
+ *   re-visit CTL-845 → ["CTL-845", "CTL-831"] (moves to front, no dup)
+ *
+ * An empty/whitespace id is ignored (returns a copy of the list unchanged) so a
+ * cold-link with no resolved entity never pollutes recents. Never mutates the
+ * input. A `cap <= 0` means "no cap" (keep everything).
+ */
+export function pushRecent(
+  list: readonly string[],
+  id: string,
+  cap: number = RECENTLY_VIEWED_CAP,
+): string[] {
+  if (!id) return [...list];
+  const next = [id, ...list.filter((x) => x !== id)];
+  return cap > 0 ? next.slice(0, cap) : next;
+}


### PR DESCRIPTION
## CTL-882 / FND2 — one ordering source for the board, the pager, and the j/k walk

The single hardest correctness item in the detail-page redesign: the board's on-screen order and the detail-page pager (`N / total`) + `j/k` walk MUST use one comparator, or the card order silently drifts from the walk order. This extracts a single `board/list-order.ts → resolveList(payload, ctx)` that encodes BOTH the ticket column-filter AND the worker rank-sort, makes `Board.tsx` render through it, and stands up the jotai nav store the shell/peek/palette/pager will read from.

**Boundary (per the ticket):** comparator + atoms ONLY. No shell chrome, no pager UI, no palette UI, no detail bodies — those consume these and are owned by the SHELL/DETAIL streams.

### Files
- `ui/src/board/list-order.ts` (new, pure) — `resolveList` + `filterTickets` / `sortWorkers` / `rankWorker` / `resolveListIds`. Overloaded on the `kind` discriminant (no cast at call sites).
- `ui/src/board/Board.tsx` — `TicketBoard` builds each column via `resolveList`; `QueueView` orders via `sortWorkers`. Byte-for-byte identical to the prior inline orderings (`Board.tsx:362` ticket filter, `:441-442` worker rank-sort).
- `ui/src/board/nav-store.ts` (new) — `listContextAtom` / `peekAtom` / `paletteOpenAtom` / `recentlyViewedAtom` (`atomWithStorage`, P11) + `recordRecentAtom`.
- `ui/src/board/recents.ts` (new, pure) — `pushRecent` recency-merge, split jotai-free so it unit-tests in the main suite.
- `tsconfig.json` — add `@/* → ui/src/*` path so the new pure test (which transitively reaches `board/types.ts`) type-checks under the orch-monitor tsc. Inert for non-ui code (nothing outside `ui/` imports `@/`).

### Gherkin scenarios → status

| Scenario | Status | Where |
|---|---|---|
| The board renders through resolveList | **satisfied** | `Board.tsx` TicketBoard → `resolveList({kind:"ticket",lens,col})`; `list-order.test.ts` "byte-for-byte identical to the prior inline linear filter (Board.tsx:362)" |
| Worker rank-sort is preserved through the same function | **satisfied** | `QueueView` → `sortWorkers`; `list-order.test.ts` "byte-for-byte identical to the prior inline sort (Board.tsx:441-442)" |
| The pager and the board agree (the correctness contract) | **satisfied** | `resolveListIds` (same ctx → same ordered ids); `list-order.test.ts` "resolveListIds — the id list the pager + j/k bind to" asserts `indexOf+1` / `length` |
| List context is captured in a jotai atom | **satisfied** | `listContextAtom {ids,kind,lens,col}` + `peekAtom` + `paletteOpenAtom`; `nav-store.test.ts` |
| Recently-viewed survives a reload | **satisfied** | `recentlyViewedAtom` via `atomWithStorage`; `recents.test.ts` (recency-order, pure) + `nav-store.test.ts` "persists to localStorage and rehydrates in recency order after a reload" (real round-trip) |

**Single-node descope:** none applicable — this ticket is pure client-side board/detail foundation with no cluster/fence/multi-host behavior.

### Validation
- `bunx tsc --noEmit` clean for **both** packages (orch-monitor + ui). The pre-existing `kpi-strip.tsx` "abandoned" error exists on `origin/main` (untouched here).
- Tests: `bun test __tests__/list-order.test.ts __tests__/recents.test.ts` → **22 pass**; `cd ui && bun test src/board/nav-store.test.ts` → **7 pass** (jotai resolves from the ui module graph; the jotai-free recency logic is also covered in the main suite via `recents.test.ts`).
- `cd ui && bun run build` succeeds. Built `public/` artifacts intentionally not committed (same convention as FND1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)