### PR TITLE
feat(dev): BFF2 cluster grouping + liveness overlay (CTL-884)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-view.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-view.test.ts
@@ -1,0 +1,349 @@
+// CTL-884 (BFF2): the read-model assembles a node-aware CLUSTER VIEW — every
+// ticket grouped by the owner_host the broker projects into the durable cache
+// (BFF11), the GitHub PR-state join layered on per ticket, and a per-host
+// live/degraded/offline liveness overlay sourced from readClusterHeartbeats.
+//
+// The single-host case (hosts.json absent or length 1) MUST be an exact identity
+// no-op: the same tickets, one node, zero added latency, no live attachment or
+// heartbeat-transport hop.
+//
+// assembleClusterView is pure + fully injectable (board, ownerHostById, hosts,
+// heartbeats, now) so these scenarios are unit-testable without a real DB, event
+// log, or subprocess.
+
+import { describe, it, expect, mock } from "bun:test";
+import { assembleClusterView, createClusterEntity } from "../lib/cluster-view.mjs";
+import { createReadModel } from "../lib/read-model.mjs";
+import type { BoardPayload, BoardTicket } from "../lib/board-data.mjs";
+import type { ClusterView } from "../lib/cluster-view.mjs";
+
+function ticket(id: string, overrides: Partial<BoardTicket> = {}): BoardTicket {
+  return {
+    id,
+    title: id,
+    type: "task",
+    repo: "catalyst",
+    team: "CTL",
+    phase: "implement",
+    status: "running",
+    model: null,
+    linearState: "Implement",
+    workerStatus: "running",
+    activeState: "active",
+    working: true,
+    lastActiveMs: 1000,
+    priority: 2,
+    estimate: null,
+    scope: null,
+    project: null,
+    costUSD: null,
+    tokens: null,
+    turns: null,
+    phaseCosts: null,
+    phaseSummary: [],
+    pr: null,
+    updatedAt: "2026-06-08T11:00:00.000Z",
+    held: null,
+    blockers: [],
+    // BFF10 stamps host:{name,id} + generation on every BoardTicket. The cluster
+    // view groups off ownerHostById (the durable fence projection), not this per-
+    // entity host, so these default null (single-host identity no-op) and tests
+    // override ownerHostById directly.
+    host: null,
+    generation: null,
+    ...overrides,
+  };
+}
+
+function board(tickets: BoardTicket[]): BoardPayload {
+  return {
+    generatedAt: "2026-06-08T12:00:00.000Z",
+    config: { maxParallel: 6, inFlight: 0, freeSlots: 6, active: 0, working: 0, stuck: 0 },
+    repos: ["catalyst"],
+    workers: [],
+    tickets,
+    queue: [],
+  };
+}
+
+const now = Date.parse("2026-06-08T12:00:00.000Z");
+const at = (msAgo: number) => new Date(now - msAgo).toISOString();
+
+describe("assembleClusterView — Scenario: groups cluster work by owning node", () => {
+  it("groups tickets by owner_host read from the durable cache (not a live fetch)", () => {
+    const b = board([ticket("CTL-1", { pr: 101 }), ticket("CTL-2"), ticket("CTL-3", { pr: 103 })]);
+    const ownerHostById = {
+      "CTL-1": "mini",
+      "CTL-2": "studio",
+      "CTL-3": "mini",
+    };
+    const view = assembleClusterView({
+      board: b,
+      ownerHostById,
+      hosts: ["mini", "studio"],
+      heartbeats: { mini: at(1_000), studio: at(2_000) },
+      now,
+    });
+    // one group per node, each carrying its owned tickets
+    const mini = view.nodes.find((n) => n.host === "mini");
+    const studio = view.nodes.find((n) => n.host === "studio");
+    expect(mini?.tickets.map((t) => t.id)).toEqual(["CTL-1", "CTL-3"]);
+    expect(studio?.tickets.map((t) => t.id)).toEqual(["CTL-2"]);
+  });
+
+  it("layers the GitHub PR-state join on per ticket (the board pr number carries through)", () => {
+    const b = board([ticket("CTL-1", { pr: 101 }), ticket("CTL-2", { pr: null })]);
+    const view = assembleClusterView({
+      board: b,
+      ownerHostById: { "CTL-1": "mini", "CTL-2": "mini" },
+      hosts: ["mini"],
+      heartbeats: { mini: at(1_000) },
+      now,
+    });
+    const tickets = view.nodes[0].tickets;
+    expect(tickets.find((t) => t.id === "CTL-1")?.pr).toBe(101);
+    expect(tickets.find((t) => t.id === "CTL-2")?.pr).toBeNull();
+  });
+
+  it("a ticket with no fence owner_host falls into the 'unassigned' group, never dropped", () => {
+    // multi-host roster: an un-fenced ticket has a real "other" owner it could
+    // belong to, so it lands in the synthetic unassigned bucket (the single-host
+    // identity no-op attributes everything to the one host instead).
+    const b = board([ticket("CTL-1"), ticket("CTL-9")]);
+    const view = assembleClusterView({
+      board: b,
+      ownerHostById: { "CTL-1": "mini" }, // CTL-9 has no fence
+      hosts: ["mini", "studio"],
+      heartbeats: { mini: at(1_000), studio: at(1_000) },
+      now,
+    });
+    const unassigned = view.nodes.find((n) => n.host === null);
+    expect(unassigned?.tickets.map((t) => t.id)).toEqual(["CTL-9"]);
+    // every input ticket is represented exactly once across all groups
+    const allIds = view.nodes.flatMap((n) => n.tickets.map((t) => t.id)).sort();
+    expect(allIds).toEqual(["CTL-1", "CTL-9"]);
+  });
+
+  it("attributes each ticket's ownerHost on the ticket itself for node-aware UI", () => {
+    const b = board([ticket("CTL-1")]);
+    const view = assembleClusterView({
+      board: b,
+      ownerHostById: { "CTL-1": "studio" },
+      hosts: ["mini", "studio"],
+      heartbeats: { mini: at(1_000), studio: at(1_000) },
+      now,
+    });
+    const t = view.nodes.find((n) => n.host === "studio")?.tickets[0];
+    expect(t?.ownerHost).toBe("studio");
+  });
+});
+
+describe("assembleClusterView — Scenario: node liveness overlay (live/degraded/offline)", () => {
+  it("marks each host live/degraded/offline against the interval + grace", () => {
+    const b = board([ticket("CTL-1"), ticket("CTL-2"), ticket("CTL-3")]);
+    const view = assembleClusterView({
+      board: b,
+      ownerHostById: { "CTL-1": "mini", "CTL-2": "studio", "CTL-3": "laptop" },
+      hosts: ["mini", "studio", "laptop"],
+      heartbeats: {
+        mini: at(5_000), // within interval → live
+        studio: at(3 * 60_000), // past interval, inside 5min grace → degraded
+        laptop: at(20 * 60_000), // past grace → offline
+      },
+      now,
+    });
+    expect(view.nodes.find((n) => n.host === "mini")?.status).toBe("live");
+    expect(view.nodes.find((n) => n.host === "studio")?.status).toBe("degraded");
+    expect(view.nodes.find((n) => n.host === "laptop")?.status).toBe("offline");
+  });
+
+  it("consumes a readClusterHeartbeats-shaped reader when heartbeats are not pre-supplied", () => {
+    const b = board([ticket("CTL-1")]);
+    const heartbeatReader = mock((_opts: { logPath?: string }) => ({ mini: at(2_000) }));
+    const view = assembleClusterView({
+      board: b,
+      ownerHostById: { "CTL-1": "mini" },
+      hosts: ["mini"],
+      heartbeatReader, // injected recovery.readClusterHeartbeats stand-in
+      logPath: "/tmp/fake-events.jsonl",
+      now,
+    });
+    expect(heartbeatReader).toHaveBeenCalledTimes(1);
+    // the reader is called with the local logPath (single-node: ONE local log)
+    expect(heartbeatReader.mock.calls[0][0]).toEqual({ logPath: "/tmp/fake-events.jsonl" });
+    expect(view.nodes[0].status).toBe("live");
+  });
+
+  it("the unassigned bucket carries no liveness (it is not a real host)", () => {
+    const b = board([ticket("CTL-9")]);
+    const view = assembleClusterView({
+      board: b,
+      ownerHostById: {},
+      hosts: ["mini", "studio"], // multi-host so the unassigned bucket exists
+      heartbeats: { mini: at(1_000), studio: at(1_000) },
+      now,
+    });
+    const unassigned = view.nodes.find((n) => n.host === null);
+    expect(unassigned?.status).toBeNull();
+  });
+});
+
+describe("assembleClusterView — Scenario: single-host is an exact identity no-op", () => {
+  it("hosts.json length 1 → one node carrying ALL board tickets, in board order", () => {
+    const tickets = [ticket("CTL-1", { pr: 101 }), ticket("CTL-2"), ticket("CTL-3", { pr: 103 })];
+    const b = board(tickets);
+    const view = assembleClusterView({
+      board: b,
+      // single-node deployment: every ticket the local daemon claimed is owned
+      // by the one host (or carries no fence yet, which still belongs to it).
+      ownerHostById: { "CTL-1": "mini", "CTL-2": "mini", "CTL-3": "mini" },
+      hosts: ["mini"],
+      heartbeats: { mini: at(1_000) },
+      now,
+    });
+    expect(view.singleHost).toBe(true);
+    expect(view.nodes).toHaveLength(1);
+    // identity: the node's ticket list is exactly the board's ticket list in
+    // board order (same ids, same order), additively node-attributed.
+    expect(view.nodes[0].tickets.map((t) => t.id)).toEqual(b.tickets.map((t) => t.id));
+    // every original board field survives untouched (the ADDITIVE-only contract)
+    view.nodes[0].tickets.forEach((t, i) => {
+      const { ownerHost, ...rest } = t;
+      expect(rest).toEqual(b.tickets[i]);
+      expect(ownerHost).toBe("mini");
+    });
+  });
+
+  it("hosts.json absent (roster falls back to [localHost]) is treated as single-host", () => {
+    const b = board([ticket("CTL-1"), ticket("CTL-2")]);
+    const view = assembleClusterView({
+      board: b,
+      ownerHostById: {}, // no fences observed yet on a fresh single node
+      hosts: ["mini"], // getClusterHosts() returns [getHostName()] when hosts.json absent
+      heartbeats: { mini: at(1_000) },
+      now,
+    });
+    expect(view.singleHost).toBe(true);
+    expect(view.nodes).toHaveLength(1);
+    expect(view.nodes[0].host).toBe("mini");
+    // even un-fenced tickets attribute to the single host (no orphan bucket on a 1-node fleet)
+    expect(view.nodes[0].tickets.map((t) => t.id)).toEqual(["CTL-1", "CTL-2"]);
+  });
+
+  it("single-host never reads heartbeats for a peer it cannot reach (one local-log read max)", () => {
+    const b = board([ticket("CTL-1")]);
+    const heartbeatReader = mock(() => ({ mini: at(1_000) }));
+    assembleClusterView({
+      board: b,
+      ownerHostById: { "CTL-1": "mini" },
+      hosts: ["mini"],
+      heartbeatReader,
+      now,
+    });
+    // exactly one read of the single local event log — no per-peer fan-out
+    expect(heartbeatReader).toHaveBeenCalledTimes(1);
+  });
+
+  it("the single-host node still carries its own liveness from the local heartbeat", () => {
+    const b = board([ticket("CTL-1")]);
+    const live = assembleClusterView({
+      board: b,
+      ownerHostById: { "CTL-1": "mini" },
+      hosts: ["mini"],
+      heartbeats: { mini: at(2_000) },
+      now,
+    });
+    expect(live.nodes[0].status).toBe("live");
+    // a stale local heartbeat surfaces the local daemon as offline (still single-host)
+    const stale = assembleClusterView({
+      board: b,
+      ownerHostById: { "CTL-1": "mini" },
+      hosts: ["mini"],
+      heartbeats: { mini: at(20 * 60_000) },
+      now,
+    });
+    expect(stale.singleHost).toBe(true);
+    expect(stale.nodes[0].status).toBe("offline");
+  });
+});
+
+describe("createClusterEntity — read-model integration (Scenario: the read-model assembles the cluster view)", () => {
+  it("registers as a read-model entity projecting off the SAME board snapshot (no second assemble)", async () => {
+    let assembleCalls = 0;
+    const snapshot = board([ticket("CTL-1", { pr: 101 }), ticket("CTL-2")]);
+    const cluster = createClusterEntity({
+      ownerHostProvider: () => Promise.resolve({ "CTL-1": "mini", "CTL-2": "mini" }),
+      rosterProvider: () => ["mini"],
+      heartbeatReader: () => ({ mini: new Date(now - 1000).toISOString() }),
+      now: () => now,
+    });
+    const m = createReadModel({
+      assemble: () => {
+        assembleCalls++;
+        return Promise.resolve(snapshot);
+      },
+      onDemandTtlMs: 5000,
+      entities: {
+        board: { project: (s) => s },
+        cluster,
+      },
+    });
+    const view = (await m.getEntity("cluster")) as ClusterView;
+    expect(view.singleHost).toBe(true);
+    expect(view.nodes).toHaveLength(1);
+    expect(view.nodes[0].host).toBe("mini");
+    expect(view.nodes[0].status).toBe("live");
+    expect(view.nodes[0].tickets.map((t) => t.id)).toEqual(["CTL-1", "CTL-2"]);
+    // the cluster entity projected off the ONE board assemble — no re-assemble
+    expect(assembleCalls).toBe(1);
+    m.stop();
+  });
+
+  it("groups by owner_host on a multi-host roster via injected deps", async () => {
+    const snapshot = board([ticket("CTL-1"), ticket("CTL-2")]);
+    const cluster = createClusterEntity({
+      ownerHostProvider: () => Promise.resolve({ "CTL-1": "mini", "CTL-2": "studio" }),
+      rosterProvider: () => ["mini", "studio"],
+      heartbeatReader: () => ({
+        mini: new Date(now - 1000).toISOString(),
+        studio: new Date(now - 3 * 60_000).toISOString(),
+      }),
+      now: () => now,
+    });
+    const m = createReadModel({
+      assemble: () => Promise.resolve(snapshot),
+      onDemandTtlMs: 5000,
+      entities: { board: { project: (s) => s }, cluster },
+    });
+    const view = (await m.getEntity("cluster")) as ClusterView;
+    expect(view.singleHost).toBe(false);
+    expect(view.nodes.find((n) => n.host === "mini")?.status).toBe("live");
+    expect(view.nodes.find((n) => n.host === "studio")?.status).toBe("degraded");
+    m.stop();
+  });
+
+  it("degrades to a single-host no-op when the execution-core deps are unavailable (no throw)", async () => {
+    // No injected deps → the entity lazily imports config/recovery; in the test
+    // sandbox those may resolve to empty (roster []) which is the safe no-op. The
+    // contract: it never throws and yields a coherent single-host view.
+    const snapshot = board([ticket("CTL-1")]);
+    const cluster = createClusterEntity({
+      // override the heartbeat reader so we don't hit the real event log, but let
+      // the roster fall back to the lazy import (which is fine if it yields []).
+      heartbeatReader: () => ({}),
+      rosterProvider: () => [],
+      now: () => now,
+    });
+    const m = createReadModel({
+      assemble: () => Promise.resolve(snapshot),
+      onDemandTtlMs: 5000,
+      entities: { board: { project: (s) => s }, cluster },
+    });
+    const view = (await m.getEntity("cluster")) as ClusterView;
+    expect(view.singleHost).toBe(true);
+    expect(view.nodes).toHaveLength(1);
+    expect(view.nodes[0].host).toBeNull();
+    expect(view.nodes[0].tickets.map((t) => t.id)).toEqual(["CTL-1"]);
+    m.stop();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-cache-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-cache-reader.test.ts
@@ -40,9 +40,12 @@ describe("readLinearCache (CTL-883 — durable-cache Linear enrichment)", () => 
       linearState: "Implement",
       // ticket_state has no title column → honest null with no eligible row (BFF9)
       title: null,
-      // BFF10: no fence attachment observed → honest null (never fabricated)
+      // BFF10/BFF2: no fence observed → all node-grouping fields honest null.
       ownerHost: null,
       generation: null,
+      fencePhase: null,
+      claimedAt: null,
+      heldSince: null,
     });
   });
 
@@ -150,6 +153,47 @@ describe("readLinearCache (CTL-883 — durable-cache Linear enrichment)", () => 
     // as a thrown error to the assemble loop.
     expect(byId).not.toBe("THREW");
   });
+
+  // CTL-884 (BFF2): the read-model groups by owner_host, which BFF11 projects
+  // into ticket_state. The enrichment map must surface that durable grouping key
+  // (+ the fence companions) so the cluster view never does a live attachment
+  // fetch. Null when no fence has been observed — never fabricated.
+  it("surfaces ownerHost + fence companions from ticket_state (the BFF11 projection)", async () => {
+    const ticketStateReader = () =>
+      Promise.resolve({
+        "CTL-1": {
+          priority: 2,
+          labels: ["feature"],
+          linearState: "Implement",
+          ownerHost: "mini",
+          generation: 3,
+          fencePhase: "implement",
+          claimedAt: "2026-06-08T11:00:00.000Z",
+          heldSince: "2026-06-08T10:00:00.000Z",
+        },
+      });
+    const byId = await readLinearCache({
+      ticketStateReader,
+      eligibleReader: () => Promise.resolve({}),
+    });
+    expect(byId["CTL-1"].ownerHost).toBe("mini");
+    expect(byId["CTL-1"].generation).toBe(3);
+    expect(byId["CTL-1"].fencePhase).toBe("implement");
+    expect(byId["CTL-1"].claimedAt).toBe("2026-06-08T11:00:00.000Z");
+    expect(byId["CTL-1"].heldSince).toBe("2026-06-08T10:00:00.000Z");
+  });
+
+  it("ownerHost + fence companions degrade to null when no fence is in the cache", async () => {
+    const byId = await readLinearCache({
+      ticketStateReader: () => Promise.resolve({ "CTL-2": { priority: 1, labels: [] } }),
+      eligibleReader: () => Promise.resolve({}),
+    });
+    expect(byId["CTL-2"].ownerHost).toBeNull();
+    expect(byId["CTL-2"].generation).toBeNull();
+    expect(byId["CTL-2"].fencePhase).toBeNull();
+    expect(byId["CTL-2"].claimedAt).toBeNull();
+    expect(byId["CTL-2"].heldSince).toBeNull();
+  });
 });
 
 describe("readLinearCache end-to-end against a real filter-state.db", () => {
@@ -171,9 +215,17 @@ describe("readLinearCache end-to-end against a real filter-state.db", () => {
       assignee: "uuid-a",
     });
     upsertTicketDescriptor({ ticket: "CTL-101", state: "Done", uuid: "u-101" });
-    // BFF10/BFF11: project a fence attachment so the e2e proves ownerHost +
-    // generation flow from ticket_state through the bulk descriptor read.
-    upsertTicketFence({ ticket: "CTL-100", ownerHost: "mac-mini", generation: 7 });
+    // BFF10/BFF11 + CTL-884 (BFF2): project a fence attachment so the e2e proves
+    // ownerHost + generation + the fence companions (phase/claimedAt) flow from
+    // ticket_state through the bulk descriptor read — the durable owner_host
+    // grouping key the cluster view reads (never a live attachment fetch).
+    upsertTicketFence({
+      ticket: "CTL-100",
+      ownerHost: "mini",
+      generation: 2,
+      phase: "implement",
+      claimedAt: "2026-06-08T11:30:00.000Z",
+    });
     closeBrokerStateDb(); // assemble path opens its own handle
     writeFileSync(
       join(eligibleDir, "CTL.json"),
@@ -194,15 +246,18 @@ describe("readLinearCache end-to-end against a real filter-state.db", () => {
     expect(byId["CTL-100"].labels).toEqual(["monitor", "feature"]);
     expect(byId["CTL-100"].assignee).toBe("uuid-a");
     expect(byId["CTL-100"].linearState).toBe("Implement");
+    // CTL-884: the durable owner_host grouping key flows through the real DB.
+    expect(byId["CTL-100"].ownerHost).toBe("mini");
+    expect(byId["CTL-100"].generation).toBe(2);
+    expect(byId["CTL-100"].fencePhase).toBe("implement");
+    expect(byId["CTL-100"].claimedAt).toBe("2026-06-08T11:30:00.000Z");
+    // CTL-101 has no fence → null grouping key (groups under "unassigned")
+    expect(byId["CTL-101"].ownerHost).toBeNull();
     // queued ticket only in the eligible projection
     expect(byId["CTL-200"].priority).toBe(3);
     expect(byId["CTL-200"].project).toBe("Web UI");
     expect(byId["CTL-200"].title).toBe("queued"); // BFF9: title from eligible
     // BFF10/BFF11: the fence projection flows through the real bulk descriptor read.
-    expect(byId["CTL-100"].ownerHost).toBe("mac-mini");
-    expect(byId["CTL-100"].generation).toBe(7);
-    // a ticket with no fence attachment → honest null
-    expect(byId["CTL-101"].ownerHost).toBeNull();
     expect(byId["CTL-101"].generation).toBeNull();
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/node-liveness.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/node-liveness.test.ts
@@ -1,0 +1,115 @@
+// CTL-884 (BFF2): node liveness overlay — classify each host live/degraded/offline
+// from the heartbeat last-seen timestamps that recovery.readClusterHeartbeats
+// yields ({ host: lastSeenISO }). The classifier is pure so the thresholds are
+// unit-testable without a real event log; assembleClusterView wires the real
+// readClusterHeartbeats reader in.
+
+import { describe, it, expect } from "bun:test";
+import {
+  classifyHostLiveness,
+  overlayClusterLiveness,
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  DEFAULT_LIVENESS_GRACE_MS,
+} from "../lib/node-liveness.mjs";
+
+describe("classifyHostLiveness (CTL-884 — live/degraded/offline thresholds)", () => {
+  const now = Date.parse("2026-06-08T12:00:00.000Z");
+  const interval = 30_000; // ~30s heartbeat cadence
+  const grace = 5 * 60_000; // 5 min grace floor
+
+  const at = (msAgo: number) => new Date(now - msAgo).toISOString();
+
+  it("a heartbeat within the interval is live", () => {
+    expect(classifyHostLiveness(at(10_000), now, { intervalMs: interval, graceMs: grace })).toBe(
+      "live",
+    );
+  });
+
+  it("a heartbeat exactly at the interval boundary is still live (inclusive)", () => {
+    expect(classifyHostLiveness(at(interval), now, { intervalMs: interval, graceMs: grace })).toBe(
+      "live",
+    );
+  });
+
+  it("past the interval but inside the grace window is degraded", () => {
+    expect(
+      classifyHostLiveness(at(interval + 1_000), now, { intervalMs: interval, graceMs: grace }),
+    ).toBe("degraded");
+    expect(classifyHostLiveness(at(2 * 60_000), now, { intervalMs: interval, graceMs: grace })).toBe(
+      "degraded",
+    );
+  });
+
+  it("a heartbeat exactly at the grace boundary is still degraded (inclusive)", () => {
+    expect(classifyHostLiveness(at(grace), now, { intervalMs: interval, graceMs: grace })).toBe(
+      "degraded",
+    );
+  });
+
+  it("past the grace window is offline", () => {
+    expect(
+      classifyHostLiveness(at(grace + 1_000), now, { intervalMs: interval, graceMs: grace }),
+    ).toBe("offline");
+    expect(classifyHostLiveness(at(20 * 60_000), now, { intervalMs: interval, graceMs: grace })).toBe(
+      "offline",
+    );
+  });
+
+  it("an absent/never-seen heartbeat is offline (no fabricated liveness)", () => {
+    expect(classifyHostLiveness(null, now, { intervalMs: interval, graceMs: grace })).toBe("offline");
+    expect(classifyHostLiveness(undefined, now, { intervalMs: interval, graceMs: grace })).toBe(
+      "offline",
+    );
+    expect(classifyHostLiveness("", now, { intervalMs: interval, graceMs: grace })).toBe("offline");
+  });
+
+  it("an unparseable timestamp is offline, never thrown", () => {
+    expect(classifyHostLiveness("not-a-date", now, { intervalMs: interval, graceMs: grace })).toBe(
+      "offline",
+    );
+  });
+
+  it("a future heartbeat (clock skew) is treated as live, never negative-age garbage", () => {
+    expect(classifyHostLiveness(at(-5_000), now, { intervalMs: interval, graceMs: grace })).toBe(
+      "live",
+    );
+  });
+
+  it("uses the design-doc 5-10min grace + 30s interval defaults when omitted", () => {
+    expect(DEFAULT_HEARTBEAT_INTERVAL_MS).toBe(30_000);
+    expect(DEFAULT_LIVENESS_GRACE_MS).toBeGreaterThanOrEqual(5 * 60_000);
+    expect(DEFAULT_LIVENESS_GRACE_MS).toBeLessThanOrEqual(10 * 60_000);
+    // within interval → live with defaults
+    expect(classifyHostLiveness(at(5_000), now)).toBe("live");
+    // 3 min ago is inside the default 5-min grace but well past the 30s interval → degraded
+    expect(classifyHostLiveness(at(3 * 60_000), now)).toBe("degraded");
+    // 6 min ago is past the default 5-min grace floor → offline
+    expect(classifyHostLiveness(at(6 * 60_000), now)).toBe("offline");
+  });
+});
+
+describe("overlayClusterLiveness (CTL-884 — per-host overlay from lastSeen map)", () => {
+  const now = Date.parse("2026-06-08T12:00:00.000Z");
+  const at = (msAgo: number) => new Date(now - msAgo).toISOString();
+
+  it("maps every roster host to its liveness + lastSeen, offline when unheard", () => {
+    const hosts = ["mini", "studio", "laptop"];
+    const lastSeen = {
+      mini: at(5_000), // live
+      studio: at(3 * 60_000), // degraded (inside default grace, past interval)
+      // laptop: never seen → offline
+    };
+    const out = overlayClusterLiveness(hosts, lastSeen, { now });
+    expect(out).toEqual([
+      { host: "mini", status: "live", lastSeen: lastSeen.mini },
+      { host: "studio", status: "degraded", lastSeen: lastSeen.studio },
+      { host: "laptop", status: "offline", lastSeen: null },
+    ]);
+  });
+
+  it("single-host roster yields exactly one node entry", () => {
+    const out = overlayClusterLiveness(["mini"], { mini: at(1_000) }, { now });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({ host: "mini", status: "live", lastSeen: out[0].lastSeen });
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
@@ -1,0 +1,58 @@
+// Type declarations for cluster-view.mjs (CTL-884 / BFF2 node-aware cluster view).
+import type { BoardPayload, BoardTicket } from "./board-data.mjs";
+import type { HostLivenessStatus, LivenessThresholds } from "./node-liveness.mjs";
+
+/** A board ticket attributed to its owning node (owner_host from the durable cache). */
+export interface ClusterTicket extends BoardTicket {
+  /** The owning host (BFF11 fence projection); null when no fence has been observed. */
+  ownerHost: string | null;
+}
+
+/** One cluster node group: the host, its liveness, and the tickets it owns.
+ *  The synthetic unassigned bucket has host:null and status:null (not a real host). */
+export interface ClusterNode {
+  host: string | null;
+  status: HostLivenessStatus | null;
+  lastSeen: string | null;
+  tickets: ClusterTicket[];
+}
+
+export interface ClusterView {
+  generatedAt: string;
+  /** True when the roster is absent or length 1 — the exact identity no-op path. */
+  singleHost: boolean;
+  /** One entry per node (stable roster order), plus the unassigned bucket when non-empty. */
+  nodes: ClusterNode[];
+}
+
+export interface AssembleClusterViewArgs extends LivenessThresholds {
+  board: BoardPayload;
+  ownerHostById?: Record<string, string | null>;
+  hosts: string[];
+  heartbeats?: Record<string, string>;
+  heartbeatReader?: (opts: { logPath?: string }) => Record<string, string>;
+  logPath?: string;
+  now?: number;
+}
+
+export function assembleClusterView(args: AssembleClusterViewArgs): ClusterView;
+
+export interface ClusterEntityDeps {
+  /** Provider for the owner_host-per-ticket map (durable cache). */
+  ownerHostProvider?: () => Promise<Record<string, string | null>> | Record<string, string | null>;
+  /** Provider for the cluster roster (config.getClusterHosts). */
+  rosterProvider?: () => string[];
+  /** recovery.readClusterHeartbeats stand-in. */
+  heartbeatReader?: (opts: { logPath?: string }) => Record<string, string>;
+  /** Local event-log path forwarded to the heartbeat reader. */
+  logPath?: string;
+  /** Injected clock for tests. */
+  now?: () => number;
+}
+
+/** A read-model entity ({ project }) that assembles the cluster view off the
+ *  board snapshot the read-model already computed. Registered via
+ *  createReadModel({ entities: { cluster: createClusterEntity(...) } }). */
+export function createClusterEntity(deps?: ClusterEntityDeps): {
+  project: (snapshot: BoardPayload) => Promise<ClusterView>;
+};

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
@@ -1,0 +1,263 @@
+// cluster-view.mjs — the node-aware CLUSTER VIEW assembler (CTL-884, BFF2).
+//
+// "What is the WHOLE CLUSTER working on" is, per the design doc, a SINGLE
+// tracker query GROUPED BY owner_host, enriched by heartbeats (liveness) and
+// GitHub (PR state) — never N merged event logs. This module is the read-model
+// consumer/superset of CTL-865's cluster-board aggregation (it ABSORBS that
+// work). It composes three durable, breaker-safe sources the read-model already
+// assembles — it spawns nothing and never hits Linear/GitHub per request:
+//
+//   1. GROUPING KEY (owner_host): read from the durable cache (filter-state.db
+//      ticket_state, projected by BFF11 from each ticket's catalyst://fence/<T>
+//      attachment), surfaced through linear-cache-reader.mjs → `ownerHostById`.
+//      NEVER a live per-request attachment fetch.
+//   2. PR-STATE JOIN: each board ticket already carries its `pr` number (board-
+//      data.mjs::prFor, from the durable phase signals); the cluster view layers
+//      it through per ticket so the UI can show PR state node-attributed.
+//   3. LIVENESS OVERLAY: recovery.readClusterHeartbeats({logPath}) → { host:
+//      lastSeenISO }, classified live/degraded/offline by node-liveness.mjs.
+//
+// SINGLE-HOST IDENTITY NO-OP (the load-bearing operator constraint):
+//   When the roster is absent or length 1 (config.mjs::getClusterHosts returns
+//   [getHostName()] when .catalyst/hosts.json is absent), the cluster view is an
+//   EXACT identity no-op: ONE node carrying ALL board tickets in board order
+//   (un-fenced tickets included — on a 1-node fleet there is no "other" owner),
+//   the local daemon's own heartbeat as its liveness, and ZERO added latency
+//   (one local-log read, no per-peer fan-out, no cross-node transport — that is
+//   BFF3's concern). The N>1 grouping/unassigned-bucket branch below is exercised
+//   ONLY once a real multi-host roster exists.
+
+import { overlayClusterLiveness } from "./node-liveness.mjs";
+
+// readClusterHeartbeats lives in execution-core/recovery.mjs — a heavy Node-only
+// module chain (config.mjs/pino, monitor.mjs, registry.mjs). We DO NOT statically
+// import it here: board-data.mjs is statically imported by ui/vite.config.ts, and
+// the BFF1/CTL-883 note proves anything in board-data's eventual static graph is
+// esbuild-bundled into the Node-evaluated vite config — a transitive `bun:`/pino
+// dep there breaks `vite build`. So the liveness reader is INJECTED: the server
+// (which runs under Bun with the full dep graph) wires the real
+// recovery.readClusterHeartbeats in; tests pass `heartbeats` or a stub reader.
+// `noLivenessReader` is the safe default — no caller, no read — so a bare
+// assembleClusterView call (no heartbeats, no reader) degrades to all-offline
+// rather than throwing.
+const noLivenessReader = () => ({});
+
+/**
+ * assembleClusterView — group the board's tickets by owning node, layer the
+ * per-ticket PR-state join, and overlay per-host liveness. Pure + fully
+ * injectable so the unit tests drive every scenario without a DB/log/subprocess.
+ *
+ * @param {object} args
+ * @param {import("./board-data.mjs").BoardPayload} args.board the assembled board payload
+ * @param {Record<string, string | null>} [args.ownerHostById] owner_host per ticket id (durable cache)
+ * @param {string[]} args.hosts the cluster roster (config.mjs::getClusterHosts)
+ * @param {Record<string, string>} [args.heartbeats] pre-read readClusterHeartbeats output
+ * @param {(opts: { logPath?: string }) => Record<string, string>} [args.heartbeatReader]
+ *   recovery.readClusterHeartbeats; called once with { logPath } when `heartbeats` is absent
+ * @param {string} [args.logPath] local event-log path forwarded to the reader
+ * @param {number} [args.now] epoch ms (injected for tests)
+ * @param {number} [args.intervalMs] liveness interval threshold
+ * @param {number} [args.graceMs] liveness grace window
+ * @returns {import("./cluster-view.d.mts").ClusterView}
+ */
+export function assembleClusterView({
+  board,
+  ownerHostById = {},
+  hosts,
+  heartbeats,
+  heartbeatReader = noLivenessReader,
+  logPath,
+  now = Date.now(),
+  intervalMs,
+  graceMs,
+}) {
+  const roster = Array.isArray(hosts) && hosts.length > 0 ? hosts : [];
+  // SINGLE-HOST: roster absent or length 1 → identity no-op. Everything belongs
+  // to the one host; there is no "other" owner to group away.
+  const singleHost = roster.length <= 1;
+  const tickets = Array.isArray(board?.tickets) ? board.tickets : [];
+
+  // Resolve liveness ONCE — read the local event log a single time (the reader is
+  // injected so tests don't touch fs; the read-model passes the real one). On a
+  // single node this is the ONE local log; there is no per-peer fan-out.
+  const lastSeen =
+    heartbeats && typeof heartbeats === "object"
+      ? heartbeats
+      : heartbeatReader({ logPath });
+  const liveness = overlayClusterLiveness(roster, lastSeen, { now, intervalMs, graceMs });
+  const livenessByHost = new Map(liveness.map((n) => [n.host, n]));
+
+  // ── grouping ──────────────────────────────────────────────────────────────
+  // A node entry is { host, status, lastSeen, tickets[] }. The `null` host is the
+  // synthetic "unassigned" bucket for tickets with no fence owner — used ONLY in
+  // the multi-host branch (a single-node fleet attributes everything to its host).
+  const makeTicket = (t, host) => ({ ...t, ownerHost: host });
+
+  if (singleHost) {
+    const host = roster[0] ?? null;
+    const node = livenessByHost.get(host) ?? { host, status: host ? "offline" : null, lastSeen: null };
+    return {
+      generatedAt: board?.generatedAt ?? new Date(now).toISOString(),
+      singleHost: true,
+      // Identity no-op: ALL board tickets, in board order, attributed to the one
+      // host (preserves the flat board's ticket identity + ordering exactly).
+      nodes: [
+        {
+          host,
+          status: node.status,
+          lastSeen: node.lastSeen,
+          tickets: tickets.map((t) => makeTicket(t, host)),
+        },
+      ],
+    };
+  }
+
+  // ── multi-host (N>1): group by the durable owner_host key ───────────────────
+  const byHost = new Map(); // host (string | null) → ticket[]
+  for (const host of roster) byHost.set(host, []); // stable roster order, even if empty
+  for (const t of tickets) {
+    const raw = ownerHostById[t.id];
+    const host = typeof raw === "string" && raw.length > 0 ? raw : null;
+    // A fenced owner not in the roster is still a real node — surface it as its
+    // own group rather than mislabel it unassigned (a roster lag, not orphaning).
+    if (host !== null && !byHost.has(host)) byHost.set(host, []);
+    if (host === null && !byHost.has(null)) byHost.set(null, []);
+    byHost.get(host).push(makeTicket(t, host));
+  }
+
+  const nodes = [];
+  for (const [host, groupTickets] of byHost) {
+    if (host === null) {
+      // the unassigned bucket — not a real host, so no liveness; skip if empty
+      if (groupTickets.length === 0) continue;
+      nodes.push({ host: null, status: null, lastSeen: null, tickets: groupTickets });
+      continue;
+    }
+    const node = livenessByHost.get(host) ?? { status: "offline", lastSeen: null };
+    nodes.push({ host, status: node.status, lastSeen: node.lastSeen, tickets: groupTickets });
+  }
+
+  return {
+    generatedAt: board?.generatedAt ?? new Date(now).toISOString(),
+    singleHost: false,
+    nodes,
+  };
+}
+
+// Computed specifiers (not string literals) so esbuild can't follow these into
+// the Node-evaluated vite config bundle — the exact CTL-883/BFF1 guard that
+// keeps bun:sqlite / pino out of `vite build` (see linear-cache-reader.mjs). The
+// server resolves them once at runtime under Bun, where the full graph exists.
+const RECOVERY_MODULE = ["..", "..", "execution-core", "recovery.mjs"].join("/");
+const CONFIG_MODULE = ["..", "..", "execution-core", "config.mjs"].join("/");
+
+// resolveClusterDeps — lazily import the heavy execution-core sources (the roster
+// reader + the heartbeat reader) ONCE, returning them as injectable deps. Each is
+// best-effort: an import or read failure degrades to the single-host identity
+// no-op (roster = [], heartbeats = {}) rather than throwing out of the assemble.
+async function resolveClusterDeps() {
+  let getClusterHosts = () => [];
+  let readClusterHeartbeats = () => ({});
+  try {
+    ({ getClusterHosts } = await import(CONFIG_MODULE));
+  } catch {
+    /* config unavailable → empty roster → single-host no-op */
+  }
+  try {
+    ({ readClusterHeartbeats } = await import(RECOVERY_MODULE));
+  } catch {
+    /* recovery unavailable → no heartbeats → all hosts offline */
+  }
+  return { getClusterHosts, readClusterHeartbeats };
+}
+
+// createClusterEntity — a read-model entity (CTL-883 registration seam) that
+// assembles the cluster view off the SAME board snapshot the read-model already
+// computed, layering the durable owner_host grouping + the heartbeat liveness
+// overlay. Registered by the server via createReadModel({ entities }) so the
+// default entity set (board/tickets/workers/queue) — and its drift guard — stay
+// untouched. All sources are injectable so this is unit-testable without the
+// execution-core import or a real DB/log.
+//
+// `ownerHostProvider()` → Promise<{ [ticketId]: ownerHost|null }> (defaults to
+// reading owner_host out of linear-cache-reader's durable enrichment map);
+// `rosterProvider()` → string[] (defaults to config.getClusterHosts);
+// `heartbeatReader({logPath})` → { host: lastSeenISO } (defaults to
+// recovery.readClusterHeartbeats). The board snapshot is passed by the read-model.
+export function createClusterEntity({
+  ownerHostProvider,
+  rosterProvider,
+  heartbeatReader,
+  logPath,
+  now = () => Date.now(),
+} = {}) {
+  // Memoize the lazy execution-core import so repeated assembles don't re-import.
+  // Only resolved when an injected provider is missing — fully-injected callers
+  // (tests, a future standalone read-model process) never touch execution-core.
+  let depsPromise = null;
+  const loadExecCoreDeps = () => {
+    if (!depsPromise) depsPromise = resolveClusterDeps();
+    return depsPromise;
+  };
+
+  // Resolve the roster + heartbeat reader: prefer the injected providers; lazily
+  // import the execution-core defaults only for whichever one is absent.
+  const resolveRosterAndHeartbeats = async () => {
+    if (rosterProvider && heartbeatReader) {
+      return { getClusterHosts: rosterProvider, readClusterHeartbeats: heartbeatReader };
+    }
+    const d = await loadExecCoreDeps();
+    return {
+      getClusterHosts: rosterProvider ?? d.getClusterHosts,
+      readClusterHeartbeats: heartbeatReader ?? d.readClusterHeartbeats,
+    };
+  };
+
+  return {
+    // project off the board snapshot the read-model already assembled — the
+    // read-model passes it in, so we never re-run assembleBoard here.
+    project: async (snapshot) => {
+      const [{ getClusterHosts, readClusterHeartbeats }, ownerHostById] = await Promise.all([
+        resolveRosterAndHeartbeats(),
+        // owner_host map: the injected provider, else derive it from the board
+        // snapshot's per-ticket ownerHost when board-data carries it (BFF10), else
+        // an empty map (every ticket unassigned → single-host no-op still holds).
+        ownerHostProvider
+          ? Promise.resolve(ownerHostProvider())
+          : Promise.resolve(deriveOwnerHostFromBoard(snapshot)),
+      ]);
+      // getClusterHosts may throw (a malformed roster read); degrade to [] so the
+      // cluster view falls to the single-host identity no-op rather than crashing.
+      let hosts;
+      try {
+        hosts = getClusterHosts() || [];
+      } catch {
+        hosts = [];
+      }
+      return assembleClusterView({
+        board: snapshot,
+        ownerHostById,
+        hosts,
+        heartbeatReader: readClusterHeartbeats,
+        logPath,
+        now: now(),
+      });
+    },
+  };
+}
+
+// deriveOwnerHostFromBoard — pull a per-ticket ownerHost map off the board
+// snapshot when board-data already stamps it (BFF10's per-entity host field).
+// Until BFF10 lands, board tickets carry no ownerHost, so this yields {} and the
+// cluster view groups everything as unassigned — which, under a single-host
+// roster, still collapses to the exact identity no-op.
+function deriveOwnerHostFromBoard(snapshot) {
+  const out = {};
+  const tickets = Array.isArray(snapshot?.tickets) ? snapshot.tickets : [];
+  for (const t of tickets) {
+    if (t && typeof t.ownerHost === "string" && t.ownerHost.length > 0) {
+      out[t.id] = t.ownerHost;
+    }
+  }
+  return out;
+}

--- a/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.d.mts
@@ -22,10 +22,12 @@ export interface LinearCacheEntry {
    */
   title: string | null;
   /**
-   * CTL-922 (BFF10): the owning host NAME, projected into ticket_state from the
-   * catalyst://fence attachment by the broker (BFF11 / CTL-923). board-data
-   * derives the host {name,id} ref from this for the node-aware surfaces. null
-   * when no fence attachment has been observed.
+   * CTL-922 (BFF10) + CTL-884 (BFF2): the owning host NAME, projected into
+   * ticket_state from the catalyst://fence attachment by the broker (BFF11 /
+   * CTL-923). board-data derives the host {name,id} ref from this for the
+   * node-aware surfaces; the cluster view groups by it. null when no fence
+   * attachment has been observed (the read-model NEVER does a live attachment
+   * fetch). Required on the type — the assembled `.mjs` ALWAYS emits it.
    */
   ownerHost: string | null;
   /**
@@ -34,6 +36,19 @@ export interface LinearCacheEntry {
    * isFenceCurrent without a live attachment fetch. null when no fence.
    */
   generation: number | null;
+  /**
+   * CTL-884 (BFF2) fence companions. OPTIONAL on the type (additive — only the
+   * cluster view consumes them; the BFF9 /api/linear fetcher and its fixtures
+   * pre-date them and never construct them) but the assembled `.mjs` ALWAYS emits
+   * them (null when no fence is cached), so a consumer that reads them gets a
+   * defined value, never `undefined`.
+   */
+  /** The pipeline phase recorded on the fence at claim time, or null. */
+  fencePhase?: string | null;
+  /** ISO timestamp the fence was claimed, or null. */
+  claimedAt?: string | null;
+  /** ISO timestamp the held label was first applied (hold duration source), or null. */
+  heldSince?: string | null;
 }
 
 export type LinearCacheById = Record<string, LinearCacheEntry>;

--- a/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
@@ -87,15 +87,21 @@ async function readTicketStateById(dbPath) {
         relations: d.relations ?? null,
         assignee: d.assignee ?? null,
         linearState: d.state ?? null,
-        // CTL-922 (BFF10): the durable fence projection (BFF11 / CTL-923 — the
-        // broker projects the catalyst://fence/<TICKET> attachment into
-        // ticket_state). board-data stamps host:{name,id} + generation onto every
-        // entity from this, so the node-aware surfaces and the fence-aware web
-        // mutations read it from the cache, NEVER a live per-request attachment
-        // fetch. owner_host is the host NAME; the {name,id} ref is derived in
-        // board-data via the canonical sha256(name)[:16] id.
+        // CTL-922 (BFF10) + CTL-884 (BFF2): the durable fence projection (BFF11 /
+        // CTL-923 — the broker projects the catalyst://fence/<TICKET> attachment
+        // into ticket_state). board-data stamps host:{name,id} + generation onto
+        // every entity from this, so the node-aware surfaces and the fence-aware
+        // web mutations read it from the cache, NEVER a live per-request
+        // attachment fetch. owner_host is the host NAME; the {name,id} ref is
+        // derived in board-data via the canonical sha256(name)[:16] id. The
+        // cluster view (BFF2) groups by owner_host and also reads the companion
+        // fence phase / claimed-at / held-since for node attribution + hold
+        // duration. All null when no fence/held label has been observed.
         ownerHost: typeof d.ownerHost === "string" ? d.ownerHost : null,
         generation: typeof d.generation === "number" ? d.generation : null,
+        fencePhase: d.fencePhase ?? null,
+        claimedAt: d.claimedAt ?? null,
+        heldSince: d.heldSince ?? null,
       };
     }
     return byId;
@@ -152,7 +158,8 @@ async function readEligibleById(eligibleDir) {
 // the unit tests drive it without a real DB or homedir layout.
 //
 // Returns: { [ticketId]: { priority, estimate, project, labels, relations,
-//   assignee, linearState, title, ownerHost, generation } }
+//   assignee, linearState, title, ownerHost, generation, fencePhase, claimedAt,
+//   heldSince } }
 export async function readLinearCache({
   dbPath = DEFAULT_DB_PATH,
   eligibleDir = DEFAULT_ELIGIBLE_DIR,
@@ -193,14 +200,19 @@ export async function readLinearCache({
       // title: ticket_state has no title column, so the eligible projection is
       // the only durable source (BFF9). Honest null when neither cache has it.
       title: ts?.title ?? el?.title ?? null,
-      // CTL-922 (BFF10): the owning host NAME + fence generation, projected into
-      // ticket_state by the broker (BFF11). The eligible projection carries no
-      // fence data — ticket_state is the sole durable source. board-data uses
-      // ownerHost (host fallback) and generation (the value the web mutations
-      // pass to isFenceCurrent without a live attachment fetch). null when no
-      // fence attachment has been observed for the ticket.
+      // CTL-922 (BFF10) + CTL-884 (BFF2): the owning host NAME + fence companions
+      // (generation, phase, claimed-at, held-since), projected into ticket_state
+      // by the broker (BFF11). The eligible projection carries no fence data —
+      // ticket_state is the sole durable source. board-data uses ownerHost (host
+      // fallback) and generation (the value the web mutations pass to
+      // isFenceCurrent without a live attachment fetch); the cluster view (BFF2)
+      // groups by ownerHost and renders hold duration from heldSince. null when
+      // no fence attachment has been observed for the ticket.
       ownerHost: ts?.ownerHost ?? null,
       generation: ts?.generation ?? null,
+      fencePhase: ts?.fencePhase ?? null,
+      claimedAt: ts?.claimedAt ?? null,
+      heldSince: ts?.heldSince ?? null,
     };
   }
   // breakerOpen is intentionally not consulted to alter output — it cannot block

--- a/plugins/dev/scripts/orch-monitor/lib/node-liveness.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/node-liveness.d.mts
@@ -1,0 +1,38 @@
+// Type declarations for node-liveness.mjs (CTL-884 / BFF2 cluster liveness overlay).
+
+export type HostLivenessStatus = "live" | "degraded" | "offline";
+
+export interface ClusterNodeLiveness {
+  /** The roster host name (config.mjs::getClusterHosts). */
+  host: string;
+  /** Liveness derived from the heartbeat freshness. */
+  status: HostLivenessStatus;
+  /** The last-seen ISO timestamp the overlay classified; null when never heard. */
+  lastSeen: string | null;
+}
+
+export interface LivenessThresholds {
+  /** One heartbeat interval (≤ this ago → live). Defaults to 30s. */
+  intervalMs?: number;
+  /** The generous grace window (≤ this ago, past interval → degraded). Defaults to 5min. */
+  graceMs?: number;
+}
+
+/** node-heartbeat cadence default (mirrors execution-core HEARTBEAT_INTERVAL_MS). */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS: number;
+/** Liveness grace-window default (design-doc 5-10min floor). */
+export const DEFAULT_LIVENESS_GRACE_MS: number;
+
+/** Classify a single host's last-seen heartbeat into live/degraded/offline. */
+export function classifyHostLiveness(
+  lastSeenISO: string | null | undefined,
+  now: number,
+  opts?: LivenessThresholds,
+): HostLivenessStatus;
+
+/** Overlay liveness across a whole roster (stable roster order, offline when unheard). */
+export function overlayClusterLiveness(
+  hosts: string[],
+  lastSeenByHost: Record<string, string>,
+  opts?: { now?: number } & LivenessThresholds,
+): ClusterNodeLiveness[];

--- a/plugins/dev/scripts/orch-monitor/lib/node-liveness.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/node-liveness.mjs
@@ -1,0 +1,90 @@
+// node-liveness.mjs — the cluster liveness overlay (CTL-884, BFF2).
+//
+// The read-model's node-aware cluster view marks every roster host live /
+// degraded / offline from the heartbeat last-seen timestamps that
+// recovery.readClusterHeartbeats({logPath}) yields ({ [hostName]: lastSeenISO }).
+// Daemons append one `node.heartbeat` event to the unified event log every
+// ~30s (execution-core/config.mjs HEARTBEAT_INTERVAL_MS), so a host's freshness
+// classifies as:
+//
+//   • live      — heard within one heartbeat interval (≤ intervalMs ago)
+//   • degraded  — past the interval but inside the generous grace window
+//   • offline   — past the grace window, OR never heard / unparseable timestamp
+//
+// The grace window is deliberately generous (5-10 min per the design doc) so a
+// host that legitimately stalls 1-2 min (Claude API latency, a long implement)
+// is NEVER false-evicted as offline.
+//
+// SINGLE-HOST IDENTITY NO-OP: for today's single-node deployment the roster is
+// [getHostName()] (config.mjs::getClusterHosts) and readClusterHeartbeats reads
+// the ONE local event log — so overlayClusterLiveness yields exactly one node
+// entry whose status reflects the local daemon's own heartbeat. There is no
+// cross-node transport here; that is BFF3's concern. This module is pure and
+// injectable (`now`/thresholds) so the classification is unit-testable without a
+// real event log.
+
+// node-heartbeat cadence (mirrors execution-core/config.mjs HEARTBEAT_INTERVAL_MS
+// — copied as a literal so this lightweight monitor lib does not pull the daemon
+// module into its import graph; the heartbeat-cadence drift is bounded by the
+// node-liveness test, the same pattern board-data.mjs uses for the held labels).
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+
+// Liveness grace window — the design doc prescribes 5-10 min to bias hard against
+// false eviction. We use 5 min (the floor) so a host is declared offline no
+// sooner than the design allows.
+export const DEFAULT_LIVENESS_GRACE_MS = 5 * 60_000;
+
+/**
+ * classifyHostLiveness — map a host's last-seen heartbeat timestamp to a
+ * liveness status. Pure: `now` and the thresholds are injected. Never throws —
+ * a null / empty / unparseable timestamp degrades to "offline" (the read-model
+ * never fabricates liveness for a host it has not heard from). A future-dated
+ * heartbeat (clock skew) clamps to age 0 → live, never negative-age garbage.
+ *
+ * @param {string | null | undefined} lastSeenISO
+ * @param {number} now epoch ms
+ * @param {{ intervalMs?: number, graceMs?: number }} [opts]
+ * @returns {"live" | "degraded" | "offline"}
+ */
+export function classifyHostLiveness(
+  lastSeenISO,
+  now,
+  { intervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS, graceMs = DEFAULT_LIVENESS_GRACE_MS } = {},
+) {
+  if (typeof lastSeenISO !== "string" || lastSeenISO.length === 0) return "offline";
+  const seen = Date.parse(lastSeenISO);
+  if (!Number.isFinite(seen)) return "offline";
+  // Clamp clock skew: a heartbeat from the future is age 0, never negative.
+  const ageMs = Math.max(0, now - seen);
+  if (ageMs <= intervalMs) return "live";
+  if (ageMs <= graceMs) return "degraded";
+  return "offline";
+}
+
+/**
+ * overlayClusterLiveness — overlay liveness across an entire roster. Returns one
+ * node entry per roster host (stable roster order), carrying its status and the
+ * lastSeen timestamp the overlay classified (null when the host was never heard).
+ * A host absent from the lastSeen map is offline.
+ *
+ * @param {string[]} hosts the cluster roster (config.mjs::getClusterHosts)
+ * @param {Record<string, string>} lastSeenByHost readClusterHeartbeats output
+ * @param {{ now?: number, intervalMs?: number, graceMs?: number }} [opts]
+ * @returns {Array<{ host: string, status: "live"|"degraded"|"offline", lastSeen: string | null }>}
+ */
+export function overlayClusterLiveness(
+  hosts,
+  lastSeenByHost,
+  { now = Date.now(), intervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS, graceMs = DEFAULT_LIVENESS_GRACE_MS } = {},
+) {
+  const roster = Array.isArray(hosts) ? hosts : [];
+  const seen = lastSeenByHost && typeof lastSeenByHost === "object" ? lastSeenByHost : {};
+  return roster.map((host) => {
+    const lastSeen = typeof seen[host] === "string" && seen[host].length > 0 ? seen[host] : null;
+    return {
+      host,
+      status: classifyHostLiveness(lastSeen, now, { intervalMs, graceMs }),
+      lastSeen,
+    };
+  });
+}


### PR DESCRIPTION
## Summary

The read-model now presents what the **WHOLE CLUSTER** is doing: every ticket grouped by its owning node, with a per-host **live / degraded / offline** liveness overlay. This makes the redesign read-model the consumer/superset of CTL-865's cluster-board aggregation (it **ABSORBS** that work) — a SINGLE durable-cache query grouped by `owner_host` + a heartbeat liveness overlay + the per-ticket GitHub PR-state join, with the single-host case as an **exact identity no-op**.

No live Linear/GitHub hit per request: the `owner_host` grouping key comes from the broker's BFF11 fence projection in `ticket_state` (durable cache), and liveness comes from `recovery.readClusterHeartbeats` reading the one local event log.

## Changes (all under `plugins/dev/scripts/orch-monitor/`)

- **`lib/cluster-view.mjs`** (+ `.d.mts`) — `assembleClusterView()` groups board tickets by the `owner_host` the broker projects into the durable cache (BFF11), layers the per-ticket PR-state join (the board ticket's `pr`), and overlays per-host liveness.
  - **Single-host** (roster absent or length 1): the exact identity no-op — one node carrying ALL board tickets in board order, the local daemon's own heartbeat, one local-log read, no per-peer fan-out, no cross-node transport.
  - **Multi-host (N>1)**: group by `owner_host` with a synthetic `null` "unassigned" bucket for un-fenced tickets (a fenced owner outside the roster still gets its own group — roster lag, not orphaning).
  - `createClusterEntity()` registers it as a read-model entity that projects off the **same** board snapshot the read-model already assembled (no second assemble), lazily importing the heavy execution-core deps via **computed specifiers** so they never enter the Node-evaluated vite-config build graph (the CTL-883/BFF1 `bun:sqlite`/pino guard).
- **`lib/node-liveness.mjs`** (+ `.d.mts`) — `classifyHostLiveness` / `overlayClusterLiveness` consume `readClusterHeartbeats`'s `{ host: lastSeenISO }` and classify **live** (≤ one ~30s interval), **degraded** (past interval, inside the generous 5-10min grace), **offline** (past grace OR never heard / unparseable). Future-dated heartbeats (clock skew) clamp to age 0. Biased hard against false eviction per the design doc.
- **`lib/linear-cache-reader.mjs`** (+ `.d.mts`) — surface the BFF11 fence projection (`ownerHost` / `generation` / `fencePhase` / `claimedAt` / `heldSince`) out of the `ticket_state` descriptor — the durable node-grouping key, **never** a live attachment fetch. Null when no fence is cached; never fabricated. (The fence fields are additive-optional on `LinearCacheEntry` — only the cluster view reads them; the BFF9 `/api/linear` fetcher ignores them.)

## Gherkin scenarios

| Scenario | Status |
| --- | --- |
| **The read-model groups cluster work by owning node** — tickets grouped by `owner_host` read from the durable cache (not a live attachment fetch); GitHub PR-state join layered per ticket | ✅ satisfied |
| **Node liveness overlay marks hosts live/degraded/offline** — consumes `recovery.readClusterHeartbeats({logPath}) → {host: lastSeenISO}`; past-grace → offline, inside-grace-past-interval → degraded | ✅ satisfied (single local-log reader; **cross-node heartbeat transport / peer fan-in is BFF3 — single-node-descoped**) |
| **Single-host is an exact identity no-op** — `hosts.json` absent or length 1 renders identically to a non-cluster assembly with zero added latency | ✅ satisfied |

### Single-node descope (per operator constraint)
The N>1 grouping branch is implemented correctly but is **only exercised once a real multi-host roster exists** (`config.getClusterHosts()` returns `[getHostName()]` when `.catalyst/hosts.json` is absent → single-host path). The cross-node heartbeat **transport / peer discovery** (a host reaching another host's event log) is explicitly **out of scope here — that is BFF3**. For today's single node, `readClusterHeartbeats` reads the one local log and the overlay is exact. The multi-node anchors (CTL-863/864/865/866/873/876) are NOT built; their contracts are satisfied by the identity no-op.

## Tests
- `__tests__/cluster-view.test.ts` — 14 tests (grouping, PR join, unassigned bucket, node attribution, liveness overlay, the readClusterHeartbeats reader contract, single-host identity no-op, read-model entity integration).
- `__tests__/node-liveness.test.ts` — 11 tests (interval/grace/offline thresholds, boundary inclusivity, absent/unparseable/clock-skew, roster overlay).
- extended `__tests__/linear-cache-reader.test.ts` (fence-field surfacing, end-to-end via a real `filter-state.db` with `upsertTicketFence`).

Verification (TARGETED, not `run-tests.sh`):
- `bun test cluster-view node-liveness linear-cache-reader read-model linear` → **61 pass, 0 fail**
- `bunx tsc --noEmit` (orch-monitor package) → clean (the only remaining errors are the pre-existing `ui/src/lib/briefings.ts` `marked`/`dompurify` missing-module errors — a fresh-worktree `bun install` gap in the `ui` package, untouched by this PR)
- `bun run build` (ui) → green (cluster-view is not in the build graph; the lazy computed-specifier imports keep execution-core out of it)
- eslint on changed files → clean; no reward-hacking patterns (`as any`/`@ts-ignore`/non-null `!` etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)