### PR TITLE
feat(dev): HOME3 reframed groups + per-row durations (CTL-901)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/board-row-durations.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-row-durations.test.ts
@@ -1,0 +1,78 @@
+// board-row-durations.test.ts — CTL-901 (HOME3): the read-model must SURFACE the
+// per-row duration anchors the calm inbox renders. The honest "how long" line
+// (HOME3 scenario 4) hinges on the BoardTicket carrying:
+//   • heldSince         — the durable applied-at of the held labels (BFF11 /
+//     CTL-923 projected it into ticket_state; linear-cache-reader surfaces it as
+//     linfo[id].heldSince). The "how long has it been waiting on you" anchor.
+//   • currentPhaseSince — the current phase's startedAt (deriveCurrentPhase
+//     already reads it; the board assembly now forwards it instead of dropping
+//     it). The "how long has it been running / in its current state" anchor.
+//
+// assembleBoard() itself is not unit-testable (WORKERS_DIR is a homedir const and
+// it shells out to `claude agents`), so — exactly like board-held-indicator.test
+// and board-phase-drift.test — this pins the wiring by STATIC source analysis:
+//   1. the live + queued BoardTicket builders both stamp the two fields,
+//   2. they are sourced from the DURABLE caches (linfo.heldSince / the surfaced
+//      phase startedAt), never fabricated,
+//   3. the .d.mts wire contract and the UI types both declare them.
+// PLUS the pure deriveCurrentPhase already exposes startedAt (the data the
+// assembly forwards), pinned directly.
+import { test, expect, describe } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { deriveCurrentPhase, PHASE_ORDER } from "../lib/board-data.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(join(HERE, "..", rel), "utf8");
+
+const boardDataSrc = read("lib/board-data.mjs");
+const boardDataDts = read("lib/board-data.d.mts");
+const uiTypesSrc = read("ui/src/board/types.ts");
+
+describe("board read-model surfaces the per-row duration anchors (CTL-901)", () => {
+  test("the live BoardTicket builder forwards the current phase startedAt", () => {
+    // The assembly reads `cur = deriveCurrentPhase(...)` and now forwards its
+    // startedAt as currentPhaseSince (it used to drop it).
+    expect(boardDataSrc).toContain("currentPhaseSince: cur.startedAt ?? null");
+  });
+
+  test("the live BoardTicket builder sources heldSince from the durable cache (never fabricated)", () => {
+    // heldSince comes from linfo (linear-cache-reader → ticket_state.held_since,
+    // BFF11). null when the durable cache has no stamp — honest, not invented.
+    expect(boardDataSrc).toContain("heldSince: linfo[id]?.heldSince ?? null");
+  });
+
+  test("the queued (Todo-column) BoardTicket also carries the two anchors honestly", () => {
+    // A queued ticket has no worker dir / phase signal → currentPhaseSince is
+    // null; its held duration comes from the durable ticket_state heldSince.
+    expect(boardDataSrc).toContain("heldSince: li.heldSince ?? null");
+    expect(boardDataSrc).toContain("currentPhaseSince: null");
+  });
+
+  test("the .d.mts wire contract declares heldSince + currentPhaseSince", () => {
+    expect(boardDataDts).toContain("heldSince: string | null");
+    expect(boardDataDts).toContain("currentPhaseSince: string | null");
+  });
+
+  test("the UI BoardTicket type mirrors the two anchors", () => {
+    expect(uiTypesSrc).toContain("heldSince?: string | null");
+    expect(uiTypesSrc).toContain("currentPhaseSince?: string | null");
+  });
+});
+
+describe("deriveCurrentPhase exposes the startedAt the assembly forwards (CTL-901)", () => {
+  test("a running phase carries its startedAt (the running-row anchor)", () => {
+    const sigs = PHASE_ORDER.map(() => null) as ({ status: string; startedAt?: string } | null)[];
+    sigs[PHASE_ORDER.indexOf("implement")] = {
+      status: "running",
+      startedAt: "2026-06-09T09:56:00Z",
+    };
+    // earlier phases done so implement is the surfaced current phase
+    sigs[PHASE_ORDER.indexOf("triage")] = { status: "done" };
+    const cur = deriveCurrentPhase(sigs);
+    expect(cur.phase).toBe("implement");
+    expect(cur.startedAt).toBe("2026-06-09T09:56:00Z");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-view.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-view.test.ts
@@ -45,6 +45,10 @@ function ticket(id: string, overrides: Partial<BoardTicket> = {}): BoardTicket {
     updatedAt: "2026-06-08T11:00:00.000Z",
     held: null,
     blockers: [],
+    // CTL-901 (HOME3): per-row duration anchors — null in this fixture (the
+    // cluster view does not read them).
+    heldSince: null,
+    currentPhaseSince: null,
     // BFF10 stamps host:{name,id} + generation on every BoardTicket. The cluster
     // view groups off ownerHostById (the durable fence projection), not this per-
     // entity host, so these default null (single-host identity no-op) and tests

--- a/plugins/dev/scripts/orch-monitor/__tests__/home-inbox.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-inbox.test.ts
@@ -22,6 +22,8 @@ import {
   moveSelection,
   rowById,
   isNeedsYouSection,
+  rowDurationAnchor,
+  rowDurationMs,
   type InboxRow,
 } from "../ui/src/board/home-inbox";
 import type { BoardPayload, BoardTicket } from "../ui/src/board/types";
@@ -264,5 +266,98 @@ describe("calmHeaderSentence — ONE sentence, never a KPI grid (CTL-899)", () =
   it("collapses to the celebratory empty-state line when the inbox is empty", () => {
     const s = calmHeaderSentence({ blocked: 0, waiting: 0, running: 0, done: 0, needsYou: 0 });
     expect(s).toBe("All clear — nothing needs you right now.");
+  });
+});
+
+// ── CTL-901 (HOME3): per-row "how long" durations (honest, never fabricated) ──
+//
+// The acceptance criteria these lock in (the HOME3 Gherkin):
+//   • A waiting/blocked row shows how long it has needed you → anchored to the
+//     DURABLE heldSince (the applied-at of the held labels, BFF11).
+//   • A running row shows how long it has been running / in its current state →
+//     anchored to currentPhaseSince (the current phase's startedAt).
+//   • A duration with no real timestamp is honest, never fabricated → rowDurationMs
+//     returns null (the UI then OMITS / marks-unavailable the cell).
+describe("rowDurationAnchor — picks the right durable timestamp per section (CTL-901)", () => {
+  // Build a row directly (the row carries the underlying ticket).
+  function mkRow(section: InboxRow["section"], over: Partial<BoardTicket> = {}): InboxRow {
+    const t = mkTicket("CTL-901", over);
+    return {
+      id: t.id,
+      title: t.title,
+      section,
+      subLabel: "x",
+      verb: null,
+      blockers: [],
+      ticket: t,
+    };
+  }
+
+  it("a blocked row anchors to heldSince (how long it has been blocked)", () => {
+    const row = mkRow("blocked", { held: "blocked", heldSince: "2026-06-09T08:00:00Z" });
+    expect(rowDurationAnchor(row)).toBe("2026-06-09T08:00:00Z");
+  });
+
+  it("a waiting row anchors to heldSince (how long it has been waiting on you)", () => {
+    const row = mkRow("waiting", { held: "waiting", heldSince: "2026-06-09T07:30:00Z" });
+    expect(rowDurationAnchor(row)).toBe("2026-06-09T07:30:00Z");
+  });
+
+  it("a running row anchors to currentPhaseSince (how long it has been running)", () => {
+    const row = mkRow("running", { currentPhaseSince: "2026-06-09T09:56:00Z" });
+    expect(rowDurationAnchor(row)).toBe("2026-06-09T09:56:00Z");
+  });
+
+  it("a done row has no live duration anchor (null)", () => {
+    const row = mkRow("done", { currentPhaseSince: "2026-06-09T08:00:00Z" });
+    expect(rowDurationAnchor(row)).toBeNull();
+  });
+
+  it("a held row with NO durable heldSince has no anchor (honest null)", () => {
+    const row = mkRow("blocked", { held: "blocked", heldSince: null });
+    expect(rowDurationAnchor(row)).toBeNull();
+  });
+
+  it("a running row with NO currentPhaseSince has no anchor (honest null)", () => {
+    const row = mkRow("running", { currentPhaseSince: null });
+    expect(rowDurationAnchor(row)).toBeNull();
+  });
+});
+
+describe("rowDurationMs — elapsed since the durable anchor, honest about absence (CTL-901)", () => {
+  function mkRow(section: InboxRow["section"], over: Partial<BoardTicket> = {}): InboxRow {
+    const t = mkTicket("CTL-901", over);
+    return { id: t.id, title: t.title, section, subLabel: "x", verb: null, blockers: [], ticket: t };
+  }
+  const now = Date.parse("2026-06-09T10:00:00Z");
+
+  it("a row blocked for 2h reports ~2h of elapsed ms", () => {
+    const row = mkRow("blocked", { held: "blocked", heldSince: "2026-06-09T08:00:00Z" });
+    expect(rowDurationMs(row, now)).toBe(2 * 60 * 60 * 1000);
+  });
+
+  it("a row running for 4m reports ~4m of elapsed ms (the implement-phase case)", () => {
+    const row = mkRow("running", { currentPhaseSince: "2026-06-09T09:56:00Z" });
+    expect(rowDurationMs(row, now)).toBe(4 * 60 * 1000);
+  });
+
+  it("returns null — NOT a fabricated 0 — when the anchor is absent", () => {
+    const row = mkRow("blocked", { held: "blocked", heldSince: null });
+    expect(rowDurationMs(row, now)).toBeNull();
+  });
+
+  it("returns null when the anchor is an unparseable timestamp", () => {
+    const row = mkRow("waiting", { held: "waiting", heldSince: "not-a-date" });
+    expect(rowDurationMs(row, now)).toBeNull();
+  });
+
+  it("clamps a clock-skewed future anchor to 0 (never a negative duration)", () => {
+    const row = mkRow("running", { currentPhaseSince: "2026-06-09T10:05:00Z" });
+    expect(rowDurationMs(row, now)).toBe(0);
+  });
+
+  it("a done row never reports a live duration even with a phase timestamp", () => {
+    const row = mkRow("done", { currentPhaseSince: "2026-06-09T08:00:00Z" });
+    expect(rowDurationMs(row, now)).toBeNull();
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/home-row-duration-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-row-duration-format.test.ts
@@ -1,0 +1,56 @@
+// home-row-duration-format.test.ts — CTL-901 (HOME3): the QUIET single-unit
+// relative-duration formatter the calm inbox rows render. Unlike the dense
+// board's fmtDuration ("2h 5m"), the inbox shows ONE coarse unit ("2h", "4m") so
+// a needs-you row reads as a glance, not a stopwatch — and a null/negative input
+// (no honest backing timestamp) yields null so the caller OMITS the cell rather
+// than fabricating a "0s". This file pins both the format and the honest-absence
+// contract directly against the React-free formatter module.
+import { describe, it, expect } from "bun:test";
+import { fmtRelativeDuration } from "../ui/src/lib/formatters";
+
+const SEC = 1000;
+const MIN = 60 * SEC;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+describe("fmtRelativeDuration — quiet single coarsest unit (CTL-901)", () => {
+  it("sub-minute → seconds", () => {
+    expect(fmtRelativeDuration(0)).toBe("0s");
+    expect(fmtRelativeDuration(30 * SEC)).toBe("30s");
+    expect(fmtRelativeDuration(59 * SEC)).toBe("59s");
+  });
+
+  it("sub-hour → minutes only (no '4m 0s')", () => {
+    expect(fmtRelativeDuration(60 * SEC)).toBe("1m");
+    expect(fmtRelativeDuration(4 * MIN)).toBe("4m"); // the implement-phase 4m case
+    expect(fmtRelativeDuration(4 * MIN + 30 * SEC)).toBe("4m"); // truncates, one unit
+    expect(fmtRelativeDuration(59 * MIN)).toBe("59m");
+  });
+
+  it("sub-day → hours only (the Gherkin '2h' example)", () => {
+    expect(fmtRelativeDuration(2 * HOUR)).toBe("2h"); // "a quiet relative duration like '2h'"
+    expect(fmtRelativeDuration(2 * HOUR + 45 * MIN)).toBe("2h");
+    expect(fmtRelativeDuration(23 * HOUR)).toBe("23h");
+  });
+
+  it("≥ a day → days", () => {
+    expect(fmtRelativeDuration(DAY)).toBe("1d");
+    expect(fmtRelativeDuration(3 * DAY + 5 * HOUR)).toBe("3d");
+  });
+});
+
+describe("fmtRelativeDuration — honest about absence (never fabricates) (CTL-901)", () => {
+  it("null input → null (caller omits the cell, no fabricated time)", () => {
+    expect(fmtRelativeDuration(null)).toBeNull();
+  });
+
+  it("a negative duration (clock skew) → null, never a '-3m'", () => {
+    expect(fmtRelativeDuration(-1)).toBeNull();
+    expect(fmtRelativeDuration(-5 * MIN)).toBeNull();
+  });
+
+  it("a non-finite duration → null", () => {
+    expect(fmtRelativeDuration(Number.NaN)).toBeNull();
+    expect(fmtRelativeDuration(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
@@ -159,6 +159,53 @@ describe("data plane — read-model SSE, never a synchronous Linear call (CTL-89
   });
 });
 
+// ── CTL-901 (HOME3): reframed groups + per-row durations + collapsed reassurance
+describe("HOME3 — per-row durations are wired honestly into the row (CTL-901)", () => {
+  it("the row computes its duration from the pure rowDurationMs + fmtRelativeDuration", () => {
+    // The row derives the elapsed ms (rowDurationMs) and formats it with the
+    // quiet single-unit formatter — not the dense board's fmtDuration.
+    expect(inboxRowSrc).toContain("rowDurationMs");
+    expect(inboxRowSrc).toContain("fmtRelativeDuration");
+  });
+
+  it("the row OMITS the duration cell when there is no honest backing timestamp", () => {
+    // The "never fabricated" Gherkin: duration is rendered only when non-null;
+    // the absent branch carries the unavailable marker, never a fabricated time.
+    expect(rowCode).toMatch(/duration\s*!=\s*null/);
+    expect(rowCode).toContain("data-row-duration-unavailable");
+  });
+
+  it("the row threads a shared `now` clock (rows agree on one time)", () => {
+    expect(inboxRowSrc).toContain("now");
+  });
+});
+
+describe("HOME3 — reframed groups read in plain operator language (CTL-901)", () => {
+  // The three sections are the plain-language reframe. The labels live in the
+  // pure home-inbox module (SECTION_LABEL); guard them at the source of truth.
+  const homeInboxSrc = read("board/home-inbox.ts");
+  it("titles the sections 'What's blocked' / 'What's waiting' / 'Running on its own'", () => {
+    expect(homeInboxSrc).toContain('"What\'s blocked"');
+    expect(homeInboxSrc).toContain('"What\'s waiting"');
+    expect(homeInboxSrc).toContain('"Running on its own"');
+  });
+});
+
+describe("HOME3 — 'Running on its own' is a collapsed reassurance count by default (CTL-901)", () => {
+  it("the section block collapses the non-needs-you (reassurance) sets by default", () => {
+    // A reassurance section starts collapsed (open === !collapsible) and exposes
+    // a count toggle; needs-you sections (blocked/waiting) stay open.
+    expect(homeSurfaceSrc).toContain("isNeedsYouSection");
+    expect(homeSurfaceSrc).toContain("data-section-toggle");
+    expect(homeSurfaceSrc).toMatch(/data-collapsed/);
+  });
+
+  it("the surface ticks a `now` clock and passes it down to the rows", () => {
+    expect(homeSurfaceSrc).toContain("setNow");
+    expect(homeSurfaceSrc).toMatch(/now=\{now\}/);
+  });
+});
+
 // ── Scenario: App wires Home into the shell's "home" surface ──────────────────
 describe("App wiring — Home mounts into the shell home surface (CTL-899)", () => {
   it("App renders HomeSurface when the active surface is 'home'", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/read-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/read-model.test.ts
@@ -71,6 +71,9 @@ function ticket(id: string): BoardTicket {
     updatedAt: "",
     held: null,
     blockers: [],
+    // CTL-901 (HOME3): per-row duration anchors (null in this fixture).
+    heldSince: null,
+    currentPhaseSince: null,
     host: null,
     generation: null,
   };

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -99,6 +99,17 @@ export interface BoardTicket {
   held: "blocked" | "waiting" | null;
   /** Dependency ids a `blocked` hold is waiting on (from triage.json). */
   blockers: string[];
+  /** CTL-901 (HOME3): ISO applied-at of the held (blocked/waiting) labels, from
+   *  the durable ticket_state.held_since the broker projects (BFF11 / CTL-923).
+   *  The honest "how long has it been waiting on you" anchor; null when the
+   *  durable cache has no stamp (rendered unavailable, never fabricated). Only
+   *  meaningful while `held` is set. */
+  heldSince: string | null;
+  /** CTL-901 (HOME3): ISO wall-clock start of the ticket's CURRENT phase
+   *  (deriveCurrentPhase's startedAt) — the "how long has it been running / in
+   *  its current state" anchor for the running set. null when the surfaced phase
+   *  carried no startedAt. */
+  currentPhaseSince: string | null;
   /** CTL-922 (BFF10): the node owning this ticket, from the phase signals
    *  host:{name,id} (CTL-852) or the durable fence projection owner_host (BFF11).
    *  null when no host is named (single-host resolves to the one node). */

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -108,6 +108,12 @@ export function synthesizeQueuedTicket(e, linfo) {
     updatedAt: e.createdAt || new Date(0).toISOString(),
     held: heldFor(li.labels),
     blockers: [],
+    // CTL-901 (HOME3): a queued ticket has no worker dir / phase signal, so it
+    // has no current-phase start (null). Its held duration, when held, comes from
+    // the durable ticket_state heldSince the broker projected (BFF11) — honest
+    // null when the cache has no stamp.
+    heldSince: li.heldSince ?? null,
+    currentPhaseSince: null,
     // CTL-922 (BFF10): node attribution. A queued ticket has no worker dir /
     // phase signal, so host + generation come purely from the durable fence
     // projection (li, via the broker's BFF11 ticket_state). team is the
@@ -669,6 +675,22 @@ export async function assembleBoard() {
       // meaningful when held === "blocked"); empty otherwise.
       held: heldFor(linfo[id]?.labels),
       blockers: ticketBlockers(triage),
+      // CTL-901 (HOME3): per-row "how long has this needed me / been running"
+      // durations, sourced from DURABLE read-model timestamps only — never
+      // fabricated. `heldSince` is the applied-at of the held (blocked/waiting)
+      // labels, projected into ticket_state by the broker (BFF11 / CTL-923) and
+      // surfaced through linear-cache-reader; it is the honest "how long has it
+      // been waiting on you" anchor. null when the durable cache has no stamp
+      // (an older filter-state.db, or a not-yet-observed hold) → the UI renders
+      // the duration cell as unavailable rather than inventing one. Only
+      // meaningful while `held` is set; cleared to null on pickup/unblock.
+      heldSince: linfo[id]?.heldSince ?? null,
+      // The wall-clock start of the ticket's CURRENT phase (deriveCurrentPhase
+      // already reads it off the live/last phase signal) — the "how long has it
+      // been running / in its current state" anchor for the running set. null
+      // when the surfaced phase carried no startedAt (pre-pipeline / corrupt
+      // signal) → again rendered unavailable, never now-anchored to a guess.
+      currentPhaseSince: cur.startedAt ?? null,
       costUSD: costs[id]?.costUSD ?? null, tokens: costs[id]?.tokens ?? null,
       turns: phaseCostsByTicket[id]
         ? Object.values(phaseCostsByTicket[id]).reduce((s, p) => s + p.turns, 0)

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/home-inbox.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/home-inbox.ts
@@ -277,3 +277,46 @@ export function rowById(model: InboxModel, id: string | null): InboxRow | null {
   if (id == null) return null;
   return model.order.find((r) => r.id === id) ?? null;
 }
+
+// ── CTL-901 (HOME3): per-row "how long" durations ───────────────────────────
+// The page answers "what needs me and for how long". Each row carries a relative
+// duration anchored to a DURABLE read-model timestamp — never a fabricated one:
+//   • blocked / waiting → `heldSince` (the applied-at of the held labels, BFF11)
+//     = how long it has been waiting on you / blocked.
+//   • running           → `currentPhaseSince` (the current phase's startedAt)
+//     = how long it has been running / in its current state.
+//   • done              → no live duration (it is finished) → null.
+// When the chosen anchor is absent or unparseable, the duration is null and the
+// UI omits / marks-unavailable the cell rather than inventing a value (the
+// "honest, never fabricated" Gherkin). PURE + side-effect-free so it is unit-
+// testable from outside the React tree; `now` is injected for the same reason.
+
+/** The ISO timestamp a row's duration is measured FROM, per section. Returns the
+ *  durable anchor (heldSince for held rows, currentPhaseSince for running) or
+ *  null when this section has no live duration OR the anchor was never stamped. */
+export function rowDurationAnchor(row: InboxRow): string | null {
+  switch (row.section) {
+    case "blocked":
+    case "waiting":
+      return row.ticket.heldSince ?? null;
+    case "running":
+      return row.ticket.currentPhaseSince ?? null;
+    case "done":
+      return null;
+  }
+}
+
+/**
+ * The elapsed milliseconds a row has been in its current waiting/blocked/running
+ * state, or null when there is no honest backing timestamp (anchor absent or
+ * unparseable) — in which case the UI MUST omit / mark the cell unavailable
+ * rather than fabricate a value. A clock-skewed anchor in the future clamps to 0
+ * (we never render a negative "−3m"); the anchor itself is never mutated.
+ */
+export function rowDurationMs(row: InboxRow, now: number): number | null {
+  const anchor = rowDurationAnchor(row);
+  if (anchor == null) return null;
+  const t = Date.parse(anchor);
+  if (!Number.isFinite(t)) return null;
+  return Math.max(0, now - t);
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
@@ -103,6 +103,15 @@ export interface BoardTicket {
   held?: "blocked" | "waiting" | null;
   /** Dependency ids a `blocked` hold is waiting on (only meaningful when held === "blocked"). */
   blockers?: string[];
+  /** CTL-901 (HOME3): ISO applied-at of the held labels (durable ticket_state
+   *  held_since, projected by the broker — BFF11). The honest "how long has it
+   *  been waiting on you" anchor; null when no durable stamp exists (rendered
+   *  unavailable, never fabricated). Only meaningful while held is set. */
+  heldSince?: string | null;
+  /** CTL-901 (HOME3): ISO start of the ticket's CURRENT phase — the "how long
+   *  has it been running / in its current state" anchor for the running set.
+   *  null when the surfaced phase carried no startedAt. */
+  currentPhaseSince?: string | null;
   /** CTL-922 (BFF10): the node owning this ticket (BOARD3 host swimlanes), from
    *  the phase signals host:{name,id} (CTL-852) or the durable fence projection
    *  owner_host (BFF11). null when no host is named. */

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
@@ -22,14 +22,86 @@ import { useEffect, useMemo, useState } from "react";
 import {
   calmHeaderSentence,
   deriveInbox,
+  isNeedsYouSection,
   moveSelection,
   rowById,
+  type InboxSection,
 } from "@/board/home-inbox";
 import { isTypingTarget } from "@/lib/surface";
 import { useBoardSnapshot } from "@/hooks/use-board-snapshot";
 import { ResizableSplit } from "./resizable-split";
 import { InboxRow } from "./inbox-row";
 import { ReadingPane } from "./reading-pane";
+
+/** One inbox section. The needs-you sections (blocked / waiting) render their
+ *  rows OPEN; the reassurance sections (running on its own / done) collapse to a
+ *  quiet count by default (CTL-901 scenario 1 — "a collapsed reassurance count
+ *  by default") and expand on click. */
+function InboxSectionBlock({
+  section,
+  selectedId,
+  onSelect,
+  now,
+}: {
+  section: InboxSection;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  now: number;
+}) {
+  // Needs-you sections are always open (you must see what needs you). The
+  // reassurance sets start collapsed so the page de-alarms by subtraction.
+  const collapsible = !isNeedsYouSection(section.kind);
+  const [open, setOpen] = useState<boolean>(!collapsible);
+
+  return (
+    <section
+      data-inbox-section={section.kind}
+      data-collapsed={collapsible && !open ? "true" : undefined}
+      className="border-b border-border last:border-b-0"
+    >
+      <h2 className="px-4 pt-4 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted">
+        {collapsible ? (
+          // A collapsed reassurance section is a count chip you can expand —
+          // "Running on its own  4" — not a wall of rows.
+          <button
+            type="button"
+            data-section-toggle={section.kind}
+            aria-expanded={open}
+            onClick={() => setOpen((v) => !v)}
+            className="flex w-full items-center gap-2 text-left uppercase tracking-wide hover:text-fg"
+          >
+            <span aria-hidden className="font-mono text-[10px] text-muted/70">
+              {open ? "▾" : "▸"}
+            </span>
+            {section.label}
+            <span className="font-mono text-muted/70">{section.rows.length}</span>
+          </button>
+        ) : (
+          <>
+            {section.label}
+            <span className="ml-2 font-mono text-muted/70">{section.rows.length}</span>
+          </>
+        )}
+      </h2>
+      {/* Rows are divided by a hairline divider between them (the list is the
+          container; each row is bare). Collapsed reassurance sections render no
+          rows — just the count chip above. */}
+      {open && (
+        <div className="divide-y divide-border-subtle">
+          {section.rows.map((row) => (
+            <InboxRow
+              key={row.id}
+              row={row}
+              selected={row.id === selectedId}
+              onSelect={onSelect}
+              now={now}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
 
 /** The left list: the calm header sentence + the grouped bare-row sections. */
 function InboxList({
@@ -38,12 +110,14 @@ function InboxList({
   selectedId,
   onSelect,
   status,
+  now,
 }: {
   header: string;
   sections: ReturnType<typeof deriveInbox>["sections"];
   selectedId: string | null;
   onSelect: (id: string) => void;
   status: string;
+  now: number;
 }) {
   return (
     <div className="flex h-full flex-col bg-surface-0">
@@ -65,24 +139,13 @@ function InboxList({
           </p>
         ) : (
           sections.map((section) => (
-            <section key={section.kind} className="border-b border-border last:border-b-0">
-              <h2 className="px-4 pt-4 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted">
-                {section.label}
-                <span className="ml-2 font-mono text-muted/70">{section.rows.length}</span>
-              </h2>
-              {/* Rows are divided by a hairline divider between them (the list is
-                  the container; each row is bare). */}
-              <div className="divide-y divide-border-subtle">
-                {section.rows.map((row) => (
-                  <InboxRow
-                    key={row.id}
-                    row={row}
-                    selected={row.id === selectedId}
-                    onSelect={onSelect}
-                  />
-                ))}
-              </div>
-            </section>
+            <InboxSectionBlock
+              key={section.kind}
+              section={section}
+              selectedId={selectedId}
+              onSelect={onSelect}
+              now={now}
+            />
           ))
         )}
       </div>
@@ -113,6 +176,16 @@ export function HomeSurface() {
   // The selection: null until the operator (or the default-select effect) picks a
   // row. Held in React state so j/k and click both drive the one reading pane.
   const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  // CTL-901 (HOME3): one shared "now" clock the row durations measure against,
+  // ticked every 30s so a row reading "4m" advances to "5m" without re-fetching.
+  // 30s cadence keeps the calm page quiet (no per-second churn) while staying
+  // honest for the coarse single-unit display.
+  const [now, setNow] = useState<number>(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, []);
 
   // Default-select the top item on load, and keep the selection valid as the
   // snapshot reshuffles: if nothing is selected (first paint) OR the current
@@ -155,6 +228,7 @@ export function HomeSurface() {
             selectedId={selectedId}
             onSelect={setSelectedId}
             status={status}
+            now={now}
           />
         }
         reading={<ReadingPane row={selectedRow} />}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/inbox-row.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/inbox-row.tsx
@@ -11,7 +11,12 @@
 // the single primary VERB. Running/Done rows are fully neutral (no accent, no
 // verb) — that's how 90% of the page de-alarms by subtraction.
 import { cn } from "@/lib/utils";
-import { isNeedsYouSection, type InboxRow as InboxRowModel } from "@/board/home-inbox";
+import {
+  isNeedsYouSection,
+  rowDurationMs,
+  type InboxRow as InboxRowModel,
+} from "@/board/home-inbox";
+import { fmtRelativeDuration } from "@/lib/formatters";
 import { StatusIcon } from "./status-icon";
 
 /** Left-accent color per section. Only the needs-you sections carry an accent;
@@ -27,16 +32,28 @@ export function InboxRow({
   row,
   selected,
   onSelect,
+  now,
 }: {
   row: InboxRowModel;
   selected: boolean;
   onSelect: (id: string) => void;
+  /** CTL-901 (HOME3): the "current time" the relative duration is measured
+   *  against, threaded from the surface so all rows agree on one clock (and so
+   *  the cell stays honest under test). */
+  now: number;
 }) {
   const needsYou = isNeedsYouSection(row.section);
   const blockerSuffix =
     row.section === "blocked" && row.blockers.length > 0
       ? ` · ${row.blockers.join(", ")}`
       : "";
+
+  // CTL-901 (HOME3): the quiet relative duration — how long this row has been
+  // waiting on you / blocked (held rows) or running in its current state
+  // (running rows). null when there is no honest backing timestamp → we OMIT the
+  // cell entirely rather than render a fabricated value (the "never fabricated"
+  // Gherkin). The done set carries no live duration.
+  const duration = fmtRelativeDuration(rowDurationMs(row, now));
 
   return (
     <button
@@ -83,6 +100,24 @@ export function InboxRow({
           {blockerSuffix}
         </span>
       </span>
+
+      {/* The quiet relative duration — "how long has this needed me / been
+          running". A muted, right-aligned figure (never an alarm). OMITTED
+          entirely when there is no honest backing timestamp (held/running rows
+          with no durable anchor, and every done row) so the row never shows a
+          fabricated time. The data-* attributes let the headless suite assert
+          the honest present/absent behaviour without a DOM. */}
+      {duration != null ? (
+        <span
+          data-row-duration={duration}
+          title={`${row.subLabel} for ${duration}`}
+          className="mt-0.5 shrink-0 font-mono text-[11px] tabular-nums text-muted"
+        >
+          {duration}
+        </span>
+      ) : (
+        <span data-row-duration-unavailable aria-hidden className="sr-only" />
+      )}
 
       {/* The single primary verb — present only on needs-you rows. Everything
           else (View in Claude / Snooze / Dismiss) is one click deeper (HOME4). */}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/formatters.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/formatters.ts
@@ -17,6 +17,24 @@ export function fmtDuration(ms: number): string {
   return h + "h " + (m % 60) + "m";
 }
 
+// CTL-901 (HOME3): a QUIET, single-coarsest-unit relative duration for the calm
+// inbox rows — "2h", "4m", "30s", "3d" — never the compound "2h 5m" the dense
+// board uses (fmtDuration). One unit keeps the row unalarming and matches the
+// Gherkin "a quiet relative duration like '2h'". A null/negative input (no honest
+// backing timestamp) yields null so the caller OMITS the cell rather than
+// rendering a fabricated "0s" — the "honest, never fabricated" acceptance line.
+export function fmtRelativeDuration(ms: number | null): string | null {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return null;
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return s + "s";
+  const m = Math.floor(s / 60);
+  if (m < 60) return m + "m";
+  const h = Math.floor(m / 60);
+  if (h < 24) return h + "h";
+  const d = Math.floor(h / 24);
+  return d + "d";
+}
+
 export function fmtTokens(n: number): string {
   if (!Number.isFinite(n) || n <= 0) return "—";
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";


### PR DESCRIPTION
## What

Carries the prototype's **"what needs me and for how long"** reframe into the real `orch-monitor` Inbox (CTL-901 / HOME3). Builds on the merged deps **HOME1** (CTL-899, the calm master-detail Inbox + grouped sections) and **BFF1** (CTL-883, the cache-backed read-model). The held-duration timestamp this ticket flagged as NEEDS-PLUMBING was delivered by **BFF11 (CTL-923)** — the broker now projects `held_since` into `ticket_state`, and `linear-cache-reader` already surfaces it as `linfo.heldSince`; HOME3 forwards it onto the `BoardTicket` and renders it.

## How

**Read-model (board-data)** — surface two DURABLE per-row duration anchors on every `BoardTicket` (`+ .d.mts` wire contract `+ ui/types.ts`):
- `heldSince` — the applied-at of the held (blocked/waiting) labels, from `linfo[id].heldSince` (BFF11). The "how long has it been waiting on you / blocked" anchor. `null` when the durable cache has no stamp.
- `currentPhaseSince` — the current phase's `startedAt` (`deriveCurrentPhase` already reads it; the assembly used to **drop** it). The "how long has it been running / in its current state" anchor.

**UI**
- `formatters.ts` → `fmtRelativeDuration` — a QUIET single-coarsest-unit relative duration ("2h" / "4m" / "30s" / "3d"), distinct from the dense board's compound `fmtDuration`. `null`/negative/non-finite → `null` so the caller **omits** the cell.
- `home-inbox.ts` → pure `rowDurationAnchor` (picks `heldSince` for held rows, `currentPhaseSince` for running, `null` for done) + `rowDurationMs` (elapsed-or-null; future clock-skew clamps to 0).
- `inbox-row.tsx` → renders the quiet muted duration cell, **omitted entirely** when there is no honest backing timestamp (the "never fabricated" line).
- `home-surface.tsx` → "Running on its own"/"Done" reassurance sections collapse to a **count by default** and expand on click; needs-you sections (blocked/waiting) stay open. A shared 30s `now` clock is threaded down so all rows agree on one time.

## Gherkin scenarios

| Scenario | Status |
|---|---|
| Home groups read in plain operator language ("What's blocked"/"What's waiting"/"Running on its own"; running = collapsed reassurance count by default) | **Satisfied** (labels from HOME1's `SECTION_LABEL`; collapse added here) |
| A waiting/blocked row shows how long it has needed you (quiet "2h") | **Satisfied** (anchored to durable `heldSince`) |
| A running row shows how long it has been running / in its current state | **Satisfied** (anchored to `currentPhaseSince`) |
| A duration with no real timestamp is honest, never fabricated | **Satisfied** (null anchor → cell omitted/marked unavailable; skew clamps to 0) |

**Single-node descope:** none of the four scenarios are N>1-only. The anchors come from the single durable read-model the broker already projects — identity no-op for a single host, no cluster branch added.

## Tests (TDD)

- `home-inbox.test.ts` — `rowDurationAnchor`/`rowDurationMs` units: durable anchor per section, honest-null on absent/unparseable anchor, future-clamp-to-0, done never reports a live duration.
- `home-row-duration-format.test.ts` — `fmtRelativeDuration` format (single coarse unit, the "2h"/"4m" examples) + honest-absence contract (null/negative/NaN → null).
- `board-row-durations.test.ts` — read-model field-surfacing guards: `deriveCurrentPhase` exposes the `startedAt` the assembly forwards; live + queued builders stamp both anchors from the durable cache; `.d.mts` + ui types declare them.
- `home-surface.test.ts` — source-analysis guards: duration wiring into the row, omit-on-absent, the plain-language section labels, the collapsed-reassurance default + shared `now` clock.
- Fixture updates: `cluster-view.test.ts` / `read-model.test.ts` carry the two new required `BoardTicket` fields.

## Validation

- `bun test` (touched + related board/read-model suites): **120 pass / 0 fail**.
- `bunx tsc --noEmit` for orch-monitor: **clean**. For `ui`: my touched files add **zero** errors; the only error is a pre-existing, unrelated `kpi-strip.tsx` `OrchestratorStats.abandoned` issue present on `origin/main` (proven by stashing my changes).
- `bun run build` (ui): **succeeds** (built `public/assets` artifacts intentionally NOT committed — HOME1 set the convention of committing source only).
- No reward-hacking patterns (`as any` / `@ts-ignore` / non-null `!` / `forEach(async`) in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)