### PR TITLE
feat(dev): BFF7 cache-backed ticket detail / artifacts / search endpoints (CTL-889)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/ticket-artifacts-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ticket-artifacts-reader.test.ts
@@ -1,0 +1,124 @@
+// CTL-889 (P9): unit tests for the ticket-artifacts reader. Pure logic — the
+// directory lister + file reader are injected, so no real thoughts tree.
+// Encodes the Gherkin acceptance scenario:
+//   • "Artifacts resolve to thoughts paths" (returns
+//      thoughts/shared/{research,plan}/*-<ticket>.md paths for the spine 📄 links;
+//      cross-node visibility gated on a thoughts-sync push — eventual consistency)
+import { describe, it, expect } from "bun:test";
+import {
+  buildArtifactList,
+  readTicketArtifacts,
+} from "../lib/ticket-artifacts-reader.mjs";
+
+// Build a fake thoughts tree: dirname → [filenames]. The reader scans
+// "research" and "plans" (and tolerates "plan").
+function fakeTree(tree: Record<string, string[]>) {
+  const lister = (dir: string): string[] => {
+    const key = Object.keys(tree).find((k) => dir.endsWith(k));
+    if (!key) throw new Error("ENOENT");
+    return tree[key];
+  };
+  const reader = (path: string): string =>
+    `# peek of ${path.split("/").pop()}\n\nbody`;
+  return { lister, reader };
+}
+
+describe("buildArtifactList — thoughts artifact resolution (P9)", () => {
+  it("resolves research + plan paths for a ticket with the spine 📄 links", async () => {
+    const { lister, reader } = fakeTree({
+      research: [
+        "2026-06-08-CTL-845-research.md",
+        "2026-06-08-CTL-900-other.md",
+      ],
+      plans: ["2026-06-08-CTL-845.md"],
+    });
+    const out = await buildArtifactList("CTL-845", {
+      thoughtsDir: "/repo/thoughts/shared",
+      lister,
+      reader,
+    });
+    const paths = out.artifacts.map((a) => a.path).sort();
+    expect(paths).toContain("thoughts/shared/research/2026-06-08-CTL-845-research.md");
+    expect(paths).toContain("thoughts/shared/plans/2026-06-08-CTL-845.md");
+    // The unrelated CTL-900 file is excluded.
+    expect(paths).not.toContain("thoughts/shared/research/2026-06-08-CTL-900-other.md");
+    // research sorts before plan.
+    expect(out.artifacts[0].kind).toBe("research");
+    expect(out.artifacts[out.artifacts.length - 1].kind).toBe("plan");
+  });
+
+  it("matches the ticket id whether suffixed OR embedded mid-name (case-insensitive)", async () => {
+    const { lister, reader } = fakeTree({
+      research: [
+        "2026-06-07-ctl-845-humanlayer-thoughts-init-crash.md", // embedded, lowercase
+        "2026-06-08-CTL-845.md", // suffixed
+      ],
+      plans: [],
+    });
+    const out = await buildArtifactList("CTL-845", {
+      thoughtsDir: "/repo/thoughts/shared",
+      lister,
+      reader,
+    });
+    expect(out.artifacts.map((a) => a.path)).toEqual(
+      expect.arrayContaining([
+        "thoughts/shared/research/2026-06-07-ctl-845-humanlayer-thoughts-init-crash.md",
+        "thoughts/shared/research/2026-06-08-CTL-845.md",
+      ]),
+    );
+  });
+
+  it("does NOT match a longer ticket id by prefix (CTL-84 ≠ CTL-845)", async () => {
+    const { lister, reader } = fakeTree({
+      research: ["2026-06-08-CTL-845-research.md"],
+      plans: [],
+    });
+    const out = await buildArtifactList("CTL-84", {
+      thoughtsDir: "/repo/thoughts/shared",
+      lister,
+      reader,
+    });
+    expect(out.artifacts).toEqual([]);
+  });
+
+  it("includes a peek preview and the cross-node eventual-consistency caveat", async () => {
+    const { lister, reader } = fakeTree({
+      research: ["2026-06-08-CTL-845.md"],
+      plans: [],
+    });
+    const out = await buildArtifactList("CTL-845", {
+      thoughtsDir: "/repo/thoughts/shared",
+      lister,
+      reader,
+    });
+    expect(out.artifacts[0].peek).toContain("# peek of 2026-06-08-CTL-845.md");
+    // CTL-866 caveat is surfaced on every response (eventual consistency).
+    expect(out.crossNodeCaveat).toMatch(/thoughts-sync push/);
+    expect(out.crossNodeCaveat).toMatch(/eventual consistency/i);
+  });
+
+  it("degrades to an empty list (never throws) when the thoughts dirs are absent", async () => {
+    const out = await buildArtifactList("CTL-845", {
+      thoughtsDir: "/repo/thoughts/shared",
+      lister: () => {
+        throw new Error("ENOENT");
+      },
+      reader: () => "",
+    });
+    expect(out.artifacts).toEqual([]);
+    expect(out.ticket).toBe("CTL-845");
+  });
+});
+
+describe("readTicketArtifacts — route-facing reader (P9)", () => {
+  it("resolves against an injected cwd + fs collaborators", async () => {
+    const out = await readTicketArtifacts("CTL-845", {
+      cwd: "/repo",
+      lister: (dir: string) =>
+        dir.endsWith("research") ? ["2026-06-08-CTL-845.md"] : [],
+      reader: () => "# body",
+    });
+    expect(out.artifacts).toHaveLength(1);
+    expect(out.artifacts[0].path).toBe("thoughts/shared/research/2026-06-08-CTL-845.md");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/ticket-detail-endpoints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ticket-detail-endpoints.test.ts
@@ -1,0 +1,161 @@
+// CTL-889: integration tests for the cache-backed Linear detail / artifacts /
+// search HTTP routes (P8/P9/P12) wired into the orch-monitor server. Seeds a
+// REAL filter-state.db via the broker helpers (pointed at a temp path) so the
+// routes exercise the actual SQLite read path — proving the data comes from the
+// durable cache, never a live `linearis` call. Encodes the ticket's Gherkin
+// scenarios end-to-end through the HTTP surface.
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+import {
+  openBrokerStateDb,
+  closeBrokerStateDb,
+  upsertTicketDescriptor,
+} from "../../broker/broker-state.mjs";
+import type { TicketDetail } from "../lib/ticket-detail-reader.d.mts";
+import type { TicketArtifacts } from "../lib/ticket-artifacts-reader.d.mts";
+import type { TicketSearchResponse } from "../lib/ticket-search-reader.d.mts";
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+let tmpDir: string;
+let dbPath: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "orch-monitor-ticket-detail-"));
+  const wtDir = join(tmpDir, "wt");
+  mkdirSync(wtDir, { recursive: true });
+  dbPath = join(tmpDir, "filter-state.db");
+
+  // Seed the durable ticket_state cache (the broker's webhook write-through).
+  // The handle is memoized at the module level, so seeding here and constructing
+  // the server with the SAME filterStateDbPath share the one temp DB.
+  closeBrokerStateDb();
+  openBrokerStateDb(dbPath);
+  upsertTicketDescriptor({
+    ticket: "CTL-845",
+    state: "Implement",
+    priority: 2,
+    assignee: "user-uuid-1",
+    labels: ["monitor", "feature", "blocked"],
+    relations: [{ type: "blocks", id: "CTL-901" }],
+    uuid: "uuid-845",
+  });
+  // A sibling that BLOCKS CTL-845 → reverse blocked_by edge on CTL-845.
+  upsertTicketDescriptor({
+    ticket: "CTL-900",
+    state: "Backlog",
+    labels: ["rate-limit", "broker"],
+    relations: [{ type: "blocks", id: "CTL-845" }],
+    uuid: "uuid-900",
+  });
+  upsertTicketDescriptor({
+    ticket: "CTL-901",
+    state: "Done",
+    labels: ["feature"],
+    uuid: "uuid-901",
+  });
+
+  // NOTE: the artifacts route reads from the real repo thoughts tree (cwd). We
+  // do not write into the repo here; the artifacts route's file-resolution logic
+  // is covered by the lib-level ticket-artifacts-reader.test.ts with injected
+  // fs. This integration test only asserts the route returns its envelope shape
+  // (caveat + artifacts array). The DB-backed detail + search routes are the
+  // focus here.
+
+  server = createServer({
+    port: 0,
+    wtDir,
+    catalystDir: tmpDir,
+    filterStateDbPath: dbPath,
+    startWatcher: false,
+    // Disable every external fetcher so the server is hermetic.
+    prStatusFetcher: null,
+    linearFetcher: null,
+    previewFetcher: null,
+    commsReader: null,
+    briefingProvider: null,
+  });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  void server?.stop(true);
+  closeBrokerStateDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("GET /api/ticket-detail/:id (P8)", () => {
+  it("returns labels, relations (forward + reverse), assignee, held — from the cache", async () => {
+    const res = await fetch(`${baseUrl}/api/ticket-detail/CTL-845`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TicketDetail;
+    expect(body.ticket).toBe("CTL-845");
+    expect(body.linearState).toBe("Implement");
+    expect(body.assignee).toBe("user-uuid-1");
+    expect(body.labels).toEqual(["monitor", "feature", "blocked"]);
+    expect(body.held).toBe("blocked");
+    expect(body.relations.forward).toContainEqual({ type: "blocks", id: "CTL-901" });
+    // Reverse edge: CTL-900 blocks CTL-845 → blocked_by on CTL-845.
+    expect(body.relations.reverse).toContainEqual({
+      type: "blocked_by",
+      id: "CTL-900",
+    });
+    // honest nulls: no cached narrative, no held-since timestamp.
+    expect(body.description).toBeNull();
+    expect(body.heldSince).toBeNull();
+    // provenance — the data is from filter-state.db, not a live Linear hit.
+    expect(body.source).toBe("filter-state.db");
+  });
+
+  it("404s a ticket with no descriptor row", async () => {
+    const res = await fetch(`${baseUrl}/api/ticket-detail/CTL-99999`);
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects a path-traversal id", async () => {
+    const res = await fetch(`${baseUrl}/api/ticket-detail/..%2Fetc`);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/search?q= (P12)", () => {
+  it("fuzzy-matches the durable cache (no live Linear call)", async () => {
+    const res = await fetch(`${baseUrl}/api/search?q=rate-limit`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TicketSearchResponse;
+    expect(body.results[0].ticket).toBe("CTL-900");
+    expect(body.source).toBe("filter-state.db");
+  });
+
+  it("matches a ticket id fragment", async () => {
+    const res = await fetch(`${baseUrl}/api/search?q=845`);
+    const body = (await res.json()) as TicketSearchResponse;
+    expect(body.results.map((r) => r.ticket)).toContain("CTL-845");
+  });
+
+  it("returns an empty result set for an empty query (palette idle)", async () => {
+    const res = await fetch(`${baseUrl}/api/search?q=`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TicketSearchResponse;
+    expect(body.results).toEqual([]);
+  });
+});
+
+describe("GET /api/ticket-artifacts/:id (P9)", () => {
+  it("returns the eventual-consistency caveat and an artifacts array", async () => {
+    const res = await fetch(`${baseUrl}/api/ticket-artifacts/CTL-845`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TicketArtifacts;
+    expect(body.ticket).toBe("CTL-845");
+    expect(Array.isArray(body.artifacts)).toBe(true);
+    expect(body.crossNodeCaveat).toMatch(/thoughts-sync push/);
+  });
+
+  it("rejects a path-traversal id", async () => {
+    const res = await fetch(`${baseUrl}/api/ticket-artifacts/..%2Fsecrets`);
+    expect(res.status).toBe(400);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/ticket-detail-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ticket-detail-reader.test.ts
@@ -1,0 +1,172 @@
+// CTL-889 (P8): unit tests for the cache-backed ticket-detail reader. Pure
+// logic — the broker descriptor readers are injected, so no DB / fs / subprocess
+// / live Linear call. Encodes the ticket's Gherkin acceptance scenarios:
+//   • "Ticket detail comes from the durable cache" (description/labels/relations/
+//      assignee/held read from filter-state.db, never a live `linearis` call)
+//   • "Reverse relations and component labels light up" (reverse edges + labels
+//      render from real cached data; nothing fabricated when a field is absent)
+import { describe, it, expect } from "bun:test";
+import {
+  buildTicketDetail,
+  readTicketDetail,
+} from "../lib/ticket-detail-reader.mjs";
+import type { TicketDescriptor } from "../../broker/broker-state.d.mts";
+
+function descriptor(partial: Partial<TicketDescriptor>): TicketDescriptor {
+  return {
+    ticket: partial.ticket ?? "CTL-845",
+    state: partial.state ?? null,
+    prNumber: partial.prNumber ?? null,
+    relations: partial.relations ?? null,
+    labels: partial.labels ?? null,
+    priority: partial.priority ?? null,
+    resolution: partial.resolution ?? null,
+    assignee: partial.assignee ?? null,
+    uuid: partial.uuid ?? null,
+    removed: partial.removed ?? false,
+    removedAt: partial.removedAt ?? null,
+    // CTL-923 (BFF11): fence projection + held-since from the durable cache.
+    ownerHost: partial.ownerHost ?? null,
+    generation: partial.generation ?? null,
+    fencePhase: partial.fencePhase ?? null,
+    claimedAt: partial.claimedAt ?? null,
+    heldSince: partial.heldSince ?? null,
+    updatedAt: partial.updatedAt ?? "2026-06-08T12:00:00.000Z",
+  };
+}
+
+describe("buildTicketDetail — cache-backed detail assembly (P8)", () => {
+  it("returns labels, relations, assignee, state, held — all from the descriptor", () => {
+    const d = descriptor({
+      ticket: "CTL-845",
+      state: "Implement",
+      priority: 2,
+      assignee: "user-uuid-1",
+      labels: ["monitor", "feature", "blocked"],
+      relations: [{ type: "blocks", id: "CTL-900" }],
+    });
+    const detail = buildTicketDetail("CTL-845", d, [d]);
+    expect(detail).not.toBeNull();
+    expect(detail!.ticket).toBe("CTL-845");
+    expect(detail!.linearState).toBe("Implement");
+    expect(detail!.priority).toBe(2);
+    expect(detail!.assignee).toBe("user-uuid-1");
+    expect(detail!.labels).toEqual(["monitor", "feature", "blocked"]);
+    expect(detail!.relations.forward).toEqual([{ type: "blocks", id: "CTL-900" }]);
+    // "blocked" label → held classification "blocked".
+    expect(detail!.held).toBe("blocked");
+    // provenance: cache, never live.
+    expect(detail!.source).toBe("filter-state.db");
+  });
+
+  it("never fabricates the narrative or a held-since duration (honest null)", () => {
+    const d = descriptor({ ticket: "CTL-845", labels: ["waiting"] });
+    const detail = buildTicketDetail("CTL-845", d, [d])!;
+    // The Linear narrative body is NOT in the durable cache → honest null.
+    expect(detail.description).toBeNull();
+    // No held-since timestamp column exists → honest null, never a fake "2h14m".
+    expect(detail.heldSince).toBeNull();
+    expect(detail.held).toBe("waiting");
+  });
+
+  it("computes REVERSE relation edges from sibling descriptors (the relation join)", () => {
+    // CTL-900 declares it BLOCKS CTL-845 → from CTL-845's view CTL-900 is a
+    // blocked_by edge. CTL-901 declares related to CTL-845 → symmetric.
+    const target = descriptor({ ticket: "CTL-845" });
+    const blocker = descriptor({
+      ticket: "CTL-900",
+      relations: [{ type: "blocks", id: "CTL-845" }],
+    });
+    const related = descriptor({
+      ticket: "CTL-901",
+      relations: [{ type: "related", id: "CTL-845" }],
+    });
+    const unrelated = descriptor({
+      ticket: "CTL-902",
+      relations: [{ type: "blocks", id: "CTL-999" }],
+    });
+    const detail = buildTicketDetail("CTL-845", target, [
+      target,
+      blocker,
+      related,
+      unrelated,
+    ])!;
+    expect(detail.relations.reverse).toContainEqual({
+      type: "blocked_by",
+      id: "CTL-900",
+    });
+    expect(detail.relations.reverse).toContainEqual({
+      type: "related",
+      id: "CTL-901",
+    });
+    // The unrelated ticket (points at CTL-999) is NOT a reverse edge here.
+    expect(detail.relations.reverse).not.toContainEqual({
+      type: "blocked_by",
+      id: "CTL-902",
+    });
+  });
+
+  it("renders dim (empty, never fabricated) when relation/label fields are absent", () => {
+    const d = descriptor({ ticket: "CTL-845", relations: null, labels: null });
+    const detail = buildTicketDetail("CTL-845", d, [d])!;
+    expect(detail.relations.forward).toEqual([]);
+    expect(detail.relations.reverse).toEqual([]);
+    expect(detail.labels).toEqual([]);
+    expect(detail.held).toBeNull();
+  });
+
+  it("returns null when the ticket has no descriptor row", () => {
+    expect(buildTicketDetail("CTL-404", null, [])).toBeNull();
+  });
+});
+
+describe("readTicketDetail — route-facing reader (P8)", () => {
+  it("reads via injected descriptor readers (NO live Linear call)", async () => {
+    const target = descriptor({
+      ticket: "CTL-845",
+      state: "Implement",
+      labels: ["monitor"],
+    });
+    const blocker = descriptor({
+      ticket: "CTL-900",
+      relations: [{ type: "blocks", id: "CTL-845" }],
+    });
+    let descriptorCalls = 0;
+    let allCalls = 0;
+    const detail = await readTicketDetail("CTL-845", {
+      descriptorReader: (t) => {
+        descriptorCalls++;
+        return t === "CTL-845" ? target : null;
+      },
+      allDescriptorsReader: () => {
+        allCalls++;
+        return [target, blocker];
+      },
+    });
+    expect(descriptorCalls).toBe(1);
+    expect(allCalls).toBe(1);
+    expect(detail!.linearState).toBe("Implement");
+    expect(detail!.relations.reverse).toContainEqual({
+      type: "blocked_by",
+      id: "CTL-900",
+    });
+  });
+
+  it("returns null for an unknown ticket", async () => {
+    const detail = await readTicketDetail("CTL-404", {
+      descriptorReader: () => null,
+      allDescriptorsReader: () => [],
+    });
+    expect(detail).toBeNull();
+  });
+
+  it("degrades to null (never throws) when a reader rejects", async () => {
+    const detail = await readTicketDetail("CTL-845", {
+      descriptorReader: () => {
+        throw new Error("db locked");
+      },
+      allDescriptorsReader: () => [],
+    });
+    expect(detail).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/ticket-search-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ticket-search-reader.test.ts
@@ -1,0 +1,110 @@
+// CTL-889 (P12): unit tests for the cache-backed fuzzy ticket search. Pure logic
+// — the descriptor reader is injected, so no DB / live Linear call. Encodes the
+// Gherkin acceptance scenario:
+//   • "Search is cache-backed and fuzzy" (fuzzy matches from the cached Linear
+//      truth; NO per-keystroke live Linear API call is made)
+import { describe, it, expect } from "bun:test";
+import {
+  searchDescriptors,
+  readTicketSearch,
+} from "../lib/ticket-search-reader.mjs";
+import type { TicketDescriptor } from "../../broker/broker-state.d.mts";
+
+function descriptor(partial: Partial<TicketDescriptor>): TicketDescriptor {
+  return {
+    ticket: partial.ticket ?? "CTL-1",
+    state: partial.state ?? null,
+    prNumber: null,
+    relations: null,
+    labels: partial.labels ?? null,
+    priority: null,
+    resolution: null,
+    assignee: null,
+    uuid: null,
+    removed: false,
+    removedAt: null,
+    // CTL-923 (BFF11): fence projection + held-since from the durable cache.
+    ownerHost: null,
+    generation: null,
+    fencePhase: null,
+    claimedAt: null,
+    heldSince: null,
+    updatedAt: "2026-06-08T12:00:00.000Z",
+  };
+}
+
+const fixtures: TicketDescriptor[] = [
+  descriptor({ ticket: "CTL-845", state: "Implement", labels: ["monitor"] }),
+  descriptor({
+    ticket: "CTL-900",
+    state: "Backlog",
+    labels: ["rate-limit", "broker"],
+  }),
+  descriptor({ ticket: "CTL-901", state: "Done", labels: ["feature"] }),
+];
+
+describe("searchDescriptors — cache-backed fuzzy search (P12)", () => {
+  it("matches on a label substring (e.g. 'rate-limit')", () => {
+    const out = searchDescriptors("rate-limit", fixtures);
+    expect(out.results[0].ticket).toBe("CTL-900");
+    expect(out.source).toBe("filter-state.db");
+  });
+
+  it("matches a ticket id fragment", () => {
+    const out = searchDescriptors("845", fixtures);
+    expect(out.results.map((r) => r.ticket)).toContain("CTL-845");
+  });
+
+  it("fuzzy-matches a subsequence (chars in order, gapped)", () => {
+    // "mntr" is a subsequence of "monitor" → CTL-845's label haystack.
+    const out = searchDescriptors("mntr", fixtures);
+    expect(out.results.map((r) => r.ticket)).toContain("CTL-845");
+  });
+
+  it("ranks an exact substring above a looser subsequence match", () => {
+    const ds = [
+      descriptor({ ticket: "CTL-100", labels: ["backoff"] }), // 'back' substring
+      descriptor({ ticket: "CTL-200", labels: ["broker"] }), // 'b..k' subsequence
+    ];
+    const out = searchDescriptors("back", ds);
+    expect(out.results[0].ticket).toBe("CTL-100");
+  });
+
+  it("returns no matches when nothing fuzzy-matches", () => {
+    const out = searchDescriptors("zzzzqqqq", fixtures);
+    expect(out.results).toEqual([]);
+  });
+
+  it("respects the limit", () => {
+    const many = Array.from({ length: 50 }, (_, i) =>
+      descriptor({ ticket: `CTL-${i}`, labels: ["monitor"] }),
+    );
+    const out = searchDescriptors("monitor", many, { limit: 5 });
+    expect(out.results).toHaveLength(5);
+  });
+});
+
+describe("readTicketSearch — route-facing reader (P12)", () => {
+  it("reads via an injected descriptor reader (NO live Linear call)", async () => {
+    let calls = 0;
+    const out = await readTicketSearch("rate-limit", {
+      descriptorsReader: () => {
+        calls++;
+        return fixtures;
+      },
+    });
+    // ONE cache read for the query — never a per-keystroke live Linear API call.
+    expect(calls).toBe(1);
+    expect(out.results[0].ticket).toBe("CTL-900");
+  });
+
+  it("degrades to an empty result set (never throws) when the reader rejects", async () => {
+    const out = await readTicketSearch("anything", {
+      descriptorsReader: () => {
+        throw new Error("db locked");
+      },
+    });
+    expect(out.results).toEqual([]);
+    expect(out.query).toBe("anything");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/ticket-artifacts-reader.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/ticket-artifacts-reader.d.mts
@@ -1,0 +1,51 @@
+// Type declarations for ticket-artifacts-reader.mjs (CTL-889, P9). Keep in sync
+// with the object assembled in the .mjs.
+
+/** One research/plan artifact resolved for a ticket. */
+export interface TicketArtifact {
+  /** The artifact kind — "research" or "plan". */
+  kind: "research" | "plan";
+  /** Repo-root-relative path to the markdown file. */
+  path: string;
+  /** First few KB of the file for the peek pane, or null when unreadable. */
+  peek: string | null;
+}
+
+export interface TicketArtifacts {
+  /** The requested ticket identifier. */
+  ticket: string;
+  /** Resolved artifacts, ordered research-before-plan then by path. */
+  artifacts: TicketArtifact[];
+  /** Eventual-consistency note (CTL-866 multi-host thoughts-sync caveat). */
+  crossNodeCaveat: string;
+}
+
+export interface BuildArtifactListOptions {
+  /** Repo-root-relative thoughts/shared dir (default "thoughts/shared"). */
+  thoughtsRel?: string;
+  /** Absolute path to the thoughts/shared dir to scan. */
+  thoughtsDir?: string;
+  /** Directory lister (default fs/promises readdir). */
+  lister?: (dir: string) => string[] | Promise<string[]>;
+  /** File reader (default fs/promises readFile utf8). */
+  reader?: (path: string) => string | Promise<string>;
+}
+
+/** Pure-ish assembler: scan thoughts dirs for a ticket's artifacts. */
+export function buildArtifactList(
+  ticket: string,
+  opts?: BuildArtifactListOptions,
+): Promise<TicketArtifacts>;
+
+export interface ReadTicketArtifactsOptions {
+  /** Working directory the thoughts tree is resolved against (default cwd). */
+  cwd?: string;
+  lister?: (dir: string) => string[] | Promise<string[]>;
+  reader?: (path: string) => string | Promise<string>;
+}
+
+/** Route-facing reader: resolve a ticket's artifacts from the local thoughts tree. */
+export function readTicketArtifacts(
+  ticket: string,
+  opts?: ReadTicketArtifactsOptions,
+): Promise<TicketArtifacts>;

--- a/plugins/dev/scripts/orch-monitor/lib/ticket-artifacts-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/ticket-artifacts-reader.mjs
@@ -1,0 +1,138 @@
+// ticket-artifacts-reader.mjs — resolve a ticket's research/plan thoughts
+// artifacts for the LIFECYCLE SPINE 📄 links (CTL-889, P9).
+//
+// The spine's `📄research` / `📄plan` nodes link to the markdown the phase
+// agents persist under `thoughts/shared/{research,plans}/`. This reader globs
+// those two directories for files whose name carries the ticket id and returns
+// their relative paths plus a small "peek" preview of the file head, so the UI
+// can render the link AND a hover/peek pane without a second round-trip.
+//
+// MULTI-HOST CAVEAT (CTL-866, inherited): thoughts are synced between nodes by a
+// push, not shared live. An artifact authored on another node is only visible
+// here AFTER that node's thoughts-sync push lands locally. This reader reads the
+// LOCAL thoughts tree only, so `crossNodeCaveat` is surfaced on every response
+// to keep that eventual-consistency honest in the UI. In the SINGLE-HOST MVP
+// (hosts.json absent / length 1) there is no other node, so the local tree IS
+// the whole truth and the caveat is informational only.
+//
+// All filesystem collaborators are injectable so the route + unit tests drive it
+// without a real thoughts tree. Tolerant of an absent dir: a missing
+// research/plans dir simply contributes no artifacts (never throws).
+
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+// The two phase-artifact kinds the spine links, mapped to their on-disk dirs.
+// `plans` is the real dir name (plural); `plan` is tolerated for forward-compat
+// in case a future writer uses the singular the design doc references.
+const ARTIFACT_DIRS = [
+  { kind: "research", dirs: ["research"] },
+  { kind: "plan", dirs: ["plans", "plan"] },
+];
+
+const PEEK_BYTES = 4096;
+
+// Does this filename belong to the requested ticket? The phase agents write
+// `<date>-<ticket>.md`, but operators also embed the id mid-name
+// (`2026-06-07-ctl-845-humanlayer-...md`), so match the id as a whole token
+// anywhere in the (case-insensitive) basename — bounded by a non-alphanumeric on
+// each side so "CTL-8" never matches "CTL-845".
+function fileMatchesTicket(name, ticket) {
+  if (!name.toLowerCase().endsWith(".md")) return false;
+  const lname = name.toLowerCase();
+  const lticket = ticket.toLowerCase();
+  let from = 0;
+  for (;;) {
+    const idx = lname.indexOf(lticket, from);
+    if (idx === -1) return false;
+    const before = idx === 0 ? "" : lname[idx - 1];
+    const after = lname[idx + lticket.length] ?? "";
+    const boundary = (c) => c === "" || !/[a-z0-9]/.test(c);
+    if (boundary(before) && boundary(after)) return true;
+    from = idx + 1;
+  }
+}
+
+// Read the first PEEK_BYTES of a file as UTF-8 for the peek pane. Returns null
+// on any read failure (the link still renders; the peek just shows nothing).
+async function peekFile(absPath, reader) {
+  try {
+    const text = await reader(absPath);
+    return typeof text === "string" ? text.slice(0, PEEK_BYTES) : null;
+  } catch {
+    return null;
+  }
+}
+
+// buildArtifactList — scan the configured kind→dir map under `thoughtsDir` for
+// files matching `ticket`, returning the sorted relative paths + peek preview.
+// Pure-ish: `lister` and `reader` are injectable so tests run without fs.
+//
+// Returns: { ticket, artifacts: [{ kind, path, peek }], crossNodeCaveat }
+//   • `path` is relative to the repo root (e.g.
+//     "thoughts/shared/research/2026-06-07-ctl-845-...md") so the UI can build a
+//     stable deep link.
+//   • `crossNodeCaveat` is always present — the eventual-consistency note.
+export async function buildArtifactList(
+  ticket,
+  {
+    thoughtsRel = join("thoughts", "shared"),
+    thoughtsDir,
+    lister,
+    reader,
+  } = {},
+) {
+  const baseAbs = thoughtsDir ?? thoughtsRel;
+  const artifacts = [];
+  for (const { kind, dirs } of ARTIFACT_DIRS) {
+    for (const dir of dirs) {
+      const absDir = join(baseAbs, dir);
+      let names;
+      try {
+        names = await lister(absDir);
+      } catch {
+        continue; // dir absent → no artifacts of this kind from this dir
+      }
+      if (!Array.isArray(names)) continue;
+      for (const name of names) {
+        if (!fileMatchesTicket(name, ticket)) continue;
+        const relPath = join(thoughtsRel, dir, name);
+        const peek = await peekFile(join(absDir, name), reader);
+        artifacts.push({ kind, path: relPath, peek });
+      }
+    }
+  }
+  // Deterministic order: by kind (research before plan) then path.
+  const kindRank = { research: 0, plan: 1 };
+  artifacts.sort((a, b) => {
+    const dk = (kindRank[a.kind] ?? 9) - (kindRank[b.kind] ?? 9);
+    if (dk !== 0) return dk;
+    return a.path < b.path ? -1 : a.path > b.path ? 1 : 0;
+  });
+  return {
+    ticket,
+    artifacts,
+    // Eventual-consistency note (CTL-866): cross-node artifacts are only visible
+    // after a thoughts-sync push. In the single-host MVP this is informational.
+    crossNodeCaveat:
+      "Artifacts are read from the local thoughts tree; cross-node artifacts " +
+      "appear only after a thoughts-sync push (eventual consistency).",
+  };
+}
+
+// readTicketArtifacts — the route-facing reader. Defaults `lister`/`reader` to
+// the real fs/promises, resolving the thoughts tree relative to `cwd` (the repo
+// root the orch-monitor server runs from). Tolerant of an absent tree (empty
+// artifact list), never throws.
+export async function readTicketArtifacts(
+  ticket,
+  { cwd = process.cwd(), lister, reader } = {},
+) {
+  const thoughtsRel = join("thoughts", "shared");
+  return buildArtifactList(ticket, {
+    thoughtsRel,
+    thoughtsDir: join(cwd, thoughtsRel),
+    lister: lister ?? ((d) => readdir(d)),
+    reader: reader ?? ((p) => readFile(p, "utf8")),
+  });
+}

--- a/plugins/dev/scripts/orch-monitor/lib/ticket-detail-reader.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/ticket-detail-reader.d.mts
@@ -1,0 +1,67 @@
+// Type declarations for ticket-detail-reader.mjs (CTL-889, P8). Keep in sync
+// with the object assembled in the .mjs.
+
+import type { TicketDescriptor } from "../../broker/broker-state.d.mts";
+
+/** One relation graph edge — a typed pointer to another ticket. */
+export interface TicketRelationEdge {
+  /** Relation type, e.g. "blocks" | "blocked_by" | "related" | "duplicate_of". */
+  type: string;
+  /** The related ticket identifier (e.g. "CTL-780"). */
+  id: string;
+}
+
+export interface TicketDetail {
+  /** The requested ticket identifier. */
+  ticket: string;
+  /** Linear workflow state name from the descriptor, or null. */
+  linearState: string | null;
+  /** 0=no priority, 1=urgent .. 4=low (Linear scale), or null when uncached. */
+  priority: number | null;
+  /** Assignee UUID from the descriptor, or null. */
+  assignee: string | null;
+  /** Linear resolution from the descriptor, or null. */
+  resolution: string | null;
+  /** Descriptor last-updated ISO timestamp, or null. */
+  updatedAt: string | null;
+  /** Linear narrative body — NOT stored in the durable cache, so always null. */
+  description: null;
+  /** Component/held labels from the descriptor. */
+  labels: string[];
+  /** Held classification from the labels ("blocked" | "waiting" | null). */
+  held: "blocked" | "waiting" | null;
+  /** Held-since timestamp — no cache column today, so always null (honest). */
+  heldSince: null;
+  /** Forward + reverse relation graph edges. */
+  relations: {
+    /** Edges THIS ticket's descriptor declares. */
+    forward: TicketRelationEdge[];
+    /** Edges OTHER tickets declare pointing at this ticket. */
+    reverse: TicketRelationEdge[];
+  };
+  /** Provenance marker — always "filter-state.db" (never a live Linear hit). */
+  source: "filter-state.db";
+}
+
+/** Pure assembler: build the detail object from durable descriptors. */
+export function buildTicketDetail(
+  ticket: string,
+  descriptor: TicketDescriptor | null | undefined,
+  allDescriptors?: TicketDescriptor[],
+): TicketDetail | null;
+
+export interface ReadTicketDetailOptions {
+  dbPath?: string;
+  descriptorReader?: (
+    ticket: string,
+  ) => TicketDescriptor | null | Promise<TicketDescriptor | null>;
+  allDescriptorsReader?: () =>
+    | TicketDescriptor[]
+    | Promise<TicketDescriptor[]>;
+}
+
+/** Route-facing reader: assemble cache-backed detail, or null (→ 404). */
+export function readTicketDetail(
+  ticket: string,
+  opts?: ReadTicketDetailOptions,
+): Promise<TicketDetail | null>;

--- a/plugins/dev/scripts/orch-monitor/lib/ticket-detail-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/ticket-detail-reader.mjs
@@ -1,0 +1,165 @@
+// ticket-detail-reader.mjs — cache-backed Linear ticket detail for the ticket
+// detail page's RELATIONS / LABELS / HELD / narrative panels (CTL-889, P8).
+//
+// The board payload (board-data.mjs) carries the FORWARD `blockers[]` edge and
+// the held label classification, but the ticket detail page also needs:
+//   • reverse relation edges (who BLOCKS this ticket, what RELATES to it),
+//   • the full component LABELS set,
+//   • the assignee,
+//   • the Linear workflow state + priority,
+//   • the held classification + the held-since timestamp (when the cache has one).
+//
+// Every field is read EXCLUSIVELY from the broker's durable filter-state.db
+// ticket_state descriptor (CTL-821) via the broker-state read helpers — this
+// route NEVER does a synchronous `linearis` call (the BFF1 / CTL-883 decision,
+// and the rate-limit win the brief calls out). The Linear circuit breaker
+// (execution-core/linear-breaker.mjs) is honored by construction: this module
+// spawns NOTHING, so it cannot trip the breaker and a cache read is always
+// served.
+//
+// HONEST-NULL CONTRACT: a field the durable cache does not carry is returned as
+// null/[] — never fabricated. In particular:
+//   • `description` (the Linear narrative body) is NOT stored in ticket_state,
+//     so it is always null here (the UI renders that row dim). Re-fetching it
+//     live would violate the cache-only architecture.
+//   • `heldSince` has no timestamp column in ticket_state today — `heldFor` is
+//     pure label classification with no "since" — so it stays null until a real
+//     timestamp lands in the cache (never a fabricated "2h14m").
+
+import { heldFor } from "./board-data.mjs";
+
+// Normalize one stored relation entry to { type, id }. ticket_state stores
+// relations as a JSON array of { type, id } (see broker ticket-descriptor.test:
+// `relations: [{ type: "blocks", id: "CTL-780" }]`). Tolerant of partial/odd
+// shapes — a malformed entry is dropped rather than throwing the whole read.
+function normRelation(rel) {
+  if (!rel || typeof rel !== "object") return null;
+  const type = typeof rel.type === "string" ? rel.type : null;
+  const id =
+    typeof rel.id === "string"
+      ? rel.id
+      : typeof rel.identifier === "string"
+        ? rel.identifier
+        : null;
+  if (!id) return null;
+  return { type: type ?? "related", id };
+}
+
+// Forward relations stored on THIS ticket's descriptor → [{ type, id }].
+function forwardRelations(descriptor) {
+  const raw = descriptor?.relations;
+  if (!Array.isArray(raw)) return [];
+  const out = [];
+  for (const r of raw) {
+    const n = normRelation(r);
+    if (n) out.push(n);
+  }
+  return out;
+}
+
+// Linear relation types come in inverse pairs. To surface the REVERSE edges the
+// board payload does not carry, scan every OTHER descriptor: if ticket B's
+// descriptor declares `{ type: "blocks", id: A }`, then from A's perspective B
+// is a `blocked_by` edge; a `related` edge is symmetric. This is the relation-
+// graph join the ticket calls out as the L/5 cost driver.
+const INVERSE_TYPE = {
+  blocks: "blocked_by",
+  blocked_by: "blocks",
+  related: "related",
+  duplicate_of: "duplicate",
+  duplicate: "duplicate_of",
+};
+
+function reverseRelations(ticket, allDescriptors) {
+  const out = [];
+  for (const d of allDescriptors) {
+    if (!d || d.ticket === ticket) continue;
+    const rels = Array.isArray(d.relations) ? d.relations : [];
+    for (const r of rels) {
+      const n = normRelation(r);
+      if (!n || n.id !== ticket) continue;
+      out.push({ type: INVERSE_TYPE[n.type] ?? n.type, id: d.ticket });
+    }
+  }
+  return out;
+}
+
+// buildTicketDetail — assemble the cache-backed detail object from the durable
+// descriptors. Pure: the descriptor + the full descriptor set are passed in, so
+// the unit tests drive it without a DB. Returns null when the ticket has no
+// descriptor row (the route maps that to 404).
+//
+// Returns: {
+//   ticket, linearState, priority, assignee, resolution, updatedAt,
+//   description (always null — narrative not cached),
+//   labels: string[],
+//   held: "blocked" | "waiting" | null,
+//   heldSince: null,           // no timestamp in the cache today (honest null)
+//   relations: {
+//     forward: [{ type, id }], // edges THIS ticket declares
+//     reverse: [{ type, id }], // edges OTHER tickets declare pointing here
+//   },
+//   source: "filter-state.db", // provenance marker — NEVER a live Linear hit
+// }
+export function buildTicketDetail(ticket, descriptor, allDescriptors = []) {
+  if (!descriptor) return null;
+  const labels = Array.isArray(descriptor.labels)
+    ? descriptor.labels.filter((l) => typeof l === "string" && l.length > 0)
+    : [];
+  return {
+    ticket,
+    linearState: descriptor.state ?? null,
+    priority: typeof descriptor.priority === "number" ? descriptor.priority : null,
+    assignee: descriptor.assignee ?? null,
+    resolution: descriptor.resolution ?? null,
+    updatedAt: descriptor.updatedAt ?? null,
+    // The Linear narrative body is not stored in ticket_state — honest null,
+    // never re-fetched live (cache-only).
+    description: null,
+    labels,
+    held: heldFor(labels),
+    // No timestamp column for the held transition exists in the cache today;
+    // surface null rather than a fabricated duration (the UI renders ↯).
+    heldSince: null,
+    relations: {
+      forward: forwardRelations(descriptor),
+      reverse: reverseRelations(ticket, allDescriptors),
+    },
+    source: "filter-state.db",
+  };
+}
+
+// readTicketDetail — the route-facing reader. Opens (or reuses) the broker's
+// shared filter-state.db handle and reads the requested descriptor plus the full
+// descriptor set for the reverse-edge join, then assembles via buildTicketDetail.
+//
+// All collaborators are injectable so the route + unit tests drive it without a
+// real DB. Tolerant of an absent/locked DB: any failure returns null (the route
+// maps that to 404), never throws, never blocks (CTL-883 cache-only contract).
+export async function readTicketDetail(
+  ticket,
+  {
+    dbPath,
+    // injection seams (default to the real broker-state durable readers)
+    descriptorReader,
+    allDescriptorsReader,
+  } = {},
+) {
+  try {
+    let descRead = descriptorReader;
+    let allRead = allDescriptorsReader;
+    if (!descRead || !allRead) {
+      const { openBrokerStateDb, getTicketDescriptor, getAllTicketDescriptors } =
+        await import("../../broker/broker-state.mjs");
+      openBrokerStateDb(dbPath);
+      descRead = descRead ?? ((t) => getTicketDescriptor(t));
+      allRead = allRead ?? (() => getAllTicketDescriptors());
+    }
+    const descriptor = await descRead(ticket);
+    if (!descriptor) return null;
+    const all = (await allRead()) ?? [];
+    return buildTicketDetail(ticket, descriptor, all);
+  } catch {
+    return null;
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/lib/ticket-search-reader.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/ticket-search-reader.d.mts
@@ -1,0 +1,46 @@
+// Type declarations for ticket-search-reader.mjs (CTL-889, P12). Keep in sync
+// with the object assembled in the .mjs.
+
+import type { TicketDescriptor } from "../../broker/broker-state.d.mts";
+
+/** One fuzzy search result row. */
+export interface TicketSearchResult {
+  /** The matched ticket identifier. */
+  ticket: string;
+  /** Linear workflow state name from the descriptor, or null. */
+  linearState: string | null;
+  /** Component/held labels from the descriptor. */
+  labels: string[];
+  /** Match score — higher is a better match (substring > subsequence). */
+  score: number;
+}
+
+export interface TicketSearchResponse {
+  /** The original query string. */
+  query: string;
+  /** Ranked matches, capped at `limit`. */
+  results: TicketSearchResult[];
+  /** Provenance marker — always "filter-state.db" (never a live Linear hit). */
+  source: "filter-state.db";
+}
+
+/** Pure fuzzy search over a descriptor array. */
+export function searchDescriptors(
+  query: string,
+  descriptors: TicketDescriptor[],
+  opts?: { limit?: number },
+): TicketSearchResponse;
+
+export interface ReadTicketSearchOptions {
+  dbPath?: string;
+  limit?: number;
+  descriptorsReader?: () =>
+    | TicketDescriptor[]
+    | Promise<TicketDescriptor[]>;
+}
+
+/** Route-facing reader: fuzzy-search the durable ticket_state cache. */
+export function readTicketSearch(
+  query: string,
+  opts?: ReadTicketSearchOptions,
+): Promise<TicketSearchResponse>;

--- a/plugins/dev/scripts/orch-monitor/lib/ticket-search-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/ticket-search-reader.mjs
@@ -1,0 +1,107 @@
+// ticket-search-reader.mjs — cache-backed fuzzy ticket search for the ⌘K
+// palette's "Search all tickets in Linear" action (CTL-889, P12).
+//
+// The palette searches the resident board payload for tickets already on the
+// board, but "search ALL tickets" needs the wider Linear-truth set. This reader
+// serves that from the broker's durable filter-state.db ticket_state cache —
+// EXACTLY like the detail route, it NEVER issues a per-keystroke live Linear
+// call (the rate-limit win, BFF1 / CTL-883). The Linear circuit breaker is
+// honored by construction: this module spawns nothing.
+//
+// The match is a lightweight fuzzy scorer over each descriptor's searchable
+// text (ticket id + workflow state + labels): an exact substring ranks highest,
+// then a contiguous-token match, then a subsequence (characters in order). This
+// is deliberately simple and dependency-free — the cache is hundreds of rows, so
+// a linear scan per query is cheap and a fuzzy library would be over-kill.
+
+// Build the searchable haystack for one descriptor: id + state + labels, joined
+// and lower-cased. The id is duplicated up front so an id-prefix query ranks it
+// strongly.
+function haystackFor(d) {
+  const parts = [d.ticket ?? ""];
+  if (d.state) parts.push(d.state);
+  if (Array.isArray(d.labels)) parts.push(...d.labels.filter(Boolean));
+  return parts.join(" ").toLowerCase();
+}
+
+// Score a query against a haystack. Higher = better; 0 = no match.
+//   • exact substring → 1000 − position (earlier is better)
+//   • subsequence (chars in order, possibly gapped) → up to ~500, denser = higher
+//   • no subsequence → 0
+function fuzzyScore(query, haystack) {
+  if (query.length === 0) return 1; // empty query matches everything weakly
+  const sub = haystack.indexOf(query);
+  if (sub !== -1) return 1000 - Math.min(sub, 999);
+  // subsequence walk
+  let qi = 0;
+  let firstHit = -1;
+  let lastHit = -1;
+  let hits = 0;
+  for (let hi = 0; hi < haystack.length && qi < query.length; hi++) {
+    if (haystack[hi] === query[qi]) {
+      if (firstHit === -1) firstHit = hi;
+      lastHit = hi;
+      hits++;
+      qi++;
+    }
+  }
+  if (qi < query.length) return 0; // not all query chars matched in order
+  // Denser spans (smaller first→last window) and earlier starts score higher.
+  const span = lastHit - firstHit + 1;
+  const density = hits / span; // (0, 1]
+  return Math.round(200 + density * 200 - Math.min(firstHit, 100));
+}
+
+// searchDescriptors — pure fuzzy search over a descriptor array. Injected by the
+// route + tests so no DB is required. Returns the top-`limit` matches as
+// lightweight result rows, ranked by score then id.
+//
+// Returns: { query, results: [{ ticket, linearState, labels, score }], source }
+export function searchDescriptors(query, descriptors, { limit = 20 } = {}) {
+  const q = (query ?? "").trim().toLowerCase();
+  const scored = [];
+  for (const d of descriptors ?? []) {
+    if (!d || !d.ticket) continue;
+    const score = fuzzyScore(q, haystackFor(d));
+    if (score <= 0) continue;
+    scored.push({
+      ticket: d.ticket,
+      linearState: d.state ?? null,
+      labels: Array.isArray(d.labels) ? d.labels.filter(Boolean) : [],
+      score,
+    });
+  }
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.ticket < b.ticket ? -1 : a.ticket > b.ticket ? 1 : 0;
+  });
+  return {
+    query: query ?? "",
+    results: scored.slice(0, Math.max(0, limit)),
+    source: "filter-state.db",
+  };
+}
+
+// readTicketSearch — the route-facing reader. Opens (or reuses) the broker's
+// shared filter-state.db handle, reads every descriptor in one pass, and fuzzy-
+// matches the query. Injectable for tests. Tolerant of an absent/locked DB:
+// returns an empty result set (never throws, never blocks — CTL-883).
+export async function readTicketSearch(
+  query,
+  { dbPath, limit = 20, descriptorsReader } = {},
+) {
+  try {
+    let read = descriptorsReader;
+    if (!read) {
+      const { openBrokerStateDb, getAllTicketDescriptors } = await import(
+        "../../broker/broker-state.mjs"
+      );
+      openBrokerStateDb(dbPath);
+      read = () => getAllTicketDescriptors();
+    }
+    const descriptors = (await read()) ?? [];
+    return searchDescriptors(query, descriptors, { limit });
+  } catch {
+    return { query: query ?? "", results: [], source: "filter-state.db" };
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -152,6 +152,13 @@ import {
   isValidChannelName,
   type CommsReader,
 } from "./lib/comms-reader";
+// CTL-889 (P8/P9/P12): cache-backed Linear detail / artifacts / search readers.
+// All three read EXCLUSIVELY from durable caches (filter-state.db ticket_state +
+// the local thoughts tree) and NEVER do a synchronous live Linear call per
+// request — the rate-limit win, consistent with the BFF1 (CTL-883) decision.
+import { readTicketDetail } from "./lib/ticket-detail-reader.mjs";
+import { readTicketArtifacts } from "./lib/ticket-artifacts-reader.mjs";
+import { readTicketSearch } from "./lib/ticket-search-reader.mjs";
 
 type BunServer = ReturnType<typeof Bun.serve>;
 
@@ -182,6 +189,13 @@ export interface CreateServerOptions {
   previewFetcher?: PreviewFetcher | null;
   previewRefreshMs?: number;
   annotationsDbPath?: string;
+  /**
+   * Override for the broker's durable filter-state.db (ticket_state cache) used
+   * by the cache-backed Linear detail/search routes (CTL-889, P8/P12). Defaults
+   * to `${catalystDir}/filter-state.db` — the broker's own default. Tests point
+   * this at a seeded temp DB so the routes don't read the live broker cache.
+   */
+  filterStateDbPath?: string;
   terminal?: boolean;
   renderOptions?: RenderOptions;
   commsReader?: CommsReader | null;
@@ -525,6 +539,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     previewFetcher: previewFetcherOpt,
     previewRefreshMs = PREVIEW_REFRESH_MS,
     annotationsDbPath,
+    filterStateDbPath,
     commsReader: commsReaderOpt,
     webhookConfig,
     linearWebhookConfig,
@@ -535,6 +550,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
   const CATALYST_DIR =
     catalystDirOpt ?? process.env.CATALYST_DIR ?? `${process.env.HOME}/catalyst`;
   const annDbPath = annotationsDbPath ?? `${CATALYST_DIR}/annotations.db`;
+  // CTL-889: the broker's durable ticket_state cache the detail/search routes
+  // read (filter-state.db). Defaults to the broker's own default path.
+  const filterStateDb = filterStateDbPath ?? `${CATALYST_DIR}/filter-state.db`;
   try {
     openDb(annDbPath);
   } catch (err) {
@@ -1412,6 +1430,88 @@ export function createServer(opts: CreateServerOptions): BunServer {
           const eventsDir = join(CATALYST_DIR, "events");
           const subSteps = readSubStepEvents(eventsDir, ticketParam);
           return Response.json({ ticket: ticketParam, subSteps });
+        }
+
+        // CTL-889 (P8): cache-backed Linear ticket detail — description (null,
+        // not cached), labels[], the relation graph (forward + reverse
+        // blocks/related edges), assignee, and held classification. Read from
+        // filter-state.db ticket_state, NEVER a live `linearis` call. 404 when
+        // the ticket has no descriptor row.
+        const ticketDetailMatch = url.pathname.match(
+          /^\/api\/ticket-detail\/([^/]+)$/,
+        );
+        if (ticketDetailMatch) {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(ticketDetailMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            ticket.includes("..") ||
+            ticket.includes("/") ||
+            ticket.includes("\0")
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const detail = await readTicketDetail(ticket, {
+            dbPath: filterStateDb,
+          });
+          if (!detail) {
+            return new Response("Not Found", { status: 404 });
+          }
+          return Response.json(detail);
+        }
+
+        // CTL-889 (P9): a ticket's research/plan thoughts artifacts for the
+        // spine 📄 links — repo-root-relative paths + a peek preview, read from
+        // the LOCAL thoughts tree. Surfaces the CTL-866 cross-node eventual-
+        // consistency caveat (artifacts authored on another node appear only
+        // after a thoughts-sync push).
+        const ticketArtifactsMatch = url.pathname.match(
+          /^\/api\/ticket-artifacts\/([^/]+)$/,
+        );
+        if (ticketArtifactsMatch) {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(ticketArtifactsMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            ticket.includes("..") ||
+            ticket.includes("/") ||
+            ticket.includes("\0")
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const artifacts = await readTicketArtifacts(ticket);
+          return Response.json(artifacts);
+        }
+
+        // CTL-889 (P12): cache-backed fuzzy ticket search for the ⌘K palette's
+        // "Search all tickets in Linear" action. Fuzzy-matches the durable
+        // ticket_state cache — NO per-keystroke live Linear API call. An empty
+        // ?q= returns an empty result set (the palette renders the row idle).
+        if (url.pathname === "/api/search") {
+          const q = url.searchParams.get("q") ?? "";
+          const limitRaw = url.searchParams.get("limit");
+          const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
+          const limit = Number.isFinite(parsedLimit)
+            ? Math.max(1, Math.min(parsedLimit, 100))
+            : 20;
+          if (q.trim() === "") {
+            return Response.json({
+              query: q,
+              results: [],
+              source: "filter-state.db",
+            });
+          }
+          const result = await readTicketSearch(q, {
+            dbPath: filterStateDb,
+            limit,
+          });
+          return Response.json(result);
         }
 
         if (url.pathname === "/api/briefing") {


### PR DESCRIPTION
## Summary

Three read-only orch-monitor routes (P8/P9/P12) that serve the ticket detail page's RELATIONS / LABELS / HELD / narrative panels, the lifecycle-spine artifact links, and the ⌘K "Search all tickets in Linear" action — **all served EXCLUSIVELY from durable caches, never a synchronous live Linear hit per request** (the BFF1 / CTL-883 rate-limit decision). The Linear circuit breaker is honored by construction: these readers spawn nothing, so they cannot trip it and a cache read is always served.

- **P8** `GET /api/ticket-detail/<id>` → `lib/ticket-detail-reader.mjs`: labels[], assignee, Linear state/priority, held classification, and the relation graph (**forward** edges from the ticket's own descriptor + **reverse** edges joined across sibling descriptors). Read from `filter-state.db` `ticket_state`. Honest nulls — `description` (narrative not cached) and `heldSince` (no timestamp column) are never fabricated. 404 when no descriptor row exists.
- **P9** `GET /api/ticket-artifacts/<id>` → `lib/ticket-artifacts-reader.mjs`: `thoughts/shared/{research,plans}/*<id>*.md` paths + a peek preview for the spine 📄 links, from the local thoughts tree. Surfaces the CTL-866 cross-node eventual-consistency caveat.
- **P12** `GET /api/search?q=` → `lib/ticket-search-reader.mjs`: cache-backed fuzzy ticket search over `ticket_state` (substring > subsequence ranking). Empty `q` → empty set (palette renders the row idle). No per-keystroke live Linear API call.

All readers are pure with injection seams and degrade soft (null / empty, never throw) on a locked/absent DB. `filterStateDbPath` is a new (test-only-defaulted) server option so the routes can be pointed at a seeded temp DB.

## Gherkin scenarios

| Scenario | Status |
|---|---|
| **Ticket detail comes from the durable cache** — `GET /api/ticket-detail/CTL-845` returns description, labels[], relation graph (blocks/related), assignee, held; read from filter-state.db, not a live `linearis` call | ✅ satisfied (P8) |
| **Artifacts resolve to thoughts paths** — `GET /api/ticket-artifacts/CTL-845` returns `thoughts/shared/{research,plan}/*-CTL-845.md` paths; cross-node visibility gated on a thoughts-sync push | ✅ satisfied (P9) |
| **Search is cache-backed and fuzzy** — `GET /api/search?q=rate-limit` returns fuzzy matches from cached Linear truth; no per-keystroke live Linear API call | ✅ satisfied (P12) |
| **Reverse relations and component labels light up** — blocks/related reverse edges + component label chips render from real cached data; nothing fabricated when a field is absent (rows render dim) | ✅ satisfied (P8) |

### Single-node MVP descope
No multi-node anchors (CTL-863/864/865/866/873/876) were built. The P9 **cross-node thoughts-sync caveat** (CTL-866) is satisfied by the single-host identity no-op: the reader reads the local thoughts tree, which IS the whole truth when `hosts.json` is absent/length 1, and surfaces `crossNodeCaveat` on every response so the eventual-consistency contract is honest without any N>1 machinery.

## Honest-null contract (never fabricated)
- `description` (Linear narrative body) — not stored in `ticket_state` → always `null` (UI renders dim). Re-fetching live would violate the cache-only architecture.
- `heldSince` — no held-transition timestamp column exists today → always `null` (never a fabricated "2h14m"; the design doc's `held-duration ↯NEEDS-PLUMBING`).
- absent relations/labels → `[]`, never invented chips/edges.

## Tests
- `__tests__/ticket-detail-reader.test.ts`, `ticket-artifacts-reader.test.ts`, `ticket-search-reader.test.ts` — pure lib logic with injected readers (no DB/fs).
- `__tests__/ticket-detail-endpoints.test.ts` — integration: seeds a real `filter-state.db` via the broker helpers and exercises the HTTP routes end-to-end (proving the data is cache-sourced).

Run: `bun test __tests__/ticket-detail-reader.test.ts __tests__/ticket-artifacts-reader.test.ts __tests__/ticket-search-reader.test.ts __tests__/ticket-detail-endpoints.test.ts` → **30 pass**. `bunx tsc --noEmit` clean for the orch-monitor package; eslint + knip clean on new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)