### PR TITLE
fix(dev): CTL-1097 — resolve artifact gate dir against signal.worktreePath

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -648,6 +648,57 @@ REASON=$(echo "$LINE" | jq -r '.body.payload.failure_reason' 2>/dev/null || echo
 assert_eq "phase.research.failed.CTL-1081" "$EVENT_NAME" "non-complete status: event name unchanged"
 assert_eq "tests red" "$REASON" "non-complete status: caller reason preserved"
 
+
+# ─── CTL-1097: artifact self-check resolves against signal.worktreePath ──────
+# A revived worker may re-emit from a cwd that is NOT the ticket worktree. The
+# gate must resolve the relative thoughts dir against signal.worktreePath
+# (CTL-615) rather than the emit process's cwd.
+
+echo ""
+echo "Test 43 (CTL-1097): revived worker — artifact in worktreePath, emit from a different cwd → complete stands"
+fresh_env t43
+WT_DIR="${TEST_DIR}/worktree"
+OTHER_CWD="${TEST_DIR}/elsewhere"
+mkdir -p "${WT_DIR}/thoughts/shared/plans" "${OTHER_CWD}"
+touch "${WT_DIR}/thoughts/shared/plans/2026-06-13-ctl-1097-x.md"
+mkdir -p "${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-1097"
+jq -nc --arg wt "$WT_DIR" '{ticket:"CTL-1097",phase:"plan",worktreePath:$wt,generation:1,attempt:1}' \
+	> "${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-1097/phase-plan.json"
+(cd "$OTHER_CWD" && "$EMIT_SCRIPT" --phase plan --ticket CTL-1097 --status complete >/dev/null 2>&1)
+LINE=$(read_event_line)
+EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"' 2>/dev/null || echo "")
+assert_eq "phase.plan.complete.CTL-1097" "$EVENT_NAME" "worktreePath resolution: complete stands from foreign cwd"
+
+echo ""
+echo "Test 44 (CTL-1097): no worktreePath in signal (pre-CTL-615) → fail-open to cwd-relative"
+fresh_env t44
+PROJ_DIR="${TEST_DIR}/proj"
+mkdir -p "${PROJ_DIR}/thoughts/shared/plans"
+touch "${PROJ_DIR}/thoughts/shared/plans/2026-06-13-ctl-1097-x.md"
+mkdir -p "${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-1097"
+echo '{"ticket":"CTL-1097","phase":"plan","generation":1,"attempt":1}' \
+	> "${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-1097/phase-plan.json"
+(cd "$PROJ_DIR" && "$EMIT_SCRIPT" --phase plan --ticket CTL-1097 --status complete >/dev/null 2>&1)
+LINE=$(read_event_line)
+EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"' 2>/dev/null || echo "")
+assert_eq "phase.plan.complete.CTL-1097" "$EVENT_NAME" "no worktreePath: cwd-relative fallback still passes"
+
+echo ""
+echo "Test 45 (CTL-1097): worktreePath set but artifact genuinely absent there → downgraded to failed"
+fresh_env t45
+WT_DIR="${TEST_DIR}/worktree"
+OTHER_CWD="${TEST_DIR}/elsewhere"
+mkdir -p "${WT_DIR}/thoughts/shared/plans" "${OTHER_CWD}"
+mkdir -p "${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-1097"
+jq -nc --arg wt "$WT_DIR" '{ticket:"CTL-1097",phase:"plan",worktreePath:$wt,generation:1,attempt:1}' \
+	> "${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-1097/phase-plan.json"
+(cd "$OTHER_CWD" && "$EMIT_SCRIPT" --phase plan --ticket CTL-1097 --status complete >/dev/null 2>&1)
+LINE=$(read_event_line)
+EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"' 2>/dev/null || echo "")
+REASON=$(echo "$LINE" | jq -r '.body.payload.failure_reason' 2>/dev/null || echo "")
+assert_eq "phase.plan.failed.CTL-1097" "$EVENT_NAME" "genuine miss in worktreePath → failed"
+assert_eq "artifact_not_gate_visible" "$REASON" "genuine miss preserves artifact_not_gate_visible reason"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -234,9 +234,26 @@ if [[ $STATUS == complete ]]; then
 	_OWN_DIR=""
 	_OWN_DIR="$(own_thoughts_artifact_dir_for_phase "$PHASE" 2>/dev/null || true)"
 	if [[ -n $_OWN_DIR ]]; then
-		if ! match_thoughts_artifact "$_OWN_DIR" "$TICKET" >/dev/null 2>&1; then
+		# CTL-1097: a revived worker can re-emit from outside the ticket worktree
+		# (repo root, ~, another worktree). The artifact lives under the worktree
+		# captured at dispatch (signal.worktreePath, CTL-615), so resolve the
+		# relative artifact dir against it before globbing — otherwise the gate
+		# inspects the wrong tree and downgrades a valid complete on a false miss.
+		# Fail-open: when worktreePath is absent/empty/non-dir (pre-CTL-615 signal,
+		# or no ORCH_DIR) or _OWN_DIR is already absolute, keep cwd-relative.
+		_GATE_DIR="$_OWN_DIR"
+		if [[ $_OWN_DIR != /* && -n $ORCH_DIR ]]; then
+			_WT_SIGNAL="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+			if [[ -f $_WT_SIGNAL ]] && command -v jq >/dev/null 2>&1; then
+				_WT_FROM_SIGNAL=$(jq -r '.worktreePath // empty' "$_WT_SIGNAL" 2>/dev/null || echo "")
+				if [[ -n $_WT_FROM_SIGNAL && -d $_WT_FROM_SIGNAL ]]; then
+					_GATE_DIR="${_WT_FROM_SIGNAL%/}/${_OWN_DIR}"
+				fi
+			fi
+		fi
+		if ! match_thoughts_artifact "$_GATE_DIR" "$TICKET" >/dev/null 2>&1; then
 			echo "phase-agent-emit-complete: refusing 'complete' for ${TICKET}/${PHASE}: own artifact not gate-visible" >&2
-			echo "  expected: ${_OWN_DIR}/*-${TICKET}*.md   cwd: $(pwd)" >&2
+			echo "  expected: ${_GATE_DIR}/*-${TICKET}*.md   cwd: $(pwd)" >&2
 			STATUS="failed"
 			REASON="artifact_not_gate_visible"
 		fi


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-13T01:43:00Z -->
<!-- Last updated: 2026-06-13T01:43:00Z -->
<!-- PR: #1932 -->
<!-- Previous commits: b62a5d3d -->

## Summary

`phase-agent-emit-complete`'s CTL-1081 artifact self-check globbed the thoughts dir relative to the **emit process's cwd**, not the ticket worktree. A revived worker re-emitting from repo root, `~`, or a different worktree therefore failed the gate with `artifact_not_gate_visible` — even when the artifact was present in the canonical worktree — and the phase was incorrectly downgraded to `failed`, triggering an unnecessary re-dispatch. This PR resolves the relative artifact directory against `signal.worktreePath` (CTL-615) before calling `match_thoughts_artifact`, with fail-open fallback for pre-CTL-615 signals.

## Problem

`own_thoughts_artifact_dir_for_phase` returns a **relative** path (e.g., `thoughts/shared/research`). `match_thoughts_artifact` globs `<relative-dir>/*-<TICKET>*.md` relative to whatever directory the `emit-complete` process is running in. Under normal operation (worker launched from the worktree) this is fine. But a revived worker may re-emit from:

- the repo root
- `~` (a `--bg` restart)
- another ticket's worktree

In all three cases the glob hits the wrong tree and the artifact is invisible, even though it was written correctly during the original phase run. The gate then forces `STATUS=failed` and emits `artifact_not_gate_visible`, kicking the orchestrator into a re-dispatch loop for a phase that already succeeded.

Live case: CTL-1085's research artifact was written at 19:30 2026-06-12; a revived worker gate-failed at 00:31 2026-06-13. An operator had to manually re-emit from inside the worktree to unblock.

## Changes Made

### `plugins/dev/scripts/phase-agent-emit-complete` (+19 / -2)

In the `STATUS == complete` artifact gate block, before calling `match_thoughts_artifact`:

1. Check if `_OWN_DIR` is relative and `ORCH_DIR` is set.
2. If so, read `worktreePath` from the phase's signal file (already present as `signal.worktreePath`, written at dispatch per CTL-615).
3. If `worktreePath` is non-empty and is a directory, prepend it to `_OWN_DIR` to form an absolute path (`_GATE_DIR`).
4. Fall back to cwd-relative if `worktreePath` is absent, empty, or not a directory (preserves compat with pre-CTL-615 signals).
5. Pass `_GATE_DIR` (instead of `_OWN_DIR`) to `match_thoughts_artifact` and update the error message accordingly.

### `plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh` (+51 / -0)

Three new tests (43–45) encoding the three scenarios:

| Test | Scenario | Expected |
|------|----------|----------|
| 43 | Revived worker, artifact in `worktreePath`, emit from a different cwd | `phase.plan.complete.CTL-1097` (gate passes via `worktreePath`) |
| 44 | No `worktreePath` in signal (pre-CTL-615) | `phase.plan.complete.CTL-1097` (fail-open, cwd-relative fallback) |
| 45 | `worktreePath` set, artifact **genuinely absent** there | `phase.plan.failed.CTL-1097` with `artifact_not_gate_visible` reason |

## How to Verify It

- [x] `validate` CI pass ✅
- [x] `audit-references` CI pass ✅
- [x] `check-versions` CI pass ✅
- [x] `docs-gate` CI pass ✅
- [x] `Cloudflare Pages` CI pass ✅
- [ ] Manually trigger a revived-worker scenario: dispatch a phase, let it write its artifact, then re-emit from a different directory and confirm the complete stands

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1097

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1081
skip CTL-1085
skip CTL-615
