### PR TITLE
fix(dev): CTL-1060 — otel-forward reliability: DLQ drain fix, stack lifecycle, lag metric

### DIFF
--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -153,10 +153,12 @@ stop_mitmproxy() {
   fi
 }
 
-start_broker()  { catalyst-broker start 2>&1 | sed 's/^/  /'; }
-stop_broker()   { catalyst-broker stop  2>&1 | sed 's/^/  /'; }
-start_monitor() { catalyst-monitor start 2>&1 | sed 's/^/  /'; }
-stop_monitor()  { catalyst-monitor stop  2>&1 | sed 's/^/  /'; }
+start_broker()   { catalyst-broker start 2>&1 | sed 's/^/  /'; }
+stop_broker()    { catalyst-broker stop  2>&1 | sed 's/^/  /'; }
+start_monitor()  { catalyst-monitor start 2>&1 | sed 's/^/  /'; }
+stop_monitor()   { catalyst-monitor stop  2>&1 | sed 's/^/  /'; }
+start_forward()  { catalyst-monitor forward-start 2>&1 | sed 's/^/  /'; }
+stop_forward()   { catalyst-monitor forward-stop  2>&1 | sed 's/^/  /'; }
 
 start_daemon() {
   local use_proxy="$1"
@@ -433,6 +435,7 @@ cmd_start() {
   start_broker
   start_monitor
   start_daemon "$use_proxy"
+  start_forward
 
   log ""
   log "stack up — current state:"
@@ -441,6 +444,7 @@ cmd_start() {
 
 cmd_stop() {
   stop_daemon
+  stop_forward
   stop_monitor
   stop_broker
   stop_mitmproxy
@@ -466,6 +470,7 @@ cmd_status() {
   echo -n "  broker           "; catalyst-broker status 2>&1 | head -1
   echo -n "  monitor          "; catalyst-monitor status 2>&1 | head -1
   echo -n "  execution-core   "; catalyst-execution-core status 2>&1 | head -1
+  echo -n "  otel-forward     "; catalyst-monitor forward-status 2>&1 | head -1
 }
 
 # ─── Dispatch ───────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/otel-forward/index.test.ts
+++ b/plugins/dev/scripts/otel-forward/index.test.ts
@@ -4,6 +4,41 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createTailer } from "./lib/tail.ts";
 import { readCheckpoint, writeCheckpoint } from "./lib/checkpoint.ts";
+import { computeLagMs, buildLagEvent } from "./index.ts";
+
+describe("computeLagMs (CTL-1060 Phase 3)", () => {
+  test("returns ms delta between localNewestTs and lastForwardedTs", () => {
+    expect(computeLagMs("2026-06-12T10:00:10Z", "2026-06-12T10:00:00Z")).toBe(10_000);
+  });
+
+  test("returns 0 when lastForwardedTs >= localNewestTs (caught-up or ahead)", () => {
+    expect(computeLagMs("2026-06-12T10:00:00Z", "2026-06-12T10:00:10Z")).toBe(0);
+    expect(computeLagMs("2026-06-12T10:00:00Z", "2026-06-12T10:00:00Z")).toBe(0);
+  });
+
+  test("returns 0 when either timestamp is undefined", () => {
+    expect(computeLagMs(undefined, "2026-06-12T10:00:00Z")).toBe(0);
+    expect(computeLagMs("2026-06-12T10:00:00Z", undefined)).toBe(0);
+    expect(computeLagMs(undefined, undefined)).toBe(0);
+  });
+});
+
+describe("buildLagEvent (CTL-1060 Phase 3)", () => {
+  test("returns canonical event with forward_lag name and correct payload fields", () => {
+    const ev = buildLagEvent({
+      localNewestTs: "2026-06-12T10:00:10Z",
+      lastForwardedTs: "2026-06-12T10:00:00Z",
+      dlqDepth: 5,
+    });
+    expect(ev.attributes["event.name"]).toBe("catalyst.observability.forward_lag");
+    expect(ev.resource["service.name"]).toBe("catalyst.otel-forward");
+    const payload = ev.body?.payload as Record<string, unknown>;
+    expect(payload.lagMs).toBe(10_000);
+    expect(payload.localNewestTs).toBe("2026-06-12T10:00:10Z");
+    expect(payload.lastForwardedTs).toBe("2026-06-12T10:00:00Z");
+    expect(payload.dlqDepth).toBe(5);
+  });
+});
 
 describe("checkpoint persists real read offset (CTL-766)", () => {
   test("a checkpoint written from tailer.currentOffset() resumes past the backlog", async () => {

--- a/plugins/dev/scripts/otel-forward/index.ts
+++ b/plugins/dev/scripts/otel-forward/index.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env bun
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
 import type { CanonicalEvent } from "../orch-monitor/lib/canonical-event.ts";
 import { loadForwarderConfig } from "./lib/config.ts";
 import { readCheckpoint, writeCheckpoint } from "./lib/checkpoint.ts";
@@ -10,6 +12,8 @@ import { OtlpSender } from "./lib/destinations/otlp.ts";
 import { PosthogSender } from "./lib/destinations/posthog.ts";
 import { CloudflareAESender } from "./lib/destinations/cloudflare-ae.ts";
 import { isFlatEvent, normalizeFlatEvent } from "./lib/normalize.ts";
+import { dlqDepth } from "./lib/dlq.ts";
+import { buildCanonicalEnvelope } from "./lib/canonical.ts";
 
 const CATALYST_DIR = process.env.CATALYST_DIR ?? join(homedir(), "catalyst");
 const EVENTS_DIR = process.env.CATALYST_EVENTS_DIR ?? join(CATALYST_DIR, "events");
@@ -24,6 +28,47 @@ const ck = readCheckpoint(CHECKPOINT_PATH);
 
 let stats = { processed: 0, skipped: 0 };
 
+// CTL-1060 Phase 3: lag tracking state. lastLocalTs = newest event ts seen from the log.
+// lastForwardedTs = newest event ts confirmed delivered to OTLP/Loki (seeded from checkpoint).
+let lastLocalTs: string | undefined;
+let lastForwardedTs: string | undefined = ck?.lastForwardedTs;
+
+// 30-second cadence for forward_lag canonical events (CTL-1060 Phase 3).
+// Tied to the OTLP/Loki path — this is the path the 2026-06-11 audit reported as "0 in Loki".
+const LAG_EMIT_MS = 30_000;
+
+/** Returns max of two ISO-8601 timestamps (or b when a is undefined). */
+export function maxTs(a: string | undefined, b: string | undefined): string | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  return a >= b ? a : b;
+}
+
+/** Returns lagMs = localNewestTs - lastForwardedTs in ms, clamped to ≥ 0. Returns 0 when either timestamp is undefined. */
+export function computeLagMs(localNewestTs: string | undefined, lastForwardedTs: string | undefined): number {
+  if (!localNewestTs || !lastForwardedTs) return 0;
+  const delta = Date.parse(localNewestTs) - Date.parse(lastForwardedTs);
+  return delta > 0 ? delta : 0;
+}
+
+/** Builds a canonical catalyst.observability.forward_lag event for the broker/HUD pipeline. */
+export function buildLagEvent(opts: {
+  localNewestTs: string | undefined;
+  lastForwardedTs: string | undefined;
+  dlqDepth: number;
+}): CanonicalEvent {
+  return buildCanonicalEnvelope({
+    serviceName: "catalyst.otel-forward",
+    eventName: "catalyst.observability.forward_lag",
+    payload: {
+      lagMs: computeLagMs(opts.localNewestTs, opts.lastForwardedTs),
+      localNewestTs: opts.localNewestTs,
+      lastForwardedTs: opts.lastForwardedTs,
+      dlqDepth: opts.dlqDepth,
+    },
+  });
+}
+
 const buffers: { otlp: CanonicalEvent[]; posthog: CanonicalEvent[]; cae: CanonicalEvent[] } = {
   otlp: [],
   posthog: [],
@@ -36,12 +81,22 @@ const CURRENT_MONTH = () => {
 };
 const EVENT_LOG_PATH = join(EVENTS_DIR, `${CURRENT_MONTH()}.jsonl`);
 
+const OTLP_DLQ_PATH = join(CATALYST_DIR, "otel-forward-dlq-otlp.jsonl");
+
 const senders = {
   otlp: cfg.otlp.enabled
     ? new OtlpSender({
         endpoint: cfg.otlp.endpoint,
-        dlqPath: join(CATALYST_DIR, "otel-forward-dlq-otlp.jsonl"),
+        dlqPath: OTLP_DLQ_PATH,
         eventLogPath: EVENT_LOG_PATH,
+        // CTL-1060 Phase 3: advance lastForwardedTs on each confirmed-delivered batch
+        onBatchDelivered: (batch) => {
+          const batchMaxTs = batch.reduce(
+            (acc, ev) => maxTs(acc, (ev as CanonicalEvent).ts),
+            undefined as string | undefined
+          );
+          lastForwardedTs = maxTs(lastForwardedTs, batchMaxTs);
+        },
       })
     : null,
   posthog: cfg.posthog.enabled
@@ -61,6 +116,22 @@ const senders = {
     : null,
 };
 
+function emitLag(): void {
+  // Skip on cold start before any event has been processed or delivered
+  if (!lastLocalTs && !lastForwardedTs) return;
+  try {
+    const ev = buildLagEvent({
+      localNewestTs: lastLocalTs,
+      lastForwardedTs,
+      dlqDepth: dlqDepth(OTLP_DLQ_PATH),
+    });
+    mkdirSync(dirname(EVENT_LOG_PATH), { recursive: true });
+    appendFileSync(EVENT_LOG_PATH, JSON.stringify(ev) + "\n");
+  } catch {
+    // Best-effort — must never throw
+  }
+}
+
 export function processLine(line: string): void {
   try {
     let ev = JSON.parse(line) as CanonicalEvent;
@@ -70,6 +141,8 @@ export function processLine(line: string): void {
       return;
     }
     stats.processed++;
+    // Track newest local event timestamp for lag metric (CTL-1060 Phase 3)
+    if (ev.ts) lastLocalTs = maxTs(lastLocalTs, ev.ts);
     if (senders.otlp) buffers.otlp.push(ev);
     if (senders.posthog) buffers.posthog.push(ev);
     if (senders.cae) buffers.cae.push(ev);
@@ -126,8 +199,12 @@ if (import.meta.main) {
     writeCheckpoint(CHECKPOINT_PATH, {
       path: tailer.currentPath(),
       offset: tailer.currentOffset(),
+      lastForwardedTs,
     });
   }, 10_000);
+
+  // CTL-1060 Phase 3: emit forward_lag canonical event every 30 s.
+  const lagTimer = setInterval(emitLag, LAG_EMIT_MS);
 
   log.info(
     {
@@ -142,6 +219,7 @@ if (import.meta.main) {
 
   clearInterval(flushTimer);
   clearInterval(ckTimer);
+  clearInterval(lagTimer);
   await flush();
   log.info({ processed: stats.processed, skipped: stats.skipped }, "stopped");
 }

--- a/plugins/dev/scripts/otel-forward/lib/checkpoint.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/checkpoint.test.ts
@@ -18,4 +18,24 @@ describe("checkpoint", () => {
     expect(ck?.path).toBe("/events/2026-05.jsonl");
     rmSync(dir, { recursive: true });
   });
+
+  test("round-trips lastForwardedTs when present", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ck-lag-"));
+    const path = join(dir, "ck.json");
+    const ts = "2026-06-12T10:00:00Z";
+    writeCheckpoint(path, { path: "/events/2026-06.jsonl", offset: 100, lastForwardedTs: ts });
+    const ck = readCheckpoint(path);
+    expect(ck?.lastForwardedTs).toBe(ts);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("readCheckpoint returns undefined for lastForwardedTs on legacy files lacking it", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ck-legacy-"));
+    const path = join(dir, "ck.json");
+    // Write a legacy checkpoint without lastForwardedTs
+    writeCheckpoint(path, { path: "/events/2026-06.jsonl", offset: 0 });
+    const ck = readCheckpoint(path);
+    expect(ck?.lastForwardedTs).toBeUndefined();
+    rmSync(dir, { recursive: true });
+  });
 });

--- a/plugins/dev/scripts/otel-forward/lib/checkpoint.ts
+++ b/plugins/dev/scripts/otel-forward/lib/checkpoint.ts
@@ -1,6 +1,12 @@
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 
-export interface Checkpoint { path: string; offset: number; updatedAt: string }
+export interface Checkpoint {
+  path: string;
+  offset: number;
+  updatedAt: string;
+  /** ISO-8601 timestamp of the newest event confirmed delivered to OTLP/Loki (CTL-1060 Phase 3). */
+  lastForwardedTs?: string;
+}
 
 export function readCheckpoint(ckPath: string): Checkpoint | null {
   if (!existsSync(ckPath)) return null;

--- a/plugins/dev/scripts/otel-forward/lib/destinations/cloudflare-ae.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/destinations/cloudflare-ae.test.ts
@@ -1,5 +1,9 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { buildCloudflareAEPayload } from "./cloudflare-ae.ts";
+import { appendToDlq, dlqDepth } from "../dlq.ts";
 import type { CanonicalEvent } from "../../../orch-monitor/lib/canonical-event.ts";
 
 const SAMPLE_EVENT: CanonicalEvent = {
@@ -32,5 +36,50 @@ describe("buildCloudflareAEPayload", () => {
     expect(payload.blobs).toHaveLength(1);
     const parsed = JSON.parse(payload.blobs[0]);
     expect(parsed.ts).toBe("2026-05-08T04:34:45Z");
+  });
+});
+
+describe("CloudflareAESender drain-outside-retry (CTL-1060)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cae-drain-")); });
+
+  test("primary success + seeded DLQ drains without recursion, no primary re-send", async () => {
+    let callCount = 0;
+    global.fetch = mock(() => {
+      callCount++;
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as unknown as typeof fetch;
+
+    const { CloudflareAESender } = await import("./cloudflare-ae.ts");
+    const dlqPath = join(dir, "dlq.jsonl");
+    appendToDlq(dlqPath, [SAMPLE_EVENT]);
+
+    const sender = new CloudflareAESender({
+      accountId: "acc", apiToken: "tok", dataset: "ds", dlqPath,
+    });
+    await sender.flush([SAMPLE_EVENT]);
+
+    // fetch called for primary event + one event in the DLQ batch
+    expect(callCount).toBe(2);
+    expect(dlqDepth(dlqPath)).toBe(0);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("no drain when primary fails: DLQ grows by 1", async () => {
+    global.fetch = mock(() =>
+      Promise.reject(new Error("down"))
+    ) as unknown as typeof fetch;
+
+    const { CloudflareAESender } = await import("./cloudflare-ae.ts");
+    const dlqPath = join(dir, "dlq2.jsonl");
+    appendToDlq(dlqPath, [SAMPLE_EVENT]);
+
+    const sender = new CloudflareAESender({
+      accountId: "acc", apiToken: "tok", dataset: "ds", dlqPath, retryDelaysMs: [0, 0, 0],
+    });
+    await sender.flush([SAMPLE_EVENT]);
+
+    expect(dlqDepth(dlqPath)).toBe(2);
+    rmSync(dir, { recursive: true });
   });
 });

--- a/plugins/dev/scripts/otel-forward/lib/destinations/cloudflare-ae.ts
+++ b/plugins/dev/scripts/otel-forward/lib/destinations/cloudflare-ae.ts
@@ -1,6 +1,6 @@
 import type { CanonicalEvent } from "../../../orch-monitor/lib/canonical-event.ts";
 import { withRetry, DEFAULT_RETRY_DELAYS_MS } from "../retry.ts";
-import { appendToDlq, drainDlq } from "../dlq.ts";
+import { appendToDlq, drainDlqBounded, DEFAULT_MAX_DRAIN_BATCHES } from "../dlq.ts";
 import { log } from "../logger.ts";
 
 const destLog = log.child({ destination: "cloudflare-ae" });
@@ -16,31 +16,39 @@ export function buildCloudflareAEPayload(event: CanonicalEvent): { indexes: stri
 }
 
 export class CloudflareAESender {
-  constructor(private opts: { accountId: string; apiToken: string; dataset: string; dlqPath: string; timeoutMs?: number }) {}
+  constructor(private opts: { accountId: string; apiToken: string; dataset: string; dlqPath: string; timeoutMs?: number; maxDrainBatches?: number; retryDelaysMs?: number[] }) {}
 
   async flush(batch: CanonicalEvent[]): Promise<void> {
     const url = `https://api.cloudflare.com/client/v4/accounts/${this.opts.accountId}/analytics_engine/datasets/${this.opts.dataset}`;
+    const retryDelays = this.opts.retryDelaysMs ?? [...DEFAULT_RETRY_DELAYS_MS];
+
+    const sendBatch = async (b: CanonicalEvent[]) => {
+      for (const ev of b) {
+        const res = await fetch(url, {
+          method: "POST",
+          headers: { "Authorization": `Bearer ${this.opts.apiToken}`, "Content-Type": "application/json" },
+          body: JSON.stringify(buildCloudflareAEPayload(ev)),
+          signal: AbortSignal.timeout(this.opts.timeoutMs ?? 5000),
+        });
+        if (!res.ok) throw new Error(`CF AE HTTP ${res.status}`);
+      }
+    };
+
     try {
-      await withRetry(async () => {
-        for (const ev of batch) {
-          const res = await fetch(url, {
-            method: "POST",
-            headers: { "Authorization": `Bearer ${this.opts.apiToken}`, "Content-Type": "application/json" },
-            body: JSON.stringify(buildCloudflareAEPayload(ev)),
-            signal: AbortSignal.timeout(this.opts.timeoutMs ?? 5000),
-          });
-          if (!res.ok) throw new Error(`CF AE HTTP ${res.status}`);
-        }
-        for (const dlqBatch of drainDlq(this.opts.dlqPath)) {
-          await this.flush(dlqBatch as CanonicalEvent[]);
-        }
-      }, 3, [...DEFAULT_RETRY_DELAYS_MS]);
+      await withRetry(() => sendBatch(batch), 3, retryDelays);
     } catch (err) {
       appendToDlq(this.opts.dlqPath, batch);
       destLog.error(
         { batchSize: batch.length, err: err instanceof Error ? err.message : String(err) },
         "flush failed, wrote events to DLQ",
       );
+      return;
     }
+
+    await drainDlqBounded(
+      this.opts.dlqPath,
+      (b) => withRetry(() => sendBatch(b as CanonicalEvent[]), 3, [...retryDelays]),
+      { maxBatches: this.opts.maxDrainBatches ?? DEFAULT_MAX_DRAIN_BATCHES }
+    );
   }
 }

--- a/plugins/dev/scripts/otel-forward/lib/destinations/otlp.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/destinations/otlp.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { buildOtlpPayload } from "./otlp.ts";
+import { appendToDlq, dlqDepth, drainDlq } from "../dlq.ts";
 import type { CanonicalEvent } from "../../../orch-monitor/lib/canonical-event.ts";
 
 const SAMPLE_EVENT: CanonicalEvent = {
@@ -261,6 +262,154 @@ describe("OtlpSender flush failure events (CTL-1008 Phase 4)", () => {
 
     expect(existsSync(eventLogPath)).toBe(false);
 
+    rmSync(dir, { recursive: true });
+  });
+});
+
+describe("OtlpSender DLQ drain — outside withRetry (CTL-1060)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "otlp-drain-test-"));
+  });
+
+  function makeEvent(overrides: Partial<CanonicalEvent> = {}): CanonicalEvent {
+    return { ...SAMPLE_EVENT, ...overrides };
+  }
+
+  test("drain failure does not re-dead-letter the primary (drain is outside withRetry)", async () => {
+    // Primary fetch succeeds; all subsequent calls (drain) fail.
+    let callCount = 0;
+    global.fetch = mock(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve(new Response(null, { status: 200 }));
+      return Promise.reject(new Error("drain network failure"));
+    }) as unknown as typeof fetch;
+
+    const { OtlpSender } = await import("./otlp.ts");
+    const dlqPath = join(dir, "drain-dlq.jsonl");
+    const eventLogPath = join(dir, "drain-events.jsonl");
+
+    // Seed DLQ with a known batch
+    appendToDlq(dlqPath, [makeEvent({ attributes: { "event.name": "queued.event" } })]);
+
+    const sender = new OtlpSender({
+      endpoint: "http://127.0.0.1:4318",
+      dlqPath,
+      eventLogPath,
+      retryDelaysMs: [0, 0, 0],
+    });
+    await sender.flush([makeEvent({ attributes: { "event.name": "primary.event" } })]);
+
+    // Primary was delivered successfully — it must NOT be in the DLQ.
+    // Only the original queued.event batch should remain (drain failed).
+    const remaining = drainDlq(dlqPath);
+    expect(remaining.length).toBe(1);
+    expect((remaining[0][0] as any).attributes["event.name"]).toBe("queued.event");
+    // Drain was attempted (fetch called > 1 time)
+    expect(callCount).toBeGreaterThan(1);
+
+    rmSync(dir, { recursive: true });
+  });
+
+  test("no drain when primary fails: DLQ grows by primary, drain never attempted", async () => {
+    global.fetch = mock(() =>
+      Promise.reject(new Error("always fail"))
+    ) as unknown as typeof fetch;
+
+    const { OtlpSender } = await import("./otlp.ts");
+    const dlqPath = join(dir, "nofail-dlq.jsonl");
+
+    // Seed DLQ with one existing batch
+    appendToDlq(dlqPath, [makeEvent({ attributes: { "event.name": "existing.batch" } })]);
+    expect(dlqDepth(dlqPath)).toBe(1);
+
+    const sender = new OtlpSender({
+      endpoint: "http://127.0.0.1:1",
+      dlqPath,
+      retryDelaysMs: [0, 0, 0],
+    });
+    await sender.flush([makeEvent({ attributes: { "event.name": "primary.event" } })]);
+
+    // DLQ now has both: original batch + newly dead-lettered primary
+    expect(dlqDepth(dlqPath)).toBe(2);
+
+    rmSync(dir, { recursive: true });
+  });
+
+  test("bounded drain across cycles: 60 batches → 10 remain after first flush, 0 after second", async () => {
+    global.fetch = mock(() =>
+      Promise.resolve(new Response(null, { status: 200 }))
+    ) as unknown as typeof fetch;
+
+    const { OtlpSender } = await import("./otlp.ts");
+    const dlqPath = join(dir, "bounded-dlq.jsonl");
+
+    // Seed DLQ with 60 batches
+    for (let i = 0; i < 60; i++) {
+      appendToDlq(dlqPath, [makeEvent({ attributes: { "event.name": `batch.${i}` } })]);
+    }
+    expect(dlqDepth(dlqPath)).toBe(60);
+
+    const sender = new OtlpSender({
+      endpoint: "http://127.0.0.1:4318",
+      dlqPath,
+      retryDelaysMs: [0],
+      maxDrainBatches: 50,
+    });
+
+    // First flush: drains 50, leaves 10
+    await sender.flush([makeEvent()]);
+    expect(dlqDepth(dlqPath)).toBe(10);
+
+    // Second flush: drains remaining 10
+    await sender.flush([makeEvent()]);
+    expect(dlqDepth(dlqPath)).toBe(0);
+
+    rmSync(dir, { recursive: true });
+  });
+
+  test("onBatchDelivered is called for primary + each drained batch on success (CTL-1060 Phase 3)", async () => {
+    global.fetch = mock(() =>
+      Promise.resolve(new Response(null, { status: 200 }))
+    ) as unknown as typeof fetch;
+
+    const { OtlpSender } = await import("./otlp.ts");
+    const dlqPath = join(dir, "obd-dlq.jsonl");
+    appendToDlq(dlqPath, [makeEvent()]);
+    appendToDlq(dlqPath, [makeEvent()]);
+
+    let deliveredCount = 0;
+    const sender = new OtlpSender({
+      endpoint: "http://127.0.0.1:4318",
+      dlqPath,
+      retryDelaysMs: [0],
+      onBatchDelivered: () => { deliveredCount++; },
+    });
+
+    await sender.flush([makeEvent()]);
+    // 1 primary + 2 DLQ batches = 3 calls to onBatchDelivered
+    expect(deliveredCount).toBe(3);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("onBatchDelivered is NOT called when primary flush fails (CTL-1060 Phase 3)", async () => {
+    global.fetch = mock(() =>
+      Promise.reject(new Error("down"))
+    ) as unknown as typeof fetch;
+
+    const { OtlpSender } = await import("./otlp.ts");
+    const dlqPath = join(dir, "obd-fail-dlq.jsonl");
+
+    let deliveredCount = 0;
+    const sender = new OtlpSender({
+      endpoint: "http://127.0.0.1:1",
+      dlqPath,
+      retryDelaysMs: [0, 0, 0],
+      onBatchDelivered: () => { deliveredCount++; },
+    });
+
+    await sender.flush([makeEvent()]);
+    expect(deliveredCount).toBe(0);
     rmSync(dir, { recursive: true });
   });
 });

--- a/plugins/dev/scripts/otel-forward/lib/destinations/otlp.ts
+++ b/plugins/dev/scripts/otel-forward/lib/destinations/otlp.ts
@@ -2,7 +2,7 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import type { CanonicalEvent } from "../../../orch-monitor/lib/canonical-event.ts";
 import { withRetry, DEFAULT_RETRY_DELAYS_MS } from "../retry.ts";
-import { appendToDlq, drainDlq } from "../dlq.ts";
+import { appendToDlq, drainDlqBounded, DEFAULT_MAX_DRAIN_BATCHES } from "../dlq.ts";
 import { log } from "../logger.ts";
 import { buildCanonicalEnvelope } from "../canonical.ts";
 
@@ -66,6 +66,10 @@ export interface OtlpSenderOpts {
   retryDelaysMs?: number[];
   /** Path to append a canonical forward_failed event on flush failure (CTL-1008 Phase 4). */
   eventLogPath?: string;
+  /** Max DLQ batches to drain per flush cycle. Defaults to DEFAULT_MAX_DRAIN_BATCHES. */
+  maxDrainBatches?: number;
+  /** Called after each successfully delivered batch (primary or DLQ). Used by Phase 3 lag tracking. */
+  onBatchDelivered?: (batch: CanonicalEvent[]) => void;
 }
 
 // CTL-1008 Phase 4: guard against re-amplifying our own failure events —
@@ -81,23 +85,21 @@ export class OtlpSender {
   async flush(batch: CanonicalEvent[]): Promise<void> {
     const url = `${this.opts.endpoint.replace(/:4317/, ":4318").replace(/\/$/, "")}/v1/logs`;
     const retryDelays = this.opts.retryDelaysMs ?? [...DEFAULT_RETRY_DELAYS_MS];
+
+    // sendBatch is the raw network call — only retried for the PRIMARY batch.
+    const sendBatch = async (b: CanonicalEvent[]) => {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildOtlpPayload(b)),
+        signal: AbortSignal.timeout(this.opts.timeoutMs ?? 5000),
+      });
+      if (!res.ok) throw new Error(`OTLP HTTP ${res.status}`);
+    };
+
     try {
-      await withRetry(
-        async () => {
-          const res = await fetch(url, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(buildOtlpPayload(batch)),
-            signal: AbortSignal.timeout(this.opts.timeoutMs ?? 5000),
-          });
-          if (!res.ok) throw new Error(`OTLP HTTP ${res.status}`);
-          for (const dlqBatch of drainDlq(this.opts.dlqPath)) {
-            await this.flush(dlqBatch as CanonicalEvent[]);
-          }
-        },
-        3,
-        retryDelays
-      );
+      // CTL-1060: PRIMARY only inside withRetry — drain is OUTSIDE.
+      await withRetry(() => sendBatch(batch), 3, retryDelays);
     } catch (err) {
       appendToDlq(this.opts.dlqPath, batch);
       destLog.error(
@@ -126,6 +128,21 @@ export class OtlpSender {
           // Best-effort — failure to write the failure event must never throw
         }
       }
+      // Primary failed → backend unhealthy → do not attempt to drain
+      return;
     }
+
+    // Primary delivered → backend healthy → bounded, failure-isolated drain OUTSIDE withRetry.
+    this.opts.onBatchDelivered?.(batch);
+    await drainDlqBounded(
+      this.opts.dlqPath,
+      (b) => withRetry(() => sendBatch(b as CanonicalEvent[]), 3, [...retryDelays]),
+      {
+        maxBatches: this.opts.maxDrainBatches ?? DEFAULT_MAX_DRAIN_BATCHES,
+        onBatchDelivered: this.opts.onBatchDelivered
+          ? (b) => this.opts.onBatchDelivered!(b as CanonicalEvent[])
+          : undefined,
+      }
+    );
   }
 }

--- a/plugins/dev/scripts/otel-forward/lib/destinations/posthog.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/destinations/posthog.test.ts
@@ -1,5 +1,9 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { buildPosthogBatch } from "./posthog.ts";
+import { appendToDlq, dlqDepth } from "../dlq.ts";
 import type { CanonicalEvent } from "../../../orch-monitor/lib/canonical-event.ts";
 
 const SAMPLE_EVENT: CanonicalEvent = {
@@ -36,5 +40,46 @@ describe("buildPosthogBatch", () => {
     const batch = buildPosthogBatch([SAMPLE_EVENT], "phc_key") as any;
     expect(batch.batch[0].properties["catalyst.session.id"]).toBe("sess_123");
     expect(batch.batch[0].properties["$lib"]).toBe("catalyst-otel-forward");
+  });
+});
+
+describe("PosthogSender drain-outside-retry (CTL-1060)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "posthog-drain-")); });
+
+  test("primary success + seeded DLQ drains without recursion, no primary re-send", async () => {
+    let callCount = 0;
+    global.fetch = mock(() => {
+      callCount++;
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as unknown as typeof fetch;
+
+    const { PosthogSender } = await import("./posthog.ts");
+    const dlqPath = join(dir, "dlq.jsonl");
+    appendToDlq(dlqPath, [SAMPLE_EVENT]);
+
+    const sender = new PosthogSender({ apiKey: "phc_k", host: "http://127.0.0.1:9999", dlqPath });
+    await sender.flush([SAMPLE_EVENT]);
+
+    // Two calls: primary + one DLQ drain batch
+    expect(callCount).toBe(2);
+    expect(dlqDepth(dlqPath)).toBe(0);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("no drain when primary fails: DLQ grows by 1", async () => {
+    global.fetch = mock(() =>
+      Promise.reject(new Error("down"))
+    ) as unknown as typeof fetch;
+
+    const { PosthogSender } = await import("./posthog.ts");
+    const dlqPath = join(dir, "dlq2.jsonl");
+    appendToDlq(dlqPath, [SAMPLE_EVENT]);
+
+    const sender = new PosthogSender({ apiKey: "phc_k", host: "http://127.0.0.1:1", dlqPath, retryDelaysMs: [0, 0, 0] });
+    await sender.flush([SAMPLE_EVENT]);
+
+    expect(dlqDepth(dlqPath)).toBe(2);
+    rmSync(dir, { recursive: true });
   });
 });

--- a/plugins/dev/scripts/otel-forward/lib/destinations/posthog.ts
+++ b/plugins/dev/scripts/otel-forward/lib/destinations/posthog.ts
@@ -1,6 +1,6 @@
 import type { CanonicalEvent } from "../../../orch-monitor/lib/canonical-event.ts";
 import { withRetry, DEFAULT_RETRY_DELAYS_MS } from "../retry.ts";
-import { appendToDlq, drainDlq } from "../dlq.ts";
+import { appendToDlq, drainDlqBounded, DEFAULT_MAX_DRAIN_BATCHES } from "../dlq.ts";
 import { log } from "../logger.ts";
 
 const destLog = log.child({ destination: "posthog" });
@@ -18,29 +18,37 @@ export function buildPosthogBatch(events: CanonicalEvent[], apiKey: string): unk
 }
 
 export class PosthogSender {
-  constructor(private opts: { apiKey: string; host: string; dlqPath: string; timeoutMs?: number }) {}
+  constructor(private opts: { apiKey: string; host: string; dlqPath: string; timeoutMs?: number; maxDrainBatches?: number; retryDelaysMs?: number[] }) {}
 
   async flush(batch: CanonicalEvent[]): Promise<void> {
     const url = `${this.opts.host.replace(/\/$/, "")}/batch`;
+    const retryDelays = this.opts.retryDelaysMs ?? [...DEFAULT_RETRY_DELAYS_MS];
+
+    const sendBatch = async (b: CanonicalEvent[]) => {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildPosthogBatch(b, this.opts.apiKey)),
+        signal: AbortSignal.timeout(this.opts.timeoutMs ?? 10000),
+      });
+      if (!res.ok) throw new Error(`PostHog HTTP ${res.status}`);
+    };
+
     try {
-      await withRetry(async () => {
-        const res = await fetch(url, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(buildPosthogBatch(batch, this.opts.apiKey)),
-          signal: AbortSignal.timeout(this.opts.timeoutMs ?? 10000),
-        });
-        if (!res.ok) throw new Error(`PostHog HTTP ${res.status}`);
-        for (const dlqBatch of drainDlq(this.opts.dlqPath)) {
-          await this.flush(dlqBatch as CanonicalEvent[]);
-        }
-      }, 3, [...DEFAULT_RETRY_DELAYS_MS]);
+      await withRetry(() => sendBatch(batch), 3, retryDelays);
     } catch (err) {
       appendToDlq(this.opts.dlqPath, batch);
       destLog.error(
         { batchSize: batch.length, err: err instanceof Error ? err.message : String(err) },
         "flush failed, wrote events to DLQ",
       );
+      return;
     }
+
+    await drainDlqBounded(
+      this.opts.dlqPath,
+      (b) => withRetry(() => sendBatch(b as CanonicalEvent[]), 3, [...retryDelays]),
+      { maxBatches: this.opts.maxDrainBatches ?? DEFAULT_MAX_DRAIN_BATCHES }
+    );
   }
 }

--- a/plugins/dev/scripts/otel-forward/lib/dlq.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/dlq.test.ts
@@ -1,8 +1,8 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { appendToDlq, drainDlq } from "./dlq.ts";
+import { appendToDlq, drainDlq, dlqDepth, drainDlqBounded } from "./dlq.ts";
 
 describe("dlq", () => {
   test("appends and drains batches", () => {
@@ -19,5 +19,100 @@ describe("dlq", () => {
 
   test("drainDlq returns empty and does not crash when file absent", () => {
     expect(drainDlq("/nonexistent/dlq.jsonl")).toEqual([]);
+  });
+});
+
+describe("dlqDepth", () => {
+  test("returns 0 for absent file", () => {
+    expect(dlqDepth("/nonexistent/dlq.jsonl")).toBe(0);
+  });
+
+  test("returns N for N appended batches", () => {
+    const dir = mkdtempSync(join(tmpdir(), "dlqdepth-"));
+    const path = join(dir, "dlq.jsonl");
+    appendToDlq(path, [{ ts: "a" }] as any);
+    appendToDlq(path, [{ ts: "b" }] as any);
+    appendToDlq(path, [{ ts: "c" }] as any);
+    expect(dlqDepth(path)).toBe(3);
+    rmSync(dir, { recursive: true });
+  });
+});
+
+describe("drainDlqBounded", () => {
+  test("drains all batches when all sends succeed, returns {drained:N, remaining:0}", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "drained-"));
+    const path = join(dir, "dlq.jsonl");
+    appendToDlq(path, [{ ts: "a" }] as any);
+    appendToDlq(path, [{ ts: "b" }] as any);
+    appendToDlq(path, [{ ts: "c" }] as any);
+    const sendBatch = mock(async () => {});
+    const result = await drainDlqBounded(path, sendBatch);
+    expect(result.drained).toBe(3);
+    expect(result.remaining).toBe(0);
+    expect(dlqDepth(path)).toBe(0);
+    expect(sendBatch).toHaveBeenCalledTimes(3);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("respects maxBatches cap: drains 2 of 5, leaves 3 in FIFO order", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "drainbounded-"));
+    const path = join(dir, "dlq.jsonl");
+    for (let i = 1; i <= 5; i++) appendToDlq(path, [{ ts: String(i) }] as any);
+    const sent: unknown[][] = [];
+    const sendBatch = mock(async (b: unknown[]) => { sent.push(b); });
+    const result = await drainDlqBounded(path, sendBatch, { maxBatches: 2 });
+    expect(result.drained).toBe(2);
+    expect(result.remaining).toBe(3);
+    expect(dlqDepth(path)).toBe(3);
+    // First 2 were sent (FIFO)
+    expect((sent[0][0] as { ts: string }).ts).toBe("1");
+    expect((sent[1][0] as { ts: string }).ts).toBe("2");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("stops at first failure, requeues failed batch + remainder", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "drainpause-"));
+    const path = join(dir, "dlq.jsonl");
+    for (let i = 1; i <= 4; i++) appendToDlq(path, [{ ts: String(i) }] as any);
+    let callCount = 0;
+    const sendBatch = mock(async () => {
+      callCount++;
+      if (callCount === 2) throw new Error("network failure");
+    });
+    const result = await drainDlqBounded(path, sendBatch);
+    // Drained 1, stopped, requeued 3 (failed + remaining 2)
+    expect(result.drained).toBe(1);
+    expect(result.remaining).toBe(3);
+    expect(dlqDepth(path)).toBe(3);
+    // sendBatch NOT called for batches after the failure
+    expect(sendBatch).toHaveBeenCalledTimes(2);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("absent/empty DLQ is a no-op returning {drained:0, remaining:0}", async () => {
+    const sendBatch = mock(async () => {});
+    const result = await drainDlqBounded("/nonexistent/dlq.jsonl", sendBatch);
+    expect(result.drained).toBe(0);
+    expect(result.remaining).toBe(0);
+    expect(sendBatch).not.toHaveBeenCalled();
+  });
+
+  test("onBatchDelivered fires for each successful send, not for failed/skipped", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "draindelivered-"));
+    const path = join(dir, "dlq.jsonl");
+    for (let i = 1; i <= 3; i++) appendToDlq(path, [{ ts: String(i) }] as any);
+    const delivered: unknown[][] = [];
+    let callCount = 0;
+    const sendBatch = mock(async (b: unknown[]) => {
+      callCount++;
+      if (callCount === 2) throw new Error("fail");
+    });
+    await drainDlqBounded(path, sendBatch, {
+      onBatchDelivered: (b) => delivered.push(b),
+    });
+    // Only first batch was delivered before failure
+    expect(delivered.length).toBe(1);
+    expect((delivered[0][0] as { ts: string }).ts).toBe("1");
+    rmSync(dir, { recursive: true });
   });
 });

--- a/plugins/dev/scripts/otel-forward/lib/dlq.ts
+++ b/plugins/dev/scripts/otel-forward/lib/dlq.ts
@@ -1,4 +1,4 @@
-import { existsSync, appendFileSync, readFileSync, unlinkSync } from "node:fs";
+import { existsSync, appendFileSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
 
 export function appendToDlq(dlqPath: string, batch: unknown[]): void {
   appendFileSync(dlqPath, JSON.stringify(batch) + "\n");
@@ -9,4 +9,58 @@ export function drainDlq(dlqPath: string): unknown[][] {
   const lines = readFileSync(dlqPath, "utf8").split("\n").filter(Boolean);
   unlinkSync(dlqPath);
   return lines.map((l: string) => JSON.parse(l));
+}
+
+export function dlqDepth(dlqPath: string): number {
+  if (!existsSync(dlqPath)) return 0;
+  return readFileSync(dlqPath, "utf8").split("\n").filter(Boolean).length;
+}
+
+export interface DrainBoundedOpts {
+  maxBatches?: number;
+  onBatchDelivered?: (batch: unknown[]) => void;
+}
+
+// CTL-1060: bounded-per-cycle DLQ drain. Reads up to maxBatches queued batches,
+// sends each via sendBatch, and stops at the first failure — requeuing that batch
+// plus all remaining ones. Prevents the unbounded recursive drain that caused the
+// 58k-event loss when ~589 backlogged batches blocked a single flush for hours.
+export const DEFAULT_MAX_DRAIN_BATCHES = 50;
+
+export async function drainDlqBounded(
+  dlqPath: string,
+  sendBatch: (batch: unknown[]) => Promise<void>,
+  opts: DrainBoundedOpts = {}
+): Promise<{ drained: number; remaining: number }> {
+  if (!existsSync(dlqPath)) return { drained: 0, remaining: 0 };
+  const lines = readFileSync(dlqPath, "utf8").split("\n").filter(Boolean);
+  if (lines.length === 0) return { drained: 0, remaining: 0 };
+
+  const maxBatches = opts.maxBatches ?? DEFAULT_MAX_DRAIN_BATCHES;
+  let drained = 0;
+  let failedAt = -1;
+
+  for (let i = 0; i < lines.length && i < maxBatches; i++) {
+    const batch = JSON.parse(lines[i]) as unknown[];
+    try {
+      await sendBatch(batch);
+      opts.onBatchDelivered?.(batch);
+      drained++;
+    } catch {
+      failedAt = i;
+      break;
+    }
+  }
+
+  // Survivors = failed batch (if any) + everything past the cap
+  const survivorStart = failedAt >= 0 ? failedAt : Math.min(drained, maxBatches);
+  const survivors = lines.slice(survivorStart);
+
+  if (survivors.length === 0) {
+    unlinkSync(dlqPath);
+  } else {
+    writeFileSync(dlqPath, survivors.join("\n") + "\n");
+  }
+
+  return { drained, remaining: survivors.length };
 }


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-12T18:24:00Z -->
<!-- Last updated: 2026-06-12T18:24:00Z -->
<!-- PR: #1909 -->
<!-- Previous commits: 6d57adcff9724069ee9aba35d558e8cb90799f4e -->

## Summary

The 2026-06-11 governance audit found 58,838 janitor events in the local event log vs 0 in Loki — the otel-forward daemon's DLQ flush was timing out because `drainDlq` had no iteration cap, and nothing surfaced the divergence. This PR fixes three distinct gaps:

1. **DLQ drain timeout** — replaces the unbounded `drainDlq` in `OtlpSender.flush()` with `drainDlqBounded` (default cap: 50 batches/cycle). Failed and over-cap batches are requeued in FIFO order; the next flush cycle continues where this one stopped rather than silently abandoning the backlog.
2. **Stack lifecycle** — adds `otel-forward` to `catalyst-stack start`, `stop`, and `status` alongside broker/monitor/execution-core. The daemon was previously unmanaged: stack stop left it running, stack start didn't launch it, stack status didn't report it.
3. **Forward lag metric** — emits a `catalyst.observability.forward_lag` canonical event every 30 s into the local event log. The event carries `lagMs` (diff between newest locally-seen event ts and newest confirmed-delivered ts), `dlqDepth`, and both timestamps. `lastForwardedTs` is seeded from the checkpoint on restart and persisted back on each checkpoint write.

## Changes Made

### `plugins/dev/scripts/catalyst-stack` — lifecycle integration

- Added `start_forward` / `stop_forward` helpers that delegate to `catalyst-monitor forward-start` / `forward-stop`.
- `cmd_start` calls `start_forward` after the rest of the stack is up.
- `cmd_stop` calls `stop_forward` before stopping monitor/broker.
- `cmd_status` prints `otel-forward` line via `catalyst-monitor forward-status`.

### `plugins/dev/scripts/otel-forward/lib/dlq.ts` — bounded drain + depth probe

- `dlqDepth(dlqPath)`: counts queued batches without consuming them (used by the lag metric).
- `drainDlqBounded(dlqPath, sendBatch, opts)`: reads up to `maxBatches` (default 50) queued batches, sends each via `sendBatch`, stops at the first failure. The failed batch and all remaining batches are requeued in FIFO order via `writeFileSync`. Accepts optional `onBatchDelivered` callback.
- `DEFAULT_MAX_DRAIN_BATCHES = 50` — exported constant for tests and configuration.

### `plugins/dev/scripts/otel-forward/lib/destinations/otlp.ts` — switch to bounded drain

- `OtlpSender.flush()` now calls `drainDlqBounded` instead of `drainDlq` after a successful main-batch send.
- Added `return` after the DLQ append in the catch block, preventing the defunct code path that could trigger a second drain after a failed send.
- Accepts `onBatchDelivered` callback in opts and threads it through to `drainDlqBounded`.
- Switched `DEFAULT_RETRY_DELAYS_MS` to a named `retryDelays` binding for readability.

### `plugins/dev/scripts/otel-forward/index.ts` — lag tracking

- `maxTs(a, b)`: returns the greater of two ISO-8601 timestamps, handling undefineds.
- `computeLagMs(localNewestTs, lastForwardedTs)`: returns ms delta, clamped to ≥ 0, returns 0 when either input is undefined.
- `buildLagEvent(opts)`: constructs a canonical `catalyst.observability.forward_lag` event via `buildCanonicalEnvelope`.
- `emitLag()`: reads `dlqDepth`, builds the event, and appends it to the event log. Best-effort — never throws.
- `processLine` now updates `lastLocalTs = maxTs(lastLocalTs, ev.ts)` on each processed event.
- `OtlpSender` is constructed with `onBatchDelivered` that advances `lastForwardedTs`.
- A 30 s `lagTimer` drives `emitLag`; cleared on shutdown alongside `flushTimer`/`ckTimer`.
- Checkpoint writes now persist `lastForwardedTs` so lag state survives restarts.

### `plugins/dev/scripts/otel-forward/lib/checkpoint.ts` — schema extension

- `Checkpoint` interface gains optional `lastForwardedTs?: string` field (backwards-compatible — existing checkpoint files without it read as `undefined`).

### Tests

- `index.test.ts`: 4 new tests for `computeLagMs` (basic delta, caught-up/zero, undefined inputs) and `buildLagEvent` (canonical event shape, payload fields).
- `checkpoint.test.ts`: 2 new tests for `lastForwardedTs` round-trip and legacy-file graceful handling.
- `dlq.test.ts`: `dlqDepth` tests (absent file, N-batch count) + 5 `drainDlqBounded` tests covering: full drain, `maxBatches` cap, first-failure stop-and-requeue, empty DLQ no-op, and `onBatchDelivered` callback firing only for successful sends.
- `otlp.test.ts` / `posthog.test.ts` / `cloudflare-ae.test.ts`: import updates to track `drainDlqBounded` and `dlqDepth`.

## How to Verify It

- [ ] Run `bun test plugins/dev/scripts/otel-forward/` — all tests should pass.
- [ ] `catalyst-stack start` should now include `otel-forward` in the startup output; `catalyst-stack status` should show the `otel-forward` line; `catalyst-stack stop` should stop it.
- [ ] Let the forwarder run for 60+ seconds, then check `~/catalyst/events/YYYY-MM.jsonl` for `catalyst.observability.forward_lag` entries with valid `lagMs` and `dlqDepth` fields.
- [ ] Simulate a backlogged DLQ with > 50 batches; confirm one flush cycle drains exactly 50 and the next cycle picks up where it left off (FIFO order preserved).

## Reviewer Notes

- The `onBatchDelivered` callback fires for DLQ-drained batches too — `drainDlqBounded` accepts it and `OtlpSender` threads it through — so `lastForwardedTs` advances correctly whether the delivery was live or from the DLQ.
- Posthog and CloudflareAE senders are **not** wired to `onBatchDelivered`; `lastForwardedTs` only tracks the OTLP/Loki path, which is the path the 2026-06-11 audit reported as silent.
- The lag timer is a 30 s `setInterval` — it doesn't fire on shutdown. The final `emitLag()` call is intentionally omitted because the shutdown `flush()` may not have completed yet; the last checkpoint write still persists `lastForwardedTs` for the next startup.

## Related Issues/PRs

- Fixes https://linear.app/coalesce/issue/CTL-1060

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip ISO-8601
