### PR TITLE
feat(dev): CTL-1108 — populate humanQuestion for remediate-cycle-cap-exhausted escalations

### DIFF
--- a/plugins/dev/scripts/execution-core/escalation-explanation.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-explanation.mjs
@@ -70,6 +70,40 @@ export function coerceExplanation(fields, ctx = {}) {
   return Object.freeze(e);
 }
 
+// CTL-1108: map a verify.json (HIGH findings + regression_risk) into the
+// escalation explanation shape for a remediate-cycle-cap-exhausted stall.
+export function buildRemediateCapExplanation(verifyJson, { ticket, cycleCount } = {}) {
+  const v = verifyJson && typeof verifyJson === "object" ? verifyJson : {};
+  const findings = Array.isArray(v.findings) ? v.findings : [];
+  const highs = findings.filter((f) => f?.severity === "high");
+  const blocker = highs[0];
+
+  const blockerDesc = blocker
+    ? `${blocker.file ?? "?"}:${blocker.line ?? "?"} — ${blocker.message ?? "(no message)"}`
+    : `regression_risk ${v.regression_risk ?? "?"} above threshold with no HIGH finding`;
+
+  const fields = {
+    what_failed: `verify still failing after ${cycleCount ?? "?"} remediation cycles. Blocking: ${blockerDesc}`,
+    observed: {
+      regression_risk: typeof v.regression_risk === "number" ? v.regression_risk : null,
+      highFindingCount: highs.length,
+      highFindings: highs.slice(0, 5).map((f) => ({
+        file: f.file,
+        line: f.line,
+        kind: f.kind,
+        message: f.message,
+        recommendation: f.recommendation,
+      })),
+    },
+    attempts: [`${cycleCount ?? 0} verify⇄remediate cycles (cap reached)`],
+    why_gave_up: `remediation budget exhausted: ${cycleCount ?? "?"} cycles attempted, verify still fails`,
+    human_question: blocker
+      ? `${ticket}: verify keeps failing on ${blocker.file ?? "?"}:${blocker.line ?? "?"} (${blocker.message ?? "blocking finding"}). Fix it on the branch, or abandon / re-scope?`
+      : `${ticket}: verify keeps failing after ${cycleCount ?? "?"} fix attempts (regression_risk ${v.regression_risk ?? "?"}). Fix on the branch, or abandon / re-scope?`,
+  };
+  return coerceExplanation(fields, { ticket, phase: "verify" });
+}
+
 function normalizeShape(f = {}) {
   return {
     what_failed: typeof f.what_failed === "string" ? f.what_failed : "",

--- a/plugins/dev/scripts/execution-core/escalation-explanation.test.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-explanation.test.mjs
@@ -4,6 +4,7 @@ import {
   validateExplanation,
   buildExplanation,
   coerceExplanation,
+  buildRemediateCapExplanation,
 } from "./escalation-explanation.mjs";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -114,6 +115,60 @@ describe("coerceExplanation", () => {
     const e = coerceExplanation({}, { ticket: "CTL-99" });
     expect(validateExplanation(e).valid).toBe(true);
     expect(e.degraded).toBe(true);
+  });
+});
+
+// CTL-1108: buildRemediateCapExplanation unit tests
+describe("buildRemediateCapExplanation", () => {
+  const verify = {
+    regression_risk: 6,
+    findings: [
+      {
+        severity: "high",
+        kind: "review",
+        file: "broker/router.mjs",
+        line: 352,
+        message: "getEventScope reads retired attr vcs.revision",
+        recommendation: "read vcs.ref.revision",
+      },
+      { severity: "low", kind: "lint", file: "x.mjs", line: 1, message: "nit" },
+    ],
+  };
+
+  test("names the blocking HIGH finding in what_failed", () => {
+    const e = buildRemediateCapExplanation(verify, { ticket: "CTL-1047", cycleCount: 3 });
+    expect(e.what_failed).toContain("broker/router.mjs:352");
+    expect(e.what_failed).toContain("getEventScope reads retired attr vcs.revision");
+  });
+
+  test("surfaces the exhausted cycle count in why_gave_up", () => {
+    const e = buildRemediateCapExplanation(verify, { ticket: "CTL-1047", cycleCount: 3 });
+    expect(e.why_gave_up).toContain("3");
+  });
+
+  test("human_question names the decision fork and is non-tautological", () => {
+    const e = buildRemediateCapExplanation(verify, { ticket: "CTL-1047", cycleCount: 3 });
+    expect(validateExplanation(e).valid).toBe(true);
+    expect(e.human_question.toLowerCase()).toContain("fix");
+    expect(e.human_question.toLowerCase()).toMatch(/abandon|re-?scope/);
+  });
+
+  test("observed carries regression_risk and high-finding count", () => {
+    const e = buildRemediateCapExplanation(verify, { ticket: "CTL-1047", cycleCount: 3 });
+    expect(e.observed.regression_risk).toBe(6);
+    expect(e.observed.highFindingCount).toBe(1);
+  });
+
+  test("no HIGH findings but risk>=5 → still produces a valid, non-empty explanation", () => {
+    const riskOnly = { regression_risk: 5, findings: [] };
+    const e = buildRemediateCapExplanation(riskOnly, { ticket: "CTL-9", cycleCount: 3 });
+    expect(validateExplanation(e).valid).toBe(true);
+    expect(e.what_failed.trim()).not.toBe("");
+  });
+
+  test("malformed/empty verify.json → valid explanation via safe defaults", () => {
+    const e = buildRemediateCapExplanation(null, { ticket: "CTL-9", cycleCount: 3 });
+    expect(validateExplanation(e).valid).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -206,6 +206,10 @@ import {
   scaleForMethod,
   mapScopeToEstimate,
 } from "./linear-estimation-method.mjs";
+import {
+  buildRemediateCapExplanation,
+  coerceExplanation,
+} from "./escalation-explanation.mjs"; // CTL-1108
 
 // The last pipeline phase — its `done` signal means the whole pipeline
 // finished. `done` is otherwise phase-dependent: a `triage: done` signal still
@@ -1318,12 +1322,24 @@ export function maybeEscalateRemediateExhausted(
     if (typeof summarizeHistory === "function") {
       try { remediateSummary = summarizeHistory(ticket); } catch { /* best-effort */ }
     }
+    // CTL-1108: source the operator-facing explanation from the verify.json that
+    // still exists on disk at cap-exhaustion time (HIGH findings + regression_risk).
+    let verifyJson = null;
+    try {
+      verifyJson = JSON.parse(
+        readFile(join(orchDir, "workers", ticket, "verify.json"), "utf8")
+      );
+    } catch {
+      // verify.json absent/unreadable → mapper degrades to a valid generic explanation
+    }
+    const explanation = buildRemediateCapExplanation(verifyJson, { ticket, cycleCount });
     writeFile(
       p,
       JSON.stringify({
         ...cur,
         status: "stalled",
         stalledReason: "remediate-cycle-cap-exhausted",
+        explanation,
         updatedAt: new Date().toISOString(),
         ...(remediateSummary !== undefined ? { remediateSummary } : {}),
       })
@@ -1767,6 +1783,15 @@ export function escalateDispatchExhausted(
     // absent / malformed → create fresh
   }
   if (existing.status === "stalled") return true; // idempotent
+  // CTL-1108: attach a coerced explanation so the inbox shows a meaningful
+  // human_question for prior-artifact-retry-exhausted escalations.
+  const explanation = coerceExplanation(
+    {
+      what_failed: `${phase} dispatch retries exhausted (${cause ?? code})`,
+      why_gave_up: "prior-artifact-retry-exhausted",
+    },
+    { ticket, phase }
+  );
   try {
     mkdirSync(dir, { recursive: true });
     writeFile(
@@ -1779,6 +1804,7 @@ export function escalateDispatchExhausted(
         stalledReason: "prior-artifact-retry-exhausted",
         dispatchFailureCode: code,   // CTL-1045 Bug 2: exit code that exhausted retries (2 = prior_artifact_missing)
         dispatchFailureCause: cause, // CTL-1045 Bug 2: human-readable reason (observability)
+        explanation,
         updatedAt: new Date().toISOString(),
       })
     );
@@ -1817,6 +1843,13 @@ function writeTerminalStalled(
     return false; // no signal to stall
   }
   if (cur.status === "stalled") return true; // idempotent
+  // CTL-1108: every terminal stall carries an explanation so the inbox shows a
+  // meaningful human_question instead of "escalated — needs human". Callers may
+  // pass a richer one via extra.explanation; fall back to a coerced generic.
+  const explanation = extra.explanation ?? coerceExplanation(
+    { what_failed: `${phase} phase stalled: ${reason}`, why_gave_up: reason },
+    { ticket, phase }
+  );
   try {
     writeFile(
       p,
@@ -1825,6 +1858,7 @@ function writeTerminalStalled(
         ...extra,
         status: "stalled",
         stalledReason: reason,
+        explanation,
         updatedAt: new Date().toISOString(),
       })
     );

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1677,6 +1677,75 @@ describe("CTL-653: maybeEscalateRemediateExhausted", () => {
       maybeEscalateRemediateExhausted(orchDir, "CTL-653", { verify: "running" }, "fail", 99)
     ).toBe(false);
   });
+
+  // CTL-1108: explanation wiring
+  test("CTL-1108: writes explanation.human_question sourced from verify.json HIGH findings", () => {
+    const wdir = join(orchDir, "workers", "CTL-1108a");
+    mkdirSync(wdir, { recursive: true });
+    writeFileSync(
+      join(wdir, "phase-verify.json"),
+      JSON.stringify({ ticket: "CTL-1108a", phase: "verify", status: "done" })
+    );
+    writeFileSync(
+      join(wdir, "verify.json"),
+      JSON.stringify({
+        regression_risk: 6,
+        findings: [
+          {
+            severity: "high",
+            file: "broker/router.mjs",
+            line: 352,
+            message: "getEventScope reads retired attr vcs.revision",
+            recommendation: "read vcs.ref.revision",
+          },
+        ],
+      })
+    );
+    expect(
+      maybeEscalateRemediateExhausted(orchDir, "CTL-1108a", { verify: "done" }, "fail", REMEDIATE_CYCLE_CAP)
+    ).toBe(true);
+    const sig = JSON.parse(readFileSync(join(wdir, "phase-verify.json"), "utf8"));
+    expect(sig.status).toBe("stalled");
+    expect(sig.stalledReason).toBe("remediate-cycle-cap-exhausted");
+    expect(sig.explanation).toBeTruthy();
+    expect(typeof sig.explanation.human_question).toBe("string");
+    expect(sig.explanation.human_question).toContain("broker/router.mjs:352");
+  });
+
+  test("CTL-1108: missing verify.json → still stalls with a (degraded) explanation, never throws", () => {
+    const wdir = join(orchDir, "workers", "CTL-1108b");
+    mkdirSync(wdir, { recursive: true });
+    writeFileSync(
+      join(wdir, "phase-verify.json"),
+      JSON.stringify({ ticket: "CTL-1108b", phase: "verify", status: "done" })
+    );
+    // no verify.json on disk
+    expect(
+      maybeEscalateRemediateExhausted(orchDir, "CTL-1108b", { verify: "done" }, "fail", REMEDIATE_CYCLE_CAP)
+    ).toBe(true);
+    const sig = JSON.parse(readFileSync(join(wdir, "phase-verify.json"), "utf8"));
+    expect(sig.status).toBe("stalled");
+    expect(sig.explanation).toBeTruthy();
+    expect(typeof sig.explanation.human_question).toBe("string");
+  });
+
+  test("CTL-1108: idempotent — already-stalled signal with existing explanation is not clobbered", () => {
+    const wdir = join(orchDir, "workers", "CTL-1108c");
+    mkdirSync(wdir, { recursive: true });
+    const existing = {
+      ticket: "CTL-1108c",
+      phase: "verify",
+      status: "stalled",
+      stalledReason: "remediate-cycle-cap-exhausted",
+      explanation: { human_question: "original question" },
+    };
+    writeFileSync(join(wdir, "phase-verify.json"), JSON.stringify(existing));
+    expect(
+      maybeEscalateRemediateExhausted(orchDir, "CTL-1108c", { verify: "done" }, "fail", REMEDIATE_CYCLE_CAP)
+    ).toBe(true);
+    const sig = JSON.parse(readFileSync(join(wdir, "phase-verify.json"), "utf8"));
+    expect(sig.explanation.human_question).toBe("original question");
+  });
 });
 
 // ─── CTL-712: escalateDispatchExhausted — retry ceiling → stalled ───
@@ -1739,6 +1808,69 @@ describe("CTL-712: escalateDispatchExhausted — retry ceiling → stalled", () 
     const sig = JSON.parse(readFileSync(join(orchDir, "workers", "CTL-712", "phase-pr.json"), "utf8"));
     expect(sig.dispatchFailureCode).toBeNull();
     expect(sig.dispatchFailureCause).toBeNull();
+  });
+
+  // CTL-1108: explanation coverage
+  test("CTL-1108: escalateDispatchExhausted attaches an explanation with non-empty human_question", () => {
+    expect(escalateDispatchExhausted(orchDir, "CTL-1108e", "pr")).toBe(true);
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", "CTL-1108e", "phase-pr.json"), "utf8")
+    );
+    expect(sig.stalledReason).toBe("prior-artifact-retry-exhausted");
+    expect(sig.explanation).toBeTruthy();
+    expect(typeof sig.explanation.human_question).toBe("string");
+    expect(sig.explanation.human_question.trim()).not.toBe("");
+  });
+});
+
+// ─── CTL-1108: writeTerminalStalled explanation coverage ───
+describe("CTL-1108: writeTerminalStalled explanation coverage", () => {
+  test("dispatch-circuit-breaker stall carries an explanation", () => {
+    const t = "CTL-1108f", phase = "research";
+    writeSignal(t, phase, "running");
+    for (let i = 1; i <= CIRCUIT_BREAKER_THRESHOLD; i++)
+      recordDispatchFailure(orchDir, t, phase, 1, i * 1000);
+    expect(maybeTripCircuitBreaker(orchDir, t, phase)).toBe(true);
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", t, `phase-${phase}.json`), "utf8")
+    );
+    expect(sig.stalledReason).toBe("dispatch-circuit-breaker");
+    expect(sig.explanation).toBeTruthy();
+    expect(typeof sig.explanation.human_question).toBe("string");
+    expect(sig.explanation.human_question.trim()).not.toBe("");
+  });
+
+  test("coverage guard: every scheduler stall reason produces a non-null explanation.human_question", () => {
+    // remediate-cycle-cap-exhausted (maybeEscalateRemediateExhausted)
+    {
+      const wdir = join(orchDir, "workers", "CTL-1108g");
+      mkdirSync(wdir, { recursive: true });
+      writeFileSync(join(wdir, "phase-verify.json"),
+        JSON.stringify({ ticket: "CTL-1108g", phase: "verify", status: "done" }));
+      maybeEscalateRemediateExhausted(orchDir, "CTL-1108g", { verify: "done" }, "fail", REMEDIATE_CYCLE_CAP);
+      const sig = JSON.parse(readFileSync(join(wdir, "phase-verify.json"), "utf8"));
+      expect(sig.explanation?.human_question?.trim()).toBeTruthy();
+    }
+    // prior-artifact-retry-exhausted (escalateDispatchExhausted)
+    {
+      escalateDispatchExhausted(orchDir, "CTL-1108h", "plan");
+      const sig = JSON.parse(
+        readFileSync(join(orchDir, "workers", "CTL-1108h", "phase-plan.json"), "utf8")
+      );
+      expect(sig.explanation?.human_question?.trim()).toBeTruthy();
+    }
+    // dispatch-circuit-breaker (maybeTripCircuitBreaker → writeTerminalStalled)
+    {
+      const t = "CTL-1108i", phase = "implement";
+      writeSignal(t, phase, "running");
+      for (let i = 1; i <= CIRCUIT_BREAKER_THRESHOLD; i++)
+        recordDispatchFailure(orchDir, t, phase, 1, i * 1000);
+      maybeTripCircuitBreaker(orchDir, t, phase);
+      const sig = JSON.parse(
+        readFileSync(join(orchDir, "workers", t, `phase-${phase}.json`), "utf8")
+      );
+      expect(sig.explanation?.human_question?.trim()).toBeTruthy();
+    }
   });
 });
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-13T21:04:00Z -->
<!-- Last updated: 2026-06-13T21:04:00Z -->
<!-- PR: #1952 -->
<!-- Previous commits: d035c31f -->

## Summary

The most common human-decision path — a ticket that exhausted its verify⇄remediate budget — was landing in the inbox with a bare "Respond" button and no context. The operator had to SSH in and read `verify.json` to understand what failed. This PR closes that gap by wiring the CTL-1065 explanation builder into every stall path that had been missing it.

Three stall paths now produce a non-null `humanQuestion`:

1. **`remediate-cycle-cap-exhausted`** (primary gap): `maybeEscalateRemediateExhausted` now reads the on-disk `verify.json`, maps HIGH findings + regression risk through a new `buildRemediateCapExplanation()`, and attaches the explanation to the stalled signal.
2. **`prior-artifact-retry-exhausted`**: `escalateDispatchExhausted` now calls `coerceExplanation` so inbox shows the dispatch failure reason.
3. **All terminal stalls** via `writeTerminalStalled`: callers may supply a richer explanation; the fallback generates one from the stall reason so no path can land context-free.

## Changes Made

### `escalation-explanation.mjs`

- Added `buildRemediateCapExplanation(verifyJson, { ticket, cycleCount })`: reads HIGH findings and `regression_risk` from a `verify.json` object, names the blocking `file:line` in `what_failed` and `human_question`, surfaces the cycle count in `why_gave_up`, and includes top-5 HIGH findings in `observed`. Degrades gracefully when `verify.json` is absent or malformed.

### `scheduler.mjs`

- `maybeEscalateRemediateExhausted`: reads `verify.json` from disk at cap-exhaustion time (still present per tick ordering), calls `buildRemediateCapExplanation`, attaches `explanation` to the stalled signal. Missing/unreadable `verify.json` handled by the mapper's safe defaults.
- `escalateDispatchExhausted`: calls `coerceExplanation` with the dispatch failure code/cause so `humanQuestion` is non-null.
- `writeTerminalStalled`: merges `extra.explanation` if provided, otherwise generates a coerced one from the stall reason. Ensures every `writeTerminalStalled` call produces a usable inbox message.

### Tests

- `escalation-explanation.test.mjs`: 6 new unit tests for `buildRemediateCapExplanation` covering HIGH-finding naming, cycle count surfacing, `human_question` decision-fork non-tautology, `observed` field shape, risk-only (no HIGH findings), and null input.
- `scheduler.test.mjs`: 6 new tests — 3 cap-escalation integration tests (explanation attached, idempotent on re-call, degrades without verify.json) and 3 terminal-stall coverage tests (explanation propagated, fallback generated, coverage guard).

## How to Verify It

- [x] All 509 tests pass: 489 scheduler + 20 escalation-explanation (0 failures, run confirmed)
- [x] `buildRemediateCapExplanation` names the blocking `file:line` from HIGH findings
- [x] `human_question` is non-null for `remediate-cycle-cap-exhausted` escalations
- [x] Degrades gracefully: missing/null `verify.json` → valid explanation via safe defaults
- [x] `escalateDispatchExhausted` and `writeTerminalStalled` both produce non-null `humanQuestion`
- [x] No TypeScript — N/A (pure `.mjs` execution-core modules)
- [x] No new dependencies

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1108
- CTL-1065 added the explanation infrastructure wired here

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1065
