### PR TITLE
feat(dev): CTL-1058 — fix advance-shadow input-skew false disagreements via EDB-locked oracle

### DIFF
--- a/plugins/dev/scripts/execution-core/beliefs/advance-shadow.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/advance-shadow.mjs
@@ -53,6 +53,47 @@ export function readAdvanceBeliefs(db, tickId) {
   return { advanceTo, cycleExhausted };
 }
 
+// readSignalsFromEdb — reconstruct the { phase: status } map the belief saw for one
+// ticket from the tick-locked obs_signal snapshot. Same shape readPhaseSignals returns,
+// but sourced from the EDB (no live-disk read) → no mid-tick input skew (CTL-1058).
+// Deterministic MIN(fact_id) tie-break on duplicate (tick_id,ticket,phase), matching
+// R16's latest_sig CTE (rules.mjs:632).
+export function readSignalsFromEdb(db, tickId, ticket) {
+  const out = {};
+  if (!db || tickId == null) return out;
+  const rows = db
+    .query(
+      "SELECT phase, status FROM obs_signal WHERE tick_id = ? AND ticket = ? ORDER BY fact_id ASC",
+    )
+    .all(tickId, ticket);
+  for (const r of rows) {
+    if (!Object.prototype.hasOwnProperty.call(out, r.phase)) {
+      out[r.phase] = r.status ?? null; // first (MIN fact_id) wins
+    }
+  }
+  return out;
+}
+
+// readVerdictFromEdb — the verify verdict the belief saw for one ticket, from the
+// tick-locked obs_verdict snapshot. Null verdicts have no row ⇒ return null.
+export function readVerdictFromEdb(db, tickId, ticket) {
+  if (!db || tickId == null) return null;
+  const row = db
+    .query("SELECT verdict FROM obs_verdict WHERE tick_id = ? AND ticket = ? LIMIT 1")
+    .get(tickId, ticket);
+  return row?.verdict ?? null;
+}
+
+// readCycleFromEdb — the remediate cycle count the belief saw for one ticket, from the
+// tick-locked obs_cycle snapshot. No row ⇒ 0 (count=0 is normally inserted, but stay safe).
+export function readCycleFromEdb(db, tickId, ticket) {
+  if (!db || tickId == null) return 0;
+  const row = db
+    .query("SELECT remediate_count FROM obs_cycle WHERE tick_id = ? AND ticket = ? LIMIT 1")
+    .get(tickId, ticket);
+  return row?.remediate_count ?? 0;
+}
+
 // signalsSummary — a compact { phase: status } map for the disagreement payload.
 function signalsSummary(signals) {
   const out = {};

--- a/plugins/dev/scripts/execution-core/beliefs/advance-shadow.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/advance-shadow.mjs
@@ -14,16 +14,15 @@
 // contract); it additionally guards each ticket so one bad ticket can't abort the
 // comparison of the rest.
 //
-// TIMING (shadow fidelity, not a bug): this comparator runs AFTER collectBeliefsTick
-// (so the advance_to/cycle_exhausted beliefs for THIS tick exist) and BEFORE
-// schedulerTick (which runs maybeResetForRemediateCycle + the real dispatch). The
-// comparator re-reads the PRE-reset signals via the injected readSignals seam, so
-// its procedural oracle is computed over the SAME inputs the belief saw — a true
-// apples-to-apples belief-vs-oracle comparison. The sweep's own deriveAdvancement
-// (over POST-reset signals on a remediate→verify re-entry tick) is a different
-// call at a different point in the tick; this comparator deliberately does NOT
-// reproduce the reset (derive-only — it owns no file deletes), so a logged
-// disagreement always reflects a belief/oracle mismatch on identical inputs.
+// TIMING (shadow fidelity): this comparator runs AFTER collectBeliefsTick (so the
+// advance_to/cycle_exhausted beliefs for THIS tick exist) and BEFORE schedulerTick
+// (which runs maybeResetForRemediateCycle + the real dispatch). In production the
+// oracle reads its inputs from the tick-locked EDB snapshot (obs_signal/obs_verdict/
+// obs_cycle for this tickId) — the SAME rows the belief consumed at collectBeliefsTick.
+// This is a true apples-to-apples comparison: a logged disagreement reflects a genuine
+// belief/oracle mismatch on identical inputs, not mid-tick input skew from a phase
+// signal file mutating between Steps 2 and 4 (CTL-1058). The disk seams remain
+// available as test-override hooks; only the production wiring was changed.
 
 // readAdvanceBeliefs — for one tick, the advance_to + cycle_exhausted beliefs
 // keyed by ticket (subject). Returns { advanceTo: Map<ticket,{from,to}>,

--- a/plugins/dev/scripts/execution-core/beliefs/advance-shadow.test.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/advance-shadow.test.mjs
@@ -11,7 +11,14 @@ import { tmpdir } from "node:os";
 
 import { openBeliefsDb } from "./schema.mjs";
 import { evaluateBeliefs } from "./rules.mjs";
-import { runAdvanceShadow, readAdvanceBeliefs, compareAdvancement } from "./advance-shadow.mjs";
+import {
+  runAdvanceShadow,
+  readAdvanceBeliefs,
+  compareAdvancement,
+  readSignalsFromEdb,
+  readVerdictFromEdb,
+  readCycleFromEdb,
+} from "./advance-shadow.mjs";
 import { deriveAdvancement } from "../scheduler.mjs";
 import { REMEDIATE_CYCLE_CAP } from "../../lib/phase-fsm.mjs";
 
@@ -215,6 +222,87 @@ describe("runAdvanceShadow — robustness + no-act contract", () => {
     const summary = events.find((e) => e["event.name"] === "beliefs.advance_shadow.tick");
     expect(summary).toBeTruthy();
     expect(summary.payload).toEqual({ agree: 1, disagree: 0 });
+  });
+});
+
+describe("EDB-backed oracle readers", () => {
+  test("readSignalsFromEdb reconstructs { phase: status } tick-locked", () => {
+    const t = tick();
+    signal(t, "CTL-1", "research", "done");
+    signal(t, "CTL-1", "plan", "running");
+    signal(t, "CTL-2", "plan", "done"); // other ticket — must not leak
+    expect(readSignalsFromEdb(db, t, "CTL-1")).toEqual({ research: "done", plan: "running" });
+  });
+
+  test("readSignalsFromEdb returns {} for unknown tick/ticket and null db", () => {
+    const t = tick();
+    expect(readSignalsFromEdb(db, t, "NOPE")).toEqual({});
+    expect(readSignalsFromEdb(db, 999999, "CTL-1")).toEqual({});
+    expect(readSignalsFromEdb(null, t, "CTL-1")).toEqual({});
+    expect(readSignalsFromEdb(db, null, "CTL-1")).toEqual({});
+  });
+
+  test("readSignalsFromEdb tie-breaks duplicate (tick,ticket,phase) deterministically by MIN(fact_id)", () => {
+    const t = tick();
+    signal(t, "CTL-1", "plan", "running"); // lower fact_id — wins
+    signal(t, "CTL-1", "plan", "done");
+    expect(readSignalsFromEdb(db, t, "CTL-1")).toEqual({ plan: "running" });
+  });
+
+  test("readVerdictFromEdb returns pass/fail and null when no row", () => {
+    const t = tick();
+    verdict(t, "CTL-1", "fail");
+    expect(readVerdictFromEdb(db, t, "CTL-1")).toBe("fail");
+    expect(readVerdictFromEdb(db, t, "CTL-2")).toBe(null);
+    expect(readVerdictFromEdb(null, t, "CTL-1")).toBe(null);
+  });
+
+  test("readCycleFromEdb returns remediate_count, 0 when no row", () => {
+    const t = tick();
+    cycle(t, "CTL-1", 2);
+    expect(readCycleFromEdb(db, t, "CTL-1")).toBe(2);
+    expect(readCycleFromEdb(db, t, "CTL-2")).toBe(0);
+    expect(readCycleFromEdb(null, t, "CTL-1")).toBe(0);
+  });
+});
+
+describe("CTL-1058: input-skew no longer fires a false disagreement", () => {
+  test("EDB says plan=running (no advance_to belief); disk-style stub says plan=done → NO disagreement", () => {
+    const t = tick();
+    // Tick-start snapshot: plan still running → R16 produces NO advance_to belief.
+    signal(t, "CTL-1", "plan", "running");
+    evaluateBeliefs(db, t);
+
+    const events = [];
+    // Wire the EDB-backed readers (production behaviour after this fix) instead of
+    // the in-memory disk stub. Even if disk had since flipped to plan=done, the
+    // oracle reads the tick-locked snapshot → plan=running → agrees with belief.
+    const res = runAdvanceShadow(db, t, {
+      orchDir: "/fake",
+      listInFlight: () => ["CTL-1"],
+      readSignals: (_od, ticket) => readSignalsFromEdb(db, t, ticket),
+      readVerdict: ({ ticket }) => readVerdictFromEdb(db, t, ticket),
+      countCycles: ({ ticket }) => readCycleFromEdb(db, t, ticket),
+      deriveAdvancement,
+      cap: REMEDIATE_CYCLE_CAP,
+      appendEvent: (e) => events.push(e),
+    });
+
+    expect(res.disagree).toBe(0);
+    expect(events.filter((e) => e["event.name"] === "beliefs.advance_shadow.disagree")).toHaveLength(0);
+  });
+
+  test("control: the SAME EDB state with a disk stub returning plan=done DOES disagree (proves the test is load-bearing)", () => {
+    const t = tick();
+    signal(t, "CTL-1", "plan", "running");
+    evaluateBeliefs(db, t);
+
+    const events = [];
+    const res = runAdvanceShadow(db, t, {
+      ...makeSeams({ "CTL-1": { plan: "done" } }, { events }), // OLD disk behaviour
+    });
+
+    expect(res.disagree).toBe(1); // demonstrates the bug the fix removes
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -86,7 +86,12 @@ import { isIntentEffective, getMaxAttempts } from "./beliefs/intent.mjs";
 // deriveAdvancement oracle against the advance_to / cycle_exhausted beliefs and
 // logs disagreements. SHADOW ONLY (reads beliefs + computes oracle + logs; never
 // dispatches/writes a signal/writes Linear).
-import { runAdvanceShadow } from "./beliefs/advance-shadow.mjs";
+import {
+  runAdvanceShadow,
+  readSignalsFromEdb,
+  readVerdictFromEdb,
+  readCycleFromEdb,
+} from "./beliefs/advance-shadow.mjs";
 // CTL-937: bounded stall-diagnostician wake wiring (opt-in CATALYST_DIAGNOSTICIAN=1).
 import { processDiagnosticianWakes } from "./diagnostician.mjs";
 import { executeEscalations } from "./beliefs/escalate.mjs";
@@ -4438,9 +4443,12 @@ function runTick() {
           runAdvanceShadow(advDb, beliefsRes.tickId, {
             orchDir: runningOpts.orchDir,
             listInFlight: (od) => listInFlightTickets(od),
-            readSignals: (od, ticket) => readPhaseSignals(od, ticket),
-            readVerdict: ({ ticket, orchDir }) => readVerifyVerdict({ ticket, orchDir }),
-            countCycles: ({ ticket }) => countRemediateCycles({ ticket }),
+            // CTL-1058: oracle inputs come from the tick-locked EDB snapshot (the SAME rows
+            // the belief saw at collectBeliefsTick), not live disk — eliminates mid-tick
+            // input-skew false disagreements. Disk seams remain test-override hooks.
+            readSignals: (_od, ticket) => readSignalsFromEdb(advDb, beliefsRes.tickId, ticket),
+            readVerdict: ({ ticket }) => readVerdictFromEdb(advDb, beliefsRes.tickId, ticket),
+            countCycles: ({ ticket }) => readCycleFromEdb(advDb, beliefsRes.tickId, ticket),
             deriveAdvancement,
             cap: REMEDIATE_CYCLE_CAP,
             appendEvent: intentEventAppender,


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-11T23:17:00Z -->
<!-- Last updated: 2026-06-11T23:17:00Z -->
<!-- PR: #1862 -->
<!-- Previous commits: bf78856f02e2c042440ff37dacdbc77d87eff2e7,5f56b47f614e52f9166fbfbe1fe68d761b645883 -->

## Summary

The advance-shadow comparator was computing its oracle over live disk reads (`readPhaseSignals` / `readVerifyVerdict` / `countRemediateCycles`) while the belief was computed from the tick-locked EDB snapshot collected at the start of each tick. A phase signal that flipped mid-tick (between Step 2 and Step 4) produced a belief/oracle mismatch even when both sides were individually correct — the comparator logged a false disagreement that polluted the gate-window metric.

This PR fixes input identity by sourcing all oracle inputs from the same EDB rows the belief consumed (`obs_signal` / `obs_verdict` / `obs_cycle`, keyed by `tickId`). A logged disagreement now means a genuine belief/oracle mismatch, not a timing artifact.

Live trigger: CTL-1024, tick #6628, 2026-06-11 17:28:24Z — `plan` flipped done at `:24.000`, comparator ran at `:24.x`, `implement` dispatched at `:27`.

## Changes Made

### `advance-shadow.mjs` — EDB-backed oracle readers (+50/-10)

Added three pure functions exported from `advance-shadow.mjs`:

- **`readSignalsFromEdb(db, tickId, ticket)`** — reconstructs `{ phase: status }` from `obs_signal` for a specific `(tickId, ticket)` pair. Deterministic `MIN(fact_id)` tie-break on duplicate rows, matching R16's `latest_sig` CTE.
- **`readVerdictFromEdb(db, tickId, ticket)`** — returns the verify verdict from `obs_verdict`, or `null` if absent.
- **`readCycleFromEdb(db, tickId, ticket)`** — returns `remediate_count` from `obs_cycle`, or `0` if no row.

Corrected the TIMING comment that incorrectly claimed the comparator already used the same inputs as the belief. The comment now accurately describes the EDB-locked guarantee.

### `advance-shadow.test.mjs` — Unit tests + regression test (+89/-1)

- Unit tests for each reader covering shape, cross-ticket isolation, `MIN(fact_id)` tie-break, and null-safety.
- Regression test: `plan=running` at tick-start → belief says no advance; EDB-wired oracle also says no advance → 0 disagreements.
- Control test: same EDB state but disk stub returns `plan=done` → 1 disagreement (proves the test is load-bearing and would have caught the original bug).

### `scheduler.mjs` — Wire EDB readers into production (+12/-4)

Replaced the three live-disk closures in `runAdvanceShadow`'s call site with the new EDB readers, passing the shared `advDb` handle and `beliefsRes.tickId`. The original `readPhaseSignals`/`readVerifyVerdict`/`countRemediateCycles` remain in place for the real dispatch path.

## How to Verify It

- [x] All CI checks pass ✅
  - `execution-core-unit-tests`: pass ✅
  - `audit-references`: pass ✅
  - `check-versions`: pass ✅
  - `docs-gate`: pass ✅
  - `validate`: pass ✅
  - Cloudflare Pages: pass ✅
- [x] Regression test in `advance-shadow.test.mjs` (`CTL-1058: input-skew no longer fires a false disagreement`) confirms zero disagreements with EDB readers
- [x] Control test confirms the same scenario with disk stub produces 1 disagreement (test is load-bearing)
- [ ] Observe next gate-window cycle: disagreement count should drop — the CTL-1024 class of false positives no longer appears

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1058

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1024
