### PR TITLE
CTL-866: Phase workers in multi-host cluster sync thoughts before handoff

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-thoughts-sync-ordering.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-thoughts-sync-ordering.test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# CTL-866: assert thoughts-sync-gate is wired into phase-research and phase-plan
+# and that the call site precedes --status complete.
+# Run: bash plugins/dev/scripts/__tests__/phase-thoughts-sync-ordering.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILLS_DIR="${REPO_ROOT}/plugins/dev/skills"
+
+FAILURES=0
+PASSES=0
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+for skill in phase-research phase-plan; do
+  f="${SKILLS_DIR}/${skill}/SKILL.md"
+
+  # 1. Gate is referenced in the skill
+  echo "Test: ${skill} references thoughts-sync-gate.sh"
+  if grep -q "thoughts-sync-gate.sh" "$f"; then
+    pass "${skill} references thoughts-sync-gate.sh"
+  else
+    fail "${skill} references thoughts-sync-gate.sh" \
+      "thoughts-sync-gate.sh not found in ${f}"
+  fi
+
+  # 2. Gate line precedes the first --status complete emit-complete call
+  echo "Test: ${skill} — gate call is before --status complete"
+  gate_line=$(grep -n "thoughts-sync-gate.sh" "$f" | head -1 | cut -d: -f1)
+  complete_line=$(grep -n -- "--status complete" "$f" | head -1 | cut -d: -f1)
+  if [[ -z "$gate_line" ]]; then
+    fail "${skill} gate ordering: gate not found"
+  elif [[ -z "$complete_line" ]]; then
+    fail "${skill} gate ordering: --status complete not found"
+  elif [[ "$gate_line" -lt "$complete_line" ]]; then
+    pass "${skill} gate (line ${gate_line}) before --status complete (line ${complete_line})"
+  else
+    fail "${skill} gate ordering: gate (line ${gate_line}) is NOT before --status complete (line ${complete_line})"
+  fi
+
+  # 3. Skill does NOT inline raw `humanlayer thoughts sync` (must go through the gate)
+  echo "Test: ${skill} does not inline raw humanlayer thoughts sync"
+  if grep -q "humanlayer thoughts sync" "$f"; then
+    fail "${skill} does not inline raw humanlayer thoughts sync" \
+      "found raw 'humanlayer thoughts sync' in ${f} — must go through the gate"
+  else
+    pass "${skill} does not inline raw humanlayer thoughts sync"
+  fi
+done
+
+echo ""
+echo "Results: $PASSES passed, $FAILURES failed"
+[[ $FAILURES -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/thoughts-sync-gate.test.sh
+++ b/plugins/dev/scripts/__tests__/thoughts-sync-gate.test.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# CTL-866: tests for plugins/dev/scripts/lib/thoughts-sync-gate.sh
+# Run: bash plugins/dev/scripts/__tests__/thoughts-sync-gate.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+GATE="${REPO_ROOT}/plugins/dev/scripts/lib/thoughts-sync-gate.sh"
+
+FAILURES=0
+PASSES=0
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+# --------------------------------------------------------------------------
+# Helpers: build a temp workspace with injectable hosts.json + fakes
+# --------------------------------------------------------------------------
+setup_workdir() {
+  local dir
+  dir="$(mktemp -d)"
+  mkdir -p "${dir}/.catalyst"
+  echo "$dir"
+}
+
+# Write hosts.json to the workdir's .catalyst/
+write_hosts() {
+  local workdir="$1" json="$2"
+  printf '%s\n' "$json" > "${workdir}/.catalyst/hosts.json"
+}
+
+# Create a fake humanlayer on PATH that exits with given code.
+# Optionally touch a sentinel file on invocation.
+make_fake_humanlayer() {
+  local bindir="$1" exit_code="$2" sentinel="${3:-}"
+  cat > "${bindir}/humanlayer" <<EOF
+#!/usr/bin/env bash
+[ -n "${sentinel:-}" ] && touch "${sentinel}"
+exit ${exit_code}
+EOF
+  chmod +x "${bindir}/humanlayer"
+}
+
+# Create a fake phase-agent-emit-complete that logs args to a file.
+make_fake_emit() {
+  local bindir="$1" logfile="$2"
+  cat > "${bindir}/phase-agent-emit-complete" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${logfile}"
+exit 0
+EOF
+  chmod +x "${bindir}/phase-agent-emit-complete"
+}
+
+# --------------------------------------------------------------------------
+# Test 1: single-host roster → exit 0, humanlayer NOT invoked
+# --------------------------------------------------------------------------
+echo "Test: single-host roster → exit 0, humanlayer not invoked"
+{
+  WD="$(setup_workdir)"
+  BINDIR="${WD}/bin"
+  mkdir -p "$BINDIR"
+  SENTINEL="${WD}/humanlayer_called"
+  write_hosts "$WD" '["mini"]'
+  make_fake_humanlayer "$BINDIR" 0 "$SENTINEL"
+  make_fake_emit "$BINDIR" "${WD}/emit.log"
+  rc=0
+  env PATH="${BINDIR}:${PATH}" \
+      CATALYST_CONFIG_FILE="${WD}/.catalyst/config.json" \
+      CATALYST_EMIT_COMPLETE="${BINDIR}/phase-agent-emit-complete" \
+      bash "$GATE" --phase research --ticket CTL-TEST || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    fail "single-host roster: gate exited $rc, want 0"
+  elif [[ -f "$SENTINEL" ]]; then
+    fail "single-host roster: humanlayer was invoked (sentinel present)"
+  else
+    pass "single-host roster → exit 0, humanlayer not invoked"
+  fi
+  rm -rf "$WD"
+}
+
+# --------------------------------------------------------------------------
+# Test 2: absent hosts.json → treated as single-host → exit 0, no sync
+# --------------------------------------------------------------------------
+echo "Test: absent hosts.json → single-host no-op"
+{
+  WD="$(setup_workdir)"
+  BINDIR="${WD}/bin"
+  mkdir -p "$BINDIR"
+  SENTINEL="${WD}/humanlayer_called"
+  # No hosts.json written
+  make_fake_humanlayer "$BINDIR" 0 "$SENTINEL"
+  make_fake_emit "$BINDIR" "${WD}/emit.log"
+  rc=0
+  env PATH="${BINDIR}:${PATH}" \
+      CATALYST_CONFIG_FILE="${WD}/.catalyst/config.json" \
+      CATALYST_EMIT_COMPLETE="${BINDIR}/phase-agent-emit-complete" \
+      bash "$GATE" --phase research --ticket CTL-TEST || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    fail "absent hosts.json: gate exited $rc, want 0"
+  elif [[ -f "$SENTINEL" ]]; then
+    fail "absent hosts.json: humanlayer was invoked (sentinel present)"
+  else
+    pass "absent hosts.json → exit 0, no sync"
+  fi
+  rm -rf "$WD"
+}
+
+# --------------------------------------------------------------------------
+# Test 3: malformed hosts.json → treated as single-host → exit 0, no sync
+# --------------------------------------------------------------------------
+echo "Test: malformed hosts.json → single-host no-op"
+{
+  WD="$(setup_workdir)"
+  BINDIR="${WD}/bin"
+  mkdir -p "$BINDIR"
+  SENTINEL="${WD}/humanlayer_called"
+  write_hosts "$WD" 'not-valid-json'
+  make_fake_humanlayer "$BINDIR" 0 "$SENTINEL"
+  make_fake_emit "$BINDIR" "${WD}/emit.log"
+  rc=0
+  env PATH="${BINDIR}:${PATH}" \
+      CATALYST_CONFIG_FILE="${WD}/.catalyst/config.json" \
+      CATALYST_EMIT_COMPLETE="${BINDIR}/phase-agent-emit-complete" \
+      bash "$GATE" --phase research --ticket CTL-TEST || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    fail "malformed hosts.json: gate exited $rc, want 0"
+  elif [[ -f "$SENTINEL" ]]; then
+    fail "malformed hosts.json: humanlayer was invoked (sentinel present)"
+  else
+    pass "malformed hosts.json → exit 0, no sync"
+  fi
+  rm -rf "$WD"
+}
+
+# --------------------------------------------------------------------------
+# Test 4: multi-host roster + sync success → exit 0
+# --------------------------------------------------------------------------
+echo "Test: multi-host roster + sync success → exit 0"
+{
+  WD="$(setup_workdir)"
+  BINDIR="${WD}/bin"
+  mkdir -p "$BINDIR"
+  SENTINEL="${WD}/humanlayer_called"
+  write_hosts "$WD" '["mini","mac-studio"]'
+  make_fake_humanlayer "$BINDIR" 0 "$SENTINEL"
+  make_fake_emit "$BINDIR" "${WD}/emit.log"
+  rc=0
+  env PATH="${BINDIR}:${PATH}" \
+      CATALYST_CONFIG_FILE="${WD}/.catalyst/config.json" \
+      CATALYST_EMIT_COMPLETE="${BINDIR}/phase-agent-emit-complete" \
+      bash "$GATE" --phase research --ticket CTL-TEST || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    fail "multi-host + sync success: gate exited $rc, want 0"
+  elif [[ ! -f "$SENTINEL" ]]; then
+    fail "multi-host + sync success: humanlayer was NOT invoked"
+  else
+    pass "multi-host roster + sync success → exit 0"
+  fi
+  rm -rf "$WD"
+}
+
+# --------------------------------------------------------------------------
+# Test 5: multi-host + sync failure → exits non-zero, emit-complete called
+#         with --reason thoughts_sync_failed
+# --------------------------------------------------------------------------
+echo "Test: multi-host + sync failure → non-zero exit, emit-complete called"
+{
+  WD="$(setup_workdir)"
+  BINDIR="${WD}/bin"
+  EMIT_LOG="${WD}/emit.log"
+  mkdir -p "$BINDIR"
+  write_hosts "$WD" '["mini","mac-studio"]'
+  make_fake_humanlayer "$BINDIR" 1 ""
+  make_fake_emit "$BINDIR" "$EMIT_LOG"
+  rc=0
+  env PATH="${BINDIR}:${PATH}" \
+      CATALYST_CONFIG_FILE="${WD}/.catalyst/config.json" \
+      CATALYST_EMIT_COMPLETE="${BINDIR}/phase-agent-emit-complete" \
+      bash "$GATE" --phase research --ticket CTL-TEST || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    fail "multi-host + sync failure: gate exited 0, want non-zero"
+  elif [[ ! -f "$EMIT_LOG" ]]; then
+    fail "multi-host + sync failure: emit-complete was not called"
+  elif ! grep -q "thoughts_sync_failed" "$EMIT_LOG"; then
+    fail "multi-host + sync failure: emit-complete not called with --reason thoughts_sync_failed" \
+      "emit log: $(cat "$EMIT_LOG")"
+  else
+    pass "multi-host + sync failure → non-zero exit, emit-complete with thoughts_sync_failed"
+  fi
+  rm -rf "$WD"
+}
+
+# --------------------------------------------------------------------------
+echo ""
+echo "Results: $PASSES passed, $FAILURES failed"
+[[ $FAILURES -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -2823,6 +2823,7 @@ export async function reclaimDeadHostWork(
       const result = defaultRebuildWorktree(ticket, { orchDir });
       return result;
     },
+    thoughtsPull = (cwd) => defaultThoughtsPull(cwd),
     dispatch = (od, ticket, phase, cwd) =>
       dispatchTicket(od, ticket, phase, { dispatch: defaultDispatch }),
   } = {},
@@ -2852,6 +2853,12 @@ export async function reclaimDeadHostWork(
       const wt = rebuildWorktree(ticket);
       if (!wt?.ok) continue;
 
+      // CTL-866: refresh thoughts/ before the artifact probes read it, so a
+      // takeover host sees the dead host's pushed research/plan docs.
+      // Fail-open: a failed pull must not abort reclaim (worst case the probe
+      // re-dispatches, the prior behavior).
+      try { thoughtsPull(wt.cwd); } catch { /* fail-open */ }
+
       // Infer the next phase to dispatch from durable artifacts.
       const phase = await inferResume(ticket, wt.cwd);
       if (!phase) continue; // terminal — nothing to resume
@@ -2867,6 +2874,19 @@ export async function reclaimDeadHostWork(
   }
 
   return { taken };
+}
+
+// defaultThoughtsPull — refresh the thoughts/ git repo inside the rebuilt
+// worktree before artifact probes read it. Best-effort; `humanlayer thoughts
+// sync` is the available primitive (no `thoughts pull` subcommand exists).
+// Returns { ok }. Never throws (caller also guards).
+function defaultThoughtsPull(cwd) {
+  try {
+    const res = spawnSync("humanlayer", ["thoughts", "sync"], { cwd, stdio: "ignore" });
+    return { ok: res.status === 0 };
+  } catch {
+    return { ok: false };
+  }
 }
 
 // defaultRebuildWorktree — fetch the ticket branch and add/reuse the worktree.

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -4461,6 +4461,48 @@ describe("reclaimDeadHostWork — takeover sweep (CTL-863)", () => {
   });
 });
 
+// ─── CTL-866: thoughtsPull seam in reclaimDeadHostWork ───────────────────────
+
+describe("reclaimDeadHostWork — thoughtsPull seam (CTL-866)", () => {
+  test("CTL-866: thoughtsPull runs after rebuildWorktree and before inferResume", async () => {
+    const order = [];
+    await reclaimDeadHostWork({ orchDir: "/o" }, makeBaseDeps({
+      rebuildWorktree: () => { order.push("rebuild"); return { ok: true, cwd: "/wt/CTL-900" }; },
+      thoughtsPull: (cwd) => { order.push(`pull:${cwd}`); return { ok: true }; },
+      inferResume: async () => { order.push("infer"); return "implement"; },
+    }));
+    expect(order).toEqual(["rebuild", "pull:/wt/CTL-900", "infer"]);
+  });
+
+  test("CTL-866: thoughtsPull failure is fail-open — reclaim still dispatches", async () => {
+    let dispatched = false;
+    const r = await reclaimDeadHostWork({ orchDir: "/o" }, makeBaseDeps({
+      thoughtsPull: () => { throw new Error("pull boom"); },
+      dispatch: () => { dispatched = true; return { code: 0 }; },
+    }));
+    expect(dispatched).toBe(true);
+    expect(r.taken).toHaveLength(1);
+  });
+
+  test("CTL-866: single-host roster → no thoughtsPull (whole fn short-circuits)", async () => {
+    let pulled = false;
+    await reclaimDeadHostWork({ orchDir: "/o" }, makeBaseDeps({
+      roster: ["mini"],
+      thoughtsPull: () => { pulled = true; return { ok: true }; },
+    }));
+    expect(pulled).toBe(false);
+  });
+
+  test("CTL-866: rebuildWorktree failure → thoughtsPull NOT called (skipped with the ticket)", async () => {
+    let pulled = false;
+    await reclaimDeadHostWork({ orchDir: "/o" }, makeBaseDeps({
+      rebuildWorktree: () => ({ ok: false, cwd: null }),
+      thoughtsPull: () => { pulled = true; return { ok: true }; },
+    }));
+    expect(pulled).toBe(false);
+  });
+});
+
 // CTL-778 Step 3 — alive-probe-reclaim: an alive worker that has emitted
 // phase.<phase>.complete AND whose probe passes is reconciled without waiting
 // for it to die. The completeEventSeen seam is the precise disambiguator

--- a/plugins/dev/scripts/lib/thoughts-sync-gate.sh
+++ b/plugins/dev/scripts/lib/thoughts-sync-gate.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# thoughts-sync-gate.sh (CTL-866) — multi-host thoughts-sync gate for the
+# write side of research/plan phases. Single source of truth, called from
+# phase-research and phase-plan immediately before phase-agent-emit-complete.
+#
+#   "${PLUGIN_ROOT}/scripts/lib/thoughts-sync-gate.sh" --phase "$PHASE" --ticket "$TICKET" || exit 11
+#
+# Contract:
+#   roster <= 1 (single-host / absent / malformed hosts.json) → exit 0  (exact no-op, no sync)
+#   roster  > 1 + `humanlayer thoughts sync` exit 0           → exit 0  (artifact pushed; proceed)
+#   roster  > 1 + sync failure                                → emit `failed`
+#                                                               (reason thoughts_sync_failed), exit 11
+set -uo pipefail
+PHASE="" TICKET=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --phase)  PHASE="$2"; shift 2 ;;
+    --ticket) TICKET="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+# Resolve roster (mirror getClusterHosts: absent/malformed → single-host default).
+CFG_DIR="$(dirname "${CATALYST_CONFIG_FILE:-$(pwd)/.catalyst/config.json}")"
+HOSTS_FILE="${CFG_DIR}/hosts.json"
+ROSTER_SIZE=1
+if [[ -f "$HOSTS_FILE" ]]; then
+  n="$(jq -r '[.[] | select(type=="string" and length>0)] | length' "$HOSTS_FILE" 2>/dev/null || echo 0)"
+  [[ "$n" =~ ^[0-9]+$ && "$n" -gt 0 ]] && ROSTER_SIZE="$n"
+fi
+[[ "$ROSTER_SIZE" -le 1 ]] && exit 0   # single-host → exact no-op
+
+# Multi-host: sync (commit+push) MUST succeed before the caller emits complete.
+if humanlayer thoughts sync >/dev/null 2>&1; then
+  exit 0
+fi
+
+echo "${PHASE}: thoughts sync failed (roster=${ROSTER_SIZE}) — not emitting complete" >&2
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "${SELF_DIR}/../.." && pwd)}"
+EMIT="${CATALYST_EMIT_COMPLETE:-${PLUGIN_ROOT}/scripts/phase-agent-emit-complete}"
+"${EMIT}" --phase "$PHASE" --ticket "$TICKET" --status failed \
+  --reason "thoughts_sync_failed" || true
+exit 11

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -264,6 +264,11 @@ EOF
 ```
 
 ```bash
+# CTL-866: multi-host thoughts-sync gate. Single-host → exact no-op. Multi-host
+# → commit+push the plan artifact before any other host can read the
+# completion event; on sync failure the gate emits `failed` and we stop here.
+"${PLUGIN_ROOT}/scripts/lib/thoughts-sync-gate.sh" --phase "$PHASE" --ticket "$TICKET" || exit 11
+
 "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
   --phase "$PHASE" --ticket "$TICKET" --status complete
 

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -279,6 +279,11 @@ label differs here). The `$(date +%Y-%m-%dT%H:%M:%S%z)` stamp carries DATE+TIME+
 daily review sorts "friction since last review" by this per-record timestamp.
 
 ```bash
+# CTL-866: multi-host thoughts-sync gate. Single-host → exact no-op. Multi-host
+# → commit+push the research artifact before any other host can read the
+# completion event; on sync failure the gate emits `failed` and we stop here.
+"${PLUGIN_ROOT}/scripts/lib/thoughts-sync-gate.sh" --phase "$PHASE" --ticket "$TICKET" || exit 11
+
 # Emit phase-complete event, close signal file, end catalyst-session.
 "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
   --phase "$PHASE" --ticket "$TICKET" --status complete


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-11T14:09:00Z -->
<!-- Last updated: 2026-06-11T14:09:00Z -->
<!-- PR: #1828 -->
<!-- Previous commits: e652453f -->

## Summary

Adds a thoughts-sync gate that ensures research and plan phase workers commit and push their artifacts to the `thoughts/` git repo before emitting `phase-complete`. In a multi-host cluster, a second host picking up a ticket must find those artifacts already committed to the remote — without this gate, the next phase would start on a stale or absent prior-artifact and silently fail.

Single-host clusters short-circuit the gate entirely: behavior is identical to the pre-patch path, with zero added latency.

A companion change wires a `thoughtsPull` injectable seam into `reclaimDeadHostWork`, pulling the remote `thoughts/` repo into the rebuilt worktree between `rebuildWorktree` and `inferResume` so that artifact probes during a dead-host takeover see the departed host's pushed output.

## Changes Made

### `plugins/dev/scripts/lib/thoughts-sync-gate.sh` (new)

Shared bash helper. Reads `.catalyst/hosts.json`; if roster count is 1 (or the file is absent/malformed), exits 0 immediately. Otherwise runs `humanlayer thoughts sync` (commit + push) and propagates its exit code. Designed to be sourced or called as a subprocess from any phase end-block; the gate is the single source of truth for sync logic.

### `plugins/dev/skills/phase-research/SKILL.md` and `phase-plan/SKILL.md`

Five-line addition to each: invoke `thoughts-sync-gate.sh --phase <phase> --ticket <ticket>` immediately before `phase-agent-emit-complete --status complete`. Gate failure blocks the emit, which triggers the phase-agent retry / stall-janitor path rather than letting a partial artifact leak downstream.

### `plugins/dev/scripts/execution-core/recovery.mjs`

Adds a `thoughtsPull` injectable seam to `reclaimDeadHostWork`. The default implementation calls `humanlayer thoughts pull`; callers can inject a stub for testing. The pull runs after `rebuildWorktree` and before `inferResume`, matching the ordering requirement: worktree must exist before `thoughts/` can be placed inside it, and the artifact must be present before phase inference reads it. Fail-open: a pull failure logs a warning but does not abort the reclaim.

### Test files

- `thoughts-sync-gate.test.sh` (new, 5 cases): roster=1 no-op, absent hosts.json no-op, malformed hosts.json no-op, sync-success path, sync-failure propagation.
- `phase-thoughts-sync-ordering.test.sh` (new, 6 assertions): verifies that `thoughts-sync-gate.sh` is referenced in both skill files and that the call site precedes `--status complete`; also asserts raw `humanlayer thoughts sync` is not inlined (must go through the gate).
- `recovery.test.mjs` (4 new assertions): `thoughtsPull` ordering after `rebuildWorktree` and before `inferResume`; fail-open on pull failure; single-host short-circuit; `rebuildWorktree`-failure skip guard.

## How to Verify It

- [x] `thoughts-sync-gate.test.sh`: 5/5 pass ✅
- [x] `phase-thoughts-sync-ordering.test.sh`: 6/6 pass ✅
- [x] `recovery.test.mjs` (full suite including 4 new CTL-866 thoughtsPull tests): 248/248 pass ✅
- [x] Lint: `bash -n` clean on all 3 shell files; `node --check` clean on recovery files ✅
- [x] Security: no shell-injection (humanlayer args are static; PHASE/TICKET passed as quoted args) ✅
- [ ] Multi-host live test: start two hosts, run a research phase on host A, kill host A mid-run, confirm host B's reclaim finds the research artifact in `thoughts/` after pulling (manual — requires two-host environment)

## Related Issues/PRs

- Fixes https://linear.app/rozich/issue/CTL-866
- Part of the distributed-orchestrator coordination epic (#1821 — CTL-1005 / CTL-1004)

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1004
skip CTL-1005
