### PR TITLE
feat(dev): BFF9 retire legacy linearis poller onto durable cache (CTL-921)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-cache-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-cache-reader.test.ts
@@ -37,7 +37,20 @@ describe("readLinearCache (CTL-883 — durable-cache Linear enrichment)", () => 
       relations: [{ type: "blocks", id: "CTL-2" }],
       assignee: "uuid-bot",
       linearState: "Implement",
+      // ticket_state has no title column → honest null with no eligible row (BFF9)
+      title: null,
     });
+  });
+
+  it("surfaces title from the eligible projection (BFF9 — for the cache-backed /api/linear)", async () => {
+    const ticketStateReader = () =>
+      Promise.resolve({ "CTL-3": { priority: 2, labels: [], linearState: "PR" } });
+    const eligibleReader = () =>
+      Promise.resolve({ "CTL-3": { title: "Retire legacy linearis poller" } });
+    const byId = await readLinearCache({ ticketStateReader, eligibleReader });
+    // ticket_state owns state/priority, eligible owns the title.
+    expect(byId["CTL-3"].linearState).toBe("PR");
+    expect(byId["CTL-3"].title).toBe("Retire legacy linearis poller");
   });
 
   it("fills priority/project/relations from the eligible projection when ticket_state lacks them", async () => {
@@ -144,5 +157,6 @@ describe("readLinearCache end-to-end against a real filter-state.db", () => {
     // queued ticket only in the eligible projection
     expect(byId["CTL-200"].priority).toBe(3);
     expect(byId["CTL-200"].project).toBe("Web UI");
+    expect(byId["CTL-200"].title).toBe("queued"); // BFF9: title from eligible
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect } from "bun:test";
 import {
   createLinearFetcher,
+  createCacheBackedLinearFetcher,
   parseTicketJson,
+  type LinearCacheReader,
   type Runner,
 } from "../lib/linear";
+import type { LinearCacheById } from "../lib/linear-cache-reader.d.mts";
 
 const validPayload = JSON.stringify({
   identifier: "ADV-214",
@@ -226,5 +229,158 @@ describe("createLinearFetcher — event-driven invalidation (CTL-211)", () => {
     await fetcher.invalidate("ADV-999");
     expect(reads).toEqual([]);
     expect(fetcher.get("ADV-999")).toBeNull();
+  });
+});
+
+// BFF9 / CTL-921 — the cache-backed LinearFetcher that retires the live
+// `linearis issues read` poller behind /api/linear + /api/briefing. It serves
+// every key from the broker's durable filter-state.db ticket_state (via
+// readLinearCache) and spawns NOTHING. These tests assert the three Gherkin
+// scenarios:
+//   1. /api/linear + /api/briefing read from the durable cache (no linearis).
+//   2. The live poller is removed, not merely shadowed (no spawn on start/poll).
+//   3. Cache miss degrades, never blocks (partial/empty, no live fan-out).
+describe("createCacheBackedLinearFetcher (BFF9 — durable-cache LinearFetcher)", () => {
+  // A reader that records its calls and returns a canned durable-cache map. It
+  // stands in for readLinearCache (which reads filter-state.db ticket_state +
+  // the eligible projection); a real `linearis` spawn would NOT route through
+  // it, so counting calls here proves "served from cache, no live call".
+  function makeCacheReader(
+    byId: LinearCacheById,
+  ): { reader: LinearCacheReader; calls: () => number } {
+    let calls = 0;
+    const reader: LinearCacheReader = () => {
+      calls++;
+      return Promise.resolve(byId);
+    };
+    return { reader, calls: () => calls };
+  }
+
+  const cacheEntry = {
+    priority: 2,
+    estimate: null,
+    project: "Web UI",
+    labels: ["monitor", "feature"],
+    relations: null,
+    assignee: "uuid-bot",
+    linearState: "Implement",
+    title: "Retire legacy linearis poller",
+  } satisfies LinearCacheById[string];
+
+  it("Scenario 1: serves /api/linear shape from the durable cache (no linearis spawn)", async () => {
+    const { reader, calls } = makeCacheReader({ "CTL-921": cacheEntry });
+    const fetcher = createCacheBackedLinearFetcher({ cacheReader: reader });
+
+    // Before any refresh the cache is empty → miss.
+    expect(fetcher.get("CTL-921")).toBeNull();
+
+    await fetcher.refreshAll(["CTL-921"]);
+    const t = fetcher.get("CTL-921");
+    expect(t).not.toBeNull();
+    expect(t?.key).toBe("CTL-921");
+    expect(t?.title).toBe("Retire legacy linearis poller");
+    expect(t?.state).toBe("Implement"); // linearState → LinearTicket.state
+    expect(t?.project).toBe("Web UI");
+    expect(t?.labels).toEqual(["monitor", "feature"]);
+    // url is derived from the key (no durable url source).
+    expect(t?.url).toBe("https://linear.app/issue/CTL-921");
+    expect(typeof t?.fetchedAt).toBe("string");
+    // Exactly one durable-cache read satisfied the request — no per-key fan-out.
+    expect(calls()).toBe(1);
+  });
+
+  it("Scenario 2: start() reloads the durable cache on the interval — never spawns linearis", async () => {
+    const { reader, calls } = makeCacheReader({ "CTL-921": cacheEntry });
+    const fetcher = createCacheBackedLinearFetcher({ cacheReader: reader });
+
+    // start() does an immediate bulk reload from the cache (not a linearis poll).
+    fetcher.start(() => ["CTL-921"], 60_000);
+    // Let the immediate void reload() settle.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fetcher.get("CTL-921")?.state).toBe("Implement");
+    expect(calls()).toBeGreaterThanOrEqual(1);
+    fetcher.stop();
+  });
+
+  it("Scenario 2: invalidate() bulk-reloads the durable cache (webhook freshness, no spawn)", async () => {
+    let state = "Plan";
+    let calls = 0;
+    const reader: LinearCacheReader = () => {
+      calls++;
+      return Promise.resolve({
+        "CTL-921": { ...cacheEntry, linearState: state },
+      });
+    };
+    const fetcher = createCacheBackedLinearFetcher({ cacheReader: reader });
+    await fetcher.refreshAll([]);
+    expect(fetcher.get("CTL-921")?.state).toBe("Plan");
+
+    // Broker wrote the new state into ticket_state; webhook → invalidate reloads.
+    state = "PR";
+    await fetcher.invalidate("CTL-921");
+    expect(fetcher.get("CTL-921")?.state).toBe("PR");
+    expect(calls).toBe(2); // one refreshAll + one invalidate, both cache reads
+  });
+
+  it("invalidate is a no-op for blank keys (parity with legacy contract)", async () => {
+    let calls = 0;
+    const reader: LinearCacheReader = () => {
+      calls++;
+      return Promise.resolve({});
+    };
+    const fetcher = createCacheBackedLinearFetcher({ cacheReader: reader });
+    await fetcher.invalidate("");
+    await fetcher.invalidate("   ");
+    expect(calls).toBe(0);
+  });
+
+  it("Scenario 3: cache miss returns null (partial/empty), never a live fan-out", async () => {
+    const { reader } = makeCacheReader({ "CTL-921": cacheEntry });
+    const fetcher = createCacheBackedLinearFetcher({ cacheReader: reader });
+    await fetcher.refreshAll([]);
+    // A key the broker has not yet seen via webhook → null, no live read.
+    expect(fetcher.get("CTL-999")).toBeNull();
+  });
+
+  it("degrades title/state to empty string when the durable cache lacks them", async () => {
+    const { reader } = makeCacheReader({
+      "CTL-7": {
+        priority: 0,
+        estimate: null,
+        project: null,
+        labels: [],
+        relations: null,
+        assignee: null,
+        linearState: null,
+        title: null,
+      },
+    });
+    const fetcher = createCacheBackedLinearFetcher({ cacheReader: reader });
+    await fetcher.refreshAll([]);
+    const t = fetcher.get("CTL-7");
+    expect(t).not.toBeNull();
+    expect(t?.title).toBe("");
+    expect(t?.state).toBe("");
+    expect(t?.labels).toEqual([]);
+    expect(t?.url).toBe("https://linear.app/issue/CTL-7");
+  });
+
+  it("never throws when the cache reader rejects — keeps the last snapshot (read-model never blocks)", async () => {
+    let ok = true;
+    const reader: LinearCacheReader = () =>
+      ok
+        ? Promise.resolve({ "CTL-921": cacheEntry })
+        : Promise.reject(new Error("db locked"));
+    const fetcher = createCacheBackedLinearFetcher({ cacheReader: reader });
+
+    // First reload succeeds and primes the snapshot.
+    await fetcher.refreshAll([]);
+    expect(fetcher.get("CTL-921")?.state).toBe("Implement");
+
+    // A later reload rejects (locked DB). reload() swallows so refreshAll does
+    // NOT reject and the previous good snapshot survives.
+    ok = false;
+    await expect(fetcher.refreshAll([])).resolves.toBeUndefined();
+    expect(fetcher.get("CTL-921")?.state).toBe("Implement"); // last good snapshot
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.d.mts
@@ -16,6 +16,11 @@ export interface LinearCacheEntry {
   assignee: string | null;
   /** Linear workflow state name from the descriptor, or null. */
   linearState: string | null;
+  /**
+   * Ticket title — only the eligible projection carries it (ticket_state has no
+   * title column), so null when the ticket has no eligible row (BFF9 / CTL-921).
+   */
+  title: string | null;
 }
 
 export type LinearCacheById = Record<string, LinearCacheEntry>;

--- a/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
@@ -126,6 +126,10 @@ async function readEligibleById(eligibleDir) {
               (typeof t.project === "string" ? t.project : null) ||
               null,
             relations: t.relations ?? null,
+            // title is only ever in the eligible projection (ticket_state has no
+            // title column). BFF9 surfaces it so the cache-backed LinearFetcher
+            // can serve /api/linear + /api/briefing without a live `linearis`.
+            title: typeof t.title === "string" ? t.title : null,
           };
         }
       }),
@@ -177,6 +181,9 @@ export async function readLinearCache({
       relations: ts?.relations ?? el?.relations ?? null,
       assignee: ts?.assignee ?? null,
       linearState: ts?.linearState ?? null,
+      // title: ticket_state has no title column, so the eligible projection is
+      // the only durable source (BFF9). Honest null when neither cache has it.
+      title: ts?.title ?? el?.title ?? null,
     };
   }
   // breakerOpen is intentionally not consulted to alter output — it cannot block

--- a/plugins/dev/scripts/orch-monitor/lib/linear.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear.ts
@@ -1,3 +1,9 @@
+import { readLinearCache } from "./linear-cache-reader.mjs";
+import type {
+  LinearCacheById,
+  ReadLinearCacheOptions,
+} from "./linear-cache-reader.d.mts";
+
 export interface LinearTicket {
   key: string;
   title: string;
@@ -11,6 +17,16 @@ export interface LinearTicket {
 export type Runner = (
   args: string[],
 ) => Promise<{ stdout: string; ok: boolean }>;
+
+const LINEAR_BASE_URL = "https://linear.app/issue";
+
+function isRecord(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+function asString(x: unknown, fallback = ""): string {
+  return typeof x === "string" ? x : fallback;
+}
 
 export interface LinearFetcher {
   get(key: string): LinearTicket | null;
@@ -28,15 +44,6 @@ export interface LinearFetcher {
 }
 
 const DEFAULT_CONCURRENCY = 5;
-const LINEAR_BASE_URL = "https://linear.app/issue";
-
-function isRecord(x: unknown): x is Record<string, unknown> {
-  return typeof x === "object" && x !== null && !Array.isArray(x);
-}
-
-function asString(x: unknown, fallback = ""): string {
-  return typeof x === "string" ? x : fallback;
-}
 
 export function parseTicketJson(raw: string): LinearTicket | null {
   let parsed: unknown;
@@ -202,6 +209,117 @@ export function createLinearFetcher(
       if (trimmed.length === 0) return;
       if (!(await probe())) return;
       await fetchOne(trimmed);
+    },
+  };
+}
+
+// ── BFF9 / CTL-921 ──────────────────────────────────────────────────────────
+// Cache-backed LinearFetcher. The legacy createLinearFetcher above polls
+// `linearis issues read <key>` live into memory, started at server.ts:768 and
+// serving the legacy /api/linear and /api/briefing routes. That second live
+// path kept counting against Linear's 2500/hr cap and contradicted BFF1's
+// (CTL-883) "no synchronous Linear call on any request path" guarantee — which
+// BFF1 only enforced for board-data.mjs::linearInfo(). This factory re-points
+// those routes at the SAME durable source BFF1 unified board reads onto:
+// readLinearCache() over ~/catalyst/filter-state.db ticket_state (+ the
+// scheduler's eligible projection as a gap-filler). It spawns NOTHING, so an
+// OPEN linear-breaker can never be tripped here and the execution-core breaker
+// is honored by construction (the read is always served from cache).
+
+export type LinearCacheReader = (
+  opts?: ReadLinearCacheOptions,
+) => Promise<LinearCacheById>;
+
+export interface CacheBackedLinearFetcherOptions {
+  /** Override the durable-cache reader (defaults to the real readLinearCache). */
+  cacheReader?: LinearCacheReader;
+  /** filter-state.db path forwarded to the cache reader (defaults to the real one). */
+  dbPath?: string;
+  /** eligible-projection dir forwarded to the cache reader (defaults to the real one). */
+  eligibleDir?: string;
+}
+
+// Build a LinearTicket from a durable-cache entry. The cache carries
+// state/labels (ticket_state) + project/title (eligible projection) but NOT a
+// url (no durable source) — so the canonical Linear issue url is derived from
+// the key. Missing title/state degrade to the empty string the legacy fetcher
+// would also have produced for a half-populated payload; the consumers
+// (/api/briefing's prompt builder, /api/linear's JSON) tolerate that.
+function cacheEntryToTicket(
+  key: string,
+  entry: LinearCacheById[string],
+  fetchedAt: string,
+): LinearTicket {
+  return {
+    key,
+    title: asString(entry.title, ""),
+    url: `${LINEAR_BASE_URL}/${encodeURIComponent(key)}`,
+    state: asString(entry.linearState, ""),
+    project: entry.project ?? null,
+    labels: Array.isArray(entry.labels) ? entry.labels.filter(Boolean) : [],
+    fetchedAt,
+  };
+}
+
+export function createCacheBackedLinearFetcher(
+  opts: CacheBackedLinearFetcherOptions = {},
+): LinearFetcher {
+  const cacheReader = opts.cacheReader ?? readLinearCache;
+  const readerOpts: ReadLinearCacheOptions = {};
+  if (opts.dbPath !== undefined) readerOpts.dbPath = opts.dbPath;
+  if (opts.eligibleDir !== undefined) readerOpts.eligibleDir = opts.eligibleDir;
+
+  let byId: LinearCacheById = {};
+  let fetchedAt = new Date(0).toISOString();
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  // Reload the entire durable cache in one pass. The legacy fetcher refreshed
+  // per-key via N `linearis` spawns; the broker already maintains the whole
+  // ticket_state table, so a single bulk read replaces all of them. Never
+  // throws: the real readLinearCache already degrades a locked/absent DB to {},
+  // but we also swallow here so the read-model never blocks on enrichment — a
+  // failed reload leaves the previous snapshot in place. The keys argument is
+  // intentionally ignored: the bulk read covers every key.
+  async function reload(): Promise<void> {
+    try {
+      const next = await cacheReader(readerOpts);
+      byId = next ?? {};
+      fetchedAt = new Date().toISOString();
+    } catch {
+      // keep the last good snapshot; degrade silently (CTL-883 contract)
+    }
+  }
+
+  return {
+    get(key) {
+      const entry = byId[key];
+      if (!entry) return null; // cache miss → partial/empty, never a live fan-out
+      return cacheEntryToTicket(key, entry, fetchedAt);
+    },
+    async refreshAll(_keys) {
+      await reload();
+    },
+    start(_keysProvider, intervalMs) {
+      void reload();
+      if (timer) clearInterval(timer);
+      timer = setInterval(() => {
+        void reload();
+      }, intervalMs);
+    },
+    stop() {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    },
+    async invalidate(key: string) {
+      // Webhook-driven freshness: the broker has already written the new state
+      // into ticket_state by the time this fires, so a cheap bulk reload picks
+      // it up. No `linearis` spawn — blank keys are still a no-op for parity
+      // with the legacy fetcher's invalidate contract.
+      const trimmed = (key ?? "").trim();
+      if (trimmed.length === 0) return;
+      await reload();
     },
   };
 }

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -54,7 +54,7 @@ import {
   type PrStatusFetcher,
 } from "./lib/pr-status";
 import {
-  createLinearFetcher,
+  createCacheBackedLinearFetcher,
   type LinearFetcher,
   type LinearTicket,
 } from "./lib/linear";
@@ -558,10 +558,17 @@ export function createServer(opts: CreateServerOptions): BunServer {
         }));
   let lastPrRefresh = 0;
 
+  // BFF9 / CTL-921: the LinearFetcher behind /api/linear + /api/briefing reads
+  // from the broker's durable filter-state.db ticket_state (via readLinearCache)
+  // instead of polling `linearis issues read` live. This retires the second
+  // surviving live-Linear path (the first, board-data.mjs::linearInfo, was
+  // retired by BFF1/CTL-883) so NO request path spawns linearis or counts
+  // against the 2500/hr cap. Cache-backed by construction: an OPEN linear-breaker
+  // can never be tripped from here.
   const linear: LinearFetcher | null =
     linearFetcher === null
       ? null
-      : (linearFetcher ?? createLinearFetcher());
+      : (linearFetcher ?? createCacheBackedLinearFetcher());
   let linearStarted = false;
 
   const briefingProvider: BriefingProvider | null =


### PR DESCRIPTION
## Summary

Retires the **second** surviving live-Linear path in orch-monitor. BFF1/CTL-883 re-pointed `board-data.mjs::linearInfo()` onto the broker's durable cache, but an independent live path survived: `lib/linear.ts::createLinearFetcher` polled `linearis issues read <key>` live into an in-memory cache (started at `server.ts:768`), serving the legacy `/api/linear` and `/api/briefing` routes via `linear.get(key)`. That kept counting against Linear's 2500/hr cap and contradicted BFF1's "no synchronous Linear call on any request path" guarantee for the legacy surface.

This adds `createCacheBackedLinearFetcher` in `lib/linear.ts` — a drop-in `LinearFetcher` that serves every key from the broker's durable `filter-state.db` `ticket_state` via `readLinearCache()` (the same source BFF1 unified board reads onto, `lib/linear-cache-reader.mjs`), and **spawns nothing**. `server.ts` now boots that factory instead of `createLinearFetcher`, so no monitor request path triggers a live `linearis` call and the execution-core `linear-breaker` is honored by construction (a cache read is always served, an OPEN breaker can never be tripped here).

`readLinearCache` now also surfaces `title` from the scheduler's eligible projection (the only durable source for a title — `ticket_state` has no title column), so `/api/briefing`'s prompt keeps the ticket title.

## Files

- `lib/linear.ts` — new `createCacheBackedLinearFetcher` + `cacheEntryToTicket`; hoisted shared `isRecord`/`asString`/`LINEAR_BASE_URL` helpers. Legacy `createLinearFetcher` and `parseTicketJson` left in place (still unit-tested) but no longer wired into any boot/request path.
- `server.ts` — boot the cache-backed fetcher (`server.ts` ~556); route logic unchanged.
- `lib/linear-cache-reader.mjs` / `.d.mts` — surface `title` from the eligible projection (additive; existing fields/consumers unchanged).
- `__tests__/linear.test.ts` — 8 new tests for the cache-backed fetcher.
- `__tests__/linear-cache-reader.test.ts` — 2 extended tests for the new `title` field.

## Gherkin acceptance

| Scenario | Status |
| --- | --- |
| `/api/linear` and `/api/briefing` read from the durable cache (no `linearis` process spawned) | **Satisfied** — fetcher reads `readLinearCache()` over `filter-state.db ticket_state`; tests assert exactly one cache read per request and zero spawns. |
| The live poller is removed, not merely shadowed (`server.ts:768` no longer starts a periodic `linearis issues read` poll; only Linear-truth source is the broker cache behind the linear-breaker) | **Satisfied** — `server.ts` boots the cache-backed fetcher; `start()`/`invalidate()` do bulk cache reloads, never a `linearis` spawn. |
| Cache miss degrades, never blocks (a key the broker has not seen → partial/empty from cache, not a live fan-out) | **Satisfied** — `get()` returns `null` on a cache miss; a rejecting/locked reader keeps the last good snapshot, never throws. |

Single-node-descoped: none — this ticket has no cluster/multi-host surface.

## Validation

- `bunx tsc --noEmit` clean for the **orch-monitor** package (the only package touched). The pre-existing `ui/src/components/kpi-strip.tsx` tsc error is on stock `origin/main` (zero diff here) and unrelated.
- Targeted tests green: `linear.test.ts` (19), `linear-cache-reader.test.ts` (8), `server.test.ts` (87), `briefings.test.ts`, `linear-webhook-handler.test.ts` — 175 pass, 0 fail.
- `bun run build` in `ui/` succeeds (build-artifact HTML/asset churn reverted — no UI source changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)