### PR TITLE
feat(dev): CTL-1064 — Auto-Unstuck Deep-Dive Sweep (classify-then-act, Pass 0u)

### DIFF
--- a/plugins/dev/scripts/execution-core/beliefs/collector.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/collector.mjs
@@ -660,9 +660,22 @@ export function collectTickFacts({
           return m;
         })();
 
+        // signalStatusBySubject: "ticket/phase" → status string, for the
+        // unstuck-sweep postcondition (CTL-1064). Built from the SAME signals
+        // already in scope — zero extra I/O. Key: only stalled/failed entries
+        // matter; everything else returns null → intent retries next tick.
+        const signalStatusBySubject = (() => {
+          const m = new Map();
+          for (const s of signals) {
+            if (!s?.ticket || s.phase == null) continue;
+            m.set(`${s.ticket}/${s.phase}`, s.status ?? null);
+          }
+          return m;
+        })();
+
         const maxAttempts = getMaxAttempts(db);
         const intentsEnforce = (env.CATALYST_INTENTS_ENFORCE ?? "0") === "1";
-        intentResult = reconcileIntents(db, tickId, { agentsBySubject, linearStateByTicket }, {
+        intentResult = reconcileIntents(db, tickId, { agentsBySubject, linearStateByTicket, signalStatusBySubject }, {
           maxAttempts,
           enforce: intentsEnforce,
           appendEvent: typeof appendIntentEvent === "function" ? appendIntentEvent : null,

--- a/plugins/dev/scripts/execution-core/beliefs/intent.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/intent.mjs
@@ -169,6 +169,13 @@ function resolvePostcondition(postcondition, worldSnapshot) {
         // Operator-acknowledged out-of-band; treat as satisfied-after-N to
         // avoid runaway paging. Caller drives max_attempts for this kind.
         return false; // never auto-satisfied — R11 will mark ineffective
+      case "unstuck-sweep": {
+        // CTL-1064: satisfied when the signal for this subject is no longer
+        // stalled. Absent map entry → retry (unreadable → never auto-satisfied).
+        const signalStatus = worldSnapshot.signalStatusBySubject?.get(pc.subject);
+        if (signalStatus == null) return false; // unreadable → retry
+        return signalStatus !== "stalled" && signalStatus !== "failed";
+      }
       default:
         return false;
     }

--- a/plugins/dev/scripts/execution-core/beliefs/intent.test.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/intent.test.mjs
@@ -666,3 +666,89 @@ describe("unreadable world facts", () => {
     expect(row.outcome).toBeNull();
   });
 });
+
+// ── CTL-1064: unstuck-sweep postcondition ────────────────────────────────────
+// Uses the outer `db` + `beforeEach`/`afterEach` already wired at the top of
+// this file — no nested setup needed. Each test inserts its own intent; the
+// outer beforeEach provides a fresh db + tick_id=1 for each test.
+describe("unstuck-sweep intent postcondition (CTL-1064)", () => {
+  test("signalStatus not 'stalled' or 'failed' → satisfied", () => {
+    const id = recordIntent(db, {
+      tickId: 1,
+      kind: "unstuck-sweep",
+      subject: "CTL-X/implement",
+      postcondition: { kind: "unstuck-sweep", subject: "CTL-X/implement" },
+    });
+    const signalStatusBySubject = new Map([["CTL-X/implement", "running"]]);
+    const result = reconcileIntents(db, 1, { signalStatusBySubject }, { maxAttempts: 3 });
+    expect(result.satisfied).toBe(1);
+    const row = db.query("SELECT outcome FROM intent WHERE intent_id = ?").get(id);
+    expect(row.outcome).toBe("satisfied");
+  });
+
+  test("signalStatus 'stalled' → not satisfied, retried", () => {
+    const id = recordIntent(db, {
+      tickId: 1,
+      kind: "unstuck-sweep",
+      subject: "CTL-X/implement",
+      postcondition: { kind: "unstuck-sweep", subject: "CTL-X/implement" },
+    });
+    const signalStatusBySubject = new Map([["CTL-X/implement", "stalled"]]);
+    const result = reconcileIntents(db, 1, { signalStatusBySubject }, { maxAttempts: 3 });
+    expect(result.satisfied).toBe(0);
+    expect(result.retried).toBe(1);
+    const row = db.query("SELECT outcome FROM intent WHERE intent_id = ?").get(id);
+    expect(row.outcome).toBeNull();
+  });
+
+  test("signalStatus 'failed' → not satisfied, retried", () => {
+    const id = recordIntent(db, {
+      tickId: 1,
+      kind: "unstuck-sweep",
+      subject: "CTL-X/implement",
+      postcondition: { kind: "unstuck-sweep", subject: "CTL-X/implement" },
+    });
+    const signalStatusBySubject = new Map([["CTL-X/implement", "failed"]]);
+    const result = reconcileIntents(db, 1, { signalStatusBySubject }, { maxAttempts: 3 });
+    expect(result.satisfied).toBe(0);
+    expect(result.retried).toBe(1);
+  });
+
+  test("subject absent from signalStatusBySubject → unreadable, intent stays open (retry)", () => {
+    const id = recordIntent(db, {
+      tickId: 1,
+      kind: "unstuck-sweep",
+      subject: "CTL-X/implement",
+      postcondition: { kind: "unstuck-sweep", subject: "CTL-X/implement" },
+    });
+    // subject absent from map → .get() returns undefined → null → retry
+    const result = reconcileIntents(db, 1, { signalStatusBySubject: new Map() }, { maxAttempts: 3 });
+    expect(result.satisfied).toBe(0);
+    expect(result.retried).toBe(1);
+  });
+
+  test("signalStatusBySubject absent from worldSnapshot → intent stays open (retry)", () => {
+    const id = recordIntent(db, {
+      tickId: 1,
+      kind: "unstuck-sweep",
+      subject: "CTL-X/implement",
+      postcondition: { kind: "unstuck-sweep", subject: "CTL-X/implement" },
+    });
+    // No signalStatusBySubject key at all in worldSnapshot.
+    const result = reconcileIntents(db, 1, {}, { maxAttempts: 3 });
+    expect(result.satisfied).toBe(0);
+    expect(result.retried).toBe(1);
+  });
+
+  test("status 'done' → satisfied (not stalled, not failed)", () => {
+    const id = recordIntent(db, {
+      tickId: 1,
+      kind: "unstuck-sweep",
+      subject: "CTL-X/implement",
+      postcondition: { kind: "unstuck-sweep", subject: "CTL-X/implement" },
+    });
+    const signalStatusBySubject = new Map([["CTL-X/implement", "done"]]);
+    const result = reconcileIntents(db, 1, { signalStatusBySubject }, { maxAttempts: 3 });
+    expect(result.satisfied).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/catB-force-with-lease.mjs
+++ b/plugins/dev/scripts/execution-core/catB-force-with-lease.mjs
@@ -14,6 +14,7 @@
 //
 // All git probes are injected as evidence fields; the classifier is pure.
 
+import { spawnSync } from "node:child_process";
 import { filterMachineLocalDirt, REBASE_NOISE_PATHS } from "./dirty-tree-classifier.mjs";
 
 // normalizeTicketKey — lowercase, strip leading zeros for comparison.
@@ -21,6 +22,22 @@ import { filterMachineLocalDirt, REBASE_NOISE_PATHS } from "./dirty-tree-classif
 function normalizeTicketKey(key) {
   if (!key) return "";
   return key.toLowerCase().replace(/(\w+-)0+(\d)/, "$1$2");
+}
+
+// buildTicketKeyRegex — whole-token matcher for a ticket key. Returns a RegExp
+// that matches the key as a bounded token (\b<prefix>-0*<num>\b), tolerant of
+// leading zeros in the subject, case-insensitive. Replaces the prior substring
+// `subjectNorm.includes(ticketNorm)` test, which prefix-matched short keys onto
+// longer ones (CTL-1 matched CTL-10) and matched the key anywhere in the body
+// (a foreign `CTL-999: revert CTL-1025 fix` or the default git-revert subject
+// `Revert "CTL-1025: ..."` false-accepted). Gate 2 is the SOLE ownership guard,
+// so a false-accept could force-push a branch carrying foreign commits (CTL-1064).
+// Returns null when the key is unparseable → caller falls back to exact-token.
+function buildTicketKeyRegex(ticket) {
+  const m = String(ticket ?? "").match(/^([A-Za-z][A-Za-z0-9]*)-0*(\d+)$/);
+  if (!m) return null;
+  const [, prefix, num] = m;
+  return new RegExp(`\\b${prefix}-0*${num}\\b`, "i");
 }
 
 // classifyCleanRebaseForcePush — PURE safety gate. No IO.
@@ -76,10 +93,15 @@ export function classifyCleanRebaseForcePush(evidence = {}) {
   if (!Array.isArray(commitSubjects) || commitSubjects.length === 0) {
     return { action: "skip", reason: "empty-commits" };
   }
+  const ticketRe = buildTicketKeyRegex(ticket);
   const ticketNorm = normalizeTicketKey(ticket);
   for (const subject of commitSubjects) {
-    const subjectNorm = normalizeTicketKey(subject);
-    if (!subjectNorm.includes(ticketNorm)) {
+    const matches = ticketRe
+      ? ticketRe.test(String(subject))
+      // Fallback for an unparseable key: exact normalized-token equality rather
+      // than substring (still avoids the CTL-1/CTL-10 prefix false-accept).
+      : normalizeTicketKey(subject).split(/\b/).some((t) => t === ticketNorm);
+    if (!matches) {
       return { action: "skip", reason: "foreign-commits" };
     }
   }
@@ -107,10 +129,11 @@ export function collectForcePushCandidates({
       if (c.evidence?.reason !== "source_conflict_ctl708_unavailable") continue;
       if (!c.worktreePath) continue;
 
-      const git = runGit ?? ((args, cwd) => {
-        const { spawnSync } = require("node:child_process");
-        return spawnSync("git", args, { encoding: "utf8", cwd: cwd ?? process.cwd() });
-      });
+      // Default git seam uses the top-level ESM import (this package is
+      // type:module — an in-body `require("node:child_process")` is undefined
+      // under node and threw, working only via bun's CJS shim) (CTL-1064).
+      const git = runGit ?? ((args, cwd) =>
+        spawnSync("git", args, { encoding: "utf8", cwd: cwd ?? process.cwd() }));
 
       // Probe 1: porcelain — non-zero exit → null (skip gates handled by classifier)
       let porcelain = null;

--- a/plugins/dev/scripts/execution-core/catB-force-with-lease.mjs
+++ b/plugins/dev/scripts/execution-core/catB-force-with-lease.mjs
@@ -1,0 +1,145 @@
+// catB-force-with-lease.mjs — CTL-1064 Category B pure classifier.
+//
+// Classifies a source_conflict_ctl708_unavailable stall as 'force-push' ONLY
+// when the worktree already holds a clean rebase of the ticket's own commits on
+// top of origin/main. Three-part safety gate (all must pass):
+//   1. Noise-filtered porcelain is empty (no real dirt, via REBASE_NOISE_PATHS).
+//   2. Every commit subject on HEAD..origin/main contains the ticket key (no foreign
+//      commits; non-empty set).
+//   3. HEAD is a strict descendant of origin/main (merge-base check).
+//
+// If any gate fails → skip with a reason code (never escalate from the classifier
+// — the caller decides). The act seam (Phase 7 scheduler-side) runs the real
+// git push --force-with-lease.
+//
+// All git probes are injected as evidence fields; the classifier is pure.
+
+import { filterMachineLocalDirt, REBASE_NOISE_PATHS } from "./dirty-tree-classifier.mjs";
+
+// normalizeTicketKey — lowercase, strip leading zeros for comparison.
+// Normalizes 'CTL-1025' and 'ctl-1025' to the same key for prefix matching.
+function normalizeTicketKey(key) {
+  if (!key) return "";
+  return key.toLowerCase().replace(/(\w+-)0+(\d)/, "$1$2");
+}
+
+// classifyCleanRebaseForcePush — PURE safety gate. No IO.
+// evidence shape:
+//   stalledReason        string    (must be 'source_conflict_ctl708_unavailable')
+//   ticket               string    (the ticket id, e.g. 'CTL-1025')
+//   porcelain            string|null   (null = unreadable → fail-safe skip)
+//   commitSubjects       string[]  (subjects of commits on HEAD above origin/main)
+//   headIsDescendant     bool      (git merge-base --is-ancestor origin/main HEAD)
+//   liveSessionInWorktree bool
+//   linearTerminal       bool
+//   alreadyPushed        bool     (.unstuck-force-pushed-<phase>.applied present)
+//
+// Returns:
+//   { action: 'force-push' }              — all gates passed
+//   { action: 'skip', reason: <code> }    — gate failed
+export function classifyCleanRebaseForcePush(evidence = {}) {
+  const {
+    stalledReason,
+    ticket,
+    porcelain,
+    commitSubjects,
+    headIsDescendant,
+    liveSessionInWorktree,
+    linearTerminal,
+    alreadyPushed,
+  } = evidence;
+
+  if (stalledReason !== "source_conflict_ctl708_unavailable") {
+    return { action: "skip", reason: "wrong-stall-reason" };
+  }
+  if (liveSessionInWorktree) {
+    return { action: "skip", reason: "live-session-in-worktree" };
+  }
+  if (linearTerminal) {
+    return { action: "skip", reason: "linear-terminal" };
+  }
+  if (alreadyPushed) {
+    return { action: "skip", reason: "already-pushed" };
+  }
+
+  // Gate 1: noise-filtered porcelain must be empty.
+  if (porcelain === null || porcelain === undefined) {
+    return { action: "skip", reason: "dirty-worktree" };
+  }
+  const lines = porcelain.split("\n").filter((l) => l.trim().length > 0);
+  const realDirt = filterMachineLocalDirt(lines);
+  if (realDirt.length > 0) {
+    return { action: "skip", reason: "dirty-worktree" };
+  }
+
+  // Gate 2: commits above origin/main must be non-empty and contain only this ticket.
+  if (!Array.isArray(commitSubjects) || commitSubjects.length === 0) {
+    return { action: "skip", reason: "empty-commits" };
+  }
+  const ticketNorm = normalizeTicketKey(ticket);
+  for (const subject of commitSubjects) {
+    const subjectNorm = normalizeTicketKey(subject);
+    if (!subjectNorm.includes(ticketNorm)) {
+      return { action: "skip", reason: "foreign-commits" };
+    }
+  }
+
+  // Gate 3: HEAD must be a strict descendant of origin/main.
+  if (!headIsDescendant) {
+    return { action: "skip", reason: "not-descendant" };
+  }
+
+  return { action: "force-push" };
+}
+
+// collectForcePushCandidates — census with injected git seams.
+// Collects stalled workers with source_conflict_ctl708_unavailable, runs the
+// three-part git probe (porcelain, log, merge-base) via injected seams, and
+// produces classifyCleanRebaseForcePush-compatible evidence objects.
+// Per-candidate catch: a failing probe skips that candidate (no throw).
+export function collectForcePushCandidates({
+  candidates = [],      // [{ticket, phase, worktreePath, signal, workerDir}]
+  runGit = null,        // (args, cwd?) → {status, stdout, stderr, error?}
+} = {}) {
+  const out = [];
+  for (const c of candidates) {
+    try {
+      if (c.evidence?.reason !== "source_conflict_ctl708_unavailable") continue;
+      if (!c.worktreePath) continue;
+
+      const git = runGit ?? ((args, cwd) => {
+        const { spawnSync } = require("node:child_process");
+        return spawnSync("git", args, { encoding: "utf8", cwd: cwd ?? process.cwd() });
+      });
+
+      // Probe 1: porcelain — non-zero exit → null (skip gates handled by classifier)
+      let porcelain = null;
+      const pRes = git(["-C", c.worktreePath, "status", "--porcelain"]);
+      if (!pRes.error && (pRes.status ?? 1) === 0) porcelain = pRes.stdout ?? "";
+
+      // Probe 2: commit subjects above origin/main — non-zero exit → empty array
+      let commitSubjects = [];
+      const lRes = git(["-C", c.worktreePath, "log", "--no-merges", "--format=%s", "origin/main..HEAD"]);
+      if (!lRes.error && (lRes.status ?? 1) === 0) {
+        commitSubjects = (lRes.stdout ?? "").split("\n").filter((s) => s.trim().length > 0);
+      }
+
+      // Probe 3: HEAD is strict descendant of origin/main
+      const mRes = git(["-C", c.worktreePath, "merge-base", "--is-ancestor", "origin/main", "HEAD"]);
+      const headIsDescendant = !mRes.error && (mRes.status ?? 1) === 0;
+
+      out.push({
+        ...c,
+        evidence: {
+          ...c.evidence,
+          porcelain,
+          commitSubjects,
+          headIsDescendant,
+        },
+      });
+    } catch {
+      // per-candidate error: skip, no throw
+    }
+  }
+  return out;
+}

--- a/plugins/dev/scripts/execution-core/catB-force-with-lease.test.mjs
+++ b/plugins/dev/scripts/execution-core/catB-force-with-lease.test.mjs
@@ -1,0 +1,178 @@
+// catB-force-with-lease.test.mjs — CTL-1064 Category B pure safety gate tests.
+
+import { describe, test, expect } from "bun:test";
+import { classifyCleanRebaseForcePush, collectForcePushCandidates } from "./catB-force-with-lease.mjs";
+
+const BASE = {
+  stalledReason: "source_conflict_ctl708_unavailable",
+  ticket: "CTL-1025",
+  porcelain: "",           // clean tree
+  commitSubjects: ["CTL-1025: fix widget rendering"],  // ticket-only commits
+  headIsDescendant: true,  // HEAD is strict descendant
+  liveSessionInWorktree: false,
+  linearTerminal: false,
+  alreadyPushed: false,
+};
+
+// ---------------------------------------------------------------------------
+// classifyCleanRebaseForcePush — pure safety gate
+// ---------------------------------------------------------------------------
+describe("classifyCleanRebaseForcePush — pure safety gate (CTL-1064 catB)", () => {
+  test("empty porcelain AND ticket-only commits AND HEAD descendant → force-push", () => {
+    expect(classifyCleanRebaseForcePush(BASE).action).toBe("force-push");
+  });
+
+  test("noise-only porcelain is treated as clean", () => {
+    const evidence = { ...BASE, porcelain: " M .catalyst/config.json\n M .claude/settings.json" };
+    expect(classifyCleanRebaseForcePush(evidence).action).toBe("force-push");
+  });
+
+  test("noise-filtered porcelain non-empty → skip/dirty-worktree", () => {
+    const evidence = { ...BASE, porcelain: " M src/foo.mjs" };
+    const r = classifyCleanRebaseForcePush(evidence);
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("dirty-worktree");
+  });
+
+  test("porcelain null (unreadable) → skip/dirty-worktree (fail-safe)", () => {
+    const r = classifyCleanRebaseForcePush({ ...BASE, porcelain: null });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("dirty-worktree");
+  });
+
+  test("git log has a non-ticket commit → skip/foreign-commits", () => {
+    const evidence = { ...BASE, commitSubjects: ["CTL-1025: fix widget", "CTL-999: unrelated change"] };
+    const r = classifyCleanRebaseForcePush(evidence);
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("foreign-commits");
+  });
+
+  test("git log origin/main..HEAD empty (zero commits ahead) → skip/empty-commits", () => {
+    const r = classifyCleanRebaseForcePush({ ...BASE, commitSubjects: [] });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("empty-commits");
+  });
+
+  test("HEAD not a descendant of origin/main → skip/not-descendant", () => {
+    const r = classifyCleanRebaseForcePush({ ...BASE, headIsDescendant: false });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("not-descendant");
+  });
+
+  test("stalledReason mismatch → skip/wrong-stall-reason", () => {
+    const r = classifyCleanRebaseForcePush({ ...BASE, stalledReason: "rebase_refused_dirty_tree" });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("wrong-stall-reason");
+  });
+
+  test("linearTerminal → skip/linear-terminal", () => {
+    const r = classifyCleanRebaseForcePush({ ...BASE, linearTerminal: true });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("linear-terminal");
+  });
+
+  test("liveSession → skip/live-session-in-worktree", () => {
+    const r = classifyCleanRebaseForcePush({ ...BASE, liveSessionInWorktree: true });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("live-session-in-worktree");
+  });
+
+  test(".unstuck-force-pushed-<phase>.applied present → skip/already-pushed", () => {
+    const r = classifyCleanRebaseForcePush({ ...BASE, alreadyPushed: true });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("already-pushed");
+  });
+
+  test("mixed-case ticket prefix normalized (CTL-1025 == ctl-1025)", () => {
+    const evidence = {
+      ...BASE,
+      ticket: "CTL-1025",
+      commitSubjects: ["ctl-1025: fix widget rendering"],
+    };
+    expect(classifyCleanRebaseForcePush(evidence).action).toBe("force-push");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectForcePushCandidates — census (injected git seams)
+// ---------------------------------------------------------------------------
+describe("collectForcePushCandidates — census (injected git seams) (CTL-1064 catB)", () => {
+  function makeCandidate(overrides = {}) {
+    return {
+      ticket: "CTL-1025",
+      phase: "implement",
+      worktreePath: "/fake/worktree/CTL-1025",
+      workerDir: "/fake/orch/workers/CTL-1025",
+      evidence: {
+        reason: "source_conflict_ctl708_unavailable",
+        ticket: "CTL-1025",
+        phase: "implement",
+        liveSessionInWorktree: false,
+        linearTerminal: false,
+        alreadyPushed: false,
+      },
+      ...overrides,
+    };
+  }
+
+  function makeGit({ porcelain = "", log = "CTL-1025: fix\n", isAncestor = true } = {}) {
+    return (args) => {
+      if (args.includes("status")) return { status: 0, stdout: porcelain, stderr: "" };
+      if (args.includes("log")) return { status: 0, stdout: log, stderr: "" };
+      if (args.includes("merge-base")) return { status: isAncestor ? 0 : 1, stdout: "", stderr: "" };
+      return { status: 1, stdout: "", stderr: "" };
+    };
+  }
+
+  test("emits candidate with probed evidence when stall has correct reason", () => {
+    const candidates = collectForcePushCandidates({
+      candidates: [makeCandidate()],
+      runGit: makeGit(),
+    });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].evidence.porcelain).toBe("");
+    expect(candidates[0].evidence.commitSubjects).toEqual(["CTL-1025: fix"]);
+    expect(candidates[0].evidence.headIsDescendant).toBe(true);
+  });
+
+  test("skips candidates with wrong stalledReason", () => {
+    const c = makeCandidate();
+    c.evidence.reason = "rebase_refused_dirty_tree";
+    const candidates = collectForcePushCandidates({ candidates: [c], runGit: makeGit() });
+    expect(candidates).toHaveLength(0);
+  });
+
+  test("skips candidates with no worktreePath", () => {
+    const c = makeCandidate({ worktreePath: null });
+    const candidates = collectForcePushCandidates({ candidates: [c], runGit: makeGit() });
+    expect(candidates).toHaveLength(0);
+  });
+
+  test("git log non-zero exit → candidate skipped (no throw)", () => {
+    const git = (args) => {
+      if (args.includes("log")) return { status: 128, stdout: "", stderr: "error", error: new Error("fail") };
+      return { status: 0, stdout: "", stderr: "" };
+    };
+    const candidates = collectForcePushCandidates({
+      candidates: [makeCandidate()],
+      runGit: git,
+    });
+    // Candidate is emitted with empty commitSubjects (graceful degradation)
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].evidence.commitSubjects).toEqual([]);
+  });
+
+  test("per-candidate catch: git throws → candidate skipped, no abort", () => {
+    let callCount = 0;
+    const git = (args) => {
+      callCount++;
+      throw new Error("git not available");
+    };
+    // Should not throw
+    const candidates = collectForcePushCandidates({
+      candidates: [makeCandidate()],
+      runGit: git,
+    });
+    expect(candidates).toHaveLength(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/catB-force-with-lease.test.mjs
+++ b/plugins/dev/scripts/execution-core/catB-force-with-lease.test.mjs
@@ -91,6 +91,68 @@ describe("classifyCleanRebaseForcePush — pure safety gate (CTL-1064 catB)", ()
     };
     expect(classifyCleanRebaseForcePush(evidence).action).toBe("force-push");
   });
+
+  // CTL-1064 remediation: Gate 2 is the SOLE ownership guard, so the prior
+  // substring match (subjectNorm.includes(ticketNorm)) was a force-push safety
+  // hole — short keys prefix-matched longer ones and the key matched anywhere in
+  // the body. Now a whole-token (\b…\b) match.
+  test("short ticket key must NOT prefix-match a longer one (CTL-1 vs CTL-10)", () => {
+    const evidence = {
+      ...BASE,
+      ticket: "CTL-1",
+      commitSubjects: ["CTL-10: someone else's commit"],
+    };
+    const r = classifyCleanRebaseForcePush(evidence);
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("foreign-commits");
+  });
+
+  test("longer key must NOT match a shorter one (CTL-10 vs CTL-1)", () => {
+    const evidence = {
+      ...BASE,
+      ticket: "CTL-10",
+      commitSubjects: ["CTL-1: someone else's commit"],
+    };
+    expect(classifyCleanRebaseForcePush(evidence).reason).toBe("foreign-commits");
+  });
+
+  test("foreign commit that merely mentions another ticket id → skip/foreign-commits", () => {
+    // A CTL-999 commit body referencing CTL-1025 must not be accepted when our
+    // ticket is CTL-1064 (the key appears nowhere as a token).
+    const evidence = {
+      ...BASE,
+      ticket: "CTL-1064",
+      commitSubjects: ["CTL-999: revert CTL-1025 fix"],
+    };
+    expect(classifyCleanRebaseForcePush(evidence).reason).toBe("foreign-commits");
+  });
+
+  test("default git-revert subject of a FOREIGN ticket → skip/foreign-commits", () => {
+    const evidence = {
+      ...BASE,
+      ticket: "CTL-1064",
+      commitSubjects: ['Revert "CTL-1025: fix widget rendering"'],
+    };
+    expect(classifyCleanRebaseForcePush(evidence).reason).toBe("foreign-commits");
+  });
+
+  test("conventional-commit prefix carrying our key as a token → force-push", () => {
+    const evidence = {
+      ...BASE,
+      ticket: "CTL-1064",
+      commitSubjects: ["feat(dev): CTL-1064 — wire the sweep", "fix(CTL-1064): follow-up"],
+    };
+    expect(classifyCleanRebaseForcePush(evidence).action).toBe("force-push");
+  });
+
+  test("leading-zero tolerance in the subject (CTL-1064 matches CTL-01064)", () => {
+    const evidence = {
+      ...BASE,
+      ticket: "CTL-1064",
+      commitSubjects: ["CTL-01064: zero-padded subject"],
+    };
+    expect(classifyCleanRebaseForcePush(evidence).action).toBe("force-push");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -174,5 +236,22 @@ describe("collectForcePushCandidates — census (injected git seams) (CTL-1064 c
       runGit: git,
     });
     expect(candidates).toHaveLength(0);
+  });
+
+  // CTL-1064 remediation: exercise the DEFAULT git seam (no runGit injected). The
+  // prior in-body `require("node:child_process")` is undefined under node (this
+  // package is type:module) and threw; it is now a top-level ESM import. Against
+  // a nonexistent worktree the spawned git exits non-zero (porcelain→null), but
+  // the default seam itself must resolve and not throw.
+  test("default git seam (no injected runGit) resolves via ESM import without throwing", () => {
+    let candidates;
+    expect(() => {
+      candidates = collectForcePushCandidates({
+        candidates: [makeCandidate({ worktreePath: "/nonexistent/worktree/CTL-1025" })],
+      });
+    }).not.toThrow();
+    // The probe ran (real git, non-zero on a bogus path) → porcelain stays null.
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].evidence.porcelain).toBeNull();
   });
 });

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -534,3 +534,46 @@ export function readStallJanitorConfig() {
     STALL_JANITOR_DEFAULT_TERMINAL_IDLE_MS;
   return { mode, terminalIdleMs };
 }
+
+// --- Unstuck sweep (CTL-1064) ---
+// OFF by default — operators opt in via shadow then enforce. Same three-layer
+// precedence as CTL-1004/CTL-1029 (env > Layer-2 catalyst.unstuckSweep.* >
+// code default). Runs as a low-frequency throttled Pass 0u (default 15 min).
+const UNSTUCK_SWEEP_MODES = new Set(["off", "shadow", "enforce"]);
+export const UNSTUCK_SWEEP_DEFAULT_INTERVAL_MS = 900_000; // 15 minutes
+
+function readLayer2UnstuckSweep() {
+  try {
+    const us = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.unstuckSweep;
+    return us && typeof us === "object" ? us : {};
+  } catch { return {}; }
+}
+
+export function readUnstuckSweepConfig() {
+  const l2 = readLayer2UnstuckSweep();
+  // CATALYST_UNSTUCK_SWEEP is the single operator knob:
+  //   "0" → off (kill-switch), off|shadow|enforce → that mode, anything else → off.
+  const env = process.env.CATALYST_UNSTUCK_SWEEP ?? process.env.EXECUTION_CORE_UNSTUCK_SWEEP_MODE;
+  let mode;
+  if (env === "0") {
+    mode = "off";
+  } else if (typeof env === "string" && UNSTUCK_SWEEP_MODES.has(env)) {
+    mode = env;
+  } else if (typeof l2.mode === "string" && UNSTUCK_SWEEP_MODES.has(l2.mode)) {
+    mode = l2.mode;
+  } else {
+    mode = "off"; // safe default: off — operators opt into shadow then enforce
+  }
+  const intervalMs =
+    Number(process.env.CATALYST_UNSTUCK_SWEEP_INTERVAL_MS) ||
+    (Number(l2.intervalSeconds) || 0) * 1000 ||
+    UNSTUCK_SWEEP_DEFAULT_INTERVAL_MS;
+  return { mode, intervalMs };
+}
+
+// isThrottled — returns true when (nowMs - lastRunMs) < intervalMs.
+// Extracted as a standalone export so tests can assert the throttle guard
+// and future low-frequency passes can reuse the same helper.
+export function isThrottled(lastRunMs, intervalMs, nowMs) {
+  return (nowMs - lastRunMs) < intervalMs;
+}

--- a/plugins/dev/scripts/execution-core/dirty-tree-classifier.mjs
+++ b/plugins/dev/scripts/execution-core/dirty-tree-classifier.mjs
@@ -1,0 +1,106 @@
+// dirty-tree-classifier.mjs — CTL-1064 Category A pure classifier.
+//
+// Classifies a rebase_refused_dirty_tree stall as 'clear-retry' when the
+// worktree's porcelain dirt, filtered through REBASE_NOISE_PATHS and the
+// deleted-node_modules predicate, is fully empty. Any remaining real dirt
+// → 'escalate' (fail-closed). All IO injected; pure given the evidence.
+//
+// SYNC OBLIGATION: REBASE_NOISE_PATHS must be kept in sync with
+// worktree-rebase.sh:38-42 (plugins/dev/scripts/lib/worktree-rebase.sh).
+// The bash array is the canonical source; this JS mirror is the secondary.
+// When you change one, change the other. A CI grep guards the comment.
+
+import { cleanPorcelain } from "./worktree-safety.mjs";
+
+// REBASE_NOISE_PATHS — JS mirror of WORKTREE_NOISE_PATHS in worktree-rebase.sh:38.
+// These are the paths that diverge per-worktree and are stashed before a rebase,
+// then popped after (CTL-990 / CTL-678 rationale in the bash source).
+// SYNC: plugins/dev/scripts/lib/worktree-rebase.sh:38-42
+export const REBASE_NOISE_PATHS = Object.freeze([
+  ".catalyst/config.json",
+  ".claude/config.json",
+  ".claude/settings.json",
+  ".trunk/actions",
+  ".trunk/logs",
+  ".trunk/notifications",
+  ".trunk/out",
+  ".trunk/tools",
+]);
+
+// isNodeModulesDeletion — returns true when a porcelain line represents a PURE
+// deletion of node_modules/ (tracked deletion: 'D  node_modules' or
+// ' D node_modules/...'). A modification (' M node_modules/...') is NOT treated
+// as noise — only deletions of the directory or its contents qualify.
+// Risk: a branch that legitimately removes node_modules from tracking would be
+// auto-cleared; the recorded intent + R11/R12 backstop catches a re-stall.
+export function isNodeModulesDeletion(line) {
+  if (!line || line.length < 4) return false;
+  // Status chars are at positions 0-1; path starts at position 3.
+  const xy = line.slice(0, 2);
+  // Must have at least one 'D' in the status column (deleted from index or worktree).
+  // Exclude modifications (both chars are space or M/A/R/C/U).
+  if (!xy.includes("D") && !xy.includes("d")) return false;
+  // Reject if any non-D/space/? status — be strict about "pure deletion".
+  const statusChars = xy.replace(/[ D?]/gi, "");
+  if (statusChars.length > 0) return false;
+  const path = line.slice(3).trim().replace(/^"|"$/g, "");
+  return path === "node_modules" || path.startsWith("node_modules/");
+}
+
+// filterMachineLocalDirt — returns the porcelain lines that are NOT in
+// REBASE_NOISE_PATHS and NOT deleted node_modules. Non-empty result means
+// real work is present that the rebase stash would not absorb.
+export function filterMachineLocalDirt(lines) {
+  return lines.filter((line) => {
+    if (!line || !line.trim()) return false;
+    // Use cleanPorcelain's filter for the canonical noise paths.
+    if (cleanPorcelain(line, REBASE_NOISE_PATHS).length === 0) return false;
+    // Additional: deleted node_modules is machine-local-safe.
+    if (isNodeModulesDeletion(line)) return false;
+    return true;
+  });
+}
+
+// classifyDirtyTreeRecoverable — PURE. Returns:
+//   { action: 'clear-retry' } — all dirt is machine-local noise; safe to auto-clear.
+//   { action: 'escalate', reason }  — real dirt present; human decision required.
+//   { action: 'skip', reason }      — wrong stall reason, live session, terminal,
+//                                     already cleared, or unreadable porcelain.
+//
+// evidence shape:
+//   stalledReason         string   (must be 'rebase_refused_dirty_tree')
+//   porcelain             string|null   (`git status --porcelain` output; null = unreadable)
+//   liveSessionInWorktree bool
+//   linearTerminal        bool
+//   alreadyCleared        bool     (.unstuck-cleared-<phase>.applied present)
+export function classifyDirtyTreeRecoverable(evidence = {}) {
+  const { stalledReason, porcelain, liveSessionInWorktree, linearTerminal, alreadyCleared } = evidence;
+
+  if (stalledReason !== "rebase_refused_dirty_tree") {
+    return { action: "skip", reason: "wrong-stall-reason" };
+  }
+  if (liveSessionInWorktree) {
+    return { action: "skip", reason: "live-session-in-worktree" };
+  }
+  if (linearTerminal) {
+    return { action: "skip", reason: "linear-terminal" };
+  }
+  if (alreadyCleared) {
+    return { action: "skip", reason: "already-cleared" };
+  }
+  // Fail-closed: null/unreadable porcelain → escalate (never auto-act on unknown state).
+  if (porcelain === null || porcelain === undefined) {
+    return { action: "escalate", reason: "unreadable-porcelain" };
+  }
+
+  const lines = porcelain
+    .split("\n")
+    .filter((l) => l.trim().length > 0);
+
+  const realDirt = filterMachineLocalDirt(lines);
+
+  if (realDirt.length === 0) {
+    return { action: "clear-retry" };
+  }
+  return { action: "escalate", reason: "real-dirt-present", dirt: realDirt };
+}

--- a/plugins/dev/scripts/execution-core/dirty-tree-classifier.test.mjs
+++ b/plugins/dev/scripts/execution-core/dirty-tree-classifier.test.mjs
@@ -1,0 +1,181 @@
+// dirty-tree-classifier.test.mjs — CTL-1064 Category A pure classifier tests.
+
+import { describe, test, expect } from "bun:test";
+import {
+  classifyDirtyTreeRecoverable,
+  isNodeModulesDeletion,
+  filterMachineLocalDirt,
+  REBASE_NOISE_PATHS,
+} from "./dirty-tree-classifier.mjs";
+
+// ---------------------------------------------------------------------------
+// isNodeModulesDeletion
+// ---------------------------------------------------------------------------
+describe("isNodeModulesDeletion (CTL-1064 catA helper)", () => {
+  test("' D node_modules' → true (worktree deletion)", () => {
+    expect(isNodeModulesDeletion(" D node_modules")).toBe(true);
+  });
+
+  test("' D node_modules/react/index.js' → true", () => {
+    expect(isNodeModulesDeletion(" D node_modules/react/index.js")).toBe(true);
+  });
+
+  test("'D  node_modules' → true (index deletion)", () => {
+    expect(isNodeModulesDeletion("D  node_modules")).toBe(true);
+  });
+
+  test("' M node_modules/react/index.js' → false (modification, not deletion)", () => {
+    expect(isNodeModulesDeletion(" M node_modules/react/index.js")).toBe(false);
+  });
+
+  test("' D src/index.mjs' → false (not under node_modules)", () => {
+    expect(isNodeModulesDeletion(" D src/index.mjs")).toBe(false);
+  });
+
+  test("'?? node_modules/' → false (untracked, not deletion)", () => {
+    expect(isNodeModulesDeletion("?? node_modules/")).toBe(false);
+  });
+
+  test("empty string → false", () => {
+    expect(isNodeModulesDeletion("")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterMachineLocalDirt
+// ---------------------------------------------------------------------------
+describe("filterMachineLocalDirt (CTL-1064 catA helper)", () => {
+  test("REBASE_NOISE_PATHS entries filtered out", () => {
+    const lines = [
+      " M .catalyst/config.json",
+      " M .claude/settings.json",
+      " M .trunk/logs",
+      " M src/foo.mjs",
+    ];
+    const dirt = filterMachineLocalDirt(lines);
+    expect(dirt).toHaveLength(1);
+    expect(dirt[0]).toBe(" M src/foo.mjs");
+  });
+
+  test("deleted node_modules filtered out", () => {
+    const lines = [" D node_modules", " D node_modules/react/index.js"];
+    expect(filterMachineLocalDirt(lines)).toHaveLength(0);
+  });
+
+  test("noise + deleted node_modules → all filtered", () => {
+    const lines = [" M .catalyst/config.json", " D node_modules"];
+    expect(filterMachineLocalDirt(lines)).toHaveLength(0);
+  });
+
+  test("real source file survives", () => {
+    const lines = [" M src/foo.mjs"];
+    expect(filterMachineLocalDirt(lines)).toHaveLength(1);
+  });
+
+  test("untracked file survives", () => {
+    const lines = ["?? scratch.json"];
+    expect(filterMachineLocalDirt(lines)).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyDirtyTreeRecoverable
+// ---------------------------------------------------------------------------
+describe("classifyDirtyTreeRecoverable (CTL-1064 catA)", () => {
+  const BASE = {
+    stalledReason: "rebase_refused_dirty_tree",
+    liveSessionInWorktree: false,
+    linearTerminal: false,
+    alreadyCleared: false,
+  };
+
+  test("empty porcelain after noise filtering → clear-retry", () => {
+    expect(classifyDirtyTreeRecoverable({ ...BASE, porcelain: "" }).action).toBe("clear-retry");
+  });
+
+  test("only REBASE_NOISE_PATHS entries → clear-retry", () => {
+    const p = " M .catalyst/config.json\n M .claude/settings.json\n M .trunk/logs";
+    expect(classifyDirtyTreeRecoverable({ ...BASE, porcelain: p }).action).toBe("clear-retry");
+  });
+
+  test("only deleted node_modules → clear-retry", () => {
+    const p = "D  node_modules\n D node_modules/foo/bar.js";
+    expect(classifyDirtyTreeRecoverable({ ...BASE, porcelain: p }).action).toBe("clear-retry");
+  });
+
+  test("noise + deleted node_modules → clear-retry", () => {
+    const p = " M .catalyst/config.json\n D node_modules";
+    expect(classifyDirtyTreeRecoverable({ ...BASE, porcelain: p }).action).toBe("clear-retry");
+  });
+
+  test("real tracked source file ( M src/foo.mjs) → escalate", () => {
+    expect(classifyDirtyTreeRecoverable({ ...BASE, porcelain: " M src/foo.mjs" }).action).toBe("escalate");
+  });
+
+  test("untracked file (?? scratch.json) → escalate", () => {
+    expect(classifyDirtyTreeRecoverable({ ...BASE, porcelain: "?? scratch.json" }).action).toBe("escalate");
+  });
+
+  test("mix of real dirt + noise → escalate", () => {
+    const p = " M .catalyst/config.json\n M src/foo.mjs";
+    expect(classifyDirtyTreeRecoverable({ ...BASE, porcelain: p }).action).toBe("escalate");
+  });
+
+  test("stalledReason !== 'rebase_refused_dirty_tree' → skip", () => {
+    const r = classifyDirtyTreeRecoverable({ ...BASE, stalledReason: "source_conflict_ctl708_unavailable", porcelain: "" });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("wrong-stall-reason");
+  });
+
+  test("liveSessionInWorktree → skip", () => {
+    const r = classifyDirtyTreeRecoverable({ ...BASE, liveSessionInWorktree: true, porcelain: "" });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("live-session-in-worktree");
+  });
+
+  test("linearTerminal → skip", () => {
+    const r = classifyDirtyTreeRecoverable({ ...BASE, linearTerminal: true, porcelain: "" });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("linear-terminal");
+  });
+
+  test("alreadyCleared → skip", () => {
+    const r = classifyDirtyTreeRecoverable({ ...BASE, alreadyCleared: true, porcelain: "" });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("already-cleared");
+  });
+
+  test("porcelain===null → escalate (fail-closed)", () => {
+    const r = classifyDirtyTreeRecoverable({ ...BASE, porcelain: null });
+    expect(r.action).toBe("escalate");
+    expect(r.reason).toBe("unreadable-porcelain");
+  });
+
+  test("same input twice → identical output (pure)", () => {
+    const evidence = { ...BASE, porcelain: " M .catalyst/config.json" };
+    const r1 = classifyDirtyTreeRecoverable(evidence);
+    const r2 = classifyDirtyTreeRecoverable(evidence);
+    expect(r1.action).toBe(r2.action);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REBASE_NOISE_PATHS
+// ---------------------------------------------------------------------------
+describe("REBASE_NOISE_PATHS (CTL-1064 catA)", () => {
+  test("includes .catalyst/config.json", () => {
+    expect(REBASE_NOISE_PATHS).toContain(".catalyst/config.json");
+  });
+  test("includes .claude/config.json and .claude/settings.json", () => {
+    expect(REBASE_NOISE_PATHS).toContain(".claude/config.json");
+    expect(REBASE_NOISE_PATHS).toContain(".claude/settings.json");
+  });
+  test("includes .trunk entries", () => {
+    for (const p of [".trunk/actions", ".trunk/logs", ".trunk/notifications", ".trunk/out", ".trunk/tools"]) {
+      expect(REBASE_NOISE_PATHS).toContain(p);
+    }
+  });
+  test("is frozen", () => {
+    expect(Object.isFrozen(REBASE_NOISE_PATHS)).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/integration-ctl-1064.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-1064.test.mjs
@@ -12,10 +12,11 @@
 //   6. stale-label candidate in shadow → would-clear-label event
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { schedulerTick, __resetForTests } from "./scheduler.mjs";
+import { openBeliefsDb } from "./beliefs/schema.mjs";
 
 let orchDir;
 beforeEach(() => {
@@ -55,7 +56,32 @@ function makeTickOpts({
   nowMs = undefined,
   candidates = [],
   intervalMs = 1, // very short so the throttle never blocks in tests
+  intentDb = null, // CTL-1064: pass a real beliefs db to exercise the intent gate
+  omitEmit = false, // CTL-1064: omit the emit seam so the production default fires
 } = {}) {
+  const unstuckSweep = {
+    mode,
+    intervalMs,
+    collectCandidates: () => candidates,
+    actByCategory: {
+      "dirty-tree": (c) => actCalls.push({ ticket: c.ticket, category: "dirty-tree" }),
+      "stale-label": (c) => actCalls.push({ ticket: c.ticket, category: "stale-label" }),
+    },
+    escalate: (c) => escalateCalls.push({ ticket: c.ticket, phase: c.phase }),
+    emit: (type, fields) => {
+      events.push({ type, ...fields });
+      return Promise.resolve(true);
+    },
+    postComment: (ticket, category, phase) => {
+      commentCalls.push({ ticket, category, phase });
+    },
+    nowMs: typeof nowMs === "function" ? nowMs : (nowMs != null ? () => nowMs : undefined),
+  };
+  // CTL-1064: when omitEmit, drop the seam entirely so schedulerTick's
+  // production default (emitUnstuckEvent) is exercised — no test should mask the
+  // real default emit (the original HIGH silent-failure: emitReapIntent threw on
+  // unstuck.* and the rejection was swallowed).
+  if (omitEmit) delete unstuckSweep.emit;
   return {
     readEligible: () => [],
     dispatch: () => ({ code: 0, stdout: "", stderr: "" }),
@@ -67,24 +93,8 @@ function makeTickOpts({
       runTransition: () => ({ applied: false }),
     },
     watchdog: { mode: "off" },
-    unstuckSweep: {
-      mode,
-      intervalMs,
-      collectCandidates: () => candidates,
-      actByCategory: {
-        "dirty-tree": (c) => actCalls.push({ ticket: c.ticket, category: "dirty-tree" }),
-        "stale-label": (c) => actCalls.push({ ticket: c.ticket, category: "stale-label" }),
-      },
-      escalate: (c) => escalateCalls.push({ ticket: c.ticket, phase: c.phase }),
-      emit: (type, fields) => {
-        events.push({ type, ...fields });
-        return Promise.resolve(true);
-      },
-      postComment: (ticket, category, phase) => {
-        commentCalls.push({ ticket, category, phase });
-      },
-      nowMs: typeof nowMs === "function" ? nowMs : (nowMs != null ? () => nowMs : undefined),
-    },
+    intentDb,
+    unstuckSweep,
   };
 }
 
@@ -349,5 +359,114 @@ describe("CTL-1064 Pass 0u integration — multiple candidates", () => {
     expect(result.unstuckWouldEscalate[0].ticket).toBe("CTL-B");
     expect(events.find((e) => e.type === "unstuck.would.clear-noise")).toBeDefined();
     expect(events.find((e) => e.type === "unstuck.would.escalate")).toBeDefined();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// CTL-1064 remediation (verify⇄remediate): regression coverage for the bugs the
+// verify phase found in the original Pass 0u landing. These drive the REAL
+// schedulerTick wiring (NOT injected stubs that masked the production default).
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("CTL-1064 remediation — real default emit seam (HIGH silent-failure)", () => {
+  let prevDir;
+  beforeEach(() => { prevDir = process.env.CATALYST_DIR; });
+  afterEach(() => {
+    if (prevDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevDir;
+  });
+
+  test("schedulerTick with NO injected emit lands unstuck.* events in the unified log", () => {
+    // The original bug: the production default emit was emitReapIntent, whose
+    // closed vocabulary throws on unstuck.* — and the fire-and-forget path
+    // swallowed the rejection, so EVERY unstuck event was silently dropped.
+    // Here we omit the emit seam so the schedulerTick default (emitUnstuckEvent)
+    // is exercised, and assert the shadow event actually reaches getEventLogPath().
+    process.env.CATALYST_DIR = orchDir; // getEventLogPath → <orchDir>/events/<ym>.jsonl
+    seedStall(TICKET_DIRTY, PHASE, "rebase_refused_dirty_tree");
+    const candidates = [{
+      ticket: TICKET_DIRTY,
+      phase: PHASE,
+      evidence: { reason: "rebase_refused_dirty_tree", ticket: TICKET_DIRTY, phase: PHASE, liveSessionInWorktree: false, linearTerminal: false },
+    }];
+
+    const result = schedulerTick(orchDir, makeTickOpts({ mode: "shadow", candidates, omitEmit: true }));
+
+    expect(result.unstuckWouldAct).toHaveLength(1);
+    const ym = `${new Date().getUTCFullYear()}-${String(new Date().getUTCMonth() + 1).padStart(2, "0")}`;
+    const logPath = join(orchDir, "events", `${ym}.jsonl`);
+    expect(existsSync(logPath)).toBe(true);
+    const lines = readFileSync(logPath, "utf8").trim().split("\n").map((l) => JSON.parse(l));
+    const ev = lines.find((l) => l.event === "unstuck.would.clear-noise");
+    expect(ev).toBeDefined();
+    expect(ev.ticket).toBe(TICKET_DIRTY);
+  });
+});
+
+describe("CTL-1064 remediation — enforce false-success when no act seam (HIGH review)", () => {
+  test("enforce + category with no act seam: no act, no emit, no comment, not reported acted", () => {
+    // source_conflict maps to category 'source-conflict', which has NO entry in
+    // actByCategory (production default is {} entirely). The original code fell
+    // through to emit the success event + post a comment + report.acted even
+    // though nothing ran. The fix skips with reason 'no-act-seam'.
+    const TICKET_SC = "CTL-1064-SOURCECONFLICT";
+    seedStall(TICKET_SC, PHASE, "source_conflict_ctl708_unavailable");
+    const events = [];
+    const actCalls = [];
+    const commentCalls = [];
+    const candidates = [{
+      ticket: TICKET_SC,
+      phase: PHASE,
+      evidence: { reason: "source_conflict_ctl708_unavailable", ticket: TICKET_SC, phase: PHASE, liveSessionInWorktree: false, linearTerminal: false },
+    }];
+
+    const result = schedulerTick(orchDir, makeTickOpts({ mode: "enforce", events, actCalls, commentCalls, candidates }));
+
+    expect(actCalls).toHaveLength(0);
+    expect(commentCalls).toHaveLength(0);
+    expect(events.find((e) => e.type === "unstuck.pushed.force-with-lease")).toBeUndefined();
+    expect(result.unstuckActed).toHaveLength(0);
+  });
+});
+
+describe("CTL-1064 remediation — intent gate act-once-then-skip + no duplicate intent (MEDIUM)", () => {
+  test("two enforce passes with a real intentDb: act once, exactly one open intent row", () => {
+    const dbPath = join(orchDir, "beliefs.db");
+    const intentDb = openBeliefsDb({ path: dbPath });
+    try {
+      // intent.tick_id is NOT NULL → the recorder anchors to the latest tick row.
+      // Production seeds ticks via collectBeliefsTick; seed one here.
+      intentDb.run("INSERT INTO tick (now_ms, host) VALUES (?, ?)", [1_000_000, "test-host"]);
+      seedStall(TICKET_DIRTY, PHASE, "rebase_refused_dirty_tree");
+      const actCalls = [];
+      const candidates = [{
+        ticket: TICKET_DIRTY,
+        phase: PHASE,
+        evidence: { reason: "rebase_refused_dirty_tree", ticket: TICKET_DIRTY, phase: PHASE, liveSessionInWorktree: false, linearTerminal: false },
+      }];
+      let clock = 1_000_000;
+      const opts = makeTickOpts({ mode: "enforce", actCalls, candidates, intentDb, nowMs: () => clock });
+
+      // Pass 1: no open intent yet → acts + records exactly one intent.
+      schedulerTick(orchDir, opts);
+      expect(actCalls).toHaveLength(1);
+      const subject = `${TICKET_DIRTY}/${PHASE}`;
+      const after1 = intentDb
+        .query("SELECT COUNT(*) AS n FROM intent WHERE kind = 'unstuck-sweep' AND subject = ?")
+        .get(subject).n;
+      expect(after1).toBe(1);
+
+      // Pass 2 (past the throttle window): the open intent gate suppresses re-acting,
+      // and the recordIntent dedup inserts no duplicate row.
+      clock += 1_000_000;
+      schedulerTick(orchDir, opts);
+      expect(actCalls).toHaveLength(1); // still 1 — NOT re-acted
+      const after2 = intentDb
+        .query("SELECT COUNT(*) AS n FROM intent WHERE kind = 'unstuck-sweep' AND subject = ?")
+        .get(subject).n;
+      expect(after2).toBe(1); // no duplicate intent
+    } finally {
+      intentDb.close();
+    }
   });
 });

--- a/plugins/dev/scripts/execution-core/integration-ctl-1064.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-1064.test.mjs
@@ -1,0 +1,353 @@
+// integration-ctl-1064.test.mjs — CTL-1064 Pass 0u end-to-end: schedulerTick
+// unstuck-sweep. Drives the REAL schedulerTick with injected census/emit/act/
+// postComment seams (no filesystem cleanup seams — the actByCategory stubs
+// simulate actions without touching disk). Mirrors integration-ctl-1005.test.mjs.
+//
+// Test matrix:
+//   1. shadow mode — emits would-* events, no act, no intent, no comment
+//   2. enforce mode — dirty-tree candidate acted, event emitted, report populated
+//   3. enforce mode — escalate path (unknown reason) pages, event emitted
+//   4. throttle guard — second tick within window skips the pass entirely
+//   5. mode='off' — census never called, no events
+//   6. stale-label candidate in shadow → would-clear-label event
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { schedulerTick, __resetForTests } from "./scheduler.mjs";
+
+let orchDir;
+beforeEach(() => {
+  __resetForTests(); // resets _unstuckLastRunMs + debounce timers
+  orchDir = mkdtempSync(join(tmpdir(), "ctl1064-int-"));
+});
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+const TICKET_DIRTY = "CTL-1064-DIRTY";
+const TICKET_UNKNOWN = "CTL-1064-UNKNOWN";
+const PHASE = "implement";
+
+function workerDir(ticket) {
+  return join(orchDir, "workers", ticket);
+}
+
+// Seed a stalled signal for a given ticket.
+function seedStall(ticket, phase, stalledReason) {
+  const d = workerDir(ticket);
+  mkdirSync(d, { recursive: true });
+  writeFileSync(
+    join(d, `phase-${phase}.json`),
+    JSON.stringify({ ticket, phase, status: "stalled", stalledReason }),
+  );
+}
+
+// Minimal schedulerTick options: inert reclaim/watchdog/dispatch + the unstuck
+// census injected. actByCategory and escalate are stubbed to record calls.
+function makeTickOpts({
+  mode,
+  events = [],
+  actCalls = [],
+  escalateCalls = [],
+  commentCalls = [],
+  nowMs = undefined,
+  candidates = [],
+  intervalMs = 1, // very short so the throttle never blocks in tests
+} = {}) {
+  return {
+    readEligible: () => [],
+    dispatch: () => ({ code: 0, stdout: "", stderr: "" }),
+    exec: () => ({ code: null }),
+    reclaimDeadWork: () => ({ class: "alive-suppressed" }),
+    writeStatus: {
+      applyLabel: () => ({ applied: true }),
+      removeLabel: () => ({ removed: true }),
+      runTransition: () => ({ applied: false }),
+    },
+    watchdog: { mode: "off" },
+    unstuckSweep: {
+      mode,
+      intervalMs,
+      collectCandidates: () => candidates,
+      actByCategory: {
+        "dirty-tree": (c) => actCalls.push({ ticket: c.ticket, category: "dirty-tree" }),
+        "stale-label": (c) => actCalls.push({ ticket: c.ticket, category: "stale-label" }),
+      },
+      escalate: (c) => escalateCalls.push({ ticket: c.ticket, phase: c.phase }),
+      emit: (type, fields) => {
+        events.push({ type, ...fields });
+        return Promise.resolve(true);
+      },
+      postComment: (ticket, category, phase) => {
+        commentCalls.push({ ticket, category, phase });
+      },
+      nowMs: typeof nowMs === "function" ? nowMs : (nowMs != null ? () => nowMs : undefined),
+    },
+  };
+}
+
+describe("CTL-1064 Pass 0u integration — mode=shadow", () => {
+  test("shadow emits would-clear-noise but does NOT act, record intent, or post comment", () => {
+    seedStall(TICKET_DIRTY, PHASE, "rebase_refused_dirty_tree");
+    const events = [];
+    const actCalls = [];
+    const commentCalls = [];
+    const candidates = [{
+      ticket: TICKET_DIRTY,
+      phase: PHASE,
+      evidence: { reason: "rebase_refused_dirty_tree", ticket: TICKET_DIRTY, phase: PHASE, liveSessionInWorktree: false, linearTerminal: false },
+    }];
+
+    const result = schedulerTick(orchDir, makeTickOpts({ mode: "shadow", events, actCalls, commentCalls, candidates }));
+
+    // shadow: would-* event emitted
+    const ev = events.find((e) => e.type === "unstuck.would.clear-noise");
+    expect(ev).toBeDefined();
+    expect(ev.ticket).toBe(TICKET_DIRTY);
+    // no act seam called
+    expect(actCalls).toHaveLength(0);
+    // no comment posted
+    expect(commentCalls).toHaveLength(0);
+    // tick report
+    expect(result.unstuckWouldAct).toHaveLength(1);
+    expect(result.unstuckWouldAct[0].ticket).toBe(TICKET_DIRTY);
+    expect(result.unstuckActed).toHaveLength(0);
+  });
+
+  test("shadow escalate path emits would-escalate but does NOT escalate or comment", () => {
+    seedStall(TICKET_UNKNOWN, PHASE, "some_unrecognized_reason");
+    const events = [];
+    const escalateCalls = [];
+    const commentCalls = [];
+    const candidates = [{
+      ticket: TICKET_UNKNOWN,
+      phase: PHASE,
+      evidence: { reason: "some_unrecognized_reason", ticket: TICKET_UNKNOWN, phase: PHASE, liveSessionInWorktree: false, linearTerminal: false },
+    }];
+
+    const result = schedulerTick(orchDir, makeTickOpts({ mode: "shadow", events, escalateCalls, commentCalls, candidates }));
+
+    const ev = events.find((e) => e.type === "unstuck.would.escalate");
+    expect(ev).toBeDefined();
+    expect(ev.ticket).toBe(TICKET_UNKNOWN);
+    expect(escalateCalls).toHaveLength(0);
+    expect(commentCalls).toHaveLength(0);
+    expect(result.unstuckWouldEscalate).toHaveLength(1);
+  });
+});
+
+describe("CTL-1064 Pass 0u integration — mode=enforce", () => {
+  test("enforce dirty-tree candidate: calls actByCategory, emits cleared-noise, posts comment, reports acted", () => {
+    seedStall(TICKET_DIRTY, PHASE, "rebase_refused_dirty_tree");
+    const events = [];
+    const actCalls = [];
+    const commentCalls = [];
+    const candidates = [{
+      ticket: TICKET_DIRTY,
+      phase: PHASE,
+      evidence: { reason: "rebase_refused_dirty_tree", ticket: TICKET_DIRTY, phase: PHASE, liveSessionInWorktree: false, linearTerminal: false },
+    }];
+
+    const result = schedulerTick(orchDir, makeTickOpts({ mode: "enforce", events, actCalls, commentCalls, candidates }));
+
+    // act seam called once
+    expect(actCalls).toHaveLength(1);
+    expect(actCalls[0]).toMatchObject({ ticket: TICKET_DIRTY, category: "dirty-tree" });
+    // enforce event emitted
+    const ev = events.find((e) => e.type === "unstuck.cleared.noise");
+    expect(ev).toBeDefined();
+    expect(ev.ticket).toBe(TICKET_DIRTY);
+    // comment posted
+    expect(commentCalls).toHaveLength(1);
+    expect(commentCalls[0].ticket).toBe(TICKET_DIRTY);
+    // tick report
+    expect(result.unstuckActed).toHaveLength(1);
+    expect(result.unstuckActed[0].ticket).toBe(TICKET_DIRTY);
+    expect(result.unstuckActed[0].category).toBe("dirty-tree");
+    expect(result.unstuckWouldAct).toHaveLength(0);
+  });
+
+  test("enforce unknown-reason candidate: calls escalate seam + emits escalated + posts comment", () => {
+    seedStall(TICKET_UNKNOWN, PHASE, "some_unrecognized_reason");
+    const events = [];
+    const escalateCalls = [];
+    const commentCalls = [];
+    const candidates = [{
+      ticket: TICKET_UNKNOWN,
+      phase: PHASE,
+      evidence: { reason: "some_unrecognized_reason", ticket: TICKET_UNKNOWN, phase: PHASE, liveSessionInWorktree: false, linearTerminal: false },
+    }];
+
+    const result = schedulerTick(orchDir, makeTickOpts({ mode: "enforce", events, escalateCalls, commentCalls, candidates }));
+
+    expect(escalateCalls).toHaveLength(1);
+    expect(escalateCalls[0].ticket).toBe(TICKET_UNKNOWN);
+    const ev = events.find((e) => e.type === "unstuck.escalated");
+    expect(ev).toBeDefined();
+    expect(ev.ticket).toBe(TICKET_UNKNOWN);
+    expect(commentCalls).toHaveLength(1);
+    expect(result.unstuckEscalated).toHaveLength(1);
+    expect(result.unstuckWouldEscalate).toHaveLength(0);
+  });
+
+  test("live-session candidate: classified as skip, no act, no event", () => {
+    const events = [];
+    const actCalls = [];
+    const candidates = [{
+      ticket: TICKET_DIRTY,
+      phase: PHASE,
+      evidence: { reason: "rebase_refused_dirty_tree", ticket: TICKET_DIRTY, phase: PHASE, liveSessionInWorktree: true, linearTerminal: false },
+    }];
+
+    const result = schedulerTick(orchDir, makeTickOpts({ mode: "enforce", events, actCalls, candidates }));
+
+    expect(actCalls).toHaveLength(0);
+    expect(events.filter((e) => e.type?.startsWith("unstuck."))).toHaveLength(0);
+    expect(result.unstuckActed).toHaveLength(0);
+  });
+
+  test("linear-terminal candidate: classified as skip, no act, no event", () => {
+    const events = [];
+    const actCalls = [];
+    const candidates = [{
+      ticket: TICKET_DIRTY,
+      phase: PHASE,
+      evidence: { reason: "rebase_refused_dirty_tree", ticket: TICKET_DIRTY, phase: PHASE, liveSessionInWorktree: false, linearTerminal: true },
+    }];
+
+    const result = schedulerTick(orchDir, makeTickOpts({ mode: "enforce", events, actCalls, candidates }));
+
+    expect(actCalls).toHaveLength(0);
+    expect(events.filter((e) => e.type?.startsWith("unstuck."))).toHaveLength(0);
+  });
+});
+
+describe("CTL-1064 Pass 0u integration — throttle guard", () => {
+  test("second tick within the throttle window skips the pass (census not called)", () => {
+    const events = [];
+    let censusCalls = 0;
+    const candidates = [{
+      ticket: TICKET_DIRTY,
+      phase: PHASE,
+      evidence: { reason: "rebase_refused_dirty_tree", ticket: TICKET_DIRTY, phase: PHASE, liveSessionInWorktree: false, linearTerminal: false },
+    }];
+    const opts = {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0, stdout: "", stderr: "" }),
+      exec: () => ({ code: null }),
+      reclaimDeadWork: () => ({ class: "alive-suppressed" }),
+      writeStatus: {
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+        runTransition: () => ({ applied: false }),
+      },
+      watchdog: { mode: "off" },
+      unstuckSweep: {
+        mode: "shadow",
+        intervalMs: 900_000, // 15-min throttle
+        collectCandidates: () => { censusCalls++; return candidates; },
+        emit: (type, fields) => { events.push({ type, ...fields }); return Promise.resolve(true); },
+        nowMs: () => Date.now(),
+      },
+    };
+
+    // Tick 1: should run (first run).
+    schedulerTick(orchDir, opts);
+    expect(censusCalls).toBe(1);
+
+    // Tick 2 immediately after: throttled — census must NOT be called again.
+    schedulerTick(orchDir, opts);
+    expect(censusCalls).toBe(1); // unchanged
+  });
+
+  test("tick outside the throttle window (elapsed > intervalMs) runs the pass again", () => {
+    let censusCalls = 0;
+    let fakeNow = 1_000_000;
+    const opts = {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0, stdout: "", stderr: "" }),
+      exec: () => ({ code: null }),
+      reclaimDeadWork: () => ({ class: "alive-suppressed" }),
+      writeStatus: {
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+        runTransition: () => ({ applied: false }),
+      },
+      watchdog: { mode: "off" },
+      unstuckSweep: {
+        mode: "shadow",
+        intervalMs: 60_000,
+        collectCandidates: () => { censusCalls++; return []; },
+        emit: () => Promise.resolve(true),
+        nowMs: () => fakeNow,
+      },
+    };
+
+    schedulerTick(orchDir, opts); // run at t=1_000_000
+    expect(censusCalls).toBe(1);
+
+    fakeNow += 60_001; // advance past the interval
+    schedulerTick(orchDir, opts);
+    expect(censusCalls).toBe(2);
+  });
+});
+
+describe("CTL-1064 Pass 0u integration — mode=off", () => {
+  test("mode=off: census never called, no events, no report entries", () => {
+    let censusCalls = 0;
+    const events = [];
+    const opts = {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0, stdout: "", stderr: "" }),
+      exec: () => ({ code: null }),
+      reclaimDeadWork: () => ({ class: "alive-suppressed" }),
+      writeStatus: {
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+        runTransition: () => ({ applied: false }),
+      },
+      watchdog: { mode: "off" },
+      unstuckSweep: {
+        mode: "off",
+        collectCandidates: () => { censusCalls++; return []; },
+        emit: (type, fields) => { events.push({ type, ...fields }); return Promise.resolve(true); },
+      },
+    };
+
+    const result = schedulerTick(orchDir, opts);
+
+    expect(censusCalls).toBe(0);
+    expect(events.filter((e) => e.type?.startsWith("unstuck."))).toHaveLength(0);
+    expect(result.unstuckActed).toHaveLength(0);
+    expect(result.unstuckWouldAct).toHaveLength(0);
+  });
+});
+
+describe("CTL-1064 Pass 0u integration — multiple candidates", () => {
+  test("two candidates in shadow → two would-* events (one dirty-tree, one escalate)", () => {
+    const events = [];
+    const candidates = [
+      {
+        ticket: "CTL-A",
+        phase: PHASE,
+        evidence: { reason: "rebase_refused_dirty_tree", ticket: "CTL-A", phase: PHASE, liveSessionInWorktree: false, linearTerminal: false },
+      },
+      {
+        ticket: "CTL-B",
+        phase: PHASE,
+        evidence: { reason: "some_unknown_reason", ticket: "CTL-B", phase: PHASE, liveSessionInWorktree: false, linearTerminal: false },
+      },
+    ];
+
+    const result = schedulerTick(orchDir, makeTickOpts({ mode: "shadow", events, candidates }));
+
+    expect(result.unstuckWouldAct).toHaveLength(1);
+    expect(result.unstuckWouldAct[0].ticket).toBe("CTL-A");
+    expect(result.unstuckWouldEscalate).toHaveLength(1);
+    expect(result.unstuckWouldEscalate[0].ticket).toBe("CTL-B");
+    expect(events.find((e) => e.type === "unstuck.would.clear-noise")).toBeDefined();
+    expect(events.find((e) => e.type === "unstuck.would.escalate")).toBeDefined();
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -81,7 +81,7 @@ import { readWorkerSignals } from "./signal-reader.mjs";
 // CTL-937: getBeliefsDb exposes the module-level db handle for the diagnostician.
 import { collectBeliefsTick, getBeliefsDb } from "./beliefs/collector.mjs";
 // CTL-1045 Bug 1: kill-storm suppression guard for defaultJanitorKillIntentRecorder.
-import { isIntentEffective, getMaxAttempts } from "./beliefs/intent.mjs";
+import { isIntentEffective, getMaxAttempts, recordIntent as recordIntentBelief } from "./beliefs/intent.mjs";
 // CTL-966 + CTL-935: the advancement shadow comparator — compares the procedural
 // deriveAdvancement oracle against the advance_to / cycle_exhausted beliefs and
 // logs disagreements. SHADOW ONLY (reads beliefs + computes oracle + logs; never
@@ -154,6 +154,18 @@ import {
   defaultCollectGhostCandidates,
   defaultCollectStallClearCandidates, // CTL-1005 J3
 } from "./stall-janitor.mjs";
+// CTL-1064: unstuck-sweep (Pass 0u) — throttled classify-then-act sweep for
+// the stalled/needs-human ticket backlog. Pure classifiers + action driver in
+// unstuck-sweep.mjs; census producers below. Mode='off' by default; operators
+// opt in via CATALYST_UNSTUCK_SWEEP=shadow then =enforce (or Layer-2 config).
+import {
+  runUnstuckSweepPass,
+  defaultCollectUnstuckCandidates,
+} from "./unstuck-sweep.mjs";
+import {
+  readUnstuckSweepConfig,
+  isThrottled,
+} from "./config.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
 // module (best-effort — every write swallows its own failures).
@@ -1281,7 +1293,15 @@ export function maybeEscalateRemediateExhausted(
   signals,
   verdict,
   cycleCount,
-  { writeFile = writeFileSync, readFile = readFileSync } = {}
+  {
+    writeFile = writeFileSync,
+    readFile = readFileSync,
+    // CTL-1064: optional seam to pre-compute the round-history summary so
+    // the unstuck-sweep's escalation comment has it available on the signal.
+    // Injected; undefined in production until a follow-up wires the real
+    // events/YYYY-MM.jsonl scanner (explicitly out of scope for this plan).
+    summarizeHistory = undefined,
+  } = {}
 ) {
   if (signals.verify !== "done" || verdict !== "fail" || cycleCount < REMEDIATE_CYCLE_CAP) {
     return false;
@@ -1290,6 +1310,10 @@ export function maybeEscalateRemediateExhausted(
   try {
     const cur = JSON.parse(readFile(p, "utf8"));
     if (cur.status === "stalled") return true; // idempotent
+    let remediateSummary;
+    if (typeof summarizeHistory === "function") {
+      try { remediateSummary = summarizeHistory(ticket); } catch { /* best-effort */ }
+    }
     writeFile(
       p,
       JSON.stringify({
@@ -1297,6 +1321,7 @@ export function maybeEscalateRemediateExhausted(
         status: "stalled",
         stalledReason: "remediate-cycle-cap-exhausted",
         updatedAt: new Date().toISOString(),
+        ...(remediateSummary !== undefined ? { remediateSummary } : {}),
       })
     );
   } catch {
@@ -2490,6 +2515,20 @@ export function schedulerTick(
       emit: _janitorEmit = emitReapIntent,
       recordKillIntent: _recordKillIntent = undefined,
     } = {},
+    // CTL-1064: unstuck-sweep seams (Pass 0u). Mode resolves from
+    // readUnstuckSweepConfig() (env > Layer-2 > 'off') unless overridden.
+    // Defaults keep a bare tick fully inert — no census means nothing runs.
+    // Production wires the real census + act seams via startScheduler.
+    unstuckSweep: {
+      mode: _unstuckMode = undefined,
+      intervalMs: _unstuckIntervalMs = undefined,
+      collectCandidates: _collectUnstuckCandidates = undefined,
+      actByCategory: _unstuckActByCategory = undefined,
+      escalate: _unstuckEscalate = undefined,
+      emit: _unstuckEmit = emitReapIntent,
+      postComment: _unstuckPostComment = undefined,
+      nowMs: _unstuckNowMs = undefined,
+    } = {},
     // CTL-936: closed-loop intent layer. When an open beliefs.db handle is
     // provided, kill actions in reclaimDeadWork are recorded as intents and
     // suppressed once ineffective. Default null → legacy behavior (all existing
@@ -2882,6 +2921,11 @@ export function schedulerTick(
   let janitorDeferred = [];
   let janitorStallsCleared = [];
   let janitorWouldClear = [];
+  // CTL-1064: Pass 0u report arrays (populated below if the pass runs).
+  let unstuckActed = [];
+  let unstuckWouldAct = [];
+  let unstuckEscalated = [];
+  let unstuckWouldEscalate = [];
   {
     const jcfg = readStallJanitorConfig();
     const jMode = _janitorMode ?? jcfg.mode;
@@ -2942,6 +2986,79 @@ export function schedulerTick(
         log.warn(
           { step: "stall-janitor", err: err.message },
           "scheduler: stall-janitor pass failed — continuing tick (CTL-1004)"
+        );
+      }
+    }
+  }
+
+  // CTL-1064: Pass 0u — throttled unstuck-sweep. Low-frequency (default 15 min)
+  // classify-then-act pass over the stalled/needs-human ticket backlog. A bare tick
+  // has no census producer → skip cleanly. Mode='off' by default; operators opt in
+  // via env (CATALYST_UNSTUCK_SWEEP=shadow / =enforce) or Layer-2 config.
+  {
+    const ucfg = readUnstuckSweepConfig();
+    const uMode = _unstuckMode ?? ucfg.mode;
+    const uIntervalMs = _unstuckIntervalMs ?? ucfg.intervalMs;
+    const nowMs = typeof _unstuckNowMs === "function" ? _unstuckNowMs() : Date.now();
+    if (
+      uMode !== "off" &&
+      _collectUnstuckCandidates &&
+      !isThrottled(_unstuckLastRunMs, uIntervalMs, nowMs)
+    ) {
+      _unstuckLastRunMs = nowMs;
+      try {
+        const ureport = runUnstuckSweepPass({
+          mode: uMode,
+          collectCandidates: _collectUnstuckCandidates,
+          actByCategory: _unstuckActByCategory ?? {},
+          escalate: _unstuckEscalate ?? (() => {}),
+          emit: _unstuckEmit,
+          recordIntent: intentDb
+            ? (kind, subject) => {
+                try {
+                  recordIntentBelief(intentDb, {
+                    tickId: null,
+                    kind,
+                    subject,
+                    postcondition: { kind: "unstuck-sweep", subject },
+                  });
+                } catch { /* best-effort */ }
+              }
+            : () => {},
+          isIntentEffective: intentDb
+            ? (kind, subject) => {
+                try {
+                  return !isIntentEffective(intentDb, kind, subject, { maxAttempts: getMaxAttempts(intentDb) });
+                } catch { return false; }
+              }
+            : () => false,
+          postComment: _unstuckPostComment ?? (() => {}),
+        });
+        unstuckActed = ureport.acted;
+        unstuckWouldAct = ureport.wouldAct;
+        unstuckEscalated = ureport.escalated;
+        unstuckWouldEscalate = ureport.wouldEscalate;
+        if (
+          ureport.acted.length || ureport.wouldAct.length ||
+          ureport.escalated.length || ureport.wouldEscalate.length
+        ) {
+          log.info(
+            {
+              mode: uMode,
+              acted: ureport.acted.length,
+              wouldAct: ureport.wouldAct.length,
+              escalated: ureport.escalated.length,
+              wouldEscalate: ureport.wouldEscalate.length,
+              skipped: ureport.skipped.length,
+              failed: ureport.failed.length,
+            },
+            "scheduler: unstuck-sweep pass (CTL-1064)"
+          );
+        }
+      } catch (err) {
+        log.warn(
+          { step: "unstuck-sweep", err: err.message },
+          "scheduler: unstuck-sweep pass failed — continuing tick (CTL-1064)"
         );
       }
     }
@@ -4329,6 +4446,10 @@ export function schedulerTick(
     janitorDeferred,     // CTL-1004 — dirty worktrees deferred (no removal, no queue)
     janitorStallsCleared, // CTL-1005 — prior-artifact-retry-exhausted stalls CLEARED this tick (enforce)
     janitorWouldClear,   // CTL-1005 — stalls that WOULD be cleared (shadow)
+    unstuckActed,        // CTL-1064 — Pass 0u actions taken this tick (enforce)
+    unstuckWouldAct,     // CTL-1064 — Pass 0u would-act (shadow)
+    unstuckEscalated,    // CTL-1064 — Pass 0u escalations this tick (enforce)
+    unstuckWouldEscalate, // CTL-1064 — Pass 0u would-escalate (shadow)
     advanced,
     dispatched,
     freeSlots,
@@ -4407,6 +4528,11 @@ const observedYieldFiles = new Set();
 // An admitted/cleared ticket is deleted so a future re-hold re-emits. Cleared on
 // daemon restart (via __resetForTests).
 const lastHeldEmitState = new Map();
+
+// CTL-1064: Pass 0u throttle — epoch-ms of the last unstuck-sweep run.
+// Module-level so the 15-min gate persists across ticks without a db write.
+// Reset to 0 on daemon restart (module reload) or via __resetForTests.
+let _unstuckLastRunMs = 0;
 
 function runTick() {
   try {
@@ -4649,6 +4775,30 @@ function runTick() {
           }),
         clearStall: defaultClearStall(runningOpts.orchDir, runningOpts.writeStatus ?? linearWrite),
       },
+      // CTL-1064: wire the unstuck-sweep census (Pass 0u). The census collects
+      // stalled/failed workers lazily; the pass only runs when mode !== 'off'
+      // AND the 15-min throttle window has elapsed. Mode defaults to 'off' so
+      // a plain startScheduler caller gets a fully inert pass unless explicitly
+      // opted in via env (CATALYST_UNSTUCK_SWEEP=shadow / =enforce) or Layer-2.
+      unstuckSweep: runningOpts.unstuckSweep ?? {
+        collectCandidates: () =>
+          defaultCollectUnstuckCandidates({
+            orchDir: runningOpts.orchDir,
+            agentsSnapshot: getAgentsCached().agents,
+            isLinearTerminal: (id) => {
+              const state = fetchTicketState(id);
+              return state != null && isLinearTerminal(state);
+            },
+          }),
+        // actByCategory: production seams undefined → no-op (escalate handles
+        // all whitelisted categories in the initial shadow rollout). Operators
+        // enable per-category enforcement via Layer-2 config.
+        actByCategory: runningOpts.unstuckActByCategory ?? {},
+        // postComment: defaultPostUnstuckComment closure over orchDir.
+        postComment: typeof runningOpts.unstuckPostComment === "function"
+          ? runningOpts.unstuckPostComment
+          : undefined,
+      },
     });
     // CTL-863: host-death takeover sweep — complement to worker-death reclaim.
     // Skip entirely on single-host installs (no-op inside the function, but the
@@ -4814,6 +4964,7 @@ export function __resetForTests() {
   stopScheduler();
   observedYieldFiles.clear(); // CTL-702: reset per-lifetime dedup set between tests
   lastHeldEmitState.clear(); // CTL-755: reset held-event only-on-change dedup
+  _unstuckLastRunMs = 0; // CTL-1064: reset Pass 0u throttle between tests
   // rankedAboveSince is cleared by stopScheduler above (CTL-705)
 }
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -161,6 +161,7 @@ import {
 import {
   runUnstuckSweepPass,
   defaultCollectUnstuckCandidates,
+  emitUnstuckEvent,
 } from "./unstuck-sweep.mjs";
 import {
   readUnstuckSweepConfig,
@@ -2525,7 +2526,12 @@ export function schedulerTick(
       collectCandidates: _collectUnstuckCandidates = undefined,
       actByCategory: _unstuckActByCategory = undefined,
       escalate: _unstuckEscalate = undefined,
-      emit: _unstuckEmit = emitReapIntent,
+      // CTL-1064: the unstuck sweep's emit seam MUST be emitUnstuckEvent, NOT
+      // emitReapIntent — the latter's closed vocabulary excludes unstuck.* and
+      // throws, and the fire-and-forget path swallowed the rejection, silently
+      // dropping every unstuck event. emitUnstuckEvent validates against the
+      // sweep's own vocabulary and appends to the same unified log.
+      emit: _unstuckEmit = emitUnstuckEvent,
       postComment: _unstuckPostComment = undefined,
       nowMs: _unstuckNowMs = undefined,
     } = {},
@@ -3016,8 +3022,24 @@ export function schedulerTick(
           recordIntent: intentDb
             ? (kind, subject) => {
                 try {
+                  // Dedup: skip the INSERT when an open intent already exists for
+                  // this kind/subject (mirrors the stall-janitor recorder at
+                  // scheduler.mjs:2199-2206). Without this, every pass would insert
+                  // a duplicate intent row for the same subject (CTL-1064).
+                  const open = intentDb
+                    .query("SELECT 1 FROM intent WHERE kind = ? AND subject = ? AND outcome IS NULL LIMIT 1")
+                    .get(kind, subject);
+                  if (open) return;
+                  // intent.tick_id is NOT NULL — the prior tickId:null always
+                  // failed the insert (the intent was never recorded, so the gate
+                  // never suppressed re-acting). Anchor to the latest tick row,
+                  // exactly as the stall-janitor recorder does (CTL-1064).
+                  const tickRow = intentDb
+                    .query("SELECT tick_id FROM tick ORDER BY tick_id DESC LIMIT 1")
+                    .get();
+                  if (!tickRow) return; // no tick yet → cannot anchor the intent
                   recordIntentBelief(intentDb, {
-                    tickId: null,
+                    tickId: tickRow.tick_id,
                     kind,
                     subject,
                     postcondition: { kind: "unstuck-sweep", subject },
@@ -3025,10 +3047,22 @@ export function schedulerTick(
                 } catch { /* best-effort */ }
               }
             : () => {},
+          // CTL-1064: the driver gate is act-once-then-skip (unstuck-sweep.mjs:257
+          // — true = an open intent already exists → skip). That is NOT
+          // isIntentEffective's semantics: isIntentEffective returns true for a
+          // FRESH subject with no intent (viable channel), which would skip the
+          // very first act; the prior `!isIntentEffective` instead returned false
+          // while open-under-cap, RE-ACTING every pass until the cap. Probe for an
+          // open intent directly so pass 1 acts (no open row yet) and every later
+          // pass skips while the intent stays open — pairs with the recordIntent
+          // dedup above (same `outcome IS NULL` predicate).
           isIntentEffective: intentDb
             ? (kind, subject) => {
                 try {
-                  return !isIntentEffective(intentDb, kind, subject, { maxAttempts: getMaxAttempts(intentDb) });
+                  const open = intentDb
+                    .query("SELECT 1 FROM intent WHERE kind = ? AND subject = ? AND outcome IS NULL LIMIT 1")
+                    .get(kind, subject);
+                  return open != null;
                 } catch { return false; }
               }
             : () => false,
@@ -4789,12 +4823,34 @@ function runTick() {
               const state = fetchTicketState(id);
               return state != null && isLinearTerminal(state);
             },
+            // CTL-1064: thread the worktree resolver from each worker's signal so
+            // the live-session gate (unstuck-sweep.mjs:118) and the classifier's
+            // live-session short-circuit are reachable in production. Without it
+            // resolveWorktreePath defaulted to () => null and worktreePath was
+            // always null, making the live-session skip dead (a latent footgun
+            // once act seams are enabled). Mirrors the prAdapter closure below.
+            resolveWorktreePath: (ticket) => {
+              for (const sig of readWorkerSignals(runningOpts.orchDir)) {
+                if (sig.ticket === ticket && sig.worktreePath) return sig.worktreePath;
+              }
+              return null;
+            },
           }),
         // actByCategory: production seams undefined → no-op (escalate handles
         // all whitelisted categories in the initial shadow rollout). Operators
-        // enable per-category enforcement via Layer-2 config.
+        // enable per-category enforcement via Layer-2 config. Pass 0u ships
+        // shadow-/escalate-only: catA-D mechanical enforcement is DEFERRED and
+        // actByCategory:{} is an intentional no-op (no real act seams exist yet).
         actByCategory: runningOpts.unstuckActByCategory ?? {},
-        // postComment: defaultPostUnstuckComment closure over orchDir.
+        // emit: the dedicated unstuck unified-log emitter (NOT emitReapIntent,
+        // whose closed vocabulary throws on unstuck.* — CTL-1064). Explicit here
+        // so the production wiring does not silently depend on the schedulerTick
+        // default.
+        emit: emitUnstuckEvent,
+        // postComment: intentionally unwired in this rollout (no Linear audit
+        // comment) unless an operator injects runningOpts.unstuckPostComment —
+        // defaultPostUnstuckComment is NOT closed over orchDir here. Mirrors the
+        // intentional actByCategory no-op above.
         postComment: typeof runningOpts.unstuckPostComment === "function"
           ? runningOpts.unstuckPostComment
           : undefined,

--- a/plugins/dev/scripts/execution-core/unstuck-orphan-merge.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-orphan-merge.mjs
@@ -1,0 +1,128 @@
+// unstuck-orphan-merge.mjs — CTL-1064 Category C pure classifier.
+//
+// Classifies an orphan-sweep-stale signal as 'emit-complete' ONLY when the PR is
+// verifiably MERGED per injected REST evidence AND the late-phase signal's bg job
+// is dead/null AND no once-marker guards a prior emit AND .terminal-done.applied is
+// absent (disjoint from J1). The REST call lives in the census (injected
+// resolvePrState), never in the pure classifier.
+//
+// The act seam (Phase 7 scheduler-side) emits a synthetic phase-complete event so
+// teardown proceeds.
+
+// STALE_WORKER_CUTOFF_MS — a signal updated within this window is considered fresh
+// and may still have a live worker even if bg_job_id appears dead. 300 seconds.
+export const STALE_WORKER_CUTOFF_MS = 300_000;
+
+// classifyOrphanMergedReconcile — PURE classifier. No IO.
+// evidence shape:
+//   ticket               string
+//   phase                string  (typically 'monitor-merge')
+//   prState              string|null  ('MERGED'|'OPEN'|'CLOSED'|null)
+//   bgJobAlive           bool    (true = a live bg job for this signal)
+//   signalUpdatedAt      number|null  (epoch-ms of signal's updatedAt, or null)
+//   nowMs                number  (current epoch-ms, injected for testability)
+//   alreadyEmitted       bool    (.unstuck-orphan-merge-<phase>.applied present)
+//   terminalDoneApplied  bool    (.terminal-done.applied present — teardown owns it)
+//   linearTerminal       bool
+//
+// Returns { action: 'emit-complete' } or { action: 'skip', reason }
+export function classifyOrphanMergedReconcile(evidence = {}) {
+  const {
+    prState,
+    bgJobAlive,
+    signalUpdatedAt,
+    nowMs,
+    alreadyEmitted,
+    terminalDoneApplied,
+    linearTerminal,
+  } = evidence;
+
+  // .terminal-done.applied present → teardown already owns this ticket; skip.
+  if (terminalDoneApplied) return { action: "skip", reason: "terminal-done-owns-it" };
+  // linearTerminal → skip (ticket is already in a terminal state).
+  if (linearTerminal) return { action: "skip", reason: "linear-terminal" };
+  // alreadyEmitted marker → idempotent skip.
+  if (alreadyEmitted) return { action: "skip", reason: "already-emitted" };
+
+  // Fail-closed: null/undefined prState → we have no evidence the PR merged.
+  // Missing evidence is never treated as MERGED.
+  if (!prState) return { action: "skip", reason: "pr-state-unknown" };
+
+  // PR must be in MERGED state.
+  if (prState !== "MERGED") return { action: "skip", reason: "pr-not-merged" };
+
+  // bg job alive → the worker is still running; let it finish naturally.
+  if (bgJobAlive) return { action: "skip", reason: "bg-job-alive" };
+
+  // Signal is fresh (within cutoff) → may still transition naturally; skip.
+  if (signalUpdatedAt != null && nowMs != null) {
+    const elapsedMs = nowMs - signalUpdatedAt;
+    if (elapsedMs < STALE_WORKER_CUTOFF_MS) {
+      return { action: "skip", reason: "signal-fresh" };
+    }
+  }
+
+  return { action: "emit-complete" };
+}
+
+// defaultCollectOrphanMergedCandidates — census with injected seams.
+// Filters candidates to those with reason 'orphan-sweep-stale', resolves PR state
+// and bg-job liveness via injected seams. Fail-closed: resolvePrState throw →
+// candidate.prState = null (skip).
+export function defaultCollectOrphanMergedCandidates({
+  candidates = [],       // from defaultCollectUnstuckCandidates
+  resolvePrState = null, // (ticket) → 'MERGED'|'OPEN'|'CLOSED'|null (async ok)
+  jobLifecycle = null,   // (bgJobId) → bool (is the bg job alive)
+  nowMs = Date.now(),
+  phaseAllowlist = ["monitor-merge", "monitor-deploy"],
+} = {}) {
+  const out = [];
+  for (const c of candidates) {
+    try {
+      if (c.evidence?.reason !== "orphan-sweep-stale") continue;
+      if (!phaseAllowlist.includes(c.phase)) continue;
+
+      // Resolve PR state — fail-closed on error
+      let prState = null;
+      try {
+        const result = resolvePrState ? resolvePrState(c.ticket) : null;
+        if (result && typeof result.then === "function") {
+          // Synchronous-only in tests; async usage is the caller's responsibility
+          prState = null; // treat async as unavailable in sync path
+        } else {
+          prState = result;
+        }
+      } catch { prState = null; }
+
+      // Resolve bg-job liveness
+      const bgJobId = c.signal?.bg_job_id ?? null;
+      let bgJobAlive = false;
+      try {
+        bgJobAlive = bgJobId != null && jobLifecycle ? jobLifecycle(bgJobId) : false;
+      } catch { bgJobAlive = false; }
+
+      // Parse signal updatedAt to epoch-ms
+      let signalUpdatedAt = null;
+      try {
+        const ua = c.signal?.updatedAt;
+        if (ua) signalUpdatedAt = new Date(ua).getTime();
+      } catch { signalUpdatedAt = null; }
+
+      out.push({
+        ...c,
+        evidence: {
+          ...c.evidence,
+          prState,
+          bgJobAlive,
+          signalUpdatedAt,
+          nowMs,
+          alreadyEmitted: false, // caller sets from marker file
+          terminalDoneApplied: false, // caller sets from marker file
+        },
+      });
+    } catch {
+      // per-candidate error: skip, no throw
+    }
+  }
+  return out;
+}

--- a/plugins/dev/scripts/execution-core/unstuck-orphan-merge.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-orphan-merge.test.mjs
@@ -1,0 +1,168 @@
+// unstuck-orphan-merge.test.mjs — CTL-1064 Category C classifier tests.
+
+import { describe, test, expect } from "bun:test";
+import {
+  classifyOrphanMergedReconcile,
+  defaultCollectOrphanMergedCandidates,
+  STALE_WORKER_CUTOFF_MS,
+} from "./unstuck-orphan-merge.mjs";
+
+const NOW = 1_700_000_000_000; // fixed epoch-ms for tests
+const STALE_UPDATED_AT = NOW - STALE_WORKER_CUTOFF_MS - 1000; // definitely stale
+
+const BASE = {
+  ticket: "CTL-MERGED",
+  phase: "monitor-merge",
+  prState: "MERGED",
+  bgJobAlive: false,
+  signalUpdatedAt: STALE_UPDATED_AT,
+  nowMs: NOW,
+  alreadyEmitted: false,
+  terminalDoneApplied: false,
+  linearTerminal: false,
+};
+
+// ---------------------------------------------------------------------------
+// classifyOrphanMergedReconcile — pure classifier
+// ---------------------------------------------------------------------------
+describe("classifyOrphanMergedReconcile — pure classifier (CTL-1064 catC)", () => {
+  test("PR MERGED + bg dead + not already emitted + no .terminal-done → emit-complete", () => {
+    expect(classifyOrphanMergedReconcile(BASE).action).toBe("emit-complete");
+  });
+
+  test("PR OPEN → skip/pr-not-merged", () => {
+    const r = classifyOrphanMergedReconcile({ ...BASE, prState: "OPEN" });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("pr-not-merged");
+  });
+
+  test("PR CLOSED → skip/pr-not-merged", () => {
+    const r = classifyOrphanMergedReconcile({ ...BASE, prState: "CLOSED" });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("pr-not-merged");
+  });
+
+  test("PR MERGED but bg alive → skip/bg-job-alive", () => {
+    const r = classifyOrphanMergedReconcile({ ...BASE, bgJobAlive: true });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("bg-job-alive");
+  });
+
+  test("PR MERGED + bg dead but signal fresh (within cutoff) → skip/signal-fresh", () => {
+    const freshUpdatedAt = NOW - 1000; // just 1 second ago
+    const r = classifyOrphanMergedReconcile({ ...BASE, signalUpdatedAt: freshUpdatedAt });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("signal-fresh");
+  });
+
+  test("PR MERGED + bg_job_id:null + stale → emit-complete (null counts as dead)", () => {
+    const r = classifyOrphanMergedReconcile({ ...BASE, bgJobAlive: false });
+    expect(r.action).toBe("emit-complete");
+  });
+
+  test("alreadyEmitted → skip/already-emitted", () => {
+    const r = classifyOrphanMergedReconcile({ ...BASE, alreadyEmitted: true });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("already-emitted");
+  });
+
+  test("prState null → skip (fail-closed — missing evidence never treated as merged)", () => {
+    const r = classifyOrphanMergedReconcile({ ...BASE, prState: null });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("pr-state-unknown");
+  });
+
+  test("prState undefined → skip (fail-closed)", () => {
+    const r = classifyOrphanMergedReconcile({ ...BASE, prState: undefined });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("pr-state-unknown");
+  });
+
+  test("linearTerminal → skip/linear-terminal", () => {
+    const r = classifyOrphanMergedReconcile({ ...BASE, linearTerminal: true });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("linear-terminal");
+  });
+
+  test(".terminal-done.applied present → skip (teardown owns it)", () => {
+    const r = classifyOrphanMergedReconcile({ ...BASE, terminalDoneApplied: true });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("terminal-done-owns-it");
+  });
+
+  test("terminalDoneApplied takes precedence over linearTerminal", () => {
+    const r = classifyOrphanMergedReconcile({ ...BASE, terminalDoneApplied: true, linearTerminal: true });
+    expect(r.reason).toBe("terminal-done-owns-it");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultCollectOrphanMergedCandidates — census
+// ---------------------------------------------------------------------------
+describe("defaultCollectOrphanMergedCandidates — census (CTL-1064 catC)", () => {
+  function makeCandidate(overrides = {}) {
+    return {
+      ticket: "CTL-MERGED",
+      phase: "monitor-merge",
+      signal: { ticket: "CTL-MERGED", phase: "monitor-merge", status: "failed", failureReason: "orphan-sweep-stale", bg_job_id: "abc123", updatedAt: new Date(STALE_UPDATED_AT).toISOString() },
+      workerDir: "/fake/orch/workers/CTL-MERGED",
+      evidence: {
+        reason: "orphan-sweep-stale",
+        ticket: "CTL-MERGED",
+        phase: "monitor-merge",
+        liveSessionInWorktree: false,
+        linearTerminal: false,
+      },
+      ...overrides,
+    };
+  }
+
+  test("normalizes orphan-sweep-stale candidate with PR MERGED + dead bg", () => {
+    const candidates = defaultCollectOrphanMergedCandidates({
+      candidates: [makeCandidate()],
+      resolvePrState: () => "MERGED",
+      jobLifecycle: () => false,
+      nowMs: NOW,
+    });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].evidence.prState).toBe("MERGED");
+    expect(candidates[0].evidence.bgJobAlive).toBe(false);
+  });
+
+  test("skips candidates with wrong reason", () => {
+    const c = makeCandidate();
+    c.evidence.reason = "rebase_refused_dirty_tree";
+    const candidates = defaultCollectOrphanMergedCandidates({ candidates: [c], nowMs: NOW });
+    expect(candidates).toHaveLength(0);
+  });
+
+  test("skips candidates not in phaseAllowlist", () => {
+    const c = makeCandidate({ phase: "implement" });
+    c.evidence.phase = "implement";
+    const candidates = defaultCollectOrphanMergedCandidates({ candidates: [c], nowMs: NOW });
+    expect(candidates).toHaveLength(0);
+  });
+
+  test("resolvePrState throw → candidate.prState=null (fail-closed)", () => {
+    const candidates = defaultCollectOrphanMergedCandidates({
+      candidates: [makeCandidate()],
+      resolvePrState: () => { throw new Error("API unavailable"); },
+      nowMs: NOW,
+    });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].evidence.prState).toBeNull();
+  });
+
+  test("per-candidate catch: a seam throw on one ticket does not abort others", () => {
+    const bad = makeCandidate({ ticket: "CTL-BAD" });
+    bad.evidence = null; // will cause a throw when accessing .reason
+    const good = makeCandidate({ ticket: "CTL-GOOD" });
+    const candidates = defaultCollectOrphanMergedCandidates({
+      candidates: [bad, good],
+      resolvePrState: () => "MERGED",
+      nowMs: NOW,
+    });
+    // bad skipped, good passes
+    expect(candidates.some(c => c.ticket === "CTL-GOOD")).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/unstuck-stale-label.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-stale-label.mjs
@@ -1,0 +1,93 @@
+// unstuck-stale-label.mjs — CTL-1064 Category D pure classifier.
+//
+// Classifies a terminal (Canceled/Duplicate/Done) ticket that still carries an
+// attention label (needs-human / blocked / waiting) as 'clear-label'. Uses
+// gateway.listLabeledTickets (NOT listStartedTickets, which excludes terminal
+// tickets — the documented enumeration gap). The act seam delegates to
+// clearStalledLabel (label-guard.mjs:124), which removes the Linear label AND
+// deletes both .linear-label-<label>.applied/.skipped markers together —
+// closing the suppression trap.
+
+// ATTENTION_LABELS — the three attention labels the sweep can clear from
+// terminal tickets. Keep in sync with deriveAttention (orch-monitor/board-data.mjs).
+export const ATTENTION_LABELS = Object.freeze(["needs-human", "blocked", "waiting"]);
+
+// TERMINAL_LINEAR_STATES — ticket states in which stale labels should be cleared.
+export const TERMINAL_LINEAR_STATES = Object.freeze(["Canceled", "Duplicate", "Done"]);
+
+// classifyTerminalStaleLabel — PURE. No IO.
+// evidence shape:
+//   linearState    string|null    (Linear state name)
+//   attentionLabels string[]      (labels currently on the ticket)
+//   ticket         string
+//
+// Returns:
+//   { action: 'clear-label', label } — terminal state + attention label found
+//   { action: 'skip', reason }       — not terminal, no label, unknown state
+export function classifyTerminalStaleLabel(evidence = {}) {
+  const { linearState, attentionLabels } = evidence;
+
+  // Fail-closed: null/unknown state → skip (we must be certain the ticket is terminal).
+  if (!linearState || !TERMINAL_LINEAR_STATES.includes(linearState)) {
+    return { action: "skip", reason: "not-terminal" };
+  }
+
+  // Find the first attention label on this ticket.
+  if (!Array.isArray(attentionLabels) || attentionLabels.length === 0) {
+    return { action: "skip", reason: "no-attention-label" };
+  }
+  const label = attentionLabels.find((l) => ATTENTION_LABELS.includes(l));
+  if (!label) {
+    return { action: "skip", reason: "no-attention-label" };
+  }
+
+  return { action: "clear-label", label };
+}
+
+// collectTerminalStaleLabelCandidates — census with injected Linear seams.
+// Queries attention-labeled tickets directly (NOT listStartedTickets).
+// Expands multi-label tickets into one candidate per attention label.
+// Per-candidate catch: a seam throw on one ticket does not abort the rest.
+export function collectTerminalStaleLabelCandidates({
+  listLabeledTickets = () => [],  // () → [{ticket, labels:string[], linearState:string|null}]
+  resolveLinearState = null,      // optional: (ticket) → string|null (override if not in struct)
+} = {}) {
+  const out = [];
+  let labeled;
+  try {
+    labeled = listLabeledTickets() ?? [];
+  } catch {
+    return out;
+  }
+
+  for (const item of labeled) {
+    try {
+      const ticket = item.ticket ?? item.id ?? item.identifier;
+      if (!ticket) continue;
+
+      const labels = Array.isArray(item.labels) ? item.labels : [];
+      const linearState = item.linearState ?? (resolveLinearState ? resolveLinearState(ticket) : null);
+
+      // Expand into one candidate per attention label.
+      for (const label of labels) {
+        if (!ATTENTION_LABELS.includes(label)) continue;
+        out.push({
+          ticket,
+          phase: "none",    // stale labels are not phase-specific
+          isStaleLabel: true,
+          evidence: {
+            ticket,
+            phase: "none",
+            linearState,
+            attentionLabels: [label], // one label per candidate (expanded)
+            liveSessionInWorktree: false,
+            linearTerminal: TERMINAL_LINEAR_STATES.includes(linearState),
+          },
+        });
+      }
+    } catch {
+      // per-candidate error: skip, no throw
+    }
+  }
+  return out;
+}

--- a/plugins/dev/scripts/execution-core/unstuck-stale-label.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-stale-label.test.mjs
@@ -1,0 +1,163 @@
+// unstuck-stale-label.test.mjs — CTL-1064 Category D classifier tests.
+
+import { describe, test, expect } from "bun:test";
+import {
+  classifyTerminalStaleLabel,
+  collectTerminalStaleLabelCandidates,
+  ATTENTION_LABELS,
+  TERMINAL_LINEAR_STATES,
+} from "./unstuck-stale-label.mjs";
+
+// ---------------------------------------------------------------------------
+// classifyTerminalStaleLabel — pure classifier
+// ---------------------------------------------------------------------------
+describe("classifyTerminalStaleLabel (CTL-1064 catD)", () => {
+  test("Canceled + needs-human → clear-label", () => {
+    const r = classifyTerminalStaleLabel({ linearState: "Canceled", attentionLabels: ["needs-human"], ticket: "CTL-X" });
+    expect(r.action).toBe("clear-label");
+    expect(r.label).toBe("needs-human");
+  });
+
+  test("Duplicate + needs-human → clear-label", () => {
+    const r = classifyTerminalStaleLabel({ linearState: "Duplicate", attentionLabels: ["needs-human"] });
+    expect(r.action).toBe("clear-label");
+    expect(r.label).toBe("needs-human");
+  });
+
+  test("Done + blocked → clear-label", () => {
+    const r = classifyTerminalStaleLabel({ linearState: "Done", attentionLabels: ["blocked"] });
+    expect(r.action).toBe("clear-label");
+    expect(r.label).toBe("blocked");
+  });
+
+  test("Done + waiting → clear-label", () => {
+    const r = classifyTerminalStaleLabel({ linearState: "Done", attentionLabels: ["waiting"] });
+    expect(r.action).toBe("clear-label");
+    expect(r.label).toBe("waiting");
+  });
+
+  test("In Progress + needs-human → skip (not terminal)", () => {
+    const r = classifyTerminalStaleLabel({ linearState: "In Progress", attentionLabels: ["needs-human"] });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("not-terminal");
+  });
+
+  test("Todo + needs-human → skip (not terminal)", () => {
+    const r = classifyTerminalStaleLabel({ linearState: "Todo", attentionLabels: ["needs-human"] });
+    expect(r.action).toBe("skip");
+  });
+
+  test("terminal + no attention label → skip/no-attention-label", () => {
+    const r = classifyTerminalStaleLabel({ linearState: "Canceled", attentionLabels: [] });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("no-attention-label");
+  });
+
+  test("terminal + empty array → skip/no-attention-label", () => {
+    const r = classifyTerminalStaleLabel({ linearState: "Done", attentionLabels: [] });
+    expect(r.action).toBe("skip");
+  });
+
+  test("terminal + non-array → skip/no-attention-label", () => {
+    const r = classifyTerminalStaleLabel({ linearState: "Canceled", attentionLabels: null });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("no-attention-label");
+  });
+
+  test("unknown linearState + attention label → skip (fail-closed)", () => {
+    const r = classifyTerminalStaleLabel({ linearState: "Some Unknown State", attentionLabels: ["needs-human"] });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("not-terminal");
+  });
+
+  test("null linearState → skip (fail-closed)", () => {
+    const r = classifyTerminalStaleLabel({ linearState: null, attentionLabels: ["needs-human"] });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("not-terminal");
+  });
+
+  test("terminal with multiple labels → first matching attention label returned", () => {
+    const r = classifyTerminalStaleLabel({ linearState: "Done", attentionLabels: ["unrelated", "needs-human", "blocked"] });
+    expect(r.action).toBe("clear-label");
+    expect(r.label).toBe("needs-human");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectTerminalStaleLabelCandidates — census
+// ---------------------------------------------------------------------------
+describe("collectTerminalStaleLabelCandidates (CTL-1064 catD census)", () => {
+  test("empty listLabeledTickets → no writes (steady-state-zero)", () => {
+    const out = collectTerminalStaleLabelCandidates({ listLabeledTickets: () => [] });
+    expect(out).toHaveLength(0);
+  });
+
+  test("Canceled ticket with needs-human → one candidate", () => {
+    const out = collectTerminalStaleLabelCandidates({
+      listLabeledTickets: () => [
+        { ticket: "CTL-CANCEL", labels: ["needs-human"], linearState: "Canceled" },
+      ],
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].ticket).toBe("CTL-CANCEL");
+    expect(out[0].evidence.attentionLabels).toEqual(["needs-human"]);
+    expect(out[0].isStaleLabel).toBe(true);
+  });
+
+  test("multi-label ticket → one candidate per attention label", () => {
+    const out = collectTerminalStaleLabelCandidates({
+      listLabeledTickets: () => [
+        { ticket: "CTL-MULTI", labels: ["needs-human", "blocked"], linearState: "Canceled" },
+      ],
+    });
+    expect(out).toHaveLength(2);
+    expect(out.map(c => c.evidence.attentionLabels[0]).sort()).toEqual(["blocked", "needs-human"]);
+  });
+
+  test("non-attention label ignored", () => {
+    const out = collectTerminalStaleLabelCandidates({
+      listLabeledTickets: () => [
+        { ticket: "CTL-NOLABEL", labels: ["some-other-label"], linearState: "Canceled" },
+      ],
+    });
+    expect(out).toHaveLength(0);
+  });
+
+  test("a seam throw on one ticket does not abort the rest", () => {
+    let callCount = 0;
+    const out = collectTerminalStaleLabelCandidates({
+      listLabeledTickets: () => [
+        null,  // will throw when accessing .ticket
+        { ticket: "CTL-OK", labels: ["needs-human"], linearState: "Canceled" },
+      ],
+    });
+    expect(out.some(c => c.ticket === "CTL-OK")).toBe(true);
+  });
+
+  test("listLabeledTickets throws → returns empty (never throws)", () => {
+    const out = collectTerminalStaleLabelCandidates({
+      listLabeledTickets: () => { throw new Error("Linear API failed"); },
+    });
+    expect(out).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+describe("ATTENTION_LABELS / TERMINAL_LINEAR_STATES (CTL-1064 catD)", () => {
+  test("ATTENTION_LABELS contains needs-human, blocked, waiting", () => {
+    expect(ATTENTION_LABELS).toContain("needs-human");
+    expect(ATTENTION_LABELS).toContain("blocked");
+    expect(ATTENTION_LABELS).toContain("waiting");
+  });
+  test("TERMINAL_LINEAR_STATES contains Canceled, Duplicate, Done", () => {
+    expect(TERMINAL_LINEAR_STATES).toContain("Canceled");
+    expect(TERMINAL_LINEAR_STATES).toContain("Duplicate");
+    expect(TERMINAL_LINEAR_STATES).toContain("Done");
+  });
+  test("both are frozen", () => {
+    expect(Object.isFrozen(ATTENTION_LABELS)).toBe(true);
+    expect(Object.isFrozen(TERMINAL_LINEAR_STATES)).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/unstuck-sweep-config.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep-config.test.mjs
@@ -1,0 +1,114 @@
+// unstuck-sweep-config.test.mjs — CTL-1064 config gate.
+// readUnstuckSweepConfig mirrors readStallJanitorConfig (CTL-1004): env >
+// Layer-2 catalyst.unstuckSweep.* > code default. Default mode is "off"
+// (safer than stall-janitor's "shadow" — operators must opt in explicitly).
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readUnstuckSweepConfig, isThrottled, UNSTUCK_SWEEP_DEFAULT_INTERVAL_MS } from "./config.mjs";
+
+const US_ENVS = [
+  "CATALYST_UNSTUCK_SWEEP",
+  "EXECUTION_CORE_UNSTUCK_SWEEP_MODE",
+  "CATALYST_UNSTUCK_SWEEP_INTERVAL_MS",
+  "CATALYST_LAYER2_CONFIG_FILE",
+];
+
+describe("readUnstuckSweepConfig (CTL-1064)", () => {
+  let saved = {};
+  let tmp;
+  beforeEach(() => {
+    for (const k of US_ENVS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    tmp = mkdtempSync(join(tmpdir(), "ctl1064-us-"));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = join(tmp, "absent.json");
+  });
+  afterEach(() => {
+    for (const k of US_ENVS) {
+      saved[k] === undefined ? delete process.env[k] : (process.env[k] = saved[k]);
+    }
+    saved = {};
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("default: mode=off (safe default — operators opt in)", () => {
+    const c = readUnstuckSweepConfig();
+    expect(c.mode).toBe("off");
+    expect(c.intervalMs).toBe(UNSTUCK_SWEEP_DEFAULT_INTERVAL_MS);
+    expect(c.intervalMs).toBe(900_000);
+  });
+
+  test("CATALYST_UNSTUCK_SWEEP=0 maps to mode:off (kill-switch)", () => {
+    process.env.CATALYST_UNSTUCK_SWEEP = "0";
+    expect(readUnstuckSweepConfig().mode).toBe("off");
+  });
+
+  test("CATALYST_UNSTUCK_SWEEP=shadow → shadow", () => {
+    process.env.CATALYST_UNSTUCK_SWEEP = "shadow";
+    expect(readUnstuckSweepConfig().mode).toBe("shadow");
+  });
+
+  test("CATALYST_UNSTUCK_SWEEP=enforce → enforce", () => {
+    process.env.CATALYST_UNSTUCK_SWEEP = "enforce";
+    expect(readUnstuckSweepConfig().mode).toBe("enforce");
+  });
+
+  test("reads catalyst.unstuckSweep.* from Layer-2", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(
+      cfg,
+      JSON.stringify({
+        catalyst: { unstuckSweep: { mode: "enforce", intervalSeconds: 300 } },
+      }),
+    );
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    const out = readUnstuckSweepConfig();
+    expect(out.mode).toBe("enforce");
+    expect(out.intervalMs).toBe(300_000);
+  });
+
+  test("env wins over Layer-2 and default", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { unstuckSweep: { mode: "off" } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    process.env.CATALYST_UNSTUCK_SWEEP = "enforce";
+    expect(readUnstuckSweepConfig().mode).toBe("enforce");
+  });
+
+  test("malformed Layer-2 file → code defaults (never throws)", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(cfg, "{ not json");
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    expect(readUnstuckSweepConfig().mode).toBe("off");
+    expect(readUnstuckSweepConfig().intervalMs).toBe(900_000);
+  });
+
+  test("invalid mode string → falls back to off", () => {
+    process.env.CATALYST_UNSTUCK_SWEEP = "banana";
+    expect(readUnstuckSweepConfig().mode).toBe("off");
+  });
+
+  test("CATALYST_UNSTUCK_SWEEP_INTERVAL_MS overrides default", () => {
+    process.env.CATALYST_UNSTUCK_SWEEP_INTERVAL_MS = "60000";
+    expect(readUnstuckSweepConfig().intervalMs).toBe(60_000);
+  });
+});
+
+describe("isThrottled (CTL-1064)", () => {
+  test("returns true when elapsed < intervalMs", () => {
+    expect(isThrottled(1000, 5000, 4000)).toBe(true);  // 3000ms elapsed < 5000ms
+  });
+  test("returns false when elapsed >= intervalMs", () => {
+    expect(isThrottled(1000, 5000, 6000)).toBe(false); // 5000ms elapsed >= 5000ms
+  });
+  test("returns false when lastRunMs=0 and nowMs > interval", () => {
+    expect(isThrottled(0, 900_000, 900_001)).toBe(false);
+  });
+  test("returns true when lastRunMs=0 and nowMs < interval", () => {
+    expect(isThrottled(0, 900_000, 500_000)).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/unstuck-sweep-escalation.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep-escalation.mjs
@@ -1,0 +1,130 @@
+// unstuck-sweep-escalation.mjs — CTL-1064 Phase 6 escalation write-up author.
+//
+// Both exports are PURE (no IO, no imports beyond constants).
+// authorEscalationComment: replaces tautological "needs a human" copy with a
+// causal write-up naming the single decision the human must make.
+// summarizeRemediateCapHistory: turns verify⇄remediate round-trips into a
+// per-round disagreement summary + a single decision sentence.
+
+// authorEscalationComment — pure. Dispatches on evidence.reason to produce a
+// causal, human-readable escalation comment.
+// evidence shape mirrors captureDeepDiveEvidence's output plus
+//   commitsAhead    number   (runtime-detected commits ahead of origin/main)
+//   reason          string   (the stalledReason / category)
+//   ticket          string
+//   phase           string
+export function authorEscalationComment(evidence = {}) {
+  const { ticket, phase, reason, commitsAhead, porcelainLines, prState, remediateHistory } = evidence;
+
+  const ticketId = ticket ?? "?";
+  const phaseStr = phase ?? "?";
+
+  // Empty-branch (runtime detection: commitsAhead.length === 0 or commitsAhead === 0).
+  // Never hardcoded to a specific stalledReason string.
+  const ahead = typeof commitsAhead === "number"
+    ? commitsAhead
+    : (Array.isArray(commitsAhead) ? commitsAhead.length : null);
+  if (ahead === 0) {
+    return [
+      `**${ticketId} / ${phaseStr} — escalated: empty branch**`,
+      "",
+      "The branch is 0 commits ahead of `origin/main`. No implementation work was committed.",
+      "This requires a human decision: the sweep cannot safely seed or close the branch.",
+      "",
+      "**Decision required:** Should this ticket be closed (no work to ship), or should the",
+      "branch be seeded with an initial commit to retry the implement phase?",
+    ].join("\n");
+  }
+
+  // dirty-tree with non-noise porcelain
+  if (reason === "rebase_refused_dirty_tree" && Array.isArray(porcelainLines) && porcelainLines.length > 0) {
+    const fileList = porcelainLines.slice(0, 10).map((l) => `  ${l}`).join("\n");
+    const more = porcelainLines.length > 10 ? `\n  … (${porcelainLines.length - 10} more)` : "";
+    return [
+      `**${ticketId} / ${phaseStr} — escalated: real worktree dirt prevents auto-clear**`,
+      "",
+      "The rebase was refused because the worktree has non-noise modified files that",
+      "the auto-clear sweep cannot safely discard:",
+      "",
+      fileList + more,
+      "",
+      "**Decision required:** Review the above files. If they are safe to discard or",
+      "stage, resolve the conflict manually and re-dispatch the phase.",
+    ].join("\n");
+  }
+
+  // source-conflict (force-push safety gate failed)
+  if (reason === "source_conflict_ctl708_unavailable") {
+    const prInfo = prState ? ` (PR state: ${prState})` : "";
+    return [
+      `**${ticketId} / ${phaseStr} — escalated: force-push safety gate failed**`,
+      "",
+      `The branch has a \`source_conflict_ctl708_unavailable\` stall${prInfo}.`,
+      "The auto-push sweep requires: empty noise-filtered porcelain, ticket-only commits,",
+      "and HEAD as a strict descendant of origin/main. One or more gates failed.",
+      "",
+      "**Decision required:** Confirm whether the worktree's rebase is safe to force-push.",
+      "If yes, run: `git -C <worktree> push --force-with-lease` and re-dispatch.",
+    ].join("\n");
+  }
+
+  // remediate-cap
+  if (reason === "remediate-cycle-cap-exhausted") {
+    const historySummary = Array.isArray(remediateHistory) && remediateHistory.length > 0
+      ? summarizeRemediateCapHistory(ticketId, remediateHistory)
+      : "_No remediate history available._";
+    return [
+      `**${ticketId} / ${phaseStr} — escalated: verify/remediate cap exhausted**`,
+      "",
+      "The verify→remediate cycle reached the iteration cap without reaching a passing",
+      "verify verdict. Round-by-round summary:",
+      "",
+      historySummary,
+      "",
+      "**Decision required:** Review the above disagreements and decide whether to extend",
+      "the remediate cap, manually fix the failing checks, or close the ticket.",
+    ].join("\n");
+  }
+
+  // generic / unknown — not mechanically resolvable
+  const reasonStr = reason ? ` (reason: \`${reason}\`)` : "";
+  return [
+    `**${ticketId} / ${phaseStr} — escalated: not mechanically resolvable**`,
+    "",
+    `This ticket is stalled${reasonStr} and is outside the auto-unstuck whitelist.`,
+    "The sweep cannot safely resolve this automatically.",
+    "",
+    "Evidence summary:",
+    `- Stall reason: \`${reason ?? "unknown"}\``,
+    `- Phase: \`${phaseStr}\``,
+    `- PR state: ${prState ?? "unknown"}`,
+    "",
+    "**Decision required:** Investigate the above and manually clear or reassign.",
+  ].join("\n");
+}
+
+// summarizeRemediateCapHistory — pure. Turns a list of remediate round objects
+// into a human-readable per-round summary + a single decision sentence.
+// Returns "" for empty history.
+// history items shape: { round, verifyFindings, remediateChanges, reVerifyResult }
+export function summarizeRemediateCapHistory(ticket, history) {
+  if (!Array.isArray(history) || history.length === 0) return "";
+
+  const lines = [];
+  for (const item of history) {
+    const round = item?.round ?? "?";
+    const findings = item?.verifyFindings ?? "findings unavailable";
+    const changes = item?.remediateChanges ?? "changes unavailable";
+    const reResult = item?.reVerifyResult ?? "result unavailable";
+    lines.push(
+      `**Round ${round}:** verify found: ${findings}; remediate changed: ${changes}; re-verify: ${reResult}`
+    );
+  }
+
+  lines.push(
+    `\n**Single decision for ${ticket}:** Review the above round disagreements and`,
+    "determine whether the failing checks are correct or the remediate approach was wrong."
+  );
+
+  return lines.join("\n");
+}

--- a/plugins/dev/scripts/execution-core/unstuck-sweep-escalation.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep-escalation.test.mjs
@@ -1,0 +1,125 @@
+// unstuck-sweep-escalation.test.mjs — CTL-1064 Phase 6 escalation comment tests.
+
+import { describe, test, expect } from "bun:test";
+import { authorEscalationComment, summarizeRemediateCapHistory } from "./unstuck-sweep-escalation.mjs";
+
+// ---------------------------------------------------------------------------
+// authorEscalationComment
+// ---------------------------------------------------------------------------
+describe("authorEscalationComment (CTL-1064)", () => {
+  test("empty-branch evidence (commitsAhead=0) → names the single decision", () => {
+    const comment = authorEscalationComment({
+      ticket: "CTL-1064",
+      phase: "implement",
+      commitsAhead: 0,
+    });
+    expect(comment.length).toBeGreaterThan(80);
+    expect(comment).toContain("decision");
+    expect(comment).toContain("0 commits");
+    expect(comment).toContain("CTL-1064");
+  });
+
+  test("empty array commitsAhead → treated as zero", () => {
+    const comment = authorEscalationComment({
+      ticket: "CTL-X",
+      phase: "implement",
+      commitsAhead: [],
+    });
+    expect(comment).toContain("0 commits");
+  });
+
+  test("rebase_refused_dirty_tree with non-noise porcelainLines → names specific dirty files", () => {
+    const comment = authorEscalationComment({
+      ticket: "CTL-TEST",
+      phase: "implement",
+      reason: "rebase_refused_dirty_tree",
+      porcelainLines: [" M src/foo.ts"],
+    });
+    expect(comment).toContain("src/foo.ts");
+    expect(comment).toContain("CTL-TEST");
+  });
+
+  test("source_conflict_ctl708_unavailable → explains stub unavailable + frames as human-verified", () => {
+    const comment = authorEscalationComment({
+      ticket: "CTL-1025",
+      phase: "implement",
+      reason: "source_conflict_ctl708_unavailable",
+      prState: "OPEN",
+    });
+    expect(comment).toContain("force-push");
+    expect(comment).toContain("PR state: OPEN");
+    expect(comment).toContain("Confirm");
+  });
+
+  test("unknown reason → 'not mechanically resolvable' + contains word whitelist", () => {
+    const comment = authorEscalationComment({
+      ticket: "CTL-X",
+      phase: "verify",
+      reason: "some_unknown_reason",
+    });
+    expect(comment).toContain("not mechanically resolvable");
+    expect(comment).toContain("whitelist");
+    expect(comment).toContain("Decision required");
+  });
+
+  test("non-empty string with subject + reason", () => {
+    const comment = authorEscalationComment({ ticket: "CTL-X", phase: "plan", reason: "other" });
+    expect(typeof comment).toBe("string");
+    expect(comment.length).toBeGreaterThan(20);
+  });
+
+  test("does not throw on null fields", () => {
+    expect(() => authorEscalationComment({ ticket: null, phase: null, reason: null })).not.toThrow();
+    expect(() => authorEscalationComment({})).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summarizeRemediateCapHistory
+// ---------------------------------------------------------------------------
+describe("summarizeRemediateCapHistory (CTL-1064)", () => {
+  test("empty history → empty string", () => {
+    expect(summarizeRemediateCapHistory("CTL-X", [])).toBe("");
+  });
+
+  test("single round → names the round", () => {
+    const s = summarizeRemediateCapHistory("CTL-X", [
+      { round: 1, verifyFindings: "type errors", remediateChanges: "fixed types", reVerifyResult: "still failed" },
+    ]);
+    expect(s).toContain("Round 1");
+    expect(s).toContain("type errors");
+    expect(s).toContain("fixed types");
+    expect(s).toContain("still failed");
+  });
+
+  test("three rounds → lists each (Round 1/2/3)", () => {
+    const history = [
+      { round: 1, verifyFindings: "A", remediateChanges: "B", reVerifyResult: "C" },
+      { round: 2, verifyFindings: "D", remediateChanges: "E", reVerifyResult: "F" },
+      { round: 3, verifyFindings: "G", remediateChanges: "H", reVerifyResult: "I" },
+    ];
+    const s = summarizeRemediateCapHistory("CTL-X", history);
+    expect(s).toContain("Round 1");
+    expect(s).toContain("Round 2");
+    expect(s).toContain("Round 3");
+  });
+
+  test("missing fields → 'findings unavailable'", () => {
+    const s = summarizeRemediateCapHistory("CTL-X", [{ round: 1 }]);
+    expect(s).toContain("findings unavailable");
+  });
+
+  test("output contains the ticket id", () => {
+    const s = summarizeRemediateCapHistory("CTL-MY-TICKET", [
+      { round: 1, verifyFindings: "x", remediateChanges: "y", reVerifyResult: "z" },
+    ]);
+    expect(s).toContain("CTL-MY-TICKET");
+  });
+
+  test("pure — same input twice → identical output", () => {
+    const history = [{ round: 1, verifyFindings: "a", remediateChanges: "b", reVerifyResult: "c" }];
+    expect(summarizeRemediateCapHistory("CTL-X", history)).toBe(
+      summarizeRemediateCapHistory("CTL-X", history)
+    );
+  });
+});

--- a/plugins/dev/scripts/execution-core/unstuck-sweep-event-types.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep-event-types.mjs
@@ -1,0 +1,27 @@
+// unstuck-sweep-event-types.mjs — CTL-1064 unstuck sweep event vocabulary.
+//
+// Dependency-free leaf, mirroring janitor-event-types.mjs:23. Every string the
+// unstuck sweep passes to its fire()/emit() seam MUST be listed here (10 strings:
+// 4 category pairs + 1 escalate pair). The sweep owns this vocabulary and emits
+// via the unified-log fire-and-forget path; JANITOR_EVENT_TYPES is NOT extended
+// (reap-intent.mjs's closed vocabulary is kept untouched, CTL-1064 §"What We're
+// NOT Doing"). Shadow twins follow the convention unstuck.would.* to mirror the
+// enforce event name minus the enforce-specific verb prefix.
+
+export const UNSTUCK_SWEEP_EVENT_TYPES = Object.freeze([
+  // ---- Category A: rebase_refused_dirty_tree ---------------------------------
+  "unstuck.cleared.noise",        // enforce: machine-noise cleared, worktree retried
+  "unstuck.would.clear-noise",    // shadow twin
+  // ---- Category B: source_conflict_ctl708_unavailable -----------------------
+  "unstuck.pushed.force-with-lease", // enforce: clean rebase pushed --force-with-lease
+  "unstuck.would.push",           // shadow twin
+  // ---- Category C: orphan-sweep-stale (normalized from failureReason) -------
+  "unstuck.emitted.phase-complete", // enforce: synthetic phase-complete emitted
+  "unstuck.would.emit-complete",  // shadow twin
+  // ---- Category D: stale attention labels on terminal tickets ---------------
+  "unstuck.cleared.stale-label",  // enforce: stale attention label cleared
+  "unstuck.would.clear-label",    // shadow twin
+  // ---- Escalate: genuine decision required from human -----------------------
+  "unstuck.escalated",            // enforce: genuine decision escalated
+  "unstuck.would.escalate",       // shadow twin
+]);

--- a/plugins/dev/scripts/execution-core/unstuck-sweep-evidence.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep-evidence.mjs
@@ -1,0 +1,64 @@
+// unstuck-sweep-evidence.mjs — CTL-1064 Phase 6 deep-dive evidence collector.
+//
+// captureDeepDiveEvidence assembles the manual rescue chain evidence envelope
+// (signal files → noise-filtered porcelain → PR REST state → event-log remediate
+// history) before an escalation comment is authored. All IO injected.
+// Mirrors diagnostician.mjs:83 pattern.
+
+import { REBASE_NOISE_PATHS } from "./dirty-tree-classifier.mjs";
+import { cleanPorcelain } from "./worktree-safety.mjs";
+
+// captureDeepDiveEvidence — assembles evidence for one stalled ticket/phase.
+// Returns { subject, signalJson, porcelainLines, prState, remediateHistory, capturedAt }.
+// Degrades gracefully: prState/remediateHistory fall back to null/[] on seam failure.
+// All IO injected — pure given the seams.
+//
+// opts shape:
+//   readSignal(ticket, phase)         → object|null
+//   runGitPorcelain(worktreePath)     → string|null
+//   isNoisePath(path)                 → bool  (use REBASE_NOISE_PATHS to build one)
+//   queryPR(ticket)                   → string|null ('MERGED'|'OPEN'|'CLOSED'|null)
+//   listRemediateEvents(ticket)       → Array<{round, verifyFindings, remediateChanges, reVerifyResult}>
+export function captureDeepDiveEvidence(subject, {
+  readSignal = () => null,
+  runGitPorcelain = () => null,
+  isNoisePath = (p) => REBASE_NOISE_PATHS.some((n) => p === n || p.startsWith(n + "/")),
+  queryPR = () => null,
+  listRemediateEvents = () => [],
+} = {}) {
+  const [ticket, phase] = String(subject).split("/");
+
+  let signalJson = null;
+  try { signalJson = readSignal(ticket, phase); } catch { signalJson = null; }
+
+  let porcelainLines = [];
+  try {
+    const raw = runGitPorcelain(signalJson?.worktreePath ?? null);
+    if (raw) {
+      const allLines = raw.split("\n").filter((l) => l.trim().length > 0);
+      porcelainLines = cleanPorcelain(allLines.join("\n"), REBASE_NOISE_PATHS)
+        .filter((l) => {
+          // Extra filter: also remove deleted node_modules via isNoisePath
+          const path = l.slice(3).trim().replace(/^"|"$/g, "");
+          return !isNoisePath(path);
+        });
+    }
+  } catch { porcelainLines = []; }
+
+  let prState = null;
+  try { prState = queryPR(ticket); } catch { prState = null; }
+
+  let remediateHistory = [];
+  try { remediateHistory = listRemediateEvents(ticket) ?? []; } catch { remediateHistory = []; }
+
+  return {
+    subject,
+    ticket,
+    phase,
+    signalJson,
+    porcelainLines,
+    prState,
+    remediateHistory,
+    capturedAt: new Date().toISOString(),
+  };
+}

--- a/plugins/dev/scripts/execution-core/unstuck-sweep-evidence.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep-evidence.test.mjs
@@ -1,0 +1,72 @@
+// unstuck-sweep-evidence.test.mjs — CTL-1064 Phase 6 evidence collector tests.
+
+import { describe, test, expect } from "bun:test";
+import { captureDeepDiveEvidence } from "./unstuck-sweep-evidence.mjs";
+
+describe("captureDeepDiveEvidence — pure collector (CTL-1064)", () => {
+  const SUBJECT = "CTL-TEST/implement";
+
+  test("returns structured envelope with all fields", () => {
+    const result = captureDeepDiveEvidence(SUBJECT);
+    expect(result).toHaveProperty("subject", SUBJECT);
+    expect(result).toHaveProperty("ticket", "CTL-TEST");
+    expect(result).toHaveProperty("phase", "implement");
+    expect(result).toHaveProperty("signalJson");
+    expect(result).toHaveProperty("porcelainLines");
+    expect(result).toHaveProperty("prState");
+    expect(result).toHaveProperty("remediateHistory");
+    expect(result).toHaveProperty("capturedAt");
+  });
+
+  test("porcelainLines is noise-filtered (deleted node_modules absent)", () => {
+    const result = captureDeepDiveEvidence(SUBJECT, {
+      readSignal: () => ({ worktreePath: "/wt/CTL-TEST" }),
+      runGitPorcelain: () => " M .catalyst/config.json\n D node_modules\n M src/foo.mjs",
+    });
+    // node_modules deletion and .catalyst/config.json filtered; src/foo.mjs kept
+    expect(result.porcelainLines.some(l => l.includes("src/foo.mjs"))).toBe(true);
+    expect(result.porcelainLines.some(l => l.includes(".catalyst/config.json"))).toBe(false);
+  });
+
+  test("prState:null when queryPR throws (still returns envelope)", () => {
+    const result = captureDeepDiveEvidence(SUBJECT, {
+      queryPR: () => { throw new Error("API unavailable"); },
+    });
+    expect(result.prState).toBeNull();
+    expect(result.subject).toBe(SUBJECT);
+  });
+
+  test("empty remediateHistory when none found", () => {
+    const result = captureDeepDiveEvidence(SUBJECT, {
+      listRemediateEvents: () => [],
+    });
+    expect(result.remediateHistory).toEqual([]);
+  });
+
+  test("readSignal→null does not throw", () => {
+    const result = captureDeepDiveEvidence(SUBJECT, {
+      readSignal: () => null,
+    });
+    expect(result.signalJson).toBeNull();
+  });
+
+  test("all IO seams injected — no filesystem access in the function body", () => {
+    // If all seams return null/[] and no IO is done, the function should still succeed
+    const result = captureDeepDiveEvidence(SUBJECT, {
+      readSignal: () => null,
+      runGitPorcelain: () => null,
+      queryPR: () => null,
+      listRemediateEvents: () => [],
+    });
+    expect(result.porcelainLines).toEqual([]);
+    expect(result.prState).toBeNull();
+    expect(result.remediateHistory).toEqual([]);
+  });
+
+  test("listRemediateEvents throw → remediateHistory=[] (graceful)", () => {
+    const result = captureDeepDiveEvidence(SUBJECT, {
+      listRemediateEvents: () => { throw new Error("event log unavailable"); },
+    });
+    expect(result.remediateHistory).toEqual([]);
+  });
+});

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
@@ -1,0 +1,398 @@
+// unstuck-sweep.mjs — CTL-1064 classify-then-act deep-dive sweep for
+// stalled/needs-human ticket backlog.
+//
+// Peer module to stall-janitor.mjs. While the janitor handles process hygiene
+// (J1 orphan worktrees, J2 ghost sessions, J3 prior-artifact retries), this
+// sweep classifies the stalled/needs-human *ticket* backlog — rebase stalls,
+// source-conflict stalls, orphan-sweep-stale signals, and stale attention
+// labels on terminal tickets — and mechanically clears whitelisted categories.
+//
+// Architecture mirrors CTL-729 watchdog: PURE classifiers (no IO, all evidence
+// injected) + an action driver (runUnstuckSweepPass — every side-effect seam
+// injected). Runs as a low-frequency throttled Pass 0u (default 15 min).
+// Ships with mode='off'; operators roll out via shadow → enforce.
+
+import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { log } from "./config.mjs";
+import { UNSTUCK_SWEEP_EVENT_TYPES } from "./unstuck-sweep-event-types.mjs";
+
+export { UNSTUCK_SWEEP_EVENT_TYPES };
+
+export const UNSTUCK_SWEEP_INTENT_KIND = "unstuck-sweep";
+
+// Named accessors over the frozen list — one per unstuck emit type. Indexing
+// the frozen array keeps the strings in ONE place; a typo here is a load error.
+const UNSTUCK_EVENT = Object.freeze({
+  clearedNoise:          UNSTUCK_SWEEP_EVENT_TYPES[0],
+  wouldClearNoise:       UNSTUCK_SWEEP_EVENT_TYPES[1],
+  pushedForceWithLease:  UNSTUCK_SWEEP_EVENT_TYPES[2],
+  wouldPush:             UNSTUCK_SWEEP_EVENT_TYPES[3],
+  emittedPhaseComplete:  UNSTUCK_SWEEP_EVENT_TYPES[4],
+  wouldEmitComplete:     UNSTUCK_SWEEP_EVENT_TYPES[5],
+  clearedStaleLabel:     UNSTUCK_SWEEP_EVENT_TYPES[6],
+  wouldClearLabel:       UNSTUCK_SWEEP_EVENT_TYPES[7],
+  escalated:             UNSTUCK_SWEEP_EVENT_TYPES[8],
+  wouldEscalate:         UNSTUCK_SWEEP_EVENT_TYPES[9],
+});
+
+// STALL_CATEGORY_MAP — routing table: stalledReason string → {category, action}.
+// Unrecognized reasons fall through to {category:'unknown', action:'escalate'}.
+// Empty-branch is NOT hardcoded here — unrecognized reasons route to escalate,
+// and empty-branch is detected at runtime via commitsAhead.length === 0.
+export const STALL_CATEGORY_MAP = Object.freeze({
+  rebase_refused_dirty_tree:          { category: "dirty-tree",     action: "clear-noise-and-retry" },
+  source_conflict_ctl708_unavailable: { category: "source-conflict", action: "force-push-if-clean" },
+  "orphan-sweep-stale":               { category: "orphan-stale",   action: "emit-phase-complete-if-merged" },
+  "remediate-cycle-cap-exhausted":    { category: "remediate-cap",  action: "escalate" },
+});
+
+// classifyStalledTicket — PURE top-level router (Phase 1). No IO.
+// Evidence shape: { reason, liveSessionInWorktree, linearTerminal, ... }
+// Returns { category, action } or { category:'skip', action:'skip', reason }.
+export function classifyStalledTicket(evidence = {}) {
+  if (evidence.liveSessionInWorktree) {
+    return { category: "skip", action: "skip", reason: "live-session" };
+  }
+  if (evidence.linearTerminal) {
+    return { category: "skip", action: "skip", reason: "linear-terminal" };
+  }
+  const mapped = STALL_CATEGORY_MAP[evidence.reason];
+  if (mapped) return mapped;
+  return { category: "unknown", action: "escalate" };
+}
+
+// defaultCollectUnstuckCandidates — dual-status census: reads BOTH
+//   (status === 'stalled' && stalledReason) AND
+//   (status === 'failed' && failureReason === 'orphan-sweep-stale')
+// normalizing into a single evidence.reason. Per-candidate try/catch.
+export function defaultCollectUnstuckCandidates({
+  orchDir,
+  readdirSync: readdir = readdirSync,
+  readFileSync: readFile = readFileSync,
+  agentsSnapshot = [],
+  isLinearTerminal = () => false,
+  resolveWorktreePath = () => null,
+} = {}) {
+  const out = [];
+  let workerDirs;
+  try {
+    workerDirs = readdir(join(orchDir, "workers"), { withFileTypes: true });
+  } catch {
+    return out; // no workers dir → nothing to census
+  }
+
+  for (const d of workerDirs) {
+    if (!d.isDirectory()) continue;
+    const ticket = d.name;
+    try {
+      const workerDir = join(orchDir, "workers", ticket);
+      let signalFiles;
+      try {
+        signalFiles = readdir(workerDir, { withFileTypes: true });
+      } catch { continue; }
+
+      for (const sf of signalFiles) {
+        if (!sf.name.startsWith("phase-") || !sf.name.endsWith(".json")) continue;
+        const signalPath = join(workerDir, sf.name);
+        let signal;
+        try {
+          signal = JSON.parse(readFile(signalPath, "utf8"));
+        } catch { continue; }
+
+        // Accept both status shapes (CTL-1064 §Confirmed gaps).
+        let reason = null;
+        if (signal.status === "stalled" && signal.stalledReason) {
+          reason = signal.stalledReason;
+        } else if (signal.status === "failed" && signal.failureReason === "orphan-sweep-stale") {
+          reason = "orphan-sweep-stale";
+        } else {
+          continue;
+        }
+
+        const phase = signal.phase ??
+          sf.name.replace(/^phase-/, "").replace(/\.json$/, "");
+        const worktreePath = resolveWorktreePath(ticket);
+
+        const liveSessionInWorktree =
+          worktreePath != null &&
+          Array.isArray(agentsSnapshot) &&
+          agentsSnapshot.some((a) => {
+            if (!a?.cwd) return false;
+            const strip = (p) => String(p).replace(/\/+$/, "");
+            const c = strip(a.cwd);
+            const r = strip(worktreePath);
+            return c === r || c.startsWith(r + "/");
+          });
+
+        const linearTerminal = isLinearTerminal(ticket);
+
+        out.push({
+          ticket,
+          phase,
+          signal,
+          workerDir,
+          worktreePath,
+          liveSessionInWorktree,
+          linearTerminal,
+          evidence: {
+            reason,
+            ticket,
+            phase,
+            signal,
+            worktreePath,
+            liveSessionInWorktree,
+            linearTerminal,
+          },
+        });
+      }
+    } catch (err) {
+      log.warn(
+        { ticket, err: err?.message },
+        "unstuck-sweep: candidate probe threw — skipping (CTL-1064)",
+      );
+    }
+  }
+  return out;
+}
+
+// buildAuditComment — assemble the three mandatory sections for a Linear mirror.
+// Every enforce action posts a three-section comment: What was found / What was
+// done / What was verified after.
+export function buildAuditComment({ found, done, verified }) {
+  return [
+    "**What was found**",
+    found ?? "_unavailable_",
+    "",
+    "**What was done**",
+    done ?? "_unavailable_",
+    "",
+    "**What was verified after**",
+    verified ?? "_unavailable_",
+  ].join("\n");
+}
+
+// defaultPostUnstuckComment — post a three-section Linear comment + write the
+// idempotency marker. Fail-open (logs, never throws). Guards existsSync on the
+// worker dir before writing the marker (mirrors recovery.mjs:607).
+export function defaultPostUnstuckComment(
+  ticket,
+  category,
+  phase,
+  commentBody,
+  {
+    runCommentPost = null,
+    orchDir = null,
+    existsSync: exists = existsSync,
+    writeMarker = (p) => writeFileSync(p, ""),
+  } = {},
+) {
+  if (!orchDir || !ticket || !phase) return;
+  const workerDir = join(orchDir, "workers", ticket);
+  if (!exists(workerDir)) return;
+  const markerPath = join(workerDir, `.unstuck-comment-${category}-${phase}.applied`);
+  if (exists(markerPath)) return; // idempotent — first-writer-wins
+  try {
+    const poster = runCommentPost ?? defaultRunCommentPost;
+    const r = typeof poster === "function" ? poster(ticket, commentBody) : null;
+    if (!r || r.status === 0) {
+      try {
+        mkdirSync(workerDir, { recursive: true });
+        writeMarker(markerPath);
+      } catch (err) {
+        log.warn({ ticket, category, phase, err: err?.message }, "unstuck-sweep: marker write failed (CTL-1064)");
+      }
+    } else {
+      log.warn(
+        { ticket, category, phase, status: r?.status },
+        "unstuck-sweep: linear-comment-post failed (CTL-1064)",
+      );
+    }
+  } catch (err) {
+    log.warn({ ticket, category, phase, err: err?.message }, "unstuck-sweep: postComment threw (CTL-1064)");
+  }
+}
+
+function defaultRunCommentPost(ticket, body) {
+  const helperPath = join(
+    process.env.PLUGIN_ROOT ?? process.cwd(),
+    "scripts/lib/linear-comment-post.sh",
+  );
+  return spawnSync(helperPath, [ticket, body], { encoding: "utf8", timeout: 10_000 });
+}
+
+// _actionToEnforceEvent / _actionToShadowEvent — map decision.action → event type.
+function _actionToEnforceEvent(action) {
+  switch (action) {
+    case "clear-noise-and-retry":         return UNSTUCK_EVENT.clearedNoise;
+    case "force-push-if-clean":           return UNSTUCK_EVENT.pushedForceWithLease;
+    case "emit-phase-complete-if-merged": return UNSTUCK_EVENT.emittedPhaseComplete;
+    case "clear-label":                   return UNSTUCK_EVENT.clearedStaleLabel;
+    default:                              return null;
+  }
+}
+
+function _actionToShadowEvent(action) {
+  switch (action) {
+    case "clear-noise-and-retry":         return UNSTUCK_EVENT.wouldClearNoise;
+    case "force-push-if-clean":           return UNSTUCK_EVENT.wouldPush;
+    case "emit-phase-complete-if-merged": return UNSTUCK_EVENT.wouldEmitComplete;
+    case "clear-label":                   return UNSTUCK_EVENT.wouldClearLabel;
+    case "escalate":                      return UNSTUCK_EVENT.wouldEscalate;
+    default:                              return null;
+  }
+}
+
+// runUnstuckSweepPass — the action driver. All side-effect seams are injected.
+// Returns { acted, wouldAct, escalated, wouldEscalate, skipped, failed }.
+//
+// Seam contract (simplified signatures — scheduler binds db/orchDir at wiring):
+//   collectCandidates()                → [{ticket, phase, evidence, ...}]
+//   classify(evidence)                 → {category, action, ...}
+//   actByCategory[category](c, decision) → void (may throw; caught per-candidate)
+//   escalate(c)                        → void (best-effort; caught per-candidate)
+//   emit(type, fields)                 → Promise|void (fire-and-forget)
+//   recordIntent(kind, subject)        → void (best-effort)
+//   isIntentEffective(kind, subject)   → bool (true = still open+viable → skip)
+//   postComment(ticket, category, phase) → void (best-effort; called after act)
+//   logger                             → pino-compatible
+export function runUnstuckSweepPass({
+  mode,
+  collectCandidates,
+  classify = classifyStalledTicket,
+  actByCategory = {},
+  escalate = () => {},
+  emit = async () => true,
+  recordIntent = () => {},
+  isIntentEffective = () => false,
+  postComment = () => {},
+  logger = log,
+} = {}) {
+  const report = {
+    acted: [],
+    wouldAct: [],
+    escalated: [],
+    wouldEscalate: [],
+    skipped: [],
+    failed: [],
+  };
+
+  // off → skip the pass entirely: no census, no events, no intents.
+  if (mode === "off") return report;
+  const enforce = mode === "enforce";
+
+  // fire-and-forget emit: never await (so a slow append can't stall the loop),
+  // never let a rejection escape (a thrown/rejecting emitter is logged, not fatal).
+  const fire = (type, fields, ticket) => {
+    try {
+      const p = emit(type, fields);
+      if (p && typeof p.catch === "function") {
+        p.catch((err) =>
+          logger.warn({ ticket, type, err: err?.message }, "unstuck-sweep: emit failed (CTL-1064)"),
+        );
+      }
+    } catch (err) {
+      // A SYNCHRONOUSLY-throwing emit seam must not abort the candidate loop —
+      // re-throw to the per-candidate catch below.
+      throw err;
+    }
+  };
+
+  // Collect candidates — a throwing census degrades to empty (no abort).
+  let candidates = [];
+  try {
+    candidates = collectCandidates() ?? [];
+  } catch (err) {
+    logger.warn({ err: err?.message }, "unstuck-sweep: census threw — skipping pass (CTL-1064)");
+    return report;
+  }
+
+  for (const c of candidates) {
+    try {
+      const decision = classify(c.evidence ?? c);
+
+      // skip — live session, linear-terminal, or classifier-level skip.
+      if (decision.action === "skip") {
+        report.skipped.push({ ticket: c.ticket, phase: c.phase, reason: decision.reason });
+        continue;
+      }
+
+      const subject = `${c.ticket}/${c.phase}`;
+
+      if (!enforce) {
+        // shadow — emit would-* twin; no act, no intent, no comment.
+        const shadowEvt = _actionToShadowEvent(decision.action);
+        if (shadowEvt) {
+          fire(
+            shadowEvt,
+            { ticket: c.ticket, phase: c.phase, category: decision.category, reason: decision.reason },
+            c.ticket,
+          );
+        }
+        if (decision.action === "escalate") {
+          report.wouldEscalate.push({ ticket: c.ticket, phase: c.phase, category: decision.category });
+        } else {
+          report.wouldAct.push({ ticket: c.ticket, phase: c.phase, category: decision.category, action: decision.action });
+        }
+        continue;
+      }
+
+      // enforce — escalate path: no intent gate (genuine decisions always surface).
+      if (decision.action === "escalate") {
+        try { escalate(c, decision); } catch (err) {
+          logger.warn({ ticket: c.ticket, err: err?.message }, "unstuck-sweep: escalate seam threw (CTL-1064)");
+        }
+        fire(UNSTUCK_EVENT.escalated, { ticket: c.ticket, phase: c.phase, category: decision.category }, c.ticket);
+        try { postComment(c.ticket, decision.category ?? "unknown", c.phase); } catch { /* best-effort */ }
+        report.escalated.push({ ticket: c.ticket, phase: c.phase, category: decision.category });
+        continue;
+      }
+
+      // enforce — clearable action: check intent gate BEFORE acting (storm-prevention).
+      if (isIntentEffective(UNSTUCK_SWEEP_INTENT_KIND, subject)) {
+        report.skipped.push({ ticket: c.ticket, phase: c.phase, reason: "intent-effective" });
+        continue;
+      }
+
+      // call the per-category act seam.
+      const actFn = actByCategory[decision.category];
+      if (actFn) {
+        try {
+          actFn(c, decision);
+        } catch (err) {
+          logger.warn(
+            { ticket: c.ticket, category: decision.category, err: err?.message },
+            "unstuck-sweep: act seam threw (CTL-1064)",
+          );
+          report.failed.push({ ticket: c.ticket, phase: c.phase, category: decision.category, err: err?.message });
+          continue;
+        }
+      }
+
+      // record intent with kind:'unstuck-sweep', subject:'<ticket>/<phase>'.
+      try { recordIntent(UNSTUCK_SWEEP_INTENT_KIND, subject); } catch (err) {
+        logger.warn({ ticket: c.ticket, err: err?.message }, "unstuck-sweep: recordIntent threw (CTL-1064)");
+      }
+
+      // post comment (after act, before emit — matches recovery.mjs:564 ordering).
+      try { postComment(c.ticket, decision.category, c.phase); } catch { /* best-effort */ }
+
+      // emit the enforce event.
+      const enforceEvt = _actionToEnforceEvent(decision.action);
+      if (enforceEvt) {
+        fire(enforceEvt, { ticket: c.ticket, phase: c.phase, category: decision.category }, c.ticket);
+      }
+
+      report.acted.push({ ticket: c.ticket, phase: c.phase, category: decision.category, action: decision.action });
+    } catch (err) {
+      logger.warn(
+        { ticket: c?.ticket, err: err?.message },
+        "unstuck-sweep: per-candidate step failed — continuing (CTL-1064)",
+      );
+      report.failed.push({ ticket: c?.ticket, phase: c?.phase, err: err?.message });
+    }
+  }
+
+  return report;
+}

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
@@ -12,15 +12,52 @@
 // injected). Runs as a low-frequency throttled Pass 0u (default 15 min).
 // Ships with mode='off'; operators roll out via shadow → enforce.
 
-import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, appendFileSync } from "node:fs";
+import { join, dirname } from "node:path";
 import { spawnSync } from "node:child_process";
-import { log } from "./config.mjs";
+import { log, getEventLogPath } from "./config.mjs";
 import { UNSTUCK_SWEEP_EVENT_TYPES } from "./unstuck-sweep-event-types.mjs";
 
 export { UNSTUCK_SWEEP_EVENT_TYPES };
 
 export const UNSTUCK_SWEEP_INTENT_KIND = "unstuck-sweep";
+
+// emitUnstuckEvent — dedicated unified-log emitter for the unstuck-sweep
+// vocabulary (CTL-1064). The sweep owns UNSTUCK_SWEEP_EVENT_TYPES and MUST NOT
+// route through emitReapIntent: reap-intent.mjs's vocabulary is closed and
+// deliberately EXCLUDES unstuck.* (unstuck-sweep-event-types.mjs §"What We're
+// NOT Doing"). Passing an unstuck.* type to emitReapIntent throws "unknown
+// reap-intent event type"; because the sweep's emit is fire-and-forget, that
+// rejected promise was swallowed by runUnstuckSweepPass's fire() p.catch and
+// EVERY unstuck event (shadow would.* twins AND enforce cleared/pushed/
+// emitted/escalated) was silently dropped — an operator in shadow mode saw zero
+// events and would wrongly conclude the sweep found nothing. This emitter
+// validates against the sweep's OWN closed list and appends to the same unified
+// log getEventLogPath() resolves to. Best-effort on write failure (returns
+// false; never throws on EACCES / disk full) — mirrors emitReapIntent.
+export async function emitUnstuckEvent(eventType, fields = {}) {
+  if (!UNSTUCK_SWEEP_EVENT_TYPES.includes(eventType)) {
+    throw new Error(`unknown unstuck-sweep event type: ${eventType}`);
+  }
+  const payload = {
+    ts: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    event: eventType,
+  };
+  for (const [k, v] of Object.entries(fields)) {
+    if (v === undefined || v === null || v === "") continue;
+    payload[k] = v;
+  }
+  const line = JSON.stringify(payload) + "\n";
+  const logPath = getEventLogPath();
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, line);
+    return true;
+  } catch (err) {
+    log.error({ err: err?.message, eventType }, "emitUnstuckEvent: append failed (CTL-1064)");
+    return false;
+  }
+}
 
 // Named accessors over the frozen list — one per unstuck emit type. Indexing
 // the frozen array keeps the strings in ONE place; a typo here is a load error.
@@ -196,7 +233,12 @@ export function defaultPostUnstuckComment(
   try {
     const poster = runCommentPost ?? defaultRunCommentPost;
     const r = typeof poster === "function" ? poster(ticket, commentBody) : null;
-    if (!r || r.status === 0) {
+    // Treat a null/undefined poster result as FAILURE (leave the marker absent
+    // so the next pass retries) — mirrors recovery.mjs:596 (hardened under
+    // CTL-835). The prior `!r || r.status === 0` wrote the idempotency marker on
+    // a null result, permanently suppressing future comment attempts for this
+    // ticket/phase/category even though nothing posted (CTL-1064).
+    if (r && r.status === 0) {
       try {
         mkdirSync(workerDir, { recursive: true });
         writeMarker(markerPath);
@@ -355,19 +397,30 @@ export function runUnstuckSweepPass({
         continue;
       }
 
-      // call the per-category act seam.
+      // call the per-category act seam. When NO act seam is wired for this
+      // category (the production default is actByCategory:{}), we must NOT fall
+      // through to record an intent, post a comment, emit a success event, or
+      // push report.acted — that asserts work that never ran (false success).
+      // Skip with reason 'no-act-seam' so telemetry reflects reality (CTL-1064).
       const actFn = actByCategory[decision.category];
-      if (actFn) {
-        try {
-          actFn(c, decision);
-        } catch (err) {
-          logger.warn(
-            { ticket: c.ticket, category: decision.category, err: err?.message },
-            "unstuck-sweep: act seam threw (CTL-1064)",
-          );
-          report.failed.push({ ticket: c.ticket, phase: c.phase, category: decision.category, err: err?.message });
-          continue;
-        }
+      if (!actFn) {
+        report.skipped.push({
+          ticket: c.ticket,
+          phase: c.phase,
+          category: decision.category,
+          reason: "no-act-seam",
+        });
+        continue;
+      }
+      try {
+        actFn(c, decision);
+      } catch (err) {
+        logger.warn(
+          { ticket: c.ticket, category: decision.category, err: err?.message },
+          "unstuck-sweep: act seam threw (CTL-1064)",
+        );
+        report.failed.push({ ticket: c.ticket, phase: c.phase, category: decision.category, err: err?.message });
+        continue;
       }
 
       // record intent with kind:'unstuck-sweep', subject:'<ticket>/<phase>'.

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
@@ -1,7 +1,7 @@
 // unstuck-sweep.test.mjs — CTL-1064 pure router, action driver, census.
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -11,6 +11,9 @@ import {
   UNSTUCK_SWEEP_EVENT_TYPES,
   defaultCollectUnstuckCandidates,
   runUnstuckSweepPass,
+  buildAuditComment,
+  defaultPostUnstuckComment,
+  emitUnstuckEvent,
 } from "./unstuck-sweep.mjs";
 
 // ---------------------------------------------------------------------------
@@ -396,5 +399,157 @@ describe("defaultCollectUnstuckCandidates — shared census builder (CTL-1064)",
     const candidates = defaultCollectUnstuckCandidates({ orchDir });
     // CTL-OK still found despite CTL-BAD being malformed
     expect(candidates.some(c => c.ticket === "CTL-OK")).toBe(true);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// CTL-1064 remediation (verify⇄remediate) — regression coverage for the verify
+// findings against the original Pass 0u landing.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("runUnstuckSweepPass — enforce false-success when no act seam (CTL-1064)", () => {
+  test("clearable category with NO act seam: skipped (no-act-seam), no intent/comment/emit/acted", () => {
+    const emitted = [];
+    const recordCalls = [];
+    const commentCalls = [];
+    const report = runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [{
+        ticket: "CTL-X", phase: "implement",
+        evidence: { reason: "rebase_refused_dirty_tree", ticket: "CTL-X", phase: "implement" },
+      }],
+      actByCategory: {}, // no seam for 'dirty-tree' — the production default
+      emit: (type, fields) => { emitted.push({ type, ...fields }); return Promise.resolve(true); },
+      recordIntent: (kind, subject) => recordCalls.push({ kind, subject }),
+      postComment: (t, c, p) => commentCalls.push({ t, c, p }),
+    });
+
+    expect(report.acted).toHaveLength(0);
+    expect(report.skipped).toHaveLength(1);
+    expect(report.skipped[0]).toMatchObject({ ticket: "CTL-X", reason: "no-act-seam" });
+    expect(recordCalls).toHaveLength(0);
+    expect(commentCalls).toHaveLength(0);
+    expect(emitted).toHaveLength(0);
+  });
+
+  test("clearable category WITH an act seam still acts, records, comments, emits", () => {
+    const emitted = [];
+    const recordCalls = [];
+    const commentCalls = [];
+    const acted = [];
+    const report = runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [{
+        ticket: "CTL-Y", phase: "implement",
+        evidence: { reason: "rebase_refused_dirty_tree", ticket: "CTL-Y", phase: "implement" },
+      }],
+      actByCategory: { "dirty-tree": (c) => acted.push(c.ticket) },
+      emit: (type, fields) => { emitted.push({ type, ...fields }); return Promise.resolve(true); },
+      recordIntent: (kind, subject) => recordCalls.push({ kind, subject }),
+      postComment: (t, c, p) => commentCalls.push({ t, c, p }),
+    });
+
+    expect(acted).toEqual(["CTL-Y"]);
+    expect(report.acted).toHaveLength(1);
+    expect(recordCalls).toHaveLength(1);
+    expect(commentCalls).toHaveLength(1);
+    expect(emitted.find((e) => e.type === "unstuck.cleared.noise")).toBeDefined();
+  });
+});
+
+describe("emitUnstuckEvent — dedicated unified-log emitter (CTL-1064)", () => {
+  let SCRATCH, LOG_PATH, prevDir;
+  beforeEach(() => {
+    SCRATCH = mkdtempSync(join(tmpdir(), "unstuck-emit-"));
+    const ym = `${new Date().getUTCFullYear()}-${String(new Date().getUTCMonth() + 1).padStart(2, "0")}`;
+    LOG_PATH = join(SCRATCH, "events", `${ym}.jsonl`);
+    prevDir = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = SCRATCH;
+  });
+  afterEach(() => {
+    if (prevDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevDir;
+    rmSync(SCRATCH, { recursive: true, force: true });
+  });
+
+  test("appends a valid unstuck.* line to the unified log (does NOT throw like emitReapIntent)", async () => {
+    const ok = await emitUnstuckEvent("unstuck.would.clear-noise", {
+      ticket: "CTL-Z", phase: "implement", category: "dirty-tree",
+    });
+    expect(ok).toBe(true);
+    expect(existsSync(LOG_PATH)).toBe(true);
+    const last = JSON.parse(readFileSync(LOG_PATH, "utf8").trim().split("\n").pop());
+    expect(last.event).toBe("unstuck.would.clear-noise");
+    expect(last.ticket).toBe("CTL-Z");
+    expect(last.category).toBe("dirty-tree");
+    expect(last.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  test("accepts every type in the sweep vocabulary", async () => {
+    for (const t of UNSTUCK_SWEEP_EVENT_TYPES) {
+      expect(await emitUnstuckEvent(t, { ticket: "CTL-Z" })).toBe(true);
+    }
+  });
+
+  test("rejects an event type outside the sweep vocabulary", async () => {
+    await expect(emitUnstuckEvent("phase.yield.reap-requested", {})).rejects.toThrow(/unknown unstuck-sweep event type/);
+  });
+});
+
+describe("defaultPostUnstuckComment — success-gated idempotency marker (CTL-1064)", () => {
+  let orchDir, ticket, markerPath;
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "unstuck-comment-"));
+    ticket = "CTL-CM";
+    mkdirSync(join(orchDir, "workers", ticket), { recursive: true });
+    markerPath = join(orchDir, "workers", ticket, ".unstuck-comment-dirty-tree-implement.applied");
+  });
+  afterEach(() => rmSync(orchDir, { recursive: true, force: true }));
+
+  test("poster returns {status:0} → marker written", () => {
+    defaultPostUnstuckComment(ticket, "dirty-tree", "implement", "body", {
+      runCommentPost: () => ({ status: 0 }), orchDir,
+    });
+    expect(existsSync(markerPath)).toBe(true);
+  });
+
+  test("poster returns null → marker ABSENT (next pass retries) — the fixed branch", () => {
+    defaultPostUnstuckComment(ticket, "dirty-tree", "implement", "body", {
+      runCommentPost: () => null, orchDir,
+    });
+    expect(existsSync(markerPath)).toBe(false);
+  });
+
+  test("poster returns {status:1} → marker ABSENT", () => {
+    defaultPostUnstuckComment(ticket, "dirty-tree", "implement", "body", {
+      runCommentPost: () => ({ status: 1 }), orchDir,
+    });
+    expect(existsSync(markerPath)).toBe(false);
+  });
+
+  test("marker already present → idempotent skip (poster never called)", () => {
+    writeFileSync(markerPath, "");
+    let called = 0;
+    defaultPostUnstuckComment(ticket, "dirty-tree", "implement", "body", {
+      runCommentPost: () => { called++; return { status: 0 }; }, orchDir,
+    });
+    expect(called).toBe(0);
+  });
+});
+
+describe("buildAuditComment — three-section assembler (CTL-1064)", () => {
+  test("renders all three sections when provided", () => {
+    const out = buildAuditComment({ found: "F", done: "D", verified: "V" });
+    expect(out).toContain("**What was found**");
+    expect(out).toContain("F");
+    expect(out).toContain("**What was done**");
+    expect(out).toContain("D");
+    expect(out).toContain("**What was verified after**");
+    expect(out).toContain("V");
+  });
+
+  test("falls back to _unavailable_ for missing sections", () => {
+    const out = buildAuditComment({});
+    expect(out.match(/_unavailable_/g)).toHaveLength(3);
   });
 });

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
@@ -1,0 +1,400 @@
+// unstuck-sweep.test.mjs — CTL-1064 pure router, action driver, census.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  classifyStalledTicket,
+  STALL_CATEGORY_MAP,
+  UNSTUCK_SWEEP_INTENT_KIND,
+  UNSTUCK_SWEEP_EVENT_TYPES,
+  defaultCollectUnstuckCandidates,
+  runUnstuckSweepPass,
+} from "./unstuck-sweep.mjs";
+
+// ---------------------------------------------------------------------------
+// classifyStalledTicket — pure top-level router (CTL-1064)
+// ---------------------------------------------------------------------------
+describe("classifyStalledTicket — pure top-level router (CTL-1064)", () => {
+  test("rebase_refused_dirty_tree → dirty-tree/clear-noise-and-retry", () => {
+    const r = classifyStalledTicket({ reason: "rebase_refused_dirty_tree" });
+    expect(r.category).toBe("dirty-tree");
+    expect(r.action).toBe("clear-noise-and-retry");
+  });
+
+  test("source_conflict_ctl708_unavailable → source-conflict/force-push-if-clean", () => {
+    const r = classifyStalledTicket({ reason: "source_conflict_ctl708_unavailable" });
+    expect(r.category).toBe("source-conflict");
+    expect(r.action).toBe("force-push-if-clean");
+  });
+
+  test("orphan-sweep-stale (normalized from failureReason) → orphan-stale", () => {
+    const r = classifyStalledTicket({ reason: "orphan-sweep-stale" });
+    expect(r.category).toBe("orphan-stale");
+    expect(r.action).toBe("emit-phase-complete-if-merged");
+  });
+
+  test("remediate-cycle-cap-exhausted → remediate-cap/escalate", () => {
+    const r = classifyStalledTicket({ reason: "remediate-cycle-cap-exhausted" });
+    expect(r.category).toBe("remediate-cap");
+    expect(r.action).toBe("escalate");
+  });
+
+  test("unknown/unrecognized reason → unknown/escalate", () => {
+    const r = classifyStalledTicket({ reason: "some-unknown-reason" });
+    expect(r.category).toBe("unknown");
+    expect(r.action).toBe("escalate");
+  });
+
+  test("empty-branch-like reason (unrecognized) → unknown/escalate", () => {
+    const r = classifyStalledTicket({ reason: "empty_branch:0_commits_ahead_of_origin/main" });
+    expect(r.category).toBe("unknown");
+    expect(r.action).toBe("escalate");
+  });
+
+  test("null reason → unknown/escalate", () => {
+    const r = classifyStalledTicket({ reason: null });
+    expect(r.category).toBe("unknown");
+    expect(r.action).toBe("escalate");
+  });
+
+  test("undefined reason → unknown/escalate", () => {
+    const r = classifyStalledTicket({ reason: undefined });
+    expect(r.category).toBe("unknown");
+    expect(r.action).toBe("escalate");
+  });
+
+  test("liveSessionInWorktree:true → action:skip regardless of reason", () => {
+    const r = classifyStalledTicket({ reason: "rebase_refused_dirty_tree", liveSessionInWorktree: true });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("live-session");
+  });
+
+  test("linearTerminal:true → action:skip regardless of reason", () => {
+    const r = classifyStalledTicket({ reason: "source_conflict_ctl708_unavailable", linearTerminal: true });
+    expect(r.action).toBe("skip");
+    expect(r.reason).toBe("linear-terminal");
+  });
+
+  test("liveSession takes precedence over linearTerminal", () => {
+    const r = classifyStalledTicket({ reason: "rebase_refused_dirty_tree", liveSessionInWorktree: true, linearTerminal: true });
+    expect(r.reason).toBe("live-session");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UNSTUCK_SWEEP_INTENT_KIND constant
+// ---------------------------------------------------------------------------
+describe("UNSTUCK_SWEEP_INTENT_KIND (CTL-1064)", () => {
+  test("equals 'unstuck-sweep'", () => {
+    expect(UNSTUCK_SWEEP_INTENT_KIND).toBe("unstuck-sweep");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UNSTUCK_SWEEP_EVENT_TYPES — 10 unique strings, all starting with 'unstuck.'
+// ---------------------------------------------------------------------------
+describe("UNSTUCK_SWEEP_EVENT_TYPES (CTL-1064)", () => {
+  test("has exactly 10 strings", () => {
+    expect(UNSTUCK_SWEEP_EVENT_TYPES.length).toBe(10);
+  });
+  test("all start with 'unstuck.'", () => {
+    for (const t of UNSTUCK_SWEEP_EVENT_TYPES) {
+      expect(t.startsWith("unstuck.")).toBe(true);
+    }
+  });
+  test("all are unique", () => {
+    const uniq = new Set(UNSTUCK_SWEEP_EVENT_TYPES);
+    expect(uniq.size).toBe(10);
+  });
+  test("is frozen", () => {
+    expect(Object.isFrozen(UNSTUCK_SWEEP_EVENT_TYPES)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runUnstuckSweepPass — action driver (CTL-1064)
+// ---------------------------------------------------------------------------
+describe("runUnstuckSweepPass — action driver (CTL-1064)", () => {
+  function makeCandidate(overrides = {}) {
+    return {
+      ticket: "CTL-TEST",
+      phase: "implement",
+      evidence: {
+        reason: "rebase_refused_dirty_tree",
+        ticket: "CTL-TEST",
+        phase: "implement",
+        liveSessionInWorktree: false,
+        linearTerminal: false,
+      },
+      ...overrides,
+    };
+  }
+
+  test("mode:'off' → pass entirely skipped (census never called, no events, no intents)", () => {
+    let censusCount = 0;
+    let emitCount = 0;
+    let intentCount = 0;
+    const report = runUnstuckSweepPass({
+      mode: "off",
+      collectCandidates: () => { censusCount++; return [makeCandidate()]; },
+      emit: () => { emitCount++; },
+      recordIntent: () => { intentCount++; },
+    });
+    expect(censusCount).toBe(0);
+    expect(emitCount).toBe(0);
+    expect(intentCount).toBe(0);
+    expect(report.acted).toEqual([]);
+    expect(report.wouldAct).toEqual([]);
+  });
+
+  test("mode:'shadow' → emits would.* only; no act seam, no intent, no comment", () => {
+    const emitted = [];
+    const actCalled = [];
+    const intentCalled = [];
+    const commentCalled = [];
+    const report = runUnstuckSweepPass({
+      mode: "shadow",
+      collectCandidates: () => [makeCandidate()],
+      actByCategory: { "dirty-tree": () => { actCalled.push(1); } },
+      emit: (type, fields) => { emitted.push({ type, fields }); },
+      recordIntent: () => { intentCalled.push(1); },
+      postComment: () => { commentCalled.push(1); },
+    });
+    expect(actCalled).toHaveLength(0);
+    expect(intentCalled).toHaveLength(0);
+    expect(commentCalled).toHaveLength(0);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].type).toBe("unstuck.would.clear-noise");
+    expect(report.wouldAct).toHaveLength(1);
+    expect(report.acted).toHaveLength(0);
+    expect(report.escalated).toHaveLength(0);
+  });
+
+  test("mode:'shadow' for escalate category → emits unstuck.would.escalate", () => {
+    const emitted = [];
+    const report = runUnstuckSweepPass({
+      mode: "shadow",
+      collectCandidates: () => [makeCandidate({
+        evidence: { reason: "remediate-cycle-cap-exhausted", ticket: "CTL-TEST", phase: "implement", liveSessionInWorktree: false, linearTerminal: false },
+      })],
+      emit: (type) => { emitted.push(type); },
+    });
+    expect(emitted).toContain("unstuck.would.escalate");
+    expect(report.wouldEscalate).toHaveLength(1);
+  });
+
+  test("mode:'enforce' + clearable → calls act seam + recordIntent + postComment + emits enforce event", () => {
+    const actCalled = [];
+    const intentCalled = [];
+    const commentCalled = [];
+    const emitted = [];
+    runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [makeCandidate()],
+      actByCategory: { "dirty-tree": (c, d) => { actCalled.push({ c, d }); } },
+      emit: (type) => { emitted.push(type); },
+      recordIntent: (kind, subject) => { intentCalled.push({ kind, subject }); },
+      isIntentEffective: () => false,
+      postComment: (t, cat, p) => { commentCalled.push({ t, cat, p }); },
+    });
+    expect(actCalled).toHaveLength(1);
+    expect(intentCalled).toHaveLength(1);
+    expect(intentCalled[0].kind).toBe("unstuck-sweep");
+    expect(intentCalled[0].subject).toBe("CTL-TEST/implement");
+    expect(commentCalled).toHaveLength(1);
+    expect(commentCalled[0].cat).toBe("dirty-tree");
+    expect(emitted).toContain("unstuck.cleared.noise");
+  });
+
+  test("mode:'enforce' + escalate category → calls escalate seam + postComment + emits unstuck.escalated", () => {
+    const escalateCalled = [];
+    const commentCalled = [];
+    const emitted = [];
+    runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [makeCandidate({
+        evidence: { reason: "remediate-cycle-cap-exhausted", ticket: "CTL-TEST", phase: "implement", liveSessionInWorktree: false, linearTerminal: false },
+      })],
+      escalate: (c) => { escalateCalled.push(c.ticket); },
+      emit: (type) => { emitted.push(type); },
+      postComment: (t) => { commentCalled.push(t); },
+    });
+    expect(escalateCalled).toContain("CTL-TEST");
+    expect(emitted).toContain("unstuck.escalated");
+    expect(commentCalled).toContain("CTL-TEST");
+  });
+
+  test("mode:'enforce' + skip (live session) → no act, no emit, no intent", () => {
+    const actCalled = [];
+    const emitted = [];
+    const intentCalled = [];
+    runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [makeCandidate({
+        evidence: { reason: "rebase_refused_dirty_tree", ticket: "CTL-TEST", phase: "implement", liveSessionInWorktree: true, linearTerminal: false },
+      })],
+      actByCategory: { "dirty-tree": () => { actCalled.push(1); } },
+      emit: () => { emitted.push(1); },
+      recordIntent: () => { intentCalled.push(1); },
+    });
+    expect(actCalled).toHaveLength(0);
+    expect(emitted).toHaveLength(0);
+    expect(intentCalled).toHaveLength(0);
+  });
+
+  test("mode:'enforce' + isIntentEffective=true → skips action (storm-prevention)", () => {
+    const actCalled = [];
+    const report = runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [makeCandidate()],
+      actByCategory: { "dirty-tree": () => { actCalled.push(1); } },
+      isIntentEffective: () => true,
+      emit: () => {},
+    });
+    expect(actCalled).toHaveLength(0);
+    expect(report.skipped).toHaveLength(1);
+    expect(report.skipped[0].reason).toBe("intent-effective");
+  });
+
+  test("records intent with kind:'unstuck-sweep' and subject:'<ticket>/<phase>'", () => {
+    const intents = [];
+    runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [makeCandidate()],
+      actByCategory: { "dirty-tree": () => {} },
+      emit: () => {},
+      recordIntent: (kind, subject) => { intents.push({ kind, subject }); },
+      isIntentEffective: () => false,
+    });
+    expect(intents[0].kind).toBe("unstuck-sweep");
+    expect(intents[0].subject).toBe("CTL-TEST/implement");
+  });
+
+  test("a throwing census never aborts the pass (degrades to empty list)", () => {
+    const report = runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => { throw new Error("census failed"); },
+      emit: () => {},
+    });
+    expect(report.acted).toHaveLength(0);
+    expect(report.failed).toHaveLength(0);
+  });
+
+  test("a throwing per-candidate seam does not abort the rest", () => {
+    const actCalled = [];
+    const report = runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [
+        makeCandidate({ ticket: "T1" }),
+        makeCandidate({ ticket: "T2" }),
+      ],
+      actByCategory: {
+        "dirty-tree": (c) => {
+          if (c.ticket === "T1") throw new Error("T1 failed");
+          actCalled.push(c.ticket);
+        },
+      },
+      emit: () => {},
+      isIntentEffective: () => false,
+    });
+    expect(actCalled).toContain("T2");
+    expect(report.failed.some(f => f.ticket === "T1")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultCollectUnstuckCandidates — shared census builder (CTL-1064)
+// ---------------------------------------------------------------------------
+describe("defaultCollectUnstuckCandidates — shared census builder (CTL-1064)", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "ctl1064-census-"));
+  });
+  afterEach(() => {
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  function makeWorker(ticket, signalOverrides = {}) {
+    const d = join(orchDir, "workers", ticket);
+    mkdirSync(d, { recursive: true });
+    const signal = {
+      ticket,
+      phase: "implement",
+      status: "stalled",
+      stalledReason: "rebase_refused_dirty_tree",
+      ...signalOverrides,
+    };
+    writeFileSync(join(d, "phase-implement.json"), JSON.stringify(signal));
+    return d;
+  }
+
+  test("reads stalledReason from status:stalled phase signals", () => {
+    makeWorker("CTL-STALLED");
+    const candidates = defaultCollectUnstuckCandidates({ orchDir });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].ticket).toBe("CTL-STALLED");
+    expect(candidates[0].evidence.reason).toBe("rebase_refused_dirty_tree");
+  });
+
+  test("reads failureReason from status:failed + failureReason:orphan-sweep-stale", () => {
+    makeWorker("CTL-ORPHAN", {
+      status: "failed",
+      failureReason: "orphan-sweep-stale",
+      stalledReason: undefined,
+    });
+    const candidates = defaultCollectUnstuckCandidates({ orchDir });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].evidence.reason).toBe("orphan-sweep-stale");
+  });
+
+  test("skips running/done signals and tickets with wrong status", () => {
+    makeWorker("CTL-RUNNING", { status: "running" });
+    makeWorker("CTL-DONE", { status: "done" });
+    const candidates = defaultCollectUnstuckCandidates({ orchDir });
+    expect(candidates).toHaveLength(0);
+  });
+
+  test("liveSessionInWorktree set from agentsSnapshot", () => {
+    makeWorker("CTL-LIVE");
+    const candidates = defaultCollectUnstuckCandidates({
+      orchDir,
+      agentsSnapshot: [{ cwd: "/some/worktree/CTL-LIVE" }],
+      resolveWorktreePath: () => "/some/worktree/CTL-LIVE",
+    });
+    expect(candidates[0].evidence.liveSessionInWorktree).toBe(true);
+  });
+
+  test("linearTerminal set from injected isLinearTerminal seam", () => {
+    makeWorker("CTL-TERMINAL");
+    const candidates = defaultCollectUnstuckCandidates({
+      orchDir,
+      isLinearTerminal: (t) => t === "CTL-TERMINAL",
+    });
+    expect(candidates[0].evidence.linearTerminal).toBe(true);
+  });
+
+  test("worktreePath from resolveWorktreePath seam (null when absent)", () => {
+    makeWorker("CTL-NOPATH");
+    const candidates = defaultCollectUnstuckCandidates({ orchDir });
+    expect(candidates[0].evidence.worktreePath).toBeNull();
+  });
+
+  test("a throwing probe for one ticket does not abort enumeration of others", () => {
+    const d1 = join(orchDir, "workers", "CTL-OK");
+    mkdirSync(d1, { recursive: true });
+    writeFileSync(
+      join(d1, "phase-implement.json"),
+      JSON.stringify({ ticket: "CTL-OK", phase: "implement", status: "stalled", stalledReason: "rebase_refused_dirty_tree" }),
+    );
+    // malformed json for second ticket
+    const d2 = join(orchDir, "workers", "CTL-BAD");
+    mkdirSync(d2, { recursive: true });
+    writeFileSync(join(d2, "phase-implement.json"), "{ not json");
+
+    const candidates = defaultCollectUnstuckCandidates({ orchDir });
+    // CTL-OK still found despite CTL-BAD being malformed
+    expect(candidates.some(c => c.ticket === "CTL-OK")).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-12T05:13:00Z -->
<!-- Last updated: 2026-06-12T05:13:00Z -->
<!-- PR: #1880 -->
<!-- Previous commits: 0ddfdfe74fb8d6351cf6af6d3bcb8cf69bda6a8b,d9c7a2120bb90e938441e59c6ed7e58df23346d6 -->

## Summary

- Adds a throttled classify-then-act recovery sweep (Pass 0u, 15-min default) for the stalled/needs-human ticket backlog, shipped with `mode='off'` so operators opt in via `CATALYST_UNSTUCK_SWEEP=shadow` then `=enforce` (or Layer-2 config)
- Five classifiers handle: dirty-tree rebase stalls, source-conflict force-push gates, orphan-sweep-stale merged PRs, stale attention labels on terminal tickets, and unknown/escalated categories
- Full beliefs/intent.mjs integration: new `unstuck-sweep` postcondition resolves via `worldSnapshot.signalStatusBySubject`; beliefs/collector.mjs populates the map from already-in-scope signals (zero extra I/O)
- Remediate pass: fixed silent-failure event emission, enforce false-success on missing act seam, intent gate polarity + dedup, catB whole-token ownership guard, and defaultPostUnstuckComment idempotency marker

## What shipped

### New modules

- `unstuck-sweep-event-types.mjs` — 10 event type strings
- `dirty-tree-classifier.mjs` — noise-filtered porcelain + recoverable classifier
- `catB-force-with-lease.mjs` — 3-part safety gate for force-push (whole-token ownership guard post-remediate)
- `unstuck-orphan-merge.mjs` — orphan merged-PR reconcile
- `unstuck-stale-label.mjs` — terminal stale-label classifier
- `unstuck-sweep-evidence.mjs` — injectable evidence collector
- `unstuck-sweep-escalation.mjs` — causal escalation comment author
- `unstuck-sweep.mjs` — main driver (`classifyStalledTicket`, `runUnstuckSweepPass`)

### Modified

- `config.mjs` — `readUnstuckSweepConfig`, `isThrottled`
- `scheduler.mjs` — Pass 0u block, unstuckSweep parameter block, report arrays, `emitUnstuckEvent` (dedicated emitter fixing silent event drops)
- `beliefs/collector.mjs` — `signalStatusBySubject` worldSnapshot field
- `beliefs/intent.mjs` — `unstuck-sweep` postcondition case
- `beliefs/intent.test.mjs` — 6 new postcondition tests
- `integration-ctl-1064.test.mjs` — 10 end-to-end tests: shadow/enforce/throttle/off/skip; extended in remediate pass with real-default-emit, enforce no-act-seam, real-intentDb two-pass act-once-then-skip

## Remediate fixes

**HIGH**
- Silent event drops: `emitReapIntent` rejected all `unstuck.*` events (closed vocabulary) and the fire-and-forget path swallowed the rejection. Added `emitUnstuckEvent` that validates against `UNSTUCK_SWEEP_EVENT_TYPES` and appends to the unified log.
- Enforce false-success: when `actByCategory[category]` was undefined, the act was skipped but execution recorded an intent, posted a comment, and pushed `report.acted`. Now skips with reason `no-act-seam` before any side effects.

**MEDIUM**
- Intent gate polarity: was `!isIntentEffective`, causing re-act every pass until cap. Replaced with open-intent probe (act-once-then-skip) with deduped INSERT.
- catB Gate 2 substring match: `CTL-1` matched `CTL-10`. Now uses whole-token `\b<prefix>-0*<num>\b` regex.
- `defaultPostUnstuckComment` idempotency marker written on null result, permanently suppressing retries. Fixed to `r && r.status===0` (mirrors recovery.mjs).
- Production census omitted `resolveWorktreePath`, making the live-session gate dead.

**LOW**
- catB used in-body `require()` (undefined in `type:module` packages). Hoisted to ESM import.
- Corrected misleading comments in `startScheduler` re: Pass 0u shadow-only intent.

## Test results

- [x] All CI checks passing (audit-references, check-versions, docs-gate, execution-core-unit-tests, validate)
- [x] `integration-ctl-1064.test.mjs` exercises shadow, enforce, throttle guard, mode=off, live-session skip, linear-terminal skip, multi-candidate, real-default-emit, enforce no-act-seam, two-pass act-once-then-skip
- [x] Existing scheduler tests (455) + integration-ctl-1004/1005 (19) unaffected
- [x] 4 pre-existing timing flakes (daemon, ctl-587, monitor burst-budget, claim fence-check) verified failing on baseline with changes stashed

## Related Issues/PRs

- Fixes https://linear.app/adva/issue/CTL-1064

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1
