### PR TITLE
feat(dev): HOME1 calm master-detail Inbox home (CTL-899)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/home-inbox.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-inbox.test.ts
@@ -1,0 +1,268 @@
+// home-inbox.test.ts — units for the calm Inbox home's PURE core (CTL-899 /
+// HOME1): the grouping, the flat j/k walk order, the default selection, and the
+// calm one-sentence header. Encodes the CTL-899 Gherkin against the React-free
+// module ui/src/board/home-inbox.ts (same pattern as list-order.test.ts /
+// route-search.test.ts — no React/jotai/router runtime needed).
+//
+// The load-bearing acceptance criteria these lock in:
+//   • "Selecting a row updates the reading pane … top item selected by default"
+//     → defaultSelectedId is the head of the flat walk order, and moveSelection
+//       walks j/k over that exact order.
+//   • "a single calm header sentence summarizing running / needs-you counts"
+//     → calmHeaderSentence is ONE sentence (never a KPI grid).
+//   • "Inbox data comes from the read-model, never a live Linear call"
+//     → deriveInbox takes a BoardPayload and reads only `held` off it (the broker
+//       already folded filter-state.db labels into BoardTicket.held); no import
+//       of any Linear/network module is even possible from this pure file.
+import { describe, it, expect } from "bun:test";
+import {
+  deriveInbox,
+  classifyTicket,
+  calmHeaderSentence,
+  moveSelection,
+  rowById,
+  isNeedsYouSection,
+  type InboxRow,
+} from "../ui/src/board/home-inbox";
+import type { BoardPayload, BoardTicket } from "../ui/src/board/types";
+
+// ── minimal fixtures (only the fields the inbox derivation reads) ───────────
+function mkTicket(id: string, over: Partial<BoardTicket> = {}): BoardTicket {
+  return {
+    id,
+    title: `${id} title`,
+    type: "feature",
+    repo: "catalyst",
+    team: "CTL",
+    phase: "implement",
+    status: "active",
+    model: null,
+    linearState: "Implement",
+    workerStatus: null,
+    activeState: "active",
+    working: true,
+    lastActiveMs: null,
+    priority: 2,
+    estimate: null,
+    scope: null,
+    project: null,
+    costUSD: null,
+    tokens: null,
+    turns: null,
+    phaseCosts: null,
+    phaseSummary: [],
+    pr: null,
+    updatedAt: "",
+    held: null,
+    blockers: [],
+    ...over,
+  };
+}
+
+function mkPayload(tickets: BoardTicket[]): BoardPayload {
+  return {
+    generatedAt: "2026-06-09T00:00:00Z",
+    config: { maxParallel: 0, inFlight: 0, freeSlots: 0, active: 0, working: 0, stuck: 0 },
+    repos: ["catalyst"],
+    workers: [],
+    tickets,
+    queue: [],
+  };
+}
+
+describe("classifyTicket — the needs-you split (held → section)", () => {
+  it("a blocked ticket lands in 'blocked' (the needs-you, Unblock case)", () => {
+    expect(classifyTicket(mkTicket("CTL-867", { held: "blocked" }))).toBe("blocked");
+  });
+  it("a waiting ticket lands in 'waiting' (the needs-you, Answer case)", () => {
+    expect(classifyTicket(mkTicket("CTL-642", { held: "waiting" }))).toBe("waiting");
+  });
+  it("an un-held, not-done ticket is the reassurance set 'running'", () => {
+    expect(classifyTicket(mkTicket("CTL-900", { held: null }))).toBe("running");
+  });
+  it("a done ticket is 'done' EVEN with a stale held label", () => {
+    expect(classifyTicket(mkTicket("CTL-880", { status: "done", held: "blocked" }))).toBe("done");
+    expect(classifyTicket(mkTicket("CTL-881", { linearState: "Done", held: "waiting" }))).toBe("done");
+  });
+});
+
+describe("deriveInbox — grouped sections + flat walk order (CTL-899)", () => {
+  // A realistic mixed snapshot: 1 blocked, 1 waiting, 2 running, 1 done.
+  const tickets = [
+    mkTicket("CTL-900", { held: null }), // running
+    mkTicket("CTL-867", { held: "blocked", blockers: ["CTL-866"] }), // needs you
+    mkTicket("CTL-880", { status: "done", linearState: "Done", held: null }), // done
+    mkTicket("CTL-642", { held: "waiting" }), // needs you
+    mkTicket("CTL-901", { held: null }), // running
+  ];
+  const model = deriveInbox(mkPayload(tickets));
+
+  it("renders sections in fixed order blocked → waiting → running → done, dropping empties", () => {
+    expect(model.sections.map((s) => s.kind)).toEqual(["blocked", "waiting", "running", "done"]);
+  });
+
+  it("drops a section that has no rows (the page only shows what exists)", () => {
+    const m = deriveInbox(mkPayload([mkTicket("CTL-900", { held: null })]));
+    expect(m.sections.map((s) => s.kind)).toEqual(["running"]);
+  });
+
+  it("the flat walk order is needs-you first, then running, then done", () => {
+    expect(model.order.map((r) => r.id)).toEqual([
+      "CTL-867", // blocked
+      "CTL-642", // waiting
+      "CTL-900", // running (payload order preserved within section)
+      "CTL-901", // running
+      "CTL-880", // done
+    ]);
+  });
+
+  it("preserves the payload's array order WITHIN a section (no re-sort)", () => {
+    const running = model.sections.find((s) => s.kind === "running")!;
+    expect(running.rows.map((r) => r.id)).toEqual(["CTL-900", "CTL-901"]);
+  });
+
+  it("counts blocked/waiting/running/done and the single needsYou figure", () => {
+    expect(model.counts).toEqual({
+      blocked: 1,
+      waiting: 1,
+      running: 2,
+      done: 1,
+      needsYou: 2,
+    });
+  });
+
+  it("the needs-you rows carry an accent section; running/done are neutral", () => {
+    expect(isNeedsYouSection("blocked")).toBe(true);
+    expect(isNeedsYouSection("waiting")).toBe(true);
+    expect(isNeedsYouSection("running")).toBe(false);
+    expect(isNeedsYouSection("done")).toBe(false);
+  });
+
+  it("a blocked row names its blocker ids; other rows carry none", () => {
+    const blocked = model.order.find((r) => r.id === "CTL-867")!;
+    expect(blocked.blockers).toEqual(["CTL-866"]);
+    expect(blocked.verb).toBe("Unblock");
+    const waiting = model.order.find((r) => r.id === "CTL-642")!;
+    expect(waiting.blockers).toEqual([]);
+    expect(waiting.verb).toBe("Answer");
+    const running = model.order.find((r) => r.id === "CTL-900")!;
+    expect(running.verb).toBeNull();
+  });
+
+  it("does not mutate the payload's ticket array", () => {
+    const ids = tickets.map((t) => t.id);
+    deriveInbox(mkPayload(tickets));
+    expect(tickets.map((t) => t.id)).toEqual(ids);
+  });
+});
+
+describe("deriveInbox — default selection (top item selected on load)", () => {
+  it("default-selects the most-urgent needs-you row when any exists", () => {
+    const m = deriveInbox(
+      mkPayload([
+        mkTicket("CTL-900", { held: null }),
+        mkTicket("CTL-867", { held: "blocked" }),
+      ]),
+    );
+    // blocked sorts ahead of running, so the head of the walk order is CTL-867.
+    expect(m.defaultSelectedId).toBe("CTL-867");
+    expect(m.order[0].id).toBe("CTL-867");
+  });
+
+  it("falls back to the first running row when nothing needs you", () => {
+    const m = deriveInbox(
+      mkPayload([
+        mkTicket("CTL-900", { held: null }),
+        mkTicket("CTL-901", { held: null }),
+      ]),
+    );
+    expect(m.defaultSelectedId).toBe("CTL-900");
+  });
+
+  it("is null on a wholly empty inbox", () => {
+    const m = deriveInbox(mkPayload([]));
+    expect(m.defaultSelectedId).toBeNull();
+    expect(m.order).toEqual([]);
+    expect(m.sections).toEqual([]);
+  });
+});
+
+describe("moveSelection — j / k walk over the flat order (CTL-899)", () => {
+  const order: InboxRow[] = (
+    deriveInbox(
+      mkPayload([
+        mkTicket("CTL-867", { held: "blocked" }),
+        mkTicket("CTL-642", { held: "waiting" }),
+        mkTicket("CTL-900", { held: null }),
+      ]),
+    )
+  ).order;
+
+  it("j (delta +1) moves the selection down the walk order", () => {
+    expect(moveSelection(order, "CTL-867", +1)).toBe("CTL-642");
+    expect(moveSelection(order, "CTL-642", +1)).toBe("CTL-900");
+  });
+
+  it("k (delta -1) moves the selection up the walk order", () => {
+    expect(moveSelection(order, "CTL-900", -1)).toBe("CTL-642");
+    expect(moveSelection(order, "CTL-642", -1)).toBe("CTL-867");
+  });
+
+  it("clamps at the ends (never wraps)", () => {
+    expect(moveSelection(order, "CTL-867", -1)).toBe("CTL-867"); // already top
+    expect(moveSelection(order, "CTL-900", +1)).toBe("CTL-900"); // already bottom
+  });
+
+  it("a null or stale selection resets to the head", () => {
+    expect(moveSelection(order, null, +1)).toBe("CTL-867");
+    expect(moveSelection(order, "CTL-vanished", +1)).toBe("CTL-867");
+  });
+
+  it("returns null on an empty order (never throws)", () => {
+    expect(moveSelection([], "CTL-867", +1)).toBeNull();
+  });
+});
+
+describe("rowById — the reading pane reads the selected row's full ticket", () => {
+  const model = deriveInbox(
+    mkPayload([mkTicket("CTL-867", { held: "blocked", title: "registry creds" })]),
+  );
+  it("returns the row (and its full ticket) for the selected id", () => {
+    const row = rowById(model, "CTL-867");
+    expect(row?.id).toBe("CTL-867");
+    expect(row?.ticket.title).toBe("registry creds");
+  });
+  it("returns null for a cleared / unknown id", () => {
+    expect(rowById(model, null)).toBeNull();
+    expect(rowById(model, "CTL-nope")).toBeNull();
+  });
+});
+
+describe("calmHeaderSentence — ONE sentence, never a KPI grid (CTL-899)", () => {
+  it('reads "N running on their own · M need you · …"', () => {
+    const s = calmHeaderSentence({ blocked: 0, waiting: 2, running: 4, done: 0, needsYou: 2 });
+    expect(s).toBe("4 running on their own · 2 need you · nothing on fire");
+    // It is ONE sentence: no newline, no metric-grid separators.
+    expect(s).not.toContain("\n");
+  });
+
+  it("names the heat when something is genuinely blocked (never lies)", () => {
+    const s = calmHeaderSentence({ blocked: 1, waiting: 0, running: 6, done: 3, needsYou: 1 });
+    expect(s).toBe("6 running on their own · 1 needs you · 1 blocked");
+  });
+
+  it("drops the needs-you clause when nothing needs you", () => {
+    const s = calmHeaderSentence({ blocked: 0, waiting: 0, running: 5, done: 0, needsYou: 0 });
+    expect(s).toBe("5 running on their own · nothing on fire");
+  });
+
+  it("uses singular grammar for one running ticket", () => {
+    const s = calmHeaderSentence({ blocked: 0, waiting: 0, running: 1, done: 0, needsYou: 0 });
+    expect(s).toBe("1 running on its own · nothing on fire");
+  });
+
+  it("collapses to the celebratory empty-state line when the inbox is empty", () => {
+    const s = calmHeaderSentence({ blocked: 0, waiting: 0, running: 0, done: 0, needsYou: 0 });
+    expect(s).toBe("All clear — nothing needs you right now.");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
@@ -1,0 +1,180 @@
+// home-surface.test.ts — CTL-899 / HOME1 acceptance guards for the React tree.
+//
+// The PURE inbox derivation (grouping / walk order / default-select / calm
+// header) is unit-tested in home-inbox.test.ts. `bun test` has no DOM, so — the
+// same way app-shell.test.ts guards SHELL1 — the STRUCTURAL Gherkin scenarios
+// (master-detail split with firm floors, bare rows not cards, j/k wiring,
+// read-model-not-Linear data source, App surface wiring) are asserted by static
+// source analysis: read the .tsx/.ts as text and assert the load-bearing wiring.
+// PLUS the pure split-clamp floor math (clampListWidth) is unit-tested directly.
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  clampListWidth,
+  shouldStack,
+  LIST_FLOOR_PX,
+  READING_FLOOR_PX,
+  STACK_BELOW_PX,
+} from "../ui/src/board/home-split";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const UI_SRC = join(HERE, "..", "ui", "src");
+const read = (rel: string) => readFileSync(join(UI_SRC, rel), "utf8");
+
+const appSrc = read("App.tsx");
+const homeSurfaceSrc = read("components/home/home-surface.tsx");
+const inboxRowSrc = read("components/home/inbox-row.tsx");
+const splitSrc = read("components/home/resizable-split.tsx");
+const useBoardSnapshotSrc = read("hooks/use-board-snapshot.ts");
+
+function stripComments(src: string): string {
+  return src
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+const homeCode = stripComments(homeSurfaceSrc);
+const rowCode = stripComments(inboxRowSrc);
+const appCode = stripComments(appSrc);
+
+// ── Scenario: The split survives an iPad-landscape width (firm floors) ────────
+describe("master-detail split — firm iPad floors (CTL-899)", () => {
+  it("declares list ≥320px and reading ≥360px floors", () => {
+    expect(LIST_FLOOR_PX).toBe(320);
+    expect(READING_FLOOR_PX).toBe(360);
+  });
+
+  it("clampListWidth keeps BOTH floors across the iPad-landscape range (1024–1366)", () => {
+    for (const container of [1024, 1112, 1180, 1280, 1366]) {
+      // A greedy desired width still leaves the reading pane its floor.
+      const wide = clampListWidth(99999, container);
+      expect(wide).toBeLessThanOrEqual(container - READING_FLOOR_PX);
+      expect(container - wide).toBeGreaterThanOrEqual(READING_FLOOR_PX);
+      // A tiny desired width still gives the list its floor.
+      const narrow = clampListWidth(0, container);
+      expect(narrow).toBeGreaterThanOrEqual(LIST_FLOOR_PX);
+      // No split ever exceeds the container (⇒ no horizontal overflow).
+      expect(wide).toBeLessThanOrEqual(container);
+    }
+  });
+
+  it("falls back to the list floor when the container is narrower than both floors", () => {
+    expect(clampListWidth(500, LIST_FLOOR_PX + READING_FLOOR_PX - 10)).toBe(LIST_FLOOR_PX);
+  });
+
+  it("stacks the panes only below the combined floor (portrait), not in landscape", () => {
+    expect(STACK_BELOW_PX).toBe(LIST_FLOOR_PX + READING_FLOOR_PX); // 680
+    expect(shouldStack(0)).toBe(false); // unmeasured container — don't stack yet
+    expect(shouldStack(640)).toBe(true); // below 680 → stack (portrait)
+    for (const landscape of [1024, 1112, 1180, 1280, 1366]) {
+      expect(shouldStack(landscape)).toBe(false); // iPad-landscape stays split
+    }
+  });
+
+  it("the split container is min-w-0 / overflow-hidden so a wide pane never overflows", () => {
+    expect(splitSrc).toContain("min-w-0");
+    expect(splitSrc).toContain("overflow-hidden");
+    expect(splitSrc).toContain("ResizableSplit");
+  });
+});
+
+// ── Scenario: Home renders the calm inbox, not the dense board ────────────────
+describe("calm inbox surface — bare rows, calm header, master-detail (CTL-899)", () => {
+  it("HomeSurface composes the resizable split with a list and a reading pane", () => {
+    expect(homeSurfaceSrc).toContain("ResizableSplit");
+    expect(homeSurfaceSrc).toContain("ReadingPane");
+    expect(homeSurfaceSrc).toMatch(/list=\{/);
+    expect(homeSurfaceSrc).toMatch(/reading=\{/);
+  });
+
+  it("renders ONE calm header sentence (not a KPI grid)", () => {
+    expect(homeSurfaceSrc).toContain("calmHeaderSentence");
+    expect(homeSurfaceSrc).toContain("data-calm-header");
+  });
+
+  it("the inbox row is a flat <button> row, NOT a bordered card", () => {
+    // It IS a button row keyed by the ticket id.
+    expect(inboxRowSrc).toContain("data-inbox-row");
+    // No card-in-card: the row must not use the Card primitive or a boxed border
+    // around itself. (Selection is a subtle surface, not a card outline.)
+    expect(rowCode).not.toContain("components/ui/card");
+    expect(rowCode).not.toMatch(/\bborder\b\s+rounded/); // no boxed card border
+  });
+
+  it("rows are hairline-divided in the list (the list is the container)", () => {
+    expect(homeSurfaceSrc).toMatch(/divide-y/);
+    expect(homeSurfaceSrc).toContain("InboxRow");
+  });
+});
+
+// ── Scenario: Selecting a row updates the reading pane + default-select top ────
+describe("selection — click + j/k drive the one reading pane (CTL-899)", () => {
+  it("default-selects the top item via the derived defaultSelectedId", () => {
+    expect(homeSurfaceSrc).toContain("defaultSelectedId");
+  });
+
+  it("binds j / k to walk the flat order through moveSelection", () => {
+    expect(homeSurfaceSrc).toContain("moveSelection");
+    expect(homeSurfaceSrc).toMatch(/=== "j"/);
+    expect(homeSurfaceSrc).toMatch(/=== "k"/);
+    // j/k must not steal typing — guarded by isTypingTarget (the SHELL contract).
+    expect(homeSurfaceSrc).toContain("isTypingTarget");
+  });
+
+  it("the reading pane is driven by the selected row (rowById)", () => {
+    expect(homeSurfaceSrc).toContain("rowById");
+    expect(homeSurfaceSrc).toMatch(/row=\{selectedRow\}/);
+  });
+});
+
+// ── Scenario: Inbox data comes from the read-model, never a live Linear call ──
+describe("data plane — read-model SSE, never a synchronous Linear call (CTL-899)", () => {
+  it("HomeSurface sources data from the board read-model snapshot hook", () => {
+    expect(homeSurfaceSrc).toContain("useBoardSnapshot");
+    expect(homeSurfaceSrc).toContain("deriveInbox");
+  });
+
+  it("the snapshot hook subscribes via connectBoard (the SSE board transport)", () => {
+    expect(useBoardSnapshotSrc).toContain("connectBoard");
+    expect(useBoardSnapshotSrc).toContain("/board/board-client");
+  });
+
+  it("NO part of the Home tree reaches for Linear / linearis / a per-load fetch", () => {
+    // Strip comments first so the prose that EXPLAINS the no-Linear contract
+    // (the word "linearis" appears in a doc comment) can't false-positive — only
+    // real CODE is checked, mirroring app-shell.test.ts's edge-to-edge guard.
+    for (const src of [homeSurfaceSrc, inboxRowSrc, splitSrc, useBoardSnapshotSrc].map(
+      stripComments,
+    )) {
+      expect(src.toLowerCase()).not.toContain("linearis");
+      expect(src).not.toContain("/api/linear");
+      // The home tree must not open its own fetch/EventSource — it rides the
+      // shared connectBoard transport (which the board already proves).
+      expect(src).not.toMatch(/\bnew EventSource\b/);
+      expect(src).not.toMatch(/\bfetch\(/);
+    }
+  });
+});
+
+// ── Scenario: App wires Home into the shell's "home" surface ──────────────────
+describe("App wiring — Home mounts into the shell home surface (CTL-899)", () => {
+  it("App renders HomeSurface when the active surface is 'home'", () => {
+    expect(appSrc).toContain("HomeSurface");
+    expect(appSrc).toContain("useSurface");
+    expect(appSrc).toMatch(/surface === "home"/);
+  });
+
+  it("keeps the dashboard as the fall-through for the other surfaces (no regression)", () => {
+    // The dashboard body is still present and still mounts the Dashboard.
+    expect(appSrc).toContain("dashboardBody");
+    expect(appSrc).toContain("Dashboard");
+  });
+
+  it("does not introduce a centered gutter on the home path (edge-to-edge)", () => {
+    expect(homeCode).not.toMatch(/\bmx-auto\b/);
+    expect(appCode).not.toMatch(/\bmx-auto\b/);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
@@ -13,6 +13,9 @@ import { useCommsChannels } from "./hooks/use-comms";
 import { AppShell } from "./components/app-shell";
 // CTL-892 / SHELL2: the surface→content map + the dense board, now hosted inside
 // the shared shell instead of its own shell-less board.html page.
+// CTL-899 / HOME1: the same switch also mounts the calm Inbox HOME surface for
+// surface === "home" (before the board check), falling through to the dashboard
+// for every other surface.
 import { useSurface } from "./lib/surface";
 import { surfaceContentKind } from "./lib/surface-content";
 import { AttentionBar } from "./components/attention-bar";
@@ -51,6 +54,14 @@ const GodModeView = lazy(() =>
 // first jumps to the Board surface (g b / nav / ⌘K).
 const Board = lazy(() =>
   import("./board/Board").then((m) => ({ default: m.Board })),
+);
+// CTL-899 / HOME1: the calm master-detail Inbox HOME surface. Lazy so its
+// transport (board snapshot SSE) + master-detail tree only load when the operator
+// is on Home — the dashboard surfaces stay untouched.
+const HomeSurface = lazy(() =>
+  import("./components/home/home-surface").then((m) => ({
+    default: m.HomeSurface,
+  })),
 );
 
 type TopView = "dashboard" | "comms" | "activity" | "god-mode";
@@ -184,10 +195,11 @@ function Monitor() {
     [],
   );
 
-  // CTL-892 / SHELL2: the existing dashboard tree, unchanged. It's the inset
-  // content for every surface EXCEPT "board" (Home/Workers/Queue still render the
-  // dashboard today; they migrate to dense surfaces in later SHELL tickets).
-  const dashboard = (
+  // CTL-892 / SHELL2 + CTL-899 / HOME1: the existing dashboard tree, unchanged.
+  // It's the inset content for every surface EXCEPT "home" (calm Inbox) and
+  // "board" (dense grid); Workers/Queue still fall through to the dashboard today
+  // — they migrate to dense surfaces in later SHELL tickets.
+  const dashboardBody = (
     <div className="flex h-full min-h-0 flex-col bg-surface-0 text-fg">
         {/* Content-level meta row: snapshot timestamp + version. The frame's
             breadcrumb + collapse live in the AppShell top strip now. */}
@@ -275,11 +287,12 @@ function Monitor() {
     // + OPERATE/OBSERVE nav).
     // CTL-892 / SHELL2: the inset content is now surface-aware. When the active
     // surface is "board" the dense <Board /> grid renders full-bleed inside the
-    // SidebarInset (embedded → fills the inset, not the viewport); every other
-    // surface keeps the dashboard. SurfaceSwitch reads SurfaceContext, so it MUST
-    // live inside AppShell (which provides it).
+    // SidebarInset (embedded → fills the inset, not the viewport).
+    // CTL-899 / HOME1: when surface === "home" the inset hosts the calm Inbox
+    // master-detail surface; every other surface keeps the dashboard. SurfaceSwitch
+    // reads SurfaceContext, so it MUST live inside AppShell (which provides it).
     <AppShell>
-      <SurfaceSwitch dashboard={dashboard} />
+      <SurfaceSwitch dashboard={dashboardBody} />
 
       {selectedSession &&
         (() => {
@@ -302,8 +315,18 @@ function Monitor() {
 // re-created on every snapshot tick ("board updates render without a second
 // EventSource per tab"). The board is full-bleed and dense; the dashboard keeps
 // its own (calmer) layout.
+// CTL-899 / HOME1: the same switch mounts the calm Inbox HOME surface for
+// surface === "home" (checked first), then the dense board, then falls through to
+// the dashboard for Workers/Queue (no regression until their own SHELL tickets).
 function SurfaceSwitch({ dashboard }: { dashboard: ReactNode }) {
   const { surface } = useSurface();
+  if (surface === "home") {
+    return (
+      <Suspense fallback={<SkeletonDashboard />}>
+        <HomeSurface />
+      </Suspense>
+    );
+  }
   if (surfaceContentKind(surface) === "board") {
     return (
       <Suspense fallback={<SkeletonDashboard />}>

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/home-inbox.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/home-inbox.ts
@@ -1,0 +1,279 @@
+// home-inbox.ts — THE pure core of the calm master-detail Inbox home (CTL-899 /
+// HOME1). This is the unit-testable spine the React HomeInbox surface renders
+// through: it derives the grouped inbox sections, the flat j/k walk order, the
+// default selection, and the calm one-sentence header — all from ONE resident
+// `BoardPayload` (the cache-backed read-model snapshot, pushed over SSE), never a
+// synchronous Linear call. Same pattern as list-order.ts / route-search.ts: a
+// React-/jotai-/router-free module so the orch-monitor `bun test` suite can unit
+// it directly from outside the `ui/` module graph.
+//
+// WHERE THE "NEEDS YOU" SIGNAL COMES FROM
+// ---------------------------------------
+// Direction A (thoughts/shared/research/2026-06-08-home-page-directions.md) +
+// the handoff (item #3) reshape the home groups into three calm sections:
+//   • "What's blocked"  — held === "blocked" (blocked on a dependency / on you).
+//   • "What's waiting"   — held === "waiting" (deps satisfied, awaiting capacity).
+//   • "Running on its own" — the reassurance set (in-flight, nothing needed).
+// "Blocked" + "Waiting" ARE the needs-you cases. The durable source for that
+// classification is the broker's filter-state.db `ticket_state.labels`, which the
+// board-data layer has ALREADY folded into `BoardTicket.held` (board-data.mjs:
+// heldFor() → board payload). So this module reads `held` off the resident
+// payload and NEVER reaches for Linear — exactly the CTL-899 "Inbox data comes
+// from the read-model, never a live Linear call" Gherkin.
+
+import type { BoardPayload, BoardTicket } from "./types";
+
+/** The kind of inbox section a row belongs to. */
+export type InboxSectionKind = "blocked" | "waiting" | "running" | "done";
+
+/**
+ * Whether a section's rows carry a status accent (the only colored rows on the
+ * calm page — the needs-you set) or render fully neutral (the reassurance +
+ * done sets). Mirrors Direction A's "color reserved for meaning" non-negotiable.
+ */
+export const NEEDS_YOU_SECTIONS: readonly InboxSectionKind[] = [
+  "blocked",
+  "waiting",
+] as const;
+
+/** True when this section is one the operator must act on (blocked | waiting). */
+export function isNeedsYouSection(kind: InboxSectionKind): boolean {
+  return (NEEDS_YOU_SECTIONS as readonly string[]).includes(kind);
+}
+
+/**
+ * One inbox row — a flattened ticket (no nested card). Carries exactly what the
+ * bare row + the (HOME4) reading pane need: the key, the one-line ask (title),
+ * the section it sits in, the muted human sub-label, and the single primary verb.
+ * `ticket` is kept so the reading pane can read the full detail without a second
+ * lookup; the row UI itself only needs the flattened fields.
+ */
+export interface InboxRow {
+  /** The ticket key (e.g. "CTL-642") — monospace, muted, the row's stable id. */
+  id: string;
+  /** The one-line ask — the bright line of the row (the ticket title). */
+  title: string;
+  /** Which section this row belongs to (drives the accent + grouping). */
+  section: InboxSectionKind;
+  /** The muted human sub-label ("blocked on you" / "running on its own" / …). */
+  subLabel: string;
+  /** The single primary verb for the row ("Unblock" / "Answer" / null). */
+  verb: string | null;
+  /** The blocker ids a `blocked` row is waiting on (empty otherwise). */
+  blockers: string[];
+  /** The underlying ticket, for the reading pane (HOME4). */
+  ticket: BoardTicket;
+}
+
+/** A grouped, titled section of the inbox (rendered as a bare list with a
+ *  hairline-divider header — never a card). */
+export interface InboxSection {
+  kind: InboxSectionKind;
+  /** The section heading shown above its rows ("What's blocked", …). */
+  label: string;
+  rows: InboxRow[];
+}
+
+/** The fully-derived inbox view the Home surface renders. */
+export interface InboxModel {
+  /** Sections in fixed render order: blocked → waiting → running → done.
+   *  Empty sections are dropped, so the page only shows what exists. */
+  sections: InboxSection[];
+  /** The flat, cross-section walk order j/k moves through and the pane reads —
+   *  blocked rows first, then waiting, then running, then done. */
+  order: InboxRow[];
+  /** The id selected by default on load: the top of `order` (the most-urgent
+   *  needs-you row when any exists, else the first running row). null on empty. */
+  defaultSelectedId: string | null;
+  /** Section counts, for the calm header sentence + the collapsed-count chips. */
+  counts: InboxCounts;
+}
+
+/** Per-section counts the calm header + section chips read. */
+export interface InboxCounts {
+  blocked: number;
+  waiting: number;
+  running: number;
+  done: number;
+  /** blocked + waiting — the single "N need you" figure in the header. */
+  needsYou: number;
+}
+
+/** Fixed render order of the sections — needs-you first (bright), reassurance
+ *  + done last (neutral, collapsed by default in the UI). */
+const SECTION_ORDER: readonly InboxSectionKind[] = ["blocked", "waiting", "running", "done"] as const;
+
+const SECTION_LABEL: Record<InboxSectionKind, string> = {
+  blocked: "What's blocked",
+  waiting: "What's waiting",
+  running: "Running on its own",
+  done: "Done while you were away",
+};
+
+// The held label values the board payload carries (board-data.mjs heldFor()).
+// Kept in lock-step with HELD_LABEL_BLOCKED / HELD_LABEL_WAITING there.
+const HELD_BLOCKED = "blocked";
+const HELD_WAITING = "waiting";
+
+/** Phase/Linear-state values that mean a ticket is finished — its row belongs in
+ *  "Done while you were away" rather than the running reassurance set. */
+function isDone(t: BoardTicket): boolean {
+  return t.status === "done" || t.linearState === "Done";
+}
+
+/**
+ * Classify ONE ticket into its inbox section. Order matters: a done ticket is
+ * done even if it still carries a stale held label; otherwise blocked/waiting
+ * (the needs-you cases) take precedence over the running reassurance set.
+ */
+export function classifyTicket(t: BoardTicket): InboxSectionKind {
+  if (isDone(t)) return "done";
+  if (t.held === HELD_BLOCKED) return "blocked";
+  if (t.held === HELD_WAITING) return "waiting";
+  return "running";
+}
+
+/** The muted human sub-label per section — plain language, never jargon
+ *  (Direction A: "waiting on your answer", not "phase-blocked needs-human"). */
+function subLabelFor(kind: InboxSectionKind): string {
+  switch (kind) {
+    case "blocked":
+      return "blocked on you";
+    case "waiting":
+      return "waiting on you";
+    case "running":
+      return "running on its own";
+    case "done":
+      return "shipped";
+  }
+}
+
+/** The single primary verb per section — null for the neutral sets (no action). */
+function verbFor(kind: InboxSectionKind): string | null {
+  switch (kind) {
+    case "blocked":
+      return "Unblock";
+    case "waiting":
+      return "Answer";
+    case "running":
+    case "done":
+      return null;
+  }
+}
+
+/** Build the row view-model for one ticket in a given section. */
+function toRow(t: BoardTicket, kind: InboxSectionKind): InboxRow {
+  return {
+    id: t.id,
+    title: t.title,
+    section: kind,
+    subLabel: subLabelFor(kind),
+    verb: verbFor(kind),
+    blockers: kind === "blocked" ? (t.blockers ?? []).filter(Boolean) : [],
+    ticket: t,
+  };
+}
+
+/**
+ * Derive the full inbox view from a resident `BoardPayload`. PURE: never mutates
+ * the payload, never throws on missing fields, and reaches for NO network/Linear
+ * — it reads only the snapshot the SSE read-model already pushed.
+ *
+ * Sections are built in `SECTION_ORDER` and empty ones are dropped (the calm page
+ * shows only what exists). `order` is the flat concatenation of those sections'
+ * rows — the single j/k walk + reading-pane source — and `defaultSelectedId` is
+ * its head (the most-urgent needs-you row, else the first running row, else the
+ * first done row; null when there is nothing at all).
+ */
+export function deriveInbox(payload: BoardPayload): InboxModel {
+  const buckets: Record<InboxSectionKind, InboxRow[]> = {
+    blocked: [],
+    waiting: [],
+    running: [],
+    done: [],
+  };
+
+  // Preserve the payload's array order WITHIN each section (no re-sort) — the
+  // board's own order is the operator's mental order, mirroring list-order.ts.
+  for (const t of payload.tickets) {
+    const kind = classifyTicket(t);
+    buckets[kind].push(toRow(t, kind));
+  }
+
+  const sections: InboxSection[] = SECTION_ORDER.filter(
+    (kind) => buckets[kind].length > 0,
+  ).map((kind) => ({ kind, label: SECTION_LABEL[kind], rows: buckets[kind] }));
+
+  const order: InboxRow[] = sections.flatMap((s) => s.rows);
+
+  const counts: InboxCounts = {
+    blocked: buckets.blocked.length,
+    waiting: buckets.waiting.length,
+    running: buckets.running.length,
+    done: buckets.done.length,
+    needsYou: buckets.blocked.length + buckets.waiting.length,
+  };
+
+  return {
+    sections,
+    order,
+    defaultSelectedId: order.length > 0 ? order[0].id : null,
+    counts,
+  };
+}
+
+/**
+ * The calm "state of things" header — ONE sentence, never a KPI grid (Direction A
+ * non-negotiable #5). Reads e.g.:
+ *   "4 running on their own · 2 need you · nothing on fire"
+ * The "need you" clause is dropped when nothing needs you (so the sentence reads
+ * the reassuring "running on their own · nothing on fire"), and the whole thing
+ * collapses to a celebratory line when the inbox is empty.
+ */
+export function calmHeaderSentence(counts: InboxCounts): string {
+  const parts: string[] = [];
+
+  if (counts.running > 0) {
+    parts.push(`${counts.running} running on ${counts.running === 1 ? "its" : "their"} own`);
+  }
+  if (counts.needsYou > 0) {
+    parts.push(`${counts.needsYou} need${counts.needsYou === 1 ? "s" : ""} you`);
+  }
+
+  // The reassurance tail: "nothing on fire" when nothing is blocked, else name
+  // the heat so the calm sentence never lies about a real blocker.
+  parts.push(counts.blocked > 0 ? `${counts.blocked} blocked` : "nothing on fire");
+
+  // Wholly-empty inbox → the relief payoff, designed as a feature not a fallback.
+  if (counts.running === 0 && counts.needsYou === 0 && counts.done === 0) {
+    return "All clear — nothing needs you right now.";
+  }
+
+  return parts.join(" · ");
+}
+
+/**
+ * Move the j/k selection by `delta` (+1 = j/down, -1 = k/up) over the flat walk
+ * order, clamped to the list ends (never wraps, never throws). Returns the new
+ * selected id; if `currentId` is not in the order (a stale selection after a
+ * snapshot reshuffle) it resets to the head, so the pane is never left pointing
+ * at a vanished row.
+ */
+export function moveSelection(
+  order: readonly InboxRow[],
+  currentId: string | null,
+  delta: number,
+): string | null {
+  if (order.length === 0) return null;
+  const idx = currentId == null ? -1 : order.findIndex((r) => r.id === currentId);
+  if (idx === -1) return order[0].id;
+  const next = Math.min(order.length - 1, Math.max(0, idx + delta));
+  return order[next].id;
+}
+
+/** Find a row by id in a derived inbox (the reading pane reads the selected
+ *  row's full ticket through this). Returns null for an unknown/cleared id. */
+export function rowById(model: InboxModel, id: string | null): InboxRow | null {
+  if (id == null) return null;
+  return model.order.find((r) => r.id === id) ?? null;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/home-split.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/home-split.ts
@@ -1,0 +1,45 @@
+// home-split.ts — the PURE floor math for the Inbox home's master-detail split
+// (CTL-899 / HOME1). Kept React-/DOM-free (the same way list-order.ts / route-
+// search.ts are) so the orch-monitor `bun test` suite can unit the iPad-floor
+// clamp directly from outside the `ui/` DOM module graph — the DOM-touching
+// ResizableSplit component imports these from here, so the floors it enforces and
+// the floors the tests assert are ONE source.
+//
+// The CTL-899 "split survives an iPad-landscape width" Gherkin lives here: the
+// list pane never shrinks below LIST_FLOOR_PX and the reading pane never below
+// READING_FLOOR_PX, and the clamp never lets the split exceed the container
+// width (so there is no horizontal overflow at any viewport).
+
+/** Firm minimum widths (px) — the CTL-899 iPad-landscape floors. */
+export const LIST_FLOOR_PX = 320;
+export const READING_FLOOR_PX = 360;
+
+/** Below this combined width the panes stack vertically instead of being
+ *  crushed below their floors (portrait fallback; landscape stays side-by-side). */
+export const STACK_BELOW_PX = LIST_FLOOR_PX + READING_FLOOR_PX;
+
+/** The default list-pane width on first load (before any drag/persist). */
+export const DEFAULT_LIST_PX = 420;
+
+/**
+ * Clamp the list-pane width so BOTH floors hold for the current container width:
+ * the list gets at least LIST_FLOOR_PX, and at most `containerWidth -
+ * READING_FLOOR_PX` so the reading pane keeps its floor too. When the container
+ * is narrower than the combined floor there is no valid horizontal split — the
+ * caller stacks instead — so this returns the list floor.
+ *
+ * PURE + total: never throws; the returned width is always ≥ LIST_FLOOR_PX and,
+ * whenever the container can hold both floors, leaves the reading pane ≥
+ * READING_FLOOR_PX and the whole split ≤ containerWidth (no overflow).
+ */
+export function clampListWidth(desiredPx: number, containerWidth: number): number {
+  const maxList = containerWidth - READING_FLOOR_PX;
+  if (maxList <= LIST_FLOOR_PX) return LIST_FLOOR_PX;
+  return Math.min(maxList, Math.max(LIST_FLOOR_PX, desiredPx));
+}
+
+/** True when the container is too narrow to hold both floors side-by-side — the
+ *  panes should stack vertically (portrait / phone) rather than be crushed. */
+export function shouldStack(containerWidth: number): boolean {
+  return containerWidth > 0 && containerWidth < STACK_BELOW_PX;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
@@ -1,0 +1,164 @@
+// home-surface.tsx — the calm master-detail Inbox HOME surface (CTL-899 / HOME1).
+// The structural keystone of the HOME stream: it stands up the surface, the
+// resizable split, the list/pane wiring, j/k selection, and the calm
+// state-of-things header sentence — fed by the cache-backed read-model snapshot
+// (SSE) rather than any synchronous Linear call.
+//
+// Composition:
+//   useBoardSnapshot()  → the resident read-model BoardPayload (SSE, no Linear).
+//   deriveInbox()       → grouped bare-row sections + the flat j/k walk order +
+//                         the default selection + the calm header counts (PURE).
+//   ResizableSplit      → the master-detail two-pane split with FIRM iPad floors.
+//   InboxRow / ReadingPane → the bare list rows + the (HOME4-stubbed) pane.
+//
+// The four CTL-899 Gherkin scenarios all land here: a flat bare-row list (no
+// nested cards) on the left driving a reading pane on the right in a resizable
+// split; clicking a row OR pressing j/k moves the selection and updates the pane,
+// with the top item selected by default; the split survives iPad-landscape via
+// the ResizableSplit floors; and the data is the read-model snapshot, never a
+// per-load Linear fetch.
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  calmHeaderSentence,
+  deriveInbox,
+  moveSelection,
+  rowById,
+} from "@/board/home-inbox";
+import { isTypingTarget } from "@/lib/surface";
+import { useBoardSnapshot } from "@/hooks/use-board-snapshot";
+import { ResizableSplit } from "./resizable-split";
+import { InboxRow } from "./inbox-row";
+import { ReadingPane } from "./reading-pane";
+
+/** The left list: the calm header sentence + the grouped bare-row sections. */
+function InboxList({
+  header,
+  sections,
+  selectedId,
+  onSelect,
+  status,
+}: {
+  header: string;
+  sections: ReturnType<typeof deriveInbox>["sections"];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  status: string;
+}) {
+  return (
+    <div className="flex h-full flex-col bg-surface-0">
+      {/* The calm "state of things" header — ONE sentence, never a KPI grid. */}
+      <header className="shrink-0 border-b border-border px-4 py-4">
+        <p className="text-[13px] text-fg" data-calm-header>
+          {header}
+        </p>
+        {status !== "connected" && (
+          <p className="mt-1 text-[11px] text-muted">connecting to the read-model…</p>
+        )}
+      </header>
+
+      {/* Flat bare-row list — sections are hairline-divided groups, NOT cards. */}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {sections.length === 0 ? (
+          <p className="px-4 py-8 text-center text-[12px] text-muted">
+            All clear — nothing needs you right now.
+          </p>
+        ) : (
+          sections.map((section) => (
+            <section key={section.kind} className="border-b border-border last:border-b-0">
+              <h2 className="px-4 pt-4 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted">
+                {section.label}
+                <span className="ml-2 font-mono text-muted/70">{section.rows.length}</span>
+              </h2>
+              {/* Rows are divided by a hairline divider between them (the list is
+                  the container; each row is bare). */}
+              <div className="divide-y divide-border-subtle">
+                {section.rows.map((row) => (
+                  <InboxRow
+                    key={row.id}
+                    row={row}
+                    selected={row.id === selectedId}
+                    onSelect={onSelect}
+                  />
+                ))}
+              </div>
+            </section>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function HomeSurface() {
+  const { payload, status } = useBoardSnapshot();
+
+  // Derive the whole inbox from the resident snapshot (PURE). When no payload has
+  // landed yet, an empty payload yields an empty (but valid) model.
+  const model = useMemo(
+    () =>
+      deriveInbox(
+        payload ?? {
+          generatedAt: "",
+          config: { maxParallel: 0, inFlight: 0, freeSlots: 0, active: 0, working: 0, stuck: 0 },
+          repos: [],
+          workers: [],
+          tickets: [],
+          queue: [],
+        },
+      ),
+    [payload],
+  );
+
+  // The selection: null until the operator (or the default-select effect) picks a
+  // row. Held in React state so j/k and click both drive the one reading pane.
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  // Default-select the top item on load, and keep the selection valid as the
+  // snapshot reshuffles: if nothing is selected (first paint) OR the current
+  // selection vanished from the order, fall back to the head of the walk order.
+  useEffect(() => {
+    setSelectedId((prev) => {
+      if (prev != null && model.order.some((r) => r.id === prev)) return prev;
+      return model.defaultSelectedId;
+    });
+  }, [model]);
+
+  // j / k walk the flat order (clamped, never wraps). Ignores typing targets so
+  // the keys never fire while the operator is in a text field.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (isTypingTarget(e.target as HTMLElement | null)) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key === "j") {
+        e.preventDefault();
+        setSelectedId((cur) => moveSelection(model.order, cur, +1));
+      } else if (e.key === "k") {
+        e.preventDefault();
+        setSelectedId((cur) => moveSelection(model.order, cur, -1));
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [model.order]);
+
+  const header = calmHeaderSentence(model.counts);
+  const selectedRow = rowById(model, selectedId);
+
+  return (
+    <div className="h-full min-h-0 w-full min-w-0 bg-surface-0 text-fg">
+      <ResizableSplit
+        list={
+          <InboxList
+            header={header}
+            sections={model.sections}
+            selectedId={selectedId}
+            onSelect={setSelectedId}
+            status={status}
+          />
+        }
+        reading={<ReadingPane row={selectedRow} />}
+      />
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/inbox-row.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/inbox-row.tsx
@@ -1,0 +1,90 @@
+// inbox-row.tsx — ONE bare inbox row (CTL-899 / HOME1). The list itself is the
+// container; this row is NOT a card. No border, no background box, no nested
+// summary — just a flat row separated from its neighbour by the list's hairline
+// divider (Direction A non-negotiable #1: "No card-in-card. Ever.").
+//
+// Row anatomy (Direction A): a 2px LEFT ACCENT (the only status signal, present
+// only on the needs-you rows — red blocked / amber waiting); the monospace muted
+// KEY; the one-line ASK (the bright line, the ticket title); a muted human
+// SUB-LABEL; and the single primary VERB. Running/Done rows are fully neutral
+// (no accent, no verb) — that's how 90% of the page de-alarms by subtraction.
+import { cn } from "@/lib/utils";
+import { isNeedsYouSection, type InboxRow as InboxRowModel } from "@/board/home-inbox";
+
+/** Left-accent color per section. Only the needs-you sections carry an accent;
+ *  running/done are intentionally accent-less (transparent). Reserved live cyan
+ *  (#5be0ff) is deliberately NOT used here — accent = meaning, not liveness. */
+function accentClass(section: InboxRowModel["section"]): string {
+  if (section === "blocked") return "bg-red";
+  if (section === "waiting") return "bg-yellow";
+  return "bg-transparent";
+}
+
+export function InboxRow({
+  row,
+  selected,
+  onSelect,
+}: {
+  row: InboxRowModel;
+  selected: boolean;
+  onSelect: (id: string) => void;
+}) {
+  const needsYou = isNeedsYouSection(row.section);
+  const blockerSuffix =
+    row.section === "blocked" && row.blockers.length > 0
+      ? ` · ${row.blockers.join(", ")}`
+      : "";
+
+  return (
+    <button
+      type="button"
+      data-inbox-row={row.id}
+      data-selected={selected ? "true" : undefined}
+      aria-current={selected ? "true" : undefined}
+      onClick={() => onSelect(row.id)}
+      className={cn(
+        // A flat row: full-width, left-aligned, NO border/box. The selected row
+        // gets a subtle raised surface (not a card outline) so the reading pane's
+        // subject is obvious without nesting.
+        "group flex w-full items-start gap-3 px-4 py-3 text-left transition-colors",
+        selected ? "bg-surface-2" : "hover:bg-surface-1",
+      )}
+    >
+      {/* 2px left accent — the single status signal, only on needs-you rows. */}
+      <span
+        aria-hidden
+        className={cn("mt-0.5 h-9 w-0.5 shrink-0 rounded-full", accentClass(row.section))}
+      />
+
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="flex items-center gap-2">
+          {/* Monospace muted key. */}
+          <span className="font-mono text-[11.5px] font-semibold text-accent">{row.id}</span>
+          {/* The one-line ask — the bright line. Truncates to one line on the row;
+              the full title lives in the reading pane (no nesting on the row). */}
+          <span className="truncate text-[13px] text-fg">{row.title}</span>
+        </span>
+        {/* The muted human sub-label — plain language, one line. */}
+        <span className="text-[11px] text-muted">
+          {row.subLabel}
+          {blockerSuffix}
+        </span>
+      </span>
+
+      {/* The single primary verb — present only on needs-you rows. Everything
+          else (View in Claude / Snooze / Dismiss) is one click deeper (HOME4). */}
+      {needsYou && row.verb && (
+        <span
+          className={cn(
+            "mt-0.5 shrink-0 rounded-md border px-2 py-0.5 text-[11px] font-medium",
+            row.section === "blocked"
+              ? "border-red/40 text-red"
+              : "border-yellow/40 text-yellow",
+          )}
+        >
+          {row.verb}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
@@ -1,0 +1,66 @@
+// reading-pane.tsx — the master-detail READING PANE (CTL-899 / HOME1), STUBBED.
+// The full reading pane ("What's needed now" + decision options / blocker +
+// View in Claude + About) is HOME4's deliverable; this ticket stands up the
+// master-detail wiring and stubs the pane body. What's load-bearing HERE is that
+// selecting a row (click or j/k) drives THIS pane to that item — the CTL-899
+// "Selecting a row updates the reading pane" Gherkin. So the stub faithfully
+// reflects the SELECTED row (key, ask, sub-label, the blocker ids when blocked)
+// and marks the deeper body as "arriving in HOME4", rather than being inert.
+import { CheckCircle2 } from "lucide-react";
+import { isNeedsYouSection, type InboxRow } from "@/board/home-inbox";
+
+/** Empty-pane state — shown when nothing is selected (a wholly empty inbox).
+ *  The relief payoff: calm, not an error. */
+function NothingSelected() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 px-8 text-center text-muted">
+      <CheckCircle2 className="h-8 w-8 opacity-40" />
+      <p className="text-[13px]">Nothing needs you right now.</p>
+      <p className="max-w-xs text-[12px] opacity-70">
+        When an agent needs a decision or hits a blocker, it lands here.
+      </p>
+    </div>
+  );
+}
+
+export function ReadingPane({ row }: { row: InboxRow | null }) {
+  if (!row) return <NothingSelected />;
+
+  const needsYou = isNeedsYouSection(row.section);
+
+  return (
+    <div data-reading-pane-id={row.id} className="flex h-full flex-col px-6 py-5">
+      {/* Header: the key + the one-line ask (the bright subject of the pane). */}
+      <div className="flex items-center gap-2">
+        <span className="font-mono text-[12px] font-semibold text-accent">{row.id}</span>
+        <span className="text-[11px] text-muted">{row.subLabel}</span>
+      </div>
+      <h1 className="mt-1 text-[18px] leading-snug text-fg">{row.title}</h1>
+
+      {/* What's needed now — the needs-you cue. The decision options / blocker
+          detail + the View-in-Claude deep link are HOME4. */}
+      {needsYou && (
+        <div className="mt-4 rounded-md border border-border bg-surface-1 px-4 py-3">
+          <p className="text-[12px] font-medium text-fg">
+            {row.section === "blocked" ? "Blocked — needs you to unblock" : "Waiting on your answer"}
+          </p>
+          {row.section === "blocked" && row.blockers.length > 0 && (
+            <p className="mt-1 font-mono text-[11px] text-muted">
+              blocked on: {row.blockers.join(", ")}
+            </p>
+          )}
+          {row.verb && (
+            <span className="mt-3 inline-block rounded-md border border-accent/40 px-3 py-1 text-[12px] font-medium text-accent">
+              {row.verb}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* The deeper body (full AI summary, phase spine, About) arrives in HOME4. */}
+      <p className="mt-6 text-[12px] text-muted opacity-60">
+        Full detail — summary, pipeline, and View in Claude — arrives with the reading-pane build (HOME4).
+      </p>
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/resizable-split.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/resizable-split.tsx
@@ -1,0 +1,162 @@
+// resizable-split.tsx — the master-detail resizable split for the Inbox home
+// (CTL-899 / HOME1). A two-pane horizontal split with a draggable divider and
+// FIRM floors: the list pane never shrinks below `LIST_FLOOR_PX` (320) and the
+// reading pane never below `READING_FLOOR_PX` (360). Those floors are the
+// CTL-899 "split survives an iPad-landscape width" Gherkin — at ~1024–1366px
+// neither pane is crushed and there is no horizontal overflow.
+//
+// Hand-rolled (no react-resizable-panels dependency) so the floors are exact and
+// the whole surface stays inside the existing ui dependency set. The container is
+// `min-w-0 overflow-hidden` so a wide reading pane can never push the split past
+// the viewport (no horizontal scrollbar). Below the combined floor (an iPad
+// PORTRAIT / phone width) the split stacks the panes vertically rather than
+// crushing either — but the firm-floor case the ticket targets is landscape.
+//
+// The PURE floor math (clampListWidth + the floor constants) lives in the
+// DOM-free board/home-split.ts so the orch-monitor `bun test` suite can unit it
+// without dragging this DOM-touching component into the DOM-less typecheck — the
+// floors enforced here and the floors the tests assert are ONE source.
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  clampListWidth,
+  shouldStack,
+  DEFAULT_LIST_PX,
+  LIST_FLOOR_PX,
+  READING_FLOOR_PX,
+} from "@/board/home-split";
+
+const STORAGE_KEY = "catalyst:home-list-width";
+
+function readStoredWidth(): number {
+  if (typeof window === "undefined") return DEFAULT_LIST_PX;
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  const n = raw == null ? NaN : Number(raw);
+  return Number.isFinite(n) && n >= LIST_FLOOR_PX ? n : DEFAULT_LIST_PX;
+}
+
+export function ResizableSplit({
+  list,
+  reading,
+}: {
+  list: React.ReactNode;
+  reading: React.ReactNode;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [listPx, setListPx] = useState<number>(readStoredWidth);
+  const draggingRef = useRef(false);
+
+  // Track the container width so the clamp keeps both floors as the window/iPad
+  // viewport resizes (ResizeObserver — no horizontal overflow at any width).
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width;
+      if (typeof w === "number") setContainerWidth(w);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const persist = useCallback((px: number) => {
+    setListPx(px);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, String(px));
+    }
+  }, []);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      draggingRef.current = true;
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    },
+    [],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!draggingRef.current) return;
+      const el = containerRef.current;
+      if (!el) return;
+      const left = el.getBoundingClientRect().left;
+      persist(clampListWidth(e.clientX - left, el.clientWidth));
+    },
+    [persist],
+  );
+
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    draggingRef.current = false;
+    try {
+      (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      /* pointer already released */
+    }
+  }, []);
+
+  // Keyboard resize for a11y: ←/→ on the focused divider nudges the split.
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const el = containerRef.current;
+      if (!el) return;
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        persist(clampListWidth(listPx - 16, el.clientWidth));
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        persist(clampListWidth(listPx + 16, el.clientWidth));
+      }
+    },
+    [listPx, persist],
+  );
+
+  // Below the combined floor (portrait / phone) the firm floors can't both hold
+  // side-by-side — stack vertically so neither pane is crushed. The landscape
+  // case the ticket targets keeps the horizontal split.
+  const stacked = shouldStack(containerWidth);
+  const effectiveListPx = clampListWidth(listPx, containerWidth || DEFAULT_LIST_PX);
+
+  if (stacked) {
+    return (
+      <div ref={containerRef} className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden">
+        <div className="min-h-0 flex-1 overflow-y-auto border-b border-border">{list}</div>
+        <div className="min-h-0 flex-1 overflow-y-auto">{reading}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="flex h-full min-h-0 w-full min-w-0 overflow-hidden">
+      {/* List pane — fixed (resizable) width, never below its floor. */}
+      <div
+        className="h-full min-h-0 shrink-0 overflow-y-auto"
+        style={{ width: effectiveListPx, minWidth: LIST_FLOOR_PX }}
+      >
+        {list}
+      </div>
+
+      {/* Draggable divider — a hairline with a wider hit area. */}
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize the inbox list"
+        tabIndex={0}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onKeyDown={onKeyDown}
+        className="relative w-px shrink-0 cursor-col-resize bg-border outline-none before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5 before:content-[''] hover:bg-accent focus-visible:bg-accent"
+      />
+
+      {/* Reading pane — flexes to fill, never below its floor; min-w-0 so it can
+          shrink within its flex track without forcing horizontal overflow. */}
+      <div
+        className="h-full min-h-0 flex-1 overflow-y-auto"
+        style={{ minWidth: READING_FLOOR_PX }}
+      >
+        {reading}
+      </div>
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-board-snapshot.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-board-snapshot.ts
@@ -1,0 +1,61 @@
+// use-board-snapshot.ts — subscribe a React surface to the cache-backed
+// read-model snapshot (CTL-899 / HOME1). The board already proved the push
+// model: `connectBoard()` (board/board-client.ts) opens ONE shared EventSource
+// over `/api/board/stream`, warm-paints from IndexedDB, and re-requests a fresh
+// snapshot on tab re-focus — all with NO synchronous Linear/linearis call per
+// page load. The Inbox home consumes that SAME transport so its data plane is
+// identical to the board's (the CTL-899 "Inbox data comes from the read-model,
+// never a live Linear call" Gherkin).
+//
+// This is the thin React adapter around the transport: it owns the subscription
+// lifecycle (connect on mount, reconcile on visibility regain, close on unmount)
+// and exposes the latest `BoardPayload` + connection status. It is deliberately
+// tiny and side-effect-free beyond that — the inbox DERIVATION lives in the pure
+// `board/home-inbox.ts`, which this feeds.
+import { useEffect, useState } from "react";
+import { connectBoard } from "../board/board-client";
+import type { BoardPayload } from "../board/types";
+import type { ConnectionStatus } from "../lib/types";
+
+export interface BoardSnapshot {
+  /** The latest read-model payload, or null until the first frame lands. */
+  payload: BoardPayload | null;
+  /** Transport status — "connected" once data is flowing (LIVE). */
+  status: ConnectionStatus;
+}
+
+/**
+ * Subscribe to the read-model board snapshot for the lifetime of the calling
+ * component. Returns the latest payload + status; both update as SSE frames land.
+ *
+ * Mirrors the exact subscription lifecycle Board.tsx uses (connectBoard +
+ * visibilitychange reconcile + close), so the Home surface and the Board share
+ * ONE EventSource via the SharedWorker — no second upstream stream.
+ */
+export function useBoardSnapshot(): BoardSnapshot {
+  const [payload, setPayload] = useState<BoardPayload | null>(null);
+  const [status, setStatus] = useState<ConnectionStatus>("connecting");
+
+  useEffect(() => {
+    let alive = true;
+    const conn = connectBoard({
+      onSnapshot: (p) => {
+        if (alive) setPayload(p);
+      },
+      onStatus: (s) => {
+        if (alive) setStatus(s);
+      },
+    });
+    const onVis = () => {
+      if (!document.hidden) conn.requestReconcile();
+    };
+    document.addEventListener("visibilitychange", onVis);
+    return () => {
+      alive = false;
+      conn.close();
+      document.removeEventListener("visibilitychange", onVis);
+    };
+  }, []);
+
+  return { payload, status };
+}


### PR DESCRIPTION
## What

Ports the calm Direction-A **Inbox** surface from the React prototype into the real `orch-monitor`: a flat, bare-row list on the left (no card-in-card, hairline dividers) that drives a reading pane on the right, master-detail style. This is the structural keystone of the HOME stream — it stands up the surface, the resizable split, the list/pane wiring, j/k selection, and the calm state-of-things header sentence, fed by the cache-backed read-model snapshot (SSE) rather than any synchronous Linear call.

Built on the merged dependencies **FND1** (CTL-881, TanStack Router), **SHELL1** (CTL-891, app-shell surface slot + `SurfaceContext`), and **BFF1** (CTL-883, cache-backed read-model). The reading-pane body is stubbed — the full pane arrives in HOME4.

## How

- **`ui/src/board/home-inbox.ts`** — PURE inbox derivation: groups tickets into `blocked` / `waiting` / `running` / `done` from `BoardTicket.held` (the broker already folds filter-state.db `ticket_state.labels` into `held` via `board-data.mjs heldFor()` — so the needs-you signal is read off the resident payload, never a Linear call), plus the flat j/k walk order, the default selection, and the calm header sentence.
- **`ui/src/board/home-split.ts`** — PURE iPad-floor clamp math (`clampListWidth`): list ≥ 320px, reading ≥ 360px, split never exceeds the container ⇒ no horizontal overflow.
- **`ui/src/hooks/use-board-snapshot.ts`** — subscribes via `connectBoard()`, the SAME SSE board transport the board uses (one shared `EventSource` via the SharedWorker; warm-paint from IndexedDB; reconcile on tab re-focus). No per-load `fetch`/Linear call.
- **`ui/src/components/home/{home-surface,resizable-split,inbox-row,reading-pane}.tsx`** — the master-detail surface, the hand-rolled resizable split (firm floors, no `react-resizable-panels` dep), the bare flat row (2px left accent only on needs-you rows — red blocked / amber waiting; reserved live cyan untouched), and the HOME4-stubbed reading pane.
- **`ui/src/App.tsx`** — a `SurfaceSwitch` renders `HomeSurface` when `surface === "home"`, falling through to the existing dense dashboard for every other surface (Board/Workers/Queue until their own SHELL tickets land — **no regression**).

## Tests (TDD)

- **`__tests__/home-inbox.test.ts`** — 27 units for the pure derivation: classification, grouped sections + flat walk order, default-select (top item), j/k `moveSelection` (clamped, never wraps), and the calm header sentence.
- **`__tests__/home-surface.test.ts`** — clamp-floor units across the full 1024–1366 iPad-landscape range (asserting both floors hold and no overflow) + static source-analysis guards for the React wiring (same pattern as `app-shell.test.ts`, since `bun test` has no DOM).

`bun test` (home + related suites) green; `tsc --noEmit` clean on both `orch-monitor` and `ui` (the one pre-existing `kpi-strip.tsx` error is on `main`, unrelated); `bun run build` in `ui` succeeds with a code-split `home-surface` chunk. Verified live in the dev server: the calm header, the bare-row list, default selection, click + j/k selection, and the master-detail split all render with real read-model data.

## Gherkin scenarios

| Scenario | Status |
|---|---|
| Home renders the calm inbox, not the dense board (flat bare rows, hairline dividers, ONE calm header sentence, master-detail resizable split) | **satisfied** |
| Selecting a row updates the reading pane (click or j/k; top item selected by default) | **satisfied** |
| The split survives an iPad-landscape width (list floor 320px, reading floor 360px, no horizontal overflow) | **satisfied** |
| Inbox data comes from the read-model, never a live Linear call (SSE board snapshot; no synchronous linearis/Linear fetch per page load) | **satisfied** |

## Single-node MVP

Node/cluster behavior is inherited from BFF1's read-model contract (the single-host identity no-op via `groupByHost()` in `lib/read-model-client.ts`). No multi-node anchors are built here — the Inbox consumes the same single-host read-model payload the board does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)