### PR TITLE
feat(dev): CTL-966 advance_to phase-prediction shadow comparator

### DIFF
--- a/plugins/dev/scripts/execution-core/beliefs/advance-rules.test.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/advance-rules.test.mjs
@@ -20,7 +20,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { openBeliefsDb } from "./schema.mjs";
-import { evaluateBeliefs } from "./rules.mjs";
+import { evaluateBeliefs, R16_advance_to_SQL_FOR_TEST } from "./rules.mjs";
 import { REMEDIATE_CYCLE_CAP, PHASES, NEXT_PHASE } from "../../lib/phase-fsm.mjs";
 import { deriveAdvancement } from "../scheduler.mjs";
 
@@ -368,6 +368,19 @@ describe("CROSS-CHECK: advance_to.to === deriveAdvancement(...) for every fixtur
       opts: { verifyVerdict: "fail", remediateCycleCount: REMEDIATE_CYCLE_CAP + 2 },
     },
   ];
+
+  // FSM-DRIFT GUARD: the R16/R17 SQL embeds the FSM phase-rank + next-phase maps
+  // (compiled from phase-fsm.mjs at module load). This asserts the rule SQL still
+  // contains every (phase, rank) and (cur, next) pair the LIVE FSM declares — so a
+  // descriptor edit (lib/workflow.default.json) that re-orders phases or changes a
+  // successor can't silently desync the belief from deriveAdvancement.
+  test("R16 SQL embeds the live FSM phase-rank + next-phase maps (single source of truth)", () => {
+    // Re-derive the expected VALUES fragments exactly as rules.mjs does.
+    const expectedRank = PHASES.map((p, i) => `('${p}', ${i})`).join(", ");
+    const expectedNext = PHASES.map((p) => `('${p}', '${NEXT_PHASE[p]}')`).join(", ");
+    expect(R16_advance_to_SQL_FOR_TEST).toContain(expectedRank);
+    expect(R16_advance_to_SQL_FOR_TEST).toContain(expectedNext);
+  });
 
   for (const [idx, fx] of fixtures.entries()) {
     test(`fixture #${idx}: ${JSON.stringify(fx.sig)} | ${JSON.stringify(fx.opts)}`, () => {

--- a/plugins/dev/scripts/execution-core/beliefs/advance-rules.test.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/advance-rules.test.mjs
@@ -1,0 +1,397 @@
+// advance-rules.test.mjs — CTL-966 belief-store N4: the FSM advancement
+// prediction beliefs (R16 advance_to, R17 cycle_exhausted) over the obs_signal +
+// obs_verdict + obs_cycle EDB.
+//
+// THE PROOF (mirror contract): advance_to MUST equal deriveAdvancement(...) on
+// every representative pipeline state. The fixture battery seeds obs_signal
+// (+obs_verdict/obs_cycle) rows under one tick, runs evaluateBeliefs, and asserts
+// the derived advance_to.value.to / cycle_exhausted match an INDEPENDENTLY
+// HAND-COMPUTED expectation. The final cross-check block calls the REAL
+// deriveAdvancement (imported from scheduler.mjs) with the SAME logical inputs and
+// asserts belief.to === deriveAdvancement(...) (or both absent) — pinning the
+// mirror so a future FSM/oracle edit that desyncs the belief fails loudly.
+//
+// DERIVE-ONLY: advance_to is a PREDICTION. These tests assert the belief value;
+// nothing here dispatches, resets a cycle, or writes Linear (CTL-966 doctrine).
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { openBeliefsDb } from "./schema.mjs";
+import { evaluateBeliefs } from "./rules.mjs";
+import { REMEDIATE_CYCLE_CAP, PHASES, NEXT_PHASE } from "../../lib/phase-fsm.mjs";
+import { deriveAdvancement } from "../scheduler.mjs";
+
+const NOW = 1781030108000;
+
+const tmps = [];
+function scratch() {
+  const d = mkdtempSync(join(tmpdir(), "ctl966-advance-"));
+  tmps.push(d);
+  return d;
+}
+let db;
+beforeEach(() => {
+  db = openBeliefsDb({ path: join(scratch(), "b.db") });
+});
+afterEach(() => {
+  try {
+    db.close();
+  } catch {
+    /* already closed */
+  }
+  while (tmps.length) {
+    try {
+      rmSync(tmps.pop(), { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+});
+
+// ── fixture builders ─────────────────────────────────────────────────────────
+function tick(now = NOW, host = "mini") {
+  db.run("INSERT INTO tick (now_ms, host) VALUES (?, ?)", [now, host]);
+  return db.query("SELECT last_insert_rowid() AS id").get().id;
+}
+function signal(tickId, ticket, phase, status) {
+  db.run(
+    "INSERT INTO obs_signal (tick_id, ticket, phase, status) VALUES (?, ?, ?, ?)",
+    [tickId, ticket, phase, status],
+  );
+  return db.query("SELECT last_insert_rowid() AS id").get().id;
+}
+function verdict(tickId, ticket, v) {
+  db.run("INSERT INTO obs_verdict (tick_id, ticket, verdict) VALUES (?, ?, ?)", [tickId, ticket, v]);
+  return db.query("SELECT last_insert_rowid() AS id").get().id;
+}
+function cycle(tickId, ticket, n) {
+  db.run("INSERT INTO obs_cycle (tick_id, ticket, remediate_count) VALUES (?, ?, ?)", [
+    tickId,
+    ticket,
+    n,
+  ]);
+  return db.query("SELECT last_insert_rowid() AS id").get().id;
+}
+
+// seedSignals — write one obs_signal per (phase→status) entry of `sigMap` under a
+// fresh tick, optionally a verdict + cycle row, evaluate beliefs, return tickId.
+// `sigMap` is the SAME { phase: status } shape deriveAdvancement consumes.
+function seed(sigMap, { ticket = "CTL-966", verdictVal, cycleCount } = {}) {
+  const tickId = tick();
+  for (const [phase, status] of Object.entries(sigMap)) signal(tickId, ticket, phase, status);
+  if (verdictVal !== undefined) verdict(tickId, ticket, verdictVal);
+  if (cycleCount !== undefined) cycle(tickId, ticket, cycleCount);
+  evaluateBeliefs(db, tickId);
+  return tickId;
+}
+
+// readers ─────────────────────────────────────────────────────────────────────
+function advanceTo(tickId, ticket = "CTL-966") {
+  const row = db
+    .query("SELECT value FROM belief WHERE tick_id = ? AND name = 'advance_to' AND subject = ?")
+    .get(tickId, ticket);
+  return row ? JSON.parse(row.value) : null;
+}
+function cycleExhausted(tickId, ticket = "CTL-966") {
+  const row = db
+    .query("SELECT value FROM belief WHERE tick_id = ? AND name = 'cycle_exhausted' AND subject = ?")
+    .get(tickId, ticket);
+  return row ? JSON.parse(row.value) : null;
+}
+function advanceToProvenance(tickId, ticket = "CTL-966") {
+  const row = db
+    .query(
+      "SELECT source_fact_ids FROM belief WHERE tick_id = ? AND name = 'advance_to' AND subject = ?",
+    )
+    .get(tickId, ticket);
+  return row ? JSON.parse(row.source_fact_ids) : null;
+}
+
+// ── 1. each normal transition triage..monitor-deploy ──────────────────────────
+describe("R16 advance_to — normal FSM transitions (latest done → successor)", () => {
+  // build the cumulative-done prefix for each phase from the FSM order so the
+  // fixture is derived from PHASES, not a hand-listed sequence.
+  const order = PHASES; // triage..teardown
+  for (let i = 0; i < order.length; i++) {
+    const cur = order[i];
+    const next = NEXT_PHASE[cur];
+    const sigMap = {};
+    for (let k = 0; k <= i; k++) sigMap[order[k]] = "done";
+    if (next === "done") {
+      // teardown done → terminal → NO advance (covered in the terminal block)
+      continue;
+    }
+    test(`${cur} done (prefix) → advance_to.to = ${next}`, () => {
+      const t = seed(sigMap);
+      expect(advanceTo(t)).toEqual({ from: cur, to: next });
+      // and it agrees with the oracle
+      expect(advanceTo(t).to).toBe(deriveAdvancement(sigMap));
+    });
+  }
+
+  test("monitor-deploy skipped → teardown (CTL-703 carve-out)", () => {
+    const sigMap = {};
+    for (const p of PHASES) {
+      if (p === "teardown") break;
+      sigMap[p] = p === "monitor-deploy" ? "skipped" : "done";
+    }
+    const t = seed(sigMap);
+    expect(advanceTo(t)).toEqual({ from: "monitor-deploy", to: "teardown" });
+    expect(advanceTo(t).to).toBe(deriveAdvancement(sigMap));
+  });
+});
+
+// ── 2. terminal / no-advance cases ────────────────────────────────────────────
+describe("R16 advance_to — no advance (terminal / not-eligible / already-dispatched)", () => {
+  test("teardown done → NO belief (pipeline terminal)", () => {
+    const sigMap = {};
+    for (const p of PHASES) sigMap[p] = "done";
+    const t = seed(sigMap);
+    expect(advanceTo(t)).toBeNull();
+    expect(deriveAdvancement(sigMap)).toBeNull();
+  });
+
+  test("latest phase running → NO belief (not eligible)", () => {
+    const sigMap = { triage: "done", research: "running" };
+    const t = seed(sigMap);
+    expect(advanceTo(t)).toBeNull();
+    expect(deriveAdvancement(sigMap)).toBeNull();
+  });
+
+  test("latest phase failed → NO belief", () => {
+    const sigMap = { implement: "failed" };
+    const t = seed(sigMap);
+    expect(advanceTo(t)).toBeNull();
+    expect(deriveAdvancement(sigMap)).toBeNull();
+  });
+
+  test("successor already dispatched → NO belief", () => {
+    const sigMap = { research: "done", plan: "dispatched" };
+    const t = seed(sigMap);
+    expect(advanceTo(t)).toBeNull();
+    expect(deriveAdvancement(sigMap)).toBeNull();
+  });
+
+  test("skipped on a NON monitor-deploy phase → NO belief (holds the slot)", () => {
+    for (const sigMap of [{ implement: "skipped" }, { verify: "skipped" }, { triage: "done", research: "skipped" }]) {
+      const t = seed(sigMap);
+      expect(advanceTo(t)).toBeNull();
+      expect(deriveAdvancement(sigMap)).toBeNull();
+    }
+  });
+
+  test("no signals → NO belief", () => {
+    const t = seed({});
+    expect(advanceTo(t)).toBeNull();
+    expect(deriveAdvancement({})).toBeNull();
+  });
+});
+
+// ── 3. verify → review / remediate verdict routing ────────────────────────────
+describe("R16 advance_to — verify verdict routing", () => {
+  const base = { triage: "done", research: "done", plan: "done", implement: "done" };
+
+  test("verify done, NO verdict row → review (absent verdict = conservative pass)", () => {
+    const sigMap = { ...base, verify: "done" };
+    const t = seed(sigMap); // no verdict row
+    expect(advanceTo(t)).toEqual({ from: "verify", to: "review" });
+    expect(advanceTo(t).to).toBe(deriveAdvancement(sigMap, { verifyVerdict: null }));
+  });
+
+  test("verify done, verdict pass → review", () => {
+    const sigMap = { ...base, verify: "done" };
+    const t = seed(sigMap, { verdictVal: "pass" });
+    expect(advanceTo(t)).toEqual({ from: "verify", to: "review" });
+    expect(advanceTo(t).to).toBe(deriveAdvancement(sigMap, { verifyVerdict: "pass" }));
+  });
+
+  test("verify done, verdict fail, cycle 0 (< cap) → remediate", () => {
+    const sigMap = { ...base, verify: "done" };
+    const t = seed(sigMap, { verdictVal: "fail", cycleCount: 0 });
+    expect(advanceTo(t)).toEqual({ from: "verify", to: "remediate" });
+    expect(advanceTo(t).to).toBe(
+      deriveAdvancement(sigMap, { verifyVerdict: "fail", remediateCycleCount: 0 }),
+    );
+    expect(cycleExhausted(t)).toBeNull();
+  });
+
+  test("verify done, verdict fail, remediate already dispatched → NO advance (no double dispatch)", () => {
+    const sigMap = { ...base, verify: "done", remediate: "running" };
+    const t = seed(sigMap, { verdictVal: "fail", cycleCount: 0 });
+    expect(advanceTo(t)).toBeNull();
+    expect(
+      deriveAdvancement(sigMap, { verifyVerdict: "fail", remediateCycleCount: 0 }),
+    ).toBeNull();
+  });
+
+  test("remediate done signal is invisible to latest-selection → still verify-routed (verdict pass → review)", () => {
+    const sigMap = { ...base, verify: "done", remediate: "done" };
+    const t = seed(sigMap, { verdictVal: "pass" });
+    expect(advanceTo(t)).toEqual({ from: "verify", to: "review" });
+    expect(advanceTo(t).to).toBe(deriveAdvancement(sigMap, { verifyVerdict: "pass" }));
+  });
+});
+
+// ── 4. THE HARD CASE: the remediate-cycle cap boundary ────────────────────────
+describe("R17 cycle_exhausted + cap boundary (count == cap-1 advances; count == cap does not)", () => {
+  const base = { triage: "done", research: "done", plan: "done", implement: "done", verify: "done" };
+
+  test(`cycle == cap-1 (${REMEDIATE_CYCLE_CAP - 1}) → advance_to remediate, NO cycle_exhausted`, () => {
+    const t = seed(base, { verdictVal: "fail", cycleCount: REMEDIATE_CYCLE_CAP - 1 });
+    expect(advanceTo(t)).toEqual({ from: "verify", to: "remediate" });
+    expect(cycleExhausted(t)).toBeNull();
+    // oracle agreement at the boundary
+    expect(advanceTo(t).to).toBe(
+      deriveAdvancement(base, { verifyVerdict: "fail", remediateCycleCount: REMEDIATE_CYCLE_CAP - 1 }),
+    );
+  });
+
+  test(`cycle == cap (${REMEDIATE_CYCLE_CAP}) → NO advance_to, cycle_exhausted fires`, () => {
+    const t = seed(base, { verdictVal: "fail", cycleCount: REMEDIATE_CYCLE_CAP });
+    expect(advanceTo(t)).toBeNull();
+    expect(cycleExhausted(t)).toEqual({
+      phase: "verify",
+      remediate_count: REMEDIATE_CYCLE_CAP,
+      cap: REMEDIATE_CYCLE_CAP,
+    });
+    // oracle: deriveAdvancement returns null at the cap (the sweep stalls it)
+    expect(
+      deriveAdvancement(base, { verifyVerdict: "fail", remediateCycleCount: REMEDIATE_CYCLE_CAP }),
+    ).toBeNull();
+  });
+
+  test(`cycle > cap (${REMEDIATE_CYCLE_CAP + 1}) → NO advance_to, cycle_exhausted still fires`, () => {
+    const t = seed(base, { verdictVal: "fail", cycleCount: REMEDIATE_CYCLE_CAP + 1 });
+    expect(advanceTo(t)).toBeNull();
+    expect(cycleExhausted(t)?.remediate_count).toBe(REMEDIATE_CYCLE_CAP + 1);
+    expect(
+      deriveAdvancement(base, { verifyVerdict: "fail", remediateCycleCount: REMEDIATE_CYCLE_CAP + 1 }),
+    ).toBeNull();
+  });
+
+  test("verdict fail but verify NOT done (running) → neither belief (not advance-eligible)", () => {
+    const sigMap = { ...base, verify: "running" };
+    const t = seed(sigMap, { verdictVal: "fail", cycleCount: REMEDIATE_CYCLE_CAP });
+    expect(advanceTo(t)).toBeNull();
+    expect(cycleExhausted(t)).toBeNull();
+    expect(
+      deriveAdvancement(sigMap, { verifyVerdict: "fail", remediateCycleCount: REMEDIATE_CYCLE_CAP }),
+    ).toBeNull();
+  });
+
+  test("verdict pass at cap → NO cycle_exhausted (cap only bites on a fail verdict)", () => {
+    const t = seed(base, { verdictVal: "pass", cycleCount: REMEDIATE_CYCLE_CAP });
+    expect(cycleExhausted(t)).toBeNull();
+    expect(advanceTo(t)).toEqual({ from: "verify", to: "review" });
+  });
+});
+
+// ── 5. provenance: advance_to cites the obs_signal / obs_verdict / obs_cycle facts
+describe("R16 provenance", () => {
+  test("remediate-arm advance_to cites the verify signal + verdict + cycle facts", () => {
+    const base = { triage: "done", research: "done", plan: "done", implement: "done", verify: "done" };
+    const t = seed(base, { verdictVal: "fail", cycleCount: 0 });
+    const refs = advanceToProvenance(t);
+    expect(Array.isArray(refs)).toBe(true);
+    // one 's' (verify signal), one 'v' (verdict), one 'c' (cycle)
+    expect(refs.some((r) => typeof r === "string" && r.startsWith("s"))).toBe(true);
+    expect(refs.some((r) => typeof r === "string" && r.startsWith("v"))).toBe(true);
+    expect(refs.some((r) => typeof r === "string" && r.startsWith("c"))).toBe(true);
+  });
+
+  test("normal-edge advance_to cites the latest done signal", () => {
+    const t = seed({ triage: "done" });
+    const refs = advanceToProvenance(t);
+    expect(refs.some((r) => typeof r === "string" && r.startsWith("s"))).toBe(true);
+  });
+});
+
+// ── 6. the cross-check battery — belief.to === deriveAdvancement(...) for a wide
+// set of (signals, verdict, cycle) tuples. Each tuple's expectation is the REAL
+// oracle, so this pins the mirror across the whole representative state space.
+describe("CROSS-CHECK: advance_to.to === deriveAdvancement(...) for every fixture", () => {
+  // Build the cumulative-done prefixes for the normal edges from the FSM order.
+  const prefixCases = [];
+  for (let i = 0; i < PHASES.length; i++) {
+    const sigMap = {};
+    for (let k = 0; k <= i; k++) sigMap[PHASES[k]] = "done";
+    prefixCases.push({ sig: sigMap, opts: {} });
+  }
+
+  const fixtures = [
+    ...prefixCases,
+    // monitor-deploy skipped carve-out
+    {
+      sig: (() => {
+        const m = {};
+        for (const p of PHASES) {
+          if (p === "teardown") break;
+          m[p] = p === "monitor-deploy" ? "skipped" : "done";
+        }
+        return m;
+      })(),
+      opts: {},
+    },
+    // not-eligible / failed / already-dispatched
+    { sig: { triage: "done", research: "running" }, opts: {} },
+    { sig: { implement: "failed" }, opts: {} },
+    { sig: { research: "done", plan: "dispatched" }, opts: {} },
+    { sig: { implement: "skipped" }, opts: {} },
+    { sig: { verify: "skipped" }, opts: {} },
+    { sig: {}, opts: {} },
+    // verdict routing
+    { sig: { implement: "done", verify: "done" }, opts: { verifyVerdict: "pass" } },
+    { sig: { implement: "done", verify: "done" }, opts: { verifyVerdict: null } },
+    { sig: { implement: "done", verify: "done" }, opts: { verifyVerdict: "fail", remediateCycleCount: 0 } },
+    {
+      sig: { implement: "done", verify: "done", remediate: "running" },
+      opts: { verifyVerdict: "fail", remediateCycleCount: 0 },
+    },
+    {
+      sig: { implement: "done", verify: "done", remediate: "done" },
+      opts: { verifyVerdict: "pass" },
+    },
+    // cap boundary
+    {
+      sig: { implement: "done", verify: "done" },
+      opts: { verifyVerdict: "fail", remediateCycleCount: REMEDIATE_CYCLE_CAP - 1 },
+    },
+    {
+      sig: { implement: "done", verify: "done" },
+      opts: { verifyVerdict: "fail", remediateCycleCount: REMEDIATE_CYCLE_CAP },
+    },
+    {
+      sig: { implement: "done", verify: "done" },
+      opts: { verifyVerdict: "fail", remediateCycleCount: REMEDIATE_CYCLE_CAP + 2 },
+    },
+  ];
+
+  for (const [idx, fx] of fixtures.entries()) {
+    test(`fixture #${idx}: ${JSON.stringify(fx.sig)} | ${JSON.stringify(fx.opts)}`, () => {
+      // Map the oracle opts onto the EDB facts the rule consumes:
+      //   verifyVerdict → obs_verdict row (undefined/null → no row)
+      //   remediateCycleCount → obs_cycle row (undefined → no row, rule COALESCEs 0)
+      const seedOpts = {};
+      if (fx.opts.verifyVerdict != null) seedOpts.verdictVal = fx.opts.verifyVerdict;
+      if (fx.opts.remediateCycleCount !== undefined) seedOpts.cycleCount = fx.opts.remediateCycleCount;
+      const t = seed(fx.sig, seedOpts);
+
+      const oracle = deriveAdvancement(fx.sig, fx.opts);
+      const belief = advanceTo(t);
+
+      if (oracle === null) {
+        // oracle owes nothing → advance_to must be ABSENT (the "remediate" oracle
+        // value is the only non-phase string; null maps to no belief)
+        expect(belief).toBeNull();
+      } else if (oracle === "remediate") {
+        expect(belief?.to).toBe("remediate");
+      } else {
+        // a normal next-phase string
+        expect(belief?.to).toBe(oracle);
+      }
+    });
+  }
+});

--- a/plugins/dev/scripts/execution-core/beliefs/advance-shadow.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/advance-shadow.mjs
@@ -1,0 +1,194 @@
+// beliefs/advance-shadow.mjs — CTL-966 + CTL-935 shadow comparator: compares the
+// PROCEDURAL advancement oracle (deriveAdvancement) against the DERIVE-ONLY
+// advance_to / cycle_exhausted beliefs for the current tick, and logs every
+// disagreement as an operator event. SHADOW ONLY — this path NEVER dispatches,
+// writes a signal, resets a cycle, or writes Linear. It READS beliefs.db +
+// computes the oracle + appends an operator event. Nothing here gates the tick.
+//
+// The free_slots-shadow pattern applied to advancement: on ANY disagreement,
+// append a `beliefs.advance_shadow.disagree` event carrying the procedural
+// answer, the belief answer, a signals summary, and the differing input — so
+// disagreements are logged with rate + direction + differing-input. On agreement
+// the caller may emit a `beliefs.advance_shadow.tick` summary (agree/disagree
+// counts). The whole function is wrapped in the caller's own try/catch (shadow
+// contract); it additionally guards each ticket so one bad ticket can't abort the
+// comparison of the rest.
+
+// readAdvanceBeliefs — for one tick, the advance_to + cycle_exhausted beliefs
+// keyed by ticket (subject). Returns { advanceTo: Map<ticket,{from,to}>,
+// cycleExhausted: Set<ticket> }. Pure read; null-safe on a missing db.
+export function readAdvanceBeliefs(db, tickId) {
+  const advanceTo = new Map();
+  const cycleExhausted = new Set();
+  if (!db || tickId == null) return { advanceTo, cycleExhausted };
+  const rows = db
+    .query(
+      "SELECT name, subject, value FROM belief WHERE tick_id = ? AND name IN ('advance_to','cycle_exhausted')",
+    )
+    .all(tickId);
+  for (const r of rows) {
+    if (r.name === "cycle_exhausted") {
+      cycleExhausted.add(r.subject);
+      continue;
+    }
+    let v = null;
+    try {
+      v = r.value ? JSON.parse(r.value) : null;
+    } catch {
+      v = null;
+    }
+    advanceTo.set(r.subject, v);
+  }
+  return { advanceTo, cycleExhausted };
+}
+
+// signalsSummary — a compact { phase: status } map for the disagreement payload.
+function signalsSummary(signals) {
+  const out = {};
+  for (const [phase, status] of Object.entries(signals ?? {})) out[phase] = status;
+  return out;
+}
+
+// compareAdvancement — pure comparison for ONE ticket. Returns null on agreement,
+// else a disagreement record. The belief side: advance_to.to (or null when no
+// advance_to belief exists). The procedural side: deriveAdvancement's return
+// (a phase string, "remediate", or null). They AGREE iff procedural === beliefTo
+// (both null counts as agreement). cycle_exhausted is compared as a secondary
+// signal: the belief fires it exactly when the oracle returns null AT the cap on a
+// failed verify verdict — a mismatch there is also a disagreement.
+//
+//   procedural : string | "remediate" | null   (deriveAdvancement output)
+//   beliefTo   : string | "remediate" | null   (advance_to.value.to or null)
+//   beliefExhausted : boolean                   (cycle_exhausted belief present)
+//   expectExhausted : boolean                   (the oracle's cap condition)
+export function compareAdvancement({
+  ticket,
+  signals,
+  procedural,
+  beliefTo,
+  beliefExhausted,
+  expectExhausted,
+  verdict,
+  cycleCount,
+}) {
+  const advanceAgrees = procedural === beliefTo;
+  const exhaustAgrees = !!beliefExhausted === !!expectExhausted;
+  if (advanceAgrees && exhaustAgrees) return null;
+  return {
+    ticket,
+    procedural,
+    belief: beliefTo,
+    procedural_exhausted: !!expectExhausted,
+    belief_exhausted: !!beliefExhausted,
+    signals: signalsSummary(signals),
+    differingInput: { verdict: verdict ?? null, remediateCycleCount: cycleCount ?? 0 },
+  };
+}
+
+// runAdvanceShadow — the daemon-facing comparator. For each in-flight ticket,
+// compute the procedural oracle and compare it to the belief. Appends a
+// `beliefs.advance_shadow.disagree` operator event per disagreement and an
+// optional `beliefs.advance_shadow.tick` summary. Returns { agree, disagree,
+// disagreements }. NEVER acts on the result.
+//
+// Injected seams (so it stays pure + testable, mirroring the scheduler sweep):
+//   listInFlight(orchDir)               -> ticket[]
+//   readSignals(orchDir, ticket)        -> { phase: status }
+//   readVerdict({ ticket, orchDir })    -> "pass" | "fail" | null
+//   countCycles({ ticket })             -> integer
+//   deriveAdvancement(signals, opts)    -> string | "remediate" | null
+//   capOf()                             -> REMEDIATE_CYCLE_CAP
+//   appendEvent(evt)                    -> void | null   (operator-event seam)
+export function runAdvanceShadow(
+  db,
+  tickId,
+  {
+    orchDir,
+    listInFlight,
+    readSignals,
+    readVerdict,
+    countCycles,
+    deriveAdvancement,
+    cap,
+    appendEvent = null,
+    emitTickSummary = false,
+  } = {},
+) {
+  const result = { agree: 0, disagree: 0, disagreements: [] };
+  if (!db || tickId == null) return result;
+
+  const { advanceTo, cycleExhausted } = readAdvanceBeliefs(db, tickId);
+
+  let tickets = [];
+  try {
+    tickets = listInFlight(orchDir) ?? [];
+    // listInFlightTickets returns a Set; normalize to an array.
+    if (!Array.isArray(tickets)) tickets = Array.from(tickets);
+  } catch {
+    tickets = [];
+  }
+
+  for (const ticket of tickets) {
+    try {
+      const signals = readSignals(orchDir, ticket) ?? {};
+      const verdict = readVerdict({ ticket, orchDir }) ?? null;
+      const cycleCount = countCycles({ ticket }) ?? 0;
+      // The PROCEDURAL oracle — the exact call the advancement sweep makes.
+      const procedural = deriveAdvancement(signals, {
+        verifyVerdict: verdict,
+        remediateCycleCount: cycleCount,
+      });
+      // The oracle's cap condition (mirrors maybeEscalateRemediateExhausted's
+      // trigger): verify done + verdict fail + cycleCount >= cap.
+      const expectExhausted =
+        signals.verify === "done" && verdict === "fail" && cycleCount >= cap;
+
+      const beliefVal = advanceTo.get(ticket) ?? null;
+      const beliefTo = beliefVal?.to ?? null;
+      const beliefExhausted = cycleExhausted.has(ticket);
+
+      const disagreement = compareAdvancement({
+        ticket,
+        signals,
+        procedural,
+        beliefTo,
+        beliefExhausted,
+        expectExhausted,
+        verdict,
+        cycleCount,
+      });
+
+      if (disagreement) {
+        result.disagree += 1;
+        result.disagreements.push(disagreement);
+        if (typeof appendEvent === "function") {
+          try {
+            appendEvent({
+              "event.name": "beliefs.advance_shadow.disagree",
+              payload: disagreement,
+            });
+          } catch {
+            /* operator-event append is best-effort — never breaks the tick */
+          }
+        }
+      } else {
+        result.agree += 1;
+      }
+    } catch {
+      // one bad ticket must not abort the comparison of the rest (shadow contract)
+    }
+  }
+
+  if (emitTickSummary && typeof appendEvent === "function" && (result.agree || result.disagree)) {
+    try {
+      appendEvent({
+        "event.name": "beliefs.advance_shadow.tick",
+        payload: { agree: result.agree, disagree: result.disagree },
+      });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  return result;
+}

--- a/plugins/dev/scripts/execution-core/beliefs/advance-shadow.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/advance-shadow.mjs
@@ -13,6 +13,17 @@
 // counts). The whole function is wrapped in the caller's own try/catch (shadow
 // contract); it additionally guards each ticket so one bad ticket can't abort the
 // comparison of the rest.
+//
+// TIMING (shadow fidelity, not a bug): this comparator runs AFTER collectBeliefsTick
+// (so the advance_to/cycle_exhausted beliefs for THIS tick exist) and BEFORE
+// schedulerTick (which runs maybeResetForRemediateCycle + the real dispatch). The
+// comparator re-reads the PRE-reset signals via the injected readSignals seam, so
+// its procedural oracle is computed over the SAME inputs the belief saw — a true
+// apples-to-apples belief-vs-oracle comparison. The sweep's own deriveAdvancement
+// (over POST-reset signals on a remediate→verify re-entry tick) is a different
+// call at a different point in the tick; this comparator deliberately does NOT
+// reproduce the reset (derive-only — it owns no file deletes), so a logged
+// disagreement always reflects a belief/oracle mismatch on identical inputs.
 
 // readAdvanceBeliefs — for one tick, the advance_to + cycle_exhausted beliefs
 // keyed by ticket (subject). Returns { advanceTo: Map<ticket,{from,to}>,

--- a/plugins/dev/scripts/execution-core/beliefs/advance-shadow.test.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/advance-shadow.test.mjs
@@ -1,0 +1,253 @@
+// advance-shadow.test.mjs — CTL-966 + CTL-935: the advancement shadow comparator.
+// Asserts it (a) logs a disagreement event when the belief diverges from the
+// procedural oracle, (b) stays SILENT on agreement, (c) NEVER acts (no dispatch /
+// signal write / Linear write — the comparator has no such seams, proven by the
+// injected-seam set), and (d) is robust to a bad ticket / missing db.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { openBeliefsDb } from "./schema.mjs";
+import { evaluateBeliefs } from "./rules.mjs";
+import { runAdvanceShadow, readAdvanceBeliefs, compareAdvancement } from "./advance-shadow.mjs";
+import { deriveAdvancement } from "../scheduler.mjs";
+import { REMEDIATE_CYCLE_CAP } from "../../lib/phase-fsm.mjs";
+
+const NOW = 1781030108000;
+const tmps = [];
+function scratch() {
+  const d = mkdtempSync(join(tmpdir(), "ctl966-shadow-"));
+  tmps.push(d);
+  return d;
+}
+let db;
+beforeEach(() => {
+  db = openBeliefsDb({ path: join(scratch(), "b.db") });
+});
+afterEach(() => {
+  try {
+    db.close();
+  } catch {
+    /* */
+  }
+  while (tmps.length) {
+    try {
+      rmSync(tmps.pop(), { recursive: true, force: true });
+    } catch {
+      /* */
+    }
+  }
+});
+
+function tick(now = NOW) {
+  db.run("INSERT INTO tick (now_ms, host) VALUES (?, 'mini')", [now]);
+  return db.query("SELECT last_insert_rowid() AS id").get().id;
+}
+function signal(tickId, ticket, phase, status) {
+  db.run("INSERT INTO obs_signal (tick_id, ticket, phase, status) VALUES (?, ?, ?, ?)", [
+    tickId,
+    ticket,
+    phase,
+    status,
+  ]);
+}
+function verdict(tickId, ticket, v) {
+  db.run("INSERT INTO obs_verdict (tick_id, ticket, verdict) VALUES (?, ?, ?)", [tickId, ticket, v]);
+}
+function cycle(tickId, ticket, n) {
+  db.run("INSERT INTO obs_cycle (tick_id, ticket, remediate_count) VALUES (?, ?, ?)", [tickId, ticket, n]);
+}
+
+// A harness that wires the REAL oracle + real belief reads but FAKE signal
+// readers (so we can force agreement / disagreement deterministically).
+function makeSeams(signalsByTicket, { verdicts = {}, cycles = {}, events } = {}) {
+  return {
+    orchDir: "/fake",
+    listInFlight: () => Object.keys(signalsByTicket),
+    readSignals: (_od, ticket) => signalsByTicket[ticket] ?? {},
+    readVerdict: ({ ticket }) => verdicts[ticket] ?? null,
+    countCycles: ({ ticket }) => cycles[ticket] ?? 0,
+    deriveAdvancement,
+    cap: REMEDIATE_CYCLE_CAP,
+    appendEvent: events ? (e) => events.push(e) : null,
+  };
+}
+
+describe("runAdvanceShadow — agreement (belief mirrors the oracle) is silent", () => {
+  test("normal edge: belief and oracle both say research → no disagreement event", () => {
+    const t = tick();
+    signal(t, "CTL-1", "triage", "done");
+    evaluateBeliefs(db, t);
+    const events = [];
+    const res = runAdvanceShadow(db, t, makeSeams({ "CTL-1": { triage: "done" } }, { events }));
+    expect(res.agree).toBe(1);
+    expect(res.disagree).toBe(0);
+    expect(events).toEqual([]);
+  });
+
+  test("remediate detour: belief and oracle both say remediate → silent", () => {
+    const sig = { triage: "done", research: "done", plan: "done", implement: "done", verify: "done" };
+    const t = tick();
+    for (const [p, s] of Object.entries(sig)) signal(t, "CTL-2", p, s);
+    verdict(t, "CTL-2", "fail");
+    cycle(t, "CTL-2", 0);
+    evaluateBeliefs(db, t);
+    const events = [];
+    const res = runAdvanceShadow(
+      db,
+      t,
+      makeSeams({ "CTL-2": sig }, { verdicts: { "CTL-2": "fail" }, cycles: { "CTL-2": 0 }, events }),
+    );
+    expect(res.disagree).toBe(0);
+    expect(events).toEqual([]);
+  });
+
+  test("cap reached: oracle null + cycle_exhausted belief → silent (agreement)", () => {
+    const sig = { triage: "done", research: "done", plan: "done", implement: "done", verify: "done" };
+    const t = tick();
+    for (const [p, s] of Object.entries(sig)) signal(t, "CTL-3", p, s);
+    verdict(t, "CTL-3", "fail");
+    cycle(t, "CTL-3", REMEDIATE_CYCLE_CAP);
+    evaluateBeliefs(db, t);
+    const events = [];
+    const res = runAdvanceShadow(
+      db,
+      t,
+      makeSeams(
+        { "CTL-3": sig },
+        { verdicts: { "CTL-3": "fail" }, cycles: { "CTL-3": REMEDIATE_CYCLE_CAP }, events },
+      ),
+    );
+    expect(res.disagree).toBe(0);
+    expect(events).toEqual([]);
+  });
+});
+
+describe("runAdvanceShadow — disagreement is logged (and only logged)", () => {
+  test("belief missing but oracle owes an advance → disagree event with differing input", () => {
+    const t = tick();
+    signal(t, "CTL-9", "triage", "done");
+    // intentionally DO NOT evaluateBeliefs → no advance_to belief exists
+    const events = [];
+    const res = runAdvanceShadow(db, t, makeSeams({ "CTL-9": { triage: "done" } }, { events }));
+    expect(res.disagree).toBe(1);
+    expect(events).toHaveLength(1);
+    expect(events[0]["event.name"]).toBe("beliefs.advance_shadow.disagree");
+    expect(events[0].payload.procedural).toBe("research");
+    expect(events[0].payload.belief).toBeNull();
+    expect(events[0].payload.ticket).toBe("CTL-9");
+    expect(events[0].payload.signals).toEqual({ triage: "done" });
+    expect(events[0].payload.differingInput).toEqual({ verdict: null, remediateCycleCount: 0 });
+  });
+
+  test("oracle says remediate but the comparator's procedural seam is fed a passing verdict → disagree", () => {
+    // belief computed from a FAIL verdict (→ remediate), but the procedural seam
+    // is fed PASS (→ review). The comparator must flag the divergence.
+    const sig = { triage: "done", research: "done", plan: "done", implement: "done", verify: "done" };
+    const t = tick();
+    for (const [p, s] of Object.entries(sig)) signal(t, "CTL-10", p, s);
+    verdict(t, "CTL-10", "fail"); // belief sees fail → remediate
+    cycle(t, "CTL-10", 0);
+    evaluateBeliefs(db, t);
+    const events = [];
+    const res = runAdvanceShadow(
+      db,
+      t,
+      makeSeams({ "CTL-10": sig }, { verdicts: { "CTL-10": "pass" }, cycles: { "CTL-10": 0 }, events }),
+    );
+    expect(res.disagree).toBe(1);
+    expect(events[0].payload.procedural).toBe("review"); // oracle (pass)
+    expect(events[0].payload.belief).toBe("remediate"); // belief (fail)
+  });
+});
+
+describe("runAdvanceShadow — robustness + no-act contract", () => {
+  test("null db / null tick → empty result, no throw", () => {
+    expect(runAdvanceShadow(null, 1, {})).toEqual({ agree: 0, disagree: 0, disagreements: [] });
+    expect(runAdvanceShadow(db, null, {})).toEqual({ agree: 0, disagree: 0, disagreements: [] });
+  });
+
+  test("a ticket whose readSignals throws is skipped, the rest still compared", () => {
+    const t = tick();
+    signal(t, "CTL-OK", "triage", "done");
+    evaluateBeliefs(db, t);
+    const events = [];
+    const res = runAdvanceShadow(db, t, {
+      orchDir: "/fake",
+      listInFlight: () => ["CTL-BAD", "CTL-OK"],
+      readSignals: (_od, ticket) => {
+        if (ticket === "CTL-BAD") throw new Error("boom");
+        return { triage: "done" };
+      },
+      readVerdict: () => null,
+      countCycles: () => 0,
+      deriveAdvancement,
+      cap: REMEDIATE_CYCLE_CAP,
+      appendEvent: (e) => events.push(e),
+    });
+    // CTL-OK agreed (advance_to=research mirrors the oracle), CTL-BAD swallowed
+    expect(res.agree).toBe(1);
+    expect(res.disagree).toBe(0);
+  });
+
+  test("the seam set exposes NO dispatch / signal-write / Linear-write hook (derive-only by construction)", () => {
+    // The comparator is a READER: its only side-effecting seam is appendEvent.
+    // This pins the no-act contract structurally — there is no dispatch, no
+    // writeSignal, no writeStatus seam to mis-wire.
+    const seamNames = Object.keys(makeSeams({}, {}));
+    expect(seamNames).not.toContain("dispatch");
+    expect(seamNames).not.toContain("writeStatus");
+    expect(seamNames).not.toContain("writeSignal");
+    expect(seamNames).toContain("appendEvent");
+  });
+
+  test("emitTickSummary appends a summary event when enabled", () => {
+    const t = tick();
+    signal(t, "CTL-S", "triage", "done");
+    evaluateBeliefs(db, t);
+    const events = [];
+    runAdvanceShadow(db, t, {
+      ...makeSeams({ "CTL-S": { triage: "done" } }, { events }),
+      emitTickSummary: true,
+    });
+    const summary = events.find((e) => e["event.name"] === "beliefs.advance_shadow.tick");
+    expect(summary).toBeTruthy();
+    expect(summary.payload).toEqual({ agree: 1, disagree: 0 });
+  });
+});
+
+describe("readAdvanceBeliefs / compareAdvancement units", () => {
+  test("readAdvanceBeliefs returns advance_to map + cycle_exhausted set", () => {
+    const sig = { triage: "done", research: "done", plan: "done", implement: "done", verify: "done" };
+    const t = tick();
+    for (const [p, s] of Object.entries(sig)) signal(t, "CTL-R", p, s);
+    verdict(t, "CTL-R", "fail");
+    cycle(t, "CTL-R", REMEDIATE_CYCLE_CAP);
+    evaluateBeliefs(db, t);
+    const { advanceTo, cycleExhausted } = readAdvanceBeliefs(db, t);
+    expect(advanceTo.has("CTL-R")).toBe(false); // no advance at the cap
+    expect(cycleExhausted.has("CTL-R")).toBe(true);
+  });
+
+  test("compareAdvancement: both null → agreement (returns null)", () => {
+    expect(
+      compareAdvancement({ ticket: "X", signals: {}, procedural: null, beliefTo: null, beliefExhausted: false, expectExhausted: false }),
+    ).toBeNull();
+  });
+
+  test("compareAdvancement: cycle_exhausted mismatch is a disagreement", () => {
+    const d = compareAdvancement({
+      ticket: "X",
+      signals: { verify: "done" },
+      procedural: null,
+      beliefTo: null,
+      beliefExhausted: false,
+      expectExhausted: true,
+    });
+    expect(d).not.toBeNull();
+    expect(d.procedural_exhausted).toBe(true);
+    expect(d.belief_exhausted).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/beliefs/collector-advance.test.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/collector-advance.test.mjs
@@ -1,0 +1,235 @@
+// collector-advance.test.mjs — CTL-966 belief-store N4: the obs_verdict +
+// obs_cycle fact layer. Verifies the collection blocks in collector.mjs against
+// real verify.json artifacts (parsed by readVerifyVerdict) and a real event log
+// (counted by countRemediateCycles) — the SAME readers the procedural
+// deriveAdvancement consumes.
+import { describe, test, expect, afterEach, beforeEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { openBeliefsDb } from "./schema.mjs";
+import { collectTickFacts, __resetBeliefsCollectorForTests } from "./collector.mjs";
+import { __resetEventScanIndexForTest } from "../event-scan.mjs";
+
+const DAY = 86_400_000;
+const NOW = 1781030108000;
+
+const tmps = [];
+function scratch() {
+  const d = mkdtempSync(join(tmpdir(), "ctl966-collect-"));
+  tmps.push(d);
+  return d;
+}
+beforeEach(() => {
+  __resetBeliefsCollectorForTests();
+  __resetEventScanIndexForTest();
+});
+afterEach(() => {
+  __resetBeliefsCollectorForTests();
+  __resetEventScanIndexForTest();
+  while (tmps.length) {
+    try {
+      rmSync(tmps.pop(), { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+});
+
+// writeVerify — drop a verify.json under orchDir/workers/<ticket>/.
+function writeVerify(orchDir, ticket, body) {
+  const wdir = join(orchDir, "workers", ticket);
+  mkdirSync(wdir, { recursive: true });
+  writeFileSync(join(wdir, "verify.json"), JSON.stringify(body));
+}
+
+// writeEventLog — write the remediate-complete events for a set of tickets, in
+// the unified event-log envelope shape ({ ts, attributes: { "event.name" } })
+// that scanEventsChunked / countRemediateCycles parse.
+function writeEventLog(path, tickets) {
+  const lines = tickets.map((t) =>
+    JSON.stringify({
+      ts: "2026-06-09T10:00:00Z",
+      attributes: { "event.name": `phase.remediate.complete.${t}` },
+    }),
+  );
+  writeFileSync(path, lines.join("\n") + (lines.length ? "\n" : ""));
+}
+
+function oneSignal(ticket = "CTL-100", phase = "verify", status = "done") {
+  return () => [
+    {
+      ticket,
+      phase,
+      status,
+      liveness: { kind: "bg", value: "aaa1" },
+      updatedAt: "2026-06-09T10:00:00Z",
+      raw: { generation: 1, startedAt: "2026-06-09T09:00:00Z" },
+    },
+  ];
+}
+
+function collect(db, { orchDir, eventLogPath, readSignals }) {
+  return collectTickFacts({
+    db,
+    orchDir,
+    now: NOW,
+    host: "mini",
+    env: { CATALYST_BELIEFS_SHADOW: "1" },
+    eventLogPath,
+    getAgents: () => [],
+    readSignals,
+    readJobState: () => ({ exists: false }),
+    findTranscriptFn: () => null,
+    linearCache: { get: () => undefined },
+  });
+}
+
+describe("obs_verdict — schema + collection (CTL-966)", () => {
+  test("table + index created by openBeliefsDb", () => {
+    const db = openBeliefsDb({ path: join(scratch(), "b.db") });
+    const tables = db.query("SELECT name FROM sqlite_master WHERE type='table'").all().map((r) => r.name);
+    expect(tables).toContain("obs_verdict");
+    expect(tables).toContain("obs_cycle");
+    const idx = db.query("SELECT name FROM sqlite_master WHERE type='index'").all().map((r) => r.name);
+    expect(idx).toContain("idx_obs_verdict_tick");
+    expect(idx).toContain("idx_obs_cycle_tick");
+    db.close();
+  });
+
+  test("regression_risk >= 5 → verdict 'fail' row", () => {
+    const orchDir = scratch();
+    const db = openBeliefsDb({ path: join(scratch(), "b.db") });
+    writeVerify(orchDir, "CTL-100", { regression_risk: 7, findings: [] });
+    const res = collect(db, {
+      orchDir,
+      eventLogPath: join(scratch(), "absent.jsonl"),
+      readSignals: oneSignal("CTL-100"),
+    });
+    expect(res.ok).toBe(true);
+    const row = db.query("SELECT ticket, verdict FROM obs_verdict").get();
+    expect(row).toEqual({ ticket: "CTL-100", verdict: "fail" });
+    db.close();
+  });
+
+  test("high-severity finding → verdict 'fail'", () => {
+    const orchDir = scratch();
+    const db = openBeliefsDb({ path: join(scratch(), "b.db") });
+    writeVerify(orchDir, "CTL-100", { regression_risk: 1, findings: [{ severity: "high" }] });
+    collect(db, { orchDir, eventLogPath: join(scratch(), "absent.jsonl"), readSignals: oneSignal("CTL-100") });
+    expect(db.query("SELECT verdict FROM obs_verdict").get().verdict).toBe("fail");
+    db.close();
+  });
+
+  test("low risk, no high finding → verdict 'pass'", () => {
+    const orchDir = scratch();
+    const db = openBeliefsDb({ path: join(scratch(), "b.db") });
+    writeVerify(orchDir, "CTL-100", { regression_risk: 2, findings: [{ severity: "low" }] });
+    collect(db, { orchDir, eventLogPath: join(scratch(), "absent.jsonl"), readSignals: oneSignal("CTL-100") });
+    expect(db.query("SELECT verdict FROM obs_verdict").get().verdict).toBe("pass");
+    db.close();
+  });
+
+  test("missing verify.json → NO obs_verdict row (null verdict contract)", () => {
+    const orchDir = scratch();
+    const db = openBeliefsDb({ path: join(scratch(), "b.db") });
+    // no verify.json written
+    collect(db, { orchDir, eventLogPath: join(scratch(), "absent.jsonl"), readSignals: oneSignal("CTL-100") });
+    expect(db.query("SELECT COUNT(*) AS n FROM obs_verdict").get().n).toBe(0);
+    db.close();
+  });
+
+  test("malformed verify.json (non-numeric risk) → NO row", () => {
+    const orchDir = scratch();
+    const db = openBeliefsDb({ path: join(scratch(), "b.db") });
+    writeVerify(orchDir, "CTL-100", { regression_risk: "high", findings: [] });
+    collect(db, { orchDir, eventLogPath: join(scratch(), "absent.jsonl"), readSignals: oneSignal("CTL-100") });
+    expect(db.query("SELECT COUNT(*) AS n FROM obs_verdict").get().n).toBe(0);
+    db.close();
+  });
+});
+
+describe("obs_cycle — collection via countRemediateCycles (CTL-966)", () => {
+  test("counts phase.remediate.complete.<ticket> events from the event log", () => {
+    const orchDir = scratch();
+    const db = openBeliefsDb({ path: join(scratch(), "b.db") });
+    const elog = join(scratch(), "events.jsonl");
+    // CTL-100 has 2 completed remediate cycles
+    writeEventLog(elog, ["CTL-100", "CTL-100"]);
+    collect(db, { orchDir, eventLogPath: elog, readSignals: oneSignal("CTL-100") });
+    expect(db.query("SELECT ticket, remediate_count FROM obs_cycle").get()).toEqual({
+      ticket: "CTL-100",
+      remediate_count: 2,
+    });
+    db.close();
+  });
+
+  test("never-remediated ticket → remediate_count 0 (exact cap-boundary comparison)", () => {
+    const orchDir = scratch();
+    const db = openBeliefsDb({ path: join(scratch(), "b.db") });
+    const elog = join(scratch(), "events.jsonl");
+    writeEventLog(elog, []); // empty log
+    collect(db, { orchDir, eventLogPath: elog, readSignals: oneSignal("CTL-100") });
+    expect(db.query("SELECT remediate_count FROM obs_cycle").get().remediate_count).toBe(0);
+    db.close();
+  });
+
+  test("exact suffix match: CTL-9 events do not count toward CTL-90", () => {
+    const orchDir = scratch();
+    const db = openBeliefsDb({ path: join(scratch(), "b.db") });
+    const elog = join(scratch(), "events.jsonl");
+    writeEventLog(elog, ["CTL-9", "CTL-9", "CTL-90"]);
+    collect(db, { orchDir, eventLogPath: elog, readSignals: oneSignal("CTL-90") });
+    expect(db.query("SELECT remediate_count FROM obs_cycle WHERE ticket='CTL-90'").get().remediate_count).toBe(1);
+    db.close();
+  });
+});
+
+describe("obs_verdict / obs_cycle — 14-day retention prune (CTL-966)", () => {
+  test("rows older than 14 days are pruned", () => {
+    const orchDir = scratch();
+    const db = openBeliefsDb({ path: join(scratch(), "b.db") });
+    const elog = join(scratch(), "events.jsonl");
+    writeEventLog(elog, ["CTL-100"]);
+    writeVerify(orchDir, "CTL-100", { regression_risk: 7, findings: [] });
+
+    // tick 1 — old (now = NOW - 15 days). prune runs on the first tick after boot.
+    collectTickFacts({
+      db,
+      orchDir,
+      now: NOW - 15 * DAY,
+      host: "mini",
+      env: { CATALYST_BELIEFS_SHADOW: "1" },
+      eventLogPath: elog,
+      pruneEveryTicks: 1,
+      getAgents: () => [],
+      readSignals: oneSignal("CTL-100"),
+      readJobState: () => ({ exists: false }),
+      findTranscriptFn: () => null,
+      linearCache: { get: () => undefined },
+    });
+    expect(db.query("SELECT COUNT(*) AS n FROM obs_verdict").get().n).toBe(1);
+    expect(db.query("SELECT COUNT(*) AS n FROM obs_cycle").get().n).toBe(1);
+
+    // tick 2 — current; prune removes the >14d-old rows from tick 1.
+    collectTickFacts({
+      db,
+      orchDir,
+      now: NOW,
+      host: "mini",
+      env: { CATALYST_BELIEFS_SHADOW: "1" },
+      eventLogPath: join(scratch(), "absent.jsonl"),
+      pruneEveryTicks: 1,
+      getAgents: () => [],
+      readSignals: () => [], // no signals this tick → no NEW verdict/cycle rows
+      readJobState: () => ({ exists: false }),
+      findTranscriptFn: () => null,
+      linearCache: { get: () => undefined },
+    });
+    // the old rows are gone; no new ones added this tick
+    expect(db.query("SELECT COUNT(*) AS n FROM obs_verdict").get().n).toBe(0);
+    expect(db.query("SELECT COUNT(*) AS n FROM obs_cycle").get().n).toBe(0);
+    db.close();
+  });
+});

--- a/plugins/dev/scripts/execution-core/beliefs/collector.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/collector.mjs
@@ -50,6 +50,11 @@ import { getAgentsCached } from "../claude-agents.mjs";
 import { readAllPhaseSignals } from "../signal-reader.mjs";
 import { findTranscript, defaultProjectsDir } from "../session-recency.mjs";
 import { getEventLogPath, getHostName, log } from "../config.mjs";
+// CTL-966: the SAME procedural readers the scheduler's deriveAdvancement reads,
+// captured as facts (obs_verdict / obs_cycle) so the advance_to belief can mirror
+// the oracle with zero new I/O semantics — derive-only, no actuation.
+import { readVerifyVerdict } from "../work-done-probes.mjs";
+import { countRemediateCycles } from "../event-scan.mjs";
 
 const DAY_MS = 86_400_000;
 const OBS_RETENTION_MS = 14 * DAY_MS; // obs_* + tick
@@ -246,7 +251,16 @@ function pruneRetention(db, now) {
   db.run("DELETE FROM intent WHERE tick_id IN (SELECT tick_id FROM tick WHERE now_ms < ?)", [
     beliefCutoff,
   ]);
-  for (const t of ["obs_agent", "obs_job", "obs_signal", "obs_transcript", "obs_linear", "obs_relation"]) {
+  for (const t of [
+    "obs_agent",
+    "obs_job",
+    "obs_signal",
+    "obs_transcript",
+    "obs_linear",
+    "obs_relation",
+    "obs_verdict",
+    "obs_cycle",
+  ]) {
     db.run(`DELETE FROM ${t} WHERE tick_id IN (SELECT tick_id FROM tick WHERE now_ms < ?)`, [
       obsCutoff,
     ]);
@@ -524,6 +538,57 @@ export function collectTickFacts({
             fail("relations", err);
           }
         }
+      }
+
+      // ── obs_verdict — the verify verdict per in-flight ticket (CTL-966) ──
+      // Parsed from workers/<T>/verify.json by the SAME readVerifyVerdict the
+      // scheduler's deriveAdvancement consumes. null/absent verdict → NO ROW
+      // (the absent-is-distinct-from-pass contract is preserved: a missing row
+      // means the advance_to rule sees no verdict and falls through to the
+      // normal verify → review edge, exactly as the oracle does). One row per
+      // distinct ticket. Per-source try/catch; orchDir absent → skipped.
+      try {
+        if (orchDir) {
+          const insV = db.prepare(
+            "INSERT INTO obs_verdict (tick_id, ticket, verdict) VALUES (?, ?, ?)",
+          );
+          const seenV = new Set();
+          for (const s of signals) {
+            if (!s?.ticket || seenV.has(s.ticket)) continue;
+            seenV.add(s.ticket);
+            const verdict = readVerifyVerdict({ ticket: s.ticket, orchDir });
+            if (verdict == null) continue; // null/absent → no row (oracle contract)
+            insV.run(tickId, String(s.ticket), String(verdict));
+          }
+        }
+      } catch (err) {
+        fail("verdict", err);
+      }
+
+      // ── obs_cycle — the event-counted remediate-cycle count (CTL-966) ────
+      // Captured via the SAME countRemediateCycles the scheduler's router uses
+      // (phase.remediate.complete.<ticket> envelopes off the unified event log).
+      // Rides the event-scan module's incremental cursor — no new disk scan
+      // beyond the heartbeat tail the collector already drives. One row per
+      // distinct ticket; a never-remediated ticket records remediate_count=0 so
+      // the cap-boundary comparison (count < cap) is exact. eventLogPath absent
+      // → countRemediateCycles falls back to getEventLogPath() (same default the
+      // scheduler uses). Per-source try/catch.
+      try {
+        const insC = db.prepare(
+          "INSERT INTO obs_cycle (tick_id, ticket, remediate_count) VALUES (?, ?, ?)",
+        );
+        const seenC = new Set();
+        for (const s of signals) {
+          if (!s?.ticket || seenC.has(s.ticket)) continue;
+          seenC.add(s.ticket);
+          const count = eventLogPath
+            ? countRemediateCycles({ ticket: s.ticket, path: eventLogPath })
+            : countRemediateCycles({ ticket: s.ticket });
+          insC.run(tickId, String(s.ticket), Number.isInteger(count) ? count : 0);
+        }
+      } catch (err) {
+        fail("cycle", err);
       }
 
       // ── derive beliefs (CTL-934) — run all four strata over this tick's

--- a/plugins/dev/scripts/execution-core/beliefs/rules.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/rules.mjs
@@ -17,6 +17,9 @@
 //   S4 escalation ladder             R10 R11 R12   (negation over intent)
 //   S5 recursive dependency beliefs  R13 R14 R15   (read obs_relation + obs_linear
 //                                                   EDB only; intra-stratum reads)
+//   S6 FSM advancement prediction    R16 R17       (read obs_signal + obs_verdict
+//                                                   + obs_cycle EDB + FSM maps;
+//                                                   derive-only — see CTL-966)
 //
 // No recursion crosses a negation. Each stratum's statements read only the
 // strata strictly below it (and the obs_* EDB), so when an S2 rule's NOT EXISTS
@@ -49,11 +52,27 @@
 //   b belief   t tick   i intent
 //   s obs_signal   a obs_agent   j obs_job   r obs_transcript
 //   h obs_heartbeat   l obs_linear   x obs_relation   (x = CTL-965 S5 dep rules)
+//   v obs_verdict   c obs_cycle   (CTL-966 S6 advancement rules)
 // json_array values become these tagged TEXT tokens; why.mjs maps prefix→table.
 //
 // Subject convention:
 //   per-phase beliefs   →  ticket || '/' || phase     (e.g. 'CTL-722/plan')
 //   capacity beliefs    →  'host:' || host            (e.g. 'host:mini')
+//   advancement beliefs →  ticket                     (e.g. 'CTL-722')   (CTL-966)
+
+// CTL-966: the FSM phase-rank + next-phase map + terminal set are imported from
+// phase-fsm.mjs (which derives them from lib/workflow.default.json) so the S6
+// advancement rules share the SINGLE source of truth with deriveAdvancement —
+// never a divergent hardcoded ordering. The maps are compiled to inline SQL
+// VALUES/CASE JOINs below (advance-rules-fsm-drift.test.mjs pins them byte-equal
+// to the live FSM so a descriptor edit can't silently desync the belief).
+import {
+  PHASES,
+  NEXT_PHASE,
+  REMEDIATE_PHASE,
+  REMEDIATE_CYCLE_CAP,
+  TERMINAL_SUCCESS,
+} from "../../lib/phase-fsm.mjs";
 
 // ── Stratum 1: ground correlations ──────────────────────────────────────────
 
@@ -528,6 +547,186 @@ WHERE t.tick_id = :tick
        AND r.relation_type = 'blocks'
        AND r.target_ticket = la.ticket)`;
 
+// ── Stratum 6: FSM advancement prediction (CTL-966) ──────────────────────────
+//
+// DERIVE-ONLY DOCTRINE (the entire point of CTL-966): advance_to is a PREDICTION
+// — the phase the procedural deriveAdvancement WOULD dispatch next. It NEVER
+// dispatches, deletes a signal, resets the verify⇄remediate cycle, or writes
+// Linear. The cycle RESET (maybeResetForRemediateCycle) and the actual dispatch
+// stay PROCEDURAL. The shadow comparator (scheduler.mjs runTick) computes the
+// real oracle and logs any disagreement; it acts on nothing.
+//
+// MIRROR CONTRACT (advance_to ≡ deriveAdvancement, zero disagreement):
+//   1. latest = the obs_signal phase with the highest FSM rank for the ticket,
+//      regardless of status (deriveAdvancement: `for (p of PHASES) if (p in sig)
+//      latest = p`). remediate ∉ PHASES so it is invisible to `latest`, exactly
+//      as the oracle's loop skips it.
+//   2. advance-eligible iff latest's status='done' OR (status='skipped' AND
+//      latest='monitor-deploy') — the CTL-703 carve-out.
+//   3. verify→remediate detour: latest='verify' AND obs_verdict='fail' →
+//        remediate_count >= cap  → NO advance (cycle_exhausted owns the stall)
+//        a remediate obs_signal already exists → NO advance (dispatched this cycle)
+//        else → advance_to = remediate
+//   4. otherwise next = NEXT_PHASE[latest]; fire iff next is non-terminal AND no
+//      obs_signal exists for (ticket, next).
+//
+// This stratum reads obs_signal + obs_verdict + obs_cycle EDB + the FSM maps
+// only. It performs NO negation over any belief (the `next.phase in sig` / latest
+// selection are over the EDB), so there is no negation cycle and it sits safely
+// below S1–S5 (no lower stratum references advance_to/cycle_exhausted). Subject =
+// ticket (not ticket/phase): advancement is a per-ticket prediction.
+//
+// SINGLE SOURCE OF TRUTH: the phase-rank, next-phase, and terminal maps below are
+// COMPILED from phase-fsm.mjs's PHASES / NEXT_PHASE / TERMINAL_SUCCESS at module
+// load — never a divergent literal. advance-rules-fsm-drift.test.mjs pins them
+// byte-equal to the live FSM.
+//
+// Provenance: source_fact_ids cite the latest obs_signal (tag 's'), the verdict
+// fact ('v'), and the cycle fact ('c'). why.mjs resolves 'v'→obs_verdict,
+// 'c'→obs_cycle (added there alongside CTL-965's 'x').
+
+// fsmRankValues — `(phase, rank)` VALUES rows for the FSM-rank map (0-based
+// PHASES index). remediate is intentionally OMITTED: deriveAdvancement's
+// `latest` loop ranges over PHASES only, so a remediate signal must never be
+// picked as `latest` (the rank JOIN simply does not match it).
+const fsmRankValues = PHASES.map((p, i) => `('${p}', ${i})`).join(", ");
+
+// nextPhaseValues — `(cur, next)` VALUES rows for NEXT_PHASE. The terminal step
+// (teardown) maps to TERMINAL_SUCCESS ('done'); the terminal-set check below
+// suppresses the advance when next === TERMINAL_SUCCESS.
+const nextPhaseValues = PHASES.map((p) => `('${p}', '${NEXT_PHASE[p]}')`).join(", ");
+
+// R16 advance_to — the predicted next phase per in-flight ticket. Mirrors
+// deriveAdvancement EXACTLY (see MIRROR CONTRACT above). Two arms UNION'd:
+//   arm A — verify→remediate detour (latest=verify, verdict=fail, budget left,
+//            no remediate signal yet) → to='remediate'.
+//   arm B — the normal FSM edge (latest=done/skipped-carveout, next non-terminal,
+//            successor not yet dispatched) → to=NEXT_PHASE[latest].
+// The arms are mutually exclusive by construction: arm A requires latest=verify
+// AND verdict=fail; arm B's WHERE excludes (latest=verify AND verdict=fail) so a
+// fail-at-verify ticket NEVER takes the normal verify→review edge (the oracle's
+// `if (latest==='verify' && verdict==='fail') return …` short-circuits before the
+// transition()). UNIQUE(tick,name,subject) guarantees one row per ticket.
+const R16_advance_to = `
+INSERT OR IGNORE INTO belief (tick_id, stratum, name, subject, value, rule_id, source_fact_ids)
+WITH
+  rank(phase, r) AS (VALUES ${fsmRankValues}),
+  nxt(cur, nextp) AS (VALUES ${nextPhaseValues}),
+  -- latest(ticket) = the max-FSM-rank phase present in obs_signal this tick.
+  -- remediate is excluded by the rank JOIN (no rank row), matching the oracle's
+  -- PHASES-only latest-selection loop.
+  latest(tick_id, ticket, phase, r) AS (
+    SELECT s.tick_id, s.ticket, s.phase, rk.r
+      FROM obs_signal s
+      JOIN rank rk ON rk.phase = s.phase
+     WHERE s.tick_id = :tick
+       AND rk.r = (SELECT MAX(rk2.r)
+                     FROM obs_signal s2
+                     JOIN rank rk2 ON rk2.phase = s2.phase
+                    WHERE s2.tick_id = s.tick_id AND s2.ticket = s.ticket)
+  ),
+  -- the latest row joined to its signal (for status + provenance) and the verdict
+  -- + cycle facts. There can be >1 obs_signal row for the latest phase only if a
+  -- producer wrote duplicates; the MIN(fact_id) picks one deterministically and
+  -- status is read from that same row.
+  latest_sig(tick_id, ticket, phase, status, sig_fact_id) AS (
+    SELECT l.tick_id, l.ticket, l.phase, s.status, MIN(s.fact_id)
+      FROM latest l
+      JOIN obs_signal s ON s.tick_id = l.tick_id AND s.ticket = l.ticket AND s.phase = l.phase
+     GROUP BY l.tick_id, l.ticket, l.phase, s.status
+  )
+-- arm A: verify→remediate detour
+SELECT ls.tick_id, 6, 'advance_to', ls.ticket,
+       json_object('from', ls.phase, 'to', '${REMEDIATE_PHASE}'),
+       'R16',
+       json_array('s' || ls.sig_fact_id,
+                  (SELECT 'v' || v.fact_id FROM obs_verdict v
+                     WHERE v.tick_id = ls.tick_id AND v.ticket = ls.ticket LIMIT 1),
+                  (SELECT 'c' || c.fact_id FROM obs_cycle c
+                     WHERE c.tick_id = ls.tick_id AND c.ticket = ls.ticket LIMIT 1))
+  FROM latest_sig ls
+ WHERE ls.tick_id = :tick
+   AND ls.phase = 'verify'
+   AND ls.status = 'done'
+   AND EXISTS (SELECT 1 FROM obs_verdict v
+                WHERE v.tick_id = ls.tick_id AND v.ticket = ls.ticket AND v.verdict = 'fail')
+   -- budget left: remediate_count < cap (count==cap-1 advances; count==cap does not)
+   AND COALESCE((SELECT c.remediate_count FROM obs_cycle c
+                  WHERE c.tick_id = ls.tick_id AND c.ticket = ls.ticket LIMIT 1), 0) < ${REMEDIATE_CYCLE_CAP}
+   -- remediate not already dispatched this cycle (no remediate signal present)
+   AND NOT EXISTS (SELECT 1 FROM obs_signal s
+                    WHERE s.tick_id = ls.tick_id AND s.ticket = ls.ticket AND s.phase = '${REMEDIATE_PHASE}')
+UNION ALL
+-- arm B: normal FSM edge
+SELECT ls.tick_id, 6, 'advance_to', ls.ticket,
+       json_object('from', ls.phase, 'to', n.nextp),
+       'R16',
+       json_array('s' || ls.sig_fact_id)
+  FROM latest_sig ls
+  JOIN nxt n ON n.cur = ls.phase
+ WHERE ls.tick_id = :tick
+   -- advance-eligible: done, OR monitor-deploy skipped (CTL-703 carve-out)
+   AND ( ls.status = 'done'
+      OR (ls.status = 'skipped' AND ls.phase = 'monitor-deploy') )
+   -- NOT the verify→remediate detour (arm A owns it): a verify ticket with a
+   -- fail verdict short-circuits in the oracle and never takes verify→review.
+   AND NOT ( ls.phase = 'verify'
+             AND EXISTS (SELECT 1 FROM obs_verdict v
+                          WHERE v.tick_id = ls.tick_id AND v.ticket = ls.ticket AND v.verdict = 'fail') )
+   -- next non-terminal (teardown→done suppresses the advance off teardown)
+   AND n.nextp <> '${TERMINAL_SUCCESS}'
+   -- successor not already dispatched
+   AND NOT EXISTS (SELECT 1 FROM obs_signal s
+                    WHERE s.tick_id = ls.tick_id AND s.ticket = ls.ticket AND s.phase = n.nextp)`;
+
+// R17 cycle_exhausted — the remediate-cycle cap is reached: latest=verify done,
+// verdict=fail, remediate_count >= cap. Mirrors maybeEscalateRemediateExhausted's
+// trigger (signals.verify==='done' && verdict==='fail' && cycleCount >= cap) as a
+// DERIVE-ONLY belief — it does NOT write the stalled signal or apply needs-human;
+// it records the conclusion with provenance. (deriveAdvancement returns null here
+// — no advance_to fires, since arm A's budget guard fails and arm B is excluded
+// by the verify+fail detour predicate. cycle_exhausted is the separate signal that
+// the ticket has run out of remediation budget.) Subject = ticket.
+const R17_cycle_exhausted = `
+INSERT OR IGNORE INTO belief (tick_id, stratum, name, subject, value, rule_id, source_fact_ids)
+WITH
+  rank(phase, r) AS (VALUES ${fsmRankValues}),
+  latest(tick_id, ticket, phase, r) AS (
+    SELECT s.tick_id, s.ticket, s.phase, rk.r
+      FROM obs_signal s
+      JOIN rank rk ON rk.phase = s.phase
+     WHERE s.tick_id = :tick
+       AND rk.r = (SELECT MAX(rk2.r)
+                     FROM obs_signal s2
+                     JOIN rank rk2 ON rk2.phase = s2.phase
+                    WHERE s2.tick_id = s.tick_id AND s2.ticket = s.ticket)
+  ),
+  latest_sig(tick_id, ticket, phase, status, sig_fact_id) AS (
+    SELECT l.tick_id, l.ticket, l.phase, s.status, MIN(s.fact_id)
+      FROM latest l
+      JOIN obs_signal s ON s.tick_id = l.tick_id AND s.ticket = l.ticket AND s.phase = l.phase
+     GROUP BY l.tick_id, l.ticket, l.phase, s.status
+  )
+SELECT ls.tick_id, 6, 'cycle_exhausted', ls.ticket,
+       json_object('phase', ls.phase, 'remediate_count',
+         COALESCE((SELECT c.remediate_count FROM obs_cycle c
+                    WHERE c.tick_id = ls.tick_id AND c.ticket = ls.ticket LIMIT 1), 0),
+         'cap', ${REMEDIATE_CYCLE_CAP}),
+       'R17',
+       json_array('s' || ls.sig_fact_id,
+                  (SELECT 'v' || v.fact_id FROM obs_verdict v
+                     WHERE v.tick_id = ls.tick_id AND v.ticket = ls.ticket LIMIT 1),
+                  (SELECT 'c' || c.fact_id FROM obs_cycle c
+                     WHERE c.tick_id = ls.tick_id AND c.ticket = ls.ticket LIMIT 1))
+  FROM latest_sig ls
+ WHERE ls.tick_id = :tick
+   AND ls.phase = 'verify'
+   AND ls.status = 'done'
+   AND EXISTS (SELECT 1 FROM obs_verdict v
+                WHERE v.tick_id = ls.tick_id AND v.ticket = ls.ticket AND v.verdict = 'fail')
+   AND COALESCE((SELECT c.remediate_count FROM obs_cycle c
+                  WHERE c.tick_id = ls.tick_id AND c.ticket = ls.ticket LIMIT 1), 0) >= ${REMEDIATE_CYCLE_CAP}`;
+
 // STRATA — the run order. Each inner array is one stratum; statements within a
 // stratum run in array order (R6 after R5; R10b after R10a) so same-stratum
 // negation sees the complete lower set. The tick loop runs strata in order
@@ -562,6 +761,14 @@ export const STRATA = [
     ["R13", R13_blocker_rank],
     ["R14", R14_cycle_detected],
     ["R15", R15_ready],
+  ],
+  // S6 FSM advancement prediction (CTL-966) — reads obs_signal + obs_verdict +
+  // obs_cycle EDB + the FSM maps only; no negation over any belief, independent
+  // of liveness (S1–S5 never reference advance_to/cycle_exhausted), so no
+  // negation cycle. DERIVE-ONLY: a prediction, never a dispatch/reset/Linear write.
+  [
+    ["R16", R16_advance_to],
+    ["R17", R17_cycle_exhausted],
   ],
 ];
 

--- a/plugins/dev/scripts/execution-core/beliefs/rules.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/rules.mjs
@@ -679,6 +679,10 @@ SELECT ls.tick_id, 6, 'advance_to', ls.ticket,
    AND NOT EXISTS (SELECT 1 FROM obs_signal s
                     WHERE s.tick_id = ls.tick_id AND s.ticket = ls.ticket AND s.phase = n.nextp)`;
 
+// Exported for the FSM-drift guard (advance-rules.test.mjs): asserts the compiled
+// rank/next-phase maps stay byte-equal to the live phase-fsm.mjs declarations.
+export const R16_advance_to_SQL_FOR_TEST = R16_advance_to;
+
 // R17 cycle_exhausted — the remediate-cycle cap is reached: latest=verify done,
 // verdict=fail, remediate_count >= cap. Mirrors maybeEscalateRemediateExhausted's
 // trigger (signals.verify==='done' && verdict==='fail' && cycleCount >= cap) as a

--- a/plugins/dev/scripts/execution-core/beliefs/schema.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/schema.mjs
@@ -106,6 +106,28 @@ const DDL = [
     target_ticket  TEXT NOT NULL,
     relation_type  TEXT NOT NULL
   )`,
+  // CTL-966: the verify verdict the advancement router branches on, parsed from
+  // workers/<T>/verify.json exactly as work-done-probes.mjs readVerifyVerdict
+  // does (regression_risk >= 5 OR any severity:"high" finding → "fail", else
+  // "pass"; null/absent verdict = NO ROW). The verify→remediate detour predicate,
+  // captured as a fact so the advance_to belief can mirror deriveAdvancement
+  // without a second disk read at rule-evaluation time.
+  `CREATE TABLE IF NOT EXISTS obs_verdict (
+    fact_id     INTEGER PRIMARY KEY AUTOINCREMENT,
+    tick_id     INTEGER NOT NULL REFERENCES tick(tick_id),
+    ticket      TEXT NOT NULL,
+    verdict     TEXT
+  )`,
+  // CTL-966: the event-counted remediate-cycle count the procedural
+  // countRemediateCycles derives (phase.remediate.complete.<ticket> envelopes).
+  // Captured as a fact so advance_to / cycle_exhausted can compare against the
+  // REMEDIATE_CYCLE_CAP exactly as deriveAdvancement / maybeEscalateRemediateExhausted do.
+  `CREATE TABLE IF NOT EXISTS obs_cycle (
+    fact_id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    tick_id          INTEGER NOT NULL REFERENCES tick(tick_id),
+    ticket           TEXT NOT NULL,
+    remediate_count  INTEGER NOT NULL
+  )`,
   // Static-ish facts the rules need.
   `CREATE TABLE IF NOT EXISTS cfg (key TEXT PRIMARY KEY, value_int INTEGER, value_text TEXT)`,
   // IDB: every derived belief, uniform shape, provenance MANDATORY.
@@ -140,6 +162,8 @@ const DDL = [
   `CREATE INDEX IF NOT EXISTS idx_obs_linear_tick ON obs_linear (tick_id)`,
   `CREATE INDEX IF NOT EXISTS idx_obs_relation_tick ON obs_relation (tick_id)`,
   `CREATE INDEX IF NOT EXISTS idx_obs_relation_source ON obs_relation (source_ticket)`,
+  `CREATE INDEX IF NOT EXISTS idx_obs_verdict_tick ON obs_verdict (tick_id)`,
+  `CREATE INDEX IF NOT EXISTS idx_obs_cycle_tick ON obs_cycle (tick_id)`,
   `CREATE INDEX IF NOT EXISTS idx_obs_heartbeat_ts ON obs_heartbeat (ts_ms)`,
   `CREATE INDEX IF NOT EXISTS idx_intent_tick ON intent (tick_id)`,
 ];

--- a/plugins/dev/scripts/execution-core/beliefs/why.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/why.mjs
@@ -39,7 +39,8 @@ export function traceTicket(db, ticket, { tickId: explicitTick } = {}) {
   // The §5 recursive CTE: start from the ticket's beliefs at this tick, walk
   // source_fact_ids transitively to reach every belief in the chain. Refs are
   // TAGGED (rules.mjs): 'b<id>' belief, 't<id>' tick, 'i<id>' intent, and the
-  // obs_* fact tags (s/a/j/r/h/l, plus 'x' obs_relation from CTL-965) — so the
+  // obs_* fact tags (s/a/j/r/h/l, 'x' obs_relation from CTL-965, plus 'v'
+  // obs_verdict + 'c' obs_cycle from CTL-966) — so the
   // belief edges are exactly the 'b'-prefixed refs (no integer-space collision).
   // Facts are leaves resolved per-table below.
   const beliefRows = db
@@ -126,6 +127,18 @@ export function traceTicket(db, ticket, { tickId: explicitTick } = {}) {
         r.relation_type === "blocks"
           ? `relation ${r.target_ticket} depends_on ${r.source_ticket} (${r.source_ticket} blocks ${r.target_ticket})`
           : `relation ${r.source_ticket} ${r.relation_type} ${r.target_ticket}`,
+    },
+    // CTL-966 — obs_verdict: the verify verdict the advance_to detour branches on.
+    v: {
+      table: "obs_verdict",
+      sql: "SELECT fact_id AS id, ticket, verdict FROM obs_verdict WHERE fact_id = ?",
+      summary: (r) => `verdict ${r.ticket} verdict=${r.verdict}`,
+    },
+    // CTL-966 — obs_cycle: the event-counted remediate-cycle count vs the cap.
+    c: {
+      table: "obs_cycle",
+      sql: "SELECT fact_id AS id, ticket, remediate_count FROM obs_cycle WHERE fact_id = ?",
+      summary: (r) => `cycle ${r.ticket} remediate_count=${r.remediate_count}`,
     },
   };
 

--- a/plugins/dev/scripts/execution-core/beliefs/why.test.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/why.test.mjs
@@ -172,3 +172,46 @@ describe("renderTrace / main — human-readable output (the Gherkin trace)", () 
     db.close();
   });
 });
+
+// CTL-966: the advance_to remediate-arm belief traces down to its obs_verdict
+// ('v') + obs_cycle ('c') facts — proving the new REF TAGGING resolvers render.
+describe("traceTicket — CTL-966 advance_to provenance (obs_verdict / obs_cycle)", () => {
+  function seedRemediateArm(dbPath) {
+    const db = openBeliefsDb({ path: dbPath });
+    db.run("INSERT INTO tick (now_ms, host) VALUES (?, 'mini')", [NOW]);
+    const t = db.query("SELECT last_insert_rowid() AS id").get().id;
+    for (const [p, s] of Object.entries({
+      triage: "done",
+      research: "done",
+      plan: "done",
+      implement: "done",
+      verify: "done",
+    })) {
+      db.run("INSERT INTO obs_signal (tick_id, ticket, phase, status) VALUES (?, 'CTL-966', ?, ?)", [t, p, s]);
+    }
+    db.run("INSERT INTO obs_verdict (tick_id, ticket, verdict) VALUES (?, 'CTL-966', 'fail')", [t]);
+    db.run("INSERT INTO obs_cycle (tick_id, ticket, remediate_count) VALUES (?, 'CTL-966', 0)", [t]);
+    // import-free belief eval via the rule module:
+    return { db, t };
+  }
+
+  test("advance_to(remediate) trace renders verdict + cycle facts", async () => {
+    const { evaluateBeliefs } = await import("./rules.mjs");
+    const { db, t } = seedRemediateArm(join(scratch(), "b.db"));
+    evaluateBeliefs(db, t);
+
+    const trace = traceTicket(db, "CTL-966", { tickId: t });
+    const adv = trace.beliefs.find((b) => b.name === "advance_to");
+    expect(adv).toBeTruthy();
+    expect(JSON.parse(adv.value)).toEqual({ from: "verify", to: "remediate" });
+    const tables = adv.sources.map((s) => s.table);
+    expect(tables).toContain("obs_verdict");
+    expect(tables).toContain("obs_cycle");
+
+    const text = renderTrace(trace);
+    expect(text).toContain("advance_to(CTL-966)");
+    expect(text).toContain("verdict CTL-966 verdict=fail");
+    expect(text).toContain("cycle CTL-966 remediate_count=0");
+    db.close();
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -73,6 +73,11 @@ import { readWorkerSignals } from "./signal-reader.mjs";
 // CTL-933: shadow belief-store fact collector (opt-in CATALYST_BELIEFS_SHADOW=1).
 // CTL-937: getBeliefsDb exposes the module-level db handle for the diagnostician.
 import { collectBeliefsTick, getBeliefsDb } from "./beliefs/collector.mjs";
+// CTL-966 + CTL-935: the advancement shadow comparator — compares the procedural
+// deriveAdvancement oracle against the advance_to / cycle_exhausted beliefs and
+// logs disagreements. SHADOW ONLY (reads beliefs + computes oracle + logs; never
+// dispatches/writes a signal/writes Linear).
+import { runAdvanceShadow } from "./beliefs/advance-shadow.mjs";
 // CTL-937: bounded stall-diagnostician wake wiring (opt-in CATALYST_DIAGNOSTICIAN=1).
 import { processDiagnosticianWakes } from "./diagnostician.mjs";
 import { executeEscalations } from "./beliefs/escalate.mjs";
@@ -3530,6 +3535,38 @@ function runTick() {
       } catch (escErr) {
         try {
           log.warn({ err: escErr?.message }, "escalate: executor threw (tick unaffected)");
+        } catch {
+          /* even logging must not break the tick */
+        }
+      }
+
+      // CTL-966 + CTL-935: advancement shadow comparator. For each in-flight
+      // ticket compute the PROCEDURAL deriveAdvancement and compare it to the
+      // DERIVE-ONLY advance_to / cycle_exhausted beliefs for this tick; log any
+      // disagreement as a `beliefs.advance_shadow.disagree` operator event.
+      // SHADOW ONLY — never dispatches, never writes a signal, never writes
+      // Linear, never resets the cycle. Wrapped in its own guard so it can never
+      // break the tick. Reads the SAME shared beliefs.db handle (no second open)
+      // and the SAME procedural readers the advancement sweep below consumes.
+      try {
+        const advDb = getBeliefsDb();
+        if (advDb) {
+          runAdvanceShadow(advDb, beliefsRes.tickId, {
+            orchDir: runningOpts.orchDir,
+            listInFlight: (od) => listInFlightTickets(od),
+            readSignals: (od, ticket) => readPhaseSignals(od, ticket),
+            readVerdict: ({ ticket, orchDir }) => readVerifyVerdict({ ticket, orchDir }),
+            countCycles: ({ ticket }) => countRemediateCycles({ ticket }),
+            deriveAdvancement,
+            cap: REMEDIATE_CYCLE_CAP,
+            appendEvent: intentEventAppender,
+            // Opt-in tick summary; off by default to keep the event log lean.
+            emitTickSummary: (process.env.CATALYST_ADVANCE_SHADOW_SUMMARY ?? "0") === "1",
+          });
+        }
+      } catch (advErr) {
+        try {
+          log.warn({ err: advErr?.message }, "advance-shadow: comparator threw (tick unaffected)");
         } catch {
           /* even logging must not break the tick */
         }


### PR DESCRIPTION
## What changed (CTL-966)

Adds a **derive-only** belief-layer shadow comparator that predicts the next pipeline phase and surfaces a cap-exhaustion signal, then cross-checks the belief against the live procedural oracle (\`deriveAdvancement\`) every tick.

- **\`obs_verdict\` / \`obs_cycle\` facts** — collector now ingests verify verdict + remediate-cycle-count observations alongside the existing phase signals.
- **\`advance_to\` belief** — a PREDICTION of the next phase the FSM would advance to (triage→research→…→teardown→done; verify-fail→remediate within cap).
- **\`cycle_exhausted\` belief** — fires only at/above the remediate cap (CAP=3): count==CAP-1 still advances to remediate with no cycle_exhausted; count==CAP yields no advance_to + cycle_exhausted.
- **\`runAdvanceShadow\`** — invoked from \`scheduler.mjs\` inside \`runTick\`, BEFORE \`schedulerTick\` (the real dispatch). Its return value is discarded; it gates nothing. It reads the real \`deriveAdvancement\`, \`readPhaseSignals\`, \`readVerifyVerdict\`, \`countRemediateCycles\` on the same shared beliefs DB the collector populated this tick.
- **FSM-drift guard** — an R16 SQL rule embeds the live phase-fsm rank + next-phase VALUES so a future FSM edit that desyncs the belief layer trips a test.

## Derive-only confirmation (the entire point)

The \`advance_to\` belief is a **prediction / intent declaration** only. It NEVER dispatches, deletes a signal, or writes Linear. The remediate-cycle RESET (file deletes) and the actual dispatch remain PROCEDURAL in the scheduler. The shadow path's output is observational and discarded — it cannot actuate. STOP-TRIGGER was respected: no rule was made to cause the cycle-reset or perform any dispatch/Linear write.

## Agreement battery

\`bun test beliefs/\` → **214 pass / 0 fail / 775 expect() calls** across 11 files. The advance-rules suite cross-checks the belief \`to\` against the real \`deriveAdvancement(...)\` across ~20 cross-check tuples (triage→research, verify-fail at count 0/CAP-1/CAP/CAP+1, monitor-deploy skipped→teardown carve-out, terminal teardown→null, empty/running edge cases). Zero disagreement. The FSM-drift guard (R16) and cap-boundary block both pass.

## Follow-up (not in this PR)

The new \`beliefs/advance-rules.test.mjs\`, \`advance-shadow.test.mjs\`, \`collector-advance.test.mjs\` (and the pre-existing CTL-964/965 \`collector-relation.test.mjs\`, \`recursive-rules.test.mjs\`) are NOT yet in the \`.github/workflows/execution-core-tests.yml\` required gate. Adding them was attempted but the OAuth token lacks the \`workflow\` scope (remote rejected). An operator with a workflow-scoped token (or a non-workflow follow-up PR) should add these to the gate. The suites are all green locally via \`bun test beliefs/\`; this is a CI coverage-gap follow-up, not a correctness issue in the shadow path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)