### PR TITLE
feat(dev): CTL-1095 — node drain mode: refuse new-work admission, CLI toggle, HUD display

### DIFF
--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -233,19 +233,30 @@ cmd_status() {
 	for arg in "$@"; do
 		[ "$arg" = "--json" ] && want_json=1
 	done
+	# CTL-1095: read drain state (shell out to drain.mjs --json for the inFlightCount).
+	local drain_json draining in_flight_count
+	drain_json=$(exec_runtime_module "drain" --json --status-read 2>/dev/null || echo '{"draining":false,"inFlightCount":0}')
+	draining=$(printf '%s' "$drain_json" | grep -o '"draining":[^,}]*' | cut -d: -f2 | tr -d ' ' || echo false)
+	in_flight_count=$(printf '%s' "$drain_json" | grep -o '"inFlightCount":[^,}]*' | cut -d: -f2 | tr -d ' ' || echo 0)
 	local pid
 	if pid=$(read_pid); then
 		if [ "$want_json" -eq 1 ]; then
-			printf '{"running":true,"pid":%s}\n' "$pid"
+			printf '{"running":true,"pid":%s,"draining":%s,"inFlightCount":%s}\n' "$pid" "$draining" "$in_flight_count"
 		else
 			echo "running (pid $pid)"
+			if [ "$draining" = "true" ]; then
+				echo "draining — ${in_flight_count} tickets to land"
+			fi
 		fi
 		return 0
 	fi
 	if [ "$want_json" -eq 1 ]; then
-		printf '{"running":false,"pid":null}\n'
+		printf '{"running":false,"pid":null,"draining":%s,"inFlightCount":%s}\n' "$draining" "$in_flight_count"
 	else
 		echo "stopped"
+		if [ "$draining" = "true" ]; then
+			echo "draining — ${in_flight_count} tickets to land"
+		fi
 	fi
 }
 
@@ -355,6 +366,10 @@ Commands:
   branches    inventory / delete merged or orphaned branch refs (list|prune)
   tidy        run sessions → worktrees → branches in the safe order, then prune git admin records
   governance  show which governance modes the daemon is actually running (--json)
+  drain       toggle node drain mode: refuse new-work admission while draining
+              Usage: catalyst-execution-core drain [--off] [--json]
+              drain         set drain flag — no new tickets admitted; in-flight pipelines finish
+              drain --off   lift drain flag — normal admission resumes
 
 Backcompat: start|stop|restart|probe|status work as top-level aliases for the daemon verbs.
 
@@ -404,6 +419,11 @@ if ! (return 0 2>/dev/null); then
 		module="$1"
 		shift
 		exec_runtime_module "$module" "$@"
+		;;
+	# CTL-1095: drain mode toggle.
+	drain)
+		shift
+		exec_runtime_module "drain" "$@"
 		;;
 	# CTL-1084: governance-env-exports emits eval-safe export lines for the four
 	# beliefs flags resolved from durable Layer-2 config. The file is named

--- a/plugins/dev/scripts/execution-core/cli/drain.mjs
+++ b/plugins/dev/scripts/execution-core/cli/drain.mjs
@@ -1,0 +1,70 @@
+// cli/drain.mjs — CTL-1095. `catalyst-execution-core drain [--off] [--json]`
+//
+// Toggles the drain flag file, emits node.drain.changed, and prints drain
+// state with in-flight count. setDrain and readDrainStatus are pure business
+// logic, exported for unit tests; main() is the CLI entry point.
+
+import { writeFileSync, rmSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { getExecutionCoreDir, getDrainFlagPath, isDraining } from "../config.mjs";
+import { listInFlightTickets } from "../scheduler.mjs";
+import { emitDrainChangedEvent } from "../drain-event.mjs";
+
+/**
+ * readDrainStatus — pure read of current drain state + in-flight count.
+ * @param {string} [orchDir]
+ * @returns {{ draining: boolean, inFlightCount: number }}
+ */
+export function readDrainStatus(orchDir) {
+  const dir = orchDir ?? getExecutionCoreDir();
+  const draining = isDraining(dir);
+  const inFlightCount = listInFlightTickets(dir).size;
+  return { draining, inFlightCount };
+}
+
+/**
+ * setDrain — toggle the drain flag, emit node.drain.changed.
+ * @param {string} [orchDir]
+ * @param {{ off?: boolean }} [opts]
+ * @returns {{ draining: boolean, inFlightCount: number }}
+ */
+export function setDrain(orchDir, { off = false } = {}) {
+  const dir = orchDir ?? getExecutionCoreDir();
+  const flagPath = getDrainFlagPath(dir);
+  if (off) {
+    try { rmSync(flagPath, { force: true }); } catch { /* best-effort */ }
+  } else {
+    try { writeFileSync(flagPath, ""); } catch { /* best-effort */ }
+  }
+  const status = readDrainStatus(dir);
+  emitDrainChangedEvent({ draining: status.draining, inFlightCount: status.inFlightCount });
+  return status;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const json = argv.includes("--json");
+  const off = argv.includes("--off");
+  const readOnly = argv.includes("--status-read");
+  const orchDir = getExecutionCoreDir();
+  const status = readOnly ? readDrainStatus(orchDir) : setDrain(orchDir, { off });
+
+  if (json) {
+    process.stdout.write(JSON.stringify(status) + "\n");
+  } else if (status.draining) {
+    process.stdout.write(
+      `draining — ${status.inFlightCount} ticket${status.inFlightCount === 1 ? "" : "s"} to land\n`
+    );
+  } else {
+    process.stdout.write("not draining\n");
+  }
+  process.exitCode = 0;
+}
+
+const isEntry =
+  import.meta.main === true ||
+  (typeof import.meta.url === "string" &&
+    fileURLToPath(import.meta.url) === process.argv[1]);
+
+if (isEntry) {
+  main();
+}

--- a/plugins/dev/scripts/execution-core/cli/drain.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/drain.test.mjs
@@ -1,0 +1,75 @@
+// cli/drain.test.mjs — CTL-1095. Unit tests for setDrain / readDrainStatus.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test cli/drain.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, existsSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setDrain, readDrainStatus } from "./drain.mjs";
+
+let tmp;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "ctl1095-cli-drain-"));
+  // Create workers dir so listInFlightTickets has somewhere to scan
+  mkdirSync(join(tmp, "workers"), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("setDrain (CTL-1095)", () => {
+  test("setDrain creates flag and returns draining:true + inFlightCount:0", () => {
+    const r = setDrain(tmp, { off: false });
+    expect(r.draining).toBe(true);
+    expect(existsSync(join(tmp, "drain"))).toBe(true);
+    expect(r.inFlightCount).toBe(0);
+  });
+
+  test("setDrain --off removes flag and returns draining:false", () => {
+    writeFileSync(join(tmp, "drain"), "");
+    const r = setDrain(tmp, { off: true });
+    expect(r.draining).toBe(false);
+    expect(existsSync(join(tmp, "drain"))).toBe(false);
+  });
+
+  test("setDrain --off on already-not-draining is a no-op", () => {
+    const r = setDrain(tmp, { off: true });
+    expect(r.draining).toBe(false);
+    expect(existsSync(join(tmp, "drain"))).toBe(false);
+  });
+
+  test("setDrain when already draining is idempotent", () => {
+    writeFileSync(join(tmp, "drain"), "");
+    const r = setDrain(tmp, { off: false });
+    expect(r.draining).toBe(true);
+    expect(existsSync(join(tmp, "drain"))).toBe(true);
+  });
+});
+
+describe("readDrainStatus (CTL-1095)", () => {
+  test("returns draining:false + inFlightCount:0 when no flag", () => {
+    const s = readDrainStatus(tmp);
+    expect(s.draining).toBe(false);
+    expect(s.inFlightCount).toBe(0);
+  });
+
+  test("returns draining:true when flag is present", () => {
+    writeFileSync(join(tmp, "drain"), "");
+    const s = readDrainStatus(tmp);
+    expect(s.draining).toBe(true);
+  });
+
+  test("inFlightCount reflects in-flight workers", () => {
+    // Seed one running worker signal
+    const wDir = join(tmp, "workers", "CTL-test");
+    mkdirSync(wDir, { recursive: true });
+    writeFileSync(join(wDir, "phase-implement.json"), JSON.stringify({
+      ticket: "CTL-test", phase: "implement", status: "running",
+    }));
+    const s = readDrainStatus(tmp);
+    expect(s.inFlightCount).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -7,8 +7,8 @@
 // daemons pin a stable value at launch.
 
 import { homedir, hostname } from "node:os";
-import { resolve } from "node:path";
-import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { readFileSync, existsSync } from "node:fs";
 
 // --- Logger (CTL-578) ---
 // Pino is the daemon's runtime logger. A worktree checkout that hasn't run
@@ -66,6 +66,15 @@ function catalystDir() {
 
 export function getExecutionCoreDir() {
   return resolve(catalystDir(), "execution-core");
+}
+
+// CTL-1095: drain-flag file. Presence = node is draining (refuse new work).
+export function getDrainFlagPath(orchDir) {
+  return join(orchDir, "drain");
+}
+
+export function isDraining(orchDir) {
+  return existsSync(getDrainFlagPath(orchDir));
 }
 
 export function getEligibleDir() {

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -26,6 +26,8 @@ import {
   getClusterHosts,
   HEARTBEAT_INTERVAL_MS,
   hostMembershipWarning,
+  getDrainFlagPath,
+  isDraining,
 } from "./config.mjs";
 
 const PREV = process.env.CATALYST_WAIT_WATCHER;
@@ -459,5 +461,38 @@ describe("hostMembershipWarning (CTL-1057)", () => {
   test("no warning for non-array roster", () => {
     expect(hostMembershipWarning(null, "laptop")).toBeNull();
     expect(hostMembershipWarning(undefined, "laptop")).toBeNull();
+  });
+});
+
+describe("getDrainFlagPath + isDraining (CTL-1095)", () => {
+  let tmp;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "drain-cfg-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("getDrainFlagPath joins orchDir/drain", () => {
+    expect(getDrainFlagPath("/tmp/ec")).toBe(join("/tmp/ec", "drain"));
+  });
+
+  test("isDraining is false when no flag file", () => {
+    expect(isDraining(tmp)).toBe(false);
+  });
+
+  test("isDraining is true when flag file is present", () => {
+    writeFileSync(join(tmp, "drain"), "");
+    expect(isDraining(tmp)).toBe(true);
+  });
+
+  test("isDraining returns false again after flag is removed", () => {
+    const flag = join(tmp, "drain");
+    writeFileSync(flag, "");
+    expect(isDraining(tmp)).toBe(true);
+    rmSync(flag);
+    expect(isDraining(tmp)).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/drain-event.mjs
+++ b/plugins/dev/scripts/execution-core/drain-event.mjs
@@ -1,0 +1,127 @@
+// drain-event.mjs — CTL-1095. Node drain event builder + best-effort appender.
+//
+// Mirrors heartbeat-event.mjs: OTel envelope, appendFileSync, never throws.
+// Two event types:
+//   node.drain.changed — operator toggled the drain flag (on or off)
+//   node.drain.drained — last in-flight ticket landed while draining
+//
+// Both are best-effort: a write failure returns false and logs a warning;
+// callers never branch on the return value for correctness.
+
+import { mkdirSync, appendFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getEventLogPath, getHostName, log } from "./config.mjs";
+import { hostName, hostId } from "./lib/host-identity.mjs";
+
+export const DRAIN_CHANGED_EVENT = "node.drain.changed";
+export const DRAINED_EVENT = "node.drain.drained";
+
+/**
+ * buildDrainChangedEnvelope — pure OTel envelope for a drain toggle.
+ */
+export function buildDrainChangedEnvelope({ draining, inFlightCount, now } = {}) {
+  const ts = now ? now() : new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const host = getHostName();
+  return {
+    ts,
+    id: randomBytes(8).toString("hex"),
+    observedTs: ts,
+    severityText: "INFO",
+    severityNumber: 9,
+    traceId: null,
+    spanId: null,
+    resource: {
+      "service.name": "catalyst.execution-core",
+      "service.namespace": "catalyst",
+      "host.name": hostName(),
+      "host.id": hostId(),
+    },
+    attributes: {
+      "event.name": DRAIN_CHANGED_EVENT,
+      "event.entity": "node",
+      "event.action": "drain.changed",
+      "event.label": host,
+    },
+    body: {
+      payload: {
+        "host.name": host,
+        draining: Boolean(draining),
+        inFlightCount: inFlightCount ?? 0,
+      },
+    },
+  };
+}
+
+/**
+ * buildDrainedEnvelope — pure OTel envelope for the drained sentinel.
+ */
+export function buildDrainedEnvelope({ inFlightCount = 0, now } = {}) {
+  const ts = now ? now() : new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const host = getHostName();
+  return {
+    ts,
+    id: randomBytes(8).toString("hex"),
+    observedTs: ts,
+    severityText: "INFO",
+    severityNumber: 9,
+    traceId: null,
+    spanId: null,
+    resource: {
+      "service.name": "catalyst.execution-core",
+      "service.namespace": "catalyst",
+      "host.name": hostName(),
+      "host.id": hostId(),
+    },
+    attributes: {
+      "event.name": DRAINED_EVENT,
+      "event.entity": "node",
+      "event.action": "drain.drained",
+      "event.label": host,
+    },
+    body: {
+      payload: {
+        "host.name": host,
+        draining: true,
+        inFlightCount: 0,
+      },
+    },
+  };
+}
+
+/**
+ * emitDrainChangedEvent — append one drain.changed envelope line. Returns true
+ * on success, false on any failure (best-effort; never throws).
+ */
+export function emitDrainChangedEvent({
+  draining,
+  inFlightCount = 0,
+  logPath = getEventLogPath(),
+  now,
+} = {}) {
+  const line = `${JSON.stringify(buildDrainChangedEnvelope({ draining, inFlightCount, now }))}\n`;
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, line);
+    return true;
+  } catch (err) {
+    log.warn({ err: err?.message }, "drain-event: event append failed");
+    return false;
+  }
+}
+
+/**
+ * emitDrainedEvent — append one drain.drained envelope line. Returns true on
+ * success, false on any failure (best-effort; never throws).
+ */
+export function emitDrainedEvent({ logPath = getEventLogPath(), now } = {}) {
+  const line = `${JSON.stringify(buildDrainedEnvelope({ now }))}\n`;
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, line);
+    return true;
+  } catch (err) {
+    log.warn({ err: err?.message }, "drain-event: event append failed");
+    return false;
+  }
+}

--- a/plugins/dev/scripts/execution-core/drain-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/drain-event.test.mjs
@@ -1,0 +1,156 @@
+// drain-event.test.mjs — CTL-1095. node.drain.changed + node.drain.drained
+// envelope builders and best-effort emitters.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test drain-event.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, readFileSync, appendFileSync, rmSync } from "node:fs";
+import { tmpdir, hostname } from "node:os";
+import { join } from "node:path";
+import {
+  buildDrainChangedEnvelope,
+  emitDrainChangedEvent,
+  buildDrainedEnvelope,
+  emitDrainedEvent,
+  DRAIN_CHANGED_EVENT,
+  DRAINED_EVENT,
+} from "./drain-event.mjs";
+
+const HOST_ENVS = ["CATALYST_HOST_NAME", "CATALYST_LAYER2_CONFIG_FILE"];
+let savedEnv = {};
+
+beforeEach(() => {
+  for (const k of HOST_ENVS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of HOST_ENVS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  savedEnv = {};
+});
+
+describe("buildDrainChangedEnvelope (CTL-1095)", () => {
+  test("drain.changed envelope: name/entity/action + draining + inFlightCount payload", () => {
+    const env = buildDrainChangedEnvelope({ draining: true, inFlightCount: 3 });
+    expect(env.attributes["event.name"]).toBe("node.drain.changed");
+    expect(DRAIN_CHANGED_EVENT).toBe("node.drain.changed");
+    expect(env.attributes["event.entity"]).toBe("node");
+    expect(env.attributes["event.action"]).toBe("drain.changed");
+    expect(env.body.payload.draining).toBe(true);
+    expect(env.body.payload.inFlightCount).toBe(3);
+    expect(env.body.payload["host.name"]).toBeDefined();
+  });
+
+  test("draining:false is reflected in payload", () => {
+    const env = buildDrainChangedEnvelope({ draining: false, inFlightCount: 0 });
+    expect(env.body.payload.draining).toBe(false);
+    expect(env.body.payload.inFlightCount).toBe(0);
+  });
+
+  test("stamps host.name + host.id on the resource block", () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    const env = buildDrainChangedEnvelope({ draining: true, inFlightCount: 1 });
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(env.resource["service.namespace"]).toBe("catalyst");
+    expect(env.resource["host.name"]).toBe("mini");
+    expect(typeof env.resource["host.id"]).toBe("string");
+    expect(env.resource["host.id"]).toHaveLength(16);
+  });
+
+  test("host.name is a non-empty string (resolved via config chain)", () => {
+    const env = buildDrainChangedEnvelope({ draining: true, inFlightCount: 0 });
+    expect(typeof env.body.payload["host.name"]).toBe("string");
+    expect(env.body.payload["host.name"].length).toBeGreaterThan(0);
+  });
+
+  test("ts is a no-millisecond ISO string by default", () => {
+    const env = buildDrainChangedEnvelope({ draining: true, inFlightCount: 0 });
+    expect(env.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  test("severityText INFO, severityNumber 9", () => {
+    const env = buildDrainChangedEnvelope({ draining: true, inFlightCount: 0 });
+    expect(env.severityText).toBe("INFO");
+    expect(env.severityNumber).toBe(9);
+  });
+});
+
+describe("buildDrainedEnvelope (CTL-1095)", () => {
+  test("drained envelope: name/entity/action + draining:true + inFlightCount:0", () => {
+    const env = buildDrainedEnvelope();
+    expect(env.attributes["event.name"]).toBe("node.drain.drained");
+    expect(DRAINED_EVENT).toBe("node.drain.drained");
+    expect(env.attributes["event.entity"]).toBe("node");
+    expect(env.attributes["event.action"]).toBe("drain.drained");
+    expect(env.body.payload.draining).toBe(true);
+    expect(env.body.payload.inFlightCount).toBe(0);
+  });
+});
+
+describe("emitDrainChangedEvent (CTL-1095)", () => {
+  let tmp;
+  let logPath;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "ctl1095-dc-"));
+    logPath = join(tmp, "events.jsonl");
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("appends one parseable node.drain.changed line to the event log", () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    expect(emitDrainChangedEvent({ draining: true, inFlightCount: 2, logPath })).toBe(true);
+    const lines = readFileSync(logPath, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+    const evt = JSON.parse(lines[0]);
+    expect(evt.attributes["event.name"]).toBe("node.drain.changed");
+    expect(evt.body.payload.draining).toBe(true);
+    expect(evt.body.payload.inFlightCount).toBe(2);
+    expect(evt.body.payload["host.name"]).toBe("mini");
+  });
+
+  test("returns false (never throws) when the log path is unwriteable", () => {
+    const fileAsDir = join(tmp, "afile");
+    appendFileSync(fileAsDir, "x");
+    const bad = join(fileAsDir, "events.jsonl");
+    expect(emitDrainChangedEvent({ draining: false, inFlightCount: 0, logPath: bad })).toBe(false);
+  });
+});
+
+describe("emitDrainedEvent (CTL-1095)", () => {
+  let tmp;
+  let logPath;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "ctl1095-dd-"));
+    logPath = join(tmp, "events.jsonl");
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("appends one parseable node.drain.drained line", () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    expect(emitDrainedEvent({ logPath })).toBe(true);
+    const line = JSON.parse(readFileSync(logPath, "utf8").trim());
+    expect(line.attributes["event.name"]).toBe("node.drain.drained");
+    expect(line.body.payload.draining).toBe(true);
+    expect(line.body.payload.inFlightCount).toBe(0);
+  });
+
+  test("returns false (never throws) when the log path is unwriteable", () => {
+    const fileAsDir = join(tmp, "afile");
+    appendFileSync(fileAsDir, "x");
+    const bad = join(fileAsDir, "events.jsonl");
+    expect(emitDrainedEvent({ logPath: bad })).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -36,6 +36,7 @@ import {
   getHostName, // CTL-862
   getClusterHosts, // CTL-862
   hostMembershipWarning, // CTL-1057
+  isDraining as isDrainingDefault, // CTL-1095: drain gate
 } from "./config.mjs";
 import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
 import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS
@@ -368,6 +369,8 @@ export function handleStateChangedEvent(
     hosts = undefined,
     hostName = undefined,
     claimDispatch = claimDispatchSync,
+    // CTL-1095: drain gate seam — thread through to dispatchTriage.
+    isDraining = (dir) => isDrainingDefault(dir),
   } = {}
 ) {
   const parsed = parseStateChangedEvent(event);
@@ -411,6 +414,7 @@ export function handleStateChangedEvent(
           hosts,
           hostName,
           claimDispatch, // CTL-862
+          isDraining, // CTL-1095
         });
       }
     } else if (!parsed.toState || parsed.toState === query.status) {
@@ -465,6 +469,7 @@ export function handleStateChangedEvent(
           hosts,
           hostName,
           claimDispatch, // CTL-862
+          isDraining, // CTL-1095
         });
       } else {
         log.debug(
@@ -547,10 +552,17 @@ function dispatchTriage(
     hosts = undefined,
     hostName = undefined,
     claimDispatch = claimDispatchSync,
+    // CTL-1095: drain gate — node-level refusal of new-triage admission.
+    isDraining = (dir) => isDrainingDefault(dir),
   }
 ) {
   if (!orchDir) {
     log.warn({ identifier }, "→Triage seen but monitor has no orchDir — skipping dispatch");
+    return false;
+  }
+  // CTL-1095: drain gate — refuse new triage dispatch before HRW filter.
+  if (isDraining(orchDir)) {
+    log.debug({ identifier }, "drain: skipping triage dispatch — node draining (CTL-1095)");
     return false;
   }
   // CTL-862/CTL-1057: HRW ownership filter. Resolve roster/self lazily per call

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -2041,3 +2041,38 @@ describe("CTL-1028 — triage forwards + persists cluster generation (monitor di
     }
   });
 });
+
+describe("dispatchTriage — drain gate (CTL-1095)", () => {
+  const orchDir = "/orch-1095-drain";
+
+  function toTriageEvent(ticket) {
+    return {
+      event: "linear.issue.state_changed",
+      detail: { ticket, teamKey: "ENG", toState: "Triage" },
+    };
+  }
+
+  test("dispatchTriage returns false and does not dispatch while draining", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    handleStateChangedEvent(toTriageEvent("ENG-DR1"), {
+      dispatch,
+      orchDir,
+      isDraining: () => true,
+      triageBudget: { remaining: 5 },
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  test("dispatchTriage dispatches normally when not draining (regression guard)", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    handleStateChangedEvent(toTriageEvent("ENG-DR2"), {
+      dispatch,
+      orchDir,
+      isDraining: () => false,
+      triageBudget: { remaining: 5 },
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -194,7 +194,8 @@ import { isLinearTerminal } from "./terminal-state.mjs";
 import { labelOnce, clearStalledLabel } from "./label-guard.mjs";
 import { processApprovedResumes } from "./boot-resume.mjs"; // CTL-644: per-tick approval poll
 import { countReapOutcomes } from "./reaper-metrics.mjs";
-import { log, getEligibleDir, getEventLogPath, getHostName, getClusterHosts, hostMembershipWarning } from "./config.mjs";
+import { log, getEligibleDir, getEventLogPath, getHostName, getClusterHosts, hostMembershipWarning, isDraining as isDrainingDefault } from "./config.mjs";
+import { emitDrainedEvent as defaultEmitDrainedEvent } from "./drain-event.mjs"; // CTL-1095: drained sentinel
 import { defaultCheckSequencing } from "./sequencing.mjs"; // CTL-537
 import { ownedBy } from "./hrw.mjs"; // CTL-850: HRW ownership filter
 import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-850: cross-host claim soft-CAS
@@ -2537,6 +2538,11 @@ export function schedulerTick(
       postComment: _unstuckPostComment = undefined,
       nowMs: _unstuckNowMs = undefined,
     } = {},
+    // CTL-1095: drain gate — node-level refusal of new-work admission. Default
+    // reads the drain flag file from orchDir; tests inject a stub.
+    isDraining = () => isDrainingDefault(orchDir),
+    // CTL-1095: drained-sentinel emitter — fires once when draining && empty.
+    emitDrained = () => defaultEmitDrainedEvent(),
     // CTL-936: closed-loop intent layer. When an open beliefs.db handle is
     // provided, kill actions in reclaimDeadWork are recorded as intents and
     // suppressed once ineffective. Default null → legacy behavior (all existing
@@ -4133,6 +4139,8 @@ export function schedulerTick(
   // independent of freeSlots and already ran, so the pipeline keeps moving; only
   // NEW admissions pause until the read recovers. Fresh (the default) → no change.
   const livenessFresh = livenessIsFresh();
+  // CTL-1095: drain gate — refuse all new-work admission while draining.
+  const draining = isDraining();
   // CTL-755: also subtract promotedCount — the triage→research promotions STEP B
   // dispatched this tick took slots that liveCount (read before STEP B) does not
   // yet reflect, so without this term sweep 2 over-admits into them (the same
@@ -4145,7 +4153,7 @@ export function schedulerTick(
   // subtracting heldStopCount removed that slot a SECOND time, over-suppressing
   // genuinely-free capacity at maxParallel>=2 (a transient single-tick throughput
   // loss; the slot frees naturally next tick via getAgentsCached deregistration).
-  const freeSlots = livenessFresh
+  const freeSlots = (livenessFresh && !draining)
     ? Math.max(0, computeFreeSlots(maxParallel, inFlightCount) - resumedCount - promotedCount)
     : 0;
   if (!livenessFresh) {
@@ -4153,6 +4161,22 @@ export function schedulerTick(
       { maxParallel, inFlightCount, resumedCount, promotedCount, heldStopCount },
       "scheduler: liveness snapshot stale/cold — holding new-work dispatch (CTL-731)"
     );
+  }
+  if (draining) {
+    log.info({ inFlightCount }, "scheduler: node draining — holding new-work dispatch (CTL-1095)");
+  }
+  // CTL-1095: drained sentinel. Once draining and nothing in flight, emit
+  // node.drain.drained exactly once per episode via a marker file. Clears
+  // the marker when drain turns off so a subsequent episode re-arms.
+  const drainedMarker = join(orchDir, "drain.drained");
+  if (draining) {
+    if (listInFlightTickets(orchDir).size === 0 && !existsSync(drainedMarker)) {
+      emitDrained();
+      try { writeFileSync(drainedMarker, ""); } catch { /* best-effort */ }
+      log.info({}, "scheduler: node drained — all in-flight work landed (CTL-1095)");
+    }
+  } else if (existsSync(drainedMarker)) {
+    try { rmSync(drainedMarker, { force: true }); } catch { /* best-effort */ }
   }
   // CTL-706: per-project caps + reserves gate selection AFTER ranking. With
   // no perProject config this is byte-for-byte selectDispatchable.

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -3,7 +3,7 @@
 //
 // Phase 3 adds the selection-core blocks; Phases 4-5 extend this same file.
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import {
   mkdtempSync,
   rmSync,
@@ -9453,5 +9453,153 @@ describe("CTL-1068: marker-hygiene and re-arm (Phase 3 regression)", () => {
     // The onRetract callback clears lastHeldEmitState for this ticket — no further assertion
     // needed here beyond confirming the retraction fired (the internal Map reset is exercised
     // by the unit test in Phase 1).
+  });
+});
+
+describe("drain gate (CTL-1095)", () => {
+  const eligibleOne = (id) => [
+    {
+      identifier: id,
+      priority: 1,
+      createdAt: "x",
+      state: "Todo",
+      relations: { nodes: [] },
+      inverseRelations: { nodes: [] },
+    },
+  ];
+
+  test("draining node zeroes freeSlots — no new dispatch", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne("CTL-drain-1"),
+      dispatch,
+      isDraining: () => true,
+      livenessIsFresh: () => true,
+      liveBackgroundCount: () => 0,
+    });
+    expect(dispatch.calls).toHaveLength(0);
+  });
+
+  test("not draining — dispatch happens as before (regression guard)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne("CTL-drain-2"),
+      dispatch,
+      isDraining: () => false,
+      livenessIsFresh: () => true,
+      liveBackgroundCount: () => 0,
+      verifyDispatched: verifyOk,
+    });
+    expect(dispatch.calls).toHaveLength(1);
+  });
+
+  test("draining with in-flight work — still zero new dispatch", () => {
+    writeSignal("CTL-existing", "implement", "running");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne("CTL-drain-3"),
+      dispatch,
+      isDraining: () => true,
+      livenessIsFresh: () => true,
+      liveBackgroundCount: () => 1,
+    });
+    expect(dispatch.calls).toHaveLength(0);
+  });
+});
+
+describe("drained-sentinel emission (CTL-1095)", () => {
+  test("emits node.drain.drained once when draining && inFlight empty", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const emitDrainedMock = mock(() => true);
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      isDraining: () => true,
+      livenessIsFresh: () => true,
+      liveBackgroundCount: () => 0,
+      emitDrained: emitDrainedMock,
+    });
+    expect(emitDrainedMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does NOT emit drained a second time (marker dedup)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const emitDrainedMock = mock(() => true);
+    const opts = {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      isDraining: () => true,
+      livenessIsFresh: () => true,
+      liveBackgroundCount: () => 0,
+      emitDrained: emitDrainedMock,
+    };
+    schedulerTick(orchDir, opts); // first tick
+    schedulerTick(orchDir, opts); // second tick — marker exists, no re-emit
+    expect(emitDrainedMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does NOT emit drained while in-flight tickets remain", () => {
+    writeSignal("CTL-inflight", "implement", "running");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const emitDrainedMock = mock(() => true);
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      isDraining: () => true,
+      livenessIsFresh: () => true,
+      liveBackgroundCount: () => 1,
+      emitDrained: emitDrainedMock,
+    });
+    expect(emitDrainedMock).not.toHaveBeenCalled();
+  });
+
+  test("does NOT emit drained when not draining", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const emitDrainedMock = mock(() => true);
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      isDraining: () => false,
+      livenessIsFresh: () => true,
+      liveBackgroundCount: () => 0,
+      emitDrained: emitDrainedMock,
+    });
+    expect(emitDrainedMock).not.toHaveBeenCalled();
+  });
+
+  test("marker clears when drain turns off so next episode re-arms", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const emitDrainedMock = mock(() => true);
+    // First drain episode: emit fires, marker written
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      isDraining: () => true,
+      liveBackgroundCount: () => 0,
+      emitDrained: emitDrainedMock,
+    });
+    expect(emitDrainedMock).toHaveBeenCalledTimes(1);
+
+    // Drain off: marker should be cleared
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      isDraining: () => false,
+      liveBackgroundCount: () => 0,
+      emitDrained: emitDrainedMock,
+    });
+
+    // Second drain episode: re-arms
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      isDraining: () => true,
+      liveBackgroundCount: () => 0,
+      emitDrained: emitDrainedMock,
+    });
+    expect(emitDrainedMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
@@ -70,6 +70,9 @@ export function assembleClusterView({
   now = Date.now(),
   intervalMs,
   graceMs,
+  // CTL-1095: injectable drain reader. Default → no drain info (fail-open:
+  // draining:false). Production wires it from the local isDraining + inFlightCount.
+  drainReader = null,
 }) {
   const roster = Array.isArray(hosts) && hosts.length > 0 ? hosts : [];
   // SINGLE-HOST: roster absent or length 1 → identity no-op. Everything belongs
@@ -86,6 +89,17 @@ export function assembleClusterView({
       : heartbeatReader({ logPath });
   const liveness = overlayClusterLiveness(roster, lastSeen, { now, intervalMs, graceMs });
   const livenessByHost = new Map(liveness.map((n) => [n.host, n]));
+
+  // CTL-1095: resolve drain state per host — fail-open on error or absent reader.
+  const resolveDrain = (host) => {
+    if (!drainReader || host === null) return { draining: false, inFlightCount: 0 };
+    try {
+      const d = drainReader(host);
+      return { draining: Boolean(d?.draining), inFlightCount: d?.inFlightCount ?? 0 };
+    } catch {
+      return { draining: false, inFlightCount: 0 };
+    }
+  };
 
   // ── grouping ──────────────────────────────────────────────────────────────
   // A node entry is { host, status, lastSeen, tickets[] }. The `null` host is the
@@ -106,6 +120,7 @@ export function assembleClusterView({
           host,
           status: node.status,
           lastSeen: node.lastSeen,
+          ...resolveDrain(host),
           tickets: tickets.map((t) => makeTicket(t, host)),
         },
       ],
@@ -134,7 +149,7 @@ export function assembleClusterView({
       continue;
     }
     const node = livenessByHost.get(host) ?? { status: "offline", lastSeen: null };
-    nodes.push({ host, status: node.status, lastSeen: node.lastSeen, tickets: groupTickets });
+    nodes.push({ host, status: node.status, lastSeen: node.lastSeen, ...resolveDrain(host), tickets: groupTickets });
   }
 
   return {

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.test.mjs
@@ -1,0 +1,83 @@
+// cluster-view.test.mjs — CTL-1095. assembleClusterView drain display.
+//
+// Run: cd plugins/dev/scripts/orch-monitor && bun test lib/cluster-view.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { assembleClusterView } from "./cluster-view.mjs";
+
+const board = { generatedAt: "2026-06-13T00:00:00Z", tickets: [] };
+const fakeHeartbeats = { mini: "2026-06-13T00:00:00Z", laptop: "2026-06-13T00:00:00Z" };
+const ROSTER = ["mini", "laptop"];
+const NOW = new Date("2026-06-13T00:00:10Z").getTime();
+
+describe("assembleClusterView — drain display (CTL-1095)", () => {
+  test("cluster view marks a host draining with inFlightCount", () => {
+    const view = assembleClusterView({
+      board,
+      hosts: ROSTER,
+      heartbeats: fakeHeartbeats,
+      now: NOW,
+      drainReader: (host) =>
+        host === "laptop"
+          ? { draining: true, inFlightCount: 2 }
+          : { draining: false, inFlightCount: 0 },
+    });
+    const laptop = view.nodes.find((n) => n.host === "laptop");
+    expect(laptop.draining).toBe(true);
+    expect(laptop.inFlightCount).toBe(2);
+  });
+
+  test("non-draining host has draining:false and inFlightCount:0", () => {
+    const view = assembleClusterView({
+      board,
+      hosts: ROSTER,
+      heartbeats: fakeHeartbeats,
+      now: NOW,
+      drainReader: (host) =>
+        host === "laptop"
+          ? { draining: true, inFlightCount: 2 }
+          : { draining: false, inFlightCount: 0 },
+    });
+    const mini = view.nodes.find((n) => n.host === "mini");
+    expect(mini.draining).toBe(false);
+    expect(mini.inFlightCount).toBe(0);
+  });
+
+  test("no drainReader → draining:false, inFlightCount:0 (fail-open)", () => {
+    const view = assembleClusterView({
+      board,
+      hosts: ["mini"],
+      heartbeats: { mini: "2026-06-13T00:00:00Z" },
+      now: NOW,
+    });
+    const node = view.nodes[0];
+    expect(node.draining).toBe(false);
+    expect(node.inFlightCount).toBe(0);
+  });
+
+  test("single-host: drain state surfaced on the one node", () => {
+    const view = assembleClusterView({
+      board,
+      hosts: ["mini"],
+      heartbeats: { mini: "2026-06-13T00:00:00Z" },
+      now: NOW,
+      drainReader: () => ({ draining: true, inFlightCount: 3 }),
+    });
+    expect(view.singleHost).toBe(true);
+    expect(view.nodes[0].draining).toBe(true);
+    expect(view.nodes[0].inFlightCount).toBe(3);
+  });
+
+  test("drainReader throws → draining:false, inFlightCount:0 (fail-open)", () => {
+    const view = assembleClusterView({
+      board,
+      hosts: ["mini"],
+      heartbeats: { mini: "2026-06-13T00:00:00Z" },
+      now: NOW,
+      drainReader: () => { throw new Error("read failed"); },
+    });
+    const node = view.nodes[0];
+    expect(node.draining).toBe(false);
+    expect(node.inFlightCount).toBe(0);
+  });
+});


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-13T01:14:00Z -->
<!-- Last updated: 2026-06-13T01:14:00Z -->
<!-- PR: #1928 -->
<!-- Previous commits: 5a6f0ba6aaf2d0e59d56ff3eba065126ffae5135 -->

## Summary

Adds **node drain mode** to the execution-core daemon — a single-command way for an operator to tell a node to finish its current in-flight work and refuse any new-ticket claims until drain is lifted. Previously, stopping a node mid-run required either killing workers mid-write or waiting until the queue happened to drain naturally. With this change, `catalyst-execution-core drain` sets a flag file; every new-work admission point checks it before dispatching, while phase advancement for already-running tickets continues unaffected.

## Changes Made

### Execution-core: drain flag helpers (`config.mjs`)

- `getDrainFlagPath(orchDir)` — returns `<orchDir>/drain`
- `isDraining(orchDir)` — `existsSync` check; file presence = draining, absence = normal

### New CLI command (`cli/drain.mjs`, `catalyst-execution-core`)

- `catalyst-execution-core drain` — enables drain mode (creates flag file)
- `catalyst-execution-core drain --off` — disables drain mode (removes flag file)
- `catalyst-execution-core drain --status-read` — read-only status check (no write)
- `--json` flag for machine-readable output
- Emits `node.drain.changed` event after every toggle
- Reports `draining — N tickets to land` or `not draining` to stdout

### Drain events (`drain-event.mjs`)

- `buildDrainChangedEnvelope()` — OTel envelope for operator-triggered toggles (`node.drain.changed`)
- `buildDrainedEnvelope()` — OTel envelope for the "last in-flight ticket landed" sentinel (`node.drain.drained`)
- `emitDrainChangedEvent()` / `emitDrainedEvent()` — best-effort `appendFileSync` to the unified event log; never throws

### Scheduler gate (`scheduler.mjs`)

- `isDraining` injected at the top of the new-work pull loop (same site as the HRW filter, ~line 4142)
- When draining: `freeSlots` forced to 0, new-work dispatch skipped; logs at `INFO`
- Drained-sentinel: once `draining && inFlightCount == 0`, writes `drain.drained` marker and emits `node.drain.drained` exactly once per drain episode; clears the marker when drain turns off so the next episode re-arms

### Monitor gate (`monitor.mjs`)

- `dispatchTriage()` checks `isDraining(orchDir)` before the HRW filter; skips the entire triage dispatch if draining
- `isDraining` is injectable for tests

### HUD / Workers view (`orch-monitor/lib/cluster-view.mjs`)

- New `drainReader` injectable parameter (default: `null`, fail-open as `draining: false`)
- `resolveDrain(host)` helper reads per-host drain state with error isolation
- Each cluster-node entry now carries `{ draining, inFlightCount }` for the Workers view to surface

### Tests

- `cli/drain.test.mjs` — CLI toggle, `--off`, `--status-read`, `--json`, event emission
- `drain-event.test.mjs` — envelope shape, `now` injection, best-effort write failure
- `config.test.mjs` — `getDrainFlagPath`, `isDraining` flag-file semantics
- `scheduler.test.mjs` — drain gate blocks dispatch; drained-sentinel fires once per episode
- `monitor.test.mjs` — `dispatchTriage` skips under drain
- `cluster-view.test.mjs` — `drainReader` injectable; fail-open on missing reader

## How to Verify It

- [x] `execution-core-unit-tests` CI check passes ✅
- [x] `validate` CI check passes ✅
- [x] `audit-references` CI check passes ✅
- [x] `check-versions` CI check passes ✅
- [x] `docs-gate` CI check passes ✅
- [ ] `quality` CI check pending
- [ ] Cloudflare Pages build pending
- [ ] Manual: run `catalyst-execution-core drain` while tickets are in-flight; confirm no new triage dispatches fire; confirm running workers advance; confirm HUD shows "draining — N tickets to land"
- [ ] Manual: run `catalyst-execution-core drain --off`; confirm new-work pickup resumes on the next tick

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1095
