### PR TITLE
fix(dev): CTL-927 exempt doc-phase workers from the cold-snapshot zombie-floor mtime kill

### DIFF
--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -146,6 +146,26 @@ export function defaultStatJob(bgJobId) {
 // status like done/skipped) — do not conflate the two.
 export const TERMINAL_JOB_STATES = new Set(["stopped", "failed", "done", "blocked"]);
 
+// CTL-927 — doc/long-fan-out phases whose forward-progress is an artifact-byte
+// progressMark (research/plan/triage/verify/review — see work-done-probes.mjs). Their
+// `claude --bg` state.json legitimately goes untouched for many minutes during an
+// in-process sub-agent fan-out, so the CTL-868 cold-snapshot mtime zombie-floor (2h)
+// would false-kill a LIVE worker on a host where `claude agents --json` is unreliable
+// (CTL-829, the headless mini) — the proximate trigger of a fleet-wide no-progress
+// storm. These phases use BUSY_CEILING_MS (6h) for the cold-snapshot mtime guess; by
+// then the busy-ceiling escalation (escalateOnce "busy-ceiling-exceeded" → needs-human)
+// already bounds a genuinely-stuck doc worker — escalate, never silent kill.
+// implement/remediate are NOT exempt: their commits/state.json churn make a 2h-stale
+// state.json a true corpse. Keep this set in sync with the artifact-byte progressMark
+// phases in work-done-probes.mjs.
+export const MTIME_ZOMBIE_EXEMPT_PHASES = new Set([
+  "research",
+  "plan",
+  "triage",
+  "verify",
+  "review",
+]);
+
 // jobLifecycle — CTL-736 Phase 2's deterministic, LOCAL death verdict from a
 // `claude --bg` job's state.json, replacing the eventually-consistent `claude
 // agents` snapshot (livenessForBgJob) in the reclaim death trigger:
@@ -1719,10 +1739,18 @@ export function reclaimDeadWorkIfPossible(
           // fan-out safe (CTL-662), and this branch only runs when the fresh-agents
           // cross-check cannot — so it never overrides a fresh "present" verdict.
           const job = statJob(prevBgJobId);
-          if (job && Number.isFinite(job.mtimeMs) && now() - job.mtimeMs > zombieStaleFloorMs) {
+          // CTL-927: doc/long-fan-out phases keep state.json untouched during a
+          // multi-minute sub-agent fan-out, so the 2h mtime guess would false-kill a
+          // live worker on this cold-snapshot branch. Give them the 6h busy ceiling
+          // (the busy-ceiling escalation above already routes a genuinely-stuck doc
+          // worker to needs-human at 6h — escalate, never silent kill).
+          const mtimeFloorMs = MTIME_ZOMBIE_EXEMPT_PHASES.has(phase)
+            ? busyCeilingMs
+            : zombieStaleFloorMs;
+          if (job && Number.isFinite(job.mtimeMs) && now() - job.mtimeMs > mtimeFloorMs) {
             ghostAbsent = true;
             log.warn(
-              { ticket, phase, prevBgJobId, staleForMs: now() - job.mtimeMs },
+              { ticket, phase, prevBgJobId, staleForMs: now() - job.mtimeMs, mtimeFloorMs },
               "ctl-868: jobLifecycle-alive but state.json mtime stale beyond zombie floor (no fresh agents snapshot) — treating as dead (zombie breaker)",
             );
           }

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -1044,6 +1044,113 @@ describe("reclaimDeadWorkIfPossible", () => {
     expect(emit.calls.length).toBe(0);
   });
 
+  // CTL-927 — DOC-PHASE ZOMBIE-FLOOR EXEMPTION. The CTL-868 cold-snapshot mtime
+  // floor fires only when no FRESH `claude agents` snapshot exists (CTL-829, the
+  // headless mini). For long-fan-out doc phases (research/plan/triage/verify/review)
+  // the worker's state.json legitimately ages during a multi-minute in-process
+  // sub-agent fan-out, so the 2h mtime guess false-kills a LIVE worker → the observed
+  // fleet-wide no-progress storm. Doc phases use BUSY_CEILING_MS (6h) instead, where
+  // the busy-ceiling escalation routes to needs-human (escalate, never silent kill).
+  // implement/remediate keep the 2h floor.
+  const BUSY_CEILING = 6 * 60 * 60_000;
+  const docSignal = (phase, { bgJobId = "807b77bd", startedAt = STARTED } = {}) => ({
+    ticket: "CTL-9",
+    phase,
+    status: "running",
+    liveness: { kind: "bg", value: bgJobId },
+    signalPath: `/x/CTL-9/phase-${phase}.json`,
+    raw: {
+      ticket: "CTL-9",
+      phase,
+      orchestrator: "CTL-9",
+      status: "running",
+      bg_job_id: bgJobId,
+      catalystSessionId: "sess_CTL-9_abc",
+      startedAt,
+    },
+  });
+
+  test("CTL-927: research worker, state.json mtime 3h stale, NO fresh snapshot → alive-suppressed (doc phase exempt from the 2h zombie floor)", () => {
+    const emit = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, docSignal("research"), {
+      // state=working (jobLifecycle → alive); state.json untouched 3h (sub-agent fan-out)
+      statJob: () => ({ exists: true, state: "working", mtimeMs: STARTED_MS }),
+      probes: { research: recorder(false) }, // research doc not written yet (artifact-bytes = 0)
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+      postReclaimMirror: () => {}, // hermetic — no linearis spawn
+      agentsSnapshot: () => ({ agents: [], isFresh: false, ageMs: Infinity }), // mini: stale/cold (CTL-829)
+      ghostGraceMs: GHOST_GRACE,
+      zombieStaleFloorMs: ZOMBIE_FLOOR, // 2h
+      busyCeilingMs: BUSY_CEILING, // 6h
+      now: () => STARTED_MS + 3 * 60 * 60_000, // 3h: past the 2h floor, under the 6h ceiling
+    });
+    expect(r).toBe("alive-suppressed"); // pre-fix: the 2h zombie-floor wrongly reclaims it
+    expect(emit.calls.length).toBe(0);
+  });
+
+  test("CTL-927 regression: implement worker, mtime 3h stale, NO fresh snapshot, work done → still reclaimed (implement keeps the 2h floor)", () => {
+    const emit = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, docSignal("implement"), {
+      statJob: () => ({ exists: true, state: "working", mtimeMs: STARTED_MS }),
+      probes: { implement: recorder(true) },
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+      postReclaimMirror: () => {},
+      agentsSnapshot: () => ({ agents: [], isFresh: false, ageMs: Infinity }),
+      ghostGraceMs: GHOST_GRACE,
+      zombieStaleFloorMs: ZOMBIE_FLOOR,
+      busyCeilingMs: BUSY_CEILING,
+      now: () => STARTED_MS + 3 * 60 * 60_000,
+    });
+    expect(r).toBe("reclaimed");
+    expect(emit.calls.length).toBe(1);
+  });
+
+  test("CTL-927 regression: research worker mtime 3h stale but PRESENT in a FRESH snapshot → alive-suppressed (fresh-present still wins; ghost-breaker unchanged)", () => {
+    const emit = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, docSignal("research"), {
+      statJob: () => ({ exists: true, state: "working", mtimeMs: STARTED_MS }),
+      probes: { research: recorder(false) },
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+      agentsSnapshot: () => ({
+        agents: [{ sessionId: "807b77bd-0000-0000-0000-000000000000" }],
+        isFresh: true,
+        ageMs: 1_000,
+      }),
+      ghostGraceMs: GHOST_GRACE,
+      zombieStaleFloorMs: ZOMBIE_FLOOR,
+      busyCeilingMs: BUSY_CEILING,
+      now: () => STARTED_MS + 3 * 60 * 60_000,
+    });
+    expect(r).toBe("alive-suppressed");
+    expect(emit.calls.length).toBe(0);
+  });
+
+  test("CTL-927 regression: research worker ABSENT from a FRESH snapshot, past grace, work done → ghost-breaker still reclaims (doc exemption only relaxes the COLD path)", () => {
+    const probe = recorder(true);
+    const emit = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, docSignal("research"), {
+      statJob: () => ({ exists: true, state: "working", mtimeMs: STARTED_MS }),
+      probes: { research: probe },
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+      postReclaimMirror: () => {},
+      agentsSnapshot: () => ({
+        agents: [{ sessionId: "deadbeef-1111-2222-3333-444444444444" }], // our worker absent
+        isFresh: true,
+        ageMs: 1_000,
+      }),
+      ghostGraceMs: GHOST_GRACE,
+      zombieStaleFloorMs: ZOMBIE_FLOOR,
+      busyCeilingMs: BUSY_CEILING,
+      now: () => STARTED_MS + 3 * 60 * 60_000,
+    });
+    expect(r).toBe("reclaimed");
+    expect(emit.calls.length).toBe(1);
+  });
+
   test("'noop' for an unknown signal (no bg_job_id)", () => {
     const sig = implementSignal();
     sig.liveness = { kind: "bg", value: null };


### PR DESCRIPTION
## What & why

Overnight the mini board hard-wedged: every research/plan worker ran ~20–40 min then got killed mid-fan-out, a **54-event "no forward progress — stopping, not respawning" storm** drove the fleet to **0 live agents**, and dispatch stopped. This fixes the proximate cause.

**Root cause** (verified by a 6-agent + 3-verifier diagnostic, then confirmed against live daemon.log):
- The reclaim **death trigger** (`jobLifecycle`, recovery.mjs:162-167) is fan-out-safe — it reads only `state.json .state`, never mtime, and an alive `working` worker early-returns `alive-suppressed` before any kill (2581 of these in the log; the CTL-662 design working). **Not touched.**
- The **one** mtime-based false-death of a live worker is the CTL-868 cold-snapshot zombie-floor (recovery.mjs:1713-1728): when no **fresh** `claude agents --json` snapshot exists (CTL-829 — confirmed live: "snapshot stale/cold", "no fresh agents snapshot"), a still-`working` worker is declared dead on `state.json` mtime > `ZOMBIE_STALE_FLOOR_MS` (2h). For **doc phases** whose state.json legitimately ages during a multi-minute in-process sub-agent fan-out, this false-kills a live worker. The downstream no-progress gate then sees artifact-bytes = 0 (doc not written until the very end) → `no-progress-stopped` → `needs-human`, fleet-wide. (A killed worker's transcript, CTL-926, had 12 `interrupt` events — it was alive when stopped.)

## The change (surgical)

`research`/`plan`/`triage`/`verify`/`review` (the artifact-byte progressMark family) now use `BUSY_CEILING_MS` (6h) for the **cold-snapshot mtime guess only**. By 6h the existing busy-ceiling escalation (recovery.mjs:1666) already routes a genuinely-stuck doc worker to `needs-human` — **escalate, never silent kill**. `implement`/`remediate` keep the 2h floor (commits/state.json churn make a 2h-stale state.json a true corpse).

Unchanged: the death trigger, alive-suppression, the **fresh**-snapshot ghost-breaker (a doc worker absent from a *fresh* snapshot is still reclaimed), the progress gate, and dead-terminal/dead-gone reclaim.

## Tests

`recovery.test.mjs` +4:
- **bug-proof** (fails on `main`, passes here): research worker, state.json mtime 3h stale, **no fresh snapshot** → `alive-suppressed` (was `revived`).
- regression: `implement` same conditions → still `reclaimed` (2h floor kept).
- regression: research worker **present** in a fresh snapshot → `alive-suppressed` (ghost-breaker unchanged).
- regression: research worker **absent** from a *fresh* snapshot → still `reclaimed` (cold-path-only relaxation).

`recovery.test.mjs` **207 pass / 0 fail** · `scheduler.test.mjs` **402 pass / 0 fail** (= baseline).

## Deploy note

Deploying this to the mini (`catalyst-stack restart --hotpatch`) would let doc-phase workers run to completion instead of being false-killed at 2h, which should let the board drain again. **Left for your review/deploy** — I did not auto-deploy.

## Follow-ups (filed in the ticket, not in this PR)
- reaper.mjs `_handleBgReap` (287-298) has no busy-gate (CTL-657): a death-inferred reap-intent `claude stop`s a present busy worker → the `interrupt`. Re-confirm idle before stopping death-inferred reaps.
- Heartbeat the worker's state.json/progress crumb during research/plan fan-out (removes reliance on the mtime guess entirely).
- Deeper: why `claude agents --json` is unreliable headless on the mini (CTL-829).

Closes CTL-927.

🤖 Generated with [Claude Code](https://claude.com/claude-code)