### PR TITLE
fix(dev): make Linear-audit mitmproxy strictly opt-in, add NO_PROXY safety guard (CTL-946)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -336,30 +336,41 @@ hand.
 | `NODE_EXTRA_CA_CERTS` | Absolute path to a CA cert to trust (e.g. `$HOME/.mitmproxy/mitmproxy-ca-cert.pem`) so a MITM proxy's intercepted TLS validates. |
 | `LINEAR_STATE_CACHE_TTL_MS` | Widen the daemon's in-process Linear workflow-state cache window (milliseconds) to cut per-ticket read volume. Independent of the proxy. |
 
-### Proxy audit (opt-in)
+### Debugging Linear API rate-limiting (mitmproxy — opt-in, default OFF)
 
-The daemon's Linear/GitHub calls go out over Node's native fetch. To observe or record them, run a
-local [mitmproxy](https://mitmproxy.org/) and point the daemon at it:
+The mitmproxy is a **rare diagnostic tool**, not always-on infrastructure. The daemon runs
+correctly without it. Use it for a short window when you need to observe Linear API traffic, inspect
+rate-limit headers, or trace which callers are exhausting the quota. Turn it off again when done.
+
+**Turn ON for a diagnostic session:**
 
 ```bash
-# 1. Start the proxy (its CA is created on first run at ~/.mitmproxy/mitmproxy-ca-cert.pem)
-mitmdump -s "$HOME/catalyst/mitm_linear_addon.py" --listen-port 8080
-
-# 2. In ~/.config/catalyst/execution-core.env:
-export NODE_USE_ENV_PROXY=1
-export HTTPS_PROXY=http://127.0.0.1:8080
-export HTTP_PROXY=http://127.0.0.1:8080
-export NODE_EXTRA_CA_CERTS=$HOME/.mitmproxy/mitmproxy-ca-cert.pem
-
-# 3. Apply it
-catalyst-execution-core restart
+catalyst-stack restart --proxy
 ```
+
+This starts mitmproxy, then restarts the execution-core daemon with `HTTPS_PROXY`,
+`NODE_USE_ENV_PROXY=1`, `NODE_EXTRA_CA_CERTS`, and `NO_PROXY=api.anthropic.com,...` set as an
+inline env prefix (not written to disk). Traffic is logged to `~/catalyst/linear-proxy.jsonl`.
+On first use, `catalyst-stack` installs mitmproxy via `brew install mitmproxy` if absent and
+generates the CA cert.
+
+**Turn OFF:**
+
+```bash
+catalyst-stack restart
+```
+
+Restarts the daemon without any proxy vars. The proxy vars are **never sticky** — they are
+injected only for the lifetime of the `--proxy` daemon process.
+
+**Important:** `NO_PROXY=api.anthropic.com,...` is always included in the `--proxy` prefix so
+Claude worker API calls bypass the proxy even if mitmdump hiccups mid-session.
 
 > **Do not `source` `execution-core.env` in an interactive shell or shell profile.** It is sourced
 > by `catalyst-execution-core start` for the daemon only. Sourcing it in your terminal pins
 > `HTTP(S)_PROXY` onto every process you launch (including interactive `claude`); when mitmproxy is
 > down, those calls fail with `connection refused`. Always apply changes with
-> `catalyst-execution-core restart`. The daemon liveness-gates the proxy and degrades to direct mode
+> `catalyst-stack restart`. The daemon liveness-gates the proxy and degrades to direct mode
 > if mitmproxy is unreachable (CTL-846); an interactive shell gets no such protection.
 >
 > Concretely: never add a line like `source ~/.config/catalyst/execution-core.env` to `~/.zshrc`,

--- a/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
@@ -159,6 +159,55 @@ run "restart exits 0" bash -c "
   PATH='${STUBDIR}:${REAL_PATH}' '${STACK}' restart >/dev/null 2>&1
 "
 
+# ── CTL-946: proxy env-injection assertions ───────────────────────────────────
+# A stub that records its env to a file, so we can assert what the daemon sees.
+
+STUBDIR_ENVLOG="${SCRATCH}/stubs_envlog"
+make_stubs "$STUBDIR_ENVLOG"
+# Overwrite execution-core stub: report stopped on status (so start_daemon proceeds),
+# then log env on any other invocation (start) and succeed.
+cat > "$STUBDIR_ENVLOG/catalyst-execution-core" <<EOF
+#!/usr/bin/env bash
+case "\${1:-}" in
+  status) echo "stopped"; exit 0 ;;
+  *) env > "${SCRATCH}/daemon.env"; echo "running"; exit 0 ;;
+esac
+EOF
+chmod +x "$STUBDIR_ENVLOG/catalyst-execution-core"
+# Provide mitmdump so --proxy can proceed (pgrep won't find it running, so start proceeds).
+cat > "$STUBDIR_ENVLOG/mitmdump" <<EOF
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$STUBDIR_ENVLOG/mitmdump"
+# Fake CA cert so the CA-missing guard doesn't block.
+mkdir -p "${SCRATCH}/fake_mitm_home/.mitmproxy"
+touch "${SCRATCH}/fake_mitm_home/.mitmproxy/mitmproxy-ca-cert.pem"
+# Fake mitm_linear_addon.py (catalyst-stack copies from vendored if not at MITM_ADDON).
+mkdir -p "${SCRATCH}/fake_mitm_home/catalyst"
+touch "${SCRATCH}/fake_mitm_home/catalyst/mitm_linear_addon.py"
+
+run "default start injects no HTTPS_PROXY into daemon env (CTL-946)" bash -c "
+  rm -f '${SCRATCH}/daemon.env'
+  PATH='${STUBDIR_ENVLOG}:${REAL_PATH}' \
+    HOME='${SCRATCH}/fake_mitm_home' \
+    '${STACK}' start >/dev/null 2>&1 || true
+  # HTTPS_PROXY must be absent from the env the daemon process sees
+  ! grep -q '^HTTPS_PROXY=' '${SCRATCH}/daemon.env' 2>/dev/null
+"
+
+run "--proxy start injects HTTPS_PROXY into daemon env (CTL-946)" bash -c "
+  rm -f '${SCRATCH}/daemon.env'
+  HOME='${SCRATCH}/fake_mitm_home' \
+    PATH='${STUBDIR_ENVLOG}:${REAL_PATH}' \
+    '${STACK}' start --proxy >/dev/null 2>&1 || true
+  grep -q '^HTTPS_PROXY=' '${SCRATCH}/daemon.env' 2>/dev/null
+"
+
+run "--proxy start injects NO_PROXY with anthropic.com into daemon env (CTL-946)" bash -c "
+  grep -q 'anthropic\.com' '${SCRATCH}/daemon.env' 2>/dev/null
+"
+
 # ── Addon portability tests ───────────────────────────────────────────────────
 
 ADDON="${REPO_ROOT}/plugins/dev/scripts/mitm_linear_addon.py"

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -172,9 +172,12 @@ start_daemon() {
     fi
   fi
   if [[ "$use_proxy" == "yes" ]]; then
+    # NO_PROXY keeps Claude/Anthropic API calls direct so a dead mitmdump cannot
+    # kill worker sessions (CTL-946 safety guard — one line, not an allowlist).
     HTTPS_PROXY="$PROXY_HOST" \
     NODE_USE_ENV_PROXY=1 \
     NODE_EXTRA_CA_CERTS="$MITM_CA" \
+    NO_PROXY="api.anthropic.com,.anthropic.com,statsig.anthropic.com,sentry.io,.sentry.io" \
       catalyst-execution-core start 2>&1 | sed 's/^/  /'
   else
     catalyst-execution-core start 2>&1 | sed 's/^/  /'

--- a/website/src/content/docs/getting-started/reboot-and-updates.md
+++ b/website/src/content/docs/getting-started/reboot-and-updates.md
@@ -41,17 +41,30 @@ The default repo path is `~/code-repos/github/coalesce-labs/catalyst`. Override 
 CATALYST_REPO_DIR=/path/to/catalyst catalyst-stack restart --hotpatch
 ```
 
-## Linear traffic capture (optional)
+## Debugging Linear API rate-limiting (mitmproxy, opt-in)
 
-To log every Linear API call with rate-limit headers and caller attribution, opt in to the mitmproxy proxy:
+The mitmproxy audit is **off by default** and is a rare diagnostic tool — use it for a short window
+when you need to inspect Linear API traffic or rate-limit headers, then turn it off.
+
+**Turn ON:**
 
 ```bash
-catalyst-stack start --proxy
+catalyst-stack restart --proxy
 ```
 
-On first use, this offers to install mitmproxy via `brew install mitmproxy` if absent, generates the CA cert, and copies the vendored addon to `~/catalyst/mitm_linear_addon.py`. Traffic is written to `~/catalyst/linear-proxy.jsonl`.
+**Turn OFF:**
 
-The proxy is **off by default**. The execution-core daemon runs correctly without it.
+```bash
+catalyst-stack restart
+```
+
+On first use, `catalyst-stack --proxy` installs mitmproxy via `brew install mitmproxy` if absent,
+generates the CA cert, and copies the vendored addon to `~/catalyst/mitm_linear_addon.py`. Traffic
+is written to `~/catalyst/linear-proxy.jsonl`.
+
+The proxy vars (`HTTPS_PROXY`, `NODE_USE_ENV_PROXY`, `NODE_EXTRA_CA_CERTS`, `NO_PROXY`) are
+injected only as an inline env prefix for the daemon process — they are never written to disk and
+disappear on the next plain `catalyst-stack restart`.
 
 ## Boot-resume guarantee
 

--- a/website/src/content/docs/reference/catalyst-stack.md
+++ b/website/src/content/docs/reference/catalyst-stack.md
@@ -34,11 +34,16 @@ Opt-in to Linear traffic capture via mitmproxy. When passed, `catalyst-stack` wi
 1. Verify `mitmdump` is installed (offer `brew install mitmproxy` if absent).
 2. Generate the mitmproxy CA cert at `~/.mitmproxy/mitmproxy-ca-cert.pem` if missing.
 3. Copy the vendored addon to `~/catalyst/mitm_linear_addon.py` if absent.
-4. Start mitmproxy, then set `HTTPS_PROXY` / `NODE_USE_ENV_PROXY` / `NODE_EXTRA_CA_CERTS` for the execution-core daemon.
+4. Start mitmproxy, then set `HTTPS_PROXY` / `NODE_USE_ENV_PROXY` / `NODE_EXTRA_CA_CERTS` /
+   `NO_PROXY=api.anthropic.com,...` as an **inline env prefix** for the execution-core daemon.
 
-Traffic is logged to `~/catalyst/linear-proxy.jsonl` (one JSON record per Linear API response, including rate-limit headers and caller attribution).
+Traffic is logged to `~/catalyst/linear-proxy.jsonl` (one JSON record per Linear API response,
+including rate-limit headers and caller attribution).
 
-Proxy is **off by default**. The daemon runs correctly without it — you only need `--proxy` when you want Linear traffic logging.
+Proxy is **off by default**. The daemon runs correctly without it — use `--proxy` only for short
+diagnostic windows (e.g. investigating Linear rate-limiting). The proxy vars are never written to
+disk; a plain `catalyst-stack restart` removes them. `NO_PROXY` ensures Claude worker API calls
+bypass the proxy even if mitmdump hiccups.
 
 ### `--no-proxy`
 


### PR DESCRIPTION
## Summary

- **NO_PROXY safety guard**: adds `NO_PROXY=api.anthropic.com,.anthropic.com,statsig.anthropic.com,sentry.io,.sentry.io` to the `--proxy` inline env prefix in `catalyst-stack` so Claude worker API calls bypass the proxy even if `mitmdump` hiccups mid-session (one line, not an allowlist)
- **Confirmed default-off**: the committed `execution-core.env.example` template already has all proxy vars commented out; the default `start_daemon` path in `catalyst-stack` already injects nothing proxy-related — both confirmed correct, no changes needed
- **Tests**: 3 new assertions in `catalyst-stack.test.sh` — default start injects no `HTTPS_PROXY`, `--proxy` injects `HTTPS_PROXY`, `--proxy` injects `NO_PROXY` with `anthropic.com`
- **Docs**: `docs/configuration.md` and website docs now frame the proxy as a rare diagnostic tool with explicit on/off instructions (`catalyst-stack restart --proxy` / `catalyst-stack restart`)

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/catalyst-stack.test.sh` — 20/24 pass; 4 pre-existing hotpatch-rsync failures identical to clean main
- [x] New tests: all 3 CTL-946 assertions pass
- [x] No new failures introduced

Fixes CTL-946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)