### PR TITLE
feat(dev): CTL-1092 — Cluster Capacity Visibility

### DIFF
--- a/plugins/dev/scripts/execution-core/autotune-capacity.test.mjs
+++ b/plugins/dev/scripts/execution-core/autotune-capacity.test.mjs
@@ -1,0 +1,110 @@
+// autotune-capacity.test.mjs — CTL-1092. Verify appendCapacityChangedEvent seam
+// fires alongside appendAdjustedEvent only when maxParallel changes.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test autotune-capacity.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { autoTuneTick } from "./autotune.mjs";
+
+function makeState(overrides = {}) {
+  return {
+    window: [],
+    windowSamples: 10,
+    trendMinSamples: 3,
+    loadSafeFactor: 4,
+    criticalPct: 5,
+    warnPct: 20,
+    ...overrides,
+  };
+}
+
+function makeSeams(overrides = {}) {
+  return {
+    liveBackgroundCount: () => 2,
+    loadavg: () => [1, 2, 3],
+    freemem: () => 8e9,
+    totalmem: () => 10e9,
+    cpus: () => Array(4),
+    readConcurrency: () => ({ maxParallel: 10, minParallel: 2, maxParallelCeiling: 20 }),
+    writeLayer2: () => true,
+    appendSampledEvent: () => true,
+    appendAdjustedEvent: () => true,
+    appendCapacityChangedEvent: () => true,
+    ...overrides,
+  };
+}
+
+describe("appendCapacityChangedEvent seam (CTL-1092)", () => {
+  test("fires alongside appendAdjustedEvent when maxParallel changes", () => {
+    // Seed 2 up-trend samples; 3rd completes the trend → next !== current
+    const upSamples = [
+      { load1: 10, load5: 8, load15: 6, memFreePct: 50, coreCount: 4 },
+      { load1: 12, load5: 9, load15: 7, memFreePct: 50, coreCount: 4 },
+    ];
+    const state = makeState({ window: upSamples });
+    const capacityCalls = [];
+    const adjustedCalls = [];
+    const seams = makeSeams({
+      loadavg: () => [15, 11, 8], // 3rd up-trend sample — completes minSamples=3
+      readConcurrency: () => ({ maxParallel: 10, minParallel: 2, maxParallelCeiling: 20 }),
+      writeLayer2: () => true,
+      appendAdjustedEvent: (a) => { adjustedCalls.push(a); return true; },
+      appendCapacityChangedEvent: (c) => { capacityCalls.push(c); return true; },
+    });
+    autoTuneTick(state, seams);
+    // trend-up → next = floor(10 * 0.75) = 7 ≠ 10
+    expect(adjustedCalls).toHaveLength(1);
+    expect(adjustedCalls[0].oldMaxParallel).toBe(10);
+    expect(adjustedCalls[0].newMaxParallel).toBe(7);
+
+    expect(capacityCalls).toHaveLength(1);
+    expect(capacityCalls[0].label).toBe("execution-core");
+    expect(capacityCalls[0].oldMaxParallel).toBe(10);
+    expect(capacityCalls[0].newMaxParallel).toBe(7);
+    expect(capacityCalls[0].reason).toBe("trend-up");
+  });
+
+  test("does NOT fire appendCapacityChangedEvent when maxParallel is unchanged", () => {
+    // Only 1 sample → insufficient-samples → hold → next === current
+    const state = makeState({ window: [{ load1: 5, load5: 5, load15: 5, memFreePct: 50, coreCount: 4 }] });
+    const capacityCalls = [];
+    const seams = makeSeams({
+      readConcurrency: () => ({ maxParallel: 10, minParallel: 2, maxParallelCeiling: 20 }),
+      appendCapacityChangedEvent: (c) => { capacityCalls.push(c); return true; },
+    });
+    autoTuneTick(state, seams);
+    expect(capacityCalls).toHaveLength(0);
+  });
+
+  test("a throwing appendCapacityChangedEvent does not propagate out of autoTuneTick", () => {
+    const upSamples = [
+      { load1: 10, load5: 8, load15: 6, memFreePct: 50, coreCount: 4 },
+      { load1: 12, load5: 9, load15: 7, memFreePct: 50, coreCount: 4 },
+    ];
+    const state = makeState({ window: upSamples });
+    const seams = makeSeams({
+      loadavg: () => [15, 11, 8],
+      readConcurrency: () => ({ maxParallel: 10, minParallel: 2, maxParallelCeiling: 20 }),
+      appendCapacityChangedEvent: () => { throw new Error("io error"); },
+    });
+    expect(() => autoTuneTick(state, seams)).not.toThrow();
+  });
+
+  test("appendCapacityChangedEvent is independent of appendAdjustedEvent throwing", () => {
+    const upSamples = [
+      { load1: 10, load5: 8, load15: 6, memFreePct: 50, coreCount: 4 },
+      { load1: 12, load5: 9, load15: 7, memFreePct: 50, coreCount: 4 },
+    ];
+    const state = makeState({ window: upSamples });
+    const capacityCalls = [];
+    const seams = makeSeams({
+      loadavg: () => [15, 11, 8],
+      readConcurrency: () => ({ maxParallel: 10, minParallel: 2, maxParallelCeiling: 20 }),
+      appendAdjustedEvent: () => { throw new Error("adjusted fails"); },
+      appendCapacityChangedEvent: (c) => { capacityCalls.push(c); return true; },
+    });
+    expect(() => autoTuneTick(state, seams)).not.toThrow();
+    // Capacity seam must fire even when the adjusted seam threw
+    expect(capacityCalls).toHaveLength(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/autotune.mjs
+++ b/plugins/dev/scripts/execution-core/autotune.mjs
@@ -29,6 +29,11 @@ import {
   defaultAppendParallelismAdjustedEvent,
   defaultAppendAutotuneGaugeEvent,
 } from "./recovery.mjs";
+import { emitCapacityChangedEvent } from "./capacity-event.mjs";
+
+function defaultAppendCapacityChangedEvent(args) {
+  emitCapacityChangedEvent(args);
+}
 import {
   AUTOTUNE_SAMPLE_INTERVAL_MS,
   AUTOTUNE_WINDOW_SAMPLES,
@@ -486,6 +491,7 @@ export function autoTuneTick(state, seams) {
     appendSampledEvent,
     appendAdjustedEvent,
     appendGaugeEvent,       // CTL-771: per-tick setpoint gauge emitter
+    appendCapacityChangedEvent, // CTL-1092: node.capacity.changed alongside parallelism-adjusted
   } = seams;
 
   try {
@@ -618,6 +624,14 @@ export function autoTuneTick(state, seams) {
           reason,
         });
       } catch {}
+      try {
+        appendCapacityChangedEvent?.({
+          label: "execution-core",
+          oldMaxParallel: current,
+          newMaxParallel: next,
+          reason,
+        });
+      } catch {}
     }
   } catch {}
 }
@@ -648,6 +662,7 @@ export function startAutoTuner({
   appendSampledEvent = defaultAppendParallelismSampledEvent,
   appendAdjustedEvent = defaultAppendParallelismAdjustedEvent,
   appendGaugeEvent = defaultAppendAutotuneGaugeEvent,  // CTL-771
+  appendCapacityChangedEvent = defaultAppendCapacityChangedEvent,  // CTL-1092
 } = {}) {
   if (!enabled) return () => {};
 
@@ -687,6 +702,7 @@ export function startAutoTuner({
     appendSampledEvent,
     appendAdjustedEvent,
     appendGaugeEvent,  // CTL-771
+    appendCapacityChangedEvent,  // CTL-1092
   };
 
   _timer = setIntervalFn(() => autoTuneTick(_state, seams), sampleIntervalMs);

--- a/plugins/dev/scripts/execution-core/capacity-event.mjs
+++ b/plugins/dev/scripts/execution-core/capacity-event.mjs
@@ -1,0 +1,71 @@
+// capacity-event.mjs — CTL-1092. Node capacity event builder + best-effort appender.
+//
+// Mirrors drain-event.mjs: OTel envelope, appendFileSync, never throws.
+// Emitted on every autotune maxParallel change (alongside parallelism-adjusted).
+
+import { mkdirSync, appendFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getEventLogPath, getHostName, log } from "./config.mjs";
+import { hostName, hostId } from "./lib/host-identity.mjs";
+
+export const CAPACITY_CHANGED_EVENT = "node.capacity.changed";
+
+/**
+ * buildCapacityChangedEnvelope — pure OTel envelope for a capacity change.
+ */
+export function buildCapacityChangedEnvelope({ oldMaxParallel, newMaxParallel, reason, now } = {}) {
+  const ts = now ? now() : new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const host = getHostName();
+  return {
+    ts,
+    id: randomBytes(8).toString("hex"),
+    observedTs: ts,
+    severityText: "INFO",
+    severityNumber: 9,
+    traceId: null,
+    spanId: null,
+    resource: {
+      "service.name": "catalyst.execution-core",
+      "service.namespace": "catalyst",
+      "host.name": hostName(),
+      "host.id": hostId(),
+    },
+    attributes: {
+      "event.name": CAPACITY_CHANGED_EVENT,
+      "event.entity": "node",
+      "event.action": "capacity.changed",
+      "event.label": host,
+    },
+    body: {
+      payload: {
+        "host.name": host,
+        old_maxParallel: oldMaxParallel,
+        new_maxParallel: newMaxParallel,
+        reason,
+      },
+    },
+  };
+}
+
+/**
+ * emitCapacityChangedEvent — append one capacity.changed envelope line. Returns
+ * true on success, false on any failure (best-effort; never throws).
+ */
+export function emitCapacityChangedEvent({
+  oldMaxParallel,
+  newMaxParallel,
+  reason,
+  logPath = getEventLogPath(),
+  now,
+} = {}) {
+  const line = `${JSON.stringify(buildCapacityChangedEnvelope({ oldMaxParallel, newMaxParallel, reason, now }))}\n`;
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, line);
+    return true;
+  } catch (err) {
+    log.warn({ err: err?.message }, "capacity-event: event append failed");
+    return false;
+  }
+}

--- a/plugins/dev/scripts/execution-core/capacity-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/capacity-event.test.mjs
@@ -1,0 +1,110 @@
+// capacity-event.test.mjs — CTL-1092. node.capacity.changed envelope builder + emitter.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test capacity-event.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, readFileSync, appendFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CAPACITY_CHANGED_EVENT,
+  buildCapacityChangedEnvelope,
+  emitCapacityChangedEvent,
+} from "./capacity-event.mjs";
+
+const HOST_ENVS = ["CATALYST_HOST_NAME", "CATALYST_LAYER2_CONFIG_FILE"];
+let savedEnv = {};
+
+beforeEach(() => {
+  for (const k of HOST_ENVS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of HOST_ENVS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  savedEnv = {};
+});
+
+describe("CAPACITY_CHANGED_EVENT constant", () => {
+  test("is 'node.capacity.changed'", () => {
+    expect(CAPACITY_CHANGED_EVENT).toBe("node.capacity.changed");
+  });
+});
+
+describe("buildCapacityChangedEnvelope (CTL-1092)", () => {
+  test("event name, entity, action attributes", () => {
+    const e = buildCapacityChangedEnvelope({ oldMaxParallel: 4, newMaxParallel: 6, reason: "saturated-scale-up" });
+    expect(e.attributes["event.name"]).toBe("node.capacity.changed");
+    expect(e.attributes["event.entity"]).toBe("node");
+    expect(e.attributes["event.action"]).toBe("capacity.changed");
+  });
+
+  test("carries old/new maxParallel, reason, and host.name in payload", () => {
+    const e = buildCapacityChangedEnvelope({ oldMaxParallel: 4, newMaxParallel: 6, reason: "saturated-scale-up" });
+    expect(e.body.payload.old_maxParallel).toBe(4);
+    expect(e.body.payload.new_maxParallel).toBe(6);
+    expect(e.body.payload.reason).toBe("saturated-scale-up");
+    expect(typeof e.body.payload["host.name"]).toBe("string");
+    expect(e.body.payload["host.name"].length).toBeGreaterThan(0);
+  });
+
+  test("resource block has service.name, service.namespace, host.name, host.id", () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    const e = buildCapacityChangedEnvelope({ oldMaxParallel: 4, newMaxParallel: 6, reason: "x" });
+    expect(e.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(e.resource["service.namespace"]).toBe("catalyst");
+    expect(e.resource["host.name"]).toBe("mini");
+    expect(typeof e.resource["host.id"]).toBe("string");
+    expect(e.resource["host.id"]).toHaveLength(16);
+  });
+
+  test("ts is a no-millisecond ISO string", () => {
+    const e = buildCapacityChangedEnvelope({ oldMaxParallel: 2, newMaxParallel: 4, reason: "x" });
+    expect(e.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  test("severityText INFO, severityNumber 9", () => {
+    const e = buildCapacityChangedEnvelope({ oldMaxParallel: 2, newMaxParallel: 4, reason: "x" });
+    expect(e.severityText).toBe("INFO");
+    expect(e.severityNumber).toBe(9);
+  });
+});
+
+describe("emitCapacityChangedEvent (CTL-1092)", () => {
+  let tmp;
+  let logPath;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "ctl1092-ce-"));
+    logPath = join(tmp, "events.jsonl");
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("appends one parseable node.capacity.changed line to the event log", () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    expect(emitCapacityChangedEvent({ oldMaxParallel: 4, newMaxParallel: 6, reason: "saturated-scale-up", logPath })).toBe(true);
+    const lines = readFileSync(logPath, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+    const evt = JSON.parse(lines[0]);
+    expect(evt.attributes["event.name"]).toBe("node.capacity.changed");
+    expect(evt.body.payload.old_maxParallel).toBe(4);
+    expect(evt.body.payload.new_maxParallel).toBe(6);
+    expect(evt.body.payload.reason).toBe("saturated-scale-up");
+    expect(evt.body.payload["host.name"]).toBe("mini");
+  });
+
+  test("returns false (never throws) when the log path is unwriteable", () => {
+    const fileAsDir = join(tmp, "afile");
+    appendFileSync(fileAsDir, "x");
+    const bad = join(fileAsDir, "events.jsonl");
+    expect(emitCapacityChangedEvent({ oldMaxParallel: 4, newMaxParallel: 6, reason: "x", logPath: bad })).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-capacity.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-capacity.test.mjs
@@ -40,7 +40,9 @@ describe("publishHeartbeat metadata capacity fields (CTL-1092)", () => {
     const calls = [];
     const post = async (q, v) => {
       calls.push({ q, v });
-      if (q.includes("ResolveIssue")) return { issues: { nodes: [{ id: "uuid-anchor" }] } };
+      // CTL-1255: resolveIssueId now uses the singular `issue(id:)` query and reads
+      // data.issue.id (the old `issues(filter:)` form 400'd). Mock the new shape.
+      if (q.includes("ResolveIssue")) return { issue: { id: "uuid-anchor" } };
       return { attachmentCreate: { success: true, attachment: { id: "a1" } } };
     };
     const rec = await publishHeartbeat(
@@ -58,7 +60,8 @@ describe("publishHeartbeat metadata capacity fields (CTL-1092)", () => {
 
   test("max_parallel defaults to null when omitted from publishHeartbeat", async () => {
     const post = async (q) => {
-      if (q.includes("ResolveIssue")) return { issues: { nodes: [{ id: "uuid-x" }] } };
+      // CTL-1255: resolveIssueId reads data.issue.id from the singular issue(id:) query.
+      if (q.includes("ResolveIssue")) return { issue: { id: "uuid-x" } };
       return { attachmentCreate: { success: true, attachment: {} } };
     };
     const rec = await publishHeartbeat(

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-capacity.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-capacity.test.mjs
@@ -1,0 +1,71 @@
+// cluster-heartbeat-capacity.test.mjs — CTL-1092. Extend cluster-heartbeat to
+// carry max_parallel and in_flight_count in the attachment metadata.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test cluster-heartbeat-capacity.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import {
+  parseHeartbeatMetadata,
+  publishHeartbeat,
+} from "./cluster-heartbeat.mjs";
+
+describe("parseHeartbeatMetadata capacity fields (CTL-1092)", () => {
+  test("normalizes max_parallel (finite int) from metadata", () => {
+    const m = parseHeartbeatMetadata({ host: "laptop", last_seen: "...", in_flight_tickets: [], max_parallel: 8 });
+    expect(m.max_parallel).toBe(8);
+  });
+
+  test("normalizes in_flight_count from metadata (fallback to in_flight_tickets.length)", () => {
+    const m = parseHeartbeatMetadata({ host: "laptop", last_seen: "...", in_flight_tickets: ["CTL-1", "CTL-2"] });
+    expect(m.in_flight_count).toBe(2);
+  });
+
+  test("uses in_flight_count field when explicitly provided", () => {
+    const m = parseHeartbeatMetadata({ host: "laptop", last_seen: "...", in_flight_tickets: [], in_flight_count: 3 });
+    expect(m.in_flight_count).toBe(3);
+  });
+
+  test("max_parallel defaults to null when missing or non-integer", () => {
+    expect(parseHeartbeatMetadata({ host: "laptop", last_seen: "...", in_flight_tickets: [] }).max_parallel).toBeNull();
+    expect(parseHeartbeatMetadata({ host: "laptop", last_seen: "...", in_flight_tickets: [], max_parallel: "bad" }).max_parallel).toBeNull();
+  });
+
+  test("in_flight_count defaults to 0 when missing tickets", () => {
+    expect(parseHeartbeatMetadata({ host: "laptop", last_seen: "...", in_flight_tickets: [] }).in_flight_count).toBe(0);
+  });
+});
+
+describe("publishHeartbeat metadata capacity fields (CTL-1092)", () => {
+  test("publishes max_parallel and in_flight_count in metadata", async () => {
+    const calls = [];
+    const post = async (q, v) => {
+      calls.push({ q, v });
+      if (q.includes("ResolveIssue")) return { issues: { nodes: [{ id: "uuid-anchor" }] } };
+      return { attachmentCreate: { success: true, attachment: { id: "a1" } } };
+    };
+    const rec = await publishHeartbeat(
+      { anchorIssue: "CTL-9999", host: "laptop", inFlightTickets: ["CTL-1", "CTL-2"], maxParallel: 8 },
+      { post, now: () => "2026-06-13T01:00:00Z" },
+    );
+    const write = calls.find((c) => c.q.includes("attachmentCreate"));
+    expect(write.v.input.metadata.max_parallel).toBe(8);
+    expect(write.v.input.metadata.in_flight_count).toBe(2);
+    expect(write.v.input.metadata.in_flight_tickets).toEqual(["CTL-1", "CTL-2"]);
+    // Returned record also carries the capacity fields
+    expect(rec.max_parallel).toBe(8);
+    expect(rec.in_flight_count).toBe(2);
+  });
+
+  test("max_parallel defaults to null when omitted from publishHeartbeat", async () => {
+    const post = async (q) => {
+      if (q.includes("ResolveIssue")) return { issues: { nodes: [{ id: "uuid-x" }] } };
+      return { attachmentCreate: { success: true, attachment: {} } };
+    };
+    const rec = await publishHeartbeat(
+      { anchorIssue: "CTL-9999", host: "mini", inFlightTickets: [] },
+      { post, now: () => "2026-06-13T01:00:00Z" },
+    );
+    expect(rec.max_parallel).toBeNull();
+    expect(rec.in_flight_count).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
@@ -11,6 +11,8 @@
 // signal directory (same predicate defaultOwnedTicketsForHost uses for the
 // fallback path), avoiding a circular dependency on recovery.mjs.
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { readWorkerSignals, TERMINAL } from "./signal-reader.mjs";
 import {
   getClusterHosts,
@@ -20,6 +22,24 @@ import {
   log,
 } from "./config.mjs";
 import { publishHeartbeatSync } from "./cluster-heartbeat-sync.mjs";
+
+// readLocalMaxParallel — this host's live parallel-slot count from state.json
+// (the autotuned value the scheduler reads via readMaxParallel). CTL-1092: the
+// heartbeat carries it so the monitor's cluster view can show per-host capacity.
+// Read directly (not via scheduler.mjs) to keep this publisher a leaf module —
+// importing the scheduler would pull its whole dispatch/recovery graph and risk
+// a cycle. Fail-open: any miss → null, so the heartbeat still publishes liveness
+// without claiming a slot count it can't prove (the monitor treats null as "no
+// data", never an error).
+function readLocalMaxParallel(orchDir) {
+  if (!orchDir) return null;
+  try {
+    const n = JSON.parse(readFileSync(join(orchDir, "state.json"), "utf8"))?.maxParallel;
+    return Number.isInteger(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
 
 // localInFlightTickets — return the in-flight ticket IDs for `hostName` from
 // the local worker signal directory. This is the same predicate as the fallback
@@ -58,6 +78,9 @@ export function startLivenessPublisher({
   anchorIssue = getLivenessAnchorIssue(),
   orchDir,
   ownedTickets = () => localInFlightTickets(self, { orchDir }),
+  // CTL-1092: this host's live slot count, published with each heartbeat so the
+  // monitor cluster view can show per-host capacity. Injectable for tests.
+  currentMaxParallel = () => readLocalMaxParallel(orchDir),
   publish = (args) => publishHeartbeatSync(args),
   logger = log, // CTL-1251: injectable so tests can assert publish-outcome logging
 } = {}) {
@@ -86,7 +109,12 @@ export function startLivenessPublisher({
   let consecutiveFailures = 0;
   const tick = () => {
     try {
-      const result = publish({ anchorIssue, host: self, inFlightTickets: ownedTickets() });
+      const result = publish({
+        anchorIssue,
+        host: self,
+        inFlightTickets: ownedTickets(),
+        maxParallel: currentMaxParallel(),
+      });
       if (result && result.ok === false) {
         if (consecutiveFailures === 0) {
           logger.warn(

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.test.mjs
@@ -52,6 +52,37 @@ describe("startLivenessPublisher (CTL-1090)", () => {
     });
   });
 
+  test("CTL-1092: publishes this host's currentMaxParallel() with each heartbeat", () => {
+    const calls = [];
+    const h = startLivenessPublisher({
+      roster: ["mini", "laptop"],
+      anchorIssue: "CTL-9",
+      self: "mini",
+      ownedTickets: () => ["CTL-1"],
+      currentMaxParallel: () => 5,
+      publish: (args) => calls.push(args),
+      intervalMs: 60_000,
+    });
+    h.stop();
+    expect(calls[0]).toMatchObject({ host: "mini", inFlightTickets: ["CTL-1"], maxParallel: 5 });
+  });
+
+  test("CTL-1092: a null currentMaxParallel() (unresolved slot count) still publishes liveness", () => {
+    const calls = [];
+    const h = startLivenessPublisher({
+      roster: ["mini", "laptop"],
+      anchorIssue: "CTL-9",
+      self: "mini",
+      ownedTickets: () => [],
+      currentMaxParallel: () => null,
+      publish: (args) => calls.push(args),
+      intervalMs: 60_000,
+    });
+    h.stop();
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    expect(calls[0]).toMatchObject({ host: "mini", maxParallel: null });
+  });
+
   test("stop() clears the interval (subsequent ticks do NOT fire)", async () => {
     const calls = [];
     const h = startLivenessPublisher({

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.mjs
@@ -38,7 +38,7 @@ const LIVENESS_TIMEOUT_MS =
 // non-ok as fail-open and never throw.
 // `spawn`/`nodeBin`/`cli`/`env`/`timeout` are injectable for unit tests.
 export function publishHeartbeatSync(
-  { anchorIssue, host, inFlightTickets = [] },
+  { anchorIssue, host, inFlightTickets = [], maxParallel = null },
   {
     spawn = spawnSync,
     nodeBin = process.execPath,
@@ -49,7 +49,12 @@ export function publishHeartbeatSync(
 ) {
   try {
     const ticketsCsv = inFlightTickets.join(",");
-    const res = spawn(nodeBin, [cli, "publish", anchorIssue, host, ticketsCsv], {
+    // CTL-1092: append max_parallel as a 4th arg ONLY when it resolves to a
+    // positive int. A host that can't resolve its slot count still publishes
+    // liveness via the back-compat 3-arg form (the CLI reads it as null).
+    const argv = [cli, "publish", anchorIssue, host, ticketsCsv];
+    if (Number.isInteger(maxParallel) && maxParallel > 0) argv.push(String(maxParallel));
+    const res = spawn(nodeBin, argv, {
       encoding: "utf8",
       env,
       timeout,

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.test.mjs
@@ -60,6 +60,40 @@ describe("publishHeartbeatSync — argv + fail-open contract", () => {
     expect(capturedArgs[3]).toBe("mini");
   });
 
+  test("CTL-1092: appends maxParallel as the 4th positional arg when it is a positive int", () => {
+    let capturedArgs;
+    const spawn = (_bin, args) => {
+      capturedArgs = args;
+      return { status: 0, stdout: '{"host":"mini","last_seen":"t","in_flight_tickets":[],"max_parallel":3}\n' };
+    };
+    publishHeartbeatSync(
+      { anchorIssue: "CTL-9", host: "mini", inFlightTickets: ["CTL-1"], maxParallel: 3 },
+      { spawn },
+    );
+    // argv: [cli, "publish", anchor, host, ticketsCsv, maxParallel]
+    expect(capturedArgs[4]).toBe("CTL-1");
+    expect(capturedArgs[5]).toBe("3");
+  });
+
+  test("CTL-1092: omits maxParallel (back-compat 3-arg form) when null/absent/non-positive", () => {
+    const grab = (args) => {
+      let captured;
+      const spawn = (_bin, a) => {
+        captured = a;
+        return { status: 0, stdout: '{"host":"mini","last_seen":"t","in_flight_tickets":[]}\n' };
+      };
+      publishHeartbeatSync({ anchorIssue: "CTL-9", host: "mini", inFlightTickets: [], ...args }, { spawn });
+      return captured;
+    };
+    // ticketsCsv is "" here, so a present maxParallel would be argv[5]; none must be appended.
+    expect(grab({}).length).toBe(5); // no maxParallel
+    expect(grab({ maxParallel: null }).length).toBe(5);
+    expect(grab({ maxParallel: 0 }).length).toBe(5);
+    expect(grab({ maxParallel: -1 }).length).toBe(5);
+    expect(grab({ maxParallel: 2.5 }).length).toBe(5);
+    expect(grab({ maxParallel: 4 }).length).toBe(6); // positive int → appended
+  });
+
   test("fail-open: non-zero exit → ok:false (never throws)", () => {
     const spawn = () => ({ status: 1, stdout: "" });
     expect(publishHeartbeatSync({ anchorIssue: "CTL-9", host: "mini" }, { spawn }).ok).toBe(false);

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat.mjs
@@ -77,15 +77,22 @@ const READ_ATTACHMENTS_QUERY = `query ReadFence($id: String!) {
 
 // parseHeartbeatMetadata — normalise an attachment's metadata into the flat
 // liveness record callers consume. `in_flight_tickets` is normalised to a
-// string array (non-string entries filtered). Exported for unit coverage.
+// string array (non-string entries filtered). CTL-1092: adds max_parallel
+// (finite int or null) and in_flight_count (int ≥ 0). Exported for unit coverage.
 export function parseHeartbeatMetadata(metadata) {
   const m = metadata ?? {};
   const raw = m.in_flight_tickets;
   const tickets = Array.isArray(raw) ? raw.filter((t) => typeof t === "string") : [];
+  const maxP = m.max_parallel;
+  const maxParallel = Number.isInteger(maxP) && maxP > 0 ? maxP : null;
+  const rawCount = m.in_flight_count;
+  const inFlightCount = Number.isInteger(rawCount) && rawCount >= 0 ? rawCount : tickets.length;
   return {
     host: m.host ?? null,
     last_seen: m.last_seen ?? null,
     in_flight_tickets: tickets,
+    max_parallel: maxParallel,
+    in_flight_count: inFlightCount,
   };
 }
 
@@ -121,13 +128,19 @@ const WRITE_ATTACHMENT_MUTATION = `mutation UpsertFence($input: AttachmentCreate
 // (resolve issue UUID, then attachmentCreate UPSERT). Returns the parsed
 // heartbeat record written, throwing on a resolution miss or success:false.
 export async function publishHeartbeat(
-  { anchorIssue, host, inFlightTickets = [] },
+  { anchorIssue, host, inFlightTickets = [], maxParallel = null },
   { post = defaultPost, now } = {},
 ) {
   const issueId = await resolveIssueId(anchorIssue, { post });
   if (!issueId) throw new Error(`cluster-heartbeat: no issue found for anchor ${anchorIssue}`);
   const last_seen = now ? now() : new Date().toISOString();
-  const metadata = { host, last_seen, in_flight_tickets: inFlightTickets };
+  const metadata = {
+    host,
+    last_seen,
+    in_flight_tickets: inFlightTickets,
+    max_parallel: maxParallel ?? null,
+    in_flight_count: inFlightTickets.length,
+  };
   const data = await post(WRITE_ATTACHMENT_MUTATION, {
     input: {
       issueId,

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat.mjs
@@ -97,7 +97,8 @@ export function parseHeartbeatMetadata(metadata) {
 }
 
 // readPeerHeartbeats — read all `catalyst://heartbeat/*` attachments from the
-// anchor issue. Returns { [host]: { host, last_seen, in_flight_tickets } }.
+// anchor issue. Returns { [host]: { host, last_seen, in_flight_tickets,
+// max_parallel, in_flight_count } } (the full parseHeartbeatMetadata record).
 // Best-effort: a missing/erroring anchor yields {}. The caller filters out
 // `self` to avoid treating its own attachment as a peer.
 export async function readPeerHeartbeats({ anchorIssue }, { post = defaultPost } = {}) {
@@ -161,13 +162,13 @@ export async function publishHeartbeat(
 // cluster-heartbeat-sync.mjs is the in-process wrapper that spawnSync's
 // `node cluster-heartbeat.mjs <cmd> …`.
 //
-//   publish <anchor> <host> <ticketsCSV>  → stdout JSON record; exit 0
-//   read <anchor>                          → stdout JSON map; exit 0
+//   publish <anchor> <host> <ticketsCSV> [maxParallel]  → stdout JSON record; exit 0
+//   read <anchor>                                        → stdout JSON map; exit 0
 export async function runCli(argv, { post = defaultPost, now } = {}) {
   const [cmd, ...rest] = argv;
   switch (cmd) {
     case "publish": {
-      const [anchor, host, ticketsCsv] = rest;
+      const [anchor, host, ticketsCsv, maxParallelRaw] = rest;
       const inFlightTickets =
         ticketsCsv
           ? ticketsCsv
@@ -175,8 +176,13 @@ export async function runCli(argv, { post = defaultPost, now } = {}) {
               .map((t) => t.trim())
               .filter(Boolean)
           : [];
+      // CTL-1092: optional 4th arg — this host's live max_parallel (slot count).
+      // Absent/blank/non-positive-int → null (back-compat: pre-CTL-1092 callers
+      // pass only 3 args, so the heartbeat still carries max_parallel: null).
+      const mp = maxParallelRaw != null && maxParallelRaw !== "" ? Number(maxParallelRaw) : null;
+      const maxParallel = Number.isInteger(mp) && mp > 0 ? mp : null;
       const rec = await publishHeartbeat(
-        { anchorIssue: anchor, host, inFlightTickets },
+        { anchorIssue: anchor, host, inFlightTickets, maxParallel },
         { post, now },
       );
       process.stdout.write(JSON.stringify(rec) + "\n");
@@ -191,7 +197,7 @@ export async function runCli(argv, { post = defaultPost, now } = {}) {
     default:
       process.stderr.write(
         `cluster-heartbeat.mjs: unknown subcommand: ${cmd ?? "(none)"}\n` +
-          "usage: cluster-heartbeat.mjs <publish <anchor> <host> <ticketsCSV> | read <anchor>>\n",
+          "usage: cluster-heartbeat.mjs <publish <anchor> <host> <ticketsCSV> [maxParallel] | read <anchor>>\n",
       );
       return 1;
   }

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat.test.mjs
@@ -35,7 +35,7 @@ describe("heartbeatUrl", () => {
 describe("parseHeartbeatMetadata", () => {
   test("normalises in_flight_tickets to an array", () => {
     expect(parseHeartbeatMetadata({ host: "mini", last_seen: "2026-06-13T01:00:00Z" }))
-      .toEqual({ host: "mini", last_seen: "2026-06-13T01:00:00Z", in_flight_tickets: [] });
+      .toMatchObject({ host: "mini", last_seen: "2026-06-13T01:00:00Z", in_flight_tickets: [] });
     expect(parseHeartbeatMetadata({ in_flight_tickets: ["CTL-1"] }).in_flight_tickets)
       .toEqual(["CTL-1"]);
   });
@@ -47,12 +47,14 @@ describe("parseHeartbeatMetadata", () => {
   });
 
   test("missing/null metadata returns all-null record with empty tickets", () => {
-    expect(parseHeartbeatMetadata(undefined)).toEqual({
+    expect(parseHeartbeatMetadata(undefined)).toMatchObject({
       host: null,
       last_seen: null,
       in_flight_tickets: [],
+      max_parallel: null,
+      in_flight_count: 0,
     });
-    expect(parseHeartbeatMetadata(null)).toEqual({
+    expect(parseHeartbeatMetadata(null)).toMatchObject({
       host: null,
       last_seen: null,
       in_flight_tickets: [],

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat.test.mjs
@@ -211,6 +211,34 @@ describe("runCli", () => {
     expect(JSON.parse(out).in_flight_tickets).toEqual([]);
   });
 
+  test("CTL-1092 publish: 4th arg sets max_parallel (positive int)", async () => {
+    const post = async (q) => {
+      if (q.includes("ResolveIssue")) return { issue: { id: "uuid-x" } };
+      return { attachmentCreate: { success: true, attachment: {} } };
+    };
+    const { code, out } = await captureStdout(() =>
+      runCli(["publish", "CTL-9999", "mini", "CTL-1", "3"], { post, now: () => "2026-06-13T01:00:00Z" }),
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(out).max_parallel).toBe(3);
+  });
+
+  test("CTL-1092 publish: absent/blank/non-positive 4th arg → max_parallel null (back-compat)", async () => {
+    const post = async (q) => {
+      if (q.includes("ResolveIssue")) return { issue: { id: "uuid-x" } };
+      return { attachmentCreate: { success: true, attachment: {} } };
+    };
+    const run = async (argv) => {
+      const { out } = await captureStdout(() => runCli(argv, { post, now: () => "t" }));
+      return JSON.parse(out).max_parallel;
+    };
+    expect(await run(["publish", "CTL-9999", "mini", "CTL-1"])).toBe(null); // 3-arg form
+    expect(await run(["publish", "CTL-9999", "mini", "CTL-1", ""])).toBe(null);
+    expect(await run(["publish", "CTL-9999", "mini", "CTL-1", "0"])).toBe(null);
+    expect(await run(["publish", "CTL-9999", "mini", "CTL-1", "-2"])).toBe(null);
+    expect(await run(["publish", "CTL-9999", "mini", "CTL-1", "abc"])).toBe(null);
+  });
+
   test("read: prints JSON map and exits 0", async () => {
     const post = async () => ({
       issue: {

--- a/plugins/dev/scripts/execution-core/host-alias.d.mts
+++ b/plugins/dev/scripts/execution-core/host-alias.d.mts
@@ -1,0 +1,15 @@
+// Type declarations for host-alias.mjs (CTL-1092). Read-time host alias
+// resolution for pre-pin OS names. The .mjs remains the single source of truth;
+// this file only gives TS callers (orch-monitor/server.ts) the signatures.
+
+/**
+ * Map a raw hostname through the alias table. Returns the aliased name if found,
+ * else the original name unchanged. A null/undefined map is pass-through.
+ */
+export function resolveHostAlias(name: string, aliases?: Record<string, string> | null): string;
+
+/**
+ * Read catalyst.host.aliases from Layer-1 config. Returns {} when the file is
+ * absent, unreadable, or the key is missing/non-object.
+ */
+export function loadHostAliases(args?: { configPath?: string }): Record<string, string>;

--- a/plugins/dev/scripts/execution-core/host-alias.mjs
+++ b/plugins/dev/scripts/execution-core/host-alias.mjs
@@ -1,0 +1,34 @@
+// host-alias.mjs — CTL-1092. Read-time host alias resolution for pre-pin OS names.
+//
+// Reads the catalyst.host.aliases map from Layer-1 config (.catalyst/config.json)
+// so old heartbeat keys (pre-pin OS hostnames) merge onto pinned roster names.
+// Pure functions — no network, no timers.
+
+import { readFileSync } from "node:fs";
+
+/**
+ * resolveHostAlias — map a raw hostname through the alias table.
+ * Returns the aliased name if found, else the original name unchanged.
+ * Null/undefined aliases map is treated as empty (pass-through).
+ */
+export function resolveHostAlias(name, aliases) {
+  if (!aliases || typeof aliases !== "object") return name;
+  return aliases[name] ?? name;
+}
+
+/**
+ * loadHostAliases — read catalyst.host.aliases from Layer-1 config.
+ * Returns {} when the file is absent, unreadable, or the key is missing.
+ */
+export function loadHostAliases({ configPath } = {}) {
+  if (!configPath) return {};
+  try {
+    const raw = readFileSync(configPath, "utf8");
+    const cfg = JSON.parse(raw);
+    const aliases = cfg?.catalyst?.host?.aliases;
+    if (!aliases || typeof aliases !== "object" || Array.isArray(aliases)) return {};
+    return aliases;
+  } catch {
+    return {};
+  }
+}

--- a/plugins/dev/scripts/execution-core/host-alias.test.mjs
+++ b/plugins/dev/scripts/execution-core/host-alias.test.mjs
@@ -1,0 +1,61 @@
+// host-alias.test.mjs — CTL-1092. Host alias resolution for pre-pin OS names.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test host-alias.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveHostAlias, loadHostAliases } from "./host-alias.mjs";
+
+describe("resolveHostAlias (CTL-1092)", () => {
+  test("maps a pre-pin OS name to the pinned roster name", () => {
+    const aliases = { "Ryans-Mac-mini-250233": "mini", "RyansMini250233.rozich": "laptop" };
+    expect(resolveHostAlias("Ryans-Mac-mini-250233", aliases)).toBe("mini");
+    expect(resolveHostAlias("RyansMini250233.rozich", aliases)).toBe("laptop");
+  });
+
+  test("passes through a name with no alias", () => {
+    expect(resolveHostAlias("mini", {})).toBe("mini");
+    expect(resolveHostAlias("mini", { "other": "something" })).toBe("mini");
+  });
+
+  test("handles null/undefined aliases gracefully", () => {
+    expect(resolveHostAlias("mini", null)).toBe("mini");
+    expect(resolveHostAlias("mini", undefined)).toBe("mini");
+  });
+});
+
+describe("loadHostAliases (CTL-1092)", () => {
+  let tmp;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "host-alias-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("returns {} when no config path is given", () => {
+    expect(loadHostAliases({ configPath: null })).toEqual({});
+  });
+
+  test("returns {} when config file is missing", () => {
+    expect(loadHostAliases({ configPath: "/nonexistent/path/config.json" })).toEqual({});
+  });
+
+  test("returns the alias map from catalyst.host.aliases", () => {
+    const config = { catalyst: { host: { aliases: { "Ryans-Mac-mini-250233": "mini" } } } };
+    const configPath = join(tmp, "config.json");
+    writeFileSync(configPath, JSON.stringify(config));
+    expect(loadHostAliases({ configPath })).toEqual({ "Ryans-Mac-mini-250233": "mini" });
+  });
+
+  test("returns {} when catalyst.host.aliases is absent", () => {
+    const config = { catalyst: { orchestration: {} } };
+    const configPath = join(tmp, "config.json");
+    writeFileSync(configPath, JSON.stringify(config));
+    expect(loadHostAliases({ configPath })).toEqual({});
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-signal-endpoints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-signal-endpoints.test.ts
@@ -80,7 +80,8 @@ describe("GET /api/cluster (CTL-898 one-shot)", () => {
     const res = await fetch(`${baseUrl}/api/cluster`);
     const body = (await res.json()) as ClusterSignal;
     expect(body.singleHost).toBe(false);
-    expect(body.nodes).toEqual([
+    // CTL-1092: nodes now carry capacity fields; check only status contract
+    expect(body.nodes).toMatchObject([
       { host: "mini", status: "live" },
       { host: "studio", status: "offline" },
     ]);
@@ -140,7 +141,8 @@ describe("GET /api/cluster — single-host identity no-op", () => {
       const res = await fetch(`http://localhost:${single.port}/api/cluster`);
       const body = (await res.json()) as ClusterSignal;
       expect(body.singleHost).toBe(true);
-      expect(body.nodes).toEqual([{ host: "mini", status: "live" }]);
+      // CTL-1092: nodes now carry capacity fields; check only status contract
+      expect(body.nodes).toMatchObject([{ host: "mini", status: "live" }]);
     } finally {
       void single.stop(true);
       rmSync(tmp2, { recursive: true, force: true });

--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-signal.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-signal.test.ts
@@ -81,10 +81,10 @@ describe("deriveClusterSignal — Scenario: Single node is an exact no-op", () =
     const signal = deriveClusterSignal(view);
     expect(signal.singleHost).toBe(true);
     expect(signal.nodes).toHaveLength(1);
-    expect(signal.nodes[0]).toEqual({ host: "mini", status: "live" });
-    // the projection carries NO ticket lists (footer/filter wire shape is tiny);
-    // toEqual above already proves the node has EXACTLY host + status and no more
-    expect(Object.keys(signal.nodes[0])).toEqual(["host", "status"]);
+    expect(signal.nodes[0]).toMatchObject({ host: "mini", status: "live" });
+    // CTL-1092: nodes now carry capacity fields (maxParallel/inFlightCount/freeSlots)
+    // in addition to host + status; no ticket lists (footer/filter wire shape stays slim)
+    expect(signal.nodes[0]).not.toHaveProperty("tickets");
     expect(signal.generatedAt).toBe(view.generatedAt);
   });
 
@@ -117,7 +117,9 @@ describe("deriveClusterSignal — Scenario: Multiple nodes show per-node health"
     });
     const signal = deriveClusterSignal(view);
     expect(signal.singleHost).toBe(false);
-    expect(signal.nodes).toEqual([
+    // CTL-1092: nodes now carry capacity fields; use toMatchObject to check the
+    // status-per-host contract without requiring an exact shape snapshot.
+    expect(signal.nodes).toMatchObject([
       { host: "mini", status: "live" },
       { host: "studio", status: "degraded" },
       { host: "laptop", status: "offline" },

--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-view-capacity.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-view-capacity.test.ts
@@ -18,23 +18,41 @@ function ticket(id: string): BoardTicket {
     status: "running",
     model: null,
     linearState: "Implement",
-    host: null,
+    workerStatus: "running",
+    activeState: "active",
+    working: true,
+    lastActiveMs: 1000,
+    priority: 2,
+    estimate: null,
+    scope: null,
+    project: null,
+    costUSD: null,
+    tokens: null,
+    turns: null,
+    phaseCosts: null,
+    phaseSummary: [],
     pr: null,
-    startedAt: null,
-    workers: [],
-    costUsd: null,
-    error: null,
+    updatedAt: "2026-06-13T10:00:00.000Z",
+    held: null,
+    blockers: [],
+    heldSince: null,
+    currentPhaseSince: null,
+    attention: null,
+    attentionSince: null,
+    host: null,
+    generation: null,
   };
 }
 
 function board(tickets: BoardTicket[]): BoardPayload {
   return {
     generatedAt: "2026-06-13T10:00:00.000Z",
-    tickets,
+    config: { maxParallel: 6, inFlight: 0, freeSlots: 6, active: 0, working: 0, stuck: 0 },
+    repos: ["catalyst"],
     workers: [],
-    queue: { tickets: [], held: [], slots: [], totalInFlight: 0, totalHeld: 0, config: { maxParallel: 6, inFlight: 0, freeSlots: 6 } } as any,
-    config: { maxParallel: 6, inFlight: 0, freeSlots: 6 },
-  } as any;
+    tickets,
+    queue: [],
+  };
 }
 
 const now = new Date("2026-06-13T10:00:00.000Z").getTime();

--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-view-capacity.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-view-capacity.test.ts
@@ -4,7 +4,7 @@
 // Run: cd plugins/dev/scripts/orch-monitor && bun test
 
 import { describe, it, expect } from "bun:test";
-import { assembleClusterView } from "../lib/cluster-view.mjs";
+import { assembleClusterView, createClusterEntity } from "../lib/cluster-view.mjs";
 import type { BoardPayload, BoardTicket } from "../lib/board-data.mjs";
 
 function ticket(id: string): BoardTicket {
@@ -126,5 +126,57 @@ describe("deriveClusterSignal capacity pass-through (CTL-1092)", () => {
     });
     const sig = deriveClusterSignal(view);
     expect(sig.nodes[0]).toMatchObject({ host: "mini", status: "live", maxParallel: 6, inFlightCount: 2, freeSlots: 4 });
+  });
+});
+
+// CTL-1092 REGRESSION GUARD — exercise the PROD path through createClusterEntity,
+// NOT assembleClusterView directly. The feature was dead in prod because
+// createClusterEntity accepted capacityReader/aliases but never forwarded them to
+// assembleClusterView; the assembleClusterView-only tests above passed regardless,
+// so they could not catch it. These tests fail the instant the forward at
+// cluster-view.mjs project() is removed — because the injected reader's values
+// would silently vanish.
+describe("createClusterEntity forwards capacityReader + aliases through project() (CTL-1092)", () => {
+  it("surfaces per-node capacity via project() — proves the forward, not just the seam", async () => {
+    const entity = createClusterEntity({
+      ownerHostProvider: () => ({ "CTL-1": "mini", "CTL-2": "mini-2" }),
+      rosterProvider: () => ["mini", "mini-2"],
+      heartbeatReader: () => ({
+        mini: new Date(now - 1000).toISOString(),
+        "mini-2": new Date(now - 1000).toISOString(),
+      }),
+      capacityReader: (h) =>
+        h === "mini"
+          ? { maxParallel: 3, inFlightCount: 1 }
+          : h === "mini-2"
+            ? { maxParallel: 4, inFlightCount: 4 }
+            : null,
+      now: () => now,
+    });
+    const view = await entity.project(board([ticket("CTL-1"), ticket("CTL-2")]));
+    expect(view.singleHost).toBe(false);
+    const mini = view.nodes.find((n) => n.host === "mini");
+    const mini2 = view.nodes.find((n) => n.host === "mini-2");
+    // freeSlots is recomputed = max(0, maxParallel − inFlightCount): mini 3−1=2; mini-2 4−4=0.
+    expect(mini).toMatchObject({ maxParallel: 3, inFlightCount: 1, freeSlots: 2 });
+    expect(mini2).toMatchObject({ maxParallel: 4, inFlightCount: 4, freeSlots: 0 });
+  });
+
+  it("forwards the alias map: a pre-pin heartbeat key folds onto the pinned roster node", async () => {
+    const entity = createClusterEntity({
+      ownerHostProvider: () => ({ "CTL-1": "mini" }),
+      rosterProvider: () => ["mini", "mini-2"],
+      heartbeatReader: () => ({
+        "Ryans-Mac-mini-250233": new Date(now - 1000).toISOString(),
+        "mini-2": new Date(now - 1000).toISOString(),
+      }),
+      aliases: { "Ryans-Mac-mini-250233": "mini" },
+      capacityReader: () => ({ maxParallel: 2, inFlightCount: 0 }),
+      now: () => now,
+    });
+    const view = await entity.project(board([ticket("CTL-1")]));
+    // The pre-pin key must NOT appear as its own node; "mini" is live (folded).
+    expect(view.nodes.find((n) => n.host === "Ryans-Mac-mini-250233")).toBeUndefined();
+    expect(view.nodes.find((n) => n.host === "mini")?.status).toBe("live");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-view-capacity.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-view-capacity.test.ts
@@ -1,0 +1,112 @@
+// cluster-view-capacity.test.ts — CTL-1092. Per-node capacity fields in
+// assembleClusterView via the capacityReader seam, and alias resolution.
+//
+// Run: cd plugins/dev/scripts/orch-monitor && bun test
+
+import { describe, it, expect } from "bun:test";
+import { assembleClusterView } from "../lib/cluster-view.mjs";
+import type { BoardPayload, BoardTicket } from "../lib/board-data.mjs";
+
+function ticket(id: string): BoardTicket {
+  return {
+    id,
+    title: id,
+    type: "task",
+    repo: "catalyst",
+    team: "CTL",
+    phase: "implement",
+    status: "running",
+    model: null,
+    linearState: "Implement",
+    host: null,
+    pr: null,
+    startedAt: null,
+    workers: [],
+    costUsd: null,
+    error: null,
+  };
+}
+
+function board(tickets: BoardTicket[]): BoardPayload {
+  return {
+    generatedAt: "2026-06-13T10:00:00.000Z",
+    tickets,
+    workers: [],
+    queue: { tickets: [], held: [], slots: [], totalInFlight: 0, totalHeld: 0, config: { maxParallel: 6, inFlight: 0, freeSlots: 6 } } as any,
+    config: { maxParallel: 6, inFlight: 0, freeSlots: 6 },
+  } as any;
+}
+
+const now = new Date("2026-06-13T10:00:00.000Z").getTime();
+
+describe("assembleClusterView capacityReader seam (CTL-1092)", () => {
+  it("attaches per-node maxParallel/inFlightCount/freeSlots via capacityReader", () => {
+    const view = assembleClusterView({
+      board: board([ticket("CTL-1"), ticket("CTL-2")]),
+      hosts: ["mini", "laptop"],
+      heartbeats: { mini: "2026-06-13T10:00:00Z", laptop: "2026-06-13T10:00:00Z" },
+      capacityReader: (h) => h === "mini"
+        ? { maxParallel: 6, inFlightCount: 2, freeSlots: 4 }
+        : { maxParallel: 8, inFlightCount: 0, freeSlots: 8 },
+      now,
+    });
+    const mini = view.nodes.find((n) => n.host === "mini");
+    const laptop = view.nodes.find((n) => n.host === "laptop");
+    expect(mini).toMatchObject({ maxParallel: 6, inFlightCount: 2, freeSlots: 4 });
+    expect(laptop).toMatchObject({ maxParallel: 8, inFlightCount: 0, freeSlots: 8 });
+  });
+
+  it("offline node reports zero capacity (not local default)", () => {
+    const view = assembleClusterView({
+      board: board([ticket("CTL-1")]),
+      hosts: ["mini", "laptop"],
+      heartbeats: { mini: "2026-06-13T10:00:00Z" }, // laptop missing → offline
+      capacityReader: (h) => h === "mini" ? { maxParallel: 6, inFlightCount: 1, freeSlots: 5 } : null,
+      now,
+    });
+    const laptop = view.nodes.find((n) => n.host === "laptop");
+    expect(laptop?.status).toBe("offline");
+    expect(laptop).toMatchObject({ maxParallel: 0, inFlightCount: 0, freeSlots: 0 });
+  });
+
+  it("capacityReader absent → no capacity fields on nodes (backward compat)", () => {
+    const view = assembleClusterView({
+      board: board([ticket("CTL-1")]),
+      hosts: ["mini"],
+      heartbeats: { mini: "2026-06-13T10:00:00Z" },
+      now,
+    });
+    const mini = view.nodes.find((n) => n.host === "mini");
+    // maxParallel should be absent or 0 — not crash
+    expect(mini).toBeDefined();
+  });
+
+  it("applies alias map so pre-pin heartbeat key resolves onto the roster node", () => {
+    const view = assembleClusterView({
+      board: board([ticket("CTL-1")]),
+      hosts: ["mini"],
+      heartbeats: { "Ryans-Mac-mini-250233": "2026-06-13T10:00:00Z" },
+      aliases: { "Ryans-Mac-mini-250233": "mini" },
+      capacityReader: () => ({ maxParallel: 6, inFlightCount: 1, freeSlots: 5 }),
+      now,
+    });
+    expect(view.nodes).toHaveLength(1);
+    expect(view.nodes[0].host).toBe("mini");
+    expect(view.nodes[0].status).toBe("live");
+  });
+});
+
+describe("deriveClusterSignal capacity pass-through (CTL-1092)", () => {
+  it("preserves maxParallel/inFlightCount/freeSlots on signal nodes", async () => {
+    const { deriveClusterSignal } = await import("../lib/cluster-signal.mjs");
+    const view = assembleClusterView({
+      board: board([ticket("CTL-1")]),
+      hosts: ["mini"],
+      heartbeats: { mini: "2026-06-13T10:00:00Z" },
+      capacityReader: () => ({ maxParallel: 6, inFlightCount: 2, freeSlots: 4 }),
+      now,
+    });
+    const sig = deriveClusterSignal(view);
+    expect(sig.nodes[0]).toMatchObject({ host: "mini", status: "live", maxParallel: 6, inFlightCount: 2, freeSlots: 4 });
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/capacity-history.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/capacity-history.d.mts
@@ -1,0 +1,31 @@
+// Type declarations for capacity-history.mjs (CTL-1092 Phase 5 capacity-over-time).
+
+/** The event.name the capacity timeline reads from the unified event log. */
+export const CAPACITY_CHANGED_EVENT: string;
+
+/** One capacity change step: a maxParallel transition with its reason + timestamp. */
+export interface CapacityHistoryStep {
+  /** ISO-8601 timestamp of the change. */
+  ts: string;
+  /** maxParallel before the change. */
+  old: number;
+  /** maxParallel after the change. */
+  new: number;
+  /** Human-readable reason from the event payload ("" when absent). */
+  reason: string;
+}
+
+/**
+ * readCapacityHistory — scan the event log for node.capacity.changed events and
+ * return a per-host map of time-ordered capacity steps (ascending by ts).
+ * Aliased (pre-pin) hostnames merge onto their pinned roster names. Read failures
+ * degrade to {}.
+ */
+export function readCapacityHistory(opts?: {
+  /** Injectable reader returning the raw log content; defaults to readFileSync(logPath). */
+  read?: () => string;
+  /** Event-log path used when `read` is absent. */
+  logPath?: string;
+  /** Static alias map (pre-pin → pinned host name); absent/null → no aliasing. */
+  aliases?: Record<string, string> | null;
+}): Record<string, CapacityHistoryStep[]>;

--- a/plugins/dev/scripts/orch-monitor/lib/capacity-history.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/capacity-history.mjs
@@ -1,0 +1,77 @@
+// capacity-history.mjs — CTL-1092 Phase 5. Reads node.capacity.changed events
+// from the unified event log and returns a per-host time-ordered change history.
+//
+// Pattern mirrors readClusterHeartbeats (execution-core/recovery.mjs): cheap
+// string pre-filter → JSON parse → field extraction, with dependency injection
+// for the log reader so tests never touch fs.
+//
+// Alias resolution (A4): pre-pin hostnames in the event log are mapped onto
+// their current pinned names via `aliases` (catalyst.host.aliases from
+// .catalyst/config.json). Steps from an aliased host merge into the pinned
+// host's array. No destructive log migration needed.
+
+import { readFileSync } from "node:fs";
+import { resolveHostAlias } from "../../execution-core/host-alias.mjs";
+
+export const CAPACITY_CHANGED_EVENT = "node.capacity.changed";
+
+/**
+ * readCapacityHistory — scan the event log for node.capacity.changed events and
+ * return a per-host map of time-ordered capacity steps.
+ *
+ * @param {{ logPath?: string, read?: () => string, aliases?: Record<string,string> }} opts
+ *   - `read`: injectable reader, called with no args, returns the raw log content.
+ *     Defaults to readFileSync(logPath). Throws are caught → returns {}.
+ *   - `aliases`: static alias map from catalyst.host.aliases (pre-pin → pinned name).
+ *     Absent/null → no aliasing.
+ * @returns {Record<string, Array<{ ts: string, old: number, new: number, reason: string }>>}
+ */
+export function readCapacityHistory({ read, logPath, aliases = null } = {}) {
+  let raw;
+  try {
+    if (typeof read === "function") {
+      raw = read();
+    } else {
+      raw = readFileSync(logPath ?? "", "utf8");
+    }
+  } catch {
+    return {};
+  }
+  if (typeof raw !== "string" || raw.length === 0) return {};
+
+  /** @type {Record<string, Array<{ ts: string, old: number, new: number, reason: string }>>} */
+  const byHost = {};
+
+  for (const line of raw.split("\n")) {
+    if (!line) continue;
+    // Cheap pre-filter — avoids JSON.parse on every heartbeat/other line.
+    if (!line.includes(CAPACITY_CHANGED_EVENT)) continue;
+    let evt;
+    try {
+      evt = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (evt?.attributes?.["event.name"] !== CAPACITY_CHANGED_EVENT) continue;
+    const rawHost =
+      evt?.body?.payload?.["host.name"] ?? evt?.resource?.["host.name"];
+    const ts = evt?.ts;
+    const oldV = evt?.body?.payload?.old_maxParallel;
+    const newV = evt?.body?.payload?.new_maxParallel;
+    const reason = evt?.body?.payload?.reason;
+    if (typeof rawHost !== "string" || rawHost.length === 0) continue;
+    if (typeof ts !== "string" || ts.length === 0) continue;
+    if (!Number.isInteger(oldV) || !Number.isInteger(newV)) continue;
+
+    const host = resolveHostAlias(rawHost, aliases);
+    if (!byHost[host]) byHost[host] = [];
+    byHost[host].push({ ts, old: oldV, new: newV, reason: reason ?? "" });
+  }
+
+  // Sort each host's steps by ts ascending (ISO-8601 sorts lexicographically).
+  for (const host of Object.keys(byHost)) {
+    byHost[host].sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
+  }
+
+  return byHost;
+}

--- a/plugins/dev/scripts/orch-monitor/lib/capacity-history.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/capacity-history.test.mjs
@@ -1,0 +1,79 @@
+// capacity-history.test.mjs — Phase 5 (CTL-1092). Backend reader for
+// node.capacity.changed events from the unified event log.
+//
+// Run: cd plugins/dev/scripts/orch-monitor && bun test lib/capacity-history.test.mjs
+import { describe, it, expect } from "bun:test";
+import { readCapacityHistory } from "./capacity-history.mjs";
+
+// Build a JSONL line matching capacity-event.mjs's OTel envelope.
+function eventLine({ name, host, old: oldV, new: newV, reason, ts }) {
+  return JSON.stringify({
+    ts: ts ?? "2026-06-13T10:00:00Z",
+    attributes: { "event.name": name },
+    resource: { "host.name": host },
+    body: {
+      payload: {
+        "host.name": host,
+        old_maxParallel: oldV,
+        new_maxParallel: newV,
+        reason,
+      },
+    },
+  });
+}
+
+describe("readCapacityHistory — basic extraction", () => {
+  it("returns per-host capacity steps from node.capacity.changed events", () => {
+    const lines = [
+      eventLine({ name: "node.capacity.changed", host: "mini", old: 4, new: 6, reason: "saturated-scale-up", ts: "2026-06-13T10:00:00Z" }),
+      eventLine({ name: "node.heartbeat", host: "mini" }), // ignored — wrong event name
+      eventLine({ name: "node.capacity.changed", host: "laptop", old: 8, new: 6, reason: "recovery-to-layer1", ts: "2026-06-13T11:00:00Z" }),
+    ].join("\n");
+    const hist = readCapacityHistory({ read: () => lines });
+    expect(hist.mini).toEqual([{ ts: "2026-06-13T10:00:00Z", old: 4, new: 6, reason: "saturated-scale-up" }]);
+    expect(hist.laptop[0].new).toBe(6);
+    expect(hist.laptop[0].reason).toBe("recovery-to-layer1");
+  });
+
+  it("returns empty object when the event log is missing", () => {
+    const hist = readCapacityHistory({ read: () => { throw new Error("ENOENT"); } });
+    expect(hist).toEqual({});
+  });
+
+  it("skips malformed / partial lines without throwing", () => {
+    const lines = [
+      "not-json{{{",
+      eventLine({ name: "node.capacity.changed", host: "mini", old: 2, new: 4, reason: "x", ts: "2026-06-13T10:00:00Z" }),
+      "",
+    ].join("\n");
+    const hist = readCapacityHistory({ read: () => lines });
+    expect(hist.mini).toHaveLength(1);
+  });
+
+  it("preserves ascending ts order for multiple steps on the same host", () => {
+    const lines = [
+      eventLine({ name: "node.capacity.changed", host: "mini", old: 4, new: 6, reason: "up", ts: "2026-06-13T10:00:00Z" }),
+      eventLine({ name: "node.capacity.changed", host: "mini", old: 6, new: 8, reason: "up2", ts: "2026-06-13T12:00:00Z" }),
+      eventLine({ name: "node.capacity.changed", host: "mini", old: 8, new: 6, reason: "dn", ts: "2026-06-13T11:00:00Z" }), // out of order in log
+    ].join("\n");
+    const hist = readCapacityHistory({ read: () => lines });
+    expect(hist.mini).toHaveLength(3);
+    expect(hist.mini[0].ts <= hist.mini[1].ts).toBe(true);
+    expect(hist.mini[1].ts <= hist.mini[2].ts).toBe(true);
+  });
+});
+
+describe("readCapacityHistory — host alias resolution", () => {
+  it("applies host aliases so pre-pin steps fold into the pinned host", () => {
+    const lines = eventLine({ name: "node.capacity.changed", host: "Ryans-Mac-mini-250233", old: 4, new: 6, reason: "x", ts: "2026-06-13T10:00:00Z" });
+    const hist = readCapacityHistory({ read: () => lines, aliases: { "Ryans-Mac-mini-250233": "mini" } });
+    expect(Object.keys(hist)).toEqual(["mini"]);
+    expect(hist.mini[0].new).toBe(6);
+  });
+
+  it("passes through names not in the alias map unchanged", () => {
+    const lines = eventLine({ name: "node.capacity.changed", host: "laptop", old: 8, new: 4, reason: "dn", ts: "2026-06-13T10:00:00Z" });
+    const hist = readCapacityHistory({ read: () => lines, aliases: { "mini-old": "mini" } });
+    expect(Object.keys(hist)).toEqual(["laptop"]);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-signal.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-signal.mjs
@@ -53,7 +53,11 @@ export function deriveClusterSignal(view) {
     // no daemon to be healthy/offline, so it gets no footer dot.
     if (!n || typeof n.host !== "string" || n.host.length === 0) continue;
     if (n.status !== "live" && n.status !== "degraded" && n.status !== "offline") continue;
-    projected.push({ host: n.host, status: n.status });
+    const node = { host: n.host, status: n.status };
+    if (n.maxParallel != null) node.maxParallel = n.maxParallel;
+    if (n.inFlightCount != null) node.inFlightCount = n.inFlightCount;
+    if (n.freeSlots != null) node.freeSlots = n.freeSlots;
+    projected.push(node);
   }
   return {
     // A malformed/absent view degrades to the single-host empty signal (the footer

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
@@ -15,6 +15,12 @@ export interface ClusterNode {
   status: HostLivenessStatus | null;
   lastSeen: string | null;
   tickets: ClusterTicket[];
+  /** CTL-1092: per-node capacity. Present when capacityReader is wired; 0/0/0 for offline nodes. */
+  maxParallel?: number;
+  inFlightCount?: number;
+  freeSlots?: number;
+  /** CTL-1095: drain state. Present when drainReader is wired. */
+  draining?: boolean;
 }
 
 export interface ClusterView {

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
@@ -60,6 +60,14 @@ export interface ClusterEntityDeps {
   heartbeatReader?: (opts: { logPath?: string }) => Record<string, string>;
   /** Local event-log path forwarded to the heartbeat reader. */
   logPath?: string;
+  /** CTL-1092: live per-host capacity reader, forwarded to assembleClusterView. */
+  capacityReader?:
+    | ((host: string) => { maxParallel?: number; inFlightCount?: number; freeSlots?: number } | null | undefined)
+    | null;
+  /** CTL-1092: host alias map { oldName → pinnedName }, forwarded to assembleClusterView. */
+  aliases?: Record<string, string> | null;
+  /** CTL-1095: live drain reader, forwarded to assembleClusterView. */
+  drainReader?: ((host: string) => { draining?: boolean; inFlightCount?: number } | null | undefined) | null;
   /** Injected clock for tests. */
   now?: () => number;
 }

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
@@ -39,6 +39,14 @@ export interface AssembleClusterViewArgs extends LivenessThresholds {
   heartbeatReader?: (opts: { logPath?: string }) => Record<string, string>;
   logPath?: string;
   now?: number;
+  /** CTL-1095: per-host drain reader → { draining, inFlightCount }. */
+  drainReader?: ((host: string) => { draining?: boolean; inFlightCount?: number } | null | undefined) | null;
+  /** CTL-1092: per-host capacity reader → { maxParallel, inFlightCount, freeSlots }. */
+  capacityReader?:
+    | ((host: string) => { maxParallel?: number; inFlightCount?: number; freeSlots?: number } | null | undefined)
+    | null;
+  /** CTL-1092: host alias map { oldName → pinnedName } for collapsing pre-pin heartbeat keys. */
+  aliases?: Record<string, string> | null;
 }
 
 export function assembleClusterView(args: AssembleClusterViewArgs): ClusterView;

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
@@ -37,6 +37,7 @@
 //   and are dropped; roster hosts are always shown regardless of status.
 
 import { overlayClusterLiveness } from "./node-liveness.mjs";
+import { resolveHostAlias } from "../../execution-core/host-alias.mjs";
 
 // readClusterHeartbeats lives in execution-core/recovery.mjs — a heavy Node-only
 // module chain (config.mjs/pino, monitor.mjs, registry.mjs). We DO NOT statically
@@ -82,6 +83,11 @@ export function assembleClusterView({
   // CTL-1095: injectable drain reader. Default → no drain info (fail-open:
   // draining:false). Production wires it from the local isDraining + inFlightCount.
   drainReader = null,
+  // CTL-1092: injectable capacity reader. (host) → { maxParallel, inFlightCount, freeSlots } | null.
+  // Default → no capacity info (offline nodes get zeros). Offline nodes always return zeros regardless.
+  capacityReader = null,
+  // CTL-1092: host alias map { oldName → pinnedName } for collapsing pre-pin heartbeat keys.
+  aliases = null,
 }) {
   const roster = Array.isArray(hosts) && hosts.length > 0 ? hosts : [];
   const tickets = Array.isArray(board?.tickets) ? board.tickets : [];
@@ -93,10 +99,29 @@ export function assembleClusterView({
   // real node (a Stage-0 SHADOW node or a roster-lagging peer) and is surfaced;
   // a stale anchor attachment (offline) from a decommissioned node is dropped.
   // Roster hosts are ALWAYS shown, whatever their status.
-  const lastSeen =
+  const rawLastSeen =
     heartbeats && typeof heartbeats === "object"
       ? heartbeats
       : heartbeatReader({ logPath });
+
+  // CTL-1092: apply the alias map to collapse pre-pin hostnames onto pinned roster
+  // names BEFORE the display-host set is derived. This MUST run first: the raw
+  // heartbeat key (a pre-pin OS hostname like "Ryans-Mac-mini-250233") would
+  // otherwise enter `heartbeatHosts`/`allHosts` as its own node and the pinned
+  // roster name ("mini") would classify offline. Folding the heartbeat onto the
+  // pinned name makes the anchor model see ONE live node, not two. Newest-wins:
+  // if both the old name and the pinned name carry entries, keep the latest.
+  let lastSeen = rawLastSeen;
+  if (aliases && typeof aliases === "object") {
+    lastSeen = {};
+    for (const [rawHost, ts] of Object.entries(rawLastSeen)) {
+      const resolved = resolveHostAlias(rawHost, aliases);
+      if (!(resolved in lastSeen) || ts > lastSeen[resolved]) {
+        lastSeen[resolved] = ts;
+      }
+    }
+  }
+
   const heartbeatHosts = lastSeen && typeof lastSeen === "object" ? Object.keys(lastSeen) : [];
   const allHosts = [...new Set([...roster, ...heartbeatHosts])];
   const rosterSet = new Set(roster);
@@ -120,6 +145,22 @@ export function assembleClusterView({
     }
   };
 
+  // CTL-1092: resolve capacity per host — offline nodes always get zeros; fail-open.
+  const resolveCapacity = (host, status) => {
+    if (status === "offline" || !capacityReader || host === null) {
+      return { maxParallel: 0, inFlightCount: 0, freeSlots: 0 };
+    }
+    try {
+      const c = capacityReader(host);
+      if (!c) return { maxParallel: 0, inFlightCount: 0, freeSlots: 0 };
+      const mp = c.maxParallel ?? 0;
+      const ifc = c.inFlightCount ?? 0;
+      return { maxParallel: mp, inFlightCount: ifc, freeSlots: Math.max(0, mp - ifc) };
+    } catch {
+      return { maxParallel: 0, inFlightCount: 0, freeSlots: 0 };
+    }
+  };
+
   // ── grouping ──────────────────────────────────────────────────────────────
   // A node entry is { host, status, lastSeen, tickets[] }. The `null` host is the
   // synthetic "unassigned" bucket for tickets with no fence owner — used ONLY in
@@ -140,6 +181,7 @@ export function assembleClusterView({
           status: node.status,
           lastSeen: node.lastSeen,
           ...resolveDrain(host),
+          ...resolveCapacity(host, node.status),
           tickets: tickets.map((t) => makeTicket(t, host)),
         },
       ],
@@ -170,7 +212,7 @@ export function assembleClusterView({
       continue;
     }
     const node = livenessByHost.get(host) ?? { status: "offline", lastSeen: null };
-    nodes.push({ host, status: node.status, lastSeen: node.lastSeen, ...resolveDrain(host), tickets: groupTickets });
+    nodes.push({ host, status: node.status, lastSeen: node.lastSeen, ...resolveDrain(host), ...resolveCapacity(host, node.status), tickets: groupTickets });
   }
 
   return {

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
@@ -146,8 +146,20 @@ export function assembleClusterView({
   };
 
   // CTL-1092: resolve capacity per host — offline nodes always get zeros; fail-open.
+  // NOTE: both this and resolveDrain (CTL-1095) surface an `inFlightCount` for the
+  // SAME physical quantity (workers in flight on the host). The node object spreads
+  // drain first, then capacity, so capacity's inFlightCount overrides drain's. That
+  // is correct WHEN a capacityReader is wired (the capacity feed is the authority).
+  // When NO capacityReader is wired at all, capacity must NOT emit inFlightCount —
+  // otherwise its default 0 would clobber the drain reader's count. The offline /
+  // null-reading branches (reader present, no usable value) still emit an explicit
+  // inFlightCount: 0, which is what the capacity callers assert for offline nodes.
   const resolveCapacity = (host, status) => {
-    if (status === "offline" || !capacityReader || host === null) {
+    if (!capacityReader || host === null) {
+      // capacity feature absent → contribute no fields, so drain's inFlightCount survives.
+      return {};
+    }
+    if (status === "offline") {
       return { maxParallel: 0, inFlightCount: 0, freeSlots: 0 };
     }
     try {

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
@@ -279,6 +279,16 @@ export function createClusterEntity({
   rosterProvider,
   heartbeatReader,
   logPath,
+  // CTL-1092: injectable capacity reader, forwarded verbatim to assembleClusterView.
+  // (host) -> { maxParallel, inFlightCount, freeSlots } | null. Default null = feature off.
+  capacityReader = null,
+  // CTL-1092: host alias map { oldName -> pinnedName }; forwarded to assembleClusterView
+  // to collapse pre-pin heartbeat keys onto pinned roster names. Default null = no folding.
+  aliases = null,
+  // CTL-1095: injectable drain reader; forwarded verbatim. Default null = drain feature off.
+  // createClusterEntity is the SOLE prod entry, so this param keeps the seam symmetric — a
+  // future live drainReader only needs the server.ts builder, not another edit here.
+  drainReader = null,
   now = () => Date.now(),
 } = {}) {
   // Memoize the lazy execution-core import so repeated assembles don't re-import.
@@ -331,6 +341,12 @@ export function createClusterEntity({
         heartbeatReader: readClusterHeartbeats,
         logPath,
         now: now(),
+        // CTL-1092/1095: forward the injected readers. Without these three lines the
+        // params are accepted but dropped — the exact gap that left the feature dead
+        // in prod while the assembleClusterView unit tests (which inject directly) passed.
+        capacityReader,
+        aliases,
+        drainReader,
       });
     },
   };

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -41,6 +41,7 @@ import type { ClusterView } from "./lib/cluster-view.mjs";
 import { mergeHeartbeatsNewestWins } from "./lib/node-liveness.mjs";
 import { deriveClusterSignal } from "./lib/cluster-signal.mjs";
 import type { ClusterSignal } from "./lib/cluster-signal.mjs";
+import { readCapacityHistory } from "./lib/capacity-history.mjs";
 // CTL-886 (BFF4): run→worker identity — surface every phase-*.json signal as a
 // queryable run entity (/api/ticket-runs/<id>) + serve one signal verbatim
 // (/api/ec-worker/<ticket>/<phase>). Pure file-reads of resident signals — no
@@ -3933,6 +3934,15 @@ export function createServer(opts: CreateServerOptions): BunServer {
           return Response.json(
             await assembleClusterSignal(await boardSnapshot.getLatest()),
           );
+        }
+
+        // CTL-1092 (Phase 5): per-node capacity change history from the event log.
+        // Read-only; no writes. Scans the current-month JSONL for capacity events.
+        if (url.pathname === "/api/capacity-history") {
+          const month = new Date().toISOString().slice(0, 7); // YYYY-MM
+          const capLogPath = join(CATALYST_DIR, "events", `${month}.jsonl`);
+          const data = readCapacityHistory({ logPath: capLogPath });
+          return Response.json({ data });
         }
 
         // CTL-898 (SHELL8): SSE push of the cluster signal. The footer opens ONE

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -38,6 +38,11 @@ import type { NavSignal, DaemonHealth } from "./lib/nav-signal.mjs";
 // is an exact identity no-op (one node — the local daemon).
 import { createClusterEntity } from "./lib/cluster-view.mjs";
 import type { ClusterView } from "./lib/cluster-view.mjs";
+// CTL-1092: alias loading + resolution for the prod capacity/liveness wiring.
+// loadHostAliases reads catalyst.host.aliases (fail-open {}); resolveHostAlias
+// folds a pre-pin heartbeat key onto its pinned roster name. Pure file/string
+// helpers — safe to import statically (no execution-core network deps).
+import { loadHostAliases, resolveHostAlias } from "../execution-core/host-alias.mjs";
 import { mergeHeartbeatsNewestWins } from "./lib/node-liveness.mjs";
 import { deriveClusterSignal } from "./lib/cluster-signal.mjs";
 import type { ClusterSignal } from "./lib/cluster-signal.mjs";
@@ -1288,7 +1293,16 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // not just the local event log. readPeerHeartbeatsSync is the same subprocess
   // the working `catalyst cluster status` CLI uses, so Linear creds resolve
   // identically (LINEAR_API_TOKEN in the process env).
-  type AnchorPeerRec = { host?: string; last_seen?: string; in_flight_tickets?: string[] };
+  // CTL-1092: readPeerHeartbeatsSync records carry max_parallel + in_flight_count
+  // (parseHeartbeatMetadata output) — declared here so the capacity cache below
+  // can read them with type safety (the runtime data was always present).
+  type AnchorPeerRec = {
+    host?: string;
+    last_seen?: string;
+    in_flight_tickets?: string[];
+    max_parallel?: number | null;
+    in_flight_count?: number;
+  };
   let daemonDepsPromise: Promise<{
     readClusterHeartbeats: (opts: { logPath?: string }) => Record<string, string>;
     getHostName: () => string;
@@ -1468,6 +1482,15 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // per-request reads merge that cache over the local-log heartbeats synchronously.
   // Production-only: tests inject clusterReaderOpt and never start the poller.
   const anchorHeartbeatCache: { map: Record<string, string> } = { map: {} };
+  // CTL-1092: parallel cache of live per-host capacity from the SAME anchor peer
+  // records. readPeerHeartbeatsSync already returns max_parallel + in_flight_count
+  // (parseHeartbeatMetadata); we were dropping them. This is the real prod data
+  // source for the cluster-capacity feature — populated in the same 60s poll so it
+  // can never skew from the liveness overlay. null max_parallel (a peer that never
+  // published a slot count) is coerced to 0 to match the reader contract.
+  const anchorCapacityCache: {
+    map: Record<string, { maxParallel: number; inFlightCount: number }>;
+  } = { map: {} };
   let execCoreDeps: Awaited<ReturnType<typeof loadDaemonDeps>> = null;
   let anchorPollTimer: ReturnType<typeof setInterval> | null = null;
   const pollAnchorHeartbeats = (): void => {
@@ -1476,18 +1499,26 @@ export function createServer(opts: CreateServerOptions): BunServer {
       const anchor = execCoreDeps.getLivenessAnchorIssue();
       if (!anchor) {
         anchorHeartbeatCache.map = {}; // no anchor configured → no peers
+        anchorCapacityCache.map = {};
         return;
       }
       const peers = execCoreDeps.readPeerHeartbeatsSync({ anchorIssue: anchor });
       const next: Record<string, string> = {};
+      const nextCap: Record<string, { maxParallel: number; inFlightCount: number }> = {};
       for (const [host, rec] of Object.entries(peers)) {
         if (rec && typeof rec.last_seen === "string" && rec.last_seen.length > 0) {
           next[host] = rec.last_seen;
         }
+        if (rec) {
+          const mp = typeof rec.max_parallel === "number" ? rec.max_parallel : 0;
+          const ifc = typeof rec.in_flight_count === "number" ? rec.in_flight_count : 0;
+          nextCap[host] = { maxParallel: mp, inFlightCount: ifc };
+        }
       }
       anchorHeartbeatCache.map = next;
+      anchorCapacityCache.map = nextCap;
     } catch {
-      // fail-open: keep the last cache; stale entries age out via node-liveness
+      // fail-open: keep the last caches; stale entries age out via node-liveness
     }
   };
   if (clusterReaderOpt == null) {
@@ -1499,6 +1530,12 @@ export function createServer(opts: CreateServerOptions): BunServer {
     anchorPollTimer = setInterval(pollAnchorHeartbeats, anchorPollMs);
     anchorPollTimer.unref?.();
   }
+
+  // CTL-1092: the alias map is a static Layer-1 config value (operator-set; a
+  // monitor restart applies a change, like every other loadX(configPath)).
+  // loadHostAliases fail-opens to {} on a missing/malformed config, so a bad
+  // aliases block can never crash the cluster view.
+  const hostAliases = loadHostAliases({ configPath: monitorConfigPath });
 
   // Inject BOTH the roster and a MERGED heartbeat reader (local event log ∪ the
   // anchor peer cache). createClusterEntity then surfaces any node currently live
@@ -1527,6 +1564,17 @@ export function createServer(opts: CreateServerOptions): BunServer {
       // ~2-min cadence must not make a live self-host (fresh ~30s local log)
       // display as degraded.
       return mergeHeartbeatsNewestWins(local, anchorHeartbeatCache.map);
+    },
+    aliases: hostAliases,
+    // CTL-1092: live per-host capacity from the anchor-peer cache. Resolve the
+    // queried host through the SAME alias table so a pre-pin cache key still
+    // matches the pinned node assembleClusterView asks about. No cache entry →
+    // null (resolveCapacity yields zeros for a live host — the fail-open "no data
+    // yet" contract, NOT an error). Offline nodes never reach this reader
+    // (assembleClusterView short-circuits them to zeros first).
+    capacityReader: (host: string) => {
+      const resolved = resolveHostAlias(host, hostAliases);
+      return anchorCapacityCache.map[resolved] ?? anchorCapacityCache.map[host] ?? null;
     },
   });
   const readClusterView = async (board: BoardPayload): Promise<ClusterView> => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/capacity-timeline.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/capacity-timeline.test.ts
@@ -1,0 +1,51 @@
+// capacity-timeline.test.ts — Phase 5 (CTL-1092). Pure transform:
+// readCapacityHistory output → per-host stepped chart series.
+//
+// Run: cd ui && bun test src/components/observe/capacity-timeline.test.ts
+import { describe, it, expect } from "bun:test";
+import { toCapacitySteps } from "./capacity-timeline";
+
+type CapStep = { ts: string; old: number; new: number; reason: string };
+
+describe("toCapacitySteps", () => {
+  it("converts history to per-host stepped series with value = new maxParallel", () => {
+    const history: Record<string, CapStep[]> = {
+      mini: [
+        { ts: "2026-06-13T10:00:00Z", old: 4, new: 6, reason: "saturated-scale-up" },
+        { ts: "2026-06-13T12:00:00Z", old: 6, new: 8, reason: "saturated-scale-up" },
+      ],
+    };
+    const series = toCapacitySteps(history);
+    expect(series.mini).toHaveLength(2);
+    expect(series.mini[0]).toMatchObject({ ts: "2026-06-13T10:00:00Z", value: 6, old: 4, reason: "saturated-scale-up" });
+    expect(series.mini[1].value).toBe(8);
+    expect(series.mini[1].old).toBe(6);
+  });
+
+  it("empty history yields empty series (not an error)", () => {
+    const series = toCapacitySteps({});
+    expect(series).toEqual({});
+  });
+
+  it("single-step host renders a series of length 1", () => {
+    const series = toCapacitySteps({
+      mini: [{ ts: "2026-06-13T10:00:00Z", old: 4, new: 6, reason: "x" }],
+    });
+    expect(series.mini).toHaveLength(1);
+    expect(series.mini[0].value).toBe(6);
+  });
+
+  it("multiple hosts each get their own series", () => {
+    const series = toCapacitySteps({
+      mini: [{ ts: "2026-06-13T10:00:00Z", old: 4, new: 6, reason: "up" }],
+      laptop: [{ ts: "2026-06-13T11:00:00Z", old: 8, new: 4, reason: "dn" }],
+    });
+    expect(Object.keys(series).sort()).toEqual(["laptop", "mini"]);
+    expect(series.laptop[0].value).toBe(4);
+  });
+
+  it("empty steps array for a host yields empty series (no crash)", () => {
+    const series = toCapacitySteps({ mini: [] });
+    expect(series.mini).toEqual([]);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/capacity-timeline.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/capacity-timeline.ts
@@ -1,0 +1,45 @@
+// capacity-timeline.ts — CTL-1092 Phase 5. Pure transform from the
+// /api/capacity-history response (per-host CapStep[]) to chart-ready stepped
+// series (per-host CapChartPoint[]). No React, no fetch — fully unit-testable.
+
+/** One capacity change record from the /api/capacity-history response. */
+export interface CapStep {
+  ts: string;
+  old: number;
+  new: number;
+  reason: string;
+}
+
+/** One chart point: `value` is the maxParallel AFTER this step. */
+export interface CapChartPoint {
+  ts: string;
+  value: number;
+  old: number;
+  reason: string;
+}
+
+/** A per-host history map, keyed by pinned host name. */
+export type CapHistory = Record<string, CapStep[]>;
+
+/** A per-host stepped chart series, keyed by pinned host name. */
+export type CapSeries = Record<string, CapChartPoint[]>;
+
+/**
+ * toCapacitySteps — map a CapHistory (from /api/capacity-history) to a
+ * per-host stepped line series suitable for a chart. Each step maps to one
+ * chart point where `value` is the new maxParallel.
+ *
+ * Pure function — no side effects, no I/O.
+ */
+export function toCapacitySteps(history: CapHistory): CapSeries {
+  const series: CapSeries = {};
+  for (const [host, steps] of Object.entries(history)) {
+    series[host] = steps.map((s) => ({
+      ts: s.ts,
+      value: s.new,
+      old: s.old,
+      reason: s.reason,
+    }));
+  }
+  return series;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/host-matrix.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/host-matrix.tsx
@@ -115,9 +115,12 @@ export function HostMatrix({ nodes, workers, maxParallel, boardAgeMs }: HostMatr
                 {/* monitor — self: if this page renders, the monitor is up. */}
                 <span style={{ color: "var(--chart-2)" }}>ok</span>
 
-                {/* wkrs — busy/total from the board (live = 0/6 on idle mini). */}
+                {/* wkrs — busy/total: per-node maxParallel from the cluster signal
+                    (CTL-1092) when available; falls back to the global prop so
+                    single-host fleets behave identically to before. Offline rows
+                    show 0/0 (no dead-worker counts). */}
                 <span className="text-muted">
-                  {busy}/{maxParallel}
+                  {n.status === "offline" ? "0/0" : `${busy}/${n.maxParallel ?? maxParallel}`}
                 </span>
 
                 {/* DEFERRED — ONE merged dimmed locked cell spanning disk/load/version.

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/utilization-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/utilization-surface.tsx
@@ -48,6 +48,8 @@ import { Sparkline } from "@/components/sparkline";
 import { fmtRelativeDuration } from "@/lib/formatters";
 import { typeSymbol } from "@/board/type-icon";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { toCapacitySteps } from "@/components/observe/capacity-timeline";
+import type { CapHistory, CapSeries } from "@/components/observe/capacity-timeline";
 
 /** The active-time payload from /api/otel/active-time (mirrors otel-queries
  *  ActiveTimeRatio). */
@@ -87,6 +89,9 @@ export function UtilizationSurface() {
   // CTL-1040: throughput by work type [loki].
   const [throughputByType, setThroughputByType] = useState<Record<string, number> | null>(null);
   const [throughputByTypeReachable, setThroughputByTypeReachable] = useState<boolean>(true);
+
+  // CTL-1092 (Phase 5): per-node capacity history [events].
+  const [capacityHistory, setCapacityHistory] = useState<CapHistory>({});
 
   // Health probe (10s TTL) — drives the ChartCard ladder for the [loki]/[prom]
   // panels. The board-backed hero/badge/idle-list never read it.
@@ -174,15 +179,29 @@ export function UtilizationSurface() {
       }
     }
 
+    // CTL-1092 (Phase 5): capacity history from the event log.
+    async function loadCapacityHistory() {
+      try {
+        const resp = await fetch("/api/capacity-history");
+        if (!resp.ok || !alive) return;
+        const body = (await resp.json()) as { data: CapHistory | null };
+        setCapacityHistory(body.data ?? {});
+      } catch {
+        /* keep last-good data on transient failure */
+      }
+    }
+
     void loadBoard();
     void loadErrors();
     void loadActiveTime();
     void loadThroughputByType();
+    void loadCapacityHistory();
     const id = setInterval(() => {
       void loadBoard();
       void loadErrors();
       void loadActiveTime();
       void loadThroughputByType();
+      void loadCapacityHistory();
     }, refreshIntervalMs(range));
     return () => {
       alive = false;
@@ -193,6 +212,11 @@ export function UtilizationSurface() {
   // ── derivations (all PURE, from the live autotuned config) ──────────────────
   const occPct = occupancyPct(config.inFlight, config.maxParallel);
   const path = pathology(config.freeSlots, queueLen);
+  // CTL-1092 (Phase 5): stepped capacity series for the timeline chart.
+  const capacitySeries: CapSeries = useMemo(
+    () => toCapacitySteps(capacityHistory),
+    [capacityHistory],
+  );
 
   const idleRows = useMemo(() => {
     const inputs: IdleTicketInput[] = tickets.map((t) => ({
@@ -459,19 +483,39 @@ export function UtilizationSurface() {
           })()}
         </ChartCard>
 
-        {/* P_occupancy OCCUPANCY TIMELINE [events] — LOCKED (OBS-15), full-width
-            (bottom). Will be a stepped area of phase.scheduler.parallelism-sampled
-            (bg_count vs maxParallel_current) + autotune-gauge against the SAMPLED
-            autotune capacity line (never a static config read). Until OBS-15: a
-            full-width dashed locked card with the dimmed stepped-area skeleton. */}
+        {/* P_occupancy OCCUPANCY TIMELINE [events] — CTL-1092 Phase 5, unlocked.
+            Shows per-node node.capacity.changed steps (when, old→new, reason)
+            from /api/capacity-history. Empty = no autotune moves this month. */}
         <ChartCard
           title="Occupancy timeline"
           dataSource="[events]"
           health={health}
-          locked={{ reason: "needs event-log reader", ticket: "OBS-15" }}
+          hasData={Object.keys(capacitySeries).length > 0}
           className="lg:col-span-2"
           bodyClassName="min-h-[180px] h-[min(24vh,200px)] p-3"
-        />
+        >
+          <div className="flex h-full flex-col overflow-y-auto">
+            <div className="grid grid-cols-[auto_1fr_auto_1fr] gap-x-3 border-b border-border/40 pb-1 text-[10px] font-medium uppercase tracking-wide text-muted/70">
+              <span>Host</span>
+              <span>Time</span>
+              <span>Capacity</span>
+              <span>Reason</span>
+            </div>
+            {Object.entries(capacitySeries).flatMap(([host, steps]) =>
+              steps.map((s, i) => (
+                <div
+                  key={`${host}-${i}`}
+                  className="grid grid-cols-[auto_1fr_auto_1fr] items-center gap-x-3 border-b border-border/20 py-1 text-[11px] tabular-nums"
+                >
+                  <span className="rounded bg-surface-3 px-1 font-mono text-[10px] text-muted">{host}</span>
+                  <span className="truncate text-muted">{s.ts.replace("T", " ").replace("Z", "")}</span>
+                  <span className="font-mono font-semibold text-fg">{s.old}→{s.value}</span>
+                  <span className="truncate text-muted">{s.reason}</span>
+                </div>
+              ))
+            )}
+          </div>
+        </ChartCard>
       </div>
     </div>
   );

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/cluster-capacity.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/cluster-capacity.test.ts
@@ -1,0 +1,180 @@
+// cluster-capacity.test.ts — CTL-1092 Phase 3. Pure cluster aggregation + host-labeled
+// slot model. Run: cd ui && bun test src/components/queue/cluster-capacity.test.ts
+
+import { describe, it, expect } from "bun:test";
+import type { BoardWorker } from "../../board/types";
+import {
+  aggregateClusterCapacity,
+  assignClusterSlots,
+  filterSlotsByNode,
+  nodeCapacity,
+  isClusterMode,
+} from "./cluster-capacity";
+
+type SignalNode = { host: string; status: string; maxParallel?: number; inFlightCount?: number; freeSlots?: number; tickets?: string[] };
+
+function liveNode(host: string, maxParallel: number, inFlight: number, tickets?: string[]): SignalNode {
+  return { host, status: "live", maxParallel, inFlightCount: inFlight, freeSlots: maxParallel - inFlight, tickets };
+}
+
+function offlineNode(host: string): SignalNode {
+  return { host, status: "offline", maxParallel: 0, inFlightCount: 0, freeSlots: 0 };
+}
+
+function worker(name: string, hostName: string, ticket: string, startedAt = 1000): BoardWorker {
+  return {
+    name,
+    tickets: [ticket],
+    phase: "implement",
+    status: "running",
+    activeState: "active",
+    working: true,
+    lastActiveMs: 100,
+    repo: "catalyst",
+    team: "CTL",
+    runtimeMs: 1000,
+    costUSD: null,
+    host: { name: hostName, id: "abc" },
+    startedAt,
+  };
+}
+
+// ─── aggregateClusterCapacity ────────────────────────────────────────────────
+
+describe("aggregateClusterCapacity (CTL-1092)", () => {
+  it("sums maxParallel/inFlight/freeSlots across live nodes (ticket example: 2 of 14, 12 open)", () => {
+    const nodes = [liveNode("mini", 6, 2), liveNode("laptop", 8, 0)];
+    expect(aggregateClusterCapacity(nodes)).toEqual({ maxParallel: 14, inFlight: 2, freeSlots: 12 });
+  });
+
+  it("excludes offline nodes' capacity from the cluster total", () => {
+    const nodes = [liveNode("mini", 6, 2), offlineNode("laptop")];
+    expect(aggregateClusterCapacity(nodes)).toEqual({ maxParallel: 6, inFlight: 2, freeSlots: 4 });
+  });
+
+  it("returns zeros for an empty node list", () => {
+    expect(aggregateClusterCapacity([])).toEqual({ maxParallel: 0, inFlight: 0, freeSlots: 0 });
+  });
+
+  it("returns zeros when all nodes are offline", () => {
+    expect(aggregateClusterCapacity([offlineNode("mini"), offlineNode("laptop")])).toEqual({
+      maxParallel: 0, inFlight: 0, freeSlots: 0,
+    });
+  });
+});
+
+// ─── assignClusterSlots ──────────────────────────────────────────────────────
+
+describe("assignClusterSlots (CTL-1092)", () => {
+  it("labels each occupied slot with its host; local workers get full refs, remote get ticket-only", () => {
+    const localW = worker("w1", "mini", "CTL-1");
+    const out = assignClusterSlots({
+      nodes: [
+        liveNode("mini", 6, 1),
+        liveNode("laptop", 8, 1, ["CTL-9"]),
+      ],
+      localHost: "mini",
+      localWorkers: [localW],
+    });
+    const miniOccupied = out.find((s) => s.host === "mini" && s.occupied);
+    const laptopOccupied = out.find((s) => s.host === "laptop" && s.occupied);
+    expect(miniOccupied?.worker?.tickets?.[0]).toBe("CTL-1");
+    expect(laptopOccupied?.ticket).toBe("CTL-9");
+    expect(out.filter((s) => s.occupied).length).toBe(2);
+  });
+
+  it("empty nodes produce no occupied slots", () => {
+    const out = assignClusterSlots({
+      nodes: [liveNode("mini", 3, 0), liveNode("laptop", 3, 0)],
+      localHost: "mini",
+      localWorkers: [],
+    });
+    expect(out.filter((s) => s.occupied).length).toBe(0);
+    expect(out.length).toBe(6); // 3 + 3 empty slots
+  });
+
+  it("offline node produces no slot cards", () => {
+    const out = assignClusterSlots({
+      nodes: [liveNode("mini", 3, 1), offlineNode("laptop")],
+      localHost: "mini",
+      localWorkers: [worker("w1", "mini", "CTL-1")],
+    });
+    expect(out.filter((s) => s.host === "laptop").length).toBe(0);
+    expect(out.filter((s) => s.host === "mini").length).toBe(3);
+  });
+});
+
+// ─── filterSlotsByNode ───────────────────────────────────────────────────────
+
+describe("filterSlotsByNode (CTL-1092)", () => {
+  it("returns only slots for the given host", () => {
+    const out = assignClusterSlots({
+      nodes: [liveNode("mini", 2, 1), liveNode("laptop", 2, 0)],
+      localHost: "mini",
+      localWorkers: [worker("w1", "mini", "CTL-1")],
+    });
+    const miniSlots = filterSlotsByNode(out, "mini");
+    expect(miniSlots.every((s) => s.host === "mini")).toBe(true);
+    expect(miniSlots.length).toBe(2);
+  });
+
+  it("returns empty array for a host not in the slots", () => {
+    const out = assignClusterSlots({
+      nodes: [liveNode("mini", 2, 0)],
+      localHost: "mini",
+      localWorkers: [],
+    });
+    expect(filterSlotsByNode(out, "laptop")).toEqual([]);
+  });
+
+  it("offline node tab shows zero slots (not dead workers)", () => {
+    const out = assignClusterSlots({
+      nodes: [liveNode("mini", 2, 0), offlineNode("laptop")],
+      localHost: "mini",
+      localWorkers: [],
+    });
+    expect(filterSlotsByNode(out, "laptop")).toEqual([]);
+  });
+});
+
+// ─── nodeCapacity ────────────────────────────────────────────────────────────
+
+describe("nodeCapacity (CTL-1092)", () => {
+  it("returns capacity for a live node", () => {
+    const nodes = [liveNode("mini", 6, 2), liveNode("laptop", 8, 0)];
+    expect(nodeCapacity(nodes, "mini")).toEqual({ maxParallel: 6, inFlight: 2, freeSlots: 4 });
+  });
+
+  it("returns zero capacity for an offline node", () => {
+    expect(nodeCapacity([offlineNode("laptop")], "laptop")).toEqual({
+      maxParallel: 0, inFlight: 0, freeSlots: 0,
+    });
+  });
+
+  it("returns zero capacity for a host not in the list", () => {
+    expect(nodeCapacity([liveNode("mini", 6, 0)], "laptop")).toEqual({
+      maxParallel: 0, inFlight: 0, freeSlots: 0,
+    });
+  });
+});
+
+// ─── isClusterMode ───────────────────────────────────────────────────────────
+
+describe("isClusterMode (CTL-1092)", () => {
+  it("is false for a single-host signal", () => {
+    expect(isClusterMode({ singleHost: true, nodes: [{ host: "mini", status: "live" }] })).toBe(false);
+  });
+
+  it("is true when singleHost is false and roster > 1 host", () => {
+    expect(isClusterMode({ singleHost: false, nodes: [{ host: "mini" }, { host: "laptop" }] })).toBe(true);
+  });
+
+  it("is false when singleHost is false but only 1 node", () => {
+    expect(isClusterMode({ singleHost: false, nodes: [{ host: "mini" }] })).toBe(false);
+  });
+
+  it("is false for null/undefined signal", () => {
+    expect(isClusterMode(null)).toBe(false);
+    expect(isClusterMode(undefined)).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/cluster-capacity.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/cluster-capacity.ts
@@ -1,0 +1,121 @@
+// cluster-capacity.ts — CTL-1092 Phase 3. Pure cluster-wide capacity aggregation
+// and host-labeled slot assignment. Consumed by ControlTower + SlotDeck in Phase 4.
+// Single-host fleets never reach this code — isClusterMode gates all callers.
+
+import type { BoardWorker } from "../../board/types";
+import { assignSlots } from "./queue-model";
+
+export interface ClusterSignalNode {
+  host: string;
+  status: string;
+  maxParallel?: number;
+  inFlightCount?: number;
+  freeSlots?: number;
+  tickets?: string[];
+}
+
+export interface ClusterSignalLike {
+  singleHost: boolean;
+  nodes: { host?: string | null; status?: string }[];
+}
+
+export interface ClusterCapacity {
+  maxParallel: number;
+  inFlight: number;
+  freeSlots: number;
+}
+
+export interface ClusterSlot {
+  host: string;
+  slotIndex: number;
+  occupied: boolean;
+  worker?: BoardWorker;
+  ticket?: string;
+}
+
+/**
+ * aggregateClusterCapacity — sum per-node capacity across non-offline nodes.
+ */
+export function aggregateClusterCapacity(nodes: ClusterSignalNode[]): ClusterCapacity {
+  let maxParallel = 0;
+  let inFlight = 0;
+  let freeSlots = 0;
+  for (const n of nodes) {
+    if (n.status === "offline") continue;
+    maxParallel += n.maxParallel ?? 0;
+    inFlight += n.inFlightCount ?? 0;
+    freeSlots += n.freeSlots ?? 0;
+  }
+  return { maxParallel, inFlight, freeSlots };
+}
+
+/**
+ * assignClusterSlots — produce an ordered ClusterSlot[] for the whole cluster.
+ * Local node: uses assignSlots (rich worker refs). Remote nodes: ticket-id labels
+ * from in_flight_tickets. Offline nodes are excluded entirely.
+ */
+export function assignClusterSlots({
+  nodes,
+  localHost,
+  localWorkers,
+}: {
+  nodes: ClusterSignalNode[];
+  localHost: string;
+  localWorkers: readonly BoardWorker[];
+}): ClusterSlot[] {
+  const slots: ClusterSlot[] = [];
+  for (const n of nodes) {
+    if (n.status === "offline" || !n.maxParallel) continue;
+    if (n.host === localHost) {
+      // Rich local slots via existing assignSlots
+      const { occupied, emptyCount } = assignSlots(localWorkers, n.maxParallel);
+      for (let i = 0; i < occupied.length; i++) {
+        slots.push({ host: n.host, slotIndex: i, occupied: true, worker: occupied[i] });
+      }
+      for (let i = 0; i < emptyCount; i++) {
+        slots.push({ host: n.host, slotIndex: occupied.length + i, occupied: false });
+      }
+    } else {
+      // Remote node: ticket labels from in_flight_tickets
+      const remoteTickets = n.tickets ?? [];
+      for (let i = 0; i < n.maxParallel; i++) {
+        if (i < remoteTickets.length) {
+          slots.push({ host: n.host, slotIndex: i, occupied: true, ticket: remoteTickets[i] });
+        } else {
+          slots.push({ host: n.host, slotIndex: i, occupied: false });
+        }
+      }
+    }
+  }
+  return slots;
+}
+
+/**
+ * filterSlotsByNode — return only slots belonging to the given host.
+ */
+export function filterSlotsByNode(slots: ClusterSlot[], host: string): ClusterSlot[] {
+  return slots.filter((s) => s.host === host);
+}
+
+/**
+ * nodeCapacity — capacity for a single node by host name.
+ */
+export function nodeCapacity(nodes: ClusterSignalNode[], host: string): ClusterCapacity {
+  const n = nodes.find((node) => node.host === host);
+  if (!n || n.status === "offline") return { maxParallel: 0, inFlight: 0, freeSlots: 0 };
+  return {
+    maxParallel: n.maxParallel ?? 0,
+    inFlight: n.inFlightCount ?? 0,
+    freeSlots: n.freeSlots ?? 0,
+  };
+}
+
+/**
+ * isClusterMode — true only when the roster has >1 host and singleHost is false.
+ * Single-host fleets always use the legacy rendering path.
+ */
+export function isClusterMode(signal: ClusterSignalLike | null | undefined): boolean {
+  if (!signal) return false;
+  if (signal.singleHost) return false;
+  return (signal.nodes?.length ?? 0) > 1;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/control-tower-cluster.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/control-tower-cluster.test.ts
@@ -1,0 +1,39 @@
+// control-tower-cluster.test.ts — CTL-1092 Phase 4. Source-text structural
+// assertions for cluster-mode node filter in ControlTower and SlotDeck.
+//
+// Run: cd ui && bun test src/components/queue/control-tower-cluster.test.ts
+
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ctSrc = readFileSync(join(import.meta.dir, "control-tower.tsx"), "utf8");
+const sdSrc = readFileSync(join(import.meta.dir, "slot-deck.tsx"), "utf8");
+
+describe("ControlTower cluster-mode (CTL-1092)", () => {
+  it("imports isClusterMode for cluster detection", () => {
+    expect(ctSrc).toContain("isClusterMode");
+  });
+
+  it("renders a NodeFilter tab strip in cluster mode", () => {
+    expect(ctSrc).toContain("NodeFilter");
+  });
+
+  it("has selectedNode state (default 'all')", () => {
+    expect(ctSrc).toContain("selectedNode");
+  });
+});
+
+describe("SlotDeck cluster-mode (CTL-1092)", () => {
+  it("references slot.host for per-host slot labeling", () => {
+    expect(sdSrc).toContain("slot.host");
+  });
+
+  it("uses assignClusterSlots in cluster-mode path", () => {
+    expect(sdSrc).toContain("assignClusterSlots");
+  });
+
+  it("uses aggregateClusterCapacity for cluster headline", () => {
+    expect(sdSrc).toContain("aggregateClusterCapacity");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/control-tower.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/control-tower.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { BoardPayload } from "../../board/types";
 import { C } from "../../board/board-tokens";
 import { queueHostMode } from "../../board/queue-grouping";
@@ -5,6 +6,9 @@ import { SlotDeck } from "./slot-deck";
 import { DispatchQueue } from "./dispatch-queue";
 import { HoldingBuckets } from "./holding-buckets";
 import { DeadStrip } from "./dead-strip";
+import { NodeFilter } from "./node-filter";
+import { isClusterMode } from "./cluster-capacity";
+import { useClusterSignalContext } from "@/hooks/use-cluster-signal";
 
 export function ControlTower({
   payload,
@@ -14,13 +18,26 @@ export function ControlTower({
   onOpenTicket: (key: string) => void;
 }) {
   const multiHost = queueHostMode(payload.queue) === "multi";
+  const cluster = useClusterSignalContext();
+  const clusterMode = isClusterMode(cluster);
+  const [selectedNode, setSelectedNode] = useState<string | "all">("all");
+
   return (
-    <div style={{ maxWidth: 1120, margin: "0 auto", padding: "8px 24px 32px", display: "flex", flexDirection: "column", gap: 28 }}>
+    <div style={{ maxWidth: 1120, margin: "0 auto", padding: "8px 24px 32px", display: "flex", flexDirection: "column", gap: 28, flexShrink: 0, maxHeight: "45vh", overflowY: "auto" }}>
+      {clusterMode && cluster && (
+        <NodeFilter
+          nodes={cluster.nodes}
+          selected={selectedNode}
+          onSelect={setSelectedNode}
+        />
+      )}
       <SlotDeck
         workers={payload.workers}
         tickets={payload.tickets}
         config={payload.config}
         onOpenTicket={onOpenTicket}
+        clusterSignal={clusterMode ? cluster : null}
+        selectedNode={clusterMode ? selectedNode : "all"}
       />
       <DispatchQueue
         queue={payload.queue}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/control-tower.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/control-tower.tsx
@@ -23,7 +23,7 @@ export function ControlTower({
   const [selectedNode, setSelectedNode] = useState<string | "all">("all");
 
   return (
-    <div style={{ maxWidth: 1120, margin: "0 auto", padding: "8px 24px 32px", display: "flex", flexDirection: "column", gap: 28, flexShrink: 0, maxHeight: "45vh", overflowY: "auto" }}>
+    <div style={{ maxWidth: 1120, margin: "0 auto", padding: "8px 24px 32px", display: "flex", flexDirection: "column", gap: 28 }}>
       {clusterMode && cluster && (
         <NodeFilter
           nodes={cluster.nodes}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/node-filter.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/node-filter.tsx
@@ -1,0 +1,73 @@
+// node-filter.tsx — CTL-1092 Phase 4. Presentational node tab strip for the
+// Workers view. Shown only in cluster mode (isClusterMode guard in ControlTower).
+import { C } from "../../board/board-tokens";
+import type { ClusterSignalNode } from "@/lib/cluster-signal";
+
+export interface NodeFilterProps {
+  nodes: readonly ClusterSignalNode[];
+  selected: string | "all";
+  onSelect: (node: string | "all") => void;
+}
+
+function statusDot(status: string): string {
+  if (status === "live") return "#4ade80";
+  if (status === "degraded") return "#facc15";
+  return "#6b7280";
+}
+
+export function NodeFilter({ nodes, selected, onSelect }: NodeFilterProps) {
+  const tabs: Array<{ key: string | "all"; label: string; dot?: string; sub?: string }> = [
+    { key: "all", label: "All nodes" },
+    ...nodes.map((n) => ({
+      key: n.host,
+      label: n.host,
+      dot: statusDot(n.status),
+      sub: n.status === "offline"
+        ? "offline"
+        : n.inFlightCount != null && n.maxParallel != null
+          ? `${n.inFlightCount}/${n.maxParallel}`
+          : undefined,
+    })),
+  ];
+
+  return (
+    <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+      {tabs.map((tab) => {
+        const active = selected === tab.key;
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => onSelect(tab.key)}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "4px 10px",
+              borderRadius: 6,
+              border: `1px solid ${active ? C.blue : C.borderSubtle}`,
+              background: active ? "rgba(59,130,246,0.12)" : "transparent",
+              color: active ? C.blue : C.fgMuted,
+              fontFamily: C.mono,
+              fontSize: 11,
+              cursor: "pointer",
+            }}
+          >
+            {tab.dot && (
+              <span
+                style={{
+                  width: 6, height: 6, borderRadius: "50%",
+                  background: tab.dot, display: "inline-block", flexShrink: 0,
+                }}
+              />
+            )}
+            <span>{tab.label}</span>
+            {tab.sub && (
+              <span style={{ color: C.fgDim, fontSize: 10 }}>{tab.sub}</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/slot-deck.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/slot-deck.tsx
@@ -18,8 +18,16 @@ import {
   useReducedMotion,
 } from "../../board/motion-utils";
 import type { BoardWorker, BoardTicket, BoardConfig } from "../../board/types";
+import type { ClusterSignal } from "@/lib/cluster-signal";
 import { assignSlots, isLiveWorker, slotLabel } from "./queue-model";
 import { TickerNumber } from "./ticker-number";
+import {
+  aggregateClusterCapacity,
+  assignClusterSlots,
+  filterSlotsByNode,
+  nodeCapacity,
+} from "./cluster-capacity";
+import type { ClusterSlot } from "./cluster-capacity";
 
 // The state word + its color for a slot's worker (mirrors workerStatusText).
 function slotState(w: BoardWorker): { word: string; color: string } {
@@ -154,18 +162,112 @@ function EmptyCard({ slotLabel, first }: { slotLabel: string; first: boolean }) 
   );
 }
 
+// RemoteSlotCard — lightweight card for a remote node's in-flight ticket (CTL-1092).
+// Shows host chip + ticket id only; no worker detail (cross-node tail is CTL-885).
+function RemoteSlotCard({ slot }: { slot: ClusterSlot }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        background: C.s2,
+        border: `1px solid ${C.borderSubtle}`,
+        borderRadius: 10,
+        padding: "10px 12px",
+        minHeight: 96,
+        opacity: 0.8,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span style={{ fontSize: 10, color: C.fgDim, letterSpacing: 1.2, textTransform: "uppercase", fontFamily: C.mono }}>
+          {slotLabel(slot.slotIndex + 1)}
+        </span>
+        <span style={{ fontSize: 10, color: C.fgDim, fontFamily: C.mono }}>remote</span>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 8 }}>
+        <span style={{ fontSize: 10, color: C.fgDim, background: C.s3, borderRadius: 4, padding: "2px 5px", fontFamily: C.mono }}>{slot.host}</span>
+        <span style={{ fontFamily: C.mono, fontSize: 13, fontWeight: 600, color: C.blue }}>{slot.ticket}</span>
+      </div>
+    </div>
+  );
+}
+
 export function SlotDeck({
   workers,
   tickets,
   config,
   onOpenTicket,
+  clusterSignal = null,
+  selectedNode = "all",
 }: {
   workers: BoardWorker[];
   tickets: BoardTicket[];
   config: BoardConfig;
   onOpenTicket?: (key: string) => void;
+  clusterSignal?: ClusterSignal | null;
+  selectedNode?: string | "all";
 }) {
   const infoById = new Map(tickets.map((t) => [t.id, t]));
+
+  // Cluster-mode path: use aggregateClusterCapacity + assignClusterSlots
+  if (clusterSignal && clusterSignal.nodes.length > 1) {
+    const localHost = clusterSignal.nodes.find((n) => n.status === "live")?.host ?? "";
+    const allSlots = assignClusterSlots({
+      nodes: clusterSignal.nodes as any,
+      localHost,
+      localWorkers: workers,
+    });
+    const displaySlots = selectedNode === "all" ? allSlots : filterSlotsByNode(allSlots, selectedNode);
+    const cap = selectedNode === "all"
+      ? aggregateClusterCapacity(clusterSignal.nodes as any)
+      : nodeCapacity(clusterSignal.nodes as any, selectedNode);
+
+    return (
+      <section>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 14 }}>
+          <span style={{ display: "inline-flex", alignItems: "baseline" }}>
+            <span style={{ fontFamily: C.mono, fontSize: 26, fontWeight: 700, fontVariantNumeric: "tabular-nums", color: C.fg }}>
+              <TickerNumber value={cap.inFlight} />
+            </span>
+            <span style={{ fontFamily: C.mono, fontSize: 18, fontWeight: 500, color: C.fgDim }}>
+              {" / "}{cap.maxParallel}
+            </span>
+          </span>
+          <span style={{ fontSize: 12, color: C.fgMuted }}>
+            slots in use ·{" "}
+            <span style={{ color: cap.freeSlots === 0 ? C.yellow : C.fgMuted, display: "inline-flex", alignItems: "baseline" }}>
+              <TickerNumber value={cap.freeSlots} />
+              <span style={{ marginLeft: 4 }}>open</span>
+            </span>
+          </span>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(264px, 1fr))", gap: 10 }}>
+          <AnimatePresence initial={false}>
+            {displaySlots.map((slot, i) => {
+              if (!slot.occupied) {
+                return <EmptyCard key={`empty-${slot.host}-${slot.slotIndex}`} slotLabel={slotLabel(slot.slotIndex + 1)} first={i === 0} />;
+              }
+              if (slot.worker) {
+                return (
+                  <OccupiedCard
+                    key={`slot-${slot.worker.name}`}
+                    w={slot.worker}
+                    ticket={infoById.get(slot.worker.tickets?.[0] ?? "")}
+                    slotLabel={slotLabel(slot.slotIndex + 1)}
+                    onOpenTicket={onOpenTicket}
+                  />
+                );
+              }
+              // Remote slot with ticket label
+              return <RemoteSlotCard key={`remote-${slot.host}-${slot.slotIndex}`} slot={slot} />;
+            })}
+          </AnimatePresence>
+        </div>
+      </section>
+    );
+  }
+
+  // Single-host / legacy path — unchanged
   const { occupied, emptyCount, overCapacity } = assignSlots(workers, config.maxParallel);
   const dead = config.dead ?? 0;
   const over = Math.max(0, config.inFlight - config.maxParallel);
@@ -207,7 +309,7 @@ export function SlotDeck({
             <OccupiedCard
               key={`slot-${w.name}`}
               w={w}
-              ticket={infoById.get(w.ticket)}
+              ticket={infoById.get(w.tickets?.[0] ?? w.ticket)}
               slotLabel={slotLabel(i + 1)}
               onOpenTicket={onOpenTicket}
             />
@@ -223,7 +325,7 @@ export function SlotDeck({
             <OccupiedCard
               key={`slot-${w.name}`}
               w={w}
-              ticket={infoById.get(w.ticket)}
+              ticket={infoById.get(w.tickets?.[0] ?? w.ticket)}
               slotLabel="OVER"
               onOpenTicket={onOpenTicket}
             />

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/cluster-signal.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/cluster-signal.ts
@@ -22,6 +22,12 @@ export type ClusterNodeStatus = "live" | "degraded" | "offline";
 export interface ClusterSignalNode {
   host: string;
   status: ClusterNodeStatus;
+  /** CTL-1092: per-node capacity from the heartbeat fan-in. 0/0/0 for offline nodes. */
+  maxParallel?: number;
+  inFlightCount?: number;
+  freeSlots?: number;
+  /** CTL-1092: in-flight ticket ids from the heartbeat (for remote slot labels). */
+  tickets?: string[];
 }
 
 /** The per-node cluster-health wire shape the footer renders (server's ClusterSignal). */


### PR DESCRIPTION
## 🔧 Dead-in-prod fix (board-janitor finish)

This PR built the capacity **data model** + the `assembleClusterView` capacity **seam**, but neither glue end was wired, so the feature was **dead in production** (green tests injected the reader directly; the daemon published no `max_parallel` and `createClusterEntity` dropped the reader). This commit wires **both ends**:

**Read (monitor):** `createClusterEntity` now forwards `capacityReader`/`aliases`/`drainReader` to `assembleClusterView`; `server.ts` builds a per-host `capacityReader` from a new `anchorCapacityCache` (populated in the same 60s anchor poll from `readPeerHeartbeatsSync`'s `max_parallel`/`in_flight_count`, which were being discarded) + loads `catalyst.host.aliases` (fail-open) + alias-resolves the lookup. Adds `host-alias.d.mts`.

**Publish (execution-core — the missing data source):** the only daemon publisher never emitted `max_parallel`, so live anchor records carried `null`. Now `cluster-heartbeat-publisher` reads this host's slot count from `state.json` and publishes it each tick; `publishHeartbeatSync` appends it as an optional 4th arg (back-compat 3-arg form); the `publish` CLI parses it.

**Regression guard:** a new test drives `createClusterEntity.project()` (not the seam the old tests use) and fails the instant the forward is removed — closing the exact "green tests, dead prod" blind spot.

**Live preconditions verified on the fleet:** bug confirmed (anchor `max_parallel:null` on mini + mini-2 today); `state.json maxParallel=3` on both (publisher will emit post-restart); aliases correctly a no-op (hostnames already pinned). **Full activation needs the daemon restart** (publish) + monitor restart (read).

---

## Summary

- **Phase 1**: `node.capacity.changed` event emitted from autotune whenever `maxParallel` changes (seam-injectable, alongside `parallelism-adjusted`; `capacity-event.mjs` mirrors `drain-event.mjs`)
- **Phase 2**: Per-node `maxParallel`/`inFlightCount`/`freeSlots` carried through the heartbeat → `assembleClusterView` → `ClusterSignal` wire; host-alias resolution (`catalyst.host.aliases`) collapses pre-pin names at read time
- **Phase 3**: Pure UI model — `aggregateClusterCapacity`, `assignClusterSlots`, `filterSlotsByNode`, `nodeCapacity`, `isClusterMode` — with 17 tests
- **Phase 4**: Workers view UI — `NodeFilter` tab strip, host-labeled slot cards, per-node `maxParallel` in `HostMatrix`, offline node rendering; guarded by `isClusterMode` so single-host fleets are unchanged
- **Phase 5**: `GET /api/capacity-history` route + `readCapacityHistory` reader + `toCapacitySteps` pure transform; unlocks the "Occupancy timeline" `ChartCard` (was locked `OBS-15`)

## Test plan

- [ ] `cd plugins/dev/scripts/execution-core && bun test` — 3596 pass, 4 pre-existing fail
- [ ] `cd plugins/dev/scripts/orch-monitor && bun test` — 4142 pass, 55 pre-existing fail (react/jotai env errors in root context, not new)
- [ ] Manual: two-node fleet shows cluster-wide headline + per-node filter tabs
- [ ] Manual: autotune move appears in Occupancy timeline card

🤖 Generated with [Claude Code](https://claude.com/claude-code)
