### PR TITLE
feat(dev): nav proportion v3 — 16px icons, muted labels, twistie beside label, Projects heading (CTL-980)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar-nav-v3.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar-nav-v3.test.ts
@@ -1,0 +1,117 @@
+// app-sidebar-nav-v3.test.ts — structure smoke-tests for CTL-980 nav proportion v3.
+// Validates that the key presentation constants and class strings satisfy the spec:
+//   - Icon size must be size-4 (16px), NOT size-6 (24px)
+//   - Twistie must NOT use ml-auto (it should be ml-1, beside the label)
+//   - Inactive label muting: text-sidebar-foreground/60 (not near-white)
+//   - "Projects" section heading is referenced in the component source
+//
+// These are pure string-inspection tests against the component source — no DOM needed.
+// Run:  cd ui && bun test src/components/app-sidebar-nav-v3.test.ts
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dir, "app-sidebar.tsx"), "utf8");
+
+describe("CTL-980 nav proportion v3 — icon size", () => {
+  it("nav-item icon uses size-4 (16px), not size-6 (24px)", () => {
+    // The icon wrapper must explicitly set size-4 on the icon element.
+    expect(src).toContain("size-4");
+  });
+
+  it("does NOT use size-6 on any nav-item icon", () => {
+    // size-6 would be 24px — the oversized icon the ticket is fixing.
+    // The only size-6 usage allowed is in the CatalystLogo (brand header), not nav icons.
+    // We check that the renderOperateItem block does not reference size-6.
+    // (This is a coarse check; exact line-range checks are brittle.)
+    const renderBlock = src.slice(
+      src.indexOf("function renderOperateItem"),
+      src.indexOf("function groupContainsActive"),
+    );
+    expect(renderBlock).not.toContain("size-6");
+  });
+});
+
+describe("CTL-980 nav proportion v3 — twistie placement", () => {
+  // Extract ChevronRightIcon className attribute values (the actual class strings, not comments).
+  function chevronClassNames(block: string): string[] {
+    const re = /<ChevronRightIcon\s+className=\{cn\(\s*"([^"]+)"/g;
+    const re2 = /<ChevronRightIcon\s+className="([^"]+)"/g;
+    const results: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(block)) !== null) results.push(m[1]);
+    while ((m = re2.exec(block)) !== null) results.push(m[1]);
+    return results;
+  }
+
+  it("per-project group ChevronRightIcon className does NOT start with ml-auto", () => {
+    const projectBlock = src.slice(
+      src.indexOf("PER-PROJECT GROUPS"),
+      src.indexOf("OBSERVE — collapsible"),
+    );
+    const classes = chevronClassNames(projectBlock);
+    expect(classes.length).toBeGreaterThan(0);
+    for (const cls of classes) {
+      expect(cls).not.toMatch(/\bml-auto\b/);
+    }
+  });
+
+  it("per-project group ChevronRightIcon uses ml-1 (adjacent to label)", () => {
+    const projectBlock = src.slice(
+      src.indexOf("PER-PROJECT GROUPS"),
+      src.indexOf("OBSERVE — collapsible"),
+    );
+    const classes = chevronClassNames(projectBlock);
+    expect(classes.some((c) => c.includes("ml-1"))).toBe(true);
+  });
+
+  it("Observe section ChevronRightIcon className does NOT use ml-auto", () => {
+    const observeBlock = src.slice(
+      src.indexOf("OBSERVE — collapsible"),
+      src.indexOf("FOOTER"),
+    );
+    const classes = chevronClassNames(observeBlock);
+    expect(classes.length).toBeGreaterThan(0);
+    for (const cls of classes) {
+      expect(cls).not.toMatch(/\bml-auto\b/);
+    }
+  });
+
+  it("Observe section ChevronRightIcon uses ml-1", () => {
+    const observeBlock = src.slice(
+      src.indexOf("OBSERVE — collapsible"),
+      src.indexOf("FOOTER"),
+    );
+    const classes = chevronClassNames(observeBlock);
+    expect(classes.some((c) => c.includes("ml-1"))).toBe(true);
+  });
+});
+
+describe("CTL-980 nav proportion v3 — label muting", () => {
+  it("inactive nav-item label uses text-sidebar-foreground/60 (muted, not near-white)", () => {
+    // CTL-977 had near-white labels; CTL-980 mutes inactive labels to /60 opacity.
+    expect(src).toContain("text-sidebar-foreground/60");
+  });
+
+  it("active nav-item label uses text-sidebar-primary (full contrast)", () => {
+    // Active/selected items must be the high-contrast state.
+    expect(src).toContain("text-sidebar-primary");
+  });
+});
+
+describe("CTL-980 nav proportion v3 — Projects section heading", () => {
+  it("renders a 'Projects' section heading above the per-project groups", () => {
+    expect(src).toContain("Projects");
+  });
+
+  it("Projects heading appears before the per-project map block", () => {
+    const projectsHeadingIdx = src.indexOf(">Projects<");
+    const reposMapIdx = src.indexOf("{repos.map(");
+    expect(projectsHeadingIdx).toBeGreaterThan(-1);
+    expect(reposMapIdx).toBeGreaterThan(-1);
+    // Heading must come BEFORE the map (higher up in the source)
+    expect(projectsHeadingIdx).toBeLessThan(reposMapIdx);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
@@ -79,6 +79,8 @@ import {
 // CTL-960 — left-nav polish: project-group headers, consistent twistie, Overall label.
 // CTL-977 — left-nav restyle v2: natural-case headers, quieter labels, rebalanced icon/label,
 //            Linear-style selected state, twistie moved to right.
+// CTL-980 — nav proportion v3: icons 16px (size-4), muted inactive labels, icon color = label
+//            color via currentColor, twistie beside label (not far-right), "Projects" heading.
 
 /** A status dot overlaid on a nav icon (emerald = live, amber = anomaly). */
 function StatusDot({ kind }: { kind: "live" | "anomaly" }) {
@@ -111,11 +113,11 @@ const OPERATE_ITEMS: Array<{ surface: Surface; label: string; icon: typeof Inbox
 ];
 
 // CTL-977: Shared classes for collapsible group trigger rows.
-// Natural-case (no uppercase), quiet/muted color, twistie on the RIGHT.
-// The favicon and label sit on the left; the chevron is ml-auto on the right.
+// Natural-case (no uppercase), quiet/muted color.
+// CTL-980: twistie is placed BESIDE the label text (no ml-auto), favicon LEFT of label.
 const GROUP_TRIGGER_BASE = cn(
   "flex h-7 w-full shrink-0 items-center rounded-md px-2 outline-hidden",
-  // CTL-977: no uppercase — render names in their natural case.
+  // CTL-977/CTL-980: no uppercase — render names in their natural case; muted color.
   "text-[11px] font-medium text-sidebar-foreground/45",
   "transition-[margin,opacity,color] duration-200 ease-linear",
   "cursor-pointer hover:text-sidebar-foreground/70 focus-visible:ring-2 focus-visible:ring-sidebar-ring",
@@ -201,6 +203,9 @@ export function AppSidebar() {
   // monotony from four repeated blocks of identical Inbox/Tickets/Workers/Queue.
   // CTL-977: active item gets sidebar-primary (accent) color on icon + label text,
   // providing a clear Linear-style selected state beyond the bg fill.
+  // CTL-980: icon size forced to 16px (size-4) so it reads as ~same size as the 13px
+  // label (not 1.7× bigger). Icon color = currentColor so it inherits the label's
+  // muted-inactive / bright-active tone automatically. Inactive labels muted to /60.
   function renderOperateItem(
     item: (typeof OPERATE_ITEMS)[number],
     scopeVal: string,
@@ -216,17 +221,21 @@ export function AppSidebar() {
           tooltip={item.label}
           size={compact ? "sm" : "default"}
           onClick={() => go(item.surface, scopeVal)}
-          // CTL-977: active item gets accent (sidebar-primary) color treatment on
-          // icon + label so the selected state is unmistakable but quiet.
-          // Inactive icon is muted; label is full-contrast sidebar-foreground.
+          // CTL-980: inactive = muted label + icon (both text-sidebar-foreground/60);
+          // active/hover = full contrast (text-sidebar-primary). Icon inherits via
+          // currentColor — no separate [&>svg]: override needed when icon is inline.
           className={cn(
             active
-              ? "text-sidebar-primary [&>svg]:text-sidebar-primary"
-              : "[&>svg]:text-sidebar-foreground/55 hover:[&>svg]:text-sidebar-foreground/80",
+              ? "text-sidebar-primary"
+              : "text-sidebar-foreground/60 hover:text-sidebar-foreground",
           )}
         >
-          <span className="relative flex items-center justify-center">
-            <item.icon />
+          {/* CTL-980: explicit size-4 because the icon is inside a <span> wrapper
+              (for the status dot overlay), so the SidebarMenuButton's [&>svg]:size-4
+              selector does NOT reach the nested SVG. Force it here. Icon uses
+              currentColor — inherits the button's muted/active text color. */}
+          <span className="relative flex shrink-0 items-center justify-center">
+            <item.icon className="size-4 shrink-0" />
             {dot && scopeVal === "all" && <StatusDot kind={dot} />}
           </span>
           <span>{item.label}</span>
@@ -275,8 +284,17 @@ export function AppSidebar() {
         </SidebarGroup>
 
         {/* ── PER-PROJECT GROUPS: one collapsible per repo ────────────────── */}
-        {/* CTL-977: natural-case repo name, twistie moved to RIGHT (ml-auto),
-            favicon stays LEFT of the label, no uppercase transformation. */}
+        {/* CTL-980: "Projects" / "Your projects" section heading above the collapsible
+            project rows — mirrors Linear's "Your teams" parent section label. Only
+            render the heading when there is at least one project to show. */}
+        {repos.length > 0 && (
+          <SidebarGroup className="pt-0 pb-0">
+            <SidebarGroupLabel>Projects</SidebarGroupLabel>
+          </SidebarGroup>
+        )}
+        {/* CTL-977: natural-case repo name, favicon stays LEFT of the label.
+            CTL-980: twistie is now BESIDE the label (no ml-auto), placed right
+            after the label text with a small gap, so the row reads "adva ⌄". */}
         {repos.map((repo) => {
           // navGroups has the per-repo group; get its dotColor + iconDataUrl (CTL-961)
           const navGroup = navGroups.find((g) => g.scope === repo);
@@ -317,10 +335,11 @@ export function AppSidebar() {
                     />
                   ) : null}
                   {repo}
-                  {/* CTL-977: twistie on the RIGHT — ml-auto pushes to far end of row. */}
+                  {/* CTL-980: twistie immediately AFTER the label text (no ml-auto).
+                      A small ml-1 gap keeps it visually adjacent to the label. */}
                   <ChevronRightIcon
                     className={cn(
-                      "ml-auto size-3 flex-shrink-0 transition-transform duration-200",
+                      "ml-1 size-3 flex-shrink-0 transition-transform duration-200",
                       isOpen && "rotate-90",
                     )}
                   />
@@ -347,8 +366,8 @@ export function AppSidebar() {
           <SidebarGroup className="pt-0">
             <CollapsibleTrigger className={GROUP_TRIGGER_BASE}>
               Observe
-              {/* CTL-977: twistie on the RIGHT — group-data-[state=open]/observe rotates. */}
-              <ChevronRightIcon className="ml-auto size-3 flex-shrink-0 transition-transform duration-200 group-data-[state=open]/observe:rotate-90" />
+              {/* CTL-980: twistie immediately after label (no ml-auto). */}
+              <ChevronRightIcon className="ml-1 size-3 flex-shrink-0 transition-transform duration-200 group-data-[state=open]/observe:rotate-90" />
             </CollapsibleTrigger>
             <CollapsibleContent>
               <SidebarGroupContent>


### PR DESCRIPTION
## Summary

- **Icon size**: Nav-item icons reduced from 24px → 16px (`size-4`) so they read as ~the same size as the 13px label, matching Linear's proportions
- **Icon color = label color**: Icons use `currentColor` to inherit the label's muted inactive / bright active tone automatically — no separate `[&>svg]:` override needed
- **Muted inactive labels**: Inactive nav-item labels drop from near-white to `text-sidebar-foreground/60` (~60% lightness); active/hover = full contrast (`text-sidebar-primary`) — the contrast jump signals selection, Linear-style
- **Twistie beside label**: Removed `ml-auto` from per-project and Observe chevrons; replaced with `ml-1` so the chevron sits immediately after the label text ("adva ⌄") rather than floating to the far-right edge
- **"Projects" heading**: Added a quiet `SidebarGroupLabel` reading "Projects" above the per-project collapsible groups, mirroring Linear's "Your teams" parent section label

## Changes

- `app-sidebar.tsx`: renderOperateItem icon wrapper gets `className="size-4 shrink-0"` on the icon, button gets muted inactive / active color classes; per-project + Observe `ChevronRightIcon` gets `ml-1` instead of `ml-auto`; new `SidebarGroupLabel` "Projects" renders when repos.length > 0
- `app-sidebar-nav-v3.test.ts`: 10 new structural tests verifying icon size class, no ml-auto on chevrons, muted label class, active contrast class, and Projects heading presence + ordering

## Test plan

- [x] `bun test src/components/app-sidebar-nav-v3.test.ts` — 10/10 pass
- [x] `bun test` (full UI suite) — 481/481 pass
- [x] `bun run build` — clean
- [x] `node ./node_modules/vite/bin/vite.js build` — clean
- [x] `bunx tsc --noEmit` — no new errors (pre-existing bun:test/node: type gaps only)

Closes CTL-980

🤖 Generated with [Claude Code](https://claude.com/claude-code)