### PR TITLE
feat(dev): queue — group workers by all activity states, blocked pinned bottom with blockers (CTL-947)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/list-order.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/list-order.test.ts
@@ -104,9 +104,17 @@ function legacyTicketFilter(
     ? tickets.filter((t) => t.linearState === col)
     : tickets.filter((t) => t.phase === col);
 }
+// CTL-947: the new rank is active=0 / waiting-on-user=1 / waiting(null)=2 /
+// stuck=3 / blocked=4. The "legacy sort" is updated to match; rankWorker also
+// takes an optional ticketHeld param (absent = no blocked override).
 function legacyWorkerSort(workers: BoardWorker[]): BoardWorker[] {
   const isActive = (s: BoardActiveState) => s === "active";
-  const rank = (w: BoardWorker) => (isActive(w.activeState) ? 0 : w.activeState === "stuck" ? 2 : 1);
+  const rank = (w: BoardWorker) => {
+    if (isActive(w.activeState) && !w.waitingOnUser) return 0;
+    if (w.waitingOnUser) return 1;
+    if (w.activeState === "stuck") return 3;
+    return 2; // null / idle / between-phases
+  };
   return [...workers].sort((a, b) => rank(a) - rank(b) || (b.runtimeMs ?? 0) - (a.runtimeMs ?? 0));
 }
 
@@ -172,12 +180,12 @@ describe("resolveList — worker queue (rank-sort preserved through the same fn)
   ];
   const payload = mkPayload({ workers });
 
-  it("orders by rank then runtimeMs desc", () => {
+  it("orders by rank then runtimeMs desc — CTL-947: active→waiting(null)→stuck", () => {
     const got = resolveList(payload, { kind: "worker" });
     expect(got.map((w) => w.name)).toEqual([
       "w-active-long", // active, 8000
       "w-active-short", // active, 1000
-      "w-idle", // else, 9000
+      "w-idle", // waiting(null), 9000
       "w-stuck-long", // stuck, 9999
       "w-stuck", // stuck, 5000
     ]);
@@ -188,10 +196,20 @@ describe("resolveList — worker queue (rank-sort preserved through the same fn)
     expect(got).toEqual(legacyWorkerSort(workers));
   });
 
-  it("rankWorker matches active=0 / stuck=2 / else=1", () => {
+  it("rankWorker matches CTL-947 ranks: active=0 / null(waiting)=2 / stuck=3", () => {
     expect(rankWorker(mkWorker("a", "active", 0))).toBe(0);
-    expect(rankWorker(mkWorker("b", null, 0))).toBe(1);
-    expect(rankWorker(mkWorker("c", "stuck", 0))).toBe(2);
+    expect(rankWorker(mkWorker("b", null, 0))).toBe(2); // CTL-947: waiting(null) is rank 2
+    expect(rankWorker(mkWorker("c", "stuck", 0))).toBe(3); // CTL-947: stuck is rank 3
+  });
+
+  it("rankWorker: waitingOnUser=true is rank 1 (between active and idle)", () => {
+    const wou = mkWorker("wou", "active", 0, { waitingOnUser: true });
+    expect(rankWorker(wou)).toBe(1);
+  });
+
+  it("rankWorker: ticketHeld='blocked' yields rank 4 (always last)", () => {
+    const blocked = mkWorker("b", "active", 0);
+    expect(rankWorker(blocked, "blocked")).toBe(4);
   });
 
   it("treats a null runtimeMs as 0 in the tie-break", () => {

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -52,6 +52,11 @@ export interface BoardWorker {
    *  (BFF11) or the phase signal — the value a fence-aware web mutation passes to
    *  isFenceCurrent without a live attachment fetch. null when no fence. */
   generation: number | null;
+  /** CTL-947: true when the worker is parked waiting for a human prompt —
+   *  derived from the durable bg-job state "blocked" (the Claude Code signal
+   *  that the job needs user input / a permission grant). false otherwise.
+   *  Optional so existing BoardWorker fixtures stay valid without back-fill. */
+  waitingOnUser?: boolean;
 }
 
 export interface BoardPhaseCost {

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -97,6 +97,16 @@ export function isBgJobDead(jobState) {
   return bgJobLifecycle(jobState) !== "alive";
 }
 
+// CTL-947: isBgJobWaitingOnUser — true when the DURABLE bg-job state is
+// "blocked", meaning Claude Code paused the job waiting for user input (a
+// permission grant or interactive prompt). This is DISTINCT from "dead" for
+// display purposes: a blocked worker IS excluded from in-flight capacity
+// (isBgJobDead also returns true) but the operator sees it as "waiting on you"
+// rather than a silent zombie. null/absent bgJobState → false (unknown).
+export function isBgJobWaitingOnUser(jobState) {
+  return jobState?.state === "blocked";
+}
+
 // CTL-755 held-indicator labels (admission-control gate). A triaged-waiting
 // ticket the scheduler holds before the triage→research promotion carries one of
 // these Linear labels: `blocked` (≥1 non-terminal blocked_by dependency) or
@@ -816,6 +826,11 @@ export async function assembleBoard() {
       // CTL-922 (BFF10): owning host + fence generation (see above).
       host: deriveHost(workerSigs, fence),
       generation: deriveGeneration(workerSigs, fence),
+      // CTL-947: a worker whose bg-job state is "blocked" is parked waiting for
+      // user input (a permission grant). Surfaced separately from the dead/active
+      // classification so the operator sees a distinct "waiting on you" group
+      // rather than having it silently merge into the zombie corpse bucket.
+      waitingOnUser: isBgJobWaitingOnUser(jobState),
     };
   }));
   // CTL-928: a worker whose durable bg job is dead is NOT in flight. Partition

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
@@ -61,6 +61,14 @@ import {
   groupQueueByHost,
   type QueueHostGroup,
 } from "./queue-grouping";
+// ── CTL-947: in-flight worker activity grouping ────────────────────────────────
+// The in-flight table groups workers by activity state: active / waiting-on-user
+// / waiting / stuck / blocked (bottom). groupWorkersByActivity is PURE (no DOM),
+// unit-tested in queue-worker-grouping.test.ts.
+import {
+  groupWorkersByActivity,
+  type WorkerActivitySection,
+} from "./queue-worker-grouping";
 // ── BOARD2 / CTL-906: the display-options popover + its persisted prefs ────────
 // One toolbar button owns every board display choice (density / grouping /
 // ordering / color / show-empty / repo-lanes). The three scattered subhead Seg
@@ -685,13 +693,34 @@ function WaitingTable({ queue, freeSlots, showHost, grouped }: { queue: QueueIte
 // + a waiting ranked table. NEW for SURF2: an optional per-node column + a
 // group-by-node toggle, both gated behind queueHostMode so a single-host fleet is
 // an exact identity no-op (no node column, no toggle, no added noise).
+// CTL-947: accent color for each activity group section header.
+const WORKER_GROUP_C: Record<string, string> = {
+  active: LIVE,
+  "waiting-on-user": C.yellow,
+  waiting: C.fgDim,
+  stuck: C.red,
+  blocked: C.red,
+};
+
+// CTL-947: status cell text for a worker row.
+function workerStatusText(w: Worker): string {
+  if (isActive(w.activeState)) return w.working ? "working" : "active";
+  if (w.activeState === "stuck") return "stuck";
+  if (w.waitingOnUser) return "waiting on you";
+  return w.activeState ?? "idle";
+}
+
 export function QueueView({ data, embedded = false }: { data: BoardPayload; embedded?: boolean }) {
   const { config, queue, workers, tickets } = data;
   const infoById: Record<string, Ticket> = Object.fromEntries(tickets.map((t) => [t.id, t]));
-  // Order through the SHARED comparator (CTL-882 / FND2): rank(active=0, stuck=2,
-  // else=1) then runtimeMs desc — the same order the worker pager + j/k walk
-  // resolve via resolveList({kind:"worker"}). Byte-for-byte the prior inline sort.
-  const inflight = sortWorkers(workers);
+  // CTL-947: build the ticket held lookup so the grouper can sink blocked tickets.
+  const ticketHeld: Record<string, "blocked" | "waiting" | null | undefined> =
+    Object.fromEntries(tickets.map((t) => [t.id, t.held]));
+  // CTL-947: group in-flight workers by activity state. This replaces the flat
+  // sortWorkers call — groupWorkersByActivity sorts internally using rankWorker
+  // (which now includes waitingOnUser + blocked from the ticket held lookup).
+  const inflightSections: WorkerActivitySection[] = groupWorkersByActivity(workers, ticketHeld);
+  const inflightCount = workers.length;
   // SINGLE-HOST IDENTITY NO-OP: only surface the node column / group affordance
   // when the queue spans two or more DISTINCT owner hosts. With hosts.json absent
   // or length 1 every row resolves to one host (or none), so this is "single" and
@@ -700,6 +729,9 @@ export function QueueView({ data, embedded = false }: { data: BoardPayload; embe
   const [groupByNode, setGroupByNode] = useState(false);
   // The toggle only makes sense in a multi-node fleet; never grouped single-host.
   const grouped = multiHost && groupByNode;
+  // Whether there are multiple non-empty groups (drives section header visibility:
+  // single-group = no chrome, multi-group = show labeled dividers).
+  const multiGroup = inflightSections.length > 1;
   return (
     <div className="cat-scroll" style={{ overflowY: "auto", height: embedded ? "100%" : "calc(var(--cat-board-vh, 100vh) - 104px)", padding: "2px 16px 24px" }}>
       <div style={{ maxWidth: 1040 }}>
@@ -712,7 +744,7 @@ export function QueueView({ data, embedded = false }: { data: BoardPayload; embe
         </div>
         <SlotBar capacity={config.maxParallel} inFlight={config.inFlight} />
 
-        <div style={{ fontSize: 12, fontWeight: 600, color: C.fgMuted, margin: "0 0 8px" }}>On the plate — in flight ({inflight.length})</div>
+        <div style={{ fontSize: 12, fontWeight: 600, color: C.fgMuted, margin: "0 0 8px" }}>On the plate — in flight ({inflightCount})</div>
         <div style={{ border: `1px solid ${C.border}`, borderRadius: 10, overflow: "hidden", marginBottom: 22 }}>
           <Table>
             <TableHeader><TableRow style={{ background: C.s1 }}>
@@ -721,16 +753,47 @@ export function QueueView({ data, embedded = false }: { data: BoardPayload; embe
               <TableHead style={{ ...th, width: 130 }}>Phase</TableHead><TableHead style={{ ...th, width: 84 }}>Status</TableHead><TableHead style={{ ...th, width: 76 }}>Age</TableHead>
             </TableRow></TableHeader>
             <TableBody>
-              {inflight.map((w) => (
-                <TableRow key={w.name} style={{ opacity: w.activeState === "stuck" ? 0.6 : 1 }}>
-                  <TableCell><ActivityDot state={w.activeState} fallback={PHASE_C[w.phase] || C.blue} /></TableCell>
-                  <TableCell><PriorityIcon p={infoById[w.ticket]?.priority ?? 0} /></TableCell>
-                  <TableCell style={{ ...mono, ...td, color: C.blue, fontWeight: 600 }}>{w.ticket}</TableCell>
-                  <TableCell style={{ ...td, ...ellip, maxWidth: 0 }}>{infoById[w.ticket]?.title || ""}</TableCell>
-                  <TableCell><PhasePill phase={w.phase} /></TableCell>
-                  <TableCell style={{ ...mono, fontSize: 11, color: isActive(w.activeState) ? LIVE : w.activeState === "stuck" ? C.red : C.fgDim }}>{isActive(w.activeState) ? (w.working ? "working" : "active") : w.activeState}</TableCell>
-                  <TableCell style={{ ...mono, fontSize: 11, color: C.fgDim }}>{fmtRuntime(w.runtimeMs)}</TableCell>
-                </TableRow>
+              {inflightSections.map((section: WorkerActivitySection) => (
+                <Fragment key={section.group}>
+                  {/* CTL-947: section header row — only rendered when there are
+                      multiple non-empty groups, so a homogenous fleet (all active)
+                      renders exactly as before with no extra chrome. */}
+                  {multiGroup && (
+                    <TableRow style={{ background: C.s1 }}>
+                      <TableCell colSpan={7} style={{ ...mono, fontSize: 11, color: C.fgMuted, padding: "6px 12px" }}>
+                        <span style={{ color: WORKER_GROUP_C[section.group] ?? C.fgDim, fontWeight: 600 }}>{section.label}</span>
+                        <span style={{ color: C.fgDim }}> · {section.workers.length}</span>
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {section.workers.map((w) => {
+                    // CTL-947: blocked rows show the blocker ids inline.
+                    const ticket = infoById[w.ticket];
+                    const blockers: string[] = section.group === "blocked"
+                      ? (ticket?.blockers ?? [])
+                      : [];
+                    return (
+                      <TableRow key={w.name} style={{ opacity: w.activeState === "stuck" ? 0.6 : 1 }}>
+                        <TableCell><ActivityDot state={w.activeState} fallback={PHASE_C[w.phase] || C.blue} /></TableCell>
+                        <TableCell><PriorityIcon p={ticket?.priority ?? 0} /></TableCell>
+                        <TableCell style={{ ...mono, ...td, color: C.blue, fontWeight: 600 }}>{w.ticket}</TableCell>
+                        <TableCell style={{ ...td, ...ellip, maxWidth: 0 }}>
+                          {ticket?.title || ""}
+                          {blockers.length > 0 && (
+                            <span style={{ marginLeft: 8, fontFamily: C.mono, fontSize: 10, color: C.red }}>
+                              blocked on: {blockers.join(", ")}
+                            </span>
+                          )}
+                        </TableCell>
+                        <TableCell><PhasePill phase={w.phase} /></TableCell>
+                        <TableCell style={{ ...mono, fontSize: 11, color: isActive(w.activeState) ? LIVE : w.activeState === "stuck" ? C.red : w.waitingOnUser ? C.yellow : C.fgDim }}>
+                          {workerStatusText(w)}
+                        </TableCell>
+                        <TableCell style={{ ...mono, fontSize: 11, color: C.fgDim }}>{fmtRuntime(w.runtimeMs)}</TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </Fragment>
               ))}
             </TableBody>
           </Table>

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/list-order.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/list-order.ts
@@ -56,12 +56,57 @@ export type ListContext =
 const isActive = (s: BoardActiveState): boolean => s === "active";
 
 /**
- * The worker rank used by the in-flight queue: active (in-loop) first, then
- * everything else, then stuck last. Byte-for-byte the closure from
- * `Board.tsx:441` — `active?0 : stuck?2 : 1`.
+ * CTL-947: the activity group a worker belongs to, for display grouping. The
+ * full ordered set of groups (first → last):
+ *   0 — active       : `activeState === "active"` (in-loop, generating)
+ *   1 — waiting-on-user: live worker parked for a human prompt (`waitingOnUser`)
+ *   2 — waiting      : idle / between-phases (`activeState === null`)
+ *   3 — stuck        : `activeState === "stuck"` (stale transcript / terminal marker)
+ *   4 — blocked      : ticket hold `held === "blocked"` — rendered LAST per spec
+ *
+ * Note: "blocked" is a ticket-level attribute; `workerActivityGroup` takes it as
+ * an optional second argument so the pure grouper can partition without needing
+ * to carry a ticket lookup internally.
  */
-export function rankWorker(w: BoardWorker): number {
-  return isActive(w.activeState) ? 0 : w.activeState === "stuck" ? 2 : 1;
+export type WorkerActivityGroup =
+  | "active"
+  | "waiting-on-user"
+  | "waiting"
+  | "stuck"
+  | "blocked";
+
+const WORKER_GROUP_RANK: Record<WorkerActivityGroup, number> = {
+  active: 0,
+  "waiting-on-user": 1,
+  waiting: 2,
+  stuck: 3,
+  blocked: 4,
+};
+
+/** Map a worker (+ optional ticket held state) to its display activity group. */
+export function workerActivityGroup(
+  w: BoardWorker,
+  ticketHeld?: "blocked" | "waiting" | null,
+): WorkerActivityGroup {
+  if (ticketHeld === "blocked") return "blocked";
+  if (w.activeState === "stuck") return "stuck";
+  if (w.waitingOnUser) return "waiting-on-user";
+  if (isActive(w.activeState)) return "active";
+  return "waiting";
+}
+
+/**
+ * The worker rank used by the in-flight queue: active (in-loop) first,
+ * waiting-on-user second, idle/between-phases third, stuck fourth, blocked last.
+ * CTL-947 extends the original `active?0 : stuck?2 : 1` closure to cover all
+ * activity states. `ticketHeld` is the associated ticket's `held` field — pass
+ * it when building the grouped queue view so blocked tickets sort to the bottom.
+ */
+export function rankWorker(
+  w: BoardWorker,
+  ticketHeld?: "blocked" | "waiting" | null,
+): number {
+  return WORKER_GROUP_RANK[workerActivityGroup(w, ticketHeld)];
 }
 
 /**

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/queue-worker-grouping.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/queue-worker-grouping.test.ts
@@ -1,0 +1,231 @@
+// queue-worker-grouping.test.ts — units for the CTL-947 in-flight worker
+// activity-state grouping. Pure logic, no DOM — run from the ui package:
+//   cd ui && bun test src/board/queue-worker-grouping.test.ts
+//
+// Scenarios:
+//   • all-active fleet → single "active" group, no group headers needed
+//   • mixed fleet → groups appear in display order (active→wou→waiting→stuck→blocked)
+//   • blocked group always last even when it has the longest runtimeMs
+//   • within a group workers are ordered by runtimeMs desc (longest-running first)
+//   • empty input → zero sections
+//   • waitingOnUser drives its own group regardless of activeState
+import { describe, it, expect } from "bun:test";
+import type { BoardWorker } from "./types";
+import {
+  groupWorkersByActivity,
+  WORKER_GROUP_LABEL,
+  type WorkerActivitySection,
+} from "./queue-worker-grouping";
+
+// Minimal worker fixture — only the fields the grouper reads.
+function w(
+  partial: Partial<BoardWorker> & { name: string; ticket: string },
+): BoardWorker {
+  return {
+    tickets: [partial.ticket],
+    phase: "implement",
+    status: "running",
+    activeState: "active",
+    working: true,
+    lastActiveMs: 100,
+    repo: "catalyst",
+    team: "CTL",
+    runtimeMs: 1000,
+    costUSD: null,
+    ...partial,
+  };
+}
+
+const noHeld: Record<string, "blocked" | "waiting" | null | undefined> = {};
+
+// ── basic grouping ───────────────────────────────────────────────────────────
+
+describe("groupWorkersByActivity — basic grouping", () => {
+  it("empty workers → zero sections", () => {
+    expect(groupWorkersByActivity([], noHeld)).toEqual([]);
+  });
+
+  it("all-active fleet → single 'active' section", () => {
+    const workers = [
+      w({ name: "w1", ticket: "CTL-1", activeState: "active" }),
+      w({ name: "w2", ticket: "CTL-2", activeState: "active" }),
+    ];
+    const sections = groupWorkersByActivity(workers, noHeld);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]?.group).toBe("active");
+    expect(sections[0]?.label).toBe(WORKER_GROUP_LABEL.active);
+    expect(sections[0]?.workers).toHaveLength(2);
+  });
+
+  it("stuck + active → two sections in display order: active first, stuck last", () => {
+    const workers = [
+      w({ name: "stuck", ticket: "CTL-1", activeState: "stuck" }),
+      w({ name: "live", ticket: "CTL-2", activeState: "active" }),
+    ];
+    const sections = groupWorkersByActivity(workers, noHeld);
+    expect(sections.map((s) => s.group)).toEqual(["active", "stuck"]);
+  });
+
+  it("idle (null activeState) → 'waiting' group between active and stuck", () => {
+    const workers = [
+      w({ name: "idle", ticket: "CTL-1", activeState: null }),
+    ];
+    const sections = groupWorkersByActivity(workers, noHeld);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]?.group).toBe("waiting");
+  });
+
+  it("full mix → groups in canonical order: active→wou→waiting→stuck→blocked", () => {
+    const held: Record<string, "blocked" | "waiting" | null> = {
+      "CTL-5": "blocked",
+    };
+    const workers = [
+      w({ name: "stuck-w", ticket: "CTL-4", activeState: "stuck" }),
+      w({ name: "wou-w", ticket: "CTL-2", activeState: "active", waitingOnUser: true }),
+      w({ name: "idle-w", ticket: "CTL-3", activeState: null }),
+      w({ name: "active-w", ticket: "CTL-1", activeState: "active", waitingOnUser: false }),
+      w({ name: "blocked-w", ticket: "CTL-5", activeState: null }),
+    ];
+    const sections = groupWorkersByActivity(workers, held);
+    expect(sections.map((s) => s.group)).toEqual([
+      "active",
+      "waiting-on-user",
+      "waiting",
+      "stuck",
+      "blocked",
+    ]);
+  });
+});
+
+// ── blocked group always last ────────────────────────────────────────────────
+
+describe("groupWorkersByActivity — blocked group is always last", () => {
+  it("blocked with the longest runtimeMs still appears last", () => {
+    const held: Record<string, "blocked" | "waiting" | null> = {
+      "CTL-1": "blocked",
+    };
+    const workers = [
+      // blocked worker has the longest runtime
+      w({ name: "blocked-w", ticket: "CTL-1", activeState: null, runtimeMs: 99999 }),
+      w({ name: "active-w", ticket: "CTL-2", activeState: "active", runtimeMs: 1 }),
+    ];
+    const sections = groupWorkersByActivity(workers, held);
+    expect(sections[0]?.group).toBe("active");
+    expect(sections.at(-1)?.group).toBe("blocked");
+  });
+
+  it("blocked worker names the blockers (ticket held lookup passed through)", () => {
+    // The grouper itself doesn't attach blockers — that's the view's job. But the
+    // group key should be "blocked" when the ticket is held === "blocked".
+    const held: Record<string, "blocked" | "waiting" | null> = {
+      "CTL-X": "blocked",
+    };
+    const workers = [w({ name: "w1", ticket: "CTL-X", activeState: "active" })];
+    const sections = groupWorkersByActivity(workers, held);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]?.group).toBe("blocked");
+  });
+});
+
+// ── within-group ordering by runtimeMs desc ─────────────────────────────────
+
+describe("groupWorkersByActivity — within-group runtimeMs desc ordering", () => {
+  it("active workers sorted by runtimeMs descending within the group", () => {
+    const workers = [
+      w({ name: "short", ticket: "CTL-1", activeState: "active", runtimeMs: 100 }),
+      w({ name: "long", ticket: "CTL-2", activeState: "active", runtimeMs: 9000 }),
+      w({ name: "mid", ticket: "CTL-3", activeState: "active", runtimeMs: 500 }),
+    ];
+    const sections = groupWorkersByActivity(workers, noHeld);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]?.workers.map((x) => x.runtimeMs)).toEqual([9000, 500, 100]);
+  });
+
+  it("stuck workers sorted by runtimeMs descending within the stuck group", () => {
+    const workers = [
+      w({ name: "s1", ticket: "CTL-1", activeState: "stuck", runtimeMs: 200 }),
+      w({ name: "s2", ticket: "CTL-2", activeState: "stuck", runtimeMs: 800 }),
+    ];
+    const sections = groupWorkersByActivity(workers, noHeld);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]?.group).toBe("stuck");
+    expect(sections[0]?.workers.map((x) => x.runtimeMs)).toEqual([800, 200]);
+  });
+});
+
+// ── waitingOnUser classification ─────────────────────────────────────────────
+
+describe("groupWorkersByActivity — waitingOnUser", () => {
+  it("waitingOnUser=true → 'waiting-on-user' group even when activeState='active'", () => {
+    const workers = [
+      w({ name: "wou", ticket: "CTL-1", activeState: "active", waitingOnUser: true }),
+    ];
+    const sections = groupWorkersByActivity(workers, noHeld);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]?.group).toBe("waiting-on-user");
+  });
+
+  it("waitingOnUser=false → not in waiting-on-user group", () => {
+    const workers = [
+      w({ name: "live", ticket: "CTL-1", activeState: "active", waitingOnUser: false }),
+    ];
+    const sections = groupWorkersByActivity(workers, noHeld);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]?.group).toBe("active");
+  });
+
+  it("waiting-on-user appears BEFORE waiting (idle) and AFTER active", () => {
+    const workers = [
+      w({ name: "idle", ticket: "CTL-1", activeState: null }),
+      w({ name: "wou", ticket: "CTL-2", activeState: "active", waitingOnUser: true }),
+      w({ name: "active", ticket: "CTL-3", activeState: "active" }),
+    ];
+    const sections = groupWorkersByActivity(workers, noHeld);
+    expect(sections.map((s) => s.group)).toEqual(["active", "waiting-on-user", "waiting"]);
+  });
+
+  it("blocked overrides waitingOnUser (ticket held=blocked wins over worker waitingOnUser)", () => {
+    const held: Record<string, "blocked" | "waiting" | null> = {
+      "CTL-1": "blocked",
+    };
+    const workers = [
+      w({ name: "wou-blocked", ticket: "CTL-1", activeState: "active", waitingOnUser: true }),
+    ];
+    const sections = groupWorkersByActivity(workers, held);
+    // ticket-level blocked wins — the worker lands in the blocked group
+    expect(sections[0]?.group).toBe("blocked");
+  });
+});
+
+// ── labels ───────────────────────────────────────────────────────────────────
+
+describe("WORKER_GROUP_LABEL — human-readable group labels", () => {
+  it("all groups have a non-empty label", () => {
+    const labels = Object.values(WORKER_GROUP_LABEL);
+    expect(labels.every((l) => l.length > 0)).toBe(true);
+  });
+  it("'waiting-on-user' label is 'Waiting on you'", () => {
+    expect(WORKER_GROUP_LABEL["waiting-on-user"]).toBe("Waiting on you");
+  });
+  it("'blocked' label is 'Blocked'", () => {
+    expect(WORKER_GROUP_LABEL.blocked).toBe("Blocked");
+  });
+});
+
+// ── no drops or dups ─────────────────────────────────────────────────────────
+
+describe("groupWorkersByActivity — invariants", () => {
+  it("every input worker appears in exactly one section (no drops, no dups)", () => {
+    const held: Record<string, "blocked" | "waiting" | null> = { "CTL-5": "blocked" };
+    const workers = [
+      w({ name: "a", ticket: "CTL-1", activeState: "active" }),
+      w({ name: "b", ticket: "CTL-2", activeState: "active", waitingOnUser: true }),
+      w({ name: "c", ticket: "CTL-3", activeState: null }),
+      w({ name: "d", ticket: "CTL-4", activeState: "stuck" }),
+      w({ name: "e", ticket: "CTL-5", activeState: null }),
+    ];
+    const sections = groupWorkersByActivity(workers, held);
+    const flat = sections.flatMap((s) => s.workers.map((x) => x.name)).sort();
+    expect(flat).toEqual(["a", "b", "c", "d", "e"]);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/queue-worker-grouping.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/queue-worker-grouping.ts
@@ -1,0 +1,88 @@
+// queue-worker-grouping.ts — PURE, DOM-free grouping of the in-flight worker
+// list by activity state (CTL-947). Extracted from the QueueView render so the
+// grouping contract is unit-testable under `bun test` without a DOM, matching
+// the queue-grouping.ts / worker-grouping.ts / board-grouping.ts pattern.
+//
+// The five groups, in display order:
+//   active          — worker is in-loop, generating (activeState === "active")
+//   waiting-on-user — worker is parked for a human prompt (waitingOnUser === true)
+//   waiting         — worker is idle / between-phases (activeState === null)
+//   stuck           — worker is stale / terminal-marker (activeState === "stuck")
+//   blocked         — ticket hold held === "blocked" with blockers[] — ALWAYS LAST
+//
+// Within each group workers keep the existing priority rank (sortWorkers order:
+// longest runtimeMs first within a group). The BLOCKED group always renders last
+// regardless of runtimeMs so the operator can always find it at the bottom.
+//
+// The grouper is ticket-aware ONLY through the injected `ticketHeld` lookup
+// (a plain Record<ticketId, "blocked"|"waiting"|null>) so it remains React-free.
+import type { BoardWorker } from "./types";
+import {
+  rankWorker,
+  workerActivityGroup,
+  type WorkerActivityGroup,
+} from "./list-order";
+
+/** Human-readable label for each activity group, used as the section header. */
+export const WORKER_GROUP_LABEL: Record<WorkerActivityGroup, string> = {
+  active: "Active",
+  "waiting-on-user": "Waiting on you",
+  waiting: "Waiting",
+  stuck: "Stuck",
+  blocked: "Blocked",
+};
+
+/** One activity-state section of the in-flight worker list. */
+export interface WorkerActivitySection {
+  /** The activity group key. */
+  group: WorkerActivityGroup;
+  /** Human-readable section header label. */
+  label: string;
+  /** Workers in this section, in sortWorkers order within the group. */
+  workers: BoardWorker[];
+}
+
+/**
+ * Group the in-flight worker list by activity state, yielding one section per
+ * non-empty group in display order. Empty groups are omitted (no ghost headers).
+ *
+ * `ticketHeld` maps ticket ids to their `held` field — pass the result of
+ * `Object.fromEntries(tickets.map(t => [t.id, t.held]))` or an empty object
+ * when ticket data is unavailable.
+ *
+ * Workers within each section are ordered by `runtimeMs` descending
+ * (longest-running first), which is the existing `sortWorkers` tie-break.
+ *
+ * The BLOCKED group is ALWAYS last (rank 4) — even if no other groups exist.
+ * Within each group the existing priority rank (`rankWorker` without a held
+ * override, i.e. just activeState/waitingOnUser) is used for tie-breaking.
+ */
+export function groupWorkersByActivity(
+  workers: readonly BoardWorker[],
+  ticketHeld: Record<string, "blocked" | "waiting" | null | undefined>,
+): WorkerActivitySection[] {
+  // Sort first: rank including ticket-held so blocked sinks to bottom; ties
+  // broken by runtimeMs descending (longest-running first, matching sortWorkers).
+  const sorted = [...workers].sort((a, b) => {
+    const ra = rankWorker(a, ticketHeld[a.ticket] ?? null);
+    const rb = rankWorker(b, ticketHeld[b.ticket] ?? null);
+    return ra - rb || (b.runtimeMs ?? 0) - (a.runtimeMs ?? 0);
+  });
+
+  // Bucket into sections preserving the sorted order (first-appearance order =
+  // the group rank order already enforced by the sort above).
+  const byGroup = new Map<WorkerActivityGroup, BoardWorker[]>();
+  for (const w of sorted) {
+    const g = workerActivityGroup(w, ticketHeld[w.ticket] ?? null);
+    const bucket = byGroup.get(g);
+    if (bucket) bucket.push(w);
+    else byGroup.set(g, [w]);
+  }
+
+  // Emit sections in insertion order (which mirrors the rank sort above).
+  return [...byGroup.entries()].map(([group, ws]) => ({
+    group,
+    label: WORKER_GROUP_LABEL[group],
+    workers: ws,
+  }));
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
@@ -60,6 +60,10 @@ export interface BoardWorker {
   /** CTL-928: the durable `claude --bg` job id this worker's liveness was derived
    *  from. null/absent when no signal carried one. */
   bgJobId?: string | null;
+  /** CTL-947: true when the worker is parked waiting for a human prompt —
+   *  derived from the durable bg-job state "blocked" (Claude Code paused for
+   *  user input / a permission grant). false/absent when not waiting. */
+  waitingOnUser?: boolean;
 }
 
 export interface BoardPhaseCost {


### PR DESCRIPTION
## Summary

- Adds a five-group activity-state split to the Queue view's in-flight table: **active → waiting-on-user → waiting (idle/between-phases) → stuck → blocked**
- **Blocked** is always pinned last; each blocked row names its blocker ticket ids inline
- **waiting-on-user** derives from the durable bg-job state `"blocked"` — Claude Code pauses a job there when it needs user input / a permission grant
- Single-group fleets (all workers active) render with zero added chrome — divider headers only appear when multiple groups exist

## Changed files

- `lib/board-data.mjs` — `isBgJobWaitingOnUser` + `waitingOnUser` field on assembled workers
- `lib/board-data.d.mts`, `ui/src/board/types.ts` — `waitingOnUser?: boolean` on `BoardWorker`
- `ui/src/board/list-order.ts` — `rankWorker` extended to 5 levels; new `workerActivityGroup` / `WorkerActivityGroup` exports
- `ui/src/board/queue-worker-grouping.ts` — new pure grouper (17 tests)
- `ui/src/board/Board.tsx` — `QueueView` renders grouped in-flight sections with labeled dividers + blocker ids
- `__tests__/list-order.test.ts` — updated rank assertions to new five-level values

## Test plan

- [ ] `bun test ui/src/board/queue-worker-grouping.test.ts` — 17 pass
- [ ] `bun test __tests__/list-order.test.ts` — 26 pass (rank assertions updated for CTL-947)
- [ ] `bun test` in `ui/` — 325 pass, 0 fail
- [ ] Pre-existing failures in `__tests__/` are unrelated (use-keyboard-nav, nav-signal, readLinearCache, output-parser) — unchanged count

Linear: CTL-947

🤖 Generated with [Claude Code](https://claude.com/claude-code)