### PR TITLE
feat(dev): SURF2 wide ranked Queue depth surface (CTL-910)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
@@ -63,6 +63,14 @@ const HomeSurface = lazy(() =>
     default: m.HomeSurface,
   })),
 );
+// CTL-910 / SURF2: the dedicated wide Queue surface. Lazy so its transport (the
+// shared board snapshot SSE) + the ranked depth table only load when the operator
+// is on the Queue surface — the dashboard + home surfaces stay untouched.
+const QueueSurface = lazy(() =>
+  import("./components/queue/queue-surface").then((m) => ({
+    default: m.QueueSurface,
+  })),
+);
 
 type TopView = "dashboard" | "comms" | "activity" | "god-mode";
 
@@ -327,6 +335,7 @@ function SurfaceSwitch({ dashboard }: { dashboard: ReactNode }) {
       </Suspense>
     );
   }
+  const kind = surfaceContentKind(surface);
   // CTL-909 / SURF1: the Workers surface is now a first-class dense grid — the
   // same <Board /> scaffolding (Column/BoardScroll/WorkerCard) opened straight
   // onto its Workers view, full-bleed in the inset, instead of the placeholder
@@ -334,17 +343,28 @@ function SurfaceSwitch({ dashboard }: { dashboard: ReactNode }) {
   // is an identity no-op. (Worker-card deep-link to /worker/$id is wired in the
   // routed board entry, which owns the router; the embedded shell has no router,
   // so cards there stay non-interactive exactly as before — no dead links.)
-  if (surfaceContentKind(surface) === "workers") {
+  if (kind === "workers") {
     return (
       <Suspense fallback={<SkeletonDashboard />}>
         <Board embedded initialView="workers" />
       </Suspense>
     );
   }
-  if (surfaceContentKind(surface) === "board") {
+  if (kind === "board") {
     return (
       <Suspense fallback={<SkeletonDashboard />}>
         <Board embedded />
+      </Suspense>
+    );
+  }
+  // CTL-910 / SURF2: the Queue surface is its OWN dedicated route now (no longer
+  // the SHELL2 dashboard fall-through). Like the board it is a stable top-level
+  // branch so its element keeps a fixed tree position and the shared board
+  // EventSource is reconciled in place, not torn down on every snapshot tick.
+  if (kind === "queue") {
+    return (
+      <Suspense fallback={<SkeletonDashboard />}>
+        <QueueSurface />
       </Suspense>
     );
   }

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { TicketDetailDrawer } from "@/components/ticket-detail-drawer";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -33,8 +33,19 @@ import {
   HOST_FILTER_ALL,
   UNATTRIBUTED_HOST,
 } from "./worker-grouping";
+// ── per-node queue grouping (CTL-910 / SURF2) ─────────────────────────────────
+// The waiting table attributes each row to its HRW owner host. queueHostMode is
+// the single-host identity-no-op detector (one/zero distinct host → no node
+// column, zero added noise); groupQueueByHost lifts the ranked queue into ordered
+// per-node buckets WITHOUT disturbing the scheduler's global rank.
+import {
+  queueHostMode,
+  groupQueueByHost,
+  type QueueHostGroup,
+} from "./queue-grouping";
 import type {
   BoardPayload,
+  BoardQueueItem as QueueItem,
   BoardWorker as Worker,
   BoardTicket as Ticket,
   BoardActiveState as ActiveState,
@@ -538,15 +549,99 @@ const td = { fontSize: 12.5, color: C.fg };
 const mono = { fontFamily: C.mono, fontVariantNumeric: "tabular-nums" as const };
 const ellip = { overflow: "hidden" as const, textOverflow: "ellipsis" as const, whiteSpace: "nowrap" as const };
 
-function QueueView({ data }: { data: BoardPayload }) {
+// ── waiting-queue row + grouped body (CTL-910 / SURF2) ───────────────────────
+// One waiting row. `showHost` adds the node column ONLY in a multi-node fleet —
+// single-host collapses it away so the column adds no visual noise (the identity
+// no-op). The host cell renders the owner name, or a dim "—" for an un-attributed
+// row (host:null, e.g. before a fence claim).
+function QueueRow({ q, freeSlots, showHost }: { q: QueueItem; freeSlots: number; showHost: boolean }) {
+  return (
+    <TableRow style={{ background: q.rank <= freeSlots ? "rgba(57,208,122,0.06)" : undefined }}>
+      <TableCell style={{ ...mono, color: C.fgMuted }}>{q.rank}</TableCell>
+      <TableCell><PriorityIcon p={q.priority} /></TableCell>
+      <TableCell style={{ ...mono, ...td, color: C.blue, fontWeight: 600 }}>{q.id}</TableCell>
+      <TableCell style={{ ...td, ...ellip, maxWidth: 0 }}>{q.title}</TableCell>
+      <TableCell><ScopeChip scope={q.scope} estimate={q.estimate} /></TableCell>
+      <TableCell style={{ ...mono, fontSize: 11, color: C.fgDim }}>{q.repo}</TableCell>
+      {showHost && (
+        <TableCell style={{ ...mono, fontSize: 11, color: q.host ? C.fgMuted : C.fgDim }}>{q.host?.name ?? "—"}</TableCell>
+      )}
+    </TableRow>
+  );
+}
+
+// The waiting table. `grouped` (only offered in a multi-node fleet) splits the
+// ranked queue into per-node sections so an operator can read per-node depth; the
+// global rank within each section is preserved (groupQueueByHost never re-sorts).
+function WaitingTable({ queue, freeSlots, showHost, grouped }: { queue: QueueItem[]; freeSlots: number; showHost: boolean; grouped: boolean }) {
+  const header = (
+    <TableHeader><TableRow style={{ background: C.s1 }}>
+      <TableHead style={{ ...th, width: 40 }}>#</TableHead><TableHead style={{ ...th, width: 44 }}>Pri</TableHead>
+      <TableHead style={{ ...th, width: 100 }}>Ticket</TableHead><TableHead style={th}>Title</TableHead>
+      <TableHead style={{ ...th, width: 70 }}>Size</TableHead><TableHead style={{ ...th, width: 84 }}>Repo</TableHead>
+      {showHost && <TableHead style={{ ...th, width: 130 }}>Node</TableHead>}
+    </TableRow></TableHeader>
+  );
+  const colSpan = showHost ? 7 : 6;
+  if (!grouped) {
+    return (
+      <div style={{ border: `1px solid ${C.border}`, borderRadius: 10, overflow: "hidden" }}>
+        <Table>
+          {header}
+          <TableBody>
+            {queue.map((q) => <QueueRow key={q.id} q={q} freeSlots={freeSlots} showHost={showHost} />)}
+          </TableBody>
+        </Table>
+      </div>
+    );
+  }
+  const groups: QueueHostGroup[] = groupQueueByHost(queue);
+  return (
+    <div style={{ border: `1px solid ${C.border}`, borderRadius: 10, overflow: "hidden" }}>
+      <Table>
+        {header}
+        <TableBody>
+          {groups.map((g) => (
+            <Fragment key={g.host?.id ?? g.label}>
+              <TableRow style={{ background: C.s1 }}>
+                <TableCell colSpan={colSpan} style={{ ...mono, fontSize: 11, color: C.fgMuted, padding: "6px 12px" }}>
+                  <span style={{ color: g.host ? C.fg : C.fgDim, fontWeight: 600 }}>{g.label}</span>
+                  <span style={{ color: C.fgDim }}> · {g.items.length} queued</span>
+                </TableCell>
+              </TableRow>
+              {g.items.map((q) => <QueueRow key={q.id} q={q} freeSlots={freeSlots} showHost={showHost} />)}
+            </Fragment>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+// CTL-910 / SURF2: the wide, ranked Queue surface. Promoted from the board's
+// internal Queue tab into the shell as its own route (see QueueSurface, which
+// connects the board transport and mounts this embedded). Reused near-verbatim
+// from the original board Queue tab: capacity Stats + SlotBar + an in-flight table
+// + a waiting ranked table. NEW for SURF2: an optional per-node column + a
+// group-by-node toggle, both gated behind queueHostMode so a single-host fleet is
+// an exact identity no-op (no node column, no toggle, no added noise).
+export function QueueView({ data, embedded = false }: { data: BoardPayload; embedded?: boolean }) {
   const { config, queue, workers, tickets } = data;
   const infoById: Record<string, Ticket> = Object.fromEntries(tickets.map((t) => [t.id, t]));
   // Order through the SHARED comparator (CTL-882 / FND2): rank(active=0, stuck=2,
   // else=1) then runtimeMs desc — the same order the worker pager + j/k walk
   // resolve via resolveList({kind:"worker"}). Byte-for-byte the prior inline sort.
   const inflight = sortWorkers(workers);
+  // SINGLE-HOST IDENTITY NO-OP: only surface the node column / group affordance
+  // when the queue spans two or more DISTINCT owner hosts. With hosts.json absent
+  // or length 1 every row resolves to one host (or none), so this is "single" and
+  // the table renders exactly as it did pre-SURF2.
+  const multiHost = queueHostMode(queue) === "multi";
+  const [groupByNode, setGroupByNode] = useState(false);
+  // The toggle only makes sense in a multi-node fleet; never grouped single-host.
+  const grouped = multiHost && groupByNode;
   return (
-    <div className="cat-scroll" style={{ overflowY: "auto", height: "calc(var(--cat-board-vh, 100vh) - 104px)", padding: "2px 16px 24px" }}>
+    <div className="cat-scroll" style={{ overflowY: "auto", height: embedded ? "100%" : "calc(var(--cat-board-vh, 100vh) - 104px)", padding: "2px 16px 24px" }}>
       <div style={{ maxWidth: 1040 }}>
         <div style={{ display: "flex", gap: 12, marginBottom: 18 }}>
           <Stat label="Max parallel" value={String(config.maxParallel)} />
@@ -581,29 +676,21 @@ function QueueView({ data }: { data: BoardPayload }) {
           </Table>
         </div>
 
-        <div style={{ fontSize: 12, fontWeight: 600, color: C.fgMuted, margin: "0 0 8px" }}>Waiting in queue ({queue.length})</div>
-        <div style={{ border: `1px solid ${C.border}`, borderRadius: 10, overflow: "hidden" }}>
-          <Table>
-            <TableHeader><TableRow style={{ background: C.s1 }}>
-              <TableHead style={{ ...th, width: 40 }}>#</TableHead><TableHead style={{ ...th, width: 44 }}>Pri</TableHead>
-              <TableHead style={{ ...th, width: 100 }}>Ticket</TableHead><TableHead style={th}>Title</TableHead>
-              <TableHead style={{ ...th, width: 70 }}>Size</TableHead><TableHead style={{ ...th, width: 84 }}>Repo</TableHead>
-            </TableRow></TableHeader>
-            <TableBody>
-              {queue.map((q) => (
-                <TableRow key={q.id} style={{ background: q.rank <= config.freeSlots ? "rgba(57,208,122,0.06)" : undefined }}>
-                  <TableCell style={{ ...mono, color: C.fgMuted }}>{q.rank}</TableCell>
-                  <TableCell><PriorityIcon p={q.priority} /></TableCell>
-                  <TableCell style={{ ...mono, ...td, color: C.blue, fontWeight: 600 }}>{q.id}</TableCell>
-                  <TableCell style={{ ...td, ...ellip, maxWidth: 0 }}>{q.title}</TableCell>
-                  <TableCell><ScopeChip scope={q.scope} estimate={q.estimate} /></TableCell>
-                  <TableCell style={{ ...mono, fontSize: 11, color: C.fgDim }}>{q.repo}</TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, margin: "0 0 8px" }}>
+          <span style={{ fontSize: 12, fontWeight: 600, color: C.fgMuted }}>Waiting in queue ({queue.length})</span>
+          <span style={{ flex: 1 }} />
+          {/* The group-by-node affordance only appears in a multi-node fleet
+              (queueHostMode === "multi"); single-host shows nothing here. */}
+          {multiHost && (
+            <Seg
+              value={groupByNode ? "node" : "rank"}
+              onChange={(v) => setGroupByNode(v === "node")}
+              options={[{ k: "rank", label: "Global rank" }, { k: "node", label: "By node" }]}
+            />
+          )}
         </div>
-        <div style={{ marginTop: 12, fontSize: 11, color: C.fgDim }}>Global rank: priority → pipeline stage → created-at → id. Per-project caps apply after ranking. Highlighted rows dispatch next as slots free.</div>
+        <WaitingTable queue={queue} freeSlots={config.freeSlots} showHost={multiHost} grouped={grouped} />
+        <div style={{ marginTop: 12, fontSize: 11, color: C.fgDim }}>Global rank: priority → pipeline stage → created-at → id. Per-project caps apply after ranking. Highlighted rows dispatch next as slots free.{multiHost ? " Node = the HRW owner host for each queued ticket." : ""}</div>
       </div>
     </div>
   );

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/queue-grouping.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/queue-grouping.test.ts
@@ -1,0 +1,146 @@
+// queue-grouping.test.ts — units for the SURF2 (CTL-910) per-node grouping of the
+// waiting queue. Pure logic, no DOM — run from the ui package:
+//   cd ui && bun test src/board/queue-grouping.test.ts
+//
+// These encode the SURF2 Gherkin scenarios that are testable without a renderer:
+//   • "Queue ordering matches the scheduler's global rank" — global rank order is
+//     preserved both flat and within each per-host group.
+//   • "Queue entries are attributable to their owning node" — multi-host yields a
+//     real node column / grouping.
+//   • "Single-host cluster is an exact identity no-op" — one (or zero) distinct
+//     host ⇒ no node column, one synthetic group, behaviourally identical to the
+//     flat list.
+import { describe, it, expect } from "bun:test";
+import type { BoardQueueItem, BoardHostRef } from "./types";
+import {
+  queueHostMode,
+  groupQueueByHost,
+  UNATTRIBUTED_HOST_LABEL,
+} from "./queue-grouping";
+
+const host = (name: string): BoardHostRef => ({ name, id: `id-${name}` });
+
+// Minimal queue item — only the fields the grouping reads matter; the rest are
+// filled with inert defaults so the fixture stays a real BoardQueueItem.
+function qi(partial: Partial<BoardQueueItem> & { id: string; rank: number }): BoardQueueItem {
+  return {
+    title: partial.id,
+    priority: 3,
+    createdAt: "2026-06-08T00:00:00.000Z",
+    repo: "catalyst",
+    team: "CTL",
+    estimate: null,
+    scope: null,
+    project: null,
+    host: null,
+    ...partial,
+  };
+}
+
+describe("queueHostMode (single-host identity no-op detector)", () => {
+  it("reports single-host when the queue is empty", () => {
+    // No rows ⇒ nothing to attribute ⇒ identity no-op (no node column).
+    expect(queueHostMode([])).toBe("single");
+  });
+
+  it("reports single-host when every row resolves to the same host", () => {
+    const q = [
+      qi({ id: "CTL-1", rank: 1, host: host("mini") }),
+      qi({ id: "CTL-2", rank: 2, host: host("mini") }),
+    ];
+    expect(queueHostMode(q)).toBe("single");
+  });
+
+  it("reports single-host when no row carries a host (un-stamped, single-node fleet)", () => {
+    // hosts.json absent / length 1 ⇒ board-data stamps host:null; the column must
+    // add no visual noise — exactly the non-cluster path.
+    const q = [qi({ id: "CTL-1", rank: 1 }), qi({ id: "CTL-2", rank: 2 })];
+    expect(queueHostMode(q)).toBe("single");
+  });
+
+  it("reports multi-host only when two or more DISTINCT hosts appear", () => {
+    const q = [
+      qi({ id: "CTL-1", rank: 1, host: host("mini") }),
+      qi({ id: "CTL-2", rank: 2, host: host("mac-studio") }),
+    ];
+    expect(queueHostMode(q)).toBe("multi");
+  });
+
+  it("treats one named host + some un-stamped rows as multi-host (the named node is real)", () => {
+    // A mixed payload during a roster rollout: one node names itself, the rest are
+    // still un-stamped. That IS more than one bucket, so the column is meaningful.
+    const q = [
+      qi({ id: "CTL-1", rank: 1, host: host("mini") }),
+      qi({ id: "CTL-2", rank: 2, host: null }),
+    ];
+    expect(queueHostMode(q)).toBe("multi");
+  });
+
+  it("dedupes hosts by id, not by name", () => {
+    // Two refs with the same id are the same node even if a display name differs;
+    // that must NOT trip multi-host.
+    const q = [
+      qi({ id: "CTL-1", rank: 1, host: { name: "mini", id: "shared" } }),
+      qi({ id: "CTL-2", rank: 2, host: { name: "mini.local", id: "shared" } }),
+    ];
+    expect(queueHostMode(q)).toBe("single");
+  });
+});
+
+describe("groupQueueByHost", () => {
+  it("single-host: one group carrying every row in global-rank order", () => {
+    const q = [
+      qi({ id: "CTL-2", rank: 2, host: host("mini") }),
+      qi({ id: "CTL-1", rank: 1, host: host("mini") }),
+    ];
+    const groups = groupQueueByHost(q);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].host).toEqual(host("mini"));
+    // global rank order preserved within the group (not re-sorted by id).
+    expect(groups[0].items.map((i) => i.rank)).toEqual([2, 1]);
+  });
+
+  it("un-stamped single-host: one synthetic group with a null host ref", () => {
+    const q = [qi({ id: "CTL-1", rank: 1 }), qi({ id: "CTL-2", rank: 2 })];
+    const groups = groupQueueByHost(q);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].host).toBeNull();
+    expect(groups[0].label).toBe(UNATTRIBUTED_HOST_LABEL);
+    expect(groups[0].items.map((i) => i.id)).toEqual(["CTL-1", "CTL-2"]);
+  });
+
+  it("multi-host: one group per distinct host, groups ordered by first appearance in rank order", () => {
+    const q = [
+      qi({ id: "CTL-1", rank: 1, host: host("mini") }),
+      qi({ id: "CTL-2", rank: 2, host: host("studio") }),
+      qi({ id: "CTL-3", rank: 3, host: host("mini") }),
+    ];
+    const groups = groupQueueByHost(q);
+    expect(groups.map((g) => g.host?.name)).toEqual(["mini", "studio"]);
+    // each group keeps the global ranks of ITS rows, in ascending rank order.
+    expect(groups[0].items.map((i) => i.rank)).toEqual([1, 3]);
+    expect(groups[1].items.map((i) => i.rank)).toEqual([2]);
+  });
+
+  it("multi-host: per-node depth = the group's row count", () => {
+    const q = [
+      qi({ id: "CTL-1", rank: 1, host: host("mini") }),
+      qi({ id: "CTL-2", rank: 2, host: host("mini") }),
+      qi({ id: "CTL-3", rank: 3, host: host("studio") }),
+    ];
+    const depthByHost = Object.fromEntries(
+      groupQueueByHost(q).map((g) => [g.host?.name, g.items.length]),
+    );
+    expect(depthByHost).toEqual({ mini: 2, studio: 1 });
+  });
+
+  it("never drops or duplicates a row (flatten round-trips the input set)", () => {
+    const q = [
+      qi({ id: "CTL-1", rank: 1, host: host("mini") }),
+      qi({ id: "CTL-2", rank: 2, host: null }),
+      qi({ id: "CTL-3", rank: 3, host: host("studio") }),
+    ];
+    const flat = groupQueueByHost(q).flatMap((g) => g.items.map((i) => i.id));
+    expect(flat.sort()).toEqual(["CTL-1", "CTL-2", "CTL-3"]);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/queue-grouping.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/queue-grouping.ts
@@ -1,0 +1,92 @@
+// queue-grouping.ts — the PURE per-node grouping of the waiting queue (SURF2 /
+// CTL-910). Pulled out of the QueueSurface view so the node-attribution contract
+// is unit-testable without a DOM, matching the surface.ts / board-logic.ts /
+// list-order.ts pattern. The view reads `queueHostMode` to decide whether the
+// node column/grouping is even shown, and `groupQueueByHost` to render the
+// grouped tables.
+//
+// SINGLE-HOST IDENTITY NO-OP (operator hard-constraint): with hosts.json absent
+// or length 1, board-data stamps `host:null` (or a single repeated host) on every
+// queue entity, so `queueHostMode` returns "single" and the surface renders
+// EXACTLY today's flat ranked table — zero node column, zero added rows, zero
+// latency. The N>1 branch (a real node column + group-by-node) only lights up
+// when the read-model resolves two or more DISTINCT HRW owner hosts; that branch
+// is the same code path, just yielding more than one bucket.
+import type { BoardQueueItem, BoardHostRef } from "./types";
+
+/** Whether the waiting table should surface a node column / group affordance. */
+export type QueueHostMode = "single" | "multi";
+
+/** Bucket label shown for queue rows the read-model could not attribute to a host
+ *  (host:null — un-stamped during a single-node fleet or before a fence claim). */
+export const UNATTRIBUTED_HOST_LABEL = "Unassigned";
+
+/** One node's slice of the waiting queue, items kept in global-rank order. */
+export interface QueueHostGroup {
+  /** The owning node, or null for the un-attributed bucket. */
+  host: BoardHostRef | null;
+  /** Display label (host name, or UNATTRIBUTED_HOST_LABEL when host is null). */
+  label: string;
+  /** This node's queued rows, preserving the scheduler's global rank order. */
+  items: BoardQueueItem[];
+}
+
+/** The stable bucket key for a queue row: the host id, or "" when un-attributed.
+ *  Dedup is by id (not display name) so the same node under two names is one
+ *  bucket — see groupByHost() in the read-model contract for the same rule. */
+function hostKey(item: BoardQueueItem): string {
+  return item.host?.id ?? "";
+}
+
+/**
+ * Detect whether the waiting queue spans more than one DISTINCT owner node.
+ *
+ * Returns "single" (the identity no-op) when the queue is empty, every row shares
+ * one host id, or every row is un-attributed. Returns "multi" only when two or
+ * more distinct buckets exist (two named hosts, or a named host alongside
+ * un-attributed rows) — i.e. when a node column actually carries information. A
+ * "single" result means the surface must add no node column and no visual noise.
+ */
+export function queueHostMode(queue: readonly BoardQueueItem[]): QueueHostMode {
+  const keys = new Set<string>();
+  for (const item of queue) {
+    keys.add(hostKey(item));
+    if (keys.size > 1) return "multi";
+  }
+  return "single";
+}
+
+/**
+ * Group the waiting queue by owning node WITHOUT disturbing the scheduler's
+ * global rank order.
+ *
+ * Groups appear in the order their first row is encountered (the queue is already
+ * globally ranked, so this is first-by-rank), and each group's items stay in that
+ * same ascending-rank order. The un-attributed bucket (host:null) participates
+ * like any other node. This is total — every input row lands in exactly one group
+ * (no drops, no dups). Single-host input yields exactly one group, so callers can
+ * always iterate `groupQueueByHost(...)` whether or not the node column is shown.
+ */
+export function groupQueueByHost(queue: readonly BoardQueueItem[]): QueueHostGroup[] {
+  const byKey = new Map<string, QueueHostGroup>();
+  // `groups` preserves first-appearance order; each entry is the SAME object
+  // reference stored in `byKey`, so pushing to `group.items` below mutates the
+  // array entry too — no second lookup, no non-null assertion.
+  const groups: QueueHostGroup[] = [];
+  for (const item of queue) {
+    const key = hostKey(item);
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.items.push(item);
+      continue;
+    }
+    const group: QueueHostGroup = {
+      host: item.host ?? null,
+      label: item.host?.name ?? UNATTRIBUTED_HOST_LABEL,
+      items: [item],
+    };
+    byKey.set(key, group);
+    groups.push(group);
+  }
+  return groups;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
@@ -71,6 +71,11 @@ type OperateItem = {
   icon: typeof InboxIcon;
 };
 
+// The OPERATE array carries ONLY the static IA (surface/label/icon). Every
+// badge/dot is DERIVED per-render from the live nav signal (CTL-896 / SHELL6) —
+// including the Queue depth badge that CTL-910 / SURF2 introduced (now fed by the
+// read-model nav-signal projection `nav.queueDepth` instead of a second snapshot
+// subscription). No mock literals here.
 const OPERATE: OperateItem[] = [
   { surface: "home", label: "Home", icon: InboxIcon },
   { surface: "board", label: "Board", icon: LayoutGridIcon },
@@ -107,6 +112,8 @@ export function AppSidebar() {
   // CTL-896 / SHELL6 — the live nav signal off the read-model SSE projection.
   // null until the first frame lands; the badges/dots simply don't render until
   // then (no mock placeholder), then go live and update without a page reload.
+  // This supersedes CTL-910 / SURF2's separate useBoardSnapshot queue-depth
+  // badge: the Queue depth is now `nav.queueDepth` from the SAME projection.
   const nav = useNavSignal();
 
   function go(s: Surface) {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/queue-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/queue-surface.tsx
@@ -1,0 +1,85 @@
+// queue-surface.tsx — the dedicated wide Queue surface (CTL-910 / SURF2).
+//
+// SURF2 promotes the board's internal Queue tab into the app shell as its OWN
+// edge-to-edge route. The shell (AppShell) already owns the Queue nav item, the
+// `g q` chord, and the top strip + breadcrumb; this component is the inset BODY
+// rendered when surface === "queue" (wired in App.tsx's SurfaceSwitch via
+// surfaceContentKind === "queue").
+//
+// Data plane: the SAME cache-backed read-model snapshot the board + Inbox consume
+// (useBoardSnapshot → connectBoard → ONE shared EventSource), so the queue is fed
+// by the BFF read-model's queue entities (the eligible projection, globally
+// ranked + host-stamped in lib/board-data.mjs) and NEVER a synchronous per-request
+// Linear call (the SURF2 "fed by the read-model, not a Linear call" requirement).
+//
+// Rendering: it reuses the QueueView render verbatim (the width-hungry capacity
+// strip + SlotBar + Stats + the in-flight table + the ranked waiting table) with
+// `embedded` so it fills the inset's flex slot. QueueView itself adds the optional
+// per-node column + group-by-node affordance, both gated behind the single-host
+// identity no-op — so a single-node fleet reads exactly like today.
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useBoardSnapshot } from "@/hooks/use-board-snapshot";
+import { QueueView } from "@/board/Board";
+
+// The dark Catalyst board surface base color (orch-monitor DESIGN.md `s0`), kept
+// in step with the Board root so the embedded QueueView's hard-coded surfaces sit
+// on the same backdrop whether it is mounted standalone or in the shell.
+const SURFACE_BG = "#0b0d10";
+
+export function QueueSurface() {
+  const { payload, status } = useBoardSnapshot();
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div
+        className="flex h-full min-h-0 flex-col"
+        style={{
+          background: SURFACE_BG,
+          color: "#e6e9ef",
+          fontSize: 13,
+          fontFamily:
+            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+        }}
+      >
+        {/* Calm one-line surface header (matches the dashboard meta row tone). */}
+        <div
+          className="flex shrink-0 items-center gap-3 px-4 py-3"
+          style={{ borderBottom: "1px solid #262d36", background: "#111318" }}
+        >
+          <h1 style={{ margin: 0, fontSize: 15, fontWeight: 600 }}>
+            Capacity &amp; queue
+          </h1>
+          <span style={{ color: "#8b93a1", fontSize: 12 }}>
+            What&apos;s on the plate, and what dispatches next
+          </span>
+          <span style={{ flex: 1 }} />
+          <span
+            style={{
+              fontFamily:
+                "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+              fontSize: 10,
+              letterSpacing: 1.5,
+              color: status === "connected" ? "#39d07a" : "#ef5d5d",
+              border: `1px solid ${status === "connected" ? "rgba(57,208,122,0.35)" : "rgba(239,93,93,0.35)"}`,
+              borderRadius: 5,
+              padding: "2px 6px",
+            }}
+          >
+            {status === "connected" ? "LIVE" : "OFFLINE"}
+          </span>
+        </div>
+
+        {/* The edge-to-edge ranked depth table, filling the inset below the strip. */}
+        <div className="min-h-0 flex-1">
+          {payload ? (
+            <QueueView data={payload} embedded />
+          ) : (
+            <div style={{ color: "#8b93a1", padding: 24 }}>
+              Connecting to execution-core…
+            </div>
+          )}
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.test.ts
@@ -22,18 +22,29 @@ describe("surfaceContentKind", () => {
     expect(surfaceContentKind("workers")).toBe("workers");
   });
 
-  it("keeps Home/Queue on the dashboard (no regression)", () => {
-    // Home + Queue must stay exactly what they rendered before — only board +
-    // workers are special-cased now.
-    const onDashboard = SURFACES.filter((s) => s !== "board" && s !== "workers");
-    for (const s of onDashboard) {
+  it("routes the queue surface to its own dedicated queue content (SURF2 / CTL-910)", () => {
+    // Gherkin: "the operator clicks the Queue nav item → the Queue surface
+    // renders edge-to-edge and wide in the SidebarInset" — the queue is its OWN
+    // route now, no longer the SHELL2 dashboard fall-through.
+    expect(surfaceContentKind("queue")).toBe("queue");
+  });
+
+  it("keeps Home on the dashboard (no regression)", () => {
+    // Home must stay exactly what SHELL1/SHELL2 rendered — only board (SHELL2),
+    // workers (SURF1), and queue (SURF2) are special-cased now.
+    const stillDashboard = SURFACES.filter(
+      (s) => s !== "board" && s !== "workers" && s !== "queue",
+    );
+    for (const s of stillDashboard) {
       expect(surfaceContentKind(s)).toBe("dashboard");
     }
   });
 
   it("covers every declared surface (no surface falls through undefined)", () => {
     for (const s of SURFACES as readonly Surface[]) {
-      expect(["board", "workers", "dashboard"]).toContain(surfaceContentKind(s));
+      expect(["board", "workers", "queue", "dashboard"]).toContain(
+        surfaceContentKind(s),
+      );
     }
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.ts
@@ -17,23 +17,26 @@ import type { Surface } from "./surface";
  *  - "board"     → the dense, full-bleed <Board /> grid (CTL-892).
  *  - "workers"   → the dense Workers grid: the SAME <Board /> opened on its
  *                  Workers view, with the node group-by + node filter (CTL-909).
+ *  - "queue"     → the dedicated wide ranked-depth Queue surface (CTL-910 / SURF2):
+ *                  capacity strip + on-the-plate table + waiting ranked table with
+ *                  the optional per-node column.
  *  - "dashboard" → the existing monitor dashboard / orchestrator / comms / etc.
  *
- * Queue still falls through to "dashboard" today; it migrates to its own dense
- * surface in a later SHELL ticket. Home is the calm dashboard inbox.
+ * Home is the calm dashboard inbox; every other surface falls through to it.
  */
-export type SurfaceContentKind = "board" | "workers" | "dashboard";
+export type SurfaceContentKind = "board" | "workers" | "queue" | "dashboard";
 
 /**
  * Resolve which content kind the inset should render for the active surface.
- * "board" was special-cased in SHELL2; SURF1 (CTL-909) adds "workers" — the
- * Workers surface is now its own dense grid instead of the placeholder
- * dashboard. Every other surface keeps the dashboard content so this stays
- * behavior-preserving for Home/Queue (no regression).
+ * "board" was special-cased in SHELL2; SURF1 (CTL-909) adds "workers" and
+ * SURF2 (CTL-910) adds "queue" — each is now its own dense, edge-to-edge
+ * surface instead of the placeholder dashboard. Every other surface keeps the
+ * dashboard content so this stays behavior-preserving for Home (no regression).
  */
 export function surfaceContentKind(surface: Surface): SurfaceContentKind {
   if (surface === "board") return "board";
   if (surface === "workers") return "workers";
+  if (surface === "queue") return "queue";
   return "dashboard";
 }
 


### PR DESCRIPTION
## Summary

Promotes the orch-monitor board's internal **Queue tab** into the app shell as its **own edge-to-edge route** (CTL-910 / SURF2). The Queue nav item (and `g q` chord) now opens a dedicated, width-hungry ranked-depth surface in the `SidebarInset`, fed by the cache-backed read-model snapshot (the eligible projection assembled in `lib/board-data.mjs`) over the SAME shared `connectBoard` EventSource the board + Inbox use — never a synchronous per-request Linear call.

**Node attribution (single-node MVP descope honored):** the waiting table gains an *optional* per-node column + a group-by-node toggle, attributing each queued ticket to its HRW owner host (`BoardQueueItem.host`, already plumbed by BFF10 / CTL-922). Both are gated behind a **single-host identity no-op** — with `hosts.json` absent or length 1 every row resolves to one host (or none), so `queueHostMode()` returns `"single"` and the surface renders **exactly today's flat ranked table** (no node column, no toggle, no added noise, zero latency). The N>1 branch is the same code path yielding more than one per-node bucket; no multi-node anchors are built here.

## Files

- `ui/src/board/queue-grouping.ts` (+ `.test.ts`) — pure `queueHostMode` / `groupQueueByHost`: the single-host detector + rank-preserving per-node grouping (no DOM; 11 units).
- `ui/src/lib/surface-content.ts` (+ test) — new `"queue"` content kind; board + queue special-cased, Home/Workers still `"dashboard"` (no regression).
- `ui/src/board/Board.tsx` — `QueueView` exported + node column / grouping + `embedded` height. The board's **internal** Queue tab is unchanged (`embedded` defaults `false`).
- `ui/src/components/queue/queue-surface.tsx` — self-connecting surface via `useBoardSnapshot`.
- `ui/src/App.tsx` — `SurfaceSwitch` routes `surface === "queue"` to the dedicated surface (stable top-level branch, no EventSource churn).
- `ui/src/components/app-sidebar.tsx` — the Queue nav badge is now **live queue depth**.

## Gherkin scenarios

| Scenario | Status |
| --- | --- |
| Queue nav item opens the ranked depth table (edge-to-edge, capacity strip, in-flight + waiting tables, next-to-dispatch rows highlighted) | **satisfied** |
| Queue ordering matches the scheduler's global rank (rank, priority, id, title, size/estimate, repo; read-model order, not a client sort) | **satisfied** |
| Queue entries are attributable to their owning node (node column + group/filter-by-node for per-node depth) | **satisfied** (host already plumbed by BFF10/CTL-922; column + group-by-node render when ≥2 distinct hosts) |
| Single-host cluster is an exact identity no-op (every row → one host, node column adds no noise) | **satisfied** |

Multi-node anchors (CTL-863/864/865/866/873/876) are **single-node-descoped** per the operator hard-constraint: their contracts are treated as satisfied by the identity no-op, and the N>1 host branch is stubbed behind the `queueHostMode` distinct-host check.

## Tests

- `cd ui && bun test` → **38 pass / 0 fail** (incl. new `queue-grouping.test.ts` 11 units + extended `surface-content.test.ts`).
- `cd ui && bunx tsc --noEmit` → clean for this diff (one pre-existing unrelated error in `kpi-strip.tsx:48`, present on clean origin/main).
- `cd ui && bun run build` → succeeds.

No reward-hacking: no `as any` / `as unknown` / `@ts-ignore` / non-null `!` / `forEach(async`. Built build output (`public/assets/`, entry HTML) intentionally NOT committed — source-only, matching the HOME1 (CTL-899) surface PR convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)