### PR TITLE
feat(dev): HOME6 calm all-clear empty state (CTL-904)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/home-inbox.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-inbox.test.ts
@@ -24,6 +24,11 @@ import {
   isNeedsYouSection,
   rowDurationAnchor,
   rowDurationMs,
+  isAllClear,
+  allClearReassurance,
+  shippedWhileAwaySummary,
+  ALL_CLEAR_HEADLINE,
+  type InboxCounts,
   type InboxRow,
 } from "../ui/src/board/home-inbox";
 import type { BoardPayload, BoardTicket } from "../ui/src/board/types";
@@ -359,5 +364,87 @@ describe("rowDurationMs — elapsed since the durable anchor, honest about absen
   it("a done row never reports a live duration even with a phase timestamp", () => {
     const row = mkRow("done", { currentPhaseSince: "2026-06-09T08:00:00Z" });
     expect(rowDurationMs(row, now)).toBeNull();
+  });
+});
+
+// ── CTL-904 / HOME6: the calm all-clear empty state (the relief payoff) ───────
+const counts = (over: Partial<InboxCounts> = {}): InboxCounts => ({
+  blocked: 0,
+  waiting: 0,
+  running: 0,
+  done: 0,
+  needsYou: 0,
+  ...over,
+});
+
+describe("isAllClear — the all-clear gate keys on read-model emptiness (CTL-904)", () => {
+  it("is all-clear when nothing needs you (zero blocked + zero waiting)", () => {
+    expect(isAllClear(counts({ running: 5, done: 3, needsYou: 0 }))).toBe(true);
+  });
+
+  it("is all-clear even with agents still running on their own", () => {
+    expect(isAllClear(counts({ running: 4, needsYou: 0 }))).toBe(true);
+  });
+
+  it("is all-clear on a wholly empty inbox", () => {
+    expect(isAllClear(counts())).toBe(true);
+  });
+
+  it("is NOT all-clear when a single item is blocked", () => {
+    expect(isAllClear(counts({ blocked: 1, needsYou: 1 }))).toBe(false);
+  });
+
+  it("is NOT all-clear when a single item is waiting", () => {
+    expect(isAllClear(counts({ waiting: 1, needsYou: 1 }))).toBe(false);
+  });
+
+  it("keys on needsYou, NOT on done/running activity (the relief is about you)", () => {
+    // Lots of running + shipped work is STILL all-clear — none of it needs you.
+    expect(isAllClear(counts({ running: 9, done: 7, needsYou: 0 }))).toBe(true);
+  });
+});
+
+describe("allClearReassurance — agents run on their own, check back whenever (CTL-904)", () => {
+  it("names how many agents are running on their own and invites checking back", () => {
+    expect(allClearReassurance(counts({ running: 4, needsYou: 0 }))).toBe(
+      "4 agents are running on their own — check back whenever.",
+    );
+  });
+
+  it("uses singular grammar for one running agent", () => {
+    expect(allClearReassurance(counts({ running: 1, needsYou: 0 }))).toBe(
+      "1 agent is running on its own — check back whenever.",
+    );
+  });
+
+  it("still reassures (never a bare blank) when nothing is in flight", () => {
+    const s = allClearReassurance(counts());
+    expect(s).toContain("running on their own");
+    expect(s).toContain("check back whenever");
+  });
+});
+
+describe("shippedWhileAwaySummary — N shipped while you were away (CTL-904)", () => {
+  it('reads "N shipped while you were away" when work shipped', () => {
+    expect(shippedWhileAwaySummary(counts({ done: 3, needsYou: 0 }))).toBe(
+      "3 shipped while you were away",
+    );
+  });
+
+  it("uses the same phrasing for a single shipped item", () => {
+    expect(shippedWhileAwaySummary(counts({ done: 1, needsYou: 0 }))).toBe(
+      "1 shipped while you were away",
+    );
+  });
+
+  it("returns null when nothing shipped (no misleading '0 shipped')", () => {
+    expect(shippedWhileAwaySummary(counts({ done: 0, needsYou: 0 }))).toBeNull();
+  });
+});
+
+describe("ALL_CLEAR_HEADLINE — everything-handled, never an alarm count (CTL-904)", () => {
+  it("reads as everything-handled rather than a KPI/alarm count", () => {
+    expect(ALL_CLEAR_HEADLINE).toBe("All clear — nothing needs you right now.");
+    expect(ALL_CLEAR_HEADLINE).not.toMatch(/\d/); // no numbers ⇒ no alarm counts
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
@@ -28,6 +28,7 @@ const homeSurfaceSrc = read("components/home/home-surface.tsx");
 const inboxRowSrc = read("components/home/inbox-row.tsx");
 const splitSrc = read("components/home/resizable-split.tsx");
 const useBoardSnapshotSrc = read("hooks/use-board-snapshot.ts");
+const allClearHeroSrc = read("components/home/all-clear-hero.tsx");
 
 function stripComments(src: string): string {
   return src
@@ -203,6 +204,62 @@ describe("HOME3 — 'Running on its own' is a collapsed reassurance count by def
   it("the surface ticks a `now` clock and passes it down to the rows", () => {
     expect(homeSurfaceSrc).toContain("setNow");
     expect(homeSurfaceSrc).toMatch(/now=\{now\}/);
+  });
+});
+
+// ── CTL-904 / HOME6: the calm all-clear empty state (the relief payoff) ───────
+const heroCode = stripComments(allClearHeroSrc);
+
+describe("all-clear empty state — the calm relief payoff (CTL-904)", () => {
+  // Scenario: All-clear hero when nothing needs you
+  it("HomeSurface gates the all-clear state on the read-model emptiness (isAllClear)", () => {
+    // The gate is the SAME read-model emptiness the inbox derives — NOT a mock
+    // toggle. isAllClear reads the derived counts (zero blocked + zero waiting).
+    expect(homeSurfaceSrc).toContain("isAllClear");
+    expect(homeSurfaceSrc).toContain("model.counts");
+  });
+
+  it("swaps the calm all-clear HERO into the reading pane (not a blank pane)", () => {
+    expect(homeSurfaceSrc).toContain("AllClearHero");
+    // The reading slot conditionally renders the hero vs. the per-row ReadingPane.
+    expect(homeSurfaceSrc).toMatch(/allClear\s*\?\s*<AllClearHero/);
+    // The hero is keyed by a stable data hook and is NOT an inert blank.
+    expect(allClearHeroSrc).toContain("data-all-clear-hero");
+    expect(allClearHeroSrc).toContain("All clear");
+  });
+
+  it('the list shows an "All clear" message with how many shipped while you were away', () => {
+    expect(homeSurfaceSrc).toContain("AllClearList");
+    expect(homeSurfaceSrc).toContain("data-all-clear-list");
+    // The shipped count flows from the derived counts, never a hardcoded number.
+    expect(homeSurfaceSrc).toContain("shippedWhileAwaySummary");
+  });
+
+  it("the header reads as everything-handled (no alarm count) in the all-clear state", () => {
+    // The all-clear header is the headline constant, NOT the alarm-count sentence.
+    expect(homeSurfaceSrc).toContain("ALL_CLEAR_HEADLINE");
+    expect(homeSurfaceSrc).toMatch(/allClear\s*\?\s*ALL_CLEAR_HEADLINE\s*:\s*calmHeaderSentence/);
+  });
+
+  // Scenario: All-clear still reassures about autonomous work
+  it("reassures that agents are running on their own (allClearReassurance)", () => {
+    expect(homeSurfaceSrc).toContain("allClearReassurance");
+    expect(allClearHeroSrc).toContain("allClearReassurance");
+  });
+
+  // Scenario: Reduced-motion users get the calm state without animation
+  it("the celebratory entrance collapses to instant under prefers-reduced-motion", () => {
+    // The entrance is a CSS fade; motion-reduce: collapses it to none (no library).
+    expect(heroCode).toContain("animate-fade-in");
+    expect(heroCode).toContain("motion-reduce:animate-none");
+    // The all-clear list entrance is honored the same way.
+    expect(stripComments(homeSurfaceSrc)).toContain("motion-reduce:animate-none");
+  });
+
+  it("the all-clear hero does NOT reach for Linear / a per-load fetch (read-model only)", () => {
+    expect(heroCode.toLowerCase()).not.toContain("linearis");
+    expect(heroCode).not.toMatch(/\bnew EventSource\b/);
+    expect(heroCode).not.toMatch(/\bfetch\(/);
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/home-inbox.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/home-inbox.ts
@@ -223,6 +223,55 @@ export function deriveInbox(payload: BoardPayload): InboxModel {
 }
 
 /**
+ * THE all-clear gate (CTL-904 / HOME6). The empty state is the relief payoff —
+ * designed as a feature, not a fallback — so it is keyed on the SAME read-model
+ * emptiness the rest of the inbox derives from: zero blocked + zero waiting (i.e.
+ * `needsYou === 0`). When this holds, NOTHING needs the operator, so Home swaps in
+ * the calm all-clear hero even while agents keep running on their own. PURE: reads
+ * only the already-derived counts, reaches for no network/Linear.
+ */
+export function isAllClear(counts: InboxCounts): boolean {
+  return counts.needsYou === 0;
+}
+
+/**
+ * The reassurance line shown in the all-clear hero (CTL-904 / HOME6). Names how
+ * many agents are still running on their own — the structural reassurance that
+ * makes the check-in operator exhale — and always closes with the "check back
+ * whenever" invitation. When nothing at all is in flight it still reassures (the
+ * agents are simply idle, not stalled), so the operator is never left with a bare
+ * blank pane.
+ */
+export function allClearReassurance(counts: InboxCounts): string {
+  if (counts.running > 0) {
+    const verb = counts.running === 1 ? "agent is" : "agents are";
+    const its = counts.running === 1 ? "its" : "their";
+    return `${counts.running} ${verb} running on ${its} own — check back whenever.`;
+  }
+  return "Agents are running on their own — check back whenever.";
+}
+
+/**
+ * The "N shipped while you were away" summary for the all-clear list (CTL-904 /
+ * HOME6). Reads the `done` count (the "Done while you were away" reassurance set
+ * the broker already folded into the snapshot). Returns null when nothing shipped,
+ * so the list shows the bare "All clear" headline without a misleading "0 shipped".
+ */
+export function shippedWhileAwaySummary(counts: InboxCounts): string | null {
+  if (counts.done <= 0) return null;
+  return `${counts.done} shipped while you were away`;
+}
+
+/**
+ * The all-clear list HEADLINE (CTL-904 / HOME6). When nothing needs the operator,
+ * the list header reads as everything-handled — "All clear" — rather than leading
+ * with an alarm count. This is intentionally SEPARATE from calmHeaderSentence (the
+ * normal one-sentence state-of-things header): the all-clear surface owns its own
+ * celebratory copy so the alarm-count sentence never leaks into the relief payoff.
+ */
+export const ALL_CLEAR_HEADLINE = "All clear — nothing needs you right now.";
+
+/**
  * The calm "state of things" header — ONE sentence, never a KPI grid (Direction A
  * non-negotiable #5). Reads e.g.:
  *   "4 running on their own · 2 need you · nothing on fire"

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/all-clear-hero.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/all-clear-hero.tsx
@@ -1,0 +1,44 @@
+// all-clear-hero.tsx — the calm ALL-CLEAR reading-pane hero (CTL-904 / HOME6).
+// The empty state is the relief payoff, designed as a FEATURE not a fallback: the
+// demo / first-impression hero shot, the shoulders-drop moment the whole
+// Direction-A page optimizes for. When nothing needs the operator (zero blocked +
+// zero waiting — the read-model emptiness gate, isAllClear), Home swaps THIS calm
+// celebratory hero into the reading pane instead of leaving a blank pane.
+//
+// It reassures structurally (Direction A): the agents are still running on their
+// own and the operator can check back whenever — never alarm, never a bare blank.
+//
+// MOTION (ethos-compliant, detail-pages §3.4): the entrance is a soft fade+rise
+// (`animate-fade-in`), and `prefers-reduced-motion` collapses that to an INSTANT,
+// still-calm state via the Tailwind `motion-reduce:` variant (no library, pure
+// CSS) — the celebratory entrance drops, the calm content stays.
+import { CheckCircle2 } from "lucide-react";
+
+import { allClearReassurance, type InboxCounts } from "@/board/home-inbox";
+
+export function AllClearHero({ counts }: { counts: InboxCounts }) {
+  return (
+    <div
+      data-all-clear-hero
+      className="animate-fade-in motion-reduce:animate-none flex h-full flex-col items-center justify-center gap-3 px-8 text-center"
+    >
+      {/* The single calm glyph — the reserved-live cyan is deliberately NOT used
+          here (accent = meaning, not celebration). A soft accent check reads as
+          "handled", not "alarm". */}
+      <CheckCircle2
+        aria-hidden
+        className="h-12 w-12 text-accent opacity-70 motion-safe:animate-fade-in"
+      />
+
+      {/* The everything-handled headline — the relief line, never an alarm count. */}
+      <p className="text-[18px] font-medium leading-snug text-fg">
+        All clear — nothing needs you right now.
+      </p>
+
+      {/* The structural reassurance: agents run on their own, check back whenever. */}
+      <p className="max-w-sm text-[13px] leading-relaxed text-muted">
+        {allClearReassurance(counts)}
+      </p>
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
@@ -20,11 +20,16 @@
 import { useEffect, useMemo, useState } from "react";
 
 import {
+  ALL_CLEAR_HEADLINE,
+  allClearReassurance,
   calmHeaderSentence,
   deriveInbox,
+  isAllClear,
   isNeedsYouSection,
   moveSelection,
   rowById,
+  shippedWhileAwaySummary,
+  type InboxCounts,
   type InboxSection,
 } from "@/board/home-inbox";
 import { isTypingTarget } from "@/lib/surface";
@@ -32,6 +37,28 @@ import { useBoardSnapshot } from "@/hooks/use-board-snapshot";
 import { ResizableSplit } from "./resizable-split";
 import { InboxRow } from "./inbox-row";
 import { ReadingPane } from "./reading-pane";
+import { AllClearHero } from "./all-clear-hero";
+
+/** The all-clear LIST state (CTL-904 / HOME6): when nothing needs the operator,
+ *  the list reads as everything-handled — the "All clear" headline + how many
+ *  shipped while you were away + the running-on-their-own reassurance — instead of
+ *  the bare alarm-count sections. The relief payoff, designed as a feature. The
+ *  celebratory entrance collapses to instant under prefers-reduced-motion. */
+function AllClearList({ counts }: { counts: InboxCounts }) {
+  const shipped = shippedWhileAwaySummary(counts);
+  return (
+    <div
+      data-all-clear-list
+      className="animate-fade-in motion-reduce:animate-none flex flex-col items-center gap-2 px-6 py-12 text-center"
+    >
+      <p className="text-[14px] font-medium text-fg">{ALL_CLEAR_HEADLINE}</p>
+      {shipped && <p className="text-[12px] text-muted">{shipped}</p>}
+      <p className="mt-1 max-w-xs text-[12px] leading-relaxed text-muted opacity-80">
+        {allClearReassurance(counts)}
+      </p>
+    </div>
+  );
+}
 
 /** One inbox section. The needs-you sections (blocked / waiting) render their
  *  rows OPEN; the reassurance sections (running on its own / done) collapse to a
@@ -107,6 +134,7 @@ function InboxSectionBlock({
 function InboxList({
   header,
   sections,
+  counts,
   selectedId,
   onSelect,
   status,
@@ -114,6 +142,7 @@ function InboxList({
 }: {
   header: string;
   sections: ReturnType<typeof deriveInbox>["sections"];
+  counts: InboxCounts;
   selectedId: string | null;
   onSelect: (id: string) => void;
   status: string;
@@ -121,7 +150,8 @@ function InboxList({
 }) {
   return (
     <div className="flex h-full flex-col bg-surface-0">
-      {/* The calm "state of things" header — ONE sentence, never a KPI grid. */}
+      {/* The calm "state of things" header — ONE sentence, never a KPI grid.
+          In the all-clear state it reads as everything-handled (no alarm count). */}
       <header className="shrink-0 border-b border-border px-4 py-4">
         <p className="text-[13px] text-fg" data-calm-header>
           {header}
@@ -131,12 +161,12 @@ function InboxList({
         )}
       </header>
 
-      {/* Flat bare-row list — sections are hairline-divided groups, NOT cards. */}
+      {/* Flat bare-row list — sections are hairline-divided groups, NOT cards.
+          When nothing needs the operator, the calm all-clear list replaces the
+          sections entirely (the relief payoff). */}
       <div className="min-h-0 flex-1 overflow-y-auto">
-        {sections.length === 0 ? (
-          <p className="px-4 py-8 text-center text-[12px] text-muted">
-            All clear — nothing needs you right now.
-          </p>
+        {isAllClear(counts) ? (
+          <AllClearList counts={counts} />
         ) : (
           sections.map((section) => (
             <InboxSectionBlock
@@ -215,7 +245,12 @@ export function HomeSurface() {
     return () => window.removeEventListener("keydown", onKey);
   }, [model.order]);
 
-  const header = calmHeaderSentence(model.counts);
+  // CTL-904 / HOME6: the all-clear gate — nothing needs the operator. When it
+  // holds, the header reads as everything-handled (not an alarm count), the list
+  // shows the celebratory all-clear state, and the reading pane shows the calm
+  // all-clear hero instead of a per-row detail (never a blank pane).
+  const allClear = isAllClear(model.counts);
+  const header = allClear ? ALL_CLEAR_HEADLINE : calmHeaderSentence(model.counts);
   const selectedRow = rowById(model, selectedId);
 
   return (
@@ -225,13 +260,16 @@ export function HomeSurface() {
           <InboxList
             header={header}
             sections={model.sections}
+            counts={model.counts}
             selectedId={selectedId}
             onSelect={setSelectedId}
             status={status}
             now={now}
           />
         }
-        reading={<ReadingPane row={selectedRow} />}
+        reading={
+          allClear ? <AllClearHero counts={model.counts} /> : <ReadingPane row={selectedRow} />
+        }
       />
     </div>
   );


### PR DESCRIPTION
## HOME6 — Calm all-clear empty state (CTL-904)

The empty state is the relief payoff, designed as a **feature not a fallback** — the demo / first-impression hero shot (the shoulders-drop moment Direction A optimizes for). When nothing needs the operator, Home greets them with a calm all-clear instead of a blank pane.

Gated on the **real read-model emptiness** (zero blocked + zero waiting, derived from the BFF inbox payload via `deriveInbox` counts → `isAllClear`), **not a mock toggle**.

### What changed
- **`ui/src/board/home-inbox.ts`** (pure core): added `isAllClear(counts)` (gate on `needsYou === 0`), `allClearReassurance(counts)`, `shippedWhileAwaySummary(counts)`, and the `ALL_CLEAR_HEADLINE` constant. `calmHeaderSentence` is unchanged and remains the source for the non-all-clear header (no HOME1 regression).
- **`ui/src/components/home/all-clear-hero.tsx`** (new): the calm reading-pane hero — `CheckCircle2` glyph, the everything-handled headline, and the running-on-their-own reassurance.
- **`ui/src/components/home/home-surface.tsx`**: when `isAllClear(model.counts)`, the header reads as everything-handled (`ALL_CLEAR_HEADLINE`), the list renders the celebratory `AllClearList` (headline + "N shipped while you were away" + reassurance), and the reading pane renders `AllClearHero` instead of a per-row detail. The non-all-clear path is behavior-preserving (just threads `counts` through).
- Tests: extended `__tests__/home-inbox.test.ts` (pure-helper units) and `__tests__/home-surface.test.ts` (static source-analysis guards, per the HOME1 convention — `bun test` has no DOM).

### Gherkin scenario coverage

| Scenario | Status | How |
|---|---|---|
| **All-clear hero when nothing needs you** | ✅ satisfied | `isAllClear` gate (zero blocked + zero waiting from the read-model); reading pane swaps in `AllClearHero` (not a blank pane); list shows `AllClearList` with `shippedWhileAwaySummary` ("N shipped while you were away"); header is `ALL_CLEAR_HEADLINE` (everything-handled, no alarm count). |
| **All-clear still reassures about autonomous work** | ✅ satisfied | `allClearReassurance(counts)` renders in both the hero and the list — "N agents are running on their own — check back whenever." |
| **Reduced-motion users get the calm state without animation** | ✅ satisfied | The celebratory entrance is a CSS `animate-fade-in`; `prefers-reduced-motion` collapses it to instant via the Tailwind `motion-reduce:animate-none` variant (no animation library — the prototype's `motion.span` is not portable, framer-motion is not a dep). Calm content stays. |

No scenarios single-node-descoped (this ticket has no cluster/fence/multi-host surface).

### Validation
- `bunx tsc --noEmit` (ui package): clean for all touched files (the only error is a pre-existing `kpi-strip.tsx` `OrchestratorStats.abandoned` mismatch, byte-identical to origin/main — unrelated).
- `bun test __tests__/home-inbox.test.ts __tests__/home-surface.test.ts`: **65 pass, 0 fail**.
- `bun run build` (ui): succeeds (build artifacts under `public/` intentionally NOT committed — source-only, per the HOME1 convention).
- No reward-hacking (`as any` / `as unknown` / `@ts-ignore` / non-null `!` / `forEach(async` / void-tricks): none introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)