### PR TITLE
feat(dev): CTL-981 nav final calibration — weight 500 + contrast /72 for label presence

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar-nav-v3.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar-nav-v3.test.ts
@@ -1,8 +1,10 @@
-// app-sidebar-nav-v3.test.ts — structure smoke-tests for CTL-980 nav proportion v3.
+// app-sidebar-nav-v3.test.ts — structure smoke-tests for CTL-980 nav proportion v3
+// and CTL-981 nav final calibration.
 // Validates that the key presentation constants and class strings satisfy the spec:
 //   - Icon size must be size-4 (16px), NOT size-6 (24px)
 //   - Twistie must NOT use ml-auto (it should be ml-1, beside the label)
-//   - Inactive label muting: text-sidebar-foreground/60 (not near-white)
+//   - Inactive label weight: font-medium (500), NOT weight 400 (CTL-981)
+//   - Inactive label contrast: text-sidebar-foreground/72 (raised from /60, CTL-981)
 //   - "Projects" section heading is referenced in the component source
 //
 // These are pure string-inspection tests against the component source — no DOM needed.
@@ -90,14 +92,39 @@ describe("CTL-980 nav proportion v3 — twistie placement", () => {
 });
 
 describe("CTL-980 nav proportion v3 — label muting", () => {
-  it("inactive nav-item label uses text-sidebar-foreground/60 (muted, not near-white)", () => {
-    // CTL-977 had near-white labels; CTL-980 mutes inactive labels to /60 opacity.
-    expect(src).toContain("text-sidebar-foreground/60");
-  });
-
   it("active nav-item label uses text-sidebar-primary (full contrast)", () => {
     // Active/selected items must be the high-contrast state.
     expect(src).toContain("text-sidebar-primary");
+  });
+});
+
+describe("CTL-981 nav final calibration — inactive label weight + contrast", () => {
+  it("inactive nav-item uses font-medium (weight 500) — primary fix for thin/small appearance", () => {
+    // CTL-981: weight 400→500 gives the text body/presence so it stops reading thin.
+    // This class must appear in the renderOperateItem inactive branch.
+    const renderBlock = src.slice(
+      src.indexOf("function renderOperateItem"),
+      src.indexOf("function groupContainsActive"),
+    );
+    expect(renderBlock).toContain("font-medium");
+  });
+
+  it("inactive nav-item contrast is /72, NOT the old /60", () => {
+    // CTL-981: opacity raised from /60 to /72 so labels read like Linear's lch(60) gray.
+    const renderBlock = src.slice(
+      src.indexOf("function renderOperateItem"),
+      src.indexOf("function groupContainsActive"),
+    );
+    expect(renderBlock).toContain("text-sidebar-foreground/72");
+    expect(renderBlock).not.toContain("text-sidebar-foreground/60");
+  });
+
+  it("active nav-item still uses text-sidebar-primary (high-contrast accent, clearly above /72)", () => {
+    const renderBlock = src.slice(
+      src.indexOf("function renderOperateItem"),
+      src.indexOf("function groupContainsActive"),
+    );
+    expect(renderBlock).toContain("text-sidebar-primary");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
@@ -81,6 +81,8 @@ import {
 //            Linear-style selected state, twistie moved to right.
 // CTL-980 — nav proportion v3: icons 16px (size-4), muted inactive labels, icon color = label
 //            color via currentColor, twistie beside label (not far-right), "Projects" heading.
+// CTL-981 — nav final calibration: inactive label weight 400→500 (font-medium) + contrast /60→/72
+//            so labels have body/presence and stop reading thin/small vs Linear's lch(60) baseline.
 
 /** A status dot overlaid on a nav icon (emerald = live, amber = anomaly). */
 function StatusDot({ kind }: { kind: "live" | "anomaly" }) {
@@ -206,6 +208,9 @@ export function AppSidebar() {
   // CTL-980: icon size forced to 16px (size-4) so it reads as ~same size as the 13px
   // label (not 1.7× bigger). Icon color = currentColor so it inherits the label's
   // muted-inactive / bright-active tone automatically. Inactive labels muted to /60.
+  // CTL-981: inactive weight → 500 (font-medium) + contrast /60 → /72 so labels
+  // have body/presence; active stays full-brightness (text-sidebar-primary) so the
+  // selection delta is still clearly visible.
   function renderOperateItem(
     item: (typeof OPERATE_ITEMS)[number],
     scopeVal: string,
@@ -221,13 +226,13 @@ export function AppSidebar() {
           tooltip={item.label}
           size={compact ? "sm" : "default"}
           onClick={() => go(item.surface, scopeVal)}
-          // CTL-980: inactive = muted label + icon (both text-sidebar-foreground/60);
-          // active/hover = full contrast (text-sidebar-primary). Icon inherits via
-          // currentColor — no separate [&>svg]: override needed when icon is inline.
+          // CTL-981: inactive = font-medium (weight 500) + text-sidebar-foreground/72
+          // (raised from /60 for better label presence — matches Linear's lch(60) gray);
+          // active = text-sidebar-primary (full accent, clearly brighter than /72).
           className={cn(
             active
               ? "text-sidebar-primary"
-              : "text-sidebar-foreground/60 hover:text-sidebar-foreground",
+              : "font-medium text-sidebar-foreground/72 hover:text-sidebar-foreground",
           )}
         >
           {/* CTL-980: explicit size-4 because the icon is inside a <span> wrapper


### PR DESCRIPTION
## Summary

- Inactive nav-item labels were weight 400 / opacity 60%, reading thin and dim vs Linear's lch(60) baseline
- Raises inactive label weight to 500 (`font-medium`) — primary fix for thin/small appearance
- Raises inactive label contrast from `/60` to `/72` — matches Linear's present-but-muted gray  
- Active state stays `text-sidebar-primary` (full accent); selection delta remains unambiguous
- Font size (14px) and icon size (16px) are **unchanged**

## Test plan

- [x] Updated `app-sidebar-nav-v3.test.ts`: removed stale `/60` assertion, added 3 CTL-981 tests (font-medium present, /72 used, /60 absent in inactive branch)
- [x] All 12 tests pass: `bun test src/components/app-sidebar-nav-v3.test.ts`
- [x] `bunx tsc --noEmit` clean
- [ ] Deploy to Mini + agent-browser verify: fontWeight 500, color opacity ~0.72, icon 16px

🤖 Generated with [Claude Code](https://claude.com/claude-code)