### PR TITLE
feat(dev): CTL-729 progress watchdog for hung phase workers

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -347,3 +347,63 @@ export const AUTOTUNE_DRIFT_DOWN_STEP =
 // high-water (reuses the legacy ×0.75 trend-up shed factor).
 export const AUTOTUNE_CLAUDE_SHED_FACTOR =
   Number(process.env.EXECUTION_CORE_AUTOTUNE_CLAUDE_SHED_FACTOR) || 0.75;
+
+// --- Progress watchdog for hung phase workers (CTL-729) ---
+// Three-layer precedence per knob (mirrors getHostName): env > Layer-2
+// (catalyst.watchdog.* in ~/.config/catalyst/config.json) > code default.
+// Re-reads on every call (mirrors readMemorySamplerConfig) so tests mutate env
+// freely. Never throws — missing/malformed Layer-2 falls through to defaults.
+
+export const WATCHDOG_MINUTES_PER_TURN =
+  Number(process.env.EXECUTION_CORE_WATCHDOG_MINUTES_PER_TURN) || 2;
+const WATCHDOG_MIN_PHASE_BUDGET_MS = 20 * 60_000;   // absolute floor
+const WATCHDOG_FALLBACK_BUDGET_MS = 90 * 60_000;    // when turnCap unparseable
+const WATCHDOG_MODES = new Set(["off", "shadow", "enforce"]);
+
+function readLayer2Watchdog() {
+  try {
+    const w = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.watchdog;
+    return w && typeof w === "object" ? w : {};
+  } catch { return {}; }
+}
+function resolveMode(envVal, l2Val) {
+  for (const v of [envVal, l2Val]) {
+    if (typeof v === "string" && WATCHDOG_MODES.has(v)) return v;
+  }
+  return "shadow"; // conservative default: detect+log, do not kill, until flipped to enforce
+}
+function resolveCount(envVal, l2Val, def) {
+  for (const v of [envVal, l2Val]) {
+    if (v === undefined || v === null || v === "") continue;
+    const n = Number(v);
+    if (Number.isInteger(n) && n >= 0) return n;
+  }
+  return def;
+}
+
+export function readWatchdogConfig() {
+  const l2 = readLayer2Watchdog();
+  // CATALYST_WATCHDOG=0 is the kill-switch → mode:off (back-compat).
+  const mode = process.env.CATALYST_WATCHDOG === "0"
+    ? "off"
+    : resolveMode(process.env.EXECUTION_CORE_WATCHDOG_MODE, l2.mode);
+  const silenceThresholdMs =
+    Number(process.env.EXECUTION_CORE_WATCHDOG_SILENCE_MS) ||
+    (Number(l2.silenceThresholdMinutes) || 0) * 60_000 ||
+    30 * 60_000;
+  const phaseBudgetMultiplier =
+    Number(process.env.EXECUTION_CORE_WATCHDOG_BUDGET_MULTIPLIER) ||
+    Number(l2.phaseBudgetMultiplier) || 1.5;
+  const reviveBudget = resolveCount(
+    process.env.EXECUTION_CORE_WATCHDOG_REVIVE_BUDGET, l2.reviveBudget, 0);
+  return { mode, silenceThresholdMs, phaseBudgetMultiplier, reviveBudget };
+}
+
+// phaseBudgetMs — expected wall-clock ceiling (ms) from the dispatch-time turnCap.
+// Pure (no clock/fs) so the predicate gate is cheaply unit-testable.
+export function phaseBudgetMs(phase, turnCap, cfg = readWatchdogConfig()) {
+  const cap = Number(turnCap);
+  if (!Number.isFinite(cap) || cap <= 0) return WATCHDOG_FALLBACK_BUDGET_MS;
+  const mult = Number(cfg?.phaseBudgetMultiplier) || 1.5;
+  return Math.max(cap * WATCHDOG_MINUTES_PER_TURN * mult * 60_000, WATCHDOG_MIN_PHASE_BUDGET_MS);
+}

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -417,4 +417,15 @@ describe("phaseBudgetMs (CTL-729)", () => {
   test("missing/NaN turnCap → safe fallback budget", () => {
     expect(phaseBudgetMs("implement", undefined, { phaseBudgetMultiplier: 1.5 })).toBeGreaterThan(0);
   });
+  test("CTL-729 coverage: undefined turnCap → exact 90-min fallback (WATCHDOG_FALLBACK_BUDGET_MS)", () => {
+    // Pin the exact fallback so a regression swapping it for the 20-min floor or 0
+    // is caught (the toBeGreaterThan(0) assertion above would not notice).
+    expect(phaseBudgetMs("implement", undefined, { phaseBudgetMultiplier: 1.5 })).toBe(90 * 60_000);
+  });
+  test("CTL-729 coverage: cap<=0 (zero/negative turnCap) → 90-min fallback, not the floor", () => {
+    // The `!Number.isFinite(cap) || cap <= 0` guard returns the fallback, NOT the
+    // 20-min floor — exercise both the zero and negative branches.
+    expect(phaseBudgetMs("implement", 0, { phaseBudgetMultiplier: 1.5 })).toBe(90 * 60_000);
+    expect(phaseBudgetMs("implement", -5, { phaseBudgetMultiplier: 1.5 })).toBe(90 * 60_000);
+  });
 });

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -340,3 +340,81 @@ describe("HEARTBEAT_INTERVAL_MS (CTL-859)", () => {
     expect(HEARTBEAT_INTERVAL_MS).toBe(30_000);
   });
 });
+
+import { readWatchdogConfig, phaseBudgetMs, WATCHDOG_MINUTES_PER_TURN } from "./config.mjs";
+
+const WD_ENVS = ["CATALYST_WATCHDOG", "EXECUTION_CORE_WATCHDOG_MODE",
+  "EXECUTION_CORE_WATCHDOG_SILENCE_MS", "EXECUTION_CORE_WATCHDOG_BUDGET_MULTIPLIER",
+  "EXECUTION_CORE_WATCHDOG_REVIVE_BUDGET", "CATALYST_LAYER2_CONFIG_FILE"];
+
+describe("readWatchdogConfig (CTL-729)", () => {
+  let saved = {}, tmp;
+  beforeEach(() => {
+    for (const k of WD_ENVS) { saved[k] = process.env[k]; delete process.env[k]; }
+    tmp = mkdtempSync(join(tmpdir(), "ctl729-wd-"));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = join(tmp, "absent.json");
+  });
+  afterEach(() => {
+    for (const k of WD_ENVS) { saved[k] === undefined ? delete process.env[k] : (process.env[k] = saved[k]); }
+    saved = {}; rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("defaults: mode=shadow, 30-min silence, mult 1.5, revive 0", () => {
+    const c = readWatchdogConfig();
+    expect(c.mode).toBe("shadow");
+    expect(c.silenceThresholdMs).toBe(30 * 60_000);
+    expect(c.phaseBudgetMultiplier).toBe(1.5);
+    expect(c.reviveBudget).toBe(0);
+  });
+  test("CATALYST_WATCHDOG=0 maps to mode:off", () => {
+    process.env.CATALYST_WATCHDOG = "0";
+    expect(readWatchdogConfig().mode).toBe("off");
+  });
+  test("reads catalyst.watchdog.* from Layer-2", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { watchdog: {
+      mode: "enforce", silenceThresholdMinutes: 45, phaseBudgetMultiplier: 2, reviveBudget: 1 } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    const out = readWatchdogConfig();
+    expect(out.mode).toBe("enforce");
+    expect(out.silenceThresholdMs).toBe(45 * 60_000);
+    expect(out.phaseBudgetMultiplier).toBe(2);
+    expect(out.reviveBudget).toBe(1);
+  });
+  test("env wins over Layer-2 and default", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { watchdog: { mode: "off", silenceThresholdMinutes: 45 } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    process.env.EXECUTION_CORE_WATCHDOG_MODE = "enforce";
+    process.env.EXECUTION_CORE_WATCHDOG_SILENCE_MS = "600000";
+    const out = readWatchdogConfig();
+    expect(out.mode).toBe("enforce");
+    expect(out.silenceThresholdMs).toBe(600_000);
+  });
+  test("malformed Layer-2 file → code defaults (never throws)", () => {
+    const cfg = join(tmp, "config.json"); writeFileSync(cfg, "{ not json");
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    expect(readWatchdogConfig().silenceThresholdMs).toBe(30 * 60_000);
+  });
+  test("invalid mode string → falls back to shadow", () => {
+    process.env.EXECUTION_CORE_WATCHDOG_MODE = "banana";
+    expect(readWatchdogConfig().mode).toBe("shadow");
+  });
+  test("reviveBudget=0 from env is honored", () => {
+    process.env.EXECUTION_CORE_WATCHDOG_REVIVE_BUDGET = "0";
+    expect(readWatchdogConfig().reviveBudget).toBe(0);
+  });
+});
+
+describe("phaseBudgetMs (CTL-729)", () => {
+  test("turnCap × MINUTES_PER_TURN × multiplier (plan=25)", () => {
+    const cfg = { phaseBudgetMultiplier: 1.5 };
+    expect(phaseBudgetMs("plan", 25, cfg)).toBe(25 * WATCHDOG_MINUTES_PER_TURN * 1.5 * 60_000);
+  });
+  test("absolute floor engages for tiny turnCap", () => {
+    expect(phaseBudgetMs("x", 3, { phaseBudgetMultiplier: 1.5 })).toBe(20 * 60_000);
+  });
+  test("missing/NaN turnCap → safe fallback budget", () => {
+    expect(phaseBudgetMs("implement", undefined, { phaseBudgetMultiplier: 1.5 })).toBeGreaterThan(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/hung-detector.mjs
+++ b/plugins/dev/scripts/execution-core/hung-detector.mjs
@@ -1,0 +1,49 @@
+// hung-detector.mjs — CTL-729 progress-watchdog decision (pure, no IO).
+// Mirrors stalled-detector.mjs:detectStalled. Returns a frozen decision object.
+// All non-determinism (clock, transcript mtime, commit count, resolved thresholds)
+// is computed by the caller and passed in — the full truth table is unit-testable
+// with zero IO.
+
+import { TERMINAL } from "./signal-reader.mjs";
+
+// Research/plan phases: 0 commits is normal (no code shipped in fan-out).
+// The commit gate is WAIVED for these phases; the silence + budget gates still apply
+// so a quietly-synthesizing research parent at 35 min is never killed (its budget
+// is ~105 min at default settings).
+const FANOUT_PHASES = new Set(["research", "plan"]);
+const ACTIONABLE_STATUS = new Set(["running", "dispatched"]);
+const NO_OP = (reason) => Object.freeze({ action: "none", reason, elapsedMin: 0 });
+
+// evaluateHungWorker — decide whether one worker should be force-killed.
+//
+// inputs: {
+//   ticket, phase, status,
+//   nowMs,           — current epoch ms
+//   startedAtMs,     — parsed startedAt, or null if unparseable
+//   transcriptAgeMs, — ms since last transcript write, or null if unmeasurable
+//   progressMark,    — commits-ahead-of-origin/main (0 for fanout phases)
+//   silenceMs,       — threshold from readWatchdogConfig().silenceThresholdMs
+//   budgetMs,        — from phaseBudgetMs(phase, turnCap)
+// }
+// returns: frozen { action: "kill-escalate"|"none", reason, elapsedMin }
+export function evaluateHungWorker(i) {
+  // (1) Status gate — terminal absorbs everything; only running/dispatched can act.
+  if (TERMINAL.has(i.status) || i.status === "complete") return NO_OP("terminal");
+  if (!ACTIONABLE_STATUS.has(i.status)) return NO_OP("not-actionable");
+  // Fail-safe: missing data is never evidence of a hang.
+  if (i.startedAtMs == null || !Number.isFinite(i.startedAtMs)) return NO_OP("no-startedat");
+  if (i.transcriptAgeMs == null) return NO_OP("no-transcript");
+  // (2) Silence gate — a fresh parent OR subagent write counts as progress.
+  if (i.transcriptAgeMs <= i.silenceMs) return NO_OP("transcript-fresh");
+  // (3) Budget gate — applies to ALL phases including fanout (minimum-elapsed floor).
+  const elapsedMs = i.nowMs - i.startedAtMs;
+  if (elapsedMs <= i.budgetMs) return NO_OP("under-budget");
+  // (4) Commit gate — waived for fanout phases (0 commits expected there).
+  if (!FANOUT_PHASES.has(i.phase) && i.progressMark > 0) return NO_OP("has-progress");
+  const elapsedMin = Math.floor(elapsedMs / 60_000); // floor → deterministic reason string
+  return Object.freeze({
+    action: "kill-escalate",
+    reason: `hung_no_progress:${i.phase}:${elapsedMin}m_${i.progressMark}_commits`,
+    elapsedMin,
+  });
+}

--- a/plugins/dev/scripts/execution-core/hung-detector.test.mjs
+++ b/plugins/dev/scripts/execution-core/hung-detector.test.mjs
@@ -1,0 +1,104 @@
+// hung-detector.test.mjs — CTL-729 Phase 3 truth table.
+// Pure IO-free tests; all inputs injected.
+
+import { describe, test, expect } from "bun:test";
+import { evaluateHungWorker } from "./hung-detector.mjs";
+
+const NOW = Date.parse("2026-06-09T12:00:00Z");
+const SIL = 30 * 60_000;        // 30 min silence threshold
+const BUD = 2 * 60 * 60_000;    // 2 hour budget
+
+// A HUNG implement worker — each test overrides one axis.
+const makeInputs = (over = {}) => ({
+  ticket: "CTL-692",
+  phase: "implement",
+  status: "running",
+  nowMs: NOW,
+  startedAtMs: NOW - BUD - 60_000,   // 1 minute past budget
+  transcriptAgeMs: SIL + 60_000,     // 1 minute past silence threshold
+  progressMark: 0,                   // 0 commits
+  silenceMs: SIL,
+  budgetMs: BUD,
+  ...over,
+});
+
+describe("evaluateHungWorker — hung cases", () => {
+  test("[hung] running + silent + 0commits + over-budget → kill-escalate", () => {
+    const o = evaluateHungWorker(makeInputs());
+    expect(o.action).toBe("kill-escalate");
+    expect(o.reason).toMatch(/^hung_no_progress:implement:\d+m_0_commits$/);
+    expect(o.elapsedMin).toBeGreaterThan(0);
+  });
+});
+
+describe("evaluateHungWorker — spared cases", () => {
+  test("[fresh] silence under threshold → none/transcript-fresh", () => {
+    expect(evaluateHungWorker(makeInputs({ transcriptAgeMs: SIL - 1 })).reason).toBe("transcript-fresh");
+  });
+  test("[has-commit] >=1 commit → none/has-progress (non-fanout)", () => {
+    expect(evaluateHungWorker(makeInputs({ progressMark: 2 })).reason).toBe("has-progress");
+  });
+  test("[under-budget] elapsed within budget → none/under-budget (ALL phases)", () => {
+    expect(evaluateHungWorker(makeInputs({ startedAtMs: NOW - 60_000 })).reason).toBe("under-budget");
+  });
+});
+
+describe("evaluateHungWorker — fanout phases (Gherkin 3)", () => {
+  test("[research-fanout] 0 commits + over budget + silent → kill (commit gate waived)", () => {
+    const o = evaluateHungWorker(makeInputs({
+      phase: "research",
+      progressMark: 0,
+      budgetMs: 105 * 60_000,
+      startedAtMs: NOW - 106 * 60_000,
+    }));
+    expect(o.action).toBe("kill-escalate");
+  });
+  test("[research-fresh] research + fresh subagent transcript → none (never killed)", () => {
+    expect(
+      evaluateHungWorker(makeInputs({ phase: "research", transcriptAgeMs: 1_000 })).action,
+    ).toBe("none");
+  });
+  test("[research-under-budget] research silent but elapsed < budget → none (NOT killed early)", () => {
+    expect(
+      evaluateHungWorker(makeInputs({
+        phase: "research",
+        budgetMs: 105 * 60_000,
+        startedAtMs: NOW - 35 * 60_000,
+      })).reason,
+    ).toBe("under-budget");
+  });
+  test("[plan-fanout] plan + fresh transcript → none", () => {
+    expect(evaluateHungWorker(makeInputs({ phase: "plan", transcriptAgeMs: 1_000 })).action).toBe("none");
+  });
+  test("[plan-hung] plan + silent + over budget → kill (commit gate waived)", () => {
+    const o = evaluateHungWorker(makeInputs({
+      phase: "plan",
+      progressMark: 0,
+      budgetMs: 105 * 60_000,
+      startedAtMs: NOW - 106 * 60_000,
+    }));
+    expect(o.action).toBe("kill-escalate");
+  });
+});
+
+describe("evaluateHungWorker — terminal + status gates (Gherkin 4)", () => {
+  test("[terminal] settled status → none", () => {
+    for (const st of ["done", "failed", "stalled", "skipped", "complete"]) {
+      expect(evaluateHungWorker(makeInputs({ status: st })).action).toBe("none");
+    }
+  });
+  test("[status] only running/dispatched are candidates", () => {
+    expect(evaluateHungWorker(makeInputs({ status: "preempted" })).action).toBe("none");
+    expect(evaluateHungWorker(makeInputs({ status: "dispatched" })).action).toBe("kill-escalate");
+  });
+});
+
+describe("evaluateHungWorker — fail-safe (missing data)", () => {
+  test("[no-startedat] unparseable startedAt → none", () => {
+    expect(evaluateHungWorker(makeInputs({ startedAtMs: null })).action).toBe("none");
+    expect(evaluateHungWorker(makeInputs({ startedAtMs: NaN })).action).toBe("none");
+  });
+  test("[no-transcript] null transcriptAgeMs → none", () => {
+    expect(evaluateHungWorker(makeInputs({ transcriptAgeMs: null })).action).toBe("none");
+  });
+});

--- a/plugins/dev/scripts/execution-core/integration-ctl-729.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-729.test.mjs
@@ -1,0 +1,190 @@
+// integration-ctl-729.test.mjs — CTL-729 end-to-end: schedulerTick Pass 0w.
+// Drives the real schedulerTick over a fixture worker dir, asserting the whole
+// chain to the injected seam boundary. Models integration-ctl-701.test.mjs.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { schedulerTick } from "./scheduler.mjs";
+
+const NOW = Date.parse("2026-06-09T12:00:00Z");
+
+let orchDir;
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "ctl729-int-"));
+});
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+function writePhaseSignal(orchDir, ticket, phase, body) {
+  const d = join(orchDir, "workers", ticket);
+  mkdirSync(d, { recursive: true });
+  writeFileSync(
+    join(d, `phase-${phase}.json`),
+    JSON.stringify({ ticket, phase, ...body }, null, 2) + "\n",
+  );
+}
+
+// Minimal tick options shared across all scenarios.
+// Injects a no-op reclaimDeadWork so the reclaim/stalled passes don't interfere
+// with what the watchdog pass did.
+function makeTickOpts({ transcriptAgeMs = () => null, progressMark = () => 0, mode = "enforce", events = [] }) {
+  return {
+    readEligible: () => [],
+    dispatch: () => ({ status: "dispatched" }),
+    exec: () => ({ code: null }),
+    // Prevent reclaim sweep from acting on the fixture workers.
+    reclaimDeadWork: () => ({ class: "alive-suppressed" }),
+    writeStatus: {
+      applyLabel: () => ({ applied: true }),
+      removeLabel: () => ({ applied: true }),
+      runTransition: () => ({ applied: false }),
+    },
+    now: () => NOW,
+    watchdog: {
+      mode,
+      transcriptAgeMs: (sig, opts) => transcriptAgeMs(sig, opts),
+      progressMark: (opts) => progressMark(opts),
+      now: () => NOW,
+      emit: (type, fields) => { events.push({ type, ...fields }); return Promise.resolve(true); },
+      killEscalate: undefined, // use real killHungWorker
+    },
+  };
+}
+
+describe("CTL-729 integration — incident scenario (enforce mode)", () => {
+  test("CTL-692 incident: hung implement → failed signal + reap event + needs-human, one tick", async () => {
+    writePhaseSignal(orchDir, "CTL-729T", "implement", {
+      status: "running",
+      bg_job_id: "abcd1234",
+      startedAt: new Date(NOW - 18 * 3600_000).toISOString(),
+      turnCap: 75,
+    });
+    const events = [];
+    const opts = makeTickOpts({
+      transcriptAgeMs: () => 31 * 60_000,  // silent (>30min)
+      progressMark: () => 0,               // no commits
+      mode: "enforce",
+      events,
+    });
+    const result = schedulerTick(orchDir, opts);
+    // Give the fire-and-forget emit time to run
+    await new Promise((r) => setTimeout(r, 10));
+    const sig = JSON.parse(readFileSync(join(orchDir, "workers", "CTL-729T", "phase-implement.json"), "utf8"));
+    expect(sig.status).toBe("failed");
+    expect(sig.failureReason).toMatch(/hung_no_progress:implement:\d+m_0_commits/);
+    // Custom emit receives camelCase fields (FIELD_MAP conversion only in the real emitReapIntent)
+    expect(events.some((e) => e.type === "phase.terminal.reap-requested" && (e.bgJobId === "abcd1234" || e.bg_job_id === "abcd1234"))).toBe(true);
+    expect(existsSync(join(orchDir, "workers", "CTL-729T", ".linear-label-needs-human.applied"))).toBe(true);
+    expect(result.watchdogKilled).toEqual([{ ticket: "CTL-729T", phase: "implement" }]);
+  });
+});
+
+describe("CTL-729 integration — spared scenarios", () => {
+  test("scenario 2: actively-progressing worker (fresh transcript) untouched", () => {
+    writePhaseSignal(orchDir, "CTL-729T", "implement", {
+      status: "running",
+      bg_job_id: "abcd1234",
+      startedAt: new Date(NOW - 18 * 3600_000).toISOString(),
+      turnCap: 75,
+    });
+    const opts = makeTickOpts({ transcriptAgeMs: () => 5_000, progressMark: () => 0, mode: "enforce" });
+    schedulerTick(orchDir, opts);
+    const sig = JSON.parse(readFileSync(join(orchDir, "workers", "CTL-729T", "phase-implement.json"), "utf8"));
+    expect(sig.status).toBe("running");
+  });
+
+  test("scenario 3: terminal worker is invisible — no reap emitted", () => {
+    writePhaseSignal(orchDir, "CTL-729T", "implement", {
+      status: "failed",
+      bg_job_id: "abcd1234",
+      startedAt: new Date(NOW - 18 * 3600_000).toISOString(),
+      turnCap: 75,
+    });
+    const events = [];
+    const opts = makeTickOpts({
+      transcriptAgeMs: () => 31 * 60_000, progressMark: () => 0, mode: "enforce", events,
+    });
+    schedulerTick(orchDir, opts);
+    expect(events.filter((e) => e.type === "phase.terminal.reap-requested")).toHaveLength(0);
+  });
+
+  test("scenario 4: worker with >=1 commit is not killed (implement phase)", () => {
+    writePhaseSignal(orchDir, "CTL-729T", "implement", {
+      status: "running",
+      bg_job_id: "abcd1234",
+      startedAt: new Date(NOW - 18 * 3600_000).toISOString(),
+      turnCap: 75,
+    });
+    const opts = makeTickOpts({
+      transcriptAgeMs: () => 31 * 60_000,
+      progressMark: () => 3, // has commits
+      mode: "enforce",
+    });
+    schedulerTick(orchDir, opts);
+    const sig = JSON.parse(readFileSync(join(orchDir, "workers", "CTL-729T", "phase-implement.json"), "utf8"));
+    expect(sig.status).toBe("running");
+  });
+});
+
+describe("CTL-729 integration — shadow mode", () => {
+  test("shadow mode: hung worker is logged but NOT killed (signal stays running, no reap)", async () => {
+    writePhaseSignal(orchDir, "CTL-729T", "implement", {
+      status: "running",
+      bg_job_id: "abcd1234",
+      startedAt: new Date(NOW - 18 * 3600_000).toISOString(),
+      turnCap: 75,
+    });
+    const events = [];
+    const opts = makeTickOpts({
+      transcriptAgeMs: () => 31 * 60_000, progressMark: () => 0, mode: "shadow", events,
+    });
+    const result = schedulerTick(orchDir, opts);
+    await new Promise((r) => setTimeout(r, 10));
+    const sig = JSON.parse(readFileSync(join(orchDir, "workers", "CTL-729T", "phase-implement.json"), "utf8"));
+    expect(sig.status).toBe("running");
+    expect(events.filter((e) => e.type === "phase.terminal.reap-requested")).toHaveLength(0);
+    expect(result.watchdogWouldKill).toEqual([{ ticket: "CTL-729T", phase: "implement" }]);
+    expect(result.watchdogKilled).toEqual([]);
+  });
+});
+
+describe("CTL-729 integration — off mode", () => {
+  test("mode:off skips the pass entirely", () => {
+    writePhaseSignal(orchDir, "CTL-729T", "implement", {
+      status: "running",
+      bg_job_id: "abcd1234",
+      startedAt: new Date(NOW - 18 * 3600_000).toISOString(),
+      turnCap: 75,
+    });
+    const opts = makeTickOpts({ transcriptAgeMs: () => 31 * 60_000, progressMark: () => 0, mode: "off" });
+    const result = schedulerTick(orchDir, opts);
+    const sig = JSON.parse(readFileSync(join(orchDir, "workers", "CTL-729T", "phase-implement.json"), "utf8"));
+    expect(sig.status).toBe("running");
+    expect(result.watchdogKilled).toEqual([]);
+    expect(result.watchdogWouldKill).toEqual([]);
+  });
+});
+
+describe("CTL-729 integration — isolated error in watchdog step", () => {
+  test("a thrown watchdog step does not abort the tick (other workers still processed)", () => {
+    writePhaseSignal(orchDir, "CTL-729T", "implement", {
+      status: "running",
+      bg_job_id: "abcd1234",
+      startedAt: new Date(NOW - 18 * 3600_000).toISOString(),
+      turnCap: 75,
+    });
+    let throws = true;
+    const opts = makeTickOpts({
+      transcriptAgeMs: () => { if (throws) { throws = false; throw new Error("injected"); } return 31 * 60_000; },
+      progressMark: () => 0,
+      mode: "enforce",
+    });
+    // Should not throw; watchdog step error is isolated
+    expect(() => schedulerTick(orchDir, opts)).not.toThrow();
+  });
+});

--- a/plugins/dev/scripts/execution-core/integration-ctl-729.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-729.test.mjs
@@ -129,6 +129,35 @@ describe("CTL-729 integration — spared scenarios", () => {
     const sig = JSON.parse(readFileSync(join(orchDir, "workers", "CTL-729T", "phase-implement.json"), "utf8"));
     expect(sig.status).toBe("running");
   });
+
+  test("CTL-729 regression: Pass 0w probes the commit gate via repoRoot, not the dropped worktreePath", () => {
+    // Guards the must-fix: the real defaultProgressMark resolves the worktree from
+    // repoRoot (resolveWorktree), NOT from worktreePath. The original wiring passed
+    // { worktreePath } so the probe got repoRoot=undefined → resolveWorktree returns
+    // null → progress always 0 → the commit gate could never spare a code worker.
+    // scenario 4 above masks this by injecting progressMark: () => 3; here we record
+    // the actual argument shape the scheduler hands the probe.
+    writePhaseSignal(orchDir, "CTL-729T", "implement", {
+      status: "running",
+      bg_job_id: "abcd1234",
+      startedAt: new Date(NOW - 18 * 3600_000).toISOString(),
+      turnCap: 75,
+      worktreePath: "/some/worktree/CTL-729T", // present on the signal, but must NOT be the probe arg
+    });
+    let seen = null;
+    const opts = makeTickOpts({
+      transcriptAgeMs: () => 31 * 60_000,        // silent + over budget → the probe fires
+      progressMark: (arg) => { seen = arg; return 0; },
+      mode: "enforce",
+    });
+    schedulerTick(orchDir, opts);
+    expect(seen).not.toBeNull();
+    // defaultProgressMark reads repoRoot; the scheduler must pass it (null is fine
+    // here — getProjectConfig won't resolve the fixture ticket — the KEY is what
+    // proves the fix), and must NOT pass the silently-ignored worktreePath.
+    expect("repoRoot" in seen).toBe(true);
+    expect("worktreePath" in seen).toBe(false);
+  });
 });
 
 describe("CTL-729 integration — shadow mode", () => {
@@ -186,5 +215,46 @@ describe("CTL-729 integration — isolated error in watchdog step", () => {
     });
     // Should not throw; watchdog step error is isolated
     expect(() => schedulerTick(orchDir, opts)).not.toThrow();
+  });
+});
+
+describe("CTL-729 integration — revive-budget production wiring", () => {
+  test("reviveBudget>0 re-dispatches the worker via dispatchTicket (NOT the claim mutex)", () => {
+    // The original wiring passed claimDispatch (claimDispatchSync — a cross-host
+    // Linear claim soft-CAS, NOT a worker re-dispatch) as reviveDispatch, so an
+    // operator enabling reviveBudget>0 would get outcome:"revived" with NO new
+    // worker spawned. This exercises the REAL killHungWorker + the scheduler's
+    // production reviveDispatch closure (no injected recorder for killEscalate):
+    // a revive must route through dispatchTicket → the injected dispatch seam.
+    const prev = process.env.EXECUTION_CORE_WATCHDOG_REVIVE_BUDGET;
+    process.env.EXECUTION_CORE_WATCHDOG_REVIVE_BUDGET = "1";
+    try {
+      writePhaseSignal(orchDir, "CTL-729T", "implement", {
+        status: "running",
+        bg_job_id: "abcd1234",
+        startedAt: new Date(NOW - 18 * 3600_000).toISOString(),
+        turnCap: 75,
+      });
+      const dispatched = [];
+      const opts = makeTickOpts({
+        transcriptAgeMs: () => 31 * 60_000, // silent + over budget → watchdog fires
+        progressMark: () => 0,              // no commits → kill-eligible
+        mode: "enforce",
+      });
+      opts.dispatch = (a) => { dispatched.push(a); return { status: "dispatched" }; };
+      opts.resolveSession = () => null;     // fixture: no live session to --resume
+      schedulerTick(orchDir, opts);
+      // killHungWorker runs its revive path synchronously (no await before the
+      // reviveDispatch call), so the dispatch lands during the tick.
+      expect(dispatched.length).toBe(1);
+      expect(dispatched[0]).toMatchObject({ ticket: "CTL-729T", phase: "implement", attempt: 1 });
+      // and the revive crumb that backs the budget cap was written
+      expect(
+        existsSync(join(orchDir, "workers", "CTL-729T", ".watchdog-revive-implement.1")),
+      ).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.EXECUTION_CORE_WATCHDOG_REVIVE_BUDGET;
+      else process.env.EXECUTION_CORE_WATCHDOG_REVIVE_BUDGET = prev;
+    }
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -73,40 +73,11 @@ const EMIT_COMPLETE_BIN = fileURLToPath(
   new URL("../phase-agent-emit-complete", import.meta.url),
 );
 
-// resolvePhaseSessionId — JS port of orchestrate-revive's resolve_phase_session_id
-// (orchestrate-revive:160-177). Resolves a `claude --resume`-compatible session
-// UUID from a dead worker's bg_job_id by reading the job's state.json.
-// Returns null on any miss (no bgJobId, no state.json, no session field).
-// MUST stay in sync with the bash resolver — they read the same on-disk contract
-// and honour the same CATALYST_REVIVE_JOBS_DIR override (NOT getJobsRoot's
-// CATALYST_HEALTHCHECK_JOBS_ROOT) so a test overriding one env var matches bash.
-//
-// Claude Code ≥2.x schema: state.json contains `resumeSessionId` directly.
-// Claude Code <2.x schema: state.json contains `linkScanPath` (path to .jsonl);
-//   the basename minus `.jsonl` is the session UUID. Still supported as fallback.
-export function resolvePhaseSessionId(
-  bgJobId,
-  { jobsDir = process.env.CATALYST_REVIVE_JOBS_DIR || join(homedir(), ".claude", "jobs") } = {},
-) {
-  if (!bgJobId) return null;
-  const stateFile = join(jobsDir, bgJobId, "state.json");
-  if (!existsSync(stateFile)) return null;
-  let parsed;
-  try {
-    parsed = JSON.parse(readFileSync(stateFile, "utf8"));
-  } catch {
-    return null;
-  }
-  // New schema (Claude Code ≥2.x): resumeSessionId stored directly.
-  if (typeof parsed?.resumeSessionId === "string" && parsed.resumeSessionId) {
-    return parsed.resumeSessionId;
-  }
-  // Legacy schema: derive UUID from linkScanPath basename.
-  const linkPath = parsed?.linkScanPath;
-  if (typeof linkPath !== "string" || !linkPath.endsWith(".jsonl")) return null;
-  const sid = basename(linkPath, ".jsonl");
-  return sid || null;
-}
+// resolvePhaseSessionId — extracted to session-resolve.mjs (CTL-729) so
+// transcript-silence.mjs can import it without pulling in recovery.mjs's
+// heavy dependency graph. Imported for local use + re-exported for callers.
+import { resolvePhaseSessionId } from "./session-resolve.mjs";
+export { resolvePhaseSessionId };
 
 // defaultStatJob — stat ~/.claude/jobs/<bgJobId>/state.json. Returns null when
 // the job dir is gone (the worker's process no longer exists), else its mtime,

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -106,6 +106,12 @@ import {
   defaultAppendRunawayEvent,
 } from "./recovery.mjs";
 import { resolvePhaseSessionId as defaultResolveSession } from "./session-resolve.mjs";
+// CTL-729: progress-watchdog imports.
+import { evaluateHungWorker } from "./hung-detector.mjs";
+import { transcriptAgeMs as defaultTranscriptAgeMs } from "./transcript-silence.mjs";
+import { killHungWorker as defaultKillEscalate } from "./watchdog-action.mjs";
+import { readWatchdogConfig, phaseBudgetMs } from "./config.mjs";
+import { defaultProgressMark } from "./work-done-probes.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
 // module (best-effort — every write swallows its own failures).
@@ -1847,6 +1853,16 @@ export function schedulerTick(
     hosts = undefined,
     hostName = undefined,
     claimDispatch = claimDispatchSync,
+    // CTL-729: progress-watchdog seams. Defaults keep every existing bare unit
+    // tick inert (null silence probe → predicate no-ops via "no-transcript").
+    watchdog: {
+      mode: _watchdogMode = undefined, // resolved inside the pass
+      transcriptAgeMs: _transcriptAgeMs = defaultTranscriptAgeMs,
+      progressMark: _progressMark = defaultProgressMark,
+      killEscalate: _killEscalate = defaultKillEscalate,
+      now: _watchdogNow = Date.now,
+      emit: _watchdogEmit = emitReapIntent,
+    } = {},
   } = {}
 ) {
   // CTL-850: resolve this host + the cluster roster ONCE per tick (cheap
@@ -1932,6 +1948,74 @@ export function schedulerTick(
         { ticket: sig.ticket, phase: sig.phase },
         "scheduler: quarantined phantom worker dir (not-found + not-eligible + dead bg) — CTL-671"
       );
+    }
+  }
+
+  // (0w) CTL-729 progress-watchdog. Force-kill a worker that is running/dispatched
+  // with a silent transcript and zero commits past its phase budget. Runs AFTER the
+  // phantom sweep and BEFORE the reclaim sweep so a kill flips the signal terminal
+  // first (the sync terminal write is the load-bearing state change — it frees the
+  // slot via isTicketInFlight and prevents re-fire next tick when status:"failed").
+  // Detection + IO ordering live here; side effects delegate to killEscalate.
+  const watchdogKilled = [];
+  const watchdogWouldKill = [];
+  {
+    const wcfg = readWatchdogConfig();
+    const wdMode = _watchdogMode ?? wcfg.mode;
+    if (wdMode !== "off") {
+      for (const sig of readWorkerSignals(orchDir)) {
+        if (!sig.ticket) continue;
+        if (!isTicketInFlight(readPhaseSignals(orchDir, sig.ticket))) continue;
+        if (sig.status === PREEMPTED_STATUS) continue;
+        try {
+          const startedAtMs = Date.parse(sig.raw?.startedAt ?? "");
+          const silenceMs = wcfg.silenceThresholdMs;
+          const budgetMs = phaseBudgetMs(sig.phase, sig.raw?.turnCap, wcfg);
+          const ageMs = _transcriptAgeMs(sig, { now: _watchdogNow() });
+          // Lazy git: only probe commits for a non-fanout worker already silent + over budget.
+          const isFanout = sig.phase === "research" || sig.phase === "plan";
+          const elapsed = _watchdogNow() - startedAtMs;
+          let progress = 0;
+          if (!isFanout && ageMs != null && ageMs > silenceMs && elapsed > budgetMs) {
+            const worktreePath = sig.raw?.worktreePath ?? null;
+            progress = _progressMark({ ticket: sig.ticket, phase: sig.phase, worktreePath, orchDir });
+          }
+          const decision = evaluateHungWorker({
+            ticket: sig.ticket, phase: sig.phase, status: sig.status,
+            nowMs: _watchdogNow(), startedAtMs, transcriptAgeMs: ageMs,
+            progressMark: progress, silenceMs, budgetMs,
+          });
+          if (decision.action !== "kill-escalate") continue;
+          if (wdMode === "shadow") {
+            watchdogWouldKill.push({ ticket: sig.ticket, phase: sig.phase });
+            log.warn(
+              { ticket: sig.ticket, phase: sig.phase, reason: decision.reason },
+              "scheduler: progress-watchdog WOULD kill (shadow mode, no action) (CTL-729)"
+            );
+            continue;
+          }
+          // enforce: fire-and-forget (async kill, sync tick continues)
+          void _killEscalate(orchDir, sig.ticket, sig, {
+            elapsedMin: decision.elapsedMin, commitCount: progress,
+            reviveBudget: wcfg.reviveBudget,
+            now: _watchdogNow, emit: _watchdogEmit,
+            writeStatus, reviveDispatch: claimDispatch,
+          }).catch((err) => log.warn(
+            { ticket: sig.ticket, phase: sig.phase, err: err.message },
+            "scheduler: watchdog kill threw (CTL-729)"
+          ));
+          watchdogKilled.push({ ticket: sig.ticket, phase: sig.phase });
+          log.warn(
+            { ticket: sig.ticket, phase: sig.phase, reason: decision.reason, elapsedMin: decision.elapsedMin },
+            "scheduler: progress-watchdog force-killed hung worker (CTL-729)"
+          );
+        } catch (err) {
+          log.warn(
+            { ticket: sig.ticket, step: "watchdog", err: err.message },
+            "scheduler: per-worker watchdog step failed — continuing tick (CTL-729)"
+          );
+        }
+      }
     }
   }
 
@@ -3086,6 +3170,8 @@ export function schedulerTick(
     noProgressStopped,
     escalated,
     quarantinedPhantoms, // CTL-671 — phantom worker dirs stalled this tick
+    watchdogKilled,      // CTL-729 — workers force-killed this tick (enforce mode)
+    watchdogWouldKill,   // CTL-729 — workers that WOULD be killed (shadow mode)
     advanced,
     dispatched,
     freeSlots,

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1977,8 +1977,15 @@ export function schedulerTick(
           const elapsed = _watchdogNow() - startedAtMs;
           let progress = 0;
           if (!isFanout && ageMs != null && ageMs > silenceMs && elapsed > budgetMs) {
-            const worktreePath = sig.raw?.worktreePath ?? null;
-            progress = _progressMark({ ticket: sig.ticket, phase: sig.phase, worktreePath, orchDir });
+            // CTL-729 remediate: defaultProgressMark resolves the ticket worktree
+            // from repoRoot (work-done-probes.mjs:60 resolveWorktree), NOT from a
+            // worktreePath — passing worktreePath was silently dropped, so the
+            // probe always returned 0 and the commit gate could never spare a
+            // committed-but-silent code worker. Resolve repoRoot exactly like the
+            // reclaim sweep below (scheduler.mjs:2098).
+            const team = teamOf(sig.ticket);
+            const repoRoot = team ? (getProjectConfig(team)?.repoRoot ?? null) : null;
+            progress = _progressMark({ ticket: sig.ticket, phase: sig.phase, repoRoot, orchDir });
           }
           const decision = evaluateHungWorker({
             ticket: sig.ticket, phase: sig.phase, status: sig.status,
@@ -1999,15 +2006,35 @@ export function schedulerTick(
             elapsedMin: decision.elapsedMin, commitCount: progress,
             reviveBudget: wcfg.reviveBudget,
             now: _watchdogNow, emit: _watchdogEmit,
-            writeStatus, reviveDispatch: claimDispatch,
+            writeStatus,
+            // CTL-729 remediate: real revive dispatcher. The prior wiring passed
+            // claimDispatch — the cross-host Linear claim soft-CAS, NOT a worker
+            // re-dispatch — so an operator enabling reviveBudget>0 would mark a
+            // hung worker "revived" while spawning NO replacement (a stuck slot).
+            // Mirror the resume sweep (1.5, scheduler.mjs:2807): resolve the dead
+            // bg job to a `claude --resume` UUID and re-dispatch the same phase
+            // with --resume continuity. killHungWorker passes { ticket, phase,
+            // attempt, bgJobId }; we ignore orchDir (closed over above).
+            reviveDispatch: ({ ticket: rt, phase: rp, attempt, bgJobId }) => {
+              const resumeSession = bgJobId ? (resolveSession(bgJobId) ?? undefined) : undefined;
+              return dispatchTicket(orchDir, rt, rp, { dispatch, resumeSession, attempt });
+            },
           }).catch((err) => log.warn(
             { ticket: sig.ticket, phase: sig.phase, err: err.message },
             "scheduler: watchdog kill threw (CTL-729)"
           ));
+          // CTL-729 remediate: watchdogKilled counts kill-attempts DISPATCHED this
+          // tick, not confirmed kills. The kill is fire-and-forget (the sync tick
+          // cannot await), so the resolved outcome — "escalated" vs "revived"
+          // (reviveBudget>0) vs "already-terminal" (a worker that raced to terminal
+          // between readWorkerSignals and the kill) — lands asynchronously via the
+          // reap pipeline, not in this array. The terminal-signal write inside
+          // killHungWorker is itself synchronous, so the slot is freed correctly
+          // regardless; only this reporting field is attempt-granular.
           watchdogKilled.push({ ticket: sig.ticket, phase: sig.phase });
           log.warn(
             { ticket: sig.ticket, phase: sig.phase, reason: decision.reason, elapsedMin: decision.elapsedMin },
-            "scheduler: progress-watchdog force-killed hung worker (CTL-729)"
+            "scheduler: progress-watchdog kill dispatched for hung worker (CTL-729)"
           );
         } catch (err) {
           log.warn(
@@ -3170,7 +3197,7 @@ export function schedulerTick(
     noProgressStopped,
     escalated,
     quarantinedPhantoms, // CTL-671 — phantom worker dirs stalled this tick
-    watchdogKilled,      // CTL-729 — workers force-killed this tick (enforce mode)
+    watchdogKilled,      // CTL-729 — kill-attempts DISPATCHED this tick (enforce mode); not confirmed kills (see Pass 0w)
     watchdogWouldKill,   // CTL-729 — workers that WOULD be killed (shadow mode)
     advanced,
     dispatched,

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -100,12 +100,12 @@ import {
   defaultKillBgJob,
   defaultAppendPreemptedEvent,
   defaultAppendResumedAfterPreemptionEvent,
-  resolvePhaseSessionId as defaultResolveSession,
   defaultAppendCooldownGcEvent,
   defaultAppendCooldownEscalatedEvent,
   defaultAppendPhaseAdvanceHeldEvent,
   defaultAppendRunawayEvent,
 } from "./recovery.mjs";
+import { resolvePhaseSessionId as defaultResolveSession } from "./session-resolve.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
 // module (best-effort — every write swallows its own failures).

--- a/plugins/dev/scripts/execution-core/session-resolve.mjs
+++ b/plugins/dev/scripts/execution-core/session-resolve.mjs
@@ -1,0 +1,42 @@
+// session-resolve.mjs — resolves a short bg_job_id to a full session UUID.
+// Extracted from recovery.mjs:87-109 (CTL-729) so transcript-silence.mjs can
+// import it without pulling in recovery.mjs's heavy dependency graph.
+// recovery.mjs re-exports for its existing callers; scheduler.mjs alias import
+// updated to point here directly.
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, basename } from "node:path";
+import { homedir } from "node:os";
+
+// resolvePhaseSessionId — JS port of orchestrate-revive's resolve_phase_session_id
+// (SKILL.md bash impl). Given an 8-char short bg_job_id, returns the full session
+// UUID from a dead worker's bg_job_id by reading the job's state.json.
+// Returns null on any miss (no bgJobId, no state.json, no session field).
+//
+// Two schemas supported:
+//   Claude Code ≥2.x schema: state.json contains `resumeSessionId` directly.
+//   Claude Code <2.x schema: state.json contains `linkScanPath` (path to .jsonl);
+//   the basename minus `.jsonl` is the session UUID. Still supported as fallback.
+export function resolvePhaseSessionId(
+  bgJobId,
+  { jobsDir = process.env.CATALYST_REVIVE_JOBS_DIR || join(homedir(), ".claude", "jobs") } = {},
+) {
+  if (!bgJobId) return null;
+  const stateFile = join(jobsDir, bgJobId, "state.json");
+  if (!existsSync(stateFile)) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(stateFile, "utf8"));
+  } catch {
+    return null;
+  }
+  // New schema (Claude Code ≥2.x): resumeSessionId stored directly.
+  if (typeof parsed?.resumeSessionId === "string" && parsed.resumeSessionId) {
+    return parsed.resumeSessionId;
+  }
+  // Legacy schema: derive UUID from linkScanPath basename.
+  const linkPath = parsed?.linkScanPath;
+  if (typeof linkPath !== "string" || !linkPath.endsWith(".jsonl")) return null;
+  const sid = basename(linkPath, ".jsonl");
+  return sid || null;
+}

--- a/plugins/dev/scripts/execution-core/transcript-silence.mjs
+++ b/plugins/dev/scripts/execution-core/transcript-silence.mjs
@@ -1,0 +1,94 @@
+// transcript-silence.mjs — synchronous transcript-silence primitive (CTL-729).
+// Returns the age (ms) of the most recent transcript write for a running worker,
+// folding in subagent transcripts so a worker mid fan-out is never killed while
+// its subagents are active (Gherkin scenario 3).
+//
+// SYNC by design: schedulerTick is synchronous; feeding an async Promise into
+// its predicate would make `Promise <= silenceMs` always false → every worker
+// would look silent. Uses statSync (not stat) and is fully injectable for tests.
+//
+// Returns null on ANY miss (no bg_job_id, no state.json, no transcript file) —
+// "can't measure" is treated as NOT-silent and the predicate spares the worker.
+
+import { statSync, readdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+import { resolvePhaseSessionId } from "./session-resolve.mjs";
+
+const PROJECTS_ROOT = () => join(homedir(), ".claude", "projects");
+
+// slugFor — fast-path slug from a worktree path.
+// ~/.claude/projects uses the worktree path with all slashes and dots replaced
+// by dashes, which lets us skip a readdirSync scan on the common case.
+export const slugFor = (wt) => (wt ? wt.replace(/[/.]/g, "-") : null);
+
+// resolveTranscriptPath — find <projectsRoot>/<slug>/<sessionId>.jsonl.
+// Fast path: derive slug from worktreePath and check directly.
+// Fallback: scan all project dirs (handles unusual setups).
+export function resolveTranscriptPath(
+  sessionId,
+  { projectsRoot = PROJECTS_ROOT(), worktreePath = null } = {},
+) {
+  if (!sessionId) return null;
+  const slug = slugFor(worktreePath);
+  if (slug) {
+    const d = join(projectsRoot, slug, `${sessionId}.jsonl`);
+    if (existsSync(d)) return d;
+  }
+  let entries;
+  try {
+    entries = readdirSync(projectsRoot, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    const cand = join(projectsRoot, e.name, `${sessionId}.jsonl`);
+    if (existsSync(cand)) return cand;
+  }
+  return null;
+}
+
+const mtimeMs = (p, stat) => {
+  try {
+    return stat(p).mtimeMs;
+  } catch {
+    return 0;
+  }
+};
+
+// transcriptAgeMs — age (ms) of the most recent transcript activity for a worker.
+// Accepts a signal-like object (plain {bgJobId} or a parsed signal with raw.bg_job_id).
+// Returns null on any miss so the watchdog predicate fails safe.
+export function transcriptAgeMs(
+  signalLike,
+  {
+    now = Date.now(),
+    projectsRoot = PROJECTS_ROOT(),
+    stat = statSync,
+    readdir = readdirSync,
+    resolveSession = resolvePhaseSessionId,
+  } = {},
+) {
+  // Accept both the flat test shape {bgJobId} and the parsed signal shape {raw.bg_job_id}.
+  const bgJobId =
+    signalLike?.raw?.bg_job_id ??
+    signalLike?.bgJobId ??
+    (signalLike?.liveness?.kind === "bg" ? signalLike.liveness.value : null);
+  if (!bgJobId) return null;
+  const sessionId = resolveSession(bgJobId);
+  if (!sessionId) return null;
+  const worktreePath = signalLike?.raw?.worktreePath ?? signalLike?.worktreePath ?? null;
+  const file = resolveTranscriptPath(sessionId, { projectsRoot, worktreePath });
+  if (!file) return null;
+  let newest = mtimeMs(file, stat);
+  const subDir = join(dirname(file), sessionId, "subagents");
+  try {
+    for (const f of readdir(subDir)) {
+      if (f.endsWith(".jsonl")) newest = Math.max(newest, mtimeMs(join(subDir, f), stat));
+    }
+  } catch {
+    // no subagents dir — parent-only age is fine
+  }
+  return newest ? Math.max(0, now - newest) : null;
+}

--- a/plugins/dev/scripts/execution-core/transcript-silence.test.mjs
+++ b/plugins/dev/scripts/execution-core/transcript-silence.test.mjs
@@ -1,0 +1,179 @@
+// transcript-silence.test.mjs — CTL-729 Phase 2 tests.
+// All fs/clock/resolver injected; never touches real ~/.claude.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { transcriptAgeMs, resolveTranscriptPath, slugFor } from "./transcript-silence.mjs";
+
+const PROJ = "-fake-wt-CTL-729";
+const SID = "afae16b9-488f-4553-b996-85611ae9ecef";
+const SHORT = "afae16b9";
+
+// stub resolver: only maps SHORT → SID
+const resolver = (bg) => (bg === SHORT ? SID : null);
+
+const setMtime = (p, sec) => utimesSync(p, sec, sec); // utimesSync takes seconds
+
+let ROOT;
+beforeEach(() => {
+  ROOT = mkdtempSync(join(tmpdir(), "ctl729-silence-"));
+  mkdirSync(join(ROOT, "projects", PROJ), { recursive: true });
+});
+afterEach(() => {
+  rmSync(ROOT, { recursive: true, force: true });
+});
+
+describe("transcriptAgeMs", () => {
+  test("parent-only: age = now − parent mtime", () => {
+    const f = join(ROOT, "projects", PROJ, `${SID}.jsonl`);
+    writeFileSync(f, "{}\n");
+    setMtime(f, 1000); // mtime = 1000s = 1_000_000ms
+    expect(
+      transcriptAgeMs(
+        { bgJobId: SHORT },
+        { now: 1_060_000, projectsRoot: join(ROOT, "projects"), resolveSession: resolver },
+      ),
+    ).toBe(60_000);
+  });
+
+  test("fresh subagent overrides stale parent → NOT silent (Gherkin 3)", () => {
+    const parent = join(ROOT, "projects", PROJ, `${SID}.jsonl`);
+    writeFileSync(parent, "{}\n");
+    setMtime(parent, 1000);
+    const subDir = join(ROOT, "projects", PROJ, SID, "subagents");
+    mkdirSync(subDir, { recursive: true });
+    const sub = join(subDir, "child-1.jsonl");
+    writeFileSync(sub, "{}\n");
+    setMtime(sub, 1058); // 1058s = 1_058_000ms, 2s before now=1_060_000
+    expect(
+      transcriptAgeMs(
+        { bgJobId: SHORT },
+        { now: 1_060_000, projectsRoot: join(ROOT, "projects"), resolveSession: resolver },
+      ),
+    ).toBe(2_000);
+  });
+
+  test("null bgJobId → null", () => {
+    expect(transcriptAgeMs({ bgJobId: null }, { now: 1, resolveSession: resolver })).toBeNull();
+  });
+
+  test("resolver miss → null", () => {
+    expect(
+      transcriptAgeMs(
+        { bgJobId: "deadbeef" },
+        { now: 1, projectsRoot: join(ROOT, "projects"), resolveSession: resolver },
+      ),
+    ).toBeNull();
+  });
+
+  test("session resolves but no transcript file → null", () => {
+    expect(
+      transcriptAgeMs(
+        { bgJobId: SHORT },
+        { now: 1, projectsRoot: join(ROOT, "projects"), resolveSession: resolver },
+      ),
+    ).toBeNull();
+  });
+
+  test("non-.jsonl noise in subagents dir is ignored (parent age used)", () => {
+    const parent = join(ROOT, "projects", PROJ, `${SID}.jsonl`);
+    writeFileSync(parent, "{}\n");
+    setMtime(parent, 1000);
+    const subDir = join(ROOT, "projects", PROJ, SID, "subagents");
+    mkdirSync(subDir, { recursive: true });
+    // a non-.jsonl file with fresh mtime should NOT affect the result
+    const lock = join(subDir, "index.lock");
+    writeFileSync(lock, "");
+    setMtime(lock, 1059);
+    // Only parent mtime (1000s = 1_000_000ms) counts → age = now - 1_000_000ms
+    expect(
+      transcriptAgeMs(
+        { bgJobId: SHORT },
+        { now: 1_060_000, projectsRoot: join(ROOT, "projects"), resolveSession: resolver },
+      ),
+    ).toBe(60_000);
+  });
+
+  test("missing subagents dir tolerated — parent-only age", () => {
+    const parent = join(ROOT, "projects", PROJ, `${SID}.jsonl`);
+    writeFileSync(parent, "{}\n");
+    setMtime(parent, 1000);
+    // no subagents dir at all
+    expect(
+      transcriptAgeMs(
+        { bgJobId: SHORT },
+        { now: 1_060_000, projectsRoot: join(ROOT, "projects"), resolveSession: resolver },
+      ),
+    ).toBe(60_000);
+  });
+
+  test("reads bg_job_id from raw.bg_job_id (parsed signal shape)", () => {
+    const parent = join(ROOT, "projects", PROJ, `${SID}.jsonl`);
+    writeFileSync(parent, "{}\n");
+    setMtime(parent, 1000);
+    // signal with nested raw
+    expect(
+      transcriptAgeMs(
+        { raw: { bg_job_id: SHORT } },
+        { now: 1_060_000, projectsRoot: join(ROOT, "projects"), resolveSession: resolver },
+      ),
+    ).toBe(60_000);
+  });
+
+  test("no signal at all → null (no crash)", () => {
+    expect(transcriptAgeMs(null, { now: 1, resolveSession: resolver })).toBeNull();
+    expect(transcriptAgeMs(undefined, { now: 1, resolveSession: resolver })).toBeNull();
+  });
+});
+
+describe("resolveTranscriptPath", () => {
+  test("fast path: slug derived from worktreePath matches dir", () => {
+    const projDir = join(ROOT, "projects", PROJ);
+    mkdirSync(projDir, { recursive: true });
+    const f = join(projDir, `${SID}.jsonl`);
+    writeFileSync(f, "");
+    const worktreePath = PROJ.replace(/-/g, "/").replace(/\//g, "/"); // rough reverse slug
+    // Direct slug check: the slugFor(wt) path should match PROJ
+    const result = resolveTranscriptPath(SID, {
+      projectsRoot: join(ROOT, "projects"),
+      worktreePath: PROJ.replace(/-/g, "/"), // produces slug matching PROJ
+    });
+    // Either fast-path or scan finds the file
+    expect(result).toBe(f);
+  });
+
+  test("fallback scan: finds transcript without worktreePath", () => {
+    const f = join(ROOT, "projects", PROJ, `${SID}.jsonl`);
+    writeFileSync(f, "");
+    const result = resolveTranscriptPath(SID, { projectsRoot: join(ROOT, "projects") });
+    expect(result).toBe(f);
+  });
+
+  test("returns null when no match", () => {
+    expect(
+      resolveTranscriptPath("no-such-session", { projectsRoot: join(ROOT, "projects") }),
+    ).toBeNull();
+  });
+
+  test("null sessionId → null", () => {
+    expect(resolveTranscriptPath(null)).toBeNull();
+  });
+});
+
+describe("slugFor", () => {
+  test("replaces slashes and dots with dashes", () => {
+    expect(slugFor("/Users/foo/wt/CTL-729")).toBe("-Users-foo-wt-CTL-729");
+  });
+  test("null input → null", () => {
+    expect(slugFor(null)).toBeNull();
+  });
+});
+
+test("module imports without circular-import crash", async () => {
+  const m = await import("./transcript-silence.mjs");
+  expect(typeof m.transcriptAgeMs).toBe("function");
+  expect(typeof m.resolveTranscriptPath).toBe("function");
+  expect(typeof m.slugFor).toBe("function");
+});

--- a/plugins/dev/scripts/execution-core/transcript-silence.test.mjs
+++ b/plugins/dev/scripts/execution-core/transcript-silence.test.mjs
@@ -126,6 +126,41 @@ describe("transcriptAgeMs", () => {
     expect(transcriptAgeMs(null, { now: 1, resolveSession: resolver })).toBeNull();
     expect(transcriptAgeMs(undefined, { now: 1, resolveSession: resolver })).toBeNull();
   });
+
+  test("CTL-729 coverage: reads bg id from the liveness:{kind:'bg',value} shape (3rd fallback)", () => {
+    // The scheduler passes a parsed signal whose id may arrive via the liveness
+    // shape (signalLike.liveness.kind === 'bg'); only the flat {bgJobId} and
+    // {raw.bg_job_id} extraction paths were covered.
+    const parent = join(ROOT, "projects", PROJ, `${SID}.jsonl`);
+    writeFileSync(parent, "{}\n");
+    setMtime(parent, 1000);
+    expect(
+      transcriptAgeMs(
+        { liveness: { kind: "bg", value: SHORT } },
+        { now: 1_060_000, projectsRoot: join(ROOT, "projects"), resolveSession: resolver },
+      ),
+    ).toBe(60_000);
+  });
+
+  test("CTL-729 coverage: file resolves but stat throws → null (fail-safe = not silent)", () => {
+    // resolveTranscriptPath finds the file, but stat throws (e.g. deleted between
+    // resolve and stat) → mtimeMs returns 0 → newest is falsy → age is null. The
+    // watchdog must NOT treat an unstat-able transcript as silent.
+    const parent = join(ROOT, "projects", PROJ, `${SID}.jsonl`);
+    writeFileSync(parent, "{}\n");
+    const throwingStat = () => { throw new Error("ENOENT: stat raced a delete"); };
+    expect(
+      transcriptAgeMs(
+        { bgJobId: SHORT },
+        {
+          now: 1_060_000,
+          projectsRoot: join(ROOT, "projects"),
+          resolveSession: resolver,
+          stat: throwingStat,
+        },
+      ),
+    ).toBeNull();
+  });
 });
 
 describe("resolveTranscriptPath", () => {

--- a/plugins/dev/scripts/execution-core/watchdog-action.mjs
+++ b/plugins/dev/scripts/execution-core/watchdog-action.mjs
@@ -1,0 +1,119 @@
+// watchdog-action.mjs — CTL-729 progress-watchdog kill + escalate action.
+// Called by Pass 0w (scheduler.mjs) after evaluateHungWorker returns
+// "kill-escalate" and mode === "enforce".
+//
+// Performs four side-effects idempotently:
+//   (1) Atomic terminal-signal rewrite: status:"failed" + failureReason + failedAt.
+//   (2) Fire-and-forget reap-intent: routes through reaper._handleBgReap → claude stop.
+//   (3) labelOnce(orchDir, ticket, "needs-human", writeStatus) — .applied marker guards.
+//   (4) OPTIONAL revive-budget (default 0 = off): one --resume re-dispatch before escalating.
+//
+// The double-fire guard is the re-read terminal status ("already-terminal"), NOT the
+// shared escalation cooldown — so a recovery escalation in the same window cannot
+// suppress a genuine watchdog kill.
+//
+// SETTLED is intentionally wider than signal-reader.mjs:TERMINAL (includes "aborted",
+// "skipped") — the watchdog's "I've already acted" check must absorb all
+// variants of "this phase is done".
+
+import { readFileSync, writeFileSync, renameSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { log } from "./config.mjs";
+import { emitReapIntent } from "./reap-intent.mjs";
+import { labelOnce, recordEscalation } from "./label-guard.mjs";
+
+const SETTLED = new Set(["done", "failed", "stalled", "aborted", "skipped", "complete"]);
+
+function priorReviveCount(orchDir, ticket, phase) {
+  try {
+    const re = new RegExp(`^\\.watchdog-revive-${phase}\\.(\\d+)$`);
+    return readdirSync(join(orchDir, "workers", ticket)).reduce((m, f) => {
+      const x = re.exec(f);
+      return x ? Math.max(m, Number(x[1])) : m;
+    }, 0);
+  } catch {
+    return 0;
+  }
+}
+
+// killHungWorker — perform the watchdog kill + escalate sequence.
+// Returns { outcome: "escalated"|"revived"|"already-terminal" }.
+// Async ONLY for the fire-and-forget reap emit; the terminal signal write is sync.
+export async function killHungWorker(
+  orchDir,
+  ticket,
+  signal,
+  {
+    elapsedMin,
+    commitCount = 0,
+    reviveBudget = 0,
+    now = Date.now,
+    writeStatus,
+    emit = emitReapIntent,
+    reviveDispatch,
+  } = {},
+) {
+  const phase = signal.phase;
+  if (SETTLED.has(signal.status)) return { outcome: "already-terminal" };
+  const bgJobId = signal.raw?.bg_job_id;
+  const failureReason = `hung_no_progress:${phase}:${Math.floor(elapsedMin)}m_${commitCount}_commits`;
+
+  // OPTIONAL revive-budget: stop the old session then re-dispatch once before escalating.
+  const used = priorReviveCount(orchDir, ticket, phase);
+  if (reviveBudget > 0 && used < reviveBudget && typeof reviveDispatch === "function") {
+    const attempt = used + 1;
+    if (bgJobId) {
+      void emit("phase.terminal.reap-requested", {
+        ticket, phase, bgJobId, reason: `${failureReason}:revive`,
+      }).catch((err) => log.warn({ ticket, phase, err }, "ctl-729: revive reap emit failed"));
+    }
+    try {
+      reviveDispatch({ orchDir, ticket, phase, attempt });
+    } catch (err) {
+      log.warn({ ticket, phase, err: err.message }, "ctl-729: revive dispatch threw");
+    }
+    try {
+      writeFileSync(
+        join(orchDir, "workers", ticket, `.watchdog-revive-${phase}.${attempt}`),
+        new Date(now()).toISOString(),
+      );
+    } catch {}
+    log.warn({ ticket, phase, attempt, reviveBudget }, "ctl-729: hung worker revived (budget)");
+    return { outcome: "revived" };
+  }
+
+  // (1) Atomic terminal write. Re-read guards a raced-to-terminal worker.
+  const sigPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
+  try {
+    const cur = JSON.parse(readFileSync(sigPath, "utf8"));
+    if (SETTLED.has(cur.status)) return { outcome: "already-terminal" };
+    const updated = {
+      ...cur,
+      status: "failed",
+      failureReason,
+      failedAt: new Date(now()).toISOString(),
+    };
+    const tmp = `${sigPath}.tmp.${process.pid}`;
+    writeFileSync(tmp, `${JSON.stringify(updated, null, 2)}\n`);
+    renameSync(tmp, sigPath);
+  } catch (err) {
+    log.error({ ticket, phase, err: err.message }, "ctl-729: terminal signal write failed");
+  }
+
+  // (2) Fire-and-forget reap-intent → reaper._handleBgReap → claude stop <shortId>.
+  if (bgJobId) {
+    void emit("phase.terminal.reap-requested", {
+      ticket, phase, bgJobId, worktreePath: signal.raw?.worktreePath, reason: failureReason,
+    }).catch((err) => log.warn({ ticket, phase, err }, "ctl-729: reap-intent emit failed"));
+  }
+
+  // (3) needs-human (idempotent via .applied marker) + escalation record.
+  labelOnce(orchDir, ticket, "needs-human", writeStatus);
+  recordEscalation(orchDir, ticket, phase, failureReason, now());
+
+  log.warn(
+    { ticket, phase, elapsedMin, commitCount },
+    "ctl-729: hung worker force-killed + escalated",
+  );
+  return { outcome: "escalated" };
+}

--- a/plugins/dev/scripts/execution-core/watchdog-action.mjs
+++ b/plugins/dev/scripts/execution-core/watchdog-action.mjs
@@ -68,7 +68,11 @@ export async function killHungWorker(
       }).catch((err) => log.warn({ ticket, phase, err }, "ctl-729: revive reap emit failed"));
     }
     try {
-      reviveDispatch({ orchDir, ticket, phase, attempt });
+      // CTL-729 remediate: pass bgJobId so the scheduler's reviveDispatch closure
+      // can resolve the dead session to a `claude --resume` UUID (re-dispatch with
+      // continuity). orchDir is included for dispatchers that need it; the
+      // production closure (scheduler Pass 0w) closes over orchDir and ignores it.
+      reviveDispatch({ orchDir, ticket, phase, attempt, bgJobId });
     } catch (err) {
       log.warn({ ticket, phase, err: err.message }, "ctl-729: revive dispatch threw");
     }
@@ -77,7 +81,16 @@ export async function killHungWorker(
         join(orchDir, "workers", ticket, `.watchdog-revive-${phase}.${attempt}`),
         new Date(now()).toISOString(),
       );
-    } catch {}
+    } catch (err) {
+      // CTL-729 remediate: this marker is the SOLE persistence backing
+      // priorReviveCount, which enforces the revive-budget cap. A silent write
+      // failure makes the next tick read a lower count and revive the same worker
+      // again (potentially unbounded), so make the failure observable.
+      log.warn(
+        { ticket, phase, attempt, err: err.message },
+        "ctl-729: revive-marker write failed — revive cap may not hold",
+      );
+    }
     log.warn({ ticket, phase, attempt, reviveBudget }, "ctl-729: hung worker revived (budget)");
     return { outcome: "revived" };
   }

--- a/plugins/dev/scripts/execution-core/watchdog-action.test.mjs
+++ b/plugins/dev/scripts/execution-core/watchdog-action.test.mjs
@@ -1,0 +1,164 @@
+// watchdog-action.test.mjs — CTL-729 Phase 4 tests.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { killHungWorker } from "./watchdog-action.mjs";
+
+const T = "CTL-729";
+const PHASE = "implement";
+
+function recorder(rv) {
+  const fn = (...a) => { fn.calls.push(a); return rv; };
+  fn.calls = [];
+  return fn;
+}
+
+let orchDir;
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "ctl729-action-"));
+  mkdirSync(join(orchDir, "workers", T), { recursive: true });
+});
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+function writeSignal(status, extra = {}) {
+  const flat = {
+    ticket: T, phase: PHASE, status,
+    startedAt: "2026-06-09T00:00:00Z",
+    bg_job_id: "abcd1234",
+    worktreePath: "/wt/CTL-729",
+    ...extra,
+  };
+  writeFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), JSON.stringify(flat, null, 2) + "\n");
+  return { ticket: T, phase: PHASE, status, raw: flat };
+}
+
+describe("killHungWorker — escalated path", () => {
+  test("rewrites signal to status:failed with hung reason; atomic (no .tmp left); preserves fields", async () => {
+    const sig = writeSignal("running");
+    const r = await killHungWorker(orchDir, T, sig, {
+      elapsedMin: 1080, commitCount: 0,
+      writeStatus: { applyLabel: recorder({ applied: true }) },
+      emit: recorder(Promise.resolve(true)),
+      now: () => 1_000_000,
+    });
+    const onDisk = JSON.parse(readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8"));
+    expect(onDisk.status).toBe("failed");
+    expect(onDisk.failureReason).toBe(`hung_no_progress:${PHASE}:1080m_0_commits`);
+    expect(onDisk.failedAt).toBeTruthy();
+    expect(onDisk.bg_job_id).toBe("abcd1234");
+    expect(onDisk.worktreePath).toBe("/wt/CTL-729");
+    expect(existsSync(`${join(orchDir, "workers", T, `phase-${PHASE}.json`)}.tmp.${process.pid}`)).toBe(false);
+    expect(r.outcome).toBe("escalated");
+  });
+
+  test("emits phase.terminal.reap-requested carrying bg_job_id", async () => {
+    const emit = recorder(Promise.resolve(true));
+    await killHungWorker(orchDir, T, writeSignal("running"), {
+      elapsedMin: 1080, commitCount: 0,
+      writeStatus: { applyLabel: recorder({ applied: true }) },
+      emit, now: () => 1,
+    });
+    const [evt, fields] = emit.calls[0];
+    expect(evt).toBe("phase.terminal.reap-requested");
+    expect(fields.bgJobId).toBe("abcd1234");
+    expect(fields.ticket).toBe(T);
+    expect(fields.reason).toMatch(/hung_no_progress/);
+  });
+
+  test("creates .linear-label-needs-human.applied marker", async () => {
+    await killHungWorker(orchDir, T, writeSignal("running"), {
+      elapsedMin: 1080, commitCount: 0,
+      writeStatus: { applyLabel: recorder({ applied: true }) },
+      emit: recorder(Promise.resolve(true)),
+      now: () => 1,
+    });
+    expect(existsSync(join(orchDir, "workers", T, ".linear-label-needs-human.applied"))).toBe(true);
+  });
+});
+
+describe("killHungWorker — already-terminal guard", () => {
+  test("raced-to-terminal: on-disk already failed → already-terminal, no emit/label", async () => {
+    const inMem = writeSignal("running");
+    // race: another writer flips the on-disk signal terminal
+    writeFileSync(
+      join(orchDir, "workers", T, `phase-${PHASE}.json`),
+      JSON.stringify({ ...inMem.raw, status: "failed" }),
+    );
+    const emit = recorder(Promise.resolve(true));
+    const ws = { applyLabel: recorder({ applied: true }) };
+    const r = await killHungWorker(orchDir, T, inMem, {
+      elapsedMin: 1080, commitCount: 0, writeStatus: ws, emit, now: () => 1,
+    });
+    expect(r.outcome).toBe("already-terminal");
+    expect(emit.calls.length).toBe(0);
+    expect(ws.applyLabel.calls.length).toBe(0);
+  });
+
+  test("in-memory signal is already terminal → already-terminal early-return", async () => {
+    const sig = writeSignal("failed");
+    const emit = recorder(Promise.resolve(true));
+    const r = await killHungWorker(orchDir, T, sig, {
+      elapsedMin: 1080, commitCount: 0,
+      writeStatus: { applyLabel: recorder({ applied: true }) },
+      emit, now: () => 1,
+    });
+    expect(r.outcome).toBe("already-terminal");
+    expect(emit.calls.length).toBe(0);
+  });
+});
+
+describe("killHungWorker — bg_job_id absent", () => {
+  test("terminal write + label still happen, no reap emitted", async () => {
+    const emit = recorder(Promise.resolve(true));
+    const ws = { applyLabel: recorder({ applied: true }) };
+    const r = await killHungWorker(orchDir, T, writeSignal("running", { bg_job_id: undefined }), {
+      elapsedMin: 1080, commitCount: 0, writeStatus: ws, emit, now: () => 1,
+    });
+    expect(JSON.parse(readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8")).status).toBe("failed");
+    expect(emit.calls.length).toBe(0);
+    expect(existsSync(join(orchDir, "workers", T, ".linear-label-needs-human.applied"))).toBe(true);
+    expect(r.outcome).toBe("escalated");
+  });
+});
+
+describe("killHungWorker — revive-budget", () => {
+  test("reviveBudget=1: first hit revives, second escalates", async () => {
+    const dispatch = recorder({ ok: true });
+    const emit = recorder(Promise.resolve(true));
+    const r1 = await killHungWorker(orchDir, T, writeSignal("running"), {
+      elapsedMin: 1080, commitCount: 0, reviveBudget: 1,
+      reviveDispatch: dispatch,
+      writeStatus: { applyLabel: recorder({ applied: true }) },
+      emit, now: () => 1,
+    });
+    expect(r1.outcome).toBe("revived");
+    expect(dispatch.calls.length).toBe(1);
+    expect(emit.calls.length).toBe(1); // old session reaped
+    expect(existsSync(join(orchDir, "workers", T, `.watchdog-revive-${PHASE}.1`))).toBe(true);
+
+    // second call (same ticket) → already used 1 revive → escalate
+    const r2 = await killHungWorker(orchDir, T, writeSignal("running"), {
+      elapsedMin: 1110, commitCount: 0, reviveBudget: 1,
+      reviveDispatch: dispatch,
+      writeStatus: { applyLabel: recorder({ applied: true }) },
+      emit: recorder(Promise.resolve(true)), now: () => 9_000_000,
+    });
+    expect(r2.outcome).toBe("escalated");
+    expect(dispatch.calls.length).toBe(1); // no second dispatch
+  });
+
+  test("reviveBudget=0 (default): always escalates, never dispatches", async () => {
+    const dispatch = recorder({ ok: true });
+    const r = await killHungWorker(orchDir, T, writeSignal("running"), {
+      elapsedMin: 1080, commitCount: 0, reviveDispatch: dispatch,
+      writeStatus: { applyLabel: recorder({ applied: true }) },
+      emit: recorder(Promise.resolve(true)), now: () => 1,
+    });
+    expect(r.outcome).toBe("escalated");
+    expect(dispatch.calls.length).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/watchdog-action.test.mjs
+++ b/plugins/dev/scripts/execution-core/watchdog-action.test.mjs
@@ -78,6 +78,24 @@ describe("killHungWorker — escalated path", () => {
     });
     expect(existsSync(join(orchDir, "workers", T, ".linear-label-needs-human.applied"))).toBe(true);
   });
+
+  test("CTL-729 coverage: writes the .escalation-cooldowns marker carrying the hung_no_progress reason", async () => {
+    // recordEscalation runs on every escalate path (label-guard.mjs); a regression
+    // dropping the call would otherwise pass all the other assertions here. Guard
+    // the marker + its failureReason so the cooldown that throttles re-escalation
+    // (CTL-638) is provably written.
+    await killHungWorker(orchDir, T, writeSignal("running"), {
+      elapsedMin: 1080, commitCount: 0,
+      writeStatus: { applyLabel: recorder({ applied: true }) },
+      emit: recorder(Promise.resolve(true)),
+      now: () => 1_700_000,
+    });
+    const marker = join(orchDir, ".escalation-cooldowns", `${T}-${PHASE}.json`);
+    expect(existsSync(marker)).toBe(true);
+    const envelope = JSON.parse(readFileSync(marker, "utf8"));
+    expect(envelope.reason).toBe(`hung_no_progress:${PHASE}:1080m_0_commits`);
+    expect(envelope.escalatedAt).toBe(1_700_000);
+  });
 });
 
 describe("killHungWorker — already-terminal guard", () => {

--- a/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
@@ -766,6 +766,21 @@ describe("defaultProgressMark (CTL-736 Phase 3)", () => {
     expect(defaultProgressMark({ ticket: "CTL-9", phase: "remediate", repoRoot: "/repo" }, { runGit })).toBe(3);
   });
 
+  test("CTL-729 regression: worktreePath without repoRoot → 0; the probe resolves via repoRoot", () => {
+    // The scheduler's Pass 0w originally passed { worktreePath } and dropped
+    // repoRoot, so resolveWorktree (work-done-probes.mjs:60) got repoRoot=undefined
+    // → null → the commit gate always read 0 and could NEVER spare a
+    // committed-but-silent code worker (the safeguard the gate exists for).
+    const runGit = makeRunGit({
+      "worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-9", WT), stderr: "" },
+      "rev-list --count origin/main..HEAD": { code: 0, stdout: "3\n", stderr: "" },
+    });
+    // Broken call shape (what the scheduler used to send): worktreePath, no repoRoot.
+    expect(defaultProgressMark({ ticket: "CTL-9", phase: "implement", worktreePath: WT }, { runGit })).toBe(0);
+    // Correct call shape (what the scheduler sends now): repoRoot resolves the worktree.
+    expect(defaultProgressMark({ ticket: "CTL-9", phase: "implement", repoRoot: "/repo" }, { runGit })).toBe(3);
+  });
+
   test("implement → 0 when the worktree does not resolve (no progress observable)", () => {
     const runGit = makeRunGit({
       "worktree list --porcelain": { code: 0, stdout: porcelainFor("OTHER", WT), stderr: "" },

--- a/plugins/dev/scripts/orch-monitor/board-data-active-state.test.ts
+++ b/plugins/dev/scripts/orch-monitor/board-data-active-state.test.ts
@@ -3,7 +3,7 @@
 // Uses a temp dir per test so marker files are fully isolated.
 
 import { describe, it, expect, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 

--- a/plugins/dev/scripts/orch-monitor/board-data-active-state.test.ts
+++ b/plugins/dev/scripts/orch-monitor/board-data-active-state.test.ts
@@ -1,0 +1,108 @@
+// CTL-729: unit tests for deriveActiveState() — the widened BoardActiveState
+// that now includes "needs-human" (escalated by the progress watchdog).
+// Uses a temp dir per test so marker files are fully isolated.
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// board-data.mjs is plain JS — import dynamically so TS doesn't choke on the path.
+const { deriveActiveState } = await import("./lib/board-data.mjs");
+
+const STUCK_MS = 1_800_000; // 30 min — matches the constant in board-data.mjs
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "ctl-729-active-state-"));
+}
+
+const cleanupDirs: string[] = [];
+afterEach(() => {
+  for (const d of cleanupDirs.splice(0)) {
+    rmSync(d, { recursive: true, force: true });
+  }
+});
+
+function withDir(cb: (dir: string) => void): string {
+  const dir = makeTmpDir();
+  cleanupDirs.push(dir);
+  cb(dir);
+  return dir;
+}
+
+describe("deriveActiveState (CTL-729)", () => {
+  it("returns 'active' when no markers and ageMs is fresh", async () => {
+    const dir = withDir(() => {});
+    const result = await deriveActiveState("CTL-999", "implement", 60_000, dir);
+    expect(result).toBe("active");
+  });
+
+  it("returns 'needs-human' when .linear-label-needs-human.applied exists", async () => {
+    const dir = withDir((d) => writeFileSync(join(d, ".linear-label-needs-human.applied"), ""));
+    const result = await deriveActiveState("CTL-999", "implement", 60_000, dir);
+    expect(result).toBe("needs-human");
+  });
+
+  it("needs-human beats stuck (marker + old transcript)", async () => {
+    const dir = withDir((d) => {
+      writeFileSync(join(d, ".linear-label-needs-human.applied"), "");
+      writeFileSync(join(d, ".terminal-done.applied"), "");
+    });
+    const result = await deriveActiveState("CTL-999", "implement", STUCK_MS + 1, dir);
+    expect(result).toBe("needs-human");
+  });
+
+  it("returns 'stuck' when .terminal-done.applied exists (no needs-human)", async () => {
+    const dir = withDir((d) => writeFileSync(join(d, ".terminal-done.applied"), ""));
+    const result = await deriveActiveState("CTL-999", "implement", 0, dir);
+    expect(result).toBe("stuck");
+  });
+
+  it("returns 'stuck' when .worktree-removed exists", async () => {
+    const dir = withDir((d) => writeFileSync(join(d, ".worktree-removed"), ""));
+    const result = await deriveActiveState("CTL-999", "implement", 0, dir);
+    expect(result).toBe("stuck");
+  });
+
+  it("returns 'stuck' when transcript is stale beyond STUCK_MS", async () => {
+    const dir = withDir(() => {});
+    const result = await deriveActiveState("CTL-999", "implement", STUCK_MS + 1, dir);
+    expect(result).toBe("stuck");
+  });
+
+  it("returns 'active' when transcript is exactly at STUCK_MS boundary", async () => {
+    const dir = withDir(() => {});
+    const result = await deriveActiveState("CTL-999", "implement", STUCK_MS, dir);
+    expect(result).toBe("active");
+  });
+
+  it("returns 'active' for wait-heavy phase (monitor-merge) even with stale transcript", async () => {
+    const dir = withDir(() => {});
+    const result = await deriveActiveState("CTL-999", "monitor-merge", STUCK_MS + 1, dir);
+    expect(result).toBe("active");
+  });
+
+  it("returns 'active' for wait-heavy phase (monitor-deploy) even with stale transcript", async () => {
+    const dir = withDir(() => {});
+    const result = await deriveActiveState("CTL-999", "monitor-deploy", STUCK_MS + 1, dir);
+    expect(result).toBe("active");
+  });
+
+  it("returns 'active' for wait-heavy phase (pr) even with stale transcript", async () => {
+    const dir = withDir(() => {});
+    const result = await deriveActiveState("CTL-999", "pr", STUCK_MS + 1, dir);
+    expect(result).toBe("active");
+  });
+
+  it("needs-human still wins for wait-heavy phase", async () => {
+    const dir = withDir((d) => writeFileSync(join(d, ".linear-label-needs-human.applied"), ""));
+    const result = await deriveActiveState("CTL-999", "monitor-merge", STUCK_MS + 1, dir);
+    expect(result).toBe("needs-human");
+  });
+
+  it("returns 'active' when ageMs is null (transcript path not found)", async () => {
+    const dir = withDir(() => {});
+    const result = await deriveActiveState("CTL-999", "implement", null, dir);
+    expect(result).toBe("active");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -3,7 +3,7 @@
 // Vite config import assembleBoard() without a TS7016 implicit-any error.
 // Keep in sync with the object assembled in board-data.mjs.
 
-export type BoardActiveState = "active" | "stuck" | null;
+export type BoardActiveState = "active" | "needs-human" | "stuck" | null;
 
 export interface BoardWorker {
   name: string;
@@ -114,4 +114,5 @@ export const HELD_LABEL_WAITING: string;
 export function heldFor(labels: unknown): "blocked" | "waiting" | null;
 export function buildPhaseSummary(phaseSigs: unknown[], now: number): BoardPhaseTiming[];
 export function deriveCurrentPhase(phaseSigs: unknown[]): BoardCurrentPhase;
+export function deriveActiveState(ticket: string, phase: string, ageMs: number | null, dir?: string): Promise<BoardActiveState>;
 export function assembleBoard(): Promise<BoardPayload>;

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -187,10 +187,13 @@ async function transcriptAgeMs(sessionId, now) {
 }
 
 // Top-level state: a live worker is "active" (in its loop — generating OR actively
-// waiting on sub-agents / CI / a merge). Only call out the exceptions: a
-// finished-but-lingering process (terminal markers) or one dead for ~30m → "stuck".
-async function deriveActiveState(ticket, phase, ageMs) {
-  const dir = join(WORKERS_DIR, ticket);
+// waiting on sub-agents / CI / a merge). Exceptions:
+//   "needs-human" — watchdog (CTL-729) or recovery escalated; marker takes priority.
+//   "stuck"       — terminal markers present, or transcript silent for >30min.
+// Exported so it is unit-testable (CTL-729).
+export async function deriveActiveState(ticket, phase, ageMs, dir = join(WORKERS_DIR, ticket)) {
+  // needs-human wins over everything — escalated tickets need operator attention.
+  if (await exists(join(dir, ".linear-label-needs-human.applied"))) return "needs-human";
   if ((await exists(join(dir, ".terminal-done.applied"))) || (await exists(join(dir, ".worktree-removed")))) return "stuck";
   // monitor-merge / monitor-deploy / pr legitimately sit in long event-waits
   // (CI, merge, deploy) — staleness alone isn't stuck for them.

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
@@ -44,7 +44,9 @@ const PHASE_COLS = [
   { key: "monitor-deploy", label: "Deploy", c: "#39d07a" },
 ];
 const WORKER_COLS = [
-  { key: "active", label: "Active", c: LIVE }, { key: "stuck", label: "Stuck", c: C.red },
+  { key: "active", label: "Active", c: LIVE },
+  { key: "needs-human", label: "Needs Human", c: C.yellow },
+  { key: "stuck", label: "Stuck", c: C.red },
 ];
 // Phase statuses that mean a phase is no longer running. MUST stay in lock-step
 // with the TERMINAL set in lib/board-data.mjs (the data-layer source of truth) —
@@ -71,6 +73,7 @@ function accentFor(t: { phase: string; repo: string; type: string; activeState: 
   if (by === "repo") return repoColor(t.repo);
   if (by === "type") return TYPE_C[t.type] || C.fgMuted;
   if (t.activeState === "active") return LIVE;
+  if (t.activeState === "needs-human") return C.yellow;
   if (t.activeState === "stuck" || t.status === "failed") return C.red;
   return "#5b6b80";
 }
@@ -120,6 +123,7 @@ function Dot({ color, pulse }: { color: string; pulse?: boolean }) {
 }
 function ActivityDot({ state, fallback }: { state: ActiveState; fallback: string }) {
   if (state === "active") return <span className="catalyst-live-dot" style={{ width: 8, height: 8, borderRadius: "50%", background: LIVE, display: "inline-block", flex: "0 0 auto" }} />;
+  if (state === "needs-human") return <Dot color={C.yellow} />;
   if (state === "stuck") return <Dot color={C.red} />;
   return <Dot color={fallback} />;
 }
@@ -238,6 +242,7 @@ function TitleText({ text }: { text: string }) {
 function TicketCard({ t, colorBy, onSelect }: { t: Ticket; colorBy: ColorBy; onSelect?: (id: string) => void }) {
   const accent = accentFor(t, colorBy);
   const live = t.activeState === "active";
+  const needsHuman = t.activeState === "needs-human";
   const stuck = t.activeState === "stuck";
   const dim = t.activeState == null;
   return (
@@ -245,7 +250,7 @@ function TicketCard({ t, colorBy, onSelect }: { t: Ticket; colorBy: ColorBy; onS
       className={live ? "catalyst-live" : undefined}
       style={{
         background: live ? C.s3 : C.s2, borderRadius: 10, padding: "11px 13px",
-        border: `1px solid ${stuck ? "rgba(239,93,93,0.5)" : C.border}`,
+        border: `1px solid ${stuck ? "rgba(239,93,93,0.5)" : needsHuman ? `${C.yellow}66` : C.border}`,
         opacity: dim ? 0.5 : 1, filter: dim ? "saturate(0.6)" : undefined, transition: "opacity .25s, background .25s",
         cursor: onSelect ? "pointer" : undefined,
       }}
@@ -257,6 +262,7 @@ function TicketCard({ t, colorBy, onSelect }: { t: Ticket; colorBy: ColorBy; onS
         <span style={{ fontFamily: C.mono, fontSize: 11.5, fontWeight: 600, color: C.blue }}>{t.id}</span>
         <span style={{ flex: 1 }} />
         {live && <span style={{ fontFamily: C.mono, fontSize: 10, color: LIVE }}>{t.working ? "working" : "active"}</span>}
+        {needsHuman && <span style={{ fontFamily: C.mono, fontSize: 10, color: C.yellow }}>needs human</span>}
         {stuck && <span style={{ fontFamily: C.mono, fontSize: 10, color: C.red }}>stuck</span>}
         <Badge variant="secondary" style={{ fontFamily: C.mono, fontSize: 10 }}>{t.type}</Badge>
       </div>
@@ -285,13 +291,15 @@ function TicketCard({ t, colorBy, onSelect }: { t: Ticket; colorBy: ColorBy; onS
 function WorkerCard({ w, info }: { w: Worker; info?: Ticket }) {
   const accent = PHASE_C[w.phase] || C.blue;
   const live = w.activeState === "active";
+  const needsHuman = w.activeState === "needs-human";
   const stuck = w.activeState === "stuck";
   const attempt = Number(/:(\d+)$/.exec(w.name)?.[1] ?? 1);
   const seen = w.lastActiveMs != null ? fmtMsAgo(w.lastActiveMs) : null;
   return (
     <div className={live ? "catalyst-live" : undefined} style={{
       background: live ? C.s3 : C.s2, borderRadius: 10, padding: "11px 13px",
-      border: `1px solid ${stuck ? "rgba(239,93,93,0.5)" : C.border}`, opacity: stuck ? 0.7 : 1,
+      border: `1px solid ${stuck ? "rgba(239,93,93,0.5)" : needsHuman ? `${C.yellow}66` : C.border}`,
+      opacity: stuck ? 0.7 : 1,
     }}>
       <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
         <ActivityDot state={w.activeState} fallback={accent} />
@@ -314,8 +322,8 @@ function WorkerCard({ w, info }: { w: Worker; info?: Ticket }) {
         {info?.model && <Badge variant="secondary" style={{ fontFamily: C.mono, fontSize: 10 }}>{info.model}</Badge>}
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: 7, marginTop: 9 }}>
-        <span style={{ fontFamily: C.mono, fontSize: 10, color: live ? LIVE : stuck ? C.red : C.fgDim }}>
-          {live ? (w.working ? "working now" : seen ? `active · ${seen}` : "active") : stuck ? `stuck · ${seen ?? "?"}` : w.status}
+        <span style={{ fontFamily: C.mono, fontSize: 10, color: live ? LIVE : needsHuman ? C.yellow : stuck ? C.red : C.fgDim }}>
+          {live ? (w.working ? "working now" : seen ? `active · ${seen}` : "active") : needsHuman ? `needs human · ${seen ?? "?"}` : stuck ? `stuck · ${seen ?? "?"}` : w.status}
         </span>
         <span style={{ flex: 1 }} />
         <Cost v={w.costUSD} />

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
@@ -4,7 +4,7 @@
 // UI subset: BoardQueueItem.state is omitted because the board never renders it).
 import type { ConnectionStatus } from "@/lib/types";
 
-export type BoardActiveState = "active" | "stuck" | null;
+export type BoardActiveState = "active" | "needs-human" | "stuck" | null;
 
 export interface BoardWorker {
   name: string;


### PR DESCRIPTION
## Summary

Implements the progress watchdog (CTL-729) that detects running+silent+zero-commits phase workers past their budget and force-kills them with a `needs-human` escalation.

- **Phase 1** — `readWatchdogConfig()` + `phaseBudgetMs()` in config.mjs (shadow mode default)
- **Phase 2** — `session-resolve.mjs` leaf module; `transcript-silence.mjs` sync silence probe with subagent mtime folding
- **Phase 3+4** — `hung-detector.mjs` pure 4-gate predicate; `watchdog-action.mjs` kill/escalate side-effects
- **Phase 5** — scheduler Pass 0w wired into `schedulerTick` with injected seams
- **Phase 6** — orch-monitor `needs-human` BoardActiveState (amber), exported `deriveActiveState`

## Test plan

- [ ] All 5 new `*.test.mjs` files pass (56 tests total across execution-core)
- [ ] `board-data-active-state.test.ts` passes (12 tests)
- [ ] Shadow mode soak before flipping to `enforce`

🤖 Generated with [Claude Code](https://claude.com/claude-code)