### PR TITLE
feat(dev): CTL-1106 — self-healing plugin-checkout refresh + checkout-lag alarm

### DIFF
--- a/plugins/dev/scripts/broker/barrel-exports.test.mjs
+++ b/plugins/dev/scripts/broker/barrel-exports.test.mjs
@@ -101,6 +101,9 @@ const REQUIRED_EXPORTS = [
   "handlePluginRefreshEvent",
   "PLUGIN_REFRESH_THROTTLE_MS",
   "__clearThrottleForTest",
+  // CTL-1106: checkout-lag alarm (plugin-refresh.mjs)
+  "CHECKOUT_LAG_FAILURE_THRESHOLD",
+  "__clearLagStateForTest",
   // CTL-1077: automatic hot-reload of the running stack (stack-reload.mjs + index.mjs)
   "decideStackReload",
   "handleStackReloadEvent",
@@ -114,11 +117,11 @@ const REQUIRED_EXPORTS = [
 ];
 
 describe("CTL-529 barrel contract", () => {
-  test("all 83 public symbols re-export from ./index.mjs", () => {
+  test("all 85 public symbols re-export from ./index.mjs", () => {
     for (const name of REQUIRED_EXPORTS) {
       expect(typeof barrel[name], `missing export: ${name}`).not.toBe("undefined");
     }
-    expect(REQUIRED_EXPORTS.length).toBe(83);
+    expect(REQUIRED_EXPORTS.length).toBe(85);
   });
 
   test("singleton getters return identity-stable live references", () => {

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -162,6 +162,8 @@ export {
   handlePluginRefreshEvent,
   PLUGIN_REFRESH_THROTTLE_MS,
   __clearThrottleForTest,
+  CHECKOUT_LAG_FAILURE_THRESHOLD, // CTL-1106
+  __clearLagStateForTest, // CTL-1106
 } from "./plugin-refresh.mjs";
 // CTL-1077: automatic hot-reload of the running stack on checkout advance.
 // router.mjs calls handleStackReloadEvent after handlePluginRefreshEvent;

--- a/plugins/dev/scripts/broker/plugin-refresh.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.mjs
@@ -12,11 +12,13 @@
 // configured repo@main arrives, the router calls handlePluginRefreshEvent,
 // which:
 //   1. resolves the pluginDirs checkout root(s)  (parity with lib/plugin-dirs.sh)
-//   2. throttles to at most one pull per N seconds per root
-//   3. runs `git pull --ff-only origin main` in each root
+//   2. throttles to at most one fetch+reset per N seconds per root
+//   3. runs `git fetch --no-tags origin main && git reset --hard origin/main`
+//      in each root (self-healing: the clone is disposable per CTL-992, so
+//      reset --hard is always safe regardless of working-tree dirt — CTL-1106)
 //   4. emits plugin.checkout.updated (new HEAD sha + daemon-skew restart_needed)
-//      on success, or plugin.checkout.refresh_failed (WARN) on a diverged/dirty
-//      checkout — never failing silently.
+//      on success, or plugin.checkout.refresh_failed (WARN) on a genuine
+//      network/auth failure — never failing silently.
 //
 // RESOLUTION-PARITY CONTRACT — keep in sync with the other two resolvers:
 //   - lib/plugin-dirs.sh:56            resolve_plugin_dirs (catalyst-stack / setup)
@@ -44,8 +46,9 @@ import { getEventName } from "./router.mjs";
 // expectation while still delivering "within seconds" freshness.
 export const PLUGIN_REFRESH_THROTTLE_MS = 60_000;
 
-// root → last-pull epoch ms. Module-level so the throttle survives across
+// root → last-fetch epoch ms. Module-level so the throttle survives across
 // events within one daemon lifetime. Cleared between tests via the seam below.
+// Name kept as _lastPullByRoot to avoid barrel-contract churn (CTL-1106).
 const _lastPullByRoot = new Map();
 
 export function __clearThrottleForTest() {
@@ -55,9 +58,9 @@ export function __clearThrottleForTest() {
 // --- default seams (production wiring) ---------------------------------------
 
 // GIT_TIMEOUT_MS — hard ceiling on every synchronous git call. The broker's
-// event loop runs these inline (execFileSync); a network-stalled `pull` with
+// event loop runs these inline (execFileSync); a network-stalled `fetch` with
 // no timeout would freeze the ENTIRE broker — the same daemon-wedging class
-// CTL-990 fixed in dispatch.mjs. A killed pull throws and surfaces as
+// CTL-990 fixed in dispatch.mjs. A killed fetch throws and surfaces as
 // refresh_failed; the next merge event retries after the throttle window.
 const GIT_TIMEOUT_MS = Number(process.env.CATALYST_PLUGIN_REFRESH_GIT_TIMEOUT_MS) || 20_000;
 
@@ -247,13 +250,14 @@ export function isThisRepoMergeEvent(event, { repoFullName } = {}) {
 // --- refresh ----------------------------------------------------------------
 
 /**
- * refreshPluginCheckout — throttle-gated ff-only pull of a single checkout root.
+ * refreshPluginCheckout — throttle-gated fetch+reset of a single checkout root.
  *
- * On a pull that advances HEAD, emits plugin.checkout.updated with old/new sha
- * and a restart_needed flag (true when the daemon's loadedCommit is known and
- * the checkout advanced past it — daemon skew is VISIBLE, not auto-restarted).
- * On an ff-only failure (diverged/dirty), emits plugin.checkout.refresh_failed
- * at WARN — surfacing the failure instead of failing silently.
+ * Runs `git fetch --no-tags origin main` then `git reset --hard origin/main`
+ * (self-healing: clone is disposable per CTL-992; reset --hard is always safe
+ * regardless of working-tree dirt — CTL-1106). On success, emits
+ * plugin.checkout.updated with old/new sha and a restart_needed flag (daemon
+ * skew is VISIBLE, not auto-restarted). On a genuine fetch/reset failure
+ * (network/auth), emits plugin.checkout.refresh_failed at WARN.
  *
  * Returns a result descriptor: { pulled, throttled, changed, failed }.
  */
@@ -283,7 +287,8 @@ export function refreshPluginCheckout({
   }
 
   try {
-    gitFn(root, ["pull", "--ff-only", "origin", "main"]);
+    gitFn(root, ["fetch", "--no-tags", "origin", "main"]);
+    gitFn(root, ["reset", "--hard", "origin/main"]);
   } catch (err) {
     emitFn({
       event: "plugin.checkout.refresh_failed",

--- a/plugins/dev/scripts/broker/plugin-refresh.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.mjs
@@ -55,6 +55,25 @@ export function __clearThrottleForTest() {
   _lastPullByRoot.clear();
 }
 
+// CTL-1106: consecutive genuine-failure count per root + one-shot lag guard.
+// A dirty tree is no longer a failure (Phase 1); these count only fetch/reset
+// failures (network/auth) that leave the checkout behind origin/main.
+export const CHECKOUT_LAG_FAILURE_THRESHOLD =
+  Number(process.env.CATALYST_CHECKOUT_LAG_FAILURE_THRESHOLD) || 2;
+
+const _failuresByRoot = new Map(); // root → { count, since }
+const _lagEmittedByRoot = new Set(); // root → already emitted this stall episode
+
+export function __clearLagStateForTest() {
+  _failuresByRoot.clear();
+  _lagEmittedByRoot.clear();
+}
+
+function _clearLagState(root) {
+  _failuresByRoot.delete(root);
+  _lagEmittedByRoot.delete(root);
+}
+
 // --- default seams (production wiring) ---------------------------------------
 
 // GIT_TIMEOUT_MS — hard ceiling on every synchronous git call. The broker's
@@ -301,6 +320,25 @@ export function refreshPluginCheckout({
         error: err?.message ?? String(err),
       },
     });
+    const prior = _failuresByRoot.get(root) ?? { count: 0, since: now };
+    const next = { count: prior.count + 1, since: prior.count === 0 ? now : prior.since };
+    _failuresByRoot.set(root, next);
+    if (next.count >= CHECKOUT_LAG_FAILURE_THRESHOLD && !_lagEmittedByRoot.has(root)) {
+      _lagEmittedByRoot.add(root);
+      emitFn({
+        event: "plugin.checkout.lag",
+        orchestrator: null,
+        worker: null,
+        severity: "ERROR",
+        detail: {
+          checkout: root,
+          old_sha: oldSha,
+          consecutive_failures: next.count,
+          behind_since: next.since,
+          error: err?.message ?? String(err),
+        },
+      });
+    }
     return { pulled: false, throttled: false, changed: false, failed: true, root, oldSha, newSha: null, restartNeeded: false };
   }
 
@@ -313,6 +351,7 @@ export function refreshPluginCheckout({
 
   // HEAD did not advance — nothing changed, stay quiet (no event noise).
   if (oldSha && newSha && oldSha === newSha) {
+    _clearLagState(root);
     return { pulled: true, throttled: false, changed: false, failed: false, root, oldSha, newSha, restartNeeded: false };
   }
 
@@ -330,6 +369,7 @@ export function refreshPluginCheckout({
     loadedCommit !== newSha &&
     (loadedCommitRoot == null || loadedCommitRoot === root);
 
+  _clearLagState(root);
   emitFn({
     event: "plugin.checkout.updated",
     orchestrator: null,

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -27,6 +27,8 @@ import {
   handlePluginRefreshEvent,
   PLUGIN_REFRESH_THROTTLE_MS,
   __clearThrottleForTest,
+  CHECKOUT_LAG_FAILURE_THRESHOLD,
+  __clearLagStateForTest,
 } from "./plugin-refresh.mjs";
 
 // ─── resolvePluginCheckoutRoots ──────────────────────────────────────────────
@@ -335,10 +337,8 @@ describe("isThisRepoMergeEvent", () => {
 
 // ─── refreshPluginCheckout ───────────────────────────────────────────────────
 
-describe("refreshPluginCheckout", () => {
-  beforeEach(() => __clearThrottleForTest());
-
-  function makeGitFn({ before = "aaaa", after = "bbbb", fetchThrows = false } = {}) {
+// makeGitFn — module-level so it can be shared across describe blocks.
+function makeGitFn({ before = "aaaa", after = "bbbb", fetchThrows = false } = {}) {
     const calls = [];
     const gitFn = (root, args) => {
       calls.push({ root, args });
@@ -362,7 +362,10 @@ describe("refreshPluginCheckout", () => {
     };
     gitFn.calls = calls;
     return gitFn;
-  }
+}
+
+describe("refreshPluginCheckout", () => {
+  beforeEach(() => __clearThrottleForTest());
 
   test("runs fetch + reset --hard and emits plugin.checkout.updated with old+new sha", () => {
     const emitted = [];
@@ -751,6 +754,120 @@ describe("handlePluginRefreshEvent — returns per-root results array (CTL-1077)
       emitFn: () => {},
     });
     expect(results).toBeNull();
+  });
+});
+
+// ─── checkout-lag alarm (CTL-1106 Phase 2) ──────────────────────────────────
+//
+// When genuine refresh failures (network/auth) persist across more than one
+// merge cycle, emit a one-shot `plugin.checkout.lag` event so Fleet Ops /
+// health surfaces the stall instead of silence. Reset on recovery.
+
+describe("checkout-lag alarm", () => {
+  beforeEach(() => {
+    __clearThrottleForTest();
+    __clearLagStateForTest();
+  });
+
+  // Helper: advance `now` past the throttle window to allow each call to execute.
+  function advanceNow(base, step) {
+    return base + step * (PLUGIN_REFRESH_THROTTLE_MS + 1);
+  }
+
+  test("a single failure does not emit plugin.checkout.lag", () => {
+    const emitted = [];
+    refreshPluginCheckout({
+      root: "/co",
+      now: advanceNow(0, 0),
+      gitFn: makeGitFn({ fetchThrows: true }),
+      emitFn: (e) => emitted.push(e),
+    });
+    expect(emitted.some((e) => e.event === "plugin.checkout.lag")).toBe(false);
+    expect(emitted.some((e) => e.event === "plugin.checkout.refresh_failed")).toBe(true);
+  });
+
+  test("N consecutive failures emit exactly one plugin.checkout.lag", () => {
+    const emitted = [];
+    for (let i = 0; i < CHECKOUT_LAG_FAILURE_THRESHOLD; i++) {
+      refreshPluginCheckout({
+        root: "/co",
+        now: advanceNow(0, i),
+        gitFn: makeGitFn({ fetchThrows: true }),
+        emitFn: (e) => emitted.push(e),
+      });
+    }
+    const lagEvents = emitted.filter((e) => e.event === "plugin.checkout.lag");
+    expect(lagEvents).toHaveLength(1);
+    expect(lagEvents[0].detail.checkout).toBe("/co");
+    expect(lagEvents[0].detail.consecutive_failures).toBeGreaterThanOrEqual(CHECKOUT_LAG_FAILURE_THRESHOLD);
+    expect(typeof lagEvents[0].detail.behind_since).toBe("number");
+    expect(lagEvents[0].severity).toBe("ERROR");
+  });
+
+  test("lag is one-shot — further failures after emit do not re-emit", () => {
+    const emitted = [];
+    for (let i = 0; i < CHECKOUT_LAG_FAILURE_THRESHOLD + 3; i++) {
+      refreshPluginCheckout({
+        root: "/co",
+        now: advanceNow(0, i),
+        gitFn: makeGitFn({ fetchThrows: true }),
+        emitFn: (e) => emitted.push(e),
+      });
+    }
+    const lagEvents = emitted.filter((e) => e.event === "plugin.checkout.lag");
+    expect(lagEvents).toHaveLength(1);
+  });
+
+  test("a success resets the failure counter — lag not emitted until threshold reached anew", () => {
+    const emitted = [];
+    // Fail threshold-1 times
+    for (let i = 0; i < CHECKOUT_LAG_FAILURE_THRESHOLD - 1; i++) {
+      refreshPluginCheckout({
+        root: "/co",
+        now: advanceNow(0, i),
+        gitFn: makeGitFn({ fetchThrows: true }),
+        emitFn: (e) => emitted.push(e),
+      });
+    }
+    // One success — advances HEAD, resets counter
+    refreshPluginCheckout({
+      root: "/co",
+      now: advanceNow(0, CHECKOUT_LAG_FAILURE_THRESHOLD - 1),
+      gitFn: makeGitFn({ before: "a", after: "b" }),
+      emitFn: (e) => emitted.push(e),
+    });
+    // Fail threshold-1 more times — should NOT emit lag (counter was reset)
+    for (let i = 0; i < CHECKOUT_LAG_FAILURE_THRESHOLD - 1; i++) {
+      refreshPluginCheckout({
+        root: "/co",
+        now: advanceNow(0, CHECKOUT_LAG_FAILURE_THRESHOLD + i),
+        gitFn: makeGitFn({ fetchThrows: true }),
+        emitFn: (e) => emitted.push(e),
+      });
+    }
+    expect(emitted.some((e) => e.event === "plugin.checkout.lag")).toBe(false);
+  });
+
+  test("lag counter is per-root — failures on /a do not push /b toward its threshold", () => {
+    const emitted = [];
+    for (let i = 0; i < CHECKOUT_LAG_FAILURE_THRESHOLD; i++) {
+      refreshPluginCheckout({
+        root: "/a",
+        now: advanceNow(0, i),
+        gitFn: makeGitFn({ fetchThrows: true }),
+        emitFn: (e) => emitted.push(e),
+      });
+    }
+    // /b has had zero failures — should emit nothing
+    const lagForB = emitted.filter(
+      (e) => e.event === "plugin.checkout.lag" && e.detail.checkout === "/b"
+    );
+    expect(lagForB).toHaveLength(0);
+    // /a should have one lag event
+    const lagForA = emitted.filter(
+      (e) => e.event === "plugin.checkout.lag" && e.detail.checkout === "/a"
+    );
+    expect(lagForA).toHaveLength(1);
   });
 });
 

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -338,21 +338,24 @@ describe("isThisRepoMergeEvent", () => {
 describe("refreshPluginCheckout", () => {
   beforeEach(() => __clearThrottleForTest());
 
-  function makeGitFn({ before = "aaaa", after = "bbbb", pullThrows = false } = {}) {
+  function makeGitFn({ before = "aaaa", after = "bbbb", fetchThrows = false } = {}) {
     const calls = [];
     const gitFn = (root, args) => {
       calls.push({ root, args });
       const sub = args[0];
       if (sub === "rev-parse") {
-        // first rev-parse → before, subsequent → after (the pull advanced HEAD)
+        // first rev-parse → before, subsequent → after (reset advanced HEAD)
         const seen = calls.filter((c) => c.args[0] === "rev-parse").length;
         return seen === 1 ? before : after;
       }
-      if (sub === "pull") {
-        if (pullThrows) {
-          const e = new Error("not fast-forwardable");
+      if (sub === "fetch") {
+        if (fetchThrows) {
+          const e = new Error("Connection refused");
           throw e;
         }
+        return "";
+      }
+      if (sub === "reset") {
         return "";
       }
       return "";
@@ -361,7 +364,7 @@ describe("refreshPluginCheckout", () => {
     return gitFn;
   }
 
-  test("runs ff-only pull and emits plugin.checkout.updated with old+new sha", () => {
+  test("runs fetch + reset --hard and emits plugin.checkout.updated with old+new sha", () => {
     const emitted = [];
     const gitFn = makeGitFn({ before: "old111", after: "new222" });
     const res = refreshPluginCheckout({
@@ -372,16 +375,37 @@ describe("refreshPluginCheckout", () => {
     });
 
     expect(res.pulled).toBe(true);
-    // an ff-only pull was issued against the right checkout
-    const pull = gitFn.calls.find((c) => c.args[0] === "pull");
-    expect(pull.root).toBe("/co");
-    expect(pull.args).toContain("--ff-only");
+    const fetchCall = gitFn.calls.find((c) => c.args[0] === "fetch");
+    expect(fetchCall.root).toBe("/co");
+    expect(fetchCall.args).toEqual(expect.arrayContaining(["fetch", "--no-tags", "origin", "main"]));
+    const resetCall = gitFn.calls.find((c) => c.args[0] === "reset");
+    expect(resetCall.args).toEqual(expect.arrayContaining(["reset", "--hard", "origin/main"]));
+    // no `pull` subcommand is ever issued
+    expect(gitFn.calls.some((c) => c.args[0] === "pull")).toBe(false);
 
     expect(emitted).toHaveLength(1);
     expect(emitted[0].event).toBe("plugin.checkout.updated");
     expect(emitted[0].detail.checkout).toBe("/co");
     expect(emitted[0].detail.old_sha).toBe("old111");
     expect(emitted[0].detail.new_sha).toBe("new222");
+  });
+
+  test("dirty working tree no longer fails — reset --hard advances HEAD and emits updated", () => {
+    // CTL-1106 regression: git pull --ff-only threw on a dirty tree, causing a
+    // refresh_failed event and silent no-reload. fetch + reset --hard is immune
+    // to working-tree dirt; the fake simply returns success.
+    const emitted = [];
+    const gitFn = makeGitFn({ before: "dirty-old", after: "clean-new" });
+    const res = refreshPluginCheckout({
+      root: "/co",
+      now: 0,
+      gitFn,
+      emitFn: (e) => emitted.push(e),
+    });
+    expect(res.failed).toBe(false);
+    expect(res.changed).toBe(true);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].event).toBe("plugin.checkout.updated");
   });
 
   test("throttles to at most one pull per N seconds for the same root", () => {
@@ -401,8 +425,8 @@ describe("refreshPluginCheckout", () => {
     const third = refreshPluginCheckout({ ...args, now: PLUGIN_REFRESH_THROTTLE_MS + 1 });
     expect(third.pulled).toBe(true);
 
-    const pulls = gitFn.calls.filter((c) => c.args[0] === "pull");
-    expect(pulls).toHaveLength(2);
+    const fetchCalls = gitFn.calls.filter((c) => c.args[0] === "fetch");
+    expect(fetchCalls).toHaveLength(2);
   });
 
   test("throttle is per-root — a different checkout is not blocked", () => {
@@ -415,9 +439,9 @@ describe("refreshPluginCheckout", () => {
     expect(b.pulled).toBe(true);
   });
 
-  test("ff-only pull failure surfaces as a refresh_failed event (not silent)", () => {
+  test("genuine fetch failure (network/auth) surfaces refresh_failed (not silent)", () => {
     const emitted = [];
-    const gitFn = makeGitFn({ pullThrows: true });
+    const gitFn = makeGitFn({ fetchThrows: true });
     const res = refreshPluginCheckout({
       root: "/co",
       now: 0,
@@ -541,10 +565,11 @@ describe("handlePluginRefreshEvent", () => {
       repoConfigPath: join(tmpDir, "nope", ".catalyst", "config.json"),
       gitToplevelFn: (pd) => pd.replace(/\/plugins\/dev$/, ""),
       gitFn: (root, args) => {
-        if (args[0] === "pull") {
+        if (args[0] === "fetch") {
           pulled = true;
           return "";
         }
+        if (args[0] === "reset") return "";
         if (args[0] === "rev-parse") return pulled ? "new" : "old";
         return "";
       },
@@ -622,7 +647,8 @@ describe("refreshPluginCheckout — enriched result shape (CTL-1077)", () => {
       now: 1,
       gitFn: (root, args) => {
         if (args[0] === "rev-parse") return head;
-        if (args[0] === "pull") { head = "new"; return ""; }
+        if (args[0] === "fetch") return "";
+        if (args[0] === "reset") { head = "new"; return ""; }
         return "";
       },
       emitFn: () => {},
@@ -699,7 +725,8 @@ describe("handlePluginRefreshEvent — returns per-root results array (CTL-1077)
       },
       gitToplevelFn: (pd) => pd.replace(/\/plugins\/dev$/, ""),
       gitFn: (root, args) => {
-        if (args[0] === "pull") { pulled = true; return ""; }
+        if (args[0] === "fetch") { pulled = true; return ""; }
+        if (args[0] === "reset") return "";
         if (args[0] === "rev-parse") return pulled ? "new" : "old";
         return "";
       },


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-13T19:44:00Z -->
<!-- Last updated: 2026-06-13T19:44:00Z -->
<!-- PR: #1949 -->
<!-- Previous commits: 85b9da9d,7fe965d0 -->

## Summary

Fixes a silent 12-hour auto-reload outage caused by the broker's `git pull --ff-only` aborting when the pristine plugin clone had an uncommitted modification (a test run wrote into a tracked file). Two-phase fix:

1. **Self-healing refresh (Phase 1)**: Replace `git pull --ff-only` with `git fetch --no-tags origin main && git reset --hard origin/main`. The clone is disposable by design (CTL-992), so `reset --hard` is always safe regardless of working-tree dirt.
2. **Checkout-lag alarm (Phase 2)**: Track consecutive genuine fetch/reset failures per checkout root. After `CHECKOUT_LAG_FAILURE_THRESHOLD` (env-configurable, default 2) consecutive failures, emit a one-shot `plugin.checkout.lag` ERROR event so Fleet Ops / health surfaces the stall instead of letting it go dark.

## Changes Made

### Broker — `plugin-refresh.mjs`

- Replaced `git pull --ff-only origin main` with a two-step `git fetch --no-tags origin main` + `git reset --hard origin/main` sequence. Dirty working-tree no longer causes `refresh_failed`; fetch is immune to local modifications.
- Added per-root consecutive failure tracking (`_failuresByRoot`, `_lagEmittedByRoot`) with `CHECKOUT_LAG_FAILURE_THRESHOLD` constant (env-configurable via `CATALYST_CHECKOUT_LAG_FAILURE_THRESHOLD`).
- Emits `plugin.checkout.lag` (severity: ERROR) once per stall episode when failure count reaches the threshold. One-shot guard prevents repeated alarm spam.
- Clears failure/lag state on any successful refresh (checkout unchanged or advanced).
- Exports `CHECKOUT_LAG_FAILURE_THRESHOLD` and `__clearLagStateForTest` through barrel (`index.mjs` + `barrel-exports.test.mjs`).

### Tests — `plugin-refresh.test.mjs`

- Updated all `pull`-based fakes to use `fetch` + `reset` subcommands.
- Added "dirty working tree regression" test confirming `fetch+reset` succeeds where `pull --ff-only` would have thrown.
- Added new `checkout-lag alarm` describe block (4 tests):
  - Single failure → no `plugin.checkout.lag`
  - N consecutive failures → exactly one `plugin.checkout.lag` with correct fields
  - Further failures after emit → no re-emit (one-shot)
  - Recovery after failures → lag state cleared, next failure episode restarts the counter

## How to Verify It

- [x] All 568 tests pass: `bun test` in `plugins/dev/scripts/broker/` — 22 files, 0 failures
- [x] Barrel contract satisfied: `barrel-exports.test.mjs` updated (83→85 symbols)
- [x] No TypeScript — N/A (pure `.mjs` broker module)
- [x] Security: git args are static literal arrays, no interpolation, no new deps
- [x] Dirty-tree regression test confirms Phase 1 behavior
- [x] One-shot lag emission confirmed by dedicated test suite (Phase 2)

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1106
- Adjacent dirtying source fixed in #1945 (CTL-1105)
- Pristine-clone disposable contract defined in CTL-992

## Changelog Entry

```
fix(dev): self-healing plugin-checkout refresh (CTL-1106 Phase 1) — fetch+reset --hard
  instead of pull --ff-only; immune to dirty working tree

feat(dev): checkout-lag alarm on persistent refresh failure (CTL-1106 Phase 2) —
  plugin.checkout.lag ERROR emitted after N consecutive genuine failures; one-shot
  per stall episode, resets on recovery
```

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1105
skip CTL-992
