### PR TITLE
CTL-1076: A finished phase's debris should not park the next phase for half an hour

### DIFF
--- a/plugins/dev/scripts/__tests__/worktree-rebase-lib.test.sh
+++ b/plugins/dev/scripts/__tests__/worktree-rebase-lib.test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Wrapper so run-tests.sh discovers the lib/__tests__ worktree-rebase suite (CTL-1076).
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "${SCRIPT_DIR}/../lib/__tests__/worktree-rebase.test.sh"

--- a/plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh
@@ -653,9 +653,16 @@ advance_origin_main_clean
     rebase_onto_base_classified "main"
   echo "$?" >"$SCRATCH/t21.rc"
   echo "${REBASE_LAST_STALL_REASON:-}" >"$SCRATCH/t21.reason"
+  # 21b: capture RT_PRECHECK inside the subshell where it is set (CTL-1076 Phase 3)
+  printf '%s\n' "${RT_PRECHECK[@]+"${RT_PRECHECK[@]}"}" >"$SCRATCH/t21.files"
 )
 assert_eq "2" "$(cat "$SCRATCH/t21.rc")" "real source dirt → rc 2"
 assert_eq "rebase_refused_dirty_tree" "$(cat "$SCRATCH/t21.reason")" "real source → typed reason"
+
+# ── 21b. RT_PRECHECK carries offending file name after stall ──────────────────
+echo "21b. RT_PRECHECK carries offending file name after stall"
+assert_eq "shared.txt" "$(grep -Fx shared.txt "$SCRATCH/t21.files")" \
+  "RT_PRECHECK lists the dirty source file"
 
 # ── 22. settling-debris-only (untracked node_modules/) → grace re-probe → clean
 echo "22. untracked node_modules settling-debris → grace re-probe → rc 0"
@@ -702,6 +709,22 @@ for s in src/index.ts shared.txt plugins/dev/scripts/foo.sh; do
   if _is_settling_debris_path "$s"; then fail "_is_settling_debris_path $s → false (expected source)"
   else pass "_is_settling_debris_path $s → false"; fi
 done
+
+# ── 25. escalation-explain.mjs threads observed.dirtyFiles through unchanged ─
+echo "25. escalation-explain.mjs round-trips observed.dirtyFiles (CTL-1076 Phase 3)"
+EXPLAIN_MJS="${SCRIPT_DIR}/../../execution-core/escalation-explain.mjs"
+if [[ -f "$EXPLAIN_MJS" ]] && command -v node >/dev/null 2>&1; then
+  OBS='{"rebaseRc":2,"stallReason":"rebase_refused_dirty_tree","dirtyFiles":["shared.txt"]}'
+  EXPL_OUT="$(node "$EXPLAIN_MJS" \
+    --ticket CTL-1076 --phase plan \
+    --what-failed "x" --why-gave-up "y" --human-question "z" \
+    --observed "$OBS" 2>/dev/null || echo '{}')"
+  assert_eq "shared.txt" \
+    "$(printf '%s' "$EXPL_OUT" | jq -r '.observed.dirtyFiles[0]' 2>/dev/null)" \
+    "escalation-explain: observed.dirtyFiles[0] passes through unchanged"
+else
+  echo "  SKIP: escalation-explain.mjs or node not available"
+fi
 
 echo
 echo "results: $PASSES passed, $FAILURES failed"

--- a/plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh
@@ -640,6 +640,69 @@ new_fixture t20b
 assert_eq "1" "$(cat "$SCRATCH/t20b.marker")" "noise_stash_push reports the deleted noise stashed"
 assert_eq "" "$(cat "$SCRATCH/t20b.afterpush")" "deleted noise path clean after stash push"
 
+# ── 21. real uncommitted source still parks IMMEDIATELY (CTL-1068 preserved) ─
+echo "21. real source dirt → immediate rebase_refused_dirty_tree (no grace)"
+new_fixture t21
+advance_origin_main_clean
+(
+  cd "$WORK"
+  printf 'local-feature\n' >local.txt
+  git add -A && git commit --quiet -m "local feature"
+  printf 'dirty-edit\n' >shared.txt            # real tracked source, uncommitted
+  CATALYST_REBASE_GRACE_TOTAL_S=0 CATALYST_REBASE_GRACE_INTERVAL_S=0 \
+    rebase_onto_base_classified "main"
+  echo "$?" >"$SCRATCH/t21.rc"
+  echo "${REBASE_LAST_STALL_REASON:-}" >"$SCRATCH/t21.reason"
+)
+assert_eq "2" "$(cat "$SCRATCH/t21.rc")" "real source dirt → rc 2"
+assert_eq "rebase_refused_dirty_tree" "$(cat "$SCRATCH/t21.reason")" "real source → typed reason"
+
+# ── 22. settling-debris-only (untracked node_modules/) → grace re-probe → clean
+echo "22. untracked node_modules settling-debris → grace re-probe → rc 0"
+new_fixture t22
+advance_origin_main_clean
+(
+  cd "$WORK"
+  printf 'local-feature\n' >local.txt
+  git add -A && git commit --quiet -m "local feature"
+  mkdir -p node_modules/pkg
+  printf 'junk\n' >node_modules/pkg/index.js   # untracked settling-debris
+  CATALYST_REBASE_GRACE_TOTAL_S=0 CATALYST_REBASE_GRACE_INTERVAL_S=0 \
+    rebase_onto_base_classified "main"
+  echo "$?" >"$SCRATCH/t22.rc"
+  [[ -f upstream.txt ]] && echo yes >"$SCRATCH/t22.base" || echo no >"$SCRATCH/t22.base"
+)
+assert_eq "0" "$(cat "$SCRATCH/t22.rc")" "node_modules-only debris → rc 0 after grace re-probe"
+assert_eq "yes" "$(cat "$SCRATCH/t22.base")" "debris re-probe still advanced onto new base"
+
+# ── 23. mixed real source + debris → stalls (real source dominates) ──────────
+echo "23. real source + debris mixed → rc 2 (real source forces park)"
+new_fixture t23
+advance_origin_main_clean
+(
+  cd "$WORK"
+  printf 'local-feature\n' >local.txt
+  git add -A && git commit --quiet -m "local feature"
+  printf 'dirty-edit\n' >shared.txt            # real source
+  mkdir -p node_modules/pkg
+  printf 'junk\n' >node_modules/pkg/index.js   # debris
+  CATALYST_REBASE_GRACE_TOTAL_S=0 CATALYST_REBASE_GRACE_INTERVAL_S=0 \
+    rebase_onto_base_classified "main"
+  echo "$?" >"$SCRATCH/t23.rc"
+)
+assert_eq "2" "$(cat "$SCRATCH/t23.rc")" "mixed source+debris → rc 2"
+
+# ── 24. _is_settling_debris_path matches debris, rejects source ───────────────
+echo "24. _is_settling_debris_path classification"
+for d in node_modules/pkg/index.js build/output.log foo.log .claude/scheduled_tasks.lock; do
+  if _is_settling_debris_path "$d"; then pass "_is_settling_debris_path $d → true"
+  else fail "_is_settling_debris_path $d → true (expected debris)"; fi
+done
+for s in src/index.ts shared.txt plugins/dev/scripts/foo.sh; do
+  if _is_settling_debris_path "$s"; then fail "_is_settling_debris_path $s → false (expected source)"
+  else pass "_is_settling_debris_path $s → false"; fi
+done
+
 echo
 echo "results: $PASSES passed, $FAILURES failed"
 [ $FAILURES -eq 0 ]

--- a/plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh
@@ -60,6 +60,7 @@ new_fixture() {
 		mkdir -p .catalyst .claude
 		printf '{"committed":true}\n' >.catalyst/config.json
 		printf '{"claude":true}\n' >.claude/config.json
+		printf '{"sessionId":"seed","pid":1,"acquiredAt":0}\n' >.claude/scheduled_tasks.lock
 		git add -A
 		git commit --quiet -m "initial"
 		git push --quiet origin main
@@ -606,6 +607,38 @@ assert_eq '{"committed":false,"dirty":true}' "$(cat "$WORK/.catalyst/config.json
   "refresh: dirty noise restored after rebase"
 T18_BASE="no"; [[ -f "$WORK/upstream.txt" ]] && T18_BASE="yes"
 assert_eq "yes" "$T18_BASE" "refresh: worktree advanced onto new base"
+
+# ── 20. deleted tracked .claude/scheduled_tasks.lock → stashed noise, clean rebase
+echo "20. deleted scheduled_tasks.lock is settling-debris noise → rc 0"
+new_fixture t20
+advance_origin_main_clean
+(
+  cd "$WORK"
+  printf 'local-feature\n' >local.txt
+  git add -A && git commit --quiet -m "local feature"
+  # Simulate the dying worker: delete the tracked lock file (unstaged deletion).
+  rm -f .claude/scheduled_tasks.lock
+  rebase_onto_base_classified "main"
+  echo "$?" >"$SCRATCH/t20.rc"
+  [[ -f upstream.txt ]] && echo yes >"$SCRATCH/t20.base" || echo no >"$SCRATCH/t20.base"
+  git diff --quiet && echo clean >"$SCRATCH/t20.tree" || echo dirty >"$SCRATCH/t20.tree"
+)
+assert_eq "0" "$(cat "$SCRATCH/t20.rc")" "deleted scheduled_tasks.lock → rc 0 (stashed as noise)"
+assert_eq "yes" "$(cat "$SCRATCH/t20.base")" "rebase still advanced onto new base"
+
+# ── 20b. noise_stash_push captures a deleted tracked noise path
+echo "20b. noise_stash_push stashes a deleted tracked noise file"
+new_fixture t20b
+(
+  cd "$WORK"
+  rm -f .claude/scheduled_tasks.lock           # tracked deletion, file absent on disk
+  marker="$(noise_stash_push)"
+  echo "$marker" >"$SCRATCH/t20b.marker"
+  git status --porcelain -- .claude/scheduled_tasks.lock >"$SCRATCH/t20b.afterpush"
+  noise_stash_pop "$marker"
+)
+assert_eq "1" "$(cat "$SCRATCH/t20b.marker")" "noise_stash_push reports the deleted noise stashed"
+assert_eq "" "$(cat "$SCRATCH/t20b.afterpush")" "deleted noise path clean after stash push"
 
 echo
 echo "results: $PASSES passed, $FAILURES failed"

--- a/plugins/dev/scripts/lib/worktree-rebase.sh
+++ b/plugins/dev/scripts/lib/worktree-rebase.sh
@@ -56,6 +56,64 @@ _is_noise_path() {
   return 1
 }
 
+# _is_settling_debris_path FILE → 0 when FILE is machine-noise that a dying
+# worker leaves behind and that settles on its own (CTL-1076). Superset of
+# _is_noise_path: also matches untracked build churn that is never real source.
+_is_settling_debris_path() {
+  local f="$1"
+  _is_noise_path "$f" && return 0
+  case "$f" in
+    node_modules/*|*/node_modules/*) return 0 ;;
+    *.log)                           return 0 ;;
+  esac
+  return 1
+}
+
+# _collect_precheck_dirt → fill RT_PRECHECK[] with all dirty paths (tracked
+# diff, staged diff, and untracked from porcelain).
+_collect_precheck_dirt() {
+  RT_PRECHECK=()
+  local _pf
+  while IFS= read -r _pf; do
+    [[ -n $_pf ]] && RT_PRECHECK+=("$_pf")
+  done < <({ git diff --name-only; git diff --cached --name-only;
+             git ls-files --others --exclude-standard; } 2>/dev/null | sort -u)
+}
+
+# _precheck_has_real_source → 0 if ANY path in RT_PRECHECK is NOT settling-debris.
+_precheck_has_real_source() {
+  local f
+  for f in "${RT_PRECHECK[@]+"${RT_PRECHECK[@]}"}"; do
+    _is_settling_debris_path "$f" || return 0
+  done
+  return 1
+}
+
+# _grace_reprobe_clears BASE MARKER → 0 if, within the grace window, the tree
+# becomes clean of tracked dirt (settling-debris settled / restashed). Bounded
+# by CATALYST_REBASE_GRACE_TOTAL_S (default 60) at
+# CATALYST_REBASE_GRACE_INTERVAL_S (default 5) intervals. Re-runs
+# noise_stash_push each probe so a freshly-settled noise path gets stashed.
+# With both knobs 0, probes exactly once (test mode).
+_grace_reprobe_clears() {
+  local _base="$1" _marker="$2"
+  local total="${CATALYST_REBASE_GRACE_TOTAL_S:-60}"
+  local interval="${CATALYST_REBASE_GRACE_INTERVAL_S:-5}"
+  local elapsed=0
+  while :; do
+    noise_stash_push >/dev/null 2>&1 || true
+    if git diff --quiet 2>/dev/null && git diff --cached --quiet 2>/dev/null; then
+      return 0
+    fi
+    _collect_precheck_dirt
+    _precheck_has_real_source && return 1   # source appeared mid-window → park now
+    (( elapsed >= total )) && return 1
+    (( interval > 0 )) && sleep "$interval"
+    elapsed=$(( elapsed + interval ))
+    (( interval == 0 )) && return 1          # test mode: one probe only
+  done
+}
+
 # rebase_in_progress → 0 when a rebase is mid-flight (stopped on a conflict),
 # 1 otherwise. Guards `git rebase --continue` (CTL-990): calling --continue
 # with nothing in progress exits non-zero and used to mis-report as
@@ -228,16 +286,26 @@ rebase_onto_base_classified() {
   # That is a pre-flight refusal, not a conflict — no unmerged paths exist, so
   # classify_conflicted_files sees nothing and the old code cascaded into a
   # bogus `git rebase --continue` → {continue_failed, files:[], category:
-  # unknown}, looping ~1,300 events per ticket. Any tracked dirt that survives
-  # noise_stash_push is real: stall with a typed reason + the offending files.
+  # unknown}, looping ~1,300 events per ticket.
+  # CTL-1076: a finished phase's settling debris (deleted .claude/scheduled_tasks.lock
+  # already stashed in Phase 1; untracked node_modules/ or *.log churn) must not
+  # blanket-park the next phase. Classify surviving dirt: real source → stall NOW
+  # (it never settles, CTL-1068); all-debris → bounded grace re-probe to let it
+  # settle, then proceed if clean.
   if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
-    RT_PRECHECK=()
-    local _pf
-    while IFS= read -r _pf; do
-      [[ -n $_pf ]] && RT_PRECHECK+=("$_pf")
-    done < <({ git diff --name-only; git diff --cached --name-only; } 2>/dev/null | sort -u)
-    _stall_and_return "$marker" rebase_refused_dirty_tree 2
-    return
+    _collect_precheck_dirt
+    if _precheck_has_real_source; then
+      _stall_and_return "$marker" rebase_refused_dirty_tree 2
+      return
+    fi
+    # All surviving dirt is settling-debris → grace re-probe.
+    if _grace_reprobe_clears "$base" "$marker"; then
+      :   # tree settled (and re-stashed); fall through to the rebase attempt
+    else
+      _collect_precheck_dirt
+      _stall_and_return "$marker" rebase_refused_dirty_tree 2
+      return
+    fi
   fi
 
   if git rebase --quiet "origin/${base}" 2>/dev/null; then

--- a/plugins/dev/scripts/lib/worktree-rebase.sh
+++ b/plugins/dev/scripts/lib/worktree-rebase.sh
@@ -34,10 +34,14 @@ _WR_DIR="$(cd "$(dirname "$_WR_SELF")" && pwd)"
 # incidents. NOTE: only these EXACT paths are noise; the rest of .claude/
 # (skills/agents/rules) is real committed content and must keep classifying
 # as source (see _is_noise_path).
+# CTL-1076: .claude/scheduled_tasks.lock is a tracked file the Claude Code
+# scheduler DELETES on worker exit (settling debris). The deletion shows in
+# `git diff --name-only` and trips the precheck, but is machine-local noise.
 # shellcheck disable=SC2034
 WORKTREE_NOISE_PATHS=(
   .catalyst/config.json
   .claude/config.json .claude/settings.json
+  .claude/scheduled_tasks.lock
   .trunk/actions .trunk/logs .trunk/notifications .trunk/out .trunk/tools
 )
 
@@ -79,7 +83,12 @@ noise_stash_push() {
   local present=()
   local p
   for p in "${WORKTREE_NOISE_PATHS[@]}"; do
-    [[ -e $p ]] && present+=("$p")
+    # CTL-1076: include a path if present on disk OR reported changed by git
+    # (a tracked-but-DELETED noise file is absent on disk — `[[ -e ]]` misses it —
+    # yet shows in `git status --porcelain` and blocks the rebase precheck).
+    if [[ -e $p ]] || [[ -n "$(git status --porcelain -- "$p" 2>/dev/null)" ]]; then
+      present+=("$p")
+    fi
   done
   [[ ${#present[@]} -eq 0 ]] && { printf ''; return 0; }
   # Only stash if at least one present noise path is actually dirty/untracked.

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -1027,11 +1027,17 @@ if [[ -z $RESUME_SESSION ]] && is_rebase_phase "$PHASE"; then
 		# retries into the same conflict.
 		echo "phase-agent-dispatch: rebase conflict (rc=${REBASE_RC}) for ${TICKET}/${PHASE}; parking with reason=${STALL_REASON}" >&2
 		TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+		# CTL-1076: RT_PRECHECK[] holds the offending dirty paths set by the rebase
+		# precheck. Surface them in the park signal + explanation for diagnosis.
+		DIRTY_FILES_JSON="$(printf '%s\n' "${RT_PRECHECK[@]+"${RT_PRECHECK[@]}"}" \
+			| jq -R . | jq -s 'map(select(length>0))' 2>/dev/null || echo '[]')"
 		# CTL-1065: build a structured explanation via the CLI shim (always exits 0).
 		EXPL_JSON="$(node "${SCRIPT_DIR}/execution-core/escalation-explain.mjs" \
 			--ticket "$TICKET" --phase "$PHASE" \
 			--what-failed "rebase conflict (rc=${REBASE_RC}) parking ${TICKET}/${PHASE}" \
-			--observed "$(jq -nc --arg r "${REBASE_RC}" --arg reason "${STALL_REASON}" '{rebaseRc:($r|tonumber),stallReason:$reason}' 2>/dev/null || echo '{}')" \
+			--observed "$(jq -nc --arg r "${REBASE_RC}" --arg reason "${STALL_REASON}" \
+				--argjson df "${DIRTY_FILES_JSON}" \
+				'{rebaseRc:($r|tonumber),stallReason:$reason,dirtyFiles:$df}' 2>/dev/null || echo '{}')" \
 			--why-gave-up "auto-rebase could not proceed (${STALL_REASON})" \
 			--human-question "resolve the conflict for ${TICKET}/${PHASE} by hand and re-run, or discard the local change?" \
 			2>/dev/null || echo '{}')"
@@ -1042,9 +1048,11 @@ if [[ -z $RESUME_SESSION ]] && is_rebase_phase "$PHASE"; then
 		# → the else branch leaves the park signal un-written). Verified in bash
 		# 3.2 and 5.x. Pass the variable directly instead.
 		[ -n "$EXPL_JSON" ] || EXPL_JSON='{}'
-		if jq --arg ts "$TS" --arg reason "$STALL_REASON" --argjson expl "$EXPL_JSON" \
+		if jq --arg ts "$TS" --arg reason "$STALL_REASON" \
+			--argjson expl "$EXPL_JSON" --argjson df "${DIRTY_FILES_JSON}" \
 			'.status = "stalled"
        | .failureReason = $reason
+       | .dirtyFiles = $df
        | .explanation = $expl
        | .updatedAt = $ts
        | .phaseTimestamps = ((.phaseTimestamps // {}) | .stalled = $ts)' \


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-12T04:55:00Z -->
<!-- Last updated: 2026-06-12T04:55:00Z -->
<!-- PR: #1882 -->
<!-- Previous commits: 4b317fb9,1f573cad,8381f1da -->

## Summary

When a phase agent finishes and its successor dispatches within seconds, the dying worker's filesystem debris (deleted `.claude/scheduled_tasks.lock`, untracked `node_modules/`, `*.log` churn) could trip the rebase precheck and park the next phase for 30 minutes on the full cool-down. Three tickets (CTL-1063, CTL-1064, CTL-1068) were each delayed ~30 minutes by this false positive.

This fix teaches the rebase classifier to distinguish **machine-local settling debris** from **real uncommitted source**. Real source still stalls immediately (preserving CTL-1068 correctness). Debris-only dirt triggers a bounded grace re-probe (~60s) before parking. Deleted tracked noise files (`.claude/scheduled_tasks.lock`) are stashed through the existing `noise_stash_push` path. The stall signal and escalation payload now include the offending file names for diagnosis.

## Changes Made

### `plugins/dev/scripts/lib/worktree-rebase.sh`

- Added `.claude/scheduled_tasks.lock` to `WORKTREE_NOISE_PATHS` (it is a tracked file the Claude Code scheduler deletes on worker exit).
- Fixed `noise_stash_push` to include tracked-but-**deleted** noise paths — `[[ -e $p ]]` was missing absent files; now checks `git status --porcelain` as a fallback.
- Added `_is_settling_debris_path`: superset of `_is_noise_path`; also matches `node_modules/*` and `*.log` churn that is never real source.
- Added `_collect_precheck_dirt`: fills `RT_PRECHECK[]` from tracked diff, staged diff, and untracked porcelain output.
- Added `_precheck_has_real_source`: returns 0 if any path in `RT_PRECHECK` fails `_is_settling_debris_path`.
- Added `_grace_reprobe_clears`: polls up to `CATALYST_REBASE_GRACE_TOTAL_S` (default 60s) at `CATALYST_REBASE_GRACE_INTERVAL_S` (default 5s) intervals, re-running `noise_stash_push` each probe; returns 0 if the tree goes clean.
- Updated `rebase_onto_base_classified` dirty-tree path: real source → stall immediately; all-debris → grace re-probe → proceed or stall.

### `plugins/dev/scripts/phase-agent-dispatch`

- Serializes `RT_PRECHECK[]` into `DIRTY_FILES_JSON` after a stall.
- Threads `dirtyFiles` into the `escalation-explain.mjs` `--observed` payload.
- Writes `dirtyFiles` into the park signal file so the escalation comment names the offending paths.

### Tests

- New `plugins/dev/scripts/__tests__/worktree-rebase-lib.test.sh` wrapper (makes the lib test suite discoverable by `run-tests.sh`).
- Added tests T20–T25 in `lib/__tests__/worktree-rebase.test.sh`:
  - T20: deleted `scheduled_tasks.lock` → stashed as noise, rebase proceeds (rc 0).
  - T20b: `noise_stash_push` captures a tracked deletion.
  - T21: real uncommitted source → immediate stall (rc 2), no grace window.
  - T21b: `RT_PRECHECK` carries the offending file name after stall.
  - T22: untracked `node_modules/` settling-debris → grace re-probe → rc 0.
  - T23: mixed real source + debris → rc 2 (real source dominates).
  - T24: `_is_settling_debris_path` unit tests (debris true, source false).
  - T25: `escalation-explain.mjs` round-trips `observed.dirtyFiles` unchanged.

## How to Verify It

- [x] All CI checks pass (audit-references, check-versions, docs-gate, validate) ✅
- [ ] Run `bash plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh` — T20–T25 should pass alongside existing T1–T18
- [ ] Simulate a phase handoff with a deleted `.claude/scheduled_tasks.lock` — successor should dispatch without parking

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1076

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1063
skip CTL-1064
skip CTL-1068
