### PR TITLE
feat(dev): turn-zero gate — stop+replace workers that never start their first turn (CTL-932)

### DIFF
--- a/plugins/dev/scripts/execution-core/claude-agents.mjs
+++ b/plugins/dev/scripts/execution-core/claude-agents.mjs
@@ -302,6 +302,19 @@ export function agentForShortId(shortId, agents) {
   );
 }
 
+// agentStateForShortId — the matched agent's `.state` string, or null. CTL-932:
+// the snapshot already retains every raw field of `claude agents --json`
+// (agents are stored verbatim, never projected), but nothing READ `.state`
+// before — and `state === "blocked"` is the listing's signature of a worker
+// that registered but never resolved its initial prompt (the wedged-never-
+// started class: all six 2026-06-09 wedges showed kind:"background",
+// status:"idle", state:"blocked"). Null on absent agent / missing field /
+// malformed input — callers treat null as "cannot prove blocked" (no-op).
+export function agentStateForShortId(shortId, agents) {
+  const agent = agentForShortId(shortId, agents);
+  return typeof agent?.state === "string" && agent.state ? agent.state : null;
+}
+
 // isBgJobAlive — true iff a live `claude agents` session matches bgJobId. This
 // replaces the pid-file keep-alive check: a crashed worker disappears from
 // `claude agents`, whereas a live one (busy OR idle between turns) is still
@@ -364,6 +377,41 @@ export function livenessForBgJob(bgJobId, { exec, agents } = {}) {
 export function countBackgroundAgents({ agents, now } = {}) {
   const list = agents ?? getAgentsCached(now ? { now } : {}).agents;
   return list.filter((a) => a?.kind === "background").length;
+}
+
+// --- CTL-932: screen capture for wedge escalations -------------------------
+
+// stripAnsi — drop ANSI CSI/OSC escape sequences from a rendered screen buffer
+// so the captured text is grep-able in the event log. Covers CSI (ESC [ … cmd),
+// OSC (ESC ] … BEL / ESC \), and bare two-byte escapes.
+const ANSI_RE =
+  /\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b[@-_]/g;
+function stripAnsi(s) {
+  return String(s).replace(ANSI_RE, "");
+}
+
+// claudeLogs — `claude logs <shortId>`: the session's rendered screen buffer,
+// the ONLY external surface that shows WHY a session is idle (it revealed the
+// "Unknown command: /catalyst-dev:phase-*" banner behind the 2026-06-09
+// fleet-wide wedge). ANSI-stripped and capped so the capture can ride inside
+// an escalation event payload without archaeology — or bloat. shortId MUST be
+// the 8-char form (same contract as claudeStop). Returns {ok, output, error?};
+// never throws.
+const CLAUDE_LOGS_CAP = 8_192;
+export function claudeLogs(shortId, { spawn = spawnSync } = {}) {
+  try {
+    const res = spawn(CLAUDE_BIN, ["logs", shortId], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if ((res.status ?? 0) !== 0) {
+      return { ok: false, output: "", error: res.stderr?.trim() || `claude logs rc=${res.status}` };
+    }
+    const cleaned = stripAnsi(res.stdout ?? "").trim();
+    return { ok: true, output: cleaned.slice(0, CLAUDE_LOGS_CAP) };
+  } catch (err) {
+    return { ok: false, output: "", error: err.message };
+  }
 }
 
 // claudeStop — `claude stop <shortId>`. shortId MUST be the 8-char form

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -252,6 +252,18 @@ export const STALE_WORKER_CUTOFF_MS =
 export const BUSY_CEILING_MS =
   Number(process.env.EXECUTION_CORE_BUSY_CEILING_MS) || 6 * 60 * 60_000;
 
+// CTL-932 — turn-zero gate threshold. A healthy `claude --bg` worker creates
+// its session transcript ~0.3s after its first turn; a wedged one (slash
+// command failed to resolve at session start — "Unknown command:
+// /catalyst-dev:phase-*") never does and idles forever holding a concurrency
+// slot. A running-signal worker older than this with NO transcript AND a
+// FRESH `claude agents` snapshot state of "blocked" is classified
+// wedged-never-started (stop + replace via the normal revive path; escalate
+// needs-human after repeated ineffective replacements). 120s comfortably
+// exceeds registration + first-turn latency. Env-overridable.
+export const NEVER_STARTED_MS =
+  Number(process.env.CATALYST_NEVER_STARTED_MS) || 120_000;
+
 // CTL-809 — ghost-breaker just-dispatched grace. The reclaim alive-branch
 // cross-checks the FRESH `claude agents` snapshot to catch a jobLifecycle-alive
 // worker whose process is actually gone (CC 2.x never flips a crashed/wedged

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -34,6 +34,7 @@ import {
   REVIVE_MAX_AGE_MS,
   GHOST_GRACE_MS,
   ZOMBIE_STALE_FLOOR_MS,
+  NEVER_STARTED_MS,
 } from "./config.mjs";
 import { HEARTBEAT_EVENT } from "./heartbeat-event.mjs"; // CTL-859: node.heartbeat reader
 import { phaseIndex, isKnownPhase } from "../lib/phase-fsm.mjs";
@@ -41,8 +42,9 @@ import { readWorkerSignals, TERMINAL, listDispatchedPhases } from "./signal-read
 import { reconcileAll } from "./monitor.mjs";
 import { listProjects } from "./registry.mjs";
 import { emitReapIntent as emitReapIntentDefault } from "./reap-intent.mjs";
-import { claudeStop, getAgentsCached, agentForShortId } from "./claude-agents.mjs";
+import { claudeStop, getAgentsCached, agentForShortId, claudeLogs } from "./claude-agents.mjs";
 import { shortIdFromSessionId } from "./claude-ids.mjs";
+import { findTranscript, defaultProjectsDir } from "./session-recency.mjs";
 import { loadCursor, resolveStartOffset } from "./event-cursor.mjs";
 import {
   WORK_DONE_PROBES,
@@ -118,6 +120,14 @@ export function resolvePhaseSessionId(
 // Claude stamps it the moment a job reaches a terminal lifecycle state, so
 // jobLifecycle can declare death even when the .state string is one we don't
 // enumerate. Null for a live/non-terminal job (and when state.json is unreadable).
+//
+// CTL-932: also parse tempo / detail / needs — the CC supervisor's self-report.
+// On 2026-06-09 every wedged-never-started worker's state.json read
+// state:"working" (alive forever) while tempo:"blocked" + detail:"stuck on a
+// startup dialog" + needs:"open this session to continue setup" sat UNREAD in
+// the same file all day. They are observability fields (logged by the reclaim
+// sweep), deliberately NOT a death trigger — the turn-zero gate keys on the
+// transcript + fresh agents-snapshot state instead.
 export function defaultStatJob(bgJobId) {
   const file = join(getJobsRoot(), bgJobId, "state.json");
   let st;
@@ -128,14 +138,20 @@ export function defaultStatJob(bgJobId) {
   }
   let state = null;
   let firstTerminalAt = null;
+  let tempo = null;
+  let detail = null;
+  let needs = null;
   try {
     const parsed = JSON.parse(readFileSync(file, "utf8"));
     state = parsed?.state ?? null;
     firstTerminalAt = parsed?.firstTerminalAt ?? null;
+    tempo = parsed?.tempo ?? null;
+    detail = parsed?.detail ?? null;
+    needs = parsed?.needs ?? null;
   } catch {
     /* state.json unreadable — liveness still proven by the dir existing */
   }
-  return { exists: true, mtimeMs: st.mtimeMs, state, firstTerminalAt };
+  return { exists: true, mtimeMs: st.mtimeMs, state, firstTerminalAt, tempo, detail, needs };
 }
 
 // CTL-736 Phase 2 — the authoritative job-lifecycle terminal states. These are
@@ -395,6 +411,145 @@ export function defaultAppendOrphanDetectedEvent({
   );
 }
 
+// ─── CTL-932: turn-zero gate primitives ─────────────────────────────────────
+//
+// A wedged-never-started worker registered with CC but never resolved its
+// slash-command prompt ("Unknown command: /catalyst-dev:phase-*") — it idles
+// forever at an empty input prompt holding a concurrency slot while every
+// existing guard reads it "alive" (state.json state:"working"; LISTED in the
+// agents snapshot, so the ghost breaker suppresses). The gate's evidence is
+// the conjunction the 2026-06-09 incident proved: dispatch age past
+// NEVER_STARTED_MS ∧ NO transcript file ∧ FRESH agents-snapshot state
+// "blocked". See thoughts/shared/research/
+// 2026-06-09-execution-core-fable-root-cause-and-architecture.md (A1/A2 +
+// Appendix 2 "minimal turn-zero gate").
+
+// How many stop+replace attempts the gate makes before declaring the
+// environment broken (marketplace wedge, plugin-registration race) and
+// escalating needs-human instead of looping. Replacement N+1 only happens if
+// replacement N ALSO wedged, so 2 ineffective replacements = 3 wedged spawns.
+export const NEVER_STARTED_ATTEMPT_CAP = 2;
+
+// Captures stored in the durable attempt marker are truncated so the marker
+// (and the final escalation payload aggregating all of them) stays bounded.
+const NEVER_STARTED_CAPTURE_CAP = 2_000;
+
+// neverStartedAttemptsPath — the durable per-(ticket, phase) attempt marker,
+// living in the worker dir like the .revive-N / .progress-<phase> crumbs.
+export function neverStartedAttemptsPath(orchDir, ticket, phase) {
+  return join(orchDir, "workers", ticket, `.never-started-${phase}.json`);
+}
+
+// defaultReadNeverStartedAttempts — {count, captures[]}. Fail-open to zero
+// attempts on a missing/corrupt marker (the conservative direction: the gate
+// retries a replacement rather than falsely escalating).
+export function defaultReadNeverStartedAttempts(orchDir, ticket, phase) {
+  try {
+    const parsed = JSON.parse(
+      readFileSync(neverStartedAttemptsPath(orchDir, ticket, phase), "utf8"),
+    );
+    const count = Number.isInteger(parsed?.count) && parsed.count > 0 ? parsed.count : 0;
+    const captures = Array.isArray(parsed?.captures)
+      ? parsed.captures.filter((c) => typeof c === "string")
+      : [];
+    return { count, captures };
+  } catch {
+    return { count: 0, captures: [] };
+  }
+}
+
+// defaultRecordNeverStartedAttempt — increment the durable count and retain the
+// (truncated) screen capture so the final escalation can carry the captures
+// from ALL attempts. Atomic tmp+rename; fail-open (a write failure costs one
+// extra replacement attempt, never a throw out of the reclaim sweep).
+export function defaultRecordNeverStartedAttempt(orchDir, ticket, phase, capture) {
+  try {
+    const prev = defaultReadNeverStartedAttempts(orchDir, ticket, phase);
+    const p = neverStartedAttemptsPath(orchDir, ticket, phase);
+    mkdirSync(dirname(p), { recursive: true });
+    const next = {
+      count: prev.count + 1,
+      captures: [
+        ...prev.captures,
+        String(capture ?? "").slice(0, NEVER_STARTED_CAPTURE_CAP),
+      ],
+      updatedAt: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    };
+    const tmp = `${p}.tmp.${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(next, null, 2));
+    renameSync(tmp, p);
+  } catch (err) {
+    log.warn({ ticket, phase, err: err.message }, "ctl-932: never-started attempt marker write failed");
+  }
+}
+
+// defaultTranscriptExists — does the session's transcript JSONL exist? A
+// healthy session creates it ~0.3s after its first turn (session-recency.mjs);
+// absence minutes after dispatch means the prompt was never processed — the
+// cleanest never-started detector (research Appendix 2).
+export function defaultTranscriptExists(sessionId, { projectsDir = defaultProjectsDir() } = {}) {
+  if (!sessionId) return false;
+  return findTranscript(sessionId, projectsDir) !== null;
+}
+
+// defaultCaptureWedgeLogs — `claude logs <shortId>`: the rendered screen, the
+// only surface that shows WHY the session idles (the "Unknown command" banner).
+// Captured BEFORE the stop (stopping destroys the buffer) and embedded in the
+// escalation event so the cause is visible without archaeology. Best-effort:
+// "" on any failure.
+export function defaultCaptureWedgeLogs(bgJobId, { logs = claudeLogs } = {}) {
+  if (!bgJobId) return "";
+  let shortId;
+  try {
+    shortId = shortIdFromSessionId(bgJobId);
+  } catch {
+    return "";
+  }
+  const res = logs(shortId);
+  return res?.ok ? res.output : "";
+}
+
+// defaultAppendWedgedNeverStartedEvent —
+// phase.<phase>.wedged-never-started.<TICKET>. The per-attempt escalation
+// event: carries the captured screen (captured_logs), the attempt ordinal, and
+// the state.json/agents-snapshot self-reports the diagnosis keyed on. Audit-
+// only (not in the broker's PHASE_EVENT_PATTERN). Exported for the round-trip
+// envelope test.
+export function defaultAppendWedgedNeverStartedEvent({
+  phase,
+  ticket,
+  orchId,
+  attempt,
+  bg_job_id = null,
+  agents_state = null,
+  tempo = null,
+  detail = null,
+  needs = null,
+  captured_logs = "",
+}) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase,
+      ticket,
+      orchId,
+      action: "wedged-never-started",
+      reason: "no-transcript-and-agents-blocked",
+      payloadExtras: {
+        attempt,
+        bg_job_id,
+        agents_state,
+        tempo,
+        detail,
+        needs,
+        captured_logs,
+        title: `phase ${phase} worker wedged at turn zero (attempt ${attempt})`,
+        body: `Worker for ${ticket} ${phase} registered but never started its first turn (no transcript; agents state=blocked). Stopped and replaced via the revive path. Captured screen:\n\n${captured_logs}`,
+      },
+    }),
+    "wedged-never-started",
+  );
+}
+
 // CTL-664: post the reclaim Linear mirror the skill End block would have posted
 // had the worker survived. Marker-guarded by the SHARED .linear-mirror-<phase>
 // (first-writer-wins: if the skill already mirrored, the marker exists and we
@@ -540,7 +695,10 @@ export function defaultAppendYieldFileSkipEvent({ ticket, orchId, filename }) {
   );
 }
 
-function defaultAppendEscalatedEvent({ phase, ticket, orchId, reason, final_attempt_count }) {
+// CTL-932: `extras` rides into the payload so an escalation can carry evidence
+// (the wedged-never-started cap escalation embeds the screen captures from all
+// attempts). Absent for every pre-existing caller — shape unchanged.
+function defaultAppendEscalatedEvent({ phase, ticket, orchId, reason, final_attempt_count, extras = {} }) {
   return appendEnvelopeBestEffort(
     buildEventEnvelope({
       phase,
@@ -548,7 +706,7 @@ function defaultAppendEscalatedEvent({ phase, ticket, orchId, reason, final_atte
       orchId,
       action: "escalated",
       reason,
-      payloadExtras: { final_attempt_count },
+      payloadExtras: { final_attempt_count, ...extras },
     }),
     "escalated",
   );
@@ -1359,9 +1517,19 @@ function defaultWriteProgressMark(orchDir, ticket, phase, value) {
 //   'inert-stale'         reclaim-eligible + work NOT done + the signal is older
 //                         than reviveMaxAgeMs — an abandoned historical dir, left
 //                         inert (no revive, no escalate). (CTL-735, kept.)
+//   'wedged-redispatched' CTL-932 turn-zero gate: an `alive` worker past
+//                         NEVER_STARTED_MS with NO transcript and a FRESH
+//                         agents-snapshot state of "blocked" never started its
+//                         first turn. Screen captured into the wedged event,
+//                         session stopped, signal flipped through reviveDispatch
+//                         (replacement worker). Durable attempt marker bumped;
+//                         past NEVER_STARTED_ATTEMPT_CAP the gate escalates
+//                         needs-human ('escalated', reason
+//                         wedged-never-started-exhausted) instead of looping.
 //   'escalated' / 'escalation-suppressed'
 //                         an `alive` worker past BUSY_CEILING_MS with no committed
-//                         work (the backstop), behind the CTL-638 cool-down.
+//                         work (the backstop), behind the CTL-638 cool-down — or
+//                         the CTL-932 wedge cap above.
 //   'superseded-noop'     reclaim-eligible BUT the signal's phase precedes the
 //                         ticket's latest-dispatched phase (CTL-606). A reap-intent
 //                         is emitted so the reaper stops the bg.
@@ -1430,6 +1598,20 @@ export function reclaimDeadWorkIfPossible(
     // registered fresh spawn — CTL-662-safe; a busy fan-out worker stays LISTED).
     agentsSnapshot = getAgentsCached,
     ghostGraceMs = GHOST_GRACE_MS,
+    // CTL-932 — TURN-ZERO GATE seams. A jobLifecycle-alive worker past
+    // neverStartedMs whose session has NO transcript AND whose FRESH agents-
+    // snapshot state is "blocked" never started its first turn: stop it,
+    // capture `claude logs` into the escalation event, and replace it through
+    // the normal revive/redispatch path — bounded by a durable per-(ticket,
+    // phase) attempt marker; past the cap, escalate needs-human instead of
+    // looping. All injectable; production defaults are the real primitives.
+    neverStartedMs = NEVER_STARTED_MS,
+    transcriptExists = defaultTranscriptExists,
+    captureWedgeLogs = defaultCaptureWedgeLogs,
+    appendWedgedEvent = defaultAppendWedgedNeverStartedEvent,
+    readNeverStartedAttempts = defaultReadNeverStartedAttempts,
+    recordNeverStartedAttempt = defaultRecordNeverStartedAttempt,
+    wedgeAttemptCap = NEVER_STARTED_ATTEMPT_CAP,
     // CTL-868 — zombie state.json staleness floor (the GHOST BREAKER's fallback
     // for when no FRESH `claude agents` snapshot is available, e.g. the headless
     // mini where CTL-829 makes `claude agents` unreliable). A `working` job whose
@@ -1511,15 +1693,21 @@ export function reclaimDeadWorkIfPossible(
   // CTL-662 removed it from every DECISION branch — it is telemetry, not a
   // trigger. Best-effort: a missing job dir (real crash) just leaves it null.
   let prevStateJsonMtime = null;
+  // CTL-932: keep the FULL statJob read so the supervisor's self-report fields
+  // (tempo/detail/needs — previously never read) reach the logs below.
+  let jobStat = null;
   if (signal?.liveness?.value) {
-    const job = statJob(signal.liveness.value);
-    if (job && typeof job.mtimeMs === "number") prevStateJsonMtime = job.mtimeMs;
+    jobStat = statJob(signal.liveness.value);
+    if (jobStat && typeof jobStat.mtimeMs === "number") prevStateJsonMtime = jobStat.mtimeMs;
   }
 
   // CTL-638 — escalation helper (unchanged): wraps appendEscalatedEvent +
   // applyStalledLabel in a per-(ticket, phase) cool-down so the same escalation
   // cannot re-fire within the window (the pre-CTL-638 self-feeding storm).
-  function escalateOnce(reason, finalAttemptCount) {
+  // CTL-932: `extras` (optional) rides evidence into the escalated event
+  // payload (e.g. the wedge screen captures). Cool-down/breaker behaviour is
+  // untouched.
+  function escalateOnce(reason, finalAttemptCount, extras) {
     // CTL-679 — while the Linear breaker is open we are rate-limited; the
     // needs-human apply would 429 and write no marker, re-firing every tick.
     // Defer: skip the audit event + label write entirely (no cool-down record,
@@ -1541,6 +1729,7 @@ export function reclaimDeadWorkIfPossible(
       orchId,
       reason,
       final_attempt_count: finalAttemptCount,
+      ...(extras ? { extras } : {}),
     });
     applyStalledLabel({ orchDir, ticket });
     recordEscalationFn(orchDir, ticket, phase, reason, now());
@@ -1683,6 +1872,114 @@ export function reclaimDeadWorkIfPossible(
     }
 
     const startedAtMs = Date.parse(signal.raw?.startedAt ?? "");
+
+    // ── CTL-932 — TURN-ZERO GATE. A worker can register with CC but never
+    // resolve its slash-command prompt ("Unknown command:
+    // /catalyst-dev:phase-*"): it idles forever at an empty input prompt. Every
+    // other guard is blind to this class — state.json stays state:"working"
+    // (jobLifecycle alive forever), the session IS listed (ghost breaker
+    // suppresses), and the 6h busy-ceiling is label-only. Evidence conjunction
+    // (all three required; any doubt → fall through, no-op):
+    //   1. dispatch age > neverStartedMs (default 120s; a healthy session
+    //      creates its transcript ~0.3s after the first turn);
+    //   2. NO transcript file for the session (the cleanest wedge detector);
+    //   3. FRESH agents-snapshot state === "blocked" (the listing's signature
+    //      of registered-but-prompt-never-resolved).
+    // INVARIANT: the committed-work probe runs BEFORE any kill — a worker with
+    // committed work is never touched here (existing paths own it). Dead
+    // workers never reach this branch (lifecycle === "alive" only), and a
+    // worker WITH a transcript falls through untouched.
+    if (
+      prevBgJobId &&
+      Number.isFinite(startedAtMs) &&
+      now() - startedAtMs > neverStartedMs
+    ) {
+      let wedgeShortId = null;
+      try {
+        wedgeShortId = shortIdFromSessionId(prevBgJobId);
+      } catch {
+        wedgeShortId = null; // malformed bg_job_id → cannot prove → no-op
+      }
+      if (wedgeShortId) {
+        const snap = agentsSnapshot();
+        const agent = snap?.isFresh ? agentForShortId(wedgeShortId, snap.agents) : null;
+        if (agent && agent.state === "blocked") {
+          const sessionId = resolveSession(prevBgJobId);
+          if (!transcriptExists(sessionId)) {
+            // Committed-work probe BEFORE any kill (the invariant): committed
+            // work means this is NOT a never-started worker — leave it to the
+            // existing alive-branch paths.
+            const workCommitted = hasProbe(phase) && probes[phase]({ ticket, repoRoot, orchDir });
+            if (!workCommitted) {
+              // Capture the rendered screen BEFORE stopping (stop destroys it)
+              // so the escalation event shows the cause without archaeology.
+              const captured = captureWedgeLogs(prevBgJobId);
+              const attempts = readNeverStartedAttempts(orchDir, ticket, phase);
+              if (attempts.count >= wedgeAttemptCap) {
+                // Replacements keep wedging — the environment is broken
+                // (marketplace wedge / plugin-registration race). Stop the
+                // corpse (it holds a slot) and page a human with the screen
+                // captures from ALL attempts instead of looping.
+                killBgJob({ bgJobId: prevBgJobId });
+                log.warn(
+                  { ticket, phase, prevBgJobId, attempts: attempts.count, tempo: jobStat?.tempo, detail: jobStat?.detail, needs: jobStat?.needs },
+                  "ctl-932: wedged-never-started replacement budget exhausted — escalating needs-human (not looping)",
+                );
+                return escalateOnce("wedged-never-started-exhausted", attempts.count, {
+                  bg_job_id: prevBgJobId,
+                  captured_logs_all_attempts: [
+                    ...attempts.captures,
+                    String(captured ?? "").slice(0, 2_000),
+                  ],
+                });
+              }
+              const attempt = attempts.count + 1;
+              appendWedgedEvent({
+                phase,
+                ticket,
+                orchId,
+                attempt,
+                bg_job_id: prevBgJobId,
+                agents_state: agent.state,
+                tempo: jobStat?.tempo ?? null,
+                detail: jobStat?.detail ?? null,
+                needs: jobStat?.needs ?? null,
+                captured_logs: captured,
+              });
+              recordNeverStartedAttempt(orchDir, ticket, phase, captured);
+              // Stop the wedged session (reap-intent for the reaper + inline
+              // best-effort stop, mirroring the no-progress STOP path), then
+              // flip the signal through the normal revive/redispatch path
+              // (reset-to-stalled + fresh dispatch, gen+1). Backoff is
+              // structural: the replacement's fresh startedAt keeps the gate
+              // silent for another neverStartedMs window.
+              emitReapIntent("phase.terminal.reap-requested", {
+                ticket,
+                phase,
+                bgJobId: prevBgJobId,
+                worktreePath: signal.raw?.worktreePath,
+                reason: "ctl-932-wedged-never-started",
+              }).catch(() => {});
+              killBgJob({ bgJobId: prevBgJobId });
+              const dr = reviveDispatch({ orchDir, ticket, phase, resumeSession: null, attempt: attempt + 1 });
+              if (dr.code === 0) {
+                log.warn(
+                  { ticket, phase, prevBgJobId, attempt, ageMs: now() - startedAtMs, tempo: jobStat?.tempo, detail: jobStat?.detail, needs: jobStat?.needs },
+                  "ctl-932: wedged-never-started worker stopped and replaced (no transcript + agents blocked)",
+                );
+              } else {
+                log.warn(
+                  { ticket, phase, attempt, code: dr.code, stderr: dr.stderr },
+                  "ctl-932: wedged replacement dispatch failed; will retry next tick",
+                );
+              }
+              return "wedged-redispatched";
+            }
+          }
+        }
+      }
+    }
+
     if (Number.isFinite(startedAtMs) && now() - startedAtMs > busyCeilingMs) {
       const workDone = hasProbe(phase) && probes[phase]({ ticket, repoRoot, orchDir });
       if (!workDone) {
@@ -1758,7 +2055,12 @@ export function reclaimDeadWorkIfPossible(
       }
     }
     if (!ghostAbsent) {
-      log.info({ ticket, phase, prevBgJobId }, "ctl-736: alive worker — reclaim suppressed");
+      // CTL-932: surface the supervisor's self-report (tempo/detail/needs) —
+      // the fields that contained the 2026-06-09 diagnosis but were never read.
+      log.info(
+        { ticket, phase, prevBgJobId, tempo: jobStat?.tempo, detail: jobStat?.detail, needs: jobStat?.needs },
+        "ctl-736: alive worker — reclaim suppressed",
+      );
       return "alive-suppressed";
     }
     // ghostAbsent → fall through to the dead-eligible reclaim path below (supersede

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2316,6 +2316,12 @@ export function schedulerTick(
         case "revived":
           revived.push(entry);
           break;
+        case "wedged-redispatched":
+          // CTL-932: a turn-zero-wedged worker (registered, never started its
+          // first turn) was stopped and replaced via the revive path. Bucket
+          // with revived — a replacement worker is now live for the phase.
+          revived.push(entry);
+          break;
         case "revive-suppressed":
           // CTL-736: the revive event could not be persisted (audit-append failure)
           // so the dispatch was skipped to preserve the attempt counter; retries

--- a/plugins/dev/scripts/execution-core/turn-zero-gate.test.mjs
+++ b/plugins/dev/scripts/execution-core/turn-zero-gate.test.mjs
@@ -1,0 +1,461 @@
+// turn-zero-gate.test.mjs — CTL-932: the wedged-never-started turn-zero gate.
+//
+// A `claude --bg` worker can register but never resolve its slash-command
+// prompt ("Unknown command: /catalyst-dev:phase-*"): it idles forever at an
+// empty input prompt, holding a concurrency slot. Detection facts (2026-06-09
+// incident, 6/6 slots starved for up to 10.4h):
+//   • NO transcript file ever appears for the session (a healthy session
+//     creates one ~0.3s after its first turn — session-recency.mjs resolver);
+//   • `claude agents --json` lists it with state === "blocked";
+//   • ~/.claude/jobs/<id>/state.json self-reports tempo:"blocked" with
+//     detail/needs fields (previously never read by statJob).
+//
+// The gate runs inside reclaimDeadWorkIfPossible's alive branch: a running-
+// signal worker past CATALYST_NEVER_STARTED_MS (default 120s) with NO
+// transcript AND a FRESH agents-snapshot state of "blocked" is classified
+// wedged-never-started → capture `claude logs`, stop, flip the signal through
+// the normal revive/redispatch path; after 2 ineffective replacement attempts
+// (tracked durably in the worker dir) escalate needs-human instead of looping.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test turn-zero-gate.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  reclaimDeadWorkIfPossible,
+  defaultStatJob,
+  defaultReadNeverStartedAttempts,
+  defaultRecordNeverStartedAttempt,
+  neverStartedAttemptsPath,
+  defaultAppendWedgedNeverStartedEvent,
+} from "./recovery.mjs";
+import { claudeLogs, agentStateForShortId } from "./claude-agents.mjs";
+
+// Frozen clock — all tests pin `now` so no wall-clock leaks in.
+const NOW = Date.parse("2026-06-09T18:35:00Z");
+
+// The CTL-722 fixture: dispatched 9h ago, bg job f377750c…, signal running.
+const BG_JOB_ID = "f377750c-aaaa-bbbb-cccc-dddddddddddd";
+const SHORT_ID = "f377750c";
+const SESSION_UUID = "11111111-2222-3333-4444-555555555555";
+const NINE_H_AGO = new Date(NOW - 9 * 60 * 60_000).toISOString();
+
+const WEDGE_LOGS =
+  "⏺ Unknown command: /catalyst-dev:phase-plan\n" +
+  "⏺ Args from unknown skill: CTL-722 --orch-dir /Users/x/catalyst/runs/r\n" +
+  "⏵⏵ bypass permissions on · Ctx: 0";
+
+let orchDir;
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "ctl932-turn-zero-"));
+});
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+function recorder(returnValue) {
+  const calls = [];
+  const fn = (...args) => {
+    calls.push(args);
+    return typeof returnValue === "function" ? returnValue(...args) : returnValue;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function wedgedSignal({
+  ticket = "CTL-722",
+  phase = "implement",
+  status = "running",
+  bgJobId = BG_JOB_ID,
+  startedAt = NINE_H_AGO,
+} = {}) {
+  return {
+    ticket,
+    phase,
+    status,
+    liveness: { kind: "bg", value: bgJobId },
+    signalPath: join(orchDir, "workers", ticket, `phase-${phase}.json`),
+    raw: {
+      ticket,
+      phase,
+      orchestrator: ticket,
+      status,
+      bg_job_id: bgJobId,
+      startedAt,
+      updatedAt: startedAt,
+    },
+  };
+}
+
+// The wedged worker's state.json self-report (the fields statJob now parses).
+const wedgedStatJob = () => ({
+  exists: true,
+  mtimeMs: NOW - 9 * 60 * 60_000 + 45_000, // frozen ≤60s after spawn
+  state: "working",
+  firstTerminalAt: null,
+  tempo: "blocked",
+  detail: "stuck on a startup dialog",
+  needs: "open this session to continue setup",
+});
+
+// Fresh agents snapshot listing the worker as kind=background state=blocked.
+const blockedSnapshot = () => ({
+  agents: [
+    {
+      sessionId: BG_JOB_ID,
+      kind: "background",
+      status: "idle",
+      state: "blocked",
+    },
+  ],
+  isFresh: true,
+  ageMs: 1_000,
+});
+
+// Common seams for the gate tests. Every side effect is an injected spy; the
+// committed-work probe defaults to false (a never-started worker has no work).
+function gateSeams(overrides = {}) {
+  return {
+    repoRoot: "/repo",
+    statJob: wedgedStatJob,
+    probes: { implement: recorder(false) },
+    emitComplete: recorder({ code: 0 }),
+    appendEvent: recorder(undefined),
+    appendReviveEvent: recorder(true),
+    appendEscalatedEvent: recorder(true),
+    reviveDispatch: recorder({ code: 0 }),
+    applyStalledLabel: recorder({ applied: true }),
+    killBgJob: recorder(undefined),
+    countReviveEvents: recorder(0),
+    writeReviveMarker: recorder(undefined),
+    resolveSession: () => SESSION_UUID,
+    postReclaimMirror: () => {},
+    emitReapIntent: () => Promise.resolve(),
+    agentsSnapshot: blockedSnapshot,
+    transcriptExists: () => false,
+    captureWedgeLogs: recorder(WEDGE_LOGS),
+    appendWedgedEvent: recorder(true),
+    inEscalationCooldownFn: () => false,
+    recordEscalationFn: recorder(undefined),
+    progressMark: () => 0,
+    readProgressMark: () => -1,
+    writeProgressMark: recorder(undefined),
+    now: () => NOW,
+    ...overrides,
+  };
+}
+
+describe("turn-zero gate — wedged-never-started detection (CTL-932)", () => {
+  test("(1) CTL-722 fixture: running 9h, blocked in fresh snapshot, no transcript → stop + redispatch flip + wedged event carrying the captured logs", () => {
+    const seams = gateSeams();
+    const r = reclaimDeadWorkIfPossible(orchDir, wedgedSignal(), seams);
+
+    expect(r).toBe("wedged-redispatched");
+    // committed-work probe ran BEFORE the kill (the invariant).
+    expect(seams.probes.implement.calls.length).toBe(1);
+    // the session was stopped…
+    expect(seams.killBgJob.calls.length).toBe(1);
+    expect(seams.killBgJob.calls[0][0]).toEqual({ bgJobId: BG_JOB_ID });
+    // …and the signal flipped through the normal revive/redispatch path.
+    expect(seams.reviveDispatch.calls.length).toBe(1);
+    expect(seams.reviveDispatch.calls[0][0]).toMatchObject({
+      orchDir,
+      ticket: "CTL-722",
+      phase: "implement",
+    });
+    // the escalation event carries the captured `claude logs` text.
+    expect(seams.appendWedgedEvent.calls.length).toBe(1);
+    const evt = seams.appendWedgedEvent.calls[0][0];
+    expect(evt.ticket).toBe("CTL-722");
+    expect(evt.phase).toBe("implement");
+    expect(evt.attempt).toBe(1);
+    expect(evt.bg_job_id).toBe(BG_JOB_ID);
+    expect(evt.captured_logs).toContain("Unknown command: /catalyst-dev:phase-plan");
+    // the kill happened AFTER the logs capture (stop destroys the screen buffer).
+    expect(seams.captureWedgeLogs.calls.length).toBe(1);
+    // the attempt count is tracked durably in the worker dir.
+    const attempts = defaultReadNeverStartedAttempts(orchDir, "CTL-722", "implement");
+    expect(attempts.count).toBe(1);
+    expect(attempts.captures.length).toBe(1);
+    expect(attempts.captures[0]).toContain("Unknown command");
+  });
+
+  test("(2) healthy worker (transcript exists) → untouched (alive-suppressed, no stop, no event)", () => {
+    const seams = gateSeams({ transcriptExists: () => true });
+    // 10 min old: past the 120s gate threshold but below the 6h busy ceiling,
+    // so "untouched" is observable as a clean alive-suppressed.
+    const sig = wedgedSignal({ startedAt: new Date(NOW - 10 * 60_000).toISOString() });
+    const r = reclaimDeadWorkIfPossible(orchDir, sig, seams);
+    expect(r).toBe("alive-suppressed");
+    expect(seams.killBgJob.calls.length).toBe(0);
+    expect(seams.reviveDispatch.calls.length).toBe(0);
+    expect(seams.appendWedgedEvent.calls.length).toBe(0);
+  });
+
+  test("(3) young worker (<120s since dispatch) → untouched, snapshot never consulted by the gate", () => {
+    let snapCalls = 0;
+    const seams = gateSeams({
+      agentsSnapshot: () => {
+        snapCalls++;
+        return blockedSnapshot();
+      },
+    });
+    const sig = wedgedSignal({ startedAt: new Date(NOW - 60_000).toISOString() });
+    const r = reclaimDeadWorkIfPossible(orchDir, sig, seams);
+    expect(r).toBe("alive-suppressed");
+    // 60s < 120s gate threshold AND < 90s ghost grace → no snapshot read at all.
+    expect(snapCalls).toBe(0);
+    expect(seams.killBgJob.calls.length).toBe(0);
+    expect(seams.appendWedgedEvent.calls.length).toBe(0);
+  });
+
+  test("(4) dead job (dir gone) → existing dead/revive path unchanged, gate silent", () => {
+    const seams = gateSeams({ statJob: () => null });
+    const r = reclaimDeadWorkIfPossible(orchDir, wedgedSignal(), seams);
+    // branch (C): work not done, first death → normal revive. The gate's seams
+    // (logs capture / wedged event) never fire on a dead worker.
+    expect(r).toBe("revived");
+    expect(seams.captureWedgeLogs.calls.length).toBe(0);
+    expect(seams.appendWedgedEvent.calls.length).toBe(0);
+  });
+
+  test("(5) attempt cap: 2 prior ineffective replacements → needs-human escalation instead of a third redispatch", () => {
+    defaultRecordNeverStartedAttempt(orchDir, "CTL-722", "implement", "capture-1");
+    defaultRecordNeverStartedAttempt(orchDir, "CTL-722", "implement", "capture-2");
+    const seams = gateSeams();
+    const r = reclaimDeadWorkIfPossible(orchDir, wedgedSignal(), seams);
+
+    expect(r).toBe("escalated");
+    // no third replacement — the loop stops.
+    expect(seams.reviveDispatch.calls.length).toBe(0);
+    // needs-human applied via the escalation path.
+    expect(seams.applyStalledLabel.calls.length).toBe(1);
+    expect(seams.appendEscalatedEvent.calls.length).toBe(1);
+    const esc = seams.appendEscalatedEvent.calls[0][0];
+    expect(esc.reason).toBe("wedged-never-started-exhausted");
+    // the escalation carries the screen captures from ALL attempts.
+    const allLogs = JSON.stringify(esc);
+    expect(allLogs).toContain("capture-1");
+    expect(allLogs).toContain("capture-2");
+    expect(allLogs).toContain("Unknown command");
+    // the wedged corpse is still stopped (it holds a slot).
+    expect(seams.killBgJob.calls.length).toBe(1);
+  });
+
+  test("stale snapshot → gate is a no-op (only a FRESH blocked verdict counts)", () => {
+    const seams = gateSeams({
+      agentsSnapshot: () => ({ agents: [], isFresh: false, ageMs: Infinity }),
+      // keep the CTL-868 zombie mtime floor out of the picture: recent mtime.
+      statJob: () => ({ ...wedgedStatJob(), mtimeMs: NOW - 60_000 }),
+    });
+    // 10 min old: past the gate threshold, below the busy ceiling.
+    const sig = wedgedSignal({ startedAt: new Date(NOW - 10 * 60_000).toISOString() });
+    const r = reclaimDeadWorkIfPossible(orchDir, sig, seams);
+    expect(r).toBe("alive-suppressed");
+    expect(seams.killBgJob.calls.length).toBe(0);
+    expect(seams.appendWedgedEvent.calls.length).toBe(0);
+  });
+
+  test("snapshot state not 'blocked' (live running session) → gate is a no-op", () => {
+    const seams = gateSeams({
+      agentsSnapshot: () => ({
+        agents: [
+          { sessionId: BG_JOB_ID, kind: "background", status: "active", state: "running" },
+        ],
+        isFresh: true,
+        ageMs: 1_000,
+      }),
+      // < busy ceiling so the busy-ceiling escalation stays out of the picture.
+      now: () => Date.parse(NINE_H_AGO) + 10 * 60_000,
+    });
+    const r = reclaimDeadWorkIfPossible(orchDir, wedgedSignal(), seams);
+    expect(r).toBe("alive-suppressed");
+    expect(seams.killBgJob.calls.length).toBe(0);
+    expect(seams.appendWedgedEvent.calls.length).toBe(0);
+  });
+
+  test("committed-work probe passes → NEVER killed by the gate (existing paths own it)", () => {
+    const probe = recorder(true);
+    const seams = gateSeams({
+      probes: { implement: probe },
+      now: () => Date.parse(NINE_H_AGO) + 10 * 60_000, // < busy ceiling
+    });
+    const r = reclaimDeadWorkIfPossible(orchDir, wedgedSignal(), seams);
+    expect(r).toBe("alive-suppressed");
+    expect(probe.calls.length).toBe(1); // probe ran before any kill decision
+    expect(seams.killBgJob.calls.length).toBe(0);
+    expect(seams.appendWedgedEvent.calls.length).toBe(0);
+  });
+});
+
+describe("durable attempt tracking — worker-dir marker (CTL-932)", () => {
+  test("read returns {count: 0, captures: []} when no marker exists", () => {
+    expect(defaultReadNeverStartedAttempts(orchDir, "CTL-1", "plan")).toEqual({
+      count: 0,
+      captures: [],
+    });
+  });
+
+  test("record increments count and retains truncated captures", () => {
+    defaultRecordNeverStartedAttempt(orchDir, "CTL-1", "plan", "first screen");
+    defaultRecordNeverStartedAttempt(orchDir, "CTL-1", "plan", "second screen");
+    const a = defaultReadNeverStartedAttempts(orchDir, "CTL-1", "plan");
+    expect(a.count).toBe(2);
+    expect(a.captures).toEqual(["first screen", "second screen"]);
+  });
+
+  test("marker is per-(ticket, phase) under the worker dir", () => {
+    const p = neverStartedAttemptsPath(orchDir, "CTL-1", "plan");
+    expect(p).toBe(join(orchDir, "workers", "CTL-1", ".never-started-plan.json"));
+    defaultRecordNeverStartedAttempt(orchDir, "CTL-1", "plan", "x");
+    expect(JSON.parse(readFileSync(p, "utf8")).count).toBe(1);
+  });
+
+  test("corrupt marker fails open to zero attempts", () => {
+    mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });
+    writeFileSync(neverStartedAttemptsPath(orchDir, "CTL-1", "plan"), "not json");
+    expect(defaultReadNeverStartedAttempts(orchDir, "CTL-1", "plan")).toEqual({
+      count: 0,
+      captures: [],
+    });
+  });
+});
+
+describe("defaultStatJob — tempo/detail/needs observability (CTL-932)", () => {
+  let jobsRoot;
+  let prevEnv;
+  beforeEach(() => {
+    jobsRoot = mkdtempSync(join(tmpdir(), "ctl932-jobs-"));
+    prevEnv = process.env.CATALYST_HEALTHCHECK_JOBS_ROOT;
+    process.env.CATALYST_HEALTHCHECK_JOBS_ROOT = jobsRoot;
+  });
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env.CATALYST_HEALTHCHECK_JOBS_ROOT;
+    else process.env.CATALYST_HEALTHCHECK_JOBS_ROOT = prevEnv;
+    rmSync(jobsRoot, { recursive: true, force: true });
+  });
+
+  test("parses tempo, detail, and needs alongside state/firstTerminalAt", () => {
+    mkdirSync(join(jobsRoot, "job-1"), { recursive: true });
+    writeFileSync(
+      join(jobsRoot, "job-1", "state.json"),
+      JSON.stringify({
+        state: "working",
+        tempo: "blocked",
+        detail: "stuck on a startup dialog",
+        needs: "open this session to continue setup",
+      }),
+    );
+    const job = defaultStatJob("job-1");
+    expect(job.state).toBe("working");
+    expect(job.tempo).toBe("blocked");
+    expect(job.detail).toBe("stuck on a startup dialog");
+    expect(job.needs).toBe("open this session to continue setup");
+  });
+
+  test("absent fields default to null (back-compat with old schemas)", () => {
+    mkdirSync(join(jobsRoot, "job-2"), { recursive: true });
+    writeFileSync(join(jobsRoot, "job-2", "state.json"), JSON.stringify({ state: "working" }));
+    const job = defaultStatJob("job-2");
+    expect(job.tempo).toBeNull();
+    expect(job.detail).toBeNull();
+    expect(job.needs).toBeNull();
+  });
+});
+
+describe("agentStateForShortId — the snapshot's .state field (CTL-932)", () => {
+  const agents = [
+    { sessionId: BG_JOB_ID, kind: "background", status: "idle", state: "blocked" },
+    { sessionId: "deadbeef-0000-0000-0000-000000000000", kind: "background", state: "running" },
+  ];
+
+  test("returns the matched agent's state", () => {
+    expect(agentStateForShortId(SHORT_ID, agents)).toBe("blocked");
+    expect(agentStateForShortId("deadbeef", agents)).toBe("running");
+  });
+
+  test("returns null when absent, when state missing, or on malformed input", () => {
+    expect(agentStateForShortId("11223344", agents)).toBeNull();
+    expect(agentStateForShortId(SHORT_ID, [{ sessionId: BG_JOB_ID }])).toBeNull();
+    expect(agentStateForShortId(null, agents)).toBeNull();
+    expect(agentStateForShortId(SHORT_ID, null)).toBeNull();
+  });
+});
+
+describe("claudeLogs — screen capture for the escalation payload (CTL-932)", () => {
+  test("invokes `claude logs <shortId>` and strips ANSI escapes", () => {
+    const spawn = recorder({
+      status: 0,
+      stdout: "[1m⏺ Unknown command:[0m /catalyst-dev:phase-plan[2J",
+      stderr: "",
+    });
+    const r = claudeLogs(SHORT_ID, { spawn });
+    expect(r.ok).toBe(true);
+    expect(spawn.calls[0][1]).toEqual(["logs", SHORT_ID]);
+    expect(r.output).toBe("⏺ Unknown command: /catalyst-dev:phase-plan");
+  });
+
+  test("caps output length so the event payload stays bounded", () => {
+    const spawn = recorder({ status: 0, stdout: "x".repeat(20_000), stderr: "" });
+    const r = claudeLogs(SHORT_ID, { spawn });
+    expect(r.ok).toBe(true);
+    expect(r.output.length).toBeLessThanOrEqual(8_192);
+  });
+
+  test("returns ok:false (never throws) on rc!=0 or a spawn error", () => {
+    expect(claudeLogs(SHORT_ID, { spawn: () => ({ status: 1, stdout: "", stderr: "no such job" }) }).ok).toBe(false);
+    expect(claudeLogs(SHORT_ID, { spawn: () => { throw new Error("ENOENT"); } }).ok).toBe(false);
+  });
+});
+
+describe("defaultAppendWedgedNeverStartedEvent — envelope round-trip (CTL-932)", () => {
+  let envCatalystDir;
+  let prevCatalystDir;
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    envCatalystDir = mkdtempSync(join(tmpdir(), "ctl932-events-"));
+    process.env.CATALYST_DIR = envCatalystDir;
+    mkdirSync(join(envCatalystDir, "events"), { recursive: true });
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(envCatalystDir, { recursive: true, force: true });
+  });
+
+  test("writes phase.<phase>.wedged-never-started.<TICKET> with the captured logs in the payload", () => {
+    const ok = defaultAppendWedgedNeverStartedEvent({
+      phase: "plan",
+      ticket: "CTL-722",
+      orchId: "CTL-722",
+      attempt: 1,
+      bg_job_id: BG_JOB_ID,
+      agents_state: "blocked",
+      tempo: "blocked",
+      detail: "stuck on a startup dialog",
+      captured_logs: WEDGE_LOGS,
+    });
+    expect(ok).toBe(true);
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const lines = readFileSync(join(envCatalystDir, "events", `${ym}.jsonl`), "utf8")
+      .split("\n")
+      .filter(Boolean);
+    const env = JSON.parse(lines[lines.length - 1]);
+    expect(env.attributes["event.name"]).toBe("phase.plan.wedged-never-started.CTL-722");
+    expect(env.attributes["event.action"]).toBe("wedged-never-started");
+    expect(env.body.payload.captured_logs).toContain("Unknown command: /catalyst-dev:phase-plan");
+    expect(env.body.payload.attempt).toBe(1);
+    expect(env.body.payload.bg_job_id).toBe(BG_JOB_ID);
+    expect(env.body.payload.agents_state).toBe("blocked");
+  });
+});


### PR DESCRIPTION
A `claude --bg` worker can register but never resolve its slash-command
prompt ("Unknown command: /catalyst-dev:phase-*"), idling forever at an
empty input prompt while holding a concurrency slot. On 2026-06-09 all six
slots starved this way for up to 10.4h: state.json stays state:"working"
(jobLifecycle alive forever), the session stays LISTED (ghost breaker
suppresses), and the 6h busy-ceiling is label-only.

The gate runs in the reclaim sweep's alive branch on the evidence
conjunction the incident proved: dispatch age > CATALYST_NEVER_STARTED_MS
(default 120s) AND no session transcript (healthy sessions create one
~0.3s after the first turn) AND FRESH agents-snapshot state === "blocked".
On match: capture `claude logs <shortId>` (ANSI-stripped) into a
phase.<phase>.wedged-never-started.<T> event, run the committed-work probe
BEFORE any kill, `claude stop` the session, and flip the signal through
the normal revive/redispatch path. A durable per-(ticket,phase) attempt
marker bounds the loop: after 2 ineffective replacements the gate
escalates needs-human (reason wedged-never-started-exhausted) carrying the
screen captures from all attempts instead of looping.

Observability (in scope per the research doc): statJob now parses
state.json's tempo/detail/needs self-reports and the reclaim sweep logs
them; claude-agents gains agentStateForShortId (the snapshot's .state was
fetched every 4s but never read) and claudeLogs.

Invariants preserved: deriveAdvancement and generation fencing untouched;
global admission never zeroed; workers with a transcript, with committed
work, or already dead are untouched by the gate.

Tests: turn-zero-gate.test.mjs — the CTL-722 fixture (stop + redispatch
flip + logs-bearing event), healthy/young/dead/stale-snapshot no-ops,
attempt-cap escalation, durable marker, statJob field parsing, ANSI strip,
envelope round-trip. 20 new tests; recovery/claude-agents/scheduler/daemon
suites green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
