### PR TITLE
CTL-1094: open broker-state DB before startup GC

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -24,6 +24,7 @@ import {
   openBrokerStateDb,
   closeBrokerStateDb,
   getActiveWaitingSessions,
+  deleteFilterState,
 } from "./broker-state.mjs";
 // CTL-532: re-export the worker-state store helpers through the barrel.
 export {
@@ -76,7 +77,6 @@ import {
   clearDebounceTimers,
 } from "./router.mjs";
 import { seedTailer, startTailing, stopTailing, loadExistingRegistrations } from "./tailer.mjs";
-import { deleteFilterState } from "./broker-state.mjs";
 import { gcStaleInterests } from "./gc-startup.mjs";
 import { getExecutionCoreDir, getRunsRoot } from "../execution-core/config.mjs";
 import { defaultStatJob } from "../execution-core/recovery.mjs";
@@ -352,6 +352,12 @@ function main() {
   loadPersistedInterests();
   loadExistingRegistrations();
 
+  // CTL-1094: open the broker-state DB before the startup GC. gcStaleInterests
+  // can call deleteFilterState() for pruned pr_lifecycle interests, which
+  // requires an open DB (ensure() throws otherwise). openBrokerStateDb() is
+  // idempotent and has no earlier-boot-step dependency.
+  openBrokerStateDb();
+
   // CTL-643: GC stale interests left over from dead orchestrators / sessions
   // before the live tailer starts ingesting filter.register events. Bulk
   // pattern (mirrors handleOrchestratorTerminated) — one log line per pruned
@@ -376,8 +382,6 @@ function main() {
   // is off by default. Single-shot info event so the HUD/operator can see them
   // without grepping broker-interests.json.
   maybeEmitProseDisabled();
-
-  openBrokerStateDb();
 
   // CTL-532: rebuild the event-sourced worker_state projection from the
   // current-month event log. Idempotent — safe to run on every (re)start.

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -4267,3 +4267,19 @@ describe("CTL-381 end-to-end: check-in → canonical webhook → filter.wake", (
     expect(countWakesInLog("filter.wake.sess-e2e")).toBe(3);
   });
 });
+
+describe("CTL-1094: broker opens broker-state DB before startup GC", () => {
+  // Read the broker boot source and compare the byte positions of the two
+  // *calls* (not the imports). openBrokerStateDb() must run before
+  // gcStaleInterests(), or the GC's deleteFilterState callback throws
+  // "broker-state DB not opened" and leaks an orphaned filter_state row.
+  const src = readFileSync(join(import.meta.dir, "index.mjs"), "utf8");
+
+  test("openBrokerStateDb() call precedes the gcStaleInterests() call", () => {
+    const openIdx = src.indexOf("openBrokerStateDb();");
+    const gcIdx = src.indexOf("gcStaleInterests({");
+    expect(openIdx).toBeGreaterThan(-1);
+    expect(gcIdx).toBeGreaterThan(-1);
+    expect(openIdx).toBeLessThan(gcIdx);
+  });
+});


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-13T00:47:47Z -->
<!-- Last updated: 2026-06-13T00:47:47Z -->
<!-- PR: #1925 -->
<!-- Previous commits: dc2c7740d0ec78b1fd5d0cdd476dd0efa1f0b329 -->

## Summary

The broker boot sequence was calling `gcStaleInterests()` before `openBrokerStateDb()` was called.
When the GC pruned a stale `pr_lifecycle` interest it invoked `deleteFilterState()`, which calls
`ensure()` internally and threw `"broker-state DB not opened"` because the DB handle was still
`null`. The throw was silently swallowed by gc-startup's `try/catch`, so the orphaned
`filter_state` row was never deleted and the warning appeared on every subsequent boot that had
stale interests.

This fix moves `openBrokerStateDb()` ahead of `gcStaleInterests()` in `main()`. The call is
idempotent and has no earlier boot-step dependency, so the reorder is safe. A duplicate
`./broker-state.mjs` import line (the `deleteFilterState` re-export at line 79) is also merged
into the existing block at line 23 — cosmetic cleanup with no behaviour change.

A source-ordering regression test is added in `index.test.mjs` that reads the compiled source and
asserts that the byte offset of `openBrokerStateDb()` precedes the byte offset of
`gcStaleInterests(` — the test would have failed before this fix.

## Changes Made

### `plugins/dev/scripts/broker/index.mjs` (+7 / -3)

- Moves `deleteFilterState` import from the duplicate block at line 79 into the consolidated
  `broker-state.mjs` import block at line 23
- Removes the duplicate `import { deleteFilterState } from "./broker-state.mjs"` line
- Inserts `openBrokerStateDb()` call with explanatory comment before `gcStaleInterests()` in
  `main()`, fixing the startup ordering bug

### `plugins/dev/scripts/broker/index.test.mjs` (+16 / -0)

- Adds `describe("CTL-1094: broker opens broker-state DB before startup GC")` block
- Single test reads `index.mjs` source text and asserts
  `openBrokerStateDb()` byte offset < `gcStaleInterests(` byte offset
- Ensures the ordering regression cannot silently re-enter

## How to Verify It

- [x] CI: all 5 checks pass (Cloudflare Pages, audit-references, check-versions, docs-gate, validate) ✅
- [x] Source-ordering regression test in `index.test.mjs` passes after fix ✅
- [x] Duplicate import removed — no duplicate symbol error on startup ✅
- [ ] Manual: restart the broker and confirm no `"broker-state DB not opened"` warning appears in logs when stale interests are present

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1094

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-623
skip CTL-633
