### PR TITLE
feat(dev): SHELL3 OPERATE/OBSERVE nav IA + brand + footer (CTL-893)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/app-shell-ia.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/app-shell-ia.test.ts
@@ -1,0 +1,219 @@
+// app-shell-ia.test.ts — CTL-893 / SHELL3 acceptance guards.
+//
+// Encodes the four SHELL3 Gherkin scenarios (OPERATE/OBSERVE two-tier nav IA,
+// the chevron brand mark + collapsing wordmark, and the footer theme toggle).
+// `bun test` has no DOM, so — matching app-shell.test.ts (CTL-891) — the
+// structural scenarios are asserted by static source analysis (read the .tsx as
+// text and assert the load-bearing wiring) and the pure theme core (lib/theme.ts)
+// is unit-tested directly.
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  THEMES,
+  THEME_LABEL,
+  THEME_STORAGE_KEY,
+  DEFAULT_THEME,
+  nextTheme,
+  readStoredTheme,
+  applyTheme,
+  type Theme,
+} from "../ui/src/lib/theme";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const UI_SRC = join(HERE, "..", "ui", "src");
+const REPO_ROOT = join(HERE, "..", "..", "..", "..", "..");
+const read = (rel: string) => readFileSync(join(UI_SRC, rel), "utf8");
+
+const sidebarSrc = read("components/app-sidebar.tsx");
+const logoSrc = read("components/catalyst-logo.tsx");
+const cssSrc = read("app.css");
+const markSvg = readFileSync(
+  join(REPO_ROOT, "assets", "brand-v2", "mark.svg"),
+  "utf8",
+);
+
+/** Strip JS/JSX comments so CLASSNAME / token assertions can't be tripped by prose. */
+function stripComments(src: string): string {
+  return src
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+const sidebarCode = stripComments(sidebarSrc);
+
+// ── Scenario: OPERATE is the always-visible primary tier ─────────────────────
+describe("OPERATE is the always-visible primary tier (CTL-893)", () => {
+  it("the OPERATE group lists Home, Board, Workers, Queue in nav order", () => {
+    const operateBlock = sidebarSrc.slice(
+      sidebarSrc.indexOf("const OPERATE"),
+      sidebarSrc.indexOf("const OBSERVE"),
+    );
+    const order = ["Home", "Board", "Workers", "Queue"].map((l) =>
+      operateBlock.indexOf(`"${l}"`),
+    );
+    for (const i of order) expect(i).toBeGreaterThan(-1);
+    // strictly increasing — declared in nav order
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+    expect(sidebarCode).toMatch(/Operate/);
+  });
+
+  it("OPERATE is a plain (always-expanded) SidebarGroup, NOT wrapped in a Collapsible", () => {
+    // The OPERATE group must render outside any Collapsible — only OBSERVE collapses.
+    const operateGroupIdx = sidebarSrc.indexOf("Operate</SidebarGroupLabel>");
+    const firstCollapsibleIdx = sidebarSrc.indexOf("<Collapsible");
+    expect(operateGroupIdx).toBeGreaterThan(-1);
+    expect(firstCollapsibleIdx).toBeGreaterThan(-1);
+    // OPERATE's label appears BEFORE the first <Collapsible> (OBSERVE) in source.
+    expect(operateGroupIdx).toBeLessThan(firstCollapsibleIdx);
+  });
+
+  it("Board is a first-class top-tier OPERATE item, not buried under OBSERVE", () => {
+    const operateBlock = sidebarSrc.slice(
+      sidebarSrc.indexOf("const OPERATE"),
+      sidebarSrc.indexOf("const OBSERVE"),
+    );
+    const observeBlock = sidebarSrc.slice(sidebarSrc.indexOf("const OBSERVE"));
+    expect(operateBlock).toContain('"Board"');
+    expect(observeBlock).not.toContain('"Board"');
+  });
+});
+
+// ── Scenario: OBSERVE is a recessed collapsible go-deeper tier ───────────────
+describe("OBSERVE is a recessed collapsible go-deeper tier (CTL-893)", () => {
+  it("OBSERVE lists Telemetry, Utilization, FinOps, Fleet Ops", () => {
+    const observeBlock = sidebarSrc.slice(
+      sidebarSrc.indexOf("const OBSERVE"),
+      sidebarSrc.indexOf("function ", sidebarSrc.indexOf("const OBSERVE")),
+    );
+    for (const label of ["Telemetry", "Utilization", "FinOps", "Fleet Ops"]) {
+      expect(observeBlock).toContain(`"${label}"`);
+    }
+  });
+
+  it("OBSERVE renders inside a Collapsible whose header is a plain CollapsibleTrigger button", () => {
+    expect(sidebarSrc).toContain("<Collapsible");
+    expect(sidebarSrc).toContain("CollapsibleTrigger");
+    // The base-ui gotcha: the trigger must NOT be a render-prop of SidebarGroupLabel.
+    expect(sidebarSrc).not.toContain("render={<SidebarGroupLabel");
+    expect(sidebarCode).toMatch(/Observe/);
+  });
+
+  it("OBSERVE items are disabled 'soon' placeholders (future routes, no content)", () => {
+    // Each OBSERVE item button is disabled and carries a 'soon' affordance.
+    const observeRender = sidebarSrc.slice(sidebarSrc.indexOf("OBSERVE.map"));
+    expect(observeRender).toContain("disabled");
+    expect(observeRender.toLowerCase()).toContain("soon");
+  });
+
+  it("OBSERVE defaults collapsed (the toggle state initialises closed)", () => {
+    // useState(false) → collapsed by default; open is bound to the Collapsible.
+    expect(sidebarSrc).toMatch(/useState\(\s*false\s*\)/);
+    expect(sidebarSrc).toMatch(/open=\{observeOpen\}/);
+  });
+});
+
+// ── Scenario: Brand header collapses gracefully ──────────────────────────────
+describe("brand header collapses gracefully (CTL-893)", () => {
+  it("the brand mark is the inline chevron from assets/brand-v2/mark.svg (inherits currentColor)", () => {
+    // It must be the real inline SVG component, NOT an <img src=favicon>.
+    expect(sidebarSrc).toContain("CatalystLogo");
+    expect(sidebarSrc).toContain("@/components/catalyst-logo");
+    expect(logoSrc).toContain('stroke="currentColor"');
+    // Faithful to the brand mark: both chevron paths are ported.
+    expect(logoSrc).toContain("M 8 44 L 32 20 L 56 44");
+    expect(markSvg).toContain("M 8 44 L 32 20 L 56 44");
+    expect(logoSrc).toContain("M 18 52 L 32 36 L 46 52");
+  });
+
+  it("the header no longer uses the old <img favicon> brand", () => {
+    expect(sidebarCode).not.toContain("favicon.svg");
+  });
+
+  it("the wordmark hides on icon-collapse but the chevron mark stays", () => {
+    // The header renders the chevron mark followed by a "Catalyst" wordmark span
+    // that carries the icon-collapse hide class. Match across whitespace/newlines.
+    const header = sidebarSrc.slice(
+      sidebarSrc.indexOf("<SidebarHeader"),
+      sidebarSrc.indexOf("</SidebarHeader>"),
+    );
+    expect(header).toContain("CatalystLogo");
+    // The wordmark text node, tolerant of the JSX newline before </span>.
+    expect(header).toMatch(/>\s*Catalyst\s*<\/span>/);
+    // …and that wordmark span hides on icon-collapse (the mark does not).
+    expect(header).toContain("group-data-[collapsible=icon]:hidden");
+  });
+
+  it("the footer keeps Settings AND a theme toggle reachable", () => {
+    const footerBlock = sidebarSrc.slice(sidebarSrc.indexOf("SidebarFooter"));
+    expect(footerBlock).toContain("Settings");
+    expect(footerBlock).toContain("useTheme");
+  });
+});
+
+// ── Scenario: Theme toggle flips calm-dark and warm-light ────────────────────
+describe("theme toggle flips calm-dark and warm-light (CTL-893)", () => {
+  it("the footer toggle is wired to the real theme system (useTheme), not re-implemented", () => {
+    expect(sidebarSrc).toContain("useTheme");
+    expect(sidebarSrc).toContain("@/lib/theme");
+    // The hook's toggle is destructured and bound to the footer button's onClick
+    // (renamed `toggle: toggleTheme` to disambiguate from the rail toggle).
+    expect(sidebarSrc).toMatch(/toggle:\s*toggleTheme/);
+    expect(sidebarSrc).toMatch(/onClick=\{toggleTheme\}/);
+  });
+
+  it("declares exactly the two themes calm-dark + warm-light", () => {
+    expect([...THEMES]).toEqual(["dark", "light"]);
+    expect(THEME_LABEL.dark.toLowerCase()).toContain("dark");
+    expect(THEME_LABEL.light.toLowerCase()).toContain("light");
+  });
+
+  it("defaults to calm-dark and reads a stored preference, ignoring junk", () => {
+    expect(DEFAULT_THEME).toBe("dark");
+    expect(readStoredTheme(null)).toBe("dark");
+    expect(readStoredTheme({ getItem: () => null })).toBe("dark");
+    expect(readStoredTheme({ getItem: () => "light" })).toBe("light");
+    expect(readStoredTheme({ getItem: () => "dark" })).toBe("dark");
+    expect(readStoredTheme({ getItem: () => "neon" })).toBe("dark");
+    expect(THEME_STORAGE_KEY).toBe("catalyst:theme");
+  });
+
+  it("nextTheme is a pure two-state flip", () => {
+    expect(nextTheme("dark")).toBe("light");
+    expect(nextTheme("light")).toBe("dark");
+  });
+
+  it("applyTheme adds `dark` for calm-dark and removes it for warm-light", () => {
+    const added: string[] = [];
+    const removed: string[] = [];
+    const root = {
+      classList: {
+        add: (c: string) => added.push(c),
+        remove: (c: string) => removed.push(c),
+      },
+    };
+    applyTheme("dark", root);
+    applyTheme("light", root);
+    expect(added).toContain("dark");
+    expect(removed).toContain("dark");
+    // no-op when there is no root (SSR / no DOM)
+    expect(() => applyTheme("dark", null)).not.toThrow();
+  });
+
+  it("app.css ships a warm-light token block that the toggle reveals when `dark` is absent", () => {
+    // The light theme must actually exist in CSS — a `.dark` override block plus
+    // light `:root` defaults — so removing `dark` from <html> visibly switches.
+    expect(cssSrc).toContain(".dark");
+    // The light defaults differ from the dark surface (proves a real second theme).
+    expect(cssSrc).toMatch(/warm-light|light theme|CTL-893/i);
+  });
+});
+
+// Sanity: every theme has a label.
+describe("theme metadata is exhaustive (CTL-893)", () => {
+  it("every theme is labelled", () => {
+    for (const t of THEMES) expect(THEME_LABEL[t as Theme]).toBeTruthy();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/index.html
+++ b/plugins/dev/scripts/orch-monitor/ui/index.html
@@ -1,12 +1,17 @@
 <!doctype html>
-<html lang="en">
+<!-- CTL-893 / SHELL3: boot calm-dark (matches board.html) so the app's default
+     theme is dark before lib/theme.ts mounts — avoids a warm-light flash now
+     that `:root` is the light theme and `.dark` is calm-dark. -->
+<html lang="en" class="dark">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Catalyst Monitor</title>
     <link rel="icon" type="image/svg+xml" href="/public/favicon.svg" />
   </head>
-  <body class="bg-[#0b0d10] text-[#e6e9ef] antialiased">
+  <!-- Use the semantic theme tokens (not hard-coded dark hex) so the body tracks
+       the active theme when the footer toggle flips calm-dark ⇄ warm-light. -->
+  <body class="bg-background text-foreground antialiased">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/plugins/dev/scripts/orch-monitor/ui/src/app.css
+++ b/plugins/dev/scripts/orch-monitor/ui/src/app.css
@@ -57,8 +57,58 @@
 /* shadcn/ui semantic tokens mapped to orch-monitor surface system.
    shadcn treats muted/accent as background-role tokens; our muted/accent
    tokens remain unchanged and continue to resolve text color utilities
-   (text-muted, text-accent) through the @theme inline block above. */
+   (text-muted, text-accent) through the @theme inline block above.
+
+   CTL-893 / SHELL3 — two themes now exist. `:root` is the WARM-LIGHT theme
+   (the default the footer toggle reveals when the `dark` class is absent); the
+   `.dark` block below restores the original CALM-DARK surfaces. The app still
+   boots calm-dark — board.html ships `class="dark"` and lib/theme.ts defaults to
+   applying `dark` — so this adds the light theme WITHOUT regressing the dark
+   default. Removing `dark` from <html> (the toggle) switches to warm light. */
 :root {
+  /* Warm-light surfaces — a paper-warm neutral ramp, not pure white, so the
+     light theme reads "warm" rather than clinical. */
+  --color-light-surface-0: #faf7f2;
+  --color-light-surface-1: #f3efe7;
+  --color-light-surface-2: #ece7dd;
+  --color-light-surface-3: #e3ddd1;
+  --color-light-surface-4: #d8d1c2;
+  --color-light-border: #ddd5c7;
+  --color-light-fg: #2b2722;
+  --color-light-muted: #76705f;
+  --color-light-accent: #1f6feb;
+
+  --background: var(--color-light-surface-0);
+  --foreground: var(--color-light-fg);
+  --card: var(--color-light-surface-1);
+  --card-foreground: var(--color-light-fg);
+  --popover: var(--color-light-surface-1);
+  --popover-foreground: var(--color-light-fg);
+  --primary: var(--color-light-accent);
+  --primary-foreground: #ffffff;
+  --secondary: var(--color-light-surface-3);
+  --secondary-foreground: var(--color-light-fg);
+  --muted-foreground: var(--color-light-muted);
+  --accent-foreground: var(--color-light-fg);
+  --destructive: var(--color-red);
+  --input: var(--color-light-border);
+  --ring: var(--color-light-accent);
+  --radius: 0.5rem;
+
+  --sidebar: var(--color-light-surface-1);
+  --sidebar-foreground: var(--color-light-fg);
+  --sidebar-primary: var(--color-light-accent);
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: var(--color-light-surface-3);
+  --sidebar-accent-foreground: var(--color-light-fg);
+  --sidebar-border: var(--color-light-border);
+  --sidebar-ring: var(--color-light-accent);
+}
+
+/* CTL-893 / SHELL3 — the CALM-DARK theme (the boot default). These are the
+   exact dark mappings that previously lived on `:root` (CTL-891 / SHELL1),
+   now scoped to `.dark` so the toggle can flip between the two themes. */
+.dark {
   --background: var(--color-surface-0);
   --foreground: var(--color-fg);
   --card: var(--color-surface-1);
@@ -74,7 +124,6 @@
   --destructive: var(--color-red);
   --input: var(--color-border);
   --ring: var(--color-accent);
-  --radius: 0.5rem;
 
   /* CTL-891 / SHELL1: sidebar surface — the rail sits one step up from the
      base surface so the SidebarInset (background) reads as a raised card. */

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
@@ -6,15 +6,19 @@ import {
   InboxIcon,
   LayoutGridIcon,
   ListOrderedIcon,
+  MoonIcon,
   SearchIcon,
   ServerIcon,
   SettingsIcon,
+  SunIcon,
   UsersIcon,
   WalletIcon,
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { useSurface, type Surface } from "@/lib/surface";
+import { useTheme } from "@/lib/theme";
+import { CatalystLogo } from "@/components/catalyst-logo";
 import {
   Collapsible,
   CollapsibleContent,
@@ -47,7 +51,14 @@ import {
 // mock/placeholder badges"). Wire to the unified event log
 // (~/catalyst/events/YYYY-MM.jsonl) the HUD already reads in a later SHELL
 // ticket — that same stream feeds worker count, queue depth, and the Board
-// anomaly dot. The workspace switcher / theme toggle are also later SHELL slots.
+// anomaly dot. The workspace switcher is a later SHELL slot.
+//
+// CTL-893 / SHELL3 — gives the rail its final shape: the brand header now uses
+// the Catalyst chevron mark (`CatalystLogo`, ported from `assets/brand-v2/
+// mark.svg`, inherits currentColor so it recolors per theme) with a wordmark
+// that hides on icon-collapse, and the footer gains a real calm-dark ⇄ warm-light
+// theme toggle wired to `@/lib/theme`'s `useTheme()` next to Settings + the
+// (still MOCK) daemon-health dot.
 
 // ── OPERATE nav — the touch-it-every-minute tier ─────────────────────────────
 type OperateItem = {
@@ -97,6 +108,7 @@ function StatusDot({ kind }: { kind: "live" | "anomaly" }) {
 export function AppSidebar() {
   const { surface, setSurface } = useSurface();
   const { setOpenMobile, isMobile } = useSidebar();
+  const { theme, toggle: toggleTheme } = useTheme();
   const [observeOpen, setObserveOpen] = useState(false);
 
   function go(s: Surface) {
@@ -106,14 +118,14 @@ export function AppSidebar() {
 
   return (
     <Sidebar variant="inset" collapsible="icon">
-      {/* ── HEADER: logo + ⌘K trigger ───────────────────────────────────────── */}
+      {/* ── HEADER: chevron mark + wordmark + ⌘K trigger ────────────────────── */}
       <SidebarHeader className="gap-2">
         <div className="flex items-center gap-2 px-1 pt-1">
-          <img
-            src="/public/favicon.svg"
-            alt="Catalyst"
-            className="size-[22px] shrink-0 group-data-[collapsible=icon]:size-5"
-          />
+          {/* The chevron mark stays at every collapse width; only the wordmark
+              hides on icon-collapse (Gherkin: "only the Catalyst chevron mark
+              remains"). currentColor → it recolors with the calm-dark/warm-light
+              theme for free. */}
+          <CatalystLogo className="size-[22px] text-foreground group-data-[collapsible=icon]:size-5" />
           <span className="text-sm font-medium tracking-tight group-data-[collapsible=icon]:hidden">
             Catalyst
           </span>
@@ -213,7 +225,7 @@ export function AppSidebar() {
         </Collapsible>
       </SidebarContent>
 
-      {/* ── FOOTER: settings + daemon-health dot ────────────────────────────── */}
+      {/* ── FOOTER: settings + theme toggle + daemon-health dot ─────────────── */}
       <SidebarFooter>
         <SidebarMenu>
           <SidebarMenuItem>
@@ -240,6 +252,25 @@ export function AppSidebar() {
                 <TooltipContent side="right">Daemon healthy</TooltipContent>
               </Tooltip>
             </SidebarMenuBadge>
+          </SidebarMenuItem>
+
+          {/* CTL-893 / SHELL3 — calm-dark ⇄ warm-light theme toggle. Stays
+              reachable at every collapse width (the icon is always shown; the
+              label hides on icon-collapse like every other SidebarMenuButton).
+              Wired to the real theme system (`useTheme`), not re-implemented. */}
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              onClick={toggleTheme}
+              tooltip={
+                theme === "dark" ? "Switch to warm light" : "Switch to calm dark"
+              }
+              aria-label={
+                theme === "dark" ? "Switch to warm light" : "Switch to calm dark"
+              }
+            >
+              {theme === "dark" ? <SunIcon /> : <MoonIcon />}
+              <span>{theme === "dark" ? "Warm light" : "Calm dark"}</span>
+            </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarFooter>

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/catalyst-logo.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/catalyst-logo.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/utils";
+
+// catalyst-logo.tsx — the Catalyst chevron brand mark (CTL-893 / SHELL3).
+//
+// Ported from the prototype `mockups/home-proto/src/components/CatalystLogo.tsx`
+// and kept byte-faithful to `assets/brand-v2/mark.svg`: an inline SVG (NOT an
+// <img>) so the chevron `stroke="currentColor"` inherits the surrounding text
+// color and recolors for free across the calm-dark / warm-light themes — an
+// <img src=…svg> can't pick up `currentColor`. The wordmark lives next to it in
+// the SidebarHeader and is what hides on icon-collapse; this mark stays.
+
+/** The double-chevron Catalyst mark. Inherits `currentColor` → themes. */
+export function CatalystLogo({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 64 64"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={6}
+      strokeLinecap="square"
+      strokeLinejoin="miter"
+      role="img"
+      aria-label="Catalyst"
+      className={cn("shrink-0", className)}
+    >
+      <title>Catalyst</title>
+      <path d="M 8 44 L 32 20 L 56 44" />
+      <path d="M 18 52 L 32 36 L 46 52" strokeWidth={4} opacity={0.75} />
+    </svg>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/theme.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/theme.ts
@@ -1,0 +1,119 @@
+// theme.ts — the calm-dark / warm-light theme core (CTL-893 / SHELL3).
+//
+// The prototype's footer theme toggle referenced `@/lib/theme` `useTheme()`, but
+// the real orch-monitor app had no JS theme system — it only hard-coded
+// `class="dark"` on <html> (board.html). This module is that theme system: the
+// PURE, framework-agnostic core (the theme union, the persistence key, the
+// localStorage read, the next-theme flip, and the `documentElement` class apply)
+// plus a thin React `useTheme()` hook that the SidebarFooter toggle binds to.
+//
+// Calm-dark is the default (board.html / index.html still ship `class="dark"`,
+// and an absent stored preference resolves to dark). Flipping the toggle
+// adds/removes the `dark` class on <html>; the warm-light token block in app.css
+// takes over when `dark` is absent. Kept React-free in its core so the contract
+// is unit-testable without a DOM (the same pattern lib/surface.ts follows).
+//
+// Type note: the pure core uses STRUCTURAL types (the minimal `{ getItem }` /
+// `{ classList: { add, remove } }` shapes) rather than the DOM globals `Storage`
+// / `DOMTokenList`, so this module type-checks even where the importing package's
+// tsconfig has no `dom` lib (the orch-monitor test package imports the pure
+// functions). The hook reaches `window`/`document` through a typed `globalThis`
+// view for the same reason.
+import { useCallback, useEffect, useState } from "react";
+
+/** The two themes the footer toggle flips between. */
+export type Theme = "dark" | "light";
+
+/** Every theme — the single source the toggle + tests iterate. */
+export const THEMES: readonly Theme[] = ["dark", "light"] as const;
+
+/** Human label per theme (toggle aria-label / tooltip). */
+export const THEME_LABEL: Record<Theme, string> = {
+  dark: "Calm dark",
+  light: "Warm light",
+};
+
+/** localStorage key the resolved preference persists under (survives reloads). */
+export const THEME_STORAGE_KEY = "catalyst:theme";
+
+/** The default theme when no preference is stored — calm-dark. */
+export const DEFAULT_THEME: Theme = "dark";
+
+/** The other theme — a pure two-state flip (dark ↔ light). */
+export function nextTheme(theme: Theme): Theme {
+  return theme === "dark" ? "light" : "dark";
+}
+
+/** The minimal storage shape `readStoredTheme` needs (a `window.localStorage`). */
+interface ThemeStorage {
+  getItem(key: string): string | null;
+}
+
+/** The minimal class-list shape `applyTheme` needs (`element.classList`). */
+interface ThemeClassList {
+  add(token: string): void;
+  remove(token: string): void;
+}
+
+/**
+ * Read the persisted theme, defaulting to calm-dark. Pure over an injected
+ * storage so it unit-tests without a real `window` (bun has none); the React
+ * hook below passes `window.localStorage`.
+ */
+export function readStoredTheme(storage: ThemeStorage | null): Theme {
+  if (!storage) return DEFAULT_THEME;
+  const raw = storage.getItem(THEME_STORAGE_KEY);
+  return raw === "light" || raw === "dark" ? raw : DEFAULT_THEME;
+}
+
+/**
+ * Apply a theme to the document root: dark adds `class="dark"` (Tailwind's dark
+ * variant + the dark token block), light removes it (the warm-light `:root`
+ * block in app.css takes over). Pure over an injected class-list so it unit-tests
+ * with a minimal `{ add, remove }` shape rather than a real DOM node.
+ */
+export function applyTheme(
+  theme: Theme,
+  root: { classList: ThemeClassList } | null,
+): void {
+  if (!root) return;
+  if (theme === "dark") root.classList.add("dark");
+  else root.classList.remove("dark");
+}
+
+/** A typed view of the browser globals the hook needs (avoids the dom lib). */
+interface BrowserGlobals {
+  window?: { localStorage: ThemeStorage & { setItem(k: string, v: string): void } };
+  document?: { documentElement: { classList: ThemeClassList } };
+}
+
+function browser(): BrowserGlobals {
+  return globalThis as unknown as BrowserGlobals;
+}
+
+/**
+ * React hook the footer toggle binds to. Resolves the stored preference on
+ * mount, keeps `<html>` in sync, and persists every change. `toggle()` flips
+ * calm-dark ⇄ warm-light.
+ */
+export function useTheme(): {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+  toggle: () => void;
+} {
+  const [theme, setThemeState] = useState<Theme>(() =>
+    readStoredTheme(browser().window?.localStorage ?? null),
+  );
+
+  // Keep <html> and localStorage in sync with the resolved theme.
+  useEffect(() => {
+    const { window: win, document: doc } = browser();
+    if (doc) applyTheme(theme, doc.documentElement);
+    if (win) win.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  }, [theme]);
+
+  const setTheme = useCallback((t: Theme) => setThemeState(t), []);
+  const toggle = useCallback(() => setThemeState((t) => nextTheme(t)), []);
+
+  return { theme, setTheme, toggle };
+}


### PR DESCRIPTION
## SHELL3 — operators read the nav as a deliberate two-tier IA (CTL-893)

Lands the rail's **final shape** on top of SHELL1's (CTL-891) app-shell frame: the chevron brand mark + collapsing wordmark, and a real calm-dark ⇄ warm-light footer theme toggle. The OPERATE/OBSERVE information architecture itself already shipped in SHELL1 and is preserved unchanged here (and now guarded by acceptance tests).

### What changed
- **Brand mark** — new `ui/src/components/catalyst-logo.tsx` renders the inline double-chevron from `assets/brand-v2/mark.svg` (`stroke="currentColor"`, so it recolors per theme). The `SidebarHeader` keeps the "Catalyst" wordmark that hides on icon-collapse while the chevron stays. Replaces the old `<img favicon>` brand.
- **Theme system** — new `ui/src/lib/theme.ts` IS the app's theme system (the prototype referenced `@/lib/theme` `useTheme()` but the real app had none — it only hard-coded `class="dark"`). A pure, DOM-free core (`THEMES`, `nextTheme`, `readStoredTheme`, `applyTheme`) plus a `useTheme()` hook that flips the `dark` class on `<html>` and persists to `localStorage`. Calm-dark is the default.
- **Footer theme toggle** — `app-sidebar.tsx` footer now has a calm-dark ⇄ warm-light toggle next to Settings + the (still MOCK) daemon-health dot, wired to `useTheme()`.
- **Two themes in CSS** — `app.css` `:root` is now **warm-light** (a paper-warm neutral ramp); the new `.dark` block restores the original SHELL1 **calm-dark** surfaces. `index.html` boots `class="dark"` (matching `board.html`) and uses semantic `bg-background`/`text-foreground` so the body tracks the active theme — dark stays the boot default, no warm-light flash.

### Gherkin scenarios
| Scenario | Status |
|---|---|
| **OPERATE is the always-visible primary tier** (Home/Board/Workers/Queue always expanded; Board first-class, not under OBSERVE) | ✅ satisfied (landed SHELL1, now test-guarded by SHELL3) |
| **OBSERVE is a recessed collapsible go-deeper tier** (labeled collapsible header; Telemetry/Utilization/FinOps/Fleet Ops disabled "soon"; defaults collapsed) | ✅ satisfied (landed SHELL1, now test-guarded by SHELL3) |
| **Brand header collapses gracefully** (only the chevron mark remains on icon-collapse; footer Settings + theme toggle stay reachable) | ✅ satisfied (new CatalystLogo + footer toggle) |
| **Theme toggle flips calm-dark and warm-light** (clicking the footer toggle switches themes) | ✅ satisfied (new theme.ts + `.dark`/warm-light CSS blocks) |

**Single-node MVP descope:** N/A — this is a nav/brand/theme ticket with no cluster/fence/multi-host/motion behavior. Nothing descoped.

### Tests
- New `plugins/dev/scripts/orch-monitor/__tests__/app-shell-ia.test.ts` encodes all four scenarios (static-source-analysis of the `.tsx` wiring + pure units for the theme core), mirroring SHELL1's `app-shell.test.ts` pattern. **18 pass.**
- SHELL1's `app-shell.test.ts` still green (**14 pass**) — no regression.
- `bunx tsc --noEmit` clean for **ui** (only the pre-existing unrelated `kpi-strip.tsx` error remains) and the **main orch-monitor** package (0 errors).
- `bun run build` (ui) succeeds. Build artifacts under `public/` are intentionally NOT committed (deploy rebuilds them; SHELL1 followed the same convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)