### PR TITLE
fix(dev): CTL-1075 — fix plan/implement dispatch gates silently fail open on macOS bash 3.2

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -370,6 +370,41 @@ STATUS_D=$(jq -r '.status' "${TEST_DIR}/glob-d.out")
 assert_eq "2" "$RC_D" "Form D: different-ticket plan file does NOT satisfy CTL-100 gate"
 assert_eq "refused" "$STATUS_D" "Form D: stdout JSON status = refused"
 
+# ─── Test 5c: gate spec is non-empty under macOS system bash (bash 3.2) — CTL-1075
+echo ""
+echo "Test 5c: plan/implement gate specs survive macOS system bash (bash 3.2)"
+fresh_env t5c
+mkdir -p "${TEST_DIR}/proj/thoughts/shared/research"
+mkdir -p "${TEST_DIR}/proj/thoughts/shared/plans"
+
+# plan with NO research doc present → must refuse with a non-empty glob spec.
+(cd "${TEST_DIR}/proj" &&
+	/bin/bash "$DISPATCH" --phase plan --ticket CTL-100 \
+		--orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run \
+		>"${TEST_DIR}/sysbash-plan.out" 2>"${TEST_DIR}/sysbash-plan.err")
+RC_PLAN=$?
+STATUS_PLAN=$(jq -r '.status'   "${TEST_DIR}/sysbash-plan.out" 2>/dev/null || echo "")
+ART_PLAN=$(jq -r '.artifact'    "${TEST_DIR}/sysbash-plan.out" 2>/dev/null || echo "")
+assert_eq "2" "$RC_PLAN" "5c plan: /bin/bash refuses when research doc absent (exit 2)"
+assert_eq "refused" "$STATUS_PLAN" "5c plan: status=refused under /bin/bash"
+assert_contains "$ART_PLAN" "thoughts/shared/research/" "5c plan: artifact spec is the non-empty research glob"
+assert_not_contains "$(cat "${TEST_DIR}/sysbash-plan.err")" "bad substitution" "5c plan: no bad-substitution under /bin/bash"
+
+rm -f "${ORCH_DIR}/workers/CTL-100/phase-plan.json"
+
+# implement with NO plan doc present → must refuse with a non-empty glob spec.
+(cd "${TEST_DIR}/proj" &&
+	/bin/bash "$DISPATCH" --phase implement --ticket CTL-100 \
+		--orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run \
+		>"${TEST_DIR}/sysbash-impl.out" 2>"${TEST_DIR}/sysbash-impl.err")
+RC_IMPL=$?
+STATUS_IMPL=$(jq -r '.status'  "${TEST_DIR}/sysbash-impl.out" 2>/dev/null || echo "")
+ART_IMPL=$(jq -r '.artifact'   "${TEST_DIR}/sysbash-impl.out" 2>/dev/null || echo "")
+assert_eq "2" "$RC_IMPL" "5c implement: /bin/bash refuses when plan doc absent (exit 2)"
+assert_eq "refused" "$STATUS_IMPL" "5c implement: status=refused under /bin/bash"
+assert_contains "$ART_IMPL" "thoughts/shared/plans/" "5c implement: artifact spec is the non-empty plan glob"
+assert_not_contains "$(cat "${TEST_DIR}/sysbash-impl.err")" "bad substitution" "5c implement: no bad-substitution under /bin/bash"
+
 # ─── Test 6: dispatcher resolves model from config (default + override paths)
 echo ""
 echo "Test 6: dispatcher resolves model from config (default and override)"

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -120,8 +120,8 @@ prior_artifact_for_phase() {
 	case "$1" in
 	triage) echo "" ;;
 	research) echo "signal:triage.json" ;;
-	plan) echo "glob:thoughts/shared/research/*-${TICKET,,}.md" ;;
-	implement) echo "glob:thoughts/shared/plans/*-${TICKET,,}.md" ;;
+	plan) echo "glob:thoughts/shared/research/*-${TICKET_LC}.md" ;;
+	implement) echo "glob:thoughts/shared/plans/*-${TICKET_LC}.md" ;;
 	verify) echo "signal:phase-implement.json" ;;
 	review) echo "signal:verify.json" ;;
 	pr) echo "signal:review.json" ;;
@@ -215,6 +215,9 @@ fi
 if [[ ! $TICKET =~ ^[A-Za-z][A-Za-z0-9_]*-[0-9]+$ ]]; then
 	die "invalid --ticket: $TICKET (expected e.g. CTL-100)"
 fi
+# CTL-1075: portable bash-3 lowercase (replaces bash-4 ${TICKET,,}, which is a
+# "bad substitution" under macOS /bin/bash 3.2 and silently empties the gate spec).
+TICKET_LC="$(printf '%s' "$TICKET" | tr '[:upper:]' '[:lower:]')"
 if [[ $PHASE == *.* ]]; then
 	die "invalid --phase: $PHASE (dots are reserved for event name parsing)"
 fi
@@ -432,7 +435,7 @@ if [[ -n $ARTIFACT_SPEC ]]; then
 		# shellcheck disable=SC2206  # word-splitting is required for glob expansion
 		MATCHES=($PATTERN)
 		if [[ ${#MATCHES[@]} -eq 0 ]]; then
-			WIDE="${PATTERN/%-${TICKET,,}.md/*${TICKET}*.md}"
+			WIDE="${PATTERN/%-${TICKET_LC}.md/*${TICKET}*.md}"
 			# shellcheck disable=SC2206
 			MATCHES=($WIDE)
 			if [[ ${#MATCHES[@]} -eq 0 ]]; then


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-12T03:40:00Z -->
<!-- Last updated: 2026-06-12T03:40:00Z -->
<!-- PR: #1877 -->
<!-- Previous commits: cf773a321c7a221dae965251f7bf585dc6e3a5cc -->

## Summary

Fixes the plan and implement dispatch gates silently failing open on macOS bash 3.2 (CTL-1075).

`phase-agent-dispatch` used bash-4-only `${TICKET,,}` lowercase expansion in two gate glob patterns. On macOS, `/bin/bash` is 3.2.57, where `${VAR,,}` is a "bad substitution" — the failed expansion empties the gate spec, which reads as "no prior artifact required." This caused plan to dispatch without a research doc and implement to dispatch without a plan doc, exactly the contract those gates exist to enforce.

**Fix:** compute `TICKET_LC` once at arg-parse via portable `tr '[:upper:]' '[:lower:]'`, then use it throughout.

## Changes Made

### Script changes (`plugins/dev/scripts/phase-agent-dispatch`)

- Added `TICKET_LC="$(printf '%s' "$TICKET" | tr '[:upper:]' '[:lower:]')"` computed once after ticket validation (portable bash 3.2 replacement for `${TICKET,,}`)
- Replaced 3 uses of `${TICKET,,}` with `${TICKET_LC}`:
  - `prior_artifact_for_phase` case `plan`: gate glob now uses `${TICKET_LC}`
  - `prior_artifact_for_phase` case `implement`: gate glob now uses `${TICKET_LC}`
  - Wide-scan fallback pattern substitution in artifact gate check

### Test additions (`plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh`)

Added Test 5c which explicitly invokes the dispatcher via `/bin/bash` (macOS system bash 3.2) to pin:
- `plan` phase refuses with `status=refused` and a non-empty `artifact` glob when the research doc is absent
- `implement` phase refuses with `status=refused` and a non-empty `artifact` glob when the plan doc is absent
- No "bad substitution" errors appear in stderr under `/bin/bash`

## How to Verify It

- [x] `audit-references` CI check passes ✅
- [x] `check-versions` CI check passes ✅
- [x] `docs-gate` CI check passes ✅
- [x] `validate` CI check passes ✅
- [ ] Run `bash plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh` locally — all tests pass including new Test 5c
- [ ] Observe that on a macOS host, dispatching plan without a research doc now correctly refuses instead of launching ungated

## Changelog Entry

**fix(dev):** Fix plan/implement dispatch gates silently failing open on macOS bash 3.2 — replace `${TICKET,,}` bashism with portable `tr`-based lowercase; add Test 5c that pins gate non-empty under `/bin/bash` 3.2.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1075
