### PR TITLE
CTL-722: Fresh repos pass the execution-core stateMap contract check without manual remediation

### DIFF
--- a/.claude/config.template.json
+++ b/.claude/config.template.json
@@ -14,14 +14,18 @@
     "linear": {
       "teamKey": "PROJ",
       "stateMap": {
-        "backlog": "Backlog",
-        "todo": "Todo",
-        "research": "In Progress",
-        "planning": "In Progress",
-        "inProgress": "In Progress",
-        "inReview": "In Review",
-        "done": "Done",
-        "canceled": "Canceled"
+        "backlog":     "Backlog",
+        "todo":        "Todo",
+        "triage":      "Triage",
+        "research":    "Research",
+        "planning":    "Plan",
+        "inProgress":  "Implement",
+        "verifying":   "Validate",
+        "reviewing":   "Review",
+        "remediating": "Remediate",
+        "inReview":    "PR",
+        "done":        "Done",
+        "canceled":    "Canceled"
       }
     },
     "thoughts": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -606,7 +606,7 @@ Edit `~/catalyst/execution-core/registry.json` directly or re-run the enrollment
 node plugins/dev/scripts/execution-core/registry.mjs upsert \
   --team CTL \
   --repo-root /path/to/repo \
-  --status Ready    # was: Todo
+  --status Todo
 ```
 
 The daemon reads `eligibleQuery.status` from the registry on each scheduler tick.

--- a/docs/orchestrator-overview.md
+++ b/docs/orchestrator-overview.md
@@ -108,15 +108,15 @@ In `execution-core` dispatch mode the daemon's monitor reacts to Linear
 
 - **`→Triage`** one-shot-dispatches the triage phase agent (the ticket is not
   scheduler-pulled).
-- **`→Ready`** is the scheduler-eligible entry. New work enters the pipeline at
-  the `research` phase on the contract that a Ready ticket has already been
+- **`→Todo`** is the scheduler-eligible entry. New work enters the pipeline at
+  the `research` phase on the contract that a Todo ticket has already been
   triaged.
 
-A user may move a ticket **Backlog → Ready directly**, skipping `→Triage`
+A user may move a ticket **Backlog → Todo directly**, skipping `→Triage`
 (an intentional human shortcut). When this happens and no `triage.json` exists
 for the ticket, the monitor **auto-dispatches the triage phase agent** rather
 than reconciling the ticket into the eligible set — triage then runs and its
-completion advances the ticket to `research` normally. This makes "Ready" a
+completion advances the ticket to `research` normally. This makes "Todo" a
 valid manual entry point: the system transparently runs the missing triage
 instead of dead-locking the research prior-artifact gate. (CTL-625)
 

--- a/plugins/dev/scripts/__tests__/check-project-setup-execution-core.test.sh
+++ b/plugins/dev/scripts/__tests__/check-project-setup-execution-core.test.sh
@@ -33,10 +33,10 @@ build_project() {
   # stateMap (the authored contract) only.
   local state_map
   if [[ $full == "1" ]]; then
-    state_map='{"backlog":"Backlog","todo":"Ready","triage":"Triage","research":"Research","planning":"Plan","inProgress":"Implement","verifying":"Validate","reviewing":"Validate","inReview":"PR","done":"Done","canceled":"Canceled"}'
+    state_map='{"backlog":"Backlog","todo":"Todo","triage":"Triage","research":"Research","planning":"Plan","inProgress":"Implement","verifying":"Validate","reviewing":"Validate","inReview":"PR","done":"Done","canceled":"Canceled"}'
   else
     # missing Validate and PR from stateMap values
-    state_map='{"backlog":"Backlog","todo":"Ready","triage":"Triage","research":"Research","planning":"Plan","inProgress":"Implement","done":"Done","canceled":"Canceled"}'
+    state_map='{"backlog":"Backlog","todo":"Todo","triage":"Triage","research":"Research","planning":"Plan","inProgress":"Implement","done":"Done","canceled":"Canceled"}'
   fi
 
   cat > "$dir/.catalyst/config.json" <<EOF
@@ -57,7 +57,7 @@ EOF
   mkdir -p "${catalyst_dir}/execution-core"
   if [[ $registry == "1" ]]; then
     cat > "${catalyst_dir}/execution-core/registry.json" <<EOF
-{ "projects": [ { "team": "CTL", "repoRoot": "${dir}", "eligibleQuery": { "status": "Ready" } } ] }
+{ "projects": [ { "team": "CTL", "repoRoot": "${dir}", "eligibleQuery": { "status": "Todo" } } ] }
 EOF
   else
     echo '{ "projects": [] }' > "${catalyst_dir}/execution-core/registry.json"
@@ -121,6 +121,19 @@ if ! grep -qiE "contract state|registry entry" <<<"$OUT4"; then
 else
   fail "fully-configured execution-core repo emits no execution-core warning"
   echo "$OUT4" | sed 's/^/    /'
+fi
+
+# ─── Test 4b: CTL-722 — no "Ready missing" false-positive on post-cutover map ─
+# After CTL-722 the contract list is (Todo …), so a correctly-configured repo
+# with todo→"Todo" in the stateMap must not trigger a contract-state warning.
+P4B="${SCRATCH}/p4b"
+CD4B="$(build_project "$P4B" "execution-core" 1 1)"
+OUT4B="$(run_check "$P4B" "$CD4B" || true)"
+if ! grep -qi "Ready.*missing\|missing.*Ready\|contract state.*Ready" <<<"$OUT4B"; then
+  pass "CTL-722: no spurious 'Ready missing' warning on post-cutover map (Todo)"
+else
+  fail "CTL-722: no spurious 'Ready missing' warning on post-cutover map (Todo)"
+  echo "$OUT4B" | sed 's/^/    /'
 fi
 
 # ─── Test 5: execution-core + missing registry entry → hard error (CTL-578) ──

--- a/plugins/dev/scripts/__tests__/config-template-statemap.test.sh
+++ b/plugins/dev/scripts/__tests__/config-template-statemap.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# CTL-722: both templates must ship a stateMap whose VALUES satisfy the
+# execution-core contract (mirrors check-project-setup.sh:181-183).
+#
+# Run: bash plugins/dev/scripts/__tests__/config-template-statemap.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    command: $*"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+echo "config-template-statemap tests (CTL-722)"
+
+CONTRACT='["Todo","Research","Plan","Implement","Validate","PR"]'
+
+for tmpl in "plugins/dev/templates/config.template.json" ".claude/config.template.json"; do
+  run "template $tmpl: stateMap values satisfy contract" \
+    bash -c "jq -e --argjson c '$CONTRACT' \
+      '[.catalyst.linear.stateMap | to_entries[].value] as \$v
+       | \$c | all(. as \$s | \$v | index(\$s))' '${REPO_ROOT}/$tmpl'"
+  run "template $tmpl: stateMap has 12 keys" \
+    bash -c "jq -e '.catalyst.linear.stateMap | keys | length == 12' '${REPO_ROOT}/$tmpl'"
+  run "template $tmpl: no archived Ready value" \
+    bash -c "! jq -e '[.catalyst.linear.stateMap | to_entries[].value] | index(\"Ready\")' '${REPO_ROOT}/$tmpl' >/dev/null"
+done
+
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/setup-catalyst-statemap-gate.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-statemap-gate.test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# CTL-722 Phase 3: setup_execution_core_states must NOT early-return for a
+# phase-agents repo — the dispatchMode gate is removed so every --full run
+# provisions the contract states + registry entry.
+#
+# Run: bash plugins/dev/scripts/__tests__/setup-catalyst-statemap-gate.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SETUP_SCRIPT="${REPO_ROOT}/setup-catalyst.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    command: $*"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+echo "setup-catalyst-statemap-gate tests (CTL-722)"
+
+# Build a fake plugin root with a sentinel states script.
+# When invoked, the sentinel writes a marker file and exits 0.
+FAKE_PLUGIN_ROOT="${SCRATCH}/fake-plugin"
+mkdir -p "${FAKE_PLUGIN_ROOT}/scripts"
+SENTINEL="${SCRATCH}/states-script-ran"
+cat > "${FAKE_PLUGIN_ROOT}/scripts/setup-execution-core-states.sh" <<STUB
+#!/usr/bin/env bash
+touch "${SENTINEL}"
+exit 0
+STUB
+chmod +x "${FAKE_PLUGIN_ROOT}/scripts/setup-execution-core-states.sh"
+
+# Build a fixture project with dispatchMode=phase-agents (the non-execution-core default).
+build_phase_agents_project() {
+  local dir="$1"
+  mkdir -p "${dir}/.catalyst"
+  cat > "${dir}/.catalyst/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "test-project",
+    "linear": { "teamKey": "CTL" },
+    "orchestration": { "dispatchMode": "phase-agents" }
+  }
+}
+EOF
+}
+
+# Build a fixture project with dispatchMode=execution-core (should always run).
+build_execution_core_project() {
+  local dir="$1"
+  mkdir -p "${dir}/.catalyst"
+  cat > "${dir}/.catalyst/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "test-project",
+    "linear": { "teamKey": "CTL" },
+    "orchestration": { "dispatchMode": "execution-core" }
+  }
+}
+EOF
+}
+
+# ─── Test: phase-agents repo calls the states script (CTL-722 regression) ────
+WORK_PA="${SCRATCH}/phase-agents"
+build_phase_agents_project "$WORK_PA"
+rm -f "$SENTINEL"
+
+(
+  CATALYST_SETUP_LIB_ONLY=1
+  export CATALYST_SETUP_LIB_ONLY
+  # shellcheck source=/dev/null
+  source "$SETUP_SCRIPT"
+  PROJECT_DIR="$WORK_PA" CLAUDE_PLUGIN_ROOT="$FAKE_PLUGIN_ROOT" \
+    setup_execution_core_states
+) > "${SCRATCH}/pa-out" 2>&1 || true
+
+run "setup_execution_core_states runs under dispatchMode=phase-agents (CTL-722)" \
+  bash -c "[ -f '${SENTINEL}' ]"
+
+# ─── Test: execution-core repo also calls the states script (regression guard) ──
+WORK_EC="${SCRATCH}/execution-core"
+build_execution_core_project "$WORK_EC"
+rm -f "$SENTINEL"
+
+(
+  CATALYST_SETUP_LIB_ONLY=1
+  export CATALYST_SETUP_LIB_ONLY
+  # shellcheck source=/dev/null
+  source "$SETUP_SCRIPT"
+  PROJECT_DIR="$WORK_EC" CLAUDE_PLUGIN_ROOT="$FAKE_PLUGIN_ROOT" \
+    setup_execution_core_states
+) > "${SCRATCH}/ec-out" 2>&1 || true
+
+run "setup_execution_core_states still runs under dispatchMode=execution-core" \
+  bash -c "[ -f '${SENTINEL}' ]"
+
+# ─── Test: missing config -> silent no-op (existing behaviour preserved) ──────
+WORK_NOCFG="${SCRATCH}/no-config"
+mkdir -p "$WORK_NOCFG"
+rm -f "$SENTINEL"
+
+(
+  CATALYST_SETUP_LIB_ONLY=1
+  export CATALYST_SETUP_LIB_ONLY
+  # shellcheck source=/dev/null
+  source "$SETUP_SCRIPT"
+  PROJECT_DIR="$WORK_NOCFG" CLAUDE_PLUGIN_ROOT="$FAKE_PLUGIN_ROOT" \
+    setup_execution_core_states
+) > "${SCRATCH}/nocfg-out" 2>&1 || true
+
+run "setup_execution_core_states is a no-op when config is missing" \
+  bash -c "[ ! -f '${SENTINEL}' ]"
+
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
@@ -49,8 +49,8 @@ run "state map is valid JSON" \
 run "state map has 12 keys" \
   bash -c "echo '$STATE_MAP_JSON' | jq -e 'length == 12'"
 
-run "state map todo -> Ready" \
-  bash -c "echo '$STATE_MAP_JSON' | jq -e '.todo == \"Ready\"'"
+run "state map todo -> Todo" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e '.todo == \"Todo\"'"
 
 run "state map remediating -> Remediate (CTL-653)" \
   bash -c "echo '$STATE_MAP_JSON' | jq -e '.remediating == \"Remediate\"'"
@@ -85,17 +85,17 @@ run "state map done -> Done" \
 run "state map canceled -> Canceled" \
   bash -c "echo '$STATE_MAP_JSON' | jq -e '.canceled == \"Canceled\"'"
 
-# contract_states — exactly Ready Research Plan Implement Validate PR (no Triage).
+# contract_states — exactly Todo Research Plan Implement Validate PR (no Triage).
 CONTRACT="$(contract_states)"
 
 run "contract_states lists the 6 contract names" \
-  bash -c "[ \"\$(echo '$CONTRACT' | jq -r '.[].name' | sort | tr '\n' ' ')\" = 'Implement Plan PR Ready Research Validate ' ]"
+  bash -c "[ \"\$(echo '$CONTRACT' | jq -r '.[].name' | sort | tr '\n' ' ')\" = 'Implement Plan PR Research Todo Validate ' ]"
 
 run "contract_states excludes Triage" \
   bash -c "! echo '$CONTRACT' | jq -e '.[] | select(.name == \"Triage\")'"
 
-run "contract_states: Ready is unstarted" \
-  bash -c "echo '$CONTRACT' | jq -e '.[] | select(.name==\"Ready\") | .type == \"unstarted\"'"
+run "contract_states: Todo is unstarted" \
+  bash -c "echo '$CONTRACT' | jq -e '.[] | select(.name==\"Todo\") | .type == \"unstarted\"'"
 
 run "contract_states: Research is unstarted" \
   bash -c "echo '$CONTRACT' | jq -e '.[] | select(.name==\"Research\") | .type == \"unstarted\"'"
@@ -117,9 +117,9 @@ FETCHED_PARTIAL='[{"name":"Triage","type":"started"},{"name":"Research","type":"
 MISSING="$(missing_contract_states "$FETCHED_PARTIAL")"
 
 run "missing_contract_states returns the absent contract states" \
-  bash -c "[ \"\$(echo '$MISSING' | tr ' ' '\n' | grep -v '^\$' | sort | tr '\n' ' ')\" = 'Implement PR Ready Validate ' ]"
+  bash -c "[ \"\$(echo '$MISSING' | tr ' ' '\n' | grep -v '^\$' | sort | tr '\n' ' ')\" = 'Implement PR Todo Validate ' ]"
 
-FETCHED_ALL='[{"name":"Triage","type":"started"},{"name":"Ready","type":"unstarted"},{"name":"Research","type":"unstarted"},{"name":"Plan","type":"started"},{"name":"Implement","type":"started"},{"name":"Validate","type":"started"},{"name":"PR","type":"started"}]'
+FETCHED_ALL='[{"name":"Triage","type":"started"},{"name":"Todo","type":"unstarted"},{"name":"Research","type":"unstarted"},{"name":"Plan","type":"started"},{"name":"Implement","type":"started"},{"name":"Validate","type":"started"},{"name":"PR","type":"started"}]'
 
 run "missing_contract_states returns empty when all present (idempotent)" \
   bash -c "[ -z \"\$(missing_contract_states '$FETCHED_ALL' | tr -d '[:space:]')\" ]"
@@ -277,7 +277,7 @@ install_fake_curl() {
 
   local states_nodes
   if [ "$states" = "all" ]; then
-    states_nodes='{"id":"s-triage","name":"Triage","type":"started"},{"id":"s-ready","name":"Ready","type":"unstarted"},{"id":"s-research","name":"Research","type":"unstarted"},{"id":"s-plan","name":"Plan","type":"started"},{"id":"s-impl","name":"Implement","type":"started"},{"id":"s-val","name":"Validate","type":"started"},{"id":"s-pr","name":"PR","type":"started"},{"id":"s-backlog","name":"Backlog","type":"backlog"},{"id":"s-done","name":"Done","type":"completed"},{"id":"s-cancel","name":"Canceled","type":"canceled"}'
+    states_nodes='{"id":"s-triage","name":"Triage","type":"started"},{"id":"s-todo","name":"Todo","type":"unstarted"},{"id":"s-research","name":"Research","type":"unstarted"},{"id":"s-plan","name":"Plan","type":"started"},{"id":"s-impl","name":"Implement","type":"started"},{"id":"s-val","name":"Validate","type":"started"},{"id":"s-pr","name":"PR","type":"started"},{"id":"s-backlog","name":"Backlog","type":"backlog"},{"id":"s-done","name":"Done","type":"completed"},{"id":"s-cancel","name":"Canceled","type":"canceled"}'
   else
     states_nodes='{"id":"s-triage","name":"Triage","type":"started"},{"id":"s-research","name":"Research","type":"unstarted"},{"id":"s-plan","name":"Plan","type":"started"},{"id":"s-backlog","name":"Backlog","type":"backlog"},{"id":"s-done","name":"Done","type":"completed"}'
   fi
@@ -361,6 +361,22 @@ run "writes execution-core stateMap (inReview -> PR)" \
 run "upserts a registry entry for the team" \
   bash -c "jq -e '.projects[] | select(.team == \"CTL\")' '${SCRATCH}/ok/catalyst/execution-core/registry.json'"
 
+# ─── Unit tests: statemap_needs_write predicate (CTL-722) ────────────────────
+run "statemap_needs_write: legacy 8-key map (In Progress/In Review values) -> needs write" \
+  bash -c 'source '"$SCRIPT"'; statemap_needs_write '"'"'{"todo":"Todo","research":"In Progress","inReview":"In Review"}'"'"''
+
+run "statemap_needs_write: empty map -> needs write" \
+  bash -c 'source '"$SCRIPT"'; statemap_needs_write "{}"'
+
+run "statemap_needs_write: null/empty string -> needs write" \
+  bash -c 'source '"$SCRIPT"'; statemap_needs_write ""'
+
+run "statemap_needs_write: contract-satisfying map -> skip (return 1)" \
+  bash -c 'source '"$SCRIPT"'; ! statemap_needs_write '"'"'{"todo":"Todo","research":"Research","planning":"Plan","inProgress":"Implement","verifying":"Validate","reviewing":"Review","inReview":"PR"}'"'"''
+
+run "statemap_needs_write: user-customised non-legacy map without contract -> skip (return 1)" \
+  bash -c 'source '"$SCRIPT"'; ! statemap_needs_write '"'"'{"todo":"MyTodo","research":"MyResearch","planning":"Plan","inProgress":"Implement","verifying":"Validate","reviewing":"Review","inReview":"PR"}'"'"''
+
 # ─── Test: idempotent — re-run produces identical config ─────────────────────
 CONFIG_AFTER1="$(cat "${WORK_OK}/.catalyst/config.json")"
 HOME="$HOME_OK" PATH="$BIN_OK:$PATH" CATALYST_DIR="${SCRATCH}/ok/catalyst" \
@@ -368,6 +384,31 @@ HOME="$HOME_OK" PATH="$BIN_OK:$PATH" CATALYST_DIR="${SCRATCH}/ok/catalyst" \
 CONFIG_AFTER2="$(cat "${WORK_OK}/.catalyst/config.json")"
 run "re-run is idempotent (config unchanged)" \
   bash -c "[ \"\$CONFIG_AFTER1\" = \"\$CONFIG_AFTER2\" ]"
+
+# ─── Test: idempotency guard preserves user-customised stateMap (CTL-722) ────
+WORK_CUSTOM="${SCRATCH}/custom"
+BIN_CUSTOM="${SCRATCH}/custom/bin"
+HOME_CUSTOM="${SCRATCH}/custom/home"
+build_repo "$WORK_CUSTOM"
+build_secrets "$HOME_CUSTOM"
+install_fake_curl "$BIN_CUSTOM" "all" "ok"
+
+# First run: let the script write the contract map
+HOME="$HOME_CUSTOM" PATH="$BIN_CUSTOM:$PATH" CATALYST_DIR="${SCRATCH}/custom/catalyst" \
+  "$SCRIPT" --config "${WORK_CUSTOM}/.catalyst/config.json" > /dev/null 2>&1 || true
+
+# Mutate one value to a custom string (still satisfies contract so guard skips on re-run)
+jq '.catalyst.linear.stateMap.backlog = "MyCustomBacklog"' \
+  "${WORK_CUSTOM}/.catalyst/config.json" > "${WORK_CUSTOM}/.catalyst/config.json.tmp" \
+  && mv "${WORK_CUSTOM}/.catalyst/config.json.tmp" "${WORK_CUSTOM}/.catalyst/config.json"
+
+# Re-run — the guard must NOT overwrite since the contract is still satisfied
+HOME="$HOME_CUSTOM" PATH="$BIN_CUSTOM:$PATH" CATALYST_DIR="${SCRATCH}/custom/catalyst" \
+  "$SCRIPT" --config "${WORK_CUSTOM}/.catalyst/config.json" > /dev/null 2>&1 || true
+
+run "idempotency guard: user-customised stateMap preserved on re-run" \
+  bash -c "jq -e '.catalyst.linear.stateMap.backlog == \"MyCustomBacklog\"' \
+    '${WORK_CUSTOM}/.catalyst/config.json'"
 
 # ─── Test: workflowStateCreate fails -> states_incomplete + fallback printed ──
 WORK_FAIL="${SCRATCH}/fail"

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -175,7 +175,9 @@ if [[ -n $CONFIG_PATH ]]; then
 		# The contract states this check expects. Mirrors contract_states() in
 		# setup-execution-core-states.sh — keep the two in sync (different
 		# languages, so a shared constant is not possible).
-		EXECUTION_CORE_CONTRACT_STATES=(Ready Research Plan Implement Validate PR)
+		# CTL-722: Ready was archived on 2026-06-02; Todo is the post-cutover
+		# scheduler-eligible entry state.
+		EXECUTION_CORE_CONTRACT_STATES=(Todo Research Plan Implement Validate PR)
 		execution_core_gaps=0
 		for contract_state in "${EXECUTION_CORE_CONTRACT_STATES[@]}"; do
 			in_state_map=$(jq -r --arg s "$contract_state" \

--- a/plugins/dev/scripts/execution-core/autotune-writeback.test.mjs
+++ b/plugins/dev/scripts/execution-core/autotune-writeback.test.mjs
@@ -34,7 +34,7 @@ describe("writeLayer2MaxParallel", () => {
     writeFileSync(p, JSON.stringify({
       catalyst: {
         orchestration: {
-          eligibleQuery: { status: ["Ready"] },
+          eligibleQuery: { status: ["Todo"] },
           executionCore: { maxParallel: 3, minParallel: 1 },
         },
       },
@@ -44,7 +44,7 @@ describe("writeLayer2MaxParallel", () => {
     const out = JSON.parse(readFileSync(p, "utf8"));
     expect(out.catalyst.orchestration.executionCore.maxParallel).toBe(7);
     expect(out.catalyst.orchestration.executionCore.minParallel).toBe(1);
-    expect(out.catalyst.orchestration.eligibleQuery.status).toEqual(["Ready"]);
+    expect(out.catalyst.orchestration.eligibleQuery.status).toEqual(["Todo"]);
     expect(out.anotherTopKey).toBe("preserved");
   });
 

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -434,7 +434,7 @@ describe("startDaemon", () => {
       watchRegistry: true,
       debounceMs: 20,
     });
-    upsertProjectEntry({ team: "DEMO", repoRoot: "/r/d", eligibleQuery: { status: "Ready" } });
+    upsertProjectEntry({ team: "DEMO", repoRoot: "/r/d", eligibleQuery: { status: "Todo" } });
     // Poll up to 2s rather than a fixed wait — fs.watch delivery latency plus
     // the debounce timer varies under concurrent full-suite load, so a fixed
     // 60ms wait is flaky. The reconcile only has to fire once.
@@ -674,7 +674,7 @@ describe("resolveBootConcurrency (CTL-678)", () => {
         orchestration: {
           executionCore: {
             maxParallel: 4,
-            eligibleQuery: { status: "Ready" },
+            eligibleQuery: { status: "Todo" },
           },
         },
       },
@@ -684,7 +684,7 @@ describe("resolveBootConcurrency (CTL-678)", () => {
     });
     expect(resolveBootConcurrency({ layer1Path, layer2Path })).toEqual({
       maxParallel: 6,
-      eligibleQuery: { status: "Ready" },
+      eligibleQuery: { status: "Todo" },
     });
   });
 });

--- a/plugins/dev/scripts/setup-execution-core-states.sh
+++ b/plugins/dev/scripts/setup-execution-core-states.sh
@@ -4,7 +4,7 @@
 #
 # For an execution-core repo this script, idempotently:
 #   1. Ensures the contract workflow states exist for the team
-#      (Ready + Research, Plan, Implement, Validate, PR — Triage already exists).
+#      (Todo + Research, Plan, Implement, Validate, PR — Triage already exists).
 #      Missing states are created via raw `workflowStateCreate` GraphQL; on a
 #      permission/transport failure it prints admin-in-app fallback instructions.
 #   2. Writes the execution-core stateMap — the 9-phase -> 5-state collapse —
@@ -30,13 +30,38 @@
 set -uo pipefail
 
 # --- The contract -----------------------------------------------------------
+
+# CTL-722: decide whether to (over)write the stateMap.
+# Detect the legacy default by VALUES: "In Progress" / "In Review" mark the old
+# 8-key template. A map that already satisfies the contract — or any
+# user-customised map without those legacy values — is preserved untouched.
+# Returns 0 (needs write) or 1 (skip).
+statemap_needs_write() {
+  local current="$1"
+  [[ -z $current || $current == "null" || $current == "{}" ]] && return 0
+  # contract satisfied? (all 6 values present) -> skip
+  if jq -e '
+        [to_entries[].value] as $v
+        | (["Todo","Research","Plan","Implement","Validate","PR"]
+           | all(. as $s | $v | index($s)))' <<<"$current" >/dev/null 2>&1; then
+    return 1
+  fi
+  # legacy signature present? -> rewrite
+  if jq -e '[to_entries[].value] | (index("In Progress") or index("In Review"))' \
+        <<<"$current" >/dev/null 2>&1; then
+    return 0
+  fi
+  # non-legacy, non-contract custom map -> preserve
+  return 1
+}
+
 # The execution-core 9-phase -> 5-state collapse map. `todo` maps to the
-# pickable contract state `Ready`; verify+review collapse to `Validate`;
+# pickable contract state `Todo`; verify+review collapse to `Validate`;
 # pr+monitor-merge+monitor-deploy collapse to `PR`.
 build_execution_core_state_map() {
   jq -nc '{
     backlog: "Backlog",
-    todo: "Ready",
+    todo: "Todo",
     triage: "Triage",
     research: "Research",
     planning: "Plan",
@@ -54,7 +79,7 @@ build_execution_core_state_map() {
 # Triage is intentionally excluded — it already exists in every team workflow.
 contract_states() {
   jq -nc '[
-    { name: "Ready",     type: "unstarted" },
+    { name: "Todo",      type: "unstarted" },
     { name: "Research",  type: "unstarted" },
     { name: "Plan",      type: "started"   },
     { name: "Implement", type: "started"   },
@@ -380,7 +405,7 @@ main() {
   # defaults it to "Triage" too, but pin it here so the registry entry is
   # self-describing.
   registry_query=$(jq -nc \
-    '{ status: "Ready", triageStatus: "Triage", project: null, label: null, priority: null }')
+    '{ status: "Todo", triageStatus: "Triage", project: null, label: null, priority: null }')
 
   # --- dry-run: report intent, write nothing ---
   if [[ $dry_run -eq 1 ]]; then
@@ -457,10 +482,16 @@ main() {
     echo "  OLD fallback: set catalyst.monitor.linear.botUserId in $config" >&2
   fi
 
-  # --- write the execution-core stateMap (atomic tmp + mv) ---
-  jq --argjson stateMap "$state_map" '.catalyst.linear.stateMap = $stateMap' \
-    "$config" > "${config}.tmp" && mv "${config}.tmp" "$config"
-  echo "Wrote execution-core stateMap to $config"
+  # --- write the execution-core stateMap (atomic tmp + mv), only if needed (CTL-722) ---
+  local current_map
+  current_map="$(jq -c '.catalyst.linear.stateMap // {}' "$config" 2>/dev/null || echo '{}')"
+  if statemap_needs_write "$current_map"; then
+    jq --argjson stateMap "$state_map" '.catalyst.linear.stateMap = $stateMap' \
+      "$config" > "${config}.tmp" && mv "${config}.tmp" "$config"
+    echo "Wrote execution-core stateMap to $config"
+  else
+    echo "stateMap already satisfies the contract or is user-customised — preserved ($config)"
+  fi
 
   # --- refresh the machine-local stateIds cache via resolve-linear-ids.sh --force ---
   # CTL-577: stateIds is cached in ~/.config/catalyst/linear-state-ids.json,

--- a/plugins/dev/templates/config.template.json
+++ b/plugins/dev/templates/config.template.json
@@ -14,14 +14,18 @@
     "linear": {
       "teamKey": "PROJ",
       "stateMap": {
-        "backlog": "Backlog",
-        "todo": "Todo",
-        "research": "In Progress",
-        "planning": "In Progress",
-        "inProgress": "In Progress",
-        "inReview": "In Review",
-        "done": "Done",
-        "canceled": "Canceled"
+        "backlog":     "Backlog",
+        "todo":        "Todo",
+        "triage":      "Triage",
+        "research":    "Research",
+        "planning":    "Plan",
+        "inProgress":  "Implement",
+        "verifying":   "Validate",
+        "reviewing":   "Review",
+        "remediating": "Remediate",
+        "inReview":    "PR",
+        "done":        "Done",
+        "canceled":    "Canceled"
       }
     },
     "thoughts": {

--- a/plugins/foundry/skills/setup-catalyst/SKILL.md
+++ b/plugins/foundry/skills/setup-catalyst/SKILL.md
@@ -147,16 +147,16 @@ The source guard (`if ! (return 0 2>/dev/null); then main "$@"; fi`) replaces th
 `BASH_SOURCE[0]`-based check and works correctly in `curl | bash` pipelines where
 `BASH_SOURCE[0]` is unset.
 
-**Execution-core state contract (CTL-564).** When a repo's
-`catalyst.orchestration.dispatchMode` is `execution-core`, `setup-catalyst.sh`
-runs an extra step — `setup_execution_core_states` — right after the Linear
-workflow-state fetch. That step delegates to the standalone
+**Execution-core state contract (CTL-564).** `setup-catalyst.sh` runs an extra
+step — `setup_execution_core_states` — right after the Linear workflow-state
+fetch for every `--full` repo (CTL-722: not gated on `dispatchMode` any more).
+That step delegates to the standalone
 `plugins/dev/scripts/setup-execution-core-states.sh`, which ensures the team's
-contract workflow states exist (`Ready` + `Research`, `Plan`, `Implement`,
+contract workflow states exist (`Todo` + `Research`, `Plan`, `Implement`,
 `Validate`, `PR`; `Triage` already exists), writes the 9-phase → 5-state
-collapse `stateMap`, refreshes `stateIds`, and upserts the team's entry in the
-central `~/catalyst/execution-core/registry.json`. The step is a silent no-op
-for `phase-agents` / `oneshot-legacy` repos, and a Linear-permission failure in
+collapse `stateMap` (idempotent — preserves user-customised maps), refreshes
+`stateIds`, and upserts the team's entry in the central
+`~/catalyst/execution-core/registry.json`. A Linear-permission failure in
 the standalone script never aborts setup. The standalone script is also
 idempotent and can be run directly per team (`setup-execution-core-states.sh
 --config .catalyst/config.json [--dry-run] [--json]`).

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -407,11 +407,10 @@ update_config_with_linear_states() {
 }
 
 # Ensure the execution-core Linear-state contract (CTL-564). A thin wrapper:
-# only when the resolved config's orchestration.dispatchMode is "execution-core"
-# does it invoke the standalone setup-execution-core-states.sh, which ensures the
-# contract states exist, writes the 9->5 collapse stateMap, refreshes stateIds,
-# and upserts the central registry entry. For phase-agents / oneshot-legacy repos
-# this is a silent no-op. A non-zero exit from the standalone script (e.g. a
+# invokes setup-execution-core-states.sh for every --full repo so the contract
+# states, collapse stateMap, and registry entry are provisioned regardless of
+# dispatchMode (CTL-722: the stateMap write is idempotent — the states script
+# preserves a template-default or user-customised map). A non-zero exit (e.g. a
 # Linear-permission failure) is tolerated (|| true) so it never aborts setup.
 setup_execution_core_states() {
 	# Resolve config the same way update_config_with_linear_states does:
@@ -422,10 +421,10 @@ setup_execution_core_states() {
 	fi
 	[[ -f $config_file ]] || return 0
 
-	local dispatch_mode
-	dispatch_mode=$(jq -r '.catalyst.orchestration.dispatchMode // empty' "$config_file" 2>/dev/null)
-	# Gate: only execution-core repos get the state-contract step.
-	[[ $dispatch_mode == "execution-core" ]] || return 0
+	# CTL-722: run the state-contract step for every --full repo, not only
+	# execution-core ones, so a fresh phase-agents repo provisions the contract
+	# states + registry entry. The stateMap write is idempotent (the states
+	# script preserves a template-default or user-customised map).
 
 	# Locate the standalone script — installed plugin root or the repo checkout.
 	local states_script=""


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-10T23:55:00Z -->
<!-- Last updated: 2026-06-10T23:55:00Z -->
<!-- PR: #1720 -->
<!-- Previous commits: 4c10364d,ab5e0216,ccf71370,e9468504,b5dca1bb -->

# CTL-722: Fresh repos pass the execution-core stateMap contract check without manual remediation

A project initialised from the config template shipped a legacy 8-key stateMap that failed the
execution-core contract check (which requires `Todo`, `Research`, `Plan`, `Implement`, `Validate`,
`PR`). Operators had to run a remediation script manually before the daemon would start, and the
scheduler used the archived `Ready` state as the eligible-entry point even though Linear retired
it in favour of `Todo` on 2026-06-02.

This PR fixes all three root causes in five phases.

## Changes Made

### Phase 1 — Templates ship the 12-key contract stateMap

- `.claude/config.template.json` and `plugins/dev/templates/config.template.json`: expanded from
  the legacy 8-key map to the full 12-key map, replacing `todo → "Ready"` with `todo → "Todo"`
  and adding `triage`, `verifying`, `reviewing`, and `remediating` entries.
- New test: `config-template-statemap.test.sh` — verifies both templates satisfy the 6-key
  contract, have exactly 12 keys, and contain no archived `Ready` value (3 assertions × 2
  templates = 6 tests).

### Phase 2 — Idempotency guard + Ready→Todo in `setup-execution-core-states.sh`

- Added `statemap_needs_write()` predicate: skips the stateMap write when the current map already
  satisfies the contract OR when it's a user-customised map without legacy `"In Progress"` /
  `"In Review"` values. Rewrites only when the map is empty/null or carries the legacy signature.
- `todo → "Ready"` → `todo → "Todo"` throughout `build_execution_core_state_map()` and
  `contract_states()`.
- 5 new unit tests for `statemap_needs_write`; 1 new idempotency test for user-customised maps.

### Phase 3 — Remove execution-core gate in `setup-catalyst.sh`

- Removed the `dispatchMode == execution-core` guard that prevented `setup_execution_core_states`
  from running for `phase-agents` repos on `--full`. The function now runs unconditionally when
  `--full` is set, ensuring any repo that opts into execution-core later doesn't need a manual
  remediation pass.
- New test: `setup-catalyst-statemap-gate.test.sh` — 3 tests covering `phase-agents`, `execution-core`,
  and missing-config cases.

### Phase 4 — `check-project-setup.sh` contract list Ready→Todo

- `EXECUTION_CORE_CONTRACT_STATES` array updated from `(Ready …)` to `(Todo …)` to eliminate
  the false-positive `Ready missing` warning on post-cutover configs.
- New regression test `Test 4b` added to `check-project-setup-execution-core.test.sh`.

### Phase 5 — Test-fixture + docs Ready→Todo sweep

- `setup-execution-core-states.test.sh`: updated 3 test assertions and mock fixture nodes
  (`s-ready` → `s-todo`, `Ready` → `Todo`).
- `autotune-writeback.test.mjs`, `daemon.test.mjs`: updated `eligibleQuery.status` fixtures
  from `"Ready"` to `"Todo"`.
- `docs/orchestrator-overview.md`: `→Ready` → `→Todo` throughout (4 occurrences).
- `docs/configuration.md`: corrected example `--status Ready` → `--status Todo`.

## How to Verify It

- [x] `bash plugins/dev/scripts/__tests__/config-template-statemap.test.sh` — 6/6 pass ✅
- [x] `bash plugins/dev/scripts/__tests__/setup-catalyst-statemap-gate.test.sh` — 3/3 pass ✅
- [x] `bash plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh` — 62/62 pass ✅
- [x] `bash plugins/dev/scripts/__tests__/check-project-setup-execution-core.test.sh` — 13/13 pass ✅
- [x] `bun test plugins/dev/scripts/execution-core/autotune-writeback.test.mjs` — 6/6 pass ✅
- [x] `bun test plugins/dev/scripts/execution-core/daemon.test.mjs` — 90/91 pass ✅ (1 pre-existing fs.watch flake on origin/main, not a CTL-722 regression)
- [x] CI: all 6 checks pass (audit-references, check-versions, docs-gate, execution-core-unit-tests, validate, Cloudflare Pages) ✅
- [ ] Manual: initialise a fresh repo from the template, run `setup-catalyst.sh --full`, confirm `check-project-setup.sh` exits 0 without manual remediation

## Changelog Entry

### feat(dev): CTL-722 — stateMap contract fix for fresh repo setup

- Updated config templates to ship the full 12-key stateMap with `Todo` as the scheduler-eligible
  entry (replaces archived `Ready`)
- Added `statemap_needs_write()` idempotency guard to `setup-execution-core-states.sh` to
  preserve user-customised stateMap values on re-runs
- Removed `dispatchMode` gate from `setup-catalyst.sh` so contract states are provisioned on
  every `--full` run regardless of dispatch mode
- Updated contract list in `check-project-setup.sh` from `Ready` to `Todo`

## Related Issues/PRs

- Fixes https://linear.app/rozich/issue/CTL-722
