### PR TITLE
CTL-1025: Operators should fly the app with single keys, Linear-style — no modifier needed

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/app-shell.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/app-shell.test.ts
@@ -181,7 +181,13 @@ describe("one edge-to-edge shell hosts every surface (CTL-891)", () => {
     // The shell wires the predicate instead of inlining the key literal.
     expect(shellSrc).toContain("shouldToggleSidebar");
     expect(shellSrc).toContain("isTypingTarget");
-    expect(shellSrc).toContain("SURFACE_CHORD");
+    // CTL-1025: the `g`-chord surface jumps now route through the action registry —
+    // buildSurfaceActions (keyed off SURFACE_CHORD in surface-actions.ts) resolved by
+    // matchAction — instead of an inline SURFACE_CHORD lookup in the shell. The chord
+    // still yields t/w/a to the detail Shell on detail routes.
+    expect(shellSrc).toContain("buildSurfaceActions");
+    expect(shellSrc).toContain("matchAction");
+    expect(shellSrc).toContain("surfaceChordYieldsToDetail");
   });
 
   it("App.tsx renders the active surface INSIDE the shell (edge-to-edge inset)", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/key-nav.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/key-nav.test.ts
@@ -32,13 +32,14 @@ describe("classifyKey — the pre-existing bindings still work unchanged", () =>
   });
 
   it("the input-focus guard swallows everything while an INPUT/TEXTAREA/SELECT is focused", () => {
-    expect(isTypingTarget("INPUT")).toBe(true);
-    expect(isTypingTarget("TEXTAREA")).toBe(true);
-    expect(isTypingTarget("SELECT")).toBe(true);
-    expect(isTypingTarget("DIV")).toBe(false);
+    // CTL-1025: migrated from string tag to TypingTargetLike structural form.
+    expect(isTypingTarget({ tagName: "INPUT" })).toBe(true);
+    expect(isTypingTarget({ tagName: "TEXTAREA" })).toBe(true);
+    expect(isTypingTarget({ tagName: "SELECT" })).toBe(true);
+    expect(isTypingTarget({ tagName: "DIV" })).toBe(false);
     // a literal `/` or `j` typed into an input is NOT a shortcut.
-    expect(classifyKey(bare("/"), "INPUT", false).type).toBe("none");
-    expect(classifyKey(bare("j"), "TEXTAREA", false).type).toBe("none");
+    expect(classifyKey(bare("/"), { tagName: "INPUT" }, false).type).toBe("none");
+    expect(classifyKey(bare("j"), { tagName: "TEXTAREA" }, false).type).toBe("none");
   });
 });
 
@@ -96,7 +97,7 @@ describe("classifyKey — ⌘K / Ctrl-K toggles the palette (NEW)", () => {
   });
 
   it("⌘K is reachable EVEN while an input is focused (the one shortcut that pierces the guard)", () => {
-    expect(classifyKey(bare("k", { metaKey: true }), "INPUT", false).type).toBe("palette");
+    expect(classifyKey(bare("k", { metaKey: true }), { tagName: "INPUT" }, false).type).toBe("palette");
   });
 
   it("a bare `k` (no modifier) is prev, NOT the palette", () => {
@@ -122,7 +123,7 @@ describe("classifyKey — g-chords g t / g w / g a (NEW)", () => {
 
   it("the chord does not fire while an input is focused", () => {
     // even with a pending chord, a focused input swallows the second key.
-    expect(classifyKey(bare("t"), "INPUT", true).type).toBe("none");
+    expect(classifyKey(bare("t"), { tagName: "INPUT" }, true).type).toBe("none");
   });
 
   it("exposes a chord window constant for the hook timer", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/key-nav.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/key-nav.test.ts
@@ -44,27 +44,29 @@ describe("classifyKey — the pre-existing bindings still work unchanged", () =>
 });
 
 // ── CTL-1049: Escape = back, but NEVER while typing ──────────────────────────
+// CTL-1025 unified the guard into lib/typing-target — the classifier takes the
+// focused-element shape ({ tagName, isContentEditable }) instead of (tag, flag).
 describe("classifyKey — Escape-means-back is input/contentEditable guarded (CTL-1049)", () => {
   it("Escape with focus NOT in a typing target classifies as `escape` (→ history back)", () => {
-    expect(classifyKey(bare("Escape"), "DIV", false).type).toBe("escape");
+    expect(classifyKey(bare("Escape"), { tagName: "DIV" }, false).type).toBe("escape");
     expect(classifyKey(bare("Escape"), null, false).type).toBe("escape");
   });
 
   it("Escape while an INPUT/TEXTAREA is focused is swallowed (`none`) — no navigation", () => {
     // the Gherkin: "Escape means back — focus not in an input". A focused field
     // must keep Escape for its own dismissal (and never silently navigate away).
-    expect(classifyKey(bare("Escape"), "INPUT", false).type).toBe("none");
-    expect(classifyKey(bare("Escape"), "TEXTAREA", false).type).toBe("none");
+    expect(classifyKey(bare("Escape"), { tagName: "INPUT" }, false).type).toBe("none");
+    expect(classifyKey(bare("Escape"), { tagName: "TEXTAREA" }, false).type).toBe("none");
   });
 
   it("a focused contentEditable host is a typing target too (Escape swallowed)", () => {
-    expect(isTypingTarget("DIV", true)).toBe(true);
-    expect(isTypingTarget("DIV", false)).toBe(false);
+    expect(isTypingTarget({ tagName: "DIV", isContentEditable: true })).toBe(true);
+    expect(isTypingTarget({ tagName: "DIV", isContentEditable: false })).toBe(false);
     // a DIV with isContentEditable=true swallows Escape (and every other shortcut).
-    expect(classifyKey(bare("Escape"), "DIV", false, true).type).toBe("none");
-    expect(classifyKey(bare("j"), "DIV", false, true).type).toBe("none");
+    expect(classifyKey(bare("Escape"), { tagName: "DIV", isContentEditable: true }, false).type).toBe("none");
+    expect(classifyKey(bare("j"), { tagName: "DIV", isContentEditable: true }, false).type).toBe("none");
     // a plain (non-editable) DIV still lets the shortcuts through.
-    expect(classifyKey(bare("Escape"), "DIV", false, false).type).toBe("escape");
+    expect(classifyKey(bare("Escape"), { tagName: "DIV", isContentEditable: false }, false).type).toBe("escape");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/settings-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/settings-surface.test.ts
@@ -71,7 +71,12 @@ describe("Settings nav item opens the preferences surface (CTL-911)", () => {
     expect(surfaceSrc).toContain("SETTINGS_BREADCRUMB");
     expect(SURFACES.map(String)).not.toContain("settings");
     expect(Object.values(SURFACE_CHORD).map(String)).not.toContain("settings");
-    const unionSrc = surfaceSrc.match(/export type Surface =([^;]*);/)?.[1] ?? "";
+    // CTL-1025: the `Surface` union + SURFACE_CHORD were extracted into
+    // surface-constants.ts (React-/router-free so surface-actions.ts can import
+    // them without pulling in @tanstack/react-router); surface.ts re-exports them.
+    // Read the union from its new home.
+    const constantsSrc = read("lib/surface-constants.ts");
+    const unionSrc = constantsSrc.match(/export type Surface =([^;]*);/)?.[1] ?? "";
     expect(unionSrc).toContain('"home"');
     expect(unionSrc).not.toContain('"settings"');
     // The shell shows the Settings breadcrumb when settingsOpen.

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/CommandPalette.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/CommandPalette.tsx
@@ -52,6 +52,7 @@ const PALETTE_CSS = `
 .cat-cmd [cmdk-item][data-disabled="true"] { color: ${C.fgDim}; cursor: not-allowed; opacity: .6; }
 .cat-cmd [cmdk-empty] { padding: 18px; text-align: center; color: ${C.fgDim}; font: 12px ${C.mono}; }
 .cat-cmd-meta { margin-left: auto; color: ${C.fgMuted}; font: 11px ${C.mono}; }
+.cat-cmd-kbd { margin-left: auto; color: ${C.fgDim}; font: 11px ${C.mono}; border: 1px solid ${C.border}; border-radius: 4px; padding: 1px 6px; letter-spacing: 0.05em; }
 .cat-cmd-soon { margin-left: auto; color: ${C.fgDim}; font: 10px ${C.mono}; border: 1px solid ${C.border}; border-radius: 4px; padding: 1px 5px; }
 .cat-cmd-live { width: 7px; height: 7px; border-radius: 50%; background: ${LIVE}; flex: 0 0 auto; }
 .cat-cmd-sep { height: 1px; margin: 6px 4px; background: ${C.border}; }
@@ -96,6 +97,8 @@ function Row({ row, onRun }: { row: PaletteItem; onRun: (r: PaletteItem) => void
         <span className="cat-cmd-soon" data-palette-soon>
           soon
         </span>
+      ) : row.keybinding ? (
+        <kbd className="cat-cmd-kbd" data-palette-keybinding={row.keybinding}>{row.keybinding}</kbd>
       ) : (
         row.meta && <span className="cat-cmd-meta">{row.meta}</span>
       )}

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/keymap.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/keymap.test.ts
@@ -3,11 +3,13 @@
 // constant, documenting j/k, g-chords, Esc layering, /, and ⌘K" — and the §3.4
 // contract that the cheatsheet documents the SAME keys the DETAIL1 classifier
 // binds (key-nav.ts), so the two can never drift.
+// CTL-1025: also cross-checks the new "Go to" surface chords against the registry.
 //
 // Pure imports only (no DOM, no jotai) — runs under `cd ui && bun test`.
 import { describe, it, expect } from "bun:test";
 import { KEYMAP, KEYMAP_BOUND_KEYS, type KeymapSection } from "./keymap";
 import { classifyKey, type KeyAction } from "../hooks/key-nav";
+import { buildSurfaceActions } from "../lib/surface-actions";
 
 function allEntries() {
   return KEYMAP.flatMap((s: KeymapSection) => s.entries);
@@ -80,4 +82,33 @@ describe("keymap — stays in sync with the live DETAIL1 classifier (key-nav.ts)
       expect(c.run().type).toBe(c.action);
     });
   }
+});
+
+// CTL-1025: surface chords + create key documented in the cheatsheet AND bound in registry.
+describe("keymap — documents the surface g-chords + create (CTL-1025)", () => {
+  for (const k of ["g h", "g b", "g w", "g q", "g t", "g u", "g f", "g o", "g d", "c"]) {
+    it(`documents "${k}"`, () => {
+      expect(KEYMAP_BOUND_KEYS.has(k)).toBe(true);
+    });
+  }
+});
+
+describe("keymap — surface chords cross-check the REGISTRY (not classifyKey)", () => {
+  const actions = buildSurfaceActions({ jumpToSurface: () => {}, create: () => {} });
+  const bound = new Set(actions.map((a) => a.keybinding));
+  for (const k of ["g h", "g b", "g q", "g u", "g f", "g o", "g d", "c"]) {
+    it(`"${k}" is documented AND a registry action binds it`, () => {
+      expect(KEYMAP_BOUND_KEYS.has(k)).toBe(true);
+      expect(bound.has(k)).toBe(true);
+    });
+  }
+  // g t and g w are bound by BOTH the classifier (detail) and the registry (surface).
+  it('"g t" is in KEYMAP and bound by the registry', () => {
+    expect(KEYMAP_BOUND_KEYS.has("g t")).toBe(true);
+    expect(bound.has("g t")).toBe(true);
+  });
+  it('"g w" is in KEYMAP and bound by the registry', () => {
+    expect(KEYMAP_BOUND_KEYS.has("g w")).toBe(true);
+    expect(bound.has("g w")).toBe(true);
+  });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/keymap.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/keymap.ts
@@ -48,9 +48,24 @@ export const KEYMAP: readonly KeymapSection[] = [
   {
     title: "Jump",
     entries: [
-      { keys: "g t", description: "From a worker → its parent ticket" },
-      { keys: "g w", description: "Fuzzy go-to a worker" },
+      { keys: "g t", description: "From a worker → its parent ticket (on a detail page)" },
+      { keys: "g w", description: "Fuzzy go-to a worker (on a detail page)" },
       { keys: "g a", description: "Scroll the lifecycle spine to the active phase node" },
+    ],
+  },
+  {
+    title: "Go to",
+    entries: [
+      { keys: "g h", description: "Inbox" },
+      { keys: "g b", description: "Tickets" },
+      { keys: "g w", description: "Workers (on non-detail pages)" },
+      { keys: "g q", description: "Dispatch" },
+      { keys: "g t", description: "Telemetry (on non-detail pages)" },
+      { keys: "g u", description: "Utilization" },
+      { keys: "g f", description: "FinOps" },
+      { keys: "g o", description: "Fleet Ops" },
+      { keys: "g d", description: "DevOps" },
+      { keys: "c", description: "Create…" },
     ],
   },
   {

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/palette-actions.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/palette-actions.test.ts
@@ -265,3 +265,15 @@ describe("lokiTailUrl", () => {
     expect(url.startsWith("https://grafana.example/explore?")).toBe(true);
   });
 });
+
+// ── CTL-1025: PaletteItem.keybinding field ───────────────────────────────────
+describe("PaletteItem — optional keybinding field (CTL-1025)", () => {
+  it("carries an optional keybinding onto rows that have one", () => {
+    const item: PaletteItem = { id: "nav.surface.board", label: "Go to Tickets", keybinding: "g b" };
+    expect(item.keybinding).toBe("g b");
+  });
+  it("keybinding is optional — rows without one compile and work", () => {
+    const item: PaletteItem = { id: "copy-session-id", label: "Copy session id" };
+    expect(item.keybinding).toBeUndefined();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/palette-actions.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/palette-actions.ts
@@ -62,6 +62,8 @@ export interface PaletteItem {
   label: string;
   /** Optional right-aligned meta (phase / state / id) shown muted + mono. */
   meta?: string;
+  /** Optional keyboard binding displayed right-aligned in the row (e.g. "g b", "c"). */
+  keybinding?: string;
   /** What firing this row does — absent on a disabled `soon` row. */
   action?: PaletteActionKind;
   /** Disabled `soon` row (no endpoint yet): rendered dim, not activatable. */

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
@@ -169,6 +169,20 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   // at rest and never shift layout.
   useEffect(() => installOverlayScroll(), []);
 
+  // CTL-1025: surface jump + create actions, built once per navigate change.
+  // Declared BEFORE the keydown effect below — that effect reads `surfaceActions`
+  // in its dependency array, so the const must already be initialized. A later
+  // declaration is a temporal-dead-zone ReferenceError that crashes AppShell on
+  // first render (target is ES2022, so the bundler keeps the TDZ check).
+  const surfaceActions = useMemo(
+    () =>
+      buildSurfaceActions({
+        jumpToSurface: (s) => void navigate({ to: surfaceToPath(s), search: (prev) => prev }),
+        create: () => setPaletteOpen(true),
+      }),
+    [navigate],
+  );
+
   // CTL-1025: `[` toggles the rail; `g <key>` chords + bare `c` go through the
   // action registry (matchAction). Both ignore typing targets.
   useEffect(() => {
@@ -285,16 +299,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     void navigate({ to: SETTINGS_PATH, search: (prev) => prev });
     setPaletteOpen(false);
   }, [navigate]);
-
-  // CTL-1025: surface jump + create actions, built once per navigate change.
-  const surfaceActions = useMemo(
-    () =>
-      buildSurfaceActions({
-        jumpToSurface: (s) => void navigate({ to: surfaceToPath(s), search: (prev) => prev }),
-        create: () => setPaletteOpen(true),
-      }),
-    [navigate],
-  );
 
   // CTL-1024: theme toggle, sidebar toggle, and board-display commands in the palette.
   const { toggle: toggleTheme } = useTheme();

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
@@ -10,10 +10,11 @@ import {
 
 import {
   SETTINGS_BREADCRUMB,
-  SURFACE_CHORD,
   isTypingTarget,
   type Surface,
 } from "@/lib/surface";
+import { buildSurfaceActions, surfaceChordYieldsToDetail } from "@/lib/surface-actions";
+import { matchAction } from "@/lib/action-keymatch";
 // CTL-989 — the active surface is now DERIVED from the route (URL = source of
 // truth for location); the nav navigates via router.navigate instead of writing
 // React surface state.
@@ -168,7 +169,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   // at rest and never shift layout.
   useEffect(() => installOverlayScroll(), []);
 
-  // `[` toggles the rail; `g <key>` chords jump surfaces. Both ignore typing.
+  // CTL-1025: `[` toggles the rail; `g <key>` chords + bare `c` go through the
+  // action registry (matchAction). Both ignore typing targets.
   useEffect(() => {
     let chordArmed = false;
     let chordTimer: ReturnType<typeof setTimeout> | undefined;
@@ -197,7 +199,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       // the `[` binding above).
       if (isTypingTarget(e.target as HTMLElement | null)) return;
 
-      // `g` arms a chord; the next key picks the surface (g h / g b / g w / g q).
+      // `g` arms a chord; the next key resolves through the surface action registry.
       if (e.key === "g" && !e.metaKey && !e.ctrlKey && !e.altKey) {
         chordArmed = true;
         clearTimeout(chordTimer);
@@ -207,17 +209,19 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         return;
       }
       if (chordArmed) {
-        const target = SURFACE_CHORD[e.key];
-        if (target) {
-          e.preventDefault();
-          // CTL-989: jumping to a surface is now a client-side route navigation
-          // (URL = source of truth). Preserve the current `?scope` (the search
-          // updater keeps the existing scope).
-          void navigate({ to: surfaceToPath(target), search: (prev) => prev });
+        const pathname = window.location.pathname;
+        // CTL-1025: on a detail route, yield g t/w/a to the detail Shell classifier.
+        if (!surfaceChordYieldsToDetail(pathname, e.key)) {
+          const hit = matchAction(surfaceActions, { surface }, { key: e.key }, true);
+          if (hit) { e.preventDefault(); hit.handler(); }
         }
         chordArmed = false;
         clearTimeout(chordTimer);
+        return;
       }
+      // Bare single-key (when no chord is pending) — e.g. `c` → open create.
+      const hit = matchAction(surfaceActions, { surface }, { key: e.key }, false);
+      if (hit) { e.preventDefault(); hit.handler(); }
     };
 
     window.addEventListener("keydown", onKey);
@@ -225,7 +229,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       window.removeEventListener("keydown", onKey);
       clearTimeout(chordTimer);
     };
-  }, [navigate]);
+  }, [navigate, surfaceActions, surface]);
 
   // ⌘K / Ctrl+K and a bare `/` (outside a field) open the command palette — the
   // SINGLE search affordance for the shell (SHELL5 de-dups the prototype's two
@@ -281,6 +285,16 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     void navigate({ to: SETTINGS_PATH, search: (prev) => prev });
     setPaletteOpen(false);
   }, [navigate]);
+
+  // CTL-1025: surface jump + create actions, built once per navigate change.
+  const surfaceActions = useMemo(
+    () =>
+      buildSurfaceActions({
+        jumpToSurface: (s) => void navigate({ to: surfaceToPath(s), search: (prev) => prev }),
+        create: () => setPaletteOpen(true),
+      }),
+    [navigate],
+  );
 
   // CTL-1024: theme toggle, sidebar toggle, and board-display commands in the palette.
   const { toggle: toggleTheme } = useTheme();
@@ -470,6 +484,23 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               ))}
             </CommandGroup>
           )}
+          {/* CTL-1025: surface navigation commands with keybinding hints. */}
+          <CommandGroup heading="Go to">
+            {surfaceActions.map((entry) => (
+              <CommandItem
+                key={entry.id}
+                value={`${entry.title} ${(entry.keywords ?? []).join(" ")}`}
+                onSelect={() => runAction(entry.handler)}
+              >
+                {entry.title}
+                {entry.keybinding && (
+                  <kbd className="ml-auto rounded border border-border px-1 text-[11px] text-muted-foreground font-mono">
+                    {entry.keybinding}
+                  </kbd>
+                )}
+              </CommandItem>
+            ))}
+          </CommandGroup>
           {/* CTL-1024: settings + board-display commands (board-scoped entries hidden off-board). */}
           <CommandGroup heading="Settings">
             <CommandItem value="Settings" onSelect={openSettings}>
@@ -483,6 +514,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                 onSelect={() => runAction(entry.handler)}
               >
                 {entry.title}
+                {entry.keybinding && (
+                  <kbd className="ml-auto rounded border border-border px-1 text-[11px] text-muted-foreground font-mono">
+                    {entry.keybinding}
+                  </kbd>
+                )}
               </CommandItem>
             ))}
           </CommandGroup>

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
@@ -18,6 +18,7 @@ import { useNavigate } from "@tanstack/react-router";
 
 import { cn } from "@/lib/utils";
 import { useSurface, type Surface } from "@/lib/surface";
+import { surfaceKeybinding } from "@/lib/surface-actions";
 // CTL-989 — nav WRITES go through router.navigate (URL = source of truth for
 // location). The active surface + Settings-open are READ from the route via
 // useSurface(); scope is written onto the `?scope` typed search param.
@@ -408,6 +409,9 @@ export function AppSidebar() {
       countBadge = queueN; // keep the 0 — "nothing waiting" is real signal
       rowTooltip = `${queueN} waiting for a slot`;
     }
+    // CTL-1025: show the keybinding hint in the tooltip for nav items that have one.
+    const kb = surfaceKeybinding(item.surface);
+    if (kb) rowTooltip = `${rowTooltip} · ${kb}`;
 
     return (
       <SidebarMenuItem key={`${scopeVal}:${item.surface}`}>
@@ -416,6 +420,7 @@ export function AppSidebar() {
           tooltip={rowTooltip}
           size={compact ? "sm" : "default"}
           onClick={() => go(item.surface, scopeVal)}
+          data-keybinding={kb || undefined}
           // CTL-981: inactive = font-medium (weight 500) + text-sidebar-foreground/72
           // (raised from /60 for better label presence — matches Linear's lch(60) gray);
           // active = text-sidebar-primary (full accent, clearly brighter than /72).
@@ -689,12 +694,14 @@ export function AppSidebar() {
                       repo-scoped, so the active check is surface-only. */}
                   {OBSERVE_LIVE.map((item) => {
                     const active = surface === item.surface;
+                    const observeKb = surfaceKeybinding(item.surface);
                     return (
                       <SidebarMenuItem key={item.surface}>
                         <SidebarMenuButton
                           isActive={active}
-                          tooltip={item.label}
+                          tooltip={observeKb ? `${item.label} · ${observeKb}` : item.label}
                           onClick={() => go(item.surface)}
+                          data-keybinding={observeKb || undefined}
                           className={cn(
                             active
                               ? "text-sidebar-primary"

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/key-nav.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/key-nav.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "bun:test";
+import { classifyKey } from "./key-nav";
+
+describe("classifyKey — unified input-focus guard (CTL-1025)", () => {
+  it("swallows j/k while a contenteditable host is focused", () => {
+    expect(classifyKey({ key: "j" }, { tagName: "DIV", isContentEditable: true }, false).type)
+      .toBe("none");
+    expect(classifyKey({ key: "k" }, { tagName: "DIV", isContentEditable: true }, false).type)
+      .toBe("none");
+  });
+
+  it("swallows j/k while SELECT is focused (newly covered by unified guard)", () => {
+    expect(classifyKey({ key: "j" }, { tagName: "SELECT" }, false).type).toBe("none");
+  });
+
+  it("still swallows in INPUT and TEXTAREA (regression)", () => {
+    expect(classifyKey({ key: "j" }, { tagName: "INPUT" }, false).type).toBe("none");
+    expect(classifyKey({ key: "j" }, { tagName: "TEXTAREA" }, false).type).toBe("none");
+  });
+
+  it("still lets ⌘K pierce the guard (kept)", () => {
+    expect(classifyKey({ key: "k", metaKey: true }, { tagName: "INPUT" }, false).type)
+      .toBe("palette");
+  });
+
+  it("still classifies j/k when no element is focused (undefined)", () => {
+    expect(classifyKey({ key: "j" }, undefined, false).type).toBe("next");
+    expect(classifyKey({ key: "k" }, undefined, false).type).toBe("prev");
+  });
+
+  it("still classifies j/k when a non-typing element is focused", () => {
+    expect(classifyKey({ key: "j" }, { tagName: "BUTTON" }, false).type).toBe("next");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/key-nav.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/key-nav.ts
@@ -11,6 +11,9 @@
 // and dispatches the returned action — so the keymap the operator feels can never
 // drift from what key-nav.test.ts locks in.
 
+import { isTypingTarget, type TypingTargetLike } from "../lib/typing-target";
+export { isTypingTarget };
+
 /** The minimal event shape the classifier reads — a structural subset of the DOM
  *  `KeyboardEvent` so the hook can pass the real event AND the test can pass a
  *  plain object (no jsdom needed). */
@@ -40,26 +43,6 @@ export type KeyAction =
   | { type: "chord-start" } // `g` pressed → arm the chord, await the second key
   | { type: "none" }; // ignored keystroke (incl. all input-focus keys)
 
-/**
- * Whether the focused element is a typing target the keymap must not steal keys
- * from. The pre-existing guard (`use-keyboard-nav.ts:24`) checks INPUT / TEXTAREA
- * / SELECT by tag name; kept byte-for-byte (uppercased tag) so `/`-into-a-textarea
- * and j/k-into-an-input still type a literal character. `tag` is the focused
- * element's `tagName` (the hook reads `document.activeElement?.tagName`).
- *
- * CTL-1049: ALSO treat a contentEditable host as a typing target — `Escape` now
- * means "navigate back" (the Escape=back Gherkin), so it must never fire while the
- * operator is editing a rich-text region. The optional `editable` flag is the
- * focused element's `isContentEditable` (the hook reads `(el as HTMLElement)
- * ?.isContentEditable`); absent/false in the no-DOM test path is a no-op.
- */
-export function isTypingTarget(
-  tag: string | undefined | null,
-  editable?: boolean,
-): boolean {
-  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || editable === true;
-}
-
 /** True when no modifier (other than the explicit ⌘/Ctrl handled for the palette)
  *  is held — single-letter shortcuts must not fire while a chord/shortcut modifier
  *  is down, so a browser hotkey like ⌥j is never swallowed as "next". */
@@ -71,7 +54,9 @@ function isBareKey(e: KeyEventLike): boolean {
  * Classify a keystroke into a nav action (detail design §3.4 keyboard table).
  *
  * @param e            the keystroke (real DOM event or a plain test object).
- * @param focusedTag   `document.activeElement?.tagName` — the input-focus guard.
+ * @param focused      the focused element shape — `{ tagName?, isContentEditable? }` or
+ *                     undefined/null (CTL-1025: unified guard now covers SELECT +
+ *                     contentEditable in addition to INPUT/TEXTAREA).
  * @param chordPending true when a `g` was pressed within the chord window and we
  *                     are awaiting the second key (the hook owns the timer).
  *
@@ -90,19 +75,16 @@ function isBareKey(e: KeyEventLike): boolean {
  */
 export function classifyKey(
   e: KeyEventLike,
-  focusedTag: string | undefined | null,
+  focused: TypingTargetLike | undefined | null,
   chordPending: boolean,
-  focusedEditable?: boolean,
 ): KeyAction {
   // 1. ⌘K / Ctrl-K — the palette toggle pierces the input guard (always reachable).
   if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
     return { type: "palette", preventDefault: true };
   }
 
-  // 2. Input-focus guard (pre-existing, kept): swallow nothing while typing.
-  //    CTL-1049: a focused contentEditable host counts as a typing target too, so
-  //    Escape-means-back can't fire mid-edit.
-  if (isTypingTarget(focusedTag, focusedEditable)) return { type: "none" };
+  // 2. Input-focus guard (unified, CTL-1025): swallow nothing while typing.
+  if (isTypingTarget(focused)) return { type: "none" };
 
   // 3. Resolve a pending `g`-chord with the second bare key.
   if (chordPending && isBareKey(e)) {

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-keyboard-nav.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-keyboard-nav.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { classifyKey, CHORD_WINDOW_MS } from "./key-nav";
+import type { TypingTargetLike } from "../lib/typing-target";
 
 interface KeyboardNavOptions {
   // ── pre-existing callbacks (unchanged) ──────────────────────────────────────
@@ -59,13 +60,9 @@ export function useKeyboardNav(options: KeyboardNavOptions): void {
     };
 
     function handleKeyDown(e: KeyboardEvent) {
-      const active = document.activeElement as HTMLElement | null;
-      const focusedTag = active?.tagName;
-      // CTL-1049: also guard a focused contentEditable host so Escape-means-back
-      // (and the other shortcuts) never fire while the operator edits rich text.
-      const focusedEditable = active?.isContentEditable === true;
+      const focused = document.activeElement as TypingTargetLike | null;
       const wasChordPending = chordPending;
-      const action = classifyKey(e, focusedTag, wasChordPending, focusedEditable);
+      const action = classifyKey(e, focused, wasChordPending);
 
       // Any resolved keystroke (the second key of a chord, or a non-`g` key)
       // clears a pending chord before we dispatch. `chord-start` re-arms below.

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/action-keymatch.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/action-keymatch.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "bun:test";
+import { parseKeybinding, matchAction } from "./action-keymatch";
+import type { ActionEntry } from "./action-registry";
+
+const noop = () => {};
+const entries: ActionEntry[] = [
+  { id: "nav.surface.board", title: "Go to Tickets", scope: "global", handler: noop, keybinding: "g b" },
+  { id: "action.create", title: "Create", scope: "global", handler: noop, keybinding: "c" },
+];
+
+describe("parseKeybinding", () => {
+  it("splits a chord into prefix + key", () => {
+    expect(parseKeybinding("g b")).toEqual({ chord: "g", key: "b" });
+  });
+  it("treats a single token as a bare key", () => {
+    expect(parseKeybinding("c")).toEqual({ chord: null, key: "c" });
+  });
+});
+
+describe("matchAction", () => {
+  const ctx = { surface: "home" as const };
+  it("fires a bare single-key action when no chord is pending", () => {
+    expect(matchAction(entries, ctx, { key: "c" }, false)?.id).toBe("action.create");
+  });
+  it("does NOT fire a single-key action while a chord is pending", () => {
+    expect(matchAction(entries, ctx, { key: "c" }, true)).toBeNull();
+  });
+  it("fires a g-chord action only when the chord is pending", () => {
+    expect(matchAction(entries, ctx, { key: "b" }, true)?.id).toBe("nav.surface.board");
+    expect(matchAction(entries, ctx, { key: "b" }, false)).toBeNull();
+  });
+  it("ignores keystrokes with meta/ctrl/alt (those belong to other handlers)", () => {
+    expect(matchAction(entries, ctx, { key: "c", metaKey: true }, false)).toBeNull();
+  });
+  it("returns null when no matching binding exists", () => {
+    expect(matchAction(entries, ctx, { key: "x" }, false)).toBeNull();
+  });
+  it("respects scope via visibleActions (board action hidden on home)", () => {
+    const boardOnly: ActionEntry[] = [
+      { id: "x", title: "X", scope: "board", handler: noop, keybinding: "x" },
+    ];
+    expect(matchAction(boardOnly, { surface: "home" }, { key: "x" }, false)).toBeNull();
+  });
+  it("board-scope action fires on board surface", () => {
+    const boardOnly: ActionEntry[] = [
+      { id: "x", title: "X", scope: "board", handler: noop, keybinding: "x" },
+    ];
+    expect(matchAction(boardOnly, { surface: "board" }, { key: "x" }, false)?.id).toBe("x");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/action-keymatch.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/action-keymatch.ts
@@ -1,0 +1,37 @@
+import type { ActionEntry, ActionContext } from "./action-registry";
+import { visibleActions } from "./action-registry";
+
+export interface ParsedBinding { chord: string | null; key: string }
+
+/** Parse a `keybinding` string: "g b" → chord "g" + key "b"; "c" → bare key "c". */
+export function parseKeybinding(binding: string): ParsedBinding {
+  const parts = binding.trim().split(/\s+/);
+  return parts.length === 2
+    ? { chord: parts[0], key: parts[1] }
+    : { chord: null, key: parts[0] };
+}
+
+interface KeyLike { key: string; metaKey?: boolean; ctrlKey?: boolean; altKey?: boolean }
+
+/**
+ * Resolve a keystroke to the ActionEntry it should fire, or null.
+ *  - modifier keys (meta/ctrl/alt) never match a no-modifier binding.
+ *  - when `chordPending`, only two-key (`g x`) bindings whose key matches fire.
+ *  - otherwise only bare single-key bindings fire.
+ * Scope is honored via visibleActions; first match in registry order wins.
+ */
+export function matchAction(
+  entries: ActionEntry[],
+  ctx: ActionContext,
+  e: KeyLike,
+  chordPending: boolean,
+): ActionEntry | null {
+  if (e.metaKey || e.ctrlKey || e.altKey) return null;
+  for (const entry of visibleActions(entries, ctx)) {
+    if (!entry.keybinding) continue;
+    const { chord, key } = parseKeybinding(entry.keybinding);
+    if (key !== e.key) continue;
+    if (chordPending ? chord === "g" : chord === null) return entry;
+  }
+  return null;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-actions.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-actions.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "bun:test";
+import { buildSurfaceActions, surfaceChordYieldsToDetail, surfaceKeybinding } from "./surface-actions";
+import { SURFACE_CHORD } from "./surface-constants";
+
+describe("buildSurfaceActions", () => {
+  const jumps: string[] = [];
+  const actions = buildSurfaceActions({
+    jumpToSurface: (s) => jumps.push(s),
+    create: () => jumps.push("create"),
+  });
+
+  it("emits one global action per SURFACE_CHORD entry with a 'g <key>' keybinding", () => {
+    for (const [key, surface] of Object.entries(SURFACE_CHORD)) {
+      const a = actions.find((x) => x.keybinding === `g ${key}`);
+      expect(a, `binding g ${key}`).toBeDefined();
+      expect(a!.scope).toBe("global");
+      a!.handler();
+      expect(jumps.at(-1)).toBe(surface);
+    }
+  });
+
+  it("registers `c` → create as a global action (deferred handler ok)", () => {
+    const c = actions.find((x) => x.keybinding === "c");
+    expect(c?.id).toBe("action.create");
+    expect(c?.scope).toBe("global");
+  });
+});
+
+describe("g-chord detail precedence (Open Question #4)", () => {
+  it("yields g t / g w / g a to the detail Shell on a detail route", () => {
+    for (const key of ["t", "w", "a"]) {
+      expect(surfaceChordYieldsToDetail("/ticket/CTL-1", key)).toBe(true);
+      expect(surfaceChordYieldsToDetail("/worker/abc", key)).toBe(true);
+    }
+  });
+  it("does NOT yield non-overlapping surface keys on a detail route", () => {
+    expect(surfaceChordYieldsToDetail("/ticket/CTL-1", "b")).toBe(false);
+  });
+  it("never yields off a detail route", () => {
+    expect(surfaceChordYieldsToDetail("/board", "w")).toBe(false);
+    expect(surfaceChordYieldsToDetail("/", "t")).toBe(false);
+  });
+});
+
+describe("surfaceKeybinding — hover-hint source", () => {
+  it("returns the g-chord for a surface", () => {
+    expect(surfaceKeybinding("board")).toBe("g b");
+    expect(surfaceKeybinding("workers")).toBe("g w");
+    expect(surfaceKeybinding("home")).toBe("g h");
+    expect(surfaceKeybinding("queue")).toBe("g q");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-actions.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-actions.ts
@@ -1,0 +1,46 @@
+import type { ActionEntry } from "./action-registry";
+// Import from surface-constants (React-/router-free) so tests don't pull in @tanstack/react-router.
+import { SURFACE_CHORD, SURFACE_LABEL, type Surface } from "./surface-constants";
+
+export interface SurfaceActionHandlers {
+  jumpToSurface: (s: Surface) => void;
+  /** Deferred — Open Question #1: no create flow exists yet. */
+  create: () => void;
+}
+
+/** The two-key sequences the detail Shell owns; the surface listener yields these on detail routes. */
+const DETAIL_CHORD_KEYS = new Set(["t", "w", "a"]);
+const DETAIL_ROUTE = /^\/(ticket|worker)\//;
+
+/** True when a pending `g <key>` on this path must defer to the detail Shell classifier. */
+export function surfaceChordYieldsToDetail(pathname: string, key: string): boolean {
+  return DETAIL_ROUTE.test(pathname) && DETAIL_CHORD_KEYS.has(key);
+}
+
+export function buildSurfaceActions(h: SurfaceActionHandlers): ActionEntry[] {
+  const surfaceJumps: ActionEntry[] = Object.entries(SURFACE_CHORD).map(([key, surface]) => ({
+    id: `nav.surface.${surface}`,
+    title: `Go to ${SURFACE_LABEL[surface as Surface]}`,
+    keywords: ["go", "navigate", surface],
+    scope: "global" as const,
+    keybinding: `g ${key}`,
+    handler: () => h.jumpToSurface(surface as Surface),
+  }));
+
+  const create: ActionEntry = {
+    id: "action.create",
+    title: "Create…",
+    keywords: ["new", "create"],
+    scope: "global",
+    keybinding: "c",
+    handler: h.create,
+  };
+
+  return [...surfaceJumps, create];
+}
+
+/** The display binding for a surface's nav hint, derived from SURFACE_CHORD (single source). */
+export function surfaceKeybinding(surface: Surface): string | undefined {
+  const key = Object.entries(SURFACE_CHORD).find(([, s]) => s === surface)?.[0];
+  return key ? `g ${key}` : undefined;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-constants.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-constants.ts
@@ -1,0 +1,62 @@
+/** Pure surface constants — React-/router-free so they can be imported in tests
+ *  without pulling in @tanstack/react-router. surface.ts re-exports from here;
+ *  surface-actions.ts imports from here directly. */
+
+export type Surface =
+  | "home"
+  | "board"
+  | "workers"
+  | "queue"
+  | "telemetry"
+  | "utilization"
+  | "finops"
+  | "fleetops"
+  | "devops";
+
+export const SURFACES: readonly Surface[] = [
+  "home",
+  "board",
+  "workers",
+  "queue",
+  "telemetry",
+  "utilization",
+  "finops",
+  "fleetops",
+  "devops",
+] as const;
+
+export const SURFACE_LABEL: Record<Surface, string> = {
+  home: "Inbox",
+  board: "Tickets",
+  workers: "Workers",
+  queue: "Dispatch",
+  telemetry: "Telemetry",
+  utilization: "Utilization",
+  finops: "FinOps",
+  fleetops: "Fleet Ops",
+  devops: "DevOps",
+};
+
+export const SURFACE_CHORD: Record<string, Surface> = {
+  h: "home",
+  b: "board",
+  w: "workers",
+  q: "queue",
+  t: "telemetry",
+  u: "utilization",
+  f: "finops",
+  o: "fleetops",
+  d: "devops",
+};
+
+export const SURFACE_BREADCRUMB: Record<Surface, string[]> = {
+  home: ["Overall", "Inbox"],
+  board: ["Overall", "Tickets"],
+  workers: ["Overall", "Workers"],
+  queue: ["Overall", "Dispatch"],
+  telemetry: ["Observe", "Telemetry"],
+  utilization: ["Observe", "Utilization"],
+  finops: ["Observe", "FinOps"],
+  fleetops: ["Observe", "Fleet Ops"],
+  devops: ["Observe", "DevOps"],
+};

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/surface.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/surface.ts
@@ -14,81 +14,17 @@
 // route-surface.ts.
 import { useRouterState } from "@tanstack/react-router";
 import { pathnameToSurface, SETTINGS_PATH } from "./route-surface";
+import type { Surface } from "./surface-constants";
 
-/** The top-level surfaces the shell can render in SidebarInset.
- *  OBS-5: the five OBSERVE analytics surfaces join the four OPERATE surfaces.
- *  Only Telemetry is wired live tonight (its content ships in OBS-6/7/8); the
- *  other four are declared here so each later surface only needs its own switch
- *  branch (the four-touch routing pattern, build-plan §2.2). */
-export type Surface =
-  | "home"
-  | "board"
-  | "workers"
-  | "queue"
-  | "telemetry"
-  | "utilization"
-  | "finops"
-  | "fleetops"
-  | "devops";
-
-/** Every surface in nav order — the single source the sidebar + palette iterate.
- *  OBS-5: OBSERVE surfaces follow the OPERATE block (after queue). */
-export const SURFACES: readonly Surface[] = [
-  "home",
-  "board",
-  "workers",
-  "queue",
-  "telemetry",
-  "utilization",
-  "finops",
-  "fleetops",
-  "devops",
-] as const;
-
-/** Human label per surface (sidebar item + command palette).
- *  CTL-930: home → "Inbox", board → "Tickets" (internal union keys unchanged).
- *  OBS-5: OBSERVE labels (Telemetry/Utilization/FinOps/Fleet Ops/DevOps). */
-export const SURFACE_LABEL: Record<Surface, string> = {
-  home: "Inbox",
-  board: "Tickets",
-  workers: "Workers",
-  queue: "Dispatch",
-  telemetry: "Telemetry",
-  utilization: "Utilization",
-  finops: "FinOps",
-  fleetops: "Fleet Ops",
-  devops: "DevOps",
-};
-
-/** The `g <key>` jump keys, kept next to the Surface union so they stay in sync.
- *  OBS-5: OBSERVE chords pick keys that don't collide with the existing h/b/w/q —
- *  t(elemetry) / u(tilization) / f(inops) / o(=fleetOps, f taken) / d(evops). */
-export const SURFACE_CHORD: Record<string, Surface> = {
-  h: "home",
-  b: "board",
-  w: "workers",
-  q: "queue",
-  t: "telemetry",
-  u: "utilization",
-  f: "finops",
-  o: "fleetops",
-  d: "devops",
-};
-
-/** Breadcrumb trail per surface — scope-less fallback (used by tests + non-scoped contexts).
- *  CTL-930: scope-aware breadcrumbs use lib/nav-model#breadcrumbFor instead.
- *  OBS-5: OBSERVE surfaces sit under an "Observe" crumb instead of "Overall". */
-export const SURFACE_BREADCRUMB: Record<Surface, string[]> = {
-  home: ["Overall", "Inbox"],
-  board: ["Overall", "Tickets"],
-  workers: ["Overall", "Workers"],
-  queue: ["Overall", "Dispatch"],
-  telemetry: ["Observe", "Telemetry"],
-  utilization: ["Observe", "Utilization"],
-  finops: ["Observe", "FinOps"],
-  fleetops: ["Observe", "Fleet Ops"],
-  devops: ["Observe", "DevOps"],
-};
+// Pure constants live in surface-constants.ts (React-/router-free) so tests that
+// import surface-actions.ts don't transitively pull in @tanstack/react-router.
+export {
+  type Surface,
+  SURFACES,
+  SURFACE_LABEL,
+  SURFACE_CHORD,
+  SURFACE_BREADCRUMB,
+} from "./surface-constants";
 
 /**
  * Breadcrumb for the Settings surface (CTL-911 / SURF3). Settings is a FOOTER
@@ -99,21 +35,10 @@ export const SURFACE_BREADCRUMB: Record<Surface, string[]> = {
  */
 export const SETTINGS_BREADCRUMB: string[] = ["Settings"];
 
-/**
- * True when focus is in a text-entry context — the shell's `[` / `g` chord
- * handlers must NOT steal those keystrokes. Pure so it can be unit-tested with a
- * minimal `{ tagName, isContentEditable }` shape rather than a real DOM node.
- */
-export function isTypingTarget(
-  target: { tagName?: string; isContentEditable?: boolean } | null,
-): boolean {
-  if (!target) return false;
-  return (
-    target.tagName === "INPUT" ||
-    target.tagName === "TEXTAREA" ||
-    target.isContentEditable === true
-  );
-}
+/** The single canonical input-focus guard (CTL-1025) — re-exported from
+ *  lib/typing-target so the existing callers (command-palette.ts, sidebar-collapse.ts)
+ *  keep compiling unchanged while gaining SELECT + contentEditable coverage. */
+export { isTypingTarget, type TypingTargetLike } from "./typing-target";
 
 /**
  * The route-derived shell location (CTL-989). The old surface-mutating + settings

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/typing-target.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/typing-target.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "bun:test";
+import { isTypingTarget } from "./typing-target";
+
+describe("isTypingTarget — single canonical input-focus guard", () => {
+  it("matches INPUT, TEXTAREA, SELECT", () => {
+    for (const tagName of ["INPUT", "TEXTAREA", "SELECT"]) {
+      expect(isTypingTarget({ tagName })).toBe(true);
+    }
+  });
+  it("matches a contenteditable host", () => {
+    expect(isTypingTarget({ tagName: "DIV", isContentEditable: true })).toBe(true);
+  });
+  it("ignores non-typing elements and null", () => {
+    expect(isTypingTarget({ tagName: "BUTTON" })).toBe(false);
+    expect(isTypingTarget(null)).toBe(false);
+  });
+  it("ignores undefined", () => {
+    expect(isTypingTarget(undefined)).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/typing-target.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/typing-target.ts
@@ -1,0 +1,17 @@
+/** The single input-focus guard for every keyboard path (CTL-1025). Covers the
+ *  union of what the two prior guards checked: INPUT / TEXTAREA / SELECT / a
+ *  contenteditable host. Pure + structural so it unit-tests without a DOM. */
+export interface TypingTargetLike {
+  tagName?: string;
+  isContentEditable?: boolean;
+}
+
+export function isTypingTarget(target: TypingTargetLike | null | undefined): boolean {
+  if (!target) return false;
+  return (
+    target.tagName === "INPUT" ||
+    target.tagName === "TEXTAREA" ||
+    target.tagName === "SELECT" ||
+    target.isContentEditable === true
+  );
+}


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-11T23:02:45Z -->
<!-- Last updated: 2026-06-11T23:02:45Z -->
<!-- PR: #1861 -->
<!-- Previous commits: 6d45d35,4c488e4,a4d8869,53625ee,78e1128,f92bcd2 -->

## Summary

- **Unified typing guard**: new `typing-target.ts` with `TypingTargetLike` structural interface covering INPUT/TEXTAREA/SELECT/contentEditable; replaces 3 separate ad-hoc guards across the codebase
- **Pure constants split**: `surface-constants.ts` extracts the `Surface` type + chord/label/breadcrumb maps out of React-importing `surface.ts`, enabling test-safe imports without pulling in `@tanstack/react-router`
- **Action-keymatch engine**: `matchAction()` + `parseKeybinding()` resolve a keystroke + chord-pending state → `ActionEntry`, replacing the hardcoded `SURFACE_CHORD` switch in AppShell
- **Surface nav via action registry**: `buildSurfaceActions()` creates all 9 `g <key>` surface-jump entries + bare-`c` create action through the existing `ActionEntry` contract; `surfaceChordYieldsToDetail()` handles detail-route precedence for g t/w/a
- **Keybinding hints UI**: palette rows show `<kbd>` chips for actions that have a `keybinding`; sidebar nav items get `data-keybinding` + tooltip hint via `surfaceKeybinding()`
- **Keymap cheatsheet updated**: "Go to" section added with all 9 surface chords + context notes disambiguating j/k/g-chord scope on detail vs. board pages

## Changes Made

### Frontend — orch-monitor UI

**Phase 1 — Canonical typing guard + surface constants split** (`6d45d35`)
- `typing-target.ts`: new `TypingTargetLike` structural interface; `isTypingTarget()` replaces 3 ad-hoc guards
- `surface-constants.ts`: pure-TS split of Surface type, chord map, label map, breadcrumb config; zero React imports → test-safe
- Existing `surface.ts` retains the router-dependent `useSurface` hook, now importing from `surface-constants.ts`

**Phase 2 — Action-keymatch + surface-actions pure logic** (`4c488e4`)
- `action-keymatch.ts`: `parseKeybinding()` tokenises chord/key strings; `matchAction()` resolves keystroke + chord state → `ActionEntry | null`; rejects all modifier keystrokes
- `surface-actions.ts`: `buildSurfaceActions()` generates 9 `g <key>` surface navigation entries + bare `c` create action; `surfaceChordYieldsToDetail()` disambiguates g t/w/a on detail routes; `surfaceKeybinding()` maps a surface to its keybinding string

**Phase 3 — Wire matchAction into AppShell; keybinding hints in sidebar** (`a4d8869`)
- `app-shell.tsx`: refactored `handleKeyDown` to use `matchAction()` + `buildSurfaceActions()` instead of hardcoded switch; `isTypingTarget()` guard replaces inline logic
- `app-sidebar.tsx`: sidebar nav items decorated with `data-keybinding` attribute and tooltip hint rendered via `surfaceKeybinding()`

**Phase 4 — Keybinding hints in palette; keymap + hook tests** (`53625ee`)
- `CommandPalette.tsx`: palette rows render `<kbd>` chips for actions with a `keybinding` field
- `keymap.ts`: "Go to" section added covering all 9 surface chords + context disambiguation notes
- Tests: `key-nav.test.ts`, `palette-actions.test.ts`, `keymap.test.ts`, `key-nav.ts` hook test (94 tests total)

**Remediation — CTL-1049 Escape-guard compat** (`78e1128`, `f92bcd2`)
- Ported CTL-1049's Escape-guard tests to canonical `typing-target` API; removed duplicate guard in `use-keyboard-nav.ts`

### Files changed: 19 (+483 / -152 lines), 5 commits

## How to Verify It

- [x] `bun test __tests__/key-nav.test.ts ui/src/lib/typing-target.test.ts ui/src/lib/action-keymatch.test.ts ui/src/lib/surface-actions.test.ts ui/src/hooks/key-nav.test.ts ui/src/board/keymap.test.ts ui/src/board/palette-actions.test.ts` — 94 tests pass ✅
- [x] `typecheck` — 6 pre-existing errors (ui React-router deps not installed in orch worktree); 0 new errors ✅
- [x] `lint` — 0 errors ✅
- [x] Full `bun test` — 4093 pass (25 net new), same 22 pre-existing unhandled errors, 3 fewer failures vs. baseline ✅
- [ ] j/k walk the list in detail view; g b/g h/g w/g q/g t navigate surfaces (manual)
- [ ] ⌘K opens palette even from an input; `/` focuses board search; `?` opens cheatsheet; `Escape` dismisses (manual)
- [ ] Palette rows show `<kbd>` chips for bound actions; sidebar nav tooltips show keybinding hints (manual)

## Pre-Merge Verification (from verify phase)

- **Regression risk**: 0 / 10
- **Tests**: pass — 94 passing tests across 7 files added; no new failures vs. baseline
- **Typecheck**: pass — 6 pre-existing errors only; 0 new type errors
- **Lint**: pass — 0 errors
- **Coverage**: pass — extracted pure logic fully unit-tested; >50% diff coverage
- **Security**: pass — pure frontend keyboard-nav refactor; no I/O, secrets, SQL, or auth boundary
- **Code review**: pass — clean constant-extraction + action-registry wiring; AppShell handler ordering sound
- **Silent-failure**: pass — no unchecked try/catch, swallowed errors, or silent fallbacks

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1025

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1049
