### PR TITLE
fix(dev): detail page fills full viewport height — no white gap (CTL-949)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/nav-signal-ui.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/nav-signal-ui.test.ts
@@ -85,7 +85,8 @@ describe("nav-signal UI contract (CTL-896 / SHELL6)", () => {
   describe("app-sidebar wiring (static source analysis)", () => {
     it("consumes the live nav signal hook (no more mock badges)", () => {
       expect(sidebarCode).toContain("useNavSignal");
-      expect(sidebarCode).toContain("const nav = useNavSignal()");
+      // CTL-930 refactored to context-based hook; accept either form
+      expect(sidebarCode).toMatch(/const nav = useNavSignal(?:Context)?\(\)/);
     });
 
     it("no longer hardcodes the mock badge numbers 4 / 7", () => {

--- a/plugins/dev/scripts/orch-monitor/ui/board.html
+++ b/plugins/dev/scripts/orch-monitor/ui/board.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Catalyst · Board</title>
+    <!-- CTL-949: full-height chain so detail routes fill the viewport.
+         html/body/#board-root must all be 100% for Shell's height:100% to reach the
+         viewport; body gets the dark app background so no white gap shows beneath
+         short content while the React tree mounts. -->
+    <style data-ctl-949-height-guard>
+      html, body, #board-root { height: 100%; }
+      body { background: #0e1116; }
+    </style>
   </head>
   <body>
     <div id="board-root"></div>

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Shell.tsx
@@ -458,12 +458,18 @@ export function Shell({
   const footerContext = breadcrumbText(breadcrumbCtx);
 
   return (
+    // CTL-949: `minHeight: "100vh"` is the viewport-fill safety net for deep-links
+    // (where the parent height chain may not be 100%). `height: "100%"` fills the
+    // container when the chain IS wired (board.html establishes html/body/#board-root
+    // at 100%); the two rules together mean the shell always fills at least the
+    // full viewport without capping shorter-than-viewport content.
     <div
       data-detail-shell={kind}
       style={{
         display: "flex",
         flexDirection: "column",
         height: "100%",
+        minHeight: "100vh",
         background: C.s0,
         color: C.fg,
         overflow: "hidden",


### PR DESCRIPTION
## Summary

- `board.html` was missing the `html, body, #board-root { height: 100%; }` chain that `index.html` establishes. Without it, `Shell`'s `height: 100%` has no resolved parent height and the dark detail surface doesn't extend to the bottom of the viewport — the browser's default white body shows below the content.
- Added a guarded `<style data-ctl-949-height-guard>` block in `board.html` with the full height chain and a matching dark body background (`#0e1116` = `--color-surface-0`) to prevent any white flash while the React tree mounts.
- Added `minHeight: 100vh` on the `Shell` root div as a belt-and-suspenders safety net for deep-link navigations where the height chain may not be present.

## Test plan

- [ ] Navigate to `/ticket/$id` — dark detail page fills the full viewport, no white area below
- [ ] Navigate to `/worker/$id` — same: no white gap
- [ ] Navigate to `/` (board) — board layout unchanged, no regression
- [ ] Inspect `board.html`: `<style data-ctl-949-height-guard>` block present
- [ ] `bun test` — 308 pass, 0 fail
- [ ] `bunx tsc --noEmit` — no new errors beyond pre-existing `kpi-strip.tsx` issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)