### PR TITLE
fix(dev): CTL-928 truthful queue-board liveness — dead bg-workers excluded, idle-between-phases lane

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/board-liveness.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-liveness.test.ts
@@ -1,0 +1,242 @@
+// CTL-928 — the queue board must truthfully account for every in-flight ticket:
+// a DEAD background worker must never look active, and an IDLE-between-phases
+// ticket must never disappear. A signal file that says `running` is NOT proof of
+// life (on 2026-06-09 four sources disagreed on liveness) — so liveness is derived
+// from the DURABLE `claude --bg` job state.json, not the phase signal.
+//
+// These tests exercise the four fix sites in board-data.mjs as PURE functions
+// (assembleBoard itself shells out to `claude agents` + reads homedir consts, so
+// it is not directly unit-testable — same convention as board-current-phase.test.ts
+// / board-data-worker-ids.test.ts):
+//   • deriveActiveState  — a dead bg-job renders "dead", not "active"
+//   • laneFor            — a terminal-intermediate / dead-but-running ticket lands
+//                          in the between-phases lane, not recent-done, not dropped
+//   • deriveCapacity     — freeSlots/inFlight reflect LIVE workers only
+//   • bgJobLifecycle     — the durable-state liveness primitive
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readBgJobState,
+  bgJobLifecycle,
+  isBgJobDead,
+  isWorkerDead,
+  deriveActiveState,
+  deriveCapacity,
+  laneFor,
+  TERMINAL_JOB_STATES,
+  PIPELINE_DONE_PHASE,
+} from "../lib/board-data.mjs";
+import type { BoardActiveState } from "../lib/board-data.d.mts";
+
+// Minimal shapes the pure helpers consume — typed so literals widen to the union,
+// not to bare `string`.
+type CapWorker = { activeState: BoardActiveState; working: boolean };
+type LaneTicket = { workerStatus: string | null; activeState: BoardActiveState; phase: string };
+
+// ── readBgJobState + deriveActiveState end-to-end against a REAL temp jobs dir ──
+// Validates the actual fs read path (the CATALYST_REVIVE_JOBS_DIR override) and the
+// failed-bg-state + fresh-transcript scenario through to the "dead" verdict.
+test("readBgJobState reads a failed state.json from a temp jobs dir, and deriveActiveState renders 'dead' despite a fresh (<30m) transcript", async () => {
+  const root = mkdtempSync(join(tmpdir(), "ctl928-jobs-"));
+  const prev = process.env.CATALYST_REVIVE_JOBS_DIR;
+  process.env.CATALYST_REVIVE_JOBS_DIR = root;
+  try {
+    const bgJobId = "abc12345";
+    mkdirSync(join(root, bgJobId), { recursive: true });
+    writeFileSync(
+      join(root, bgJobId, "state.json"),
+      JSON.stringify({ state: "failed", firstTerminalAt: "2026-06-09T08:00:00Z", detail: "API Error" }),
+    );
+
+    const jobState = await readBgJobState(bgJobId);
+    expect(jobState).toEqual({ state: "failed", firstTerminalAt: "2026-06-09T08:00:00Z" });
+    expect(isBgJobDead(jobState)).toBe(true);
+
+    // 8-minute-fresh transcript — under STUCK_MS — would have been "active" pre-CTL-928.
+    const state = await deriveActiveState("CTL-722", "plan", 8 * 60_000, jobState, /* bgKnown */ true);
+    expect(state).toBe("dead");
+  } finally {
+    if (prev === undefined) delete process.env.CATALYST_REVIVE_JOBS_DIR;
+    else process.env.CATALYST_REVIVE_JOBS_DIR = prev;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("readBgJobState: gone job dir → null (dead-gone); a 'working' state.json → alive", async () => {
+  const root = mkdtempSync(join(tmpdir(), "ctl928-jobs-"));
+  const prev = process.env.CATALYST_REVIVE_JOBS_DIR;
+  process.env.CATALYST_REVIVE_JOBS_DIR = root;
+  try {
+    expect(await readBgJobState("does-not-exist")).toBeNull();
+    const alive = "live9999";
+    mkdirSync(join(root, alive), { recursive: true });
+    writeFileSync(join(root, alive, "state.json"), JSON.stringify({ state: "working" }));
+    const js = await readBgJobState(alive);
+    expect(js).toEqual({ state: "working", firstTerminalAt: null });
+    expect(bgJobLifecycle(js)).toBe("alive");
+  } finally {
+    if (prev === undefined) delete process.env.CATALYST_REVIVE_JOBS_DIR;
+    else process.env.CATALYST_REVIVE_JOBS_DIR = prev;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── bgJobLifecycle: the durable-state liveness primitive (mirrors recovery.mjs) ─
+test("bgJobLifecycle: gone job dir (null state) → dead-gone", () => {
+  expect(bgJobLifecycle(null)).toBe("dead-gone");
+});
+
+test("bgJobLifecycle: terminal .state (stopped/failed/done/blocked) → dead-terminal", () => {
+  for (const s of ["stopped", "failed", "done", "blocked"]) {
+    expect(bgJobLifecycle({ state: s, firstTerminalAt: null })).toBe("dead-terminal");
+  }
+});
+
+test("bgJobLifecycle: firstTerminalAt set → dead-terminal even on an unknown state", () => {
+  expect(bgJobLifecycle({ state: "weird-unenumerated", firstTerminalAt: "2026-06-09T08:00:00Z" }))
+    .toBe("dead-terminal");
+});
+
+test("bgJobLifecycle: 'working' (or unreadable-but-present) → alive (mtime NOT consulted)", () => {
+  expect(bgJobLifecycle({ state: "working", firstTerminalAt: null })).toBe("alive");
+  // an unreadable-but-present state.json surfaces { state:null } → alive (dir exists)
+  expect(bgJobLifecycle({ state: null, firstTerminalAt: null })).toBe("alive");
+});
+
+test("isBgJobDead: true for terminal/gone, false for alive", () => {
+  expect(isBgJobDead(null)).toBe(true);
+  expect(isBgJobDead({ state: "failed", firstTerminalAt: null })).toBe(true);
+  expect(isBgJobDead({ state: "working", firstTerminalAt: null })).toBe(false);
+});
+
+test("TERMINAL_JOB_STATES is exactly the four Claude bg terminal states", () => {
+  expect([...TERMINAL_JOB_STATES].sort()).toEqual(["blocked", "done", "failed", "stopped"]);
+  expect(TERMINAL_JOB_STATES.has("working")).toBe(false);
+});
+
+// ── SCENARIO: A worker whose background job has FAILED is shown as dead ──────────
+//   Given a ticket's phase worker has a background job in state "failed"
+//   And that worker's transcript was last touched 8 minutes ago
+//   Then the worker is shown as dead (not "active"), excluded from inFlight + capacity
+test("deriveActiveState: failed bg-job + FRESH (<30m) transcript → 'dead' (signal-age does not resurrect it)", async () => {
+  const eightMinMs = 8 * 60_000; // well under STUCK_MS (30m) — would have rendered "active" before CTL-928
+  const state = await deriveActiveState(
+    "CTL-722", "plan", eightMinMs,
+    { state: "failed", firstTerminalAt: "2026-06-09T08:00:00Z" },
+    /* bgKnown */ true,
+  );
+  expect(state).toBe("dead");
+});
+
+test("deriveActiveState: gone job dir (null) with bgKnown → 'dead'", async () => {
+  const state = await deriveActiveState("CTL-865", "plan", 1000, null, true);
+  expect(state).toBe("dead");
+});
+
+test("deriveActiveState: alive 'working' bg-job + fresh transcript → 'active'", async () => {
+  const state = await deriveActiveState(
+    "CTL-999", "implement", 1000,
+    { state: "working", firstTerminalAt: null }, true,
+  );
+  expect(state).toBe("active");
+});
+
+test("deriveActiveState: NO resolvable bg_job_id (bgKnown=false) → falls back to transcript age, never fabricates dead", async () => {
+  // bgKnown=false: we cannot prove death from the durable state, so a fresh
+  // transcript stays "active" (matches the daemon's classifyWorker "unknown" path).
+  const fresh = await deriveActiveState("CTL-1", "implement", 1000, null, false);
+  expect(fresh).toBe("active");
+  // a >30m-stale transcript with no bg state is the pre-existing "stuck" verdict.
+  const stale = await deriveActiveState("CTL-1", "implement", 31 * 60_000, null, false);
+  expect(stale).toBe("stuck");
+});
+
+test("isWorkerDead: keys off the derived activeState 'dead'", () => {
+  expect(isWorkerDead({ activeState: "dead" })).toBe(true);
+  expect(isWorkerDead({ activeState: "active" })).toBe(false);
+  expect(isWorkerDead({ activeState: "stuck" })).toBe(false);
+  expect(isWorkerDead(null)).toBe(false);
+});
+
+// ── SCENARIO: Free-slot count reflects LIVE capacity, not worker-dir count ───────
+//   Given 6 in-flight workers and 3 of their background jobs are dead
+//   Then the board reports 3 live in-flight and 3 free slots
+test("deriveCapacity: 6 listed, 3 dead → inFlight 3, freeSlots 3, dead 3 (dead workers do not consume capacity)", () => {
+  const workers: CapWorker[] = [
+    { activeState: "active", working: true },
+    { activeState: "active", working: true },
+    { activeState: "stuck", working: false },
+    { activeState: "dead", working: false },
+    { activeState: "dead", working: false },
+    { activeState: "dead", working: false },
+  ];
+  const cfg = deriveCapacity(workers, 6);
+  expect(cfg.inFlight).toBe(3); // only the 3 live workers
+  expect(cfg.freeSlots).toBe(3); // 6 − 3 live
+  expect(cfg.dead).toBe(3);
+  expect(cfg.active).toBe(2);
+  expect(cfg.stuck).toBe(1);
+  expect(cfg.working).toBe(2);
+  expect(cfg.maxParallel).toBe(6);
+});
+
+test("deriveCapacity: all dead → 0 inFlight, full free capacity", () => {
+  const workers: CapWorker[] = [
+    { activeState: "dead", working: false },
+    { activeState: "dead", working: false },
+  ];
+  const cfg = deriveCapacity(workers, 6);
+  expect(cfg.inFlight).toBe(0);
+  expect(cfg.freeSlots).toBe(6);
+  expect(cfg.dead).toBe(2);
+});
+
+// ── SCENARIO: A triaged ticket waiting for its next phase is between-phases ──────
+//   Given a ticket has finished triage (worker dir exists, latest signal "done")
+//   And no live worker is currently assigned to it
+//   Then the ticket appears in an "idle / between-phases" lane (not recent-done, not dropped)
+test("laneFor: triage/done + no live worker → 'between-phases' (NOT recent-done, NOT dropped)", () => {
+  // deriveCurrentPhase surfaces a terminal-intermediate triage as phase:"triage".
+  const ticket = { workerStatus: null, activeState: null, phase: "triage" };
+  expect(laneFor(ticket)).toBe("between-phases");
+});
+
+test("laneFor: verify/done + no live worker → 'between-phases' (a mid-pipeline terminal is idle, not done)", () => {
+  expect(laneFor({ workerStatus: null, activeState: null, phase: "verify" })).toBe("between-phases");
+});
+
+test("laneFor: a DEAD-but-running worker's ticket → 'between-phases', never 'live'", () => {
+  // A dead worker is stripped from inFlightTickets, so its ticket has workerStatus
+  // null; even if a stale activeState leaked through, a "dead" worker is not live.
+  expect(laneFor({ workerStatus: "running", activeState: "dead", phase: "plan" })).toBe("between-phases");
+});
+
+test("laneFor: a LIVE worker (active/stuck) → 'live'", () => {
+  expect(laneFor({ workerStatus: "running", activeState: "active", phase: "implement" })).toBe("live");
+  expect(laneFor({ workerStatus: "running", activeState: "stuck", phase: "implement" })).toBe("live");
+});
+
+test("laneFor: only the synthetic pipeline-done phase is 'recent-done'", () => {
+  expect(laneFor({ workerStatus: null, activeState: null, phase: PIPELINE_DONE_PHASE })).toBe("recent-done");
+  expect(PIPELINE_DONE_PHASE).toBe("done");
+});
+
+// ── SCENARIO: every non-terminal ticket is in EXACTLY one lane ───────────────────
+test("laneFor: every ticket lands in exactly one of live | between-phases | recent-done", () => {
+  const tickets: LaneTicket[] = [
+    { workerStatus: "running", activeState: "active", phase: "implement" }, // live
+    { workerStatus: "running", activeState: "dead", phase: "plan" },         // between-phases (dead)
+    { workerStatus: null, activeState: null, phase: "triage" },              // between-phases (idle)
+    { workerStatus: null, activeState: null, phase: "research" },            // between-phases (idle)
+    { workerStatus: null, activeState: null, phase: "done" },                // recent-done
+  ];
+  const lanes = tickets.map(laneFor);
+  const valid = new Set(["live", "between-phases", "recent-done"]);
+  for (const l of lanes) expect(valid.has(l)).toBe(true);
+  // partition is total: live(1) + between(3) + done(1) = 5, none dropped
+  expect(lanes.filter((l) => l === "live").length).toBe(1);
+  expect(lanes.filter((l) => l === "between-phases").length).toBe(3);
+  expect(lanes.filter((l) => l === "recent-done").length).toBe(1);
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -3,7 +3,11 @@
 // Vite config import assembleBoard() without a TS7016 implicit-any error.
 // Keep in sync with the object assembled in board-data.mjs.
 
-export type BoardActiveState = "active" | "stuck" | null;
+// CTL-928: "dead" joins the liveness states — a worker whose DURABLE bg-job state
+// (~/.claude/jobs/<id>/state.json) is terminal (stopped/failed/done/blocked) or
+// whose job dir is gone, regardless of a phase signal still saying `running`. A
+// dead worker is excluded from in-flight + consumed capacity.
+export type BoardActiveState = "active" | "stuck" | "dead" | null;
 
 /** CTL-922 (BFF10): a node's stable identity stamped on every board entity so
  *  the node-aware surfaces can attribute/group by host. `name` is the
@@ -36,6 +40,10 @@ export interface BoardWorker {
   pid: number | null;
   /** CTL-888 (BFF6) P7: catalyst `sess_…` id (catalyst.session heartbeat key); null when unknown. */
   catalystSessionId: string | null;
+  /** CTL-928: the durable `claude --bg` job id this worker's liveness was derived
+   *  from (read off the phase signal). null when no signal carried one. Optional so
+   *  existing BoardWorker fixtures stay valid; the runtime always populates it. */
+  bgJobId?: string | null;
   /** CTL-922 (BFF10): the node owning this worker, from the phase signal
    *  host:{name,id} (CTL-852) or the durable fence projection owner_host (BFF11).
    *  null when no host is named (single-host resolves to the one node). */
@@ -139,11 +147,20 @@ export interface BoardQueueItem {
 
 export interface BoardConfig {
   maxParallel: number;
+  /** CTL-928: LIVE in-flight workers (dead bg-jobs excluded). */
   inFlight: number;
+  /** CTL-928: maxParallel − live inFlight — true free capacity (dead workers no
+   *  longer suppress it). */
   freeSlots: number;
   active: number;
   working: number;
   stuck: number;
+  /** CTL-928: workers whose durable bg-job is dead (terminal state.json or gone
+   *  job dir) yet still listed by `claude agents`. Surfaced so the operator sees
+   *  the corpses; they do NOT consume capacity (excluded from inFlight/freeSlots).
+   *  Optional so existing BoardConfig fixtures stay valid; the runtime always
+   *  populates it via deriveCapacity. */
+  dead?: number;
 }
 
 export interface BoardPayload {
@@ -158,9 +175,75 @@ export interface BoardPayload {
 export const PHASE_ORDER: string[];
 export const PHASE_TO_LINEAR: Record<string, string>;
 export const TERMINAL: Set<string>;
+/** CTL-928: the `claude --bg` job-lifecycle terminal `state` values (distinct from
+ *  the worker-signal TERMINAL set). In lock-step with recovery.mjs. */
+export const TERMINAL_JOB_STATES: Set<string>;
+/** CTL-928: the synthetic current-phase that marks a genuinely pipeline-done
+ *  ticket (deriveCurrentPhase collapses terminal monitor-deploy/teardown to it). */
+export const PIPELINE_DONE_PHASE: string;
 export const HELD_LABEL_BLOCKED: string;
 export const HELD_LABEL_WAITING: string;
 export function heldFor(labels: unknown): "blocked" | "waiting" | null;
+
+/** CTL-928: a single ticket's lane on the queue board (live | between-phases |
+ *  recent-done). Honors the terminal-intermediate vs pipeline-done distinction. */
+export type BoardLane = "live" | "between-phases" | "recent-done";
+
+/** CTL-928: the already-read `claude --bg` job state (state.json) shape consumed
+ *  by bgJobLifecycle — { state, firstTerminalAt }, or null when the job dir is gone. */
+export interface BgJobState {
+  state: string | null;
+  firstTerminalAt: string | null;
+}
+
+/** CTL-928: read a `claude --bg` job's durable state from
+ *  ~/.claude/jobs/<bgJobId>/state.json (honours CATALYST_REVIVE_JOBS_DIR). Returns
+ *  { state, firstTerminalAt }, or null when the job dir is gone. A present-but-
+ *  unreadable state.json yields { state:null, firstTerminalAt:null } (alive). Never
+ *  throws. */
+export function readBgJobState(bgJobId: string | null | undefined): Promise<BgJobState | null>;
+
+/** CTL-928: PURE read-model mirror of recovery.mjs::jobLifecycle. null jobState →
+ *  "dead-gone"; firstTerminalAt set or terminal `state` → "dead-terminal"; else
+ *  "alive". mtime is intentionally NOT consulted (CTL-662 fan-out trap). */
+export function bgJobLifecycle(jobState: BgJobState | null): "dead-gone" | "dead-terminal" | "alive";
+
+/** CTL-928: true iff bgJobLifecycle(jobState) is not "alive" (dead-gone or
+ *  dead-terminal). null jobState → dead. */
+export function isBgJobDead(jobState: BgJobState | null): boolean;
+
+/** CTL-928: true iff a board worker's derived activeState is "dead". A dead worker
+ *  is excluded from ticketIds, inFlight, freeSlots, and the "active" count. */
+export function isWorkerDead(worker: { activeState?: BoardActiveState } | null | undefined): boolean;
+
+/** CTL-928: PURE capacity summary — dead bg-workers excluded from inFlight +
+ *  freeSlots, surfaced as `dead`. Drives the board config block. */
+export function deriveCapacity(
+  workers: ReadonlyArray<{ activeState?: BoardActiveState; working?: boolean }>,
+  maxParallel: number,
+): BoardConfig;
+
+/** CTL-928: classify a worker's top-level liveness — durable bg-job state FIRST
+ *  (a `running` signal is not proof of life), transcript age second. Returns
+ *  "dead" | "stuck" | "active". `jobState` is the worker's read bg-job state (or
+ *  null); `bgKnown` distinguishes a positively-read bg state (a dead verdict is
+ *  trustworthy) from an unresolvable bg_job_id (fall back to transcript age). */
+export function deriveActiveState(
+  ticket: string,
+  phase: string,
+  ageMs: number | null,
+  jobState: BgJobState | null,
+  bgKnown: boolean,
+): Promise<"dead" | "stuck" | "active">;
+
+/** CTL-928: PURE single-source lane classifier for a non-queued ticket — "live"
+ *  (a live, non-dead worker attached), "recent-done" (phase === PIPELINE_DONE_PHASE),
+ *  else "between-phases" (terminal-intermediate / dead-but-running, no live worker). */
+export function laneFor(ticket: {
+  workerStatus: string | null;
+  activeState: BoardActiveState;
+  phase: string;
+}): BoardLane;
 export function buildPhaseSummary(phaseSigs: unknown[], now: number): BoardPhaseTiming[];
 export function deriveCurrentPhase(phaseSigs: unknown[]): BoardCurrentPhase;
 /** Build a thin Todo-column BoardTicket from an eligible queue entry (CTL-767). */

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -30,6 +30,16 @@ const EC = join(HOME, "catalyst", "execution-core");
 const WORKERS_DIR = join(EC, "workers");
 const ELIGIBLE_DIR = join(EC, "eligible");
 const DB = join(HOME, "catalyst", "catalyst.db");
+// CTL-928: the durable per-`claude --bg`-job state directory. A worker's
+// liveness is proven by its job's state.json HERE, NOT by a phase signal that
+// merely says `running` (on 2026-06-09 four sources disagreed on liveness — the
+// signal file was the least reliable). Mirrors the daemon's recovery.mjs lookup
+// (~/.claude/jobs/<bg_job_id>/state.json) and honours the same
+// CATALYST_REVIVE_JOBS_DIR override. Resolved at call time (like recovery.mjs's
+// getJobsRoot) so a test can point it at a temp dir without an import dance.
+function jobsRoot() {
+  return process.env.CATALYST_REVIVE_JOBS_DIR || join(HOME, ".claude", "jobs");
+}
 
 // Canonical 10-phase pipeline order + which statuses are terminal for a phase.
 export const PHASE_ORDER = [
@@ -43,6 +53,49 @@ export const PHASE_ORDER = [
 export const TERMINAL = new Set([
   "done", "failed", "stalled", "skipped", "signal_corrupt", "superseded", "canceled",
 ]);
+
+// CTL-928 — the authoritative `claude --bg` job-LIFECYCLE terminal states (the
+// `state` value Claude writes into ~/.claude/jobs/<id>/state.json). DISTINCT from
+// the worker-SIGNAL TERMINAL set above (a phase-signal `status` like done/skipped):
+// a signal can say `running` while the durable job state is `stopped`/`failed`/
+// `done` — that disagreement is exactly the dead-worker-shown-active bug. Kept in
+// lock-step with execution-core/recovery.mjs TERMINAL_JOB_STATES (the daemon's
+// dead-detection source); `working` is the sole non-terminal value.
+export const TERMINAL_JOB_STATES = new Set(["stopped", "failed", "done", "blocked"]);
+
+// CTL-928: the FINAL pipeline phases. A ticket whose CURRENT phase (per
+// deriveCurrentPhase) is one of these and is terminal has genuinely finished the
+// pipeline → it belongs in the recent-done tail. deriveCurrentPhase already
+// collapses a terminal monitor-deploy/teardown to the synthetic phase "done"
+// (CTL-745, :258), so "done" is the one true pipeline-done marker. Every OTHER
+// terminal phase (triage/research/plan/verify/review… done) is an INTERMEDIATE
+// completion → the ticket is idle BETWEEN phases, not finished.
+export const PIPELINE_DONE_PHASE = "done";
+
+// bgJobLifecycle — CTL-928 read-model mirror of recovery.mjs::jobLifecycle. PURE
+// given the already-read job state (so it is trivially unit-testable and the
+// async fs read stays at the edge). `jobState` is { state, firstTerminalAt } as
+// read from ~/.claude/jobs/<id>/state.json, or null when the dir is gone.
+//   "dead-gone"     — job dir gone (null): the worker process no longer exists.
+//   "dead-terminal" — firstTerminalAt set OR .state ∈ TERMINAL_JOB_STATES: Claude
+//                     marked the job terminal. Definitive — no grace window.
+//   "alive"         — any other readable state (notably "working", or an
+//                     unreadable state.json whose dir still exists). mtime is NOT
+//                     consulted — a multi-minute in-process sub-agent fan-out keeps
+//                     .state non-terminal while mtime ages (the CTL-662 trap).
+export function bgJobLifecycle(jobState) {
+  if (!jobState) return "dead-gone";
+  if (jobState.firstTerminalAt || TERMINAL_JOB_STATES.has(jobState.state)) return "dead-terminal";
+  return "alive";
+}
+
+// isBgJobDead — convenience predicate over bgJobLifecycle: a job is DEAD when its
+// lifecycle is either dead-gone or dead-terminal. A worker whose bg job is dead
+// must NOT count as in-flight, hold a maxParallel slot, or render "active"
+// (CTL-928). null jobState (no bg_job_id resolvable) → treated as dead-gone.
+export function isBgJobDead(jobState) {
+  return bgJobLifecycle(jobState) !== "alive";
+}
 
 // CTL-755 held-indicator labels (admission-control gate). A triaged-waiting
 // ticket the scheduler holds before the triage→research promotion carries one of
@@ -137,6 +190,47 @@ async function exists(p) {
   try { await stat(p); return true; } catch { return false; }
 }
 
+// CTL-928: read a `claude --bg` job's durable state from
+// ~/.claude/jobs/<bgJobId>/state.json. Returns { state, firstTerminalAt } — the
+// two fields bgJobLifecycle needs — or null when the job dir/file is gone
+// (worker process no longer exists). An UNREADABLE-but-present state.json yields
+// { state: null, firstTerminalAt: null }, which bgJobLifecycle treats as "alive"
+// (dir existence still proves the process is up — same fail-open as recovery.mjs).
+// Fail-open everywhere: a missing bg_job_id or any error never throws. Exported
+// so the CTL-928 liveness read is unit-testable against a temp jobs dir via the
+// CATALYST_REVIVE_JOBS_DIR override (set before import — JOBS_DIR is read once).
+export async function readBgJobState(bgJobId) {
+  if (!bgJobId) return null;
+  const root = jobsRoot();
+  const file = join(root, bgJobId, "state.json");
+  // The dir/file being gone is the death signal — distinguish it from a present
+  // dir whose state.json is merely unparseable.
+  if (!(await exists(file))) {
+    // The file may be absent while the dir still exists (job up, state not yet
+    // written). Treat a present dir as alive; a gone dir as dead.
+    return (await exists(join(root, bgJobId))) ? { state: null, firstTerminalAt: null } : null;
+  }
+  try {
+    const parsed = JSON.parse(await readFile(file, "utf8"));
+    return { state: parsed?.state ?? null, firstTerminalAt: parsed?.firstTerminalAt ?? null };
+  } catch {
+    // Present but unreadable — dir existence still proves liveness.
+    return { state: null, firstTerminalAt: null };
+  }
+}
+
+// CTL-928: a worker maps to a ticket:phase via `claude agents --json`, but the
+// durable bg_job_id lives on the phase SIGNAL (phase-<phase>.json `.bg_job_id`).
+// Resolve it so the board can read the worker's bg-job state. Returns the raw
+// bg_job_id string or null (no signal / no bg_job_id) — null then flows to
+// readBgJobState → null → bgJobLifecycle "dead-gone" only if the job dir is also
+// absent, so an as-yet-unstamped signal does not falsely kill a live worker
+// (readBgJobState falls open on a present dir; a null id with no dir is dead).
+async function workerBgJobId(ticket, phase) {
+  const sig = await readJSON(join(WORKERS_DIR, ticket, `phase-${phase}.json`));
+  return sig?.bg_job_id ?? sig?.bgJobId ?? null;
+}
+
 // ── live workers via `claude agents --json` ─────────────────────────────────
 async function liveAgents() {
   try {
@@ -213,10 +307,30 @@ async function transcriptAgeMs(sessionId, now) {
   return newest ? Math.max(0, now - newest) : null;
 }
 
-// Top-level state: a live worker is "active" (in its loop — generating OR actively
-// waiting on sub-agents / CI / a merge). Only call out the exceptions: a
-// finished-but-lingering process (terminal markers) or one dead for ~30m → "stuck".
-async function deriveActiveState(ticket, phase, ageMs) {
+// CTL-928 — classify a worker's top-level liveness from the DURABLE bg-job state
+// FIRST, transcript age second. A signal file that says `running` is NOT proof of
+// life (the 2026-06-09 evidence: 7 signals said running, the durable job states
+// said 0 working). `jobState` is the worker's bg-job state.json read (or null),
+// passed in (read at the edge) so this stays pure-ish and testable.
+//
+//   "dead"   — the bg job reached a terminal lifecycle (stopped/failed/done/
+//              blocked) OR its job dir is gone. Definitive death — a transcript
+//              touched 8 minutes ago does NOT resurrect it. EXCLUDED from
+//              in-flight / consumed capacity by the caller.
+//   "stuck"  — bg job still alive (or its liveness is unknowable) but a terminal
+//              marker file is present, or the transcript has been silent ~30m
+//              (likely zombie/abandoned, not yet reaped).
+//   "active" — alive and recently generating / legitimately event-waiting.
+//
+// `bgKnown` distinguishes "we positively read a bg-job state" (then a dead verdict
+// is trustworthy) from "no bg_job_id resolvable" (legacy/just-dispatched worker —
+// fall back to transcript age rather than fabricate death, matching the daemon's
+// classifyWorker "unknown" handling).
+export async function deriveActiveState(ticket, phase, ageMs, jobState, bgKnown) {
+  // Durable death wins over everything — but only when we actually read a bg-job
+  // state (bgKnown). Without a resolvable bg_job_id we cannot prove death, so we
+  // do NOT mark a live `claude agents` worker dead on a missing id alone.
+  if (bgKnown && isBgJobDead(jobState)) return "dead";
   const dir = join(WORKERS_DIR, ticket);
   if ((await exists(join(dir, ".terminal-done.applied"))) || (await exists(join(dir, ".worktree-removed")))) return "stuck";
   // monitor-merge / monitor-deploy / pr legitimately sit in long event-waits
@@ -224,6 +338,55 @@ async function deriveActiveState(ticket, phase, ageMs) {
   const waitHeavy = phase === "monitor-merge" || phase === "monitor-deploy" || phase === "pr";
   if (!waitHeavy && ageMs != null && ageMs > STUCK_MS) return "stuck";
   return "active";
+}
+
+// isWorkerDead — CTL-928 single predicate the in-flight/capacity buckets use to
+// decide whether a live `claude agents` worker is actually a corpse. True iff its
+// derived activeState is "dead". A dead worker is excluded from ticketIds,
+// inFlight, freeSlots, and the "active" config count.
+export function isWorkerDead(worker) {
+  return worker?.activeState === "dead";
+}
+
+// deriveCapacity — CTL-928 PURE capacity summary over the assembled worker set,
+// so the freeSlots/inFlight fix is unit-testable without shelling out. Dead
+// bg-workers are EXCLUDED from inFlight and freeSlots (they no longer hold a
+// maxParallel slot) and surfaced as their own `dead` count. `workers` is the
+// full BoardWorker[] (live + dead); `maxParallel` the configured ceiling.
+export function deriveCapacity(workers, maxParallel) {
+  const all = Array.isArray(workers) ? workers : [];
+  const live = all.filter((w) => !isWorkerDead(w));
+  return {
+    maxParallel,
+    inFlight: live.length,
+    freeSlots: Math.max(0, maxParallel - live.length),
+    active: live.filter((w) => w.activeState === "active").length,
+    working: live.filter((w) => w.working).length,
+    stuck: live.filter((w) => w.activeState === "stuck").length,
+    dead: all.filter((w) => isWorkerDead(w)).length,
+  };
+}
+
+// laneFor — CTL-928 single source of truth for which board lane a non-queued
+// ticket belongs to, so every non-terminal ticket lands in EXACTLY one lane and
+// none is silently dropped. PURE + exported for unit tests.
+//   "live"           — a live (non-dead) worker is attached. workerStatus is set
+//                      AND its activeState is not "dead".
+//   "recent-done"    — no live worker AND the ticket's current phase is the
+//                      synthetic pipeline-done phase (monitor-deploy/teardown
+//                      terminal, per deriveCurrentPhase). Genuinely finished.
+//   "between-phases" — no live worker AND a terminal INTERMEDIATE phase (triage/
+//                      research/plan/verify/review… done, or a dead worker whose
+//                      phase never reached pipeline-done). Idle, awaiting its next
+//                      dispatch — visible, not dropped (the invisible-ticket bug).
+// A ticket with a non-terminal status and no live worker (a dead-but-running
+// signal) also lands in between-phases — it is in-flight-on-paper but idle in
+// reality, and must be surfaced rather than vanish.
+export function laneFor(ticket) {
+  const hasLiveWorker = ticket.workerStatus !== null && ticket.activeState !== "dead";
+  if (hasLiveWorker) return "live";
+  if (ticket.phase === PIPELINE_DONE_PHASE) return "recent-done";
+  return "between-phases";
 }
 
 // ── derive a ticket's current phase + status from its signal files ──────────
@@ -613,8 +776,16 @@ export async function assembleBoard() {
     // null (not 0) when there is no metrics row — distinguishes "no data" from "free".
     const cost = costs[p.ticket]?.costUSD ?? null;
     const lastActiveMs = await transcriptAgeMs(a.sessionId, now);
-    const activeState = await deriveActiveState(p.ticket, p.phase, lastActiveMs);
-    const working = lastActiveMs != null && lastActiveMs < WORKING_MS; // detail-level only
+    // CTL-928: resolve the worker's DURABLE bg-job state before classifying. The
+    // bg_job_id lives on the phase signal; the state lives under ~/.claude/jobs.
+    // A null bgJobId means we cannot prove death (bgKnown=false) → fall back to
+    // transcript age rather than fabricate a dead verdict.
+    const bgJobId = await workerBgJobId(p.ticket, p.phase);
+    const jobState = bgJobId ? await readBgJobState(bgJobId) : null;
+    const bgKnown = bgJobId != null;
+    const activeState = await deriveActiveState(p.ticket, p.phase, lastActiveMs, jobState, bgKnown);
+    // A dead bg-job is not "working" however fresh its transcript looks.
+    const working = activeState !== "dead" && lastActiveMs != null && lastActiveMs < WORKING_MS; // detail-level only
     // CTL-922 (BFF10): node attribution. host:{name,id} from the worker's own
     // phase signal (CTL-852, dispatch-stamped) falling back to the durable fence
     // projection owner_host (BFF11); generation from the fence projection first,
@@ -638,22 +809,38 @@ export async function assembleBoard() {
       // sessionId — surfaces both id spaces (Loki catalyst.session heartbeat
       // joins on this one). null when the db has no row for this CC-UUID.
       catalystSessionId: catalystSessByUuid[a.sessionId] ?? null,
+      // CTL-928: the durable bg-job id this worker's liveness was derived from
+      // (from the phase signal). null when no signal carried one — surfaced so the
+      // worker rail and the dead-worker capacity logic share one provenance.
+      bgJobId,
       // CTL-922 (BFF10): owning host + fence generation (see above).
       host: deriveHost(workerSigs, fence),
       generation: deriveGeneration(workerSigs, fence),
     };
   }));
-  const inFlightTickets = new Map(workers.map((w) =>
+  // CTL-928: a worker whose durable bg job is dead is NOT in flight. Partition
+  // the `claude agents` workers into the live set (real consumed capacity) and the
+  // dead set (corpses still listed by `claude agents` / lingering job dirs). Only
+  // the live set feeds inFlight, freeSlots, ticketIds, and the "active" count.
+  const liveWorkers = workers.filter((w) => !isWorkerDead(w));
+  const inFlightTickets = new Map(liveWorkers.map((w) =>
     [w.ticket, { phase: w.phase, status: w.status, activeState: w.activeState, working: w.working, lastActiveMs: w.lastActiveMs }]));
 
-  // tickets = in-flight (have a worker dir / live agent) ∪ eligible(queued)
+  // tickets = in-flight (have a LIVE worker dir / live agent) ∪ eligible(queued).
+  // CTL-928: a workers/<T>/ dir whose latest signal is a terminal INTERMEDIATE
+  // phase with NO live worker is between-phases — it still gets a card (read via
+  // its dir below), but it must NOT count toward in-flight capacity, so we exclude
+  // dead-bg worker TICKETS from the in-flight `ticketIds` (used only for the
+  // queue's notInFlight exclusion). Worker dirs remain a card source via tickets.
   let workerDirs = [];
   if (await exists(WORKERS_DIR)) {
     try { workerDirs = (await readdir(WORKERS_DIR)).filter((d) => /^[A-Z]+-\d+$/.test(d)); } catch { /* none */ }
   }
-  const ticketIds = new Set([...workers.map((w) => w.ticket), ...workerDirs]);
+  // Every card we render (live workers, dead-worker dirs, plain worker dirs) — the
+  // union of card sources, so a between-phases ticket still gets a BoardTicket.
+  const cardTicketIds = new Set([...workers.map((w) => w.ticket), ...workerDirs]);
 
-  let tickets = await Promise.all([...ticketIds].map(async (id) => {
+  let tickets = await Promise.all([...cardTicketIds].map(async (id) => {
     const { phaseSigs, triage, prSigs } = await readTicketArtifacts(id);
     const cur = deriveCurrentPhase(phaseSigs);
     const phaseSummary = buildPhaseSummary(phaseSigs, now);
@@ -709,24 +896,32 @@ export async function assembleBoard() {
     };
   }));
 
-  // Keep the board legible: live workers + recently-touched moving tickets +
-  // a recent-done tail. A "moving" signal that's actually stale (dead worker,
-  // old non-terminal signal) is bounded by recency so a fat workers dir can't
-  // render hundreds of cards.
+  // CTL-928 lane assembly — every non-queued ticket lands in EXACTLY one lane via
+  // laneFor (the single source of truth), so a dead-but-running ticket is never
+  // silently dropped and a terminal-intermediate ticket is never mis-bucketed into
+  // recent-done. A "between-phases" bucket (the old `moving`) is bounded by recency
+  // so a fat workers dir can't render hundreds of cards.
+  //   live           — a LIVE worker is attached (dead workers fell out of
+  //                    inFlightTickets above, so their tickets are NOT live here).
+  //   between-phases — terminal-intermediate / dead-but-running, no live worker:
+  //                    idle awaiting its next dispatch. THE FORMERLY-INVISIBLE lane.
+  //   recent-done    — genuinely pipeline-done (phase === "done"), a short tail.
   const byRecent = (a, b) => String(b.updatedAt).localeCompare(String(a.updatedAt));
-  const liveTickets = tickets.filter((t) => t.workerStatus !== null);
-  const moving = tickets
-    .filter((t) => t.workerStatus === null && t.status !== "done")
+  const liveTickets = tickets.filter((t) => laneFor(t) === "live");
+  const betweenPhases = tickets
+    .filter((t) => laneFor(t) === "between-phases")
     .sort(byRecent)
     .slice(0, 30);
   const recentDone = tickets
-    .filter((t) => t.workerStatus === null && t.status === "done")
+    .filter((t) => laneFor(t) === "recent-done")
     .sort(byRecent)
     .slice(0, 12);
-  // eligible queue tickets → thin Todo-column board cards (CTL-767)
-  const notInFlight = eligible.filter((e) => !ticketIds.has(e.id));
+  // eligible queue tickets → thin Todo-column board cards (CTL-767). A ticket with
+  // ANY worker dir is already surfaced as live / between-phases above, so it is
+  // excluded here (cardTicketIds) — it is accounted for, not duplicated.
+  const notInFlight = eligible.filter((e) => !cardTicketIds.has(e.id));
   const queuedTickets = notInFlight.map((e) => synthesizeQueuedTicket(e, linfo));
-  tickets = [...liveTickets, ...moving, ...recentDone, ...queuedTickets];
+  tickets = [...liveTickets, ...betweenPhases, ...recentDone, ...queuedTickets];
 
   // priority queue: eligible (not yet in-flight), globally ranked (Queue tab)
   const queue = await Promise.all(notInFlight
@@ -752,12 +947,12 @@ export async function assembleBoard() {
 
   return {
     generatedAt: new Date().toISOString(),
-    config: {
-      maxParallel: mp, inFlight: workers.length, freeSlots: Math.max(0, mp - workers.length),
-      active: workers.filter((w) => w.activeState === "active").length,
-      working: workers.filter((w) => w.working).length,
-      stuck: workers.filter((w) => w.activeState === "stuck").length,
-    },
+    // CTL-928: capacity reflects LIVE workers only. A dead bg-job no longer holds a
+    // maxParallel slot, so inFlight + freeSlots tell the true dispatch picture (e.g.
+    // 6 listed, 3 dead → inFlight 3, freeSlots 3). `dead` is surfaced as its own
+    // count so the operator sees the corpses without them consuming capacity. The
+    // computation lives in the PURE deriveCapacity (unit-tested) — DRY.
+    config: deriveCapacity(workers, mp),
     repos,
     workers: workers.sort((a, b) => (a.runtimeMs ?? 0) - (b.runtimeMs ?? 0)),
     tickets,

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
@@ -11,7 +11,11 @@
 import type { ConnectionStatus } from "@/lib/types";
 import type { ReadModelPayload } from "../../../lib/read-model-client";
 
-export type BoardActiveState = "active" | "stuck" | null;
+// CTL-928: "dead" — a worker whose durable bg-job state.json is terminal
+// (stopped/failed/done/blocked) or whose job dir is gone, even when a phase signal
+// still says `running`. Excluded from in-flight + consumed capacity by the server;
+// the board renders it as a distinct dead/zombie state, not "active".
+export type BoardActiveState = "active" | "stuck" | "dead" | null;
 
 /** CTL-922 (BFF10): a node's stable identity stamped on every board entity so the
  *  node-aware surfaces (BOARD3 host swimlanes, SURF1 worker node group, SURF2
@@ -53,6 +57,9 @@ export interface BoardWorker {
   /** CTL-922 (BFF10): the fence generation (BFF8 stop passes it to the
    *  fence-check). null when no fence. */
   generation?: number | null;
+  /** CTL-928: the durable `claude --bg` job id this worker's liveness was derived
+   *  from. null/absent when no signal carried one. */
+  bgJobId?: string | null;
 }
 
 export interface BoardPhaseCost {
@@ -182,6 +189,9 @@ export interface BoardConfig {
   active: number;
   working: number;
   stuck: number;
+  /** CTL-928: dead bg-job workers still listed by `claude agents` but excluded
+   *  from inFlight/freeSlots. Optional so existing config fixtures stay valid. */
+  dead?: number;
 }
 
 export interface BoardPayload {


### PR DESCRIPTION
## CTL-928 — the queue board should truthfully account for every in-flight ticket

The `:7400` queue board derived worker liveness from the phase signal alone, so a worker whose `claude --bg` job had `stopped`/`failed`/`done` still rendered `active`, held a `maxParallel` slot, and tickets idle between phases vanished. On 2026-06-09 the board read "Waiting in queue (0)" while 12 tickets sat in Todo, and 3 of the 5 "in flight" workers were actually dead.

**Root principle (per ticket):** a signal-file status of `running` is **not** proof the worker is alive — four sources disagreed on liveness at the same instant. Liveness is now derived from the **durable** `claude --bg` job state (`~/.claude/jobs/<bg_job_id>/state.json`), mirroring the daemon's `recovery.mjs::jobLifecycle` (`TERMINAL_JOB_STATES = {stopped, failed, done, blocked}`; `firstTerminalAt` set ⇒ dead; `working`/unreadable-but-present ⇒ alive — mtime is NOT consulted).

**Read-model only.** The fix lives entirely in `board-data.mjs` (+ its `.d.mts` type decl, the UI's mirror `BoardActiveState`, and a new test file). It does **not** touch the execution-core daemon — the daemon-side causes of the unreliable signals are tracked separately (CTL-729 watchdog).

### Gherkin scenarios → how satisfied

| Scenario | Satisfied by | Test |
| --- | --- | --- |
| **A worker whose bg job has failed is shown as dead, not active** (failed bg state + 8-min-fresh transcript ⇒ dead, excluded from in-flight + capacity) | `deriveActiveState` now reads the worker's bg-job `state.json` (bg_job_id off the phase signal) FIRST; a terminal/gone job returns the new `"dead"` state regardless of transcript freshness. Dead workers are stripped from `inFlightTickets`, `deriveCapacity`, and the `active` count. | `deriveActiveState: failed bg-job + FRESH (<30m) transcript → 'dead'`; `readBgJobState … renders 'dead' despite a fresh transcript` (real temp jobs dir) |
| **A triaged ticket waiting for its next phase is visible as between-phases** (worker dir exists, signal `triage/done`, no live worker) | New `laneFor` classifier puts a terminal **intermediate** phase (triage/research/plan/verify/review done, no live worker) in the `between-phases` lane — not `recentDone`, not dropped. Honors `deriveCurrentPhase`'s distinction: only the synthetic `done` phase (monitor-deploy/teardown terminal) is pipeline-done. | `laneFor: triage/done + no live worker → 'between-phases'`; `verify/done → 'between-phases'` |
| **Free-slot count reflects live capacity, not worker-dir count** (6 in-flight, 3 dead ⇒ 3 live in-flight, 3 free) | `ticketIds` split into `cardTicketIds` (card sources) vs `liveWorkers` (capacity). `deriveCapacity` excludes dead workers from `inFlight`/`freeSlots`, surfaces them as a new `dead` count. `config` block now `deriveCapacity(workers, mp)`. | `deriveCapacity: 6 listed, 3 dead → inFlight 3, freeSlots 3, dead 3` |
| **Every non-terminal ticket is in exactly one lane** | `laneFor` is the single source of truth for `live` / `between-phases` / `recent-done`; a dead-but-`running` ticket also lands in `between-phases` rather than vanishing. | `laneFor: every ticket lands in exactly one of live \| between-phases \| recent-done` |

### Fix sites (`board-data.mjs`)
- **`deriveActiveState`** — reads durable bg-job state; returns `"dead"` for a terminal/gone job. No resolvable `bg_job_id` falls back to transcript age (matches the daemon's `classifyWorker` "unknown" path) — never fabricates death.
- **in-flight set** — `cardTicketIds` (all card sources) split from `liveWorkers` (real consumed capacity); dead-bg worker tickets excluded from in-flight.
- **lane assembly** — `laneFor` honoring terminal-intermediate vs pipeline-done.
- **`freeSlots`/`inFlight`/`active`/`stuck`/`working`** — via pure `deriveCapacity`, live workers only; new `dead` count.

### Validation
- `bunx tsc --noEmit`: byte-identical to the origin/main baseline (one pre-existing `nav-signal.test.ts` `heldSince` error — unrelated). UI `tsc`: only the pre-existing `kpi-strip.tsx` `abandoned` error remains.
- Targeted tests green: `board-liveness` (21 new, RED-first) + all board / read-model / cluster suites (175 pass, 0 fail).
- Both `bunx vite build` and `node ./node_modules/vite/bin/vite.js build` pass.
- No reward-hacking (`as any` / `@ts-ignore` / etc.).

**Deploy is monitor-only:** `ssh mini '~/.catalyst/bin/catalyst-monitor restart'` — does not touch the exec-core daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)