### PR TITLE
feat(dev): pristine main-only plugin-source checkout + merge-to-main auto-refresh (CTL-992, CTL-993)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-stack-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-parity.test.sh
@@ -139,6 +139,30 @@ t7() {
 }
 check "parity reports whether pluginDirs is set in machine config" t7
 
+# ── 8. off-main checkout → drift naming "main" (CTL-992) ────────────────────
+make_fixture offmain
+$GITC -C "${FIX_CHECKOUT}" checkout -q -b feature
+t8() {
+  local out rc
+  out="$(parity "${FIX_CHECKOUT}/plugins/dev" "" 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qi "main" <<<"$out" && grep -q "feature" <<<"$out"
+}
+check "off-main checkout exits nonzero and names main + branch" t8
+
+# ── 9. linked-worktree pluginDirs → drift naming "worktree" (CTL-992) ───────
+make_fixture linked
+# park primary off main so the linked worktree can itself sit on main,
+# isolating the worktree signal from the off-main signal.
+$GITC -C "${FIX_CHECKOUT}" checkout -q -b parking
+LINKED_WT="${SCRATCH}/fix_linked/linkedwt"
+$GITC -C "${FIX_CHECKOUT}" worktree add -q "$LINKED_WT" main
+t9() {
+  local out rc
+  out="$(parity "${LINKED_WT}/plugins/dev" "" 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qi "worktree" <<<"$out"
+}
+check "linked-worktree pluginDirs exits nonzero and names worktree" t9
+
 echo ""
 TOTAL=$((PASSES + FAILURES))
 echo "catalyst-stack-parity: $PASSES/$TOTAL passed, $FAILURES failed"

--- a/plugins/dev/scripts/__tests__/setup-plugin-source.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-plugin-source.test.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Shell tests for setup-plugin-source.sh (CTL-992): provisions a pristine
+# main-only plugin-source checkout and registers it as
+# catalyst.orchestration.pluginDirs in the machine config. Idempotent;
+# refuses linked worktrees and non-main branches.
+# Run: bash plugins/dev/scripts/__tests__/setup-plugin-source.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SETUP="${REPO_ROOT}/plugins/dev/scripts/setup-plugin-source.sh"
+REAL_PATH="$PATH"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+check() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+GITC="git -c user.email=t@t -c user.name=t -c commit.gpgsign=false -c init.defaultBranch=main"
+
+# make_origin NAME → bare origin.git with plugins/dev seeded; sets ORIGIN, SEED.
+make_origin() {
+  local base="${SCRATCH}/orig_$1"
+  mkdir -p "${base}/seed"
+  $GITC -C "${base}/seed" init -q
+  mkdir -p "${base}/seed/plugins/dev/.claude-plugin"
+  echo '{"name":"catalyst-dev","version":"1.0.0"}' \
+    > "${base}/seed/plugins/dev/.claude-plugin/plugin.json"
+  echo "v1" > "${base}/seed/plugins/dev/marker.txt"
+  $GITC -C "${base}/seed" add -A
+  $GITC -C "${base}/seed" commit -qm "initial"
+  $GITC init -q --bare "${base}/origin.git"
+  $GITC -C "${base}/seed" remote add origin "${base}/origin.git"
+  $GITC -C "${base}/seed" push -q -u origin main
+  ORIGIN="${base}/origin.git"
+  SEED="${base}/seed"
+}
+
+advance_origin() {
+  echo "v2" > "${SEED}/plugins/dev/marker.txt"
+  $GITC -C "${SEED}" commit -qam "update marker"
+  $GITC -C "${SEED}" push -q origin main
+}
+
+# run_setup MACHINE_CFG PATH_ARG REPO_URL [extra args...]
+run_setup() {
+  local mcfg="$1" path_arg="$2" url="$3"; shift 3
+  env PATH="$REAL_PATH" CATALYST_MACHINE_CONFIG="$mcfg" GIT_TERMINAL_PROMPT=0 \
+    bash "$SETUP" --path "$path_arg" --repo-url "$url" "$@"
+}
+
+echo "setup-plugin-source (CTL-992) tests"
+
+# ── 1. fresh clone → clones + registers pluginDirs in machine config ────────
+make_origin fresh
+MCFG1="${SCRATCH}/mcfg1.json"
+CO1="${SCRATCH}/co1"
+t1() {
+  local rc reg head
+  run_setup "$MCFG1" "$CO1" "$ORIGIN" >/dev/null 2>&1; rc=$?
+  [[ $rc -eq 0 ]] || return 1
+  [[ -f "${CO1}/.git/HEAD" || -d "${CO1}/.git" ]] || return 1
+  reg="$(jq -r '.catalyst.orchestration.pluginDirs' "$MCFG1")"
+  [[ "$reg" == "${CO1}/plugins/dev" ]] || return 1
+  head="$($GITC -C "$CO1" rev-parse --abbrev-ref HEAD)"
+  [[ "$head" == "main" ]]
+}
+check "fresh clone registers pluginDirs and lands on main" t1
+
+# ── 2. reuse + behind → ff-pulls to v2 ──────────────────────────────────────
+make_origin behind
+MCFG2="${SCRATCH}/mcfg2.json"
+CO2="${SCRATCH}/co2"
+$GITC clone -q "$ORIGIN" "$CO2"
+advance_origin
+t2() {
+  run_setup "$MCFG2" "$CO2" "$ORIGIN" >/dev/null 2>&1 || return 1
+  grep -q "v2" "${CO2}/plugins/dev/marker.txt"
+}
+check "reuse of a behind checkout ff-pulls to origin/main" t2
+
+# ── 3. idempotent: second run is a no-op write ──────────────────────────────
+make_origin idem
+MCFG3="${SCRATCH}/mcfg3.json"
+CO3="${SCRATCH}/co3"
+t3() {
+  run_setup "$MCFG3" "$CO3" "$ORIGIN" >/dev/null 2>&1 || return 1
+  local out
+  out="$(run_setup "$MCFG3" "$CO3" "$ORIGIN" 2>&1)" || return 1
+  grep -qi "already registered" <<<"$out"
+}
+check "second run with same args reports already-registered" t3
+
+# ── 4. preserves unrelated machine-config keys ──────────────────────────────
+make_origin preserve
+MCFG4="${SCRATCH}/mcfg4.json"
+printf '%s\n' '{"catalyst":{"host":{"name":"x"}},"groq":{"apiKey":"k"}}' > "$MCFG4"
+CO4="${SCRATCH}/co4"
+t4() {
+  run_setup "$MCFG4" "$CO4" "$ORIGIN" >/dev/null 2>&1 || return 1
+  [[ "$(jq -r '.catalyst.host.name' "$MCFG4")" == "x" ]] || return 1
+  [[ "$(jq -r '.groq.apiKey' "$MCFG4")" == "k" ]] || return 1
+  [[ "$(jq -r '.catalyst.orchestration.pluginDirs' "$MCFG4")" == "${CO4}/plugins/dev" ]]
+}
+check "preserves unrelated machine-config keys" t4
+
+# ── 5. refuses a linked worktree ────────────────────────────────────────────
+make_origin linkrefuse
+MCFG5="${SCRATCH}/mcfg5.json"
+PRIMARY5="${SCRATCH}/primary5"
+$GITC clone -q "$ORIGIN" "$PRIMARY5"
+$GITC -C "$PRIMARY5" checkout -q -b parking
+LINKED5="${SCRATCH}/linked5"
+$GITC -C "$PRIMARY5" worktree add -q "$LINKED5" main
+t5() {
+  local out rc
+  out="$(run_setup "$MCFG5" "$LINKED5" "$ORIGIN" 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qi "worktree" <<<"$out"
+}
+check "refuses a linked worktree as the plugin source" t5
+
+# ── 6. refuses a non-main branch ────────────────────────────────────────────
+make_origin branchrefuse
+MCFG6="${SCRATCH}/mcfg6.json"
+CO6="${SCRATCH}/co6"
+$GITC clone -q "$ORIGIN" "$CO6"
+$GITC -C "$CO6" checkout -q -b feature
+t6() {
+  local out rc
+  out="$(run_setup "$MCFG6" "$CO6" "$ORIGIN" 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qi "main" <<<"$out"
+}
+check "refuses a checkout on a non-main branch" t6
+
+# ── 7. --force re-registers even when already set ───────────────────────────
+make_origin forcecase
+MCFG7="${SCRATCH}/mcfg7.json"
+CO7A="${SCRATCH}/co7a"
+CO7B="${SCRATCH}/co7b"
+t7() {
+  run_setup "$MCFG7" "$CO7A" "$ORIGIN" >/dev/null 2>&1 || return 1
+  [[ "$(jq -r '.catalyst.orchestration.pluginDirs' "$MCFG7")" == "${CO7A}/plugins/dev" ]] || return 1
+  run_setup "$MCFG7" "$CO7B" "$ORIGIN" --force >/dev/null 2>&1 || return 1
+  [[ "$(jq -r '.catalyst.orchestration.pluginDirs' "$MCFG7")" == "${CO7B}/plugins/dev" ]]
+}
+check "--force re-registers a new checkout path" t7
+
+# ── 8. creates machine config when absent ───────────────────────────────────
+make_origin createcfg
+MCFG8="${SCRATCH}/sub/dir/mcfg8.json"   # parent dir does not exist
+CO8="${SCRATCH}/co8"
+t8() {
+  [[ ! -e "$MCFG8" ]] || return 1
+  run_setup "$MCFG8" "$CO8" "$ORIGIN" >/dev/null 2>&1 || return 1
+  [[ -f "$MCFG8" ]] || return 1
+  [[ "$(jq -r '.catalyst.orchestration.pluginDirs' "$MCFG8")" == "${CO8}/plugins/dev" ]]
+}
+check "creates the machine config (and parent dir) when absent" t8
+
+echo ""
+TOTAL=$((PASSES + FAILURES))
+echo "setup-plugin-source: $PASSES/$TOTAL passed, $FAILURES failed"
+exit "$FAILURES"

--- a/plugins/dev/scripts/broker/barrel-exports.test.mjs
+++ b/plugins/dev/scripts/broker/barrel-exports.test.mjs
@@ -3,11 +3,12 @@
 // singleton getters return identity-stable references. Goes RED if any
 // extraction phase drops a re-export or breaks getter identity.
 //
-// Note: the barrel re-exports 67 public symbols (CTL-529 established 55; CTL-532
+// Note: the barrel re-exports 75 public symbols (CTL-529 established 55; CTL-532
 // added 12 worker-state-projection symbols — 9 store helpers, the reducer, and
-// the two projection drivers). The count is the length of the enumerated
-// REQUIRED_EXPORTS list below — `grep -cE '^export '` undercounts because most
-// re-exports are multi-name `export { … } from` blocks.
+// the two projection drivers; CTL-993 added 7 plugin-refresh symbols). The count
+// is the length of the enumerated REQUIRED_EXPORTS list below — `grep -cE
+// '^export '` undercounts because most re-exports are multi-name `export { … }
+// from` blocks.
 import { describe, test, expect } from "bun:test";
 import * as barrel from "./index.mjs";
 
@@ -88,14 +89,22 @@ const REQUIRED_EXPORTS = [
   "reduceWorkerStateEvent",
   "projectWorkerStateEvent",
   "replayWorkerStateProjection",
+  // CTL-993: merge-to-main plugin-checkout refresh (plugin-refresh.mjs)
+  "resolvePluginCheckoutRoots",
+  "resolveRepoFullName",
+  "isThisRepoMergeEvent",
+  "refreshPluginCheckout",
+  "handlePluginRefreshEvent",
+  "PLUGIN_REFRESH_THROTTLE_MS",
+  "__clearThrottleForTest",
 ];
 
 describe("CTL-529 barrel contract", () => {
-  test("all 68 public symbols re-export from ./index.mjs", () => {
+  test("all 75 public symbols re-export from ./index.mjs", () => {
     for (const name of REQUIRED_EXPORTS) {
       expect(typeof barrel[name], `missing export: ${name}`).not.toBe("undefined");
     }
-    expect(REQUIRED_EXPORTS.length).toBe(68);
+    expect(REQUIRED_EXPORTS.length).toBe(75);
   });
 
   test("singleton getters return identity-stable live references", () => {

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -82,11 +82,12 @@ import { defaultStatJob } from "../execution-core/recovery.mjs";
 
 // --- Public re-export barrel (CTL-529) ---
 // The execution-core split moved every public symbol into a named module.
-// index.mjs re-exports all 67 of them so the import surface — depended on by
+// index.mjs re-exports all 75 of them so the import surface — depended on by
 // the broker test suite — is byte-for-byte preserved. See barrel-exports.test.mjs.
 // CTL-532 added 12 worker-state-projection symbols: 9 store helpers (Phase 1),
 // the pure reduceWorkerStateEvent reducer (Phase 2), and the
 // projectWorkerStateEvent + replayWorkerStateProjection drivers (Phase 3).
+// CTL-993 added 7 plugin-refresh symbols (merge-to-main checkout refresh).
 export { readGroqConfig, readGroqApiKeyFromConfig } from "./config.mjs";
 export {
   getInterests,
@@ -149,6 +150,18 @@ export {
   handleWorkerStateChanged,
 } from "./router.mjs";
 export { loadExistingRegistrations } from "./tailer.mjs";
+// CTL-993: merge-to-main plugin-checkout refresh. router.mjs calls
+// handlePluginRefreshEvent in processEvent; the rest are pure units re-exported
+// through the barrel so the public import surface stays complete.
+export {
+  resolvePluginCheckoutRoots,
+  resolveRepoFullName,
+  isThisRepoMergeEvent,
+  refreshPluginCheckout,
+  handlePluginRefreshEvent,
+  PLUGIN_REFRESH_THROTTLE_MS,
+  __clearThrottleForTest,
+} from "./plugin-refresh.mjs";
 
 // Identity-stable aliases for the shared maps main()/shutdown() read.
 const interests = getInterests();

--- a/plugins/dev/scripts/broker/plugin-refresh.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.mjs
@@ -1,0 +1,341 @@
+// plugin-refresh.mjs — refresh every node's pluginDirs checkout on merge-to-main
+// (CTL-993).
+//
+// CTL-941 keeps headless plugin checkouts fresh via a PERIODIC ff-only
+// auto-pull. We iterate many times a day; waiting on the poll interval (or the
+// daily release-please version bump, or a manual `catalyst-stack hotpatch`)
+// delays feedback on every fix. GitHub webhooks already flow into the unified
+// event log via the webhook receiver + broker — the merge signal exists, and
+// this module is the consumer that turns it into an instant checkout pull.
+//
+// The broker tails the event log; when a GitHub push/merge event for the
+// configured repo@main arrives, the router calls handlePluginRefreshEvent,
+// which:
+//   1. resolves the pluginDirs checkout root(s)  (parity with lib/plugin-dirs.sh)
+//   2. throttles to at most one pull per N seconds per root
+//   3. runs `git pull --ff-only origin main` in each root
+//   4. emits plugin.checkout.updated (new HEAD sha + daemon-skew restart_needed)
+//      on success, or plugin.checkout.refresh_failed (WARN) on a diverged/dirty
+//      checkout — never failing silently.
+//
+// RESOLUTION-PARITY CONTRACT — keep in sync with the other two resolvers:
+//   - lib/plugin-dirs.sh:56            resolve_plugin_dirs (catalyst-stack / setup)
+//   - phase-agent-dispatch:891         --plugin-dir flag builder (workers)
+// We re-implement the same env → repo-config → machine-config precedence and the
+// same string-or-`:`-array pluginDirs parse IN JS here (pure file reads), rather
+// than sourcing bash from a long-lived daemon. The broker stays no-shell-out
+// except the single `git` invocation, which goes through the injected gitFn seam.
+//
+// All OS/git/config/clock interactions are injected seams (gitFn, gitToplevelFn,
+// readFileFn, emitFn, now, env) so the decision core and lifecycle are
+// deterministically testable without real load, timers, network, or a checkout.
+// Mirrors the gc-liveness.mjs / autotune.mjs seam-injection convention.
+
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { getEventName } from "./router.mjs";
+
+// Throttle window: at most one pull per N seconds per checkout root. A merge
+// often arrives as both a github.pr.merged AND a github.push to main within the
+// same second; the throttle collapses that pair into a single pull, and also
+// caps a burst of rapid merges. 60s mirrors the catalyst-stack hotpatch cadence
+// expectation while still delivering "within seconds" freshness.
+export const PLUGIN_REFRESH_THROTTLE_MS = 60_000;
+
+// root → last-pull epoch ms. Module-level so the throttle survives across
+// events within one daemon lifetime. Cleared between tests via the seam below.
+const _lastPullByRoot = new Map();
+
+export function __clearThrottleForTest() {
+  _lastPullByRoot.clear();
+}
+
+// --- default seams (production wiring) ---------------------------------------
+
+// defaultGitFn — run a git subcommand in `root` and return trimmed stdout.
+// GIT_TERMINAL_PROMPT=0 so an auth-required fetch fails fast instead of hanging
+// a daemon with no tty/ssh-agent. Throws on non-zero exit (execFileSync), which
+// the pull path catches and surfaces as refresh_failed.
+function defaultGitFn(root, args) {
+  return execFileSync("git", ["-C", root, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+  }).trim();
+}
+
+// defaultGitToplevelFn — map a pluginDirs entry (<checkout>/plugins/dev) to its
+// git toplevel checkout root, or null when it is not inside a git checkout.
+function defaultGitToplevelFn(pluginDir) {
+  try {
+    return execFileSync("git", ["-C", pluginDir, "rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function defaultMachineConfigPath() {
+  const xdg = process.env.XDG_CONFIG_HOME || `${homedir()}/.config`;
+  return resolve(process.env.CATALYST_MACHINE_CONFIG || `${xdg}/catalyst/config.json`);
+}
+
+// --- config parsing ----------------------------------------------------------
+
+// __pluginDirsFromFile — extract pluginDirs from one config file. Same
+// string-or-array tolerance as lib/plugin-dirs.sh::__plugin_dirs_from_file and
+// phase-agent-dispatch:891. Returns "" when the file is absent/unparseable or
+// the key is unset.
+function __pluginDirsFromFile(path, readFileFn) {
+  if (!path) return "";
+  let raw;
+  try {
+    raw = readFileFn(path);
+  } catch {
+    return "";
+  }
+  let cfg;
+  try {
+    cfg = JSON.parse(raw);
+  } catch {
+    return "";
+  }
+  const v = cfg?.catalyst?.orchestration?.pluginDirs;
+  if (Array.isArray(v)) return v.join(":");
+  if (typeof v === "string") return v;
+  return "";
+}
+
+/**
+ * resolvePluginCheckoutRoots — JS mirror of lib/plugin-dirs.sh::resolve_plugin_dirs.
+ *
+ * Precedence: CATALYST_PLUGIN_DIRS env → repo .catalyst/config.json →
+ * machine config. pluginDirs may be a string or array (joined with ":") in
+ * either config file. Each `:`-separated entry points at <checkout>/plugins/dev
+ * and is mapped through gitToplevelFn to its checkout root; unresolvable entries
+ * are dropped and the resulting roots are deduped (order-preserving).
+ *
+ * @returns {string[]} deduped checkout roots, [] when pluginDirs is unset.
+ */
+export function resolvePluginCheckoutRoots({
+  env = process.env,
+  machineConfigPath = defaultMachineConfigPath(),
+  repoConfigPath = null,
+  readFileFn = (p) => readFileSync(p, "utf8"),
+  gitToplevelFn = defaultGitToplevelFn,
+} = {}) {
+  let value = "";
+  if (env.CATALYST_PLUGIN_DIRS) {
+    value = env.CATALYST_PLUGIN_DIRS;
+  } else {
+    value = __pluginDirsFromFile(repoConfigPath, readFileFn);
+    if (!value) value = __pluginDirsFromFile(machineConfigPath, readFileFn);
+  }
+  if (!value) return [];
+
+  const roots = [];
+  const seen = new Set();
+  for (const entry of value.split(":")) {
+    const pd = entry.trim();
+    if (!pd) continue;
+    const root = gitToplevelFn(pd);
+    if (!root) continue;
+    if (seen.has(root)) continue;
+    seen.add(root);
+    roots.push(root);
+  }
+  return roots;
+}
+
+// __readConfig — parse one config file through the readFileFn seam, tolerant of
+// absent/unparseable files (returns {}).
+function __readConfig(path, readFileFn) {
+  if (!path) return {};
+  try {
+    return JSON.parse(readFileFn(path)) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * resolveRepoFullName — the "owner/repo" whose merges trigger a checkout
+ * refresh. Read from .catalyst.feedback.githubRepo, falling back to the first
+ * .catalyst.monitor.linear.teams[].vcsRepo. Repo config (.catalyst/config.json)
+ * takes precedence over the machine config. Returns null when unconfigured.
+ */
+export function resolveRepoFullName({
+  machineConfigPath = defaultMachineConfigPath(),
+  repoConfigPath = null,
+  readFileFn = (p) => readFileSync(p, "utf8"),
+} = {}) {
+  for (const path of [repoConfigPath, machineConfigPath]) {
+    const cfg = __readConfig(path, readFileFn);
+    const fromFeedback = cfg?.catalyst?.feedback?.githubRepo;
+    if (typeof fromFeedback === "string" && fromFeedback) return fromFeedback;
+    const teams = cfg?.catalyst?.monitor?.linear?.teams;
+    if (Array.isArray(teams)) {
+      const hit = teams.find((t) => typeof t?.vcsRepo === "string" && t.vcsRepo);
+      if (hit) return hit.vcsRepo;
+    }
+  }
+  return null;
+}
+
+// --- merge-event matcher -----------------------------------------------------
+
+// Read the repo identity from an event shape-agnostically: canonical envelopes
+// carry it at attributes["vcs.repository.name"], legacy flat events at
+// scope.repo (mirrors how router.summarizeEvent resolves repo).
+function eventRepo(event) {
+  return event.attributes?.["vcs.repository.name"] ?? event.scope?.repo ?? null;
+}
+
+// Resolve the pushed ref name from canonical (attributes["vcs.ref.name"]) or
+// legacy (scope.ref, which is the full refs/heads/<branch>) shape.
+function eventRefBranch(event) {
+  const ref = event.attributes?.["vcs.ref.name"] ?? event.scope?.ref ?? "";
+  return ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : ref;
+}
+
+/**
+ * isThisRepoMergeEvent — true when the event is a merge of new code into main
+ * of the configured repo: github.pr.merged OR github.push to main, AND the
+ * event's repository matches repoFullName. Returns false when repoFullName is
+ * unconfigured (no identity to match → never refresh on an unknown repo).
+ */
+export function isThisRepoMergeEvent(event, { repoFullName } = {}) {
+  if (!repoFullName) return false;
+  if (eventRepo(event) !== repoFullName) return false;
+  const name = getEventName(event);
+  if (name === "github.pr.merged") return true;
+  if (name === "github.push") return eventRefBranch(event) === "main";
+  return false;
+}
+
+// --- refresh ----------------------------------------------------------------
+
+/**
+ * refreshPluginCheckout — throttle-gated ff-only pull of a single checkout root.
+ *
+ * On a pull that advances HEAD, emits plugin.checkout.updated with old/new sha
+ * and a restart_needed flag (true when the daemon's loadedCommit is known and
+ * the checkout advanced past it — daemon skew is VISIBLE, not auto-restarted).
+ * On an ff-only failure (diverged/dirty), emits plugin.checkout.refresh_failed
+ * at WARN — surfacing the failure instead of failing silently.
+ *
+ * Returns a result descriptor: { pulled, throttled, changed, failed }.
+ */
+export function refreshPluginCheckout({
+  root,
+  now = Date.now(),
+  gitFn = defaultGitFn,
+  emitFn,
+  loadedCommit = null,
+}) {
+  if (!root) return { pulled: false, throttled: false, changed: false, failed: false };
+
+  const last = _lastPullByRoot.get(root);
+  if (last !== undefined && now - last < PLUGIN_REFRESH_THROTTLE_MS) {
+    return { pulled: false, throttled: true, changed: false, failed: false };
+  }
+  // Reserve the slot BEFORE the (possibly slow) pull so a duplicate event that
+  // arrives mid-pull is throttled rather than launching a second git process.
+  _lastPullByRoot.set(root, now);
+
+  let oldSha = null;
+  try {
+    oldSha = gitFn(root, ["rev-parse", "HEAD"]);
+  } catch {
+    oldSha = null;
+  }
+
+  try {
+    gitFn(root, ["pull", "--ff-only", "origin", "main"]);
+  } catch (err) {
+    emitFn({
+      event: "plugin.checkout.refresh_failed",
+      orchestrator: null,
+      worker: null,
+      severity: "WARN",
+      detail: {
+        checkout: root,
+        old_sha: oldSha,
+        error: err?.message ?? String(err),
+      },
+    });
+    return { pulled: false, throttled: false, changed: false, failed: true };
+  }
+
+  let newSha = null;
+  try {
+    newSha = gitFn(root, ["rev-parse", "HEAD"]);
+  } catch {
+    newSha = null;
+  }
+
+  // HEAD did not advance — nothing changed, stay quiet (no event noise).
+  if (oldSha && newSha && oldSha === newSha) {
+    return { pulled: true, throttled: false, changed: false, failed: false };
+  }
+
+  // Daemon skew: the checkout advanced, but the long-lived daemon still runs the
+  // code it loaded at boot. Surface restart_needed so the operator/HUD can see
+  // the skew (ties into the CTL-669 loadedCommit/restartNeeded model). Daemon
+  // restart stays a gated OPERATOR action — never automated here.
+  const restartNeeded = loadedCommit != null && newSha != null && loadedCommit !== newSha;
+
+  emitFn({
+    event: "plugin.checkout.updated",
+    orchestrator: null,
+    worker: null,
+    detail: {
+      checkout: root,
+      old_sha: oldSha,
+      new_sha: newSha,
+      loaded_commit: loadedCommit,
+      restart_needed: restartNeeded,
+    },
+  });
+  return { pulled: true, throttled: false, changed: true, failed: false };
+}
+
+/**
+ * handlePluginRefreshEvent — top-level wiring the router calls for every event.
+ * No-op unless the event is a merge-to-main of the configured repo. Resolves
+ * the pluginDirs checkout root(s) and refreshes each (throttle-gated). Pure
+ * orchestration over the three units above — never throws (best-effort, the
+ * routing path must not die on a refresh).
+ */
+export function handlePluginRefreshEvent({
+  event,
+  now = Date.now(),
+  env = process.env,
+  repoFullName,
+  machineConfigPath,
+  repoConfigPath = null,
+  readFileFn,
+  gitToplevelFn,
+  gitFn,
+  emitFn,
+  loadedCommit = null,
+}) {
+  try {
+    if (!isThisRepoMergeEvent(event, { repoFullName })) return;
+    const roots = resolvePluginCheckoutRoots({
+      env,
+      machineConfigPath,
+      repoConfigPath,
+      readFileFn,
+      gitToplevelFn,
+    });
+    for (const root of roots) {
+      refreshPluginCheckout({ root, now, gitFn, emitFn, loadedCommit });
+    }
+  } catch {
+    // Best-effort — a refresh failure must never break event routing. Genuine
+    // pull failures are already surfaced as refresh_failed events above.
+  }
+}

--- a/plugins/dev/scripts/broker/plugin-refresh.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.mjs
@@ -54,6 +54,13 @@ export function __clearThrottleForTest() {
 
 // --- default seams (production wiring) ---------------------------------------
 
+// GIT_TIMEOUT_MS — hard ceiling on every synchronous git call. The broker's
+// event loop runs these inline (execFileSync); a network-stalled `pull` with
+// no timeout would freeze the ENTIRE broker — the same daemon-wedging class
+// CTL-990 fixed in dispatch.mjs. A killed pull throws and surfaces as
+// refresh_failed; the next merge event retries after the throttle window.
+const GIT_TIMEOUT_MS = Number(process.env.CATALYST_PLUGIN_REFRESH_GIT_TIMEOUT_MS) || 20_000;
+
 // defaultGitFn — run a git subcommand in `root` and return trimmed stdout.
 // GIT_TERMINAL_PROMPT=0 so an auth-required fetch fails fast instead of hanging
 // a daemon with no tty/ssh-agent. Throws on non-zero exit (execFileSync), which
@@ -61,6 +68,8 @@ export function __clearThrottleForTest() {
 function defaultGitFn(root, args) {
   return execFileSync("git", ["-C", root, ...args], {
     encoding: "utf8",
+    timeout: GIT_TIMEOUT_MS,
+    killSignal: "SIGKILL",
     env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
   }).trim();
 }
@@ -71,6 +80,8 @@ function defaultGitToplevelFn(pluginDir) {
   try {
     return execFileSync("git", ["-C", pluginDir, "rev-parse", "--show-toplevel"], {
       encoding: "utf8",
+      timeout: GIT_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     }).trim();
   } catch {
     return null;
@@ -234,6 +245,7 @@ export function refreshPluginCheckout({
   gitFn = defaultGitFn,
   emitFn,
   loadedCommit = null,
+  loadedCommitRoot = null,
 }) {
   if (!root) return { pulled: false, throttled: false, changed: false, failed: false };
 
@@ -285,7 +297,15 @@ export function refreshPluginCheckout({
   // code it loaded at boot. Surface restart_needed so the operator/HUD can see
   // the skew (ties into the CTL-669 loadedCommit/restartNeeded model). Daemon
   // restart stays a gated OPERATOR action — never automated here.
-  const restartNeeded = loadedCommit != null && newSha != null && loadedCommit !== newSha;
+  // restart_needed only fires for the checkout the daemon itself runs from
+  // (loadedCommitRoot): a broker running from checkout A must not flag skew
+  // because an unrelated pluginDirs checkout B advanced. A null loadedCommitRoot
+  // (caller didn't resolve it) preserves the coarse loadedCommit comparison.
+  const restartNeeded =
+    loadedCommit != null &&
+    newSha != null &&
+    loadedCommit !== newSha &&
+    (loadedCommitRoot == null || loadedCommitRoot === root);
 
   emitFn({
     event: "plugin.checkout.updated",
@@ -321,6 +341,7 @@ export function handlePluginRefreshEvent({
   gitFn,
   emitFn,
   loadedCommit = null,
+  loadedCommitRoot = null,
 }) {
   try {
     if (!isThisRepoMergeEvent(event, { repoFullName })) return;
@@ -332,7 +353,7 @@ export function handlePluginRefreshEvent({
       gitToplevelFn,
     });
     for (const root of roots) {
-      refreshPluginCheckout({ root, now, gitFn, emitFn, loadedCommit });
+      refreshPluginCheckout({ root, now, gitFn, emitFn, loadedCommit, loadedCommitRoot });
     }
   } catch {
     // Best-effort — a refresh failure must never break event routing. Genuine

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -393,6 +393,34 @@ describe("refreshPluginCheckout", () => {
     });
     expect(emitted[0].detail.restart_needed).toBe(false);
   });
+
+  test("restart_needed only fires for the daemon's OWN checkout (loadedCommitRoot)", () => {
+    // The broker runs from checkout /broker-co; an unrelated pluginDirs
+    // checkout /co advancing must NOT flag the broker as stale.
+    const emittedOther = [];
+    refreshPluginCheckout({
+      root: "/co",
+      now: 0,
+      gitFn: makeGitFn({ before: "boot00", after: "fresh1" }),
+      emitFn: (e) => emittedOther.push(e),
+      loadedCommit: "boot00",
+      loadedCommitRoot: "/broker-co",
+    });
+    expect(emittedOther[0].event).toBe("plugin.checkout.updated");
+    expect(emittedOther[0].detail.restart_needed).toBe(false);
+
+    // Same checkout → skew DOES flag.
+    const emittedOwn = [];
+    refreshPluginCheckout({
+      root: "/broker-co",
+      now: 0,
+      gitFn: makeGitFn({ before: "boot00", after: "fresh1" }),
+      emitFn: (e) => emittedOwn.push(e),
+      loadedCommit: "boot00",
+      loadedCommitRoot: "/broker-co",
+    });
+    expect(emittedOwn[0].detail.restart_needed).toBe(true);
+  });
 });
 
 // ─── handlePluginRefreshEvent (orchestration) ────────────────────────────────

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -1,0 +1,516 @@
+// Unit tests for plugin-refresh.mjs (CTL-993).
+//
+// A merge to main should refresh every node's pluginDirs checkout within
+// seconds: the broker tails the unified event log, and when a GitHub
+// push/merge event for the configured repo@main arrives it runs an ff-only
+// pull in the resolved checkout, emits plugin.checkout.updated with the new
+// HEAD sha, throttles to at most one pull per N seconds, surfaces pull
+// failures (instead of failing silently), and makes daemon skew visible
+// (restart_needed) without auto-restarting.
+//
+// Every OS/git/config/clock interaction is an injected seam so the decision
+// core and lifecycle are deterministically testable without real load,
+// timers, network, or a real checkout. Mirrors the gc-liveness.mjs /
+// autotune.mjs seam-injection convention.
+//
+// Run: bun test plugins/dev/scripts/broker/plugin-refresh.test.mjs
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  resolvePluginCheckoutRoots,
+  resolveRepoFullName,
+  isThisRepoMergeEvent,
+  refreshPluginCheckout,
+  handlePluginRefreshEvent,
+  PLUGIN_REFRESH_THROTTLE_MS,
+  __clearThrottleForTest,
+} from "./plugin-refresh.mjs";
+
+// ─── resolvePluginCheckoutRoots ──────────────────────────────────────────────
+//
+// JS mirror of lib/plugin-dirs.sh::resolve_plugin_dirs precedence:
+//   1. CATALYST_PLUGIN_DIRS env (colon-separated)
+//   2. repo .catalyst/config.json → .catalyst.orchestration.pluginDirs
+//   3. machine config → .catalyst.orchestration.pluginDirs
+// pluginDirs may be a string or array in either file; each entry points at
+// <checkout>/plugins/dev and is mapped to its git toplevel and deduped.
+
+describe("resolvePluginCheckoutRoots", () => {
+  test("resolves from CATALYST_PLUGIN_DIRS env (highest precedence)", () => {
+    const roots = resolvePluginCheckoutRoots({
+      env: { CATALYST_PLUGIN_DIRS: "/co/checkout-a/plugins/dev" },
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: () => '{"catalyst":{"orchestration":{"pluginDirs":"/other/plugins/dev"}}}',
+      gitToplevelFn: (pd) => pd.replace(/\/plugins\/dev$/, ""),
+    });
+    expect(roots).toEqual(["/co/checkout-a"]);
+  });
+
+  test("falls back to repo config when env unset", () => {
+    const roots = resolvePluginCheckoutRoots({
+      env: {},
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: (p) =>
+        p === "/repo/.catalyst/config.json"
+          ? '{"catalyst":{"orchestration":{"pluginDirs":"/repo-co/plugins/dev"}}}'
+          : "{}",
+      gitToplevelFn: (pd) => pd.replace(/\/plugins\/dev$/, ""),
+    });
+    expect(roots).toEqual(["/repo-co"]);
+  });
+
+  test("falls back to machine config when env + repo config absent", () => {
+    const roots = resolvePluginCheckoutRoots({
+      env: {},
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: (p) =>
+        p === "/cfg/machine.json"
+          ? '{"catalyst":{"orchestration":{"pluginDirs":"/mach-co/plugins/dev"}}}'
+          : (() => {
+              throw new Error("ENOENT");
+            })(),
+      gitToplevelFn: (pd) => pd.replace(/\/plugins\/dev$/, ""),
+    });
+    expect(roots).toEqual(["/mach-co"]);
+  });
+
+  test("splits a colon-joined env value and dedupes shared roots", () => {
+    const roots = resolvePluginCheckoutRoots({
+      env: { CATALYST_PLUGIN_DIRS: "/co/plugins/dev:/co/plugins/pm:/co2/plugins/dev" },
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: () => "{}",
+      gitToplevelFn: (pd) => pd.replace(/\/plugins\/(dev|pm)$/, ""),
+    });
+    expect(roots).toEqual(["/co", "/co2"]);
+  });
+
+  test("accepts pluginDirs as a JSON array in config (string-or-array tolerant)", () => {
+    const roots = resolvePluginCheckoutRoots({
+      env: {},
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: (p) =>
+        p === "/cfg/machine.json"
+          ? '{"catalyst":{"orchestration":{"pluginDirs":["/a/plugins/dev","/b/plugins/dev"]}}}'
+          : "{}",
+      gitToplevelFn: (pd) => pd.replace(/\/plugins\/dev$/, ""),
+    });
+    expect(roots).toEqual(["/a", "/b"]);
+  });
+
+  test("returns [] when pluginDirs is unset everywhere", () => {
+    const roots = resolvePluginCheckoutRoots({
+      env: {},
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: () => "{}",
+      gitToplevelFn: (pd) => pd,
+    });
+    expect(roots).toEqual([]);
+  });
+
+  test("drops entries whose git toplevel cannot be resolved", () => {
+    const roots = resolvePluginCheckoutRoots({
+      env: { CATALYST_PLUGIN_DIRS: "/good/plugins/dev:/bad/plugins/dev" },
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: () => "{}",
+      gitToplevelFn: (pd) => (pd.startsWith("/good") ? "/good" : null),
+    });
+    expect(roots).toEqual(["/good"]);
+  });
+});
+
+// ─── resolveRepoFullName ─────────────────────────────────────────────────────
+//
+// Repo identity (the repository whose merges trigger a refresh) is read from
+// .catalyst.feedback.githubRepo, with the first .catalyst.monitor.linear.teams
+// vcsRepo as a fallback. Repo config takes precedence over machine config.
+
+describe("resolveRepoFullName", () => {
+  test("reads feedback.githubRepo from the repo config", () => {
+    const name = resolveRepoFullName({
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: (p) =>
+        p === "/repo/.catalyst/config.json"
+          ? '{"catalyst":{"feedback":{"githubRepo":"coalesce-labs/catalyst"}}}'
+          : "{}",
+    });
+    expect(name).toBe("coalesce-labs/catalyst");
+  });
+
+  test("falls back to the first monitor.linear.teams[].vcsRepo", () => {
+    const name = resolveRepoFullName({
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: (p) =>
+        p === "/repo/.catalyst/config.json"
+          ? '{"catalyst":{"monitor":{"linear":{"teams":[{"key":"CTL","vcsRepo":"coalesce-labs/catalyst"}]}}}}'
+          : "{}",
+    });
+    expect(name).toBe("coalesce-labs/catalyst");
+  });
+
+  test("returns null when no repo identity is configured anywhere", () => {
+    const name = resolveRepoFullName({
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: () => "{}",
+    });
+    expect(name).toBeNull();
+  });
+});
+
+// ─── isThisRepoMergeEvent ────────────────────────────────────────────────────
+
+describe("isThisRepoMergeEvent", () => {
+  const repoFullName = "coalesce-labs/catalyst";
+
+  test("true for canonical github.pr.merged on the configured repo", () => {
+    const event = {
+      attributes: {
+        "event.name": "github.pr.merged",
+        "vcs.repository.name": "coalesce-labs/catalyst",
+      },
+      body: { payload: { merged: true } },
+    };
+    expect(isThisRepoMergeEvent(event, { repoFullName })).toBe(true);
+  });
+
+  test("true for canonical github.push to refs/heads/main on the configured repo", () => {
+    const event = {
+      attributes: {
+        "event.name": "github.push",
+        "vcs.repository.name": "coalesce-labs/catalyst",
+        "vcs.ref.name": "main",
+      },
+      body: { payload: {} },
+    };
+    expect(isThisRepoMergeEvent(event, { repoFullName })).toBe(true);
+  });
+
+  test("true for legacy flat github.pr.merged shape on the configured repo", () => {
+    const event = {
+      event: "github.pr.merged",
+      scope: { repo: "coalesce-labs/catalyst" },
+      detail: { merged: true },
+    };
+    expect(isThisRepoMergeEvent(event, { repoFullName })).toBe(true);
+  });
+
+  test("false for a github.push to a non-main branch", () => {
+    const event = {
+      attributes: {
+        "event.name": "github.push",
+        "vcs.repository.name": "coalesce-labs/catalyst",
+        "vcs.ref.name": "feat/x",
+      },
+      body: { payload: {} },
+    };
+    expect(isThisRepoMergeEvent(event, { repoFullName })).toBe(false);
+  });
+
+  test("false for a merge event on a DIFFERENT repo", () => {
+    const event = {
+      attributes: {
+        "event.name": "github.pr.merged",
+        "vcs.repository.name": "coalesce-labs/adva",
+      },
+      body: { payload: { merged: true } },
+    };
+    expect(isThisRepoMergeEvent(event, { repoFullName })).toBe(false);
+  });
+
+  test("false for unrelated event names", () => {
+    const event = {
+      attributes: {
+        "event.name": "github.check_suite.completed",
+        "vcs.repository.name": "coalesce-labs/catalyst",
+      },
+      body: { payload: {} },
+    };
+    expect(isThisRepoMergeEvent(event, { repoFullName })).toBe(false);
+  });
+
+  test("false when repoFullName is not configured (no identity to match)", () => {
+    const event = {
+      attributes: {
+        "event.name": "github.pr.merged",
+        "vcs.repository.name": "coalesce-labs/catalyst",
+      },
+      body: { payload: { merged: true } },
+    };
+    expect(isThisRepoMergeEvent(event, { repoFullName: null })).toBe(false);
+  });
+});
+
+// ─── refreshPluginCheckout ───────────────────────────────────────────────────
+
+describe("refreshPluginCheckout", () => {
+  beforeEach(() => __clearThrottleForTest());
+
+  function makeGitFn({ before = "aaaa", after = "bbbb", pullThrows = false } = {}) {
+    const calls = [];
+    const gitFn = (root, args) => {
+      calls.push({ root, args });
+      const sub = args[0];
+      if (sub === "rev-parse") {
+        // first rev-parse → before, subsequent → after (the pull advanced HEAD)
+        const seen = calls.filter((c) => c.args[0] === "rev-parse").length;
+        return seen === 1 ? before : after;
+      }
+      if (sub === "pull") {
+        if (pullThrows) {
+          const e = new Error("not fast-forwardable");
+          throw e;
+        }
+        return "";
+      }
+      return "";
+    };
+    gitFn.calls = calls;
+    return gitFn;
+  }
+
+  test("runs ff-only pull and emits plugin.checkout.updated with old+new sha", () => {
+    const emitted = [];
+    const gitFn = makeGitFn({ before: "old111", after: "new222" });
+    const res = refreshPluginCheckout({
+      root: "/co",
+      now: 1_000_000,
+      gitFn,
+      emitFn: (e) => emitted.push(e),
+    });
+
+    expect(res.pulled).toBe(true);
+    // an ff-only pull was issued against the right checkout
+    const pull = gitFn.calls.find((c) => c.args[0] === "pull");
+    expect(pull.root).toBe("/co");
+    expect(pull.args).toContain("--ff-only");
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].event).toBe("plugin.checkout.updated");
+    expect(emitted[0].detail.checkout).toBe("/co");
+    expect(emitted[0].detail.old_sha).toBe("old111");
+    expect(emitted[0].detail.new_sha).toBe("new222");
+  });
+
+  test("throttles to at most one pull per N seconds for the same root", () => {
+    const emitted = [];
+    const gitFn = makeGitFn();
+    const args = { root: "/co", gitFn, emitFn: (e) => emitted.push(e) };
+
+    const first = refreshPluginCheckout({ ...args, now: 0 });
+    expect(first.pulled).toBe(true);
+
+    // within the throttle window → skipped, no second pull
+    const second = refreshPluginCheckout({ ...args, now: PLUGIN_REFRESH_THROTTLE_MS - 1 });
+    expect(second.pulled).toBe(false);
+    expect(second.throttled).toBe(true);
+
+    // after the window elapses → pull again
+    const third = refreshPluginCheckout({ ...args, now: PLUGIN_REFRESH_THROTTLE_MS + 1 });
+    expect(third.pulled).toBe(true);
+
+    const pulls = gitFn.calls.filter((c) => c.args[0] === "pull");
+    expect(pulls).toHaveLength(2);
+  });
+
+  test("throttle is per-root — a different checkout is not blocked", () => {
+    const emitted = [];
+    const gitFnA = makeGitFn();
+    const gitFnB = makeGitFn();
+    const a = refreshPluginCheckout({ root: "/a", now: 0, gitFn: gitFnA, emitFn: (e) => emitted.push(e) });
+    const b = refreshPluginCheckout({ root: "/b", now: 0, gitFn: gitFnB, emitFn: (e) => emitted.push(e) });
+    expect(a.pulled).toBe(true);
+    expect(b.pulled).toBe(true);
+  });
+
+  test("ff-only pull failure surfaces as a refresh_failed event (not silent)", () => {
+    const emitted = [];
+    const gitFn = makeGitFn({ pullThrows: true });
+    const res = refreshPluginCheckout({
+      root: "/co",
+      now: 0,
+      gitFn,
+      emitFn: (e) => emitted.push(e),
+    });
+    expect(res.pulled).toBe(false);
+    expect(res.failed).toBe(true);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].event).toBe("plugin.checkout.refresh_failed");
+    expect(emitted[0].detail.checkout).toBe("/co");
+    expect(typeof emitted[0].detail.error).toBe("string");
+    expect(emitted[0].severity).toBe("WARN");
+  });
+
+  test("no-op (no event) when HEAD did not advance", () => {
+    const emitted = [];
+    const gitFn = makeGitFn({ before: "same", after: "same" });
+    const res = refreshPluginCheckout({
+      root: "/co",
+      now: 0,
+      gitFn,
+      emitFn: (e) => emitted.push(e),
+    });
+    expect(res.pulled).toBe(true);
+    expect(res.changed).toBe(false);
+    expect(emitted).toHaveLength(0);
+  });
+
+  test("surfaces daemon skew: restart_needed flag on the updated event", () => {
+    const emitted = [];
+    const gitFn = makeGitFn({ before: "boot00", after: "fresh1" });
+    refreshPluginCheckout({
+      root: "/co",
+      now: 0,
+      gitFn,
+      emitFn: (e) => emitted.push(e),
+      // the daemon booted at boot00; the checkout just advanced past it
+      loadedCommit: "boot00",
+    });
+    expect(emitted[0].event).toBe("plugin.checkout.updated");
+    expect(emitted[0].detail.restart_needed).toBe(true);
+    expect(emitted[0].detail.loaded_commit).toBe("boot00");
+  });
+
+  test("restart_needed is false when the daemon's loaded commit is unknown", () => {
+    const emitted = [];
+    const gitFn = makeGitFn({ before: "a", after: "b" });
+    refreshPluginCheckout({
+      root: "/co",
+      now: 0,
+      gitFn,
+      emitFn: (e) => emitted.push(e),
+    });
+    expect(emitted[0].detail.restart_needed).toBe(false);
+  });
+});
+
+// ─── handlePluginRefreshEvent (orchestration) ────────────────────────────────
+
+describe("handlePluginRefreshEvent", () => {
+  let tmpDir;
+  let machineConfigPath;
+
+  beforeEach(() => {
+    __clearThrottleForTest();
+    tmpDir = mkdtempSync(join(tmpdir(), "plugin-refresh-test-"));
+    machineConfigPath = join(tmpDir, "machine.json");
+    mkdirSync(join(tmpDir, "co"), { recursive: true });
+    writeFileSync(
+      machineConfigPath,
+      JSON.stringify({
+        catalyst: { orchestration: { pluginDirs: join(tmpDir, "co", "plugins", "dev") } },
+      })
+    );
+  });
+
+  test("pulls + emits on a merge event for the configured repo", () => {
+    const emitted = [];
+    let pulled = false;
+    handlePluginRefreshEvent({
+      event: {
+        attributes: {
+          "event.name": "github.pr.merged",
+          "vcs.repository.name": "coalesce-labs/catalyst",
+        },
+        body: { payload: { merged: true } },
+      },
+      now: 0,
+      env: {},
+      repoFullName: "coalesce-labs/catalyst",
+      machineConfigPath,
+      repoConfigPath: join(tmpDir, "nope", ".catalyst", "config.json"),
+      gitToplevelFn: (pd) => pd.replace(/\/plugins\/dev$/, ""),
+      gitFn: (root, args) => {
+        if (args[0] === "pull") {
+          pulled = true;
+          return "";
+        }
+        if (args[0] === "rev-parse") return pulled ? "new" : "old";
+        return "";
+      },
+      emitFn: (e) => emitted.push(e),
+    });
+    expect(pulled).toBe(true);
+    expect(emitted.some((e) => e.event === "plugin.checkout.updated")).toBe(true);
+  });
+
+  test("ignores events that are not a merge to the configured repo", () => {
+    const emitted = [];
+    let pulled = false;
+    handlePluginRefreshEvent({
+      event: {
+        attributes: {
+          "event.name": "github.pr.merged",
+          "vcs.repository.name": "coalesce-labs/adva",
+        },
+        body: { payload: { merged: true } },
+      },
+      now: 0,
+      env: {},
+      repoFullName: "coalesce-labs/catalyst",
+      machineConfigPath,
+      repoConfigPath: join(tmpDir, "nope", ".catalyst", "config.json"),
+      gitToplevelFn: (pd) => pd.replace(/\/plugins\/dev$/, ""),
+      gitFn: () => {
+        pulled = true;
+        return "";
+      },
+      emitFn: (e) => emitted.push(e),
+    });
+    expect(pulled).toBe(false);
+    expect(emitted).toHaveLength(0);
+  });
+
+  test("is a no-op (no throw) when no pluginDirs are configured", () => {
+    writeFileSync(machineConfigPath, "{}");
+    const emitted = [];
+    expect(() =>
+      handlePluginRefreshEvent({
+        event: {
+          attributes: {
+            "event.name": "github.pr.merged",
+            "vcs.repository.name": "coalesce-labs/catalyst",
+          },
+          body: { payload: { merged: true } },
+        },
+        now: 0,
+        env: {},
+        repoFullName: "coalesce-labs/catalyst",
+        machineConfigPath,
+        repoConfigPath: join(tmpDir, "nope", ".catalyst", "config.json"),
+        gitToplevelFn: (pd) => pd,
+        gitFn: () => "",
+        emitFn: (e) => emitted.push(e),
+      })
+    ).not.toThrow();
+    expect(emitted).toHaveLength(0);
+  });
+});
+
+// ─── self-filter loop guard (CTL-346 / CTL-993) ──────────────────────────────
+// The events this module emits must be dropped by shouldSkipEvent on re-ingest
+// so the broker never wakes itself on its own plugin.checkout.* output.
+
+describe("emitted events cannot loop through shouldSkipEvent", () => {
+  test("plugin.checkout.updated / refresh_failed wrapped in a broker envelope are skipped", async () => {
+    const { buildCanonicalEnvelope, shouldSkipEvent } = await import("./router.mjs");
+    for (const name of ["plugin.checkout.updated", "plugin.checkout.refresh_failed"]) {
+      const canonical = buildCanonicalEnvelope({ event: name, detail: {} });
+      // buildCanonicalEnvelope stamps resource["service.name"] = catalyst.broker,
+      // which shouldSkipEvent drops on re-ingest.
+      expect(canonical.resource["service.name"]).toBe("catalyst.broker");
+      expect(shouldSkipEvent(canonical)).toBe(true);
+    }
+  });
+});

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -125,7 +125,11 @@ function __repoFullName() {
 // The broker's own HEAD at boot (the code it is actually running). Lets the
 // refresh emit restart_needed when the checkout advances past it. Best-effort —
 // null when not in a checkout (skew simply not flagged). CTL-669 model.
+// __loadedCommitRoot pairs it with the broker's own checkout toplevel so
+// restart_needed only fires for THAT checkout — not for an unrelated
+// pluginDirs checkout that happens to advance.
 let __loadedCommitCached;
+let __loadedCommitRootCached;
 function __loadedCommit() {
   if (__loadedCommitCached === undefined) {
     try {
@@ -139,6 +143,20 @@ function __loadedCommit() {
     }
   }
   return __loadedCommitCached;
+}
+function __loadedCommitRoot() {
+  if (__loadedCommitRootCached === undefined) {
+    try {
+      __loadedCommitRootCached = execFileSync(
+        "git",
+        ["-C", dirname(fileURLToPath(import.meta.url)), "rev-parse", "--show-toplevel"],
+        { encoding: "utf8" }
+      ).trim();
+    } catch {
+      __loadedCommitRootCached = null;
+    }
+  }
+  return __loadedCommitRootCached;
 }
 
 // === Emission ===
@@ -1777,6 +1795,7 @@ export function processEvent(event) {
     repoConfigPath: __REPO_CONFIG_PATH,
     emitFn: appendEvent,
     loadedCommit: __loadedCommit(),
+    loadedCommitRoot: __loadedCommitRoot(),
   });
 
   if (name === "filter.register") {

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -12,6 +12,7 @@
 import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
 import {
   log,
   getEventLogPath,
@@ -66,6 +67,7 @@ import {
   clearWaitingSession,
 } from "./broker-state.mjs";
 import { sessionLiveness } from "./session-liveness.mjs";
+import { handlePluginRefreshEvent, resolveRepoFullName } from "./plugin-refresh.mjs";
 import {
   severityNumber,
   deriveTraceId,
@@ -86,6 +88,58 @@ const orchestratorStatusMap = getOrchestratorStatusMap();
 
 // CTL-352: empty-interests degraded threshold (5-minute startup grace).
 const DEGRADED_THRESHOLD_MS = 5 * 60 * 1000;
+
+// CTL-993: merge-to-main plugin-checkout refresh wiring. The broker module lives
+// at <repo>/plugins/dev/scripts/broker/router.mjs, so the repo .catalyst config
+// (which carries feedback.githubRepo) is four levels up. The machine config path
+// matches lib/plugin-dirs.sh's resolution (CATALYST_MACHINE_CONFIG override).
+const __REPO_CONFIG_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "..",
+  ".catalyst",
+  "config.json"
+);
+function __machineConfigPath() {
+  const xdg = process.env.XDG_CONFIG_HOME || `${process.env.HOME ?? ""}/.config`;
+  return resolve(process.env.CATALYST_MACHINE_CONFIG || `${xdg}/catalyst/config.json`);
+}
+// Resolved once per daemon lifetime — the repo identity does not change while
+// the broker runs, and the file walk should not repeat on every event.
+let __repoFullNameCached;
+function __repoFullName() {
+  if (__repoFullNameCached === undefined) {
+    try {
+      __repoFullNameCached = resolveRepoFullName({
+        machineConfigPath: __machineConfigPath(),
+        repoConfigPath: __REPO_CONFIG_PATH,
+      });
+    } catch {
+      __repoFullNameCached = null;
+    }
+  }
+  return __repoFullNameCached;
+}
+// The broker's own HEAD at boot (the code it is actually running). Lets the
+// refresh emit restart_needed when the checkout advances past it. Best-effort —
+// null when not in a checkout (skew simply not flagged). CTL-669 model.
+let __loadedCommitCached;
+function __loadedCommit() {
+  if (__loadedCommitCached === undefined) {
+    try {
+      __loadedCommitCached = execFileSync(
+        "git",
+        ["-C", dirname(fileURLToPath(import.meta.url)), "rev-parse", "HEAD"],
+        { encoding: "utf8" }
+      ).trim();
+    } catch {
+      __loadedCommitCached = null;
+    }
+  }
+  return __loadedCommitCached;
+}
 
 // === Emission ===
 // Canonical envelope helpers. Primitives (sha256Hex, severityNumber,
@@ -1708,6 +1762,22 @@ export function processEvent(event) {
   // non-consuming — the projection is a side-channel observer and never
   // returns, so existing routing below is untouched).
   projectWorkerStateEvent(event);
+
+  // CTL-993: on a merge-to-main of the configured repo, ff-only pull the
+  // pluginDirs checkout so fixes go live within seconds. Non-consuming
+  // side-channel like projectWorkerStateEvent — runs ABOVE the shouldSkipEvent /
+  // interests.size gates because GitHub merge events arrive whether or not any
+  // orchestration is active. handlePluginRefreshEvent never throws and the
+  // events it emits carry resource["service.name"]=catalyst.broker, which
+  // shouldSkipEvent drops on re-ingest (no self-wake loop).
+  handlePluginRefreshEvent({
+    event,
+    repoFullName: __repoFullName(),
+    machineConfigPath: __machineConfigPath(),
+    repoConfigPath: __REPO_CONFIG_PATH,
+    emitFn: appendEvent,
+    loadedCommit: __loadedCommit(),
+  });
 
   if (name === "filter.register") {
     handleRegister(event);

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -310,6 +310,27 @@ _parity_check_dir() {
   fi
   log "parity: checking $pd (checkout: $root)"
 
+  # Structural health (CTL-992): the checkout must be a pristine, standalone,
+  # main-only checkout. plugin_source_health surfaces these as typed lines; we
+  # consume the two NEW structural conditions here (LINKED_WORKTREE, OFF_MAIN).
+  # MISSING / NOT_A_CHECKOUT are already handled above; DIRTY stays inline below.
+  local _hline _htok _harg1 _harg2
+  while IFS= read -r _hline; do
+    [[ -z "$_hline" ]] && continue
+    _htok="${_hline%% *}"
+    _harg1="${_hline#"$_htok" }"
+    case "$_htok" in
+      LINKED_WORKTREE)
+        drift "pluginDirs checkout is a linked worktree, not a pristine main checkout: ${_harg1} — run setup-plugin-source.sh"
+        ;;
+      OFF_MAIN)
+        _harg2="${_harg1##* }"
+        _harg1="${_harg1% *}"
+        drift "pluginDirs checkout is on branch ${_harg2}, not main: ${_harg1} — run setup-plugin-source.sh"
+        ;;
+    esac
+  done < <(plugin_source_health "$pd")
+
   # Manifest must parse — a gutted/corrupt plugin dir wedges workers.
   local manifest="${pd}/.claude-plugin/plugin.json"
   if [[ ! -f "$manifest" ]]; then

--- a/plugins/dev/scripts/lib/plugin-dirs-health.test.mjs
+++ b/plugins/dev/scripts/lib/plugin-dirs-health.test.mjs
@@ -1,0 +1,124 @@
+// plugin-dirs-health.test.mjs — tests for the plugin_source_health bash
+// function in lib/plugin-dirs.sh (CTL-992): offline, read-only structural
+// health check of a pluginDirs checkout.
+// Run from plugins/dev/scripts/broker: bun test ../lib/plugin-dirs-health.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const LIB = join(HERE, "plugin-dirs.sh");
+
+// git, configured for hermetic commits (no signing, fixed identity, main default).
+function git(cwd, ...args) {
+  return execFileSync(
+    "git",
+    [
+      "-c", "user.email=t@t",
+      "-c", "user.name=t",
+      "-c", "commit.gpgsign=false",
+      "-c", "init.defaultBranch=main",
+      "-C", cwd,
+      ...args,
+    ],
+    { encoding: "utf8" },
+  );
+}
+
+// Run `plugin_source_health <dir>` via bash and capture stdout + exit code.
+function health(pd) {
+  try {
+    const out = execFileSync(
+      "bash",
+      ["-c", `source "${LIB}"; plugin_source_health "${pd}"`],
+      { encoding: "utf8" },
+    );
+    return { out, code: 0 };
+  } catch (e) {
+    return { out: (e.stdout || "").toString(), code: e.status ?? 1 };
+  }
+}
+
+// Build a clean checkout on main with a plugins/dev manifest committed.
+function makeCheckout(root) {
+  mkdirSync(root, { recursive: true });
+  git(root, "init", "-q");
+  const pd = join(root, "plugins", "dev", ".claude-plugin");
+  mkdirSync(pd, { recursive: true });
+  writeFileSync(
+    join(pd, "plugin.json"),
+    JSON.stringify({ name: "catalyst-dev", version: "1.0.0" }),
+  );
+  writeFileSync(join(root, "plugins", "dev", "marker.txt"), "v1\n");
+  git(root, "add", "-A");
+  git(root, "commit", "-qm", "initial");
+}
+
+describe("plugin_source_health", () => {
+  let tmp;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "pdh-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("clean main checkout → no lines, exit 0", () => {
+    const root = join(tmp, "checkout");
+    makeCheckout(root);
+    const { out, code } = health(join(root, "plugins", "dev"));
+    expect(out.trim()).toBe("");
+    expect(code).toBe(0);
+  });
+
+  test("off-main checkout → OFF_MAIN line, nonzero", () => {
+    const root = join(tmp, "checkout");
+    makeCheckout(root);
+    git(root, "checkout", "-q", "-b", "feature");
+    const { out, code } = health(join(root, "plugins", "dev"));
+    expect(out).toContain("OFF_MAIN");
+    expect(out).toContain("feature");
+    expect(code).not.toBe(0);
+  });
+
+  test("dirty working tree → DIRTY line, nonzero", () => {
+    const root = join(tmp, "checkout");
+    makeCheckout(root);
+    writeFileSync(join(root, "plugins", "dev", "marker.txt"), "edit\n");
+    const { out, code } = health(join(root, "plugins", "dev"));
+    expect(out).toContain("DIRTY");
+    expect(code).not.toBe(0);
+  });
+
+  test("missing dir → MISSING line, nonzero", () => {
+    const { out, code } = health(join(tmp, "does-not-exist", "plugins", "dev"));
+    expect(out).toContain("MISSING");
+    expect(code).not.toBe(0);
+  });
+
+  test("non-git dir → NOT_A_CHECKOUT line, nonzero", () => {
+    const pd = join(tmp, "plain", "plugins", "dev");
+    mkdirSync(pd, { recursive: true });
+    const { out, code } = health(pd);
+    expect(out).toContain("NOT_A_CHECKOUT");
+    expect(code).not.toBe(0);
+  });
+
+  test("linked worktree → LINKED_WORKTREE line, nonzero", () => {
+    const root = join(tmp, "primary");
+    makeCheckout(root);
+    // main is occupied by the primary; park it on a throwaway branch so the
+    // linked worktree can itself sit on main (isolating LINKED_WORKTREE from
+    // OFF_MAIN).
+    git(root, "checkout", "-q", "-b", "parking");
+    const linked = join(tmp, "linked");
+    git(root, "worktree", "add", "-q", linked, "main");
+    const { out, code } = health(join(linked, "plugins", "dev"));
+    expect(out).toContain("LINKED_WORKTREE");
+    expect(code).not.toBe(0);
+  });
+});

--- a/plugins/dev/scripts/lib/plugin-dirs.sh
+++ b/plugins/dev/scripts/lib/plugin-dirs.sh
@@ -88,3 +88,65 @@ plugin_checkout_root() {
   [[ -d "$pd" ]] || return 1
   git -C "$pd" rev-parse --show-toplevel 2>/dev/null
 }
+
+# plugin_source_health PLUGIN_DIR — offline, read-only structural health check
+# of a pluginDirs checkout (CTL-992). Emits zero or more TYPED warning lines to
+# stdout (stable prefix tokens so callers can switch on them, mirroring the
+# catalyst-stack drift() taxonomy) and returns the line count as the exit code
+# (0 = healthy). Dependency-light (only git); never fetches (freshness vs
+# origin stays in `catalyst-stack parity`, which fetches) and never exits.
+#
+# Typed lines (one per detected problem, first match wins per checkout):
+#   MISSING <pd>                  the pluginDirs entry does not exist
+#   NOT_A_CHECKOUT <pd>           exists but is not inside a git checkout
+#   LINKED_WORKTREE <root>        resolves to a git linked worktree, not a
+#                                 standalone pristine checkout
+#   OFF_MAIN <root> <branch>      checkout HEAD is not on main
+#   DIRTY <root>                  working tree has uncommitted changes
+plugin_source_health() {
+  local pd="$1"
+  local n=0
+
+  if [[ ! -d "$pd" ]]; then
+    printf 'MISSING %s\n' "$pd"
+    return 1
+  fi
+
+  local root
+  root="$(git -C "$pd" rev-parse --show-toplevel 2>/dev/null)"
+  if [[ -z "$root" ]]; then
+    printf 'NOT_A_CHECKOUT %s\n' "$pd"
+    return 1
+  fi
+
+  # Linked worktree: its per-worktree git dir differs from the shared common
+  # dir. A pristine plugin source must be a standalone checkout, never a
+  # worktree linked to some other primary repo. Resolve both to absolute paths
+  # ourselves (--git-common-dir can be relative on older git) before comparing.
+  local git_dir common_dir
+  git_dir="$(git -C "$root" rev-parse --absolute-git-dir 2>/dev/null)"
+  common_dir="$(git -C "$root" rev-parse --git-common-dir 2>/dev/null)"
+  if [[ -n "$common_dir" && "$common_dir" != /* ]]; then
+    common_dir="$(cd "$root" && cd "$common_dir" 2>/dev/null && pwd -P)"
+  fi
+  if [[ -n "$git_dir" && -n "$common_dir" && "$git_dir" != "$common_dir" ]]; then
+    printf 'LINKED_WORKTREE %s\n' "$root"
+    n=$((n + 1))
+  fi
+
+  # Off main: workers must run from a pristine main-only checkout.
+  local branch
+  branch="$(git -C "$root" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+  if [[ -n "$branch" && "$branch" != "main" ]]; then
+    printf 'OFF_MAIN %s %s\n' "$root" "$branch"
+    n=$((n + 1))
+  fi
+
+  # Dirty: a dirty tree blocks the ff-only auto-pull.
+  if [[ -n "$(git -C "$root" status --porcelain 2>/dev/null)" ]]; then
+    printf 'DIRTY %s\n' "$root"
+    n=$((n + 1))
+  fi
+
+  return "$n"
+}

--- a/plugins/dev/scripts/setup-plugin-source.sh
+++ b/plugins/dev/scripts/setup-plugin-source.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# setup-plugin-source.sh — provision a pristine, main-only plugin-source
+# checkout and register it as catalyst.orchestration.pluginDirs in the machine
+# config (CTL-992).
+#
+# What this script does:
+#   1. Clones (or reuses) a dedicated checkout of the catalyst repo on main,
+#      single-branch, at <path> (default ~/catalyst/plugin-source).
+#   2. Refuses to use a linked git worktree or a non-main checkout as the
+#      source — workers must run from a pristine, standalone, main-only tree.
+#   3. ff-only pulls origin/main into the reused checkout to keep it fresh.
+#   4. Registers <path>/plugins/dev as catalyst.orchestration.pluginDirs in the
+#      machine config (Layer 2), preserving every other key.
+#
+# Re-running is safe and idempotent: when pluginDirs already points at the
+# resolved target, the config write is skipped (the ff-only pull still runs).
+# Pass --force to re-register a different checkout path.
+#
+# The path of the machine config is resolved via lib/plugin-dirs.sh — the same
+# single source of truth phase-agent-dispatch and catalyst-stack use, so the
+# dir registered here is exactly the dir the dispatcher hands to workers.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Single source of truth for the machine-config path + resolution order.
+# shellcheck source=lib/plugin-dirs.sh
+if [[ ! -f "${SCRIPT_DIR}/lib/plugin-dirs.sh" ]]; then
+	echo "ERROR: missing lib/plugin-dirs.sh next to setup-plugin-source.sh" >&2
+	exit 1
+fi
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/lib/plugin-dirs.sh"
+
+DEFAULT_PATH="${CATALYST_PLUGIN_SOURCE:-$HOME/catalyst/plugin-source}"
+CHECKOUT_PATH=""
+REPO_URL=""
+FORCE=0
+
+usage() {
+	cat <<EOF
+Usage: $(basename "$0") [--path DIR] [--repo-url URL] [--force]
+
+Provisions a pristine main-only plugin-source checkout and registers it as
+catalyst.orchestration.pluginDirs in the machine config.
+
+Options:
+  --path DIR        Checkout location (default: ${DEFAULT_PATH}).
+                    Override the default via \$CATALYST_PLUGIN_SOURCE.
+  --repo-url URL    Clone source. Defaults to this repo's origin (https).
+  --force           Re-register even if pluginDirs is already set to a
+                    different path.
+  -h|--help         Show this message.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--path)
+			if [[ $# -lt 2 || -z "${2:-}" ]]; then
+				echo "ERROR: --path requires an argument" >&2
+				exit 1
+			fi
+			CHECKOUT_PATH="$2"; shift 2 ;;
+		--repo-url)
+			if [[ $# -lt 2 || -z "${2:-}" ]]; then
+				echo "ERROR: --repo-url requires an argument" >&2
+				exit 1
+			fi
+			REPO_URL="$2"; shift 2 ;;
+		--force) FORCE=1; shift ;;
+		-h|--help) usage; exit 0 ;;
+		*) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+	esac
+done
+
+require_cmd() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		echo "ERROR: '$1' is required but not installed" >&2
+		exit 1
+	fi
+}
+require_cmd git
+require_cmd jq
+
+CHECKOUT_PATH="${CHECKOUT_PATH:-$DEFAULT_PATH}"
+
+# Derive the repo URL from this repo's origin (https) when not supplied.
+if [[ -z "$REPO_URL" ]]; then
+	REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+	REPO_URL="$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || true)"
+	if [[ -z "$REPO_URL" ]]; then
+		REPO_URL="https://github.com/coalesce-labs/catalyst.git"
+	fi
+fi
+# Daemon contexts have no ssh-agent — refuse ssh remotes so the ff-only pull
+# stays unattended-fetchable.
+case "$REPO_URL" in
+	git@*|ssh://*)
+		echo "ERROR: repo URL uses ssh ($REPO_URL) — unauthable from daemon contexts; use an https URL" >&2
+		exit 1
+		;;
+esac
+
+# ─── 1. Clone or reuse ──────────────────────────────────────────────────────
+if [[ ! -e "${CHECKOUT_PATH}/.git" ]]; then
+	echo "Cloning ${REPO_URL} → ${CHECKOUT_PATH} (main, single-branch)…"
+	mkdir -p "$(dirname "$CHECKOUT_PATH")"
+	GIT_TERMINAL_PROMPT=0 git clone --branch main --single-branch \
+		"$REPO_URL" "$CHECKOUT_PATH"
+else
+	# Refuse a linked worktree: its per-worktree git dir differs from the shared
+	# common dir. A pristine plugin source must be a standalone checkout.
+	gitdir="$(git -C "$CHECKOUT_PATH" rev-parse --absolute-git-dir 2>/dev/null || true)"
+	commondir="$(git -C "$CHECKOUT_PATH" rev-parse --git-common-dir 2>/dev/null || true)"
+	if [[ -n "$commondir" && "$commondir" != /* ]]; then
+		commondir="$(cd "$CHECKOUT_PATH" && cd "$commondir" 2>/dev/null && pwd -P || true)"
+	fi
+	if [[ -z "$gitdir" ]]; then
+		echo "ERROR: ${CHECKOUT_PATH} is not a git checkout" >&2
+		exit 1
+	fi
+	if [[ -n "$commondir" && "$gitdir" != "$commondir" ]]; then
+		echo "ERROR: ${CHECKOUT_PATH} is a linked git worktree, not a standalone checkout — point --path at a dedicated pristine checkout" >&2
+		exit 1
+	fi
+
+	# Refuse a non-main branch.
+	branch="$(git -C "$CHECKOUT_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+	if [[ "$branch" != "main" ]]; then
+		echo "ERROR: ${CHECKOUT_PATH} is on branch '${branch}', not main — the plugin source must be a pristine main checkout" >&2
+		exit 1
+	fi
+
+	echo "Reusing existing checkout at ${CHECKOUT_PATH} — ff-only pull origin/main…"
+	GIT_TERMINAL_PROMPT=0 git -C "$CHECKOUT_PATH" pull --ff-only origin main \
+		|| { echo "ERROR: git pull --ff-only failed in ${CHECKOUT_PATH} — resolve manually then retry" >&2; exit 1; }
+fi
+
+HEAD_SHA="$(git -C "$CHECKOUT_PATH" rev-parse HEAD)"
+TARGET_DIR="${CHECKOUT_PATH}/plugins/dev"
+
+# ─── 2. Register pluginDirs in the machine config ───────────────────────────
+MACHINE_CFG="$(plugin_dirs_machine_config_path)"
+mkdir -p "$(dirname "$MACHINE_CFG")"
+if [[ ! -f "$MACHINE_CFG" ]]; then
+	echo "{}" > "$MACHINE_CFG"
+fi
+
+CURRENT="$(jq -r '.catalyst.orchestration.pluginDirs // empty' "$MACHINE_CFG" 2>/dev/null || true)"
+
+if [[ "$CURRENT" == "$TARGET_DIR" && $FORCE -eq 0 ]]; then
+	echo "pluginDirs already registered as ${TARGET_DIR} in ${MACHINE_CFG} — leaving as-is."
+	echo "  checkout: ${CHECKOUT_PATH}"
+	echo "  HEAD:     ${HEAD_SHA}"
+	exit 0
+fi
+
+tmp="$(mktemp)"
+jq --arg pd "$TARGET_DIR" '
+	.catalyst //= {}
+	| .catalyst.orchestration //= {}
+	| .catalyst.orchestration.pluginDirs = $pd
+' "$MACHINE_CFG" > "$tmp"
+mv "$tmp" "$MACHINE_CFG"
+
+echo "Registered pluginDirs in ${MACHINE_CFG}:"
+echo "  old: ${CURRENT:-<unset>}"
+echo "  new: ${TARGET_DIR}"
+echo "  checkout: ${CHECKOUT_PATH}"
+echo "  HEAD:     ${HEAD_SHA}"

--- a/plugins/dev/scripts/setup-plugin-source.sh
+++ b/plugins/dev/scripts/setup-plugin-source.sh
@@ -157,7 +157,11 @@ if [[ "$CURRENT" == "$TARGET_DIR" && $FORCE -eq 0 ]]; then
 	exit 0
 fi
 
-tmp="$(mktemp)"
+# Same-directory tmp so the final mv is an atomic same-filesystem rename
+# (a default mktemp lands on a different volume on macOS, making mv a
+# non-atomic copy+unlink — a crash mid-write would corrupt the config).
+tmp="$(mktemp "$(dirname "$MACHINE_CFG")/.config.json.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT
 jq --arg pd "$TARGET_DIR" '
 	.catalyst //= {}
 	| .catalyst.orchestration //= {}

--- a/website/src/content/docs/getting-started/reboot-and-updates.md
+++ b/website/src/content/docs/getting-started/reboot-and-updates.md
@@ -19,27 +19,60 @@ That's it. The command is idempotent — already-running services are skipped. C
 catalyst-stack status
 ```
 
+## Plugin source checkout
+
+Workers run their plugin code (skills, scripts, agents) from a dedicated
+**pristine, main-only checkout** of the catalyst repo — registered as
+`catalyst.orchestration.pluginDirs` and resolved by `phase-agent-dispatch` when
+it builds each worker's `--plugin-dir` flags. Keeping the source on a clean,
+single-branch `main` checkout (separate from any worktree you develop in) means
+updates are a simple `git pull --ff-only` and there is never local drift between
+what you edit and what workers execute.
+
+Provision it once:
+
+```bash
+plugins/dev/scripts/setup-plugin-source.sh
+```
+
+This clones the repo (main, single-branch) to `~/catalyst/plugin-source` and
+registers `~/catalyst/plugin-source/plugins/dev` as `pluginDirs` in your machine
+config. Choose a different location with `--path DIR` (or
+`$CATALYST_PLUGIN_SOURCE`). Re-running is idempotent: it ff-only pulls the
+existing checkout and leaves an already-correct registration untouched (use
+`--force` to point `pluginDirs` at a new path).
+
+The script **refuses** to register a linked git worktree or a checkout on any
+branch other than `main` — the plugin source must be pristine so the unattended
+ff-only auto-pull always succeeds.
+
+Keep it fresh with `catalyst-stack hotpatch` (below) — and, once it ships, the
+broker auto-refreshes it on every merge to `main`. `catalyst-stack parity`
+flags it as drift if the checkout ever ends up off `main` or becomes a linked
+worktree.
+
 ## After merging or pulling new code
 
-The fastest way to apply an update to the live plugin cache and restart:
+The fastest way to refresh the plugin-source checkout and restart:
 
 ```bash
 catalyst-stack restart --hotpatch
 ```
 
-This does three things in sequence:
+This does two things in sequence:
 
-1. `git pull --ff-only origin main` in your catalyst repo checkout.
-2. `rsync -ac --exclude=node_modules` from `plugins/dev/` into the resolved plugin-cache version directory.
-3. Stops and restarts the stack.
+1. `git pull --ff-only origin main` in each `pluginDirs` checkout (resolved via
+   `lib/plugin-dirs.sh`: `CATALYST_PLUGIN_DIRS` env → repo `.catalyst/config.json`
+   → machine config). It refuses dirty or diverged checkouts and emits a
+   `node.checkout.updated` event recording the old → new commit.
+2. Stops and restarts the stack.
 
-If the pull fails (non-fast-forward), the command aborts before touching the cache. Resolve the conflict manually, then retry.
+If the pull fails (non-fast-forward), the command aborts before restarting.
+Resolve the conflict manually, then retry.
 
-The default repo path is `~/code-repos/github/coalesce-labs/catalyst`. Override with `CATALYST_REPO_DIR`:
-
-```bash
-CATALYST_REPO_DIR=/path/to/catalyst catalyst-stack restart --hotpatch
-```
+> The legacy marketplace-cache `rsync` flow survives only behind
+> `catalyst-stack hotpatch --legacy-rsync` and is deprecated — migrate the node
+> to the one-checkout model above.
 
 ## Debugging Linear API rate-limiting (mitmproxy, opt-in)
 

--- a/website/src/content/docs/reference/catalyst-stack.md
+++ b/website/src/content/docs/reference/catalyst-stack.md
@@ -51,7 +51,7 @@ Accepted for backward compatibility; no-op (proxy is already off by default).
 
 ### `--hotpatch`
 
-Apply a post-merge update in one command: ff-pull `main`, rsync `plugins/dev/` into the resolved plugin-cache version directory, then start/restart.
+Apply a post-merge update in one command: ff-only pull each `pluginDirs` checkout, then start/restart.
 
 ```bash
 # After merging or pulling new code:
@@ -59,10 +59,27 @@ catalyst-stack restart --hotpatch
 ```
 
 Behavior:
-- Requires `CATALYST_REPO_DIR` to point at the catalyst repo checkout, or defaults to `~/code-repos/github/coalesce-labs/catalyst`.
-- Uses `git pull --ff-only origin main` — aborts on non-fast-forward merges (resolve manually, then retry).
-- Rsyncs with `-ac --exclude=node_modules --exclude=.orphaned_at`. **Never uses `--delete`** — that would wipe `node_modules`.
+- Resolves the checkout(s) from `pluginDirs` via `lib/plugin-dirs.sh` (`CATALYST_PLUGIN_DIRS` env → repo `.catalyst/config.json` → machine config).
+- Uses `git pull --ff-only origin main` — aborts on non-fast-forward merges or a dirty/diverged checkout (resolve manually, then retry).
+- Emits a `node.checkout.updated` event recording the old → new commit.
 - `start --hotpatch` refuses if the stack is already running. Use `restart --hotpatch` instead.
+- The deprecated marketplace-cache rsync survives only behind `catalyst-stack hotpatch --legacy-rsync` (uses `CATALYST_REPO_DIR`).
+
+### `setup-plugin-source.sh`
+
+`plugins/dev/scripts/setup-plugin-source.sh` provisions the pristine, main-only checkout that `--hotpatch` keeps fresh and registers it as `catalyst.orchestration.pluginDirs` in the machine config.
+
+```bash
+plugins/dev/scripts/setup-plugin-source.sh [--path DIR] [--repo-url URL] [--force]
+```
+
+- Clones the repo (main, single-branch) to `~/catalyst/plugin-source` by default (`--path` or `$CATALYST_PLUGIN_SOURCE` to override), or ff-only pulls an existing checkout.
+- Registers `<path>/plugins/dev` as `pluginDirs`, preserving every other machine-config key. Idempotent; `--force` re-points to a new path.
+- **Refuses** a linked git worktree or a non-`main` checkout — the source must stay pristine.
+
+### `parity`
+
+`catalyst-stack parity` reports node-freshness + setup drift for the `pluginDirs` checkout (exit code = number of drift findings). In addition to the freshness/dirty/manifest checks, it flags a checkout that is **off `main`** or is a **linked worktree** (run `setup-plugin-source.sh` to fix).
 
 ### `--yes`
 
@@ -72,7 +89,8 @@ Non-interactive mode under `--proxy`: auto-approves `brew install mitmproxy` ins
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `CATALYST_REPO_DIR` | `~/code-repos/github/coalesce-labs/catalyst` | Repo root used by `--hotpatch`. |
+| `CATALYST_REPO_DIR` | `~/code-repos/github/coalesce-labs/catalyst` | Repo root used by the deprecated `hotpatch --legacy-rsync` path. |
+| `CATALYST_PLUGIN_SOURCE` | `~/catalyst/plugin-source` | Default checkout location used by `setup-plugin-source.sh`. |
 | `MITM_LOG` | `~/catalyst/linear-proxy.jsonl` | JSONL capture path read by the mitmproxy addon (`mitm_linear_addon.py`) — not the process log. The mitmdump process log is fixed at `~/catalyst/mitm.log` and cannot be overridden. |
 
 ## Exit codes

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -79,6 +79,7 @@ The `orchestration.dispatchMode` key picks how Catalyst runs each ticket:
 | `orchestration.dispatchMode` | `oneshot-legacy` | Which run mode to use (above) |
 | `orchestration.maxParallel` | `3` | How many tickets run at once |
 | `orchestration.worktreeDir` | `~/catalyst/wt/<projectKey>` | Where worktrees are created |
+| `orchestration.pluginDirs` | unset | Path(s) to the plugin checkout(s) workers run from (`<checkout>/plugins/dev`). Set by `setup-plugin-source.sh`; resolved by `phase-agent-dispatch` and refreshed by `catalyst-stack hotpatch` / merge-to-main. String or `:`-joined array. May also live in the machine config (Layer 2); the `CATALYST_PLUGIN_DIRS` env var overrides both. |
 | `orchestration.phaseAgents.models[phase]` | `opus` | Model per step (`opus`, `sonnet`, or `haiku`). Phases: `triage`, `research`, `plan`, `implement`, `verify`, `review`, `pr`, `monitor-merge`, `monitor-deploy`, `teardown` |
 | `orchestration.phaseAgents.turnCaps[phase]` | per-phase | Max Claude turns per step |
 | `orchestration.draftPr.enabled` | `true` | Open a draft PR at the first implement commit; phase-pr flips it ready. Set `false` to create the PR only at the pr phase. |


### PR DESCRIPTION
## Why

The CTL-940 checkout model (`pluginDirs` → `--plugin-dir`, no marketplace cache for workers) currently points at the **interactive working checkout** on both hosts — which sits on feature branches (laptop was on `feat/ticket-markdown` at filing time), gets branches created in it by agents, and on mini carried the corrupted `.catalyst/config.json` that froze 100% of Linear status writes AND seeded the CTL-990 rebase storm into 27/34 worktrees. Freshness is periodic-pull only; iteration waits on polls or the daily release.

## CTL-992 — pristine main-only plugin source

- **`setup-plugin-source.sh`** (new, idempotent): clone-or-ff-update a dedicated main-only checkout (default `~/catalyst/plugin-source`), refuse linked worktrees and non-main branches, register it as `catalyst.orchestration.pluginDirs` in the machine config (atomic same-dir tmp+rename jq write, preserves unknown keys, creates config+parent when absent)
- **Runtime guard**: `plugin_source_health` in `lib/plugin-dirs.sh` (MISSING / NOT_A_CHECKOUT / LINKED_WORKTREE / OFF_MAIN / DIRTY); `catalyst-stack` parity check now fails loudly on LINKED_WORKTREE + OFF_MAIN. Hosts with `pluginDirs` unset are untouched
- **Docs**: pristine-checkout model + setup flow; `orchestration.pluginDirs` added to the configuration reference (was undocumented)

## CTL-993 — merge to main refreshes the checkout within seconds

- **`broker/plugin-refresh.mjs`** (new): on a GitHub merge-to-main event for the configured repo, throttle-gated (60s) `git pull --ff-only` of every pluginDirs checkout root; emits `plugin.checkout.updated` (old/new sha + `restart_needed` daemon-skew hint, scoped to the daemon's own checkout) or `plugin.checkout.refresh_failed` at WARN
- Wired in `router.mjs` as a non-consuming side-channel above the `shouldSkipEvent`/interests gates; emitted events carry `service.name=catalyst.broker` so the self-filter drops them on re-ingest (loop-safety proven by unit + end-to-end test)
- Every synchronous git call carries a hard timeout (default 20s) + SIGKILL — a stalled network pull surfaces as `refresh_failed` instead of freezing the broker loop
- Daemon restart stays a gated operator action (`restart_needed` is visibility only, CTL-669 model)

## Tests

TDD throughout (red→green): setup-plugin-source 8/8 · catalyst-stack-parity 9/9 (+2 new) · plugin-dirs-health 6/6 · plugin-refresh 29/29 · barrel-exports updated · regression: catalyst-stack-hotpatch 14/14, check-project-setup 13/13, lib batch 378/378, broker index suite green. Multi-lens adversarial review applied (the three confirmed findings fixed in the follow-up commit).

Closes CTL-992
Closes CTL-993

🤖 Generated with [Claude Code](https://claude.com/claude-code)