### PR TITLE
fix(dev): CTL-1044 — shadow clock records evidence (operator-event appender + daemon wiring)

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -83,7 +83,7 @@ import {
   readAllEligibleTickets, // CTL-862: boot-log ownership count
   clearHoldStopCooldown, // CTL-768
 } from "./scheduler.mjs";
-import { writeBootMarker, clearProgressMarks, resolvePhaseSessionId } from "./recovery.mjs"; // CTL-655: window the revive budget to this run; CTL-736: reset progress high-water; CTL-768: --resume
+import { writeBootMarker, clearProgressMarks, resolvePhaseSessionId, defaultAppendOperatorEvent } from "./recovery.mjs"; // CTL-655: window the revive budget to this run; CTL-736: reset progress high-water; CTL-768: --resume; CTL-1044: operator-event appender for the scheduler's appendIntentEvent seam
 import { startAutoTuner } from "./autotune.mjs"; // CTL-684: side-car maxParallel auto-tuner
 import { dispatchTicket } from "./dispatch.mjs"; // CTL-549: comment-wake re-dispatch
 import { removeLabel as defaultRemoveLabel } from "./linear-write.mjs"; // CTL-549: clear needs-human/question on resume
@@ -541,7 +541,19 @@ export function startDaemon({
       // live in production, not just in unit tests.
       gateway: gatewayReader,
       isBgJobAlive,
-    }); // CTL-536 + CTL-634 + CTL-665 + CTL-671 + CTL-676 + CTL-678 — pull-loop scheduler (configPath + layer2Path enable per-tick Layer-1+Layer-2 re-read)
+      // CTL-1044: provide the production operator-event appender for the
+      // scheduler's `appendIntentEvent` seam (scheduler.mjs:4300). Without this
+      // the seam is null and the advance-shadow comparator's disagree/tick
+      // events (beliefs/advance-shadow.mjs:177-198), CTL-936 intent.ineffective,
+      // and executeEscalations emissions all silently no-op — the bug this fixes
+      // (zero beliefs.* events ever reached the log despite the shadow window
+      // running live on mini). The seam contract is a raw
+      // { "event.name": string, payload: object } object, which does NOT fit
+      // buildEventEnvelope's phase/action schema — hence the dedicated
+      // operator-event envelope builder in recovery.mjs. startScheduler keeps
+      // its null default (CTL-936 chose silence for legacy/tests).
+      appendIntentEvent: defaultAppendOperatorEvent,
+    }); // CTL-536 + CTL-634 + CTL-665 + CTL-671 + CTL-676 + CTL-678 + CTL-1044 — pull-loop scheduler (configPath + layer2Path enable per-tick Layer-1+Layer-2 re-read; appendIntentEvent wires operator telemetry to the event log)
     // CTL-684: start the side-car auto-tuner AFTER the scheduler so the
     // scheduler's first tick runs with the operator's current Layer-2 value
     // before any auto-tune adjustments. configPath + layer2Path are threaded

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -224,6 +224,46 @@ describe("startDaemon", () => {
     expect(schedulerConfigPath).toBeNull();
   });
 
+  // CTL-1044: the daemon MUST pass an `appendIntentEvent` appender into the
+  // scheduler. Without it, runningOpts.appendIntentEvent is undefined and the
+  // advance-shadow comparator / CTL-936 intent.ineffective / executeEscalations
+  // emitters silently no-op (the bug: zero beliefs.* events ever reached the log
+  // on mini despite the shadow flags being live). This wiring test mirrors the
+  // gateway/configPath wiring tests above: capture the scheduler's opts and
+  // assert the appender is a function that actually lands a line in the unified
+  // event log carrying event.name verbatim + payload intact.
+  test("CTL-1044: passes appendIntentEvent into startScheduler — and it writes to the event log", () => {
+    let captured;
+    startDaemon({
+      recover: () => ({ coldStart: false, workers: {} }),
+      reconcileBoot: () => {},
+      startMonitor: () => {},
+      startScheduler: (o) => {
+        captured = o;
+      },
+      watchRegistry: false,
+    });
+    // The seam the advance-shadow comparator (and intent/escalation emitters)
+    // consume must be a real function in production — not null/undefined.
+    expect(typeof captured.appendIntentEvent).toBe("function");
+
+    // Drive exactly the object advance-shadow.mjs:177-180 hands `appendEvent`
+    // and prove it reaches the log (CATALYST_DIR is pinned to this test's tmp
+    // dir by the suite's beforeEach, so getEventLogPath resolves there).
+    const ok = captured.appendIntentEvent({
+      "event.name": "beliefs.advance_shadow.disagree",
+      payload: { ticket: "CTL-1044-IT", procedural: "research", belief: null },
+    });
+    expect(ok).toBe(true);
+
+    const lines = readFileSync(getEventLogPath(), "utf8").split("\n").filter(Boolean);
+    const env = JSON.parse(lines[lines.length - 1]);
+    expect(env.attributes["event.name"]).toBe("beliefs.advance_shadow.disagree");
+    expect(env.body.payload.ticket).toBe("CTL-1044-IT");
+    expect(env.body.payload.procedural).toBe("research");
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+  });
+
   // CTL-634: one cache instance is created in startDaemon and threaded into
   // BOTH composed boots, so the monitor's write-through and the scheduler's
   // read path share state. Capture each boot's `cache` arg and assert identity.

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -1084,6 +1084,58 @@ export function defaultAppendAutotuneGaugeEvent({
   );
 }
 
+// CTL-1044: generic operator-event appender. The scheduler's `appendIntentEvent`
+// seam (scheduler.mjs:4300, threaded into the advance-shadow comparator, CTL-936
+// reconcileIntents, and executeEscalations) consumes a RAW operator-event object:
+//   { "event.name": string, payload: object }
+// This does NOT fit buildEventEnvelope's phase.<phase>.<action>.<ticket> schema
+// (those events are phase-keyed; operator telemetry is name-keyed), so it gets a
+// dedicated envelope builder here. The envelope carries `evt["event.name"]`
+// VERBATIM as attributes["event.name"] and `evt.payload` under body.payload —
+// matching the unified-event-log line shape every other daemon emitter writes
+// (ts/id/observedTs/severity/resource{service.name,namespace,host}/attributes/body).
+// Production wires this at daemon.mjs's schedulerFn({ appendIntentEvent }) call;
+// startScheduler keeps its null default (CTL-936 chose silence for legacy/tests).
+// Best-effort: a malformed evt or an unwriteable log never throws — operator
+// telemetry must never break a tick (the shadow contract). The broker's
+// shouldSkipEvent (broker/router.mjs:1395) does NOT skip beliefs.* names and no
+// handler keys off them, so these land in the log as inert telemetry — no loop.
+export function defaultAppendOperatorEvent(evt) {
+  try {
+    const name = evt?.["event.name"];
+    if (typeof name !== "string" || name.length === 0) return false;
+    const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+    const line =
+      JSON.stringify({
+        ts,
+        id: randomBytes(8).toString("hex"),
+        observedTs: ts,
+        // Operator telemetry (shadow disagreements, intent.ineffective,
+        // escalations) is INFO — it records evidence; it is NOT a daemon-health
+        // warning. Matches the dispatch-lifecycle precedent (CTL-700 Item B).
+        severityText: "INFO",
+        severityNumber: 9,
+        traceId: randomBytes(16).toString("hex"),
+        spanId: randomBytes(8).toString("hex"),
+        resource: {
+          "service.name": "catalyst.execution-core",
+          "service.namespace": "catalyst",
+          "host.name": hostName(),
+          "host.id": hostId(),
+        },
+        attributes: {
+          "event.name": name,
+        },
+        body: { payload: evt?.payload ?? null },
+      }) + "\n";
+    return appendEnvelopeBestEffort(line, "operator-event");
+  } catch {
+    // Best-effort — a serialization failure (e.g. a circular payload) must
+    // never break the tick. The caller's own try/catch is a second backstop.
+    return false;
+  }
+}
+
 // CTL-587 default seams — all overridable for tests, all best-effort for prod.
 
 // defaultReviveDispatch — reset the signal to status: "stalled" first (to bypass

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -41,6 +41,8 @@ import {
   clearProgressMarks,
   // CTL-1006
   defaultAppendBootResumePhaseRegressionEvent,
+  // CTL-1044
+  defaultAppendOperatorEvent,
 } from "./recovery.mjs";
 import { saveCursor } from "./event-cursor.mjs";
 import { dropProject } from "./eligible-set.mjs";
@@ -2983,6 +2985,101 @@ describe("dispatch lifecycle event envelopes (CTL-660)", () => {
     expect(env.body.payload.load_per_core).toBe(0.3);
     expect(env.body.payload.mem_free_pct).toBe(42.5);
     expect(env.body.payload.decision_reason).toBe("converge-to-setpoint");
+  });
+});
+
+// CTL-1044: the generic operator-event appender. This is the PRODUCTION default
+// for the scheduler's `appendIntentEvent` seam (advance-shadow disagree/tick,
+// CTL-936 intent.ineffective, executeEscalations). The seam contract is a RAW
+// `{ "event.name": string, payload: object }` object that does NOT fit
+// buildEventEnvelope's phase/action schema — so this helper wraps it in a valid
+// unified-event-log envelope, carrying event.name VERBATIM and payload intact.
+describe("defaultAppendOperatorEvent (CTL-1044)", () => {
+  let envCatalystDir;
+  let prevCatalystDir;
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    envCatalystDir = mkdtempSync(join(tmpdir(), "ctl1044-op-"));
+    process.env.CATALYST_DIR = envCatalystDir;
+    mkdirSync(join(envCatalystDir, "events"), { recursive: true });
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(envCatalystDir, { recursive: true, force: true });
+  });
+
+  function readBackEnvelope() {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const lines = readFileSync(join(envCatalystDir, "events", `${ym}.jsonl`), "utf8")
+      .split("\n")
+      .filter(Boolean);
+    return JSON.parse(lines[lines.length - 1]);
+  }
+
+  test("writes a parseable envelope carrying event.name verbatim and payload intact", () => {
+    // Exactly the object the advance-shadow comparator hands the seam
+    // (advance-shadow.mjs:177-180): the disagree event.
+    const disagreement = {
+      ticket: "CTL-9",
+      procedural: "research",
+      belief: null,
+      procedural_exhausted: false,
+      belief_exhausted: false,
+      signals: { triage: "done" },
+      differingInput: { verdict: null, remediateCycleCount: 0 },
+    };
+    const ok = defaultAppendOperatorEvent({
+      "event.name": "beliefs.advance_shadow.disagree",
+      payload: disagreement,
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    // event.name is preserved VERBATIM — NOT mangled into phase.<phase>.<action>.
+    expect(env.attributes["event.name"]).toBe("beliefs.advance_shadow.disagree");
+    // payload survives the round-trip byte-for-byte.
+    expect(env.body.payload).toEqual(disagreement);
+    // Same resource/service fields every other daemon emitter stamps.
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(env.resource["service.namespace"]).toBe("catalyst");
+    expect(env.resource["host.name"]).toBeTruthy();
+    expect(env.resource["host.id"]).toBeTruthy();
+    // Required envelope scaffold the log reader/otel-forward depend on.
+    expect(typeof env.id).toBe("string");
+    expect(env.id.length).toBeGreaterThan(0);
+    expect(env.ts).toBeTruthy();
+    expect(env.severityText).toBe("INFO");
+    expect(env.severityNumber).toBe(9);
+  });
+
+  test("writes the tick-summary event with its agree/disagree counts", () => {
+    const ok = defaultAppendOperatorEvent({
+      "event.name": "beliefs.advance_shadow.tick",
+      payload: { agree: 3, disagree: 1 },
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["event.name"]).toBe("beliefs.advance_shadow.tick");
+    expect(env.body.payload).toEqual({ agree: 3, disagree: 1 });
+  });
+
+  test("is best-effort: returns false (never throws) on a malformed event with no event.name", () => {
+    expect(defaultAppendOperatorEvent({ payload: { x: 1 } })).toBe(false);
+    expect(defaultAppendOperatorEvent(null)).toBe(false);
+    expect(defaultAppendOperatorEvent({})).toBe(false);
+  });
+
+  test("is fail-open: returns false (never throws) when the log dir is unwriteable", () => {
+    const filePath = join(envCatalystDir, "not-a-dir-op");
+    writeFileSync(filePath, "x");
+    process.env.CATALYST_DIR = join(filePath, "nested");
+    expect(
+      defaultAppendOperatorEvent({
+        "event.name": "beliefs.advance_shadow.disagree",
+        payload: { ticket: "CTL-FAIL" },
+      }),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Root cause (verified 2026-06-11)

`startScheduler` threads an `appendIntentEvent` seam (`scheduler.mjs:4300`, stored in `runningOpts:4326`) consumed by **three** emitters: advance-shadow tick/disagree (`beliefs/advance-shadow.mjs:177-198`), CTL-936 `reconcileIntents` `intent.ineffective`, and `executeEscalations` (`scheduler.mjs:4113`).

**No production caller ever passed it.** `daemon.mjs:520` `schedulerFn({...})` passed `orchDir/cache/gateway/isBgJobAlive/...` but NOT `appendIntentEvent` → the seam was `null` → every emit silently no-op'd behind its `typeof appendEvent === "function"` guard. Result: **zero `beliefs.*` events in the entire June event log on mini** despite `CATALYST_BELIEFS_SHADOW=1 + CATALYST_ADVANCE_SHADOW_SUMMARY=1` live and `beliefs.db` actively ticking (397MB). The CTL-935 7-day shadow window was running BLIND and the CTL-968 evidence pack could not be produced.

Contrast: `appendPhaseAdvanceHeldEvent` DEFAULTS to `defaultAppendPhaseAdvanceHeldEvent` (`recovery.mjs:948`), which is why `phase.advance.held` events DO reach the log.

## Fix

1. **New `defaultAppendOperatorEvent(evt)`** in `recovery.mjs`, beside the sibling `default*Event` emitters (follows `appendEnvelopeBestEffort` conventions). The seam's contract is a raw `{"event.name": string, payload: object}` object (`advance-shadow.mjs:177`) that does NOT fit `buildEventEnvelope`'s `phase.<phase>.<action>.<ticket>` schema — so this builds a valid unified-event-log envelope directly: `attributes["event.name"]` carries `evt["event.name"]` **verbatim**, `body.payload` carries `evt.payload` intact, with the same `ts/id/observedTs/severity/resource{service.name,namespace,host.name,host.id}/attributes/body` scaffold every other daemon emitter stamps (matched against a real line in `~/catalyst/events` and `buildEventEnvelope`). Best-effort — never throws.
2. **`daemon.mjs:520`** — `schedulerFn` now passes `appendIntentEvent: defaultAppendOperatorEvent`. The seam's null default in `startScheduler` is **unchanged** (CTL-936 chose silence for legacy/tests; production wiring is the fix).

## Broker `shouldSkipEvent` evidence

The broker correctly ingests these as inert telemetry — no handler acts, no loop:

- `shouldSkipEvent` (`broker/router.mjs:1395`) returns **false** for `beliefs.advance_shadow.disagree`/`.tick`/`beliefs.intent.ineffective`: `resource["service.name"]` is `catalyst.execution-core` (not `catalyst.broker`); the name has no `filter.`/`broker.daemon` prefix; it is not `session.heartbeat`. → **NOT skipped, correctly ingested.**
- In `processEvent` (`router.mjs:1776`), after `shouldSkipEvent`, the name-keyed handlers match only `filter.*` / `agent.*` / `session.heartbeat` / `worker.*` / `orchestrator.*` / `linear.issue.*` / `heartbeat` / `orchestrator-completed|failed`, and the four deterministic routers (`tryDeterministicRoute`=pr, `tryTicketLifecycleRoute`=`linear.issue.`, `tryPhaseLifecycleRoute`=`phase.`, `tryWorkflowSubstepRoute`) key on `pr.`/`linear.issue.`/`phase.`/substep prefixes. **`beliefs.*` matches none** → no handler acts, and the event is never re-emitted → **no loop.**

## Tests (TDD: RED first, then GREEN)

- **Unit** (`recovery.test.mjs`, `defaultAppendOperatorEvent (CTL-1044)`): writes a parseable envelope with `attributes["event.name"]` preserved verbatim + `body.payload` intact (round-tripped via a temp `CATALYST_DIR` events file); tick-summary counts survive; best-effort on a malformed event (no `event.name`) and fail-open on an unwriteable log dir. **4 pass.**
- **Integration** (`daemon.test.mjs`, `CTL-1044: passes appendIntentEvent into startScheduler`): drives `startDaemon`'s `schedulerFn` wiring (mirrors the gateway/configPath wiring tests), asserts `appendIntentEvent` is a function, and that calling it lands a `beliefs.advance_shadow.disagree` line in the log. **1 pass** (RED before wiring: `appendIntentEvent` was `undefined`).

Suite results (all green): daemon 96, recovery 244, scheduler 450, advance-shadow 12, intent 29, reap-intent 9. `node --check` passes on all 4 changed `.mjs`. The known pre-existing failures (CTL-716, CTL-587, CTL-685, broker gc-startup ×3) are unrelated and not touched. The "quality" check is red from pre-existing debt (CTL-1043) and is not a required check.

Rollout: daemon-side — activates at the next mini restart.

Refs CTL-1044.

🤖 Generated with [Claude Code](https://claude.com/claude-code)