### PR TITLE
fix(dev): estimate fallback query uses team+number filter — fixes 400 error (CTL-976)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/estimate-fallback.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/estimate-fallback.test.ts
@@ -1,9 +1,12 @@
-// CTL-974: supplemental estimate fallback — tests for linear-estimate-fallback.mjs
+// CTL-974 / CTL-976: supplemental estimate fallback — tests for linear-estimate-fallback.mjs
 //
 // Three concerns:
 //  1. fillEstimateFallback fires when cache null, does NOT re-fetch cached IDs.
 //  2. Cached result is served on second call (no re-fetch within TTL).
-//  3. estimateDisplay is correct per method (fibonacci → number, tShirt → label).
+//  3. The GraphQL query uses team key + number filter (NOT the invalid 'identifier' filter
+//     that caused 400s — CTL-976 fix).
+//  4. Mocked Linear responses keyed by number + team.key map back to the correct identifier.
+//  5. estimateDisplay is correct per method (fibonacci → number, tShirt → label).
 
 import { describe, it, expect, beforeEach } from "bun:test";
 import {
@@ -19,13 +22,13 @@ import {
 
 function mockFetch(responseData: unknown) {
   let callCount = 0;
-  const calls: string[] = [];
+  const calls: Array<{ query: string; variables: unknown }> = [];
   const originalFetch = globalThis.fetch;
 
   const spy = async (url: string | URL | Request, init?: RequestInit) => {
     callCount++;
     const body = init?.body ? JSON.parse(init.body as string) : {};
-    calls.push(JSON.stringify({ query: body.query?.split("\n")[0], variables: body.variables }));
+    calls.push({ query: body.query ?? "", variables: body.variables });
     return {
       ok: true,
       json: async () => responseData,
@@ -50,31 +53,92 @@ function mockFetchFail() {
 
 // ── (1) fillEstimateFallback fires when cache null ────────────────────────────
 
-describe("CTL-974: fillEstimateFallback — estimate fetched and cached", () => {
+describe("CTL-976: fillEstimateFallback — query uses team+number NOT identifier", () => {
   beforeEach(() => {
     _clearEstimateCache();
     _clearMethodCache();
   });
 
-  it("fetches estimates for null-cache IDs and returns them", async () => {
+  it("sends a query with teamKey + numbers (not identifier)", async () => {
     const spy = mockFetch({
       data: {
         issues: {
           nodes: [
-            { identifier: "CTL-774", estimate: 8 },
-            { identifier: "CTL-100", estimate: 3 },
+            { number: 774, estimate: 8, team: { key: "CTL" } },
           ],
         },
       },
     });
 
     try {
-      const result = await fillEstimateFallback(["CTL-774", "CTL-100"]);
-      expect(result["CTL-774"]).toBe(8);
-      expect(result["CTL-100"]).toBe(3);
-      expect(spy.callCount).toBe(1); // batched — one call for both IDs
+      await fillEstimateFallback(["CTL-774"]);
+      expect(spy.callCount).toBe(1);
+      const call = spy.calls[0];
+      // Query must NOT use 'identifier' filter
+      expect(call.query).not.toContain("identifier");
+      // Query must use number + team key filters
+      expect(call.query).toContain("number");
+      expect(call.query).toContain("teamKey");
+      // Variables must contain the team key and the number
+      const vars = call.variables as { teamKey?: string; numbers?: number[] };
+      expect(vars.teamKey).toBe("CTL");
+      expect(vars.numbers).toContain(774);
     } finally {
       spy.restore();
+    }
+  });
+
+  it("maps Linear response (number + team.key) back to the correct identifier", async () => {
+    const spy = mockFetch({
+      data: {
+        issues: {
+          nodes: [
+            { number: 774, estimate: 8, team: { key: "CTL" } },
+            { number: 930, estimate: 5, team: { key: "CTL" } },
+            { number: 908, estimate: 3, team: { key: "CTL" } },
+          ],
+        },
+      },
+    });
+
+    try {
+      const result = await fillEstimateFallback(["CTL-774", "CTL-930", "CTL-908"]);
+      expect(result["CTL-774"]).toBe(8);
+      expect(result["CTL-930"]).toBe(5);
+      expect(result["CTL-908"]).toBe(3);
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it("groups cross-team IDs into separate per-team queries", async () => {
+    const calls: Array<{ teamKey?: string; numbers?: number[] }> = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      calls.push(body.variables as { teamKey?: string; numbers?: number[] });
+      // Return the appropriate team's issues
+      const teamKey = body.variables?.teamKey as string;
+      const nodes = teamKey === "CTL"
+        ? [{ number: 774, estimate: 8, team: { key: "CTL" } }]
+        : [{ number: 1, estimate: 2, team: { key: "ADV" } }];
+      return {
+        ok: true,
+        json: async () => ({ data: { issues: { nodes } } }),
+      } as Response;
+    }) as typeof fetch;
+
+    try {
+      const result = await fillEstimateFallback(["CTL-774", "ADV-1"]);
+      // Two separate queries (one per team)
+      expect(calls.length).toBe(2);
+      const teamKeys = calls.map((c) => c.teamKey).sort();
+      expect(teamKeys).toEqual(["ADV", "CTL"]);
+      // Results map back correctly
+      expect(result["CTL-774"]).toBe(8);
+      expect(result["ADV-1"]).toBe(2);
+    } finally {
+      globalThis.fetch = originalFetch;
     }
   });
 
@@ -95,10 +159,32 @@ describe("CTL-974: fillEstimateFallback — estimate fetched and cached", () => 
     }
   });
 
+  it("fetches estimates for null-cache IDs and returns them", async () => {
+    const spy = mockFetch({
+      data: {
+        issues: {
+          nodes: [
+            { number: 774, estimate: 8, team: { key: "CTL" } },
+            { number: 100, estimate: 3, team: { key: "CTL" } },
+          ],
+        },
+      },
+    });
+
+    try {
+      const result = await fillEstimateFallback(["CTL-774", "CTL-100"]);
+      expect(result["CTL-774"]).toBe(8);
+      expect(result["CTL-100"]).toBe(3);
+      expect(spy.callCount).toBe(1); // batched — one call for both IDs (same team)
+    } finally {
+      spy.restore();
+    }
+  });
+
   it("does NOT re-fetch cached IDs (cache hit — no second fetch)", async () => {
     // Prime the cache with one fetch.
     const spy1 = mockFetch({
-      data: { issues: { nodes: [{ identifier: "CTL-500", estimate: 5 }] } },
+      data: { issues: { nodes: [{ number: 500, estimate: 5, team: { key: "CTL" } }] } },
     });
     await fillEstimateFallback(["CTL-500"]);
     spy1.restore();
@@ -117,24 +203,24 @@ describe("CTL-974: fillEstimateFallback — estimate fetched and cached", () => 
   it("only fetches the un-cached subset when called with mixed IDs", async () => {
     // Prime cache for CTL-1.
     const spy1 = mockFetch({
-      data: { issues: { nodes: [{ identifier: "CTL-1", estimate: 1 }] } },
+      data: { issues: { nodes: [{ number: 1, estimate: 1, team: { key: "CTL" } }] } },
     });
     await fillEstimateFallback(["CTL-1"]);
     spy1.restore();
 
     // Now call with CTL-1 (cached) + CTL-2 (not cached).
     const spy2 = mockFetch({
-      data: { issues: { nodes: [{ identifier: "CTL-2", estimate: 2 }] } },
+      data: { issues: { nodes: [{ number: 2, estimate: 2, team: { key: "CTL" } }] } },
     });
     try {
       const result = await fillEstimateFallback(["CTL-1", "CTL-2"]);
       expect(result["CTL-1"]).toBe(1); // from cache
       expect(result["CTL-2"]).toBe(2); // from fresh fetch
       expect(spy2.callCount).toBe(1); // only one batch fetch (for CTL-2 only)
-      // The fetch should NOT have included CTL-1 in its variables.
-      const call = JSON.parse(spy2.calls[0]);
-      expect(call.variables.ids).not.toContain("CTL-1");
-      expect(call.variables.ids).toContain("CTL-2");
+      // The fetch should NOT have included CTL-1's number in the variables.
+      const vars = spy2.calls[0].variables as { teamKey?: string; numbers?: number[] };
+      expect(vars.numbers).not.toContain(1);
+      expect(vars.numbers).toContain(2);
     } finally {
       spy2.restore();
     }
@@ -144,8 +230,18 @@ describe("CTL-974: fillEstimateFallback — estimate fetched and cached", () => 
     const spy = mockFetchFail();
     try {
       const result = await fillEstimateFallback(["CTL-FAIL"]);
-      // fail-open: null for the ID, no throw
+      // CTL-FAIL does not parse as a valid identifier (no numeric suffix) → null
       expect(result["CTL-FAIL"]).toBeNull();
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it("is fail-open for valid IDs: returns null on network failure", async () => {
+    const spy = mockFetchFail();
+    try {
+      const result = await fillEstimateFallback(["CTL-9999"]);
+      expect(result["CTL-9999"]).toBeNull();
     } finally {
       spy.restore();
     }
@@ -157,8 +253,8 @@ describe("CTL-974: fillEstimateFallback — estimate fetched and cached", () => 
       data: {
         issues: {
           nodes: [
-            { identifier: "CTL-10", estimate: 10 },
-            { identifier: "CTL-20", estimate: null }, // Linear returns null estimate
+            { number: 10, estimate: 10, team: { key: "CTL" } },
+            { number: 20, estimate: null, team: { key: "CTL" } }, // Linear returns null estimate
           ],
         },
       },

--- a/plugins/dev/scripts/orch-monitor/lib/linear-estimate-fallback.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-estimate-fallback.mjs
@@ -61,14 +61,42 @@ function methodCachePath(teamId) {
 const LINEAR_GRAPHQL_ENDPOINT = "https://api.linear.app/graphql";
 const BATCH_CHUNK_SIZE = 250;
 
-// The estimate query: filter by identifier (the human-readable key like "CTL-774")
-// since the board only knows identifiers, not internal UUIDs.
-// identifier contains "CTL-774" and similar.
-const ESTIMATE_QUERY = `query FallbackEstimates($ids: [String!]) {
-  issues(filter: { identifier: { in: $ids } }, first: ${BATCH_CHUNK_SIZE}) {
+// parseIdentifier — splits "CTL-774" into { teamKey: "CTL", number: 774 }.
+// Returns null if the identifier does not match the expected format.
+function parseIdentifier(id) {
+  if (typeof id !== "string") return null;
+  const match = id.match(/^([A-Za-z][A-Za-z0-9]*)-(\d+)$/);
+  if (!match) return null;
+  return { teamKey: match[1].toUpperCase(), number: parseInt(match[2], 10) };
+}
+
+// groupByTeam — partitions an array of identifier strings by their team key.
+// Identifiers that don't parse (no dash, non-numeric suffix) are silently skipped.
+// Returns a Map<teamKey, number[]>.
+function groupByTeam(ids) {
+  const groups = new Map();
+  for (const id of ids) {
+    const parsed = parseIdentifier(id);
+    if (!parsed) continue;
+    const { teamKey, number } = parsed;
+    if (!groups.has(teamKey)) groups.set(teamKey, []);
+    groups.get(teamKey).push(number);
+  }
+  return groups;
+}
+
+// The estimate query: filter by team key + issue numbers (valid Linear IssueFilter
+// fields).  The old `identifier: { in: $ids }` filter is NOT a valid IssueFilter
+// field and causes a 400 on every call (CTL-976).
+// We run one query per team key so cross-team boards (CTL + ADV, etc.) all resolve.
+const ESTIMATE_QUERY_FOR_TEAM = `query FallbackEstimates($teamKey: String!, $numbers: [Float!]) {
+  issues(filter: { team: { key: { eq: $teamKey } }, number: { in: $numbers } }, first: ${BATCH_CHUNK_SIZE}) {
     nodes {
-      identifier
+      number
       estimate
+      team {
+        key
+      }
     }
   }
 }`;
@@ -199,32 +227,44 @@ export async function fillEstimateFallback(ticketIds) {
 
   if (toFetch.length === 0) return result;
 
-  // Chunk into batches of BATCH_CHUNK_SIZE.
-  const chunks = [];
-  for (let i = 0; i < toFetch.length; i += BATCH_CHUNK_SIZE) {
-    chunks.push(toFetch.slice(i, i + BATCH_CHUNK_SIZE));
+  // Group uncached IDs by team key (e.g. "CTL" → [774, 930, ...]).
+  // IDs that don't parse are quietly stored as null (can't query them).
+  const teamGroups = groupByTeam(toFetch);
+  const unparseable = toFetch.filter((id) => parseIdentifier(id) === null);
+  for (const id of unparseable) {
+    _estimateCache.set(id, { estimate: null, ts: Date.now() });
+    result[id] = null;
+  }
+
+  // For each team key, chunk its numbers and fire one query per chunk.
+  const perTeamChunks = [];
+  for (const [teamKey, numbers] of teamGroups) {
+    for (let i = 0; i < numbers.length; i += BATCH_CHUNK_SIZE) {
+      perTeamChunks.push({ teamKey, numbers: numbers.slice(i, i + BATCH_CHUNK_SIZE) });
+    }
   }
 
   await Promise.allSettled(
-    chunks.map(async (chunk) => {
-      const data = await graphql(ESTIMATE_QUERY, { ids: chunk });
+    perTeamChunks.map(async ({ teamKey, numbers }) => {
+      const data = await graphql(ESTIMATE_QUERY_FOR_TEAM, { teamKey, numbers });
       const nodes = data?.issues?.nodes ?? [];
 
-      // Build a set of IDs that came back from Linear.
-      const fetched = new Set();
+      // Build a set of numbers returned for this team.
+      const fetchedNumbers = new Set();
       for (const node of nodes) {
-        const id = node.identifier;
-        if (!id) continue;
+        if (typeof node.number !== "number") continue;
+        const returnedKey = node.team?.key?.toUpperCase() ?? teamKey;
+        const id = `${returnedKey}-${node.number}`;
         const estimate = typeof node.estimate === "number" ? node.estimate : null;
         _estimateCache.set(id, { estimate, ts: Date.now() });
         result[id] = estimate;
-        fetched.add(id);
+        fetchedNumbers.add(node.number);
       }
 
-      // IDs that Linear did not return (ticket not found, or genuinely no estimate)
-      // are stored as null so we don't re-fetch every board refresh.
-      for (const id of chunk) {
-        if (!fetched.has(id)) {
+      // Numbers that Linear did not return → honest null (not found or unset).
+      for (const num of numbers) {
+        if (!fetchedNumbers.has(num)) {
+          const id = `${teamKey}-${num}`;
           _estimateCache.set(id, { estimate: null, ts: Date.now() });
           result[id] = null;
         }


### PR DESCRIPTION
## Summary

- Replaces the invalid `identifier: { in: $ids }` Linear IssueFilter (not a valid field → HTTP 400) with per-team `team.key + number.in` queries
- Parses each identifier (e.g. `CTL-774`) into `{ teamKey: "CTL", number: 774 }` and groups by team key, so cross-team boards (CTL + ADV) each get their own query
- Maps returned nodes back to identifiers via `team.key + number`
- All other behavior preserved: 5-min TTL, fail-open, 250-ID chunking, estimateMethod/deriveEstimateDisplay, disk cache

## Root cause

`fillEstimateFallback` sent `filter: { identifier: { in: $ids } }` but `identifier` is not a valid field in Linear's `IssueFilter` type. Linear returned HTTP 400 on every call. The module fail-opens by design, so every ticket's estimate stayed `null` forever, and the board showed t-shirt sizes (L/M/S) instead of Fibonacci points.

## Test plan

- [x] `bun test __tests__/estimate-fallback.test.ts` — 14 tests pass
- [x] New assertions: query contains `number`/`teamKey` (not `identifier`); cross-team IDs produce separate per-team queries; mocked response maps `number + team.key` back to correct identifier
- [x] `bunx tsc --noEmit` — clean

Fixes CTL-976.