### PR TITLE
fix(dev): CTL-990 — kill the dirty-worktree rebase loop (root fix + typed precheck + recreate guard + dispatch timeout)

### DIFF
--- a/plugins/dev/scripts/__tests__/create-worktree-tracked-clean.test.sh
+++ b/plugins/dev/scripts/__tests__/create-worktree-tracked-clean.test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Tests for CTL-990: create-worktree.sh must not dirty TRACKED files in the
+# fresh worktree. `cp -R .claude` / `cp -R .catalyst` copy the MAIN checkout's
+# working-tree versions — local edits included — over the freshly-checked-out
+# branch versions, so every new worktree starts with dirty tracked config and
+# the dispatch-time rebase refuses to start (the ADV-1326/ADV-1308 loop).
+# Untracked machine-local files (settings.local.json, …) must still be copied.
+# Run: bash plugins/dev/scripts/__tests__/create-worktree-tracked-clean.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+CREATE_WT="${REPO_ROOT}/plugins/dev/scripts/create-worktree.sh"
+
+FAILURES=0
+PASSES=0
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+}
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+assert_eq() {
+	if [[ $1 == "$2" ]]; then pass "$3"; else fail "$3 — expected '$1', got '$2'"; fi
+}
+
+# Scratch layout mirrors create-worktree-base-ref.test.sh:
+#   SCRATCH/origin.git   bare origin
+#   SCRATCH/src          main checkout (where tracked config gets locally dirtied)
+#   SCRATCH/wt           worktree base
+# The committed config carries catalyst.worktree.setup=["true"] so creation
+# takes the config-driven setup path (a no-op) instead of the auto-detected
+# thoughts-init path, which requires a live humanlayer thoughts profile.
+COMMITTED_CATALYST_CFG='{"catalyst":{"projectKey":"t","worktree":{"setup":["true"]}}}'
+build_scratch() {
+	SCRATCH="$(mktemp -d -t cwt-ctl990-XXXXXX)"
+	ORIGIN="$SCRATCH/origin.git"
+	SRC="$SCRATCH/src"
+	WT="$SCRATCH/wt"
+	FAKEHOME="$SCRATCH/home"
+	mkdir -p "$WT" "$FAKEHOME"
+	git init -q --bare "$ORIGIN"
+
+	# Seed origin/main with TRACKED .claude/config.json + .catalyst/config.json.
+	local SEED="$SCRATCH/seed"
+	git clone -q "$ORIGIN" "$SEED"
+	git -C "$SEED" config user.email t@t.t
+	git -C "$SEED" config user.name t
+	git -C "$SEED" checkout -q -b main 2>/dev/null || git -C "$SEED" checkout -q main
+	mkdir -p "$SEED/.claude" "$SEED/.catalyst"
+	printf '{"claude":"committed"}\n' >"$SEED/.claude/config.json"
+	printf '%s\n' "$COMMITTED_CATALYST_CFG" >"$SEED/.catalyst/config.json"
+	git -C "$SEED" add -A
+	git -C "$SEED" commit -q -m c1
+	git -C "$SEED" push -q -u origin main
+
+	git clone -q "$ORIGIN" "$SRC"
+	git -C "$SRC" config user.email t@t.t
+	git -C "$SRC" config user.name t
+}
+
+run_create() { # $1 worktree name; $@ extra args
+	local NAME="$1"
+	shift
+	OUTPUT="$(cd "$SRC" && HOME="$FAKEHOME" \
+		bash "$CREATE_WT" "$NAME" main --worktree-dir "$WT" "$@" 2>&1)"
+	EXIT=$?
+	WT_PATH="$WT/$NAME"
+}
+
+# Case 1 — dirty tracked config in the main checkout must NOT dirty the worktree.
+echo "Test 1: locally-modified tracked config does not dirty the fresh worktree"
+build_scratch
+printf '{"claude":"machine-local-edit"}\n' >"$SRC/.claude/config.json"
+printf '{"catalyst":{"projectKey":"t","worktree":{"setup":["true"]},"machineLocal":true}}\n' >"$SRC/.catalyst/config.json"
+printf '{"local":"untracked-settings"}\n' >"$SRC/.claude/settings.local.json"
+run_create wt-clean
+assert_eq "0" "$EXIT" "exits 0"
+PORCELAIN="$(git -C "$WT_PATH" status --porcelain -- .claude .catalyst 2>/dev/null | grep -v '^??' || true)"
+assert_eq "" "$PORCELAIN" "no tracked .claude/.catalyst changes in the fresh worktree"
+assert_eq '{"claude":"committed"}' "$(cat "$WT_PATH/.claude/config.json" 2>/dev/null)" \
+	"tracked .claude/config.json carries the BRANCH content, not the dirty copy"
+assert_eq "$COMMITTED_CATALYST_CFG" "$(cat "$WT_PATH/.catalyst/config.json" 2>/dev/null)" \
+	"tracked .catalyst/config.json carries the BRANCH content, not the dirty copy"
+assert_eq '{"local":"untracked-settings"}' "$(cat "$WT_PATH/.claude/settings.local.json" 2>/dev/null)" \
+	"untracked machine-local settings.local.json still copied"
+rm -rf "$SCRATCH"
+
+# Case 2 — a wholly-untracked .claude dir copies fine (checkout pathspec no-match tolerated).
+echo "Test 2: untracked-only .claude dir copies without error"
+build_scratch
+git -C "$SRC" rm -q -r .claude
+git -C "$SRC" commit -q -m "drop tracked .claude"
+git -C "$SRC" push -q origin main
+mkdir -p "$SRC/.claude"
+printf '{"only":"untracked"}\n' >"$SRC/.claude/settings.local.json"
+run_create wt-untracked
+assert_eq "0" "$EXIT" "exits 0 when .claude has no tracked files"
+assert_eq '{"only":"untracked"}' "$(cat "$WT_PATH/.claude/settings.local.json" 2>/dev/null)" \
+	"untracked-only .claude content still copied"
+rm -rf "$SCRATCH"
+
+echo ""
+echo "Passed: $PASSES  Failed: $FAILURES"
+[[ $FAILURES -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -1908,6 +1908,58 @@ assert_eq "prior_artifact_missing" \
 [[ -f "${WORKER_DIR}/phase-teardown.json" ]] && SIG_TD_EXISTS="yes" || SIG_TD_EXISTS="no"
 assert_eq "no" "$SIG_TD_EXISTS" "no teardown signal written when refused"
 
+# ─── Test 61 (CTL-990): recreate runs at most ONCE — guard env parks instead ─
+# The ADV-1308 storm: research/plan rc=2 → destroy+recreate → exec $0 → the
+# recreated worktree is dirty again → rc=2 → recreate → exec … an in-process
+# infinite loop no scheduler cooldown can see. With CATALYST_RECREATE_ATTEMPTED
+# already set, the dispatcher must PARK (stalled, exit 1), never re-recreate.
+echo ""
+echo "Test 61 (CTL-990): CATALYST_RECREATE_ATTEMPTED set → source conflict parks, no second recreate"
+fresh_env t61_recreate_guard
+git_worktree_fixture t61
+advance_origin_conflict
+printf '{"ticket":"CTL-100","phase":"triage","status":"done"}\n' >"${WORKER_DIR}/triage.json"
+(
+	cd "$GWORK"
+	printf 'local-edit\n' >shared.txt
+	git add -A && git commit --quiet -m "local conflicting edit"
+)
+ORIG_HEAD="$(cd "$GWORK" && git rev-parse HEAD)"
+(cd "$GWORK" && CATALYST_BASE_BRANCH=main CATALYST_RECREATE_ATTEMPTED=1 \
+	"$DISPATCH" --phase research --ticket CTL-100 \
+	--orch-dir "$ORCH_DIR" --orch-id orch-test >"${TEST_DIR}/t61.out" 2>/dev/null)
+RC61=$?
+SIGNAL="${WORKER_DIR}/phase-research.json"
+assert_eq "1" "$RC61" "recreate guard: dispatcher exits 1 (parked, not exec-looped)"
+CLAUDE61="no"; [[ -s $CLAUDE_STUB_LOG ]] && CLAUDE61="yes"
+assert_eq "no" "$CLAUDE61" "recreate guard: claude --bg was NOT invoked"
+assert_eq "stalled" "$(jq -r '.status' "$SIGNAL" 2>/dev/null)" "recreate guard: signal status = stalled"
+NOW_HEAD="$(cd "$GWORK" && git rev-parse HEAD)"
+assert_eq "$ORIG_HEAD" "$NOW_HEAD" "recreate guard: worktree NOT destroyed/recreated (HEAD unchanged)"
+
+# ─── Test 62 (CTL-990): pre-flight dirty-tree refusal parks with the TYPED reason ─
+# A tracked dirty non-noise file makes git refuse to start the rebase. The
+# signal's failureReason must carry rebase_refused_dirty_tree — not the old
+# misleading source_conflict_ctl708_unavailable (from a continue_failed cascade).
+echo ""
+echo "Test 62 (CTL-990): dirty tracked file → park with failureReason=rebase_refused_dirty_tree"
+fresh_env t62_precheck_reason
+git_worktree_fixture t62
+advance_origin_clean
+seed_local_plan_commit
+# Dirty a tracked NON-noise file AFTER the local commit (uncommitted edit).
+printf 'uncommitted-dirty-edit\n' >"${GWORK}/shared.txt"
+(cd "$GWORK" && CATALYST_BASE_BRANCH=main "$DISPATCH" --phase implement --ticket CTL-100 \
+	--orch-dir "$ORCH_DIR" --orch-id orch-test >"${TEST_DIR}/t62.out" 2>/dev/null)
+RC62=$?
+SIGNAL="${WORKER_DIR}/phase-implement.json"
+assert_eq "1" "$RC62" "precheck park: dispatcher exits 1"
+CLAUDE62="no"; [[ -s $CLAUDE_STUB_LOG ]] && CLAUDE62="yes"
+assert_eq "no" "$CLAUDE62" "precheck park: claude --bg was NOT invoked"
+assert_eq "stalled" "$(jq -r '.status' "$SIGNAL" 2>/dev/null)" "precheck park: signal status = stalled"
+assert_eq "rebase_refused_dirty_tree" "$(jq -r '.failureReason' "$SIGNAL" 2>/dev/null)" \
+	"precheck park: signal failureReason = rebase_refused_dirty_tree (typed, not continue_failed cascade)"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -174,6 +174,19 @@ if [ -d ".catalyst" ]; then
 	cp -R .catalyst "$WORKTREE_PATH/"
 fi
 
+# CTL-990: the cp -R above copies the MAIN checkout's working-tree versions of
+# git-TRACKED files (e.g. a locally-modified .claude/config.json) over the
+# freshly-checked-out branch versions — every new worktree then starts with
+# dirty tracked config, and the dispatch-time rebase refuses to start
+# ("you have unstaged changes"), which looped ADV-1326/ADV-1308. Restore
+# tracked paths to the branch state; untracked machine-local files
+# (settings.local.json, …) survive untouched.
+for CFG_DIR in .claude .catalyst; do
+	if [ -d "$WORKTREE_PATH/$CFG_DIR" ]; then
+		git -C "$WORKTREE_PATH" checkout --quiet -- "$CFG_DIR" 2>/dev/null || true
+	fi
+done
+
 # Pre-trust worktree in Claude Code so no trust dialog appears on first launch
 CLAUDE_JSON="$HOME/.claude.json"
 if [ -f "$CLAUDE_JSON" ]; then

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -52,6 +52,15 @@ function defaultResolveProject(ticket) {
 // the dead session) instead of a fresh phase-0 `$PROMPT` start. Omitted entirely
 // when null/undefined → today's fresh-start behaviour. `spawn` is injectable so
 // the unit test can assert the built arg array without a real spawn.
+// CTL-990: hard ceiling on the synchronous phase-agent-dispatch spawn. A
+// wedged dispatch (the recreate→rebase-refused exec recursion looped here for
+// hours, invisible — no rc, no failure ladder) must surface as a failed
+// dispatch, not block the daemon. Generous: worktree provisioning (bun
+// install et al) can legitimately take minutes. Read lazily so tests and
+// operators can override at runtime.
+const getDispatchTimeoutMs = () =>
+  Number(process.env.CATALYST_DISPATCH_TIMEOUT_MS) || 15 * 60 * 1000;
+
 export function defaultRunPhaseAgent(
   { orchDir, ticket, phase, worktreePath, resumeSession, handoffPath, attempt },
   { spawn = spawnSync } = {},
@@ -64,6 +73,8 @@ export function defaultRunPhaseAgent(
   const res = spawn(PHASE_AGENT_DISPATCH_BIN, args, {
     cwd: worktreePath,
     encoding: "utf8",
+    timeout: getDispatchTimeoutMs(), // CTL-990
+    killSignal: "SIGKILL", // CTL-990: a wedged dispatch may ignore SIGTERM mid-exec-loop
     env: {
       ...process.env,
       CATALYST_ORCHESTRATOR_DIR: orchDir,

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -70,20 +70,25 @@ export function defaultRunPhaseAgent(
   if (attempt != null) args.push("--attempt", String(attempt)); // CTL-761
   const extraEnv = {};
   if (handoffPath) extraEnv.CATALYST_HANDOFF_PATH = handoffPath;
+  const env = {
+    ...process.env,
+    CATALYST_ORCHESTRATOR_DIR: orchDir,
+    CATALYST_ORCHESTRATOR_ID: ticket,
+    CATALYST_PHASE: phase,
+    CATALYST_TICKET: ticket,
+    CATALYST_EXECUTION_CORE: "1",
+    ...extraEnv,
+  };
+  // CTL-990: the recreate-once marker is PER DISPATCH CHAIN — only the chain's
+  // own exec may set it. An ambient daemon-env value would pre-spend every
+  // fresh dispatch's single recreate attempt.
+  delete env.CATALYST_RECREATE_ATTEMPTED;
   const res = spawn(PHASE_AGENT_DISPATCH_BIN, args, {
     cwd: worktreePath,
     encoding: "utf8",
     timeout: getDispatchTimeoutMs(), // CTL-990
     killSignal: "SIGKILL", // CTL-990: a wedged dispatch may ignore SIGTERM mid-exec-loop
-    env: {
-      ...process.env,
-      CATALYST_ORCHESTRATOR_DIR: orchDir,
-      CATALYST_ORCHESTRATOR_ID: ticket,
-      CATALYST_PHASE: phase,
-      CATALYST_TICKET: ticket,
-      CATALYST_EXECUTION_CORE: "1",
-      ...extraEnv,
-    },
+    env,
   });
   if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
   return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };

--- a/plugins/dev/scripts/execution-core/dispatch.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.test.mjs
@@ -254,6 +254,34 @@ describe("defaultRunPhaseAgent — spawn-arg construction (CTL-658)", () => {
     expect(args).not.toContain("--resume-session");
     expect(args).toEqual(["--phase", "implement", "--ticket", "CTL-1", "--orch-dir", "/ec", "--orch-id", "CTL-1"]);
   });
+
+  // CTL-990: an exec-looping phase-agent-dispatch (the recreate→rebase-refused
+  // recursion) blocked the daemon's synchronous spawn forever — no rc, no
+  // failure ladder. The spawn must carry a hard timeout + SIGKILL.
+  test("passes a hard timeout + SIGKILL so a wedged dispatch cannot block the daemon (CTL-990)", () => {
+    const spawn = spy();
+    defaultRunPhaseAgent(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "research", worktreePath: "/wt/CTL-1" },
+      { spawn },
+    );
+    const { opts } = spawn.calls[0];
+    expect(opts.timeout).toBeGreaterThan(0);
+    expect(opts.killSignal).toBe("SIGKILL");
+  });
+
+  test("CATALYST_DISPATCH_TIMEOUT_MS overrides the spawn timeout (CTL-990)", () => {
+    const spawn = spy();
+    process.env.CATALYST_DISPATCH_TIMEOUT_MS = "12345";
+    try {
+      defaultRunPhaseAgent(
+        { orchDir: "/ec", ticket: "CTL-1", phase: "research", worktreePath: "/wt/CTL-1" },
+        { spawn },
+      );
+    } finally {
+      delete process.env.CATALYST_DISPATCH_TIMEOUT_MS;
+    }
+    expect(spawn.calls[0].opts.timeout).toBe(12345);
+  });
 });
 
 describe("dispatchTicket", () => {

--- a/plugins/dev/scripts/execution-core/dispatch.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.test.mjs
@@ -282,6 +282,23 @@ describe("defaultRunPhaseAgent — spawn-arg construction (CTL-658)", () => {
     }
     expect(spawn.calls[0].opts.timeout).toBe(12345);
   });
+
+  // CTL-990: the recreate-once marker must be PER DISPATCH CHAIN (set only by
+  // phase-agent-dispatch's own exec). An ambient value in the daemon's env
+  // would pre-spend every fresh dispatch's recreate budget via ...process.env.
+  test("strips an ambient CATALYST_RECREATE_ATTEMPTED from the spawned env (CTL-990)", () => {
+    const spawn = spy();
+    process.env.CATALYST_RECREATE_ATTEMPTED = "1";
+    try {
+      defaultRunPhaseAgent(
+        { orchDir: "/ec", ticket: "CTL-1", phase: "research", worktreePath: "/wt/CTL-1" },
+        { spawn },
+      );
+    } finally {
+      delete process.env.CATALYST_RECREATE_ATTEMPTED;
+    }
+    expect("CATALYST_RECREATE_ATTEMPTED" in spawn.calls[0].opts.env).toBe(false);
+  });
 });
 
 describe("dispatchTicket", () => {

--- a/plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh
@@ -551,6 +551,42 @@ advance_origin_main_conflict
 assert_eq "yes" "$(cat "$SCRATCH/t17.during")" "rebase_in_progress=true mid-conflict"
 assert_eq "no" "$(cat "$SCRATCH/t17.after")" "rebase_in_progress=false after abort"
 
+# ── 19. untracked-overwrite refusal → dirty-tree stall with files listed ────
+# git ALSO refuses to start a rebase when an UNTRACKED file would be
+# overwritten by the incoming base — invisible to the tracked-only precheck.
+# The no-rebase-in-progress guard must report it as the dirty-tree class with
+# the worktree's dirt listed, not as an opaque internal/[] stall.
+echo "19. untracked-overwrite refusal → rebase_refused_dirty_tree with files"
+new_fixture t19
+(
+  cd "$UP"
+  git checkout --quiet main
+  printf 'upstream-version\n' >colliding.txt
+  git add -A && git commit --quiet -m "upstream adds colliding.txt"
+  git push --quiet origin main
+)
+(
+  cd "$WORK"
+  printf 'local-feature\n' >local.txt
+  git add -A && git commit --quiet -m "local feature"
+  # UNTRACKED file at the path origin/main now tracks → rebase refuses to start.
+  printf 'untracked-local-version\n' >colliding.txt
+  rebase_onto_base_classified "main"
+  echo "$?" >"$SCRATCH/t19.rc"
+  echo "${REBASE_LAST_STALL_REASON:-}" >"$SCRATCH/t19.reason_var"
+  cat colliding.txt >"$SCRATCH/t19.untracked"
+)
+assert_eq "2" "$(cat "$SCRATCH/t19.rc")" "untracked-overwrite refusal → rc 2"
+assert_eq "rebase_refused_dirty_tree" "$(cat "$SCRATCH/t19.reason_var")" \
+  "untracked-overwrite: typed dirty-tree reason (not no_rebase_in_progress)"
+assert_eq "untracked-local-version" "$(cat "$SCRATCH/t19.untracked")" \
+  "untracked-overwrite: local untracked file left intact"
+STALL19="$(last_telem_line)"
+assert_eq "precheck" "$(jq -r '.body.payload.category' <<<"$STALL19")" \
+  "untracked-overwrite: stalled event category=precheck"
+T19_HAS_FILE="$(jq -r '.body.payload.files | index("colliding.txt") != null' <<<"$STALL19")"
+assert_eq "true" "$T19_HAS_FILE" "untracked-overwrite: colliding file listed in event"
+
 # ── 18. refresh_worktree (periodic path) stashes noise too ──────────────────
 echo "18. refresh_worktree stashes noise (periodic timer path)"
 new_fixture t18

--- a/plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh
@@ -44,7 +44,8 @@ source "$REBASE_LIB"
 # ─── Fixture builder ────────────────────────────────────────────────────────
 # new_fixture <tag> → sets ORIGIN (bare), WORK (clone, on branch `work`), UP
 # (upstream-editor clone, on main). Seeds an initial commit on main with
-# shared.txt (the conflict target) + a tracked .catalyst/config.json.
+# shared.txt (the conflict target) + tracked .catalyst/config.json and
+# .claude/config.json (both noise-stash members — CTL-990).
 new_fixture() {
 	local tag="$1"
 	ORIGIN="$SCRATCH/$tag/origin.git"
@@ -56,8 +57,9 @@ new_fixture() {
 	(
 		cd "$UP"
 		printf 'base-line\n' >shared.txt
-		mkdir -p .catalyst
+		mkdir -p .catalyst .claude
 		printf '{"committed":true}\n' >.catalyst/config.json
+		printf '{"claude":true}\n' >.claude/config.json
 		git add -A
 		git commit --quiet -m "initial"
 		git push --quiet origin main
@@ -418,6 +420,156 @@ new_fixture t13
 )
 assert_eq "1" "$(cat "$SCRATCH/t13.rc")" "fetch failure → rc 1"
 assert_eq "$(cat "$SCRATCH/t13.orig")" "$(cat "$SCRATCH/t13.head")" "fetch failure: HEAD unchanged"
+
+# ─── CTL-990: dirty-tree precheck, .claude noise, continue guard ─────────────
+# Root incident: a tracked dirty file OUTSIDE the noise set makes `git rebase`
+# refuse to START (pre-flight, not a conflict). classify_conflicted_files then
+# sees 0 unmerged paths, every branch is skipped, and the old code fell through
+# to a bogus `git rebase --continue` → {continue_failed, files:[], category:
+# unknown} — looping ~1,300 events on ADV-1326/ADV-1308.
+
+# ── 14. dirty tracked NON-noise file → typed precheck stall (rc 2) ──────────
+echo "14. rebase_onto_base_classified dirty tracked source file → precheck stall"
+new_fixture t14
+advance_origin_main_clean
+(
+  cd "$WORK"
+  printf 'local-feature\n' >local.txt
+  git add -A && git commit --quiet -m "local feature"
+  # Uncommitted edit to a tracked non-noise file — survives noise_stash_push.
+  printf 'dirty-edit\n' >shared.txt
+  ORIG_HEAD="$(git rev-parse HEAD)"
+  echo "$ORIG_HEAD" >"$SCRATCH/t14.orig"
+  rebase_onto_base_classified "main"
+  echo "$?" >"$SCRATCH/t14.rc"
+  echo "${REBASE_LAST_STALL_REASON:-}" >"$SCRATCH/t14.reason_var"
+  git rev-parse HEAD >"$SCRATCH/t14.head"
+  cat shared.txt >"$SCRATCH/t14.dirty"
+  [[ -d .git/rebase-merge ]] && echo leftover >"$SCRATCH/t14.rebasedir" || echo clean >"$SCRATCH/t14.rebasedir"
+)
+assert_eq "2" "$(cat "$SCRATCH/t14.rc")" "precheck stall → rc 2"
+assert_eq "rebase_refused_dirty_tree" "$(cat "$SCRATCH/t14.reason_var")" \
+  "REBASE_LAST_STALL_REASON carries the typed reason"
+assert_eq "$(cat "$SCRATCH/t14.orig")" "$(cat "$SCRATCH/t14.head")" "precheck: HEAD unchanged"
+assert_eq "dirty-edit" "$(cat "$SCRATCH/t14.dirty")" "precheck: dirty edit left intact"
+assert_eq "clean" "$(cat "$SCRATCH/t14.rebasedir")" "precheck: no rebase-merge leftover"
+STALL14="$(last_telem_line)"
+assert_eq "rebase_refused_dirty_tree" "$(jq -r '.body.payload.reason' <<<"$STALL14")" \
+  "precheck: stalled event reason=rebase_refused_dirty_tree"
+assert_eq "precheck" "$(jq -r '.body.payload.category' <<<"$STALL14")" \
+  "precheck: stalled event category=precheck"
+assert_eq "shared.txt" "$(jq -r '.body.payload.files[0]' <<<"$STALL14")" \
+  "precheck: offending dirty file listed in event"
+
+# ── 15. dirty tracked .claude/config.json → stashed noise, clean rebase ─────
+echo "15. rebase_onto_base_classified dirty .claude/config.json is stashed noise"
+new_fixture t15
+advance_origin_main_clean
+(
+  cd "$WORK"
+  printf 'local-feature\n' >local.txt
+  git add -A && git commit --quiet -m "local feature"
+  # The ADV-1326/ADV-1308 blocker: a tracked, locally-modified .claude config.
+  printf '{"claude":false,"dirty":true}\n' >.claude/config.json
+  rebase_onto_base_classified "main"
+  echo "$?" >"$SCRATCH/t15.rc"
+  cat .claude/config.json >"$SCRATCH/t15.config"
+  [[ -f upstream.txt ]] && echo yes >"$SCRATCH/t15.base" || echo no >"$SCRATCH/t15.base"
+)
+assert_eq "0" "$(cat "$SCRATCH/t15.rc")" "dirty .claude/config.json → rc 0 (stashed as noise)"
+assert_eq '{"claude":false,"dirty":true}' "$(cat "$SCRATCH/t15.config")" \
+  ".claude/config.json dirty content restored after rebase"
+assert_eq "yes" "$(cat "$SCRATCH/t15.base")" "rebase still advanced onto new base"
+
+# ── 16. .claude/config.json CONFLICT classifies as noise; other .claude files stay source ──
+echo "16. classifier sync: .claude/config.json conflict → noise; .claude/skills/* → source"
+new_fixture t16
+(
+  cd "$UP"
+  git checkout --quiet main
+  printf '{"upstream":true}\n' >.claude/config.json
+  git add -A && git commit --quiet -m "upstream claude config"
+  git push --quiet origin main
+)
+(
+  cd "$WORK"
+  printf '{"local":true}\n' >.claude/config.json
+  git add -A && git commit --quiet -m "local claude config"
+  rebase_onto_base_classified "main"
+  echo "$?" >"$SCRATCH/t16.rc"
+  cat .claude/config.json >"$SCRATCH/t16.config"
+)
+assert_eq "0" "$(cat "$SCRATCH/t16.rc")" ".claude/config.json conflict → rc 0 (noise take-ours)"
+assert_eq '{"upstream":true}' "$(cat "$SCRATCH/t16.config")" \
+  ".claude/config.json noise take-ours: upstream content wins"
+
+# Non-noise .claude content (skills/agents/rules) must STAY a source conflict —
+# auto-resolving it take-ours would silently discard committed branch work.
+new_fixture t16b
+(
+  cd "$UP"
+  git checkout --quiet main
+  mkdir -p .claude/skills
+  printf 'upstream-skill\n' >.claude/skills/foo.md
+  git add -A && git commit --quiet -m "upstream skill"
+  git push --quiet origin main
+)
+(
+  cd "$WORK"
+  mkdir -p .claude/skills
+  printf 'local-skill\n' >.claude/skills/foo.md
+  git add -A && git commit --quiet -m "local skill"
+  ORIG_HEAD="$(git rev-parse HEAD)"
+  echo "$ORIG_HEAD" >"$SCRATCH/t16b.orig"
+  rebase_onto_base_classified "main"
+  echo "$?" >"$SCRATCH/t16b.rc"
+  git rev-parse HEAD >"$SCRATCH/t16b.head"
+)
+assert_eq "2" "$(cat "$SCRATCH/t16b.rc")" ".claude/skills conflict stays source → rc 2"
+assert_eq "$(cat "$SCRATCH/t16b.orig")" "$(cat "$SCRATCH/t16b.head")" \
+  ".claude/skills conflict: HEAD restored (no silent take-ours)"
+
+# ── 17. rebase_in_progress predicate ────────────────────────────────────────
+echo "17. rebase_in_progress predicate"
+new_fixture t17
+(
+  cd "$WORK"
+  if rebase_in_progress; then echo yes; else echo no; fi >"$SCRATCH/t17.idle"
+)
+assert_eq "no" "$(cat "$SCRATCH/t17.idle")" "rebase_in_progress=false in an idle repo"
+advance_origin_main_conflict
+(
+  cd "$WORK"
+  printf 'local-edit\n' >shared.txt
+  git add -A && git commit --quiet -m "local conflicting edit"
+  git fetch --quiet origin main 2>/dev/null
+  git rebase --quiet "origin/main" 2>/dev/null # stops on the conflict
+  if rebase_in_progress; then echo yes; else echo no; fi >"$SCRATCH/t17.during"
+  git rebase --abort 2>/dev/null
+  if rebase_in_progress; then echo yes; else echo no; fi >"$SCRATCH/t17.after"
+)
+assert_eq "yes" "$(cat "$SCRATCH/t17.during")" "rebase_in_progress=true mid-conflict"
+assert_eq "no" "$(cat "$SCRATCH/t17.after")" "rebase_in_progress=false after abort"
+
+# ── 18. refresh_worktree (periodic path) stashes noise too ──────────────────
+echo "18. refresh_worktree stashes noise (periodic timer path)"
+new_fixture t18
+advance_origin_main_clean
+(
+  cd "$WORK"
+  printf 'local-feature\n' >local.txt
+  git add -A && git commit --quiet -m "local feature"
+  printf '{"committed":false,"dirty":true}\n' >.catalyst/config.json
+)
+# shellcheck source=../worktree-refresh.sh
+source "$LIB_DIR/worktree-refresh.sh"
+refresh_worktree "$WORK" main
+echo "$?" >"$SCRATCH/t18.rc"
+assert_eq "0" "$(cat "$SCRATCH/t18.rc")" "refresh with dirty noise → rc 0"
+assert_eq '{"committed":false,"dirty":true}' "$(cat "$WORK/.catalyst/config.json")" \
+  "refresh: dirty noise restored after rebase"
+T18_BASE="no"; [[ -f "$WORK/upstream.txt" ]] && T18_BASE="yes"
+assert_eq "yes" "$T18_BASE" "refresh: worktree advanced onto new base"
 
 echo
 echo "results: $PASSES passed, $FAILURES failed"

--- a/plugins/dev/scripts/lib/worktree-rebase.sh
+++ b/plugins/dev/scripts/lib/worktree-rebase.sh
@@ -283,10 +283,22 @@ rebase_onto_base_classified() {
   fi
 
   # CTL-990 guard: never call `git rebase --continue` with nothing in progress
-  # — it exits non-zero and used to mis-report as continue_failed. With the
-  # precheck above this state should be unreachable; keep it as belt-and-braces.
+  # — it exits non-zero and used to mis-report as continue_failed. Reaching
+  # here without a rebase means git refused to START it for a reason the
+  # tracked-only precheck can't see (e.g. an UNTRACKED file the incoming base
+  # would overwrite). Report THAT as the dirty-tree class with the worktree's
+  # dirt listed; no_rebase_in_progress is reserved for a genuinely clean tree.
   if ! rebase_in_progress; then
-    _stall_and_return "$marker" no_rebase_in_progress 2
+    RT_PRECHECK=()
+    local _gf
+    while IFS= read -r _gf; do
+      [[ -n $_gf ]] && RT_PRECHECK+=("${_gf:3}")
+    done < <(git status --porcelain 2>/dev/null)
+    if [[ ${#RT_PRECHECK[@]} -gt 0 ]]; then
+      _stall_and_return "$marker" rebase_refused_dirty_tree 2
+    else
+      _stall_and_return "$marker" no_rebase_in_progress 2
+    fi
     return
   fi
 

--- a/plugins/dev/scripts/lib/worktree-rebase.sh
+++ b/plugins/dev/scripts/lib/worktree-rebase.sh
@@ -28,11 +28,40 @@ _WR_DIR="$(cd "$(dirname "$_WR_SELF")" && pwd)"
 # We keep .catalyst/config.json in this list because it still carries other
 # per-worktree state (e.g. .workflow-context.json regeneration); the .trunk/*
 # paths still emit machine-local files.
+# CTL-990: .claude/config.json (tracked) and .claude/settings.json are copied
+# from the main checkout's working tree by create-worktree.sh and can arrive
+# locally modified — they blocked rebase startup in the ADV-1326/ADV-1308
+# incidents. NOTE: only these EXACT paths are noise; the rest of .claude/
+# (skills/agents/rules) is real committed content and must keep classifying
+# as source (see _is_noise_path).
 # shellcheck disable=SC2034
 WORKTREE_NOISE_PATHS=(
   .catalyst/config.json
+  .claude/config.json .claude/settings.json
   .trunk/actions .trunk/logs .trunk/notifications .trunk/out .trunk/tools
 )
+
+# _is_noise_path FILE → 0 when FILE is an exact WORKTREE_NOISE_PATHS entry.
+# Keeps classify_conflicted_files in sync with the stash set without blanket-
+# classifying all of .claude/ as noise.
+_is_noise_path() {
+  local f="$1" p
+  for p in "${WORKTREE_NOISE_PATHS[@]}"; do
+    [[ $f == "$p" ]] && return 0
+  done
+  return 1
+}
+
+# rebase_in_progress → 0 when a rebase is mid-flight (stopped on a conflict),
+# 1 otherwise. Guards `git rebase --continue` (CTL-990): calling --continue
+# with nothing in progress exits non-zero and used to mis-report as
+# {continue_failed, files:[], category:unknown}.
+rebase_in_progress() {
+  local d
+  d="$(git rev-parse --git-path rebase-merge 2>/dev/null)" && [[ -d $d ]] && return 0
+  d="$(git rev-parse --git-path rebase-apply 2>/dev/null)" && [[ -d $d ]] && return 0
+  return 1
+}
 
 # resolve_base_branch → echoes the rebase target branch name (no origin/ prefix).
 resolve_base_branch() {
@@ -114,7 +143,7 @@ classify_conflicted_files() {
     esac
     if printf '%s' "$f" | grep -qE '(\.test\.|\.spec\.|__test__|_test\.)'; then
       RT_TEST+=("$f")
-    elif printf '%s' "$f" | grep -qE '^(\.catalyst/|\.trunk/)'; then
+    elif printf '%s' "$f" | grep -qE '^(\.catalyst/|\.trunk/)' || _is_noise_path "$f"; then
       RT_NOISE+=("$f")
     else
       RT_SOURCE+=("$f")
@@ -128,8 +157,13 @@ ctl708_escalate() { return 1; }
 
 # _stall_and_return MARKER REASON RC — shared stall helper: abort in-progress
 # rebase, pop the noise stash, emit a stalled event, return the given RC.
+# CTL-990: also exports REBASE_LAST_STALL_REASON so callers (phase-agent-
+# dispatch) can park the signal with the TRUE typed reason instead of
+# hardcoding source_conflict_ctl708_unavailable for every rc=2.
 _stall_and_return() {
   local marker="$1" reason="$2" rc="$3"
+  # shellcheck disable=SC2034  # consumed by the sourcing dispatcher
+  REBASE_LAST_STALL_REASON="$reason"
   git rebase --abort 2>/dev/null || true
   noise_stash_pop "$marker"
   # Build a JSON array from the stalled files for telemetry.
@@ -141,6 +175,9 @@ _stall_and_return() {
     source_conflict_ctl708_unavailable|continue_failed)
       all_stalled=("${RT_SOURCE[@]+"${RT_SOURCE[@]}"}")
       ;;
+    rebase_refused_dirty_tree)
+      all_stalled=("${RT_PRECHECK[@]+"${RT_PRECHECK[@]}"}")
+      ;;
   esac
   local files_json="[]"
   if [[ ${#all_stalled[@]} -gt 0 ]]; then
@@ -150,6 +187,8 @@ _stall_and_return() {
   case "$reason" in
     thoughts_symlink_broken)             category="thoughts" ;;
     source_conflict_ctl708_unavailable)  category="source"   ;;
+    rebase_refused_dirty_tree)           category="precheck" ;;
+    no_rebase_in_progress)               category="internal" ;;
     *)                                   category="unknown"  ;;
   esac
   emit_rebase_conflict_stalled \
@@ -175,6 +214,22 @@ rebase_onto_base_classified() {
   local base="$1" marker
   git fetch --quiet origin "$base" 2>/dev/null || return 1
   marker="$(noise_stash_push)"
+
+  # CTL-990 precheck: git refuses to START a rebase over dirty TRACKED changes.
+  # That is a pre-flight refusal, not a conflict — no unmerged paths exist, so
+  # classify_conflicted_files sees nothing and the old code cascaded into a
+  # bogus `git rebase --continue` → {continue_failed, files:[], category:
+  # unknown}, looping ~1,300 events per ticket. Any tracked dirt that survives
+  # noise_stash_push is real: stall with a typed reason + the offending files.
+  if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+    RT_PRECHECK=()
+    local _pf
+    while IFS= read -r _pf; do
+      [[ -n $_pf ]] && RT_PRECHECK+=("$_pf")
+    done < <({ git diff --name-only; git diff --cached --name-only; } 2>/dev/null | sort -u)
+    _stall_and_return "$marker" rebase_refused_dirty_tree 2
+    return
+  fi
 
   if git rebase --quiet "origin/${base}" 2>/dev/null; then
     noise_stash_pop "$marker"
@@ -225,6 +280,14 @@ rebase_onto_base_classified() {
   if [[ $tc -gt 0 ]]; then
     git checkout --theirs -- "${RT_TEST[@]}"  2>/dev/null
     git add               -- "${RT_TEST[@]}"  2>/dev/null
+  fi
+
+  # CTL-990 guard: never call `git rebase --continue` with nothing in progress
+  # — it exits non-zero and used to mis-report as continue_failed. With the
+  # precheck above this state should be unreachable; keep it as belt-and-braces.
+  if ! rebase_in_progress; then
+    _stall_and_return "$marker" no_rebase_in_progress 2
+    return
   fi
 
   if git rebase --continue 2>/dev/null; then

--- a/plugins/dev/scripts/lib/worktree-refresh.sh
+++ b/plugins/dev/scripts/lib/worktree-refresh.sh
@@ -3,18 +3,36 @@
 # origin/<base>. Called by the daemon's periodic refresh timer.
 # Clean rebase → 0; conflict (aborted) → 2; fetch failure → 1.
 # Can be sourced (provides refresh_worktree function) or executed directly.
+#
+# CTL-990: shares the noise-stash helpers with the dispatch-time rebase
+# (lib/worktree-rebase.sh) so a dirty machine-local config — the same class
+# that looped the dispatch path — cannot fail the periodic refresh either.
 
 set -uo pipefail
 
-# refresh_worktree DIR BASE → fetch origin/<base>, try rebase; abort on conflict.
+_WRF_SELF="${BASH_SOURCE[0]:-${(%):-%x}}"
+_WRF_DIR="$(cd "$(dirname "$_WRF_SELF")" && pwd)"
+# shellcheck source=./worktree-rebase.sh
+source "${_WRF_DIR}/worktree-rebase.sh"
+
+# refresh_worktree DIR BASE → fetch origin/<base>, stash noise, try rebase;
+# abort on conflict. Subshell-cd so the noise helpers (which operate on the
+# cwd) target DIR without leaking a directory change to the caller.
 refresh_worktree() {
   local dir="$1" base="$2"
-  git -C "$dir" fetch --quiet origin "$base" 2>/dev/null || return 1
-  if git -C "$dir" rebase --quiet "origin/${base}" 2>/dev/null; then
-    return 0
-  fi
-  git -C "$dir" rebase --abort 2>/dev/null || true
-  return 2
+  (
+    cd "$dir" 2>/dev/null || exit 1
+    git fetch --quiet origin "$base" 2>/dev/null || exit 1
+    local marker
+    marker="$(noise_stash_push)"
+    if git rebase --quiet "origin/${base}" 2>/dev/null; then
+      noise_stash_pop "$marker"
+      exit 0
+    fi
+    git rebase --abort 2>/dev/null || true
+    noise_stash_pop "$marker"
+    exit 2
+  )
 }
 
 # Direct invocation: bash worktree-refresh.sh <dir> <base>

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -942,16 +942,25 @@ if [[ -z $RESUME_SESSION ]] && is_rebase_phase "$PHASE"; then
 	rebase_onto_base_classified "$BASE_BRANCH"
 	REBASE_RC=$?
 	if [[ $REBASE_RC -eq 2 || $REBASE_RC -eq 3 ]]; then
-		# Determine the stall reason from the rc.
+		# Determine the stall reason from the rc. CTL-990: the rebase lib exports
+		# the TRUE typed reason (rebase_refused_dirty_tree, continue_failed,
+		# source_conflict_ctl708_unavailable, …) in REBASE_LAST_STALL_REASON —
+		# park with that instead of mislabeling every rc=2 as a source conflict.
 		if [[ $REBASE_RC -eq 3 ]]; then
 			STALL_REASON="thoughts_conflict_with_origin_main"
 		else
-			STALL_REASON="source_conflict_ctl708_unavailable"
+			STALL_REASON="${REBASE_LAST_STALL_REASON:-source_conflict_ctl708_unavailable}"
 		fi
 
-		# research/plan + source conflict (rc 2) → destroy+recreate worktree.
-		# thoughts conflict (rc 3) or source on non-research/plan → park as stalled.
-		if [[ $REBASE_RC -eq 2 ]] && { [[ $PHASE == "research" ]] || [[ $PHASE == "plan" ]]; }; then
+		# research/plan + rc 2 → destroy+recreate worktree, AT MOST ONCE per
+		# dispatch chain (CTL-990): the recreated worktree used to come back
+		# dirty (create-worktree cp -R), rc=2 again, recreate again — an
+		# in-process exec recursion (~2.5s/cycle, 1,300+ events on ADV-1308)
+		# invisible to every scheduler cooldown. CATALYST_RECREATE_ATTEMPTED
+		# survives the exec; a second rc=2 parks as stalled instead.
+		# thoughts conflict (rc 3) or rc 2 on non-research/plan → park as stalled.
+		if [[ $REBASE_RC -eq 2 ]] && [[ -z ${CATALYST_RECREATE_ATTEMPTED:-} ]] \
+			&& { [[ $PHASE == "research" ]] || [[ $PHASE == "plan" ]]; }; then
 			# CTL-707 Layer 3: destroy and recreate the worktree from origin/<base>.
 			# Derive the main checkout root from this worktree's git common dir.
 			_REPO_ROOT=""
@@ -985,6 +994,9 @@ if [[ -z $RESUME_SESSION ]] && is_rebase_phase "$PHASE"; then
 					rm -f "${WORKER_DIR}/${PHASE}.claim."* 2>/dev/null || true
 					echo "phase-agent-dispatch: recreated worktree at ${_NEW_WT}; re-dispatching ${TICKET}/${PHASE}" >&2
 					cd "$_NEW_WT"
+					# CTL-990: mark the recreate as spent — survives the exec, so a
+					# second rc=2 in the re-dispatched run parks instead of looping.
+					export CATALYST_RECREATE_ATTEMPTED=1
 					exec "$0" --phase "$PHASE" --ticket "$TICKET" \
 						--orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID"
 				else


### PR DESCRIPTION
## Incident

ADV-1326 and ADV-1308 entered an infinite pre-dispatch rebase loop (~2.5s/cycle, 1,300–1,553 `rebase-conflict-stalled` events each, `{reason:continue_failed, files:[], category:unknown}`), flooding the event log for hours. Live forensics on ADV-1308 found **two concurrent `phase-agent-dispatch` processes exec-looping on the recreate path**, a stale `index.lock`, and a worktree wrecked into 3,174 staged deletions by the racing destroy/recreate cycles.

## Root cause chain

1. **`create-worktree.sh` `cp -R .claude`/`.catalyst`** copies the main checkout's *working-tree* versions of **tracked** files — local edits included — so every fresh worktree starts with dirty tracked config.
2. `git rebase` then **refuses to start** ("you have unstaged changes") — a pre-flight refusal, not a conflict. `classify_conflicted_files` (`--diff-filter=U`) sees zero unmerged paths, every branch is skipped, and control falls into a bogus `git rebase --continue` → the misleading `continue_failed` stall.
3. For research/plan, the rc=2 **recreate hatch `exec`s itself**: the recreated worktree is instantly re-dirtied by the same `cp -R`, rc=2 again, recreate again — an in-process recursion **invisible to every scheduler cooldown/breaker because the dispatch never returns**.

## Fix set (ordered root-first)

- **`create-worktree.sh`** — restore tracked `.claude`/`.catalyst` paths to branch state after `cp -R`; untracked machine-local files still copied (ROOT fix — removes the class)
- **`worktree-rebase.sh`** — `.claude/config.json` + `.claude/settings.json` join `WORKTREE_NOISE_PATHS`; `_is_noise_path` keeps the conflict classifier in sync (exact paths only — `.claude/skills` etc. stay source); typed dirty-tree **precheck** (`rebase_refused_dirty_tree`/`precheck` + offending files); `rebase_in_progress` guard before `--continue`; the guard also catches the **untracked-overwrite refusal** class (reproduced during adversarial review) and reports it as dirty-tree instead of an opaque internal stall; `_stall_and_return` exports `REBASE_LAST_STALL_REASON`
- **`phase-agent-dispatch`** — parks with the TRUE typed reason; **recreate at most once per dispatch chain** (`CATALYST_RECREATE_ATTEMPTED` survives the exec)
- **`dispatch.mjs`** — hard spawn **timeout** (`CATALYST_DISPATCH_TIMEOUT_MS`, default 15 min) + SIGKILL so a wedged dispatch surfaces to the existing CTL-712/713 failure ladder instead of wedging the daemon; ambient `CATALYST_RECREATE_ATTEMPTED` stripped from the spawned env
- **`worktree-refresh.sh`** — periodic timer path now shares the noise stash

## Not regressed (verified by multi-lens adversarial review + tests)

- Genuine source conflicts still dead-end at the CTL-708 stub; recreate hatch stays research/plan-only
- Repo-wide consumer sweep: every `failureReason`/event-category reader is value-agnostic — new reason strings are safe
- Suites: worktree-rebase 82/0 · phase-agent-dispatch 239/0 (incl. new tests 61/62) · dispatch.test.mjs 35/0 · create-worktree-tracked-clean 7/0 (new) · orchestrate-rebase 34/0 · orchestrate-auto-rebase 35/0

Closes CTL-990 (#1732)

🤖 Generated with [Claude Code](https://claude.com/claude-code)