### PR TITLE
feat(dev): SHELL6 live nav badges/dots from read-model (CTL-896)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/nav-signal-endpoints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/nav-signal-endpoints.test.ts
@@ -1,0 +1,109 @@
+// nav-signal-endpoints.test.ts — HTTP route-plumbing tests for the nav-signal
+// projection routes (CTL-896, SHELL6): GET /api/nav (one-shot) and GET
+// /api/nav/stream (SSE `nav` frames). Validates the server.ts wiring — the routes
+// are mounted, return the projected NavSignal shape, layer the injected daemon
+// health, and the stream emits a `nav` event on connect. The projection LOGIC
+// itself (worker count / queue depth / anomaly / daemon mapping) is covered
+// exhaustively by the pure injectable unit tests in nav-signal.test.ts; these
+// prove the route is mounted, shaped, and rides the read-model push transport.
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+import type { NavSignal } from "../lib/nav-signal.mjs";
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "nav-signal-endpoint-"));
+  const wtDir = join(tmpDir, "wt");
+  mkdirSync(wtDir, { recursive: true });
+  // Inject a deterministic daemon health so the route doesn't read the live event
+  // log; the board snapshot assembles from this empty temp dir (no workers/queue).
+  server = createServer({
+    port: 0,
+    wtDir,
+    catalystDir: tmpDir,
+    startWatcher: false,
+    daemonHealthReader: () => "healthy",
+  });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  void server?.stop(true);
+  if (tmpDir) {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+function isNavSignal(v: unknown): v is NavSignal {
+  if (!v || typeof v !== "object") return false;
+  const s = v as Record<string, unknown>;
+  return (
+    typeof s.workerCount === "number" &&
+    typeof s.queueDepth === "number" &&
+    typeof s.anomaly === "boolean" &&
+    (s.daemon === "healthy" || s.daemon === "degraded" || s.daemon === "offline") &&
+    typeof s.generatedAt === "string"
+  );
+}
+
+describe("GET /api/nav (CTL-896 one-shot)", () => {
+  it("returns the projected NavSignal shape", async () => {
+    const res = await fetch(`${baseUrl}/api/nav`);
+    expect(res.status).toBe(200);
+    const body: unknown = await res.json();
+    expect(isNavSignal(body)).toBe(true);
+  });
+
+  it("layers the injected daemon health into the projection", async () => {
+    const res = await fetch(`${baseUrl}/api/nav`);
+    const body = (await res.json()) as NavSignal;
+    expect(body.daemon).toBe("healthy");
+  });
+
+  it("an empty fleet projects zero badges and no anomaly", async () => {
+    const res = await fetch(`${baseUrl}/api/nav`);
+    const body = (await res.json()) as NavSignal;
+    expect(body.workerCount).toBe(0);
+    expect(body.queueDepth).toBe(0);
+    expect(body.anomaly).toBe(false);
+  });
+});
+
+describe("GET /api/nav/stream (CTL-896 SSE)", () => {
+  it("is a text/event-stream that emits a `nav` frame on connect", async () => {
+    const res = await fetch(`${baseUrl}/api/nav/stream`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+    // Read just the first frame off the stream, then bail (don't hang on the
+    // keep-alive). The connect frame is `event: nav\ndata: {…}\n\n`.
+    const reader = res.body?.getReader();
+    expect(reader).toBeTruthy();
+    const decoder = new TextDecoder();
+    let buf = "";
+    if (reader) {
+      for (let i = 0; i < 5 && !buf.includes("\n\n"); i++) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+      }
+      await reader.cancel();
+    }
+    expect(buf).toContain("event: nav");
+    const dataLine = buf.split("\n").find((l) => l.startsWith("data: "));
+    expect(dataLine).toBeTruthy();
+    const payload: unknown = JSON.parse((dataLine as string).slice("data: ".length));
+    expect(isNavSignal(payload)).toBe(true);
+    expect((payload as NavSignal).daemon).toBe("healthy");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/nav-signal-ui.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/nav-signal-ui.test.ts
@@ -1,0 +1,110 @@
+// nav-signal-ui.test.ts — CTL-896 / SHELL6 UI-contract guards. `bun test` has no
+// DOM, so — matching app-shell-ia.test.ts (CTL-893) — the pure UI contract
+// (lib/nav-signal.ts: the decode guard + the daemon color/label mapping) is unit-
+// tested directly, and the rail-wiring scenario (mocks replaced by the live
+// nav-signal projection) is asserted by static source analysis of app-sidebar.tsx.
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  isNavSignal,
+  decodeNavSignalFrame,
+  daemonDotClass,
+  daemonLabel,
+  type NavSignal,
+} from "../ui/src/lib/nav-signal";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const UI_SRC = join(HERE, "..", "ui", "src");
+const read = (rel: string) => readFileSync(join(UI_SRC, rel), "utf8");
+
+const sidebarSrc = read("components/app-sidebar.tsx");
+
+/** Strip JS/JSX comments so token assertions can't be tripped by prose. */
+function stripComments(src: string): string {
+  return src
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+const sidebarCode = stripComments(sidebarSrc);
+
+const signal = (overrides: Partial<NavSignal> = {}): NavSignal => ({
+  workerCount: 0,
+  queueDepth: 0,
+  anomaly: false,
+  daemon: "healthy",
+  generatedAt: "2026-06-08T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("nav-signal UI contract (CTL-896 / SHELL6)", () => {
+  describe("isNavSignal / decodeNavSignalFrame", () => {
+    it("accepts a well-formed signal", () => {
+      expect(isNavSignal(signal())).toBe(true);
+    });
+
+    it("rejects a frame missing fields or with a bad daemon value", () => {
+      expect(isNavSignal({ workerCount: 1 })).toBe(false);
+      expect(isNavSignal({ ...signal(), daemon: "green" })).toBe(false);
+      expect(isNavSignal(null)).toBe(false);
+    });
+
+    it("decodes a JSON frame, returning null on garbage (not a throw)", () => {
+      expect(decodeNavSignalFrame(JSON.stringify(signal({ workerCount: 4 })))?.workerCount).toBe(4);
+      expect(decodeNavSignalFrame("{ not json")).toBeNull();
+      expect(decodeNavSignalFrame(JSON.stringify({ daemon: "x" }))).toBeNull();
+    });
+  });
+
+  describe("daemon color discipline (emerald/amber/red — cyan is reserved)", () => {
+    it("maps healthy → emerald, degraded → amber, offline → red", () => {
+      expect(daemonDotClass("healthy")).toBe("bg-emerald-500");
+      expect(daemonDotClass("degraded")).toBe("bg-amber-500");
+      expect(daemonDotClass("offline")).toBe("bg-red-500");
+    });
+
+    it("never uses the reserved cyan live-signal color for any daemon state", () => {
+      for (const d of ["healthy", "degraded", "offline"] as const) {
+        expect(daemonDotClass(d)).not.toContain("5be0ff");
+        expect(daemonDotClass(d)).not.toContain("cyan");
+      }
+    });
+
+    it("labels each daemon state", () => {
+      expect(daemonLabel("healthy")).toBe("Daemon healthy");
+      expect(daemonLabel("degraded")).toBe("Daemon degraded");
+      expect(daemonLabel("offline")).toBe("Daemon offline");
+    });
+  });
+
+  describe("app-sidebar wiring (static source analysis)", () => {
+    it("consumes the live nav signal hook (no more mock badges)", () => {
+      expect(sidebarCode).toContain("useNavSignal");
+      expect(sidebarCode).toContain("const nav = useNavSignal()");
+    });
+
+    it("no longer hardcodes the mock badge numbers 4 / 7", () => {
+      // The OPERATE IA must not carry literal `badge: 4` / `badge: 7` mocks.
+      expect(sidebarCode).not.toMatch(/badge:\s*4\b/);
+      expect(sidebarCode).not.toMatch(/badge:\s*7\b/);
+    });
+
+    it("derives the Workers count + Queue depth badges from the signal", () => {
+      expect(sidebarCode).toContain("nav.workerCount");
+      expect(sidebarCode).toContain("nav.queueDepth");
+    });
+
+    it("derives the Board anomaly dot from the signal", () => {
+      expect(sidebarCode).toContain("nav.anomaly");
+    });
+
+    it("wires the footer daemon-health dot to the signal (no hardcoded emerald)", () => {
+      expect(sidebarCode).toContain("daemonDotClass(nav.daemon)");
+      // The old SHELL1 footer hardcoded `bg-emerald-500` for the daemon dot;
+      // SHELL6 must drive it off daemonDotClass, not a literal class.
+      expect(sidebarCode).not.toMatch(/rounded-full bg-emerald-500/);
+    });
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/nav-signal.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/nav-signal.test.ts
@@ -1,0 +1,246 @@
+// nav-signal.test.ts — CTL-896 / SHELL6 acceptance guards for the nav-signal
+// projection. Encodes the five SHELL6 Gherkin scenarios against the PURE
+// projection (deriveNavSignal / deriveDaemonHealth), which is fully injectable so
+// every scenario is unit-testable without an fs/DB/subprocess/event-log.
+import { describe, it, expect } from "bun:test";
+import {
+  deriveNavSignal,
+  deriveDaemonHealth,
+} from "../lib/nav-signal.mjs";
+import type {
+  BoardPayload,
+  BoardWorker,
+  BoardTicket,
+  BoardQueueItem,
+} from "../lib/board-data.mjs";
+
+function worker(name: string, overrides: Partial<BoardWorker> = {}): BoardWorker {
+  return {
+    name,
+    ticket: name,
+    tickets: [name],
+    phase: "implement",
+    status: "running",
+    activeState: "active",
+    working: true,
+    lastActiveMs: 1000,
+    repo: "catalyst",
+    team: "CTL",
+    runtimeMs: null,
+    costUSD: null,
+    sessionId: "sess",
+    startedAt: null,
+    pid: null,
+    catalystSessionId: null,
+    host: null,
+    generation: null,
+    ...overrides,
+  };
+}
+
+function ticket(id: string, overrides: Partial<BoardTicket> = {}): BoardTicket {
+  return {
+    id,
+    title: id,
+    type: "task",
+    repo: "catalyst",
+    team: "CTL",
+    phase: "implement",
+    status: "running",
+    model: null,
+    linearState: "Implement",
+    workerStatus: "running",
+    activeState: "active",
+    working: true,
+    lastActiveMs: 1000,
+    priority: 2,
+    estimate: null,
+    scope: null,
+    project: null,
+    costUSD: null,
+    tokens: null,
+    turns: null,
+    phaseCosts: null,
+    phaseSummary: [],
+    pr: null,
+    updatedAt: "2026-06-08T11:00:00.000Z",
+    held: null,
+    blockers: [],
+    host: null,
+    generation: null,
+    ...overrides,
+  };
+}
+
+function queued(id: string, overrides: Partial<BoardQueueItem> = {}): BoardQueueItem {
+  return {
+    id,
+    title: id,
+    priority: 2,
+    createdAt: "2026-06-08T10:00:00.000Z",
+    state: "Todo",
+    repo: "catalyst",
+    team: "CTL",
+    rank: 0,
+    estimate: null,
+    scope: null,
+    project: null,
+    host: null,
+    ...overrides,
+  };
+}
+
+function board(overrides: Partial<BoardPayload> = {}): BoardPayload {
+  return {
+    generatedAt: "2026-06-08T12:00:00.000Z",
+    config: { maxParallel: 6, inFlight: 0, freeSlots: 6, active: 0, working: 0, stuck: 0 },
+    repos: ["catalyst"],
+    workers: [],
+    tickets: [],
+    queue: [],
+    ...overrides,
+  };
+}
+
+describe("nav-signal projection (CTL-896 / SHELL6)", () => {
+  // Scenario: Worker count badge reflects live sessions
+  describe("worker count badge", () => {
+    it("counts the active execution-core workers", () => {
+      const sig = deriveNavSignal(
+        board({ workers: [worker("CTL-1"), worker("CTL-2"), worker("CTL-3")] }),
+      );
+      expect(sig.workerCount).toBe(3);
+    });
+
+    it("is zero when no worker is running", () => {
+      expect(deriveNavSignal(board()).workerCount).toBe(0);
+    });
+
+    // "updates as workers start and finish" — the projection is a pure function of
+    // the latest snapshot, so a finished worker (dropped from board.workers) lowers
+    // the count on the very next frame; no page reload, no stale bookkeeping.
+    it("tracks the count down when a worker finishes", () => {
+      const before = deriveNavSignal(board({ workers: [worker("a"), worker("b")] }));
+      const after = deriveNavSignal(board({ workers: [worker("a")] }));
+      expect(before.workerCount).toBe(2);
+      expect(after.workerCount).toBe(1);
+    });
+  });
+
+  // Scenario: Queue depth badge reflects waiting work
+  describe("queue depth badge", () => {
+    it("reflects the number of tickets waiting in the queue", () => {
+      const sig = deriveNavSignal(
+        board({ queue: [queued("q1"), queued("q2"), queued("q3"), queued("q4")] }),
+      );
+      expect(sig.queueDepth).toBe(4);
+    });
+
+    it("is zero when the queue is empty", () => {
+      expect(deriveNavSignal(board()).queueDepth).toBe(0);
+    });
+  });
+
+  // Scenario: Board anomaly dot
+  describe("board anomaly dot", () => {
+    it("flags an anomaly when a ticket is held blocked (needs-human / dependency)", () => {
+      const sig = deriveNavSignal(
+        board({ tickets: [ticket("CTL-1"), ticket("CTL-2", { held: "blocked" })] }),
+      );
+      expect(sig.anomaly).toBe(true);
+    });
+
+    it("flags an anomaly when a worker is stuck", () => {
+      const sig = deriveNavSignal(
+        board({ config: { maxParallel: 6, inFlight: 1, freeSlots: 5, active: 0, working: 0, stuck: 1 } }),
+      );
+      expect(sig.anomaly).toBe(true);
+    });
+
+    it("clears the anomaly when nothing is blocked or stuck", () => {
+      const sig = deriveNavSignal(
+        board({ tickets: [ticket("CTL-1"), ticket("CTL-2", { held: "waiting" })] }),
+      );
+      // a `waiting` hold is NOT an anomaly — deps satisfied, just awaiting capacity.
+      expect(sig.anomaly).toBe(false);
+    });
+
+    it("clears the anomaly on the frame after the block resolves", () => {
+      const blocked = deriveNavSignal(board({ tickets: [ticket("x", { held: "blocked" })] }));
+      const resolved = deriveNavSignal(board({ tickets: [ticket("x", { held: null })] }));
+      expect(blocked.anomaly).toBe(true);
+      expect(resolved.anomaly).toBe(false);
+    });
+  });
+
+  // Scenario: Daemon-health dot
+  describe("daemon-health dot", () => {
+    it("maps a live local heartbeat to healthy (green)", () => {
+      expect(deriveNavSignal(board(), { liveness: "live" }).daemon).toBe("healthy");
+    });
+
+    it("maps a degraded local heartbeat to degraded (amber)", () => {
+      expect(deriveNavSignal(board(), { liveness: "degraded" }).daemon).toBe("degraded");
+    });
+
+    it("maps an offline local heartbeat to offline (red)", () => {
+      expect(deriveNavSignal(board(), { liveness: "offline" }).daemon).toBe("offline");
+    });
+
+    it("defaults to offline when no liveness is known (never fabricates health)", () => {
+      expect(deriveNavSignal(board()).daemon).toBe("offline");
+    });
+
+    it("an explicit daemon health overrides the liveness mapping", () => {
+      expect(deriveNavSignal(board(), { daemon: "degraded" }).daemon).toBe("degraded");
+    });
+  });
+
+  // Single-host identity no-op: the LOCAL daemon's own heartbeat IS the health.
+  describe("deriveDaemonHealth (single-host local liveness)", () => {
+    const now = Date.parse("2026-06-08T12:00:00.000Z");
+
+    it("a fresh local heartbeat → healthy", () => {
+      const last = { "mac-mini": "2026-06-08T11:59:50.000Z" }; // 10s ago
+      expect(deriveDaemonHealth(last, "mac-mini", { now })).toBe("healthy");
+    });
+
+    it("a stale-but-grace local heartbeat → degraded", () => {
+      const last = { "mac-mini": "2026-06-08T11:58:00.000Z" }; // 2min ago (> 30s, < 5min)
+      expect(deriveDaemonHealth(last, "mac-mini", { now })).toBe("degraded");
+    });
+
+    it("a very old local heartbeat → offline", () => {
+      const last = { "mac-mini": "2026-06-08T11:00:00.000Z" }; // 1h ago
+      expect(deriveDaemonHealth(last, "mac-mini", { now })).toBe("offline");
+    });
+
+    it("never-heard local host → offline (no fabrication)", () => {
+      expect(deriveDaemonHealth({}, "mac-mini", { now })).toBe("offline");
+      expect(deriveDaemonHealth({ "other-host": "2026-06-08T11:59:55.000Z" }, "mac-mini", { now })).toBe(
+        "offline",
+      );
+    });
+  });
+
+  // Scenario: Live without thrash — the projection passes the snapshot's
+  // generatedAt through so a consumer can dedupe identical frames; it does no I/O.
+  describe("passthrough + purity", () => {
+    it("carries the source snapshot's generatedAt", () => {
+      expect(deriveNavSignal(board({ generatedAt: "2026-06-08T13:00:00.000Z" })).generatedAt).toBe(
+        "2026-06-08T13:00:00.000Z",
+      );
+    });
+
+    it("is total over a null/garbage snapshot (degrades, never throws)", () => {
+      const sig = deriveNavSignal(null);
+      expect(sig).toEqual({
+        workerCount: 0,
+        queueDepth: 0,
+        anomaly: false,
+        daemon: "offline",
+        generatedAt: "",
+      });
+    });
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/nav-signal.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/nav-signal.d.mts
@@ -1,0 +1,33 @@
+// Type declarations for nav-signal.mjs (CTL-896 / SHELL6 nav-signal projection).
+import type { BoardPayload } from "./board-data.mjs";
+import type { HostLivenessStatus, LivenessThresholds } from "./node-liveness.mjs";
+
+/** The footer daemon-health vocabulary (mapped from node-liveness status). */
+export type DaemonHealth = "healthy" | "degraded" | "offline";
+
+/** The single nav-signal projection that feeds the rail's live badges/dots. */
+export interface NavSignal {
+  /** Active execution-core workers — the Workers nav badge. */
+  workerCount: number;
+  /** Tickets waiting in the queue — the Queue nav badge. */
+  queueDepth: number;
+  /** A board anomaly exists (blocked/needs-human or a stuck worker) — the Board amber dot. */
+  anomaly: boolean;
+  /** The local daemon's liveness — the footer health dot. */
+  daemon: DaemonHealth;
+  /** The source snapshot's generatedAt (passthrough for cache/debug; "" when absent). */
+  generatedAt: string;
+}
+
+/** Project the four nav signals off a board snapshot + the local daemon liveness. */
+export function deriveNavSignal(
+  board: BoardPayload | null | undefined,
+  opts?: { daemon?: DaemonHealth; liveness?: HostLivenessStatus },
+): NavSignal;
+
+/** Classify the LOCAL daemon's health from the heartbeat last-seen map. */
+export function deriveDaemonHealth(
+  lastSeenByHost: Record<string, string>,
+  localHostName: string,
+  opts?: { now?: number } & LivenessThresholds,
+): DaemonHealth;

--- a/plugins/dev/scripts/orch-monitor/lib/nav-signal.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/nav-signal.mjs
@@ -1,0 +1,111 @@
+// nav-signal.mjs — the dedicated NAV-SIGNAL projection (CTL-896 / SHELL6).
+//
+// The vertical rail's payoff is per-item live signal a top tab strip can't carry
+// (app-shell research §2 "Live badges are the payoff"). This module is the single
+// cache-backed projection that feeds those badges/dots: the Workers active-count
+// badge, the Queue depth badge, the Board anomaly dot, and the footer daemon-
+// health dot. It is PURE + injectable so the exact scenarios are unit-testable
+// without an fs/DB/subprocess, and it derives EXCLUSIVELY off the read-model's
+// already-assembled board snapshot (BoardPayload) plus an injected daemon-liveness
+// status — it NEVER does a synchronous per-request scan of the source files (the
+// load-bearing ticket constraint). The server layers it onto the SAME reactive
+// boardSnapshot the board SSE already pushes, so a nav badge update rides the
+// read-model SSE stream, not a per-tab poll.
+//
+// SINGLE-HOST IDENTITY NO-OP: daemon health is the LOCAL node's liveness. On
+// today's single-node deployment (hosts.json absent → getClusterHosts() returns
+// [localHostName]), the read-model classifies the one local daemon's own
+// node.heartbeat freshness via node-liveness.mjs::classifyHostLiveness — exactly
+// one node, the local one, zero cross-node transport. The N>1 fleet-health roll-up
+// is a later cluster concern (BFF3); here the daemon dot reflects the local daemon
+// and nothing else.
+
+import { classifyHostLiveness } from "./node-liveness.mjs";
+
+/**
+ * @typedef {"healthy" | "degraded" | "offline"} DaemonHealth
+ */
+
+/**
+ * @typedef {object} NavSignal
+ * @property {number} workerCount   active execution-core workers (the Workers badge)
+ * @property {number} queueDepth    tickets waiting in the queue (the Queue badge)
+ * @property {boolean} anomaly      a board anomaly exists — blocked/needs-human or a stuck worker (the Board dot)
+ * @property {DaemonHealth} daemon  the local daemon's liveness (the footer health dot)
+ * @property {string} generatedAt   the source snapshot's generatedAt (passthrough for cache/debug)
+ */
+
+/** node-liveness `live`/`degraded`/`offline` → the nav daemon-health vocabulary. */
+function daemonFromLiveness(status) {
+  if (status === "live") return "healthy";
+  if (status === "degraded") return "degraded";
+  return "offline";
+}
+
+/**
+ * deriveNavSignal — project the four nav signals off the read-model's board
+ * snapshot + the local daemon's liveness. Pure: no fs, no clock, no subprocess —
+ * everything is read off the passed snapshot and the injected `daemon`/`liveness`.
+ *
+ * Anomaly discipline (color: amber dot): a board anomaly is a ticket the operator
+ * must look at — one held `blocked` (the in-payload representation of a dependency
+ * hold / needs-human) OR a stuck worker (config.stuck). A `waiting` hold is NOT an
+ * anomaly: deps are satisfied, it is just awaiting capacity (home-inbox.ts split).
+ *
+ * @param {import("./board-data.mjs").BoardPayload | null | undefined} board
+ * @param {{ daemon?: DaemonHealth, liveness?: "live"|"degraded"|"offline" }} [opts]
+ *   `daemon` sets the health vocabulary directly; `liveness` maps a node-liveness
+ *   status through. When neither is given the daemon defaults to "offline" (the
+ *   read-model never fabricates health for a daemon it has not heard from).
+ * @returns {NavSignal}
+ */
+export function deriveNavSignal(board, { daemon, liveness } = {}) {
+  const workers = Array.isArray(board?.workers) ? board.workers : [];
+  const queue = Array.isArray(board?.queue) ? board.queue : [];
+  const tickets = Array.isArray(board?.tickets) ? board.tickets : [];
+  const stuck = typeof board?.config?.stuck === "number" ? board.config.stuck : 0;
+
+  const blocked = tickets.some((t) => t && t.held === "blocked");
+  const anomaly = blocked || stuck > 0;
+
+  const resolvedDaemon =
+    daemon ?? (liveness ? daemonFromLiveness(liveness) : "offline");
+
+  return {
+    workerCount: workers.length,
+    queueDepth: queue.length,
+    anomaly,
+    daemon: resolvedDaemon,
+    generatedAt:
+      typeof board?.generatedAt === "string" ? board.generatedAt : "",
+  };
+}
+
+/**
+ * deriveDaemonHealth — classify the LOCAL daemon's liveness from the heartbeat
+ * last-seen map (recovery.readClusterHeartbeats output: { [hostName]: lastSeenISO })
+ * for the local host. Single-host identity no-op: the local host's own heartbeat IS
+ * the daemon's health. Pure: `now` and the local host name are injected.
+ *
+ * @param {Record<string, string>} lastSeenByHost  readClusterHeartbeats output
+ * @param {string} localHostName  the local node's name (config.getHostName / hostName())
+ * @param {{ now?: number, intervalMs?: number, graceMs?: number }} [opts]
+ * @returns {DaemonHealth}
+ */
+export function deriveDaemonHealth(
+  lastSeenByHost,
+  localHostName,
+  { now = Date.now(), intervalMs, graceMs } = {},
+) {
+  const seen =
+    lastSeenByHost && typeof lastSeenByHost === "object" ? lastSeenByHost : {};
+  const lastSeen =
+    typeof localHostName === "string" &&
+    typeof seen[localHostName] === "string" &&
+    seen[localHostName].length > 0
+      ? seen[localHostName]
+      : null;
+  return daemonFromLiveness(
+    classifyHostLiveness(lastSeen, now, { intervalMs, graceMs }),
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -13,6 +13,12 @@ import { readSessionStore } from "./lib/session-store";
 import { readReconcileHealth } from "./lib/reconcile-health-reader"; // CTL-867
 import type { BoardPayload } from "./lib/board-data.mjs";
 import { createBoardSnapshotManager } from "./lib/board-snapshot.mjs";
+// CTL-896 (SHELL6): the dedicated nav-signal projection — worker count, queue
+// depth, board anomaly, and the local daemon-health dot — derived off the SAME
+// reactive board snapshot the board SSE already pushes (never a per-request
+// scan), with the daemon health layered from the local node.heartbeat liveness.
+import { deriveNavSignal } from "./lib/nav-signal.mjs";
+import type { NavSignal, DaemonHealth } from "./lib/nav-signal.mjs";
 // CTL-886 (BFF4): run→worker identity — surface every phase-*.json signal as a
 // queryable run entity (/api/ticket-runs/<id>) + serve one signal verbatim
 // (/api/ec-worker/<ticket>/<phase>). Pure file-reads of resident signals — no
@@ -237,6 +243,15 @@ export interface CreateServerOptions {
    * this at a seeded temp DB so the routes don't read the live broker cache.
    */
   filterStateDbPath?: string;
+  /**
+   * CTL-896 (SHELL6): override for the local daemon-health reader that feeds the
+   * footer health dot in the nav-signal projection (/api/nav, /api/nav/stream).
+   * Production lazily resolves the local node's last `node.heartbeat` (recovery
+   * .readClusterHeartbeats) and classifies it via node-liveness — the single-host
+   * identity no-op (the one local daemon's own heartbeat IS the health). Tests
+   * inject a deterministic status so the routes don't read the live event log.
+   */
+  daemonHealthReader?: (() => DaemonHealth | Promise<DaemonHealth>) | null;
   terminal?: boolean;
   renderOptions?: RenderOptions;
   commsReader?: CommsReader | null;
@@ -584,6 +599,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     commsReader: commsReaderOpt,
     webhookConfig,
     linearWebhookConfig,
+    daemonHealthReader: daemonHealthReaderOpt,
   } = opts;
 
   const buildOpts: BuildSnapshotOptions = { dbPath, runsDir };
@@ -866,6 +882,70 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // (/api/board/stream) — replaces per-tab polling of /api/board. Subscriber-
   // gated, so it does zero work when no board tab is open.
   const boardSnapshot = createBoardSnapshotManager();
+
+  // CTL-896 (SHELL6): the local daemon-health reader for the footer health dot.
+  //
+  // SINGLE-HOST IDENTITY NO-OP: the read-model classifies the ONE local daemon's
+  // own `node.heartbeat` freshness (live/degraded/offline → healthy/degraded/
+  // offline). The heavy execution-core deps (recovery.readClusterHeartbeats reads
+  // the local event log; config.getHostName names the local node) are imported
+  // LAZILY via computed specifiers — the same dependency-hygiene guard cluster-
+  // view.mjs uses so esbuild can't pull pino/bun:sqlite into any browser bundle —
+  // and resolved ONCE under Bun. Every step is best-effort: an import or read
+  // failure degrades to "offline" rather than throwing out of a nav request
+  // (the read-model never fabricates health for a daemon it cannot hear).
+  let daemonDepsPromise: Promise<{
+    readClusterHeartbeats: (opts: { logPath?: string }) => Record<string, string>;
+    getHostName: () => string;
+    deriveDaemonHealth: typeof import("./lib/nav-signal.mjs").deriveDaemonHealth;
+  } | null> | null = null;
+  const loadDaemonDeps = () => {
+    if (!daemonDepsPromise) {
+      daemonDepsPromise = (async () => {
+        try {
+          const recoveryMod = ["..", "execution-core", "recovery.mjs"].join("/");
+          const configMod = ["..", "execution-core", "config.mjs"].join("/");
+          const [recovery, config, navSignal] = await Promise.all([
+            import(recoveryMod),
+            import(configMod),
+            import("./lib/nav-signal.mjs"),
+          ]);
+          return {
+            readClusterHeartbeats: recovery.readClusterHeartbeats,
+            getHostName: config.getHostName,
+            deriveDaemonHealth: navSignal.deriveDaemonHealth,
+          };
+        } catch {
+          return null; // execution-core unavailable → degrade to offline
+        }
+      })();
+    }
+    return daemonDepsPromise;
+  };
+  const productionDaemonHealth = async (): Promise<DaemonHealth> => {
+    try {
+      const deps = await loadDaemonDeps();
+      if (!deps) return "offline";
+      // Let recovery.readClusterHeartbeats resolve the canonical current-month
+      // event-log path itself (config.getEventLogPath, UTC YYYY-MM) so the read
+      // path matches exactly what the daemon writes — no format drift here.
+      const lastSeen = deps.readClusterHeartbeats({});
+      return deps.deriveDaemonHealth(lastSeen, deps.getHostName());
+    } catch {
+      return "offline";
+    }
+  };
+  const readDaemonHealth: () => Promise<DaemonHealth> =
+    daemonHealthReaderOpt != null
+      ? async () => daemonHealthReaderOpt()
+      : productionDaemonHealth;
+
+  // assembleNavSignal — project the four nav signals off the board snapshot the
+  // read-model already computed, layering the local daemon health. One board read
+  // (the shared, reactively-cached snapshot) + one heartbeat classify; NO
+  // synchronous per-request scan of the source signal files.
+  const assembleNavSignal = async (board: BoardPayload): Promise<NavSignal> =>
+    deriveNavSignal(board, { daemon: await readDaemonHealth() });
 
   const unsubscribers: Array<() => void> = [];
   for (const eventType of BUS_BROADCAST_EVENTS) {
@@ -2415,6 +2495,73 @@ export function createServer(opts: CreateServerOptions): BunServer {
                 send(controller, await boardSnapshot.getLatest());
               } catch (err) {
                 console.error(`[server] board stream initial snapshot failed:`, err);
+              }
+            },
+            cancel() {
+              closed = true;
+              unsubscribe?.();
+              unsubscribe = null;
+            },
+          });
+          return new Response(stream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+              "Access-Control-Allow-Origin": "*",
+            },
+          });
+        }
+
+        // CTL-896 (SHELL6): the nav-signal projection — worker count, queue depth,
+        // board anomaly, and the daemon-health dot — as a single one-shot read for
+        // the warm paint + the SSE reconcile. Derived off the SAME shared board
+        // snapshot the board endpoints serve plus the local daemon health; NEVER a
+        // synchronous per-request scan of the source signal files.
+        if (url.pathname === "/api/nav") {
+          return Response.json(
+            await assembleNavSignal(await boardSnapshot.getLatest()),
+          );
+        }
+
+        // CTL-896 (SHELL6): SSE push of the nav signal. The rail opens ONE of these
+        // and receives a `nav` event on connect and on every reactive board
+        // recompute — the live badges update without a page reload and WITHOUT
+        // per-tab polling of the source files (Gherkin: "Live without thrash").
+        if (url.pathname === "/api/nav/stream") {
+          let unsubscribe: (() => void) | null = null;
+          let closed = false;
+          const sendNav = (
+            controller: ReadableStreamDefaultController<Uint8Array>,
+            signal: NavSignal,
+          ) => {
+            if (closed) return;
+            try {
+              controller.enqueue(
+                encoder.encode(`event: nav\ndata: ${JSON.stringify(signal)}\n\n`),
+              );
+            } catch {
+              unsubscribe?.();
+              unsubscribe = null;
+            }
+          };
+          const stream = new ReadableStream<Uint8Array>({
+            async start(controller) {
+              // subscribe first so no recompute is missed between bootstrap +
+              // subscribe; each board frame is projected into a nav signal (the
+              // daemon health is re-read per frame so the dot tracks heartbeats).
+              unsubscribe = boardSnapshot.subscribe((snap) => {
+                void assembleNavSignal(snap).then((signal) =>
+                  sendNav(controller, signal),
+                );
+              });
+              try {
+                sendNav(
+                  controller,
+                  await assembleNavSignal(await boardSnapshot.getLatest()),
+                );
+              } catch (err) {
+                console.error(`[server] nav stream initial signal failed:`, err);
               }
             },
             cancel() {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
@@ -17,6 +17,8 @@ import {
 import { cn } from "@/lib/utils";
 import { useSurface, type Surface } from "@/lib/surface";
 import { useTheme } from "@/lib/theme";
+import { useNavSignal } from "@/hooks/use-nav-signal";
+import { daemonDotClass, daemonLabel } from "@/lib/nav-signal";
 import { CatalystLogo } from "@/components/catalyst-logo";
 import {
   Collapsible,
@@ -45,42 +47,35 @@ import {
 } from "@/components/ui/sidebar";
 
 // CTL-891 / SHELL1 — the OPERATE/OBSERVE left nav, ported from the prototype
-// `mockups/home-proto/src/components/AppSidebar.tsx`. Live badges + status dots
-// are MOCK now (per the ticket: "lands the frame and the OPERATE nav shell with
-// mock/placeholder badges"). Wire to the unified event log
-// (~/catalyst/events/YYYY-MM.jsonl) the HUD already reads in a later SHELL
-// ticket — that same stream feeds worker count, queue depth, and the Board
-// anomaly dot. The workspace switcher is a later SHELL slot.
+// `mockups/home-proto/src/components/AppSidebar.tsx`.
 //
 // CTL-893 / SHELL3 — gives the rail its final shape: the brand header now uses
 // the Catalyst chevron mark (`CatalystLogo`, ported from `assets/brand-v2/
 // mark.svg`, inherits currentColor so it recolors per theme) with a wordmark
 // that hides on icon-collapse, and the footer gains a real calm-dark ⇄ warm-light
-// theme toggle wired to `@/lib/theme`'s `useTheme()` next to Settings + the
-// (still MOCK) daemon-health dot.
+// theme toggle wired to `@/lib/theme`'s `useTheme()` next to Settings.
+//
+// CTL-896 / SHELL6 — the live signal that is the whole payoff of a vertical rail.
+// The Workers active-count badge, the Queue depth badge, the Board anomaly dot,
+// and the footer daemon-health dot are NO LONGER MOCK: they are fed by the read-
+// model's dedicated nav-signal projection over SSE (`useNavSignal` →
+// `/api/nav/stream`), the SAME push model the board uses — never a per-tab tail
+// of the source files. The OPERATE array below carries only the static IA
+// (surface/label/icon); the badge/dot for each item is DERIVED per-render from
+// the live signal in this component. The workspace switcher is a later SHELL slot.
 
 // ── OPERATE nav — the touch-it-every-minute tier ─────────────────────────────
 type OperateItem = {
   surface: Surface;
   label: string;
   icon: typeof InboxIcon;
-  /** Numeric badge (active worker count / queue depth). MOCK for SHELL1. */
-  badge?: number;
-  /** A small status dot overlaying the icon — survives the icon-collapse. MOCK. */
-  dot?: "live" | "anomaly";
 };
 
 const OPERATE: OperateItem[] = [
   { surface: "home", label: "Home", icon: InboxIcon },
-  { surface: "board", label: "Board", icon: LayoutGridIcon, dot: "anomaly" },
-  {
-    surface: "workers",
-    label: "Workers",
-    icon: UsersIcon,
-    badge: 4,
-    dot: "live",
-  },
-  { surface: "queue", label: "Queue", icon: ListOrderedIcon, badge: 7 },
+  { surface: "board", label: "Board", icon: LayoutGridIcon },
+  { surface: "workers", label: "Workers", icon: UsersIcon },
+  { surface: "queue", label: "Queue", icon: ListOrderedIcon },
 ];
 
 // ── OBSERVE — the "go deeper" tier, ships now, items land over time ───────────
@@ -109,10 +104,31 @@ export function AppSidebar() {
   const { setOpenMobile, isMobile } = useSidebar();
   const { theme, toggle: toggleTheme } = useTheme();
   const [observeOpen, setObserveOpen] = useState(false);
+  // CTL-896 / SHELL6 — the live nav signal off the read-model SSE projection.
+  // null until the first frame lands; the badges/dots simply don't render until
+  // then (no mock placeholder), then go live and update without a page reload.
+  const nav = useNavSignal();
 
   function go(s: Surface) {
     setSurface(s);
     if (isMobile) setOpenMobile(false);
+  }
+
+  // Derive the live badge + dot for an OPERATE item from the nav signal. Workers
+  // shows the active count + an emerald live dot when any worker is running;
+  // Queue shows its depth; Board shows an amber anomaly dot when the read-model
+  // reports a blocked/needs-human/stuck anomaly. Home carries no live signal.
+  function liveBadge(s: Surface): number | null {
+    if (!nav) return null;
+    if (s === "workers") return nav.workerCount;
+    if (s === "queue") return nav.queueDepth;
+    return null;
+  }
+  function liveDot(s: Surface): "live" | "anomaly" | null {
+    if (!nav) return null;
+    if (s === "workers") return nav.workerCount > 0 ? "live" : null;
+    if (s === "board") return nav.anomaly ? "anomaly" : null;
+    return null;
   }
 
   return (
@@ -148,24 +164,28 @@ export function AppSidebar() {
           <SidebarGroupLabel>Operate</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {OPERATE.map((item) => (
-                <SidebarMenuItem key={item.surface}>
-                  <SidebarMenuButton
-                    isActive={surface === item.surface}
-                    tooltip={item.label}
-                    onClick={() => go(item.surface)}
-                  >
-                    <span className="relative flex items-center justify-center">
-                      <item.icon />
-                      {item.dot && <StatusDot kind={item.dot} />}
-                    </span>
-                    <span>{item.label}</span>
-                  </SidebarMenuButton>
-                  {item.badge != null && (
-                    <SidebarMenuBadge>{item.badge}</SidebarMenuBadge>
-                  )}
-                </SidebarMenuItem>
-              ))}
+              {OPERATE.map((item) => {
+                const dot = liveDot(item.surface);
+                const badge = liveBadge(item.surface);
+                return (
+                  <SidebarMenuItem key={item.surface}>
+                    <SidebarMenuButton
+                      isActive={surface === item.surface}
+                      tooltip={item.label}
+                      onClick={() => go(item.surface)}
+                    >
+                      <span className="relative flex items-center justify-center">
+                        <item.icon />
+                        {dot && <StatusDot kind={dot} />}
+                      </span>
+                      <span>{item.label}</span>
+                    </SidebarMenuButton>
+                    {badge != null && (
+                      <SidebarMenuBadge>{badge}</SidebarMenuBadge>
+                    )}
+                  </SidebarMenuItem>
+                );
+              })}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
@@ -222,23 +242,34 @@ export function AppSidebar() {
               <SettingsIcon />
               <span>Settings</span>
             </SidebarMenuButton>
-            {/* daemon-health dot — emerald = daemon healthy. MOCK for SHELL1;
-                wire to the event stream (~/catalyst/events/YYYY-MM.jsonl). */}
+            {/* CTL-896 / SHELL6 — daemon-health dot wired to the read-model's
+                local-node liveness (the single-host identity no-op: the one local
+                daemon's own node.heartbeat freshness). Emerald = healthy, amber =
+                degraded, red = offline. The cyan #5be0ff live-signal color is
+                RESERVED and deliberately not used here. Until the first nav frame
+                lands `nav` is null → an unknown (muted) dot, never a fake green. */}
             <SidebarMenuBadge>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
                     type="button"
-                    aria-label="Daemon healthy"
+                    aria-label={
+                      nav ? daemonLabel(nav.daemon) : "Daemon health unknown"
+                    }
                     className="flex size-5 cursor-default items-center justify-center"
                   >
                     <span
                       aria-hidden
-                      className="size-2 rounded-full bg-emerald-500"
+                      className={cn(
+                        "size-2 rounded-full",
+                        nav ? daemonDotClass(nav.daemon) : "bg-muted-foreground/40",
+                      )}
                     />
                   </button>
                 </TooltipTrigger>
-                <TooltipContent side="right">Daemon healthy</TooltipContent>
+                <TooltipContent side="right">
+                  {nav ? daemonLabel(nav.daemon) : "Daemon health unknown"}
+                </TooltipContent>
               </Tooltip>
             </SidebarMenuBadge>
           </SidebarMenuItem>

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-nav-signal.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-nav-signal.ts
@@ -1,0 +1,110 @@
+// use-nav-signal.ts — subscribe the rail to the read-model's nav-signal
+// projection (CTL-896 / SHELL6). The live badges/dots ride the SAME read-model
+// SSE push model the board uses: ONE EventSource over `/api/nav/stream` that
+// receives a `nav` frame on connect and on every reactive board recompute — the
+// badges update as workers start/finish and as the queue/anomaly/daemon change,
+// WITHOUT a page reload and WITHOUT per-tab polling of the source files (Gherkin
+// "Live without thrash").
+//
+// It mirrors board-client.ts's direct-SSE fallback: under standalone `bun run
+// dev` the SSE 404s, so a capped-backoff reconcile poll against `/api/nav` is the
+// data source instead — the badges still go live. The nav signal is tiny (four
+// fields), so a per-tab EventSource is fine; no SharedWorker is needed.
+import { useEffect, useState } from "react";
+import { decodeNavSignalFrame, isNavSignal, type NavSignal } from "../lib/nav-signal";
+
+const INITIAL_BACKOFF_MS = 500;
+const MAX_BACKOFF_MS = 15_000;
+
+/**
+ * Subscribe to the nav-signal projection for the lifetime of the calling
+ * component. Returns the latest signal (null until the first frame lands).
+ */
+export function useNavSignal(): NavSignal | null {
+  const [signal, setSignal] = useState<NavSignal | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    let es: EventSource | null = null;
+    let backoff = INITIAL_BACKOFF_MS;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let controller: AbortController | undefined;
+
+    const apply = (next: NavSignal) => {
+      if (alive) setSignal(next);
+    };
+
+    // Returns true when a fresh signal was applied (drives connected/reconnecting).
+    const reconcile = async (): Promise<boolean> => {
+      if (!alive) return false;
+      controller?.abort();
+      controller = new AbortController();
+      try {
+        const r = await fetch("/api/nav", { signal: controller.signal });
+        if (r.ok) {
+          const body: unknown = await r.json();
+          if (isNavSignal(body)) {
+            apply(body);
+            return true;
+          }
+        }
+      } catch {
+        /* offline — the backoff loop retries */
+      }
+      return false;
+    };
+
+    const scheduleReconnect = () => {
+      if (!alive) return;
+      const delay = backoff;
+      backoff = Math.min(MAX_BACKOFF_MS, backoff * 2);
+      reconnectTimer = setTimeout(connect, delay);
+      void reconcile();
+    };
+
+    function connect() {
+      if (!alive) return;
+      try {
+        es = new EventSource("/api/nav/stream");
+      } catch {
+        scheduleReconnect();
+        return;
+      }
+      es.addEventListener("nav", (ev) => {
+        backoff = INITIAL_BACKOFF_MS; // reset on a real frame
+        const next = decodeNavSignalFrame((ev as MessageEvent).data as string);
+        if (next) apply(next);
+      });
+      es.onerror = () => {
+        try {
+          es?.close();
+        } catch {
+          /* noop */
+        }
+        es = null;
+        scheduleReconnect();
+      };
+    }
+
+    connect();
+    // Re-pull a fresh signal when the tab regains focus (matches the board hook).
+    const onVis = () => {
+      if (!document.hidden) void reconcile();
+    };
+    document.addEventListener("visibilitychange", onVis);
+
+    return () => {
+      alive = false;
+      try {
+        es?.close();
+      } catch {
+        /* noop */
+      }
+      clearTimeout(reconnectTimer);
+      controller?.abort();
+      document.removeEventListener("visibilitychange", onVis);
+    };
+  }, []);
+
+  return signal;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/nav-signal.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/nav-signal.ts
@@ -1,0 +1,69 @@
+// nav-signal.ts — the UI contract for the read-model's nav-signal projection
+// (CTL-896 / SHELL6). The rail's live badges/dots — Workers active count, Queue
+// depth, the Board anomaly dot, and the footer daemon-health dot — are fed by the
+// server's `/api/nav` + `/api/nav/stream` projection (lib/nav-signal.mjs), NOT by
+// hardcoded mocks and NOT by a per-tab tail of the source files.
+//
+// This module is the browser-side mirror of the server's `NavSignal` shape plus a
+// structural decode guard, kept deliberately runtime-free + pure so it is unit-
+// testable without a DOM (the same pattern lib/surface.ts and the read-model
+// client contract follow). The subscription lifecycle lives in
+// hooks/use-nav-signal.ts; the badge/dot wiring lives in components/app-sidebar.tsx.
+
+/** The footer daemon-health vocabulary (mirrors the server's nav-signal.mjs). */
+export type DaemonHealth = "healthy" | "degraded" | "offline";
+
+/** The four nav signals the rail renders — the server's NavSignal wire shape. */
+export interface NavSignal {
+  /** Active execution-core workers — the Workers nav badge. */
+  workerCount: number;
+  /** Tickets waiting in the queue — the Queue nav badge. */
+  queueDepth: number;
+  /** A board anomaly exists (blocked/needs-human or a stuck worker) — the Board amber dot. */
+  anomaly: boolean;
+  /** The local daemon's liveness — the footer health dot (emerald/amber/red). */
+  daemon: DaemonHealth;
+  /** The source snapshot's generatedAt (passthrough for dedupe/debug). */
+  generatedAt: string;
+}
+
+const DAEMON_VALUES: readonly DaemonHealth[] = ["healthy", "degraded", "offline"];
+
+/** Structural guard: keep a truncated/garbage SSE frame from reaching the rail. */
+export function isNavSignal(value: unknown): value is NavSignal {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.workerCount === "number" &&
+    typeof v.queueDepth === "number" &&
+    typeof v.anomaly === "boolean" &&
+    typeof v.daemon === "string" &&
+    (DAEMON_VALUES as readonly string[]).includes(v.daemon) &&
+    typeof v.generatedAt === "string"
+  );
+}
+
+/** Decode an SSE `nav` frame's data; returns null (skipped) on garbage. */
+export function decodeNavSignalFrame(data: string): NavSignal | null {
+  try {
+    const parsed: unknown = JSON.parse(data);
+    return isNavSignal(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The Tailwind dot color for a daemon-health status — emerald/amber/red. The
+ *  cyan #5be0ff live-signal color is RESERVED and deliberately NOT used here. */
+export function daemonDotClass(daemon: DaemonHealth): string {
+  if (daemon === "healthy") return "bg-emerald-500";
+  if (daemon === "degraded") return "bg-amber-500";
+  return "bg-red-500";
+}
+
+/** The human label for a daemon-health status (tooltip + aria-label). */
+export function daemonLabel(daemon: DaemonHealth): string {
+  if (daemon === "healthy") return "Daemon healthy";
+  if (daemon === "degraded") return "Daemon degraded";
+  return "Daemon offline";
+}


### PR DESCRIPTION
## CTL-896 / SHELL6 — Live nav badges/dots from the read-model

Wires the left rail's per-item live signal to the cache-backed read-model instead of the hardcoded mocks the SHELL1/SHELL3 prototype left as a seam (`badge: 4`/`badge: 7`, the Board anomaly dot, the footer hardcoded `bg-emerald-500` daemon dot).

### What changed
- **`lib/nav-signal.mjs`** (new, pure + injectable) — `deriveNavSignal(board, {daemon|liveness})` projects worker count / queue depth / anomaly off the read-model's `BoardPayload`; `deriveDaemonHealth(lastSeen, localHost)` classifies the local daemon's heartbeat via `node-liveness.mjs`. No synchronous per-request scan.
- **`server.ts`** — new `GET /api/nav` (one-shot) + `GET /api/nav/stream` (SSE `nav` frames), layered onto the SAME reactive `boardSnapshot` the board SSE pushes; an injectable `daemonHealthReader` option (production lazily imports `recovery.readClusterHeartbeats` + `config.getHostName` via computed specifiers, degrades to `offline` on failure).
- **`ui/src/lib/nav-signal.ts`** (new) — UI type + decode guard + emerald/amber/red daemon color mapping (cyan `#5be0ff` stays RESERVED for the live signal).
- **`ui/src/hooks/use-nav-signal.ts`** (new) — one `EventSource` over `/api/nav/stream` with a `/api/nav` reconcile fallback (so badges still go live under standalone `bun run dev`).
- **`ui/src/components/app-sidebar.tsx`** — every badge/dot now derived per-render from the live signal.

### Gherkin acceptance mapping
| Scenario | Status | How |
|---|---|---|
| Worker count badge reflects live sessions | **satisfied** | Workers badge = `nav.workerCount` (= `board.workers.length`); updates per SSE frame as workers start/finish, no reload. Covered by `nav-signal.test.ts` + `nav-signal-ui.test.ts`. |
| Queue depth badge reflects waiting work | **satisfied** | Queue badge = `nav.queueDepth` (= `board.queue.length`). |
| Board anomaly dot | **satisfied** | Amber dot when `nav.anomaly` (a ticket `held === "blocked"` / needs-human, or a stuck worker); clears on the frame the block resolves. |
| Daemon-health dot | **satisfied** | Footer dot colored by `nav.daemon` (healthy→emerald / degraded→amber / offline→red), from the local node heartbeat liveness. Muted until the first frame — never a fake green. |
| Live without thrash | **satisfied** | Updates arrive over the read-model SSE stream (`/api/nav/stream`, same push model as `/api/board/stream`), never per-tab polling of the source files. |

### Single-node descope (per operator constraint)
Daemon health is the **single-host identity no-op**: `getClusterHosts()` returns `[localHostName]` when `hosts.json` is absent, so the read-model classifies the ONE local daemon's own `node.heartbeat` freshness — exactly one node, zero cross-node transport. No multi-node fleet-health roll-up was built (that is a later cluster concern, CTL-863/864/873); the N>1 branch is satisfied by the identity no-op.

### Validation
- `bunx tsc --noEmit` clean for the server package and for every touched UI file (the only remaining UI tsc error is `kpi-strip.tsx`'s `OrchestratorStats.abandoned`, byte-identical to `origin/main` — pre-existing, not from this diff).
- `bun test` green: `nav-signal.test.ts` (20), `nav-signal-endpoints.test.ts` (4), `nav-signal-ui.test.ts` (11); plus `board-snapshot`, `node-liveness`, `cluster-view`, `read-model`, `server`, `stop-worker-endpoint`, `ec-worker-stream-endpoints` suites pass with no regression.
- `bun run build` (vite) succeeds. The one `app-shell.test.ts` failure (`Shell.tsx` `[` literal) is pre-existing on `origin/main` (the SHELL4 refactor moved the literal into `lib/sidebar-collapse.ts`); unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)