### PR TITLE
feat(dev): BFF5 live EC-worker transcript tail SSE (CTL-887)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/ec-worker-stream-endpoints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ec-worker-stream-endpoints.test.ts
@@ -1,0 +1,123 @@
+// CTL-887 (BFF5): HTTP route-plumbing tests for the live transcript-tail SSE
+// endpoint. Validates the server.ts wiring — sessionId validation (400), the
+// 404 for a session with no transcript, and the SSE happy path (a real
+// ~/.claude/projects/<dir>/<sessionId>.jsonl that grows while a client is
+// subscribed emits typed `stream-event` frames). The conversion LOGIC itself
+// (resting-transcript → StreamEvent[], the incremental tail) is covered by the
+// injectable unit tests in ec-worker-stream.test.ts; these prove the route is
+// mounted, matched, guarded, and streams.
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  appendFileSync,
+} from "fs";
+import { tmpdir, homedir } from "os";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import { createServer } from "../server";
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+let tmpDir: string;
+
+// A real, uniquely-named project dir under ~/.claude/projects so the endpoint's
+// transcript resolver finds our fixture, then we clean it up.
+const PROJECTS = join(homedir(), ".claude", "projects");
+const projectDir = join(PROJECTS, `ec-worker-stream-test-${randomUUID()}`);
+const sessionId = randomUUID();
+const transcriptFile = join(projectDir, `${sessionId}.jsonl`);
+
+function assistantLine(content: unknown[]): string {
+  return (
+    JSON.stringify({
+      type: "assistant",
+      timestamp: new Date().toISOString(),
+      sessionId,
+      message: { role: "assistant", model: "claude-opus-4-8", content },
+    }) + "\n"
+  );
+}
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "ec-worker-stream-endpoints-"));
+  const wtDir = join(tmpDir, "wt");
+  mkdirSync(wtDir, { recursive: true });
+  mkdirSync(projectDir, { recursive: true });
+  // Seed the transcript with one record so the resolver's scan finds the file.
+  writeFileSync(transcriptFile, assistantLine([{ type: "text", text: "boot" }]));
+  server = createServer({ port: 0, wtDir, startWatcher: false });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  void server?.stop(true);
+  for (const d of [projectDir, tmpDir]) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+describe("GET /api/ec-worker-stream/:sessionId (CTL-887)", () => {
+  it("rejects a malformed sessionId with 400 (no path traversal / arbitrary read)", async () => {
+    expect((await fetch(`${baseUrl}/api/ec-worker-stream/not a uuid!`)).status).toBe(400);
+    expect((await fetch(`${baseUrl}/api/ec-worker-stream/..%2F..%2Fetc`)).status).toBe(400);
+    expect((await fetch(`${baseUrl}/api/ec-worker-stream/short`)).status).toBe(400);
+  });
+
+  it("returns 404 when no transcript exists for that session id", async () => {
+    const res = await fetch(`${baseUrl}/api/ec-worker-stream/${randomUUID()}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("streams typed StreamEvents over SSE as the transcript grows", async () => {
+    const res = await fetch(`${baseUrl}/api/ec-worker-stream/${sessionId}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    expect(res.body).not.toBeNull();
+
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    // Read until we have seen the `open` frame plus at least one stream-event.
+    const deadline = Date.now() + 8000;
+    let sawOpen = false;
+    let sawToolStart = false;
+
+    // Append a tool_use record AFTER subscribing so we prove live growth, not
+    // just the initial tail.
+    appendFileSync(
+      transcriptFile,
+      assistantLine([{ type: "tool_use", name: "Bash", input: { command: "bun test" } }]),
+    );
+
+    while (Date.now() < deadline && !(sawOpen && sawToolStart)) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      for (const frame of buffer.split("\n\n")) {
+        if (frame.includes("event: open")) sawOpen = true;
+        if (frame.includes("event: stream-event")) {
+          const dataLine = frame.split("\n").find((l) => l.startsWith("data: "));
+          if (dataLine) {
+            const ev = JSON.parse(dataLine.slice("data: ".length)) as {
+              type: string;
+              tool?: string;
+            };
+            if (ev.type === "tool_start" && ev.tool === "Bash") sawToolStart = true;
+          }
+        }
+      }
+    }
+    await reader.cancel();
+
+    expect(sawOpen).toBe(true);
+    expect(sawToolStart).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/ec-worker-stream.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ec-worker-stream.test.ts
@@ -1,0 +1,242 @@
+// CTL-887 (BFF5): unit tests for the live EC-worker transcript tail. Encodes the
+// ticket's Gherkin acceptance scenarios against the RESTING-transcript JSONL
+// format that every Claude Code session writes to
+// ~/.claude/projects/<dir>/<sessionId>.jsonl — pure parser + incremental tail,
+// no live worker, no network.
+//
+//   • "A running worker streams its live transcript" — tool calls, text,
+//      turns, retries, rate-limits are emitted as the file grows.
+//   • "And reasoning rows (◌ thinking…) are emitted" — assistant `thinking`
+//      blocks surface as `reasoning` StreamEvents.
+//   • "Footer counters and diagnostics derive from the stream" — event/tool/
+//      retry counts are derivable client-side from the emitted rows.
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, appendFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  parseTranscriptLine,
+  TranscriptTail,
+  INITIAL_TAIL_BYTES,
+  type StreamEvent,
+} from "../lib/ec-worker-stream.mjs";
+
+const TS = "2026-06-08T14:02:11.000Z";
+const TS_MS = Date.parse(TS);
+
+function assistant(content: unknown[], timestamp = TS): string {
+  return JSON.stringify({
+    type: "assistant",
+    timestamp,
+    sessionId: "sess-uuid",
+    message: { role: "assistant", model: "claude-opus-4-8", content },
+  });
+}
+
+describe("parseTranscriptLine — typed StreamEvents from the resting transcript", () => {
+  it("emits a tool_start (with a one-line input preview) for an assistant tool_use block", () => {
+    const events = parseTranscriptLine(
+      assistant([
+        { type: "tool_use", name: "Bash", input: { command: "bun test board", description: "run tests" } },
+      ]),
+    );
+    const tool = events.find((e) => e.type === "tool_start");
+    expect(tool).toBeDefined();
+    expect(tool!.tool).toBe("Bash");
+    expect(tool!.toolInput).toBe("bun test board");
+    expect(tool!.ts).toBe(TS_MS);
+  });
+
+  it("emits a text row for an assistant text block", () => {
+    const events = parseTranscriptLine(assistant([{ type: "text", text: "Editing board-data.mjs now" }]));
+    const text = events.find((e) => e.type === "text");
+    expect(text).toBeDefined();
+    expect(text!.text).toBe("Editing board-data.mjs now");
+  });
+
+  it("emits a reasoning row (◌ thinking…) for an assistant thinking block", () => {
+    const events = parseTranscriptLine(
+      assistant([{ type: "thinking", thinking: "I should reconcile the phase signal schema first" }]),
+    );
+    const reasoning = events.find((e) => e.type === "reasoning");
+    expect(reasoning).toBeDefined();
+    expect(reasoning!.text).toContain("reconcile the phase signal schema");
+  });
+
+  it("anchors every assistant message with one turn row carrying its turnTools", () => {
+    const events = parseTranscriptLine(
+      assistant([
+        { type: "text", text: "Running two tools" },
+        { type: "tool_use", name: "Read", input: { file_path: "/a/types.ts" } },
+        { type: "tool_use", name: "Edit", input: { file_path: "/a/board.tsx" } },
+      ]),
+    );
+    const turns = events.filter((e) => e.type === "turn");
+    expect(turns).toHaveLength(1);
+    expect(turns[0].turnTools).toEqual(["Read", "Edit"]);
+    expect(turns[0].text).toBe("Running two tools");
+  });
+
+  it("emits a retry row from a system api_error (generic overloaded)", () => {
+    const line = JSON.stringify({
+      type: "system",
+      subtype: "api_error",
+      timestamp: TS,
+      retryAttempt: 2,
+      maxRetries: 10,
+      retryInMs: 1109,
+      error: { error: { error: { type: "overloaded_error" } } },
+    });
+    const events = parseTranscriptLine(line);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("retry");
+    expect(events[0].retryInfo).toEqual({ attempt: 2, maxRetries: 10, error: "overloaded_error" });
+  });
+
+  it("emits a rate_limit row (not a retry) when the api_error is a rate-limit", () => {
+    const line = JSON.stringify({
+      type: "system",
+      subtype: "api_error",
+      timestamp: TS,
+      retryAttempt: 1,
+      maxRetries: 10,
+      retryInMs: 8000,
+      error: { error: { error: { type: "rate_limit_error" } } },
+    });
+    const events = parseTranscriptLine(line);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("rate_limit");
+    expect(events[0].rateLimitInfo?.status).toContain("rate_limit");
+    // resetsAt is epoch-SECONDS = (ts + retryInMs) / 1000
+    expect(events[0].rateLimitInfo?.resetsAt).toBe(Math.round((TS_MS + 8000) / 1000));
+  });
+
+  it("falls back to `now` when a record carries no timestamp", () => {
+    const now = 1_700_000_000_000;
+    const events = parseTranscriptLine(
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "hi" }] } }),
+      now,
+    );
+    expect(events.every((e) => e.ts === now)).toBe(true);
+  });
+
+  it("returns [] for malformed JSON and for user/tool_result records (no own row)", () => {
+    expect(parseTranscriptLine("not json")).toEqual([]);
+    expect(parseTranscriptLine("")).toEqual([]);
+    expect(
+      parseTranscriptLine(
+        JSON.stringify({ type: "user", message: { content: [{ type: "tool_result", content: "ok" }] } }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("footer counters are derivable client-side from the emitted rows", () => {
+    // Scenario: "event/tool/retry counts are derivable client-side from received rows".
+    const lines = [
+      assistant([{ type: "text", text: "starting" }]),
+      assistant([{ type: "tool_use", name: "Read", input: { file_path: "/x" } }]),
+      assistant([{ type: "tool_use", name: "Edit", input: { file_path: "/y" } }]),
+      JSON.stringify({
+        type: "system",
+        subtype: "api_error",
+        timestamp: TS,
+        retryAttempt: 1,
+        maxRetries: 10,
+        error: { error: { error: { type: "overloaded_error" } } },
+      }),
+    ];
+    const events: StreamEvent[] = lines.flatMap((l) => parseTranscriptLine(l));
+    const toolCalls = events.filter((e) => e.type === "tool_start").length;
+    const retries = events.filter((e) => e.type === "retry").length;
+    const turns = events.filter((e) => e.type === "turn").length;
+    expect(toolCalls).toBe(2);
+    expect(retries).toBe(1);
+    expect(turns).toBe(3);
+    expect(events.length).toBeGreaterThan(0);
+  });
+});
+
+describe("TranscriptTail — incremental file-growth tail", () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ec-worker-stream-"));
+    file = join(dir, "session.jsonl");
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it("returns [] for a missing file", async () => {
+    const tail = new TranscriptTail(join(dir, "absent.jsonl"));
+    expect(await tail.poll()).toEqual([]);
+  });
+
+  it("emits StreamEvents as the file grows across polls (the live tail)", async () => {
+    writeFileSync(file, assistant([{ type: "text", text: "first turn" }]) + "\n");
+    const tail = new TranscriptTail(file);
+    const first = await tail.poll();
+    expect(first.some((e) => e.type === "text" && e.text === "first turn")).toBe(true);
+
+    // No growth → no new events.
+    expect(await tail.poll()).toEqual([]);
+
+    // Append a new record; only the delta is parsed.
+    appendFileSync(file, assistant([{ type: "tool_use", name: "Bash", input: { command: "ls" } }]) + "\n");
+    const second = await tail.poll();
+    expect(second.some((e) => e.type === "tool_start" && e.tool === "Bash")).toBe(true);
+    expect(second.some((e) => e.type === "text" && e.text === "first turn")).toBe(false);
+  });
+
+  it("carries a partial trailing line forward until its newline arrives", async () => {
+    const tail = new TranscriptTail(file);
+    const full = assistant([{ type: "tool_use", name: "Read", input: { file_path: "/z" } }]);
+    // Write the record WITHOUT a trailing newline → partial, not yet parseable.
+    writeFileSync(file, full);
+    expect(await tail.poll()).toEqual([]);
+    // Now complete the line.
+    appendFileSync(file, "\n");
+    const events = await tail.poll();
+    expect(events.some((e) => e.type === "tool_start" && e.tool === "Read")).toBe(true);
+  });
+
+  it("primes from the tail of a large existing file without replaying the whole thing", async () => {
+    // A resting transcript larger than INITIAL_TAIL_BYTES: only the recent
+    // window should be replayed on first poll.
+    const filler = assistant([{ type: "text", text: "old line" }]) + "\n";
+    const repeats = Math.ceil((INITIAL_TAIL_BYTES * 2) / filler.length);
+    writeFileSync(file, filler.repeat(repeats));
+    const tail = new TranscriptTail(file);
+    const first = await tail.poll();
+    // It replayed *some* recent rows, but far fewer than the full file.
+    expect(first.length).toBeGreaterThan(0);
+    expect(first.length).toBeLessThan(repeats);
+
+    // A brand-new appended record is still picked up cleanly afterwards.
+    appendFileSync(file, assistant([{ type: "tool_use", name: "Grep", input: { pattern: "foo" } }]) + "\n");
+    const second = await tail.poll();
+    expect(second.some((e) => e.type === "tool_start" && e.tool === "Grep")).toBe(true);
+  });
+
+  it("restarts cleanly if the file is truncated/rotated under it", async () => {
+    // Seed with several records so the offset advances well past a later, smaller file.
+    const big =
+      assistant([{ type: "text", text: "before one with a fairly long body so the offset advances" }]) +
+      "\n" +
+      assistant([{ type: "text", text: "before two also long enough to move the read offset forward" }]) +
+      "\n";
+    writeFileSync(file, big);
+    const tail = new TranscriptTail(file);
+    await tail.poll();
+    // Truncate to a strictly smaller size (size < offset) → the tail must reset.
+    writeFileSync(file, assistant([{ type: "text", text: "after" }]) + "\n");
+    const events = await tail.poll();
+    expect(events.some((e) => e.type === "text" && e.text === "after")).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -173,3 +173,16 @@ export function deriveGeneration(
   phaseSigs: unknown[],
   fence?: { generation?: number | null },
 ): number | null;
+
+/**
+ * CTL-887 (BFF5): cache-only peek of the resident transcript-path cache. Returns
+ * the absolute `~/.claude/projects/<dir>/<sessionId>.jsonl` path if board
+ * assembly has already resolved it, or null on a miss (no directory scan).
+ */
+export function peekTranscriptCache(sessionId: string): string | null;
+
+/**
+ * CTL-733: resolve a sessionId to its transcript `.jsonl` path, caching the hit.
+ * Falls back to a single project-dir scan only on a cache miss.
+ */
+export function resolveTranscript(sessionId: string): Promise<string | null>;

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -160,7 +160,19 @@ const STUCK_MS = 1_800_000;    // no transcript activity for 30m → likely aban
 // (expensive) ~1.5k-project-dir scan. Only cache HITS — a brand-new worker whose
 // transcript dir is created after a miss must still be found on a later pass.
 const _transcriptPathCache = new Map(); // sessionId -> absolute path
-async function resolveTranscript(sessionId) {
+
+// CTL-887 (BFF5): cache-only peek so the live-tail SSE endpoint resolves a
+// running worker's transcript without ever triggering the ~1.5k-dir scan —
+// board assembly has already populated the cache for every live session.
+// Returns the cached absolute path, or null on a miss (the caller decides
+// whether a single fallback scan is warranted).
+export function peekTranscriptCache(sessionId) {
+  if (!sessionId) return null;
+  return _transcriptPathCache.get(sessionId) ?? null;
+}
+
+export async function resolveTranscript(sessionId) {
+  if (!sessionId) return null;
   const cached = _transcriptPathCache.get(sessionId);
   if (cached) return cached;
   const projectsDir = join(HOME, ".claude", "projects");

--- a/plugins/dev/scripts/orch-monitor/lib/ec-worker-stream.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/ec-worker-stream.d.mts
@@ -1,0 +1,59 @@
+// Type declarations for ec-worker-stream.mjs (CTL-887, BFF5) — the live
+// transcript tail for execution-core workers. Lets the typechecked TS server
+// (server.ts) import the parser + tail without a TS7016 implicit-any error.
+// The StreamEvent shape MUST stay in sync with lib/stream-reader.ts and
+// ui/src/lib/types.ts so the existing StreamEventRow renderer consumes it
+// unchanged.
+
+export type StreamEventType =
+  | "tool_start"
+  | "tool_end"
+  | "text"
+  | "reasoning"
+  | "turn"
+  | "init"
+  | "retry"
+  | "result"
+  | "rate_limit";
+
+export interface StreamEvent {
+  ts: number;
+  type: StreamEventType;
+  tool?: string;
+  toolInput?: string;
+  text?: string;
+  /** Tool names invoked in this assistant turn. */
+  turnTools?: string[];
+  retryInfo?: { attempt: number; maxRetries: number; error: string };
+  rateLimitInfo?: { status: string; resetsAt?: number };
+  usage?: Record<string, unknown>;
+  sessionId?: string;
+}
+
+/** Max bytes read on the first poll so a long resting transcript isn't replayed. */
+export const INITIAL_TAIL_BYTES: number;
+
+/**
+ * Convert ONE resting-transcript JSONL line into zero or more StreamEvents.
+ * Pure — no filesystem. `now` is the fallback ts for records with no timestamp.
+ */
+export function parseTranscriptLine(line: string, now?: number): StreamEvent[];
+
+/**
+ * Resolve a sessionId to its `~/.claude/projects/<dir>/<sessionId>.jsonl` path.
+ * Prefers the resident board-data transcript-path cache (no rescan); falls back
+ * to a single scan only on a cold miss unless `allowScan` is false.
+ */
+export function resolveTranscriptPath(
+  sessionId: string,
+  options?: { allowScan?: boolean },
+): Promise<string | null>;
+
+/** A stateful, incremental tail over one transcript file. */
+export class TranscriptTail {
+  constructor(filePath: string);
+  filePath: string;
+  offset: number;
+  /** Read only the bytes appended since the last poll; parse new lines. */
+  poll(): Promise<StreamEvent[]>;
+}

--- a/plugins/dev/scripts/orch-monitor/lib/ec-worker-stream.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/ec-worker-stream.mjs
@@ -1,0 +1,286 @@
+// ec-worker-stream.mjs — CTL-887 (BFF5): the live transcript tail for
+// execution-core workers.
+//
+// The legacy /api/worker-stream (lib/stream-reader.ts) reads the Plane-B
+// `runs/<orch>/workers/<ticket>-stream.jsonl` tree, which is EMPTY for
+// execution-core `claude --bg` workers (design §2). This module is the EC
+// equivalent: it tails the RESTING transcript that every Claude Code session
+// writes to `~/.claude/projects/<dir>/<sessionId>.jsonl` and converts the
+// growing file into the same typed StreamEvent[] the existing StreamEventRow
+// renderer consumes (tool calls, text, reasoning, turns, retries, rate-limits).
+//
+// Two format families exist. The legacy stream-reader parses the `claude --bg`
+// stream-json frames (system/init, stream_event/content_block_*, assistant,
+// rate_limit_event, result). The on-disk transcript this module tails is the
+// RESTING format: line-delimited records of type "assistant" | "user" |
+// "system", each carrying an ISO `timestamp` and (for assistant/user) a
+// `message.content[]` array of `{type: thinking|text|tool_use|tool_result}`
+// blocks. `system` records of subtype "api_error" carry retryAttempt /
+// maxRetries / retryInMs plus a nested error whose `error.error.type` tells a
+// rate-limit apart from a generic overloaded/server retry.
+//
+// Path resolution reuses board-data.mjs's resident transcript-path cache
+// (peekTranscriptCache — cache HITS only, no ~1.5k-dir rescan) and only falls
+// back to a single scan (resolveTranscript) on a cold miss.
+//
+// Cross-node note (CTL-873/BFF3, single-node-descoped): this tail is
+// host-local and stateless — a multi-host fan-in is a clean wrap around N of
+// these, keyed by host.name. No cluster state is read here.
+
+import { stat, open } from "node:fs/promises";
+import { peekTranscriptCache, resolveTranscript } from "./board-data.mjs";
+
+/** Max bytes to read on the very first poll so a huge resting transcript does
+ *  not flood the client — the live tail only needs the recent window. */
+export const INITIAL_TAIL_BYTES = 64 * 1024;
+
+/** Cap on how many bytes a single growth poll reads (defensive against a
+ *  pathological burst); the next poll picks up any remainder. */
+const MAX_GROWTH_BYTES = 1024 * 1024;
+
+/** Parse an ISO-8601 timestamp to epoch-ms, or fall back to `fallback`. */
+function tsToMs(iso, fallback) {
+  if (typeof iso === "string") {
+    const ms = Date.parse(iso);
+    if (Number.isFinite(ms)) return ms;
+  }
+  return fallback;
+}
+
+/**
+ * Convert ONE resting-transcript JSONL line into zero or more StreamEvents.
+ * Pure + exported so the conversion is exhaustively unit-testable without any
+ * filesystem. `now` is the fallback ts for records that carry no timestamp.
+ *
+ * @param {string} line
+ * @param {number} [now]
+ * @returns {import("./ec-worker-stream.d.mts").StreamEvent[]}
+ */
+export function parseTranscriptLine(line, now = Date.now()) {
+  let obj;
+  try {
+    obj = JSON.parse(line);
+  } catch {
+    return [];
+  }
+  if (!obj || typeof obj.type !== "string") return [];
+  const ts = tsToMs(obj.timestamp, now);
+
+  // ── system records: retries / rate-limits ──────────────────────────────
+  if (obj.type === "system") {
+    if (obj.subtype === "api_error") {
+      // The nested error type disambiguates a rate-limit from a generic retry.
+      const nestedType =
+        obj?.error?.error?.error?.type ?? // {error:{error:{type,error:{type}}}}
+        obj?.error?.error?.type ??
+        obj?.error?.type ??
+        null;
+      const isRateLimit =
+        typeof nestedType === "string" && nestedType.includes("rate_limit");
+      if (isRateLimit) {
+        const resetsAt =
+          typeof obj.retryInMs === "number"
+            ? Math.round((ts + obj.retryInMs) / 1000)
+            : undefined;
+        return [
+          {
+            ts,
+            type: "rate_limit",
+            rateLimitInfo: { status: nestedType ?? "rate_limited", resetsAt },
+          },
+        ];
+      }
+      return [
+        {
+          ts,
+          type: "retry",
+          retryInfo: {
+            attempt:
+              typeof obj.retryAttempt === "number" ? obj.retryAttempt : 0,
+            maxRetries:
+              typeof obj.maxRetries === "number" ? obj.maxRetries : 0,
+            error:
+              (typeof nestedType === "string" && nestedType) ||
+              (typeof obj.error === "string" ? obj.error : "api_error"),
+          },
+        },
+      ];
+    }
+    return [];
+  }
+
+  // ── assistant records: turn + per-block text / reasoning / tool_use ─────
+  if (obj.type === "assistant" && obj.message && Array.isArray(obj.message.content)) {
+    const events = [];
+    const tools = [];
+    let textPreview;
+    for (const block of obj.message.content) {
+      if (!block || typeof block !== "object") continue;
+      if (block.type === "thinking" || block.type === "redacted_thinking") {
+        const thinking =
+          typeof block.thinking === "string" ? block.thinking : "";
+        events.push({ ts, type: "reasoning", text: thinking.slice(0, 200) });
+      } else if (block.type === "text" && typeof block.text === "string") {
+        if (textPreview === undefined) textPreview = block.text.slice(0, 200);
+        events.push({ ts, type: "text", text: block.text.slice(0, 200) });
+      } else if (block.type === "tool_use") {
+        const name = typeof block.name === "string" ? block.name : "tool";
+        tools.push(name);
+        events.push({
+          ts,
+          type: "tool_start",
+          tool: name,
+          toolInput: summarizeToolInput(block.input),
+        });
+      }
+    }
+    // One `turn` row anchors the assistant message (turnTools + first text).
+    events.unshift({
+      ts,
+      type: "turn",
+      turnTools: tools.length > 0 ? tools : undefined,
+      text: textPreview,
+      sessionId:
+        typeof obj.sessionId === "string" ? obj.sessionId : undefined,
+    });
+    return events;
+  }
+
+  // user / tool_result records are not surfaced as their own rows (the
+  // tool_start already carries the call; the next assistant turn shows the
+  // reaction). Everything else is silently skipped.
+  return [];
+}
+
+/** A short, single-line preview of a tool's input for the activity row. */
+function summarizeToolInput(input) {
+  if (!input || typeof input !== "object") return undefined;
+  // Prefer the human-meaningful fields, in priority order.
+  for (const key of [
+    "command",
+    "file_path",
+    "path",
+    "pattern",
+    "query",
+    "description",
+    "prompt",
+    "url",
+  ]) {
+    const v = input[key];
+    if (typeof v === "string" && v.length > 0) {
+      return v.replace(/\s+/g, " ").slice(0, 120);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a sessionId to its transcript path WITHOUT a full project-dir rescan
+ * on the hot path. Prefers the resident cache (a live worker has already been
+ * resolved by board assembly); falls back to a single scan only on a cold
+ * miss (e.g. a freshly-spawned session whose first board pass hasn't run yet).
+ *
+ * @param {string} sessionId
+ * @param {{ allowScan?: boolean }} [options]
+ * @returns {Promise<string | null>}
+ */
+export async function resolveTranscriptPath(sessionId, options = {}) {
+  if (!sessionId) return null;
+  const cached = peekTranscriptCache(sessionId);
+  if (cached) return cached;
+  if (options.allowScan === false) return null;
+  return resolveTranscript(sessionId);
+}
+
+/**
+ * A stateful tail over one transcript file. `poll()` reads only the bytes
+ * appended since the last call, parses any newly-completed lines into
+ * StreamEvents, and carries a partial trailing line forward. The first poll
+ * starts from the tail (last INITIAL_TAIL_BYTES) so a long resting transcript
+ * doesn't replay in full.
+ */
+export class TranscriptTail {
+  /** @param {string} filePath */
+  constructor(filePath) {
+    this.filePath = filePath;
+    this.offset = 0;
+    this.carry = "";
+    this.primed = false;
+    // When primed from a non-zero offset the first chunk's leading bytes are a
+    // partial line; drop everything up to the first newline so a half-record is
+    // never parsed.
+    this.skipPartialLead = false;
+  }
+
+  /**
+   * @returns {Promise<import("./ec-worker-stream.d.mts").StreamEvent[]>}
+   */
+  async poll() {
+    let size;
+    try {
+      size = (await stat(this.filePath)).size;
+    } catch {
+      return [];
+    }
+    if (!this.primed) {
+      // Start from the tail of the existing file on the first poll.
+      if (size > INITIAL_TAIL_BYTES) {
+        this.offset = size - INITIAL_TAIL_BYTES;
+        this.skipPartialLead = true;
+      } else {
+        this.offset = 0;
+      }
+      this.primed = true;
+    }
+    if (size < this.offset) {
+      // File truncated/rotated under us — restart from its current end.
+      this.offset = 0;
+      this.carry = "";
+      this.skipPartialLead = false;
+    }
+    if (size <= this.offset) return [];
+
+    const length = Math.min(size - this.offset, MAX_GROWTH_BYTES);
+    let chunk;
+    let fh;
+    try {
+      fh = await open(this.filePath, "r");
+      const buf = Buffer.alloc(length);
+      const { bytesRead } = await fh.read(buf, 0, length, this.offset);
+      chunk = buf.toString("utf8", 0, bytesRead);
+      this.offset += bytesRead;
+    } catch {
+      return [];
+    } finally {
+      if (fh) await fh.close().catch(() => {});
+    }
+
+    let text = this.carry + chunk;
+    if (this.skipPartialLead) {
+      const firstNl = text.indexOf("\n");
+      // Drop the leading partial line; if no newline yet, wait for more bytes.
+      text = firstNl === -1 ? "" : text.slice(firstNl + 1);
+      if (firstNl !== -1) this.skipPartialLead = false;
+    }
+
+    const lastNl = text.lastIndexOf("\n");
+    let complete;
+    if (lastNl === -1) {
+      // No complete line yet — carry it all forward.
+      this.carry = this.skipPartialLead ? "" : text;
+      complete = "";
+    } else {
+      complete = text.slice(0, lastNl);
+      this.carry = text.slice(lastNl + 1);
+    }
+
+    const now = Date.now();
+    const events = [];
+    for (const line of complete.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      events.push(...parseTranscriptLine(trimmed, now));
+    }
+    return events;
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/lib/stream-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/stream-reader.ts
@@ -28,6 +28,9 @@ interface StreamEvent {
     | "tool_start"
     | "tool_end"
     | "text"
+    // CTL-887 (BFF5): assistant `thinking` blocks from the EC transcript tail
+    // surface as `reasoning` rows (◌ thinking…).
+    | "reasoning"
     | "turn"
     | "init"
     | "retry"

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -21,6 +21,15 @@ import {
   assembleTicketRuns,
   readPhaseSignalVerbatim,
 } from "./lib/ticket-runs.mjs";
+// CTL-887 (BFF5): the live transcript tail for execution-core workers. The
+// legacy /api/worker-stream reads the Plane-B runs/ tree (empty for EC); this
+// is the EC equivalent — tails ~/.claude/projects/*/<sessionId>.jsonl and
+// emits typed StreamEvents over SSE for the worker [● live] tab + reasoning
+// rows + footer counters + the ticket active-node live tail.
+import {
+  resolveTranscriptPath,
+  TranscriptTail,
+} from "./lib/ec-worker-stream.mjs";
 import { queryHistory, queryStats, compareSessions } from "./lib/history-store";
 import {
   listArchivedOrchestrators,
@@ -1979,6 +1988,93 @@ export function createServer(opts: CreateServerOptions): BunServer {
             return new Response("Not Found", { status: 404 });
           }
           return Response.json(signal);
+        }
+
+        // CTL-887 (BFF5): the live transcript tail. Resolves a CC session UUID
+        // to its ~/.claude/projects/<dir>/<sessionId>.jsonl path (reusing the
+        // resident transcript-path cache — only a cold miss triggers a single
+        // scan) and streams typed StreamEvents over SSE as the file grows. This
+        // is the EC equivalent of the legacy /api/worker-stream (which is empty
+        // for execution-core workers). Host-local + stateless so a cluster
+        // fan-in (BFF3, single-node-descoped) is a clean wrap.
+        const ecWorkerStreamMatch = url.pathname.match(
+          /^\/api\/ec-worker-stream\/([^/]+)$/,
+        );
+        if (ecWorkerStreamMatch) {
+          let sessionId: string;
+          try {
+            sessionId = decodeURIComponent(ecWorkerStreamMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          // A CC session id is a UUID — reject anything else so no arbitrary
+          // path ever reaches the filesystem.
+          if (
+            !/^[0-9a-fA-F-]{8,64}$/.test(sessionId) ||
+            sessionId.includes("..") ||
+            sessionId.includes("/")
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const transcriptPath = await resolveTranscriptPath(sessionId);
+          if (!transcriptPath) {
+            return new Response("Not Found", { status: 404 });
+          }
+
+          let timer: ReturnType<typeof setInterval> | null = null;
+          let inFlight = false;
+          let closed = false;
+          const tail = new TranscriptTail(transcriptPath);
+          const stream = new ReadableStream<Uint8Array>({
+            start(controller) {
+              const pump = () => {
+                if (inFlight || closed) return;
+                inFlight = true;
+                void (async () => {
+                  try {
+                    const events = await tail.poll();
+                    if (closed) return;
+                    for (const ev of events) {
+                      controller.enqueue(
+                        encoder.encode(
+                          `event: stream-event\ndata: ${JSON.stringify(ev)}\n\n`,
+                        ),
+                      );
+                    }
+                  } catch {
+                    // client likely went away mid-enqueue; stop pumping
+                    closed = true;
+                    if (timer) clearInterval(timer);
+                    timer = null;
+                  } finally {
+                    inFlight = false;
+                  }
+                })();
+              };
+              // Open frame so a cold connection paints the tail immediately,
+              // then poll for growth on a fixed cadence.
+              controller.enqueue(
+                encoder.encode(
+                  `event: open\ndata: ${JSON.stringify({ sessionId })}\n\n`,
+                ),
+              );
+              pump();
+              timer = setInterval(pump, 750);
+            },
+            cancel() {
+              closed = true;
+              if (timer) clearInterval(timer);
+              timer = null;
+            },
+          });
+          return new Response(stream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+              "Access-Control-Allow-Origin": "*",
+            },
+          });
         }
 
         if (url.pathname === "/api/board") {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/worker-detail-drawer.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/worker-detail-drawer.tsx
@@ -107,6 +107,21 @@ function StreamEventRow({ event }: { event: StreamEvent }) {
           </span>
         </div>
       );
+    // CTL-887 (BFF5): ◌ thinking… reasoning rows from the EC transcript tail.
+    case "reasoning":
+      return (
+        <div className="flex items-start gap-2 py-1">
+          <span className="mt-0.5 shrink-0 font-mono text-[11px] leading-none text-muted">
+            ◌
+          </span>
+          <span className="min-w-0 flex-1 truncate text-[11px] italic text-muted">
+            {event.text?.slice(0, 100) || "thinking…"}
+          </span>
+          <span className="shrink-0 font-mono text-[10px] text-muted tabular-nums">
+            {fmtSince(age)}
+          </span>
+        </div>
+      );
     case "turn": {
       const hasTools = event.turnTools && event.turnTools.length > 0;
       const hasText = event.text && event.text.length > 0;

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/types.ts
@@ -41,6 +41,9 @@ export interface StreamEvent {
     | "tool_start"
     | "tool_end"
     | "text"
+    // CTL-887 (BFF5): assistant `thinking` blocks from the EC transcript tail
+    // surface as `reasoning` rows (◌ thinking…).
+    | "reasoning"
     | "turn"
     | "init"
     | "retry"


### PR DESCRIPTION
## Summary

P4 / the design's "biggest gap": execution-core workers had **no live tail**. The legacy `/api/worker-stream` reads the Plane-B `runs/` tree, which is empty for EC `claude --bg` workers. This adds the EC equivalent — a new SSE route `GET /api/ec-worker-stream/<sessionId>` that tails `~/.claude/projects/*/<sessionId>.jsonl` and emits typed `StreamEvent`s as the file grows, so the worker `[● live]` tab, the ticket active-node tail, the footer counters, and the retry/turn/tool-error diagnostics can all derive from one host-local, stateless stream.

Depends on **BFF1** (server mount, merged) and **BFF4** (per-run `sessionId` resolution via `/api/ticket-runs`, merged — `TicketRun.sessionId` is what the ticket active-node tail subscribes with).

## What landed

- **`lib/ec-worker-stream.mjs` (+ `.d.mts`)** — the parser + tail:
  - `parseTranscriptLine(line, now)` converts one **resting-transcript** JSONL record into `StreamEvent[]`. This is the on-disk format (`assistant`/`user`/`system` records with `message.content[]` blocks + ISO `timestamp`), which is **distinct** from the `--bg` stream-json frames the legacy `lib/stream-reader.ts` parses. `system`/`api_error` records become `retry` rows, with a `rate_limit` row when the nested `error…type` is a rate-limit; assistant `thinking` blocks become `reasoning` (◌) rows; `tool_use` blocks become `tool_start` with a one-line input preview; each assistant message is anchored by one `turn` row carrying `turnTools`.
  - `TranscriptTail` incrementally tails a growing file — primes from the tail of a large resting transcript (so it never replays the whole thing), carries a partial trailing line forward until its newline arrives, and restarts cleanly on truncation/rotation.
  - `resolveTranscriptPath(sessionId)` reuses board-data's resident transcript-path cache — **cache HITS only** (no ~1.5k-dir rescan), with a single fallback scan on a cold miss.
- **`lib/board-data.mjs`** — export `resolveTranscript` (unchanged behavior) + a new `peekTranscriptCache` (cache-only peek) so the SSE endpoint avoids the dir scan on the hot path.
- **`server.ts`** — the SSE route: UUID validation (400), no-transcript (404), an `open` frame then a 750ms growth poll emitting `stream-event` frames.
- **`StreamEvent` `reasoning` variant** added to `lib/stream-reader.ts` + `ui/src/lib/types.ts`, and a `◌ thinking…` case in the `StreamEventRow` renderer so reasoning rows render end-to-end.

## Gherkin scenario mapping

| Scenario | Status |
|---|---|
| A running worker streams its live transcript (tool/text/turn/retry/rate-limit StreamEvents as the file grows) | **Satisfied** — `parseTranscriptLine` + `TranscriptTail` + the SSE route; covered by parser + live-growth endpoint tests |
| …and reasoning rows (◌ thinking…) are emitted | **Satisfied** — `thinking` blocks → `reasoning` events + renderer row |
| Footer counters and diagnostics derive from the stream (event/tool/retry counts client-derivable; retries/rate-limit/tool-errors/turn from the tail) | **Satisfied** — endpoint emits the typed rows the client tallies; unit test asserts the counts are derivable from emitted rows |
| The same source feeds the ticket active-node tail (consumes the same `ec-worker-stream` for that phase's `sessionId`) | **Satisfied (endpoint)** — keyed on `sessionId` (the value BFF4's `TicketRun.sessionId` carries); the ticket-page wiring that consumes it is a separate UI ticket |
| Resolving the transcript path is cache-backed (reuses the transcript-path cache, not a full re-scan) | **Satisfied** — `peekTranscriptCache` (HITS only) + single fallback scan on cold miss |

## Single-node descope

No multi-node scenarios in this ticket. The cross-node note (cluster fan-in keyed by `host.name`, BFF3/CTL-873) is **single-node-descoped**: the tail is host-local and stateless by construction, so a fan-in is a clean wrap — no cluster/fence/hosts.json state is read here.

## Tests

- `__tests__/ec-worker-stream.test.ts` — 14 tests (parser: tool/text/reasoning/turn/retry/rate-limit, ts fallback, malformed input, counter-derivability; tail: missing file, live growth across polls, partial-line carry, large-file priming, truncation restart).
- `__tests__/ec-worker-stream-endpoints.test.ts` — 3 tests (sessionId 400 validation, 404 no-transcript, SSE happy path streaming `stream-event` frames as a real `~/.claude/projects` transcript grows).

Run: `bun test __tests__/ec-worker-stream.test.ts __tests__/ec-worker-stream-endpoints.test.ts` → 17 pass. `bunx tsc --noEmit` clean for touched files in both the server and `ui` packages (two pre-existing unrelated errors remain: `ui/src/lib/briefings.ts` missing `marked`/`dompurify` in the server tsconfig scope, and `ui/src/components/kpi-strip.tsx` `abandoned` prop — both present on clean main). `bun run build` in `ui` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)