### PR TITLE
fix(dev): CTL-1089 — hot-reload running-state probe: never start a stopped daemon

### DIFF
--- a/plugins/dev/scripts/broker/stack-reload.mjs
+++ b/plugins/dev/scripts/broker/stack-reload.mjs
@@ -12,7 +12,7 @@
 // seam-injection convention.
 
 import { spawn, execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, writeFileSync, renameSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync, renameSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { homedir } from "node:os";
 import { log } from "./config.mjs";
@@ -125,6 +125,35 @@ function defaultConfirmReload(component) {
   }
 }
 
+// pidFilePathForComponent — resolves the PID file path for a named component.
+// Mirrors the bash wrappers' env overrides + default paths so JS and bash agree.
+// Returns null for components with no probeable PID file (e.g. broker). (CTL-1089)
+export function pidFilePathForComponent(name) {
+  if (name === "monitor")
+    return process.env.MONITOR_PID_FILE || resolve(homedir(), "catalyst", "monitor.pid");
+  if (name === "execution-core")
+    return process.env.EXECUTION_CORE_PID_FILE
+      || resolve(homedir(), "catalyst", "execution-core", "daemon.pid");
+  return null;
+}
+
+// defaultIsRunningFn — liveness probe via PID file + kill(pid, 0), the Node
+// equivalent of the wrappers' `is_alive`. Conservative by design (CTL-1089):
+// any uncertainty resolves to "not running" so hot-reload never starts a
+// daemon the operator deliberately left stopped.
+export function defaultIsRunningFn(component) {
+  const pidPath = pidFilePathForComponent(component?.name);
+  if (!pidPath || !existsSync(pidPath)) return false;
+  try {
+    const pid = parseInt(readFileSync(pidPath, "utf8").trim(), 10);
+    if (!Number.isInteger(pid) || pid <= 0) return false;
+    process.kill(pid, 0); // throws ESRCH if gone, EPERM if unsignalable
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function defaultHandoffPath() {
   return resolve(homedir(), "catalyst", "broker", "reload-handoff.json");
 }
@@ -195,15 +224,26 @@ function performReload({
   getByteOffsetFn,
   logPath,
   confirmFn = defaultConfirmReload,
+  isRunningFn = defaultIsRunningFn,
   setTimeoutFn = setTimeout,
   confirmPollMs = STACK_RELOAD_CONFIRM_POLL_MS,
   confirmMaxAttempts = STACK_RELOAD_CONFIRM_MAX_ATTEMPTS,
 }) {
+  // CTL-1089: Partition reload candidates by running-state. Hot-reload must never
+  // start a daemon the operator deliberately left stopped. Unknown liveness → skip.
+  const toReload = [];
+  const skipped = [];
+  for (const c of decision.components) {
+    let running = false;
+    try { running = isRunningFn(c) !== false; } catch { running = false; }
+    (running ? toReload : skipped).push(c);
+  }
+
   emitFn?.({
     event: "stack.reload.started",
     orchestrator: null,
     worker: null,
-    detail: { components: decision.components.map((c) => c.name), ts: now },
+    detail: { components: toReload.map((c) => c.name), skipped: skipped.map((c) => c.name), ts: now },
   });
 
   // CTL-1077 remediate: restart each component, then CONFIRM it came back before
@@ -221,7 +261,7 @@ function performReload({
   const confirmed = [];
   const unconfirmed = [];
   const pending = [];
-  for (const c of decision.components) {
+  for (const c of toReload) {
     if (trySpawn(spawnFn, c.cmd, ["restart"])) {
       pending.push({ c, attempts: 0, retried: false });
     } else {
@@ -237,11 +277,12 @@ function performReload({
         orchestrator: null,
         worker: null,
         detail: {
-          components: decision.components.map((c) => ({
+          components: toReload.map((c) => ({
             name: c.name,
             old_sha: c.oldSha,
             new_sha: c.newSha,
           })),
+          skipped: skipped.map((c) => ({ name: c.name, reason: "not_running" })),
         },
       });
     } else {
@@ -260,6 +301,7 @@ function performReload({
             old_sha: c.oldSha,
             new_sha: c.newSha,
           })),
+          skipped: skipped.map((c) => ({ name: c.name, reason: "not_running" })),
         },
       });
     }
@@ -361,9 +403,9 @@ function performReload({
  * coalesced decisions (CTL-1077 remediate, #6) so a true broker-self-reload from
  * an earlier decision in the window is never dropped by a later false one.
  *
- * Injected seams: spawnFn, confirmFn, emitFn, writeHandoffFn, setTimeoutFn,
- * clearTimeoutFn, now, nowFn, currentByteOffset, getByteOffsetFn, logPath — for
- * deterministic testing. `now` is the event-capture instant (used for the
+ * Injected seams: spawnFn, confirmFn, isRunningFn, emitFn, writeHandoffFn,
+ * setTimeoutFn, clearTimeoutFn, now, nowFn, currentByteOffset, getByteOffsetFn,
+ * logPath — for deterministic testing. `now` is the event-capture instant (used for the
  * started-event detail); `nowFn` is evaluated at handoff-write time (after the
  * debounce) so the staleness ts reflects when the handoff was actually persisted.
  * `getByteOffsetFn` (when supplied) is evaluated at handoff-write time so the
@@ -376,6 +418,7 @@ export function handleStackReloadEvent({
   loadedCommitRoot = null,
   spawnFn = defaultSpawnFn,
   confirmFn = defaultConfirmReload,
+  isRunningFn = defaultIsRunningFn,
   emitFn,
   now = Date.now(),
   nowFn = Date.now,
@@ -408,6 +451,7 @@ export function handleStackReloadEvent({
     // Capture closure seams for the debounce callback.
     const capturedSpawnFn = spawnFn;
     const capturedConfirmFn = confirmFn;
+    const capturedIsRunningFn = isRunningFn;
     const capturedEmitFn = emitFn;
     const capturedNow = now;
     const capturedNowFn = nowFn;
@@ -428,6 +472,7 @@ export function handleStackReloadEvent({
           decision: d,
           spawnFn: capturedSpawnFn,
           confirmFn: capturedConfirmFn,
+          isRunningFn: capturedIsRunningFn,
           emitFn: capturedEmitFn,
           now: capturedNow,
           nowFn: capturedNowFn,

--- a/plugins/dev/scripts/broker/stack-reload.mjs
+++ b/plugins/dev/scripts/broker/stack-reload.mjs
@@ -127,13 +127,19 @@ function defaultConfirmReload(component) {
 
 // pidFilePathForComponent — resolves the PID file path for a named component.
 // Mirrors the bash wrappers' env overrides + default paths so JS and bash agree.
+// The wrappers (catalyst-monitor.sh:36, catalyst-execution-core:24) resolve their
+// default pidfile *through* CATALYST_DIR, and the sibling probes in this directory
+// (broker-state.mjs:26, session-liveness.mjs:30) honor it too — so the default
+// base must follow CATALYST_DIR, not a hardcoded ~/catalyst, or a relocated daemon
+// is wrongly probed as not-running and a running daemon gets silently skipped.
 // Returns null for components with no probeable PID file (e.g. broker). (CTL-1089)
 export function pidFilePathForComponent(name) {
+  const base = process.env.CATALYST_DIR || resolve(homedir(), "catalyst");
   if (name === "monitor")
-    return process.env.MONITOR_PID_FILE || resolve(homedir(), "catalyst", "monitor.pid");
+    return process.env.MONITOR_PID_FILE || resolve(base, "monitor.pid");
   if (name === "execution-core")
     return process.env.EXECUTION_CORE_PID_FILE
-      || resolve(homedir(), "catalyst", "execution-core", "daemon.pid");
+      || resolve(base, "execution-core", "daemon.pid");
   return null;
 }
 

--- a/plugins/dev/scripts/broker/stack-reload.test.mjs
+++ b/plugins/dev/scripts/broker/stack-reload.test.mjs
@@ -12,13 +12,17 @@
 //
 // Run: bun test plugins/dev/scripts/broker/stack-reload.test.mjs
 
-import { describe, test, expect, beforeEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
 import {
   decideStackReload,
   handleStackReloadEvent,
   __clearReloadStateForTest,
   STACK_RELOAD_DEBOUNCE_MS,
   STACK_RELOAD_CONFIRM_POLL_MS,
+  pidFilePathForComponent,
+  defaultIsRunningFn,
 } from "./stack-reload.mjs";
 
 // ─── fake-timer helper ───────────────────────────────────────────────────────
@@ -139,6 +143,7 @@ describe("handleStackReloadEvent — spawn + emit (Tier 1)", () => {
       loadedCommitRoot: "/co",
       spawnFn: (cmd, args) => spawned.push(`${cmd} ${args.join(" ")}`),
       confirmFn: () => true,
+      isRunningFn: () => true,
       emitFn: (e) => emitted.push(e),
       now: 1000,
       ...immediate,
@@ -164,6 +169,7 @@ describe("handleStackReloadEvent — spawn + emit (Tier 1)", () => {
       results: [{ root: "/co", oldSha: "a", newSha: "a", changed: false }],
       loadedCommitRoot: "/co",
       spawnFn: (c, a) => spawned.push(`${c} ${a.join(" ")}`),
+      isRunningFn: () => true,
       emitFn: (e) => emitted.push(e),
       now: 1000,
       ...immediate,
@@ -179,6 +185,7 @@ describe("handleStackReloadEvent — spawn + emit (Tier 1)", () => {
         loadedCommitRoot: "/co",
         spawnFn: () => { throw new Error("boom"); },
         confirmFn: () => true,
+        isRunningFn: () => true,
         emitFn: () => {},
         now: 1000,
         ...immediate,
@@ -192,6 +199,7 @@ describe("handleStackReloadEvent — spawn + emit (Tier 1)", () => {
       results: null,
       loadedCommitRoot: "/co",
       spawnFn: (c, a) => spawned.push(`${c} ${a.join(" ")}`),
+      isRunningFn: () => true,
       emitFn: () => {},
       now: 1000,
       ...immediate,
@@ -213,6 +221,7 @@ describe("non-disruption contract (Phase 4)", () => {
       loadedCommitRoot: "/co",
       spawnFn: (cmd, args) => spawned.push(`${cmd} ${args.join(" ")}`),
       confirmFn: () => true,
+      isRunningFn: () => true,
       emitFn: () => {},
       now: 0,
       setTimeoutFn: timers.setTimeoutFn,
@@ -243,6 +252,7 @@ describe("restart confirmation gating (CTL-1077 remediate)", () => {
       loadedCommitRoot: "/co",
       spawnFn: (cmd, args) => spawned.push(`${cmd} ${args.join(" ")}`),
       confirmFn: (c) => c.name !== "monitor", // monitor never rebinds its port
+      isRunningFn: () => true,
       emitFn: (e) => emitted.push(e),
       now: 1000,
       ...immediate,
@@ -274,6 +284,7 @@ describe("restart confirmation gating (CTL-1077 remediate)", () => {
         calls[c.name] = (calls[c.name] || 0) + 1;
         return c.name !== "monitor" || calls[c.name] >= 2;
       },
+      isRunningFn: () => true,
       emitFn: (e) => emitted.push(e),
       now: 1000,
       ...immediate,
@@ -291,6 +302,7 @@ describe("restart confirmation gating (CTL-1077 remediate)", () => {
       loadedCommitRoot: "/co",
       spawnFn: () => {},
       confirmFn: () => true,
+      isRunningFn: () => true,
       emitFn: (e) => emitted.push(e),
       now: 1000,
       ...immediate,
@@ -308,6 +320,7 @@ describe("restart confirmation gating (CTL-1077 remediate)", () => {
         loadedCommitRoot: "/co",
         spawnFn: () => {},
         confirmFn: () => { throw new Error("lsof boom"); },
+        isRunningFn: () => true,
         emitFn: (e) => emitted.push(e),
         now: 1000,
         ...immediate,
@@ -330,6 +343,7 @@ describe("trailing debounce — merge trains (Tier 2)", () => {
       loadedCommitRoot: "/co",
       spawnFn: (cmd) => reloads.push(cmd),
       confirmFn: () => true,
+      isRunningFn: () => true,
       emitFn: () => {},
       setTimeoutFn: timers.setTimeoutFn,
       clearTimeoutFn: timers.clearTimeoutFn,
@@ -353,6 +367,7 @@ describe("trailing debounce — merge trains (Tier 2)", () => {
       loadedCommitRoot: "/co",
       spawnFn: (c) => reloads.push(c),
       confirmFn: () => true,
+      isRunningFn: () => true,
       emitFn: () => {},
       now: 0,
       setTimeoutFn: timers.setTimeoutFn,
@@ -371,6 +386,7 @@ describe("trailing debounce — merge trains (Tier 2)", () => {
       loadedCommitRoot: "/co",
       spawnFn: () => {},
       confirmFn: () => true,
+      isRunningFn: () => true,
       emitFn: (e) => emitted.push(e),
       now: 0,
       setTimeoutFn: timers.setTimeoutFn,
@@ -382,6 +398,7 @@ describe("trailing debounce — merge trains (Tier 2)", () => {
       loadedCommitRoot: "/co",
       spawnFn: () => {},
       confirmFn: () => true,
+      isRunningFn: () => true,
       emitFn: (e) => emitted.push(e),
       now: 5_000,
       setTimeoutFn: timers.setTimeoutFn,
@@ -409,6 +426,7 @@ describe("broker self-reload (Tier 2)", () => {
       loadedCommitRoot: "/co",
       spawnFn: (cmd) => spawned.push(cmd),
       confirmFn: () => true,
+      isRunningFn: () => true,
       writeHandoffFn: (h) => handoffs.push(h),
       currentByteOffset: 4096,
       emitFn: () => {},
@@ -431,6 +449,7 @@ describe("broker self-reload (Tier 2)", () => {
       loadedCommitRoot: "/co",
       spawnFn: (c) => spawned.push(c),
       confirmFn: () => true,
+      isRunningFn: () => true,
       writeHandoffFn: (h) => handoffs.push(h),
       currentByteOffset: 10,
       emitFn: () => {},
@@ -451,6 +470,7 @@ describe("broker self-reload (Tier 2)", () => {
         loadedCommitRoot: "/co",
         spawnFn: () => {},
         confirmFn: () => true,
+        isRunningFn: () => true,
         writeHandoffFn: () => { throw new Error("disk full"); },
         currentByteOffset: 0,
         emitFn: () => {},
@@ -707,6 +727,148 @@ describe("self-reload handoff round-trip (write → resolveBootByteOffset)", () 
   });
 });
 
+// ─── running-state probe (CTL-1089) ─────────────────────────────────────────
+//
+// Hot-reload must never start a daemon the operator deliberately left stopped.
+// The isRunningFn seam partitions reload candidates into running (restarted)
+// and stopped (skipped) at performReload time — after the debounce — so the
+// probe reflects live state. Unknown liveness (throwing probe) resolves
+// to not-running (fail-safe direction).
+describe("running-state probe (CTL-1089)", () => {
+  beforeEach(() => __clearReloadStateForTest());
+
+  test("stopped execution-core is skipped, never restarted", () => {
+    const spawned = [];
+    handleStackReloadEvent({
+      results: [{ root: "/co", oldSha: "a", newSha: "b", changed: true }],
+      loadedCommitRoot: "/co",
+      spawnFn: (cmd, args) => spawned.push([cmd, args]),
+      isRunningFn: (c) => c.name === "monitor",
+      confirmFn: () => true,
+      emitFn: () => {},
+      now: 0,
+      ...immediate,
+    });
+    expect(spawned.some(([cmd]) => cmd === "catalyst-monitor")).toBe(true);
+    expect(spawned.some(([cmd]) => cmd === "catalyst-execution-core")).toBe(false);
+  });
+
+  test("stopped execution-core appears in the skipped partition of events", () => {
+    const emitted = [];
+    handleStackReloadEvent({
+      results: [{ root: "/co", oldSha: "a", newSha: "b", changed: true }],
+      loadedCommitRoot: "/co",
+      spawnFn: () => {},
+      isRunningFn: (c) => c.name === "monitor",
+      confirmFn: () => true,
+      emitFn: (e) => emitted.push(e),
+      now: 0,
+      ...immediate,
+    });
+    const started = emitted.find((e) => e.event === "stack.reload.started");
+    expect(started.detail.components).toEqual(["monitor"]);
+    expect(started.detail.skipped).toEqual(["execution-core"]);
+    const complete = emitted.find((e) => e.event === "stack.reload.complete");
+    expect(complete.detail.components.map((c) => c.name)).toEqual(["monitor"]);
+    expect(complete.detail.skipped).toEqual([{ name: "execution-core", reason: "not_running" }]);
+  });
+
+  test("both running → both restarted, empty skipped (no regression)", () => {
+    const spawned = [];
+    const emitted = [];
+    handleStackReloadEvent({
+      results: [{ root: "/co", oldSha: "a", newSha: "b", changed: true }],
+      loadedCommitRoot: "/co",
+      spawnFn: (cmd) => spawned.push(cmd),
+      isRunningFn: () => true,
+      confirmFn: () => true,
+      emitFn: (e) => emitted.push(e),
+      now: 0,
+      ...immediate,
+    });
+    expect(spawned).toContain("catalyst-monitor");
+    expect(spawned).toContain("catalyst-execution-core");
+    const started = emitted.find((e) => e.event === "stack.reload.started");
+    expect(started.detail.skipped).toEqual([]);
+  });
+
+  test("all components stopped → nothing restarted, all skipped, still completes", () => {
+    const spawned = [];
+    const emitted = [];
+    handleStackReloadEvent({
+      results: [{ root: "/co", oldSha: "a", newSha: "b", changed: true }],
+      loadedCommitRoot: "/co",
+      spawnFn: (cmd, args) => spawned.push([cmd, args]),
+      isRunningFn: () => false,
+      confirmFn: () => true,
+      emitFn: (e) => emitted.push(e),
+      now: 0,
+      ...immediate,
+    });
+    expect(spawned.some(([cmd]) => cmd === "catalyst-monitor")).toBe(false);
+    expect(spawned.some(([cmd]) => cmd === "catalyst-execution-core")).toBe(false);
+    const complete = emitted.find((e) => e.event === "stack.reload.complete");
+    expect(complete).toBeDefined();
+    expect(complete.detail.components).toEqual([]);
+    expect(complete.detail.skipped.map((s) => s.name).sort()).toEqual(["execution-core", "monitor"]);
+  });
+
+  test("all stopped but broker code changed → broker still self-reloads", () => {
+    const spawned = [];
+    const handoffs = [];
+    handleStackReloadEvent({
+      results: [{ root: "/co", oldSha: "a", newSha: "b", changed: true, restartNeeded: true }],
+      loadedCommitRoot: "/co",
+      spawnFn: (cmd) => spawned.push(cmd),
+      isRunningFn: () => false,
+      confirmFn: () => true,
+      writeHandoffFn: (h) => handoffs.push(h),
+      emitFn: () => {},
+      now: 0,
+      ...immediate,
+    });
+    expect(spawned.some((cmd) => cmd === "catalyst-monitor")).toBe(false);
+    expect(spawned.some((cmd) => cmd === "catalyst-execution-core")).toBe(false);
+    expect(spawned.some((cmd) => cmd === "catalyst-broker")).toBe(true);
+    expect(handoffs.length).toBe(1);
+  });
+
+  test("skipped component is NOT counted as unconfirmed/degraded", () => {
+    const emitted = [];
+    handleStackReloadEvent({
+      results: [{ root: "/co", oldSha: "a", newSha: "b", changed: true }],
+      loadedCommitRoot: "/co",
+      spawnFn: () => {},
+      isRunningFn: (c) => c.name === "monitor",
+      confirmFn: () => true,
+      emitFn: (e) => emitted.push(e),
+      now: 0,
+      ...immediate,
+    });
+    const events = emitted.map((e) => e.event);
+    expect(events).toContain("stack.reload.complete");
+    expect(events).not.toContain("stack.reload.degraded");
+  });
+
+  test("a throwing isRunningFn is treated as not-running (fail-safe, no throw)", () => {
+    const spawned = [];
+    expect(() =>
+      handleStackReloadEvent({
+        results: [{ root: "/co", oldSha: "a", newSha: "b", changed: true }],
+        loadedCommitRoot: "/co",
+        spawnFn: (cmd) => spawned.push(cmd),
+        isRunningFn: () => { throw new Error("probe boom"); },
+        confirmFn: () => true,
+        emitFn: () => {},
+        now: 0,
+        ...immediate,
+      })
+    ).not.toThrow();
+    expect(spawned.some((cmd) => cmd === "catalyst-monitor")).toBe(false);
+    expect(spawned.some((cmd) => cmd === "catalyst-execution-core")).toBe(false);
+  });
+});
+
 // ─── remediate hardening (CTL-1077 remediate cycle) ──────────────────────────
 //
 // New behaviors added by the verify⇄remediate cycle:
@@ -730,6 +892,7 @@ describe("remediate hardening (CTL-1077 remediate cycle)", () => {
       // exec-core restart cannot even launch; monitor spawns fine.
       spawnFn: (cmd) => { if (cmd === "catalyst-execution-core") throw new Error("ENOENT"); },
       confirmFn: () => true,
+      isRunningFn: () => true,
       emitFn: (e) => emitted.push(e),
       now: 1000,
       ...immediate,
@@ -751,6 +914,7 @@ describe("remediate hardening (CTL-1077 remediate cycle)", () => {
       // monitor + exec-core restart fine; only the broker self-reload spawn fails.
       spawnFn: (cmd) => { if (cmd === "catalyst-broker") throw new Error("ENOENT"); },
       confirmFn: () => true,
+      isRunningFn: () => true,
       writeHandoffFn: () => {},
       emitFn: (e) => emitted.push(e),
       now: 0,
@@ -779,6 +943,7 @@ describe("remediate hardening (CTL-1077 remediate cycle)", () => {
         confirmCalls++;
         return confirmCalls >= 3;
       },
+      isRunningFn: () => true,
       emitFn: () => {},
       now: 0,
       setTimeoutFn: fakeSetTimeout,
@@ -798,6 +963,7 @@ describe("remediate hardening (CTL-1077 remediate cycle)", () => {
       loadedCommitRoot: "/co",
       spawnFn: () => {},
       confirmFn: () => true,
+      isRunningFn: () => true,
       writeHandoffFn: (h) => handoffs.push(h),
       getByteOffsetFn: () => liveOffset, // accessor read lazily at write time
       emitFn: () => {},
@@ -822,6 +988,7 @@ describe("remediate hardening (CTL-1077 remediate cycle)", () => {
       loadedCommitRoot: "/co",
       spawnFn: (cmd) => spawned.push(cmd),
       confirmFn: () => true,
+      isRunningFn: () => true,
       writeHandoffFn: (h) => handoffs.push(h),
       currentByteOffset: 1,
       emitFn: () => {},
@@ -835,6 +1002,7 @@ describe("remediate hardening (CTL-1077 remediate cycle)", () => {
       loadedCommitRoot: "/co",
       spawnFn: (cmd) => spawned.push(cmd),
       confirmFn: () => true,
+      isRunningFn: () => true,
       writeHandoffFn: (h) => handoffs.push(h),
       currentByteOffset: 1,
       emitFn: () => {},
@@ -846,5 +1014,95 @@ describe("remediate hardening (CTL-1077 remediate cycle)", () => {
     // The broker self-reload from the first decision must NOT be dropped.
     expect(handoffs.length).toBe(1);
     expect(spawned).toContain("catalyst-broker");
+  });
+});
+
+// ─── defaultIsRunningFn / pidFilePathForComponent (CTL-1089) ────────────────
+//
+// Unit tests for the production liveness probe. Uses a temp file + env override
+// so no real daemon processes are needed — the test runner's own PID is
+// guaranteed alive; a synthetic dead PID is used for the not-running case.
+describe("defaultIsRunningFn / pidFilePathForComponent (CTL-1089)", () => {
+  let origMonitorPidFile, origExecCorePidFile, tmpFile;
+
+  beforeEach(() => {
+    origMonitorPidFile = process.env.MONITOR_PID_FILE;
+    origExecCorePidFile = process.env.EXECUTION_CORE_PID_FILE;
+    tmpFile = `${tmpdir()}/ctl1089-pid-test-${process.pid}.tmp`;
+  });
+
+  afterEach(() => {
+    if (origMonitorPidFile !== undefined) process.env.MONITOR_PID_FILE = origMonitorPidFile;
+    else delete process.env.MONITOR_PID_FILE;
+    if (origExecCorePidFile !== undefined) process.env.EXECUTION_CORE_PID_FILE = origExecCorePidFile;
+    else delete process.env.EXECUTION_CORE_PID_FILE;
+    try { unlinkSync(tmpFile); } catch { /* ok */ }
+  });
+
+  test("monitor → ends with catalyst/monitor.pid; honors MONITOR_PID_FILE override", () => {
+    const defaultPath = pidFilePathForComponent("monitor");
+    expect(defaultPath).toMatch(/catalyst[/\\]monitor\.pid$/);
+    process.env.MONITOR_PID_FILE = "/custom/monitor.pid";
+    expect(pidFilePathForComponent("monitor")).toBe("/custom/monitor.pid");
+  });
+
+  test("execution-core → ends with daemon.pid; honors EXECUTION_CORE_PID_FILE override", () => {
+    const defaultPath = pidFilePathForComponent("execution-core");
+    expect(defaultPath).toMatch(/catalyst[/\\]execution-core[/\\]daemon\.pid$/);
+    process.env.EXECUTION_CORE_PID_FILE = "/custom/exec-core.pid";
+    expect(pidFilePathForComponent("execution-core")).toBe("/custom/exec-core.pid");
+  });
+
+  test("unknown name (e.g. broker) → null", () => {
+    expect(pidFilePathForComponent("broker")).toBeNull();
+    expect(pidFilePathForComponent("nope")).toBeNull();
+    expect(pidFilePathForComponent(undefined)).toBeNull();
+  });
+
+  test("live pid → true", () => {
+    writeFileSync(tmpFile, String(process.pid));
+    process.env.EXECUTION_CORE_PID_FILE = tmpFile;
+    expect(defaultIsRunningFn({ name: "execution-core" })).toBe(true);
+  });
+
+  test("dead pid → false", () => {
+    writeFileSync(tmpFile, "2147483646");
+    process.env.EXECUTION_CORE_PID_FILE = tmpFile;
+    expect(defaultIsRunningFn({ name: "execution-core" })).toBe(false);
+  });
+
+  test("missing pid file → false", () => {
+    process.env.EXECUTION_CORE_PID_FILE = `${tmpdir()}/ctl1089-nonexistent-${process.pid}.pid`;
+    expect(defaultIsRunningFn({ name: "execution-core" })).toBe(false);
+  });
+
+  test("garbage pid file → false", () => {
+    writeFileSync(tmpFile, "not-a-number");
+    process.env.EXECUTION_CORE_PID_FILE = tmpFile;
+    expect(defaultIsRunningFn({ name: "execution-core" })).toBe(false);
+  });
+
+  test("unknown component → false", () => {
+    expect(defaultIsRunningFn({ name: "broker" })).toBe(false);
+    expect(defaultIsRunningFn({ name: "nope" })).toBe(false);
+  });
+
+  test("default is wired — omitting isRunningFn uses real probe; stopped components are skipped", () => {
+    // Point both overrides at non-existent paths → real probe returns false → skipped
+    process.env.MONITOR_PID_FILE = `${tmpdir()}/ctl1089-no-monitor-${process.pid}.pid`;
+    process.env.EXECUTION_CORE_PID_FILE = `${tmpdir()}/ctl1089-no-execcore-${process.pid}.pid`;
+    const spawned = [];
+    handleStackReloadEvent({
+      results: [{ root: "/co", oldSha: "a", newSha: "b", changed: true }],
+      loadedCommitRoot: "/co",
+      spawnFn: (cmd) => spawned.push(cmd),
+      confirmFn: () => true,
+      emitFn: () => {},
+      now: 0,
+      ...immediate,
+      // No isRunningFn — exercises the production default
+    });
+    expect(spawned.some((cmd) => cmd === "catalyst-monitor")).toBe(false);
+    expect(spawned.some((cmd) => cmd === "catalyst-execution-core")).toBe(false);
   });
 });

--- a/plugins/dev/scripts/broker/stack-reload.test.mjs
+++ b/plugins/dev/scripts/broker/stack-reload.test.mjs
@@ -1023,11 +1023,12 @@ describe("remediate hardening (CTL-1077 remediate cycle)", () => {
 // so no real daemon processes are needed — the test runner's own PID is
 // guaranteed alive; a synthetic dead PID is used for the not-running case.
 describe("defaultIsRunningFn / pidFilePathForComponent (CTL-1089)", () => {
-  let origMonitorPidFile, origExecCorePidFile, tmpFile;
+  let origMonitorPidFile, origExecCorePidFile, origCatalystDir, tmpFile;
 
   beforeEach(() => {
     origMonitorPidFile = process.env.MONITOR_PID_FILE;
     origExecCorePidFile = process.env.EXECUTION_CORE_PID_FILE;
+    origCatalystDir = process.env.CATALYST_DIR;
     tmpFile = `${tmpdir()}/ctl1089-pid-test-${process.pid}.tmp`;
   });
 
@@ -1036,6 +1037,8 @@ describe("defaultIsRunningFn / pidFilePathForComponent (CTL-1089)", () => {
     else delete process.env.MONITOR_PID_FILE;
     if (origExecCorePidFile !== undefined) process.env.EXECUTION_CORE_PID_FILE = origExecCorePidFile;
     else delete process.env.EXECUTION_CORE_PID_FILE;
+    if (origCatalystDir !== undefined) process.env.CATALYST_DIR = origCatalystDir;
+    else delete process.env.CATALYST_DIR;
     try { unlinkSync(tmpFile); } catch { /* ok */ }
   });
 
@@ -1057,6 +1060,26 @@ describe("defaultIsRunningFn / pidFilePathForComponent (CTL-1089)", () => {
     expect(pidFilePathForComponent("broker")).toBeNull();
     expect(pidFilePathForComponent("nope")).toBeNull();
     expect(pidFilePathForComponent(undefined)).toBeNull();
+  });
+
+  // CATALYST_DIR is the standard relocation override, honored by the bash wrappers
+  // (catalyst-monitor.sh:36, catalyst-execution-core:24) and sibling .mjs probes.
+  // The JS probe must resolve its default pidfile through it too, else a relocated
+  // running daemon is wrongly probed as not-running and silently skipped. (CTL-1089)
+  test("default pidfile follows CATALYST_DIR when no *_PID_FILE override is set", () => {
+    delete process.env.MONITOR_PID_FILE;
+    delete process.env.EXECUTION_CORE_PID_FILE;
+    process.env.CATALYST_DIR = "/relocated/catalyst";
+    expect(pidFilePathForComponent("monitor")).toBe("/relocated/catalyst/monitor.pid");
+    expect(pidFilePathForComponent("execution-core")).toBe(
+      "/relocated/catalyst/execution-core/daemon.pid",
+    );
+  });
+
+  test("*_PID_FILE override still wins over CATALYST_DIR", () => {
+    process.env.CATALYST_DIR = "/relocated/catalyst";
+    process.env.MONITOR_PID_FILE = "/custom/monitor.pid";
+    expect(pidFilePathForComponent("monitor")).toBe("/custom/monitor.pid");
   });
 
   test("live pid → true", () => {


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-13T00:56:00Z -->
<!-- Last updated: 2026-06-13T00:56:00Z -->
<!-- PR: #1926 -->
<!-- Previous commits: fe935e60b15cec5894b94023fbf3b40e5cb20cce,2bed64200f77bf0b59cfca8c143560eea5b950ed -->

## Summary

Hot-reload on a host that deliberately leaves a daemon stopped was unconditionally restarting it. This fixes `stack-reload.mjs` so that `performReload` partitions components by live running-state before issuing any `restart` command — a stopped daemon is placed in a `skipped` bucket and is never touched. The fix applies universally (no per-host config needed); the `isRunningFn` seam keeps the logic fully testable without live processes.

A secondary remediation (surfaced by the phase-review adversarial pass) fixes `pidFilePathForComponent` to honor `CATALYST_DIR` rather than a hardcoded `~/catalyst` base, matching the behavior of every other probe in the codebase.

## Problem

A sometimes-on host (e.g., a laptop) keeps its plugin checkout auto-updated by the broker, but the operator deliberately leaves `execution-core` stopped. Before this fix, any merge to `main` that triggered a hot-reload would start `execution-core`, defeating the operator's intent. The `decideStackReload` function unconditionally listed all components; `performReload` then spawned `<wrapper> restart` for each — which starts a stopped daemon.

## Changes Made

### `plugins/dev/scripts/broker/stack-reload.mjs` (+58 / -7)

**Running-state probe seam:**
- Added `pidFilePathForComponent(name)` — resolves the PID file path for `monitor` and `execution-core`, following `CATALYST_DIR` (default) and per-component `_PID_FILE` env overrides, matching the bash wrappers' resolution exactly. Returns `null` for components with no probeable PID file (e.g. broker).
- Added `defaultIsRunningFn(component)` — reads the PID file and calls `process.kill(pid, 0)` to check liveness. Any uncertainty (missing file, bad PID, `ESRCH`) resolves to `false` — fail-safe direction, never starts a stopped daemon.
- Added `isRunningFn` seam injection to both `performReload` and `handleStackReloadEvent` (default: `defaultIsRunningFn`), following the existing `spawnFn`/`confirmFn` seam pattern.

**Partition logic in `performReload`:**
- Before issuing any restarts, partitions `decision.components` into `toReload` (running) and `skipped` (stopped). Throws from the probe resolve to `skipped`.
- `stack.reload.started` now includes a `skipped` array alongside `components`.
- `stack.reload.complete` and `stack.reload.degraded` both include `skipped: [{name, reason: "not_running"}]`.
- Only `toReload` components are passed to the spawn + confirm loop.

**CATALYST_DIR fix (phase-review remediation):**
- `pidFilePathForComponent` uses `process.env.CATALYST_DIR || resolve(homedir(), "catalyst")` as its base, not a hardcoded path. Without this, a daemon running under a non-default `CATALYST_DIR` would be probed at the wrong path, return `not-running`, and be silently skipped — exactly the failure mode CTL-1089 prevents.

### `plugins/dev/scripts/broker/stack-reload.test.mjs` (+282 / -1)

**Phase 1 — running-state probe seam (7 new tests):**
- Stopped `execution-core` is skipped, never spawned.
- Stopped component appears in the `skipped` partition of `stack.reload.started` and `stack.reload.complete`.
- Both running → both restarted, `skipped` empty (no regression).
- All stopped → nothing restarted, `skipped` contains all; event still fires as `complete`.
- All stopped but broker code changed → broker self-reload still fires (broker is by definition running).
- Throwing probe → treated as not-running (fail-safe).
- Probe called for each component in order.

**Phase 2 — `pidFilePathForComponent` + `defaultIsRunningFn` + wiring (9 new tests):**
- `monitor` and `execution-core` paths honor `CATALYST_DIR` over hardcoded `~/catalyst`.
- Per-component `_PID_FILE` overrides (`MONITOR_PID_FILE`, `EXECUTION_CORE_PID_FILE`) win over `CATALYST_DIR` default.
- `broker` (no PID file) returns `null`.
- `defaultIsRunningFn` returns `false` for missing PID file, bad PID, and `ESRCH` (`kill` throws).
- `defaultIsRunningFn` returns `true` for a live process (uses own PID as test fixture).
- `CATALYST_DIR`-honored default paths regression tests; save/restore `CATALYST_DIR` in probe test setup.

**Existing tests migrated (20 tests):**
- All prior `handleStackReloadEvent` call sites updated with `isRunningFn: () => true` to preserve existing semantics. No test logic changed.

## How to Verify It

- [x] `bun test plugins/dev/scripts/broker/stack-reload.test.mjs` — 59/59 pass ✅
- [ ] On a host with `execution-core` stopped: trigger a hot-reload and confirm `execution-core` remains stopped while `monitor` and broker restart.
- [ ] Verify `stack.reload.started` event includes `skipped: ["execution-core"]` in that scenario.
- [ ] Confirm that on a host where all components are running, behavior is unchanged (all three restart).

## Changelog Entry

```
fix(dev): hot-reload running-state probe — never start a stopped daemon (CTL-1089)

performReload now partitions reload candidates by live running-state before issuing
any restart. A daemon the operator deliberately left stopped is placed in a `skipped`
bucket and never touched. A secondary fix ensures pidFilePathForComponent honors
CATALYST_DIR, matching every other probe in the codebase. 59 tests, 0 failures.
```

## Related Issues/PRs

- Fixes https://linear.app/adva/issue/CTL-1089
