### PR TITLE
fix(dev): wire applyNeedsHuman in scheduler + clean up dead code in diagnostician (CTL-937)

### DIFF
--- a/plugins/dev/scripts/execution-core/diagnostician.mjs
+++ b/plugins/dev/scripts/execution-core/diagnostician.mjs
@@ -58,10 +58,10 @@
 
 import { execSync } from "node:child_process";
 
-// ── module-level state (reset hook for tests) ─────────────────────────────
-let _capturedThisBoot = new Set(); // de-dup within a single tick across calls
+// ── test reset hook (no-op: the boot-level de-dup set was removed in CTL-937 fix
+// after review found it was declared but never .add()ed or .has()-checked)
 export function __resetDiagnosticianForTests() {
-  _capturedThisBoot = new Set();
+  /* no-op — retained for test import compatibility */
 }
 
 // ── captureEvidence — deterministic evidence-collector (v1) ──────────────
@@ -133,7 +133,9 @@ function isWithinCooldown(db, subject, nowMs) {
 
 // ── recordWakeIntent — inserts a wake-diagnostician intent row.
 // This is what R10's "not recent_intent" check reads across ticks.
-function recordWakeIntent(db, tickId, subject, beliefId, evidence) {
+// Evidence is NOT stored here: the intent table has no evidence column.
+// CTL-828 (LLM diagnostician) should add evidence_json to the schema.
+function recordWakeIntent(db, tickId, subject, beliefId) {
   db.run(
     `INSERT INTO intent (tick_id, kind, subject, belief_id, postcondition, attempts, outcome)
      VALUES (?, ?, ?, ?, ?, ?, ?)`,
@@ -261,7 +263,7 @@ export function processDiagnosticianWakes(db, tickId, opts = {}) {
         evidence.reason = reason;
 
         // ── record wake intent (the cooldown key for R10 and isWithinCooldown)
-        recordWakeIntent(db, tickId, subject, wb.belief_id, evidence);
+        recordWakeIntent(db, tickId, subject, wb.belief_id);
 
         ran.push({
           subject,

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -3416,7 +3416,17 @@ function runTick() {
       try {
         const diagDb = getBeliefsDb();
         if (diagDb) {
-          processDiagnosticianWakes(diagDb, beliefsRes.tickId);
+          processDiagnosticianWakes(diagDb, beliefsRes.tickId, {
+            // Wire R12 escalation: apply needs-human via the scheduler's
+            // idempotent labelOnce so the once-marker and Linear label stay
+            // in sync with all other escalation paths. Subject is TICKET/phase.
+            applyNeedsHuman: (subject, _evidence) => {
+              const ticket = subject.split("/")[0];
+              if (ticket) {
+                labelOnce(runningOpts.orchDir, ticket, "needs-human", runningOpts.writeStatus);
+              }
+            },
+          });
         }
       } catch (diagErr) {
         try {


### PR DESCRIPTION
## Summary

Post-merge review (adversarial findings) for CTL-937 (#1641, merged 410a3acd):

- **MEDIUM fixed**: `processDiagnosticianWakes` was called without `opts` in `scheduler.mjs`, so `opts.applyNeedsHuman?.()` silently no-oped via optional-chaining. R12 escalation captured evidence and threw it away every cooldown cycle. Now wired: extracts ticket from `subject` (`TICKET/phase`), calls `labelOnce(orchDir, ticket, "needs-human", writeStatus)` — the same idempotent path as all other escalation paths.

- **LOW fixed**: `_capturedThisBoot` was declared, reset (via `__resetDiagnosticianForTests`), and never `.add()`ed or `.has()`-checked. Dead Set removed. `__resetDiagnosticianForTests` kept as a no-op export to avoid breaking test imports.

- **LOW fixed**: `recordWakeIntent(db, tickId, subject, beliefId, evidence)` — `evidence` was accepted but the `intent` table has no `evidence` column. Value was silently dropped. Parameter removed; comment added pointing at CTL-828 for the schema addition.

## Test plan

- [x] All 11 diagnostician tests pass
- [x] All 69 beliefs suite tests pass
- [x] Finding 1 (applyNeedsHuman dead wiring) verified against the post-merge `origin/main` scheduler.mjs before fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)