### PR TITLE
fix(dev): CTL-1050 service health — broker/exec-core show green when daemons are live

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/service-health-monitor.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/service-health-monitor.test.ts
@@ -57,6 +57,48 @@ describe("readEmissionAge", () => {
   });
 });
 
+describe("broker / execution-core recency uses catalyst.* service names", () => {
+  it("broker shows up when catalyst.broker emitted recently", async () => {
+    // The catalyst event log records service.name as "catalyst.broker" (prefixed),
+    // not the bare "broker". The RECENCY_MATCHERS must use the prefixed form.
+    const now = Date.parse("2026-06-11T12:00:00.000Z");
+    writeEvent("2026-06-11T11:59:00.000Z", "catalyst.broker"); // 1m ago → within 3m degraded
+    const monitor = createServiceHealthMonitor({
+      config: {
+        lokiUrl: null,
+        prometheusUrl: null,
+        grafanaUrl: null,
+        collectorHealthUrl: null,
+        webhookConfigured: false,
+      },
+      catalystDir,
+      now: () => now,
+    });
+    await monitor.tick();
+    const snap = monitor.snapshot();
+    expect(snap.services.find((s) => s.id === "broker")!.severity).toBe("up");
+  });
+
+  it("execution-core shows up when catalyst.execution-core emitted recently", async () => {
+    const now = Date.parse("2026-06-11T12:00:00.000Z");
+    writeEvent("2026-06-11T11:59:30.000Z", "catalyst.execution-core"); // 30s ago
+    const monitor = createServiceHealthMonitor({
+      config: {
+        lokiUrl: null,
+        prometheusUrl: null,
+        grafanaUrl: null,
+        collectorHealthUrl: null,
+        webhookConfigured: false,
+      },
+      catalystDir,
+      now: () => now,
+    });
+    await monitor.tick();
+    const snap = monitor.snapshot();
+    expect(snap.services.find((s) => s.id === "execution-core")!.severity).toBe("up");
+  });
+});
+
 describe("collector recency fallback — no cascade", () => {
   it("marks collector unknown (not down) when Loki itself is down", async () => {
     // Loki probe always fails → after 3 ticks Loki is down. No ingest events at
@@ -79,6 +121,27 @@ describe("collector recency fallback — no cascade", () => {
     const snap = monitor.snapshot();
     expect(snap.services.find((s) => s.id === "loki")!.severity).toBe("down");
     expect(snap.services.find((s) => s.id === "otel-collector")!.severity).toBe("unknown");
+  });
+
+  it("marks collector up when Loki is up (no direct probe configured)", async () => {
+    // When collectorHealthUrl is absent and the catalyst event log doesn't carry
+    // claude-code telemetry (it goes direct to Loki via OTel), the collector
+    // recency fallback infers liveness from Loki: Loki up → collector up.
+    const monitor = createServiceHealthMonitor({
+      config: {
+        lokiUrl: "http://loki",
+        prometheusUrl: null,
+        grafanaUrl: null,
+        collectorHealthUrl: null,
+        webhookConfigured: false,
+      },
+      catalystDir,
+      fetcher: () => Promise.resolve(new Response(null, { status: 200 })),
+    });
+    await monitor.tick();
+    const snap = monitor.snapshot();
+    expect(snap.services.find((s) => s.id === "loki")!.severity).toBe("up");
+    expect(snap.services.find((s) => s.id === "otel-collector")!.severity).toBe("up");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/lib/service-health-monitor.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/service-health-monitor.ts
@@ -169,10 +169,12 @@ export function readEmissionAge(
   return Math.max(0, now - newestTs);
 }
 
-/** Per-service recency matcher for event-recency entries. */
+/** Per-service recency matcher for event-recency entries. The catalyst event log
+ *  records service.name as "catalyst.<component>" (e.g. "catalyst.broker",
+ *  "catalyst.execution-core") — match the prefixed form, not the bare id. */
 const RECENCY_MATCHERS: Partial<Record<ServiceId, RecencyMatcher>> = {
-  broker: { serviceName: "broker" },
-  "execution-core": { serviceName: "execution-core" },
+  broker: { serviceName: "catalyst.broker" },
+  "execution-core": { serviceName: "catalyst.execution-core" },
 };
 
 export interface ServiceHealthMonitor {
@@ -250,18 +252,34 @@ export function createServiceHealthMonitor(
 
     // event-recency.
     if (d.id === "otel-collector") {
-      // Collector recency fallback = Loki ingest freshness. If LOKI itself is
-      // down we cannot infer the collector → unknown (no cascade red).
+      // Collector recency fallback: we infer collector health from Loki's state
+      // rather than searching the local event log for "claude-code" events (the
+      // catalyst event log doesn't carry claude-code telemetry — those go directly
+      // to Loki via OTel). When Loki is up the collector is almost certainly
+      // forwarding; when Loki is down we cannot distinguish → both are unknown.
       const lokiStatus = statuses.get("loki");
-      if (lokiStatus && lokiStatus.severity === "down") {
+      const lokiSev = lokiStatus?.severity ?? "unknown";
+      if (lokiSev === "down") {
         return {
           kind: "event-recency",
           forcedSeverity: "unknown",
           detail: "inferred from telemetry ingest — Loki unreachable",
         };
       }
-      const age = readRecency({ serviceName: "claude-code" });
-      return { kind: "event-recency", ageMs: age };
+      if (lokiSev === "up") {
+        // Loki is healthy → collector is forwarding (inferred; no direct probe).
+        return {
+          kind: "event-recency",
+          forcedSeverity: "up",
+          detail: "inferred from Loki reachability",
+        };
+      }
+      // Loki degraded/unknown → collector state is indeterminate → unknown (grey).
+      return {
+        kind: "event-recency",
+        forcedSeverity: "unknown",
+        detail: "collector state indeterminate (Loki not fully up)",
+      };
     }
 
     const matcher = RECENCY_MATCHERS[d.id];


### PR DESCRIPTION
## Summary

- Fix `RECENCY_MATCHERS` to use `catalyst.broker`/`catalyst.execution-core` (the actual service names the catalyst event log uses, prefixed with `catalyst.`) instead of bare `broker`/`execution-core` — fixes false-down on both daemons
- Fix OTel collector recency fallback to infer liveness from Loki status (Loki up → collector up) instead of searching for `claude-code` events that never appear in the local catalyst event log
- Add regression tests for both fixes (8 total, all green)

## Test plan

- [x] `bun test __tests__/service-health-monitor.test.ts` — 8 pass, 0 fail
- [x] Live: `/api/health/services` on mini shows broker/execution-core as green after merge+deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)