### PR TITLE
feat(dev): BFF8 fence-aware stop-worker mutation (CTL-890)

### DIFF
--- a/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
@@ -65,3 +65,57 @@ export function claimDispatchSync(
     return { won: false, generation: null };
   }
 }
+
+// FENCE_STALE_EXIT — mirror of cluster-claim.mjs's exit code: the CLI exits 10
+// when the ticket's current claim generation no longer matches the generation we
+// asked about (a stale/partitioned generation). Kept in sync deliberately; the
+// two files are the only places this contract lives.
+const FENCE_STALE_EXIT = 10;
+
+// fenceCheckSync — is `generation` still the CURRENT fence for `ticket`?
+// Synchronously drives `node cluster-claim.mjs fence-check <ticket> <gen>` over
+// spawnSync (the same sync-subprocess convention as claimDispatchSync). Returns a
+// discriminated result the caller can act on WITHOUT a second interpretation pass:
+//   { current: true }              → exit 0: the generation is current, proceed.
+//   { current: false, stale: true } → exit 10 (FENCE_STALE_EXIT): a takeover
+//                                      bumped past us; we are a stale/partitioned
+//                                      generation → the side-effect must be rejected.
+//   { current: false, stale: false }→ ANY other failure (spawn error, timeout,
+//                                      other non-zero exit, unparseable stdout).
+//
+// FAIL-CLOSED for a destructive caller: this returns current:false (NOT current)
+// on every non-success, so the only path that yields current:true is an explicit
+// exit-0 from the fence CLI. A stop-worker caller treats current:false as "do not
+// kill" — the conservative answer when the fence cannot be affirmatively
+// confirmed (we never SIGKILL a worker on an uncertain or errored fence read).
+// `stale` distinguishes the verified-stale rejection (the Gherkin "fenced out"
+// case) from an indeterminate failure for honest UI messaging.
+//
+// `spawn`/`nodeBin`/`cli`/`env`/`timeout` are injectable so the unit tests never
+// spawn a real process.
+export function fenceCheckSync(
+  { ticket, generation },
+  {
+    spawn = spawnSync,
+    nodeBin = process.execPath,
+    cli = CLUSTER_CLAIM_CLI,
+    env = process.env,
+    timeout = CLAIM_TIMEOUT_MS,
+  } = {},
+) {
+  try {
+    const res = spawn(nodeBin, [cli, "fence-check", ticket, String(generation)], {
+      encoding: "utf8",
+      env,
+      timeout,
+    });
+    if (!res) return { current: false, stale: false };
+    if (res.status === 0) return { current: true, stale: false };
+    if (res.status === FENCE_STALE_EXIT) return { current: false, stale: true };
+    // Any other exit / spawn error / timeout: indeterminate → not current, not
+    // verified-stale. Fail-closed for the destructive caller.
+    return { current: false, stale: false };
+  } catch {
+    return { current: false, stale: false };
+  }
+}

--- a/plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs
@@ -4,7 +4,7 @@
 // the FAIL-CLOSED contract (won:false on any failure).
 import { describe, it, expect } from "bun:test";
 
-import { claimDispatchSync } from "./cluster-claim-sync.mjs";
+import { claimDispatchSync, fenceCheckSync } from "./cluster-claim-sync.mjs";
 
 describe("claimDispatchSync — argv + parsing", () => {
   it("builds the right argv: node <cli> claim <ticket> <host> <phase>", () => {
@@ -84,6 +84,71 @@ describe("claimDispatchSync — FAIL-CLOSED on every failure mode", () => {
     expect(claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn })).toEqual({
       won: true,
       generation: null,
+    });
+  });
+});
+
+describe("fenceCheckSync — argv + exit-code interpretation (CTL-890)", () => {
+  it("builds the right argv: node <cli> fence-check <ticket> <gen>", () => {
+    let captured;
+    const spawn = (bin, args) => {
+      captured = { bin, args };
+      return { status: 0 };
+    };
+    fenceCheckSync(
+      { ticket: "CTL-7", generation: 4 },
+      { spawn, nodeBin: "/usr/bin/node", cli: "/x/cluster-claim.mjs" },
+    );
+    expect(captured.bin).toBe("/usr/bin/node");
+    expect(captured.args).toEqual([
+      "/x/cluster-claim.mjs",
+      "fence-check",
+      "CTL-7",
+      "4",
+    ]);
+  });
+
+  it("exit 0 → { current:true } (the generation is current — proceed)", () => {
+    const spawn = () => ({ status: 0, stdout: '{"current":true}\n' });
+    expect(fenceCheckSync({ ticket: "CTL-1", generation: 2 }, { spawn })).toEqual({
+      current: true,
+      stale: false,
+    });
+  });
+
+  it("exit 10 (FENCE_STALE_EXIT) → { current:false, stale:true } (a partitioned generation)", () => {
+    const spawn = () => ({ status: 10, stdout: '{"current":false}\n' });
+    expect(fenceCheckSync({ ticket: "CTL-1", generation: 2 }, { spawn })).toEqual({
+      current: false,
+      stale: true,
+    });
+  });
+});
+
+describe("fenceCheckSync — FAIL-CLOSED on every indeterminate failure", () => {
+  it("any other non-zero exit → { current:false, stale:false }", () => {
+    const spawn = () => ({ status: 1, stdout: "" });
+    expect(fenceCheckSync({ ticket: "CTL-1", generation: 2 }, { spawn })).toEqual({
+      current: false,
+      stale: false,
+    });
+  });
+
+  it("timeout / spawn error (status null) → { current:false, stale:false }", () => {
+    const spawn = () => ({ status: null, error: new Error("ETIMEDOUT") });
+    expect(fenceCheckSync({ ticket: "CTL-1", generation: 2 }, { spawn })).toEqual({
+      current: false,
+      stale: false,
+    });
+  });
+
+  it("spawn throws → { current:false, stale:false } (never propagates)", () => {
+    const spawn = () => {
+      throw new Error("EACCES");
+    };
+    expect(fenceCheckSync({ ticket: "CTL-1", generation: 2 }, { spawn })).toEqual({
+      current: false,
+      stale: false,
     });
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/stop-worker-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/stop-worker-endpoint.test.ts
@@ -1,0 +1,98 @@
+// stop-worker-endpoint.test.ts — HTTP route-plumbing tests for the read-model's
+// ONE destructive endpoint, POST /api/ec-worker/<ticket>/stop (CTL-890, BFF8 —
+// the design's P10). Validates the server.ts wiring — method gate, param + body
+// validation (400), the typed-confirm gate (400), and the 404 for a ticket/phase
+// with no run signal on disk. The mutation LOGIC itself (shortId derivation,
+// fence branches, optimistic `stopping` contract) is covered exhaustively by the
+// injectable unit tests in stop-worker.test.ts; these tests prove the route is
+// mounted, matched, method-gated, and guarded.
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+let tmpDir: string;
+
+// A ticket id that definitively has no worker dir on this machine, so the route's
+// behavior is deterministic regardless of host state.
+const ABSENT_TICKET = "ZZZ-999999";
+
+async function postStop(ticket: string, body: unknown) {
+  return fetch(`${baseUrl}/api/ec-worker/${ticket}/stop`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "stop-worker-endpoint-"));
+  const wtDir = join(tmpDir, "wt");
+  mkdirSync(wtDir, { recursive: true });
+  server = createServer({ port: 0, wtDir, startWatcher: false });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  void server?.stop(true);
+  if (tmpDir) {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+describe("POST /api/ec-worker/:ticket/stop (CTL-890)", () => {
+  it("rejects a malformed ticket id with 400 (no path traversal / arbitrary read)", async () => {
+    expect((await postStop("not-a-ticket", { phase: "implement", confirm: "x" })).status).toBe(400);
+    expect((await postStop("CTL", { phase: "implement", confirm: "x" })).status).toBe(400);
+    expect((await postStop("..%2F..%2Fetc", { phase: "implement", confirm: "x" })).status).toBe(400);
+  });
+
+  it("rejects an invalid JSON body with 400", async () => {
+    const res = await postStop(ABSENT_TICKET, "{ not json");
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a missing / malformed phase with 400 (no traversal via the phase field)", async () => {
+    expect((await postStop(ABSENT_TICKET, { confirm: ABSENT_TICKET })).status).toBe(400);
+    expect((await postStop(ABSENT_TICKET, { phase: "Implement", confirm: ABSENT_TICKET })).status).toBe(400);
+    expect((await postStop(ABSENT_TICKET, { phase: "../triage", confirm: ABSENT_TICKET })).status).toBe(400);
+    expect((await postStop(ABSENT_TICKET, { phase: 7, confirm: ABSENT_TICKET })).status).toBe(400);
+  });
+
+  it("returns 404 when the ticket/phase has no run signal on disk", async () => {
+    // confirm matches the ticket so we pass the typed-confirm gate and reach the
+    // signal read, which 404s for an absent worker dir.
+    const res = await postStop(ABSENT_TICKET, {
+      phase: "implement",
+      confirm: ABSENT_TICKET,
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("not_found");
+  });
+
+  it("a GET to /stop is NOT the mutation (method-gated) — never issues a stop", async () => {
+    // The POST-stop route is gated on `req.method === "POST"`, so a GET falls
+    // through to the verbatim ec-worker reader, which treats "stop" as a phase
+    // name and 404s on the absent `phase-stop.json` — proving the GET never
+    // triggered the mutation (a fired stop would 200/409/404-with-`status` JSON).
+    const res = await fetch(`${baseUrl}/api/ec-worker/${ABSENT_TICKET}/stop`);
+    expect(res.status).toBe(404);
+    // the reader returns a plain "Not Found" body (no JSON `status` field that
+    // the mutation handler would emit), confirming we hit the reader, not stopWorker.
+    expect(res.headers.get("content-type")).not.toContain("application/json");
+  });
+
+  it("the verbatim GET reader still works for a real phase name (route ordering intact)", async () => {
+    // POST-stop matching must not shadow the GET verbatim reader for normal phases.
+    const res = await fetch(`${baseUrl}/api/ec-worker/${ABSENT_TICKET}/implement`);
+    expect(res.status).toBe(404); // absent worker dir → 404, not a routing miss (would be 404 "Not Found" w/o JSON)
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/stop-worker.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/stop-worker.test.ts
@@ -1,0 +1,402 @@
+// stop-worker.test.ts — unit coverage for the read-model's ONE destructive
+// endpoint helper (CTL-890, BFF8 — the design's P10). Every collaborator is
+// injected so nothing reads a real signal, spawns a real `claude`, or runs the
+// real fence CLI. These tests encode the four Gherkin scenarios directly:
+//   1. A confirmed stop terminates the worker.
+//   2. Optimistic rollback on a flaky stop (the endpoint's `stopping` contract
+//      + the stop-failed path the UI rolls back from).
+//   3. A stale-generation node is fenced out (verified-stale → rejected).
+//   4. Single-host stop is unaffected (fence-check is an identity no-op pass).
+import { describe, it, expect } from "bun:test";
+import {
+  stopWorker,
+  runFenceCheck,
+  readClusterHostCount,
+  claudeStop,
+} from "../lib/stop-worker.mjs";
+
+// A 36-char UUID and its 8-char short form (the `claude stop` target).
+const FULL_UUID = "a1b2c3d4-0000-0000-0000-000000000000";
+const SHORT_ID = "a1b2c3d4";
+
+// A minimal verbatim phase signal as readPhaseSignalVerbatim returns it.
+function signal(over: Record<string, unknown> = {}) {
+  return {
+    ticket: "CTL-845",
+    phase: "implement",
+    status: "working",
+    bg_job_id: FULL_UUID,
+    generation: 3,
+    ...over,
+  };
+}
+
+// Default injections: single-host (fence no-op), a successful stop.
+function deps(over: Partial<Parameters<typeof stopWorker>[1]> = {}) {
+  return {
+    readSignal: () => Promise.resolve(signal()),
+    fenceCheck: () => ({ ok: true, noop: true, stale: false }),
+    stop: () => ({ ok: true }),
+    ...over,
+  };
+}
+
+describe("stopWorker — Scenario 1: a confirmed stop terminates the worker", () => {
+  it("typed confirm matches → issues `claude stop <shortId>` and reports `stopping`", async () => {
+    const stopped: string[] = [];
+    const res = await stopWorker(
+      { ticket: "CTL-845", phase: "implement", confirm: "CTL-845" },
+      deps({
+        stop: (id: string) => {
+          stopped.push(id);
+          return { ok: true };
+        },
+      }),
+    );
+    expect(stopped).toEqual([SHORT_ID]);
+    expect(res).toEqual({
+      status: "stopping",
+      ticket: "CTL-845",
+      phase: "implement",
+      shortId: SHORT_ID,
+      fenceNoop: true,
+    });
+  });
+
+  it("derives the 8-char shortId from a full-UUID bg_job_id (claude stop rejects UUIDs)", async () => {
+    const stopped: string[] = [];
+    await stopWorker(
+      { ticket: "CTL-845", phase: "implement", confirm: "CTL-845" },
+      deps({
+        readSignal: () => Promise.resolve(signal({ bg_job_id: FULL_UUID })),
+        stop: (id: string) => {
+          stopped.push(id);
+          return { ok: true };
+        },
+      }),
+    );
+    expect(stopped).toEqual([SHORT_ID]);
+    expect(stopped[0]?.length).toBe(8);
+  });
+
+  it("an already-short bg_job_id passes through unchanged", async () => {
+    const stopped: string[] = [];
+    await stopWorker(
+      { ticket: "CTL-845", phase: "implement", confirm: "CTL-845" },
+      deps({
+        readSignal: () => Promise.resolve(signal({ bg_job_id: SHORT_ID })),
+        stop: (id: string) => {
+          stopped.push(id);
+          return { ok: true };
+        },
+      }),
+    );
+    expect(stopped).toEqual([SHORT_ID]);
+  });
+});
+
+describe("stopWorker — typed-confirm gate", () => {
+  it("a mismatched confirm is rejected WITHOUT issuing any stop", async () => {
+    let stopCalled = false;
+    const res = await stopWorker(
+      { ticket: "CTL-845", phase: "implement", confirm: "CTL-844" },
+      deps({
+        stop: () => {
+          stopCalled = true;
+          return { ok: true };
+        },
+      }),
+    );
+    expect(stopCalled).toBe(false);
+    expect(res).toEqual({ status: "confirm_mismatch", expected: "CTL-845" });
+  });
+
+  it("a missing confirm is rejected", async () => {
+    const res = await stopWorker(
+      { ticket: "CTL-845", phase: "implement", confirm: undefined },
+      deps(),
+    );
+    expect(res.status).toBe("confirm_mismatch");
+  });
+});
+
+describe("stopWorker — no run / no live session", () => {
+  it("a missing signal → not_found (nothing to stop)", async () => {
+    const res = await stopWorker(
+      { ticket: "CTL-845", phase: "implement", confirm: "CTL-845" },
+      deps({ readSignal: () => Promise.resolve(null) }),
+    );
+    expect(res).toEqual({ status: "not_found" });
+  });
+
+  it("a run with no bg_job_id → no_session, never a blind kill", async () => {
+    let stopCalled = false;
+    const res = await stopWorker(
+      { ticket: "CTL-845", phase: "implement", confirm: "CTL-845" },
+      deps({
+        readSignal: () => Promise.resolve(signal({ bg_job_id: null })),
+        stop: () => {
+          stopCalled = true;
+          return { ok: true };
+        },
+      }),
+    );
+    expect(stopCalled).toBe(false);
+    expect(res).toEqual({ status: "no_session", ticket: "CTL-845", phase: "implement" });
+  });
+
+  it("a run with an unparseable bg_job_id → no_session", async () => {
+    const res = await stopWorker(
+      { ticket: "CTL-845", phase: "implement", confirm: "CTL-845" },
+      deps({ readSignal: () => Promise.resolve(signal({ bg_job_id: "not-a-hex-id" })) }),
+    );
+    expect(res.status).toBe("no_session");
+  });
+});
+
+describe("stopWorker — Scenario 2: optimistic rollback on a flaky stop", () => {
+  it("`stopping` is the optimistic contract the UI marks before the rollback window", async () => {
+    const res = await stopWorker(
+      { ticket: "CTL-845", phase: "implement", confirm: "CTL-845" },
+      deps(),
+    );
+    // The endpoint reports `stopping` + the exact identity; the UI arms its ~10s
+    // timer and rolls back if the next board frame still shows the worker working.
+    expect(res.status).toBe("stopping");
+  });
+
+  it("a `claude stop` failure surfaces as stop_failed (the UI rolls back from this too)", async () => {
+    const res = await stopWorker(
+      { ticket: "CTL-845", phase: "implement", confirm: "CTL-845" },
+      deps({ stop: () => ({ ok: false, error: "no such session" }) }),
+    );
+    expect(res).toEqual({
+      status: "stop_failed",
+      ticket: "CTL-845",
+      phase: "implement",
+      shortId: SHORT_ID,
+      error: "no such session",
+    });
+  });
+});
+
+describe("stopWorker — Scenario 3: a stale-generation node is fenced out", () => {
+  it("a verified-stale fence rejects the stop and does NOT kill the worker", async () => {
+    let stopCalled = false;
+    const res = await stopWorker(
+      { ticket: "CTL-845", phase: "implement", confirm: "CTL-845" },
+      deps({
+        // multi-host fence reports VERIFIED stale (CLI exit 10)
+        fenceCheck: () => ({ ok: false, noop: false, stale: true }),
+        stop: () => {
+          stopCalled = true;
+          return { ok: true };
+        },
+      }),
+    );
+    expect(stopCalled).toBe(false);
+    expect(res).toEqual({
+      status: "fenced",
+      ticket: "CTL-845",
+      phase: "implement",
+      shortId: SHORT_ID,
+    });
+  });
+
+  it("an indeterminate fence (CLI errored) refuses to kill — fail-closed", async () => {
+    let stopCalled = false;
+    const res = await stopWorker(
+      { ticket: "CTL-845", phase: "implement", confirm: "CTL-845" },
+      deps({
+        fenceCheck: () => ({ ok: false, noop: false, stale: false }),
+        stop: () => {
+          stopCalled = true;
+          return { ok: true };
+        },
+      }),
+    );
+    expect(stopCalled).toBe(false);
+    expect(res.status).toBe("fence_indeterminate");
+  });
+});
+
+describe("stopWorker — Scenario 4: single-host stop is unaffected (fence no-op)", () => {
+  it("single-host fence pass proceeds normally with fenceNoop:true", async () => {
+    const res = await stopWorker(
+      { ticket: "CTL-845", phase: "implement", confirm: "CTL-845" },
+      deps({ fenceCheck: () => ({ ok: true, noop: true, stale: false }) }),
+    );
+    expect(res.status).toBe("stopping");
+    expect((res as { fenceNoop: boolean }).fenceNoop).toBe(true);
+  });
+
+  it("a multi-host CURRENT fence also proceeds, but fenceNoop:false", async () => {
+    const res = await stopWorker(
+      { ticket: "CTL-845", phase: "implement", confirm: "CTL-845" },
+      deps({ fenceCheck: () => ({ ok: true, noop: false, stale: false }) }),
+    );
+    expect(res.status).toBe("stopping");
+    expect((res as { fenceNoop: boolean }).fenceNoop).toBe(false);
+  });
+});
+
+describe("runFenceCheck — single-host no-op vs multi-host CLI", () => {
+  it("hostCount<=1 → identity no-op pass, NEVER spawns a subprocess", () => {
+    let spawned = false;
+    const out = runFenceCheck(
+      { ticket: "CTL-845", generation: 3 },
+      {
+        hostCount: 1,
+        spawn: () => {
+          spawned = true;
+          return { status: 0, stdout: "" };
+        },
+      },
+    );
+    expect(spawned).toBe(false);
+    expect(out).toEqual({ ok: true, noop: true, stale: false });
+  });
+
+  it("hostCount=0 (degenerate roster) also treated as single-host no-op", () => {
+    const out = runFenceCheck({ ticket: "CTL-845", generation: 3 }, { hostCount: 0 });
+    expect(out.ok).toBe(true);
+    expect(out.noop).toBe(true);
+  });
+
+  it("multi-host + fence CLI exit 0 → current (ok, not noop)", () => {
+    const out = runFenceCheck(
+      { ticket: "CTL-845", generation: 3 },
+      { hostCount: 2, spawn: () => ({ status: 0, stdout: '{"current":true}\n' }) },
+    );
+    expect(out).toEqual({ ok: true, noop: false, stale: false });
+  });
+
+  it("multi-host + fence CLI exit 10 → verified stale", () => {
+    const out = runFenceCheck(
+      { ticket: "CTL-845", generation: 3 },
+      { hostCount: 2, spawn: () => ({ status: 10, stdout: '{"current":false}\n' }) },
+    );
+    expect(out).toEqual({ ok: false, noop: false, stale: true });
+  });
+
+  it("multi-host + any other non-zero / spawn error → indeterminate (fail-closed)", () => {
+    expect(
+      runFenceCheck(
+        { ticket: "CTL-845", generation: 3 },
+        { hostCount: 2, spawn: () => ({ status: 1, stdout: "" }) },
+      ),
+    ).toEqual({ ok: false, noop: false, stale: false });
+    expect(
+      runFenceCheck(
+        { ticket: "CTL-845", generation: 3 },
+        { hostCount: 2, spawn: () => ({ status: null, error: new Error("ETIMEDOUT"), stdout: null }) },
+      ),
+    ).toEqual({ ok: false, noop: false, stale: false });
+  });
+
+  it("multi-host + a null generation can't be fence-checked → indeterminate, no spawn", () => {
+    let spawned = false;
+    const out = runFenceCheck(
+      { ticket: "CTL-845", generation: null },
+      {
+        hostCount: 2,
+        spawn: () => {
+          spawned = true;
+          return { status: 0, stdout: "" };
+        },
+      },
+    );
+    expect(spawned).toBe(false);
+    expect(out).toEqual({ ok: false, noop: false, stale: false });
+  });
+
+  it("multi-host builds the right argv: node <cli> fence-check <ticket> <gen>", () => {
+    const captured: { bin: string; args: readonly string[] }[] = [];
+    runFenceCheck(
+      { ticket: "CTL-845", generation: 3 },
+      {
+        hostCount: 2,
+        nodeBin: "/usr/bin/node",
+        cli: "/x/cluster-claim.mjs",
+        spawn: (bin: string, args: readonly string[]) => {
+          captured.push({ bin, args });
+          return { status: 0, stdout: "" };
+        },
+      },
+    );
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.bin).toBe("/usr/bin/node");
+    expect(captured[0]?.args).toEqual([
+      "/x/cluster-claim.mjs",
+      "fence-check",
+      "CTL-845",
+      "3",
+    ]);
+  });
+});
+
+describe("readClusterHostCount — single-host default", () => {
+  it("an absent / unreadable hosts.json → single-host default of 1", () => {
+    const out = readClusterHostCount({
+      env: {},
+      read: () => {
+        throw new Error("ENOENT");
+      },
+    });
+    expect(out).toBe(1);
+  });
+
+  it("a roster of one → 1", () => {
+    const out = readClusterHostCount({
+      env: { CATALYST_CONFIG_FILE: "/repo/.catalyst/config.json" },
+      read: () => JSON.stringify(["mini"]),
+    });
+    expect(out).toBe(1);
+  });
+
+  it("a roster of three → 3", () => {
+    const out = readClusterHostCount({
+      env: { CATALYST_CONFIG_FILE: "/repo/.catalyst/config.json" },
+      read: () => JSON.stringify(["mini", "mac-studio", "laptop"]),
+    });
+    expect(out).toBe(3);
+  });
+
+  it("a malformed / non-array roster → single-host default of 1", () => {
+    expect(
+      readClusterHostCount({ env: {}, read: () => "not json" }),
+    ).toBe(1);
+    expect(
+      readClusterHostCount({ env: {}, read: () => JSON.stringify({ not: "an array" }) }),
+    ).toBe(1);
+    expect(
+      readClusterHostCount({ env: {}, read: () => JSON.stringify([]) }),
+    ).toBe(1);
+    // an array of empties is filtered to zero valid hosts → 1
+    expect(
+      readClusterHostCount({ env: {}, read: () => JSON.stringify(["", null, 7]) }),
+    ).toBe(1);
+  });
+});
+
+describe("claudeStop — the kill primitive", () => {
+  it("exit 0 → ok:true", () => {
+    expect(claudeStop(SHORT_ID, { spawn: () => ({ status: 0 }) })).toEqual({ ok: true });
+  });
+
+  it("non-zero exit → ok:false with the stderr message", () => {
+    expect(
+      claudeStop(SHORT_ID, { spawn: () => ({ status: 1, stderr: "no such session" }) }),
+    ).toEqual({ ok: false, error: "no such session" });
+  });
+
+  it("spawn throwing → ok:false, never propagates", () => {
+    const res = claudeStop(SHORT_ID, {
+      spawn: () => {
+        throw new Error("EACCES");
+      },
+    });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe("EACCES");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/stop-worker.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/stop-worker.d.mts
@@ -1,0 +1,97 @@
+// Type declarations for stop-worker.mjs (CTL-890, BFF8) — the read-model's ONE
+// destructive endpoint (the design's P10). Lets the strict TS server (server.ts)
+// import stopWorker without a TS7016 implicit-any error. Keep in sync with the
+// objects returned in stop-worker.mjs.
+
+/** Verbatim phase signal shape (the subset stopWorker reads). */
+interface PhaseSignalLike {
+  bg_job_id?: unknown;
+  generation?: unknown;
+  status?: unknown;
+  phase?: unknown;
+  ticket?: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * The injectable spawnSync seam. Typed as the SUBSET of the spawnSync return the
+ * lib actually reads (status/stdout/stderr/error), so unit-test fakes can return
+ * a minimal object without satisfying the full SpawnSyncReturns shape (pid/output/
+ * signal). The real spawnSync return is structurally assignable to this.
+ */
+export type SpawnSyncLike = (
+  command: string,
+  args: readonly string[],
+  options?: unknown,
+) => {
+  status?: number | null;
+  stdout?: string | null;
+  stderr?: string | null;
+  error?: Error;
+};
+
+/** Outcome of the cross-host fence-check (single-host no-op pass or CLI). */
+export interface FenceOutcome {
+  /** true ⇒ proceed (current, or single-host no-op). */
+  ok: boolean;
+  /** true ⇒ single-host identity no-op pass (no subprocess ran). */
+  noop: boolean;
+  /** true ⇒ VERIFIED stale (fence CLI exit 10) — a partitioned/stale generation. */
+  stale: boolean;
+}
+
+/** Result of the `claude stop <shortId>` primitive. */
+export interface ClaudeStopResult {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * Discriminated outcome of stopWorker; the route maps `status` to an HTTP code.
+ * - not_found            → 404 (no run signal on disk)
+ * - confirm_mismatch     → 400 (typed confirm did not match the ticket id)
+ * - no_session           → 409 (run never had a live bg session)
+ * - fenced               → 409 (verified-stale fence; a partitioned node rejected)
+ * - fence_indeterminate  → 409 (multi-host fence unconfirmed; refuse to kill)
+ * - stop_failed          → 502 (`claude stop` errored)
+ * - stopping             → 200 (kill issued; UI marks `stopping` + arms rollback)
+ */
+export type StopWorkerResult =
+  | { status: "not_found" }
+  | { status: "confirm_mismatch"; expected: string }
+  | { status: "no_session"; ticket: string; phase: string }
+  | { status: "fenced"; ticket: string; phase: string; shortId: string }
+  | { status: "fence_indeterminate"; ticket: string; phase: string; shortId: string }
+  | { status: "stop_failed"; ticket: string; phase: string; shortId: string; error?: string }
+  | { status: "stopping"; ticket: string; phase: string; shortId: string; fenceNoop: boolean };
+
+export function readClusterHostCount(opts?: {
+  env?: Record<string, string | undefined>;
+  read?: (path: string, encoding: "utf8") => string;
+}): number;
+
+export function runFenceCheck(
+  args: { ticket: string; generation: number | null },
+  opts?: {
+    hostCount?: number;
+    spawn?: SpawnSyncLike;
+    nodeBin?: string;
+    cli?: string;
+    env?: Record<string, string | undefined>;
+    timeout?: number;
+  },
+): FenceOutcome;
+
+export function claudeStop(
+  shortId: string,
+  opts?: { spawn?: SpawnSyncLike },
+): ClaudeStopResult;
+
+export function stopWorker(
+  args: { ticket: string; phase: string; confirm: unknown },
+  opts?: {
+    readSignal?: (ticket: string, phase: string) => Promise<PhaseSignalLike | null>;
+    fenceCheck?: (args: { ticket: string; generation: number | null }) => FenceOutcome;
+    stop?: (shortId: string) => ClaudeStopResult;
+  },
+): Promise<StopWorkerResult>;

--- a/plugins/dev/scripts/orch-monitor/lib/stop-worker.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/stop-worker.mjs
@@ -1,0 +1,241 @@
+// stop-worker.mjs — the read-model's ONE destructive endpoint helper (CTL-890,
+// BFF8 — the design's P10, gated last).
+//
+// The ⌘K palette's `⛔ Stop worker` action has no substrate today: the underlying
+// `claude stop <shortId>` is known-flaky (the per-job pid file is absent on Claude
+// Code 2.1.152, the spare-pool model). This module backs `POST /api/ec-worker/
+// <ticket>/stop` with the full design §3.4 contract for the only write-action in
+// the redesign:
+//
+//   1. TYPED CONFIRM — the operator must type the ticket id back; the endpoint
+//      refuses unless the typed token matches the path ticket exactly. The
+//      response always echoes the exact { shortId, ticket, phase } so the UI can
+//      show the operator precisely what they are about to kill (no ambiguity
+//      about which run).
+//   2. FENCE-AWARE (multi-node requirement) — before issuing the kill, the
+//      endpoint passes a cross-host fence-check (cluster-claim.mjs fence-check
+//      <ticket> <generation>, exit FENCE_STALE_EXIT=10 ⇒ stale). A stop request
+//      that originates from a partitioned / stale-generation node is REJECTED so a
+//      zombie node can't kill a worker the cluster has already taken over.
+//      SINGLE-HOST (hosts.json absent / length ≤ 1) ⇒ the fence-check is an
+//      identity NO-OP pass: there is no other node, so the stop proceeds normally
+//      with ZERO added latency and no subprocess (the single-node MVP path).
+//   3. The actual kill wraps `claude stop <shortId>` where shortId is the 8-char
+//      form derived from the run signal's bg_job_id (the daemon's existing
+//      termination primitive — claude-agents.mjs::claudeStop; `claude stop`
+//      rejects full UUIDs, so we truncate).
+//
+// OPTIMISTIC ROLLBACK is a UI-side timer (design §3.4: roll back if the next
+// board frame still shows the worker `working` after ~10s) — the endpoint's job
+// is to (a) fire the kill, (b) return the verbatim { shortId, ticket, phase }
+// identity + the issued/stale outcome so the client can mark the worker
+// `stopping` optimistically and arm its rollback timer against the live board.
+//
+// READ-then-ACT, fail-safe: a missing run signal → 404 (nothing to stop); a
+// missing bg_job_id → the run never had a live background session → 409 (no live
+// session to stop), never a blind `claude stop` of an empty id; a verified-stale
+// fence → 409 fenced; an indeterminate fence (multi-host, fence CLI errored) →
+// 409 (do NOT kill on an unconfirmed fence — the conservative answer for a
+// destructive action). All filesystem / subprocess / fence collaborators are
+// injectable so the route + unit tests drive this without a real worker, a real
+// hosts.json, or a real `claude` binary.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { shortIdFromSessionId } from "../../execution-core/claude-ids.mjs";
+import { readPhaseSignalVerbatim } from "./ticket-runs.mjs";
+
+// Mirror cluster-claim.mjs's exit contract: the fence CLI exits 10 when the
+// generation we asked about is no longer the current claim generation (stale).
+const FENCE_STALE_EXIT = 10;
+
+// Absolute path to the cross-host fence CLI, resolved relative to this module so
+// it works regardless of the server's cwd (same resolution cluster-claim-sync.mjs
+// uses for the claim CLI).
+const CLUSTER_CLAIM_CLI = fileURLToPath(
+  new URL("../../execution-core/cluster-claim.mjs", import.meta.url),
+);
+
+// Hard cap on the fence subprocess (the soft-CAS read is up to a couple of Linear
+// round-trips). Generous for a healthy API; bounds a hung call so a stuck fence
+// read can't wedge the request handler. Env-overridable for tests / slow networks.
+const FENCE_TIMEOUT_MS = Number(process.env.EXECUTION_CORE_CLAIM_TIMEOUT_MS) || 15_000;
+
+// ── single-host detection (the identity no-op gate) ──────────────────────────
+// readClusterHostCount — how many hosts are in the committed cluster roster
+// (<repoRoot>/.catalyst/hosts.json, a JSON array of host names). Mirrors
+// execution-core/config.mjs::getClusterHosts's tolerance: an absent / unreadable
+// / malformed / non-array / empty-array roster collapses to the SINGLE-HOST
+// default of 1. Kept LOCAL (not imported from config.mjs) so the orch-monitor
+// package stays self-contained and PR-order-independent; the externalities are
+// the env var + the file read, both injectable. Never throws.
+export function readClusterHostCount({
+  env = process.env,
+  read = readFileSync,
+} = {}) {
+  const cfgFile = env.CATALYST_CONFIG_FILE;
+  // <repoRoot>/.catalyst/config.json → <repoRoot>/.catalyst (else cwd/.catalyst)
+  const catalystDir = cfgFile ? resolve(cfgFile, "..") : resolve(process.cwd(), ".catalyst");
+  try {
+    const raw = read(resolve(catalystDir, "hosts.json"), "utf8");
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      const hosts = parsed.filter((h) => typeof h === "string" && h.length > 0);
+      if (hosts.length > 0) return hosts.length;
+    }
+  } catch {
+    /* absent/malformed roster → single-host default */
+  }
+  return 1;
+}
+
+// ── fence-check (single-host no-op pass; multi-host CLI) ──────────────────────
+// runFenceCheck — is `generation` still the CURRENT fence for `ticket`?
+// Returns a discriminated outcome:
+//   { ok: true,  noop: true }               → single-host: identity no-op pass.
+//   { ok: true,  noop: false }              → multi-host: fence CLI exit 0 (current).
+//   { ok: false, stale: true }              → multi-host: fence CLI exit 10 (stale).
+//   { ok: false, stale: false }             → multi-host: any other failure / a
+//                                              null generation we can't fence-check
+//                                              (indeterminate → fail-closed).
+//
+// In the SINGLE-HOST MVP this NEVER spawns a subprocess — `hostCount <= 1` short-
+// circuits to the no-op pass with zero added latency, exactly the non-cluster
+// path. The N>1 branch is the only place the fence CLI runs.
+//
+// `hostCount`/`spawn`/`nodeBin`/`cli`/`env`/`timeout` are injectable; tests drive
+// both branches without a real hosts.json or a real subprocess.
+export function runFenceCheck(
+  { ticket, generation },
+  {
+    hostCount = readClusterHostCount(),
+    spawn = spawnSync,
+    nodeBin = process.execPath,
+    cli = CLUSTER_CLAIM_CLI,
+    env = process.env,
+    timeout = FENCE_TIMEOUT_MS,
+  } = {},
+) {
+  // Single-host identity no-op: no other node exists, nothing to fence out.
+  if (hostCount <= 1) return { ok: true, noop: true, stale: false };
+
+  // Multi-host: a missing generation can't be affirmatively fence-checked — for a
+  // destructive action, fail-closed (treat as not-current, but not verified-stale).
+  if (typeof generation !== "number" || !Number.isFinite(generation)) {
+    return { ok: false, noop: false, stale: false };
+  }
+
+  try {
+    const res = spawn(nodeBin, [cli, "fence-check", ticket, String(generation)], {
+      encoding: "utf8",
+      env,
+      timeout,
+    });
+    if (res && res.status === 0) return { ok: true, noop: false, stale: false };
+    if (res && res.status === FENCE_STALE_EXIT) {
+      return { ok: false, noop: false, stale: true };
+    }
+    // Indeterminate (spawn error, timeout, other non-zero): fail-closed.
+    return { ok: false, noop: false, stale: false };
+  } catch {
+    return { ok: false, noop: false, stale: false };
+  }
+}
+
+// ── the kill primitive ───────────────────────────────────────────────────────
+// claudeStop — `claude stop <shortId>`. shortId MUST be the 8-char form (`claude
+// stop` rejects full UUIDs with rc=1). Returns { ok, error? }; never throws.
+// Local mirror of execution-core/claude-agents.mjs::claudeStop so this lib carries
+// no dependency on that module's TTL-cache / agents-list machinery.
+const CLAUDE_BIN = process.env.CATALYST_DISPATCH_CLAUDE_BIN || "claude";
+export function claudeStop(shortId, { spawn = spawnSync } = {}) {
+  try {
+    const res = spawn(CLAUDE_BIN, ["stop", shortId], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if ((res?.status ?? 0) === 0) return { ok: true };
+    return { ok: false, error: res?.stderr?.trim() || `claude stop rc=${res?.status}` };
+  } catch (err) {
+    return { ok: false, error: err?.message ?? String(err) };
+  }
+}
+
+// ── orchestration: the endpoint body ─────────────────────────────────────────
+// stopWorker — drive the full P10 contract for `POST /api/ec-worker/<ticket>/<phase>/stop`.
+// Outcome is a discriminated result the route maps to an HTTP status:
+//   { status: "not_found" }                          → 404: no run signal on disk.
+//   { status: "confirm_mismatch", expected }         → 400: typed confirm wrong.
+//   { status: "no_session", ticket, phase }          → 409: run never had a live
+//                                                       bg session (no bg_job_id /
+//                                                       unparseable id) — nothing
+//                                                       to kill, never a blind stop.
+//   { status: "fenced", ticket, phase, shortId }     → 409: a verified-stale fence
+//                                                       (exit 10) — a partitioned
+//                                                       node is rejected.
+//   { status: "fence_indeterminate", ticket, phase, shortId }
+//                                                     → 409: multi-host fence could
+//                                                       not be confirmed — refuse
+//                                                       (don't kill on uncertainty).
+//   { status: "stop_failed", ticket, phase, shortId, error }
+//                                                     → 502: `claude stop` errored.
+//   { status: "stopping", ticket, phase, shortId, fenceNoop }
+//                                                     → 200: kill issued; UI marks
+//                                                       the worker `stopping` and
+//                                                       arms its ~10s optimistic-
+//                                                       rollback timer.
+//
+// `readSignal`/`fenceCheck`/`stop` are injectable so tests cover every branch
+// without a real signal, a real fence, or a real `claude`.
+export async function stopWorker(
+  { ticket, phase, confirm },
+  {
+    readSignal = readPhaseSignalVerbatim,
+    fenceCheck = runFenceCheck,
+    stop = claudeStop,
+  } = {},
+) {
+  // Read the run signal first — it is BOTH the existence check and the source of
+  // the shortId + generation we need. 404 when the phase has no signal on disk.
+  const sig = await readSignal(ticket, phase);
+  if (!sig || typeof sig !== "object") {
+    return { status: "not_found" };
+  }
+
+  // The exact run identity the UI must show in the typed-confirm dialog. shortId is
+  // derived below; ticket/phase come from the path (validated by the route).
+  // Typed confirm: the operator must type the ticket id back, exactly.
+  if (confirm !== ticket) {
+    return { status: "confirm_mismatch", expected: ticket };
+  }
+
+  // Derive the 8-char shortId from the run's bg_job_id (the live background
+  // session). No bg_job_id (a run that never spawned a bg session, or a finished
+  // run whose id was cleared) ⇒ nothing to stop — 409, never a blind kill.
+  const bgJobId = sig.bg_job_id;
+  let shortId;
+  try {
+    shortId = shortIdFromSessionId(bgJobId);
+  } catch {
+    return { status: "no_session", ticket, phase };
+  }
+
+  // Fence-aware guard (single-host no-op pass; multi-host CLI). The generation we
+  // fence-check is the run signal's own generation.
+  const generation = typeof sig.generation === "number" ? sig.generation : null;
+  const fence = fenceCheck({ ticket, generation });
+  if (!fence.ok) {
+    return fence.stale
+      ? { status: "fenced", ticket, phase, shortId }
+      : { status: "fence_indeterminate", ticket, phase, shortId };
+  }
+
+  // Fence current (or no-op single-host): issue the kill.
+  const res = stop(shortId);
+  if (!res.ok) {
+    return { status: "stop_failed", ticket, phase, shortId, error: res.error };
+  }
+  return { status: "stopping", ticket, phase, shortId, fenceNoop: fence.noop === true };
+}

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -30,6 +30,13 @@ import {
   resolveTranscriptPath,
   TranscriptTail,
 } from "./lib/ec-worker-stream.mjs";
+// CTL-890 (BFF8): the read-model's ONE destructive endpoint (design P10) —
+// POST /api/ec-worker/<ticket>/stop wraps the flaky `claude stop <shortId>`
+// behind a typed confirm + a fence-aware guard (single-host no-op pass;
+// multi-host rejects a stale/partitioned generation). Optimistic rollback is a
+// UI-side timer; the endpoint returns the verbatim shortId+ticket+phase identity
+// the client needs to mark `stopping` and arm that timer.
+import { stopWorker, type StopWorkerResult } from "./lib/stop-worker.mjs";
 import { queryHistory, queryStats, compareSessions } from "./lib/history-store";
 import {
   listArchivedOrchestrators,
@@ -1959,6 +1966,95 @@ export function createServer(opts: CreateServerOptions): BunServer {
             return new Response("Bad Request", { status: 400 });
           }
           return Response.json(await assembleTicketRuns(ticket));
+        }
+
+        // CTL-890 (BFF8) P10: the redesign's ONE destructive endpoint, gated last.
+        // POST /api/ec-worker/<ticket>/stop wraps the flaky `claude stop <shortId>`
+        // (pid-file absent on CC 2.1.152). Matched BEFORE the GET verbatim route
+        // and gated on POST so a stop request is never confused with the
+        // signal reader (and "stop" is not a valid phase, so a GET here 404s
+        // harmlessly). Contract (design §3.4):
+        //   • TYPED CONFIRM — body.confirm must equal the ticket id exactly.
+        //   • TARGET RUN    — body.phase selects which run (its phase-<phase>.json
+        //     signal carries the bg_job_id → shortId). The response echoes the
+        //     exact shortId+ticket+phase so the UI shows what it is killing.
+        //   • FENCE-AWARE   — single-host (hosts.json absent/len 1) is a no-op
+        //     pass; multi-host rejects a verified-stale generation (a partitioned
+        //     node) and refuses on an unconfirmable fence.
+        //   • OPTIMISTIC ROLLBACK is a UI-side ~10s timer; on success we return the
+        //     identity + a `stopping` status the client marks optimistically.
+        const ecStopMatch = url.pathname.match(
+          /^\/api\/ec-worker\/([^/]+)\/stop$/,
+        );
+        if (ecStopMatch && req.method === "POST") {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(ecStopMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          let body: Record<string, unknown>;
+          try {
+            body = (await req.json()) as Record<string, unknown>;
+          } catch {
+            return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+          }
+          const phase = typeof body.phase === "string" ? body.phase : "";
+          if (!/^[a-z][a-z-]*$/.test(phase)) {
+            return Response.json(
+              { error: "phase is required and must be a valid phase name" },
+              { status: 400 },
+            );
+          }
+          const result: StopWorkerResult = await stopWorker({
+            ticket,
+            phase,
+            confirm: body.confirm,
+          });
+          switch (result.status) {
+            case "not_found":
+              return Response.json(
+                { status: "not_found", error: `no run signal for ${ticket}:${phase}` },
+                { status: 404 },
+              );
+            case "confirm_mismatch":
+              return Response.json(
+                {
+                  status: "confirm_mismatch",
+                  error: "typed confirmation did not match the ticket id",
+                  expected: result.expected,
+                },
+                { status: 400 },
+              );
+            case "no_session":
+              return Response.json(result, { status: 409 });
+            case "fenced":
+              // A stale-generation node is fenced out — the worker is NOT killed.
+              return Response.json(
+                {
+                  ...result,
+                  error: "stop rejected: this node's generation is stale (fenced out)",
+                },
+                { status: 409 },
+              );
+            case "fence_indeterminate":
+              return Response.json(
+                {
+                  ...result,
+                  error: "stop rejected: fence could not be confirmed",
+                },
+                { status: 409 },
+              );
+            case "stop_failed":
+              return Response.json(result, { status: 502 });
+            case "stopping":
+              // Kill issued; the UI marks the worker `stopping` and arms its ~10s
+              // optimistic-rollback timer against the next board frame.
+              return Response.json(result, { status: 200 });
+          }
         }
 
         // CTL-886 (BFF4) companion P3: one phase signal served VERBATIM — the raw


### PR DESCRIPTION
## CTL-890 (BFF8) — Stop-worker mutation (fence-aware)

P10, the redesign's **only destructive endpoint**, gated last per the design. Backs the ⌘K `⛔ Stop worker` action with `POST /api/ec-worker/<ticket>/stop` on the read-model (BFF1), wrapping the known-flaky `claude stop <shortId>` (pid-file absent on CC 2.1.152) behind a typed confirm, a fence-aware guard, and an optimistic-rollback contract.

### What landed
- **`lib/stop-worker.mjs`** (+ `.d.mts`) — the endpoint helper. Reads the target run's verbatim `phase-<phase>.json` signal (reusing BFF4's `readPhaseSignalVerbatim`), derives the 8-char shortId from its `bg_job_id`, enforces the typed confirm, runs the fence-check, then wraps `claude stop`. Discriminated result → HTTP status.
- **`server.ts`** — `POST /api/ec-worker/<ticket>/stop` mounted **before** the GET verbatim reader and **method-gated** on POST (so a GET to `…/stop` still hits the reader, never the mutation).
- **`execution-core/cluster-claim-sync.mjs`** — new `fenceCheckSync`, the synchronous spawn bridge over `cluster-claim.mjs fence-check` (mirrors the existing `claimDispatchSync` fail-closed pattern; interprets `FENCE_STALE_EXIT=10`).

### Fence behavior (single-node MVP)
- **Single-host** (`hosts.json` absent / length ≤ 1) → the fence-check is an **identity no-op pass**: no subprocess, zero added latency, exactly the non-cluster path.
- **Multi-host** (length > 1) → shells `cluster-claim.mjs fence-check <ticket> <gen>`. Exit 0 = current → proceed; exit 10 = **stale** → reject (`409 fenced`), the worker is **not** killed by a partitioned node. Any other failure / unconfirmable fence → fail-closed reject (never SIGKILL on an uncertain fence — the conservative answer for a destructive action).

### Gherkin scenarios
| Scenario | Status |
|---|---|
| A confirmed stop terminates the worker | **satisfied** — typed confirm + shortId derivation + `claude stop` + `stopping` response |
| Optimistic rollback on a flaky stop | **satisfied** — endpoint returns the `stopping` optimistic contract + identity the UI arms its ~10s timer against; `stop_failed` is the explicit rollback-from path |
| A stale-generation node is fenced out | **satisfied** — multi-host fence-check exit 10 → `409 fenced`, no kill |
| Single-host stop is unaffected | **satisfied** — `hostCount ≤ 1` identity no-op pass, stop proceeds (`fenceNoop:true`) |

### Single-node-descoped
The new TanStack-router worker/ticket detail pages and the ⌘K Stop-worker **palette row** (sibling redesign tickets) are not built in this branch, so the `↯ soon` disabled-row → live-action flip and the client-side ~10s rollback timer are descoped to those tickets. This PR delivers the **endpoint** they will call, plus the full server-side contract the rollback timer keys off.

### Tests (run locally — repo CI has no unit-test gate)
- `bun test __tests__/stop-worker.test.ts __tests__/stop-worker-endpoint.test.ts` → **34 pass / 0 fail** (every `stopWorker` branch + the four Gherkin scenarios + route plumbing/method-gate/400/404).
- `bun test plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs` → **14 pass / 0 fail** (new `fenceCheckSync` argv + exit-10 + fail-closed).
- `bunx tsc --noEmit` (orch-monitor) → clean for all touched files (only pre-existing `ui/src/lib/briefings.ts` `marked`/`dompurify` errors remain — a worktree node_modules env gap, present on clean main).
- `bunx eslint` on touched files → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)