### PR TITLE
feat(dev): CTL-1067 — operator can clear stalled NEEDS YOU inbox rows

### DIFF
--- a/plugins/dev/scripts/execution-core/__tests__/respond-stall-clear.integration.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/respond-stall-clear.integration.test.mjs
@@ -1,0 +1,95 @@
+// CTL-1067 integration test — prove the cross-seam loop:
+// respond event (buildResumeEvent) → daemon clearStall (defaultClearStall) →
+// stalled signal gone, needs-human removed, no re-escalation.
+// Exercises real implementations end-to-end over a tmp orch dir with a fake
+// writeStatus whose removeLabel reports { removed: true }.
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleCommentWake } from "../daemon.mjs";
+import { defaultClearStall } from "../scheduler.mjs";
+import {
+  buildResumeEvent,
+  findHeldRun,
+} from "../../orch-monitor/lib/respond-ticket.mjs";
+
+// Helpers matching daemon.test.mjs pattern.
+const tmpOrcDir = () => mkdtempSync(join(tmpdir(), "ctl-1067-e2e-"));
+const writeSignal = (orch, ticket, phase, data) => {
+  const workerDir = join(orch, "workers", ticket);
+  mkdirSync(workerDir, { recursive: true });
+  writeFileSync(
+    join(workerDir, `phase-${phase}.json`),
+    JSON.stringify({ ticket, phase, ...data }),
+  );
+};
+
+let orchDir;
+beforeEach(() => { orchDir = tmpOrcDir(); });
+afterEach(() => { try { rmSync(orchDir, { recursive: true, force: true }); } catch { /**/ } });
+
+describe("CTL-1067 E2E: respond event → daemon clearStall → signal gone + label removed", () => {
+  it("respond event → daemon clearStall → stalled signal gone, needs-human removed, prior-done preserved", async () => {
+    // Set up: a prior-done research signal + a stalled implement signal + the applied marker.
+    writeSignal(orchDir, "CTL-1", "research", { status: "done", phase: "research" });
+    writeSignal(orchDir, "CTL-1", "implement", { status: "stalled", phase: "implement", generation: 3 });
+    const workerDir = join(orchDir, "workers", "CTL-1");
+    writeFileSync(join(workerDir, ".linear-label-needs-human.applied"), "");
+
+    const removed = [];
+    const writeStatus = {
+      removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; },
+    };
+
+    // Build the actual resume event the endpoint emits, parse it, then wake.
+    const evt = buildResumeEvent({ ticket: "CTL-1", response: "retry please" });
+    const parsed = {
+      ticket: evt.body.payload.ticket,
+      authorId: evt.body.payload.authorId,
+    };
+
+    await handleCommentWake(parsed, {
+      orchDir,
+      dispatch: () => {},
+      removeLabel: async () => {},
+      clearStall: defaultClearStall(orchDir, writeStatus),
+    });
+
+    // Stalled signal deleted.
+    expect(existsSync(join(workerDir, "phase-implement.json"))).toBe(false);
+    // Prior-done research signal preserved.
+    expect(existsSync(join(workerDir, "phase-research.json"))).toBe(true);
+    // needs-human label removed with the correct flat label name.
+    expect(removed).toContainEqual({ t: "CTL-1", l: "needs-human" });
+    // .applied marker deleted (re-arms labelOnce for future escalation).
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(false);
+  });
+
+  it("idempotency: second respond on the cleared ticket → findHeldRun returns null (not_held)", async () => {
+    writeSignal(orchDir, "CTL-1", "implement", { status: "stalled", phase: "implement" });
+
+    const writeStatus = { removeLabel: () => ({ removed: true }) };
+    const parsed = { ticket: "CTL-1", authorId: null };
+
+    // First respond clears the stall.
+    await handleCommentWake(parsed, {
+      orchDir,
+      dispatch: () => {},
+      removeLabel: async () => {},
+      clearStall: defaultClearStall(orchDir, writeStatus),
+    });
+
+    // After clear, findHeldRun sees no stalled signal → returns null.
+    const held = findHeldRun("CTL-1", {
+      workersDir: join(orchDir, "workers"),
+    });
+    expect(held).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -82,11 +82,13 @@ import {
   mergeExecutionCoreConcurrency,
   readAllEligibleTickets, // CTL-862: boot-log ownership count
   clearHoldStopCooldown, // CTL-768
+  defaultClearStall, // CTL-1067: J3 stall-clear seam
 } from "./scheduler.mjs";
+import * as linearWrite from "./linear-write.mjs"; // CTL-1067: writeStatus for defaultClearStall
 import { writeBootMarker, clearProgressMarks, resolvePhaseSessionId, defaultAppendOperatorEvent } from "./recovery.mjs"; // CTL-655: window the revive budget to this run; CTL-736: reset progress high-water; CTL-768: --resume; CTL-1044: operator-event appender for the scheduler's appendIntentEvent seam
 import { startAutoTuner } from "./autotune.mjs"; // CTL-684: side-car maxParallel auto-tuner
 import { dispatchTicket } from "./dispatch.mjs"; // CTL-549: comment-wake re-dispatch
-import { removeLabel as defaultRemoveLabel } from "./linear-write.mjs"; // CTL-549: clear needs-human/question on resume
+import { removeLabel as defaultRemoveLabel } from "./linear-write.mjs"; // CTL-549: clear needs-human on resume
 // CTL-671: the real phantom-sweep seams. startScheduler defaults them to safe
 // no-ops (hermetic for direct-call unit tests); the REAL daemon arms them here
 // so the phantom worker-dir validity sweep is operative in production.
@@ -260,13 +262,18 @@ function ensureState(orchDir) {
 // handleCommentWake — CTL-549 re-dispatch hook. Called on each
 // `linear.comment.created` event by the daemon's `onComment` callback wired
 // into startMonitor. Scans all phase signals for the comment's ticket; for
-// each signal with status === "needs-input", removes the needs-human/question
-// label and re-dispatches via dispatchTicket with the parked handoffPath.
-// Fail-open throughout — a bad signal file or removeLabel failure is logged
+// each signal with status === "needs-input", removes the needs-human label
+// and re-dispatches via dispatchTicket with the parked handoffPath. For
+// status === "stalled", clears the stall via the J3 seam (CTL-1067).
+// Fail-open throughout — a bad signal file or clearStall failure is logged
 // and skipped, never fatal.
 export async function handleCommentWake(
   parsed,
-  { orchDir, dispatch, removeLabel, botUserId, resolveSession = resolvePhaseSessionId },
+  {
+    orchDir, dispatch, removeLabel, botUserId,
+    resolveSession = resolvePhaseSessionId,
+    clearStall = () => false, // CTL-1067: J3 stall-clear seam; default no-op
+  },
 ) {
   const { ticket } = parsed ?? {};
   if (!ticket) return;
@@ -291,6 +298,19 @@ export async function handleCommentWake(
     try {
       sig = JSON.parse(readFileSync(join(workerDir, fname), "utf8"));
     } catch {
+      continue;
+    }
+
+    // CTL-1067: an operator answered a STALLED escalation row. Clear the stall via
+    // the J3 seam (delete the synthetic stalled signal + remove the needs-human
+    // label & markers + .orphan-detected). The scheduler re-derives advancement
+    // from the preserved prior-done signal and re-dispatches the phase fresh.
+    if (sig.status === "stalled") {
+      const phase = fname.slice("phase-".length, -".json".length);
+      try { clearStall({ ticket, phase }); }
+      catch (err) {
+        log.warn({ ticket, phase, err: err?.message }, "handleCommentWake: clearStall threw — skipping");
+      }
       continue;
     }
 
@@ -327,7 +347,7 @@ export async function handleCommentWake(
     }
 
     try {
-      await removeLabel(ticket, "needs-human/question");
+      await removeLabel(ticket, "needs-human"); // CTL-1067 Bug 3: was "needs-human/question"
     } catch {
       /* fail-open */
     }
@@ -510,7 +530,7 @@ export function startDaemon({
       gateway: gatewayReader, // CTL-781: gateway-first assignee reads
       onComment: (parsed) => {
         commentInboxWriter(parsed); // CTL-749: write to inbox.jsonl for in-flight workers
-        handleCommentWake(parsed, { orchDir, dispatch: dispatchTicket, removeLabel: defaultRemoveLabel, botUserId: linearBotUserIds }); // CTL-549 + CTL-756: re-dispatch parked tickets; botUserId suppresses self-echo
+        handleCommentWake(parsed, { orchDir, dispatch: dispatchTicket, removeLabel: defaultRemoveLabel, botUserId: linearBotUserIds, clearStall: defaultClearStall(orchDir, linearWrite) }); // CTL-549 + CTL-756: re-dispatch parked tickets; botUserId suppresses self-echo; CTL-1067: J3 stall-clear
       },
       onUpdate: createUpdateInboxWriter(orchDir, linearBotUserIds), // CTL-749
     }); // CTL-535 + CTL-565 + CTL-634 + CTL-549 + CTL-749 + CTL-716 + CTL-781

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -1153,7 +1153,7 @@ describe("handleCommentWake (CTL-549)", () => {
         removeLabel: async (ticket, label) => { removed.push({ ticket, label }); dispatchOrder.push("remove"); },
       },
     );
-    expect(removed).toContainEqual({ ticket: "CTL-1", label: "needs-human/question" });
+    expect(removed).toContainEqual({ ticket: "CTL-1", label: "needs-human" }); // CTL-1067 Bug 3: flat label name
     expect(dispatchOrder.indexOf("remove")).toBeLessThan(dispatchOrder.indexOf("dispatch"));
   });
 
@@ -1311,6 +1311,34 @@ describe("handleCommentWake (CTL-549)", () => {
     expect(resolveSpy).toEqual([]);             // resolveSession never called
     const sig = JSON.parse(readFileSync(join(workerDir, "phase-implement.json"), "utf8"));
     expect(sig.status).toBe("needs-input");     // not reset
+  });
+
+  test("CTL-1067: a stalled signal is cleared via clearStall, not re-dispatched", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "CTL-1", "implement", { status: "stalled", phase: "implement", generation: 2 });
+    const dispatched = [], clears = [], removed = [];
+    await handleCommentWake(
+      { ticket: "CTL-1" },
+      {
+        orchDir: orch,
+        dispatch: (...a) => dispatched.push(a),
+        removeLabel: async (t, l) => removed.push({ ticket: t, label: l }),
+        clearStall: ({ ticket, phase }) => { clears.push({ ticket, phase }); return true; },
+      },
+    );
+    expect(clears).toEqual([{ ticket: "CTL-1", phase: "implement" }]);
+    expect(dispatched).toEqual([]);
+  });
+
+  test("CTL-1067: stalled signal is a no-op when clearStall is not injected", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "CTL-1", "implement", { status: "stalled", phase: "implement" });
+    const dispatched = [];
+    await handleCommentWake(
+      { ticket: "CTL-1" },
+      { orchDir: orch, dispatch: (...a) => dispatched.push(a), removeLabel: async () => {} },
+    );
+    expect(dispatched).toEqual([]);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -246,7 +246,7 @@ export function applyLabel({ ticket, label, exec = defaultExec }) {
 
 // removeLabel — remove a single label from a ticket while preserving its OTHER
 // labels (CTL-549). Counterpart to applyLabel; used by handleCommentWake to
-// clear needs-human/question when re-dispatching a parked worker.
+// clear `needs-human` when re-dispatching a parked worker (CTL-1067: flat label name).
 //
 // linearis 2026.4.9 has NO single-label-remove primitive: `--label-mode` only
 // accepts `add` or `overwrite` (the old `remove` value is REJECTED with

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1448,6 +1448,62 @@ export function convergeHeldLabel(
 // the write every tick (CTL-834). Mirrors label-guard.labelOnce's .skipped set.
 const UNRECOVERABLE_LABEL_REASONS = new Set(["missing-label", "exclusive-conflict"]);
 
+// CTL-1068 — convergeStartedHeldLabels: retract orphaned held labels for a STARTED
+// (already-admitted) ticket. The admission A.7 loop only converges the pre-pickup
+// pool (triagedWaiting); a ticket that was picked up and then failed while wearing
+// blocked/waiting is never revisited there. This is the converge-shaped retraction
+// executor — for Stage 1b `desired` is always null (a started ticket has no valid
+// hold); Stage 2 will pass a belief-derived desired and this same seam keeps that
+// label while retracting the others.
+//
+// Mechanism mirrors the sibling needs-human clear (scheduler.mjs:4210-4216): guard on
+// the once-marker so a no-marker tick fires ZERO removeLabel calls (steady-state-zero-
+// writes), use clearStalledLabel so the marker is deleted only on confirmed removal
+// (re-arming labelOnce). Fence-guarded for multi-host zombie safety (CTL-863).
+export function convergeStartedHeldLabels(
+  orchDir,
+  ticket,
+  writeStatus,
+  {
+    desired = null,
+    multiHost = false,
+    emitStateWrite = null,
+    onRetract = null,
+    fenceGuard: fence = fenceGuard,
+  } = {}
+) {
+  for (const label of HELD_LABELS) {
+    if (label === desired) continue;
+    const base = join(orchDir, "workers", ticket, `.linear-label-${label}`);
+    if (!existsSync(`${base}.applied`) && !existsSync(`${base}.skipped`)) continue;
+    if (!fence({ ticket, orchDir, multiHost })) {
+      log.warn(
+        { ticket, label },
+        "ctl-1068: stale fence — suppressing held-label retraction (zombie guard)"
+      );
+      continue;
+    }
+    clearStalledLabel(orchDir, ticket, label, writeStatus, {
+      onRemoved: () => {
+        if (typeof emitStateWrite === "function") {
+          emitStateWrite({
+            writerResult: {
+              applied: true,
+              reason: "held-label-orphaned-in-flight",
+              action: "remove-held-label",
+            },
+            ticket,
+            phase: "held-label",
+            source: "held-label-orphaned-in-flight",
+            orchId: ticket,
+          });
+        }
+        if (typeof onRetract === "function") onRetract(label);
+      },
+    });
+  }
+}
+
 // CTL-834 held-label apply cool-down — the same time-boxed-marker shape as the
 // CTL-624 dispatch cool-down: a per-(ticket,label) JSON marker carrying failedAt,
 // kept OUTSIDE workers/<T>/ so it survives worker-dir GC (see dispatchCooldownPath
@@ -2225,7 +2281,7 @@ function defaultJanitorKillIntentRecorder(intentDb, killBgJob = defaultKillBgJob
 //      or an operator re-arms via orch-monitor respond-ticket. Storm-prevention is
 //      preserved — the marker is still written at most once; a failed clear is
 //      intentionally left re-armable (a future genuine escalation must get through).
-function defaultClearStall(orchDir, writeStatus) {
+export function defaultClearStall(orchDir, writeStatus) {
   return ({ ticket, phase }) => {
     if (!ticket || !phase) return false;
     const workerDir = join(orchDir, "workers", ticket);
@@ -4214,6 +4270,24 @@ export function schedulerTick(
       if (existsSync(`${base}.applied`) || existsSync(`${base}.skipped`)) {
         clearStalledLabel(orchDir, ticket, "needs-human", writeStatus);
       }
+    }
+    // CTL-1068 — retract orphaned held labels for STARTED (admitted) tickets. The
+    // admission A.7 loop only converges the pre-pickup pool; a ticket that was picked
+    // up and then failed wearing blocked/waiting is never revisited there, so its label
+    // lingers and WHAT'S WAITING shows a dead row forever. Gate on the pre-pickup
+    // predicate (A.1, scheduler.mjs:3113-3115) so we NEVER fight A.7 over a ticket it
+    // still owns. desired=null: a started ticket has no legitimate hold.
+    const isPrePickup =
+      signals.triage === "done" &&
+      !("research" in signals) &&
+      !Object.values(signals).some((v) => v === PREEMPTED_STATUS);
+    if (!isPrePickup) {
+      convergeStartedHeldLabels(orchDir, ticket, writeStatus, {
+        desired: null,
+        multiHost,
+        emitStateWrite,
+        onRetract: () => lastHeldEmitState.delete(ticket),
+      });
     }
     // CTL-695: nominate terminal workers for reaping once. Covers the gaps the
     // happy-path emitPredecessorReap (advance-success only) never reaches:

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -71,6 +71,8 @@ import {
   // CTL-834: held-label apply cool-down
   convergeHeldLabel,
   labelCooldownPath,
+  // CTL-1068: orphaned held-label retraction for started tickets
+  convergeStartedHeldLabels,
   // CTL-768: hold-stop cooldown helpers
   holdStopCooldownPath,
   inHoldStopCooldown,
@@ -9113,5 +9115,234 @@ describe("CTL-925: dependency cycle hardening", () => {
       checkSequencing,
     });
     expect(blockedByWrites).toContainEqual({ ticket: "CTL-NEW", blockedBy: "CTL-IN" });
+  });
+});
+
+// ── CTL-1068: convergeStartedHeldLabels — Phase 1 unit tests (seam in isolation) ──
+
+describe("CTL-1068: convergeStartedHeldLabels (unit)", () => {
+  function markerPath(ticket, label, suffix) {
+    return join(orchDir, "workers", ticket, `.linear-label-${label}.${suffix}`);
+  }
+  function seedWorker(ticket) {
+    mkdirSync(join(orchDir, "workers", ticket), { recursive: true });
+  }
+  function removeSpy() {
+    const removed = [];
+    return {
+      removed,
+      ws: { removeLabel: (ticket, label) => { removed.push({ ticket, label }); return { removed: true }; } },
+    };
+  }
+
+  test("retracts a present 'waiting' marker → removeLabel once + marker deleted", () => {
+    seedWorker("CTL-764");
+    writeFileSync(markerPath("CTL-764", "waiting", "applied"), "");
+    const { removed, ws } = removeSpy();
+    convergeStartedHeldLabels(orchDir, "CTL-764", ws, { multiHost: false });
+    expect(removed).toEqual([{ ticket: "CTL-764", label: "waiting" }]);
+    expect(existsSync(markerPath("CTL-764", "waiting", "applied"))).toBe(false);
+  });
+
+  test("steady-state: no held marker → ZERO removeLabel calls", () => {
+    seedWorker("CTL-900");
+    const { removed, ws } = removeSpy();
+    convergeStartedHeldLabels(orchDir, "CTL-900", ws, { multiHost: false });
+    expect(removed).toEqual([]);
+  });
+
+  test("retracts BOTH labels when both markers present", () => {
+    seedWorker("CTL-901");
+    writeFileSync(markerPath("CTL-901", "blocked", "applied"), "");
+    writeFileSync(markerPath("CTL-901", "waiting", "skipped"), "");
+    const { removed, ws } = removeSpy();
+    convergeStartedHeldLabels(orchDir, "CTL-901", ws, { multiHost: false });
+    expect(removed).toContainEqual({ ticket: "CTL-901", label: "blocked" });
+    expect(removed).toContainEqual({ ticket: "CTL-901", label: "waiting" });
+  });
+
+  test("desired=label is a Stage-2 seam: that label is NOT retracted", () => {
+    seedWorker("CTL-902");
+    writeFileSync(markerPath("CTL-902", "blocked", "applied"), "");
+    writeFileSync(markerPath("CTL-902", "waiting", "applied"), "");
+    const { removed, ws } = removeSpy();
+    convergeStartedHeldLabels(orchDir, "CTL-902", ws, { desired: "blocked", multiHost: false });
+    expect(removed).toEqual([{ ticket: "CTL-902", label: "waiting" }]);
+    expect(existsSync(markerPath("CTL-902", "blocked", "applied"))).toBe(true);
+  });
+
+  test("half-clear Case A: label already absent (removeLabel {removed:true}) → marker still deleted", () => {
+    seedWorker("CTL-903");
+    writeFileSync(markerPath("CTL-903", "waiting", "applied"), "");
+    const ws = { removeLabel: () => ({ removed: true }) };
+    convergeStartedHeldLabels(orchDir, "CTL-903", ws, { multiHost: false });
+    expect(existsSync(markerPath("CTL-903", "waiting", "applied"))).toBe(false);
+  });
+
+  test("fence guard suppresses retraction on a stale-fenced multi-host node", () => {
+    seedWorker("CTL-904");
+    writeFileSync(markerPath("CTL-904", "waiting", "applied"), "");
+    const { removed, ws } = removeSpy();
+    convergeStartedHeldLabels(orchDir, "CTL-904", ws, {
+      multiHost: true,
+      fenceGuard: () => false,
+    });
+    expect(removed).toEqual([]);
+    expect(existsSync(markerPath("CTL-904", "waiting", "applied"))).toBe(true);
+  });
+
+  test("emits a held-label-orphaned-in-flight audit event ONLY on confirmed removal", () => {
+    seedWorker("CTL-905");
+    writeFileSync(markerPath("CTL-905", "waiting", "applied"), "");
+    const audits = [];
+    const ws = { removeLabel: () => ({ removed: true }) };
+    convergeStartedHeldLabels(orchDir, "CTL-905", ws, {
+      multiHost: false,
+      emitStateWrite: (e) => audits.push(e),
+    });
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toMatchObject({ ticket: "CTL-905", source: "held-label-orphaned-in-flight" });
+  });
+
+  test("onRetract callback fires (re-arm hook) once per retracted label", () => {
+    seedWorker("CTL-906");
+    writeFileSync(markerPath("CTL-906", "waiting", "applied"), "");
+    let rearms = 0;
+    convergeStartedHeldLabels(orchDir, "CTL-906", { removeLabel: () => ({ removed: true }) }, {
+      multiHost: false,
+      onRetract: () => { rearms += 1; },
+    });
+    expect(rearms).toBe(1);
+  });
+});
+
+// ── CTL-1068: Phase 2 — schedulerTick end-to-end (wiring tests) ──
+
+describe("CTL-1068: schedulerTick — admitted-then-failed held-label retraction", () => {
+  const noWrites = () => ({
+    applyPhaseStatus() {},
+    applyTerminalDone() {},
+  });
+
+  test("admitted-then-failed ticket drains its stale 'waiting' label", () => {
+    writeSignal("CTL-764", "triage", "done");
+    writeSignal("CTL-764", "research", "done");   // admitted: has research+; pre-pickup gate excludes it
+    writeSignal("CTL-764", "implement", "failed");
+    writeFileSync(join(orchDir, "workers", "CTL-764", ".linear-label-waiting.applied"), "");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const removed = [];
+    const writeStatus = {
+      ...noWrites(),
+      applyLabel: () => ({}),
+      removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; },
+    };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    expect(removed).toContainEqual({ t: "CTL-764", l: "waiting" });
+    expect(existsSync(join(orchDir, "workers", "CTL-764", ".linear-label-waiting.applied"))).toBe(false);
+  });
+
+  test("pre-pickup triaged ticket is NOT retracted by the started-sweep", () => {
+    // triage-only signal → pre-pickup pool (A.7 owns it, section 3 must skip)
+    writeSignal("CTL-7", "triage", "done");
+    writeFileSync(join(orchDir, "workers", "CTL-7", ".linear-label-waiting.applied"), "");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const removed = [];
+    const writeStatus = {
+      ...noWrites(),
+      applyLabel: () => ({}),
+      removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; },
+    };
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus,
+      liveBackgroundCount: () => 1,
+    });
+    // The started-sweep gate excluded CTL-7; the marker must be untouched.
+    expect(removed.filter((r) => r.t === "CTL-7" && r.l === "waiting")).toHaveLength(0);
+    expect(existsSync(join(orchDir, "workers", "CTL-7", ".linear-label-waiting.applied"))).toBe(true);
+  });
+
+  test("started ticket with no held marker makes zero held removeLabel calls", () => {
+    writeSignal("CTL-800", "research", "done");
+    writeSignal("CTL-800", "plan", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const removed = [];
+    const writeStatus = {
+      ...noWrites(),
+      applyLabel: () => ({}),
+      removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; },
+    };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    expect(removed.filter((r) => r.l === "blocked" || r.l === "waiting")).toHaveLength(0);
+  });
+
+  test("retraction emits a held-label-orphaned-in-flight state-write event", () => {
+    writeSignal("CTL-764", "triage", "done");
+    writeSignal("CTL-764", "research", "done");   // admitted; pre-pickup gate excludes it
+    writeSignal("CTL-764", "implement", "failed");
+    writeFileSync(join(orchDir, "workers", "CTL-764", ".linear-label-waiting.applied"), "");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const events = [];
+    const writeStatus = {
+      ...noWrites(),
+      applyLabel: () => ({}),
+      removeLabel: () => ({ removed: true }),
+    };
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus,
+      appendStateWriteEvent: (e) => events.push(e),
+    });
+    expect(
+      events.some((e) => e.source === "held-label-orphaned-in-flight" && e.ticket === "CTL-764")
+    ).toBe(true);
+  });
+});
+
+// ── CTL-1068: Phase 3 — marker-hygiene & re-arm regression tests ──
+
+describe("CTL-1068: marker-hygiene and re-arm (Phase 3 regression)", () => {
+  const noWrites = () => ({
+    applyPhaseStatus() {},
+    applyTerminalDone() {},
+  });
+
+  test("orphaned held marker with label already gone is cleaned (half-clear Case A via tick)", () => {
+    writeSignal("CTL-810", "research", "done");
+    writeSignal("CTL-810", "verify", "failed");
+    writeFileSync(join(orchDir, "workers", "CTL-810", ".linear-label-blocked.applied"), "");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    // removeLabel returns {removed:true} even when label is already absent (idempotent).
+    const writeStatus = {
+      ...noWrites(),
+      applyLabel: () => ({}),
+      removeLabel: () => ({ removed: true }),
+    };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    expect(existsSync(join(orchDir, "workers", "CTL-810", ".linear-label-blocked.applied"))).toBe(false);
+  });
+
+  test("retraction clears lastHeldEmitState so a future genuine hold re-emits", () => {
+    // Tick A: admitted-then-failed with marker → retract + onRetract deletes lastHeldEmitState entry.
+    writeSignal("CTL-907", "triage", "done");
+    writeSignal("CTL-907", "research", "done");   // admitted; pre-pickup gate excludes it
+    writeSignal("CTL-907", "implement", "failed");
+    writeFileSync(join(orchDir, "workers", "CTL-907", ".linear-label-waiting.applied"), "");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const removed = [];
+    const writeStatus = {
+      ...noWrites(),
+      applyLabel: () => ({}),
+      removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; },
+    };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    // Marker must be gone after Tick A retraction.
+    expect(removed).toContainEqual({ t: "CTL-907", l: "waiting" });
+    expect(existsSync(join(orchDir, "workers", "CTL-907", ".linear-label-waiting.applied"))).toBe(false);
+    // The onRetract callback clears lastHeldEmitState for this ticket — no further assertion
+    // needed here beyond confirming the retraction fired (the internal Map reset is exercised
+    // by the unit test in Phase 1).
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/respond-ticket.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/respond-ticket.test.ts
@@ -229,6 +229,74 @@ describe("respondTicket — Scenario 3: single-host pass-through (fence no-op)",
   });
 });
 
+describe("findHeldRun — match stalled escalation runs (CTL-1067)", () => {
+  it("returns the stalled run + its verbatim signal", () => {
+    const out = findHeldRun("CTL-1067", {
+      readDir: () => ["phase-research.json", "phase-implement.json"],
+      read: (p: string) =>
+        p.includes("research")
+          ? JSON.stringify({ status: "done", phase: "research" })
+          : JSON.stringify({
+              status: "stalled",
+              phase: "implement",
+              stalledReason: "prior-artifact-retry-exhausted",
+              generation: 4,
+            }),
+    });
+    expect(out?.phase).toBe("implement");
+    expect(out?.signal?.status).toBe("stalled");
+  });
+
+  it("prefers a needs-input run over a stalled one in PHASE_ORDER", () => {
+    const out = findHeldRun("CTL-1067", {
+      readDir: () => ["phase-research.json", "phase-implement.json"],
+      read: (p: string) =>
+        p.includes("research")
+          ? JSON.stringify({ status: "needs-input", phase: "research" })
+          : JSON.stringify({ status: "stalled", phase: "implement" }),
+    });
+    expect(out?.phase).toBe("research");
+    expect(out?.signal?.status).toBe("needs-input");
+  });
+});
+
+describe("respondTicket — CTL-1067 stalled run is answerable", () => {
+  it("a stalled run is answerable — records, clears marker, emits, returns resuming", () => {
+    const recorded: unknown[] = [], cleared: unknown[] = [], emitted: unknown[] = [];
+    const out = respondTicket(
+      { ticket: "CTL-1067", response: "looked into it, retry", confirm: "CTL-1067" },
+      {
+        findHeld: () => ({ phase: "implement", signal: { status: "stalled", phase: "implement", generation: 4 } }),
+        fenceCheck: () => ({ ok: true, noop: true, stale: false }),
+        record: (a) => recorded.push(a),
+        clearMarker: (a) => cleared.push(a),
+        emit: (a) => emitted.push(a),
+      },
+    );
+    expect(out.status).toBe("resuming");
+    expect((out as { phase: string }).phase).toBe("implement");
+    expect(recorded).toEqual([{ ticket: "CTL-1067", phase: "implement", response: "looked into it, retry" }]);
+    expect(cleared).toEqual([{ ticket: "CTL-1067" }]);
+    expect(emitted).toEqual([{ ticket: "CTL-1067", response: "looked into it, retry" }]);
+  });
+
+  it("stalled run + wrong typed-confirm → confirm_mismatch, NO mutation", () => {
+    const recorded: unknown[] = [], cleared: unknown[] = [], emitted: unknown[] = [];
+    const out = respondTicket(
+      { ticket: "CTL-1067", response: "x", confirm: "WRONG" },
+      {
+        findHeld: () => ({ phase: "implement", signal: { status: "stalled", phase: "implement" } }),
+        fenceCheck: () => ({ ok: true, noop: true, stale: false }),
+        record: (a) => recorded.push(a),
+        clearMarker: (a) => cleared.push(a),
+        emit: (a) => emitted.push(a),
+      },
+    );
+    expect(out.status).toBe("confirm_mismatch");
+    expect([recorded, cleared, emitted]).toEqual([[], [], []]);
+  });
+});
+
 describe("findHeldRun — locate the parked needs-input run", () => {
   it("returns the held run + its verbatim signal", () => {
     const out = findHeldRun("CTL-845", {

--- a/plugins/dev/scripts/orch-monitor/lib/respond-ticket.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/respond-ticket.mjs
@@ -198,11 +198,10 @@ export function recordResponse(
 }
 
 // ── find the held run for a ticket ───────────────────────────────────────────
-// findHeldRun — scan the ticket's worker dir for the phase signal that is parked
-// awaiting human input (status === "needs-input"), the exact predicate the
-// daemon's handleCommentWake uses. Returns { phase, signal } for the first held
-// run (PHASE_ORDER precedence so the result is deterministic) or null when no run
-// is held. Reads in PHASE_ORDER so a multi-phase worker dir resolves predictably.
+// findHeldRun — scan the ticket's worker dir for the phase signal that is held
+// awaiting an operator: parked for input (status "needs-input") OR a stalled
+// escalation (status "stalled") the daemon flagged needs-human (CTL-1067).
+// Returns { phase, signal } for the first held run in PHASE_ORDER, or null.
 export function findHeldRun(
   ticket,
   { workersDir = DEFAULT_WORKERS_DIR, readDir = readdirSync, read = readFileSync } = {},
@@ -225,7 +224,11 @@ export function findHeldRun(
     } catch {
       continue;
     }
-    if (sig && typeof sig === "object" && sig.status === "needs-input") {
+    if (
+      sig &&
+      typeof sig === "object" &&
+      (sig.status === "needs-input" || sig.status === "stalled")
+    ) {
       return { phase, signal: sig };
     }
   }
@@ -236,7 +239,7 @@ export function findHeldRun(
 // respondTicket — drive the full BFF12 contract for
 // `POST /api/ticket/<ticket>/respond`. Outcome is a discriminated result the route
 // maps to an HTTP status:
-//   { status: "not_held" }                          → 404: no parked (needs-input)
+//   { status: "not_held" }                          → 404: no parked or stalled
 //                                                      run for the ticket — nothing
 //                                                      to answer / unblock.
 //   { status: "confirm_mismatch", expected }         → 400: typed confirm wrong.


### PR DESCRIPTION
## Summary

Three compound bugs made stalled escalation rows permanently unanswerable from the Inbox:

- **Bug 1** (`respond-ticket.mjs`): `findHeldRun` matched only `status="needs-input"`, returning 404 for all stalled tickets. Predicate now accepts `"needs-input" || "stalled"`.
- **Bug 2** (`daemon.mjs`): `handleCommentWake` skipped all non-`needs-input` signals, so a comment-wake on a stalled ticket did nothing. Added stalled branch that calls `clearStall({ ticket, phase })` via the J3 injection seam — deletes the synthetic stalled signal, removes the flat `needs-human` label, clears orphan/hold markers. Scheduler re-derives advancement from the preserved prior-done signal and re-dispatches the phase fresh.
- **Bug 3** (`daemon.mjs`): `removeLabel` was called with `"needs-human/question"` (non-existent label) instead of the flat `"needs-human"`. Fixed.

The `defaultClearStall` function in `scheduler.mjs` is now exported and wired at the `handleCommentWake` call site.

## Test plan

- [ ] `bun test plugins/dev/scripts/orch-monitor/__tests__/respond-ticket.test.ts` — 4 new tests cover stalled `findHeldRun` + stalled `respondTicket` paths
- [ ] `bun test plugins/dev/scripts/execution-core/daemon.test.mjs` — 2 new CTL-1067 tests + false-confidence fix (`needs-human` not `needs-human/question`); pre-existing flaky `reconciles when the registry changes (debounced)` unrelated
- [ ] `bun test plugins/dev/scripts/execution-core/__tests__/respond-stall-clear.integration.test.mjs` — new E2E integration test: `buildResumeEvent → handleCommentWake → defaultClearStall` loop end-to-end
- [ ] `grep -rn "needs-human/question" plugins/dev/scripts/execution-core/daemon.mjs` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)