### PR TITLE
CTL-1040: FinOps and Utilization should group by work type — where the

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/otel-queries.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/otel-queries.test.ts
@@ -34,6 +34,7 @@ import {
   workerHistoryLogQL,
   parseHistoryLine,
   isValidCcSessionId,
+  throughputByWorkType,
 } from "../lib/otel-queries";
 import type { PrometheusFetcher, PrometheusQueryResult } from "../lib/prometheus";
 import type { LokiFetcher, LokiQueryResult } from "../lib/loki";
@@ -1569,5 +1570,55 @@ describe("activeTimeRatio", () => {
 
   it("returns null ONLY when Prometheus is unavailable (query failed)", async () => {
     expect(await activeTimeRatio(mockProm(null), "1h")).toBeNull();
+  });
+});
+
+// CTL-1040: throughput-by-work-type — counts phase.teardown.complete.* events
+// per catalyst_ticket_type over the window. Loki-backed matrix parse that takes
+// the LAST value of each series (count_over_time is monotone within the range).
+// Added by phase-verify (test-only) — the pure rankCountMap sibling is already
+// covered in utilization-kit.test.ts; this pins the untested Loki parse path.
+describe("throughputByWorkType", () => {
+  it("maps catalyst_ticket_type → count, taking the last value of each series", async () => {
+    const loki = mockLoki({
+      data: {
+        resultType: "matrix",
+        result: [
+          {
+            metric: { catalyst_ticket_type: "feature" },
+            values: [
+              [1713100000, "2"],
+              [1713100600, "5"],
+            ],
+          },
+          { metric: { catalyst_ticket_type: "bug" }, values: [[1713100600, "3"]] },
+        ],
+      },
+    });
+    const result = await throughputByWorkType(loki, "24h");
+    expect(result).toEqual({ feature: 5, bug: 3 });
+  });
+
+  it("returns null when Loki is unavailable", async () => {
+    expect(await throughputByWorkType(mockLoki(null), "24h")).toBeNull();
+  });
+
+  it("returns an empty map for an empty result set (honest zero state)", async () => {
+    const loki = mockLoki({ data: { resultType: "matrix", result: [] } });
+    expect(await throughputByWorkType(loki, "24h")).toEqual({});
+  });
+
+  it("skips series with a missing type label or no values (no fabricated rows)", async () => {
+    const loki = mockLoki({
+      data: {
+        resultType: "matrix",
+        result: [
+          { metric: { catalyst_ticket_type: "feature" }, values: [[1713100600, "4"]] },
+          { metric: {}, values: [[1713100600, "9"]] },
+          { metric: { catalyst_ticket_type: "docs" }, values: [] },
+        ],
+      },
+    });
+    expect(await throughputByWorkType(loki, "24h")).toEqual({ feature: 4 });
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/otel-queries.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-queries.ts
@@ -1449,6 +1449,54 @@ export async function activeTimeRatio(
   return { activeSecondsPerSecond: extractScalar(result) };
 }
 
+// ── CTL-1040: cost / throughput grouped by work type ─────────────────────────
+
+/** Sum signal-file cost (BoardTicket.costUSD) by work type. Null/empty/"task"
+ *  types fold into "unknown" so the bucket is HONEST, never dropped (CTL-1040).
+ *  Returns a type→USD map; feed through rankCostMap() for the mandatory zero-filter
+ *  + descending order. PURE. */
+export function costByWorkType(
+  tickets: ReadonlyArray<{ type: string | null | undefined; costUSD: number | null | undefined }>,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const t of tickets) {
+    const raw = (t.type ?? "").toLowerCase();
+    const key = raw === "" || raw === "task" ? "unknown" : raw;
+    const usd = Number.isFinite(t.costUSD as number) ? (t.costUSD as number) : 0;
+    out[key] = (out[key] ?? 0) + Math.max(0, usd);
+  }
+  return out;
+}
+
+/** Count completed tickets by work type from Loki `phase.teardown.complete.*`
+ *  events keyed by `catalyst_ticket_type`. Returns a type→count map, or null
+ *  when Loki is unreachable. PURE side of the throughput panel (CTL-1040). */
+export async function throughputByWorkType(
+  loki: LokiFetcher,
+  range: string,
+): Promise<Record<string, number> | null> {
+  const r = safeDuration(range, "24h");
+  const now = new Date();
+  const start = new Date(now.getTime() - parseDuration(r));
+  const result = await loki.queryRange(
+    `sum by (catalyst_ticket_type) (count_over_time(` +
+      `{service_name=~"catalyst.*"} | event_name=~"phase\\.teardown\\.complete\\..+" ` +
+      `| catalyst_ticket_type=~".+" [${r}]))`,
+    start.toISOString(),
+    now.toISOString(),
+  );
+  if (!result) return null;
+  const map: Record<string, number> = {};
+  for (const entry of result.data.result) {
+    const m = entry as { metric?: Record<string, string>; values?: Array<[number, string]> };
+    const name = m.metric?.["catalyst_ticket_type"];
+    if (!name || !m.values?.length) continue;
+    const last = m.values[m.values.length - 1];
+    if (last) map[name] = parseInt(last[1], 10) || 0;
+  }
+  return map;
+}
+
 function parseDuration(s: string): number {
   const match = /^(\d+)(ms|s|m|h|d)$/.exec(s);
   if (!match) return 3600_000;

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -234,6 +234,8 @@ import {
   workerBurnSeries,
   ticketTelemetrySeries,
   isValidLinearKey,
+  costByWorkType,
+  throughputByWorkType,
 } from "./lib/otel-queries";
 import {
   openDb,
@@ -2167,6 +2169,28 @@ export function createServer(opts: CreateServerOptions): BunServer {
           }
           const range = url.searchParams.get("range") ?? "24h";
           const result = await costByDimension(prom, dim, range);
+          return Response.json({ data: result });
+        }
+
+        // CTL-1040 (FINOPS): cost grouped by work type. Board-backed — groups the SAME
+        // signal-file costs the expensive-tickets table shows (BoardTicket.costUSD) by
+        // BoardTicket.type. Prometheus carries no catalyst_ticket_type label, so this
+        // is the honest current-state source (UI carries a "data since 2026-06-11"
+        // caption). Always 200 — no Prometheus dependency.
+        if (url.pathname === "/api/otel/cost-by-work-type") {
+          const board = await boardSnapshot.getLatest();
+          const tickets = (board?.tickets ?? []).map((t) => ({ type: t.type, costUSD: t.costUSD }));
+          return Response.json({ data: costByWorkType(tickets) });
+        }
+
+        // CTL-1040 (UTILIZATION): throughput grouped by work type. Loki-backed —
+        // counts phase.teardown.complete.* events per catalyst_ticket_type over the
+        // window. 503 when Loki is not configured (the ChartCard degrades via the ladder).
+        if (url.pathname === "/api/otel/throughput-by-work-type") {
+          if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "24h";
+          const result = await throughputByWorkType(loki, range);
+          if (result === null) return Response.json({ error: "Loki unavailable" }, { status: 503 });
           return Response.json({ data: result });
         }
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/cost-breakdown-bars.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/cost-breakdown-bars.tsx
@@ -41,6 +41,9 @@ export interface CostBreakdownBarsProps {
   onSelect?: (label: string) => void;
   /** Cap the rendered rows (default 12 — by-stage has ~12 task_types, by-model ~6). */
   limit?: number;
+  /** CTL-1040: per-label fill override (e.g. typeSymbol(label).color). When
+   *  omitted, rows keep the --chart-N round-robin (P-B / P-D unchanged). */
+  colorFor?: (label: string) => string;
 }
 
 function BreakdownRow({
@@ -93,6 +96,7 @@ export function CostBreakdownBars({
   labelHeader,
   onSelect,
   limit = 12,
+  colorFor,
 }: CostBreakdownBarsProps) {
   const rows = useMemo(() => rankCostMap(data).slice(0, limit), [data, limit]);
   const max = useMemo(() => maxUsd(rows), [rows]);
@@ -111,7 +115,7 @@ export function CostBreakdownBars({
             row={row}
             max={max}
             total={total}
-            colorVar={CHART_VARS[i % CHART_VARS.length]!}
+            colorVar={colorFor ? colorFor(row.label) : CHART_VARS[i % CHART_VARS.length]!}
             onSelect={onSelect ? () => onSelect(row.label) : undefined}
           />
         ))}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-breakdowns.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-breakdowns.test.ts
@@ -22,6 +22,7 @@ import {
   concentration,
   worstDrift,
   TOKEN_BUCKETS,
+  costByWorkType,
 } from "./finops-breakdowns";
 
 describe("rankCostMap — the mandatory zero-series filter", () => {
@@ -178,6 +179,50 @@ describe("concentration — footer A4 'top 3 = N% of spend'", () => {
   it("empty rows → 0 share / 0 count (footer shows '—')", () => {
     const c = concentration([], 3);
     expect(c).toEqual({ count: 0, share: 0, totalUsd: 0 });
+  });
+});
+
+describe("costByWorkType — CTL-1040 honest cost-by-type aggregation", () => {
+  it("sums costUSD per type", () => {
+    const tickets = [
+      { type: "feature", costUSD: 2 },
+      { type: "feature", costUSD: 3 },
+      { type: "bug", costUSD: 1 },
+    ];
+    expect(costByWorkType(tickets)).toEqual({ feature: 5, bug: 1 });
+  });
+
+  it("keeps 'unknown' as an honest bucket, never dropped or renamed", () => {
+    const tickets = [
+      { type: "unknown", costUSD: 4 },
+      { type: "feature", costUSD: 1 },
+    ];
+    expect(costByWorkType(tickets).unknown).toBe(4);
+  });
+
+  it("folds null/absent type into 'unknown' (board uses 'task' fallback)", () => {
+    const tickets = [
+      { type: "task", costUSD: 2 },
+      { type: "", costUSD: 1 },
+      { type: null as unknown as string, costUSD: 1 },
+    ];
+    expect(costByWorkType(tickets).unknown).toBe(4);
+  });
+
+  it("treats null/0 costUSD as 0 (no NaN, no negative)", () => {
+    const tickets = [
+      { type: "docs", costUSD: null },
+      { type: "docs", costUSD: 0 },
+    ];
+    expect(rankCostMap(costByWorkType(tickets))).toEqual([]);
+  });
+
+  it("flows through rankCostMap zero-filter (zero-spend types dropped)", () => {
+    const map = costByWorkType([
+      { type: "feature", costUSD: 5 },
+      { type: "chore", costUSD: 0 },
+    ]);
+    expect(rankCostMap(map)).toEqual([{ label: "feature", usd: 5 }]);
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-breakdowns.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-breakdowns.ts
@@ -16,6 +16,10 @@
 
 import type { CostValidationRow } from "@/lib/types";
 
+// CTL-1040: costByWorkType lives in lib/otel-queries (server-importable); re-exported
+// here so the UI and its tests import from the canonical observe module path.
+export { costByWorkType } from "../../../../lib/otel-queries";
+
 // ── ranked cost rows (P-C expensive tickets, P-B by-stage, P-D by-model/agent) ──
 
 /** One ranked breakdown row: the label (ticket / stage / model / agent) and its

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/finops-surface.tsx
@@ -49,6 +49,7 @@ import {
   hasTokenData,
   type CostDimension,
 } from "@/components/observe/finops-breakdowns";
+import { typeSymbol } from "@/board/type-icon";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 
 /** The clicked-spike focus: the hour's epoch second + its label + the fetched
@@ -90,6 +91,7 @@ export function FinopsSurface() {
   const [byDim, setByDim] = useState<CostMap>(null);
   const [byDimReachable, setByDimReachable] = useState(true);
   const [costDim, setCostDim] = useState<CostDimension>("model");
+  const [byType, setByType] = useState<CostMap>(null);
   const [tokens, setTokens] = useState<TokenSplit | null>(null);
   const [tokensReachable, setTokensReachable] = useState(true);
   const [validation, setValidation] = useState<CostValidationRow[] | null>(null);
@@ -193,6 +195,19 @@ export function FinopsSurface() {
       }
     }
 
+    // CTL-1040: cost grouped by work type. Board-backed → always reachable (no prom gate).
+    async function loadByType() {
+      try {
+        const resp = await fetch("/api/otel/cost-by-work-type");
+        if (!alive) return;
+        if (!resp.ok) return;
+        const body = (await resp.json()) as { data: CostMap };
+        setByType(body.data ?? null);
+      } catch {
+        /* board-backed — fail silently, show honest empty state */
+      }
+    }
+
     // OBS-11 P-E (token type split) — the 4 buckets + cache hit rate.
     async function loadTokens() {
       try {
@@ -226,6 +241,7 @@ export function FinopsSurface() {
     void loadCache();
     void loadCost();
     void loadByStage();
+    void loadByType();
     void loadTokens();
     void loadValidation();
     const id = setInterval(() => {
@@ -234,6 +250,7 @@ export function FinopsSurface() {
       void loadCache();
       void loadCost();
       void loadByStage();
+      void loadByType();
       void loadTokens();
       void loadValidation();
     }, refreshIntervalMs(range));
@@ -315,6 +332,7 @@ export function FinopsSurface() {
   const costHasData = useMemo(() => rankCostMap(cost).length > 0, [cost]);
   const byStageHasData = useMemo(() => rankCostMap(byStage).length > 0, [byStage]);
   const byDimHasData = useMemo(() => rankCostMap(byDim).length > 0, [byDim]);
+  const byTypeHasData = useMemo(() => rankCostMap(byType).length > 0, [byType]);
   const tokensHasData = useMemo(
     () => hasTokenData(tokens?.tokens ?? null),
     [tokens],
@@ -462,6 +480,27 @@ export function FinopsSurface() {
           <CostBreakdownBars
             data={byDim}
             labelHeader={costDim === "model" ? "model" : "agent"}
+          />
+        </ChartCard>
+
+        {/* CTL-1040: cost by work type (board-backed ranked bar). Colored by the
+            CTL-1033 TYPE palette so feature=blue, bug=red, etc. Board-backed →
+            always available (no Prometheus gate); caption is honest about coverage. */}
+        <ChartCard
+          title="Cost by work type"
+          dataSource="[board]"
+          health={null}
+          hasData={byTypeHasData}
+          className="shrink-0"
+          bodyClassName="min-h-[220px] h-[280px] p-2"
+          headerExtra={
+            <span className="font-mono text-[10px] text-muted/60">since 2026-06-11</span>
+          }
+        >
+          <CostBreakdownBars
+            data={byType}
+            labelHeader="type"
+            colorFor={(label) => typeSymbol(label).color}
           />
         </ChartCard>
       </div>

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/utilization-kit.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/utilization-kit.test.ts
@@ -14,6 +14,7 @@ import {
   idleBetweenPhases,
   isRateLimitError,
   rateLimitErrors,
+  rankCountMap,
   type Pathology,
   type IdleTicketInput,
 } from "./utilization-kit";
@@ -172,6 +173,24 @@ describe("idleBetweenPhases — the CTL-928 lane derivation (P3)", () => {
       now,
     );
     expect(rows.map((r) => r.id)).toEqual(["CTL-B", "CTL-A"]);
+  });
+});
+
+describe("rankCountMap — CTL-1040 throughput count ranking", () => {
+  it("ranks type→count descending and drops zero/negative/non-finite", () => {
+    expect(rankCountMap({ feature: 3, bug: 5, chore: 0, docs: NaN })).toEqual([
+      { label: "bug", count: 5 },
+      { label: "feature", count: 3 },
+    ]);
+  });
+
+  it("keeps an 'unknown' bucket with a positive count", () => {
+    expect(rankCountMap({ unknown: 2 })).toEqual([{ label: "unknown", count: 2 }]);
+  });
+
+  it("null/empty map → empty array (honest empty state)", () => {
+    expect(rankCountMap(null)).toEqual([]);
+    expect(rankCountMap({})).toEqual([]);
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/utilization-kit.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/utilization-kit.ts
@@ -137,6 +137,26 @@ export function idleBetweenPhases(
 // matching the error string / status_code / raw line against the rate-limit tokens.
 // Live → [] (no 429s in range — the healthy zero the ChartCard renders honestly).
 
+// ── CTL-1040: throughput by work type (P_throughput) ────────────────────────
+
+/** One ranked throughput row: the type label and its completed-ticket count. */
+export interface CountRow {
+  label: string;
+  /** Completed-ticket count over the window (> 0 — zero rows are dropped). */
+  count: number;
+}
+
+/** Rank a type→count map into descending rows with the mandatory zero-filter
+ *  (drop count ≤ 0 and non-finite). PURE — a null/empty map is an empty array
+ *  (the ChartCard renders the honest empty state, never a fabricated row). */
+export function rankCountMap(map: Record<string, number> | null): CountRow[] {
+  if (!map) return [];
+  return Object.entries(map)
+    .filter(([, n]) => Number.isFinite(n) && n > 0)
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
 /** The rate-limit / overload tokens an api_error line is matched against. 429 =
  *  rate_limit, 529 = overloaded; the word forms catch the JSON `type` shapes
  *  Anthropic returns ("rate_limit_error", "overloaded_error"). Matched

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/utilization-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/utilization-surface.tsx
@@ -38,11 +38,14 @@ import {
   occupancyPct,
   idleBetweenPhases,
   rateLimitErrors,
+  rankCountMap,
   type IdleTicketInput,
+  type CountRow,
 } from "@/components/observe/utilization-kit";
-import { errorTrendSparkline } from "@/components/observe/telemetry-panels";
+import { errorTrendSparkline, barPercent } from "@/components/observe/telemetry-panels";
 import { Sparkline } from "@/components/sparkline";
 import { fmtRelativeDuration } from "@/lib/formatters";
+import { typeSymbol } from "@/board/type-icon";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 
 /** The active-time payload from /api/otel/active-time (mirrors otel-queries
@@ -78,6 +81,10 @@ export function UtilizationSurface() {
   // P_active [prom] — the active-time ratio.
   const [activeTime, setActiveTime] = useState<ActiveTimePayload | null>(null);
   const [activeReachable, setActiveReachable] = useState<boolean>(true);
+
+  // CTL-1040: throughput by work type [loki].
+  const [throughputByType, setThroughputByType] = useState<Record<string, number> | null>(null);
+  const [throughputByTypeReachable, setThroughputByTypeReachable] = useState<boolean>(true);
 
   // Health probe (10s TTL) — drives the ChartCard ladder for the [loki]/[prom]
   // panels. The board-backed hero/badge/idle-list never read it.
@@ -150,13 +157,30 @@ export function UtilizationSurface() {
       }
     }
 
+    // CTL-1040: throughput grouped by work type [loki].
+    async function loadThroughputByType() {
+      try {
+        const resp = await fetch(`/api/otel/throughput-by-work-type?range=${otelRange}`);
+        if (!alive) return;
+        if (resp.status === 503) return setThroughputByTypeReachable(false);
+        if (!resp.ok) return;
+        const body = (await resp.json()) as { data: Record<string, number> | null };
+        setThroughputByType(body.data ?? null);
+        setThroughputByTypeReachable(true);
+      } catch {
+        if (alive) setThroughputByTypeReachable(false);
+      }
+    }
+
     void loadBoard();
     void loadErrors();
     void loadActiveTime();
+    void loadThroughputByType();
     const id = setInterval(() => {
       void loadBoard();
       void loadErrors();
       void loadActiveTime();
+      void loadThroughputByType();
     }, refreshIntervalMs(range));
     return () => {
       alive = false;
@@ -192,6 +216,12 @@ export function UtilizationSurface() {
   const computingPct = hasBusySlots
     ? Math.max(0, Math.min(100, Math.round((activeRate / config.inFlight) * 100)))
     : 0;
+
+  // CTL-1040: ranked throughput rows for the type panel.
+  const throughputRows = useMemo<CountRow[]>(
+    () => rankCountMap(throughputByType),
+    [throughputByType],
+  );
 
   // Per-panel health for the [loki]/[prom] cards (layer the per-route reachability
   // over the global probe — same idiom telemetry uses).
@@ -376,6 +406,56 @@ export function UtilizationSurface() {
           locked={{ reason: "needs event-log reader", ticket: "OBS-15" }}
           bodyClassName="min-h-[180px] h-[min(28vh,220px)] p-3"
         />
+
+        {/* CTL-1040: throughput by work type [loki] — completed tickets per type.
+            Ranked count bars colored by the TYPE palette. Degrades via the ChartCard
+            ladder when Loki is unconfigured. */}
+        <ChartCard
+          title="Throughput by work type"
+          dataSource="[loki]"
+          health={lokiHealth(throughputByTypeReachable)}
+          hasData={throughputRows.length > 0}
+          bodyClassName="min-h-[180px] h-[min(28vh,220px)] p-2"
+          headerExtra={
+            <span className="font-mono text-[10px] text-muted/60">since 2026-06-11</span>
+          }
+        >
+          {(() => {
+            const maxCount = throughputRows[0]?.count ?? 0;
+            return (
+              <div className="flex h-full flex-col gap-1">
+                <div className="flex items-center justify-between px-3 text-[10px] text-muted/70">
+                  <span>type · completed</span>
+                  <span>ranked ↓</span>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto rounded-md border border-border bg-surface-2">
+                  {throughputRows.map((row) => (
+                    <div
+                      key={row.label}
+                      className="flex w-full items-center gap-3 border-b border-border/40 px-3 py-1.5 last:border-b-0"
+                    >
+                      <span className="w-24 shrink-0 truncate font-mono text-[11px] text-fg">
+                        {row.label}
+                      </span>
+                      <span className="relative h-2.5 flex-1 overflow-hidden rounded-sm bg-surface-3">
+                        <span
+                          className="absolute inset-y-0 left-0 rounded-sm"
+                          style={{
+                            width: `${barPercent(row.count, maxCount)}%`,
+                            backgroundColor: typeSymbol(row.label).color,
+                          }}
+                        />
+                      </span>
+                      <span className="w-8 shrink-0 text-right font-mono text-[11px] tabular-nums text-fg">
+                        {row.count}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })()}
+        </ChartCard>
 
         {/* P_occupancy OCCUPANCY TIMELINE [events] — LOCKED (OBS-15), full-width
             (bottom). Will be a stepped area of phase.scheduler.parallelism-sampled


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-12T14:49:00Z -->
<!-- Last updated: 2026-06-12T14:49:00Z -->
<!-- PR: #1889 -->
<!-- Previous commits: 9eb6b0207d91e275a90ceaa097058d1dded74c56,e44f0d3576ea9a033aea5a21d910d408a6b00d1e -->

## Summary

Adds two new **work-type breakdown panels** to the Observe dashboards, consuming the `catalyst_ticket_type` telemetry dimension introduced in CTL-1023 (live in Loki since 2026-06-11):

- **FinOps — Cost by work type**: ranked-bar panel showing spend split across bug/feature/chore/refactor/docs/test, board-backed, always available
- **Utilization — Throughput by work type**: ranked-bar panel showing ticket count by type over the window, Loki-backed (degrades gracefully when Loki is unconfigured)

Both panels use the shared CTL-1033 TYPE color palette. Unknown-typed work is shown honestly as `"unknown"` and never dropped.

## Changes

### Backend (`plugins/dev/scripts/orch-monitor/`)

- **`lib/otel-queries.ts`**: `costByWorkType()` pure shaper (aggregates `BoardTicket.costUSD` by `BoardTicket.type`, folds null/empty/`"task"` → `"unknown"`) + `throughputByWorkType()` Loki query (counts `phase.teardown.complete.*` events by `catalyst_ticket_type`)
- **`server.ts`**: two new routes — `/api/otel/cost-by-work-type` (board-backed, always 200) and `/api/otel/throughput-by-work-type` (Loki-backed, 503 when absent)

### Frontend (`plugins/dev/scripts/orch-monitor/ui/src/components/observe/`)

- **`cost-breakdown-bars.tsx`**: optional `colorFor` prop for per-label fill overrides (backward-compatible; existing P-B/P-D panels unchanged)
- **`finops-breakdowns.ts`**: re-exports `costByWorkType` for UI tests via relative import
- **`finops-surface.tsx`**: new Cost by work type ChartCard in breakdown grid
- **`utilization-kit.ts`**: `rankCountMap()` helper + `CountRow` interface
- **`utilization-surface.tsx`**: new Throughput by work type ChartCard

### Tests (`plugins/dev/scripts/orch-monitor/`)

- **`ui/src/components/observe/finops-breakdowns.test.ts`**: 5 new `costByWorkType` cases (null/unknown/task folds, zero-filter, flow-through)
- **`ui/src/components/observe/utilization-kit.test.ts`**: 3 new `rankCountMap` cases
- **`ui/src/components/observe/finops-layout.test.ts`**: structural `shrink-0` invariants
- **`__tests__/otel-queries.test.ts`**: 4 new cases pinning the async Loki matrix parse path (last-value semantics, null-loki, empty-set, missing-label skip) — added by phase-verify to cover the previously-untested parse branch

## How to Verify

- [x] `bun test src/components/observe/finops-breakdowns.test.ts` — 5 new `costByWorkType` tests pass
- [x] `bun test src/components/observe/utilization-kit.test.ts` — 3 new `rankCountMap` tests pass
- [x] `bun test src/components/observe/finops-layout.test.ts` — structural invariants pass
- [x] `bun test plugins/dev/scripts/orch-monitor/__tests__/otel-queries.test.ts` — 4 new Loki-parse path tests pass
- [x] `tsc --noEmit` — no type errors
- [x] `eslint .` — 0 errors (52 pre-existing warnings unchanged)
- [x] Full `bun test` — 4556 pass, 7 pre-existing failures (live fleet + shell integration tests)
- [ ] Verify Cost by work type panel appears in FinOps surface with correct TYPE colors
- [ ] Verify Throughput by work type panel appears in Utilization surface, degrades gracefully when Loki is unconfigured

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-1040

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1023
skip CTL-1033
