### PR TITLE
CTL-1109: claude-cli provider for AI summaries (no gateway required)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/ai-briefing.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ai-briefing.test.ts
@@ -325,13 +325,7 @@ describe("createBriefingProvider", () => {
   });
 });
 
-type FakeSpawnResult = { status: number; stdout: string; stderr: string };
-function fakeSpawn(result: FakeSpawnResult) {
-  // Cast to spawnSync-compatible type via unknown to satisfy strict generics
-  return (..._args: unknown[]) => result as unknown as ReturnType<typeof import("node:child_process").spawnSync>;
-}
-
-describe("createBriefingProvider — claude-cli spawn path", () => {
+describe("createBriefingProvider — claude-cli (--bg subscription) path", () => {
   const CLI_CONFIG: AiConfig = {
     enabled: true,
     provider: "claude-cli",
@@ -343,11 +337,11 @@ describe("createBriefingProvider — claude-cli spawn path", () => {
     suggestedLabels: { "CTL-10": ["feature"] },
   });
 
-  it("uses claude-cli spawn path (never fetches) when provider is claude-cli", async () => {
+  it("uses claude-cli path (never fetches) when provider is claude-cli", async () => {
     let fetched = false;
     const provider = createBriefingProvider(CLI_CONFIG, {
       fetcher: () => { fetched = true; throw new Error("should not fetch"); },
-      spawn: fakeSpawn({ status: 0, stdout: CLI_JSON_OUTPUT, stderr: "" }) as never,
+      runClaudeCli: () => Promise.resolve({ text: CLI_JSON_OUTPUT, tokens: 0 }),
     });
     const res = await provider.generate(makeSnapshot(), makeLinearTickets());
     expect(fetched).toBe(false);
@@ -357,7 +351,7 @@ describe("createBriefingProvider — claude-cli spawn path", () => {
 
   it("degrades to null when claude-cli produces no output", async () => {
     const provider = createBriefingProvider(CLI_CONFIG, {
-      spawn: fakeSpawn({ status: 1, stdout: "", stderr: "x" }) as never,
+      runClaudeCli: () => Promise.resolve({ text: null, tokens: 0 }),
     });
     const res = await provider.generate(makeSnapshot(), makeLinearTickets());
     expect(res).toBeNull();

--- a/plugins/dev/scripts/orch-monitor/__tests__/ai-briefing.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ai-briefing.test.ts
@@ -324,3 +324,42 @@ describe("createBriefingProvider", () => {
     expect(() => provider.stop()).not.toThrow();
   });
 });
+
+type FakeSpawnResult = { status: number; stdout: string; stderr: string };
+function fakeSpawn(result: FakeSpawnResult) {
+  // Cast to spawnSync-compatible type via unknown to satisfy strict generics
+  return (..._args: unknown[]) => result as unknown as ReturnType<typeof import("node:child_process").spawnSync>;
+}
+
+describe("createBriefingProvider — claude-cli spawn path", () => {
+  const CLI_CONFIG: AiConfig = {
+    enabled: true,
+    provider: "claude-cli",
+    model: "claude-haiku-4-5-20251001",
+  };
+
+  const CLI_JSON_OUTPUT = JSON.stringify({
+    briefing: "All good.",
+    suggestedLabels: { "CTL-10": ["feature"] },
+  });
+
+  it("uses claude-cli spawn path (never fetches) when provider is claude-cli", async () => {
+    let fetched = false;
+    const provider = createBriefingProvider(CLI_CONFIG, {
+      fetcher: () => { fetched = true; throw new Error("should not fetch"); },
+      spawn: fakeSpawn({ status: 0, stdout: CLI_JSON_OUTPUT, stderr: "" }) as never,
+    });
+    const res = await provider.generate(makeSnapshot(), makeLinearTickets());
+    expect(fetched).toBe(false);
+    expect(res?.briefing).toBe("All good.");
+    expect(res?.suggestedLabels["CTL-10"]).toContain("feature");
+  });
+
+  it("degrades to null when claude-cli produces no output", async () => {
+    const provider = createBriefingProvider(CLI_CONFIG, {
+      spawn: fakeSpawn({ status: 1, stdout: "", stderr: "x" }) as never,
+    });
+    const res = await provider.generate(makeSnapshot(), makeLinearTickets());
+    expect(res).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/ai-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ai-config.test.ts
@@ -168,4 +168,22 @@ describe("loadAiConfig", () => {
     const cfg = loadAiConfig(projectPath, join(tmpRoot, "missing.json"));
     expect(cfg.enabled).toBe(false);
   });
+
+  it("enables claude-cli provider with no gateway or apiKey in secrets", () => {
+    const projectPath = join(tmpRoot, "project.json");
+    const secretsPath = join(tmpRoot, "secrets.json");
+    writeFileSync(projectPath, JSON.stringify({ catalyst: { ai: { enabled: true } } }));
+    writeFileSync(secretsPath, JSON.stringify({ ai: { provider: "claude-cli" } }));
+    const cfg = loadAiConfig(projectPath, secretsPath);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.provider).toBe("claude-cli");
+  });
+
+  it("still disables non-claude-cli providers without a gateway/apiKey", () => {
+    const projectPath = join(tmpRoot, "project.json");
+    const secretsPath = join(tmpRoot, "secrets.json");
+    writeFileSync(projectPath, JSON.stringify({ catalyst: { ai: { enabled: true } } }));
+    writeFileSync(secretsPath, JSON.stringify({ ai: { provider: "anthropic" } }));
+    expect(loadAiConfig(projectPath, secretsPath).enabled).toBe(false);
+  });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/summarize-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/summarize-config.test.ts
@@ -165,4 +165,28 @@ describe("loadSummarizeConfig", () => {
     expect(cfg.enabled).toBe(true);
     expect(Object.keys(cfg.providers)).toEqual(["anthropic"]);
   });
+
+  it("enables claude-cli provider without an apiKeyEnv/apiKey", () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        catalyst: { ai: { enabled: true, defaultProvider: "claude-cli", providers: { "claude-cli": {} } } },
+      }),
+    );
+    const cfg = loadSummarizeConfig(configPath, {});
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.defaultProvider).toBe("claude-cli");
+    expect(cfg.providers["claude-cli"]).toBeDefined();
+  });
+
+  it("still ignores genuinely unknown provider names", () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        catalyst: { ai: { enabled: true, providers: { "made-up": { apiKeyEnv: "X" } } } },
+      }),
+    );
+    const cfg = loadSummarizeConfig(configPath, { X: "key" });
+    expect(cfg.providers["made-up" as never]).toBeUndefined();
+  });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/summarize-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/summarize-endpoint.test.ts
@@ -94,6 +94,7 @@ describe("POST /api/summarize", () => {
       anthropic: stubProvider({ count: callCount }),
       openai: stubProvider(),
       grok: stubProvider(),
+      "claude-cli": stubProvider(),
     };
 
     const handler = createSummarizeHandler({
@@ -316,6 +317,7 @@ describe("POST /api/summarize — rate limited", () => {
       anthropic: stubProvider(),
       openai: stubProvider(),
       grok: stubProvider(),
+      "claude-cli": stubProvider(),
     };
 
     const handler = createSummarizeHandler({
@@ -350,5 +352,99 @@ describe("POST /api/summarize — rate limited", () => {
       body: JSON.stringify({ orchId: "orch-test" }),
     });
     expect(res.status).toBe(429);
+  });
+});
+
+describe("POST /api/summarize — claude-cli keyless provider", () => {
+  let tmp: string;
+  let wtDir: string;
+  let server: Server;
+  let baseUrl: string;
+  let cliProviderCallCount: { n: number };
+
+  beforeAll(() => {
+    tmp = mkdtempSync(join(tmpdir(), "summarize-cli-endpoint-"));
+    wtDir = join(tmp, "wt");
+    mkdirSync(join(wtDir, "orch-cli", "workers"), { recursive: true });
+    writeFileSync(
+      join(wtDir, "orch-cli", "state.json"),
+      JSON.stringify({
+        orchestrator: "orch-cli",
+        startedAt: "2026-04-22T12:00:00Z",
+        waves: [{ wave: 1, status: "in_progress", tickets: ["CTL-1"] }],
+        currentWave: 1,
+        totalWaves: 1,
+      }),
+    );
+    writeFileSync(
+      join(wtDir, "orch-cli", "workers", "CTL-1.json"),
+      JSON.stringify({
+        ticket: "CTL-1",
+        orchestrator: "orch-cli",
+        status: "researching",
+        phase: 1,
+        startedAt: "2026-04-22T12:01:00Z",
+        updatedAt: "2026-04-22T12:01:00Z",
+      }),
+    );
+
+    cliProviderCallCount = { n: 0 };
+
+    const cliConfig: SummarizeConfig = {
+      enabled: true,
+      defaultProvider: "claude-cli",
+      defaultModel: "claude-haiku-4-5-20251001",
+      providers: { "claude-cli": { apiKeyEnv: "" } },
+    };
+
+    const providers: Record<ProviderName, SummarizeProvider> = {
+      anthropic: stubProvider(),
+      openai: stubProvider(),
+      grok: stubProvider(),
+      "claude-cli": {
+        name: "claude-cli",
+        summarize: () => {
+          cliProviderCallCount.n += 1;
+          return Promise.resolve({ summary: "cli summary", cost: 0, tokens: 0 });
+        },
+      },
+    };
+
+    const handler = createSummarizeHandler({
+      config: cliConfig,
+      buildSnapshot: (orchId) => buildSummarizeSnapshot(wtDir, orchId),
+      providers,
+      cache: createCache(60_000),
+      rateLimiter: createRateLimiter({ maxConcurrent: 10, minIntervalMs: 0 }),
+    });
+
+    server = createServer({
+      port: 0,
+      wtDir,
+      startWatcher: false,
+      prStatusFetcher: null,
+      linearFetcher: null,
+      annotationsDbPath: join(tmp, "ann2.db"),
+      summarizeHandler: handler,
+    });
+    baseUrl = `http://localhost:${String(server.port)}`;
+  });
+
+  afterAll(() => {
+    void server.stop(true);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns 200 with claude-cli provider (no apiKey required)", async () => {
+    const res = await fetch(`${baseUrl}/api/summarize`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ orchId: "orch-cli" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { provider?: string; summary?: string };
+    expect(body.provider).toBe("claude-cli");
+    expect(body.summary).toBe("cli summary");
+    expect(cliProviderCallCount.n).toBe(1);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/summarize-providers.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/summarize-providers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "bun:test";
 import { getProvider, calculateCost } from "../lib/summarize/providers";
 import { claudeCliProvider } from "../lib/summarize/providers/claude-cli";
 import type { AiFetcher } from "../lib/ai-briefing";
+import type { ClaudeCliResult, RunClaudeCli } from "../lib/claude-cli";
 
 interface RequestRecord {
   url: string;
@@ -159,29 +160,33 @@ describe("anthropicProvider", () => {
   });
 });
 
-type FakeSpawnResult = { status: number; stdout: string; stderr: string };
-function fakeCliSpawn(result: FakeSpawnResult) {
-  return (..._args: unknown[]) => result as unknown as ReturnType<typeof import("node:child_process").spawnSync>;
+// CTL-1109: the provider was remediated to drive `claude --bg` via the
+// injectable `runClaudeCli` seam (lib/claude-cli.ts). Tests inject a fake
+// `runClaudeCli` so they touch no real CLI/fs/clock — the old `spawn` double
+// no longer matches the provider's injection point and fell through to the
+// real CLI (5s --bg timeout).
+function fakeRunClaudeCli(result: ClaudeCliResult): RunClaudeCli {
+  return () => Promise.resolve(result);
 }
 
 describe("claudeCliProvider", () => {
-  it("returns stdout as summary with zero cost", async () => {
+  it("returns CLI text as summary with zero cost", async () => {
     const res = await claudeCliProvider.summarize({
       systemPrompt: "SYS", userPrompt: "USR", model: "claude-haiku-4-5-20251001",
       apiKey: "",
-      spawn: fakeCliSpawn({ status: 0, stdout: "A concise summary.\n", stderr: "" }),
+      runClaudeCli: fakeRunClaudeCli({ text: "A concise summary.", tokens: 0 }),
     } as never);
     expect(res.summary).toBe("A concise summary.");
     expect(res.cost).toBe(0);
     expect(res.tokens).toBe(0);
   });
 
-  it("rejects (maps to 502) on CLI failure", async () => {
+  it("rejects when the CLI produces no output", async () => {
     let caught: Error | null = null;
     try {
       await claudeCliProvider.summarize({
         systemPrompt: "", userPrompt: "x", model: "m", apiKey: "",
-        spawn: fakeCliSpawn({ status: 1, stdout: "", stderr: "boom" }),
+        runClaudeCli: fakeRunClaudeCli({ text: null, tokens: 0 }),
       } as never);
     } catch (err) {
       caught = err as Error;

--- a/plugins/dev/scripts/orch-monitor/__tests__/summarize-providers.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/summarize-providers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import { getProvider, calculateCost } from "../lib/summarize/providers";
+import { claudeCliProvider } from "../lib/summarize/providers/claude-cli";
 import type { AiFetcher } from "../lib/ai-briefing";
 
 interface RequestRecord {
@@ -155,6 +156,41 @@ describe("anthropicProvider", () => {
       caught = err as Error;
     }
     expect(caught).not.toBeNull();
+  });
+});
+
+type FakeSpawnResult = { status: number; stdout: string; stderr: string };
+function fakeCliSpawn(result: FakeSpawnResult) {
+  return (..._args: unknown[]) => result as unknown as ReturnType<typeof import("node:child_process").spawnSync>;
+}
+
+describe("claudeCliProvider", () => {
+  it("returns stdout as summary with zero cost", async () => {
+    const res = await claudeCliProvider.summarize({
+      systemPrompt: "SYS", userPrompt: "USR", model: "claude-haiku-4-5-20251001",
+      apiKey: "",
+      spawn: fakeCliSpawn({ status: 0, stdout: "A concise summary.\n", stderr: "" }),
+    } as never);
+    expect(res.summary).toBe("A concise summary.");
+    expect(res.cost).toBe(0);
+    expect(res.tokens).toBe(0);
+  });
+
+  it("rejects (maps to 502) on CLI failure", async () => {
+    let caught: Error | null = null;
+    try {
+      await claudeCliProvider.summarize({
+        systemPrompt: "", userPrompt: "x", model: "m", apiKey: "",
+        spawn: fakeCliSpawn({ status: 1, stdout: "", stderr: "boom" }),
+      } as never);
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).not.toBeNull();
+  });
+
+  it("has name 'claude-cli'", () => {
+    expect(claudeCliProvider.name).toBe("claude-cli");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/lib/ai-briefing.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/ai-briefing.ts
@@ -1,6 +1,8 @@
+import type { spawnSync } from "node:child_process";
 import type { AiConfig } from "./ai-config";
 import type { MonitorSnapshot, WorkerState } from "./state-reader";
 import type { LinearTicket } from "./linear";
+import { runClaudeCli } from "./claude-cli";
 
 export interface BriefingResult {
   briefing: string;
@@ -133,19 +135,9 @@ function extractTextFromOpenAIResponse(parsed: unknown): string | null {
   return typeof message.content === "string" ? message.content : null;
 }
 
-export function parseBriefingResponse(raw: string): BriefingResult | null {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw) as unknown;
-  } catch {
-    return null;
-  }
-
-  const text =
-    extractTextFromAnthropicResponse(parsed) ??
-    extractTextFromOpenAIResponse(parsed);
-  if (!text) return null;
-
+/** Parse raw model text (not an API envelope) into a BriefingResult.
+ *  Used by the claude-cli path where stdout IS the model text directly. */
+export function parseBriefingText(text: string): BriefingResult | null {
   let briefingData: unknown;
   try {
     briefingData = JSON.parse(text) as unknown;
@@ -177,6 +169,22 @@ export function parseBriefingResponse(raw: string): BriefingResult | null {
     suggestedLabels: labels,
     generatedAt: new Date().toISOString(),
   };
+}
+
+export function parseBriefingResponse(raw: string): BriefingResult | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+
+  const text =
+    extractTextFromAnthropicResponse(parsed) ??
+    extractTextFromOpenAIResponse(parsed);
+  if (!text) return null;
+
+  return parseBriefingText(text);
 }
 
 function buildGatewayUrl(config: AiConfig): string {
@@ -231,12 +239,15 @@ const defaultFetcher: AiFetcher = async (url, init) => {
   };
 };
 
+const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
+
 export function createBriefingProvider(
   config: AiConfig,
-  opts: { fetcher?: AiFetcher; cacheTtlMs?: number } = {},
+  opts: { fetcher?: AiFetcher; cacheTtlMs?: number; spawn?: typeof spawnSync } = {},
 ): BriefingProvider {
   const fetcher = opts.fetcher ?? defaultFetcher;
   const cacheTtlMs = opts.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  const isCli = config.provider === "claude-cli";
   let cache: CacheEntry | null = null;
 
   return {
@@ -248,6 +259,18 @@ export function createBriefingProvider(
       }
 
       const prompt = buildPrompt(snapshot, linearTickets);
+
+      if (isCli) {
+        const { text } = runClaudeCli(
+          { model: config.model ?? DEFAULT_MODEL, systemPrompt: "", userPrompt: prompt },
+          opts.spawn ? { spawn: opts.spawn } : {},
+        );
+        if (text === null) return null;
+        const result = parseBriefingText(text);
+        if (result) cache = { result, fetchedAt: Date.now() };
+        return result;
+      }
+
       const url = buildGatewayUrl(config);
       const headers = buildHeaders(config);
       const body = buildRequestBody(config, prompt);

--- a/plugins/dev/scripts/orch-monitor/lib/ai-briefing.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/ai-briefing.ts
@@ -1,8 +1,7 @@
-import type { spawnSync } from "node:child_process";
 import type { AiConfig } from "./ai-config";
 import type { MonitorSnapshot, WorkerState } from "./state-reader";
 import type { LinearTicket } from "./linear";
-import { runClaudeCli } from "./claude-cli";
+import { type RunClaudeCli, runClaudeCli } from "./claude-cli";
 
 export interface BriefingResult {
   briefing: string;
@@ -243,7 +242,7 @@ const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
 
 export function createBriefingProvider(
   config: AiConfig,
-  opts: { fetcher?: AiFetcher; cacheTtlMs?: number; spawn?: typeof spawnSync } = {},
+  opts: { fetcher?: AiFetcher; cacheTtlMs?: number; runClaudeCli?: RunClaudeCli } = {},
 ): BriefingProvider {
   const fetcher = opts.fetcher ?? defaultFetcher;
   const cacheTtlMs = opts.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
@@ -261,10 +260,12 @@ export function createBriefingProvider(
       const prompt = buildPrompt(snapshot, linearTickets);
 
       if (isCli) {
-        const { text } = runClaudeCli(
-          { model: config.model ?? DEFAULT_MODEL, systemPrompt: "", userPrompt: prompt },
-          opts.spawn ? { spawn: opts.spawn } : {},
-        );
+        const run = opts.runClaudeCli ?? runClaudeCli;
+        const { text } = await run({
+          model: config.model ?? DEFAULT_MODEL,
+          systemPrompt: "",
+          userPrompt: prompt,
+        });
         if (text === null) return null;
         const result = parseBriefingText(text);
         if (result) cache = { result, fetchedAt: Date.now() };

--- a/plugins/dev/scripts/orch-monitor/lib/ai-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/ai-config.ts
@@ -43,16 +43,16 @@ export function loadAiConfig(
   const aiSecrets = isRecord(secrets.ai) ? secrets.ai : null;
   if (!aiSecrets) return DISABLED;
 
-  const gateway =
-    typeof aiSecrets.gateway === "string" ? aiSecrets.gateway : "";
-  const apiKey = typeof aiSecrets.apiKey === "string" ? aiSecrets.apiKey : "";
-
-  if (!gateway || !apiKey) return DISABLED;
-
   const provider =
     typeof aiSecrets.provider === "string" && aiSecrets.provider
       ? aiSecrets.provider
       : DEFAULT_PROVIDER;
+  const gateway =
+    typeof aiSecrets.gateway === "string" ? aiSecrets.gateway : "";
+  const apiKey = typeof aiSecrets.apiKey === "string" ? aiSecrets.apiKey : "";
+
+  if (provider !== "claude-cli" && (!gateway || !apiKey)) return DISABLED;
+
   const model =
     typeof aiSecrets.model === "string" && aiSecrets.model
       ? aiSecrets.model

--- a/plugins/dev/scripts/orch-monitor/lib/claude-cli.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/claude-cli.test.ts
@@ -1,65 +1,179 @@
 import { describe, it, expect } from "bun:test";
-import { runClaudeCli } from "./claude-cli";
+import {
+  type ClaudeCliDeps,
+  type ClaudeJobState,
+  type SpawnFn,
+  encodeProjectDir,
+  parseBackgroundJobId,
+  runClaudeCli,
+} from "./claude-cli";
 
+// A spawn double that records calls and returns a fixed `claude --bg` result.
+// Typed as the minimal SpawnFn seam — no `as unknown as typeof spawnSync` cast.
 function fakeSpawn(result: { status: number; stdout: string; stderr?: string }) {
-  const calls: Array<{ bin: string; args: string[]; input?: string }> = [];
-  const spawn = (bin: string, args: string[], opts: { input?: string }) => {
-    calls.push({ bin, args, input: opts?.input });
+  const calls: Array<{ bin: string; args: string[] }> = [];
+  const spawn: SpawnFn = (bin, args) => {
+    calls.push({ bin, args });
     return { status: result.status, stdout: result.stdout, stderr: result.stderr ?? "" };
   };
   return { spawn, calls };
 }
 
-describe("runClaudeCli", () => {
-  it("invokes `claude -p --model <model>` and returns trimmed stdout", () => {
-    const { spawn, calls } = fakeSpawn({ status: 0, stdout: "  hello world\n" });
-    const res = runClaudeCli(
+// Default happy-path deps: a launch banner, an immediately-terminal job, and a
+// transcript that yields text. Individual tests override one seam at a time.
+function happyDeps(
+  overrides: Partial<ClaudeCliDeps> = {},
+  spawnResult: { status: number; stdout: string; stderr?: string } = {
+    status: 0,
+    stdout: "backgrounded · 729bf9f1\n",
+  },
+): { deps: ClaudeCliDeps; spawnCalls: Array<{ bin: string; args: string[] }> } {
+  const { spawn, calls } = fakeSpawn(spawnResult);
+  const state: ClaudeJobState = {
+    state: "stopped",
+    sessionId: "729bf9f1-0708-4723-9aa3-f1f1ad3eac3f",
+    cwd: "/Users/me/wt/CTL-1",
+    firstTerminalAt: "2026-06-13T22:00:00Z",
+  };
+  const deps: ClaudeCliDeps = {
+    spawn,
+    readState: () => state,
+    readTranscript: () => "hello world",
+    sleep: () => Promise.resolve(),
+    ...overrides,
+  };
+  return { deps, spawnCalls: calls };
+}
+
+describe("parseBackgroundJobId", () => {
+  it("extracts the short hex id from the backgrounded banner", () => {
+    expect(parseBackgroundJobId("backgrounded · 729bf9f1\n")).toBe("729bf9f1");
+  });
+  it("tolerates banner spacing/punctuation variants", () => {
+    expect(parseBackgroundJobId("✔ backgrounded - 164891e9 (CTL-1)")).toBe("164891e9");
+  });
+  it("returns null when no 8-hex token is present", () => {
+    expect(parseBackgroundJobId("nothing here")).toBeNull();
+  });
+});
+
+describe("encodeProjectDir", () => {
+  it("maps / and . to - (matches ~/.claude/projects encoding)", () => {
+    expect(encodeProjectDir("/a/b/CTL-1")).toBe("-a-b-CTL-1");
+    expect(encodeProjectDir("/x/.claude/wt")).toBe("-x--claude-wt");
+  });
+});
+
+describe("runClaudeCli (--bg subscription flow)", () => {
+  it("drives `claude --bg --model <m> --dangerously-skip-permissions <prompt>`", async () => {
+    const { deps, spawnCalls } = happyDeps();
+    const res = await runClaudeCli(
       { model: "claude-haiku-4-5-20251001", systemPrompt: "SYS", userPrompt: "USR" },
-      { spawn },
+      deps,
     );
     expect(res.text).toBe("hello world");
-    expect(calls[0].bin).toContain("claude");
-    expect(calls[0].args).toEqual(["-p", "--model", "claude-haiku-4-5-20251001"]);
-    expect(calls[0].input).toContain("SYS");
-    expect(calls[0].input).toContain("USR");
+    expect(spawnCalls[0].bin).toContain("claude");
+    expect(spawnCalls[0].args.slice(0, 4)).toEqual([
+      "--bg",
+      "--model",
+      "claude-haiku-4-5-20251001",
+      "--dangerously-skip-permissions",
+    ]);
+    // Prompt is passed as the trailing positional arg (NOT `-p`, NOT stdin).
+    expect(spawnCalls[0].args[4]).toBe("SYS\n\nUSR");
+    expect(spawnCalls[0].args).not.toContain("-p");
   });
 
-  it("returns null text on non-zero exit", () => {
-    const { spawn } = fakeSpawn({ status: 1, stdout: "", stderr: "boom" });
-    const res = runClaudeCli(
-      { model: "m", systemPrompt: "", userPrompt: "x" },
-      { spawn },
-    );
-    expect(res.text).toBeNull();
+  it("uses only userPrompt when systemPrompt is empty", async () => {
+    const { deps, spawnCalls } = happyDeps();
+    await runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "ONLY" }, deps);
+    expect(spawnCalls[0].args[4]).toBe("ONLY");
   });
 
-  it("returns null text when spawn throws", () => {
-    const spawn = () => { throw new Error("ENOENT"); };
-    const res = runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "x" }, { spawn });
-    expect(res.text).toBeNull();
+  it("reads the last assistant text from the resolved transcript", async () => {
+    const seen: Array<{ cwd: string; sessionId: string }> = [];
+    const { deps } = happyDeps({
+      readTranscript: (cwd, sessionId) => {
+        seen.push({ cwd, sessionId });
+        return "the summary";
+      },
+    });
+    const res = await runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "x" }, deps);
+    expect(res.text).toBe("the summary");
+    expect(seen[0]).toEqual({
+      cwd: "/Users/me/wt/CTL-1",
+      sessionId: "729bf9f1-0708-4723-9aa3-f1f1ad3eac3f",
+    });
   });
 
-  it("returns null text when stdout is empty string after trim", () => {
-    const { spawn } = fakeSpawn({ status: 0, stdout: "   \n  " });
-    const res = runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "x" }, { spawn });
-    expect(res.text).toBeNull();
-  });
-
-  it("always returns tokens: 0 (no usage envelope from claude -p)", () => {
-    const { spawn } = fakeSpawn({ status: 0, stdout: "hi" });
-    const res = runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "x" }, { spawn });
+  it("always returns tokens: 0 (subscription run, no API usage envelope)", async () => {
+    const { deps } = happyDeps();
+    const res = await runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "x" }, deps);
     expect(res.tokens).toBe(0);
   });
 
-  it("concatenates systemPrompt and userPrompt with double newline", () => {
-    const { spawn, calls } = fakeSpawn({ status: 0, stdout: "ok" });
-    runClaudeCli({ model: "m", systemPrompt: "SYSTEM", userPrompt: "USER" }, { spawn });
-    expect(calls[0].input).toBe("SYSTEM\n\nUSER");
+  it("returns null when the --bg launch exits non-zero", async () => {
+    const { deps } = happyDeps({}, { status: 1, stdout: "", stderr: "boom" });
+    const res = await runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "x" }, deps);
+    expect(res.text).toBeNull();
   });
 
-  it("uses only userPrompt when systemPrompt is empty", () => {
-    const { spawn, calls } = fakeSpawn({ status: 0, stdout: "ok" });
-    runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "ONLY_USER" }, { spawn });
-    expect(calls[0].input).toBe("ONLY_USER");
+  it("returns null when spawn throws", async () => {
+    const spawn: SpawnFn = () => {
+      throw new Error("ENOENT");
+    };
+    const res = await runClaudeCli(
+      { model: "m", systemPrompt: "", userPrompt: "x" },
+      { spawn, sleep: () => Promise.resolve() },
+    );
+    expect(res.text).toBeNull();
+  });
+
+  it("returns null when no job id can be parsed from the banner", async () => {
+    const { deps } = happyDeps({}, { status: 0, stdout: "no id here\n" });
+    const res = await runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "x" }, deps);
+    expect(res.text).toBeNull();
+  });
+
+  it("polls until the job reaches a terminal state", async () => {
+    const states: ClaudeJobState[] = [
+      { state: "running" },
+      { state: "running" },
+      {
+        state: "stopped",
+        sessionId: "abc",
+        cwd: "/w",
+        firstTerminalAt: "2026-06-13T22:00:00Z",
+      },
+    ];
+    let i = 0;
+    const { deps } = happyDeps({
+      readState: () => states[Math.min(i++, states.length - 1)],
+      readTranscript: () => "done",
+    });
+    const res = await runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "x" }, deps);
+    expect(res.text).toBe("done");
+    expect(i).toBeGreaterThanOrEqual(3);
+  });
+
+  it("returns null when the job never reaches a terminal state before timeout", async () => {
+    const { deps } = happyDeps({ readState: () => ({ state: "running" }) });
+    const res = await runClaudeCli(
+      { model: "m", systemPrompt: "", userPrompt: "x" },
+      { ...deps, timeout: 3000 },
+    );
+    expect(res.text).toBeNull();
+  });
+
+  it("returns null when the transcript has no assistant text", async () => {
+    const { deps } = happyDeps({ readTranscript: () => null });
+    const res = await runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "x" }, deps);
+    expect(res.text).toBeNull();
+  });
+
+  it("returns null when the terminal state lacks sessionId/cwd", async () => {
+    const { deps } = happyDeps({ readState: () => ({ state: "stopped" }) });
+    const res = await runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "x" }, deps);
+    expect(res.text).toBeNull();
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/claude-cli.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/claude-cli.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "bun:test";
+import { runClaudeCli } from "./claude-cli";
+
+function fakeSpawn(result: { status: number; stdout: string; stderr?: string }) {
+  const calls: Array<{ bin: string; args: string[]; input?: string }> = [];
+  const spawn = (bin: string, args: string[], opts: { input?: string }) => {
+    calls.push({ bin, args, input: opts?.input });
+    return { status: result.status, stdout: result.stdout, stderr: result.stderr ?? "" };
+  };
+  return { spawn, calls };
+}
+
+describe("runClaudeCli", () => {
+  it("invokes `claude -p --model <model>` and returns trimmed stdout", () => {
+    const { spawn, calls } = fakeSpawn({ status: 0, stdout: "  hello world\n" });
+    const res = runClaudeCli(
+      { model: "claude-haiku-4-5-20251001", systemPrompt: "SYS", userPrompt: "USR" },
+      { spawn },
+    );
+    expect(res.text).toBe("hello world");
+    expect(calls[0].bin).toContain("claude");
+    expect(calls[0].args).toEqual(["-p", "--model", "claude-haiku-4-5-20251001"]);
+    expect(calls[0].input).toContain("SYS");
+    expect(calls[0].input).toContain("USR");
+  });
+
+  it("returns null text on non-zero exit", () => {
+    const { spawn } = fakeSpawn({ status: 1, stdout: "", stderr: "boom" });
+    const res = runClaudeCli(
+      { model: "m", systemPrompt: "", userPrompt: "x" },
+      { spawn },
+    );
+    expect(res.text).toBeNull();
+  });
+
+  it("returns null text when spawn throws", () => {
+    const spawn = () => { throw new Error("ENOENT"); };
+    const res = runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "x" }, { spawn });
+    expect(res.text).toBeNull();
+  });
+
+  it("returns null text when stdout is empty string after trim", () => {
+    const { spawn } = fakeSpawn({ status: 0, stdout: "   \n  " });
+    const res = runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "x" }, { spawn });
+    expect(res.text).toBeNull();
+  });
+
+  it("always returns tokens: 0 (no usage envelope from claude -p)", () => {
+    const { spawn } = fakeSpawn({ status: 0, stdout: "hi" });
+    const res = runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "x" }, { spawn });
+    expect(res.tokens).toBe(0);
+  });
+
+  it("concatenates systemPrompt and userPrompt with double newline", () => {
+    const { spawn, calls } = fakeSpawn({ status: 0, stdout: "ok" });
+    runClaudeCli({ model: "m", systemPrompt: "SYSTEM", userPrompt: "USER" }, { spawn });
+    expect(calls[0].input).toBe("SYSTEM\n\nUSER");
+  });
+
+  it("uses only userPrompt when systemPrompt is empty", () => {
+    const { spawn, calls } = fakeSpawn({ status: 0, stdout: "ok" });
+    runClaudeCli({ model: "m", systemPrompt: "", userPrompt: "ONLY_USER" }, { spawn });
+    expect(calls[0].input).toBe("ONLY_USER");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/claude-cli.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/claude-cli.ts
@@ -1,7 +1,13 @@
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
 
 const CLAUDE_BIN = process.env.CATALYST_DISPATCH_CLAUDE_BIN || "claude";
-const DEFAULT_TIMEOUT_MS = 120_000;
+// Bounded poll budget for a one-shot --bg job to reach a terminal state.
+// A --bg one-shot spins a full agent session (~5s) so we allow headroom but
+// cap it: this provider is LOW-VOLUME only (escalation blurbs / briefings).
+const DEFAULT_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 1_000;
 
 export interface ClaudeCliArgs {
   model: string;
@@ -14,28 +20,239 @@ export interface ClaudeCliResult {
   tokens: number;
 }
 
-// Injectable spawn seam (mirrors stop-worker.mjs pattern): tests pass a fake.
-export function runClaudeCli(
+/**
+ * Minimal spawn seam (CTL-1109 remediate). We only depend on this slice of
+ * `spawnSync`, so test doubles satisfy it without `as unknown as` casts —
+ * unlike `typeof spawnSync`, whose `NonSharedBuffer` stdout and full overload
+ * set the fakes could not match.
+ */
+export type SpawnFn = (
+  bin: string,
+  args: string[],
+  opts: { input?: string; encoding?: string; timeout?: number },
+) => { status: number | null; stdout: string; stderr: string };
+
+/** The slice of `~/.claude/jobs/<jobid>/state.json` we read. */
+export interface ClaudeJobState {
+  state?: string;
+  sessionId?: string;
+  cwd?: string;
+  firstTerminalAt?: string;
+}
+
+/** Injectable seams for the --bg job lifecycle so tests touch no real fs/clock. */
+export interface ClaudeCliDeps {
+  spawn?: SpawnFn;
+  /** Read+parse `~/.claude/jobs/<jobid>/state.json`; null if absent/unreadable. */
+  readState?: (jobId: string) => ClaudeJobState | null;
+  /** Last assistant text from the session transcript; null if absent/empty. */
+  readTranscript?: (cwd: string, sessionId: string) => string | null;
+  /** Poll delay — injected so tests resolve instantly. */
+  sleep?: (ms: number) => Promise<void>;
+  timeout?: number;
+}
+
+export type RunClaudeCli = (
   args: ClaudeCliArgs,
-  { spawn = spawnSync, timeout = DEFAULT_TIMEOUT_MS }: {
-    spawn?: typeof spawnSync;
-    timeout?: number;
-  } = {},
-): ClaudeCliResult {
-  const input = args.systemPrompt
+  deps?: ClaudeCliDeps,
+) => Promise<ClaudeCliResult>;
+
+// A daemon job that has reached any of these is done (or `firstTerminalAt` set).
+const TERMINAL_STATES = new Set([
+  "stopped",
+  "completed",
+  "complete",
+  "failed",
+  "error",
+  "killed",
+  "cancelled",
+]);
+
+const defaultSpawn: SpawnFn = (bin, args, opts) => {
+  const res = spawnSync(bin, args, {
+    input: opts.input,
+    encoding: "utf8",
+    timeout: opts.timeout,
+  });
+  return {
+    status: res.status,
+    stdout: typeof res.stdout === "string" ? res.stdout : "",
+    stderr: typeof res.stderr === "string" ? res.stderr : "",
+  };
+};
+
+function defaultReadState(jobId: string): ClaudeJobState | null {
+  try {
+    const raw = readFileSync(`${homedir()}/.claude/jobs/${jobId}/state.json`, "utf8");
+    return JSON.parse(raw) as ClaudeJobState;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Encode an absolute cwd to its `~/.claude/projects/<dir>` form. Claude Code
+ * maps `/` and `.` to `-` (e.g. `/a/.claude` → `-a--claude`); verified against
+ * live project dirs (CTL-1109).
+ */
+export function encodeProjectDir(cwd: string): string {
+  return cwd.replace(/[/.]/g, "-");
+}
+
+function extractAssistantText(evt: unknown): string | null {
+  if (!evt || typeof evt !== "object") return null;
+  const e = evt as { type?: string; message?: { role?: string; content?: unknown } };
+  if (e.type !== "assistant" || e.message?.role !== "assistant") return null;
+  const content = e.message.content;
+  if (typeof content === "string") return content.trim() || null;
+  if (!Array.isArray(content)) return null;
+  const parts: string[] = [];
+  for (const block of content) {
+    if (
+      block && typeof block === "object" &&
+      (block as { type?: string }).type === "text"
+    ) {
+      const t = (block as { text?: unknown }).text;
+      if (typeof t === "string") parts.push(t);
+    }
+  }
+  const joined = parts.join("").trim();
+  return joined.length > 0 ? joined : null;
+}
+
+function defaultReadTranscript(cwd: string, sessionId: string): string | null {
+  try {
+    const path =
+      `${homedir()}/.claude/projects/${encodeProjectDir(cwd)}/${sessionId}.jsonl`;
+    const raw = readFileSync(path, "utf8");
+    const lines = raw.split("\n");
+    // Walk backwards to the LAST assistant message that carries text — the
+    // final turn is often a tool_use block with no text (verified live).
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i].trim();
+      if (line.length === 0) continue;
+      let evt: unknown;
+      try {
+        evt = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const text = extractAssistantText(evt);
+      if (text) return text;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Parse the `backgrounded · <jobid>` banner `claude --bg` prints to stdout.
+ * The job ID is the 8-char hex short ID (see lib/claude-ids.sh).
+ */
+export function parseBackgroundJobId(stdout: string): string | null {
+  const banner = stdout.match(/backgrounded[^0-9a-f]*([0-9a-f]{8})\b/i);
+  if (banner) return banner[1];
+  const hex = stdout.match(/\b([0-9a-f]{8})\b/);
+  return hex ? hex[1] : null;
+}
+
+function isTerminal(state: ClaudeJobState): boolean {
+  if (state.firstTerminalAt) return true;
+  return state.state ? TERMINAL_STATES.has(state.state) : false;
+}
+
+/**
+ * Run a one-shot Claude generation on the host's **Claude Max subscription**
+ * (cost = 0 against the metered API) by driving `claude --bg`, NOT `claude -p`.
+ *
+ * Correction verified live 2026-06-13 (CTL-1109): `-p` now bills the metered
+ * API; only `--bg` runs on the subscription windows. Flow:
+ *   1. spawn `claude --bg --model <m> --dangerously-skip-permissions "<prompt>"`,
+ *      parse `backgrounded · <jobid>` from stdout;
+ *   2. read sessionId from `~/.claude/jobs/<jobid>/state.json`;
+ *   3. poll state.json to a terminal state (bounded by `timeout`);
+ *   4. extract the last assistant text from the session transcript
+ *      `~/.claude/projects/<enc(cwd)>/<sessionId>.jsonl`.
+ * `claude logs` is deliberately avoided — it returns raw TUI escape codes.
+ *
+ * All failure modes (spawn throw, non-zero exit, no banner, missing state,
+ * timeout, empty transcript) degrade to `{ text: null, tokens: 0 }` with a
+ * single `[claude-cli]` warn for observability (the degrade-to-null contract
+ * the callers depend on is unchanged). tokens is always 0: subscription runs
+ * carry no API usage envelope here.
+ */
+export async function runClaudeCli(
+  args: ClaudeCliArgs,
+  deps: ClaudeCliDeps = {},
+): Promise<ClaudeCliResult> {
+  const spawn = deps.spawn ?? defaultSpawn;
+  const readState = deps.readState ?? defaultReadState;
+  const readTranscript = deps.readTranscript ?? defaultReadTranscript;
+  const sleep = deps.sleep ?? defaultSleep;
+  const timeout = deps.timeout ?? DEFAULT_TIMEOUT_MS;
+
+  const prompt = args.systemPrompt
     ? `${args.systemPrompt}\n\n${args.userPrompt}`
     : args.userPrompt;
+
   try {
-    const res = spawn(CLAUDE_BIN, ["-p", "--model", args.model], {
-      input,
-      encoding: "utf8",
-      timeout,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    if ((res?.status ?? 1) !== 0) return { text: null, tokens: 0 };
-    const text = typeof res.stdout === "string" ? res.stdout.trim() : "";
-    return { text: text.length > 0 ? text : null, tokens: 0 };
-  } catch {
+    const launch = spawn(
+      CLAUDE_BIN,
+      ["--bg", "--model", args.model, "--dangerously-skip-permissions", prompt],
+      { encoding: "utf8", timeout },
+    );
+    if ((launch?.status ?? 1) !== 0) {
+      console.warn(
+        `[claude-cli] --bg launch exited ${String(launch?.status)}: ${launch?.stderr ?? ""}`,
+      );
+      return { text: null, tokens: 0 };
+    }
+    const jobId = parseBackgroundJobId(launch.stdout ?? "");
+    if (!jobId) {
+      console.warn(`[claude-cli] could not parse a job id from --bg stdout`);
+      return { text: null, tokens: 0 };
+    }
+
+    let waited = 0;
+    let state: ClaudeJobState | null = null;
+    for (;;) {
+      state = readState(jobId);
+      if (state && isTerminal(state)) break;
+      if (waited >= timeout) {
+        console.warn(
+          `[claude-cli] job ${jobId} did not reach terminal within ${String(timeout)}ms`,
+        );
+        return { text: null, tokens: 0 };
+      }
+      await sleep(POLL_INTERVAL_MS);
+      waited += POLL_INTERVAL_MS;
+    }
+
+    const sessionId = state.sessionId;
+    const cwd = state.cwd;
+    if (!sessionId || !cwd) {
+      console.warn(
+        `[claude-cli] job ${jobId} terminal but missing sessionId/cwd in state.json`,
+      );
+      return { text: null, tokens: 0 };
+    }
+
+    const text = readTranscript(cwd, sessionId);
+    if (!text) {
+      console.warn(
+        `[claude-cli] no assistant text in transcript for session ${sessionId}`,
+      );
+      return { text: null, tokens: 0 };
+    }
+    return { text, tokens: 0 };
+  } catch (err) {
+    console.warn(
+      `[claude-cli] run failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return { text: null, tokens: 0 };
   }
 }

--- a/plugins/dev/scripts/orch-monitor/lib/claude-cli.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/claude-cli.ts
@@ -1,0 +1,41 @@
+import { spawnSync } from "node:child_process";
+
+const CLAUDE_BIN = process.env.CATALYST_DISPATCH_CLAUDE_BIN || "claude";
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+export interface ClaudeCliArgs {
+  model: string;
+  systemPrompt: string;
+  userPrompt: string;
+}
+
+export interface ClaudeCliResult {
+  text: string | null;
+  tokens: number;
+}
+
+// Injectable spawn seam (mirrors stop-worker.mjs pattern): tests pass a fake.
+export function runClaudeCli(
+  args: ClaudeCliArgs,
+  { spawn = spawnSync, timeout = DEFAULT_TIMEOUT_MS }: {
+    spawn?: typeof spawnSync;
+    timeout?: number;
+  } = {},
+): ClaudeCliResult {
+  const input = args.systemPrompt
+    ? `${args.systemPrompt}\n\n${args.userPrompt}`
+    : args.userPrompt;
+  try {
+    const res = spawn(CLAUDE_BIN, ["-p", "--model", args.model], {
+      input,
+      encoding: "utf8",
+      timeout,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    if ((res?.status ?? 1) !== 0) return { text: null, tokens: 0 };
+    const text = typeof res.stdout === "string" ? res.stdout.trim() : "";
+    return { text: text.length > 0 ? text : null, tokens: 0 };
+  } catch {
+    return { text: null, tokens: 0 };
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-summary.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-summary.test.ts
@@ -250,7 +250,7 @@ describe("createInboxSummaryProvider", () => {
     expect(r!.generatedAt).toBeTruthy();
   });
 
-  describe("claude-cli spawn path", () => {
+  describe("claude-cli (--bg subscription) path", () => {
     const CLI_CONFIG: AiConfig = {
       enabled: true,
       provider: "claude-cli",
@@ -264,18 +264,12 @@ describe("createInboxSummaryProvider", () => {
       blocker: null,
     });
 
-    type FakeSpawnResult = { status: number; stdout: string; stderr: string };
-    function fakeSpawn(result: FakeSpawnResult) {
-      return (..._args: unknown[]) =>
-        result as unknown as ReturnType<typeof import("node:child_process").spawnSync>;
-    }
-
-    test("uses claude-cli spawn path (never fetches) when provider is claude-cli", async () => {
+    test("uses claude-cli path (never fetches) when provider is claude-cli", async () => {
       let fetched = false;
       const provider = createInboxSummaryProvider(CLI_CONFIG, {
         fetcher: () => { fetched = true; throw new Error("should not fetch"); },
         collectState: () => Promise.resolve(STATE_FIXTURE),
-        spawn: fakeSpawn({ status: 0, stdout: CLI_JSON_OUTPUT, stderr: "" }),
+        runClaudeCli: () => Promise.resolve({ text: CLI_JSON_OUTPUT, tokens: 0 }),
       });
       const res = await provider.generate("CTL-1");
       expect(fetched).toBe(false);
@@ -286,7 +280,7 @@ describe("createInboxSummaryProvider", () => {
     test("degrades to null when claude-cli produces no output", async () => {
       const provider = createInboxSummaryProvider(CLI_CONFIG, {
         collectState: () => Promise.resolve(STATE_FIXTURE),
-        spawn: fakeSpawn({ status: 1, stdout: "", stderr: "x" }),
+        runClaudeCli: () => Promise.resolve({ text: null, tokens: 0 }),
       });
       expect(await provider.generate("CTL-1")).toBeNull();
     });
@@ -295,10 +289,9 @@ describe("createInboxSummaryProvider", () => {
       let callCount = 0;
       const provider = createInboxSummaryProvider(CLI_CONFIG, {
         collectState: () => Promise.resolve(STATE_FIXTURE),
-        spawn: (..._args: unknown[]) => {
+        runClaudeCli: () => {
           callCount++;
-          return { status: 0, stdout: CLI_JSON_OUTPUT, stderr: "" } as unknown as
-            ReturnType<typeof import("node:child_process").spawnSync>;
+          return Promise.resolve({ text: CLI_JSON_OUTPUT, tokens: 0 });
         },
       });
       await provider.generate("CTL-1");

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-summary.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-summary.test.ts
@@ -250,6 +250,63 @@ describe("createInboxSummaryProvider", () => {
     expect(r!.generatedAt).toBeTruthy();
   });
 
+  describe("claude-cli spawn path", () => {
+    const CLI_CONFIG: AiConfig = {
+      enabled: true,
+      provider: "claude-cli",
+      model: "claude-haiku-4-5-20251001",
+    };
+
+    const CLI_JSON_OUTPUT = JSON.stringify({
+      summary: "S",
+      ask: "A",
+      options: null,
+      blocker: null,
+    });
+
+    type FakeSpawnResult = { status: number; stdout: string; stderr: string };
+    function fakeSpawn(result: FakeSpawnResult) {
+      return (..._args: unknown[]) =>
+        result as unknown as ReturnType<typeof import("node:child_process").spawnSync>;
+    }
+
+    test("uses claude-cli spawn path (never fetches) when provider is claude-cli", async () => {
+      let fetched = false;
+      const provider = createInboxSummaryProvider(CLI_CONFIG, {
+        fetcher: () => { fetched = true; throw new Error("should not fetch"); },
+        collectState: () => Promise.resolve(STATE_FIXTURE),
+        spawn: fakeSpawn({ status: 0, stdout: CLI_JSON_OUTPUT, stderr: "" }),
+      });
+      const res = await provider.generate("CTL-1");
+      expect(fetched).toBe(false);
+      expect(res?.summary).toBe("S");
+      expect(res?.ask).toBe("A");
+    });
+
+    test("degrades to null when claude-cli produces no output", async () => {
+      const provider = createInboxSummaryProvider(CLI_CONFIG, {
+        collectState: () => Promise.resolve(STATE_FIXTURE),
+        spawn: fakeSpawn({ status: 1, stdout: "", stderr: "x" }),
+      });
+      expect(await provider.generate("CTL-1")).toBeNull();
+    });
+
+    test("caches claude-cli result on second call", async () => {
+      let callCount = 0;
+      const provider = createInboxSummaryProvider(CLI_CONFIG, {
+        collectState: () => Promise.resolve(STATE_FIXTURE),
+        spawn: (..._args: unknown[]) => {
+          callCount++;
+          return { status: 0, stdout: CLI_JSON_OUTPUT, stderr: "" } as unknown as
+            ReturnType<typeof import("node:child_process").spawnSync>;
+        },
+      });
+      await provider.generate("CTL-1");
+      await provider.generate("CTL-1");
+      expect(callCount).toBe(1);
+    });
+  });
+
   test("phase parameter is forwarded to collectState", async () => {
     let capturedPhase: string | undefined;
     const provider = createInboxSummaryProvider(CONFIG, {

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-summary.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-summary.ts
@@ -3,9 +3,11 @@
 // buildInboxSummaryPrompt / parseInboxSummaryResponse, a provider closure with
 // a (ticket, phase, questionHash) cache. No network in tests.
 
+import type { spawnSync } from "node:child_process";
 import type { AiConfig } from "./ai-config";
 import type { InboxItemState } from "./inbox-state";
 import { computeQuestionHash } from "./inbox-state";
+import { runClaudeCli } from "./claude-cli";
 
 // ── public interfaces ─────────────────────────────────────────────────────────
 
@@ -125,29 +127,14 @@ export function buildInboxSummaryPrompt(state: InboxItemState): string {
   return parts.join("\n");
 }
 
-/** Parse the model's raw API response body into an InboxSummary.
- *  Handles Anthropic + OpenAI response shapes. If the model text is not valid
- *  JSON, degrades to summary-only (the raw prose becomes the summary). */
-export function parseInboxSummaryResponse(raw: string): InboxSummary | null {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw) as unknown;
-  } catch {
-    return null;
-  }
-
-  const text =
-    extractTextFromAnthropicResponse(parsed) ??
-    extractTextFromOpenAIResponse(parsed);
-  if (!text) return null;
-
+/** Parse raw model text (not an API envelope) into an InboxSummary.
+ *  Used by the claude-cli path where stdout IS the model text directly. */
+export function parseInboxSummaryText(text: string): InboxSummary | null {
   const generatedAt = new Date().toISOString();
-
   let data: unknown;
   try {
     data = JSON.parse(text) as unknown;
   } catch {
-    // Prose fallback — wrap the raw text as the summary.
     return { summary: text, ask: null, options: null, blocker: null, generatedAt };
   }
 
@@ -174,6 +161,25 @@ export function parseInboxSummaryResponse(raw: string): InboxSummary | null {
   return { summary, ask, options, blocker, generatedAt };
 }
 
+/** Parse the model's raw API response body into an InboxSummary.
+ *  Handles Anthropic + OpenAI response shapes. If the model text is not valid
+ *  JSON, degrades to summary-only (the raw prose becomes the summary). */
+export function parseInboxSummaryResponse(raw: string): InboxSummary | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+
+  const text =
+    extractTextFromAnthropicResponse(parsed) ??
+    extractTextFromOpenAIResponse(parsed);
+  if (!text) return null;
+
+  return parseInboxSummaryText(text);
+}
+
 // ── provider factory ──────────────────────────────────────────────────────────
 
 const DEFAULT_CACHE_TTL_MS = 5 * 60_000;
@@ -183,20 +189,24 @@ interface CacheEntry {
   fetchedAt: number;
 }
 
+const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
+
 /** Create an InboxSummaryProvider: generates summaries via the Cloudflare AI
- *  Gateway, caches per `${ticket}:${phase}:${questionHash}`, degrades to null
- *  on any error (Scenario 3). The AiFetcher and collectState are injectable. */
+ *  Gateway or local claude-cli, caches per `${ticket}:${phase}:${questionHash}`,
+ *  degrades to null on any error. The AiFetcher, collectState, and spawn are injectable. */
 export function createInboxSummaryProvider(
   config: AiConfig,
   opts: {
     fetcher?: AiFetcher;
     cacheTtlMs?: number;
+    spawn?: typeof spawnSync;
     collectState: (ticket: string, phase?: string) => Promise<InboxItemState | null>;
   },
 ): InboxSummaryProvider {
   const fetcher = opts.fetcher ?? defaultFetcher;
   const cacheTtlMs = opts.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
   const cache = new Map<string, CacheEntry>();
+  const isCli = config.provider === "claude-cli";
 
   return {
     async generate(ticket, phase) {
@@ -214,6 +224,18 @@ export function createInboxSummaryProvider(
       }
 
       const prompt = buildInboxSummaryPrompt(state);
+
+      if (isCli) {
+        const { text } = runClaudeCli(
+          { model: config.model ?? DEFAULT_MODEL, systemPrompt: "", userPrompt: prompt },
+          opts.spawn ? { spawn: opts.spawn } : {},
+        );
+        if (text === null) return null;
+        const result = parseInboxSummaryText(text);
+        if (result) cache.set(cacheKey, { result, fetchedAt: Date.now() });
+        return result;
+      }
+
       const url = buildGatewayUrl(config);
       const headers = buildHeaders(config);
       const body = buildRequestBody(config, prompt);

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-summary.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-summary.ts
@@ -3,11 +3,10 @@
 // buildInboxSummaryPrompt / parseInboxSummaryResponse, a provider closure with
 // a (ticket, phase, questionHash) cache. No network in tests.
 
-import type { spawnSync } from "node:child_process";
 import type { AiConfig } from "./ai-config";
 import type { InboxItemState } from "./inbox-state";
 import { computeQuestionHash } from "./inbox-state";
-import { runClaudeCli } from "./claude-cli";
+import { type RunClaudeCli, runClaudeCli } from "./claude-cli";
 
 // ── public interfaces ─────────────────────────────────────────────────────────
 
@@ -199,7 +198,7 @@ export function createInboxSummaryProvider(
   opts: {
     fetcher?: AiFetcher;
     cacheTtlMs?: number;
-    spawn?: typeof spawnSync;
+    runClaudeCli?: RunClaudeCli;
     collectState: (ticket: string, phase?: string) => Promise<InboxItemState | null>;
   },
 ): InboxSummaryProvider {
@@ -226,10 +225,12 @@ export function createInboxSummaryProvider(
       const prompt = buildInboxSummaryPrompt(state);
 
       if (isCli) {
-        const { text } = runClaudeCli(
-          { model: config.model ?? DEFAULT_MODEL, systemPrompt: "", userPrompt: prompt },
-          opts.spawn ? { spawn: opts.spawn } : {},
-        );
+        const run = opts.runClaudeCli ?? runClaudeCli;
+        const { text } = await run({
+          model: config.model ?? DEFAULT_MODEL,
+          systemPrompt: "",
+          userPrompt: prompt,
+        });
         if (text === null) return null;
         const result = parseInboxSummaryText(text);
         if (result) cache.set(cacheKey, { result, fetchedAt: Date.now() });

--- a/plugins/dev/scripts/orch-monitor/lib/summarize/config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/summarize/config.ts
@@ -1,11 +1,12 @@
 import { readFileSync } from "fs";
 
-export type ProviderName = "anthropic" | "openai" | "grok";
+export type ProviderName = "anthropic" | "openai" | "grok" | "claude-cli";
 
 export const KNOWN_PROVIDERS: readonly ProviderName[] = [
   "anthropic",
   "openai",
   "grok",
+  "claude-cli",
 ];
 
 export function isKnownProvider(x: unknown): x is ProviderName {
@@ -80,6 +81,10 @@ export function loadSummarizeConfig(
   const providers: Partial<Record<ProviderName, ProviderConfig>> = {};
   for (const [name, cfg] of Object.entries(providersRaw)) {
     if (!isKnownProvider(name)) continue;
+    if (name === "claude-cli") {
+      providers["claude-cli"] = { apiKeyEnv: "" };
+      continue;
+    }
     if (!isRecord(cfg)) continue;
     const apiKeyEnv = typeof cfg.apiKeyEnv === "string" ? cfg.apiKeyEnv : "";
     if (!apiKeyEnv) continue;
@@ -87,10 +92,10 @@ export function loadSummarizeConfig(
     providers[name] = { apiKeyEnv, apiKey: apiKey || undefined };
   }
 
-  const hasAnyKey = Object.values(providers).some(
-    (p) => p?.apiKey && p.apiKey.length > 0,
-  );
-  if (!hasAnyKey) return DISABLED;
+  const hasUsableProvider =
+    Boolean(providers["claude-cli"]) ||
+    Object.values(providers).some((p) => p?.apiKey && p.apiKey.length > 0);
+  if (!hasUsableProvider) return DISABLED;
 
   const defaultProvider = isKnownProvider(ai.defaultProvider)
     ? ai.defaultProvider

--- a/plugins/dev/scripts/orch-monitor/lib/summarize/index.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/summarize/index.ts
@@ -178,7 +178,10 @@ export function createSummarizeHandler(
           systemPrompt,
           userPrompt,
           model,
-          apiKey: providerCfg.apiKey,
+          // claude-cli runs on the subscription and ignores apiKey; coalesce so
+          // the gate's `needsKey === false` branch (apiKey may be undefined)
+          // still satisfies SummarizeArgs.apiKey: string (CTL-1109 remediate).
+          apiKey: providerCfg.apiKey ?? "",
           fetcher: deps.fetcher,
         });
         const generatedAt = new Date().toISOString();

--- a/plugins/dev/scripts/orch-monitor/lib/summarize/index.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/summarize/index.ts
@@ -133,7 +133,8 @@ export function createSummarizeHandler(
       const provider = parsed.provider ?? deps.config.defaultProvider;
       const model = parsed.model ?? deps.config.defaultModel;
       const providerCfg = deps.config.providers[provider];
-      if (!providerCfg?.apiKey) {
+      const needsKey = provider !== "claude-cli";
+      if (!providerCfg || (needsKey && !providerCfg.apiKey)) {
         return Response.json(
           { error: `provider ${provider} is not configured` },
           { status: 503 },

--- a/plugins/dev/scripts/orch-monitor/lib/summarize/providers/claude-cli.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/summarize/providers/claude-cli.ts
@@ -1,0 +1,19 @@
+import type { spawnSync } from "node:child_process";
+import type { SummarizeArgs, SummarizeProvider, SummarizeResult } from "./index";
+import { runClaudeCli } from "../../claude-cli";
+
+export const claudeCliProvider: SummarizeProvider = {
+  name: "claude-cli",
+  summarize(
+    args: SummarizeArgs & { spawn?: typeof spawnSync },
+  ): Promise<SummarizeResult> {
+    const { text, tokens } = runClaudeCli(
+      { model: args.model, systemPrompt: args.systemPrompt, userPrompt: args.userPrompt },
+      args.spawn ? { spawn: args.spawn } : {},
+    );
+    if (text === null) {
+      return Promise.reject(new Error("claude-cli provider produced no output"));
+    }
+    return Promise.resolve({ summary: text, cost: 0, tokens });
+  },
+};

--- a/plugins/dev/scripts/orch-monitor/lib/summarize/providers/claude-cli.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/summarize/providers/claude-cli.ts
@@ -1,19 +1,20 @@
-import type { spawnSync } from "node:child_process";
 import type { SummarizeArgs, SummarizeProvider, SummarizeResult } from "./index";
-import { runClaudeCli } from "../../claude-cli";
+import { type RunClaudeCli, runClaudeCli } from "../../claude-cli";
 
 export const claudeCliProvider: SummarizeProvider = {
   name: "claude-cli",
-  summarize(
-    args: SummarizeArgs & { spawn?: typeof spawnSync },
+  async summarize(
+    args: SummarizeArgs & { runClaudeCli?: RunClaudeCli },
   ): Promise<SummarizeResult> {
-    const { text, tokens } = runClaudeCli(
-      { model: args.model, systemPrompt: args.systemPrompt, userPrompt: args.userPrompt },
-      args.spawn ? { spawn: args.spawn } : {},
-    );
+    const run = args.runClaudeCli ?? runClaudeCli;
+    const { text, tokens } = await run({
+      model: args.model,
+      systemPrompt: args.systemPrompt,
+      userPrompt: args.userPrompt,
+    });
     if (text === null) {
-      return Promise.reject(new Error("claude-cli provider produced no output"));
+      throw new Error("claude-cli provider produced no output");
     }
-    return Promise.resolve({ summary: text, cost: 0, tokens });
+    return { summary: text, cost: 0, tokens };
   },
 };

--- a/plugins/dev/scripts/orch-monitor/lib/summarize/providers/index.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/summarize/providers/index.ts
@@ -3,6 +3,7 @@ import type { ProviderName } from "../config";
 import { anthropicProvider } from "./anthropic";
 import { openaiProvider } from "./openai";
 import { grokProvider } from "./grok";
+import { claudeCliProvider } from "./claude-cli";
 
 export type { AiFetcher } from "../../ai-briefing";
 
@@ -33,6 +34,8 @@ export function getProvider(name: ProviderName): SummarizeProvider {
       return openaiProvider;
     case "grok":
       return grokProvider;
+    case "claude-cli":
+      return claudeCliProvider;
   }
 }
 

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -4099,6 +4099,7 @@ if (import.meta.main) {
       anthropic: getProvider("anthropic"),
       openai: getProvider("openai"),
       grok: getProvider("grok"),
+      "claude-cli": getProvider("claude-cli"),
     };
     summarizeHandler = createSummarizeHandler({
       config: summarizeCfg,


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-13T22:50:00Z -->
<!-- Last updated: 2026-06-13T22:50:00Z -->
<!-- PR: #1954 -->
<!-- Previous commits: 9634afee,8bb77bb1,5ab4e696 -->

## Summary

Adds a `claude-cli` provider to the orch-monitor's summarize/briefing pipeline so low-volume AI text (escalation descriptions, daily briefings) can run on the host's Claude Max subscription quota — no Cloudflare AI Gateway, no `apiKey`, zero per-token cost. Previously `ai-config.ts` hard-required `gateway && apiKey` for any provider, making local-subscription AI impossible until the full gateway stack was wired up. This PR relaxes that gate specifically for `claude-cli` and adds the end-to-end seam.

## Changes Made

### `lib/claude-cli.ts` (new)

Core `runClaudeCli` seam. Spawns `claude --bg --model <m> --dangerously-skip-permissions "<prompt>"`, parses the `backgrounded · <jobid>` banner, polls `~/.claude/jobs/<jobid>/state.json` until a terminal state (stopped / completed / failed / firstTerminalAt), then reads the last assistant text block from the session transcript at `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`. All failure paths (non-zero exit, no job ID, timeout, empty transcript) degrade to `{ text: null, tokens: 0 }` with a single `[claude-cli]` warning — preserving the degrade-to-null contract callers depend on. `tokens` is always 0; the subscription is quota-metered, not per-token billed.

Key design: uses `claude --bg`, not `claude -p`. Verified live 2026-06-13: `-p` bills the metered API; only `--bg` runs against the subscription window.

### `lib/summarize/providers/claude-cli.ts` (new)

Implements `SummarizeProvider` over `runClaudeCli`. Thin wrapper: delegates to `runClaudeCli`, returns `{ summary: text, cost: 0, tokens }`, throws on null output (consistent with existing provider contract).

### `lib/summarize/providers/index.ts`

Registered `claude-cli` in `getProvider()` alongside `anthropic`, `openai`, `grok`. Added `"claude-cli"` to `ProviderName`.

### `lib/summarize/config.ts`

Added `"claude-cli"` to the known-provider allowlist. Relaxed the API key gate: `claude-cli` providers are valid with an empty/absent `apiKeyEnv`.

### `lib/ai-config.ts`

Relaxed the `if (!gateway || !apiKey) return DISABLED` guard with `if (provider !== "claude-cli" && (!gateway || !apiKey)) return DISABLED`. Remote providers (anthropic, openai, grok) still require both; `claude-cli` only requires `catalyst.ai.enabled = true` and `provider = "claude-cli"`.

### `lib/ai-briefing.ts` and `lib/inbox-summary.ts`

Wired the `runClaudeCli` injectable dep into `createBriefingProvider` and `createInboxSummaryProvider`. Both now accept a `{ runClaudeCli?: RunClaudeCli }` seam so tests can substitute a pure function without spawning real processes.

### Tests (5 files)

- `lib/claude-cli.test.ts`: full seam coverage — happy path, non-zero exit, missing banner, timeout, missing state, no transcript text, `encodeProjectDir`, `parseBackgroundJobId`
- `lib/inbox-summary.test.ts`: claude-cli path (no fetch), degrade-to-null
- `__tests__/ai-briefing.test.ts`: two new cases — claude-cli path never fetches, degrade-to-null
- `__tests__/ai-config.test.ts`: claude-cli enabled with no gateway/apiKey; non-claude-cli disabled without gateway
- `__tests__/summarize-config.test.ts`: claude-cli valid without `apiKeyEnv`; unknown provider still ignored
- `__tests__/summarize-endpoint.test.ts`: `claude-cli` stub provider registered in all handler setups; dedicated keyless-provider suite with its own server lifecycle

## How to Verify It

- [x] `bun test plugins/dev/scripts/orch-monitor/lib/claude-cli.test.ts` — all pass
- [x] `bun test plugins/dev/scripts/orch-monitor/lib/inbox-summary.test.ts` — all pass
- [x] `bun test plugins/dev/scripts/orch-monitor/__tests__/` — all new cases pass
- [x] Lint passes (0 errors)
- [ ] Configure `.config/catalyst/config.json → ai.provider = "claude-cli"` with no gateway/apiKey; start orch-monitor; confirm `/api/summarize` returns a response without error
- [ ] Confirm `claude --bg` output appears in `~/.claude/jobs/` on the host

## Pre-merge Verification (from verify phase)

- **Regression risk**: 2 / 10
- **typecheck**: fail — 6 tsc errors, all pre-existing baseline in `ui/src/lib/*` (UI node_modules not installed); 0 errors in CTL-1109 diff
- **tests**: fail — 4517 pass / 33 fail / 23 errors = origin/main baseline; 2 branch-introduced claudeCliProvider failures fixed in-phase (commit 5ab4e69)
- **lint**: pass — 0 errors, 53 pre-existing warnings; 1 branch-introduced require-await fixed in-phase

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1109
- Prerequisite for #1952 (AI-generated escalation descriptions)
