### PR TITLE
feat(dev): BOARD1 dense Linear-anatomy board in shell (CTL-905)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/board-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-surface.test.ts
@@ -1,0 +1,204 @@
+// board-surface.test.ts — CTL-905 / BOARD1 acceptance guards.
+//
+// Encodes the three BOARD1 Gherkin scenarios. `bun test` has no DOM, so —
+// matching the board-todo-column.test.ts + app-shell.test.ts pattern — the
+// structural scenarios are asserted by static source analysis (read the .tsx as
+// text and assert the load-bearing wiring), and the data-driven column membership
+// (the "no drag, filter by linearState|phase" mechanism) is unit-tested directly
+// against the shared resolveList comparator (FND2 / CTL-882).
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { resolveList } from "../ui/src/board/list-order";
+import type { BoardPayload, BoardTicket } from "../ui/src/board/types";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const UI_SRC = join(HERE, "..", "ui", "src");
+const read = (rel: string) => readFileSync(join(UI_SRC, rel), "utf8");
+
+const boardSrc = read("board/Board.tsx");
+const appSrc = read("App.tsx");
+
+/**
+ * Strip JS/JSX comments so CLASSNAME / token assertions can't be tripped by prose
+ * in a comment that merely mentions a token (e.g. a `// max-w-…` note).
+ */
+function stripComments(src: string): string {
+  return src
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "") // {/* jsx comment */}
+    .replace(/\/\*[\s\S]*?\*\//g, "") // /* block */
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1"); // // line (skip http://)
+}
+
+const boardCode = stripComments(boardSrc);
+const appCode = stripComments(appSrc);
+
+// ── Scenario: Board surface renders real tickets in the new shell ─────────────
+describe("Board surface renders the real dense board in the shell (CTL-905)", () => {
+  it("Board.tsx exports an EmbeddedBoard surface (the in-shell mount) AND keeps the standalone Board", () => {
+    // The standalone board.html mount (FND1 router `/`) stays exported and
+    // behavior-preserving; the new embedded surface is a sibling export.
+    expect(boardSrc).toMatch(/export function EmbeddedBoard\b/);
+    expect(boardSrc).toMatch(/export function Board\b/);
+    // Both compose the SAME extracted BoardSurface — one dense surface, two hosts.
+    expect(boardSrc).toMatch(/function BoardSurface\b/);
+    expect(boardCode).toMatch(/<BoardSurface\s*\/>/); // standalone: no chrome flag
+    expect(boardCode).toMatch(/<BoardSurface\s+embedded\b/); // embedded: chrome off
+  });
+
+  it("App.tsx mounts the EmbeddedBoard when the shell surface is `board`", () => {
+    expect(appSrc).toContain("EmbeddedBoard");
+    expect(appSrc).toContain("useSurface");
+    // The inset gate switches on the board surface specifically.
+    expect(appCode).toMatch(/surface\s*===\s*"board"/);
+    // Lazy import of the real board module (so the SSE transport only boots on Board).
+    expect(appCode).toMatch(/import\(["']\.\/board\/Board["']\)/);
+  });
+
+  it("renders the dense Linear-anatomy card parts (priority icon, type chip, phase pill, held, status, scope/estimate, phase strip, cost/turns or PR)", () => {
+    // The hand-rolled dense card (per the board doc — NOT a prebuilt kanban block).
+    for (const part of [
+      "PriorityIcon",
+      "PhasePill",
+      "HeldBadge",
+      "StatusBadge",
+      "ScopeChip",
+      "PhaseStrip",
+      "Cost",
+      "function TicketCard",
+    ]) {
+      expect(boardSrc).toContain(part);
+    }
+    // cost/turns or PR row.
+    expect(boardSrc).toMatch(/t\.turns/);
+    expect(boardSrc).toMatch(/t\.pr\b/);
+  });
+
+  it("the board is the existing CTL-733 live SSE surface (connectBoard over the board transport), not a per-request Linear pass-through", () => {
+    expect(boardSrc).toContain("connectBoard");
+    expect(boardSrc).toContain("requestReconcile");
+  });
+
+  it("keeps the board hand-rolled + data-driven — NO drag-and-drop kanban (no @dnd-kit, no draggable/onDragEnd, no useSortable)", () => {
+    expect(boardCode).not.toContain("@dnd-kit");
+    expect(boardCode).not.toContain("useSortable");
+    expect(boardCode).not.toContain("onDragEnd");
+    expect(boardCode).not.toMatch(/\bdraggable\b/);
+  });
+
+  it("column membership is derived from the shared resolveList comparator (FND2), never re-implemented inline or by drag", () => {
+    // The board renders columns THROUGH resolveList so the on-screen order is the
+    // same list the detail pager / j/k walk derive.
+    expect(boardSrc).toContain("resolveList");
+    // The ticket-column filter is a pure linearState|phase filter, no re-sort.
+    const cards: BoardTicket[] = [
+      mkTicket({ id: "CTL-1", linearState: "Implement", phase: "implement" }),
+      mkTicket({ id: "CTL-2", linearState: "PR", phase: "pr" }),
+      mkTicket({ id: "CTL-3", linearState: "Implement", phase: "verify" }),
+    ];
+    const payload = mkPayload(cards);
+    // Linear-state lens → membership by linearState.
+    expect(
+      resolveList(payload, { kind: "ticket", lens: "linear", col: "Implement" }).map((t) => t.id),
+    ).toEqual(["CTL-1", "CTL-3"]);
+    // Pipeline lens → membership by phase (the SAME cards, a different lens).
+    expect(
+      resolveList(payload, { kind: "ticket", lens: "phase", col: "implement" }).map((t) => t.id),
+    ).toEqual(["CTL-1"]);
+    // No re-sort: payload array order is preserved within a column.
+    expect(
+      resolveList(payload, { kind: "ticket", lens: "linear", col: "Implement" }).map((t) => t.id),
+    ).toEqual(["CTL-1", "CTL-3"]);
+  });
+});
+
+// ── Scenario: Live worker on a ticket is visibly distinguished ────────────────
+describe("live + stuck cards are visibly distinguished, cyan reserved for live (CTL-905)", () => {
+  it("reserves cyan #5be0ff for the live signal only", () => {
+    // The reserved live color is defined once and tagged as reserved.
+    expect(boardSrc).toContain("#5be0ff");
+    expect(boardSrc).toMatch(/const LIVE = "#5be0ff"/);
+  });
+
+  it("ships the live-ring + pulsing live-dot keyframes and applies the ring to a live card", () => {
+    expect(boardSrc).toContain("catalystLiveRing");
+    expect(boardSrc).toContain("catalystLivePing");
+    expect(boardSrc).toContain("catalyst-live-dot");
+    // A live ticket gets the breathing ring class.
+    expect(boardCode).toMatch(/live \? "catalyst-live"/);
+  });
+
+  it("a stuck worker gets the red stuck treatment instead of the live ring", () => {
+    // accentFor: stuck (or failed) → red, not the reserved cyan.
+    expect(boardCode).toMatch(/activeState === "stuck".*C\.red/);
+    // The stuck card uses the red border treatment.
+    expect(boardCode).toContain("rgba(239,93,93,0.5)");
+  });
+});
+
+// ── Scenario: Board fills the window edge-to-edge (dense mode) ────────────────
+describe("the embedded board fills the inset edge-to-edge, lanes flow horizontally (CTL-905)", () => {
+  it("the embedded surface flex-fills its parent (height:100%), it does NOT re-impose a 100vh viewport box", () => {
+    // BoardSurface picks the fill height by host: 100% embedded, viewport-minus-
+    // chrome standalone — so the dense board fills the SidebarInset with no
+    // double scrollbar and no centered gutter.
+    expect(boardCode).toMatch(/embedded \? "100%" : "calc\(100vh - 104px\)"/);
+    expect(boardCode).toMatch(/height: embedded \? "100%" : "100vh"/);
+  });
+
+  it("lanes flow horizontally (BoardScroll uses overflowX:auto, fixed-width columns)", () => {
+    expect(boardCode).toMatch(/overflowX: "auto"/);
+    // Columns are fixed-width so the board scrolls horizontally edge-to-edge.
+    expect(boardCode).toMatch(/flex: "0 0 300px"/);
+  });
+
+  it("App.tsx imposes no centered max-w / mx-auto gutter on the inset (dense edge-to-edge)", () => {
+    expect(appCode).not.toMatch(/\bmx-auto\b/);
+    expect(appCode).not.toMatch(
+      /\bmax-w-(sm|md|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl|screen)\b/,
+    );
+  });
+});
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+function mkTicket(over: Partial<BoardTicket> & Pick<BoardTicket, "id">): BoardTicket {
+  return {
+    title: "t",
+    type: "feature",
+    repo: "catalyst",
+    team: "CTL",
+    phase: "implement",
+    status: "running",
+    model: null,
+    linearState: "Implement",
+    workerStatus: null,
+    activeState: null,
+    working: false,
+    lastActiveMs: null,
+    priority: 2,
+    estimate: null,
+    scope: null,
+    project: null,
+    costUSD: null,
+    tokens: null,
+    turns: null,
+    phaseCosts: null,
+    phaseSummary: [],
+    pr: null,
+    updatedAt: "2026-06-08T00:00:00Z",
+    held: null,
+    ...over,
+  };
+}
+
+function mkPayload(tickets: BoardTicket[]): BoardPayload {
+  return {
+    generatedAt: "",
+    config: { maxParallel: 0, inFlight: 0, freeSlots: 0, active: 0, working: 0, stuck: 0 },
+    repos: [],
+    workers: [],
+    tickets,
+    queue: [],
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
@@ -3,6 +3,7 @@ import { useMonitor } from "./hooks/use-monitor";
 import { useKeyboardNav } from "./hooks/use-keyboard-nav";
 import { useCommsChannels } from "./hooks/use-comms";
 import { AppShell } from "./components/app-shell";
+import { useSurface } from "./lib/surface";
 import { AttentionBar } from "./components/attention-bar";
 import { SessionDetailDrawer } from "./components/session-detail-drawer";
 import { ConnectionBanner } from "./components/ui/connection-banner";
@@ -13,6 +14,14 @@ import {
   type SessionTimeFilter,
   type CommsFilter,
 } from "./lib/types";
+
+// CTL-905 / BOARD1: the real dense Linear-anatomy operator board, mounted as the
+// shell's `board` surface. Lazy so the board transport (SharedWorker + SSE) only
+// boots when the operator actually switches to the Board surface — the calm Home
+// reading column never pays for it.
+const EmbeddedBoard = lazy(() =>
+  import("./board/Board").then((m) => ({ default: m.EmbeddedBoard })),
+);
 
 const Dashboard = lazy(() =>
   import("./components/dashboard").then((m) => ({ default: m.Dashboard })),
@@ -167,91 +176,93 @@ function Monitor() {
   );
 
   return (
-    // CTL-891 / SHELL1: the AppShell is now the app frame — a full-viewport,
+    // CTL-891 / SHELL1: the AppShell is the app frame — a full-viewport,
     // edge-to-edge shadcn Sidebar shell (controlled SidebarProvider + SidebarInset
-    // + OPERATE/OBSERVE nav). The existing dashboard content renders edge-to-edge
-    // inside the inset. Surface→content wiring (Board/Workers/Queue) and live
-    // badges are later SHELL tickets; here the dashboard is the inset content.
+    // + OPERATE/OBSERVE nav). CTL-905 / BOARD1 wires the shell's `board` surface
+    // to the real dense operator board (MonitorInset reads useSurface() inside the
+    // provider and swaps the inset content). Other surfaces keep the dashboard.
     <AppShell>
-      <div className="flex h-full min-h-0 flex-col bg-surface-0 text-fg">
-        {/* Content-level meta row: snapshot timestamp + version. The frame's
-            breadcrumb + collapse live in the AppShell top strip now. */}
-        <div className="flex items-center justify-end gap-3 border-b border-border bg-surface-1 px-5 py-2 text-[12px] text-muted">
-          {snapshot.timestamp && (
-            <span>
-              {new Date(snapshot.timestamp).toLocaleDateString(undefined, {
-                month: "short",
-                day: "numeric",
-                year: "numeric",
-              })}{" "}
-              {new Date(snapshot.timestamp).toLocaleTimeString()}
-            </span>
-          )}
-          {version && <span className="font-mono opacity-50">v{version}</span>}
-        </div>
-
-        <ConnectionBanner status={connectionStatus} className="mx-5 mt-3" />
-        <OtelHealthBanner health={otelHealth} className="mx-5 mt-3" />
-
-        <div className="min-h-0 flex-1 overflow-y-auto p-5">
-          <Suspense fallback={<SkeletonDashboard />}>
-            {topView === "comms" ? (
-              <div className="animate-fade-in">
-                <CommsView initialFilter={commsInitialFilter} />
-              </div>
-            ) : topView === "activity" ? (
-              <div className="animate-fade-in">
-                <ActivityView onPivot={handleActivityPivot} />
-              </div>
-            ) : topView === "god-mode" ? (
-              <div className="animate-fade-in">
-                <GodModeView />
-              </div>
-            ) : effectiveOrch ? (
-              <div key={effectiveOrch.id} className="animate-fade-in flex flex-col gap-4">
-                {attention.filter((a) => a.orchId === effectiveOrch.id)
-                  .length > 0 && (
-                  <AttentionBar
-                    items={attention.filter(
-                      (a) => a.orchId === effectiveOrch.id,
-                    )}
-                    onItemClick={handleAttentionClick}
-                  />
-                )}
-                <OrchestratorView
-                  orch={effectiveOrch}
-                  events={events}
-                  getAnalytics={analytics}
-                  getLinear={linear}
-                  staleThreshold={staleThreshold}
-                  otelHealth={otelHealth}
-                  commsAuthors={commsAuthorsForSelected || undefined}
-                  onCommsLink={handleWorkerCommsLink}
-                  selectedWorker={selectedWorker}
-                  onWorkerSelect={setSelectedWorker}
-                />
-              </div>
-            ) : (
-              <div className="animate-fade-in">
-                <Dashboard
-                  orchestrators={snapshot.orchestrators}
-                  sessions={sessions}
-                  attention={attention}
-                  events={events}
-                  getAnalytics={analytics}
-                  onSelectOrch={(id) => setSelectedOrchId(id)}
-                  selectedSessionId={selectedSession}
-                  onSessionSelect={handleSessionSelect}
-                  timeFilter={timeFilter}
-                  otelConfigured={otelHealth?.configured === true}
-                  otelTools={otelTools}
-                  otelErrors={otelErrors}
-                />
-              </div>
+      <MonitorInset>
+        <div className="flex h-full min-h-0 flex-col bg-surface-0 text-fg">
+          {/* Content-level meta row: snapshot timestamp + version. The frame's
+              breadcrumb + collapse live in the AppShell top strip now. */}
+          <div className="flex items-center justify-end gap-3 border-b border-border bg-surface-1 px-5 py-2 text-[12px] text-muted">
+            {snapshot.timestamp && (
+              <span>
+                {new Date(snapshot.timestamp).toLocaleDateString(undefined, {
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                })}{" "}
+                {new Date(snapshot.timestamp).toLocaleTimeString()}
+              </span>
             )}
-          </Suspense>
+            {version && <span className="font-mono opacity-50">v{version}</span>}
+          </div>
+
+          <ConnectionBanner status={connectionStatus} className="mx-5 mt-3" />
+          <OtelHealthBanner health={otelHealth} className="mx-5 mt-3" />
+
+          <div className="min-h-0 flex-1 overflow-y-auto p-5">
+            <Suspense fallback={<SkeletonDashboard />}>
+              {topView === "comms" ? (
+                <div className="animate-fade-in">
+                  <CommsView initialFilter={commsInitialFilter} />
+                </div>
+              ) : topView === "activity" ? (
+                <div className="animate-fade-in">
+                  <ActivityView onPivot={handleActivityPivot} />
+                </div>
+              ) : topView === "god-mode" ? (
+                <div className="animate-fade-in">
+                  <GodModeView />
+                </div>
+              ) : effectiveOrch ? (
+                <div key={effectiveOrch.id} className="animate-fade-in flex flex-col gap-4">
+                  {attention.filter((a) => a.orchId === effectiveOrch.id)
+                    .length > 0 && (
+                    <AttentionBar
+                      items={attention.filter(
+                        (a) => a.orchId === effectiveOrch.id,
+                      )}
+                      onItemClick={handleAttentionClick}
+                    />
+                  )}
+                  <OrchestratorView
+                    orch={effectiveOrch}
+                    events={events}
+                    getAnalytics={analytics}
+                    getLinear={linear}
+                    staleThreshold={staleThreshold}
+                    otelHealth={otelHealth}
+                    commsAuthors={commsAuthorsForSelected || undefined}
+                    onCommsLink={handleWorkerCommsLink}
+                    selectedWorker={selectedWorker}
+                    onWorkerSelect={setSelectedWorker}
+                  />
+                </div>
+              ) : (
+                <div className="animate-fade-in">
+                  <Dashboard
+                    orchestrators={snapshot.orchestrators}
+                    sessions={sessions}
+                    attention={attention}
+                    events={events}
+                    getAnalytics={analytics}
+                    onSelectOrch={(id) => setSelectedOrchId(id)}
+                    selectedSessionId={selectedSession}
+                    onSessionSelect={handleSessionSelect}
+                    timeFilter={timeFilter}
+                    otelConfigured={otelHealth?.configured === true}
+                    otelTools={otelTools}
+                    otelErrors={otelErrors}
+                  />
+                </div>
+              )}
+            </Suspense>
+          </div>
         </div>
-      </div>
+      </MonitorInset>
 
       {selectedSession &&
         (() => {
@@ -265,4 +276,32 @@ function Monitor() {
         })()}
     </AppShell>
   );
+}
+
+/**
+ * The SidebarInset content gate (CTL-905 / BOARD1). Rendered INSIDE <AppShell> so
+ * it can read the active surface from SurfaceContext (useSurface()). When the
+ * operator is on the `board` surface it mounts the real dense Linear-anatomy
+ * operator board edge-to-edge (filling the inset); every other surface renders
+ * the existing dashboard `children` unchanged — a behavior-preserving default so
+ * Home/Workers/Queue keep today's content until their own surface tickets land.
+ */
+function MonitorInset({ children }: { children: React.ReactNode }) {
+  const { surface } = useSurface();
+  if (surface === "board") {
+    return (
+      <div className="h-full min-h-0">
+        <Suspense
+          fallback={
+            <div className="p-6 text-sm text-muted-foreground">
+              Connecting to execution-core…
+            </div>
+          }
+        >
+          <EmbeddedBoard />
+        </Suspense>
+      </div>
+    );
+  }
+  return <>{children}</>;
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
@@ -361,18 +361,25 @@ function Column({ label, color, count, live = 0, children }: { label: string; co
     </div>
   );
 }
-function BoardScroll({ children, fill }: { children: React.ReactNode; fill: boolean }) {
+// `fillHeight` is the CSS height the board scroll area fills when `fill` is on.
+// Standalone (board.html) it is `calc(100vh - 104px)` — the viewport minus the
+// 48px header + ~56px subhead chrome the standalone Board() renders. Embedded in
+// the app shell (CTL-905 / BOARD1) there is no board-internal header (the shell's
+// top strip lives OUTSIDE the surface), so the surface flexes to `100%` of the
+// SidebarInset content area instead. Defaulting to the standalone value keeps
+// every existing call site byte-identical.
+function BoardScroll({ children, fill, fillHeight = "calc(100vh - 104px)" }: { children: React.ReactNode; fill: boolean; fillHeight?: string }) {
   return (
-    <div className="cat-scroll" style={{ display: "flex", gap: 16, overflowX: "auto", alignItems: "flex-start", padding: "2px 16px 8px", height: fill ? "calc(100vh - 104px)" : "auto" }}>
+    <div className="cat-scroll" style={{ display: "flex", gap: 16, overflowX: "auto", alignItems: "flex-start", padding: "2px 16px 8px", height: fill ? fillHeight : "auto" }}>
       {children}
     </div>
   );
 }
 
-function TicketBoard({ tickets, lens, colorBy, fill, onSelect }: { tickets: Ticket[]; lens: "linear" | "phase"; colorBy: ColorBy; fill: boolean; onSelect?: (id: string) => void }) {
+function TicketBoard({ tickets, lens, colorBy, fill, fillHeight, onSelect }: { tickets: Ticket[]; lens: "linear" | "phase"; colorBy: ColorBy; fill: boolean; fillHeight?: string; onSelect?: (id: string) => void }) {
   const cols = lens === "linear" ? LINEAR_COLS : PHASE_COLS;
   return (
-    <BoardScroll fill={fill}>
+    <BoardScroll fill={fill} fillHeight={fillHeight}>
       {cols.map((c: any) => {
         // Render through resolveList (CTL-882 / FND2) so the on-screen column
         // order is the SAME list the detail-page pager + j/k walk derive. The
@@ -391,11 +398,11 @@ function TicketBoard({ tickets, lens, colorBy, fill, onSelect }: { tickets: Tick
     </BoardScroll>
   );
 }
-function WorkerBoard({ workers, tickets, grouping, fill }: { workers: Worker[]; tickets: Ticket[]; grouping: WorkerGrouping; fill: boolean }) {
+function WorkerBoard({ workers, tickets, grouping, fill, fillHeight }: { workers: Worker[]; tickets: Ticket[]; grouping: WorkerGrouping; fill: boolean; fillHeight?: string }) {
   const infoById: Record<string, Ticket> = Object.fromEntries(tickets.map((t) => [t.id, t]));
   const cols = grouping === "phase" ? PHASE_COLS : WORKER_COLS;
   return (
-    <BoardScroll fill={fill}>
+    <BoardScroll fill={fill} fillHeight={fillHeight}>
       {cols.map((c: any) => {
         const items = grouping === "phase"
           ? workers.filter((w) => w.phase === c.key)
@@ -456,7 +463,7 @@ const td = { fontSize: 12.5, color: C.fg };
 const mono = { fontFamily: C.mono, fontVariantNumeric: "tabular-nums" as const };
 const ellip = { overflow: "hidden" as const, textOverflow: "ellipsis" as const, whiteSpace: "nowrap" as const };
 
-function QueueView({ data }: { data: BoardPayload }) {
+function QueueView({ data, fillHeight = "calc(100vh - 104px)" }: { data: BoardPayload; fillHeight?: string }) {
   const { config, queue, workers, tickets } = data;
   const infoById: Record<string, Ticket> = Object.fromEntries(tickets.map((t) => [t.id, t]));
   // Order through the SHARED comparator (CTL-882 / FND2): rank(active=0, stuck=2,
@@ -464,7 +471,7 @@ function QueueView({ data }: { data: BoardPayload }) {
   // resolve via resolveList({kind:"worker"}). Byte-for-byte the prior inline sort.
   const inflight = sortWorkers(workers);
   return (
-    <div className="cat-scroll" style={{ overflowY: "auto", height: "calc(100vh - 104px)", padding: "2px 16px 24px" }}>
+    <div className="cat-scroll" style={{ overflowY: "auto", height: fillHeight, padding: "2px 16px 24px" }}>
       <div style={{ maxWidth: 1040 }}>
         <div style={{ display: "flex", gap: 12, marginBottom: 18 }}>
           <Stat label="Max parallel" value={String(config.maxParallel)} />
@@ -538,7 +545,24 @@ function Seg<T extends string>({ value, onChange, options }: { value: T; onChang
   );
 }
 
-export function Board() {
+// ── BoardSurface — the dense board body, host-agnostic (CTL-905 / BOARD1) ─────
+// Extracted from the standalone Board() so the SAME proven dense surface (the
+// Linear-anatomy TicketCard, the data-driven Column/BoardScroll/TicketBoard
+// filtered by linearState|phase via resolveList, the reserved-cyan live-ring +
+// red stuck treatment, and the CTL-733 SharedWorker SSE wiring) renders in TWO
+// hosts with ZERO data-layer change:
+//   - standalone  (board.html, via Board()):  embedded={false} → keeps its own
+//     48px logo header + daemon/broker/monitor health dots + LIVE pill, sizes to
+//     the viewport (100vh / `calc(100vh - 104px)`). Byte-identical to before.
+//   - embedded    (the app shell's `board` surface):  embedded → DROPS the
+//     duplicate top chrome (the shell already owns the logo, breadcrumb, ⌘K, and
+//     nav frame) and FLEX-FILLS the SidebarInset edge-to-edge (height:100%), so
+//     the board lanes flow horizontally across the full viewport width — the
+//     dense mode that contrasts the calm capped Home reading column.
+// The lens/colorBy/repo/swimlanes controls + the live-active chip stay in BOTH
+// hosts (they are board state, not chrome). No drag affordance in either host:
+// column membership stays derived from linearState/phase, never a move handler.
+function BoardSurface({ embedded = false }: { embedded?: boolean }) {
   const [data, setData] = useState<BoardPayload | null>(null);
   const [status, setStatus] = useState<ConnectionStatus>("connecting");
   const [view, setView] = useState<View>("tickets");
@@ -579,36 +603,59 @@ export function Board() {
       ? (data?.tickets ?? []).find((t) => t.id === selectedTicketId) ?? null
       : null;
 
+  // Standalone keeps the viewport-minus-chrome math; embedded flex-fills its
+  // parent (the SidebarInset content area) so the surface fills the window
+  // edge-to-edge with no double-scrollbar. `fillHeight` flows down to every
+  // BoardScroll/Lane so the inner column scroll matches the host.
+  const fillHeight = embedded ? "100%" : "calc(100vh - 104px)";
+
   return (
     <TooltipProvider delayDuration={200}>
-      <div style={{ background: C.s0, color: C.fg, height: "100vh", display: "flex", flexDirection: "column", fontSize: 13, fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif', overflow: "hidden" }}>
+      <div style={{ background: C.s0, color: C.fg, height: embedded ? "100%" : "100vh", display: "flex", flexDirection: "column", fontSize: 13, fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif', overflow: "hidden" }}>
         <style>{PULSE_CSS}</style>
-        {/* chrome */}
-        <header style={{ height: 48, display: "flex", alignItems: "center", gap: 18, padding: "0 16px", background: C.s1, borderBottom: `1px solid ${C.border}`, flex: "0 0 auto" }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 9, fontWeight: 600 }}>
-            <span style={{ width: 16, height: 16, borderRadius: 4, background: "linear-gradient(135deg,#4ea1ff,#39d07a)", boxShadow: "0 0 12px rgba(78,161,255,0.45)" }} />Catalyst
-          </div>
-          <div className="cat-nav">
-            <Tabs value={view} onValueChange={(v) => setView(v as View)}>
-              <TabsList>
-                <TabsTrigger value="tickets">Tickets</TabsTrigger>
-                <TabsTrigger value="workers">Workers</TabsTrigger>
-                <TabsTrigger value="queue">Queue</TabsTrigger>
-              </TabsList>
-            </Tabs>
-          </div>
-          <span style={{ flex: 1 }} />
-          <div style={{ display: "flex", alignItems: "center", gap: 14, fontSize: 11.5, color: C.fgMuted }}>
-            {data && <span style={{ display: "flex", alignItems: "center", gap: 6, color: C.fg }}><span className="catalyst-live-dot" style={{ width: 8, height: 8, borderRadius: "50%", background: LIVE, display: "inline-block" }} />{data.config.active} active{data.config.stuck > 0 ? ` · ${data.config.stuck} stuck` : ""}</span>}
-            <span style={{ display: "flex", alignItems: "center", gap: 6 }}><Dot color={C.green} pulse /> daemon</span>
-            <span style={{ display: "flex", alignItems: "center", gap: 6 }}><Dot color={C.green} pulse /> broker</span>
-            <span style={{ display: "flex", alignItems: "center", gap: 6 }}><Dot color={C.green} pulse /> monitor</span>
-            <span style={{ fontFamily: C.mono, fontSize: 10, letterSpacing: 1.5, color: status === "connected" ? C.green : C.red, border: `1px solid ${status === "connected" ? "rgba(57,208,122,0.35)" : "rgba(239,93,93,0.35)"}`, borderRadius: 5, padding: "2px 6px" }}>{status === "connected" ? "LIVE" : "OFFLINE"}</span>
-          </div>
-        </header>
+        {/* standalone-only chrome: the shell already provides the logo, nav, and
+            breadcrumb when embedded, so drop the duplicate top header there. */}
+        {!embedded && (
+          <header style={{ height: 48, display: "flex", alignItems: "center", gap: 18, padding: "0 16px", background: C.s1, borderBottom: `1px solid ${C.border}`, flex: "0 0 auto" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 9, fontWeight: 600 }}>
+              <span style={{ width: 16, height: 16, borderRadius: 4, background: "linear-gradient(135deg,#4ea1ff,#39d07a)", boxShadow: "0 0 12px rgba(78,161,255,0.45)" }} />Catalyst
+            </div>
+            <div className="cat-nav">
+              <Tabs value={view} onValueChange={(v) => setView(v as View)}>
+                <TabsList>
+                  <TabsTrigger value="tickets">Tickets</TabsTrigger>
+                  <TabsTrigger value="workers">Workers</TabsTrigger>
+                  <TabsTrigger value="queue">Queue</TabsTrigger>
+                </TabsList>
+              </Tabs>
+            </div>
+            <span style={{ flex: 1 }} />
+            <div style={{ display: "flex", alignItems: "center", gap: 14, fontSize: 11.5, color: C.fgMuted }}>
+              {data && <span style={{ display: "flex", alignItems: "center", gap: 6, color: C.fg }}><span className="catalyst-live-dot" style={{ width: 8, height: 8, borderRadius: "50%", background: LIVE, display: "inline-block" }} />{data.config.active} active{data.config.stuck > 0 ? ` · ${data.config.stuck} stuck` : ""}</span>}
+              <span style={{ display: "flex", alignItems: "center", gap: 6 }}><Dot color={C.green} pulse /> daemon</span>
+              <span style={{ display: "flex", alignItems: "center", gap: 6 }}><Dot color={C.green} pulse /> broker</span>
+              <span style={{ display: "flex", alignItems: "center", gap: 6 }}><Dot color={C.green} pulse /> monitor</span>
+              <span style={{ fontFamily: C.mono, fontSize: 10, letterSpacing: 1.5, color: status === "connected" ? C.green : C.red, border: `1px solid ${status === "connected" ? "rgba(57,208,122,0.35)" : "rgba(239,93,93,0.35)"}`, borderRadius: 5, padding: "2px 6px" }}>{status === "connected" ? "LIVE" : "OFFLINE"}</span>
+            </div>
+          </header>
+        )}
 
-        {/* subhead */}
+        {/* subhead — board view + lens/colorBy/repo controls, in BOTH hosts.
+            Embedded, the Tickets/Workers/Queue tabs move here (they live in the
+            standalone header above) so the board view stays switchable without
+            the shell's nav owning sub-surface state. */}
         <div style={{ display: "flex", alignItems: "center", gap: 14, padding: "10px 16px", flex: "0 0 auto", flexWrap: "wrap" }}>
+          {embedded && (
+            <div className="cat-nav">
+              <Tabs value={view} onValueChange={(v) => setView(v as View)}>
+                <TabsList>
+                  <TabsTrigger value="tickets">Tickets</TabsTrigger>
+                  <TabsTrigger value="workers">Workers</TabsTrigger>
+                  <TabsTrigger value="queue">Queue</TabsTrigger>
+                </TabsList>
+              </Tabs>
+            </div>
+          )}
           <h1 style={{ margin: 0, fontSize: 15, fontWeight: 600 }}>{view === "tickets" ? "Tickets" : view === "workers" ? "Workers" : "Capacity & queue"}</h1>
           <span style={{ color: C.fgMuted, fontSize: 12 }}>{view === "tickets" ? "Where each ticket sits in the pipeline · cyan = a worker is live on it now" : view === "workers" ? "Workers the daemon has deployed — active vs stuck" : "What's on the plate, and what dispatches next"}</span>
           <span style={{ flex: 1 }} />
@@ -627,12 +674,12 @@ export function Board() {
         <div style={{ flex: 1, minHeight: 0 }}>
           {!data && <div style={{ color: C.fgMuted, padding: 24 }}>Connecting to execution-core…</div>}
           {data && view === "tickets" && (combined
-            ? <TicketBoard tickets={fTickets} lens={lens} colorBy={colorBy} fill onSelect={(id) => setSelectedTicketId(id)} />
-            : <div className="cat-scroll" style={{ overflowY: "auto", height: "calc(100vh - 104px)", paddingTop: 4 }}>{ticketLanes.map((r) => <Lane key={r} repo={r}><TicketBoard tickets={fTickets.filter((t) => t.repo === r)} lens={lens} colorBy={colorBy} fill={false} onSelect={(id) => setSelectedTicketId(id)} /></Lane>)}</div>)}
+            ? <TicketBoard tickets={fTickets} lens={lens} colorBy={colorBy} fill fillHeight={fillHeight} onSelect={(id) => setSelectedTicketId(id)} />
+            : <div className="cat-scroll" style={{ overflowY: "auto", height: fillHeight, paddingTop: 4 }}>{ticketLanes.map((r) => <Lane key={r} repo={r}><TicketBoard tickets={fTickets.filter((t) => t.repo === r)} lens={lens} colorBy={colorBy} fill={false} onSelect={(id) => setSelectedTicketId(id)} /></Lane>)}</div>)}
           {data && view === "workers" && (combined
-            ? <WorkerBoard workers={fWorkers} tickets={data.tickets} grouping={workerGrouping} fill />
-            : <div className="cat-scroll" style={{ overflowY: "auto", height: "calc(100vh - 104px)", paddingTop: 4 }}>{workerLanes.map((r) => <Lane key={r} repo={r}><WorkerBoard workers={fWorkers.filter((w) => w.repo === r)} tickets={data.tickets} grouping={workerGrouping} fill={false} /></Lane>)}</div>)}
-          {data && view === "queue" && <QueueView data={{ ...data, queue: data.queue.filter((q) => repo === "all" || q.repo === repo) }} />}
+            ? <WorkerBoard workers={fWorkers} tickets={data.tickets} grouping={workerGrouping} fill fillHeight={fillHeight} />
+            : <div className="cat-scroll" style={{ overflowY: "auto", height: fillHeight, paddingTop: 4 }}>{workerLanes.map((r) => <Lane key={r} repo={r}><WorkerBoard workers={fWorkers.filter((w) => w.repo === r)} tickets={data.tickets} grouping={workerGrouping} fill={false} /></Lane>)}</div>)}
+          {data && view === "queue" && <QueueView data={{ ...data, queue: data.queue.filter((q) => repo === "all" || q.repo === repo) }} fillHeight={fillHeight} />}
         </div>
         {selectedTicket && (
           <TicketDetailDrawer
@@ -643,4 +690,20 @@ export function Board() {
       </div>
     </TooltipProvider>
   );
+}
+
+/**
+ * Standalone board (board.html, mounted by the FND1 router at `/`). Renders the
+ * BoardSurface with its own chrome — behavior-identical to the pre-CTL-905 board.
+ */
+export function Board() {
+  return <BoardSurface />;
+}
+
+/**
+ * The dense operator board mounted INSIDE the app shell's `board` surface
+ * (CTL-905 / BOARD1). Same data-driven surface, no duplicate chrome, edge-to-edge.
+ */
+export function EmbeddedBoard() {
+  return <BoardSurface embedded />;
 }


### PR DESCRIPTION
## BOARD1 — Dense Linear-anatomy operator board inside the new shell (CTL-905)

Wires the app shell's `board` surface to the real, data-driven dense operator board instead of falling through to the legacy dashboard.

### Context
The BOARD1 ticket's technical notes were authored against the untracked `mockups/home-proto/` prototype (which does not exist in the repo). The redesign dependencies all landed in the **real** `orch-monitor/ui` instead:
- FND1 (CTL-881) — TanStack Router routes
- FND2 (CTL-882) — `board/list-order.ts` `resolveList()` + jotai nav store
- SHELL1 (CTL-891) — edge-to-edge `AppShell` + left nav with `surface` state (home/board/workers/queue)
- BFF (CTL-883/886/888…) — cache-backed board payload

The shell's `surface` state was fully wired in the sidebar nav, ⌘K palette, and `g`-chords — but `App.tsx` ignored `surface` and always rendered the legacy `Dashboard` inset. So clicking "Board" highlighted the nav item while the content stayed the dashboard placeholder. That is the "placeholder, not the real dense board" this ticket fixes, in real-app terms.

### Change
- **`board/Board.tsx`**: extracted `BoardSurface` from the standalone `Board()`. One dense surface — the hand-rolled Linear-anatomy `TicketCard` (priority icon, type chip, phase pill, held badge, status, scope/estimate, phase strip, cost/turns or PR), the data-driven `Column`/`BoardScroll`/`TicketBoard` filtered by `linearState`|`phase` through the shared `resolveList` comparator (FND2), the reserved-cyan `#5be0ff` live-ring + pulsing live-dot, the red stuck treatment, and the CTL-733 SharedWorker SSE wiring — now renders in two hosts via an `embedded` flag:
  - standalone (`board.html`, FND1 router `/`): keeps its own logo header + daemon/broker/monitor health dots + LIVE pill, sizes to the viewport. **Byte-identical to before** (`Board()` === `<BoardSurface />`).
  - embedded (the shell's board surface): drops the duplicate chrome the shell already owns and flex-fills the `SidebarInset` edge-to-edge (`height:100%`), lanes flowing horizontally — the dense mode.
- **`App.tsx`**: new `EmbeddedBoard` export, lazy-mounted behind a `MonitorInset` gate that reads `useSurface()` inside the provider; `surface==="board"` renders the dense board, every other surface keeps the dashboard unchanged. Lazy so the SSE transport only boots when the operator switches to Board.
- No drag-and-drop: column membership stays derived from `linearState`/`phase` via `resolveList`, never a move handler (per the board doc follow-up).

### Gherkin scenarios
| Scenario | Status |
|---|---|
| **Board surface renders real tickets in the new shell** (dense Linear-anatomy card; status chip + progress indicator; columns filtered by linearState/phase, no drag) | **satisfied** — `EmbeddedBoard` mounts on `surface==="board"`; ports the dense `TicketCard` + `Column`/`TicketBoard` + `resolveList` column filter; live `connectBoard` SSE; no `@dnd-kit`/`useSortable`/`onDragEnd`. |
| **Live worker on a ticket is visibly distinguished** (reserved cyan live-ring + pulsing live dot; stuck → red) | **satisfied** — `catalystLiveRing`/`catalystLivePing` keyframes + `LIVE = "#5be0ff"` reserved for the live signal only; stuck uses the red border + `accentFor` red. |
| **Board fills the window edge-to-edge** (lanes flow horizontally, full viewport width in dense mode) | **satisfied** — embedded surface uses `height:100%` / `fillHeight:100%` (not a re-imposed `100vh` box), `overflowX:auto` with fixed 300px columns, and the inset has no `max-w`/`mx-auto` gutter. |

**Single-node descope:** N/A — this ticket has no cluster/fence/multi-host behavior to descope.

### Tests / validation
- `__tests__/board-surface.test.ts` (new): 12 tests encoding all three scenarios — source-analysis for the structural wiring + a `resolveList` unit assertion that column membership is data-driven by `linearState`|`phase` (Linear-state lens vs Pipeline lens), payload order preserved, no re-sort.
- `bunx tsc --noEmit` (ui): no new errors from touched files (one pre-existing `kpi-strip.tsx` error on clean main is unrelated). orch-monitor package tsc clean.
- `bun run build` (ui): green; the board is now its own lazy chunk.
- Targeted suites green: `app-shell`, `board-surface`, `board-todo-column`, `board-phase-drift`, `board-current-phase`, `board-held-indicator`, `board-snapshot`, `board-phase-summary`, `board-client`, `list-order`, `recents` (80 + 22 pass).
- (Did NOT run the red-on-main `run-tests.sh` aggregate per the operational guidance; build artifacts under `public/` were intentionally not committed, matching the FND/SHELL source-only convention.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)