### PR TITLE
CTL-1059: Deep links should land where they point — hard-loading a detail URL currently bounces to home

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/observe-nav.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/observe-nav.test.ts
@@ -1,0 +1,30 @@
+// observe-nav.test.ts — CTL-1059 / Pass-B: OBSERVE surface jumps are client-side.
+//
+// The legacy `window.location.assign("/?surface=…")` full-page-reload calls
+// in the Utilization and Host Matrix panels are replaced with client-side
+// `navigate({ to: "…" })` calls. These static-source assertions confirm the
+// migration: the legacy pattern is gone and the correct router navigate wiring
+// is present.
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const UI = join(HERE, "..", "ui", "src", "components", "observe");
+const utilSrc = readFileSync(join(UI, "utilization-surface.tsx"), "utf8");
+const hostSrc = readFileSync(join(UI, "host-matrix.tsx"), "utf8");
+
+describe("OBSERVE surface nav is client-side (CTL-1059 / Pass-B)", () => {
+  it("no surface jump uses the legacy /?surface= full reload", () => {
+    expect(utilSrc).not.toContain('location.assign("/?surface=');
+    expect(hostSrc).not.toContain('location.assign("/?surface=');
+  });
+  it("queue/fleetops jumps use the router navigate to the real routes", () => {
+    expect(utilSrc).toContain("useNavigate");
+    expect(utilSrc).toMatch(/to:\s*"\/dispatch"/);
+    expect(utilSrc).toMatch(/to:\s*"\/fleetops"/);
+    expect(hostSrc).toContain("useNavigate");
+    expect(hostSrc).toMatch(/to:\s*"\/dispatch"/);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/prefs.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/prefs.test.ts
@@ -19,6 +19,7 @@ import {
   LANDING_SURFACES,
   normalizeLandingSurface,
   readStoredLandingSurface,
+  shouldApplyLandingRedirect,
 } from "../ui/src/lib/prefs";
 import { SURFACES } from "../ui/src/lib/surface";
 
@@ -95,5 +96,19 @@ describe("landing-surface pref — survives a (simulated) reload (CTL-911)", () 
       getItem: (k) => store.get(k) ?? null,
     });
     expect(rehydrated).toBe("board");
+  });
+});
+
+describe("shouldApplyLandingRedirect — deep-link guard (CTL-1059)", () => {
+  it("redirects when hard-loaded at / with a non-home preference", () => {
+    expect(shouldApplyLandingRedirect({ initialPathname: "/", pref: "board" })).toBe(true);
+  });
+  it("never redirects when the preference is home (default)", () => {
+    expect(shouldApplyLandingRedirect({ initialPathname: "/", pref: "home" })).toBe(false);
+  });
+  it("does NOT redirect when the app was hard-loaded at a deep-link path", () => {
+    expect(shouldApplyLandingRedirect({ initialPathname: "/ticket/CTL-1", pref: "board" })).toBe(false);
+    expect(shouldApplyLandingRedirect({ initialPathname: "/worker/CTL-1:1", pref: "board" })).toBe(false);
+    expect(shouldApplyLandingRedirect({ initialPathname: "/dep-graph", pref: "fleetops" })).toBe(false);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/settings-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/settings-surface.test.ts
@@ -168,6 +168,12 @@ describe("Shell preferences persist (CTL-911)", () => {
     expect(routerSrc).toMatch(/redirect\(\{\s*to:\s*surfaceToPath\(pref\)/);
   });
 
+  it("the home-route redirect is guarded against deep-link initial loads (CTL-1059)", () => {
+    // The beforeLoad must consult the captured initial pathname so a cold deep-link
+    // never bounces a non-home-preference operator to their landing surface.
+    expect(routerSrc).toContain("shouldApplyLandingRedirect");
+  });
+
   it("Settings exposes the landing-surface control and writes it through lib/prefs", () => {
     expect(settingsSrc).toContain("writeLandingSurface");
     expect(settingsSrc).toContain("LANDING_SURFACES");

--- a/plugins/dev/scripts/orch-monitor/ui/src/app-router.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/app-router.tsx
@@ -35,7 +35,13 @@ import { SkeletonDashboard } from "./components/ui/skeleton";
 import { validateDetailSearch } from "./board/route-search";
 import { validateRootSearch } from "./lib/root-search";
 import { surfaceToPath } from "./lib/route-surface";
-import { readLandingSurface } from "./lib/prefs";
+import { readLandingSurface, shouldApplyLandingRedirect } from "./lib/prefs";
+
+// CTL-1059: capture the URL the operator actually hard-loaded, evaluated once
+// at module import time (before the router processes any route). This reflects
+// the true cold-load path, not a later in-session `/` visit.
+const INITIAL_PATHNAME =
+  typeof window !== "undefined" ? window.location.pathname : "/";
 
 // ── surface components (the existing surfaces, code-split as before) ──────────
 // Home / Queue / the OBSERVE surfaces stay lazy (HomeSurface pulls its
@@ -136,9 +142,12 @@ const homeRoute = createRoute({
   // beforeLoad redirect lands them there. A real "/" navigation with a preference
   // of "home" (the default) is a no-op, so this never traps the operator on a
   // surface they explicitly navigated to via the URL.
+  // CTL-1059: guard against deep-link initial loads — the redirect only fires
+  // when the app was genuinely hard-loaded at `/`, not when a `/` visit happens
+  // during a deep-link session (e.g. via a stray history.back()).
   beforeLoad: () => {
     const pref = readLandingSurface();
-    if (pref !== "home") {
+    if (shouldApplyLandingRedirect({ initialPathname: INITIAL_PATHNAME, pref })) {
       throw redirect({ to: surfaceToPath(pref), search: (prev) => prev });
     }
   },

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Shell.tsx
@@ -42,6 +42,7 @@ import {
 } from "./nav-store";
 import type { DetailSearch } from "./route-search";
 import { useKeyboardNav } from "../hooks/use-keyboard-nav";
+import { canReturnViaBack } from "./detail-nav";
 import { ChevronUp, ChevronDown } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { HeaderActions } from "@/components/header-actions";
@@ -561,12 +562,16 @@ export function Shell({
   // navigate forward to the originating surface route (Workers vs the Tickets
   // board, derived from `?from`). Display-options ride their own persisted atoms.
   const goRoot = useCallback(() => {
-    if (canGoBack) {
+    // CTL-1059: __TSR_index is the router-owned position in the history stack.
+    // On a cold deep-link it is 0/undefined even when useCanGoBack() is spuriously
+    // true, so we must NOT back() out of the tab to the prior `/` entry.
+    const tsrIndex = (router.state.location.state as { __TSR_index?: number })
+      .__TSR_index;
+    if (canReturnViaBack({ canGoBack, tsrIndex })) {
       router.history.back();
       return;
     }
-    // Cold deep-link (no back entry): forward to the originating surface route.
-    // A worker page returns to /workers; a ticket page to the Tickets board.
+    // Cold deep-link (or first entry): forward to the originating surface route.
     void navigate({ to: kind === "worker" ? "/workers" : "/board" });
   }, [canGoBack, router, navigate, kind]);
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/detail-nav.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/detail-nav.test.ts
@@ -22,6 +22,7 @@ import {
   detailNavigateOptions,
   openDetail,
   isNewTabClick,
+  canReturnViaBack,
 } from "./detail-nav";
 import type { BoardPayload, BoardTicket, BoardWorker } from "./types";
 import { laneColumns, visibleColumnDefs } from "./board-display";
@@ -345,6 +346,25 @@ describe("pager order == board order (CTL-951 deliverable b — the shared compa
   });
 });
 
+describe("canReturnViaBack — cold deep-link guard (CTL-1059)", () => {
+  it("returns false when there is no back entry at all", () => {
+    expect(canReturnViaBack({ canGoBack: false, tsrIndex: 0 })).toBe(false);
+    expect(canReturnViaBack({ canGoBack: false, tsrIndex: 3 })).toBe(false);
+  });
+
+  it("returns false on the FIRST router-owned entry even if canGoBack is spuriously true", () => {
+    // Cold deep-link: session-restoration left a stale __TSR_key but this IS entry 0.
+    expect(canReturnViaBack({ canGoBack: true, tsrIndex: 0 })).toBe(false);
+    expect(canReturnViaBack({ canGoBack: true, tsrIndex: undefined })).toBe(false);
+    expect(canReturnViaBack({ canGoBack: true, tsrIndex: null })).toBe(false);
+  });
+
+  it("returns true only when canGoBack AND we are past the first entry", () => {
+    expect(canReturnViaBack({ canGoBack: true, tsrIndex: 1 })).toBe(true);
+    expect(canReturnViaBack({ canGoBack: true, tsrIndex: 5 })).toBe(true);
+  });
+});
+
 describe("Shell Esc-restore wiring (static source, CTL-989 — client-side back)", () => {
   const shellSrc = readFileSync(join(HERE, "Shell.tsx"), "utf8");
   it("Esc / breadcrumb-root returns to the board via a CLIENT-SIDE router navigation", () => {
@@ -352,6 +372,15 @@ describe("Shell Esc-restore wiring (static source, CTL-989 — client-side back)
     // tree, so goRoot prefers history.back() (replays scroll restoration) and
     // falls back to a forward navigate for a cold deep-link.
     expect(shellSrc).not.toContain("hardNavigate");
+    expect(shellSrc).toContain("router.history.back()");
+    expect(shellSrc).toContain("useCanGoBack");
+  });
+
+  it("goRoot guards history.back() behind the cold-deep-link helper (CTL-1059)", () => {
+    // history.back() must be gated so a stale __TSR_index can't bounce a cold load to /.
+    expect(shellSrc).toContain("canReturnViaBack");
+    expect(shellSrc).toContain("__TSR_index");
+    // The existing wiring stays intact.
     expect(shellSrc).toContain("router.history.back()");
     expect(shellSrc).toContain("useCanGoBack");
   });

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/detail-nav.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/detail-nav.ts
@@ -114,6 +114,25 @@ export function detailNavigateOptions(
   } as NavigateOptions;
 }
 
+/**
+ * CTL-1059: decide whether goRoot may use history.back().
+ *
+ * `useCanGoBack()` can spuriously report true on a COLD deep-link when browser
+ * session-restoration leaves a non-null history.state carrying a prior TanStack
+ * session's __TSR_key (so @tanstack/history skips its index-0 stamp). Returning
+ * via back() then pops to whatever browser entry preceded the tab — often `/` —
+ * which is the home bounce. Guard: only honor back() when we are genuinely PAST
+ * the first router-owned entry (__TSR_index >= 1).
+ */
+export function canReturnViaBack(args: {
+  canGoBack: boolean;
+  tsrIndex: number | null | undefined;
+}): boolean {
+  const { canGoBack, tsrIndex } = args;
+  if (!canGoBack) return false;
+  return typeof tsrIndex === "number" && tsrIndex >= 1;
+}
+
 // ── the click → navigate seam (the DOM-touching helpers) ──────────────────────
 
 /**

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/host-matrix.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/host-matrix.tsx
@@ -12,6 +12,7 @@
 // the grid wrapper (the collapse-bug rule — see fleetops-surface.tsx).
 
 import { Lock } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
 import { Panel, PanelHeader, SectionLabel } from "@/components/ui/panel";
 import type { ClusterSignalNode } from "@/lib/cluster-signal";
 import type { BoardWorker } from "@/board/types";
@@ -38,6 +39,7 @@ const GRID_COLS =
   "grid-cols-[1.4fr_auto_auto_auto_auto_minmax(0,1.6fr)]";
 
 export function HostMatrix({ nodes, workers, maxParallel, boardAgeMs }: HostMatrixProps) {
+  const navigate = useNavigate();
   const brokerFresh = boardAgeMs != null && boardAgeMs < BROKER_STALE_MS;
 
   return (
@@ -75,7 +77,7 @@ export function HostMatrix({ nodes, workers, maxParallel, boardAgeMs }: HostMatr
               <button
                 key={n.host}
                 type="button"
-                onClick={() => window.location.assign("/?surface=queue")}
+                onClick={() => void navigate({ to: "/dispatch" })}
                 title={`${shortHostName(n.host)} — host swimlane`}
                 className={`grid ${GRID_COLS} h-10 items-center gap-x-3 rounded px-2 text-left text-[12px] tabular-nums hover:bg-surface-3`}
               >

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/utilization-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/utilization-surface.tsx
@@ -20,6 +20,7 @@
 // ChartCard ladder. The two deferred panels render the dashed "needs event-log
 // reader · OBS-15" locked state — never blank, never fabricated.
 import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import { useAtom } from "jotai";
 import { HeaderActions } from "@/components/header-actions";
 import type { OtelHealth, OtelLogEntry } from "@/lib/types";
@@ -67,6 +68,7 @@ const EMPTY_CONFIG: BoardConfig = {
 };
 
 export function UtilizationSurface() {
+  const navigate = useNavigate();
   const [range, setRange] = useAtom(timeRangeAtom);
 
   const [health, setHealth] = useState<OtelHealth | null>(null);
@@ -282,9 +284,9 @@ export function UtilizationSurface() {
           // FleetOps ships its own surface later; until then a full-document nav to
           // the dashboard's health view is the closest existing destination.
           if (target === "eligible") {
-            window.location.assign("/?surface=queue");
+            void navigate({ to: "/dispatch" });
           } else {
-            window.location.assign("/?surface=fleetops");
+            void navigate({ to: "/fleetops" });
           }
         }}
       />

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/utilization-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/utilization-surface.tsx
@@ -280,9 +280,9 @@ export function UtilizationSurface() {
         maxParallel={config.maxParallel}
         queueLen={queueLen}
         onAction={(target) => {
-          // Cross-surface drill: STARVED → eligible set, JAMMED → FleetOps reconcile.
-          // FleetOps ships its own surface later; until then a full-document nav to
-          // the dashboard's health view is the closest existing destination.
+          // Cross-surface drill: STARVED → eligible set (Dispatch), JAMMED →
+          // FleetOps reconcile. Both are client-side router navigations to the
+          // surface's own route (no full-document reload).
           if (target === "eligible") {
             void navigate({ to: "/dispatch" });
           } else {

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/prefs.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/prefs.ts
@@ -77,6 +77,20 @@ function browser(): BrowserGlobals {
   return globalThis as unknown as BrowserGlobals;
 }
 
+/**
+ * CTL-1059: a landing-preference redirect is only valid for a genuine fresh `/`
+ * load. If the app was hard-loaded at a deep-link path, any `/` visit during that
+ * session (e.g. a stray navigate) must NOT bounce the operator to their landing
+ * surface — they explicitly asked for the deep link.
+ */
+export function shouldApplyLandingRedirect(args: {
+  initialPathname: string;
+  pref: Surface;
+}): boolean {
+  if (args.pref === "home") return false;
+  return args.initialPathname === "/";
+}
+
 /** Browser-bound read — what the shell seeds its initial surface from. */
 export function readLandingSurface(): Surface {
   return readStoredLandingSurface(browser().window?.localStorage ?? null);


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-12T15:00:00Z -->
<!-- Last updated: 2026-06-12T15:00:00Z -->
<!-- PR: #1890 -->
<!-- Previous commits: d450af9b19479c53f6afbefab6f4360eddf0d1ed,d5a7c4050dbaf87e27ee5b9b0b2edb070b01f182 -->

## Summary

Fixes a hard-navigation bounce in the orch-monitor SPA where directly loading `/ticket/<id>`, `/worker/<id>`, or `/dep-graph` would render briefly then redirect to `/`. Three independent root causes were identified and addressed:

- **`canReturnViaBack` helper** (`detail-nav.ts`) — gates `goRoot`'s `history.back()` on `__TSR_index >= 1`, so a cold deep-link with a spuriously-true `useCanGoBack()` navigates forward to the originating surface instead of popping back to `/`.
- **`shouldApplyLandingRedirect` helper** (`prefs.ts`) — `homeRoute.beforeLoad` now only redirects when `INITIAL_PATHNAME` (captured once at module load) is exactly `/`, ensuring a deep-link session is never interrupted by the landing-surface preference redirect.
- **Client-side navigate migration** (`utilization-surface.tsx`, `host-matrix.tsx`) — replaces three `window.location.assign("/?surface=…")` full-page reloads with `navigate({ to: "/dispatch" | "/fleetops" })`, eliminating a code path that re-entered `/` and re-exposed the landing redirect.

All changes follow the established TDD pattern: pure decision helpers with full unit-test coverage plus static-source assertions confirming the components are wired correctly. 61 tests pass; no new typecheck errors.

## Changes Made

### Core navigation helpers

- **`plugins/dev/scripts/orch-monitor/ui/src/board/detail-nav.ts`** — adds `canReturnViaBack({ canGoBack, tsrIndex })`: only allows `history.back()` when `canGoBack` is true AND `__TSR_index >= 1`, guarding against spurious back-entry flags left by browser session restoration on cold deep-links.
- **`plugins/dev/scripts/orch-monitor/ui/src/lib/prefs.ts`** — adds `shouldApplyLandingRedirect({ initialPathname, pref })`: returns `true` only when `pref !== "home"` and `initialPathname === "/"`, preventing the landing-surface redirect from firing during deep-link sessions.
- **`plugins/dev/scripts/orch-monitor/ui/src/app-router.tsx`** — captures `INITIAL_PATHNAME` once at module import time; replaces `pref !== "home"` guard in `homeRoute.beforeLoad` with `shouldApplyLandingRedirect(...)`.
- **`plugins/dev/scripts/orch-monitor/ui/src/board/Shell.tsx`** — reads `__TSR_index` from `router.state.location.state`; replaces `if (canGoBack)` with `if (canReturnViaBack({ canGoBack, tsrIndex }))` in `goRoot`.

### Observe surface client-side migration

- **`plugins/dev/scripts/orch-monitor/ui/src/components/observe/utilization-surface.tsx`** — replaces `window.location.assign("/?surface=queue")` and `window.location.assign("/?surface=fleetops")` with `navigate({ to: "/dispatch" })` and `navigate({ to: "/fleetops" })`.
- **`plugins/dev/scripts/orch-monitor/ui/src/components/observe/host-matrix.tsx`** — replaces `window.location.assign("/?surface=queue")` with `navigate({ to: "/dispatch" })`.

### Tests

- **`plugins/dev/scripts/orch-monitor/ui/src/board/detail-nav.test.ts`** — adds `canReturnViaBack` unit tests (false when no back entry, false when `tsrIndex` is 0/undefined/null even if `canGoBack` is true, true only when both conditions are met); adds static-source assertions that `Shell.tsx` is wired to `canReturnViaBack` and `__TSR_index`.
- **`plugins/dev/scripts/orch-monitor/__tests__/prefs.test.ts`** — adds `shouldApplyLandingRedirect` unit tests covering the redirect, home-pref no-op, and deep-link suppression cases.
- **`plugins/dev/scripts/orch-monitor/__tests__/settings-surface.test.ts`** — adds static-source assertion that `app-router.tsx` contains `shouldApplyLandingRedirect`.
- **`plugins/dev/scripts/orch-monitor/__tests__/observe-nav.test.ts`** (new file) — static-source assertions confirming the legacy `/?surface=` full-reload pattern is gone and the `useNavigate` / `to: "/dispatch"` / `to: "/fleetops"` router wiring is present.

## How to Verify It

- [x] `bun test __tests__/observe-nav.test.ts __tests__/prefs.test.ts __tests__/settings-surface.test.ts ui/src/board/detail-nav.test.ts` (run from `plugins/dev/scripts/orch-monitor/`) — 61 tests pass ✅
- [ ] Hard-load `/ticket/CTL-1` in a fresh browser tab — page stays on ticket detail, no bounce to `/`
- [ ] Hard-load `/worker/<id>` in a fresh browser tab — page stays on worker detail, no bounce to `/`
- [ ] Hard-load `/dep-graph` in a fresh browser tab — page renders dep-graph, no redirect
- [ ] With a non-home landing preference set, navigate to `/` from within the app — preference redirect fires correctly
- [ ] With a non-home landing preference, hard-load `/ticket/CTL-1` — preference redirect does NOT fire
- [ ] Click the STARVED drill in Utilization — client-side navigates to `/dispatch`, no full reload
- [ ] Click the JAMMED drill in Utilization — client-side navigates to `/fleetops`, no full reload
- [ ] Click a host row in Host Matrix — client-side navigates to `/dispatch`, no full reload
- [x] CI checks: audit-references, check-versions, docs-gate, validate — all pass ✅

## Related Issues / PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1059
