### PR TITLE
feat(dev): HUD2 terminal HUD consumes the shared read-model (CTL-920)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/Dashboard.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/Dashboard.tsx
@@ -5,6 +5,7 @@ import type { BrokerInterest } from "../lib/broker-interests-reader.ts";
 import { readBrokerInterests } from "../lib/broker-interests-reader.ts";
 import type { WorkerSignal } from "../lib/worker-signals-reader.ts";
 import { readWorkerSignals } from "../lib/worker-signals-reader.ts";
+import { selectWorkers } from "../lib/read-model-workers.ts";
 import type { OrchState } from "../lib/orch-state-reader.ts";
 import { readOrchStates } from "../lib/orch-state-reader.ts";
 import type { RunRow } from "../lib/runs-reader.ts";
@@ -39,6 +40,15 @@ interface DashboardProps {
    * the SAME contract. Optional/additive — absent ⇒ no node label rendered.
    */
   nodeName?: string;
+  /**
+   * CTL-920 / HUD2: the Workers view's PRIMARY state, mapped from the shared
+   * read-model SSE (the SAME assembled BoardWorker[] the web/iPad render). When
+   * non-null the Dashboard renders THESE rows instead of re-deriving them from
+   * raw `workers/*.json` scans — one assembly, many readers. When null the
+   * read-model is unavailable (server down) and the Dashboard falls back to its
+   * raw-file scan so the HUD never goes dark.
+   */
+  readModelWorkers?: WorkerSignal[] | null;
 }
 
 interface DashboardState {
@@ -71,7 +81,14 @@ function rowCount(view: DashboardView, state: DashboardState): number {
   return state.runs.length;
 }
 
-export function Dashboard({ visibleRows, cols, brokerState, onClose, nodeName }: DashboardProps) {
+export function Dashboard({
+  visibleRows,
+  cols,
+  brokerState,
+  onClose,
+  nodeName,
+  readModelWorkers,
+}: DashboardProps) {
   const [view, setView] = useState<DashboardView>("interests");
   const [data, setData] = useState<DashboardState>(() => readAll());
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -88,8 +105,15 @@ export function Dashboard({ visibleRows, cols, brokerState, onClose, nodeName }:
     return () => clearInterval(id);
   }, []);
 
+  // CTL-920 / HUD2: prefer the read-model-backed workers (the shared assembled
+  // BoardWorker[] the web/iPad render). When the read-model is unavailable
+  // (server down ⇒ prop is null), fall back to the raw `workers/*.json` scan so
+  // the HUD never goes dark. The em-dash "—" entries the read-model worker slice
+  // omits (PR, worktree) render identically to a raw signal that lacks them.
+  const effectiveWorkers = selectWorkers(readModelWorkers ?? null, data.workers);
+
   const sortedWorkers = useMemo(() => {
-    const arr = [...data.workers];
+    const arr = [...effectiveWorkers];
     const dir = workerSortDir === "asc" ? 1 : -1;
     arr.sort((a, b) => {
       let av: number | string, bv: number | string;
@@ -111,7 +135,7 @@ export function Dashboard({ visibleRows, cols, brokerState, onClose, nodeName }:
       return 0;
     });
     return arr;
-  }, [data.workers, workerSortKey, workerSortDir]);
+  }, [effectiveWorkers, workerSortKey, workerSortDir]);
 
   const sortedOrchs = useMemo(() => {
     const arr = [...data.orchs];

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useReadModel.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useReadModel.ts
@@ -1,0 +1,93 @@
+// useReadModel.ts — the terminal HUD's React hook onto the shared read-model SSE
+// (CTL-920 / HUD2).
+//
+// This is the thin React adapter over createReadModelConnection() (the tested,
+// React-free controller). It subscribes to the SAME `/api/board/stream` the
+// web/iPad consume, through the SAME contract (lib/read-model-client), so the
+// HUD's PRIMARY state (workers/tickets/queue/config) comes from the one
+// assembly the BFF fans out — not from the HUD re-deriving it by scanning raw
+// files. When the server is down the connection reports `down` and the HUD's
+// callers fall back to their existing raw-file readers, so the HUD never blocks
+// on the read-model endpoint.
+//
+// The HUD's live event-log drill-down tail (useEventLog) is DELIBERATELY left
+// alone — per the cluster design, per-host event logs serve only the drill-down;
+// only the HUD's primary fleet state moves onto the read-model here.
+
+import { useEffect, useState, useRef } from "react";
+
+import {
+  createReadModelConnection,
+  type ReadModelConnectionState,
+  type ReadModelStatus,
+} from "../lib/read-model-connection";
+import { createNodeEventSource } from "../lib/node-event-source";
+import { resolveReadModelUrl } from "../lib/read-model-url";
+import {
+  groupByHost,
+  type ReadModelPayload,
+  type ClusterReadModel,
+  type ReadModelEventSource,
+} from "../../lib/read-model-client";
+import { localHostRef } from "../lib/read-model-cluster";
+
+export interface UseReadModelOptions {
+  /** Override the SSE URL (defaults to resolveReadModelUrl(process.env)). */
+  url?: string;
+  /** Override the EventSource factory (defaults to the fetch-based Node one). */
+  eventSourceFactory?: (url: string) => ReadModelEventSource;
+}
+
+export interface UseReadModelResult {
+  /** Connection status. `connected` ⇒ primary state is read-model-backed;
+   *  `down` ⇒ the caller should fall back to its raw-file scan. */
+  status: ReadModelStatus;
+  /** The latest decoded read-model snapshot, or null before the first one. */
+  payload: ReadModelPayload | null;
+  /** The node-aware view of the latest payload (single-host ⇒ one group — the
+   *  identity no-op; N>1 ⇒ N groups via the same contract). null until a payload
+   *  lands. */
+  cluster: ClusterReadModel | null;
+  /** True while the read-model is the live source of primary state. */
+  connected: boolean;
+}
+
+/**
+ * Subscribe to the shared read-model SSE for the lifetime of the HUD process.
+ * Returns the latest snapshot, its node-aware cluster view, and a connection
+ * status the caller uses to choose read-model vs raw-file fallback.
+ */
+export function useReadModel(options: UseReadModelOptions = {}): UseReadModelResult {
+  // Host identity is stable for the process lifetime; resolve once.
+  const localRef = useRef(localHostRef()).current;
+  const url = useRef(options.url ?? resolveReadModelUrl(process.env)).current;
+  const factory = useRef(
+    options.eventSourceFactory ?? ((u: string) => createNodeEventSource(u)),
+  ).current;
+
+  const [state, setState] = useState<ReadModelConnectionState>({
+    status: "connecting",
+    payload: null,
+  });
+
+  useEffect(() => {
+    const conn = createReadModelConnection({
+      url,
+      eventSourceFactory: factory,
+      onChange: setState,
+    });
+    conn.start();
+    // Seed initial state in case start() synchronously transitioned.
+    setState(conn.snapshot());
+    return () => conn.stop();
+  }, [url, factory]);
+
+  const cluster = state.payload ? groupByHost(state.payload, localRef) : null;
+
+  return {
+    status: state.status,
+    payload: state.payload,
+    cluster,
+    connected: state.status === "connected",
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -38,6 +38,14 @@ import { loadHudConfig } from "../lib/monitor-config.ts";
 // read-model contract the web/iPad client uses. Single-host ⇒ one node (identity
 // no-op); the contract is the typed door HUD2's cluster consolidation builds on.
 import { localHostRef } from "./lib/read-model-cluster.ts";
+// CTL-920 / HUD2: the HUD consumes the shared read-model SSE for its PRIMARY
+// fleet state (the SAME `/api/board/stream` the web/iPad consume — one assembly,
+// many readers) and maps the assembled BoardWorker[] onto the Dashboard's
+// Workers view. When the server is down the hook reports `connected: false` and
+// the HUD falls back to its raw `workers/*.json` scan, so it never goes dark.
+import { useReadModel } from "./hooks/useReadModel.ts";
+import { boardWorkersToSignals } from "./lib/read-model-workers.ts";
+import type { WorkerSignal } from "./lib/worker-signals-reader.ts";
 
 interface AppProps {
   repoFilter: string;
@@ -170,6 +178,22 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
   // single-host fleet shows this one node on the Dashboard's view tabs (identity
   // no-op); the multi-node HUD groups by host through the same contract.
   const nodeName = useRef(localHostRef().name).current;
+
+  // CTL-920 / HUD2: subscribe to the shared read-model SSE for primary fleet
+  // state. `connected` ⇒ the read-model is driving the Workers view; otherwise
+  // the Dashboard falls back to its raw-file scan (graceful degrade). This adds
+  // the SSE/fetch client path the HUD never had — and consumes the EXACT stream
+  // the web/iPad consume, so a fix to the BFF assembly reaches all three readers.
+  const readModel = useReadModel();
+  // Map the assembled BoardWorker[] onto the Dashboard's WorkerSignal rows when
+  // connected; null tells the Dashboard to use its raw `workers/*.json` scan.
+  const readModelWorkers = useMemo<WorkerSignal[] | null>(
+    () =>
+      readModel.connected && readModel.payload
+        ? boardWorkersToSignals(readModel.payload.workers, Date.now())
+        : null,
+    [readModel.connected, readModel.payload],
+  );
 
   // CTL-473: hoist the Header `version` literal so the memoized Header can
   // short-circuit. `versionChip` is frozen at mount via useRef, so this memo
@@ -526,6 +550,7 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
             cols={innerCols}
             brokerState={brokerState}
             nodeName={nodeName}
+            readModelWorkers={readModelWorkers}
             onClose={() => setShowDashboard(false)}
           />
         ) : (

--- a/plugins/dev/scripts/orch-monitor/cli/lib/node-event-source.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/node-event-source.test.ts
@@ -1,0 +1,131 @@
+// CTL-920 / HUD2: bun/Node has no global `EventSource`, so the HUD injects this
+// fetch-based one into the SHARED `subscribeReadModel()` helper. These tests
+// prove it parses the SSE wire framing the server emits
+// (`event: board\ndata: <json>\n\n`, server.ts:2001) and conforms to the
+// contract's minimal `ReadModelEventSource` shape — addEventListener / close /
+// onerror — so the SAME subscribe logic drives the HUD and the browser.
+import { describe, it, expect } from "bun:test";
+import { createNodeEventSource } from "./node-event-source";
+import {
+  subscribeReadModel,
+  type ReadModelPayload,
+} from "../../lib/read-model-client";
+
+function payload(overrides: Partial<ReadModelPayload> = {}): ReadModelPayload {
+  return {
+    generatedAt: "2026-06-09T00:00:00.000Z",
+    config: { maxParallel: 6, inFlight: 0, freeSlots: 6, active: 0, working: 0, stuck: 0 },
+    repos: [],
+    workers: [],
+    tickets: [],
+    queue: [],
+    ...overrides,
+  };
+}
+
+function sseFrame(p: ReadModelPayload): string {
+  return `event: board\ndata: ${JSON.stringify(p)}\n\n`;
+}
+
+/** A fetch stub that streams the given chunks then ends the body. */
+function fetchStreaming(chunks: string[]): typeof fetch {
+  return (async () => {
+    const enc = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const c of chunks) controller.enqueue(enc.encode(c));
+        controller.close();
+      },
+    });
+    return new Response(stream, { status: 200 });
+  }) as unknown as typeof fetch;
+}
+
+describe("createNodeEventSource (CTL-920)", () => {
+  it("decodes a single SSE board frame and delivers it to the matching listener", async () => {
+    const p = payload({ generatedAt: "2026-06-09T01:02:03.000Z" });
+    const es = createNodeEventSource("http://x/api/board/stream", {
+      fetchImpl: fetchStreaming([sseFrame(p)]),
+    });
+    const got: string[] = [];
+    es.addEventListener("board", (ev) => got.push(ev.data));
+    await es.whenIdle();
+    expect(got.length).toBe(1);
+    expect(JSON.parse(got[0]!).generatedAt).toBe("2026-06-09T01:02:03.000Z");
+    es.close();
+  });
+
+  it("reassembles a frame split across multiple network chunks", async () => {
+    const p = payload();
+    const whole = sseFrame(p);
+    const mid = Math.floor(whole.length / 2);
+    const es = createNodeEventSource("http://x/api/board/stream", {
+      fetchImpl: fetchStreaming([whole.slice(0, mid), whole.slice(mid)]),
+    });
+    const got: string[] = [];
+    es.addEventListener("board", (ev) => got.push(ev.data));
+    await es.whenIdle();
+    expect(got.length).toBe(1);
+    es.close();
+  });
+
+  it("drives the SHARED subscribeReadModel() helper end-to-end", async () => {
+    const p = payload({ workers: [] });
+    const factory = (url: string) =>
+      createNodeEventSource(url, { fetchImpl: fetchStreaming([sseFrame(p)]) });
+    const snaps: ReadModelPayload[] = [];
+    subscribeReadModel(
+      { onSnapshot: (s) => snaps.push(s) },
+      { url: "http://x/api/board/stream", eventSourceFactory: factory },
+    );
+    // Give the injected stream a microtask turn to flush.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(snaps.length).toBe(1);
+    expect(Array.isArray(snaps[0]!.workers)).toBe(true);
+  });
+
+  it("invokes onerror when the connection fails, never throwing into the loop", async () => {
+    const failing = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const es = createNodeEventSource("http://x/api/board/stream", { fetchImpl: failing });
+    let errored = false;
+    es.onerror = () => {
+      errored = true;
+    };
+    await es.whenIdle();
+    expect(errored).toBe(true);
+    es.close();
+  });
+
+  it("a non-200 response triggers onerror (server up but endpoint missing)", async () => {
+    const notFound = (async () => new Response("nope", { status: 404 })) as unknown as typeof fetch;
+    const es = createNodeEventSource("http://x/api/board/stream", { fetchImpl: notFound });
+    let errored = false;
+    es.onerror = () => {
+      errored = true;
+    };
+    await es.whenIdle();
+    expect(errored).toBe(true);
+    es.close();
+  });
+
+  it("close() before the body resolves aborts and delivers no events", async () => {
+    let aborted = false;
+    const slow = ((_url: string, init?: { signal?: AbortSignal }) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          aborted = true;
+          reject(new Error("aborted"));
+        });
+      });
+    }) as unknown as typeof fetch;
+    const es = createNodeEventSource("http://x/api/board/stream", { fetchImpl: slow });
+    const got: string[] = [];
+    es.addEventListener("board", (ev) => got.push(ev.data));
+    es.close();
+    await es.whenIdle();
+    expect(aborted).toBe(true);
+    expect(got.length).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/lib/node-event-source.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/node-event-source.ts
@@ -1,0 +1,173 @@
+// node-event-source.ts — a tiny fetch-based Server-Sent-Events client for the
+// terminal HUD (CTL-920 / HUD2).
+//
+// WHY THIS EXISTS
+// ---------------
+// The shared read-model contract (lib/read-model-client.ts) ships a
+// transport-agnostic `subscribeReadModel()` that defaults to the browser's
+// global `EventSource`. The Node/bun runtime the HUD runs in has NO global
+// `EventSource`, so the contract lets a non-browser host INJECT an
+// `eventSourceFactory`. This file is that factory: a minimal `EventSource`-shaped
+// client built on `fetch` (which bun/Node DO have), so the HUD subscribes to the
+// SAME `/api/board/stream` SSE the web/iPad consume — one assembly, many readers.
+//
+// It implements only the surface the contract depends on
+// (`ReadModelEventSource`: addEventListener / close / onerror) plus a
+// test-only `whenIdle()` so suites can await the streamed body deterministically.
+// It is dependency-free (no `eventsource` npm package), honouring the repo's
+// "markdown + bash + bun stdlib" constraint.
+//
+// SCOPE: this is a one-shot reader of the current stream connection. Reconnect /
+// backoff policy is owned by the HUD hook (useReadModel) so this stays a thin,
+// well-tested transport — exactly as the contract's `subscribeReadModel()` is
+// transport-only.
+
+import type { ReadModelEventSource } from "../../lib/read-model-client";
+
+type SseListener = (ev: { data: string }) => void;
+
+export interface NodeEventSourceOptions {
+  /** Injectable `fetch` for tests; defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+/** The HUD-facing handle: the contract's `ReadModelEventSource` plus a
+ *  test-only `whenIdle()` that resolves once the streamed body is fully drained
+ *  (or the connection errored / was closed). */
+export interface NodeEventSource extends ReadModelEventSource {
+  /** Resolves when the underlying stream has finished draining. Test-only — the
+   *  HUD never awaits it (it reacts to events), but suites need a deterministic
+   *  settle point. */
+  whenIdle(): Promise<void>;
+}
+
+/**
+ * Open an SSE connection to `url` and dispatch each `event: <name>` frame to the
+ * listeners registered for `<name>`. Conforms to the contract's
+ * `ReadModelEventSource` so it slots straight into `subscribeReadModel()`.
+ *
+ * Failure modes are funnelled to `onerror` (never thrown into the consumer's
+ * loop): a rejected `fetch` (server down — the graceful-degrade path), a non-2xx
+ * response (endpoint absent), or a mid-stream read error. The HUD hook treats any
+ * `onerror` as "read-model unavailable" and falls back to its raw-file scan.
+ */
+export function createNodeEventSource(
+  url: string,
+  options: NodeEventSourceOptions = {},
+): NodeEventSource {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const listeners = new Map<string, Set<SseListener>>();
+  const controller = new AbortController();
+  let closed = false;
+
+  const self: NodeEventSource = {
+    addEventListener(type, listener) {
+      let set = listeners.get(type);
+      if (!set) {
+        set = new Set();
+        listeners.set(type, set);
+      }
+      set.add(listener);
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      controller.abort();
+    },
+    onerror: null,
+    whenIdle: () => idle,
+  };
+
+  const fail = (err: unknown) => {
+    if (closed) return;
+    self.onerror?.(err);
+  };
+
+  const dispatch = (eventName: string, data: string) => {
+    const set = listeners.get(eventName);
+    if (!set) return;
+    for (const l of set) l({ data });
+  };
+
+  // Drive the connection. The returned promise (`idle`) settles when the body is
+  // drained or the connection ends — consumers ignore it; tests await it.
+  const idle = (async () => {
+    let res: Response;
+    try {
+      res = await fetchImpl(url, {
+        signal: controller.signal,
+        headers: { Accept: "text/event-stream" },
+      });
+    } catch (err) {
+      fail(err);
+      return;
+    }
+    if (!res.ok || !res.body) {
+      fail(new Error(`read-model stream HTTP ${res.status}`));
+      return;
+    }
+    try {
+      await pump(res.body, dispatch, () => closed);
+    } catch (err) {
+      // An abort (close()) is expected — surface only genuine read errors.
+      if (!closed) fail(err);
+    }
+  })();
+
+  return self;
+}
+
+/**
+ * Read the SSE byte stream, buffering partial frames across network chunks, and
+ * dispatch each complete `event:`/`data:` block. SSE frames are separated by a
+ * blank line (`\n\n`); a frame may carry multiple `data:` lines (joined by `\n`
+ * per the spec). We track the most recent `event:` name (defaulting to
+ * `"message"`) so the contract's `READ_MODEL_SSE_EVENT === "board"` matches the
+ * server's `event: board` framing (server.ts:2001).
+ */
+async function pump(
+  body: ReadableStream<Uint8Array>,
+  dispatch: (eventName: string, data: string) => void,
+  isClosed: () => boolean,
+): Promise<void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  // Normalise CRLF and split off every complete frame currently in `buffer`.
+  const flushFrames = () => {
+    buffer = buffer.replace(/\r\n/g, "\n");
+    let sep = buffer.indexOf("\n\n");
+    while (sep !== -1) {
+      const block = buffer.slice(0, sep);
+      buffer = buffer.slice(sep + 2);
+      emitBlock(block, dispatch);
+      sep = buffer.indexOf("\n\n");
+    }
+  };
+
+  for (;;) {
+    if (isClosed()) return;
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    flushFrames();
+  }
+  // Flush a trailing frame the server emitted without a final blank line.
+  buffer += decoder.decode();
+  if (buffer.trim()) emitBlock(buffer, dispatch);
+}
+
+function emitBlock(block: string, dispatch: (eventName: string, data: string) => void): void {
+  let eventName = "message";
+  const dataLines: string[] = [];
+  for (const line of block.split("\n")) {
+    if (line.startsWith(":")) continue; // SSE comment / heartbeat keep-alive
+    if (line.startsWith("event:")) {
+      eventName = line.slice("event:".length).trim();
+    } else if (line.startsWith("data:")) {
+      dataLines.push(line.slice("data:".length).replace(/^ /, ""));
+    }
+  }
+  if (dataLines.length > 0) dispatch(eventName, dataLines.join("\n"));
+}

--- a/plugins/dev/scripts/orch-monitor/cli/lib/read-model-connection.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/read-model-connection.test.ts
@@ -1,0 +1,152 @@
+// CTL-920 / HUD2: the HUD's read-model connection controller. Drives the SHARED
+// subscribeReadModel() contract, tracks connection status, and reconnects when
+// the server comes back — the pure core behind useReadModel(), tested without
+// React. Encodes the ticket's Gherkin: primary state from the SSE when up;
+// graceful "down" status (→ raw-file fallback) when the server is absent.
+import { describe, it, expect } from "bun:test";
+import { createReadModelConnection } from "./read-model-connection";
+import type {
+  ReadModelPayload,
+  ReadModelEventSource,
+} from "../../lib/read-model-client";
+
+function payload(overrides: Partial<ReadModelPayload> = {}): ReadModelPayload {
+  return {
+    generatedAt: "2026-06-09T00:00:00.000Z",
+    config: { maxParallel: 6, inFlight: 0, freeSlots: 6, active: 0, working: 0, stuck: 0 },
+    repos: [],
+    workers: [],
+    tickets: [],
+    queue: [],
+    ...overrides,
+  };
+}
+
+/** A controllable fake EventSource: the test pushes snapshots / errors at will. */
+function fakeSource() {
+  const listeners = new Map<string, (ev: { data: string }) => void>();
+  let onerror: ((ev: unknown) => void) | null = null;
+  let closed = false;
+  const es: ReadModelEventSource = {
+    addEventListener(type, l) {
+      listeners.set(type, l);
+    },
+    close() {
+      closed = true;
+    },
+    get onerror() {
+      return onerror;
+    },
+    set onerror(fn) {
+      onerror = fn;
+    },
+  };
+  return {
+    es,
+    pushSnapshot: (p: ReadModelPayload) => listeners.get("board")?.({ data: JSON.stringify(p) }),
+    pushRaw: (data: string) => listeners.get("board")?.({ data }),
+    pushError: () => onerror?.(new Error("stream error")),
+    isClosed: () => closed,
+  };
+}
+
+describe("createReadModelConnection (CTL-920)", () => {
+  it("starts in 'connecting' and flips to 'connected' on the first snapshot", () => {
+    const fake = fakeSource();
+    const states: string[] = [];
+    const conn = createReadModelConnection({
+      url: "http://x/api/board/stream",
+      eventSourceFactory: () => fake.es,
+      onChange: (s) => states.push(s.status),
+    });
+    conn.start();
+    expect(conn.snapshot().status).toBe("connecting");
+    fake.pushSnapshot(payload({ generatedAt: "2026-06-09T09:09:09.000Z" }));
+    expect(conn.snapshot().status).toBe("connected");
+    expect(conn.snapshot().payload?.generatedAt).toBe("2026-06-09T09:09:09.000Z");
+    expect(states).toContain("connected");
+    conn.stop();
+  });
+
+  it("flips to 'down' on a stream error (graceful-degrade → raw-file fallback)", () => {
+    const fake = fakeSource();
+    const conn = createReadModelConnection({
+      url: "http://x/api/board/stream",
+      eventSourceFactory: () => fake.es,
+    });
+    conn.start();
+    fake.pushError();
+    expect(conn.snapshot().status).toBe("down");
+    conn.stop();
+  });
+
+  it("schedules a reconnect after an error so a restarted server is re-consumed", () => {
+    let built = 0;
+    const fakes: ReturnType<typeof fakeSource>[] = [];
+    const scheduled: Array<() => void> = [];
+    const conn = createReadModelConnection({
+      url: "http://x/api/board/stream",
+      eventSourceFactory: () => {
+        built++;
+        const f = fakeSource();
+        fakes.push(f);
+        return f.es;
+      },
+      reconnectDelayMs: 1000,
+      setTimer: (fn) => {
+        scheduled.push(fn);
+        return 0;
+      },
+      clearTimer: () => {},
+    });
+    conn.start();
+    expect(built).toBe(1);
+    fakes[0]!.pushError();
+    expect(conn.snapshot().status).toBe("down");
+    // Fire the scheduled reconnect.
+    expect(scheduled.length).toBe(1);
+    scheduled[0]!();
+    expect(built).toBe(2);
+    expect(conn.snapshot().status).toBe("connecting");
+    // The new connection delivers a snapshot → connected again.
+    fakes[1]!.pushSnapshot(payload());
+    expect(conn.snapshot().status).toBe("connected");
+    conn.stop();
+  });
+
+  it("stop() closes the underlying source and cancels a pending reconnect", () => {
+    const fake = fakeSource();
+    let cleared = false;
+    const conn = createReadModelConnection({
+      url: "http://x/api/board/stream",
+      eventSourceFactory: () => fake.es,
+      setTimer: () => 7,
+      clearTimer: () => {
+        cleared = true;
+      },
+    });
+    conn.start();
+    fake.pushError(); // schedules a reconnect timer
+    conn.stop();
+    expect(fake.isClosed()).toBe(true);
+    expect(cleared).toBe(true);
+  });
+
+  it("a malformed frame is skipped via the shared decoder (no crash, stays connecting)", () => {
+    const fake = fakeSource();
+    const conn = createReadModelConnection({
+      url: "http://x/api/board/stream",
+      eventSourceFactory: () => fake.es,
+    });
+    conn.start();
+    // The connection routes every frame through decodeReadModelFrame(); a garbage
+    // frame returns null and is dropped, so status never advances to "connected".
+    fake.pushRaw("this is not json");
+    expect(conn.snapshot().status).toBe("connecting");
+    expect(conn.snapshot().payload).toBeNull();
+    // A valid frame after the garbage one still lands.
+    fake.pushSnapshot(payload());
+    expect(conn.snapshot().status).toBe("connected");
+    conn.stop();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/lib/read-model-connection.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/read-model-connection.ts
@@ -1,0 +1,142 @@
+// read-model-connection.ts — the terminal HUD's read-model connection controller
+// (CTL-920 / HUD2). The pure, React-free core behind the useReadModel() hook.
+//
+// WHY A CONTROLLER (not just a hook)
+// ----------------------------------
+// All the load-bearing behavior — subscribe via the SHARED contract, track
+// connection status, reconnect when a stopped server comes back, fall to "down"
+// (so the HUD drops to its raw-file scan) on error — is plain state-machine
+// logic. Putting it in a controller lets it be unit-tested deterministically
+// (inject the EventSource factory + timers) without rendering React; the hook is
+// then a thin React adapter over `subscribe()`.
+//
+// ONE ASSEMBLY, MANY READERS
+// --------------------------
+// The HUD consumes the EXACT same `/api/board/stream` SSE the web/iPad consume,
+// decoded through the SAME `decodeReadModelFrame()` / `subscribeReadModel()`
+// contract (lib/read-model-client.ts). So a fix to how the BFF assembles worker
+// state reaches the HUD, the web board, and the iPad identically — no
+// HUD-specific data-path.
+
+import {
+  subscribeReadModel,
+  type ReadModelPayload,
+  type ReadModelEventSource,
+  type ReadModelSubscription,
+} from "../../lib/read-model-client";
+
+/** Connection lifecycle as the HUD sees it. `down` is the signal to fall back to
+ *  the raw-file scan; `connected` means the read-model is driving primary state. */
+export type ReadModelStatus = "connecting" | "connected" | "down";
+
+export interface ReadModelConnectionState {
+  status: ReadModelStatus;
+  /** The most recent decoded snapshot, or null before the first one lands. */
+  payload: ReadModelPayload | null;
+}
+
+export interface ReadModelConnectionOptions {
+  /** Absolute SSE URL (see resolveReadModelUrl). */
+  url: string;
+  /** Node EventSource factory (createNodeEventSource); tests inject a fake. */
+  eventSourceFactory: (url: string) => ReadModelEventSource;
+  /** Notified on every state transition so the hook can re-render. */
+  onChange?: (state: ReadModelConnectionState) => void;
+  /** Delay before retrying a dropped/failed connection. Default 3s. */
+  reconnectDelayMs?: number;
+  /** Injectable timer fns (default global setTimeout/clearTimeout) for tests. */
+  setTimer?: (fn: () => void, ms: number) => unknown;
+  clearTimer?: (handle: unknown) => void;
+}
+
+export interface ReadModelConnection {
+  /** Open the connection (idempotent). */
+  start(): void;
+  /** Close the connection and cancel any pending reconnect (idempotent). */
+  stop(): void;
+  /** Read the current state synchronously. */
+  snapshot(): ReadModelConnectionState;
+}
+
+export function createReadModelConnection(
+  options: ReadModelConnectionOptions,
+): ReadModelConnection {
+  const reconnectMs = options.reconnectDelayMs ?? 3000;
+  const setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+  const clearTimer = options.clearTimer ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
+
+  let state: ReadModelConnectionState = { status: "connecting", payload: null };
+  let subscription: ReadModelSubscription | null = null;
+  let reconnectHandle: unknown = null;
+  let started = false;
+  let stopped = false;
+
+  const set = (next: Partial<ReadModelConnectionState>) => {
+    state = { ...state, ...next };
+    options.onChange?.(state);
+  };
+
+  const clearReconnect = () => {
+    if (reconnectHandle !== null) {
+      clearTimer(reconnectHandle);
+      reconnectHandle = null;
+    }
+  };
+
+  const connect = () => {
+    if (stopped) return;
+    // A reconnect attempt is a fresh "connecting" cycle; preserve the last
+    // payload so the HUD keeps showing the most-recent picture while it retries.
+    set({ status: "connecting" });
+    subscription = subscribeReadModel(
+      {
+        onSnapshot: (payload) => {
+          if (stopped) return;
+          set({ status: "connected", payload });
+        },
+        onError: () => {
+          if (stopped) return;
+          // The stream dropped (server down / restarted). Mark down so the HUD
+          // falls back to its raw-file scan, then schedule a reconnect so a
+          // server that comes back up is re-consumed without a HUD restart.
+          set({ status: "down" });
+          teardownSubscription();
+          scheduleReconnect();
+        },
+      },
+      { url: options.url, eventSourceFactory: options.eventSourceFactory },
+    );
+  };
+
+  const scheduleReconnect = () => {
+    clearReconnect();
+    reconnectHandle = setTimer(() => {
+      reconnectHandle = null;
+      connect();
+    }, reconnectMs);
+  };
+
+  const teardownSubscription = () => {
+    if (subscription) {
+      subscription.close();
+      subscription = null;
+    }
+  };
+
+  return {
+    start() {
+      if (started) return;
+      started = true;
+      stopped = false;
+      connect();
+    },
+    stop() {
+      stopped = true;
+      clearReconnect();
+      teardownSubscription();
+    },
+    snapshot() {
+      return state;
+    },
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/cli/lib/read-model-url.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/read-model-url.test.ts
@@ -1,0 +1,41 @@
+// CTL-920 / HUD2: the HUD resolves the local orch-monitor server's read-model
+// SSE URL the same way the server binds its port — MONITOR_PORT env, else the
+// 7400 default — so the HUD's new client path points at the exact stream the
+// web/iPad consume. Pure + env-injectable so we never touch process.env in tests.
+import { describe, it, expect } from "bun:test";
+import { resolveReadModelUrl, DEFAULT_MONITOR_PORT } from "./read-model-url";
+
+describe("resolveReadModelUrl (CTL-920)", () => {
+  it("defaults to the loopback host on the server's default port", () => {
+    expect(resolveReadModelUrl({})).toBe(
+      `http://127.0.0.1:${DEFAULT_MONITOR_PORT}/api/board/stream`,
+    );
+  });
+
+  it("honours MONITOR_PORT exactly as server.ts does", () => {
+    expect(resolveReadModelUrl({ MONITOR_PORT: "8123" })).toBe(
+      "http://127.0.0.1:8123/api/board/stream",
+    );
+  });
+
+  it("falls back to the default port when MONITOR_PORT is empty or non-numeric", () => {
+    expect(resolveReadModelUrl({ MONITOR_PORT: "" })).toBe(
+      `http://127.0.0.1:${DEFAULT_MONITOR_PORT}/api/board/stream`,
+    );
+    expect(resolveReadModelUrl({ MONITOR_PORT: "not-a-port" })).toBe(
+      `http://127.0.0.1:${DEFAULT_MONITOR_PORT}/api/board/stream`,
+    );
+  });
+
+  it("an explicit CATALYST_MONITOR_URL base wins over the port (remote/proxied server)", () => {
+    expect(resolveReadModelUrl({ CATALYST_MONITOR_URL: "http://mac-mini.local:9000" })).toBe(
+      "http://mac-mini.local:9000/api/board/stream",
+    );
+  });
+
+  it("trims a trailing slash on the base URL so the path is not doubled", () => {
+    expect(resolveReadModelUrl({ CATALYST_MONITOR_URL: "http://host:9000/" })).toBe(
+      "http://host:9000/api/board/stream",
+    );
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/lib/read-model-url.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/read-model-url.ts
@@ -1,0 +1,53 @@
+// read-model-url.ts — resolve the local orch-monitor server's read-model SSE
+// URL for the terminal HUD (CTL-920 / HUD2).
+//
+// The HUD has historically made ZERO `fetch`/`EventSource` calls — it scanned
+// raw files itself. HUD2 makes it a CONSUMER of the shared read-model SSE the
+// web/iPad already consume (`/api/board/stream`). The web client uses a
+// browser-relative path (the page origin IS the server); the Node-side HUD has
+// no page origin, so it must build an ABSOLUTE URL pointing at the local server.
+//
+// It resolves the port the SAME way the server binds it (server.ts:2189-2190 —
+// `MONITOR_PORT` env, else the 7400 default) so the HUD always targets the exact
+// stream the server is serving. An explicit `CATALYST_MONITOR_URL` base wins for
+// the rare proxied/remote case. This is pure + env-injectable; the HUD passes
+// `process.env`, tests pass a literal.
+
+import { READ_MODEL_STREAM_PATH } from "../../lib/read-model-client";
+
+/** The server's default port (server.ts:243 `DEFAULT_PORT = 7400`). */
+export const DEFAULT_MONITOR_PORT = 7400;
+
+/**
+ * The env this resolver reads. A plain string→string|undefined record so the
+ * HUD can pass `process.env` directly (Bun's `ProcessEnv`) while tests pass a
+ * literal. Only `MONITOR_PORT` and `CATALYST_MONITOR_URL` are consulted.
+ */
+export type ReadModelUrlEnv = Record<string, string | undefined>;
+
+/**
+ * Resolve the absolute SSE URL the HUD subscribes to.
+ *
+ * Precedence:
+ *   1. `CATALYST_MONITOR_URL` base (trailing slash trimmed) + the stream path.
+ *   2. `http://127.0.0.1:<MONITOR_PORT|7400>` + the stream path.
+ *
+ * The path component is the shared `READ_MODEL_STREAM_PATH` from the contract,
+ * so the HUD and the web client agree on the endpoint by construction.
+ */
+export function resolveReadModelUrl(env: ReadModelUrlEnv): string {
+  const base = explicitBase(env.CATALYST_MONITOR_URL) ?? `http://127.0.0.1:${resolvePort(env)}`;
+  return `${base}${READ_MODEL_STREAM_PATH}`;
+}
+
+function explicitBase(raw: string | undefined): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  return trimmed.replace(/\/+$/, "");
+}
+
+function resolvePort(env: ReadModelUrlEnv): number {
+  const parsed = parseInt(env.MONITOR_PORT ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MONITOR_PORT;
+}

--- a/plugins/dev/scripts/orch-monitor/cli/lib/read-model-workers.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/read-model-workers.test.ts
@@ -1,0 +1,125 @@
+// CTL-920 / HUD2: map the read-model's assembled BoardWorker[] onto the HUD's
+// WorkerSignal[] shape so the Dashboard's Workers view renders the SAME worker
+// state the web/iPad show — instead of the HUD re-deriving it from raw signal
+// files. This is the "one assembly, many readers" mapping for the headline
+// worker primary-state consolidation; raw readWorkerSignals() remains the
+// down-server fallback (tested at the Dashboard level).
+import { describe, it, expect } from "bun:test";
+import { boardWorkersToSignals, selectWorkers } from "./read-model-workers";
+import type { BoardWorker } from "../../lib/read-model-client";
+import type { WorkerSignal } from "./worker-signals-reader";
+
+function boardWorker(overrides: Partial<BoardWorker> = {}): BoardWorker {
+  return {
+    name: "alice",
+    ticket: "CTL-100",
+    tickets: ["CTL-100"],
+    phase: "implement",
+    status: "active",
+    activeState: "active",
+    working: true,
+    lastActiveMs: 30_000,
+    repo: "owner/repo",
+    team: "CTL",
+    runtimeMs: 120_000,
+    costUSD: 1.23,
+    sessionId: "sess-abc",
+    startedAt: 1_700_000_000_000,
+    pid: 4242,
+    catalystSessionId: "sess_xyz",
+    // CTL-922/BFF11 made BoardWorker.host and .generation required fields
+    // (BoardHostRef | null / number | null) after this branch was cut; single-host
+    // identity no-op ⇒ both null (no host named, resolves to the one local node; no
+    // fence). Additive rebase fix-up — keeps the fixture assignable without changing
+    // any HUD2 behavior.
+    host: null,
+    generation: null,
+    ...overrides,
+  };
+}
+
+describe("boardWorkersToSignals (CTL-920)", () => {
+  it("maps the load-bearing fields the WorkerList renders", () => {
+    const [w] = boardWorkersToSignals([boardWorker()], 1_700_000_100_000);
+    expect(w!.ticket).toBe("CTL-100");
+    expect(w!.workerName).toBe("alice");
+    expect(w!.status).toBe("active");
+    // BoardWorker.phase is the per-phase NAME (string) → WorkerSignal.phaseName.
+    expect(w!.phaseName).toBe("implement");
+    expect(w!.phase).toBeNull(); // legacy integer phase has no read-model source
+  });
+
+  it("derives lastHeartbeat ISO from lastActiveMs relative to now", () => {
+    const now = 1_700_000_100_000;
+    const [w] = boardWorkersToSignals([boardWorker({ lastActiveMs: 60_000 })], now);
+    expect(w!.lastHeartbeat).toBe(new Date(now - 60_000).toISOString());
+  });
+
+  it("a null lastActiveMs yields a null lastHeartbeat (not Epoch)", () => {
+    const [w] = boardWorkersToSignals([boardWorker({ lastActiveMs: null })], Date.now());
+    expect(w!.lastHeartbeat).toBeNull();
+  });
+
+  it("leaves pr null — the read-model worker slice carries no PR (PR is on the ticket slice)", () => {
+    const [w] = boardWorkersToSignals([boardWorker()], Date.now());
+    expect(w!.pr).toBeNull();
+  });
+
+  it("maps startedAt epoch-ms to an ISO string and preserves the orchestrator-as-team note", () => {
+    const [w] = boardWorkersToSignals([boardWorker({ startedAt: 1_700_000_000_000 })], Date.now());
+    expect(w!.startedAt).toBe(new Date(1_700_000_000_000).toISOString());
+  });
+
+  it("carries the source BoardWorker through as `raw` so the detail pane shows it verbatim", () => {
+    const src = boardWorker();
+    const [w] = boardWorkersToSignals([src], Date.now());
+    expect(w!.raw).toBe(src);
+  });
+
+  it("a stuck worker surfaces as status with no fabricated stalledReason", () => {
+    const [w] = boardWorkersToSignals([boardWorker({ status: "stuck", activeState: "stuck" })], Date.now());
+    expect(w!.status).toBe("stuck");
+    expect(w!.stalledReason).toBeNull();
+  });
+});
+
+describe("selectWorkers — read-model-vs-raw fallback (CTL-920)", () => {
+  const rmRow = boardWorkersToSignals([boardWorker({ ticket: "CTL-READMODEL" })], Date.now());
+  const rawRow: WorkerSignal[] = [
+    {
+      ticket: "CTL-RAW",
+      orchestrator: "orch-1",
+      wave: null,
+      workerName: "raw-worker",
+      label: null,
+      status: "active",
+      stalledReason: null,
+      phase: 3,
+      phaseName: "implement",
+      phaseTimestamps: {},
+      lastHeartbeat: null,
+      startedAt: null,
+      updatedAt: null,
+      completedAt: null,
+      worktreePath: null,
+      pr: null,
+      linearState: null,
+      definitionOfDone: null,
+      raw: {},
+    },
+  ];
+
+  it("prefers the read-model rows when connected (server up)", () => {
+    expect(selectWorkers(rmRow, rawRow)[0]!.ticket).toBe("CTL-READMODEL");
+  });
+
+  it("falls back to the raw scan when the read-model is unavailable (server down ⇒ null)", () => {
+    expect(selectWorkers(null, rawRow)[0]!.ticket).toBe("CTL-RAW");
+  });
+
+  it("an empty read-model worker list is still authoritative (NOT treated as fallback)", () => {
+    // A connected read-model with zero workers is the truth — selecting it (not
+    // the raw scan) is what keeps the HUD in lockstep with the web's empty board.
+    expect(selectWorkers([], rawRow)).toEqual([]);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/lib/read-model-workers.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/read-model-workers.ts
@@ -1,0 +1,80 @@
+// read-model-workers.ts — map the read-model's assembled BoardWorker[] onto the
+// HUD's WorkerSignal[] shape (CTL-920 / HUD2).
+//
+// The HUD's Dashboard Workers view renders WorkerSignal rows it historically
+// scanned itself from `~/catalyst/runs/<orch>/workers/*.json` (worker-signals-
+// reader.ts). HUD2 makes the read-model the PRIMARY source: when the server is
+// up, the assembled BoardWorker[] (the SAME slice the web/iPad render) is mapped
+// to the WorkerSignal fields the WorkerList already knows how to draw, so the
+// HUD shows the one assembled picture instead of re-deriving it. The raw scan
+// stays the fallback when the server is down (chosen in the Dashboard).
+//
+// The mapping only fills the fields the Workers view actually reads (ticket,
+// workerName, status, phaseName, lastHeartbeat, pr, startedAt) plus `raw` (the
+// verbatim BoardWorker for the detail pane). Fields the read-model does not
+// carry (legacy integer `phase`, `worktreePath`, `definitionOfDone`, …) are left
+// null rather than fabricated — the list renders an em-dash for them, exactly as
+// it does for a raw signal that omits them.
+
+import type { BoardWorker } from "../../lib/read-model-client";
+import type { WorkerSignal } from "./worker-signals-reader";
+
+/**
+ * Project the read-model's BoardWorker[] into WorkerSignal[] for the HUD's
+ * Workers view. `nowMs` anchors the `lastActiveMs` → `lastHeartbeat` conversion
+ * (injectable so tests are deterministic).
+ */
+export function boardWorkersToSignals(workers: BoardWorker[], nowMs: number): WorkerSignal[] {
+  return workers.map((w) => boardWorkerToSignal(w, nowMs));
+}
+
+/**
+ * The HUD's read-model-vs-raw worker source decision (CTL-920 / HUD2). When the
+ * read-model is connected the caller passes the mapped read-model rows; null
+ * means the server is down and the HUD must fall back to its raw-file scan. This
+ * is the single, tested choke point for "one assembly, many readers" with a
+ * graceful raw-file fallback — extracted so the rule is provable without
+ * rendering the Dashboard.
+ */
+export function selectWorkers(
+  readModelWorkers: WorkerSignal[] | null,
+  rawWorkers: WorkerSignal[],
+): WorkerSignal[] {
+  return readModelWorkers ?? rawWorkers;
+}
+
+function boardWorkerToSignal(w: BoardWorker, nowMs: number): WorkerSignal {
+  const lastHeartbeat =
+    typeof w.lastActiveMs === "number" && Number.isFinite(w.lastActiveMs)
+      ? new Date(nowMs - w.lastActiveMs).toISOString()
+      : null;
+  const startedAt =
+    typeof w.startedAt === "number" && Number.isFinite(w.startedAt)
+      ? new Date(w.startedAt).toISOString()
+      : null;
+
+  return {
+    ticket: w.ticket,
+    orchestrator: "",
+    wave: null,
+    workerName: w.name,
+    label: null,
+    status: w.status,
+    stalledReason: null,
+    phase: null,
+    phaseName: w.phase || null,
+    phaseTimestamps: {},
+    lastHeartbeat,
+    startedAt,
+    updatedAt: lastHeartbeat,
+    completedAt: null,
+    worktreePath: null,
+    // The read-model's worker slice carries no PR (PR lives on the ticket slice);
+    // null renders an em-dash exactly as a raw signal without a PR does. We do
+    // NOT fabricate one.
+    pr: null,
+    linearState: null,
+    definitionOfDone: null,
+    raw: w,
+  };
+}


### PR DESCRIPTION
## Summary

Makes the terminal HUD a **CONSUMER** of the same cache-backed read-model the web and iPad consume — **one assembly, many readers** — instead of independently re-deriving its primary worker state from raw-file scans. The HUD historically made **zero** `fetch`/`EventSource` calls; this adds the SSE/fetch client path it never had, consuming the **exact** `/api/board/stream` SSE the web/iPad consume, through the **same** HUD1 client contract (`lib/read-model-client.ts`). A fix to how the BFF assembles worker state now reaches all three readers with no HUD-specific data-path change.

Depends on **HUD1** (CTL-919, the shared client contract) and **BFF1** (CTL-883, the read-model core) — both already merged to `main`.

### New modules (dependency-free, bun-stdlib only)
- **`cli/lib/read-model-url.ts`** — resolves the local server SSE URL the way `server.ts` binds its port (`MONITOR_PORT`|7400; `CATALYST_MONITOR_URL` base wins for a proxied/remote server).
- **`cli/lib/node-event-source.ts`** — a tiny fetch-based `EventSource` (bun has no global `EventSource`) conforming to the contract's `ReadModelEventSource`, so it injects straight into `subscribeReadModel()`. Parses the server's `event: board\ndata: <json>\n\n` framing, reassembles chunk-split frames, and funnels every failure to `onerror` (never throws into the consumer loop).
- **`cli/lib/read-model-connection.ts`** — the React-free connection controller: subscribe via the shared contract, track `connecting`/`connected`/`down`, reconnect when a stopped server comes back, drop to `down` (→ raw-file fallback) on error.
- **`cli/hooks/useReadModel.ts`** — thin React adapter over the controller; surfaces `payload` + the node-aware `ClusterReadModel` (single-host identity no-op) + a `connected` flag.
- **`cli/lib/read-model-workers.ts`** — maps the assembled `BoardWorker[]` onto the HUD's `WorkerSignal` rows (`boardWorkersToSignals`) plus the read-model-vs-raw source decision (`selectWorkers`) — the single, tested choke point.

### Wiring (behavior-preserving where the scenario says "no regression")
- `cli/hud.tsx` subscribes via `useReadModel` and passes read-model-backed workers to the Dashboard when connected, `null` when the server is down.
- `cli/components/Dashboard.tsx` Workers view renders the read-model rows when present, falls back to its raw `workers/*.json` scan otherwise — the HUD never goes dark. The live event-log **drill-down tail** (`useEventLog`) and the broker chips are **deliberately left on their local paths**, exactly as the cluster design prescribes (per-host logs serve only the drill-down).

## Gherkin acceptance scenarios

| Scenario | Status |
|---|---|
| **1. HUD primary state matches the web and iPad exactly** — orchestrators/workers/board read from the SAME read-model SSE; same per-host attribution and counts, no re-derivation | ✅ satisfied (workers) — HUD subscribes to the SAME `/api/board/stream` via the shared `subscribeReadModel()`/`decodeReadModelFrame()` contract; the assembled `BoardWorker[]` drives the Dashboard Workers view through `boardWorkersToSignals`. Per-host attribution via `groupByHost()` (single-host = one group). **Scoped note:** the headline *worker* primary-state is consolidated; interests/orchs/runs slices remain on their raw readers (the board payload does not carry those shapes), so the consolidation is partial-by-design for this ticket. |
| **2. One fix fixes all readers** — a BFF worker-assembly fix reaches HUD/web/iPad with no HUD-specific data-path change | ✅ satisfied — the HUD decodes the identical envelope via the shared contract; a change to `BoardPayload`/assembly is a compile-time break + a runtime fix across all three consumers at once. |
| **3. HUD keeps its live drill-down tail** — scope-to-trace / scope-to-orchestrator / `:since` reloads still driven by the raw event-log tail | ✅ satisfied — `useEventLog` and all scope/`:since` keybindings are untouched; only primary *fleet* state moved onto the read-model. |
| **4. HUD degrades gracefully when the server is down** — falls back to its raw-file scan, never errors or blocks on the missing endpoint | ✅ satisfied — `node-event-source` funnels a refused/non-200/aborted connection to `onerror`; the connection controller flips to `down`; `selectWorkers(null, raw)` returns the raw scan; the Dashboard renders it. No throw reaches the render loop. |

### Single-node MVP descope
Node-awareness is implemented as the **single-host identity no-op** (`groupByHost()` yields exactly one group attributed to the local `hostName()`/`hostId()`, zero added latency). The N>1 multi-node grouping is satisfied by the **same** contract code path and **not separately built** (no CTL-863/864/865/866/873/876 anchors). The per-host attribution in scenario 1 is the single-host branch done correctly.

## Tests / validation
- 4 new suites encode the Gherkin: `cli/lib/read-model-url.test.ts`, `cli/lib/node-event-source.test.ts`, `cli/lib/read-model-connection.test.ts`, `cli/lib/read-model-workers.test.ts`.
- `bun test cli/ __tests__/{read-model*,board-client,board-snapshot}.test.ts` → **374 pass, 0 fail**.
- `bunx tsc --noEmit` (orch-monitor) → **clean**. UI `tsc` has a single **pre-existing** `kpi-strip.tsx` error on `origin/main` (untouched, documented in HUD1).
- `bun run build` (ui vite) → succeeds (contract bundles into the browser). `public/` build artifacts intentionally **not committed** (reproducible; the ui change graph is unchanged so the committed bundle stays correct).
- No reward-hacking in source: no `as any` / `as unknown as` / `@ts-ignore` / non-null `!` / `forEach(async`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)