### PR TITLE
fix(dev): CTL-1057 — gate HRW read-side filter on multiHost, add membership warning

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -194,6 +194,21 @@ export function getClusterHosts() {
   return [getHostName()];
 }
 
+// CTL-1057: a multi-host roster that does NOT include this host means every
+// ticket HRW-routes to some OTHER host and this daemon silently owns nothing.
+// Returns a human warning string in that case, null otherwise. Single-host
+// (roster.length <= 1) → null — Phase 1 makes that a deliberate no-op and
+// a name mismatch there is not an error worth surfacing.
+export function hostMembershipWarning(roster, self) {
+  if (!Array.isArray(roster) || roster.length <= 1) return null;
+  if (roster.includes(self)) return null;
+  return (
+    `host "${self}" is not in the cluster roster [${roster.join(", ")}] — ` +
+    `this daemon will own zero tickets under HRW. Set catalyst.host.name ` +
+    `(Layer-2 config) to a roster entry or fix .catalyst/hosts.json.`
+  );
+}
+
 // CTL-859 — node-heartbeat cadence. The daemon appends one node.heartbeat event
 // to the unified event log every interval so a future liveness reader can decide
 // "dead" = no heartbeat for a generous grace window (see the design doc: 5–10 min

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -25,6 +25,7 @@ import {
   getHostName,
   getClusterHosts,
   HEARTBEAT_INTERVAL_MS,
+  hostMembershipWarning,
 } from "./config.mjs";
 
 const PREV = process.env.CATALYST_WAIT_WATCHER;
@@ -427,5 +428,36 @@ describe("phaseBudgetMs (CTL-729)", () => {
     // 20-min floor — exercise both the zero and negative branches.
     expect(phaseBudgetMs("implement", 0, { phaseBudgetMultiplier: 1.5 })).toBe(90 * 60_000);
     expect(phaseBudgetMs("implement", -5, { phaseBudgetMultiplier: 1.5 })).toBe(90 * 60_000);
+  });
+});
+
+describe("hostMembershipWarning (CTL-1057)", () => {
+  test("warns when multiHost and self not in roster", () => {
+    const w = hostMembershipWarning(["mini", "studio"], "laptop");
+    expect(w).toMatch(/not in the cluster roster/i);
+    expect(w).toContain("laptop");
+    expect(w).toContain("mini");
+    expect(w).toContain("studio");
+  });
+
+  test("no warning on single-host roster even when name mismatches", () => {
+    expect(hostMembershipWarning(["mini"], "RyansMini250233.rozich")).toBeNull();
+  });
+
+  test("no warning when self is the only roster entry (matches)", () => {
+    expect(hostMembershipWarning(["solo"], "solo")).toBeNull();
+  });
+
+  test("no warning when self is in a multi-host roster", () => {
+    expect(hostMembershipWarning(["mini", "studio"], "studio")).toBeNull();
+  });
+
+  test("no warning for empty roster", () => {
+    expect(hostMembershipWarning([], "laptop")).toBeNull();
+  });
+
+  test("no warning for non-array roster", () => {
+    expect(hostMembershipWarning(null, "laptop")).toBeNull();
+    expect(hostMembershipWarning(undefined, "laptop")).toBeNull();
   });
 });

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -35,6 +35,7 @@ import {
   log,
   getHostName, // CTL-862
   getClusterHosts, // CTL-862
+  hostMembershipWarning, // CTL-1057
 } from "./config.mjs";
 import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
 import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS
@@ -552,12 +553,21 @@ function dispatchTriage(
     log.warn({ identifier }, "→Triage seen but monitor has no orchDir — skipping dispatch");
     return false;
   }
-  // CTL-862: HRW ownership filter. Resolve roster/self lazily per call so hot
-  // roster reloads need no restart. Single-host roster → ownedBy is identity.
+  // CTL-862/CTL-1057: HRW ownership filter. Resolve roster/self lazily per call
+  // so hot roster reloads need no restart. Single-host (multiHost===false) is a
+  // TRUE no-op regardless of whether the lone roster entry string-matches the
+  // resolved hostName (stale/aliased hosts.json). HRW filtering engages only
+  // when roster.length > 1, matching the multiHost gate on the claim below.
   const roster = hosts ?? getClusterHosts();
   const self = hostName ?? getHostName();
   const multiHost = roster.length > 1;
-  if (!ownedBy(identifier, roster, self)) {
+  // CTL-1057: loud one-time warning when this host is absent from a multi-host roster.
+  const _mw = hostMembershipWarning(roster, self);
+  if (_mw && !globalThis.__ctl1057_monitor_warned) {
+    globalThis.__ctl1057_monitor_warned = true;
+    log.warn({ roster, self }, _mw);
+  }
+  if (multiHost && !ownedBy(identifier, roster, self)) {
     log.debug(
       { identifier, self, roster },
       "ctl-862: ticket not owned by this host under HRW — skipping triage dispatch"

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -1865,6 +1865,25 @@ describe("CTL-862 — HRW ownership + claim-on-dispatch (monitor dispatchTriage)
     expect(dispatch).toHaveBeenCalledWith({ orchDir: fakeOrchDir, ticket: TICKET, phase: "triage" });
   });
 
+  test("CTL-1057: single-host roster with a NON-matching hostName is still a no-op — dispatch proceeds, no claim", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const claimDispatch = recordClaim({ won: false, generation: null });
+    handleStateChangedEvent(triageEvent(), {
+      dispatch,
+      orchDir: fakeOrchDir,
+      hosts: ["mini"],                   // roster entry...
+      hostName: "RyansMini250233.rozich", // ...does NOT match resolved host
+      claimDispatch,
+      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      appendEvent: () => {},
+    });
+    // With the ungated filter this fails: dispatch is skipped because
+    // ownedBy("ENG-1", ["mini"], "RyansMini250233.rozich") === false.
+    expect(dispatch).toHaveBeenCalledWith({ orchDir: fakeOrchDir, ticket: TICKET, phase: "triage" });
+    expect(claimDispatch.calls).toHaveLength(0); // single-host never touches Linear
+  });
+
   test("multi-host: a ticket OWNED by this host is dispatched + claim ran with phase 'triage'", () => {
     enroll("ENG", { status: "Ready" });
     const dispatch = mock(() => ({ code: 0 }));

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -174,7 +174,7 @@ import { isLinearTerminal } from "./terminal-state.mjs";
 import { labelOnce, clearStalledLabel } from "./label-guard.mjs";
 import { processApprovedResumes } from "./boot-resume.mjs"; // CTL-644: per-tick approval poll
 import { countReapOutcomes } from "./reaper-metrics.mjs";
-import { log, getEligibleDir, getEventLogPath, getHostName, getClusterHosts } from "./config.mjs";
+import { log, getEligibleDir, getEventLogPath, getHostName, getClusterHosts, hostMembershipWarning } from "./config.mjs";
 import { defaultCheckSequencing } from "./sequencing.mjs"; // CTL-537
 import { ownedBy } from "./hrw.mjs"; // CTL-850: HRW ownership filter
 import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-850: cross-host claim soft-CAS
@@ -2445,6 +2445,12 @@ export function schedulerTick(
   const roster = hosts ?? getClusterHosts();
   const self = hostName ?? getHostName();
   const multiHost = roster.length > 1;
+  // CTL-1057: loud one-time warning when this host is absent from a multi-host roster.
+  const _smw = hostMembershipWarning(roster, self);
+  if (_smw && !globalThis.__ctl1057_scheduler_warned) {
+    globalThis.__ctl1057_scheduler_warned = true;
+    log.warn({ roster, self }, _smw);
+  }
   // CTL-757: emitStateWrite — caller-emit the canonical linear.state.write audit
   // event for ONE scheduler write site. `writerResult` is the runTransition return
   // ({applied, reason, from_state, to_state, ...}) from applyPhaseStatus /
@@ -3883,14 +3889,16 @@ export function schedulerTick(
       }
     }
   }
-  // CTL-850: HRW ownership filter — keep only the tickets THIS host owns under
-  // the cluster roster so freeSlots + per-project caps compute over owned work
-  // only. Applied to `ready` (NOT the raw `eligible`, whose `eligibleIds` drives
-  // the phantom-quarantine sweep above — narrowing that would mis-quarantine a
-  // sibling host's worker dirs). Identity filter for a single-host roster
-  // (ownedBy is always true), so this is an exact no-op until a 2nd host joins.
-  const ready = computeReadyTickets(eligible, { blockerStates }).filter((t) =>
-    ownedBy(t.identifier, roster, self)
+  // CTL-850/CTL-1057: HRW ownership filter — keep only the tickets THIS host owns
+  // under the cluster roster so freeSlots + per-project caps compute over owned
+  // work only. Applied to `ready` (NOT the raw `eligible`, whose `eligibleIds`
+  // drives the phantom-quarantine sweep above — narrowing that would mis-quarantine
+  // a sibling host's worker dirs). Single-host (multiHost===false) is a TRUE no-op
+  // regardless of whether the lone roster entry string-matches the resolved
+  // hostName (stale/aliased hosts.json). HRW filtering engages only when a 2nd
+  // host actually joins (roster.length > 1).
+  const ready = computeReadyTickets(eligible, { blockerStates }).filter(
+    (t) => !multiHost || ownedBy(t.identifier, roster, self)
   );
   // CTL-657: the in-flight count is the live `background` claude-agents count,
   // not listInFlightTickets(orchDir).size. A worker that leaked (signal terminal

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -8087,6 +8087,25 @@ describe("CTL-850 — HRW ownership + claim-on-dispatch (schedulerTick new-work)
     expect(dispatch.calls[0]).toMatchObject({ ticket: TICKET, phase: "research" });
   });
 
+  test("CTL-1057: single-host ready filter keeps tickets even when hostName != roster entry", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    const claimDispatch = recordClaim({ won: false, generation: null });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne(),
+      dispatch,
+      hosts: ["mini"],
+      hostName: "RyansMini250233.rozich",
+      claimDispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+    });
+    expect(claimDispatch.calls).toHaveLength(0); // multiHost gate skipped the claim
+    expect(dispatch.calls).toHaveLength(1); // HRW single-host → dispatched
+    expect(dispatch.calls[0]).toMatchObject({ ticket: TICKET, phase: "research" });
+  });
+
   test("multi-host: a ticket OWNED by this host is dispatched (HRW keeps it)", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const dispatch = fakeDispatch({ code: 0 });


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-11T23:14:00Z -->
<!-- Last updated: 2026-06-11T23:14:00Z -->
<!-- PR: #1863 -->
<!-- Previous commits: ae62034f -->

## Summary

Fixes a silent dispatch-stall on single-host installs where the cluster `hosts.json` roster contains an alias (e.g. `"mini"`) that does not string-match the OS-resolved hostname (e.g. `"RyansMini250233.rozich"`).

The HRW ownership filter in `dispatchTriage()` and `schedulerTick`'s ready-set selection was applied unconditionally — without checking whether the current install is actually multi-host. On a single-host setup, `ownedBy(ticket, ["mini"], "RyansMini250233.rozich")` always returned `false`, silently dropping every triage dispatch and every ready-set entry. The daemon appeared healthy (no errors, events flowing) but no work was picked up.

**Phase 1 (correctness):** Gate the HRW filter on `multiHost` (`roster.length > 1`). Single-host installs become a true no-op regardless of roster entry name, matching the pre-existing `multiHost` gate on the claim-dispatch path.

**Phase 2 (observability):** Add `hostMembershipWarning()` to `config.mjs` — emits a `log.warn` (throttled once-per-process via `globalThis.__ctl1057_*_warned`) when this host is absent from a multi-host roster, so the misconfiguration is loud instead of silent.

## Changes Made

### `config.mjs`
- Added `hostMembershipWarning(roster, self)` — returns a human-readable warning string when `self` is not in a multi-host roster, `null` otherwise. Single-host rosters always return `null` (deliberate: a name mismatch there is never an error worth surfacing).

### `monitor.mjs`
- Changed `if (!ownedBy(...))` → `if (multiHost && !ownedBy(...))` in `dispatchTriage()`.
- Wired `hostMembershipWarning()` as a throttled `log.warn` before the ownership check.

### `scheduler.mjs`
- Changed `ready.filter(t => ownedBy(...))` → `ready.filter(t => !multiHost || ownedBy(...))`.
- Wired `hostMembershipWarning()` as a throttled `log.warn` in `schedulerTick`.

### Test files
- `config.test.mjs`: 6 new tests for `hostMembershipWarning` covering multi-host mismatch (warn), single-host (no warn), self-in-roster (no warn), empty/null roster (no warn).
- `monitor.test.mjs`: new red→green test — single-host roster with non-matching hostname dispatches correctly.
- `scheduler.test.mjs`: new red→green test — single-host ready filter keeps tickets even when `hostName != roster entry`.

## How to Verify It

- [x] `execution-core-unit-tests` CI check passes (confirmed: config 59 pass, scheduler 455 pass, monitor 123 pass)
- [x] No TypeScript errors (pure ESM `.mjs`, no tsconfig in scope — skip is expected)
- [x] No lint errors (no eslint config in execution-core — skip is expected)
- [x] Regression risk: 1/10 (verify.json)
- [ ] On a single-host install: restart the daemon with a roster entry that does not match the OS hostname — confirm dispatch proceeds and a `log.warn` is emitted once

## Related Issues / PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1057

## Changelog Entry

```
fix(dev): gate HRW read-side filter on multiHost, add host membership warning

Single-host installs with a stale or aliased hosts.json roster entry (e.g.
"mini" vs "RyansMini250233.rozich") silently dropped every triage dispatch and
every scheduler ready-set entry because ownedBy() returned false unconditionally.

Fix: gate `!ownedBy(...)` on `multiHost` (roster.length > 1) in both
dispatchTriage and schedulerTick, symmetrizing with the pre-existing multiHost
gate on the claim-dispatch path. Add hostMembershipWarning() for an explicit
log.warn when the daemon is in a multi-host roster it doesn't belong to.
```
