### PR TITLE
test(dev): add 6 belief suites to execution-core CI gate (CTL-966 follow-up)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -83,8 +83,14 @@ jobs:
         #   Memory ref: project_execution_core_daemon_flaky_test
         run: |
           bun test \
+            beliefs/advance-rules.test.mjs \
+            beliefs/advance-shadow.test.mjs \
+            beliefs/collector-advance.test.mjs \
+            beliefs/collector-relation.test.mjs \
             beliefs/collector.test.mjs \
+            beliefs/escalate.test.mjs \
             beliefs/intent.test.mjs \
+            beliefs/recursive-rules.test.mjs \
             beliefs/rules.test.mjs \
             beliefs/schema.test.mjs \
             beliefs/why.test.mjs \


### PR DESCRIPTION
## What

The execution-core CI gate (`.github/workflows/execution-core-tests.yml`) ran only 5 belief suites (`collector`, `intent`, `rules`, `schema`, `why`). Six stable belief suites shipped during the inference-engine program but were never added to the gate (the overnight OAuth token lacked `workflow` scope — CTL-966 evidence-log follow-up):

- `beliefs/advance-rules.test.mjs`
- `beliefs/advance-shadow.test.mjs`
- `beliefs/collector-advance.test.mjs`
- `beliefs/collector-relation.test.mjs`
- `beliefs/escalate.test.mjs`
- `beliefs/recursive-rules.test.mjs`

## Change

Adds those 6 to the `bun test` allowlist, grouped with the existing `beliefs/` entries. **Only** the workflow YAML changes — no branch-protection / required-check registration (that remains an operator gate, per the note already in the workflow header).

## Verification

None of the 6 is in the known-flaky EXCLUDED list (`daemon`, `scheduler`, `integration-ctl-587`, `monitor`). Full belief-suite run on this base: **214 pass / 0 fail** across 11 files; the 6 new suites alone: **115 pass / 0 fail**. Adversarially verified: diff is the single YAML file, all 6 filenames exist on disk, no protection change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)