### PR TITLE
feat(dev): CTL-1066 — queue board distinguishes held, retrying, and gave-up tickets

### DIFF
--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -154,6 +154,9 @@ export interface BoardTicket {
    *  (BFF11) or the phase signal — the value a fence-aware web mutation passes to
    *  isFenceCurrent without a live attachment fetch. null when no fence. */
   generation: number | null;
+  /** CTL-1066: reason a stalled/failed phase gave up, from the surfaced phase
+   *  signal's stalledReason/failureReason. null unless status is stalled/failed. */
+  failureReason: string | null;
 }
 
 export interface BoardQueueItem {
@@ -175,6 +178,9 @@ export interface BoardQueueItem {
   /** CTL-922 (BFF10): the node owning this queued ticket, from the durable fence
    *  projection owner_host (BFF11); null when no fence attachment observed. */
   host: BoardHostRef | null;
+  /** CTL-1066: active dispatch retry cool-down for this queued ticket; null when
+   *  not cooling down. expiresAt is epoch ms; consecutiveFailures is the attempt count. */
+  dispatchCooldown: { expiresAt: number; consecutiveFailures: number } | null;
 }
 
 export interface BoardConfig {

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -156,7 +156,7 @@ export interface BoardTicket {
   generation: number | null;
   /** CTL-1066: reason a stalled/failed phase gave up, from the surfaced phase
    *  signal's stalledReason/failureReason. null unless status is stalled/failed. */
-  failureReason: string | null;
+  failureReason?: string | null;
 }
 
 export interface BoardQueueItem {
@@ -180,7 +180,7 @@ export interface BoardQueueItem {
   host: BoardHostRef | null;
   /** CTL-1066: active dispatch retry cool-down for this queued ticket; null when
    *  not cooling down. expiresAt is epoch ms; consecutiveFailures is the attempt count. */
-  dispatchCooldown: { expiresAt: number; consecutiveFailures: number } | null;
+  dispatchCooldown?: { expiresAt: number; consecutiveFailures: number } | null;
 }
 
 export interface BoardConfig {

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -47,6 +47,7 @@ const HOME = homedir();
 const EC = join(HOME, "catalyst", "execution-core");
 const WORKERS_DIR = join(EC, "workers");
 const ELIGIBLE_DIR = join(EC, "eligible");
+const COOLDOWNS_DIR = join(EC, ".dispatch-cooldowns"); // CTL-1066
 const DB = join(HOME, "catalyst", "catalyst.db");
 // CTL-928: the durable per-`claude --bg`-job state directory. A worker's
 // liveness is proven by its job's state.json HERE, NOT by a phase signal that
@@ -496,14 +497,14 @@ export function deriveCurrentPhase(phaseSigs) {
     const phase = PHASE_ORDER[i];
     const status = sig.status || "unknown";
     if (!TERMINAL.has(status)) {
-      return { phase, status, model: sig.model || null, startedAt: sig.startedAt, updatedAt: sig.updatedAt };
+      return { phase, status, model: sig.model || null, startedAt: sig.startedAt, updatedAt: sig.updatedAt, failureReason: sig.failureReason ?? sig.stalledReason ?? null };
     }
-    lastTerminal = { phase, status, model: sig.model || null, startedAt: sig.startedAt, updatedAt: sig.updatedAt };
+    lastTerminal = { phase, status, model: sig.model || null, startedAt: sig.startedAt, updatedAt: sig.updatedAt, failureReason: sig.failureReason ?? sig.stalledReason ?? null };
     lastTerminalIndex = i;
   }
   // No phase has written a signal file yet → pre-pipeline. Surface the first
   // column (Research), never Done (CTL-745).
-  if (!lastTerminal) return { phase: PHASE_ORDER[0], status: "unknown", model: null };
+  if (!lastTerminal) return { phase: PHASE_ORDER[0], status: "unknown", model: null, failureReason: null };
   // A failed/stalled phase always surfaces at its own column, wherever it sits.
   if (lastTerminal.status === "failed" || lastTerminal.status === "stalled") return lastTerminal;
   // CTL-745: the pipeline is genuinely "done" ONLY when its FINAL phase
@@ -544,6 +545,7 @@ export function derivePhaseWithRemediate(phaseSigs, remediateSig) {
       model: remediateSig.model || null,
       startedAt: remediateSig.startedAt ?? null,
       updatedAt: remediateSig.updatedAt ?? null,
+      failureReason: remediateSig.failureReason ?? remediateSig.stalledReason ?? null,
     };
   }
   // Case 2: remediate is terminal but more recent than what PHASE_ORDER surfaced.
@@ -557,6 +559,7 @@ export function derivePhaseWithRemediate(phaseSigs, remediateSig) {
       model: remediateSig.model || null,
       startedAt: remediateSig.startedAt ?? null,
       updatedAt: remUpdated || null,
+      failureReason: remediateSig.failureReason ?? remediateSig.stalledReason ?? null,
     };
   }
   return cur;
@@ -965,11 +968,32 @@ async function readWorkerPhaseSignals(ticket, phase) {
   return sigs;
 }
 
+// CTL-1066: active dispatch cool-downs, keyed by ticket. Markers are
+// `${ticket}-${phase}.json` ({expiresAt, consecutiveFailures}); a queue item is a
+// new-work ticket so we match by ticket id across phases and keep the latest expiry.
+async function loadDispatchCooldowns(now) {
+  const out = new Map();
+  if (!(await exists(COOLDOWNS_DIR))) return out;
+  let files;
+  try { files = await readdir(COOLDOWNS_DIR); } catch { return out; }
+  const markers = await Promise.all(
+    files.filter((f) => f.endsWith(".json")).map((f) => readJSON(join(COOLDOWNS_DIR, f))),
+  );
+  for (const m of markers) {
+    if (!m?.ticket || typeof m.expiresAt !== "number" || m.expiresAt <= now) continue;
+    const prev = out.get(m.ticket);
+    if (!prev || m.expiresAt > prev.expiresAt) {
+      out.set(m.ticket, { expiresAt: m.expiresAt, consecutiveFailures: m.consecutiveFailures ?? 1 });
+    }
+  }
+  return out;
+}
+
 // ── main assembly ───────────────────────────────────────────────────────────
 export async function assembleBoard() {
-  const [agents, costs, phaseCostsByTicket, eligible, linfo, mp, catalystSessByUuid] = await Promise.all([
+  const [agents, costs, phaseCostsByTicket, eligible, linfo, mp, catalystSessByUuid, cooldowns] = await Promise.all([
     liveAgents(), costByTicket(), costByPhase(), loadEligible(), linearInfo(), maxParallel(),
-    catalystSessionByCcUuid(),
+    catalystSessionByCcUuid(), loadDispatchCooldowns(Date.now()),
   ]);
   const eligibleIndex = Object.fromEntries(eligible.map((e) => [e.id, e]));
 
@@ -1232,6 +1256,7 @@ export async function assembleBoard() {
       // no cluster branch, no live attachment fetch.
       host: deriveHost(phaseSigs, linfo[id] ?? {}),
       generation: deriveGeneration(phaseSigs, linfo[id] ?? {}),
+      failureReason: cur.failureReason ?? null,
     };
   }));
 
@@ -1285,6 +1310,8 @@ export async function assembleBoard() {
         // a queued ticket has no phase signal, so [] forces the fence fallback.
         // null when no fence attachment has been observed — never fabricated.
         host: deriveHost([], linfo[e.id] ?? {}),
+        // CTL-1066: active dispatch retry cool-down; null when not cooling down.
+        dispatchCooldown: cooldowns.get(e.id) ?? null,
       };
     }));
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
@@ -340,7 +340,7 @@ export function HeldBadge({ held, blockers }: { held: "blocked" | "waiting" | nu
   const ids = (blockers ?? []).filter(Boolean);
   const label = isBlocked
     ? `⏸ blocked${ids.length ? `: ${ids.join(", ")}` : ""}`
-    : "⏸ waiting";
+    : "⏸ held";
   const tip = isBlocked
     ? ids.length
       ? `Held — blocked on open dependency: ${ids.join(", ")}`

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
@@ -151,6 +151,9 @@ export interface BoardTicket {
   /** CTL-922 (BFF10): the fence generation (HOME5 unblock passes it to the
    *  fence-check). null when no fence. */
   generation?: number | null;
+  /** CTL-1066: reason a stalled/failed phase gave up; drives the "Stalled — gave
+   *  up" holding bucket copy. null/absent unless status is stalled/failed. */
+  failureReason?: string | null;
   // ── CTL-902 (HOME4): the reading-pane CONTENT fields ─────────────────────
   // The "What's needed now" hero + the About block read these. They are NOT in
   // the board payload today — they derive from the ticket's AI summary + the
@@ -209,6 +212,9 @@ export interface BoardQueueItem {
    *  column), from the durable fence projection owner_host (BFF11). null when
    *  no fence attachment has been observed. */
   host?: BoardHostRef | null;
+  /** CTL-1066: active dispatch retry cool-down; drives the "retrying in …" chip.
+   *  null when not cooling down. expiresAt is epoch ms; consecutiveFailures is the attempt count. */
+  dispatchCooldown?: { expiresAt: number; consecutiveFailures: number } | null;
 }
 
 export interface BoardConfig {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/dispatch-queue.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/dispatch-queue.tsx
@@ -23,7 +23,7 @@ import {
 } from "../../board/queue-grouping";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { BoardQueueItem } from "../../board/types";
-import { ordinal, fmtAge } from "./queue-model";
+import { ordinal, fmtAge, fmtCountdown } from "./queue-model";
 import { QueueRowShell } from "./queue-row";
 
 const DISPATCH_BG = "rgba(65,189,125,0.05)";
@@ -88,6 +88,11 @@ function DispatchRow({
         meta={
           <>
             <ScopeChip scope={q.scope} estimate={q.estimate} estimateDisplay={q.estimateDisplay} />
+            {q.dispatchCooldown && (
+              <span style={{ fontFamily: C.mono, fontSize: 11, color: C.fgMuted, lineHeight: "18px" }}>
+                retrying in {fmtCountdown(q.dispatchCooldown.expiresAt - Date.now())} (attempt {q.dispatchCooldown.consecutiveFailures})
+              </span>
+            )}
             {age && (
               <span style={{ fontFamily: C.mono, fontSize: 11, fontVariantNumeric: "tabular-nums", color: C.fgDim, lineHeight: "18px" }}>
                 {age}
@@ -125,6 +130,7 @@ export function DispatchQueue({
   const multiHost = queueHostMode(queue) === "multi";
   const [groupByNode, setGroupByNode] = useState(false);
   const grouped = multiHost && groupByNode;
+  const coolingCount = queue.filter((q) => q.dispatchCooldown).length;
 
   // dispatches-next affordance: the top min(freeSlots, queue.length) rows tint.
   const dispatchCount = Math.min(Math.max(0, freeSlots), queue.length);
@@ -156,7 +162,7 @@ export function DispatchQueue({
     <section>
       <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
         <span style={{ fontSize: 13, fontWeight: 600, color: C.fg }}>Dispatching next</span>
-        <span style={{ fontSize: 13, fontWeight: 400, color: C.fgDim }}>· {queue.length} waiting</span>
+        <span style={{ fontSize: 13, fontWeight: 400, color: C.fgDim }}>· {queue.length} waiting{coolingCount > 0 ? ` · ${coolingCount} cooling down` : ""}</span>
         <span style={{ flex: 1 }} />
         {multiHost && (
           <ToggleGroup

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/holding-buckets.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/holding-buckets.tsx
@@ -23,13 +23,15 @@ import { QueueRowShell } from "./queue-row";
 
 const DOT_COLOR: Record<HoldingBucket["kind"], string> = {
   "needs-you": C.yellow,
+  stalled: C.yellow,
   blocked: C.red,
   waiting: C.fgDim,
 };
 const BUCKET_LABEL: Record<HoldingBucket["kind"], string> = {
   "needs-you": "Needs you",
+  stalled: "Stalled — gave up",
   blocked: "Blocked by dependencies",
-  waiting: "Waiting",
+  waiting: "Held — awaiting capacity",
 };
 
 function ColorDot({ color }: { color: string }) {
@@ -84,6 +86,12 @@ function BucketRow({
 
   const t: BoardTicket = item.ticket;
   const blockers = (t.blockers ?? []).filter(Boolean);
+  const stalledLine =
+    t.status === "stalled" ? (
+      <div style={{ fontSize: 11, color: C.yellowSoft, fontFamily: C.mono, marginTop: 2 }}>
+        gave up — {t.failureReason || "unknown reason"}
+      </div>
+    ) : undefined;
   return wrap(
     <QueueRowShell
       repo={t.repo}
@@ -93,11 +101,12 @@ function BucketRow({
       withTopHairline={withTopHairline}
       onClick={onOpenTicket ? () => onOpenTicket(t.id) : undefined}
       subline={
-        blockers.length > 0 ? (
+        stalledLine ??
+        (blockers.length > 0 ? (
           <div style={{ fontSize: 11, color: C.redSoft, fontFamily: C.mono, marginTop: 2 }}>
             blocked by {blockers.join(", ")}
           </div>
-        ) : undefined
+        ) : undefined)
       }
       meta={
         <ScopeChip scope={t.scope} estimate={t.estimate} estimateDisplay={t.estimateDisplay} />
@@ -163,6 +172,7 @@ export function HoldingBuckets({
       ) : (
         <>
           <Bucket bucket={buckets.needsYou} onOpenTicket={onOpenTicket} titleByTicket={titleByTicket} />
+          <Bucket bucket={buckets.stalled} onOpenTicket={onOpenTicket} titleByTicket={titleByTicket} />
           <Bucket bucket={buckets.blocked} onOpenTicket={onOpenTicket} titleByTicket={titleByTicket} />
           <Bucket bucket={buckets.waiting} onOpenTicket={onOpenTicket} titleByTicket={titleByTicket} />
         </>

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/queue-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/queue-model.test.ts
@@ -6,6 +6,7 @@ import type { BoardWorker, BoardTicket } from "../../board/types";
 import {
   ordinal,
   fmtAge,
+  fmtCountdown,
   assignSlots,
   slotLabel,
   groupHoldingBuckets,
@@ -60,6 +61,7 @@ function t(p: Partial<BoardTicket> & { id: string }): BoardTicket {
     currentPhaseSince: null,
     host: null,
     generation: null,
+    failureReason: null,
     ...p,
   };
 }
@@ -233,6 +235,49 @@ describe("slotLabel — vacant slots keep their numbers (CTL-1035)", () => {
       slotLabel(a.occupied.length + i + 1),
     );
     expect(emptyLabels).toEqual(["SLOT 1", "SLOT 2", "SLOT 3", "SLOT 4"]);
+  });
+});
+
+describe("groupHoldingBuckets — stalled bucket (CTL-1066)", () => {
+  it("stalled bucket = tickets with status 'stalled' NOT in flight, carrying the reason", () => {
+    const tickets = [
+      t({ id: "CTL-1", status: "stalled", failureReason: "prior-artifact-retry-exhausted" }),
+      t({ id: "CTL-2", status: "stalled" }),
+      t({ id: "CTL-3", held: "waiting" }),
+    ];
+    const b = groupHoldingBuckets(tickets, [], 4);
+    expect(b.stalled.items.map((i) => (i.kind === "ticket" ? i.ticket.id : ""))).toEqual(["CTL-1", "CTL-2"]);
+    expect(b.waiting.items.map((i) => (i.kind === "ticket" ? i.ticket.id : ""))).toEqual(["CTL-3"]);
+  });
+
+  it("a stalled ticket attached to a LIVE worker is excluded (not double-listed)", () => {
+    const tickets = [t({ id: "CTL-1", status: "stalled" })];
+    const workers = [w({ name: "w1", ticket: "CTL-1", startedAt: 1 })];
+    const b = groupHoldingBuckets(tickets, workers, 4);
+    expect(b.stalled.items).toHaveLength(0);
+  });
+
+  it("allEmpty is false when only a stalled ticket is present", () => {
+    const b = groupHoldingBuckets([t({ id: "CTL-1", status: "stalled" })], [], 4);
+    expect(b.allEmpty).toBe(false);
+  });
+
+  it("holdingTicketIds includes stalled ids", () => {
+    const b = groupHoldingBuckets([t({ id: "CTL-1", status: "stalled" })], [], 4);
+    expect(holdingTicketIds(b)).toContain("CTL-1");
+  });
+});
+
+describe("fmtCountdown (CTL-1066)", () => {
+  it("formats remaining time, flooring to the coarsest unit", () => {
+    expect(fmtCountdown(18 * 60_000)).toBe("18m");
+    expect(fmtCountdown(2 * 3_600_000)).toBe("2h");
+    expect(fmtCountdown(30_000)).toBe("<1m");
+  });
+  it("non-positive / non-finite → 'now'", () => {
+    expect(fmtCountdown(0)).toBe("now");
+    expect(fmtCountdown(-5)).toBe("now");
+    expect(fmtCountdown(NaN)).toBe("now");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/queue-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/queue-model.ts
@@ -31,6 +31,17 @@ export function fmtAge(ms: number): string {
   return `${Math.floor(h / 24)}d`;
 }
 
+/** CTL-1066: compact "time until X" countdown: "2h", "18m", "<1m"; non-positive/non-finite → "now". */
+export function fmtCountdown(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "now";
+  const m = Math.floor(ms / 60000);
+  if (m < 1) return "<1m";
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+
 // ── ordinal ──────────────────────────────────────────────────────────────────
 
 /**
@@ -102,7 +113,7 @@ export function slotLabel(slot: number): string {
 
 // ── holding buckets ("why work isn't moving") ──────────────────────────────────
 
-export type HoldingBucketKind = "needs-you" | "blocked" | "waiting";
+export type HoldingBucketKind = "needs-you" | "stalled" | "blocked" | "waiting";
 
 export interface HoldingBucketWorkerItem {
   kind: "worker";
@@ -126,9 +137,11 @@ export interface HoldingBucket {
 
 export interface HoldingBuckets {
   needsYou: HoldingBucket;
+  /** CTL-1066: tickets with status=stalled — the circuit breaker gave up; human must intervene. */
+  stalled: HoldingBucket;
   blocked: HoldingBucket;
   waiting: HoldingBucket;
-  /** True when all three buckets are empty (render the "nothing blocked" line). */
+  /** True when all four buckets are empty (render the "nothing blocked" line). */
   allEmpty: boolean;
 }
 
@@ -175,17 +188,21 @@ export function groupHoldingBuckets(
     }
   }
 
+  const stalled: HoldingBucketItem[] = [];
   const blocked: HoldingBucketItem[] = [];
   const waiting: HoldingBucketItem[] = [];
   for (const t of tickets) {
     if (inFlightTicketIds.has(t.id)) continue;
-    if (t.held === "blocked") blocked.push({ kind: "ticket", ticket: t });
+    if (t.status === "stalled") stalled.push({ kind: "ticket", ticket: t });
+    else if (t.held === "blocked") blocked.push({ kind: "ticket", ticket: t });
     else if (t.held === "waiting") waiting.push({ kind: "ticket", ticket: t });
   }
 
-  const allEmpty = needsYou.length === 0 && blocked.length === 0 && waiting.length === 0;
+  const allEmpty =
+    needsYou.length === 0 && stalled.length === 0 && blocked.length === 0 && waiting.length === 0;
   return {
     needsYou: { kind: "needs-you", items: needsYou },
+    stalled: { kind: "stalled", items: stalled },
     blocked: { kind: "blocked", items: blocked },
     waiting: { kind: "waiting", items: waiting },
     allEmpty,
@@ -194,7 +211,7 @@ export function groupHoldingBuckets(
 
 /** Flatten all bucket items to their ticket ids — for the bucket ∉ queue test. */
 export function holdingTicketIds(b: HoldingBuckets): string[] {
-  return [...b.needsYou.items, ...b.blocked.items, ...b.waiting.items].map(itemTicketId);
+  return [...b.needsYou.items, ...b.stalled.items, ...b.blocked.items, ...b.waiting.items].map(itemTicketId);
 }
 
 // ── dead / stale ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-12T03:27:00Z -->
<!-- Last updated: 2026-06-12T03:27:00Z -->
<!-- PR: #1875 -->
<!-- Previous commits: 9dc95502,f5c76625 -->

## Summary

The queue board previously labeled three visually distinct states — held tickets, dispatch retry cool-downs, and stalled/gave-up tickets — all as "waiting," creating operator confusion. This PR surfaces each state distinctly:

- **Held — awaiting capacity**: tickets with a hold label (waiting/blocked) now use "⏸ held" instead of "⏸ waiting"
- **Retrying in N min (attempt X)**: tickets in dispatch retry cool-down read `.dispatch-cooldowns/` markers and display a live countdown chip
- **Stalled — gave up**: a new holding bucket groups terminal-failed tickets and shows the `failureReason` from the phase signal

No new endpoints. All data was already on disk — three vertical slices reading existing state.

## Changes Made

### Backend (board-data.mjs / board-data.d.mts)

- `loadDispatchCooldowns(now)` — reads `~/.catalyst/execution-core/.dispatch-cooldowns/*.json`, keeps the latest expiry per ticket, returns a `Map<ticketId, {expiresAt, consecutiveFailures}>`
- `assembleBoard()` — adds `cooldowns` to the parallel load, projects `dispatchCooldown` onto `BoardQueueItem`
- `deriveCurrentPhase()` / `derivePhaseWithRemediate()` — surfaces `failureReason` (from `failureReason ?? stalledReason`) on the returned phase descriptor
- `BoardTicket.failureReason?: string | null` and `BoardQueueItem.dispatchCooldown?: {expiresAt, consecutiveFailures} | null` added to both `.d.mts` and `types.ts`

### UI (queue components)

- **dispatch-queue.tsx**: adds "retrying in Xm (attempt N)" mono chip when `dispatchCooldown` is set; header subtitle shows "N cooling down" count
- **holding-buckets.tsx**: new `stalled` bucket rendered between `needsYou` and `blocked`; stalled rows show `gave up — <reason>` sub-line; "Waiting" bucket label changed to "Held — awaiting capacity"
- **Board.tsx**: `HeldBadge` label "⏸ waiting" → "⏸ held"
- **queue-model.ts**: `fmtCountdown(ms)` helper — formats remaining ms as `"Xh Ym"` / `"Xm Ys"` / `"<1m"`; `groupHoldingBuckets()` — new `stalled` bucket collects `status=stalled` tickets not attached to a live worker

### Tests (queue-model.test.ts)

- `fmtCountdown` — covers hours/minutes/seconds boundaries and `<1m` floor
- `groupHoldingBuckets — stalled bucket` — stalled lands in `stalled`, live-worker stalled excluded, held-only lands in `waiting`
- `dispatchCooldown` handling in queue factory helper

## How to Verify It

- [ ] Open the queue board with a ticket whose phase is stalled — it appears under "Stalled — gave up" with the reason text
- [ ] Open the queue board with a ticket in dispatch cool-down (`.dispatch-cooldowns/` marker exists with future expiry) — the row shows "retrying in Nm (attempt X)"
- [ ] A held ticket shows "⏸ held" not "⏸ waiting"
- [x] `bun run typecheck` passes (no errors)
- [x] `bun test` passes (queue-model tests green)

## Changelog Entry

`feat(dev)`: Queue board now distinguishes held, retrying, and stalled tickets — each state shows a distinct chip and bucket instead of the ambiguous "waiting" label.

## Related Issues/PRs

- Fixes https://linear.app/adva/issue/CTL-1066

