### PR TITLE
fix(dev): CTL-1078 — classify retraction-sweep auth/scope failures correctly and break per-tick storm

### DIFF
--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -121,13 +121,24 @@ export function labelOnce(orchDir, ticket, label, writeStatus, { appendEvent = n
 // permanently disarmed. Best-effort and never throws (mirrors labelOnce).
 // The marker is deleted ONLY on a confirmed removal so a transient API failure
 // is retried next tick.
-export function clearStalledLabel(orchDir, ticket, label, writeStatus, { onRemoved = null } = {}) {
+//
+// CTL-1078: accepts optional `now` seam (defaults to Date.now) for testability.
+// After REMOVAL_ESCALATION_THRESHOLD consecutive failures, activates a back-off
+// window (inRemovalBackoff) that short-circuits before calling removeLabel — the
+// storm-break. Escalates once with a log.error on the threshold trip.
+export function clearStalledLabel(orchDir, ticket, label, writeStatus, { onRemoved = null, now = () => Date.now() } = {}) {
   const base = labelMarkerBase(orchDir, ticket, label);
+  // CTL-1078: guard at entry — if we're in backoff, skip the doomed removeLabel.
+  if (inRemovalBackoff(orchDir, ticket, label, now())) {
+    return;
+  }
   try {
     const res = writeStatus.removeLabel(ticket, label);
     const finalize = (r) => {
       // undefined (test stub) treated as success; otherwise require removed:true.
       if (r === undefined || r?.removed) {
+        // Success: clear the failure counter and delete the once-markers.
+        clearRemovalFailures(orchDir, ticket, label);
         for (const suffix of [".applied", ".skipped"]) {
           const p = `${base}${suffix}`;
           if (existsSync(p)) { try { unlinkSync(p); } catch { /* best-effort */ } }
@@ -140,6 +151,15 @@ export function clearStalledLabel(orchDir, ticket, label, writeStatus, { onRemov
             log.warn({ ticket, label, err: err?.message }, "clearStalledLabel: onRemoved threw — continuing");
           }
         }
+      } else if (r?.removed === false) {
+        // CTL-1078: record failure and escalate once at threshold.
+        const { count } = recordRemovalFailure(orchDir, ticket, label, r.reason, now());
+        if (count === REMOVAL_ESCALATION_THRESHOLD) {
+          log.error(
+            { ticket, label, reason: r.reason, count },
+            "clearStalledLabel: removal failed threshold times — entering back-off (CTL-1078)"
+          );
+        }
       }
     };
     if (res && typeof res.then === "function") {
@@ -151,6 +171,68 @@ export function clearStalledLabel(orchDir, ticket, label, writeStatus, { onRemov
   } catch (err) {
     log.warn({ ticket, label, err: err.message }, "clearStalledLabel: threw — continuing tick");
   }
+}
+
+// ─── CTL-1078: per-(ticket, label) removal failure counter + backoff ───
+//
+// Mirrors the escalation-cooldown subsystem above but for the REMOVE path.
+// Counts consecutive removeLabel failures per (ticket, label) and activates a
+// back-off window (reusing ESCALATION_COOLDOWN_MS) after REMOVAL_ESCALATION_THRESHOLD
+// consecutive failures. This breaks the per-tick retry storm without requiring
+// the underlying auth issue to be resolved first.
+//
+// Marker lives under orchDir/.removal-failures/ (same rationale as
+// .escalation-cooldowns/ — outside workers/<T>/ to avoid manufacturing worker dirs).
+const REMOVAL_ESCALATION_THRESHOLD =
+  Number(process.env.REMOVAL_ESCALATION_THRESHOLD) || 3;
+
+function removalFailurePath(orchDir, ticket, label) {
+  return join(orchDir, ".removal-failures", `${ticket}-${label}.json`);
+}
+
+export function recordRemovalFailure(orchDir, ticket, label, reason, now) {
+  const p = removalFailurePath(orchDir, ticket, label);
+  const dir = join(orchDir, ".removal-failures");
+  let count = 1;
+  let firstFailedAt = now;
+  try {
+    try {
+      const existing = JSON.parse(readFileSync(p, "utf8"));
+      count = (existing?.count ?? 0) + 1;
+      firstFailedAt = existing?.firstFailedAt ?? now;
+    } catch {
+      // absent or malformed → start fresh
+    }
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(p, JSON.stringify({ ticket, label, count, firstFailedAt, lastReason: reason, lastFailedAt: now }));
+  } catch (err) {
+    log.warn({ ticket, label, err: err.message }, "label-guard: removal-failure marker write failed — continuing");
+    return { count };
+  }
+  return { count };
+}
+
+export function clearRemovalFailures(orchDir, ticket, label) {
+  const p = removalFailurePath(orchDir, ticket, label);
+  try {
+    if (existsSync(p)) unlinkSync(p);
+  } catch (err) {
+    log.warn({ ticket, label, err: err.message }, "label-guard: removal-failure marker delete failed — continuing");
+  }
+}
+
+export function inRemovalBackoff(orchDir, ticket, label, now) {
+  const p = removalFailurePath(orchDir, ticket, label);
+  let data;
+  try {
+    data = JSON.parse(readFileSync(p, "utf8"));
+  } catch {
+    return false;
+  }
+  if (typeof data?.count !== "number" || data.count < REMOVAL_ESCALATION_THRESHOLD) return false;
+  const lastFailedAt = data?.lastFailedAt ?? data?.firstFailedAt;
+  if (typeof lastFailedAt !== "number") return false;
+  return now - lastFailedAt < ESCALATION_COOLDOWN_MS;
 }
 
 // ─── CTL-638: per-(ticket, phase) escalation cool-down ───

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -13,6 +13,9 @@ import {
   recordEscalation,
   escalationCooldownPath,
   ESCALATION_COOLDOWN_MS,
+  recordRemovalFailure,
+  clearRemovalFailures,
+  inRemovalBackoff,
 } from "./label-guard.mjs";
 
 let orchDir;
@@ -509,5 +512,156 @@ describe("labelOnce CTL-936 operator-visible event", () => {
     expect(
       existsSync(join(orchDir, "workers", "CTL-936-D", ".linear-label-needs-human.skipped"))
     ).toBe(false);
+  });
+});
+
+// ─── CTL-1078: remove-path failure counter + storm-break ─────────────────────
+
+describe("recordRemovalFailure / clearRemovalFailures / inRemovalBackoff", () => {
+  test("inRemovalBackoff is false when no marker exists", () => {
+    expect(inRemovalBackoff(orchDir, "CTL-1", "needs-human", Date.now())).toBe(false);
+  });
+
+  test("recordRemovalFailure increments count and persists state", () => {
+    mkdirSync(join(orchDir, ".removal-failures"), { recursive: true });
+    const r1 = recordRemovalFailure(orchDir, "CTL-1", "needs-human", "transient", Date.now());
+    expect(r1.count).toBe(1);
+    const r2 = recordRemovalFailure(orchDir, "CTL-1", "needs-human", "transient", Date.now());
+    expect(r2.count).toBe(2);
+  });
+
+  test("clearRemovalFailures resets counter and disarms backoff", () => {
+    recordRemovalFailure(orchDir, "CTL-1", "needs-human", "transient", Date.now());
+    clearRemovalFailures(orchDir, "CTL-1", "needs-human");
+    expect(inRemovalBackoff(orchDir, "CTL-1", "needs-human", Date.now())).toBe(false);
+    // recordRemovalFailure after clear starts from 1 again
+    const r = recordRemovalFailure(orchDir, "CTL-1", "needs-human", "transient", Date.now());
+    expect(r.count).toBe(1);
+  });
+
+  test("inRemovalBackoff is true within cooldown window after threshold reached", () => {
+    const now = 1_000_000;
+    // Simulate threshold failures having been recorded and backoff marker written
+    recordRemovalFailure(orchDir, "CTL-1", "needs-human", "auth-error", now);
+    recordRemovalFailure(orchDir, "CTL-1", "needs-human", "auth-error", now);
+    recordRemovalFailure(orchDir, "CTL-1", "needs-human", "auth-error", now);
+    // Within the cooldown window → still in backoff
+    expect(inRemovalBackoff(orchDir, "CTL-1", "needs-human", now + 1000)).toBe(true);
+  });
+
+  test("inRemovalBackoff is false after cooldown window expires", () => {
+    const now = 1_000_000;
+    recordRemovalFailure(orchDir, "CTL-1", "needs-human", "auth-error", now);
+    recordRemovalFailure(orchDir, "CTL-1", "needs-human", "auth-error", now);
+    recordRemovalFailure(orchDir, "CTL-1", "needs-human", "auth-error", now);
+    // After the cooldown window expires → no longer in backoff
+    expect(inRemovalBackoff(orchDir, "CTL-1", "needs-human", now + ESCALATION_COOLDOWN_MS + 1)).toBe(false);
+  });
+
+  test("recordRemovalFailure swallows write errors (warn-only, no throw)", () => {
+    // Pass a non-writable orchDir path — should not throw
+    expect(() => recordRemovalFailure("/nonexistent/orchdir", "CTL-X", "lbl", "transient", Date.now())).not.toThrow();
+  });
+});
+
+describe("clearStalledLabel — CTL-1078 storm-break", () => {
+  function makeWorkerDir(ticket) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  test("storm-break: removeLabel not called after threshold consecutive failures within cooldown", () => {
+    makeWorkerDir("CTL-S1");
+    let calls = 0;
+    const ws = {
+      removeLabel: () => { calls++; return { removed: false, reason: "auth-error" }; },
+    };
+    const THRESHOLD = Number(process.env.REMOVAL_ESCALATION_THRESHOLD) || 3;
+    const now = () => Date.now();
+    // Drive to threshold
+    for (let i = 0; i < THRESHOLD; i++) {
+      clearStalledLabel(orchDir, "CTL-S1", "needs-human", ws, { now });
+    }
+    const callsAtThreshold = calls;
+    // Additional ticks within cooldown — removeLabel should NOT be called again
+    clearStalledLabel(orchDir, "CTL-S1", "needs-human", ws, { now });
+    clearStalledLabel(orchDir, "CTL-S1", "needs-human", ws, { now });
+    expect(calls).toBe(callsAtThreshold); // storm stopped
+  });
+
+  test("self-heal: two failures then success resets counter, no escalation", () => {
+    makeWorkerDir("CTL-S2");
+    let callCount = 0;
+    const responses = [
+      { removed: false, reason: "transient" },
+      { removed: false, reason: "transient" },
+      { removed: true },
+    ];
+    const ws = { removeLabel: () => { return responses[callCount++] ?? { removed: true }; } };
+    const now = () => Date.now();
+    clearStalledLabel(orchDir, "CTL-S2", "needs-human", ws, { now });
+    clearStalledLabel(orchDir, "CTL-S2", "needs-human", ws, { now });
+    clearStalledLabel(orchDir, "CTL-S2", "needs-human", ws, { now }); // success → counter reset
+    // After clear, new failures start from zero
+    const ws2 = { removeLabel: () => { calls2++; return { removed: false, reason: "transient" }; } };
+    let calls2 = 0;
+    clearStalledLabel(orchDir, "CTL-S2", "needs-human", ws2, { now });
+    expect(calls2).toBe(1); // fresh start — not immediately backed off
+  });
+
+  test("counter resets after success, subsequent failures start fresh", () => {
+    makeWorkerDir("CTL-S3");
+    const THRESHOLD = Number(process.env.REMOVAL_ESCALATION_THRESHOLD) || 3;
+    let phase = "fail";
+    let failCalls = 0;
+    const ws = {
+      removeLabel: () => {
+        if (phase === "fail") { failCalls++; return { removed: false, reason: "transient" }; }
+        return { removed: true };
+      },
+    };
+    const now = () => Date.now();
+    // Two failures then success
+    clearStalledLabel(orchDir, "CTL-S3", "needs-human", ws, { now });
+    clearStalledLabel(orchDir, "CTL-S3", "needs-human", ws, { now });
+    phase = "succeed";
+    clearStalledLabel(orchDir, "CTL-S3", "needs-human", ws, { now });
+    // Now re-fail — count starts at 1 not 2 (the prior two were reset)
+    phase = "fail";
+    failCalls = 0;
+    for (let i = 0; i < THRESHOLD - 1; i++) {
+      clearStalledLabel(orchDir, "CTL-S3", "needs-human", ws, { now });
+    }
+    // Haven't reached threshold yet — still calling removeLabel
+    expect(failCalls).toBe(THRESHOLD - 1);
+  });
+
+  test("transient tolerated under threshold: two failures then success → no storm-break", () => {
+    makeWorkerDir("CTL-S4");
+    const workerDir = join(orchDir, "workers", "CTL-S4");
+    writeFileSync(join(workerDir, ".linear-label-needs-human.applied"), "");
+    let calls = 0;
+    const responses = [
+      { removed: false, reason: "transient" },
+      { removed: false, reason: "transient" },
+      { removed: true },
+    ];
+    const ws = { removeLabel: () => responses[calls++] ?? { removed: true } };
+    const now = () => Date.now();
+    clearStalledLabel(orchDir, "CTL-S4", "needs-human", ws, { now });
+    clearStalledLabel(orchDir, "CTL-S4", "needs-human", ws, { now });
+    clearStalledLabel(orchDir, "CTL-S4", "needs-human", ws, { now });
+    expect(calls).toBe(3); // all three calls went through — marker cleared on 3rd
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(false);
+  });
+
+  test("never throws even if counter-file write errors (fail-open)", () => {
+    makeWorkerDir("CTL-S5");
+    // orchDir points to a file, not dir — writing .removal-failures/ inside it fails
+    const badOrchDir = join(orchDir, "workers", "CTL-S5", ".linear-label-needs-human.applied");
+    writeFileSync(badOrchDir, ""); // this is a FILE, not a dir
+    const ws = { removeLabel: () => ({ removed: false, reason: "transient" }) };
+    expect(() => clearStalledLabel(badOrchDir, "CTL-S5", "needs-human", ws, { now: () => Date.now() })).not.toThrow();
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -385,22 +385,28 @@ export function fetchTicketsBatch(identifiers, { exec = defaultBatchExec, cache 
   return result;
 }
 
-// fetchTicketLabels — current label-name list for one ticket, or null on any
-// failure. CTL-587: used by linear-write.mjs::applyLabel for the
-// verify-write-landed step that closes the silent-success gap in linearis
-// label writes (memory project_linear_transition_silent_success). The shape
-// `labels.nodes[].name` is the Linear API contract — confirmed by
-// orch-monitor/lib/linear.ts and pre-assign-migrations.sh. null is the
-// "did not land — retry next tick" signal callers interpret as verify-failed.
-export function fetchTicketLabels(identifier, { exec = defaultExec } = {}) {
-  const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
-  if (code !== 0) return null;
+// readTicketLabels — richer label reader returning { ok, labels, code, stderr }.
+// CTL-1078: allows callers (removeLabel) to classify auth vs transient failures
+// from the read-step stderr rather than collapsing all failures to null.
+// The shape `labels.nodes[].name` is the Linear API contract.
+export function readTicketLabels(identifier, { exec = defaultExec } = {}) {
+  const { code, stdout, stderr } = exec("linearis", ["issues", "read", identifier]);
+  if (code !== 0) return { ok: false, labels: null, code, stderr: stderr ?? "" };
   try {
     const node = JSON.parse(stdout);
-    return node?.labels?.nodes?.map((n) => n.name) ?? [];
+    const labels = node?.labels?.nodes?.map((n) => n.name) ?? [];
+    return { ok: true, labels };
   } catch {
-    return null;
+    return { ok: false, labels: null, code, stderr: stderr ?? "" };
   }
+}
+
+// fetchTicketLabels — back-compat wrapper around readTicketLabels. Returns the
+// label array on success or null on any failure. Existing callers unchanged.
+// CTL-587: used by linear-write.mjs::applyLabel for the verify-write-landed
+// step. null is the "did not land — retry next tick" signal.
+export function fetchTicketLabels(identifier, { exec = defaultExec } = {}) {
+  return readTicketLabels(identifier, { exec }).labels;
 }
 
 // classifyTicketResolution — CTL-671 3-valued phantom probe. Distinguishes a

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -7,6 +7,7 @@ import {
   runEligibleQuery,
   fetchTicketState,
   fetchTicketLabels,
+  readTicketLabels,
   fetchTicketRelations,
   fetchTicketsBatch,
   authHeader,
@@ -296,6 +297,51 @@ describe("fetchTicketLabels", () => {
     fetchTicketLabels("CTL-9", { exec });
     expect(calls[0].cmd).toBe("linearis");
     expect(calls[0].args).toEqual(["issues", "read", "CTL-9"]);
+  });
+});
+
+// CTL-1078 — readTicketLabels: richer shape { ok, labels, code, stderr }
+describe("readTicketLabels", () => {
+  test("success → { ok: true, labels: [...] }", () => {
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({
+        identifier: "CTL-9",
+        labels: { nodes: [{ name: "triaged" }, { name: "needs-human" }] },
+      }),
+      stderr: "",
+    });
+    expect(readTicketLabels("CTL-9", { exec })).toEqual({ ok: true, labels: ["triaged", "needs-human"] });
+  });
+
+  test("non-zero exit → { ok: false, labels: null, code, stderr }", () => {
+    const exec = () => ({ code: 1, stdout: "", stderr: "400 invalid_scope" });
+    const result = readTicketLabels("CTL-9", { exec });
+    expect(result.ok).toBe(false);
+    expect(result.labels).toBeNull();
+    expect(result.code).toBe(1);
+    expect(result.stderr).toBe("400 invalid_scope");
+  });
+
+  test("non-JSON stdout → { ok: false, labels: null }", () => {
+    const exec = () => ({ code: 0, stdout: "not-json", stderr: "" });
+    const result = readTicketLabels("CTL-9", { exec });
+    expect(result.ok).toBe(false);
+    expect(result.labels).toBeNull();
+  });
+
+  test("fetchTicketLabels back-compat: returns array on success", () => {
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({ labels: { nodes: [{ name: "blocked" }] } }),
+      stderr: "",
+    });
+    expect(fetchTicketLabels("CTL-9", { exec })).toEqual(["blocked"]);
+  });
+
+  test("fetchTicketLabels back-compat: returns null on failure", () => {
+    const exec = () => ({ code: 1, stdout: "", stderr: "boom" });
+    expect(fetchTicketLabels("CTL-9", { exec })).toBeNull();
   });
 });
 

--- a/plugins/dev/scripts/execution-core/linear-remint.mjs
+++ b/plugins/dev/scripts/execution-core/linear-remint.mjs
@@ -18,9 +18,11 @@ const DEFAULT_COOLDOWN_MS = 60_000;
 // loosely (message wording unverified against a live expired token; the
 // GraphQL contract is errors[].extensions.code === "AUTHENTICATION_ERROR"
 // with "Authentication required" messages; the oauth layer can serve 401).
-// Deliberately does NOT overlap isRateLimitError.
+// CTL-1078: broadened to also match OAuth scope rejections (400 invalid_scope,
+// 403 forbidden, insufficient_scope) which the CTL-835 incident produced.
+// Deliberately does NOT overlap isRateLimitError (no 429/rate-limit).
 export function isAuthError(stderr) {
-  return /authentication[ _-]?(required|error)|unauthorized|\b401\b/i.test(
+  return /authentication[ _-]?(required|error)|unauthorized|\b401\b|\b403\b|invalid[_ -]?scope|insufficient[_ -]?scope|forbidden/i.test(
     String(stderr ?? ""),
   );
 }

--- a/plugins/dev/scripts/execution-core/linear-remint.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-remint.test.mjs
@@ -40,6 +40,19 @@ describe("isAuthError", () => {
     expect(isAuthError(null)).toBe(false));
   test("does NOT match undefined", () =>
     expect(isAuthError(undefined)).toBe(false));
+  // CTL-1078: OAuth scope-rejection shapes
+  test("matches '400 invalid_scope'", () =>
+    expect(isAuthError("error: 400 invalid_scope")).toBe(true));
+  test("matches 'invalid_scope' standalone", () =>
+    expect(isAuthError("invalid_scope")).toBe(true));
+  test("matches 'forbidden'", () =>
+    expect(isAuthError("forbidden")).toBe(true));
+  test("matches 'HTTP 403'", () =>
+    expect(isAuthError("HTTP 403")).toBe(true));
+  test("matches 'insufficient_scope'", () =>
+    expect(isAuthError("insufficient_scope")).toBe(true));
+  test("does NOT match '429 Rate limit' (must not overlap isRateLimitError)", () =>
+    expect(isAuthError("429 Rate limit exceeded")).toBe(false));
 });
 
 // ── isBatchAuthError ──────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -9,9 +9,9 @@ import { fileURLToPath } from "node:url";
 import { linearKeyForPhase, TERMINAL_LINEAR_KEY } from "../lib/phase-fsm.mjs";
 import { getProjectConfig } from "./registry.mjs";
 import { log } from "./config.mjs";
-import { fetchTicketLabels, fetchTicketState } from "./linear-query.mjs";
+import { fetchTicketLabels, readTicketLabels, fetchTicketState } from "./linear-query.mjs";
 import { withBreaker } from "./linear-breaker.mjs";
-import { withAuthRemint } from "./linear-remint.mjs";
+import { withAuthRemint, isAuthError } from "./linear-remint.mjs";
 // CTL-758: the SHARED Linear terminal-state predicate ({Done,Canceled} — its OWN
 // set, NOT TERMINAL_LINEAR_KEY which is the transition KEY "done"). Gates the
 // backward-write guard below.
@@ -257,22 +257,35 @@ export function applyLabel({ ticket, label, exec = defaultExec }) {
 // This keeps the write inside linearis and preserves the issue's other labels.
 //
 // Idempotent: if the label is already absent we return { removed: true } without
-// a write. A failed read (fetchLabels returns non-array) is { removed: false,
-// reason: 'transient' } so the caller retries. Mirrors applyLabel's shape for
-// logging + failure classification. Never throws.
+// a write. A failed read is { removed: false, reason } where reason is
+// "auth-error" when the read's stderr matches isAuthError, otherwise "transient".
+// CTL-1078: injectable readLabels seam (defaults to readTicketLabels) returns the
+// richer { ok, labels, code, stderr } shape so the auth-vs-transient distinction
+// can be made. fetchLabels is accepted for back-compat (old test stubs). Never throws.
 export async function removeLabel(
   ticket,
   label,
-  { exec = defaultExec, fetchLabels = fetchTicketLabels } = {}
+  { exec = defaultExec, fetchLabels = null, readLabels = null } = {}
 ) {
+  // Resolve the reader: prefer readLabels (richer), wrap legacy fetchLabels,
+  // or default to readTicketLabels.
+  const reader = readLabels
+    ?? (fetchLabels
+      ? (t, opts) => {
+          const arr = fetchLabels(t, opts);
+          return arr === null
+            ? { ok: false, labels: null, code: 1, stderr: "" }
+            : { ok: true, labels: arr };
+        }
+      : readTicketLabels);
   try {
-    const current = fetchLabels(ticket, { exec });
-    if (!Array.isArray(current)) {
-      // Read failed (linearis non-zero / non-JSON) — cannot safely overwrite
-      // without knowing the current set, so retry next tick.
-      log.warn({ ticket, label, reason: "transient" }, "removeLabel: read failed");
-      return { removed: false, reason: "transient" };
+    const readResult = reader(ticket, { exec });
+    if (!readResult.ok) {
+      const reason = isAuthError(readResult.stderr ?? "") ? "auth-error" : "transient";
+      log.warn({ ticket, label, reason, stderr: readResult.stderr }, "removeLabel: read failed");
+      return { removed: false, reason };
     }
+    const current = readResult.labels;
     if (!current.includes(label)) {
       // Idempotent: the label is already gone, no write needed.
       return { removed: true };
@@ -525,5 +538,6 @@ export function classifyLabelFailure(stderr) {
   if (s.includes("incorrect team")) return "missing-label";
   if (s.includes("not exclusive")) return "exclusive-conflict";
   if (s.includes("Rate limit")) return "rate-limited";
+  if (isAuthError(s)) return "auth-error";
   return "transient";
 }

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -501,6 +501,17 @@ describe("classifyLabelFailure (CTL-834)", () => {
     expect(classifyLabelFailure("anything else")).toBe("transient");
     expect(classifyLabelFailure(undefined)).toBe("transient");
   });
+  // CTL-1078: auth/scope failures classify as auth-error, not transient
+  test("'400 invalid_scope' → 'auth-error'", () => {
+    expect(classifyLabelFailure("error: 400 invalid_scope")).toBe("auth-error");
+  });
+  test("'forbidden' → 'auth-error'", () => {
+    expect(classifyLabelFailure("forbidden")).toBe("auth-error");
+  });
+  test("auth-error does not steal 'not found' (ordering guard)", () => {
+    expect(classifyLabelFailure('Label "x" not found')).toBe("missing-label");
+    expect(classifyLabelFailure("LabelIds not exclusive child labels")).toBe("exclusive-conflict");
+  });
 });
 
 // CTL-704: applyTriageStatus — verified Todo→Triage write-back with pre/post state reads.
@@ -638,6 +649,27 @@ describe("removeLabel (CTL-549)", () => {
     const exec = (cmd, args) => { cmds.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
     const fetchLabels = () => null; // linearis read failed
     const result = await removeLabel("CTL-1", "needs-human/question", { exec, fetchLabels });
+    expect(result.removed).toBe(false);
+    expect(result.reason).toBe("transient");
+    expect(cmds).toHaveLength(0);
+  });
+
+  // CTL-1078: richer readLabels seam — auth-error vs transient classification
+  test("read failure with auth stderr (readLabels) → removed:false, reason:auth-error, no write", async () => {
+    const cmds = [];
+    const exec = (cmd, args) => { cmds.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const readLabels = () => ({ ok: false, labels: null, code: 1, stderr: "400 invalid_scope" });
+    const result = await removeLabel("CTL-1", "needs-human/question", { exec, readLabels });
+    expect(result.removed).toBe(false);
+    expect(result.reason).toBe("auth-error");
+    expect(cmds).toHaveLength(0);
+  });
+
+  test("read failure with non-auth stderr (readLabels) → removed:false, reason:transient, no write", async () => {
+    const cmds = [];
+    const exec = (cmd, args) => { cmds.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const readLabels = () => ({ ok: false, labels: null, code: 1, stderr: "network timeout" });
+    const result = await removeLabel("CTL-1", "needs-human/question", { exec, readLabels });
     expect(result.removed).toBe(false);
     expect(result.reason).toBe("transient");
     expect(cmds).toHaveLength(0);


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-12T15:20:30Z -->
<!-- Last updated: 2026-06-12T15:20:30Z -->
<!-- PR: #1894 -->
<!-- Previous commits: 594be0071580b852ac1a0e4366f7c630776ee6da -->

## Summary

Fixes the retraction-sweep label removal loop that was retrying indefinitely on permanent auth/scope failures. Two phases:

1. **Auth classification** — broadens `isAuthError` (linear-remint.mjs) to match OAuth scope-rejection shapes (`400 invalid_scope`, `403 forbidden`, `insufficient_scope`); adds an `auth-error` branch to `classifyLabelFailure` (linear-write.mjs); introduces `readTicketLabels` (linear-query.mjs) returning `{ ok, labels, code, stderr }` so `removeLabel` can distinguish auth vs transient from the read-step stderr.

2. **Storm-break** — adds a per-(ticket, label) removal failure counter in `label-guard.mjs` (`recordRemovalFailure` / `clearRemovalFailures` / `inRemovalBackoff`); wires a backoff guard into `clearStalledLabel` that short-circuits before calling `removeLabel` after `REMOVAL_ESCALATION_THRESHOLD` (default: 3) consecutive failures, emitting a single `log.error` escalation on the threshold trip and resetting on confirmed removal.

## Changes Made

### `plugins/dev/scripts/execution-core/linear-remint.mjs`
- Broadened `isAuthError` regex to match `\b403\b`, `invalid[_ -]?scope`, `insufficient[_ -]?scope`, and `forbidden` — covers the OAuth scope-rejection shapes from the CTL-835 incident.
- Explicitly excludes rate-limit (429) from the extended pattern.

### `plugins/dev/scripts/execution-core/linear-query.mjs`
- Added `readTicketLabels(identifier, opts)` returning `{ ok, labels, code, stderr }` — callers can now distinguish auth from transient based on the stderr text.
- Preserved `fetchTicketLabels` as a back-compat wrapper (`readTicketLabels(...).labels`) so existing callers are unaffected.

### `plugins/dev/scripts/execution-core/linear-write.mjs`
- `removeLabel`: replaced the `fetchLabels` seam with a `readLabels` seam (accepts legacy `fetchLabels` for back-compat) — on read failure classifies `auth-error` vs `transient` from stderr.
- `classifyLabelFailure`: added `isAuthError(s) → "auth-error"` branch (after existing `missing-label`/`exclusive-conflict`/`rate-limited` checks so those remain priority).

### `plugins/dev/scripts/execution-core/label-guard.mjs`
- Added `REMOVAL_ESCALATION_THRESHOLD` (env-overridable, default 3).
- New exports: `recordRemovalFailure`, `clearRemovalFailures`, `inRemovalBackoff` — per-(ticket, label) JSON counter stored under `orchDir/.removal-failures/`.
- `clearStalledLabel`: checks `inRemovalBackoff` at entry (short-circuit if in window); on `removed: false` calls `recordRemovalFailure` and emits `log.error` once at threshold; on `removed: true` calls `clearRemovalFailures` to reset.
- Accepts injectable `now` seam for deterministic testing.

## How to Verify It

- [x] All 282 tests pass across the 4 modified test files (`bun test label-guard.test.mjs linear-query.test.mjs linear-remint.test.mjs linear-write.test.mjs`) ✅
- [ ] In a daemon with an expired/scope-limited OAuth token, verify `removeLabel: read failed, reason: auth-error` appears (not `transient`) in daemon.log
- [ ] Verify that after 3 consecutive failures the storm-break activates — subsequent ticks log at `error` level once and do not call `removeLabel` again within the cooldown window
- [ ] Confirm `needs-human` labels still clear after token rotation (backoff resets on successful removal)

## Related Issues/PRs

- Fixes https://linear.app/getadva/issue/CTL-1078

## Changelog Entry

```
fix(dev): classify retraction-sweep auth/scope failures correctly and break per-tick storm (CTL-1078)
```

_Permanent auth/scope errors (400 invalid_scope, 403 forbidden) in the retraction-sweep label read path were misclassified as "transient", causing 100+ retry attempts per daemon tick with zero labels ever removed. Broadens `isAuthError` to match OAuth scope-rejection shapes, surfaces the richer `{ ok, labels, code, stderr }` shape from `readTicketLabels` so `removeLabel` can distinguish auth from transient failures, and adds a per-(ticket,label) failure counter + cooldown window (storm-break) that halts retries after 3 consecutive failures._

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-835
