### PR TITLE
fix(dev): CTL-1045 — stall-janitor enforce-readiness hardening (J2 kill-storm, J3 cause + prior-signal, once-marker)

### DIFF
--- a/plugins/dev/scripts/execution-core/integration-ctl-1004.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-1004.test.mjs
@@ -325,4 +325,13 @@ describe("CTL-1045 Bug 1 — J2 kill-storm: ineffective-intent suppression in de
 
     expect(killed).toEqual(["ghostjob"]); // guard must not over-suppress
   });
+
+  test("enforce: intentDb=null bypasses the guard entirely — kill still fires", () => {
+    const killed = [];
+    // intentDb omitted → null default → isIntentEffective check is skipped
+    // entirely; killBgJob must still be called (fail-open when beliefs db absent).
+    schedulerTick(orchDir, prodTickOpts({ mode: "enforce", killed, intentDb: null }));
+
+    expect(killed).toEqual(["ghostjob"]);
+  });
 });

--- a/plugins/dev/scripts/execution-core/integration-ctl-1004.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-1004.test.mjs
@@ -214,6 +214,42 @@ describe("CTL-1004 integration — isolation", () => {
 // recordKillIntent seam — so defaultJanitorKillIntentRecorder(intentDb,
 // killBgJob) is what runs. The assertion is that a REAL stop seam fires (not
 // merely that an intent row was written).
+// Tick opts with the PRODUCTION recorder path (recordKillIntent NOT injected),
+// a real intentDb, and a spy killBgJob so we can observe the stop seam.
+// Module-scoped so CTL-1045 suppression tests can reuse it.
+function prodTickOpts({ mode, killed, intentDb }) {
+  return {
+    readEligible: () => [],
+    dispatch: () => ({ status: "dispatched" }),
+    exec: () => ({ code: null }),
+    reclaimDeadWork: () => ({ class: "alive-suppressed" }),
+    writeStatus: {
+      applyLabel: () => ({ applied: true }),
+      removeLabel: () => ({ removed: true }),
+      runTransition: () => ({ applied: false }),
+    },
+    now: () => NOW,
+    watchdog: { mode: "off" },
+    intentDb,
+    // Spy stop seam — records every bgJobId killBgJob is asked to stop.
+    killBgJob: ({ bgJobId }) => killed.push(bgJobId),
+    stallJanitor: {
+      mode,
+      collectGhostCandidates: () => [
+        {
+          ticket: "CTL-1004G",
+          phase: "monitor-deploy",
+          bgJobId: "ghostjob",
+          terminalForMs: 700_000,
+          sessionKind: "background",
+          sessionStatus: "idle",
+        },
+      ],
+      // recordKillIntent intentionally NOT injected → production recorder.
+    },
+  };
+}
+
 describe("CTL-1004 J2 enforce — a real stop seam fires (killBgJob), not just an intent row", () => {
   // A real beliefs.db with a single tick row (defaultJanitorKillIntentRecorder
   // needs the latest tick_id to anchor the intent insert).
@@ -221,41 +257,6 @@ describe("CTL-1004 J2 enforce — a real stop seam fires (killBgJob), not just a
     const db = openBeliefsDb({ path: join(orchDir, "beliefs.db") });
     db.run("INSERT INTO tick (now_ms, host) VALUES (?, 'testhost')", [NOW]);
     return db;
-  }
-
-  // Tick opts with the PRODUCTION recorder path (recordKillIntent NOT injected),
-  // a real intentDb, and a spy killBgJob so we can observe the stop seam.
-  function prodTickOpts({ mode, killed, intentDb }) {
-    return {
-      readEligible: () => [],
-      dispatch: () => ({ status: "dispatched" }),
-      exec: () => ({ code: null }),
-      reclaimDeadWork: () => ({ class: "alive-suppressed" }),
-      writeStatus: {
-        applyLabel: () => ({ applied: true }),
-        removeLabel: () => ({ removed: true }),
-        runTransition: () => ({ applied: false }),
-      },
-      now: () => NOW,
-      watchdog: { mode: "off" },
-      intentDb,
-      // Spy stop seam — records every bgJobId killBgJob is asked to stop.
-      killBgJob: ({ bgJobId }) => killed.push(bgJobId),
-      stallJanitor: {
-        mode,
-        collectGhostCandidates: () => [
-          {
-            ticket: "CTL-1004G",
-            phase: "monitor-deploy",
-            bgJobId: "ghostjob",
-            terminalForMs: 700_000,
-            sessionKind: "background",
-            sessionStatus: "idle",
-          },
-        ],
-        // recordKillIntent intentionally NOT injected → production recorder.
-      },
-    };
   }
 
   test("enforce: killBgJob IS called with the ghost's bgJobId AND an intent row is recorded", () => {
@@ -286,5 +287,42 @@ describe("CTL-1004 J2 enforce — a real stop seam fires (killBgJob), not just a
       .query("SELECT subject FROM intent WHERE kind = 'kill' AND subject = ?")
       .get("CTL-1004G/monitor-deploy");
     expect(row == null).toBe(true); // no intent row recorded in shadow
+  });
+});
+
+// ── CTL-1045 Bug 1 — isIntentEffective suppression in the J2 kill recorder ─
+describe("CTL-1045 Bug 1 — J2 kill-storm: ineffective-intent suppression in defaultJanitorKillIntentRecorder", () => {
+  function makeIntentDbWithSeededIntent(attempts) {
+    const db = openBeliefsDb({ path: join(orchDir, "beliefs.db") });
+    db.run("INSERT INTO tick (now_ms, host) VALUES (?, 'testhost')", [NOW]);
+    const tickRow = db.query("SELECT tick_id FROM tick ORDER BY tick_id DESC LIMIT 1").get();
+    db.run(
+      "INSERT INTO intent (tick_id, kind, subject, postcondition, attempts, outcome) VALUES (?, 'kill', ?, ?, ?, NULL)",
+      [
+        tickRow.tick_id,
+        "CTL-1004G/monitor-deploy",
+        JSON.stringify({ kind: "kill", subject: "CTL-1004G/monitor-deploy", bgJobId: "ghostjob", sessionNotRegistered: true }),
+        attempts,
+      ],
+    );
+    return db;
+  }
+
+  test("enforce: a plateaued ineffective kill intent (attempts >= max) suppresses killBgJob", () => {
+    const killed = [];
+    // Seed an intent already at cap (attempts=2, outcome IS NULL — the plateaued state).
+    const intentDb = makeIntentDbWithSeededIntent(2);
+    schedulerTick(orchDir, prodTickOpts({ mode: "enforce", killed, intentDb }));
+
+    expect(killed).toEqual([]); // guard suppressed the stop
+  });
+
+  test("enforce: a still-effective kill intent (attempts < max) DOES call killBgJob", () => {
+    const killed = [];
+    // Seed an intent at attempts=1 (below default maxAttempts=2 → still effective).
+    const intentDb = makeIntentDbWithSeededIntent(1);
+    schedulerTick(orchDir, prodTickOpts({ mode: "enforce", killed, intentDb }));
+
+    expect(killed).toEqual(["ghostjob"]); // guard must not over-suppress
   });
 });

--- a/plugins/dev/scripts/execution-core/integration-ctl-1005.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-1005.test.mjs
@@ -248,6 +248,8 @@ describe("CTL-1045 Bug 4 — once-marker withheld on failed needs-human clear", 
     expect(existsSync(join(workerDir(), `phase-${PHASE}.json`))).toBe(false);
     // The once-marker is withheld — a future genuine escalation must be re-armable.
     expect(existsSync(join(workerDir(), `.janitor-cleared-${PHASE}.applied`))).toBe(false);
+    // The needs-human marker is RETAINED (removeLabel failed → retry on next tick).
+    expect(existsSync(join(workerDir(), ".linear-label-needs-human.applied"))).toBe(true);
     expect(result.janitorStallsCleared).toEqual([{ ticket: TICKET, phase: PHASE }]);
   });
 });

--- a/plugins/dev/scripts/execution-core/integration-ctl-1005.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-1005.test.mjs
@@ -228,6 +228,30 @@ describe("CTL-1045 J3 integration — new gates", () => {
   });
 });
 
+describe("CTL-1045 Bug 4 — once-marker withheld on failed needs-human clear", () => {
+  test("a FAILED needs-human clear withholds the once-marker (stalled signal still deleted)", () => {
+    seedStall();
+    const events = [];
+    // Wire removeLabel to return {removed: false} — simulates a Linear API failure.
+    const result = schedulerTick(
+      orchDir,
+      {
+        ...makeTickOpts({ mode: "enforce", events }),
+        writeStatus: {
+          applyLabel: () => ({ applied: true }),
+          removeLabel: () => ({ removed: false }), // label removal fails
+          runTransition: () => ({ applied: false }),
+        },
+      },
+    );
+    // The stalled signal IS deleted (the unstick happens regardless of label-clear).
+    expect(existsSync(join(workerDir(), `phase-${PHASE}.json`))).toBe(false);
+    // The once-marker is withheld — a future genuine escalation must be re-armable.
+    expect(existsSync(join(workerDir(), `.janitor-cleared-${PHASE}.applied`))).toBe(false);
+    expect(result.janitorStallsCleared).toEqual([{ ticket: TICKET, phase: PHASE }]);
+  });
+});
+
 describe("CTL-1005 J3 integration — shadow mutates nothing", () => {
   test("shadow emits janitor.would.clear but deletes no signal and writes no marker", () => {
     seedStall();

--- a/plugins/dev/scripts/execution-core/integration-ctl-1005.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-1005.test.mjs
@@ -104,7 +104,7 @@ describe("CTL-1005 J3 integration — enforce performs the real clear", () => {
     expect(existsSync(join(workerDir(), ".linear-label-needs-human.applied"))).toBe(false);
     // .orphan-detected.applied cleared (a future stall re-emits, not silently suppressed).
     expect(existsSync(join(workerDir(), ".orphan-detected.applied"))).toBe(false);
-    // .janitor-cleared-<phase>.applied once-marker written (one clear per lifetime).
+    // .janitor-cleared-<phase>.applied once-marker written (one clear per worker-dir lifetime).
     expect(existsSync(join(workerDir(), `.janitor-cleared-${PHASE}.applied`))).toBe(true);
     // The event + the tick report.
     const ev = events.find((e) => e.type === "janitor.stall.cleared");

--- a/plugins/dev/scripts/execution-core/integration-ctl-1005.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-1005.test.mjs
@@ -34,7 +34,7 @@ function seedStall() {
   mkdirSync(d, { recursive: true });
   writeFileSync(
     join(d, `phase-${PHASE}.json`),
-    JSON.stringify({ ticket: TICKET, phase: PHASE, status: "stalled", stalledReason: "prior-artifact-retry-exhausted" }),
+    JSON.stringify({ ticket: TICKET, phase: PHASE, status: "stalled", stalledReason: "prior-artifact-retry-exhausted", dispatchFailureCode: 2 }),
   );
   // The completed prior-phase (research) signal that should survive the clear so
   // the scheduler can re-derive `plan` next tick.
@@ -77,6 +77,8 @@ function makeTickOpts({ mode, events = [], stallCtx } = {}) {
           artifactPresent: true,
           artifactComplete: true,
           alreadyCleared: false,
+          dispatchFailureCode: 2,       // CTL-1045 Bug 2
+          priorDoneSignalPresent: true, // CTL-1045 Bug 3
         },
       ],
       emit: (type, fields) => {
@@ -131,6 +133,8 @@ describe("CTL-1005 J3 integration — enforce performs the real clear", () => {
           artifactPresent: true,
           artifactComplete: true,
           alreadyCleared: true, // the marker the census would have read
+          dispatchFailureCode: 2,
+          priorDoneSignalPresent: true,
         },
       }),
     );
@@ -157,6 +161,64 @@ describe("CTL-1005 J3 integration — enforce performs the real clear", () => {
           artifactPresent: true,
           artifactComplete: false, // present but truncated
           alreadyCleared: false,
+          dispatchFailureCode: 2,
+          priorDoneSignalPresent: true,
+        },
+      }),
+    );
+    expect(existsSync(join(workerDir(), `phase-${PHASE}.json`))).toBe(true);
+    expect(events.filter((e) => e.type === "janitor.stall.cleared")).toHaveLength(0);
+    expect(result.janitorStallsCleared).toEqual([]);
+  });
+});
+
+describe("CTL-1045 J3 integration — new gates", () => {
+  test("CTL-1045 Bug 2: stall with non-benign dispatchFailureCode stays frozen (verify_failed code=0)", () => {
+    seedStall();
+    const events = [];
+    const result = schedulerTick(
+      orchDir,
+      makeTickOpts({
+        mode: "enforce",
+        events,
+        stallCtx: {
+          ticket: TICKET,
+          phase: PHASE,
+          stalledReason: "prior-artifact-retry-exhausted",
+          linearTerminal: false,
+          liveSessionInWorktree: false,
+          artifactPresent: true,
+          artifactComplete: true,
+          alreadyCleared: false,
+          dispatchFailureCode: 0,       // verify_failed — NOT clearable
+          priorDoneSignalPresent: true,
+        },
+      }),
+    );
+    expect(existsSync(join(workerDir(), `phase-${PHASE}.json`))).toBe(true);
+    expect(events.filter((e) => e.type === "janitor.stall.cleared")).toHaveLength(0);
+    expect(result.janitorStallsCleared).toEqual([]);
+  });
+
+  test("CTL-1045 Bug 3: stall with code=2 but no prior-done signal stays frozen (empty-dir re-walk guard)", () => {
+    seedStall();
+    const events = [];
+    const result = schedulerTick(
+      orchDir,
+      makeTickOpts({
+        mode: "enforce",
+        events,
+        stallCtx: {
+          ticket: TICKET,
+          phase: PHASE,
+          stalledReason: "prior-artifact-retry-exhausted",
+          linearTerminal: false,
+          liveSessionInWorktree: false,
+          artifactPresent: true,
+          artifactComplete: true,
+          alreadyCleared: false,
+          dispatchFailureCode: 2,
+          priorDoneSignalPresent: false, // prior-done signal absent
         },
       }),
     );

--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -121,7 +121,7 @@ export function labelOnce(orchDir, ticket, label, writeStatus, { appendEvent = n
 // permanently disarmed. Best-effort and never throws (mirrors labelOnce).
 // The marker is deleted ONLY on a confirmed removal so a transient API failure
 // is retried next tick.
-export function clearStalledLabel(orchDir, ticket, label, writeStatus) {
+export function clearStalledLabel(orchDir, ticket, label, writeStatus, { onRemoved = null } = {}) {
   const base = labelMarkerBase(orchDir, ticket, label);
   try {
     const res = writeStatus.removeLabel(ticket, label);
@@ -131,6 +131,14 @@ export function clearStalledLabel(orchDir, ticket, label, writeStatus) {
         for (const suffix of [".applied", ".skipped"]) {
           const p = `${base}${suffix}`;
           if (existsSync(p)) { try { unlinkSync(p); } catch { /* best-effort */ } }
+        }
+        // CTL-1045 Bug 4: run the caller's confirmed-removal hook ONLY when
+        // removal is confirmed — e.g. the J3 once-marker write. A failed removal
+        // must NOT disarm future genuine escalations via the once-marker.
+        if (typeof onRemoved === "function") {
+          try { onRemoved(); } catch (err) {
+            log.warn({ ticket, label, err: err?.message }, "clearStalledLabel: onRemoved threw — continuing");
+          }
         }
       }
     };

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -386,6 +386,45 @@ describe("clearStalledLabel", () => {
   });
 });
 
+// ─── CTL-1045 Bug 4: clearStalledLabel onRemoved callback ───────────────────
+
+describe("CTL-1045 Bug 4 — clearStalledLabel onRemoved callback", () => {
+  test("onRemoved is invoked only when removal is confirmed (removed: true)", () => {
+    const workerDir = join(orchDir, "workers", "CTL-1");
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, ".linear-label-needs-human.applied"), "");
+    let called = 0;
+
+    clearStalledLabel(orchDir, "CTL-1", "needs-human", { removeLabel: () => ({ removed: true }) }, { onRemoved: () => { called++; } });
+    expect(called).toBe(1);
+  });
+
+  test("onRemoved is withheld when removal is NOT confirmed (removed: false)", () => {
+    const workerDir = join(orchDir, "workers", "CTL-1");
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, ".linear-label-needs-human.applied"), "");
+    let called = 0;
+
+    clearStalledLabel(orchDir, "CTL-1", "needs-human", { removeLabel: () => ({ removed: false }) }, { onRemoved: () => { called++; } });
+    expect(called).toBe(0);
+  });
+
+  test("onRemoved fires after an async removeLabel resolving removed:true", async () => {
+    const workerDir = join(orchDir, "workers", "CTL-1");
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, ".linear-label-needs-human.applied"), "");
+    let called = 0;
+
+    clearStalledLabel(
+      orchDir, "CTL-1", "needs-human",
+      { removeLabel: () => Promise.resolve({ removed: true }) },
+      { onRemoved: () => { called++; } },
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(called).toBe(1);
+  });
+});
+
 // ─── CTL-936: labelOnce — operator-visible event on unrecoverable failure ────
 
 describe("labelOnce CTL-936 operator-visible event", () => {

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -423,6 +423,23 @@ describe("CTL-1045 Bug 4 — clearStalledLabel onRemoved callback", () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(called).toBe(1);
   });
+
+  test("a throwing onRemoved does not propagate — clearStalledLabel stays best-effort", () => {
+    const workerDir = join(orchDir, "workers", "CTL-1");
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, ".linear-label-needs-human.applied"), "");
+
+    // onRemoved throws — clearStalledLabel must not re-throw.
+    expect(() =>
+      clearStalledLabel(
+        orchDir, "CTL-1", "needs-human",
+        { removeLabel: () => ({ removed: true }) },
+        { onRemoved: () => { throw new Error("disk full"); } },
+      )
+    ).not.toThrow();
+    // The marker deletion still completed before onRemoved was called.
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(false);
+  });
 });
 
 // ─── CTL-936: labelOnce — operator-visible event on unrecoverable failure ────

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -80,6 +80,8 @@ import { readWorkerSignals } from "./signal-reader.mjs";
 // CTL-933: shadow belief-store fact collector (opt-in CATALYST_BELIEFS_SHADOW=1).
 // CTL-937: getBeliefsDb exposes the module-level db handle for the diagnostician.
 import { collectBeliefsTick, getBeliefsDb } from "./beliefs/collector.mjs";
+// CTL-1045 Bug 1: kill-storm suppression guard for defaultJanitorKillIntentRecorder.
+import { isIntentEffective, getMaxAttempts } from "./beliefs/intent.mjs";
 // CTL-966 + CTL-935: the advancement shadow comparator — compares the procedural
 // deriveAdvancement oracle against the advance_to / cycle_exhausted beliefs and
 // logs disagreements. SHADOW ONLY (reads beliefs + computes oracle + logs; never
@@ -2120,6 +2122,24 @@ function emitOrphanDetectedOnce(orchDir, ticket, signals, appendOrphanDetectedEv
 function defaultJanitorKillIntentRecorder(intentDb, killBgJob = defaultKillBgJob) {
   return ({ subject, bgJobId }) => {
     if (!subject || !bgJobId) return false;
+    // CTL-1045 Bug 1: suppress the stop when the kill intent has plateaued
+    // ineffective — mirrors intentAwareKill's isIntentEffective guard (recovery.mjs).
+    // NOT additionally gated on CATALYST_INTENTS_ENFORCE: the J2 kill only fires
+    // under CATALYST_STALL_JANITOR=enforce, and that mode must be storm-safe on its
+    // own. Fail-open when intentDb is null.
+    if (intentDb) {
+      try {
+        if (!isIntentEffective(intentDb, "kill", subject, { maxAttempts: getMaxAttempts(intentDb) })) {
+          log.warn(
+            { subject, bgJobId },
+            "stall-janitor: kill intent ineffective — skipping claude stop (CTL-1045 storm prevention)",
+          );
+          return false;
+        }
+      } catch (err) {
+        log.warn({ subject, err: err?.message }, "stall-janitor: isIntentEffective threw — continuing kill (CTL-1045)");
+      }
+    }
     // Issue the real stop FIRST so a record-failure can never swallow the kill
     // (intentAwareKill records-then-kills, but its record path is best-effort and
     // never short-circuits the kill either — here the kill is the load-bearing act).

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1645,7 +1645,7 @@ export function escalateDispatchExhausted(
   orchDir,
   ticket,
   phase,
-  { writeFile = writeFileSync, readFile = readFileSync } = {}
+  { writeFile = writeFileSync, readFile = readFileSync, code = null, cause = null } = {}
 ) {
   const dir = join(orchDir, "workers", ticket);
   const p = join(dir, `phase-${phase}.json`);
@@ -1666,6 +1666,8 @@ export function escalateDispatchExhausted(
         phase,
         status: "stalled",
         stalledReason: "prior-artifact-retry-exhausted",
+        dispatchFailureCode: code,   // CTL-1045 Bug 2: exit code that exhausted retries (2 = prior_artifact_missing)
+        dispatchFailureCause: cause, // CTL-1045 Bug 2: human-readable reason (observability)
         updatedAt: new Date().toISOString(),
       })
     );
@@ -2544,7 +2546,7 @@ export function schedulerTick(
       const cd = recordDispatchFailure(orchDir, ticket, phase, 0, now());
       if (fullFailureLadder) {
         if (cd.consecutiveFailures >= getMaxDispatchRetries())
-          escalateDispatchExhausted(orchDir, ticket, phase); // CTL-712 terminal stop
+          escalateDispatchExhausted(orchDir, ticket, phase, { code: 0, cause: reason }); // CTL-712 terminal stop; CTL-1045 Bug 2
         maybeTripCircuitBreaker(orchDir, ticket, phase); // CTL-671: trip same tick if at threshold
         appendDispatchFailedEvent({
           orchId: ticket,
@@ -2580,7 +2582,7 @@ export function schedulerTick(
     const cd = recordDispatchFailure(orchDir, ticket, phase, r.code, now()); // CTL-624: arm the cool-down window
     if (fullFailureLadder) {
       if (cd.consecutiveFailures >= getMaxDispatchRetries())
-        escalateDispatchExhausted(orchDir, ticket, phase); // CTL-712 terminal stop
+        escalateDispatchExhausted(orchDir, ticket, phase, { code: r.code, cause: reason }); // CTL-712 terminal stop; CTL-1045 Bug 2
       maybeTripCircuitBreaker(orchDir, ticket, phase); // CTL-671: trip same tick if at threshold
       // CTL-611 Gap 2: surface the silent drop as an event.
       appendDispatchFailedEvent({

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2196,10 +2196,12 @@ function defaultJanitorKillIntentRecorder(intentDb, killBgJob = defaultKillBgJob
 //      marker (clearStalledLabel) so a future genuine escalation can re-apply;
 //   3. delete .orphan-detected.applied (CTL-868) so a future stall re-emits the
 //      orphan-detected event instead of being silently suppressed;
-//   4. write the .janitor-cleared-<phase>.applied once-marker so a re-stall on the
-//      same phase this daemon lifetime is NOT re-cleared (operator review).
-// The once-marker is written LAST and unconditionally so even a partial clear is
-// not retried into a clear-storm — the gate is "did we ever clear this phase".
+//   4. write the .janitor-cleared-<phase>.applied once-marker ON CONFIRMED label
+//      removal only (CTL-1045 Bug 4). Scope is the worker-dir lifetime: file-backed,
+//      survives daemon restarts, deleted only when the reaper removes the worker dir
+//      or an operator re-arms via orch-monitor respond-ticket. Storm-prevention is
+//      preserved — the marker is still written at most once; a failed clear is
+//      intentionally left re-armable (a future genuine escalation must get through).
 function defaultClearStall(orchDir, writeStatus) {
   return ({ ticket, phase }) => {
     if (!ticket || !phase) return false;
@@ -2210,9 +2212,20 @@ function defaultClearStall(orchDir, writeStatus) {
     } catch (err) {
       log.warn({ ticket, phase, err: err?.message }, "stall-janitor: stalled-signal delete failed (CTL-1005)");
     }
-    // 2. clear the needs-human label + its once-marker (re-arms a future escalation).
+    // 2. clear the needs-human label; write the once-marker ONLY on confirmed removal
+    //    (CTL-1045 Bug 4 — a failed clear must NOT disarm future escalations).
     try {
-      clearStalledLabel(orchDir, ticket, "needs-human", writeStatus);
+      clearStalledLabel(orchDir, ticket, "needs-human", writeStatus, {
+        onRemoved: () => {
+          try {
+            mkdirSync(workerDir, { recursive: true });
+            // One clear per ticket per phase per worker-dir lifetime (CTL-1045 Bug 5).
+            writeFileSync(join(workerDir, `.janitor-cleared-${phase}.applied`), "");
+          } catch (err) {
+            log.warn({ ticket, phase, err: err?.message }, "stall-janitor: cleared-marker write failed (CTL-1005)");
+          }
+        },
+      });
     } catch (err) {
       log.warn({ ticket, phase, err: err?.message }, "stall-janitor: needs-human clear failed (CTL-1005)");
     }
@@ -2220,14 +2233,6 @@ function defaultClearStall(orchDir, writeStatus) {
     try {
       rmSync(join(workerDir, ".orphan-detected.applied"), { force: true });
     } catch { /* best-effort */ }
-    // 4. write the .janitor-cleared-<phase>.applied once-marker LAST (one clear per
-    //    ticket per phase per daemon lifetime — a re-stall is left for operators).
-    try {
-      mkdirSync(workerDir, { recursive: true });
-      writeFileSync(join(workerDir, `.janitor-cleared-${phase}.applied`), "");
-    } catch (err) {
-      log.warn({ ticket, phase, err: err?.message }, "stall-janitor: cleared-marker write failed (CTL-1005)");
-    }
     return true;
   };
 }

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1713,6 +1713,24 @@ describe("CTL-712: escalateDispatchExhausted — retry ceiling → stalled", () 
     escalateDispatchExhausted(orchDir, "CTL-712", "pr");
     expect(existsSync(dispatchCooldownPath(orchDir, "CTL-712", "pr"))).toBe(false);
   });
+
+  // CTL-1045 Bug 2: persist the dispatch failure exit code + cause so J3 can
+  // tell the benign prior-artifact-missing case (code 2) from verify_failed (0)
+  // or crash (≠ 2). A legacy signal without code stays operator-owned.
+  test("CTL-1045 Bug 2: persists dispatchFailureCode + dispatchFailureCause when provided", () => {
+    escalateDispatchExhausted(orchDir, "CTL-712", "pr", { code: 2, cause: "prior_artifact_missing:research_doc" });
+    const sig = JSON.parse(readFileSync(join(orchDir, "workers", "CTL-712", "phase-pr.json"), "utf8"));
+    expect(sig.stalledReason).toBe("prior-artifact-retry-exhausted");
+    expect(sig.dispatchFailureCode).toBe(2);
+    expect(sig.dispatchFailureCause).toBe("prior_artifact_missing:research_doc");
+  });
+
+  test("CTL-1045 Bug 2: defaults dispatchFailureCode / dispatchFailureCause to null when omitted (back-compat)", () => {
+    escalateDispatchExhausted(orchDir, "CTL-712", "pr");
+    const sig = JSON.parse(readFileSync(join(orchDir, "workers", "CTL-712", "phase-pr.json"), "utf8"));
+    expect(sig.dispatchFailureCode).toBeNull();
+    expect(sig.dispatchFailureCause).toBeNull();
+  });
 });
 
 // ─── CTL-712: dispatch retry ceiling wired into schedulerTick ───

--- a/plugins/dev/scripts/execution-core/stall-janitor.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.mjs
@@ -342,7 +342,7 @@ export function runStallJanitorPass({
       if (enforce) {
         // The clear is the executor: delete the synthetic stalled signal, clear
         // needs-human + .orphan-detected.applied, write .janitor-cleared-<phase>
-        // .applied (one clear per lifetime), and let the scheduler re-dispatch.
+        // .applied (one clear per worker-dir lifetime), and let the scheduler re-dispatch.
         clearStall({ ticket: c.ticket, phase: c.phase });
         fire(
           "janitor.stall.cleared",

--- a/plugins/dev/scripts/execution-core/stall-janitor.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.mjs
@@ -113,8 +113,10 @@ export function classifyGhostSession(ctx = {}) {
 // because the PRIOR-phase artifact was missing, then never re-checks whether the
 // artifact later arrived — the ticket freezes to needs-human permanently.
 //   "clear" — the prior artifact is now present AND complete (non-truncated), the
-//             Linear state is non-terminal, no live session owns the worktree, and
-//             we have not already cleared this phase once this daemon lifetime.
+//             Linear state is non-terminal, no live session owns the worktree,
+//             we have not already cleared this phase once this worker-dir lifetime,
+//             the stall was caused by prior-artifact-missing (exit code 2), and
+//             the prior-phase done signal still survives.
 //   "skip"  — anything else. Every gate fails CLOSED (stay frozen) — a borderline
 //             case is left for operator review, never force-unstuck.
 //
@@ -126,16 +128,32 @@ export function classifyGhostSession(ctx = {}) {
 //   artifactComplete       — …AND is non-truncated (existence alone is not enough;
 //                            re-walk artifact-validation precedent).
 //   alreadyCleared         — a .janitor-cleared-<phase>.applied marker is present.
+//   dispatchFailureCode    — CTL-1045 Bug 2: exit code that exhausted retries.
+//                            Only 2 (prior_artifact_missing) is clearable.
+//   priorDoneSignalPresent — CTL-1045 Bug 3: the prior-phase done signal survives;
+//                            without it a clear empties the worker dir → pipeline drop.
+
+// Exit code 2 is the phase-agent-dispatch structural refusal for a missing prior
+// artifact (PERMANENT_FAILURE_CODES in scheduler.mjs). It is the ONLY benign cause
+// that J3 is safe to auto-clear; any other code means re-dispatch would repeat the
+// same failure class.
+const PRIOR_ARTIFACT_MISSING_EXIT_CODE = 2;
+
 export function classifyStallClear(ctx = {}) {
   // Only the transient prior-artifact-retry-exhausted stall is auto-clearable.
   // A dispatch-circuit-breaker / phantom-ticket / any other stall is operator-owned.
   if (ctx.stalledReason !== "prior-artifact-retry-exhausted")
     return { action: "skip", reason: "not-retry-exhausted-reason" };
+  // CTL-1045 Bug 2: only the benign prior-artifact-missing exhaustion is clearable.
+  // A verify_failed (code 0) or crash (code ≠ 2) would re-dispatch into the same
+  // failure; a legacy signal (code null) is operator-owned (conservative default).
+  if (ctx.dispatchFailureCode !== PRIOR_ARTIFACT_MISSING_EXIT_CODE)
+    return { action: "skip", reason: "non-artifact-dispatch-cause" };
   // NEVER unstick a terminal/merged Linear ticket (the pipeline is genuinely done).
   if (ctx.linearTerminal) return { action: "skip", reason: "linear-terminal" };
   // NEVER touch a live worker (the safety fence, mirrors J1).
   if (ctx.liveSessionInWorktree) return { action: "skip", reason: "live-session-in-worktree" };
-  // One clear per ticket per phase per daemon lifetime — a re-stall after one
+  // One clear per ticket per phase per worker-dir lifetime — a re-stall after one
   // clear is left frozen for operator review (the Gherkin's re-stall scenario).
   if (ctx.alreadyCleared) return { action: "skip", reason: "already-cleared" };
   // The artifact must be PRESENT and COMPLETE — existence alone is not enough
@@ -143,6 +161,10 @@ export function classifyStallClear(ctx = {}) {
   // class; re-walk artifact-validation precedent).
   if (!ctx.artifactPresent) return { action: "skip", reason: "artifact-absent" };
   if (!ctx.artifactComplete) return { action: "skip", reason: "artifact-truncated" };
+  // CTL-1045 Bug 3: never empty a worker dir — the prior-phase done signal must
+  // survive the clear, else the next tick sees an empty signals map, isTicketInFlight
+  // returns false, and deriveAdvancement finds no `done` to advance from → silent drop.
+  if (!ctx.priorDoneSignalPresent) return { action: "skip", reason: "prior-done-signal-absent" };
   return { action: "clear", reason: "prior-artifact-now-complete" };
 }
 
@@ -638,7 +660,9 @@ export function defaultCollectStallClearCandidates({
     try {
       const workerDir = join(orchDir, "workers", ticket);
       // Find a `stalled` phase signal carrying the J3-relevant reason.
+      // Hoist stalledRaw so CTL-1045 Bug 2+3 can read its fields below.
       let stalledPhase = null;
+      let stalledRaw = null;
       for (const f of readdirSync(workerDir)) {
         const m = /^phase-(.+)\.json$/.exec(f);
         if (!m) continue;
@@ -646,6 +670,7 @@ export function defaultCollectStallClearCandidates({
         try { raw = JSON.parse(readFileSync(join(workerDir, f), "utf8")); } catch { continue; }
         if (raw?.status === "stalled" && raw?.stalledReason === "prior-artifact-retry-exhausted") {
           stalledPhase = m[1];
+          stalledRaw = raw;
           break;
         }
       }
@@ -668,6 +693,23 @@ export function defaultCollectStallClearCandidates({
         (artifactComplete ?? defaultPriorArtifactComplete)(probeCtx) === true;
       const present = artifactPresent ? artifactPresent(probeCtx) === true : complete;
 
+      // CTL-1045 Bug 2: read the persisted dispatch failure exit code from the signal.
+      // A signal without the field (older signals) gets null → treated as non-clearable.
+      const dispatchFailureCode =
+        typeof stalledRaw?.dispatchFailureCode === "number" ? stalledRaw.dispatchFailureCode : null;
+
+      // CTL-1045 Bug 3: verify the prior-phase done signal still exists.
+      // Without it, clearing the stalled signal leaves an empty worker dir → silent
+      // pipeline drop (isTicketInFlight sees no signals → deriveAdvancement finds no done).
+      const priorPhaseForStall = PRIOR_PHASE[stalledPhase];
+      let priorDoneSignalPresent = false;
+      if (priorPhaseForStall) {
+        try {
+          const pj = JSON.parse(readFileSync(join(workerDir, `phase-${priorPhaseForStall}.json`), "utf8"));
+          priorDoneSignalPresent = pj?.status === "done";
+        } catch { priorDoneSignalPresent = false; }
+      }
+
       out.push({
         ticket,
         phase: stalledPhase,
@@ -677,6 +719,8 @@ export function defaultCollectStallClearCandidates({
         artifactPresent: present,
         artifactComplete: complete,
         alreadyCleared,
+        dispatchFailureCode,       // CTL-1045 Bug 2
+        priorDoneSignalPresent,    // CTL-1045 Bug 3
         worktreePath,
       });
     } catch (err) {

--- a/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
@@ -357,6 +357,8 @@ describe("classifyStallClear (CTL-1005 J3)", () => {
     artifactPresent: true,
     artifactComplete: true, // existence + non-truncation
     alreadyCleared: false, // no .janitor-cleared-<phase>.applied marker yet
+    dispatchFailureCode: 2,       // CTL-1045 Bug 2: benign prior-artifact-missing exit code
+    priorDoneSignalPresent: true, // CTL-1045 Bug 3: prior-phase done signal survives
   };
 
   test("retry-exhausted stall + complete artifact + non-terminal + no live session → clear", () => {
@@ -393,10 +395,25 @@ describe("classifyStallClear (CTL-1005 J3)", () => {
     expect(d.reason).toMatch(/live/);
   });
 
-  test("already cleared once (.janitor-cleared marker present) → skip (one clear per lifetime)", () => {
+  test("already cleared once (.janitor-cleared marker present) → skip (one clear per worker-dir lifetime)", () => {
     const d = classifyStallClear({ ...base, alreadyCleared: true });
     expect(d.action).toBe("skip");
     expect(d.reason).toMatch(/already-cleared/);
+  });
+
+  // CTL-1045 Bug 2: only exit code 2 (prior_artifact_missing) is clearable.
+  test("CTL-1045 Bug 2: clear requires dispatchFailureCode === 2 (benign prior-artifact-missing)", () => {
+    expect(classifyStallClear({ ...base, dispatchFailureCode: 2 }).action).toBe("clear");
+    expect(classifyStallClear({ ...base, dispatchFailureCode: 0 }).action).toBe("skip");   // verify_failed
+    expect(classifyStallClear({ ...base, dispatchFailureCode: 1 }).action).toBe("skip");   // crash
+    expect(classifyStallClear({ ...base, dispatchFailureCode: null }).action).toBe("skip"); // legacy signal
+  });
+
+  // CTL-1045 Bug 3: never empty a worker dir — prior-phase done signal must survive.
+  test("CTL-1045 Bug 3: clear declines when the prior-phase done signal is absent", () => {
+    const d = classifyStallClear({ ...base, priorDoneSignalPresent: false });
+    expect(d.action).toBe("skip");
+    expect(d.reason).toBe("prior-done-signal-absent");
   });
 });
 
@@ -417,6 +434,8 @@ function makeStallWorld(overrides = {}) {
         artifactPresent: true,
         artifactComplete: true,
         alreadyCleared: false,
+        dispatchFailureCode: 2,       // CTL-1045 Bug 2
+        priorDoneSignalPresent: true, // CTL-1045 Bug 3
       },
     ],
     ...overrides,

--- a/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
@@ -835,4 +835,21 @@ describe("defaultCollectStallClearCandidates (CTL-1005 J3)", () => {
     });
     expect(out[0].alreadyCleared).toBe(true);
   });
+
+  // CTL-1045 Bug 5: doctrine guard — once-marker is file-backed and survives
+  // across daemon restarts (per worker-dir lifetime, NOT per daemon lifetime).
+  test("CTL-1045 Bug 5: once-marker survives across a simulated daemon restart (per worker-dir lifetime)", () => {
+    const d = mkStalled("CTL-854", "plan", { cleared: true });
+    // Simulate a daemon restart by constructing a fresh census call (new call stack,
+    // no module-level state persisted across the call).
+    const out = defaultCollectStallClearCandidates({
+      orchDir,
+      isLinearTerminal: () => false,
+      resolveWorktreePath: () => d,
+      artifactPresent: () => true,
+      artifactComplete: () => true,
+    });
+    // The marker file survives the restart — alreadyCleared reads true from disk.
+    expect(out[0].alreadyCleared).toBe(true);
+  });
 });

--- a/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
@@ -742,7 +742,7 @@ describe("defaultCollectStallClearCandidates (CTL-1005 J3)", () => {
     mkdirSync(d, { recursive: true });
     writeFileSync(
       join(d, `phase-${phase}.json`),
-      JSON.stringify({ ticket, phase, status: "stalled", stalledReason: reason }),
+      JSON.stringify({ ticket, phase, status: "stalled", stalledReason: reason, dispatchFailureCode: 2 }),
     );
     if (cleared) writeFileSync(join(d, `.janitor-cleared-${phase}.applied`), "");
     return d;


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-11T13:25:00Z -->
<!-- Last updated: 2026-06-11T13:25:00Z -->
<!-- PR: #1826 -->
<!-- Previous commits: 9ccfd34d,fecf96bc,38546c8d,e94f9b92,4945251f,86a383d6,b0646464 -->

## Summary

Enforce-readiness hardening for the stall-janitor: five latent bugs (all invisible in the default shadow mode, all real once `CATALYST_STALL_JANITOR=enforce`) fixed before the enforce flip is safe to make.

**Bug 1 (J2 kill-storm):** `defaultJanitorKillIntentRecorder` was missing the `isIntentEffective` guard that `intentAwareKill` already carried. A plateaued, ineffective kill intent (attempts ≥ maxAttempts) re-fired `claude stop` on every stall-janitor tick instead of being suppressed.

**Bug 2 (J3 wrong-cause):** `escalateDispatchExhausted` applied `prior-artifact-retry-exhausted` to *all* dispatch-exhaustion causes (verify_failed, crashes, prior-artifact-missing). J3 treated all of them as the benign "try again" case, potentially re-dispatching into a repeat failure.

**Bug 3 (J3 prior-signal gap):** J3's clear path never verified that the prior-phase done signal still existed. Deleting a stalled signal without a surviving prior-phase done signal leaves an empty worker dir → `isTicketInFlight` returns false → `deriveAdvancement` finds no `done` to advance from → silent pipeline drop.

**Bug 4 (once-marker on failed clear):** The `needs-human` label once-marker was written unconditionally, even when the Linear label removal failed. A transient API failure silently disarmed future genuine escalations.

**Bug 5 (once-marker doctrine):** Comments and tests described the `.janitor-cleared-<phase>.applied` marker as "per daemon lifetime" but it is a persistent disk file with per-worker-dir lifetime. The scope was corrected in all docs and a doctrine guard test was added.

## Changes Made

### `stall-janitor.mjs`

- `classifyStallClear`: two new gates — `dispatchFailureCode === 2` (only the benign prior-artifact-missing exit code is clearable) and `priorDoneSignalPresent` (prior-phase done signal must survive).
- `defaultCollectStallClearCandidates`: reads `dispatchFailureCode` from the stalled signal JSON and probes the prior-phase done signal file; both fields are passed into the census entry for `classifyStallClear`.
- Comment and string cleanups: "per daemon lifetime" → "per worker-dir lifetime" throughout.
- Added `PRIOR_ARTIFACT_MISSING_EXIT_CODE = 2` constant to name the structural refusal code.

### `scheduler.mjs`

- `escalateDispatchExhausted`: extended with `{ code, cause }` options; both dispatch call sites now pass the exit code and reason so the stalled signal carries `dispatchFailureCode` / `dispatchFailureCause`.

### `label-guard.mjs`

- `clearStalledLabel`: added `{ onRemoved }` callback option; the callback is invoked only on confirmed label removal. The J3 once-marker write is now passed as this callback so it is withheld on API failure.

### Test files

- `integration-ctl-1004.test.mjs`: promoted `prodTickOpts` helper to module scope (reused by CTL-1045 suppression tests); added three new tests for Bug 1 (effective/ineffective/null intentDb).
- `integration-ctl-1005.test.mjs`: added integration tests for Bugs 2, 3, and 4; updated existing fixtures to include `dispatchFailureCode: 2` and `priorDoneSignalPresent: true`.
- `stall-janitor.test.mjs`: added `classifyStallClear` unit tests for Bugs 2 and 3; once-marker doctrine guard test (Bug 5); updated `mkStalled` fixture and `makeStallWorld` defaults.
- `label-guard.test.mjs`: added unit tests for the `onRemoved` callback (called only on confirmed removal, swallows onRemoved throws).
- `scheduler.test.mjs`: added tests verifying `dispatchFailureCode`/`dispatchFailureCause` are persisted onto the stalled signal.

## How to Verify It

- [x] Tests pass: `bun test stall-janitor.test.mjs scheduler.test.mjs label-guard.test.mjs` — **545 pass, 0 fail** ✅
- [x] Integration tests pass (CTL-1004, CTL-1005 suites) ✅
- [ ] Flip `CATALYST_STALL_JANITOR=enforce` in a dev environment and confirm no kill-storm on a plateaued ghost session (manual)
- [ ] Verify a `prior-artifact-retry-exhausted` stall with `dispatchFailureCode: 0` stays frozen after the patch (manual)

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1045
- Precondition for enabling stall-janitor enforce mode
- Based on adversarial review findings from #1821 (CTL-1005)
