### PR TITLE
test(dev): CTL-1080 — broker gc fixtures track TERMINAL_PHASE=teardown

### DIFF
--- a/plugins/dev/scripts/broker/gc-liveness.test.mjs
+++ b/plugins/dev/scripts/broker/gc-liveness.test.mjs
@@ -37,10 +37,10 @@ beforeEach(() => {
     status: "running",
     bg_job_id: "live-job",
   });
-  // Execution-core: all-terminal ticket (monitor-deploy done).
-  writeSignal(execCoreOrchDir, "CTL-701", "monitor-deploy", {
+  // Execution-core: all-terminal ticket (teardown done — TERMINAL_PHASE since the 10-phase pipeline).
+  writeSignal(execCoreOrchDir, "CTL-701", "teardown", {
     ticket: "CTL-701",
-    phase: "monitor-deploy",
+    phase: "teardown",
     status: "done",
   });
   // Execution-core: failed ticket — not in-flight.

--- a/plugins/dev/scripts/broker/gc-startup.test.mjs
+++ b/plugins/dev/scripts/broker/gc-startup.test.mjs
@@ -54,7 +54,7 @@ beforeEach(() => {
     bg_job_id: "live-job",
   });
   // Terminal tickets (worker dir exists, all signals terminal).
-  writeSignal(execCoreOrchDir, "CTL-701", "monitor-deploy", "done");
+  writeSignal(execCoreOrchDir, "CTL-701", "teardown", "done");
   writeSignal(execCoreOrchDir, "CTL-702", "verify", "failed");
   // CTL-999 has no dir at all → pure orphan.
 


### PR DESCRIPTION
Heals 3 pre-existing broker test failures on clean main (fixtures predate the teardown terminal phase). Test-only. Fixes CTL-1080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)