### PR TITLE
fix(dev): dependency graph — draw edges, scope labels, /dep-graph SPA fallback, knip cleanup (CTL-959)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/detail-deep-link-fallback.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/detail-deep-link-fallback.test.ts
@@ -44,6 +44,16 @@ describe("isDetailDeepLinkPath (CTL-942)", () => {
     expect(isDetailDeepLinkPath("/events")).toBe(false);
     expect(isDetailDeepLinkPath("/tickets/CTL-845")).toBe(false);
   });
+
+  // CTL-959: /dep-graph is a board-entry route (same AppRouter as /ticket, /worker)
+  it("matches /dep-graph for hard-nav SPA fallback (CTL-959)", () => {
+    expect(isDetailDeepLinkPath("/dep-graph")).toBe(true);
+  });
+
+  it("does not match /dep-graph/ with trailing slash or sub-paths", () => {
+    expect(isDetailDeepLinkPath("/dep-graph/")).toBe(false);
+    expect(isDetailDeepLinkPath("/dep-graph/sub")).toBe(false);
+  });
 });
 
 // ── Served fallback (integration through createServer) ──────────────────────
@@ -128,5 +138,22 @@ describe("GET /ticket/$id and /worker/$id SPA fallback (CTL-942)", () => {
       expect(res.headers.get("content-type")).toContain("text/html");
       expect(await res.text()).toBe(body);
     }
+  });
+});
+
+// CTL-959: /dep-graph SPA fallback — hard navigation must serve board.html
+describe("GET /dep-graph SPA fallback (CTL-959)", () => {
+  it("serves board.html for a hard navigation to /dep-graph", async () => {
+    const res = await fetch(`${baseUrl}/dep-graph`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(await res.text()).toBe(BOARD_HTML);
+  });
+
+  it("does not serve board.html for /dep-graph/ or /dep-graph/sub", async () => {
+    const trailing = await fetch(`${baseUrl}/dep-graph/`);
+    expect(trailing.status).toBe(404);
+    const nested = await fetch(`${baseUrl}/dep-graph/sub`);
+    expect(nested.status).toBe(404);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -244,7 +244,12 @@ type BunServer = ReturnType<typeof Bun.serve>;
 // look like an asset (no "." extension) so a mistyped asset URL keeps 404ing
 // instead of receiving html. /api/* and /events* can never match (the
 // ^/(ticket|worker)/ prefix excludes them by construction).
+//
+// CTL-959: /dep-graph is also a board-entry route (mounted by AppRouter in
+// board.html via src/board/main.tsx). Hard navigation / refresh must serve
+// board.html rather than 404ing.
 export function isDetailDeepLinkPath(pathname: string): boolean {
+  if (pathname === "/dep-graph") return true;
   const m = /^\/(ticket|worker)\/([^/]+)$/.exec(pathname);
   return m != null && !m[2].includes(".");
 }

--- a/plugins/dev/scripts/orch-monitor/ui/bun.lock
+++ b/plugins/dev/scripts/orch-monitor/ui/bun.lock
@@ -29,7 +29,6 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.7",
-        "@types/dagre": "^0.7.54",
         "@types/lodash.throttle": "^4.1.9",
         "@types/react": "^19.1.4",
         "@types/react-dom": "^19.1.5",
@@ -397,8 +396,6 @@
     "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
 
     "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
-
-    "@types/dagre": ["@types/dagre@0.7.54", "", {}, "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 

--- a/plugins/dev/scripts/orch-monitor/ui/package.json
+++ b/plugins/dev/scripts/orch-monitor/ui/package.json
@@ -32,7 +32,6 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.7",
-    "@types/dagre": "^0.7.54",
     "@types/lodash.throttle": "^4.1.9",
     "@types/react": "^19.1.4",
     "@types/react-dom": "^19.1.5",

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/dependency-graph.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/dependency-graph.test.ts
@@ -111,6 +111,33 @@ function mkTicket(id: string, blockers: string[] = []): BoardTicket {
   };
 }
 
+/**
+ * Computes the full set of node IDs that BacklogDepGraph renders — including
+ * "terminal" blocker nodes whose IDs appear in some ticket's blockers[] but
+ * are not themselves present in the `tickets` array (Done / excluded).
+ * Mirrors the CTL-959 fix: edges must have both endpoints in the graph.
+ */
+function participatingWithTerminals(tickets: BoardTicket[]): { participating: Set<string>; terminals: Set<string> } {
+  const rev = buildReverseIndex(tickets);
+  const p = new Set<string>();
+  for (const t of tickets) {
+    if ((t.blockers?.length ?? 0) > 0 || rev.has(t.id)) {
+      p.add(t.id);
+    }
+  }
+  const ticketIds = new Set(tickets.map((t) => t.id));
+  const terminals = new Set<string>();
+  for (const id of p) {
+    const t = tickets.find((x) => x.id === id);
+    for (const blockerId of t?.blockers ?? []) {
+      if (!p.has(blockerId) && !ticketIds.has(blockerId)) {
+        terminals.add(blockerId);
+      }
+    }
+  }
+  return { participating: p, terminals };
+}
+
 // ── BacklogDepGraph: participating set ───────────────────────────────────────
 describe("BacklogDepGraph — participating ticket filter", () => {
   it("returns empty set when no tickets have dep relations", () => {
@@ -136,6 +163,37 @@ describe("BacklogDepGraph — participating ticket filter", () => {
   it("does not crash on empty blockers array", () => {
     const tickets = [mkTicket("X", []), mkTicket("Y", [])];
     expect(participating(tickets).size).toBe(0);
+  });
+});
+
+// ── BacklogDepGraph: terminal (Done/excluded) blocker nodes ──────────────────
+// CTL-959: edges need both endpoints. When a blocker is Done and excluded from
+// the payload, the component must add a "terminal" dimmed node so the edge
+// actually renders instead of being silently skipped.
+describe("BacklogDepGraph — terminal nodes for Done/excluded blockers (CTL-959)", () => {
+  it("detects a terminal node when a blocker is not in the tickets list", () => {
+    // B is blocked by A, but A was Done and is absent from the payload.
+    const tickets = [mkTicket("B", ["A"])];
+    const { participating: p, terminals } = participatingWithTerminals(tickets);
+    expect(p.has("B")).toBe(true);   // B participates (it has a blocker)
+    expect(terminals.has("A")).toBe(true); // A is a terminal (referenced but absent)
+  });
+
+  it("does not add terminal nodes when the blocker IS in the payload", () => {
+    const tickets = [mkTicket("A"), mkTicket("B", ["A"])];
+    const { participating: p, terminals } = participatingWithTerminals(tickets);
+    expect(p.has("A")).toBe(true);
+    expect(terminals.size).toBe(0); // A is present — no terminals needed
+  });
+
+  it("handles mixed: some blockers present, some Done/excluded", () => {
+    // C blocked by both A (present) and GONE (absent)
+    const tickets = [mkTicket("A"), mkTicket("C", ["A", "GONE"])];
+    const { participating: p, terminals } = participatingWithTerminals(tickets);
+    expect(p.has("A")).toBe(true);
+    expect(p.has("C")).toBe(true);
+    expect(terminals.has("GONE")).toBe(true);
+    expect(terminals.has("A")).toBe(false); // A is present, not terminal
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/dependency-graph.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/dependency-graph.tsx
@@ -83,6 +83,18 @@ function applyDagreLayout(
   });
 }
 
+// ── scope label helpers ──────────────────────────────────────────────────────
+// Maps the raw scope string stored on BoardTicket to the 2-letter display abbr
+// used everywhere else in the board (e.g. Board.tsx SCOPE_ABBR). Raw values
+// come from Linear's estimate field as lowercase size names.
+const SCOPE_ABBR: Record<string, string> = {
+  xs: "XS",
+  small: "S",
+  medium: "M",
+  large: "L",
+  xl: "XL",
+};
+
 // ── shared node color helpers ────────────────────────────────────────────────
 function phaseColor(phase: string): string {
   return PHASE[phase] ?? C.fgDim;
@@ -91,6 +103,7 @@ function phaseColor(phase: string): string {
 // ── TicketNode custom React Flow node ────────────────────────────────────────
 // A compact card: ID monospace chip · title truncated · scope/estimate badge.
 // Colored left-border uses the phase color. Used in both graph variants.
+// `terminal` = true for Done/excluded tickets included only to anchor an edge.
 interface TicketNodeData {
   id: string;
   title: string;
@@ -98,23 +111,25 @@ interface TicketNodeData {
   estimate: number | null;
   scope: string | null;
   focused?: boolean;
+  terminal?: boolean; // Done/excluded node — dimmed, exists only to draw edges
   [key: string]: unknown;
 }
 
 function TicketNode({ data }: { data: TicketNodeData }) {
-  const pc = phaseColor(data.phase);
+  const pc = data.terminal ? C.fgDim : phaseColor(data.phase);
   const scopeLabel = data.estimate != null
     ? `${data.estimate}pt`
     : data.scope
-    ? data.scope.toUpperCase().slice(0, 2)
+    ? (SCOPE_ABBR[data.scope.toLowerCase()] ?? data.scope.toUpperCase().slice(0, 2))
     : null;
 
   return (
     <div
       style={{
-        background: data.focused ? C.s3 : C.s2,
+        background: data.terminal ? C.s1 : data.focused ? C.s3 : C.s2,
         border: `1px solid ${data.focused ? pc : C.border}`,
         borderLeft: `3px solid ${pc}`,
+        opacity: data.terminal ? 0.55 : 1,
         borderRadius: 7,
         padding: "7px 10px",
         width: NODE_WIDTH,
@@ -224,29 +239,42 @@ export function BacklogDepGraph({ tickets, visibleIds }: BacklogDepGraphProps) {
   const { nodes: rawNodes, edges: rawEdges } = useMemo(() => {
     const nodes: Node[] = [];
     const edges: Edge[] = [];
+    const addedNodeIds = new Set<string>();
 
-    for (const id of participating) {
+    // Helper: add a node (idempotent by addedNodeIds)
+    function addNode(id: string, terminal: boolean) {
+      if (addedNodeIds.has(id)) return;
+      addedNodeIds.add(id);
       const t = ticketById.get(id);
-      if (!t) continue;
       nodes.push({
-        id: t.id,
+        id,
         type: "ticket",
         position: { x: 0, y: 0 }, // dagre fills this
         data: {
-          id: t.id,
-          title: t.title,
-          phase: t.phase,
-          estimate: t.estimate,
-          scope: t.scope,
+          id,
+          title: t?.title ?? id, // fallback to id for completely unknown tickets
+          phase: t?.phase ?? "done",
+          estimate: t?.estimate ?? null,
+          scope: t?.scope ?? null,
+          terminal,
         } satisfies TicketNodeData,
       });
+    }
+
+    for (const id of participating) {
+      addNode(id, false);
+      const t = ticketById.get(id);
 
       // Edge from each blocker → this ticket (blocker must execute first → left of target)
-      for (const blockerId of t.blockers ?? []) {
-        // Only draw the edge if both ends are in the graph
-        if (participating.has(blockerId)) {
-          edges.push(makeEdge(blockerId, t.id));
+      for (const blockerId of t?.blockers ?? []) {
+        if (!addedNodeIds.has(blockerId)) {
+          // Blocker is not in participating set (Done/excluded) — add as terminal node
+          // so the edge has both endpoints and actually renders.
+          if (!participating.has(blockerId)) {
+            addNode(blockerId, true);
+          }
         }
+        edges.push(makeEdge(blockerId, id));
       }
     }
 


### PR DESCRIPTION
## Summary

- **EDGES NOT DRAWN** (CTL-959 #1): Done/excluded blocker tickets were missing from the node set, so `blocked_by` edges had no target endpoint and were silently skipped. Fix adds terminal (dimmed, 55% opacity) nodes for any referenced blocker not in the active payload, ensuring all edges render.
- **SCOPE LABELS** (CTL-959 #2): Node chips were showing 2-letter truncations (`LA`/`SM`/`EP`/`ME`) instead of clean size abbrs. Replaced `.toUpperCase().slice(0,2)` with a `SCOPE_ABBR` map (`xs→XS, small→S, medium→M, large→L, xl→XL`) matching `Board.tsx`.
- **`/dep-graph` SPA FALLBACK** (CTL-959 #3): Hard navigation to `/dep-graph` 404'd. Added `pathname === "/dep-graph"` to `isDetailDeepLinkPath` so the server serves `board.html` (the AppRouter entry) instead.
- **KNIP DEBT** (CTL-959 #4): `@types/dagre` was an unused devDependency — `@dagrejs/dagre@3` ships its own types at `dist/types/index.d.ts`. Removed from `ui/package.json`; knip quality gate now passes.

## Test plan

- [x] `bun test src/board/dependency-graph.test.ts` — 15 pass (3 new: terminal-node detection)
- [x] `bun test __tests__/detail-deep-link-fallback.test.ts` — 13 pass (3 new: `/dep-graph` predicate + integration)
- [x] `bunx tsc --noEmit -p tsconfig.json` — only pre-existing `kpi-strip.tsx` error, none new
- [x] `bun x knip` — `@types/dagre` gone, only pre-existing `class-variance-authority` hint remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)