### PR TITLE
feat(dev): CTL-1047 — OTel semconv remediation (all clusters A–H, hard cutover)

### DIFF
--- a/plugins/dev/scripts/__tests__/canonical-event.test.sh
+++ b/plugins/dev/scripts/__tests__/canonical-event.test.sh
@@ -235,10 +235,10 @@ OVR_OUT="$(echo "$LINE_OVR" | jq -r '.resource."linear.key"')"
 expect_eq "build_canonical_line --linear-key overrides promotion" "CTL-999" "$OVR_OUT"
 
 # project sourced from OTEL_RESOURCE_ATTRIBUTES
-LINE_PROJ="$(OTEL_RESOURCE_ATTRIBUTES='project=catalyst-workspace,linear.key=CTL-636' \
+LINE_PROJ="$(OTEL_RESOURCE_ATTRIBUTES='catalyst.project=catalyst-workspace,linear.key=CTL-636' \
   build_canonical_line --ts "2026-05-25T18:00:00Z" --severity INFO \
   --service "catalyst.session" --event-name "x")"
-PROJ_OUT="$(echo "$LINE_PROJ" | jq -r '.resource."project" // ""')"
+PROJ_OUT="$(echo "$LINE_PROJ" | jq -r '.resource."catalyst.project" // ""')"
 expect_eq "build_canonical_line sources project from OTEL_RESOURCE_ATTRIBUTES" "catalyst-workspace" "$PROJ_OUT"
 
 SEV_NUM="$(echo "$LINE" | jq -r '.severityNumber')"

--- a/plugins/dev/scripts/__tests__/emit-otel-event.test.sh
+++ b/plugins/dev/scripts/__tests__/emit-otel-event.test.sh
@@ -115,12 +115,12 @@ assert_eq "claude_code.session.outcome" \
   "body.stringValue is event name"
 
 assert_eq "success" \
-  "$(echo "$BODY" | jq -r '.resourceLogs[0].scopeLogs[0].logRecords[0].attributes[]? | select(.key=="outcome") | .value.stringValue')" \
-  "outcome attribute"
+  "$(echo "$BODY" | jq -r '.resourceLogs[0].scopeLogs[0].logRecords[0].attributes[]? | select(.key=="catalyst.outcome") | .value.stringValue')" \
+  "catalyst.outcome attribute"
 
 assert_eq "sess_abc" \
-  "$(echo "$BODY" | jq -r '.resourceLogs[0].scopeLogs[0].logRecords[0].attributes[]? | select(.key=="session_id") | .value.stringValue')" \
-  "session_id attribute"
+  "$(echo "$BODY" | jq -r '.resourceLogs[0].scopeLogs[0].logRecords[0].attributes[]? | select(.key=="claude.session.id") | .value.stringValue')" \
+  "claude.session.id attribute"
 
 # ─── Test 2: linear.key resource attribute ──────────────────────────────────
 echo ""
@@ -161,8 +161,8 @@ export CURL_STUB_BODY="$SCRATCH/body3"
 
 BODY=$(cat "$SCRATCH/body3")
 assert_eq "quality gates failed" \
-  "$(echo "$BODY" | jq -r '.resourceLogs[0].scopeLogs[0].logRecords[0].attributes[]? | select(.key=="reason") | .value.stringValue')" \
-  "reason attribute"
+  "$(echo "$BODY" | jq -r '.resourceLogs[0].scopeLogs[0].logRecords[0].attributes[]? | select(.key=="catalyst.reason") | .value.stringValue')" \
+  "catalyst.reason attribute"
 
 # ─── Test 4: silent no-op when OTEL_EXPORTER_OTLP_ENDPOINT unset ────────────
 echo ""
@@ -308,8 +308,8 @@ export CURL_STUB_BODY="$SCRATCH/body11"
 BODY_11=$(cat "$SCRATCH/body11" 2>/dev/null || echo "{}")
 PHASE_ATTR=$(echo "$BODY_11" | jq -r '
   .resourceLogs[0].scopeLogs[0].logRecords[0].attributes[]
-  | select(.key == "phase") | .value.stringValue // ""')
-assert_eq "research" "$PHASE_ATTR" "--phase adds phase attribute to log record"
+  | select(.key == "catalyst.phase") | .value.stringValue // ""')
+assert_eq "research" "$PHASE_ATTR" "--phase adds catalyst.phase attribute to log record"
 
 # ─── Test 12: --resource-attr string lands in resource attrs ────────────────
 echo ""

--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -443,10 +443,10 @@ SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
 echo '{"status":"running","ticket":"CTL-100","phase":"implement","attempt":3}' >"$SIGNAL"
 "$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status complete >/dev/null 2>&1
 LINE=$(read_event_line)
-ATT=$(echo "$LINE" | jq -r '.attributes["phase.attempt"] // empty')
-RC=$(echo "$LINE" | jq -r '.attributes["phase.revive_count"] // empty')
-assert_eq "3" "$ATT" "attributes[\"phase.attempt\"] = 3 from signal"
-assert_eq "2" "$RC" "attributes[\"phase.revive_count\"] = attempt-1 = 2"
+ATT=$(echo "$LINE" | jq -r '.attributes["catalyst.phase.attempt"] // empty')
+RC=$(echo "$LINE" | jq -r '.attributes["catalyst.phase.revive_count"] // empty')
+assert_eq "3" "$ATT" "attributes[\"catalyst.phase.attempt\"] = 3 from signal"
+assert_eq "2" "$RC" "attributes[\"catalyst.phase.revive_count\"] = attempt-1 = 2"
 
 echo ""
 echo "Test 26 (CTL-761): cold dispatch attempt=1 → revive_count=0"
@@ -455,8 +455,8 @@ SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-triage.json"
 echo '{"status":"running","ticket":"CTL-100","phase":"triage","attempt":1}' >"$SIGNAL"
 "$EMIT_SCRIPT" --phase triage --ticket CTL-100 --status complete >/dev/null 2>&1
 LINE=$(read_event_line)
-assert_eq "1" "$(echo "$LINE" | jq -r '.attributes["phase.attempt"]')" "attempt=1"
-assert_eq "0" "$(echo "$LINE" | jq -r '.attributes["phase.revive_count"]')" "revive_count clamped to 0"
+assert_eq "1" "$(echo "$LINE" | jq -r '.attributes["catalyst.phase.attempt"]')" "attempt=1"
+assert_eq "0" "$(echo "$LINE" | jq -r '.attributes["catalyst.phase.revive_count"]')" "revive_count clamped to 0"
 
 echo ""
 echo "Test 27 (CTL-761): attributes omitted when signal lacks attempt"
@@ -465,8 +465,8 @@ SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
 echo '{"status":"running","ticket":"CTL-100","phase":"implement"}' >"$SIGNAL"
 "$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status complete >/dev/null 2>&1
 LINE=$(read_event_line)
-assert_eq "false" "$(echo "$LINE" | jq -r '.attributes | has("phase.attempt")')" "phase.attempt omitted"
-assert_eq "false" "$(echo "$LINE" | jq -r '.attributes | has("phase.revive_count")')" "phase.revive_count omitted"
+assert_eq "false" "$(echo "$LINE" | jq -r '.attributes | has("catalyst.phase.attempt")')" "catalyst.phase.attempt omitted"
+assert_eq "false" "$(echo "$LINE" | jq -r '.attributes | has("catalyst.phase.revive_count")')" "catalyst.phase.revive_count omitted"
 
 echo ""
 echo "Test 28 (CTL-761): failed status also carries attempt/revive_count"
@@ -475,8 +475,8 @@ SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
 echo '{"status":"running","ticket":"CTL-100","phase":"implement","attempt":2}' >"$SIGNAL"
 "$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status failed --reason "test_reason" >/dev/null 2>&1
 LINE=$(read_event_line)
-assert_eq "2" "$(echo "$LINE" | jq -r '.attributes["phase.attempt"]')" "failed path: phase.attempt=2"
-assert_eq "1" "$(echo "$LINE" | jq -r '.attributes["phase.revive_count"]')" "failed path: revive_count=1"
+assert_eq "2" "$(echo "$LINE" | jq -r '.attributes["catalyst.phase.attempt"]')" "failed path: catalyst.phase.attempt=2"
+assert_eq "1" "$(echo "$LINE" | jq -r '.attributes["catalyst.phase.revive_count"]')" "failed path: catalyst.phase.revive_count=1"
 
 # ─── CTL-777: signal flip fires from --orch-dir even when the env var is dropped ─
 # `claude --bg` drops the plain env prefix, so a worker can run with

--- a/plugins/dev/scripts/catalyst-agent/host.mjs
+++ b/plugins/dev/scripts/catalyst-agent/host.mjs
@@ -12,15 +12,15 @@
 // bun. The standalone agent does NOT import from execution-core.
 //
 // Contract attrs (host.metrics.sampled, entity=host, event.label=hostname):
-//   host.cpu_pct       1 decimal, clamped 0..100
-//   host.cpu_count     integer (os.cpus().length)
-//   host.load1         os.loadavg()[0], 2 decimals
-//   host.mem_used_mb   integer
-//   host.mem_total_mb  integer
-//   host.mem_used_pct  1 decimal, clamped 0..100
-//   host.disk_used_gb  1 decimal
-//   host.disk_total_gb 1 decimal
-//   host.disk_used_pct 1 decimal, clamped 0..100
+//   system.cpu.utilization       0.0–1.0 (clamped), 3 decimals
+//   system.cpu.logical_count     integer (os.cpus().length)
+//   system.linux.cpu.load_1m     os.loadavg()[0], 2 decimals
+//   system.memory.usage          bytes (roundInt(MB) × 1048576)
+//   system.memory.limit          bytes (roundInt(MB) × 1048576)
+//   system.memory.utilization    0.0–1.0 (clamped), 3 decimals
+//   system.filesystem.usage      bytes (round1(GB) × 1073741824, rounded to int)
+//   system.filesystem.capacity   bytes (round1(GB) × 1073741824, rounded to int)
+//   system.filesystem.utilization 0.0–1.0 (clamped), 3 decimals
 
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
@@ -269,16 +269,23 @@ export async function sampleHost({
   const diskUsedPct =
     isPos(disk.totalGb) && disk.usedGb != null ? (disk.usedGb / disk.totalGb) * 100 : null;
 
+  const cpuUtil = round1(clampPct(cpu.cpuPct));
+  const memUsedMb = roundInt(mem.usedMb);
+  const memTotalMb = roundInt(mem.totalMb);
+  const memUtil = round1(clampPct(memUsedPct));
+  const diskUsedGb = round1(disk.usedGb);
+  const diskTotalGb = round1(disk.totalGb);
+  const diskUtil = round1(clampPct(diskUsedPct));
   const attrs = {
-    "host.cpu_pct": round1(clampPct(cpu.cpuPct)),
-    "host.cpu_count": roundInt(cpu.cpuCount),
-    "host.load1": round2(load1),
-    "host.mem_used_mb": roundInt(mem.usedMb),
-    "host.mem_total_mb": roundInt(mem.totalMb),
-    "host.mem_used_pct": round1(clampPct(memUsedPct)),
-    "host.disk_used_gb": round1(disk.usedGb),
-    "host.disk_total_gb": round1(disk.totalGb),
-    "host.disk_used_pct": round1(clampPct(diskUsedPct)),
+    "system.cpu.utilization":      cpuUtil    == null ? null : cpuUtil / 100,
+    "system.cpu.logical_count":    roundInt(cpu.cpuCount),
+    "system.linux.cpu.load_1m":    round2(load1),
+    "system.memory.usage":         memUsedMb  == null ? null : memUsedMb  * 1048576,
+    "system.memory.limit":         memTotalMb == null ? null : memTotalMb * 1048576,
+    "system.memory.utilization":   memUtil    == null ? null : memUtil / 100,
+    "system.filesystem.usage":     diskUsedGb  == null ? null : Math.round(diskUsedGb  * 1073741824),
+    "system.filesystem.capacity":  diskTotalGb == null ? null : Math.round(diskTotalGb * 1073741824),
+    "system.filesystem.utilization": diskUtil  == null ? null : diskUtil / 100,
   };
 
   // `await` normalizes both emit seams: the default async defaultEmit (which

--- a/plugins/dev/scripts/catalyst-agent/host.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/host.test.mjs
@@ -2,8 +2,8 @@
 //
 // sampleHost is exercised purely through injected seams (readCpu / readMem /
 // readDisk / readLoad / emit) so there is no real /proc, df, vm_stat, or sleep.
-// Covers: exact contract attrs, partial-probe failure still emits, pct bounds
-// clamped 0..100, rounding (pct 1dp, mb int, gb 1dp, load1 2dp), the put()
+// Covers: exact contract attrs (OTel system.* names + unit conversions), partial-probe
+// failure still emits, pct bounds clamped 0..1.0 utilization, the put()
 // pattern (null probe → attr omitted), and the pure parse helpers against real
 // `df -k /` and `vm_stat` output captured on macOS.
 //
@@ -66,19 +66,19 @@ describe("sampleHost — emits one host.metrics.sampled per contract", () => {
     expect(calls[0].opts.now).toBe(now);
   });
 
-  test("carries every contract attr with correct rounding", async () => {
+  test("carries every contract attr with correct values and OTel units", async () => {
     const { calls, emit } = captureEmit();
     await sampleHost({ ...healthyProbes(), emit });
     const a = calls[0].spec.attrs;
-    expect(a["host.cpu_pct"]).toBe(12.3); // 1 decimal
-    expect(a["host.cpu_count"]).toBe(10); // int
-    expect(a["host.load1"]).toBe(2.35); // 2 decimals
-    expect(a["host.mem_used_mb"]).toBe(8193); // int (8192.6 → 8193)
-    expect(a["host.mem_total_mb"]).toBe(16384); // int
-    expect(a["host.mem_used_pct"]).toBe(50.0); // 8192.6/16384*100 → 50.0
-    expect(a["host.disk_used_gb"]).toBe(120.5); // 1 decimal (120.45 → 120.5)
-    expect(a["host.disk_total_gb"]).toBe(500.0); // 1 decimal
-    expect(a["host.disk_used_pct"]).toBe(24.1); // 120.45/500*100 = 24.09 → 24.1
+    expect(a["system.cpu.utilization"]).toBeCloseTo(0.123, 3); // 12.3% → 0.123
+    expect(a["system.cpu.logical_count"]).toBe(10);
+    expect(a["system.linux.cpu.load_1m"]).toBe(2.35);
+    expect(a["system.memory.usage"]).toBe(8193 * 1048576);   // 8193 MB → bytes
+    expect(a["system.memory.limit"]).toBe(16384 * 1048576);  // 16384 MB → bytes
+    expect(a["system.memory.utilization"]).toBeCloseTo(0.5, 3); // 50% → 0.5
+    expect(a["system.filesystem.usage"]).toBe(Math.round(120.5 * 1073741824));   // 120.5 GB → bytes
+    expect(a["system.filesystem.capacity"]).toBe(Math.round(500.0 * 1073741824)); // 500 GB → bytes
+    expect(a["system.filesystem.utilization"]).toBeCloseTo(0.241, 3); // 24.1% → 0.241
   });
 });
 
@@ -96,12 +96,12 @@ describe("sampleHost — partial-probe failure still emits", () => {
     expect(calls.length).toBe(1);
     const a = calls[0].spec.attrs;
     // disk probe threw → all three disk attrs are null (dropped downstream).
-    expect(a["host.disk_used_gb"]).toBe(null);
-    expect(a["host.disk_total_gb"]).toBe(null);
-    expect(a["host.disk_used_pct"]).toBe(null);
+    expect(a["system.filesystem.usage"]).toBe(null);
+    expect(a["system.filesystem.capacity"]).toBe(null);
+    expect(a["system.filesystem.utilization"]).toBe(null);
     // the others are unaffected.
-    expect(a["host.cpu_pct"]).toBe(12.3);
-    expect(a["host.mem_used_mb"]).toBe(8193);
+    expect(a["system.cpu.utilization"]).toBeCloseTo(0.123, 3);
+    expect(a["system.memory.usage"]).toBe(8193 * 1048576);
   });
 
   test("a null-returning probe omits only its attrs", async () => {
@@ -111,9 +111,9 @@ describe("sampleHost — partial-probe failure still emits", () => {
       emit,
     });
     const a = calls[0].spec.attrs;
-    expect(a["host.cpu_pct"]).toBe(null);
-    expect(a["host.cpu_count"]).toBe(null);
-    expect(a["host.load1"]).toBe(2.35); // still present
+    expect(a["system.cpu.utilization"]).toBe(null);
+    expect(a["system.cpu.logical_count"]).toBe(null);
+    expect(a["system.linux.cpu.load_1m"]).toBe(2.35); // still present
   });
 
   test("a rejected async probe is swallowed and the event still emits", async () => {
@@ -124,9 +124,9 @@ describe("sampleHost — partial-probe failure still emits", () => {
     });
     expect(calls.length).toBe(1);
     const a = calls[0].spec.attrs;
-    expect(a["host.mem_used_mb"]).toBe(null);
-    expect(a["host.mem_total_mb"]).toBe(null);
-    expect(a["host.mem_used_pct"]).toBe(null);
+    expect(a["system.memory.usage"]).toBe(null);
+    expect(a["system.memory.limit"]).toBe(null);
+    expect(a["system.memory.utilization"]).toBe(null);
   });
 
   test("an async probe value is awaited (not emitted as a Promise)", async () => {
@@ -135,8 +135,8 @@ describe("sampleHost — partial-probe failure still emits", () => {
       ...healthyProbes({ readCpu: async () => ({ cpuPct: 50, cpuCount: 8 }) }),
       emit,
     });
-    expect(calls[0].spec.attrs["host.cpu_pct"]).toBe(50);
-    expect(calls[0].spec.attrs["host.cpu_count"]).toBe(8);
+    expect(calls[0].spec.attrs["system.cpu.utilization"]).toBeCloseTo(0.5, 3);
+    expect(calls[0].spec.attrs["system.cpu.logical_count"]).toBe(8);
   });
 
   test("all probes failing still emits an event (all value attrs null)", async () => {
@@ -152,28 +152,28 @@ describe("sampleHost — partial-probe failure still emits", () => {
 });
 
 describe("sampleHost — pct bounds clamped to 0..100", () => {
-  test("cpu_pct above 100 is clamped to 100", async () => {
+  test("cpu_pct above 100 is clamped to 1.0 utilization", async () => {
     const { calls, emit } = captureEmit();
     await sampleHost({ ...healthyProbes({ readCpu: () => ({ cpuPct: 150, cpuCount: 4 }) }), emit });
-    expect(calls[0].spec.attrs["host.cpu_pct"]).toBe(100);
+    expect(calls[0].spec.attrs["system.cpu.utilization"]).toBe(1.0);
   });
 
-  test("cpu_pct below 0 is clamped to 0", async () => {
+  test("cpu_pct below 0 is clamped to 0.0 utilization", async () => {
     const { calls, emit } = captureEmit();
     await sampleHost({ ...healthyProbes({ readCpu: () => ({ cpuPct: -5, cpuCount: 4 }) }), emit });
-    expect(calls[0].spec.attrs["host.cpu_pct"]).toBe(0);
+    expect(calls[0].spec.attrs["system.cpu.utilization"]).toBe(0.0);
   });
 
-  test("derived mem_used_pct over 100 (used > total) is clamped to 100", async () => {
+  test("derived mem_used_pct over 100 (used > total) is clamped to 1.0 utilization", async () => {
     const { calls, emit } = captureEmit();
     await sampleHost({
       ...healthyProbes({ readMem: () => ({ usedMb: 20000, totalMb: 16384 }) }),
       emit,
     });
-    expect(calls[0].spec.attrs["host.mem_used_pct"]).toBe(100);
+    expect(calls[0].spec.attrs["system.memory.utilization"]).toBe(1.0);
   });
 
-  test("a zero/absent denominator yields a null pct (no div-by-zero / NaN)", async () => {
+  test("a zero/absent denominator yields a null utilization (no div-by-zero / NaN)", async () => {
     const { calls, emit } = captureEmit();
     await sampleHost({
       ...healthyProbes({
@@ -182,8 +182,8 @@ describe("sampleHost — pct bounds clamped to 0..100", () => {
       }),
       emit,
     });
-    expect(calls[0].spec.attrs["host.mem_used_pct"]).toBe(null);
-    expect(calls[0].spec.attrs["host.disk_used_pct"]).toBe(null);
+    expect(calls[0].spec.attrs["system.memory.utilization"]).toBe(null);
+    expect(calls[0].spec.attrs["system.filesystem.utilization"]).toBe(null);
   });
 });
 
@@ -223,9 +223,9 @@ describe("parseDfRoot — real `df -k /` fixtures", () => {
       emit,
     });
     const a = calls[0].spec.attrs;
-    expect(a["host.disk_total_gb"]).toBe(926.4); // 971350180/1048576 = 926.36 → 926.4
-    expect(a["host.disk_used_gb"]).toBe(15.6); // 16324544/1048576 = 15.57 → 15.6
-    expect(a["host.disk_used_pct"]).toBe(1.7); // 16324544/971350180*100 = 1.68 → 1.7
+    expect(a["system.filesystem.capacity"]).toBe(Math.round(926.4 * 1073741824)); // 926.4 GB → bytes
+    expect(a["system.filesystem.usage"]).toBe(Math.round(15.6 * 1073741824));    // 15.6 GB → bytes
+    expect(a["system.filesystem.utilization"]).toBeCloseTo(0.017, 3);             // 1.7% → 0.017
   });
 });
 

--- a/plugins/dev/scripts/catalyst-agent/processes.mjs
+++ b/plugins/dev/scripts/catalyst-agent/processes.mjs
@@ -281,10 +281,10 @@ export async function sampleProcesses({
         // (the put() pattern in buildAgentEnvelope drops null/undefined).
         attrs: {
           "process.command": row.command,
-          "process.cpu_pct": row.cpu_pct,
-          "process.rss_mb": row.rss_kb == null ? null : Math.round(row.rss_kb / 1024),
-          "process.ticket": worker?.ticket ?? null,
-          "process.phase": worker?.phase ?? null,
+          "process.cpu.utilization": row.cpu_pct == null ? null : row.cpu_pct / 100,
+          "process.memory.usage": row.rss_kb == null ? null : Math.round(row.rss_kb * 1024),
+          "catalyst.process.ticket": worker?.ticket ?? null,
+          "catalyst.process.phase": worker?.phase ?? null,
         },
         // High-cardinality fields stay in the payload, never as labels.
         payload: {

--- a/plugins/dev/scripts/catalyst-agent/processes.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/processes.test.mjs
@@ -409,8 +409,8 @@ describe("sampleProcesses", () => {
     const claude = envelopes.find((e) => e.body.payload.pid === 1200);
     // dot-form value attributes
     expect(claude.attributes["process.command"]).toBe("claude");
-    expect(claude.attributes["process.cpu_pct"]).toBe(25.5);
-    expect(claude.attributes["process.rss_mb"]).toBe(Math.round(900000 / 1024));
+    expect(claude.attributes["process.cpu.utilization"]).toBeCloseTo(25.5 / 100, 4);
+    expect(claude.attributes["process.memory.usage"]).toBe(Math.round(900000 * 1024));
     // high-cardinality fields live ONLY in the payload, never as attributes
     expect("pid" in claude.attributes).toBe(false);
     expect("args" in claude.attributes).toBe(false);
@@ -423,8 +423,8 @@ describe("sampleProcesses", () => {
     const { emit, envelopes } = recordingEmit();
     await sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 5, emit, ...DARWIN });
     const root = envelopes.find((e) => e.body.payload.pid === 1000);
-    expect(root.attributes["process.ticket"]).toBe("CTL-555");
-    expect(root.attributes["process.phase"]).toBe("implement");
+    expect(root.attributes["catalyst.process.ticket"]).toBe("CTL-555");
+    expect(root.attributes["catalyst.process.phase"]).toBe("implement");
     expect(root.body.payload.bg_job_id).toBe("job-9");
   });
 
@@ -432,8 +432,8 @@ describe("sampleProcesses", () => {
     const { emit, envelopes } = recordingEmit();
     await sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 5, emit, ...DARWIN });
     const claude = envelopes.find((e) => e.body.payload.pid === 1200);
-    expect(claude.attributes["process.ticket"]).toBe("CTL-555");
-    expect(claude.attributes["process.phase"]).toBe("implement");
+    expect(claude.attributes["catalyst.process.ticket"]).toBe("CTL-555");
+    expect(claude.attributes["catalyst.process.phase"]).toBe("implement");
     expect(claude.body.payload.bg_job_id).toBe("job-9");
   });
 
@@ -441,8 +441,8 @@ describe("sampleProcesses", () => {
     const { emit, envelopes } = recordingEmit();
     await sampleProcesses({ psLines: psSnapshot, readWorkerMap: workerMap, topN: 5, emit, ...DARWIN });
     const chrome = envelopes.find((e) => e.body.payload.pid === 2000);
-    expect("process.ticket" in chrome.attributes).toBe(false);
-    expect("process.phase" in chrome.attributes).toBe(false);
+    expect("catalyst.process.ticket" in chrome.attributes).toBe(false);
+    expect("catalyst.process.phase" in chrome.attributes).toBe(false);
     expect(chrome.body.payload.bg_job_id).toBeNull();
   });
 
@@ -456,8 +456,8 @@ describe("sampleProcesses", () => {
       ...DARWIN,
     });
     for (const e of envelopes) {
-      expect("process.ticket" in e.attributes).toBe(false);
-      expect("process.phase" in e.attributes).toBe(false);
+      expect("catalyst.process.ticket" in e.attributes).toBe(false);
+      expect("catalyst.process.phase" in e.attributes).toBe(false);
       expect(e.body.payload.bg_job_id).toBeNull();
     }
   });
@@ -499,7 +499,7 @@ describe("sampleProcesses", () => {
     }
     expect(threw).toBe(false);
     expect(envelopes.length).toBe(2);
-    for (const e of envelopes) expect("process.ticket" in e.attributes).toBe(false);
+    for (const e of envelopes) expect("catalyst.process.ticket" in e.attributes).toBe(false);
   });
 
   test("a throwing emit does not abort the tick (best-effort per row)", async () => {

--- a/plugins/dev/scripts/emit-otel-event.sh
+++ b/plugins/dev/scripts/emit-otel-event.sh
@@ -127,17 +127,17 @@ LOG_ATTRS_JSON=$(jq -nc \
   --arg outcome "$OUTCOME" \
   --arg sid "$SESSION_ID" \
   '[{key:"event.name",value:{stringValue:$event}},
-    {key:"outcome",value:{stringValue:$outcome}},
-    {key:"session_id",value:{stringValue:$sid}}]')
+    {key:"catalyst.outcome",value:{stringValue:$outcome}},
+    {key:"claude.session.id",value:{stringValue:$sid}}]')
 
 if [[ -n "$REASON" ]]; then
   LOG_ATTRS_JSON=$(echo "$LOG_ATTRS_JSON" \
-    | jq -c --arg r "$REASON" '. + [{key:"reason",value:{stringValue:$r}}]')
+    | jq -c --arg r "$REASON" '. + [{key:"catalyst.reason",value:{stringValue:$r}}]')
 fi
 
 if [[ -n "$PHASE" ]]; then
   LOG_ATTRS_JSON=$(echo "$LOG_ATTRS_JSON" \
-    | jq -c --arg p "$PHASE" '. + [{key:"phase",value:{stringValue:$p}}]')
+    | jq -c --arg p "$PHASE" '. + [{key:"catalyst.phase",value:{stringValue:$p}}]')
 fi
 
 for kv in "${EXTRA_ATTRS[@]:-}"; do

--- a/plugins/dev/scripts/execution-core/ratelimit-event.mjs
+++ b/plugins/dev/scripts/execution-core/ratelimit-event.mjs
@@ -59,15 +59,15 @@ export function buildRatelimitEnvelope(name, payload = {}, { now } = {}) {
   const put = (key, value) => {
     if (value !== null && value !== undefined) attributes[key] = value;
   };
-  put("account.email", email);
-  put("ratelimit.five_hour_pct", fiveHourPct);
-  put("ratelimit.seven_day_pct", sevenDayPct);
-  put("ratelimit.five_hour_resets_at", fiveHourResetsAt);
-  put("ratelimit.seven_day_resets_at", sevenDayResetsAt);
-  put("ratelimit.seven_day_opus_pct", opusPct);
-  put("ratelimit.seven_day_sonnet_pct", sonnetPct);
-  put("subscription.type", subscriptionType);
-  put("rate_limit.tier", rateLimitTier);
+  put("catalyst.account.email", email);
+  put("catalyst.ratelimit.five_hour_pct", fiveHourPct);
+  put("catalyst.ratelimit.seven_day_pct", sevenDayPct);
+  put("catalyst.ratelimit.five_hour_resets_at", fiveHourResetsAt);
+  put("catalyst.ratelimit.seven_day_resets_at", sevenDayResetsAt);
+  put("catalyst.ratelimit.seven_day_opus_pct", opusPct);
+  put("catalyst.ratelimit.seven_day_sonnet_pct", sonnetPct);
+  put("catalyst.subscription.type", subscriptionType);
+  put("catalyst.ratelimit.tier", rateLimitTier);
 
   return {
     ts,

--- a/plugins/dev/scripts/execution-core/ratelimit-event.mjs
+++ b/plugins/dev/scripts/execution-core/ratelimit-event.mjs
@@ -52,9 +52,9 @@ export function buildRatelimitEnvelope(name, payload = {}, { now } = {}) {
   // collector never promotes an empty label.
   const attributes = {
     "event.name": name,
-    "event.entity": "account",
-    "event.action": action,
-    "event.label": email ?? "unknown",
+    "catalyst.event.entity": "account",
+    "catalyst.event.action": action,
+    "catalyst.event.label": email ?? "unknown",
   };
   const put = (key, value) => {
     if (value !== null && value !== undefined) attributes[key] = value;

--- a/plugins/dev/scripts/execution-core/ratelimit-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/ratelimit-event.test.mjs
@@ -43,18 +43,18 @@ describe("buildRatelimitEnvelope", () => {
     expect(env.attributes["catalyst.event.label"]).toBe("ryan@rozich.com");
   });
 
-  test("DOT-form attributes present with correct values", () => {
+  test("catalyst.* attributes present with correct values", () => {
     const env = buildRatelimitEnvelope(RATELIMIT_EVENT_SAMPLED, basePayload);
     const a = env.attributes;
-    expect(a["account.email"]).toBe("ryan@rozich.com");
-    expect(a["ratelimit.five_hour_pct"]).toBe(42);
-    expect(a["ratelimit.seven_day_pct"]).toBe(17);
-    expect(a["ratelimit.five_hour_resets_at"]).toBe("2026-06-06T18:00:00Z");
-    expect(a["ratelimit.seven_day_resets_at"]).toBe("2026-06-13T00:00:00Z");
-    expect(a["ratelimit.seven_day_opus_pct"]).toBe(12);
-    expect(a["ratelimit.seven_day_sonnet_pct"]).toBe(5);
-    expect(a["subscription.type"]).toBe("active");
-    expect(a["rate_limit.tier"]).toBe("default_claude_max_20x");
+    expect(a["catalyst.account.email"]).toBe("ryan@rozich.com");
+    expect(a["catalyst.ratelimit.five_hour_pct"]).toBe(42);
+    expect(a["catalyst.ratelimit.seven_day_pct"]).toBe(17);
+    expect(a["catalyst.ratelimit.five_hour_resets_at"]).toBe("2026-06-06T18:00:00Z");
+    expect(a["catalyst.ratelimit.seven_day_resets_at"]).toBe("2026-06-13T00:00:00Z");
+    expect(a["catalyst.ratelimit.seven_day_opus_pct"]).toBe(12);
+    expect(a["catalyst.ratelimit.seven_day_sonnet_pct"]).toBe(5);
+    expect(a["catalyst.subscription.type"]).toBe("active");
+    expect(a["catalyst.ratelimit.tier"]).toBe("default_claude_max_20x");
   });
 
   test("zero utilization is preserved (not dropped as falsy)", () => {
@@ -63,8 +63,8 @@ describe("buildRatelimitEnvelope", () => {
       fiveHourPct: 0,
       sevenDayPct: 0,
     });
-    expect(env.attributes["ratelimit.five_hour_pct"]).toBe(0);
-    expect(env.attributes["ratelimit.seven_day_pct"]).toBe(0);
+    expect(env.attributes["catalyst.ratelimit.five_hour_pct"]).toBe(0);
+    expect(env.attributes["catalyst.ratelimit.seven_day_pct"]).toBe(0);
   });
 
   test("absent keys are omitted when null", () => {
@@ -73,18 +73,18 @@ describe("buildRatelimitEnvelope", () => {
       fiveHourPct: 42,
     });
     const a = env.attributes;
-    expect("ratelimit.seven_day_pct" in a).toBe(false);
-    expect("ratelimit.five_hour_resets_at" in a).toBe(false);
-    expect("ratelimit.seven_day_opus_pct" in a).toBe(false);
-    expect("ratelimit.seven_day_sonnet_pct" in a).toBe(false);
-    expect("subscription.type" in a).toBe(false);
-    expect("rate_limit.tier" in a).toBe(false);
+    expect("catalyst.ratelimit.seven_day_pct" in a).toBe(false);
+    expect("catalyst.ratelimit.five_hour_resets_at" in a).toBe(false);
+    expect("catalyst.ratelimit.seven_day_opus_pct" in a).toBe(false);
+    expect("catalyst.ratelimit.seven_day_sonnet_pct" in a).toBe(false);
+    expect("catalyst.subscription.type" in a).toBe(false);
+    expect("catalyst.ratelimit.tier" in a).toBe(false);
   });
 
   test("catalyst.event.label falls back to 'unknown' when email absent", () => {
     const env = buildRatelimitEnvelope(RATELIMIT_EVENT_SAMPLED, { fiveHourPct: 1 });
     expect(env.attributes["catalyst.event.label"]).toBe("unknown");
-    expect("account.email" in env.attributes).toBe(false);
+    expect("catalyst.account.email" in env.attributes).toBe(false);
   });
 
   test("body.payload mirrors the same fields for human readability", () => {
@@ -134,7 +134,7 @@ describe("emitRatelimitEvent", () => {
     expect(lines.length).toBe(1);
     const parsed = JSON.parse(lines[0]);
     expect(parsed.attributes["event.name"]).toBe(RATELIMIT_EVENT_SAMPLED);
-    expect(parsed.attributes["account.email"]).toBe("ryan@rozich.com");
+    expect(parsed.attributes["catalyst.account.email"]).toBe("ryan@rozich.com");
     expect(parsed.body.payload.opusPct).toBe(12);
   });
 

--- a/plugins/dev/scripts/execution-core/ratelimit-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/ratelimit-event.test.mjs
@@ -35,12 +35,12 @@ describe("buildRatelimitEnvelope", () => {
     expect(env.resource["service.namespace"]).toBe("catalyst");
   });
 
-  test("event.* identity attributes", () => {
+  test("catalyst.event.* identity attributes", () => {
     const env = buildRatelimitEnvelope(RATELIMIT_EVENT_SAMPLED, basePayload);
     expect(env.attributes["event.name"]).toBe("account.ratelimit.sampled");
-    expect(env.attributes["event.entity"]).toBe("account");
-    expect(env.attributes["event.action"]).toBe("ratelimit.sampled");
-    expect(env.attributes["event.label"]).toBe("ryan@rozich.com");
+    expect(env.attributes["catalyst.event.entity"]).toBe("account");
+    expect(env.attributes["catalyst.event.action"]).toBe("ratelimit.sampled");
+    expect(env.attributes["catalyst.event.label"]).toBe("ryan@rozich.com");
   });
 
   test("DOT-form attributes present with correct values", () => {
@@ -81,9 +81,9 @@ describe("buildRatelimitEnvelope", () => {
     expect("rate_limit.tier" in a).toBe(false);
   });
 
-  test("event.label falls back to 'unknown' when email absent", () => {
+  test("catalyst.event.label falls back to 'unknown' when email absent", () => {
     const env = buildRatelimitEnvelope(RATELIMIT_EVENT_SAMPLED, { fiveHourPct: 1 });
-    expect(env.attributes["event.label"]).toBe("unknown");
+    expect(env.attributes["catalyst.event.label"]).toBe("unknown");
     expect("account.email" in env.attributes).toBe(false);
   });
 

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -344,8 +344,8 @@ build_canonical_line() {
         + (if $claude_rl_7d == "" then {} else { "claude.ratelimit.seven_day_pct": ($claude_rl_7d | tonumber) } end)
         + (if $claude_rl_7d_opus   == "" then {} else { "claude.ratelimit.seven_day_opus_pct":   ($claude_rl_7d_opus   | tonumber) } end)
         + (if $claude_rl_7d_sonnet == "" then {} else { "claude.ratelimit.seven_day_sonnet_pct": ($claude_rl_7d_sonnet | tonumber) } end)
-        + (if $phase_attempt == "" then {} else { "phase.attempt": ($phase_attempt | tonumber) } end)
-        + (if $phase_revive_count == "" then {} else { "phase.revive_count": ($phase_revive_count | tonumber) } end)
+        + (if $phase_attempt == "" then {} else { "catalyst.phase.attempt": ($phase_attempt | tonumber) } end)
+        + (if $phase_revive_count == "" then {} else { "catalyst.phase.revive_count": ($phase_revive_count | tonumber) } end)
         + { "catalyst.ticket.type": $ticket_type }
       ),
       body: (

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -251,7 +251,7 @@ build_canonical_line() {
   [[ -n "$cat_orch" ]]   || cat_orch="$orch"
   if [[ -z "$project" && -n "${OTEL_RESOURCE_ATTRIBUTES:-}" ]]; then
     project="$(printf '%s\n' "$OTEL_RESOURCE_ATTRIBUTES" \
-      | grep -oE 'project=[^,]+' | head -1 | cut -d= -f2- || true)"
+      | grep -oE 'catalyst\.project=[^,]+' | head -1 | cut -d= -f2- || true)"
   fi
 
   local sev_num event_id host_name host_id_val
@@ -317,7 +317,7 @@ build_canonical_line() {
           "host.name": $host_name,
           "host.id": $host_id
         }
-        + (if $project    == "" then {} else { "project": $project } end)
+        + (if $project    == "" then {} else { "catalyst.project": $project } end)
         + (if $linear_key == "" then {} else { "linear.key": $linear_key } end)
         + (if $cat_orch   == "" then {} else { "catalyst.orchestration": $cat_orch } end)
       ),

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -323,11 +323,11 @@ build_canonical_line() {
       ),
       attributes: (
         { "event.name": $event_name }
-        + (if $entity  == "" then {} else { "event.entity": $entity }  end)
-        + (if $action  == "" then {} else { "event.action": $action }  end)
-        + (if $label   == "" then {} else { "event.label":  $label }   end)
-        + (if $value   == "" then {} else { "event.value":  $value }   end)
-        + (if $channel == "" then {} else { "event.channel": $channel } end)
+        + (if $entity  == "" then {} else { "catalyst.event.entity": $entity }  end)
+        + (if $action  == "" then {} else { "catalyst.event.action": $action }  end)
+        + (if $label   == "" then {} else { "catalyst.event.label":  $label }   end)
+        + (if $value   == "" then {} else { "catalyst.event.value":  $value }   end)
+        + (if $channel == "" then {} else { "catalyst.event.channel": $channel } end)
         + (if $orch    == "" then {} else { "catalyst.orchestrator.id": $orch } end)
         + (if $worker  == "" then {} else { "catalyst.worker.ticket": $worker } end)
         + (if $session == "" then {} else { "catalyst.session.id": $session } end)

--- a/plugins/dev/scripts/orch-monitor/__tests__/canonical-event.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/canonical-event.test.ts
@@ -152,7 +152,7 @@ describe("buildCanonicalEvent", () => {
       });
       expect("linear.key" in ev.resource).toBe(false);
       expect("catalyst.orchestration" in ev.resource).toBe(false);
-      expect("project" in ev.resource).toBe(false);
+      expect("catalyst.project" in ev.resource).toBe(false);
     } finally {
       if (prev === undefined) delete process.env.OTEL_RESOURCE_ATTRIBUTES;
       else process.env.OTEL_RESOURCE_ATTRIBUTES = prev;
@@ -175,7 +175,7 @@ describe("buildCanonicalEvent", () => {
   it("sources project from OTEL_RESOURCE_ATTRIBUTES when present (CTL-636)", () => {
     const prev = process.env.OTEL_RESOURCE_ATTRIBUTES;
     process.env.OTEL_RESOURCE_ATTRIBUTES =
-      "project=catalyst-workspace,linear.key=CTL-636,catalyst.orchestration=CTL-636";
+      "catalyst.project=catalyst-workspace,linear.key=CTL-636,catalyst.orchestration=CTL-636";
     try {
       const ev = buildCanonicalEvent({
         ts: "2026-05-25T18:00:00.000Z",
@@ -186,7 +186,7 @@ describe("buildCanonicalEvent", () => {
         attributes: { "event.name": "x" },
         body: {},
       });
-      expect(ev.resource["project"]).toBe("catalyst-workspace");
+      expect(ev.resource["catalyst.project"]).toBe("catalyst-workspace");
     } finally {
       if (prev === undefined) delete process.env.OTEL_RESOURCE_ATTRIBUTES;
       else process.env.OTEL_RESOURCE_ATTRIBUTES = prev;

--- a/plugins/dev/scripts/orch-monitor/__tests__/canonical-event.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/canonical-event.test.ts
@@ -202,19 +202,19 @@ describe("buildCanonicalEvent", () => {
       resource: { "service.name": "catalyst.github" },
       attributes: {
         "event.name": "github.pr.merged",
-        "event.entity": "pr",
-        "event.action": "merged",
-        "event.label": "PR #342",
-        "event.channel": "webhook",
+        "catalyst.event.entity": "pr",
+        "catalyst.event.action": "merged",
+        "catalyst.event.label": "PR #342",
+        "catalyst.event.channel": "webhook",
         "vcs.repository.name": "org/repo",
         "vcs.pr.number": 342,
       },
       body: { payload: { merged: true } },
     });
-    expect(ev.attributes["event.entity"]).toBe("pr");
-    expect(ev.attributes["event.action"]).toBe("merged");
-    expect(ev.attributes["event.label"]).toBe("PR #342");
-    expect(ev.attributes["event.channel"]).toBe("webhook");
+    expect(ev.attributes["catalyst.event.entity"]).toBe("pr");
+    expect(ev.attributes["catalyst.event.action"]).toBe("merged");
+    expect(ev.attributes["catalyst.event.label"]).toBe("PR #342");
+    expect(ev.attributes["catalyst.event.channel"]).toBe("webhook");
     expect(ev.attributes["vcs.pr.number"]).toBe(342);
   });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
@@ -141,7 +141,7 @@ describe("status/orch/worker formatters", () => {
       formatStatus(makeEvent({
         attributes: {
           "event.name": "github.check_suite.completed",
-          "cicd.pipeline.run.conclusion": "success",
+          "cicd.pipeline.run.result": "success",
         },
       })),
     ).toBe("✓ ");
@@ -152,7 +152,7 @@ describe("status/orch/worker formatters", () => {
       formatStatus(makeEvent({
         attributes: {
           "event.name": "github.check_suite.completed",
-          "cicd.pipeline.run.conclusion": "failure",
+          "cicd.pipeline.run.result": "failure",
         },
       })),
     ).toBe("✗ ");
@@ -181,7 +181,7 @@ describe("status/orch/worker formatters", () => {
       const result = formatStatus(makeEvent({
         attributes: {
           "event.name": "github.workflow_run.in_progress",
-          "cicd.pipeline.run.conclusion": "in_progress",
+          "cicd.pipeline.run.result": "in_progress",
         },
       }));
       expect(result).toBe("… ");
@@ -201,7 +201,7 @@ describe("status/orch/worker formatters", () => {
       const result = formatStatus(makeEvent({
         attributes: {
           "event.name": "github.workflow_run.in_progress",
-          "cicd.pipeline.run.conclusion": "in_progress",
+          "cicd.pipeline.run.result": "in_progress",
         },
       }));
       expect(result.codePointAt(0)).toBe(0xf252);

--- a/plugins/dev/scripts/orch-monitor/__tests__/event-writer.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/event-writer.test.ts
@@ -40,8 +40,8 @@ function sampleEvent(overrides: Partial<CanonicalEvent> = {}): CanonicalEvent {
     },
     attributes: {
       "event.name": "github.pr.merged",
-      "event.entity": "pr",
-      "event.action": "merged",
+      "catalyst.event.entity": "pr",
+      "catalyst.event.action": "merged",
     },
     body: { message: "test" },
     ...overrides,

--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -123,7 +123,7 @@ describe("formatSource", () => {
       ...baseEvent,
       attributes: {
         "event.name": "comms.message.posted",
-        "event.label": "CTL-330",
+        "catalyst.event.label": "CTL-330",
         "catalyst.worker.ticket": "CTL-330",
       },
     } as unknown as CanonicalEvent;
@@ -883,7 +883,7 @@ describe("formatDetails (comms.message.posted, CTL-391)", () => {
       ...baseEvent,
       attributes: {
         "event.name": "comms.message.posted",
-        "event.label": "CTL-330",
+        "catalyst.event.label": "CTL-330",
         "catalyst.worker.ticket": "CTL-330",
       },
       body: { message: "stalled: CI failed", payload: { type: "attention", channel: "orch-demo", to: "all" } },
@@ -917,7 +917,7 @@ describe("formatDetails (comms.message.posted, CTL-391)", () => {
       ...baseEvent,
       attributes: {
         "event.name": "comms.message.posted",
-        "event.label": "CTL-330",
+        "catalyst.event.label": "CTL-330",
       },
       body: { message: "msg", payload: {} },
     } as unknown as CanonicalEvent;
@@ -929,7 +929,7 @@ describe("formatDetails (comms.message.posted, CTL-391)", () => {
       ...baseEvent,
       attributes: {
         "event.name": "comms.message.posted",
-        "event.label": "CTL-330",
+        "catalyst.event.label": "CTL-330",
       },
       body: { payload: { type: "attention" } },
     } as unknown as CanonicalEvent;
@@ -1229,7 +1229,7 @@ describe("formatIcon (CTL-391, Nerd Font enabled)", () => {
       ...baseEvent,
       attributes: {
         "event.name": "comms.message.posted",
-        "event.label": "CTL-330",
+        "catalyst.event.label": "CTL-330",
         "catalyst.worker.ticket": "CTL-330",
       },
       body: { payload: { type: "attention" } },

--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -267,7 +267,7 @@ describe("formatEvent", () => {
       ...baseEvent,
       attributes: {
         "event.name": "github.check_suite.completed",
-        "cicd.pipeline.run.conclusion": "failure",
+        "cicd.pipeline.run.result": "failure",
       },
     } as unknown as CanonicalEvent;
     expect(formatEvent(e)).toBe("github.check_suite.completed");
@@ -1023,7 +1023,7 @@ describe("shouldSkipEvent", () => {
       ...baseEvent,
       attributes: {
         "event.name": "github.check_run.completed",
-        "cicd.pipeline.run.conclusion": "success",
+        "cicd.pipeline.run.result": "success",
       },
     } as unknown as CanonicalEvent;
     expect(shouldSkipEvent(e)).toBe(true);
@@ -1034,7 +1034,7 @@ describe("shouldSkipEvent", () => {
       ...baseEvent,
       attributes: {
         "event.name": "github.check_run.completed",
-        "cicd.pipeline.run.conclusion": "neutral",
+        "cicd.pipeline.run.result": "neutral",
       },
     } as unknown as CanonicalEvent;
     expect(shouldSkipEvent(e)).toBe(true);
@@ -1045,7 +1045,7 @@ describe("shouldSkipEvent", () => {
       ...baseEvent,
       attributes: {
         "event.name": "github.check_run.completed",
-        "cicd.pipeline.run.conclusion": "failure",
+        "cicd.pipeline.run.result": "failure",
       },
     } as unknown as CanonicalEvent;
     expect(shouldSkipEvent(e)).toBe(false);

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
@@ -143,8 +143,8 @@ describe("createLinearWebhookHandler", () => {
     expect(env.resource["service.name"]).toBe("catalyst.linear");
     expect(env.attributes["event.name"]).toBe("linear.issue.state_changed");
     expect(env.attributes["linear.issue.identifier"]).toBe("CTL-210");
-    expect(env.attributes["event.label"]).toBe("CTL-210");
-    expect(env.attributes["event.channel"]).toBe("webhook");
+    expect(env.attributes["catalyst.event.label"]).toBe("CTL-210");
+    expect(env.attributes["catalyst.event.channel"]).toBe("webhook");
   });
 
   it("emits to in-process bus on success", async () => {
@@ -547,8 +547,8 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
     expect(env!.attributes["event.name"]).toBe("linear.issue.state_changed");
     expect(env!.attributes["linear.issue.identifier"]).toBe("CTL-1");
     expect(env!.attributes["linear.team.key"]).toBe("CTL");
-    expect(env!.attributes["event.entity"]).toBe("issue");
-    expect(env!.attributes["event.action"]).toBe("state_changed");
+    expect(env!.attributes["catalyst.event.entity"]).toBe("issue");
+    expect(env!.attributes["catalyst.event.action"]).toBe("state_changed");
   });
 
   it("state_changed event forwards toState into body.payload (CTL-399)", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/reactive-pr-filter.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/reactive-pr-filter.test.ts
@@ -47,8 +47,8 @@ const REACTIVE_FILTER = `
   (.attributes."event.name" == "github.pr.closed" and .attributes."vcs.pr.number" == ${PR}) or
   (.attributes."event.name" == "github.check_suite.completed"
      and (.body.payload.prNumbers // [] | index(${PR}) != null)
-     and (.attributes."cicd.pipeline.run.conclusion" == "failure"
-          or .attributes."cicd.pipeline.run.conclusion" == "timed_out")) or
+     and (.attributes."cicd.pipeline.run.result" == "failure"
+          or .attributes."cicd.pipeline.run.result" == "timed_out")) or
   (.attributes."event.name" == "github.pr_review.submitted"
      and .attributes."vcs.pr.number" == ${PR}
      and .body.payload.state == "changes_requested") or

--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-handler.test.ts
@@ -733,10 +733,10 @@ describe("buildEventLogEnvelope (canonical)", () => {
     expect(env!.attributes["event.name"]).toBe("github.pr.merged");
     expect(env!.attributes["vcs.repository.name"]).toBe("o/r");
     expect(env!.attributes["vcs.pr.number"]).toBe(1);
-    expect(env!.attributes["event.entity"]).toBe("pr");
-    expect(env!.attributes["event.action"]).toBe("merged");
-    expect(env!.attributes["event.label"]).toBe("PR #1");
-    expect(env!.attributes["event.channel"]).toBe("webhook");
+    expect(env!.attributes["catalyst.event.entity"]).toBe("pr");
+    expect(env!.attributes["catalyst.event.action"]).toBe("merged");
+    expect(env!.attributes["catalyst.event.label"]).toBe("PR #1");
+    expect(env!.attributes["catalyst.event.channel"]).toBe("webhook");
     expect(env!.resource["service.name"]).toBe("catalyst.github");
   });
 
@@ -837,7 +837,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
     );
     expect(env!.attributes["event.name"]).toBe("github.release.published");
     expect(env!.attributes["vcs.repository.name"]).toBe("o/r");
-    expect(env!.attributes["event.label"]).toBe("catalyst-dev-v8.0.0");
+    expect(env!.attributes["catalyst.event.label"]).toBe("catalyst-dev-v8.0.0");
   });
 
   it("maps workflow_run.completed → github.workflow_run.completed with cicd attrs", () => {
@@ -1070,7 +1070,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
       TS,
     );
     expect(env!.attributes["event.name"]).toBe("github.status.failure");
-    expect(env!.attributes["event.label"]).toBe("abcdef0");
+    expect(env!.attributes["catalyst.event.label"]).toBe("abcdef0");
     expect(env!.severityText).toBe("ERROR");
   });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-handler.test.ts
@@ -860,11 +860,11 @@ describe("buildEventLogEnvelope (canonical)", () => {
       TS,
     );
     expect(env!.attributes["event.name"]).toBe("github.workflow_run.completed");
-    expect(env!.attributes["vcs.revision"]).toBe("abc123");
+    expect(env!.attributes["vcs.ref.revision"]).toBe("abc123");
     expect(env!.attributes["vcs.pr.number"]).toBe(326);
     expect(env!.attributes["cicd.pipeline.run.id"]).toBe(555);
     expect(env!.attributes["cicd.pipeline.run.status"]).toBe("completed");
-    expect(env!.attributes["cicd.pipeline.run.conclusion"]).toBe("success");
+    expect(env!.attributes["cicd.pipeline.run.result"]).toBe("success");
     expect(env!.attributes["cicd.pipeline.name"]).toBe("CI");
     const payload = env!.body.payload as { prNumbers: number[] };
     expect(payload.prNumbers).toEqual([326]);
@@ -891,7 +891,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
     );
     expect(env!.attributes["event.name"]).toBe("github.workflow_run.in_progress");
     expect(env!.attributes["cicd.pipeline.run.status"]).toBe("in_progress");
-    expect(env!.attributes["cicd.pipeline.run.conclusion"]).toBeUndefined();
+    expect(env!.attributes["cicd.pipeline.run.result"]).toBeUndefined();
   });
 
   it("workflow_run with multiple PRs uses the first PR number (first-match policy)", () => {
@@ -933,7 +933,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
     );
     expect(env!.attributes["event.name"]).toBe("github.check_suite.completed");
     expect(env!.attributes["cicd.pipeline.run.status"]).toBe("completed");
-    expect(env!.attributes["cicd.pipeline.run.conclusion"]).toBe("failure");
+    expect(env!.attributes["cicd.pipeline.run.result"]).toBe("failure");
     expect(env!.attributes["vcs.pr.number"]).toBe(1);
     expect(env!.severityText).toBe("WARN");
     expect(env!.severityNumber).toBe(13);
@@ -954,7 +954,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
     );
     expect(env!.attributes["event.name"]).toBe("github.check_suite.in_progress");
     expect(env!.attributes["cicd.pipeline.run.status"]).toBe("in_progress");
-    expect(env!.attributes["cicd.pipeline.run.conclusion"]).toBeUndefined();
+    expect(env!.attributes["cicd.pipeline.run.result"]).toBeUndefined();
   });
 
   it("maps deployment_status.success → github.deployment_status.success", () => {
@@ -971,7 +971,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
       TS,
     );
     expect(env!.attributes["event.name"]).toBe("github.deployment_status.success");
-    expect(env!.attributes["deployment.environment"]).toBe("preview");
+    expect(env!.attributes["deployment.environment.name"]).toBe("preview");
     expect(env!.attributes["deployment.id"]).toBe(100);
   });
 
@@ -1088,7 +1088,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
     );
     expect(env!.attributes["event.name"]).toBe("github.push");
     expect(env!.attributes["vcs.ref.name"]).toBe("refs/heads/main");
-    expect(env!.attributes["vcs.revision"]).toBe("bbb");
+    expect(env!.attributes["vcs.ref.revision"]).toBe("bbb");
   });
 
   // CTL-396: check_suite with multiple PRs uses first match
@@ -1122,7 +1122,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
       },
       TS,
     );
-    expect(env!.attributes["vcs.revision"]).toBe("deadbeef1234");
+    expect(env!.attributes["vcs.ref.revision"]).toBe("deadbeef1234");
   });
 
   // CTL-396: workflow_run with no PR but headBranch → vcs.ref.name

--- a/plugins/dev/scripts/orch-monitor/cli/components/DetailPane.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/DetailPane.tsx
@@ -71,7 +71,7 @@ export function buildDetailLines(
     lines.push({ k: "field", label: "phase", value: String(phase) });
   }
 
-  const conclusion = attrs["cicd.pipeline.run.conclusion"];
+  const conclusion = attrs["cicd.pipeline.run.result"];
   const pipeline = attrs["cicd.pipeline.name"];
   if (conclusion || pipeline) {
     lines.push({ k: "sep" });

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useFilter.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useFilter.test.ts
@@ -56,7 +56,7 @@ const fixture: CanonicalEvent[] = [
       "vcs.pr.number": 343,
       "vcs.repository.name": "coalesce-labs/catalyst",
       "catalyst.orchestrator.id": "orch-A",
-      "cicd.pipeline.run.conclusion": "failure",
+      "cicd.pipeline.run.result": "failure",
     },
     body: { message: "CI failed", payload: {} },
   },

--- a/plugins/dev/scripts/orch-monitor/cli/lib/colors.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/colors.ts
@@ -15,7 +15,7 @@ const COLOR_MAP: Record<string, RowColor> = {
 export function getRowColor(event: CanonicalEvent): RowColor {
   const name = event.attributes["event.name"];
   if (name === "github.check_suite.completed") {
-    return event.attributes["cicd.pipeline.run.conclusion"] === "success" ? "green" : "red";
+    return event.attributes["cicd.pipeline.run.result"] === "success" ? "green" : "red";
   }
   if (name.startsWith("filter.wake")) return "cyan";
   return COLOR_MAP[name] ?? "gray";

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.test.ts
@@ -78,14 +78,14 @@ describe("formatDetails — github.pr.* (CTL-418)", () => {
 describe("formatDetails — github.check_suite.* (CTL-418)", () => {
   test("success from attributes", () => {
     const ev = makeEvent("github.check_suite.completed", {
-      "cicd.pipeline.run.conclusion": "success",
+      "cicd.pipeline.run.result": "success",
     });
     expect(formatDetails(ev)).toBe("CI: success");
   });
 
   test("failure from attributes", () => {
     const ev = makeEvent("github.check_suite.completed", {
-      "cicd.pipeline.run.conclusion": "failure",
+      "cicd.pipeline.run.result": "failure",
     });
     expect(formatDetails(ev)).toBe("CI: failure");
   });
@@ -105,7 +105,7 @@ describe("formatDetails — github.workflow_run.* (CTL-418)", () => {
   test("workflow name + conclusion", () => {
     const ev = makeEvent("github.workflow_run.completed", {
       "cicd.pipeline.name": "Deploy Website",
-      "cicd.pipeline.run.conclusion": "success",
+      "cicd.pipeline.run.result": "success",
     });
     expect(formatDetails(ev)).toBe("Deploy Website: success");
   });

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -71,7 +71,7 @@ function classifySource(event: CanonicalEvent): string {
   if (name.startsWith("github.")) return "github";
   if (name.startsWith("linear.")) return "linear";
   if (name === "comms.message.posted") {
-    const label = event.attributes["event.label"];
+    const label = event.attributes["catalyst.event.label"];
     if (label) return label;
     const worker = event.attributes["catalyst.worker.ticket"];
     if (worker) return worker;
@@ -570,7 +570,7 @@ export function formatDetails(event: CanonicalEvent): string {
   // the natural place — DETAILS already carries the message body for comms
   // events, and the prefix reads cleanly with the body.
   if (name === "comms.message.posted") {
-    const sender = event.attributes?.["event.label"]
+    const sender = event.attributes?.["catalyst.event.label"]
       ?? event.attributes?.["catalyst.worker.ticket"];
     const p = payload as Record<string, unknown> | undefined;
     const rawType = p?.["type"];

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -23,7 +23,7 @@ export function shouldSkipEvent(event: CanonicalEvent): boolean {
   if (!name) return true; // skip legacy/malformed events missing the canonical envelope
   if (SKIP_EVENTS.has(name)) return true;
   if (name === "github.check_run.completed") {
-    const c = event.attributes["cicd.pipeline.run.conclusion"];
+    const c = event.attributes["cicd.pipeline.run.result"];
     if (c === "success" || c === "neutral" || c === "skipped") return true;
   }
   if (name.startsWith("filter.wake")) {
@@ -148,7 +148,7 @@ export function formatIcon(event: CanonicalEvent): string {
 // disagree on its East Asian width.
 export function formatStatus(event: CanonicalEvent): string {
   const attrs = event.attributes ?? ({} as CanonicalEvent["attributes"]);
-  const conclusion = attrs["cicd.pipeline.run.conclusion"];
+  const conclusion = attrs["cicd.pipeline.run.result"];
   if (conclusion === "success") return "✓ ";
   if (conclusion === "failure" || conclusion === "cancelled") return "✗ ";
   const name = attrs["event.name"];
@@ -469,7 +469,7 @@ export function formatDetails(event: CanonicalEvent): string {
   if (name?.startsWith("github.check_suite.")) {
     const p = payload as Record<string, unknown> | undefined;
     const conclusion =
-      event.attributes?.["cicd.pipeline.run.conclusion"] ?? p?.["conclusion"];
+      event.attributes?.["cicd.pipeline.run.result"] ?? p?.["conclusion"];
     if (typeof conclusion === "string" && conclusion.length > 0) {
       const out = sanitize(`CI: ${conclusion}`, "oneline");
       detailsCache.set(event, out);
@@ -482,7 +482,7 @@ export function formatDetails(event: CanonicalEvent): string {
       event.attributes?.["cicd.pipeline.name"] ??
       (typeof p?.["name"] === "string" ? p["name"] : undefined);
     const conclusion =
-      event.attributes?.["cicd.pipeline.run.conclusion"] ??
+      event.attributes?.["cicd.pipeline.run.result"] ??
       (typeof p?.["conclusion"] === "string" ? p["conclusion"] : undefined);
     if (typeof wfName === "string" && wfName.length > 0) {
       const suffix =

--- a/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
+++ b/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
@@ -11,8 +11,8 @@ Do **not** edit this file directly.
 | Classification | Count |
 | --- | --- |
 | ✓ Conforming | 28 |
-| → Rename-to | 18 |
-| ● Legitimately Custom | 23 |
+| → Rename-to | 9 |
+| ● Legitimately Custom | 32 |
 | **Total** | 69 |
 
 ## Classification by Emitter
@@ -75,9 +75,17 @@ Do **not** edit this file directly.
 
 | Key | Source | Classification | Target | Cluster | Note |
 | --- | --- | --- | --- | --- | --- |
-| `account.email` | `ratelimit-event.mjs:62` | → rename-to | → `catalyst.account.email` | Cluster B |  |
+| `catalyst.account.email` | `ratelimit-event.mjs:62` | ● custom |  |  |  |
 | `catalyst.process.phase` | `processes.mjs:287` | ✓ conforming |  |  |  |
 | `catalyst.process.ticket` | `processes.mjs:286` | ✓ conforming |  |  |  |
+| `catalyst.ratelimit.five_hour_pct` | `ratelimit-event.mjs:63` | ● custom |  |  |  |
+| `catalyst.ratelimit.five_hour_resets_at` | `ratelimit-event.mjs:65` | ● custom |  |  |  |
+| `catalyst.ratelimit.seven_day_opus_pct` | `ratelimit-event.mjs:67` | ● custom |  |  |  |
+| `catalyst.ratelimit.seven_day_pct` | `ratelimit-event.mjs:64` | ● custom |  |  |  |
+| `catalyst.ratelimit.seven_day_resets_at` | `ratelimit-event.mjs:66` | ● custom |  |  |  |
+| `catalyst.ratelimit.seven_day_sonnet_pct` | `ratelimit-event.mjs:68` | ● custom |  |  |  |
+| `catalyst.ratelimit.tier` | `ratelimit-event.mjs:70` | ● custom |  |  |  |
+| `catalyst.subscription.type` | `ratelimit-event.mjs:69` | ● custom |  |  |  |
 | `host.cpu_count` | `host.mjs:274` | → rename-to | → `system.cpu.logical_count` | Cluster C |  |
 | `host.cpu_pct` | `host.mjs:273` | → rename-to | → `system.cpu.utilization` | Cluster C | unit: ÷100 → 0.0–1.0 |
 | `host.disk_total_gb` | `host.mjs:280` | → rename-to | → `system.filesystem.capacity` | Cluster C | unit: ×1073741824 → bytes |
@@ -90,14 +98,6 @@ Do **not** edit this file directly.
 | `process.command` | `processes.mjs:283` | ✓ conforming |  |  |  |
 | `process.cpu.utilization` | `processes.mjs:284` | ✓ conforming |  |  |  |
 | `process.memory.usage` | `processes.mjs:285` | ✓ conforming |  |  |  |
-| `rate_limit.tier` | `ratelimit-event.mjs:71` | → rename-to | → `catalyst.ratelimit.tier` | Cluster B |  |
-| `ratelimit.five_hour_pct` | `ratelimit-event.mjs:64` | → rename-to | → `catalyst.ratelimit.five_hour_pct` | Cluster B |  |
-| `ratelimit.five_hour_resets_at` | `ratelimit-event.mjs:66` | → rename-to | → `catalyst.ratelimit.five_hour_resets_at` | Cluster B |  |
-| `ratelimit.seven_day_opus_pct` | `ratelimit-event.mjs:68` | → rename-to | → `catalyst.ratelimit.seven_day_opus_pct` | Cluster B |  |
-| `ratelimit.seven_day_pct` | `ratelimit-event.mjs:65` | → rename-to | → `catalyst.ratelimit.seven_day_pct` | Cluster B |  |
-| `ratelimit.seven_day_resets_at` | `ratelimit-event.mjs:67` | → rename-to | → `catalyst.ratelimit.seven_day_resets_at` | Cluster B |  |
-| `ratelimit.seven_day_sonnet_pct` | `ratelimit-event.mjs:69` | → rename-to | → `catalyst.ratelimit.seven_day_sonnet_pct` | Cluster B |  |
-| `subscription.type` | `ratelimit-event.mjs:70` | → rename-to | → `catalyst.subscription.type` | Cluster B |  |
 
 ### Legacy Bash (`emit-otel-event.sh`)
 
@@ -113,29 +113,6 @@ derived from the manifest. Per the operator decision (Ryan, 2026-06-11),
 every rename uses a **hard cutover** — no dual-emit period, no deprecated-name
 emission. Each cluster ships emit-side rename + all consumer updates in ONE PR,
 validated against live Loki.
-
-### Cluster B — ratelimit.* / account.* / subscription.*
-
-- **Emit-side files**: `ratelimit-event.mjs`
-- **Where**: both
-- **Migration**: hard-cutover (no dual-emit)
-- **Consumer-update checklist** (all in ONE PR, validated against live Loki):
-  - [ ] emit-side rename in the file(s) above
-  - [ ] Grafana dashboard JSON updates
-  - [ ] orch-monitor otel-queries updates
-- **Historical-data note**: queries spanning the rename date must use an old-name-OR-new-name clause (2y Prometheus retention keeps the old name)
-
-| Current key | Target name | Note |
-| --- | --- | --- |
-| `account.email` | `catalyst.account.email` |  |
-| `rate_limit.tier` | `catalyst.ratelimit.tier` |  |
-| `ratelimit.five_hour_pct` | `catalyst.ratelimit.five_hour_pct` |  |
-| `ratelimit.five_hour_resets_at` | `catalyst.ratelimit.five_hour_resets_at` |  |
-| `ratelimit.seven_day_opus_pct` | `catalyst.ratelimit.seven_day_opus_pct` |  |
-| `ratelimit.seven_day_pct` | `catalyst.ratelimit.seven_day_pct` |  |
-| `ratelimit.seven_day_resets_at` | `catalyst.ratelimit.seven_day_resets_at` |  |
-| `ratelimit.seven_day_sonnet_pct` | `catalyst.ratelimit.seven_day_sonnet_pct` |  |
-| `subscription.type` | `catalyst.subscription.type` |  |
 
 ### Cluster C — host.* system metrics
 

--- a/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
+++ b/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
@@ -10,8 +10,8 @@ Do **not** edit this file directly.
 
 | Classification | Count |
 | --- | --- |
-| ✓ Conforming | 28 |
-| → Rename-to | 9 |
+| ✓ Conforming | 37 |
+| → Rename-to | 0 |
 | ● Legitimately Custom | 32 |
 | **Total** | 69 |
 
@@ -86,18 +86,18 @@ Do **not** edit this file directly.
 | `catalyst.ratelimit.seven_day_sonnet_pct` | `ratelimit-event.mjs:68` | ● custom |  |  |  |
 | `catalyst.ratelimit.tier` | `ratelimit-event.mjs:70` | ● custom |  |  |  |
 | `catalyst.subscription.type` | `ratelimit-event.mjs:69` | ● custom |  |  |  |
-| `host.cpu_count` | `host.mjs:274` | → rename-to | → `system.cpu.logical_count` | Cluster C |  |
-| `host.cpu_pct` | `host.mjs:273` | → rename-to | → `system.cpu.utilization` | Cluster C | unit: ÷100 → 0.0–1.0 |
-| `host.disk_total_gb` | `host.mjs:280` | → rename-to | → `system.filesystem.capacity` | Cluster C | unit: ×1073741824 → bytes |
-| `host.disk_used_gb` | `host.mjs:279` | → rename-to | → `system.filesystem.usage` | Cluster C | unit: ×1073741824 → bytes, state=used |
-| `host.disk_used_pct` | `host.mjs:281` | → rename-to | → `system.filesystem.utilization` | Cluster C | unit: ÷100 → 0.0–1.0 |
-| `host.load1` | `host.mjs:275` | → rename-to | → `system.linux.cpu.load_1m` | Cluster C |  |
-| `host.mem_total_mb` | `host.mjs:277` | → rename-to | → `system.memory.limit` | Cluster C | unit: ×1048576 → bytes |
-| `host.mem_used_mb` | `host.mjs:276` | → rename-to | → `system.memory.usage` | Cluster C | unit: ×1048576 → bytes, state=used |
-| `host.mem_used_pct` | `host.mjs:278` | → rename-to | → `system.memory.utilization` | Cluster C | unit: ÷100 → 0.0–1.0 |
 | `process.command` | `processes.mjs:283` | ✓ conforming |  |  |  |
 | `process.cpu.utilization` | `processes.mjs:284` | ✓ conforming |  |  |  |
 | `process.memory.usage` | `processes.mjs:285` | ✓ conforming |  |  |  |
+| `system.cpu.logical_count` | `host.mjs:279` | ✓ conforming |  |  |  |
+| `system.cpu.utilization` | `host.mjs:278` | ✓ conforming |  |  |  |
+| `system.filesystem.capacity` | `host.mjs:285` | ✓ conforming |  |  |  |
+| `system.filesystem.usage` | `host.mjs:284` | ✓ conforming |  |  |  |
+| `system.filesystem.utilization` | `host.mjs:286` | ✓ conforming |  |  |  |
+| `system.linux.cpu.load_1m` | `host.mjs:280` | ✓ conforming |  |  |  |
+| `system.memory.limit` | `host.mjs:282` | ✓ conforming |  |  |  |
+| `system.memory.usage` | `host.mjs:281` | ✓ conforming |  |  |  |
+| `system.memory.utilization` | `host.mjs:283` | ✓ conforming |  |  |  |
 
 ### Legacy Bash (`emit-otel-event.sh`)
 
@@ -110,32 +110,9 @@ Do **not** edit this file directly.
 
 Each cluster below is a unit of work for CTL-1008. Emit-side files are
 derived from the manifest. Per the operator decision (Ryan, 2026-06-11),
-every rename uses a **hard cutover** — no dual-emit period, no deprecated-name
+every rename uses a **hard-cutover** — no dual-emit period, no deprecated-name
 emission. Each cluster ships emit-side rename + all consumer updates in ONE PR,
 validated against live Loki.
-
-### Cluster C — host.* system metrics
-
-- **Emit-side files**: `host.mjs`
-- **Where**: both
-- **Migration**: hard-cutover (no dual-emit)
-- **Consumer-update checklist** (all in ONE PR, validated against live Loki):
-  - [ ] emit-side rename in the file(s) above
-  - [ ] Grafana dashboard JSON updates
-  - [ ] orch-monitor otel-queries updates
-- **Historical-data note**: queries spanning the rename date must use an old-name-OR-new-name clause (2y Prometheus retention keeps the old name)
-
-| Current key | Target name | Note |
-| --- | --- | --- |
-| `host.cpu_count` | `system.cpu.logical_count` |  |
-| `host.cpu_pct` | `system.cpu.utilization` | unit: ÷100 → 0.0–1.0 |
-| `host.disk_total_gb` | `system.filesystem.capacity` | unit: ×1073741824 → bytes |
-| `host.disk_used_gb` | `system.filesystem.usage` | unit: ×1073741824 → bytes, state=used |
-| `host.disk_used_pct` | `system.filesystem.utilization` | unit: ÷100 → 0.0–1.0 |
-| `host.load1` | `system.linux.cpu.load_1m` |  |
-| `host.mem_total_mb` | `system.memory.limit` | unit: ×1048576 → bytes |
-| `host.mem_used_mb` | `system.memory.usage` | unit: ×1048576 → bytes, state=used |
-| `host.mem_used_pct` | `system.memory.utilization` | unit: ÷100 → 0.0–1.0 |
 
 ---
 

--- a/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
+++ b/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
@@ -11,9 +11,9 @@ Do **not** edit this file directly.
 | Classification | Count |
 | --- | --- |
 | ✓ Conforming | 28 |
-| → Rename-to | 23 |
-| ● Legitimately Custom | 20 |
-| **Total** | 71 |
+| → Rename-to | 19 |
+| ● Legitimately Custom | 22 |
+| **Total** | 69 |
 
 ## Classification by Emitter
 
@@ -103,10 +103,8 @@ Do **not** edit this file directly.
 
 | Key | Source | Classification | Target | Cluster | Note |
 | --- | --- | --- | --- | --- | --- |
-| `outcome` | `emit-otel-event.sh:130` | → rename-to | → `catalyst.outcome` | Cluster G |  |
-| `phase` | `emit-otel-event.sh:141` | → rename-to | → `catalyst.phase` | Cluster G |  |
-| `reason` | `emit-otel-event.sh:135` | → rename-to | → `catalyst.reason` | Cluster G |  |
-| `session_id` | `emit-otel-event.sh:131` | → rename-to | → `claude.session.id` | Cluster G |  |
+| `catalyst.outcome` | `emit-otel-event.sh:130` | ● custom |  |  |  |
+| `catalyst.reason` | `emit-otel-event.sh:135` | ● custom |  |  |  |
 
 ## Remediation Map (CTL-1008 Handoff)
 
@@ -161,24 +159,6 @@ validated against live Loki.
 | `host.mem_total_mb` | `system.memory.limit` | unit: ×1048576 → bytes |
 | `host.mem_used_mb` | `system.memory.usage` | unit: ×1048576 → bytes, state=used |
 | `host.mem_used_pct` | `system.memory.utilization` | unit: ÷100 → 0.0–1.0 |
-
-### Cluster G — emit-otel-event.sh legacy bare attributes
-
-- **Emit-side files**: `emit-otel-event.sh`
-- **Where**: emit
-- **Migration**: hard-cutover (no dual-emit)
-- **Consumer-update checklist** (all in ONE PR, validated against live Loki):
-  - [ ] emit-side rename in the file(s) above
-  - [ ] Grafana dashboard JSON updates
-  - [ ] orch-monitor otel-queries updates
-- **Historical-data note**: queries spanning the rename date must use an old-name-OR-new-name clause (2y Prometheus retention keeps the old name)
-
-| Current key | Target name | Note |
-| --- | --- | --- |
-| `outcome` | `catalyst.outcome` |  |
-| `phase` | `catalyst.phase` |  |
-| `reason` | `catalyst.reason` |  |
-| `session_id` | `claude.session.id` |  |
 
 ### Cluster H — resource project field
 

--- a/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
+++ b/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
@@ -10,8 +10,8 @@ Do **not** edit this file directly.
 
 | Classification | Count |
 | --- | --- |
-| ✓ Conforming | 26 |
-| → Rename-to | 25 |
+| ✓ Conforming | 28 |
+| → Rename-to | 23 |
 | ● Legitimately Custom | 20 |
 | **Total** | 71 |
 
@@ -63,13 +63,13 @@ Do **not** edit this file directly.
 
 | Key | Source | Classification | Target | Cluster | Note |
 | --- | --- | --- | --- | --- | --- |
+| `catalyst.phase.attempt` | `canonical-event.sh:347` | ✓ conforming |  |  |  |
+| `catalyst.phase.revive_count` | `canonical-event.sh:348` | ✓ conforming |  |  |  |
 | `catalyst.ticket.type` | `canonical-event.sh:349` | ● custom |  |  | CTL-1023 |
 | `claude.ratelimit.five_hour_pct` | `canonical-event.sh:343` | ● custom |  |  | CTL-760 |
 | `claude.ratelimit.seven_day_opus_pct` | `canonical-event.sh:345` | ● custom |  |  | CTL-763 |
 | `claude.ratelimit.seven_day_pct` | `canonical-event.sh:344` | ● custom |  |  | CTL-760 |
 | `claude.ratelimit.seven_day_sonnet_pct` | `canonical-event.sh:346` | ● custom |  |  | CTL-763 |
-| `phase.attempt` | `canonical-event.sh:347` | → rename-to | → `catalyst.phase.attempt` | Cluster F | CTL-761 |
-| `phase.revive_count` | `canonical-event.sh:348` | → rename-to | → `catalyst.phase.revive_count` | Cluster F | CTL-761 |
 
 ### MJS (execution-core / catalyst-agent)
 
@@ -161,22 +161,6 @@ validated against live Loki.
 | `host.mem_total_mb` | `system.memory.limit` | unit: ×1048576 → bytes |
 | `host.mem_used_mb` | `system.memory.usage` | unit: ×1048576 → bytes, state=used |
 | `host.mem_used_pct` | `system.memory.utilization` | unit: ÷100 → 0.0–1.0 |
-
-### Cluster F — phase.* unnamespaced fields
-
-- **Emit-side files**: `canonical-event.sh`
-- **Where**: emit
-- **Migration**: hard-cutover (no dual-emit)
-- **Consumer-update checklist** (all in ONE PR, validated against live Loki):
-  - [ ] emit-side rename in the file(s) above
-  - [ ] Grafana dashboard JSON updates
-  - [ ] orch-monitor otel-queries updates
-- **Historical-data note**: queries spanning the rename date must use an old-name-OR-new-name clause (2y Prometheus retention keeps the old name)
-
-| Current key | Target name | Note |
-| --- | --- | --- |
-| `phase.attempt` | `catalyst.phase.attempt` | CTL-761 |
-| `phase.revive_count` | `catalyst.phase.revive_count` | CTL-761 |
 
 ### Cluster G — emit-otel-event.sh legacy bare attributes
 

--- a/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
+++ b/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
@@ -11,8 +11,8 @@ Do **not** edit this file directly.
 | Classification | Count |
 | --- | --- |
 | ✓ Conforming | 28 |
-| → Rename-to | 19 |
-| ● Legitimately Custom | 22 |
+| → Rename-to | 18 |
+| ● Legitimately Custom | 23 |
 | **Total** | 69 |
 
 ## Classification by Emitter
@@ -29,6 +29,7 @@ Do **not** edit this file directly.
 | `catalyst.orchestration` | `canonical-event.ts:54` | ● custom |  |  |  |
 | `catalyst.orchestrator.id` | `canonical-event.ts:67` | ● custom |  |  |  |
 | `catalyst.phase` | `canonical-event.ts:70` | ● custom |  |  |  |
+| `catalyst.project` | `canonical-event.ts:52` | ● custom |  |  |  |
 | `catalyst.session.id` | `canonical-event.ts:69` | ● custom |  |  |  |
 | `catalyst.worker.ticket` | `canonical-event.ts:68` | ● custom |  |  |  |
 | `cicd.pipeline.name` | `canonical-event.ts:82` | ✓ conforming |  |  |  |
@@ -50,7 +51,6 @@ Do **not** edit this file directly.
 | `linear.issue.identifier` | `canonical-event.ts:85` | ● custom |  |  |  |
 | `linear.key` | `canonical-event.ts:53` | ● custom |  |  |  |
 | `linear.team.key` | `canonical-event.ts:87` | ● custom |  |  |  |
-| `project` | `canonical-event.ts:52` | → rename-to | → `catalyst.project` | Cluster H |  |
 | `service.name` | `canonical-event.ts:43` | ✓ conforming |  |  |  |
 | `service.namespace` | `canonical-event.ts:44` | ✓ conforming |  |  |  |
 | `service.version` | `canonical-event.ts:45` | ✓ conforming |  |  |  |
@@ -159,21 +159,6 @@ validated against live Loki.
 | `host.mem_total_mb` | `system.memory.limit` | unit: ×1048576 → bytes |
 | `host.mem_used_mb` | `system.memory.usage` | unit: ×1048576 → bytes, state=used |
 | `host.mem_used_pct` | `system.memory.utilization` | unit: ÷100 → 0.0–1.0 |
-
-### Cluster H — resource project field
-
-- **Emit-side files**: `canonical-event.ts`
-- **Where**: both
-- **Migration**: hard-cutover (no dual-emit)
-- **Consumer-update checklist** (all in ONE PR, validated against live Loki):
-  - [ ] emit-side rename in the file(s) above
-  - [ ] Grafana dashboard JSON updates
-  - [ ] orch-monitor otel-queries updates
-- **Historical-data note**: queries spanning the rename date must use an old-name-OR-new-name clause (2y Prometheus retention keeps the old name)
-
-| Current key | Target name | Note |
-| --- | --- | --- |
-| `project` | `catalyst.project` |  |
 
 ---
 

--- a/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
+++ b/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
@@ -10,8 +10,8 @@ Do **not** edit this file directly.
 
 | Classification | Count |
 | --- | --- |
-| ✓ Conforming | 19 |
-| → Rename-to | 32 |
+| ✓ Conforming | 23 |
+| → Rename-to | 28 |
 | ● Legitimately Custom | 20 |
 | **Total** | 71 |
 
@@ -76,6 +76,8 @@ Do **not** edit this file directly.
 | Key | Source | Classification | Target | Cluster | Note |
 | --- | --- | --- | --- | --- | --- |
 | `account.email` | `ratelimit-event.mjs:62` | → rename-to | → `catalyst.account.email` | Cluster B |  |
+| `catalyst.process.phase` | `processes.mjs:287` | ✓ conforming |  |  |  |
+| `catalyst.process.ticket` | `processes.mjs:286` | ✓ conforming |  |  |  |
 | `host.cpu_count` | `host.mjs:274` | → rename-to | → `system.cpu.logical_count` | Cluster C |  |
 | `host.cpu_pct` | `host.mjs:273` | → rename-to | → `system.cpu.utilization` | Cluster C | unit: ÷100 → 0.0–1.0 |
 | `host.disk_total_gb` | `host.mjs:280` | → rename-to | → `system.filesystem.capacity` | Cluster C | unit: ×1073741824 → bytes |
@@ -86,10 +88,8 @@ Do **not** edit this file directly.
 | `host.mem_used_mb` | `host.mjs:276` | → rename-to | → `system.memory.usage` | Cluster C | unit: ×1048576 → bytes, state=used |
 | `host.mem_used_pct` | `host.mjs:278` | → rename-to | → `system.memory.utilization` | Cluster C | unit: ÷100 → 0.0–1.0 |
 | `process.command` | `processes.mjs:283` | ✓ conforming |  |  |  |
-| `process.cpu_pct` | `processes.mjs:284` | → rename-to | → `process.cpu.utilization` | Cluster D | unit: ÷100 → 0.0–1.0 |
-| `process.phase` | `processes.mjs:287` | → rename-to | → `catalyst.process.phase` | Cluster D |  |
-| `process.rss_mb` | `processes.mjs:285` | → rename-to | → `process.memory.usage` | Cluster D | unit: ×1048576 → bytes |
-| `process.ticket` | `processes.mjs:286` | → rename-to | → `catalyst.process.ticket` | Cluster D |  |
+| `process.cpu.utilization` | `processes.mjs:284` | ✓ conforming |  |  |  |
+| `process.memory.usage` | `processes.mjs:285` | ✓ conforming |  |  |  |
 | `rate_limit.tier` | `ratelimit-event.mjs:71` | → rename-to | → `catalyst.ratelimit.tier` | Cluster B |  |
 | `ratelimit.five_hour_pct` | `ratelimit-event.mjs:64` | → rename-to | → `catalyst.ratelimit.five_hour_pct` | Cluster B |  |
 | `ratelimit.five_hour_resets_at` | `ratelimit-event.mjs:66` | → rename-to | → `catalyst.ratelimit.five_hour_resets_at` | Cluster B |  |
@@ -161,24 +161,6 @@ validated against live Loki.
 | `host.mem_total_mb` | `system.memory.limit` | unit: ×1048576 → bytes |
 | `host.mem_used_mb` | `system.memory.usage` | unit: ×1048576 → bytes, state=used |
 | `host.mem_used_pct` | `system.memory.utilization` | unit: ÷100 → 0.0–1.0 |
-
-### Cluster D — process.* non-conforming fields
-
-- **Emit-side files**: `processes.mjs`
-- **Where**: emit
-- **Migration**: hard-cutover (no dual-emit)
-- **Consumer-update checklist** (all in ONE PR, validated against live Loki):
-  - [ ] emit-side rename in the file(s) above
-  - [ ] Grafana dashboard JSON updates
-  - [ ] orch-monitor otel-queries updates
-- **Historical-data note**: queries spanning the rename date must use an old-name-OR-new-name clause (2y Prometheus retention keeps the old name)
-
-| Current key | Target name | Note |
-| --- | --- | --- |
-| `process.cpu_pct` | `process.cpu.utilization` | unit: ÷100 → 0.0–1.0 |
-| `process.phase` | `catalyst.process.phase` |  |
-| `process.rss_mb` | `process.memory.usage` | unit: ×1048576 → bytes |
-| `process.ticket` | `catalyst.process.ticket` |  |
 
 ### Cluster E — vcs.revision / cicd.conclusion / deployment.environment
 

--- a/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
+++ b/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
@@ -10,8 +10,8 @@ Do **not** edit this file directly.
 
 | Classification | Count |
 | --- | --- |
-| ✓ Conforming | 23 |
-| → Rename-to | 28 |
+| ✓ Conforming | 26 |
+| → Rename-to | 25 |
 | ● Legitimately Custom | 20 |
 | **Total** | 71 |
 
@@ -32,15 +32,15 @@ Do **not** edit this file directly.
 | `catalyst.session.id` | `canonical-event.ts:69` | ● custom |  |  |  |
 | `catalyst.worker.ticket` | `canonical-event.ts:68` | ● custom |  |  |  |
 | `cicd.pipeline.name` | `canonical-event.ts:82` | ✓ conforming |  |  |  |
-| `cicd.pipeline.run.conclusion` | `canonical-event.ts:81` | → rename-to | → `cicd.pipeline.run.result` | Cluster E |  |
 | `cicd.pipeline.run.id` | `canonical-event.ts:79` | ✓ conforming |  |  |  |
+| `cicd.pipeline.run.result` | `canonical-event.ts:81` | ✓ conforming |  |  |  |
 | `cicd.pipeline.run.status` | `canonical-event.ts:80` | ✓ conforming |  |  |  |
 | `claude.context.tokens` | `canonical-event.ts:100` | ● custom |  |  |  |
 | `claude.context.used_pct` | `canonical-event.ts:99` | ● custom |  |  |  |
 | `claude.model` | `canonical-event.ts:98` | ● custom |  |  |  |
 | `claude.session.id` | `canonical-event.ts:97` | ● custom |  |  |  |
 | `claude.turn` | `canonical-event.ts:101` | ● custom |  |  |  |
-| `deployment.environment` | `canonical-event.ts:91` | → rename-to | → `deployment.environment.name` | Cluster E |  |
+| `deployment.environment.name` | `canonical-event.ts:91` | ✓ conforming |  |  |  |
 | `deployment.id` | `canonical-event.ts:92` | ✓ conforming |  |  | type should be string per OTel semconv; currently number |
 | `event.name` | `canonical-event.ts:59` | ✓ conforming |  |  |  |
 | `host.id` | `canonical-event.ts:48` | ✓ conforming |  |  |  |
@@ -56,8 +56,8 @@ Do **not** edit this file directly.
 | `service.version` | `canonical-event.ts:45` | ✓ conforming |  |  |  |
 | `vcs.pr.number` | `canonical-event.ts:74` | ✓ conforming |  |  |  |
 | `vcs.ref.name` | `canonical-event.ts:75` | ✓ conforming |  |  |  |
+| `vcs.ref.revision` | `canonical-event.ts:76` | ✓ conforming |  |  |  |
 | `vcs.repository.name` | `canonical-event.ts:73` | ✓ conforming |  |  |  |
-| `vcs.revision` | `canonical-event.ts:76` | → rename-to | → `vcs.ref.revision` | Cluster E |  |
 
 ### Bash (`canonical-event.sh`)
 
@@ -161,23 +161,6 @@ validated against live Loki.
 | `host.mem_total_mb` | `system.memory.limit` | unit: ×1048576 → bytes |
 | `host.mem_used_mb` | `system.memory.usage` | unit: ×1048576 → bytes, state=used |
 | `host.mem_used_pct` | `system.memory.utilization` | unit: ÷100 → 0.0–1.0 |
-
-### Cluster E — vcs.revision / cicd.conclusion / deployment.environment
-
-- **Emit-side files**: `canonical-event.ts`
-- **Where**: emit
-- **Migration**: hard-cutover (no dual-emit)
-- **Consumer-update checklist** (all in ONE PR, validated against live Loki):
-  - [ ] emit-side rename in the file(s) above
-  - [ ] Grafana dashboard JSON updates
-  - [ ] orch-monitor otel-queries updates
-- **Historical-data note**: queries spanning the rename date must use an old-name-OR-new-name clause (2y Prometheus retention keeps the old name)
-
-| Current key | Target name | Note |
-| --- | --- | --- |
-| `cicd.pipeline.run.conclusion` | `cicd.pipeline.run.result` |  |
-| `deployment.environment` | `deployment.environment.name` |  |
-| `vcs.revision` | `vcs.ref.revision` |  |
 
 ### Cluster F — phase.* unnamespaced fields
 

--- a/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
+++ b/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
@@ -10,8 +10,8 @@ Do **not** edit this file directly.
 
 | Classification | Count |
 | --- | --- |
-| ✓ Conforming | 14 |
-| → Rename-to | 37 |
+| ✓ Conforming | 19 |
+| → Rename-to | 32 |
 | ● Legitimately Custom | 20 |
 | **Total** | 71 |
 
@@ -21,6 +21,11 @@ Do **not** edit this file directly.
 
 | Key | Source | Classification | Target | Cluster | Note |
 | --- | --- | --- | --- | --- | --- |
+| `catalyst.event.action` | `canonical-event.ts:61` | ✓ conforming |  |  |  |
+| `catalyst.event.channel` | `canonical-event.ts:64` | ✓ conforming |  |  |  |
+| `catalyst.event.entity` | `canonical-event.ts:60` | ✓ conforming |  |  |  |
+| `catalyst.event.label` | `canonical-event.ts:62` | ✓ conforming |  |  |  |
+| `catalyst.event.value` | `canonical-event.ts:63` | ✓ conforming |  |  |  |
 | `catalyst.orchestration` | `canonical-event.ts:54` | ● custom |  |  |  |
 | `catalyst.orchestrator.id` | `canonical-event.ts:67` | ● custom |  |  |  |
 | `catalyst.phase` | `canonical-event.ts:70` | ● custom |  |  |  |
@@ -37,12 +42,7 @@ Do **not** edit this file directly.
 | `claude.turn` | `canonical-event.ts:101` | ● custom |  |  |  |
 | `deployment.environment` | `canonical-event.ts:91` | → rename-to | → `deployment.environment.name` | Cluster E |  |
 | `deployment.id` | `canonical-event.ts:92` | ✓ conforming |  |  | type should be string per OTel semconv; currently number |
-| `event.action` | `canonical-event.ts:61` | → rename-to | → `catalyst.event.action` | Cluster A |  |
-| `event.channel` | `canonical-event.ts:64` | → rename-to | → `catalyst.event.channel` | Cluster A |  |
-| `event.entity` | `canonical-event.ts:60` | → rename-to | → `catalyst.event.entity` | Cluster A |  |
-| `event.label` | `canonical-event.ts:62` | → rename-to | → `catalyst.event.label` | Cluster A |  |
 | `event.name` | `canonical-event.ts:59` | ✓ conforming |  |  |  |
-| `event.value` | `canonical-event.ts:63` | → rename-to | → `catalyst.event.value` | Cluster A |  |
 | `host.id` | `canonical-event.ts:48` | ✓ conforming |  |  |  |
 | `host.name` | `canonical-event.ts:47` | ✓ conforming |  |  |  |
 | `linear.actor.id` | `canonical-event.ts:88` | ● custom |  |  |  |
@@ -115,25 +115,6 @@ derived from the manifest. Per the operator decision (Ryan, 2026-06-11),
 every rename uses a **hard cutover** — no dual-emit period, no deprecated-name
 emission. Each cluster ships emit-side rename + all consumer updates in ONE PR,
 validated against live Loki.
-
-### Cluster A — event.* non-name fields
-
-- **Emit-side files**: `canonical-event.ts`
-- **Where**: emit
-- **Migration**: hard-cutover (no dual-emit)
-- **Consumer-update checklist** (all in ONE PR, validated against live Loki):
-  - [ ] emit-side rename in the file(s) above
-  - [ ] Grafana dashboard JSON updates
-  - [ ] orch-monitor otel-queries updates
-- **Historical-data note**: queries spanning the rename date must use an old-name-OR-new-name clause (2y Prometheus retention keeps the old name)
-
-| Current key | Target name | Note |
-| --- | --- | --- |
-| `event.action` | `catalyst.event.action` |  |
-| `event.channel` | `catalyst.event.channel` |  |
-| `event.entity` | `catalyst.event.entity` |  |
-| `event.label` | `catalyst.event.label` |  |
-| `event.value` | `catalyst.event.value` |  |
 
 ### Cluster B — ratelimit.* / account.* / subscription.*
 

--- a/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
@@ -27,7 +27,7 @@ export function isAllowedTargetNamespace(target: string): boolean {
 
 /** Expected per-cluster rename-to counts (CTL-1009 research §6). */
 export const EXPECTED_CLUSTER_COUNTS: Readonly<Record<RemediationCluster, number>> = {
-  A: 5,
+  A: 0,
   B: 9,
   C: 9,
   D: 4,

--- a/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
@@ -30,7 +30,7 @@ export const EXPECTED_CLUSTER_COUNTS: Readonly<Record<RemediationCluster, number
   A: 0,
   B: 9,
   C: 9,
-  D: 4,
+  D: 0,
   E: 3,
   F: 2,
   G: 4,

--- a/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
@@ -28,7 +28,7 @@ export function isAllowedTargetNamespace(target: string): boolean {
 /** Expected per-cluster rename-to counts (CTL-1009 research §6). */
 export const EXPECTED_CLUSTER_COUNTS: Readonly<Record<RemediationCluster, number>> = {
   A: 0,
-  B: 9,
+  B: 0,
   C: 9,
   D: 0,
   E: 0,

--- a/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
@@ -29,7 +29,7 @@ export function isAllowedTargetNamespace(target: string): boolean {
 export const EXPECTED_CLUSTER_COUNTS: Readonly<Record<RemediationCluster, number>> = {
   A: 0,
   B: 0,
-  C: 9,
+  C: 0,
   D: 0,
   E: 0,
   F: 0,

--- a/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
@@ -31,7 +31,7 @@ export const EXPECTED_CLUSTER_COUNTS: Readonly<Record<RemediationCluster, number
   B: 9,
   C: 9,
   D: 0,
-  E: 3,
+  E: 0,
   F: 2,
   G: 4,
   H: 1,

--- a/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
@@ -33,7 +33,7 @@ export const EXPECTED_CLUSTER_COUNTS: Readonly<Record<RemediationCluster, number
   D: 0,
   E: 0,
   F: 0,
-  G: 4,
+  G: 0,
   H: 1,
 };
 

--- a/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
@@ -34,7 +34,7 @@ export const EXPECTED_CLUSTER_COUNTS: Readonly<Record<RemediationCluster, number
   E: 0,
   F: 0,
   G: 0,
-  H: 1,
+  H: 0,
 };
 
 // ── Extractor helpers ────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/attribute-extractors.ts
@@ -32,7 +32,7 @@ export const EXPECTED_CLUSTER_COUNTS: Readonly<Record<RemediationCluster, number
   C: 9,
   D: 0,
   E: 0,
-  F: 2,
+  F: 0,
   G: 4,
   H: 1,
 };

--- a/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
@@ -49,7 +49,7 @@ export interface Resource {
   // CTL-636: optional orchestration-context resource keys. Present only when
   // the event carries the corresponding data; omitted otherwise so external
   // (webhook / broker-daemon) events keep the bare 3-key block.
-  "project"?: string;
+  "catalyst.project"?: string;
   "linear.key"?: string;
   "catalyst.orchestration"?: string;
 }
@@ -131,7 +131,7 @@ export interface BuildInput {
   resource: {
     "service.name": string;
     "service.version"?: string;
-    "project"?: string;
+    "catalyst.project"?: string;
     "linear.key"?: string;
     "catalyst.orchestration"?: string;
   };
@@ -174,13 +174,13 @@ export function pluginVersion(): string {
   return cachedVersion;
 }
 
-/** CTL-636: pull `project=<val>` out of the ambient OTEL_RESOURCE_ATTRIBUTES
+/** CTL-636: pull `catalyst.project=<val>` out of the ambient OTEL_RESOURCE_ATTRIBUTES
  *  env (set by phase-agent-dispatch for --bg workers and by direnv for
- *  interactive sessions). Mirrors the bash parse in emit-otel-event.sh:82-88. */
+ *  interactive sessions). Mirrors the bash parse in canonical-event.sh. */
 function projectFromEnv(): string | undefined {
   const raw = process.env.OTEL_RESOURCE_ATTRIBUTES;
   if (!raw) return undefined;
-  const m = raw.match(/(?:^|,)project=([^,]+)/);
+  const m = raw.match(/(?:^|,)catalyst\.project=([^,]+)/);
   return m ? m[1] : undefined;
 }
 
@@ -206,8 +206,8 @@ export function buildCanonicalEvent(input: BuildInput): CanonicalEvent {
   // CTL-636: promote orchestration context into resource. Explicit resource
   // input wins; otherwise fall back to the matching attribute (TS emitters
   // already set these) or the ambient env (project only).
-  const project = input.resource["project"] ?? projectFromEnv();
-  if (project) resource["project"] = project;
+  const project = input.resource["catalyst.project"] ?? projectFromEnv();
+  if (project) resource["catalyst.project"] = project;
   const linearKey =
     input.resource["linear.key"] ?? input.attributes["linear.issue.identifier"];
   if (linearKey) resource["linear.key"] = linearKey;

--- a/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
@@ -57,11 +57,11 @@ export interface Resource {
 export interface Attributes {
   // catalyst-internal classifier
   "event.name": string;
-  "event.entity"?: string;
-  "event.action"?: string;
-  "event.label"?: string;
-  "event.value"?: string | number;
-  "event.channel"?: "webhook" | "sme.io";
+  "catalyst.event.entity"?: string;
+  "catalyst.event.action"?: string;
+  "catalyst.event.label"?: string;
+  "catalyst.event.value"?: string | number;
+  "catalyst.event.channel"?: "webhook" | "sme.io";
 
   // catalyst entities
   "catalyst.orchestrator.id"?: string;

--- a/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
@@ -73,12 +73,12 @@ export interface Attributes {
   "vcs.repository.name"?: string;
   "vcs.pr.number"?: number;
   "vcs.ref.name"?: string;
-  "vcs.revision"?: string;
+  "vcs.ref.revision"?: string;
 
   // CI/CD semconv (OTel published)
   "cicd.pipeline.run.id"?: number;
   "cicd.pipeline.run.status"?: string;
-  "cicd.pipeline.run.conclusion"?: string;
+  "cicd.pipeline.run.result"?: string;
   "cicd.pipeline.name"?: string;
 
   // Linear (catalyst-defined; no OTel semconv yet)
@@ -88,7 +88,7 @@ export interface Attributes {
   "linear.actor.id"?: string;
 
   // Deployment semconv (OTel published)
-  "deployment.environment"?: string;
+  "deployment.environment.name"?: string;
   "deployment.id"?: number;
 
   // Claude Code metadata (CTL-374). PII note: cost is intentionally absent

--- a/plugins/dev/scripts/orch-monitor/lib/event-analysis.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/event-analysis.ts
@@ -184,7 +184,7 @@ export function normalize(line: string): NormalizedEvent | null {
   // CI conclusion
   let ciConclusion: string | null = null;
   if (isCanonical) {
-    ciConclusion = asString(attrs["cicd.pipeline.run.conclusion"]);
+    ciConclusion = asString(attrs["cicd.pipeline.run.result"]);
   }
   if (ciConclusion === null && detail !== null) {
     ciConclusion = asString(detail["conclusion"]);

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
@@ -70,12 +70,12 @@ function canonical(args: LinearCanonicalArgs): CanonicalEvent {
   const attributes: Attributes = {
     ...args.attrs,
     "event.name": args.eventName,
-    "event.entity": args.entity,
-    "event.action": args.action,
-    "event.channel": "webhook",
+    "catalyst.event.entity": args.entity,
+    "catalyst.event.action": args.action,
+    "catalyst.event.channel": "webhook",
   };
   if (args.label !== undefined) {
-    attributes["event.label"] = args.label;
+    attributes["catalyst.event.label"] = args.label;
   }
   return buildCanonicalEvent({
     ts: args.ts,

--- a/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
@@ -50,12 +50,12 @@ export const AUDIT_MANIFEST: AttributeAuditEntry[] = [
   { key: "vcs.repository.name", emitter: "ts", source: "canonical-event.ts:73", classification: "conforming" },
   { key: "vcs.pr.number",       emitter: "ts", source: "canonical-event.ts:74", classification: "conforming" },
   { key: "vcs.ref.name",        emitter: "ts", source: "canonical-event.ts:75", classification: "conforming" },
-  { key: "vcs.revision",        emitter: "ts", source: "canonical-event.ts:76", classification: "rename-to", targetName: "vcs.ref.revision", remediationCluster: "E", where: "emit" },
+  { key: "vcs.ref.revision",    emitter: "ts", source: "canonical-event.ts:76", classification: "conforming" },
 
   // §4e: CI/CD semconv
   { key: "cicd.pipeline.run.id",         emitter: "ts", source: "canonical-event.ts:79", classification: "conforming" },
   { key: "cicd.pipeline.run.status",     emitter: "ts", source: "canonical-event.ts:80", classification: "conforming" },
-  { key: "cicd.pipeline.run.conclusion", emitter: "ts", source: "canonical-event.ts:81", classification: "rename-to", targetName: "cicd.pipeline.run.result", remediationCluster: "E", where: "emit" },
+  { key: "cicd.pipeline.run.result",     emitter: "ts", source: "canonical-event.ts:81", classification: "conforming" },
   { key: "cicd.pipeline.name",           emitter: "ts", source: "canonical-event.ts:82", classification: "conforming" },
 
   // Linear — legitimately-custom (no OTel semconv; linear.* vendor namespace)
@@ -65,7 +65,7 @@ export const AUDIT_MANIFEST: AttributeAuditEntry[] = [
   { key: "linear.actor.id",         emitter: "ts", source: "canonical-event.ts:88", classification: "legitimately-custom" },
 
   // §4f: Deployment semconv
-  { key: "deployment.environment", emitter: "ts", source: "canonical-event.ts:91", classification: "rename-to", targetName: "deployment.environment.name", remediationCluster: "E", where: "emit" },
+  { key: "deployment.environment.name", emitter: "ts", source: "canonical-event.ts:91", classification: "conforming" },
   { key: "deployment.id",          emitter: "ts", source: "canonical-event.ts:92", classification: "conforming", note: "type should be string per OTel semconv; currently number" },
 
   // §4g: Claude Code metadata (CTL-374) — legitimately-custom (claude.* vendor namespace)

--- a/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
@@ -34,11 +34,11 @@ export const AUDIT_MANIFEST: AttributeAuditEntry[] = [
   // ── TS emitter — Attributes interface (canonical-event.ts) ───────────────
   // §4b: Event classifier family
   { key: "event.name",    emitter: "ts", source: "canonical-event.ts:59", classification: "conforming" },
-  { key: "event.entity",  emitter: "ts", source: "canonical-event.ts:60", classification: "rename-to", targetName: "catalyst.event.entity",  remediationCluster: "A", where: "emit" },
-  { key: "event.action",  emitter: "ts", source: "canonical-event.ts:61", classification: "rename-to", targetName: "catalyst.event.action",  remediationCluster: "A", where: "emit" },
-  { key: "event.label",   emitter: "ts", source: "canonical-event.ts:62", classification: "rename-to", targetName: "catalyst.event.label",   remediationCluster: "A", where: "emit" },
-  { key: "event.value",   emitter: "ts", source: "canonical-event.ts:63", classification: "rename-to", targetName: "catalyst.event.value",   remediationCluster: "A", where: "emit" },
-  { key: "event.channel", emitter: "ts", source: "canonical-event.ts:64", classification: "rename-to", targetName: "catalyst.event.channel", remediationCluster: "A", where: "emit" },
+  { key: "catalyst.event.entity",  emitter: "ts", source: "canonical-event.ts:60", classification: "conforming" },
+  { key: "catalyst.event.action",  emitter: "ts", source: "canonical-event.ts:61", classification: "conforming" },
+  { key: "catalyst.event.label",   emitter: "ts", source: "canonical-event.ts:62", classification: "conforming" },
+  { key: "catalyst.event.value",   emitter: "ts", source: "canonical-event.ts:63", classification: "conforming" },
+  { key: "catalyst.event.channel", emitter: "ts", source: "canonical-event.ts:64", classification: "conforming" },
 
   // §4c: Catalyst internal — legitimately-custom (catalyst.* namespace)
   { key: "catalyst.orchestrator.id", emitter: "ts", source: "canonical-event.ts:67", classification: "legitimately-custom" },

--- a/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
@@ -102,16 +102,16 @@ export const AUDIT_MANIFEST: AttributeAuditEntry[] = [
   { key: "catalyst.ratelimit.tier",    emitter: "mjs", source: "ratelimit-event.mjs:70", classification: "legitimately-custom" },
 
   // ── MJS emitter — catalyst-agent/host.mjs ────────────────────────────────
-  // §4j: Host system metrics cluster C — rename-to (host.* → system.*)
-  { key: "host.cpu_pct",      emitter: "mjs", source: "host.mjs:273", classification: "rename-to", targetName: "system.cpu.utilization",       remediationCluster: "C", where: "both", note: "unit: ÷100 → 0.0–1.0" },
-  { key: "host.cpu_count",    emitter: "mjs", source: "host.mjs:274", classification: "rename-to", targetName: "system.cpu.logical_count",     remediationCluster: "C", where: "both" },
-  { key: "host.load1",        emitter: "mjs", source: "host.mjs:275", classification: "rename-to", targetName: "system.linux.cpu.load_1m",     remediationCluster: "C", where: "both" },
-  { key: "host.mem_used_mb",  emitter: "mjs", source: "host.mjs:276", classification: "rename-to", targetName: "system.memory.usage",          remediationCluster: "C", where: "both", note: "unit: ×1048576 → bytes, state=used" },
-  { key: "host.mem_total_mb", emitter: "mjs", source: "host.mjs:277", classification: "rename-to", targetName: "system.memory.limit",          remediationCluster: "C", where: "both", note: "unit: ×1048576 → bytes" },
-  { key: "host.mem_used_pct", emitter: "mjs", source: "host.mjs:278", classification: "rename-to", targetName: "system.memory.utilization",    remediationCluster: "C", where: "both", note: "unit: ÷100 → 0.0–1.0" },
-  { key: "host.disk_used_gb", emitter: "mjs", source: "host.mjs:279", classification: "rename-to", targetName: "system.filesystem.usage",      remediationCluster: "C", where: "both", note: "unit: ×1073741824 → bytes, state=used" },
-  { key: "host.disk_total_gb",emitter: "mjs", source: "host.mjs:280", classification: "rename-to", targetName: "system.filesystem.capacity",   remediationCluster: "C", where: "both", note: "unit: ×1073741824 → bytes" },
-  { key: "host.disk_used_pct",emitter: "mjs", source: "host.mjs:281", classification: "rename-to", targetName: "system.filesystem.utilization",remediationCluster: "C", where: "both", note: "unit: ÷100 → 0.0–1.0" },
+  // §4j: Host system metrics cluster C — now conforming (renamed in place, units converted)
+  { key: "system.cpu.utilization",       emitter: "mjs", source: "host.mjs:278", classification: "conforming" },
+  { key: "system.cpu.logical_count",     emitter: "mjs", source: "host.mjs:279", classification: "conforming" },
+  { key: "system.linux.cpu.load_1m",     emitter: "mjs", source: "host.mjs:280", classification: "conforming" },
+  { key: "system.memory.usage",          emitter: "mjs", source: "host.mjs:281", classification: "conforming" },
+  { key: "system.memory.limit",          emitter: "mjs", source: "host.mjs:282", classification: "conforming" },
+  { key: "system.memory.utilization",    emitter: "mjs", source: "host.mjs:283", classification: "conforming" },
+  { key: "system.filesystem.usage",      emitter: "mjs", source: "host.mjs:284", classification: "conforming" },
+  { key: "system.filesystem.capacity",   emitter: "mjs", source: "host.mjs:285", classification: "conforming" },
+  { key: "system.filesystem.utilization",emitter: "mjs", source: "host.mjs:286", classification: "conforming" },
 
   // ── MJS emitter — catalyst-agent/processes.mjs ───────────────────────────
   // §4k: Process metrics — partially conforming, cluster D

--- a/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
@@ -90,16 +90,16 @@ export const AUDIT_MANIFEST: AttributeAuditEntry[] = [
   { key: "catalyst.ticket.type", emitter: "sh", source: "canonical-event.sh:349", classification: "legitimately-custom", note: "CTL-1023" },
 
   // ── MJS emitter — execution-core/ratelimit-event.mjs ─────────────────────
-  // §4i: Account rate-limit cluster B — rename-to
-  { key: "account.email",               emitter: "mjs", source: "ratelimit-event.mjs:62", classification: "rename-to", targetName: "catalyst.account.email",               remediationCluster: "B", where: "both" },
-  { key: "ratelimit.five_hour_pct",     emitter: "mjs", source: "ratelimit-event.mjs:64", classification: "rename-to", targetName: "catalyst.ratelimit.five_hour_pct",     remediationCluster: "B", where: "both" },
-  { key: "ratelimit.seven_day_pct",     emitter: "mjs", source: "ratelimit-event.mjs:65", classification: "rename-to", targetName: "catalyst.ratelimit.seven_day_pct",     remediationCluster: "B", where: "both" },
-  { key: "ratelimit.five_hour_resets_at", emitter: "mjs", source: "ratelimit-event.mjs:66", classification: "rename-to", targetName: "catalyst.ratelimit.five_hour_resets_at", remediationCluster: "B", where: "both" },
-  { key: "ratelimit.seven_day_resets_at", emitter: "mjs", source: "ratelimit-event.mjs:67", classification: "rename-to", targetName: "catalyst.ratelimit.seven_day_resets_at", remediationCluster: "B", where: "both" },
-  { key: "ratelimit.seven_day_opus_pct",   emitter: "mjs", source: "ratelimit-event.mjs:68", classification: "rename-to", targetName: "catalyst.ratelimit.seven_day_opus_pct",   remediationCluster: "B", where: "both" },
-  { key: "ratelimit.seven_day_sonnet_pct", emitter: "mjs", source: "ratelimit-event.mjs:69", classification: "rename-to", targetName: "catalyst.ratelimit.seven_day_sonnet_pct", remediationCluster: "B", where: "both" },
-  { key: "subscription.type", emitter: "mjs", source: "ratelimit-event.mjs:70", classification: "rename-to", targetName: "catalyst.subscription.type", remediationCluster: "B", where: "both" },
-  { key: "rate_limit.tier",   emitter: "mjs", source: "ratelimit-event.mjs:71", classification: "rename-to", targetName: "catalyst.ratelimit.tier",    remediationCluster: "B", where: "both" },
+  // §4i: Account rate-limit cluster B — now legitimately-custom (renamed in place)
+  { key: "catalyst.account.email",               emitter: "mjs", source: "ratelimit-event.mjs:62", classification: "legitimately-custom" },
+  { key: "catalyst.ratelimit.five_hour_pct",     emitter: "mjs", source: "ratelimit-event.mjs:63", classification: "legitimately-custom" },
+  { key: "catalyst.ratelimit.seven_day_pct",     emitter: "mjs", source: "ratelimit-event.mjs:64", classification: "legitimately-custom" },
+  { key: "catalyst.ratelimit.five_hour_resets_at", emitter: "mjs", source: "ratelimit-event.mjs:65", classification: "legitimately-custom" },
+  { key: "catalyst.ratelimit.seven_day_resets_at", emitter: "mjs", source: "ratelimit-event.mjs:66", classification: "legitimately-custom" },
+  { key: "catalyst.ratelimit.seven_day_opus_pct",   emitter: "mjs", source: "ratelimit-event.mjs:67", classification: "legitimately-custom" },
+  { key: "catalyst.ratelimit.seven_day_sonnet_pct", emitter: "mjs", source: "ratelimit-event.mjs:68", classification: "legitimately-custom" },
+  { key: "catalyst.subscription.type", emitter: "mjs", source: "ratelimit-event.mjs:69", classification: "legitimately-custom" },
+  { key: "catalyst.ratelimit.tier",    emitter: "mjs", source: "ratelimit-event.mjs:70", classification: "legitimately-custom" },
 
   // ── MJS emitter — catalyst-agent/host.mjs ────────────────────────────────
   // §4j: Host system metrics cluster C — rename-to (host.* → system.*)

--- a/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
@@ -122,9 +122,9 @@ export const AUDIT_MANIFEST: AttributeAuditEntry[] = [
   { key: "catalyst.process.phase",   emitter: "mjs", source: "processes.mjs:287", classification: "conforming" },
 
   // ── Legacy SH emitter — emit-otel-event.sh (OTLP direct) ─────────────────
-  // §4l: Legacy bare attributes cluster G — rename-to
-  { key: "outcome",    emitter: "legacy-sh", source: "emit-otel-event.sh:130", classification: "rename-to", targetName: "catalyst.outcome",   remediationCluster: "G", where: "emit" },
-  { key: "session_id", emitter: "legacy-sh", source: "emit-otel-event.sh:131", classification: "rename-to", targetName: "claude.session.id",  remediationCluster: "G", where: "emit" },
-  { key: "reason",     emitter: "legacy-sh", source: "emit-otel-event.sh:135", classification: "rename-to", targetName: "catalyst.reason",    remediationCluster: "G", where: "emit" },
-  { key: "phase",      emitter: "legacy-sh", source: "emit-otel-event.sh:141", classification: "rename-to", targetName: "catalyst.phase",     remediationCluster: "G", where: "emit" },
+  // §4l: Legacy bare attributes cluster G — now conforming (renamed in place).
+  // catalyst.phase and claude.session.id are owned by the TS emitter and filtered
+  // by tsKeys in extractLegacyOtlpKeys; only emit-only keys are listed here.
+  { key: "catalyst.outcome", emitter: "legacy-sh", source: "emit-otel-event.sh:130", classification: "legitimately-custom" },
+  { key: "catalyst.reason",  emitter: "legacy-sh", source: "emit-otel-event.sh:135", classification: "legitimately-custom" },
 ];

--- a/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
@@ -27,7 +27,7 @@ export const AUDIT_MANIFEST: AttributeAuditEntry[] = [
   { key: "host.name",         emitter: "ts", source: "canonical-event.ts:47", classification: "conforming" },
   { key: "host.id",           emitter: "ts", source: "canonical-event.ts:48", classification: "conforming" },
   // CTL-636 optional resource context
-  { key: "project",                 emitter: "ts", source: "canonical-event.ts:52", classification: "rename-to",            targetName: "catalyst.project",        remediationCluster: "H", where: "both" },
+  { key: "catalyst.project",         emitter: "ts", source: "canonical-event.ts:52", classification: "legitimately-custom" },
   { key: "linear.key",              emitter: "ts", source: "canonical-event.ts:53", classification: "legitimately-custom" },
   { key: "catalyst.orchestration",  emitter: "ts", source: "canonical-event.ts:54", classification: "legitimately-custom" },
 

--- a/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
@@ -116,10 +116,10 @@ export const AUDIT_MANIFEST: AttributeAuditEntry[] = [
   // ── MJS emitter — catalyst-agent/processes.mjs ───────────────────────────
   // §4k: Process metrics — partially conforming, cluster D
   { key: "process.command",  emitter: "mjs", source: "processes.mjs:283", classification: "conforming" },
-  { key: "process.cpu_pct",  emitter: "mjs", source: "processes.mjs:284", classification: "rename-to", targetName: "process.cpu.utilization", remediationCluster: "D", where: "emit", note: "unit: ÷100 → 0.0–1.0" },
-  { key: "process.rss_mb",   emitter: "mjs", source: "processes.mjs:285", classification: "rename-to", targetName: "process.memory.usage",    remediationCluster: "D", where: "emit", note: "unit: ×1048576 → bytes" },
-  { key: "process.ticket",   emitter: "mjs", source: "processes.mjs:286", classification: "rename-to", targetName: "catalyst.process.ticket", remediationCluster: "D", where: "emit" },
-  { key: "process.phase",    emitter: "mjs", source: "processes.mjs:287", classification: "rename-to", targetName: "catalyst.process.phase",  remediationCluster: "D", where: "emit" },
+  { key: "process.cpu.utilization",  emitter: "mjs", source: "processes.mjs:284", classification: "conforming" },
+  { key: "process.memory.usage",     emitter: "mjs", source: "processes.mjs:285", classification: "conforming" },
+  { key: "catalyst.process.ticket",  emitter: "mjs", source: "processes.mjs:286", classification: "conforming" },
+  { key: "catalyst.process.phase",   emitter: "mjs", source: "processes.mjs:287", classification: "conforming" },
 
   // ── Legacy SH emitter — emit-otel-event.sh (OTLP direct) ─────────────────
   // §4l: Legacy bare attributes cluster G — rename-to

--- a/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
@@ -83,8 +83,8 @@ export const AUDIT_MANIFEST: AttributeAuditEntry[] = [
   { key: "claude.ratelimit.seven_day_sonnet_pct", emitter: "sh", source: "canonical-event.sh:346", classification: "legitimately-custom", note: "CTL-763" },
 
   // §4h: Phase attempt tracking (CTL-761) — rename-to cluster F
-  { key: "phase.attempt",      emitter: "sh", source: "canonical-event.sh:347", classification: "rename-to", targetName: "catalyst.phase.attempt",      remediationCluster: "F", where: "emit", note: "CTL-761" },
-  { key: "phase.revive_count", emitter: "sh", source: "canonical-event.sh:348", classification: "rename-to", targetName: "catalyst.phase.revive_count", remediationCluster: "F", where: "emit", note: "CTL-761" },
+  { key: "catalyst.phase.attempt",      emitter: "sh", source: "canonical-event.sh:347", classification: "conforming" },
+  { key: "catalyst.phase.revive_count", emitter: "sh", source: "canonical-event.sh:348", classification: "conforming" },
 
   // CTL-1023: work-type dimension — legitimately-custom (catalyst.* namespace)
   { key: "catalyst.ticket.type", emitter: "sh", source: "canonical-event.sh:349", classification: "legitimately-custom", note: "CTL-1023" },

--- a/plugins/dev/scripts/orch-monitor/lib/render-attribute-audit.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/render-attribute-audit.ts
@@ -105,7 +105,7 @@ export function renderAuditMarkdown(entries: AttributeAuditEntry[]): string {
   lines.push(
     "Each cluster below is a unit of work for CTL-1008. Emit-side files are",
     "derived from the manifest. Per the operator decision (Ryan, 2026-06-11),",
-    "every rename uses a **hard cutover** — no dual-emit period, no deprecated-name",
+    "every rename uses a **hard-cutover** — no dual-emit period, no deprecated-name",
     "emission. Each cluster ships emit-side rename + all consumer updates in ONE PR,",
     "validated against live Loki.",
     "",

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-handler.ts
@@ -237,14 +237,14 @@ export function buildEventLogEnvelope(
         "vcs.repository.name": event.repo,
         "cicd.pipeline.run.status": event.status,
       };
-      if (event.headSha) attrs["vcs.revision"] = event.headSha;
+      if (event.headSha) attrs["vcs.ref.revision"] = event.headSha;
       const effectivePr =
         event.prNumbers.length >= 1
           ? event.prNumbers[0]
           : opts?.cachedPrNumber ?? null;
       if (effectivePr !== null) attrs["vcs.pr.number"] = effectivePr;
       if (event.conclusion !== null) {
-        attrs["cicd.pipeline.run.conclusion"] = event.conclusion;
+        attrs["cicd.pipeline.run.result"] = event.conclusion;
       }
       return canonical({
         ts,
@@ -275,7 +275,7 @@ export function buildEventLogEnvelope(
         severity: statusSeverity(event.state),
         attrs: {
           "vcs.repository.name": event.repo,
-          "vcs.revision": event.sha,
+          "vcs.ref.revision": event.sha,
         },
         message: `${eventName} for ${event.repo} sha ${event.sha.slice(0, 7)}`,
         payload: { state: event.state },
@@ -292,7 +292,7 @@ export function buildEventLogEnvelope(
         attrs: {
           "vcs.repository.name": event.repo,
           "vcs.ref.name": event.ref,
-          "vcs.revision": event.headSha,
+          "vcs.ref.revision": event.headSha,
         },
         message: `github.push to ${event.repo} ${event.ref} (${event.headSha.slice(0, 7)})`,
         payload: {
@@ -356,9 +356,9 @@ export function buildEventLogEnvelope(
         severity: "INFO",
         attrs: {
           "vcs.repository.name": event.repo,
-          "vcs.revision": event.sha,
+          "vcs.ref.revision": event.sha,
           "vcs.ref.name": event.refName,
-          "deployment.environment": event.environment,
+          "deployment.environment.name": event.environment,
           "deployment.id": event.deploymentId,
         },
         message: `github.deployment.created in ${event.repo} env ${event.environment}`,
@@ -379,7 +379,7 @@ export function buildEventLogEnvelope(
         severity: deploymentStatusSeverity(event.state),
         attrs: {
           "vcs.repository.name": event.repo,
-          "deployment.environment": event.environment,
+          "deployment.environment.name": event.environment,
           "deployment.id": event.deploymentId,
         },
         message: `${eventName} in ${event.repo} env ${event.environment}`,
@@ -418,7 +418,7 @@ export function buildEventLogEnvelope(
       const eventName = `github.workflow_run.${event.action}`;
       const attrs: Omit<Attributes, "event.name"> = {
         "vcs.repository.name": event.repo,
-        "vcs.revision": event.headSha,
+        "vcs.ref.revision": event.headSha,
         "cicd.pipeline.run.id": event.runId,
         "cicd.pipeline.run.status": event.status,
         "cicd.pipeline.name": event.name,
@@ -430,7 +430,7 @@ export function buildEventLogEnvelope(
           : opts?.cachedPrNumber ?? null;
       if (effectivePr !== null) attrs["vcs.pr.number"] = effectivePr;
       if (event.conclusion !== null) {
-        attrs["cicd.pipeline.run.conclusion"] = event.conclusion;
+        attrs["cicd.pipeline.run.result"] = event.conclusion;
       }
       return canonical({
         ts,

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-handler.ts
@@ -476,12 +476,12 @@ function canonical(args: CanonicalBuildArgs): CanonicalEvent {
   const attributes: Attributes = {
     ...args.attrs,
     "event.name": args.eventName,
-    "event.entity": args.entity,
-    "event.action": args.action,
-    "event.channel": "webhook",
+    "catalyst.event.entity": args.entity,
+    "catalyst.event.action": args.action,
+    "catalyst.event.channel": "webhook",
   };
   if (args.label !== undefined) {
-    attributes["event.label"] = args.label;
+    attributes["catalyst.event.label"] = args.label;
   }
   return buildCanonicalEvent({
     ts: args.ts,

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -861,9 +861,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
           resource: { "service.name": "monitor" },
           attributes: {
             "event.name": "catalyst.service.health",
-            "event.entity": "service",
-            "event.action": t.action,
-            "event.label": t.serviceId,
+            "catalyst.event.entity": "service",
+            "catalyst.event.action": t.action,
+            "catalyst.event.label": t.serviceId,
           },
           body: { message: t.body },
         }),


### PR DESCRIPTION
## Summary

- Renames 37 telemetry attribute keys across 8 clusters to OTel semantic-convention targets
- Hard cutover per operator decision (Ryan 2026-06-11) — no dual-emit window
- All clusters ship as atomic commits with TDD (Red→Green per cluster)
- Drift guard (`otel-attribute-audit.test.ts`) enforced throughout; all `EXPECTED_CLUSTER_COUNTS` now 0

## Clusters

| Cluster | Keys | Change |
|---------|------|--------|
| A | 5 | `event.*` → `catalyst.event.*` |
| D | 4 | `process.*` → OTel semconv + unit conversions |
| E | 3 | `vcs.revision`, `cicd.pipeline.run.conclusion`, `deployment.environment` → conforming names |
| F | 2 | `phase.attempt/revive_count` → `catalyst.phase.*` |
| G | 4 | Legacy bare attrs in `emit-otel-event.sh` → `catalyst.*`/`claude.*` |
| H | 1 | `project` → `catalyst.project` |
| B | 9 | `ratelimit.*`/`account.*`/`subscription.*` → `catalyst.*` |
| C | 9 | `host.*` → `system.*` with unit conversions (pct÷100, MB/GB×bytes factor) |

## Test plan
- [ ] `bun test __tests__/otel-attribute-audit.test.ts` — 23 pass, drift guard green
- [ ] `bun test __tests__/canonical-event.test.ts __tests__/webhook-handler.test.ts __tests__/linear-webhook-handler.test.ts` — 178 pass
- [ ] `bun test host.test.mjs processes.test.mjs` (catalyst-agent) — 74 pass
- [ ] `bun test ratelimit-event.test.mjs` (execution-core) — 13 pass
- [ ] `bash __tests__/emit-otel-event.test.sh` — 33 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)