### PR TITLE
chore(meta): CTL-1096 add SLI and EVR to monitor Linear team map

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -46,6 +46,14 @@
           {
             "key": "OTL",
             "vcsRepo": "coalesce-labs/catalyst-otel"
+          },
+          {
+            "key": "SLI",
+            "vcsRepo": "ryanrozich/slides"
+          },
+          {
+            "key": "EVR",
+            "vcsRepo": "coalesce-labs/evergreen"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Adds the two newly onboarded projects to `catalyst.monitor.linear.teams[]` so Linear webhook events from those teams carry `vcs.repository.name` attribution (CTL-362 mechanism):

- **SLI** → `ryanrozich/slides`
- **EVR** → `coalesce-labs/evergreen`

All other onboarding for these projects is already in place: execution-core state contract + stateMap, registry entries (laptop + mini), Linear webhooks + per-team secrets, Layer 2 configs, thoughts symlinks.

Closes CTL-1096

🤖 Generated with [Claude Code](https://claude.com/claude-code)