### PR TITLE
feat(dev): CTL-1023 — catalyst.ticket.type telemetry dimension (work-type on all phase events)

### DIFF
--- a/plugins/dev/scripts/__tests__/canonical-event.test.sh
+++ b/plugins/dev/scripts/__tests__/canonical-event.test.sh
@@ -482,6 +482,23 @@ LINE_BARE="$(build_canonical_line \
 HAS=$(echo "$LINE_BARE" | jq -r '.attributes | has("phase.attempt")')
 expect_eq "phase.attempt omitted when flag absent" "false" "$HAS"
 
+# CTL-1023: catalyst.ticket.type — work-type dimension, ALWAYS present.
+LINE_TT="$(build_canonical_line \
+  --ts "2026-06-05T00:00:00Z" --severity INFO \
+  --service catalyst.phase-agent --event-name "phase.implement.complete.CTL-1023" \
+  --ticket-type bug)"
+TT=$(echo "$LINE_TT" | jq -r '.attributes["catalyst.ticket.type"]')
+expect_eq "build_canonical_line catalyst.ticket.type from --ticket-type" "bug" "$TT"
+
+# Default: omitted/empty --ticket-type → "unknown" (never inconsistently missing).
+LINE_TT_BARE="$(build_canonical_line \
+  --ts "2026-06-05T00:00:00Z" --severity INFO \
+  --service catalyst.phase-agent --event-name "phase.implement.complete.CTL-1023")"
+TT_HAS=$(echo "$LINE_TT_BARE" | jq -r '.attributes | has("catalyst.ticket.type")')
+TT_DEF=$(echo "$LINE_TT_BARE" | jq -r '.attributes["catalyst.ticket.type"]')
+expect_eq "catalyst.ticket.type present even when flag absent" "true" "$TT_HAS"
+expect_eq "catalyst.ticket.type defaults to 'unknown'" "unknown" "$TT_DEF"
+
 echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES"
 exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -568,6 +568,38 @@ SIGNAL_REASON=$(jq -r '.failureReason' "$SIGNAL" 2>/dev/null)
 assert_eq "turn cap hit (75)" "$PAYLOAD_REASON" "turn-cap path still carries failure_reason in event"
 assert_eq "turn cap hit (75)" "$SIGNAL_REASON" "turn-cap path still carries failureReason in signal"
 
+# CTL-1023: the work-type dimension (catalyst.ticket.type) rides on every phase
+# terminal event, resolved from workers/<ticket>/triage.json .classification.
+echo ""
+echo "Test 36 (CTL-1023): catalyst.ticket.type reads triage.json .classification"
+fresh_env t36
+mkdir -p "${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100"
+echo '{"classification":"bug","estimated_scope":"small"}' >"${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/triage.json"
+"$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status complete >/dev/null 2>&1
+LINE=$(read_event_line)
+TTYPE=$(echo "$LINE" | jq -r '.attributes."catalyst.ticket.type"')
+assert_eq "bug" "$TTYPE" "catalyst.ticket.type = classification from triage.json"
+
+echo ""
+echo "Test 37 (CTL-1023): catalyst.ticket.type defaults to 'unknown' with no triage.json"
+fresh_env t37
+"$EMIT_SCRIPT" --phase triage --ticket CTL-100 --status complete >/dev/null 2>&1
+LINE=$(read_event_line)
+TTYPE=$(echo "$LINE" | jq -r '.attributes."catalyst.ticket.type"')
+HAS_TTYPE=$(echo "$LINE" | jq -r '.attributes | has("catalyst.ticket.type")')
+assert_eq "true" "$HAS_TTYPE" "catalyst.ticket.type is present even with no classification"
+assert_eq "unknown" "$TTYPE" "catalyst.ticket.type defaults to 'unknown' (never inconsistently missing)"
+
+echo ""
+echo "Test 38 (CTL-1023): catalyst.ticket.type rides the .failed event too"
+fresh_env t38
+mkdir -p "${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100"
+echo '{"classification":"feature"}' >"${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/triage.json"
+"$EMIT_SCRIPT" --phase verify --ticket CTL-100 --status failed --reason "tests red" >/dev/null 2>&1
+LINE=$(read_event_line)
+TTYPE=$(echo "$LINE" | jq -r '.attributes."catalyst.ticket.type"')
+assert_eq "feature" "$TTYPE" "catalyst.ticket.type present on failed event"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/execution-core/linear-state-write-event.mjs
+++ b/plugins/dev/scripts/execution-core/linear-state-write-event.mjs
@@ -26,6 +26,7 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { getEventLogPath, log } from "./config.mjs";
 import { hostName, hostId } from "./lib/host-identity.mjs";
+import { UNKNOWN_TICKET_TYPE } from "./ticket-type.mjs"; // CTL-1023: work-type dimension
 
 // defaultAppend — writes a JSONL line to the canonical event log.
 function defaultAppend(line) {
@@ -48,6 +49,10 @@ export function buildLinearStateWriteEvent({
   applied = false,
   verified = false,
   actor = "catalyst.execution-core",
+  // CTL-1023: work-type dimension. Post-triage writes carry the real type; the
+  // caller resolves it from triage.json (resolveTicketType). Defaults to
+  // "unknown" so the attribute is always present.
+  ticketType = UNKNOWN_TICKET_TYPE,
 } = {}) {
   const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
   return (
@@ -76,6 +81,7 @@ export function buildLinearStateWriteEvent({
         "event.channel": "execution-core",
         "catalyst.orchestration": orchId ?? ticket,
         "linear.issue.identifier": ticket,
+        "catalyst.ticket.type": ticketType ?? UNKNOWN_TICKET_TYPE, // CTL-1023
       },
       body: {
         payload: {

--- a/plugins/dev/scripts/execution-core/linear-state-write-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-state-write-event.test.mjs
@@ -76,6 +76,18 @@ describe("buildLinearStateWriteEvent", () => {
     expect(ev.resource["service.name"]).toBe("catalyst.execution-core");
   });
 
+  // CTL-1023: work-type dimension. Post-triage state writes carry the resolved
+  // type; the attribute defaults to "unknown" so it is never inconsistently missing.
+  test("CTL-1023: catalyst.ticket.type passes through when supplied (post-triage write)", () => {
+    const ev = JSON.parse(buildLinearStateWriteEvent({ ticket: "CTL-757", ticketType: "feature" }));
+    expect(ev.attributes["catalyst.ticket.type"]).toBe("feature");
+  });
+
+  test("CTL-1023: catalyst.ticket.type defaults to 'unknown' when omitted", () => {
+    const ev = JSON.parse(buildLinearStateWriteEvent({ ticket: "CTL-757" }));
+    expect(ev.attributes["catalyst.ticket.type"]).toBe("unknown");
+  });
+
   test("payload round-trip — all caller-supplied fields survive serialization", () => {
     const ev = JSON.parse(
       buildLinearStateWriteEvent({

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -37,6 +37,7 @@ import {
   NEVER_STARTED_MS,
 } from "./config.mjs";
 import { HEARTBEAT_EVENT } from "./heartbeat-event.mjs"; // CTL-859: node.heartbeat reader
+import { resolveTicketType, UNKNOWN_TICKET_TYPE } from "./ticket-type.mjs"; // CTL-1023: work-type dimension
 import { phaseIndex, isKnownPhase } from "../lib/phase-fsm.mjs";
 import { readWorkerSignals, TERMINAL, listDispatchedPhases } from "./signal-reader.mjs";
 import { reconcileAll } from "./monitor.mjs";
@@ -286,7 +287,12 @@ function defaultEmitComplete({ orchDir, signal }, { spawn = spawnSync } = {}) {
 // revive, escalated, and revive-suppressed audit events (CTL-574 + CTL-587).
 // Shape mirrors lib/canonical-event.sh. Centralizing it here keeps the four
 // per-action helpers tiny and prevents shape drift between actions.
-function buildEventEnvelope({ phase, ticket, orchId, action, reason, payloadExtras = {}, severityText = "WARN", severityNumber = 13 }) {
+//
+// CTL-1023: every event carries `catalyst.ticket.type` (work-type dimension).
+// `ticketType` is resolved by the caller from triage.json (resolveTicketType);
+// when omitted it defaults to UNKNOWN_TICKET_TYPE so the attribute is ALWAYS
+// present, never inconsistently missing (the gherkin contract).
+function buildEventEnvelope({ phase, ticket, orchId, action, reason, payloadExtras = {}, severityText = "WARN", severityNumber = 13, ticketType = UNKNOWN_TICKET_TYPE }) {
   const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
   return (
     JSON.stringify({
@@ -310,6 +316,7 @@ function buildEventEnvelope({ phase, ticket, orchId, action, reason, payloadExtr
         "event.label": ticket,
         "catalyst.orchestration": orchId ?? ticket,
         "linear.issue.identifier": ticket,
+        "catalyst.ticket.type": ticketType ?? UNKNOWN_TICKET_TYPE,
       },
       body: { payload: { phase, ticket, status: action, reason, ...payloadExtras } },
     }) + "\n"
@@ -351,6 +358,7 @@ export function defaultAppendReclaimEvent({
   phase,
   ticket,
   orchId,
+  orchDir,
   death_signal,
   prev_state_json_mtime = null,
   probe_passed = true,
@@ -368,6 +376,7 @@ export function defaultAppendReclaimEvent({
       orchId,
       action: "reclaim",
       reason: "work-done-despite-dead-bg",
+      ticketType: resolveTicketType(orchDir, ticket), // CTL-1023
       payloadExtras: {
         death_signal,
         prev_state_json_mtime,
@@ -700,6 +709,7 @@ export function defaultAppendReviveEvent({
   phase,
   ticket,
   orchId,
+  orchDir,
   attempt,
   reason,
   prev_state_json_mtime,
@@ -712,6 +722,7 @@ export function defaultAppendReviveEvent({
       orchId,
       action: "revive",
       reason,
+      ticketType: resolveTicketType(orchDir, ticket), // CTL-1023
       payloadExtras: { attempt, prev_state_json_mtime, prev_bg_job_id },
     }),
     "revive",
@@ -844,7 +855,7 @@ export function defaultAppendRunawayEvent({ ticket, orchId, count, window_ms }) 
 // defaultAppendDispatchRequestedEvent — phase.dispatch.requested.<TICKET>.
 // Emitted when the scheduler/recovery DECIDES to dispatch a phase, before the
 // `claude --bg` spawn. reason ∈ {new-work, advance, revive}.
-export function defaultAppendDispatchRequestedEvent({ orchId, ticket, target_phase, reason }) {
+export function defaultAppendDispatchRequestedEvent({ orchId, orchDir, ticket, target_phase, reason }) {
   return appendEnvelopeBestEffort(
     buildEventEnvelope({
       phase: "dispatch",
@@ -855,6 +866,8 @@ export function defaultAppendDispatchRequestedEvent({ orchId, ticket, target_pha
       payloadExtras: { target_phase },
       severityText: "INFO",
       severityNumber: 9,
+      // CTL-1023: resolves to "unknown" pre-triage (no triage.json yet) — correct.
+      ticketType: resolveTicketType(orchDir, ticket),
     }),
     "dispatch-requested",
   );
@@ -866,6 +879,7 @@ export function defaultAppendDispatchRequestedEvent({ orchId, ticket, target_pha
 // launched↔complete wall-clock can be computed downstream.
 export function defaultAppendDispatchLaunchedEvent({
   orchId,
+  orchDir,
   ticket,
   target_phase,
   bg_job_id,
@@ -880,6 +894,8 @@ export function defaultAppendDispatchLaunchedEvent({
       payloadExtras: { target_phase, bg_job_id, worktree_path },
       severityText: "INFO",
       severityNumber: 9,
+      // CTL-1023: "unknown" until triage.json lands; full type post-triage.
+      ticketType: resolveTicketType(orchDir, ticket),
     }),
     "dispatch-launched",
   );
@@ -1158,7 +1174,7 @@ export function defaultReviveDispatch(
   // then the verified launch after a clean dispatch. Both best-effort — the
   // default emitters swallow IO errors (appendEnvelopeBestEffort); the revive
   // proceeds regardless of either return value.
-  appendRequested({ orchId, ticket, target_phase: phase, reason: "revive" });
+  appendRequested({ orchId, orchDir, ticket, target_phase: phase, reason: "revive" });
   const res = dispatch(dispatchArgs);
   if (res && res.code === 0) {
     // Re-read the signal the dispatcher just rewrote (status dispatched/running
@@ -1171,6 +1187,7 @@ export function defaultReviveDispatch(
     }
     appendLaunched({
       orchId,
+      orchDir,
       ticket,
       target_phase: phase,
       bg_job_id: sig2?.bg_job_id,
@@ -1898,6 +1915,7 @@ export function reclaimDeadWorkIfPossible(
       phase,
       ticket,
       orchId,
+      orchDir,
       death_signal: "terminal-short-circuit",
       prev_state_json_mtime: prevStateJsonMtime,
       probe_passed: false,
@@ -1972,6 +1990,7 @@ export function reclaimDeadWorkIfPossible(
         phase,
         ticket,
         orchId,
+        orchDir,
         death_signal: "alive-probe-done",
         prev_state_json_mtime: null,
         probe_passed: true,
@@ -2323,6 +2342,7 @@ export function reclaimDeadWorkIfPossible(
       phase,
       ticket,
       orchId,
+      orchDir,
       death_signal,
       prev_state_json_mtime: prevStateJsonMtime,
       probe_passed: true,
@@ -2520,6 +2540,7 @@ export function reclaimDeadWorkIfPossible(
     phase,
     ticket,
     orchId,
+    orchDir,
     attempt,
     reason: "work-not-done-after-stale-bg",
     prev_state_json_mtime: prevStateJsonMtime,

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -2820,6 +2820,42 @@ describe("dispatch lifecycle event envelopes (CTL-660)", () => {
     expect(env.severityNumber).toBe(9);
   });
 
+  // CTL-1023: the work-type dimension rides on every dispatch lifecycle event.
+  // Resolved from workers/<ticket>/triage.json .classification; "unknown" when
+  // no triage.json exists yet (the pre-triage first dispatch).
+  test("CTL-1023: dispatch-requested carries catalyst.ticket.type from triage.json", () => {
+    const orchDir = mkdtempSync(join(tmpdir(), "ctl1023-disp-"));
+    mkdirSync(join(orchDir, "workers", "CTL-TT-1"), { recursive: true });
+    writeFileSync(
+      join(orchDir, "workers", "CTL-TT-1", "triage.json"),
+      JSON.stringify({ classification: "bug" }),
+    );
+    const ok = defaultAppendDispatchRequestedEvent({
+      orchId: "orch-tt",
+      orchDir,
+      ticket: "CTL-TT-1",
+      target_phase: "implement",
+      reason: "advance",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["catalyst.ticket.type"]).toBe("bug");
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  test("CTL-1023: dispatch-requested defaults catalyst.ticket.type to 'unknown' pre-triage", () => {
+    const ok = defaultAppendDispatchRequestedEvent({
+      orchId: "orch-tt",
+      orchDir: undefined,
+      ticket: "CTL-TT-2",
+      target_phase: "triage",
+      reason: "new-work",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["catalyst.ticket.type"]).toBe("unknown");
+  });
+
   test("defaultAppendRunawayEvent writes a runaway envelope (CTL-671)", () => {
     const ok = defaultAppendRunawayEvent({
       ticket: "CTL-9",

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -132,6 +132,7 @@ import * as linearWrite from "./linear-write.mjs";
 // runTransition (would double-audit the triage path, which keeps its own
 // phase.triage.linear-transition event). Best-effort: swallow-on-error.
 import { appendLinearStateWriteEvent } from "./linear-state-write-event.mjs";
+import { resolveTicketType } from "./ticket-type.mjs"; // CTL-1023: work-type dimension
 // CTL-642 + CTL-758: the SHARED Linear terminal-state predicate. isLinearTerminal
 // ({Done,Canceled} — its OWN set) backs both the reconcile-backstop's
 // "live state !terminal" check and the recovery short-circuit threaded into
@@ -2177,6 +2178,8 @@ export function schedulerTick(
         applied: writerResult.applied ?? false,
         verified: writerResult.verified ?? false,
         reason: writerResult.reason ?? null,
+        // CTL-1023: post-triage state writes always have a classification.
+        ticketType: resolveTicketType(orchDir, ticket),
       },
       { ticket, phase, source }
     );
@@ -2233,7 +2236,7 @@ export function schedulerTick(
     // CTL-660: record the dispatch DECISION before the spawn. Best-effort.
     safeEmit(
       appendDispatchRequestedEvent,
-      { orchId: ticket, ticket, target_phase: phase, reason: requestedReason },
+      { orchId: ticket, orchDir, ticket, target_phase: phase, reason: requestedReason },
       { ticket, phase }
     );
     // Pass 1.5: reset the parked signal to "stalled" before dispatch; a false
@@ -2257,6 +2260,7 @@ export function schedulerTick(
           appendDispatchLaunchedEvent,
           {
             orchId: ticket,
+            orchDir,
             ticket,
             target_phase: phase,
             bg_job_id: signal?.bg_job_id,

--- a/plugins/dev/scripts/execution-core/ticket-type.mjs
+++ b/plugins/dev/scripts/execution-core/ticket-type.mjs
@@ -1,0 +1,38 @@
+// ticket-type.mjs — resolve the canonical work-type dimension (CTL-1023).
+//
+// Work type (bug/feature/chore/refactor/docs/test) is a telemetry dimension so
+// DevOps/FinOps views can group cost, effort, duration, and throughput by it.
+// The single source of truth is triage.json `.classification` in the worker dir
+// (workers/<TICKET>/triage.json) — written by phase-triage (skills/phase-triage)
+// as one of feature|bug|docs|refactor|chore.
+//
+// CONTRACT (gherkin, CTL-1023): the resolved value is attached to phase /
+// dispatch / linear-state events under the `catalyst.ticket.type` attribute and
+// must be CONSISTENTLY present — a ticket with no classification yet (e.g. the
+// triage phase itself, or a pre-triage dispatch) carries "unknown" rather than
+// omitting the attribute. Naming coordinates with CTL-1009's semconv audit;
+// `catalyst.ticket.type` is additive and renames/removes nothing.
+//
+// Additive + fail-open: any read error (missing file, bad JSON, absent orchDir)
+// resolves to UNKNOWN_TICKET_TYPE. No throw.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const UNKNOWN_TICKET_TYPE = "unknown";
+
+// resolveTicketType — read workers/<ticket>/triage.json and return its
+// `.classification` (feature|bug|docs|refactor|chore), else UNKNOWN_TICKET_TYPE.
+// Pure-ish: the only side effect is a single best-effort file read. Never throws.
+export function resolveTicketType(orchDir, ticket) {
+  if (!orchDir || !ticket) return UNKNOWN_TICKET_TYPE;
+  try {
+    const raw = readFileSync(join(orchDir, "workers", ticket, "triage.json"), "utf8");
+    const classification = JSON.parse(raw)?.classification;
+    if (typeof classification === "string" && classification.trim() !== "") {
+      return classification;
+    }
+    return UNKNOWN_TICKET_TYPE;
+  } catch {
+    return UNKNOWN_TICKET_TYPE;
+  }
+}

--- a/plugins/dev/scripts/execution-core/ticket-type.test.mjs
+++ b/plugins/dev/scripts/execution-core/ticket-type.test.mjs
@@ -1,0 +1,62 @@
+// ticket-type.test.mjs — CTL-1023: resolveTicketType work-type dimension.
+// Run: cd plugins/dev/scripts/execution-core && bun test ticket-type.test.mjs
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveTicketType, UNKNOWN_TICKET_TYPE } from "./ticket-type.mjs";
+
+let orchDir;
+
+function writeTriage(ticket, obj) {
+  const dir = join(orchDir, "workers", ticket);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "triage.json"), JSON.stringify(obj));
+}
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "ctl1023-tickettype-"));
+});
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+describe("resolveTicketType", () => {
+  test("classified ticket — returns the triage.json classification", () => {
+    writeTriage("CTL-1023", { classification: "feature", estimated_scope: "small" });
+    expect(resolveTicketType(orchDir, "CTL-1023")).toBe("feature");
+  });
+
+  test("bug classification — returns 'bug'", () => {
+    writeTriage("CTL-500", { classification: "bug" });
+    expect(resolveTicketType(orchDir, "CTL-500")).toBe("bug");
+  });
+
+  test("no triage.json on disk — falls back to 'unknown'", () => {
+    expect(resolveTicketType(orchDir, "CTL-404")).toBe(UNKNOWN_TICKET_TYPE);
+    expect(resolveTicketType(orchDir, "CTL-404")).toBe("unknown");
+  });
+
+  test("triage.json present but classification null — falls back to 'unknown'", () => {
+    writeTriage("CTL-1", { classification: null, type: null });
+    expect(resolveTicketType(orchDir, "CTL-1")).toBe("unknown");
+  });
+
+  test("triage.json present but classification empty string — falls back to 'unknown'", () => {
+    writeTriage("CTL-2", { classification: "   " });
+    expect(resolveTicketType(orchDir, "CTL-2")).toBe("unknown");
+  });
+
+  test("malformed triage.json — fails open to 'unknown' (no throw)", () => {
+    const dir = join(orchDir, "workers", "CTL-3");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "triage.json"), "{not json");
+    expect(resolveTicketType(orchDir, "CTL-3")).toBe("unknown");
+  });
+
+  test("missing orchDir or ticket — 'unknown', no throw", () => {
+    expect(resolveTicketType(undefined, "CTL-1023")).toBe("unknown");
+    expect(resolveTicketType(orchDir, undefined)).toBe("unknown");
+    expect(resolveTicketType(null, null)).toBe("unknown");
+  });
+});

--- a/plugins/dev/scripts/execution-core/triage-transition-event.mjs
+++ b/plugins/dev/scripts/execution-core/triage-transition-event.mjs
@@ -9,6 +9,7 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { getEventLogPath, log } from "./config.mjs";
 import { hostName, hostId } from "./lib/host-identity.mjs";
+import { UNKNOWN_TICKET_TYPE } from "./ticket-type.mjs"; // CTL-1023: work-type dimension
 
 // defaultAppend — writes a JSONL line to the canonical event log.
 function defaultAppend(line) {
@@ -27,6 +28,10 @@ export function buildTriageTransitionEvent({
   verified = false,
   applied = false,
   reason = null,
+  // CTL-1023: this IS the triage phase — classification is still being decided,
+  // so the work-type dimension is "unknown" here by design. Param kept for shape
+  // parity with the other emitters; callers normally omit it.
+  ticketType = UNKNOWN_TICKET_TYPE,
 } = {}) {
   const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
   return (
@@ -51,6 +56,7 @@ export function buildTriageTransitionEvent({
         "event.label": ticket,
         "catalyst.orchestration": orchId ?? ticket,
         "linear.issue.identifier": ticket,
+        "catalyst.ticket.type": ticketType ?? UNKNOWN_TICKET_TYPE, // CTL-1023
       },
       body: {
         payload: { phase: "triage", ticket, from_state, to_state, verified, applied, reason },

--- a/plugins/dev/scripts/execution-core/triage-transition-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/triage-transition-event.test.mjs
@@ -52,6 +52,19 @@ describe("buildTriageTransitionEvent", () => {
     const ev = JSON.parse(buildTriageTransitionEvent({ ticket: "CTL-1", verified: false }));
     expect(ev.body.payload.reason).toBeNull();
   });
+
+  // CTL-1023: this IS the triage phase — classification is still being decided,
+  // so the work-type dimension defaults to "unknown" here. The attribute must
+  // still be present (never inconsistently missing).
+  test("CTL-1023: catalyst.ticket.type defaults to 'unknown' on the triage event", () => {
+    const ev = JSON.parse(buildTriageTransitionEvent({ ticket: "CTL-1023" }));
+    expect(ev.attributes["catalyst.ticket.type"]).toBe("unknown");
+  });
+
+  test("CTL-1023: catalyst.ticket.type passes through when supplied", () => {
+    const ev = JSON.parse(buildTriageTransitionEvent({ ticket: "CTL-1023", ticketType: "bug" }));
+    expect(ev.attributes["catalyst.ticket.type"]).toBe("bug");
+  });
 });
 
 describe("appendTriageTransitionEvent", () => {

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -165,6 +165,10 @@ synthesize_event_id() {
 #   --claude-ratelimit-7d-sonnet-pct N  claude.ratelimit.seven_day_sonnet_pct (integer, CTL-763)
 #   --phase-attempt N        phase.attempt (integer, CTL-761)
 #   --phase-revive-count N   phase.revive_count (integer, CTL-761)
+#   --ticket-type TYPE       catalyst.ticket.type (CTL-1023 work-type dimension;
+#                            bug|feature|chore|refactor|docs|test). Defaults to
+#                            "unknown" when omitted/empty so the attribute is
+#                            CONSISTENTLY present, never sometimes-missing.
 build_canonical_line() {
   local ts="" severity="" service="" event_name=""
   local trace_id="" span_id=""
@@ -183,6 +187,9 @@ build_canonical_line() {
   local claude_rl_7d_opus="" claude_rl_7d_sonnet=""
   # CTL-761: dispatch attempt + revive count (typed int attributes).
   local phase_attempt="" phase_revive_count=""
+  # CTL-1023: work-type dimension (catalyst.ticket.type). Default "unknown" so the
+  # attribute is consistently present even when the caller cannot resolve a type.
+  local ticket_type=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -221,6 +228,7 @@ build_canonical_line() {
       --claude-ratelimit-7d-sonnet-pct) claude_rl_7d_sonnet="$2"; shift 2 ;;
       --phase-attempt)       phase_attempt="$2"; shift 2 ;;
       --phase-revive-count)  phase_revive_count="$2"; shift 2 ;;
+      --ticket-type)         ticket_type="$2"; shift 2 ;;
       *) echo "build_canonical_line: unknown flag: $1" >&2; return 1 ;;
     esac
   done
@@ -230,6 +238,9 @@ build_canonical_line() {
   [[ -n "$service"    ]] || { echo "build_canonical_line: --service required" >&2; return 1; }
   [[ -n "$event_name" ]] || { echo "build_canonical_line: --event-name required" >&2; return 1; }
   [[ -n "$service_version" ]] || service_version="$(plugin_version)"
+  # CTL-1023: the work-type dimension is ALWAYS present — fall back to "unknown"
+  # so consumers can group by it without coping with a sometimes-missing key.
+  [[ -n "$ticket_type" ]] || ticket_type="unknown"
 
   # CTL-636: promote orchestration context into the resource block. Existing
   # callers already pass --orch / --linear-ticket (which land in attributes);
@@ -289,6 +300,7 @@ build_canonical_line() {
     --arg claude_rl_7d_sonnet "$claude_rl_7d_sonnet" \
     --arg phase_attempt "$phase_attempt" \
     --arg phase_revive_count "$phase_revive_count" \
+    --arg ticket_type "$ticket_type" \
     '{
       ts: $ts,
       id: $id,
@@ -334,6 +346,7 @@ build_canonical_line() {
         + (if $claude_rl_7d_sonnet == "" then {} else { "claude.ratelimit.seven_day_sonnet_pct": ($claude_rl_7d_sonnet | tonumber) } end)
         + (if $phase_attempt == "" then {} else { "phase.attempt": ($phase_attempt | tonumber) } end)
         + (if $phase_revive_count == "" then {} else { "phase.revive_count": ($phase_revive_count | tonumber) } end)
+        + { "catalyst.ticket.type": $ticket_type }
       ),
       body: (
         (if $message == "" then {} else { message: $message } end)

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -173,6 +173,24 @@ resolve_project_key() {
 }
 PROJECT_KEY="$(resolve_project_key)"
 
+# ─── CTL-1023: resolve the work-type dimension (catalyst.ticket.type) ─────────
+#
+# Source of truth is triage.json `.classification` (bug|feature|chore|refactor|
+# docs|test) in the worker dir — written by phase-triage. Every phase terminal
+# event (complete / failed / turn-cap-exhausted / skipped / park) carries it so
+# DevOps/FinOps can group cost, effort, and throughput by work type. Fail-open
+# to empty; build_canonical_line then defaults the attribute to "unknown" — so a
+# pre-triage / unclassified ticket carries "unknown" rather than omitting the
+# attribute inconsistently (the gherkin contract).
+resolve_ticket_type() {
+	command -v jq >/dev/null 2>&1 || return 0
+	[[ -n $ORCH_DIR ]] || return 0
+	local triage="${ORCH_DIR}/workers/${TICKET}/triage.json"
+	[[ -f $triage ]] || return 0
+	jq -r '.classification // empty' "$triage" 2>/dev/null || true
+}
+TICKET_TYPE="$(resolve_ticket_type)"
+
 # ─── 0. CTL-736 Phase 1: fencing check (stale generation bows out) ───────────
 #
 # A worker carries its dispatch generation in CATALYST_GENERATION. If the phase
@@ -290,6 +308,7 @@ LINE=$(build_canonical_line \
 	--payload-json "$PAYLOAD" \
 	--phase-attempt "$PHASE_ATTEMPT" \
 	--phase-revive-count "$PHASE_REVIVE_COUNT" \
+	--ticket-type "$TICKET_TYPE" \
 	2>/dev/null) || warn "failed to build canonical event line"
 
 if [[ -n $LINE ]]; then


### PR DESCRIPTION
## Summary

Adds `catalyst.ticket.type` as an OTel attribute on every phase event so cost, effort, and throughput can be grouped by work type (bug / feature / chore / refactor / docs / test) in Grafana/Loki.

- **`ticket-type.mjs`** — new resolver: reads `workers/<ticket>/triage.json` `.classification`, falls back to `"unknown"`. Additive, fail-open, never throws.
- **`recovery.mjs` / `scheduler.mjs` / `linear-state-write-event.mjs` / `triage-transition-event.mjs`** — JS-side: `orchDir` threaded into `buildEventEnvelope`, dispatch/reclaim/revive helpers, state-write audit, and triage-transition event. `catalyst.ticket.type` is **always present** — `"unknown"` pre-triage.
- **`lib/canonical-event.sh`** — new `--ticket-type` flag on `build_canonical_line`; defaults to `"unknown"` when omitted so the attribute is never inconsistently missing.
- **`phase-agent-emit-complete`** — resolves type from `workers/<ticket>/triage.json` and passes `--ticket-type` on every terminal emit (complete / failed / turn-cap / skipped / park).

The OTLP forwarder (`otel-forward`) needs no change — `toAttrArray(ev.attributes)` is a generic pass-through with no allowlist; the new attribute flows to Loki/OTLP as-is.

## Tests

- `ticket-type.test.mjs` — 7 tests: classified / bug / label-absent unknown / malformed / missing-orchDir
- `recovery.test.mjs` — dispatch envelope reads triage.json classification; `"unknown"` pre-triage (213 pass)
- `triage-transition-event.test.mjs` + `linear-state-write-event.test.mjs` — attribute assertions (19 pass)
- `canonical-event.test.sh` — `--ticket-type` value + `"unknown"` default + always-present (81 pass)
- `phase-agent-emit-complete.test.sh` — reads triage.json on complete; `"unknown"` with no triage.json; rides `.failed` event (80 pass)

## Deployment note

Emit-side change — goes live at the next operator-approved daemon restart for broker / execution-core. The monitor-side forwarder is unchanged; no monitor restart needed.

## Gherkin contract (CTL-1023)

- Phase events carry `catalyst.ticket.type`; tickets with no classification carry `"unknown"` (never missing)
- Existing dashboards keep working (no renamed or removed attributes — purely additive)

Closes CTL-1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)