### PR TITLE
feat(dev): SHELL5 top strip — single search palette + '/' open (CTL-895)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
@@ -21,6 +21,7 @@ import {
   writeSidebarOpen,
   shouldToggleSidebar,
 } from "@/lib/sidebar-collapse";
+import { shouldOpenPalette } from "@/lib/command-palette";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -133,13 +134,31 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
-  // ⌘K / Ctrl+K opens the command palette; clicks on the sidebar's search field
-  // (data-cmdk-trigger) open it too.
+  // ⌘K / Ctrl+K and a bare `/` (outside a field) open the command palette — the
+  // SINGLE search affordance for the shell (SHELL5 de-dups the prototype's two
+  // search bars). Clicks on the top-strip search field (data-cmdk-trigger) open
+  // it too. The open contract — including the "'/' never hijacks typing" guard —
+  // lives in lib/command-palette.ts (`shouldOpenPalette`) so it is unit-tested
+  // without a DOM, the same way `[` uses shouldToggleSidebar. ⌘K toggles; `/`
+  // opens (a quick-open shouldn't re-close on a second slash).
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+      if (
+        shouldOpenPalette({
+          key: e.key,
+          metaKey: e.metaKey,
+          ctrlKey: e.ctrlKey,
+          altKey: e.altKey,
+          target: e.target as HTMLElement | null,
+        })
+      ) {
         e.preventDefault();
-        setPaletteOpen((o) => !o);
+        // ⌘K toggles (open ⇄ close); `/` only opens.
+        if (e.key === "k" || e.key === "K") {
+          setPaletteOpen((o) => !o);
+        } else {
+          setPaletteOpen(true);
+        }
       }
     };
     const onClick = (e: MouseEvent) => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
@@ -7,7 +7,6 @@ import {
   LayoutGridIcon,
   ListOrderedIcon,
   MoonIcon,
-  SearchIcon,
   ServerIcon,
   SettingsIcon,
   SunIcon,
@@ -124,7 +123,12 @@ export function AppSidebar() {
     // an explicit later nicety, not the v1 emphasis; the `group-data-[collapsible=
     // icon]:…` classes below stay as inert documentation of that optional mode.
     <Sidebar variant="inset" collapsible="offcanvas">
-      {/* ── HEADER: chevron mark + wordmark + ⌘K trigger ────────────────────── */}
+      {/* ── HEADER: chevron mark + wordmark ─────────────────────────────────── */}
+      {/* CTL-895 / SHELL5 — the redundant sidebar-header search field was REMOVED
+          here (handoff cosmetic #1: the prototype shipped TWO ⌘K triggers, one in
+          this header and one in the top strip). Search now lives in EXACTLY one
+          place — the top-strip ⌘K trigger (app-shell.tsx) — plus the ⌘K / `/`
+          keyboard openers. Keep the header to the brand only. */}
       <SidebarHeader className="gap-2">
         <div className="flex items-center gap-2 px-1 pt-1">
           {/* The chevron mark stays at every collapse width; only the wordmark
@@ -136,27 +140,6 @@ export function AppSidebar() {
             Catalyst
           </span>
         </div>
-
-        {/* ⌘K search trigger, styled as a muted field. Opens the command palette
-            (the cmd+k handler lives in AppShell). */}
-        <button
-          type="button"
-          data-cmdk-trigger
-          className={cn(
-            "flex h-8 w-full items-center gap-2 rounded-md border border-border bg-secondary/40 px-2 text-sm text-muted-foreground",
-            "transition-colors hover:bg-secondary hover:text-foreground",
-            "group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0",
-          )}
-          aria-label="Search or jump to…"
-        >
-          <SearchIcon className="size-4 shrink-0" />
-          <span className="flex-1 text-left group-data-[collapsible=icon]:hidden">
-            Search…
-          </span>
-          <kbd className="rounded border border-border bg-background/60 px-1 py-0.5 text-[10px] text-muted-foreground group-data-[collapsible=icon]:hidden">
-            ⌘K
-          </kbd>
-        </button>
       </SidebarHeader>
 
       <SidebarContent>

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/command-palette.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/command-palette.test.ts
@@ -1,0 +1,90 @@
+// command-palette.test.ts — units for the SHELL5 command-palette keyboard core
+// (CTL-895). These encode the ticket's Gherkin acceptance scenarios at the pure
+// logic layer (no DOM), the same way sidebar-collapse.test.ts proves the `[`
+// binding + "typing is never stolen" guard.
+//
+// `shouldOpenPalette` is pure and needs no DOM shim.
+//
+// Run from the ui package:  `cd ui && bun test src/lib/command-palette.test.ts`.
+import { describe, it, expect } from "bun:test";
+import { shouldOpenPalette, type PaletteKeyEvent } from "./command-palette";
+
+const press = (over: Partial<PaletteKeyEvent>): PaletteKeyEvent => ({
+  key: "/",
+  target: null,
+  ...over,
+});
+
+// ── Scenario: Cmd-K and '/' open the palette ───────────────────────────────────
+describe("shouldOpenPalette — ⌘K / Ctrl+K open the palette", () => {
+  it("Scenario: ⌘K opens the palette — meta+k fires", () => {
+    expect(shouldOpenPalette(press({ key: "k", metaKey: true }))).toBe(true);
+  });
+
+  it("Scenario: Ctrl+K opens the palette — ctrl+k fires", () => {
+    expect(shouldOpenPalette(press({ key: "k", ctrlKey: true }))).toBe(true);
+  });
+
+  it("⌘K fires even while typing in a field (the modifier is unambiguous)", () => {
+    // Unlike `/`, the ⌘/Ctrl chord can never be confused with typed text, so a
+    // command palette opens it from anywhere — including an input.
+    expect(
+      shouldOpenPalette(
+        press({ key: "k", metaKey: true, target: { tagName: "INPUT" } }),
+      ),
+    ).toBe(true);
+  });
+
+  it("⌘K is case-insensitive (some layouts deliver an uppercase K)", () => {
+    expect(shouldOpenPalette(press({ key: "K", metaKey: true }))).toBe(true);
+  });
+
+  it("a bare `k` (no meta/ctrl) does NOT open the palette", () => {
+    expect(shouldOpenPalette(press({ key: "k" }))).toBe(false);
+  });
+});
+
+describe("shouldOpenPalette — `/` quick-opens the palette outside a field", () => {
+  it("Scenario: `/` opens the palette — a bare `/` outside a field opens", () => {
+    // Given my cursor is NOT in an input, When I press `/` Then the palette opens.
+    expect(shouldOpenPalette(press({}))).toBe(true);
+  });
+
+  it("does not fire for an unrelated key", () => {
+    expect(shouldOpenPalette(press({ key: "j" }))).toBe(false);
+    expect(shouldOpenPalette(press({ key: "]" }))).toBe(false);
+  });
+});
+
+// ── Scenario: '/' never hijacks typing ─────────────────────────────────────────
+describe("shouldOpenPalette — `/` never hijacks typing", () => {
+  it("Scenario: `/` inside an <input> is left alone (a slash is typed)", () => {
+    expect(shouldOpenPalette(press({ target: { tagName: "INPUT" } }))).toBe(
+      false,
+    );
+  });
+
+  it("Scenario: `/` inside a <textarea> is left alone", () => {
+    expect(shouldOpenPalette(press({ target: { tagName: "TEXTAREA" } }))).toBe(
+      false,
+    );
+  });
+
+  it("Scenario: `/` in a contenteditable is left alone", () => {
+    expect(
+      shouldOpenPalette(
+        press({ target: { tagName: "DIV", isContentEditable: true } }),
+      ),
+    ).toBe(false);
+  });
+
+  it("`/` with a meta/ctrl/alt modifier is NOT the quick-open (left for other shortcuts)", () => {
+    expect(shouldOpenPalette(press({ metaKey: true }))).toBe(false);
+    expect(shouldOpenPalette(press({ ctrlKey: true }))).toBe(false);
+    expect(shouldOpenPalette(press({ altKey: true }))).toBe(false);
+  });
+
+  it("`/` with only shift held still quick-opens (shift does not gate it)", () => {
+    expect(shouldOpenPalette(press({ shiftKey: true }))).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/command-palette.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/command-palette.ts
@@ -1,0 +1,54 @@
+// command-palette.ts — the PURE keyboard core for the ⌘K command palette
+// (CTL-895 / SHELL5).
+//
+// Extracted out of `app-shell.tsx` so the SHELL5 acceptance scenarios — "⌘K /
+// '/' open the palette" and "'/' never hijacks typing" — are unit-testable
+// WITHOUT a DOM, following the same framework-agnostic pattern as surface.ts /
+// sidebar-collapse.ts (the `[`-toggle predicate `shouldToggleSidebar`).
+//
+// The palette is the SINGLE search affordance for the shell (SHELL5 de-dups the
+// two redundant search bars the prototype shipped). Two keys open it:
+//   - ⌘K / Ctrl+K  — the universal command-palette chord (fires even while
+//                     typing, like every command palette; the meta/ctrl modifier
+//                     means it can never be mistaken for typed text).
+//   - `/`          — the bare slash quick-open, but ONLY when focus is not in a
+//                     text-entry target, so a `/` typed into an input/textarea/
+//                     contenteditable is left alone ("'/' never hijacks typing").
+import { isTypingTarget } from "@/lib/surface";
+
+/** The minimal shape of a keydown event the palette-open predicate inspects. */
+export interface PaletteKeyEvent {
+  key: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  shiftKey?: boolean;
+  target?: { tagName?: string; isContentEditable?: boolean } | null;
+}
+
+/**
+ * True when a keydown should OPEN (toggle) the ⌘K command palette.
+ *
+ * Encodes the SHELL5 contract:
+ *  - `⌘K` / `Ctrl+K` always opens — the meta/ctrl modifier makes it unambiguous,
+ *    so (like every command palette) it fires even when a field has focus.
+ *  - a bare `/` opens too, but ONLY when focus is NOT a text-entry target and no
+ *    meta/ctrl/alt modifier is held — so "'/' never hijacks typing": a `/` typed
+ *    into an input/textarea/contenteditable is left alone, and `Ctrl+/` (a
+ *    different shortcut family) is not swallowed.
+ */
+export function shouldOpenPalette(e: PaletteKeyEvent): boolean {
+  // ⌘K / Ctrl+K — the universal palette chord. Always opens.
+  if ((e.key === "k" || e.key === "K") && (e.metaKey || e.ctrlKey)) {
+    return true;
+  }
+
+  // `/` quick-open — bare key only, and never while typing.
+  if (e.key === "/") {
+    if (e.metaKey || e.ctrlKey || e.altKey) return false;
+    if (isTypingTarget(e.target ?? null)) return false;
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## CTL-895 / SHELL5 — Top strip: breadcrumb + single palette

Operators get a single thin top strip with breadcrumb context and **one** Cmd-K / `/` search palette instead of the prototype's two redundant search bars (handoff cosmetic #1).

The top strip + breadcrumb + ⌘K command palette were already ported into the real app by **SHELL1 (CTL-891)**. This PR lands the two remaining SHELL5 deltas on top of that frame:

1. **De-dup the two search bars.** The prototype shipped TWO `data-cmdk-trigger` buttons — one in the sidebar header (`app-sidebar.tsx`) and one in the top strip (`app-shell.tsx`). Removed the sidebar-header one; search now lives in **exactly one** place — the top-strip trigger — plus the keyboard openers.
2. **Add a `/` quick-open** alongside ⌘K, with the same `isTypingTarget` guard the `[`/chord bindings use.

The open contract is extracted into a **pure, DOM-free predicate** `shouldOpenPalette` (`lib/command-palette.ts`), mirroring SHELL4's `shouldToggleSidebar`, so the keyboard scenarios are unit-tested without a DOM.

### Gherkin scenarios → status

| Scenario | Status | Where |
| --- | --- | --- |
| One top strip with breadcrumb | **satisfied** (already shipped by SHELL1; unchanged here) | `app-shell.tsx` header (`SidebarTrigger` + `Separator` + `Breadcrumb`) |
| Exactly one search affordance (prior sidebar-header field + duplicate top-strip field gone) | **satisfied** | removed the sidebar-header `data-cmdk-trigger` in `app-sidebar.tsx`; one trigger remains in `app-shell.tsx` |
| Cmd-K and `/` open the palette; selecting a surface navigates + closes | **satisfied** | `shouldOpenPalette` + the AppShell keydown effect; `jumpTo` (unchanged) closes on select |
| `/` never hijacks typing (input/textarea/contenteditable → slash is typed) | **satisfied** | `shouldOpenPalette` guards on `isTypingTarget`; unit-tested |

**Single-node descope:** none applicable — this is a pure client-side shell/keyboard ticket with no cluster/fence/multi-host behavior.

### Implementation notes
- ⌘K **toggles** (open ⇄ close); `/` only **opens** (a quick-open shouldn't re-close on a second slash). ⌘K fires even while typing (the meta/ctrl chord is unambiguous); `/` is bare-key only and never while typing.
- `shouldOpenPalette` is case-insensitive on `k`/`K` and rejects `Ctrl+/` (a different shortcut family) for the slash quick-open.
- Breadcrumb labels still come from FND's `SURFACE_BREADCRUMB` (`@/lib/surface`) — consumed, not re-filed. Base-ui breadcrumb gotcha (separator as sibling of item) preserved from SHELL1.

### Tests
- `bun test src/lib/command-palette.test.ts` → **12 pass** (new file; encodes the two keyboard Gherkin scenarios).
- Targeted lib suite (`command-palette` + `sidebar-collapse` + `surface-content`) → **31 pass**.
- `bun run build` (vite type+bundle gate) → green.
- `bunx tsc --noEmit` → **no new application-code errors** (the only error touching my files is the pre-existing `bun:test` module-resolution pattern shared by every `*.test.ts`; the 7 real baseline errors are in untouched `../lib/canonical-event*` and `kpi-strip.tsx`).
- No reward-hacking: no `as any` / `as unknown as` / `@ts-ignore` / non-null `!` / `forEach(async`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)