### PR TITLE
feat(dev): HOME2 status glyph + phase strip (CTL-900)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/board-phase-drift.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-phase-drift.test.ts
@@ -64,6 +64,14 @@ const SOT = "workflow.default.json (via lib/workflow-descriptor.mjs PHASES)";
 // formatters.ts is pure (no imports) → direct import is safe under bun test.
 import { PHASE_COLORS as FMT_PHASE_COLORS } from "../ui/src/lib/formatters.ts";
 
+// CTL-900 / HOME2: the calm-home StatusIcon/PhaseStrip glyph reads its phase
+// model from ui/src/board/phase-model.ts. bun test resolves the `@/` tsconfig
+// path, so we import the model directly (its only `@/` dep, formatters, is pure)
+// and lock its hand-rolled phase list + terminal-status set to the SAME data-layer
+// source of truth the rest of the board is guarded against — so the glyph can
+// never silently drift from the real pipeline.
+import { PHASE_LIST, TERMINAL_STATUSES } from "@/board/phase-model";
+
 // ── Board.tsx text extraction ───────────────────────────────────────────────
 // We read Board.tsx as TEXT (never import it) because it pulls in React + CSS +
 // "@/…" path-aliased modules that don't resolve under `bun test`. This mirrors
@@ -315,4 +323,48 @@ test("Board.tsx TERMINAL_STATUSES equals board-data.mjs TERMINAL (terminal-bound
     );
   }
   expect(ui).toEqual(data);
+});
+
+// ── CTL-900 / HOME2: phase-model.ts PHASE_LIST === board-data PHASE_ORDER ──────
+// The calm-home StatusIcon glyph + PhaseStrip read their ordered phase list from
+// ui/src/board/phase-model.ts PHASE_LIST. It is a hand-rolled copy of the
+// canonical pipeline (no synthetic "done" step — "done" is a status), so it MUST
+// equal the data-layer PHASE_ORDER exactly or the glyph silently mis-renders the
+// fill fraction / strip dots when a phase is renamed, reordered, added or dropped.
+test("phase-model.ts PHASE_LIST equals board-data.mjs PHASE_ORDER (glyph fraction drift)", () => {
+  // Widen the readonly literal-tuple to string[] so the comparison element type
+  // matches board-data's plain string[] PHASE_ORDER (no cast — a plain copy).
+  const model: string[] = [...PHASE_LIST];
+  if (JSON.stringify(model) !== JSON.stringify(PHASE_ORDER)) {
+    throw new Error(
+      `DRIFT: ui/src/board/phase-model.ts PHASE_LIST diverged from the data-layer ` +
+        `source of truth (lib/board-data.mjs PHASE_ORDER).\n` +
+        `  board-data PHASE_ORDER:   ${JSON.stringify(PHASE_ORDER)}\n` +
+        `  phase-model PHASE_LIST:   ${JSON.stringify(model)}\n` +
+        `The HOME2 StatusIcon fill fraction ((phaseIndex+1)/total) and PhaseStrip ` +
+        `dots are computed off PHASE_LIST; a divergence mis-renders progress. ` +
+        `Reconcile PHASE_LIST to PHASE_ORDER (rooted in workflow.default.json).`,
+    );
+  }
+  expect(model).toEqual(PHASE_ORDER);
+});
+
+// ── CTL-900 / HOME2: phase-model.ts TERMINAL_STATUSES === board-data TERMINAL ──
+// The glyph flips to the done disc+check off a terminal-status check; its
+// TERMINAL_STATUSES set is a hand-rolled copy of the data-layer TERMINAL. Lock
+// them (unordered Set → compare as sorted) so a new terminal status can't make
+// the glyph treat a finished phase as still in-flight (or vice-versa).
+test("phase-model.ts TERMINAL_STATUSES equals board-data.mjs TERMINAL (glyph terminal drift)", () => {
+  const model = [...TERMINAL_STATUSES].sort();
+  const data = [...TERMINAL].sort();
+  if (JSON.stringify(model) !== JSON.stringify(data)) {
+    throw new Error(
+      `DRIFT: ui/src/board/phase-model.ts TERMINAL_STATUSES diverged from the ` +
+        `data-layer source of truth (lib/board-data.mjs TERMINAL).\n` +
+        `  board-data TERMINAL:          ${JSON.stringify(data)}\n` +
+        `  phase-model TERMINAL_STATUSES: ${JSON.stringify(model)}\n` +
+        `Reconcile the two; TERMINAL in board-data.mjs is the source of truth.`,
+    );
+  }
+  expect(model).toEqual(data);
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/phase-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/phase-model.test.ts
@@ -1,0 +1,148 @@
+// phase-model.test.ts — units for the StatusIcon/PhaseStrip phase model (CTL-900
+// / HOME2): the canonical phase list, the index lookup that drives the glyph fill
+// fraction, the done-status detection that flips the glyph to the disc+check, and
+// the per-phase color (which must NEVER be the reserved live cyan). This is the
+// React-free spine the hand-rolled glyph reads, so it unit-tests directly under
+// `bun test` (same precedent as home-inbox.test.ts).
+//
+// The Gherkin these lock in (CTL-900):
+//   • "a single StatusIcon shows a partial ring + pie fill proportional to
+//      (phaseIndex+1)/total" → phaseFraction((phaseIndex)) === (phaseIndex+1)/total.
+//   • "the glyph is colored by the current phase on the early->late spectrum"
+//      → phaseColor(phase) resolves a non-cyan color for every canonical phase.
+//   • "a finished item … shows a filled disc with a check mark" → isDoneStatus.
+//   • "the current phase as a ringed/larger dot … pending as faint hollow dots"
+//      → phaseIndexOf gives the strip its done/current/pending split.
+import { describe, it, expect } from "bun:test";
+import {
+  PHASE_LIST,
+  PHASE_COUNT,
+  PHASE_LABEL,
+  PHASE_SHORT,
+  TERMINAL_STATUSES,
+  phaseIndexOf,
+  phaseFraction,
+  isPhase,
+  isDoneStatus,
+  phaseColor,
+} from "@/board/phase-model";
+
+// The reserved live-loop color — must never be used for a phase glyph (it stays
+// reserved for the "in-loop" liveness signal, Board.tsx LIVE).
+const LIVE_CYAN = "#5be0ff";
+
+describe("PHASE_LIST — the canonical pipeline (no synthetic 'done' step)", () => {
+  it("is the 10 canonical pipeline phases, in order", () => {
+    expect([...PHASE_LIST]).toEqual([
+      "triage",
+      "research",
+      "plan",
+      "implement",
+      "verify",
+      "review",
+      "pr",
+      "monitor-merge",
+      "monitor-deploy",
+      "teardown",
+    ]);
+  });
+  it("does NOT carry a synthetic 'done' pseudo-phase ('done' is a status)", () => {
+    expect((PHASE_LIST as readonly string[]).includes("done")).toBe(false);
+  });
+  it("PHASE_COUNT equals the list length", () => {
+    expect(PHASE_COUNT).toBe(PHASE_LIST.length);
+  });
+  it("every phase has a full + short human label", () => {
+    for (const p of PHASE_LIST) {
+      expect(PHASE_LABEL[p]).toBeTruthy();
+      expect(PHASE_SHORT[p]).toBeTruthy();
+    }
+  });
+});
+
+describe("phaseIndexOf — the strip's done/current/pending split source", () => {
+  it("maps each canonical phase to its 0-based index", () => {
+    expect(phaseIndexOf("triage")).toBe(0);
+    expect(phaseIndexOf("implement")).toBe(3);
+    expect(phaseIndexOf("teardown")).toBe(PHASE_COUNT - 1);
+  });
+  it("returns -1 for an unknown / pre-pipeline / ancillary phase", () => {
+    expect(phaseIndexOf("remediate")).toBe(-1);
+    expect(phaseIndexOf("")).toBe(-1);
+    expect(phaseIndexOf(null)).toBe(-1);
+    expect(phaseIndexOf(undefined)).toBe(-1);
+  });
+});
+
+describe("phaseFraction — the ring/pie fill = (phaseIndex+1)/total (Scenario 1)", () => {
+  it("counts the current phase as in-flight: phase 0 already shows a sliver", () => {
+    expect(phaseFraction(0)).toBeCloseTo(1 / PHASE_COUNT, 10);
+  });
+  it("is proportional to (phaseIndex+1)/total at the implement phase", () => {
+    const idx = phaseIndexOf("implement"); // 3
+    expect(phaseFraction(idx)).toBeCloseTo((idx + 1) / PHASE_COUNT, 10);
+  });
+  it("the terminal pipeline phase reads as a full ring", () => {
+    expect(phaseFraction(PHASE_COUNT - 1)).toBeCloseTo(1, 10);
+  });
+  it("an unknown phase (index -1) reads as no progress (empty ring)", () => {
+    expect(phaseFraction(-1)).toBe(0);
+  });
+  it("never exceeds 1 even for an out-of-range index", () => {
+    expect(phaseFraction(PHASE_COUNT + 5)).toBe(1);
+  });
+});
+
+describe("isDoneStatus — the disc+check terminal (Scenario 2)", () => {
+  it("is true only for the success terminal 'done'", () => {
+    expect(isDoneStatus("done")).toBe(true);
+  });
+  it("is false for in-flight statuses", () => {
+    expect(isDoneStatus("active")).toBe(false);
+    expect(isDoneStatus("running")).toBe(false);
+    expect(isDoneStatus("unknown")).toBe(false);
+  });
+  it("is false for NON-success terminal statuses (no reassuring check on a failure)", () => {
+    expect(isDoneStatus("failed")).toBe(false);
+    expect(isDoneStatus("stalled")).toBe(false);
+    expect(isDoneStatus("canceled")).toBe(false);
+  });
+});
+
+describe("isPhase — phase-id narrowing for the label lookups", () => {
+  it("accepts canonical phases", () => {
+    expect(isPhase("review")).toBe(true);
+  });
+  it("rejects unknown / nullish phases", () => {
+    expect(isPhase("done")).toBe(false);
+    expect(isPhase("remediate")).toBe(false);
+    expect(isPhase(null)).toBe(false);
+    expect(isPhase(undefined)).toBe(false);
+  });
+});
+
+describe("phaseColor — early->late spectrum, NEVER the reserved live cyan", () => {
+  it("resolves a concrete hex color for every canonical phase", () => {
+    for (const p of PHASE_LIST) {
+      const c = phaseColor(p);
+      expect(c).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+  it("never colors a phase with the reserved live cyan (#5be0ff)", () => {
+    for (const p of PHASE_LIST) {
+      expect(phaseColor(p).toLowerCase()).not.toBe(LIVE_CYAN);
+    }
+  });
+});
+
+describe("TERMINAL_STATUSES — the no-longer-running set", () => {
+  it("includes the canonical terminal statuses", () => {
+    for (const s of ["done", "failed", "stalled", "skipped", "signal_corrupt", "superseded", "canceled"]) {
+      expect(TERMINAL_STATUSES.has(s)).toBe(true);
+    }
+  });
+  it("does NOT include in-flight statuses", () => {
+    expect(TERMINAL_STATUSES.has("active")).toBe(false);
+    expect(TERMINAL_STATUSES.has("running")).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/status-glyph.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/status-glyph.test.ts
@@ -1,0 +1,123 @@
+// status-glyph.test.ts — CTL-900 / HOME2 acceptance guards for the StatusIcon
+// glyph + PhaseStrip wiring into the calm Inbox row + reading pane.
+//
+// The PURE phase model (fraction math / done detection / index / color) is unit-
+// tested in phase-model.test.ts, and its drift to the canonical pipeline is locked
+// in board-phase-drift.test.ts. `bun test` has no DOM, so — the same way
+// home-surface.test.ts guards HOME1 — the STRUCTURAL Gherkin (a single glyph on the
+// row with NO text status badge; the disc+check done terminal; the reading-pane
+// "where it's at" phase strip) is asserted by static source analysis: read the
+// component .tsx as text and assert the load-bearing wiring.
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const UI_SRC = join(HERE, "..", "ui", "src");
+const read = (rel: string) => readFileSync(join(UI_SRC, rel), "utf8");
+
+function stripComments(src: string): string {
+  return src
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+const statusIconSrc = read("components/home/status-icon.tsx");
+const phaseStripSrc = read("components/home/phase-strip.tsx");
+const inboxRowSrc = read("components/home/inbox-row.tsx");
+const readingPaneSrc = read("components/home/reading-pane.tsx");
+
+const iconCode = stripComments(statusIconSrc);
+const stripCode = stripComments(phaseStripSrc);
+const rowCode = stripComments(inboxRowSrc);
+const paneCode = stripComments(readingPaneSrc);
+
+// ── Scenario: A row shows progress and stage in one glyph ─────────────────────
+describe("Scenario: A row shows progress and stage in one glyph (CTL-900)", () => {
+  it("the inbox row renders a single StatusIcon glyph fed by the ticket's phase + status", () => {
+    expect(rowCode).toContain("StatusIcon");
+    // Fed from the read-model item's phase + status (board-data deriveActiveState).
+    expect(rowCode).toMatch(/phase=\{row\.ticket\.phase\}/);
+    expect(rowCode).toMatch(/status=\{row\.ticket\.status\}/);
+  });
+
+  it("the glyph's fill is proportional to (phaseIndex+1)/total via the phase model", () => {
+    // The icon derives the index from the canonical model and the fraction off it.
+    expect(iconCode).toContain("phaseIndexOf");
+    expect(iconCode).toContain("phaseFraction");
+    expect(iconCode).toContain("PHASE_COUNT");
+  });
+
+  it("the glyph is colored by the current phase (early->late spectrum), via phaseColor", () => {
+    expect(iconCode).toContain("phaseColor");
+  });
+
+  it("the glyph NEVER hard-codes the reserved live cyan (#5be0ff)", () => {
+    // Check the comment-STRIPPED code: the doc comments legitimately mention the
+    // reserved cyan to explain it is deliberately NOT used, so only real code is
+    // guarded (mirrors home-surface.test.ts's stripped no-Linear guard).
+    expect(iconCode.toLowerCase()).not.toContain("5be0ff");
+    expect(stripCode.toLowerCase()).not.toContain("5be0ff");
+  });
+
+  it("NO separate text status badge is shown on the row (the glyph IS the status)", () => {
+    // The row must not render a status/label Badge chip — status reads from the
+    // glyph alone (Direction A). The only row affordances are the section accent,
+    // the key, the title, the muted sub-label, and the single needs-you verb.
+    expect(rowCode).not.toContain("components/ui/badge");
+    expect(rowCode).not.toMatch(/<Badge\b/);
+  });
+});
+
+// ── Scenario: A finished item reads as done ───────────────────────────────────
+describe("Scenario: A finished item reads as done (CTL-900)", () => {
+  it("the glyph flips to a filled disc + check on the done terminal status", () => {
+    expect(iconCode).toContain("isDoneStatus");
+    // The terminal branch draws a filled disc + a check path.
+    expect(iconCode).toContain("checkPath");
+    expect(iconCode).toMatch(/done\s*\?/);
+  });
+});
+
+// ── Scenario: The reading pane shows the full phase strip ─────────────────────
+describe("Scenario: The reading pane shows the full phase strip (CTL-900)", () => {
+  it("the reading pane renders a 'where it's at' block with the PhaseStrip", () => {
+    expect(paneCode).toContain("PhaseStrip");
+    expect(readingPaneSrc.toLowerCase()).toContain("where it's at");
+    // Driven by the selected row's ticket phase/status.
+    expect(paneCode).toMatch(/phase=\{row\.ticket\.phase\}/);
+  });
+
+  it("the reading-pane header also carries the single StatusIcon glyph", () => {
+    expect(paneCode).toContain("StatusIcon");
+  });
+
+  it("the PhaseStrip splits steps into done / current / pending off the phase index", () => {
+    expect(stripCode).toContain("isDone");
+    expect(stripCode).toContain("isCurrent");
+    // Current = larger ringed dot (boxShadow ring + larger size); pending = faint
+    // hollow dot (transparent bg + a border); done = solid phase-color dot.
+    expect(stripCode).toContain("boxShadow");
+    expect(stripCode).toMatch(/size-2\.5/); // larger current dot
+    expect(stripCode).toMatch(/size-1\.5/); // smaller done/pending dot
+  });
+
+  it("the PhaseStrip walks the canonical PHASE_LIST (no synthetic 'done' step)", () => {
+    expect(stripCode).toContain("PHASE_LIST");
+    // It must not re-introduce a synthetic terminal 'done' pseudo-phase.
+    expect(stripCode).not.toMatch(/"done"/);
+  });
+});
+
+// ── No-regression: the glyph components stay pure (no Linear / fetch) ──────────
+describe("no-regression: the glyph tree never reaches for Linear or a fetch (CTL-900)", () => {
+  it("status-icon / phase-strip open no network and touch no Linear", () => {
+    for (const src of [iconCode, stripCode]) {
+      expect(src.toLowerCase()).not.toContain("linearis");
+      expect(src).not.toMatch(/\bnew EventSource\b/);
+      expect(src).not.toMatch(/\bfetch\(/);
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/phase-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/phase-model.ts
@@ -1,0 +1,133 @@
+// phase-model.ts — the ONE phase-model the calm-home StatusIcon glyph + PhaseStrip
+// read (CTL-900 / HOME2). It hand-rolls the canonical pipeline view the glyph
+// needs: the ordered phase list, the per-phase human labels (full + short), the
+// index lookup that drives the StatusIcon fill fraction, and the terminal-status
+// set that flips the glyph to the "done disc + check". It deliberately does NOT
+// re-declare colors — those live ONCE in ui/src/lib/formatters.ts (PHASE_COLORS),
+// the canonical UI color source already drift-guarded against the pipeline. We
+// re-export `phaseColor` from there so the glyph never carries a hand-copied
+// color map that could silently drift.
+//
+// DRIFT GUARD (why this is safe to hand-roll)
+// ───────────────────────────────────────────
+// PHASE_LIST + TERMINAL_STATUSES below are hand-written copies of the single
+// source of truth: lib/board-data.mjs PHASE_ORDER / TERMINAL (themselves rooted
+// in workflow.default.json via lib/workflow-descriptor.mjs PHASES). The
+// board-phase-drift.test.ts guard asserts PHASE_LIST === PHASE_ORDER and
+// TERMINAL_STATUSES === TERMINAL exactly, so a renamed/reordered/added phase or a
+// new terminal status is a hard CI failure here rather than a silently-stale
+// glyph. NEVER edit these two lists to "fix" a failing drift test — fix the copy
+// the failure names against workflow.default.json.
+//
+// "done" is a terminal STATUS, not a pipeline phase. The canonical PHASE_LIST has
+// no "done" entry (the prototype's data.ts added a synthetic one); the glyph
+// instead reads the ticket's `status` and renders the all-clear disc+check when
+// that status is in TERMINAL_STATUSES with a successful outcome.
+import { phaseColor } from "@/lib/formatters";
+
+/**
+ * The canonical 10-phase pipeline order, early → late. A copy of
+ * lib/board-data.mjs PHASE_ORDER (rooted in workflow.default.json); the
+ * board-phase-drift guard asserts exact equality, so this never drifts.
+ */
+export const PHASE_LIST = [
+  "triage",
+  "research",
+  "plan",
+  "implement",
+  "verify",
+  "review",
+  "pr",
+  "monitor-merge",
+  "monitor-deploy",
+  "teardown",
+] as const;
+
+export type Phase = (typeof PHASE_LIST)[number];
+
+/** Total number of pipeline phases — drives the StatusIcon fill fraction. */
+export const PHASE_COUNT = PHASE_LIST.length;
+
+/**
+ * Phase statuses that mean a phase is no longer running. A copy of
+ * lib/board-data.mjs TERMINAL; the drift guard asserts set-equality. A ticket
+ * whose current status is one of these (and not a failure — see `isDoneStatus`)
+ * reads as finished, so the glyph shows the all-clear disc + check.
+ */
+export const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  "done",
+  "failed",
+  "stalled",
+  "skipped",
+  "signal_corrupt",
+  "superseded",
+  "canceled",
+]);
+
+/** Human-friendly full phase label for the glyph tooltip / pane sub-label. */
+export const PHASE_LABEL: Record<Phase, string> = {
+  triage: "Triaging",
+  research: "Researching",
+  plan: "Planning",
+  implement: "Implementing",
+  verify: "Verifying",
+  review: "Reviewing",
+  pr: "Opening PR",
+  "monitor-merge": "Merging",
+  "monitor-deploy": "Deploying",
+  teardown: "Tearing down",
+};
+
+/** Tighter one/two-word label for the compact phase STRIP dots in the pane. */
+export const PHASE_SHORT: Record<Phase, string> = {
+  triage: "Triage",
+  research: "Research",
+  plan: "Plan",
+  implement: "Implement",
+  verify: "Verify",
+  review: "Review",
+  pr: "PR",
+  "monitor-merge": "Merge",
+  "monitor-deploy": "Deploy",
+  teardown: "Teardown",
+};
+
+/** True when `phase` is a known canonical pipeline phase. */
+export function isPhase(phase: string | null | undefined): phase is Phase {
+  return phase != null && (PHASE_LIST as readonly string[]).includes(phase);
+}
+
+/**
+ * 0-based index of `phase` in the canonical pipeline. Returns -1 for an unknown
+ * phase (e.g. a pre-pipeline / ancillary value) so callers can clamp safely; the
+ * StatusIcon treats -1 as "no progress yet" (empty ring).
+ */
+export function phaseIndexOf(phase: string | null | undefined): number {
+  if (phase == null) return -1;
+  return (PHASE_LIST as readonly string[]).indexOf(phase);
+}
+
+/**
+ * The glyph fill fraction for a phase index: (index + 1) / PHASE_COUNT, counting
+ * the CURRENT phase as in-flight (so phase 0 already shows a sliver). Clamped to
+ * [0, 1]; an unknown phase (index < 0) yields 0.
+ */
+export function phaseFraction(phaseIndex: number): number {
+  if (phaseIndex < 0) return 0;
+  return Math.max(0, Math.min(1, (phaseIndex + 1) / PHASE_COUNT));
+}
+
+/**
+ * Whether a ticket status reads as SUCCESSFULLY finished — the all-clear the
+ * glyph renders as a filled disc + check. `done` is the canonical success
+ * terminal; the other TERMINAL_STATUSES are non-success outcomes (failed /
+ * stalled / canceled …) that should NOT show the reassuring check.
+ */
+export function isDoneStatus(status: string | null | undefined): boolean {
+  return status === "done";
+}
+
+/** Resolve the per-phase color from the canonical UI color source (formatters).
+ *  Re-exported so the glyph has ONE color source (never cyan — that stays
+ *  reserved for live; formatters.PHASE_COLORS already excludes it). */
+export { phaseColor };

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/inbox-row.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/inbox-row.tsx
@@ -3,13 +3,16 @@
 // summary — just a flat row separated from its neighbour by the list's hairline
 // divider (Direction A non-negotiable #1: "No card-in-card. Ever.").
 //
-// Row anatomy (Direction A): a 2px LEFT ACCENT (the only status signal, present
-// only on the needs-you rows — red blocked / amber waiting); the monospace muted
-// KEY; the one-line ASK (the bright line, the ticket title); a muted human
-// SUB-LABEL; and the single primary VERB. Running/Done rows are fully neutral
-// (no accent, no verb) — that's how 90% of the page de-alarms by subtraction.
+// Row anatomy (Direction A): a 2px LEFT ACCENT (the section-meaning signal,
+// present only on the needs-you rows — red blocked / amber waiting); a single
+// Catalyst StatusIcon GLYPH (CTL-900 / HOME2) that encodes BOTH progress + stage,
+// replacing the old text status/label chips; the monospace muted KEY; the
+// one-line ASK (the bright line, the ticket title); a muted human SUB-LABEL; and
+// the single primary VERB. Running/Done rows are fully neutral (no accent, no
+// verb) — that's how 90% of the page de-alarms by subtraction.
 import { cn } from "@/lib/utils";
 import { isNeedsYouSection, type InboxRow as InboxRowModel } from "@/board/home-inbox";
+import { StatusIcon } from "./status-icon";
 
 /** Left-accent color per section. Only the needs-you sections carry an accent;
  *  running/done are intentionally accent-less (transparent). Reserved live cyan
@@ -50,10 +53,20 @@ export function InboxRow({
         selected ? "bg-surface-2" : "hover:bg-surface-1",
       )}
     >
-      {/* 2px left accent — the single status signal, only on needs-you rows. */}
+      {/* 2px left accent — the section-meaning signal, only on needs-you rows. */}
       <span
         aria-hidden
         className={cn("mt-0.5 h-9 w-0.5 shrink-0 rounded-full", accentClass(row.section))}
+      />
+
+      {/* The single Catalyst StatusIcon glyph — encodes progress (ring/pie fill =
+          (phaseIndex+1)/total) AND stage (phase color). This REPLACES any text
+          status badge on the row (Direction A: status is one glyph, not chips). */}
+      <StatusIcon
+        phase={row.ticket.phase}
+        status={row.ticket.status}
+        size={16}
+        className="mt-0.5"
       />
 
       <span className="flex min-w-0 flex-1 flex-col gap-0.5">

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/phase-strip.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/phase-strip.tsx
@@ -1,0 +1,50 @@
+// phase-strip.tsx — the compact "where it's at" pipeline indicator (CTL-900 /
+// HOME2). A hand-rolled strip of done / current / pending dots joined by hairline
+// connectors, rendered in the reading pane for a fuller progress read than the
+// single row glyph gives. Calm, flat, no nesting (Direction A): done phases are a
+// solid phase-color dot, the current phase a larger ringed dot, and pending
+// phases a faint hollow dot. The 10 canonical pipeline steps come from the ONE
+// phase-model (no synthetic "done" pseudo-step — "done" is the outcome, not a
+// step). Colors come from formatters.PHASE_COLORS via phaseColor (never cyan).
+import { cn } from "@/lib/utils";
+import { phaseColor, PHASE_LIST, PHASE_SHORT } from "@/board/phase-model";
+
+export function PhaseStrip({ phaseIndex }: { phaseIndex: number }) {
+  return (
+    <ol className="flex items-center gap-0" aria-label="Pipeline progress">
+      {PHASE_LIST.map((phase, i) => {
+        const isDone = i < phaseIndex;
+        const isCurrent = i === phaseIndex;
+        const color = phaseColor(phase);
+        return (
+          <li key={phase} className="flex min-w-0 items-center">
+            <span
+              className="relative flex shrink-0 items-center justify-center"
+              title={`${PHASE_SHORT[phase]}${isCurrent ? " — current" : isDone ? " — done" : ""}`}
+            >
+              <span
+                aria-hidden
+                className={cn("block rounded-full transition-all", isCurrent ? "size-2.5" : "size-1.5")}
+                style={{
+                  backgroundColor: isDone || isCurrent ? color : "transparent",
+                  border: isDone || isCurrent ? undefined : `1.5px solid var(--color-border)`,
+                  boxShadow: isCurrent ? `0 0 0 3px ${color}33` : undefined,
+                }}
+              />
+            </span>
+            {i < PHASE_LIST.length - 1 && (
+              <span
+                aria-hidden
+                className="h-px w-3 shrink-0"
+                style={{
+                  backgroundColor: isDone ? color : "var(--color-border)",
+                  opacity: isDone ? 0.5 : 1,
+                }}
+              />
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
@@ -8,6 +8,9 @@
 // and marks the deeper body as "arriving in HOME4", rather than being inert.
 import { CheckCircle2 } from "lucide-react";
 import { isNeedsYouSection, type InboxRow } from "@/board/home-inbox";
+import { isDoneStatus, isPhase, phaseIndexOf, PHASE_LABEL } from "@/board/phase-model";
+import { StatusIcon } from "./status-icon";
+import { PhaseStrip } from "./phase-strip";
 
 /** Empty-pane state — shown when nothing is selected (a wholly empty inbox).
  *  The relief payoff: calm, not an error. */
@@ -23,6 +26,25 @@ function NothingSelected() {
   );
 }
 
+/** The compact "Where it's at" block (CTL-900 / HOME2) — a small glyph + the
+ *  human phase label + the full done/current/pending phase strip. Flat, no
+ *  nested card (Direction A). */
+function WhereItsAt({ phase, status }: { phase: string; status: string }) {
+  const phaseIndex = phaseIndexOf(phase);
+  const done = isDoneStatus(status);
+  const phaseLabel = done ? "Done" : isPhase(phase) ? PHASE_LABEL[phase] : phase;
+  return (
+    <div className="mt-6">
+      <p className="text-[11px] font-medium uppercase tracking-wide text-muted">Where it's at</p>
+      <div className="mt-2 flex items-center gap-3">
+        <StatusIcon phase={phase} status={status} size={16} />
+        <span className="text-[12px] text-muted">{phaseLabel}</span>
+        <PhaseStrip phaseIndex={phaseIndex} />
+      </div>
+    </div>
+  );
+}
+
 export function ReadingPane({ row }: { row: InboxRow | null }) {
   if (!row) return <NothingSelected />;
 
@@ -30,12 +52,21 @@ export function ReadingPane({ row }: { row: InboxRow | null }) {
 
   return (
     <div data-reading-pane-id={row.id} className="flex h-full flex-col px-6 py-5">
-      {/* Header: the key + the one-line ask (the bright subject of the pane). */}
-      <div className="flex items-center gap-2">
-        <span className="font-mono text-[12px] font-semibold text-accent">{row.id}</span>
-        <span className="text-[11px] text-muted">{row.subLabel}</span>
+      {/* Header: the StatusIcon glyph + the key + the one-line ask (the bright
+          subject of the pane). The glyph carries progress + stage in one slot. */}
+      <div className="flex items-start gap-3">
+        <StatusIcon phase={row.ticket.phase} status={row.ticket.status} size={24} className="mt-0.5" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-[12px] font-semibold text-accent">{row.id}</span>
+            <span className="text-[11px] text-muted">{row.subLabel}</span>
+          </div>
+          <h1 className="mt-1 text-[18px] leading-snug text-fg">{row.title}</h1>
+        </div>
       </div>
-      <h1 className="mt-1 text-[18px] leading-snug text-fg">{row.title}</h1>
+
+      {/* Where it's at — the full phase strip read. */}
+      <WhereItsAt phase={row.ticket.phase} status={row.ticket.status} />
 
       {/* What's needed now — the needs-you cue. The decision options / blocker
           detail + the View-in-Claude deep link are HOME4. */}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/status-icon.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/status-icon.tsx
@@ -1,0 +1,165 @@
+// status-icon.tsx — the Catalyst-specific StatusIcon glyph (CTL-900 / HOME2).
+//
+// A Linear-style status glyph that doubles as a progress meter: an SVG ring with
+// a partial pie fill that steps empty → quarter → half → three-quarter → full →
+// check, exactly the way Linear's workflow-state icons walk Backlog → Todo → In
+// Progress → Done. The fill fraction is (phaseIndex + 1) / PHASE_COUNT and the
+// whole glyph is COLORED by the current phase on the early→late spectrum
+// (formatters.PHASE_COLORS). The operator reads BOTH "how far along" and "what
+// stage" from ONE consistent slot — this intentionally REPLACES the old row of
+// status/label chips (Direction A: status = a single dot/accent, not a cluster).
+//
+// This is a hand-rolled Catalyst-specific glyph (not a stock shadcn component),
+// per the standing preference to hand-roll only Catalyst-specifics. Cyan
+// (#5be0ff) stays RESERVED for the live signal and is never used here — the phase
+// color comes from formatters.PHASE_COLORS, which excludes it.
+import { cn } from "@/lib/utils";
+import {
+  isDoneStatus,
+  phaseColor,
+  phaseFraction,
+  phaseIndexOf,
+  PHASE_COUNT,
+  PHASE_LABEL,
+  type Phase,
+} from "@/board/phase-model";
+
+interface StatusIconProps {
+  /** The ticket's current pipeline phase (canonical phase id). */
+  phase: string;
+  /** The ticket's current phase status — drives the terminal done disc+check. */
+  status: string;
+  /** Pixel size of the square glyph. */
+  size?: number;
+  className?: string;
+}
+
+export function StatusIcon({ phase, status, size = 16, className }: StatusIconProps) {
+  const phaseIndex = phaseIndexOf(phase);
+  const color = phaseColor(phase);
+  const done = isDoneStatus(status);
+
+  // Geometry: a ring of radius r, with an inner pie wedge whose angle encodes
+  // progress. The CURRENT phase counts as in-flight, so the fraction is
+  // (phaseIndex + 1) / PHASE_COUNT — phase 0 already shows a sliver of progress.
+  const fraction = phaseFraction(phaseIndex);
+
+  const c = size / 2;
+  const ringR = size * 0.4; // outer ring radius
+  const ringW = Math.max(1.5, size * 0.115); // ring stroke width
+  const pieR = size * 0.225; // inner pie radius (the fill that grows)
+
+  const stepLabel = phaseIndex >= 0 ? `step ${phaseIndex + 1} of ${PHASE_COUNT}` : "pre-pipeline";
+  const phaseLabel = isKnownPhase(phase) ? PHASE_LABEL[phase] : phase;
+  const label = done ? "Done" : `${phaseLabel} — ${stepLabel}`;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      role="img"
+      aria-label={label}
+      className={cn("shrink-0", className)}
+    >
+      <title>{label}</title>
+
+      {/* The faint full-circle track — the "not yet" remainder. */}
+      <circle
+        cx={c}
+        cy={c}
+        r={ringR}
+        fill="none"
+        stroke={color}
+        strokeOpacity={0.28}
+        strokeWidth={ringW}
+      />
+
+      {done ? (
+        // Terminal success: filled disc + check, the all-clear.
+        <>
+          <circle cx={c} cy={c} r={ringR + ringW / 2} fill={color} />
+          <path
+            d={checkPath(c, size)}
+            fill="none"
+            stroke="white"
+            strokeWidth={Math.max(1.4, size * 0.11)}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </>
+      ) : (
+        <>
+          {/* Progress arc traced on the ring, full-opacity, from 12 o'clock. */}
+          <RingArc cx={c} cy={c} r={ringR} fraction={fraction} color={color} width={ringW} />
+          {/* Inner pie wedge that grows with progress — the Linear "fill". */}
+          {fraction > 0 && <path d={piePath(c, pieR, fraction)} fill={color} />}
+        </>
+      )}
+    </svg>
+  );
+}
+
+/** Narrow a string to a known Phase for the label lookup (avoids an unsafe cast). */
+function isKnownPhase(phase: string): phase is Phase {
+  return phase in PHASE_LABEL;
+}
+
+/** A stroked arc along the ring from 12 o'clock, clockwise, for `fraction`. */
+function RingArc({
+  cx,
+  cy,
+  r,
+  fraction,
+  color,
+  width,
+}: {
+  cx: number;
+  cy: number;
+  r: number;
+  fraction: number;
+  color: string;
+  width: number;
+}) {
+  if (fraction <= 0) return null;
+  // Near-full arcs render cleanly as a full circle to avoid a hairline seam.
+  if (fraction >= 0.999) {
+    return <circle cx={cx} cy={cy} r={r} fill="none" stroke={color} strokeWidth={width} />;
+  }
+  const start = polar(cx, cy, r, 0);
+  const end = polar(cx, cy, r, fraction * 360);
+  const largeArc = fraction > 0.5 ? 1 : 0;
+  return (
+    <path
+      d={`M ${start.x} ${start.y} A ${r} ${r} 0 ${largeArc} 1 ${end.x} ${end.y}`}
+      fill="none"
+      stroke={color}
+      strokeWidth={width}
+      strokeLinecap="round"
+    />
+  );
+}
+
+/** SVG path for a pie wedge from 12 o'clock, clockwise, covering `fraction`. */
+function piePath(c: number, r: number, fraction: number): string {
+  if (fraction >= 0.999) {
+    // Full disc.
+    return `M ${c} ${c - r} A ${r} ${r} 0 1 1 ${c - 0.01} ${c - r} Z`;
+  }
+  const start = polar(c, c, r, 0);
+  const end = polar(c, c, r, fraction * 360);
+  const largeArc = fraction > 0.5 ? 1 : 0;
+  return `M ${c} ${c} L ${start.x} ${start.y} A ${r} ${r} 0 ${largeArc} 1 ${end.x} ${end.y} Z`;
+}
+
+/** Point on a circle, angle measured clockwise from 12 o'clock (degrees). */
+function polar(cx: number, cy: number, r: number, angleDeg: number) {
+  const rad = ((angleDeg - 90) * Math.PI) / 180;
+  return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) };
+}
+
+/** A check mark sized to the glyph. */
+function checkPath(c: number, size: number): string {
+  const s = size;
+  return `M ${c - s * 0.16} ${c + s * 0.01} L ${c - s * 0.04} ${c + s * 0.13} L ${c + s * 0.18} ${c - s * 0.13}`;
+}


### PR DESCRIPTION
## HOME2 (CTL-900) — Status glyph + phase strip

Operators read pipeline progress from ONE Linear-style status glyph instead of a row of chips. Each calm-Inbox row and the reading pane render a single Catalyst-specific **StatusIcon** — a ring + pie glyph that encodes BOTH *how-far-along* (fill = `(phaseIndex+1)/total`) and *what-stage* (phase color on the early→late spectrum). The reading pane also gets a compact **PhaseStrip** (done / current / pending dots) for a fuller "where it's at" read. This replaces the old cluster of status/label chips, in service of the Direction-A "status = a single dot/accent, not a cluster" rule.

Builds on **HOME1 (CTL-899)** — the row + reading-pane host components.

### Gherkin scenarios

| Scenario | Status |
|---|---|
| **A row shows progress and stage in one glyph** — single StatusIcon with partial ring + pie fill proportional to `(phaseIndex+1)/total`, colored by the current phase, no separate text status badge on the row | ✅ satisfied |
| **A finished item reads as done** — terminal `done` status renders a filled disc + check | ✅ satisfied |
| **The reading pane shows the full phase strip** — done phases = solid dots, current = larger ringed dot, pending = faint hollow dots, hairline connectors | ✅ satisfied |

No scenarios single-node-descoped — HOME2 is a pure single-host UI glyph with no cluster/fence/multi-host surface.

### What changed
- **`ui/src/board/phase-model.ts`** (new) — the one React-free phase model the glyph reads: canonical 10-phase `PHASE_LIST` (no synthetic `done` step — `done` is a *status*), full/short labels, `phaseIndexOf` / `phaseFraction` / `isDoneStatus`, and `TERMINAL_STATUSES`. Colors come from the canonical `formatters.PHASE_COLORS` (re-exported `phaseColor`) so the glyph carries no hand-copied color map. Reserved live cyan (`#5be0ff`) is never used.
- **`ui/src/components/home/status-icon.tsx`** (new) — hand-rolled SVG glyph ported from the `home-proto` prototype, fed by the read-model item's `phase` + `status`.
- **`ui/src/components/home/phase-strip.tsx`** (new) — the compact pipeline strip over `PHASE_LIST`.
- **`ui/src/components/home/inbox-row.tsx`** / **`reading-pane.tsx`** (HOME1 hosts) — wire the glyph into the row (no text status badge) + pane header, and add the PhaseStrip "Where it's at" block.

### Drift guard (no silent divergence from the real pipeline)
`__tests__/board-phase-drift.test.ts` now also locks `phase-model.PHASE_LIST` to `board-data.PHASE_ORDER` and `phase-model.TERMINAL_STATUSES` to `board-data.TERMINAL` (both rooted in `workflow.default.json`). A renamed/reordered/added phase or a new terminal status is a hard CI failure here rather than a stale glyph.

### Tests
- `bun test __tests__/phase-model.test.ts __tests__/status-glyph.test.ts __tests__/board-phase-drift.test.ts __tests__/home-surface.test.ts __tests__/home-inbox.test.ts` → **86 pass, 0 fail** (includes HOME1 no-regression).
- `bunx tsc --noEmit` in the **orch-monitor** package → clean (exit 0).
- `bunx tsc --noEmit` in the **ui** package → my files clean; the single remaining error is the pre-existing `kpi-strip.tsx` `OrchestratorStats.abandoned` issue on `origin/main` (verified by stashing my changes), untouched here.
- `bun run build` (ui) → succeeds; build artifacts intentionally NOT committed (matching HOME1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)