### PR TITLE
CTL-1065: Every escalation should state plainly what failed, what was tried, and the exact decision the human must make

### DIFF
--- a/plugins/dev/scripts/execution-core/beliefs/escalate.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/escalate.mjs
@@ -52,6 +52,11 @@
 
 import { labelOnce } from "../label-guard.mjs";
 import { log } from "../config.mjs";
+import { coerceExplanation } from "../escalation-explanation.mjs";
+
+function firstLine(s) {
+  return String(s ?? "").split(/\r?\n/)[0].slice(0, 200);
+}
 
 // ── executeEscalations — per-tick executor for R12 escalate_human beliefs.
 //
@@ -79,6 +84,7 @@ export function executeEscalations(
     enforce = false,
     labelOnceFn = labelOnce,
     env = process.env,
+    evidenceBySubject = {},
   } = {},
 ) {
   let escalated = 0; // subjects whose intent we flipped to 'escalated'
@@ -147,9 +153,25 @@ export function executeEscalations(
         paged++;
         if (typeof appendEvent === "function") {
           try {
+            const ev = evidenceBySubject[subject] ?? {};
+            const phaseName = subject.split("/")[1] ?? null;
+            const explanation = coerceExplanation(
+              {
+                what_failed: ev.logsOutput
+                  ? `${phaseName ?? "phase"} failed: ${firstLine(ev.logsOutput)}`
+                  : `${phaseName ?? "phase"} escalated (${why ?? "no diagnosis"})`,
+                observed: ev.jobState ?? {},
+                attempts: ev.attempts ?? [],
+                why_gave_up: why
+                  ? `diagnostician reason: ${why}`
+                  : "diagnostician produced no actionable verdict",
+                human_question: ev.humanQuestion ?? "",
+              },
+              { ticket, phase: phaseName },
+            );
             appendEvent({
               "event.name": "escalate.human",
-              payload: { subject, ticket, why },
+              payload: { subject, ticket, why, explanation },
             });
           } catch (evtErr) {
             errors.push({ subject, phase: "appendEvent", err: String(evtErr?.message ?? evtErr) });

--- a/plugins/dev/scripts/execution-core/beliefs/escalate.test.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/escalate.test.mjs
@@ -529,3 +529,65 @@ describe("MULTI-TICK LADDER — R4 → R10 → R11 → R12 in real tick order, p
     expect(events.filter((e) => e["event.name"] === "escalate.human")).toHaveLength(1);
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────────
+// CTL-1065: structured explanation in escalate.human events
+// ──────────────────────────────────────────────────────────────────────────
+import { validateExplanation } from "../escalation-explanation.mjs";
+
+describe("CTL-1065: executeEscalations emits structured explanation", () => {
+  test("page emits escalate.human with a valid explanation when evidenceBySubject provided", () => {
+    seedCfg("max_attempts", 2);
+    const tickId = insertTick(NOW);
+    const subject = "CTL-7/implement";
+    insertEscalateHuman(tickId, subject, "stalled-alive");
+    insertWakeIntent(tickId, subject, { attempts: 2, outcome: null });
+
+    const events = [];
+    const evidenceBySubject = {
+      "CTL-7/implement": {
+        logsOutput: "Error: tsc failed with 3 errors",
+        jobState: { elapsedMin: 42, commitCount: 0, bgJobId: "ab12ef34" },
+      },
+    };
+
+    executeEscalations(db, tickId, {
+      orchDir: scratch(),
+      writeStatus: { applyLabel: () => ({ applied: true }) },
+      appendEvent: (e) => events.push(e),
+      enforce: true,
+      labelOnceFn: () => true,
+      evidenceBySubject,
+    });
+
+    const ev = events.find((e) => e["event.name"] === "escalate.human");
+    expect(ev).toBeTruthy();
+    expect(validateExplanation(ev.payload.explanation).valid).toBe(true);
+    expect(ev.payload.explanation.observed.bgJobId).toBe("ab12ef34");
+    // backward compat: why still present
+    expect(ev.payload.why).toBe("stalled-alive");
+  });
+
+  test("missing evidence still pages with a coerced explanation", () => {
+    seedCfg("max_attempts", 2);
+    const tickId = insertTick(NOW);
+    const subject = "CTL-7/implement";
+    insertEscalateHuman(tickId, subject, "stalled-alive");
+    insertWakeIntent(tickId, subject, { attempts: 2, outcome: null });
+
+    const events = [];
+    executeEscalations(db, tickId, {
+      orchDir: scratch(),
+      writeStatus: { applyLabel: () => ({ applied: true }) },
+      appendEvent: (e) => events.push(e),
+      enforce: true,
+      labelOnceFn: () => true,
+      // no evidenceBySubject
+    });
+
+    const ev = events.find((e) => e["event.name"] === "escalate.human");
+    expect(ev).toBeTruthy();
+    expect(validateExplanation(ev.payload.explanation).valid).toBe(true);
+    expect(ev.payload.explanation.human_question).toContain("CTL-7");
+  });
+});

--- a/plugins/dev/scripts/execution-core/escalation-explain.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-explain.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// escalation-explain.mjs — CTL-1065 CLI shim. Shell write sites call this to
+// produce a validated explanation JSON blob to splice into signal files with jq.
+// Always exits 0; degrades rather than dropping a park.
+import { coerceExplanation } from "./escalation-explanation.mjs";
+
+const args = process.argv.slice(2);
+const get = (flag) => {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+
+let observed = {};
+try {
+  observed = get("--observed") ? JSON.parse(get("--observed")) : {};
+} catch {
+  observed = {};
+}
+
+let attempts = [];
+try {
+  attempts = get("--attempts") ? JSON.parse(get("--attempts")) : [];
+} catch {
+  attempts = [];
+}
+
+const e = coerceExplanation(
+  {
+    what_failed: get("--what-failed"),
+    observed,
+    attempts,
+    why_gave_up: get("--why-gave-up"),
+    human_question: get("--human-question"),
+  },
+  { ticket: get("--ticket"), phase: get("--phase") },
+);
+
+process.stdout.write(JSON.stringify(e));
+process.exit(0);

--- a/plugins/dev/scripts/execution-core/escalation-explanation.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-explanation.mjs
@@ -1,0 +1,84 @@
+// escalation-explanation.mjs — CTL-1065: structured escalation explanation contract.
+// Single source of truth for all five escalation write sites. Pure, no I/O.
+//
+// Shape: { what_failed, observed, attempts[], why_gave_up, human_question }
+//   - validateExplanation(obj)         -> { valid, errors[] }   (pure predicate)
+//   - buildExplanation(fields)         -> frozen valid object    (throws if invalid)
+//   - coerceExplanation(fields, ctx)   -> frozen valid object    (never throws; degrades)
+
+const REQUIRED_STRINGS = ["what_failed", "why_gave_up", "human_question"];
+
+// Tautological human_question patterns — operator gets no decision from these.
+const TAUTOLOGY_RE =
+  /^(this |it )?(requires?|needs?|escalate[sd]? to|page|ask)( a| the)? (human|operator|person|someone)( to (decide|intervene|look))?\.?$/i;
+const VAGUE_RE = /^(needs?|requires?) (human|manual) (intervention|action|review)\.?$/i;
+// "a human must decide", "a person should intervene", etc.
+const DEFER_RE =
+  /^(a |the )?(human|operator|person|someone) (must|should|needs? to|has to) (decide|intervene|review|act|handle|look)\.?$/i;
+
+function norm(s) {
+  return String(s ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+}
+
+export function validateExplanation(e) {
+  const errors = [];
+  if (!e || typeof e !== "object" || Array.isArray(e)) {
+    return { valid: false, errors: ["explanation: not an object"] };
+  }
+  for (const k of REQUIRED_STRINGS) {
+    if (typeof e[k] !== "string" || e[k].trim() === "") errors.push(`${k}: missing or empty`);
+  }
+  if (e.observed == null || typeof e.observed !== "object" || Array.isArray(e.observed)) {
+    errors.push("observed: must be a non-null object");
+  }
+  if (!Array.isArray(e.attempts)) errors.push("attempts: must be an array");
+  // Tautology gate — only meaningful once human_question is a non-empty string.
+  if (typeof e.human_question === "string" && e.human_question.trim() !== "") {
+    const q = norm(e.human_question);
+    if (TAUTOLOGY_RE.test(q) || VAGUE_RE.test(q) || DEFER_RE.test(q)) {
+      errors.push("human_question: tautological — names no decision");
+    }
+    if (q === norm(e.what_failed)) {
+      errors.push("human_question: merely restates what_failed");
+    }
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+export function buildExplanation(fields) {
+  const e = normalizeShape(fields);
+  const { valid, errors } = validateExplanation(e);
+  if (!valid) throw new Error(`buildExplanation: invalid — ${errors.join("; ")}`);
+  return Object.freeze(e);
+}
+
+export function coerceExplanation(fields, ctx = {}) {
+  const e = normalizeShape(fields);
+  const { valid } = validateExplanation(e);
+  if (valid) return Object.freeze(e);
+  // Degrade: fill missing required fields with safe fallbacks so the operator
+  // still gets a real page even when input is thin.
+  const ticket = ctx.ticket ?? "this ticket";
+  const phase = ctx.phase ? ` ${ctx.phase} phase` : "";
+  if (!e.what_failed) e.what_failed = `unexplained failure in ${ticket}${phase}`;
+  if (!e.why_gave_up) e.why_gave_up = `no actionable diagnosis available`;
+  e.human_question = `Review ${ticket}${phase}: ${e.what_failed} — decide whether to retry, hand off, or cancel.`;
+  e.degraded = true;
+  return Object.freeze(e);
+}
+
+function normalizeShape(f = {}) {
+  return {
+    what_failed: typeof f.what_failed === "string" ? f.what_failed : "",
+    observed:
+      f.observed != null && typeof f.observed === "object" && !Array.isArray(f.observed)
+        ? f.observed
+        : {},
+    attempts: Array.isArray(f.attempts) ? f.attempts : [],
+    why_gave_up: typeof f.why_gave_up === "string" ? f.why_gave_up : "",
+    human_question: typeof f.human_question === "string" ? f.human_question : "",
+  };
+}

--- a/plugins/dev/scripts/execution-core/escalation-explanation.test.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-explanation.test.mjs
@@ -1,0 +1,143 @@
+// escalation-explanation.test.mjs — CTL-1065: contract + tautology validator tests.
+import { describe, test, expect } from "bun:test";
+import {
+  validateExplanation,
+  buildExplanation,
+  coerceExplanation,
+} from "./escalation-explanation.mjs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const SHIM_PATH = fileURLToPath(new URL("./escalation-explain.mjs", import.meta.url));
+
+const good = {
+  what_failed: "implement phase worker made no commits in 42 minutes",
+  observed: { elapsedMin: 42, commitCount: 0, bgJobId: "ab12ef34" },
+  attempts: [{ attempt: 1, outcome: "revived", reason: "watchdog_revive" }],
+  why_gave_up: "revive budget (1) exhausted after attempt 2 produced no commits",
+  human_question: "restart CTL-1 implement from scratch, or is this a known flaky env?",
+};
+
+describe("validateExplanation", () => {
+  test("accepts a fully-formed explanation", () => {
+    expect(validateExplanation(good)).toEqual({ valid: true, errors: [] });
+  });
+
+  test("requires all five fields present and non-empty", () => {
+    for (const k of ["what_failed", "observed", "why_gave_up", "human_question"]) {
+      const bad = { ...good, [k]: "" };
+      const r = validateExplanation(bad);
+      expect(r.valid).toBe(false);
+      expect(r.errors.join(" ")).toContain(k);
+    }
+  });
+
+  test("observed must be a non-null, non-array object", () => {
+    expect(validateExplanation({ ...good, observed: null }).valid).toBe(false);
+    expect(validateExplanation({ ...good, observed: [] }).valid).toBe(false);
+    expect(validateExplanation({ ...good, observed: "string" }).valid).toBe(false);
+  });
+
+  test("attempts must be an array (empty allowed)", () => {
+    expect(validateExplanation({ ...good, attempts: [] }).valid).toBe(true);
+    expect(validateExplanation({ ...good, attempts: "nope" }).valid).toBe(false);
+  });
+
+  test("rejects a human_question that just says 'needs a human'", () => {
+    for (const q of [
+      "this requires a human",
+      "needs human intervention",
+      "escalate to operator",
+      "a human must decide",
+    ]) {
+      const r = validateExplanation({ ...good, human_question: q });
+      expect(r.valid).toBe(false);
+    }
+  });
+
+  test("rejects a human_question that merely restates what_failed", () => {
+    const r = validateExplanation({ ...good, human_question: good.what_failed });
+    expect(r.valid).toBe(false);
+  });
+
+  test("rejects null / non-object input", () => {
+    expect(validateExplanation(null).valid).toBe(false);
+    expect(validateExplanation("string").valid).toBe(false);
+  });
+});
+
+describe("buildExplanation", () => {
+  test("returns a valid object", () => {
+    const e = buildExplanation({
+      what_failed: "x failed in y",
+      observed: { a: 1 },
+      attempts: [],
+      why_gave_up: "budget spent",
+      human_question: "should we retry x with a clean checkout?",
+    });
+    expect(e.human_question).toContain("retry");
+    expect(validateExplanation(e).valid).toBe(true);
+  });
+
+  test("throws on invalid input", () => {
+    expect(() =>
+      buildExplanation({ what_failed: "", observed: {}, attempts: [], why_gave_up: "", human_question: "" }),
+    ).toThrow();
+  });
+});
+
+describe("coerceExplanation", () => {
+  test("never throws; degrades an invalid question to a safe fallback", () => {
+    const e = coerceExplanation(
+      {
+        what_failed: "worker hung",
+        observed: { elapsedMin: 42 },
+        attempts: [],
+        why_gave_up: "no progress",
+        human_question: "needs human",
+      },
+      { ticket: "CTL-1", phase: "implement" },
+    );
+    expect(e.degraded).toBe(true);
+    expect(validateExplanation(e).valid).toBe(true);
+    expect(e.human_question).toContain("CTL-1");
+  });
+
+  test("returns valid object unchanged when fields are valid", () => {
+    const e = coerceExplanation(good, { ticket: "CTL-1" });
+    expect(e.degraded).toBeUndefined();
+    expect(validateExplanation(e).valid).toBe(true);
+  });
+
+  test("never throws on completely empty input", () => {
+    expect(() => coerceExplanation({}, { ticket: "CTL-99", phase: "plan" })).not.toThrow();
+    const e = coerceExplanation({}, { ticket: "CTL-99" });
+    expect(validateExplanation(e).valid).toBe(true);
+    expect(e.degraded).toBe(true);
+  });
+});
+
+describe("CLI shim (escalation-explain.mjs)", () => {
+  test("emits validated JSON on stdout, exit 0", () => {
+    const r = spawnSync("node", [
+      SHIM_PATH,
+      "--what-failed", "rebase conflict on thoughts/",
+      "--observed", JSON.stringify({ files: ["a.md"], rc: 1 }),
+      "--why-gave-up", "auto-rebase refused a dirty tree",
+      "--human-question", "resolve a.md by hand then re-run, or discard the local thoughts edit?",
+    ], { encoding: "utf8" });
+    expect(r.status).toBe(0);
+    const obj = JSON.parse(r.stdout);
+    expect(obj.what_failed).toContain("rebase");
+  });
+
+  test("degrades a tautological question but still exits 0", () => {
+    const r = spawnSync("node", [
+      SHIM_PATH,
+      "--ticket", "CTL-9", "--phase", "implement",
+      "--what-failed", "x", "--why-gave-up", "y", "--human-question", "needs a human",
+    ], { encoding: "utf8" });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout).degraded).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/orphan-sweep-explain.test.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-sweep-explain.test.mjs
@@ -65,4 +65,77 @@ describe("CTL-1065: orphan-sweep explanation pipeline", () => {
     expect(expl.degraded).toBe(true);
     expect(validateExplanation(expl).valid).toBe(true);
   });
+
+  // CTL-1065 regression: the earlier tests pass `shimResult.stdout` straight to
+  // jq's --argjson and so never exercise the bash quoting the real scripts use.
+  // Both write sites originally wrote `--argjson expl "${expl_json:-{}}"`, where
+  // bash closes the parameter expansion at the FIRST `}` — so a non-empty value
+  // `{"a":1}` expands to `{"a":1}}` (trailing brace → invalid JSON → jq exits 2).
+  // These tests run the actual bash expansion to lock that in.
+
+  test("the broken ${var:-{}} expansion produces a trailing brace and fails jq", () => {
+    const broken = spawnSync(
+      "bash",
+      ["-c", 'printf "%s" "${expl_json:-{}}" | jq -e . >/dev/null'],
+      { env: { ...process.env, expl_json: '{"a":1}' }, encoding: "utf8" },
+    );
+    // jq must reject the malformed `{"a":1}}` — proving the old pattern was buggy.
+    expect(broken.status).not.toBe(0);
+
+    // And confirm the malformed expansion really is the trailing-brace string.
+    const expanded = spawnSync(
+      "bash",
+      ["-c", 'printf "%s" "${expl_json:-{}}"'],
+      { env: { ...process.env, expl_json: '{"a":1}' }, encoding: "utf8" },
+    );
+    expect(expanded.stdout).toBe('{"a":1}}');
+  });
+
+  test("the fixed guard + direct expansion merges valid JSON through real bash", () => {
+    const sigPath = join(dir, "phase-fixed.json");
+    writeFileSync(sigPath, JSON.stringify({
+      ticket: "CTL-99", phase: "implement", status: "running",
+      bg_job_id: "ab12ef34", updatedAt: "2026-01-01T00:00:00Z",
+    }));
+
+    const shimResult = spawnSync("node", [
+      SHIM,
+      "--ticket", "CTL-99", "--phase", "implement",
+      "--what-failed", "orphan-sweep found a stale phase signal for CTL-99/implement",
+      "--observed", JSON.stringify({ bgJobId: "ab12ef34", staleMarker: "orphan-sweep-stale" }),
+      "--why-gave-up", "the bg job is gone but the signal was never finalized",
+      "--human-question", "re-dispatch CTL-99/implement, or mark it abandoned?",
+    ], { encoding: "utf8" });
+    expect(shimResult.status).toBe(0);
+
+    // Mirror the real script exactly: guard on a prior line, pass the var directly.
+    const tmpOut = join(dir, "phase-fixed.out.json");
+    const merged = spawnSync(
+      "bash",
+      ["-c",
+        '[ -n "$expl_json" ] || expl_json="{}"; ' +
+        'jq --arg ts "2026-01-01T01:00:00Z" --argjson expl "$expl_json" ' +
+        "'.status=\"failed\" | .failureReason=\"orphan-sweep-stale\" | .explanation=$expl | .updatedAt=$ts' " +
+        '"$sig" > "$out"',
+      ],
+      { env: { ...process.env, expl_json: shimResult.stdout, sig: sigPath, out: tmpOut }, encoding: "utf8" },
+    );
+    expect(merged.status).toBe(0);
+
+    const updated = JSON.parse(readFileSync(tmpOut, "utf8"));
+    expect(updated.status).toBe("failed");
+    expect(updated.failureReason).toBe("orphan-sweep-stale");
+    expect(validateExplanation(updated.explanation).valid).toBe(true);
+    expect(updated.explanation.observed.bgJobId).toBe("ab12ef34");
+  });
+
+  test("the fixed guard supplies {} when the shim value is empty", () => {
+    const merged = spawnSync(
+      "bash",
+      ["-c", '[ -n "$expl_json" ] || expl_json="{}"; printf "%s" "$expl_json" | jq -e . >/dev/null && printf "%s" "$expl_json"'],
+      { env: { ...process.env, expl_json: "" }, encoding: "utf8" },
+    );
+    expect(merged.status).toBe(0);
+    expect(merged.stdout).toBe("{}");
+  });
 });

--- a/plugins/dev/scripts/execution-core/orphan-sweep-explain.test.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-sweep-explain.test.mjs
@@ -1,0 +1,68 @@
+// orphan-sweep-explain.test.mjs — CTL-1065 Phase 4: verify the CLI shim pipeline
+// that orphan-sweep.sh and phase-agent-dispatch use to splice explanation JSON.
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { writeFileSync, readFileSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { validateExplanation } from "./escalation-explanation.mjs";
+
+const SHIM = fileURLToPath(new URL("./escalation-explain.mjs", import.meta.url));
+
+describe("CTL-1065: orphan-sweep explanation pipeline", () => {
+  let dir;
+  beforeAll(() => { dir = mkdtempSync(join(tmpdir(), "ctl1065-orphan-")); });
+  afterAll(() => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* */ } });
+
+  test("shim + jq merge produces a valid explanation in the signal file", () => {
+    const sigPath = join(dir, "phase-implement.json");
+    writeFileSync(sigPath, JSON.stringify({
+      ticket: "CTL-99", phase: "implement", status: "running",
+      bg_job_id: "ab12ef34", updatedAt: "2026-01-01T00:00:00Z",
+    }));
+
+    // Simulate what orphan-sweep.sh does
+    const shimResult = spawnSync("node", [
+      SHIM,
+      "--ticket", "CTL-99", "--phase", "implement",
+      "--what-failed", "orphan-sweep found a stale phase signal for CTL-99/implement",
+      "--observed", JSON.stringify({ bgJobId: "ab12ef34", staleMarker: "orphan-sweep-stale" }),
+      "--why-gave-up", "the bg job is gone but the signal was never finalized",
+      "--human-question", "re-dispatch CTL-99/implement, or mark it abandoned?",
+    ], { encoding: "utf8" });
+    expect(shimResult.status).toBe(0);
+
+    const expl = JSON.parse(shimResult.stdout);
+    expect(validateExplanation(expl).valid).toBe(true);
+
+    // Merge via jq (same pipeline as the shell script)
+    const mergeResult = spawnSync("jq", [
+      "--arg", "ts", "2026-01-01T01:00:00Z",
+      "--argjson", "expl", shimResult.stdout,
+      '.status = "failed" | .failureReason = "orphan-sweep-stale" | .explanation = $expl | .updatedAt = $ts',
+      sigPath,
+    ], { encoding: "utf8" });
+    expect(mergeResult.status).toBe(0);
+
+    const updated = JSON.parse(mergeResult.stdout);
+    expect(updated.status).toBe("failed");
+    expect(updated.failureReason).toBe("orphan-sweep-stale");
+    expect(validateExplanation(updated.explanation).valid).toBe(true);
+    expect(updated.explanation.observed.bgJobId).toBe("ab12ef34");
+  });
+
+  test("shim degrades a tautological question but jq merge still succeeds", () => {
+    const shimResult = spawnSync("node", [
+      SHIM,
+      "--ticket", "CTL-99", "--phase", "implement",
+      "--what-failed", "x",
+      "--why-gave-up", "y",
+      "--human-question", "needs human",
+    ], { encoding: "utf8" });
+    expect(shimResult.status).toBe(0);
+    const expl = JSON.parse(shimResult.stdout);
+    expect(expl.degraded).toBe(true);
+    expect(validateExplanation(expl).valid).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -90,6 +90,7 @@ const EMIT_COMPLETE_BIN = fileURLToPath(
 // heavy dependency graph. Imported for local use + re-exported for callers.
 import { resolvePhaseSessionId } from "./session-resolve.mjs";
 export { resolvePhaseSessionId };
+import { coerceExplanation } from "./escalation-explanation.mjs";
 
 // defaultStatJob — stat ~/.claude/jobs/<bgJobId>/state.json. Returns null when
 // the job dir is gone (the worker's process no longer exists), else its mtime,
@@ -1908,6 +1909,22 @@ export function reclaimDeadWorkIfPossible(
   // CTL-932: `extras` (optional) rides evidence into the escalated event
   // payload (e.g. the wedge screen captures). Cool-down/breaker behaviour is
   // untouched.
+  // reasonToWhyGaveUp — central map so per-reason phrasing is testable.
+  function reasonToWhyGaveUp(r, n) {
+    switch (r) {
+      case "busy-ceiling-exceeded":
+        return "worker was alive past the busy ceiling with no committed work";
+      case "no-progress":
+        return `no forward progress after ${n} attempt(s) — stop-and-escalate`;
+      case "no-probe-for-phase":
+        return "no probe available for this phase — cannot verify work is done";
+      case "wedged-never-started-exhausted":
+        return `wedged-never-started replacement budget exhausted after ${n} attempt(s)`;
+      default:
+        return `escalation reason: ${r} (after ${n} attempt(s))`;
+    }
+  }
+
   function escalateOnce(reason, finalAttemptCount, extras) {
     // CTL-679 — while the Linear breaker is open we are rate-limited; the
     // needs-human apply would 429 and write no marker, re-firing every tick.
@@ -1924,13 +1941,26 @@ export function reclaimDeadWorkIfPossible(
     if (inEscalationCooldownFn(orchDir, ticket, phase, now())) {
       return "escalation-suppressed";
     }
+    // CTL-1065: build a coerced explanation and attach it to extras so the
+    // escalated event payload carries structured, decision-shaped context.
+    const explanation = coerceExplanation(
+      {
+        what_failed: `${phase} escalated after ${finalAttemptCount} attempt(s): ${reason}`,
+        observed: { final_attempt_count: finalAttemptCount, ...(extras?.observed ?? {}) },
+        attempts: extras?.attempts ?? [],
+        why_gave_up: reasonToWhyGaveUp(reason, finalAttemptCount),
+        human_question: extras?.human_question ?? "",
+      },
+      { ticket, phase },
+    );
+    const enrichedExtras = { ...(extras ?? {}), explanation };
     appendEscalatedEvent({
       phase,
       ticket,
       orchId,
       reason,
       final_attempt_count: finalAttemptCount,
-      ...(extras ? { extras } : {}),
+      extras: enrichedExtras,
     });
     applyStalledLabel({ orchDir, ticket });
     recordEscalationFn(orchDir, ticket, phase, reason, now());

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -4602,3 +4602,51 @@ describe("reclaimDeadWorkIfPossible — CTL-778 alive-probe-reclaim", () => {
     expect(emit.calls.length).toBe(0);
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────────
+// CTL-1065: escalateOnce carries a valid structured explanation
+// ──────────────────────────────────────────────────────────────────────────
+import { validateExplanation } from "./escalation-explanation.mjs";
+
+describe("CTL-1065: reclaimDeadWorkIfPossible escalated event carries explanation", () => {
+  const orch = mkdtempSync(join(tmpdir(), "ctl1065-reclaim-"));
+  afterEach(() => { try { rmSync(orch, { recursive: true, force: true }); } catch { /* */ } });
+
+  function impl1065(extra = {}) {
+    mkdirSync(join(orch, "workers", "CTL-65"), { recursive: true });
+    return {
+      ticket: "CTL-65", phase: "implement", status: "running",
+      startedAt: new Date(0).toISOString(),
+      liveness: { kind: "bg", value: "abcd1234" },
+      raw: { bg_job_id: "abcd1234", generation: 1, startedAt: new Date(0).toISOString() },
+      ...extra,
+    };
+  }
+
+  test("busy-ceiling escalation carries a valid explanation alongside reason", () => {
+    const captured = [];
+    const appendEscalatedEvent = (obj) => captured.push(obj);
+    reclaimDeadWorkIfPossible(
+      orch,
+      impl1065(),
+      {
+        statJob: () => ({ mtimeMs: Date.now(), exists: true }),
+        jobLifecycle: () => "alive",
+        busyCeilingMs: 1,
+        now: () => 10_000,
+        probes: { implement: () => false },
+        appendEscalatedEvent,
+        applyStalledLabel: recorder({ applied: true }),
+        inEscalationCooldownFn: () => false,
+        recordEscalationFn: () => {},
+        breaker: { isOpen: () => false },
+      },
+    );
+    expect(captured.length).toBeGreaterThanOrEqual(1);
+    const call = captured[0];
+    expect(call.reason).toBe("busy-ceiling-exceeded"); // unchanged
+    const expl = call.extras?.explanation;
+    expect(expl).toBeTruthy();
+    expect(validateExplanation(expl).valid).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4459,6 +4459,10 @@ function runTick() {
     // when CATALYST_BELIEFS_SHADOW=1 (collector opened the db) AND
     // CATALYST_DIAGNOSTICIAN=1 (diagnostician gate).
     if (beliefsRes?.ok && beliefsRes?.tickId != null) {
+      // CTL-1065: diagResult is populated by the diagnostician block below and
+      // consumed by executeEscalations to enrich the escalation payload.
+      let diagResult = null;
+
       try {
         const diagDb = getBeliefsDb();
         if (diagDb) {
@@ -4466,7 +4470,9 @@ function runTick() {
           // applies needs-human. The single label owner is executeEscalations
           // (beliefs/escalate.mjs), called immediately after, which pages off the
           // same R12 escalate_human beliefs exactly once.
-          processDiagnosticianWakes(diagDb, beliefsRes.tickId, {});
+          // CTL-1065: capture the result so escalated[].evidence can be threaded
+          // into executeEscalations as evidenceBySubject.
+          diagResult = processDiagnosticianWakes(diagDb, beliefsRes.tickId, {});
         }
       } catch (diagErr) {
         try {
@@ -4487,12 +4493,20 @@ function runTick() {
       try {
         const escDb = getBeliefsDb();
         if (escDb) {
+          // CTL-1065: build evidenceBySubject from the diagnostician's escalated
+          // subjects so the explanation payload carries real observed data.
+          const evidenceBySubject = Object.fromEntries(
+            (diagResult?.escalated ?? [])
+              .filter((x) => x?.subject)
+              .map((x) => [x.subject, x.evidence ?? {}]),
+          );
           executeEscalations(escDb, beliefsRes.tickId, {
             orchDir: runningOpts.orchDir,
             writeStatus: runningOpts.writeStatus,
             appendEvent: intentEventAppender,
             enforce: (process.env.CATALYST_INTENTS_ENFORCE ?? "0") === "1",
             env: process.env,
+            evidenceBySubject,
           });
         }
       } catch (escErr) {

--- a/plugins/dev/scripts/execution-core/watchdog-action.mjs
+++ b/plugins/dev/scripts/execution-core/watchdog-action.mjs
@@ -21,6 +21,7 @@ import { join } from "node:path";
 import { log } from "./config.mjs";
 import { emitReapIntent } from "./reap-intent.mjs";
 import { labelOnce, recordEscalation } from "./label-guard.mjs";
+import { coerceExplanation } from "./escalation-explanation.mjs";
 
 const SETTLED = new Set(["done", "failed", "stalled", "aborted", "skipped", "complete"]);
 
@@ -100,10 +101,22 @@ export async function killHungWorker(
   try {
     const cur = JSON.parse(readFileSync(sigPath, "utf8"));
     if (SETTLED.has(cur.status)) return { outcome: "already-terminal" };
+    // CTL-1065: build structured explanation alongside failureReason.
+    const explanation = coerceExplanation(
+      {
+        what_failed: `${phase} phase worker made no commits in ${Math.floor(elapsedMin)} minutes`,
+        observed: { elapsedMin: Math.floor(elapsedMin), commitCount, bgJobId },
+        attempts: [],
+        why_gave_up: `watchdog killed the worker — no progress within the hung-worker threshold`,
+        human_question: `restart ${ticket} ${phase} from scratch, or is this a known slow/flaky step (extend the threshold)?`,
+      },
+      { ticket, phase },
+    );
     const updated = {
       ...cur,
       status: "failed",
       failureReason,
+      explanation,
       failedAt: new Date(now()).toISOString(),
     };
     const tmp = `${sigPath}.tmp.${process.pid}`;

--- a/plugins/dev/scripts/execution-core/watchdog-action.test.mjs
+++ b/plugins/dev/scripts/execution-core/watchdog-action.test.mjs
@@ -180,3 +180,37 @@ describe("killHungWorker — revive-budget", () => {
     expect(dispatch.calls.length).toBe(0);
   });
 });
+
+// CTL-1065: structured explanation written to signal on hung-worker kill
+import { validateExplanation } from "./escalation-explanation.mjs";
+
+describe("CTL-1065: killHungWorker writes signal.explanation alongside failureReason", () => {
+  test("escalated path writes a valid explanation with observed elapsedMin/commitCount/bgJobId", async () => {
+    const sig = writeSignal("running");
+    await killHungWorker(orchDir, T, sig, {
+      elapsedMin: 42, commitCount: 0,
+      writeStatus: { applyLabel: recorder({ applied: true }) },
+      emit: recorder(Promise.resolve(true)),
+      now: () => 1_000_000,
+    });
+    const onDisk = JSON.parse(readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8"));
+    expect(onDisk.failureReason).toContain("hung_no_progress"); // unchanged
+    expect(validateExplanation(onDisk.explanation).valid).toBe(true);
+    expect(onDisk.explanation.observed.elapsedMin).toBe(42);
+    expect(onDisk.explanation.observed.bgJobId).toBe("abcd1234");
+  });
+
+  test("already-terminal path does NOT overwrite existing signal", async () => {
+    const sig = writeSignal("failed");
+    const r = await killHungWorker(orchDir, T, sig, {
+      elapsedMin: 42, commitCount: 0,
+      writeStatus: { applyLabel: recorder({ applied: true }) },
+      emit: recorder(Promise.resolve(true)),
+      now: () => 1,
+    });
+    expect(r.outcome).toBe("already-terminal");
+    const onDisk = JSON.parse(readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8"));
+    // explanation was not written (already-terminal early return)
+    expect(onDisk.explanation).toBeUndefined();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/home-inbox-attention.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-inbox-attention.test.ts
@@ -202,3 +202,41 @@ describe("rowDurationAnchor — attention rows anchor to attentionSince ?? heldS
     expect(rowDurationAnchor(row)).toBeNull();
   });
 });
+
+// ── CTL-1065: humanQuestion surfaces as attention sub-label ───────────────────
+
+describe("CTL-1065: attentionSubLabel uses humanQuestion when present", () => {
+  it("needs-human row uses humanQuestion as sub-label when present", () => {
+    const t = mkTicket("CTL-1065", {
+      attention: "needs-human",
+      humanQuestion: "restart CTL-1065 implement, or extend the threshold?",
+    });
+    const model = deriveInbox(mkPayload([t]));
+    const row = model.order.find((r) => r.id === "CTL-1065")!;
+    expect(row.subLabel).toBe("restart CTL-1065 implement, or extend the threshold?");
+  });
+
+  it("falls back to 'escalated — needs human' when humanQuestion absent", () => {
+    const t = mkTicket("CTL-1065", { attention: "needs-human" });
+    const model = deriveInbox(mkPayload([t]));
+    const row = model.order.find((r) => r.id === "CTL-1065")!;
+    expect(row.subLabel).toBe("escalated — needs human");
+  });
+
+  it("falls back when humanQuestion is empty string", () => {
+    const t = mkTicket("CTL-1065", { attention: "needs-human", humanQuestion: "" });
+    const model = deriveInbox(mkPayload([t]));
+    const row = model.order.find((r) => r.id === "CTL-1065")!;
+    expect(row.subLabel).toBe("escalated — needs human");
+  });
+
+  it("waiting-on-you still uses 'waiting on your answer' regardless of humanQuestion", () => {
+    const t = mkTicket("CTL-1065", {
+      attention: "waiting-on-you",
+      humanQuestion: "which path?",
+    });
+    const model = deriveInbox(mkPayload([t]));
+    const row = model.order.find((r) => r.id === "CTL-1065")!;
+    expect(row.subLabel).toBe("waiting on your answer");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data-human-question.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data-human-question.test.mjs
@@ -1,0 +1,49 @@
+// board-data-human-question.test.mjs — units for deriveHumanQuestion (CTL-1065).
+// Covers the inbox sub-label source: scans phase signals newest-first and
+// surfaces the most-recent explanation.human_question, null when none carry one.
+//
+//   cd plugins/dev/scripts/orch-monitor && bun test lib/board-data-human-question.test.mjs
+
+import { describe, it, expect } from "bun:test";
+import { deriveHumanQuestion } from "./board-data.mjs";
+
+describe("CTL-1065: deriveHumanQuestion", () => {
+  it("returns the human_question from a single signal that carries an explanation", () => {
+    const sigs = [{ status: "running" }, { explanation: { human_question: "retry or hand off?" } }];
+    expect(deriveHumanQuestion(sigs)).toBe("retry or hand off?");
+  });
+
+  it("scans newest-first — the highest-index explanation wins", () => {
+    const sigs = [
+      { explanation: { human_question: "OLD question?" } },
+      { explanation: { human_question: "NEW question?" } },
+    ];
+    expect(deriveHumanQuestion(sigs)).toBe("NEW question?");
+  });
+
+  it("falls back to an earlier signal when the newest carries no explanation", () => {
+    const sigs = [
+      { explanation: { human_question: "earlier question?" } },
+      { status: "running" },
+    ];
+    expect(deriveHumanQuestion(sigs)).toBe("earlier question?");
+  });
+
+  it("returns null when no signal carries an explanation", () => {
+    expect(deriveHumanQuestion([{ status: "running" }, { status: "failed" }])).toBeNull();
+  });
+
+  it("returns null for an empty array", () => {
+    expect(deriveHumanQuestion([])).toBeNull();
+  });
+
+  it("ignores non-object / null entries without throwing", () => {
+    const sigs = [null, "bogus", 42, { explanation: { human_question: "still found?" } }];
+    expect(deriveHumanQuestion(sigs)).toBe("still found?");
+  });
+
+  it("ignores an explanation whose human_question is not a string", () => {
+    const sigs = [{ explanation: { human_question: 123 } }, { explanation: {} }];
+    expect(deriveHumanQuestion(sigs)).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -709,6 +709,21 @@ function ticketUpdatedAt(phaseSigs) {
   return max;
 }
 
+/** CTL-1065: extract human_question from the most-recent phase signal that
+ *  carries a structured explanation. Scanned newest-phase-first so the most
+ *  actionable question surfaces. Returns null when no signal has one. */
+export function deriveHumanQuestion(phaseSigs) {
+  for (let i = phaseSigs.length - 1; i >= 0; i--) {
+    const sig = phaseSigs[i];
+    if (!sig || typeof sig !== "object") continue;
+    const expl = sig.explanation;
+    if (expl && typeof expl === "object" && typeof expl.human_question === "string") {
+      return expl.human_question;
+    }
+  }
+  return null;
+}
+
 // CTL-1041: the TITLE is the outcome line and must lead on every surface (slot
 // cards, inbox detail, holding rows). The triage `summary` is the DESCRIPTION
 // (e.g. "Live probe confirmed the unified event log…") and must NEVER stand in
@@ -1235,6 +1250,9 @@ export async function assembleBoard() {
       // when the surfaced phase carried no startedAt (pre-pipeline / corrupt
       // signal) → again rendered unavailable, never now-anchored to a guess.
       currentPhaseSince: cur.startedAt ?? null,
+      // CTL-1065: human_question from the most-recent phase signal's explanation,
+      // surfaced as the inbox sub-label for needs-human rows.
+      humanQuestion: deriveHumanQuestion(phaseSigs),
       // CTL-729: the single needs-attention bucket — 'waiting-on-you' (live
       // blocked bg job) | 'needs-human' (escalation label/marker) | null, with an
       // ISO attentionSince anchor (or null, never fabricated). Drives the ONE

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-state.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-state.test.ts
@@ -229,3 +229,58 @@ describe("computeQuestionHash — stable cache key", () => {
     expect(h).toMatch(/^[0-9a-f]{12}$/);
   });
 });
+
+// ── CTL-1065: humanQuestion surfaced from signal.explanation ──────────────────
+
+describe("CTL-1065: humanQuestion threaded from signal.explanation.human_question", () => {
+  test("humanQuestion is read from signal.explanation.human_question", async () => {
+    const opts = makeWorkerFixture("CTL-1065", {
+      "phase-implement.json": {
+        status: "stalled",
+        phase: "implement",
+        stalledReason: "busy-ceiling-max-escalations",
+        explanation: {
+          what_failed: "implement phase hit busy-ceiling escalation limit",
+          observed: { elapsedMin: 90, commitCount: 0, bgJobId: "ab12ef34" },
+          attempts: [],
+          why_gave_up: "exceeded the busy-ceiling escalation budget",
+          human_question: "restart CTL-1065 implement from scratch, or extend the threshold?",
+        },
+      },
+    });
+
+    const state = await collectInboxItemState("CTL-1065", opts);
+    expect(state).not.toBeNull();
+    expect(state!.humanQuestion).toBe(
+      "restart CTL-1065 implement from scratch, or extend the threshold?",
+    );
+  });
+
+  test("humanQuestion is null when no explanation present (back-compat)", async () => {
+    const opts = makeWorkerFixture("CTL-1065", {
+      "phase-implement.json": {
+        status: "stalled",
+        phase: "implement",
+        stalledReason: "busy-ceiling-max-escalations",
+      },
+    });
+
+    const state = await collectInboxItemState("CTL-1065", opts);
+    expect(state).not.toBeNull();
+    expect(state!.humanQuestion).toBeNull();
+  });
+
+  test("humanQuestion is null when explanation.human_question is absent", async () => {
+    const opts = makeWorkerFixture("CTL-1065", {
+      "phase-implement.json": {
+        status: "stalled",
+        phase: "implement",
+        explanation: { what_failed: "x", observed: {}, attempts: [], why_gave_up: "y" },
+      },
+    });
+
+    const state = await collectInboxItemState("CTL-1065", opts);
+    expect(state).not.toBeNull();
+    expect(state!.humanQuestion).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-state.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-state.ts
@@ -43,6 +43,9 @@ export interface InboxItemState {
    *  null when the transcript is absent or unreadable. */
   transcriptTail: string | null;
   bgJobId: string | null;
+  /** CTL-1065: structured escalation question from signal.explanation.human_question.
+   *  null when no explanation is present or the field is absent (back-compat). */
+  humanQuestion: string | null;
 }
 
 export interface CollectOptions {
@@ -243,6 +246,10 @@ export function collectInboxItemState(
     jobsDir,
   );
 
+  const expl = isRecord(signal.explanation) ? signal.explanation : null;
+  const humanQuestion =
+    expl !== null && typeof expl.human_question === "string" ? expl.human_question : null;
+
   return Promise.resolve({
     ticket,
     title: opts.title,
@@ -256,5 +263,6 @@ export function collectInboxItemState(
     raisedQuestion,
     transcriptTail,
     bgJobId,
+    humanQuestion,
   });
 }

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-summary.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-summary.test.ts
@@ -34,6 +34,7 @@ const STATE_FIXTURE: InboxItemState = {
   raisedQuestion: "Should the cache key include the model id?",
   transcriptTail: "Worker was implementing the cache. Should the cache key include the model id?",
   bgJobId: "testjob1",
+  humanQuestion: null,
 };
 
 const ANTHROPIC_OK_RESPONSE = JSON.stringify({

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/home-inbox.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/home-inbox.ts
@@ -170,12 +170,16 @@ export function classifyTicket(t: BoardTicket): InboxSectionKind {
   return "running";
 }
 
-/** CTL-729: the muted human sub-label for an attention row, in plain language —
- *  naming WHY it needs you (the operator-approved small sub-text). */
+/** CTL-729/CTL-1065: the muted human sub-label for an attention row, in plain
+ *  language — naming WHY it needs you. For needs-human rows, uses the structured
+ *  explanation's human_question when present; falls back to the generic phrase. */
 function attentionSubLabel(t: BoardTicket): string {
-  return t.attention === "needs-human"
-    ? "escalated — needs human"
-    : "waiting on your answer";
+  if (t.attention === "needs-human") {
+    return t.humanQuestion && t.humanQuestion.trim() !== ""
+      ? t.humanQuestion
+      : "escalated — needs human";
+  }
+  return "waiting on your answer";
 }
 
 /** The muted human sub-label per section — plain language, never jargon

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
@@ -134,6 +134,10 @@ export interface BoardTicket {
    *  has it been running / in its current state" anchor for the running set.
    *  null when the surfaced phase carried no startedAt. */
   currentPhaseSince?: string | null;
+  /** CTL-1065: structured escalation question from the most-recent stalled/failed
+   *  signal's explanation.human_question. Used by home-inbox attentionSubLabel as
+   *  the sub-label for needs-human rows. null when absent (back-compat). */
+  humanQuestion?: string | null;
   /** CTL-729: the single needs-attention bucket — 'waiting-on-you' (live worker's
    *  bg job blocked, paused for a human prompt) | 'needs-human' (a watchdog/phase
    *  escalation via a needs-human/needs-input label or the host-local marker) |

--- a/plugins/dev/scripts/orphan-sweep.sh
+++ b/plugins/dev/scripts/orphan-sweep.sh
@@ -197,8 +197,14 @@ sweep_signals() {
       --why-gave-up "the bg job is gone but the signal was never finalized" \
       --human-question "re-dispatch ${sig_ticket}/${sig_phase}, or mark it abandoned?" \
       2>/dev/null || echo '{}')"
+    # CTL-1065: guard on a prior line — `${expl_json:-{}}` is a bash trap: the
+    # parser closes the expansion at the FIRST `}`, so a non-empty value like
+    # `{"a":1}` expands to `{"a":1}}` (trailing brace → invalid JSON → jq exit 2
+    # → the `&& mv` is skipped and the stale signal is never flipped). Verified
+    # in bash 3.2 and 5.x. Pass the variable directly instead.
+    [ -n "$expl_json" ] || expl_json='{}'
     local tmp="${f}.tmp.$$"
-    jq --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson expl "${expl_json:-{}}" \
+    jq --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson expl "$expl_json" \
        '.status = "failed" | .failureReason = "orphan-sweep-stale" | .explanation = $expl | .updatedAt = $ts' \
        "$f" > "$tmp" && mv "$tmp" "$f"
     log "flipped stale signal: $f"

--- a/plugins/dev/scripts/orphan-sweep.sh
+++ b/plugins/dev/scripts/orphan-sweep.sh
@@ -185,9 +185,21 @@ sweep_signals() {
       continue
     fi
 
+    # CTL-1065: build structured explanation via CLI shim (always exits 0).
+    local sig_ticket sig_phase
+    sig_ticket="$(jq -r '.ticket // empty' "$f" 2>/dev/null)"
+    sig_phase="$(jq -r '.phase // empty' "$f" 2>/dev/null)"
+    local expl_json
+    expl_json="$(node "${SCRIPT_DIR}/execution-core/escalation-explain.mjs" \
+      --ticket "$sig_ticket" --phase "$sig_phase" \
+      --what-failed "orphan-sweep found a stale phase signal for ${sig_ticket}/${sig_phase}" \
+      --observed "$(jq -nc --arg job "$bg_job_id" '{bgJobId:$job,staleMarker:"orphan-sweep-stale"}' 2>/dev/null || echo '{}')" \
+      --why-gave-up "the bg job is gone but the signal was never finalized" \
+      --human-question "re-dispatch ${sig_ticket}/${sig_phase}, or mark it abandoned?" \
+      2>/dev/null || echo '{}')"
     local tmp="${f}.tmp.$$"
-    jq --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-       '.status = "failed" | .failureReason = "orphan-sweep-stale" | .updatedAt = $ts' \
+    jq --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson expl "${expl_json:-{}}" \
+       '.status = "failed" | .failureReason = "orphan-sweep-stale" | .explanation = $expl | .updatedAt = $ts' \
        "$f" > "$tmp" && mv "$tmp" "$f"
     log "flipped stale signal: $f"
     emit_reclaim stale_signal "$f"

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -1027,10 +1027,19 @@ if [[ -z $RESUME_SESSION ]] && is_rebase_phase "$PHASE"; then
 		# retries into the same conflict.
 		echo "phase-agent-dispatch: rebase conflict (rc=${REBASE_RC}) for ${TICKET}/${PHASE}; parking with reason=${STALL_REASON}" >&2
 		TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+		# CTL-1065: build a structured explanation via the CLI shim (always exits 0).
+		EXPL_JSON="$(node "${SCRIPT_DIR}/execution-core/escalation-explain.mjs" \
+			--ticket "$TICKET" --phase "$PHASE" \
+			--what-failed "rebase conflict (rc=${REBASE_RC}) parking ${TICKET}/${PHASE}" \
+			--observed "$(jq -nc --arg r "${REBASE_RC}" --arg reason "${STALL_REASON}" '{rebaseRc:($r|tonumber),stallReason:$reason}' 2>/dev/null || echo '{}')" \
+			--why-gave-up "auto-rebase could not proceed (${STALL_REASON})" \
+			--human-question "resolve the conflict for ${TICKET}/${PHASE} by hand and re-run, or discard the local change?" \
+			2>/dev/null || echo '{}')"
 		tmp="${SIGNAL_FILE}.tmp.$$"
-		if jq --arg ts "$TS" --arg reason "$STALL_REASON" \
+		if jq --arg ts "$TS" --arg reason "$STALL_REASON" --argjson expl "${EXPL_JSON:-{}}" \
 			'.status = "stalled"
        | .failureReason = $reason
+       | .explanation = $expl
        | .updatedAt = $ts
        | .phaseTimestamps = ((.phaseTimestamps // {}) | .stalled = $ts)' \
 			"$SIGNAL_FILE" >"$tmp" 2>/dev/null; then

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -1036,7 +1036,13 @@ if [[ -z $RESUME_SESSION ]] && is_rebase_phase "$PHASE"; then
 			--human-question "resolve the conflict for ${TICKET}/${PHASE} by hand and re-run, or discard the local change?" \
 			2>/dev/null || echo '{}')"
 		tmp="${SIGNAL_FILE}.tmp.$$"
-		if jq --arg ts "$TS" --arg reason "$STALL_REASON" --argjson expl "${EXPL_JSON:-{}}" \
+		# CTL-1065: guard on a prior line — `${EXPL_JSON:-{}}` is a bash trap: the
+		# parser closes the expansion at the FIRST `}`, so a non-empty value like
+		# `{"a":1}` expands to `{"a":1}}` (trailing brace → invalid JSON → jq fails
+		# → the else branch leaves the park signal un-written). Verified in bash
+		# 3.2 and 5.x. Pass the variable directly instead.
+		[ -n "$EXPL_JSON" ] || EXPL_JSON='{}'
+		if jq --arg ts "$TS" --arg reason "$STALL_REASON" --argjson expl "$EXPL_JSON" \
 			'.status = "stalled"
        | .failureReason = $reason
        | .explanation = $expl

--- a/plugins/dev/skills/_phase-agent-template/SKILL.md
+++ b/plugins/dev/skills/_phase-agent-template/SKILL.md
@@ -240,10 +240,16 @@ EXPL_JSON="$(node "${PLUGIN_ROOT}/scripts/execution-core/escalation-explain.mjs"
   2>/dev/null || echo '{}')"
 ```
 
-Then merge it into the signal alongside `failureReason`:
+Then merge it into the signal alongside `failureReason`. Guard the value on a
+prior line and pass the variable directly — never inline `${EXPL_JSON:-{}}`: the
+bash parser closes the parameter expansion at the FIRST `}`, so a non-empty value
+like `{"a":1}` expands to `{"a":1}}` (trailing brace → invalid JSON → jq exits
+non-zero → the `&& mv` is skipped and the signal is never written). Verified in
+bash 3.2 and 5.x.
 
 ```bash
-jq --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson expl "${EXPL_JSON:-{}}" \
+[ -n "$EXPL_JSON" ] || EXPL_JSON='{}'
+jq --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson expl "$EXPL_JSON" \
    '.status = "failed" | .failureReason = "{{ reason }}" | .explanation = $expl | .updatedAt = $ts' \
    "$SIGNAL_FILE" > "$SIGNAL_FILE.tmp.$$" && mv "$SIGNAL_FILE.tmp.$$" "$SIGNAL_FILE"
 ```

--- a/plugins/dev/skills/_phase-agent-template/SKILL.md
+++ b/plugins/dev/skills/_phase-agent-template/SKILL.md
@@ -211,6 +211,59 @@ fi
 [[ -n "$COMMS" ]] && "$COMMS" done "$CHANNEL" --as "$TICKET" >/dev/null 2>&1 || true
 ```
 
+## Structured escalation explanation (CTL-1065)
+
+Whenever a phase writes a failed/stalled signal that will be shown to the
+operator (e.g. via the Inbox "Needs you" section), it MUST populate an
+`explanation` block alongside `failureReason`. The contract shape:
+
+```json
+{
+  "what_failed":    "<specific symptom in plain language>",
+  "observed":       { "<key>": "<value>", ... },
+  "attempts":       ["<what was tried>", ...],
+  "why_gave_up":    "<reason no further autonomous action was taken>",
+  "human_question": "<one specific, answerable question for the operator>"
+}
+```
+
+Use the CLI shim so the shell can build the JSON without risk of syntax
+errors or missing fields:
+
+```bash
+EXPL_JSON="$(node "${PLUGIN_ROOT}/scripts/execution-core/escalation-explain.mjs" \
+  --ticket "$TICKET" --phase "$PHASE" \
+  --what-failed "{{ specific symptom }}" \
+  --observed "$(jq -nc '{key:"value"}' 2>/dev/null || echo '{}')" \
+  --why-gave-up "{{ reason }}" \
+  --human-question "{{ specific question }}" \
+  2>/dev/null || echo '{}')"
+```
+
+Then merge it into the signal alongside `failureReason`:
+
+```bash
+jq --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson expl "${EXPL_JSON:-{}}" \
+   '.status = "failed" | .failureReason = "{{ reason }}" | .explanation = $expl | .updatedAt = $ts' \
+   "$SIGNAL_FILE" > "$SIGNAL_FILE.tmp.$$" && mv "$SIGNAL_FILE.tmp.$$" "$SIGNAL_FILE"
+```
+
+### Banned human_question phrases (tautology gate)
+
+The CLI shim rejects these with `degraded: true` and substitutes a
+generic fallback. Never write:
+
+- "needs a human" / "requires human intervention" / "needs human review"
+- "a human must decide" / "someone must decide"
+- "escalate to operator" / "escalate to human"
+- "requires intervention" / "requires action" (bare)
+- "needs attention" (bare)
+
+Write the **specific question** instead:
+- Bad: "this phase needs human attention"
+- Good: "should the rebase conflict in foo/bar.ts be resolved by discarding
+  the local change or by cherry-picking the remote version?"
+
 ## Failure handling
 
 Any non-recoverable failure (turn cap hit, prior artifact missing, scope

--- a/plugins/dev/skills/phase-remediate/SKILL.md
+++ b/plugins/dev/skills/phase-remediate/SKILL.md
@@ -326,10 +326,20 @@ fi
 
 ## Failure handling
 
-One failure mode — hard error (caller-supplied reason).
+One failure mode — hard error (caller-supplied reason). When escalating to
+`stalled`/`needs-human`, populate an `explanation` block per CTL-1065 using
+the CLI shim (always exits 0; degrades gracefully on bad input):
 
 ```bash
 REASON="${1:-remediation failed}"  # caller-supplied short string
+
+# CTL-1065: build structured explanation for the operator inbox.
+EXPL_JSON="$(node "${PLUGIN_ROOT}/scripts/execution-core/escalation-explain.mjs" \
+  --ticket "$TICKET" --phase "$PHASE" \
+  --what-failed "remediation failed: ${REASON}" \
+  --why-gave-up "exhausted remediation budget or encountered an unrecoverable error" \
+  --human-question "should ${TICKET} be re-remediated manually, or should verify findings be waived?" \
+  2>/dev/null || echo '{}')"
 
 # Hard-error: emit failed + attention, exit non-zero. A `failed` event lets
 # the FSM revive remediate once (REVIVE_BUDGET) before stalling — distinct

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -406,3 +406,26 @@ guard fails the build if this skill ever emits a `linearis issues update` call.
 
 The refinement step is deliberately optional — the orchestrator hand-off in CTL-452 only needs the
 `phase.triage.complete.<TICKET>` event, and the bash body already emits that.
+
+## Structured escalation (CTL-1065)
+
+If triage genuinely cannot proceed (e.g., the ticket description is too
+ambiguous to classify, or a required external resource is unavailable), emit
+`failed` with a structured `explanation` block. Use the CLI shim:
+
+```bash
+EXPL_JSON="$(node "${PLUGIN_ROOT}/scripts/execution-core/escalation-explain.mjs" \
+  --ticket "$TICKET" --phase triage \
+  --what-failed "{{ specific symptom }}" \
+  --why-gave-up "{{ reason autonomous triage cannot complete }}" \
+  --human-question "{{ one specific answerable question }}" \
+  2>/dev/null || echo '{}')"
+```
+
+The `human_question` MUST be specific and answerable — never:
+- "needs a human" / "requires human review"
+- "a human must decide" / "escalate to operator"
+
+Write the specific question instead:
+- Good: "should CTL-NNN be classified as a feature or a refactor — the
+  description mentions both adding a new API and removing the old one?"


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-12T03:55:00Z -->
<!-- Last updated: 2026-06-12T03:55:00Z -->
<!-- PR: #1876 -->
<!-- Previous commits: 5a9adee0,af204022,b646c7e6,4d9c79a2,5eef4e7c,7339d0a1,c9038632,54367eed,29f80aa5 -->

## Summary

When a ticket stalls and surfaces to the Inbox, the operator previously saw only a bare reason code — "we need a human to resolve the merge conflict because merge conflicts require humans." This PR closes the tautology gap end-to-end:

- **Phase 1**: New `escalation-explanation.mjs` contract module — `validateExplanation`, `buildExplanation`, `coerceExplanation`, plus a CLI shim (`escalation-explain.mjs`) for shell write sites. Tautology gate rejects empty/vague/self-referential `human_question` phrases and degrades gracefully (never blocks escalation).
- **Phase 2**: Diagnostician evidence threaded from `processDiagnosticianWakes` into `executeEscalations` via `evidenceBySubject` in `scheduler.mjs`; `beliefs/escalate.mjs` builds a structured explanation from evidence and attaches it to every `escalate.human` page event.
- **Phase 3**: `watchdog-action.mjs` writes `explanation` alongside `failureReason` on hung-worker kill; `recovery.mjs` `escalateOnce` attaches explanation to stall escalations with a `reasonToWhyGaveUp` map.
- **Phase 4**: `phase-agent-dispatch` (source-conflict park) and `orphan-sweep.sh` (stale signal flip) both call the CLI shim and merge `explanation` into the signal via `jq`. Both degrade gracefully when node is absent.
- **Phase 5**: `InboxItemState.humanQuestion`, `BoardTicket.humanQuestion`, `deriveHumanQuestion` helper in `board-data.mjs`, and `attentionSubLabel` in `home-inbox.ts` updated to surface the structured question as the Inbox sub-label for `needs-human` rows.
- **Phase 6**: `_phase-agent-template`, `phase-remediate`, and `phase-triage` SKILL.md files updated to document the contract, provide CLI shim usage patterns, and explicitly ban tautological `human_question` phrases.
- **Fix commits**: remediated verify findings (regression risk 6), fixed `${var:-{}}` brace-default bug at explanation write sites, and addressed phase-review remediations.

## Changes Made

### New contract module (execution-core)

- `escalation-explanation.mjs` — `validateExplanation` (schema + tautology gate), `buildExplanation` (assembles from raw evidence), `coerceExplanation` (wraps any existing `why` string into the contract shape, never throws)
- `escalation-explain.mjs` — CLI shim: parses `--ticket`, `--phase`, `--reason`, `--evidence` args and prints the JSON result to stdout for shell `$(…)` capture

### Execution-core wiring

- `beliefs/escalate.mjs` — accepts `evidenceBySubject`, calls `coerceExplanation`, attaches to escalation event extras
- `scheduler.mjs` — captures `processDiagnosticianWakes` result, passes `evidenceBySubject` to `executeEscalations`
- `recovery.mjs` — `escalateOnce` builds coerced explanation (via `reasonToWhyGaveUp` map) and attaches it to `extras.explanation`
- `watchdog-action.mjs` — writes `signal.explanation` alongside `failureReason` on the atomic terminal write
- `phase-agent-dispatch` — source-conflict park block calls `escalation-explain.mjs` shim, merges JSON into signal
- `orphan-sweep.sh` — stale-flip block does the same, deriving ticket/phase from the signal file

### Orch-monitor surface

- `lib/inbox-state.ts` — `InboxItemState.humanQuestion: string | null`
- `lib/board-data.mjs` — `BoardTicket.humanQuestion`, `deriveHumanQuestion(signal)` helper
- `ui/src/board/types.ts` — `BoardTicket.humanQuestion?: string | null`
- `ui/src/board/home-inbox.ts` — `attentionSubLabel` renders `humanQuestion` for `needs-human` rows instead of "escalated — needs human"

### Skill documentation

- `skills/_phase-agent-template/SKILL.md` — structured escalation explanation contract section: CLI shim usage, jq merge pattern, banned tautological phrases
- `skills/phase-remediate/SKILL.md` — shim call in failure handling section
- `skills/phase-triage/SKILL.md` — escalation guidance for Opus-mode agents

## How to Verify It

- [ ] Trigger a source-conflict park — the signal file's `.explanation.human_question` contains a concrete decision question, not a category label
- [ ] Open the Inbox with a stalled `needs-human` ticket — the sub-label shows the structured `humanQuestion` instead of "escalated — needs human"
- [x] `bun test` (execution-core): 3053 pass, 4 pre-existing failures unchanged; new files: `escalation-explanation.test.mjs` (14), `orphan-sweep-explain.test.mjs` (2), extended `watchdog-action.test.mjs`, `recovery.test.mjs`, `escalate.test.mjs`
- [x] `bun test` (orch-monitor): `board*.test.ts`, `home-inbox*.test.ts`, `inbox-state.test.ts` — 227 pass, 0 fail; `inbox-summary.test.ts` fixture updated with `humanQuestion: null`
- [x] `bun run typecheck` (orch-monitor): clean
- [x] All verify gates pass (regression risk: 1/10)

## Changelog Entry

`feat(dev)`: Escalations now carry a structured explanation — what failed, what was tried, and the concrete decision the human must make — surfaced as the Inbox sub-label for stuck tickets.

## Related Issues/PRs

- Fixes https://linear.app/adva/issue/CTL-1065
