### PR TITLE
CTL-1100: Read-only governance endpoints + shared client/components

### DIFF
--- a/plugins/dev/scripts/lib/fsm-descriptor.d.mts
+++ b/plugins/dev/scripts/lib/fsm-descriptor.d.mts
@@ -1,0 +1,43 @@
+// Type declarations for fsm-descriptor.mjs (CTL-1100 Phase 2).
+
+export interface FsmEdge {
+  edgeId: string;
+  from: string;
+  to: string;
+  kind: string;
+  guardText: string | null;
+  datalog: string | null;
+  sourceRef: string | null;
+  classification: string;
+}
+
+export interface FsmDescriptor {
+  phases: string[];
+  nextPhase: Record<string, string>;
+  stageRank: Record<string, number>;
+  terminalPhase: string;
+  entryPhase: string;
+  nonPreemptable: string[];
+  ancillaryPhases: string[];
+  remediateCycleCap: number;
+  reviveBudget: number;
+  cycles: Array<{ id: string; members: string[]; cap: number }>;
+  transitions: FsmEdge[];
+  descriptorSha: string;
+  rulesSha: string | null;
+}
+
+/**
+ * Enumerate all FSM transitions: advance edges (NEXT_PHASE), per-phase
+ * non-linear edges (revive/escalation/park/turn-cap), needs-input→resume,
+ * and the verify⇄remediate router cycle. Never drops an edge.
+ */
+export declare function enumerateTransitions(
+  guards?: Record<string, unknown>
+): FsmEdge[];
+
+/**
+ * Build the full /api/fsm/descriptor response object.
+ * Async because it reads the raw descriptor file hash + RULES_SHA at request-time.
+ */
+export declare function buildFsmDescriptor(): Promise<FsmDescriptor>;

--- a/plugins/dev/scripts/lib/fsm-descriptor.mjs
+++ b/plugins/dev/scripts/lib/fsm-descriptor.mjs
@@ -1,0 +1,217 @@
+// fsm-descriptor.mjs — pure assembler for the GET /api/fsm/descriptor endpoint.
+// Exports:
+//   enumerateTransitions(guards?) — totality edge list (NEXT_PHASE + non-linear)
+//   buildFsmDescriptor()         — full response object (async: reads RULES_SHA)
+//
+// Static-imports workflow-descriptor.mjs + phase-fsm.mjs (both bun:sqlite-free).
+// RULES_SHA is loaded via a try/catch computed import (degrades to null).
+// fsm-guards.json is loaded once at module-load time; a malformed file degrades
+// to {} (all-unclassified) rather than crashing.
+//
+// No bun:sqlite anywhere in this module's transitive graph — safe for a plain
+// static import in server.ts.
+
+import { createHash, } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  PHASES,
+  NEXT_PHASE,
+  DESCRIPTOR_PATH,
+  STAGE_RANK,
+  TERMINAL_PHASE,
+  NEW_WORK_ENTRY_PHASE,
+  NON_PREEMPTABLE_PHASES,
+  ANCILLARY_PHASES,
+  REMEDIATE_PHASE,
+  REMEDIATE_CYCLE_CAP,
+} from "./workflow-descriptor.mjs";
+import { REVIVE_BUDGET, PARK_STATE, TERMINAL_FAILURE } from "./phase-fsm.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GUARDS_PATH = join(HERE, "fsm-guards.json");
+
+// loadGuards() — read fsm-guards.json once at module load; degrade to {} on any error.
+function loadGuards() {
+  try {
+    return JSON.parse(readFileSync(GUARDS_PATH, "utf8"));
+  } catch {
+    return {};
+  }
+}
+const GUARDS = loadGuards();
+
+// resolveGuard — look up guard data for an edge using exact key then wildcard.
+// Returns { guardText, datalog, sourceRef, classification } or the unclassified default.
+function resolveGuard(from, to, kind) {
+  const exactKey = `${from}->${to}`;
+  const wildcardKey = `*->${kind}`;
+  const g = GUARDS[exactKey] ?? GUARDS[wildcardKey] ?? null;
+  if (g) {
+    return {
+      guardText: g.guardText ?? null,
+      datalog: g.datalog ?? null,
+      sourceRef: g.sourceRef ?? null,
+      classification: g.classification ?? "unclassified",
+    };
+  }
+  return { guardText: null, datalog: null, sourceRef: null, classification: "unclassified" };
+}
+
+// readRulesSha — try to import rules.mjs via computed specifier (bun:sqlite-free
+// but execution-core/beliefs/rules.generated.mjs may import bun:sqlite; the try/catch
+// ensures the endpoint still responds with rulesSha:null if unavailable).
+async function readRulesSha() {
+  try {
+    const rulesMod = ["../execution-core/beliefs/rules.mjs"].join("");
+    const mod = await import(rulesMod);
+    return mod.RULES_SHA ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// enumerateTransitions — produce the full edge set:
+//   (1) one advance edge per NEXT_PHASE entry (happy-path)
+//   (2) per pipeline phase: revive / escalate / park / turn-cap self-loops
+//   (3) needs-input->resume
+//   (4) verify->remediate / remediate->verify router cycle
+// Never drops an edge; un-curated edges get classification:'unclassified'.
+export function enumerateTransitions(guards = GUARDS) {
+  const result = [];
+
+  // Helper: build a guard lookup from the supplied guards map.
+  function lookup(from, to, kind) {
+    const exactKey = `${from}->${to}`;
+    const wildcardKey = `*->${kind}`;
+    const g = guards[exactKey] ?? guards[wildcardKey] ?? null;
+    if (g) {
+      return {
+        guardText: g.guardText ?? null,
+        datalog: g.datalog ?? null,
+        sourceRef: g.sourceRef ?? null,
+        classification: g.classification ?? "unclassified",
+      };
+    }
+    return { guardText: null, datalog: null, sourceRef: null, classification: "unclassified" };
+  }
+
+  // 1. Advance edges (happy-path).
+  for (const [from, to] of Object.entries(NEXT_PHASE)) {
+    const g = lookup(from, to, "advance");
+    result.push({
+      edgeId: `${from}->advance`,
+      from,
+      to,
+      kind: "advance",
+      ...g,
+    });
+  }
+
+  // 2. Per-pipeline-phase non-linear edges.
+  for (const phase of PHASES) {
+    // revive self-loop: failed → same phase when reviveCount < REVIVE_BUDGET
+    const reviveG = lookup(phase, phase, "revive");
+    result.push({
+      edgeId: `${phase}->revive`,
+      from: phase,
+      to: phase,
+      kind: "revive",
+      ...reviveG,
+    });
+
+    // escalation to stalled (2nd failure)
+    const stalledG = lookup(phase, TERMINAL_FAILURE, "stalled");
+    result.push({
+      edgeId: `${phase}->stalled`,
+      from: phase,
+      to: TERMINAL_FAILURE,
+      kind: "escalation",
+      ...stalledG,
+    });
+
+    // park → needs-input
+    const parkG = lookup(phase, PARK_STATE, "needs-input");
+    result.push({
+      edgeId: `${phase}->park`,
+      from: phase,
+      to: PARK_STATE,
+      kind: "park",
+      ...parkG,
+    });
+
+    // turn-cap continuation self-loop (distinct edgeId from revive)
+    const tcG = lookup(phase, phase, "turn-cap");
+    result.push({
+      edgeId: `${phase}->turn-cap`,
+      from: phase,
+      to: phase,
+      kind: "turn-cap",
+      ...tcG,
+    });
+  }
+
+  // 3. needs-input -> resume (return to parkedFrom phase)
+  const resumeG = lookup(PARK_STATE, "resume", "resume");
+  result.push({
+    edgeId: `needs-input->resume`,
+    from: PARK_STATE,
+    to: "resume",
+    kind: "resume",
+    ...resumeG,
+  });
+
+  // 4. verify⇄remediate router cycle (deriveAdvancement, not transition())
+  const vrG = lookup("verify", REMEDIATE_PHASE, "remediate-cycle");
+  result.push({
+    edgeId: `verify->remediate`,
+    from: "verify",
+    to: REMEDIATE_PHASE,
+    kind: "remediate-cycle",
+    ...vrG,
+  });
+  const rvG = lookup(REMEDIATE_PHASE, "verify", "remediate-cycle");
+  result.push({
+    edgeId: `remediate->verify`,
+    from: REMEDIATE_PHASE,
+    to: "verify",
+    kind: "remediate-cycle",
+    ...rvG,
+  });
+
+  return result;
+}
+
+// buildFsmDescriptor — assemble the full /api/fsm/descriptor response.
+// Async because we read the file hash + RULES_SHA at request-time.
+export async function buildFsmDescriptor() {
+  const [descriptorSha, rulesSha] = await Promise.all([
+    Promise.resolve(
+      createHash("sha256").update(readFileSync(DESCRIPTOR_PATH)).digest("hex")
+    ),
+    readRulesSha(),
+  ]);
+
+  return {
+    phases: PHASES,
+    nextPhase: NEXT_PHASE,
+    stageRank: STAGE_RANK,
+    terminalPhase: TERMINAL_PHASE,
+    entryPhase: NEW_WORK_ENTRY_PHASE,
+    nonPreemptable: [...NON_PREEMPTABLE_PHASES],
+    ancillaryPhases: ANCILLARY_PHASES,
+    remediateCycleCap: REMEDIATE_CYCLE_CAP,
+    reviveBudget: REVIVE_BUDGET,
+    cycles: [
+      {
+        id: "verify-remediate",
+        members: ["verify", REMEDIATE_PHASE],
+        cap: REMEDIATE_CYCLE_CAP,
+      },
+    ],
+    transitions: enumerateTransitions(),
+    descriptorSha,
+    rulesSha,
+  };
+}

--- a/plugins/dev/scripts/lib/fsm-descriptor.test.mjs
+++ b/plugins/dev/scripts/lib/fsm-descriptor.test.mjs
@@ -1,0 +1,136 @@
+// CTL-1100 Phase 2: fsm-descriptor.mjs — unit tests (bun test, no server).
+// Tests: sha correctness, totality over NEXT_PHASE, non-linear edges,
+// unclassified fallback, drift guard.
+
+import { describe, test, expect } from "bun:test";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  PHASES,
+  NEXT_PHASE,
+  DESCRIPTOR_PATH,
+  ANCILLARY_PHASES,
+  TERMINAL_PHASE,
+  NEW_WORK_ENTRY_PHASE,
+  NON_PREEMPTABLE_PHASES,
+  STAGE_RANK,
+  REMEDIATE_CYCLE_CAP,
+} from "./workflow-descriptor.mjs";
+import { REVIVE_BUDGET } from "./phase-fsm.mjs";
+import {
+  enumerateTransitions,
+  buildFsmDescriptor,
+} from "./fsm-descriptor.mjs";
+
+// ─── 1. descriptorSha matches raw file bytes ────────────────────────────────
+
+test("descriptorSha === sha256 of raw DESCRIPTOR_PATH bytes", async () => {
+  const body = await buildFsmDescriptor();
+  const expected = createHash("sha256")
+    .update(readFileSync(DESCRIPTOR_PATH))
+    .digest("hex");
+  expect(body.descriptorSha).toBe(expected);
+});
+
+// ─── 2. Totality over NEXT_PHASE (every advance edge present) ───────────────
+
+test("all NEXT_PHASE advance edges are present", () => {
+  const transitions = enumerateTransitions();
+  const advanceEdges = transitions.filter((t) => t.kind === "advance");
+  // Every NEXT_PHASE entry should have an advance edge
+  for (const [from, to] of Object.entries(NEXT_PHASE)) {
+    const edge = advanceEdges.find((t) => t.from === from && t.to === to);
+    expect(edge).toBeDefined();
+  }
+  // Count should match
+  expect(advanceEdges.length).toBe(Object.keys(NEXT_PHASE).length);
+});
+
+// ─── 3. Non-linear edges present for a representative phase ─────────────────
+
+test("non-linear edges present for 'implement' phase", () => {
+  const transitions = enumerateTransitions();
+  const fromImplement = transitions.filter((t) => t.from === "implement");
+  const edgeTypes = fromImplement.map((t) => t.edgeKind ?? t.kind);
+
+  // revive self-loop (failed → same phase when reviveCount < budget)
+  const revive = fromImplement.find((t) => t.to === "implement" && t.kind === "revive");
+  expect(revive).toBeDefined();
+
+  // escalation to stalled
+  const stalled = fromImplement.find((t) => t.to === "stalled");
+  expect(stalled).toBeDefined();
+
+  // park to needs-input
+  const park = fromImplement.find((t) => t.to === "needs-input");
+  expect(park).toBeDefined();
+
+  // turn-cap continuation self-loop (distinct edgeId from revive)
+  const turnCap = fromImplement.find(
+    (t) => t.to === "implement" && t.kind === "turn-cap"
+  );
+  expect(turnCap).toBeDefined();
+  if (revive && turnCap) {
+    expect(revive.edgeId).not.toBe(turnCap.edgeId);
+  }
+});
+
+test("verify->remediate and remediate->verify edges present", () => {
+  const transitions = enumerateTransitions();
+  const vr = transitions.find((t) => t.from === "verify" && t.to === "remediate");
+  const rv = transitions.find((t) => t.from === "remediate" && t.to === "verify");
+  expect(vr).toBeDefined();
+  expect(rv).toBeDefined();
+});
+
+test("needs-input->resume edge present", () => {
+  const transitions = enumerateTransitions();
+  const resume = transitions.find(
+    (t) => t.from === "needs-input" && t.to === "resume"
+  );
+  expect(resume).toBeDefined();
+});
+
+// ─── 4. Unclassified fallback + seeded guard data ──────────────────────────
+
+test("un-curated happy-path edge has classification:'unclassified'", () => {
+  const transitions = enumerateTransitions();
+  // research->plan is a happy-path advance edge, not in fsm-guards.json
+  const edge = transitions.find((t) => t.from === "research" && t.to === "plan");
+  expect(edge).toBeDefined();
+  expect(edge?.classification).toBe("unclassified");
+  expect(edge?.guard ?? null).toBeNull();
+});
+
+test("seeded verify->remediate edge has classification and guardText", () => {
+  const transitions = enumerateTransitions();
+  const edge = transitions.find((t) => t.from === "verify" && t.to === "remediate");
+  expect(edge?.classification).not.toBe("unclassified");
+  expect(edge?.guardText).toBeTruthy();
+  expect(edge?.sourceRef).toMatch(/phase-fsm|scheduler/);
+});
+
+// ─── 5. Drift guard: buildFsmDescriptor phases match PHASES ─────────────────
+
+test("buildFsmDescriptor().phases deep-equals PHASES", async () => {
+  const body = await buildFsmDescriptor();
+  expect(body.phases).toEqual(PHASES);
+});
+
+test("buildFsmDescriptor() structural shape", async () => {
+  const body = await buildFsmDescriptor();
+  expect(body.terminalPhase).toBe(TERMINAL_PHASE);
+  expect(body.entryPhase).toBe(NEW_WORK_ENTRY_PHASE);
+  expect(Array.isArray(body.ancillaryPhases)).toBe(true);
+  expect(body.ancillaryPhases).toEqual(ANCILLARY_PHASES);
+  expect(body.remediateCycleCap).toBe(REMEDIATE_CYCLE_CAP);
+  expect(body.reviveBudget).toBe(REVIVE_BUDGET);
+  expect(body.descriptorSha).toMatch(/^[0-9a-f]{64}$/);
+  expect(Array.isArray(body.transitions)).toBe(true);
+  expect(body.transitions.length).toBeGreaterThan(Object.keys(NEXT_PHASE).length);
+  // stageRank should be present
+  expect(typeof body.stageRank).toBe("object");
+  expect(body.stageRank).toMatchObject(STAGE_RANK);
+});

--- a/plugins/dev/scripts/lib/fsm-guards.json
+++ b/plugins/dev/scripts/lib/fsm-guards.json
@@ -1,0 +1,44 @@
+{
+  "*->revive": {
+    "guardText": "reviveCount < REVIVE_BUDGET (1); 2nd failure escalates to stalled",
+    "datalog": null,
+    "sourceRef": "plugins/dev/scripts/lib/phase-fsm.mjs:189-192",
+    "classification": "crash-revive"
+  },
+  "*->stalled": {
+    "guardText": "reviveCount >= REVIVE_BUDGET — escalation to terminal failure sink",
+    "datalog": null,
+    "sourceRef": "plugins/dev/scripts/lib/phase-fsm.mjs:192",
+    "classification": "escalation"
+  },
+  "*->needs-input": {
+    "guardText": "event.type === 'park' — operator-initiated pause",
+    "datalog": null,
+    "sourceRef": "plugins/dev/scripts/lib/phase-fsm.mjs:198-199",
+    "classification": "park"
+  },
+  "needs-input->resume": {
+    "guardText": "event.type === 'resume' from needs-input state",
+    "datalog": null,
+    "sourceRef": "plugins/dev/scripts/lib/phase-fsm.mjs:167-168",
+    "classification": "resume"
+  },
+  "verify->remediate": {
+    "guardText": "deriveAdvancement: verify.json regression_risk > 0 and remediateCycleCount < REMEDIATE_CYCLE_CAP",
+    "datalog": "advance_to('remediate', T) :- phase_done('verify', T), regression_risk(T, R), R > 0, cycle_count(T, C), C < 3.",
+    "sourceRef": "plugins/dev/scripts/execution-core/scheduler.mjs:1188",
+    "classification": "remediate-cycle"
+  },
+  "remediate->verify": {
+    "guardText": "deriveAdvancement: after remediate completes, advance back to verify",
+    "datalog": "advance_to('verify', T) :- phase_done('remediate', T).",
+    "sourceRef": "plugins/dev/scripts/execution-core/scheduler.mjs:1188",
+    "classification": "remediate-cycle"
+  },
+  "*->turn-cap": {
+    "guardText": "event.type === 'turn-cap-exhausted' — continuation self-loop, revive budget untouched",
+    "datalog": null,
+    "sourceRef": "plugins/dev/scripts/lib/phase-fsm.mjs:194-196",
+    "classification": "turn-cap"
+  }
+}

--- a/plugins/dev/scripts/lib/fsm-guards.json
+++ b/plugins/dev/scripts/lib/fsm-guards.json
@@ -24,15 +24,15 @@
     "classification": "resume"
   },
   "verify->remediate": {
-    "guardText": "deriveAdvancement: verify.json regression_risk > 0 and remediateCycleCount < REMEDIATE_CYCLE_CAP",
-    "datalog": "advance_to('remediate', T) :- phase_done('verify', T), regression_risk(T, R), R > 0, cycle_count(T, C), C < 3.",
-    "sourceRef": "plugins/dev/scripts/execution-core/scheduler.mjs:1188",
+    "guardText": "deriveAdvancement: verify verdict == 'fail' (regression_risk >= 5 OR any severity:high finding) and remediateCycleCount < REMEDIATE_CYCLE_CAP (3)",
+    "datalog": "advance_to('remediate', T) :- phase_done('verify', T), verify_fail(T), cycle_count(T, C), C < 3.  verify_fail(T) :- regression_risk(T, R), R >= 5.  verify_fail(T) :- high_finding(T).",
+    "sourceRef": "plugins/dev/scripts/execution-core/scheduler.mjs:1207-1210; plugins/dev/scripts/execution-core/work-done-probes.mjs:137",
     "classification": "remediate-cycle"
   },
   "remediate->verify": {
-    "guardText": "deriveAdvancement: after remediate completes, advance back to verify",
+    "guardText": "deriveAdvancement: after remediate completes, advance back to verify (verify⇄remediate cycle, cap 3)",
     "datalog": "advance_to('verify', T) :- phase_done('remediate', T).",
-    "sourceRef": "plugins/dev/scripts/execution-core/scheduler.mjs:1188",
+    "sourceRef": "plugins/dev/scripts/execution-core/scheduler.mjs:901-904",
     "classification": "remediate-cycle"
   },
   "*->turn-cap": {

--- a/plugins/dev/scripts/lib/phase-fsm.d.mts
+++ b/plugins/dev/scripts/lib/phase-fsm.d.mts
@@ -1,0 +1,20 @@
+// Type declarations for phase-fsm.mjs (CTL-1100).
+// Exposes the per-phase FSM constants and transition function to TypeScript
+// consumers (server.ts, fsm-descriptor.mjs, test files).
+
+export declare const PARK_STATE: string;
+export declare const TERMINAL_SUCCESS: string;
+export declare const TERMINAL_FAILURE: string;
+export declare const TERMINAL_STATES: ReadonlySet<string>;
+export declare const EVENT_TYPES: ReadonlySet<string>;
+export declare const REVIVE_BUDGET: number;
+export declare const TERMINAL_LINEAR_KEY: string;
+
+export declare class PhaseFsmError extends Error {}
+
+export declare function isKnownPhase(phase: string): boolean;
+export declare function linearKeyForPhase(phase: string): string;
+export declare function phaseIndex(phase: string): number;
+export declare function initialState(): Record<string, unknown>;
+export declare function isTerminal(state: Record<string, unknown>): boolean;
+export declare function transition(state: Record<string, unknown>, event: string): Record<string, unknown>;

--- a/plugins/dev/scripts/orch-monitor/__tests__/beliefs-read-endpoints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/beliefs-read-endpoints.test.ts
@@ -1,0 +1,368 @@
+// CTL-1100 Phase 3: GET /api/beliefs/rules|summary|rates|recent|cfg
+// Pure unit tests for query functions + HTTP integration tests.
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+// Load query fns via computed specifier for isolation.
+const queryMod = await import("../lib/belief-store-queries.mjs");
+const {
+  beliefSummary,
+  beliefRates,
+  beliefRecent,
+  beliefCfg,
+  RECENT_DEFAULT_LIMIT,
+  RATES_LRU_CAP,
+} = queryMod as {
+  beliefSummary: (db: Database) => unknown;
+  beliefRates: (db: Database, lru: Map<number | null, unknown>) => unknown;
+  beliefRecent: (db: Database, opts?: { limit?: number }) => unknown;
+  beliefCfg: (db: Database) => unknown;
+  RECENT_DEFAULT_LIMIT: number;
+  RATES_LRU_CAP: number;
+};
+
+// Load RULE_MANIFEST via computed specifier (no static bun:sqlite chain).
+const rulesMod = await import("../../execution-core/beliefs/rules.mjs");
+const { RULE_MANIFEST } = rulesMod as { RULE_MANIFEST: { strata: unknown[]; rules: Array<{ rule_id: string; name: string }> } };
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeDb(): Database {
+  const db = new Database(":memory:");
+  db.run(`CREATE TABLE tick (
+    tick_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    now_ms  INTEGER NOT NULL,
+    host    TEXT    NOT NULL,
+    rules_sha TEXT
+  )`);
+  db.run(`CREATE TABLE belief (
+    belief_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tick_id   INTEGER NOT NULL,
+    stratum   INTEGER NOT NULL,
+    name      TEXT NOT NULL,
+    subject   TEXT NOT NULL,
+    value     TEXT,
+    rule_id   TEXT NOT NULL,
+    source_fact_ids TEXT NOT NULL,
+    UNIQUE (tick_id, name, subject)
+  )`);
+  db.run(`CREATE INDEX idx_belief_rule_id ON belief (rule_id)`);
+  db.run(`CREATE TABLE cfg (key TEXT PRIMARY KEY, value_int INTEGER, value_text TEXT)`);
+  return db;
+}
+
+function insertTick(db: Database, nowMs: number, host = "h1"): number {
+  db.run("INSERT INTO tick (now_ms, host) VALUES (?, ?)", [nowMs, host]);
+  return (db.query("SELECT last_insert_rowid() AS id").get() as { id: number }).id;
+}
+
+function insertBelief(
+  db: Database,
+  tickId: number,
+  name: string,
+  subject: string,
+  ruleId = "R1",
+  value: string | null = null,
+): void {
+  db.run(
+    `INSERT OR IGNORE INTO belief (tick_id, stratum, name, subject, value, rule_id, source_fact_ids)
+     VALUES (?, 1, ?, ?, ?, ?, '[]')`,
+    [tickId, name, subject, value, ruleId],
+  );
+}
+
+// ─── 1. beliefRulesManifest() — no db needed ────────────────────────────────
+
+describe("RULE_MANIFEST shape", () => {
+  it("has strata[] and rules[] arrays", () => {
+    expect(Array.isArray(RULE_MANIFEST.strata)).toBe(true);
+    expect(Array.isArray(RULE_MANIFEST.rules)).toBe(true);
+  });
+
+  it("first rule is R1 session_registered", () => {
+    expect(RULE_MANIFEST.rules[0]?.rule_id).toBe("R1");
+    expect(RULE_MANIFEST.rules[0]?.name).toBe("session_registered");
+  });
+
+  it("RULE_MANIFEST is frozen", () => {
+    expect(Object.isFrozen(RULE_MANIFEST)).toBe(true);
+  });
+});
+
+// ─── 2. beliefSummary — latest tick only ────────────────────────────────────
+
+describe("beliefSummary", () => {
+  it("excludes older-tick counts; tickId matches latest", () => {
+    const db = makeDb();
+    const t1 = insertTick(db, 1000);
+    const t2 = insertTick(db, 2000);
+    insertBelief(db, t1, "session_registered", "CTL-1/plan");
+    insertBelief(db, t2, "session_registered", "CTL-1/plan");
+    insertBelief(db, t2, "session_registered", "CTL-2/plan");
+    const result = beliefSummary(db) as { tickId: number; rows: Array<{ name: string; subjects: number; total: number }> };
+    expect(result.tickId).toBe(t2);
+    const row = result.rows.find((r) => r.name === "session_registered");
+    expect(row?.subjects).toBe(2); // only tick 2's 2 subjects
+    db.close();
+  });
+
+  it("empty belief table returns {tickId:null, rows:[]}", () => {
+    const db = makeDb();
+    const result = beliefSummary(db) as { tickId: null; rows: unknown[] };
+    expect(result.tickId).toBeNull();
+    expect(result.rows).toEqual([]);
+    db.close();
+  });
+});
+
+// ─── 3. beliefSummary — empty table no throw ─────────────────────────────────
+
+// (covered above)
+
+// ─── 4. beliefRates — counts per rule_id per tick ──────────────────────────
+
+describe("beliefRates", () => {
+  it("returns count per rule_id per tick, maxTick correct", () => {
+    const db = makeDb();
+    const t1 = insertTick(db, 1000);
+    const t2 = insertTick(db, 2000);
+    insertBelief(db, t1, "a", "s1", "R1");
+    insertBelief(db, t2, "b", "s2", "R2");
+    insertBelief(db, t2, "c", "s3", "R2");
+    const lru = new Map();
+    const result = beliefRates(db, lru) as { maxTick: number; rows: Array<{ tick_id: number; rule_id: string; count: number }> };
+    expect(result.maxTick).toBe(t2);
+    const r2rows = result.rows.filter((r) => r.rule_id === "R2");
+    const totalR2 = r2rows.reduce((s, r) => s + r.count, 0);
+    expect(totalR2).toBe(2);
+    db.close();
+  });
+
+  // ─── 5. LRU behavior ─────────────────────────────────────────────────────
+
+  it("second call with unchanged maxTick returns same object reference", () => {
+    const db = makeDb();
+    const t1 = insertTick(db, 1000);
+    insertBelief(db, t1, "a", "s1", "R1");
+    const lru = new Map();
+    const r1 = beliefRates(db, lru);
+    const r2 = beliefRates(db, lru);
+    expect(r1).toBe(r2);
+    db.close();
+  });
+
+  it("recomputes after a new tick is inserted", () => {
+    const db = makeDb();
+    const t1 = insertTick(db, 1000);
+    insertBelief(db, t1, "a", "s1", "R1");
+    const lru = new Map();
+    const r1 = beliefRates(db, lru);
+    const t2 = insertTick(db, 2000);
+    insertBelief(db, t2, "b", "s2", "R2");
+    const r2 = beliefRates(db, lru);
+    expect(r1).not.toBe(r2);
+    db.close();
+  });
+
+  it("LRU size never exceeds RATES_LRU_CAP", () => {
+    const db = makeDb();
+    const lru = new Map();
+    // Insert enough ticks to exceed the cap
+    for (let i = 0; i <= RATES_LRU_CAP + 5; i++) {
+      const t = insertTick(db, 1000 + i);
+      insertBelief(db, t, `n${i}`, `s${i}`, "R1");
+      beliefRates(db, lru);
+    }
+    expect(lru.size).toBeLessThanOrEqual(RATES_LRU_CAP);
+    db.close();
+  });
+});
+
+// ─── 6. beliefRecent — newest-first, limit, join with tick ─────────────────
+
+describe("beliefRecent", () => {
+  it("returns newest-first up to limit", () => {
+    const db = makeDb();
+    const t1 = insertTick(db, 1000);
+    const t2 = insertTick(db, 2000);
+    insertBelief(db, t1, "a", "s1");
+    insertBelief(db, t2, "b", "s2");
+    const result = beliefRecent(db, { limit: 10 }) as { rows: Array<{ name: string; ts_ms: number }> };
+    expect(result.rows.length).toBe(2);
+    // newest first
+    expect(result.rows[0]?.ts_ms).toBe(2000);
+    db.close();
+  });
+
+  it("default limit is RECENT_DEFAULT_LIMIT", () => {
+    expect(RECENT_DEFAULT_LIMIT).toBe(50);
+  });
+});
+
+// ─── 7. beliefCfg — returns cfg rows ─────────────────────────────────────
+
+describe("beliefCfg", () => {
+  it("returns cfg rows", () => {
+    const db = makeDb();
+    db.run("INSERT INTO cfg (key, value_int) VALUES ('max_parallel', 6)");
+    const result = beliefCfg(db) as { rows: Array<{ key: string; value_int: number }> };
+    expect(result.rows.some((r) => r.key === "max_parallel")).toBe(true);
+    db.close();
+  });
+
+  it("empty cfg returns rows:[]", () => {
+    const db = makeDb();
+    const result = beliefCfg(db) as { rows: unknown[] };
+    expect(result.rows).toEqual([]);
+    db.close();
+  });
+});
+
+// ─── HTTP integration tests ──────────────────────────────────────────────────
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+let tmpDir: string;
+let beliefsDbPath: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "beliefs-read-test-"));
+  const dbPath = join(tmpDir, "catalyst.db");
+  beliefsDbPath = join(tmpDir, "beliefs.db"); // does NOT exist — absent db tests
+  server = createServer({
+    port: 0,
+    startWatcher: false,
+    dbPath,
+    beliefStoreDbPath: beliefsDbPath, // explicitly absent — forces degradation
+  });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  void server?.stop(true);
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ─── 8. HTTP routes — seeded db ─────────────────────────────────────────────
+
+describe("GET /api/beliefs/* HTTP (with seeded db)", () => {
+  let seededServer: ReturnType<typeof createServer>;
+  let seededUrl: string;
+  let seededDir: string;
+
+  beforeAll(async () => {
+    seededDir = mkdtempSync(join(tmpdir(), "beliefs-seeded-"));
+    const dbPath = join(seededDir, "catalyst.db");
+    const beliefPath = join(seededDir, "beliefs.db");
+    // Seed the beliefs db via openBeliefsDb (runs migrations)
+    const schemaSpecifier = ["../../execution-core/beliefs/schema.mjs"].join("");
+    const { openBeliefsDb } = await import(schemaSpecifier) as {
+      openBeliefsDb: (opts: { path: string }) => Database;
+    };
+    const bdb = openBeliefsDb({ path: beliefPath });
+    const t1 = insertTick(bdb, 1000);
+    insertBelief(bdb, t1, "session_registered", "CTL-1/plan", "R1");
+    bdb.run("INSERT OR IGNORE INTO cfg (key, value_int) VALUES ('max_parallel', 6)");
+    bdb.close();
+
+    seededServer = createServer({
+      port: 0,
+      startWatcher: false,
+      dbPath,
+      beliefStoreDbPath: beliefPath,
+    });
+    seededUrl = `http://localhost:${seededServer.port}`;
+  });
+
+  afterAll(() => {
+    void seededServer?.stop(true);
+    try { rmSync(seededDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it("GET /api/beliefs/rules → 200 with rules manifest (no db needed)", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/rules`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = await res.json() as { rules: Array<{ rule_id: string }> };
+    expect(Array.isArray(body.rules)).toBe(true);
+    expect(body.rules.length).toBeGreaterThan(0);
+    expect(body.rules[0]?.rule_id).toBe("R1");
+  });
+
+  it("GET /api/beliefs/summary → 200 with shape {tickId, rows}", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/summary`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { tickId: number; rows: unknown[] };
+    expect("tickId" in body).toBe(true);
+    expect(Array.isArray(body.rows)).toBe(true);
+  });
+
+  it("GET /api/beliefs/rates → 200 with {maxTick, rows}", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/rates`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { maxTick: unknown; rows: unknown[] };
+    expect("maxTick" in body).toBe(true);
+    expect(Array.isArray(body.rows)).toBe(true);
+  });
+
+  it("GET /api/beliefs/recent → 200 with {rows}", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/recent`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { rows: unknown[] };
+    expect(Array.isArray(body.rows)).toBe(true);
+  });
+
+  it("GET /api/beliefs/cfg → 200 with {rows}", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/cfg`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { rows: unknown[] };
+    expect(Array.isArray(body.rows)).toBe(true);
+  });
+});
+
+// ─── 9. HTTP graceful degradation (absent db) ────────────────────────────────
+
+describe("GET /api/beliefs/* HTTP graceful degradation (absent db)", () => {
+  it("/api/beliefs/rules → manifest (needs no db)", async () => {
+    const res = await fetch(`${baseUrl}/api/beliefs/rules`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { rules: unknown[] };
+    expect(Array.isArray(body.rules)).toBe(true);
+    expect(body.rules.length).toBeGreaterThan(0);
+  });
+
+  it("/api/beliefs/summary → 200 {tickId:null,rows:[]}", async () => {
+    const res = await fetch(`${baseUrl}/api/beliefs/summary`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { tickId: null; rows: unknown[] };
+    expect(body.tickId).toBeNull();
+    expect(body.rows).toEqual([]);
+  });
+
+  it("/api/beliefs/rates → 200 {maxTick:null,rows:[]}", async () => {
+    const res = await fetch(`${baseUrl}/api/beliefs/rates`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { maxTick: null; rows: unknown[] };
+    expect(body.maxTick).toBeNull();
+    expect(body.rows).toEqual([]);
+  });
+
+  it("/api/beliefs/recent → 200 {rows:[]}", async () => {
+    const res = await fetch(`${baseUrl}/api/beliefs/recent`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { rows: unknown[] };
+    expect(body.rows).toEqual([]);
+  });
+
+  it("/api/beliefs/cfg → 200 {rows:[]}", async () => {
+    const res = await fetch(`${baseUrl}/api/beliefs/cfg`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { rows: unknown[] };
+    expect(body.rows).toEqual([]);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/beliefs-read-endpoints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/beliefs-read-endpoints.test.ts
@@ -240,6 +240,7 @@ beforeAll(() => {
     startWatcher: false,
     dbPath,
     wtDir: tmpDir,
+    annotationsDbPath: join(tmpDir, "annotations.db"), // hermetic — never the host ~/catalyst path
     beliefStoreDbPath: beliefsDbPath, // explicitly absent — forces degradation
   });
   baseUrl = `http://localhost:${server.port}`;
@@ -277,6 +278,7 @@ describe("GET /api/beliefs/* HTTP (with seeded db)", () => {
       startWatcher: false,
       dbPath,
       wtDir: seededDir,
+      annotationsDbPath: join(seededDir, "annotations.db"), // hermetic — never the host ~/catalyst path
       beliefStoreDbPath: beliefPath,
     });
     seededUrl = `http://localhost:${seededServer.port}`;

--- a/plugins/dev/scripts/orch-monitor/__tests__/beliefs-read-endpoints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/beliefs-read-endpoints.test.ts
@@ -27,7 +27,7 @@ const {
 };
 
 // Load RULE_MANIFEST via computed specifier (no static bun:sqlite chain).
-// @ts-ignore — execution-core mjs module has no .d.mts; runtime types are correct
+// @ts-expect-error — execution-core mjs module has no .d.mts; runtime types are correct
 const rulesMod = await import("../../execution-core/beliefs/rules.mjs");
 const { RULE_MANIFEST } = rulesMod as { RULE_MANIFEST: { strata: unknown[]; rules: Array<{ rule_id: string; name: string }> } };
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/beliefs-read-endpoints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/beliefs-read-endpoints.test.ts
@@ -27,6 +27,7 @@ const {
 };
 
 // Load RULE_MANIFEST via computed specifier (no static bun:sqlite chain).
+// @ts-ignore — execution-core mjs module has no .d.mts; runtime types are correct
 const rulesMod = await import("../../execution-core/beliefs/rules.mjs");
 const { RULE_MANIFEST } = rulesMod as { RULE_MANIFEST: { strata: unknown[]; rules: Array<{ rule_id: string; name: string }> } };
 
@@ -238,6 +239,7 @@ beforeAll(() => {
     port: 0,
     startWatcher: false,
     dbPath,
+    wtDir: tmpDir,
     beliefStoreDbPath: beliefsDbPath, // explicitly absent — forces degradation
   });
   baseUrl = `http://localhost:${server.port}`;
@@ -274,6 +276,7 @@ describe("GET /api/beliefs/* HTTP (with seeded db)", () => {
       port: 0,
       startWatcher: false,
       dbPath,
+      wtDir: seededDir,
       beliefStoreDbPath: beliefPath,
     });
     seededUrl = `http://localhost:${seededServer.port}`;

--- a/plugins/dev/scripts/orch-monitor/__tests__/beliefs-why-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/beliefs-why-endpoint.test.ts
@@ -10,28 +10,6 @@ import { createServer } from "../server";
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
-function makeDb(): Database {
-  const db = new Database(":memory:");
-  db.run(`CREATE TABLE tick (
-    tick_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    now_ms  INTEGER NOT NULL,
-    host    TEXT    NOT NULL,
-    rules_sha TEXT
-  )`);
-  db.run(`CREATE TABLE belief (
-    belief_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    tick_id   INTEGER NOT NULL,
-    stratum   INTEGER NOT NULL,
-    name      TEXT NOT NULL,
-    subject   TEXT NOT NULL,
-    value     TEXT,
-    rule_id   TEXT NOT NULL,
-    source_fact_ids TEXT NOT NULL,
-    UNIQUE (tick_id, name, subject)
-  )`);
-  return db;
-}
-
 async function seedBeliefDbAsync(dbPath: string): Promise<{ tickId: number }> {
   const schemaSpecifier = ["../../execution-core/beliefs/schema.mjs"].join("");
   const { openBeliefsDb } = await import(schemaSpecifier) as {

--- a/plugins/dev/scripts/orch-monitor/__tests__/beliefs-why-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/beliefs-why-endpoint.test.ts
@@ -45,6 +45,7 @@ beforeAll(async () => {
     startWatcher: false,
     dbPath,
     wtDir: seededDir,
+    annotationsDbPath: join(seededDir, "annotations.db"), // hermetic — never the host ~/catalyst path
     beliefStoreDbPath: beliefPath,
   });
   seededUrl = `http://localhost:${seededServer.port}`;
@@ -69,6 +70,7 @@ beforeAll(() => {
     startWatcher: false,
     dbPath,
     wtDir: absentDir,
+    annotationsDbPath: join(absentDir, "annotations.db"), // hermetic — never the host ~/catalyst path
     beliefStoreDbPath: join(absentDir, "nonexistent.db"), // absent
   });
   absentUrl = `http://localhost:${absentServer.port}`;

--- a/plugins/dev/scripts/orch-monitor/__tests__/beliefs-why-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/beliefs-why-endpoint.test.ts
@@ -66,6 +66,7 @@ beforeAll(async () => {
     port: 0,
     startWatcher: false,
     dbPath,
+    wtDir: seededDir,
     beliefStoreDbPath: beliefPath,
   });
   seededUrl = `http://localhost:${seededServer.port}`;
@@ -89,6 +90,7 @@ beforeAll(() => {
     port: 0,
     startWatcher: false,
     dbPath,
+    wtDir: absentDir,
     beliefStoreDbPath: join(absentDir, "nonexistent.db"), // absent
   });
   absentUrl = `http://localhost:${absentServer.port}`;

--- a/plugins/dev/scripts/orch-monitor/__tests__/beliefs-why-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/beliefs-why-endpoint.test.ts
@@ -1,0 +1,204 @@
+// CTL-1100 Phase 4: GET /api/beliefs/why?ticket=&tick=
+// HTTP integration tests; backed-by-code deep-equal test.
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeDb(): Database {
+  const db = new Database(":memory:");
+  db.run(`CREATE TABLE tick (
+    tick_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    now_ms  INTEGER NOT NULL,
+    host    TEXT    NOT NULL,
+    rules_sha TEXT
+  )`);
+  db.run(`CREATE TABLE belief (
+    belief_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tick_id   INTEGER NOT NULL,
+    stratum   INTEGER NOT NULL,
+    name      TEXT NOT NULL,
+    subject   TEXT NOT NULL,
+    value     TEXT,
+    rule_id   TEXT NOT NULL,
+    source_fact_ids TEXT NOT NULL,
+    UNIQUE (tick_id, name, subject)
+  )`);
+  return db;
+}
+
+async function seedBeliefDbAsync(dbPath: string): Promise<{ tickId: number }> {
+  const schemaSpecifier = ["../../execution-core/beliefs/schema.mjs"].join("");
+  const { openBeliefsDb } = await import(schemaSpecifier) as {
+    openBeliefsDb: (opts: { path: string }) => Database;
+  };
+  const db = openBeliefsDb({ path: dbPath });
+  db.run("INSERT INTO tick (now_ms, host) VALUES (1000, 'h1')");
+  const tickId = (db.query("SELECT last_insert_rowid() AS id").get() as { id: number }).id;
+  db.run(
+    `INSERT OR IGNORE INTO belief (tick_id, stratum, name, subject, value, rule_id, source_fact_ids)
+     VALUES (?, 1, 'session_registered', 'CTL-1234/plan', NULL, 'R1', '[]')`,
+    [tickId],
+  );
+  db.close();
+  return { tickId };
+}
+
+// ─── Seeded server ─────────────────────────────────────────────────────────
+
+let seededServer: ReturnType<typeof createServer>;
+let seededUrl: string;
+let seededDir: string;
+let seededTickId: number;
+
+beforeAll(async () => {
+  seededDir = mkdtempSync(join(tmpdir(), "beliefs-why-seeded-"));
+  const dbPath = join(seededDir, "catalyst.db");
+  const beliefPath = join(seededDir, "beliefs.db");
+  const { tickId } = await seedBeliefDbAsync(beliefPath);
+  seededTickId = tickId;
+  seededServer = createServer({
+    port: 0,
+    startWatcher: false,
+    dbPath,
+    beliefStoreDbPath: beliefPath,
+  });
+  seededUrl = `http://localhost:${seededServer.port}`;
+});
+
+afterAll(() => {
+  void seededServer?.stop(true);
+  try { rmSync(seededDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ─── Absent db server ──────────────────────────────────────────────────────
+
+let absentServer: ReturnType<typeof createServer>;
+let absentUrl: string;
+let absentDir: string;
+
+beforeAll(() => {
+  absentDir = mkdtempSync(join(tmpdir(), "beliefs-why-absent-"));
+  const dbPath = join(absentDir, "catalyst.db");
+  absentServer = createServer({
+    port: 0,
+    startWatcher: false,
+    dbPath,
+    beliefStoreDbPath: join(absentDir, "nonexistent.db"), // absent
+  });
+  absentUrl = `http://localhost:${absentServer.port}`;
+});
+
+afterAll(() => {
+  void absentServer?.stop(true);
+  try { rmSync(absentDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ─── 1. Seeded belief → 200 with full trace ─────────────────────────────────
+
+describe("GET /api/beliefs/why — seeded db", () => {
+  it("seeded belief → 200, ticket/tickId/beliefs present", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/why?ticket=CTL-1234`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ticket: string; tickId: number; beliefs: Array<{ rule_id: string; subject: string; name: string; sources: unknown[] }> };
+    expect(body.ticket).toBe("CTL-1234");
+    expect(body.tickId).not.toBeNull();
+    expect(body.beliefs.length).toBeGreaterThan(0);
+    expect(body.beliefs[0]?.rule_id).toBe("R1");
+    expect(body.beliefs[0]?.subject).toBe("CTL-1234/plan");
+    expect(body.beliefs[0]?.name).toBe("session_registered");
+    expect(Array.isArray(body.beliefs[0]?.sources)).toBe(true);
+  });
+
+  // ─── 2. Explicit tick= honored ───────────────────────────────────────────
+
+  it("explicit &tick= honored, correct tickId returned", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/why?ticket=CTL-1234&tick=${seededTickId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { tickId: number; beliefs: unknown[] };
+    expect(body.tickId).toBe(seededTickId);
+    expect(body.beliefs.length).toBe(1);
+  });
+
+  it("&tick=999999 (no rows) → 200 beliefs:[] (not 404)", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/why?ticket=CTL-1234&tick=999999`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { beliefs: unknown[] };
+    expect(body.beliefs).toEqual([]);
+  });
+
+  // ─── 3. Unknown well-formed ticket → 200 empty ───────────────────────────
+
+  it("unknown well-formed ticket → 200 {ticket, tickId:null, beliefs:[]}", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/why?ticket=ZZZ-999999`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ticket: string; tickId: null; beliefs: unknown[] };
+    expect(body.ticket).toBe("ZZZ-999999");
+    expect(body.tickId).toBeNull();
+    expect(body.beliefs).toEqual([]);
+  });
+
+  // ─── 4. Input validation → 400 ───────────────────────────────────────────
+
+  it("missing ticket → 400", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/why`);
+    expect(res.status).toBe(400);
+  });
+
+  it("not-a-ticket (no dash) → 400", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/why?ticket=notavalidticket`);
+    expect(res.status).toBe(400);
+  });
+
+  it("just prefix (CTL only, no number) → 400", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/why?ticket=CTL`);
+    expect(res.status).toBe(400);
+  });
+
+  it("encoded path traversal ..%2F.. → 400", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/why?ticket=..%2F..`);
+    expect(res.status).toBe(400);
+  });
+
+  it("non-numeric tick → 400", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/why?ticket=CTL-1234&tick=abc`);
+    expect(res.status).toBe(400);
+  });
+
+  // ─── 5. Absent db → 200 empty, no 500 ────────────────────────────────────
+
+  it("absent beliefs.db → 200 {ticket, tickId:null, beliefs:[]}", async () => {
+    const res = await fetch(`${absentUrl}/api/beliefs/why?ticket=CTL-1234`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ticket: string; tickId: null; beliefs: unknown[] };
+    expect(body.ticket).toBe("CTL-1234");
+    expect(body.tickId).toBeNull();
+    expect(body.beliefs).toEqual([]);
+  });
+
+  // ─── 6. Backed-by-code deep-equal ────────────────────────────────────────
+
+  it("HTTP body deep-equals traceTicket() on same db", async () => {
+    const schemaSpecifier = ["../../execution-core/beliefs/schema.mjs"].join("");
+    const { openBeliefsDb } = await import(schemaSpecifier) as {
+      openBeliefsDb: (opts: { path: string }) => Database;
+    };
+    const beliefPath = join(seededDir, "beliefs.db");
+    const db = openBeliefsDb({ path: beliefPath });
+    const whySpecifier = ["../../execution-core/beliefs/why.mjs"].join("");
+    const { traceTicket } = await import(whySpecifier) as {
+      traceTicket: (db: Database, ticket: string, opts?: { tickId?: number }) => unknown;
+    };
+    const expected = JSON.parse(JSON.stringify(traceTicket(db, "CTL-1234")));
+    db.close();
+
+    const res = await fetch(`${seededUrl}/api/beliefs/why?ticket=CTL-1234`);
+    const actual = await res.json();
+    expect(actual).toEqual(expected);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/fsm-descriptor-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/fsm-descriptor-endpoint.test.ts
@@ -1,0 +1,115 @@
+// CTL-1100 Phase 2: GET /api/fsm/descriptor — HTTP integration tests.
+// Uses createServer({port:0,startWatcher:false}) + fetch.
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+import { createHash } from "crypto";
+import { readFileSync } from "fs";
+import {
+  PHASES,
+  NEXT_PHASE,
+  DESCRIPTOR_PATH,
+  ANCILLARY_PHASES,
+  TERMINAL_PHASE,
+  NEW_WORK_ENTRY_PHASE,
+  REMEDIATE_CYCLE_CAP,
+} from "../../lib/workflow-descriptor.mjs";
+import { REVIVE_BUDGET } from "../../lib/phase-fsm.mjs";
+import { enumerateTransitions } from "../../lib/fsm-descriptor.mjs";
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "fsm-descriptor-test-"));
+  const dbPath = join(tmpDir, "catalyst.db");
+  server = createServer({ port: 0, startWatcher: false, dbPath });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  void server?.stop(true);
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ─── 6. GET /api/fsm/descriptor returns 200 + full shape ────────────────────
+
+describe("GET /api/fsm/descriptor", () => {
+  it("returns 200 JSON with the correct shape", async () => {
+    const res = await fetch(`${baseUrl}/api/fsm/descriptor`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+  });
+
+  it("phases deep-equals PHASES", async () => {
+    const body = await (await fetch(`${baseUrl}/api/fsm/descriptor`)).json() as Record<string, unknown>;
+    expect(body.phases).toEqual(PHASES);
+  });
+
+  it("terminalPhase, entryPhase, remediateCycleCap, reviveBudget are correct", async () => {
+    const body = await (await fetch(`${baseUrl}/api/fsm/descriptor`)).json() as Record<string, unknown>;
+    expect(body.terminalPhase).toBe(TERMINAL_PHASE);
+    expect(body.entryPhase).toBe(NEW_WORK_ENTRY_PHASE);
+    expect(body.remediateCycleCap).toBe(REMEDIATE_CYCLE_CAP);
+    expect(body.reviveBudget).toBe(REVIVE_BUDGET);
+    expect(body.ancillaryPhases).toEqual(ANCILLARY_PHASES);
+    expect(typeof body.nonPreemptable).toBe("object");
+    expect(typeof body.stageRank).toBe("object");
+    expect(typeof body.nextPhase).toBe("object");
+    expect(typeof body.cycles).toBe("object");
+  });
+
+  it("descriptorSha is a 64-char hex string matching raw file bytes", async () => {
+    const body = await (await fetch(`${baseUrl}/api/fsm/descriptor`)).json() as Record<string, unknown>;
+    expect(typeof body.descriptorSha).toBe("string");
+    expect(body.descriptorSha as string).toMatch(/^[0-9a-f]{64}$/);
+    const expected = createHash("sha256").update(readFileSync(DESCRIPTOR_PATH)).digest("hex");
+    expect(body.descriptorSha).toBe(expected);
+  });
+
+  it("rulesSha field is present (string or null)", async () => {
+    const body = await (await fetch(`${baseUrl}/api/fsm/descriptor`)).json() as Record<string, unknown>;
+    expect("rulesSha" in body).toBe(true);
+    // null or a hex string are both valid
+    if (body.rulesSha !== null) {
+      expect(typeof body.rulesSha).toBe("string");
+    }
+  });
+
+  it("transitions[] contains all NEXT_PHASE advance edges", async () => {
+    const body = await (await fetch(`${baseUrl}/api/fsm/descriptor`)).json() as {
+      transitions: Array<{ from: string; to: string; kind: string; classification: string }>;
+    };
+    for (const [from, to] of Object.entries(NEXT_PHASE)) {
+      const edge = body.transitions.find((t) => t.from === from && t.to === to && t.kind === "advance");
+      expect(edge).toBeDefined();
+    }
+  });
+
+  it("has verify->remediate and remediate->verify in transitions", async () => {
+    const body = await (await fetch(`${baseUrl}/api/fsm/descriptor`)).json() as {
+      transitions: Array<{ from: string; to: string }>;
+    };
+    expect(body.transitions.some((t) => t.from === "verify" && t.to === "remediate")).toBe(true);
+    expect(body.transitions.some((t) => t.from === "remediate" && t.to === "verify")).toBe(true);
+  });
+
+  it("at least one transition is classification:'unclassified'", async () => {
+    const body = await (await fetch(`${baseUrl}/api/fsm/descriptor`)).json() as {
+      transitions: Array<{ classification: string }>;
+    };
+    expect(body.transitions.some((t) => t.classification === "unclassified")).toBe(true);
+  });
+
+  it("transitions count matches enumerateTransitions() output", async () => {
+    const body = await (await fetch(`${baseUrl}/api/fsm/descriptor`)).json() as {
+      transitions: unknown[];
+    };
+    const expected = enumerateTransitions();
+    expect(body.transitions.length).toBe(expected.length);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/fsm-descriptor-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/fsm-descriptor-endpoint.test.ts
@@ -27,7 +27,7 @@ let tmpDir: string;
 beforeAll(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "fsm-descriptor-test-"));
   const dbPath = join(tmpDir, "catalyst.db");
-  server = createServer({ port: 0, startWatcher: false, dbPath });
+  server = createServer({ port: 0, startWatcher: false, dbPath, wtDir: tmpDir });
   baseUrl = `http://localhost:${server.port}`;
 });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-fsm-descriptor.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-fsm-descriptor.contract.test.ts
@@ -32,7 +32,7 @@ let tmpDir: string;
 
 beforeAll(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "gov-fsm-contract-"));
-  server = createServer({ port: 0, startWatcher: false, dbPath: join(tmpDir, "catalyst.db"), wtDir: tmpDir });
+  server = createServer({ port: 0, startWatcher: false, dbPath: join(tmpDir, "catalyst.db"), wtDir: tmpDir, annotationsDbPath: join(tmpDir, "annotations.db") });
   baseUrl = `http://localhost:${server.port}`;
 });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-fsm-descriptor.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-fsm-descriptor.contract.test.ts
@@ -50,7 +50,7 @@ async function fetchDescriptor(): Promise<Record<string, unknown>> {
 }
 
 function jsonNorm<T>(v: T): T {
-  return JSON.parse(JSON.stringify(v));
+  return JSON.parse(JSON.stringify(v)) as T;
 }
 
 // ─── 1. descriptorSha matches sha256(bytes of DESCRIPTOR_PATH) ──────────────

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-fsm-descriptor.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-fsm-descriptor.contract.test.ts
@@ -1,0 +1,155 @@
+// governance-fsm-descriptor.contract.test.ts — CTL-1100 Phase 7
+// Contract: the /api/fsm/descriptor HTTP body is derived from the exact same
+// daemon modules the contract test imports. A hand-copied phase list or a
+// stale workflow.default.json must turn this suite red.
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createHash } from "crypto";
+import { createServer } from "../server";
+
+// Import the exact daemon modules the endpoint serves from.
+import {
+  PHASES,
+  NEXT_PHASE,
+  DESCRIPTOR_PATH,
+  STAGE_RANK,
+  TERMINAL_PHASE,
+  NEW_WORK_ENTRY_PHASE,
+  NON_PREEMPTABLE_PHASES,
+  ANCILLARY_PHASES,
+  REMEDIATE_CYCLE_CAP,
+} from "../../lib/workflow-descriptor.mjs";
+import { REVIVE_BUDGET } from "../../lib/phase-fsm.mjs";
+import { enumerateTransitions } from "../../lib/fsm-descriptor.mjs";
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "gov-fsm-contract-"));
+  server = createServer({ port: 0, startWatcher: false, dbPath: join(tmpDir, "catalyst.db"), wtDir: tmpDir });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  void server?.stop(true);
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+async function fetchDescriptor(): Promise<Record<string, unknown>> {
+  const res = await fetch(`${baseUrl}/api/fsm/descriptor`);
+  expect(res.status).toBe(200);
+  return res.json() as Promise<Record<string, unknown>>;
+}
+
+function jsonNorm<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v));
+}
+
+// ─── 1. descriptorSha matches sha256(bytes of DESCRIPTOR_PATH) ──────────────
+
+describe("GET /api/fsm/descriptor — descriptorSha contract", () => {
+  it("descriptorSha equals sha256 of workflow-descriptor.mjs bytes", async () => {
+    const body = await fetchDescriptor();
+    const expected = createHash("sha256")
+      .update(readFileSync(DESCRIPTOR_PATH))
+      .digest("hex");
+    expect(body.descriptorSha).toBe(expected);
+  });
+});
+
+// ─── 2. Scalar fields deep-equal live daemon exports ─────────────────────────
+
+describe("GET /api/fsm/descriptor — scalar field contracts", () => {
+  it("phases deep-equals PHASES", async () => {
+    const body = await fetchDescriptor();
+    expect(body.phases).toEqual(jsonNorm(PHASES));
+  });
+
+  it("stageRank deep-equals STAGE_RANK", async () => {
+    const body = await fetchDescriptor();
+    // Key-order-sensitive: STAGE_RANK is an object keyed by phase name.
+    expect(body.stageRank).toEqual(jsonNorm(STAGE_RANK));
+  });
+
+  it("nextPhase map deep-equals NEXT_PHASE", async () => {
+    const body = await fetchDescriptor();
+    expect(body.nextPhase).toEqual(jsonNorm(NEXT_PHASE));
+  });
+
+  it("terminalPhase equals TERMINAL_PHASE", async () => {
+    const body = await fetchDescriptor();
+    expect(body.terminalPhase).toBe(TERMINAL_PHASE);
+  });
+
+  it("entryPhase equals NEW_WORK_ENTRY_PHASE", async () => {
+    const body = await fetchDescriptor();
+    expect(body.entryPhase).toBe(NEW_WORK_ENTRY_PHASE);
+  });
+
+  it("nonPreemptable deep-equals [...NON_PREEMPTABLE_PHASES] (Set spread to array)", async () => {
+    const body = await fetchDescriptor();
+    // NON_PREEMPTABLE_PHASES is a Set; the endpoint spreads it to an array.
+    expect(body.nonPreemptable).toEqual([...NON_PREEMPTABLE_PHASES]);
+  });
+
+  it("ancillaryPhases deep-equals ANCILLARY_PHASES", async () => {
+    const body = await fetchDescriptor();
+    expect(body.ancillaryPhases).toEqual(jsonNorm(ANCILLARY_PHASES));
+  });
+
+  it("remediateCycleCap equals REMEDIATE_CYCLE_CAP", async () => {
+    const body = await fetchDescriptor();
+    expect(body.remediateCycleCap).toBe(REMEDIATE_CYCLE_CAP);
+  });
+
+  it("reviveBudget equals REVIVE_BUDGET", async () => {
+    const body = await fetchDescriptor();
+    expect(body.reviveBudget).toBe(REVIVE_BUDGET);
+  });
+});
+
+// ─── 3. Edge totality — enumerateTransitions() produces the expected set ────
+
+describe("GET /api/fsm/descriptor — edge totality contract", () => {
+  it("transitions includes every edge from enumerateTransitions()", async () => {
+    const body = await fetchDescriptor();
+    const bodyTransitions = body.transitions as Array<{ from: string; to: string; classification: string }>;
+
+    const expectedEdges = new Set(
+      enumerateTransitions().map((t: { from: string; to: string }) => `${t.from}->${t.to}`)
+    );
+    const bodyEdges = new Set(bodyTransitions.map((t) => `${t.from}->${t.to}`));
+
+    // Every expected edge must appear in the body (no dropped edges).
+    for (const edge of expectedEdges) {
+      expect(bodyEdges.has(edge)).toBe(true);
+    }
+    // No extra edges should appear.
+    expect(bodyEdges.size).toBe(expectedEdges.size);
+  });
+
+  it("every uncurated edge has classification:'unclassified'", async () => {
+    const body = await fetchDescriptor();
+    const bodyTransitions = body.transitions as Array<{ from: string; to: string; classification: string; guardText: string | null }>;
+
+    // Edges with no guard in fsm-guards.json must be unclassified, not dropped.
+    const uncurated = bodyTransitions.filter((t) => t.guardText === null);
+    for (const t of uncurated) {
+      expect(t.classification).toBe("unclassified");
+    }
+  });
+
+  it("transitions array is non-empty (at least the happy-path edges exist)", async () => {
+    const body = await fetchDescriptor();
+    const transitions = body.transitions as unknown[];
+    expect(transitions.length).toBeGreaterThan(0);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-janitor-exclusion.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-janitor-exclusion.contract.test.ts
@@ -1,0 +1,181 @@
+// governance-janitor-exclusion.contract.test.ts — CTL-1100 Phase 7
+//
+// Contract: isGovernanceEvent(name) must EXCLUDE every reap/janitor event type
+// that could pollute a governance feed, and INCLUDE only the legitimate per-step
+// phase lifecycle events.
+//
+// Key regression guard: a naive `startsWith('phase.')` allowlist would wrongly
+// admit `phase.predecessor.reap-requested` and `phase.terminal.reap-complete`
+// (both start with "phase."). The two-step gate (blocklist + per-step prefix
+// allowlist) in governance-reader.mjs prevents this. This test suite FAILS if
+// the predicate is simplified to a prefix-only check.
+
+import { describe, it, expect } from "bun:test";
+import {
+  isGovernanceEvent,
+  GOVERNANCE_EVENT_PREFIXES,
+} from "../lib/governance-reader.mjs";
+// @ts-ignore — execution-core mjs modules have no .d.mts; runtime types are correct
+import { JANITOR_EVENT_TYPES } from "../../execution-core/janitor-event-types.mjs";
+// @ts-ignore
+import { REAP_INTENT_TYPES } from "../../execution-core/reap-intent.mjs";
+
+// ─── Build the full reap vocabulary ──────────────────────────────────────────
+//
+// REAP_TYPES = the complete set of event names that must NEVER pass
+// isGovernanceEvent(). This includes:
+//   - All entries from REAP_INTENT_TYPES (the closed vocabulary the reaper/janitor
+//     emit): phase.*.reap-requested, worktree.*, orphans.*, janitor.*, etc.
+//   - The reaper re-emit suffixes: *.reap-complete, *.reap-failed (from reaper.mjs
+//     rethrow path that re-emits after handling).
+//   - The JANITOR_EVENT_TYPES (leaf module, already spread into REAP_INTENT_TYPES,
+//     but imported directly for explicit documentation of the J1/J2/J3 types).
+
+// Build derived complete + *.reap-complete siblings.
+const REAP_TYPES: ReadonlyArray<string> = [
+  ...REAP_INTENT_TYPES,
+  // reaper.mjs re-emits these after handling (reap-requested → reap-complete/failed)
+  "phase.yield.reap-complete",
+  "phase.predecessor.reap-complete",
+  "phase.supersede.reap-complete",
+  "phase.revive.reap-complete",
+  "phase.abort.reap-complete",
+  "phase.reclaim.reap-complete",
+  "phase.reconcile.reap-complete",
+  "phase.terminal.reap-complete",
+  "worktree.presweep.reap-complete",
+  "phase.yield.reap-failed",
+  "phase.predecessor.reap-failed",
+  "phase.terminal.reap-failed",
+  "orphans.reap-complete",
+  "orphans.reap-failed",
+];
+
+// ─── 1. Every JANITOR_EVENT_TYPE → false ─────────────────────────────────────
+
+describe("isGovernanceEvent — janitor types are excluded", () => {
+  for (const name of JANITOR_EVENT_TYPES) {
+    it(`isGovernanceEvent("${name}") === false`, () => {
+      expect(isGovernanceEvent(name)).toBe(false);
+    });
+  }
+});
+
+// ─── 2. Every REAP_INTENT_TYPE → false ──────────────────────────────────────
+
+describe("isGovernanceEvent — reap-intent types are excluded", () => {
+  for (const name of REAP_INTENT_TYPES) {
+    it(`isGovernanceEvent("${name}") === false`, () => {
+      expect(isGovernanceEvent(name)).toBe(false);
+    });
+  }
+});
+
+// ─── 3. All *.reap-complete / *.reap-failed siblings → false ────────────────
+
+describe("isGovernanceEvent — reap-complete/reap-failed siblings are excluded", () => {
+  for (const name of REAP_TYPES) {
+    if (name.endsWith("-complete") || name.endsWith("-failed")) {
+      it(`isGovernanceEvent("${name}") === false`, () => {
+        expect(isGovernanceEvent(name)).toBe(false);
+      });
+    }
+  }
+});
+
+// ─── 4. Explicit regression assertions ───────────────────────────────────────
+//
+// These two names start with "phase." — a naive `startsWith('phase.')` allowlist
+// would wrongly admit them into a governance feed. Document them explicitly so any
+// future simplification of isGovernanceEvent immediately fails this test.
+
+describe("isGovernanceEvent — regression: phase.*.reap names start with 'phase.' but must be excluded", () => {
+  it("phase.predecessor.reap-requested → false (starts with 'phase.' but is a reap intent)", () => {
+    // REGRESSION: `startsWith('phase.')` alone would return true here.
+    // The blocklist gate (name.includes('reap')) must catch it first.
+    expect(isGovernanceEvent("phase.predecessor.reap-requested")).toBe(false);
+  });
+
+  it("phase.terminal.reap-complete → false (starts with 'phase.' but is a reap re-emit)", () => {
+    // REGRESSION: `startsWith('phase.')` alone would return true here.
+    expect(isGovernanceEvent("phase.terminal.reap-complete")).toBe(false);
+  });
+
+  it("janitor.would.reap-request → false (would. prefix AND reap both block it)", () => {
+    expect(isGovernanceEvent("janitor.would.reap-request")).toBe(false);
+  });
+
+  it("phase.predecessor.reap-requested does NOT start with any GOVERNANCE_EVENT_PREFIX", () => {
+    // Document: none of the governance prefixes matches the predecessor/terminal sub-steps.
+    const admitted = GOVERNANCE_EVENT_PREFIXES.some((p) =>
+      "phase.predecessor.reap-requested".startsWith(p)
+    );
+    expect(admitted).toBe(false);
+  });
+});
+
+// ─── 5. Positive controls: real governance events → true ─────────────────────
+
+describe("isGovernanceEvent — positive controls (governance events are admitted)", () => {
+  const POSITIVE_CONTROLS = [
+    "phase.implement.complete.CTL-1234",
+    "phase.implement.started.CTL-1234",
+    "phase.verify.complete.CTL-9999",
+    "phase.plan.started.CTL-0001",
+    "phase.monitor-deploy.complete.CTL-7777",
+    "phase.remediate.started.CTL-8888",
+    "phase.teardown.complete.CTL-0002",
+    "phase.triage.started.CTL-3333",
+    "phase.review.complete.CTL-4444",
+    "phase.pr.started.CTL-5555",
+    "phase.monitor-merge.complete.CTL-6666",
+    "phase.research.started.CTL-1111",
+  ];
+
+  for (const name of POSITIVE_CONTROLS) {
+    it(`isGovernanceEvent("${name}") === true`, () => {
+      expect(isGovernanceEvent(name)).toBe(true);
+    });
+  }
+});
+
+// ─── 6. advance.held → false (not in allowlist) ─────────────────────────────
+
+describe("isGovernanceEvent — advance.held is NOT a governance event", () => {
+  it("advance.held.CTL-1234 → false (not in GOVERNANCE_EVENT_PREFIXES)", () => {
+    // advance.held is emitted by the scheduler but is NOT a per-step phase event.
+    expect(isGovernanceEvent("advance.held.CTL-1234")).toBe(false);
+  });
+});
+
+// ─── 7. Filter mixed synthetic stream — zero survivors match /reap|would\.reap/ ──
+
+describe("isGovernanceEvent — mixed stream filter", () => {
+  it("filtering a mixed stream yields zero events matching /reap|would\\.reap/", () => {
+    const mixedStream = [
+      "phase.implement.complete.CTL-9001",
+      "phase.predecessor.reap-requested", // reap — must be filtered out
+      "phase.terminal.reap-complete",     // reap re-emit — must be filtered out
+      "janitor.would.reap-request",       // janitor shadow — must be filtered out
+      "janitor.stall.cleared",            // janitor enforce — must be filtered out
+      "worktree.presweep.reap-requested", // worktree reap — must be filtered out
+      "orphans.reap-requested",           // orphan reap — must be filtered out
+      "phase.verify.complete.CTL-9001",   // governance — admitted
+      "advance.held.CTL-9001",            // not governance — filtered out
+      "phase.review.started.CTL-9001",    // governance — admitted
+    ];
+
+    const survivors = mixedStream.filter((name) => isGovernanceEvent(name));
+
+    // Zero survivors must match the reap/would.reap pattern.
+    const reapSurvivors = survivors.filter((name) => /reap|would\.reap/.test(name));
+    expect(reapSurvivors).toEqual([]);
+
+    // Only the legitimate governance events survive.
+    expect(survivors).toEqual([
+      "phase.implement.complete.CTL-9001",
+      "phase.verify.complete.CTL-9001",
+      "phase.review.started.CTL-9001",
+    ]);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-janitor-exclusion.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-janitor-exclusion.contract.test.ts
@@ -15,9 +15,9 @@ import {
   isGovernanceEvent,
   GOVERNANCE_EVENT_PREFIXES,
 } from "../lib/governance-reader.mjs";
-// @ts-ignore — execution-core mjs modules have no .d.mts; runtime types are correct
+// @ts-expect-error — execution-core mjs modules have no .d.mts; runtime types are correct
 import { JANITOR_EVENT_TYPES } from "../../execution-core/janitor-event-types.mjs";
-// @ts-ignore
+// @ts-expect-error — execution-core mjs modules have no .d.mts; runtime types are correct
 import { REAP_INTENT_TYPES } from "../../execution-core/reap-intent.mjs";
 
 // ─── Build the full reap vocabulary ──────────────────────────────────────────

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-journey.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-journey.contract.test.ts
@@ -1,0 +1,136 @@
+// governance-journey.contract.test.ts — CTL-1100 Phase 7
+// Contract: GET /api/journey/:ticket gates deep-equal deriveAdvancement()
+// computed from the same readers. Mutating verify.json between fetches must
+// change body.gates (proves recomputation, not cached storage).
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+// @ts-ignore — execution-core mjs modules have no .d.mts; runtime types are correct
+import { readPhaseSignals, deriveAdvancement } from "../../execution-core/scheduler.mjs";
+// @ts-ignore
+import { readVerifyVerdict } from "../../execution-core/work-done-probes.mjs";
+
+// ─── Setup: seed a temp orch dir with phase signals + verify artifact ─────────
+
+let tmpDir: string;
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+const TICKET = "CTL-5555";
+
+function workerDir(): string {
+  return join(tmpDir, "workers", TICKET);
+}
+
+function writeSignal(phase: string, status: string) {
+  writeFileSync(
+    join(workerDir(), `phase-${phase}.json`),
+    JSON.stringify({ status, bg_job_id: "bg_test", updatedAt: new Date().toISOString() }),
+  );
+}
+
+function writeVerify(regressionRisk: number, findings: Array<{ severity: string; title: string }> = []) {
+  writeFileSync(
+    join(workerDir(), "verify.json"),
+    JSON.stringify({
+      regression_risk: regressionRisk,
+      findings,
+      tests_attempted: true,
+      generatedAt: new Date().toISOString(),
+    }),
+  );
+}
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "gov-journey-contract-"));
+  mkdirSync(workerDir(), { recursive: true });
+
+  // Seed: implement done → verify done (no high findings → should advance to review).
+  writeSignal("implement", "done");
+  writeSignal("verify", "done");
+  writeVerify(0, []); // regression_risk < 5, no high findings → "pass"
+
+  server = createServer({
+    port: 0,
+    startWatcher: false,
+    dbPath: join(tmpDir, "catalyst.db"),
+    wtDir: tmpDir,
+  });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  void server?.stop(true);
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function jsonNorm<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v));
+}
+
+// ─── 1. gates deep-equals deriveAdvancement() on same data ──────────────────
+
+describe("GET /api/journey/:ticket — gates contract", () => {
+  it("body.gates.nextPhase deep-equals deriveAdvancement(signals, {verifyVerdict, remediateCycleCount})", async () => {
+    const res = await fetch(`${baseUrl}/api/journey/${TICKET}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      ticket: string;
+      gates: { nextPhase: unknown; checklist: unknown[] };
+      remediateCycles: number;
+    };
+
+    // Re-derive using the exact same daemon functions.
+    const signals = readPhaseSignals(tmpDir, TICKET);
+    const verdict = readVerifyVerdict({ ticket: TICKET, orchDir: tmpDir });
+    const expectedNext = deriveAdvancement(signals, {
+      verifyVerdict: verdict ?? undefined,
+      remediateCycleCount: 0,
+    });
+
+    expect(body.gates.nextPhase).toEqual(jsonNorm(expectedNext));
+  });
+
+  it("body.gates.checklist has all phases as objects with phase/signalStatus/satisfied", async () => {
+    const res = await fetch(`${baseUrl}/api/journey/${TICKET}`);
+    const body = await res.json() as { gates: { checklist: Array<{ phase: string; signalStatus: string | null; satisfied: boolean }> } };
+
+    expect(Array.isArray(body.gates.checklist)).toBe(true);
+    expect(body.gates.checklist.length).toBeGreaterThan(0);
+    for (const item of body.gates.checklist) {
+      expect(typeof item.phase).toBe("string");
+      expect("signalStatus" in item).toBe(true);
+      expect(typeof item.satisfied).toBe("boolean");
+    }
+  });
+});
+
+// ─── 2. Mutation of verify.json between fetches changes body.gates ───────────
+
+describe("GET /api/journey/:ticket — recomputation contract (not cached)", () => {
+  it("changing verify.json to high-finding changes nextPhase to remediate", async () => {
+    // First fetch: pass verdict → expect review (or further).
+    const before = await fetch(`${baseUrl}/api/journey/${TICKET}`);
+    const bodyBefore = await before.json() as { gates: { nextPhase: unknown } };
+    const nextBefore = bodyBefore.gates.nextPhase;
+
+    // Mutate: inject a high-severity finding → "fail" verdict → remediate.
+    writeVerify(0, [{ severity: "high", title: "regression detected" }]);
+
+    // Second fetch: must reflect the mutation (proves recomputation).
+    const after = await fetch(`${baseUrl}/api/journey/${TICKET}`);
+    const bodyAfter = await after.json() as { gates: { nextPhase: unknown } };
+    const nextAfter = bodyAfter.gates.nextPhase;
+
+    // Restore to pass state for other tests.
+    writeVerify(0, []);
+
+    // The nextPhase must have changed (pass → fail diverts to remediate).
+    expect(nextAfter).not.toEqual(nextBefore);
+    expect(nextAfter).toBe("remediate");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-journey.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-journey.contract.test.ts
@@ -8,10 +8,24 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { createServer } from "../server";
-// @ts-ignore — execution-core mjs modules have no .d.mts; runtime types are correct
-import { readPhaseSignals, deriveAdvancement } from "../../execution-core/scheduler.mjs";
-// @ts-ignore
-import { readVerifyVerdict } from "../../execution-core/work-done-probes.mjs";
+// @ts-expect-error — execution-core mjs modules have no .d.mts; runtime types are correct
+import * as schedulerMod from "../../execution-core/scheduler.mjs";
+// @ts-expect-error — execution-core mjs modules have no .d.mts; runtime types are correct
+import * as workDoneProbesMod from "../../execution-core/work-done-probes.mjs";
+
+// Re-type the untyped .mjs exports at the boundary so call sites stay type-safe.
+const readPhaseSignals = (schedulerMod as {
+  readPhaseSignals: (orchDir: string, ticket: string) => unknown;
+}).readPhaseSignals;
+const deriveAdvancement = (schedulerMod as {
+  deriveAdvancement: (
+    signals: unknown,
+    opts: { verifyVerdict?: unknown; remediateCycleCount?: number },
+  ) => unknown;
+}).deriveAdvancement;
+const readVerifyVerdict = (workDoneProbesMod as {
+  readVerifyVerdict: (opts: { ticket: string; orchDir: string }) => unknown;
+}).readVerifyVerdict;
 
 // ─── Setup: seed a temp orch dir with phase signals + verify artifact ─────────
 
@@ -69,7 +83,7 @@ afterAll(() => {
 // ─── helpers ────────────────────────────────────────────────────────────────
 
 function jsonNorm<T>(v: T): T {
-  return JSON.parse(JSON.stringify(v));
+  return JSON.parse(JSON.stringify(v)) as T;
 }
 
 // ─── 1. gates deep-equals deriveAdvancement() on same data ──────────────────

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-journey.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-journey.contract.test.ts
@@ -71,6 +71,7 @@ beforeAll(() => {
     startWatcher: false,
     dbPath: join(tmpDir, "catalyst.db"),
     wtDir: tmpDir,
+    annotationsDbPath: join(tmpDir, "annotations.db"), // hermetic — never the host ~/catalyst path
   });
   baseUrl = `http://localhost:${server.port}`;
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-reader.test.ts
@@ -1,0 +1,230 @@
+// CTL-1100 Phase 1: governance-reader.mjs — openBeliefsDbRO, withBeliefsDbRO,
+// defaultBeliefsDbPath, GOVERNANCE_EVENT_PREFIXES, isGovernanceEvent.
+//
+// Tests drive against a real file-based bun:sqlite db (no server started).
+// Modeled on beliefs-stream.test.ts pattern: dynamic import via computed
+// specifier so bun:sqlite never appears as a static import in test infra.
+
+import { describe, it, expect, afterAll } from "bun:test";
+import { Database } from "bun:sqlite";
+import { tmpdir, homedir } from "os";
+import { join } from "path";
+import { mkdtempSync, rmSync, existsSync } from "fs";
+
+// Load governance-reader via computed specifier (mirrors server.ts discipline).
+const govMod = await import("../lib/governance-reader.mjs");
+const {
+  openBeliefsDbRO,
+  withBeliefsDbRO,
+  defaultBeliefsDbPath,
+  isGovernanceEvent,
+} = govMod as {
+  openBeliefsDbRO: (p: string) => Promise<InstanceType<typeof Database> | null>;
+  withBeliefsDbRO: <T>(p: string, fn: (db: InstanceType<typeof Database>) => T, fallback: T) => Promise<T>;
+  defaultBeliefsDbPath: (env?: Record<string, string | undefined>) => string;
+  isGovernanceEvent: (name: string) => boolean;
+};
+
+// Minimal DDL to create a writable seed db for RO tests.
+function seedDb(path: string): InstanceType<typeof Database> {
+  const db = new Database(path);
+  db.run(`CREATE TABLE IF NOT EXISTS tick (
+    tick_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    now_ms  INTEGER NOT NULL,
+    host    TEXT    NOT NULL
+  )`);
+  db.run(`CREATE TABLE IF NOT EXISTS belief (
+    belief_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tick_id   INTEGER NOT NULL,
+    stratum   INTEGER NOT NULL,
+    name      TEXT NOT NULL,
+    subject   TEXT NOT NULL,
+    value     TEXT,
+    rule_id   TEXT NOT NULL,
+    source_fact_ids TEXT NOT NULL,
+    UNIQUE (tick_id, name, subject)
+  )`);
+  db.close();
+  return db; // already closed; caller reopens RO
+}
+
+const tmpDirs: string[] = [];
+function mkTmp() {
+  const d = mkdtempSync(join(tmpdir(), "gov-reader-test-"));
+  tmpDirs.push(d);
+  return d;
+}
+
+afterAll(() => {
+  for (const d of tmpDirs) {
+    try { rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+// ─── 1. openBeliefsDbRO returns null (never throws) when file absent ───────
+
+describe("openBeliefsDbRO — absent file", () => {
+  it("returns null for a path in a fresh tmp dir", async () => {
+    const dir = mkTmp();
+    const absent = join(dir, "nonexistent.db");
+    const result = await openBeliefsDbRO(absent);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── 2. Opens existing db read-only — write attempt throws ─────────────────
+
+describe("openBeliefsDbRO — existing db is read-only", () => {
+  it("opens the db and rejects writes", async () => {
+    const dir = mkTmp();
+    const dbPath = join(dir, "seed.db");
+    seedDb(dbPath);
+
+    const db = await openBeliefsDbRO(dbPath);
+    expect(db).not.toBeNull();
+    if (db == null) return;
+    expect(() => {
+      db.run("INSERT INTO tick (now_ms, host) VALUES (1, 'test')");
+    }).toThrow();
+    db.close();
+  });
+});
+
+// ─── 3. create:false does NOT materialize a missing file ───────────────────
+
+describe("openBeliefsDbRO — no file materialization", () => {
+  it("does not create the file when absent", async () => {
+    const dir = mkTmp();
+    const absent = join(dir, "should-not-exist.db");
+    expect(existsSync(absent)).toBe(false);
+    const result = await openBeliefsDbRO(absent);
+    expect(result).toBeNull();
+    expect(existsSync(absent)).toBe(false);
+  });
+});
+
+// ─── 4. withBeliefsDbRO — absent db returns fallback, fn never called ──────
+
+describe("withBeliefsDbRO — absent db", () => {
+  it("returns the fallback and never invokes fn", async () => {
+    const dir = mkTmp();
+    const absent = join(dir, "absent.db");
+    let fnCalled = false;
+    const result = await withBeliefsDbRO(
+      absent,
+      (_db) => { fnCalled = true; return "should-not-reach"; },
+      "degraded-fallback",
+    );
+    expect(result).toBe("degraded-fallback");
+    expect(fnCalled).toBe(false);
+  });
+});
+
+// ─── 5. withBeliefsDbRO — closes handle even when fn throws ────────────────
+
+describe("withBeliefsDbRO — fn throws", () => {
+  it("returns the fallback and the db is closed after fn throws", async () => {
+    const dir = mkTmp();
+    const dbPath = join(dir, "throw.db");
+    seedDb(dbPath);
+
+    // Track if the db is closed by attempting a write after withBeliefsDbRO.
+    // We can't reach into the closed handle directly, so we verify the fallback
+    // is returned without the error escaping.
+    const result = await withBeliefsDbRO(
+      dbPath,
+      (_db) => { throw new Error("deliberate throw"); },
+      "fallback-on-throw",
+    );
+    expect(result).toBe("fallback-on-throw");
+  });
+});
+
+// ─── 6. defaultBeliefsDbPath — env precedence ──────────────────────────────
+
+describe("defaultBeliefsDbPath", () => {
+  it("CATALYST_BELIEFS_DB wins outright", () => {
+    const p = defaultBeliefsDbPath({ CATALYST_BELIEFS_DB: "/tmp/custom.db" });
+    expect(p).toBe("/tmp/custom.db");
+  });
+
+  it("uses CATALYST_DIR/beliefs.db when CATALYST_BELIEFS_DB absent", () => {
+    const p = defaultBeliefsDbPath({ CATALYST_DIR: "/tmp/mydir" });
+    expect(p).toBe(join("/tmp/mydir", "beliefs.db"));
+  });
+
+  it("falls back to ~/catalyst/beliefs.db when neither env var set", () => {
+    const p = defaultBeliefsDbPath({});
+    expect(p).toMatch(/catalyst[/\\]beliefs\.db$/);
+    expect(p.startsWith(homedir())).toBe(true);
+  });
+});
+
+// ─── 7. Reconciliation: idx_belief_rule_id already exists (verify-only) ────
+
+describe("idx_belief_rule_id — pre-existing index (reconciliation verify)", () => {
+  it("idx_belief_rule_id exists in sqlite_master after openBeliefsDb", async () => {
+    const dir = mkTmp();
+    const dbPath = join(dir, "schema-verify.db");
+    // Open via the WRITER path (openBeliefsDb runs migrations + creates index).
+    const schemaModSpecifier = ["../../execution-core/beliefs/schema.mjs"].join("");
+    const { openBeliefsDb } = await import(schemaModSpecifier) as {
+      openBeliefsDb: (opts: { path: string }) => InstanceType<typeof Database>;
+    };
+    const writable = openBeliefsDb({ path: dbPath });
+    const rows = writable
+      .query("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_belief_rule_id'")
+      .all() as Array<{ name: string }>;
+    writable.close();
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.name).toBe("idx_belief_rule_id");
+  });
+});
+
+// ─── 8. isGovernanceEvent — allowlist + blocklist ──────────────────────────
+
+describe("isGovernanceEvent", () => {
+  it("phase.verify.complete.CTL-700 is a governance event", () => {
+    expect(isGovernanceEvent("phase.verify.complete.CTL-700")).toBe(true);
+  });
+
+  it("phase.implement.complete.CTL-700 is a governance event", () => {
+    expect(isGovernanceEvent("phase.implement.complete.CTL-700")).toBe(true);
+  });
+
+  it("phase.remediate.complete.CTL-100 is a governance event", () => {
+    expect(isGovernanceEvent("phase.remediate.complete.CTL-100")).toBe(true);
+  });
+
+  it("janitor.would.reap-request is NOT a governance event (janitor prefix)", () => {
+    expect(isGovernanceEvent("janitor.would.reap-request")).toBe(false);
+  });
+
+  it("phase.terminal.reap-complete is NOT a governance event (contains reap, invalid prefix)", () => {
+    expect(isGovernanceEvent("phase.terminal.reap-complete")).toBe(false);
+  });
+
+  it("orphans.reap-requested is NOT a governance event (orphans prefix + reap)", () => {
+    expect(isGovernanceEvent("orphans.reap-requested")).toBe(false);
+  });
+
+  it("phase.yield.reap-requested is NOT a governance event (contains reap)", () => {
+    expect(isGovernanceEvent("phase.yield.reap-requested")).toBe(false);
+  });
+
+  it("janitor.stall.cleared is NOT a governance event (janitor prefix)", () => {
+    expect(isGovernanceEvent("janitor.stall.cleared")).toBe(false);
+  });
+
+  it("worktree.something is NOT a governance event (worktree prefix)", () => {
+    expect(isGovernanceEvent("worktree.something")).toBe(false);
+  });
+
+  it("phase.research.complete.CTL-5 is a governance event", () => {
+    expect(isGovernanceEvent("phase.research.complete.CTL-5")).toBe(true);
+  });
+
+  it("unrelated.event is NOT a governance event (no valid prefix)", () => {
+    expect(isGovernanceEvent("unrelated.event")).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-rules-manifest.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-rules-manifest.contract.test.ts
@@ -29,7 +29,7 @@ let tmpDir: string;
 
 beforeAll(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "gov-rules-contract-"));
-  server = createServer({ port: 0, startWatcher: false, dbPath: join(tmpDir, "catalyst.db"), wtDir: tmpDir });
+  server = createServer({ port: 0, startWatcher: false, dbPath: join(tmpDir, "catalyst.db"), wtDir: tmpDir, annotationsDbPath: join(tmpDir, "annotations.db") });
   baseUrl = `http://localhost:${server.port}`;
 });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-rules-manifest.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-rules-manifest.contract.test.ts
@@ -10,7 +10,7 @@ import { createServer } from "../server";
 
 // Contract: import the exact same module the endpoint serves from.
 // Computed specifier: rules.mjs transitively imports bun:sqlite via schema.mjs.
-// @ts-ignore — execution-core mjs module has no .d.mts; runtime types are correct
+// @ts-expect-error — execution-core mjs module has no .d.mts; runtime types are correct
 const rulesMod = await import("../../execution-core/beliefs/rules.mjs");
 const { RULE_MANIFEST } = rulesMod as {
   RULE_MANIFEST: {
@@ -20,7 +20,7 @@ const { RULE_MANIFEST } = rulesMod as {
 };
 
 function jsonNorm<T>(v: T): T {
-  return JSON.parse(JSON.stringify(v));
+  return JSON.parse(JSON.stringify(v)) as T;
 }
 
 let server: ReturnType<typeof createServer>;

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-rules-manifest.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-rules-manifest.contract.test.ts
@@ -1,0 +1,92 @@
+// governance-rules-manifest.contract.test.ts — CTL-1100 Phase 7
+// Contract: GET /api/beliefs/rules body deep-equals RULE_MANIFEST from
+// rules.mjs. Recompiling the rules without re-exporting must turn this red.
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+// Contract: import the exact same module the endpoint serves from.
+// Computed specifier: rules.mjs transitively imports bun:sqlite via schema.mjs.
+// @ts-ignore — execution-core mjs module has no .d.mts; runtime types are correct
+const rulesMod = await import("../../execution-core/beliefs/rules.mjs");
+const { RULE_MANIFEST } = rulesMod as {
+  RULE_MANIFEST: {
+    strata: Array<{ stratum: number; name: string }>;
+    rules: Array<{ rule_id: string; name: string; sql?: string }>;
+  };
+};
+
+function jsonNorm<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v));
+}
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "gov-rules-contract-"));
+  server = createServer({ port: 0, startWatcher: false, dbPath: join(tmpDir, "catalyst.db"), wtDir: tmpDir });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  void server?.stop(true);
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+async function fetchRules(): Promise<Record<string, unknown>> {
+  const res = await fetch(`${baseUrl}/api/beliefs/rules`);
+  expect(res.status).toBe(200);
+  return res.json() as Promise<Record<string, unknown>>;
+}
+
+// ─── 1. Full deep-equal against live RULE_MANIFEST ──────────────────────────
+
+describe("GET /api/beliefs/rules — full contract", () => {
+  it("body deep-equals JSON.parse(JSON.stringify(RULE_MANIFEST))", async () => {
+    const body = await fetchRules();
+    expect(body).toEqual(jsonNorm(RULE_MANIFEST));
+  });
+});
+
+// ─── 2. Anti-stub guards (derived counts, not hardcoded) ────────────────────
+
+describe("GET /api/beliefs/rules — anti-stub guards", () => {
+  it("body.rules.length === RULE_MANIFEST.rules.length (not hardcoded)", async () => {
+    const body = await fetchRules() as { rules: unknown[] };
+    // This must be derived from the live import, NOT hardcoded.
+    expect(body.rules.length).toBe(RULE_MANIFEST.rules.length);
+  });
+
+  it("body.strata.length matches RULE_MANIFEST.strata.length", async () => {
+    const body = await fetchRules() as { strata: unknown[] };
+    expect(body.strata.length).toBe(RULE_MANIFEST.strata.length);
+  });
+
+  it("first rule has rule_id 'R1'", async () => {
+    const body = await fetchRules() as { rules: Array<{ rule_id: string }> };
+    expect(body.rules[0]?.rule_id).toBe("R1");
+  });
+
+  it("body.rules key set matches RULE_MANIFEST rule key set", async () => {
+    const body = await fetchRules() as { rules: Array<Record<string, unknown>> };
+    const bodyIds = new Set(body.rules.map((r) => r.rule_id));
+    const manifestIds = new Set(RULE_MANIFEST.rules.map((r) => r.rule_id));
+    expect(bodyIds).toEqual(manifestIds);
+  });
+
+  it("at least one rule arm carries a sql string", async () => {
+    const body = await fetchRules() as { rules: Array<{ arms: Array<{ sql?: string }> }> };
+    // sql lives under each rule's arms[], not directly on the rule object.
+    const hasSql = body.rules.some((r) =>
+      Array.isArray(r.arms) && r.arms.some((a) => typeof a.sql === "string" && a.sql.length > 0)
+    );
+    expect(hasSql).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-why.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-why.contract.test.ts
@@ -52,6 +52,7 @@ beforeAll(async () => {
     dbPath: join(seededDir, "catalyst.db"),
     beliefStoreDbPath: beliefPath,
     wtDir: seededDir,
+    annotationsDbPath: join(seededDir, "annotations.db"), // hermetic — never the host ~/catalyst path
   });
   seededUrl = `http://localhost:${seededServer.port}`;
 });
@@ -75,6 +76,7 @@ beforeAll(() => {
     dbPath: join(absentDir, "catalyst.db"),
     beliefStoreDbPath: join(absentDir, "nonexistent.db"),
     wtDir: absentDir,
+    annotationsDbPath: join(absentDir, "annotations.db"), // hermetic — never the host ~/catalyst path
   });
   absentUrl = `http://localhost:${absentServer.port}`;
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-why.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-why.contract.test.ts
@@ -30,7 +30,7 @@ async function seedBeliefDb(dbPath: string): Promise<{ tickId: number }> {
 }
 
 function jsonNorm<T>(v: T): T {
-  return JSON.parse(JSON.stringify(v));
+  return JSON.parse(JSON.stringify(v)) as T;
 }
 
 // ─── Seeded server ───────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-why.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-why.contract.test.ts
@@ -1,0 +1,157 @@
+// governance-why.contract.test.ts — CTL-1100 Phase 7
+// Contract: GET /api/beliefs/why HTTP body deep-equals traceTicket() on the
+// same beliefs.db. Any divergence between HTTP wrapper and the CLI function
+// must turn this suite red.
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+async function seedBeliefDb(dbPath: string): Promise<{ tickId: number }> {
+  const schemaSpecifier = ["../../execution-core/beliefs/schema.mjs"].join("");
+  const { openBeliefsDb } = await import(schemaSpecifier) as {
+    openBeliefsDb: (opts: { path: string }) => Database;
+  };
+  const db = openBeliefsDb({ path: dbPath });
+  db.run("INSERT INTO tick (now_ms, host) VALUES (1000, 'h1')");
+  const tickId = (db.query("SELECT last_insert_rowid() AS id").get() as { id: number }).id;
+  db.run(
+    `INSERT OR IGNORE INTO belief (tick_id, stratum, name, subject, value, rule_id, source_fact_ids)
+     VALUES (?, 1, 'session_registered', 'CTL-9991/plan', NULL, 'R1', '[]')`,
+    [tickId],
+  );
+  db.close();
+  return { tickId };
+}
+
+function jsonNorm<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v));
+}
+
+// ─── Seeded server ───────────────────────────────────────────────────────────
+
+let seededServer: ReturnType<typeof createServer>;
+let seededUrl: string;
+let seededDir: string;
+let seededTickId: number;
+let beliefPath: string;
+
+beforeAll(async () => {
+  seededDir = mkdtempSync(join(tmpdir(), "gov-why-seeded-"));
+  beliefPath = join(seededDir, "beliefs.db");
+  const { tickId } = await seedBeliefDb(beliefPath);
+  seededTickId = tickId;
+  seededServer = createServer({
+    port: 0,
+    startWatcher: false,
+    dbPath: join(seededDir, "catalyst.db"),
+    beliefStoreDbPath: beliefPath,
+    wtDir: seededDir,
+  });
+  seededUrl = `http://localhost:${seededServer.port}`;
+});
+
+afterAll(() => {
+  void seededServer?.stop(true);
+  try { rmSync(seededDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ─── Absent db server ────────────────────────────────────────────────────────
+
+let absentServer: ReturnType<typeof createServer>;
+let absentUrl: string;
+let absentDir: string;
+
+beforeAll(() => {
+  absentDir = mkdtempSync(join(tmpdir(), "gov-why-absent-"));
+  absentServer = createServer({
+    port: 0,
+    startWatcher: false,
+    dbPath: join(absentDir, "catalyst.db"),
+    beliefStoreDbPath: join(absentDir, "nonexistent.db"),
+    wtDir: absentDir,
+  });
+  absentUrl = `http://localhost:${absentServer.port}`;
+});
+
+afterAll(() => {
+  void absentServer?.stop(true);
+  try { rmSync(absentDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ─── 1. Implicit tick: body deep-equals traceTicket() ───────────────────────
+
+describe("GET /api/beliefs/why — implicit tick contract", () => {
+  it("HTTP body deep-equals traceTicket(db, ticket) on same db", async () => {
+    const schemaSpecifier = ["../../execution-core/beliefs/schema.mjs"].join("");
+    const { openBeliefsDb } = await import(schemaSpecifier) as {
+      openBeliefsDb: (opts: { path: string }) => Database;
+    };
+    const db = openBeliefsDb({ path: beliefPath });
+    const whySpecifier = ["../../execution-core/beliefs/why.mjs"].join("");
+    const { traceTicket } = await import(whySpecifier) as {
+      traceTicket: (db: Database, ticket: string, opts?: { tickId?: number }) => unknown;
+    };
+    const expected = jsonNorm(traceTicket(db, "CTL-9991"));
+    db.close();
+
+    const res = await fetch(`${seededUrl}/api/beliefs/why?ticket=CTL-9991`);
+    expect(res.status).toBe(200);
+    const actual = await res.json();
+    expect(actual).toEqual(expected);
+  });
+});
+
+// ─── 2. Explicit tick= honored ───────────────────────────────────────────────
+
+describe("GET /api/beliefs/why — explicit tick contract", () => {
+  it("HTTP body deep-equals traceTicket(db, ticket, {tickId}) on same db", async () => {
+    const schemaSpecifier = ["../../execution-core/beliefs/schema.mjs"].join("");
+    const { openBeliefsDb } = await import(schemaSpecifier) as {
+      openBeliefsDb: (opts: { path: string }) => Database;
+    };
+    const db = openBeliefsDb({ path: beliefPath });
+    const whySpecifier = ["../../execution-core/beliefs/why.mjs"].join("");
+    const { traceTicket } = await import(whySpecifier) as {
+      traceTicket: (db: Database, ticket: string, opts?: { tickId?: number }) => unknown;
+    };
+    const expected = jsonNorm(traceTicket(db, "CTL-9991", { tickId: seededTickId }));
+    db.close();
+
+    const res = await fetch(`${seededUrl}/api/beliefs/why?ticket=CTL-9991&tick=${seededTickId}`);
+    expect(res.status).toBe(200);
+    const actual = await res.json();
+    expect(actual).toEqual(expected);
+  });
+});
+
+// ─── 3. Absent db → 200 {beliefs:[]} ────────────────────────────────────────
+
+describe("GET /api/beliefs/why — absent db contract", () => {
+  it("absent db → 200 with beliefs:[] (graceful degradation)", async () => {
+    const res = await fetch(`${absentUrl}/api/beliefs/why?ticket=CTL-9991`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { beliefs: unknown[]; ticket: string };
+    expect(body.beliefs).toEqual([]);
+    expect(body.ticket).toBe("CTL-9991");
+  });
+});
+
+// ─── 4. Missing ticket → 400 ────────────────────────────────────────────────
+
+describe("GET /api/beliefs/why — validation contract", () => {
+  it("missing ticket → 400", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/why`);
+    expect(res.status).toBe(400);
+  });
+
+  it("invalid ticket format → 400", async () => {
+    const res = await fetch(`${seededUrl}/api/beliefs/why?ticket=notavalidticket`);
+    expect(res.status).toBe(400);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/journey-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/journey-endpoint.test.ts
@@ -1,0 +1,58 @@
+// CTL-1100 Phase 5: GET /api/journey/:ticket — HTTP integration tests.
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "journey-endpoint-test-"));
+  const dbPath = join(tmpDir, "catalyst.db");
+  server = createServer({ port: 0, startWatcher: false, dbPath, wtDir: tmpDir });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  void server?.stop(true);
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe("GET /api/journey/:ticket", () => {
+  it("well-formed ticket with no data → 200 empty-but-well-formed", async () => {
+    const res = await fetch(`${baseUrl}/api/journey/CTL-0000`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      ticket: string; hops: unknown[]; gates: { checklist: unknown[]; nextPhase: unknown };
+      verifyVerdict: unknown; remediateCycles: number; unblockHints: unknown[]; hosts: unknown[];
+    };
+    expect(body.ticket).toBe("CTL-0000");
+    expect(Array.isArray(body.hops)).toBe(true);
+    expect(Array.isArray(body.gates.checklist)).toBe(true);
+    expect(Array.isArray(body.unblockHints)).toBe(true);
+    expect(Array.isArray(body.hosts)).toBe(true);
+    expect("remediateCycles" in body).toBe(true);
+  });
+
+  it("not-a-ticket → 400", async () => {
+    const res = await fetch(`${baseUrl}/api/journey/notaticket`);
+    expect(res.status).toBe(400);
+  });
+
+  it("encoded traversal ..%2F.. → 400", async () => {
+    const res = await fetch(`${baseUrl}/api/journey/..%2F..`);
+    expect(res.status).toBe(400);
+  });
+
+  it("response has all expected top-level keys", async () => {
+    const res = await fetch(`${baseUrl}/api/journey/CTL-0000`);
+    const body = await res.json() as Record<string, unknown>;
+    for (const key of ["ticket", "hops", "gates", "verifyVerdict", "remediateCycles", "unblockHints", "hosts"]) {
+      expect(key in body).toBe(true);
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/journey.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/journey.test.ts
@@ -103,7 +103,7 @@ describe("scanHops + dedupeHops", () => {
     const launched = hops.filter((h) => h.phase === "dispatch" && h.eventType === "launched");
     expect(launched.length).toBe(1);
     // advance.held carries blockers
-    const held = hops.find((h) => h.phase === "advance" && h.eventType === "held") as typeof raw[0] | undefined;
+    const held = hops.find((h) => h.phase === "advance" && h.eventType === "held");
     expect(held?.blockers).toEqual(["x"]);
     expect(held?.reason).toBe("capacity");
     // hops sorted ts asc

--- a/plugins/dev/scripts/orch-monitor/__tests__/journey.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/journey.test.ts
@@ -1,0 +1,288 @@
+// CTL-1100 Phase 5: journey.mjs unit tests — hops/dedupe/gate/verdict/unblock/host/degradation.
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+// Load journey functions via computed specifier (bun:sqlite-free but guards module graph).
+const journeyMod = await import(["../lib/journey.mjs"].join("")) as {
+  scanHops: (ticket: string, opts: { eventLogPath: string }) => Array<{
+    phase: string; eventType: string; ts: string; host: string;
+    bg_job_id?: string; reason?: string; targetPhase?: string; blockers?: unknown[];
+  }>;
+  dedupeHops: (hops: Array<unknown>) => Array<unknown>;
+  buildGateChecklist: (ticket: string, opts: { orchDir: string; eventLogPath?: string }) => {
+    nextPhase: string | null;
+    checklist: Array<{ phase: string; signalStatus: string | null; satisfied: boolean }>;
+    remediateCycles: number;
+  };
+  readVerifyVerdictDetail: (ticket: string, opts: { orchDir: string }) => {
+    verdict: string | null; regressionRisk: number | null; highFindings: number; reason: string | null;
+  };
+  collectUnblockHints: (ticket: string, opts: { orchDir: string; hops: Array<unknown> }) => Array<{
+    kind: string; note?: string; reason?: string; blockers?: unknown[];
+  }>;
+  assembleJourney: (ticket: string, opts?: {
+    workersDir?: string; orchDir?: string; eventLogPath?: string; dbPath?: string;
+  }) => Promise<{
+    ticket: string;
+    hops: unknown[];
+    gates: { checklist: unknown[]; nextPhase: string | null };
+    verifyVerdict: { verdict: string | null };
+    remediateCycles: number;
+    unblockHints: unknown[];
+    hosts: string[];
+  }>;
+};
+const { scanHops, dedupeHops, buildGateChecklist, readVerifyVerdictDetail, collectUnblockHints, assembleJourney } = journeyMod;
+
+// Import deriveAdvancement + readPhaseSignals for backed-by-code assertions.
+const schedMod = await import(["../../execution-core/scheduler.mjs"].join("")) as {
+  deriveAdvancement: (signals: Record<string, string | null>, opts?: { verifyVerdict?: string; remediateCycleCount?: number }) => string | null;
+  readPhaseSignals: (orchDir: string, ticket: string) => Record<string, string | null>;
+};
+const { deriveAdvancement, readPhaseSignals } = schedMod;
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "journey-test-"));
+});
+afterAll(() => {
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function makeEventLine(name: string, host: string | null, ts: string, payload: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    ts,
+    resource: host ? { "host.name": host } : {},
+    attributes: { "event.name": name },
+    body: { payload },
+  });
+}
+
+function writeEventLog(filename: string, lines: string[]): string {
+  const p = join(tmpDir, filename);
+  writeFileSync(p, lines.join("\n") + "\n");
+  return p;
+}
+
+function writeSignal(dir: string, phase: string, status: string, extra: Record<string, unknown> = {}): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify({ status, ...extra }));
+}
+
+// ─── 1. scanHops / dedupeHops — suffix collision guard ──────────────────────
+
+describe("scanHops + dedupeHops", () => {
+  it("only CTL-9001 events returned; CTL-90010 excluded", () => {
+    const logPath = writeEventLog("hops-collision.jsonl", [
+      makeEventLine("phase.dispatch.requested.CTL-9001", "h1", "2024-01-01T01:00:00Z"),
+      makeEventLine("phase.dispatch.launched.CTL-9001",  "h1", "2024-01-01T01:01:00Z", { bg_job_id: "j1" }),
+      makeEventLine("phase.implement.complete.CTL-9001", "h1", "2024-01-01T01:02:00Z", { bg_job_id: "j1" }),
+      makeEventLine("phase.implement.revive.CTL-9001",   "h2", "2024-01-01T01:03:00Z", { bg_job_id: "j2" }),
+      // duplicate — same phase+eventType+bg_job_id as the launched event above
+      makeEventLine("phase.dispatch.launched.CTL-9001",  "h1", "2024-01-01T01:01:00Z", { bg_job_id: "j1" }),
+      // advance.held with blockers
+      makeEventLine("phase.advance.held.CTL-9001",       "h1", "2024-01-01T01:04:00Z", { reason: "capacity", blockers: ["x"] }),
+      makeEventLine("phase.remediate.complete.CTL-9001", "h1", "2024-01-01T01:05:00Z"),
+      // noise for a DIFFERENT ticket (must be excluded)
+      makeEventLine("phase.implement.complete.CTL-90010", "h3", "2024-01-01T02:00:00Z"),
+      makeEventLine("phase.dispatch.launched.NOPE-1",     "h4", "2024-01-01T02:01:00Z"),
+    ]);
+    const raw = scanHops("CTL-9001", { eventLogPath: logPath });
+    // All raw hops must be for CTL-9001
+    for (const h of raw) {
+      expect(h.phase + "." + h.eventType).not.toContain("CTL-90010");
+    }
+    const hops = dedupeHops(raw) as typeof raw;
+    // Dedup collapses the duplicate launched hop
+    const launched = hops.filter((h) => h.phase === "dispatch" && h.eventType === "launched");
+    expect(launched.length).toBe(1);
+    // advance.held carries blockers
+    const held = hops.find((h) => h.phase === "advance" && h.eventType === "held") as typeof raw[0] | undefined;
+    expect(held?.blockers).toEqual(["x"]);
+    expect(held?.reason).toBe("capacity");
+    // hops sorted ts asc
+    const tsList = hops.map((h) => h.ts);
+    expect(tsList).toEqual([...tsList].sort());
+  });
+
+  it("each hop has {phase, eventType, ts, host}", () => {
+    const logPath = writeEventLog("hops-shape.jsonl", [
+      makeEventLine("phase.implement.complete.CTL-9001", null, "2024-01-01T01:00:00Z"),
+    ]);
+    const hops = dedupeHops(scanHops("CTL-9001", { eventLogPath: logPath })) as Array<{
+      phase: string; eventType: string; ts: string; host: string;
+    }>;
+    expect(hops.length).toBe(1);
+    expect(hops[0]?.phase).toBe("implement");
+    expect(hops[0]?.eventType).toBe("complete");
+    expect(typeof hops[0]?.ts).toBe("string");
+    // host falls back when absent from resource
+    expect(typeof hops[0]?.host).toBe("string");
+  });
+});
+
+// ─── 2. buildGateChecklist drives deriveAdvancement ──────────────────────────
+
+describe("buildGateChecklist backed-by-code invariant", () => {
+  it("case A: implement done → nextPhase === 'verify'", () => {
+    const orchDir = join(tmpDir, "orch-case-a");
+    const workerDir = join(orchDir, "workers", "CTL-9001");
+    writeSignal(workerDir, "triage",    "done");
+    writeSignal(workerDir, "research",  "done");
+    writeSignal(workerDir, "plan",      "done");
+    writeSignal(workerDir, "implement", "done");
+
+    const gates = buildGateChecklist("CTL-9001", { orchDir });
+    expect(gates.nextPhase).toBe("verify");
+
+    // backed-by-code
+    const signals = readPhaseSignals(orchDir, "CTL-9001");
+    const expected = deriveAdvancement(signals, { verifyVerdict: undefined, remediateCycleCount: 0 });
+    expect(gates.nextPhase).toBe(expected);
+
+    // checklist exists
+    expect(Array.isArray(gates.checklist)).toBe(true);
+    const implRow = gates.checklist.find((r: { phase: string }) => r.phase === "implement");
+    expect(implRow?.satisfied).toBe(true);
+  });
+
+  it("case B: verify done + regression_risk:7 → nextPhase === 'remediate'", () => {
+    const orchDir = join(tmpDir, "orch-case-b");
+    const workerDir = join(orchDir, "workers", "CTL-9001");
+    writeSignal(workerDir, "implement", "done");
+    writeSignal(workerDir, "verify",    "done");
+    writeFileSync(join(workerDir, "verify.json"), JSON.stringify({ regression_risk: 7, findings: [] }));
+
+    const gates = buildGateChecklist("CTL-9001", { orchDir });
+    expect(gates.nextPhase).toBe("remediate");
+
+    const signals = readPhaseSignals(orchDir, "CTL-9001");
+    const expected = deriveAdvancement(signals, { verifyVerdict: "fail", remediateCycleCount: 0 });
+    expect(gates.nextPhase).toBe(expected);
+  });
+
+  it("case C: verify done + clean verify.json → nextPhase === 'review'", () => {
+    const orchDir = join(tmpDir, "orch-case-c");
+    const workerDir = join(orchDir, "workers", "CTL-9001");
+    writeSignal(workerDir, "implement", "done");
+    writeSignal(workerDir, "verify",    "done");
+    writeFileSync(join(workerDir, "verify.json"), JSON.stringify({ regression_risk: 1, findings: [] }));
+
+    const gates = buildGateChecklist("CTL-9001", { orchDir });
+    expect(gates.nextPhase).toBe("review");
+
+    const signals = readPhaseSignals(orchDir, "CTL-9001");
+    const expected = deriveAdvancement(signals, { verifyVerdict: "pass", remediateCycleCount: 0 });
+    expect(gates.nextPhase).toBe(expected);
+  });
+});
+
+// ─── 3. Verdict detail + cycles ──────────────────────────────────────────────
+
+describe("readVerifyVerdictDetail + remediateCycles", () => {
+  it("regression_risk:5, high finding → verdict=fail, regressionRisk=5, highFindings=1", () => {
+    const orchDir = join(tmpDir, "orch-verdict");
+    const workerDir = join(orchDir, "workers", "CTL-9001");
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, "verify.json"), JSON.stringify({
+      regression_risk: 5,
+      findings: [{ severity: "high" }, { severity: "low" }],
+    }));
+    const detail = readVerifyVerdictDetail("CTL-9001", { orchDir });
+    expect(detail.verdict).toBe("fail");
+    expect(detail.regressionRisk).toBe(5);
+    expect(detail.highFindings).toBe(1);
+    expect(typeof detail.reason).toBe("string");
+    expect(detail.reason).not.toBe("");
+  });
+
+  it("absent verify.json → verdict null, full shape returned", () => {
+    const orchDir = join(tmpDir, "orch-absent-verify");
+    mkdirSync(join(orchDir, "workers", "CTL-no-verify"), { recursive: true });
+    const detail = readVerifyVerdictDetail("CTL-no-verify", { orchDir });
+    expect(detail.verdict).toBeNull();
+    expect("regressionRisk" in detail).toBe(true);
+    expect("highFindings" in detail).toBe(true);
+  });
+
+  it("remediateCycles counted from event log", () => {
+    const logPath = writeEventLog("remediate-cycles.jsonl", [
+      makeEventLine("phase.remediate.complete.CTL-9001", "h1", "2024-01-01T01:00:00Z"),
+      makeEventLine("phase.remediate.complete.CTL-9001", "h1", "2024-01-01T02:00:00Z"),
+    ]);
+    const orchDir = join(tmpDir, "orch-cycles");
+    const gates = buildGateChecklist("CTL-9001", { orchDir, eventLogPath: logPath });
+    expect(gates.remediateCycles).toBe(2);
+  });
+});
+
+// ─── 4. Unblock hints ────────────────────────────────────────────────────────
+
+describe("collectUnblockHints", () => {
+  it("operator respond note + latest held hop → two hints", () => {
+    const orchDir = join(tmpDir, "orch-unblock");
+    const workerDir = join(orchDir, "workers", "CTL-9001");
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, ".respond-implement.json"), JSON.stringify({
+      response: "Try again with X",
+      respondedAt: "2024-01-01T01:00:00Z",
+    }));
+    const hops = [
+      { phase: "advance", eventType: "held", ts: "2024-01-01T01:00:00Z", host: "h1",
+        reason: "capacity_limit", blockers: ["slot-busy"] },
+    ];
+    const hints = collectUnblockHints("CTL-9001", { orchDir, hops });
+    expect(hints.some((h: { kind: string }) => h.kind === "operator-note")).toBe(true);
+    expect(hints.some((h: { kind: string }) => h.kind === "held-reason")).toBe(true);
+  });
+
+  it("no sources → []", () => {
+    const orchDir = join(tmpDir, "orch-no-hints");
+    mkdirSync(join(orchDir, "workers", "CTL-empty"), { recursive: true });
+    const hints = collectUnblockHints("CTL-empty", { orchDir, hops: [] });
+    expect(hints).toEqual([]);
+  });
+});
+
+// ─── 5. Node-aware + degradation ─────────────────────────────────────────────
+
+describe("assembleJourney degradation", () => {
+  it("ticket with no worker dir and no event log → empty-but-well-formed, never throws", async () => {
+    const orchDir = join(tmpDir, "orch-degrade");
+    mkdirSync(orchDir, { recursive: true });
+    const journey = await assembleJourney("CTL-99999", {
+      workersDir: join(orchDir, "workers-nonexistent"),
+      orchDir,
+      eventLogPath: join(orchDir, "nonexistent.jsonl"),
+    });
+    expect(journey.ticket).toBe("CTL-99999");
+    expect(Array.isArray(journey.hops)).toBe(true);
+    expect(Array.isArray(journey.gates.checklist)).toBe(true);
+    expect(Array.isArray(journey.unblockHints)).toBe(true);
+    expect(Array.isArray(journey.hosts)).toBe(true);
+  });
+
+  it("multi-host hops → hosts[] is deduped union", async () => {
+    const logPath = writeEventLog("multi-host.jsonl", [
+      makeEventLine("phase.implement.complete.CTL-9001", "host-a", "2024-01-01T01:00:00Z"),
+      makeEventLine("phase.verify.complete.CTL-9001",   "host-b", "2024-01-01T02:00:00Z"),
+    ]);
+    const orchDir = join(tmpDir, "orch-multi");
+    mkdirSync(orchDir, { recursive: true });
+    const journey = await assembleJourney("CTL-9001", {
+      workersDir: join(orchDir, "workers"),
+      orchDir,
+      eventLogPath: logPath,
+    });
+    expect(journey.hosts).toContain("host-a");
+    expect(journey.hosts).toContain("host-b");
+    // no duplicates
+    expect(journey.hosts.length).toBe(new Set(journey.hosts).size);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/knip.config.ts
+++ b/plugins/dev/scripts/orch-monitor/knip.config.ts
@@ -8,6 +8,16 @@ const config: KnipConfig = {
   ignoreFiles: [
     "ui/src/components/layout/sidebar.tsx",
     "ui/src/components/workspace-switcher.tsx",
+    // CTL-1100: shared governance building blocks shipped ahead of their
+    // consuming pages. Per the plan's scope boundary ("No Process / Execution /
+    // Rulebook surfaces — those are CTL-1101 / CTL-1102 / CTL-1103, which this
+    // ticket BLOCKS. We ship the shared building blocks, not the pages."), these
+    // have no consumer until those follow-up tickets land. Remove each entry as
+    // its consuming page wires the component in.
+    "ui/src/components/governance/derivation-tree.tsx",
+    "ui/src/components/governance/governance-flags-chip.tsx",
+    "ui/src/components/governance/journey-strip.tsx",
+    "ui/src/components/governance/source-sheet.tsx",
   ],
   workspaces: {
     ".": {

--- a/plugins/dev/scripts/orch-monitor/lib/belief-store-queries.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/belief-store-queries.d.mts
@@ -1,0 +1,14 @@
+// Type declarations for belief-store-queries.mjs (CTL-1100).
+// Pure db-injected query functions; no bun:sqlite transitive import safe for
+// static import in server.ts. Keep in sync with belief-store-queries.mjs.
+
+import type { Database } from "bun:sqlite";
+
+export declare const RECENT_DEFAULT_LIMIT: number;
+export declare const RATES_LRU_CAP: number;
+
+export declare function beliefSummary(db: Database): unknown;
+export declare function beliefRates(db: Database, lru: Map<number | null, unknown>): unknown;
+export declare function beliefRecent(db: Database, opts?: { limit?: number }): unknown;
+export declare function beliefCfg(db: Database): unknown;
+export declare function beliefRulesManifest(db: Database): unknown;

--- a/plugins/dev/scripts/orch-monitor/lib/belief-store-queries.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/belief-store-queries.mjs
@@ -1,0 +1,127 @@
+// belief-store-queries.mjs — pure, db-injected query functions for the
+// GET /api/beliefs/{summary,rates,recent,cfg} read endpoints (CTL-1100 Phase 3).
+// All SQL lives here (single source); callers inject the db handle and get
+// plain JS values back. No bun:sqlite static import — callers open/close via
+// governance-reader.mjs:withBeliefsDbRO.
+//
+// RULE_MANIFEST is served by a computed-import re-export so the /rules route
+// never needs a db handle. DO NOT change the specifier to a string literal
+// (VITE-GRAPH GUARD — see governance-reader.mjs header).
+
+// beliefRulesManifest — serve RULE_MANIFEST verbatim via computed import.
+// Returns the frozen manifest or null on import failure (404 the route).
+// NOTE: DO NOT inline the specifier — computed specifier required (CTL-883).
+export async function beliefRulesManifest() {
+  try {
+    const rulesMod = ["../../execution-core/beliefs/rules.mjs"].join("");
+    const mod = await import(rulesMod);
+    return mod.RULE_MANIFEST ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// beliefSummary — COUNT(DISTINCT subject) + COUNT(*) per name at the LATEST tick.
+// Rows sorted by name. Returns {tickId:null,rows:[]} on empty belief table.
+export function beliefSummary(db) {
+  try {
+    const maxRow = db.query("SELECT MAX(tick_id) AS max_id FROM belief").get();
+    const tickId = maxRow?.max_id ?? null;
+    if (tickId == null) return { tickId: null, rows: [] };
+    const rows = db.query(
+      `SELECT name,
+              COUNT(DISTINCT subject) AS subjects,
+              COUNT(*) AS total
+         FROM belief
+        WHERE tick_id = ?
+        GROUP BY name
+        ORDER BY name`
+    ).all(tickId);
+    return { tickId, rows };
+  } catch {
+    return { tickId: null, rows: [] };
+  }
+}
+
+// Constants exposed for tests.
+export const RECENT_DEFAULT_LIMIT = 50;
+export const RECENT_MAX_LIMIT = 500;
+export const RATES_LRU_CAP = 64;
+
+// beliefRatesRaw — compute full GROUP BY tick_id, rule_id rates over idx_belief_rule_id.
+// Returns {maxTick, rows} or {maxTick:null, rows:[]}.
+// NOTE: idx_belief_rule_id already exists (schema.mjs:170, CTL-1063 Phase 4) — no migration.
+function beliefRatesRaw(db) {
+  try {
+    const maxRow = db.query("SELECT MAX(tick_id) AS max_id FROM belief").get();
+    const maxTick = maxRow?.max_id ?? null;
+    if (maxTick == null) return { maxTick: null, rows: [] };
+    const rows = db.query(
+      `SELECT tick_id, rule_id, COUNT(*) AS count
+         FROM belief
+        GROUP BY tick_id, rule_id
+        ORDER BY tick_id, rule_id`
+    ).all();
+    return { maxTick, rows };
+  } catch {
+    return { maxTick: null, rows: [] };
+  }
+}
+
+// beliefRates — return cached result if maxTick unchanged; else recompute.
+// Evicts oldest entry when size exceeds RATES_LRU_CAP.
+export function beliefRates(db, lru) {
+  try {
+    const maxRow = db.query("SELECT MAX(tick_id) AS max_id FROM belief").get();
+    const maxTick = maxRow?.max_id ?? null;
+    if (lru.has(maxTick)) return lru.get(maxTick);
+    const result = beliefRatesRaw(db);
+    lru.set(maxTick, result);
+    // Evict oldest entries when over cap.
+    if (lru.size > RATES_LRU_CAP) {
+      const oldest = lru.keys().next().value;
+      lru.delete(oldest);
+    }
+    return result;
+  } catch {
+    return { maxTick: null, rows: [] };
+  }
+}
+
+// beliefRecent — return the last N beliefs newest-first, joined with tick.now_ms and tick.host.
+// Cap enforced at RECENT_MAX_LIMIT. Missing rules_sha column degrades to null.
+export function beliefRecent(db, { limit = RECENT_DEFAULT_LIMIT } = {}) {
+  try {
+    const safeLimit = Math.min(Math.max(1, limit), RECENT_MAX_LIMIT);
+    // Check if rules_sha column exists (same probe as belief-reader.mjs).
+    let tickCols;
+    try {
+      const cols = db.query("PRAGMA table_info(tick)").all();
+      const hasRulesSha = cols.some((c) => c.name === "rules_sha");
+      tickCols = hasRulesSha ? "t.now_ms AS ts_ms, t.host, t.rules_sha" : "t.now_ms AS ts_ms, t.host, NULL AS rules_sha";
+    } catch {
+      tickCols = "t.now_ms AS ts_ms, t.host, NULL AS rules_sha";
+    }
+    const rows = db.query(
+      `SELECT b.belief_id, b.tick_id, b.rule_id, b.name, b.subject, b.value,
+              b.source_fact_ids, b.stratum, ${tickCols}
+         FROM belief b
+         LEFT JOIN tick t ON t.tick_id = b.tick_id
+        ORDER BY b.belief_id DESC
+        LIMIT ?`
+    ).all(safeLimit);
+    return { rows };
+  } catch {
+    return { rows: [] };
+  }
+}
+
+// beliefCfg — return all cfg rows ordered by key.
+export function beliefCfg(db) {
+  try {
+    const rows = db.query("SELECT key, value_int, value_text FROM cfg ORDER BY key").all();
+    return { rows };
+  } catch {
+    return { rows: [] };
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/lib/belief-why.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/belief-why.mjs
@@ -1,0 +1,56 @@
+// belief-why.mjs — thin re-export of traceTicket/latestTickForTicket from
+// execution-core/beliefs/why.mjs, plus traceTicketJson that delegates the db
+// open to openBeliefsDbRO (no second open path).
+//
+// NOTE: DO NOT inline the specifiers below — computed specifiers required
+// (VITE-GRAPH GUARD, CTL-883). This file IS the single bun:sqlite-touching
+// path via governance-reader.mjs:openBeliefsDbRO; server.ts loads this file
+// itself via a computed specifier to keep that chain graph-isolated from the
+// Vite graph.
+
+// Re-export the resolver and the tick-finder so callers can drive them
+// directly without importing from execution-core (which has bun:sqlite at
+// top level via schema.mjs).
+
+const WHY_SPECIFIER = ["../../execution-core/beliefs/why.mjs"].join("");
+const READER_SPECIFIER = ["./governance-reader.mjs"].join("");
+
+let _why = null;
+async function getWhy() {
+  if (_why) return _why;
+  _why = await import(WHY_SPECIFIER);
+  return _why;
+}
+
+let _reader = null;
+async function getReader() {
+  if (_reader) return _reader;
+  _reader = await import(READER_SPECIFIER);
+  return _reader;
+}
+
+// traceTicketJson — one-shot wrapper:
+//   1. Opens the db via openBeliefsDbRO (read-only, create:false).
+//   2. If absent/unreadable returns empty trace immediately.
+//   3. Calls traceTicket, closes in finally, returns the result.
+//   4. On any resolver throw, returns the empty trace.
+//
+// opts.tickId: optional explicit tick_id (number); undefined = latest.
+export async function traceTicketJson({ ticket, tickId, dbPath } = {}) {
+  const emptyTrace = { ticket: ticket ?? null, tickId: null, beliefs: [] };
+  try {
+    const { openBeliefsDbRO } = await getReader();
+    const db = await openBeliefsDbRO(dbPath);
+    if (db == null) return emptyTrace;
+    try {
+      const { traceTicket } = await getWhy();
+      return traceTicket(db, ticket, tickId != null ? { tickId } : {});
+    } catch {
+      return emptyTrace;
+    } finally {
+      try { db.close(); } catch { /* already closed */ }
+    }
+  } catch {
+    return emptyTrace;
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/lib/governance-reader.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/governance-reader.d.mts
@@ -1,0 +1,42 @@
+// Type declarations for governance-reader.mjs (CTL-1100).
+// governance-reader.mjs lazy-imports bun:sqlite via a computed specifier so
+// esbuild cannot pull it into the browser bundle; these types give server.ts
+// and test files full type safety without a static bun:sqlite import.
+
+import type { Database } from "bun:sqlite";
+
+/**
+ * Resolve the beliefs.db path from the environment.
+ * Precedence: CATALYST_BELIEFS_DB › CATALYST_DIR/beliefs.db › ~/catalyst/beliefs.db.
+ */
+export declare function defaultBeliefsDbPath(env?: NodeJS.ProcessEnv): string;
+
+/**
+ * Open beliefs.db READ-ONLY (create:false).
+ * Returns null on any error (absent file, import failure, etc.).
+ * Never throws. Callers must treat null as "data unavailable".
+ */
+export declare function openBeliefsDbRO(dbPath: string): Promise<Database | null>;
+
+/**
+ * Single degradation wrapper for db-backed governance endpoints.
+ * Opens a RO handle, runs fn(db), closes in finally, returns fallback on null/throw.
+ */
+export declare function withBeliefsDbRO<T>(
+  dbPath: string,
+  fn: (db: Database) => T | Promise<T>,
+  fallback: T,
+): Promise<T>;
+
+/**
+ * The allowlist of event name prefixes that qualify as governance lifecycle events.
+ * One entry per pipeline step (phase.triage. … phase.teardown.) plus phase.remediate.
+ */
+export declare const GOVERNANCE_EVENT_PREFIXES: ReadonlyArray<string>;
+
+/**
+ * True iff the event name is a governance-relevant phase lifecycle event.
+ * Rejects names containing "reap" or "would." and reaper-family prefixes.
+ * Admits only names starting with a GOVERNANCE_EVENT_PREFIXES entry.
+ */
+export declare function isGovernanceEvent(name: string): boolean;

--- a/plugins/dev/scripts/orch-monitor/lib/governance-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/governance-reader.mjs
@@ -1,0 +1,103 @@
+// governance-reader.mjs — shared read-only foundation for all governance HTTP
+// endpoints (CTL-1100). Exports the canonical open/wrap helpers, the event
+// allowlist predicate, and the path resolver.
+//
+// VITE-GRAPH GUARD (same pattern as belief-reader.mjs, CTL-883):
+// execution-core/beliefs/schema.mjs has a top-level
+//   import { Database } from "bun:sqlite"
+// This module is imported by server.ts via a COMPUTED specifier so esbuild
+// cannot follow the dependency graph into bun:sqlite. See openBeliefsDbRO()
+// for the lazy import pattern. DO NOT change the computed specifier to a
+// string literal.
+//
+// Graceful degradation (audit-tap-must-not-be-load-bearing):
+// Every read endpoint that uses this module returns 200 + an empty/open payload
+// when the data source is absent. openBeliefsDbRO returns null (never throws)
+// on any failure; withBeliefsDbRO always closes the handle and always returns
+// the caller-supplied fallback when the db is unavailable or the fn throws.
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// defaultBeliefsDbPath — mirrors schema.mjs:33-37 env precedence exactly.
+// CATALYST_BELIEFS_DB wins; then CATALYST_DIR/beliefs.db; then ~/catalyst/beliefs.db.
+export function defaultBeliefsDbPath(env = process.env) {
+  if (env.CATALYST_BELIEFS_DB) return env.CATALYST_BELIEFS_DB;
+  const catalystDir = env.CATALYST_DIR || join(homedir(), "catalyst");
+  return join(catalystDir, "beliefs.db");
+}
+
+// openBeliefsDbRO — lazily open beliefs.db READ-ONLY.
+// Returns the db handle or null if the file is absent / import fails.
+// Callers must treat null as "data unavailable — degrade to empty".
+// DO NOT cache the returned handle long-term (avoids pinning a WAL checkpoint).
+export async function openBeliefsDbRO(dbPath) {
+  try {
+    const { Database } = await import("bun:sqlite");
+    return new Database(dbPath, { readonly: true, create: false });
+  } catch {
+    return null;
+  }
+}
+
+// withBeliefsDbRO — the single degradation wrapper for all db-backed endpoints.
+// Opens a RO handle, runs fn(db), closes in finally, returns fallback on null/throw.
+export async function withBeliefsDbRO(dbPath, fn, fallback) {
+  const db = await openBeliefsDbRO(dbPath);
+  if (db == null) return fallback;
+  try {
+    return await fn(db);
+  } catch {
+    return fallback;
+  } finally {
+    try { db.close(); } catch { /* already closed */ }
+  }
+}
+
+// GOVERNANCE_EVENT_PREFIXES — the allowlist of valid event name prefixes for
+// governance feed filtering. Covers every step in the workflow pipeline
+// (triage → teardown) plus the ancillary remediate step. Each prefix is
+// `phase.<step>.` so a startsWith check narrows the allow-region precisely
+// (e.g. `phase.terminal.reap-complete` is NOT admitted because `phase.terminal.`
+// is not in this set — CTL-1100 Phase 7 regression contract).
+export const GOVERNANCE_EVENT_PREFIXES = Object.freeze([
+  "phase.triage.",
+  "phase.research.",
+  "phase.plan.",
+  "phase.implement.",
+  "phase.verify.",
+  "phase.review.",
+  "phase.pr.",
+  "phase.monitor-merge.",
+  "phase.monitor-deploy.",
+  "phase.teardown.",
+  "phase.remediate.",
+]);
+
+// isGovernanceEvent — true iff the event name is a governance-relevant phase
+// lifecycle event that should appear in governance feeds.
+//
+// Two-step gate:
+//   1. Blocklist: reject names that contain "reap" or "would." or that start
+//      with the reaper-family prefixes (janitor. / worktree. / orphans.).
+//      This structural guard means a future reap type is safe regardless of its
+//      exact name, provided it contains "reap" or "would." or carries a
+//      reaper-family prefix.
+//   2. Allowlist: the name must start with one of GOVERNANCE_EVENT_PREFIXES.
+//      A bare `startsWith("phase.")` would wrongly admit
+//      `phase.terminal.reap-complete` and `phase.predecessor.reap-requested`
+//      (Phase 7 regression contract). Only the curated per-step prefixes admit.
+export function isGovernanceEvent(name) {
+  // Blocklist check.
+  if (
+    name.includes("reap") ||
+    name.includes("would.") ||
+    name.startsWith("janitor.") ||
+    name.startsWith("worktree.") ||
+    name.startsWith("orphans.")
+  ) {
+    return false;
+  }
+  // Allowlist check.
+  return GOVERNANCE_EVENT_PREFIXES.some((prefix) => name.startsWith(prefix));
+}

--- a/plugins/dev/scripts/orch-monitor/lib/journey.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/journey.d.mts
@@ -1,0 +1,64 @@
+// Type declarations for journey.mjs (CTL-1100).
+// Bun:sqlite-free (uses sqlite3 binary via ticket-runs.mjs); safe for static
+// import in server.ts. Keep in sync with journey.mjs.
+
+export interface JourneyHop {
+  phase: string;
+  eventType: string;
+  ts: string;
+  bg_job_id?: string | null;
+  generation?: number | null;
+  reason?: string | null;
+  blockers?: string[] | null;
+}
+
+export interface GateChecklistItem {
+  phase: string;
+  signalStatus: string | null;
+  satisfied: boolean;
+}
+
+export interface GateChecklist {
+  nextPhase: string | null;
+  checklist: GateChecklistItem[];
+  remediateCycles: number;
+}
+
+export interface VerifyVerdictDetail {
+  verdict: string | null;
+  regressionRisk: number | null;
+  highFindings: number;
+  reason: string | null;
+}
+
+export interface UnblockHint {
+  kind: "operator-note" | "held-reason";
+  note?: string;
+  reason?: string | null;
+  blockers?: string[] | null;
+  respondedAt?: string;
+}
+
+export interface Journey {
+  ticket: string;
+  hops: JourneyHop[];
+  gates: GateChecklist;
+  verifyVerdict: VerifyVerdictDetail;
+  remediateCycles: number;
+  unblockHints: UnblockHint[];
+  hosts: string[];
+}
+
+export interface JourneyOptions {
+  workersDir?: string;
+  orchDir?: string;
+  eventLogPath?: string;
+  dbPath?: string;
+}
+
+export declare function scanHops(ticket: string, opts?: { eventLogPath?: string }): JourneyHop[];
+export declare function dedupeHops(hops: JourneyHop[]): JourneyHop[];
+export declare function readVerifyVerdictDetail(ticket: string, opts?: { orchDir?: string }): VerifyVerdictDetail;
+export declare function buildGateChecklist(ticket: string, opts?: { orchDir?: string; eventLogPath?: string }): GateChecklist;
+export declare function collectUnblockHints(ticket: string, opts?: { orchDir?: string; hops?: JourneyHop[] }): UnblockHint[];
+export declare function assembleJourney(ticket: string, opts?: JourneyOptions): Promise<Journey>;

--- a/plugins/dev/scripts/orch-monitor/lib/journey.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/journey.mjs
@@ -1,0 +1,235 @@
+// journey.mjs — GET /api/journey/:ticket data assembly (CTL-1100 Phase 5).
+// bun:sqlite-free throughout (ticket-runs uses the sqlite3 binary, not bun:sqlite).
+// Plain static import safe in server.ts.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// ── dependency imports ───────────────────────────────────────────────────────
+
+import { scanEventsChunked } from "../../execution-core/event-tail.mjs";
+import { deriveAdvancement, readPhaseSignals } from "../../execution-core/scheduler.mjs";
+import { readVerifyVerdict } from "../../execution-core/work-done-probes.mjs";
+import { countRemediateCycles } from "../../execution-core/event-scan.mjs";
+import { assembleTicketRuns } from "./ticket-runs.mjs";
+import { PHASE_ORDER } from "./board-data.mjs";
+
+// ── defaults ─────────────────────────────────────────────────────────────────
+
+function defaultOrchDir() {
+  return join(homedir(), "catalyst", "execution-core");
+}
+
+function defaultWorkersDir() {
+  return join(defaultOrchDir(), "workers");
+}
+
+function defaultEventLogPath() {
+  const now = new Date();
+  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  return join(homedir(), "catalyst", "events", `${ym}.jsonl`);
+}
+
+// ── scanHops ─────────────────────────────────────────────────────────────────
+// Scan the event log for `phase.*.<ticket>` events. Uses exact suffix
+// ".ticket" so CTL-9001 never matches CTL-90010 (leading-dot suffix fix).
+// Returns an array of raw hop objects (may have duplicates).
+export function scanHops(ticket, { eventLogPath = defaultEventLogPath() } = {}) {
+  const suffix = "." + ticket;
+  const hops = [];
+  try {
+    scanEventsChunked({
+      path: eventLogPath,
+      onEvent: (ev) => {
+        const name = ev?.attributes?.["event.name"];
+        if (typeof name !== "string") return;
+        if (!name.startsWith("phase.")) return;
+        if (!name.endsWith(suffix)) return;
+        // Parse: "phase.<phase>.<eventType>.<ticket>"
+        // Strip "phase." prefix and ".<ticket>" suffix, split on first ".".
+        const inner = name.slice("phase.".length, name.length - suffix.length);
+        const dotIdx = inner.indexOf(".");
+        if (dotIdx < 0) return;
+        const phase = inner.slice(0, dotIdx);
+        const eventType = inner.slice(dotIdx + 1);
+        const payload = ev?.body?.payload ?? {};
+        hops.push({
+          phase,
+          eventType,
+          ts: ev?.ts ?? "",
+          host: ev?.resource?.["host.name"] ?? ev?.resource?.["service.instance.id"] ?? "",
+          bg_job_id: payload.bg_job_id ?? undefined,
+          reason: payload.reason ?? undefined,
+          targetPhase: payload.target_phase ?? undefined,
+          blockers: Array.isArray(payload.blockers) ? payload.blockers : undefined,
+        });
+      },
+    });
+  } catch { /* missing log or parse error — degrade to [] */ }
+  return hops;
+}
+
+// ── dedupeHops ───────────────────────────────────────────────────────────────
+// Dedup by (phase, eventType, bg_job_id|generation|ts). Keep earliest.
+// Sort ascending by ts (unparseable sorts last).
+export function dedupeHops(hops) {
+  const seen = new Map();
+  for (const h of hops) {
+    const key = `${h.phase}|${h.eventType}|${h.bg_job_id ?? h.generation ?? h.ts}`;
+    const existing = seen.get(key);
+    if (!existing || Date.parse(h.ts) < Date.parse(existing.ts)) {
+      seen.set(key, h);
+    }
+  }
+  return [...seen.values()].sort((a, b) => {
+    const ta = Date.parse(a.ts);
+    const tb = Date.parse(b.ts);
+    if (isNaN(ta) && isNaN(tb)) return 0;
+    if (isNaN(ta)) return 1;
+    if (isNaN(tb)) return -1;
+    return ta - tb;
+  });
+}
+
+// ── readVerifyVerdictDetail ───────────────────────────────────────────────────
+// Reads verify.json for raw drivers plus calls readVerifyVerdict for
+// the canonical pass/fail/null classification.
+export function readVerifyVerdictDetail(ticket, { orchDir = defaultOrchDir() } = {}) {
+  const empty = { verdict: null, regressionRisk: null, highFindings: 0, reason: null };
+  if (!ticket || !orchDir) return empty;
+  try {
+    const path = join(orchDir, "workers", ticket, "verify.json");
+    const raw = JSON.parse(readFileSync(path, "utf8"));
+    const regressionRisk = typeof raw.regression_risk === "number" ? raw.regression_risk : null;
+    const highFindings = Array.isArray(raw.findings)
+      ? raw.findings.filter((f) => f?.severity === "high").length
+      : 0;
+    const verdict = readVerifyVerdict({ ticket, orchDir });
+    let reason = null;
+    if (verdict === "fail") {
+      if (regressionRisk != null && regressionRisk >= 5) reason = "regression_risk";
+      else if (highFindings > 0) reason = "high_severity_finding";
+    }
+    return { verdict, regressionRisk, highFindings, reason };
+  } catch {
+    return empty;
+  }
+}
+
+// ── buildGateChecklist ────────────────────────────────────────────────────────
+// Reads signals, verdict, cycles. Calls deriveAdvancement to compute nextPhase.
+// Returns { nextPhase, checklist[], remediateCycles }.
+export function buildGateChecklist(ticket, { orchDir = defaultOrchDir(), eventLogPath } = {}) {
+  const empty = { nextPhase: null, checklist: [], remediateCycles: 0 };
+  if (!ticket || !orchDir) return empty;
+  try {
+    const signals = readPhaseSignals(orchDir, ticket);
+    const { verdict } = readVerifyVerdictDetail(ticket, { orchDir });
+    let remediateCycles = 0;
+    try {
+      remediateCycles = countRemediateCycles({
+        ticket,
+        path: eventLogPath ?? defaultEventLogPath(),
+      });
+    } catch { /* no event log or error — stay at 0 */ }
+
+    const nextPhase = deriveAdvancement(signals, {
+      verifyVerdict: verdict ?? undefined,
+      remediateCycleCount: remediateCycles,
+    });
+
+    const checklist = PHASE_ORDER.map((phase) => {
+      const signalStatus = signals[phase] ?? null;
+      const satisfied = signalStatus === "done" ||
+        (phase === "monitor-deploy" && signalStatus === "skipped");
+      return { phase, signalStatus, satisfied };
+    });
+
+    return { nextPhase, checklist, remediateCycles };
+  } catch {
+    return empty;
+  }
+}
+
+// ── collectUnblockHints ───────────────────────────────────────────────────────
+// Returns operator-note hints from .respond-<phase>.json files and the latest
+// phase.advance.held hop's reason/blockers.
+export function collectUnblockHints(ticket, { orchDir = defaultOrchDir(), hops = [] } = {}) {
+  const hints = [];
+  if (!ticket || !orchDir) return hints;
+  // Operator respond notes from .respond-<phase>.json files.
+  const workerDir = join(orchDir, "workers", ticket);
+  try {
+    const files = readdirSync(workerDir);
+    for (const f of files) {
+      if (!f.startsWith(".respond-") || !f.endsWith(".json")) continue;
+      try {
+        const data = JSON.parse(readFileSync(join(workerDir, f), "utf8"));
+        if (data.response) {
+          hints.push({ kind: "operator-note", note: data.response, respondedAt: data.respondedAt });
+        }
+      } catch { /* malformed respond file — skip */ }
+    }
+  } catch { /* no worker dir — no hints */ }
+
+  // Latest held event's reason/blockers.
+  const held = [...hops].filter((h) => h.phase === "advance" && h.eventType === "held");
+  const latest = held.sort((a, b) => Date.parse(b.ts) - Date.parse(a.ts))[0];
+  if (latest && (latest.reason || latest.blockers)) {
+    hints.push({ kind: "held-reason", reason: latest.reason, blockers: latest.blockers });
+  }
+
+  return hints;
+}
+
+// ── assembleJourney ──────────────────────────────────────────────────────────
+// Top-level assembler. Returns the full journey shape. Never throws.
+export async function assembleJourney(ticket, {
+  workersDir = defaultWorkersDir(),
+  orchDir = defaultOrchDir(),
+  eventLogPath = defaultEventLogPath(),
+  dbPath,
+} = {}) {
+  const empty = {
+    ticket,
+    hops: [],
+    gates: { checklist: [], nextPhase: null },
+    verifyVerdict: { verdict: null, regressionRisk: null, highFindings: 0, reason: null },
+    remediateCycles: 0,
+    unblockHints: [],
+    hosts: [],
+  };
+  try {
+    const [spine, verdictDetail] = await Promise.all([
+      (async () => {
+        try {
+          return await assembleTicketRuns(ticket, { workersDir, dbPath });
+        } catch { return { ticket, runs: [] }; }
+      })(),
+      Promise.resolve(readVerifyVerdictDetail(ticket, { orchDir })),
+    ]);
+
+    const rawHops = scanHops(ticket, { eventLogPath });
+    const hops = dedupeHops(rawHops);
+    const gates = buildGateChecklist(ticket, { orchDir, eventLogPath });
+    const unblockHints = collectUnblockHints(ticket, { orchDir, hops });
+
+    // hosts = deduped union of hop hosts + spine run hosts.
+    const hostSet = new Set();
+    for (const h of hops) if (h.host) hostSet.add(h.host);
+    for (const r of (spine.runs ?? [])) if (r.host?.name) hostSet.add(r.host.name);
+
+    return {
+      ticket,
+      hops,
+      gates: { checklist: gates.checklist, nextPhase: gates.nextPhase },
+      verifyVerdict: verdictDetail,
+      remediateCycles: gates.remediateCycles,
+      unblockHints,
+      hosts: [...hostSet],
+    };
+  } catch {
+    return empty;
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -47,6 +47,8 @@ import {
   beliefRecent,
   beliefCfg,
 } from "./lib/belief-store-queries.mjs";
+// CTL-1100: journey assembler (bun:sqlite-free — plain static import safe).
+import { assembleJourney } from "./lib/journey.mjs";
 // CTL-887 (BFF5): the live transcript tail for execution-core workers. The
 // legacy /api/worker-stream reads the Plane-B runs/ tree (empty for EC); this
 // is the EC equivalent — tails ~/.claude/projects/*/<sessionId>.jsonl and
@@ -2900,6 +2902,27 @@ export function createServer(opts: CreateServerOptions): BunServer {
             eventCount24h: stats.eventCount24h,
             eventCount24hByRepo: stats.eventCount24hByRepo,
           });
+        }
+
+        // CTL-1100: GET /api/journey/:ticket — chronological hop timeline + gates + verdict.
+        // bun:sqlite-free (assembleJourney uses sqlite3 binary via ticket-runs.mjs).
+        // Mirrors ticketRunsMatch guard for input validation.
+        const journeyMatch = url.pathname.match(/^\/api\/journey\/([^/]+)$/);
+        if (journeyMatch) {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(journeyMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          return Response.json(await assembleJourney(ticket, {
+            orchDir: wtDir,
+            workersDir: `${wtDir}/workers`,
+            dbPath,
+          }));
         }
 
         // CTL-886 (BFF4) keystone P2: a ticket's full run history. One run entity

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -36,6 +36,9 @@ import {
   assembleTicketRuns,
   readPhaseSignalVerbatim,
 } from "./lib/ticket-runs.mjs";
+// CTL-1100: FSM descriptor endpoint. Confirmed bun:sqlite-free (no computed
+// specifier needed — plain static import is safe for Vite/esbuild graph).
+import { buildFsmDescriptor } from "../lib/fsm-descriptor.mjs";
 // CTL-887 (BFF5): the live transcript tail for execution-core workers. The
 // legacy /api/worker-stream reads the Plane-B runs/ tree (empty for EC); this
 // is the EC equivalent — tails ~/.claude/projects/*/<sessionId>.jsonl and
@@ -3687,6 +3690,14 @@ export function createServer(opts: CreateServerOptions): BunServer {
               "Access-Control-Allow-Origin": "*",
             },
           });
+        }
+
+        // ── CTL-1100 governance read endpoints ──────────────────────────────
+        // Inserted between the /api/beliefs/stream block and the 404 fallthrough.
+        // Re-locate by grep after each insertion — line numbers shift.
+
+        if (url.pathname === "/api/fsm/descriptor") {
+          return Response.json(await buildFsmDescriptor());
         }
 
         return new Response("Not Found", { status: 404 });

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -3752,6 +3752,20 @@ export function createServer(opts: CreateServerOptions): BunServer {
         // Inserted between the /api/beliefs/stream block and the 404 fallthrough.
         // Re-locate by grep after each insertion — line numbers shift.
 
+        // GET /api/governance — current daemon governance config snapshot.
+        // DO NOT inline the specifier (computed import, VITE-GRAPH GUARD, CTL-883).
+        if (url.pathname === "/api/governance") {
+          const configSpecifier = ["../execution-core/config.mjs"].join("");
+          try {
+            const { readGovernanceConfig } = await import(configSpecifier) as {
+              readGovernanceConfig: (env?: NodeJS.ProcessEnv) => Record<string, unknown>;
+            };
+            return Response.json({ available: true, ...readGovernanceConfig() });
+          } catch {
+            return Response.json({ available: false });
+          }
+        }
+
         if (url.pathname === "/api/fsm/descriptor") {
           return Response.json(await buildFsmDescriptor());
         }

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1226,10 +1226,26 @@ export function createServer(opts: CreateServerOptions): BunServer {
           const readerMod = ["./lib/governance-reader.mjs"].join("");
           const whyMod = ["../execution-core/beliefs/why.mjs"].join("");
           const rulesMod = ["../execution-core/beliefs/rules.mjs"].join("");
+          // Structural casts (not `typeof import(specifier)`) keep the computed
+          // specifiers erased at build — preserving the VITE-GRAPH GUARD — while
+          // typing the destructure so the no-unsafe-* lint rules pass without
+          // authoring .d.mts for the execution-core modules. Mirrors loadDaemonDeps
+          // (server.ts ~1188). CTL-1100 phase-review remediation.
           const [reader, why, rules] = await Promise.all([
-            import(readerMod),
-            import(whyMod),
-            import(rulesMod),
+            import(readerMod) as Promise<{
+              openBeliefsDbRO: (p: string) => Promise<import("bun:sqlite").Database | null>;
+              withBeliefsDbRO: <T>(p: string, fn: (db: import("bun:sqlite").Database) => T, fallback: T) => Promise<T>;
+              defaultBeliefsDbPath: (env?: NodeJS.ProcessEnv) => string;
+              isGovernanceEvent: (name: string) => boolean;
+            }>,
+            import(whyMod) as Promise<{
+              traceTicket: (db: import("bun:sqlite").Database, ticket: string, opts?: { tickId?: number | null }) => unknown;
+              latestTickForTicket: (db: import("bun:sqlite").Database, ticket: string) => number | null;
+            }>,
+            import(rulesMod) as Promise<{
+              RULE_MANIFEST: unknown;
+              RULES_SHA: string;
+            }>,
           ]);
           return {
             openBeliefsDbRO: reader.openBeliefsDbRO,

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -3783,6 +3783,47 @@ export function createServer(opts: CreateServerOptions): BunServer {
           );
         }
 
+        // GET /api/beliefs/why?ticket=<ticket>[&tick=<tickId>]
+        // HTTP wrapper over traceTicket() — same resolver as `catalyst why`.
+        // Input validation (ticket required, /^[A-Za-z]+-\d+$/, tick must be
+        // integer) happens BEFORE any db touch so traversal attempts are
+        // rejected before reaching the db. Degrades to 200+empty trace when
+        // beliefs.db absent or unreadable (no 500).
+        // NOTE: DO NOT inline the specifier — computed import required (CTL-883).
+        if (url.pathname === "/api/beliefs/why") {
+          const rawTicket = url.searchParams.get("ticket");
+          if (!rawTicket) return new Response("ticket required", { status: 400 });
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(rawTicket);
+          } catch {
+            return new Response("invalid ticket encoding", { status: 400 });
+          }
+          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+            return new Response("invalid ticket format", { status: 400 });
+          }
+          const rawTick = url.searchParams.get("tick");
+          let tickId: number | undefined;
+          if (rawTick != null) {
+            const parsed = parseInt(rawTick, 10);
+            if (!Number.isInteger(parsed) || String(parsed) !== rawTick.trim()) {
+              return new Response("tick must be an integer", { status: 400 });
+            }
+            tickId = parsed;
+          }
+          // DO NOT inline this specifier (VITE-GRAPH GUARD, CTL-883).
+          const whyMod = ["./lib/belief-why.mjs"].join("");
+          try {
+            const { traceTicketJson } = await import(whyMod) as {
+              traceTicketJson: (opts: { ticket: string; tickId?: number; dbPath: string }) => Promise<unknown>;
+            };
+            const trace = await traceTicketJson({ ticket, tickId, dbPath: govDbPath() });
+            return Response.json(trace);
+          } catch {
+            return Response.json({ ticket, tickId: null, beliefs: [] });
+          }
+        }
+
         return new Response("Not Found", { status: 404 });
       } catch (err) {
         console.error(`[server] fetch handler error:`, err);

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -2921,7 +2921,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
           return Response.json(await assembleJourney(ticket, {
             orchDir: wtDir,
             workersDir: `${wtDir}/workers`,
-            dbPath,
+            dbPath: dbPath ?? undefined,
           }));
         }
 

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -39,6 +39,14 @@ import {
 // CTL-1100: FSM descriptor endpoint. Confirmed bun:sqlite-free (no computed
 // specifier needed — plain static import is safe for Vite/esbuild graph).
 import { buildFsmDescriptor } from "../lib/fsm-descriptor.mjs";
+// CTL-1100: belief store query functions (pure, db-injected). belief-store-queries.mjs
+// has no static bun:sqlite import — plain static import is safe for Vite/esbuild graph.
+import {
+  beliefSummary,
+  beliefRates,
+  beliefRecent,
+  beliefCfg,
+} from "./lib/belief-store-queries.mjs";
 // CTL-887 (BFF5): the live transcript tail for execution-core workers. The
 // legacy /api/worker-stream reads the Plane-B runs/ tree (empty for EC); this
 // is the EC equivalent — tails ~/.claude/projects/*/<sessionId>.jsonl and
@@ -358,6 +366,12 @@ export interface CreateServerOptions {
   previewFetcher?: PreviewFetcher | null;
   previewRefreshMs?: number;
   annotationsDbPath?: string;
+  /**
+   * CTL-1100: override for beliefs.db used by governance read endpoints.
+   * Production resolves via defaultBeliefsDbPath(process.env); tests inject
+   * a seeded temp path so routes don't read the live beliefs store.
+   */
+  beliefStoreDbPath?: string;
   /**
    * Override for the broker's durable filter-state.db (ticket_state cache) used
    * by the cache-backed Linear detail/search routes (CTL-889, P8/P12). Defaults
@@ -775,6 +789,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     previewRefreshMs = PREVIEW_REFRESH_MS,
     annotationsDbPath,
     filterStateDbPath,
+    beliefStoreDbPath,
     commsReader: commsReaderOpt,
     webhookConfig,
     linearWebhookConfig,
@@ -800,6 +815,24 @@ export function createServer(opts: CreateServerOptions): BunServer {
       { cause: err },
     );
   }
+
+  // CTL-1100: in-process LRU cache for /api/beliefs/rates (keyed by max tick_id,
+  // cap RATES_LRU_CAP=64; beliefs are insert-only so the cached value per max tick
+  // is invariant). One cache per server lifetime.
+  const beliefRatesCache = new Map<number | null, unknown>();
+
+  // CTL-1100: resolve the beliefs.db path for governance read endpoints.
+  // Per-request resolution inside handlers — never at module top level — so a
+  // server started before beliefs.db exists picks it up later without restart.
+  const govDbPath = (): string => {
+    if (beliefStoreDbPath) return beliefStoreDbPath;
+    const govDeps = governanceDepsPromise; // best-effort sync peek (may be null)
+    void govDeps; // suppress unused warning — govDbPath resolves via env below
+    // Inline the same precedence as defaultBeliefsDbPath to avoid a dependency cycle.
+    if (process.env.CATALYST_BELIEFS_DB) return process.env.CATALYST_BELIEFS_DB;
+    const cDir = catalystDirOpt ?? process.env.CATALYST_DIR ?? `${process.env.HOME}/catalyst`;
+    return `${cDir}/beliefs.db`;
+  };
 
   // Forward reference: the webhook handler is constructed below but
   // the prFetcher's freshness filter needs to call into it. We hold a mutable
@@ -3698,6 +3731,56 @@ export function createServer(opts: CreateServerOptions): BunServer {
 
         if (url.pathname === "/api/fsm/descriptor") {
           return Response.json(await buildFsmDescriptor());
+        }
+
+        // GET /api/beliefs/rules — served from frozen RULE_MANIFEST; no db required.
+        if (url.pathname === "/api/beliefs/rules") {
+          const govDeps = await loadGovernanceDeps();
+          const manifest = govDeps?.RULE_MANIFEST ?? null;
+          if (!manifest) return Response.json({ rules: [], strata: [] });
+          return Response.json(manifest);
+        }
+
+        // GET /api/beliefs/summary — latest-tick aggregate per belief name.
+        if (url.pathname === "/api/beliefs/summary") {
+          const dbPath = govDbPath();
+          const govDeps = await loadGovernanceDeps();
+          if (!govDeps) return Response.json({ tickId: null, rows: [] });
+          return Response.json(
+            await govDeps.withBeliefsDbRO(dbPath, (db) => beliefSummary(db), { tickId: null, rows: [] })
+          );
+        }
+
+        // GET /api/beliefs/rates — full belief counts per rule_id per tick (LRU cached).
+        if (url.pathname === "/api/beliefs/rates") {
+          const dbPath = govDbPath();
+          const govDeps = await loadGovernanceDeps();
+          if (!govDeps) return Response.json({ maxTick: null, rows: [] });
+          return Response.json(
+            await govDeps.withBeliefsDbRO(dbPath, (db) => beliefRates(db, beliefRatesCache), { maxTick: null, rows: [] })
+          );
+        }
+
+        // GET /api/beliefs/recent — newest-first belief rows, limit param.
+        if (url.pathname === "/api/beliefs/recent") {
+          const dbPath = govDbPath();
+          const govDeps = await loadGovernanceDeps();
+          if (!govDeps) return Response.json({ rows: [] });
+          const limitParam = url.searchParams.get("limit");
+          const limit = limitParam ? Math.max(1, parseInt(limitParam, 10) || 50) : undefined;
+          return Response.json(
+            await govDeps.withBeliefsDbRO(dbPath, (db) => beliefRecent(db, { limit }), { rows: [] })
+          );
+        }
+
+        // GET /api/beliefs/cfg — static config rows from the beliefs store.
+        if (url.pathname === "/api/beliefs/cfg") {
+          const dbPath = govDbPath();
+          const govDeps = await loadGovernanceDeps();
+          if (!govDeps) return Response.json({ rows: [] });
+          return Response.json(
+            await govDeps.withBeliefsDbRO(dbPath, (db) => beliefCfg(db), { rows: [] })
+          );
         }
 
         return new Response("Not Found", { status: 404 });

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1164,6 +1164,58 @@ export function createServer(opts: CreateServerOptions): BunServer {
     }
     return daemonDepsPromise;
   };
+
+  // loadGovernanceDeps — memoized loader for governance read endpoints.
+  // Imports lib/governance-reader.mjs + execution-core/beliefs/why.mjs +
+  // execution-core/beliefs/rules.mjs via computed specifiers so bun:sqlite
+  // never reaches the Vite/esbuild browser bundle (CTL-883 VITE-GRAPH GUARD).
+  // Returns null on any import failure — all callers degrade gracefully.
+  // DO NOT inline the specifiers to string literals (see governance-reader.mjs header).
+  let governanceDepsPromise: Promise<{
+    openBeliefsDbRO: (p: string) => Promise<import("bun:sqlite").Database | null>;
+    withBeliefsDbRO: <T>(p: string, fn: (db: import("bun:sqlite").Database) => T, fallback: T) => Promise<T>;
+    defaultBeliefsDbPath: (env?: NodeJS.ProcessEnv) => string;
+    isGovernanceEvent: (name: string) => boolean;
+    traceTicket: (db: import("bun:sqlite").Database, ticket: string, opts?: { tickId?: number | null }) => unknown;
+    latestTickForTicket: (db: import("bun:sqlite").Database, ticket: string) => number | null;
+    RULE_MANIFEST: unknown;
+    RULES_SHA: string;
+  } | null> | null = null;
+  const loadGovernanceDeps = () => {
+    if (!governanceDepsPromise) {
+      governanceDepsPromise = (async () => {
+        try {
+          const readerMod = ["./lib/governance-reader.mjs"].join("");
+          const whyMod = ["../execution-core/beliefs/why.mjs"].join("");
+          const rulesMod = ["../execution-core/beliefs/rules.mjs"].join("");
+          const [reader, why, rules] = await Promise.all([
+            import(readerMod),
+            import(whyMod),
+            import(rulesMod),
+          ]);
+          return {
+            openBeliefsDbRO: reader.openBeliefsDbRO,
+            withBeliefsDbRO: reader.withBeliefsDbRO,
+            defaultBeliefsDbPath: reader.defaultBeliefsDbPath,
+            isGovernanceEvent: reader.isGovernanceEvent,
+            traceTicket: why.traceTicket,
+            latestTickForTicket: why.latestTickForTicket,
+            RULE_MANIFEST: rules.RULE_MANIFEST,
+            RULES_SHA: rules.RULES_SHA,
+          };
+        } catch {
+          return null; // execution-core unavailable → degrade
+        }
+      })();
+    }
+    return governanceDepsPromise;
+  };
+
+  // Route-insertion anchor for CTL-1100 governance read endpoints.
+  // New /api/fsm/*, /api/beliefs/*, /api/governance, /api/journey/:ticket
+  // routes insert between the /api/beliefs/stream branch and the 404 fallthrough.
+  // Re-locate this anchor by grep after each insertion — cited line numbers shift.
+
   const productionDaemonHealth = async (): Promise<DaemonHealth> => {
     try {
       const deps = await loadDaemonDeps();

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
@@ -37,6 +37,8 @@ import { ALL_NODES, NodeScopeContext, type NodeScope } from "@/lib/node-scope";
 // one EventSource each instead of opening independent duplicate connections.
 import { useNavSignal, NavSignalContext } from "@/hooks/use-nav-signal";
 import { useClusterSignal, ClusterSignalContext } from "@/hooks/use-cluster-signal";
+// CTL-1100: lift useBeliefs into AppShell so no surface opens a second EventSource.
+import { useBeliefs, BeliefsContext } from "@/hooks/use-beliefs";
 import {
   readSidebarOpen,
   writeSidebarOpen,
@@ -152,6 +154,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   // these hooks independently, reducing persistent EventSources from 6 → 4.
   const navSignal = useNavSignal();
   const clusterSignal = useClusterSignal();
+  // CTL-1100: single belief stream subscription — surfaces use useBeliefsContext().
+  const beliefsState = useBeliefs();
 
   // Persist collapse state across reloads (the controlled provider replaces the
   // primitive's cookie path; localStorage is the source of truth here). Logic +
@@ -350,6 +354,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const crumbs = detailId != null ? [...baseCrumbs, detailId] : baseCrumbs;
 
   return (
+    <BeliefsContext.Provider value={beliefsState}>
     <NavSignalContext.Provider value={navSignal}>
     <ClusterSignalContext.Provider value={clusterSignal}>
       <NodeScopeContext.Provider value={nodeScopeCtx}>
@@ -533,5 +538,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       </NodeScopeContext.Provider>
     </ClusterSignalContext.Provider>
     </NavSignalContext.Provider>
+    </BeliefsContext.Provider>
   );
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/governance/derivation-tree.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/governance/derivation-tree.tsx
@@ -1,0 +1,78 @@
+// derivation-tree.tsx — CTL-1100 Phase 6: recursive TraceResult tree.
+// Modeled on board/subworker-tree.tsx. rule-id chip click → onOpenSource.
+import type { TraceResult, TraceBelief, TraceSource } from "../../lib/why-model";
+
+interface SourceChipProps {
+  ruleId: string;
+  onOpenSource?: (ruleId: string) => void;
+}
+
+function RuleChip({ ruleId, onOpenSource }: SourceChipProps) {
+  return (
+    <button
+      className="rounded bg-muted px-1 py-0.5 font-mono text-xs hover:bg-muted/80"
+      onClick={() => onOpenSource?.(ruleId)}
+      type="button"
+    >
+      {ruleId}
+    </button>
+  );
+}
+
+interface SourceRowProps {
+  source: TraceSource;
+}
+
+function SourceRow({ source }: SourceRowProps) {
+  return (
+    <li className="flex items-start gap-1 text-xs text-muted-foreground">
+      <span className="shrink-0 font-mono">[{source.table}#{source.id}]</span>
+      <span className="truncate">{source.summary}</span>
+    </li>
+  );
+}
+
+interface BeliefNodeProps {
+  belief: TraceBelief;
+  onOpenSource?: (ruleId: string) => void;
+}
+
+function BeliefNode({ belief, onOpenSource }: BeliefNodeProps) {
+  return (
+    <div className="rounded border border-border p-2 text-sm">
+      <div className="flex items-center gap-2 font-medium">
+        <span>{belief.name}({belief.subject})</span>
+        <RuleChip ruleId={belief.rule_id} onOpenSource={onOpenSource} />
+        {belief.value && <span className="text-muted-foreground">{belief.value}</span>}
+      </div>
+      {belief.sources.length > 0 && (
+        <ul className="mt-1 space-y-0.5 pl-3">
+          {belief.sources.map((s, i) => (
+            <SourceRow key={i} source={s} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+interface DerivationTreeProps {
+  trace: TraceResult;
+  onOpenSource?: (ruleId: string) => void;
+}
+
+export function DerivationTree({ trace, onOpenSource }: DerivationTreeProps) {
+  if (!trace.tickId) {
+    return <p className="text-sm text-muted-foreground">no derivation recorded</p>;
+  }
+  if (trace.beliefs.length === 0) {
+    return <p className="text-sm text-muted-foreground">no beliefs at tick #{trace.tickId}</p>;
+  }
+  return (
+    <div className="space-y-2">
+      {trace.beliefs.map((b) => (
+        <BeliefNode key={b.belief_id} belief={b} onOpenSource={onOpenSource} />
+      ))}
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/governance/governance-flags-chip.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/governance/governance-flags-chip.tsx
@@ -1,0 +1,72 @@
+// governance-flags-chip.tsx — CTL-1100 Phase 6: governance mode status chips.
+// Fetches /api/governance once with capped retry. Degrades to placeholder when
+// absent or unavailable. Modeled on Board.tsx ScopeChip/StatusBadge pattern.
+import { useEffect, useState } from "react";
+import {
+  isGovernanceSnapshot,
+  flagTone,
+  modeTone,
+  GOVERNANCE_FLAG_LABELS,
+  type GovernanceSnapshot,
+} from "../../lib/governance-model";
+
+const MAX_RETRIES = 3;
+
+export function GovernanceFlagsChip() {
+  const [snapshot, setSnapshot] = useState<GovernanceSnapshot | null>(null);
+  const [retries, setRetries] = useState(0);
+
+  useEffect(() => {
+    if (retries > MAX_RETRIES) return;
+    let cancelled = false;
+    fetch("/api/governance")
+      .then((r) => r.json())
+      .then((body) => {
+        if (cancelled) return;
+        if (isGovernanceSnapshot(body)) setSnapshot(body);
+        else setRetries((r) => r + 1);
+      })
+      .catch(() => {
+        if (!cancelled) setRetries((r) => r + 1);
+      });
+    return () => { cancelled = true; };
+  }, [retries]);
+
+  if (!snapshot || !snapshot.available) {
+    return <span className="text-muted-foreground text-xs">governance —</span>;
+  }
+
+  const boolFlags = ["beliefsShadow", "diagnostician", "intentsEnforce", "advanceShadowSummary"] as const;
+  const modeFlags = ["stallJanitor", "watchdog", "unstuckSweep"] as const;
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {boolFlags.map((key) => {
+        const val = snapshot[key] ?? false;
+        const tone = flagTone(val);
+        return (
+          <span
+            key={key}
+            title={GOVERNANCE_FLAG_LABELS[key]}
+            className={`rounded px-1 py-0.5 text-xs font-mono ${tone === "green" ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200" : "bg-muted text-muted-foreground"}`}
+          >
+            {GOVERNANCE_FLAG_LABELS[key] ?? key}
+          </span>
+        );
+      })}
+      {modeFlags.map((key) => {
+        const val = (snapshot[key] as { mode?: string } | undefined)?.mode ?? "off";
+        const tone = modeTone(val);
+        return (
+          <span
+            key={key}
+            title={`${GOVERNANCE_FLAG_LABELS[key] ?? key}: ${val}`}
+            className={`rounded px-1 py-0.5 text-xs font-mono ${tone === "green" ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200" : tone === "yellow" ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200" : "bg-muted text-muted-foreground"}`}
+          >
+            {GOVERNANCE_FLAG_LABELS[key] ?? key}:{val}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/governance/journey-strip.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/governance/journey-strip.tsx
@@ -1,0 +1,32 @@
+// journey-strip.tsx — CTL-1100 Phase 6: 10-phase horizontal status strip.
+// Modeled on components/home/phase-strip.tsx. Pure CSS colors from board/phase-model.
+import { journeyPhaseStatus, PHASE_LIST, type Journey } from "../../lib/journey-model";
+
+const STATUS_CLASSES: Record<string, string> = {
+  done:    "bg-green-500",
+  current: "bg-blue-500",
+  failed:  "bg-red-500",
+  pending: "bg-muted",
+};
+
+interface PhaseDotsProps {
+  journey: Journey;
+}
+
+export function JourneyStrip({ journey }: PhaseDotsProps) {
+  return (
+    <div className="flex items-center gap-1" role="list" aria-label="journey phases">
+      {PHASE_LIST.map((phase) => {
+        const status = journeyPhaseStatus(journey, phase);
+        return (
+          <div
+            key={phase}
+            role="listitem"
+            title={`${phase}: ${status}`}
+            className={`h-2 w-2 rounded-full ${STATUS_CLASSES[status] ?? "bg-muted"}`}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/governance/source-sheet.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/governance/source-sheet.tsx
@@ -1,0 +1,68 @@
+// source-sheet.tsx — CTL-1100 Phase 6: controlled Sheet showing rule/edge source.
+// Resolves guardText, datalog, SQL from manifest or descriptor transitions[].
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "../ui/sheet";
+import {
+  resolveRuleSource,
+  resolveEdgeSource,
+  type RuleManifest,
+  type FsmDescriptorLike,
+  type SourceTarget,
+} from "./source-target";
+
+interface SourceSheetProps {
+  open: boolean;
+  onClose: () => void;
+  target: SourceTarget | null;
+  manifest: RuleManifest | null;
+  descriptor: FsmDescriptorLike | null;
+}
+
+export function SourceSheet({ open, onClose, target, manifest, descriptor }: SourceSheetProps) {
+  let guardText: string | null = null;
+  let datalog: string | null = null;
+  let sql: string | null = null;
+  let title = "";
+
+  if (target?.kind === "rule" && manifest) {
+    title = `Rule ${target.rule_id}`;
+    const info = resolveRuleSource(manifest, target);
+    guardText = info?.guardText ?? null;
+    datalog = info?.datalog ?? null;
+    sql = info?.sql ?? null;
+  } else if (target?.kind === "edge" && descriptor) {
+    title = `${target.from} → ${target.to}`;
+    const info = resolveEdgeSource(descriptor, target);
+    guardText = info.guardText;
+    datalog = info.datalog;
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <SheetContent side="right" className="w-[420px] sm:w-[540px]">
+        <SheetHeader>
+          <SheetTitle>{title}</SheetTitle>
+        </SheetHeader>
+        <div className="mt-4 space-y-4 text-sm">
+          <Section label="Guard" content={guardText} />
+          <Section label="Datalog" content={datalog} mono />
+          {sql && <Section label="SQL" content={sql} mono />}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function Section({ label, content, mono = false }: { label: string; content: string | null; mono?: boolean }) {
+  return (
+    <div>
+      <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{label}</p>
+      {content ? (
+        <pre className={`whitespace-pre-wrap rounded bg-muted p-2 text-xs ${mono ? "font-mono" : ""}`}>
+          {content}
+        </pre>
+      ) : (
+        <p className="text-muted-foreground">no source recorded</p>
+      )}
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/governance/source-target.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/governance/source-target.test.ts
@@ -1,0 +1,57 @@
+// source-target.test.ts — CTL-1100 Phase 6
+
+import { describe, it, expect } from "bun:test";
+import {
+  resolveRuleSource,
+  resolveEdgeSource,
+  type RuleManifest,
+  type FsmDescriptorLike,
+} from "./source-target";
+
+const manifest: RuleManifest = {
+  rules: [
+    { rule_id: "R1", name: "session_registered", datalog: "R1 datalog text", sql: "SELECT 1", guardText: null },
+    { rule_id: "R2", name: "session_active", datalog: "R2 datalog", sql: null, guardText: "some guard" },
+  ],
+};
+
+const descriptor: FsmDescriptorLike = {
+  transitions: [
+    { from: "implement", to: "verify", kind: "advance", guardText: null, datalog: null, sourceRef: null },
+    { from: "verify", to: "remediate", kind: "detour", guardText: "fail verdict", datalog: "detour logic", sourceRef: null },
+  ],
+};
+
+describe("resolveRuleSource", () => {
+  it("returns datalog + sql for known rule_id", () => {
+    const info = resolveRuleSource(manifest, { kind: "rule", rule_id: "R1" });
+    expect(info).not.toBeNull();
+    expect(info?.datalog).toBe("R1 datalog text");
+    expect(info?.sql).toBe("SELECT 1");
+    expect(info?.guardText).toBeNull();
+  });
+
+  it("returns guardText when present", () => {
+    const info = resolveRuleSource(manifest, { kind: "rule", rule_id: "R2" });
+    expect(info?.guardText).toBe("some guard");
+  });
+
+  it("returns null for unknown rule_id (no throw)", () => {
+    expect(resolveRuleSource(manifest, { kind: "rule", rule_id: "R999" })).toBeNull();
+  });
+});
+
+describe("resolveEdgeSource", () => {
+  it("resolves a known from→to edge", () => {
+    const info = resolveEdgeSource(descriptor, { kind: "edge", from: "verify", to: "remediate" });
+    expect(info.guardText).toBe("fail verdict");
+    expect(info.datalog).toBe("detour logic");
+  });
+
+  it("returns empty SourceInfo when edge not found (no throw)", () => {
+    const info = resolveEdgeSource(descriptor, { kind: "edge", from: "plan", to: "teardown" });
+    expect(info.guardText).toBeNull();
+    expect(info.datalog).toBeNull();
+    expect(info.sql).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/governance/source-target.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/governance/source-target.ts
@@ -1,0 +1,62 @@
+// source-target.ts — CTL-1100 Phase 6: resolve rule/edge source info for SourceSheet.
+// Pure; no DOM dependency.
+
+export interface RuleEntry {
+  rule_id: string;
+  name?: string;
+  guardText?: string | null;
+  datalog?: string | null;
+  sql?: string | null;
+}
+
+export interface RuleManifest {
+  rules: RuleEntry[];
+  strata?: unknown[];
+}
+
+export interface EdgeEntry {
+  from: string;
+  to: string;
+  kind?: string;
+  guardText?: string | null;
+  datalog?: string | null;
+  sourceRef?: string | null;
+  classification?: string;
+}
+
+export interface FsmDescriptorLike {
+  transitions: EdgeEntry[];
+}
+
+export type SourceTarget =
+  | { kind: "rule"; rule_id: string }
+  | { kind: "edge"; from: string; to: string };
+
+export interface SourceInfo {
+  guardText: string | null;
+  datalog: string | null;
+  sql: string | null;
+}
+
+/** Resolve source info for a rule by rule_id. Returns null when not found. */
+export function resolveRuleSource(manifest: RuleManifest, target: SourceTarget & { kind: "rule" }): SourceInfo | null {
+  const rule = manifest.rules.find((r) => r.rule_id === target.rule_id);
+  if (!rule) return null;
+  return {
+    guardText: rule.guardText ?? null,
+    datalog: rule.datalog ?? null,
+    sql: rule.sql ?? null,
+  };
+}
+
+/** Resolve source info for an FSM edge by from→to. Returns empty info when not found (never throws). */
+export function resolveEdgeSource(descriptor: FsmDescriptorLike, target: SourceTarget & { kind: "edge" }): SourceInfo {
+  const edge = descriptor.transitions.find(
+    (t) => t.from === target.from && t.to === target.to,
+  );
+  return {
+    guardText: edge?.guardText ?? null,
+    datalog: edge?.datalog ?? null,
+    sql: null, // edges have no SQL
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-beliefs.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-beliefs.ts
@@ -1,0 +1,79 @@
+// use-beliefs.ts — CTL-1100 Phase 6: belief stream subscription hook.
+// One EventSource('/api/beliefs/stream'); AppShell calls useBeliefs() ONCE and
+// distributes via BeliefsContext (CTL-945 pattern). Consumers use
+// useBeliefsContext() — never a direct useBeliefs() call in leaf components.
+import { createContext, useContext, useEffect, useState } from "react";
+import {
+  applyBeliefFrame,
+  decodeBeliefFrame,
+  EMPTY_BELIEFS_STATE,
+  type BeliefsState,
+} from "../lib/beliefs-model";
+
+// ── Shared context (CTL-945 pattern) ─────────────────────────────────────────
+
+export const BeliefsContext = createContext<BeliefsState>(EMPTY_BELIEFS_STATE);
+
+export function useBeliefsContext(): BeliefsState {
+  return useContext(BeliefsContext);
+}
+
+// ── SSE subscription hook ─────────────────────────────────────────────────────
+
+const INITIAL_BACKOFF_MS = 500;
+const MAX_BACKOFF_MS = 15_000;
+
+export function useBeliefs(): BeliefsState {
+  const [state, setState] = useState<BeliefsState>(EMPTY_BELIEFS_STATE);
+
+  useEffect(() => {
+    let alive = true;
+    let es: EventSource | null = null;
+    let backoff = INITIAL_BACKOFF_MS;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const apply = (frame: BeliefsState) => {
+      if (alive) setState(frame);
+    };
+
+    const scheduleReconnect = () => {
+      if (!alive) return;
+      const delay = backoff;
+      backoff = Math.min(MAX_BACKOFF_MS, backoff * 2);
+      reconnectTimer = setTimeout(connect, delay);
+    };
+
+    function connect() {
+      if (!alive) return;
+      try {
+        es = new EventSource("/api/beliefs/stream");
+      } catch {
+        scheduleReconnect();
+        return;
+      }
+      es.addEventListener("open", () => {
+        backoff = INITIAL_BACKOFF_MS;
+      });
+      es.addEventListener("belief", (ev) => {
+        const frame = decodeBeliefFrame((ev as MessageEvent).data as string);
+        if (!frame) return;
+        setState((prev) => applyBeliefFrame(prev, frame));
+      });
+      es.onerror = () => {
+        try { es?.close(); } catch { /* noop */ }
+        es = null;
+        scheduleReconnect();
+      };
+    }
+
+    connect();
+
+    return () => {
+      alive = false;
+      try { es?.close(); } catch { /* noop */ }
+      clearTimeout(reconnectTimer);
+    };
+  }, []);
+
+  return state;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/beliefs-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/beliefs-model.test.ts
@@ -1,0 +1,78 @@
+// beliefs-model.test.ts — CTL-1100 Phase 6
+
+import { describe, it, expect } from "bun:test";
+import {
+  isBeliefFrame,
+  decodeBeliefFrame,
+  beliefKey,
+  applyBeliefFrame,
+  beliefsToArray,
+  EMPTY_BELIEFS_STATE,
+  type BeliefFrame,
+} from "./beliefs-model";
+
+function makeFrame(belief_id: number, rule_id = "R1", subject = "CTL-1/plan"): BeliefFrame {
+  return { belief_id, tick_id: 1, rule_id, name: "session_registered", subject,
+           value: null, source_fact_ids: "[]", stratum: 1, ts_ms: 1000, host: "h1", rules_sha: null };
+}
+
+describe("isBeliefFrame", () => {
+  it("accepts a valid frame", () => {
+    expect(isBeliefFrame(makeFrame(1))).toBe(true);
+  });
+  it("rejects null", () => {
+    expect(isBeliefFrame(null)).toBe(false);
+  });
+  it("rejects missing belief_id", () => {
+    const { belief_id: _, ...rest } = makeFrame(1);
+    expect(isBeliefFrame(rest)).toBe(false);
+  });
+  it("rejects non-string rule_id", () => {
+    expect(isBeliefFrame({ ...makeFrame(1), rule_id: 42 })).toBe(false);
+  });
+});
+
+describe("decodeBeliefFrame", () => {
+  it("parses valid JSON frame", () => {
+    const f = makeFrame(5);
+    expect(decodeBeliefFrame(JSON.stringify(f))).toEqual(f);
+  });
+  it("returns null for bad JSON", () => {
+    expect(decodeBeliefFrame("{not json")).toBeNull();
+  });
+  it("returns null for truncated object", () => {
+    expect(decodeBeliefFrame(JSON.stringify({ belief_id: 1 }))).toBeNull();
+  });
+});
+
+describe("applyBeliefFrame", () => {
+  it("latest belief_id per key wins", () => {
+    const s0 = EMPTY_BELIEFS_STATE;
+    const s1 = applyBeliefFrame(s0, makeFrame(5));
+    const s2 = applyBeliefFrame(s1, makeFrame(3)); // lower id — must NOT overwrite
+    const frames = beliefsToArray(s2.store);
+    expect(frames.length).toBe(1);
+    expect(frames[0]?.belief_id).toBe(5);
+  });
+
+  it("higher belief_id replaces lower", () => {
+    const s0 = EMPTY_BELIEFS_STATE;
+    const s1 = applyBeliefFrame(s0, makeFrame(3));
+    const s2 = applyBeliefFrame(s1, makeFrame(7));
+    expect(beliefsToArray(s2.store)[0]?.belief_id).toBe(7);
+  });
+
+  it("cursor is monotonically increasing", () => {
+    const s0 = EMPTY_BELIEFS_STATE;
+    const s1 = applyBeliefFrame(s0, makeFrame(10));
+    const s2 = applyBeliefFrame(s1, makeFrame(5)); // lower — cursor stays at 10
+    expect(s2.cursor).toBe(10);
+  });
+
+  it("two different keys coexist", () => {
+    const s0 = EMPTY_BELIEFS_STATE;
+    const s1 = applyBeliefFrame(s0, makeFrame(1, "R1", "CTL-1/plan"));
+    const s2 = applyBeliefFrame(s1, makeFrame(2, "R2", "CTL-2/plan"));
+    expect(s2.store.size).toBe(2);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/beliefs-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/beliefs-model.ts
@@ -1,0 +1,77 @@
+// beliefs-model.ts — CTL-1100 Phase 6: belief stream data model.
+// Pure; no DOM dependency.
+
+/** One row from the /api/beliefs/stream `belief` SSE event. */
+export interface BeliefFrame {
+  belief_id: number;
+  tick_id: number;
+  rule_id: string;
+  name: string;
+  subject: string;
+  value: string | null;
+  source_fact_ids: string;
+  stratum: number;
+  ts_ms: number | null;
+  host: string | null;
+  rules_sha: string | null;
+}
+
+/** Map: beliefKey → latest BeliefFrame. */
+export type BeliefStore = Map<string, BeliefFrame>;
+
+/** The current belief state passed through BeliefsContext. */
+export interface BeliefsState {
+  store: BeliefStore;
+  cursor: number; // latest belief_id seen; monotonically increasing
+}
+
+export function isBeliefFrame(v: unknown): v is BeliefFrame {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.belief_id === "number" &&
+    typeof r.tick_id === "number" &&
+    typeof r.rule_id === "string" &&
+    typeof r.name === "string" &&
+    typeof r.subject === "string"
+  );
+}
+
+export function decodeBeliefFrame(data: string): BeliefFrame | null {
+  try {
+    const parsed: unknown = JSON.parse(data);
+    return isBeliefFrame(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Stable key for deduplication: last-writer-wins by belief_id. */
+export function beliefKey(r: BeliefFrame): string {
+  return `${r.rule_id} ${r.subject}`;
+}
+
+/** Fold a new frame into the store. Only replaces if belief_id is higher (monotonic). */
+export function applyBeliefFrame(state: BeliefsState, frame: BeliefFrame): BeliefsState {
+  const key = beliefKey(frame);
+  const existing = state.store.get(key);
+  if (existing && existing.belief_id >= frame.belief_id) {
+    // newer cursor still advances even if this key doesn't update
+    const nextCursor = Math.max(state.cursor, frame.belief_id);
+    return nextCursor === state.cursor
+      ? state
+      : { store: state.store, cursor: nextCursor };
+  }
+  const nextStore = new Map(state.store);
+  nextStore.set(key, frame);
+  return { store: nextStore, cursor: Math.max(state.cursor, frame.belief_id) };
+}
+
+export function beliefsToArray(store: BeliefStore): BeliefFrame[] {
+  return [...store.values()];
+}
+
+export const EMPTY_BELIEFS_STATE: BeliefsState = {
+  store: new Map(),
+  cursor: -1,
+};

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/governance-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/governance-model.test.ts
@@ -1,0 +1,52 @@
+// governance-model.test.ts — CTL-1100 Phase 6
+
+import { describe, it, expect } from "bun:test";
+import {
+  isGovernanceSnapshot,
+  flagTone,
+  modeTone,
+  GOVERNANCE_FLAG_LABELS,
+} from "./governance-model";
+
+describe("isGovernanceSnapshot", () => {
+  it("accepts minimal {available:false}", () => {
+    expect(isGovernanceSnapshot({ available: false })).toBe(true);
+  });
+  it("accepts full readGovernanceConfig() shape", () => {
+    expect(isGovernanceSnapshot({
+      available: true,
+      beliefsShadow: true,
+      diagnostician: false,
+      intentsEnforce: false,
+      advanceShadowSummary: false,
+      stallJanitor: { mode: "enforce" },
+      watchdog: { mode: "shadow" },
+      unstuckSweep: { mode: "off" },
+    })).toBe(true);
+  });
+  it("rejects null", () => expect(isGovernanceSnapshot(null)).toBe(false));
+  it("rejects missing available", () => expect(isGovernanceSnapshot({ beliefsShadow: true })).toBe(false));
+  it("rejects non-boolean available", () => expect(isGovernanceSnapshot({ available: "yes" })).toBe(false));
+});
+
+describe("flagTone", () => {
+  it("true → green", () => expect(flagTone(true)).toBe("green"));
+  it("false → muted", () => expect(flagTone(false)).toBe("muted"));
+});
+
+describe("modeTone", () => {
+  it("enforce → green", () => expect(modeTone("enforce")).toBe("green"));
+  it("shadow → yellow", () => expect(modeTone("shadow")).toBe("yellow"));
+  it("off → muted", () => expect(modeTone("off")).toBe("muted"));
+  it("unknown → muted", () => expect(modeTone("disabled")).toBe("muted"));
+});
+
+describe("GOVERNANCE_FLAG_LABELS", () => {
+  it("covers all 7 modes", () => {
+    expect(Object.keys(GOVERNANCE_FLAG_LABELS).length).toBe(7);
+  });
+  it("includes beliefsShadow and stallJanitor", () => {
+    expect("beliefsShadow" in GOVERNANCE_FLAG_LABELS).toBe(true);
+    expect("stallJanitor" in GOVERNANCE_FLAG_LABELS).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/governance-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/governance-model.ts
@@ -1,0 +1,43 @@
+// governance-model.ts — CTL-1100 Phase 6: /api/governance snapshot model.
+// Pure; no DOM dependency.
+
+/** Shape returned by GET /api/governance (mirrors readGovernanceConfig). */
+export interface GovernanceSnapshot {
+  available: boolean;
+  beliefsShadow?: boolean;
+  diagnostician?: boolean;
+  intentsEnforce?: boolean;
+  advanceShadowSummary?: boolean;
+  stallJanitor?: { mode: string };
+  watchdog?: { mode: string };
+  unstuckSweep?: { mode: string };
+}
+
+export function isGovernanceSnapshot(v: unknown): v is GovernanceSnapshot {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  return typeof r.available === "boolean";
+}
+
+/** Human labels for the 7 governance modes, in display order. */
+export const GOVERNANCE_FLAG_LABELS: Record<string, string> = {
+  beliefsShadow:        "Beliefs shadow",
+  diagnostician:        "Diagnostician",
+  intentsEnforce:       "Intents enforce",
+  advanceShadowSummary: "Advance shadow",
+  stallJanitor:         "Stall janitor",
+  watchdog:             "Watchdog",
+  unstuckSweep:         "Unstuck sweep",
+};
+
+/** Boolean flag tone: on→"green", off→"muted". */
+export function flagTone(enabled: boolean): "green" | "muted" {
+  return enabled ? "green" : "muted";
+}
+
+/** Mode subsystem tone: "enforce"→"green", "shadow"→"yellow", "off"→"muted". */
+export function modeTone(mode: string): "green" | "yellow" | "muted" {
+  if (mode === "enforce") return "green";
+  if (mode === "shadow")  return "yellow";
+  return "muted";
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/journey-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/journey-model.test.ts
@@ -1,0 +1,92 @@
+// journey-model.test.ts — CTL-1100 Phase 6
+
+import { describe, it, expect } from "bun:test";
+import { isJourney, journeyPhaseStatus, PHASE_LIST, type Journey } from "./journey-model";
+
+function makeJourney(overrides: Partial<Journey> = {}): Journey {
+  return {
+    ticket: "CTL-9001",
+    hops: [],
+    gates: {
+      checklist: PHASE_LIST.map((p) => ({
+        phase: p,
+        signalStatus: null,
+        satisfied: false,
+      })),
+      nextPhase: null,
+    },
+    verifyVerdict: { verdict: null },
+    remediateCycles: 0,
+    unblockHints: [],
+    hosts: [],
+    ...overrides,
+  };
+}
+
+describe("isJourney", () => {
+  it("accepts a well-formed journey", () => {
+    expect(isJourney(makeJourney())).toBe(true);
+  });
+  it("rejects null", () => expect(isJourney(null)).toBe(false));
+  it("rejects missing ticket", () => expect(isJourney({ hops: [], gates: { checklist: [], nextPhase: null }, hosts: [], remediateCycles: 0, unblockHints: [], verifyVerdict: { verdict: null } })).toBe(false));
+  it("rejects non-array hops", () => expect(isJourney({ ...makeJourney(), hops: "x" })).toBe(false));
+});
+
+describe("journeyPhaseStatus", () => {
+  it("satisfied gate → done", () => {
+    const j = makeJourney({
+      gates: {
+        checklist: PHASE_LIST.map((p) => ({
+          phase: p,
+          signalStatus: p === "implement" ? "done" : null,
+          satisfied: p === "implement",
+        })),
+        nextPhase: "verify",
+      },
+    });
+    expect(journeyPhaseStatus(j, "implement")).toBe("done");
+  });
+
+  it("nextPhase → current", () => {
+    const j = makeJourney({
+      gates: {
+        checklist: PHASE_LIST.map((p) => ({
+          phase: p,
+          signalStatus: p === "implement" ? "done" : null,
+          satisfied: p === "implement",
+        })),
+        nextPhase: "verify",
+      },
+    });
+    expect(journeyPhaseStatus(j, "verify")).toBe("current");
+  });
+
+  it("verify with fail verdict → failed", () => {
+    const j = makeJourney({
+      gates: {
+        checklist: PHASE_LIST.map((p) => ({
+          phase: p,
+          signalStatus: p === "verify" ? "done" : (p === "implement" ? "done" : null),
+          satisfied: p !== "verify" && p !== "implement" ? false : p === "implement",
+        })),
+        nextPhase: "remediate",
+      },
+      verifyVerdict: { verdict: "fail" },
+    });
+    expect(journeyPhaseStatus(j, "verify")).toBe("failed");
+  });
+
+  it("untouched phase → pending", () => {
+    const j = makeJourney();
+    expect(journeyPhaseStatus(j, "teardown")).toBe("pending");
+  });
+
+  it("anchored to PHASE_LIST (10 phases)", () => {
+    expect(PHASE_LIST.length).toBe(10);
+    const j = makeJourney();
+    for (const p of PHASE_LIST) {
+      const status = journeyPhaseStatus(j, p);
+      expect(["done","current","pending","failed"].includes(status)).toBe(true);
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/journey-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/journey-model.ts
@@ -1,0 +1,64 @@
+// journey-model.ts — CTL-1100 Phase 6: /api/journey/:ticket model.
+// Pure; no DOM dependency.
+
+import { PHASE_LIST } from "../board/phase-model";
+
+export interface JourneyHop {
+  phase: string;
+  eventType: string;
+  ts: string;
+  host: string;
+  bg_job_id?: string;
+  reason?: string;
+  targetPhase?: string;
+  blockers?: unknown[];
+}
+
+export interface JourneyGate {
+  phase: string;
+  signalStatus: string | null;
+  satisfied: boolean;
+}
+
+export interface Journey {
+  ticket: string;
+  hops: JourneyHop[];
+  gates: { checklist: JourneyGate[]; nextPhase: string | null };
+  verifyVerdict: { verdict: string | null; regressionRisk?: number | null; highFindings?: number };
+  remediateCycles: number;
+  unblockHints: Array<{ kind: string; note?: string; reason?: string; blockers?: unknown[] }>;
+  hosts: string[];
+}
+
+export function isJourney(v: unknown): v is Journey {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.ticket === "string" &&
+    Array.isArray(r.hops) &&
+    r.gates !== null && typeof r.gates === "object" &&
+    Array.isArray((r.gates as Record<string, unknown>).checklist) &&
+    Array.isArray(r.unblockHints) &&
+    Array.isArray(r.hosts) &&
+    typeof r.remediateCycles === "number"
+  );
+}
+
+export type PhaseStatus = "done" | "current" | "pending" | "failed";
+
+/** Derive the display status for a given phase in the 10-phase strip. */
+export function journeyPhaseStatus(journey: Journey, phase: string): PhaseStatus {
+  const gate = journey.gates.checklist.find((g) => g.phase === phase);
+  if (!gate) return "pending";
+  if (gate.satisfied) return "done";
+  if (gate.signalStatus === "failed" || gate.signalStatus === "stalled") return "failed";
+  // Verify in a fail cycle → show "failed" visually
+  if (phase === "verify" && journey.verifyVerdict.verdict === "fail") return "failed";
+  // Current = this is the nextPhase, or has a running signal
+  if (phase === journey.gates.nextPhase) return "current";
+  if (gate.signalStatus === "running" || gate.signalStatus === "stalled") return "current";
+  if (gate.signalStatus !== null && gate.signalStatus !== "pending") return "current";
+  return "pending";
+}
+
+export { PHASE_LIST };

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/sse-dedup.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/sse-dedup.test.ts
@@ -71,3 +71,27 @@ describe("CTL-945 Fix2 — Board is eagerly imported (no lazy chunk-fetch race)"
     expect(board["$$typeof"]).not.toBe(lazyType);
   });
 });
+
+// ── CTL-1100 — BeliefsContext exported (single-EventSource guard) ─────────────
+// Mirrors the CTL-945 Fix1 pattern: exactly ONE /api/beliefs/stream EventSource
+// must exist across the app. AppShell calls useBeliefs() once and distributes
+// via BeliefsContext so surfaces use useBeliefsContext() — never a direct
+// useBeliefs() call in a leaf component.
+describe("CTL-1100 — BeliefsContext exported", () => {
+  it("BeliefsContext is exported and has a Provider", async () => {
+    const mod = await import("../hooks/use-beliefs");
+    expect(mod.BeliefsContext).toBeDefined();
+    expect(typeof mod.BeliefsContext).toBe("object");
+    expect(mod.BeliefsContext).toHaveProperty("Provider");
+  });
+
+  it("useBeliefsContext is exported and is a function", async () => {
+    const mod = await import("../hooks/use-beliefs");
+    expect(typeof mod.useBeliefsContext).toBe("function");
+  });
+
+  it("useBeliefs (the SSE hook) is exported for the single provider call", async () => {
+    const mod = await import("../hooks/use-beliefs");
+    expect(typeof mod.useBeliefs).toBe("function");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/why-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/why-model.test.ts
@@ -1,0 +1,34 @@
+// why-model.test.ts — CTL-1100 Phase 6
+
+import { describe, it, expect } from "bun:test";
+import { isTraceResult, emptyTrace } from "./why-model";
+
+describe("isTraceResult", () => {
+  it("accepts documented shape", () => {
+    expect(isTraceResult({
+      ticket: "CTL-1234",
+      tickId: 42,
+      nowMs: 1000,
+      host: "h1",
+      beliefs: [{ belief_id: 1, name: "session_registered", subject: "CTL-1234/plan",
+                  value: null, rule_id: "R1", stratum: 1, sources: [] }],
+    })).toBe(true);
+  });
+  it("accepts empty shape {ticket, tickId:null, beliefs:[]}", () => {
+    expect(isTraceResult({ ticket: "CTL-99", tickId: null, beliefs: [] })).toBe(true);
+  });
+  it("rejects null", () => expect(isTraceResult(null)).toBe(false));
+  it("rejects missing beliefs", () => expect(isTraceResult({ ticket: "CTL-1", tickId: 1 })).toBe(false));
+  it("rejects non-string ticket", () => expect(isTraceResult({ ticket: 123, tickId: 1, beliefs: [] })).toBe(false));
+});
+
+describe("emptyTrace", () => {
+  it("is a valid TraceResult", () => {
+    expect(isTraceResult(emptyTrace("CTL-1"))).toBe(true);
+  });
+  it("has tickId null and empty beliefs", () => {
+    const t = emptyTrace("CTL-1");
+    expect(t.tickId).toBeNull();
+    expect(t.beliefs).toEqual([]);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/why-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/why-model.ts
@@ -1,0 +1,42 @@
+// why-model.ts — CTL-1100 Phase 6: /api/beliefs/why trace model.
+// Pure; no DOM dependency.
+
+export interface TraceSource {
+  kind: "belief" | "fact";
+  table: string;
+  id: number;
+  summary: string;
+  ts_ms: number | null;
+}
+
+export interface TraceBelief {
+  belief_id: number;
+  name: string;
+  subject: string;
+  value: string | null;
+  rule_id: string;
+  stratum: number;
+  sources: TraceSource[];
+}
+
+export interface TraceResult {
+  ticket: string;
+  tickId: number | null;
+  nowMs?: number | null;
+  host?: string | null;
+  beliefs: TraceBelief[];
+}
+
+export function isTraceResult(v: unknown): v is TraceResult {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.ticket === "string" &&
+    Array.isArray(r.beliefs) &&
+    ("tickId" in r)
+  );
+}
+
+export function emptyTrace(ticket = ""): TraceResult {
+  return { ticket, tickId: null, beliefs: [] };
+}


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-13T21:33:00Z -->
<!-- Last updated: 2026-06-13T21:33:00Z -->
<!-- PR: #1951 -->
<!-- Previous commits: b65ccad9b23eb51c9346973f61610e89d59190f0,ab435735790f3de8f331227a2a515c74f19f23ed,09eae3f3f71c95c2e7c6349197d5067869872c16,c905a7ceb1d81e505ab80326a81519aad3573e88,0c91a6ae9330a731ac66a8b5d52ce63fbedf9b68,a3e08bead0fba7ffd49f12d55fea42d63792dedf,ada750351f4c3d9a95b5ae1e0f165d7bee1fb51e,b39005956f46c86f3c3e76f52319907806773f5f -->

## Summary

Adds a complete set of read-only governance HTTP endpoints to the `orch-monitor` `Bun.serve` instance, backed by the **exact same daemon modules** so UI and daemon code cannot drift.

### Endpoints added

| Endpoint | Description |
|---|---|
| `GET /api/fsm/descriptor` | FSM compiled at request-time from `workflow-descriptor.mjs` + `fsm-guards.json`. Includes `descriptorSha`, `rulesSha`, all edges (uncurated → `'unclassified'`). |
| `GET /api/beliefs/rules` | Frozen `RULE_MANIFEST` served verbatim. |
| `GET /api/beliefs/why?ticket=&tick=` | HTTP wrapper over `traceTicket()` from `execution-core/beliefs/why.mjs`. |
| `GET /api/beliefs/summary\|rates\|recent\|cfg` | Read-only `beliefs.db` queries (graceful degradation when absent). |
| `GET /api/journey/:ticket` | Per-ticket journey: event-log hops, gate checklist, verify verdict, unblock hints, hosts. |
| `GET /api/governance` | Snapshot of CTL-1062 governance modes (7 flags/modes). |

### Frontend shared components

- `useBeliefs` hook + `BeliefsContext` — single EventSource per app shell (CTL-945 pattern)
- `GovernanceFlagsChip` — 7 governance mode chips with tone-based colors
- `DerivationTree` — recursive `TraceResult` display with rule-id chips linking to `SourceSheet`
- `JourneyStrip` — 10-phase dot strip using `journeyPhaseStatus`
- `SourceSheet` — shadcn Sheet showing guardText/datalog/sql

### Contract tests (Phase 7)

5 contract suites ensure every endpoint body is re-derived from the daemon module:
- `governance-fsm-descriptor.contract.test.ts` — descriptorSha byte-identity, scalar field deep-equals, edge totality via `enumerateTransitions()`
- `governance-rules-manifest.contract.test.ts` — full RULE_MANIFEST deep-equal, anti-stub guards
- `governance-why.contract.test.ts` — `traceTicket()` deep-equal on same seeded beliefs.db
- `governance-journey.contract.test.ts` — `deriveAdvancement()` deep-equal; verify.json mutation proves recomputation
- `governance-janitor-exclusion.contract.test.ts` — every JANITOR/REAP type → false; explicit regression assertions for `phase.predecessor.reap-requested` / `phase.terminal.reap-complete`

### Phase-review remediations (final commit)

- `server.ts loadGovernanceDeps`: cleared 18 `no-unsafe-*` lint errors via structural casts (preserves CTL-883 VITE-GRAPH GUARD; casts are type-only, computed specifiers stay erased)
- `fsm-guards.json`: corrected verify→remediate guard metadata (`regression_risk >= 5 OR any severity:high finding`); fixed stale `sourceRef` pointers
- Deferred (recorded in `review.json`, not auto-fixed): `GET /api/journey/:ticket` wtDir injection; 15 residual contract-test lint errors

## Changes Made

### Backend (43 files, +4290 lines)

- **`governance-reader.mjs`** — loads governance dependencies via computed `import()` with the VITE-GRAPH GUARD
- **`fsm-descriptor.mjs`** + **`fsm-descriptor.d.mts`** — compiles FSM at request-time from `workflow.default.json`; guard manifest sourced from `fsm-guards.json`
- **`belief-store-queries.mjs`** — pure query functions (db-injected, LRU-cached rates); adds `beliefStoreDbPath` option for test isolation
- **`belief-why.mjs`** — thin HTTP wrapper over `traceTicket()`; computed-specifier import with VITE-GRAPH GUARD
- **`journey.mjs`** — assembles hops (`scanEventsChunked`), gates (`deriveAdvancement`), verify verdict, remediation cycles, unblock hints; multi-host dedup
- **`server.ts`** — wires 6 governance routes; graceful degradation (absent db → 200 + empty)

### Frontend

- **`ui/src/hooks/use-beliefs.ts`** — single EventSource per app shell via `BeliefsContext`
- **`ui/src/lib/beliefs-model.ts`** — `applyBeliefFrame` monotonic LRU; `max_belief_id` cursor
- **`ui/src/lib/governance-model.ts`** — 7 flag labels, `flagTone`/`modeTone`
- **`ui/src/lib/why-model.ts`** — `isTraceResult`, `emptyTrace`
- **`ui/src/lib/journey-model.ts`** — `journeyPhaseStatus` anchored to `PHASE_LIST`
- **`ui/src/components/governance/`** — `GovernanceFlagsChip`, `DerivationTree`, `JourneyStrip`, `SourceSheet`, `source-target.ts`

### Tests (162 total across Phase 2-7)

- 23 beliefs-read-endpoint tests
- 11 beliefs-why-endpoint tests
- 16 journey tests (unit + HTTP + degradation + suffix-collision guard)
- 5 × contract suites (backed-by-code verification)
- 54 UI component tests

## How to Verify It

- [ ] `cd plugins/dev/scripts/orch-monitor && bun test` — 162 tests pass
- [ ] `npx tsc --noEmit` — 0 new errors (6 pre-existing UI missing-dep errors remain; 15 residual contract-test lint errors deferred)
- [x] CI checks pass: `audit-references`, `check-versions`, `docs-gate`, `validate`
- [ ] Reviewer confirms no expected value is hand-transcribed; all are imported from daemon modules
- [ ] Reviewer confirms `phase.predecessor.reap-requested` and `phase.terminal.reap-complete` (both start with `phase.`) are correctly excluded by `isGovernanceEvent`
- [ ] All 5 contract test files use temp dirs/dbs with `afterAll` cleanup; no real `beliefs.db` touched

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1100

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1062
skip CTL-883
skip CTL-945
