### PR TITLE
feat(dev): SHELL1 edge-to-edge app shell + left nav (CTL-891)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/app-shell.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/app-shell.test.ts
@@ -1,0 +1,176 @@
+// app-shell.test.ts — CTL-891 / SHELL1 acceptance guards.
+//
+// Encodes the three SHELL1 Gherkin scenarios. `bun test` has no DOM, so —
+// matching the existing board-todo-column.test.ts pattern — the structural
+// scenarios are asserted by static source analysis (read the .tsx as text and
+// assert the load-bearing wiring), and the pure surface-contract core
+// (lib/surface.ts) is unit-tested directly.
+import { describe, it, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  SURFACES,
+  SURFACE_CHORD,
+  SURFACE_BREADCRUMB,
+  SURFACE_LABEL,
+  isTypingTarget,
+  type Surface,
+} from "../ui/src/lib/surface";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const UI_SRC = join(HERE, "..", "ui", "src");
+const read = (rel: string) => readFileSync(join(UI_SRC, rel), "utf8");
+
+const appSrc = read("App.tsx");
+const shellSrc = read("components/app-shell.tsx");
+const sidebarComponentSrc = read("components/app-sidebar.tsx");
+const sidebarPrimitiveSrc = read("components/ui/sidebar.tsx");
+
+/**
+ * Strip JS comments so "edge-to-edge" CLASSNAME assertions can't be tripped by
+ * prose that merely mentions `mx-auto` / `max-w-*` in a code comment. Removes
+ * block comments, JSX `{/* … *​/}` comments, and `//` line comments.
+ */
+function stripComments(src: string): string {
+  return src
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "") // {/* jsx comment */}
+    .replace(/\/\*[\s\S]*?\*\//g, "") // /* block */
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1"); // // line (skip http://)
+}
+
+const appCode = stripComments(appSrc);
+const shellCode = stripComments(shellSrc);
+
+// ── Pure surface contract (lib/surface.ts) ───────────────────────────────────
+describe("surface contract (CTL-891)", () => {
+  it("declares exactly the four OPERATE surfaces in nav order", () => {
+    expect([...SURFACES]).toEqual(["home", "board", "workers", "queue"]);
+  });
+
+  it("maps a g-chord key to every surface (g h / g b / g w / g q)", () => {
+    expect(SURFACE_CHORD).toEqual({
+      h: "home",
+      b: "board",
+      w: "workers",
+      q: "queue",
+    });
+    // Every surface is reachable by some chord, and every chord targets a real surface.
+    const chordTargets = new Set(Object.values(SURFACE_CHORD));
+    for (const s of SURFACES) expect(chordTargets.has(s)).toBe(true);
+  });
+
+  it("has a label and a breadcrumb trail for every surface", () => {
+    for (const s of SURFACES) {
+      expect(SURFACE_LABEL[s]).toBeTruthy();
+      expect(SURFACE_BREADCRUMB[s].length).toBeGreaterThan(0);
+    }
+    // Home is the calm Inbox — its trail reads "Home · Inbox".
+    expect(SURFACE_BREADCRUMB.home).toEqual(["Home", "Inbox"]);
+  });
+
+  it("isTypingTarget guards INPUT/TEXTAREA/contentEditable so chords never steal typing", () => {
+    expect(isTypingTarget({ tagName: "INPUT" })).toBe(true);
+    expect(isTypingTarget({ tagName: "TEXTAREA" })).toBe(true);
+    expect(isTypingTarget({ isContentEditable: true })).toBe(true);
+    expect(isTypingTarget({ tagName: "DIV" })).toBe(false);
+    expect(isTypingTarget(null)).toBe(false);
+  });
+});
+
+// ── Scenario: shadcn Sidebar primitive is the foundation, not the hand-rolled one
+describe("shadcn Sidebar primitive is the foundation (CTL-891)", () => {
+  it("ships a shadcn sidebar primitive exporting the load-bearing parts", () => {
+    for (const sym of [
+      "SidebarProvider",
+      "Sidebar",
+      "SidebarInset",
+      "SidebarMenu",
+      "SidebarTrigger",
+      "SidebarRail",
+      "useSidebar",
+    ]) {
+      expect(sidebarPrimitiveSrc).toContain(sym);
+    }
+  });
+
+  it("the sidebar primitive is built on radix-ui + cva (matches the ui conventions, not base-ui)", () => {
+    expect(sidebarPrimitiveSrc).toContain('from "radix-ui"');
+    expect(sidebarPrimitiveSrc).toContain("class-variance-authority");
+    // base-nova/base-ui drift must be reconciled away — no @base-ui imports leak in.
+    expect(sidebarPrimitiveSrc).not.toContain("@base-ui");
+  });
+
+  it("AppSidebar composes the shadcn primitives (Provider/Inset live in AppShell)", () => {
+    expect(sidebarComponentSrc).toContain("@/components/ui/sidebar");
+    for (const sym of [
+      "Sidebar",
+      "SidebarContent",
+      "SidebarGroup",
+      "SidebarMenu",
+      "SidebarMenuButton",
+      "SidebarRail",
+    ]) {
+      expect(sidebarComponentSrc).toContain(sym);
+    }
+  });
+
+  it("the OPERATE group lists Home, Board, Workers, Queue", () => {
+    for (const label of ["Home", "Board", "Workers", "Queue"]) {
+      expect(sidebarComponentSrc).toContain(label);
+    }
+    expect(sidebarComponentSrc).toMatch(/Operate/i);
+  });
+
+  it("the legacy hand-rolled components/layout/sidebar is no longer the App frame", () => {
+    // App.tsx must not import the hand-rolled layout sidebar as its frame anymore.
+    expect(appSrc).not.toContain("./components/layout/sidebar");
+    expect(appSrc).not.toContain("components/layout/sidebar");
+    // The new shadcn shell is the frame instead.
+    expect(appSrc).toContain("app-shell");
+  });
+});
+
+// ── Scenario: One shell hosts every surface + Edge-to-edge by default ─────────
+describe("one edge-to-edge shell hosts every surface (CTL-891)", () => {
+  it("AppShell uses a CONTROLLED SidebarProvider wrapping SidebarInset", () => {
+    expect(shellSrc).toContain("SidebarProvider");
+    expect(shellSrc).toContain("SidebarInset");
+    // Controlled (owns open + onOpenChange) so BOTH `[` and Cmd/Ctrl+B drive collapse.
+    expect(shellSrc).toMatch(/onOpenChange/);
+  });
+
+  it("the shell is full-viewport (h-screen) with NO centered gutter", () => {
+    expect(shellSrc).toContain("h-screen");
+    // Edge-to-edge: no centered max-w / mx-auto CLASSNAME around the chrome
+    // (comments stripped so prose mentioning the tokens doesn't false-positive).
+    expect(shellCode).not.toMatch(/\bmx-auto\b/);
+    expect(shellCode).not.toMatch(
+      /\bmax-w-(sm|md|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl|screen)\b/,
+    );
+    expect(appCode).not.toMatch(/\bmx-auto\b/);
+  });
+
+  it("AppShell binds the `[` collapse toggle and `g`-chord surface jumps", () => {
+    expect(shellSrc).toContain('"["');
+    expect(shellSrc).toContain("isTypingTarget");
+    expect(shellSrc).toContain("SURFACE_CHORD");
+  });
+
+  it("App.tsx renders the active surface INSIDE the shell (edge-to-edge inset)", () => {
+    expect(appSrc).toContain("AppShell");
+  });
+});
+
+// Sanity: the Surface type is exhaustively iterable (compile-time exhaustiveness
+// is also enforced by `satisfies`-free switch usage in App; this is the runtime guard).
+test("SURFACES round-trips the Surface union", () => {
+  const seen: Record<Surface, boolean> = {
+    home: false,
+    board: false,
+    workers: false,
+    queue: false,
+  };
+  for (const s of SURFACES) seen[s] = true;
+  expect(Object.values(seen).every(Boolean)).toBe(true);
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
@@ -2,14 +2,12 @@ import { useMemo, useState, useCallback, useEffect, lazy, Suspense } from "react
 import { useMonitor } from "./hooks/use-monitor";
 import { useKeyboardNav } from "./hooks/use-keyboard-nav";
 import { useCommsChannels } from "./hooks/use-comms";
-import { Sidebar } from "./components/layout/sidebar";
+import { AppShell } from "./components/app-shell";
 import { AttentionBar } from "./components/attention-bar";
 import { SessionDetailDrawer } from "./components/session-detail-drawer";
 import { ConnectionBanner } from "./components/ui/connection-banner";
 import { OtelHealthBanner } from "./components/ui/otel-health-banner";
 import { SkeletonDashboard } from "./components/ui/skeleton";
-import { ChevronRight, Home, PanelLeftClose, PanelLeft } from "lucide-react";
-import type { GroupingMode } from "./lib/grouping";
 import {
   SESSION_TIME_FILTERS,
   type SessionTimeFilter,
@@ -76,30 +74,19 @@ function Monitor() {
   // `selectedWorker` is lifted up from `OrchestratorView` so the Activity pane
   // can pivot directly to a worker drawer via cross-link chips.
   const [selectedWorker, setSelectedWorker] = useState<string | null>(null);
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  // CTL-891 / SHELL1: the AppShell now owns sidebar collapse + the grouping
+  // affordance moved off the frame; the dashboard content keeps its own
+  // time-filter (set by internal controls) and topView switching.
   const [topView, setTopView] = useState<TopView>("dashboard");
   const [commsInitialFilter, setCommsInitialFilter] =
     useState<CommsFilter | null>(null);
-  const [groupingMode, setGroupingMode] = useState<GroupingMode>(
-    () => (localStorage.getItem("catalyst-sidebar-grouping") as GroupingMode) || "flat",
-  );
-  const [timeFilter, setTimeFilter] = useState<SessionTimeFilter>(() => {
+  const [timeFilter] = useState<SessionTimeFilter>(() => {
     const stored = localStorage.getItem("catalyst-session-filter");
     return SESSION_TIME_FILTERS.includes(stored as SessionTimeFilter)
       ? (stored as SessionTimeFilter)
       : "active";
   });
   const [version, setVersion] = useState<string | null>(null);
-
-  const handleGroupingChange = useCallback((mode: GroupingMode) => {
-    setGroupingMode(mode);
-    localStorage.setItem("catalyst-sidebar-grouping", mode);
-  }, []);
-
-  const handleTimeFilterChange = useCallback((filter: SessionTimeFilter) => {
-    setTimeFilter(filter);
-    localStorage.setItem("catalyst-session-filter", filter);
-  }, []);
 
   useEffect(() => {
     fetch("/api/version")
@@ -122,40 +109,11 @@ function Monitor() {
   const effectiveOrch =
     selectedOrchId && !selectedOrch ? null : selectedOrch;
 
-  const handleSelect = useCallback((orchId: string | null) => {
-    setSelectedOrchId(orchId);
-    setSelectedSession(null);
-    setSelectedWorker(null);
-    setTopView("dashboard");
-  }, []);
-
   const handleSessionSelect = useCallback((sessionId: string) => {
     setSelectedSession(sessionId);
     setSelectedOrchId(null);
     setSelectedWorker(null);
     setTopView("dashboard");
-  }, []);
-
-  const handleCommsSelect = useCallback(() => {
-    setTopView("comms");
-    setSelectedOrchId(null);
-    setSelectedSession(null);
-    setSelectedWorker(null);
-    setCommsInitialFilter(null);
-  }, []);
-
-  const handleActivitySelect = useCallback(() => {
-    setTopView("activity");
-    setSelectedOrchId(null);
-    setSelectedSession(null);
-    setSelectedWorker(null);
-  }, []);
-
-  const handleGodModeSelect = useCallback(() => {
-    setTopView("god-mode");
-    setSelectedOrchId(null);
-    setSelectedSession(null);
-    setSelectedWorker(null);
   }, []);
 
   const handleActivityPivot = useCallback(
@@ -209,96 +167,33 @@ function Monitor() {
   );
 
   return (
-    <div className="flex h-screen bg-surface-0 text-fg">
-      <Sidebar
-        orchestrators={snapshot.orchestrators}
-        sessions={sessions}
-        selectedOrchId={effectiveOrch ? selectedOrchId : null}
-        onSelect={handleSelect}
-        selectedSessionId={selectedSession}
-        onSessionSelect={handleSessionSelect}
-        connectionStatus={connectionStatus}
-        attentionCount={attention.length}
-        collapsed={!sidebarOpen}
-        onToggle={() => setSidebarOpen((o) => !o)}
-        groupingMode={groupingMode}
-        onGroupingModeChange={handleGroupingChange}
-        timeFilter={timeFilter}
-        onTimeFilterChange={handleTimeFilterChange}
-        topView={topView}
-        onCommsSelect={handleCommsSelect}
-        onActivitySelect={handleActivitySelect}
-        onGodModeSelect={handleGodModeSelect}
-      />
-
-      <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        <header className="flex items-center justify-between border-b border-border bg-surface-1 px-5 py-2.5">
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() => setSidebarOpen((o) => !o)}
-              className="rounded p-1 text-muted transition-colors hover:bg-surface-3 hover:text-fg"
-              aria-label="Toggle sidebar"
-            >
-              {sidebarOpen ? (
-                <PanelLeftClose className="h-4 w-4" />
-              ) : (
-                <PanelLeft className="h-4 w-4" />
-              )}
-            </button>
-            <nav className="flex items-center gap-1.5 text-[13px]">
-              <button
-                onClick={() => {
-                  setSelectedOrchId(null);
-                  setTopView("dashboard");
-                }}
-                className="flex items-center gap-1 text-muted transition-colors hover:text-fg"
-              >
-                <Home className="h-3.5 w-3.5" />
-                Dashboard
-              </button>
-              {topView === "comms" && (
-                <>
-                  <ChevronRight className="h-3 w-3 text-border" />
-                  <span className="font-medium text-fg">Comms</span>
-                </>
-              )}
-              {topView === "activity" && (
-                <>
-                  <ChevronRight className="h-3 w-3 text-border" />
-                  <span className="font-medium text-fg">Activity</span>
-                </>
-              )}
-              {topView === "dashboard" && effectiveOrch && (
-                <>
-                  <ChevronRight className="h-3 w-3 text-border" />
-                  <span className="font-mono font-medium text-fg">
-                    {effectiveOrch.id}
-                  </span>
-                </>
-              )}
-            </nav>
-          </div>
-          <div className="flex items-center gap-3 text-[12px] text-muted">
-            {snapshot.timestamp && (
-              <span>
-                {new Date(snapshot.timestamp).toLocaleDateString(undefined, {
-                  month: "short",
-                  day: "numeric",
-                  year: "numeric",
-                })}{" "}
-                {new Date(snapshot.timestamp).toLocaleTimeString()}
-              </span>
-            )}
-            {version && (
-              <span className="font-mono opacity-50">v{version}</span>
-            )}
-          </div>
-        </header>
+    // CTL-891 / SHELL1: the AppShell is now the app frame — a full-viewport,
+    // edge-to-edge shadcn Sidebar shell (controlled SidebarProvider + SidebarInset
+    // + OPERATE/OBSERVE nav). The existing dashboard content renders edge-to-edge
+    // inside the inset. Surface→content wiring (Board/Workers/Queue) and live
+    // badges are later SHELL tickets; here the dashboard is the inset content.
+    <AppShell>
+      <div className="flex h-full min-h-0 flex-col bg-surface-0 text-fg">
+        {/* Content-level meta row: snapshot timestamp + version. The frame's
+            breadcrumb + collapse live in the AppShell top strip now. */}
+        <div className="flex items-center justify-end gap-3 border-b border-border bg-surface-1 px-5 py-2 text-[12px] text-muted">
+          {snapshot.timestamp && (
+            <span>
+              {new Date(snapshot.timestamp).toLocaleDateString(undefined, {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              })}{" "}
+              {new Date(snapshot.timestamp).toLocaleTimeString()}
+            </span>
+          )}
+          {version && <span className="font-mono opacity-50">v{version}</span>}
+        </div>
 
         <ConnectionBanner status={connectionStatus} className="mx-5 mt-3" />
         <OtelHealthBanner health={otelHealth} className="mx-5 mt-3" />
 
-        <div className="flex-1 overflow-y-auto p-5">
+        <div className="min-h-0 flex-1 overflow-y-auto p-5">
           <Suspense fallback={<SkeletonDashboard />}>
             {topView === "comms" ? (
               <div className="animate-fade-in">
@@ -356,7 +251,7 @@ function Monitor() {
             )}
           </Suspense>
         </div>
-      </main>
+      </div>
 
       {selectedSession &&
         (() => {
@@ -368,6 +263,6 @@ function Monitor() {
             />
           ) : null;
         })()}
-    </div>
+    </AppShell>
   );
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/app.css
+++ b/plugins/dev/scripts/orch-monitor/ui/src/app.css
@@ -36,6 +36,18 @@
   --color-input: var(--input);
   --color-ring: var(--ring);
 
+  /* CTL-891 / SHELL1: shadcn `sidebar` primitive tokens, bridged to the
+     orch-monitor surface system below (reconciles the prototype's base-nova
+     drift onto this ui's new-york tokens). */
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -63,6 +75,17 @@
   --input: var(--color-border);
   --ring: var(--color-accent);
   --radius: 0.5rem;
+
+  /* CTL-891 / SHELL1: sidebar surface — the rail sits one step up from the
+     base surface so the SidebarInset (background) reads as a raised card. */
+  --sidebar: var(--color-surface-1);
+  --sidebar-foreground: var(--color-fg);
+  --sidebar-primary: var(--color-accent);
+  --sidebar-primary-foreground: var(--color-surface-0);
+  --sidebar-accent: var(--color-surface-3);
+  --sidebar-accent-foreground: var(--color-fg);
+  --sidebar-border: var(--color-border);
+  --sidebar-ring: var(--color-accent);
 }
 
 * {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
@@ -1,0 +1,238 @@
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  InboxIcon,
+  LayoutGridIcon,
+  ListOrderedIcon,
+  SearchIcon,
+  UsersIcon,
+} from "lucide-react";
+
+import {
+  SurfaceContext,
+  SURFACE_BREADCRUMB,
+  SURFACE_CHORD,
+  SURFACE_LABEL,
+  SURFACES,
+  isTypingTarget,
+  type Surface,
+} from "@/lib/surface";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Separator } from "@/components/ui/separator";
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
+import { AppSidebar } from "@/components/app-sidebar";
+
+// CTL-891 / SHELL1 — the full-viewport (h-screen, NO outer max-w / mx-auto)
+// frame, ported from the prototype `mockups/home-proto/src/components/AppShell`.
+// Owns:
+//  - a CONTROLLED SidebarProvider (own open + onOpenChange) so BOTH `[` and the
+//    built-in Cmd/Ctrl+B drive collapse; persists open-state to localStorage.
+//  - the `g h` / `g b` / `g w` / `g q` chord handlers + `[` toggle, all of which
+//    ignore text-entry targets.
+//  - the active SURFACE state, exposed via SurfaceContext to the sidebar.
+//  - the ⌘K command palette (jump to any surface).
+//  - the top strip inside SidebarInset (trigger + breadcrumb + ⌘K).
+// Surface→route wiring is the FND stream's concern; this shell only exposes the
+// SurfaceContext contract the nav binds to.
+
+const SIDEBAR_STORAGE_KEY = "catalyst:sidebar-open";
+
+/** Read persisted sidebar-open state (defaults open). */
+function readSidebarOpen(): boolean {
+  if (typeof window === "undefined") return true;
+  return window.localStorage.getItem(SIDEBAR_STORAGE_KEY) !== "false";
+}
+
+const SURFACE_ICON: Record<Surface, typeof InboxIcon> = {
+  home: InboxIcon,
+  board: LayoutGridIcon,
+  workers: UsersIcon,
+  queue: ListOrderedIcon,
+};
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState<boolean>(readSidebarOpen);
+  const [surface, setSurface] = useState<Surface>("home");
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  // Persist collapse state across reloads (the controlled provider replaces the
+  // primitive's cookie path; localStorage is the source of truth here).
+  useEffect(() => {
+    window.localStorage.setItem(SIDEBAR_STORAGE_KEY, String(open));
+  }, [open]);
+
+  // `[` toggles the rail; `g <key>` chords jump surfaces. Both ignore typing.
+  useEffect(() => {
+    let chordArmed = false;
+    let chordTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const onKey = (e: KeyboardEvent) => {
+      if (isTypingTarget(e.target as HTMLElement | null)) return;
+
+      // `[` — primary collapse toggle (Cmd/Ctrl+B handled by the provider).
+      if (e.key === "[" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        setOpen((o) => !o);
+        return;
+      }
+
+      // `g` arms a chord; the next key picks the surface (g h / g b / g w / g q).
+      if (e.key === "g" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        chordArmed = true;
+        clearTimeout(chordTimer);
+        chordTimer = setTimeout(() => {
+          chordArmed = false;
+        }, 800);
+        return;
+      }
+      if (chordArmed) {
+        const target = SURFACE_CHORD[e.key];
+        if (target) {
+          e.preventDefault();
+          setSurface(target);
+        }
+        chordArmed = false;
+        clearTimeout(chordTimer);
+      }
+    };
+
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      clearTimeout(chordTimer);
+    };
+  }, []);
+
+  // ⌘K / Ctrl+K opens the command palette; clicks on the sidebar's search field
+  // (data-cmdk-trigger) open it too.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setPaletteOpen((o) => !o);
+      }
+    };
+    const onClick = (e: MouseEvent) => {
+      const el = e.target as HTMLElement | null;
+      if (el?.closest("[data-cmdk-trigger]")) {
+        e.preventDefault();
+        setPaletteOpen(true);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("click", onClick);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("click", onClick);
+    };
+  }, []);
+
+  const jumpTo = useCallback((s: Surface) => {
+    setSurface(s);
+    setPaletteOpen(false);
+  }, []);
+
+  const surfaceCtx = useMemo(() => ({ surface, setSurface }), [surface]);
+
+  const crumbs = SURFACE_BREADCRUMB[surface];
+
+  return (
+    <SurfaceContext.Provider value={surfaceCtx}>
+      {/* Controlled provider → Cmd/Ctrl+B still fires through onOpenChange, so
+          `[` and Cmd/Ctrl+B both work with no vendoring. h-screen, edge-to-edge:
+          no outer max-w / mx-auto container around the chrome. */}
+      <SidebarProvider
+        open={open}
+        onOpenChange={setOpen}
+        className="h-screen min-h-screen"
+      >
+        <AppSidebar />
+        <SidebarInset className="min-h-0 overflow-hidden">
+          {/* ── Thin top strip: hamburger + breadcrumb + ⌘K search ─────────── */}
+          <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-3">
+            <SidebarTrigger className="text-muted-foreground" />
+            <Separator orientation="vertical" className="mr-1 h-4!" />
+            <Breadcrumb>
+              <BreadcrumbList>
+                {crumbs.map((crumb, i) => {
+                  const isLast = i === crumbs.length - 1;
+                  return (
+                    // Separators are SIBLINGS of items (both <li>) — never nest a
+                    // separator inside an item, or it's <li> within <li>.
+                    <Fragment key={crumb}>
+                      <BreadcrumbItem>
+                        {isLast ? (
+                          <BreadcrumbPage>{crumb}</BreadcrumbPage>
+                        ) : (
+                          <span className="text-muted-foreground">{crumb}</span>
+                        )}
+                      </BreadcrumbItem>
+                      {!isLast && <BreadcrumbSeparator />}
+                    </Fragment>
+                  );
+                })}
+              </BreadcrumbList>
+            </Breadcrumb>
+
+            {/* ⌘K search trigger. */}
+            <button
+              type="button"
+              data-cmdk-trigger
+              className="ml-auto flex h-7 items-center gap-2 rounded-md border border-border bg-secondary/30 px-2 text-xs text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+              aria-label="Search or jump to…"
+            >
+              <SearchIcon className="size-3.5" />
+              <span className="hidden sm:inline">Search…</span>
+              <kbd className="rounded border border-border bg-background/60 px-1 py-0.5 text-[10px]">
+                ⌘K
+              </kbd>
+            </button>
+          </header>
+
+          {/* The active surface renders edge-to-edge below the strip. */}
+          <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
+        </SidebarInset>
+      </SidebarProvider>
+
+      {/* ── ⌘K command palette — jump to any surface ───────────────────────── */}
+      <CommandDialog open={paletteOpen} onOpenChange={setPaletteOpen}>
+        <CommandInput placeholder="Jump to a surface or search a ticket…" />
+        <CommandList>
+          <CommandEmpty>No results.</CommandEmpty>
+          <CommandGroup heading="Go to">
+            {SURFACES.map((s) => {
+              const Icon = SURFACE_ICON[s];
+              return (
+                <CommandItem
+                  key={s}
+                  value={SURFACE_LABEL[s]}
+                  onSelect={() => jumpTo(s)}
+                >
+                  <Icon className="size-4" />
+                  {SURFACE_LABEL[s]}
+                </CommandItem>
+              );
+            })}
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>
+    </SurfaceContext.Provider>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
@@ -1,0 +1,251 @@
+import { useState } from "react";
+import {
+  ActivityIcon,
+  ChevronRightIcon,
+  GaugeIcon,
+  InboxIcon,
+  LayoutGridIcon,
+  ListOrderedIcon,
+  SearchIcon,
+  ServerIcon,
+  SettingsIcon,
+  UsersIcon,
+  WalletIcon,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useSurface, type Surface } from "@/lib/surface";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+  useSidebar,
+} from "@/components/ui/sidebar";
+
+// CTL-891 / SHELL1 — the OPERATE/OBSERVE left nav, ported from the prototype
+// `mockups/home-proto/src/components/AppSidebar.tsx`. Live badges + status dots
+// are MOCK now (per the ticket: "lands the frame and the OPERATE nav shell with
+// mock/placeholder badges"). Wire to the unified event log
+// (~/catalyst/events/YYYY-MM.jsonl) the HUD already reads in a later SHELL
+// ticket — that same stream feeds worker count, queue depth, and the Board
+// anomaly dot. The workspace switcher / theme toggle are also later SHELL slots.
+
+// ── OPERATE nav — the touch-it-every-minute tier ─────────────────────────────
+type OperateItem = {
+  surface: Surface;
+  label: string;
+  icon: typeof InboxIcon;
+  /** Numeric badge (active worker count / queue depth). MOCK for SHELL1. */
+  badge?: number;
+  /** A small status dot overlaying the icon — survives the icon-collapse. MOCK. */
+  dot?: "live" | "anomaly";
+};
+
+const OPERATE: OperateItem[] = [
+  { surface: "home", label: "Home", icon: InboxIcon },
+  { surface: "board", label: "Board", icon: LayoutGridIcon, dot: "anomaly" },
+  {
+    surface: "workers",
+    label: "Workers",
+    icon: UsersIcon,
+    badge: 4,
+    dot: "live",
+  },
+  { surface: "queue", label: "Queue", icon: ListOrderedIcon, badge: 7 },
+];
+
+// ── OBSERVE — the "go deeper" tier, ships now, items land over time ───────────
+const OBSERVE = [
+  { label: "Telemetry", icon: ActivityIcon },
+  { label: "Utilization", icon: GaugeIcon },
+  { label: "FinOps", icon: WalletIcon },
+  { label: "Fleet Ops", icon: ServerIcon },
+] as const;
+
+/** A status dot overlaid on a nav icon (emerald = live, amber = anomaly). */
+function StatusDot({ kind }: { kind: "live" | "anomaly" }) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "pointer-events-none absolute -top-0.5 -right-0.5 size-2 rounded-full ring-2 ring-sidebar",
+        kind === "live" ? "bg-emerald-500" : "bg-amber-500",
+      )}
+    />
+  );
+}
+
+export function AppSidebar() {
+  const { surface, setSurface } = useSurface();
+  const { setOpenMobile, isMobile } = useSidebar();
+  const [observeOpen, setObserveOpen] = useState(false);
+
+  function go(s: Surface) {
+    setSurface(s);
+    if (isMobile) setOpenMobile(false);
+  }
+
+  return (
+    <Sidebar variant="inset" collapsible="icon">
+      {/* ── HEADER: logo + ⌘K trigger ───────────────────────────────────────── */}
+      <SidebarHeader className="gap-2">
+        <div className="flex items-center gap-2 px-1 pt-1">
+          <img
+            src="/public/favicon.svg"
+            alt="Catalyst"
+            className="size-[22px] shrink-0 group-data-[collapsible=icon]:size-5"
+          />
+          <span className="text-sm font-medium tracking-tight group-data-[collapsible=icon]:hidden">
+            Catalyst
+          </span>
+        </div>
+
+        {/* ⌘K search trigger, styled as a muted field. Opens the command palette
+            (the cmd+k handler lives in AppShell). */}
+        <button
+          type="button"
+          data-cmdk-trigger
+          className={cn(
+            "flex h-8 w-full items-center gap-2 rounded-md border border-border bg-secondary/40 px-2 text-sm text-muted-foreground",
+            "transition-colors hover:bg-secondary hover:text-foreground",
+            "group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0",
+          )}
+          aria-label="Search or jump to…"
+        >
+          <SearchIcon className="size-4 shrink-0" />
+          <span className="flex-1 text-left group-data-[collapsible=icon]:hidden">
+            Search…
+          </span>
+          <kbd className="rounded border border-border bg-background/60 px-1 py-0.5 text-[10px] text-muted-foreground group-data-[collapsible=icon]:hidden">
+            ⌘K
+          </kbd>
+        </button>
+      </SidebarHeader>
+
+      <SidebarContent>
+        {/* ── OPERATE — always expanded, the primary tier ─────────────────── */}
+        <SidebarGroup>
+          <SidebarGroupLabel>Operate</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {OPERATE.map((item) => (
+                <SidebarMenuItem key={item.surface}>
+                  <SidebarMenuButton
+                    isActive={surface === item.surface}
+                    tooltip={item.label}
+                    onClick={() => go(item.surface)}
+                  >
+                    <span className="relative flex items-center justify-center">
+                      <item.icon />
+                      {item.dot && <StatusDot kind={item.dot} />}
+                    </span>
+                    <span>{item.label}</span>
+                  </SidebarMenuButton>
+                  {item.badge != null && (
+                    <SidebarMenuBadge>{item.badge}</SidebarMenuBadge>
+                  )}
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        {/* ── OBSERVE — collapsible, defaults collapsed, "soon" items ──────── */}
+        <Collapsible
+          open={observeOpen}
+          onOpenChange={setObserveOpen}
+          className="group/observe"
+        >
+          <SidebarGroup>
+            {/* Trigger styled to MATCH SidebarGroupLabel, kept as a plain
+                interactive CollapsibleTrigger <button>. */}
+            <CollapsibleTrigger
+              className={cn(
+                "flex h-8 w-full shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-hidden transition-[margin,opacity,color] duration-200 ease-linear",
+                "cursor-pointer hover:text-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+                "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+              )}
+            >
+              <ChevronRightIcon className="mr-1 size-3.5 transition-transform duration-200 group-data-[state=open]/observe:rotate-90" />
+              Observe
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  {OBSERVE.map((item) => (
+                    <SidebarMenuItem key={item.label}>
+                      <SidebarMenuButton
+                        disabled
+                        tooltip={`${item.label} — coming soon`}
+                        className="cursor-not-allowed opacity-55"
+                      >
+                        <item.icon />
+                        <span>{item.label}</span>
+                      </SidebarMenuButton>
+                      <SidebarMenuBadge className="text-[10px] text-muted-foreground/70">
+                        soon
+                      </SidebarMenuBadge>
+                    </SidebarMenuItem>
+                  ))}
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </CollapsibleContent>
+          </SidebarGroup>
+        </Collapsible>
+      </SidebarContent>
+
+      {/* ── FOOTER: settings + daemon-health dot ────────────────────────────── */}
+      <SidebarFooter>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton tooltip="Settings">
+              <SettingsIcon />
+              <span>Settings</span>
+            </SidebarMenuButton>
+            {/* daemon-health dot — emerald = daemon healthy. MOCK for SHELL1;
+                wire to the event stream (~/catalyst/events/YYYY-MM.jsonl). */}
+            <SidebarMenuBadge>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Daemon healthy"
+                    className="flex size-5 cursor-default items-center justify-center"
+                  >
+                    <span
+                      aria-hidden
+                      className="size-2 rounded-full bg-emerald-500"
+                    />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right">Daemon healthy</TooltipContent>
+              </Tooltip>
+            </SidebarMenuBadge>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+
+      {/* Click the hairline rail to collapse/expand (calls toggleSidebar). */}
+      <SidebarRail />
+    </Sidebar>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ui/breadcrumb.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,112 @@
+import * as React from "react";
+import { Slot } from "radix-ui";
+import { ChevronRight, MoreHorizontal } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+// CTL-891: shadcn `breadcrumb` primitive for the AppShell top strip
+// (Home · Inbox trail). Canonical shadcn new-york, adapted to the ui's
+// `radix-ui` unified import + `data-slot` convention.
+function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />;
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1.5", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbLink({
+  asChild,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean;
+}) {
+  const Comp = asChild ? Slot.Root : "a";
+
+  return (
+    <Comp
+      data-slot="breadcrumb-link"
+      className={cn("hover:text-foreground transition-colors", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("text-foreground font-normal", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5", className)}
+      {...props}
+    >
+      {children ?? <ChevronRight />}
+    </li>
+  );
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontal className="size-4" />
+      <span className="sr-only">More</span>
+    </span>
+  );
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+};

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ui/button.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ui/button.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+import { Slot } from "radix-ui";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+// CTL-891: shadcn `sidebar` primitive dependency (SidebarMenuButton/Trigger lean
+// on Button for the icon/ghost variants). Canonical shadcn new-york Button,
+// adapted to the ui's `radix-ui` unified import + `data-slot` convention.
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? Slot.Root : "button";
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ui/collapsible.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ui/collapsible.tsx
@@ -1,0 +1,34 @@
+import { Collapsible as CollapsiblePrimitive } from "radix-ui";
+
+// CTL-891: shadcn `collapsible` primitive — backs the OBSERVE group's
+// expand/collapse in AppSidebar. Canonical shadcn new-york, on the ui's
+// `radix-ui` unified import + `data-slot` convention.
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Trigger>) {
+  return (
+    <CollapsiblePrimitive.Trigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  );
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Content>) {
+  return (
+    <CollapsiblePrimitive.Content
+      data-slot="collapsible-content"
+      {...props}
+    />
+  );
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ui/input.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+// CTL-891: shadcn `sidebar` primitive dependency (SidebarInput). Canonical
+// shadcn new-york Input, using the ui's `data-slot` convention.
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ui/sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ui/sidebar.tsx
@@ -1,0 +1,726 @@
+import * as React from "react";
+import { Slot } from "radix-ui";
+import { cva, type VariantProps } from "class-variance-authority";
+import { PanelLeftIcon } from "lucide-react";
+
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+// CTL-891 / SHELL1: the shadcn `sidebar` primitive — the load-bearing foundation
+// for the whole app shell. Authored to MATCH the ui's existing shadcn new-york
+// conventions (the `radix-ui` unified package + `data-slot` + `lucide-react`),
+// reconciling the base-nova/base-ui drift the prototype carried. Every later
+// SHELL ticket (collapse, IA, badges, top strip, switcher, nav-health) builds on
+// these exports.
+const SIDEBAR_COOKIE_NAME = "sidebar_state";
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+const SIDEBAR_WIDTH = "16rem";
+const SIDEBAR_WIDTH_MOBILE = "18rem";
+const SIDEBAR_WIDTH_ICON = "3rem";
+const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+
+type SidebarContextProps = {
+  state: "expanded" | "collapsed";
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  openMobile: boolean;
+  setOpenMobile: (open: boolean) => void;
+  isMobile: boolean;
+  toggleSidebar: () => void;
+};
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null);
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext);
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.");
+  }
+  return context;
+}
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  className,
+  style,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const isMobile = useIsMobile();
+  const [openMobile, setOpenMobile] = React.useState(false);
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
+  const [_open, _setOpen] = React.useState(defaultOpen);
+  const open = openProp ?? _open;
+  const setOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === "function" ? value(open) : value;
+      if (setOpenProp) {
+        setOpenProp(openState);
+      } else {
+        _setOpen(openState);
+      }
+
+      // This sets the cookie to keep the sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+    },
+    [setOpenProp, open],
+  );
+
+  // Helper to toggle the sidebar.
+  const toggleSidebar = React.useCallback(() => {
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
+  }, [isMobile, setOpen, setOpenMobile]);
+
+  // Adds a keyboard shortcut to toggle the sidebar (Cmd/Ctrl+B).
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault();
+        toggleSidebar();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [toggleSidebar]);
+
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
+  const state = open ? "expanded" : "collapsed";
+
+  const contextValue = React.useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+    }),
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar],
+  );
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <TooltipProvider delayDuration={0}>
+        <div
+          data-slot="sidebar-wrapper"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH,
+              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+              ...style,
+            } as React.CSSProperties
+          }
+          className={cn(
+            "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </div>
+      </TooltipProvider>
+    </SidebarContext.Provider>
+  );
+}
+
+function Sidebar({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  side?: "left" | "right";
+  variant?: "sidebar" | "floating" | "inset";
+  collapsible?: "offcanvas" | "icon" | "none";
+}) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+
+  if (collapsible === "none") {
+    return (
+      <div
+        data-slot="sidebar"
+        className={cn(
+          "bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <div
+      className="group peer text-sidebar-foreground hidden md:block"
+      data-state={state}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-variant={variant}
+      data-side={side}
+      data-slot="sidebar"
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        data-slot="sidebar-gap"
+        className={cn(
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "group-data-[collapsible=offcanvas]:w-0",
+          "group-data-[side=right]:rotate-180",
+          variant === "floating" || variant === "inset"
+            ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
+        )}
+      />
+      <div
+        data-slot="sidebar-container"
+        className={cn(
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          side === "left"
+            ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
+            : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+          // Adjust the padding for floating and inset variants.
+          variant === "floating" || variant === "inset"
+            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          className,
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar"
+          data-slot="sidebar-inner"
+          className="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SidebarTrigger({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon"
+      className={cn("size-7", className)}
+      onClick={(event) => {
+        onClick?.(event);
+        toggleSidebar();
+      }}
+      {...props}
+    >
+      <PanelLeftIcon />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  );
+}
+
+function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        "bg-background relative flex w-full flex-1 flex-col",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn("bg-background h-8 w-full shadow-none", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn("bg-sidebar-border mx-2 w-auto", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn(
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupLabel({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "div";
+
+  return (
+    <Comp
+      data-slot="sidebar-group-label"
+      data-sidebar="group-label"
+      className={cn(
+        "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupAction({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "button";
+
+  return (
+    <Comp
+      data-slot="sidebar-group-action"
+      data-sidebar="group-action"
+      className={cn(
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn("w-full text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn("group/menu-item relative", className)}
+      {...props}
+    />
+  );
+}
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        outline:
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+      },
+      size: {
+        default: "h-8 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function SidebarMenuButton({
+  asChild = false,
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean;
+  isActive?: boolean;
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>;
+} & VariantProps<typeof sidebarMenuButtonVariants>) {
+  const Comp = asChild ? Slot.Root : "button";
+  const { isMobile, state } = useSidebar();
+
+  const button = (
+    <Comp
+      data-slot="sidebar-menu-button"
+      data-sidebar="menu-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+
+  if (!tooltip) {
+    return button;
+  }
+
+  if (typeof tooltip === "string") {
+    tooltip = {
+      children: tooltip,
+    };
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent
+        side="right"
+        align="center"
+        hidden={state !== "collapsed" || isMobile}
+        {...tooltip}
+      />
+    </Tooltip>
+  );
+}
+
+function SidebarMenuAction({
+  className,
+  asChild = false,
+  showOnHover = false,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean;
+  showOnHover?: boolean;
+}) {
+  const Comp = asChild ? Slot.Root : "button";
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-action"
+      data-sidebar="menu-action"
+      className={cn(
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        showOnHover &&
+          "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuBadge({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-menu-badge"
+      data-sidebar="menu-badge"
+      className={cn(
+        "text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none",
+        "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSkeleton({
+  className,
+  showIcon = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showIcon?: boolean;
+}) {
+  // Random width between 50 to 90%.
+  const width = React.useMemo(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`;
+  }, []);
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
+      )}
+      <Skeleton
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            "--skeleton-width": width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  );
+}
+
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        "border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSubItem({
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn("group/menu-sub-item relative", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSubButton({
+  asChild = false,
+  size = "md",
+  isActive = false,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean;
+  size?: "sm" | "md";
+  isActive?: boolean;
+}) {
+  const Comp = asChild ? Slot.Root : "a";
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-sub-button"
+      data-sidebar="menu-sub-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+        "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
+        size === "sm" && "text-xs",
+        size === "md" && "text-sm",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+};

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ui/skeleton.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ui/skeleton.tsx
@@ -1,7 +1,16 @@
+import type * as React from "react";
 import { cn } from "@/lib/utils";
 
-function Skeleton({ className }: { className?: string }) {
-  return <div className={cn("animate-shimmer rounded bg-surface-3", className)} />;
+// CTL-891: exported so the shadcn `sidebar` primitive's SidebarMenuSkeleton can
+// reuse the same shimmer skeleton. `style` / `data-*` passthrough lets the
+// sidebar drive its --skeleton-width and data-sidebar slots.
+export function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("animate-shimmer rounded bg-surface-3", className)}
+      {...props}
+    />
+  );
 }
 
 function SkeletonKpiStrip() {

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-mobile.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-mobile.ts
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+// CTL-891: shadcn `sidebar` primitive dependency. Tracks the mobile breakpoint
+// so the rail switches to an off-canvas Sheet on narrow widths. Standard shadcn
+// new-york hook (matchMedia listener, SSR-safe initial undefined).
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    };
+    mql.addEventListener("change", onChange);
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return !!isMobile;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/surface.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/surface.ts
@@ -1,0 +1,75 @@
+// surface.ts — the app-shell surface contract (CTL-891 / SHELL1).
+//
+// Ported from the prototype `mockups/home-proto/src/lib/surface.ts`. This is the
+// PURE, framework-agnostic core of the shell: the surface union, the `g`-chord
+// jump map, and the per-surface breadcrumb trail. AppShell/AppSidebar consume it;
+// keeping it free of React makes the keyboard/IA contract unit-testable without a
+// DOM (the same pattern board-logic.ts / route-search.ts follow).
+//
+// Surface switching itself is consumed from the FND routing/store stream — this
+// module only declares the contract the shell binds to; it does NOT own routing.
+import { createContext, useContext } from "react";
+
+/** The top-level surfaces the shell can render in SidebarInset. */
+export type Surface = "home" | "board" | "workers" | "queue";
+
+/** Every surface in nav order — the single source the sidebar + palette iterate. */
+export const SURFACES: readonly Surface[] = [
+  "home",
+  "board",
+  "workers",
+  "queue",
+] as const;
+
+/** Human label per surface (sidebar item + command palette). */
+export const SURFACE_LABEL: Record<Surface, string> = {
+  home: "Home",
+  board: "Board",
+  workers: "Workers",
+  queue: "Queue",
+};
+
+/** The `g <key>` jump keys, kept next to the Surface union so they stay in sync. */
+export const SURFACE_CHORD: Record<string, Surface> = {
+  h: "home",
+  b: "board",
+  w: "workers",
+  q: "queue",
+};
+
+/** Breadcrumb trail per surface — drives the top strip. */
+export const SURFACE_BREADCRUMB: Record<Surface, string[]> = {
+  home: ["Home", "Inbox"],
+  board: ["Board"],
+  workers: ["Workers"],
+  queue: ["Queue"],
+};
+
+/**
+ * True when focus is in a text-entry context — the shell's `[` / `g` chord
+ * handlers must NOT steal those keystrokes. Pure so it can be unit-tested with a
+ * minimal `{ tagName, isContentEditable }` shape rather than a real DOM node.
+ */
+export function isTypingTarget(
+  target: { tagName?: string; isContentEditable?: boolean } | null,
+): boolean {
+  if (!target) return false;
+  return (
+    target.tagName === "INPUT" ||
+    target.tagName === "TEXTAREA" ||
+    target.isContentEditable === true
+  );
+}
+
+interface SurfaceContextValue {
+  surface: Surface;
+  setSurface: (s: Surface) => void;
+}
+
+export const SurfaceContext = createContext<SurfaceContextValue | null>(null);
+
+export function useSurface(): SurfaceContextValue {
+  const ctx = useContext(SurfaceContext);
+  if (!ctx) throw new Error("useSurface must be used within an AppShell.");
+  return ctx;
+}


### PR DESCRIPTION
## CTL-891 / SHELL1 — Edge-to-edge app shell + left nav

Keystone port of the proven prototype shell (`mockups/home-proto` `AppShell`/`AppSidebar`) into the real orch-monitor `ui`, replacing the hand-rolled `components/layout/sidebar` frame with the shadcn `Sidebar` foundation that every later SHELL ticket (collapse, IA, badges, top strip, switcher, nav-health) builds on. Lands the frame + OPERATE nav with **mock/placeholder badges** — does NOT yet wire live data or fold the board page into the shell (SHELL2), and consumes FND's surface contract rather than re-filing routing.

### What changed
- **New shadcn new-york primitives** the `ui` was missing, authored to MATCH the existing conventions (the `radix-ui` unified package + `data-slot` + `lucide-react`, reconciling the prototype's `base-nova`→`new-york` token drift): `ui/sidebar.tsx`, `ui/breadcrumb.tsx`, `ui/collapsible.tsx`, `ui/button.tsx`, `ui/input.tsx`, and the `hooks/use-mobile.ts` hook. `skeleton.tsx` now exports `Skeleton` for `SidebarMenuSkeleton`. `app.css` bridges the `--sidebar-*` tokens onto the existing surface system.
- **`lib/surface.ts`** — the pure, framework-agnostic surface contract (union, `g`-chord map, breadcrumb trail, `isTypingTarget`) the shell + sidebar bind to; unit-testable without a DOM.
- **`components/app-shell.tsx`** — full-viewport (`h-screen`, NO outer `max-w`/`mx-auto`) frame: a CONTROLLED `SidebarProvider` so BOTH `[` and the built-in `Cmd/Ctrl+B` toggle collapse; `g h/b/w/q` chord jumps; the `SidebarInset` top strip (trigger + breadcrumb + ⌘K); the ⌘K command palette.
- **`components/app-sidebar.tsx`** — OPERATE (Home/Board/Workers/Queue) + collapsible OBSERVE nav with MOCK badges/status dots + footer daemon-health dot.
- **`App.tsx`** — `Monitor()` renders the existing dashboard content edge-to-edge inside the shell's inset; the hand-rolled `Sidebar` + duplicate header chrome are removed.

### Gherkin scenarios
| Scenario | Status |
|---|---|
| **One shell hosts every surface** — full-viewport shell, left OPERATE group (Home/Board/Workers/Queue), active surface edge-to-edge in `SidebarInset` | ✅ satisfied |
| **shadcn Sidebar primitive is the foundation, not the hand-rolled one** — `Sidebar`/`SidebarProvider`/`SidebarInset`/`SidebarMenu` used; legacy `components/layout/sidebar` no longer the App frame | ✅ satisfied |
| **Edge-to-edge by default** — shell fills the viewport, no centered gutter around the chrome | ✅ satisfied (verified in-browser, expanded + `[`-collapsed focus mode) |

**Single-node descope:** N/A — this ticket carries no cluster/fence/multi-host scope.

### Verification
- `__tests__/app-shell.test.ts` — 14 tests green (pure surface contract + static-source guards for each Gherkin scenario).
- Related suites green: `route-search`, `board-todo-column`, `ui-features`, `mockups` → **102 tests pass**.
- `bunx tsc --noEmit` clean for both `ui` and `orch-monitor` (the single pre-existing `kpi-strip.tsx` error exists on clean `main` and is untouched here).
- `ui` `bun run build` succeeds. Build artifacts under `public/` are intentionally **not** committed (matching FND1/BFF1 convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)