### PR TITLE
feat(dev): CTL-1081 — phase artifacts land where the gate looks for them

### DIFF
--- a/plugins/dev/scripts/__tests__/assert-thoughts-project.test.sh
+++ b/plugins/dev/scripts/__tests__/assert-thoughts-project.test.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Tests for lib/assert-thoughts-project.sh (CTL-1081 Phase 3).
+#
+# The helper checks that thoughts/shared symlink target contains
+# /repos/<catalyst.thoughts.directory>/. Fail-open when config or
+# symlink is absent (non-orchestrated runs unaffected).
+#
+# Run: bash plugins/dev/scripts/__tests__/assert-thoughts-project.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+HELPER="${REPO_ROOT}/plugins/dev/scripts/lib/assert-thoughts-project.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t assert-thoughts-project-test-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+assert_eq() {
+	local expected="$1" actual="$2" label="$3"
+	if [[ $expected == "$actual" ]]; then
+		pass "$label"
+	else
+		fail "$label — expected '$expected', got '$actual'"
+	fi
+}
+
+if [[ ! -f $HELPER ]]; then
+	echo "FATAL: helper not found — expected at $HELPER" >&2
+	exit 1
+fi
+
+# Build a fake thoughts repo layout:
+# ${SCRATCH}/repos/catalyst-workspace/shared/
+# ${SCRATCH}/repos/adva/shared/
+THOUGHTS_REPO="${SCRATCH}/repos"
+mkdir -p "${THOUGHTS_REPO}/catalyst-workspace/shared"
+mkdir -p "${THOUGHTS_REPO}/adva/shared"
+
+# ─── Test 1: correct symlink → exits 0, silent ───────────────────────────────
+
+echo "Test 1: correct symlink (catalyst-workspace) → exits 0 silently"
+PROJ1="${SCRATCH}/proj1"
+mkdir -p "${PROJ1}/.catalyst"
+cat >"${PROJ1}/.catalyst/config.json" <<EOF
+{
+  "catalyst": {
+    "thoughts": { "directory": "catalyst-workspace" },
+    "projectKey": "test-proj"
+  }
+}
+EOF
+mkdir -p "${PROJ1}/thoughts"
+ln -sf "${THOUGHTS_REPO}/catalyst-workspace/shared" "${PROJ1}/thoughts/shared"
+
+RC=0
+OUT="$(cd "$PROJ1" && bash "$HELPER" 2>&1)" || RC=$?
+assert_eq "0" "$RC" "correct symlink: exits 0"
+assert_eq "" "$OUT" "correct symlink: no output"
+
+# ─── Test 2: wrong symlink (adva) → exits non-zero, stderr names both paths ──
+
+echo ""
+echo "Test 2: wrong symlink (adva) → exits non-zero, stderr names both paths"
+PROJ2="${SCRATCH}/proj2"
+mkdir -p "${PROJ2}/.catalyst"
+cat >"${PROJ2}/.catalyst/config.json" <<EOF
+{
+  "catalyst": {
+    "thoughts": { "directory": "catalyst-workspace" },
+    "projectKey": "test-proj"
+  }
+}
+EOF
+mkdir -p "${PROJ2}/thoughts"
+ln -sf "${THOUGHTS_REPO}/adva/shared" "${PROJ2}/thoughts/shared"
+
+RC2=0
+OUT2="$(cd "$PROJ2" && bash "$HELPER" 2>&1)" || RC2=$?
+assert_eq "1" "$RC2" "wrong symlink: exits non-zero"
+if printf '%s\n' "$OUT2" | grep -q "catalyst-workspace"; then
+	pass "wrong symlink: stderr mentions expected directory (catalyst-workspace)"
+else
+	fail "wrong symlink: stderr did NOT mention expected directory (catalyst-workspace)"
+fi
+if printf '%s\n' "$OUT2" | grep -q "adva"; then
+	pass "wrong symlink: stderr mentions actual directory (adva)"
+else
+	fail "wrong symlink: stderr did NOT mention actual directory (adva)"
+fi
+
+# ─── Test 3: missing config → fails-open (exits 0, optional warning) ─────────
+
+echo ""
+echo "Test 3: missing .catalyst/config.json → fails-open (exits 0)"
+PROJ3="${SCRATCH}/proj3"
+mkdir -p "${PROJ3}/thoughts"
+ln -sf "${THOUGHTS_REPO}/catalyst-workspace/shared" "${PROJ3}/thoughts/shared"
+RC3=0
+(cd "$PROJ3" && bash "$HELPER" >/dev/null 2>&1) || RC3=$?
+assert_eq "0" "$RC3" "missing config: fails-open (exits 0)"
+
+# ─── Test 4: missing symlink → fails-open (exits 0) ──────────────────────────
+
+echo ""
+echo "Test 4: missing thoughts/shared symlink → fails-open (exits 0)"
+PROJ4="${SCRATCH}/proj4"
+mkdir -p "${PROJ4}/.catalyst"
+cat >"${PROJ4}/.catalyst/config.json" <<EOF
+{
+  "catalyst": {
+    "thoughts": { "directory": "catalyst-workspace" }
+  }
+}
+EOF
+RC4=0
+(cd "$PROJ4" && bash "$HELPER" >/dev/null 2>&1) || RC4=$?
+assert_eq "0" "$RC4" "missing symlink: fails-open (exits 0)"
+
+# ─── Test 5: missing thoughts.directory in config → fails-open ───────────────
+
+echo ""
+echo "Test 5: thoughts.directory absent in config → fails-open (exits 0)"
+PROJ5="${SCRATCH}/proj5"
+mkdir -p "${PROJ5}/.catalyst" "${PROJ5}/thoughts"
+cat >"${PROJ5}/.catalyst/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "test-proj"
+  }
+}
+EOF
+ln -sf "${THOUGHTS_REPO}/catalyst-workspace/shared" "${PROJ5}/thoughts/shared"
+RC5=0
+(cd "$PROJ5" && bash "$HELPER" >/dev/null 2>&1) || RC5=$?
+assert_eq "0" "$RC5" "no thoughts.directory in config: fails-open (exits 0)"
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "assert-thoughts-project: ${PASSES} passed, ${FAILURES} failed"
+if [[ $FAILURES -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -387,7 +387,7 @@ STATUS_PLAN=$(jq -r '.status'   "${TEST_DIR}/sysbash-plan.out" 2>/dev/null || ec
 ART_PLAN=$(jq -r '.artifact'    "${TEST_DIR}/sysbash-plan.out" 2>/dev/null || echo "")
 assert_eq "2" "$RC_PLAN" "5c plan: /bin/bash refuses when research doc absent (exit 2)"
 assert_eq "refused" "$STATUS_PLAN" "5c plan: status=refused under /bin/bash"
-assert_contains "$ART_PLAN" "thoughts/shared/research/" "5c plan: artifact spec is the non-empty research glob"
+assert_contains "$ART_PLAN" "thoughts/shared/research" "5c plan: artifact spec is the non-empty research glob"
 assert_not_contains "$(cat "${TEST_DIR}/sysbash-plan.err")" "bad substitution" "5c plan: no bad-substitution under /bin/bash"
 
 rm -f "${ORCH_DIR}/workers/CTL-100/phase-plan.json"
@@ -402,7 +402,7 @@ STATUS_IMPL=$(jq -r '.status'  "${TEST_DIR}/sysbash-impl.out" 2>/dev/null || ech
 ART_IMPL=$(jq -r '.artifact'   "${TEST_DIR}/sysbash-impl.out" 2>/dev/null || echo "")
 assert_eq "2" "$RC_IMPL" "5c implement: /bin/bash refuses when plan doc absent (exit 2)"
 assert_eq "refused" "$STATUS_IMPL" "5c implement: status=refused under /bin/bash"
-assert_contains "$ART_IMPL" "thoughts/shared/plans/" "5c implement: artifact spec is the non-empty plan glob"
+assert_contains "$ART_IMPL" "thoughts/shared/plans" "5c implement: artifact spec is the non-empty plan glob"
 assert_not_contains "$(cat "${TEST_DIR}/sysbash-impl.err")" "bad substitution" "5c implement: no bad-substitution under /bin/bash"
 
 # ─── Test 6: dispatcher resolves model from config (default + override paths)

--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -600,6 +600,54 @@ LINE=$(read_event_line)
 TTYPE=$(echo "$LINE" | jq -r '.attributes."catalyst.ticket.type"')
 assert_eq "feature" "$TTYPE" "catalyst.ticket.type present on failed event"
 
+# ─── CTL-1081 Phase 2: artifact self-check in emit-complete ──────────────────
+# For thoughts-producing phases (research, plan), --status complete is downgraded
+# to failed with reason=artifact_not_gate_visible when the own artifact is absent.
+# Non-thoughts phases and non-complete statuses are unaffected.
+
+echo ""
+echo "Test 39 (CTL-1081 P2): research + doc present → complete emits phase.research.complete"
+fresh_env t39
+PROJ_DIR="${TEST_DIR}/proj"
+mkdir -p "${PROJ_DIR}/thoughts/shared/research"
+touch "${PROJ_DIR}/thoughts/shared/research/2026-06-12-ctl-1081-x.md"
+(cd "$PROJ_DIR" && "$EMIT_SCRIPT" --phase research --ticket CTL-1081 --status complete >/dev/null 2>&1)
+LINE=$(read_event_line)
+EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"' 2>/dev/null || echo "")
+assert_eq "phase.research.complete.CTL-1081" "$EVENT_NAME" "doc present → complete event emitted"
+
+echo ""
+echo "Test 40 (CTL-1081 P2): research + doc absent → complete downgraded to failed with artifact_not_gate_visible"
+fresh_env t40
+PROJ_DIR="${TEST_DIR}/proj"
+mkdir -p "${PROJ_DIR}/thoughts/shared/research"
+(cd "$PROJ_DIR" && "$EMIT_SCRIPT" --phase research --ticket CTL-1081 --status complete >/dev/null 2>&1)
+LINE=$(read_event_line)
+EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"' 2>/dev/null || echo "")
+REASON=$(echo "$LINE" | jq -r '.body.payload.failure_reason' 2>/dev/null || echo "")
+assert_eq "phase.research.failed.CTL-1081" "$EVENT_NAME" "doc absent → failed event emitted"
+assert_eq "artifact_not_gate_visible" "$REASON" "failure_reason=artifact_not_gate_visible"
+
+echo ""
+echo "Test 41 (CTL-1081 P2): verify (non-thoughts phase) → complete unaffected"
+fresh_env t41
+(cd "${TEST_DIR}" && "$EMIT_SCRIPT" --phase verify --ticket CTL-1081 --status complete >/dev/null 2>&1)
+LINE=$(read_event_line)
+EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"' 2>/dev/null || echo "")
+assert_eq "phase.verify.complete.CTL-1081" "$EVENT_NAME" "non-thoughts phase: complete unaffected by self-check"
+
+echo ""
+echo "Test 42 (CTL-1081 P2): research + status failed → NOT altered by self-check"
+fresh_env t42
+PROJ_DIR="${TEST_DIR}/proj"
+mkdir -p "${PROJ_DIR}/thoughts/shared/research"
+(cd "$PROJ_DIR" && "$EMIT_SCRIPT" --phase research --ticket CTL-1081 --status failed --reason "tests red" >/dev/null 2>&1)
+LINE=$(read_event_line)
+EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"' 2>/dev/null || echo "")
+REASON=$(echo "$LINE" | jq -r '.body.payload.failure_reason' 2>/dev/null || echo "")
+assert_eq "phase.research.failed.CTL-1081" "$EVENT_NAME" "non-complete status: event name unchanged"
+assert_eq "tests red" "$REASON" "non-complete status: caller reason preserved"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/phase-artifact-gate.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-artifact-gate.test.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Contract tests for lib/phase-artifact-gate.sh (CTL-1081).
+#
+# Covers:
+#  1. match_thoughts_artifact: tail form, slug form (lowercase), slug form (uppercase),
+#     cross-ticket lookalike rejection, wrong-ticket rejection, no-match return.
+#  2. Spec map: prior_artifact_for_phase, own_thoughts_artifact_dir_for_phase.
+#  3. Contract / divergence: dispatch + emit-complete both source the lib;
+#     phase-research + phase-plan SKILLs reference match_thoughts_artifact.
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-artifact-gate.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+LIB="${REPO_ROOT}/plugins/dev/scripts/lib/phase-artifact-gate.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t phase-artifact-gate-test-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+assert_eq() {
+	local expected="$1" actual="$2" label="$3"
+	if [[ $expected == "$actual" ]]; then
+		pass "$label"
+	else
+		fail "$label — expected '$expected', got '$actual'"
+	fi
+}
+
+assert_contains() {
+	local haystack="$1" needle="$2" label="$3"
+	if printf '%s\n' "$haystack" | grep -qF "$needle"; then
+		pass "$label"
+	else
+		fail "$label — output did not contain '$needle'"
+	fi
+}
+
+assert_not_contains() {
+	local haystack="$1" needle="$2" label="$3"
+	if printf '%s\n' "$haystack" | grep -qF "$needle"; then
+		fail "$label — output unexpectedly contained '$needle'"
+	else
+		pass "$label"
+	fi
+}
+
+if [[ ! -f $LIB ]]; then
+	echo "FATAL: lib not found — expected at $LIB" >&2
+	exit 1
+fi
+
+# shellcheck source=../lib/phase-artifact-gate.sh
+source "$LIB"
+
+# ─── Build fixture dir ────────────────────────────────────────────────────────
+
+FIXTURES="${SCRATCH}/thoughts/shared/research"
+mkdir -p "$FIXTURES"
+touch "${FIXTURES}/2026-06-12-ctl-1081.md"                         # tail form
+touch "${FIXTURES}/2026-06-12-ctl-1081-per-image-ai-captions.md"   # lowercase slug
+touch "${FIXTURES}/2026-06-12-CTL-1081-foo.md"                     # uppercase slug
+touch "${FIXTURES}/2026-06-12-ctl-10812-bar.md"                    # cross-ticket lookalike
+touch "${FIXTURES}/2026-06-12-ctl-999.md"                          # different ticket
+
+echo "Test 1: match_thoughts_artifact returns 0 and prints the three valid fixtures"
+OUT="$(match_thoughts_artifact "$FIXTURES" "CTL-1081")"
+RC=$?
+assert_eq "0" "$RC" "return code is 0 (at least one match)"
+assert_contains "$OUT" "2026-06-12-ctl-1081.md"                       "output includes tail form"
+assert_contains "$OUT" "2026-06-12-ctl-1081-per-image-ai-captions.md" "output includes lowercase slug"
+assert_contains "$OUT" "2026-06-12-CTL-1081-foo.md"                   "output includes uppercase slug"
+
+echo ""
+echo "Test 2: match_thoughts_artifact excludes cross-ticket lookalike and wrong-ticket file"
+assert_not_contains "$OUT" "2026-06-12-ctl-10812-bar.md" "cross-ticket lookalike NOT in output"
+assert_not_contains "$OUT" "2026-06-12-ctl-999.md"       "wrong-ticket file NOT in output"
+
+echo ""
+echo "Test 3: match_thoughts_artifact returns non-zero when no match"
+EMPTY_DIR="${SCRATCH}/empty"
+mkdir -p "$EMPTY_DIR"
+OUT3="$(match_thoughts_artifact "$EMPTY_DIR" "CTL-9999" 2>/dev/null || echo "")"
+RC3=0
+match_thoughts_artifact "$EMPTY_DIR" "CTL-9999" >/dev/null 2>&1 || RC3=$?
+assert_eq "1" "$RC3" "no-match returns non-zero"
+assert_eq "" "$OUT3" "no-match output is empty"
+
+echo ""
+echo "Test 4: prior_artifact_for_phase spec map"
+assert_eq "glob:thoughts/shared/research" "$(prior_artifact_for_phase plan)"      "plan → research dir"
+assert_eq "glob:thoughts/shared/plans"    "$(prior_artifact_for_phase implement)" "implement → plans dir"
+assert_eq "signal:triage.json"            "$(prior_artifact_for_phase research)"  "research → triage signal"
+assert_eq ""                              "$(prior_artifact_for_phase triage)"    "triage → empty (entry point)"
+
+echo ""
+echo "Test 5: own_thoughts_artifact_dir_for_phase"
+assert_eq "thoughts/shared/research" "$(own_thoughts_artifact_dir_for_phase research)" "research → research dir"
+assert_eq "thoughts/shared/plans"    "$(own_thoughts_artifact_dir_for_phase plan)"      "plan → plans dir"
+assert_eq ""                         "$(own_thoughts_artifact_dir_for_phase verify)"    "verify → empty (not thoughts-producing)"
+assert_eq ""                         "$(own_thoughts_artifact_dir_for_phase implement)" "implement → empty (not thoughts-producing)"
+
+echo ""
+echo "Test 6 (divergence): phase-agent-dispatch sources lib/phase-artifact-gate.sh"
+DISPATCH="${REPO_ROOT}/plugins/dev/scripts/phase-agent-dispatch"
+if grep -qF 'lib/phase-artifact-gate.sh' "$DISPATCH"; then
+	pass "phase-agent-dispatch sources lib/phase-artifact-gate.sh"
+else
+	fail "phase-agent-dispatch does NOT source lib/phase-artifact-gate.sh"
+fi
+
+echo ""
+echo "Test 7 (divergence): phase-agent-emit-complete sources lib/phase-artifact-gate.sh"
+EMIT="${REPO_ROOT}/plugins/dev/scripts/phase-agent-emit-complete"
+if grep -qF 'lib/phase-artifact-gate.sh' "$EMIT"; then
+	pass "phase-agent-emit-complete sources lib/phase-artifact-gate.sh"
+else
+	fail "phase-agent-emit-complete does NOT source lib/phase-artifact-gate.sh"
+fi
+
+echo ""
+echo "Test 8 (divergence/contract): phase-research SKILL references match_thoughts_artifact"
+SKILL_RESEARCH="${REPO_ROOT}/plugins/dev/skills/phase-research/SKILL.md"
+if [[ -f $SKILL_RESEARCH ]] && grep -qF 'match_thoughts_artifact' "$SKILL_RESEARCH"; then
+	pass "phase-research SKILL references match_thoughts_artifact"
+else
+	fail "phase-research SKILL does NOT reference match_thoughts_artifact"
+fi
+
+echo ""
+echo "Test 9 (divergence/contract): phase-plan SKILL references match_thoughts_artifact"
+SKILL_PLAN="${REPO_ROOT}/plugins/dev/skills/phase-plan/SKILL.md"
+if [[ -f $SKILL_PLAN ]] && grep -qF 'match_thoughts_artifact' "$SKILL_PLAN"; then
+	pass "phase-plan SKILL references match_thoughts_artifact"
+else
+	fail "phase-plan SKILL does NOT reference match_thoughts_artifact"
+fi
+
+echo ""
+echo "Test 10 (contract): slugged writer name matches the gate"
+SLUG_DIR="${SCRATCH}/thoughts/shared/plans"
+mkdir -p "$SLUG_DIR"
+touch "${SLUG_DIR}/2026-06-12-ctl-1081-phase-artifact-gate-contracts.md"
+OUT10="$(match_thoughts_artifact "$SLUG_DIR" "CTL-1081")"
+RC10=$?
+assert_eq "0" "$RC10" "slugged plan doc satisfies the gate (writer↔gate agreement)"
+assert_contains "$OUT10" "phase-artifact-gate-contracts.md" "slugged plan doc found by matcher"
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "phase-artifact-gate: ${PASSES} passed, ${FAILURES} failed"
+if [[ $FAILURES -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/__tests__/phase-skill-globs.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-skill-globs.test.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
-# Verify phase-plan and phase-research SKILLs use the same glob-relax pattern
-# as the dispatcher (CTL-494 Phase 3). They share the same defense-in-depth
-# artifact confirmation logic and must accept both filename conventions
-# (lowercase-tail and uppercase + descriptive suffix).
+# Verify phase-plan and phase-research SKILLs route artifact matching through
+# the shared lib/phase-artifact-gate.sh (CTL-1081) and preserve the failure-reason
+# strings that the orchestrator's wake-handler depends on.
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
@@ -41,13 +40,10 @@ for f in "$PHASE_PLAN" "$PHASE_RESEARCH"; do
   fi
 done
 
-echo "Test: phase-plan SKILL has the relaxed glob pattern at both sites"
-# Site 1: research-doc check. Site 2: plan-doc check. Both should reference
-# the wider *${TICKET}*.md pattern and nocaseglob fallback.
-assert_count_at_least "$PHASE_PLAN" '\*\$\{TICKET\}\*\.md' 2 \
-  "phase-plan SKILL uses *\${TICKET}*.md pattern at >= 2 sites"
-assert_count_at_least "$PHASE_PLAN" 'nocaseglob' 2 \
-  "phase-plan SKILL uses nocaseglob fallback at >= 2 sites"
+echo "Test: phase-plan SKILL routes through match_thoughts_artifact (CTL-1081)"
+# The inline 3-step glob is replaced — both artifact checks now use the shared matcher.
+assert_count_at_least "$PHASE_PLAN" 'match_thoughts_artifact' 2 \
+  "phase-plan SKILL uses match_thoughts_artifact at >= 2 sites"
 # Failure-reason names must be preserved so the orchestrator's wake-handler
 # can still distinguish the two kinds of artifact miss.
 assert_grep "$PHASE_PLAN" 'prior_artifact_missing:research_doc' \
@@ -56,11 +52,9 @@ assert_grep "$PHASE_PLAN" 'plan_doc_not_written' \
   "phase-plan SKILL preserves plan_doc_not_written failure reason"
 
 echo ""
-echo "Test: phase-research SKILL has the relaxed glob pattern"
-assert_grep "$PHASE_RESEARCH" '\*\$\{TICKET\}\*\.md' \
-  "phase-research SKILL uses *\${TICKET}*.md pattern"
-assert_grep "$PHASE_RESEARCH" 'nocaseglob' \
-  "phase-research SKILL uses nocaseglob fallback"
+echo "Test: phase-research SKILL routes through match_thoughts_artifact (CTL-1081)"
+assert_grep "$PHASE_RESEARCH" 'match_thoughts_artifact' \
+  "phase-research SKILL uses match_thoughts_artifact"
 assert_grep "$PHASE_RESEARCH" 'research_doc_not_written' \
   "phase-research SKILL preserves research_doc_not_written failure reason"
 

--- a/plugins/dev/scripts/lib/assert-thoughts-project.sh
+++ b/plugins/dev/scripts/lib/assert-thoughts-project.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# lib/assert-thoughts-project.sh — assert thoughts/shared belongs to this project (CTL-1081).
+#
+# Verifies that the thoughts/shared symlink target contains /repos/<directory>/
+# where <directory> is read from the nearest ancestor .catalyst/config.json's
+# catalyst.thoughts.directory field.
+#
+# Exit codes:
+#   0  — assertion passed (or cannot be determined — fail-open)
+#   1  — mismatch (wrong project's thoughts root); stderr names both paths
+#
+# Usage: source or execute from the worktree cwd.
+# Bash-3.2 safe.
+
+set -uo pipefail
+
+_resolve_config_dir() {
+	command -v jq >/dev/null 2>&1 || return 0
+	local dir
+	dir="$(pwd)"
+	while [[ $dir != "/" ]]; do
+		if [[ -f "${dir}/.catalyst/config.json" ]]; then
+			echo "$dir"
+			return 0
+		fi
+		dir="$(dirname "$dir")"
+	done
+}
+
+CONFIG_DIR="$(_resolve_config_dir)"
+if [[ -z "$CONFIG_DIR" ]]; then
+	# No config found — fail-open (non-orchestrated run or missing config).
+	exit 0
+fi
+
+THOUGHTS_DIR="$(jq -r '.catalyst.thoughts.directory // empty' \
+	"${CONFIG_DIR}/.catalyst/config.json" 2>/dev/null || true)"
+if [[ -z "$THOUGHTS_DIR" ]]; then
+	# thoughts.directory not configured — fail-open.
+	exit 0
+fi
+
+# Resolve the symlink target of thoughts/shared (relative to the worktree cwd).
+SYMLINK_TARGET=""
+if [[ -L "thoughts/shared" ]]; then
+	SYMLINK_TARGET="$(readlink "thoughts/shared" 2>/dev/null || true)"
+elif [[ -L "${CONFIG_DIR}/thoughts/shared" ]]; then
+	SYMLINK_TARGET="$(readlink "${CONFIG_DIR}/thoughts/shared" 2>/dev/null || true)"
+fi
+
+if [[ -z "$SYMLINK_TARGET" ]]; then
+	# Symlink absent or unresolvable — fail-open.
+	exit 0
+fi
+
+# The expected layout segment inside the target path.
+EXPECTED_SEGMENT="/repos/${THOUGHTS_DIR}/"
+
+if printf '%s' "$SYMLINK_TARGET" | grep -qF "$EXPECTED_SEGMENT"; then
+	# Assertion passed — the symlink points to the right project's thoughts tree.
+	exit 0
+fi
+
+# Extract the actual segment for the error message.
+ACTUAL_SEGMENT="$(printf '%s' "$SYMLINK_TARGET" | sed -n 's|.*/repos/\([^/]*\)/.*|\1|p')"
+if [[ -z "$ACTUAL_SEGMENT" ]]; then
+	ACTUAL_SEGMENT="$SYMLINK_TARGET"
+fi
+
+echo "assert-thoughts-project: thoughts/shared points to wrong project" >&2
+echo "  expected: …/repos/${THOUGHTS_DIR}/shared" >&2
+echo "  actual:   ${SYMLINK_TARGET} (segment: ${ACTUAL_SEGMENT})" >&2
+exit 1

--- a/plugins/dev/scripts/lib/phase-artifact-gate.sh
+++ b/plugins/dev/scripts/lib/phase-artifact-gate.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# lib/phase-artifact-gate.sh — shared phase-artifact gate contract (CTL-1081).
+#
+# Exposes three functions:
+#   prior_artifact_for_phase <phase>
+#       Gate spec for the artifact the PRIOR phase produces (consumer view).
+#       Returns "signal:<file>", "glob:<dir>", or "" (entry point).
+#
+#   own_thoughts_artifact_dir_for_phase <phase>
+#       Directory where THIS phase writes its thoughts artifact (producer view).
+#       Returns a directory path ("thoughts/shared/research", etc.) or "".
+#
+#   match_thoughts_artifact <dir> <ticket>
+#       Slug-tolerant, boundary-safe, case-insensitive matcher.
+#       Prints matching filenames; returns 0 if at least one match, 1 otherwise.
+#       Bash-3.2 safe (no mapfile, no ${var,,}).
+#
+# Source this file; do NOT execute it. It has no side-effects on sourcing.
+
+# Guard against double-sourcing.
+if [[ -n "${_PHASE_ARTIFACT_GATE_LOADED:-}" ]]; then
+	return 0
+fi
+_PHASE_ARTIFACT_GATE_LOADED=1
+
+# ─── Gate spec map ─────────────────────────────────────────────────────────────
+
+# prior_artifact_for_phase <phase>
+#
+# Gate spec: what the prior phase must have produced before this phase can start.
+#   "signal:<file>"  → a signal file under ${ORCH_DIR}/workers/<TICKET>/
+#   "glob:<dir>"     → a thoughts artifact under <dir>/ (evaluated via match_thoughts_artifact)
+#   ""               → this phase is the pipeline entry point (no prior artifact)
+prior_artifact_for_phase() {
+	case "$1" in
+	triage) echo "" ;;
+	research) echo "signal:triage.json" ;;
+	plan) echo "glob:thoughts/shared/research" ;;
+	implement) echo "glob:thoughts/shared/plans" ;;
+	verify) echo "signal:phase-implement.json" ;;
+	review) echo "signal:verify.json" ;;
+	pr) echo "signal:review.json" ;;
+	monitor-merge) echo "signal:phase-pr.json" ;;
+	monitor-deploy) echo "signal:phase-monitor-merge.json" ;;
+	remediate) echo "signal:verify.json" ;;
+	teardown) echo "signal:phase-monitor-deploy.json" ;;
+	*) echo "" ;;
+	esac
+}
+
+# own_thoughts_artifact_dir_for_phase <phase>
+#
+# Directory where this phase writes its own thoughts artifact (the producer view).
+# Returns "" for phases that do not produce thoughts artifacts.
+own_thoughts_artifact_dir_for_phase() {
+	case "$1" in
+	research) echo "thoughts/shared/research" ;;
+	plan) echo "thoughts/shared/plans" ;;
+	*) echo "" ;;
+	esac
+}
+
+# ─── Slug-tolerant, boundary-safe, case-insensitive matcher ────────────────────
+
+# match_thoughts_artifact <dir> <ticket>
+#
+# Finds thoughts artifacts in <dir> that belong to <ticket>.
+# Accepts both the tail form (…-ctl-1081.md) and the slug form (…-ctl-1081-<slug>.md).
+# The word-boundary guard (-${lc}. and -${lc}-) rejects cross-ticket lookalikes
+# (e.g. ctl-10812 does NOT satisfy a ctl-1081 gate). nocaseglob absorbs the
+# uppercase-ticket convention (CTL-1081 writer, ctl-1081 glob) in one step.
+# Bash-3.2 safe: uses tr for lowercasing, no mapfile.
+match_thoughts_artifact() {
+	local dir="$1" ticket="$2" lc
+	lc="$(printf '%s' "$ticket" | tr '[:upper:]' '[:lower:]')"
+
+	# nullglob: missing dir → empty array, no error.
+	# nocaseglob: absorbs uppercase ticket names in one pass.
+	shopt -s nullglob nocaseglob
+	# shellcheck disable=SC2206
+	local matches=( "${dir}"/*-"${lc}".md "${dir}"/*-"${lc}"-*.md )
+	shopt -u nullglob nocaseglob
+
+	if [[ ${#matches[@]} -gt 0 ]]; then
+		printf '%s\n' "${matches[@]}"
+		return 0
+	fi
+	return 1
+}

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -80,6 +80,8 @@ source "${SCRIPT_DIR}/lib/resume.sh"
 source "${SCRIPT_DIR}/lib/phase-sequence.sh"
 # shellcheck source=lib/worktree-rebase.sh
 source "${SCRIPT_DIR}/lib/worktree-rebase.sh"
+# shellcheck source=lib/phase-artifact-gate.sh
+source "${SCRIPT_DIR}/lib/phase-artifact-gate.sh"
 
 die() {
 	echo "phase-agent-dispatch: $*" >&2
@@ -111,27 +113,7 @@ phase_default_turn_cap() {
 	esac
 }
 
-# Prior-phase artifact lookup. Returns one of two shapes:
-#   "signal:<filename>"   → file inside ${ORCH_DIR}/workers/<TICKET>/
-#   "glob:<pattern>"      → glob pattern (used for thoughts/ artifacts where
-#                           the filename includes a date)
-# Empty output means this phase is the entry point — no prior artifact.
-prior_artifact_for_phase() {
-	case "$1" in
-	triage) echo "" ;;
-	research) echo "signal:triage.json" ;;
-	plan) echo "glob:thoughts/shared/research/*-${TICKET_LC}.md" ;;
-	implement) echo "glob:thoughts/shared/plans/*-${TICKET_LC}.md" ;;
-	verify) echo "signal:phase-implement.json" ;;
-	review) echo "signal:verify.json" ;;
-	pr) echo "signal:review.json" ;;
-	monitor-merge) echo "signal:phase-pr.json" ;;
-	monitor-deploy) echo "signal:phase-monitor-merge.json" ;;
-	remediate) echo "signal:verify.json" ;; # CTL-653: reads verify's findings[], NOT review.json
-	teardown) echo "signal:phase-monitor-deploy.json" ;;
-	*) echo "" ;;
-	esac
-}
+# prior_artifact_for_phase is now in lib/phase-artifact-gate.sh (CTL-1081).
 
 # ─── Parse args ─────────────────────────────────────────────────────────────
 
@@ -215,9 +197,6 @@ fi
 if [[ ! $TICKET =~ ^[A-Za-z][A-Za-z0-9_]*-[0-9]+$ ]]; then
 	die "invalid --ticket: $TICKET (expected e.g. CTL-100)"
 fi
-# CTL-1075: portable bash-3 lowercase (replaces bash-4 ${TICKET,,}, which is a
-# "bad substitution" under macOS /bin/bash 3.2 and silently empties the gate spec).
-TICKET_LC="$(printf '%s' "$TICKET" | tr '[:upper:]' '[:lower:]')"
 if [[ $PHASE == *.* ]]; then
 	die "invalid --phase: $PHASE (dots are reserved for event name parsing)"
 fi
@@ -424,29 +403,12 @@ if [[ -n $ARTIFACT_SPEC ]]; then
 		[[ -f $ARTIFACT_FILE ]] || ARTIFACT_OK=0
 		;;
 	glob:*)
-		# CTL-494: two-step match. The lowercase-ticket-at-tail form
-		# (phase-plan prose convention) is tried first; on miss, fall back to
-		# a wider pattern that accepts the canonical create-plan form
-		# (uppercase ticket + descriptive suffix). Case-insensitive nocaseglob
-		# is the final fallback. The ticket is still required to appear in the
-		# filename, so cross-ticket lookalikes do not satisfy this gate.
-		PATTERN="${ARTIFACT_SPEC#glob:}"
-		shopt -s nullglob
-		# shellcheck disable=SC2206  # word-splitting is required for glob expansion
-		MATCHES=($PATTERN)
-		if [[ ${#MATCHES[@]} -eq 0 ]]; then
-			WIDE="${PATTERN/%-${TICKET_LC}.md/*${TICKET}*.md}"
-			# shellcheck disable=SC2206
-			MATCHES=($WIDE)
-			if [[ ${#MATCHES[@]} -eq 0 ]]; then
-				shopt -s nocaseglob
-				# shellcheck disable=SC2206
-				MATCHES=($WIDE)
-				shopt -u nocaseglob
-			fi
-		fi
-		shopt -u nullglob
-		[[ ${#MATCHES[@]} -gt 0 ]] || ARTIFACT_OK=0
+		# CTL-1081: delegate to the shared slug-tolerant matcher (lib/phase-artifact-gate.sh).
+		# The spec carries a directory ("glob:thoughts/shared/research") instead of a
+		# fragile glob pattern; match_thoughts_artifact handles tail form, slug form, and
+		# cross-ticket lookalike rejection in one boundary-safe, case-insensitive pass.
+		GATE_DIR="${ARTIFACT_SPEC#glob:}"
+		match_thoughts_artifact "$GATE_DIR" "$TICKET" >/dev/null || ARTIFACT_OK=0
 		;;
 	esac
 fi

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -62,6 +62,8 @@ SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 
 # shellcheck source=lib/canonical-event.sh
 source "${SCRIPT_DIR}/lib/canonical-event.sh"
+# shellcheck source=lib/phase-artifact-gate.sh
+source "${SCRIPT_DIR}/lib/phase-artifact-gate.sh"
 
 CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
 EVENTS_DIR="${CATALYST_DIR}/events"
@@ -216,6 +218,27 @@ if [[ -n ${CATALYST_GENERATION:-} && -n $ORCH_DIR ]]; then
 				echo "phase-agent-emit-complete: stale-generation-bow-out — mine=${CATALYST_GENERATION} < signal=${_SIG_GEN} for ${TICKET}/${PHASE}; not emitting" >&2
 				exit 0
 			fi
+		fi
+	fi
+fi
+
+# ─── CTL-1081 Phase 2: artifact self-check (thoughts-producing phases only) ──
+#
+# If this phase is supposed to have written a thoughts artifact (research, plan)
+# and we're about to report 'complete', verify the artifact is actually gate-visible
+# from cwd before allowing the complete. On miss, downgrade to failed with reason
+# artifact_not_gate_visible so the revive loop can re-dispatch.
+# Fail-open: any matcher error allows the original complete (a matcher bug must not
+# permanently stall the pipeline).
+if [[ $STATUS == complete ]]; then
+	_OWN_DIR=""
+	_OWN_DIR="$(own_thoughts_artifact_dir_for_phase "$PHASE" 2>/dev/null || true)"
+	if [[ -n $_OWN_DIR ]]; then
+		if ! match_thoughts_artifact "$_OWN_DIR" "$TICKET" >/dev/null 2>&1; then
+			echo "phase-agent-emit-complete: refusing 'complete' for ${TICKET}/${PHASE}: own artifact not gate-visible" >&2
+			echo "  expected: ${_OWN_DIR}/*-${TICKET}*.md   cwd: $(pwd)" >&2
+			STATUS="failed"
+			REASON="artifact_not_gate_visible"
 		fi
 	fi
 fi

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -84,30 +84,18 @@ jq --arg ts "$TS" --arg sid "${CATALYST_SESSION_ID:-}" '
 ' "$SIGNAL_FILE" > "$TMP" \
   && mv "$TMP" "$SIGNAL_FILE"
 
-# Prior-phase artifact: the research document. Dispatcher gates this via glob;
-# we re-read it here so we can fail loudly on race. Two-step match (CTL-494)
-# mirrors the dispatcher: lowercase-tail form first, wider *${TICKET}*.md
-# fallback with nocaseglob to also accept the canonical create-plan
-# filename convention (uppercase ticket + descriptive suffix).
-shopt -s nullglob
-RESEARCH_MATCHES=( thoughts/shared/research/*-${TICKET,,}.md )
-if [[ ${#RESEARCH_MATCHES[@]} -eq 0 ]]; then
-  RESEARCH_MATCHES=( thoughts/shared/research/*${TICKET}*.md )
-  if [[ ${#RESEARCH_MATCHES[@]} -eq 0 ]]; then
-    shopt -s nocaseglob
-    RESEARCH_MATCHES=( thoughts/shared/research/*${TICKET}*.md )
-    shopt -u nocaseglob
-  fi
-fi
-shopt -u nullglob
-if [[ ${#RESEARCH_MATCHES[@]} -eq 0 ]]; then
+# Prior-phase artifact: the research document. Dispatcher gates this via
+# match_thoughts_artifact (lib/phase-artifact-gate.sh, CTL-1081); re-read
+# here so we can fail loudly on race.
+source "${PLUGIN_ROOT}/scripts/lib/phase-artifact-gate.sh"
+RESEARCH_DOC="$(match_thoughts_artifact thoughts/shared/research "$TICKET" | tail -1 || true)"
+if [[ -z "$RESEARCH_DOC" || ! -f "$RESEARCH_DOC" ]]; then
   echo "phase-plan: research document missing for $TICKET" >&2
   "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
     --phase "$PHASE" --ticket "$TICKET" --status failed \
     --reason "prior_artifact_missing:research_doc"
   exit 1
 fi
-RESEARCH_DOC="${RESEARCH_MATCHES[-1]}"
 ```
 
 <!-- Linear status is written by the coordinator (CTL-558): the execution-core
@@ -136,33 +124,30 @@ research document as the input and operate non-interactively:
    directly-matching entries under `thoughts/shared/learnings/`, and let those
    prior problem→solution notes inform the plan (the heavy grep lens lives in
    phase-research — don't re-run it here).
-2. Invoke `/catalyst-dev:create-plan` against the research document. When that skill
+2. Assert the `thoughts/` root belongs to this project before writing (CTL-1081):
+   ```bash
+   bash "${PLUGIN_ROOT}/scripts/lib/assert-thoughts-project.sh" || {
+     "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+       --phase "$PHASE" --ticket "$TICKET" --status failed \
+       --reason "wrong_project_thoughts_root"
+     exit 1
+   }
+   ```
+3. Invoke `/catalyst-dev:create-plan` against the research document. When that skill
    asks for clarifications, answer from the research document; if the research
    document is silent on a point, default to the most conservative reasonable choice
    and record the assumption in the plan's "Open questions" section.
-3. Confirm the artifact exists. Two-step match (CTL-494) — try lowercase-tail
-   first, then the wider `*${TICKET}*.md` pattern with `nocaseglob` fallback
-   so canonical create-plan filenames (uppercase ticket + descriptive
-   suffix) are accepted alongside the phase-plan prose convention:
+4. Confirm the artifact exists using the shared matcher (CTL-1081):
    ```bash
-   shopt -s nullglob
-   PLAN_MATCHES=( thoughts/shared/plans/*-${TICKET,,}.md )
-   if [[ ${#PLAN_MATCHES[@]} -eq 0 ]]; then
-     PLAN_MATCHES=( thoughts/shared/plans/*${TICKET}*.md )
-     if [[ ${#PLAN_MATCHES[@]} -eq 0 ]]; then
-       shopt -s nocaseglob
-       PLAN_MATCHES=( thoughts/shared/plans/*${TICKET}*.md )
-       shopt -u nocaseglob
-     fi
-   fi
-   shopt -u nullglob
-   [[ ${#PLAN_MATCHES[@]} -gt 0 ]] || {
+   # source already called above in the prelude (idempotent guard in the lib).
+   source "${PLUGIN_ROOT}/scripts/lib/phase-artifact-gate.sh"
+   PLAN_DOC="$(match_thoughts_artifact thoughts/shared/plans "$TICKET" | tail -1 || true)"
+   [[ -n "$PLAN_DOC" && -f "$PLAN_DOC" ]] || {
      "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
        --phase "$PHASE" --ticket "$TICKET" --status failed \
        --reason "plan_doc_not_written"
      exit 1
    }
-   PLAN_DOC="${PLAN_MATCHES[-1]}"
    ```
 
 If [[create-plan]] runs into a question it cannot resolve from the research

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -141,27 +141,23 @@ is performed.
    `title — path — one-line guidance`. Write `None found.` when the store is empty
    or nothing matches. The store may not exist yet — the `-d` guard above makes this
    best-effort; NEVER block research on an empty store.
-4. Invoke `/catalyst-dev:research-codebase` against the ticket's research question.
+4. Assert the `thoughts/` root belongs to this project before writing (CTL-1081):
+   ```bash
+   bash "${PLUGIN_ROOT}/scripts/lib/assert-thoughts-project.sh" || {
+     "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+       --phase "$PHASE" --ticket "$TICKET" --status failed \
+       --reason "wrong_project_thoughts_root"
+     exit 1
+   }
+   ```
+5. Invoke `/catalyst-dev:research-codebase` against the ticket's research question.
    That skill spawns parallel sub-agents, synthesizes findings, and writes the
    document. Do not duplicate its logic.
-5. Confirm the artifact exists at the expected path before continuing.
-   Two-step match (CTL-494) — try lowercase-tail first, then the wider
-   `*${TICKET}*.md` pattern with `nocaseglob` fallback so canonical
-   create-plan filenames (uppercase ticket + descriptive suffix) are
-   accepted alongside the phase-research prose convention:
+6. Confirm the artifact exists at the expected path before continuing.
+   Use the shared slug-tolerant matcher from lib/phase-artifact-gate.sh (CTL-1081):
    ```bash
-   shopt -s nullglob
-   RESEARCH_MATCHES=( thoughts/shared/research/*-${TICKET,,}.md )
-   if [[ ${#RESEARCH_MATCHES[@]} -eq 0 ]]; then
-     RESEARCH_MATCHES=( thoughts/shared/research/*${TICKET}*.md )
-     if [[ ${#RESEARCH_MATCHES[@]} -eq 0 ]]; then
-       shopt -s nocaseglob
-       RESEARCH_MATCHES=( thoughts/shared/research/*${TICKET}*.md )
-       shopt -u nocaseglob
-     fi
-   fi
-   shopt -u nullglob
-   RESEARCH_DOC="${RESEARCH_MATCHES[-1]:-}"
+   source "${PLUGIN_ROOT}/scripts/lib/phase-artifact-gate.sh"
+   RESEARCH_DOC="$(match_thoughts_artifact thoughts/shared/research "$TICKET" | tail -1 || true)"
    [[ -n "$RESEARCH_DOC" && -f "$RESEARCH_DOC" ]] || {
      "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
        --phase "$PHASE" --ticket "$TICKET" --status failed \


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-12T17:29:30Z -->
<!-- Last updated: 2026-06-12T17:29:30Z -->
<!-- PR: #1904 -->
<!-- Previous commits: 8666ef800a848f486a321f2edf6fd616013fd3bc,09a8bfd359e7695e041c482074a2bb588af4914d,9a937831ca6bf1634dd05c25246c207802fa5f0f -->

## Summary

Fixes the two-part phase artifact gate contract failure that caused plan phases to refuse research artifacts even when the doc existed:

1. **Slug-tolerant gate matcher** — `lib/phase-artifact-gate.sh` extracts the naming contract into a shared library with a boundary-safe, case-insensitive, slug-tolerant matcher. A doc named `2026-06-12-ctl-1081-some-slug.md` now satisfies the gate; a cross-ticket lookalike (`ctl-10812`) is rejected.

2. **emit-complete self-check** — `phase-agent-emit-complete` refuses to emit `phase.<name>.complete` when the phase's own downstream-gate-visible artifact is absent, downgrading to `failed/artifact_not_gate_visible` so the revive loop can re-dispatch rather than silently advancing with an invisible artifact.

3. **Project assertion helper** — `lib/assert-thoughts-project.sh` verifies the `thoughts/shared` symlink resolves to the correct project repo before a phase writes its artifact, preventing the cross-project fallback class (wrong-project thoughts root).

## Changes Made

### New library files

- **`plugins/dev/scripts/lib/phase-artifact-gate.sh`** — shared gate contract library:
  - `prior_artifact_for_phase` — spec map (`signal:`, `glob:<dir>`, or `""`)
  - `own_thoughts_artifact_dir_for_phase` — producer view (the `thoughts/` dir a phase writes into)
  - `match_thoughts_artifact` — slug-tolerant, boundary-safe, case-insensitive matcher

- **`plugins/dev/scripts/lib/assert-thoughts-project.sh`** — verifies `thoughts/shared` symlink target contains `/repos/<catalyst.thoughts.directory>/`. Fails-open when config or symlink is absent (non-orchestrated runs unaffected). Bash-3.2 safe.

### Modified scripts

- **`plugins/dev/scripts/phase-agent-dispatch`** — sources the shared lib, removes inline `prior_artifact_for_phase`, replaces fragile 3-step glob with single `match_thoughts_artifact` call, removes now-dead `TICKET_LC` variable.

- **`plugins/dev/scripts/phase-agent-emit-complete`** — adds self-check: for thoughts-producing phases, verifies own gate-visible artifact exists before emitting `complete`; downgrades to `failed/artifact_not_gate_visible` otherwise. Fail-open: matcher runtime error allows original complete.

### Modified skills

- **`plugins/dev/skills/phase-research/SKILL.md`** — replaces inline 3-step glob self-check with `match_thoughts_artifact` from shared lib; adds `assert-thoughts-project.sh` invocation before writing doc.

- **`plugins/dev/skills/phase-plan/SKILL.md`** — same pattern as phase-research.

### Test files

- **`__tests__/phase-artifact-gate.test.sh`** (NEW, 22 tests) — contract + divergence tests; verifies dispatch, emit-complete, and both SKILLs all route through shared lib.

- **`__tests__/assert-thoughts-project.test.sh`** (NEW, 8 tests) — verifies project assertion logic.

- **`__tests__/phase-agent-emit-complete.test.sh`** — 6 new tests (39–42+): complete with doc, complete downgraded when absent, non-thoughts phase unaffected, non-complete status unchanged.

- **`__tests__/phase-agent-dispatch.test.sh`** — updates 5 assertions for dir-based spec format.

- **`__tests__/phase-skill-globs.test.sh`** — updates 5 assertions for `match_thoughts_artifact` usage.

## How to Verify It

- [x] `plugins/dev/scripts/__tests__/phase-artifact-gate.test.sh` — 22/22 pass ✅
- [x] `plugins/dev/scripts/__tests__/assert-thoughts-project.test.sh` — 8/8 pass ✅
- [x] `plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh` — all pass (39–42 new tests included) ✅
- [x] `plugins/dev/scripts/__tests__/phase-skill-globs.test.sh` — 5/5 pass ✅
- [x] CI: audit-references, check-versions, docs-gate, validate — all pass ✅
- [ ] E2E: dispatch a phase-research job with a slugged artifact name and verify plan gate accepts it (manual)

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1081
