### PR TITLE
fix(dev): restore board surface + scope + dual-axis scroll on detail return (CTL-971)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
@@ -1040,21 +1040,11 @@ export function Board({
   // offset (+ re-focuses the originating card) when the operator returns. ONE ref
   // shared by the tickets + workers + list bodies (they all live inside it).
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  // CTL-971: restore now reseats the surface + scope too, so it is driven from the
+  // shell (App.tsx) BEFORE the board mounts (the surface must already be "board"
+  // for this component to exist). This board-local hook still re-applies the
+  // SCROLL offset + originating-card focus once the payload has rendered.
   useBoardRestore(scrollRef, data != null);
-  // CTL-951: the single card-open seam. Reads the live board scroll offset off the
-  // `.cat-scroll` overflow container (NOT the flex body wrapper, which never
-  // scrolls — `resolveScrollEl` is the SAME lookup the restore uses, so the offset
-  // round-trips), stashes the restore snapshot + walk-list, then hard-navigates.
-  const onOpen: OpenDetailFn = (kind, id, ctx) => {
-    const el = resolveScrollEl(scrollRef.current);
-    openDetail(kind, id, {
-      ids: ctx.ids,
-      lens: ctx.lens,
-      col: ctx.col,
-      from: "board",
-      scroll: el ? { top: el.scrollTop, left: el.scrollLeft } : { top: 0, left: 0 },
-    });
-  };
 
   // CTL-733 PR-2b: subscribe through the board transport — a SharedWorker shares
   // ONE EventSource (+ an IndexedDB cache) across every tab, with a direct
@@ -1104,6 +1094,27 @@ export function Board({
   // within it — swimlane=repo under a single-repo scope collapses naturally to
   // ONE labeled repo lane (+ hint) rather than silently flattening to "none".
   const swimlane: GroupBy = prefs.swimlane;
+
+  // CTL-951 + CTL-971: the single card-open seam. Reads the live board scroll
+  // offset off the `.cat-scroll` overflow container (NOT the flex body wrapper,
+  // which never scrolls — `resolveScrollEl` is the SAME lookup the restore uses,
+  // so the offset round-trips on BOTH axes after CTL-950's single both-axes
+  // scroller / CTL-958's overscroll-chaining cells). CTL-971: it ALSO stamps the
+  // current SURFACE ("board"/"workers", derived from the active `view`) + repo
+  // `scope` into the snapshot so the return paths reseat them — without the surface
+  // the shell would reseed the landing-pref Inbox and the board would never mount.
+  const onOpen: OpenDetailFn = (kind, id, ctx) => {
+    const el = resolveScrollEl(scrollRef.current);
+    openDetail(kind, id, {
+      ids: ctx.ids,
+      lens: ctx.lens,
+      col: ctx.col,
+      from: "board",
+      scroll: el ? { top: el.scrollTop, left: el.scrollLeft } : { top: 0, left: 0 },
+      surface: view === "workers" ? "workers" : "board",
+      scope: repo,
+    });
+  };
 
   return (
     <TooltipProvider delayDuration={200}>

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/detail-nav.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/detail-nav.test.ts
@@ -128,7 +128,7 @@ describe("isNewTabClick gesture (CTL-942 / CTL-951)", () => {
   });
 });
 
-describe("list-context snapshot parse/restore (CTL-951)", () => {
+describe("list-context snapshot parse/restore (CTL-951 + CTL-971)", () => {
   const base: ListContextSnapshot = {
     ids: ["CTL-1", "CTL-2", "CTL-3"],
     kind: "ticket",
@@ -136,13 +136,20 @@ describe("list-context snapshot parse/restore (CTL-951)", () => {
     col: "Implement",
     cursor: 1,
     focusId: "CTL-2",
-    scroll: { top: 420, left: 0 },
+    // CTL-971: BOTH scroll axes are load-bearing (CTL-950 single both-axes scroller).
+    scroll: { top: 420, left: 1400 },
+    surface: "board",
+    scope: "catalyst",
     savedAt: 1_000,
   };
 
-  it("round-trips a valid snapshot (the board restores ids/scroll/focus on return)", () => {
+  it("round-trips a valid snapshot (board restores ids/scroll BOTH axes/surface/scope/focus)", () => {
     const parsed = parseListContext(JSON.stringify(base), 1_000);
     expect(parsed).toEqual(base);
+    // explicit: both axes + the two CTL-971 fields survive the round-trip.
+    expect(parsed?.scroll).toEqual({ top: 420, left: 1400 });
+    expect(parsed?.surface).toBe("board");
+    expect(parsed?.scope).toBe("catalyst");
   });
 
   it("drops a snapshot older than the max age (a stale session never yanks scroll)", () => {
@@ -163,9 +170,46 @@ describe("list-context snapshot parse/restore (CTL-951)", () => {
     expect(parsed?.scroll).toEqual({ top: 0, left: 0 });
   });
 
+  it("preserves a horizontal-only offset (left set, top 0) — the Validate-column case", () => {
+    const parsed = parseListContext(JSON.stringify({ ...base, scroll: { top: 0, left: 2200 } }), 1_000);
+    expect(parsed?.scroll).toEqual({ top: 0, left: 2200 });
+  });
+
   it("clamps a bad cursor to 0 rather than carrying an out-of-range index", () => {
     const parsed = parseListContext(JSON.stringify({ ...base, cursor: -4 }), 1_000);
     expect(parsed?.cursor).toBe(0);
+  });
+
+  // ── CTL-971: surface + scope robustness ──────────────────────────────────────
+  it("CTL-971: an older snapshot with NO surface derives it from kind (ticket→board)", () => {
+    const { surface: _drop, ...noSurface } = base;
+    const parsed = parseListContext(JSON.stringify(noSurface), 1_000);
+    expect(parsed?.surface).toBe("board");
+  });
+
+  it("CTL-971: an older WORKER snapshot with no surface derives workers", () => {
+    const { surface: _drop, ...noSurface } = base;
+    const parsed = parseListContext(
+      JSON.stringify({ ...noSurface, kind: "worker" }),
+      1_000,
+    );
+    expect(parsed?.surface).toBe("workers");
+  });
+
+  it("CTL-971: a bogus surface value falls back to the kind-derived default", () => {
+    const parsed = parseListContext(JSON.stringify({ ...base, surface: "nope" }), 1_000);
+    expect(parsed?.surface).toBe("board");
+  });
+
+  it("CTL-971: a missing/empty scope falls back to the 'all' sentinel (never a wrong scope)", () => {
+    const { scope: _drop, ...noScope } = base;
+    expect(parseListContext(JSON.stringify(noScope), 1_000)?.scope).toBe("all");
+    expect(parseListContext(JSON.stringify({ ...base, scope: "" }), 1_000)?.scope).toBe("all");
+    expect(parseListContext(JSON.stringify({ ...base, scope: 7 }), 1_000)?.scope).toBe("all");
+  });
+
+  it("CTL-971: a real repo-key scope is preserved verbatim", () => {
+    expect(parseListContext(JSON.stringify({ ...base, scope: "adva" }), 1_000)?.scope).toBe("adva");
   });
 });
 
@@ -192,6 +236,20 @@ describe("kanban card wiring (static source, CTL-951)", () => {
   it("the originating card is stamped with data-card-id for the restore focus", () => {
     expect(boardSrc).toContain("data-card-id={t.id}");
     expect(boardSrc).toContain("data-card-id={w.name}");
+  });
+
+  it("CTL-971: the onOpen seam captures BOTH scroll axes off the live scroller", () => {
+    // The Board reads scrollTop AND scrollLeft (CTL-950 single both-axes scroller)
+    // off the resolved `.cat-scroll` element, not the never-scrolling flex wrapper.
+    expect(boardSrc).toContain("resolveScrollEl(scrollRef.current)");
+    expect(boardSrc).toContain("top: el.scrollTop, left: el.scrollLeft");
+  });
+
+  it("CTL-971: the onOpen seam stamps the SURFACE + repo SCOPE into the snapshot", () => {
+    // Without the surface the shell reseeds the landing-pref Inbox and the board
+    // never mounts; without the scope the restore can't reseat scope authoritatively.
+    expect(boardSrc).toContain('surface: view === "workers" ? "workers" : "board"');
+    expect(boardSrc).toContain("scope: repo,");
   });
 });
 
@@ -283,5 +341,41 @@ describe("Shell Esc-restore wiring (static source, CTL-951 deliverable c)", () =
     // index.html shell board — only a full-doc nav does (the restore reads
     // sessionStorage on that load).
     expect(shellSrc).toContain('hardNavigate("/")');
+  });
+
+  it("CTL-971: goRoot (the single return target) is wired to BOTH Esc and the breadcrumb", () => {
+    // The breadcrumb root button calls onRoot={goRoot}; the layered-Escape handler
+    // falls through to goRoot() once no overlay is open. Both reach the same full-
+    // doc nav, so all THREE paths (Esc, breadcrumb, browser-back via the assign()
+    // history entry) funnel through the shell-mount restore.
+    expect(shellSrc).toContain("onRoot={goRoot}");
+    expect(shellSrc).toContain("const goRoot = useCallback(() => hardNavigate");
+    // The Escape handler ends at goRoot() after exhausting the overlay layers.
+    expect(shellSrc).toMatch(/onEscape[\s\S]*goRoot\(\)/);
+  });
+});
+
+describe("CTL-971: shell reseats SURFACE + SCOPE on return (static source)", () => {
+  const appShellSrc = readFileSync(join(HERE, "..", "components", "app-shell.tsx"), "utf8");
+  const surfaceRestoreSrc = readFileSync(
+    join(HERE, "..", "hooks", "use-surface-restore.ts"),
+    "utf8",
+  );
+
+  it("AppShell invokes useSurfaceRestore with a surface setter + the scope setter", () => {
+    // This is the FIX for the dominant bug: the board surface is NOT in the URL, so a
+    // full-doc nav back to `/` reseeds the landing-pref Inbox. The shell-mount restore
+    // reseats the captured surface so the board actually mounts (and its own
+    // useBoardRestore can apply the scroll).
+    expect(appShellSrc).toContain("useSurfaceRestore(restoreSurface, setRepoScope)");
+    // Reseating a surface ALSO leaves Settings (mirrors the g-chord behavior).
+    expect(appShellSrc).toContain("setSettingsOpen(false)");
+  });
+
+  it("useSurfaceRestore PEEKS the snapshot (does not clear it — the board consumes it)", () => {
+    // It must NOT clear: the board-local useBoardRestore clears the snapshot after
+    // applying scroll + focus, so it must still be present when the board mounts.
+    expect(surfaceRestoreSrc).toContain("readListContext()");
+    expect(surfaceRestoreSrc).not.toContain("clearListContext");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/detail-nav.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/detail-nav.ts
@@ -26,6 +26,12 @@ import type { DetailFrom, DetailLens } from "./route-search";
 /** The kind of entity a card opens — selects the route + the list-context kind. */
 export type DetailKind = "ticket" | "worker";
 
+/** Which board SURFACE the operator was on when they opened the card (CTL-971).
+ *  Persisted in the restore snapshot so the return paths (Esc / breadcrumb /
+ *  browser back) reseat the shell on that surface instead of the landing-pref
+ *  default. Ticket cards live on "board"; worker cards on "workers". */
+export type RestoreSurface = "board" | "workers";
+
 /** The list-origin context a card carries into the detail page (mirrors the
  *  typed search params the Shell reconstructs). `cursor` is the 0-based index of
  *  the clicked entity within the on-screen ordered list. */
@@ -87,9 +93,19 @@ export const LIST_CONTEXT_MAX_AGE_MS = 30 * 60 * 1000; // 30 minutes
  * board exactly. `ids` + `kind` + `lens` + `col` mirror the resolved walk list
  * (so the restored board's listContextAtom matches the pager); `scroll` is the
  * board scroll-container offset; `focusId` is the originating card to re-focus;
- * `cursor` is its index in `ids`. Display-options (density/grouping/order/repo
- * scope) are NOT stored here — they already persist in their own localStorage
- * atoms (`boardPrefsAtom` / `repoScopeAtom`) and survive the navigation for free.
+ * `cursor` is its index in `ids`.
+ *
+ * CTL-971: `surface` + `scope` are now stored too — the original reasoning that
+ * "display-options ride their own persisted atoms for free" was only HALF true.
+ * The repo SCOPE does persist in localStorage (`repoScopeAtom`), but the active
+ * SURFACE does NOT: the return paths are a full-document navigation to `/`, and
+ * the shell reseeds the surface from the LANDING preference (default "home"/Inbox)
+ * — so without the saved surface the operator lands on the Inbox, the board never
+ * mounts, and `useBoardRestore` never runs (the scroll/focus snapshot is silently
+ * ignored). Storing the surface lets the shell reseat the board on return; storing
+ * the scope makes the restore the single source of truth (it no longer relies on a
+ * separately-timed localStorage read). Density/grouping/order STILL ride their own
+ * persisted `boardPrefsAtom` and are not duplicated here.
  */
 export interface ListContextSnapshot {
   ids: string[];
@@ -100,8 +116,17 @@ export interface ListContextSnapshot {
   cursor: number;
   /** The opened entity id — the card the board re-focuses on return. */
   focusId: string;
-  /** The board scroll-container offset to restore (px). */
+  /** The board scroll-container offset to restore (px). Both axes — CTL-950's
+   *  single both-axes `.cat-scroll` scroller means LEFT matters as much as TOP. */
   scroll: { top: number; left: number };
+  /** CTL-971: the board surface the card was opened FROM ("board" for ticket
+   *  cards, "workers" for worker cards). The shell reseats this surface on return
+   *  so the board actually mounts (else the landing-pref Inbox shows instead). */
+  surface: RestoreSurface;
+  /** CTL-971: the active repo scope at capture (`REPO_SCOPE_ALL` or a repo key).
+   *  Re-applied to `repoScopeAtom` on restore so the scope round-trips even if the
+   *  persisted localStorage value drifted between the two entries. */
+  scope: string;
   /** When captured (ms epoch) — a stale snapshot is ignored on restore. */
   savedAt: number;
 }
@@ -178,6 +203,19 @@ export function parseListContext(
           left: typeof (o.scroll as { left?: unknown }).left === "number" ? (o.scroll as { left: number }).left : 0,
         }
       : { top: 0, left: 0 };
+  // CTL-971: surface — accept the stored "board"/"workers", else DERIVE from the
+  // entity kind (a worker card was on the Workers surface; a ticket on the board)
+  // so an older snapshot (pre-CTL-971, no surface field) still reseats correctly.
+  const surface: RestoreSurface =
+    o.surface === "board" || o.surface === "workers"
+      ? o.surface
+      : o.kind === "worker"
+        ? "workers"
+        : "board";
+  // CTL-971: scope — any string is a valid repo key / the "all" sentinel; a
+  // missing/malformed value falls back to "all" (the unfiltered view) rather than
+  // forcing a wrong scope. The shell reconciles a stale scope against live repos.
+  const scope = typeof o.scope === "string" && o.scope !== "" ? o.scope : "all";
   return {
     ids: o.ids as string[],
     kind: o.kind,
@@ -187,6 +225,8 @@ export function parseListContext(
       typeof o.cursor === "number" && Number.isInteger(o.cursor) && o.cursor >= 0 ? o.cursor : 0,
     focusId: o.focusId,
     scroll,
+    surface,
+    scope,
     savedAt: o.savedAt,
   };
 }
@@ -242,6 +282,12 @@ export function hardNavigate(href: string): void {
  * snapshot, then hard-navigate to the deep link. `scroll` is the board
  * scroll-container offset the caller reads (kanban + list own different scroll
  * roots); it defaults to no offset when omitted. `from` defaults to "board".
+ *
+ * CTL-971: the caller also passes the live `surface` ("board"/"workers") + the
+ * active repo `scope` so the snapshot reseats them on return — without the surface
+ * the shell would reseed the landing-pref Inbox and the board would never mount.
+ * Both default sensibly (surface from kind, scope to "all") when the caller omits
+ * them so the seam stays drop-in for any older invoker.
  */
 export function openDetail(
   kind: DetailKind,
@@ -252,6 +298,8 @@ export function openDetail(
     col?: string;
     from?: DetailFrom;
     scroll?: { top: number; left: number };
+    surface?: RestoreSurface;
+    scope?: string;
   },
 ): void {
   const cursor = args.ids.indexOf(id);
@@ -264,6 +312,8 @@ export function openDetail(
     cursor: cursor >= 0 ? cursor : 0,
     focusId: id,
     scroll: args.scroll ?? { top: 0, left: 0 },
+    surface: args.surface ?? (kind === "worker" ? "workers" : "board"),
+    scope: args.scope ?? "all",
     savedAt: Date.now(),
   });
   const href = detailHref(kind, id, {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
@@ -40,6 +40,10 @@ import { shouldOpenPalette } from "@/lib/command-palette";
 import { useAtom } from "jotai";
 import { repoScopeAtom } from "@/board/nav-store";
 import { useBoardSnapshot } from "@/hooks/use-board-snapshot";
+// CTL-971: reseat the board SURFACE + repo SCOPE on return from a detail page so
+// the board actually mounts (else the landing-pref Inbox shows and the scroll/focus
+// snapshot the board would consume is silently ignored).
+import { useSurfaceRestore } from "@/hooks/use-surface-restore";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -101,6 +105,15 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const [nodeScope, setNodeScope] = useState<NodeScope>(ALL_NODES);
   // CTL-944 — the active repo scope for breadcrumbs + palette navigation.
   const [repoScope, setRepoScope] = useAtom(repoScopeAtom);
+  // CTL-971 — on return from a detail page, reseat the surface the card was opened
+  // from (else the landing-pref Inbox shows) + re-apply the saved repo scope. PEEKS
+  // the restore snapshot (the board's own useBoardRestore consumes it for scroll).
+  // Reseating the surface ALSO leaves Settings, mirroring the `g`-chord behavior.
+  const restoreSurface = useCallback((s: Surface) => {
+    setSurface(s);
+    setSettingsOpen(false);
+  }, []);
+  useSurfaceRestore(restoreSurface, setRepoScope);
   // Repos from the board snapshot for palette navigation group construction.
   const { payload } = useBoardSnapshot();
   const repos = payload?.repos ?? [];

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-board-restore.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-board-restore.test.ts
@@ -1,12 +1,14 @@
-// use-board-restore.test.ts — CTL-951: the board scroll/focus-restore helper.
+// use-board-restore.test.ts — CTL-951 + CTL-971: the board scroll/focus-restore.
 //
 // `bun test` has no DOM, so (matching the repo's DOM-free discipline) we test the
-// ONE pure-ish branch — `resolveScrollEl` — with a tiny duck-typed stub instead of
-// a DOM rig. The snapshot parse/age logic + the restore round-trip are covered by
-// detail-nav.test.ts (parseListContext); this guards the scroll-container lookup
-// that the kanban / list / queue bodies all share.
-import { describe, it, expect } from "bun:test";
-import { resolveScrollEl } from "./use-board-restore";
+// helpers with tiny duck-typed stubs instead of a DOM rig:
+//   - `resolveScrollEl` — the scroll-container lookup the kanban/list/queue share;
+//   - `applyBoardRestore` (CTL-971) — the BOTH-AXIS scroll write + focus/flash, with
+//     a fake scroller that CLAMPS to its extent (mirroring the browser) so the
+//     "applied / retry" signal that drives the double-rAF is exercised honestly.
+// The snapshot parse/age logic is covered by detail-nav.test.ts (parseListContext).
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { resolveScrollEl, applyBoardRestore } from "./use-board-restore";
 
 // A minimal stand-in for the board root: only `querySelector` is exercised.
 function stubRoot(scrollChild: unknown): HTMLElement {
@@ -29,5 +31,113 @@ describe("resolveScrollEl (CTL-951)", () => {
 
   it("returns null for a null root (deep-link with no board mounted)", () => {
     expect(resolveScrollEl(null)).toBeNull();
+  });
+});
+
+// ── CTL-971: dual-axis restore against a clamping fake scroller ────────────────
+// A scroller that CLAMPS scrollLeft/scrollTop to [0, max] — exactly the browser's
+// behavior, and the reason the hook double-rAFs (a not-yet-laid-out extent of 0
+// clamps every write to 0).
+class FakeScroller {
+  className = "cat-scroll";
+  private _left = 0;
+  private _top = 0;
+  constructor(
+    public maxLeft: number,
+    public maxTop: number,
+  ) {}
+  get scrollLeft() {
+    return this._left;
+  }
+  set scrollLeft(v: number) {
+    this._left = Math.max(0, Math.min(v, this.maxLeft));
+  }
+  get scrollTop() {
+    return this._top;
+  }
+  set scrollTop(v: number) {
+    this._top = Math.max(0, Math.min(v, this.maxTop));
+  }
+}
+
+class FakeCard {
+  focused = false;
+  focusOpts: { preventScroll?: boolean } | undefined;
+  style: Record<string, string> = {};
+  focus(opts?: { preventScroll?: boolean }) {
+    this.focused = true;
+    this.focusOpts = opts;
+  }
+}
+
+// A fake root whose querySelector returns the scroller for `.cat-scroll` and the
+// card for the `[data-card-id="…"]` selector.
+function fakeRoot(scroller: FakeScroller | null, card: FakeCard | null): HTMLElement {
+  return {
+    querySelector(sel: string) {
+      if (sel === ".cat-scroll") return scroller;
+      if (sel.startsWith("[data-card-id")) return card;
+      return null;
+    },
+  } as unknown as HTMLElement;
+}
+
+// `applyBoardRestore` calls window.setTimeout (flashCard) — stub a window + drop
+// CSS.escape so the cssEscape fallback (the worker-id ":" path) is exercised.
+const realWindow = (globalThis as { window?: unknown }).window;
+const realCSS = (globalThis as { CSS?: unknown }).CSS;
+beforeEach(() => {
+  (globalThis as { window?: unknown }).window = { setTimeout: () => 0 };
+  (globalThis as { CSS?: unknown }).CSS = undefined;
+});
+afterEach(() => {
+  (globalThis as { window?: unknown }).window = realWindow;
+  (globalThis as { CSS?: unknown }).CSS = realCSS;
+});
+
+const SNAP = { scroll: { top: 300, left: 1400 }, focusId: "CTL-774" };
+
+describe("applyBoardRestore — both-axis scroll + focus (CTL-971)", () => {
+  it("restores BOTH scrollLeft AND scrollTop when the extent can hold them", () => {
+    const sc = new FakeScroller(2000, 600);
+    const ok = applyBoardRestore(fakeRoot(sc, new FakeCard()), SNAP);
+    expect(sc.scrollLeft).toBe(1400);
+    expect(sc.scrollTop).toBe(300);
+    expect(ok).toBe(true); // both axes landed → no retry needed
+  });
+
+  it("reports NOT-applied when the extent hasn't laid out yet (signals a retry)", () => {
+    const sc = new FakeScroller(0, 0); // 0-extent → both writes clamp to 0
+    const ok = applyBoardRestore(fakeRoot(sc, null), SNAP);
+    expect(sc.scrollLeft).toBe(0);
+    expect(sc.scrollTop).toBe(0);
+    expect(ok).toBe(false);
+  });
+
+  it("treats a {0,0} target as applied (nothing to wait for)", () => {
+    const sc = new FakeScroller(0, 0);
+    const ok = applyBoardRestore(fakeRoot(sc, null), { scroll: { top: 0, left: 0 }, focusId: "X" });
+    expect(ok).toBe(true);
+  });
+
+  it("focuses the originating card WITHOUT scrolling it into view (preventScroll)", () => {
+    const card = new FakeCard();
+    applyBoardRestore(fakeRoot(new FakeScroller(2000, 600), card), SNAP);
+    expect(card.focused).toBe(true);
+    expect(card.focusOpts?.preventScroll).toBe(true);
+  });
+
+  it("never throws when the board root is absent (deep-link, no board) and reports not-applied", () => {
+    // A null root → resolveScrollEl returns null → no element to scroll → false
+    // (the hook's retry then no-ops; the snapshot is consumed and the deep-linked
+    // page simply has no board to restore).
+    expect(() => applyBoardRestore(null, SNAP)).not.toThrow();
+    expect(applyBoardRestore(null, SNAP)).toBe(false);
+  });
+
+  it("flashes the restored card (sets an inline outline)", () => {
+    const card = new FakeCard();
+    applyBoardRestore(fakeRoot(new FakeScroller(2000, 600), card), SNAP);
+    expect(card.style.outline).toContain("solid");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-board-restore.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-board-restore.ts
@@ -1,37 +1,90 @@
-// use-board-restore.ts — CTL-951: restore the board to the EXACT state it was
-// left in when the operator returns from a detail page (Esc / browser Back).
+// use-board-restore.ts — CTL-951 + CTL-971: restore the board to the EXACT state
+// it was left in when the operator returns from a detail page (Esc / breadcrumb /
+// browser Back).
 //
 // The card-click navigation is a full-document navigation (the detail routes only
 // exist in the board.html entry's router — see detail-nav.ts), so the board
-// re-mounts from scratch on return. Display-options (density / grouping / order /
-// repo scope) restore for free — they live in their own persisted localStorage
-// atoms (`boardPrefsAtom` / `repoScopeAtom`) and survive the navigation. What this
-// hook re-applies is the two things NOT covered by those atoms: the board's
-// SCROLL offset and the originating CARD focus, read from the sessionStorage
-// snapshot `openDetail` stashed.
+// re-mounts from scratch on return. The SURFACE + repo SCOPE are reseated at SHELL
+// mount by `useSurfaceRestore` (so the board actually mounts at all — without it
+// the landing-pref Inbox shows and this hook never runs). Density / grouping /
+// order ride their own persisted `boardPrefsAtom`. What THIS hook re-applies is the
+// two things still not covered: the board's SCROLL offset (BOTH axes) and the
+// originating CARD focus, read from the sessionStorage snapshot `openDetail`
+// stashed.
 //
-// The scroll element is resolved at runtime from the board root: every board body
-// (kanban SwimlaneBoard, dense BoardList, QueueView) owns a `.cat-scroll`
-// overflow container, so the hook finds the FIRST one under the board root rather
-// than threading a ref through every sub-component. The restore runs once, only
-// after the payload has rendered (so the cards + the scroll extent exist), then
-// clears the snapshot so it never re-fires on a later unrelated board visit.
+// The scroll element is resolved at runtime from the board root: the kanban
+// SwimlaneBoard / dense BoardList / QueueView each own a `.cat-scroll` overflow
+// container, so the hook finds the FIRST one under the board root rather than
+// threading a ref through every sub-component.
+//
+// CTL-971: the restore is hardened for CTL-950's single both-axes `.cat-scroll`
+// scroller + CTL-958's overscroll-chaining constrained cells:
+//   - it re-FINDS the scroller on restore (the element may not exist on the first
+//     committed frame), and DOUBLE-rAFs so sticky headers + constrained-cell
+//     layout have settled before we set the offset (a not-yet-laid-out extent
+//     clamps scrollLeft/scrollTop to 0);
+//   - it restores BOTH `scrollLeft` AND `scrollTop` (CTL-950 made horizontal scroll
+//     a first-class axis — losing it dropped the operator back to the leftmost
+//     column);
+//   - it FLASHES the originating card (a brief focus ring) so the operator's eye
+//     lands where they left, then consumes the snapshot.
 
 import { useEffect, useRef, type RefObject } from "react";
 import { readListContext, clearListContext } from "../board/detail-nav";
 
 /** Find the board's scroll container — the first `.cat-scroll` overflow element
  *  under `root` (the kanban / list / queue bodies each render one). Falls back to
- *  `root` itself when none is found (defensive — never throws). */
+ *  `root` itself when none is found (defensive — never throws).
+ *
+ *  NOTE: after CTL-958 the constrained per-cell scroll boxes are tagged
+ *  `data-lane-cell`, NOT `.cat-scroll`, so this still resolves the BOARD-level
+ *  both-axes scroller (the single horizontal axis + the board vertical axis) —
+ *  exactly the element whose offset `openDetail` captured. */
 export function resolveScrollEl(root: HTMLElement | null): HTMLElement | null {
   if (!root) return null;
   const found = root.querySelector<HTMLElement>(".cat-scroll");
   return found ?? root;
 }
 
+/** Apply a snapshot's scroll offset to the resolved scroller (both axes) +
+ *  flash-focus the originating card. Re-resolves the scroller from `root` so a
+ *  late-mounting `.cat-scroll` is still found. Returns true once the scroller was
+ *  found AND its scroll extent is non-trivial (so a caller can retry on the next
+ *  frame while the layout is still 0-height). PURE of React — only DOM. */
+export function applyBoardRestore(
+  root: HTMLElement | null,
+  snapshot: { scroll: { top: number; left: number }; focusId: string },
+): boolean {
+  const el = resolveScrollEl(root);
+  let applied = false;
+  if (el) {
+    // Restore BOTH axes (CTL-950 single both-axes scroller). The browser clamps
+    // to the current extent — if the layout hasn't settled (extent still ~0) the
+    // write no-ops, which the double-rAF / retry below guards against.
+    el.scrollLeft = snapshot.scroll.left;
+    el.scrollTop = snapshot.scroll.top;
+    // "Applied" only when the extent can actually hold the requested offset (or
+    // the requested offset was 0 to begin with) — else the caller should retry.
+    const horizOk = snapshot.scroll.left === 0 || el.scrollLeft > 0;
+    const vertOk = snapshot.scroll.top === 0 || el.scrollTop > 0;
+    applied = horizOk && vertOk;
+  }
+  // Re-focus + flash the originating card (the `data-card-id` the cards stamp) so
+  // the keyboard cursor lands where the operator left — without scrolling it into
+  // view (we just set the offset; `preventScroll` keeps it).
+  const card = root?.querySelector<HTMLElement>(
+    `[data-card-id="${cssEscape(snapshot.focusId)}"]`,
+  );
+  if (card) {
+    card.focus({ preventScroll: true });
+    flashCard(card);
+  }
+  return applied;
+}
+
 /**
- * Re-apply the persisted scroll offset + originating-card focus when the board
- * mounts after a return from a detail page.
+ * Re-apply the persisted scroll offset (both axes) + originating-card focus when
+ * the board mounts after a return from a detail page.
  *
  * @param rootRef  the board root element (the scroll container is resolved under it)
  * @param ready    true once the board payload has rendered (cards + scroll extent
@@ -52,27 +105,48 @@ export function useBoardRestore(
     if (!snapshot) return;
     restoredRef.current = true;
 
-    // Defer to the next frame so the just-rendered cards + scroll extent are laid
-    // out before we set the offset (a 0-height-then-grow container would clamp the
-    // scrollTop to 0 if applied synchronously on the first paint).
-    const raf = requestAnimationFrame(() => {
-      const el = resolveScrollEl(rootRef.current);
-      if (el) {
-        el.scrollTop = snapshot.scroll.top;
-        el.scrollLeft = snapshot.scroll.left;
+    // Double-rAF so the just-rendered cards + the sticky headers + CTL-958's
+    // constrained-cell layout settle before we set the offset (a 0-height-then-grow
+    // container clamps scrollLeft/scrollTop to 0 if applied on the first paint).
+    // If the first apply doesn't "stick" (extent still settling), the second frame
+    // re-applies against the now-laid-out extent.
+    let raf2 = 0;
+    const raf1 = requestAnimationFrame(() => {
+      const okFirst = applyBoardRestore(rootRef.current, snapshot);
+      if (okFirst) {
+        clearListContext();
+        return;
       }
-      // Re-focus the originating card (the `data-card-id` the cards stamp) so the
-      // keyboard cursor lands where the operator left — without scrolling it into
-      // view (we just set the offset; `preventScroll` keeps it).
-      const card = rootRef.current?.querySelector<HTMLElement>(
-        `[data-card-id="${cssEscape(snapshot.focusId)}"]`,
-      );
-      card?.focus({ preventScroll: true });
-      // Consume the snapshot so a later unrelated board visit doesn't re-restore.
-      clearListContext();
+      raf2 = requestAnimationFrame(() => {
+        applyBoardRestore(rootRef.current, snapshot);
+        // Consume the snapshot on the second frame regardless — a board this tall
+        // is laid out by now; a stale snapshot must never re-fire on a later visit.
+        clearListContext();
+      });
     });
-    return () => cancelAnimationFrame(raf);
+    return () => {
+      cancelAnimationFrame(raf1);
+      if (raf2) cancelAnimationFrame(raf2);
+    };
   }, [ready, rootRef]);
+}
+
+/** Briefly outline the restored card so the operator's eye finds it. Pure DOM:
+ *  sets an inline outline, then clears it on a timer. No-ops if the element has no
+ *  style (defensive — the bun shim / detached nodes). */
+function flashCard(card: HTMLElement): void {
+  if (!card.style) return;
+  const prevOutline = card.style.outline;
+  const prevOffset = card.style.outlineOffset;
+  const prevTransition = card.style.transition;
+  card.style.transition = "outline-color .5s ease-out";
+  card.style.outline = "2px solid var(--cat-focus, #5e9ee8)";
+  card.style.outlineOffset = "2px";
+  window.setTimeout(() => {
+    card.style.outline = prevOutline;
+    card.style.outlineOffset = prevOffset;
+    card.style.transition = prevTransition;
+  }, 900);
 }
 
 /** Minimal CSS.escape shim for the `data-card-id` attribute selector (ids carry

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-surface-restore.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-surface-restore.test.ts
@@ -1,0 +1,67 @@
+// use-surface-restore.test.ts — CTL-971: the pure surface/scope reseat decision.
+//
+// `bun test` has no DOM, so we unit-test the PURE `resolveSurfaceRestore` mapping
+// (snapshot → {surface, scope}) directly, and assert the hook's wiring (peek, no
+// clear; reseat surface + scope) by static source analysis — matching the
+// established detail-nav.test.ts / app-shell.test.ts pattern.
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { resolveSurfaceRestore } from "./use-surface-restore";
+import type { RestoreSurface } from "../board/detail-nav";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+const snap = (surface: RestoreSurface, scope: string) => ({ surface, scope });
+
+describe("resolveSurfaceRestore — snapshot → surface + scope (CTL-971)", () => {
+  it("returns null for a null snapshot (the shell keeps its landing-pref default)", () => {
+    expect(resolveSurfaceRestore(null)).toBeNull();
+  });
+
+  it("maps a board-card snapshot to the board surface, preserving the scope", () => {
+    expect(resolveSurfaceRestore(snap("board", "catalyst"))).toEqual({
+      surface: "board",
+      scope: "catalyst",
+    });
+  });
+
+  it("maps a worker-card snapshot to the workers surface", () => {
+    expect(resolveSurfaceRestore(snap("workers", "all"))).toEqual({
+      surface: "workers",
+      scope: "all",
+    });
+  });
+
+  it("carries the 'all' sentinel through unchanged (the unfiltered view)", () => {
+    expect(resolveSurfaceRestore(snap("board", "all"))?.scope).toBe("all");
+  });
+
+  it("carries an arbitrary repo-key scope through unchanged", () => {
+    expect(resolveSurfaceRestore(snap("workers", "adva"))?.scope).toBe("adva");
+  });
+});
+
+describe("useSurfaceRestore wiring (static source, CTL-971)", () => {
+  const src = readFileSync(join(HERE, "use-surface-restore.ts"), "utf8");
+
+  it("PEEKS the snapshot — reads it but never clears it (the board consumes it)", () => {
+    expect(src).toContain("readListContext()");
+    // The board-local useBoardRestore owns clearListContext; this hook must not.
+    expect(src).not.toContain("clearListContext");
+  });
+
+  it("applies the scope BEFORE the surface so the board mounts already scoped", () => {
+    const scopeIdx = src.indexOf("applyScope(restore.scope)");
+    const surfaceIdx = src.indexOf("applySurface(restore.surface)");
+    expect(scopeIdx).toBeGreaterThan(-1);
+    expect(surfaceIdx).toBeGreaterThan(-1);
+    expect(scopeIdx).toBeLessThan(surfaceIdx);
+  });
+
+  it("fires AT MOST once per shell mount (a later deliberate jump is not yanked)", () => {
+    expect(src).toContain("appliedRef");
+    expect(src).toContain("if (appliedRef.current) return;");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-surface-restore.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-surface-restore.ts
@@ -1,0 +1,83 @@
+// use-surface-restore.ts — CTL-971: reseat the board SURFACE + repo SCOPE when the
+// operator returns from a detail page (Esc / breadcrumb "◂ Board" / browser Back).
+//
+// THE BUG THIS FIXES: after CTL-951 a single click opens the detail page via a
+// FULL-DOCUMENT navigation (the detail routes only live in the board.html entry).
+// On return — all three paths land back on `/` (index.html shell) — the shell
+// reseeds the active surface from the persisted LANDING preference (default
+// "home"/Inbox). So the operator lands on the Inbox, the <Board> never mounts, and
+// the board-local `useBoardRestore` (scroll + focus) never runs: the snapshot sits
+// in sessionStorage, unconsumed. (Verified on mini 2026-06-10.)
+//
+// THE FIX: at SHELL mount, peek the restore snapshot. If a FRESH one exists, set
+// the surface back to the one the card was opened from ("board"/"workers" → the
+// `Surface` union) and re-apply the saved repo scope. This MUST run before/at the
+// board mount so <Board> exists and its own `useBoardRestore` can apply the scroll.
+//
+// IMPORTANT: this hook PEEKS — it does NOT clear the snapshot. The board-local
+// `useBoardRestore` clears it after applying scroll + focus, so it must still be
+// present when the board mounts. (If the board never mounts — e.g. the snapshot is
+// stale and we don't reseat — the stale snapshot is simply ignored by the 30-min
+// max-age guard and overwritten on the next card open.)
+//
+// The surface→Surface mapping is the PURE `resolveSurfaceRestore` (unit-testable
+// without React/DOM); the hook is the thin effect that applies it once on mount.
+
+import { useEffect, useRef } from "react";
+import { readListContext, type RestoreSurface } from "../board/detail-nav";
+import type { Surface } from "../lib/surface";
+
+/** What the shell should reseat on return from a detail page. */
+export interface SurfaceRestore {
+  /** The OPERATE surface to show ("board" or "workers"). */
+  surface: Surface;
+  /** The repo scope to re-apply (`REPO_SCOPE_ALL` sentinel or a repo key). */
+  scope: string;
+}
+
+/**
+ * Map a fresh restore snapshot to the surface + scope the shell should reseat.
+ * Returns null when there is no (fresh) snapshot — the shell then keeps its
+ * landing-pref default untouched. PURE: pass the already-read snapshot so this is
+ * testable without a storage runtime.
+ *
+ * The `RestoreSurface` union ("board"/"workers") is a subset of the shell's
+ * `Surface` union, so the mapping is the identity — but we keep it explicit (and
+ * guarded) so a future surface value can't silently leak an invalid `Surface`.
+ */
+export function resolveSurfaceRestore(
+  snapshot: { surface: RestoreSurface; scope: string } | null,
+): SurfaceRestore | null {
+  if (!snapshot) return null;
+  const surface: Surface = snapshot.surface === "workers" ? "workers" : "board";
+  return { surface, scope: snapshot.scope };
+}
+
+/**
+ * Run-once-at-mount effect: if a fresh board-restore snapshot exists, reseat the
+ * shell's surface + repo scope so the board mounts (and its own `useBoardRestore`
+ * can apply the scroll/focus). PEEKS the snapshot — does NOT clear it.
+ *
+ * @param applySurface  set the active OPERATE surface (AppShell's `setSurface`).
+ * @param applyScope    set the active repo scope (AppShell's `repoScopeAtom` setter).
+ */
+export function useSurfaceRestore(
+  applySurface: (s: Surface) => void,
+  applyScope: (scope: string) => void,
+): void {
+  // Guard so the reseat fires AT MOST once per shell mount — a later navigation
+  // (the operator deliberately jumping to the Inbox) must not be yanked back.
+  const appliedRef = useRef(false);
+
+  useEffect(() => {
+    if (appliedRef.current) return;
+    appliedRef.current = true;
+    const snapshot = readListContext(); // peek (no clear)
+    const restore = resolveSurfaceRestore(snapshot);
+    if (!restore) return;
+    applyScope(restore.scope);
+    applySurface(restore.surface);
+    // The snapshot is intentionally LEFT in sessionStorage — the board-local
+    // useBoardRestore consumes it once the board mounts + the payload renders.
+  }, [applySurface, applyScope]);
+}


### PR DESCRIPTION
## Problem

After CTL-951 made a single click open the detail page, **NONE** of the three return paths returned the operator to the board state they left — Esc, the "◂ Board" breadcrumb, and the browser Back button all landed on a FRESH surface (the landing-pref Inbox, top-left, default scope).

Operator repro (verified on mini 2026-06-10): scope=catalyst, Tickets board, scrolled ~3/4 right to the Validate column and down to a ticket, single-clicked it → on return, all of it was lost. The restore snapshot stayed in sessionStorage, unconsumed; the "All clear" Inbox empty-state was shown.

## Root cause

The board **surface is not in the URL**. The card-open nav is a full-document navigation to `/` (board.html → index.html shell). On that load the shell reseeds the active surface from the persisted LANDING preference (default `home`/Inbox), so the `<Board>` never mounts, `useBoardRestore` never runs, and the dual-axis scroll/focus snapshot is silently ignored. (The repo scope *does* persist in localStorage, but the restore never drove it authoritatively.)

## Fix

1. **Persist `{surface, scope}`** in the restore snapshot alongside the existing dual-axis scroll + `focusId`. `openDetail` now stamps the live board `view` ("board"/"workers") + the active repo scope.
2. **New `useSurfaceRestore`** (run at AppShell mount) PEEKS the fresh snapshot and reseats the surface + repo scope **before** the board mounts — so the board actually renders and its own `useBoardRestore` can apply the scroll. It does NOT clear the snapshot (the board-local hook consumes it). All three return paths funnel through the same full-doc nav to `/`, so all three now restore.
3. **Harden `useBoardRestore`** for CTL-950's single both-axes `.cat-scroll` scroller + CTL-958's overscroll-chaining cells: restore BOTH `scrollLeft` and `scrollTop`, re-find the scroller + double-rAF so a not-yet-laid-out extent doesn't clamp the offset to 0, and flash the originating card.

Reconciles additively with CTL-958: its constrained per-cell scroll boxes are `data-lane-cell`, NOT `.cat-scroll`, so `resolveScrollEl` still targets the board-level both-axes scroller whose offset was captured.

## Tests

- Snapshot capture+restore incl. **surface + scope + both scroll axes** (+ backward-compat: surface derived from kind, scope→"all" fallback).
- Dual-axis apply against a clamping fake scroller, the retry-on-unsettled-extent signal, and focus/flash.
- Shell reseat wiring: peek-not-clear, scope-before-surface, once-per-mount; all three return paths funnel through `goRoot`.

442 ui tests pass; `tsc` clean (no new errors); `vite build` green. Verified end-to-end on a local dev server: with the landing pref set to Inbox and scope drifted to "all", a fresh load reseated to the Tickets board, scope=catalyst, scrollLeft=1400/scrollTop=250, snapshot consumed; no-snapshot and stale-snapshot cases correctly stay on the landing default.

Closes CTL-971.

🤖 Generated with [Claude Code](https://claude.com/claude-code)