### PR TITLE
fix(dev): CTL-1046 cross-team rows show titles on the control tower

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/cross-team-title-fallback.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cross-team-title-fallback.test.ts
@@ -1,0 +1,130 @@
+// cross-team-title-fallback.test.ts — CTL-1046: the control-tower waiting / dead
+// lists must show the Linear TITLE for EVERY team's rows, not just CTL.
+//
+// The bug: CTL tickets carry their Linear title via the eligible projection
+// (eligible/CTL.json → eligibleIndex[id].title), but cross-team records (ADV)
+// reach the payload only through ticket_state — which has NO title column — AND
+// have no eligible entry (ADV's eligible/<TEAM>.json is empty). So linfo[id].title
+// and eligibleIndex[id].title are BOTH null for ADV, and ticketTitle() falls
+// through to triage.summary (the DESCRIPTION). That is exactly why ADV-1352
+// rendered "The jobs calendar opens empty because…" (description) instead of
+// "Demo data should stay current…" (title).
+//
+// The fix (data layer, not another component fallback): assembleBoard() now
+// collects every board ID whose title is null from BOTH sources, batch-fetches the
+// real Linear titles (cross-team aware, fail-open — see linear-title-description-
+// fallback.test.ts for the fetch contract), and merges them into linfo so
+// ticketTitle() returns the Linear title for ALL teams.
+//
+// This file drives the two NEW pure pieces CTL-1046 adds to assembleBoard()'s
+// title-fallback block — collectNullTitleIds and mergeTitleFallback — and asserts
+// the end-to-end title resolution through ticketTitle() for a MIXED CTL + ADV
+// fixture. It deliberately exercises the merge with a pre-built `fetched` map
+// (exactly the shape fillTitleDescriptionFallback returns) rather than swapping
+// globalThis.fetch — the network path already has its own suite, and a global-fetch
+// swap here would race other concurrently-running test files' fetch mocks.
+import { describe, expect, it } from "bun:test";
+import {
+  collectNullTitleIds,
+  mergeTitleFallback,
+  ticketTitle,
+} from "../lib/board-data.mjs";
+
+// The per-ID shape fillTitleDescriptionFallback resolves to (title is the field
+// the merge consumes; the rest ride along on the board-detail path).
+function fetchedTitle(title: string | null) {
+  return { title, description: null, labels: null, relations: null };
+}
+
+describe("collectNullTitleIds (CTL-1046) — only IDs missing a title in BOTH sources", () => {
+  it("skips IDs covered by linfo OR eligible, flags the rest, de-dupes", () => {
+    const linfo = { "CTL-700": { title: "CTL durable title" }, "ADV-1352": { title: null } };
+    const eligibleIndex = { "CTL-764": { title: "CTL eligible title" } };
+    const boardIds = ["CTL-700", "CTL-764", "ADV-1352", "ADV-1352"]; // dup ADV
+
+    // CTL-700 (linfo title) and CTL-764 (eligible title) are covered; ADV-1352 is
+    // not, and the duplicate collapses.
+    expect(collectNullTitleIds(boardIds, linfo, eligibleIndex)).toEqual(["ADV-1352"]);
+  });
+
+  it("flags an ID with no linfo entry at all (eligible-only, no ticket_state row)", () => {
+    expect(collectNullTitleIds(["ADV-999"], {}, {})).toEqual(["ADV-999"]);
+  });
+
+  it("treats an empty-string title as present (does not re-fetch a real-but-empty title)", () => {
+    // ?? only coalesces null/undefined — an empty title is a value, left alone.
+    expect(collectNullTitleIds(["CTL-1"], { "CTL-1": { title: "" } }, {})).toEqual([]);
+  });
+});
+
+describe("mergeTitleFallback (CTL-1046) — merge fetched Linear titles into linfo", () => {
+  it("writes a fetched title onto an existing linfo entry, preserving other fields", () => {
+    const linfo: Record<string, { title: string | null; priority?: number }> = {
+      "ADV-1352": { title: null, priority: 2 },
+    };
+    mergeTitleFallback(linfo, ["ADV-1352"], { "ADV-1352": fetchedTitle("Demo data should stay current") });
+    expect(linfo["ADV-1352"].title).toBe("Demo data should stay current");
+    expect(linfo["ADV-1352"].priority).toBe(2); // merge, not replace
+  });
+
+  it("creates a linfo entry for an eligible-only ticket with no ticket_state row", () => {
+    const linfo: Record<string, { title: string | null }> = {};
+    mergeTitleFallback(linfo, ["ADV-999"], { "ADV-999": fetchedTitle("ADV ticket, no local linfo") });
+    expect(linfo["ADV-999"]).toBeDefined();
+    expect(linfo["ADV-999"].title).toBe("ADV ticket, no local linfo");
+  });
+
+  it("is a no-op (honest null) when Linear had no title — fail-open, no throw", () => {
+    const linfo: Record<string, { title: string | null }> = { "ADV-1352": { title: null } };
+    expect(() => mergeTitleFallback(linfo, ["ADV-1352"], { "ADV-1352": fetchedTitle(null) })).not.toThrow();
+    expect(linfo["ADV-1352"].title).toBeNull();
+    // A totally absent fetched entry is tolerated too (whole-batch fetch failure).
+    expect(() => mergeTitleFallback(linfo, ["ADV-1352"], {})).not.toThrow();
+    expect(linfo["ADV-1352"].title).toBeNull();
+  });
+});
+
+describe("end-to-end title resolution for a MIXED CTL + ADV fixture (CTL-1046)", () => {
+  it("both teams render their Linear title after the fallback — the bug repro", () => {
+    // ADV-1352: ticket_state row exists (so it's on the board) but title is null,
+    // and it has no eligible entry. CTL-764 already has its title from eligible.
+    const linfo: Record<string, { title: string | null }> = {
+      "ADV-1352": { title: null }, // ticket_state row, no title column
+      "CTL-764": { title: null }, // title comes from eligible, not linfo
+    };
+    const eligibleIndex = {
+      "CTL-764": { title: "The daemon should record every worker state transition" },
+    };
+    const advTriage = {
+      summary: "The jobs calendar opens empty because every demo job is scheduled in the past",
+    };
+    const ADV_TITLE = "Demo data should stay current: future jobs scheduled through September";
+
+    // BEFORE: ADV-1352 falls through to its description (the CTL-1046 bug).
+    expect(ticketTitle("ADV-1352", advTriage, eligibleIndex, linfo)).toBe(advTriage.summary);
+
+    // The assembleBoard title-fallback block: collect → (fetch) → merge.
+    const ids = collectNullTitleIds(["ADV-1352", "CTL-764"], linfo, eligibleIndex);
+    expect(ids).toEqual(["ADV-1352"]); // CTL-764 already covered by eligible — not fetched
+    // The fetched map is exactly what fillTitleDescriptionFallback returns for `ids`.
+    mergeTitleFallback(linfo, ids, { "ADV-1352": fetchedTitle(ADV_TITLE) });
+
+    // AFTER: both teams resolve to their real Linear title — neither a description.
+    expect(ticketTitle("ADV-1352", advTriage, eligibleIndex, linfo)).toBe(ADV_TITLE);
+    expect(ticketTitle("CTL-764", { summary: "irrelevant desc" }, eligibleIndex, linfo)).toBe(
+      "The daemon should record every worker state transition",
+    );
+  });
+
+  it("a record genuinely missing a title still falls back honestly (summary, not crash)", () => {
+    const linfo: Record<string, { title: string | null }> = { "ADV-1352": { title: null } };
+    const triage = { summary: "honest description fallback" };
+
+    const ids = collectNullTitleIds(["ADV-1352"], linfo, {});
+    // Linear returned nothing for it (not found) → honest null merge.
+    mergeTitleFallback(linfo, ids, { "ADV-1352": fetchedTitle(null) });
+
+    expect(linfo["ADV-1352"].title).toBeNull();
+    expect(ticketTitle("ADV-1352", triage, {}, linfo)).toBe("honest description fallback");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -322,6 +322,23 @@ export function ticketTitle(
   eligibleIndex: Record<string, { title?: string | null } | undefined>,
   linfo?: Record<string, { title?: string | null } | undefined>,
 ): string;
+/** CTL-1046: board IDs whose title is null in BOTH sources ticketTitle() consults
+ *  (durable linfo cache + eligible projection) — i.e. cross-team (ADV) records that
+ *  reach the payload via ticket_state (no title column) with no eligible entry.
+ *  De-duped, order preserved. */
+export function collectNullTitleIds(
+  boardIds: string[],
+  linfo?: Record<string, { title?: string | null } | undefined>,
+  eligibleIndex?: Record<string, { title?: string | null } | undefined>,
+): string[];
+/** CTL-1046: merge fetched Linear titles into linfo in-place (creates a linfo entry
+ *  for eligible-only tickets). A null fetched title is left untouched (honest null).
+ *  Returns the mutated linfo. */
+export function mergeTitleFallback(
+  linfo: Record<string, { title?: string | null } & Record<string, unknown>>,
+  nullTitleIds: string[],
+  fetched: Record<string, { title?: string | null } | undefined>,
+): Record<string, { title?: string | null } & Record<string, unknown>>;
 export function assembleBoard(): Promise<BoardPayload>;
 /** CTL-922 (BFF10): build a {name,id} HostRef from a bare host name (id =
  *  sha256(name)[:16]); null for a null/empty name. */

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -23,6 +23,15 @@ import { join, dirname } from "node:path";
 import { promisify } from "node:util";
 import { readLinearCache } from "./linear-cache-reader.mjs";
 import { fillEstimateFallback, getEstimationMethodAsync } from "./linear-estimate-fallback.mjs";
+// CTL-1046: supplemental Linear-title fallback for cross-team (e.g. ADV) records.
+// CTL records carry their title via the eligible projection (eligible/CTL.json),
+// but ADV records reach the payload only through ticket_state (no title column)
+// and have NO eligible entry → linfo[id].title === null → ticketTitle() falls
+// through to triage.summary (the DESCRIPTION), which is the CTL-1046 bug. This
+// batched, TTL-cached, fail-open fetcher (already cross-team aware) fills title
+// for ALL teams at the DATA layer so the CTL-1041 title-preferred component logic
+// renders correctly without another component fallback.
+import { fillTitleDescriptionFallback } from "./linear-title-description-fallback.mjs";
 // CTL-1020: project Linear blocked-by/blocks relations into per-ticket blockers[]
 // so the dependency graph draws edges for tickets WITHOUT a triage.json (queued /
 // relation-only). Additive — triage-derived blockers stay authoritative.
@@ -713,6 +722,43 @@ export function ticketTitle(ticket, triage, eligibleIndex, linfo = {}) {
   if (triage?.summary) return triage.summary;
   return ticket;
 }
+
+// CTL-1046: which board IDs need a supplemental Linear-title fetch. A title is
+// "present" if EITHER source ticketTitle() consults has it (durable linfo cache
+// OR the eligible projection). CTL tickets carry their title via the eligible
+// projection; cross-team (ADV) records reach the payload only through ticket_state
+// (no title column) and have no eligible entry → both sources null → fetch needed.
+// Returns a de-duped array (order preserved).
+export function collectNullTitleIds(boardIds, linfo = {}, eligibleIndex = {}) {
+  return [
+    ...new Set(
+      boardIds.filter(
+        (id) => (linfo[id]?.title ?? eligibleIndex[id]?.title ?? null) === null,
+      ),
+    ),
+  ];
+}
+
+// CTL-1046: merge fetched Linear titles into linfo in-place (mirrors the
+// estimate-fallback merge). For each null-title ID, write the fetched title onto
+// linfo[id], creating a linfo entry first if the ticket was eligible-only (no
+// ticket_state row). A ticket Linear genuinely has no title for is left untouched
+// (honest null) so ticketTitle()'s summary/key fallback still runs. Returns linfo.
+export function mergeTitleFallback(linfo, nullTitleIds, fetched) {
+  for (const id of nullTitleIds) {
+    const fetchedTitle = fetched?.[id]?.title ?? null;
+    if (fetchedTitle === null) continue; // Linear has no title → leave honest null
+    if (!linfo[id]) {
+      linfo[id] = {
+        priority: 0, estimate: null, project: null, labels: [], relations: null,
+        assignee: null, linearState: null, title: null,
+        ownerHost: null, generation: null, fencePhase: null, claimedAt: null, heldSince: null,
+      };
+    }
+    linfo[id] = { ...linfo[id], title: fetchedTitle };
+  }
+  return linfo;
+}
 const ticketType = (triage) => triage?.classification || triage?.type || "task";
 // CTL-755: the scraped dependency ids triage recorded (flat string[] or rich
 // [{id}] — readTriageDependencies in the scheduler tolerates both, so we do too).
@@ -1072,6 +1118,34 @@ export async function assembleBoard() {
         estimateMethod: linfo[id].estimateMethod ?? method?.type ?? null,
       };
     }
+  })();
+
+  // CTL-1046: supplemental TITLE fallback — the same data-layer pattern as the
+  // estimate fallback above. CTL tickets carry their Linear title via the eligible
+  // projection (eligibleIndex[id].title), but cross-team records (e.g. ADV) reach
+  // the payload only through ticket_state, which has NO title column, AND have no
+  // eligible entry (ADV's eligible/<TEAM>.json is empty) → linfo[id].title === null.
+  // Without this, ticketTitle() falls through to triage.summary (the description),
+  // which is the CTL-1046 bug (ADV rows rendered descriptions). Collect every board
+  // ticket ID whose title is null, batch-fetch from Linear (5-min TTL, fail-open,
+  // cross-team aware), and merge the real title into linfo so ticketTitle() returns
+  // the Linear title for ALL teams. A ticket genuinely missing a Linear title still
+  // resolves to null here, so ticketTitle()'s honest summary/key fallback still runs.
+  await (async () => {
+    const allBoardIds = [
+      ...[...cardTicketIds],
+      ...eligible.map((e) => e.id),
+    ];
+    // Only fetch titles for IDs that have NO title from either source the title
+    // resolver consults (durable linfo cache OR the eligible projection).
+    const nullTitleIds = collectNullTitleIds(allBoardIds, linfo, eligibleIndex);
+    if (nullTitleIds.length === 0) return;
+
+    // Batch-fetch titles (and descriptions/labels/relations) for null-title IDs,
+    // then merge the real titles into linfo (in-place — linfo is a plain object,
+    // never shared with the broker DB or cache reader, so mutation here is safe).
+    const fallback = await fillTitleDescriptionFallback(nullTitleIds);
+    mergeTitleFallback(linfo, nullTitleIds, fallback);
   })();
 
   let tickets = await Promise.all([...cardTicketIds].map(async (id) => {


### PR DESCRIPTION
## Root cause

ADV (cross-team) rows in the control-tower Waiting/Dead lists rendered their description instead of their Linear title. CTL tickets carry their title via the eligible projection (`eligible/CTL.json` → `eligibleIndex`), but ADV records reach the payload only through `ticket_state` — which has no title column — and have no eligible entry. So `linfo[id].title` and `eligibleIndex[id].title` are both null for ADV, and `ticketTitle()` falls through to `triage.summary` (the description). ADV-1352 showed "The jobs calendar opens empty…" instead of "Demo data should stay current…".

## Fix summary

- Fix at the **data layer** in `assembleBoard()` (mirrors the existing CTL-974 estimate fallback pattern)
- `collectNullTitleIds` — finds every board ID whose title is null in both `linfo` and `eligibleIndex`
- `fillTitleDescriptionFallback` — batch-fetches real Linear titles via the existing cross-team-aware, TTL-cached, fail-open helper
- `mergeTitleFallback` — merges fetched titles back into `linfo` so `ticketTitle()` returns the correct title for all teams
- Tickets Linear genuinely has no title for stay null and fall back honestly (summary/key)
- The CTL-1041 title-preferred component selection is untouched

## Tests

`cross-team-title-fallback.test.ts` covers `collectNullTitleIds` + `mergeTitleFallback` + end-to-end `ticketTitle()` over a mixed CTL+ADV fixture. Server-only change — no UI bundle rebuild needed.

Fixes CTL-1046, follow-up to CTL-1041 (#1820).