### PR TITLE
feat(dev): OBSERVE FinOps surface — cost routes + hero(today-vs-7d + cache-ROI) + breakdowns (OBS-9/10/11)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/otel-queries.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/otel-queries.test.ts
@@ -20,6 +20,13 @@ import {
   extractHeatmap,
   HEATMAP_BUCKET_SECONDS,
   costValidation,
+  costToday,
+  costSeries,
+  cacheSavings,
+  scoreSpikes,
+  avgPrior7FullDays,
+  secondsSinceLocalMidnight,
+  inputPricePerToken,
   safeDuration,
   workerHistoryBySession,
   workerHistoryLogQL,
@@ -79,6 +86,32 @@ describe("costByTicket", () => {
     expect(result).not.toBeNull();
     expect(result!["CTL-39"]).toBeCloseTo(1.234);
     expect(result!["CTL-40"]).toBeCloseTo(0.567);
+  });
+
+  // OBS-9: the MANDATORY zero-series filter. increase() returns a series for every
+  // ticket that ever carried the metric, most exact-0 in any window (live: ~24 of
+  // ~36). A topk/bottomk/table on those renders all-zeros garbage — so costByTicket
+  // MUST drop value===0 series at the query layer.
+  it("OBS-9: filters out exact-0 ticket series (the zero-series filter)", async () => {
+    const prom = mockProm({
+      data: {
+        resultType: "vector",
+        result: [
+          { metric: { linear_key: "CTL-850" }, value: [0, "621.0"] },
+          { metric: { linear_key: "CTL-ZERO" }, value: [0, "0"] },
+          { metric: { linear_key: "CTL-696" }, value: [0, "214.0"] },
+          { metric: { linear_key: "CTL-ZERO2" }, value: [0, "0.0"] },
+        ],
+      },
+    });
+    const result = await costByTicket(prom, "24h");
+    expect(result).not.toBeNull();
+    expect(result!["CTL-850"]).toBeCloseTo(621);
+    expect(result!["CTL-696"]).toBeCloseTo(214);
+    // The two exact-0 tickets are GONE, not present-as-0.
+    expect("CTL-ZERO" in result!).toBe(false);
+    expect("CTL-ZERO2" in result!).toBe(false);
+    expect(Object.keys(result!)).toHaveLength(2);
   });
 
   it("returns null when Prometheus is unavailable", async () => {
@@ -222,6 +255,342 @@ describe("costByTaskType", () => {
     expect(capturedQuery).toContain("sum by (task_type)");
     expect(capturedQuery).toContain(`task_type=~".+"`);
     expect(capturedQuery).toContain("claude_code_cost_usage_USD_total");
+  });
+
+  // OBS-9: by-stage gets the same zero-series filter — live, ~5 of 12 task_types
+  // are exact-0 over 24h and must not render as empty phases in the P-B bar.
+  it("OBS-9: filters out exact-0 task_type series", async () => {
+    const prom = mockProm({
+      data: {
+        resultType: "vector",
+        result: [
+          { metric: { task_type: "interactive" }, value: [0, "1382.05"] },
+          { metric: { task_type: "phase-triage" }, value: [0, "0"] },
+          { metric: { task_type: "phase-research" }, value: [0, "39.21"] },
+          { metric: { task_type: "phase-pr" }, value: [0, "0.0"] },
+        ],
+      },
+    });
+    const result = await costByTaskType(prom, "24h");
+    expect(result).not.toBeNull();
+    expect(result!["interactive"]).toBeCloseTo(1382.05);
+    expect(result!["phase-research"]).toBeCloseTo(39.21);
+    expect("phase-triage" in result!).toBe(false);
+    expect("phase-pr" in result!).toBe(false);
+    expect(Object.keys(result!)).toHaveLength(2);
+  });
+});
+
+// ── OBS-9 (FINOPS) ───────────────────────────────────────────────────────────
+
+/** A Prometheus mock that returns DIFFERENT results for `query` vs `queryRange`
+ *  (the today-vs-7d hero fires both), and records every PromQL it sees. */
+function mockPromSplit(opts: {
+  query?: PrometheusQueryResult | null;
+  queryRange?: PrometheusQueryResult | null;
+}): { prom: PrometheusFetcher; queries: string[]; ranges: string[] } {
+  const queries: string[] = [];
+  const ranges: string[] = [];
+  const prom: PrometheusFetcher = {
+    query: (q: string) => {
+      queries.push(q);
+      return Promise.resolve(opts.query ?? null);
+    },
+    queryRange: (q: string) => {
+      ranges.push(q);
+      return Promise.resolve(opts.queryRange ?? null);
+    },
+    isAvailable: () => true,
+  };
+  return { prom, queries, ranges };
+}
+
+describe("secondsSinceLocalMidnight", () => {
+  it("returns whole seconds elapsed since local midnight", () => {
+    const noon = new Date(2026, 5, 10, 12, 0, 0); // local 12:00:00
+    expect(secondsSinceLocalMidnight(noon)).toBe(12 * 3600);
+    const t = new Date(2026, 5, 10, 1, 2, 3); // 01:02:03
+    expect(secondsSinceLocalMidnight(t)).toBe(3723);
+  });
+
+  it("clamps to a 1s floor so the today window is never 0-width", () => {
+    const midnight = new Date(2026, 5, 10, 0, 0, 0);
+    expect(secondsSinceLocalMidnight(midnight)).toBe(1);
+  });
+});
+
+describe("avgPrior7FullDays", () => {
+  it("averages the prior full days, EXCLUDING the current partial day", () => {
+    // 8 daily buckets; the LAST is today (partial) and must be dropped.
+    const pts: Array<[number, number]> = [
+      [1, 600],
+      [2, 300],
+      [3, 300],
+      [4, 300],
+      [5, 380],
+      [6, 600],
+      [7, 340],
+      [8, 9999], // today — partial — EXCLUDED
+    ];
+    // mean of the 7 full days = (600+300+300+300+380+600+340)/7 = 2820/7
+    expect(avgPrior7FullDays(pts)).toBeCloseTo(2820 / 7);
+  });
+
+  it("keeps only the last 7 full days when more are present", () => {
+    const pts: Array<[number, number]> = Array.from({ length: 12 }, (_, i) => [
+      i,
+      i === 11 ? 0 : 100, // last is partial-today=0, the rest are 100
+    ]);
+    // last 7 full days are all 100 → avg 100
+    expect(avgPrior7FullDays(pts)).toBeCloseTo(100);
+  });
+
+  it("returns 0 for empty or single-bucket input", () => {
+    expect(avgPrior7FullDays([])).toBe(0);
+    expect(avgPrior7FullDays([[1, 500]])).toBe(0); // only the partial day
+  });
+});
+
+describe("costToday", () => {
+  it("computes todayUsd, avg7d baseline, delta, and EOD projection", async () => {
+    const noon = new Date(2026, 5, 10, 12, 0, 0); // half the day elapsed
+    const { prom, queries, ranges } = mockPromSplit({
+      query: {
+        data: { resultType: "vector", result: [{ metric: {}, value: [0, "300"] }] },
+      },
+      queryRange: {
+        data: {
+          resultType: "matrix",
+          result: [
+            {
+              metric: {},
+              values: [
+                [1, "200"],
+                [2, "200"],
+                [3, "200"],
+                [4, "200"],
+                [5, "200"],
+                [6, "200"],
+                [7, "200"],
+                [8, "150"], // today partial — excluded from baseline
+              ],
+            },
+          ],
+        },
+      },
+    });
+    const result = await costToday(prom, noon);
+    expect(result).not.toBeNull();
+    expect(result!.todayUsd).toBeCloseTo(300);
+    expect(result!.avg7dUsd).toBeCloseTo(200);
+    // delta = (300 - 200) / 200 = +0.5
+    expect(result!.deltaFraction).toBeCloseTo(0.5);
+    // half a day elapsed → projection ≈ 300 / (43200/86400) = 600
+    expect(result!.projectionEodUsd).toBeCloseTo(600);
+    expect(result!.elapsedTodaySeconds).toBe(12 * 3600);
+    // today is an instant query over the elapsed-today window; baseline is a range.
+    expect(queries[0]).toContain(`increase(claude_code_cost_usage_USD_total[${12 * 3600}s]))`);
+    expect(ranges[0]).toContain("increase(claude_code_cost_usage_USD_total[1d])");
+  });
+
+  it("null delta when there is no 7d baseline (avg===0)", async () => {
+    const { prom } = mockPromSplit({
+      query: {
+        data: { resultType: "vector", result: [{ metric: {}, value: [0, "50"] }] },
+      },
+      queryRange: { data: { resultType: "matrix", result: [] } },
+    });
+    const result = await costToday(prom, new Date(2026, 5, 10, 6, 0, 0));
+    expect(result).not.toBeNull();
+    expect(result!.avg7dUsd).toBe(0);
+    expect(result!.deltaFraction).toBeNull();
+  });
+
+  it("returns null when Prometheus is unavailable", async () => {
+    const result = await costToday(mockProm(null));
+    expect(result).toBeNull();
+  });
+});
+
+describe("scoreSpikes", () => {
+  it("flags an hour exceeding both 2× median and μ+2σ", () => {
+    // calm baseline at 10, one big spike at 200.
+    const pts: Array<[number, number]> = [
+      [1, 10],
+      [2, 12],
+      [3, 9],
+      [4, 11],
+      [5, 200], // the spike
+      [6, 10],
+    ];
+    const scored = scoreSpikes(pts);
+    expect(scored.find((p) => p.t === 5)!.isSpike).toBe(true);
+    // every other hour is calm — not a spike.
+    expect(scored.filter((p) => p.isSpike)).toHaveLength(1);
+  });
+
+  it("never flags an all-zero or quiet series", () => {
+    const scored = scoreSpikes([
+      [1, 0],
+      [2, 0],
+      [3, 0],
+    ]);
+    expect(scored.every((p) => !p.isSpike)).toBe(true);
+  });
+
+  it("flags nothing with fewer than 3 points (no distribution)", () => {
+    const scored = scoreSpikes([
+      [1, 1],
+      [2, 1000],
+    ]);
+    expect(scored.every((p) => !p.isSpike)).toBe(true);
+  });
+
+  it("preserves the points and their order", () => {
+    const pts: Array<[number, number]> = [
+      [100, 5],
+      [200, 6],
+      [300, 7],
+    ];
+    const scored = scoreSpikes(pts);
+    expect(scored.map((p) => [p.t, p.usd])).toEqual(pts);
+  });
+});
+
+describe("costSeries", () => {
+  it("returns hourly points with spike flags from a query_range matrix", async () => {
+    const { prom, ranges } = mockPromSplit({
+      queryRange: {
+        data: {
+          resultType: "matrix",
+          result: [
+            {
+              metric: {},
+              values: [
+                [1, "10"],
+                [2, "11"],
+                [3, "9"],
+                [4, "250"], // spike — clears both thresholds against the calm tail
+                [5, "10"],
+                [6, "11"],
+                [7, "9"],
+                [8, "10"],
+                [9, "11"],
+                [10, "10"],
+              ],
+            },
+          ],
+        },
+      },
+    });
+    const result = await costSeries(prom, "24h");
+    expect(result).not.toBeNull();
+    expect(result!).toHaveLength(10);
+    expect(result!.find((p) => p.t === 4)!.isSpike).toBe(true);
+    expect(result!.filter((p) => p.isSpike)).toHaveLength(1);
+    // hourly bars: a 1h window stepped at 1h.
+    expect(ranges[0]).toContain("increase(claude_code_cost_usage_USD_total[1h])");
+  });
+
+  it("returns null when Prometheus is unavailable", async () => {
+    const result = await costSeries(mockProm(null), "24h");
+    expect(result).toBeNull();
+  });
+
+  it("returns [] honestly for a reachable-but-empty stack", async () => {
+    const { prom } = mockPromSplit({
+      queryRange: { data: { resultType: "matrix", result: [] } },
+    });
+    const result = await costSeries(prom, "24h");
+    expect(result).toEqual([]);
+  });
+});
+
+describe("inputPricePerToken", () => {
+  it("maps each model family to its per-token input price", () => {
+    expect(inputPricePerToken("claude-opus-4-8")).toBeCloseTo(5.0 / 1e6);
+    expect(inputPricePerToken("claude-opus-4-8[1m]")).toBeCloseTo(5.0 / 1e6);
+    expect(inputPricePerToken("claude-sonnet-4-6")).toBeCloseTo(3.0 / 1e6);
+    expect(inputPricePerToken("claude-haiku-4-5-20251001")).toBeCloseTo(1.0 / 1e6);
+    expect(inputPricePerToken("claude-fable-5")).toBeCloseTo(5.0 / 1e6);
+  });
+
+  it("falls back to the sonnet rate for an unknown model (never zero)", () => {
+    expect(inputPricePerToken("some-future-model")).toBeCloseTo(3.0 / 1e6);
+  });
+});
+
+describe("cacheSavings", () => {
+  it("computes per-model savings = cacheRead × input × 0.9 + the multiplier", async () => {
+    // cacheSavings fires two query() calls — cacheRead-by-model first, total spend
+    // second — so a call-ordered mock returns the right shape per call.
+    let call = 0;
+    const promOrdered: PrometheusFetcher = {
+      query: () => {
+        call += 1;
+        if (call === 1) {
+          return Promise.resolve({
+            data: {
+              resultType: "vector",
+              result: [
+                { metric: { model: "claude-opus-4-8" }, value: [0, "1000000"] },
+                { metric: { model: "claude-sonnet-4-6" }, value: [0, "2000000"] },
+                { metric: { model: "claude-zero" }, value: [0, "0"] }, // dropped
+              ],
+            },
+          } as PrometheusQueryResult);
+        }
+        return Promise.resolve({
+          data: { resultType: "vector", result: [{ metric: {}, value: [0, "100"] }] },
+        } as PrometheusQueryResult);
+      },
+      queryRange: () => Promise.resolve(null),
+      isAvailable: () => true,
+    };
+    const result = await cacheSavings(promOrdered, "24h");
+    expect(result).not.toBeNull();
+    // opus: 1e6 tokens × 5/1e6 × 0.9 = 4.5 ; sonnet: 2e6 × 3/1e6 × 0.9 = 5.4
+    expect(result!.savedUsd).toBeCloseTo(4.5 + 5.4);
+    expect(result!.cacheReadTokens).toBe(3_000_000);
+    expect(result!.actualSpendUsd).toBeCloseTo(100);
+    expect(result!.multiplier).toBeCloseTo((4.5 + 5.4) / 100);
+    // per-model, descending; the zero-token model is filtered out.
+    expect(result!.byModel.map((m) => m.model)).toEqual([
+      "claude-sonnet-4-6",
+      "claude-opus-4-8",
+    ]);
+  });
+
+  it("null multiplier when actual spend is 0", async () => {
+    let call = 0;
+    const prom: PrometheusFetcher = {
+      query: () => {
+        call += 1;
+        if (call === 1) {
+          return Promise.resolve({
+            data: {
+              resultType: "vector",
+              result: [{ metric: { model: "claude-opus-4-8" }, value: [0, "1000000"] }],
+            },
+          } as PrometheusQueryResult);
+        }
+        return Promise.resolve({
+          data: { resultType: "vector", result: [] },
+        } as PrometheusQueryResult);
+      },
+      queryRange: () => Promise.resolve(null),
+      isAvailable: () => true,
+    };
+    const result = await cacheSavings(prom, "24h");
+    expect(result).not.toBeNull();
+    expect(result!.actualSpendUsd).toBe(0);
+    expect(result!.multiplier).toBeNull();
+    expect(result!.savedUsd).toBeGreaterThan(0);
+  });
+
+  it("returns null when Prometheus is unavailable", async () => {
+    const result = await cacheSavings(mockProm(null), "24h");
+    expect(result).toBeNull();
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/otel-queries.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/otel-queries.test.ts
@@ -23,6 +23,7 @@ import {
   costToday,
   costSeries,
   cacheSavings,
+  costAtHour,
   scoreSpikes,
   avgPrior7FullDays,
   secondsSinceLocalMidnight,
@@ -590,6 +591,99 @@ describe("cacheSavings", () => {
 
   it("returns null when Prometheus is unavailable", async () => {
     const result = await cacheSavings(mockProm(null), "24h");
+    expect(result).toBeNull();
+  });
+});
+
+describe("costAtHour", () => {
+  it("anchors a 1h window to the target hour via PromQL offset + zero-filters both maps", async () => {
+    const queries: string[] = [];
+    let call = 0;
+    const prom: PrometheusFetcher = {
+      query: (q: string) => {
+        queries.push(q);
+        call += 1;
+        // call 1 = by-ticket, call 2 = by-model (the Promise.all order).
+        if (call === 1) {
+          return Promise.resolve({
+            data: {
+              resultType: "vector",
+              result: [
+                { metric: { linear_key: "CTL-928" }, value: [0, "31.7"] },
+                { metric: { linear_key: "CTL-ZERO" }, value: [0, "0"] }, // dropped
+                { metric: { linear_key: "CTL-850" }, value: [0, "14.22"] },
+              ],
+            },
+          } as PrometheusQueryResult);
+        }
+        return Promise.resolve({
+          data: {
+            resultType: "vector",
+            result: [
+              { metric: { model: "claude-opus-4-8[1m]" }, value: [0, "28.84"] },
+              { metric: { model: "claude-zero" }, value: [0, "0"] }, // dropped
+            ],
+          },
+        } as PrometheusQueryResult);
+      },
+      queryRange: () => Promise.resolve(null),
+      isAvailable: () => true,
+    };
+    // Fix "now" 2h after the target hour-end → offset = 7200s.
+    const hourEnd = 1781000000;
+    const now = new Date((hourEnd + 7200) * 1000);
+    const result = await costAtHour(prom, hourEnd, now);
+    expect(result).not.toBeNull();
+    expect(result!.hourEndSeconds).toBe(hourEnd);
+    // by-ticket zero-filtered, by-model zero-filtered.
+    expect(result!.byTicket).toEqual({ "CTL-928": 31.7, "CTL-850": 14.22 });
+    expect(result!.byModel).toEqual({ "claude-opus-4-8[1m]": 28.84 });
+    // Both queries carry the computed offset + a 1h increase window.
+    expect(queries[0]).toContain("offset 7200s");
+    expect(queries[0]).toContain("[1h]");
+    expect(queries[0]).toContain("sum by (linear_key)");
+    expect(queries[1]).toContain("offset 7200s");
+    expect(queries[1]).toContain("sum by (model)");
+  });
+
+  it("omits the offset clause when the hour is current (offset 0)", async () => {
+    const queries: string[] = [];
+    const prom: PrometheusFetcher = {
+      query: (q: string) => {
+        queries.push(q);
+        return Promise.resolve({
+          data: { resultType: "vector", result: [] },
+        } as PrometheusQueryResult);
+      },
+      queryRange: () => Promise.resolve(null),
+      isAvailable: () => true,
+    };
+    const now = new Date(1781000000 * 1000);
+    await costAtHour(prom, 1781000000, now);
+    expect(queries[0]).not.toContain("offset");
+  });
+
+  it("clamps a future hour to offset 0 (never a negative-offset 400)", async () => {
+    const queries: string[] = [];
+    const prom: PrometheusFetcher = {
+      query: (q: string) => {
+        queries.push(q);
+        return Promise.resolve({
+          data: { resultType: "vector", result: [] },
+        } as PrometheusQueryResult);
+      },
+      queryRange: () => Promise.resolve(null),
+      isAvailable: () => true,
+    };
+    // hour-end 1h in the FUTURE relative to now → offset clamps to 0.
+    const now = new Date(1781000000 * 1000);
+    await costAtHour(prom, 1781000000 + 3600, now);
+    expect(queries[0]).not.toContain("offset -");
+    expect(queries[0]).not.toContain("offset");
+  });
+
+  it("returns null when Prometheus is unavailable", async () => {
+    const result = await costAtHour(mockProm(null), 1781000000);
     expect(result).toBeNull();
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
@@ -474,6 +474,13 @@ describe("OTel API endpoints", () => {
     const res = await fetch(`${baseUrl}/api/otel/cache-savings`);
     expect(res.status).toBe(503);
   });
+
+  // OBS-10: the spike-drill route. Same 503-when-unconfigured contract; it also
+  // 503s before reading `hour` (the not-configured guard runs first).
+  it("returns 503 for /api/otel/cost-at-hour when not configured", async () => {
+    const res = await fetch(`${baseUrl}/api/otel/cost-at-hour?hour=1781000000`);
+    expect(res.status).toBe(503);
+  });
 });
 
 describe("OTel health endpoint (/api/health/otel)", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
@@ -452,6 +452,28 @@ describe("OTel API endpoints", () => {
     const res = await fetch(`${baseUrl}/api/otel/cost-rate`);
     expect(res.status).toBe(503);
   });
+
+  // OBS-9: the four new FinOps routes follow the same "503 when Prometheus is not
+  // configured" contract so the FinOps surface degrades via the ChartCard ladder.
+  it("returns 503 for /api/otel/cost-by-stage when not configured", async () => {
+    const res = await fetch(`${baseUrl}/api/otel/cost-by-stage`);
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 503 for /api/otel/cost-today when not configured", async () => {
+    const res = await fetch(`${baseUrl}/api/otel/cost-today`);
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 503 for /api/otel/cost-series when not configured", async () => {
+    const res = await fetch(`${baseUrl}/api/otel/cost-series`);
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 503 for /api/otel/cache-savings when not configured", async () => {
+    const res = await fetch(`${baseUrl}/api/otel/cache-savings`);
+    expect(res.status).toBe(503);
+  });
 });
 
 describe("OTel health endpoint (/api/health/otel)", () => {

--- a/plugins/dev/scripts/orch-monitor/lib/otel-queries.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-queries.ts
@@ -103,6 +103,51 @@ export async function costByTaskType(
   return extractVectorMap(result, "task_type", true);
 }
 
+// OBS-11 (FINOPS P-D): cost grouped by a native Prometheus dimension — `model`
+// (the model mix) or `agent_name` (the closest real "what machinery costs most"
+// signal: workflow-subagent vs general-purpose vs …, design §3.3 #9b). Both are
+// native labels on the cost counter (verified live: 6 model values, 8 agent_name
+// values, all non-zero over 24h/7d). The dimension is WHITELISTED (never
+// interpolated from caller input) so the PromQL can't be an injection vector, and
+// the OBS-9 zero-series filter is applied so the ranked bar never shows the
+// exact-0 dimensions an `increase()` window always carries.
+
+/** The whitelisted P-D grouping dimensions. `model` and `agent_name` are the only
+ *  native cost labels the by-model/by-agent toggle ever groups on — a fixed map so
+ *  the PromQL label is never derived from caller input. */
+export const COST_DIMENSIONS = {
+  model: "model",
+  agent: "agent_name",
+} as const;
+
+export type CostDimensionKey = keyof typeof COST_DIMENSIONS;
+
+/** True when a string is a known P-D dimension key (route input validation). */
+export function isCostDimension(s: string): s is CostDimensionKey {
+  return s === "model" || s === "agent";
+}
+
+/** Cost grouped by a whitelisted native dimension (`model` / `agent_name`),
+ *  descending-ready + zero-filtered. The label is looked up from COST_DIMENSIONS —
+ *  NEVER interpolated from caller input — so it can't inject PromQL. Returns null
+ *  when Prometheus is unavailable; an empty map when the window had no spend on that
+ *  dimension. */
+export async function costByDimension(
+  prom: PrometheusFetcher,
+  dimension: CostDimensionKey,
+  range: string,
+): Promise<Record<string, number> | null> {
+  const r = safeDuration(range, "24h");
+  const label = COST_DIMENSIONS[dimension];
+  const result = await prom.query(
+    `sum by (${label}) (increase(claude_code_cost_usage_USD_total{${label}=~".+"}[${r}]))`,
+  );
+  if (!result) return null;
+  // OBS-9 zero-series filter — drop dimensions with $0 spend in the window so the
+  // ranked P-D bar never renders the exact-0 models/agents.
+  return extractVectorMap(result, label, true);
+}
+
 export async function toolUsageByName(
   loki: LokiFetcher,
   range: string,

--- a/plugins/dev/scripts/orch-monitor/lib/otel-queries.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-queries.ts
@@ -1254,6 +1254,53 @@ export async function cacheSavings(
   return { savedUsd, actualSpendUsd, multiplier, cacheReadTokens, byModel };
 }
 
+// ── OBS-10 (FINOPS P-A drill): cost at a single spiking hour ─────────────────
+// Clicking a spiking bar in the P-A spend-over-time chart drills into THAT hour's
+// by-ticket + by-model split (the "one re-query with the hour window", layout spec
+// §2 P-A). The hour window is anchored with PromQL's `offset`: a 1h `increase()`
+// shifted back so the window ENDS at the clicked hour. Both maps reuse the
+// zero-series filter (a past hour has even more exact-0 series than a live window).
+//
+// `offsetSeconds` is whole seconds from NOW back to the END of the target hour
+// (i.e. now − spikeHourEnd). Clamped ≥0 (a future/negative offset would 400 in
+// PromQL); when 0 the `offset 0s` is harmless (window ends at NOW).
+
+/** The per-hour drill payload: the by-ticket and by-model cost split for ONE hour,
+ *  both zero-filtered + descending-ready. `null` when Prometheus is unavailable. */
+export interface CostAtHour {
+  /** Epoch SECONDS of the hour's END (the clicked bar's right edge ≈ its ts). */
+  hourEndSeconds: number;
+  /** linear_key → USD for the hour (zero-filtered). */
+  byTicket: Record<string, number>;
+  /** model → USD for the hour (zero-filtered). */
+  byModel: Record<string, number>;
+}
+
+export async function costAtHour(
+  prom: PrometheusFetcher,
+  hourEndSeconds: number,
+  now: Date = new Date(),
+): Promise<CostAtHour | null> {
+  const nowSec = Math.floor(now.getTime() / 1000);
+  // Whole seconds from now back to the end of the target hour. Clamp ≥0.
+  const offsetSeconds = Math.max(0, nowSec - Math.floor(hourEndSeconds));
+  const off = offsetSeconds > 0 ? ` offset ${offsetSeconds}s` : "";
+  const [ticketRes, modelRes] = await Promise.all([
+    prom.query(
+      `sum by (linear_key) (increase(claude_code_cost_usage_USD_total{linear_key=~".+"}[1h]${off}))`,
+    ),
+    prom.query(
+      `sum by (model) (increase(claude_code_cost_usage_USD_total[1h]${off}))`,
+    ),
+  ]);
+  if (ticketRes === null && modelRes === null) return null;
+  return {
+    hourEndSeconds: Math.floor(hourEndSeconds),
+    byTicket: ticketRes ? extractVectorMap(ticketRes, "linear_key", true) : {},
+    byModel: modelRes ? extractVectorMap(modelRes, "model", true) : {},
+  };
+}
+
 function parseDuration(s: string): number {
   const match = /^(\d+)(ms|s|m|h|d)$/.exec(s);
   if (!match) return 3600_000;

--- a/plugins/dev/scripts/orch-monitor/lib/otel-queries.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-queries.ts
@@ -7,16 +7,28 @@ export function safeDuration(s: string, fallback: string): string {
   return DURATION_RE.test(s) ? s : fallback;
 }
 
+// OBS-9: `increase()` over a fixed window returns a series for EVERY label value
+// that has EVER carried the metric, most with value 0 in any given window (the
+// `/api/otel/cost` route returns ~24 exact-0 tickets out of ~36 live). A topk /
+// bottomk / table built on that renders all-zeros garbage. The ZERO-SERIES FILTER
+// is therefore MANDATORY at the QUERY layer on every cost map (design §1/§2): pass
+// `filterZero: true` to drop value===0 series. Default is false so the
+// cost-VALIDATION path (which legitimately compares signal-vs-otel for tickets that
+// may be 0 on one side) keeps every ticket.
 function extractVectorMap(
   result: { data: { result: PrometheusMetricValue[] } },
   labelKey: string,
+  filterZero = false,
 ): Record<string, number> {
   const map: Record<string, number> = {};
   for (const entry of result.data.result) {
     const key = entry.metric[labelKey];
     if (!key) continue;
     const val = entry.value ? parseFloat(entry.value[1]) : 0;
-    if (Number.isFinite(val)) map[key] = val;
+    if (!Number.isFinite(val)) continue;
+    // Drop exact-0 series so a topk/bottomk/table never renders all-zeros garbage.
+    if (filterZero && val === 0) continue;
+    map[key] = val;
   }
   return map;
 }
@@ -30,7 +42,9 @@ export async function costByTicket(
     `sum by (linear_key) (increase(claude_code_cost_usage_USD_total{linear_key=~".+"}[${r}]))`,
   );
   if (!result) return null;
-  return extractVectorMap(result, "linear_key");
+  // OBS-9: zero-series filter — exclude tickets with $0 spend in the window so the
+  // expensive-tickets table (and any bottomk) only ever shows real cost.
+  return extractVectorMap(result, "linear_key", true);
 }
 
 export async function tokensByType(
@@ -83,7 +97,10 @@ export async function costByTaskType(
     `sum by (task_type) (increase(claude_code_cost_usage_USD_total{task_type=~".+"}[${r}]))`,
   );
   if (!result) return null;
-  return extractVectorMap(result, "task_type");
+  // OBS-9: zero-series filter — drop phases with $0 spend in the window so the
+  // by-stage bar (P-B) doesn't render a forest of empty phases (live: 5 of 12
+  // task_types are exact-0 over 24h).
+  return extractVectorMap(result, "task_type", true);
 }
 
 export async function toolUsageByName(
@@ -950,6 +967,291 @@ export async function costValidation(
     });
   }
   return entries;
+}
+
+// ── OBS-9 (FINOPS): the hero today-vs-7d + EOD projection ────────────────────
+// The FinOps surface question is "how much did I spend today, and is that normal?"
+// The hero needs THREE numbers off Prometheus: today's spend (since local
+// midnight), the avg of the prior 7 FULL days (the "normal" baseline the delta is
+// vs), and an end-of-day projection (today extrapolated to a full 24h). All three
+// are `increase()` over the SAME cost counter — no new plumbing.
+//
+// "Today" is anchored to the SERVER's local midnight (the operator's wall clock),
+// elapsed as whole seconds, so the window is exactly the part of today that has
+// happened. The 7d baseline is a `query_range` with a 1-DAY window + 1-DAY step
+// over the prior 8 days, taking the 7 fully-elapsed daily buckets and averaging
+// them (the current partial day is excluded — comparing a partial day to full days
+// would always read "under budget", a lie). The projection linearly extrapolates
+// today's run-rate to 24h (the simplest honest "if the rest of today looks like so
+// far" estimate — design §1 Hero-B marks it neutral/informational, never colored).
+
+/** The hero's dollar band: today's spend, the prior-7-full-day average (the delta
+ *  baseline), the delta fraction (today vs avg, or null when avg===0 so the UI
+ *  shows "—" not a divide-by-zero), and the linear EOD projection. `null` ONLY when
+ *  Prometheus is unavailable (caller surfaces a 503); a live-but-quiet stack
+ *  returns zeros honestly. */
+export interface CostTodaySummary {
+  /** `sum(increase(cost[<elapsed-today>]))` — spend since local midnight, USD. */
+  todayUsd: number;
+  /** Mean of the prior 7 FULL days' daily spend (the "normal" baseline), USD. */
+  avg7dUsd: number;
+  /** (today − avg7d) / avg7d, or null when avg7d===0 (no baseline → no delta). */
+  deltaFraction: number | null;
+  /** today extrapolated to a full 24h via the elapsed-fraction run-rate, USD. */
+  projectionEodUsd: number;
+  /** Whole seconds elapsed since local midnight (the today window width). */
+  elapsedTodaySeconds: number;
+}
+
+/** Whole seconds elapsed since LOCAL midnight for a given instant. Exported so a
+ *  test can pin the wall-clock anchoring (the today window is exactly this wide).
+ *  Clamped to a 1s floor so a query fired in the first second of the day never
+ *  produces a 0-width range (`increase(...[0s])` is undefined). */
+export function secondsSinceLocalMidnight(now: Date = new Date()): number {
+  const secs =
+    now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
+  return Math.max(1, secs);
+}
+
+/** Pull the single scalar from a `sum(...)`-shaped instant vector (one series, no
+ *  grouping label). Returns 0 for an empty/unparseable result — an honest "no spend
+ *  in window", never null-as-zero confusion (the caller already handles the
+ *  Prometheus-unavailable case separately). */
+function extractScalar(result: {
+  data: { result: PrometheusMetricValue[] };
+}): number {
+  const series = result.data.result[0];
+  if (!series?.value) return 0;
+  const v = parseFloat(series.value[1]);
+  return Number.isFinite(v) ? v : 0;
+}
+
+/** Average of the FULLY-elapsed daily buckets in a 1d-window/1d-step matrix. The
+ *  caller queries the prior 8 days; the LAST point is the current partial day and
+ *  is EXCLUDED (comparing a partial day to full days under-reports "today is
+ *  normal"). Exported for direct unit testing of the partial-day exclusion. */
+export function avgPrior7FullDays(points: SparklinePoint[]): number {
+  if (points.length === 0) return 0;
+  // Drop the final (current, partial) bucket; keep up to the prior 7 full days.
+  const full = points.slice(0, -1).slice(-7);
+  if (full.length === 0) return 0;
+  const sum = full.reduce((acc, [, v]) => acc + v, 0);
+  return sum / full.length;
+}
+
+export async function costToday(
+  prom: PrometheusFetcher,
+  now: Date = new Date(),
+): Promise<CostTodaySummary | null> {
+  const elapsed = secondsSinceLocalMidnight(now);
+  // today: instant query over the elapsed-today window.
+  const todayRes = await prom.query(
+    `sum(increase(claude_code_cost_usage_USD_total[${elapsed}s]))`,
+  );
+  // 7d baseline: 1d window, 1d step, over the prior 8 days (7 full + today partial).
+  const start = new Date(now.getTime() - 8 * 86400_000).toISOString();
+  const end = now.toISOString();
+  const baselineRes = await prom.queryRange(
+    `sum(increase(claude_code_cost_usage_USD_total[1d]))`,
+    start,
+    end,
+    "86400s",
+  );
+  // Prometheus unavailable → both probes null.
+  if (todayRes === null && baselineRes === null) return null;
+
+  const todayUsd = todayRes ? extractScalar(todayRes) : 0;
+  const dailyPoints = baselineRes ? extractSeriesPoints(baselineRes) : [];
+  const avg7dUsd = avgPrior7FullDays(dailyPoints);
+  const deltaFraction = avg7dUsd > 0 ? (todayUsd - avg7dUsd) / avg7dUsd : null;
+  // EOD projection: linear run-rate extrapolation to a full day. elapsed is clamped
+  // ≥1s so this never divides by zero; capped at the day so it never under-projects.
+  const dayFraction = Math.min(1, elapsed / 86400);
+  const projectionEodUsd = dayFraction > 0 ? todayUsd / dayFraction : todayUsd;
+  return {
+    todayUsd,
+    avg7dUsd,
+    deltaFraction,
+    projectionEodUsd,
+    elapsedTodaySeconds: elapsed,
+  };
+}
+
+// ── OBS-9 (FINOPS): spend-over-time series + spike scoring ───────────────────
+// The P-A panel is hourly spend bars with the spiking hours flagged. The series is
+// a `query_range` of `sum(increase(cost[1h]))` stepped at 1h (24h/7d window). Spike
+// scoring is a PURE function over the returned points so it is unit-testable
+// without Prometheus: an hour is a spike when its spend exceeds
+// max(2× the trailing-window median, μ+2σ) of the series (design §2 P-A). Both
+// guards matter — the median guard catches a 2× jump over a calm baseline; the
+// μ+2σ guard catches a genuine statistical outlier on a noisy series — and a spike
+// must clear BOTH (the stricter bar) so a merely-busy hour isn't flagged.
+
+/** One hourly spend point with its spike verdict. `t` is epoch SECONDS (the Loki/
+ *  Prom matrix point ts); `usd` is the hour's spend; `isSpike` drives the
+ *  `--chart-4` dot ON that bar (the one status-color use in P-A). */
+export interface CostSeriesPoint {
+  t: number;
+  usd: number;
+  isSpike: boolean;
+}
+
+/** Median of a numeric array (0 for empty). Pure helper for the spike threshold. */
+function median(xs: number[]): number {
+  if (xs.length === 0) return 0;
+  const sorted = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+/** Score hourly spend points for spikes. PURE + exported so a test pins the rule:
+ *  an hour is a spike iff its spend > max(2× median(series), μ+2σ) AND > 0. With
+ *  fewer than 3 points there is no meaningful distribution → nothing is flagged
+ *  (a 2-hour window can't have a statistical outlier). The `> 0` floor keeps a
+ *  quiet all-zero series from flagging anything. */
+export function scoreSpikes(points: SparklinePoint[]): CostSeriesPoint[] {
+  const values = points.map(([, v]) => v);
+  let threshold = Infinity;
+  if (values.length >= 3) {
+    const med = median(values);
+    const mean = values.reduce((a, b) => a + b, 0) / values.length;
+    const variance =
+      values.reduce((a, b) => a + (b - mean) ** 2, 0) / values.length;
+    const std = Math.sqrt(variance);
+    threshold = Math.max(2 * med, mean + 2 * std);
+  }
+  return points.map(([t, usd]) => ({
+    t,
+    usd,
+    isSpike: usd > 0 && usd > threshold,
+  }));
+}
+
+/** Hourly spend series with spike flags over the window. `null` ONLY when
+ *  Prometheus is unavailable (caller surfaces a 503); a live-but-quiet stack is an
+ *  honest `[]` (no hours in range → the ChartCard empty state). The window is the
+ *  passed range (24h/7d); the step is fixed at 1h so each bar is one hour. */
+export async function costSeries(
+  prom: PrometheusFetcher,
+  range: string,
+): Promise<CostSeriesPoint[] | null> {
+  const r = safeDuration(range, "24h");
+  const now = new Date();
+  const start = new Date(now.getTime() - parseDuration(r)).toISOString();
+  const end = now.toISOString();
+  const result = await prom.queryRange(
+    `sum(increase(claude_code_cost_usage_USD_total[1h]))`,
+    start,
+    end,
+    "3600s",
+  );
+  if (result === null) return null;
+  const points = extractSeriesPoints(result);
+  return scoreSpikes(points);
+}
+
+// ── OBS-9 (FINOPS): cache-ROI $ (THE HEADLINE) ───────────────────────────────
+// The single most motivating FinOps number (99.8% hit rate live): how many real
+// dollars the prompt cache saved by NOT charging cacheRead tokens at the full input
+// rate. savings = Σ_model cacheRead_tokens(model) × (input_price − cache_read_price)
+// for that model. The catalyst-otel dashboard's "Cache Savings ($)" panel proves a
+// flat `cacheRead × 0.000003` ($3/1M, a sonnet-ish input rate); we improve on it
+// with a PER-MODEL price book so the savings is accurate across the opus/sonnet/
+// haiku/fable mix (each model has a different input price, so a flat rate over- or
+// under-states the win depending on the live model split).
+//
+// Price book (USD per TOKEN) sourced from the /catalyst-dev:claude-api skill price
+// table (per-1M ÷ 1e6). Anthropic prompt-cache pricing: a cache READ costs 0.1× the
+// input price (the standard cache-read discount), so the per-token saving is
+// input_price − cache_read_price = input_price × 0.9.
+
+/** Per-1M-token INPUT price by model family (USD). From the claude-api skill price
+ *  table. We match on a substring of the Prometheus `model` label (which carries
+ *  values like `claude-opus-4-8`, `claude-opus-4-8[1m]`, `claude-sonnet-4-6`,
+ *  `claude-haiku-4-5`, `claude-fable-5`). Fable exceeds opus-tier; we price it at
+ *  the opus rate as a conservative floor rather than fabricate a number the skill
+ *  table doesn't publish. */
+const INPUT_PRICE_PER_1M: Record<string, number> = {
+  opus: 5.0,
+  sonnet: 3.0,
+  haiku: 1.0,
+  fable: 5.0,
+  mythos: 5.0,
+};
+
+/** The cache-read discount: an Anthropic prompt-cache READ is billed at 0.1× the
+ *  input price, so the per-token SAVING (vs paying full input) is input × 0.9. */
+const CACHE_READ_PRICE_MULTIPLIER = 0.1;
+
+/** Default input price (USD/1M) for a model whose family we don't recognise —
+ *  the sonnet rate, matching the dashboard's flat $3/1M assumption so an unknown
+ *  model never zeroes out (it would silently drop savings) nor over-states it. */
+const DEFAULT_INPUT_PRICE_PER_1M = 3.0;
+
+/** Resolve a model label to its per-TOKEN input price (USD). Exported so a test can
+ *  pin the family matching (opus/sonnet/haiku/fable, with the `[1m]` long-context
+ *  suffix and date suffixes tolerated). */
+export function inputPricePerToken(model: string): number {
+  const lower = model.toLowerCase();
+  for (const family of Object.keys(INPUT_PRICE_PER_1M)) {
+    if (lower.includes(family)) return INPUT_PRICE_PER_1M[family] / 1_000_000;
+  }
+  return DEFAULT_INPUT_PRICE_PER_1M / 1_000_000;
+}
+
+/** The cache-ROI payload: the headline savings $ + the multiplier (savings / actual
+ *  spend, i.e. "spend would have been Nx higher without the cache"), the cacheRead
+ *  token total the savings is computed from, and the per-model breakdown for a
+ *  drill. `null` ONLY when Prometheus is unavailable. */
+export interface CacheSavings {
+  /** Σ_model cacheRead_tokens × (input − cache_read) price — USD saved by the cache. */
+  savedUsd: number;
+  /** Actual spend in the SAME window (for the "(Nx)" multiplier), USD. */
+  actualSpendUsd: number;
+  /** savedUsd / actualSpendUsd, or null when actual spend is 0 (no base to multiply). */
+  multiplier: number | null;
+  /** Total cacheRead tokens in the window (the savings driver). */
+  cacheReadTokens: number;
+  /** Per-model saving, USD, descending — the drill behind the headline. */
+  byModel: Array<{ model: string; savedUsd: number; cacheReadTokens: number }>;
+}
+
+export async function cacheSavings(
+  prom: PrometheusFetcher,
+  range: string,
+): Promise<CacheSavings | null> {
+  const r = safeDuration(range, "24h");
+  // cacheRead tokens BY MODEL so we can apply the per-model price; + total spend in
+  // the same window for the multiplier.
+  const [cacheReadRes, spendRes] = await Promise.all([
+    prom.query(
+      `sum by (model) (increase(claude_code_token_usage_tokens_total{type="cacheRead"}[${r}]))`,
+    ),
+    prom.query(`sum(increase(claude_code_cost_usage_USD_total[${r}]))`),
+  ]);
+  if (cacheReadRes === null && spendRes === null) return null;
+
+  const byModelTokens = cacheReadRes
+    ? extractVectorMap(cacheReadRes, "model", true)
+    : {};
+  const byModel: CacheSavings["byModel"] = [];
+  let savedUsd = 0;
+  let cacheReadTokens = 0;
+  for (const [model, tokens] of Object.entries(byModelTokens)) {
+    const perToken =
+      inputPricePerToken(model) * (1 - CACHE_READ_PRICE_MULTIPLIER);
+    const modelSaved = tokens * perToken;
+    savedUsd += modelSaved;
+    cacheReadTokens += tokens;
+    byModel.push({ model, savedUsd: modelSaved, cacheReadTokens: tokens });
+  }
+  byModel.sort((a, b) => b.savedUsd - a.savedUsd);
+
+  const actualSpendUsd = spendRes ? extractScalar(spendRes) : 0;
+  const multiplier = actualSpendUsd > 0 ? savedUsd / actualSpendUsd : null;
+  return { savedUsd, actualSpendUsd, multiplier, cacheReadTokens, byModel };
 }
 
 function parseDuration(s: string): number {

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -196,6 +196,8 @@ import {
 import {
   costByTicket,
   costByTaskType,
+  costByDimension,
+  isCostDimension,
   tokensByType,
   cacheHitRate,
   costRateByModel,
@@ -1894,6 +1896,23 @@ export function createServer(opts: CreateServerOptions): BunServer {
           if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
           const range = url.searchParams.get("range") ?? "24h";
           const result = await costByTaskType(prom, range);
+          return Response.json({ data: result });
+        }
+
+        // OBS-11 (FINOPS P-D): cost by model / agent. Groups the cost counter by a
+        // WHITELISTED native dimension (`model` or `agent_name` — never interpolated
+        // from input, so no PromQL injection) with the OBS-9 zero-series filter
+        // applied so the ranked bar never shows the exact-0 models/agents an
+        // increase() window carries. `dim` defaults to model; an unknown dim → 400
+        // (honest, never a silently-empty bar). 503 when Prometheus is off.
+        if (url.pathname === "/api/otel/cost-by-dim") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const dim = url.searchParams.get("dim") ?? "model";
+          if (!isCostDimension(dim)) {
+            return Response.json({ error: "unknown dimension" }, { status: 400 });
+          }
+          const range = url.searchParams.get("range") ?? "24h";
+          const result = await costByDimension(prom, dim, range);
           return Response.json({ data: result });
         }
 

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -195,6 +195,7 @@ import {
 } from "./lib/otel-health";
 import {
   costByTicket,
+  costByTaskType,
   tokensByType,
   cacheHitRate,
   costRateByModel,
@@ -205,6 +206,9 @@ import {
   recentTail,
   eventsHeatmap,
   costValidation,
+  costToday,
+  costSeries,
+  cacheSavings,
   workerHistoryBySession,
   isValidCcSessionId,
   workerBurnSeries,
@@ -1877,6 +1881,61 @@ export function createServer(opts: CreateServerOptions): BunServer {
           if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
           const interval = url.searchParams.get("interval") ?? "5m";
           const result = await costRateByModel(prom, interval);
+          return Response.json({ data: result });
+        }
+
+        // OBS-9 (FINOPS P-B): cost by pipeline stage. Routes the EXISTING (but
+        // previously unrouted) `costByTaskType` — `sum by (task_type)(increase(
+        // cost[r]))` — with the OBS-9 zero-series filter applied at the query layer
+        // so the by-stage bar never renders the ~5 exact-0 phases. 503 when
+        // Prometheus is not configured (the P-B ChartCard degrades via the ladder).
+        if (url.pathname === "/api/otel/cost-by-stage") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "24h";
+          const result = await costByTaskType(prom, range);
+          return Response.json({ data: result });
+        }
+
+        // OBS-9 (FINOPS HERO): the today-vs-7d dollar band. todayUsd (spend since
+        // local midnight) + avg7dUsd (the prior 7 FULL days' mean baseline) + the
+        // delta fraction + a linear EOD projection — all off the cost counter, no
+        // new plumbing. The partial current day is EXCLUDED from the 7d baseline so
+        // "is today normal?" compares like-for-like. 503 when Prometheus is absent.
+        if (url.pathname === "/api/otel/cost-today") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const result = await costToday(prom);
+          if (result === null) {
+            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+          }
+          return Response.json({ data: result });
+        }
+
+        // OBS-9 (FINOPS P-A): hourly spend-over-time bars + spike flags. A
+        // query_range of `sum(increase(cost[1h]))` stepped at 1h over the window;
+        // each point carries `isSpike` (spend > max(2× median, μ+2σ) — the P-A
+        // `--chart-4` dot). 503 when Prometheus is absent; an honest `[]` for a
+        // quiet stack (the ChartCard empty state, never a fabricated bar).
+        if (url.pathname === "/api/otel/cost-series") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "24h";
+          const result = await costSeries(prom, range);
+          if (result === null) {
+            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+          }
+          return Response.json({ data: result });
+        }
+
+        // OBS-9 (FINOPS HERO-C, THE HEADLINE): cache-ROI $. Σ_model cacheRead_tokens
+        // × (input_price − cache_read_price) from a per-model price book — the real
+        // dollars the 99.8%-hit-rate prompt cache saved — plus the "(Nx)" multiplier
+        // (savings / actual spend). 503 when Prometheus is absent.
+        if (url.pathname === "/api/otel/cache-savings") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "24h";
+          const result = await cacheSavings(prom, range);
+          if (result === null) {
+            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+          }
           return Response.json({ data: result });
         }
 

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -209,6 +209,7 @@ import {
   costToday,
   costSeries,
   cacheSavings,
+  costAtHour,
   workerHistoryBySession,
   isValidCcSessionId,
   workerBurnSeries,
@@ -1933,6 +1934,27 @@ export function createServer(opts: CreateServerOptions): BunServer {
           if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
           const range = url.searchParams.get("range") ?? "24h";
           const result = await cacheSavings(prom, range);
+          if (result === null) {
+            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+          }
+          return Response.json({ data: result });
+        }
+
+        // OBS-10 (FINOPS P-A drill): cost at a single spiking hour. Clicking a
+        // spiking bar in the spend-over-time chart re-queries THAT hour's by-ticket
+        // + by-model split (the "one re-query with the hour window"). `hour` is the
+        // clicked bar's epoch-SECOND timestamp; the query anchors a 1h `increase()`
+        // window to it via PromQL `offset`. Both maps are zero-filtered. 503 when
+        // Prometheus is absent; 400 when `hour` is missing/non-numeric (never a
+        // fabricated empty drill).
+        if (url.pathname === "/api/otel/cost-at-hour") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const hourParam = url.searchParams.get("hour");
+          const hour = hourParam !== null ? Number(hourParam) : NaN;
+          if (!Number.isFinite(hour) || hour <= 0) {
+            return Response.json({ error: "hour (epoch seconds) required" }, { status: 400 });
+          }
+          const result = await costAtHour(prom, hour);
           if (result === null) {
             return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
           }

--- a/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
@@ -83,6 +83,13 @@ const TelemetrySurface = lazy(() =>
     default: m.TelemetrySurface,
   })),
 );
+// OBS-10: the OBSERVE FinOps surface. Lazy/code-split like Telemetry so the
+// chart-kit (recharts) chunk only loads when the operator is on FinOps.
+const FinopsSurface = lazy(() =>
+  import("./components/observe/finops-surface").then((m) => ({
+    default: m.FinopsSurface,
+  })),
+);
 
 type TopView = "dashboard" | "comms" | "activity" | "god-mode";
 
@@ -384,6 +391,14 @@ function SurfaceSwitch({ dashboard }: { dashboard: ReactNode }) {
     return (
       <Suspense fallback={<SkeletonDashboard />}>
         <TelemetrySurface />
+      </Suspense>
+    );
+  }
+  // OBS-10: the second OBSERVE surface. Same lazy/code-split branch as Telemetry.
+  if (kind === "finops") {
+    return (
+      <Suspense fallback={<SkeletonDashboard />}>
+        <FinopsSurface />
       </Suspense>
     );
   }

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
@@ -98,17 +98,18 @@ function StatusDot({ kind }: { kind: "live" | "anomaly" }) {
 }
 
 // ── OBSERVE — live items (clickable surfaces) ────────────────────────────────
-// OBS-5: Telemetry is the first OBSERVE surface to ship a real content shell, so
-// it is a clickable nav item (navigates to surface === "telemetry"). The other
-// four stay disabled "soon" until their own OBS tickets land.
+// OBS-5: Telemetry is the first OBSERVE surface to ship a real content shell.
+// OBS-10: FinOps is the second — the dollar+ROI hero + spend-over-time bars. Both
+// are clickable nav items; the remaining three stay disabled "soon" until their
+// own OBS tickets land.
 const OBSERVE_LIVE: Array<{ surface: Surface; label: string; icon: typeof InboxIcon }> = [
   { surface: "telemetry", label: "Telemetry", icon: ActivityIcon },
+  { surface: "finops", label: "FinOps", icon: WalletIcon },
 ];
 
 // ── OBSERVE — disabled "soon" items ──────────────────────────────────────────
 const OBSERVE_SOON = [
   { label: "Utilization", icon: GaugeIcon },
-  { label: "FinOps", icon: WalletIcon },
   { label: "Fleet Ops", icon: ServerIcon },
   { label: "DevOps", icon: CodeIcon },
 ] as const;

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/cost-breakdown-bars.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/cost-breakdown-bars.tsx
@@ -1,0 +1,121 @@
+// cost-breakdown-bars.tsx — the shared FINOPS ranked bar-row body for P-B
+// (cost by pipeline stage) and P-D (cost by model / agent), OBS-11.
+//
+// A metric-row "bar-horizontal" (Principle 9: FinOps = bar + donut + table;
+// Principle 10: table-driven), NOT a Recharts chart — each bar is a CSS-width div
+// whose fill is a categorical --chart-N token round-robin (Principle 8: chart
+// colors via token, never a hex/Tailwind color class on the fill). Rows are ranked
+// descending by spend (the operator's real question is "which stage/model costs
+// most" = ordering, not part-of-whole — that is why this is a bar, not a pie).
+//
+// Renders the LIVE state's children — the surrounding ChartCard (dataSource="[prom]")
+// owns the unconfigured / unreachable / empty honesty states. An empty rows array
+// never reaches here (the ChartCard's hasData gate shows the empty state first).
+
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { compactUsd } from "./finops-panels";
+import { barPercent } from "./telemetry-panels";
+import { rankCostMap, maxUsd, type CostRow } from "./finops-breakdowns";
+
+/** The six categorical chart tokens, round-robined across the ranked rows (NOT a
+ *  status color — these are categories, Principle 3). The top spender leads with
+ *  --chart-1 (brand blue). */
+const CHART_VARS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+] as const;
+
+export interface CostBreakdownBarsProps {
+  /** The label→USD cost map (e.g. /api/otel/cost-by-stage, or /api/otel/cost
+   *  grouped by model/agent). Zero-filtered + ranked here via rankCostMap. */
+  data: Record<string, number> | null;
+  /** Column header for the label, e.g. "stage" / "model" / "agent". */
+  labelHeader: string;
+  /** Optional click-to-drill on a row (the label is passed back). */
+  onSelect?: (label: string) => void;
+  /** Cap the rendered rows (default 12 — by-stage has ~12 task_types, by-model ~6). */
+  limit?: number;
+}
+
+function BreakdownRow({
+  row,
+  max,
+  colorVar,
+  total,
+  onSelect,
+}: {
+  row: CostRow;
+  max: number;
+  colorVar: string;
+  total: number;
+  onSelect?: () => void;
+}) {
+  const width = barPercent(row.usd, max);
+  const sharePct = total > 0 ? Math.round((row.usd / total) * 100) : 0;
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      disabled={!onSelect}
+      className={cn(
+        "group flex w-full items-center gap-3 px-3 py-1.5 text-left",
+        "border-b border-border/40 last:border-b-0",
+        onSelect ? "hover:bg-surface-1" : "cursor-default",
+      )}
+    >
+      <span className="w-32 shrink-0 truncate font-mono text-[11px] text-fg group-hover:text-accent">
+        {row.label}
+      </span>
+      <span className="relative h-2.5 flex-1 overflow-hidden rounded-sm bg-surface-3">
+        <span
+          className="absolute inset-y-0 left-0 rounded-sm"
+          style={{ width: `${width}%`, backgroundColor: colorVar }}
+        />
+      </span>
+      <span className="w-14 shrink-0 text-right font-mono text-[11px] tabular-nums text-fg">
+        {compactUsd(row.usd)}
+      </span>
+      <span className="w-9 shrink-0 text-right font-mono text-[10px] tabular-nums text-muted/70">
+        {sharePct}%
+      </span>
+    </button>
+  );
+}
+
+export function CostBreakdownBars({
+  data,
+  labelHeader,
+  onSelect,
+  limit = 12,
+}: CostBreakdownBarsProps) {
+  const rows = useMemo(() => rankCostMap(data).slice(0, limit), [data, limit]);
+  const max = useMemo(() => maxUsd(rows), [rows]);
+  const total = useMemo(() => rows.reduce((s, r) => s + r.usd, 0), [rows]);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-1.5">
+      <div className="flex items-center justify-between px-3 text-[10px] text-muted/70">
+        <span>{labelHeader} · spend</span>
+        <span>ranked ↓</span>
+      </div>
+      <ScrollArea className="min-h-0 flex-1 rounded-md border border-border bg-surface-0">
+        {rows.map((row, i) => (
+          <BreakdownRow
+            key={row.label}
+            row={row}
+            max={max}
+            total={total}
+            colorVar={CHART_VARS[i % CHART_VARS.length]!}
+            onSelect={onSelect ? () => onSelect(row.label) : undefined}
+          />
+        ))}
+      </ScrollArea>
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/expensive-tickets-table.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/expensive-tickets-table.tsx
@@ -1,0 +1,207 @@
+// expensive-tickets-table.tsx — the FINOPS P-C panel body (OBS-11, layout spec §2):
+// the sortable expensive-tickets table. The DEFAULT FinOps view (Principle 10:
+// table-driven by default; charts are the "explore" affordance).
+//
+// HONESTY (design §1/§2):
+//   - The rows come from /api/otel/cost via rankCostMap, which applies the MANDATORY
+//     zero-series filter at the data layer — a least-expensive sort can never render
+//     the ~24 exact-0 tickets as all-zeros garbage.
+//   - The $/point and $/PR columns are DEFERRED (need OBS-12 estimate write-through):
+//     they render as DIMMED locked column headers with a "needs estimate sync"
+//     tooltip + an em-dash cell — never a fabricated number, and never hidden (which
+//     would shift the table width when OBS-12 lands).
+//   - Each row carries a proportional magnitude bar (real data: the row's share of
+//     the top spender) — NOT a fabricated time-series sparkline. /api/otel/cost
+//     returns a scalar per ticket; inventing a per-row trend line would be dishonest.
+//
+// Row click → the ticket detail page (the CTL-918 telemetry strip) via the same
+// `window.location.assign(ticketDetailHref(...))` idiom the telemetry surface uses
+// for its worker drill.
+
+import { useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import { ArrowDown, ArrowUp, Lock } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { formatUsd } from "./finops-panels";
+import { barPercent } from "./telemetry-panels";
+import { rankCostMap, maxUsd, type CostRow } from "./finops-breakdowns";
+import { ticketDetailHref } from "@/board/detail-nav";
+
+type SortKey = "label" | "usd";
+type SortDir = "asc" | "desc";
+
+export interface ExpensiveTicketsTableProps {
+  /** /api/otel/cost payload (linear_key → USD). Zero-filtered + ranked here. */
+  data: Record<string, number> | null;
+  /** Cap the rendered rows (default 10 — the layout spec's ranked-10). */
+  limit?: number;
+}
+
+/** Sort the zero-filtered rows by the active key/dir. $ sort is the default
+ *  (descending = most-expensive-first, the panel's question). */
+function sortRows(rows: CostRow[], key: SortKey, dir: SortDir): CostRow[] {
+  const sorted = [...rows].sort((a, b) => {
+    if (key === "label") return a.label.localeCompare(b.label);
+    return a.usd - b.usd;
+  });
+  return dir === "desc" ? sorted.reverse() : sorted;
+}
+
+/** The dimmed "needs estimate sync" locked column header (OBS-12). Renders the
+ *  header text greyed with a lock + a tooltip explaining what unlocks it — never
+ *  hidden (so the table width is stable when OBS-12 lands). */
+function LockedHeader({ label }: { label: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex items-center gap-1 text-muted/50">
+          <Lock className="h-2.5 w-2.5" aria-hidden />
+          {label}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-[220px] text-[11px]">
+        Needs estimate sync (OBS-12). $ per point + $ per merged PR appear once the
+        estimate write-through lands — never imputed.
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function SortHeader({
+  label,
+  active,
+  dir,
+  onClick,
+  className,
+}: {
+  label: string;
+  active: boolean;
+  dir: SortDir;
+  onClick: () => void;
+  className?: string;
+}) {
+  const Icon = dir === "desc" ? ArrowDown : ArrowUp;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1 font-medium hover:text-fg",
+        active ? "text-fg" : "text-muted",
+        className,
+      )}
+    >
+      {label}
+      {active && <Icon className="h-3 w-3" />}
+    </button>
+  );
+}
+
+export function ExpensiveTicketsTable({
+  data,
+  limit = 10,
+}: ExpensiveTicketsTableProps) {
+  const [sortKey, setSortKey] = useState<SortKey>("usd");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const ranked = useMemo(() => rankCostMap(data), [data]);
+  const max = useMemo(() => maxUsd(ranked), [ranked]);
+  const rows = useMemo(
+    () => sortRows(ranked, sortKey, sortDir).slice(0, limit),
+    [ranked, sortKey, sortDir, limit],
+  );
+
+  function toggle(key: SortKey) {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "desc" ? "asc" : "desc"));
+    } else {
+      setSortKey(key);
+      setSortDir(key === "usd" ? "desc" : "asc");
+    }
+  }
+
+  return (
+    <ScrollArea className="h-full min-h-0 rounded-md border border-border bg-surface-0">
+      <Table className="text-[12px]">
+        <TableHeader>
+          <TableRow className="border-border/60 hover:bg-transparent">
+            <TableHead className="h-9 px-3 py-0 text-[11px]">
+              <SortHeader
+                label="ticket"
+                active={sortKey === "label"}
+                dir={sortDir}
+                onClick={() => toggle("label")}
+              />
+            </TableHead>
+            <TableHead className="h-9 px-2 py-0 text-right text-[11px]">
+              <SortHeader
+                label="spend"
+                active={sortKey === "usd"}
+                dir={sortDir}
+                onClick={() => toggle("usd")}
+                className="justify-end"
+              />
+            </TableHead>
+            <TableHead className="h-9 w-[88px] px-2 py-0 text-[11px]">
+              {/* proportional magnitude bar header (no sort) */}
+              <span className="text-muted/60">share</span>
+            </TableHead>
+            <TableHead className="h-9 px-2 py-0 text-right text-[11px]">
+              <LockedHeader label="$/pt" />
+            </TableHead>
+            <TableHead className="h-9 px-2 py-0 text-right text-[11px]">
+              <LockedHeader label="$/PR" />
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow
+              key={row.label}
+              className="h-10 cursor-pointer border-border/40"
+              onClick={() => window.location.assign(ticketDetailHref(row.label))}
+            >
+              <TableCell className="px-3 py-0 font-mono text-[12px] text-fg">
+                {row.label}
+              </TableCell>
+              <TableCell className="px-2 py-0 text-right font-mono tabular-nums text-fg">
+                {formatUsd(row.usd)}
+              </TableCell>
+              <TableCell className="px-2 py-0">
+                <span className="relative block h-2 w-full overflow-hidden rounded-sm bg-surface-3">
+                  <span
+                    className="absolute inset-y-0 left-0 rounded-sm"
+                    style={{
+                      width: `${barPercent(row.usd, max)}%`,
+                      backgroundColor: "var(--chart-1)",
+                    }}
+                  />
+                </span>
+              </TableCell>
+              {/* DEFERRED — dimmed em-dash, never a fabricated number (OBS-12). */}
+              <TableCell className="px-2 py-0 text-right font-mono text-muted/40">
+                —
+              </TableCell>
+              <TableCell className="px-2 py-0 text-right font-mono text-muted/40">
+                —
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </ScrollArea>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-breakdowns.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-breakdowns.test.ts
@@ -1,0 +1,201 @@
+// finops-breakdowns.test.ts — units for the OBS-11 FINOPS breakdown pure logic
+// (finops-breakdowns.ts). The load-bearing honesty invariants:
+//   1. rankCostMap applies the MANDATORY zero-series filter (drop usd <= 0) — the
+//      caught-a-shipped-bug discipline; a ranked view of raw /api/otel/cost would
+//      otherwise render all-zeros garbage.
+//   2. toTokenSlices NEVER collapses cache into input — always four fixed buckets.
+//   3. concentration ("top 3 = N%") and worstDrift (A8) are honest on empty input.
+//
+// All pure (no React render), so they run under the ui package's `bun test`:
+//   cd ui && bun test src/components/observe/finops-breakdowns.test.ts
+import { describe, it, expect } from "bun:test";
+import type { CostValidationRow } from "@/lib/types";
+import {
+  rankCostMap,
+  maxUsd,
+  totalUsd,
+  toTokenSlices,
+  hasTokenData,
+  compactTokens,
+  tokenBucketLabel,
+  formatHitRate,
+  concentration,
+  worstDrift,
+  TOKEN_BUCKETS,
+} from "./finops-breakdowns";
+
+describe("rankCostMap — the mandatory zero-series filter", () => {
+  it("drops exact-0 series and ranks the rest descending", () => {
+    // The live /api/otel/cost shape: many exact-0 tickets mixed with real spend.
+    const map = {
+      "CTL-693": 0,
+      "CTL-850": 586.54,
+      "CTL-862": 0,
+      "CTL-928": 403.91,
+      "ADV-1294": 0,
+      "CTL-696": 42.71,
+    };
+    const rows = rankCostMap(map);
+    expect(rows.map((r) => r.label)).toEqual(["CTL-850", "CTL-928", "CTL-696"]);
+    expect(rows[0]!.usd).toBe(586.54);
+    // not a single zero series survived (the all-zeros-garbage guard).
+    expect(rows.every((r) => r.usd > 0)).toBe(true);
+  });
+
+  it("drops negative and non-finite values too", () => {
+    const rows = rankCostMap({ A: -5, B: NaN, C: 10, D: Infinity });
+    expect(rows.map((r) => r.label)).toEqual(["C"]);
+  });
+
+  it("null / empty map → empty rows (no fabricated row)", () => {
+    expect(rankCostMap(null)).toEqual([]);
+    expect(rankCostMap({})).toEqual([]);
+    // an all-zero map (a quiet window) is honestly empty, not a forest of $0 bars.
+    expect(rankCostMap({ A: 0, B: 0 })).toEqual([]);
+  });
+});
+
+describe("maxUsd + totalUsd", () => {
+  it("max is the top row's spend; total sums all", () => {
+    const rows = rankCostMap({ A: 100, B: 40, C: 10 });
+    expect(maxUsd(rows)).toBe(100);
+    expect(totalUsd(rows)).toBe(150);
+  });
+
+  it("empty rows → 0 (no divide-by-zero for the bar scale)", () => {
+    expect(maxUsd([])).toBe(0);
+    expect(totalUsd([])).toBe(0);
+  });
+});
+
+describe("toTokenSlices — NEVER collapse cache into input", () => {
+  // The live /api/otel/tokens shape: cacheRead dwarfs every other bucket.
+  const tokens = {
+    input: 6_698_817,
+    output: 9_259_550,
+    cacheRead: 1_326_434_860,
+    cacheCreation: 50_556_358,
+  };
+
+  it("keeps all four buckets separate, in fixed order", () => {
+    const slices = toTokenSlices(tokens);
+    expect(slices.map((s) => s.bucket)).toEqual([
+      "input",
+      "output",
+      "cacheRead",
+      "cacheCreation",
+    ]);
+    // cacheRead is its OWN bucket — never folded into input.
+    const cacheRead = slices.find((s) => s.bucket === "cacheRead")!;
+    const input = slices.find((s) => s.bucket === "input")!;
+    expect(cacheRead.tokens).toBe(1_326_434_860);
+    expect(input.tokens).toBe(6_698_817);
+    expect(cacheRead.tokens).toBeGreaterThan(input.tokens * 100);
+  });
+
+  it("shares sum to ~1 and reflect the real split (cacheRead ~96%)", () => {
+    const slices = toTokenSlices(tokens);
+    const sum = slices.reduce((s, x) => s + x.share, 0);
+    expect(sum).toBeCloseTo(1, 6);
+    const cacheRead = slices.find((s) => s.bucket === "cacheRead")!;
+    expect(cacheRead.share).toBeGreaterThan(0.9);
+  });
+
+  it("ALWAYS returns four slices, even for a partial / null map", () => {
+    // A map missing two buckets still yields four slices (absent → 0, never dropped).
+    const partial = toTokenSlices({ input: 100, output: 50 });
+    expect(partial).toHaveLength(4);
+    expect(partial.find((s) => s.bucket === "cacheRead")!.tokens).toBe(0);
+
+    const nul = toTokenSlices(null);
+    expect(nul).toHaveLength(4);
+    expect(nul.every((s) => s.tokens === 0 && s.share === 0)).toBe(true);
+  });
+
+  it("TOKEN_BUCKETS is exactly the four canonical buckets", () => {
+    expect([...TOKEN_BUCKETS]).toEqual([
+      "input",
+      "output",
+      "cacheRead",
+      "cacheCreation",
+    ]);
+  });
+});
+
+describe("hasTokenData", () => {
+  it("true when any bucket is positive; false for null / all-zero", () => {
+    expect(hasTokenData({ cacheRead: 5 })).toBe(true);
+    expect(hasTokenData(null)).toBe(false);
+    expect(hasTokenData({ input: 0, output: 0 })).toBe(false);
+  });
+});
+
+describe("compactTokens + tokenBucketLabel + formatHitRate", () => {
+  it("compacts to B/M/k", () => {
+    expect(compactTokens(1_326_434_860)).toBe("1.3B");
+    expect(compactTokens(50_556_358)).toBe("50.6M");
+    expect(compactTokens(9_259)).toBe("9.3k");
+    expect(compactTokens(42)).toBe("42");
+    expect(compactTokens(NaN)).toBe("0");
+  });
+
+  it("labels cache buckets in plain language", () => {
+    expect(tokenBucketLabel("cacheRead")).toBe("cache read");
+    expect(tokenBucketLabel("cacheCreation")).toBe("cache write");
+    expect(tokenBucketLabel("input")).toBe("input");
+  });
+
+  it("formats the hit rate; null → '—'", () => {
+    expect(formatHitRate(0.994975)).toBe("99.5%");
+    expect(formatHitRate(null)).toBe("—");
+    expect(formatHitRate(Infinity)).toBe("—");
+  });
+});
+
+describe("concentration — footer A4 'top 3 = N% of spend'", () => {
+  it("computes the top-3 share over ranked rows", () => {
+    const rows = rankCostMap({
+      "CTL-850": 586,
+      "CTL-928": 404,
+      "ADV-1121": 314,
+      "ADR-0045": 48,
+      "CTL-696": 43,
+    });
+    const c = concentration(rows, 3);
+    expect(c.count).toBe(3);
+    // (586+404+314) / 1395 ≈ 0.792
+    expect(c.share).toBeCloseTo((586 + 404 + 314) / (586 + 404 + 314 + 48 + 43), 4);
+    expect(c.totalUsd).toBe(586 + 404 + 314 + 48 + 43);
+  });
+
+  it("counts fewer than N honestly when there are fewer tickets", () => {
+    const rows = rankCostMap({ A: 10, B: 5 });
+    const c = concentration(rows, 3);
+    expect(c.count).toBe(2);
+    expect(c.share).toBe(1);
+  });
+
+  it("empty rows → 0 share / 0 count (footer shows '—')", () => {
+    const c = concentration([], 3);
+    expect(c).toEqual({ count: 0, share: 0, totalUsd: 0 });
+  });
+});
+
+describe("worstDrift — footer A8 signal-vs-OTEL data-trust", () => {
+  const rows: CostValidationRow[] = [
+    { ticket: "CTL-850", signalCost: 580, otelCost: 586, discrepancy: 6 },
+    { ticket: "CTL-928", signalCost: 404, otelCost: 404, discrepancy: 0 },
+    { ticket: "CTL-696", signalCost: 30, otelCost: 43, discrepancy: 13 },
+  ];
+
+  it("picks the largest absolute discrepancy", () => {
+    const w = worstDrift(rows);
+    expect(w?.ticket).toBe("CTL-696");
+    expect(w?.discrepancy).toBe(13);
+  });
+
+  it("null / empty → null (footer shows '—', never a fabricated $0)", () => {
+    expect(worstDrift(null)).toBeNull();
+    expect(worstDrift([])).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-breakdowns.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-breakdowns.ts
@@ -1,0 +1,191 @@
+// finops-breakdowns.ts — PURE data-shaping for the OBS-11 FINOPS breakdown panels.
+// DOM-/React-free so every numeric decision (the mandatory zero-filter, the ranked
+// rows, the 4-bucket token split, the concentration share, the worst-drift pick)
+// unit-tests directly under the ui package's `bun test` — the same discipline
+// finops-panels.ts / telemetry-panels.ts follow. The panel components are skin only.
+//
+// FinOps's soul is HONESTY (design §2):
+//   - ZERO-SERIES FILTER is mandatory on every cost map. /api/otel/cost returns many
+//     increase()==0 series in-window; a ranked/least-expensive view without a > 0
+//     filter renders all-zeros garbage. We re-filter here belt-and-braces even though
+//     the server already filters at the query layer.
+//   - NEVER collapse cache tokens into "input". input / output / cacheRead /
+//     cacheCreation are ALWAYS four separate buckets (collapsing over-reports 35-50%).
+//   - DEGRADE honestly: an empty map is an empty array (the ChartCard renders the
+//     honest empty state), never a fabricated row.
+
+import type { CostValidationRow } from "@/lib/types";
+
+// ── ranked cost rows (P-C expensive tickets, P-B by-stage, P-D by-model/agent) ──
+
+/** One ranked breakdown row: the label (ticket / stage / model / agent) and its
+ *  USD spend. Rows are always zero-filtered + descending. */
+export interface CostRow {
+  /** The category label: linear_key, task_type, model, or agent_name. */
+  label: string;
+  /** The category's spend over the window, USD (> 0 — zero rows are dropped). */
+  usd: number;
+}
+
+/** Rank a label→USD cost map into descending rows with the MANDATORY zero-series
+ *  filter applied (drop value <= 0, and any non-finite). PURE — a null/empty map is
+ *  an empty array (the ChartCard renders the honest empty state, never a fabricated
+ *  row). This is the single choke point every cost breakdown flows through, so the
+ *  zero-filter can never be forgotten by a panel. */
+export function rankCostMap(map: Record<string, number> | null): CostRow[] {
+  if (!map) return [];
+  return Object.entries(map)
+    .filter(([, usd]) => Number.isFinite(usd) && usd > 0)
+    .map(([label, usd]) => ({ label, usd }))
+    .sort((a, b) => b.usd - a.usd);
+}
+
+/** The largest USD in a ranked row set (for the bar scale). 0 for an empty set —
+ *  barPercent then renders empty bars, never a divide-by-zero. PURE. */
+export function maxUsd(rows: CostRow[]): number {
+  return rows.reduce((m, r) => (r.usd > m ? r.usd : m), 0);
+}
+
+/** Sum the USD across ranked rows (the breakdown total). PURE. */
+export function totalUsd(rows: CostRow[]): number {
+  return rows.reduce((s, r) => s + r.usd, 0);
+}
+
+// ── P-D by-model / by-agent toggle ──────────────────────────────────────────────
+
+/** The P-D grouping axis: native Prometheus cost labels. `model` is the model mix
+ *  (which model costs most); `agent` is `agent_name` (workflow-subagent vs
+ *  general-purpose vs … — the closest real "what machinery costs most" signal,
+ *  design §3.3 #9b). Both are RANKED BARS, never pies (Principle 9: model/agent
+ *  counts are unbounded + rankable → bar-horizontal, not a part-of-whole pie). */
+export type CostDimension = "model" | "agent";
+
+// ── P-E token-type split (the 4-bucket donut) ───────────────────────────────────
+
+/** The four FIXED token buckets, in display order. They are NEVER collapsed — the
+ *  donut always shows all four (input/output/cacheRead/cacheCreation), each its own
+ *  --chart-N category. Collapsing cache into input over-reports cost 35-50%. */
+export const TOKEN_BUCKETS = [
+  "input",
+  "output",
+  "cacheRead",
+  "cacheCreation",
+] as const;
+
+export type TokenBucket = (typeof TOKEN_BUCKETS)[number];
+
+/** One token-bucket slice for the P-E donut: the bucket name, its token count, and
+ *  its share of the 4-bucket total (0..1). share is 0 when the total is 0 (no
+ *  divide-by-zero); a bucket absent from the source map is shown as 0 (never
+ *  dropped — the donut always has four slices so the part-of-whole is honest). */
+export interface TokenSlice {
+  bucket: TokenBucket;
+  tokens: number;
+  /** Fraction of the 4-bucket total (0..1). */
+  share: number;
+}
+
+/** Shape a `type → tokens` map (from /api/otel/tokens) into the four fixed donut
+ *  slices, in TOKEN_BUCKETS order, with each slice's share of the total. PURE.
+ *  A null/empty map yields four zero slices (the ChartCard's hasData gate then
+ *  renders the empty state — we still never collapse or drop a bucket). The
+ *  cacheRead bucket is enormous live (~99% of tokens) — that is the whole point of
+ *  the cache-ROI story and must NOT be folded into input. */
+export function toTokenSlices(map: Record<string, number> | null): TokenSlice[] {
+  const tokensOf = (b: TokenBucket): number => {
+    const v = map?.[b];
+    return typeof v === "number" && Number.isFinite(v) && v > 0 ? v : 0;
+  };
+  const counts = TOKEN_BUCKETS.map(tokensOf);
+  const total = counts.reduce((s, n) => s + n, 0);
+  return TOKEN_BUCKETS.map((bucket, i) => ({
+    bucket,
+    tokens: counts[i]!,
+    share: total > 0 ? counts[i]! / total : 0,
+  }));
+}
+
+/** Whether a token map carries ANY positive bucket (the P-E hasData gate). A null
+ *  map or an all-zero map is "no data" → the ChartCard empty state. PURE. */
+export function hasTokenData(map: Record<string, number> | null): boolean {
+  return toTokenSlices(map).some((s) => s.tokens > 0);
+}
+
+/** Compact a token count: 1_326_434_860 → "1.3B", 50_556_358 → "50.6M",
+ *  6_698_817 → "6.7M", 9_259 → "9.3k". A non-finite input → "0". PURE. */
+export function compactTokens(n: number): string {
+  if (!Number.isFinite(n)) return "0";
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
+  if (abs >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(Math.round(n));
+}
+
+/** A human bucket label for the donut legend / center copy. PURE. */
+export function tokenBucketLabel(bucket: TokenBucket): string {
+  switch (bucket) {
+    case "input":
+      return "input";
+    case "output":
+      return "output";
+    case "cacheRead":
+      return "cache read";
+    case "cacheCreation":
+      return "cache write";
+  }
+}
+
+/** Format a cache hit rate (0..1) as a one-decimal percent for the donut center,
+ *  e.g. "99.5%". null → "—" (no rate to show — honest, never a fabricated 0%).
+ *  PURE. */
+export function formatHitRate(rate: number | null): string {
+  if (rate === null || !Number.isFinite(rate)) return "—";
+  return `${(rate * 100).toFixed(1)}%`;
+}
+
+// ── footer A4: concentration ("top 3 tickets = N% of spend") ────────────────────
+
+/** The concentration read-out: the top-N share of total spend + the N actually
+ *  counted (so the copy is honest when fewer than N tickets exist). */
+export interface Concentration {
+  /** How many top tickets the share covers (≤ topN, ≤ the live ticket count). */
+  count: number;
+  /** The topN tickets' share of total spend, 0..1. 0 when there is no spend. */
+  share: number;
+  /** Total spend across all ranked tickets, USD. */
+  totalUsd: number;
+}
+
+/** Compute the top-N concentration share over ranked cost rows. PURE. The rows MUST
+ *  already be zero-filtered + descending (rankCostMap). An empty set → 0 share over
+ *  0 count (the footer shows "—", never a fabricated number). Defaults to the top 3
+ *  (design §3.3 footer A4: "top 3 tickets = 61% of spend"). */
+export function concentration(rows: CostRow[], topN = 3): Concentration {
+  const total = totalUsd(rows);
+  if (total <= 0 || rows.length === 0) {
+    return { count: 0, share: 0, totalUsd: 0 };
+  }
+  const top = rows.slice(0, topN);
+  const topSum = totalUsd(top);
+  return { count: top.length, share: topSum / total, totalUsd: total };
+}
+
+// ── footer A8: cost-validation drift ────────────────────────────────────────────
+
+/** The worst (largest-absolute) signal-vs-OTEL discrepancy, the A8 data-trust
+ *  footer number. The rows are /api/otel/cost-validation entries; we pick the max
+ *  |discrepancy| so the footer surfaces the single worst measurement disagreement.
+ *  PURE. null when there are no rows (the footer shows "—", never a fabricated $0
+ *  that would falsely claim perfect agreement). */
+export function worstDrift(
+  rows: CostValidationRow[] | null,
+): CostValidationRow | null {
+  if (!rows || rows.length === 0) return null;
+  let worst: CostValidationRow | null = null;
+  for (const row of rows) {
+    if (!Number.isFinite(row.discrepancy)) continue;
+    if (worst === null || row.discrepancy > worst.discrepancy) worst = row;
+  }
+  return worst;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-footer.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-footer.tsx
@@ -1,0 +1,86 @@
+// finops-footer.tsx — the FINOPS footer strip (OBS-11, layout spec §2 footer):
+// a single dense row of data-trust read-outs, NOT panels (counts toward density,
+// not the ≤8 element budget — it reads as one strip).
+//
+//   A4 Concentration — "top 3 tickets = N% of spend" (topk share over /api/otel/cost).
+//   A8 Cost-validation drift — the worst signal-file-vs-OTEL Δ$ (/api/otel/cost-
+//      validation). A data-trust footer: best-in-class dashboards surface their own
+//      measurement error.
+//   $/story-point — DEFERRED (locked): needs OBS-12 estimate write-through. Rendered
+//      as a dimmed, dashed, plain-language locked chip occupying its real footprint —
+//      NEVER a blank or a fabricated number (Principle 6).
+//
+// HONESTY: every number flows through the pure helpers (concentration / worstDrift),
+// each of which returns an honest "—" / null on empty input — no fabricated $0 that
+// would falsely claim "no concentration" or "perfect signal agreement".
+
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { Lock } from "lucide-react";
+import { compactUsd, formatUsd } from "./finops-panels";
+import {
+  rankCostMap,
+  concentration,
+  worstDrift,
+} from "./finops-breakdowns";
+import type { CostValidationRow } from "@/lib/types";
+
+export interface FinopsFooterProps {
+  /** /api/otel/cost map — the A4 concentration source. */
+  cost: Record<string, number> | null;
+  /** /api/otel/cost-validation rows — the A8 drift source. */
+  validation: CostValidationRow[] | null;
+}
+
+function FooterCell({
+  label,
+  children,
+  className,
+}: {
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex min-w-0 flex-col gap-0.5", className)}>
+      <span className="text-[9px] font-medium uppercase tracking-wide text-muted/60">
+        {label}
+      </span>
+      <span className="truncate font-mono text-[12px] tabular-nums text-fg">
+        {children}
+      </span>
+    </div>
+  );
+}
+
+export function FinopsFooter({ cost, validation }: FinopsFooterProps) {
+  const conc = useMemo(() => concentration(rankCostMap(cost), 3), [cost]);
+  const drift = useMemo(() => worstDrift(validation), [validation]);
+
+  const concText =
+    conc.count > 0
+      ? `top ${conc.count} = ${Math.round(conc.share * 100)}% of ${compactUsd(conc.totalUsd)}`
+      : "—";
+
+  const driftText = drift
+    ? `${drift.ticket} Δ${formatUsd(drift.discrepancy)}`
+    : "—";
+
+  return (
+    <div className="flex flex-wrap items-stretch gap-x-8 gap-y-3 rounded-md border border-border bg-surface-1/40 px-4 py-2.5">
+      <FooterCell label="A4 · concentration">{concText}</FooterCell>
+      <FooterCell label="A8 · signal vs otel drift">{driftText}</FooterCell>
+
+      {/* DEFERRED — $/story-point. A dimmed dashed locked chip (Principle 6). */}
+      <div className="flex min-w-0 flex-col gap-0.5 rounded-sm border border-dashed border-border/60 px-2 py-1 opacity-60">
+        <span className="flex items-center gap-1 text-[9px] font-medium uppercase tracking-wide text-muted/60">
+          <Lock className="h-2.5 w-2.5" aria-hidden />
+          $/story-point
+        </span>
+        <span className="truncate text-[11px] text-muted">
+          needs estimate sync (OBS-12)
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-hero.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-hero.tsx
@@ -1,0 +1,166 @@
+// finops-hero.tsx — the FINOPS hero dollar+ROI band (OBS-10, layout spec §1).
+//
+// The surface's ONE answer (Principle 1): "How much did I spend today, and is that
+// normal?" Three KPIs on one full-width line, with the cache-ROI number visually
+// the LOUDEST (it is the single most motivating FinOps figure — a 99.8%-hit-rate
+// prompt cache saved real dollars):
+//
+//   TODAY  $470  ▲-10% vs 7d avg ($524/day)  ·  proj EOD $1.3k  ·  CACHE SAVED $5,237 (3.5×)
+//
+// Dollars LEAD; tokens are demoted to a later panel (P-E). Color discipline
+// (Principle 3): the ONLY status color in the hero is the today-vs-avg delta badge
+// (spend up = bad/amber via KpiNumber's deltaDirection="up-bad"→ we pass the delta
+// so a RISING spend reads red). The cache-saved number is the green accent (a WIN,
+// deltaless — its size + color carry the emphasis, not a delta pill).
+//
+// Honesty (Principle 6): the whole band is wrapped by the caller in a single
+// <ChartCard dataSource="[prom]"> so a no-Prometheus install shows the configure
+// CTA and the band NEVER fabricates a number. The locked dual-currency quota chip
+// renders as a clearly-labeled dimmed placeholder ("quota — needs ratelimit
+// reader"), NOT a fake number — it lights up after OBS-15.
+
+import { cn } from "@/lib/utils";
+import { KpiNumber } from "@/components/observe/kpi-number";
+import { Badge } from "@/components/ui/badge";
+import { Lock } from "lucide-react";
+import {
+  formatUsd,
+  compactUsd,
+  formatDeltaPercent,
+  deltaPercentValue,
+  formatMultiplier,
+} from "./finops-panels";
+import type { CostTodaySummary, CacheSavings } from "@/lib/types";
+
+export interface FinopsHeroProps {
+  /** /api/otel/cost-today — today's spend + 7d baseline + EOD projection. null
+   *  while loading (the band renders dashes, never a fabricated 0). */
+  today: CostTodaySummary | null;
+  /** /api/otel/cache-savings — the cache-ROI headline. null while loading. */
+  cache: CacheSavings | null;
+}
+
+/** A small neutral KPI slot (EOD projection): label above, value below. Never
+ *  colored — it is informational, never a status (layout spec §1 Hero-B). */
+function HeroSlot({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[11px] font-medium uppercase tracking-wide text-muted/70">
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+export function FinopsHero({ today, cache }: FinopsHeroProps) {
+  // today-vs-avg delta. KpiNumber renders the arrow off the delta SIGN; we pass
+  // deltaDirection="up-good"=false → "down-good" would mislabel, so we use the
+  // explicit semantics: spend UP is BAD. KpiNumber has up-good/down-good/neutral;
+  // for "rising spend = bad" we want a RISING delta to read RED → that is the
+  // mirror of "up-good", i.e. down-good (a falling cost is good = green). So a
+  // rising (positive) delta under down-good reads red, exactly the budget signal.
+  const deltaPct = today ? deltaPercentValue(today.deltaFraction) : undefined;
+  const avgLabel =
+    today && today.avg7dUsd > 0
+      ? `vs 7d avg (${compactUsd(today.avg7dUsd)}/day)`
+      : "no 7d baseline yet";
+
+  const multiplier = cache ? formatMultiplier(cache.multiplier) : "";
+
+  return (
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      {/* Hero-A — TODAY spend (the primary number) + the today-vs-avg delta badge
+          (the ONE allowed status color in the hero: rising spend reads red via
+          down-good semantics). */}
+      <div className="flex flex-col gap-1">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-muted/70">
+          Today
+        </span>
+        <KpiNumber
+          value={today?.todayUsd ?? 0}
+          unit="$"
+          unitPosition="prefix"
+          delta={deltaPct}
+          deltaLabel={avgLabel}
+          // down-good = a falling cost is green / a rising cost is red — the
+          // over-budget signal (layout spec §1: "amber when over-budget trending").
+          deltaDirection="down-good"
+        />
+      </div>
+
+      {/* the · separators + the supporting slots, right-aligned on desktop. */}
+      <div className="flex flex-wrap items-center gap-x-8 gap-y-4">
+        {/* Hero-B — EOD projection (neutral, never colored — informational). */}
+        <HeroSlot label="proj EOD">
+          <span className="font-mono text-xl font-semibold tabular-nums text-fg">
+            {today ? formatUsd(today.projectionEodUsd) : "—"}
+          </span>
+        </HeroSlot>
+
+        {/* Hero-C — CACHE SAVED (THE HEADLINE). Green --chart-2 accent + the
+            "(Nx)" multiplier so it reads as the win. Deltaless (its size + color
+            carry the emphasis); honest "—" while loading, drops "(Nx)" when there
+            is no spend to multiply. */}
+        <div className="flex flex-col gap-1">
+          <span className="text-[11px] font-medium uppercase tracking-wide text-muted/70">
+            Cache saved today
+          </span>
+          <div className="flex items-baseline gap-2">
+            <span
+              className="font-mono text-3xl font-bold leading-none tabular-nums"
+              style={{ color: "var(--chart-2)" }}
+            >
+              {cache ? formatUsd(cache.savedUsd) : "—"}
+            </span>
+            {multiplier && (
+              <span
+                className="font-mono text-base font-semibold"
+                style={{ color: "var(--chart-2)" }}
+              >
+                ({multiplier})
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Locked dual-currency quota chip (DEFERRED — render honestly, never a
+            fake number; layout spec §3). Dashed, dimmed, lock icon + the plain-
+            language "what unlocks this" copy. Lights up after OBS-15. */}
+        <QuotaChipLocked />
+      </div>
+    </div>
+  );
+}
+
+/** The deferred dual-currency quota chip. No endpoint reads the
+ *  `account.ratelimit.sampled` events server-side yet (needs the OBS-15 event-log
+ *  read-model), so this is a LOCKED placeholder — dashed border, dimmed, lock icon,
+ *  and a tooltip that explains what lights it up. NEVER a fabricated quota number
+ *  (design §2 / layout spec §3). */
+export function QuotaChipLocked() {
+  return (
+    <div
+      className={cn(
+        "flex max-w-[15rem] items-center gap-2 rounded-md border border-dashed border-border/70 px-3 py-1.5",
+        "opacity-60",
+      )}
+      title="Quota burn — enable the event-log reader (OBS-15) to show 5h/7d quota beside dollars. On Max plans quota is the real budget."
+    >
+      <Lock className="h-3.5 w-3.5 shrink-0 text-muted" />
+      <div className="flex flex-col leading-tight">
+        <span className="text-[11px] font-medium text-muted">quota</span>
+        <span className="text-[10px] text-muted/70">needs ratelimit reader</span>
+      </div>
+      <Badge variant="outline" className="ml-auto font-mono text-[9px] text-muted/60">
+        OBS-15
+      </Badge>
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-kit.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-kit.test.ts
@@ -1,0 +1,124 @@
+// finops-kit.test.ts — units for the OBS-10 FINOPS pure logic (finops-panels.ts):
+//   1. dollar / percent / multiplier formatters (the hero copy + dense rows)
+//   2. delta semantics (null baseline → "—", never a fabricated 0%)
+//   3. spend-bar shaping + spike count (the P-A chart data, spike flags preserved)
+//
+// All pure (no React render), so they run under the ui package's `bun test`:
+//   cd ui && bun test src/components/observe/finops-kit.test.ts
+import { describe, it, expect } from "bun:test";
+import type { CostSeriesPoint } from "@/lib/types";
+import {
+  formatUsd,
+  compactUsd,
+  formatDeltaPercent,
+  deltaPercentValue,
+  formatMultiplier,
+  hourLabel,
+  toSpendBars,
+  spikeCount,
+} from "./finops-panels";
+
+describe("formatUsd", () => {
+  it("drops cents above $100 (a glance number)", () => {
+    expect(formatUsd(469.85)).toBe("$470");
+    expect(formatUsd(1323.27)).toBe("$1,323");
+  });
+
+  it("keeps one decimal in the $10–$100 band and two below $10", () => {
+    expect(formatUsd(42.5)).toBe("$42.5");
+    expect(formatUsd(7.03)).toBe("$7.03");
+  });
+
+  it("a thousands separator above 1000", () => {
+    expect(formatUsd(5236.89)).toBe("$5,237");
+  });
+
+  it("non-finite → $0 (honest, never NaN)", () => {
+    expect(formatUsd(NaN)).toBe("$0");
+    expect(formatUsd(Infinity)).toBe("$0");
+  });
+});
+
+describe("compactUsd", () => {
+  it("compacts thousands and millions", () => {
+    expect(compactUsd(1607.43)).toBe("$1.6k");
+    expect(compactUsd(588)).toBe("$588");
+    expect(compactUsd(22)).toBe("$22");
+    expect(compactUsd(2_400_000)).toBe("$2.4M");
+  });
+
+  it("non-finite → $0", () => {
+    expect(compactUsd(NaN)).toBe("$0");
+  });
+});
+
+describe("formatDeltaPercent + deltaPercentValue", () => {
+  it("signs a positive delta and rounds", () => {
+    expect(formatDeltaPercent(0.384)).toBe("+38%");
+    expect(deltaPercentValue(0.384)).toBe(38);
+  });
+
+  it("renders a negative delta without a + sign", () => {
+    expect(formatDeltaPercent(-0.1034)).toBe("-10%");
+    expect(deltaPercentValue(-0.1034)).toBe(-10);
+  });
+
+  it("null baseline → '—' string and undefined value (no fabricated 0%)", () => {
+    expect(formatDeltaPercent(null)).toBe("—");
+    expect(deltaPercentValue(null)).toBeUndefined();
+  });
+
+  it("non-finite → '—' / undefined", () => {
+    expect(formatDeltaPercent(Infinity)).toBe("—");
+    expect(deltaPercentValue(NaN)).toBeUndefined();
+  });
+});
+
+describe("formatMultiplier", () => {
+  it("renders the (Nx) suffix to one decimal", () => {
+    expect(formatMultiplier(3.498)).toBe("3.5×");
+    expect(formatMultiplier(4.1)).toBe("4.1×");
+  });
+
+  it("null → '' (dropped, never (NaN×) / fabricated (1×))", () => {
+    expect(formatMultiplier(null)).toBe("");
+    expect(formatMultiplier(Infinity)).toBe("");
+  });
+});
+
+describe("toSpendBars + spikeCount", () => {
+  const pts: CostSeriesPoint[] = [
+    { t: 1781011878, usd: 41.4, isSpike: false },
+    { t: 1781015478, usd: 110.97, isSpike: true },
+    { t: 1781019078, usd: 5.44, isSpike: false },
+  ];
+
+  it("carries usd + the spike flag through to the bars", () => {
+    const bars = toSpendBars(pts);
+    expect(bars).toHaveLength(3);
+    expect(bars[1]!.isSpike).toBe(true);
+    expect(bars[1]!.usd).toBe(110.97);
+    // the epoch-second key is preserved (the drill re-query key).
+    expect(bars[1]!.t).toBe(1781015478);
+  });
+
+  it("adds an hh:00 label (local time)", () => {
+    const bars = toSpendBars(pts);
+    expect(bars[0]!.label).toMatch(/^\d{2}:00$/);
+  });
+
+  it("empty input → empty bars (no fabricated bar)", () => {
+    expect(toSpendBars([])).toEqual([]);
+  });
+
+  it("spikeCount tallies only the flagged hours", () => {
+    expect(spikeCount(pts)).toBe(1);
+    expect(spikeCount([])).toBe(0);
+  });
+});
+
+describe("hourLabel", () => {
+  it("is a two-digit local hour ending in :00", () => {
+    expect(hourLabel(1781015478)).toMatch(/^\d{2}:00$/);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-panels.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-panels.ts
@@ -1,0 +1,107 @@
+// finops-panels.ts — PURE data-shaping + formatters for the OBS-10 FINOPS hero and
+// the P-A spend-over-time bars. DOM-/React-free so every numeric decision (the
+// dollar formatting, the delta sign, the cache-ROI multiplier, the spike-bar
+// shaping) unit-tests directly under the ui package's `bun test` (the same
+// discipline telemetry-panels.ts follows). The panel components are the skin only.
+//
+// FinOps's soul is HONESTY: a null delta renders "—" (never a fabricated 0%); a
+// missing multiplier drops the "(Nx)" rather than dividing by zero; an empty
+// series is an empty bar set the ChartCard degrades, never a fabricated bar.
+
+import type { CostSeriesPoint } from "@/lib/types";
+
+// ── dollar / percent formatters ──────────────────────────────────────────────
+
+/** Format a USD amount the way the hero/P-A read it: no cents above $100 (the
+ *  hero is a glance number — "$470", not "$469.85"), one decimal below $100, and a
+ *  thousands separator. A non-finite input → "$0" (honest, never "NaN"). */
+export function formatUsd(usd: number): string {
+  if (!Number.isFinite(usd)) return "$0";
+  const abs = Math.abs(usd);
+  const fractionDigits = abs >= 100 ? 0 : abs >= 10 ? 1 : 2;
+  return `$${usd.toLocaleString(undefined, {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  })}`;
+}
+
+/** A compact USD for dense per-model rows: "$1.6k" / "$588" / "$22". A non-finite
+ *  input → "$0". */
+export function compactUsd(usd: number): string {
+  if (!Number.isFinite(usd)) return "$0";
+  const abs = Math.abs(usd);
+  if (abs >= 1_000_000) return `$${(usd / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `$${(usd / 1_000).toFixed(1)}k`;
+  return `$${Math.round(usd)}`;
+}
+
+/** Format a delta FRACTION (e.g. -0.103) as a signed percent string for the hero's
+ *  delta label, e.g. "+38%" / "-10%". null → "—" (no baseline → no comparison,
+ *  honest, never a fabricated 0%). PURE. */
+export function formatDeltaPercent(deltaFraction: number | null): string {
+  if (deltaFraction === null || !Number.isFinite(deltaFraction)) return "—";
+  const pct = Math.round(deltaFraction * 100);
+  const sign = pct > 0 ? "+" : "";
+  return `${sign}${pct}%`;
+}
+
+/** The hero's delta MAGNITUDE as a whole-percent number for KpiNumber's `delta`
+ *  prop (which renders the arrow + abs value). null → undefined (KpiNumber then
+ *  shows no delta pill at all — the honest "no baseline" rendering). PURE. */
+export function deltaPercentValue(deltaFraction: number | null): number | undefined {
+  if (deltaFraction === null || !Number.isFinite(deltaFraction)) return undefined;
+  return Math.round(deltaFraction * 100);
+}
+
+/** Format the cache-ROI multiplier as the "(4.1×)" suffix on the headline. null →
+ *  "" (no actual spend to divide by → drop the multiplier, never "(NaN×)" or a
+ *  fabricated "(1×)"). PURE. */
+export function formatMultiplier(multiplier: number | null): string {
+  if (multiplier === null || !Number.isFinite(multiplier)) return "";
+  return `${multiplier.toFixed(1)}×`;
+}
+
+// ── P-A: spend-over-time bars ─────────────────────────────────────────────────
+
+/** One bar in the P-A chart, shaped from a CostSeriesPoint for the recharts
+ *  BarChart. `label` is the hour-of-day tick ("14:00"); `usd` is the bar height;
+ *  `isSpike` flags the `--chart-4` dot + the spike fill; `t` is kept as the
+ *  epoch-second key the spike-click drill re-queries on. */
+export interface SpendBar {
+  /** Epoch seconds — the drill re-query key (the clicked hour's window). */
+  t: number;
+  /** Hour-of-day tick label, e.g. "14:00" (local time). */
+  label: string;
+  /** The hour's spend, USD. */
+  usd: number;
+  /** True when this hour scored a spike (set by scoreSpikes server-side). */
+  isSpike: boolean;
+}
+
+/** A two-digit-hour local label for an epoch-SECONDS timestamp, e.g. "09:00".
+ *  PURE-ish (reads the host's local zone, the operator's wall clock — the same
+ *  anchoring costToday uses for "today"). */
+export function hourLabel(epochSeconds: number): string {
+  const d = new Date(epochSeconds * 1000);
+  const hh = String(d.getHours()).padStart(2, "0");
+  return `${hh}:00`;
+}
+
+/** Shape a CostSeriesPoint[] (from /api/otel/cost-series) into P-A bars. PURE: an
+ *  empty input is an empty array (the ChartCard renders the honest empty state;
+ *  this never fabricates a bar). The points are already spike-scored server-side
+ *  (scoreSpikes) — we only add the display label + carry the fields through. */
+export function toSpendBars(points: CostSeriesPoint[]): SpendBar[] {
+  return points.map((p) => ({
+    t: p.t,
+    label: hourLabel(p.t),
+    usd: p.usd,
+    isSpike: p.isSpike,
+  }));
+}
+
+/** The count of spiking hours in the series (for the P-A header "(n spikes)"
+ *  annotation). PURE. */
+export function spikeCount(points: CostSeriesPoint[]): number {
+  return points.reduce((n, p) => (p.isSpike ? n + 1 : n), 0);
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-surface.tsx
@@ -15,7 +15,7 @@
 // NOW. The hero's "today" number always reads /api/otel/cost-today (anchored to
 // local midnight, independent of the picker); the spend-over-time bars + the
 // cache-ROI follow the picker via TIME_RANGE_TO_PROM.
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAtom } from "jotai";
 import type {
   OtelHealth,
@@ -23,6 +23,9 @@ import type {
   CostSeriesPoint,
   CacheSavings,
   CostAtHour,
+  CostMap,
+  TokenSplit,
+  CostValidationRow,
 } from "@/lib/types";
 import {
   timeRangeAtom,
@@ -35,7 +38,16 @@ import { ChartCard } from "@/components/observe/chart-card";
 import { FinopsHero } from "@/components/observe/finops-hero";
 import { SpendOverTimePanel } from "@/components/observe/spend-over-time-panel";
 import { SpikeDrillStrip } from "@/components/observe/spike-drill-strip";
+import { ExpensiveTicketsTable } from "@/components/observe/expensive-tickets-table";
+import { CostBreakdownBars } from "@/components/observe/cost-breakdown-bars";
+import { TokenDonutPanel } from "@/components/observe/token-donut-panel";
+import { FinopsFooter } from "@/components/observe/finops-footer";
 import { hourLabel, spikeCount } from "@/components/observe/finops-panels";
+import {
+  rankCostMap,
+  hasTokenData,
+  type CostDimension,
+} from "@/components/observe/finops-breakdowns";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 
 /** The clicked-spike focus: the hour's epoch second + its label + the fetched
@@ -66,6 +78,20 @@ export function FinopsSurface() {
   const [series, setSeries] = useState<CostSeriesPoint[]>([]);
   const [seriesReachable, setSeriesReachable] = useState(true);
   const [cache, setCache] = useState<CacheSavings | null>(null);
+
+  // OBS-11 breakdown panels — each reads an EXISTING /api/otel/* route. The
+  // `*Reachable` flags carry the route-level 503 over the global probe so a panel
+  // degrades to STALE (not a fabricated empty) when Prometheus drops mid-flight.
+  const [cost, setCost] = useState<CostMap>(null);
+  const [costReachable, setCostReachable] = useState(true);
+  const [byStage, setByStage] = useState<CostMap>(null);
+  const [byStageReachable, setByStageReachable] = useState(true);
+  const [byDim, setByDim] = useState<CostMap>(null);
+  const [byDimReachable, setByDimReachable] = useState(true);
+  const [costDim, setCostDim] = useState<CostDimension>("model");
+  const [tokens, setTokens] = useState<TokenSplit | null>(null);
+  const [tokensReachable, setTokensReachable] = useState(true);
+  const [validation, setValidation] = useState<CostValidationRow[] | null>(null);
 
   const [spike, setSpike] = useState<SpikeFocus | null>(null);
 
@@ -136,19 +162,113 @@ export function FinopsSurface() {
       }
     }
 
+    // OBS-11 P-C (expensive tickets) + footer A4 (concentration) both ride this.
+    async function loadCost() {
+      try {
+        const resp = await fetch(`/api/otel/cost?range=${promRange}`);
+        if (!alive) return;
+        if (resp.status === 503) return setCostReachable(false);
+        if (!resp.ok) return;
+        const body = (await resp.json()) as { data: CostMap };
+        setCost(body.data ?? null);
+        setCostReachable(true);
+      } catch {
+        if (alive) setCostReachable(false);
+      }
+    }
+
+    // OBS-11 P-B (cost by pipeline stage) — the OBS-9-routed costByTaskType.
+    async function loadByStage() {
+      try {
+        const resp = await fetch(`/api/otel/cost-by-stage?range=${promRange}`);
+        if (!alive) return;
+        if (resp.status === 503) return setByStageReachable(false);
+        if (!resp.ok) return;
+        const body = (await resp.json()) as { data: CostMap };
+        setByStage(body.data ?? null);
+        setByStageReachable(true);
+      } catch {
+        if (alive) setByStageReachable(false);
+      }
+    }
+
+    // OBS-11 P-E (token type split) — the 4 buckets + cache hit rate.
+    async function loadTokens() {
+      try {
+        const resp = await fetch(`/api/otel/tokens?range=${promRange}`);
+        if (!alive) return;
+        if (resp.status === 503) return setTokensReachable(false);
+        if (!resp.ok) return;
+        const body = (await resp.json()) as { data: TokenSplit };
+        setTokens(body.data);
+        setTokensReachable(true);
+      } catch {
+        if (alive) setTokensReachable(false);
+      }
+    }
+
+    // OBS-11 footer A8 — signal-vs-OTEL drift. Best-effort (footer shows "—").
+    async function loadValidation() {
+      try {
+        const resp = await fetch(`/api/otel/cost-validation?range=${promRange}`);
+        if (!alive) return;
+        if (!resp.ok) return;
+        const body = (await resp.json()) as { data: CostValidationRow[] | null };
+        setValidation(body.data ?? null);
+      } catch {
+        /* A8 best-effort: the footer shows "—" rather than blocking. */
+      }
+    }
+
     void loadToday();
     void loadSeries();
     void loadCache();
+    void loadCost();
+    void loadByStage();
+    void loadTokens();
+    void loadValidation();
     const id = setInterval(() => {
       void loadToday();
       void loadSeries();
       void loadCache();
+      void loadCost();
+      void loadByStage();
+      void loadTokens();
+      void loadValidation();
     }, refreshIntervalMs(range));
     return () => {
       alive = false;
       clearInterval(id);
     };
   }, [range]);
+
+  // P-D by-model/agent — separate effect so the model⇄agent toggle re-queries
+  // without re-running the whole panel set. Reads /api/otel/cost-by-dim?dim=…
+  useEffect(() => {
+    let alive = true;
+    const promRange = TIME_RANGE_TO_PROM[range];
+    async function loadByDim() {
+      try {
+        const resp = await fetch(
+          `/api/otel/cost-by-dim?dim=${costDim}&range=${promRange}`,
+        );
+        if (!alive) return;
+        if (resp.status === 503) return setByDimReachable(false);
+        if (!resp.ok) return;
+        const body = (await resp.json()) as { data: CostMap };
+        setByDim(body.data ?? null);
+        setByDimReachable(true);
+      } catch {
+        if (alive) setByDimReachable(false);
+      }
+    }
+    void loadByDim();
+    const id = setInterval(() => void loadByDim(), refreshIntervalMs(range));
+    return () => {
+      alive = false;
+      clearInterval(id);
+    };
+  }, [range, costDim]);
 
   // Spike-click drill: re-query that hour's by-ticket + by-model split (one
   // re-query with the hour window, layout spec §2 P-A).
@@ -187,6 +307,17 @@ export function FinopsSurface() {
         };
 
   const nSpikes = spikeCount(series);
+
+  // hasData gates for the OBS-11 breakdown ChartCards — true only when the
+  // zero-filtered map / token split carries a real row (else the card shows the
+  // honest empty state, never a fabricated bar).
+  const costHasData = useMemo(() => rankCostMap(cost).length > 0, [cost]);
+  const byStageHasData = useMemo(() => rankCostMap(byStage).length > 0, [byStage]);
+  const byDimHasData = useMemo(() => rankCostMap(byDim).length > 0, [byDim]);
+  const tokensHasData = useMemo(
+    () => hasTokenData(tokens?.tokens ?? null),
+    [tokens],
+  );
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto bg-surface-0 p-5 text-fg">
@@ -256,6 +387,81 @@ export function FinopsSurface() {
           onClose={() => setSpike(null)}
         />
       )}
+
+      {/* OBS-11 BREAKDOWN GRID — two columns below the hero+P-A (layout spec §2).
+          Left = trend/where-it-went bars (by-stage, by-model/agent); right = the
+          default table (P-C) + the proportional token donut (P-E). */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {/* P-C — expensive tickets table (the default view, Principle 10). */}
+        <ChartCard
+          title="Expensive tickets"
+          dataSource="[prom]"
+          health={promHealth(costReachable)}
+          hasData={costHasData}
+          bodyClassName="min-h-[300px] h-[340px] p-0"
+        >
+          <ExpensiveTicketsTable data={cost} />
+        </ChartCard>
+
+        {/* P-E — token type split (the ONE sanctioned donut, Principle 9 carve-out). */}
+        <ChartCard
+          title="Token type split"
+          dataSource="[prom]"
+          health={promHealth(tokensReachable)}
+          hasData={tokensHasData}
+          bodyClassName="min-h-[200px] h-[340px] p-4"
+        >
+          <TokenDonutPanel
+            tokens={tokens?.tokens ?? null}
+            cacheHitRate={tokens?.cacheHitRate ?? null}
+          />
+        </ChartCard>
+
+        {/* P-B — cost by pipeline stage (ranked bar, NOT a 12-slice pie). */}
+        <ChartCard
+          title="Cost by pipeline stage"
+          dataSource="[prom]"
+          health={promHealth(byStageReachable)}
+          hasData={byStageHasData}
+          bodyClassName="min-h-[220px] h-[280px] p-2"
+        >
+          <CostBreakdownBars data={byStage} labelHeader="stage" />
+        </ChartCard>
+
+        {/* P-D — cost by model / agent (ranked bar + model⇄agent toggle). */}
+        <ChartCard
+          title="Cost by model / agent"
+          dataSource="[prom]"
+          health={promHealth(byDimReachable)}
+          hasData={byDimHasData}
+          bodyClassName="min-h-[220px] h-[280px] p-2"
+          headerExtra={
+            <ToggleGroup
+              type="single"
+              variant="outline"
+              size="sm"
+              value={costDim}
+              onValueChange={(v) => v && setCostDim(v as CostDimension)}
+              aria-label="Group cost by"
+            >
+              <ToggleGroupItem value="model" className="h-6 px-2 text-[10px]">
+                model
+              </ToggleGroupItem>
+              <ToggleGroupItem value="agent" className="h-6 px-2 text-[10px]">
+                agent
+              </ToggleGroupItem>
+            </ToggleGroup>
+          }
+        >
+          <CostBreakdownBars
+            data={byDim}
+            labelHeader={costDim === "model" ? "model" : "agent"}
+          />
+        </ChartCard>
+      </div>
+
+      {/* FOOTER strip — A4 concentration · A8 drift · locked $/story-point. */}
+      <FinopsFooter cost={cost} validation={validation} />
     </div>
   );
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-surface.tsx
@@ -1,0 +1,261 @@
+// finops-surface.tsx — the OBSERVE FinOps surface (OBS-10).
+//
+// "How much did I spend today, and is that normal?" The surface leads with ONE
+// full-width dollar+ROI hero band (today's spend vs the 7d baseline + EOD
+// projection + the cache-ROI headline) over the P-A spend-over-time bars with
+// spike markers. Dollars LEAD; tokens are demoted to OBS-11's breakdown panels.
+//
+// FinOps is Prometheus-anchored: EVERY panel is wrapped in <ChartCard
+// dataSource="[prom]"> so a no-Prometheus install shows the "Configure
+// Prometheus — catalyst-otel" state and NEVER a blank/fabricated number (design
+// §2 honesty rule). The Mini HAS Prometheus so the panels render LIVE.
+//
+// The surface defaults the shared time-range atom to TODAY on mount (FinOps's
+// per-surface default, build-plan §2.5) — the only surface whose default is not
+// NOW. The hero's "today" number always reads /api/otel/cost-today (anchored to
+// local midnight, independent of the picker); the spend-over-time bars + the
+// cache-ROI follow the picker via TIME_RANGE_TO_PROM.
+import { useEffect, useRef, useState } from "react";
+import { useAtom } from "jotai";
+import type {
+  OtelHealth,
+  CostTodaySummary,
+  CostSeriesPoint,
+  CacheSavings,
+  CostAtHour,
+} from "@/lib/types";
+import {
+  timeRangeAtom,
+  TIME_RANGES,
+  TIME_RANGE_LABEL,
+  TIME_RANGE_TO_PROM,
+  refreshIntervalMs,
+} from "@/lib/observe-store";
+import { ChartCard } from "@/components/observe/chart-card";
+import { FinopsHero } from "@/components/observe/finops-hero";
+import { SpendOverTimePanel } from "@/components/observe/spend-over-time-panel";
+import { SpikeDrillStrip } from "@/components/observe/spike-drill-strip";
+import { hourLabel, spikeCount } from "@/components/observe/finops-panels";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+
+/** The clicked-spike focus: the hour's epoch second + its label + the fetched
+ *  per-hour split (null while the re-query is in flight). */
+interface SpikeFocus {
+  t: number;
+  label: string;
+  data: CostAtHour | null;
+}
+
+export function FinopsSurface() {
+  const [range, setRange] = useAtom(timeRangeAtom);
+
+  // FinOps's per-surface default is TODAY (build-plan §2.5). Apply it ONCE on
+  // mount — only if the operator hasn't already moved the shared picker — so
+  // navigating in from Telemetry (NOW) lands on the right FinOps default without
+  // clobbering an explicit later selection. The ref makes this a true mount-once.
+  const appliedDefault = useRef(false);
+  useEffect(() => {
+    if (appliedDefault.current) return;
+    appliedDefault.current = true;
+    setRange((prev) => (prev === "NOW" ? "TODAY" : prev));
+  }, [setRange]);
+
+  const [health, setHealth] = useState<OtelHealth | null>(null);
+  const [today, setToday] = useState<CostTodaySummary | null>(null);
+  const [todayReachable, setTodayReachable] = useState(true);
+  const [series, setSeries] = useState<CostSeriesPoint[]>([]);
+  const [seriesReachable, setSeriesReachable] = useState(true);
+  const [cache, setCache] = useState<CacheSavings | null>(null);
+
+  const [spike, setSpike] = useState<SpikeFocus | null>(null);
+
+  // Health probe (10s TTL) — drives the ChartCard ladder. Same idiom as Telemetry.
+  useEffect(() => {
+    let alive = true;
+    async function probe() {
+      try {
+        const resp = await fetch("/api/health/otel");
+        if (!resp.ok || !alive) return;
+        setHealth((await resp.json()) as OtelHealth);
+      } catch {
+        /* leave health as-is → next probe corrects it */
+      }
+    }
+    void probe();
+    const id = setInterval(() => void probe(), 10_000);
+    return () => {
+      alive = false;
+      clearInterval(id);
+    };
+  }, []);
+
+  // The FinOps data, refreshed on the shared cadence. The hero `today` is anchored
+  // to local midnight (the dedicated route, no range param); the spend-over-time
+  // bars + cache-ROI follow the picker via TIME_RANGE_TO_PROM.
+  useEffect(() => {
+    let alive = true;
+    const promRange = TIME_RANGE_TO_PROM[range];
+
+    async function loadToday() {
+      try {
+        const resp = await fetch("/api/otel/cost-today");
+        if (!alive) return;
+        if (resp.status === 503) return setTodayReachable(false);
+        if (!resp.ok) return;
+        const body = (await resp.json()) as { data: CostTodaySummary };
+        setToday(body.data);
+        setTodayReachable(true);
+      } catch {
+        if (alive) setTodayReachable(false);
+      }
+    }
+
+    async function loadSeries() {
+      try {
+        const resp = await fetch(`/api/otel/cost-series?range=${promRange}`);
+        if (!alive) return;
+        if (resp.status === 503) return setSeriesReachable(false);
+        if (!resp.ok) return;
+        const body = (await resp.json()) as { data: CostSeriesPoint[] | null };
+        setSeries(body.data ?? []);
+        setSeriesReachable(true);
+      } catch {
+        if (alive) setSeriesReachable(false);
+      }
+    }
+
+    async function loadCache() {
+      try {
+        const resp = await fetch(`/api/otel/cache-savings?range=${promRange}`);
+        if (!alive) return;
+        if (!resp.ok) return;
+        const body = (await resp.json()) as { data: CacheSavings | null };
+        setCache(body.data ?? null);
+      } catch {
+        /* cache-ROI best-effort: the hero shows "—" rather than blocking. */
+      }
+    }
+
+    void loadToday();
+    void loadSeries();
+    void loadCache();
+    const id = setInterval(() => {
+      void loadToday();
+      void loadSeries();
+      void loadCache();
+    }, refreshIntervalMs(range));
+    return () => {
+      alive = false;
+      clearInterval(id);
+    };
+  }, [range]);
+
+  // Spike-click drill: re-query that hour's by-ticket + by-model split (one
+  // re-query with the hour window, layout spec §2 P-A).
+  function onSpikeClick(epochSeconds: number) {
+    const label = hourLabel(epochSeconds);
+    setSpike({ t: epochSeconds, label, data: null });
+    void (async () => {
+      try {
+        const resp = await fetch(
+          `/api/otel/cost-at-hour?hour=${Math.floor(epochSeconds)}`,
+        );
+        if (!resp.ok) return;
+        const body = (await resp.json()) as { data: CostAtHour };
+        // Only apply if this is still the focused spike (avoid a stale re-query
+        // overwriting a newer click).
+        setSpike((cur) =>
+          cur && cur.t === epochSeconds ? { ...cur, data: body.data } : cur,
+        );
+      } catch {
+        /* drill re-query failed → the strip shows its honest empty state. */
+      }
+    })();
+  }
+
+  // The hero's health gates on Prometheus reachability (the today/cache routes are
+  // [prom]); layer the route-level 503 signal over the global probe.
+  const promHealth = (reachable: boolean): OtelHealth | null =>
+    health === null
+      ? null
+      : {
+          ...health,
+          prometheus: {
+            ...health.prometheus,
+            reachable: health.prometheus.reachable && reachable,
+          },
+        };
+
+  const nSpikes = spikeCount(series);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto bg-surface-0 p-5 text-fg">
+      <header className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-lg font-semibold tracking-tight">FinOps</h1>
+          <p className="text-[12px] text-muted">
+            How much did I spend today, and is that normal?
+          </p>
+        </div>
+        <ToggleGroup
+          type="single"
+          variant="outline"
+          size="sm"
+          value={range}
+          onValueChange={(v) => v && setRange(v as (typeof TIME_RANGES)[number])}
+          aria-label="Time range"
+        >
+          {TIME_RANGES.map((r) => (
+            <ToggleGroupItem key={r} value={r} className="text-[12px]">
+              {TIME_RANGE_LABEL[r]}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </header>
+
+      {/* HERO — the full-width dollar+ROI band, the surface's ONE answer
+          (Principle 1). Wrapped in a [prom] ChartCard so a no-Prometheus install
+          shows the configure CTA, never a fabricated dollar. */}
+      <ChartCard
+        title="Today's spend"
+        dataSource="[prom]"
+        health={promHealth(todayReachable)}
+        hasData={today !== null}
+        bodyClassName="min-h-[120px] p-4"
+      >
+        <FinopsHero today={today} cache={cache} />
+      </ChartCard>
+
+      {/* P-A — spend-over-time hourly bars + spike markers. Spike bar click drills
+          into that hour's by-ticket/by-model split (the strip below). */}
+      <ChartCard
+        title="Spend over time"
+        dataSource="[prom]"
+        health={promHealth(seriesReachable)}
+        hasData={series.length > 0}
+        bodyClassName="min-h-[260px] h-[min(40vh,320px)] p-3"
+        headerExtra={
+          nSpikes > 0 ? (
+            <span
+              className="font-mono text-[10px]"
+              style={{ color: "var(--chart-4)" }}
+            >
+              {nSpikes} {nSpikes === 1 ? "spike" : "spikes"}
+            </span>
+          ) : undefined
+        }
+      >
+        <SpendOverTimePanel points={series} onSpikeClick={onSpikeClick} />
+      </ChartCard>
+
+      {/* Spike drill strip — appears below P-A on a spike click. */}
+      {spike && (
+        <SpikeDrillStrip
+          data={spike.data}
+          hourLabel={spike.label}
+          onClose={() => setSpike(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/spend-over-time-panel.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/spend-over-time-panel.tsx
@@ -1,0 +1,131 @@
+// spend-over-time-panel.tsx — the FINOPS P-A panel body (OBS-10, layout spec §2).
+//
+// Hourly spend bars over the window (24h/7d) with the SPIKING hours flagged. A
+// spike is scored server-side (scoreSpikes: hour > max(2× trailing median, μ+2σ))
+// and rendered as a `--chart-4` (red) FILL on that one bar plus a red dot above it
+// — the ONE status-color use in this panel (Principle 3). Every other bar is the
+// categorical `--chart-1` (brand blue). Spike detection reads better on discrete
+// hourly bars than a filled area, so P-A is a bar (layout spec §4.4).
+//
+// Drill (progressive disclosure): clicking a spiking bar fires onSpikeClick with
+// that hour's epoch-second timestamp so the caller can re-query that hour's
+// by-ticket / by-model split (one re-query, layout spec §2 P-A).
+//
+// The spike dot + fill are drawn by a custom Bar `shape` (a self-contained
+// rect + dot keyed off the bar's own payload.isSpike) rather than recharts'
+// deprecated <Customized> layer — it is version-stable across recharts 3.x and
+// needs no access to the chart's internal computed-geometry array.
+//
+// This renders the LIVE state's children — the surrounding ChartCard
+// (dataSource="[prom]") owns the unconfigured / unreachable / empty honesty states.
+
+import { useMemo } from "react";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { toSpendBars, type SpendBar, formatUsd } from "./finops-panels";
+import type { CostSeriesPoint } from "@/lib/types";
+
+const CHART_CONFIG = {
+  usd: { label: "Spend", color: "var(--chart-1)" },
+} satisfies ChartConfig;
+
+export interface SpendOverTimePanelProps {
+  /** /api/otel/cost-series points (already spike-scored server-side). */
+  points: CostSeriesPoint[];
+  /** Drill: click a SPIKING bar → that hour's by-ticket/by-model split. Receives
+   *  the bar's epoch-SECOND timestamp (the re-query window key). */
+  onSpikeClick?: (epochSeconds: number) => void;
+}
+
+/** The geometry + payload recharts injects into a Bar `shape`. We only read the
+ *  rect box + the row's payload (the SpendBar) — kept minimal so it is stable
+ *  across recharts 3.x point shapes. */
+interface BarShapeProps {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  payload?: SpendBar;
+}
+
+/** Custom bar shape: the rect (categorical --chart-1, or --chart-4 when this hour
+ *  spiked) plus a --chart-4 dot floating just above a spiking bar (the one
+ *  status-color use in this panel, Principle 3). Non-spiking hours render just the
+ *  blue rect. */
+function SpendBarShape({ x = 0, y = 0, width = 0, height = 0, payload }: BarShapeProps) {
+  const isSpike = payload?.isSpike ?? false;
+  const fill = isSpike ? "var(--chart-4)" : "var(--chart-1)";
+  return (
+    <g>
+      <rect x={x} y={y} width={width} height={height} rx={2} ry={2} fill={fill} />
+      {isSpike && (
+        <circle
+          cx={x + width / 2}
+          cy={Math.max(4, y - 6)}
+          r={3.5}
+          fill="var(--chart-4)"
+        />
+      )}
+    </g>
+  );
+}
+
+export function SpendOverTimePanel({
+  points,
+  onSpikeClick,
+}: SpendOverTimePanelProps) {
+  const bars = useMemo(() => toSpendBars(points), [points]);
+
+  return (
+    <ChartContainer config={CHART_CONFIG} className="h-full w-full">
+      <BarChart
+        accessibilityLayer
+        data={bars}
+        margin={{ top: 12, right: 8, left: 0, bottom: 0 }}
+      >
+        <CartesianGrid vertical={false} strokeDasharray="3 3" />
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={6}
+          minTickGap={24}
+          fontSize={10}
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          width={44}
+          fontSize={10}
+          tickFormatter={(v: number) => formatUsd(v)}
+        />
+        <ChartTooltip
+          cursor={{ fill: "var(--surface-2, rgba(255,255,255,0.04))" }}
+          content={
+            <ChartTooltipContent
+              labelKey="label"
+              formatter={(value) => formatUsd(Number(value))}
+            />
+          }
+        />
+        <Bar
+          dataKey="usd"
+          shape={<SpendBarShape />}
+          // Click a spiking bar → drill into that hour (layout spec §2 P-A).
+          onClick={(data: { payload?: SpendBar }) => {
+            const bar = data?.payload;
+            if (bar?.isSpike && onSpikeClick) onSpikeClick(bar.t);
+          }}
+          // pointer only over spiking bars — recharts applies this at the series
+          // level; the shape's dot makes the spiking bar the obvious affordance.
+          cursor={onSpikeClick ? "pointer" : "default"}
+        />
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/spike-drill-strip.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/spike-drill-strip.tsx
@@ -1,0 +1,117 @@
+// spike-drill-strip.tsx — the FINOPS P-A spike-click drill (OBS-10, layout spec
+// §2 P-A: "spike bar click → that hour's by-ticket + by-model split").
+//
+// When the operator clicks a spiking hour in the spend-over-time chart, this strip
+// appears below it showing WHO (by-ticket) and WHICH MODEL drove that hour's
+// spend — both ranked descending, both zero-filtered server-side. It is the
+// "one re-query with the hour window" the design calls for (/api/otel/cost-at-hour
+// with the clicked bar's epoch second). Dismissable; honest empty state when the
+// hour had no attributed spend.
+//
+// Bars are CSS-width metric rows (NOT a recharts chart) filled with the
+// categorical --chart-1 token (Principle 8) — the same idiom as tool-mix-panel.
+
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { X } from "lucide-react";
+import { compactUsd } from "./finops-panels";
+import { barPercent } from "./telemetry-panels";
+import type { CostAtHour } from "@/lib/types";
+
+export interface SpikeDrillStripProps {
+  /** /api/otel/cost-at-hour payload for the clicked hour. null while loading. */
+  data: CostAtHour | null;
+  /** The hour label being drilled (e.g. "14:00"), for the strip header. */
+  hourLabel: string;
+  /** Dismiss the drill. */
+  onClose: () => void;
+}
+
+/** Sort a label→USD map into ranked [label, usd] rows, descending, dropping any
+ *  zero (server already zero-filters; this is belt-and-braces). */
+function rankRows(map: Record<string, number>): Array<[string, number]> {
+  return Object.entries(map)
+    .filter(([, v]) => v > 0)
+    .sort((a, b) => b[1] - a[1]);
+}
+
+function DrillColumn({
+  title,
+  rows,
+}: {
+  title: string;
+  rows: Array<[string, number]>;
+}) {
+  const max = rows.length > 0 ? rows[0]![1] : 0;
+  return (
+    <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <span className="text-[10px] font-medium uppercase tracking-wide text-muted/70">
+        {title}
+      </span>
+      {rows.length === 0 ? (
+        <span className="py-1 text-[11px] text-muted/60">no attributed spend</span>
+      ) : (
+        <div className="flex flex-col gap-0.5">
+          {rows.slice(0, 6).map(([label, usd]) => (
+            <div key={label} className="flex items-center gap-2">
+              <span className="w-24 shrink-0 truncate font-mono text-[11px] text-fg">
+                {label}
+              </span>
+              <span className="relative h-2 flex-1 overflow-hidden rounded-sm bg-surface-3">
+                <span
+                  className="absolute inset-y-0 left-0 rounded-sm"
+                  style={{
+                    width: `${barPercent(usd, max)}%`,
+                    backgroundColor: "var(--chart-1)",
+                  }}
+                />
+              </span>
+              <span className="w-14 shrink-0 text-right font-mono text-[11px] tabular-nums text-muted">
+                {compactUsd(usd)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SpikeDrillStrip({
+  data,
+  hourLabel,
+  onClose,
+}: SpikeDrillStripProps) {
+  const byTicket = useMemo(() => rankRows(data?.byTicket ?? {}), [data]);
+  const byModel = useMemo(() => rankRows(data?.byModel ?? {}), [data]);
+
+  return (
+    <div
+      className={cn(
+        "mt-2 rounded-md border border-border bg-surface-1/60 p-3",
+        "flex flex-col gap-3",
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] font-medium text-fg">
+          Spike at {hourLabel}
+          <span className="ml-2 font-normal text-muted/70">
+            who + which model drove this hour
+          </span>
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded p-0.5 text-muted hover:bg-surface-2 hover:text-fg"
+          aria-label="Close spike drill"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <div className="flex flex-col gap-4 sm:flex-row sm:gap-6">
+        <DrillColumn title="by ticket" rows={byTicket} />
+        <DrillColumn title="by model" rows={byModel} />
+      </div>
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/token-donut-panel.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/token-donut-panel.tsx
@@ -1,0 +1,153 @@
+// token-donut-panel.tsx — the FINOPS P-E panel body (OBS-11, layout spec §2 + §4):
+// the four-bucket token-type donut. This is the ONE sanctioned donut on the surface
+// (Principle 9 carve-out): a fixed, small (4), mutually-exclusive, sums-to-100%
+// partition (input / output / cacheRead / cacheCreation) where the part-of-whole
+// relationship IS the message and the center hole carries the cache hit-rate number.
+//
+// HONESTY (design §2): the four buckets are NEVER collapsed — toTokenSlices always
+// returns all four, each its own --chart-1..4 category. Collapsing cacheRead into
+// input over-reports cost 35-50% on this cache-heavy workload (cacheRead is ~96% of
+// tokens live). The center text is the cache hit-rate (99.5% live), the headline
+// that motivates the cache-ROI story in the hero.
+//
+// Renders the LIVE state's children — the surrounding ChartCard (dataSource="[prom]")
+// owns the unconfigured / unreachable / empty honesty states.
+
+import { useMemo } from "react";
+import { Label, Pie, PieChart } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  toTokenSlices,
+  compactTokens,
+  tokenBucketLabel,
+  formatHitRate,
+  type TokenBucket,
+} from "./finops-breakdowns";
+
+// Each bucket → its own categorical chart token (Principle 8: via ChartConfig, no
+// hex in JSX). cacheRead/cacheCreation get the green/yellow accents so the cache
+// story reads as the win, input/output the blue/cyan neutrals.
+const CHART_CONFIG = {
+  input: { label: "input", color: "var(--chart-1)" },
+  output: { label: "output", color: "var(--chart-5)" },
+  cacheRead: { label: "cache read", color: "var(--chart-2)" },
+  cacheCreation: { label: "cache write", color: "var(--chart-3)" },
+} satisfies ChartConfig;
+
+const BUCKET_COLOR: Record<TokenBucket, string> = {
+  input: "var(--chart-1)",
+  output: "var(--chart-5)",
+  cacheRead: "var(--chart-2)",
+  cacheCreation: "var(--chart-3)",
+};
+
+export interface TokenDonutPanelProps {
+  /** /api/otel/tokens `tokens` map (type → token count). Shaped into the four
+   *  fixed slices via toTokenSlices (never collapsed). */
+  tokens: Record<string, number> | null;
+  /** /api/otel/tokens `cacheHitRate` (0..1), rendered in the donut center. */
+  cacheHitRate: number | null;
+}
+
+export function TokenDonutPanel({ tokens, cacheHitRate }: TokenDonutPanelProps) {
+  const slices = useMemo(() => toTokenSlices(tokens), [tokens]);
+
+  // recharts pie data: name + value + per-slice fill (the categorical token).
+  const pieData = useMemo(
+    () =>
+      slices
+        .filter((s) => s.tokens > 0)
+        .map((s) => ({
+          bucket: s.bucket,
+          label: tokenBucketLabel(s.bucket),
+          tokens: s.tokens,
+          fill: BUCKET_COLOR[s.bucket],
+        })),
+    [slices],
+  );
+
+  const hitLabel = formatHitRate(cacheHitRate);
+
+  return (
+    <div className="flex h-full min-h-0 items-center gap-4">
+      <ChartContainer
+        config={CHART_CONFIG}
+        className="aspect-square h-full max-h-[180px] min-w-[160px]"
+      >
+        <PieChart>
+          <ChartTooltip
+            content={
+              <ChartTooltipContent
+                nameKey="label"
+                formatter={(value) => `${compactTokens(Number(value))} tokens`}
+              />
+            }
+          />
+          <Pie
+            data={pieData}
+            dataKey="tokens"
+            nameKey="label"
+            innerRadius={52}
+            outerRadius={78}
+            strokeWidth={2}
+            paddingAngle={2}
+          >
+            <Label
+              content={({ viewBox }) => {
+                if (!viewBox || !("cx" in viewBox)) return null;
+                const { cx, cy } = viewBox as { cx: number; cy: number };
+                return (
+                  <text x={cx} y={cy} textAnchor="middle" dominantBaseline="middle">
+                    <tspan
+                      x={cx}
+                      y={cy - 6}
+                      className="fill-fg font-mono text-lg font-bold"
+                    >
+                      {hitLabel}
+                    </tspan>
+                    <tspan
+                      x={cx}
+                      y={cy + 12}
+                      className="fill-muted text-[10px]"
+                    >
+                      cache hit
+                    </tspan>
+                  </text>
+                );
+              }}
+            />
+          </Pie>
+        </PieChart>
+      </ChartContainer>
+
+      {/* Legend: all four buckets, each with its real token count + share. The
+          legend ALWAYS lists four rows so an absent bucket reads as 0, never hidden
+          (the four-bucket honesty rule, even in the legend). */}
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        {slices.map((s) => (
+          <div key={s.bucket} className="flex items-center gap-2">
+            <span
+              className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+              style={{ backgroundColor: BUCKET_COLOR[s.bucket] }}
+              aria-hidden
+            />
+            <span className="w-20 shrink-0 truncate text-[11px] text-fg">
+              {tokenBucketLabel(s.bucket)}
+            </span>
+            <span className="w-12 shrink-0 text-right font-mono text-[11px] tabular-nums text-muted">
+              {compactTokens(s.tokens)}
+            </span>
+            <span className="w-9 shrink-0 text-right font-mono text-[10px] tabular-nums text-muted/70">
+              {Math.round(s.share * 100)}%
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/observe-store.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/observe-store.ts
@@ -71,3 +71,21 @@ export const TIME_RANGE_TO_LOKI: Record<TimeRange, string> = {
 export function refreshIntervalMs(range: TimeRange): number {
   return range === "NOW" ? 15_000 : 60_000;
 }
+
+// ── range → Prometheus increase() window (OBS-10) ────────────────────────────
+// The FinOps spend-over-time series + cache-savings read Prometheus `increase()`
+// over a window. Unlike the Loki tail (which caps at 7d for retention), Prometheus
+// keeps the longer history, so 30D maps to a real 30d window. NOW/TODAY both map
+// to 24h here: the FinOps surface's HERO answers "today" off the dedicated
+// /api/otel/cost-today route (anchored to local midnight, not a rolling window),
+// while the spend-over-time bars want a full 24h of hourly context regardless of
+// where in the day we are — a 15m "NOW" window would render a single near-empty
+// bar. CYCLE maps to 7d as a pragmatic stand-in until the cycle boundary is wired.
+export const TIME_RANGE_TO_PROM: Record<TimeRange, string> = {
+  NOW: "24h",
+  TODAY: "24h",
+  "24H": "24h",
+  "7D": "7d",
+  CYCLE: "7d",
+  "30D": "30d",
+};

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.test.ts
@@ -36,17 +36,25 @@ describe("surfaceContentKind", () => {
     expect(surfaceContentKind("telemetry")).toBe("telemetry");
   });
 
+  it("routes the FinOps surface to its own OBSERVE content shell (OBS-10)", () => {
+    // Gherkin (OBS-10): "the operator clicks the FinOps nav item → the FinOps
+    // OBSERVE shell renders in the SidebarInset" — the SECOND OBSERVE surface to
+    // leave the dashboard fall-through.
+    expect(surfaceContentKind("finops")).toBe("finops");
+  });
+
   it("keeps Home on the dashboard (no regression)", () => {
     // Home must stay exactly what SHELL1/SHELL2 rendered — only board (SHELL2),
-    // workers (SURF1), queue (SURF2), and telemetry (OBS-5) are special-cased.
-    // The remaining OBSERVE surfaces (utilization/finops/fleetops/devops) keep
-    // the dashboard fall-through until their own OBS tickets ship.
+    // workers (SURF1), queue (SURF2), telemetry (OBS-5), and finops (OBS-10) are
+    // special-cased. The remaining OBSERVE surfaces (utilization/fleetops/devops)
+    // keep the dashboard fall-through until their own OBS tickets ship.
     const stillDashboard = SURFACES.filter(
       (s) =>
         s !== "board" &&
         s !== "workers" &&
         s !== "queue" &&
-        s !== "telemetry",
+        s !== "telemetry" &&
+        s !== "finops",
     );
     for (const s of stillDashboard) {
       expect(surfaceContentKind(s)).toBe("dashboard");
@@ -55,9 +63,14 @@ describe("surfaceContentKind", () => {
 
   it("covers every declared surface (no surface falls through undefined)", () => {
     for (const s of SURFACES as readonly Surface[]) {
-      expect(["board", "workers", "queue", "telemetry", "dashboard"]).toContain(
-        surfaceContentKind(s),
-      );
+      expect([
+        "board",
+        "workers",
+        "queue",
+        "telemetry",
+        "finops",
+        "dashboard",
+      ]).toContain(surfaceContentKind(s));
     }
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.ts
@@ -23,17 +23,19 @@ import type { Surface } from "./surface";
  *  - "dashboard" → the existing monitor dashboard / orchestrator / comms / etc.
  *
  * Home is the calm dashboard inbox; every other surface falls through to it.
- *  - "telemetry" → the OBSERVE Telemetry surface shell (OBS-5). The other four
- *                  OBSERVE surfaces (utilization/finops/fleetops/devops) keep the
+ *  - "telemetry" → the OBSERVE Telemetry surface shell (OBS-5).
+ *  - "finops"    → the OBSERVE FinOps surface shell (OBS-10): the dollar+ROI hero
+ *                  band + spend-over-time bars with spikes. The remaining three
+ *                  OBSERVE surfaces (utilization/fleetops/devops) keep the
  *                  dashboard fall-through until their content ships in later OBS
- *                  tickets — they are nav-disabled ("soon") for now, so the kind
- *                  is never actually reached, but the mapping stays total.
+ *                  tickets — they are nav-disabled ("soon") for now.
  */
 export type SurfaceContentKind =
   | "board"
   | "workers"
   | "queue"
   | "telemetry"
+  | "finops"
   | "dashboard";
 
 /**
@@ -48,9 +50,11 @@ export function surfaceContentKind(surface: Surface): SurfaceContentKind {
   if (surface === "workers") return "workers";
   if (surface === "queue") return "queue";
   // OBS-5: Telemetry is the first OBSERVE surface to ship its own content shell.
-  // The other four OBSERVE surfaces stay on the dashboard fall-through (and are
-  // nav-disabled "soon") until their own OBS tickets land.
   if (surface === "telemetry") return "telemetry";
+  // OBS-10: FinOps is the second OBSERVE surface to ship its own content shell.
+  // The remaining three (utilization/fleetops/devops) stay on the dashboard
+  // fall-through (and are nav-disabled "soon") until their own OBS tickets land.
+  if (surface === "finops") return "finops";
   return "dashboard";
 }
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/types.ts
@@ -344,6 +344,63 @@ export interface EventsHeatmap {
   cells: HeatmapCell[];
 }
 
+// ── OBS-9/OBS-10 (FINOPS): the hero dollar band wire shape ───────────────────
+// Mirrors lib/otel-queries.ts CostTodaySummary. todayUsd is spend since local
+// midnight; avg7dUsd is the prior-7-FULL-day mean baseline (the delta vs);
+// deltaFraction is (today − avg7d)/avg7d, null when avg7d===0 (the UI shows "—",
+// never a divide-by-zero); projectionEodUsd extrapolates today's run-rate to 24h.
+export interface CostTodaySummary {
+  todayUsd: number;
+  avg7dUsd: number;
+  /** (today − avg7d) / avg7d, or null when there is no baseline to compare against. */
+  deltaFraction: number | null;
+  projectionEodUsd: number;
+  elapsedTodaySeconds: number;
+}
+
+// ── OBS-9/OBS-10 (FINOPS P-A): hourly spend-over-time + spike flag ───────────
+// Mirrors lib/otel-queries.ts CostSeriesPoint. `t` is epoch SECONDS (the Prom
+// matrix point ts); `usd` is the hour's spend; `isSpike` drives the `--chart-4`
+// dot ON that bar (the one status-color use in P-A).
+export interface CostSeriesPoint {
+  t: number;
+  usd: number;
+  isSpike: boolean;
+}
+
+// ── OBS-9/OBS-10 (FINOPS HERO-C, THE HEADLINE): cache-ROI $ wire shape ───────
+// Mirrors lib/otel-queries.ts CacheSavings. savedUsd is Σ_model cacheRead_tokens
+// × (input_price − cache_read_price); multiplier is savedUsd/actualSpendUsd, null
+// when actual spend is 0 (no base to multiply — the UI shows the $ without "Nx").
+export interface CacheSavingsModelRow {
+  model: string;
+  savedUsd: number;
+  cacheReadTokens: number;
+}
+
+export interface CacheSavings {
+  savedUsd: number;
+  actualSpendUsd: number;
+  /** savedUsd / actualSpendUsd, or null when actual spend is 0. */
+  multiplier: number | null;
+  cacheReadTokens: number;
+  /** Per-model saving, USD, descending — the drill behind the headline. */
+  byModel: CacheSavingsModelRow[];
+}
+
+// ── OBS-10 (FINOPS P-A drill): per-hour cost split wire shape ────────────────
+// Mirrors lib/otel-queries.ts CostAtHour. Clicking a spiking bar re-queries that
+// hour's by-ticket + by-model split (both zero-filtered) so the operator sees WHO
+// + WHICH MODEL drove the spike — one re-query, no fabricated rows.
+export interface CostAtHour {
+  /** Epoch seconds of the hour's END (the clicked bar's timestamp). */
+  hourEndSeconds: number;
+  /** linear_key → USD for the hour (zero-filtered). */
+  byTicket: Record<string, number>;
+  /** model → USD for the hour (zero-filtered). */
+  byModel: Record<string, number>;
+}
+
 export type CommsMessageType =
   | "proposal"
   | "question"

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/types.ts
@@ -401,6 +401,38 @@ export interface CostAtHour {
   byModel: Record<string, number>;
 }
 
+// ── OBS-11 (FINOPS breakdown panels): wire shapes for the four breakdown routes ─
+// All four read EXISTING /api/otel/* routes — no new server plumbing (the OBS-9
+// zero-series filter already lives at the query layer for /cost and /cost-by-stage).
+//   P-C expensive tickets → /api/otel/cost           (linear_key → USD, zero-filtered)
+//   P-B by-stage          → /api/otel/cost-by-stage  (task_type → USD, zero-filtered)
+//   P-D by-model/agent    → /api/otel/cost           grouped by model / agent_name
+//   P-E token split       → /api/otel/tokens         (the 4 buckets + cacheHitRate)
+//   footer A8 drift       → /api/otel/cost-validation (signal vs OTEL per ticket)
+
+/** A label→USD cost map (the /api/otel/cost and /cost-by-stage payload `data`).
+ *  null when Prometheus is unavailable (the panel's ChartCard degrades). Every
+ *  value is already zero-filtered server-side, but the UI re-filters belt-and-braces. */
+export type CostMap = Record<string, number> | null;
+
+/** The /api/otel/tokens payload `data`: the four token buckets + the cache hit rate.
+ *  `tokens` keys are exactly input / output / cacheRead / cacheCreation (NEVER
+ *  collapsed). null tokens ⇒ Prometheus unavailable; cacheHitRate is 0..1 or null. */
+export interface TokenSplit {
+  tokens: Record<string, number> | null;
+  cacheHitRate: number | null;
+}
+
+/** One /api/otel/cost-validation row: signal-file cost vs OTEL cost for a ticket.
+ *  The footer A8 strip surfaces the worst absolute drift (best-in-class dashboards
+ *  own their measurement error). discrepancy = |signalCost − otelCost|. */
+export interface CostValidationRow {
+  ticket: string;
+  signalCost: number;
+  otelCost: number;
+  discrepancy: number;
+}
+
 export type CommsMessageType =
   | "proposal"
   | "question"


### PR DESCRIPTION
## OBSERVE FinOps surface (OBS-9 / OBS-10 / OBS-11)

Builds the second OBSERVE analytics surface — **"How much did I spend today, and is that normal?"** — on top of the shipped chart-grammar + panel-honesty foundation. Every panel wraps `<ChartCard>` (4-state ladder, dataSource chip); all queries are Prometheus-backed and proven against live data.

### OBS-9 — FinOps core query routes (`otel-queries.ts` + `server.ts`)
New monitor routes, all Prometheus-anchored:
- `/api/otel/cost-by-stage` — routes the previously-unrouted `costByTaskType` (`sum by (task_type) increase(cost)`); 13 phases live (interactive, phase-implement, phase-verify…).
- `/api/otel/cost-today` — `sum(increase(cost[<elapsed-today>]))` vs prior-7-full-day average; end-of-day projection from elapsed-day fraction.
- `/api/otel/cost-series` — hourly `query_range` bars (24h/7d) with spike scoring (`> max(2× median, μ+2σ)` and `> 0`).
- `/api/otel/cache-savings` — `Σ_model cacheRead_tokens × (input − cache_read price)`; cache ROI multiplier.
- **Zero-series filter** enforced at the query layer (`increase()` over a window emits an all-zeros series per label; `bottomk`/tables without a `> 0` filter render garbage). Verified live: 92 cost-by-ticket series → 86 non-zero.

### OBS-10 — FinOps hero + spend-over-time + spikes
- Dollar KPI hero: `TODAY $ ▲±% vs 7d avg · proj EOD · cache saved $ (×)` — dollars lead, never tokens.
- Hourly spend bars with red spike dots; spike-click drill strip re-queries that hour by linear_key (`offset`-anchored).
- Cache-ROI headline; cache buckets (cacheRead / cacheCreation / input / output) never collapsed.

### OBS-11 — FinOps breakdown panels
- Expensive-tickets table (zero-filtered, sortable: $ absolute).
- Cost by-stage / by-token-type (`pie-donut-text`) / by-model / by-agent breakdown bars.
- Cost-validation drift footer (OTEL vs signal Δ) — surfaces measurement error.

### Surface wiring
- `lib/surface.ts` / `surface-content.ts` finops content kind; lazy `<Suspense>` route in `App.tsx`; un-soon'd in `app-sidebar.tsx`. Per-surface default time range = TODAY via `observe-store.ts`.

### Deferred (explicitly out of scope, dimmed in UI per the honesty kit)
- Dual-currency **quota chip** (needs `account.ratelimit.sampled` event plumbing).
- **$/story-point** column (needs OBS-12 estimate write-through).

### Verification
- Parent (`plugins/dev/scripts/orch-monitor`): `tsc --noEmit` clean; `bun test __tests__/otel-queries.test.ts __tests__/server.test.ts` → **187 pass / 0 fail**.
- UI (`ui/`): `tsc --noEmit` clean; `bun test` finops + surface suites → **45 pass / 0 fail**; `vite build` green (no `bun:sqlite` ESM trap).
- **Ground-truth**: every new query proven against live Prometheus (`prometheus.otel.rozich.com`) returning real non-zero data — cost-today $1477/1d, 13 task_types, 4 token buckets, 6 cacheRead models, 86/92 non-zero tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)