### PR TITLE
feat(dev): LIFECYCLE SPINE real per-phase cost/tokens + artifact links + prominent Gantt (CTL-953)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/board/ticket-page-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/ticket-page-model.test.ts
@@ -233,16 +233,78 @@ describe("Scenario: LIFECYCLE SPINE renders one node per phase with a compact ga
     expect(nodes.find((n) => n.phase === "plan")?.model).toBe("opus");
   });
 
-  it("run-link / artifact / cost-sparkline render PENDING (dimmed, never empty/fabricated)", () => {
+  it("run-link / artifact / cost-sparkline render PENDING when no phaseCosts (dimmed, never fabricated)", () => {
     const t = ticket({
       phase: "implement",
       phaseSummary: [phaseTiming({ phase: "triage", status: "done" })],
+      phaseCosts: null,
     });
     const [node] = resolveSpineNodes(t);
-    // these three depend on the BFF run-records endpoint (DETAIL6/DETAIL7)
+    // run-link and artifact always pending (BFF run-records not yet wired)
     expect(node.runLink).toBe("pending");
     expect(node.artifact).toBe("pending");
+    // costSparkline pending when no phaseCosts (honest dim)
     expect(node.costSparkline).toBe("pending");
+    expect(node.costUSD).toBeNull();
+    expect(node.tokens).toBeNull();
+  });
+
+  // ── CTL-953: per-phase cost/tokens from phaseCosts ──────────────────────────
+  it("CTL-953: costUSD and tokens are resolved from phaseCosts when present (never fabricated)", () => {
+    const t = ticket({
+      phase: "implement",
+      phaseSummary: [
+        phaseTiming({ phase: "research", status: "done" }),
+        phaseTiming({ phase: "plan", status: "done" }),
+        phaseTiming({ phase: "implement", status: "in_progress", completedAt: null }),
+      ],
+      phaseCosts: {
+        research: { costUSD: 0.21, tokens: 400_000, turns: 3 },
+        plan: { costUSD: 0.38, tokens: 750_000, turns: 2 },
+        // implement has no phaseCost yet (still running)
+      },
+    });
+    const nodes = resolveSpineNodes(t);
+    const byPhase = Object.fromEntries(nodes.map((n) => [n.phase, n]));
+
+    // research — plumbed from phaseCosts
+    expect(byPhase.research.costUSD).toBe(0.21);
+    expect(byPhase.research.tokens).toBe(400_000);
+    expect(byPhase.research.costSparkline).toBe("plumbed");
+
+    // plan — plumbed from phaseCosts
+    expect(byPhase.plan.costUSD).toBe(0.38);
+    expect(byPhase.plan.tokens).toBe(750_000);
+    expect(byPhase.plan.costSparkline).toBe("plumbed");
+
+    // implement — no entry yet (still running) → dim placeholder
+    expect(byPhase.implement.costUSD).toBeNull();
+    expect(byPhase.implement.tokens).toBeNull();
+    expect(byPhase.implement.costSparkline).toBe("pending");
+  });
+
+  it("CTL-953: a phase with costUSD=0 is treated as absent (zero is not a fabricated value, but we dim it honestly)", () => {
+    const t = ticket({
+      phaseSummary: [phaseTiming({ phase: "triage", status: "done" })],
+      phaseCosts: { triage: { costUSD: 0, tokens: 0, turns: 1 } },
+    });
+    const [node] = resolveSpineNodes(t);
+    // zero cost = no real cost data (free phase or instrumentation gap) — dim pending
+    expect(node.costUSD).toBeNull();
+    expect(node.tokens).toBeNull();
+    expect(node.costSparkline).toBe("pending");
+  });
+
+  it("CTL-953: tokens can be absent even when costUSD is present (null, never fabricated)", () => {
+    const t = ticket({
+      phaseSummary: [phaseTiming({ phase: "research", status: "done" })],
+      phaseCosts: { research: { costUSD: 0.15, tokens: 0, turns: 2 } },
+    });
+    const [node] = resolveSpineNodes(t);
+    // costUSD present, tokens=0 → tokens null (dim), cost plumbed
+    expect(node.costUSD).toBe(0.15);
+    expect(node.tokens).toBeNull();
+    expect(node.costSparkline).toBe("plumbed");
   });
 
   it("an empty phaseSummary yields no nodes (skin shows an honest empty state)", () => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/ticket-page-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/ticket-page-model.ts
@@ -194,19 +194,32 @@ export interface SpineNode {
   /** True iff this node IS the ticket's current (active) phase — the skin anchors
    *  the spine scroll + the cyan "here now" treatment on it. */
   isActive: boolean;
-  /** Cells that depend on the BFF run-records endpoint (DETAIL6/DETAIL7) and so
-   *  render DIMMED with a NEEDS-PLUMBING marker until those tickets land. */
-  runLink: SpineCellState;
-  artifact: SpineCellState;
+  /** Per-phase cost in USD from BoardTicket.phaseCosts (CTL-953, AVAILABLE NOW).
+   *  null when phaseCosts is absent or has no entry for this phase — never fabricated. */
+  costUSD: number | null;
+  /** Per-phase token count from BoardTicket.phaseCosts (CTL-953, AVAILABLE NOW).
+   *  null when phaseCosts is absent or has no entry for this phase — never fabricated. */
+  tokens: number | null;
+  /** `plumbed` when costUSD is non-null (real phaseCosts data available);
+   *  `pending` when no per-phase cost exists yet (skin dims it honestly). */
   costSparkline: SpineCellState;
+  /** Artifact plumbing: `pending` always at model level — the skin issues
+   *  the /api/ticket-artifacts/<id> fetch and passes resolved links down. */
+  artifact: SpineCellState;
+  /** Run-link plumbing: `pending` — /api/ticket-runs not yet wired. */
+  runLink: SpineCellState;
 }
 
 /**
  * Resolve the LIFECYCLE SPINE (design §4.2 "LIFECYCLE SPINE"): one node per
  * `phaseSummary[]` entry, carrying the cells that ARE resident-plumbed
- * (phase/status/duration/startedAt/completedAt/model) and the per-node
- * NEEDS-PLUMBING flags for the cells that depend on the BFF run-records endpoint
- * (run-link / artifact / cost-sparkline — DETAIL6/DETAIL7).
+ * (phase/status/duration/timestamps/model/cost/tokens from phaseCosts) and the
+ * NEEDS-PLUMBING flags for cells that still require backend wiring
+ * (artifact = fetch-in-skin; run-link = future endpoint).
+ *
+ * CTL-953: `costUSD` and `tokens` are resolved directly from
+ * `BoardTicket.phaseCosts[phase]` — no new endpoint. `costSparkline` is
+ * `"plumbed"` when the value exists, `"pending"` otherwise.
  *
  * `isActive` is true for the node whose phase === ticket.phase AND that is not
  * terminal — i.e. the live/current node the spine scroll + cyan ring anchor on.
@@ -215,10 +228,13 @@ export interface SpineNode {
  * honest "no phases yet" empty state, never a fabricated row).
  */
 export function resolveSpineNodes(
-  ticket: Pick<BoardTicket, "phase" | "phaseSummary">,
+  ticket: Pick<BoardTicket, "phase" | "phaseSummary" | "phaseCosts">,
 ): SpineNode[] {
   return ticket.phaseSummary.map((row: BoardPhaseTiming): SpineNode => {
     const isActive = row.phase === ticket.phase && !TERMINAL_SPINE_STATUSES.has(row.status);
+    const phaseCost = ticket.phaseCosts?.[row.phase] ?? null;
+    const costUSD = phaseCost && phaseCost.costUSD > 0 ? phaseCost.costUSD : null;
+    const tokens = phaseCost && phaseCost.tokens > 0 ? phaseCost.tokens : null;
     return {
       phase: row.phase,
       label: phaseLabel(row.phase),
@@ -228,11 +244,13 @@ export function resolveSpineNodes(
       completedAt: row.completedAt,
       model: row.model,
       isActive,
-      // All three depend on the BFF run-records endpoint — not yet plumbed
-      // (DETAIL6/DETAIL7). Marked `pending` so the skin dims them honestly.
-      runLink: "pending",
+      costUSD,
+      tokens,
+      costSparkline: costUSD != null ? "plumbed" : "pending",
+      // artifact links are resolved in the skin via /api/ticket-artifacts fetch.
       artifact: "pending",
-      costSparkline: "pending",
+      // run-link depends on /api/ticket-runs (not yet wired) — honest pending.
+      runLink: "pending",
     };
   });
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-detail-page.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-detail-page.tsx
@@ -78,12 +78,46 @@ function Needs({ label }: { label: string }) {
   return (
     <span
       data-needs-plumbing={label}
-      title={`${label} — NEEDS-PLUMBING (DETAIL6/DETAIL7)`}
+      title={`${label} — NEEDS-PLUMBING`}
       style={{ color: C.fgDim, font: `10px ${C.mono}` }}
     >
       ↯ {label}
     </span>
   );
+}
+
+// ── Ticket artifact links (CTL-953) ─────────────────────────────────────────
+/** One artifact returned by /api/ticket-artifacts/<id>. */
+interface TicketArtifact {
+  kind: "research" | "plan" | string;
+  path: string;
+  peek: string | null;
+}
+
+/** /api/ticket-artifacts/<id> response shape. */
+interface ArtifactsResponse {
+  ticket: string;
+  artifacts: TicketArtifact[];
+  crossNodeCaveat?: string;
+}
+
+/** Fetch the ticket's research/plan artifact links from /api/ticket-artifacts.
+ *  Returns an empty array while loading or on any error — the spine renders a
+ *  dim placeholder when none exist, never a fabricated link. */
+function useTicketArtifacts(ticketId: string): TicketArtifact[] {
+  const [artifacts, setArtifacts] = useState<TicketArtifact[]>([]);
+  useEffect(() => {
+    if (!ticketId) return;
+    let stop = false;
+    fetch(`/api/ticket-artifacts/${encodeURIComponent(ticketId)}`)
+      .then((r) => r.ok ? r.json() as Promise<ArtifactsResponse> : null)
+      .then((body) => {
+        if (!stop && body?.artifacts) setArtifacts(body.artifacts);
+      })
+      .catch(() => {});
+    return () => { stop = true; };
+  }, [ticketId]);
+  return artifacts;
 }
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
@@ -350,10 +384,20 @@ function LifecycleSpine({
    *  live stream (DETAIL7). */
   activeSession: string | null;
 }) {
+  // compact = hide per-phase rows; Gantt is ALWAYS prominent.
   const [compact, setCompact] = useState(false);
   const nodes = resolveSpineNodes(ticket);
   // One SSE per ticket page, subscribed only while there IS a running phase.
   const activeNodeTail = useActiveNodeTail(activeSession);
+  // CTL-953: artifact links from /api/ticket-artifacts — keyed by kind.
+  const artifacts = useTicketArtifacts(ticket.id);
+  const artifactsByKind = useMemo<Record<string, TicketArtifact[]>>(() => {
+    const map: Record<string, TicketArtifact[]> = {};
+    for (const a of artifacts) {
+      (map[a.kind] ??= []).push(a);
+    }
+    return map;
+  }, [artifacts]);
 
   return (
     <section data-ticket-spine style={{ marginBottom: 16 }}>
@@ -375,29 +419,33 @@ function LifecycleSpine({
             cursor: "pointer",
           }}
         >
-          ⊟ compact
+          {compact ? "⊞ expand rows" : "⊟ hide rows"}
         </button>
       </div>
 
-      {compact ? (
-        // The [compact] toggle swaps in the existing TicketGantt over the SAME
-        // phaseSummary data (design §4.2 — verified drop-in consumer).
-        <div data-spine-gantt>
-          <TicketGantt ticket={ticket} />
+      {/* CTL-953: Gantt is ALWAYS prominent — shown above the rows, never hidden. */}
+      {ticket.phaseSummary.length > 0 && (
+        <div data-spine-gantt style={{ marginBottom: compact ? 0 : 10 }}>
+          <TicketGantt ticket={ticket} phaseCosts={ticket.phaseCosts} />
         </div>
-      ) : nodes.length === 0 ? (
-        <EmptyState icon={ListTree} message="No phases yet" />
-      ) : (
-        <div data-spine-nodes>
-          {nodes.map((node) => (
-            <SpineRow
-              key={node.phase}
-              node={node}
-              registerNode={registerNode}
-              activeNodeTail={node.isActive ? activeNodeTail : null}
-            />
-          ))}
-        </div>
+      )}
+
+      {!compact && (
+        nodes.length === 0 ? (
+          <EmptyState icon={ListTree} message="No phases yet" />
+        ) : (
+          <div data-spine-nodes>
+            {nodes.map((node) => (
+              <SpineRow
+                key={node.phase}
+                node={node}
+                registerNode={registerNode}
+                activeNodeTail={node.isActive ? activeNodeTail : null}
+                artifactsByKind={artifactsByKind}
+              />
+            ))}
+          </div>
+        )
       )}
     </section>
   );
@@ -407,16 +455,24 @@ function SpineRow({
   node,
   registerNode,
   activeNodeTail,
+  artifactsByKind,
 }: {
   node: SpineNode;
   registerNode: (phase: string, el: HTMLDivElement | null) => void;
   /** CTL-918 (DETAIL7): the live tail for THIS node when it is the running phase
    *  (null otherwise) — renders the `now: …` line + 3-line in-loop tail beneath. */
   activeNodeTail: ActiveNodeTail | null;
+  /** CTL-953: artifact links keyed by kind ("research"/"plan") from
+   *  /api/ticket-artifacts — used to render the artifact link in research/plan rows. */
+  artifactsByKind: Record<string, TicketArtifact[]>;
 }) {
   const color = phaseColor(node.phase);
   const started = node.startedAt ? fmtClock(new Date(Date.parse(node.startedAt))) : null;
   const completed = node.completedAt ? fmtClock(new Date(Date.parse(node.completedAt))) : null;
+  // CTL-953: map spine phase to artifact kind ("research"→"research", "plan"→"plan")
+  const phaseArtifactKind = node.phase === "research" ? "research" : node.phase === "plan" ? "plan" : null;
+  const phaseArtifacts = phaseArtifactKind ? (artifactsByKind[phaseArtifactKind] ?? []) : [];
+
   return (
     <div
       ref={(el) => registerNode(node.phase, el)}
@@ -473,11 +529,44 @@ function SpineRow({
 
       <span style={{ flex: 1 }} />
 
-      {/* run-link / artifact / cost-sparkline — NEEDS-PLUMBING (DETAIL6/DETAIL7) */}
-      <span style={{ display: "inline-flex", gap: 10, flexShrink: 0 }}>
-        {node.costSparkline === "pending" && <Needs label="cost" />}
+      {/* CTL-953: cost (real from phaseCosts), run (dim placeholder), artifact link */}
+      <span style={{ display: "inline-flex", gap: 10, flexShrink: 0, alignItems: "center" }}>
+        {/* cost — real from phaseCosts when available, dim placeholder otherwise */}
+        {node.costSparkline === "plumbed" && node.costUSD != null ? (
+          <span
+            data-spine-cost={node.phase}
+            title={node.tokens != null ? `${fmtTokens(node.tokens)} tokens` : "per-phase cost"}
+            style={{ color: C.fgMuted, font: `10px ${C.mono}`, whiteSpace: "nowrap" }}
+          >
+            {fmtCost(node.costUSD)}
+            {node.tokens != null && (
+              <span style={{ color: C.fgDim }}> · {fmtTokens(node.tokens)}</span>
+            )}
+          </span>
+        ) : (
+          <Needs label="cost" />
+        )}
+        {/* run-link — pending until /api/ticket-runs lands */}
         {node.runLink === "pending" && <Needs label="run" />}
-        {node.artifact === "pending" && <Needs label="artifact" />}
+        {/* artifact — real link when present, dim placeholder otherwise */}
+        {phaseArtifacts.length > 0 ? (
+          <span data-spine-artifact={node.phase} style={{ display: "inline-flex", gap: 4 }}>
+            {phaseArtifacts.map((a) => (
+              <a
+                key={a.path}
+                href={`/api/artifact-raw?path=${encodeURIComponent(a.path)}`}
+                target="_blank"
+                rel="noreferrer noopener"
+                title={a.peek ? a.peek.slice(0, 200) : a.path}
+                style={{ color: "#4ea1ff", font: `10px ${C.mono}`, textDecoration: "none" }}
+              >
+                📄 {a.kind}
+              </a>
+            ))}
+          </span>
+        ) : node.artifact === "pending" && phaseArtifactKind ? (
+          <Needs label="artifact" />
+        ) : null}
       </span>
     </div>
     {/* DETAIL7: the active node's live tail (now: <tool> · turn N · ctx% + 3-line

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-gantt.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-gantt.test.ts
@@ -1,0 +1,109 @@
+// ticket-gantt.test.ts — units for the ticket Gantt timing + per-phase cost
+// wiring (CTL-953). Tests the pure buildBars computation: bar placement,
+// cost/tokens annotation from phaseCosts, and running-phase detection.
+//
+// Pure module — no DOM. Run from ui:
+//   cd ui && bun test src/components/ticket-gantt.test.ts
+import { describe, it, expect } from "bun:test";
+import { buildBars } from "./ticket-gantt";
+import type { BoardPhaseTiming } from "@/board/types";
+
+function pt(over: Partial<BoardPhaseTiming> & { phase: string }): BoardPhaseTiming {
+  return {
+    phase: over.phase,
+    status: over.status ?? "done",
+    durationMs: over.durationMs ?? 60_000,
+    startedAt: over.startedAt ?? "2026-06-08T10:00:00.000Z",
+    completedAt: over.completedAt ?? "2026-06-08T10:01:00.000Z",
+    model: over.model ?? null,
+  };
+}
+
+// ── Scenario: buildBars computes correct bar geometry ───────────────────────
+describe("Scenario: buildBars computes correct bar geometry (CTL-953)", () => {
+  it("returns null when no rows have startedAt (no timing data yet)", () => {
+    const rows: BoardPhaseTiming[] = [
+      { phase: "triage", status: "done", durationMs: null, startedAt: null, completedAt: null, model: null },
+    ];
+    expect(buildBars(rows, Date.now())).toBeNull();
+  });
+
+  it("a single completed phase spans the full axis (leftPct=0, widthPct≈100)", () => {
+    const rows = [
+      pt({ phase: "triage", startedAt: "2026-06-08T10:00:00.000Z", completedAt: "2026-06-08T10:05:00.000Z" }),
+    ];
+    const bars = buildBars(rows, Date.now());
+    expect(bars).not.toBeNull();
+    expect(bars![0].leftPct).toBeCloseTo(0, 1);
+    expect(bars![0].widthPct).toBeCloseTo(100, 1);
+  });
+
+  it("two sequential phases: second starts where first ends", () => {
+    const rows = [
+      pt({ phase: "triage",   startedAt: "2026-06-08T10:00:00.000Z", completedAt: "2026-06-08T10:05:00.000Z" }),
+      pt({ phase: "research", startedAt: "2026-06-08T10:05:00.000Z", completedAt: "2026-06-08T10:10:00.000Z" }),
+    ];
+    const bars = buildBars(rows, Date.now())!;
+    expect(bars[0].leftPct).toBeCloseTo(0, 1);
+    expect(bars[0].widthPct).toBeCloseTo(50, 1);
+    expect(bars[1].leftPct).toBeCloseTo(50, 1);
+    expect(bars[1].widthPct).toBeCloseTo(50, 1);
+  });
+
+  it("a running (non-terminal, no completedAt) phase uses the `now` clock as its end", () => {
+    const start = Date.now() - 60_000; // 1 min ago
+    const rows: BoardPhaseTiming[] = [
+      { phase: "implement", status: "in_progress", durationMs: null, startedAt: new Date(start).toISOString(), completedAt: null, model: null },
+    ];
+    const bars = buildBars(rows, Date.now())!;
+    expect(bars[0].isRunning).toBe(true);
+    // spans the full axis (only bar)
+    expect(bars[0].widthPct).toBeGreaterThan(0);
+  });
+
+  it("isRunning is false for terminal statuses even without completedAt", () => {
+    const rows: BoardPhaseTiming[] = [
+      { phase: "implement", status: "failed", durationMs: null, startedAt: "2026-06-08T10:00:00.000Z", completedAt: null, model: null },
+    ];
+    const bars = buildBars(rows, Date.now())!;
+    expect(bars[0].isRunning).toBe(false);
+  });
+
+  it("durationLabel is formatted for a completed phase", () => {
+    const rows = [
+      pt({ phase: "triage", durationMs: 90_000 }), // 1m 30s
+    ];
+    const bars = buildBars(rows, Date.now())!;
+    expect(bars[0].durationLabel).toBe("1m 30s");
+  });
+});
+
+// ── Scenario: TicketGantt receives phaseCosts and renders cost column ────────
+// The JSX rendering is not DOM-tested here, but the data plumbing is verified:
+// phaseCosts keys match phase names in the bars so the Gantt can annotate each row.
+describe("Scenario: Gantt cost annotation data plumbing (CTL-953)", () => {
+  it("buildBars includes the phase name so phaseCosts[row.phase] can be looked up", () => {
+    const rows = [
+      pt({ phase: "research", startedAt: "2026-06-08T10:00:00.000Z", completedAt: "2026-06-08T10:05:00.000Z" }),
+      pt({ phase: "plan",     startedAt: "2026-06-08T10:05:00.000Z", completedAt: "2026-06-08T10:10:00.000Z" }),
+    ];
+    const bars = buildBars(rows, Date.now())!;
+    const phases = bars.map((b) => b.row.phase);
+    expect(phases).toEqual(["research", "plan"]);
+    // A consumer can look up costs: phaseCosts[bars[0].row.phase]
+    const fakePhaseCosts: Record<string, { costUSD: number; tokens: number; turns: number }> = {
+      research: { costUSD: 0.21, tokens: 400_000, turns: 3 },
+    };
+    expect(fakePhaseCosts[bars[0].row.phase]?.costUSD).toBe(0.21);
+    expect(fakePhaseCosts[bars[1].row.phase]).toBeUndefined(); // plan has no cost yet
+  });
+
+  it("rows with no startedAt are filtered out (no phantom bar for unstarted phases)", () => {
+    const rows: BoardPhaseTiming[] = [
+      pt({ phase: "triage", startedAt: "2026-06-08T10:00:00.000Z", completedAt: "2026-06-08T10:01:00.000Z" }),
+      { phase: "research", status: "pending", durationMs: null, startedAt: null, completedAt: null, model: null },
+    ];
+    const bars = buildBars(rows, Date.now())!;
+    expect(bars.map((b) => b.row.phase)).toEqual(["triage"]); // research absent — no start time
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-gantt.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-gantt.tsx
@@ -1,7 +1,7 @@
 import { BarChart3 } from "lucide-react";
-import { phaseColor, fmtDuration, fmtClock, phaseModelLabel } from "@/lib/formatters";
+import { phaseColor, fmtDuration, fmtClock, phaseModelLabel, fmtCost, fmtTokens } from "@/lib/formatters";
 import { EmptyState } from "./ui/empty-state";
-import type { BoardTicket, BoardPhaseTiming } from "@/board/types";
+import type { BoardTicket, BoardPhaseTiming, BoardPhaseCost } from "@/board/types";
 
 // kibo-ui/gantt is a scheduler-oriented component (day/month/quarter ranges)
 // that does not cleanly express absolute-minute precision within a single ticket
@@ -10,6 +10,9 @@ import type { BoardTicket, BoardPhaseTiming } from "@/board/types";
 
 interface TicketGanttProps {
   ticket: BoardTicket;
+  /** CTL-953: per-phase cost from BoardTicket.phaseCosts — shown as a right-side
+   *  annotation on each bar row. Dim when absent (never fabricated). */
+  phaseCosts?: Record<string, BoardPhaseCost> | null;
 }
 
 interface PhaseBar {
@@ -22,7 +25,8 @@ interface PhaseBar {
   endLabel: string;
 }
 
-function buildBars(rows: BoardPhaseTiming[], now: number): PhaseBar[] | null {
+/** Exported for unit tests only — prefer the React component in production code. */
+export function buildBars(rows: BoardPhaseTiming[], now: number): PhaseBar[] | null {
   const timed = rows.filter((r) => r.startedAt != null);
   if (!timed.length) return null;
 
@@ -54,7 +58,73 @@ function buildBars(rows: BoardPhaseTiming[], now: number): PhaseBar[] | null {
   });
 }
 
-export function TicketGantt({ ticket }: TicketGanttProps) {
+// ── Shared-timeline axis ─────────────────────────────────────────────────────
+
+function GanttAxis({ bars }: { bars: PhaseBar[] }) {
+  // Pick 4–5 tick marks at even human-readable intervals.
+  const starts = bars.map((b) => b.row.startedAt!).map((s) => Date.parse(s));
+  const axisStart = Math.min(...starts);
+  // axisEnd derived from bars' computed extents via leftPct+widthPct inverse:
+  // since leftPct = (s - axisStart) / span * 100 and widthPct = (e - s) / span * 100,
+  // span = (e - s) / (widthPct/100). Use durationMs as a proxy.
+  // Simpler: re-derive span from bars themselves.
+  const TERMINAL = new Set(["done", "complete", "failed", "blocked"]);
+  const now = Date.now();
+  const ends = bars.map((b) => {
+    if (b.row.completedAt) return Date.parse(b.row.completedAt);
+    if (!TERMINAL.has(b.row.status)) return now;
+    return Date.parse(b.row.startedAt!);
+  });
+  const axisEnd = Math.max(...ends, axisStart + 1);
+  const span = axisEnd - axisStart;
+
+  // Pick interval: 5 / 10 / 15 / 30 / 60 min
+  const minutes = span / 60000;
+  const interval = minutes <= 20 ? 5 * 60000
+    : minutes <= 60 ? 15 * 60000
+    : minutes <= 120 ? 30 * 60000
+    : 60 * 60000;
+
+  const ticks: { leftPct: number; label: string }[] = [];
+  const firstTick = Math.ceil(axisStart / interval) * interval;
+  for (let t = firstTick; t <= axisEnd; t += interval) {
+    ticks.push({ leftPct: ((t - axisStart) / span) * 100, label: fmtClock(new Date(t)) });
+  }
+  if (!ticks.length) return null;
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        height: 16,
+        marginLeft: 82,
+        marginRight: 148,
+        marginBottom: 2,
+        borderBottom: "1px solid rgba(255,255,255,0.08)",
+      }}
+    >
+      {ticks.map((tick, i) => (
+        <div
+          key={i}
+          style={{
+            position: "absolute",
+            top: 0,
+            left: tick.leftPct.toFixed(2) + "%",
+            transform: "translateX(-50%)",
+            fontSize: 9,
+            color: "rgba(255,255,255,0.3)",
+            whiteSpace: "nowrap",
+            pointerEvents: "none",
+          }}
+        >
+          {tick.label}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function TicketGantt({ ticket, phaseCosts }: TicketGanttProps) {
   const now = Date.now();
   const bars = buildBars(ticket.phaseSummary, now);
 
@@ -65,101 +135,134 @@ export function TicketGantt({ ticket }: TicketGanttProps) {
   }
 
   return (
-    <div style={{ fontFamily: "monospace" }}>
-      {bars.map(({ row, leftPct, widthPct, isRunning, durationLabel, startLabel, endLabel }) => (
-        <div
-          key={row.phase}
-          style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}
-        >
-          <div
-            style={{
-              width: 80,
-              flexShrink: 0,
-              fontSize: 11,
-              opacity: 0.75,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {row.phase}
-          </div>
+    <div
+      data-ticket-gantt
+      style={{
+        fontFamily: "monospace",
+        padding: "8px 10px",
+        borderRadius: 6,
+        background: "rgba(255,255,255,0.03)",
+        border: "1px solid rgba(255,255,255,0.07)",
+      }}
+    >
+      {/* Shared-timeline axis */}
+      <GanttAxis bars={bars} />
 
-          {/* Bar track */}
+      {bars.map(({ row, leftPct, widthPct, isRunning, durationLabel, startLabel, endLabel }) => {
+        const pc = phaseCosts?.[row.phase] ?? null;
+        const costLabel = pc && pc.costUSD > 0 ? fmtCost(pc.costUSD) : null;
+        const tokLabel = pc && pc.tokens > 0 ? fmtTokens(pc.tokens) : null;
+
+        return (
           <div
-            style={{
-              flex: 1,
-              position: "relative",
-              height: 14,
-              borderRadius: 3,
-              background: "rgba(255,255,255,0.06)",
-            }}
+            key={row.phase}
+            style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 5 }}
           >
+            {/* Phase label */}
             <div
               style={{
-                position: "absolute",
-                top: 0,
-                bottom: 0,
-                left: leftPct.toFixed(2) + "%",
-                width: Math.max(widthPct, 1).toFixed(2) + "%",
-                background: phaseColor(row.phase),
-                borderRadius: 3,
-                opacity: isRunning ? 0.9 : 0.75,
+                width: 74,
+                flexShrink: 0,
+                fontSize: 10,
+                color: "rgba(255,255,255,0.55)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                textAlign: "right",
+                paddingRight: 6,
               }}
-              title={`${row.phase} · ${startLabel}–${endLabel} · ${durationLabel}`}
             >
-              {isRunning && (
-                /* running-phase pulse marker */
-                <div
-                  style={{
-                    position: "absolute",
-                    inset: "0 0 0 auto",
-                    width: 3,
-                    background: "rgba(255,255,255,0.4)",
-                    borderRadius: "0 3px 3px 0",
-                    animation: "gantt-pulse 1.4s ease-in-out infinite",
-                  }}
-                />
-              )}
+              {row.phase}
+            </div>
+
+            {/* Bar track */}
+            <div
+              style={{
+                flex: 1,
+                position: "relative",
+                height: 16,
+                borderRadius: 3,
+                background: "rgba(255,255,255,0.05)",
+              }}
+            >
+              <div
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  bottom: 0,
+                  left: leftPct.toFixed(2) + "%",
+                  width: Math.max(widthPct, 0.5).toFixed(2) + "%",
+                  background: phaseColor(row.phase),
+                  borderRadius: 3,
+                  opacity: isRunning ? 0.95 : 0.78,
+                }}
+                title={`${row.phase} · ${startLabel}–${endLabel} · ${durationLabel}${costLabel ? ` · ${costLabel}` : ""}${tokLabel ? ` · ${tokLabel}` : ""}`}
+              >
+                {isRunning && (
+                  <div
+                    style={{
+                      position: "absolute",
+                      inset: "0 0 0 auto",
+                      width: 3,
+                      background: "rgba(255,255,255,0.45)",
+                      borderRadius: "0 3px 3px 0",
+                      animation: "gantt-pulse 1.4s ease-in-out infinite",
+                    }}
+                  />
+                )}
+              </div>
+            </div>
+
+            {/* Duration */}
+            <div
+              style={{
+                width: 48,
+                flexShrink: 0,
+                fontSize: 10,
+                opacity: 0.4,
+                textAlign: "right",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {durationLabel}
+            </div>
+
+            {/* CTL-953: per-phase cost + tokens (real from phaseCosts, dim when absent) */}
+            <div
+              data-gantt-cost={row.phase}
+              style={{
+                width: 56,
+                flexShrink: 0,
+                fontSize: 10,
+                textAlign: "right",
+                whiteSpace: "nowrap",
+                color: costLabel ? "rgba(255,255,255,0.55)" : "rgba(255,255,255,0.18)",
+              }}
+            >
+              {costLabel ?? "—"}
+            </div>
+
+            {/* Per-phase model (CTL-915 / DETAIL4) */}
+            <div
+              data-gantt-model={row.phase}
+              data-plumbed={row.model != null}
+              title={row.model ? `model ${row.model}` : "no per-phase model in signal"}
+              style={{
+                width: 96,
+                flexShrink: 0,
+                fontSize: 10,
+                opacity: row.model ? 0.6 : 0.28,
+                textAlign: "right",
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {phaseModelLabel(row.model)}
             </div>
           </div>
-
-          <div
-            style={{
-              width: 60,
-              flexShrink: 0,
-              fontSize: 10,
-              opacity: 0.45,
-              textAlign: "right",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {durationLabel}
-          </div>
-
-          {/* Per-phase model (CTL-915 / DETAIL4): the SAME phaseModelLabel the
-              lifecycle spine renders, off this row's BoardPhaseTiming.model
-              (BFF6). Dimmer when the phase signal carried none — never the
-              ticket-level model. */}
-          <div
-            data-gantt-model={row.phase}
-            data-plumbed={row.model != null}
-            title={row.model ? `model ${row.model}` : "no per-phase model in signal"}
-            style={{
-              width: 96,
-              flexShrink: 0,
-              fontSize: 10,
-              opacity: row.model ? 0.6 : 0.35,
-              textAlign: "right",
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-            }}
-          >
-            {phaseModelLabel(row.model)}
-          </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Cost/tokens per spine row**: Resolves `BoardTicket.phaseCosts[phase].{costUSD,tokens}` directly (no new endpoint) — shown as `$0.21 · 400k` inline on each `SpineRow`; `Needs cost` placeholder when phaseCosts absent
- **Artifact links**: `useTicketArtifacts` hook fetches `/api/ticket-artifacts/<id>` (endpoint already exists) → `📄 research` / `📄 plan` links with peek-tooltip on matching spine rows; dim placeholder when none found
- **Run-link**: Stays honest dim `↯ run` — `/api/ticket-runs` not yet available
- **Gantt made prominent**: `TicketGantt` renders always above the detail rows (never hidden). Compact toggle now hides/shows the per-phase rows; Gantt stays visible. Gantt enhanced with a per-phase cost column, shared-timeline axis ticks, and cleaner bar styling

## Changes

- `ticket-page-model.ts`: `resolveSpineNodes` now resolves `costUSD`/`tokens` from `phaseCosts`; `costSparkline` is `"plumbed"` when data exists
- `ticket-detail-page.tsx`: `LifecycleSpine` adds `useTicketArtifacts`, passes cost + artifact data to `SpineRow`; Gantt always shown above rows; compact toggle label updated
- `ticket-gantt.tsx`: Accepts `phaseCosts` prop → per-phase cost column; timeline axis with tick marks; `buildBars` exported for unit tests
- `ticket-page-model.test.ts`: 4 new CTL-953 cost/tokens tests
- `ticket-gantt.test.ts` (new): 8 Gantt geometry + cost plumbing tests

## Test plan
- [ ] 304 board unit tests pass (`bun test src/board/`)
- [ ] 8 new Gantt tests pass (`bun test src/components/ticket-gantt.test.ts`)
- [ ] `bunx tsc --noEmit` clean on changed files
- [ ] CI gates green

Fixes CTL-953

🤖 Generated with [Claude Code](https://claude.com/claude-code)