### PR TITLE
fix(dev): CTL-1088 — restarting monitor must not dirty the pristine plugin clone

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-monitor-dist-redirect.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-monitor-dist-redirect.test.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# CTL-1088: catalyst-monitor bootstrap() must redirect the vite build to an
+# out-of-repo dist dir and leave the committed public/ byte-identical.
+#
+# Uses a stub vite that writes a marker index.html + assets/app.js into
+# $MONITOR_UI_DIST_DIR instead of running the real heavy build. The stub bun
+# captures its args to a file so cmd_start assertions can verify the env injection.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+MONITOR_SH="${REPO_ROOT}/plugins/dev/scripts/catalyst-monitor.sh"
+
+FAILURES=0
+PASSES=0
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+if [[ ! -f "$MONITOR_SH" ]]; then
+  echo "FATAL: catalyst-monitor.sh missing: $MONITOR_SH" >&2
+  exit 1
+fi
+
+# Build a hermetic sandbox.
+# - $root/srv/  — fake orch-monitor dir (server.ts, node_modules/, ui/, public/)
+# - $root/dist/ — out-of-repo dist target (empty initially)
+# - $root/catalyst/ — CATALYST_DIR
+# - $root/bin/  — stub binaries (vite, bun) on PATH
+make_sandbox() {
+  local root
+  root="$(mktemp -d)"
+
+  # Fake committed public/ with non-vite static assets
+  mkdir -p "$root/srv/public/vendor" "$root/srv/public/mockups" "$root/srv/public/assets"
+  echo "history" > "$root/srv/public/history.html"
+  echo "favicon-ico" > "$root/srv/public/favicon.ico"
+  echo "favicon-svg" > "$root/srv/public/favicon.svg"
+  echo "vendor-js" > "$root/srv/public/vendor/lib.js"
+  echo "mockup-html" > "$root/srv/public/mockups/index.html"
+  # Simulate a committed index.html that stub vite should NOT overwrite in public/
+  echo "committed-index" > "$root/srv/public/index.html"
+
+  # Fake orch-monitor dir with node_modules/ (skips bun install)
+  mkdir -p "$root/srv/node_modules"
+  : > "$root/srv/server.ts"
+
+  # Fake ui/ with node_modules/ (skips UI bun install)
+  mkdir -p "$root/srv/ui/node_modules"
+
+  # CATALYST_DIR
+  mkdir -p "$root/catalyst"
+
+  # Stub binaries dir
+  mkdir -p "$root/bin"
+
+  # Stub vite: writes marker files into $MONITOR_UI_DIST_DIR
+  cat > "$root/bin/vite" <<'VITE'
+#!/usr/bin/env bash
+# Stub vite build — writes markers into $MONITOR_UI_DIST_DIR
+if [[ "${1:-}" == "build" ]]; then
+  DIST="${MONITOR_UI_DIST_DIR:-/tmp/stub-dist-missing}"
+  mkdir -p "$DIST/assets"
+  echo "stub-index" > "$DIST/index.html"
+  echo "stub-app" > "$DIST/assets/app.js"
+fi
+VITE
+  chmod +x "$root/bin/vite"
+
+  # Stub bunx: first arg is the package name (e.g. "vite"), skip it and pass the rest.
+  cat > "$root/bin/bunx" <<BUNX
+#!/usr/bin/env bash
+shift  # drop package name
+exec "$root/bin/vite" "\$@"
+BUNX
+  chmod +x "$root/bin/bunx"
+
+  # Stub sqlite3 (bootstrap checks for it)
+  cat > "$root/bin/sqlite3" <<'SQ'
+#!/usr/bin/env bash
+exit 0
+SQ
+  chmod +x "$root/bin/sqlite3"
+
+  echo "$root"
+}
+
+# Helper: run bootstrap() in isolation with stub PATH.
+# Extra NAME=VALUE args (after $root) are forwarded via env so they land as env vars.
+run_bootstrap() {
+  local root="$1"
+  shift
+  env \
+    PATH="$root/bin:$PATH" \
+    CATALYST_DIR="$root/catalyst" \
+    MONITOR_SERVER_SCRIPT="$root/srv/server.ts" \
+    MONITOR_UI_DIST_DIR="$root/dist" \
+    "$@" \
+    bash -c '
+      source "'"$MONITOR_SH"'" url >/dev/null 2>&1
+      bootstrap 2>&1; echo "rc=$?"
+    '
+}
+
+# ─── Test 1: build is redirected to dist dir ────────────────────────────────
+echo "Test 1: bootstrap redirects vite build to MONITOR_UI_DIST_DIR"
+ROOT="$(make_sandbox)"
+OUT="$(run_bootstrap "$ROOT")"
+RC="${OUT##*rc=}"
+if [[ "$RC" == "0" ]]; then
+  pass "bootstrap returns 0"
+else
+  fail "bootstrap returned non-zero (rc=$RC); output: $OUT"
+fi
+if [[ -f "$ROOT/dist/index.html" ]]; then
+  CONTENT="$(cat "$ROOT/dist/index.html")"
+  if [[ "$CONTENT" == "stub-index" ]]; then
+    pass "dist/index.html written by stub vite"
+  else
+    fail "dist/index.html has unexpected content: $CONTENT"
+  fi
+else
+  fail "dist/index.html missing — build not redirected to MONITOR_UI_DIST_DIR"
+fi
+if [[ -f "$ROOT/dist/assets/app.js" ]]; then
+  pass "dist/assets/app.js written by stub vite"
+else
+  fail "dist/assets/app.js missing"
+fi
+rm -rf "$ROOT"
+
+# ─── Test 2: committed public/ is byte-identical after bootstrap ─────────────
+echo ""
+echo "Test 2: committed public/ unchanged after bootstrap"
+ROOT="$(make_sandbox)"
+# Snapshot committed public/ checksums
+BEFORE="$(find "$ROOT/srv/public" -type f | sort | xargs md5 -q 2>/dev/null || find "$ROOT/srv/public" -type f | sort | xargs md5sum 2>/dev/null)"
+run_bootstrap "$ROOT" >/dev/null 2>&1
+AFTER="$(find "$ROOT/srv/public" -type f | sort | xargs md5 -q 2>/dev/null || find "$ROOT/srv/public" -type f | sort | xargs md5sum 2>/dev/null)"
+if [[ "$BEFORE" == "$AFTER" ]]; then
+  pass "committed public/ is byte-identical after bootstrap"
+else
+  fail "committed public/ was modified by bootstrap"
+  echo "    BEFORE: $BEFORE"
+  echo "    AFTER:  $AFTER"
+fi
+rm -rf "$ROOT"
+
+# ─── Test 3: non-vite static assets are copied into dist ─────────────────────
+echo ""
+echo "Test 3: non-vite static assets copied into dist"
+ROOT="$(make_sandbox)"
+run_bootstrap "$ROOT" >/dev/null 2>&1
+for asset in history.html favicon.ico favicon.svg; do
+  if [[ -f "$ROOT/dist/$asset" ]]; then
+    pass "dist/$asset copied from public/"
+  else
+    fail "dist/$asset missing — non-vite static assets not copied"
+  fi
+done
+if [[ -d "$ROOT/dist/vendor" ]]; then
+  pass "dist/vendor/ copied from public/"
+else
+  fail "dist/vendor/ missing"
+fi
+if [[ -d "$ROOT/dist/mockups" ]]; then
+  pass "dist/mockups/ copied from public/"
+else
+  fail "dist/mockups/ missing"
+fi
+rm -rf "$ROOT"
+
+# ─── Test 4: second bootstrap skips rebuild (guard fixed) ────────────────────
+echo ""
+echo "Test 4: second bootstrap skips rebuild when dist/index.html exists"
+ROOT="$(make_sandbox)"
+mkdir -p "$ROOT/dist"
+echo "already-built" > "$ROOT/dist/index.html"
+VITE_RAN_FILE="$ROOT/vite-ran"
+# Override stub to record whether it ran
+cat > "$ROOT/bin/vite" <<VITE2
+#!/usr/bin/env bash
+touch "$VITE_RAN_FILE"
+VITE2
+chmod +x "$ROOT/bin/vite"
+cat > "$ROOT/bin/bunx" <<BUNX2
+#!/usr/bin/env bash
+shift
+exec "$ROOT/bin/vite" "\$@"
+BUNX2
+chmod +x "$ROOT/bin/bunx"
+run_bootstrap "$ROOT" >/dev/null 2>&1
+if [[ ! -f "$VITE_RAN_FILE" ]]; then
+  pass "stub vite NOT re-run when dist/index.html already exists"
+else
+  fail "stub vite was re-run on second bootstrap (always-true guard not fixed)"
+fi
+rm -rf "$ROOT"
+
+# ─── Test 5: MONITOR_FORCE_BUILD=1 forces rebuild ────────────────────────────
+echo ""
+echo "Test 5: MONITOR_FORCE_BUILD=1 forces rebuild even when dist/index.html exists"
+ROOT="$(make_sandbox)"
+mkdir -p "$ROOT/dist"
+echo "already-built" > "$ROOT/dist/index.html"
+VITE_RAN_FILE="$ROOT/vite-ran"
+cat > "$ROOT/bin/vite" <<VITE3
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "build" ]]; then
+  touch "$VITE_RAN_FILE"
+  DIST="\${MONITOR_UI_DIST_DIR:-/tmp/stub-dist-missing}"
+  mkdir -p "\$DIST"
+  echo "forced-rebuild" > "\$DIST/index.html"
+fi
+VITE3
+chmod +x "$ROOT/bin/vite"
+cat > "$ROOT/bin/bunx" <<BUNX3
+#!/usr/bin/env bash
+shift
+exec "$ROOT/bin/vite" "\$@"
+BUNX3
+chmod +x "$ROOT/bin/bunx"
+run_bootstrap "$ROOT" MONITOR_FORCE_BUILD=1 >/dev/null 2>&1
+if [[ -f "$VITE_RAN_FILE" ]]; then
+  pass "stub vite re-run when MONITOR_FORCE_BUILD=1"
+else
+  fail "stub vite NOT re-run despite MONITOR_FORCE_BUILD=1"
+fi
+rm -rf "$ROOT"
+
+# ─── Test 6: cmd_start injects MONITOR_PUBLIC_DIR ────────────────────────────
+echo ""
+echo "Test 6: cmd_start injects MONITOR_PUBLIC_DIR into server env"
+ROOT="$(make_sandbox)"
+mkdir -p "$ROOT/dist" && echo "built" > "$ROOT/dist/index.html"
+ENV_CAPTURE="$ROOT/env-captured"
+
+# Stub bun that captures its env and immediately exits (so we can inspect without
+# actually running the server).
+cat > "$ROOT/bin/bun" <<STUB_BUN
+#!/usr/bin/env bash
+printenv > "$ENV_CAPTURE"
+STUB_BUN
+chmod +x "$ROOT/bin/bun"
+
+# Run cmd_start in a subshell; it will background the stub bun. Give it a moment.
+PATH="$ROOT/bin:$PATH" \
+CATALYST_DIR="$ROOT/catalyst" \
+MONITOR_SERVER_SCRIPT="$ROOT/srv/server.ts" \
+MONITOR_UI_DIST_DIR="$ROOT/dist" \
+MONITOR_SKIP_BOOTSTRAP=1 \
+bash -c '
+  source "'"$MONITOR_SH"'" url >/dev/null 2>&1
+  cmd_start >/dev/null 2>&1 || true
+' 2>/dev/null || true
+sleep 0.2
+
+if [[ -f "$ENV_CAPTURE" ]]; then
+  if grep -q "MONITOR_PUBLIC_DIR=$ROOT/dist" "$ENV_CAPTURE" 2>/dev/null; then
+    pass "cmd_start injects MONITOR_PUBLIC_DIR=\$MONITOR_UI_DIST_DIR"
+  else
+    ACTUAL="$(grep MONITOR_PUBLIC_DIR "$ENV_CAPTURE" 2>/dev/null || echo '(not found)')"
+    fail "MONITOR_PUBLIC_DIR not set correctly in server env; got: $ACTUAL"
+  fi
+else
+  fail "stub bun did not capture env (cmd_start may not have launched the server)"
+fi
+rm -rf "$ROOT"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASSES passed, $FAILURES failed"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -43,6 +43,9 @@ done
 SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 SERVER_SCRIPT="${MONITOR_SERVER_SCRIPT:-$SCRIPT_DIR/orch-monitor/server.ts}"
 MONITOR_DIR="$(cd "$(dirname "$SERVER_SCRIPT")" && pwd)"
+# CTL-1088: default out-of-repo dist dir for the vite build (single definition
+# used by both bootstrap and cmd_start).
+MONITOR_UI_DIST_DIR="${MONITOR_UI_DIST_DIR:-$CATALYST_DIR/monitor-ui-dist}"
 FORWARD_PID_FILE="${CATALYST_DIR}/otel-forward.pid"
 FORWARD_LOG="${CATALYST_DIR}/otel-forward.log"
 FORWARD_SCRIPT="${SCRIPT_DIR}/otel-forward/index.ts"
@@ -199,9 +202,26 @@ bootstrap() {
       (cd "$MONITOR_DIR/ui" && bun install --frozen-lockfile 2>/dev/null || bun install)
     fi
 
-    if [[ -d "$MONITOR_DIR/ui" && ! -d "$MONITOR_DIR/ui/dist" ]]; then
-      echo "Building orch-monitor frontend..."
-      (cd "$MONITOR_DIR/ui" && bunx vite build)
+    if [[ -d "$MONITOR_DIR/ui" ]]; then
+      mkdir -p "$MONITOR_UI_DIST_DIR"
+      export MONITOR_UI_DIST_DIR
+
+      # CTL-1088: build only when the out-of-repo dist has no built index.html yet.
+      # The old guard (`! -d ui/dist`) was always true — vite never wrote there.
+      # Force a rebuild with MONITOR_FORCE_BUILD=1.
+      if [[ "${MONITOR_FORCE_BUILD:-}" == "1" || ! -f "$MONITOR_UI_DIST_DIR/index.html" ]]; then
+        echo "Building orch-monitor frontend → $MONITOR_UI_DIST_DIR ..."
+        (cd "$MONITOR_DIR/ui" && bunx vite build)
+      fi
+
+      # Complete the dist: copy non-vite static assets so the out-of-repo dir is a
+      # full served root (server uses one publicDir for everything). Idempotent.
+      for _asset in history.html favicon.ico favicon.svg; do
+        [[ -f "$MONITOR_DIR/public/$_asset" ]] && cp -f "$MONITOR_DIR/public/$_asset" "$MONITOR_UI_DIST_DIR/" 2>/dev/null || true
+      done
+      for _dir in vendor mockups; do
+        [[ -d "$MONITOR_DIR/public/$_dir" ]] && cp -R "$MONITOR_DIR/public/$_dir" "$MONITOR_UI_DIST_DIR/" 2>/dev/null || true
+      done
     fi
   fi
 }
@@ -227,7 +247,9 @@ cmd_start() {
   mkdir -p "$(dirname "$PID_FILE")" 2>/dev/null || true
   mkdir -p "$CATALYST_DIR/wt" 2>/dev/null || true
 
-  MONITOR_PORT="$PORT" nohup bun run "$SERVER_SCRIPT" --pid-file "$PID_FILE" \
+  MONITOR_PORT="$PORT" \
+  MONITOR_PUBLIC_DIR="${MONITOR_UI_DIST_DIR}" \
+  nohup bun run "$SERVER_SCRIPT" --pid-file "$PID_FILE" \
     > "$CATALYST_DIR/monitor.log" 2>&1 &
   local server_pid=$!
   disown "$server_pid" 2>/dev/null || true

--- a/plugins/dev/scripts/orch-monitor/__tests__/resolve-public-dir.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/resolve-public-dir.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "bun:test";
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { resolvePublicDir } from "../server";
+
+const fallback = "/committed/public";
+
+describe("resolvePublicDir", () => {
+  it("returns fallback when env is unset/empty", () => {
+    expect(resolvePublicDir(undefined, fallback)).toBe(fallback);
+    expect(resolvePublicDir("", fallback)).toBe(fallback);
+  });
+
+  it("returns the env dir when it exists on disk", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1088-"));
+    expect(resolvePublicDir(dir, fallback)).toBe(dir);
+  });
+
+  it("falls back when the env dir does not exist", () => {
+    expect(resolvePublicDir("/no/such/dist/dir", fallback)).toBe(fallback);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -630,6 +630,17 @@ const ALLOWED_PUBLIC_EXTENSIONS = new Set([
   ".ico",
 ]);
 
+// CTL-1088: choose the served public dir. Prefer the out-of-repo dist the wrapper
+// built into (MONITOR_PUBLIC_DIR); fall back to the committed bundle when the env
+// var is unset/empty or points at a missing dir (cold-start path).
+export function resolvePublicDir(
+  envDir: string | undefined,
+  fallback: string,
+): string {
+  if (envDir && envDir.length > 0 && existsSync(envDir)) return envDir;
+  return fallback;
+}
+
 function resolveSafeStaticPath(
   publicDir: string,
   relative: string,
@@ -3892,12 +3903,17 @@ if (import.meta.main) {
       });
     }
   } else {
+    const PUBLIC_DIR = resolvePublicDir(
+      process.env.MONITOR_PUBLIC_DIR,
+      join(import.meta.dir, "public"),
+    );
     const srv = createServer({
       port: PORT,
       wtDir: WT_DIR,
       runsDir: RUNS_DIR,
       dbPath: DB_PATH,
       pidFile: pidFilePath,
+      publicDir: PUBLIC_DIR,
       prometheusUrl: otelCfg.enabled ? otelCfg.prometheusUrl : null,
       lokiUrl: otelCfg.enabled ? otelCfg.lokiUrl : null,
       grafanaUrl: otelCfg.enabled ? otelCfg.grafanaUrl : null,

--- a/plugins/dev/scripts/orch-monitor/ui/__tests__/vite-config-outdir.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/__tests__/vite-config-outdir.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { resolve } from "path";
+
+afterEach(() => {
+  delete process.env.MONITOR_UI_DIST_DIR;
+});
+
+describe("vite outDir", () => {
+  it("uses MONITOR_UI_DIST_DIR when set", async () => {
+    process.env.MONITOR_UI_DIST_DIR = "/tmp/catalyst-dist-test";
+    const { OUT_DIR } = await import(`../vite.config.ts?t=${performance.now()}`);
+    expect(OUT_DIR).toBe("/tmp/catalyst-dist-test");
+  });
+
+  it("falls back to the committed ../public when unset", async () => {
+    delete process.env.MONITOR_UI_DIST_DIR;
+    const { OUT_DIR } = await import(`../vite.config.ts?t=${performance.now()}`);
+    expect(OUT_DIR).toBe(resolve(__dirname, "../../public"));
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/vite.config.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/vite.config.ts
@@ -4,6 +4,14 @@ import tailwindcss from "@tailwindcss/vite";
 import { resolve } from "path";
 import { assembleBoard } from "../lib/board-data.mjs";
 
+// CTL-1088: build out of the pristine plugin clone. When the wrapper provides a
+// dist dir, writes outside the tracked public/; falls back to ../public so plain
+// `bunx vite build` from a checkout still behaves as before.
+export const OUT_DIR =
+  process.env.MONITOR_UI_DIST_DIR && process.env.MONITOR_UI_DIST_DIR.length > 0
+    ? resolve(process.env.MONITOR_UI_DIST_DIR)
+    : resolve(__dirname, "../public");
+
 // CTL-727/730: serve the live board payload from the dev server (Node side), so
 // the React board can fetch real execution-core state without the legacy :7400
 // monitor. Matches the SAME path the production monitor serves (`/api/board`,
@@ -41,7 +49,7 @@ export default defineConfig({
     },
   },
   build: {
-    outDir: resolve(__dirname, "../public"),
+    outDir: OUT_DIR,
     emptyOutDir: false,
     rollupOptions: {
       // CTL-989: SINGLE entry. The two SPA bundles are unified into ONE TanStack


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-12T20:19:00Z -->
<!-- Last updated: 2026-06-12T20:19:00Z -->
<!-- PR: #1914 -->
<!-- Previous commits: eaed3b681da74de63d865c992748bf060e74ef70 -->

## Summary

The `catalyst-monitor` wrapper was running `bunx vite build` on every (re)start with vite's
`outDir` pointing into the tracked `orch-monitor/public/` directory. The bootstrap guard
(`! -d ui/dist`) was always true because vite never wrote there — so every restart dirtied the
pristine plugin clone with a modified `public/index.html` plus new untracked hashed chunk files.
The dirty `index.html` is also a latent broker wedge: the broker's `git pull --ff-only` fails the
first time an upstream commit touches `index.html` (CTL-993).

This fix redirects the vite build to an out-of-repo directory (`$MONITOR_UI_DIST_DIR`, defaulting
to `~/catalyst/monitor-ui-dist/`), copies non-vite static assets there, and passes the dist path
to the server via `MONITOR_PUBLIC_DIR`. The committed `public/` is now a cold-start fallback only —
never written to at runtime.

## Changes Made

### `catalyst-monitor.sh` (+26 / -4)

- Hoists `MONITOR_UI_DIST_DIR` default near the top of the script
- Fixes the always-true `! -d ui/dist` bootstrap guard to check `"$MONITOR_UI_DIST_DIR/index.html"` instead
- After the vite build, copies non-vite static assets (`history.html`, `favicon.ico`, `favicon.svg`, `vendor/`, `mockups/`) from `public/` into the dist dir to complete the served tree
- `cmd_start` injects `MONITOR_PUBLIC_DIR="$MONITOR_UI_DIST_DIR"` so the server serves from the dist rather than the committed `public/`

### `orch-monitor/ui/vite.config.ts` (+9 / -1)

- Reads `MONITOR_UI_DIST_DIR` for `outDir`; exports `OUT_DIR` for tests
- Falls back to `../public` when the env var is unset so plain `bunx vite build` still works

### `orch-monitor/server.ts` (+16)

- Adds exported `resolvePublicDir(envDir, fallback)` helper
- `main()` reads `MONITOR_PUBLIC_DIR` and passes it as `publicDir` to `createServer()`, falling back to the committed `public/` when unset/missing

### Tests (+314 lines, all new)

| File | Type | Assertions |
|------|------|-----------|
| `__tests__/catalyst-monitor-dist-redirect.test.sh` | Shell integration | 12 |
| `orch-monitor/__tests__/resolve-public-dir.test.ts` | Unit (TypeScript) | 3 |
| `orch-monitor/ui/__tests__/vite-config-outdir.test.ts` | Unit (TypeScript) | 2 |

## How to Verify It

- [x] TypeScript typecheck: `tsc --noEmit` — ✅ clean after `bun install`
- [x] Unit tests (`resolve-public-dir`, `vite-config-outdir`): 5/5 pass ✅
- [x] Shell integration (`catalyst-monitor-dist-redirect`): 12/12 pass ✅
- [x] Regression suite: 4584 pass / 7 fail (all 7 are environmental — port 7400 EADDRINUSE from live monitor PID 90721, sqlite+nav fixtures — none diff-related) ✅
- [x] Lint: eslint 0 errors ✅
- [x] Security: env-driven dist path served via existing `resolveSafeStaticPath` guard; no new deps ✅
- [x] CI: all 6 checks pass (Cloudflare Pages, audit-references, check-versions, docs-gate, quality, validate) ✅
- [ ] Manual: restart the monitor and confirm `git status` in the plugin clone shows no modified/untracked files after restart

## Verification (from verify phase)

**Regression risk**: 1 / 10

All gates pass. One low-severity review finding (not blocking): the static-asset copy list in `catalyst-monitor.sh:218` is hardcoded to the current `public/` entries — a future non-vite file added to `public/` would 404 from the dist dir until the list is updated.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1088
- Context: CTL-992 established the "pristine clone" invariant; CTL-993 is the broker auto-pull that this wedge would break; CTL-1084 (one-command restart, see #1910) is the umbrella where boot self-report could loudly flag a dirty clone

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1084
skip CTL-992
skip CTL-993
