### PR TITLE
feat(dev): DETAIL1 shared detail chrome + pager + keyboard (CTL-912)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/detail-chrome.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/detail-chrome.test.ts
@@ -1,0 +1,183 @@
+// detail-chrome.test.ts — units for the PURE detail-page shell derivations
+// (CTL-912 / DETAIL1, detail design §3). Encodes the breadcrumb, pager, cold-link
+// and live-dot Gherkin scenarios against ui/src/board/detail-chrome.ts — no React
+// / jotai / router needed (the same pure-module discipline as list-order.test.ts
+// / recents.test.ts). `Shell.tsx` is a thin skin over these functions, so the
+// breadcrumb / `N / total` / dot the operator sees can never drift from what
+// these units lock in.
+import { describe, it, expect } from "bun:test";
+import {
+  resolveBreadcrumb,
+  breadcrumbText,
+  resolvePager,
+  resolveLiveDot,
+  LIVE_CYAN,
+  STUCK_RED,
+  CHROME_BLUE,
+} from "../ui/src/board/detail-chrome";
+
+// ── Gherkin: From-context breadcrumb reconstructs from the URL ───────────────
+describe("resolveBreadcrumb / breadcrumbText — pure fn of the search params", () => {
+  it('reads "◂ Board · Implement  CTL-845" for ?from=board&lens=phase&col=Implement', () => {
+    const ctx = { id: "CTL-845", from: "board" as const, lens: "phase" as const, col: "Implement" };
+    expect(breadcrumbText(ctx)).toBe("◂ Board · Implement  CTL-845");
+
+    const crumbs = resolveBreadcrumb(ctx);
+    expect(crumbs).toEqual([
+      { label: "◂ Board", to: "/" },
+      { label: "Implement", to: "/" },
+      { label: "CTL-845", to: null },
+    ]);
+  });
+
+  it('clicking "◂ Board" returns to / (the board root, always navigable)', () => {
+    const crumbs = resolveBreadcrumb({ id: "CTL-845", from: "board", col: "Implement" });
+    expect(crumbs[0].label).toBe("◂ Board");
+    expect(crumbs[0].to).toBe("/");
+    // the middle (list-context) crumb also routes to / — the shell restores the
+    // column + scroll from the URL on land, so bare / is the right back-target.
+    expect(crumbs[1].to).toBe("/");
+    // the entity crumb is inert.
+    expect(crumbs[crumbs.length - 1].to).toBeNull();
+  });
+
+  it('the SAME CTL-845 with ?from=stuck renders a "Stuck" middle crumb instead', () => {
+    const crumbs = resolveBreadcrumb({ id: "CTL-845", from: "stuck" });
+    expect(crumbs[0].label).toBe("◂ Stuck");
+    // no col on a stuck walk → no middle column crumb, just root + entity.
+    expect(crumbs.map((c) => c.label)).toEqual(["◂ Stuck", "CTL-845"]);
+  });
+
+  it("renders ?from=recent as a Recent root", () => {
+    const crumbs = resolveBreadcrumb({ id: "CTL-831", from: "recent" });
+    expect(crumbs[0].label).toBe("◂ Recent");
+  });
+
+  it('a degraded deep-link (no ?from) collapses to "Board › CTL-845"', () => {
+    const ctx = { id: "CTL-845" };
+    expect(breadcrumbText(ctx)).toBe("Board › CTL-845");
+    expect(resolveBreadcrumb(ctx)).toEqual([
+      { label: "Board", to: "/" },
+      { label: "CTL-845", to: null },
+    ]);
+  });
+});
+
+// ── Gherkin: Pager walks the resolved list in place ─────────────────────────
+describe("resolvePager — N/total over a resolved board list", () => {
+  const ids = ["CTL-845", "CTL-877", "CTL-880", "CTL-881"];
+
+  it('reports "N / total" with the right 1-based position and neighbours', () => {
+    const p = resolvePager({ ids, id: "CTL-877" });
+    expect(p.n).toBe(2);
+    expect(p.total).toBe(4);
+    expect(p.text).toBe("2 / 4");
+    expect(p.inList).toBe(true);
+    expect(p.ghosted).toBe(false);
+    // ▾ / j → next, ▴ / k → prev
+    expect(p.nextId).toBe("CTL-880");
+    expect(p.prevId).toBe("CTL-845");
+    expect(p.atStart).toBe(false);
+    expect(p.atEnd).toBe(false);
+  });
+
+  it("disables (inerts) the chevrons at the ends of the list", () => {
+    const first = resolvePager({ ids, id: "CTL-845" });
+    expect(first.atStart).toBe(true);
+    expect(first.prevId).toBeNull();
+    expect(first.nextId).toBe("CTL-877");
+
+    const last = resolvePager({ ids, id: "CTL-881" });
+    expect(last.atEnd).toBe(true);
+    expect(last.nextId).toBeNull();
+    expect(last.prevId).toBe("CTL-880");
+  });
+});
+
+// ── Gherkin: Cold-linked URL renders, pager lights up later ─────────────────
+describe("resolvePager — cold-link ghost then silent light-up", () => {
+  it('shows a ghosted "5 / —" with inert chevrons for a pasted ?cursor=4 with no list', () => {
+    // cursor is 0-based on the URL; the counter is 1-based → cursor=4 ⇒ "5 / —".
+    const ghost = resolvePager({ ids: [], id: "CTL-845", cursor: 4 });
+    expect(ghost.ghosted).toBe(true);
+    expect(ghost.text).toBe("5 / —");
+    expect(ghost.total).toBeNull();
+    expect(ghost.prevId).toBeNull();
+    expect(ghost.nextId).toBeNull();
+    expect(ghost.atStart).toBe(true);
+    expect(ghost.atEnd).toBe(true);
+    expect(ghost.inList).toBe(false);
+  });
+
+  it("silently lights up (no separate path) once the stream rehydrates the list", () => {
+    // cold: ghost.
+    const cold = resolvePager({ ids: [], id: "CTL-845", cursor: 0 });
+    expect(cold.ghosted).toBe(true);
+    // rehydrated: the SAME function with the populated list → a real pager.
+    const ids = ["CTL-845", "CTL-877"];
+    const lit = resolvePager({ ids, id: "CTL-845", cursor: 0 });
+    expect(lit.ghosted).toBe(false);
+    expect(lit.text).toBe("1 / 2");
+    expect(lit.inList).toBe(true);
+  });
+
+  it('stays "— / —" when $id is not in the resolved list (only the breadcrumb navigates)', () => {
+    const offList = resolvePager({ ids: ["CTL-877", "CTL-880"], id: "CTL-845" });
+    expect(offList.text).toBe("— / —");
+    expect(offList.n).toBeNull();
+    expect(offList.total).toBeNull();
+    expect(offList.inList).toBe(false);
+    expect(offList.prevId).toBeNull();
+    expect(offList.nextId).toBeNull();
+  });
+
+  it('falls to "— / —" for a cold-link with neither a list nor a cursor', () => {
+    const bare = resolvePager({ ids: [], id: "CTL-845" });
+    expect(bare.text).toBe("— / —");
+    expect(bare.ghosted).toBe(true);
+  });
+
+  it("never mutates the input id list", () => {
+    const ids = ["CTL-845", "CTL-877"];
+    const copy = [...ids];
+    resolvePager({ ids, id: "CTL-877" });
+    expect(ids).toEqual(copy);
+  });
+});
+
+// ── Gherkin: Live-dot title reserves cyan for genuine liveness only ─────────
+describe("resolveLiveDot — cyan reserved to working && active", () => {
+  it("a working active entity → a cyan breathing ring", () => {
+    const dot = resolveLiveDot({ working: true, activeState: "active" });
+    expect(dot.kind).toBe("live");
+    if (dot.kind === "live") {
+      expect(dot.color).toBe(LIVE_CYAN);
+      expect(dot.color).toBe("#5be0ff");
+      expect(dot.breathing).toBe(true);
+    }
+  });
+
+  it("a stuck worker → a static red dot (never cyan)", () => {
+    const dot = resolveLiveDot({ working: false, activeState: "stuck" });
+    expect(dot.kind).toBe("stuck");
+    if (dot.kind === "stuck") {
+      expect(dot.color).toBe(STUCK_RED);
+      expect(dot.color).toBe("#ef5d5d");
+      expect(dot.breathing).toBe(false);
+    }
+  });
+
+  it("a settled entity → no dot", () => {
+    expect(resolveLiveDot({ working: false, activeState: null }).kind).toBe("none");
+  });
+
+  it("active but NOT working does not earn cyan (the license is the conjunction)", () => {
+    // between tool calls a worker can be active yet working===false — no cyan.
+    expect(resolveLiveDot({ working: false, activeState: "active" }).kind).toBe("none");
+  });
+
+  it("the chrome's non-live accents are blue, NEVER the cyan live token", () => {
+    expect(CHROME_BLUE).toBe("#4ea1ff");
+    expect(CHROME_BLUE).not.toBe(LIVE_CYAN);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/detail-shell.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/detail-shell.test.ts
@@ -1,0 +1,166 @@
+// detail-shell.test.ts — CTL-912 / DETAIL1 structural acceptance guards.
+//
+// `bun test` has no DOM, so — matching the existing app-shell.test.ts pattern
+// (SHELL1) — the React-component Gherkin scenarios are asserted by static source
+// analysis (read the .tsx/.ts as text and assert the load-bearing wiring), while
+// the PURE chrome/keymap cores are unit-tested directly in detail-chrome.test.ts
+// and key-nav.test.ts. Together they cover all six DETAIL1 Gherkin scenarios.
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const UI_SRC = join(HERE, "..", "ui", "src");
+const read = (rel: string) => readFileSync(join(UI_SRC, rel), "utf8");
+
+const shellSrc = read("board/Shell.tsx");
+const routerSrc = read("board/router.tsx");
+const detailRouteSrc = read("board/detail-route.tsx");
+const keyboardHookSrc = read("hooks/use-keyboard-nav.ts");
+const chromeSrc = read("board/detail-chrome.ts");
+
+// ── Gherkin: the shell is the chrome both detail pages mount inside ─────────
+describe("Shell.tsx — the shared detail-page chrome, distinct from AppShell", () => {
+  it("exports a Shell component and a DetailBody slot", () => {
+    expect(shellSrc).toMatch(/export function Shell\b/);
+    expect(shellSrc).toMatch(/export function DetailBody\b/);
+  });
+
+  it("is the detail-PAGE chrome, NOT the app-nav Sidebar (no AppShell/Sidebar import)", () => {
+    // the two are distinct components that nest — the shell must not re-mount the
+    // app frame. (it lives under board/, app-shell lives under components/.)
+    expect(shellSrc).not.toMatch(/from "[^"]*app-shell"/);
+    expect(shellSrc).not.toMatch(/from "[^"]*app-sidebar"/);
+  });
+
+  it("both detail routes mount the Shell (ticket + worker)", () => {
+    expect(detailRouteSrc).toMatch(/<Shell\b/);
+    expect(detailRouteSrc).toMatch(/export function TicketDetailRoute\b/);
+    expect(detailRouteSrc).toMatch(/export function WorkerDetailRoute\b/);
+    // the router wires those containers onto /ticket/$id + /worker/$id.
+    expect(routerSrc).toMatch(/TicketDetailRoute/);
+    expect(routerSrc).toMatch(/WorkerDetailRoute/);
+    expect(routerSrc).toMatch(/path: "\/ticket\/\$id"/);
+    expect(routerSrc).toMatch(/path: "\/worker\/\$id"/);
+  });
+});
+
+// ── Gherkin: breadcrumb + pager are pure fns of the URL search params ───────
+describe("Shell.tsx — breadcrumb + pager consume the pure derivations", () => {
+  it("uses resolveBreadcrumb / resolvePager from detail-chrome (the shared list-order kin)", () => {
+    expect(shellSrc).toMatch(/resolveBreadcrumb/);
+    expect(shellSrc).toMatch(/resolvePager/);
+  });
+
+  it("resolves the walk list via the SHARED resolveList(ids), not a private re-sort", () => {
+    // the route container resolves ids through list-order's resolveListIds — the
+    // P1 keystone correctness item, so the pager order matches the board.
+    expect(detailRouteSrc).toMatch(/resolveListIds/);
+    expect(detailRouteSrc).toMatch(/from "\.\/list-order"/);
+  });
+
+  it("walks in place via a typed route-param swap with a ?cursor tick (no full reload)", () => {
+    expect(shellSrc).toMatch(/navigate\(\{\s*to: "\/ticket\/\$id"/);
+    expect(shellSrc).toMatch(/navigate\(\{\s*to: "\/worker\/\$id"/);
+    expect(shellSrc).toMatch(/cursor:/);
+  });
+
+  it("disables the chevrons at the list ends (atStart/atEnd or null neighbour)", () => {
+    expect(shellSrc).toMatch(/disabled=\{pager\.atStart \|\| pager\.prevId === null\}/);
+    expect(shellSrc).toMatch(/disabled=\{pager\.atEnd \|\| pager\.nextId === null\}/);
+  });
+});
+
+// ── Gherkin: cold-link renders immediately, pager lights up from the atom ───
+describe("Shell.tsx — cold-link ghost lights up silently on rehydrate", () => {
+  it("mirrors the resolved ids into listContextAtom so a stream rehydrate re-lights the pager", () => {
+    expect(shellSrc).toMatch(/listContextAtom/);
+    expect(shellSrc).toMatch(/setListContext\(/);
+  });
+
+  it("the entity renders immediately (body + title) regardless of list resolution", () => {
+    // LiveDotTitle + DetailBody children render off the entity props, not the list.
+    expect(shellSrc).toMatch(/<LiveDotTitle\b/);
+  });
+});
+
+// ── Gherkin: live-dot reserves cyan for genuine liveness only ───────────────
+describe("Shell.tsx — live-dot title reserves cyan for liveness only", () => {
+  it("derives the dot via resolveLiveDot (cyan iff working && active)", () => {
+    expect(shellSrc).toMatch(/resolveLiveDot/);
+  });
+
+  it("the breathing-ring keyframe is the SAME cyan rgba(91,224,255,...) as the board", () => {
+    expect(shellSrc).toMatch(/rgba\(91,224,255/);
+  });
+
+  it("no chrome element uses the cyan token except the live dot — accents are blue #4ea1ff", () => {
+    expect(chromeSrc).toMatch(/LIVE_CYAN = "#5be0ff"/);
+    expect(chromeSrc).toMatch(/CHROME_BLUE = "#4ea1ff"/);
+    // the cyan token literal must not appear as a static chrome colour in Shell —
+    // it only reaches the DOM through resolveLiveDot's returned `color`.
+    expect(shellSrc).not.toMatch(/#5be0ff/);
+    // reduced-motion collapses the breathing animation (ethos-compliant).
+    expect(shellSrc).toMatch(/prefers-reduced-motion/);
+  });
+});
+
+// ── Gherkin: keyboard hook is extended, not forked ──────────────────────────
+describe("use-keyboard-nav.ts — extended in place, pre-existing bindings kept", () => {
+  it("still binds the pre-existing onEscape / onSlash / onQuestionMark callbacks", () => {
+    expect(keyboardHookSrc).toMatch(/onEscape\?:/);
+    expect(keyboardHookSrc).toMatch(/onSlash\?:/);
+    expect(keyboardHookSrc).toMatch(/onQuestionMark\?:/);
+    // and the `/`-focus-search still preventDefaults (kept verbatim).
+    expect(keyboardHookSrc).toMatch(/case "focus-search":\s*\n\s*e\.preventDefault\(\)/);
+  });
+
+  it("ADDS the new j/k / palette / g-chord callbacks (not a fork)", () => {
+    expect(keyboardHookSrc).toMatch(/onNext\?:/);
+    expect(keyboardHookSrc).toMatch(/onPrev\?:/);
+    expect(keyboardHookSrc).toMatch(/onPalette\?:/);
+    expect(keyboardHookSrc).toMatch(/onGoto(Ticket|Worker|Active)\?:/);
+  });
+
+  it("classifies through the pure key-nav keymap (so the input guard + ⌘K-pierce are unit-tested)", () => {
+    expect(keyboardHookSrc).toMatch(/from "\.\/key-nav"/);
+    expect(keyboardHookSrc).toMatch(/classifyKey/);
+  });
+
+  it("the shell wires j/k to the pager walk and Esc back to the originating list", () => {
+    expect(shellSrc).toMatch(/onNext: goNext/);
+    expect(shellSrc).toMatch(/onPrev: goPrev/);
+    expect(shellSrc).toMatch(/onEscape: goRoot/);
+  });
+});
+
+// ── Gherkin: Properties rail never fabricates a value ───────────────────────
+describe("Shell.tsx — Properties rail dims unplumbed rows, never fabricates", () => {
+  it("renders the shared cheap rows (Status/Phase/Priority/Estimate/Scope/Project/Repo/Team/Updated/PR)", () => {
+    for (const label of ["Status", "Phase", "Priority", "Estimate", "Scope", "Project", "Repo", "Team", "Updated", "PR"]) {
+      expect(detailRouteSrc).toContain(`label: "${label}"`);
+    }
+  });
+
+  it("labels the model row honestly as the CURRENT phase's signal only", () => {
+    expect(detailRouteSrc).toMatch(/Model \(current phase\)/);
+  });
+
+  it("an unplumbed (undefined) row renders dimmed, never with an invented value", () => {
+    // undefined → dimmed; the rendered value falls to an em-dash, never fabricated.
+    expect(shellSrc).toMatch(/const unplumbed = r\.value === undefined/);
+    expect(shellSrc).toMatch(/data-unplumbed=\{unplumbed\}/);
+    expect(shellSrc).toMatch(/r\.value == null \? "—"/);
+  });
+});
+
+// ── footer stream-health never claims "live" without a real frame ───────────
+describe("Shell.tsx — footer stream-health is honest", () => {
+  it("only claims 'live' when a frame actually arrived (never fabricated)", () => {
+    expect(shellSrc).toMatch(/data-shell-stream-health/);
+    // unknown state renders a dim 'stream —', not a fake 'live'.
+    expect(shellSrc).toMatch(/"stream —"/);
+    expect(detailRouteSrc).toMatch(/lastFrameAt != null/);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/key-nav.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/key-nav.test.ts
@@ -1,0 +1,106 @@
+// key-nav.test.ts — units for the PURE keystroke classifier behind the extended
+// use-keyboard-nav.ts (CTL-912 / DETAIL1, detail design §3.4). Encodes the
+// "Keyboard hook is extended, not forked" Gherkin: j/k walk the list, the g-chords
+// resolve, ⌘K toggles the palette, and the pre-existing `/`→search + the
+// INPUT/TEXTAREA/SELECT input guard still behave unchanged. Pure module → runs in
+// the main `bun test` with no jsdom (the hook feeds real KeyboardEvents through
+// this exact function, so the keymap can't drift from these units).
+import { describe, it, expect } from "bun:test";
+import {
+  classifyKey,
+  isTypingTarget,
+  CHORD_WINDOW_MS,
+  type KeyEventLike,
+} from "../ui/src/hooks/key-nav";
+
+const bare = (key: string, over: Partial<KeyEventLike> = {}): KeyEventLike => ({ key, ...over });
+
+// ── pre-existing bindings are kept verbatim (no regression) ─────────────────
+describe("classifyKey — the pre-existing bindings still work unchanged", () => {
+  it("`/` focuses the board search and preventDefaults (kept)", () => {
+    const a = classifyKey(bare("/"), null, false);
+    expect(a.type).toBe("focus-search");
+    if (a.type === "focus-search") expect(a.preventDefault).toBe(true);
+  });
+
+  it("`?` opens the cheatsheet (kept)", () => {
+    expect(classifyKey(bare("?"), null, false).type).toBe("help");
+  });
+
+  it("Escape dismisses (kept; the hook owns the layered ordering)", () => {
+    expect(classifyKey(bare("Escape"), null, false).type).toBe("escape");
+  });
+
+  it("the input-focus guard swallows everything while an INPUT/TEXTAREA/SELECT is focused", () => {
+    expect(isTypingTarget("INPUT")).toBe(true);
+    expect(isTypingTarget("TEXTAREA")).toBe(true);
+    expect(isTypingTarget("SELECT")).toBe(true);
+    expect(isTypingTarget("DIV")).toBe(false);
+    // a literal `/` or `j` typed into an input is NOT a shortcut.
+    expect(classifyKey(bare("/"), "INPUT", false).type).toBe("none");
+    expect(classifyKey(bare("j"), "TEXTAREA", false).type).toBe("none");
+  });
+});
+
+// ── new: j/k walk the list in place ─────────────────────────────────────────
+describe("classifyKey — j/k walk listContextAtom.ids (NEW)", () => {
+  it("`j` → next, `k` → prev, each preventDefaulting", () => {
+    const j = classifyKey(bare("j"), null, false);
+    const k = classifyKey(bare("k"), null, false);
+    expect(j.type).toBe("next");
+    expect(k.type).toBe("prev");
+    if (j.type === "next") expect(j.preventDefault).toBe(true);
+    if (k.type === "prev") expect(k.preventDefault).toBe(true);
+  });
+
+  it("does not steal j/k while a modifier is held (so ⌥j stays a browser key)", () => {
+    expect(classifyKey(bare("j", { altKey: true }), null, false).type).toBe("none");
+  });
+});
+
+// ── new: ⌘K toggles the palette, even over an input ─────────────────────────
+describe("classifyKey — ⌘K / Ctrl-K toggles the palette (NEW)", () => {
+  it("⌘K toggles the palette and preventDefaults", () => {
+    const a = classifyKey(bare("k", { metaKey: true }), null, false);
+    expect(a.type).toBe("palette");
+    if (a.type === "palette") expect(a.preventDefault).toBe(true);
+  });
+
+  it("Ctrl-K also toggles the palette (cross-platform)", () => {
+    expect(classifyKey(bare("k", { ctrlKey: true }), null, false).type).toBe("palette");
+  });
+
+  it("⌘K is reachable EVEN while an input is focused (the one shortcut that pierces the guard)", () => {
+    expect(classifyKey(bare("k", { metaKey: true }), "INPUT", false).type).toBe("palette");
+  });
+
+  it("a bare `k` (no modifier) is prev, NOT the palette", () => {
+    expect(classifyKey(bare("k"), null, false).type).toBe("prev");
+  });
+});
+
+// ── new: g-chords ────────────────────────────────────────────────────────────
+describe("classifyKey — g-chords g t / g w / g a (NEW)", () => {
+  it("a bare `g` arms the chord", () => {
+    expect(classifyKey(bare("g"), null, false).type).toBe("chord-start");
+  });
+
+  it("with a pending chord, `t`/`w`/`a` resolve to the goto actions", () => {
+    expect(classifyKey(bare("t"), null, true).type).toBe("goto-ticket");
+    expect(classifyKey(bare("w"), null, true).type).toBe("goto-worker");
+    expect(classifyKey(bare("a"), null, true).type).toBe("goto-active");
+  });
+
+  it("an unknown second key cancels the chord (no stray action)", () => {
+    expect(classifyKey(bare("z"), null, true).type).toBe("none");
+  });
+
+  it("the chord does not fire while an input is focused", () => {
+    // even with a pending chord, a focused input swallows the second key.
+    expect(classifyKey(bare("t"), "INPUT", true).type).toBe("none");
+  });
+
+  it("exposes a chord window constant for the hook timer", () => {
+    expect(CHORD_WINDOW_MS).toBeGreaterThan(0);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Shell.tsx
@@ -1,0 +1,475 @@
+// Shell.tsx — the shared detail-PAGE chrome both the ticket page (DETAIL2) and
+// the worker page (DETAIL3) render inside (CTL-912 / DETAIL1, detail design §3).
+//
+// IMPORTANT: this is the detail-PAGE chrome (breadcrumb · pager · live-dot title ·
+// Properties rail · <DetailBody> slot · footer) — it is NOT the app-nav Sidebar
+// (that is the SHELL stream's `AppShell` frame). The two are distinct components
+// that nest: AppShell is the application frame; Shell is the per-entity detail
+// chrome inside a route.
+//
+// All ordering / breadcrumb / pager / live-dot logic is the PURE detail-chrome.ts
+// + list-order.ts (unit-tested without a DOM). This file is the thin React skin:
+//   - it reads the typed `?from&lens&col&cursor` search params off the URL,
+//   - resolves the walk list via `resolveList` (the SAME comparator as Board.tsx,
+//     so `N / total` can never drift from the on-screen order),
+//   - drives the jotai nav store (listContextAtom / peekAtom / paletteOpenAtom /
+//     recentlyViewedAtom) — owned by FND, READ (not re-created) here,
+//   - extends the existing keyboard hook in place with j/k / g-chords / ⌘K
+//     (use-keyboard-nav.ts), preserving `/`→search, `?`, Esc + the input guard.
+//
+// The page surface drops its body into <DetailBody> and appends page-specific
+// Property rows below the shared rail divider; the shell never renders body panels.
+
+import { useCallback, useEffect, useMemo, type ReactNode } from "react";
+import { useAtom, useSetAtom } from "jotai";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  breadcrumbText,
+  resolveBreadcrumb,
+  resolvePager,
+  resolveLiveDot,
+  CHROME_BLUE,
+  type LiveSignal,
+  type PagerState,
+} from "./detail-chrome";
+import { listContextAtom, recordRecentAtom } from "./nav-store";
+import type { DetailFrom, DetailLens } from "./route-search";
+import { useKeyboardNav } from "../hooks/use-keyboard-nav";
+
+// ── tokens (mirror Board.tsx's inline-`C` palette; DESIGN.md dark surfaces) ──
+const C = {
+  s0: "#0b0d10",
+  s1: "#111318",
+  border: "#262d36",
+  fg: "#e6e9ef",
+  fgMuted: "#8b93a1",
+  fgDim: "#5b626f",
+  green: "#39d07a",
+  red: "#ef5d5d",
+  mono: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+} as const;
+
+// ── live-dot CSS (reuses the board's `catalyst-live-dot` breathing-ring keyframe,
+//    Board.tsx:118/121 — the SAME cyan signal, no new animation) ──────────────
+const SHELL_PULSE_CSS = `
+@keyframes catalystShellLivePing { 0%{box-shadow:0 0 0 0 rgba(91,224,255,.6)} 70%{box-shadow:0 0 0 6px rgba(91,224,255,0)} 100%{box-shadow:0 0 0 0 rgba(91,224,255,0)} }
+.catalyst-shell-live-dot { animation: catalystShellLivePing 1.9s infinite; }
+@media (prefers-reduced-motion: reduce) { .catalyst-shell-live-dot { animation: none; } }
+`;
+
+/** The route kind the shell is chrome-ing — selects the list-context `kind` and
+ *  the route the breadcrumb/pager navigate to (`/ticket/$id` vs `/worker/$id`). */
+export type ShellKind = "ticket" | "worker";
+
+/** The freshness of the board stream the footer reports. `unknown` renders a dim
+ *  dot with no "live" claim (the never-fabricate discipline) until the page surface
+ *  passes a real `EventSource.readyState`-derived value. */
+export type StreamHealth =
+  | { state: "live"; lastFrameAgoMs: number | null }
+  | { state: "reconnecting" }
+  | { state: "unknown" };
+
+/** The shared, cheap Property rows the shell knows how to render (detail design
+ *  §3.3 "Properties rail"). Any row whose value is `undefined` renders DIMMED with
+ *  an em-dash — NEVER an invented value. `null` is a real, plumbed "absent" (e.g.
+ *  no project) and renders as "—" but not dimmed. */
+export interface PropertyRow {
+  label: string;
+  /** A plumbed value (string), a plumbed-but-empty value (null), or an unplumbed
+   *  field (undefined → dimmed placeholder, never fabricated). */
+  value: string | null | undefined;
+}
+
+export interface ShellProps {
+  /** Route kind — ticket or worker. */
+  kind: ShellKind;
+  /** The route `$id` (e.g. "CTL-845" or "CTL-845:2"). */
+  id: string;
+  /** Typed search params off the URL (validated by route-search.ts). */
+  search: { from?: DetailFrom; lens?: DetailLens; col?: string; cursor?: number };
+  /** The resident board id list for this context (resolved by the page via
+   *  `resolveList(payload, ctx)`); `[]` for a cold-link until the stream rehydrates. */
+  listIds: readonly string[];
+  /** The entity's liveness signal (working + activeState) for the title dot. */
+  live: LiveSignal;
+  /** The entity's display title prose. */
+  title: string;
+  /** The shared Properties-rail rows (page may append more below the divider). */
+  properties: PropertyRow[];
+  /** Footer stream-health (defaults to `unknown` → dim, no fabricated "live"). */
+  streamHealth?: StreamHealth;
+  /** Page-specific extra Property rows, rendered below the shared rail divider. */
+  railExtra?: ReactNode;
+  /** The page body — ticket: spine/telemetry/runs; worker: burn-strip/tail/diag. */
+  children: ReactNode;
+  /** Open the ⌘K palette (saves/restores focus in the caller). Optional so the
+   *  shell degrades to a no-op until the palette ticket (DETAIL/T8) wires it. */
+  onPalette?: () => void;
+}
+
+// ── pager chevron ────────────────────────────────────────────────────────────
+function Chevron({
+  dir,
+  disabled,
+  onClick,
+}: {
+  dir: "up" | "down";
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={dir === "up" ? "Previous" : "Next"}
+      disabled={disabled}
+      onClick={onClick}
+      style={{
+        background: "transparent",
+        border: "none",
+        color: disabled ? C.fgDim : C.fgMuted,
+        cursor: disabled ? "default" : "pointer",
+        font: `12px ${C.mono}`,
+        padding: "2px 4px",
+        lineHeight: 1,
+      }}
+    >
+      {dir === "up" ? "▴" : "▾"}
+    </button>
+  );
+}
+
+// ── pager ────────────────────────────────────────────────────────────────────
+function Pager({
+  pager,
+  onPrev,
+  onNext,
+}: {
+  pager: PagerState;
+  onPrev: () => void;
+  onNext: () => void;
+}) {
+  return (
+    <div
+      data-shell-pager
+      data-ghosted={pager.ghosted}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        border: `1px solid ${C.border}`,
+        borderRadius: 6,
+        padding: "1px 4px",
+        opacity: pager.ghosted ? 0.5 : 1,
+      }}
+    >
+      <span style={{ font: `11px ${C.mono}`, color: C.fgMuted, padding: "0 4px" }}>{pager.text}</span>
+      <Chevron dir="up" disabled={pager.atStart || pager.prevId === null} onClick={onPrev} />
+      <Chevron dir="down" disabled={pager.atEnd || pager.nextId === null} onClick={onNext} />
+    </div>
+  );
+}
+
+// ── breadcrumb ─────────────────────────────────────────────────────────────
+function Breadcrumb({
+  ctx,
+  onRoot,
+}: {
+  ctx: Parameters<typeof resolveBreadcrumb>[0];
+  onRoot: () => void;
+}) {
+  const crumbs = resolveBreadcrumb(ctx);
+  return (
+    <nav data-shell-breadcrumb aria-label="Breadcrumb" style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0 }}>
+      {crumbs.map((c, i) => {
+        const last = i === crumbs.length - 1;
+        const sep = i > 0 ? (ctx.from ? " · " : " › ") : "";
+        return (
+          <span key={`${c.label}-${i}`} style={{ display: "inline-flex", alignItems: "center", whiteSpace: "nowrap" }}>
+            {sep && <span style={{ color: C.fgDim, margin: "0 2px" }}>{sep}</span>}
+            {c.to !== null ? (
+              <button
+                type="button"
+                onClick={onRoot}
+                style={{
+                  background: "transparent",
+                  border: "none",
+                  color: C.fgMuted,
+                  cursor: "pointer",
+                  font: `12px ${C.mono}`,
+                  padding: 0,
+                }}
+              >
+                {c.label}
+              </button>
+            ) : (
+              <span style={{ font: `12px ${C.mono}`, color: last ? C.fg : C.fgMuted }}>{c.label}</span>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}
+
+// ── live-dot title anchor ─────────────────────────────────────────────────
+function LiveDotTitle({ id, title, live }: { id: string; title: string; live: LiveSignal }) {
+  const dot = resolveLiveDot(live);
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 10, minWidth: 0 }}>
+      {dot.kind === "live" && (
+        <span
+          data-shell-live-dot="live"
+          className="catalyst-shell-live-dot"
+          style={{ width: 9, height: 9, borderRadius: "50%", background: dot.color, flex: "0 0 auto" }}
+        />
+      )}
+      {dot.kind === "stuck" && (
+        <span
+          data-shell-live-dot="stuck"
+          style={{ width: 9, height: 9, borderRadius: "50%", background: dot.color, flex: "0 0 auto" }}
+        />
+      )}
+      <span style={{ font: `11px ${C.mono}`, color: C.fgMuted, flex: "0 0 auto" }}>{id}</span>
+      <span style={{ color: C.fg, fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {title}
+      </span>
+    </div>
+  );
+}
+
+// ── Properties rail ─────────────────────────────────────────────────────────
+function PropertiesRail({ rows, extra }: { rows: PropertyRow[]; extra?: ReactNode }) {
+  return (
+    <aside
+      data-shell-rail
+      style={{
+        width: 280,
+        flex: "0 0 280px",
+        background: C.s1,
+        borderLeft: `1px solid ${C.border}`,
+        padding: "12px 14px",
+        overflowY: "auto",
+      }}
+    >
+      {rows.map((r) => {
+        const unplumbed = r.value === undefined;
+        return (
+          <div
+            key={r.label}
+            data-shell-prop={r.label}
+            data-unplumbed={unplumbed}
+            style={{ display: "flex", justifyContent: "space-between", gap: 12, padding: "3px 0", fontSize: 12 }}
+          >
+            <span style={{ color: C.fgMuted }}>{r.label}</span>
+            <span
+              style={{
+                font: `11px ${C.mono}`,
+                color: unplumbed ? C.fgDim : C.fg,
+                textAlign: "right",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {/* unplumbed → dimmed em-dash placeholder, NEVER a fabricated value;
+                  a plumbed-but-null value (e.g. no project) reads "—" too but lit. */}
+              {r.value == null ? "—" : r.value}
+            </span>
+          </div>
+        );
+      })}
+      {extra != null && (
+        <div data-shell-rail-extra style={{ marginTop: 10, paddingTop: 10, borderTop: `1px solid ${C.border}` }}>
+          {extra}
+        </div>
+      )}
+    </aside>
+  );
+}
+
+// ── footer ─────────────────────────────────────────────────────────────────
+function ShellFooter({ health, context }: { health: StreamHealth; context: string }) {
+  const dotColor =
+    health.state === "live" ? C.green : health.state === "reconnecting" ? C.red : C.fgDim;
+  const label =
+    health.state === "live"
+      ? `stream live${health.lastFrameAgoMs != null ? ` · ${Math.round(health.lastFrameAgoMs / 1000)}s ago` : ""}`
+      : health.state === "reconnecting"
+        ? "stream reconnecting"
+        : "stream —"; // unknown → dim, no fabricated "live"
+  return (
+    <footer
+      data-shell-footer
+      style={{
+        height: 28,
+        flex: "0 0 auto",
+        display: "flex",
+        alignItems: "center",
+        gap: 16,
+        padding: "0 14px",
+        background: C.s1,
+        borderTop: `1px solid ${C.border}`,
+        font: `11px ${C.mono}`,
+        color: C.fgMuted,
+      }}
+    >
+      <span data-shell-stream-health={health.state} style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+        <span style={{ width: 7, height: 7, borderRadius: "50%", background: dotColor, display: "inline-block" }} />
+        {label}
+      </span>
+      <span>j/k move · esc back · ⌘K actions · ? keys</span>
+      <span style={{ flex: 1 }} />
+      <span style={{ color: C.fgDim }}>{context}</span>
+    </footer>
+  );
+}
+
+/**
+ * The shared detail-page shell. Both the ticket and worker pages render their
+ * body through `children` and append page-specific Property rows via `railExtra`.
+ */
+export function Shell({
+  kind,
+  id,
+  search,
+  listIds,
+  live,
+  title,
+  properties,
+  streamHealth = { state: "unknown" },
+  railExtra,
+  children,
+  onPalette,
+}: ShellProps) {
+  const navigate = useNavigate();
+  const [listContext, setListContext] = useAtom(listContextAtom);
+  const recordRecent = useSetAtom(recordRecentAtom);
+
+  // Mirror the resolved walk list into the jotai store so peek / palette read the
+  // SAME ids. The page resolves `listIds` from the resident payload via
+  // resolveList; the shell only reflects it (FND owns the atoms, the shell reads).
+  useEffect(() => {
+    setListContext({ ids: [...listIds], kind, lens: search.lens, col: search.col });
+  }, [listIds, kind, search.lens, search.col, setListContext]);
+
+  // Record this entity into recents on LAND (drives the ⌘K RECENT group, P11).
+  useEffect(() => {
+    recordRecent(id);
+  }, [id, recordRecent]);
+
+  // The pager resolves from the jotai-mirrored ids (so a stream rehydrate that
+  // updates the atom re-lights the pager) falling back to the prop on first paint.
+  const ids = listContext.ids.length > 0 ? listContext.ids : listIds;
+  const pager = useMemo(
+    () => resolvePager({ ids, id, cursor: search.cursor }),
+    [ids, id, search.cursor],
+  );
+
+  const breadcrumbCtx = {
+    id,
+    from: search.from,
+    lens: search.lens,
+    col: search.col,
+    total: pager.total ?? undefined,
+  };
+
+  // ── navigation: walk in place (route-param swap), back to the originating list ─
+  // Typed TanStack navigate — `to` is the literal route, `params.id` the swapped
+  // run/ticket id, `search` carries the ?cursor tick. No casts (the route tree is
+  // type-registered in router.tsx, so these resolve against the real routes).
+  const walk = useCallback(
+    (targetId: string | null) => {
+      if (targetId === null) return; // bounds-nudge no-op at the ends
+      const nextCursor = ids.indexOf(targetId);
+      const nextSearch = { ...search, ...(nextCursor >= 0 ? { cursor: nextCursor } : {}) };
+      if (kind === "ticket") {
+        void navigate({ to: "/ticket/$id", params: { id: targetId }, search: nextSearch });
+      } else {
+        void navigate({ to: "/worker/$id", params: { id: targetId }, search: nextSearch });
+      }
+    },
+    [ids, kind, navigate, search],
+  );
+
+  const goPrev = useCallback(() => walk(pager.prevId), [walk, pager.prevId]);
+  const goNext = useCallback(() => walk(pager.nextId), [walk, pager.nextId]);
+  const goRoot = useCallback(() => void navigate({ to: "/" }), [navigate]);
+
+  // ── keyboard: extend the existing hook IN PLACE (j/k/⌘K/g-chords); the
+  //    pre-existing `/`→search + `?` + the input guard are kept by the hook ────
+  useKeyboardNav({
+    onNext: goNext,
+    onPrev: goPrev,
+    onEscape: goRoot, // a clean detail-page Esc returns to the originating list (board root)
+    onPalette: onPalette,
+    onGotoActive: () => {
+      document.querySelector("[data-spine-active]")?.scrollIntoView({ block: "center" });
+    },
+    // g t / g w are page-surface concerns (a worker→ticket jump needs the parent
+    // ticket id the page holds) — left unbound here; the page can re-bind via its
+    // own useKeyboardNav if it needs them. The shell wires the universal ones.
+  });
+
+  const footerContext = breadcrumbText(breadcrumbCtx);
+
+  return (
+    <div
+      data-detail-shell={kind}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        background: C.s0,
+        color: C.fg,
+        overflow: "hidden",
+      }}
+    >
+      <style>{SHELL_PULSE_CSS}</style>
+
+      {/* ShellHeader — breadcrumb (left) + pager (right) */}
+      <header
+        data-shell-header
+        style={{
+          height: 44,
+          flex: "0 0 auto",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 16,
+          padding: "0 14px",
+          background: C.s1,
+          borderBottom: `1px solid ${C.border}`,
+        }}
+      >
+        <Breadcrumb ctx={breadcrumbCtx} onRoot={goRoot} />
+        {/* Pager hidden on a fully-degraded deep-link (no list, no cursor) — the
+            "— / —" state still renders so the operator sees why it's inert; only a
+            cold bare link with no context at all suppresses it. */}
+        {(pager.inList || pager.ghosted) && <Pager pager={pager} onPrev={goPrev} onNext={goNext} />}
+      </header>
+
+      {/* Body row: <DetailBody> slot + Properties rail */}
+      <div style={{ display: "flex", flex: "1 1 auto", minHeight: 0 }}>
+        <div data-shell-body style={{ flex: "1 1 auto", minWidth: 0, overflowY: "auto", padding: "14px 16px" }}>
+          <LiveDotTitle id={id} title={title} live={live} />
+          <div style={{ marginTop: 12 }}>{children}</div>
+        </div>
+        <PropertiesRail rows={properties} extra={railExtra} />
+      </div>
+
+      <ShellFooter health={streamHealth} context={footerContext} />
+    </div>
+  );
+}
+
+/** A thin named export for the body slot so page surfaces can compose explicitly
+ *  (`<Shell …><DetailBody>…</DetailBody></Shell>`). It is a passthrough — the slot
+ *  semantics live in `Shell`'s `children`; this just documents intent + reserves
+ *  the data attribute the body region is keyed on for tests. */
+export function DetailBody({ children }: { children: ReactNode }) {
+  return <div data-detail-body>{children}</div>;
+}
+
+/** Re-export the accent so page surfaces use the SAME blue (never cyan) for their
+ *  own chrome (focus ring / peek frame), per the cyan-restraint discipline. */
+export { CHROME_BLUE };

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/detail-chrome.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/detail-chrome.ts
@@ -1,0 +1,252 @@
+// detail-chrome.ts — the PURE derivations behind the shared detail-page shell
+// (CTL-912 / DETAIL1, detail design §3). React-/jotai-/router-free on purpose
+// (it imports only the hoisted board *types* + the typed search contract) so the
+// orch-monitor `bun test` suite can unit-test the breadcrumb, the pager, and the
+// live-dot directly — the same dependency-free-so-it's-testable discipline as
+// list-order.ts / route-search.ts. `Shell.tsx` is the thin React skin over these
+// functions; because the chrome reads the URL (search params) + the resolved
+// list + the entity through these helpers, the breadcrumb / `N / total` / dot can
+// never disagree with what the Gherkin specifies.
+//
+// THE THREE DERIVATIONS:
+//   - resolveBreadcrumb(ctx) → the left crumb trail, a PURE fn of the search
+//     params (the SAME CTL-845 renders "Board · Implement" or "Stuck" purely from
+//     `?from`/`?col`); degraded entry (no ?from) collapses to "Board › <id>".
+//   - resolvePager({ids, id, cursor}) → the `N / total` pager state, incl. the
+//     cold-link ghost ("4 / —", inert chevrons) and the "— / —" not-in-list case.
+//   - resolveLiveDot(entity) → cyan iff working && activeState==="active"; static
+//     red iff stuck; otherwise none. Cyan is reserved to liveness ONLY.
+
+import type { DetailFrom, DetailLens } from "./route-search";
+import type { BoardActiveState } from "./types";
+
+// ── colour tokens (mirror Board.tsx; cyan is the reserved live signal) ───────
+/** The reserved "in-loop" live colour — `Board.tsx:33` `LIVE = "#5be0ff"`. The
+ *  detail chrome reuses the SAME token; it is the only cyan in the whole shell
+ *  (peek frame + focus ring use blue, below). */
+export const LIVE_CYAN = "#5be0ff";
+/** Stuck/error red — `Board.tsx` `C.red`. A stuck worker's static dot. */
+export const STUCK_RED = "#ef5d5d";
+/** The chrome's accent blue — peek frame + focus ring (NEVER cyan), `C.blue`. */
+export const CHROME_BLUE = "#4ea1ff";
+
+// ── breadcrumb ───────────────────────────────────────────────────────────────
+/**
+ * The context the breadcrumb + pager reconstruct from the URL. `id` is the route
+ * `$id` (the entity); the rest mirror the typed search params (`route-search.ts`).
+ * `total` is the resolved-list length (it drives the middle crumb's count and
+ * whether the pager shows at all) — the shell passes `listContextAtom.ids.length`.
+ */
+export interface BreadcrumbContext {
+  id: string;
+  from?: DetailFrom;
+  lens?: DetailLens;
+  col?: string;
+  /** Resolved-list length; a `(N)` count rides the middle crumb when > 0. */
+  total?: number;
+}
+
+/** One crumb in the trail. `to` is the click target (a route path) or null for
+ *  the non-navigable entity crumb at the end. `live` flags the entity crumb so
+ *  the shell can hang the live-dot off it. */
+export interface Crumb {
+  label: string;
+  /** Route path to navigate to on click, or null when the crumb is inert. */
+  to: string | null;
+}
+
+/** Human label for each `?from` value (the middle crumb's root word). */
+const FROM_LABEL: Record<DetailFrom, string> = {
+  board: "Board",
+  stuck: "Stuck",
+  recent: "Recent",
+};
+
+/**
+ * Reconstruct the breadcrumb trail purely from the URL context (detail design
+ * §3.3 "Breadcrumb"):
+ *
+ *   - With a `?from` context: `◂ <From>`  ·  `<Col>`  ·  `<id>`
+ *       /ticket/CTL-845?from=board&lens=phase&col=Implement
+ *         → "◂ Board"(→/) · "Implement"(→/) · "CTL-845"(inert)
+ *       /ticket/CTL-845?from=stuck
+ *         → "◂ Stuck"(→/) · "CTL-845"(inert)   (no col → no middle crumb)
+ *   - Degraded entry (no `?from`, a pasted bare URL): "Board"(→/) · "<id>"(inert)
+ *     — the pager is hidden by the shell in this case (resolvePager handles it).
+ *
+ * The first crumb always routes to `/` (board root, always clickable). The middle
+ * crumb (the list context) also routes to `/` — the shell restores the column +
+ * scroll from the URL on land, so a bare `/` is the correct back-target. The
+ * entity crumb (`$id`) is inert (`to: null`).
+ *
+ * Pure: no side effects, no router, no throw on a missing/unknown field.
+ */
+export function resolveBreadcrumb(ctx: BreadcrumbContext): Crumb[] {
+  const crumbs: Crumb[] = [];
+
+  if (ctx.from) {
+    const root = FROM_LABEL[ctx.from];
+    crumbs.push({ label: `◂ ${root}`, to: "/" }); // ◂ <From>
+    if (ctx.col) {
+      crumbs.push({ label: ctx.col, to: "/" });
+    }
+  } else {
+    // Degraded deep-link: only the board root + the entity.
+    crumbs.push({ label: "Board", to: "/" });
+  }
+
+  crumbs.push({ label: ctx.id, to: null });
+  return crumbs;
+}
+
+/**
+ * The breadcrumb rendered as a single string with the design's separators
+ * (`◂ Board · Implement  CTL-845`), used by the static-source Gherkin assertion
+ * and the footer's repeated context crumb. The leading `◂` already lives on the
+ * first crumb; list crumbs join with ` · ` and the entity crumb is separated by a
+ * double space (the wireframe's spacing). A degraded trail reads `Board › <id>`.
+ */
+export function breadcrumbText(ctx: BreadcrumbContext): string {
+  const crumbs = resolveBreadcrumb(ctx);
+  const entity = crumbs[crumbs.length - 1];
+  const lead = crumbs.slice(0, -1);
+  if (lead.length === 0) return entity.label;
+  // Degraded (no ?from) → "Board › CTL-845" (the design's degraded separator).
+  if (!ctx.from) return `${lead[0].label} › ${entity.label}`; // ›
+  return `${lead.map((c) => c.label).join(" · ")}  ${entity.label}`; // ·  + double space
+}
+
+// ── pager ──────────────────────────────────────────────────────────────────
+/**
+ * The pager's resolved display state (detail design §3.3 "Pager"):
+ *   - `n`        the 1-based position, or null when unknown (cold-link / off-list)
+ *   - `total`    the resolved-list length, or null when not yet rehydrated
+ *   - `prevId`   the id to walk to on ▴ / `k`, or null at the start / when inert
+ *   - `nextId`   the id to walk to on ▾ / `j`, or null at the end / when inert
+ *   - `text`     the rendered counter: "4 / 27", the cold-link ghost "4 / —", or "— / —"
+ *   - `ghosted`  true when the counter is a cold-link placeholder (dimmed, inert)
+ *   - `atStart` / `atEnd`  the chevrons are disabled at the list ends
+ *   - `inList`   whether `$id` is actually in the resolved list
+ */
+export interface PagerState {
+  n: number | null;
+  total: number | null;
+  prevId: string | null;
+  nextId: string | null;
+  text: string;
+  ghosted: boolean;
+  atStart: boolean;
+  atEnd: boolean;
+  inList: boolean;
+}
+
+/** The em-dash placeholder used in a ghosted / unresolved pager. */
+const DASH = "—"; // —
+
+/**
+ * Resolve the pager state from the resident id list, the current `$id`, and the
+ * `?cursor` from the URL. Encodes all three pager Gherkin scenarios:
+ *
+ *   1. RESOLVED board walk: `ids=[…CTL-845…]`, id="CTL-845" → "N / total", with
+ *      prev/next neighbours, chevrons inert at the ends.
+ *   2. COLD-LINK (pasted URL, no resident list yet): `ids=[]` but a `?cursor=4`
+ *      → ghosted "5 / —" (cursor is 0-based, the counter is 1-based), inert
+ *      chevrons (prev/next null). When the board stream rehydrates `ids`, calling
+ *      this again with the populated list lights the pager up — no separate path.
+ *   3. OFF-LIST: `ids` populated but `$id` not in it (a Done ticket off the board)
+ *      → "— / —", everything inert; the breadcrumb still navigates (shell concern).
+ *
+ * Pure: never mutates `ids`, never throws. A negative/garbage cursor is treated
+ * as absent (route-search already coerces it, but be defensive).
+ */
+export function resolvePager(input: {
+  ids: readonly string[];
+  id: string;
+  cursor?: number;
+}): PagerState {
+  const { ids, id, cursor } = input;
+  const idx = ids.indexOf(id);
+
+  // ── resolved walk: $id is in the resident list ──
+  if (idx >= 0) {
+    const total = ids.length;
+    const atStart = idx === 0;
+    const atEnd = idx === total - 1;
+    return {
+      n: idx + 1,
+      total,
+      prevId: atStart ? null : ids[idx - 1],
+      nextId: atEnd ? null : ids[idx + 1],
+      text: `${idx + 1} / ${total}`,
+      ghosted: false,
+      atStart,
+      atEnd,
+      inList: true,
+    };
+  }
+
+  // ── cold-link ghost: no resident position, but a ?cursor hint exists ──
+  if (typeof cursor === "number" && Number.isInteger(cursor) && cursor >= 0) {
+    const n = cursor + 1; // cursor is 0-based; the counter is 1-based
+    return {
+      n,
+      total: null,
+      prevId: null,
+      nextId: null,
+      text: `${n} / ${DASH}`, // "4 / —"
+      ghosted: true,
+      atStart: true,
+      atEnd: true,
+      inList: false,
+    };
+  }
+
+  // ── off-list / no context at all: "— / —", fully inert ──
+  return {
+    n: null,
+    total: null,
+    prevId: null,
+    nextId: null,
+    text: `${DASH} / ${DASH}`, // "— / —"
+    ghosted: true,
+    atStart: true,
+    atEnd: true,
+    inList: false,
+  };
+}
+
+// ── live-dot ─────────────────────────────────────────────────────────────────
+/** The live-dot variants the title anchor renders (detail design §3.3 "Title"). */
+export type LiveDot =
+  | { kind: "live"; color: string; breathing: true } // cyan breathing ring
+  | { kind: "stuck"; color: string; breathing: false } // static red
+  | { kind: "none" }; // settled entity → no dot
+
+/** The minimal liveness signal the dot reads off a `BoardTicket` / `BoardWorker`. */
+export interface LiveSignal {
+  working: boolean;
+  activeState: BoardActiveState;
+}
+
+/**
+ * Derive the title's live-dot (detail design §3.3 "Title block", cyan license
+ * §3.4). Cyan is reserved to GENUINE liveness only:
+ *
+ *   - `working && activeState === "active"` → cyan `#5be0ff` breathing ring.
+ *   - `activeState === "stuck"`             → static red `#ef5d5d` dot.
+ *   - otherwise (settled / done)            → no dot at all.
+ *
+ * Mirrors the board's `board-data.mjs:499`-style derivation surfaced on
+ * `BoardTicket`/`BoardWorker` (`working` + `activeState`). A worker that is
+ * `active` but momentarily `working === false` (between tool calls) does NOT earn
+ * cyan — the cyan license is the conjunction, per the Gherkin.
+ */
+export function resolveLiveDot(sig: LiveSignal): LiveDot {
+  if (sig.working && sig.activeState === "active") {
+    return { kind: "live", color: LIVE_CYAN, breathing: true };
+  }
+  if (sig.activeState === "stuck") {
+    return { kind: "stuck", color: STUCK_RED, breathing: false };
+  }
+  return { kind: "none" };
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/detail-route.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/detail-route.tsx
@@ -1,0 +1,150 @@
+// detail-route.tsx — the route container that mounts the shared <Shell> chrome
+// for /ticket/$id and /worker/$id (CTL-912 / DETAIL1). It subscribes to the
+// resident board payload (the SAME `connectBoard` transport the board uses),
+// resolves the walk list + the entity through the SHARED `resolveList` (so the
+// pager order matches the board), maps the entity to the shell's chrome props,
+// and renders the page body in the <DetailBody> slot.
+//
+// SCOPE: this ticket (DETAIL1) owns the CHROME — the breadcrumb, pager, live-dot
+// title, Properties rail skeleton, footer, and keyboard. The page BODIES (ticket
+// spine/telemetry/runs in DETAIL2, worker burn-strip/tail/diagnostics in DETAIL3)
+// drop into the slot later; here the body is an honest "coming in DETAIL2/3"
+// placeholder. The Properties rail already binds the shared cheap rows off the
+// resident payload (AVAILABLE-NOW); unplumbed rows render dimmed, never faked.
+
+import { useEffect, useState } from "react";
+import { connectBoard } from "./board-client";
+import { resolveListIds } from "./list-order";
+import { Shell, type PropertyRow, type ShellKind, type StreamHealth } from "./Shell";
+import type { BoardPayload, BoardTicket, BoardWorker } from "./types";
+import type { DetailSearch } from "./route-search";
+
+// ── resident payload subscription (same transport as Board.tsx) ─────────────
+function useBoardPayload(): { payload: BoardPayload | null; health: StreamHealth } {
+  const [payload, setPayload] = useState<BoardPayload | null>(null);
+  const [health, setHealth] = useState<StreamHealth>({ state: "unknown" });
+
+  useEffect(() => {
+    let alive = true;
+    let lastFrameAt: number | null = null;
+    const conn = connectBoard({
+      onSnapshot: (p) => {
+        if (!alive) return;
+        lastFrameAt = Date.now();
+        setPayload(p);
+      },
+      onStatus: (s) => {
+        if (!alive) return;
+        // Map the board transport's connection status to a footer stream-health.
+        // We only ever claim "live" when a frame actually arrived (never fabricate).
+        if (s === "connected" && lastFrameAt != null) {
+          setHealth({ state: "live", lastFrameAgoMs: Date.now() - lastFrameAt });
+        } else if (s === "connected") {
+          setHealth({ state: "unknown" }); // connected but no frame yet — honest dim
+        } else {
+          setHealth({ state: "reconnecting" });
+        }
+      },
+    });
+    return () => {
+      alive = false;
+      conn.close();
+    };
+  }, []);
+
+  return { payload, health };
+}
+
+// ── property-row assembly (shared cheap rows; unplumbed → undefined → dimmed) ─
+function ticketRows(t: BoardTicket | undefined): PropertyRow[] {
+  // Every value is the AVAILABLE-NOW BoardTicket field, or `undefined` (dimmed)
+  // when the entity isn't in the resident payload yet (a cold-linked Done ticket).
+  return [
+    { label: "Status", value: t ? `${t.linearState} · ${activeLabel(t.activeState, t.working)}` : undefined },
+    { label: "Phase", value: t?.phase },
+    { label: "Priority", value: t ? priorityLabel(t.priority) : undefined },
+    { label: "Estimate", value: t?.estimate != null ? `${t.estimate} pts` : t ? null : undefined },
+    { label: "Scope", value: t ? (t.scope ?? null) : undefined },
+    { label: "Project", value: t ? (t.project ?? null) : undefined },
+    { label: "Repo", value: t?.repo },
+    { label: "Team", value: t?.team },
+    { label: "Updated", value: t?.updatedAt },
+    { label: "PR", value: t?.pr != null ? `#${t.pr}` : t ? null : undefined },
+    // `model` is the CURRENT phase's signal model only — labelled honestly.
+    { label: "Model (current phase)", value: t ? (t.model ?? null) : undefined },
+  ];
+}
+
+function workerRows(w: BoardWorker | undefined): PropertyRow[] {
+  return [
+    { label: "Status", value: w ? activeLabel(w.activeState, w.working) : undefined },
+    { label: "Phase", value: w?.phase },
+    { label: "Repo", value: w?.repo },
+    { label: "Team", value: w?.team },
+    { label: "Runtime", value: w?.runtimeMs != null ? fmtDuration(w.runtimeMs) : w ? null : undefined },
+  ];
+}
+
+function activeLabel(state: BoardTicket["activeState"], working: boolean): string {
+  if (state === "active") return working ? "Working" : "Active";
+  if (state === "stuck") return "Stuck";
+  return "Settled";
+}
+
+function priorityLabel(p: number): string {
+  return p > 0 ? `P${p}` : "—";
+}
+
+function fmtDuration(ms: number): string {
+  const m = Math.floor(ms / 60000);
+  return m < 60 ? `${m}m` : `${Math.floor(m / 60)}h ${m % 60}m`;
+}
+
+// ── route components ─────────────────────────────────────────────────────────
+export function TicketDetailRoute({ id, search }: { id: string; search: DetailSearch }) {
+  const { payload, health } = useBoardPayload();
+  const kind: ShellKind = "ticket";
+  const listIds = payload ? resolveListIds(payload, { kind, lens: search.lens, col: search.col }) : [];
+  const ticket = payload?.tickets.find((t) => t.id === id);
+
+  return (
+    <Shell
+      kind={kind}
+      id={id}
+      search={search}
+      listIds={listIds}
+      live={{ working: ticket?.working ?? false, activeState: ticket?.activeState ?? null }}
+      title={ticket?.title ?? id}
+      properties={ticketRows(ticket)}
+      streamHealth={health}
+    >
+      <div data-detail-body-placeholder="ticket" style={{ color: "#5b626f", font: "12px ui-monospace, monospace" }}>
+        Ticket lifecycle body (spine · telemetry · runs) lands in DETAIL2.
+      </div>
+    </Shell>
+  );
+}
+
+export function WorkerDetailRoute({ id, search }: { id: string; search: DetailSearch }) {
+  const { payload, health } = useBoardPayload();
+  const kind: ShellKind = "worker";
+  const listIds = payload ? resolveListIds(payload, { kind, lens: search.lens, col: search.col }) : [];
+  const worker = payload?.workers.find((w) => w.name === id);
+
+  return (
+    <Shell
+      kind={kind}
+      id={id}
+      search={search}
+      listIds={listIds}
+      live={{ working: worker?.working ?? false, activeState: worker?.activeState ?? null }}
+      title={worker?.name ?? id}
+      properties={workerRows(worker)}
+      streamHealth={health}
+    >
+      <div data-detail-body-placeholder="worker" style={{ color: "#5b626f", font: "12px ui-monospace, monospace" }}>
+        Worker run body (burn-strip · tail · diagnostics) lands in DETAIL3.
+      </div>
+    </Shell>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/router.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/router.tsx
@@ -9,14 +9,17 @@
 //                    board stream in board-client.ts is untouched — routing wraps
 //                    the tree, it never touches data flow).
 //   /ticket/$id    → typed `id` param + typed `?from&lens&col&cursor` search;
-//                    renders a placeholder detail container (body filled later by
-//                    the DETAIL stream — out of scope for FND1).
+//                    renders the shared detail-page <Shell> chrome (CTL-912 /
+//                    DETAIL1) with a ticket-body placeholder slot (the body itself
+//                    is DETAIL2).
 //   /worker/$id    → same shape; `id` is e.g. "CTL-845:2" (a colon is legal
 //                    inside a single path segment, so the run-id resolves whole).
+//                    Renders the shared <Shell> with a worker-body slot (DETAIL3).
 //
-// Detail-page bodies, the Sidebar nav frame (SHELL stream), and the jotai store
-// are explicitly NOT in this ticket — this is purely the routing skeleton and
-// the typed search-param contract (route-search.ts) everything else binds to.
+// CTL-912 / DETAIL1 wires the shared shell chrome (breadcrumb · pager · live-dot
+// title · Properties rail · footer · keyboard) into these routes; the per-page
+// BODIES (spine/telemetry/runs, burn-strip/tail/diagnostics) drop into the slot in
+// later DETAIL tickets. The Sidebar nav frame (SHELL stream) is still separate.
 import { StrictMode } from "react";
 import {
   createRootRoute,
@@ -27,6 +30,7 @@ import {
 } from "@tanstack/react-router";
 import { Board } from "./Board";
 import { validateDetailSearch } from "./route-search";
+import { TicketDetailRoute, WorkerDetailRoute } from "./detail-route";
 
 // Root route: holds the <Outlet> the matched child renders into. No chrome yet
 // (the Sidebar/SHELL frame is a later ticket) — the root is a bare passthrough
@@ -42,49 +46,35 @@ const boardRoute = createRoute({
   component: Board,
 });
 
-// `/ticket/$id` — typed id param + typed search contract. Body is a placeholder
-// container the DETAIL stream fills in a later ticket; for FND1 the route just
-// has to resolve, expose the typed param, and parse the search params safely.
+// `/ticket/$id` — typed id param + typed search contract. Renders the shared
+// detail-page <Shell> (CTL-912 / DETAIL1) with a ticket-body slot (DETAIL2).
 const ticketRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/ticket/$id",
   validateSearch: validateDetailSearch,
-  component: TicketDetailPlaceholder,
+  component: TicketDetailContainer,
 });
 
-// `/worker/$id` — single-run page. Same typed param + search contract.
+// `/worker/$id` — single-run page. Same typed param + search contract; renders the
+// shared <Shell> with a worker-body slot (DETAIL3).
 const workerRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/worker/$id",
   validateSearch: validateDetailSearch,
-  component: WorkerDetailPlaceholder,
+  component: WorkerDetailContainer,
 });
 
-function TicketDetailPlaceholder() {
+function TicketDetailContainer() {
   const { id } = ticketRoute.useParams();
-  return (
-    <div data-detail-kind="ticket" data-detail-id={id} style={PLACEHOLDER_STYLE}>
-      ticket {id}
-    </div>
-  );
+  const search = ticketRoute.useSearch();
+  return <TicketDetailRoute id={id} search={search} />;
 }
 
-function WorkerDetailPlaceholder() {
+function WorkerDetailContainer() {
   const { id } = workerRoute.useParams();
-  return (
-    <div data-detail-kind="worker" data-detail-id={id} style={PLACEHOLDER_STYLE}>
-      worker {id}
-    </div>
-  );
+  const search = workerRoute.useSearch();
+  return <WorkerDetailRoute id={id} search={search} />;
 }
-
-// Minimal, theme-neutral placeholder so the route renders something while the
-// real detail body is out of scope (filled by the DETAIL stream later).
-const PLACEHOLDER_STYLE = {
-  padding: "24px",
-  color: "#8b93a1",
-  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
-} as const;
 
 const routeTree = rootRoute.addChildren([boardRoute, ticketRoute, workerRoute]);
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/key-nav.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/key-nav.ts
@@ -1,0 +1,136 @@
+// key-nav.ts — the PURE keystroke classifier behind use-keyboard-nav.ts
+// (CTL-912 / DETAIL1, detail design §3.4). Split out of the React hook (which
+// owns the listener + the g-chord timer) so the orch-monitor `bun test` suite
+// can unit-test the keymap directly — every Gherkin key behaviour is a pure
+// function of (key, modifiers, the input-focus guard, the pending g-chord).
+//
+// THE EXTENSION IS ADDITIVE: the pre-existing bindings (Escape, `/`→search with
+// preventDefault, `?`, and the INPUT/TEXTAREA/SELECT early-return) are encoded
+// here UNCHANGED; this only ADDS j/k, ⌘K, and the g-chords (g t / g w / g a).
+// `use-keyboard-nav.ts` is the thin effect that feeds events through `classifyKey`
+// and dispatches the returned action — so the keymap the operator feels can never
+// drift from what key-nav.test.ts locks in.
+
+/** The minimal event shape the classifier reads — a structural subset of the DOM
+ *  `KeyboardEvent` so the hook can pass the real event AND the test can pass a
+ *  plain object (no jsdom needed). */
+export interface KeyEventLike {
+  key: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  shiftKey?: boolean;
+}
+
+/** The actions the global nav keymap can produce. A discriminated union so the
+ *  hook's dispatch is exhaustive and the `g`-chord state is carried explicitly. */
+export type KeyAction =
+  // pre-existing (kept verbatim) ───────────────────────────────────────────
+  | { type: "escape" } // Esc — layered dismiss (hook owns the layers)
+  | { type: "focus-search"; preventDefault: true } // `/` — focus board search
+  | { type: "help" } // `?` — cheatsheet overlay
+  // new for DETAIL1 ──────────────────────────────────────────────────────────
+  | { type: "next"; preventDefault: true } // j / ▾ — next in listContext
+  | { type: "prev"; preventDefault: true } // k / ▴ — prev in listContext
+  | { type: "palette"; preventDefault: true } // ⌘K / Ctrl-K — toggle palette
+  | { type: "goto-ticket" } // g t — worker → its ticket
+  | { type: "goto-worker" } // g w — fuzzy go-to worker
+  | { type: "goto-active" } // g a — scroll spine to the active node
+  // chord lifecycle (not dispatched to callbacks; drives the hook's timer) ────
+  | { type: "chord-start" } // `g` pressed → arm the chord, await the second key
+  | { type: "none" }; // ignored keystroke (incl. all input-focus keys)
+
+/**
+ * Whether the focused element is a typing target the keymap must not steal keys
+ * from. The pre-existing guard (`use-keyboard-nav.ts:24`) checks INPUT / TEXTAREA
+ * / SELECT by tag name; kept byte-for-byte (uppercased tag) so `/`-into-a-textarea
+ * and j/k-into-an-input still type a literal character. `tag` is the focused
+ * element's `tagName` (the hook reads `document.activeElement?.tagName`).
+ */
+export function isTypingTarget(tag: string | undefined | null): boolean {
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+}
+
+/** True when no modifier (other than the explicit ⌘/Ctrl handled for the palette)
+ *  is held — single-letter shortcuts must not fire while a chord/shortcut modifier
+ *  is down, so a browser hotkey like ⌥j is never swallowed as "next". */
+function isBareKey(e: KeyEventLike): boolean {
+  return !e.metaKey && !e.ctrlKey && !e.altKey;
+}
+
+/**
+ * Classify a keystroke into a nav action (detail design §3.4 keyboard table).
+ *
+ * @param e            the keystroke (real DOM event or a plain test object).
+ * @param focusedTag   `document.activeElement?.tagName` — the input-focus guard.
+ * @param chordPending true when a `g` was pressed within the chord window and we
+ *                     are awaiting the second key (the hook owns the timer).
+ *
+ * Resolution order (each rule is exact):
+ *   1. ⌘K / Ctrl-K → toggle palette. Checked FIRST so it works even while an
+ *      input is focused (a command palette must always be reachable) — this is
+ *      the one shortcut that intentionally pierces the input guard.
+ *   2. If a typing target is focused → `none` (the pre-existing guard, kept).
+ *   3. A pending `g` chord: the next bare key resolves it — `t`→goto-ticket,
+ *      `w`→goto-worker, `a`→goto-active; anything else cancels (`none`).
+ *   4. Bare single keys: `j`→next, `k`→prev, `g`→chord-start, `/`→focus-search
+ *      (preventDefault, kept), `?`→help (kept), `Escape`→escape (kept).
+ *   5. Everything else → `none`.
+ *
+ * Pure + total: no DOM reads, no throw, no side effects.
+ */
+export function classifyKey(
+  e: KeyEventLike,
+  focusedTag: string | undefined | null,
+  chordPending: boolean,
+): KeyAction {
+  // 1. ⌘K / Ctrl-K — the palette toggle pierces the input guard (always reachable).
+  if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+    return { type: "palette", preventDefault: true };
+  }
+
+  // 2. Input-focus guard (pre-existing, kept): swallow nothing while typing.
+  if (isTypingTarget(focusedTag)) return { type: "none" };
+
+  // 3. Resolve a pending `g`-chord with the second bare key.
+  if (chordPending && isBareKey(e)) {
+    switch (e.key) {
+      case "t":
+        return { type: "goto-ticket" };
+      case "w":
+        return { type: "goto-worker" };
+      case "a":
+        return { type: "goto-active" };
+      default:
+        return { type: "none" }; // unknown second key cancels the chord
+    }
+  }
+
+  // 4. Bare single keys (no modifier).
+  if (isBareKey(e)) {
+    switch (e.key) {
+      case "j":
+        return { type: "next", preventDefault: true };
+      case "k":
+        return { type: "prev", preventDefault: true };
+      case "g":
+        return { type: "chord-start" };
+      case "/":
+        return { type: "focus-search", preventDefault: true }; // kept (preventDefault)
+      case "?":
+        return { type: "help" }; // kept
+      case "Escape":
+        return { type: "escape" }; // kept (hook owns the layered dismiss)
+    }
+  }
+
+  // Escape can arrive with shift/modifiers on some layouts — honour it regardless
+  // so the layered dismiss is never wedged.
+  if (e.key === "Escape") return { type: "escape" };
+
+  return { type: "none" };
+}
+
+/** The chord window (ms) the hook waits for the second key of a `g`-chord before
+ *  it lapses. Exposed so the hook and any test share the one constant. */
+export const CHORD_WINDOW_MS = 800;

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-keyboard-nav.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-keyboard-nav.ts
@@ -1,43 +1,119 @@
 import { useEffect, useRef } from "react";
+import { classifyKey, CHORD_WINDOW_MS } from "./key-nav";
 
 interface KeyboardNavOptions {
+  // ── pre-existing callbacks (unchanged) ──────────────────────────────────────
   onEscape?: () => void;
   onSlash?: () => void;
   onQuestionMark?: () => void;
+  // ── new for the detail-page shell (CTL-912 / DETAIL1, detail design §3.4) ────
+  /** `j` / ▾ — walk to the next entity in listContextAtom.ids (in place). */
+  onNext?: () => void;
+  /** `k` / ▴ — walk to the previous entity in listContextAtom.ids (in place). */
+  onPrev?: () => void;
+  /** `⌘K` / `Ctrl-K` — toggle the command palette (saves/restores focus in the
+   *  caller). Reachable even while an input is focused. */
+  onPalette?: () => void;
+  /** `g t` — from a worker, jump to its parent ticket. */
+  onGotoTicket?: () => void;
+  /** `g w` — fuzzy go-to a worker (opens the palette pre-scoped, in the caller). */
+  onGotoWorker?: () => void;
+  /** `g a` — scroll the lifecycle spine to the active phase node. */
+  onGotoActive?: () => void;
 }
 
 /**
- * Binds global keyboard shortcuts for dashboard navigation.
+ * Binds global keyboard shortcuts for dashboard + detail-page navigation.
  *
- * Shortcuts are ignored when an input, textarea, or select is focused.
- *   - Escape  → onEscape      (e.g. go back to dashboard)
- *   - /       → onSlash        (e.g. focus search input, preventDefault)
- *   - ?       → onQuestionMark (e.g. show keyboard help)
+ * Shortcuts are ignored when an input, textarea, or select is focused — EXCEPT
+ * `⌘K`/`Ctrl-K`, which must always reach the command palette (detail design
+ * §3.4). The keymap itself is the pure `classifyKey` (see `./key-nav.ts`); this
+ * hook only owns the listener, the `g`-chord timer, and dispatch — so the bindings
+ * are unit-tested without a DOM.
+ *
+ *   Pre-existing (kept verbatim):
+ *     - Escape  → onEscape        (e.g. layered dismiss / go back)
+ *     - /       → onSlash          (focus search input, preventDefault)
+ *     - ?       → onQuestionMark   (show keyboard help)
+ *   New (CTL-912 / DETAIL1):
+ *     - j / k   → onNext / onPrev  (walk the list you came from, in place)
+ *     - ⌘K      → onPalette        (toggle the command palette)
+ *     - g t / g w / g a → onGotoTicket / onGotoWorker / onGotoActive (chords)
  */
 export function useKeyboardNav(options: KeyboardNavOptions): void {
   const callbacksRef = useRef(options);
   callbacksRef.current = options;
 
   useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      const tag = document.activeElement?.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+    // The `g`-chord state lives in the effect closure: `g` arms a pending chord
+    // for CHORD_WINDOW_MS; the next key resolves or cancels it.
+    let chordPending = false;
+    let chordTimer: ReturnType<typeof setTimeout> | undefined;
 
-      switch (e.key) {
-        case "Escape":
-          callbacksRef.current.onEscape?.();
+    const clearChord = () => {
+      chordPending = false;
+      if (chordTimer) {
+        clearTimeout(chordTimer);
+        chordTimer = undefined;
+      }
+    };
+
+    function handleKeyDown(e: KeyboardEvent) {
+      const focusedTag = document.activeElement?.tagName;
+      const wasChordPending = chordPending;
+      const action = classifyKey(e, focusedTag, wasChordPending);
+
+      // Any resolved keystroke (the second key of a chord, or a non-`g` key)
+      // clears a pending chord before we dispatch. `chord-start` re-arms below.
+      if (wasChordPending) clearChord();
+
+      const cb = callbacksRef.current;
+      switch (action.type) {
+        case "escape":
+          cb.onEscape?.();
           break;
-        case "/":
+        case "focus-search":
           e.preventDefault();
-          callbacksRef.current.onSlash?.();
+          cb.onSlash?.();
           break;
-        case "?":
-          callbacksRef.current.onQuestionMark?.();
+        case "help":
+          cb.onQuestionMark?.();
+          break;
+        case "next":
+          e.preventDefault();
+          cb.onNext?.();
+          break;
+        case "prev":
+          e.preventDefault();
+          cb.onPrev?.();
+          break;
+        case "palette":
+          e.preventDefault();
+          cb.onPalette?.();
+          break;
+        case "goto-ticket":
+          cb.onGotoTicket?.();
+          break;
+        case "goto-worker":
+          cb.onGotoWorker?.();
+          break;
+        case "goto-active":
+          cb.onGotoActive?.();
+          break;
+        case "chord-start":
+          // Arm the chord and start the lapse timer (a stale `g` shouldn't linger).
+          chordPending = true;
+          chordTimer = setTimeout(clearChord, CHORD_WINDOW_MS);
+          break;
+        case "none":
           break;
       }
     }
 
     document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      clearChord();
+    };
   }, []);
 }


### PR DESCRIPTION
## CTL-912 (DETAIL1) — Shared detail chrome + pager + keyboard

Builds the shared detail-**PAGE** chrome (`Shell.tsx`) that both the ticket page (DETAIL2) and worker page (DETAIL3) render inside: a from-context breadcrumb (pure fn of the URL search params), an `N / total` pager that walks the list you came from in place, a live-signal title anchor, a Properties-rail skeleton, a `<DetailBody>` slot, and a footer. Extends the existing keyboard hook in place with `j`/`k` list-walk, `g`-chords, and `⌘K`, preserving today's behavior. This is the detail-page chrome from detail design §3 — NOT the app-nav Sidebar (the SHELL stream's `AppShell`); the two are distinct components that nest.

Depends on FND1/FND2/SHELL1 (CTL-881/882/891, all merged): consumes their typed search params (`route-search.ts`), the shared `resolveList`/`resolveListIds` (`list-order.ts` — the P1 keystone so the pager order can't drift from the board), and the jotai nav store (`nav-store.ts` `listContextAtom`/`recordRecentAtom`) — read here, not re-created.

### Gherkin scenarios

| Scenario | Status | Where |
|---|---|---|
| From-context breadcrumb reconstructs from the URL | **satisfied** | `resolveBreadcrumb`/`breadcrumbText` (`◂ Board · Implement  CTL-845`; `?from=stuck` → `Stuck` crumb; degraded → `Board › CTL-845`). `Breadcrumb` routes `◂ Board` + middle crumb to `/`. Tests: detail-chrome (breadcrumb) + detail-shell structural. |
| Pager walks the resolved list in place | **satisfied** | `resolvePager` (1-based N/total, prev/next neighbours, chevrons inert at ends). `Shell` walks via a typed route-param swap (`navigate({ to: "/ticket/$id", params, search:{…cursor} })`) — no full reload; `j`/`k` bound to it. |
| Cold-linked (pasted) URL renders immediately, pager lights up later | **satisfied** | `resolvePager` cold-link branch (`?cursor=4` → ghosted `5 / —`, inert chevrons); entity + body render off props regardless of list; `Shell` mirrors resolved ids into `listContextAtom`, so a `/api/board/stream` rehydrate re-lights the pager via the SAME function (no separate path, no spinner). `$id` off-list → stays `— / —`, only the breadcrumb navigates. |
| Live-dot title reserves cyan for genuine liveness only | **satisfied** | `resolveLiveDot`: cyan `#5be0ff` breathing ring iff `working && activeState==="active"`; static red `#ef5d5d` if stuck; no dot when settled. Cyan reaches the DOM only through the dot's returned color; all chrome accents are blue `#4ea1ff` (`CHROME_BLUE`). Reduced-motion collapses the breathing ring. |
| Keyboard hook is extended, not forked | **satisfied** | `use-keyboard-nav.ts` keeps `onEscape`/`onSlash`(preventDefault)/`onQuestionMark` + the INPUT/TEXTAREA/SELECT guard verbatim, ADDS `j`/`k`/`⌘K`/`g`-chords. `⌘K` is the one shortcut that pierces the input guard. Keymap is the pure `classifyKey` (`key-nav.ts`), unit-tested without a DOM. `Esc` from a clean page returns to the originating list (board root). |
| Properties rail never fabricates a value | **satisfied** | `PropertiesRail` renders shared cheap rows (Status/Phase/Priority/Estimate/Scope/Project/Repo/Team/Updated/PR) off `BoardTicket`; an unplumbed (`undefined`) row renders dimmed with an em-dash, never an invented value. `model` row is labelled `Model (current phase)` honestly. |

### Single-node descope
N/A — this ticket is pure detail-page chrome (routing + jotai + keyboard) on a single board payload. No cluster/fence/multi-host/motion/resume behavior is in scope, so there was nothing to gate behind a `hosts.json` length check.

### Tests / validation
- `bun test __tests__/detail-chrome.test.ts` → 17 pass (breadcrumb, pager, cold-link, live-dot Gherkin).
- `bun test __tests__/key-nav.test.ts` → 15 pass (the extended keymap incl. input guard + ⌘K-pierce).
- `bun test __tests__/detail-shell.test.ts` → 20 pass (structural wiring: shell mount, router wiring, cyan restraint, rail honesty — DOM-less, matching the SHELL1 `app-shell.test.ts` pattern).
- Dependency suites still green: list-order (24), recents (10), route-search, app-shell, nav-store (ui pkg, jotai runtime). Broad board sweep: no regression.
- `bunx tsc --noEmit` in `ui/` → clean (1 pre-existing unrelated `kpi-strip.tsx` error on origin/main, not touched). Root orch-monitor tsc → 0 errors.
- `bun run build` in `ui/` → green. No reward-hacking casts (`as any`/`as unknown`/`@ts-ignore`/`as never`/non-null `!`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)