### PR TITLE
fix(dev): CTL-926 — eligible projection refreshes when blocked_by relations change out-of-band

### DIFF
--- a/plugins/dev/scripts/execution-core/eligible-set.mjs
+++ b/plugins/dev/scripts/execution-core/eligible-set.mjs
@@ -43,9 +43,46 @@ function byIdentifier(a, b) {
 // CTL-957: `estimate` added to the signature so an estimate-only change
 // (e.g. PM sets points on a queued ticket) forces a projection rewrite and the
 // board picks up the new value without waiting for a state/priority change.
+//
+// CTL-926: relation edges (`blocks` / `blocked_by`) are also part of the
+// signature. The scheduler bakes each ticket's relations into the on-disk
+// projection and derives the blocked/ready graph from them (dependency-graph.mjs).
+// A pure edge delta — a blocker added or removed in Linear with no state/
+// priority/parent change — left all tuple fields identical, so the write
+// was skipped and the scheduler kept reading stale edges, deadlocking a ticket
+// whose blockers were already cleared. Only `blocks`/`blocked_by` types matter:
+// they are the only types buildDependencyEdges consumes; `related`/`duplicate`
+// are ignored and excluded to avoid spurious rewrites.
+//
+// The signature is order-independent (sorted) and array-source-independent: an
+// edge appears in `relations` on one endpoint and `inverseRelations` on the
+// other, but both encode the same dependency, so we normalize both into one
+// sorted "type:peer" list per ticket.
+function relationsSignature(t) {
+  const edges = [];
+  for (const n of t.relations?.nodes ?? []) {
+    if (n?.type === "blocks" || n?.type === "blocked_by") {
+      edges.push(`${n.type}:${n.relatedIssue?.identifier ?? ""}`);
+    }
+  }
+  for (const n of t.inverseRelations?.nodes ?? []) {
+    if (n?.type === "blocks" || n?.type === "blocked_by") {
+      edges.push(`${n.type}:${n.issue?.identifier ?? ""}`);
+    }
+  }
+  return edges.sort().join("|");
+}
+
 function contentKey(tickets) {
   return JSON.stringify(
-    tickets.map((t) => [t.identifier, t.state, t.priority, t.parent ?? null, t.estimate ?? null]),
+    tickets.map((t) => [
+      t.identifier,
+      t.state,
+      t.priority,
+      t.parent ?? null,
+      t.estimate ?? null,
+      relationsSignature(t),
+    ]),
   );
 }
 

--- a/plugins/dev/scripts/execution-core/eligible-set.test.mjs
+++ b/plugins/dev/scripts/execution-core/eligible-set.test.mjs
@@ -143,6 +143,95 @@ describe("setProjectEligible", () => {
     const doc = JSON.parse(readFileSync(projFile("alpha"), "utf8"));
     expect(doc.tickets[0].parent).toBe("A-9"); // parent persisted to disk
   });
+
+  test("CTL-926: a blocked_by edge delta DOES rewrite the file (relations are in the content key)", async () => {
+    // A-1 starts blocked by A-2 (inverseRelations: A-2 blocks A-1). The blocker
+    // is then removed in Linear with NO state/priority/parent change. Pre-fix,
+    // contentKey ignored relations so the rewrite was skipped and the scheduler
+    // kept reading the stale blocked edge — the ticket stayed falsely blocked.
+    setProjectEligible(
+      "alpha",
+      [
+        {
+          identifier: "A-1",
+          state: "Todo",
+          priority: 1,
+          inverseRelations: { nodes: [{ type: "blocks", issue: { identifier: "A-2" } }] },
+        },
+      ],
+      { source: "reconcile", query: {} },
+    );
+    const mtime1 = statSync(projFile("alpha")).mtimeMs;
+    await sleep(15);
+    // Same identifier/state/priority/parent — only the blocker edge is gone.
+    setProjectEligible(
+      "alpha",
+      [{ identifier: "A-1", state: "Todo", priority: 1, inverseRelations: { nodes: [] } }],
+      { source: "reconcile", query: {} },
+    );
+    expect(statSync(projFile("alpha")).mtimeMs).toBeGreaterThan(mtime1);
+    const doc = JSON.parse(readFileSync(projFile("alpha"), "utf8"));
+    expect(doc.tickets[0].inverseRelations.nodes).toEqual([]); // fresh edges persisted to disk
+  });
+
+  test("CTL-926: an edge-order-only permutation does NOT rewrite (signature is order-independent)", async () => {
+    // Two blockers in one order, then the same two in the reverse order. The set
+    // of edges is identical, so the signature must match and the write must skip.
+    setProjectEligible(
+      "alpha",
+      [
+        {
+          identifier: "A-1",
+          state: "Todo",
+          priority: 1,
+          inverseRelations: {
+            nodes: [
+              { type: "blocks", issue: { identifier: "A-2" } },
+              { type: "blocks", issue: { identifier: "A-3" } },
+            ],
+          },
+        },
+      ],
+      { source: "reconcile", query: {} },
+    );
+    const mtime1 = statSync(projFile("alpha")).mtimeMs;
+    await sleep(15);
+    setProjectEligible(
+      "alpha",
+      [
+        {
+          identifier: "A-1",
+          state: "Todo",
+          priority: 1,
+          inverseRelations: {
+            nodes: [
+              { type: "blocks", issue: { identifier: "A-3" } },
+              { type: "blocks", issue: { identifier: "A-2" } },
+            ],
+          },
+        },
+      ],
+      { source: "reconcile", query: {} },
+    );
+    expect(statSync(projFile("alpha")).mtimeMs).toBe(mtime1); // no spurious rewrite
+  });
+
+  test("CTL-926: a deleted projection file IS recreated on the next reconcile", () => {
+    setProjectEligible("alpha", [{ identifier: "A-1", state: "Todo", priority: 1 }], {
+      source: "reconcile",
+      query: {},
+    });
+    expect(existsSync(projFile("alpha"))).toBe(true);
+    rmSync(projFile("alpha"), { force: true }); // simulate the incident's deleted file
+    expect(existsSync(projFile("alpha"))).toBe(false);
+    // Next reconcile delivers the same content; existsSync=false must bypass the
+    // skip-guard and rewrite the file.
+    setProjectEligible("alpha", [{ identifier: "A-1", state: "Todo", priority: 1 }], {
+      source: "reconcile",
+      query: {},
+    });
+    expect(existsSync(projFile("alpha"))).toBe(true);
+  });
 });
 
 describe("removeTicket", () => {


### PR DESCRIPTION
## CTL-926 — eligible projection refreshes when blocked_by relations change out-of-band

### Problem
Pure `blocked_by` relation edits in Linear (a blocker added or removed with no
state/priority/parent change) produced an **identical** skip-write content
signature in `eligible-set.mjs`, so the projection write was skipped. The
scheduler kept reading stale edges from the on-disk projection and wedged
tickets in "blocked" forever. Live incident 2026-06-08: four tickets stuck 40+
min. This is the CTL-838-class wedge.

### Fix
The `contentKey` signature now includes a relation-edge signature
(`relationsSignature`) alongside `identifier/state/priority/parent/estimate`.
Relation changes now dirty the signature, so the projection refreshes within
one poll.

- Only `blocks`/`blocked_by` edges count (the only types `buildDependencyEdges`
  consumes); `related`/`duplicate` are excluded to avoid spurious rewrites.
- The signature is order-independent (sorted) and array-source-independent:
  `relations` and `inverseRelations` are normalized into one sorted `type:peer`
  list per ticket.

### Provenance
Cherry-picked from preserved WIP `2047b37c` (operator unstick 2026-06-11). The
single conflict was in the `contentKey` tuple — the WIP branch added the
relation-edge signature while main (CTL-957) had added an `estimate` field.
**Proven resolution**: keep BOTH fields in the tuple
`[identifier, state, priority, parent, estimate, relationsSignature]` and keep
the `relationsSignature` helper intact.

### Verification
- `node --check eligible-set.mjs` — passes
- `bun test eligible-set` — **24 pass / 0 fail** (includes the WIP's 89-line
  test addition)
- `bun test scheduler` — **461 pass / 0 fail**
- Final diff vs `origin/main` contains ONLY `eligible-set.mjs` +
  `eligible-set.test.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
