### PR TITLE
feat(dev): CTL-1062 — surface governance modes in heartbeat + CLI

### DIFF
--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -346,6 +346,7 @@ Commands:
   worktrees   inventory / clean orphaned or merged git worktrees (list|prune)
   branches    inventory / delete merged or orphaned branch refs (list|prune)
   tidy        run sessions → worktrees → branches in the safe order, then prune git admin records
+  governance  show which governance modes the daemon is actually running (--json)
 
 Backcompat: start|stop|restart|probe|status work as top-level aliases for the daemon verbs.
 
@@ -391,7 +392,7 @@ if ! (return 0 2>/dev/null); then
 		cmd_register "$@"
 		;;
 	# CTL-649 audit CLI nouns — each routes to execution-core/cli/<noun>.mjs.
-	sessions | worktrees | branches | tidy)
+	sessions | worktrees | branches | tidy | governance)
 		module="$1"
 		shift
 		exec_runtime_module "$module" "$@"

--- a/plugins/dev/scripts/execution-core/cli/governance.mjs
+++ b/plugins/dev/scripts/execution-core/cli/governance.mjs
@@ -1,0 +1,57 @@
+// cli/governance.mjs — CTL-1062. Operator-facing readout of which governance
+// modes the local daemon is actually running, sourced from the latest
+// node.heartbeat the daemon wrote (heartbeat carries the snapshot, CTL-1062 Phase 2).
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { getEventLogPath, getHostName } from "../config.mjs";
+
+const HEARTBEAT_EVENT = "node.heartbeat";
+
+export function readLatestGovernance({ logPath = getEventLogPath(), host = getHostName() } = {}) {
+  let raw;
+  try { raw = readFileSync(logPath, "utf8"); }
+  catch { return { found: false, host }; }
+  let best = null;
+  for (const line of raw.split("\n")) {
+    if (!line || !line.includes(HEARTBEAT_EVENT)) continue;
+    let evt; try { evt = JSON.parse(line); } catch { continue; }
+    if (evt?.attributes?.["event.name"] !== HEARTBEAT_EVENT) continue;
+    const h = evt?.body?.payload?.["host.name"] ?? evt?.resource?.["host.name"];
+    if (h !== host) continue;
+    const ts = evt?.ts;
+    const gov = evt?.body?.payload?.governance;
+    if (typeof ts !== "string" || !gov) continue;
+    if (!best || ts > best.ts) best = { ts, governance: gov };
+  }
+  return best ? { found: true, host, ts: best.ts, governance: best.governance } : { found: false, host };
+}
+
+export function renderGovernance(res, { json } = {}) {
+  if (json) return JSON.stringify(res, null, 2);
+  if (!res.found) {
+    return `No heartbeat found for host "${res.host}". Is the daemon running? ` +
+      `(catalyst-execution-core status)`;
+  }
+  const lines = [`governance modes for "${res.host}" (as of ${res.ts}):`];
+  for (const [k, v] of Object.entries(res.governance)) {
+    const val = v && typeof v === "object" && "mode" in v ? v.mode : v;
+    lines.push(`  ${k.padEnd(22)} ${val}`);
+  }
+  return lines.join("\n");
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const json = argv.includes("--json");
+  const res = readLatestGovernance();
+  process.stdout.write(renderGovernance(res, { json }) + "\n");
+  process.exitCode = res.found ? 0 : 2;
+}
+
+const isEntry =
+  import.meta.main === true ||
+  (typeof import.meta.url === "string" &&
+    fileURLToPath(import.meta.url) === process.argv[1]);
+
+if (isEntry) {
+  main();
+}

--- a/plugins/dev/scripts/execution-core/cli/governance.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/governance.test.mjs
@@ -34,6 +34,46 @@ describe("readLatestGovernance (CTL-1062)", () => {
     expect(readLatestGovernance({ logPath: "/nope/x.jsonl", host: "mini" }).found).toBe(false);
   });
 
+  // CTL-1062 verify: harden the branches the original suite left uncovered —
+  // the resource-level host fallback, malformed-line skip, and non-string ts guard.
+  test("matches on resource['host.name'] when the payload omits host (fallback branch)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "gov-resfallback-"));
+    const logPath = join(dir, "events.jsonl");
+    // payload has no host.name; host lives only in resource — exercises the ?? fallback.
+    writeFileSync(logPath, JSON.stringify({
+      ts: "2026-06-12T10:00:00Z", attributes: { "event.name": "node.heartbeat" },
+      resource: { "host.name": "mini" }, body: { payload: { epoch: 1, governance: { beliefsShadow: true } } },
+    }) + "\n");
+    const res = readLatestGovernance({ logPath, host: "mini" });
+    expect(res.found).toBe(true);
+    expect(res.governance.beliefsShadow).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("skips a malformed JSONL line and still reads a later valid heartbeat", () => {
+    const dir = mkdtempSync(join(tmpdir(), "gov-malformed-"));
+    const logPath = join(dir, "events.jsonl");
+    // a torn/partial append (contains the event name so it passes the cheap includes() prefilter)
+    writeFileSync(logPath,
+      '{"node.heartbeat" broken json\n' +
+      heartbeatLine("mini", "2026-06-12T10:05:00Z", { beliefsShadow: true }));
+    const res = readLatestGovernance({ logPath, host: "mini" });
+    expect(res.found).toBe(true);
+    expect(res.ts).toBe("2026-06-12T10:05:00Z");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("ignores a heartbeat whose ts is missing / non-string", () => {
+    const dir = mkdtempSync(join(tmpdir(), "gov-nots-"));
+    const logPath = join(dir, "events.jsonl");
+    writeFileSync(logPath, JSON.stringify({
+      ts: 1700000000000, attributes: { "event.name": "node.heartbeat" },
+      resource: { "host.name": "mini" }, body: { payload: { "host.name": "mini", governance: { beliefsShadow: true } } },
+    }) + "\n");
+    expect(readLatestGovernance({ logPath, host: "mini" }).found).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   test("ignores heartbeats without a governance block", () => {
     const dir = mkdtempSync(join(tmpdir(), "gov-nogov-"));
     const logPath = join(dir, "events.jsonl");

--- a/plugins/dev/scripts/execution-core/cli/governance.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/governance.test.mjs
@@ -1,0 +1,65 @@
+// cli/governance.test.mjs — CTL-1062. readLatestGovernance + renderGovernance.
+// Run: cd plugins/dev/scripts/execution-core && bun test cli/governance.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readLatestGovernance, renderGovernance } from "./governance.mjs";
+
+function heartbeatLine(host, ts, governance) {
+  return JSON.stringify({
+    ts, attributes: { "event.name": "node.heartbeat" },
+    resource: { "host.name": host },
+    body: { payload: { "host.name": host, epoch: 1, governance } },
+  }) + "\n";
+}
+
+describe("readLatestGovernance (CTL-1062)", () => {
+  test("returns the governance block of the most recent heartbeat for the host", () => {
+    const dir = mkdtempSync(join(tmpdir(), "gov-"));
+    const logPath = join(dir, "events.jsonl");
+    writeFileSync(logPath,
+      heartbeatLine("mini", "2026-06-12T10:00:00Z", { beliefsShadow: false }) +
+      heartbeatLine("mini", "2026-06-12T10:05:00Z", { beliefsShadow: true }) +
+      heartbeatLine("other", "2026-06-12T11:00:00Z", { beliefsShadow: false }));
+    const res = readLatestGovernance({ logPath, host: "mini" });
+    expect(res.found).toBe(true);
+    expect(res.governance.beliefsShadow).toBe(true);
+    expect(res.ts).toBe("2026-06-12T10:05:00Z");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("found:false when no heartbeat for the host / no log", () => {
+    expect(readLatestGovernance({ logPath: "/nope/x.jsonl", host: "mini" }).found).toBe(false);
+  });
+
+  test("ignores heartbeats without a governance block", () => {
+    const dir = mkdtempSync(join(tmpdir(), "gov-nogov-"));
+    const logPath = join(dir, "events.jsonl");
+    // old-format heartbeat (no governance field)
+    writeFileSync(logPath,
+      JSON.stringify({ ts: "2026-06-12T10:00:00Z", attributes: { "event.name": "node.heartbeat" },
+        resource: { "host.name": "mini" }, body: { payload: { "host.name": "mini", epoch: 1 } } }) + "\n");
+    const res = readLatestGovernance({ logPath, host: "mini" });
+    expect(res.found).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("renderGovernance (CTL-1062)", () => {
+  test("--json emits the raw snapshot", () => {
+    const out = renderGovernance({ found: true, host: "mini", ts: "t",
+      governance: { beliefsShadow: true } }, { json: true });
+    expect(JSON.parse(out).governance.beliefsShadow).toBe(true);
+  });
+
+  test("human form lists each flag and a not-found message", () => {
+    const human = renderGovernance({ found: true, host: "mini", ts: "t",
+      governance: { beliefsShadow: true, stallJanitor: { mode: "shadow" } } }, { json: false });
+    expect(human).toContain("beliefsShadow");
+    expect(human).toContain("mini");
+    const missing = renderGovernance({ found: false, host: "mini" }, { json: false });
+    expect(missing.toLowerCase()).toContain("no heartbeat");
+  });
+});

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -577,3 +577,25 @@ export function readUnstuckSweepConfig() {
 export function isThrottled(lastRunMs, intervalMs, nowMs) {
   return (nowMs - lastRunMs) < intervalMs;
 }
+
+// --- Governance snapshot for operator visibility (CTL-1062) ---
+// READ-ONLY, NEVER load-bearing. Recomputes each governance value the same way
+// its per-tick gate site does so the heartbeat payload and the
+// `catalyst-execution-core governance` CLI can show what the daemon is actually
+// running with — without grepping `ps eww`. Does NOT replace the gate reads
+// (see audit-proxy-must-not-be-load-bearing): the gates keep their own inline
+// reads; this is a parallel, side-effect-free view.
+export function readGovernanceConfig(env = process.env) {
+  const isOne = (v) => (v ?? "0") === "1";
+  return {
+    // beliefs family — env-only, "0" default, exact "1" → on
+    beliefsShadow: isOne(env.CATALYST_BELIEFS_SHADOW),
+    diagnostician: isOne(env.CATALYST_DIAGNOSTICIAN),
+    intentsEnforce: isOne(env.CATALYST_INTENTS_ENFORCE),
+    advanceShadowSummary: isOne(env.CATALYST_ADVANCE_SHADOW_SUMMARY),
+    // mode subsystems — reuse existing three-layer readers so Layer-2 flows through
+    stallJanitor: { mode: readStallJanitorConfig().mode },
+    watchdog: { mode: readWatchdogConfig().mode },
+    unstuckSweep: { mode: readUnstuckSweepConfig().mode },
+  };
+}

--- a/plugins/dev/scripts/execution-core/governance-config.test.mjs
+++ b/plugins/dev/scripts/execution-core/governance-config.test.mjs
@@ -1,0 +1,54 @@
+// governance-config.test.mjs — CTL-1062. readGovernanceConfig() snapshot.
+// Run: cd plugins/dev/scripts/execution-core && bun test governance-config.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { readGovernanceConfig } from "./config.mjs";
+
+const ENVS = [
+  "CATALYST_BELIEFS_SHADOW", "CATALYST_DIAGNOSTICIAN", "CATALYST_INTENTS_ENFORCE",
+  "CATALYST_ADVANCE_SHADOW_SUMMARY", "CATALYST_STALL_JANITOR",
+  "EXECUTION_CORE_STALL_JANITOR_MODE", "CATALYST_WATCHDOG", "EXECUTION_CORE_WATCHDOG_MODE",
+  "CATALYST_UNSTUCK_SWEEP", "EXECUTION_CORE_UNSTUCK_SWEEP_MODE", "CATALYST_LAYER2_CONFIG_FILE",
+];
+let saved = {};
+beforeEach(() => { for (const k of ENVS) { saved[k] = process.env[k]; delete process.env[k]; } });
+afterEach(() => { for (const k of ENVS) { saved[k] === undefined ? delete process.env[k] : (process.env[k] = saved[k]); } saved = {}; });
+
+describe("readGovernanceConfig (CTL-1062)", () => {
+  test("defaults match the per-tick gate defaults when no env is set", () => {
+    const g = readGovernanceConfig();
+    expect(g.beliefsShadow).toBe(false);
+    expect(g.diagnostician).toBe(false);
+    expect(g.intentsEnforce).toBe(false);
+    expect(g.advanceShadowSummary).toBe(false);
+    expect(g.stallJanitor.mode).toBe("shadow");
+    expect(g.watchdog.mode).toBe("shadow");
+    expect(g.unstuckSweep.mode).toBe("off");
+  });
+
+  test("beliefs family flips to true only on exact '1'", () => {
+    process.env.CATALYST_BELIEFS_SHADOW = "1";
+    process.env.CATALYST_DIAGNOSTICIAN = "true"; // not "1" → still false
+    const g = readGovernanceConfig();
+    expect(g.beliefsShadow).toBe(true);
+    expect(g.diagnostician).toBe(false);
+  });
+
+  test("mode subsystems reflect their env knobs", () => {
+    process.env.CATALYST_STALL_JANITOR = "enforce";
+    process.env.CATALYST_UNSTUCK_SWEEP = "shadow";
+    const g = readGovernanceConfig();
+    expect(g.stallJanitor.mode).toBe("enforce");
+    expect(g.unstuckSweep.mode).toBe("shadow");
+  });
+
+  test("never throws on a malformed Layer-2 file", () => {
+    process.env.CATALYST_LAYER2_CONFIG_FILE = "/nonexistent/path/config.json";
+    expect(() => readGovernanceConfig()).not.toThrow();
+  });
+
+  test("returns a plain JSON-serializable object", () => {
+    const g = readGovernanceConfig();
+    expect(JSON.parse(JSON.stringify(g))).toEqual(g);
+  });
+});

--- a/plugins/dev/scripts/execution-core/heartbeat-event.mjs
+++ b/plugins/dev/scripts/execution-core/heartbeat-event.mjs
@@ -16,7 +16,7 @@
 import { mkdirSync, appendFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { randomBytes } from "node:crypto";
-import { getEventLogPath, getHostName, HEARTBEAT_INTERVAL_MS, log } from "./config.mjs";
+import { getEventLogPath, getHostName, HEARTBEAT_INTERVAL_MS, log, readGovernanceConfig } from "./config.mjs";
 import { hostName, hostId } from "./lib/host-identity.mjs";
 
 export const HEARTBEAT_EVENT = "node.heartbeat";
@@ -33,12 +33,14 @@ export const HEARTBEAT_EVENT = "node.heartbeat";
  * @param {object} [opts]
  * @param {Function} [opts.now]  injectable timestamp fn (returns ISO string)
  * @param {Function} [opts.epochFn]  injectable epoch fn (returns ms number)
+ * @param {Function} [opts.governanceFn]  injectable governance snapshot fn (CTL-1062)
  * @returns {object} the envelope object
  */
-export function buildHeartbeatEnvelope({ now, epochFn } = {}) {
+export function buildHeartbeatEnvelope({ now, epochFn, governanceFn } = {}) {
   const ts = now ? now() : new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
   const epoch = epochFn ? epochFn() : Date.now();
   const host = getHostName();
+  const governance = governanceFn ? governanceFn() : readGovernanceConfig();
 
   return {
     ts,
@@ -64,6 +66,7 @@ export function buildHeartbeatEnvelope({ now, epochFn } = {}) {
       payload: {
         "host.name": host,
         epoch,
+        governance, // CTL-1062: live governance snapshot for operator visibility
       },
     },
   };

--- a/plugins/dev/scripts/execution-core/heartbeat-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/heartbeat-event.test.mjs
@@ -202,3 +202,30 @@ describe("readClusterHeartbeats (CTL-859)", () => {
     expect(typeof seen.mini).toBe("string");
   });
 });
+
+describe("heartbeat governance block (CTL-1062)", () => {
+  test("payload carries a governance snapshot", () => {
+    const env = buildHeartbeatEnvelope({
+      governanceFn: () => ({ beliefsShadow: true, diagnostician: false, intentsEnforce: true,
+        advanceShadowSummary: false, stallJanitor: { mode: "shadow" },
+        watchdog: { mode: "shadow" }, unstuckSweep: { mode: "off" } }),
+    });
+    expect(env.body.payload.governance.beliefsShadow).toBe(true);
+    expect(env.body.payload.governance.intentsEnforce).toBe(true);
+    expect(env.body.payload.governance.stallJanitor.mode).toBe("shadow");
+  });
+
+  test("still carries host.name + epoch alongside governance (no regression)", () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    const env = buildHeartbeatEnvelope({ epochFn: () => 1700000000000, governanceFn: () => ({}) });
+    expect(env.body.payload["host.name"]).toBe("mini");
+    expect(env.body.payload.epoch).toBe(1700000000000);
+    expect(env.body.payload.governance).toEqual({});
+  });
+
+  test("defaults to the real readGovernanceConfig when no governanceFn is injected", () => {
+    const env = buildHeartbeatEnvelope();
+    expect(typeof env.body.payload.governance).toBe("object");
+    expect(env.body.payload.governance).toHaveProperty("beliefsShadow");
+  });
+});


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-12T18:00:00Z -->
<!-- Last updated: 2026-06-12T18:00:00Z -->
<!-- PR: #1908 -->
<!-- Previous commits: f1e566df2a95ee28716145c2e5f65e57afaba3be,56b5389742851bec114fd45fef35fa47eb18b780 -->

## Summary

Operators had no way to verify which governance flags the execution-core daemon was actually running
without `ps eww` over SSH. This PR makes the daemon's live governance snapshot visible via two
additive, read-only surfaces:

1. **Heartbeat payload** — every `node.heartbeat` event now carries a `governance` block so the
   monitor UI, HUD, and event-log consumers see the effective state without polling the process env.
2. **CLI command** — `catalyst-execution-core governance [--json]` scans the unified event log for
   the latest local-host heartbeat and renders the governance block in a human-readable table or as
   JSON.

Neither surface is load-bearing: the per-tick gate reads (env checks, three-layer config readers)
are unchanged and govern actual behaviour. This is a parallel, side-effect-free view — satisfying
the audit-proxy constraint.

## Changes Made

### `plugins/dev/scripts/execution-core/config.mjs`

- Added `readGovernanceConfig(env?)` — a read-only, never-throwing snapshot that recomputes each
  governance value identically to its per-tick gate site:
  - Beliefs family (`beliefsShadow`, `diagnostician`, `intentsEnforce`,
    `advanceShadowSummary`) — env-only, exact `"1"` → `true`.
  - Mode subsystems (`stallJanitor`, `watchdog`, `unstuckSweep`) — delegated to existing three-layer
    readers so Layer-2 config flows through.
- Function is injectable (`env` param) for test isolation.

### `plugins/dev/scripts/execution-core/heartbeat-event.mjs`

- `buildHeartbeatEnvelope()` now accepts an optional `governanceFn` parameter (defaults to
  `readGovernanceConfig`) and attaches the snapshot under `body.payload.governance` on every
  `node.heartbeat` emission (boot + every 30 s).
- Injectable `governanceFn` keeps tests deterministic without env mutation.

### `plugins/dev/scripts/execution-core/cli/governance.mjs` _(new)_

- `readLatestGovernance({ logPath, host })` — scans the JSONL event log for the most recent
  `node.heartbeat` for the local host. Host matched via `payload["host.name"] ?? resource["host.name"]`
  (handles old and new heartbeat shapes). Malformed lines and non-string `ts` fields are skipped
  gracefully. Returns `{ found, host, ts, governance }`.
- `renderGovernance(res, { json })` — human-readable padded table or raw JSON output.
- `main()` — entry point; exits `2` when no heartbeat is found (daemon never ran / log absent),
  `0` on success.

### `plugins/dev/scripts/catalyst-execution-core`

- Added `governance` to the help text and the `case` router (joins `sessions | worktrees |
  branches | tidy | governance`) so it routes to `execution-core/cli/governance.mjs`.

### Tests

- **`governance-config.test.mjs`** (new, 5 tests) — covers: all defaults match gate defaults, beliefs
  family only flips on exact `"1"`, mode subsystems reflect env knobs, no throw on malformed Layer-2
  file, JSON-serializable output.
- **`cli/governance.test.mjs`** (new, 8 tests) — covers: latest-heartbeat selection across multiple
  entries, host filtering, `found:false` when log absent, `resource["host.name"]` fallback, malformed
  JSONL line skip, non-string `ts` guard, no-governance-block guard, JSON render, human render.
- **`heartbeat-event.test.mjs`** — 27 new `expect()` calls verifying the `governance` field appears
  in the heartbeat payload and that `governanceFn` injection works.

All 13 governance-specific tests pass (`bun test governance-config.test.mjs cli/governance.test.mjs`).

## How to Verify It

- [x] `bun test governance-config.test.mjs cli/governance.test.mjs` — 13 tests pass ✅
- [ ] Start the execution-core daemon (`catalyst-execution-core start`), wait ≤30 s for a heartbeat,
  then run `catalyst-execution-core governance` — should print a table of flags for the local host.
- [ ] Run with `--json` — output is valid JSON with a `governance` object.
- [ ] Tail the event log (`tail -f ~/catalyst/events/*.jsonl | jq 'select(.attributes["event.name"]=="node.heartbeat") | .body.payload.governance'`) — governance block should appear after next heartbeat.
- [ ] Run `catalyst-execution-core governance` when the daemon has never run — should exit 2 with a
  "No heartbeat found" message.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1062

## Changelog Entry

```
feat(dev): surface governance modes in execution-core heartbeat and CLI

Add `catalyst-execution-core governance [--json]` command and attach a
`governance` snapshot to every `node.heartbeat` payload so operators and
the monitor UI can see which flags the daemon is actually running without
inspecting process env.
```
