### PR TITLE
fix(dev): CTL-929 exempt zero-dep tickets from the triage→research read-failure fail-safe hold

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -237,6 +237,23 @@ function readTriageDependencies(orchDir, ticket) {
   return out;
 }
 
+// CTL-929: does triage.json EXPLICITLY declare a zero-dependency picture?
+// A triaged-waiting candidate whose durable signal carries `dependencies: []`
+// has a fully-known, unblocked dependency picture from disk — it needs no live
+// Linear read to confirm it. Contrast readTriageDependencies, which returns []
+// for BOTH an explicit empty array AND a missing/unreadable file; here we must
+// distinguish them so a genuinely-UNKNOWN picture (missing/malformed file, or a
+// non-array `dependencies`) still fails SAFE (held until a read succeeds).
+// Never throws.
+function triageDeclaresZeroDeps(orchDir, ticket) {
+  try {
+    const raw = JSON.parse(readFileSync(join(orchDir, "workers", ticket, "triage.json"), "utf8"));
+    return Array.isArray(raw?.dependencies) && raw.dependencies.length === 0;
+  } catch {
+    return false; // missing / unreadable / malformed → unknown → fail safe
+  }
+}
+
 // Missing or unreadable → {priority: 5, createdAt: null} (safe lowest-band
 // default). Never throws.
 export function readWorkerPriority(orchDir, ticket) {
@@ -2405,7 +2422,15 @@ export function schedulerTick(
       for (const ticket of triagedWaiting) {
         const rel = relByTicket.get(ticket) ?? null;
         const { priority, createdAt } = readWorkerPriority(orchDir, ticket);
-        if (rel === null) readFailedTickets.add(ticket);
+        if (rel === null && !triageDeclaresZeroDeps(orchDir, ticket)) {
+          // CTL-929: a transient Linear read failure (commonly linearBreaker open
+          // from a 429) must NOT strand a ticket whose dependency picture is already
+          // known-empty from the durable triage.json signal. Only apply the fail-safe
+          // hold when the picture is genuinely unknown — i.e. the ticket may have
+          // declared blockers whose state we cannot confirm without the read, OR
+          // triage.json is missing/malformed.
+          readFailedTickets.add(ticket);
+        }
         // missing rel → fail-safe: non-terminal sentinel state, no edges, no labels.
         const stateName = rel?.state ?? UNFETCHED_BLOCKER_STATE;
         labelsByTicket.set(ticket, rel?.labels ?? []);

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -6436,6 +6436,117 @@ describe("CTL-755: admission gate", () => {
     expect(held.events[0].reason).not.toBe("blocked-by-open-dependency");
   });
 
+  // ── CTL-929: zero-dependency tickets must not strand on a failed read ──
+  describe("CTL-929: explicit zero-dep tickets are exempt from the read-failure fail-safe", () => {
+    afterEach(() => __resetForTests());
+
+    function writeTriage(ticket, obj) {
+      writeFileSync(join(orchDir, "workers", ticket, "triage.json"), JSON.stringify(obj));
+    }
+
+    test("null read + triage.json dependencies:[] + free slot → dispatched to research (NOT held)", () => {
+      writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+      writeSignal("CTL-7", "triage", "done");
+      writeTriage("CTL-7", { ticket: "CTL-7", classification: "bug", dependencies: [] });
+      const dispatch = fakeDispatch();
+      const { ws } = labelSpy();
+      const held = heldSpy();
+      const r = schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch,
+        writeStatus: ws,
+        verifyDispatched: verifyOk,
+        liveBackgroundCount: () => 0,
+        fetchBatch: mkBatch(() => null),
+        appendPhaseAdvanceHeldEvent: held.fn,
+      });
+      expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "research" }]);
+      expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
+      expect(held.events).toEqual([]);
+    });
+
+    test("null read + triage.json dependencies:[] + NO free slot → held 'awaiting-capacity-or-priority' (not 'dependency-state-unknown')", () => {
+      writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+      writeSignal("CTL-7", "triage", "done");
+      writeTriage("CTL-7", { ticket: "CTL-7", dependencies: [] });
+      const dispatch = fakeDispatch();
+      const { ws } = labelSpy();
+      const held = heldSpy();
+      const r = schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch,
+        writeStatus: ws,
+        verifyDispatched: verifyOk,
+        liveBackgroundCount: () => 1,
+        fetchBatch: mkBatch(() => null),
+        appendPhaseAdvanceHeldEvent: held.fn,
+      });
+      expect(dispatch.calls).toEqual([]);
+      expect(r.advanced).toEqual([]);
+      expect(held.events).toHaveLength(1);
+      expect(held.events[0]).toMatchObject({ ticket: "CTL-7", reason: "awaiting-capacity-or-priority" });
+    });
+
+    test("null read + triage.json with a DECLARED dependency → still fail-safe held 'dependency-state-unknown'", () => {
+      writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+      writeSignal("CTL-7", "triage", "done");
+      writeTriage("CTL-7", { ticket: "CTL-7", dependencies: ["CTL-99"] });
+      const dispatch = fakeDispatch();
+      const { ws } = labelSpy();
+      const held = heldSpy();
+      const r = schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch,
+        writeStatus: ws,
+        verifyDispatched: verifyOk,
+        liveBackgroundCount: () => 0,
+        fetchBatch: mkBatch(() => null),
+        appendPhaseAdvanceHeldEvent: held.fn,
+      });
+      expect(dispatch.calls).toEqual([]);
+      expect(r.advanced).toEqual([]);
+      expect(held.events[0]).toMatchObject({ ticket: "CTL-7", reason: "dependency-state-unknown" });
+    });
+
+    test("null read + NO triage.json → still fail-safe held (unknown picture, conservative default)", () => {
+      writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+      writeSignal("CTL-7", "triage", "done");
+      const dispatch = fakeDispatch();
+      const { ws } = labelSpy();
+      const held = heldSpy();
+      const r = schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch,
+        writeStatus: ws,
+        verifyDispatched: verifyOk,
+        liveBackgroundCount: () => 0,
+        fetchBatch: mkBatch(() => null),
+        appendPhaseAdvanceHeldEvent: held.fn,
+      });
+      expect(dispatch.calls).toEqual([]);
+      expect(held.events[0]).toMatchObject({ ticket: "CTL-7", reason: "dependency-state-unknown" });
+    });
+
+    test("idempotent: a zero-dep ticket already advanced (research signal present) is not re-dispatched", () => {
+      writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+      writeSignal("CTL-7", "triage", "done");
+      writeSignal("CTL-7", "research", "running");
+      writeTriage("CTL-7", { ticket: "CTL-7", dependencies: [] });
+      const dispatch = fakeDispatch();
+      const { ws } = labelSpy();
+      const r = schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch,
+        writeStatus: ws,
+        verifyDispatched: verifyOk,
+        liveBackgroundCount: () => 0,
+        fetchBatch: mkBatch(() => null),
+      });
+      expect(dispatch.calls).toEqual([]);
+      expect(r.advanced).toEqual([]);
+    });
+  });
+
   // ── STEP E: dep persistence (scheduler-side) ──
   //
   // A writeStatus spy that ALSO records applyBlockedByRelation (the durable


### PR DESCRIPTION
## What

Stops triage-complete **zero-dependency** tickets stranding at `triage/done` when the process-wide `linearBreaker` is open. STEP A's admission gate hydrates dependency state via a live Linear read; a single 429 opens the breaker → the read returns null → **all** candidates were held `dependency-state-unknown`, even tickets whose durable `triage.json` already declares `dependencies: []`.

Adds a tri-state helper `triageDeclaresZeroDeps()` and exempts *explicitly* zero-dep tickets from the read-failure hold. Fail-safe preserved for declared-dep tickets and missing/malformed `triage.json`. +5 TDD tests covering the full truth table.

## Why fast-tracked

The daemon's own pipeline produced this fix (vetted research + plan + diff), but its `review` phase wedged (~80min looping on a 137-line diff, no auto-escalation since review isn't progress-gated). `verify` already passed the full gate (`phase.verify.complete.CTL-929`). Diff reviewed against the plan — exact match, no reward-hacking. Merging unblocks ~8 stranded tickets on the live board.

## Follow-up

Durable hardening (architecture proposal P4): anchor the exemption on the **intersection** of empty durable `blocked_by` edge-set AND zero-dep scrape, not the scrape alone (avoids the CTL-878 projection trap). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)