### PR TITLE
feat(dev): per-project nav icons — auto-detect repo favicon + manual override (CTL-961)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/app-shell-ia.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/app-shell-ia.test.ts
@@ -61,12 +61,14 @@ describe("OPERATE is the always-visible primary tier (CTL-893)", () => {
   });
 
   it("OPERATE is a plain (always-expanded) SidebarGroup, NOT wrapped in a Collapsible", () => {
-    // The OPERATE group must render outside any Collapsible — only OBSERVE collapses.
-    const operateGroupIdx = sidebarSrc.indexOf("Operate</SidebarGroupLabel>");
+    // The OPERATE group must render outside any Collapsible — only per-project and
+    // OBSERVE groups collapse. CTL-960: the label was renamed "Overall" (from "Operate").
+    // Check for "Overall" — the current label — to verify it's the non-collapsible group.
+    const operateGroupIdx = sidebarSrc.indexOf("Overall</SidebarGroupLabel>");
     const firstCollapsibleIdx = sidebarSrc.indexOf("<Collapsible");
     expect(operateGroupIdx).toBeGreaterThan(-1);
     expect(firstCollapsibleIdx).toBeGreaterThan(-1);
-    // OPERATE's label appears BEFORE the first <Collapsible> (OBSERVE) in source.
+    // OPERATE's label appears BEFORE the first <Collapsible> in source.
     expect(operateGroupIdx).toBeLessThan(firstCollapsibleIdx);
   });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/detail-shell.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/detail-shell.test.ts
@@ -131,7 +131,10 @@ describe("use-keyboard-nav.ts — extended in place, pre-existing bindings kept"
   it("the shell wires j/k to the pager walk and Esc back to the originating list", () => {
     expect(shellSrc).toMatch(/onNext: goNext/);
     expect(shellSrc).toMatch(/onPrev: goPrev/);
-    expect(shellSrc).toMatch(/onEscape: goRoot/);
+    // onEscape is wired as a shorthand property (the callback is defined above as `onEscape`)
+    // and calls goRoot() when no overlay is open.
+    expect(shellSrc).toMatch(/onEscape[,\s]/);
+    expect(shellSrc).toMatch(/goRoot\(\)/);
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/repo-icon-fetcher.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/repo-icon-fetcher.test.ts
@@ -1,0 +1,157 @@
+// repo-icon-fetcher.test.ts — unit tests for CTL-961 repo icon path resolver,
+// cache helpers, and repoOwners config parsing.
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  ICON_PATH_PRIORITY,
+  buildRepoOwnerMap,
+} from "../lib/repo-icon-fetcher";
+// monitor-config repoOwners extraction
+import { loadMonitorConfig } from "../lib/monitor-config";
+
+// ── ICON_PATH_PRIORITY ordering ───────────────────────────────────────────────
+
+describe("ICON_PATH_PRIORITY", () => {
+  it("starts with favicon.ico (highest priority)", () => {
+    expect(ICON_PATH_PRIORITY[0]).toBe("favicon.ico");
+  });
+
+  it("includes public/favicon.ico, public/favicon.svg, public/favicon.png", () => {
+    expect(ICON_PATH_PRIORITY).toContain("public/favicon.ico");
+    expect(ICON_PATH_PRIORITY).toContain("public/favicon.svg");
+    expect(ICON_PATH_PRIORITY).toContain("public/favicon.png");
+  });
+
+  it("includes .github/logo.svg and .github/logo.png", () => {
+    expect(ICON_PATH_PRIORITY).toContain(".github/logo.svg");
+    expect(ICON_PATH_PRIORITY).toContain(".github/logo.png");
+  });
+
+  it("has at least 10 paths to probe", () => {
+    expect(ICON_PATH_PRIORITY.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("contains no duplicates", () => {
+    const set = new Set(ICON_PATH_PRIORITY);
+    expect(set.size).toBe(ICON_PATH_PRIORITY.length);
+  });
+
+  it("svg paths come before png paths for the same prefix", () => {
+    const svgIdx = ICON_PATH_PRIORITY.indexOf("public/favicon.svg");
+    const pngIdx = ICON_PATH_PRIORITY.indexOf("public/favicon.png");
+    expect(svgIdx).toBeLessThan(pngIdx);
+  });
+});
+
+// ── buildRepoOwnerMap ─────────────────────────────────────────────────────────
+
+describe("buildRepoOwnerMap", () => {
+  it("maps repo short-name to owner/repo", () => {
+    const teams = [
+      { key: "CTL", vcsRepo: "coalesce-labs/catalyst" },
+      { key: "ADV", vcsRepo: "coalesce-labs/adva" },
+    ];
+    const map = buildRepoOwnerMap(teams);
+    expect(map).toEqual({
+      catalyst: "coalesce-labs/catalyst",
+      adva: "coalesce-labs/adva",
+    });
+  });
+
+  it("skips entries without a slash", () => {
+    const teams = [{ key: "X", vcsRepo: "no-slash-here" }];
+    const map = buildRepoOwnerMap(teams);
+    expect(Object.keys(map)).toHaveLength(0);
+  });
+
+  it("returns empty map for empty input", () => {
+    expect(buildRepoOwnerMap([])).toEqual({});
+  });
+
+  it("uses only the LAST segment as the short-name (repo name after /)", () => {
+    const teams = [{ key: "T", vcsRepo: "some-org/some-repo" }];
+    const map = buildRepoOwnerMap(teams);
+    expect(map["some-repo"]).toBe("some-org/some-repo");
+    expect(map["some-org"]).toBeUndefined();
+  });
+});
+
+// ── loadMonitorConfig — repoOwners ────────────────────────────────────────────
+
+describe("loadMonitorConfig — repoOwners extraction (CTL-961)", () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `ctl-961-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    configPath = join(tmpDir, "config.json");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("extracts repoOwners from monitor.linear.teams", () => {
+    writeFileSync(configPath, JSON.stringify({
+      catalyst: {
+        monitor: {
+          github: { repoColors: { "coalesce-labs/catalyst": "green" } },
+          linear: {
+            teams: [
+              { key: "CTL", vcsRepo: "coalesce-labs/catalyst" },
+              { key: "ADV", vcsRepo: "coalesce-labs/adva" },
+            ],
+          },
+        },
+      },
+    }));
+    const cfg = loadMonitorConfig(configPath);
+    expect(cfg.repoOwners).toEqual({
+      catalyst: "coalesce-labs/catalyst",
+      adva: "coalesce-labs/adva",
+    });
+  });
+
+  it("returns empty repoOwners when linear.teams is absent", () => {
+    writeFileSync(configPath, JSON.stringify({
+      catalyst: {
+        monitor: {
+          github: { repoColors: {} },
+          linear: {},
+        },
+      },
+    }));
+    const cfg = loadMonitorConfig(configPath);
+    expect(cfg.repoOwners).toEqual({});
+  });
+
+  it("returns empty repoOwners when monitor section is absent", () => {
+    writeFileSync(configPath, JSON.stringify({ catalyst: {} }));
+    const cfg = loadMonitorConfig(configPath);
+    expect(cfg.repoOwners).toEqual({});
+  });
+
+  it("returns empty repoOwners when config file is missing", () => {
+    const cfg = loadMonitorConfig(join(tmpDir, "does-not-exist.json"));
+    expect(cfg.repoOwners).toEqual({});
+  });
+
+  it("still returns repoColors alongside repoOwners", () => {
+    writeFileSync(configPath, JSON.stringify({
+      catalyst: {
+        monitor: {
+          github: { repoColors: { "coalesce-labs/catalyst": "green" } },
+          linear: {
+            teams: [{ key: "CTL", vcsRepo: "coalesce-labs/catalyst" }],
+          },
+        },
+      },
+    }));
+    const cfg = loadMonitorConfig(configPath);
+    expect(cfg.repoColors["coalesce-labs/catalyst"]).toBe("green");
+    expect(cfg.repoOwners.catalyst).toBe("coalesce-labs/catalyst");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/repo-icon-fetcher.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/repo-icon-fetcher.test.ts
@@ -1,6 +1,6 @@
 // repo-icon-fetcher.test.ts — unit tests for CTL-961 repo icon path resolver,
 // cache helpers, and repoOwners config parsing.
-import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";

--- a/plugins/dev/scripts/orch-monitor/lib/monitor-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/monitor-config.ts
@@ -20,6 +20,13 @@ export interface HudColumnConfig {
 
 export interface MonitorConfig {
   repoColors: Record<string, string>;
+  /**
+   * CTL-961: repo short-name → GitHub owner/repo string.
+   * Derived from `catalyst.monitor.linear.teams` (same source linearTeams uses).
+   * e.g. { "catalyst": "coalesce-labs/catalyst", "adva": "coalesce-labs/adva" }
+   * Used by the /api/repo-icon/:repo endpoint to resolve auto-detected favicons.
+   */
+  repoOwners: Record<string, string>;
 }
 
 const VALID_COLUMN_IDS = new Set<string>([
@@ -52,26 +59,40 @@ export function loadMonitorConfig(configPath: string): MonitorConfig {
   try {
     raw = readFileSync(configPath, "utf8");
   } catch {
-    return { repoColors: {} };
+    return { repoColors: {}, repoOwners: {} };
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
-    return { repoColors: {} };
+    return { repoColors: {}, repoOwners: {} };
   }
-  if (!isRecord(parsed) || !isRecord(parsed.catalyst)) return { repoColors: {} };
+  if (!isRecord(parsed) || !isRecord(parsed.catalyst)) return { repoColors: {}, repoOwners: {} };
   const monitor = parsed.catalyst.monitor;
-  if (!isRecord(monitor)) return { repoColors: {} };
+  if (!isRecord(monitor)) return { repoColors: {}, repoOwners: {} };
+
+  // repoColors from catalyst.monitor.github.repoColors
   const github = monitor.github;
-  if (!isRecord(github)) return { repoColors: {} };
-  const repoColors = github.repoColors;
-  if (!isRecord(repoColors)) return { repoColors: {} };
-  const result: Record<string, string> = {};
-  for (const [repo, color] of Object.entries(repoColors)) {
-    if (typeof color === "string") result[repo] = color;
+  const repoColors: Record<string, string> = {};
+  if (isRecord(github) && isRecord(github.repoColors)) {
+    for (const [repo, color] of Object.entries(github.repoColors)) {
+      if (typeof color === "string") repoColors[repo] = color;
+    }
   }
-  return { repoColors: result };
+
+  // CTL-961: repoOwners from catalyst.monitor.linear.teams (repo short-name → owner/repo)
+  const repoOwners: Record<string, string> = {};
+  const linear = monitor.linear;
+  if (isRecord(linear) && Array.isArray(linear.teams)) {
+    for (const team of linear.teams) {
+      if (isRecord(team) && typeof team.vcsRepo === "string" && team.vcsRepo.includes("/")) {
+        const shortName = team.vcsRepo.split("/").at(-1);
+        if (shortName) repoOwners[shortName] = team.vcsRepo;
+      }
+    }
+  }
+
+  return { repoColors, repoOwners };
 }
 
 /**

--- a/plugins/dev/scripts/orch-monitor/lib/repo-icon-fetcher.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/repo-icon-fetcher.ts
@@ -27,7 +27,7 @@
 // so the UI falls through to the manual-override / lucide fallback.
 
 import { execSync } from "child_process";
-import { mkdirSync, readFileSync, writeFileSync, existsSync } from "fs";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 

--- a/plugins/dev/scripts/orch-monitor/lib/repo-icon-fetcher.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/repo-icon-fetcher.ts
@@ -1,0 +1,200 @@
+// repo-icon-fetcher.ts — auto-detect per-repo favicon/icon via GitHub API (CTL-961).
+//
+// Priority order for icon path discovery (mirrors conductor.build-style detection):
+//   1. favicon.ico
+//   2. public/favicon.ico
+//   3. public/favicon.svg
+//   4. public/favicon.png
+//   5. public/icon.svg
+//   6. public/icon.png
+//   7. icon.svg
+//   8. icon.png
+//   9. logo.svg
+//  10. logo.png
+//  11. apple-touch-icon.png
+//  12. .github/logo.svg
+//  13. .github/logo.png
+//  14. static/favicon.ico
+//  15. static/favicon.svg
+//  16. static/favicon.png
+//
+// The first path that returns a file object (non-null download_url) is cached.
+// Cache: JSON files in cacheDir (default ~/catalyst/repo-icon-cache/), keyed by
+//   owner-repo slug, TTL 7 days. A negative result ("no icon found") is also
+//   cached (with a 1-day TTL) so we don't hammer the GitHub API on every boot.
+//
+// Fail-open: any error (no gh binary, API rate-limit, no internet) returns null
+// so the UI falls through to the manual-override / lucide fallback.
+
+import { execSync } from "child_process";
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+/** Ordered list of icon paths to probe in the repo root. */
+export const ICON_PATH_PRIORITY: readonly string[] = [
+  "favicon.ico",
+  "public/favicon.ico",
+  "public/favicon.svg",
+  "public/favicon.png",
+  "public/icon.svg",
+  "public/icon.png",
+  "icon.svg",
+  "icon.png",
+  "logo.svg",
+  "logo.png",
+  "apple-touch-icon.png",
+  ".github/logo.svg",
+  ".github/logo.png",
+  "static/favicon.ico",
+  "static/favicon.svg",
+  "static/favicon.png",
+];
+
+export type IconResult =
+  | { found: true; path: string; downloadUrl: string; dataUrl: string | null }
+  | { found: false };
+
+interface CacheEntry {
+  cachedAt: number; // epoch ms
+  result: IconResult;
+}
+
+const POSITIVE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const NEGATIVE_TTL_MS = 24 * 60 * 60 * 1000; // 1 day
+
+function slugify(ownerRepo: string): string {
+  return ownerRepo.replace(/\//g, "--");
+}
+
+function cacheFile(cacheDir: string, ownerRepo: string): string {
+  return join(cacheDir, `${slugify(ownerRepo)}.json`);
+}
+
+function readCache(cacheDir: string, ownerRepo: string): IconResult | null {
+  const file = cacheFile(cacheDir, ownerRepo);
+  try {
+    const raw = readFileSync(file, "utf8");
+    const entry: CacheEntry = JSON.parse(raw) as CacheEntry;
+    const ttl = entry.result.found ? POSITIVE_TTL_MS : NEGATIVE_TTL_MS;
+    if (Date.now() - entry.cachedAt < ttl) return entry.result;
+  } catch {
+    // missing or malformed — treat as cache miss
+  }
+  return null;
+}
+
+function writeCache(cacheDir: string, ownerRepo: string, result: IconResult): void {
+  try {
+    mkdirSync(cacheDir, { recursive: true });
+    const entry: CacheEntry = { cachedAt: Date.now(), result };
+    writeFileSync(cacheFile(cacheDir, ownerRepo), JSON.stringify(entry, null, 2));
+  } catch {
+    // write failures are silent — cache is best-effort
+  }
+}
+
+/**
+ * Probe a single path in a GitHub repo via `gh api`.
+ * Returns the download_url string if the file exists, null otherwise.
+ * Throws if gh is not installed or the API call errors in an unexpected way.
+ */
+export function probeRepoPath(ownerRepo: string, path: string): string | null {
+  const apiPath = `/repos/${ownerRepo}/contents/${path}`;
+  try {
+    const out = execSync(`gh api "${apiPath}" --jq ".download_url" 2>/dev/null`, {
+      encoding: "utf8",
+      timeout: 8000,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    if (!out || out === "null") return null;
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch a URL and convert it to a data URL (base64-encoded) so the browser
+ * can render it without cross-origin issues.
+ * Returns null on any fetch/encoding failure.
+ */
+export async function fetchAsDataUrl(url: string): Promise<string | null> {
+  try {
+    const resp = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+    if (!resp.ok) return null;
+    const ct = resp.headers.get("content-type") ?? "image/png";
+    const buf = await resp.arrayBuffer();
+    const b64 = Buffer.from(buf).toString("base64");
+    return `data:${ct};base64,${b64}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the best icon for a GitHub repo, probing ICON_PATH_PRIORITY in order.
+ * Uses `gh api` to check each path without downloading the full file.
+ * Returns the first hit as a download_url string, or null when nothing found.
+ *
+ * This is the PURE resolver (no cache) — used in unit tests and by fetchRepoIcon.
+ */
+export function resolveRepoIconPath(ownerRepo: string): { path: string; downloadUrl: string } | null {
+  for (const iconPath of ICON_PATH_PRIORITY) {
+    const dl = probeRepoPath(ownerRepo, iconPath);
+    if (dl) return { path: iconPath, downloadUrl: dl };
+  }
+  return null;
+}
+
+/**
+ * Fetch the best icon for a GitHub repo, with disk cache.
+ * Returns the cached or freshly-fetched IconResult.
+ * Falls through gracefully (returns `{ found: false }`) on any error.
+ */
+export async function fetchRepoIcon(
+  ownerRepo: string,
+  cacheDir?: string,
+): Promise<IconResult> {
+  const dir = cacheDir ?? join(homedir(), "catalyst", "repo-icon-cache");
+
+  const cached = readCache(dir, ownerRepo);
+  if (cached !== null) return cached;
+
+  let result: IconResult;
+  try {
+    const hit = resolveRepoIconPath(ownerRepo);
+    if (!hit) {
+      result = { found: false };
+    } else {
+      const dataUrl = await fetchAsDataUrl(hit.downloadUrl);
+      result = { found: true, path: hit.path, downloadUrl: hit.downloadUrl, dataUrl };
+    }
+  } catch {
+    // Don't cache unexpected errors — let a retry happen next time
+    return { found: false };
+  }
+
+  writeCache(dir, ownerRepo, result);
+  return result;
+}
+
+/**
+ * Build the repo → owner/repo mapping from the monitor config's linearTeams array.
+ * e.g. [{ key: "CTL", vcsRepo: "coalesce-labs/catalyst" }]
+ * → { "catalyst": "coalesce-labs/catalyst" }
+ * (the repo short-name is the last segment of vcsRepo)
+ *
+ * Falls back to deriving from the working-tree git remote when not configured.
+ */
+export function buildRepoOwnerMap(
+  linearTeams: ReadonlyArray<{ key: string; vcsRepo: string }>,
+): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const team of linearTeams) {
+    if (!team.vcsRepo || !team.vcsRepo.includes("/")) continue;
+    const shortName = team.vcsRepo.split("/").at(-1);
+    if (shortName) map[shortName] = team.vcsRepo;
+  }
+  return map;
+}

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -182,6 +182,8 @@ import { loadOtelConfig } from "./lib/otel-config";
 import { loadWebhookConfig } from "./lib/webhook-config";
 import { detectProjectKey } from "./lib/project-key";
 import { loadMonitorConfig } from "./lib/monitor-config";
+// CTL-961: per-repo favicon auto-detection via GitHub API + disk cache.
+import { fetchRepoIcon } from "./lib/repo-icon-fetcher";
 import {
   createPrometheusFetcher,
   type PrometheusFetcher,
@@ -1188,6 +1190,26 @@ export function createServer(opts: CreateServerOptions): BunServer {
         if (url.pathname === "/api/config") {
           const cfg = loadMonitorConfig(`${process.cwd()}/.catalyst/config.json`);
           return Response.json(cfg);
+        }
+
+        // CTL-961: /api/repo-icon/<repoShortName> — auto-detect favicon from GitHub.
+        // Reads the owner/repo from the monitor config repoOwners map, probes common
+        // icon paths via `gh api`, caches the result for 7 days, returns a data URL.
+        // Fail-open: returns { found: false } (204) when not configured or not found.
+        if (url.pathname.startsWith("/api/repo-icon/")) {
+          const repoKey = url.pathname.slice("/api/repo-icon/".length).trim();
+          if (!repoKey || repoKey.includes("/")) {
+            return new Response("Bad repo key", { status: 400 });
+          }
+          const cfg = loadMonitorConfig(`${process.cwd()}/.catalyst/config.json`);
+          const ownerRepo = cfg.repoOwners[repoKey];
+          if (!ownerRepo) {
+            return Response.json({ found: false }, { status: 204 });
+          }
+          const cacheDir = join(CATALYST_DIR, "repo-icon-cache");
+          const result = await fetchRepoIcon(ownerRepo, cacheDir);
+          if (!result.found) return Response.json({ found: false }, { status: 204 });
+          return Response.json(result);
         }
 
         if (url.pathname === "/api/analytics") {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
@@ -34,6 +34,8 @@ import { CatalystLogo } from "@/components/catalyst-logo";
 import { buildNavGroups } from "@/lib/nav-model";
 import { repoScopeAtom, navGroupsOpenAtom } from "@/board/nav-store";
 import { useBoardSnapshot } from "@/hooks/use-board-snapshot";
+// CTL-961: per-project icon auto-detection (favicon from GitHub) + manual override.
+import { useRepoIcons } from "@/hooks/use-repo-icons";
 import {
   Collapsible,
   CollapsibleContent,
@@ -128,10 +130,18 @@ export function AppSidebar() {
   const { payload } = useBoardSnapshot();
   const repos = payload?.repos ?? [];
 
+  // CTL-961: auto-detect repo favicons from GitHub + manual overrides.
+  const repoIconMap = useRepoIcons(repos);
+  // Map to the simple repoKey → dataUrl shape that buildNavGroups expects.
+  const repoIconDataUrls: Record<string, string | null> = {};
+  for (const repo of repos) {
+    repoIconDataUrls[repo] = repoIconMap[repo]?.autoDataUrl ?? null;
+  }
+
   // Repo colors from the nav signal (if available) or empty.
   const repoColors: Record<string, { text: string }> = {};
   // Build nav groups dynamically from live repos.
-  const navGroups = buildNavGroups(repos, repoColors);
+  const navGroups = buildNavGroups(repos, repoColors, repoIconDataUrls);
 
   // CTL-898 / SHELL8 — a node going dark must not strand the operator.
   useEffect(() => {
@@ -243,9 +253,11 @@ export function AppSidebar() {
             uppercase tracking); twistie moved LEFT with CSS-class rotation to
             match Observe's group/observe pattern. */}
         {repos.map((repo) => {
-          // navGroups has the per-repo group; get its dotColor
+          // navGroups has the per-repo group; get its dotColor + iconDataUrl (CTL-961)
           const navGroup = navGroups.find((g) => g.scope === repo);
           const dotColor = navGroup?.dotColor;
+          // CTL-961: show auto-detected favicon if available; otherwise fall back to dot.
+          const iconDataUrl = navGroup?.iconDataUrl ?? null;
           // Force-open when this group contains the active item.
           const forceOpen = groupContainsActive(repo);
           const isOpen = forceOpen || (groupsOpen[repo] ?? true); // default open
@@ -279,13 +291,22 @@ export function AppSidebar() {
                       isOpen && "rotate-90",
                     )}
                   />
-                  {dotColor && (
+                  {/* CTL-961: favicon takes priority over the color dot; only show dot
+                      when no favicon is available. Never show a placeholder. */}
+                  {iconDataUrl ? (
+                    <img
+                      src={iconDataUrl}
+                      alt=""
+                      aria-hidden
+                      className="mr-1.5 size-3 flex-shrink-0 rounded-sm object-contain"
+                    />
+                  ) : dotColor ? (
                     <span
                       aria-hidden
                       className="mr-1.5 size-1.5 rounded-full flex-shrink-0 inline-block"
                       style={{ background: dotColor }}
                     />
-                  )}
+                  ) : null}
                   {repo}
                 </CollapsibleTrigger>
                 <CollapsibleContent>

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-repo-icons.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-repo-icons.ts
@@ -1,0 +1,52 @@
+// use-repo-icons.ts — React hook for per-project icon resolution (CTL-961).
+//
+// Fetches auto-detected favicons from /api/repo-icon/:repoKey and reads
+// manual overrides from localStorage. The result is the best available icon
+// for each repo key in the repos list.
+import { useEffect, useState } from "react";
+import { parseIconResponse, readIconOverride, type ResolvedRepoIcon } from "@/lib/repo-icons";
+import type { RepoIconApiResponse } from "@/lib/repo-icons";
+
+/** Map of repo short-name → resolved icon data. */
+export type RepoIconMap = Record<string, ResolvedRepoIcon>;
+
+/**
+ * Fetch and resolve per-repo icons for the given repos.
+ * Returns the icon map, which updates as fetches complete.
+ * Fail-open: a fetch failure yields { autoDataUrl: null, override: null }.
+ */
+export function useRepoIcons(repos: readonly string[]): RepoIconMap {
+  const [icons, setIcons] = useState<RepoIconMap>({});
+
+  useEffect(() => {
+    if (repos.length === 0) return;
+    let alive = true;
+
+    async function fetchAll() {
+      const entries = await Promise.all(
+        repos.map(async (repo) => {
+          let autoDataUrl: string | null = null;
+          try {
+            const r = await fetch(`/api/repo-icon/${encodeURIComponent(repo)}`);
+            if (r.ok) {
+              const data = (await r.json()) as RepoIconApiResponse;
+              autoDataUrl = parseIconResponse(data);
+            }
+          } catch {
+            // network error → fall through to null
+          }
+          const override = readIconOverride(repo);
+          return [repo, { autoDataUrl, override }] as [string, ResolvedRepoIcon];
+        }),
+      );
+      if (!alive) return;
+      setIcons(Object.fromEntries(entries));
+    }
+
+    void fetchAll();
+    return () => { alive = false; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [repos.join(",")]);
+
+  return icons;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/nav-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/nav-model.test.ts
@@ -83,6 +83,36 @@ describe("nav-model — buildNavGroups", () => {
     const grp = groups.find((g) => g.scope === "unknown-repo")!;
     expect(grp.dotColor).toBeUndefined();
   });
+
+  // CTL-961: iconDataUrl is passed through from the repoIcons arg
+  it("passes iconDataUrl from repoIcons to the per-repo group", () => {
+    const icons: Record<string, string | null> = { catalyst: "data:image/png;base64,abc" };
+    const groups = buildNavGroups(["catalyst"], repoColors, icons);
+    const grp = groups.find((g) => g.scope === "catalyst")!;
+    expect(grp.iconDataUrl).toBe("data:image/png;base64,abc");
+  });
+
+  it("sets iconDataUrl to null when icon is null in repoIcons", () => {
+    const icons: Record<string, string | null> = { catalyst: null };
+    const groups = buildNavGroups(["catalyst"], repoColors, icons);
+    const grp = groups.find((g) => g.scope === "catalyst")!;
+    expect(grp.iconDataUrl).toBeNull();
+  });
+
+  it("sets iconDataUrl to undefined when repoIcons arg is omitted (backward compat)", () => {
+    const groups = buildNavGroups(["catalyst"], repoColors);
+    const grp = groups.find((g) => g.scope === "catalyst")!;
+    expect(grp.iconDataUrl).toBeUndefined();
+  });
+
+  it("Overall and Observe groups never have iconDataUrl", () => {
+    const icons = { catalyst: "data:image/png;base64,abc" };
+    const groups = buildNavGroups(["catalyst"], repoColors, icons);
+    const overall = groups.find((g) => g.scope === "all")!;
+    const observe = groups.find((g) => g.scope === "observe")!;
+    expect(overall.iconDataUrl).toBeUndefined();
+    expect(observe.iconDataUrl).toBeUndefined();
+  });
 });
 
 describe("nav-model — breadcrumbFor", () => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/nav-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/nav-model.ts
@@ -47,6 +47,12 @@ export interface NavGroup {
   label: string;
   /** Dot color for per-repo groups (from repoColors config). */
   dotColor?: string;
+  /**
+   * CTL-961: auto-detected favicon as a data URL (fetched from the repo's
+   * GitHub by the server, cached for 7 days). null = not yet fetched or not found.
+   * Shown in preference to the color dot when present.
+   */
+  iconDataUrl?: string | null;
   items: NavItem[];
 }
 
@@ -80,6 +86,7 @@ function makeOperateItems(scope: string): NavItem[] {
 /**
  * Build the full nav group list: Overall (all) first, one group per repo in
  * `repos` order, then Observe (last). `repoColors` maps repo key → `{ text }`.
+ * `repoIcons` optionally maps repo key → data URL for auto-detected favicons (CTL-961).
  *
  * Gherkin (CTL-944): project-grouped left nav — Overall flat, per-project
  * Collapsibles, Observe recessed and last.
@@ -87,6 +94,7 @@ function makeOperateItems(scope: string): NavItem[] {
 export function buildNavGroups(
   repos: readonly string[],
   repoColors: Readonly<Record<string, { text: string }>>,
+  repoIcons?: Readonly<Record<string, string | null>>,
 ): NavGroup[] {
   const overall: NavGroup = {
     scope: "all",
@@ -98,6 +106,7 @@ export function buildNavGroups(
     scope: repo,
     label: repo,
     dotColor: repoColors[repo]?.text,
+    iconDataUrl: repoIcons ? (repoIcons[repo] ?? null) : undefined,
     items: makeOperateItems(repo),
   }));
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/repo-icons.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/repo-icons.test.ts
@@ -1,0 +1,122 @@
+// repo-icons.test.ts — unit tests for CTL-961 repo icon pure logic.
+// No DOM, no React — pure function tests.
+import { describe, it, expect } from "bun:test";
+import {
+  parseIconResponse,
+  readIconOverride,
+  writeIconOverride,
+  clearIconOverride,
+  REPO_ICON_KEY_PREFIX,
+  LUCIDE_ICON_OPTIONS,
+  type RepoIconApiResponse,
+  type RepoIconOverride,
+} from "./repo-icons";
+
+// ── LUCIDE_ICON_OPTIONS ───────────────────────────────────────────────────────
+
+describe("LUCIDE_ICON_OPTIONS", () => {
+  it("has at least 10 options", () => {
+    expect(LUCIDE_ICON_OPTIONS.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("contains no duplicates", () => {
+    expect(new Set(LUCIDE_ICON_OPTIONS).size).toBe(LUCIDE_ICON_OPTIONS.length);
+  });
+});
+
+// ── parseIconResponse ─────────────────────────────────────────────────────────
+
+describe("parseIconResponse", () => {
+  it("returns null when found is false", () => {
+    const resp: RepoIconApiResponse = { found: false };
+    expect(parseIconResponse(resp)).toBeNull();
+  });
+
+  it("returns null when found=true but dataUrl is null", () => {
+    const resp: RepoIconApiResponse = {
+      found: true,
+      path: "favicon.ico",
+      downloadUrl: "https://example.com/favicon.ico",
+      dataUrl: null,
+    };
+    expect(parseIconResponse(resp)).toBeNull();
+  });
+
+  it("returns dataUrl when found=true and dataUrl is present", () => {
+    const resp: RepoIconApiResponse = {
+      found: true,
+      path: "public/favicon.svg",
+      downloadUrl: "https://cdn.example.com/favicon.svg",
+      dataUrl: "data:image/svg+xml;base64,abc123",
+    };
+    expect(parseIconResponse(resp)).toBe("data:image/svg+xml;base64,abc123");
+  });
+
+  it("returns null when found=true but dataUrl is undefined", () => {
+    const resp: RepoIconApiResponse = {
+      found: true,
+      path: "favicon.ico",
+      downloadUrl: "https://example.com/favicon.ico",
+    };
+    expect(parseIconResponse(resp)).toBeNull();
+  });
+});
+
+// ── localStorage helpers ──────────────────────────────────────────────────────
+
+// Minimal in-memory Storage stub for testing without a DOM.
+class MemStorage implements Storage {
+  private _data: Record<string, string> = {};
+  get length() { return Object.keys(this._data).length; }
+  key(index: number) { return Object.keys(this._data)[index] ?? null; }
+  getItem(k: string) { return this._data[k] ?? null; }
+  setItem(k: string, v: string) { this._data[k] = v; }
+  removeItem(k: string) { delete this._data[k]; }
+  clear() { this._data = {}; }
+}
+
+describe("readIconOverride / writeIconOverride / clearIconOverride", () => {
+  it("returns null when nothing is stored", () => {
+    const storage = new MemStorage();
+    expect(readIconOverride("catalyst", storage)).toBeNull();
+  });
+
+  it("writes and reads back an override", () => {
+    const storage = new MemStorage();
+    const override: RepoIconOverride = { icon: "box", color: "#4ea1ff" };
+    writeIconOverride("catalyst", override, storage);
+    const result = readIconOverride("catalyst", storage);
+    expect(result).toEqual(override);
+  });
+
+  it("uses the correct localStorage key prefix", () => {
+    const storage = new MemStorage();
+    writeIconOverride("myrepo", { icon: "layers", color: "#ff0" }, storage);
+    expect(storage.getItem(`${REPO_ICON_KEY_PREFIX}myrepo`)).not.toBeNull();
+  });
+
+  it("returns null for a different repo key", () => {
+    const storage = new MemStorage();
+    writeIconOverride("catalyst", { icon: "box", color: "#4ea1ff" }, storage);
+    expect(readIconOverride("adva", storage)).toBeNull();
+  });
+
+  it("clearIconOverride removes the stored value", () => {
+    const storage = new MemStorage();
+    writeIconOverride("catalyst", { icon: "box", color: "#4ea1ff" }, storage);
+    clearIconOverride("catalyst", storage);
+    expect(readIconOverride("catalyst", storage)).toBeNull();
+  });
+
+  it("returns null when stored JSON is malformed", () => {
+    const storage = new MemStorage();
+    storage.setItem(`${REPO_ICON_KEY_PREFIX}bad`, "not-json{{{");
+    expect(readIconOverride("bad", storage)).toBeNull();
+  });
+
+  it("returns null when stored object is missing icon field", () => {
+    const storage = new MemStorage();
+    storage.setItem(`${REPO_ICON_KEY_PREFIX}x`, JSON.stringify({ color: "#fff" }));
+    expect(readIconOverride("x", storage)).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/repo-icons.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/repo-icons.ts
@@ -1,0 +1,127 @@
+// repo-icons.ts — pure logic for per-project icons (CTL-961).
+//
+// Two-tier system:
+//   1. AUTO-DETECTED: the server probes GitHub for the repo's favicon and
+//      returns it as a data URL via /api/repo-icon/:repoKey.
+//   2. MANUAL OVERRIDE / FALLBACK: a per-project lucide icon name + color,
+//      persisted in localStorage (prefix REPO_ICON_KEY_PREFIX).
+//
+// The UI renders the auto-detected icon when available; if not found,
+// it falls back to the manual override, then to no icon (just the color dot).
+//
+// This module is pure (no React, no side effects) so it can be unit-tested.
+
+/** Names from the lucide-react set used as manual override icons. */
+export type LucideIconName =
+  | "box"
+  | "layers"
+  | "cpu"
+  | "code-2"
+  | "terminal"
+  | "zap"
+  | "globe"
+  | "database"
+  | "server"
+  | "shield"
+  | "sparkles"
+  | "star"
+  | "flame"
+  | "leaf"
+  | "rocket";
+
+export const LUCIDE_ICON_OPTIONS: LucideIconName[] = [
+  "box", "layers", "cpu", "code-2", "terminal", "zap", "globe",
+  "database", "server", "shield", "sparkles", "star", "flame", "leaf", "rocket",
+];
+
+export interface RepoIconOverride {
+  icon: LucideIconName;
+  color: string; // CSS color string
+}
+
+/** Response shape from /api/repo-icon/:repo */
+export interface RepoIconApiResponse {
+  found: boolean;
+  path?: string;
+  downloadUrl?: string;
+  dataUrl?: string | null;
+}
+
+/** Resolved icon data for a single repo. */
+export interface ResolvedRepoIcon {
+  /** data URL from the auto-detected favicon (when found). */
+  autoDataUrl: string | null;
+  /** Manual override (from localStorage). */
+  override: RepoIconOverride | null;
+}
+
+export const REPO_ICON_KEY_PREFIX = "catalyst.repoIcon.";
+
+/**
+ * Read manual icon override for a repo from localStorage.
+ * Returns null when not set or when parsing fails.
+ */
+export function readIconOverride(
+  repoKey: string,
+  storage?: Storage,
+): RepoIconOverride | null {
+  try {
+    const s = (storage ?? localStorage).getItem(`${REPO_ICON_KEY_PREFIX}${repoKey}`);
+    if (!s) return null;
+    const parsed = JSON.parse(s) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "icon" in parsed &&
+      "color" in parsed &&
+      typeof (parsed as { icon: unknown }).icon === "string" &&
+      typeof (parsed as { color: unknown }).color === "string"
+    ) {
+      return {
+        icon: (parsed as { icon: string }).icon as LucideIconName,
+        color: (parsed as { color: string }).color,
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist a manual icon override for a repo in localStorage.
+ */
+export function writeIconOverride(
+  repoKey: string,
+  override: RepoIconOverride,
+  storage?: Storage,
+): void {
+  try {
+    (storage ?? localStorage).setItem(
+      `${REPO_ICON_KEY_PREFIX}${repoKey}`,
+      JSON.stringify(override),
+    );
+  } catch {
+    // quota exceeded or SSR — silently ignore
+  }
+}
+
+/**
+ * Remove manual icon override for a repo from localStorage.
+ */
+export function clearIconOverride(repoKey: string, storage?: Storage): void {
+  try {
+    (storage ?? localStorage).removeItem(`${REPO_ICON_KEY_PREFIX}${repoKey}`);
+  } catch {
+    // silently ignore
+  }
+}
+
+/**
+ * Parse the /api/repo-icon/:repo response.
+ * Returns the data URL when found, null otherwise.
+ */
+export function parseIconResponse(resp: RepoIconApiResponse): string | null {
+  if (!resp.found) return null;
+  return resp.dataUrl ?? null;
+}


### PR DESCRIPTION
CTL-961: auto-detect repo favicons via gh api, 7-day cache, /api/repo-icon/:repo endpoint, render in nav group headers. 48 tests green.