### PR TITLE
feat(dev): BFF10 per-entity host/team/generation (CTL-922)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/board-node-attribution.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-node-attribution.test.ts
@@ -1,0 +1,188 @@
+// board-node-attribution.test.ts — CTL-922 (BFF10).
+//
+// Every BoardTicket / BoardWorker / BoardQueueItem must carry its owning
+// `host:{name,id}` (+ team on the queue item) and the per-ticket/worker
+// `generation`, so the node-aware surfaces (BOARD3 host swimlanes, SURF1 worker
+// node group, SURF2 queue node column) bind to a real field, and the fence-aware
+// web mutations (BFF8 stop, HOME5 unblock) can pass a real generation to
+// isFenceCurrent without a live attachment fetch.
+//
+// host source precedence: the phase signal `host:{name,id}` (CTL-852,
+// phase-agent-dispatch) first, then the durable fence projection owner_host
+// (BFF11 broker projection). generation precedence: the durable fence projection
+// generation first, then the phase signal generation.
+//
+// These exercise the PURE exported helpers (deriveHost / deriveGeneration /
+// synthesizeQueuedTicket) — assembleBoard itself is not unit-testable (it reads
+// a homedir const and shells out to `claude agents`), mirroring the established
+// board-current-phase / board-phase-summary test approach.
+
+import { test, expect } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  deriveHost,
+  deriveGeneration,
+  synthesizeQueuedTicket,
+  hostRefFromName,
+  PHASE_ORDER,
+} from "../lib/board-data.mjs";
+
+type Sig = Record<string, unknown> | null;
+const sigs = (): Sig[] => PHASE_ORDER.map(() => null);
+const idx = (phase: string) => PHASE_ORDER.indexOf(phase);
+const expectedId = (name: string) => createHash("sha256").update(name).digest("hex").slice(0, 16);
+
+// ── Scenario: Board entities are node-attributed ────────────────────────────
+
+test("deriveHost reads host:{name,id} from the active phase signal (CTL-852)", () => {
+  const s = sigs();
+  s[idx("implement")] = {
+    status: "running",
+    host: { name: "mac-mini", id: "abc123def456abcd" },
+  };
+  expect(deriveHost(s, {})).toEqual({ name: "mac-mini", id: "abc123def456abcd" });
+});
+
+test("deriveHost falls back to the fence projection owner_host when no signal host", () => {
+  const s = sigs();
+  s[idx("research")] = { status: "running" }; // no host on the signal
+  const host = deriveHost(s, { ownerHost: "mac-mini" });
+  // id derived as sha256(name)[:16] — the canonical host-id shape, identical to
+  // the bash/mjs/ts primitives — so the fence fallback yields a full {name,id}.
+  expect(host).toEqual({ name: "mac-mini", id: expectedId("mac-mini") });
+});
+
+test("deriveHost prefers the signal host even when the fence also carries owner_host", () => {
+  const s = sigs();
+  s[idx("verify")] = {
+    status: "running",
+    host: { name: "signal-host", id: "1111222233334444" },
+  };
+  expect(deriveHost(s, { ownerHost: "fence-host" })).toEqual({
+    name: "signal-host",
+    id: "1111222233334444",
+  });
+});
+
+test("deriveHost is null when neither the signal nor the fence names a host", () => {
+  const s = sigs();
+  s[idx("triage")] = { status: "done" };
+  expect(deriveHost(s, {})).toBeNull();
+  expect(deriveHost(s, { ownerHost: null })).toBeNull();
+});
+
+test("deriveHost walks the same precedence as the current phase — newest non-terminal wins", () => {
+  // A terminal earlier phase carries an OLD host; the active phase carries the
+  // current host. The current (non-terminal) phase's host is the live owner.
+  const s = sigs();
+  s[idx("triage")] = { status: "done", host: { name: "old-host", id: "deadbeefdeadbeef" } };
+  s[idx("implement")] = { status: "running", host: { name: "cur-host", id: "0000111122223333" } };
+  expect(deriveHost(s, {})).toEqual({ name: "cur-host", id: "0000111122223333" });
+});
+
+test("hostRefFromName derives the canonical sha256(name)[:16] id; null/empty → null", () => {
+  expect(hostRefFromName("mac-mini")).toEqual({
+    name: "mac-mini",
+    id: expectedId("mac-mini"),
+  });
+  expect(hostRefFromName(null)).toBeNull();
+  expect(hostRefFromName("")).toBeNull();
+});
+
+// ── Scenario: Generation is available for fence-aware writes ─────────────────
+
+test("deriveGeneration reads the durable fence projection generation first (BFF11)", () => {
+  const s = sigs();
+  s[idx("implement")] = { status: "running", generation: 2 };
+  // fence projection wins — it is the durable cache the web mutation reads from,
+  // never a live attachment fetch.
+  expect(deriveGeneration(s, { generation: 5 })).toBe(5);
+});
+
+test("deriveGeneration falls back to the phase signal generation when fence absent", () => {
+  const s = sigs();
+  s[idx("implement")] = { status: "running", generation: 3 };
+  expect(deriveGeneration(s, {})).toBe(3);
+  expect(deriveGeneration(s, { generation: null })).toBe(3);
+});
+
+test("deriveGeneration is null when neither source carries it", () => {
+  const s = sigs();
+  s[idx("research")] = { status: "running" };
+  expect(deriveGeneration(s, {})).toBeNull();
+  expect(deriveGeneration([], {})).toBeNull();
+});
+
+test("deriveGeneration accepts a literal 0 generation (not coerced to null)", () => {
+  expect(deriveGeneration([], { generation: 0 })).toBe(0);
+  const s = sigs();
+  s[idx("implement")] = { status: "running", generation: 0 };
+  expect(deriveGeneration(s, {})).toBe(0);
+});
+
+// ── Scenario: Single-host is identity ────────────────────────────────────────
+// One node ⇒ every entity resolves to that same host. There is no separate
+// cluster code path: the helper that single-host hits is the SAME one a multi-
+// host fleet hits — it simply yields the one host. Zero added chrome/latency.
+
+test("single-host: every entity resolves to the one host with no extra branch", () => {
+  const sTicket = sigs();
+  sTicket[idx("implement")] = {
+    status: "running",
+    host: { name: "mac-mini", id: "abc123def456abcd" },
+    generation: 1,
+  };
+  const sWorker = sigs();
+  sWorker[idx("implement")] = {
+    status: "running",
+    host: { name: "mac-mini", id: "abc123def456abcd" },
+    generation: 1,
+  };
+  // Same host object shape for ticket and worker derived from the same single node.
+  expect(deriveHost(sTicket, {})).toEqual(deriveHost(sWorker, {}));
+  expect(deriveHost(sTicket, {})).toEqual({ name: "mac-mini", id: "abc123def456abcd" });
+});
+
+// ── synthesizeQueuedTicket carries host + team + generation ──────────────────
+// Queue cards have no worker dir / phase signal, so host/generation come purely
+// from the durable fence projection (linfo). team is the prefix-derived team.
+
+test("synthesizeQueuedTicket carries team and host (from fence projection) + generation", () => {
+  const eligible = {
+    id: "CTL-900",
+    title: "Queued ticket",
+    priority: 2,
+    createdAt: "2026-06-07T00:00:00Z",
+    state: "Todo",
+    repo: "catalyst",
+    team: "CTL",
+  };
+  const linfo = {
+    "CTL-900": {
+      priority: 2,
+      labels: [],
+      ownerHost: "mac-mini",
+      generation: 4,
+    },
+  };
+  const t = synthesizeQueuedTicket(eligible, linfo);
+  expect(t.team).toBe("CTL");
+  expect(t.host).toEqual({ name: "mac-mini", id: expectedId("mac-mini") });
+  expect(t.generation).toBe(4);
+});
+
+test("synthesizeQueuedTicket: host null + generation null when the fence projection is empty", () => {
+  const eligible = {
+    id: "ADV-1",
+    title: "queued",
+    priority: 0,
+    createdAt: "2026-06-07T00:00:00Z",
+    state: "Todo",
+    repo: "adva",
+    team: "ADV",
+  };
+  const t = synthesizeQueuedTicket(eligible, {});
+  expect(t.team).toBe("ADV");
+  expect(t.host).toBeNull();
+  expect(t.generation).toBeNull();
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-cache-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-cache-reader.test.ts
@@ -13,6 +13,7 @@ import {
   openBrokerStateDb,
   closeBrokerStateDb,
   upsertTicketDescriptor,
+  upsertTicketFence,
 } from "../../broker/broker-state.mjs";
 
 describe("readLinearCache (CTL-883 — durable-cache Linear enrichment)", () => {
@@ -39,6 +40,9 @@ describe("readLinearCache (CTL-883 — durable-cache Linear enrichment)", () => 
       linearState: "Implement",
       // ticket_state has no title column → honest null with no eligible row (BFF9)
       title: null,
+      // BFF10: no fence attachment observed → honest null (never fabricated)
+      ownerHost: null,
+      generation: null,
     });
   });
 
@@ -51,6 +55,39 @@ describe("readLinearCache (CTL-883 — durable-cache Linear enrichment)", () => 
     // ticket_state owns state/priority, eligible owns the title.
     expect(byId["CTL-3"].linearState).toBe("PR");
     expect(byId["CTL-3"].title).toBe("Retire legacy linearis poller");
+  });
+
+  it("surfaces ownerHost + generation from the ticket_state fence projection (BFF10/BFF11)", async () => {
+    // The broker projects the catalyst://fence attachment into ticket_state
+    // (BFF11). readLinearCache hands ownerHost + generation to board-data so the
+    // node-aware surfaces and the fence-aware web mutations read them from the
+    // cache, never a live attachment fetch.
+    const ticketStateReader = () =>
+      Promise.resolve({
+        "CTL-9": {
+          priority: 2,
+          labels: [],
+          linearState: "Implement",
+          ownerHost: "mac-mini",
+          generation: 3,
+        },
+      });
+    const byId = await readLinearCache({
+      ticketStateReader,
+      eligibleReader: () => Promise.resolve({}),
+    });
+    expect(byId["CTL-9"].ownerHost).toBe("mac-mini");
+    expect(byId["CTL-9"].generation).toBe(3);
+  });
+
+  it("ownerHost/generation default to null when the fence projection is absent", async () => {
+    const byId = await readLinearCache({
+      ticketStateReader: () => Promise.resolve({ "CTL-10": { labels: [] } }),
+      eligibleReader: () => Promise.resolve({ "CTL-10": { title: "queued" } }),
+    });
+    // the eligible projection carries no fence data — honest null, never fabricated.
+    expect(byId["CTL-10"].ownerHost).toBeNull();
+    expect(byId["CTL-10"].generation).toBeNull();
   });
 
   it("fills priority/project/relations from the eligible projection when ticket_state lacks them", async () => {
@@ -134,6 +171,9 @@ describe("readLinearCache end-to-end against a real filter-state.db", () => {
       assignee: "uuid-a",
     });
     upsertTicketDescriptor({ ticket: "CTL-101", state: "Done", uuid: "u-101" });
+    // BFF10/BFF11: project a fence attachment so the e2e proves ownerHost +
+    // generation flow from ticket_state through the bulk descriptor read.
+    upsertTicketFence({ ticket: "CTL-100", ownerHost: "mac-mini", generation: 7 });
     closeBrokerStateDb(); // assemble path opens its own handle
     writeFileSync(
       join(eligibleDir, "CTL.json"),
@@ -158,5 +198,11 @@ describe("readLinearCache end-to-end against a real filter-state.db", () => {
     expect(byId["CTL-200"].priority).toBe(3);
     expect(byId["CTL-200"].project).toBe("Web UI");
     expect(byId["CTL-200"].title).toBe("queued"); // BFF9: title from eligible
+    // BFF10/BFF11: the fence projection flows through the real bulk descriptor read.
+    expect(byId["CTL-100"].ownerHost).toBe("mac-mini");
+    expect(byId["CTL-100"].generation).toBe(7);
+    // a ticket with no fence attachment → honest null
+    expect(byId["CTL-101"].ownerHost).toBeNull();
+    expect(byId["CTL-101"].generation).toBeNull();
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear.test.ts
@@ -265,6 +265,8 @@ describe("createCacheBackedLinearFetcher (BFF9 — durable-cache LinearFetcher)"
     assignee: "uuid-bot",
     linearState: "Implement",
     title: "Retire legacy linearis poller",
+    ownerHost: null,
+    generation: null,
   } satisfies LinearCacheById[string];
 
   it("Scenario 1: serves /api/linear shape from the durable cache (no linearis spawn)", async () => {
@@ -353,6 +355,8 @@ describe("createCacheBackedLinearFetcher (BFF9 — durable-cache LinearFetcher)"
         assignee: null,
         linearState: null,
         title: null,
+        ownerHost: null,
+        generation: null,
       },
     });
     const fetcher = createCacheBackedLinearFetcher({ cacheReader: reader });

--- a/plugins/dev/scripts/orch-monitor/__tests__/read-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/read-model.test.ts
@@ -38,6 +38,8 @@ function worker(ticket: string): BoardWorker {
     startedAt: null,
     pid: null,
     catalystSessionId: null,
+    host: null,
+    generation: null,
   };
 }
 
@@ -69,6 +71,8 @@ function ticket(id: string): BoardTicket {
     updatedAt: "",
     held: null,
     blockers: [],
+    host: null,
+    generation: null,
   };
 }
 
@@ -85,6 +89,7 @@ function queueItem(id: string): BoardQueueItem {
     estimate: null,
     scope: null,
     project: null,
+    host: null,
   };
 }
 

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -5,6 +5,16 @@
 
 export type BoardActiveState = "active" | "stuck" | null;
 
+/** CTL-922 (BFF10): a node's stable identity stamped on every board entity so
+ *  the node-aware surfaces can attribute/group by host. `name` is the
+ *  configurable host name (CATALYST_HOST_NAME / os.hostname() minus ".local");
+ *  `id` is sha256(name)[:16] — identical across the bash/mjs/ts host-identity
+ *  primitives. Same shape as the read-model contract's HostRef. */
+export interface BoardHostRef {
+  name: string;
+  id: string;
+}
+
 export interface BoardWorker {
   name: string;
   ticket: string;
@@ -26,6 +36,14 @@ export interface BoardWorker {
   pid: number | null;
   /** CTL-888 (BFF6) P7: catalyst `sess_…` id (catalyst.session heartbeat key); null when unknown. */
   catalystSessionId: string | null;
+  /** CTL-922 (BFF10): the node owning this worker, from the phase signal
+   *  host:{name,id} (CTL-852) or the durable fence projection owner_host (BFF11).
+   *  null when no host is named (single-host resolves to the one node). */
+  host: BoardHostRef | null;
+  /** CTL-922 (BFF10): the fence generation, from the durable fence projection
+   *  (BFF11) or the phase signal — the value a fence-aware web mutation passes to
+   *  isFenceCurrent without a live attachment fetch. null when no fence. */
+  generation: number | null;
 }
 
 export interface BoardPhaseCost {
@@ -81,6 +99,14 @@ export interface BoardTicket {
   held: "blocked" | "waiting" | null;
   /** Dependency ids a `blocked` hold is waiting on (from triage.json). */
   blockers: string[];
+  /** CTL-922 (BFF10): the node owning this ticket, from the phase signals
+   *  host:{name,id} (CTL-852) or the durable fence projection owner_host (BFF11).
+   *  null when no host is named (single-host resolves to the one node). */
+  host: BoardHostRef | null;
+  /** CTL-922 (BFF10): the fence generation, from the durable fence projection
+   *  (BFF11) or the phase signal — the value a fence-aware web mutation passes to
+   *  isFenceCurrent without a live attachment fetch. null when no fence. */
+  generation: number | null;
 }
 
 export interface BoardQueueItem {
@@ -95,6 +121,9 @@ export interface BoardQueueItem {
   estimate: number | null;
   scope: string | null;
   project: string | null;
+  /** CTL-922 (BFF10): the node owning this queued ticket, from the durable fence
+   *  projection owner_host (BFF11); null when no fence attachment observed. */
+  host: BoardHostRef | null;
 }
 
 export interface BoardConfig {
@@ -123,4 +152,24 @@ export const HELD_LABEL_WAITING: string;
 export function heldFor(labels: unknown): "blocked" | "waiting" | null;
 export function buildPhaseSummary(phaseSigs: unknown[], now: number): BoardPhaseTiming[];
 export function deriveCurrentPhase(phaseSigs: unknown[]): BoardCurrentPhase;
+/** Build a thin Todo-column BoardTicket from an eligible queue entry (CTL-767). */
+export function synthesizeQueuedTicket(
+  eligible: unknown,
+  linfo: Record<string, unknown>,
+): BoardTicket;
 export function assembleBoard(): Promise<BoardPayload>;
+/** CTL-922 (BFF10): build a {name,id} HostRef from a bare host name (id =
+ *  sha256(name)[:16]); null for a null/empty name. */
+export function hostRefFromName(name: unknown): BoardHostRef | null;
+/** CTL-922 (BFF10): resolve an entity's owning host — phase-signal host:{name,id}
+ *  first (CTL-852), else the durable fence projection owner_host (BFF11). */
+export function deriveHost(
+  phaseSigs: unknown[],
+  fence?: { ownerHost?: string | null },
+): BoardHostRef | null;
+/** CTL-922 (BFF10): resolve an entity's fence generation — durable fence
+ *  projection (BFF11) first, else the phase signal generation; null when neither. */
+export function deriveGeneration(
+  phaseSigs: unknown[],
+  fence?: { generation?: number | null },
+): number | null;

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -16,6 +16,7 @@
 // Vite dev middleware.
 
 import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
 import { readFile, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
@@ -107,6 +108,13 @@ export function synthesizeQueuedTicket(e, linfo) {
     updatedAt: e.createdAt || new Date(0).toISOString(),
     held: heldFor(li.labels),
     blockers: [],
+    // CTL-922 (BFF10): node attribution. A queued ticket has no worker dir /
+    // phase signal, so host + generation come purely from the durable fence
+    // projection (li, via the broker's BFF11 ticket_state). team is the
+    // prefix-derived team (BoardQueueItem also carries it now). All null/identity
+    // for a queued ticket with no fence attachment yet — never fabricated.
+    host: deriveHost([], li),
+    generation: deriveGeneration([], li),
   };
 }
 
@@ -233,6 +241,94 @@ export function deriveCurrentPhase(phaseSigs) {
     return { phase: "done", status: "done", model: lastTerminal.model };
   }
   return lastTerminal;
+}
+
+// ── per-entity node attribution (CTL-922 / BFF10) ────────────────────────────
+// Every BoardTicket / BoardWorker / BoardQueueItem carries its owning
+// host:{name,id} so the node-aware surfaces (BOARD3 host swimlanes, SURF1 worker
+// node group, SURF2 queue node column) bind to a real field, and a per-entity
+// `generation` so the fence-aware web mutations (BFF8 stop, HOME5 unblock) can
+// pass a real value to isFenceCurrent without a live attachment fetch.
+//
+// SINGLE-HOST IDENTITY NO-OP: with one node, every entity resolves to that one
+// host through this SAME code path — there is no separate cluster branch. A
+// multi-node fleet simply yields different hosts per entity from the same
+// derivation, with zero added latency or chrome.
+
+// hostRefFromName — build a {name,id} HostRef from a bare host NAME, deriving the
+// id as sha256(name)[:16] — the canonical host-id shape shared by the bash
+// (lib/host-identity.sh), mjs (execution-core/lib/host-identity.mjs), and ts
+// (lib/canonical-event-shared.ts::hostId) primitives, so a name resolved from
+// the fence projection yields the identical id those producers stamp. null/empty
+// name → null (no host attribution rather than a fabricated id).
+export function hostRefFromName(name) {
+  if (typeof name !== "string" || name.length === 0) return null;
+  return { name, id: createHash("sha256").update(name).digest("hex").slice(0, 16) };
+}
+
+// deriveHost — resolve a {name,id} HostRef for an entity. Precedence:
+//   1. the active phase signal's `host:{name,id}` (CTL-852, stamped at dispatch
+//      by phase-agent-dispatch) — the live, full ref.
+//   2. the durable fence projection owner_host (BFF11 / CTL-923), a host NAME —
+//      its {name,id} is derived via hostRefFromName.
+// Returns null when neither source names a host. `fence` is the linfo entry for
+// the ticket ({ ownerHost } among other fields), already read from the durable
+// cache — NEVER a live attachment fetch.
+export function deriveHost(phaseSigs, fence = {}) {
+  // Walk phase signals using the SAME precedence as deriveCurrentPhase (the
+  // active non-terminal phase first, else the latest terminal phase that has a
+  // host) so the host tracks the entity's current owner.
+  const sigHost = currentSignalHost(phaseSigs);
+  if (sigHost && typeof sigHost.name === "string" && sigHost.name.length > 0) {
+    return {
+      name: sigHost.name,
+      // the dispatch signal already carries the canonical id; only derive it if
+      // a malformed signal somehow omitted it.
+      id:
+        typeof sigHost.id === "string" && sigHost.id.length > 0
+          ? sigHost.id
+          : (hostRefFromName(sigHost.name)?.id ?? null),
+    };
+  }
+  return hostRefFromName(fence?.ownerHost ?? null);
+}
+
+// currentSignalHost — the `host` object off the phase signal that deriveCurrentPhase
+// would surface (active non-terminal phase, else the most-recent terminal one
+// that carries a host). Internal helper — pure, no I/O.
+function currentSignalHost(phaseSigs) {
+  let lastTerminalHost = null;
+  for (let i = 0; i < PHASE_ORDER.length; i++) {
+    const sig = phaseSigs[i];
+    if (!sig) continue;
+    const status = sig.status || "unknown";
+    if (!TERMINAL.has(status)) return sig.host ?? null; // active phase wins
+    if (sig.host) lastTerminalHost = sig.host;
+  }
+  return lastTerminalHost;
+}
+
+// deriveGeneration — the fence generation for an entity. Precedence: the durable
+// fence projection generation (BFF11 / CTL-923, the value the web mutations pass
+// to isFenceCurrent) first, then the phase signal `generation` (stamped by
+// phase-agent-dispatch). null when neither carries it. A literal 0 is a valid
+// generation and must NOT be coerced to null (hence the typeof guard).
+export function deriveGeneration(phaseSigs, fence = {}) {
+  if (typeof fence?.generation === "number") return fence.generation;
+  for (let i = 0; i < PHASE_ORDER.length; i++) {
+    const sig = phaseSigs[i];
+    if (!sig) continue;
+    const status = sig.status || "unknown";
+    if (!TERMINAL.has(status)) {
+      return typeof sig.generation === "number" ? sig.generation : null;
+    }
+  }
+  // No active phase signal — fall back to the latest signal that carries one.
+  for (let i = PHASE_ORDER.length - 1; i >= 0; i--) {
+    const sig = phaseSigs[i];
+    if (sig && typeof sig.generation === "number") return sig.generation;
+  }
+  return null;
 }
 
 // CTL-754: per-phase timing for the board progression strip. Pure + exported so
@@ -465,6 +561,21 @@ async function readTicketArtifacts(id) {
   return { phaseSigs, triage, prSigs };
 }
 
+// CTL-922 (BFF10): read a single worker's own phase signal, positioned into a
+// PHASE_ORDER-aligned sparse array so deriveHost / deriveGeneration walk it the
+// same way they walk a full ticket's signals. A live worker's phase is
+// non-terminal, so its host/generation surface as the active phase. Returns []
+// (no host attribution) when the signal is absent — never blocks.
+async function readWorkerPhaseSignals(ticket, phase) {
+  const sig = await readJSON(join(WORKERS_DIR, ticket, `phase-${phase}.json`));
+  if (!sig) return [];
+  const i = PHASE_ORDER.indexOf(phase);
+  if (i < 0) return [];
+  const sigs = PHASE_ORDER.map(() => null);
+  sigs[i] = sig;
+  return sigs;
+}
+
 // ── main assembly ───────────────────────────────────────────────────────────
 export async function assembleBoard() {
   const [agents, costs, phaseCostsByTicket, eligible, linfo, mp, catalystSessByUuid] = await Promise.all([
@@ -486,6 +597,13 @@ export async function assembleBoard() {
     const lastActiveMs = await transcriptAgeMs(a.sessionId, now);
     const activeState = await deriveActiveState(p.ticket, p.phase, lastActiveMs);
     const working = lastActiveMs != null && lastActiveMs < WORKING_MS; // detail-level only
+    // CTL-922 (BFF10): node attribution. host:{name,id} from the worker's own
+    // phase signal (CTL-852, dispatch-stamped) falling back to the durable fence
+    // projection owner_host (BFF11); generation from the fence projection first,
+    // then the signal. SINGLE-HOST: every worker resolves to the one node via
+    // this same path — no separate cluster branch, no live attachment fetch.
+    const workerSigs = await readWorkerPhaseSignals(p.ticket, p.phase);
+    const fence = linfo[p.ticket] ?? {};
     return {
       name: a.name, ticket: p.ticket, tickets: [p.ticket], phase: p.phase,
       status: a.status || "idle", activeState, working, lastActiveMs,
@@ -502,6 +620,9 @@ export async function assembleBoard() {
       // sessionId — surfaces both id spaces (Loki catalyst.session heartbeat
       // joins on this one). null when the db has no row for this CC-UUID.
       catalystSessionId: catalystSessByUuid[a.sessionId] ?? null,
+      // CTL-922 (BFF10): owning host + fence generation (see above).
+      host: deriveHost(workerSigs, fence),
+      generation: deriveGeneration(workerSigs, fence),
     };
   }));
   const inFlightTickets = new Map(workers.map((w) =>
@@ -544,6 +665,13 @@ export async function assembleBoard() {
       phaseSummary,
       pr: prFor(prSigs),
       updatedAt: ticketUpdatedAt(phaseSigs),
+      // CTL-922 (BFF10): node attribution. host:{name,id} from the ticket's phase
+      // signals (CTL-852, dispatch-stamped) falling back to the durable fence
+      // projection owner_host (BFF11); generation from the fence projection first,
+      // then the signal. SINGLE-HOST: resolves to the one node via this same path,
+      // no cluster branch, no live attachment fetch.
+      host: deriveHost(phaseSigs, linfo[id] ?? {}),
+      generation: deriveGeneration(phaseSigs, linfo[id] ?? {}),
     };
   }));
 
@@ -572,10 +700,17 @@ export async function assembleBoard() {
     .map(async (e, i) => {
       const { triage } = await readTicketArtifacts(e.id);
       return {
+        // `...e` already carries `team` (loadEligible stamps teamFor(id)) — the
+        // BoardQueueItem type now declares it so the SURF2 node column / lane
+        // grouping can read it (CTL-922 / BFF10).
         ...e, rank: i + 1,
         priority: linfo[e.id]?.priority ?? e.priority ?? 0,
         estimate: linfo[e.id]?.estimate ?? null, scope: ticketScope(triage),
         project: linfo[e.id]?.project ?? e.project ?? null,
+        // CTL-922 (BFF10): owning host from the durable fence projection (BFF11);
+        // a queued ticket has no phase signal, so [] forces the fence fallback.
+        // null when no fence attachment has been observed — never fabricated.
+        host: deriveHost([], linfo[e.id] ?? {}),
       };
     }));
 

--- a/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.d.mts
@@ -21,6 +21,19 @@ export interface LinearCacheEntry {
    * title column), so null when the ticket has no eligible row (BFF9 / CTL-921).
    */
   title: string | null;
+  /**
+   * CTL-922 (BFF10): the owning host NAME, projected into ticket_state from the
+   * catalyst://fence attachment by the broker (BFF11 / CTL-923). board-data
+   * derives the host {name,id} ref from this for the node-aware surfaces. null
+   * when no fence attachment has been observed.
+   */
+  ownerHost: string | null;
+  /**
+   * CTL-922 (BFF10): the fence generation from the same durable projection — the
+   * value a fence-aware web mutation (BFF8 stop, HOME5 unblock) passes to
+   * isFenceCurrent without a live attachment fetch. null when no fence.
+   */
+  generation: number | null;
 }
 
 export type LinearCacheById = Record<string, LinearCacheEntry>;

--- a/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
@@ -87,6 +87,15 @@ async function readTicketStateById(dbPath) {
         relations: d.relations ?? null,
         assignee: d.assignee ?? null,
         linearState: d.state ?? null,
+        // CTL-922 (BFF10): the durable fence projection (BFF11 / CTL-923 — the
+        // broker projects the catalyst://fence/<TICKET> attachment into
+        // ticket_state). board-data stamps host:{name,id} + generation onto every
+        // entity from this, so the node-aware surfaces and the fence-aware web
+        // mutations read it from the cache, NEVER a live per-request attachment
+        // fetch. owner_host is the host NAME; the {name,id} ref is derived in
+        // board-data via the canonical sha256(name)[:16] id.
+        ownerHost: typeof d.ownerHost === "string" ? d.ownerHost : null,
+        generation: typeof d.generation === "number" ? d.generation : null,
       };
     }
     return byId;
@@ -143,7 +152,7 @@ async function readEligibleById(eligibleDir) {
 // the unit tests drive it without a real DB or homedir layout.
 //
 // Returns: { [ticketId]: { priority, estimate, project, labels, relations,
-//   assignee, linearState } }
+//   assignee, linearState, title, ownerHost, generation } }
 export async function readLinearCache({
   dbPath = DEFAULT_DB_PATH,
   eligibleDir = DEFAULT_ELIGIBLE_DIR,
@@ -184,6 +193,14 @@ export async function readLinearCache({
       // title: ticket_state has no title column, so the eligible projection is
       // the only durable source (BFF9). Honest null when neither cache has it.
       title: ts?.title ?? el?.title ?? null,
+      // CTL-922 (BFF10): the owning host NAME + fence generation, projected into
+      // ticket_state by the broker (BFF11). The eligible projection carries no
+      // fence data — ticket_state is the sole durable source. board-data uses
+      // ownerHost (host fallback) and generation (the value the web mutations
+      // pass to isFenceCurrent without a live attachment fetch). null when no
+      // fence attachment has been observed for the ticket.
+      ownerHost: ts?.ownerHost ?? null,
+      generation: ts?.generation ?? null,
     };
   }
   // breakerOpen is intentionally not consulted to alter output — it cannot block

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
@@ -13,6 +13,15 @@ import type { ReadModelPayload } from "../../../lib/read-model-client";
 
 export type BoardActiveState = "active" | "stuck" | null;
 
+/** CTL-922 (BFF10): a node's stable identity stamped on every board entity so the
+ *  node-aware surfaces (BOARD3 host swimlanes, SURF1 worker node group, SURF2
+ *  queue node column) can attribute/group by host. Mirrors the server's
+ *  BoardHostRef (lib/board-data.d.mts) and the read-model contract's HostRef. */
+export interface BoardHostRef {
+  name: string;
+  id: string;
+}
+
 export interface BoardWorker {
   name: string;
   ticket: string;
@@ -37,6 +46,13 @@ export interface BoardWorker {
    *  Loki `catalyst.session` heartbeat / `catalyst.phase-agent` lifecycle
    *  streams. null when catalyst.db has no row for this CC-UUID. */
   catalystSessionId?: string | null;
+  /** CTL-922 (BFF10): the node owning this worker (SURF1 node group/filter),
+   *  from the phase signal host:{name,id} (CTL-852) or the durable fence
+   *  projection owner_host (BFF11). null when no host is named. */
+  host?: BoardHostRef | null;
+  /** CTL-922 (BFF10): the fence generation (BFF8 stop passes it to the
+   *  fence-check). null when no fence. */
+  generation?: number | null;
 }
 
 export interface BoardPhaseCost {
@@ -87,6 +103,13 @@ export interface BoardTicket {
   held?: "blocked" | "waiting" | null;
   /** Dependency ids a `blocked` hold is waiting on (only meaningful when held === "blocked"). */
   blockers?: string[];
+  /** CTL-922 (BFF10): the node owning this ticket (BOARD3 host swimlanes), from
+   *  the phase signals host:{name,id} (CTL-852) or the durable fence projection
+   *  owner_host (BFF11). null when no host is named. */
+  host?: BoardHostRef | null;
+  /** CTL-922 (BFF10): the fence generation (HOME5 unblock passes it to the
+   *  fence-check). null when no fence. */
+  generation?: number | null;
 }
 
 export interface WorkflowSubStep {
@@ -108,6 +131,10 @@ export interface BoardQueueItem {
   estimate: number | null;
   scope: string | null;
   project: string | null;
+  /** CTL-922 (BFF10): the node owning this queued ticket (SURF2 queue node
+   *  column), from the durable fence projection owner_host (BFF11). null when
+   *  no fence attachment has been observed. */
+  host?: BoardHostRef | null;
 }
 
 export interface BoardConfig {


### PR DESCRIPTION
## CTL-922 (BFF10) — Per-entity host/team/generation

Stamps the owning `host:{name,id}` + fence `generation` onto every `BoardTicket`, `BoardWorker`, and `BoardQueueItem` (and `team` where it was missing) so the node-aware UI surfaces bind to a real field rather than an implied one, and the fence-aware web mutations can pass a real generation to `isFenceCurrent` without a live attachment fetch. This is the per-ENTITY field producer that BOARD3 / SURF1 / SURF2 / BFF8 / HOME5 consume.

Builds on the already-merged deps: **BFF1** (CTL-883, cache-backed read-model) and **BFF11** (CTL-923, broker projects `owner_host`/`catalyst_generation` into `ticket_state`).

### Files
- `lib/board-data.mjs` — new pure helpers `hostRefFromName` / `deriveHost` / `deriveGeneration`; wired into worker, ticket, queue, and `synthesizeQueuedTicket`. host precedence: phase signal `host:{name,id}` (CTL-852) → durable fence projection `owner_host` (BFF11); generation precedence: durable fence projection → phase signal. The fence fallback derives the canonical `sha256(name)[:16]` id matching the bash/mjs/ts host-identity primitives.
- `lib/linear-cache-reader.mjs` — surface `ownerHost` + `generation` from the `ticket_state` fence projection (durable cache only, never a live attachment fetch).
- `ui/src/board/types.ts`, `lib/board-data.d.mts`, `lib/linear-cache-reader.d.mts` — add `BoardHostRef`, the `host`/`generation` fields (+ `host`/`team` on `BoardQueueItem`), and declare the new helpers. UI fields optional / server fields required, preserving the CTL-919 `ContractPayloadFitsUiView` assignability assertion.

### Gherkin acceptance scenarios

| Scenario | Status |
|---|---|
| **Board entities are node-attributed** — ticket/worker/queue-item carry `host:{name,id}` sourced from the phase signal host (CTL-852) or the fence `owner_host`; BoardTicket/BoardQueueItem additionally carry `team` | **satisfied** — `host` stamped on all three entity types; `deriveHost` reads the signal first, falls back to the fence projection; `team` added to BoardQueueItem (already prefix-derived in the eligible entry) |
| **Generation is available for fence-aware writes** — a worker/ticket carries `catalyst_generation` read from the durable fence projection; a web mutation can pass it to `isFenceCurrent` without a live attachment fetch | **satisfied** — `generation` stamped on BoardWorker + BoardTicket; `deriveGeneration` reads the durable fence projection (via `linear-cache-reader`, BFF11) first, then the phase signal; literal `0` preserved |
| **Single-host is identity** — one node ⇒ every entity resolves to that host with no added latency or chrome | **satisfied** — every entity resolves through the SAME `deriveHost`/`deriveGeneration` path a multi-node fleet would use; no separate cluster branch, no extra I/O beyond the per-entity phase signal already read. No multi-node anchors (BFF2/BOARD3 grouping) built here — single-node-descoped per operator decision; this ticket only produces the per-entity field they consume |

### Tests (run locally — repo CI has no unit-test gate)
- **NEW** `__tests__/board-node-attribution.test.ts` — 13 tests: `deriveHost` (signal/fence precedence, null cases, current-phase walk), `hostRefFromName` (canonical id derivation), `deriveGeneration` (fence/signal precedence, literal 0), single-host identity, `synthesizeQueuedTicket` host/team/generation.
- `__tests__/linear-cache-reader.test.ts` — +2 pure tests (fence-projection surfacing + null defaults) and e2e via `upsertTicketFence` against a real `filter-state.db`.
- `__tests__/read-model.test.ts`, `__tests__/linear.test.ts` — fixtures updated for the new required type fields.

`bun test` (board-node-attribution, linear-cache-reader, linear, read-model, board-todo-column, board-snapshot, board-current-phase, board-phase-summary, board-phase-drift, board-held-indicator, board-data-phase-costs, broker fence) → all green. `bunx tsc --noEmit` clean in orch-monitor; the only ui tsc error is the **pre-existing** `kpi-strip.tsx` / `OrchestratorStats.abandoned` failure on origin/main (proven pre-existing, untouched by this change). `bun run build` in `ui` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)