### PR TITLE
fix(dev): CTL-1083 — The Workers grouping switcher and dep-graph navigation should work

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/board/board-dep-graph-nav.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/board-dep-graph-nav.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const boardSrc = readFileSync(join(import.meta.dir, "Board.tsx"), "utf8");
+const routerSrc = readFileSync(join(import.meta.dir, "..", "app-router.tsx"), "utf8");
+
+describe("CTL-1083 — Dep Graph button navigates to the registered route", () => {
+  it("the Dep Graph button calls navigate to /dep-graph", () => {
+    expect(boardSrc).toMatch(/navigate\(\{\s*to:\s*"\/dep-graph"/);
+  });
+  it("the /dep-graph route is registered in the router", () => {
+    expect(routerSrc).toMatch(/path:\s*"\/dep-graph"/);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/board-workers-layout.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/board-workers-layout.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const towerSrc = readFileSync(
+  join(import.meta.dir, "..", "components", "queue", "control-tower.tsx"),
+  "utf8",
+);
+const boardSrc = readFileSync(join(import.meta.dir, "Board.tsx"), "utf8");
+
+describe("CTL-1083 — ControlTower is height-bounded inside the workers flex column", () => {
+  it("does not shrink (keeps natural height, never collapses the board)", () => {
+    expect(towerSrc).toContain("flexShrink: 0");
+  });
+  it("caps its height and scrolls internally instead of starving the swimlane board", () => {
+    expect(towerSrc).toMatch(/overflowY:\s*"auto"/);
+    expect(towerSrc).toMatch(/maxHeight:/);
+  });
+});
+
+describe("CTL-1083 — workers grouping Seg stays wired to local state", () => {
+  it("binds value={workerGrouping} and onChange={setWorkerGrouping}", () => {
+    expect(boardSrc).toContain("value={workerGrouping}");
+    expect(boardSrc).toContain("onChange={setWorkerGrouping}");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/control-tower.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/control-tower.tsx
@@ -15,7 +15,7 @@ export function ControlTower({
 }) {
   const multiHost = queueHostMode(payload.queue) === "multi";
   return (
-    <div style={{ maxWidth: 1120, margin: "0 auto", padding: "8px 24px 32px", display: "flex", flexDirection: "column", gap: 28 }}>
+    <div style={{ maxWidth: 1120, margin: "0 auto", padding: "8px 24px 32px", display: "flex", flexDirection: "column", gap: 28, flexShrink: 0, maxHeight: "45vh", overflowY: "auto" }}>
       <SlotDeck
         workers={payload.workers}
         tickets={payload.tickets}


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-12T17:30:00Z -->
<!-- Last updated: 2026-06-12T17:30:00Z -->
<!-- PR: #1905 -->
<!-- Previous commits: 876956c48e54a51a551f12633bc647dba37b77e9 -->

## Summary

Regression fix: `ControlTower` was inserted into the Workers surface's flex column without height
constraints, causing it to expand to full content height and starve the `WorkerSwimlaneBoard` to
near-zero height. The grouping Seg (`value`/`onChange` wiring) and dep-graph navigation button
both appeared dead because the swimlane board had no visible area to render into.

- Adds `flexShrink: 0`, `maxHeight: 45vh`, and `overflowY: auto` to the `ControlTower` root div
  so it takes its natural height up to a cap and scrolls internally
- Adds regression-guard source-scan tests for the three invariants the prior PR omitted:
  height boundary, grouping Seg binding, and dep-graph navigation target

## Changes Made

### Frontend Changes

**`plugins/dev/scripts/orch-monitor/ui/src/components/queue/control-tower.tsx`**

Added three CSS properties to the root `<div>` of `ControlTower`:

```diff
- style={{ maxWidth: 1120, margin: "0 auto", padding: "8px 24px 32px", display: "flex", flexDirection: "column", gap: 28 }}
+ style={{ maxWidth: 1120, margin: "0 auto", padding: "8px 24px 32px", display: "flex", flexDirection: "column", gap: 28, flexShrink: 0, maxHeight: "45vh", overflowY: "auto" }}
```

- `flexShrink: 0` — prevents the flex layout from collapsing the tower when sibling `flex: 1` elements compete for space
- `maxHeight: "45vh"` — caps the tower at 45% of the viewport so the swimlane board always retains at least 55vh
- `overflowY: "auto"` — tower content scrolls internally rather than pushing the board out

### Test Changes

**`plugins/dev/scripts/orch-monitor/ui/src/board/board-workers-layout.test.ts`** (new)

Source-scan tests asserting the three layout invariants:

- `ControlTower` has `flexShrink: 0` (no collapse)
- `ControlTower` has `maxHeight` and `overflowY: "auto"` (bounded + scrolls)
- `Board.tsx` binds `value={workerGrouping}` and `onChange={setWorkerGrouping}` on the grouping Seg

**`plugins/dev/scripts/orch-monitor/ui/src/board/board-dep-graph-nav.test.ts`** (new)

Source-scan tests asserting dep-graph navigation wiring:

- `Board.tsx` calls `navigate({ to: "/dep-graph" })` for the Dep Graph button
- `app-router.tsx` registers the `/dep-graph` route

## How to Verify It

- [x] TypeScript: no type errors in changed files (`tsc`) ✅
- [x] Tests: 1065 pass / 0 fail (77 files; 5 new CTL-1083 tests pass) ✅
- [x] Security: no secrets, no new deps ✅
- [x] Reward hacking: no `as any` / `@ts-ignore` / non-null bypass in added lines ✅
- [x] CI: audit-references ✅, check-versions ✅, docs-gate ✅, validate ✅
- [ ] Manual: open the Workers surface in the orch-monitor and confirm the grouping Seg switches lanes; click the Dep Graph button and confirm navigation to `/dep-graph`

## Pre-merge Verification

- **Regression risk**: 0 / 10
- **typecheck**: pass — zero type errors in changed production file
- **tests**: pass — 1065/0 across 77 files; all 5 new tests pass
- **lint**: skip — no lint config in orch-monitor/ui
- **security**: pass — pure CSS + test change, no new deps
- **code_review**: pass — fix is sound; nav-row wiring confirmed intact
- **coverage**: pass — production change directly guarded by new tests
- **reward_hacking**: pass — no bypass patterns in added lines

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1083

## Changelog Entry

```
fix(dev): CTL-1083 — bound ControlTower height so workers swimlane board is not starved

ControlTower inserted by #1888 had no height cap, starving WorkerSwimlaneBoard to
near-zero. Add flexShrink:0 + maxHeight:45vh + overflowY:auto; add regression tests
for height boundary, grouping Seg binding, and dep-graph navigation target.
```
