### PR TITLE
fix(dev): CTL-1014 — repo-identity resolver honors canonical catalyst.repository key

### DIFF
--- a/plugins/dev/scripts/broker/plugin-refresh.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.mjs
@@ -173,9 +173,21 @@ function __readConfig(path, readFileFn) {
 
 /**
  * resolveRepoFullName — the "owner/repo" whose merges trigger a checkout
- * refresh. Read from .catalyst.feedback.githubRepo, falling back to the first
- * .catalyst.monitor.linear.teams[].vcsRepo. Repo config (.catalyst/config.json)
- * takes precedence over the machine config. Returns null when unconfigured.
+ * refresh.
+ *
+ * Precedence (per config file, repo config before machine config):
+ *   1. canonical catalyst.repository.{org,name} — the schema key
+ *      check-project-setup tells operators to set (joined as "org/name", both
+ *      must be non-empty strings)
+ *   2. legacy catalyst.feedback.githubRepo
+ *   3. legacy first catalyst.monitor.linear.teams[].vcsRepo
+ *
+ * Returns null when unconfigured. Reading the canonical key FIRST is CTL-1014:
+ * without it, hosts configured canonically resolve null here and
+ * isThisRepoMergeEvent rejects every merge, so the CTL-993 merge-to-main
+ * auto-pull never fires (verified live on mini 2026-06-11). A malformed
+ * canonical block (missing/empty/non-string org or name) falls through to the
+ * legacy keys unchanged.
  */
 export function resolveRepoFullName({
   machineConfigPath = defaultMachineConfigPath(),
@@ -184,6 +196,12 @@ export function resolveRepoFullName({
 } = {}) {
   for (const path of [repoConfigPath, machineConfigPath]) {
     const cfg = __readConfig(path, readFileFn);
+    const repo = cfg?.catalyst?.repository;
+    const org = repo?.org;
+    const name = repo?.name;
+    if (typeof org === "string" && org && typeof name === "string" && name) {
+      return `${org}/${name}`;
+    }
     const fromFeedback = cfg?.catalyst?.feedback?.githubRepo;
     if (typeof fromFeedback === "string" && fromFeedback) return fromFeedback;
     const teams = cfg?.catalyst?.monitor?.linear?.teams;

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -167,6 +167,87 @@ describe("resolveRepoFullName", () => {
     });
     expect(name).toBeNull();
   });
+
+  // ── canonical catalyst.repository.{org,name} (CTL-1014) ────────────────────
+  //
+  // check-project-setup tells operators to set the canonical schema key
+  // catalyst.repository.{org,name}. The resolver MUST read it (joined as
+  // "org/name") — and prefer it over the legacy feedback.githubRepo /
+  // monitor.linear.teams[].vcsRepo keys — or repo identity resolves null on a
+  // canonically-configured host and isThisRepoMergeEvent rejects every merge,
+  // so the CTL-993 merge-to-main auto-pull never fires (verified live on mini).
+
+  test("reads canonical catalyst.repository.{org,name} joined as org/name", () => {
+    const name = resolveRepoFullName({
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: (p) =>
+        p === "/repo/.catalyst/config.json"
+          ? '{"catalyst":{"repository":{"org":"coalesce-labs","name":"catalyst"}}}'
+          : "{}",
+    });
+    expect(name).toBe("coalesce-labs/catalyst");
+  });
+
+  test("canonical catalyst.repository WINS over legacy feedback.githubRepo when both set", () => {
+    const name = resolveRepoFullName({
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: (p) =>
+        p === "/repo/.catalyst/config.json"
+          ? '{"catalyst":{"repository":{"org":"coalesce-labs","name":"catalyst"},"feedback":{"githubRepo":"legacy-org/legacy-repo"}}}'
+          : "{}",
+    });
+    expect(name).toBe("coalesce-labs/catalyst");
+  });
+
+  test("malformed canonical repository (missing name) falls through to legacy keys", () => {
+    const name = resolveRepoFullName({
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: (p) =>
+        p === "/repo/.catalyst/config.json"
+          ? '{"catalyst":{"repository":{"org":"coalesce-labs"},"feedback":{"githubRepo":"coalesce-labs/catalyst"}}}'
+          : "{}",
+    });
+    expect(name).toBe("coalesce-labs/catalyst");
+  });
+
+  test("malformed canonical repository (empty org) falls through to legacy keys", () => {
+    const name = resolveRepoFullName({
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: (p) =>
+        p === "/repo/.catalyst/config.json"
+          ? '{"catalyst":{"repository":{"org":"","name":"catalyst"},"feedback":{"githubRepo":"coalesce-labs/catalyst"}}}'
+          : "{}",
+    });
+    expect(name).toBe("coalesce-labs/catalyst");
+  });
+
+  test("malformed canonical repository (non-string org) falls through to legacy keys", () => {
+    const name = resolveRepoFullName({
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: (p) =>
+        p === "/repo/.catalyst/config.json"
+          ? '{"catalyst":{"repository":{"org":42,"name":"catalyst"},"feedback":{"githubRepo":"coalesce-labs/catalyst"}}}'
+          : "{}",
+    });
+    expect(name).toBe("coalesce-labs/catalyst");
+  });
+
+  test("returns null when canonical is malformed AND no legacy key is set", () => {
+    const name = resolveRepoFullName({
+      machineConfigPath: "/cfg/machine.json",
+      repoConfigPath: "/repo/.catalyst/config.json",
+      readFileFn: (p) =>
+        p === "/repo/.catalyst/config.json"
+          ? '{"catalyst":{"repository":{"org":"coalesce-labs"}}}'
+          : "{}",
+    });
+    expect(name).toBeNull();
+  });
 });
 
 // ─── isThisRepoMergeEvent ────────────────────────────────────────────────────


### PR DESCRIPTION
## CTL-1014

### Bug
The broker's `resolveRepoFullName()` in `plugins/dev/scripts/broker/plugin-refresh.mjs` read **only** the legacy keys `catalyst.feedback.githubRepo` and the first `catalyst.monitor.linear.teams[].vcsRepo`. It never read `catalyst.repository.{org,name}` — the **canonical** schema key that `check-project-setup` tells operators to set (documented in `website/src/content/docs/reference/configuration.md`).

On a host configured canonically, repo identity resolved `null`, so `isThisRepoMergeEvent` rejected **every** merge event (`plugin-refresh.mjs:220-227`) and the CTL-993 merge-to-main auto-pull never fired. Verified live on mini 2026-06-11.

### Fix
In the existing per-file precedence loop over `[repoConfigPath, machineConfigPath]`, check `catalyst.repository.{org,name}` **first** — both must be non-empty strings, joined as `"org/name"` — then fall back to the two legacy keys unchanged. A malformed canonical block (missing/empty/non-string `org` or `name`) falls through to the legacy keys. The function stays pure/injectable.

**Precedence per config file** (repo config before machine config):
1. canonical `catalyst.repository.{org,name}` → `"org/name"`
2. legacy `catalyst.feedback.githubRepo`
3. legacy first `catalyst.monitor.linear.teams[].vcsRepo`

### Tests (TDD — RED then GREEN)
Added 6 tests to `plugin-refresh.test.mjs`:
- canonical key alone resolves `"coalesce-labs/catalyst"`
- canonical key **wins** over `feedback.githubRepo` when both set
- malformed canonical (missing `name`) falls through to legacy
- malformed canonical (empty `org`) falls through to legacy
- malformed canonical (non-string `org`) falls through to legacy
- canonical malformed AND no legacy → `null`

`bun test plugin-refresh.test.mjs` → **35/35 pass**; `node --check plugin-refresh.mjs` clean. (The 3 unrelated `gc-startup.test.mjs` failures in the full broker suite are pre-existing on clean `main` — confirmed against origin/main `b2f8d1fd` — and untouched by this branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)