### PR TITLE
fix(dev): CTL-1085 — removeLabel UUID overwrite fixes cross-team label collision

### DIFF
--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -49,8 +49,9 @@ function labelMarkerBase(orchDir, ticket, label) {
 // UNRECOVERABLE_LABEL_REASONS — applyLabel reasons that can never land this
 // daemon lifetime (CTL-834); labelOnce writes its .skipped marker for these to
 // stop the per-tick retry storm. "missing-label": the workspace lacks the label;
-// "exclusive-conflict": the label's exclusive-group sibling is already present.
-const UNRECOVERABLE_LABEL_REASONS = new Set(["missing-label", "exclusive-conflict"]);
+// "exclusive-conflict": the label's exclusive-group sibling is already present;
+// "team-mismatch": name resolution used the wrong team's UUID context (CTL-1085).
+const UNRECOVERABLE_LABEL_REASONS = new Set(["missing-label", "exclusive-conflict", "team-mismatch"]);
 
 // CTL-936: labelOnce now accepts an optional `appendEvent` seam. When provided
 // AND CATALYST_INTENTS_ENFORCE=1, an unrecoverable label-write failure emits an
@@ -78,7 +79,7 @@ export function labelOnce(orchDir, ticket, label, writeStatus, { appendEvent = n
       const reason = res.reason;
       log.warn(
         { ticket, label, reason },
-        "scheduler: label unrecoverable (missing / exclusive-conflict) — skipping retries for this run"
+        "scheduler: label unrecoverable (missing / exclusive-conflict / team-mismatch) — skipping retries for this run"
       );
       // CTL-936: emit operator-visible event when enforce mode is on.
       if ((env.CATALYST_INTENTS_ENFORCE ?? "0") === "1" && typeof appendEvent === "function") {

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -111,6 +111,20 @@ describe("labelOnce", () => {
     );
   });
 
+  test("CTL-1085: team-mismatch reason → writes .skipped marker (storm-break preserved)", () => {
+    const ws = { applyLabel: recorder({ applied: false, reason: "team-mismatch" }) };
+    mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });
+
+    labelOnce(orchDir, "CTL-1", "needs-human", ws);
+
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".linear-label-needs-human.skipped"))).toBe(
+      true
+    );
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".linear-label-needs-human.applied"))).toBe(
+      false
+    );
+  });
+
   test("transient reason → NO marker (retries next tick)", () => {
     const ws = { applyLabel: recorder({ applied: false, reason: "transient" }) };
     mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -409,6 +409,24 @@ export function fetchTicketLabels(identifier, { exec = defaultExec } = {}) {
   return readTicketLabels(identifier, { exec }).labels;
 }
 
+// readTicketLabelNodes — like readTicketLabels but preserves the { id, name }
+// node shape so callers (removeLabel, CTL-1085) can build a write payload from
+// ticket-native label UUIDs. Using UUIDs read off the ticket itself avoids the
+// cross-team name-resolution ambiguity that makes name-based overwrites fail on
+// ADV tickets whose label names collide with CTL-team label names.
+export function readTicketLabelNodes(identifier, { exec = defaultExec } = {}) {
+  const { code, stdout, stderr } = exec("linearis", ["issues", "read", identifier]);
+  if (code !== 0) return { ok: false, nodes: null, code, stderr: stderr ?? "" };
+  try {
+    const node = JSON.parse(stdout);
+    const nodes =
+      node?.labels?.nodes?.map((n) => ({ id: n.id, name: n.name })) ?? [];
+    return { ok: true, nodes };
+  } catch {
+    return { ok: false, nodes: null, code, stderr: stderr ?? "" };
+  }
+}
+
 // classifyTicketResolution — CTL-671 3-valued phantom probe. Distinguishes a
 // DEFINITIVELY non-existent ticket (clean exit 0, empty/null node) from a
 // TRANSIENT failure (nonzero exit: auth/network/rate-limit/not-found — all

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -8,6 +8,7 @@ import {
   fetchTicketState,
   fetchTicketLabels,
   readTicketLabels,
+  readTicketLabelNodes,
   fetchTicketRelations,
   fetchTicketsBatch,
   authHeader,
@@ -342,6 +343,56 @@ describe("readTicketLabels", () => {
   test("fetchTicketLabels back-compat: returns null on failure", () => {
     const exec = () => ({ code: 1, stdout: "", stderr: "boom" });
     expect(fetchTicketLabels("CTL-9", { exec })).toBeNull();
+  });
+});
+
+// CTL-1085 — readTicketLabelNodes: returns { id, name } nodes (not just names)
+// so removeLabel can build a UUID-based overwrite payload that avoids cross-team
+// name-resolution ambiguity.
+describe("readTicketLabelNodes (CTL-1085)", () => {
+  test("returns { ok: true, nodes: [{id,name}] } on success", () => {
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({
+        labels: { nodes: [
+          { id: "b4a67f92-cfce-444d-97b5-61f5575ccbd9", name: "bug" },
+          { id: "62139cba-ed7b-4372-a588-5af63f6c090b", name: "orchestrator" },
+        ] },
+      }),
+      stderr: "",
+    });
+    const r = readTicketLabelNodes("CTL-1", { exec });
+    expect(r.ok).toBe(true);
+    expect(r.nodes).toEqual([
+      { id: "b4a67f92-cfce-444d-97b5-61f5575ccbd9", name: "bug" },
+      { id: "62139cba-ed7b-4372-a588-5af63f6c090b", name: "orchestrator" },
+    ]);
+  });
+
+  test("returns { ok: false, nodes: null, stderr } on non-zero exit", () => {
+    const exec = () => ({ code: 1, stdout: "", stderr: "400 invalid_scope" });
+    const r = readTicketLabelNodes("CTL-1", { exec });
+    expect(r.ok).toBe(false);
+    expect(r.nodes).toBeNull();
+    expect(r.stderr).toBe("400 invalid_scope");
+  });
+
+  test("returns { ok: false, nodes: null } on unparseable stdout", () => {
+    const exec = () => ({ code: 0, stdout: "", stderr: "" });
+    const r = readTicketLabelNodes("CTL-1", { exec });
+    expect(r.ok).toBe(false);
+    expect(r.nodes).toBeNull();
+  });
+
+  test("returns { ok: true, nodes: [] } when ticket has no labels", () => {
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({ labels: { nodes: [] } }),
+      stderr: "",
+    });
+    const r = readTicketLabelNodes("CTL-1", { exec });
+    expect(r.ok).toBe(true);
+    expect(r.nodes).toEqual([]);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 import { linearKeyForPhase, TERMINAL_LINEAR_KEY } from "../lib/phase-fsm.mjs";
 import { getProjectConfig } from "./registry.mjs";
 import { log } from "./config.mjs";
-import { fetchTicketLabels, readTicketLabels, fetchTicketState } from "./linear-query.mjs";
+import { fetchTicketLabels, readTicketLabels, readTicketLabelNodes, fetchTicketState } from "./linear-query.mjs";
 import { withBreaker } from "./linear-breaker.mjs";
 import { withAuthRemint, isAuthError } from "./linear-remint.mjs";
 // CTL-758: the SHARED Linear terminal-state predicate ({Done,Canceled} — its OWN
@@ -265,7 +265,7 @@ export function applyLabel({ ticket, label, exec = defaultExec }) {
 export async function removeLabel(
   ticket,
   label,
-  { exec = defaultExec, fetchLabels = null, readLabels = null } = {}
+  { exec = defaultExec, fetchLabels = null, readLabels = null, readLabelNodes = readTicketLabelNodes } = {}
 ) {
   // Resolve the reader: prefer readLabels (richer), wrap legacy fetchLabels,
   // or default to readTicketLabels.
@@ -291,17 +291,29 @@ export async function removeLabel(
       return { removed: true };
     }
     const remaining = current.filter((l) => l !== label);
-    const res = remaining.length
-      ? exec("linearis", [
-          "issues",
-          "update",
-          ticket,
-          "--labels",
-          remaining.join(","),
-          "--label-mode",
-          "overwrite",
-        ])
-      : exec("linearis", ["issues", "update", ticket, "--clear-labels"]);
+    let res;
+    if (remaining.length) {
+      // CTL-1085: prefer ticket-native UUIDs to avoid cross-team name resolution.
+      // Fall back to names when the node read is unavailable or any remaining
+      // name has no matching node (preserves prior behavior + back-compat).
+      let labelArg = remaining.join(",");
+      try {
+        const nodeRead = readLabelNodes(ticket, { exec });
+        if (nodeRead?.ok && Array.isArray(nodeRead.nodes)) {
+          const ids = remaining.map(
+            (name) => nodeRead.nodes.find((n) => n.name === name)?.id
+          );
+          if (ids.length && ids.every((id) => typeof id === "string" && id.length)) {
+            labelArg = ids.join(",");
+          }
+        }
+      } catch {
+        // node read threw → keep the name-based labelArg
+      }
+      res = exec("linearis", ["issues", "update", ticket, "--labels", labelArg, "--label-mode", "overwrite"]);
+    } else {
+      res = exec("linearis", ["issues", "update", ticket, "--clear-labels"]);
+    }
     if ((res.code ?? res.status ?? 0) !== 0) {
       const reason = classifyLabelFailure(res.stderr ?? "");
       log.warn({ ticket, label, reason, stderr: res.stderr }, "removeLabel: write failed");
@@ -520,12 +532,12 @@ export function applyBlockedByRelation({ ticket, blockedBy, exec = defaultExec }
 //   - "Rate limit": linearis CLI surfaced an HTTP 429 (CTL-679 trigger).
 //   - "incorrect team": Linear's labels are team-scoped (different UUIDs per
 //     team for the same name). linearis resolved the label name in the wrong
-//     team's workspace context and sent the cross-team UUID, which Linear
-//     rejects. Permanent within one daemon lifetime (the resolver is global) —
-//     classified as missing-label so labelOnce writes the .skipped marker and
-//     stops the per-tick retry storm. (Observed on ADV tickets when the daemon
-//     orchestrates a team whose labels share names with the resolver's default
-//     team but have different UUIDs.)
+//     team's workspace context and sent the cross-team UUID. CTL-1085: now its
+//     own "team-mismatch" reason (previously "missing-label") — both are in
+//     UNRECOVERABLE_LABEL_REASONS so the applyLabel storm-break is preserved,
+//     while operators can distinguish "label absent" from "name resolved to
+//     wrong team". (Observed on ADV tickets whose label names share strings with
+//     CTL-team label names.)
 //   - "not exclusive child" (CTL-834): the label belongs to an EXCLUSIVE Linear
 //     label group and a SIBLING from that group is already on the ticket, so the
 //     add can never land while the sibling is present. Its own unrecoverable
@@ -535,7 +547,7 @@ export function applyBlockedByRelation({ ticket, blockedBy, exec = defaultExec }
 export function classifyLabelFailure(stderr) {
   const s = String(stderr ?? "");
   if (s.includes("not found")) return "missing-label";
-  if (s.includes("incorrect team")) return "missing-label";
+  if (s.includes("incorrect team")) return "team-mismatch"; // CTL-1085 (was missing-label)
   if (s.includes("not exclusive")) return "exclusive-conflict";
   if (s.includes("Rate limit")) return "rate-limited";
   if (isAuthError(s)) return "auth-error";

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -440,12 +440,13 @@ describe("applyLabel", () => {
     const r = applyLabel({ ticket: "CTL-1", label: "triaged", exec });
     expect(r).toEqual({ applied: false, reason: "rate-limited" });
   });
-  test("classifies a cross-team label-UUID stderr as reason:'missing-label' (no per-tick retry storm)", () => {
+  test("CTL-1085: classifies a cross-team label-UUID stderr as reason:'team-mismatch' (unrecoverable, storm-break preserved)", () => {
     // Linear's labels are team-scoped: same name, different UUID per team. When
     // linearis resolves the label in the wrong team's workspace context and
     // sends the cross-team UUID, Linear returns this exact error. It is
     // permanently unrecoverable inside one daemon lifetime (the resolver is
-    // global), so it must classify as missing-label to short-circuit retries.
+    // global), so it classifies as team-mismatch (added to UNRECOVERABLE_LABEL_REASONS)
+    // to short-circuit retries while giving operators a legible distinct reason.
     const exec = () => ({
       code: 1,
       stdout: "",
@@ -453,7 +454,7 @@ describe("applyLabel", () => {
         'GraphQL request failed: LabelIds for incorrect team - The label \'needs-human\' is not associated with the same team as the issue.',
     });
     const r = applyLabel({ ticket: "ADV-1213", label: "needs-human", exec });
-    expect(r).toEqual({ applied: false, reason: "missing-label" });
+    expect(r).toEqual({ applied: false, reason: "team-mismatch" });
   });
   test("CTL-585: any other non-zero exit is reason:'transient'", () => {
     const exec = () => ({ code: 1, stdout: "", stderr: "boom" });
@@ -494,9 +495,9 @@ describe("classifyLabelFailure (CTL-834)", () => {
     expect(classifyLabelFailure("LabelIds not exclusive child labels")).toBe("exclusive-conflict");
     expect(classifyLabelFailure("... not exclusive ...")).toBe("exclusive-conflict");
   });
-  test("existing mappings are unchanged", () => {
+  test("existing mappings are unchanged (CTL-1085: incorrect team now team-mismatch)", () => {
     expect(classifyLabelFailure('Label "x" not found')).toBe("missing-label");
-    expect(classifyLabelFailure("LabelIds for incorrect team")).toBe("missing-label");
+    expect(classifyLabelFailure("LabelIds for incorrect team")).toBe("team-mismatch");
     expect(classifyLabelFailure("Rate limit exceeded")).toBe("rate-limited");
     expect(classifyLabelFailure("anything else")).toBe("transient");
     expect(classifyLabelFailure(undefined)).toBe("transient");
@@ -511,6 +512,17 @@ describe("classifyLabelFailure (CTL-834)", () => {
   test("auth-error does not steal 'not found' (ordering guard)", () => {
     expect(classifyLabelFailure('Label "x" not found')).toBe("missing-label");
     expect(classifyLabelFailure("LabelIds not exclusive child labels")).toBe("exclusive-conflict");
+  });
+  test("CTL-1085: 'incorrect team' → 'team-mismatch' (distinct from missing-label)", () => {
+    expect(classifyLabelFailure("LabelIds for incorrect team")).toBe("team-mismatch");
+  });
+  test("CTL-1085: applyLabel cross-team → reason 'team-mismatch' (still unrecoverable)", () => {
+    const exec = () => ({
+      code: 1, stdout: "",
+      stderr: 'GraphQL request failed: LabelIds for incorrect team - The label \'needs-human\' is not associated with the same team as the issue.',
+    });
+    const r = applyLabel({ ticket: "ADV-1213", label: "needs-human", exec });
+    expect(r).toEqual({ applied: false, reason: "team-mismatch" });
   });
 });
 
@@ -599,11 +611,11 @@ describe("removeLabel (CTL-549)", () => {
     const cmds = [];
     const exec = (cmd, args) => { cmds.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
     // ticket has ['blocked','orchestrator']; remove 'blocked' → overwrite with 'orchestrator'
+    // exec stub returns empty stdout so the node read falls back to names (CTL-1085).
     const fetchLabels = () => ["blocked", "orchestrator"];
     const result = await removeLabel("CTL-1", "blocked", { exec, fetchLabels });
     expect(result.removed).toBe(true);
-    expect(cmds).toHaveLength(1);
-    const args = cmds[0].args;
+    const args = cmds.find((c) => c.args[1] === "update").args;
     expect(args.slice(0, 3)).toEqual(["issues", "update", "CTL-1"]);
     expect(args).toContain("--labels");
     expect(args[args.indexOf("--labels") + 1]).toBe("orchestrator");
@@ -619,7 +631,7 @@ describe("removeLabel (CTL-549)", () => {
     const fetchLabels = () => ["needs-human/question", "orchestrator", "bug"];
     const result = await removeLabel("CTL-1", "needs-human/question", { exec, fetchLabels });
     expect(result.removed).toBe(true);
-    const args = cmds[0].args;
+    const args = cmds.find((c) => c.args[1] === "update").args;
     expect(args[args.indexOf("--labels") + 1]).toBe("orchestrator,bug");
     expect(args[args.indexOf("--label-mode") + 1]).toBe("overwrite");
   });
@@ -689,6 +701,97 @@ describe("removeLabel (CTL-549)", () => {
     const result = await removeLabel("CTL-1", "needs-human/question", { exec, fetchLabels });
     expect(result.removed).toBe(false);
     expect(result.reason).toBe("transient");
+  });
+});
+
+// CTL-1085: removeLabel UUID-based overwrite — avoids cross-team name collision.
+describe("removeLabel UUID path (CTL-1085)", () => {
+  test("builds --labels from ticket-native UUIDs when node read succeeds", async () => {
+    const cmds = [];
+    const exec = (cmd, args) => {
+      cmds.push({ cmd, args });
+      if (args[1] === "read") {
+        return { code: 0, stdout: JSON.stringify({ labels: { nodes: [
+          { id: "uuid-frontend", name: "frontend" },
+          { id: "uuid-orch", name: "orchestrator" },
+        ] } }), stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    const readLabels = () => ({ ok: true, labels: ["frontend", "orchestrator"] });
+    const result = await removeLabel("ADV-1", "frontend", { exec, readLabels });
+    expect(result.removed).toBe(true);
+    const write = cmds.find((c) => c.args[1] === "update");
+    expect(write.args[write.args.indexOf("--labels") + 1]).toBe("uuid-orch");
+    expect(write.args[write.args.indexOf("--label-mode") + 1]).toBe("overwrite");
+  });
+
+  test("maps multiple remaining names to their UUIDs", async () => {
+    const exec = (cmd, args) => {
+      if (args[1] === "read") {
+        return { code: 0, stdout: JSON.stringify({ labels: { nodes: [
+          { id: "uuid-nh", name: "needs-human" },
+          { id: "uuid-orch", name: "orchestrator" },
+          { id: "uuid-bug", name: "bug" },
+        ] } }), stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    let writeArgs;
+    const wrapExec = (cmd, args) => { const r = exec(cmd, args); if (args[1] === "update") writeArgs = args; return r; };
+    const readLabels = () => ({ ok: true, labels: ["needs-human", "orchestrator", "bug"] });
+    const result = await removeLabel("ADV-1", "needs-human", { exec: wrapExec, readLabels });
+    expect(result.removed).toBe(true);
+    expect(writeArgs[writeArgs.indexOf("--labels") + 1]).toBe("uuid-orch,uuid-bug");
+  });
+
+  test("falls back to names when node read returns unparseable stdout", async () => {
+    const cmds = [];
+    const exec = (cmd, args) => { cmds.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const readLabels = () => ({ ok: true, labels: ["frontend", "orchestrator"] });
+    const result = await removeLabel("ADV-1", "frontend", { exec, readLabels });
+    expect(result.removed).toBe(true);
+    const write = cmds.find((c) => c.args[1] === "update");
+    expect(write.args[write.args.indexOf("--labels") + 1]).toBe("orchestrator");
+  });
+
+  test("falls back to names when a remaining name has no matching node", async () => {
+    const exec = (cmd, args) => {
+      if (args[1] === "read") {
+        return { code: 0, stdout: JSON.stringify({ labels: { nodes: [
+          { id: "uuid-frontend", name: "frontend" },
+        ] } }), stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    let writeArgs;
+    const wrapExec = (cmd, args) => { const r = exec(cmd, args); if (args[1] === "update") writeArgs = args; return r; };
+    const readLabels = () => ({ ok: true, labels: ["frontend", "orchestrator"] });
+    const result = await removeLabel("ADV-1", "frontend", { exec: wrapExec, readLabels });
+    expect(result.removed).toBe(true);
+    expect(writeArgs[writeArgs.indexOf("--labels") + 1]).toBe("orchestrator");
+  });
+
+  test("empty remaining still uses --clear-labels (no node read needed)", async () => {
+    const cmds = [];
+    const exec = (cmd, args) => { cmds.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const readLabels = () => ({ ok: true, labels: ["needs-human"] });
+    const result = await removeLabel("ADV-1", "needs-human", { exec, readLabels });
+    expect(result.removed).toBe(true);
+    expect(cmds.find((c) => c.args[1] === "update").args).toEqual(["issues", "update", "ADV-1", "--clear-labels"]);
+  });
+
+  test("injectable readLabelNodes seam overrides default node reader", async () => {
+    let writeArgs;
+    const exec = (cmd, args) => { if (args[1] === "update") writeArgs = args; return { code: 0, stdout: "", stderr: "" }; };
+    const readLabels = () => ({ ok: true, labels: ["frontend", "orchestrator"] });
+    const readLabelNodes = () => ({ ok: true, nodes: [
+      { id: "uuid-frontend", name: "frontend" },
+      { id: "uuid-orch", name: "orchestrator" },
+    ] });
+    const result = await removeLabel("ADV-1", "frontend", { exec, readLabels, readLabelNodes });
+    expect(result.removed).toBe(true);
+    expect(writeArgs[writeArgs.indexOf("--labels") + 1]).toBe("uuid-orch");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1475,7 +1475,10 @@ export function convergeHeldLabel(
 // UNRECOVERABLE_LABEL_REASONS — applyLabel reasons that can never land this
 // daemon lifetime, so convergeHeldLabel arms a cool-down instead of re-issuing
 // the write every tick (CTL-834). Mirrors label-guard.labelOnce's .skipped set.
-const UNRECOVERABLE_LABEL_REASONS = new Set(["missing-label", "exclusive-conflict"]);
+// "team-mismatch": CTL-1085 split it out of "missing-label" in classifyLabelFailure;
+// it MUST stay in this set or convergeHeldLabel loses its cool-down on cross-team
+// (ADV) label failures and re-introduces the CTL-834 per-tick retry storm.
+const UNRECOVERABLE_LABEL_REASONS = new Set(["missing-label", "exclusive-conflict", "team-mismatch"]);
 
 // CTL-1068 — convergeStartedHeldLabels: retract orphaned held labels for a STARTED
 // (already-admitted) ticket. The admission A.7 loop only converges the pre-pickup

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -8531,6 +8531,29 @@ describe("CTL-834 — convergeHeldLabel apply cool-down", () => {
     expect(cd("CTL-1", "blocked")).toBe(true);
   });
 
+  // CTL-1085 regression guard: classifyLabelFailure now returns "team-mismatch"
+  // for the cross-team (ADV) failure that previously surfaced as "missing-label".
+  // It MUST stay in UNRECOVERABLE_LABEL_REASONS here or convergeHeldLabel loses
+  // its cool-down on that path and re-opens the CTL-834 per-tick retry storm.
+  test("unrecoverable apply (team-mismatch, CTL-1085) → arms the cool-down marker", () => {
+    const ws = makeWs({ applied: false, reason: "team-mismatch" });
+    const writes = convergeHeldLabel("CTL-1", [], "blocked", ws, { orchDir, now: () => 1000 });
+    expect(writes).toBe(1);
+    expect(ws.applyLabel.calls).toHaveLength(1);
+    expect(cd("CTL-1", "blocked")).toBe(true);
+  });
+
+  test("team-mismatch WITHIN the window: apply is SUPPRESSED (storm-break holds)", () => {
+    const ws = makeWs({ applied: false, reason: "team-mismatch" });
+    convergeHeldLabel("CTL-1", [], "blocked", ws, { orchDir, now: () => 1000 }); // arms cooldown
+    const writes = convergeHeldLabel("CTL-1", [], "blocked", ws, {
+      orchDir,
+      now: () => 1000 + 30_000,
+    });
+    expect(writes).toBe(0);
+    expect(ws.applyLabel.calls).toHaveLength(1); // NOT re-attempted this tick
+  });
+
   test("WITHIN the window: apply is SUPPRESSED (0 writes, applyLabel not re-called)", () => {
     const ws = makeWs({ applied: false, reason: "exclusive-conflict" });
     convergeHeldLabel("CTL-1", [], "blocked", ws, { orchDir, now: () => 1000 }); // arms cooldown

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -3972,7 +3972,7 @@ describe("schedulerTick — retraction sweep uses gateway cache (CTL-1079)", () 
     mkdirSync(join(orchDir, "workers", TICKET), { recursive: true });
   });
 
-  test("CTL-1079: cache hit → retraction does ZERO live label reads, mutation still fires", async () => {
+  test("CTL-1079: cache hit → idempotency read suppressed by cache; CTL-1085 write-path node read fires once", async () => {
     writeFileSync(join(orchDir, "workers", TICKET, ".linear-label-needs-human.applied"), "");
     const exec = makeExecSpy();
     const gateway = {
@@ -3984,8 +3984,9 @@ describe("schedulerTick — retraction sweep uses gateway cache (CTL-1079)", () 
       writeStatus: makeWriteStatus(exec),
       gateway,
     });
-    // The cache hit avoids the live read entirely.
-    expect(exec.calls.filter(isLiveRead)).toHaveLength(0);
+    // Cache hit suppresses the idempotency read. The write-path node read (CTL-1085
+    // UUID resolution) is the only live read — it fires exactly once on the write path.
+    expect(exec.calls.filter(isLiveRead)).toHaveLength(1);
     // The mutation (overwrite without needs-human) still fires.
     const writes = exec.calls.filter(isOverwrite);
     expect(writes).toHaveLength(1);
@@ -3994,7 +3995,7 @@ describe("schedulerTick — retraction sweep uses gateway cache (CTL-1079)", () 
     expect(writes[0].args.join(" ")).not.toContain("needs-human");
   });
 
-  test("CTL-1079: cache miss (gateway returns null) → falls back to ONE live read", async () => {
+  test("CTL-1079: cache miss → idempotency live read + CTL-1085 node read = TWO live reads total", async () => {
     writeFileSync(join(orchDir, "workers", TICKET, ".linear-label-needs-human.applied"), "");
     const exec = makeExecSpy();
     const gateway = { getDescriptor: () => null };
@@ -4004,7 +4005,8 @@ describe("schedulerTick — retraction sweep uses gateway cache (CTL-1079)", () 
       writeStatus: makeWriteStatus(exec),
       gateway,
     });
-    expect(exec.calls.filter(isLiveRead)).toHaveLength(1);
+    // Cache miss → idempotency live read; CTL-1085 UUID write-path node read adds one more.
+    expect(exec.calls.filter(isLiveRead)).toHaveLength(2);
   });
 
   test("CTL-1079: cache hit, label already absent → idempotent no-op, no read AND no write", async () => {
@@ -4024,7 +4026,7 @@ describe("schedulerTick — retraction sweep uses gateway cache (CTL-1079)", () 
     expect(exec.calls.filter(isOverwrite)).toHaveLength(0);
   });
 
-  test("CTL-1079: no gateway injected → unchanged behavior (live read fires)", async () => {
+  test("CTL-1079: no gateway → idempotency live read + CTL-1085 node read = TWO live reads total", async () => {
     writeFileSync(join(orchDir, "workers", TICKET, ".linear-label-needs-human.applied"), "");
     const exec = makeExecSpy();
     schedulerTick(orchDir, {
@@ -4033,7 +4035,8 @@ describe("schedulerTick — retraction sweep uses gateway cache (CTL-1079)", () 
       writeStatus: makeWriteStatus(exec),
       // gateway intentionally omitted
     });
-    expect(exec.calls.filter(isLiveRead)).toHaveLength(1);
+    // No gateway → idempotency live read fires. CTL-1085 write-path node read adds one more.
+    expect(exec.calls.filter(isLiveRead)).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-13T01:25:00Z -->
<!-- Last updated: 2026-06-13T01:25:00Z -->
<!-- PR: #1930 -->
<!-- Previous commits: 05e176af,8161b2c5 -->

## Summary

`removeLabel` used name-based label overwrites that fail for ADV tickets whose label names ("frontend", "schema", etc.) collide with identically-named CTL-team labels. Linear resolves these names against the wrong team's UUID context and rejects the write, leaving `needs-human` permanently stuck on affected tickets and draining the inbox attention queue. This PR fixes the write path to use ticket-native label UUIDs and adds a distinct `team-mismatch` reason code so the CTL-834 retry storm-break continues to fire correctly.

## Problem

When `removeLabel` removes a label from an ADV ticket, it:
1. Fetches the current label list by **name** (`fetchTicketLabels`)
2. Filters out the target label
3. Overwrites with `linearis issues update --labels remaining.join(",") --label-mode overwrite`

Linear resolves label names workspace-wide. When an ADV ticket carries labels like "frontend" or "schema" that also exist in the CTL team (with different UUIDs), linearis resolves the CTL-team UUID and Linear rejects the write:

```
LabelIds for incorrect team - The label 'schema' is not associated with the same team as the issue
```

The old code classified this as `missing-label` — an unrecoverable reason that wrote a `.skipped` marker — so the label write was silently abandoned. On the `applyLabel` path the storm-break still fired, but operators couldn't distinguish "label absent from workspace" from "label present but resolved to wrong team UUID."

Observed on ADV-1349, ADV-1351, ADV-1329 on 2026-06-12: tickets sat `Done` while still wearing `needs-human` because the sweep could never remove it.

## Changes Made

### `linear-query.mjs` — new `readTicketLabelNodes` seam

Adds `readTicketLabelNodes(identifier)` that returns `{ ok, nodes: [{id, name}] }` — the ticket's own label nodes with UUIDs. Unlike `fetchTicketLabels` (names only), this preserves the UUID so callers can build a write payload anchored to the ticket's team context.

### `linear-write.mjs` — UUID-based `removeLabel` overwrite

`removeLabel` now calls `readLabelNodes(ticket)` before building the overwrite `--labels` argument:
- If the node read succeeds and every remaining name maps to a UUID → pass UUIDs (avoids cross-team resolution)
- Otherwise → fall back to names (existing behavior, back-compat preserved)

Also renames `classifyLabelFailure`'s "incorrect team" bucket from `"missing-label"` → `"team-mismatch"` so operators get a distinct, legible reason code. Both reasons remain in `UNRECOVERABLE_LABEL_REASONS`.

### `label-guard.mjs` + `scheduler.mjs` — sync UNRECOVERABLE sets

Both modules maintain a local `UNRECOVERABLE_LABEL_REASONS` set that mirrors `classifyLabelFailure`'s output. The phase-review remediation commit (commit 2) caught that `scheduler.mjs`'s local set was not updated, which would have dropped the CTL-834 cool-down on cross-team `convergeHeldLabel` failures. Both sets now include `"team-mismatch"`.

### Tests (8 files, +213 / -15 lines)

- `linear-query.test.mjs`: 4 new tests for `readTicketLabelNodes` (success, non-zero exit, unparseable, empty labels)
- `linear-write.test.mjs`: 7 new tests for UUID path (success, multi-name map, fallback on bad node read, fallback on missing node, clear-labels path, `classifyLabelFailure` rename, regression pin)
- `label-guard.test.mjs`: 1 new test pinning `.skipped` marker on `team-mismatch` input
- `scheduler.test.mjs`: regression tests for `convergeHeldLabel` cool-down on `team-mismatch`

## How to Verify It

- [x] `execution-core-unit-tests` CI pass ✅ (19s, all label-write and scheduler tests green)
- [x] `validate` CI pass ✅
- [x] `audit-references` CI pass ✅
- [x] `check-versions` CI pass ✅
- [x] `docs-gate` CI pass ✅
- [ ] Manually confirm: trigger a `removeLabel("needs-human")` against a live ADV ticket that carries a label whose name exists in both CTL and ADV teams — confirm write succeeds and only `needs-human` is removed

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1085

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip ADV-1329
skip ADV-1349
skip ADV-1351
skip CTL-834
