### PR TITLE
feat(dev): bounded stall-diagnostician wake wiring + evidence capture (CTL-937)

### DIFF
--- a/plugins/dev/scripts/execution-core/beliefs/collector.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/collector.mjs
@@ -264,6 +264,15 @@ function getModuleDb(env) {
   return _moduleDb;
 }
 
+// getBeliefsDb — expose the shared module-level db handle so adjacent modules
+// (e.g. diagnostician.mjs CTL-937) can read beliefs without opening a second
+// connection. Returns null when the collector has never been initialised
+// (CATALYST_BELIEFS_SHADOW=0 path — the diagnostician gates on its own flag
+// and should skip when this returns null).
+export function getBeliefsDb() {
+  return _moduleDb;
+}
+
 // collectTickFacts — the hermetic core. All sources injectable; returns
 // { ok, tickId, errors } and NEVER throws.
 //

--- a/plugins/dev/scripts/execution-core/diagnostician.mjs
+++ b/plugins/dev/scripts/execution-core/diagnostician.mjs
@@ -1,0 +1,297 @@
+// diagnostician.mjs — CTL-937: bounded stall-diagnostician wake wiring.
+//
+// This module is the wire between the belief store (CTL-933/934) and the
+// diagnostician action. Each tick the daemon calls processDiagnosticianWakes(),
+// which reads wake_diagnostician beliefs from beliefs.db for the CURRENT tick,
+// applies the cooldown guard (by reading intent rows directly — no CTL-936
+// reconciler dependency; we read the belief store DB directly per the spec),
+// runs evidence capture for fresh wakes, records a wake-diagnostician intent,
+// and — when R12 escalate_human also fired AND the prior intent is ineffective
+// — calls applyNeedsHuman with the captured evidence attached.
+//
+// ── Design choice: deterministic evidence-collector (v1), not a full agent ──
+//
+// CTL-828 specifies a single-shot LLM agent as the eventual diagnostician, but
+// CTL-937 is the WAKE WIRING + EVIDENCE ENVELOPE + SECOND-LINE ORDERING — the
+// core gap Appendix 2 identified is that the evidence exists on disk but is
+// never captured. A deterministic evidence-collector v1:
+//
+//   1. Captures `claude logs <shortId>` output (the screen buffer that revealed
+//      the "Unknown command" banner — the 2026-06-09 root cause in one command)
+//   2. Reads the full job state.json (tempo/detail/needs — fields the daemon
+//      never read even though they contained the diagnosis)
+//   3. Packages this as a structured evidence envelope and records it on the
+//      wake intent
+//
+// This is exactly the gap Appendix 2 identifies as the "minimal turn-zero gate"
+// and is the precondition for the LLM pass (CTL-828) — the agent needs the
+// evidence before it can interpret it. The v1 ships dark (CATALYST_DIAGNOSTICIAN
+// default OFF), is structured to be upgraded (replace captureEvidence with an
+// LLM call), and the intent/cooldown machinery is identical in both versions.
+//
+// Rationale for deterministic first cut (not spawning a full LLM agent here):
+//   - Wake storms are blocked by the intent/cooldown; an LLM spawn per stuck
+//     worker per tick is expensive and the rule guard is not yet proven.
+//   - The evidence envelope is the observable outcome the operator needs NOW;
+//     the LLM pass is post-evidence commentary that CTL-828 scopes separately.
+//   - The interface (captureLogs injectable fake) makes the upgrade non-breaking.
+//
+// ── Gating ──────────────────────────────────────────────────────────────────
+// CATALYST_DIAGNOSTICIAN=1 required. Default: OFF. Ships dark, enabled
+// deliberately by the operator or test infrastructure.
+//
+// ── Cooldown ────────────────────────────────────────────────────────────────
+// Cooldown = cfg.diag_cooldown_ms (default 10min, seeded by rules.mjs). The
+// guard is enforced HERE by reading the intent table directly. R10 already
+// enforces it at the belief level (wake_diagnostician is never derived when
+// a recent intent exists), but we double-check at execution time in case the
+// belief evaluation and this code ever run with a clock skew. Recording the
+// intent is what makes R10's cooldown self-enforce across ticks.
+//
+// ── Second-line escalation ──────────────────────────────────────────────────
+// needs-human fires when BOTH:
+//   (a) R12 escalate_human belief exists for the current tick
+//   (b) The wake-diagnostician intent for the subject is ineffective
+//       (attempts >= max_attempts AND outcome IS NULL)
+// This ordering means: the machine always gets at least one pass before the
+// human is paged, and the escalation carries the evidence the machine captured.
+
+import { execSync } from "node:child_process";
+
+// ── module-level state (reset hook for tests) ─────────────────────────────
+let _capturedThisBoot = new Set(); // de-dup within a single tick across calls
+export function __resetDiagnosticianForTests() {
+  _capturedThisBoot = new Set();
+}
+
+// ── captureEvidence — deterministic evidence-collector (v1) ──────────────
+//
+// Captures the evidence surface for a stuck worker:
+//   1. claude logs <shortId> — the rendered screen buffer
+//   2. Full job state (tempo/detail/needs) from the injected readJobState
+//
+// Both sources are injectable for tests (no real process spawning in tests).
+// The 'Unknown command' banner in logsOutput is the 2026-06-09 root cause.
+function captureEvidence(subject, bgJobId, { captureLogs, readJobState } = {}) {
+  const shortId = bgJobId; // subject's short ID (already resolved by the caller)
+
+  // claude logs output — the screen buffer that reveals WHY the session is idle
+  let logsOutput = null;
+  try {
+    logsOutput = captureLogs ? captureLogs(shortId) : defaultCaptureLogs(shortId);
+  } catch (err) {
+    logsOutput = `capture-failed: ${err?.message ?? err}`;
+  }
+
+  // Full job state (beyond what statJob reads)
+  let jobState = null;
+  try {
+    jobState = readJobState ? readJobState(shortId) : null;
+  } catch (err) {
+    jobState = { error: String(err?.message ?? err) };
+  }
+
+  return {
+    subject,
+    shortId,
+    logsOutput,
+    jobState,
+    capturedAt: Date.now(),
+  };
+}
+
+// defaultCaptureLogs — real implementation for production (not used in tests).
+// Runs `claude logs <shortId>` and returns stdout. If the CLI is absent or
+// returns non-zero we capture the error text (still useful for diagnosis).
+function defaultCaptureLogs(shortId) {
+  try {
+    return execSync(`claude logs ${shortId}`, {
+      timeout: 10_000,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch (err) {
+    return `claude-logs-failed: ${err?.stderr ?? err?.message ?? err}`;
+  }
+}
+
+// ── cooldownCheck — reads intent table to see if we're within the cooldown
+// This is the execution-time guard (R10 is the belief-time guard; both fire).
+function isWithinCooldown(db, subject, nowMs) {
+  const row = db
+    .query(
+      `SELECT i.intent_id FROM intent i
+       JOIN tick t ON t.tick_id = i.tick_id, cfg c
+       WHERE c.key = 'diag_cooldown_ms'
+         AND i.kind = 'wake-diagnostician'
+         AND i.subject = ?
+         AND ? - t.now_ms <= c.value_int`,
+    )
+    .get(subject, nowMs);
+  return row != null;
+}
+
+// ── recordWakeIntent — inserts a wake-diagnostician intent row.
+// This is what R10's "not recent_intent" check reads across ticks.
+function recordWakeIntent(db, tickId, subject, beliefId, evidence) {
+  db.run(
+    `INSERT INTO intent (tick_id, kind, subject, belief_id, postcondition, attempts, outcome)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [
+      tickId,
+      "wake-diagnostician",
+      subject,
+      beliefId ?? null,
+      "diagnostician_ran", // postcondition the reconciler can verify
+      1,
+      null, // outcome is null until the diagnostician verifies resolution
+    ],
+  );
+}
+
+// ── isActionIneffective — checks whether the wake-diagnostician intent for
+// the subject has exhausted its attempts (R11 condition, checked here at the
+// action layer so the applyNeedsHuman decision is synchronous).
+function isActionIneffective(db, subject) {
+  const row = db
+    .query(
+      `SELECT i.intent_id, i.attempts FROM intent i, cfg c
+       WHERE c.key = 'max_attempts'
+         AND i.kind = 'wake-diagnostician'
+         AND i.subject = ?
+         AND i.attempts >= c.value_int
+         AND i.outcome IS NULL`,
+    )
+    .get(subject);
+  return row != null;
+}
+
+// ── processDiagnosticianWakes — the per-tick entry point ─────────────────
+//
+// Called once per scheduler tick, AFTER evaluateBeliefs() has run for tickId.
+// Reads wake_diagnostician beliefs for the current tick, applies cooldown and
+// gating guards, runs evidence capture, records intents, and escalates to
+// needs-human when R12 also fired and the prior action is ineffective.
+//
+// Parameters:
+//   db        — the beliefs.db Database (bun:sqlite), already open
+//   tickId    — the current tick's tick_id (inserted by the collector)
+//   opts      — {
+//     env              : Record<string,string>    (process.env in production)
+//     captureLogs      : (shortId) => string      (injectable for tests)
+//     readJobState     : (bgJobId) => object      (injectable for tests)
+//     applyNeedsHuman  : (subject, evidence) => void (injectable for tests)
+//   }
+//
+// Returns: { skipped, ran, cooled } (never throws — failures are logged).
+export function processDiagnosticianWakes(db, tickId, opts = {}) {
+  const env = opts.env ?? process.env;
+
+  // ── gate: CATALYST_DIAGNOSTICIAN=1 required ────────────────────────────
+  if ((env.CATALYST_DIAGNOSTICIAN ?? "0") !== "1") {
+    return { skipped: "disabled" };
+  }
+
+  const ran = [];
+  const cooled = [];
+  const errors = [];
+
+  try {
+    // Read the current tick's now_ms for cooldown arithmetic
+    const tickRow = db.query("SELECT now_ms FROM tick WHERE tick_id = ?").get(tickId);
+    if (!tickRow) return { skipped: "no-tick" };
+    const nowMs = tickRow.now_ms;
+
+    // Read wake_diagnostician beliefs for this tick
+    const wakeBeliefs = db
+      .query(
+        "SELECT * FROM belief WHERE tick_id = ? AND name = 'wake_diagnostician'",
+      )
+      .all(tickId);
+
+    // Read escalate_human beliefs for this tick (R12 — second-line guard)
+    const humanBeliefs = new Set(
+      db
+        .query(
+          "SELECT subject FROM belief WHERE tick_id = ? AND name = 'escalate_human'",
+        )
+        .all(tickId)
+        .map((r) => r.subject),
+    );
+
+    for (const wb of wakeBeliefs) {
+      const subject = wb.subject;
+      const reason = (() => {
+        try {
+          return JSON.parse(wb.value ?? "{}").reason ?? "unknown";
+        } catch {
+          return "unknown";
+        }
+      })();
+
+      try {
+        // ── escalate_human check (R12): if the belief fired AND the prior
+        // action is ineffective, page the human WITH evidence BEFORE we
+        // consider running another diagnostician pass (R12 is a second-line
+        // gate; we still run the diagnostician below if it's a fresh wake).
+        if (humanBeliefs.has(subject) && isActionIneffective(db, subject)) {
+          // Capture evidence for the escalation (re-captures fresh state)
+          const bgJobId = extractShortId(db, tickId, subject);
+          const evidence = captureEvidence(subject, bgJobId, opts);
+          evidence.reason = reason;
+          try {
+            opts.applyNeedsHuman?.(subject, evidence);
+          } catch (err) {
+            errors.push({ subject, phase: "applyNeedsHuman", err: String(err?.message ?? err) });
+          }
+          // Do not run the diagnostician again for this subject this tick
+          // (it already ran; this is the second line firing).
+          continue;
+        }
+
+        // ── cooldown check: skip if within diag_cooldown_ms ───────────────
+        if (isWithinCooldown(db, subject, nowMs)) {
+          cooled.push(subject);
+          continue;
+        }
+
+        // ── evidence capture ───────────────────────────────────────────────
+        const bgJobId = extractShortId(db, tickId, subject);
+        const evidence = captureEvidence(subject, bgJobId, opts);
+        evidence.reason = reason;
+
+        // ── record wake intent (the cooldown key for R10 and isWithinCooldown)
+        recordWakeIntent(db, tickId, subject, wb.belief_id, evidence);
+
+        ran.push({
+          subject,
+          reason,
+          evidence,
+          beliefId: wb.belief_id,
+        });
+      } catch (subjectErr) {
+        errors.push({ subject, err: String(subjectErr?.message ?? subjectErr) });
+      }
+    }
+  } catch (err) {
+    errors.push({ phase: "outer", err: String(err?.message ?? err) });
+  }
+
+  return { ran, cooled, errors: errors.length ? errors : undefined };
+}
+
+// ── extractShortId — resolve the bg_job_id / short_id for a subject ──────
+// subject is "TICKET/phase". We join obs_signal → obs_agent to get the
+// short_id that 'claude logs <shortId>' accepts.
+function extractShortId(db, tickId, subject) {
+  const [ticket, phase] = subject.split("/");
+  if (!ticket || !phase) return subject;
+
+  // Try obs_signal first (bg_job_id is already the short_id in the schema)
+  const sigRow = db
+    .query(
+      "SELECT bg_job_id FROM obs_signal WHERE tick_id = ? AND ticket = ? AND phase = ?",
+    )
+    .get(tickId, ticket, phase);
+  return sigRow?.bg_job_id ?? subject;
+}

--- a/plugins/dev/scripts/execution-core/diagnostician.test.mjs
+++ b/plugins/dev/scripts/execution-core/diagnostician.test.mjs
@@ -1,0 +1,584 @@
+// diagnostician.test.mjs — CTL-937: TDD tests for the diagnostician wiring.
+//
+// Coverage:
+//  1. wake_diagnostician belief (never-started) → diagnostician runs once,
+//     captures evidence (fake 'claude logs' returns the 'Unknown command'
+//     banner), records the wake intent in beliefs.db
+//  2. Cooldown → does NOT re-run next tick for the same subject
+//  3. Unresolved/ineffective → needs-human applied WITH evidence attached,
+//     NOT before the diagnostician ran
+//  4. Stalled-alive variant (lease_expired + job state="working")
+//  5. Gating flag OFF → no diagnostician runs (pure shadow of the belief)
+//
+// All tests use frozen time (tick rows) and injected fakes — no real process
+// spawning, no real DB on disk, no real 'claude logs' invocation.
+//
+// The diagnostician wiring reads wake_diagnostician beliefs from beliefs.db
+// (the CTL-933/934 SQLite store, already opened by the caller). It does NOT
+// depend on CTL-936's intent reconciler; it reads belief rows directly.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { openBeliefsDb } from "./beliefs/schema.mjs";
+import { evaluateBeliefs } from "./beliefs/rules.mjs";
+import {
+  processDiagnosticianWakes,
+  __resetDiagnosticianForTests,
+} from "./diagnostician.mjs";
+
+// ── frozen time ───────────────────────────────────────────────────────────
+const NOW = 1781030108000; // 2026-06-09T18:35:08Z
+const HOUR = 3_600_000;
+const MIN = 60_000;
+
+// ── test directory management ─────────────────────────────────────────────
+const tmps = [];
+function scratch() {
+  const d = mkdtempSync(join(tmpdir(), "ctl937-diag-"));
+  tmps.push(d);
+  return d;
+}
+
+let db;
+beforeEach(() => {
+  db = openBeliefsDb({ path: join(scratch(), "b.db") });
+  __resetDiagnosticianForTests();
+});
+afterEach(() => {
+  try {
+    db.close();
+  } catch {
+    /* already closed */
+  }
+  while (tmps.length) {
+    try {
+      rmSync(tmps.pop(), { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+});
+
+// ── fixture builders (mirror rules.test.mjs patterns) ────────────────────
+function insertTick(now = NOW, host = "mini") {
+  db.run("INSERT INTO tick (now_ms, host) VALUES (?, ?)", [now, host]);
+  return db.query("SELECT last_insert_rowid() AS id").get().id;
+}
+function insertSignal(tickId, o) {
+  db.run(
+    `INSERT INTO obs_signal (tick_id, ticket, phase, status, bg_job_id, generation, started_at_ms, updated_at_ms)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      tickId,
+      o.ticket,
+      o.phase,
+      o.status ?? "running",
+      o.bg_job_id ?? null,
+      o.generation ?? null,
+      o.started_at_ms ?? null,
+      o.updated_at_ms ?? null,
+    ],
+  );
+  return db.query("SELECT last_insert_rowid() AS id").get().id;
+}
+function insertAgent(tickId, o) {
+  db.run(
+    `INSERT INTO obs_agent (tick_id, session_id, short_id, kind, status, state, started_at_ms)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [
+      tickId,
+      o.session_id,
+      o.short_id,
+      o.kind ?? "background",
+      o.status ?? null,
+      o.state ?? null,
+      o.started_at_ms ?? null,
+    ],
+  );
+  return db.query("SELECT last_insert_rowid() AS id").get().id;
+}
+function insertJob(tickId, o) {
+  db.run(
+    `INSERT INTO obs_job (tick_id, bg_job_id, state, tempo, detail, needs, first_terminal_at, exists_flag)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      tickId,
+      o.bg_job_id,
+      o.state ?? null,
+      o.tempo ?? null,
+      o.detail ?? null,
+      o.needs ?? null,
+      o.first_terminal_at ?? null,
+      o.exists_flag ?? 1,
+    ],
+  );
+  return db.query("SELECT last_insert_rowid() AS id").get().id;
+}
+function insertHeartbeat(o) {
+  db.run(
+    "INSERT INTO obs_heartbeat (ticket, phase, generation, kind, ts_ms) VALUES (?, ?, ?, ?, ?)",
+    [o.ticket, o.phase, o.generation ?? null, o.kind ?? "tool", o.ts_ms],
+  );
+  return db.query("SELECT last_insert_rowid() AS id").get().id;
+}
+
+// Seed a tick such that R4 (wedged_never_started) fires for CTL-T1/plan.
+// Signal running for >never_started_ms (default 2min); agent registered; no
+// transcript; job not terminal. Returns { tickId, bgJobId, sessionId, shortId }.
+function seedNeverStartedTick({ now = NOW, ticket = "CTL-T1", phase = "plan" } = {}) {
+  const bgJobId = `abc${ticket.replace(/\W/g, "")}`;
+  const sessionId = `${bgJobId}-session`;
+  const shortId = bgJobId.slice(0, 8);
+  const tickId = insertTick(now);
+  // Signal started 10 min ago — well past never_started_ms (120s)
+  insertSignal(tickId, {
+    ticket,
+    phase,
+    bg_job_id: shortId,
+    started_at_ms: now - 10 * MIN,
+    updated_at_ms: now - 10 * MIN,
+  });
+  // Agent registered as background, state blocked
+  insertAgent(tickId, {
+    session_id: sessionId,
+    short_id: shortId,
+    kind: "background",
+    state: "blocked",
+  });
+  // Job exists, state=working, tempo=blocked (the 2026-06-09 class)
+  insertJob(tickId, {
+    bg_job_id: shortId,
+    state: "working",
+    tempo: "blocked",
+    detail: "stuck on a startup dialog",
+    needs: "open this session to continue setup",
+  });
+  // No transcript → R2 (turn_started) will NOT fire → R4 fires
+  evaluateBeliefs(db, tickId);
+  return { tickId, bgJobId: shortId, sessionId, shortId, ticket, phase };
+}
+
+// Seed a tick such that R10b (stalled-alive / lease_expired + job working) fires.
+// Signal has progress evidence (stale), transcript EXISTS (so R4 never-started
+// does NOT fire — agent started its turn), lease is expired (stale evidence).
+// R10b fires: lease_expired AND job.state="working" AND NOT wake_diagnostician yet.
+function seedStalledAliveTick({ now = NOW, ticket = "CTL-T2", phase = "implement" } = {}) {
+  const bgJobId = `xyz${ticket.replace(/\W/g, "")}`;
+  const shortId = bgJobId.slice(0, 8);
+  const sessionId = `${shortId}-sess`;
+  const tickId = insertTick(now);
+  // Signal running; progress evidence is 2 hours stale (build window is 30min)
+  insertSignal(tickId, {
+    ticket,
+    phase,
+    bg_job_id: shortId,
+    started_at_ms: now - 3 * HOUR,
+    updated_at_ms: now - 2 * HOUR,
+  });
+  insertAgent(tickId, {
+    session_id: sessionId,
+    short_id: shortId,
+    kind: "background",
+    state: "blocked",
+  });
+  insertJob(tickId, {
+    bg_job_id: shortId,
+    state: "working",
+    tempo: "blocked",
+  });
+  // Transcript EXISTS → R2 (turn_started) fires → R4 (wedged_never_started) does NOT fire
+  // This ensures R10b (stalled-alive) fires instead of R10a (never-started)
+  db.run(
+    "INSERT INTO obs_transcript (tick_id, session_id, exists_flag, mtime_ms, bytes) VALUES (?, ?, ?, ?, ?)",
+    [tickId, sessionId, 1, now - 2 * HOUR, 1234],
+  );
+  // Heartbeat exists but is stale (> lease_window_build_ms = 30min)
+  insertHeartbeat({ ticket, phase, ts_ms: now - 2 * HOUR });
+  evaluateBeliefs(db, tickId);
+  return { tickId, bgJobId: shortId, shortId, ticket, phase };
+}
+
+// Helper: read all intent rows for a given kind+subject
+function getIntents(kind, subject) {
+  return db.query("SELECT * FROM intent WHERE kind = ? AND subject = ?").all(kind, subject);
+}
+
+// Helper: seed a prior wake-diagnostician intent for a subject (simulates
+// cooldown: a previous tick fired and recorded the intent)
+function seedPriorIntent(subject, priorNowMs = NOW - 5 * MIN) {
+  const priorTickId = insertTick(priorNowMs);
+  db.run(
+    "INSERT INTO intent (tick_id, kind, subject, attempts, outcome) VALUES (?, ?, ?, ?, ?)",
+    [priorTickId, "wake-diagnostician", subject, 1, null],
+  );
+}
+
+// ── Fake evidence-capture that simulates 'claude logs <id>' returning
+// the "Unknown command" banner (the 2026-06-09 wedge signature).
+function fakeCaptureLogs(shortId) {
+  return `⏺ Unknown command: /catalyst-dev:phase-plan\n⏺ Args from unknown skill: CTL-T1 --orch-dir /home/user/catalyst\nCtx: 0\n`;
+}
+
+// Fake job-state reader (no disk access)
+function fakeReadJobState(bgJobId) {
+  return {
+    exists: true,
+    state: "working",
+    tempo: "blocked",
+    detail: "stuck on a startup dialog",
+    needs: "open this session to continue setup",
+  };
+}
+
+// ── TESTS ─────────────────────────────────────────────────────────────────
+
+describe("gating flag OFF", () => {
+  test("no diagnostician runs when CATALYST_DIAGNOSTICIAN is unset", () => {
+    const { tickId, shortId, ticket, phase } = seedNeverStartedTick();
+    const subject = `${ticket}/${phase}`;
+
+    // Confirm belief exists (shadow layer works)
+    const wakeBeliefs = db
+      .query("SELECT * FROM belief WHERE name = 'wake_diagnostician'")
+      .all();
+    expect(wakeBeliefs.length).toBeGreaterThan(0);
+
+    // Run without the env flag set
+    const result = processDiagnosticianWakes(db, tickId, {
+      env: {},
+      captureLogs: fakeCaptureLogs,
+      readJobState: fakeReadJobState,
+      applyNeedsHuman: () => {},
+    });
+
+    expect(result.skipped).toBe("disabled");
+    expect(result.ran).toBeUndefined();
+    // No intent recorded when gated off
+    const intents = getIntents("wake-diagnostician", subject);
+    expect(intents).toHaveLength(0);
+  });
+
+  test("no diagnostician runs when CATALYST_DIAGNOSTICIAN=0", () => {
+    const { tickId, ticket, phase } = seedNeverStartedTick();
+    const result = processDiagnosticianWakes(db, tickId, {
+      env: { CATALYST_DIAGNOSTICIAN: "0" },
+      captureLogs: fakeCaptureLogs,
+      readJobState: fakeReadJobState,
+      applyNeedsHuman: () => {},
+    });
+    expect(result.skipped).toBe("disabled");
+  });
+});
+
+describe("never-started wake → diagnostician runs once, captures evidence", () => {
+  test("processes a wake_diagnostician(never-started) belief and records intent", () => {
+    const { tickId, shortId, ticket, phase } = seedNeverStartedTick();
+    const subject = `${ticket}/${phase}`;
+
+    const captured = [];
+    const result = processDiagnosticianWakes(db, tickId, {
+      env: { CATALYST_DIAGNOSTICIAN: "1" },
+      captureLogs: (id) => {
+        captured.push(id);
+        return fakeCaptureLogs(id);
+      },
+      readJobState: fakeReadJobState,
+      applyNeedsHuman: () => {},
+    });
+
+    // One diagnostician ran
+    expect(result.ran).toHaveLength(1);
+    expect(result.ran[0].subject).toBe(subject);
+    expect(result.ran[0].reason).toBe("never-started");
+
+    // Captured the 'claude logs' output for the short ID
+    expect(captured).toContain(shortId);
+
+    // Evidence is in the result
+    const ev = result.ran[0].evidence;
+    expect(ev.logsOutput).toContain("Unknown command");
+    expect(ev.jobState.state).toBe("working");
+    expect(ev.jobState.tempo).toBe("blocked");
+
+    // Wake-diagnostician intent recorded in beliefs.db (the cooldown guard key)
+    const intents = getIntents("wake-diagnostician", subject);
+    expect(intents).toHaveLength(1);
+    expect(intents[0].attempts).toBe(1);
+    // Intent carries the postcondition for the reconciler
+    expect(intents[0].postcondition).toBeTruthy();
+  });
+
+  test("exactly one wake intent is created per subject (not one per belief row)", () => {
+    // Two ticks with beliefs for the same subject — only one intent expected
+    const { tickId, ticket, phase } = seedNeverStartedTick({ now: NOW });
+    const subject = `${ticket}/${phase}`;
+
+    // Second tick with the same subject (simulates the same worker on next tick)
+    const tickId2 = insertTick(NOW + 30 * 1000);
+    insertSignal(tickId2, {
+      ticket,
+      phase,
+      bg_job_id: "abcCTLT1",
+      started_at_ms: NOW - 10 * MIN,
+      updated_at_ms: NOW - 10 * MIN,
+    });
+    insertAgent(tickId2, { session_id: "abcCTLT1-session", short_id: "abcCTLT1", kind: "background" });
+    insertJob(tickId2, { bg_job_id: "abcCTLT1", state: "working", tempo: "blocked" });
+    evaluateBeliefs(db, tickId2);
+
+    // Run on tick 1 → intent created
+    processDiagnosticianWakes(db, tickId, {
+      env: { CATALYST_DIAGNOSTICIAN: "1" },
+      captureLogs: fakeCaptureLogs,
+      readJobState: fakeReadJobState,
+      applyNeedsHuman: () => {},
+    });
+    const intentsAfterTick1 = getIntents("wake-diagnostician", subject);
+    expect(intentsAfterTick1).toHaveLength(1);
+  });
+});
+
+describe("cooldown — does NOT re-run next tick for the same subject", () => {
+  test("skips subject when a recent wake-diagnostician intent exists within cooldown window", () => {
+    const { tickId, ticket, phase } = seedNeverStartedTick({ now: NOW });
+    const subject = `${ticket}/${phase}`;
+
+    // Simulate a prior intent (5 min ago — within 10min cooldown)
+    seedPriorIntent(subject, NOW - 5 * MIN);
+
+    const captured = [];
+    const result = processDiagnosticianWakes(db, tickId, {
+      env: { CATALYST_DIAGNOSTICIAN: "1" },
+      captureLogs: (id) => {
+        captured.push(id);
+        return fakeCaptureLogs(id);
+      },
+      readJobState: fakeReadJobState,
+      applyNeedsHuman: () => {},
+    });
+
+    // No new diagnostician runs (cooldown guards it)
+    expect(result.ran ?? []).toHaveLength(0);
+    expect(result.cooled).toBeDefined();
+    expect(result.cooled).toContain(subject);
+
+    // 'claude logs' was NOT invoked
+    expect(captured).toHaveLength(0);
+
+    // No new intent created (still just the one from before)
+    const intents = getIntents("wake-diagnostician", subject);
+    expect(intents).toHaveLength(1); // the seeded prior only
+  });
+
+  test("runs when prior intent is OUTSIDE the cooldown window", () => {
+    const { tickId, ticket, phase } = seedNeverStartedTick({ now: NOW });
+    const subject = `${ticket}/${phase}`;
+
+    // Prior intent is 15 min ago — outside the 10min cooldown
+    seedPriorIntent(subject, NOW - 15 * MIN);
+
+    const captured = [];
+    const result = processDiagnosticianWakes(db, tickId, {
+      env: { CATALYST_DIAGNOSTICIAN: "1" },
+      captureLogs: (id) => {
+        captured.push(id);
+        return fakeCaptureLogs(id);
+      },
+      readJobState: fakeReadJobState,
+      applyNeedsHuman: () => {},
+    });
+
+    // Diagnostician ran because the prior intent is expired
+    expect(result.ran).toHaveLength(1);
+    expect(captured).toHaveLength(1);
+    // A new intent was recorded
+    const intents = getIntents("wake-diagnostician", subject);
+    expect(intents).toHaveLength(2); // old + new
+  });
+});
+
+describe("stalled-alive variant", () => {
+  test("processes a wake_diagnostician(stalled-alive) belief", () => {
+    const { tickId, shortId, ticket, phase } = seedStalledAliveTick();
+    const subject = `${ticket}/${phase}`;
+
+    // Confirm R10b fired (stalled-alive)
+    const stalledBelief = db
+      .query(
+        "SELECT * FROM belief WHERE name = 'wake_diagnostician' AND subject = ?",
+      )
+      .get(subject);
+    expect(stalledBelief).toBeTruthy();
+    expect(JSON.parse(stalledBelief.value).reason).toBe("stalled-alive");
+
+    const captured = [];
+    const result = processDiagnosticianWakes(db, tickId, {
+      env: { CATALYST_DIAGNOSTICIAN: "1" },
+      captureLogs: (id) => {
+        captured.push(id);
+        return "stalled output";
+      },
+      readJobState: fakeReadJobState,
+      applyNeedsHuman: () => {},
+    });
+
+    expect(result.ran).toHaveLength(1);
+    expect(result.ran[0].reason).toBe("stalled-alive");
+    expect(result.ran[0].evidence.logsOutput).toBe("stalled output");
+
+    const intents = getIntents("wake-diagnostician", subject);
+    expect(intents).toHaveLength(1);
+    expect(intents[0].outcome).toBeNull(); // unresolved → reconciler decides later
+  });
+});
+
+describe("second-line escalation — needs-human only AFTER diagnostician ran", () => {
+  test("needs-human NOT called on first wake (diagnostician just ran)", () => {
+    const { tickId, ticket, phase } = seedNeverStartedTick();
+    const subject = `${ticket}/${phase}`;
+
+    const humanCalls = [];
+    processDiagnosticianWakes(db, tickId, {
+      env: { CATALYST_DIAGNOSTICIAN: "1" },
+      captureLogs: fakeCaptureLogs,
+      readJobState: fakeReadJobState,
+      applyNeedsHuman: (s, ev) => humanCalls.push({ s, ev }),
+    });
+
+    // Diagnostician ran but has not yet been deemed ineffective → no human paged
+    expect(humanCalls).toHaveLength(0);
+  });
+
+  test("needs-human called WITH evidence when wake action is ineffective (attempts >= max_attempts)", () => {
+    const { tickId, ticket, phase } = seedNeverStartedTick({ now: NOW });
+    const subject = `${ticket}/${phase}`;
+
+    // Simulate the diagnostician ran before (prior intent, max_attempts reached)
+    // R11 (action_ineffective) fires when attempts >= max_attempts (default: 2)
+    // We seed an intent that has max_attempts attempts with no outcome.
+    const priorTickId = insertTick(NOW - 15 * MIN);
+    db.run(
+      "INSERT INTO intent (tick_id, kind, subject, attempts, outcome, postcondition) VALUES (?, ?, ?, ?, ?, ?)",
+      [priorTickId, "wake-diagnostician", subject, 2, null, "diagnostician_ran"],
+    );
+
+    // Now also evaluate beliefs for the prior tick so R11 can fire
+    // (R11 is computed over the intent table across all ticks — it uses
+    // the CURRENT tick's belief evaluation, not a past tick's)
+    // The current tick already has wake_diagnostician; we re-run evaluation
+    // to pick up R11 + R12 for the current tickId
+    // (evaluateBeliefs was already called in seedNeverStartedTick)
+    // We need a fresh tick with R12 derived:
+    const tick2 = insertTick(NOW + 5 * MIN);
+    // Re-seed signal facts for the new tick so R4/R10 fire again
+    insertSignal(tick2, {
+      ticket,
+      phase,
+      bg_job_id: "abcCTLT1",
+      started_at_ms: NOW - 10 * MIN,
+      updated_at_ms: NOW - 10 * MIN,
+    });
+    insertAgent(tick2, { session_id: "abcCTLT1-session", short_id: "abcCTLT1", kind: "background" });
+    insertJob(tick2, { bg_job_id: "abcCTLT1", state: "working", tempo: "blocked" });
+    evaluateBeliefs(db, tick2);
+
+    // Confirm R12 escalate_human fired for tick2
+    const humanBelief = db
+      .query("SELECT * FROM belief WHERE name = 'escalate_human' AND tick_id = ?")
+      .get(tick2);
+    expect(humanBelief).toBeTruthy();
+
+    // Run processDiagnosticianWakes on tick2 — now the intent is "ineffective"
+    // and R12 is present; needs-human should fire WITH evidence
+    const humanCalls = [];
+    const result = processDiagnosticianWakes(db, tick2, {
+      env: { CATALYST_DIAGNOSTICIAN: "1" },
+      captureLogs: fakeCaptureLogs,
+      readJobState: fakeReadJobState,
+      applyNeedsHuman: (s, ev) => humanCalls.push({ s, ev }),
+    });
+
+    // needs-human fired for the subject with evidence attached
+    expect(humanCalls).toHaveLength(1);
+    expect(humanCalls[0].s).toBe(subject);
+    expect(humanCalls[0].ev).toBeDefined();
+    // Evidence carries what the diagnostician captured
+    expect(humanCalls[0].ev.reason).toBeDefined();
+  });
+
+  test("needs-human carries the diagnostician evidence, not a bare label", () => {
+    const { ticket, phase } = seedNeverStartedTick({ now: NOW });
+    const subject = `${ticket}/${phase}`;
+
+    // Seed a maxed-out intent + second tick with R12
+    const priorTickId = insertTick(NOW - 15 * MIN);
+    db.run(
+      "INSERT INTO intent (tick_id, kind, subject, attempts, outcome, postcondition) VALUES (?, ?, ?, ?, ?, ?)",
+      [priorTickId, "wake-diagnostician", subject, 2, null, "diagnostician_ran"],
+    );
+    const tick2 = insertTick(NOW + 5 * MIN);
+    insertSignal(tick2, {
+      ticket,
+      phase,
+      bg_job_id: "abcCTLT1",
+      started_at_ms: NOW - 10 * MIN,
+      updated_at_ms: NOW - 10 * MIN,
+    });
+    insertAgent(tick2, { session_id: "abcCTLT1-session", short_id: "abcCTLT1", kind: "background" });
+    insertJob(tick2, { bg_job_id: "abcCTLT1", state: "working", tempo: "blocked" });
+    evaluateBeliefs(db, tick2);
+
+    const humanCalls = [];
+    processDiagnosticianWakes(db, tick2, {
+      env: { CATALYST_DIAGNOSTICIAN: "1" },
+      captureLogs: () => "⏺ Unknown command: /catalyst-dev:phase-implement",
+      readJobState: fakeReadJobState,
+      applyNeedsHuman: (s, ev) => humanCalls.push({ s, ev }),
+    });
+
+    expect(humanCalls).toHaveLength(1);
+    const { ev } = humanCalls[0];
+    // Evidence must carry diagnostic information (not just the subject)
+    expect(ev).toHaveProperty("reason");
+    expect(ev).toHaveProperty("logsOutput");
+    expect(ev.logsOutput).toContain("Unknown command");
+    expect(ev).toHaveProperty("jobState");
+  });
+});
+
+describe("multiple subjects in one tick", () => {
+  test("processes each fresh wake_diagnostician belief independently", () => {
+    // Seed two different stuck workers on the same tick
+    const t1 = seedNeverStartedTick({ ticket: "CTL-A", phase: "plan" });
+    // For the second subject, use the SAME tickId but add more facts
+    const tickId = insertTick(NOW + 1);
+    insertSignal(tickId, {
+      ticket: "CTL-B",
+      phase: "implement",
+      bg_job_id: "bbbshort",
+      started_at_ms: NOW - 10 * MIN,
+      updated_at_ms: NOW - 10 * MIN,
+    });
+    insertAgent(tickId, { session_id: "bbbshort-sess", short_id: "bbbshort", kind: "background" });
+    insertJob(tickId, { bg_job_id: "bbbshort", state: "working", tempo: "blocked" });
+    evaluateBeliefs(db, tickId);
+
+    const captured = [];
+    const result = processDiagnosticianWakes(db, tickId, {
+      env: { CATALYST_DIAGNOSTICIAN: "1" },
+      captureLogs: (id) => {
+        captured.push(id);
+        return `logs for ${id}`;
+      },
+      readJobState: fakeReadJobState,
+      applyNeedsHuman: () => {},
+    });
+
+    // CTL-B/implement processed on tickId
+    expect(result.ran).toHaveLength(1);
+    expect(result.ran[0].subject).toBe("CTL-B/implement");
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -71,7 +71,10 @@ import { getProjectConfig, listProjects } from "./registry.mjs";
 // presweep + non-force `git worktree remove`) in phase-teardown/SKILL.md.
 import { readWorkerSignals } from "./signal-reader.mjs";
 // CTL-933: shadow belief-store fact collector (opt-in CATALYST_BELIEFS_SHADOW=1).
-import { collectBeliefsTick } from "./beliefs/collector.mjs";
+// CTL-937: getBeliefsDb exposes the module-level db handle for the diagnostician.
+import { collectBeliefsTick, getBeliefsDb } from "./beliefs/collector.mjs";
+// CTL-937: bounded stall-diagnostician wake wiring (opt-in CATALYST_DIAGNOSTICIAN=1).
+import { processDiagnosticianWakes } from "./diagnostician.mjs";
 // CTL-642/758: the live PR-merged adapter. makePrView is the single gh
 // `pr view` source of truth (shared with the scan CLI's makeScanAdapters), so
 // the daemon's recovery short-circuit + reconcile backstop run the identical
@@ -3403,7 +3406,26 @@ function runTick() {
     }
     // CTL-933: record this tick's liveness observations BEFORE the decisions run
     // (write-only shadow; own try/catch inside — never throws, never gates).
-    collectBeliefsTick({ orchDir: runningOpts.orchDir, linearCache: runningOpts.cache });
+    const beliefsRes = collectBeliefsTick({ orchDir: runningOpts.orchDir, linearCache: runningOpts.cache });
+    // CTL-937: bounded stall-diagnostician wake wiring (opt-in CATALYST_DIAGNOSTICIAN=1).
+    // Reads wake_diagnostician beliefs for the current tick from the shared beliefs.db
+    // handle (same connection — no second db open). Never throws. Only activates
+    // when CATALYST_BELIEFS_SHADOW=1 (collector opened the db) AND
+    // CATALYST_DIAGNOSTICIAN=1 (diagnostician gate).
+    if (beliefsRes?.ok && beliefsRes?.tickId != null) {
+      try {
+        const diagDb = getBeliefsDb();
+        if (diagDb) {
+          processDiagnosticianWakes(diagDb, beliefsRes.tickId);
+        }
+      } catch (diagErr) {
+        try {
+          log.warn({ err: diagErr?.message }, "diagnostician: wake processing threw (tick unaffected)");
+        } catch {
+          /* even logging must not break the tick */
+        }
+      }
+    }
     schedulerTick(runningOpts.orchDir, {
       readEligible: runningOpts.readEligible,
       dispatch: runningOpts.dispatch,


### PR DESCRIPTION
## Summary

- **Wire R10 `wake_diagnostician` beliefs** to a deterministic evidence-collector that runs each scheduler tick for stuck workers the daemon can't classify (never-started, stalled-alive)
- **Evidence capture**: `claude logs <shortId>` (the rendered screen buffer — this single command revealed the "Unknown command" banner that was the 2026-06-09 root cause) + full job `state.json` fields (`tempo`/`detail`/`needs`) that the daemon never read even though they contained the diagnosis
- **Second-line ordering enforced**: `needs-human` fires only when R12 `escalate_human` fires AND the prior `wake-diagnostician` intent is ineffective (≥2 attempts, no outcome) — carrying the captured evidence envelope, not a bare label
- **No-storm by construction**: cooldown is enforced via the `intent` table (R10's `not recent_intent` guard + `isWithinCooldown` at execution time), so wake storms are structurally impossible
- **Ships dark**: `CATALYST_DIAGNOSTICIAN=1` required; default OFF. The collector gate (`CATALYST_BELIEFS_SHADOW=1`) must also be on for the db to be open

## Design choice: deterministic evidence-collector (v1), not a full LLM agent

The v1 is a deterministic evidence-collector rather than spawning a full LLM agent (CTL-828 spec). Rationale:

1. The primary gap Appendix 2 identified is that the evidence exists on disk but is never captured — the `claude logs` output and full `state.json` fields are the diagnosis, not the LLM interpretation of them
2. Wake storm risk: R10's cooldown guard is not yet proven in production; a bounded evidence-capture is safer for the first ship
3. The interface (`captureLogs`/`readJobState` injectable fakes) makes the upgrade to a full LLM agent (CTL-828) non-breaking
4. The intent/cooldown machinery is identical in both versions — CTL-828 replaces `captureEvidence()` body, not the wiring

## Files

- `plugins/dev/scripts/execution-core/diagnostician.mjs` — `processDiagnosticianWakes()` entry point
- `plugins/dev/scripts/execution-core/diagnostician.test.mjs` — 11 TDD tests (frozen time, injected fakes)
- `plugins/dev/scripts/execution-core/beliefs/collector.mjs` — `getBeliefsDb()` export for shared handle
- `plugins/dev/scripts/execution-core/scheduler.mjs` — wiring after `collectBeliefsTick`

## Test plan

- [x] `bun test diagnostician.test.mjs` — 11 tests: gating flag OFF, never-started wake, cooldown guards, stalled-alive variant, second-line escalation ordering, evidence contents
- [x] `bun test beliefs/` — 69 existing belief-store tests (no regressions)
- [x] `bun test beliefs/collector.test.mjs` — 28 collector tests pass with `getBeliefsDb` added
- [x] `bun scheduler.mjs` — scheduler loads and parses without error after import additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)