### PR TITLE
fix(dev): FinOps hero + spend cards collapsed to 2px (shrink-0 on scroll-column children)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-layout.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-layout.test.ts
@@ -1,0 +1,95 @@
+// finops-layout.test.ts — a structural regression guard for the FinOps scroll
+// column (CTL hero/spend collapse fix).
+//
+// THE BUG: finops-surface's root container is a height-constrained flex column
+// (`flex h-full min-h-0 flex-col … overflow-y-auto`). ChartCard renders an
+// `overflow-hidden` Panel with the flex default `shrink:1`, so under the column's
+// height constraint the "Today's spend" hero card and the "Spend over time" card
+// SHRANK to clipped min-content (~2px) instead of the column scrolling — the hero
+// number vanished before scroll (violates design Principle 1: the surface's ONE
+// answer must lead).
+//
+// THE INVARIANT: every DIRECT child of that scroll column must keep its natural
+// height (`shrink-0`) so the column's `overflow-y-auto` scrolls instead of
+// collapsing the children. CSS layout is not unit-testable without a DOM render
+// harness (none is installed — the observe suites are pure-logic), so this is a
+// source-structure guard: it asserts the two leading ChartCards and the breakdown
+// grid carry `shrink-0`, and that the Panel base classes were NOT globally
+// mutated (that would regress fixed-height board/dashboard cells).
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const surfaceSrc = readFileSync(
+  new URL("./finops-surface.tsx", import.meta.url),
+  "utf8",
+);
+const panelSrc = readFileSync(
+  new URL("../ui/panel.tsx", import.meta.url),
+  "utf8",
+);
+const chartCardSrc = readFileSync(
+  new URL("./chart-card.tsx", import.meta.url),
+  "utf8",
+);
+
+/** Pull the JSX opening tag for a ChartCard by its `title="…"` prop (props only,
+ *  not the children). The opening tag is closed by a `>` sitting alone on its own
+ *  indentation line (`\n      >`) — searching for a bare `>` would false-match the
+ *  `>` inside an expression prop like `hasData={series.length > 0}`. */
+function chartCardOpenTag(title: string): string {
+  const idx = surfaceSrc.indexOf(`title="${title}"`);
+  expect(idx).toBeGreaterThan(-1);
+  // Walk back to the `<ChartCard` that owns this title.
+  const open = surfaceSrc.lastIndexOf("<ChartCard", idx);
+  expect(open).toBeGreaterThan(-1);
+  // The opening tag ends at the `>` on its own line after the last prop.
+  const close = surfaceSrc.indexOf("\n      >", idx);
+  expect(close).toBeGreaterThan(-1);
+  return surfaceSrc.slice(open, close + "\n      >".length);
+}
+
+describe("FinOps scroll-column children keep natural height (collapse fix)", () => {
+  it("the hero ChartCard ('Today's spend') carries shrink-0", () => {
+    expect(chartCardOpenTag("Today's spend")).toContain(
+      'className="shrink-0"',
+    );
+  });
+
+  it("the spend-over-time ChartCard carries shrink-0", () => {
+    expect(chartCardOpenTag("Spend over time")).toContain(
+      'className="shrink-0"',
+    );
+  });
+
+  it("the breakdown grid wrapper carries shrink-0", () => {
+    // The breakdown grid is the OBS-11 two-column wrapper directly below P-A.
+    expect(surfaceSrc).toContain(
+      'className="grid shrink-0 grid-cols-1 gap-4 lg:grid-cols-2"',
+    );
+  });
+
+  it("the footer + spike-drill strip are wrapped in shrink-0 boxes", () => {
+    // Both are components without a className passthrough, so each is wrapped in
+    // a shrink-0 div to hold its natural height as a direct scroll-column child.
+    const shrinkWrappers = surfaceSrc.match(/className="shrink-0"/g) ?? [];
+    // hero + spend (on the cards) + footer wrapper + strip wrapper = 4.
+    expect(shrinkWrappers.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe("the global Panel/ChartCard primitives were not regressed", () => {
+  it("Panel base classes do NOT hard-code shrink-0 (board/dashboard cells)", () => {
+    // The fix must be LOCAL to FinOps — a global shrink-0 on Panel would regress
+    // fixed-height board/dashboard cells.
+    const baseClasses =
+      panelSrc.match(/"overflow-hidden rounded-lg[^"]*"/)?.[0] ?? "";
+    expect(baseClasses).not.toContain("shrink-0");
+  });
+
+  it("ChartCard forwards className through to its root Panel", () => {
+    // The shrink-0 passthrough relies on ChartCard merging `className` onto the
+    // Panel. (No-op safeguard: keep the passthrough intact.)
+    expect(chartCardSrc).toContain("<Panel className={cn(");
+    expect(chartCardSrc).toMatch(/<Panel className=\{cn\([^)]*className/s);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-surface.tsx
@@ -352,6 +352,7 @@ export function FinopsSurface() {
         dataSource="[prom]"
         health={promHealth(todayReachable)}
         hasData={today !== null}
+        className="shrink-0"
         bodyClassName="min-h-[120px] p-4"
       >
         <FinopsHero today={today} cache={cache} />
@@ -364,6 +365,7 @@ export function FinopsSurface() {
         dataSource="[prom]"
         health={promHealth(seriesReachable)}
         hasData={series.length > 0}
+        className="shrink-0"
         bodyClassName="min-h-[260px] h-[min(40vh,320px)] p-3"
         headerExtra={
           nSpikes > 0 ? (
@@ -379,19 +381,23 @@ export function FinopsSurface() {
         <SpendOverTimePanel points={series} onSpikeClick={onSpikeClick} />
       </ChartCard>
 
-      {/* Spike drill strip — appears below P-A on a spike click. */}
+      {/* Spike drill strip — appears below P-A on a spike click. Wrapped in a
+          shrink-0 box so it keeps its natural height as a direct child of the
+          scroll column (the column scrolls; the strip never collapses). */}
       {spike && (
-        <SpikeDrillStrip
-          data={spike.data}
-          hourLabel={spike.label}
-          onClose={() => setSpike(null)}
-        />
+        <div className="shrink-0">
+          <SpikeDrillStrip
+            data={spike.data}
+            hourLabel={spike.label}
+            onClose={() => setSpike(null)}
+          />
+        </div>
       )}
 
       {/* OBS-11 BREAKDOWN GRID — two columns below the hero+P-A (layout spec §2).
           Left = trend/where-it-went bars (by-stage, by-model/agent); right = the
           default table (P-C) + the proportional token donut (P-E). */}
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <div className="grid shrink-0 grid-cols-1 gap-4 lg:grid-cols-2">
         {/* P-C — expensive tickets table (the default view, Principle 10). */}
         <ChartCard
           title="Expensive tickets"
@@ -460,8 +466,12 @@ export function FinopsSurface() {
         </ChartCard>
       </div>
 
-      {/* FOOTER strip — A4 concentration · A8 drift · locked $/story-point. */}
-      <FinopsFooter cost={cost} validation={validation} />
+      {/* FOOTER strip — A4 concentration · A8 drift · locked $/story-point.
+          Wrapped in a shrink-0 box so it keeps its natural height as a direct
+          child of the scroll column. */}
+      <div className="shrink-0">
+        <FinopsFooter cost={cost} validation={validation} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Root cause

The OBSERVE FinOps surface jumped straight from the header to the breakdown grid — there was **no hero number before scroll** (violates design Principle 1). The data was always correct and present in the DOM; this was purely a CSS layout bug.

The surface root (`finops-surface.tsx`) is a height-constrained flex column:
`flex h-full min-h-0 flex-col gap-4 overflow-y-auto`. `ChartCard` renders a `Panel` that is `overflow-hidden` with the flex default `shrink: 1` and no `shrink-0`. Under the column's height constraint the **"Today's spend"** hero card (`$492` spend + `$5176` cache-saved) and the **"Spend over time"** 25-bar chart shrank to clipped min-content (~2px) instead of the column scrolling. The breakdown grid + footer survived only because they are `overflow: visible`.

## Fix (LOCAL to finops-surface.tsx)

Add `shrink-0` to every direct child of the scroll column so the column's `overflow-y-auto` scrolls instead of collapsing the children:
- the two leading `ChartCard`s (`className` passthrough → root `Panel`)
- the breakdown grid wrapper
- the spike-drill strip + footer (wrapped in `shrink-0` boxes since those components have no `className` passthrough)

The global `Panel` component is **untouched** — a global `shrink-0` would regress fixed-height board/dashboard cells. `telemetry-surface` already avoids this via its `flex-1` grid, so it is left unchanged.

Adds `finops-layout.test.ts` — a source-structure regression guard (CSS layout is not unit-testable without a DOM render harness; the observe suites are pure-logic) asserting the scroll-column children carry `shrink-0` and that the `Panel`/`ChartCard` primitives were not globally regressed.

## Verification

- `bun run build` (ui) — pass
- parent `bun run build:ui` (real deploy invocation path; bun:sqlite trap clear) — pass
- `bun test finops-layout.test.ts` — 6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)