### PR TITLE
fix(dev): CTL-1105 — stop phase workers stranding commits on transient bgIsolation branches

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -2099,6 +2099,37 @@ assert_eq "true" "$T64_HAS_GEN" "CATALYST_GENERATION still present alongside the
 assert_eq "yes" "$T64_VALID" "settings JSON valid with CATALYST_CLUSTER_GENERATION absent"
 
 echo ""
+echo "Test 65 (CTL-1105): spawn carries --settings with worktree.bgIsolation = none"
+fresh_env t65
+cat >"${CONFIG_DIR}/config.json" <<EOF
+{ "catalyst": { "projectKey": "test-proj" } }
+EOF
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
+SETTINGS_T65="$(settings_json_from_log)"
+T65_BG_ISO=$(echo "$SETTINGS_T65" | jq -r '.worktree.bgIsolation // empty' 2>/dev/null)
+assert_eq "none" "$T65_BG_ISO" ".settings.worktree.bgIsolation = none"
+
+echo ""
+echo "Test 66 (CTL-1105): worktree.bgIsolation coexists with telemetry env + statusLine"
+T66_HAS_ENV=$(echo "$SETTINGS_T65" | jq -r '.env | has("CLAUDE_CODE_ENABLE_TELEMETRY")' 2>/dev/null)
+T66_VALID=$(echo "$SETTINGS_T65" | jq -e . >/dev/null 2>&1 && echo yes || echo no)
+assert_eq "true" "$T66_HAS_ENV" "settings still carries the telemetry env block alongside worktree"
+assert_eq "yes" "$T66_VALID" "settings JSON remains valid with worktree key present"
+
+echo ""
+echo "Test 67 (CTL-1105): --dry-run JSON includes worktree.bgIsolation = none"
+fresh_env t67
+cat >"${CONFIG_DIR}/config.json" <<EOF
+{ "catalyst": { "projectKey": "test-proj" } }
+EOF
+DRY_OUT_T67=$(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run 2>/dev/null)
+T67_BG_ISO=$(echo "$DRY_OUT_T67" | jq -r '.settings.worktree.bgIsolation // empty' 2>/dev/null)
+assert_eq "none" "$T67_BG_ISO" "dry-run .settings.worktree.bgIsolation = none"
+
+echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"
 if [[ $FAILURES -gt 0 ]]; then

--- a/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
@@ -770,6 +770,39 @@ else
 	fail "gate base-unknown: warning" "stderr:$(printf '\n%s' "$(cat "$CASE_G/stderr.log" 2>/dev/null)")"
 fi
 
+# Case H (CTL-1105): stranded on a transient worktree branch with REAL commits
+# ahead of origin/main. The CTL-608 commits-ahead arm would pass; the new
+# branch/worktree-mismatch arm must FAIL.
+build_git_fixture_transient() {
+	local dir="$1"
+	mkdir -p "$dir"
+	(
+		cd "$dir" || exit 1
+		git init --quiet --initial-branch=main
+		git config user.email "test@example.com"
+		git config user.name "Test"
+		git commit --quiet --allow-empty -m "base"
+		git update-ref refs/remotes/origin/main HEAD
+		# Simulate bgIsolation migration: a worktree-* branch with commits ahead.
+		git checkout --quiet -b worktree-transient-spinning-cherny
+		git commit --quiet --allow-empty -m "stranded work 1"
+		git commit --quiet --allow-empty -m "stranded work 2"
+	)
+}
+
+CASE_H="$(run_empty_branch_gate transient build_git_fixture_transient)"
+assert_eq "1" "$(cat "$CASE_H/exit-code")" "gate transient-branch: exit 1"
+if grep -q -- '--status failed' "$CASE_H/emit-capture.log" 2>/dev/null; then
+	pass "gate transient-branch: emits --status failed"
+else
+	fail "gate transient-branch: --status failed" "capture:$(printf '\n%s' "$(cat "$CASE_H/emit-capture.log" 2>/dev/null)")"
+fi
+if grep -qE 'stranded_transient_worktree|wrong_branch' "$CASE_H/emit-capture.log" 2>/dev/null; then
+	pass "gate transient-branch: reason names the stranding"
+else
+	fail "gate transient-branch: reason" "capture:$(printf '\n%s' "$(cat "$CASE_H/emit-capture.log" 2>/dev/null)")"
+fi
+
 # ─── Test 15 (CTL-632): phase-pr + phase-monitor-merge mirror blocks present ──
 echo ""
 echo "Test 15 (CTL-632): phase-pr + phase-monitor-merge contract — mirror blocks present"

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -816,7 +816,12 @@ compose_worker_settings_json() {
          + (if $ticket == "" then {} else { "CATALYST_TICKET": $ticket } end)
          + (if $generation == "" then {} else { "CATALYST_GENERATION": $generation } end)
          + (if $cluster_generation == "" then {} else { "CATALYST_CLUSTER_GENERATION": $cluster_generation } end)
-       )
+       ),
+       # CTL-1105: phase workers run with cwd = the ticket worktree (not under
+       # .claude/worktrees/), so the default bgIsolation would force EnterWorktree
+       # and strand commits on a transient worktree-* branch. Opt out so the worker
+       # edits the ticket worktree directly. --settings MERGES with the user settings.
+       worktree: { bgIsolation: "none" }
      }
      + (if $have_statusline
         then { statusLine: { type: "command", command: $statusline_cmd } }

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -298,11 +298,37 @@ Then the empty-branch self-emit gate (CTL-608). Runs **before** the terminal `--
 a worker cannot self-report implement success on an empty ticket branch (0 commits ahead of its
 integration base). This is the ADV-1128 failure mode: sub-agent commits stranded in nested
 `.claude/worktrees/agent-*` worktrees never reach `refs/heads/<ticket>`, leaving HEAD at base and
-opening an empty PR. Uniquely-named fence so the e2e harness can extract+exercise it; uses only
+opening an empty PR. The gate now also refuses when HEAD is on a `worktree-*` branch or the
+worktree resolves under `.claude/worktrees/` (CTL-1105) — the stranding case the commits-ahead
+check alone cannot see. Uniquely-named fence so the e2e harness can extract+exercise it; uses only
 POSIX/zsh-safe `git rev-list --count` (no `${VAR,,}` / `shopt`). Fail-open (warn + allow) only when
 the base is unresolvable, mirroring the mirror block's `_base branch unknown_` tolerance.
 
 ```bash phase-implement-empty-branch-gate
+# CTL-1105: stranded-in-transient-worktree guard. Claude Code bgIsolation can
+# migrate a phase worker into .claude/worktrees/<name> on a worktree-* branch;
+# commits there never reach refs/heads/<ticket>. The CTL-608 commits-ahead arm
+# below does NOT catch this (the transient worktree has real commits), so check
+# it explicitly first. Deterministic + local; POSIX/zsh-safe.
+GATE_TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+GATE_BRANCH="$(git branch --show-current 2>/dev/null || true)"
+case "${GATE_TOPLEVEL}" in
+  */.claude/worktrees/*) GATE_STRANDED="claude_worktree:${GATE_TOPLEVEL}";;
+  *) GATE_STRANDED="";;
+esac
+case "${GATE_BRANCH}" in
+  worktree-*) GATE_STRANDED="${GATE_STRANDED:-transient_branch:${GATE_BRANCH}}";;
+esac
+if [[ -n "${GATE_STRANDED}" ]]; then
+  echo "phase-implement: stranded in a transient isolation worktree (${GATE_STRANDED}); refusing to emit complete (CTL-1105)" >&2
+  "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+    --phase "$PHASE" --ticket "$TICKET" --status failed \
+    --reason "stranded_transient_worktree:${GATE_STRANDED}"
+  [[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
+    "phase-implement failed: stranded in transient worktree (${GATE_STRANDED})" \
+    --as "$TICKET" --type attention --orch "$ORCH_ID" >/dev/null 2>&1 || true
+  exit 1
+fi
 EMPTY_BRANCH_GATE_BASE=""
 if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
   EMPTY_BRANCH_GATE_BASE="origin/main"


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-13T03:59:30Z -->
<!-- Last updated: 2026-06-13T03:59:30Z -->
<!-- PR: #1945 -->
<!-- Previous commits: 0e6ab0a6 -->

## Summary

Phase workers were silently migrating into transient `.claude/worktrees/worktree-*` branches when Claude Code's `bgIsolation` setting triggered `EnterWorktree` on a worker whose cwd was already the ticket's tracked worktree. Commits landed on the transient branch, not `refs/heads/<ticket>`, so downstream phases (verify, review) ran against an empty tree while the real work existed only on an untracked ephemeral branch (CTL-1091 autopsy).

Two complementary fixes: the dispatcher now opts workers out of `bgIsolation` via `--settings` (prevention), and phase-implement now refuses to emit `complete` if it detects it is running on a `worktree-*` branch or under `.claude/worktrees/` (detection).

## Changes Made

### Dispatcher — prevention (`phase-agent-dispatch`)

Added `worktree: { bgIsolation: "none" }` to the `--settings` JSON that `phase-agent-dispatch` passes to every worker spawn. Claude Code's `--settings` flag merges with the user's settings, so this suppresses the `bgIsolation` isolation path only for phase workers while leaving the user's own IDE/CLI settings untouched. Workers already run with `cwd = <ticket-worktree>`, so there is no reason to isolate further.

### Guard — detection (`phase-implement/SKILL.md`)

Extended the empty-branch gate (CTL-608) with a new stranded-in-transient-worktree check that runs **before** the commits-ahead test. The commits-ahead test cannot catch this failure mode because a transient worktree can have real commits ahead of main. The new guard:

- Checks `git rev-parse --show-toplevel` against the `.claude/worktrees/` path pattern
- Checks `git branch --show-current` against the `worktree-*` naming pattern
- Emits `--status failed --reason stranded_transient_worktree:…` and exits 1 if either fires

Deterministic, local, POSIX/zsh-safe — same discipline as the existing gate.

### Tests

- **Tests 65–67 (`phase-agent-dispatch.test.sh`)**: Verify that `compose_worker_settings_json` always emits `worktree.bgIsolation = "none"`, that this key coexists correctly with the telemetry env block and statusLine key, and that `--dry-run` output includes it.
- **Case H (`phase-implement-e2e.test.sh`)**: Exercises the stranded-in-transient-worktree gate with a fixture that has real commits ahead of origin/main on a `worktree-*` branch — the CTL-608 commits-ahead arm would (incorrectly) pass; the new branch/worktree-mismatch arm must fail with `exit 1` and emit `stranded_transient_worktree` or `wrong_branch`.

## How to Verify It

- [x] All CI checks pass ✅ (audit-references, check-versions, docs-gate, validate, Cloudflare Pages)
- [x] `phase-agent-dispatch.test.sh` Tests 65–67 pass: `worktree.bgIsolation = "none"` present in settings JSON ✅
- [x] `phase-implement-e2e.test.sh` Case H passes: stranded-branch gate fires with exit 1 and correct reason ✅
- [ ] Integration: dispatch a triage phase and verify the spawned worker does not create a `worktree-*` branch (manual, requires fleet run)

## Related Issues / PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1105
- Root cause surfaced by CTL-1091 (PR #1941 stranded on `worktree-transient-spinning-cherny`)
- Builds on CTL-608 empty-branch gate; extends it with the new detection path

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1091
skip CTL-608
