### PR TITLE
fix(dev): CTL-1086 — keep synthetic test events out of the live fleet event log

### DIFF
--- a/plugins/dev/scripts/__tests__/canonical-event-sentinel-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/canonical-event-sentinel-guard.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# CTL-1086: test _canonical_is_sentinel_leak predicate and canonical_jsonl_append
+# sentinel guard in canonical-event.sh.
+#
+# Cases:
+#   1. orch-test event to default prod events dir → NOT written (dropped)
+#   2. orch-test event to a temp CATALYST_DIR override → written (legit test)
+#   3. real orch event to the default prod events dir → written
+#
+# Run: bash plugins/dev/scripts/__tests__/canonical-event-sentinel-guard.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+LIB="${REPO_ROOT}/plugins/dev/scripts/lib/canonical-event.sh"
+
+# shellcheck disable=SC1090
+source "$LIB"
+
+FAILURES=0
+PASSES=0
+
+ok()   { PASSES=$((PASSES+1));   echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; echo "    $2"; }
+
+# Use a scratch HOME so the "default prod path" is a throwaway.
+FAKE_HOME="$(mktemp -d)"
+trap 'rm -rf "$FAKE_HOME"' EXIT
+
+REAL_HOME="${HOME}"
+
+# Build a minimal canonical JSON line with the given orchestration id
+make_line() {
+  local orch="$1"
+  printf '{"resource":{"catalyst.orchestration":"%s"},"name":"phase.test.sentinel"}' "$orch"
+}
+
+# ── Test 1: orch-test to default prod dir → dropped ─────────────────────────
+HOME="${FAKE_HOME}"
+PROD_EVENTS_DIR="${FAKE_HOME}/catalyst/events"
+mkdir -p "${PROD_EVENTS_DIR}"
+LINE1="$(make_line "orch-test")"
+canonical_jsonl_append "${PROD_EVENTS_DIR}" "${LINE1}" 2>/dev/null
+MONTH_FILE="${PROD_EVENTS_DIR}/$(date -u +%Y-%m).jsonl"
+if [[ -f "${MONTH_FILE}" ]]; then
+  COUNT1="$(wc -l < "${MONTH_FILE}" | tr -d ' ')"
+else
+  COUNT1=0
+fi
+HOME="${REAL_HOME}"
+
+if [[ "${COUNT1}" -eq 0 ]]; then
+  ok "orch-test to default prod dir is dropped"
+else
+  fail "orch-test to default prod dir is dropped" "expected 0 lines, got ${COUNT1}"
+fi
+
+# ── Test 2: orch-test to a temp CATALYST_DIR override → written ──────────────
+TEMP_DIR="$(mktemp -d)"
+TEMP_EVENTS="${TEMP_DIR}/events"
+mkdir -p "${TEMP_EVENTS}"
+LINE2="$(make_line "orch-test")"
+canonical_jsonl_append "${TEMP_EVENTS}" "${LINE2}"
+TEMP_MONTH="${TEMP_EVENTS}/$(date -u +%Y-%m).jsonl"
+if [[ -f "${TEMP_MONTH}" ]]; then
+  COUNT2="$(wc -l < "${TEMP_MONTH}" | tr -d ' ')"
+else
+  COUNT2=0
+fi
+rm -rf "${TEMP_DIR}"
+
+if [[ "${COUNT2}" -eq 1 ]]; then
+  ok "orch-test to temp dir is written (legit test)"
+else
+  fail "orch-test to temp dir is written (legit test)" "expected 1 line, got ${COUNT2}"
+fi
+
+# ── Test 3: real orch to default prod dir → written ──────────────────────────
+HOME="${FAKE_HOME}"
+PROD_EVENTS_DIR2="${FAKE_HOME}/catalyst/events"
+mkdir -p "${PROD_EVENTS_DIR2}"
+LINE3="$(make_line "orch-CTL-1086")"
+canonical_jsonl_append "${PROD_EVENTS_DIR2}" "${LINE3}"
+MONTH_FILE2="${PROD_EVENTS_DIR2}/$(date -u +%Y-%m).jsonl"
+if [[ -f "${MONTH_FILE2}" ]]; then
+  COUNT3="$(wc -l < "${MONTH_FILE2}" | tr -d ' ')"
+else
+  COUNT3=0
+fi
+HOME="${REAL_HOME}"
+
+if [[ "${COUNT3}" -ge 1 ]]; then
+  ok "real orch to default prod dir is written"
+else
+  fail "real orch to default prod dir is written" "expected >=1 line, got ${COUNT3}"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[[ "${FAILURES}" -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/broker/bunfig.toml
+++ b/plugins/dev/scripts/broker/bunfig.toml
@@ -1,0 +1,4 @@
+[test]
+# CTL-1086 test-leak guard: pin CATALYST_DIR to a hermetic temp dir before any
+# *.test.mjs loads, so no broker test can append to the real ~/catalyst event log.
+preload = ["./test-setup.mjs"]

--- a/plugins/dev/scripts/broker/config.mjs
+++ b/plugins/dev/scripts/broker/config.mjs
@@ -9,7 +9,7 @@
 
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { resolve } from "node:path";
+import { dirname, resolve, sep } from "node:path";
 import pino from "pino";
 import { resolveApiKey, deriveGroqEndpoint } from "../lib/api-key-health.mjs";
 
@@ -76,11 +76,35 @@ export const ORCH_STATUS_REPLAY_STALE_MS = parseInt(
 // --- Event log ---
 export function getEventLogPath() {
   const now = new Date();
-  const ym = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+  // CTL-1086: use UTC month (parity with execution-core/config.mjs) so
+  // fleet hosts never disagree at the midnight-UTC month boundary.
+  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
   // Re-read CATALYST_DIR per call so tests can redirect by setting the env
   // var. Production deployments still pin a stable value via daemon launch.
-  const catalystDir = process.env.CATALYST_DIR ?? `${homedir()}/catalyst`;
+  const home = process.env.HOME ?? homedir();
+  const catalystDir = process.env.CATALYST_DIR ?? `${home}/catalyst`;
   return resolve(catalystDir, "events", `${ym}.jsonl`);
+}
+
+// CTL-1086: sentinel guard — drop synthetic test events aimed at the default
+// production log. Parity with shell layer in canonical-event.sh.
+export const SENTINEL_ORCHIDS = new Set(["orch-test"]);
+
+export function defaultProductionEventsDir() {
+  // Prefer process.env.HOME so tests can override the "default production"
+  // path without depending on the platform homedir() syscall (macOS ignores HOME).
+  const home = process.env.HOME ?? homedir();
+  return resolve(`${home}/catalyst`, "events");
+}
+
+// A leak = sentinel-stamped event whose resolved write path is the default
+// production events dir. Tests writing to their own CATALYST_DIR are unaffected.
+export function isSentinelLeak(event, logPath) {
+  const orch = event?.resource?.["catalyst.orchestration"] ?? event?.orchestrator;
+  if (!SENTINEL_ORCHIDS.has(orch)) return false;
+  const prodDir = defaultProductionEventsDir();
+  const resolvedLog = resolve(logPath);
+  return resolvedLog.startsWith(prodDir + sep) || dirname(resolvedLog) === prodDir;
 }
 
 // CTL-357: the interest types that route deterministically (no Groq prose

--- a/plugins/dev/scripts/broker/config.test.mjs
+++ b/plugins/dev/scripts/broker/config.test.mjs
@@ -1,0 +1,17 @@
+// config.test.mjs — CTL-1086 broker config unit tests.
+import { describe, expect, test } from "bun:test";
+import { getEventLogPath } from "./config.mjs";
+
+describe("CTL-1086: broker config", () => {
+  test("getEventLogPath uses UTC year-month (parity with execution-core/config.mjs)", () => {
+    const prev = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = "/tmp/ctl1086-utc";
+    try {
+      const now = new Date();
+      const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+      expect(getEventLogPath()).toBe(`/tmp/ctl1086-utc/events/${ym}.jsonl`);
+    } finally {
+      process.env.CATALYST_DIR = prev;
+    }
+  });
+});

--- a/plugins/dev/scripts/broker/event-leak-guard.test.mjs
+++ b/plugins/dev/scripts/broker/event-leak-guard.test.mjs
@@ -1,0 +1,49 @@
+// event-leak-guard.test.mjs — CTL-1086 sentinel write guard tests.
+// Verifies isSentinelLeak predicate + appendEvent drop behavior.
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, existsSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { appendEvent } from "./router.mjs";
+import { isSentinelLeak, defaultProductionEventsDir, getEventLogPath } from "./config.mjs";
+
+describe("CTL-1086 sentinel write guard", () => {
+  test("orch-test aimed at default prod path is a leak", () => {
+    const prodPath = resolve(homedir(), "catalyst", "events", "2026-06.jsonl");
+    expect(isSentinelLeak({ resource: { "catalyst.orchestration": "orch-test" } }, prodPath)).toBe(true);
+  });
+
+  test("orch-test aimed at a temp dir is NOT a leak (legit test write)", () => {
+    expect(
+      isSentinelLeak({ resource: { "catalyst.orchestration": "orch-test" } },
+        "/tmp/scratch/events/2026-06.jsonl")
+    ).toBe(false);
+  });
+
+  test("real orchestration aimed at default prod path is NOT a leak", () => {
+    const prodPath = resolve(homedir(), "catalyst", "events", "2026-06.jsonl");
+    expect(
+      isSentinelLeak({ resource: { "catalyst.orchestration": "orch-CTL-1086" } }, prodPath)
+    ).toBe(false);
+  });
+
+  test("appendEvent drops a leak and writes nothing", () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "ctl1086-home-"));
+    const prevHome = process.env.HOME;
+    const prevDir = process.env.CATALYST_DIR;
+    process.env.HOME = fakeHome;
+    delete process.env.CATALYST_DIR;
+    try {
+      appendEvent({ name: "phase.plan.complete.CTL-100", orchestrator: "orch-test" });
+      expect(existsSync(getEventLogPath())).toBe(false);
+    } finally {
+      process.env.HOME = prevHome;
+      const hermetic = process.env.CATALYST_HERMETIC_DIR;
+      if (hermetic) {
+        process.env.CATALYST_DIR = hermetic;
+      } else if (prevDir !== undefined) {
+        process.env.CATALYST_DIR = prevDir;
+      }
+    }
+  });
+});

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -66,7 +66,14 @@ beforeEach(() => {
 afterEach(() => {
   closeBrokerStateDb();
   rmSync(tmpDir, { recursive: true, force: true });
-  delete process.env.CATALYST_DIR;
+  // CTL-1086: restore to hermetic preload value rather than deleting; deletion
+  // opened a window where the default ~/catalyst fallback could be reached.
+  const hermetic = process.env.CATALYST_HERMETIC_DIR;
+  if (hermetic) {
+    process.env.CATALYST_DIR = hermetic;
+  } else {
+    delete process.env.CATALYST_DIR;
+  }
 });
 
 // ─── ticket_lifecycle interest registration ───────────────────────────────────

--- a/plugins/dev/scripts/broker/phase-lifecycle.test.mjs
+++ b/plugins/dev/scripts/broker/phase-lifecycle.test.mjs
@@ -36,7 +36,13 @@ beforeEach(() => {
 afterEach(() => {
   closeBrokerStateDb();
   rmSync(tmpDir, { recursive: true, force: true });
-  delete process.env.CATALYST_DIR;
+  // CTL-1086: restore to hermetic preload value rather than deleting.
+  const hermetic = process.env.CATALYST_HERMETIC_DIR;
+  if (hermetic) {
+    process.env.CATALYST_DIR = hermetic;
+  } else {
+    delete process.env.CATALYST_DIR;
+  }
 });
 
 function registerPhaseInterest({

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -16,6 +16,7 @@ import { execFileSync } from "node:child_process";
 import {
   log,
   getEventLogPath,
+  isSentinelLeak,
   GROQ_API_KEY,
   GROQ_ENDPOINT,
   GROQ_EXTRA_HEADERS,
@@ -272,6 +273,12 @@ export function buildCanonicalEnvelope(legacy) {
 
 export function appendEvent(event) {
   const logPath = getEventLogPath();
+  if (isSentinelLeak(event, logPath)) {
+    process.stderr.write(
+      `[catalyst] dropped sentinel(orch-test) event from default prod log: ${getEventName(event)}\n`
+    );
+    return;
+  }
   mkdirSync(dirname(logPath), { recursive: true });
   const canonical = buildCanonicalEnvelope(event);
   appendFileSync(logPath, JSON.stringify(canonical) + "\n");

--- a/plugins/dev/scripts/broker/stack-reload.test.mjs
+++ b/plugins/dev/scripts/broker/stack-reload.test.mjs
@@ -1029,6 +1029,12 @@ describe("defaultIsRunningFn / pidFilePathForComponent (CTL-1089)", () => {
     origMonitorPidFile = process.env.MONITOR_PID_FILE;
     origExecCorePidFile = process.env.EXECUTION_CORE_PID_FILE;
     origCatalystDir = process.env.CATALYST_DIR;
+    // CTL-1086: the broker suite's [test].preload pins CATALYST_DIR to a
+    // hermetic temp dir (catalyst-broker-hermetic-*). The default-path
+    // assertions below assert the real ~/catalyst layout, so clear the pin
+    // here; afterEach restores it. Tests that exercise relocation set
+    // CATALYST_DIR explicitly in their own body.
+    delete process.env.CATALYST_DIR;
     tmpFile = `${tmpdir()}/ctl1089-pid-test-${process.pid}.tmp`;
   });
 

--- a/plugins/dev/scripts/broker/test-setup.mjs
+++ b/plugins/dev/scripts/broker/test-setup.mjs
@@ -1,0 +1,14 @@
+// test-setup.mjs — bun [test].preload for the broker suite (CTL-1086).
+// Pin CATALYST_DIR to a fresh per-run temp dir BEFORE any test module loads so
+// no broker test — and no code-under-test reaching a default appendEvent seam
+// during the afterEach-delete window — can append to ~/catalyst/events/*.jsonl.
+// Mirrors execution-core/test-setup.mjs (CTL-810). CATALYST_HERMETIC_DIR is the
+// stable record the tripwire asserts on; sibling tests may repoint CATALYST_DIR.
+import { join } from "node:path";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+const hermeticDir = mkdtempSync(join(tmpdir(), "catalyst-broker-hermetic-"));
+process.env.CATALYST_DIR = hermeticDir;
+process.env.CATALYST_HERMETIC_DIR = hermeticDir;
+process.env.CATALYST_TEST = "1";

--- a/plugins/dev/scripts/broker/test-setup.test.mjs
+++ b/plugins/dev/scripts/broker/test-setup.test.mjs
@@ -1,0 +1,50 @@
+// test-setup.test.mjs — CTL-1086 broker suite hermeticity tripwire.
+//
+// The preload (test-setup.mjs, wired via bunfig [test].preload) must pin
+// CATALYST_DIR to a fresh per-run temp dir BEFORE any test module loads, so
+// no broker test (or code-under-test reaching a default appendEvent seam
+// during the afterEach-delete window) can append to the real
+// ~/catalyst/events/YYYY-MM.jsonl.
+//
+// Mirrors execution-core/test-setup.test.mjs (CTL-810).
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve, sep } from "node:path";
+
+import { getEventLogPath } from "./config.mjs";
+import { appendEvent } from "./router.mjs";
+
+const realCatalystDir = resolve(homedir(), "catalyst");
+
+describe("CTL-1086: hermetic CATALYST_DIR preload (broker)", () => {
+  test("preload pinned CATALYST_DIR to a per-run temp dir and recorded it", () => {
+    const pinned = process.env.CATALYST_HERMETIC_DIR;
+    expect(pinned).toBeDefined();
+    expect(pinned).toContain("catalyst-broker-hermetic-");
+    expect(resolve(pinned).startsWith(realCatalystDir + sep)).toBe(false);
+    expect(resolve(pinned)).not.toBe(realCatalystDir);
+    expect(existsSync(pinned)).toBe(true);
+  });
+
+  test("getEventLogPath() resolves outside the real ~/catalyst", () => {
+    expect(resolve(getEventLogPath()).startsWith(realCatalystDir + sep)).toBe(false);
+  });
+
+  test("functional: appendEvent lands under the hermetic dir, never ~/catalyst", () => {
+    const pinned = process.env.CATALYST_HERMETIC_DIR;
+    const prev = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = pinned;
+    try {
+      appendEvent({ name: "phase.test.tripwire.CTL-1086", orchestrator: "orch-test-tripwire-CTL-1086" });
+      const p = resolve(getEventLogPath());
+      expect(p.startsWith(resolve(pinned))).toBe(true);
+      const lines = readdirSync(resolve(pinned, "events"))
+        .map((f) => readFileSync(resolve(pinned, "events", f), "utf8"))
+        .join("");
+      expect(lines).toContain("CTL-1086");
+    } finally {
+      process.env.CATALYST_DIR = prev;
+    }
+  });
+});

--- a/plugins/dev/scripts/broker/worker-state.test.mjs
+++ b/plugins/dev/scripts/broker/worker-state.test.mjs
@@ -21,7 +21,13 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true });
-  delete process.env.CATALYST_DIR;
+  // CTL-1086: restore to hermetic preload value rather than deleting.
+  const hermetic = process.env.CATALYST_HERMETIC_DIR;
+  if (hermetic) {
+    process.env.CATALYST_DIR = hermetic;
+  } else {
+    delete process.env.CATALYST_DIR;
+  }
   delete process.env.CATALYST_RUNS_DIR;
 });
 

--- a/plugins/dev/scripts/broker/workflow-substep.test.mjs
+++ b/plugins/dev/scripts/broker/workflow-substep.test.mjs
@@ -27,7 +27,13 @@ beforeEach(() => {
 afterEach(() => {
   closeBrokerStateDb();
   rmSync(tmpDir, { recursive: true, force: true });
-  delete process.env.CATALYST_DIR;
+  // CTL-1086: restore to hermetic preload value rather than deleting.
+  const hermetic = process.env.CATALYST_HERMETIC_DIR;
+  if (hermetic) {
+    process.env.CATALYST_DIR = hermetic;
+  } else {
+    delete process.env.CATALYST_DIR;
+  }
 });
 
 function registerSubstepInterest({ interestId = "watcher-1", ticket = "CTL-100" } = {}) {

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -355,6 +355,23 @@ build_canonical_line() {
     }'
 }
 
+# _canonical_is_sentinel_leak BASE_DIR LINE
+# Returns 0 (true) if LINE is a sentinel-stamped event aimed at the default
+# production events dir (BASE_DIR resolves to $HOME/catalyst/events). Parity
+# with JS isSentinelLeak in broker/config.mjs (CTL-1086).
+_canonical_is_sentinel_leak() {
+  local base_dir="$1" line="$2"
+  local orch sentinels default_dir
+  orch="$(printf '%s' "$line" | jq -r '.resource["catalyst.orchestration"] // empty' 2>/dev/null)"
+  [[ -n "$orch" ]] || return 1
+  sentinels="orch-test ${CATALYST_SENTINEL_ORCHIDS:-}"
+  case " $sentinels " in *" $orch "*) ;; *) return 1 ;; esac
+  default_dir="${HOME:-$HOME}/catalyst/events"
+  # Compare resolved real paths so symlinks/trailing slashes don't fool the check.
+  [[ "$(cd "$base_dir" 2>/dev/null && pwd -P || echo "$base_dir")" == \
+     "$(cd "$default_dir" 2>/dev/null && pwd -P || echo "$default_dir")" ]]
+}
+
 # canonical_jsonl_append BASE_DIR LINE
 # Append a JSONL line to ${BASE_DIR}/YYYY-MM.jsonl. Rotates the existing file
 # to *.legacy on first canonical write if the first existing line lacks an
@@ -363,6 +380,11 @@ build_canonical_line() {
 canonical_jsonl_append() {
   local base_dir="$1" line="$2"
   [[ -n "$base_dir" ]] || return 0
+  # CTL-1086: drop sentinel(orch-test) events aimed at the default prod log.
+  if _canonical_is_sentinel_leak "$base_dir" "$line"; then
+    printf '[catalyst] dropped sentinel(orch-test) event from default prod log\n' >&2
+    return 0
+  fi
   mkdir -p "$base_dir" 2>/dev/null || return 0
   local month_file
   month_file="${base_dir}/$(date -u +%Y-%m).jsonl"

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -362,11 +362,13 @@ build_canonical_line() {
 _canonical_is_sentinel_leak() {
   local base_dir="$1" line="$2"
   local orch sentinels default_dir
-  orch="$(printf '%s' "$line" | jq -r '.resource["catalyst.orchestration"] // empty' 2>/dev/null)"
+  # Parity with JS isSentinelLeak: canonical `.resource["catalyst.orchestration"]`
+  # first, then the legacy top-level `.orchestrator` field.
+  orch="$(printf '%s' "$line" | jq -r '.resource["catalyst.orchestration"] // .orchestrator // empty' 2>/dev/null)"
   [[ -n "$orch" ]] || return 1
   sentinels="orch-test ${CATALYST_SENTINEL_ORCHIDS:-}"
   case " $sentinels " in *" $orch "*) ;; *) return 1 ;; esac
-  default_dir="${HOME:-$HOME}/catalyst/events"
+  default_dir="${HOME}/catalyst/events"
   # Compare resolved real paths so symlinks/trailing slashes don't fool the check.
   [[ "$(cd "$base_dir" 2>/dev/null && pwd -P || echo "$base_dir")" == \
      "$(cd "$default_dir" 2>/dev/null && pwd -P || echo "$default_dir")" ]]

--- a/plugins/dev/scripts/lib/scrub-test-events.mjs
+++ b/plugins/dev/scripts/lib/scrub-test-events.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// scrub-test-events.mjs — CTL-1086 one-time remediation scrubber.
+//
+// Strips sentinel-stamped (orch-test) lines from a fleet event log.
+// Dry-run by default; pass --apply to rewrite the file atomically after
+// creating a .pre-scrub-<UTC-ts> backup.
+//
+// Usage:
+//   node scrub-test-events.mjs [path]           # dry-run: report counts
+//   node scrub-test-events.mjs [path] --apply   # backup + rewrite
+//   node scrub-test-events.mjs --apply          # default path (current UTC month)
+//
+// Never deletes the backup. Dependency-free (Node/Bun stdlib only).
+
+import { readFileSync, writeFileSync, renameSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve, dirname, basename } from "node:path";
+
+const SENTINEL_ORCHIDS = new Set(["orch-test"]);
+
+function isSentinelLine(line) {
+  if (!line.trim()) return false;
+  try {
+    const parsed = JSON.parse(line);
+    const orch = parsed?.resource?.["catalyst.orchestration"];
+    return SENTINEL_ORCHIDS.has(orch);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Scrub a single event log file.
+ * @param {string} filePath - path to the .jsonl file
+ * @param {{ apply?: boolean }} options
+ * @returns {{ sentinelCount: number, realCount: number, applied: boolean }}
+ */
+export async function scrubFile(filePath, { apply = false } = {}) {
+  const content = readFileSync(filePath, "utf8");
+  const allLines = content.split("\n");
+  // Preserve trailing newline behavior: remove the last empty element if file ended with \n
+  const hasTrailingNewline = content.endsWith("\n");
+  const lines = hasTrailingNewline ? allLines.slice(0, -1) : allLines;
+
+  const sentinelLines = lines.filter((l) => isSentinelLine(l));
+  const keepLines = lines.filter((l) => !isSentinelLine(l));
+
+  if (!apply) {
+    return { sentinelCount: sentinelLines.length, realCount: keepLines.length, applied: false };
+  }
+
+  if (sentinelLines.length === 0) {
+    return { sentinelCount: 0, realCount: keepLines.length, applied: true };
+  }
+
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const dir = dirname(filePath);
+  const base = basename(filePath);
+  const backupPath = resolve(dir, `${base}.pre-scrub-${ts}`);
+
+  // Backup then atomically rewrite.
+  writeFileSync(backupPath, content);
+  const newContent = keepLines.join("\n") + (hasTrailingNewline ? "\n" : "");
+  const tmpPath = `${filePath}.scrub-tmp`;
+  writeFileSync(tmpPath, newContent);
+  renameSync(tmpPath, filePath);
+
+  return { sentinelCount: sentinelLines.length, realCount: keepLines.length, applied: true };
+}
+
+// CLI entrypoint
+if (import.meta.url === new URL(import.meta.url).href && process.argv[1] === new URL(import.meta.url).pathname) {
+  const args = process.argv.slice(2);
+  const apply = args.includes("--apply");
+  const pathArg = args.find((a) => !a.startsWith("--"));
+
+  let filePath;
+  if (pathArg) {
+    filePath = resolve(pathArg);
+  } else {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const home = process.env.HOME ?? homedir();
+    const catalystDir = process.env.CATALYST_DIR ?? `${home}/catalyst`;
+    filePath = resolve(catalystDir, "events", `${ym}.jsonl`);
+  }
+
+  if (!existsSync(filePath)) {
+    console.error(`scrub-test-events: file not found: ${filePath}`);
+    process.exit(1);
+  }
+
+  const result = await scrubFile(filePath, { apply });
+  if (!apply) {
+    console.log(`Dry-run: ${result.sentinelCount} sentinel lines, ${result.realCount} real lines in ${filePath}`);
+    console.log("Pass --apply to rewrite the file.");
+  } else {
+    console.log(`Applied: removed ${result.sentinelCount} sentinel lines, kept ${result.realCount} real lines.`);
+    if (result.sentinelCount > 0) {
+      console.log(`Backup created at ${filePath}.pre-scrub-*`);
+    }
+  }
+}

--- a/plugins/dev/scripts/lib/scrub-test-events.mjs
+++ b/plugins/dev/scripts/lib/scrub-test-events.mjs
@@ -15,6 +15,7 @@
 import { readFileSync, writeFileSync, renameSync, existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve, dirname, basename } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const SENTINEL_ORCHIDS = new Set(["orch-test"]);
 
@@ -69,7 +70,7 @@ export async function scrubFile(filePath, { apply = false } = {}) {
 }
 
 // CLI entrypoint
-if (import.meta.url === new URL(import.meta.url).href && process.argv[1] === new URL(import.meta.url).pathname) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const args = process.argv.slice(2);
   const apply = args.includes("--apply");
   const pathArg = args.find((a) => !a.startsWith("--"));

--- a/plugins/dev/scripts/lib/scrub-test-events.test.mjs
+++ b/plugins/dev/scripts/lib/scrub-test-events.test.mjs
@@ -1,0 +1,76 @@
+// scrub-test-events.test.mjs — CTL-1086 one-time remediation scrubber tests.
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scrubFile } from "./scrub-test-events.mjs";
+
+const REAL_LINE = JSON.stringify({ resource: { "catalyst.orchestration": "orch-CTL-1086" }, name: "phase.real" });
+const SENTINEL_LINE = JSON.stringify({ resource: { "catalyst.orchestration": "orch-test" }, name: "phase.sentinel" });
+const MALFORMED_LINE = "this is not json {";
+
+let tmpDir;
+let logFile;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "scrub-test-"));
+  logFile = join(tmpDir, "2026-06.jsonl");
+});
+
+afterEach(() => {
+  const { rmSync } = require("node:fs");
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
+
+describe("CTL-1086 scrub-test-events", () => {
+  test("dry-run: reports sentinel count, writes nothing", async () => {
+    const content = [REAL_LINE, SENTINEL_LINE, REAL_LINE, SENTINEL_LINE].join("\n") + "\n";
+    writeFileSync(logFile, content);
+    const result = await scrubFile(logFile, { apply: false });
+    expect(result.sentinelCount).toBe(2);
+    expect(result.realCount).toBe(2);
+    expect(result.applied).toBe(false);
+    // file unchanged
+    expect(readFileSync(logFile, "utf8")).toBe(content);
+  });
+
+  test("apply: removes sentinel lines, keeps real lines in order", async () => {
+    const lines = [REAL_LINE, SENTINEL_LINE, REAL_LINE, SENTINEL_LINE, MALFORMED_LINE];
+    writeFileSync(logFile, lines.join("\n") + "\n");
+    const result = await scrubFile(logFile, { apply: true });
+    expect(result.sentinelCount).toBe(2);
+    expect(result.applied).toBe(true);
+    const after = readFileSync(logFile, "utf8");
+    const afterLines = after.split("\n").filter(Boolean);
+    expect(afterLines).toHaveLength(3);
+    expect(afterLines[0]).toBe(REAL_LINE);
+    expect(afterLines[1]).toBe(REAL_LINE);
+    expect(afterLines[2]).toBe(MALFORMED_LINE);
+  });
+
+  test("apply: creates a .pre-scrub-<ts> backup", async () => {
+    const content = [REAL_LINE, SENTINEL_LINE].join("\n") + "\n";
+    writeFileSync(logFile, content);
+    await scrubFile(logFile, { apply: true });
+    const dir = tmpDir;
+    const files = readdirSync(dir);
+    const backup = files.find((f) => f.includes(".pre-scrub-"));
+    expect(backup).toBeDefined();
+    expect(readFileSync(join(dir, backup), "utf8")).toBe(content);
+  });
+
+  test("idempotent: second apply removes 0 lines", async () => {
+    writeFileSync(logFile, [REAL_LINE, SENTINEL_LINE].join("\n") + "\n");
+    await scrubFile(logFile, { apply: true });
+    const result2 = await scrubFile(logFile, { apply: true });
+    expect(result2.sentinelCount).toBe(0);
+  });
+
+  test("malformed/non-JSON lines are preserved", async () => {
+    const content = [REAL_LINE, MALFORMED_LINE, SENTINEL_LINE].join("\n") + "\n";
+    writeFileSync(logFile, content);
+    await scrubFile(logFile, { apply: true });
+    const after = readFileSync(logFile, "utf8");
+    expect(after).toContain(MALFORMED_LINE);
+  });
+});


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-13T01:24:00Z -->
<!-- Last updated: 2026-06-13T01:24:00Z -->
<!-- PR: #1929 -->
<!-- Previous commits: 07198dc605d83fa349585060d5d8ebe24995d724,aef0cec157b09b1e5115cee84d02476541ab8280 -->

## Summary

Prevents synthetic test events from leaking into the live fleet event log (`~/catalyst/events/YYYY-MM.jsonl`). Before this fix, running the broker or execution-core test suites on a fleet host wrote orch-test-stamped events directly into the production log, causing 1,553 spurious lines visible to the HUD, orch-monitor, and event-scan counters.

Three coordinated changes:

- **Hermetic test preload** (`broker/bunfig.toml` + `broker/test-setup.mjs`): pins `CATALYST_DIR` to a per-run temp dir before any test file loads, so all path resolution inside the suite is isolated. Aligns `getEventLogPath()` to UTC month (parity with execution-core). Fixes four existing broker test files that unconditionally deleted `CATALYST_DIR` in `afterEach`.
- **Write-time sentinel guard**: `isSentinelLeak()` in `broker/config.mjs` + `appendEvent()` in `broker/router.mjs` drop any event whose `resource["catalyst.orchestration"]` matches a known test sentinel (`orch-test`) when targeted at the default production log path. Shell-side parity: `_canonical_is_sentinel_leak()` + guard in `canonical-event.sh`.
- **Operator scrubber** (`lib/scrub-test-events.mjs`): dry-run-by-default tool to remediate the 1,553 already-landed sentinel lines. Creates a `.pre-scrub-*` backup before atomic rewrite.

## Changes Made

### New files
- `plugins/dev/scripts/broker/bunfig.toml` — Bun test preload config
- `plugins/dev/scripts/broker/test-setup.mjs` — hermetic CATALYST_DIR pin
- `plugins/dev/scripts/broker/test-setup.test.mjs` — tripwire: verify the preload fires before test code
- `plugins/dev/scripts/broker/config.test.mjs` — UTC month alignment test
- `plugins/dev/scripts/broker/event-leak-guard.test.mjs` — JS sentinel-guard suite (4 tests)
- `plugins/dev/scripts/__tests__/canonical-event-sentinel-guard.test.sh` — shell sentinel-guard suite (3 tests)
- `plugins/dev/scripts/lib/scrub-test-events.mjs` — dry-run scrubber with atomic rewrite
- `plugins/dev/scripts/lib/scrub-test-events.test.mjs` — scrubber suite (5 tests)

### Modified files
- `plugins/dev/scripts/broker/config.mjs` — `SENTINEL_ORCHIDS`, `defaultProductionEventsDir()`, `isSentinelLeak()`; UTC month alignment
- `plugins/dev/scripts/broker/router.mjs` — `appendEvent()` guard using `isSentinelLeak()`
- `plugins/dev/scripts/lib/canonical-event.sh` — `_canonical_is_sentinel_leak()` + guard in `canonical_jsonl_append`; also falls back to top-level `.orchestrator` for parity with JS; drop `${HOME:-$HOME}` tautology
- `plugins/dev/scripts/broker/index.test.mjs`, `phase-lifecycle.test.mjs`, `worker-state.test.mjs`, `workflow-substep.test.mjs` — restore `CATALYST_DIR` to hermetic value in `afterEach` instead of deleting
- `plugins/dev/scripts/broker/stack-reload.test.mjs` — clear `CATALYST_DIR` in CTL-1089 block's `beforeEach` so default-pid-path assertions still work under the hermetic preload

### Remediation commit (verify findings)
- Fixed the HIGH regression: two stack-reload tests asserting the default `~/catalyst` path broke under the hermetic preload. Clear `CATALYST_DIR` in that block's `beforeEach`. Broker suite: 562 pass / 0 fail.
- Fixed 3 LOW findings: sentinel-guard fallback for `.orchestrator`, `${HOME}` tautology, and `import.meta.url` cross-platform correctness in scrubber.

## How to Verify It

- [x] `cd plugins/dev/scripts/broker && bun test` → 562 pass, 0 fail ✅
- [x] `bash plugins/dev/scripts/__tests__/canonical-event-sentinel-guard.test.sh` → 3 pass ✅
- [x] `cd plugins/dev/scripts && bun test lib/scrub-test-events.test.mjs` → 5 pass ✅
- [x] `bash plugins/dev/scripts/__tests__/canonical-event.test.sh` → 81 pass ✅
- [ ] Dry-run scrubber on live log: `node plugins/dev/scripts/lib/scrub-test-events.mjs ~/catalyst/events/2026-06.jsonl` → reports ~1,553 sentinel lines (manual)
- [ ] After merge: run scrubber on live log to remediate existing pollution (manual)

## Related Issues

- Fixes https://linear.app/adva/issue/CTL-1086

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1089
