### PR TITLE
feat(dev): SHELL4 collapse via [ / Cmd+B / rail, persisted (CTL-894)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
@@ -17,6 +17,11 @@ import {
   type Surface,
 } from "@/lib/surface";
 import {
+  readSidebarOpen,
+  writeSidebarOpen,
+  shouldToggleSidebar,
+} from "@/lib/sidebar-collapse";
+import {
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbList,
@@ -52,14 +57,6 @@ import { AppSidebar } from "@/components/app-sidebar";
 // Surface→route wiring is the FND stream's concern; this shell only exposes the
 // SurfaceContext contract the nav binds to.
 
-const SIDEBAR_STORAGE_KEY = "catalyst:sidebar-open";
-
-/** Read persisted sidebar-open state (defaults open). */
-function readSidebarOpen(): boolean {
-  if (typeof window === "undefined") return true;
-  return window.localStorage.getItem(SIDEBAR_STORAGE_KEY) !== "false";
-}
-
 const SURFACE_ICON: Record<Surface, typeof InboxIcon> = {
   home: InboxIcon,
   board: LayoutGridIcon,
@@ -73,9 +70,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const [paletteOpen, setPaletteOpen] = useState(false);
 
   // Persist collapse state across reloads (the controlled provider replaces the
-  // primitive's cookie path; localStorage is the source of truth here).
+  // primitive's cookie path; localStorage is the source of truth here). Logic +
+  // key live in lib/sidebar-collapse.ts so the persistence round-trip is unit-
+  // tested without a DOM (CTL-894 / SHELL4).
   useEffect(() => {
-    window.localStorage.setItem(SIDEBAR_STORAGE_KEY, String(open));
+    writeSidebarOpen(open);
   }, [open]);
 
   // `[` toggles the rail; `g <key>` chords jump surfaces. Both ignore typing.
@@ -84,14 +83,28 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     let chordTimer: ReturnType<typeof setTimeout> | undefined;
 
     const onKey = (e: KeyboardEvent) => {
-      if (isTypingTarget(e.target as HTMLElement | null)) return;
-
-      // `[` — primary collapse toggle (Cmd/Ctrl+B handled by the provider).
-      if (e.key === "[" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      // `[` — primary collapse toggle (Cmd/Ctrl+B is handled by the controlled
+      // provider). shouldToggleSidebar owns the full contract: `[` with no
+      // meta/ctrl/alt AND not while typing — see lib/sidebar-collapse.ts. The
+      // DOM `e.target` is the standard HTMLElement cast (same idiom as the
+      // isTypingTarget callers); the predicate only reads tagName/isContentEditable.
+      if (
+        shouldToggleSidebar({
+          key: e.key,
+          metaKey: e.metaKey,
+          ctrlKey: e.ctrlKey,
+          altKey: e.altKey,
+          target: e.target as HTMLElement | null,
+        })
+      ) {
         e.preventDefault();
         setOpen((o) => !o);
         return;
       }
+
+      // The `g`-chord path must not steal typing either (separate concern from
+      // the `[` binding above).
+      if (isTypingTarget(e.target as HTMLElement | null)) return;
 
       // `g` arms a chord; the next key picks the surface (g h / g b / g w / g q).
       if (e.key === "g" && !e.metaKey && !e.ctrlKey && !e.altKey) {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
@@ -117,7 +117,13 @@ export function AppSidebar() {
   }
 
   return (
-    <Sidebar variant="inset" collapsible="icon">
+    // CTL-894 / SHELL4 — headline collapse is full↔HIDDEN ("offcanvas"): collapsed
+    // slides the whole rail off-screen so the active surface goes truly full-bleed
+    // and reclaims the ENTIRE nav width (Board gains a full lane; Home re-centers),
+    // per app-shell research §3. The `collapsible="icon"` icon-rail middle state is
+    // an explicit later nicety, not the v1 emphasis; the `group-data-[collapsible=
+    // icon]:…` classes below stay as inert documentation of that optional mode.
+    <Sidebar variant="inset" collapsible="offcanvas">
       {/* ── HEADER: chevron mark + wordmark + ⌘K trigger ────────────────────── */}
       <SidebarHeader className="gap-2">
         <div className="flex items-center gap-2 px-1 pt-1">

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/sidebar-collapse.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/sidebar-collapse.test.ts
@@ -1,0 +1,151 @@
+// sidebar-collapse.test.ts — units for the SHELL4 collapse-interaction core
+// (CTL-894). These encode the ticket's Gherkin acceptance scenarios at the pure
+// logic layer (no DOM), the same way nav-store.test.ts proves the persistence
+// round-trip behind a localStorage shim.
+//
+// `readSidebarOpen` / `writeSidebarOpen` read `window.localStorage` lazily, so —
+// like nav-store.test.ts — we install a minimal in-memory `window.localStorage`
+// under bun (which has no `window`). `shouldToggleSidebar` is pure and needs no
+// shim.
+//
+// Run from the ui package:  `cd ui && bun test src/lib/sidebar-collapse.test.ts`.
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  SIDEBAR_STORAGE_KEY,
+  readSidebarOpen,
+  writeSidebarOpen,
+  shouldToggleSidebar,
+  type SidebarToggleKeyEvent,
+} from "./sidebar-collapse";
+
+class MemStorage {
+  private m = new Map<string, string>();
+  getItem(k: string) {
+    return this.m.has(k) ? this.m.get(k)! : null;
+  }
+  setItem(k: string, v: string) {
+    this.m.set(k, v);
+  }
+  removeItem(k: string) {
+    this.m.delete(k);
+  }
+  clear() {
+    this.m.clear();
+  }
+  key(i: number) {
+    return [...this.m.keys()][i] ?? null;
+  }
+  get length() {
+    return this.m.size;
+  }
+}
+
+function installWindowStorage(): MemStorage {
+  const mem = new MemStorage();
+  (globalThis as unknown as { window: unknown }).window = { localStorage: mem };
+  return mem;
+}
+
+function removeWindow() {
+  delete (globalThis as unknown as { window?: unknown }).window;
+}
+
+// ── shouldToggleSidebar — the `[` binding + "typing is never stolen" guard ─────
+describe("shouldToggleSidebar — `[` toggles the rail, never steals typing", () => {
+  const press = (over: Partial<SidebarToggleKeyEvent>): SidebarToggleKeyEvent => ({
+    key: "[",
+    target: null,
+    ...over,
+  });
+
+  it("Scenario: `[` toggles the rail — a bare `[` outside a field toggles", () => {
+    // Given focus is not in a text input, When I press `[`
+    expect(shouldToggleSidebar(press({}))).toBe(true);
+  });
+
+  it("Scenario: Typing is never stolen — `[` inside an <input> is left alone", () => {
+    expect(shouldToggleSidebar(press({ target: { tagName: "INPUT" } }))).toBe(
+      false,
+    );
+  });
+
+  it("Scenario: Typing is never stolen — `[` inside a <textarea> is left alone", () => {
+    expect(shouldToggleSidebar(press({ target: { tagName: "TEXTAREA" } }))).toBe(
+      false,
+    );
+  });
+
+  it("Scenario: Typing is never stolen — `[` in a contenteditable is left alone", () => {
+    expect(
+      shouldToggleSidebar(
+        press({ target: { tagName: "DIV", isContentEditable: true } }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not fire for a non-`[` key", () => {
+    expect(shouldToggleSidebar(press({ key: "]" }))).toBe(false);
+    expect(shouldToggleSidebar(press({ key: "b" }))).toBe(false);
+  });
+
+  it("ignores `[` with a meta/ctrl/alt modifier (those are not the `[` binding)", () => {
+    expect(shouldToggleSidebar(press({ metaKey: true }))).toBe(false);
+    expect(shouldToggleSidebar(press({ ctrlKey: true }))).toBe(false);
+    expect(shouldToggleSidebar(press({ altKey: true }))).toBe(false);
+  });
+
+  it("still fires for `[` with only shift held (shift does not gate the toggle)", () => {
+    // shift isn't one of the disqualifying modifiers — `[` is a base-row key.
+    expect(shouldToggleSidebar(press({ shiftKey: true }))).toBe(true);
+  });
+});
+
+// ── persistence — the "Collapse state persists across reloads" scenario ────────
+describe("sidebar collapse persistence (survives a reload)", () => {
+  beforeEach(() => {
+    installWindowStorage();
+  });
+  afterEach(() => {
+    removeWindow();
+  });
+
+  it("defaults OPEN when nothing is stored", () => {
+    expect(readSidebarOpen()).toBe(true);
+  });
+
+  it("Scenario: Collapse state persists — collapse writes false, next read is collapsed", () => {
+    // Given I collapsed the rail (open -> false is persisted)…
+    writeSidebarOpen(false);
+    // …When I reload the page (a fresh read) Then the rail is still collapsed.
+    expect(readSidebarOpen()).toBe(false);
+    expect(window.localStorage.getItem(SIDEBAR_STORAGE_KEY)).toBe("false");
+  });
+
+  it("re-expanding persists open again (round-trip both directions)", () => {
+    writeSidebarOpen(false);
+    expect(readSidebarOpen()).toBe(false);
+    writeSidebarOpen(true);
+    expect(readSidebarOpen()).toBe(true);
+    expect(window.localStorage.getItem(SIDEBAR_STORAGE_KEY)).toBe("true");
+  });
+
+  it("only an explicit \"false\" collapses — any other stored value reads open", () => {
+    window.localStorage.setItem(SIDEBAR_STORAGE_KEY, "garbage");
+    expect(readSidebarOpen()).toBe(true);
+  });
+});
+
+// ── SSR / no-window safety — readers/writers must not throw without a DOM ───────
+describe("sidebar collapse — no-window safety", () => {
+  beforeEach(() => {
+    removeWindow();
+  });
+
+  it("readSidebarOpen defaults open with no window", () => {
+    expect(readSidebarOpen()).toBe(true);
+  });
+
+  it("writeSidebarOpen is a no-op (does not throw) with no window", () => {
+    expect(() => writeSidebarOpen(false)).not.toThrow();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/sidebar-collapse.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/sidebar-collapse.ts
@@ -1,0 +1,67 @@
+// sidebar-collapse.ts — the PURE collapse-interaction core for the app shell
+// (CTL-894 / SHELL4).
+//
+// Extracted out of `app-shell.tsx` so the SHELL4 acceptance scenarios — the `[`
+// toggle, the "typing is never stolen" guard, and the localStorage persistence
+// that survives a reload — are unit-testable WITHOUT a DOM, following the same
+// framework-agnostic pattern as surface.ts / board-logic.ts / nav-store.ts.
+//
+// The shell stays a CONTROLLED `SidebarProvider` (it owns `open` + `onOpenChange`)
+// so BOTH `[` (added here) and the primitive's built-in `Cmd/Ctrl+B` drive the same
+// collapse, with no vendoring of the primitive — see the app-shell research doc §3
+// "How `[` coexists with the built-in Cmd/Ctrl+B".
+import { isTypingTarget } from "@/lib/surface";
+
+/**
+ * localStorage key for the persisted open/closed sidebar state. The controlled
+ * provider replaces the primitive's cookie path, so this is the single source of
+ * truth for "stay full-screen across reloads".
+ */
+export const SIDEBAR_STORAGE_KEY = "catalyst:sidebar-open";
+
+/**
+ * Read persisted sidebar-open state. Defaults OPEN — only an explicit stored
+ * `"false"` collapses, so a fresh/cleared store (or SSR with no `window`) renders
+ * expanded. This is what makes the "Collapse state persists" scenario hold: after
+ * a collapse writes `"false"`, the next load reads `false`.
+ */
+export function readSidebarOpen(): boolean {
+  if (typeof window === "undefined") return true;
+  return window.localStorage.getItem(SIDEBAR_STORAGE_KEY) !== "false";
+}
+
+/** Persist the current open/closed state (called whenever `open` changes). */
+export function writeSidebarOpen(open: boolean): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(SIDEBAR_STORAGE_KEY, String(open));
+}
+
+/** The minimal shape of a keydown event the `[`-toggle predicate inspects. */
+export interface SidebarToggleKeyEvent {
+  key: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  shiftKey?: boolean;
+  target?: { tagName?: string; isContentEditable?: boolean } | null;
+}
+
+/**
+ * True when a keydown should toggle the sidebar via the `[` binding.
+ *
+ * Encodes the SHELL4 contract:
+ *  - the key is exactly `[` with NO meta/ctrl/alt modifier (so it never collides
+ *    with shortcuts; `Cmd/Ctrl+B` is the primitive's own, handled separately),
+ *  - focus is NOT a text-entry target (input / textarea / contenteditable) — so
+ *    "typing is never stolen": `[` typed into a field is left alone.
+ *
+ * `Cmd/Ctrl+B` is intentionally NOT handled here — the controlled provider routes
+ * the primitive's built-in shortcut through `onOpenChange`, so both bindings work
+ * with a single source of collapse state.
+ */
+export function shouldToggleSidebar(e: SidebarToggleKeyEvent): boolean {
+  if (e.key !== "[") return false;
+  if (e.metaKey || e.ctrlKey || e.altKey) return false;
+  if (isTypingTarget(e.target ?? null)) return false;
+  return true;
+}


### PR DESCRIPTION
## What & why

Lands the **headline collapse interaction** for the orch-monitor app shell (CTL-894 / SHELL4): operators who live full-screen get a fast, muscle-memory collapse that survives reloads.

SHELL1 (CTL-891) already shipped most of the plumbing — the controlled `SidebarProvider`, the `[` toggle keydown, Cmd/Ctrl+B routing through `onOpenChange`, the `SidebarRail` click, and localStorage persistence. SHELL4 **completes the contract**:

1. **Full ↔ HIDDEN headline collapse.** `AppSidebar` switches from `collapsible="icon"` to `collapsible="offcanvas"`, so collapsing slides the rail fully off-screen and the active surface reclaims the **entire** nav width — truly full-bleed focus mode — per the app-shell research doc §3. The icon-rail middle state stays an explicit later nicety, not the v1 emphasis (the `group-data-[collapsible=icon]:…` classes remain as inert documentation of that optional mode).
2. **Extracted, tested collapse core.** The persistence + keybinding logic moves out of `app-shell.tsx` into a pure, DOM-free `lib/sidebar-collapse.ts` (same pattern as `surface.ts` / `board-logic.ts` / `nav-store.ts`): `readSidebarOpen` / `writeSidebarOpen` (the `SIDEBAR_STORAGE_KEY` round-trip) and `shouldToggleSidebar` (the `[`-with-no-modifier + not-while-typing predicate). `app-shell.tsx` consumes them — behavior-preserving, now unit-tested.

## Gherkin scenarios

| Scenario | Status |
|---|---|
| `` `[` `` toggles the rail | ✅ satisfied — `shouldToggleSidebar` + `setOpen((o) => !o)` |
| Cmd/Ctrl+B still works (fires through the controlled `onOpenChange`) | ✅ satisfied — controlled provider routes the primitive's built-in shortcut; unchanged from SHELL1 |
| Clicking the rail collapses | ✅ satisfied — `<SidebarRail />` calls `toggleSidebar`; unchanged |
| Typing is never stolen (input / textarea / contenteditable) | ✅ satisfied — `isTypingTarget` guard, now inside the tested predicate |
| Collapse state persists across reloads | ✅ satisfied — localStorage round-trip, unit-tested |
| Collapsed gives the surface the reclaimed width (truly full-bleed) | ✅ satisfied — **this was NOT satisfied under `collapsible="icon"`**; fixed by the `offcanvas` switch |

**Single-node descope:** none applicable — SHELL4 is a pure client-side AppShell interaction with no cluster/fence/multi-host surface.

## Tests

- `src/lib/sidebar-collapse.test.ts` — **13 new units** encoding the Gherkin at the pure-logic layer (the `[` predicate incl. modifier/typing guards, the persistence round-trip "survives a reload", and no-window/SSR safety).
- Full `bun test` in the ui package: **20/20 pass** (13 new + 7 existing).
- `bunx tsc --noEmit`: clean for `orch-monitor/ui` (the single remaining error is the **pre-existing** `kpi-strip.tsx` `OrchestratorStats.abandoned` error present on `main`, unrelated to this diff).
- `bun run build` succeeds.

Built artifacts under `public/` are intentionally **not** committed (SHELL1 committed source only; the deploy pipeline rebuilds them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)