### PR TITLE
feat(dev): BFF12 fence-aware Answer/Unblock read-model mutation endpoint (CTL-924)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/respond-ticket-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/respond-ticket-endpoint.test.ts
@@ -1,0 +1,87 @@
+// respond-ticket-endpoint.test.ts — HTTP route-plumbing tests for the read-model's
+// SECOND write endpoint, POST /api/ticket/<ticket>/respond (CTL-924, BFF12 —
+// HOME5's Answer / Unblock verb). Validates the server.ts wiring — method gate,
+// ticket param validation (400), invalid-body (400), and the 404 for a ticket
+// with no parked (needs-input) run on disk. The mutation LOGIC itself (held-run
+// scan, typed-confirm gate, fence branches, record + clear-marker + emit-resume
+// ordering, the optimistic `resuming` contract) is covered exhaustively by the
+// injectable unit tests in respond-ticket.test.ts; these tests prove the route is
+// mounted, matched, method-gated, and guarded.
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+let tmpDir: string;
+
+// A ticket id that definitively has no worker dir on this machine, so the route's
+// behavior is deterministic regardless of host state (no parked run → not_held).
+const ABSENT_TICKET = "ZZZ-999999";
+
+async function postRespond(ticket: string, body: unknown) {
+  return fetch(`${baseUrl}/api/ticket/${ticket}/respond`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "respond-ticket-endpoint-"));
+  const wtDir = join(tmpDir, "wt");
+  mkdirSync(wtDir, { recursive: true });
+  server = createServer({ port: 0, wtDir, startWatcher: false });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  void server?.stop(true);
+  if (tmpDir) {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+describe("POST /api/ticket/:ticket/respond (CTL-924, BFF12)", () => {
+  it("rejects a malformed ticket id with 400 (no path traversal / arbitrary read)", async () => {
+    expect((await postRespond("not-a-ticket", { confirm: "x" })).status).toBe(400);
+    expect((await postRespond("CTL", { confirm: "x" })).status).toBe(400);
+    expect((await postRespond("..%2F..%2Fetc", { confirm: "x" })).status).toBe(400);
+  });
+
+  it("rejects an invalid JSON body with 400", async () => {
+    const res = await postRespond(ABSENT_TICKET, "{ not json");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the ticket has no parked (needs-input) run on disk", async () => {
+    // confirm matches the ticket so we pass the typed-confirm gate; the held-run
+    // scan finds no worker dir → not_held (nothing to answer / unblock).
+    const res = await postRespond(ABSENT_TICKET, {
+      response: "go ahead",
+      confirm: ABSENT_TICKET,
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("not_held");
+  });
+
+  it("a GET to /respond is NOT the mutation (method-gated)", async () => {
+    // The POST-respond route is gated on `req.method === "POST"`; a GET falls
+    // through to the static / SPA handler, never the mutation handler. The key
+    // assertion is that no mutation `status` JSON is returned for a GET.
+    const res = await fetch(`${baseUrl}/api/ticket/${ABSENT_TICKET}/respond`);
+    const ct = res.headers.get("content-type") ?? "";
+    if (ct.includes("application/json")) {
+      const body = (await res.json()) as { status?: string };
+      expect(body.status).not.toBe("not_held");
+      expect(body.status).not.toBe("resuming");
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/respond-ticket.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/respond-ticket.test.ts
@@ -1,0 +1,412 @@
+// respond-ticket.test.ts — unit coverage for the read-model's SECOND write
+// endpoint helper (CTL-924, BFF12 — HOME5's Answer / Unblock verb). Every
+// collaborator is injected so nothing reads a real worker dir, runs the real
+// fence CLI, touches the real Linear API, or appends to the real event log. These
+// tests encode the three Gherkin scenarios directly:
+//   1. Answer/unblock records the response, clears the needs-human marker, and
+//      emits the resume event that drives CTL-876's loop.
+//   2. The mutation is fence-aware: a verified-stale generation is rejected and
+//      NOTHING is mutated.
+//   3. Single-host pass-through: the fence-check is an identity no-op and the
+//      response is recorded normally.
+import { describe, it, expect } from "bun:test";
+import {
+  respondTicket,
+  findHeldRun,
+  clearNeedsHumanMarker,
+  recordResponse,
+  buildResumeEvent,
+  emitResumeEvent,
+  eventLogPath,
+} from "../lib/respond-ticket.mjs";
+
+// A minimal held phase signal (status:"needs-input" is the parked predicate the
+// daemon's handleCommentWake matches).
+function heldSignal(over: Record<string, unknown> = {}) {
+  return {
+    ticket: "CTL-845",
+    phase: "implement",
+    status: "needs-input",
+    generation: 3,
+    ...over,
+  };
+}
+
+// Default injections: a held implement run, single-host fence no-op, recording
+// collaborators captured so assertions can confirm the side effects fired.
+function deps(over: Partial<Parameters<typeof respondTicket>[1]> = {}) {
+  return {
+    findHeld: () => ({ phase: "implement", signal: heldSignal() }),
+    fenceCheck: () => ({ ok: true, noop: true, stale: false }),
+    record: () => undefined,
+    clearMarker: () => undefined,
+    emit: () => undefined,
+    ...over,
+  };
+}
+
+describe("respondTicket — Scenario 1: answer/unblock records the response and resumes", () => {
+  it("typed confirm matches → records, clears the marker, emits the resume event, reports `resuming`", () => {
+    const recorded: unknown[] = [];
+    const cleared: unknown[] = [];
+    const emitted: unknown[] = [];
+    const res = respondTicket(
+      { ticket: "CTL-845", response: "go ahead — the dep is merged", confirm: "CTL-845" },
+      deps({
+        record: (a) => recorded.push(a),
+        clearMarker: (a) => cleared.push(a),
+        emit: (a) => emitted.push(a),
+      }),
+    );
+    expect(res).toEqual({
+      status: "resuming",
+      ticket: "CTL-845",
+      phase: "implement",
+      fenceNoop: true,
+    });
+    // The response is recorded with the parked phase + the operator's note.
+    expect(recorded).toEqual([
+      { ticket: "CTL-845", phase: "implement", response: "go ahead — the dep is merged" },
+    ]);
+    // The needs-human marker is cleared (re-arms the daemon's labelOnce guard).
+    expect(cleared).toEqual([{ ticket: "CTL-845" }]);
+    // The resume event (CTL-876 loop) is emitted carrying the operator's response.
+    expect(emitted).toEqual([
+      { ticket: "CTL-845", response: "go ahead — the dep is merged" },
+    ]);
+  });
+
+  it("the three mutations fire IN ORDER: record → clear marker → emit resume", () => {
+    const order: string[] = [];
+    respondTicket(
+      { ticket: "CTL-845", response: "ok", confirm: "CTL-845" },
+      deps({
+        record: () => order.push("record"),
+        clearMarker: () => order.push("clear"),
+        emit: () => order.push("emit"),
+      }),
+    );
+    expect(order).toEqual(["record", "clear", "emit"]);
+  });
+});
+
+describe("respondTicket — no held run", () => {
+  it("no parked needs-input run for the ticket → not_held, NOTHING mutated", () => {
+    let mutated = false;
+    const res = respondTicket(
+      { ticket: "CTL-845", response: "ok", confirm: "CTL-845" },
+      deps({
+        findHeld: () => null,
+        record: () => {
+          mutated = true;
+        },
+        clearMarker: () => {
+          mutated = true;
+        },
+        emit: () => {
+          mutated = true;
+        },
+      }),
+    );
+    expect(res).toEqual({ status: "not_held" });
+    expect(mutated).toBe(false);
+  });
+});
+
+describe("respondTicket — typed-confirm gate", () => {
+  it("a mismatched confirm is rejected WITHOUT any mutation", () => {
+    let mutated = false;
+    const mark = () => {
+      mutated = true;
+    };
+    const res = respondTicket(
+      { ticket: "CTL-845", response: "ok", confirm: "CTL-844" },
+      deps({ record: mark, clearMarker: mark, emit: mark }),
+    );
+    expect(res).toEqual({ status: "confirm_mismatch", expected: "CTL-845" });
+    expect(mutated).toBe(false);
+  });
+
+  it("a missing confirm is rejected", () => {
+    const res = respondTicket(
+      { ticket: "CTL-845", response: "ok", confirm: undefined },
+      deps(),
+    );
+    expect(res.status).toBe("confirm_mismatch");
+  });
+});
+
+describe("respondTicket — Scenario 2: the mutation is fence-aware", () => {
+  it("a verified-stale fence (exit 10) rejects the response and mutates NOTHING", () => {
+    let mutated = false;
+    const mark = () => {
+      mutated = true;
+    };
+    const res = respondTicket(
+      { ticket: "CTL-845", response: "ok", confirm: "CTL-845" },
+      deps({
+        // multi-host fence reports VERIFIED stale (CLI exit 10)
+        fenceCheck: () => ({ ok: false, noop: false, stale: true }),
+        record: mark,
+        clearMarker: mark,
+        emit: mark,
+      }),
+    );
+    expect(res).toEqual({ status: "fenced", ticket: "CTL-845", phase: "implement" });
+    expect(mutated).toBe(false);
+  });
+
+  it("an indeterminate fence (CLI errored) refuses to mutate — fail-closed", () => {
+    let mutated = false;
+    const mark = () => {
+      mutated = true;
+    };
+    const res = respondTicket(
+      { ticket: "CTL-845", response: "ok", confirm: "CTL-845" },
+      deps({
+        fenceCheck: () => ({ ok: false, noop: false, stale: false }),
+        record: mark,
+        clearMarker: mark,
+        emit: mark,
+      }),
+    );
+    expect(res).toEqual({
+      status: "fence_indeterminate",
+      ticket: "CTL-845",
+      phase: "implement",
+    });
+    expect(mutated).toBe(false);
+  });
+
+  it("fence-checks the held run signal's OWN generation", () => {
+    const seen: (number | null)[] = [];
+    respondTicket(
+      { ticket: "CTL-845", response: "ok", confirm: "CTL-845" },
+      deps({
+        findHeld: () => ({ phase: "implement", signal: heldSignal({ generation: 7 }) }),
+        fenceCheck: ({ generation }) => {
+          seen.push(generation);
+          return { ok: true, noop: false, stale: false };
+        },
+      }),
+    );
+    expect(seen).toEqual([7]);
+  });
+
+  it("a non-numeric generation is passed to the fence-check as null (multi-host fails closed there)", () => {
+    const seen: (number | null)[] = [];
+    respondTicket(
+      { ticket: "CTL-845", response: "ok", confirm: "CTL-845" },
+      deps({
+        findHeld: () => ({ phase: "implement", signal: heldSignal({ generation: undefined }) }),
+        fenceCheck: ({ generation }) => {
+          seen.push(generation);
+          return { ok: true, noop: true, stale: false };
+        },
+      }),
+    );
+    expect(seen).toEqual([null]);
+  });
+});
+
+describe("respondTicket — Scenario 3: single-host pass-through (fence no-op)", () => {
+  it("single-host fence pass records normally with fenceNoop:true", () => {
+    const res = respondTicket(
+      { ticket: "CTL-845", response: "ok", confirm: "CTL-845" },
+      deps({ fenceCheck: () => ({ ok: true, noop: true, stale: false }) }),
+    );
+    expect(res.status).toBe("resuming");
+    expect((res as { fenceNoop: boolean }).fenceNoop).toBe(true);
+  });
+
+  it("a multi-host CURRENT fence also resumes, but fenceNoop:false", () => {
+    const res = respondTicket(
+      { ticket: "CTL-845", response: "ok", confirm: "CTL-845" },
+      deps({ fenceCheck: () => ({ ok: true, noop: false, stale: false }) }),
+    );
+    expect(res.status).toBe("resuming");
+    expect((res as { fenceNoop: boolean }).fenceNoop).toBe(false);
+  });
+});
+
+describe("findHeldRun — locate the parked needs-input run", () => {
+  it("returns the held run + its verbatim signal", () => {
+    const out = findHeldRun("CTL-845", {
+      // only implement is parked; research is a finished (done) run
+      readDir: () => ["phase-implement.json", "phase-research.json"],
+      read: (p: string) =>
+        p.includes("research")
+          ? JSON.stringify({ status: "done", phase: "research" })
+          : JSON.stringify({ status: "needs-input", phase: "implement", generation: 3 }),
+    });
+    expect(out?.phase).toBe("implement");
+    expect(out?.signal?.status).toBe("needs-input");
+  });
+
+  it("returns null when no run is parked (status not needs-input)", () => {
+    const out = findHeldRun("CTL-845", {
+      readDir: () => ["phase-implement.json"],
+      read: () => JSON.stringify({ status: "working", phase: "implement" }),
+    });
+    expect(out).toBeNull();
+  });
+
+  it("an absent worker dir → null (nothing held)", () => {
+    const out = findHeldRun("CTL-845", {
+      readDir: () => {
+        throw new Error("ENOENT");
+      },
+    });
+    expect(out).toBeNull();
+  });
+
+  it("resolves the FIRST held run in PHASE_ORDER when several are parked", () => {
+    const out = findHeldRun("CTL-845", {
+      // listed out of order on disk; PHASE_ORDER puts research before implement
+      readDir: () => ["phase-implement.json", "phase-research.json"],
+      read: (p: string) =>
+        JSON.stringify({
+          status: "needs-input",
+          phase: p.includes("research") ? "research" : "implement",
+        }),
+    });
+    expect(out?.phase).toBe("research");
+  });
+
+  it("skips an unparseable signal without throwing", () => {
+    const out = findHeldRun("CTL-845", {
+      readDir: () => ["phase-implement.json"],
+      read: () => "{ not json",
+    });
+    expect(out).toBeNull();
+  });
+});
+
+describe("clearNeedsHumanMarker — inverse of the daemon's labelOnce marker", () => {
+  it("removes the .applied + .skipped once-markers and reports what was removed", () => {
+    const removed: string[] = [];
+    const out = clearNeedsHumanMarker(
+      { ticket: "CTL-845" },
+      {
+        workersDir: "/w",
+        rm: (p: string) => {
+          removed.push(p);
+        },
+      },
+    );
+    expect(out).toEqual([
+      "/w/CTL-845/.linear-label-needs-human.applied",
+      "/w/CTL-845/.linear-label-needs-human.skipped",
+    ]);
+    expect(removed).toEqual(out);
+  });
+
+  it("an absent marker is best-effort (never throws), removes only what exists", () => {
+    const out = clearNeedsHumanMarker(
+      { ticket: "CTL-845" },
+      {
+        workersDir: "/w",
+        rm: (p: string) => {
+          if (p.endsWith(".skipped")) throw new Error("ENOENT");
+        },
+      },
+    );
+    expect(out).toEqual(["/w/CTL-845/.linear-label-needs-human.applied"]);
+  });
+});
+
+describe("recordResponse — durable operator-answer artifact", () => {
+  it("writes a .respond-<phase>.json record with the operator's note", () => {
+    const writes: { path: string; data: string }[] = [];
+    const out = recordResponse(
+      { ticket: "CTL-845", phase: "implement", response: "unblocked: dep merged", now: new Date("2026-06-09T00:00:00Z") },
+      {
+        workersDir: "/w",
+        write: (path: string, data: string) => writes.push({ path, data }),
+        mkdir: () => undefined,
+      },
+    );
+    expect(out.path).toBe("/w/CTL-845/.respond-implement.json");
+    expect(writes).toHaveLength(1);
+    const parsed = JSON.parse(writes[0].data) as Record<string, unknown>;
+    expect(parsed.ticket).toBe("CTL-845");
+    expect(parsed.phase).toBe("implement");
+    expect(parsed.response).toBe("unblocked: dep merged");
+    expect(parsed.respondedAt).toBe("2026-06-09T00:00:00.000Z");
+  });
+
+  it("a non-string response is coerced to an empty string (never undefined in the record)", () => {
+    const writes: string[] = [];
+    recordResponse(
+      { ticket: "CTL-845", phase: "implement", response: undefined },
+      { workersDir: "/w", write: (_p: string, d: string) => writes.push(d), mkdir: () => undefined },
+    );
+    expect((JSON.parse(writes[0]) as { response: unknown }).response).toBe("");
+  });
+
+  it("a failed write is swallowed (path:null), never throws", () => {
+    const out = recordResponse(
+      { ticket: "CTL-845", phase: "implement", response: "x" },
+      {
+        workersDir: "/w",
+        write: () => {
+          throw new Error("EACCES");
+        },
+        mkdir: () => undefined,
+      },
+    );
+    expect(out.path).toBeNull();
+  });
+});
+
+describe("buildResumeEvent — the daemon's resume trigger shape", () => {
+  it("is a canonical linear.comment.created event the daemon's parseCommentCreatedEvent reads", () => {
+    const ev = buildResumeEvent({ ticket: "CTL-845", response: "go", now: new Date("2026-06-09T00:00:00Z") });
+    expect(ev.attributes["event.name"]).toBe("linear.comment.created");
+    expect(ev.attributes["linear.issue.identifier"]).toBe("CTL-845");
+    // The operator's note IS the comment body (the durable recorded response).
+    expect(ev.body.payload.ticket).toBe("CTL-845");
+    expect(ev.body.payload.body).toBe("go");
+    // Null author → the daemon's self-echo guard is fail-open (not the bot).
+    expect(ev.body.payload.authorId).toBeNull();
+    expect(ev.body.payload.source).toBe("orch-monitor/respond");
+  });
+
+  it("coerces a non-string response to an empty comment body", () => {
+    const ev = buildResumeEvent({ ticket: "CTL-845", response: null });
+    expect(ev.body.payload.body).toBe("");
+  });
+});
+
+describe("emitResumeEvent — append to the unified event log", () => {
+  it("appends ONE JSONL line to the resolved monthly log path", () => {
+    const appended: { path: string; data: string }[] = [];
+    const out = emitResumeEvent(
+      { ticket: "CTL-845", response: "go" },
+      {
+        append: (path: string, data: string) => appended.push({ path, data }),
+        pathFor: () => "/events/2026-06.jsonl",
+        mkdir: () => undefined,
+        now: new Date("2026-06-09T00:00:00Z"),
+      },
+    );
+    expect(out.path).toBe("/events/2026-06.jsonl");
+    expect(appended).toHaveLength(1);
+    expect(appended[0].path).toBe("/events/2026-06.jsonl");
+    expect(appended[0].data.endsWith("\n")).toBe(true);
+    const parsed = JSON.parse(appended[0].data) as { attributes: Record<string, string> };
+    expect(parsed.attributes["event.name"]).toBe("linear.comment.created");
+  });
+});
+
+describe("eventLogPath — UTC monthly path (matches the daemon tailer)", () => {
+  it("honors CATALYST_DIR and uses UTC year-month", () => {
+    const p = eventLogPath({ env: { CATALYST_DIR: "/cat" }, now: new Date("2026-06-09T00:00:00Z") });
+    expect(p).toBe("/cat/events/2026-06.jsonl");
+  });
+
+  it("zero-pads single-digit months", () => {
+    const p = eventLogPath({ env: { CATALYST_DIR: "/cat" }, now: new Date("2026-01-15T00:00:00Z") });
+    expect(p).toBe("/cat/events/2026-01.jsonl");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/respond-ticket.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/respond-ticket.d.mts
@@ -1,0 +1,125 @@
+// Type declarations for respond-ticket.mjs (CTL-924, BFF12) — the read-model's
+// SECOND write endpoint (HOME5's Answer / Unblock verb). Lets the strict TS
+// server (server.ts) import respondTicket without a TS7016 implicit-any error.
+// Keep in sync with the objects returned in respond-ticket.mjs.
+
+import type { FenceOutcome } from "./stop-worker.d.mts";
+
+/** Phase signal shape (the subset findHeldRun / respondTicket read). */
+interface PhaseSignalLike {
+  generation?: unknown;
+  status?: unknown;
+  phase?: unknown;
+  ticket?: unknown;
+  [key: string]: unknown;
+}
+
+/** The held run findHeldRun resolves: the parked phase + its verbatim signal. */
+export interface HeldRun {
+  phase: string;
+  signal: PhaseSignalLike;
+}
+
+/** A canonical `linear.comment.created` resume event (the daemon's resume trigger). */
+export interface ResumeEvent {
+  ts: string;
+  id: string;
+  observedTs: string;
+  severityText: "INFO";
+  severityNumber: number;
+  traceId: string;
+  spanId: string;
+  resource: Record<string, string>;
+  attributes: Record<string, string>;
+  body: { payload: Record<string, unknown> };
+}
+
+export function eventLogPath(opts?: {
+  env?: Record<string, string | undefined>;
+  now?: Date;
+}): string;
+
+export function buildResumeEvent(args: {
+  ticket: string;
+  response: unknown;
+  now?: Date;
+}): ResumeEvent;
+
+export function emitResumeEvent(
+  args: { ticket: string; response: unknown },
+  opts?: {
+    append?: (path: string, data: string) => void;
+    pathFor?: (opts: { now: Date }) => string;
+    mkdir?: (path: string, opts: { recursive: boolean }) => void;
+    now?: Date;
+  },
+): { path: string; event: ResumeEvent };
+
+export function clearNeedsHumanMarker(
+  args: { ticket: string; label?: string },
+  opts?: {
+    workersDir?: string;
+    rm?: (path: string) => void;
+  },
+): string[];
+
+export function recordResponse(
+  args: { ticket: string; phase: string; response: unknown; now?: Date },
+  opts?: {
+    workersDir?: string;
+    write?: (path: string, data: string) => void;
+    mkdir?: (path: string, opts: { recursive: boolean }) => void;
+  },
+): { path: string | null; record: Record<string, unknown> };
+
+export function findHeldRun(
+  ticket: string,
+  opts?: {
+    workersDir?: string;
+    readDir?: (path: string) => string[];
+    read?: (path: string, encoding: "utf8") => string;
+  },
+): HeldRun | null;
+
+export function readClusterHostCount(opts?: {
+  env?: Record<string, string | undefined>;
+  read?: (path: string, encoding: "utf8") => string;
+}): number;
+
+export function runFenceCheck(
+  args: { ticket: string; generation: number | null },
+  opts?: {
+    hostCount?: number;
+    spawn?: unknown;
+    nodeBin?: string;
+    cli?: string;
+    env?: Record<string, string | undefined>;
+    timeout?: number;
+  },
+): FenceOutcome;
+
+/**
+ * Discriminated outcome of respondTicket; the route maps `status` to an HTTP code.
+ * - not_held            → 404 (no parked needs-input run for the ticket)
+ * - confirm_mismatch    → 400 (typed confirm did not match the ticket id)
+ * - fenced              → 409 (verified-stale fence; a partitioned node rejected)
+ * - fence_indeterminate → 409 (multi-host fence unconfirmed; refuse to mutate)
+ * - resuming            → 200 (response recorded + marker cleared + resume emitted)
+ */
+export type RespondTicketResult =
+  | { status: "not_held" }
+  | { status: "confirm_mismatch"; expected: string }
+  | { status: "fenced"; ticket: string; phase: string }
+  | { status: "fence_indeterminate"; ticket: string; phase: string }
+  | { status: "resuming"; ticket: string; phase: string; fenceNoop: boolean };
+
+export function respondTicket(
+  args: { ticket: string; response: unknown; confirm: unknown },
+  opts?: {
+    findHeld?: (ticket: string) => HeldRun | null;
+    fenceCheck?: (args: { ticket: string; generation: number | null }) => FenceOutcome;
+    record?: (args: { ticket: string; phase: string; response: unknown }) => unknown;
+    clearMarker?: (args: { ticket: string }) => unknown;
+    emit?: (args: { ticket: string; response: unknown }) => unknown;
+  },
+): RespondTicketResult;

--- a/plugins/dev/scripts/orch-monitor/lib/respond-ticket.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/respond-ticket.mjs
@@ -1,0 +1,303 @@
+// respond-ticket.mjs — the read-model's SECOND write endpoint (CTL-924, BFF12).
+//
+// HOME5's Inbox `Answer / Unblock` verb needs a read-model WRITE that does three
+// things to a HELD ticket and then hands control back to the daemon:
+//
+//   1. RECORD the operator's response (their answer / unblock note) so the human's
+//      input is durable — written as a `.respond-<phase>.json` artifact in the
+//      ticket's worker dir AND carried in the resume event's payload (the unified
+//      event log is the system-wide record).
+//   2. CLEAR the `needs-human` label + the `.linear-label-needs-human.applied`
+//      once-marker. This is the exact inverse of the daemon's labelOnce guard
+//      (execution-core/label-guard.mjs clearStalledLabel, CTL-646): the label is
+//      removed from Linear AND the marker deleted, together, so the daemon's apply
+//      guard re-arms and a stale-label / stale-marker split-brain can't form.
+//   3. TRIGGER re-dispatch — CTL-876's resume loop. The daemon already resumes a
+//      parked (`status:"needs-input"`) worker on a `linear.comment.created` event
+//      for the ticket (execution-core/daemon.mjs handleCommentWake, CTL-549): it
+//      removes the held label and re-dispatches the parked phase with its handoff.
+//      So this endpoint emits ONE canonical `linear.comment.created` event into
+//      the unified event log carrying the operator's response as the comment body.
+//      The monitor NEVER calls dispatchTicket directly — it stays on the
+//      "UI triggers, the daemon dispatches" side of the boundary (the same shape
+//      BFF8's stop endpoint keeps: it issues the kill, it does not own the daemon).
+//
+// SHARED MUTATION FOUNDATION with BFF8 (stop-worker.mjs): this endpoint reuses
+// stop-worker's typed-confirm gate + fence-check scaffolding verbatim
+// (runFenceCheck / readClusterHostCount are imported, not re-implemented) so the
+// two web writes never diverge. The optimistic-rollback contract is identical —
+// the endpoint returns the verbatim { ticket, phase } identity + a `resuming`
+// status the client marks optimistically and rolls back against the next board
+// frame (the held label/row should clear within the rollback window).
+//
+// FENCE-AWARE (multi-node requirement, CTL-863/864): before mutating, the
+// endpoint passes the run signal's generation through the cross-host fence-check.
+// A request whose generation is behind the current fence (fence-check exit 10 =
+// stale) is REJECTED and NOTHING is mutated — a partitioned / stale node cannot
+// unblock a ticket the cluster has taken over. SINGLE-HOST (hosts.json absent /
+// length <= 1) is an identity NO-OP pass: the fence-check never spawns, the
+// response is recorded and the ticket resumed normally with zero added latency.
+//
+// READ-then-ACT, fail-safe: no held run signal for the ticket → 404 (nothing to
+// answer); a verified-stale fence → 409 fenced; an indeterminate multi-host fence
+// → 409 (do NOT mutate on an unconfirmed fence — the conservative answer for a
+// write). All collaborators (signal read, fence-check, label clear, response
+// record, event emit) are injectable so the route + unit tests drive every branch
+// without a real worker dir, a real hosts.json, a real `linearis`, or a real
+// event log.
+
+import { appendFileSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { readClusterHostCount, runFenceCheck } from "./stop-worker.mjs";
+import { PHASE_ORDER } from "./board-data.mjs";
+
+// The execution-core worker tree root — ~/catalyst/execution-core/workers/<T>/.
+// Byte-identical to ticket-runs.mjs::DEFAULT_WORKERS_DIR and board-data.mjs's
+// WORKERS_DIR (the on-disk home of both the phase-*.json signals AND the
+// .linear-label-needs-human.applied marker the daemon's labelOnce writes there).
+const HOME = homedir();
+const DEFAULT_WORKERS_DIR = join(HOME, "catalyst", "execution-core", "workers");
+
+// The held marker the daemon's labelOnce (label-guard.mjs) writes when it applies
+// the flat `needs-human` label. clearStalledLabel deletes BOTH this and the
+// `.skipped` sibling on a confirmed removal; we mirror that exactly.
+const NEEDS_HUMAN_LABEL = "needs-human";
+
+// re-export the shared fence primitives so the endpoint + tests resolve one
+// fence implementation (DRY with BFF8 — never a second copy that can drift).
+export { readClusterHostCount, runFenceCheck };
+
+// ── the unified-event-log resume trigger ─────────────────────────────────────
+// getEventLogPath — the canonical monthly event log path. UTC month to match the
+// orch-monitor event-writer (event-writer.ts uses getUTCFullYear/getUTCMonth) and
+// the execution-core tailer (config.mjs::getEventLogPath), so the event we append
+// lands on the SAME file the daemon's monitor follows. CATALYST_DIR override is
+// honored (tests + non-default roots) exactly like config.mjs::catalystDir.
+export function eventLogPath({ env = process.env, now = new Date() } = {}) {
+  const root = env.CATALYST_DIR ? env.CATALYST_DIR : join(HOME, "catalyst");
+  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  return join(root, "events", `${ym}.jsonl`);
+}
+
+// buildResumeEvent — a canonical `linear.comment.created` event carrying the
+// operator's response as the comment body. This is the shape the daemon's
+// monitor.mjs::parseCommentCreatedEvent reads (event.name + body.payload.{ticket,
+// body, authorId, ...}) and handleCommentWake acts on. authorId is left null: the
+// daemon's self-echo guard (_isBotId) is fail-open on an unset/non-bot author, so
+// an operator-originated resume event is never mistaken for the bot's own comment.
+export function buildResumeEvent({ ticket, response, now = new Date() }) {
+  const ts = now.toISOString().replace(/\.\d{3}Z$/, "Z");
+  return {
+    ts,
+    id: randomBytes(8).toString("hex"),
+    observedTs: ts,
+    severityText: "INFO",
+    severityNumber: 9,
+    traceId: randomBytes(16).toString("hex"),
+    spanId: randomBytes(8).toString("hex"),
+    resource: {
+      "service.name": "catalyst.orch-monitor",
+      "service.namespace": "catalyst",
+    },
+    attributes: {
+      "event.name": "linear.comment.created",
+      "event.entity": "linear",
+      "event.action": "comment.created",
+      "event.label": ticket,
+      "linear.issue.identifier": ticket,
+    },
+    body: {
+      payload: {
+        ticket,
+        // The operator's answer/unblock note IS the comment body — the durable
+        // system-wide record of the human's response (the daemon re-dispatches on
+        // ANY ticket comment; the body is the recorded answer, not a trigger flag).
+        body: typeof response === "string" ? response : "",
+        commentId: null,
+        issueId: null,
+        // Null author → the daemon's self-echo guard is fail-open (not the bot).
+        authorId: null,
+        authorName: "operator (web)",
+        // Mark the provenance so an operator can tell a web-resume from a real
+        // Linear comment when scanning the unified log.
+        source: "orch-monitor/respond",
+      },
+    },
+  };
+}
+
+// emitResumeEvent — append the resume event to the unified event log (best-effort
+// disk write; the daemon's monitor tails the file and resumes). Returns the path
+// written so the caller can surface it. The `append`/`pathFor` seams are injected
+// in tests so nothing touches the real log.
+export function emitResumeEvent(
+  { ticket, response },
+  { append = appendFileSync, pathFor = eventLogPath, mkdir = mkdirSync, now = new Date() } = {},
+) {
+  const event = buildResumeEvent({ ticket, response, now });
+  const path = pathFor({ now });
+  mkdir(dirname(path), { recursive: true });
+  append(path, JSON.stringify(event) + "\n");
+  return { path, event };
+}
+
+// ── clear the needs-human label + marker (inverse of labelOnce) ──────────────
+// clearNeedsHumanMarker — delete the `.linear-label-needs-human.{applied,skipped}`
+// once-marker(s) under the ticket's worker dir, re-arming the daemon's labelOnce
+// guard. Mirrors label-guard.mjs::clearStalledLabel's marker half exactly. The
+// Linear LABEL removal itself rides on the daemon's handleCommentWake (it strips
+// the held label as it re-dispatches), so this endpoint owns only the local
+// marker — clearing it WITHOUT the daemon also clearing the label would re-arm
+// the apply, which is the safe direction (the daemon re-applies if still held).
+// Best-effort, never throws. Returns the list of markers actually removed.
+export function clearNeedsHumanMarker(
+  { ticket, label = NEEDS_HUMAN_LABEL },
+  { workersDir = DEFAULT_WORKERS_DIR, rm = unlinkSync } = {},
+) {
+  const base = join(workersDir, ticket, `.linear-label-${label}`);
+  const removed = [];
+  for (const suffix of [".applied", ".skipped"]) {
+    const p = `${base}${suffix}`;
+    try {
+      rm(p);
+      removed.push(p);
+    } catch {
+      /* absent / unreadable → nothing to clear for this suffix */
+    }
+  }
+  return removed;
+}
+
+// ── record the operator's response ───────────────────────────────────────────
+// recordResponse — durably write the operator's answer/unblock note as a
+// `.respond-<phase>.json` artifact in the ticket's worker dir, alongside the
+// phase signal it answers. Best-effort; never throws (the resume event in the
+// unified log is the authoritative record, this is the local breadcrumb).
+export function recordResponse(
+  { ticket, phase, response, now = new Date() },
+  { workersDir = DEFAULT_WORKERS_DIR, write = writeFileSync, mkdir = mkdirSync } = {},
+) {
+  const dir = join(workersDir, ticket);
+  const path = join(dir, `.respond-${phase}.json`);
+  const record = {
+    ticket,
+    phase,
+    response: typeof response === "string" ? response : "",
+    respondedAt: now.toISOString(),
+    source: "orch-monitor/respond",
+  };
+  try {
+    mkdir(dir, { recursive: true });
+    write(path, JSON.stringify(record, null, 2));
+    return { path, record };
+  } catch {
+    return { path: null, record };
+  }
+}
+
+// ── find the held run for a ticket ───────────────────────────────────────────
+// findHeldRun — scan the ticket's worker dir for the phase signal that is parked
+// awaiting human input (status === "needs-input"), the exact predicate the
+// daemon's handleCommentWake uses. Returns { phase, signal } for the first held
+// run (PHASE_ORDER precedence so the result is deterministic) or null when no run
+// is held. Reads in PHASE_ORDER so a multi-phase worker dir resolves predictably.
+export function findHeldRun(
+  ticket,
+  { workersDir = DEFAULT_WORKERS_DIR, readDir = readdirSync, read = readFileSync } = {},
+) {
+  let files;
+  try {
+    files = readDir(join(workersDir, ticket));
+  } catch {
+    return null; // no worker dir → nothing held
+  }
+  const phaseFiles = new Set(
+    files.filter((f) => f.startsWith("phase-") && f.endsWith(".json")),
+  );
+  for (const phase of PHASE_ORDER) {
+    const fname = `phase-${phase}.json`;
+    if (!phaseFiles.has(fname)) continue;
+    let sig;
+    try {
+      sig = JSON.parse(read(join(workersDir, ticket, fname), "utf8"));
+    } catch {
+      continue;
+    }
+    if (sig && typeof sig === "object" && sig.status === "needs-input") {
+      return { phase, signal: sig };
+    }
+  }
+  return null;
+}
+
+// ── orchestration: the endpoint body ─────────────────────────────────────────
+// respondTicket — drive the full BFF12 contract for
+// `POST /api/ticket/<ticket>/respond`. Outcome is a discriminated result the route
+// maps to an HTTP status:
+//   { status: "not_held" }                          → 404: no parked (needs-input)
+//                                                      run for the ticket — nothing
+//                                                      to answer / unblock.
+//   { status: "confirm_mismatch", expected }         → 400: typed confirm wrong.
+//   { status: "fenced", ticket, phase }              → 409: a verified-stale fence
+//                                                      (exit 10) — a partitioned
+//                                                      node is rejected, NOTHING
+//                                                      mutated.
+//   { status: "fence_indeterminate", ticket, phase } → 409: multi-host fence could
+//                                                      not be confirmed — refuse.
+//   { status: "resuming", ticket, phase, fenceNoop } → 200: response recorded,
+//                                                      marker cleared, resume event
+//                                                      emitted; the UI marks the row
+//                                                      `resuming` optimistically and
+//                                                      arms its rollback timer.
+//
+// confirm is the typed-confirm token (the operator types the ticket id back), the
+// same gate BFF8 uses; mismatch is a hard 400 BEFORE any mutation. All
+// collaborators are injectable so tests cover every branch deterministically.
+export function respondTicket(
+  { ticket, response, confirm },
+  {
+    findHeld = findHeldRun,
+    fenceCheck = runFenceCheck,
+    record = recordResponse,
+    clearMarker = clearNeedsHumanMarker,
+    emit = emitResumeEvent,
+  } = {},
+) {
+  // Read first — the held run is BOTH the existence check and the source of the
+  // generation we fence-check + the phase we record/resume. 404 when nothing held.
+  const held = findHeld(ticket);
+  if (!held) {
+    return { status: "not_held" };
+  }
+  const { phase, signal } = held;
+
+  // Typed confirm: the operator must type the ticket id back, exactly. Gate BEFORE
+  // any mutation (mirrors BFF8 stop-worker).
+  if (confirm !== ticket) {
+    return { status: "confirm_mismatch", expected: ticket };
+  }
+
+  // Fence-aware guard (single-host no-op pass; multi-host CLI). The generation we
+  // fence-check is the held run signal's own generation (surfaced by BFF10).
+  const generation =
+    typeof signal.generation === "number" && Number.isFinite(signal.generation)
+      ? signal.generation
+      : null;
+  const fence = fenceCheck({ ticket, generation });
+  if (!fence.ok) {
+    return fence.stale
+      ? { status: "fenced", ticket, phase }
+      : { status: "fence_indeterminate", ticket, phase };
+  }
+
+  // Fence current (or single-host no-op): mutate. Record the human's response,
+  // clear the needs-human marker (re-arm the daemon's apply guard), then emit the
+  // resume event that drives CTL-876's loop (handleCommentWake re-dispatches).
+  record({ ticket, phase, response });
+  clearMarker({ ticket });
+  emit({ ticket, response });
+
+  return { status: "resuming", ticket, phase, fenceNoop: fence.noop === true };
+}

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -50,6 +50,18 @@ import { hostName } from "./lib/canonical-event-shared.ts";
 // UI-side timer; the endpoint returns the verbatim shortId+ticket+phase identity
 // the client needs to mark `stopping` and arm that timer.
 import { stopWorker, type StopWorkerResult } from "./lib/stop-worker.mjs";
+// CTL-924 (BFF12): the read-model's SECOND write endpoint (HOME5's Answer /
+// Unblock verb) — POST /api/ticket/<ticket>/respond records the operator's
+// response, clears the needs-human marker, and emits the resume event that
+// drives CTL-876's loop (the daemon re-dispatches the parked worker). Shares
+// BFF8's typed-confirm + fence-aware scaffolding (single-host no-op pass;
+// multi-host rejects a stale/partitioned generation). Optimistic rollback is a
+// UI-side timer; the endpoint returns the verbatim ticket+phase identity the
+// client needs to mark the row `resuming` and arm that timer.
+import {
+  respondTicket,
+  type RespondTicketResult,
+} from "./lib/respond-ticket.mjs";
 import { queryHistory, queryStats, compareSessions } from "./lib/history-store";
 import {
   listArchivedOrchestrators,
@@ -2084,6 +2096,88 @@ export function createServer(opts: CreateServerOptions): BunServer {
             case "stopping":
               // Kill issued; the UI marks the worker `stopping` and arms its ~10s
               // optimistic-rollback timer against the next board frame.
+              return Response.json(result, { status: 200 });
+          }
+        }
+
+        // CTL-924 (BFF12): the read-model's SECOND write endpoint — HOME5's Inbox
+        // `Answer / Unblock` verb. POST /api/ticket/<ticket>/respond records the
+        // operator's answer/unblock note, clears the `.linear-label-needs-human`
+        // marker, and emits ONE `linear.comment.created` event into the unified
+        // log — the daemon's handleCommentWake (CTL-549) consumes it, strips the
+        // held label, and re-dispatches the parked worker (CTL-876's resume loop).
+        // Contract mirrors BFF8's stop route:
+        //   • TYPED CONFIRM — body.confirm must equal the ticket id exactly.
+        //   • FENCE-AWARE   — single-host (hosts.json absent/len 1) is a no-op
+        //     pass; multi-host rejects a verified-stale generation (a partitioned
+        //     node) and refuses on an unconfirmable fence. NOTHING is mutated on
+        //     a fence rejection.
+        //   • OPTIMISTIC ROLLBACK is a UI-side timer; on success we return the
+        //     ticket+phase identity + a `resuming` status the client marks
+        //     optimistically (the held row should clear within the window).
+        const respondMatch = url.pathname.match(
+          /^\/api\/ticket\/([^/]+)\/respond$/,
+        );
+        if (respondMatch && req.method === "POST") {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(respondMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          let body: Record<string, unknown>;
+          try {
+            body = (await req.json()) as Record<string, unknown>;
+          } catch {
+            return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+          }
+          const response = typeof body.response === "string" ? body.response : "";
+          const result: RespondTicketResult = respondTicket({
+            ticket,
+            response,
+            confirm: body.confirm,
+          });
+          switch (result.status) {
+            case "not_held":
+              return Response.json(
+                {
+                  status: "not_held",
+                  error: `no parked (needs-input) run for ${ticket} to answer/unblock`,
+                },
+                { status: 404 },
+              );
+            case "confirm_mismatch":
+              return Response.json(
+                {
+                  status: "confirm_mismatch",
+                  error: "typed confirmation did not match the ticket id",
+                  expected: result.expected,
+                },
+                { status: 400 },
+              );
+            case "fenced":
+              // A stale-generation node is fenced out — nothing was mutated.
+              return Response.json(
+                {
+                  ...result,
+                  error: "respond rejected: this node's generation is stale (fenced out)",
+                },
+                { status: 409 },
+              );
+            case "fence_indeterminate":
+              return Response.json(
+                {
+                  ...result,
+                  error: "respond rejected: fence could not be confirmed",
+                },
+                { status: 409 },
+              );
+            case "resuming":
+              // Response recorded + marker cleared + resume event emitted; the UI
+              // marks the row `resuming` and arms its optimistic-rollback timer.
               return Response.json(result, { status: 200 });
           }
         }


### PR DESCRIPTION
## What

Adds the read-model's **second** write endpoint, `POST /api/ticket/<ticket>/respond` — HOME5's Inbox **Answer / Unblock** verb. It is the sibling to BFF8's stop route (`POST /api/ec-worker/<ticket>/stop`), and the two web mutations now share **one** fence-aware-write + typed-confirm + optimistic-rollback foundation (resolving the P2-before-P4 inversion the ticket calls out).

On an answer/unblock it:
1. **Records** the operator's response — a durable `.respond-<phase>.json` artifact in the ticket's worker dir, and the operator's note carried as the `linear.comment.created` body in the unified event log (the system-wide record).
2. **Clears** the `.linear-label-needs-human.{applied,skipped}` once-marker (the inverse of the daemon's `labelOnce` guard, `label-guard.mjs::clearStalledLabel`), re-arming the apply guard.
3. **Triggers re-dispatch** — emits one canonical `linear.comment.created` event into `~/catalyst/events/YYYY-MM.jsonl`. The daemon's existing `handleCommentWake` (CTL-549) consumes it, strips the held label, and re-dispatches the parked (`status:"needs-input"`) worker with its handoff — **CTL-876's resume loop**. The monitor never calls `dispatchTicket` directly; it stays on the "UI triggers, the daemon dispatches" boundary (the same shape BFF8 keeps).

## Fence-awareness (single-node MVP)

Reuses BFF8's `runFenceCheck` / `readClusterHostCount` **verbatim** (imported, not re-implemented) so the two writes can never diverge:
- **Single-host** (`hosts.json` absent / length ≤ 1) → identity **no-op pass**, never spawns the fence CLI, zero added latency, `fenceNoop:true`.
- **Multi-host** → fence-check the held run's own generation (surfaced by BFF10); a verified-stale generation (`cluster-claim.mjs fence-check` **exit 10**) → `409 fenced`, an unconfirmable fence → `409` fail-closed. **Nothing is mutated** on any fence rejection.

## Files

- `lib/respond-ticket.mjs` (+ `respond-ticket.d.mts`) — the endpoint helper, all collaborators injectable.
- `server.ts` — wires the POST route (gated so it cannot shadow the existing GET readers).
- `__tests__/respond-ticket.test.ts` — 26 unit tests (every branch, fully injected).
- `__tests__/respond-ticket-endpoint.test.ts` — 4 route-plumbing tests (method gate, 400s, 404 not_held).

## Gherkin scenarios

| Scenario | Status |
|---|---|
| Answer/unblock records the response and resumes | **SATISFIED** — record → clear marker → emit resume event (asserted in order); daemon re-dispatches via `handleCommentWake` |
| The mutation is fence-aware | **SATISFIED** — verified-stale exit-10 generation → `409 fenced`, nothing mutated; indeterminate multi-host fence → `409`, fail-closed |
| Single-host pass-through | **SATISFIED** — `hosts.json` absent/len ≤ 1 → fence no-op, response recorded normally, `fenceNoop:true` |

No scenarios were single-node-descoped: the spec's three scenarios all build cleanly on the single-host identity no-op + the existing CTL-549 resume backend (treated as CTL-876's loop). The N>1 fence branch is exercised by the injected unit tests but, per the MVP descope, runs only behind the `hosts.json` length check.

## Tests

- `bun test __tests__/respond-ticket.test.ts __tests__/respond-ticket-endpoint.test.ts` → **30 pass, 0 fail**
- `bun test __tests__/stop-worker.test.ts __tests__/stop-worker-endpoint.test.ts` → 34 pass (no regression)
- `bun test __tests__/server.test.ts` → 88 pass (route ordering intact)
- `bunx tsc --noEmit` (orch-monitor root tsconfig) → **clean** (exit 0)

Pre-existing, unrelated to this PR: the `ui/` package (excluded from the root tsconfig) has a baseline tsc error in `kpi-strip.tsx` (missing `abandoned` field) present on clean `origin/main`; this PR touches **no** `ui/` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)