### PR TITLE
feat(dev): one-checkout node updates — hotpatch pulls the pluginDirs checkout, parity reports drift (CTL-940, CTL-941)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-stack-hotpatch.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-hotpatch.test.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Shell tests for the CTL-940 hotpatch rework: `catalyst-stack hotpatch`
+# updates the pluginDirs git checkout (ff-only) and never touches the
+# marketplace plugin cache. --legacy-rsync keeps the deprecated cache-rsync.
+# Run: bash plugins/dev/scripts/__tests__/catalyst-stack-hotpatch.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+STACK="${REPO_ROOT}/plugins/dev/scripts/catalyst-stack"
+REAL_PATH="$PATH"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+check() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+# ── Git fixtures: bare origin + node checkout containing plugins/dev ────────
+GITC="git -c user.email=t@t -c user.name=t -c commit.gpgsign=false -c init.defaultBranch=main"
+
+make_fixture() {
+  # make_fixture NAME → sets FIX_SEED, FIX_ORIGIN, FIX_CHECKOUT
+  local base="${SCRATCH}/fix_$1"
+  mkdir -p "${base}/seed"
+  $GITC -C "${base}/seed" init -q
+  mkdir -p "${base}/seed/plugins/dev/.claude-plugin"
+  echo '{"name":"catalyst-dev","version":"1.0.0"}' \
+    > "${base}/seed/plugins/dev/.claude-plugin/plugin.json"
+  echo "v1" > "${base}/seed/plugins/dev/marker.txt"
+  $GITC -C "${base}/seed" add -A
+  $GITC -C "${base}/seed" commit -qm "initial"
+  $GITC init -q --bare "${base}/origin.git"
+  $GITC -C "${base}/seed" remote add origin "${base}/origin.git"
+  $GITC -C "${base}/seed" push -q -u origin main
+  $GITC clone -q "${base}/origin.git" "${base}/checkout"
+  FIX_SEED="${base}/seed"
+  FIX_ORIGIN="${base}/origin.git"
+  FIX_CHECKOUT="${base}/checkout"
+}
+
+advance_origin() {
+  echo "v2" > "${FIX_SEED}/plugins/dev/marker.txt"
+  $GITC -C "${FIX_SEED}" commit -qam "update marker"
+  $GITC -C "${FIX_SEED}" push -q origin main
+}
+
+# Service stubs; rsync stub records invocations so we can assert the new
+# hotpatch path never calls it.
+STUBDIR="${SCRATCH}/stubs"
+mkdir -p "$STUBDIR"
+for svc in catalyst-broker catalyst-monitor; do
+  printf '#!/usr/bin/env bash\necho running; exit 0\n' > "$STUBDIR/$svc"
+  chmod +x "$STUBDIR/$svc"
+done
+cat > "$STUBDIR/catalyst-execution-core" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in status) echo "stopped" ;; *) echo "running" ;; esac
+exit 0
+EOF
+chmod +x "$STUBDIR/catalyst-execution-core"
+cat > "$STUBDIR/rsync" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> "${SCRATCH}/rsync.args"
+exit 0
+EOF
+chmod +x "$STUBDIR/rsync"
+
+# Fake HOME with a marketplace plugin cache that must never be touched.
+FAKE_HOME="${SCRATCH}/fake_home"
+FAKE_CACHE="${FAKE_HOME}/.claude/plugins/cache/catalyst/catalyst-dev/1.0.0"
+mkdir -p "$FAKE_CACHE"
+echo "untouched" > "${FAKE_CACHE}/sentinel.txt"
+
+# Neutral cwd outside any repo carrying .catalyst/config.json so only the
+# env/machine-config layers are in play.
+NEUTRAL="${SCRATCH}/neutral"
+mkdir -p "$NEUTRAL"
+
+# hotpatch PLUGIN_DIRS_ENV MACHINE_CFG [extra args...] — runs the subcommand
+# from the neutral cwd. Pass "" to leave a layer unset.
+hotpatch() {
+  local pdirs="$1" mcfg="$2"; shift 2
+  local env_args=(PATH="${STUBDIR}:${REAL_PATH}" HOME="$FAKE_HOME"
+                  CATALYST_MACHINE_CONFIG="${mcfg:-${SCRATCH}/absent.json}")
+  [[ -n "$pdirs" ]] && env_args+=(CATALYST_PLUGIN_DIRS="$pdirs")
+  (cd "$NEUTRAL" && env "${env_args[@]}" "$STACK" hotpatch "$@")
+}
+
+echo "catalyst-stack hotpatch (CTL-940) tests"
+
+# ── 1. clean + behind → ff-pull updates the checkout ─────────────────────────
+make_fixture pull
+advance_origin
+rm -f "${SCRATCH}/rsync.args"
+t1() {
+  hotpatch "${FIX_CHECKOUT}/plugins/dev" "" || return 1
+  [[ "$(cat "${FIX_CHECKOUT}/plugins/dev/marker.txt")" == v2 ]]
+}
+check "hotpatch ff-pulls a clean behind checkout to origin/main" t1
+check "hotpatch never invokes rsync on the new path" \
+  bash -c "[[ ! -f '${SCRATCH}/rsync.args' ]]"
+t1c() {
+  [[ "$(cat "${FAKE_CACHE}/sentinel.txt")" == untouched ]] \
+    && [[ "$(ls "$FAKE_CACHE")" == sentinel.txt ]]
+}
+check "hotpatch never touches the plugin cache" t1c
+t1d() { hotpatch "${FIX_CHECKOUT}/plugins/dev" "" 2>&1 | grep -qi "up to date"; }
+check "hotpatch is idempotent when already up to date" t1d
+
+# ── 2. dirty checkout → refuse ───────────────────────────────────────────────
+make_fixture dirty
+advance_origin
+echo "local edit" >> "${FIX_CHECKOUT}/plugins/dev/marker.txt"
+t2() {
+  local out rc
+  out="$(hotpatch "${FIX_CHECKOUT}/plugins/dev" "" 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qi dirty <<<"$out"
+}
+check "hotpatch refuses a dirty checkout with a clear message" t2
+t2b() {
+  grep -q "local edit" "${FIX_CHECKOUT}/plugins/dev/marker.txt" \
+    && ! grep -q v2 "${FIX_CHECKOUT}/plugins/dev/marker.txt"
+}
+check "refused dirty checkout is left un-pulled" t2b
+
+# ── 3. diverged checkout → refuse ────────────────────────────────────────────
+make_fixture diverged
+advance_origin
+( cd "${FIX_CHECKOUT}" \
+  && echo "local commit" > local.txt \
+  && $GITC add local.txt \
+  && $GITC commit -qm "local divergence" )
+t3() {
+  local out rc
+  out="$(hotpatch "${FIX_CHECKOUT}/plugins/dev" "" 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qiE "diverg|ahead" <<<"$out"
+}
+check "hotpatch refuses a diverged checkout" t3
+
+# ── 4. pluginDirs resolution order ───────────────────────────────────────────
+make_fixture mcfg
+advance_origin
+MACHINE_CFG="${SCRATCH}/machine-config.json"
+printf '{"catalyst":{"orchestration":{"pluginDirs":["%s"]}}}\n' \
+  "${FIX_CHECKOUT}/plugins/dev" > "$MACHINE_CFG"
+t4() {
+  hotpatch "" "$MACHINE_CFG" || return 1
+  [[ "$(cat "${FIX_CHECKOUT}/plugins/dev/marker.txt")" == v2 ]]
+}
+check "hotpatch resolves the checkout from machine-config pluginDirs" t4
+
+make_fixture envwins
+advance_origin
+t5() {
+  # machine config still points at the (already-updated) mcfg fixture;
+  # env points at the envwins fixture — the env one must get pulled.
+  hotpatch "${FIX_CHECKOUT}/plugins/dev" "$MACHINE_CFG" || return 1
+  [[ "$(cat "${FIX_CHECKOUT}/plugins/dev/marker.txt")" == v2 ]]
+}
+check "env CATALYST_PLUGIN_DIRS wins over machine config" t5
+
+make_fixture repocfg
+advance_origin
+REPO_CWD="${SCRATCH}/repocfg_cwd"
+mkdir -p "${REPO_CWD}/.catalyst"
+printf '{"catalyst":{"orchestration":{"pluginDirs":["%s"]}}}\n' \
+  "${FIX_CHECKOUT}/plugins/dev" > "${REPO_CWD}/.catalyst/config.json"
+t6() {
+  (cd "$REPO_CWD" && \
+    env PATH="${STUBDIR}:${REAL_PATH}" HOME="$FAKE_HOME" \
+        CATALYST_MACHINE_CONFIG="$MACHINE_CFG" \
+        "$STACK" hotpatch) || return 1
+  [[ "$(cat "${FIX_CHECKOUT}/plugins/dev/marker.txt")" == v2 ]]
+}
+check "repo .catalyst/config.json pluginDirs wins over machine config" t6
+
+# ── 5. no pluginDirs anywhere → refuse with config guidance ──────────────────
+t7() {
+  local out rc
+  out="$(hotpatch "" "" 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -q "pluginDirs" <<<"$out"
+}
+check "hotpatch without pluginDirs fails naming pluginDirs config" t7
+
+# ── 6. --legacy-rsync keeps the deprecated cache-rsync path ──────────────────
+make_fixture legacy
+rm -f "${SCRATCH}/rsync.args"
+t8() {
+  local out
+  out="$( (cd "$NEUTRAL" && \
+    env PATH="${STUBDIR}:${REAL_PATH}" HOME="$FAKE_HOME" \
+        CATALYST_REPO_DIR="${FIX_CHECKOUT}" \
+        "$STACK" hotpatch --legacy-rsync 2>&1) )" || return 1
+  grep -q -- "-ac" "${SCRATCH}/rsync.args" && grep -qi deprecat <<<"$out"
+}
+check "--legacy-rsync still rsyncs into the cache and warns deprecated" t8
+check "legacy rsync still never uses --delete" \
+  bash -c "! grep -q -- '--delete' '${SCRATCH}/rsync.args'"
+
+# ── 7. static guard: only the legacy path references the plugin cache ────────
+t9() {
+  local count legacy_count
+  count=$(grep -c "plugins/cache" "$STACK")
+  legacy_count=$(awk '/BEGIN LEGACY RSYNC/,/END LEGACY RSYNC/' "$STACK" \
+    | grep -c "plugins/cache")
+  [[ "$count" -gt 0 && "$count" -le "$legacy_count" ]]
+}
+check "new hotpatch path has no plugin-cache reference outside legacy block" t9
+
+echo ""
+TOTAL=$((PASSES + FAILURES))
+echo "catalyst-stack-hotpatch: $PASSES/$TOTAL passed, $FAILURES failed"
+exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/catalyst-stack-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-parity.test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Shell tests for `catalyst-stack parity` (CTL-941): freshness + drift report
+# for the per-host plugin checkout. Nonzero exit on drift.
+# Run: bash plugins/dev/scripts/__tests__/catalyst-stack-parity.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+STACK="${REPO_ROOT}/plugins/dev/scripts/catalyst-stack"
+REAL_PATH="$PATH"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+check() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+GITC="git -c user.email=t@t -c user.name=t -c commit.gpgsign=false -c init.defaultBranch=main"
+
+make_fixture() {
+  local base="${SCRATCH}/fix_$1"
+  mkdir -p "${base}/seed"
+  $GITC -C "${base}/seed" init -q
+  mkdir -p "${base}/seed/plugins/dev/.claude-plugin"
+  echo '{"name":"catalyst-dev","version":"1.0.0"}' \
+    > "${base}/seed/plugins/dev/.claude-plugin/plugin.json"
+  echo "v1" > "${base}/seed/plugins/dev/marker.txt"
+  $GITC -C "${base}/seed" add -A
+  $GITC -C "${base}/seed" commit -qm "initial"
+  $GITC init -q --bare "${base}/origin.git"
+  $GITC -C "${base}/seed" remote add origin "${base}/origin.git"
+  $GITC -C "${base}/seed" push -q -u origin main
+  $GITC clone -q "${base}/origin.git" "${base}/checkout"
+  FIX_SEED="${base}/seed"
+  FIX_CHECKOUT="${base}/checkout"
+}
+
+advance_origin() {
+  echo "v2" > "${FIX_SEED}/plugins/dev/marker.txt"
+  $GITC -C "${FIX_SEED}" commit -qam "update marker"
+  $GITC -C "${FIX_SEED}" push -q origin main
+}
+
+NEUTRAL="${SCRATCH}/neutral"
+mkdir -p "$NEUTRAL"
+MACHINE_CFG_ABSENT="${SCRATCH}/absent.json"
+
+# parity PLUGIN_DIRS_ENV MACHINE_CFG → runs the subcommand from neutral cwd
+parity() {
+  local pdirs="$1" mcfg="$2"; shift 2
+  local env_args=(PATH="$REAL_PATH"
+                  CATALYST_MACHINE_CONFIG="${mcfg:-$MACHINE_CFG_ABSENT}")
+  [[ -n "$pdirs" ]] && env_args+=(CATALYST_PLUGIN_DIRS="$pdirs")
+  (cd "$NEUTRAL" && env "${env_args[@]}" "$STACK" parity "$@")
+}
+
+echo "catalyst-stack parity (CTL-941) tests"
+
+# ── 1. clean, current checkout via machine config → exit 0 ──────────────────
+make_fixture clean
+MACHINE_CFG="${SCRATCH}/machine-config.json"
+printf '{"catalyst":{"orchestration":{"pluginDirs":["%s"]}}}\n' \
+  "${FIX_CHECKOUT}/plugins/dev" > "$MACHINE_CFG"
+t1() {
+  local out rc
+  out="$(parity "" "$MACHINE_CFG" 2>&1)"; rc=$?
+  [[ $rc -eq 0 ]] && grep -qi "machine-config" <<<"$out"
+}
+check "clean current checkout (machine config) exits 0" t1
+
+# ── 2. behind origin/main → drift, reports behind count ─────────────────────
+make_fixture behind
+advance_origin
+t2() {
+  local out rc
+  out="$(parity "${FIX_CHECKOUT}/plugins/dev" "" 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qi "behind origin/main by 1" <<<"$out"
+}
+check "behind checkout exits nonzero and reports behind-by count" t2
+
+# ── 3. dirty checkout → drift, reports dirty files ──────────────────────────
+make_fixture dirtyp
+echo "edit" >> "${FIX_CHECKOUT}/plugins/dev/marker.txt"
+t3() {
+  local out rc
+  out="$(parity "${FIX_CHECKOUT}/plugins/dev" "" 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qi "dirty" <<<"$out" && grep -q "marker.txt" <<<"$out"
+}
+check "dirty checkout exits nonzero and names the dirty file" t3
+
+# ── 4. SSH remote → drift (unauthable from daemon contexts) ─────────────────
+make_fixture sshp
+$GITC -C "${FIX_CHECKOUT}" remote set-url origin git@github.com:fake/fake.git
+t4() {
+  local out rc
+  out="$(parity "${FIX_CHECKOUT}/plugins/dev" "" 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qiE "ssh" <<<"$out"
+}
+check "ssh remote is flagged as drift" t4
+
+# ── 5. pluginDirs unset everywhere → drift naming the config ────────────────
+t5() {
+  local out rc
+  out="$(parity "" "" 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -q "pluginDirs" <<<"$out"
+}
+check "missing pluginDirs config exits nonzero naming pluginDirs" t5
+
+# ── 6. broken plugin manifest → drift ────────────────────────────────────────
+make_fixture badmanifest
+echo "{not json" > "${FIX_CHECKOUT}/plugins/dev/.claude-plugin/plugin.json"
+$GITC -C "${FIX_CHECKOUT}" commit -qam "break manifest" 2>/dev/null || true
+t6() {
+  local out rc
+  out="$(parity "${FIX_CHECKOUT}/plugins/dev" "" 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qi "manifest" <<<"$out"
+}
+check "unparseable plugin manifest exits nonzero" t6
+
+# ── 7. env-resolved pluginDirs reports machine config as unset ──────────────
+make_fixture envsrc
+t7() {
+  local out
+  out="$(parity "${FIX_CHECKOUT}/plugins/dev" "" 2>&1)" || true
+  grep -qi "machine config" <<<"$out"
+}
+check "parity reports whether pluginDirs is set in machine config" t7
+
+echo ""
+TOTAL=$((PASSES + FAILURES))
+echo "catalyst-stack-parity: $PASSES/$TOTAL passed, $FAILURES failed"
+exit "$FAILURES"

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -14,6 +14,8 @@
 #   catalyst-stack stop
 #   catalyst-stack restart [--proxy] [--hotpatch] [--yes]
 #   catalyst-stack status
+#   catalyst-stack hotpatch [--legacy-rsync]
+#   catalyst-stack parity
 #
 # --proxy:
 #   Opt-in to mitmproxy and set HTTPS_PROXY / NODE_USE_ENV_PROXY /
@@ -24,10 +26,19 @@
 # --no-proxy:
 #   Accepted for backward compatibility; a no-op (proxy is already off by default).
 #
-# --hotpatch (start/restart only):
-#   ff-pull main, rsync plugins/dev/ into the resolved plugin-cache version dir,
-#   then start/restart. Use 'restart --hotpatch' after merging main to apply
-#   updates without a full reinstall.
+# hotpatch / --hotpatch (CTL-940):
+#   ff-only pull of the per-host plugin checkout(s) resolved from pluginDirs
+#   (lib/plugin-dirs.sh: env > repo config > machine config). Refuses dirty or
+#   diverged checkouts. Emits a node.checkout.updated event recording old/new
+#   commits. The deprecated marketplace-cache rsync survives only behind
+#   'catalyst-stack hotpatch --legacy-rsync'. 'start/restart --hotpatch' runs
+#   the checkout pull first, then starts/restarts.
+#
+# parity (CTL-941):
+#   Node freshness + setup-drift report for the per-host plugin checkout:
+#   pluginDirs configured, paths exist and are git checkouts, plugin manifest
+#   parses, working tree clean, remote daemon-fetchable (no ssh), checkout at
+#   origin/main. Exit code = number of drift findings (0 = clean).
 #
 # --yes:
 #   Non-interactive — auto-approve brew install of mitmproxy under --proxy.
@@ -71,6 +82,11 @@ pid_alive() {
   local pid="${1:-}"
   [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
 }
+
+# Single source of truth for resolving the per-host plugin checkout (CTL-940).
+# shellcheck source=lib/plugin-dirs.sh
+[[ -f "${SCRIPT_DIR}/lib/plugin-dirs.sh" ]] || fail "missing lib/plugin-dirs.sh next to catalyst-stack"
+. "${SCRIPT_DIR}/lib/plugin-dirs.sh"
 
 mitm_pid() { pgrep -f "mitmdump -s.*mitm_linear_addon" 2>/dev/null | head -1; }
 
@@ -167,22 +183,201 @@ start_daemon() {
 
 stop_daemon() { catalyst-execution-core stop 2>&1 | sed 's/^/  /'; }
 
-# ─── Hotpatch ────────────────────────────────────────────────────────────────
+# ─── Hotpatch (CTL-940: one-checkout nodes) ─────────────────────────────────
+# The daemon, script wrappers, and dispatched workers all run from the
+# pluginDirs checkout, so updating a node is a single ff-only pull of that
+# checkout. The marketplace plugin cache is never written on this path.
+
+# _emit_checkout_updated CHECKOUT OLD_SHA NEW_SHA — best-effort telemetry
+# (CTL-941: the update is logged + evented with old and new commits).
+# Never fails the hotpatch.
+_emit_checkout_updated() {
+  local checkout="$1" old="$2" new="$3"
+  (
+    set +e
+    # shellcheck source=lib/canonical-event.sh
+    source "${SCRIPT_DIR}/lib/canonical-event.sh" 2>/dev/null || exit 0
+    command -v jq >/dev/null 2>&1 || exit 0
+    local events_dir="${CATALYST_DIR:-$HOME/catalyst}/events"
+    mkdir -p "$events_dir" 2>/dev/null || exit 0
+    build_canonical_line \
+      --ts "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+      --severity INFO \
+      --service catalyst.stack \
+      --event-name node.checkout.updated \
+      --entity checkout --action updated \
+      --label "$checkout" \
+      --message "plugin checkout updated ${old:0:8} → ${new:0:8}" \
+      --payload-json "$(jq -nc --arg c "$checkout" --arg o "$old" --arg n "$new" \
+        '{checkout:$c, old_commit:$o, new_commit:$n}')" \
+      >> "${events_dir}/$(date -u +%Y-%m).jsonl"
+  ) || true
+}
+
+# _hotpatch_checkout CHECKOUT_ROOT — ff-only update of one checkout.
+_hotpatch_checkout() {
+  local root="$1"
+  if [[ -n "$(git -C "$root" status --porcelain 2>/dev/null)" ]]; then
+    fail "checkout is dirty — refusing to pull: $root (commit/stash local changes, then retry)"
+  fi
+  GIT_TERMINAL_PROMPT=0 git -C "$root" fetch -q origin main \
+    || fail "git fetch origin main failed in $root"
+  local ahead behind
+  ahead="$(git -C "$root" rev-list --count origin/main..HEAD 2>/dev/null || echo 0)"
+  behind="$(git -C "$root" rev-list --count HEAD..origin/main 2>/dev/null || echo 0)"
+  if [[ "$ahead" -gt 0 ]]; then
+    fail "checkout has diverged — $ahead local commit(s) ahead of origin/main in $root; refusing ff-only pull"
+  fi
+  if [[ "$behind" -eq 0 ]]; then
+    log "hotpatch: $root already up to date ($(git -C "$root" rev-parse --short HEAD))"
+    return 0
+  fi
+  local old new
+  old="$(git -C "$root" rev-parse HEAD)"
+  git -C "$root" pull --ff-only -q origin main \
+    || fail "git pull --ff-only failed in $root — resolve manually then retry"
+  new="$(git -C "$root" rev-parse HEAD)"
+  log "hotpatch: $root updated ${old:0:8} → ${new:0:8} (was behind by $behind)"
+  _emit_checkout_updated "$root" "$old" "$new"
+}
+
+cmd_hotpatch() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --legacy-rsync) cmd_hotpatch_legacy; return $? ;;
+      *) fail "unknown hotpatch arg: $arg (try: --legacy-rsync)" ;;
+    esac
+  done
+
+  resolve_plugin_dirs
+  if [[ -z "$RESOLVED_PLUGIN_DIRS" ]]; then
+    fail "no pluginDirs configured — set .catalyst.orchestration.pluginDirs in a repo .catalyst/config.json or $(plugin_dirs_machine_config_path) (or export CATALYST_PLUGIN_DIRS)"
+  fi
+  log "hotpatch: pluginDirs (${RESOLVED_PLUGIN_DIRS_SOURCE}): ${RESOLVED_PLUGIN_DIRS}"
+
+  local seen=" " pd root
+  IFS=':' read -r -a _HOTPATCH_PDS <<<"$RESOLVED_PLUGIN_DIRS"
+  for pd in "${_HOTPATCH_PDS[@]}"; do
+    [[ -z "$pd" ]] && continue
+    root="$(plugin_checkout_root "$pd")"
+    [[ -n "$root" ]] || fail "pluginDirs entry is not inside a git checkout: $pd"
+    case "$seen" in *" $root "*) continue ;; esac
+    seen="${seen}${root} "
+    _hotpatch_checkout "$root"
+  done
+}
+
+# BEGIN LEGACY RSYNC (deprecated — delete once every node is one-checkout)
 _resolve_cache_dir() {
   local cache="${HOME}/.claude/plugins/cache/catalyst/catalyst-dev"
   ls -d "${cache}"/[0-9]*.*.*/ 2>/dev/null | sort -V | tail -1 | sed 's|/$||'
 }
 
-cmd_hotpatch() {
+cmd_hotpatch_legacy() {
+  warn "hotpatch --legacy-rsync is DEPRECATED: it rsyncs into the marketplace plugin cache instead of updating the pluginDirs checkout. Migrate this node to one-checkout (CTL-940) and drop the flag."
   local repo="${CATALYST_REPO_DIR:-${HOME}/code-repos/github/coalesce-labs/catalyst}"
   [[ -d "$repo/.git" ]] || fail "catalyst repo not found at $repo (set CATALYST_REPO_DIR)"
-  log "hotpatch: ff-pull main in $repo"
+  log "hotpatch(legacy): ff-pull main in $repo"
   git -C "$repo" pull --ff-only origin main || fail "git pull --ff-only failed — resolve manually then retry"
   local dest; dest="$(_resolve_cache_dir)"
   [[ -n "$dest" ]] || fail "could not resolve plugin cache version dir under ${HOME}/.claude/plugins/cache/catalyst/catalyst-dev"
-  log "hotpatch: rsync plugins/dev/ → ${dest}/"
+  log "hotpatch(legacy): rsync plugins/dev/ → ${dest}/"
   rsync -ac --exclude=node_modules --exclude=.orphaned_at \
     "$repo/plugins/dev/" "${dest}/"
+}
+# END LEGACY RSYNC
+
+# ─── Parity (CTL-941: node freshness + setup drift) ─────────────────────────
+PARITY_DRIFT=0
+drift() { printf '[catalyst-stack] DRIFT: %s\n' "$*"; PARITY_DRIFT=$((PARITY_DRIFT+1)); }
+
+# _parity_check_dir PLUGIN_DIR — run all drift checks for one pluginDirs entry.
+_parity_check_dir() {
+  local pd="$1"
+  if [[ ! -d "$pd" ]]; then
+    drift "pluginDirs entry does not exist: $pd (referenced via ${RESOLVED_PLUGIN_DIRS_SOURCE})"
+    return
+  fi
+  local root
+  root="$(plugin_checkout_root "$pd")"
+  if [[ -z "$root" ]]; then
+    drift "pluginDirs entry is not inside a git checkout: $pd"
+    return
+  fi
+  log "parity: checking $pd (checkout: $root)"
+
+  # Manifest must parse — a gutted/corrupt plugin dir wedges workers.
+  local manifest="${pd}/.claude-plugin/plugin.json"
+  if [[ ! -f "$manifest" ]]; then
+    drift "plugin manifest missing: $manifest"
+  elif command -v jq >/dev/null 2>&1 && ! jq -e . "$manifest" >/dev/null 2>&1; then
+    drift "plugin manifest unparseable: $manifest"
+  fi
+
+  # Working tree must be clean (a dirty checkout blocks the ff-only auto-pull).
+  local dirty
+  dirty="$(git -C "$root" status --porcelain 2>/dev/null)"
+  if [[ -n "$dirty" ]]; then
+    drift "dirty working tree in $root:"
+    printf '%s\n' "$dirty" | sed 's/^/    /'
+  fi
+
+  # Remote must be fetchable from daemon contexts (no ssh-agent there).
+  local url
+  url="$(git -C "$root" remote get-url origin 2>/dev/null || true)"
+  if [[ -z "$url" ]]; then
+    drift "no origin remote in $root — freshness cannot be checked"
+    return
+  fi
+  case "$url" in
+    git@*|ssh://*)
+      drift "origin remote uses ssh ($url) — unauthable from daemon contexts; switch to https"
+      return
+      ;;
+  esac
+
+  # Freshness vs origin/main.
+  if ! GIT_TERMINAL_PROMPT=0 git -C "$root" fetch -q origin main 2>/dev/null; then
+    drift "git fetch origin main failed in $root"
+    return
+  fi
+  local ahead behind
+  ahead="$(git -C "$root" rev-list --count origin/main..HEAD 2>/dev/null || echo 0)"
+  behind="$(git -C "$root" rev-list --count HEAD..origin/main 2>/dev/null || echo 0)"
+  [[ "$behind" -gt 0 ]] && drift "checkout is behind origin/main by $behind commit(s) in $root — run 'catalyst-stack hotpatch'"
+  [[ "$ahead" -gt 0 ]] && drift "checkout is ahead of origin/main by $ahead local commit(s) in $root"
+  if [[ "$behind" -eq 0 && "$ahead" -eq 0 ]]; then
+    log "parity: $root at origin/main ($(git -C "$root" rev-parse --short HEAD))"
+  fi
+}
+
+cmd_parity() {
+  local mcfg; mcfg="$(plugin_dirs_machine_config_path)"
+  resolve_plugin_dirs
+  log "parity: pluginDirs source: ${RESOLVED_PLUGIN_DIRS_SOURCE}"
+  local mset="unset"
+  [[ -n "$(__plugin_dirs_from_file "$mcfg")" ]] && mset="set"
+  log "parity: machine config (${mcfg}): pluginDirs ${mset}"
+
+  if [[ -z "$RESOLVED_PLUGIN_DIRS" ]]; then
+    drift "pluginDirs not configured anywhere — set .catalyst.orchestration.pluginDirs in a repo .catalyst/config.json or ${mcfg} (or export CATALYST_PLUGIN_DIRS)"
+    exit 1
+  fi
+
+  local pd
+  IFS=':' read -r -a _PARITY_PDS <<<"$RESOLVED_PLUGIN_DIRS"
+  for pd in "${_PARITY_PDS[@]}"; do
+    [[ -z "$pd" ]] && continue
+    _parity_check_dir "$pd"
+  done
+
+  if [[ "$PARITY_DRIFT" -eq 0 ]]; then
+    log "parity: OK — no drift"
+  else
+    log "parity: $PARITY_DRIFT drift finding(s)"
+  fi
+  exit "$PARITY_DRIFT"
 }
 
 # ─── Top-level commands ─────────────────────────────────────────────────────
@@ -251,12 +446,14 @@ cmd_status() {
 
 # ─── Dispatch ───────────────────────────────────────────────────────────────
 case "${1:-}" in
-  start)   shift; cmd_start "$@" ;;
-  stop)    cmd_stop ;;
-  restart) shift; cmd_restart "$@" ;;
+  start)    shift; cmd_start "$@" ;;
+  stop)     cmd_stop ;;
+  restart)  shift; cmd_restart "$@" ;;
+  hotpatch) shift; cmd_hotpatch "$@" ;;
+  parity)   shift; cmd_parity "$@" ;;
   status|"") cmd_status ;;
   -h|--help)
     sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
     ;;
-  *) fail "unknown command: $1 (try: start | stop | restart | status)" ;;
+  *) fail "unknown command: $1 (try: start | stop | restart | status | hotpatch | parity)" ;;
 esac

--- a/plugins/dev/scripts/lib/plugin-dirs.sh
+++ b/plugins/dev/scripts/lib/plugin-dirs.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# lib/plugin-dirs.sh — single source of truth for resolving the per-host
+# plugin checkout (CTL-940).
+#
+# Mirrors the resolution order phase-agent-dispatch uses when it builds
+# `--plugin-dir` flags for worker sessions (PR #1614):
+#
+#   1. CATALYST_PLUGIN_DIRS env (colon-separated)
+#   2. repo .catalyst/config.json  → .catalyst.orchestration.pluginDirs
+#   3. machine config ${CATALYST_MACHINE_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/catalyst/config.json}
+#      → .catalyst.orchestration.pluginDirs
+#
+# pluginDirs may be a string or an array in either config file; arrays are
+# joined with ":". Consumers that update the checkout (catalyst-stack
+# --hotpatch, node-freshness.sh) MUST resolve through this lib so the dir
+# they update is exactly the dir the dispatcher hands to workers.
+#
+# Idempotent-source guard — safe to source multiple times.
+[[ -n "${_CATALYST_PLUGIN_DIRS_SH_LOADED:-}" ]] && return 0
+_CATALYST_PLUGIN_DIRS_SH_LOADED=1
+
+# plugin_dirs_machine_config_path — echoes the machine-config path
+# (CTL-689 convention; CATALYST_MACHINE_CONFIG overrides for tests).
+plugin_dirs_machine_config_path() {
+  printf '%s' "${CATALYST_MACHINE_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/catalyst/config.json}"
+}
+
+# plugin_dirs_repo_config_path [START_DIR] — walk up from START_DIR (default
+# $PWD) looking for .catalyst/config.json; echoes its path or "".
+plugin_dirs_repo_config_path() {
+  local dir="${1:-$PWD}"
+  while [[ "$dir" != "/" && -n "$dir" ]]; do
+    if [[ -f "${dir}/.catalyst/config.json" ]]; then
+      printf '%s' "${dir}/.catalyst/config.json"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  printf ''
+}
+
+# __plugin_dirs_from_file FILE — extract pluginDirs from one config file.
+# Same jq program as phase-agent-dispatch:891 (string-or-array tolerant).
+__plugin_dirs_from_file() {
+  local file="$1"
+  [[ -n "$file" && -f "$file" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  jq -r '.catalyst.orchestration.pluginDirs
+         | if type=="array" then join(":") else . end // empty' \
+    "$file" 2>/dev/null || true
+}
+
+# resolve_plugin_dirs — resolves pluginDirs into globals (no subshell needed):
+#   RESOLVED_PLUGIN_DIRS        colon-separated dirs, "" when unset anywhere
+#   RESOLVED_PLUGIN_DIRS_SOURCE env | repo-config | machine-config | none
+resolve_plugin_dirs() {
+  RESOLVED_PLUGIN_DIRS=""
+  RESOLVED_PLUGIN_DIRS_SOURCE="none"
+
+  if [[ -n "${CATALYST_PLUGIN_DIRS:-}" ]]; then
+    RESOLVED_PLUGIN_DIRS="$CATALYST_PLUGIN_DIRS"
+    RESOLVED_PLUGIN_DIRS_SOURCE="env"
+    return 0
+  fi
+
+  local v
+  v="$(__plugin_dirs_from_file "$(plugin_dirs_repo_config_path)")"
+  if [[ -n "$v" ]]; then
+    RESOLVED_PLUGIN_DIRS="$v"
+    RESOLVED_PLUGIN_DIRS_SOURCE="repo-config"
+    return 0
+  fi
+
+  v="$(__plugin_dirs_from_file "$(plugin_dirs_machine_config_path)")"
+  if [[ -n "$v" ]]; then
+    RESOLVED_PLUGIN_DIRS="$v"
+    RESOLVED_PLUGIN_DIRS_SOURCE="machine-config"
+    return 0
+  fi
+  return 0
+}
+
+# plugin_checkout_root PLUGIN_DIR — echoes the git toplevel containing the
+# plugin dir (pluginDirs entries point at <checkout>/plugins/dev). Returns
+# non-zero (and echoes nothing) when the dir is not inside a git checkout.
+plugin_checkout_root() {
+  local pd="$1"
+  [[ -d "$pd" ]] || return 1
+  git -C "$pd" rev-parse --show-toplevel 2>/dev/null
+}

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -888,6 +888,10 @@ fi
 # Empty (the default) = no flags; marketplace behavior unchanged. Entries that
 # are not directories are skipped loudly — a typo must not silently change
 # which plugin the fleet loads.
+# NOTE (CTL-940): lib/plugin-dirs.sh mirrors this resolution for update-side
+# consumers (catalyst-stack hotpatch/parity). The jq program and precedence
+# here MUST stay in sync with resolve_plugin_dirs() there — the dir hotpatch
+# updates must be exactly the dir this dispatcher hands to workers.
 PLUGIN_DIRS_RESOLVED="${CATALYST_PLUGIN_DIRS:-$(config_value '.catalyst.orchestration.pluginDirs | if type=="array" then join(":") else . end' "")}"
 PLUGIN_DIR_ARGS=()
 if [[ -n $PLUGIN_DIRS_RESOLVED ]]; then


### PR DESCRIPTION
## Summary

Closes the 2026-06-09 incident class (in-place cache rsync leaving mixed-version plugin content) by making the per-host **pluginDirs checkout** the thing `catalyst-stack` updates, and adding a drift report for it.

- **`catalyst-stack hotpatch`** (also `start/restart --hotpatch`): resolves the checkout via the new `lib/plugin-dirs.sh` (env `CATALYST_PLUGIN_DIRS` > repo `.catalyst/config.json` > machine config — identical precedence + jq program to `phase-agent-dispatch`'s `--plugin-dir` resolution), then `git pull --ff-only origin main`. Refuses dirty or diverged checkouts; idempotent when up to date; dedupes multiple pluginDirs entries in the same checkout.
- **Evented (CTL-941)**: each successful pull appends a `node.checkout.updated` canonical event (old + new commits) to `~/catalyst/events/YYYY-MM.jsonl` via `lib/canonical-event.sh`, best-effort.
- **Cache writes fenced off**: the marketplace-cache rsync is unreachable from the default path; it survives only behind explicit `hotpatch --legacy-rsync` with a loud deprecation warning, inside a `BEGIN/END LEGACY RSYNC` block. A static test asserts no `plugins/cache` reference exists outside that block.
- **`catalyst-stack parity` (CTL-941)**: node freshness + setup-drift report — pluginDirs configured, entries exist and are git checkouts, plugin manifest parses, working tree clean, origin remote daemon-fetchable (no ssh), checkout at origin/main, and whether machine config carries pluginDirs. Exit code = drift-finding count, so cron/launchd on a headless node can run `catalyst-stack hotpatch && catalyst-stack parity` and alert on nonzero.

## Tests

- `catalyst-stack-hotpatch.test.sh` — 14/14 (git fixtures: ff-pull, idempotence, dirty/diverged refusal, all three resolution layers, no-rsync/no-cache-touch guards, legacy path)
- `catalyst-stack-parity.test.sh` — 7/7 (clean exit 0, behind-by count, dirty file naming, ssh remote, missing pluginDirs, bad manifest, machine-config reporting)
- Regression: `phase-agent-dispatch.test.sh` 231/231, dispatch-name 6/6; lib sources clean under zsh.

## Scope notes / follow-ups (not in this PR)

- Dispatcher keeps its own resolution expression (now cross-referenced with a MUST-stay-in-sync note both ways); folding it onto the lib touches the highest-blast-radius script without dedicated pluginDirs tests there.
- `install-cli.sh` symlink-mode default for worker nodes, marketplace decommission on workers, and the launchd timer plist are operator/follow-up steps; the timer's payload (`hotpatch`, ff-only, evented, refuses dev-dirty checkouts) is what this PR ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)