### PR TITLE
feat(dev): DETAIL2 ticket detail page skeleton (CTL-913)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/board/detail-route.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/detail-route.tsx
@@ -18,6 +18,7 @@ import { resolveListIds } from "./list-order";
 import { Shell, type PropertyRow, type ShellKind, type StreamHealth } from "./Shell";
 import type { BoardPayload, BoardTicket, BoardWorker } from "./types";
 import type { DetailSearch } from "./route-search";
+import { TicketDetailPage } from "../components/ticket-detail-page";
 
 // ── resident payload subscription (same transport as Board.tsx) ─────────────
 function useBoardPayload(): { payload: BoardPayload | null; health: StreamHealth } {
@@ -118,9 +119,10 @@ export function TicketDetailRoute({ id, search }: { id: string; search: DetailSe
       properties={ticketRows(ticket)}
       streamHealth={health}
     >
-      <div data-detail-body-placeholder="ticket" style={{ color: "#5b626f", font: "12px ui-monospace, monospace" }}>
-        Ticket lifecycle body (spine · telemetry · runs) lands in DETAIL2.
-      </div>
+      {/* DETAIL2 (CTL-913): the lifecycle aggregate body — header · PIPELINE rail ·
+          HELD banner · LIFECYCLE SPINE + compact gantt · COMMS · ACTIVITY — all
+          off the RESIDENT BoardTicket + phaseSummary (zero new endpoints). */}
+      <TicketDetailPage ticket={ticket} />
     </Shell>
   );
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/ticket-page-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/ticket-page-model.test.ts
@@ -1,0 +1,285 @@
+// ticket-page-model.test.ts — units for the ticket detail PAGE derivations
+// (CTL-913 / DETAIL2). Each `describe` block maps to a Gherkin scenario in the
+// DETAIL2 ticket spec; the page renders RESIDENT board data alone (BoardTicket +
+// phaseSummary), so these pure functions ARE the page's acceptance surface.
+//
+// Pure module — no DOM, no jotai, no router (mirrors detail-chrome / list-order
+// test style). Run from the ui package:
+//   cd ui && bun test src/board/ticket-page-model.test.ts
+import { describe, it, expect } from "bun:test";
+import {
+  PIPELINE_PHASES,
+  resolvePipelineRail,
+  resolveHeldBanner,
+  resolveSpineNodes,
+  linearDeepLink,
+  orchChannelFor,
+  activityPredicateForTicket,
+  phaseLabel,
+  HELD_DURATION_MARKER,
+} from "./ticket-page-model";
+import type { BoardPhaseTiming, BoardTicket } from "./types";
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+function phaseTiming(over: Partial<BoardPhaseTiming> & { phase: string }): BoardPhaseTiming {
+  return {
+    phase: over.phase,
+    status: over.status ?? "done",
+    durationMs: over.durationMs ?? 42_000,
+    startedAt: over.startedAt ?? "2026-06-08T10:00:00.000Z",
+    completedAt: over.completedAt ?? "2026-06-08T10:00:42.000Z",
+    model: over.model ?? null,
+  };
+}
+
+function ticket(over: Partial<BoardTicket>): BoardTicket {
+  return {
+    id: "CTL-845",
+    title: "reclaim false-dead premature advance",
+    type: "feature",
+    repo: "plugins/dev",
+    team: "CTL",
+    phase: "implement",
+    status: "in_progress",
+    model: "opus-4-8[1m]",
+    linearState: "Implement",
+    workerStatus: null,
+    activeState: "active",
+    working: true,
+    lastActiveMs: 1000,
+    priority: 2,
+    estimate: 3,
+    scope: "M",
+    project: null,
+    costUSD: 1.14,
+    tokens: 2_500_000,
+    turns: 9,
+    phaseCosts: null,
+    phaseSummary: [],
+    pr: null,
+    updatedAt: "2026-06-08T10:05:00.000Z",
+    held: null,
+    blockers: [],
+    ...over,
+  };
+}
+
+// ── Scenario: Header and PIPELINE rail render from BoardTicket ────────────────
+describe("Scenario: Header and PIPELINE rail render from BoardTicket", () => {
+  it("header Linear deep-link is built from the ticket id (never a dead arrow)", () => {
+    expect(linearDeepLink("CTL-845")).toBe("https://linear.app/issue/CTL-845");
+  });
+
+  it("a blank id yields no deep-link (skin renders id as plain text, not a dead ↗)", () => {
+    expect(linearDeepLink("")).toBeNull();
+    expect(linearDeepLink("   ")).toBeNull();
+  });
+
+  it("colors past phases solid, the current phase cyan, future phases as dotted ghosts", () => {
+    const t = ticket({
+      phase: "implement",
+      phaseSummary: [
+        phaseTiming({ phase: "triage", status: "done" }),
+        phaseTiming({ phase: "research", status: "done" }),
+        phaseTiming({ phase: "plan", status: "done" }),
+        phaseTiming({ phase: "implement", status: "in_progress", completedAt: null }),
+      ],
+    });
+    const rail = resolvePipelineRail(t);
+
+    // one segment per canonical phase, in canonical order
+    expect(rail.map((s) => s.phase)).toEqual([...PIPELINE_PHASES]);
+
+    const placement = Object.fromEntries(rail.map((s) => [s.phase, s.placement]));
+    // past = solid
+    expect(placement.triage).toBe("past");
+    expect(placement.research).toBe("past");
+    expect(placement.plan).toBe("past");
+    // current = cyan
+    expect(placement.implement).toBe("current");
+    // future = dotted ghost
+    expect(placement.verify).toBe("future");
+    expect(placement.review).toBe("future");
+    expect(placement.teardown).toBe("future");
+  });
+
+  it("surfaces the real per-phase status from phaseSummary (never fabricated)", () => {
+    const t = ticket({
+      phase: "implement",
+      phaseSummary: [
+        phaseTiming({ phase: "triage", status: "done" }),
+        phaseTiming({ phase: "implement", status: "in_progress", completedAt: null }),
+      ],
+    });
+    const rail = resolvePipelineRail(t);
+    const byPhase = Object.fromEntries(rail.map((s) => [s.phase, s.status]));
+    expect(byPhase.triage).toBe("done");
+    expect(byPhase.implement).toBe("in_progress");
+    // a future phase that never ran has no fabricated status
+    expect(byPhase.verify).toBeNull();
+  });
+
+  it("exactly one segment is current (the cyan 'here now' is unambiguous)", () => {
+    const rail = resolvePipelineRail(ticket({ phase: "pr", phaseSummary: [] }));
+    expect(rail.filter((s) => s.placement === "current")).toHaveLength(1);
+    expect(rail.find((s) => s.placement === "current")?.phase).toBe("pr");
+  });
+
+  it("an off-rail current phase (e.g. 'done') reads the whole lifecycle as walked, no cyan", () => {
+    const rail = resolvePipelineRail(ticket({ phase: "done", phaseSummary: [] }));
+    expect(rail.every((s) => s.placement === "past")).toBe(true);
+    expect(rail.some((s) => s.placement === "current")).toBe(false);
+  });
+});
+
+// ── Scenario: HELD banner renders only when held ──────────────────────────────
+describe("Scenario: HELD banner renders only when held", () => {
+  it('a "blocked" hold renders a red-bordered banner naming the blockers', () => {
+    const banner = resolveHeldBanner(
+      ticket({ held: "blocked", blockers: ["CTL-778", "CTL-844"] }),
+    );
+    expect(banner).not.toBeNull();
+    expect(banner?.tone).toBe("blocked"); // skin → red border
+    expect(banner?.blockers).toEqual(["CTL-778", "CTL-844"]);
+  });
+
+  it('a "waiting" hold renders a yellow-bordered banner (no blockers)', () => {
+    const banner = resolveHeldBanner(ticket({ held: "waiting", blockers: ["ignored"] }));
+    expect(banner).not.toBeNull();
+    expect(banner?.tone).toBe("waiting"); // skin → yellow border
+    // a waiting hold lost the selection tick; deps are satisfied → no blockers named
+    expect(banner?.blockers).toEqual([]);
+  });
+
+  it("held-duration is NEEDS-PLUMBING (heldFor carries no timestamp) — never fabricated", () => {
+    const banner = resolveHeldBanner(ticket({ held: "blocked", blockers: ["CTL-778"] }));
+    expect(banner?.durationMarker).toBe(HELD_DURATION_MARKER);
+    expect(banner?.durationMarker).toBe("NEEDS-PLUMBING");
+  });
+
+  it("when held is null the banner does not render at all", () => {
+    expect(resolveHeldBanner(ticket({ held: null }))).toBeNull();
+    expect(resolveHeldBanner(ticket({ held: undefined }))).toBeNull();
+  });
+
+  it("a blocked hold with no blockers named yields an empty list (no fabricated id)", () => {
+    const banner = resolveHeldBanner(ticket({ held: "blocked", blockers: [] }));
+    expect(banner?.tone).toBe("blocked");
+    expect(banner?.blockers).toEqual([]);
+  });
+});
+
+// ── Scenario: LIFECYCLE SPINE renders one node per phase ──────────────────────
+describe("Scenario: LIFECYCLE SPINE renders one node per phase with a compact gantt toggle", () => {
+  it("each spine node shows phase, status, duration, startedAt/completedAt", () => {
+    const t = ticket({
+      phase: "implement",
+      phaseSummary: [
+        phaseTiming({ phase: "triage", status: "done", durationMs: 42_000 }),
+        phaseTiming({ phase: "research", status: "done", durationMs: 198_000 }),
+        phaseTiming({ phase: "plan", status: "done", durationMs: 125_000 }),
+        phaseTiming({
+          phase: "implement",
+          status: "in_progress",
+          durationMs: null,
+          completedAt: null,
+        }),
+      ],
+    });
+    const nodes = resolveSpineNodes(t);
+    expect(nodes.map((n) => n.phase)).toEqual(["triage", "research", "plan", "implement"]);
+
+    const triage = nodes[0];
+    expect(triage.status).toBe("done");
+    expect(triage.durationMs).toBe(42_000);
+    expect(triage.startedAt).toBe("2026-06-08T10:00:00.000Z");
+    expect(triage.completedAt).toBe("2026-06-08T10:00:42.000Z");
+  });
+
+  it("the active (current, non-terminal) phase node is flagged isActive; others are not", () => {
+    const t = ticket({
+      phase: "implement",
+      phaseSummary: [
+        phaseTiming({ phase: "triage", status: "done" }),
+        phaseTiming({ phase: "implement", status: "in_progress", completedAt: null }),
+      ],
+    });
+    const nodes = resolveSpineNodes(t);
+    expect(nodes.find((n) => n.phase === "triage")?.isActive).toBe(false);
+    expect(nodes.find((n) => n.phase === "implement")?.isActive).toBe(true);
+    // exactly one active node
+    expect(nodes.filter((n) => n.isActive)).toHaveLength(1);
+  });
+
+  it("a terminal current phase is NOT active (no cyan ring on a finished lifecycle)", () => {
+    const t = ticket({
+      phase: "implement",
+      phaseSummary: [phaseTiming({ phase: "implement", status: "done" })],
+    });
+    const nodes = resolveSpineNodes(t);
+    expect(nodes[0].isActive).toBe(false);
+  });
+
+  it("per-phase model is surfaced when plumbed (BFF6 BoardPhaseTiming.model)", () => {
+    const t = ticket({
+      phase: "plan",
+      phaseSummary: [
+        phaseTiming({ phase: "research", status: "done", model: "sonnet" }),
+        phaseTiming({ phase: "plan", status: "in_progress", model: "opus", completedAt: null }),
+      ],
+    });
+    const nodes = resolveSpineNodes(t);
+    expect(nodes.find((n) => n.phase === "research")?.model).toBe("sonnet");
+    expect(nodes.find((n) => n.phase === "plan")?.model).toBe("opus");
+  });
+
+  it("run-link / artifact / cost-sparkline render PENDING (dimmed, never empty/fabricated)", () => {
+    const t = ticket({
+      phase: "implement",
+      phaseSummary: [phaseTiming({ phase: "triage", status: "done" })],
+    });
+    const [node] = resolveSpineNodes(t);
+    // these three depend on the BFF run-records endpoint (DETAIL6/DETAIL7)
+    expect(node.runLink).toBe("pending");
+    expect(node.artifact).toBe("pending");
+    expect(node.costSparkline).toBe("pending");
+  });
+
+  it("an empty phaseSummary yields no nodes (skin shows an honest empty state)", () => {
+    expect(resolveSpineNodes(ticket({ phaseSummary: [] }))).toEqual([]);
+  });
+});
+
+// ── Scenario: COMMS and ACTIVITY reuse existing components ─────────────────────
+describe("Scenario: COMMS and ACTIVITY reuse existing components", () => {
+  it('COMMS reuses CommsView for channel "orch-<id>"', () => {
+    expect(orchChannelFor("CTL-845")).toBe("orch-CTL-845");
+  });
+
+  it("ACTIVITY predicate scopes the stream to this ticket (worker.ticket / linear.issue)", () => {
+    const pred = activityPredicateForTicket("CTL-845");
+    expect(pred).toContain("catalyst.worker.ticket");
+    expect(pred).toContain("linear.issue.identifier");
+    expect(pred).toContain("CTL-845");
+  });
+
+  it("a blank ticket id yields the unfiltered all-events sentinel (not match-nothing)", () => {
+    expect(activityPredicateForTicket("")).toBe("");
+    expect(activityPredicateForTicket("   ")).toBe("");
+  });
+
+  it("the predicate escapes quotes/backslashes so a crafted id can't break the jq filter", () => {
+    const pred = activityPredicateForTicket('a"b\\c');
+    expect(pred).toContain('a\\"b\\\\c');
+  });
+});
+
+// ── phaseLabel helper ─────────────────────────────────────────────────────────
+describe("phaseLabel", () => {
+  it("maps canonical phases to Board column labels and passes through unknowns", () => {
+    expect(phaseLabel("monitor-merge")).toBe("Merge");
+    expect(phaseLabel("monitor-deploy")).toBe("Deploy");
+    expect(phaseLabel("triage")).toBe("Triage");
+    expect(phaseLabel("some-future-phase")).toBe("some-future-phase");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/ticket-page-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/ticket-page-model.ts
@@ -1,0 +1,306 @@
+// ticket-page-model.ts — the PURE derivations behind the ticket detail PAGE BODY
+// (CTL-913 / DETAIL2, detail design §4). React-/jotai-/router-free on purpose (it
+// imports only the hoisted board *types*) so the orch-monitor `bun test` suite can
+// unit-test the PIPELINE rail, the HELD banner, and the LIFECYCLE SPINE node
+// derivation directly — the SAME dependency-free-so-it's-testable discipline as
+// detail-chrome.ts / list-order.ts / route-search.ts. `ticket-detail-page.tsx` is
+// the thin React skin over these functions.
+//
+// The ticket page is the lifecycle aggregate sourced from RESIDENT board data
+// ALONE (BoardTicket + phaseSummary): zero new endpoints. Every cell that needs
+// backend plumbing it does not yet have is surfaced HONESTLY as a "NEEDS-PLUMBING"
+// marker, never a fabricated value (design §4.2):
+//   - held-duration: `heldFor` is pure label classification with NO timestamp, so
+//     the banner's duration is `NEEDS-PLUMBING` (depends on the BFF ticket-detail
+//     endpoint, DETAIL trailing tickets) — never a fabricated "2h14m".
+//   - spine run-link / artifact / cost-sparkline: depend on the BFF run-records
+//     endpoint (DETAIL6/DETAIL7) — surfaced as `pending` per-node markers so the
+//     row renders DIMMED, never empty or invented.
+//
+// THE THREE DERIVATIONS:
+//   - resolvePipelineRail(ticket) → one segment per canonical phase, classified
+//     past | current | future (current = the ticket's `phase`); colors/dotted
+//     state are the React skin's concern, the class is decided here purely.
+//   - resolveHeldBanner(ticket) → null when not held; otherwise the banner tone
+//     (blocked → red, waiting → yellow), the blocker ids, and the explicit
+//     held-duration NEEDS-PLUMBING marker.
+//   - resolveSpineNodes(ticket) → one node per phaseSummary entry with the cells
+//     that ARE plumbed (phase/status/duration/timestamps/model) and the per-node
+//     NEEDS-PLUMBING flags for the cells that are not (run-link/artifact/cost).
+
+import type { BoardTicket, BoardPhaseTiming } from "./types";
+
+// ── canonical phase order ───────────────────────────────────────────────────
+// Mirrors lib/board-data.mjs:35 PHASE_ORDER (the data-layer source of truth) and
+// Board.tsx:48 PHASE_COLS — the pipeline rail walks these 10 phases left→right.
+// Kept as a local const (the server list is .mjs, not import-able into the typed
+// UI) but asserted against the resident `phaseSummary` order at render time, so a
+// future phase added server-side surfaces rather than silently mis-classifies.
+export const PIPELINE_PHASES = [
+  "triage",
+  "research",
+  "plan",
+  "implement",
+  "verify",
+  "review",
+  "pr",
+  "monitor-merge",
+  "monitor-deploy",
+  "teardown",
+] as const;
+
+export type PipelinePhase = (typeof PIPELINE_PHASES)[number];
+
+/** Human label per canonical phase (mirrors Board.tsx:48 PHASE_COLS labels). */
+const PHASE_LABEL: Record<string, string> = {
+  triage: "Triage",
+  research: "Research",
+  plan: "Plan",
+  implement: "Implement",
+  verify: "Verify",
+  review: "Review",
+  pr: "PR",
+  "monitor-merge": "Merge",
+  "monitor-deploy": "Deploy",
+  teardown: "Teardown",
+};
+
+export function phaseLabel(phase: string): string {
+  return PHASE_LABEL[phase] ?? phase;
+}
+
+// ── PIPELINE rail ───────────────────────────────────────────────────────────
+
+/** Where a phase sits relative to the ticket's current phase. */
+export type SegmentPlacement = "past" | "current" | "future";
+
+export interface PipelineSegment {
+  phase: string;
+  /** Display label (Board.tsx:48 PHASE_COLS labels). */
+  label: string;
+  /** past = solid (walked); current = cyan (here now); future = dotted ghost. */
+  placement: SegmentPlacement;
+  /** The phase's status from phaseSummary[], or null when it has no entry (a
+   *  future phase that never ran). Drives the skin's tooltip — never fabricated. */
+  status: string | null;
+}
+
+/**
+ * Resolve the PIPELINE rail (design §4.2 "PIPELINE rail"): one segment per
+ * canonical phase, classified `past` / `current` / `future` off the ticket's
+ * `phase` (the current phase) + `phaseSummary[].status`.
+ *
+ *   - The segment whose phase === ticket.phase is `current` (the skin colors it
+ *     cyan — the reserved live signal).
+ *   - Every canonical phase BEFORE the current one is `past` (solid). Whether it
+ *     actually ran is reflected in `status` (from phaseSummary), not invented.
+ *   - Every canonical phase AFTER the current one is `future` (a dotted ghost).
+ *
+ * Pure: no side effects, no throw on an unknown phase. An off-list `ticket.phase`
+ * (e.g. a legacy "done") classifies every canonical phase as `past` (the lifecycle
+ * is complete) — the rail still renders honestly rather than crashing.
+ */
+export function resolvePipelineRail(ticket: Pick<BoardTicket, "phase" | "phaseSummary">): PipelineSegment[] {
+  const statusByPhase = new Map<string, string>();
+  for (const p of ticket.phaseSummary) {
+    // last-write-wins is fine; phaseSummary has at most one entry per phase.
+    statusByPhase.set(p.phase, p.status);
+  }
+
+  // findIndex (not indexOf) so the comparison stays string-vs-string without a
+  // widening cast — an off-rail phase (e.g. "done") yields -1, handled below.
+  const currentIdx = PIPELINE_PHASES.findIndex((p) => p === ticket.phase);
+
+  return PIPELINE_PHASES.map((phase, i) => {
+    let placement: SegmentPlacement;
+    if (currentIdx === -1) {
+      // current phase isn't on the canonical rail (e.g. "done"/"merged") → the
+      // whole lifecycle reads as walked. No cyan (nothing is "here now").
+      placement = "past";
+    } else if (i < currentIdx) {
+      placement = "past";
+    } else if (i === currentIdx) {
+      placement = "current";
+    } else {
+      placement = "future";
+    }
+    return {
+      phase,
+      label: phaseLabel(phase),
+      placement,
+      status: statusByPhase.get(phase) ?? null,
+    };
+  });
+}
+
+// ── HELD banner ─────────────────────────────────────────────────────────────
+
+/** The banner's severity tone (drives the border color in the skin). */
+export type HeldTone = "blocked" | "waiting";
+
+export interface HeldBanner {
+  /** blocked → red border; waiting → yellow border (design §4.2). */
+  tone: HeldTone;
+  /** The blocker ids a `blocked` hold names (only populated for tone==="blocked";
+   *  a `waiting` hold has no blockers — deps satisfied, lost the selection tick). */
+  blockers: string[];
+  /** held-duration is NEEDS-PLUMBING: `heldFor` carries NO timestamp, so the
+   *  banner shows this honest marker, NEVER a fabricated duration (design §4.2).
+   *  The literal string the skin renders verbatim. */
+  durationMarker: "NEEDS-PLUMBING";
+}
+
+export const HELD_DURATION_MARKER = "NEEDS-PLUMBING" as const;
+
+/**
+ * Resolve the HELD banner (design §4.2 "HELD banner"):
+ *
+ *   - `held == null`  → returns null (the banner does NOT render at all).
+ *   - `held === "blocked"` → red-bordered banner naming `blockers[]`.
+ *   - `held === "waiting"` → yellow-bordered banner; no blockers.
+ *   - held-duration is ALWAYS the NEEDS-PLUMBING marker (no timestamp exists).
+ *
+ * Pure: no side effects. A `blocked` hold with an absent/empty `blockers` array
+ * yields `blockers: []` (the skin renders "no blockers named" — honest, not a
+ * fabricated id).
+ */
+export function resolveHeldBanner(
+  ticket: Pick<BoardTicket, "held" | "blockers">,
+): HeldBanner | null {
+  if (ticket.held == null) return null;
+  return {
+    tone: ticket.held, // "blocked" | "waiting" — the type narrows here
+    blockers: ticket.held === "blocked" ? (ticket.blockers ?? []) : [],
+    durationMarker: HELD_DURATION_MARKER,
+  };
+}
+
+// ── LIFECYCLE SPINE ─────────────────────────────────────────────────────────
+
+/** A per-node cell whose backend plumbing has NOT landed yet (design §4.2). The
+ *  skin renders these DIMMED, never empty or fabricated. */
+export type SpineCellState = "plumbed" | "pending";
+
+export interface SpineNode {
+  phase: string;
+  label: string;
+  status: string;
+  durationMs: number | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  /** Per-phase model (◆sonnet/◆opus) — plumbed via BFF6 (BoardPhaseTiming.model);
+   *  null when the phase signal carried no model. */
+  model: string | null;
+  /** True iff this node IS the ticket's current (active) phase — the skin anchors
+   *  the spine scroll + the cyan "here now" treatment on it. */
+  isActive: boolean;
+  /** Cells that depend on the BFF run-records endpoint (DETAIL6/DETAIL7) and so
+   *  render DIMMED with a NEEDS-PLUMBING marker until those tickets land. */
+  runLink: SpineCellState;
+  artifact: SpineCellState;
+  costSparkline: SpineCellState;
+}
+
+/**
+ * Resolve the LIFECYCLE SPINE (design §4.2 "LIFECYCLE SPINE"): one node per
+ * `phaseSummary[]` entry, carrying the cells that ARE resident-plumbed
+ * (phase/status/duration/startedAt/completedAt/model) and the per-node
+ * NEEDS-PLUMBING flags for the cells that depend on the BFF run-records endpoint
+ * (run-link / artifact / cost-sparkline — DETAIL6/DETAIL7).
+ *
+ * `isActive` is true for the node whose phase === ticket.phase AND that is not
+ * terminal — i.e. the live/current node the spine scroll + cyan ring anchor on.
+ *
+ * Pure: no side effects. An empty phaseSummary yields `[]` (the skin renders an
+ * honest "no phases yet" empty state, never a fabricated row).
+ */
+export function resolveSpineNodes(
+  ticket: Pick<BoardTicket, "phase" | "phaseSummary">,
+): SpineNode[] {
+  return ticket.phaseSummary.map((row: BoardPhaseTiming): SpineNode => {
+    const isActive = row.phase === ticket.phase && !TERMINAL_SPINE_STATUSES.has(row.status);
+    return {
+      phase: row.phase,
+      label: phaseLabel(row.phase),
+      status: row.status,
+      durationMs: row.durationMs,
+      startedAt: row.startedAt,
+      completedAt: row.completedAt,
+      model: row.model,
+      isActive,
+      // All three depend on the BFF run-records endpoint — not yet plumbed
+      // (DETAIL6/DETAIL7). Marked `pending` so the skin dims them honestly.
+      runLink: "pending",
+      artifact: "pending",
+      costSparkline: "pending",
+    };
+  });
+}
+
+/** Phase statuses that mean a phase is no longer running — mirrors the TERMINAL
+ *  set in lib/board-data.mjs / Board.tsx TERMINAL_STATUSES, so the spine's
+ *  "active node" never lights cyan on a finished phase. */
+const TERMINAL_SPINE_STATUSES = new Set([
+  "done",
+  "failed",
+  "stalled",
+  "skipped",
+  "signal_corrupt",
+  "superseded",
+  "canceled",
+]);
+
+// ── Linear deep-link ────────────────────────────────────────────────────────
+
+/**
+ * Build the Linear deep-link for a ticket header (design §4.2 "Header"):
+ * `↗ Linear` uses the workspace issue URL keyed by the ticket id. Mirrors the
+ * existing worker-table.tsx:275 fallback shape
+ * (`https://linear.app/issue/<ID>`).
+ *
+ * Pure: an empty/blank id returns null (the skin renders the id as plain text,
+ * NEVER a dead `↗` — the honesty discipline from design §4.2).
+ */
+export function linearDeepLink(id: string): string | null {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) return null;
+  return `https://linear.app/issue/${encodeURIComponent(trimmed)}`;
+}
+
+// ── COMMS channel ───────────────────────────────────────────────────────────
+
+/**
+ * The orch comms channel name for a ticket (design §4.2 "COMMS"): the existing
+ * `CommsView` is keyed by `channel = "orch-" + id`. Pure helper so the test
+ * pins the exact channel string the Gherkin names ("orch-CTL-845").
+ */
+export function orchChannelFor(id: string): string {
+  return `orch-${id}`;
+}
+
+// ── ACTIVITY predicate ──────────────────────────────────────────────────────
+
+/**
+ * The jq predicate scoping the ACTIVITY feed to ONE ticket (design §4.2
+ * "ACTIVITY" — the existing activity stream scoped to the ticket's orchestrator
+ * run). `useActivityStream` takes a jq predicate; we filter the global event log
+ * to rows whose ticket scope matches this ticket. Canonical event scope keys
+ * (verified against the existing row renderer, activity-event-row.tsx:278-279):
+ *   - `catalyst.worker.ticket`    — the phase-agent worker's ticket
+ *   - `linear.issue.identifier`   — the Linear-sourced ticket id
+ * Either match keeps the feed honest to "this ticket's activity" without an
+ * orchestrator-id lookup the resident payload does not carry.
+ *
+ * Empty/blank id → "" (the unfiltered all-events stream — the hook's documented
+ * no-filter sentinel, use-activity.ts:29), rather than a predicate that silently
+ * matches nothing.
+ */
+export function activityPredicateForTicket(ticketId: string): string {
+  const trimmed = ticketId.trim();
+  if (trimmed.length === 0) return "";
+  const esc = trimmed.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return (
+    `(.attributes["catalyst.worker.ticket"] == "${esc}"` +
+    ` or .attributes["linear.issue.identifier"] == "${esc}")`
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-detail-page.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-detail-page.tsx
@@ -1,0 +1,490 @@
+// ticket-detail-page.tsx — the ticket detail PAGE BODY (CTL-913 / DETAIL2,
+// detail design §4). Drops into the shared <Shell> chrome's <DetailBody> slot
+// (DETAIL1 owns the breadcrumb/pager/live-dot/Properties rail/footer; this owns
+// the lifecycle aggregate body: header link · PIPELINE rail · HELD banner ·
+// LIFECYCLE SPINE + compact-gantt toggle · COMMS · ACTIVITY).
+//
+// Sourced from RESIDENT board data ALONE — BoardTicket + phaseSummary, zero new
+// endpoints. Every cell that needs backend plumbing it does not have yet renders
+// DIMMED and HONEST (a "↯" NEEDS-PLUMBING marker), never empty or fabricated
+// (design §4.2). Telemetry strips, run-record links, and the active-node live
+// tail are added by trailing tickets (DETAIL6/DETAIL7) and degrade gracefully.
+//
+// The PURE derivations (pipeline placement, held tone, spine nodes, deep-link,
+// channel, activity predicate) live in board/ticket-page-model.ts and are unit-
+// tested without a DOM; this file is the thin React skin over them.
+
+import { useCallback, useRef, useState } from "react";
+import {
+  resolvePipelineRail,
+  resolveHeldBanner,
+  resolveSpineNodes,
+  linearDeepLink,
+  orchChannelFor,
+  activityPredicateForTicket,
+  type PipelineSegment,
+  type SpineNode,
+} from "@/board/ticket-page-model";
+import type { BoardTicket } from "@/board/types";
+import { phaseColor, fmtDuration, fmtClock } from "@/lib/formatters";
+import { TicketGantt } from "./ticket-gantt";
+import { CommsView } from "./comms-view";
+import { ActivityEventRow } from "./activity-event-row";
+import { useActivityStream } from "@/hooks/use-activity";
+import { useRepoColors } from "@/hooks/use-repo-colors";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./ui/collapsible";
+import { EmptyState } from "./ui/empty-state";
+import { ListTree, MessageSquare, Radio } from "lucide-react";
+
+// ── tokens (mirror Shell.tsx / Board.tsx inline-`C` palette; cyan reserved) ──
+const C = {
+  s1: "#111318",
+  s2: "#171a21",
+  border: "#262d36",
+  fg: "#e6e9ef",
+  fgMuted: "#8b93a1",
+  fgDim: "#5b626f",
+  cyan: "#5be0ff", // the reserved live signal — current phase / active node only
+  red: "#ef5d5d",
+  yellow: "#eab308",
+  mono: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+} as const;
+
+/** A NEEDS-PLUMBING cell marker — dimmed "↯" + label. Never an invented value. */
+function Needs({ label }: { label: string }) {
+  return (
+    <span
+      data-needs-plumbing={label}
+      title={`${label} — NEEDS-PLUMBING (DETAIL6/DETAIL7)`}
+      style={{ color: C.fgDim, font: `10px ${C.mono}` }}
+    >
+      ↯ {label}
+    </span>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        font: `10px ${C.mono}`,
+        letterSpacing: 1,
+        color: C.fgMuted,
+        textTransform: "uppercase",
+        margin: "0 0 8px",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ── Header (title link + meta) ───────────────────────────────────────────────
+function Header({ ticket }: { ticket: BoardTicket }) {
+  const link = linearDeepLink(ticket.id);
+  return (
+    <div data-ticket-header style={{ marginBottom: 14 }}>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 8, flexWrap: "wrap" }}>
+        <span style={{ font: `12px ${C.mono}`, color: C.fgMuted }}>{ticket.type}</span>
+        <span style={{ color: C.fgDim }}>·</span>
+        <span style={{ font: `12px ${C.mono}`, color: C.fgMuted }}>{ticket.repo}</span>
+        <span style={{ color: C.fgDim }}>·</span>
+        <span style={{ font: `12px ${C.mono}`, color: C.fgMuted }}>{ticket.team}</span>
+        <span style={{ flex: 1 }} />
+        {/* ↗ Linear deep-link; absent id → plain text (never a dead arrow). */}
+        {link ? (
+          <a
+            data-linear-link
+            href={link}
+            target="_blank"
+            rel="noreferrer noopener"
+            style={{ font: `12px ${C.mono}`, color: "#4ea1ff", textDecoration: "none" }}
+          >
+            ↗ Linear
+          </a>
+        ) : (
+          <span style={{ font: `12px ${C.mono}`, color: C.fgDim }}>{ticket.id}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── PIPELINE rail ─────────────────────────────────────────────────────────────
+function PipelineRail({
+  ticket,
+  onSegmentClick,
+}: {
+  ticket: BoardTicket;
+  onSegmentClick: (phase: string) => void;
+}) {
+  const segments = resolvePipelineRail(ticket);
+  return (
+    <section data-ticket-pipeline style={{ marginBottom: 16 }}>
+      <SectionLabel>Pipeline</SectionLabel>
+      <div style={{ display: "flex", alignItems: "center", gap: 4, flexWrap: "wrap" }}>
+        {segments.map((seg, i) => (
+          <PipelineSegmentChip
+            key={seg.phase}
+            seg={seg}
+            isLast={i === segments.length - 1}
+            onClick={() => onSegmentClick(seg.phase)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function PipelineSegmentChip({
+  seg,
+  isLast,
+  onClick,
+}: {
+  seg: PipelineSegment;
+  isLast: boolean;
+  onClick: () => void;
+}) {
+  const base = phaseColor(seg.phase);
+  // current = cyan (the reserved live signal); past = solid phase color; future
+  // = dotted ghost (muted, dashed border, no fill).
+  const isCurrent = seg.placement === "current";
+  const isFuture = seg.placement === "future";
+  return (
+    <>
+      <button
+        type="button"
+        data-pipeline-segment={seg.phase}
+        data-placement={seg.placement}
+        onClick={onClick}
+        title={`${seg.label}${seg.status ? ` · ${seg.status}` : ""} — click to scroll spine`}
+        style={{
+          font: `10px ${C.mono}`,
+          letterSpacing: 0.4,
+          padding: "2px 7px",
+          borderRadius: 4,
+          cursor: "pointer",
+          color: isFuture ? C.fgDim : isCurrent ? "#04222a" : C.fg,
+          background: isCurrent ? C.cyan : isFuture ? "transparent" : base + "33",
+          border: isFuture
+            ? `1px dashed ${C.border}`
+            : `1px solid ${isCurrent ? C.cyan : base + "55"}`,
+        }}
+      >
+        {seg.label}
+      </button>
+      {!isLast && <span style={{ color: C.fgDim, font: `10px ${C.mono}` }}>▸</span>}
+    </>
+  );
+}
+
+// ── HELD banner ────────────────────────────────────────────────────────────────
+function HeldBanner({ ticket }: { ticket: BoardTicket }) {
+  const held = resolveHeldBanner(ticket);
+  if (!held) return null; // renders ONLY when held != null
+  const borderColor = held.tone === "blocked" ? C.red : C.yellow;
+  return (
+    <section
+      data-ticket-held={held.tone}
+      style={{
+        marginBottom: 16,
+        padding: "8px 12px",
+        borderRadius: 6,
+        border: `1px solid ${borderColor}`,
+        background: borderColor + "14",
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        flexWrap: "wrap",
+        font: `12px ${C.mono}`,
+      }}
+    >
+      <span style={{ color: borderColor, fontWeight: 600 }}>
+        ⚠ HELD · {held.tone}
+      </span>
+      {held.tone === "blocked" && (
+        <span style={{ color: C.fgMuted }}>
+          {held.blockers.length > 0 ? (
+            <>
+              waiting on{" "}
+              {held.blockers.map((b, i) => (
+                <span key={b}>
+                  {i > 0 && ", "}
+                  <span style={{ color: C.fg }}>{b}</span>
+                </span>
+              ))}
+            </>
+          ) : (
+            <span style={{ color: C.fgDim }}>no blockers named</span>
+          )}
+        </span>
+      )}
+      <span style={{ flex: 1 }} />
+      {/* held-duration carries no timestamp — honest NEEDS-PLUMBING, never faked. */}
+      <span style={{ color: C.fgMuted }}>
+        held-duration <Needs label="NEEDS-PLUMBING" />
+      </span>
+    </section>
+  );
+}
+
+// ── LIFECYCLE SPINE ─────────────────────────────────────────────────────────────
+function LifecycleSpine({
+  ticket,
+  registerNode,
+}: {
+  ticket: BoardTicket;
+  registerNode: (phase: string, el: HTMLDivElement | null) => void;
+}) {
+  const [compact, setCompact] = useState(false);
+  const nodes = resolveSpineNodes(ticket);
+
+  return (
+    <section data-ticket-spine style={{ marginBottom: 16 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+        <SectionLabel>Lifecycle Spine</SectionLabel>
+        <span style={{ flex: 1 }} />
+        <button
+          type="button"
+          data-spine-compact-toggle
+          aria-pressed={compact}
+          onClick={() => setCompact((v) => !v)}
+          style={{
+            font: `10px ${C.mono}`,
+            color: compact ? C.fg : C.fgMuted,
+            background: compact ? C.s2 : "transparent",
+            border: `1px solid ${C.border}`,
+            borderRadius: 4,
+            padding: "2px 8px",
+            cursor: "pointer",
+          }}
+        >
+          ⊟ compact
+        </button>
+      </div>
+
+      {compact ? (
+        // The [compact] toggle swaps in the existing TicketGantt over the SAME
+        // phaseSummary data (design §4.2 — verified drop-in consumer).
+        <div data-spine-gantt>
+          <TicketGantt ticket={ticket} />
+        </div>
+      ) : nodes.length === 0 ? (
+        <EmptyState icon={ListTree} message="No phases yet" />
+      ) : (
+        <div data-spine-nodes>
+          {nodes.map((node) => (
+            <SpineRow key={node.phase} node={node} registerNode={registerNode} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SpineRow({
+  node,
+  registerNode,
+}: {
+  node: SpineNode;
+  registerNode: (phase: string, el: HTMLDivElement | null) => void;
+}) {
+  const color = phaseColor(node.phase);
+  const started = node.startedAt ? fmtClock(new Date(Date.parse(node.startedAt))) : null;
+  const completed = node.completedAt ? fmtClock(new Date(Date.parse(node.completedAt))) : null;
+  return (
+    <div
+      ref={(el) => registerNode(node.phase, el)}
+      data-spine-row={node.phase}
+      {...(node.isActive ? { "data-spine-active": "true" } : {})}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        padding: "6px 8px",
+        borderRadius: 5,
+        marginBottom: 4,
+        background: node.isActive ? C.cyan + "12" : C.s1,
+        border: `1px solid ${node.isActive ? C.cyan + "55" : C.border}`,
+        font: `11px ${C.mono}`,
+      }}
+    >
+      {/* phase chip + active ring */}
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 6, width: 110, flexShrink: 0 }}>
+        <span
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
+            background: node.isActive ? C.cyan : color,
+            flex: "0 0 auto",
+          }}
+        />
+        <span style={{ color: C.fg }}>{node.label}</span>
+      </span>
+
+      {/* status */}
+      <span style={{ width: 86, flexShrink: 0, color: C.fgMuted }}>{node.status}</span>
+
+      {/* duration */}
+      <span style={{ width: 64, flexShrink: 0, color: C.fgMuted, textAlign: "right" }}>
+        {node.durationMs != null ? fmtDuration(node.durationMs) : "…"}
+      </span>
+
+      {/* started → completed */}
+      <span style={{ width: 96, flexShrink: 0, color: C.fgDim }}>
+        {started ?? "—"}
+        {completed ? `–${completed}` : node.isActive ? "–now" : ""}
+      </span>
+
+      {/* model — plumbed (BFF6); dimmed em-dash when the signal carried none */}
+      <span style={{ width: 72, flexShrink: 0, color: node.model ? C.fgMuted : C.fgDim }}>
+        {node.model ? `◆${node.model}` : "—"}
+      </span>
+
+      <span style={{ flex: 1 }} />
+
+      {/* run-link / artifact / cost-sparkline — NEEDS-PLUMBING (DETAIL6/DETAIL7) */}
+      <span style={{ display: "inline-flex", gap: 10, flexShrink: 0 }}>
+        {node.costSparkline === "pending" && <Needs label="cost" />}
+        {node.runLink === "pending" && <Needs label="run" />}
+        {node.artifact === "pending" && <Needs label="artifact" />}
+      </span>
+    </div>
+  );
+}
+
+// ── COMMS (collapsed → CommsView) ───────────────────────────────────────────────
+function CommsSection({ ticket }: { ticket: BoardTicket }) {
+  const [open, setOpen] = useState(false);
+  const channel = orchChannelFor(ticket.id);
+  return (
+    <section data-ticket-comms style={{ marginBottom: 16 }}>
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger
+          data-comms-toggle
+          aria-expanded={open}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            width: "100%",
+            font: `10px ${C.mono}`,
+            letterSpacing: 1,
+            color: C.fgMuted,
+            textTransform: "uppercase",
+            background: "transparent",
+            border: "none",
+            cursor: "pointer",
+            padding: "4px 0",
+          }}
+        >
+          <MessageSquare size={12} />
+          <span>Comms</span>
+          <span style={{ color: C.fgDim }}>{open ? "▾" : "▸"}</span>
+          <span style={{ color: C.fgDim, textTransform: "none" }}>{channel}</span>
+        </CollapsibleTrigger>
+        <CollapsibleContent data-comms-content>
+          {/* Reuses the existing CommsView, keyed to "orch-<id>" (design §4.2). */}
+          {open && (
+            <div style={{ marginTop: 8 }}>
+              <CommsView
+                initialFilter={{ channel, types: null, author: null }}
+              />
+            </div>
+          )}
+        </CollapsibleContent>
+      </Collapsible>
+    </section>
+  );
+}
+
+// ── ACTIVITY (scoped live feed) ─────────────────────────────────────────────────
+function ActivitySection({ ticket }: { ticket: BoardTicket }) {
+  const predicate = activityPredicateForTicket(ticket.id);
+  const { events, status, live } = useActivityStream(predicate);
+  const repoColors = useRepoColors();
+  // newest first (the backend returns chronological order, mirroring ActivityView)
+  const ordered = [...events].reverse();
+
+  return (
+    <section data-ticket-activity style={{ marginBottom: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+        <SectionLabel>Activity</SectionLabel>
+        <span style={{ flex: 1 }} />
+        <span style={{ font: `10px ${C.mono}`, color: live ? C.cyan : C.fgDim }}>
+          {events.length} event{events.length === 1 ? "" : "s"}
+          {live ? " · live" : ""}
+        </span>
+      </div>
+      <div
+        style={{
+          maxHeight: 320,
+          overflowY: "auto",
+          borderRadius: 6,
+          border: `1px solid ${C.border}`,
+          background: C.s2,
+        }}
+      >
+        {status === "loading" && events.length === 0 ? (
+          <EmptyState icon={Radio} message="Connecting to activity stream…" />
+        ) : ordered.length === 0 ? (
+          <EmptyState icon={Radio} message="No activity for this ticket yet" />
+        ) : (
+          ordered.map((e, i) => (
+            // The existing row renderer; cyan accents the active row internally.
+            // No onPivot — the ticket page is a route, not a drawer-pivot host.
+            <ActivityEventRow key={`${e.ts}-${i}`} event={e} repoColors={repoColors} />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+// ── page body ─────────────────────────────────────────────────────────────────
+/**
+ * The ticket detail page body. Renders inside the shared <Shell>'s <DetailBody>
+ * slot (DETAIL1). `ticket` is the resident BoardTicket; when it is undefined (a
+ * cold-linked Done ticket not in the resident payload) the body shows an honest
+ * placeholder rather than a fabricated lifecycle (design §4 — resident-only).
+ */
+export function TicketDetailPage({ ticket }: { ticket: BoardTicket | undefined }) {
+  // Spine node refs so a PIPELINE segment click smooth-scrolls to its node.
+  const nodeRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const registerNode = useCallback((phase: string, el: HTMLDivElement | null) => {
+    if (el) nodeRefs.current.set(phase, el);
+    else nodeRefs.current.delete(phase);
+  }, []);
+  const scrollToPhase = useCallback((phase: string) => {
+    nodeRefs.current.get(phase)?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, []);
+
+  if (!ticket) {
+    return (
+      <div
+        data-ticket-page-empty
+        style={{ color: C.fgDim, font: `12px ${C.mono}` }}
+      >
+        This ticket is not in the resident board payload — its lifecycle is not
+        available off resident data alone (a Done ticket off the board). Open it in
+        Linear from the header.
+      </div>
+    );
+  }
+
+  return (
+    <div data-ticket-page={ticket.id}>
+      <Header ticket={ticket} />
+      <PipelineRail ticket={ticket} onSegmentClick={scrollToPhase} />
+      <HeldBanner ticket={ticket} />
+      <LifecycleSpine ticket={ticket} registerNode={registerNode} />
+      <CommsSection ticket={ticket} />
+      <ActivitySection ticket={ticket} />
+    </div>
+  );
+}


### PR DESCRIPTION
## CTL-913 (DETAIL2) — Ticket page skeleton

Replaces the DETAIL1 placeholder in the shared `<Shell>` chrome's `<DetailBody>` slot with the real ticket **lifecycle aggregate** body, sourced from **resident board data alone** (`BoardTicket` + `phaseSummary`) — zero new endpoints, shippable behind the flag with every unplumbed cell dimmed and honest (design doc §4).

### Files
- `ui/src/board/ticket-page-model.ts` — pure, DOM-less derivations (pipeline placement, held tone, spine nodes, Linear deep-link, comms channel, activity predicate). Same testable discipline as `detail-chrome.ts`.
- `ui/src/board/ticket-page-model.test.ts` — 22 `bun:test` units encoding the four Gherkin scenarios.
- `ui/src/components/ticket-detail-page.tsx` — the thin React skin (header · PIPELINE rail · HELD banner · LIFECYCLE SPINE + compact gantt · COMMS · ACTIVITY).
- `ui/src/board/detail-route.tsx` — swaps the placeholder for `<TicketDetailPage>`.

### Gherkin scenario → status

**Scenario: Header and PIPELINE rail render from BoardTicket** — **satisfied**
- Header shows type/repo/team + a Linear deep-link (`linearDeepLink`; absent id → plain text, never a dead `↗`).
- PIPELINE rail colors past phases solid, the current phase cyan, future phases as dotted ghosts from `phase` + `phaseSummary[].status` (`resolvePipelineRail`).
- Clicking a pipeline segment smooth-scrolls the lifecycle spine to that phase (`scrollToPhase` over per-node refs).

**Scenario: HELD banner renders only when held** — **satisfied**
- `held === "blocked"` → red-bordered banner naming `blockers[]`; `held === "waiting"` → yellow border; `held == null` → banner does not render (`resolveHeldBanner`).
- held-duration renders the explicit `NEEDS-PLUMBING` marker (`heldFor` carries no timestamp) — never a fabricated duration.

**Scenario: LIFECYCLE SPINE renders one node per phase with a compact gantt toggle** — **satisfied**
- Each spine node shows phase/status/duration/startedAt/completedAt (`resolveSpineNodes`).
- The `[⊟ compact]` toggle swaps in the existing `TicketGantt` over the same `phaseSummary` data.
- Per-phase model is plumbed (BFF6 `BoardPhaseTiming.model`); run-link / artifact / cost-sparkline render dimmed `↯ NEEDS-PLUMBING` (DETAIL6/DETAIL7), never empty or fabricated.

**Scenario: COMMS and ACTIVITY reuse existing components** — **satisfied**
- Expanding COMMS renders the existing `CommsView` for channel `orch-<id>` (`orchChannelFor`).
- ACTIVITY renders the existing `useActivityStream` + `ActivityEventRow`, scoped to this ticket (`activityPredicateForTicket` over `catalyst.worker.ticket` / `linear.issue.identifier`); cyan only on the active row.

### Single-node descope
No cluster/fence/host/motion branches were added. The page binds the single-host resident payload through the same code path (the spec-mandated single-host identity no-op) — there is no N>1 chrome to stub on this page; host attribution is a board-surface concern (BOARD3/SURF*), not the ticket detail body.

### Tests
- `cd ui && bun test` → **48 pass** (incl. the new 22).
- `cd ui && bunx tsc --noEmit` → clean for the new code (the single pre-existing `kpi-strip.tsx` baseline error on `origin/main` is unchanged, not touched).
- `cd ui && bun run build` → succeeds.
- Root orch-monitor `detail-chrome` + `detail-shell` suites → **37 pass** (DETAIL1 chrome contract unbroken).

The rebuilt `public/` bundle is intentionally NOT committed (matches the DETAIL1 convention — source only; the bundle is regenerated at deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)