### PR TITLE
feat(dev): SURF1 Workers grid grouped/filtered by host node (CTL-909)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
@@ -327,6 +327,20 @@ function SurfaceSwitch({ dashboard }: { dashboard: ReactNode }) {
       </Suspense>
     );
   }
+  // CTL-909 / SURF1: the Workers surface is now a first-class dense grid — the
+  // same <Board /> scaffolding (Column/BoardScroll/WorkerCard) opened straight
+  // onto its Workers view, full-bleed in the inset, instead of the placeholder
+  // dashboard. It carries the node group-by + node filter; the single-host case
+  // is an identity no-op. (Worker-card deep-link to /worker/$id is wired in the
+  // routed board entry, which owns the router; the embedded shell has no router,
+  // so cards there stay non-interactive exactly as before — no dead links.)
+  if (surfaceContentKind(surface) === "workers") {
+    return (
+      <Suspense fallback={<SkeletonDashboard />}>
+        <Board embedded initialView="workers" />
+      </Suspense>
+    );
+  }
   if (surfaceContentKind(surface) === "board") {
     return (
       <Suspense fallback={<SkeletonDashboard />}>

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
@@ -18,6 +18,21 @@ import { connectBoard } from "./board-client";
 // detail-page pager (N/total) and the j/k walk read the SAME order. See
 // list-order.ts — the P1 keystone correctness item.
 import { resolveList, sortWorkers } from "./list-order";
+// ── CTL-909 / SURF1: node grouping + node filter (pure, DOM-free) ─────────────
+// The Workers surface adds a "node" grouping axis + a host filter that read the
+// BoardWorker.host {name,id} field (BFF10/CTL-922). The column derivation lives
+// in worker-grouping.ts so the Gherkin scenarios are unit-tested without a DOM;
+// Board.tsx only renders the columns it returns. SINGLE-HOST is an identity
+// no-op there (one node → one column, byte-for-byte the host-unaware order).
+import {
+  type WorkerGrouping,
+  nodeColumns,
+  workerHostNames,
+  filterWorkersByHost,
+  isMultiHost,
+  HOST_FILTER_ALL,
+  UNATTRIBUTED_HOST,
+} from "./worker-grouping";
 import type {
   BoardPayload,
   BoardWorker as Worker,
@@ -84,6 +99,20 @@ const TYPE_C: Record<string, string> = {
 };
 const repoColor = (repo: string) => (repo === "adva" ? "#c084fc" : "#4ea1ff");
 const isActive = (s: ActiveState) => s === "active";
+// CTL-909 / SURF1: a stable per-node accent so the "group by Node" columns +
+// the host chip on each worker card carry a consistent color. Hashed from the
+// host name (the unattributed bucket reads dim) — deterministic, no palette
+// state, and the single-host case simply gets its one color.
+const NODE_PALETTE = ["#4ea1ff", "#39d07a", "#a855f7", "#eabc3b", "#f472b6", "#5be0ff", "#fb8b3a"];
+const nodeColor = (host: string): string => {
+  if (host === UNATTRIBUTED_HOST) return C.fgDim;
+  let h = 0;
+  for (let i = 0; i < host.length; i++) h = (h * 31 + host.charCodeAt(i)) >>> 0;
+  // `?? C.blue` covers the (unreachable, but type-honest) empty-palette case
+  // without a non-null assertion — noUncheckedIndexedAccess types this as
+  // string | undefined.
+  return NODE_PALETTE[h % NODE_PALETTE.length] ?? C.blue;
+};
 
 function accentFor(t: { phase: string; repo: string; type: string; activeState: ActiveState; status: string }, by: ColorBy): string {
   if (by === "phase") return PHASE_C[t.phase] || C.blue;
@@ -300,18 +329,47 @@ function TicketCard({ t, colorBy, onSelect }: { t: Ticket; colorBy: ColorBy; onS
   );
 }
 
+// ── host chip — the worker's owning node (CTL-909 / SURF1) ────────────────────
+// Renders the BoardWorker.host.name (BFF10/CTL-922). SINGLE-HOST: with one node
+// every card shows the same name — it reads as a quiet provenance tag, not extra
+// chrome; the moment a second node joins, the per-host color disambiguates them.
+// A worker with no named host shows nothing (we never fabricate a host name).
+function HostChip({ host }: { host: Worker["host"] }) {
+  if (!host?.name) return null;
+  const c = nodeColor(host.name);
+  return (
+    <Tooltip><TooltipTrigger asChild>
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontFamily: C.mono, fontSize: 10, color: c, background: `${c}1f`, border: `1px solid ${c}3a`, padding: "0 6px", borderRadius: 5, whiteSpace: "nowrap" }}>
+        <span style={{ width: 6, height: 6, borderRadius: "50%", background: c, display: "inline-block" }} />{host.name}
+      </span>
+    </TooltipTrigger><TooltipContent>node {host.name}</TooltipContent></Tooltip>
+  );
+}
+
 // ── worker card (Workers board) ─────────────────────────────────────────────
-function WorkerCard({ w, info }: { w: Worker; info?: Ticket }) {
+function WorkerCard({ w, info, onSelect }: { w: Worker; info?: Ticket; onSelect?: (name: string) => void }) {
   const accent = PHASE_C[w.phase] || C.blue;
   const live = w.activeState === "active";
   const stuck = w.activeState === "stuck";
   const attempt = Number(/:(\d+)$/.exec(w.name)?.[1] ?? 1);
   const seen = w.lastActiveMs != null ? fmtMsAgo(w.lastActiveMs) : null;
   return (
-    <div className={live ? "catalyst-live" : undefined} style={{
-      background: live ? C.s3 : C.s2, borderRadius: 10, padding: "11px 13px",
-      border: `1px solid ${stuck ? "rgba(239,93,93,0.5)" : C.border}`, opacity: stuck ? 0.7 : 1,
-    }}>
+    <div
+      className={live ? "catalyst-live" : undefined}
+      // CTL-909 / SURF1: clicking a worker card deep-links to its single-run
+      // detail page (`/worker/$id`, keyed by w.name) via the supplied callback.
+      // When no callback is wired (the legacy embedded mount has no router) the
+      // card stays non-interactive exactly as before — no regression.
+      onClick={onSelect ? () => onSelect(w.name) : undefined}
+      role={onSelect ? "button" : undefined}
+      tabIndex={onSelect ? 0 : undefined}
+      onKeyDown={onSelect ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelect(w.name); } } : undefined}
+      style={{
+        background: live ? C.s3 : C.s2, borderRadius: 10, padding: "11px 13px",
+        border: `1px solid ${stuck ? "rgba(239,93,93,0.5)" : C.border}`, opacity: stuck ? 0.7 : 1,
+        cursor: onSelect ? "pointer" : undefined,
+      }}
+    >
       <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
         <ActivityDot state={w.activeState} fallback={accent} />
         {info && <PriorityIcon p={info.priority} />}
@@ -329,6 +387,8 @@ function WorkerCard({ w, info }: { w: Worker; info?: Ticket }) {
       {info?.title && <TitleText text={info.title} />}
       <div style={{ display: "flex", alignItems: "center", gap: 7, flexWrap: "wrap", marginTop: info?.title ? 0 : 9 }}>
         <PhasePill phase={w.phase} />
+        {/* CTL-909 / SURF1: owning host.name on every worker card. */}
+        <HostChip host={w.host} />
         <Badge variant="outline" style={{ fontFamily: C.mono, fontSize: 10, color: C.fgDim }}>{w.repo}</Badge>
         {info?.model && <Badge variant="secondary" style={{ fontFamily: C.mono, fontSize: 10 }}>{info.model}</Badge>}
       </div>
@@ -395,8 +455,26 @@ function TicketBoard({ tickets, lens, colorBy, fill, onSelect }: { tickets: Tick
     </BoardScroll>
   );
 }
-function WorkerBoard({ workers, tickets, grouping, fill }: { workers: Worker[]; tickets: Ticket[]; grouping: WorkerGrouping; fill: boolean }) {
+function WorkerBoard({ workers, tickets, grouping, fill, onWorkerSelect }: { workers: Worker[]; tickets: Ticket[]; grouping: WorkerGrouping; fill: boolean; onWorkerSelect?: (name: string) => void }) {
   const infoById: Record<string, Ticket> = Object.fromEntries(tickets.map((t) => [t.id, t]));
+  // CTL-909 / SURF1: "node" grouping lays out one column per host.name via the
+  // pure nodeColumns derivation (single-host → one column, identity no-op). The
+  // status/phase lenses are unchanged.
+  if (grouping === "node") {
+    const cols = nodeColumns(workers);
+    return (
+      <BoardScroll fill={fill}>
+        {cols.map((c) => {
+          const live = c.workers.filter((w) => w.activeState === "active").length;
+          return (
+            <Column key={c.host} label={c.host} color={nodeColor(c.host)} count={c.workers.length} live={live}>
+              {c.workers.map((w) => <WorkerCard key={w.name} w={w} info={infoById[w.ticket]} onSelect={onWorkerSelect} />)}
+            </Column>
+          );
+        })}
+      </BoardScroll>
+    );
+  }
   const cols = grouping === "phase" ? PHASE_COLS : WORKER_COLS;
   return (
     <BoardScroll fill={fill}>
@@ -409,7 +487,7 @@ function WorkerBoard({ workers, tickets, grouping, fill }: { workers: Worker[]; 
         const live = grouping === "phase" ? items.filter((w) => w.activeState === "active").length : 0;
         return (
           <Column key={c.key} label={c.label} color={c.c} count={items.length} live={live}>
-            {items.map((w) => <WorkerCard key={w.name} w={w} info={infoById[w.ticket]} />)}
+            {items.map((w) => <WorkerCard key={w.name} w={w} info={infoById[w.ticket]} onSelect={onWorkerSelect} />)}
           </Column>
         );
       })}
@@ -533,7 +611,8 @@ function QueueView({ data }: { data: BoardPayload }) {
 
 // ── shell (real shadcn Tabs + ToggleGroup, TooltipProvider) ─────────────────
 type View = "tickets" | "workers" | "queue";
-type WorkerGrouping = "status" | "phase";
+// WorkerGrouping ("status" | "phase" | "node") is now owned by worker-grouping.ts
+// (CTL-909 / SURF1) so the column derivation + the type stay in lock-step.
 function Seg<T extends string>({ value, onChange, options }: { value: T; onChange: (v: T) => void; options: { k: T; label: string }[] }) {
   return (
     <ToggleGroup type="single" value={value} onValueChange={(v) => v && onChange(v as T)} variant="outline" size="sm">
@@ -548,12 +627,26 @@ function Seg<T extends string>({ value, onChange, options }: { value: T; onChang
 // difference: it swaps the root height from 100vh → 100% so the dense grid fills
 // the inset's flex slot instead of overflowing the viewport by the strip height.
 // The data path (connectBoard / SharedWorker EventSource) is untouched in both.
-export function Board({ embedded = false }: { embedded?: boolean } = {}) {
+//
+// CTL-909 / SURF1:
+//   - `initialView` lets a host (e.g. the Workers app-shell surface) open the
+//     board straight onto the Workers grid instead of the Tickets default.
+//   - `onWorkerSelect` is the worker-card deep-link: the routed `/` board passes
+//     a `useNavigate`-backed callback to `/worker/$id`; when absent (the embedded
+//     mount has no router) the cards stay non-interactive, exactly as before.
+export function Board({
+  embedded = false,
+  initialView = "tickets",
+  onWorkerSelect,
+}: { embedded?: boolean; initialView?: View; onWorkerSelect?: (name: string) => void } = {}) {
   const [data, setData] = useState<BoardPayload | null>(null);
   const [status, setStatus] = useState<ConnectionStatus>("connecting");
-  const [view, setView] = useState<View>("tickets");
+  const [view, setView] = useState<View>(initialView);
   const [lens, setLens] = useState<"linear" | "phase">("linear");
   const [workerGrouping, setWorkerGrouping] = useState<WorkerGrouping>("status");
+  // CTL-909 / SURF1: the Workers node FILTER — "all" (no filter, single-host
+  // identity no-op) or a specific host.name to scope the grid to one node.
+  const [hostFilter, setHostFilter] = useState<string>(HOST_FILTER_ALL);
   const [repo, setRepo] = useState<string>("all");
   const [swimlanes, setSwimlanes] = useState(false); // default Combined (single Linear board)
   const [colorBy, setColorBy] = useState<ColorBy>("phase");
@@ -581,6 +674,22 @@ export function Board({ embedded = false }: { embedded?: boolean } = {}) {
   const repos = data?.repos ?? [];
   const fWorkers = useMemo(() => (data?.workers ?? []).filter((w) => repo === "all" || w.repo === repo), [data, repo]);
   const fTickets = useMemo(() => (data?.tickets ?? []).filter((t) => repo === "all" || t.repo === repo), [data, repo]);
+  // CTL-909 / SURF1: distinct host names across the (repo-filtered) workers — the
+  // node filter's option list. With one node this is a single entry, so the
+  // filter control hides (isMultiHost === false) and the single-host case stays
+  // chrome-free. The node grid + filter scope `fWorkers` (repo ∧ host).
+  const workerHosts = useMemo(() => workerHostNames(fWorkers), [fWorkers]);
+  const showNodeFilter = useMemo(() => isMultiHost(fWorkers), [fWorkers]);
+  // Drop a stale host filter when the selected node no longer has workers (its
+  // column vanished) so the grid never goes silently empty — fall back to "all".
+  const activeHostFilter =
+    hostFilter !== HOST_FILTER_ALL && !workerHosts.includes(hostFilter)
+      ? HOST_FILTER_ALL
+      : hostFilter;
+  const nodeWorkers = useMemo(
+    () => filterWorkersByHost(fWorkers, activeHostFilter),
+    [fWorkers, activeHostFilter],
+  );
   const ticketLanes = repos.filter((r) => fTickets.some((t) => t.repo === r));
   const workerLanes = repos.filter((r) => fWorkers.some((w) => w.repo === r));
   const combined = !swimlanes || repo !== "all";
@@ -628,9 +737,20 @@ export function Board({ embedded = false }: { embedded?: boolean } = {}) {
             <Seg value={colorBy} onChange={setColorBy} options={[{ k: "phase", label: "Phase" }, { k: "status", label: "Status" }, { k: "repo", label: "Repo" }, { k: "type", label: "Type" }]} />
             <Seg value={swimlanes ? "lanes" : "flat"} onChange={(v) => setSwimlanes(v === "lanes")} options={[{ k: "flat", label: "Combined" }, { k: "lanes", label: "Repo lanes" }]} />
           </>}
-          {view === "workers" && (
-            <Seg value={workerGrouping} onChange={setWorkerGrouping} options={[{ k: "status", label: "Status" }, { k: "phase", label: "Pipeline" }]} />
-          )}
+          {view === "workers" && <>
+            {/* CTL-909 / SURF1: group-by Status · Pipeline phase · Node. */}
+            <Seg value={workerGrouping} onChange={setWorkerGrouping} options={[{ k: "status", label: "Status" }, { k: "phase", label: "Pipeline" }, { k: "node", label: "Node" }]} />
+            {/* CTL-909 / SURF1: the node FILTER scopes the grid to one host. Shown
+                only for a multi-node fleet — with a single node the filter is
+                inert, so the single-host case stays chrome-free (identity no-op). */}
+            {showNodeFilter && (
+              <Seg
+                value={activeHostFilter}
+                onChange={setHostFilter}
+                options={[{ k: HOST_FILTER_ALL, label: "All nodes" }, ...workerHosts.map((h) => ({ k: h, label: h === UNATTRIBUTED_HOST ? "Unattributed" : h }))]}
+              />
+            )}
+          </>}
         </div>
 
         {/* body */}
@@ -640,8 +760,10 @@ export function Board({ embedded = false }: { embedded?: boolean } = {}) {
             ? <TicketBoard tickets={fTickets} lens={lens} colorBy={colorBy} fill onSelect={(id) => setSelectedTicketId(id)} />
             : <div className="cat-scroll" style={{ overflowY: "auto", height: "calc(var(--cat-board-vh, 100vh) - 104px)", paddingTop: 4 }}>{ticketLanes.map((r) => <Lane key={r} repo={r}><TicketBoard tickets={fTickets.filter((t) => t.repo === r)} lens={lens} colorBy={colorBy} fill={false} onSelect={(id) => setSelectedTicketId(id)} /></Lane>)}</div>)}
           {data && view === "workers" && (combined
-            ? <WorkerBoard workers={fWorkers} tickets={data.tickets} grouping={workerGrouping} fill />
-            : <div className="cat-scroll" style={{ overflowY: "auto", height: "calc(var(--cat-board-vh, 100vh) - 104px)", paddingTop: 4 }}>{workerLanes.map((r) => <Lane key={r} repo={r}><WorkerBoard workers={fWorkers.filter((w) => w.repo === r)} tickets={data.tickets} grouping={workerGrouping} fill={false} /></Lane>)}</div>)}
+            // CTL-909 / SURF1: the node filter scopes the combined grid to one
+            // host; "all" is the identity no-op (nodeWorkers === fWorkers).
+            ? <WorkerBoard workers={nodeWorkers} tickets={data.tickets} grouping={workerGrouping} fill onWorkerSelect={onWorkerSelect} />
+            : <div className="cat-scroll" style={{ overflowY: "auto", height: "calc(var(--cat-board-vh, 100vh) - 104px)", paddingTop: 4 }}>{workerLanes.map((r) => <Lane key={r} repo={r}><WorkerBoard workers={filterWorkersByHost(fWorkers.filter((w) => w.repo === r), activeHostFilter)} tickets={data.tickets} grouping={workerGrouping} fill={false} onWorkerSelect={onWorkerSelect} /></Lane>)}</div>)}
           {data && view === "queue" && <QueueView data={{ ...data, queue: data.queue.filter((q) => repo === "all" || q.repo === repo) }} />}
         </div>
         {selectedTicket && (

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/router.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/router.tsx
@@ -27,6 +27,7 @@ import {
   createRouter,
   Outlet,
   RouterProvider,
+  useNavigate,
 } from "@tanstack/react-router";
 import { Board } from "./Board";
 import { validateDetailSearch } from "./route-search";
@@ -39,11 +40,24 @@ const rootRoute = createRootRoute({
   component: () => <Outlet />,
 });
 
-// `/` — the existing board, mounted unchanged.
+// `/` — the existing board. CTL-909 / SURF1: a thin wrapper injects the
+// worker-card deep-link (onWorkerSelect → navigate to `/worker/$id`) so the
+// Workers grid's cards open the single-run detail page. The Board itself stays
+// router-free (it also mounts in the embedded, router-less app shell).
+function BoardRoot() {
+  const navigate = useNavigate();
+  return (
+    <Board
+      onWorkerSelect={(name) =>
+        void navigate({ to: "/worker/$id", params: { id: name }, search: { from: "board" } })
+      }
+    />
+  );
+}
 const boardRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/",
-  component: Board,
+  component: BoardRoot,
 });
 
 // `/ticket/$id` — typed id param + typed search contract. Renders the shared

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/worker-grouping.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/worker-grouping.test.ts
@@ -1,0 +1,215 @@
+// worker-grouping.test.ts — units for the SURF1 Workers node grouping + filter
+// (CTL-909). Pure logic, no DOM — run from the ui package:
+//   cd ui && bun test src/board/worker-grouping.test.ts
+//
+// Each `describe` maps to a Gherkin scenario in the ticket (SURF1):
+//   - "Worker cards are attributable to their host node"  → workerHostName / columns
+//   - "selecting group-by Node lays out one column per host.name" → nodeColumns
+//   - "a node filter lets the operator scope the grid to a single host" → filterWorkersByHost
+//   - "Single-host cluster is an exact identity no-op" → the single-host collapse
+import { describe, it, expect } from "bun:test";
+import type { BoardWorker } from "./types";
+import { sortWorkers } from "./list-order";
+import {
+  workerHostName,
+  workerHostNames,
+  filterWorkersByHost,
+  nodeColumns,
+  isMultiHost,
+  HOST_FILTER_ALL,
+  UNATTRIBUTED_HOST,
+} from "./worker-grouping";
+
+// Minimal worker factory — only the fields the grouping reads matter; the rest
+// are filled with inert defaults so the BoardWorker shape is satisfied.
+function w(
+  over: Partial<BoardWorker> & Pick<BoardWorker, "name">,
+): BoardWorker {
+  return {
+    ticket: over.name.split(":")[0] ?? over.name,
+    tickets: [over.name.split(":")[0] ?? over.name],
+    phase: "implement",
+    status: "running",
+    activeState: null,
+    working: false,
+    lastActiveMs: null,
+    repo: "catalyst",
+    team: "CTL",
+    runtimeMs: null,
+    costUSD: null,
+    host: null,
+    ...over,
+  };
+}
+
+const host = (name: string) => ({ name, id: `id-${name}` });
+
+describe("workerHostName — host attribution off the worker entity", () => {
+  it("returns the worker's host.name when a host is named", () => {
+    expect(workerHostName(w({ name: "CTL-1:1", host: host("mini") }))).toBe("mini");
+  });
+
+  it("returns null when the worker has no named host (never fabricates one)", () => {
+    expect(workerHostName(w({ name: "CTL-1:1", host: null }))).toBeNull();
+    expect(workerHostName(w({ name: "CTL-1:1" }))).toBeNull();
+  });
+});
+
+describe("workerHostNames — distinct nodes in display order", () => {
+  it("lists distinct real host names sorted alphabetically", () => {
+    const workers = [
+      w({ name: "CTL-1:1", host: host("zed") }),
+      w({ name: "CTL-2:1", host: host("alpha") }),
+      w({ name: "CTL-3:1", host: host("alpha") }),
+      w({ name: "CTL-4:1", host: host("mini") }),
+    ];
+    expect(workerHostNames(workers)).toEqual(["alpha", "mini", "zed"]);
+  });
+
+  it("appends the unattributed bucket LAST when a worker has no host", () => {
+    const workers = [
+      w({ name: "CTL-1:1", host: host("mini") }),
+      w({ name: "CTL-2:1", host: null }),
+      w({ name: "CTL-3:1", host: host("alpha") }),
+    ];
+    expect(workerHostNames(workers)).toEqual(["alpha", "mini", UNATTRIBUTED_HOST]);
+  });
+
+  it("yields no columns for an empty worker set", () => {
+    expect(workerHostNames([])).toEqual([]);
+  });
+
+  // Single-host identity no-op: exactly one column.
+  it("collapses to a single entry when only one node exists", () => {
+    const workers = [
+      w({ name: "CTL-1:1", host: host("mini") }),
+      w({ name: "CTL-2:1", host: host("mini") }),
+    ];
+    expect(workerHostNames(workers)).toEqual(["mini"]);
+  });
+});
+
+describe("filterWorkersByHost — the node filter scopes the grid", () => {
+  const workers = [
+    w({ name: "CTL-1:1", host: host("mini") }),
+    w({ name: "CTL-2:1", host: host("alpha") }),
+    w({ name: "CTL-3:1", host: null }),
+  ];
+
+  it("is an identity no-op for the ALL sentinel (every node)", () => {
+    expect(filterWorkersByHost(workers, HOST_FILTER_ALL).map((x) => x.name)).toEqual([
+      "CTL-1:1",
+      "CTL-2:1",
+      "CTL-3:1",
+    ]);
+  });
+
+  it("scopes to exactly one host when a host name is selected", () => {
+    expect(filterWorkersByHost(workers, "alpha").map((x) => x.name)).toEqual([
+      "CTL-2:1",
+    ]);
+  });
+
+  it("scopes to the hostless workers under the unattributed sentinel", () => {
+    expect(filterWorkersByHost(workers, UNATTRIBUTED_HOST).map((x) => x.name)).toEqual([
+      "CTL-3:1",
+    ]);
+  });
+
+  it("yields an empty list for a host with no workers (never throws)", () => {
+    expect(filterWorkersByHost(workers, "ghost")).toEqual([]);
+  });
+
+  it("does not mutate the input array", () => {
+    const before = workers.map((x) => x.name);
+    filterWorkersByHost(workers, "mini");
+    expect(workers.map((x) => x.name)).toEqual(before);
+  });
+});
+
+describe("nodeColumns — one column (lane) per host.name", () => {
+  it("lays out one column per node, in workerHostNames order", () => {
+    const workers = [
+      w({ name: "CTL-1:1", host: host("mini") }),
+      w({ name: "CTL-2:1", host: host("alpha") }),
+      w({ name: "CTL-3:1", host: host("alpha") }),
+    ];
+    const cols = nodeColumns(workers);
+    expect(cols.map((c) => c.host)).toEqual(["alpha", "mini"]);
+    expect(cols[0]!.workers.map((x) => x.name).sort()).toEqual(["CTL-2:1", "CTL-3:1"]);
+    expect(cols[1]!.workers.map((x) => x.name)).toEqual(["CTL-1:1"]);
+  });
+
+  it("orders each column's workers by the shared sortWorkers comparator", () => {
+    // active sorts before idle before stuck; within a rank, longer runtime first.
+    const workers = [
+      w({ name: "CTL-1:1", host: host("mini"), activeState: "stuck" }),
+      w({ name: "CTL-2:1", host: host("mini"), activeState: "active", runtimeMs: 1000 }),
+      w({ name: "CTL-3:1", host: host("mini"), activeState: "active", runtimeMs: 5000 }),
+      w({ name: "CTL-4:1", host: host("mini"), activeState: null, runtimeMs: 2000 }),
+    ];
+    const col = nodeColumns(workers)[0]!;
+    const expected = sortWorkers(workers).map((x) => x.name);
+    expect(col.workers.map((x) => x.name)).toEqual(expected);
+    // sanity: active (longest first) → idle → stuck
+    expect(col.workers.map((x) => x.name)).toEqual([
+      "CTL-3:1",
+      "CTL-2:1",
+      "CTL-4:1",
+      "CTL-1:1",
+    ]);
+  });
+
+  it("yields no columns for an empty worker set", () => {
+    expect(nodeColumns([])).toEqual([]);
+  });
+
+  // ── Single-host cluster is an exact identity no-op ──────────────────────────
+  it("collapses to ONE column whose order is the host-unaware sortWorkers order", () => {
+    const workers = [
+      w({ name: "CTL-1:1", host: host("mini"), activeState: "active", runtimeMs: 100 }),
+      w({ name: "CTL-2:1", host: host("mini"), activeState: "stuck" }),
+      w({ name: "CTL-3:1", host: host("mini"), activeState: "active", runtimeMs: 900 }),
+    ];
+    const cols = nodeColumns(workers);
+    expect(cols).toHaveLength(1);
+    expect(cols[0]!.host).toBe("mini");
+    // byte-for-byte the host-unaware ordering — no extra chrome, no reordering.
+    expect(cols[0]!.workers.map((x) => x.name)).toEqual(
+      sortWorkers(workers).map((x) => x.name),
+    );
+  });
+});
+
+describe("isMultiHost — the node filter is only worth showing for N>1 nodes", () => {
+  it("is false for a single-host fleet (the filter would be inert)", () => {
+    expect(
+      isMultiHost([
+        w({ name: "CTL-1:1", host: host("mini") }),
+        w({ name: "CTL-2:1", host: host("mini") }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("is false for an empty fleet", () => {
+    expect(isMultiHost([])).toBe(false);
+  });
+
+  it("is true once a second distinct node joins", () => {
+    expect(
+      isMultiHost([
+        w({ name: "CTL-1:1", host: host("mini") }),
+        w({ name: "CTL-2:1", host: host("alpha") }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("counts the unattributed bucket as a distinct lane", () => {
+    expect(
+      isMultiHost([
+        w({ name: "CTL-1:1", host: host("mini") }),
+        w({ name: "CTL-2:1", host: null }),
+      ]),
+    ).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/worker-grouping.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/worker-grouping.ts
@@ -1,0 +1,115 @@
+// worker-grouping.ts — the PURE, DOM-free grouping/filter decision for the
+// Workers surface (CTL-909 / SURF1).
+//
+// The Workers board lays its worker cards out in columns. Today the grouping
+// axis is "status" (Active/Stuck) or "phase" (one column per pipeline phase);
+// SURF1 adds a third axis, "node" — one column per owning HOST, plus a node
+// FILTER that scopes the whole grid to a single host. Both read the
+// `BoardWorker.host` field (a {name,id} HostRef, plumbed by BFF10/CTL-922 onto
+// every worker entity from the phase signal's host:{name,id}, CTL-852).
+//
+// SINGLE-HOST IDENTITY NO-OP (the hard operator constraint): with one node the
+// node grouping collapses to exactly ONE column and the grid reads identically
+// to a host-unaware grid — there is no separate cluster code path, no added
+// latency, no extra chrome. The same column-derivation runs whether there are
+// one or N hosts; N just yields N columns. A worker with no named host falls
+// into an explicit "unattributed" bucket rather than being dropped.
+//
+// Kept React-/router-free (the same discipline surface.ts / list-order.ts /
+// route-search.ts follow) so the Gherkin acceptance scenarios are unit-tested
+// under `bun test` without a DOM. Board.tsx renders the columns this module
+// derives; it owns no layout itself.
+import type { BoardWorker } from "./types";
+import { sortWorkers } from "./list-order";
+
+/** The worker-board grouping axis. SURF1 adds "node" to the existing pair. */
+export type WorkerGrouping = "status" | "phase" | "node";
+
+/** The sentinel host-filter value meaning "every node" (no filter applied). */
+export const HOST_FILTER_ALL = "all" as const;
+
+/** The label a worker with no named host is grouped/displayed under. A worker's
+ *  `host` is null until a phase signal stamps host:{name,id} (CTL-852); we name
+ *  that honestly rather than inventing a host id. */
+export const UNATTRIBUTED_HOST = "unattributed" as const;
+
+/** One node column on the Workers grid: the host name (its column label) and the
+ *  workers that resolve to it, already ordered by the shared worker comparator. */
+export interface NodeColumn {
+  /** The host name the column groups by, or `UNATTRIBUTED_HOST` for hostless workers. */
+  host: string;
+  /** This node's workers, in `sortWorkers` order (active → others → stuck). */
+  workers: BoardWorker[];
+}
+
+/** The host a worker is attributed to: its `host.name`, or null when unnamed. */
+export function workerHostName(w: BoardWorker): string | null {
+  return w.host?.name ?? null;
+}
+
+/**
+ * The distinct host names present across the given workers, in stable display
+ * order: real host names sorted alphabetically, with the `unattributed` bucket
+ * (if any worker lacks a host) appended LAST so a hostless worker never hides a
+ * real node. An empty input yields `[]` (no columns) — never a fabricated host.
+ *
+ * SINGLE-HOST: one node ⇒ exactly one entry, so `nodeColumns` collapses to one
+ * column — the identity no-op the spec mandates.
+ */
+export function workerHostNames(workers: readonly BoardWorker[]): string[] {
+  const named = new Set<string>();
+  let hasUnattributed = false;
+  for (const w of workers) {
+    const name = workerHostName(w);
+    if (name === null || name === "") hasUnattributed = true;
+    else named.add(name);
+  }
+  const out = [...named].sort((a, b) => a.localeCompare(b));
+  if (hasUnattributed) out.push(UNATTRIBUTED_HOST);
+  return out;
+}
+
+/**
+ * Scope a worker list to a single host. `HOST_FILTER_ALL` is a pure identity
+ * no-op (returns the same membership, never a copy-induced reorder concern —
+ * callers pass the result straight into grouping). `UNATTRIBUTED_HOST` selects
+ * exactly the hostless workers. Any other value selects the workers whose
+ * `host.name` matches. Returns a new array (never mutates the payload).
+ */
+export function filterWorkersByHost(
+  workers: readonly BoardWorker[],
+  host: string,
+): BoardWorker[] {
+  if (host === HOST_FILTER_ALL) return [...workers];
+  if (host === UNATTRIBUTED_HOST) {
+    return workers.filter((w) => {
+      const n = workerHostName(w);
+      return n === null || n === "";
+    });
+  }
+  return workers.filter((w) => workerHostName(w) === host);
+}
+
+/**
+ * Lay the workers out as one column per host name (the "node" grouping axis).
+ * Columns follow `workerHostNames` order; each column's workers are ordered by
+ * the SAME `sortWorkers` comparator the status/phase lenses and the in-flight
+ * queue use, so card order is consistent across every Workers view.
+ *
+ * SINGLE-HOST IDENTITY NO-OP: with one node this returns a single column whose
+ * workers are exactly `sortWorkers(workers)` — byte-for-byte the host-unaware
+ * ordering, no extra chrome. An empty input yields `[]`.
+ */
+export function nodeColumns(workers: readonly BoardWorker[]): NodeColumn[] {
+  return workerHostNames(workers).map((host) => ({
+    host,
+    workers: sortWorkers(filterWorkersByHost(workers, host)),
+  }));
+}
+
+/** True when the workers span more than one node (so the node FILTER control is
+ *  worth showing). With a single host the filter would be inert, so the surface
+ *  can hide it — the single-host case stays chrome-free. */
+export function isMultiHost(workers: readonly BoardWorker[]): boolean {
+  return workerHostNames(workers).length > 1;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.test.ts
@@ -15,18 +15,25 @@ describe("surfaceContentKind", () => {
     expect(surfaceContentKind("board")).toBe("board");
   });
 
-  it("keeps every non-board surface on the dashboard (no regression)", () => {
-    // Home/Workers/Queue must stay exactly what SHELL1 rendered — only the board
-    // surface is newly special-cased in SHELL2.
-    const nonBoard = SURFACES.filter((s) => s !== "board");
-    for (const s of nonBoard) {
+  it("routes the Workers surface to the dense Workers grid (CTL-909 / SURF1)", () => {
+    // Gherkin (SURF1): "the operator clicks the Workers nav item → the Workers
+    // surface renders edge-to-edge in the SidebarInset" — no longer the
+    // placeholder dashboard.
+    expect(surfaceContentKind("workers")).toBe("workers");
+  });
+
+  it("keeps Home/Queue on the dashboard (no regression)", () => {
+    // Home + Queue must stay exactly what they rendered before — only board +
+    // workers are special-cased now.
+    const onDashboard = SURFACES.filter((s) => s !== "board" && s !== "workers");
+    for (const s of onDashboard) {
       expect(surfaceContentKind(s)).toBe("dashboard");
     }
   });
 
   it("covers every declared surface (no surface falls through undefined)", () => {
     for (const s of SURFACES as readonly Surface[]) {
-      expect(["board", "dashboard"]).toContain(surfaceContentKind(s));
+      expect(["board", "workers", "dashboard"]).toContain(surfaceContentKind(s));
     }
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.ts
@@ -15,22 +15,26 @@ import type { Surface } from "./surface";
 /**
  * The kind of content the SidebarInset renders for a surface.
  *  - "board"     → the dense, full-bleed <Board /> grid (CTL-892).
+ *  - "workers"   → the dense Workers grid: the SAME <Board /> opened on its
+ *                  Workers view, with the node group-by + node filter (CTL-909).
  *  - "dashboard" → the existing monitor dashboard / orchestrator / comms / etc.
  *
- * Workers + Queue still fall through to "dashboard" today; they migrate to their
- * own dense surfaces in later SHELL tickets. Home is the calm dashboard inbox.
+ * Queue still falls through to "dashboard" today; it migrates to its own dense
+ * surface in a later SHELL ticket. Home is the calm dashboard inbox.
  */
-export type SurfaceContentKind = "board" | "dashboard";
+export type SurfaceContentKind = "board" | "workers" | "dashboard";
 
 /**
  * Resolve which content kind the inset should render for the active surface.
- * Only "board" is special-cased in SHELL2; every other surface keeps the
- * dashboard content so this ticket stays behavior-preserving for Home/Workers/
- * Queue (no regression — the Gherkin "no capped reading column" requirement only
- * applies to the board surface).
+ * "board" was special-cased in SHELL2; SURF1 (CTL-909) adds "workers" — the
+ * Workers surface is now its own dense grid instead of the placeholder
+ * dashboard. Every other surface keeps the dashboard content so this stays
+ * behavior-preserving for Home/Queue (no regression).
  */
 export function surfaceContentKind(surface: Surface): SurfaceContentKind {
-  return surface === "board" ? "board" : "dashboard";
+  if (surface === "board") return "board";
+  if (surface === "workers") return "workers";
+  return "dashboard";
 }
 
 /**


### PR DESCRIPTION
## SURF1 (CTL-909) — Workers grid grouped/filtered by host

Makes the redesigned shell's **Workers** nav item a first-class dense surface: the same Board `Column`/`BoardScroll`/`WorkerCard` scaffolding opened on its Workers view, full-bleed in the `SidebarInset`, with a net-new **node grouping axis** + **node filter**. Each worker card now surfaces its owning host node.

The host data was already plumbed onto every worker entity by BFF10/CTL-922 (`BoardWorker.host: {name,id}`, assembled in `lib/board-data.mjs` from the phase signal's `host:{name,id}`, CTL-852). This ticket is the UI surface that consumes it — no data-layer changes.

### What changed
- **`ui/src/board/worker-grouping.ts`** (new) — PURE, DOM-free column derivation: one column per `host.name`, a host filter, and the `WorkerGrouping = "status" | "phase" | "node"` type. Columns order each node's workers by the shared `sortWorkers` comparator. Hostless workers fall into an explicit `unattributed` bucket (never a fabricated host).
- **`ui/src/board/worker-grouping.test.ts`** (new) — 19 unit tests encoding the Gherkin scenarios.
- **`ui/src/board/Board.tsx`** — adds the `"node"` group-by, a node filter (shown only for N>1 hosts so the single-host case stays chrome-free), a per-card `HostChip` rendering `host.name`, the `initialView`/`onWorkerSelect` props, and the node-aware `WorkerBoard` branch.
- **`ui/src/lib/surface-content.ts` (+ test)** — routes `surface === "workers"` to its own dense grid (`"workers"` content kind) instead of the placeholder dashboard.
- **`ui/src/App.tsx`** — mounts `<Board embedded initialView="workers" />` for the Workers surface.
- **`ui/src/board/router.tsx`** — the routed `/` board wires `onWorkerSelect → navigate({ to: "/worker/$id" })` so worker cards open the single-run detail page.

### Gherkin scenarios
| Scenario | Status |
|---|---|
| Workers nav item opens the live session grid | ✅ satisfied — `surface==="workers"` renders the dense Board Workers grid edge-to-edge in the SidebarInset (reusing Column/BoardScroll/WorkerCard); `g w` already jumps to it (SHELL stream) |
| Worker cards are attributable to their host node | ✅ satisfied — each card shows `host.name` (HostChip); group-by offers Status · Pipeline · **Node**; group-by Node lays out one column per `host.name`; a node filter scopes to a single host |
| Single-host cluster is an exact identity no-op | ✅ satisfied — one node collapses to exactly one column whose order is byte-for-byte `sortWorkers`; the node filter is hidden (`isMultiHost === false`); no extra chrome, no separate cluster path |
| A worker card deep-links to its run | ✅ satisfied (routed board) — `onWorkerSelect → /worker/$id` (keyed by `w.name`). The embedded app-shell mount has no router, so its cards stay non-interactive exactly as before — **no dead links** |

### Single-node MVP descope
Per the operator constraint, multi-node behavior is built as the spec-mandated **single-host identity no-op**: the same `nodeColumns` derivation runs whether there are one or N hosts; N just yields N columns. No multi-node anchors (CTL-863/864/865/866/873/876) were built — their host-field contract is satisfied by the already-landed BFF10/CTL-922 `host` field, which this surface only consumes.

### Validation
- `bunx tsc --noEmit` (ui package) — clean on all touched files (pre-existing baseline errors in `canonical-event*.ts` / `kpi-strip.tsx` / `bun:test` resolution are unrelated and unchanged).
- `bun run build` (ui) — green.
- `bun test src/board/worker-grouping.test.ts src/lib/surface-content.test.ts src/board/nav-store.test.ts src/lib/sidebar-collapse.test.ts` — **46 pass, 0 fail**.
- No reward-hacking (`as any` / `as unknown` / `@ts-ignore` / non-null `!` in source / `forEach(async`).
- `public/` build artifacts intentionally not committed (per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)