### PR TITLE
fix(dev): CTL-1028 plumb cluster generation through triage dispatch path

### DIFF
--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -56,7 +56,7 @@ import {
 } from "./linear-write.mjs";
 import { appendTriageTransitionEvent as defaultAppendEvent } from "./triage-transition-event.mjs";
 import { countBackgroundAgents, resetLivenessCache } from "./claude-agents.mjs";
-import { readMaxParallel, computeFreeSlots } from "./scheduler.mjs";
+import { readMaxParallel, computeFreeSlots, writeClusterGeneration } from "./scheduler.mjs";
 import {
   recordReconcileSuccess,
   recordReconcileFailure,
@@ -587,17 +587,11 @@ function dispatchTriage(
   }
   // CTL-862: cross-host claim soft-CAS immediately before the spawn. Skipped on
   // single-host (no Linear write). A lost claim is NOT a failure — defer cleanly.
-  // The claim returns a won {generation} here too — CTL-862 supplies a
-  // claim+generation on this triage path.
-  //
-  // CTL-864 reduced scope: even with a won generation in hand, triage is
-  // dispatched WITHOUT forwarding a cross-host fence token. phase-triage's only
-  // side-effects (its Linear mirror comment + Todo→Triage transition) are
-  // idempotent and cheap, so an unfenced double-triage from a partitioned host is
-  // benign relative to the push / PR / merge side-effects the scheduler-dispatched
-  // phases (now fenced) guard against. We therefore intentionally do NOT fence
-  // triage nor persist its generation — a fast-follow ticket will plumb the
-  // generation through if triage ever needs fencing.
+  // CTL-1028: lift claim.generation out of the block so it can be forwarded to
+  // the triage worker as CATALYST_CLUSTER_GENERATION (mirrors CTL-864 scheduler
+  // path). null on single-host → writeClusterGeneration and dispatchTicket both
+  // treat null as a no-op (fence token is omitted from the env).
+  let clusterGeneration = null;
   if (multiHost) {
     const claim = claimDispatch({ ticket: identifier, hostName: self, phase: "triage" });
     if (!claim.won) {
@@ -607,12 +601,16 @@ function dispatchTriage(
       );
       return false;
     }
+    clusterGeneration = claim.generation; // CTL-1028: forward to worker (mirrors CTL-864)
   }
-  const r = dispatchTicket(orchDir, identifier, "triage", { dispatch });
+  const r = dispatchTicket(orchDir, identifier, "triage", { dispatch, clusterGeneration });
   if (r.code !== 0) {
     log.warn({ identifier, code: r.code }, "monitor: triage dispatch failed");
     return false;
   }
+  // CTL-1028: persist the won generation so a later flapping-host triage worker
+  // is fenced. null (single-host) is a no-op inside writeClusterGeneration.
+  writeClusterGeneration(orchDir, identifier, clusterGeneration);
   if (budget) budget.remaining -= 1;
   // CTL-704: write Linear Todo→Triage (verified) + emit observability event.
   let res = { applied: false, verified: false, from_state: null, to_state: null, reason: null };

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -7,7 +7,8 @@
 
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { ownerForTicket } from "./hrw.mjs"; // CTL-862: HRW owner computation for ownership-filter tests
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, appendFileSync, statSync } from "node:fs";
+import { readClusterGeneration } from "./scheduler.mjs"; // CTL-1028: persistence assertion
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, appendFileSync, statSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -1937,5 +1938,87 @@ describe("CTL-862 — HRW ownership + claim-on-dispatch (monitor dispatchTriage)
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(claimDispatch.calls).toHaveLength(1);
     expect(claimDispatch.calls[0]).toMatchObject({ ticket: TICKET, phase: "triage" });
+  });
+});
+
+// ── CTL-1028: triage forwards + persists cluster generation (monitor dispatchTriage) ──
+//
+// Mirrors the CTL-864 scheduler tests but drives dispatchTriage through the
+// exported handleStateChangedEvent (→Triage branch), since dispatchTriage is not
+// exported. The CTL-862 single-host exact-args assertion doubles as a regression
+// guard that single-host remains a true no-op after this change.
+describe("CTL-1028 — triage forwards + persists cluster generation (monitor dispatchTriage)", () => {
+  const ROSTER = ["mini", "mac-studio"];
+  const TICKET = "ENG-1";
+  const OWNER = ownerForTicket(TICKET, ROSTER);
+
+  const triageEvent = () => ({
+    event: "linear.issue.state_changed",
+    detail: { ticket: TICKET, teamKey: "ENG", toState: "Triage" },
+  });
+
+  const recordClaim = (verdict) => {
+    const calls = [];
+    const fn = (arg) => { calls.push(arg); return verdict; };
+    fn.calls = calls;
+    return fn;
+  };
+
+  test("multi-host won claim forwards claim.generation as clusterGeneration", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const claimDispatch = recordClaim({ won: true, generation: 7 });
+    handleStateChangedEvent(triageEvent(), {
+      dispatch,
+      orchDir: "/fake-orch-1028",
+      hosts: ROSTER,
+      hostName: OWNER,
+      claimDispatch,
+      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      appendEvent: () => {},
+    });
+    expect(dispatch.mock.calls[0][0].clusterGeneration).toBe(7);
+  });
+
+  test("single-host passes NO clusterGeneration key (exact no-op)", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const claimDispatch = recordClaim({ won: false, generation: null });
+    handleStateChangedEvent(triageEvent(), {
+      dispatch,
+      orchDir: "/fake-orch-1028",
+      hosts: ["solo"],
+      hostName: "solo",
+      claimDispatch,
+      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      appendEvent: () => {},
+    });
+    expect("clusterGeneration" in dispatch.mock.calls[0][0]).toBe(false);
+  });
+
+  test("won multi-host claim persists cluster-generation.json", () => {
+    enroll("ENG", { status: "Ready" });
+    const orchDir = mkdtempSync(join(tmpdir(), "ctl-1028-persist-"));
+    try {
+      // dispatch stub creates the worker dir (mirrors dispatchCreatesDir in scheduler.test.mjs)
+      // so writeClusterGeneration's tmp+rename succeeds.
+      const dispatch = mock((args) => {
+        mkdirSync(join(orchDir, "workers", args.ticket), { recursive: true });
+        return { code: 0 };
+      });
+      const claimDispatch = recordClaim({ won: true, generation: 7 });
+      handleStateChangedEvent(triageEvent(), {
+        dispatch,
+        orchDir,
+        hosts: ROSTER,
+        hostName: OWNER,
+        claimDispatch,
+        applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+        appendEvent: () => {},
+      });
+      expect(readClusterGeneration(orchDir, TICKET)).toBe(7);
+    } finally {
+      rmSync(orchDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-11T22:32:00Z -->
<!-- Last updated: 2026-06-11T22:32:00Z -->
<!-- PR: #1859 -->
<!-- Previous commits: 58a91c017d6bef9f52ac0d1bafa3dd5031a831d6 -->

## Summary

Closes the gap left intentionally open by CTL-864: the triage dispatch path now forwards `claim.generation` to the triage worker as `CATALYST_CLUSTER_GENERATION` and persists `cluster-generation.json` afterward, so `cluster-fence-guard.sh` in `phase-triage` can fire when a flapping host tries to double-post its triage comment after losing the ticket to a takeover.

Single-host installs are an exact no-op — `null` generation causes `writeClusterGeneration` and `dispatchTicket` to both short-circuit cleanly.

## Changes Made

### `plugins/dev/scripts/execution-core/monitor.mjs`

- Imports `writeClusterGeneration` from `scheduler.mjs` (alongside the existing `readMaxParallel`, `computeFreeSlots`).
- Lifts `clusterGeneration` out of the `if (multiHost)` block: set to `null` initially, set to `claim.generation` after a won multi-host claim.
- Passes `clusterGeneration` into `dispatchTicket(…, { dispatch, clusterGeneration })`.
- Calls `writeClusterGeneration(orchDir, identifier, clusterGeneration)` after a successful dispatch to persist the generation for the fence guard (mirrors the CTL-864 scheduler path exactly).
- Removes the now-superseded comment that said triage intentionally did NOT persist its generation.

### `plugins/dev/scripts/execution-core/monitor.test.mjs`

Three new tests under **CTL-1028 — triage forwards + persists cluster generation**:

1. **Multi-host won claim forwards `claim.generation` as `clusterGeneration`** — verifies `dispatch.calls[0].clusterGeneration === 7` when the claim returns `{ won: true, generation: 7 }`.
2. **Single-host passes NO `clusterGeneration` key (exact no-op)** — verifies `"clusterGeneration" in dispatch.calls[0][0]` is `false` when `hosts` has only one entry.
3. **Won multi-host claim persists `cluster-generation.json`** — creates a real temp dir, stubs dispatch to create the worker sub-dir (mirrors the CTL-864 scheduler test pattern), then asserts `readClusterGeneration(orchDir, TICKET) === 7`.

## How to Verify It

- [x] TypeScript/lint: no compilation step — JS-only file. `bun scripts/ci/lint.ts` expected clean.
- [x] Tests: `cd plugins/dev/scripts/execution-core && bun test monitor.test.mjs` — three new CTL-1028 tests pass, no regressions.
- [ ] Manual (multi-host): spin up two hosts against the same execution-core dir, dispatch a ticket, confirm `cluster-generation.json` is written in `workers/<TICKET>/` after triage dispatch.

## Related Issues/PRs

- Fixes https://linear.app/adva/issue/CTL-1028

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-864
