### PR TITLE
feat(dev): CTL-1051 — push-verify HEAD before announce/merge to prevent stale-ref PRs

### DIFF
--- a/plugins/dev/scripts/__tests__/create-pr-title.test.sh
+++ b/plugins/dev/scripts/__tests__/create-pr-title.test.sh
@@ -66,6 +66,14 @@ echo "F: docs/architecture.md contains draft-PR-early / work record section"
 assert_grep 'draft.*PR.*work record|work record.*draft PR|implement-plan-draft-pr-early|draft_pr_promote|draft.*implementing|ready.*in review' "$ARCH_DOC" \
   "F: architecture.md documents the PR-as-work-record convention"
 
+# ─── G. CTL-1051: create-pr push step uses force-with-lease + post-push verify
+echo ""
+echo "G: CTL-1051 — create-pr push uses --force-with-lease and verifies push"
+assert_grep '\-\-force-with-lease' "$SKILL_CREATE_PR" \
+  "G1: create-pr push retries with --force-with-lease"
+assert_grep 'git fetch' "$SKILL_CREATE_PR" \
+  "G2: create-pr verifies push via git fetch"
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/phase-monitor-merge-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-monitor-merge-guard.test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Static guard: phase-monitor-merge/SKILL.md has the pre-merge stale-ref check (CTL-1051).
+# Run: bash plugins/dev/scripts/__tests__/phase-monitor-merge-guard.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILL="${REPO_ROOT}/plugins/dev/skills/phase-monitor-merge/SKILL.md"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+
+assert_contains() {
+  local body="$1" substr="$2" label="$3"
+  if [[ "$body" == *"$substr"* ]]; then pass "$label"
+  else fail "$label — '$substr' not found"; fi
+}
+
+echo "CTL-1051: phase-monitor-merge pre-merge stale-ref guard"
+
+if [[ -f "$SKILL" ]]; then
+  BODY="$(cat "$SKILL")"
+  assert_contains "$BODY" "draft_pr_push_verify" \
+    "monitor-merge push-verifies on headRefOid mismatch"
+  assert_contains "$BODY" "head.sha" \
+    "monitor-merge reads PR head SHA pre-merge"
+else
+  fail "SKILL.md missing: $SKILL"
+fi
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "phase-monitor-merge-guard: ${PASSES} passed, ${FAILURES} failed"
+echo "─────────────────────────────────────────────"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/phase-pr-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-pr-e2e.test.sh
@@ -372,6 +372,21 @@ STUB
   fi
 fi
 
+# ─── CTL-1051 Suite C: push-verify wiring ────────────────────────────────────
+echo ""
+echo "CTL-1051 Suite C: phase-pr push-verify wiring"
+
+if [[ -f "$SKILL" ]]; then
+  BODY="$(cat "$SKILL")"
+
+  assert_contains "$BODY" "draft_pr_push_verify" \
+    "CTL-1051 C1: phase-pr calls draft_pr_push_verify"
+  assert_contains "$BODY" "draft_pr_head_oid" \
+    "CTL-1051 C2: phase-pr compares PR.headRefOid"
+  assert_contains "$BODY" "stale_ref_push_verify_failed" \
+    "CTL-1051 C3: phase-pr fails loudly on stale ref"
+fi
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
@@ -699,6 +699,84 @@ else
   fail "Suite 2 ext: draft_pr_ensure --title should be 'feat: CTL-709 work commit', got: '$TITLE_LINE'"
 fi
 
+# ─── Suite 6: draft_pr_push_verify + draft_pr_head_oid (CTL-1051) ─────────────
+echo ""
+echo "Suite 6: draft_pr_push_verify and draft_pr_head_oid"
+
+# 6a: fast-forward push — no prior remote ref; returns 0, echoes HEAD sha, origin == HEAD.
+echo "6a: fast-forward push → returns 0, echoes HEAD sha, origin/feature == HEAD"
+new_fixture pv-ff
+(
+  cd "$WORK"
+  source "$DRAFT_PR_LIB"
+  set +e
+  out="$(draft_pr_push_verify 2>/dev/null)"; rc=$?
+  set -e
+  echo "$rc" > "${SCRATCH}/pv-ff.exit"
+  echo "$out" > "${SCRATCH}/pv-ff.out"
+  git rev-parse HEAD > "${SCRATCH}/pv-ff.local"
+  git rev-parse origin/feature > "${SCRATCH}/pv-ff.remote" 2>/dev/null || echo "" > "${SCRATCH}/pv-ff.remote"
+) || true
+assert_eq "0" "$(cat "${SCRATCH}/pv-ff.exit" 2>/dev/null)" "6a: push_verify ff returns 0"
+assert_eq "$(cat "${SCRATCH}/pv-ff.local")" "$(cat "${SCRATCH}/pv-ff.out")" "6a: push_verify ff echoes HEAD sha"
+assert_eq "$(cat "${SCRATCH}/pv-ff.local")" "$(cat "${SCRATCH}/pv-ff.remote")" "6a: origin/feature == HEAD after ff"
+
+# 6b: non-fast-forward (rebase/amend) — plain push fails; force-with-lease succeeds;
+#     rc==0, origin/feature advances to HEAD.
+echo "6b: non-fast-forward (rebase) → force-with-lease; rc==0; origin advanced"
+new_fixture pv-nff
+(
+  cd "$WORK"
+  git -c core.hooksPath=/dev/null push -u origin HEAD >/dev/null 2>&1   # commit A on origin
+  git commit --quiet --amend -m "feat: amended work commit"              # diverge → commit B
+  source "$DRAFT_PR_LIB"
+  set +e
+  out="$(draft_pr_push_verify 2>/dev/null)"; rc=$?
+  set -e
+  echo "$rc" > "${SCRATCH}/pv-nff.exit"
+  git rev-parse HEAD > "${SCRATCH}/pv-nff.local"
+  git rev-parse origin/feature > "${SCRATCH}/pv-nff.remote" 2>/dev/null || echo "" > "${SCRATCH}/pv-nff.remote"
+) || true
+assert_eq "0" "$(cat "${SCRATCH}/pv-nff.exit" 2>/dev/null)" "6b: push_verify rebase returns 0 (force-with-lease)"
+assert_eq "$(cat "${SCRATCH}/pv-nff.local")" "$(cat "${SCRATCH}/pv-nff.remote")" "6b: origin/feature advanced to HEAD"
+
+# 6c: detached HEAD — fail-closed; returns non-zero; echoes nothing.
+echo "6c: detached HEAD → fail-closed; rc!=0; no output"
+new_fixture pv-detached
+(
+  cd "$WORK"
+  git checkout --quiet --detach HEAD
+  source "$DRAFT_PR_LIB"
+  set +e
+  out="$(draft_pr_push_verify 2>/dev/null)"; rc=$?
+  set -e
+  echo "$rc" > "${SCRATCH}/pv-det.exit"
+  echo "$out" > "${SCRATCH}/pv-det.out"
+) || true
+DET_EXIT="$(cat "${SCRATCH}/pv-det.exit" 2>/dev/null)"
+DET_OUT="$(cat "${SCRATCH}/pv-det.out" 2>/dev/null)"
+if [[ "$DET_EXIT" != "0" ]]; then pass "6c: push_verify detached HEAD returns non-zero"
+else fail "6c: detached HEAD should return non-zero — got rc=$DET_EXIT"; fi
+if [[ -z "$DET_OUT" ]]; then pass "6c: push_verify detached HEAD echoes nothing"
+else fail "6c: detached HEAD should echo nothing — got '$DET_OUT'"; fi
+
+# 6d: draft_pr_head_oid reads PR.headRefOid from gh stub.
+echo "6d: draft_pr_head_oid reads PR.headRefOid"
+P6D_BIN="${SCRATCH}/hoid/bin"
+mkdir -p "$P6D_BIN"
+cat > "${P6D_BIN}/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "view" ]]; then echo "deadbeefcafe"; exit 0; fi
+exit 1
+STUB
+chmod +x "${P6D_BIN}/gh"
+(
+  source "$DRAFT_PR_LIB"
+  out="$(PATH="${P6D_BIN}:$PATH" draft_pr_head_oid 2>/dev/null)"
+  echo "$out" > "${SCRATCH}/hoid.out"
+) || true
+assert_eq "deadbeefcafe" "$(cat "${SCRATCH}/hoid.out" 2>/dev/null)" "6d: head_oid echoes PR.headRefOid"
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/lib/draft-pr.sh
+++ b/plugins/dev/scripts/lib/draft-pr.sh
@@ -141,6 +141,49 @@ draft_pr_promote() {
   return 0
 }
 
+# draft_pr_push_verify — push current HEAD to origin and PROVE the remote tip
+# equals local HEAD. Unlike draft_pr_push (fail-open), this is fail-CLOSED: it
+# returns 0 ONLY when origin/<branch> == local HEAD after the push, so callers
+# can fail the phase rather than announce/merge a stale ref (CTL-1051).
+#   - First attempt: plain push (fast-forward). CTL-693 hook suppression.
+#   - Non-fast-forward (branch rebased/amended after a prior push): retry with
+#     --force-with-lease (mirrors the BEHIND handler in phase-monitor-merge).
+#   - Verify: git fetch the branch, compare origin/<branch> to local HEAD.
+# Echoes the verified SHA on success; nothing on failure.
+draft_pr_push_verify() {
+  command -v git >/dev/null 2>&1 || { _draft_pr_warn "git unavailable"; return 1; }
+  local branch local_sha remote_sha
+  branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  [[ -z "$branch" || "$branch" == "HEAD" ]] && { _draft_pr_warn "detached HEAD; cannot push-verify"; return 1; }
+  local_sha="$(git rev-parse HEAD 2>/dev/null || true)"
+  [[ -z "$local_sha" ]] && { _draft_pr_warn "cannot resolve local HEAD"; return 1; }
+
+  if ! git -c core.hooksPath=/dev/null push -u origin HEAD >/dev/null 2>&1; then
+    _draft_pr_warn "fast-forward push failed; retrying with --force-with-lease"
+    git -c core.hooksPath=/dev/null push --force-with-lease -u origin HEAD >/dev/null 2>&1 \
+      || { _draft_pr_warn "force-with-lease push failed"; return 1; }
+  fi
+
+  git fetch --quiet origin "$branch" 2>/dev/null || true
+  remote_sha="$(git rev-parse "origin/${branch}" 2>/dev/null || true)"
+  if [[ -n "$remote_sha" && "$remote_sha" == "$local_sha" ]]; then
+    printf '%s\n' "$local_sha"
+    return 0
+  fi
+  _draft_pr_warn "post-push verify mismatch: local=${local_sha} origin/${branch}=${remote_sha:-<none>}"
+  return 1
+}
+
+# draft_pr_head_oid — echo the open PR's headRefOid (the remote SHA the PR
+# points at) for the current branch. Empty + non-zero when unavailable.
+draft_pr_head_oid() {
+  command -v gh >/dev/null 2>&1 || return 1
+  local oid
+  oid="$(gh pr view --json headRefOid -q '.headRefOid' 2>/dev/null || true)"
+  [[ -n "$oid" ]] && { printf '%s\n' "$oid"; return 0; }
+  return 1
+}
+
 # draft_pr_enabled — read .catalyst/config.json knob. Returns "true" (default) or "false".
 # Fail-open to "true" when jq or the config file are absent.
 # NOTE: cannot use jq's `// true` default — jq's alternative operator treats `false` as

--- a/plugins/dev/skills/create-pr/SKILL.md
+++ b/plugins/dev/skills/create-pr/SKILL.md
@@ -148,13 +148,18 @@ fi
 ### 8. Push branch
 
 ```bash
-# Check if branch has upstream
-if ! git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null; then
-    # No upstream, push with -u
-    git push -u origin HEAD
-else
-    # Has upstream, check if up-to-date
-    git push
+# Push current HEAD and verify origin == HEAD. On a non-fast-forward (branch
+# rebased/amended after a prior push), retry with --force-with-lease so the PR
+# never points at a stale commit (CTL-1051).
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if ! git push -u origin HEAD; then
+    echo "create-pr: fast-forward push failed; retrying with --force-with-lease" >&2
+    git push --force-with-lease -u origin HEAD
+fi
+git fetch --quiet origin "$BRANCH" || true
+if [[ "$(git rev-parse "origin/${BRANCH}")" != "$(git rev-parse HEAD)" ]]; then
+    echo "create-pr: post-push verify failed — origin/${BRANCH} != HEAD" >&2
+    exit 1
 fi
 ```
 

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -154,6 +154,20 @@ Once `mergeable_state == "clean"` (and the PR isn't already merged):
 ```bash
 # CTL-864: cross-host fence — bow out if a takeover superseded us. No-op single-host.
 "${PLUGIN_ROOT}/scripts/lib/cluster-fence-guard.sh" --phase "$PHASE" --ticket "$TICKET" || exit 10
+# CTL-1051: never merge a stale ref. Compare the PR head to the worktree HEAD;
+# on mismatch, re-push with lease and re-verify before merging.
+if [[ -r "${PLUGIN_ROOT}/scripts/lib/draft-pr.sh" ]]; then
+  source "${PLUGIN_ROOT}/scripts/lib/draft-pr.sh"
+  PR_HEAD_OID="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha' 2>/dev/null || true)"
+  LOCAL_HEAD="$(git rev-parse HEAD 2>/dev/null || true)"
+  if [[ -n "$PR_HEAD_OID" && -n "$LOCAL_HEAD" && "$PR_HEAD_OID" != "$LOCAL_HEAD" ]]; then
+    echo "phase-monitor-merge: PR head ${PR_HEAD_OID} != worktree HEAD ${LOCAL_HEAD}; re-pushing" >&2
+    if ! draft_pr_push_verify >/dev/null; then
+      echo "phase-monitor-merge: could not reconcile stale ref before merge" >&2
+      exit 1
+    fi
+  fi
+fi
 gh pr merge "$PR_NUMBER" --squash --delete-branch
 # REST is authoritative — confirm via REST, never GraphQL
 MERGED_OK=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.merged' 2>/dev/null || echo "false")

--- a/plugins/dev/skills/phase-pr/SKILL.md
+++ b/plugins/dev/skills/phase-pr/SKILL.md
@@ -176,10 +176,31 @@ When an existing open PR is found, promote it (if draft) and finish — **withou
 "${PLUGIN_ROOT}/scripts/lib/cluster-fence-guard.sh" --phase "$PHASE" --ticket "$TICKET" || exit 10
 if [[ -n "$EXISTING_PR_NUMBER" ]]; then
   echo "phase-pr: promoting existing PR #${EXISTING_PR_NUMBER} (draft=${EXISTING_PR_IS_DRAFT})" >&2
+  if [[ -r "${PLUGIN_ROOT}/scripts/lib/draft-pr.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "${PLUGIN_ROOT}/scripts/lib/draft-pr.sh"
+  fi
+  # CTL-1051: prove the remote branch (and the PR head) equal the worktree HEAD
+  # BEFORE announcing the promoted PR — remediation/rebase may have advanced
+  # local HEAD past the draft's pushed commit. Fail-closed: a stale ref is a
+  # phase FAILURE, not a silent complete.
+  if ! VERIFIED_SHA="$(draft_pr_push_verify)"; then
+    echo "phase-pr: push-verify failed for #${EXISTING_PR_NUMBER} (stale ref)" >&2
+    "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+      --phase "$PHASE" --ticket "$TICKET" --status failed \
+      --reason "stale_ref_push_verify_failed"
+    exit 1
+  fi
+  PR_HEAD_OID="$(draft_pr_head_oid || true)"
+  if [[ -n "$PR_HEAD_OID" && "$PR_HEAD_OID" != "$VERIFIED_SHA" ]]; then
+    echo "phase-pr: PR headRefOid ${PR_HEAD_OID} != worktree HEAD ${VERIFIED_SHA}" >&2
+    "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+      --phase "$PHASE" --ticket "$TICKET" --status failed \
+      --reason "stale_ref_push_verify_failed"
+    exit 1
+  fi
   if [[ "$EXISTING_PR_IS_DRAFT" == "true" ]]; then
-    if [[ -r "${PLUGIN_ROOT}/scripts/lib/draft-pr.sh" ]]; then
-      # shellcheck source=/dev/null
-      source "${PLUGIN_ROOT}/scripts/lib/draft-pr.sh"
+    if type draft_pr_promote >/dev/null 2>&1; then
       draft_pr_promote || gh pr ready "$EXISTING_PR_NUMBER" 2>/dev/null || true
     else
       gh pr ready "$EXISTING_PR_NUMBER" 2>/dev/null || true
@@ -227,9 +248,27 @@ itself.
    and Linear `inReview` transition.
 
 3. After either path, capture the PR metadata via `gh` and write it into the phase signal file so
-   `phase-monitor-merge` can read it directly without re-querying GitHub:
+   `phase-monitor-merge` can read it directly without re-querying GitHub. For the create-pr path,
+   push-verify before recording metadata (CTL-1051):
 
    ```bash
+   # CTL-1051: ensure create-pr's push left origin == HEAD and the PR points at it.
+   [[ -r "${PLUGIN_ROOT}/scripts/lib/draft-pr.sh" ]] && source "${PLUGIN_ROOT}/scripts/lib/draft-pr.sh"
+   if ! VERIFIED_SHA="$(draft_pr_push_verify)"; then
+     echo "phase-pr: post-create-pr push-verify failed (stale ref)" >&2
+     "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+       --phase "$PHASE" --ticket "$TICKET" --status failed \
+       --reason "stale_ref_push_verify_failed"
+     exit 1
+   fi
+   PR_HEAD_OID="$(draft_pr_head_oid || true)"
+   if [[ -n "$PR_HEAD_OID" && "$PR_HEAD_OID" != "$VERIFIED_SHA" ]]; then
+     echo "phase-pr: PR headRefOid ${PR_HEAD_OID} != HEAD ${VERIFIED_SHA}" >&2
+     "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+       --phase "$PHASE" --ticket "$TICKET" --status failed \
+       --reason "stale_ref_push_verify_failed"
+     exit 1
+   fi
    PR_INFO=$(gh pr view --json number,url,headRefName,baseRefName 2>/dev/null || echo "{}")
    PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number // empty')
    PR_URL=$(echo "$PR_INFO" | jq -r '.url // empty')


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-12T14:50:00Z -->
<!-- Last updated: 2026-06-12T14:50:00Z -->
<!-- PR: #1891 -->
<!-- Previous commits: 5ffd03b18811fc4f9f552f0cc81cb320c87e866d -->

## Summary

Adds a fail-closed `draft_pr_push_verify` primitive and wires it into the three sites where a stale ref can leak into an open PR:

- **`phase-pr` promote-and-finish path**: push-verify + `headRefOid` comparison before `gh pr ready` — fails loudly on mismatch
- **`phase-pr` post-`create-pr` metadata capture**: same gate before recording PR metadata in the signal file
- **`phase-monitor-merge` pre-merge block**: compares `PR.head.sha` to worktree HEAD; re-pushes with lease and aborts if it cannot reconcile

Root cause: after a rebase/remediation flow, the worktree HEAD advances but the previous push is not repeated, so the PR can silently point at a pre-rebase commit. This was caught twice in production (CTL-997 PR #1759, CTL-1009 PR #1830).

## Changes Made

### Library — `plugins/dev/scripts/lib/draft-pr.sh`

- **`draft_pr_push_verify`** (new): push current HEAD with plain push first; on non-fast-forward, retry with `--force-with-lease`; then `git fetch` + SHA comparison. Returns 0 only when `origin/<branch> == local HEAD`. Echoes the verified SHA on success; nothing on failure.
- **`draft_pr_head_oid`** (new): reads `PR.headRefOid` via `gh pr view` so callers can compare the remote PR pointer to the local HEAD without a full `gh api` call.

### Skill Updates

- **`create-pr/SKILL.md`** — Step 8 push block replaced: plain push first, `--force-with-lease` retry on non-fast-forward, post-push `git fetch` + SHA equality check; exits 1 if origin tip doesn't match HEAD.
- **`phase-pr/SKILL.md`** — Promote-and-finish path (CTL-709 existing-open-PR detection): calls `draft_pr_push_verify` before `gh pr ready`; compares `draft_pr_head_oid` to local HEAD and emits `stale_ref_push_verify_failed` on mismatch. Post-`create-pr` path: same gate before writing `pr.number`/`pr.url` to the signal file.
- **`phase-monitor-merge/SKILL.md`** — Pre-merge block: reads `PR.head.sha` via REST, compares to `git rev-parse HEAD`, calls `draft_pr_push_verify` on mismatch, aborts merge if reconciliation fails.

### Tests

- **`draft-pr.test.sh`** — Suite 6 (8 new unit tests): fast-forward push returns 0 and echoes HEAD SHA; non-fast-forward/rebase returns 0 via force-with-lease; detached HEAD is fail-closed (rc≠0, no output); `draft_pr_head_oid` echoes `PR.headRefOid` from a `gh` stub.
- **`phase-pr-e2e.test.sh`** — Suite C (3 static guards): verifies `draft_pr_push_verify`, `draft_pr_head_oid`, and `stale_ref_push_verify_failed` are present in `phase-pr/SKILL.md`.
- **`create-pr-title.test.sh`** — Suite G (2 static guards): verifies `--force-with-lease` and `git fetch` are present in `create-pr/SKILL.md`.
- **`phase-monitor-merge-guard.test.sh`** (new file, 2 static guards): verifies `draft_pr_push_verify` and `head.sha` are present in `phase-monitor-merge/SKILL.md`.

## How to Verify It

- [x] `bash plugins/dev/scripts/lib/__tests__/draft-pr.test.sh` — Suite 6 passes (fast-forward, force-with-lease, detached-HEAD, head-oid stub)
- [x] `bash plugins/dev/scripts/__tests__/phase-pr-e2e.test.sh` — Suite C passes (push-verify wiring)
- [x] `bash plugins/dev/scripts/__tests__/create-pr-title.test.sh` — Suite G passes (force-with-lease in create-pr)
- [x] `bash plugins/dev/scripts/__tests__/phase-monitor-merge-guard.test.sh` — passes (monitor-merge stale-ref guard)
- [x] CI checks: audit-references, check-versions, docs-gate, validate — all pass

## Related Issues / PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1051

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1009
