### PR TITLE
fix(dev): unify board phase with phase-agent-type + remediate column + lens label (CTL-972)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/board-phase-drift.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-phase-drift.test.ts
@@ -28,8 +28,11 @@
 //                 DOM-free column-derivation tests can read them; the board now
 //                 imports them from here — ONE definition).
 //     • PHASE_COLUMNS   the visual board's phase columns (key + user-facing
-//                       label). The .key order is the literal column order the
-//                       user sees, so it MUST equal descriptor PHASES exactly.
+//                       label). SUPERSET of PHASES (CTL-972: also includes
+//                       ancillary phases like 'remediate' interleaved at the
+//                       correct position). Pipeline PHASES must all appear, in
+//                       correct relative order; ancillary phases are allowed as
+//                       extras (same superset rule PHASE_C already follows).
 //     • LINEAR_COLUMNS  the visual board's Linear-lens columns. Must match the
 //                       value-space the data layer (PHASE_TO_LINEAR) produces —
 //                       every label the data layer emits needs a UI column, and
@@ -226,18 +229,54 @@ test("board-data.mjs PHASE_TO_LINEAR keys cover every descriptor PHASE (superset
   expect(missing).toEqual([]);
 });
 
-// ── Requirement 5a: board-display PHASE_COLUMNS .key order === PHASES (exact) ──
-test("board-display PHASE_COLUMNS keys equal descriptor PHASES exactly (visual column order)", () => {
-  if (JSON.stringify(phaseColsKeys) !== JSON.stringify([...PHASES])) {
+// ── Requirement 5a: board-display PHASE_COLUMNS ⊇ PHASES in order (superset ok) ─
+// CTL-972: PHASE_COLUMNS is now a SUPERSET of PHASES — it also includes the
+// ancillary 'remediate' phase (which cycles with verify). The guard checks:
+//   (a) every pipeline PHASE appears in PHASE_COLUMNS (no missing columns);
+//   (b) the pipeline PHASES appear in the CORRECT RELATIVE ORDER within
+//       PHASE_COLUMNS (ancillary phases may be interleaved, but the pipeline
+//       skeleton must be preserved so the visual left→right column order
+//       reflects pipeline progression).
+// "exact equality" is no longer enforced — PHASE_C already legitimately
+// includes ancillary phases, and PHASE_COLUMNS now follows the same superset rule.
+test("board-display PHASE_COLUMNS covers every descriptor PHASE in order (ancillary ok)", () => {
+  const phases = [...PHASES];
+  const colKeys = phaseColsKeys;
+  // (a) every pipeline phase must be present.
+  const missing = phases.filter((p) => !colKeys.includes(p));
+  if (missing.length > 0) {
     throw new Error(
-      `DRIFT: ui/src/board/board-display.ts PHASE_COLUMNS (the visual board columns) ` +
-        `diverged from ${SOT}.\n` +
-        `  descriptor PHASES:        ${JSON.stringify([...PHASES])}\n` +
-        `  board-display PHASE_COLUMNS: ${JSON.stringify(phaseColsKeys)}\n` +
-        `Fix PHASE_COLUMNS .key order/membership to match workflow.default.json.`,
+      `DRIFT: ui/src/board/board-display.ts PHASE_COLUMNS is missing column(s) ` +
+        `${JSON.stringify(missing)} from ${SOT}. Add them to PHASE_COLUMNS.`,
     );
   }
-  expect(phaseColsKeys).toEqual([...PHASES]);
+  // (b) pipeline phases must appear in their descriptor order within PHASE_COLUMNS.
+  const pipelineColIndices = phases.map((p) => colKeys.indexOf(p));
+  const ordered = pipelineColIndices.every((idx, i) => i === 0 || pipelineColIndices[i] > pipelineColIndices[i - 1]);
+  if (!ordered) {
+    throw new Error(
+      `DRIFT: ui/src/board/board-display.ts PHASE_COLUMNS pipeline phases are out of ` +
+        `order relative to ${SOT}.\n` +
+        `  descriptor PHASES:            ${JSON.stringify(phases)}\n` +
+        `  board-display PHASE_COLUMNS:  ${JSON.stringify(colKeys)}\n` +
+        `  expected pipeline indices:    ${JSON.stringify(pipelineColIndices)}\n` +
+        `Restore the correct relative order in PHASE_COLUMNS.`,
+    );
+  }
+  // (c) only ancillary phases (ANCILLARY_PHASES) may be the extra keys.
+  const ancillarySet = new Set(ANCILLARY_PHASES);
+  const unexpected = colKeys.filter((k) => !phases.includes(k) && !ancillarySet.has(k));
+  if (unexpected.length > 0) {
+    throw new Error(
+      `DRIFT: ui/src/board/board-display.ts PHASE_COLUMNS contains key(s) ` +
+        `${JSON.stringify(unexpected)} that are neither a descriptor PHASE nor an ` +
+        `ancillary phase (${JSON.stringify(ANCILLARY_PHASES)}). ` +
+        `Remove unexpected keys or add them to workflow.default.json ancillarySteps.`,
+    );
+  }
+  expect(missing).toEqual([]);
+  expect(ordered).toBe(true);
+  expect(unexpected).toEqual([]);
 });
 
 // ── Requirement 5b: Board.tsx PHASE_C keys ⊇ PHASES (colors; extras allowed) ──

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-remediate.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-remediate.test.ts
@@ -1,0 +1,246 @@
+// board-remediate.test.ts — CTL-972: verify the three-part fix:
+//   1. derivePhaseWithRemediate: ticket.phase='remediate' for active + dead-worker
+//   2. PHASE_COLUMNS: remediate column exists between verify and review
+//   3. A remediate ticket lands in the remediate board column + list group
+//
+// All tests are pure (no DOM, no I/O) — same discipline as board-display.test.ts
+// and board-current-phase.test.ts.
+
+import { describe, it, expect, test } from "bun:test";
+import {
+  deriveCurrentPhase,
+  derivePhaseWithRemediate,
+  PHASE_ORDER,
+  TERMINAL,
+  REMEDIATE_PHASE,
+} from "../lib/board-data.mjs";
+import {
+  PHASE_COLUMNS,
+  ticketColumns,
+} from "../ui/src/board/board-display";
+import type { BoardTicket } from "../ui/src/board/types";
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+type Sig = {
+  status: string;
+  model?: string | null;
+  startedAt?: string;
+  updatedAt?: string;
+  completedAt?: string;
+} | null;
+
+function sigs(): Sig[] {
+  return PHASE_ORDER.map(() => null);
+}
+
+const idx = (phase: string) => PHASE_ORDER.indexOf(phase);
+
+function mkTicket(id: string, over: Partial<BoardTicket> = {}): BoardTicket {
+  return {
+    id, title: id, type: "feature", repo: "catalyst", team: "CTL",
+    phase: "verify", status: "done", model: null, linearState: "Validate",
+    workerStatus: null, activeState: null, working: false, lastActiveMs: null,
+    priority: 2, estimate: null, scope: null, project: null, costUSD: null,
+    tokens: null, turns: null, phaseCosts: null, phaseSummary: [], pr: null,
+    updatedAt: "", ...over,
+  };
+}
+
+// ── 1. derivePhaseWithRemediate ──────────────────────────────────────────────
+
+describe("derivePhaseWithRemediate — no remediate signal", () => {
+  it("returns deriveCurrentPhase result unchanged when remediateSig is null", () => {
+    const s = sigs();
+    s[idx("verify")] = { status: "running", startedAt: "2026-06-09T10:00:00Z" };
+    const cur = deriveCurrentPhase(s);
+    const withR = derivePhaseWithRemediate(s, null);
+    expect(withR).toEqual(cur);
+    expect(withR.phase).toBe("verify");
+  });
+
+  it("returns deriveCurrentPhase result unchanged when remediateSig is undefined", () => {
+    const s = sigs();
+    s[idx("implement")] = { status: "done", updatedAt: "2026-06-09T09:00:00Z" };
+    expect(derivePhaseWithRemediate(s, undefined as unknown as null).phase).toBe("implement");
+  });
+});
+
+describe("derivePhaseWithRemediate — remediate RUNNING (non-terminal)", () => {
+  it("returns phase='remediate' when remediate is actively running", () => {
+    const s = sigs();
+    s[idx("verify")] = { status: "done", updatedAt: "2026-06-09T10:00:00Z" };
+    const remediateSig = { status: "running", startedAt: "2026-06-09T10:05:00Z", updatedAt: "2026-06-09T10:06:00Z" };
+    const result = derivePhaseWithRemediate(s, remediateSig);
+    expect(result.phase).toBe(REMEDIATE_PHASE);
+    expect(result.status).toBe("running");
+    expect(result.startedAt).toBe("2026-06-09T10:05:00Z");
+  });
+
+  it("remediate running wins even when verify has no terminal status", () => {
+    const s = sigs();
+    // verify not yet written (null)
+    const remediateSig = { status: "running", startedAt: "2026-06-09T10:00:00Z" };
+    expect(derivePhaseWithRemediate(s, remediateSig).phase).toBe(REMEDIATE_PHASE);
+  });
+
+  it("passes through model from the remediate signal", () => {
+    const s = sigs();
+    s[idx("verify")] = { status: "done", updatedAt: "2026-06-09T10:00:00Z" };
+    const remediateSig = { status: "running", model: "claude-opus-4-5", startedAt: "2026-06-09T10:05:00Z" };
+    const result = derivePhaseWithRemediate(s, remediateSig);
+    expect(result.model).toBe("claude-opus-4-5");
+  });
+});
+
+describe("derivePhaseWithRemediate — remediate TERMINAL (dead-worker case)", () => {
+  it("returns phase='remediate' when remediate.updatedAt > verify.updatedAt (dead worker)", () => {
+    // CTL-729 scenario: verify.done at T1, remediate.done at T2 > T1.
+    // The (dead) remediate worker ran last — board must show 'remediate'.
+    const s = sigs();
+    s[idx("verify")] = { status: "done", updatedAt: "2026-06-09T10:00:00Z" };
+    const remediateSig: Sig = {
+      status: "done",
+      updatedAt: "2026-06-09T10:10:00Z", // remediate ran AFTER verify
+    };
+    const result = derivePhaseWithRemediate(s, remediateSig);
+    expect(result.phase).toBe(REMEDIATE_PHASE);
+    expect(result.status).toBe("done");
+  });
+
+  it("returns phase='remediate' using completedAt when updatedAt is absent", () => {
+    const s = sigs();
+    s[idx("verify")] = { status: "done", updatedAt: "2026-06-09T10:00:00Z" };
+    const remediateSig: Sig = {
+      status: "done",
+      completedAt: "2026-06-09T10:15:00Z", // fallback to completedAt
+    };
+    const result = derivePhaseWithRemediate(s, remediateSig);
+    expect(result.phase).toBe(REMEDIATE_PHASE);
+  });
+
+  it("returns verify phase when verify ran AFTER remediate (new verify pass started)", () => {
+    // verify → remediate → verify again: the new verify.done at T3 > remediate.done at T2
+    const s = sigs();
+    s[idx("verify")] = { status: "done", updatedAt: "2026-06-09T10:20:00Z" }; // latest
+    const remediateSig: Sig = {
+      status: "done",
+      updatedAt: "2026-06-09T10:10:00Z", // remediate was before this verify pass
+    };
+    const result = derivePhaseWithRemediate(s, remediateSig);
+    expect(result.phase).toBe("verify");
+  });
+
+  it("returns verify when verify is currently RUNNING (regardless of remediate terminal)", () => {
+    const s = sigs();
+    // verify is running (non-terminal) — deriveCurrentPhase returns verify running
+    // and remediateSig is terminal but older, so verify wins
+    s[idx("verify")] = { status: "running", updatedAt: "2026-06-09T10:20:00Z" };
+    const remediateSig: Sig = {
+      status: "done",
+      updatedAt: "2026-06-09T10:10:00Z",
+    };
+    const result = derivePhaseWithRemediate(s, remediateSig);
+    // verify is running (non-terminal) → deriveCurrentPhase surfaces it;
+    // remediateSig is terminal AND older → no override → verify wins
+    expect(result.phase).toBe("verify");
+    expect(result.status).toBe("running");
+  });
+
+  it("remediate failed surfaces as phase=remediate status=failed (mid-verify-cycle fail)", () => {
+    const s = sigs();
+    s[idx("verify")] = { status: "done", updatedAt: "2026-06-09T10:00:00Z" };
+    const remediateSig: Sig = {
+      status: "failed",
+      updatedAt: "2026-06-09T10:05:00Z",
+    };
+    const result = derivePhaseWithRemediate(s, remediateSig);
+    expect(result.phase).toBe(REMEDIATE_PHASE);
+    expect(result.status).toBe("failed");
+  });
+});
+
+// ── 2. PHASE_COLUMNS includes remediate between verify and review ─────────────
+
+describe("PHASE_COLUMNS — remediate column exists", () => {
+  test("PHASE_COLUMNS contains a 'remediate' column", () => {
+    const keys = PHASE_COLUMNS.map((c) => c.key);
+    expect(keys).toContain("remediate");
+  });
+
+  test("remediate is positioned between verify and review", () => {
+    const keys = PHASE_COLUMNS.map((c) => c.key);
+    const iVerify = keys.indexOf("verify");
+    const iRemediate = keys.indexOf("remediate");
+    const iReview = keys.indexOf("review");
+    expect(iVerify).toBeGreaterThanOrEqual(0);
+    expect(iRemediate).toBeGreaterThanOrEqual(0);
+    expect(iReview).toBeGreaterThanOrEqual(0);
+    expect(iRemediate).toBeGreaterThan(iVerify);
+    expect(iRemediate).toBeLessThan(iReview);
+  });
+
+  test("remediate column color is #d98ab2", () => {
+    const col = PHASE_COLUMNS.find((c) => c.key === "remediate");
+    expect(col?.c).toBe("#d98ab2");
+  });
+
+  test("remediate column label is 'Remediate'", () => {
+    const col = PHASE_COLUMNS.find((c) => c.key === "remediate");
+    expect(col?.label).toBe("Remediate");
+  });
+});
+
+// ── 3. A remediate ticket lands in the remediate board column + list group ────
+
+describe("ticketColumns — remediate ticket routes to remediate column", () => {
+  const remediateTicket = mkTicket("CTL-729", { phase: "remediate", linearState: "Validate" });
+  const verifyTicket = mkTicket("CTL-730", { phase: "verify", linearState: "Validate" });
+
+  it("with phase lens, a remediate ticket lands in the 'remediate' column", () => {
+    const cols = ticketColumns([remediateTicket, verifyTicket], {
+      groupBy: "phase",
+      showEmptyColumns: false,
+    });
+    const remCol = cols.find((c) => c.key === "remediate");
+    expect(remCol).toBeTruthy();
+    expect(remCol?.items.map((t) => t.id)).toContain("CTL-729");
+    // verify ticket stays in verify column, not remediate
+    expect(remCol?.items.map((t) => t.id)).not.toContain("CTL-730");
+  });
+
+  it("with phase lens, a verify ticket does NOT land in the remediate column", () => {
+    const cols = ticketColumns([verifyTicket], {
+      groupBy: "phase",
+      showEmptyColumns: false,
+    });
+    const remCol = cols.find((c) => c.key === "remediate");
+    // remediate column should be absent (no items + showEmptyColumns=false)
+    expect(remCol).toBeUndefined();
+  });
+
+  it("with linear lens, a remediate ticket lands in 'Validate' (not a remediate column)", () => {
+    const cols = ticketColumns([remediateTicket], {
+      groupBy: "linear",
+      showEmptyColumns: false,
+    });
+    const valCol = cols.find((c) => c.key === "Validate");
+    expect(valCol?.items.map((t) => t.id)).toContain("CTL-729");
+    // no 'remediate' key in linear lens
+    expect(cols.find((c) => c.key === "remediate")).toBeUndefined();
+  });
+
+  it("showEmptyColumns=true always shows the remediate column (phase lens)", () => {
+    const cols = ticketColumns([], {
+      groupBy: "phase",
+      showEmptyColumns: true,
+    });
+    expect(cols.map((c) => c.key)).toContain("remediate");
+  });
+});
+
+// ── 4. REMEDIATE_PHASE constant ───────────────────────────────────────────────
+
+test("REMEDIATE_PHASE export equals 'remediate'", () => {
+  expect(REMEDIATE_PHASE).toBe("remediate");
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -186,6 +186,10 @@ export interface BoardPayload {
 }
 
 export const PHASE_ORDER: string[];
+/** CTL-972: the ancillary remediate phase — not in PHASE_ORDER (cycles with
+ *  verify), but a real phase-agent type. Used by derivePhaseWithRemediate to
+ *  unify ticket.phase with the worker/queue's phase-agent-type value. */
+export const REMEDIATE_PHASE: string;
 export const PHASE_TO_LINEAR: Record<string, string>;
 export const TERMINAL: Set<string>;
 /** CTL-928: the `claude --bg` job-lifecycle terminal `state` values (distinct from
@@ -259,6 +263,15 @@ export function laneFor(ticket: {
 }): BoardLane;
 export function buildPhaseSummary(phaseSigs: unknown[], now: number): BoardPhaseTiming[];
 export function deriveCurrentPhase(phaseSigs: unknown[]): BoardCurrentPhase;
+/** CTL-972: derive a ticket's current phase, overlaying the remediate signal on
+ *  top of the PHASE_ORDER-based result. Returns phase='remediate' when the
+ *  remediate agent is active (non-terminal) OR when remediate was the most-recently-
+ *  active phase (terminal but more recent than the base phase). Returns the
+ *  deriveCurrentPhase result unchanged when remediateSig is null/absent. PURE. */
+export function derivePhaseWithRemediate(
+  phaseSigs: unknown[],
+  remediateSig: unknown | null | undefined,
+): BoardCurrentPhase;
 /** Build a thin Todo-column BoardTicket from an eligible queue entry (CTL-767). */
 export function synthesizeQueuedTicket(
   eligible: unknown,

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -46,6 +46,12 @@ export const PHASE_ORDER = [
   "triage", "research", "plan", "implement", "verify",
   "review", "pr", "monitor-merge", "monitor-deploy", "teardown",
 ];
+// CTL-972: the ancillary remediate phase. It is NOT in PHASE_ORDER (it cycles
+// WITH verify, not in the linear pipeline order), but it IS a real phase-agent
+// type surfaced by the queue/workers. We read its signal file separately and
+// use it to override ticket.phase when remediate is the most-recently-active
+// phase — so the board column and the queue agree on the ticket's current agent type.
+export const REMEDIATE_PHASE = "remediate";
 // Single source of truth for which phase statuses are terminal (no longer
 // running). Exported so the UI's PhaseStrip terminal-status list can be guarded
 // against drift (board-phase-drift.test.ts) instead of carrying a silent
@@ -132,9 +138,11 @@ export function heldFor(labels) {
 }
 
 // phase → Linear workflow state (board columns for the Tickets/Linear lens).
+// CTL-972: remediate maps to "Validate" (the Linear stage it cycles within,
+// alongside verify — both are part of the validate gate loop).
 export const PHASE_TO_LINEAR = {
   triage: "Triage", research: "Research", plan: "Plan", implement: "Implement",
-  verify: "Validate", review: "Validate", pr: "PR", "monitor-merge": "PR",
+  verify: "Validate", remediate: "Validate", review: "Validate", pr: "PR", "monitor-merge": "PR",
   "monitor-deploy": "Done", teardown: "Done", done: "Done",
   queued: "Todo",  // synthetic phase for eligible-queue board cards (CTL-767)
 };
@@ -432,6 +440,49 @@ export function deriveCurrentPhase(phaseSigs) {
     return { phase: "done", status: "done", model: lastTerminal.model };
   }
   return lastTerminal;
+}
+
+// CTL-972: override ticket.phase with 'remediate' when the remediate phase-agent
+// is (or was most recently) active. The remediate signal is NOT in PHASE_ORDER
+// (it cycles alongside verify, not in the linear pipeline), so deriveCurrentPhase
+// is blind to it — this function layers the remediate signal on top:
+//
+//   1. remediateSig non-terminal (running)        → 'remediate' wins unconditionally.
+//   2. remediateSig terminal + more recent than cur (updatedAt comparison) →
+//      remediate was the last thing that ran (e.g. dead worker, CTL-928 case) →
+//      surface 'remediate' so board column and queue agree.
+//   3. Otherwise                                  → return cur unchanged.
+//
+// "more recent" uses string ISO-8601 comparison (lexicographic = chronological),
+// falling back to the remediate sig being present at all (no updatedAt on base).
+// PURE — exported so unit tests can drive it directly.
+export function derivePhaseWithRemediate(phaseSigs, remediateSig) {
+  const cur = deriveCurrentPhase(phaseSigs);
+  if (!remediateSig) return cur;
+  const remStatus = remediateSig.status || "unknown";
+  // Case 1: remediate is actively running.
+  if (!TERMINAL.has(remStatus)) {
+    return {
+      phase: REMEDIATE_PHASE, status: remStatus,
+      model: remediateSig.model || null,
+      startedAt: remediateSig.startedAt ?? null,
+      updatedAt: remediateSig.updatedAt ?? null,
+    };
+  }
+  // Case 2: remediate is terminal but more recent than what PHASE_ORDER surfaced.
+  // Compare updatedAt strings (ISO-8601, lexicographic = chronological). When
+  // cur has no updatedAt (unknown phase, no signal), treat remediate as the winner.
+  const remUpdated = remediateSig.updatedAt ?? remediateSig.completedAt ?? "";
+  const curUpdated = cur.updatedAt ?? "";
+  if (remUpdated > curUpdated || (!curUpdated && remUpdated)) {
+    return {
+      phase: REMEDIATE_PHASE, status: remStatus,
+      model: remediateSig.model || null,
+      startedAt: remediateSig.startedAt ?? null,
+      updatedAt: remUpdated || null,
+    };
+  }
+  return cur;
 }
 
 // ── per-entity node attribution (CTL-922 / BFF10) ────────────────────────────
@@ -755,16 +806,19 @@ async function maxParallel() {
 }
 
 // Read a ticket's worker-dir artifacts once (phase signals + triage + PR signals).
+// CTL-972: also reads phase-remediate.json separately (it is NOT in PHASE_ORDER,
+// so derivePhaseWithRemediate overlays it on top of the PHASE_ORDER-based result).
 async function readTicketArtifacts(id) {
   const dir = join(WORKERS_DIR, id);
-  if (!(await exists(dir))) return { phaseSigs: [], triage: null, prSigs: [] };
-  const [phaseSigs, triage, prSigs] = await Promise.all([
+  if (!(await exists(dir))) return { phaseSigs: [], remediateSig: null, triage: null, prSigs: [] };
+  const [phaseSigs, remediateSig, triage, prSigs] = await Promise.all([
     Promise.all(PHASE_ORDER.map((p) => readJSON(join(dir, `phase-${p}.json`)))),
+    readJSON(join(dir, `phase-${REMEDIATE_PHASE}.json`)),
     readJSON(join(dir, "triage.json")),
     Promise.all(["phase-pr.json", "phase-monitor-merge.json", "phase-monitor-deploy.json"]
       .map((f) => readJSON(join(dir, f)))),
   ]);
-  return { phaseSigs, triage, prSigs };
+  return { phaseSigs, remediateSig, triage, prSigs };
 }
 
 // CTL-922 (BFF10): read a single worker's own phase signal, positioned into a
@@ -871,8 +925,10 @@ export async function assembleBoard() {
   const cardTicketIds = new Set([...workers.map((w) => w.ticket), ...workerDirs]);
 
   let tickets = await Promise.all([...cardTicketIds].map(async (id) => {
-    const { phaseSigs, triage, prSigs } = await readTicketArtifacts(id);
-    const cur = deriveCurrentPhase(phaseSigs);
+    const { phaseSigs, remediateSig, triage, prSigs } = await readTicketArtifacts(id);
+    // CTL-972: use derivePhaseWithRemediate so ticket.phase matches the
+    // phase-AGENT TYPE the queue/worker surfaces (incl. 'remediate').
+    const cur = derivePhaseWithRemediate(phaseSigs, remediateSig);
     const phaseSummary = buildPhaseSummary(phaseSigs, now);
     const live = inFlightTickets.get(id);
     return {

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
@@ -1197,7 +1197,19 @@ export function Board({
         {/* subhead */}
         <div style={{ display: "flex", alignItems: "center", gap: 14, padding: "10px 16px", flex: "0 0 auto", flexWrap: "wrap" }}>
           <h1 style={{ margin: 0, fontSize: 15, fontWeight: 600 }}>{view === "tickets" ? "Tickets" : "Workers"}</h1>
-          <span style={{ color: C.fgMuted, fontSize: 12 }}>{view === "tickets" ? "Where each ticket sits in the pipeline · cyan = a worker is live on it now" : "Workers the daemon has deployed — active vs stuck"}</span>
+          {/* CTL-972: lens-aware tagline + quiet active-lens indicator */}
+          <span style={{ color: C.fgMuted, fontSize: 12 }}>
+            {view === "tickets"
+              ? lens === "phase"
+                ? "Which phase-agent is working each ticket · cyan = live worker"
+                : "Linear stage for each ticket · cyan = a worker is live on it now"
+              : "Workers the daemon has deployed — active vs stuck"}
+          </span>
+          {view === "tickets" && (
+            <span style={{ fontSize: 11, color: C.fgDim, background: C.s1, border: `1px solid ${C.border}`, borderRadius: 4, padding: "1px 6px", whiteSpace: "nowrap" }}>
+              {lens === "phase" ? "Pipeline phase" : "Linear stage"}
+            </span>
+          )}
           <span style={{ flex: 1 }} />
           {/* BOARD2 / CTL-906: the three scattered Tickets subhead toggles (lens /
               colorBy / repo-lanes) are folded into ONE Display-options popover —

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/board-display.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/board-display.ts
@@ -33,12 +33,17 @@ export const LINEAR_COLUMNS: readonly BoardColumnDef[] = [
   { key: "Done", label: "Done", c: "#6b7280" },
 ];
 
+// CTL-972: PHASE_COLUMNS includes the ancillary 'remediate' phase between
+// verify and review. Remediate is not in PHASE_ORDER (the linear pipeline) but
+// is a real phase-agent type that cycles with verify; its color matches Board.tsx
+// PHASE_C.remediate (#d98ab2, already defined there).
 export const PHASE_COLUMNS: readonly BoardColumnDef[] = [
   { key: "triage", label: "Triage", c: "#64748b" },
   { key: "research", label: "Research", c: "#3b82f6" },
   { key: "plan", label: "Plan", c: "#a855f7" },
   { key: "implement", label: "Implement", c: "#10b981" },
   { key: "verify", label: "Verify", c: "#f59e0b" },
+  { key: "remediate", label: "Remediate", c: "#d98ab2" },
   { key: "review", label: "Review", c: "#eab308" },
   { key: "pr", label: "PR", c: "#14b8a6" },
   { key: "monitor-merge", label: "Merge", c: "#4ea1ff" },


### PR DESCRIPTION
## Summary

- **UNIFY (core data fix)**: `board-data.mjs` now reads `phase-remediate.json` alongside the regular PHASE_ORDER signals and derives `ticket.phase` via the new `derivePhaseWithRemediate` function. This makes `ticket.phase` carry the same phase-agent-type value the worker/queue uses (`worker.phase`), including `'remediate'`. For the CTL-729 live bug case: a dead remediate worker whose `phase-remediate.json` has a later `updatedAt` than `phase-verify.json` now correctly surfaces `ticket.phase='remediate'` instead of collapsing to `'verify'`.
- **REMEDIATE COLUMN**: `PHASE_COLUMNS` in `board-display.ts` now includes `{ key: "remediate", label: "Remediate", c: "#d98ab2" }` between `verify` and `review`. The shared-header column set, `laneColumns`, and `groupTicketsByStage` (CTL-955 list grouping) all pick it up automatically via `PHASE_COLUMNS` iteration. The drift guard test (`board-phase-drift.test.ts`) is updated to allow ancillary phases as extras (same superset rule `PHASE_C` already follows).
- **LENS LABEL**: The Tickets subhead now shows a small quiet badge ("Pipeline phase" or "Linear stage") and a lens-aware tagline ("which phase-agent is working each ticket" vs "Linear stage for each ticket"). Board.tsx footprint is minimal — only the tagline span and the badge.

## Test plan

- [x] 19 new TDD tests in `__tests__/board-remediate.test.ts` covering all three deliverables
- [x] `derivePhaseWithRemediate` for running remediate, terminal dead-worker case, verify-wins-after-new-pass, no-remediate-sig pass-through
- [x] `PHASE_COLUMNS` contains remediate at the correct position (between verify and review) with color `#d98ab2`
- [x] A remediate ticket routes to the remediate column in phase lens; Validate column in linear lens
- [x] `bun test` 46/46 pass (27 existing + 19 new)
- [x] `bunx tsc --noEmit` clean (only pre-existing `marked`/`dompurify` errors)

Fixes CTL-972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)