### PR TITLE
feat(dev): CTL-1099 — Warm/Slate brand theme system (warm default, Settings picker, semantic-invariant)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/app-shell-ia.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/app-shell-ia.test.ts
@@ -19,6 +19,11 @@ import {
   readStoredTheme,
   applyTheme,
 } from "../ui/src/lib/theme";
+import {
+  BRANDS,
+  DEFAULT_BRAND,
+  BRAND_STORAGE_KEY,
+} from "../ui/src/lib/brand";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const UI_SRC = join(HERE, "..", "ui", "src");
@@ -258,6 +263,22 @@ describe("theme toggle flips calm-dark and warm-light (CTL-893)", () => {
 describe("theme metadata is exhaustive (CTL-893)", () => {
   it("every theme is labelled", () => {
     for (const t of THEMES) expect(THEME_LABEL[t]).toBeTruthy();
+  });
+});
+
+// ── CTL-1099: the orthogonal BRAND axis (Warm / Slate) ───────────────────────
+describe("brand axis is the second, orthogonal theme dimension (CTL-1099)", () => {
+  it("declares exactly the two brands warm + slate, default warm, pinned key", () => {
+    expect([...BRANDS]).toEqual(["warm", "slate"]);
+    expect(DEFAULT_BRAND).toBe("warm");
+    expect(BRAND_STORAGE_KEY).toBe("catalyst:brand");
+  });
+
+  it("the Settings surface + the shell both wire the brand hook (useBrand)", () => {
+    const settingsSrc = read("components/settings-surface.tsx");
+    const shellSrc = read("components/app-shell.tsx");
+    expect(settingsSrc).toContain("useBrand");
+    expect(shellSrc).toContain("useBrand");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/settings-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/settings-surface.test.ts
@@ -133,16 +133,93 @@ describe("Theme routes through the ONE theme system, @/lib/theme (CTL-911)", () 
     expect(sidebarSrc).not.toContain("toggleTheme");
   });
 
-  it("NO parallel data-theme system exists (the SURF3⇄SHELL3 clash resolution)", () => {
-    // The `.dark`-class mechanism is the one theme model: no data-theme
-    // attribute plumbing in the surface, the shell, or the stylesheet.
-    expect(settingsSrc).not.toContain("data-theme");
-    expect(shellSrc).not.toContain("data-theme");
-    expect(cssSrc).not.toContain("data-theme");
-    expect(settingsSrc).not.toContain("calm-dark"); // the dead union values
-    expect(settingsSrc).not.toContain("warm-light");
-    // The `.dark` token block (SHELL3) is still what the theme flips.
+  it("data-theme is the brand axis; .dark is the sole MODE axis (CTL-1099 reverses the SURF3⇄SHELL3 single-axis decision)", () => {
+    // CTL-1099 REVERSES the prior CTL-911 invariant ("NO parallel data-theme
+    // system exists"). There are now TWO orthogonal axes:
+    //   - MODE  → the `.dark` class on <html> (catalyst:theme). dark ⇄ light.
+    //   - BRAND → the `data-theme` attribute on <html> (catalyst:brand). warm ⇄ slate.
+    // So `data-theme` is no longer a forbidden parallel theme system — it is the
+    // LEGITIMATE brand mechanism. The two are independent: a single .dark MODE
+    // block, plus data-theme="slate" override blocks that ONLY fork the accent
+    // (slate-light) / the full surface ramp (slate-dark).
+    // The `.dark` MODE mechanism is still present (the one mode flip)…
     expect(cssSrc).toContain(".dark");
+    // …and data-theme="slate" is the legitimate brand mechanism in CSS.
+    expect(cssSrc).toContain('data-theme="slate"');
+    // The surface + the shell both wire the brand hook (useBrand).
+    expect(settingsSrc).toContain("useBrand");
+    expect(shellSrc).toContain("useBrand");
+    // The dead kebab union-strings stay banned (they were never real values).
+    expect(settingsSrc).not.toContain("calm-dark");
+    expect(settingsSrc).not.toContain("warm-light");
+  });
+});
+
+// ── CTL-1099: the brand axis must preserve the semantic palette ────────────────
+describe("CTL-1099 brand axis preserves the semantic palette", () => {
+  const boardTokensSrc = read("board/board-tokens.ts");
+
+  /** Slice every [data-theme="slate"] rule body (balanced braces) out of css. */
+  function slateBlocks(): string[] {
+    const blocks: string[] = [];
+    const re = /\[data-theme="slate"\]\s*\{/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(cssSrc)) !== null) {
+      const open = cssSrc.indexOf("{", m.index);
+      let depth = 0;
+      for (let i = open; i < cssSrc.length; i++) {
+        if (cssSrc[i] === "{") depth++;
+        else if (cssSrc[i] === "}") {
+          depth--;
+          if (depth === 0) {
+            blocks.push(cssSrc.slice(open, i + 1));
+            break;
+          }
+        }
+      }
+    }
+    return blocks;
+  }
+
+  /** Strip CSS comments so a token MENTIONED in prose (e.g. "--chart-* inherit")
+   *  never trips the literal declaration scan. */
+  const stripCss = (s: string) => s.replace(/\/\*[\s\S]*?\*\//g, "");
+
+  it("no [data-theme=\"slate\"] block redefines a semantic --color-* or chart slot", () => {
+    const blocks = slateBlocks().map(stripCss);
+    // Both the slate-light (:root[...]) and slate-dark (.dark[...]) blocks exist.
+    expect(blocks.length).toBe(2);
+    // A slate block may CONSUME a semantic token (e.g. `--destructive:
+    // var(--color-red)` — the base .dark does the same), but must never REDEFINE
+    // one. A redefinition is the token immediately followed by `:` at declaration
+    // position; a `var(--color-red)` reference never matches `--color-red\s*:`.
+    const REDEFINES = (b: string, token: string) =>
+      new RegExp(`${token}\\s*:`).test(b);
+    for (const b of blocks) {
+      expect(REDEFINES(b, "--color-green")).toBe(false);
+      expect(REDEFINES(b, "--color-red")).toBe(false);
+      expect(REDEFINES(b, "--color-yellow")).toBe(false);
+      expect(REDEFINES(b, "--color-live")).toBe(false);
+      expect(REDEFINES(b, "--chart-[0-9]")).toBe(false);
+    }
+  });
+
+  it("the 9 canonical PHASE hexes in board-tokens.ts are untouched by the warm-dark C change", () => {
+    const PINNED: Record<string, string> = {
+      todo: "#97a3b4",
+      triage: "#8492a4",
+      research: "#5e9ee8",
+      plan: "#a98ee3",
+      implement: "#45c08a",
+      verify: "#dba14f",
+      review: "#cdb84e",
+      pr: "#45bcab",
+      done: "#788596",
+    };
+    for (const [phase, hex] of Object.entries(PINNED)) {
+      // The phase key's literal hex still appears verbatim in board-tokens.ts.
+      expect(boardTokensSrc).toContain(`${phase}: "${hex}"`);
+    }
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/ui/index.html
+++ b/plugins/dev/scripts/orch-monitor/ui/index.html
@@ -1,13 +1,33 @@
 <!doctype html>
 <!-- CTL-893 / SHELL3: boot calm-dark (matches board.html) so the app's default
-     theme is dark before lib/theme.ts mounts — avoids a warm-light flash now
-     that `:root` is the light theme and `.dark` is calm-dark. -->
+     mode is dark before lib/theme.ts mounts.
+     CTL-1099: TWO axes now — MODE (.dark class, catalyst:theme) and BRAND
+     (data-theme="slate", catalyst:brand). Warm is the no-attribute base, so a
+     stored slate brand needs the attribute set BEFORE first paint to avoid a
+     brand FOUC (and the pre-existing mode FOUC). The inline <head> script below
+     applies both from localStorage; class="dark" stays the static JS-disabled
+     fallback. -->
 <html lang="en" class="dark">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Catalyst Monitor</title>
     <link rel="icon" type="image/svg+xml" href="/public/favicon.svg" />
+    <!-- CTL-1099: pre-paint brand + mode resolve (FOUC fix). Runs before the
+         module loads (which is at end of <body>), so the right tokens are live
+         on first paint. try/catch is mandatory — localStorage throws in
+         private-mode / SSR. -->
+    <script>
+      try {
+        var b = localStorage.getItem("catalyst:brand");
+        if (b === "slate")
+          document.documentElement.setAttribute("data-theme", "slate");
+        var t = localStorage.getItem("catalyst:theme");
+        var d = document.documentElement.classList;
+        if (t === "light") d.remove("dark");
+        else d.add("dark");
+      } catch (e) {}
+    </script>
   </head>
   <!-- Use the semantic theme tokens (not hard-coded dark hex) so the body tracks
        the active theme when the footer toggle flips calm-dark ⇄ warm-light. -->

--- a/plugins/dev/scripts/orch-monitor/ui/src/app.css
+++ b/plugins/dev/scripts/orch-monitor/ui/src/app.css
@@ -43,7 +43,11 @@
   --color-border-subtle: var(--border-subtle);
   --color-fg: var(--fg);
   --color-muted: var(--fg-muted);
-  --color-accent: #5e9ee8;
+  /* CTL-1099: accent is now a per-theme/brand var (was the literal blue #5e9ee8),
+     so text-accent + every var(--color-accent) consumer (md-content links,
+     ticket-ref pills, blockquote borders, prose-invert links) flips with the
+     brand axis: terracotta in warm (light + dark), Linear-blue in slate. */
+  --color-accent: var(--accent);
   --color-green: #41bd7d;
   --color-red: #e36b6b;
   --color-yellow: #d9a843;
@@ -128,6 +132,10 @@
   --color-light-fg: #2b2722;
   --color-light-muted: #76705f;
   --color-light-accent: #a9512f; /* CTL-1071: terracotta accent (warm-light only) */
+  /* CTL-1099: --accent is the per-brand accent var --color-accent now resolves to
+     (@theme inline). On warm-light it IS the terracotta light accent; this also
+     corrects text-accent, which previously resolved to a stray blue in :root. */
+  --accent: var(--color-light-accent);
 
   /* CTL-1033: warm-light SEMANTIC ladder (same upward direction as dark):
      chrome darkest-tinted → canvas → subtle → card → elevated (lightest paper).
@@ -195,22 +203,21 @@
   --sidebar-ring: var(--color-light-accent);
 }
 
-/* CTL-893 / SHELL3 — the CALM-DARK theme (the boot default). These are the
-   exact dark mappings that previously lived on `:root` (CTL-891 / SHELL1),
-   now scoped to `.dark` so the toggle can flip between the two themes. */
+/* CTL-1099 — base `.dark` is now the WARM-DARK theme (the boot default, FOUC-free:
+   no data-theme attribute needed). Charcoal ramp extracted VERBATIM from
+   mockups/governance-rulebook-v2-textbook.html :root (sidebar-bg #11100e → hairline
+   #34312a), remapped onto the app's semantic surface ladder. Accent is TERRACOTTA
+   (#d28e63), NOT the textbook's amber clay #e8ad4a. The prior calm-dark
+   blue-graphite identity (CTL-893 / SHELL3) moves verbatim to
+   `.dark[data-theme="slate"]` (the slate brand override, appended below). */
 .dark {
-  /* CTL-1033: per-theme dark SEMANTIC elevation ladder (OKLCH-derived, blue-tinted
-     hue H≈257 preserved; +0.04–0.06 L between neighbors so cards FLOAT, not emboss).
-     chrome (anchor, sidebar GOOD — unchanged) → canvas → subtle (lane bands/zebra) →
-     card → elevated (popovers). --surface-hover is the interaction tint (top, NOT an
-     elevation level). The previous ramp's card step was a +0.03 imperceptible nudge;
-     the new card sits +0.089 L above canvas → a clearly visible step. */
-  --surface-chrome: #0e1116; /* chrome (sidebar/nav/footer) — anchor, UNCHANGED */
-  --surface-canvas: #181d24; /* every route's content shell */
-  --surface-subtle: #20262f; /* lane bands, zebra, column-header chips, inset wells */
-  --surface-card: #2b333d; /* cards / panels */
-  --surface-elevated: #39424f; /* popovers, command palette, dropdowns, modals */
-  --surface-hover: #434d5b; /* hover fills, scrollbar thumbs/tracks (interaction) */
+  /* warm-charcoal semantic elevation ladder (monotonic, +luminance each step) */
+  --surface-chrome: #11100e; /* chrome (sidebar/nav/footer) — anchor (textbook --sidebar-bg) */
+  --surface-canvas: #161513; /* content shell (textbook --canvas) */
+  --surface-subtle: #1b1a17; /* lane bands / zebra / inset wells (textbook --panel) */
+  --surface-card: #1e1d1a; /* cards / panels (textbook --surface) */
+  --surface-elevated: #242220; /* popovers / palette / dropdowns (textbook --surface-2) */
+  --surface-hover: #2e2c27; /* hover fills / scrollbar thumbs (textbook --border) — interaction, EXEMPT */
   /* Numeric aliases onto the semantic ladder (back-compat for --surface-N + the
      shadcn bridge below). --surface-3 → elevated, --surface-4 → hover. */
   --surface-0: var(--surface-chrome);
@@ -218,16 +225,18 @@
   --surface-2: var(--surface-card);
   --surface-3: var(--surface-elevated);
   --surface-4: var(--surface-hover);
-  /* CTL-1033: alpha-WHITE borders, scaled inversely with surface lightness (the
-     embossing cure's garnish — lightness is load-bearing, borders are the edge). */
+  /* warm hairline borders (textbook --border / --border-soft family). Keep the
+     alpha-white form so card edges read on the charcoal ramp like the prior dark. */
   --border-strong: rgba(255, 255, 255, 0.11); /* inputs, interactive outlines */
   --border-subtle: rgba(255, 255, 255, 0.07); /* card edges, in-card hairlines */
-  --fg: #edf1f7;
-  --fg-muted: #9ba6b5;
+  --fg: #e9e5dc; /* textbook --ink */
+  --fg-muted: #a39d91; /* textbook --ink-dim */
+  /* warm-dark accent — terracotta (NOT amber). Drives --primary/--ring/--sidebar-primary. */
+  --accent: #d28e63;
 
   /* CTL-1033: dark card lift — soft ambient outer shadow + inset top-edge highlight
      (the standard Stripe/Linear/Vercel combo, the single best embossing cure). Card
-     bg is the PRIMARY lift (lightness); the shadow is the secondary signal. */
+     bg is the PRIMARY lift (lightness); the shadow is the secondary signal. UNCHANGED. */
   --shadow-card: inset 0 1px 0 rgba(255, 255, 255, 0.07), 0 1px 4px rgba(0, 0, 0, 0.35);
   --shadow-elevated: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 8px 24px rgba(0, 0, 0, 0.45);
 
@@ -248,7 +257,7 @@
   --ring: var(--color-accent);
 
   /* OBS-1: categorical chart palette (same values as :root — the palette is
-     theme-independent; status color is reserved for health, not series). */
+     theme-invariant; status color is reserved for health, not series). UNCHANGED. */
   --chart-1: #4ea1ff;
   --chart-2: #39d07a;
   --chart-3: #eabc3b;
@@ -266,6 +275,73 @@
   --sidebar-accent: var(--surface-2); /* gentler active-item lift on the darker rail */
   --sidebar-accent-foreground: var(--color-fg);
   --sidebar-border: var(--border-subtle); /* seam already separated by luminance */
+  --sidebar-ring: var(--color-accent);
+}
+
+/* ── CTL-1099 :root[data-theme="slate"] = SLATE-LIGHT. The pre-CTL-1071
+   blue-on-paper light identity. Reuses warm-light's paper-warm neutral surface ramp
+   VERBATIM (inherited from :root above) and ONLY overrides the accent family to
+   Linear blue #1f6feb. Placed AFTER :root so it wins on specificity-equal
+   (:root[data-theme] is higher specificity than :root anyway). Must NOT redefine any
+   --color-{green,red,yellow,live} or --chart-* (semantic-invariant contract). ── */
+:root[data-theme="slate"] {
+  --accent: #1f6feb; /* drives text-accent + all var(--color-accent) */
+  --primary: #1f6feb;
+  --ring: #1f6feb;
+  --sidebar-primary: #1f6feb;
+  --sidebar-ring: #1f6feb;
+  --input: var(--color-light-border); /* unchanged; restated for clarity */
+  /* surfaces (--surface-*, --fg, --border-*, --background, --card, --popover,
+     --secondary, --destructive, --chart-*) all INHERIT from :root unchanged —
+     slate only forks the accent. Do NOT restate the surface ramp. */
+}
+
+/* ── CTL-1099 .dark[data-theme="slate"] = SLATE-DARK. The CURRENT/old calm-dark
+   blue-graphite identity (CTL-893 / SHELL3, CTL-1033 ladder) moved VERBATIM. The
+   blue accent #5e9ee8 flows through --primary/--ring/--sidebar-primary via
+   var(--color-accent) = var(--accent). Must NOT redefine any --color-{green,red,
+   yellow,live} or --chart-* beyond the historical --chart-5 already shared. ── */
+.dark[data-theme="slate"] {
+  --surface-chrome: #0e1116; /* chrome (sidebar/nav/footer) — anchor */
+  --surface-canvas: #181d24; /* every route's content shell */
+  --surface-subtle: #20262f; /* lane bands, zebra, column-header chips, inset wells */
+  --surface-card: #2b333d; /* cards / panels */
+  --surface-elevated: #39424f; /* popovers, command palette, dropdowns, modals */
+  --surface-hover: #434d5b; /* hover fills, scrollbar thumbs/tracks (interaction) */
+  --surface-0: var(--surface-chrome);
+  --surface-1: var(--surface-canvas);
+  --surface-2: var(--surface-card);
+  --surface-3: var(--surface-elevated);
+  --surface-4: var(--surface-hover);
+  --border-strong: rgba(255, 255, 255, 0.11);
+  --border-subtle: rgba(255, 255, 255, 0.07);
+  --fg: #edf1f7;
+  --fg-muted: #9ba6b5;
+  --accent: #5e9ee8; /* slate-dark accent — Linear-graphite blue */
+  --shadow-card: inset 0 1px 0 rgba(255, 255, 255, 0.07), 0 1px 4px rgba(0, 0, 0, 0.35);
+  --shadow-elevated: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 8px 24px rgba(0, 0, 0, 0.45);
+  --background: var(--surface-1);
+  --foreground: var(--color-fg);
+  --card: var(--surface-2);
+  --card-foreground: var(--color-fg);
+  --popover: var(--surface-3);
+  --popover-foreground: var(--color-fg);
+  --primary: var(--color-accent);
+  --primary-foreground: var(--surface-0);
+  --secondary: var(--surface-3);
+  --secondary-foreground: var(--color-fg);
+  --muted-foreground: var(--color-muted);
+  --accent-foreground: var(--color-fg);
+  --destructive: var(--color-red);
+  --input: var(--border-strong);
+  --ring: var(--color-accent);
+  --sidebar: var(--surface-0);
+  --sidebar-foreground: var(--color-fg);
+  --sidebar-primary: var(--color-accent);
+  --sidebar-primary-foreground: var(--surface-0);
+  --sidebar-accent: var(--surface-2);
+  --sidebar-accent-foreground: var(--color-fg);
+  --sidebar-border: var(--border-subtle);
   --sidebar-ring: var(--color-accent);
 }
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/board-tokens.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/board-tokens.ts
@@ -7,26 +7,28 @@
 // and the "N active" header). Decorative chrome must never reach for it.
 
 export const C = {
-  // CTL-1033 elevation ladder (dark): surfaces stack UPWARD, darkest → lightest,
-  // with PERCEPTIBLE +0.04–0.06 L steps so cards float (not emboss). These hexes
-  // are kept byte-identical to the .dark semantic vars in app.css (the contract
-  // test surface-contract.test.ts asserts the two stay in sync — kills drift).
-  // s0 = chrome (anchor, sidebar GOOD — UNCHANGED). s1 = content canvas. subtle =
+  // CTL-1033 elevation ladder (dark): surfaces stack UPWARD, darkest → lightest.
+  // CTL-1099: the base `.dark` theme is now WARM-DARK (the textbook charcoal ramp),
+  // so this ladder carries the warm-charcoal hexes — byte-identical to the base
+  // `.dark` semantic vars in app.css (surface-contract.test.ts asserts the two
+  // stay in sync — kills drift). Monotonic ascending luminance verified:
+  //   s0 0.00521 < s1 0.00754 < subtle 0.01034 < s2 0.01229 < s3 0.01623 < s4 0.02529.
+  // s0 = chrome (anchor, textbook --sidebar-bg). s1 = content canvas. subtle =
   // lane bands/zebra/column-header chips. s2 = cards. s3 = elevated (popovers/
   // palette). s4 = hover/tracks (interaction, top — NOT an elevation level).
-  s0: "#0e1116", // chrome (anchor, unchanged)
-  s1: "#181d24", // content canvas (was #151a21)
-  subtle: "#20262f", // lane bands / zebra / column-header chips / inset wells (NEW)
-  s2: "#2b333d", // cards (was #1b212a)
-  s3: "#39424f", // elevated: popover / palette / dropdowns (was #242c37)
-  s4: "#434d5b", // hover / tracks (was #2e3845)
+  s0: "#11100e", // chrome (anchor) — textbook --sidebar-bg (was #0e1116)
+  s1: "#161513", // content canvas — textbook --canvas (was #181d24)
+  subtle: "#1b1a17", // lane bands / zebra / inset wells — textbook --panel (was #20262f)
+  s2: "#1e1d1a", // cards — textbook --surface (was #2b333d)
+  s3: "#242220", // elevated: popover / palette — textbook --surface-2 (was #39424f)
+  s4: "#2e2c27", // hover / tracks — textbook --border (was #434d5b)
   // CTL-1033: alpha-white borders, scaled inversely with surface lightness (the
   // embossing cure's garnish). Drop straight into `1px solid ${C.border}` templates.
-  borderSubtle: "rgba(255,255,255,0.07)", // card edges, in-card hairlines
-  border: "rgba(255,255,255,0.11)", // inputs, interactive outlines, strong separators
-  fg: "#edf1f7",
-  fgMuted: "#9ba6b5",
-  fgDim: "#6e7a8a",
+  borderSubtle: "rgba(255,255,255,0.07)", // card edges, in-card hairlines — UNCHANGED
+  border: "rgba(255,255,255,0.11)", // inputs, interactive outlines, strong separators — UNCHANGED
+  fg: "#e9e5dc", // textbook --ink (was #edf1f7)
+  fgMuted: "#a39d91", // textbook --ink-dim (was #9ba6b5)
+  fgDim: "#6f6a5f", // textbook --ink-faint (was #6e7a8a)
   green: "#41bd7d",
   blue: "#5e9ee8",
   red: "#e36b6b",

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
@@ -53,6 +53,7 @@ import { useTicketSearch } from "@/hooks/use-ticket-search";
 import { ticketSearchItems } from "@/lib/ticket-search-items";
 import { ticketDetailHref } from "@/board/detail-nav";
 import { useTheme } from "@/lib/theme";
+import { useBrand } from "@/lib/brand";
 import { useBoardSnapshot } from "@/hooks/use-board-snapshot";
 import {
   Breadcrumb,
@@ -299,13 +300,16 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   }, [navigate]);
 
   // CTL-1024: theme toggle, sidebar toggle, and board-display commands in the palette.
+  // CTL-1099: brand cycle (Warm ⇄ Slate) too.
   const { toggle: toggleTheme } = useTheme();
+  const { cycle: cycleBrand } = useBrand();
   const setBoardPrefs = useSetAtom(boardPrefsAtom);
   const settingsActions = useMemo(
     () =>
       visibleActions(
         buildSettingsActions({
           toggleTheme,
+          cycleBrand,
           toggleSidebar: () => setOpen((o) => !o),
           setGroupBy: (groupBy) => setBoardPrefs((p) => patchBoardPrefs(p, { groupBy })),
           setOrder: (order) => setBoardPrefs((p) => patchBoardPrefs(p, { order })),
@@ -313,7 +317,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         }),
         { surface },
       ),
-    [toggleTheme, setBoardPrefs, surface],
+    [toggleTheme, cycleBrand, setBoardPrefs, surface],
   );
 
   // CTL-1024: live ticket search via /api/search, debounced in the hook.

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings-surface.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/toggle-group";
 import { useSidebar } from "@/components/ui/sidebar";
 import { THEMES, THEME_LABEL, useTheme } from "@/lib/theme";
+import { BRANDS, BRAND_LABEL, useBrand } from "@/lib/brand";
 import {
   LANDING_SURFACES,
   readLandingSurface,
@@ -130,8 +131,11 @@ export function SettingsSurface() {
   const patch = (d: Partial<BoardPrefs>) =>
     setBoardPrefs((p) => patchBoardPrefs(p, d));
 
-  // Theme — the SHELL3 theme system (`.dark` class + catalyst:theme key).
+  // Theme — TWO orthogonal axes (CTL-1099):
+  //   MODE  → the SHELL3 theme system (`.dark` class + catalyst:theme key).
+  //   BRAND → the CTL-1099 brand system (`data-theme` attr + catalyst:brand key).
   const { theme, setTheme } = useTheme();
+  const { brand, setBrand } = useBrand();
 
   // Sidebar collapse — the shell's controlled provider (persisted by the
   // shell's writeSidebarOpen effect, SHELL4).
@@ -223,15 +227,26 @@ export function SettingsSurface() {
         </Section>
 
         {/* ── Theme ──────────────────────────────────────────────────────────── */}
+        {/* CTL-1099: two orthogonal axes. "Appearance" = MODE (dark ⇄ light, the
+            SHELL3 `.dark` class). "Theme" = BRAND (Warm ⇄ Slate, the data-theme
+            attribute). Warm is the no-attribute default. */}
         <Section
           title="Theme"
-          description="Calm dark is the default. The footer toggle writes this same choice."
+          description="Warm is the default theme; Slate is the cooler graphite alternative. Appearance picks dark or light mode."
         >
           <Field
             label="Appearance"
+            hint="Dark or light mode — the footer toggle writes this same choice."
             value={theme}
             onChange={(v) => setTheme(v)}
             options={THEMES.map((t) => ({ k: t, label: THEME_LABEL[t] }))}
+          />
+          <Field
+            label="Theme"
+            hint="Warm (terracotta) or Slate (Linear blue/graphite)."
+            value={brand}
+            onChange={(v) => setBrand(v)}
+            options={BRANDS.map((b) => ({ k: b, label: BRAND_LABEL[b] }))}
           />
         </Section>
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/brand.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/brand.test.ts
@@ -1,0 +1,84 @@
+// brand.test.ts — CTL-1099 brand-axis contract tests.
+//
+// Pins the PURE brand core (mirrors theme.ts's app-shell-ia tests): the union,
+// the persistence key, the default, the clamp, and the apply mechanism — all
+// without a DOM (bun has none), via injected structural-type stubs.
+//
+//   cd ui && bun test src/lib/brand.test.ts
+import { describe, it, expect } from "bun:test";
+import {
+  BRANDS,
+  BRAND_LABEL,
+  BRAND_STORAGE_KEY,
+  DEFAULT_BRAND,
+  readStoredBrand,
+  applyBrand,
+} from "./brand";
+
+describe("CTL-1099 brand axis — constants", () => {
+  it("the storage key + default are pinned", () => {
+    expect(BRAND_STORAGE_KEY).toBe("catalyst:brand");
+    expect(DEFAULT_BRAND).toBe("warm");
+  });
+
+  it("declares exactly the two brands warm + slate", () => {
+    expect([...BRANDS]).toEqual(["warm", "slate"]);
+  });
+
+  it("every brand is labelled", () => {
+    expect(BRAND_LABEL.warm).toBeTruthy();
+    expect(BRAND_LABEL.slate).toBeTruthy();
+  });
+});
+
+describe("CTL-1099 brand axis — readStoredBrand clamps to the default", () => {
+  it("no storage → warm", () => {
+    expect(readStoredBrand(null)).toBe("warm");
+  });
+  it("absent value → warm", () => {
+    expect(readStoredBrand({ getItem: () => null })).toBe("warm");
+  });
+  it("stored 'slate' → slate", () => {
+    expect(readStoredBrand({ getItem: () => "slate" })).toBe("slate");
+  });
+  it("stored 'warm' → warm", () => {
+    expect(readStoredBrand({ getItem: () => "warm" })).toBe("warm");
+  });
+  it("junk → warm (clamped)", () => {
+    expect(readStoredBrand({ getItem: () => "junk" })).toBe("warm");
+  });
+});
+
+describe("CTL-1099 brand axis — applyBrand sets/removes data-theme", () => {
+  function rootStub() {
+    const set: Array<[string, string]> = [];
+    const removed: string[] = [];
+    return {
+      set,
+      removed,
+      root: {
+        setAttribute: (n: string, v: string) => set.push([n, v]),
+        removeAttribute: (n: string) => removed.push(n),
+      },
+    };
+  }
+
+  it("slate sets data-theme=slate (never removes)", () => {
+    const { set, removed, root } = rootStub();
+    applyBrand("slate", root);
+    expect(set).toContainEqual(["data-theme", "slate"]);
+    expect(removed).toEqual([]);
+  });
+
+  it("warm removes data-theme and never sets it (warm is the no-attribute base)", () => {
+    const { set, removed, root } = rootStub();
+    applyBrand("warm", root);
+    expect(removed).toContain("data-theme");
+    expect(set).toEqual([]);
+  });
+
+  it("no-ops when there is no root (SSR / no DOM)", () => {
+    expect(() => applyBrand("slate", null)).not.toThrow();
+    expect(() => applyBrand("warm", null)).not.toThrow();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/brand.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/brand.ts
@@ -1,0 +1,121 @@
+// brand.ts — the Warm / Slate BRAND theme core (CTL-1099).
+//
+// CTL-1099 introduces a SECOND, orthogonal theme axis to the MODE axis owned by
+// lib/theme.ts. The two axes:
+//   - MODE (lib/theme.ts): `.dark` class on <html>, catalyst:theme. dark ⇄ light.
+//   - BRAND (this module):  `data-theme` attribute on <html>, catalyst:brand.
+//                           warm ⇄ slate.
+//
+// WARM is the no-attribute DEFAULT (FOUC-free — the base :root / .dark CSS blocks
+// ARE warm), so `applyBrand('warm', root)` REMOVES the attribute and
+// `applyBrand('slate', root)` SETS data-theme="slate", which the
+// `:root[data-theme="slate"]` (slate-light) and `.dark[data-theme="slate"]`
+// (slate-dark) override blocks in app.css select on.
+//
+// Structurally this mirrors lib/theme.ts: a PURE, framework-agnostic core (the
+// brand union, the persistence key, the localStorage read, the apply) plus a thin
+// React `useBrand()` hook the Settings Theme picker + the ⌘K brand command bind to.
+//
+// Type note: the pure core uses STRUCTURAL types (a minimal `{ setAttribute,
+// removeAttribute }` shape) rather than the DOM globals `Element` / `HTMLElement`,
+// so this module type-checks even where the importing package's tsconfig has no
+// `dom` lib (the orch-monitor test package imports the pure functions). The hook
+// reaches `window`/`document` through a typed `globalThis` view for the same reason.
+import { useCallback, useEffect, useState } from "react";
+
+/** The two brand themes the picker flips between. */
+export type Brand = "warm" | "slate";
+
+/** Every brand — the single source the picker + tests iterate. */
+export const BRANDS: readonly Brand[] = ["warm", "slate"] as const;
+
+/** Human label per brand (the Settings Theme picker option labels). */
+export const BRAND_LABEL: Record<Brand, string> = {
+  warm: "Warm",
+  slate: "Slate",
+};
+
+/** localStorage key the resolved brand persists under (survives reloads). */
+export const BRAND_STORAGE_KEY = "catalyst:brand";
+
+/** The default brand when no preference is stored — warm (the no-attribute base). */
+export const DEFAULT_BRAND: Brand = "warm";
+
+/** The other brand — a pure two-state flip (warm ↔ slate). */
+export function nextBrand(brand: Brand): Brand {
+  return brand === "warm" ? "slate" : "warm";
+}
+
+/** The minimal storage shape `readStoredBrand` needs (a `window.localStorage`). */
+interface BrandStorage {
+  getItem(key: string): string | null;
+}
+
+/** The minimal element shape `applyBrand` needs (`document.documentElement`). */
+interface BrandRoot {
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+}
+
+/**
+ * Read the persisted brand, defaulting to warm. Pure over an injected storage so
+ * it unit-tests without a real `window` (bun has none); the React hook below
+ * passes `window.localStorage`. Junk values clamp to the default.
+ */
+export function readStoredBrand(storage: BrandStorage | null): Brand {
+  if (!storage) return DEFAULT_BRAND;
+  const raw = storage.getItem(BRAND_STORAGE_KEY);
+  return raw === "slate" || raw === "warm" ? raw : DEFAULT_BRAND;
+}
+
+/**
+ * Apply a brand to the document root: slate sets `data-theme="slate"` (the
+ * slate-light / slate-dark override blocks take over), warm REMOVES the
+ * attribute (warm is the no-attribute base — the :root / .dark blocks ARE warm).
+ * Pure over an injected element so it unit-tests with a minimal
+ * `{ setAttribute, removeAttribute }` shape rather than a real DOM node.
+ */
+export function applyBrand(brand: Brand, root: BrandRoot | null): void {
+  if (!root) return;
+  if (brand === "slate") root.setAttribute("data-theme", "slate");
+  else root.removeAttribute("data-theme");
+}
+
+/** A typed view of the browser globals the hook needs (avoids the dom lib). */
+interface BrowserGlobals {
+  window?: {
+    localStorage: BrandStorage & { setItem(k: string, v: string): void };
+  };
+  document?: { documentElement: BrandRoot };
+}
+
+function browser(): BrowserGlobals {
+  return globalThis as unknown as BrowserGlobals;
+}
+
+/**
+ * React hook the Settings Theme picker + the ⌘K brand command bind to. Resolves
+ * the stored brand on mount, keeps `<html>`'s data-theme in sync, and persists
+ * every change. `cycle()` flips warm ⇄ slate.
+ */
+export function useBrand(): {
+  brand: Brand;
+  setBrand: (b: Brand) => void;
+  cycle: () => void;
+} {
+  const [brand, setBrandState] = useState<Brand>(() =>
+    readStoredBrand(browser().window?.localStorage ?? null),
+  );
+
+  // Keep <html>'s data-theme attribute and localStorage in sync with the brand.
+  useEffect(() => {
+    const { window: win, document: doc } = browser();
+    if (doc) applyBrand(brand, doc.documentElement);
+    if (win) win.localStorage.setItem(BRAND_STORAGE_KEY, brand);
+  }, [brand]);
+
+  const setBrand = useCallback((b: Brand) => setBrandState(b), []);
+  const cycle = useCallback(() => setBrandState((b) => nextBrand(b)), []);
+
+  return { brand, setBrand, cycle };
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/settings-actions.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/settings-actions.test.ts
@@ -5,6 +5,7 @@ import { visibleActions } from "./action-registry";
 function handlers() {
   return {
     toggleTheme: mock(() => {}),
+    cycleBrand: mock(() => {}),
     toggleSidebar: mock(() => {}),
     setGroupBy: mock((_g: "linear" | "phase") => {}),
     setOrder: mock((_o: "priority" | "recent" | "live") => {}),
@@ -25,6 +26,18 @@ describe("buildSettingsActions", () => {
     const h = handlers();
     buildSettingsActions(h).find((a) => a.id === "settings.theme.toggle")!.handler();
     expect(h.toggleTheme).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes brand cycle as global-scoped (CTL-1099)", () => {
+    const actions = buildSettingsActions(handlers());
+    const brand = actions.find((a) => a.id === "settings.brand.cycle");
+    expect(brand?.scope).toBe("global");
+  });
+
+  it("brand command fires cycleBrand (CTL-1099)", () => {
+    const h = handlers();
+    buildSettingsActions(h).find((a) => a.id === "settings.brand.cycle")!.handler();
+    expect(h.cycleBrand).toHaveBeenCalledTimes(1);
   });
 
   it("board-display commands are board-scoped and hidden off-board", () => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/settings-actions.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/settings-actions.ts
@@ -6,6 +6,8 @@ export type Layout = "board" | "list";
 
 export interface SettingsActionHandlers {
   toggleTheme: () => void;
+  /** CTL-1099: cycle the brand axis (Warm ⇄ Slate). */
+  cycleBrand: () => void;
   toggleSidebar: () => void;
   setGroupBy: (g: GroupBy) => void;
   setOrder: (o: Ordering) => void;
@@ -36,6 +38,13 @@ export function buildSettingsActions(h: SettingsActionHandlers): ActionEntry[] {
       keywords: ["dark", "light", "appearance"],
       scope: "global",
       handler: h.toggleTheme,
+    },
+    {
+      id: "settings.brand.cycle",
+      title: "Switch theme (Warm / Slate)",
+      keywords: ["theme", "brand", "appearance"],
+      scope: "global",
+      handler: h.cycleBrand,
     },
     {
       id: "settings.sidebar.toggle",

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/theme.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/theme.ts
@@ -27,10 +27,12 @@ export type Theme = "dark" | "light";
 /** Every theme — the single source the toggle + tests iterate. */
 export const THEMES: readonly Theme[] = ["dark", "light"] as const;
 
-/** Human label per theme (toggle aria-label / tooltip). */
+/** Human label per theme — the MODE axis (CTL-1099 relabel: was "Calm dark" /
+ *  "Warm light", now plain "Dark" / "Light" so it reads as a pure mode control,
+ *  distinct from the BRAND axis Warm/Slate. The "dark"|"light" union is unchanged. */
 export const THEME_LABEL: Record<Theme, string> = {
-  dark: "Calm dark",
-  light: "Warm light",
+  dark: "Dark",
+  light: "Light",
 };
 
 /** localStorage key the resolved preference persists under (survives reloads). */

--- a/plugins/dev/scripts/orch-monitor/ui/src/warm-tokens.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/warm-tokens.test.ts
@@ -38,6 +38,26 @@ function selectorBlock(selector: string): string {
   throw new Error(`unbalanced block for ${selector}`);
 }
 
+/** Balanced body of the CTL-1099 `.dark[data-theme="slate"]` slate-dark rule.
+ *  (The generic selectorBlock can't escape the `[...]` attribute selector, so
+ *  match the literal rule head directly.) */
+function slateDarkBlock(): string {
+  // Match the literal rule HEAD (selector immediately followed by optional
+  // whitespace + `{`), not a mention inside a comment.
+  const m = /\.dark\[data-theme="slate"\]\s*\{/.exec(css);
+  if (!m) throw new Error("slate-dark rule not found");
+  const open = css.indexOf("{", m.index);
+  let depth = 0;
+  for (let i = open; i < css.length; i++) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}") {
+      depth--;
+      if (depth === 0) return css.slice(open, i + 1);
+    }
+  }
+  throw new Error("unbalanced slate-dark block");
+}
+
 // ── Phase 1 (Pass A): warm-light accent fork ──────────────────────────────
 
 describe("CTL-1071 Pass A — warm-light accent fork", () => {
@@ -46,8 +66,14 @@ describe("CTL-1071 Pass A — warm-light accent fork", () => {
     expect(tokenHex(root, "--color-light-accent")).toBe("#a9512f");
     expect(root).not.toContain("#1f6feb");
   });
-  it("dark accent is untouched (still blue)", () => {
-    expect(css).toContain("--color-accent: #5e9ee8");
+  it("warm-dark accent is terracotta; slate-dark preserves blue (CTL-1099)", () => {
+    // CTL-1099: the base `.dark` accent is now TERRACOTTA, and the @theme inline
+    // `--color-accent` became `var(--accent)` (so it flips with the brand axis).
+    // The OLD blue identity moved verbatim to `.dark[data-theme="slate"]`.
+    expect(selectorBlock(".dark").trim()).toContain("--accent: #d28e63");
+    expect(slateDarkBlock()).toContain("--accent: #5e9ee8");
+    // The @theme inline accent is the per-brand var, not a literal blue.
+    expect(css).toContain("--color-accent: var(--accent)");
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a **brand/theme axis** to orch-monitor, separate from light/dark mode, defaulting to a new **Warm** identity with the prior look preserved as **Slate**. Operators switch from a Settings picker; future brandings are one token block + one registry entry.

Closes CTL-1099. First deliverable of the governance-UI program (epics CTL-1100–1104 filed in Backlog).

## Design: two orthogonal axes

| Axis | Mechanism | Values | Storage |
|---|---|---|---|
| **Mode** (unchanged) | `.dark` class on `<html>` | light / dark | `catalyst:theme` |
| **Brand** (new) | `data-theme` attribute | warm (default) / slate | `catalyst:brand` |

They compose into four quadrants. **Warm is the FOUC-free default** (no attribute → base `:root`/`.dark` are warm); **Slate is the opt-in override** (`[data-theme="slate"]` / `.dark[data-theme="slate"]` = the prior blue-graphite, moved verbatim). A pre-paint inline script in `index.html` applies both axes from localStorage before first paint.

## Semantic state colors are theme-invariant

Themes restyle **chrome**, never **information**. The nine phase colors (`board-tokens.ts` `PHASE`, TS literals consumed as inline styles), severity red/amber/green, and the live cyan `#53cde2` are defined once and never redeclared in any `[data-theme]` block. A new contract test enforces this — the nine-phase stepper keeps its colors in every theme.

## What changed

- **`ui/src/lib/brand.ts`** (new) — `Brand` registry mirroring `theme.ts`: `BRANDS`, `BRAND_LABEL`, `BRAND_STORAGE_KEY`, `DEFAULT_BRAND='warm'`, pure `readStoredBrand`/`applyBrand`, `useBrand()` hook. Structural types (no DOM lib), same idiom as `theme.ts`.
- **`ui/src/app.css`** — `--color-accent` now indirects through `var(--accent)`; base `:root` = warm-light, base `.dark` = warm-dark (charcoal ramp from the textbook mockup, terracotta `#d28e63`); new `:root[data-theme="slate"]` (slate-light, blue `#1f6feb`) and `.dark[data-theme="slate"]` (slate-dark, the prior blue-graphite verbatim).
- **`ui/src/board/board-tokens.ts`** — `C` surface ladder adopts the warm-charcoal hexes (byte-identical to base `.dark`, monotonic). `PHASE`/`TYPE`/`LIVE` untouched.
- **`ui/index.html`** — pre-paint brand+mode boot script (fixes brand FOUC and the pre-existing mode FOUC).
- **`settings-surface.tsx`** — new "Theme" picker (Warm/Slate) beside the relabelled Mode control.
- **`app-shell.tsx` / `settings-actions.ts`** — `settings.brand.cycle` ⌘K command.
- **`theme.ts`** — mode labels relabelled "Dark"/"Light" (union unchanged).

## Deliberate test reversal

`settings-surface.test.ts` previously banned all `data-theme` (the "SURF3⇄SHELL3 clash resolution" — a prior single-axis decision). Per operator direction this is reversed: the test now asserts **one mechanism per axis** (`.dark` = sole mode, `data-theme` = sole brand — not a re-introduced clash) and adds a semantic-palette-preserved contract. Commented citing CTL-1099.

## Test plan

- 84 targeted tests pass (settings-surface, app-shell-ia, warm-tokens, elevation-ladder, surface-contract, settings-actions, brand); full `ui/` suite 1084 pass / 0 fail.
- `tsc --noEmit` clean on both `ui/` and parent `orch-monitor/`; `bun run build:ui` succeeds; lint/knip clean.
- **Live-verified** (production build): warm-dark default, switch to slate-dark, warm-light — `data-theme` + `--surface-canvas` + persistence all confirmed. The 6 pre-existing `catalyst-monitor.sh`/`session-store` baseline failures are unrelated (fail identically on clean main).

## Known v1 limitation (fast-follow)

The dense board grid cards read `board-tokens.ts` `C` inline (not CSS vars), so under **Slate** they stay warm-charcoal until those surfaces migrate to CSS vars / a brand-aware `C`. Default (warm) is fully consistent. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)