### PR TITLE
feat(dev): CTL-1110 — escalated ticket detail pane CTA-led explanation card

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/reading-pane-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/reading-pane-model.test.ts
@@ -25,6 +25,7 @@ import {
   blockerFor,
   accentFor,
   aboutBlockFor,
+  escalationExplanationFor,
 } from "../ui/src/board/reading-pane-model";
 import { deriveInbox, type InboxRow } from "../ui/src/board/home-inbox";
 import type { BoardPayload, BoardTicket, BoardWorker, DecisionOption } from "../ui/src/board/types";
@@ -291,5 +292,63 @@ describe("honesty contract — omitted read-model fields render absent (CTL-902)
   it("an empty-string ask/blocker is treated as absent (null)", () => {
     expect(askFor(rowFor(mkTicket("CTL-642", { held: "waiting", ask: "" })))).toBeNull();
     expect(blockerFor(rowFor(mkTicket("CTL-867", { held: "blocked", blocker: "" })))).toBeNull();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// CTL-1110: escalationExplanationFor — CTA-led card view-model
+// ════════════════════════════════════════════════════════════════════════════
+const FULL_EXPL = {
+  call_to_action: "Decide: finish the fix on this branch, or descope it.",
+  outcome: "Operators see real-time cluster capacity.",
+  problem: "capacityReader is not passed to assembleClusterView().",
+  why_you: "The fixes need human judgment after automation gave up.",
+  why_not_auto: "3 fix attempts failed; tests lock in the broken behavior.",
+  what_to_do: "Review why the 2 wiring fixes failed; resolve or shrink scope.",
+};
+
+describe("CTL-1110: escalationExplanationFor", () => {
+  it("returns the camelCase view for a needs-human row with a full explanation", () => {
+    const row = rowFor(mkTicket("CTL-1092", { attention: "needs-human", explanation: FULL_EXPL }));
+    expect(escalationExplanationFor(row)).toEqual({
+      callToAction: FULL_EXPL.call_to_action,
+      outcome: FULL_EXPL.outcome,
+      problem: FULL_EXPL.problem,
+      whyYou: FULL_EXPL.why_you,
+      whyNotAuto: FULL_EXPL.why_not_auto,
+      whatToDo: FULL_EXPL.what_to_do,
+    });
+  });
+
+  it("projects absent sub-fields to null (graceful partial)", () => {
+    const row = rowFor(mkTicket("CTL-1", {
+      attention: "needs-human",
+      explanation: { call_to_action: "Decide.", outcome: null, problem: "X.",
+                     why_you: null, why_not_auto: null, what_to_do: null },
+    }));
+    const v = escalationExplanationFor(row)!;
+    expect(v.callToAction).toBe("Decide.");
+    expect(v.problem).toBe("X.");
+    expect(v.outcome).toBeNull();
+    expect(v.whatToDo).toBeNull();
+  });
+
+  it("returns null for a needs-human row with no explanation (graceful absent → bare hero)", () => {
+    const row = rowFor(mkTicket("CTL-2", { attention: "needs-human" }));
+    expect(escalationExplanationFor(row)).toBeNull();
+  });
+
+  it("returns null when every explanation field is null/empty", () => {
+    const row = rowFor(mkTicket("CTL-3", {
+      attention: "needs-human",
+      explanation: { call_to_action: "", outcome: null, problem: null,
+                     why_you: null, why_not_auto: null, what_to_do: null },
+    }));
+    expect(escalationExplanationFor(row)).toBeNull();
+  });
+
+  it("returns null for a waiting-on-you (non-escalated) row even if explanation is present", () => {
+    const row = rowFor(mkTicket("CTL-4", { attention: "waiting-on-you", explanation: FULL_EXPL }));
+    expect(escalationExplanationFor(row)).toBeNull();
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/board-data-explanation.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data-explanation.test.mjs
@@ -1,0 +1,65 @@
+// board-data-explanation.test.mjs — units for deriveExplanation (CTL-1110).
+// Covers the detail-pane CTA-led card data source: scans phase signals
+// newest-first and surfaces the six extended explanation fields as a nested
+// object, null when none carry extended fields.
+//
+//   cd plugins/dev/scripts/orch-monitor && bun test lib/board-data-explanation.test.mjs
+
+import { describe, it, expect } from "bun:test";
+import { deriveExplanation } from "./board-data.mjs";
+
+describe("CTL-1110: deriveExplanation", () => {
+  it("returns the six extended fields from a signal carrying them", () => {
+    const sigs = [
+      { status: "running" },
+      { explanation: {
+          human_question: "decide?", call_to_action: "Decide: fix or descope.",
+          outcome: "Operators see capacity.", problem: "capacityReader not passed.",
+          why_you: "Fixes need judgment.", why_not_auto: "3 attempts failed.",
+          what_to_do: "Review why fixes failed.",
+        } },
+    ];
+    expect(deriveExplanation(sigs)).toEqual({
+      call_to_action: "Decide: fix or descope.",
+      outcome: "Operators see capacity.",
+      problem: "capacityReader not passed.",
+      why_you: "Fixes need judgment.",
+      why_not_auto: "3 attempts failed.",
+      what_to_do: "Review why fixes failed.",
+    });
+  });
+
+  it("scans newest-first — the highest-index extended explanation wins", () => {
+    const sigs = [
+      { explanation: { call_to_action: "OLD" } },
+      { explanation: { call_to_action: "NEW" } },
+    ];
+    expect(deriveExplanation(sigs)?.call_to_action).toBe("NEW");
+  });
+
+  it("projects absent sub-fields to null (graceful partial)", () => {
+    const sigs = [{ explanation: { call_to_action: "Decide.", what_to_do: "Pick an option." } }];
+    expect(deriveExplanation(sigs)).toEqual({
+      call_to_action: "Decide.", outcome: null, problem: null,
+      why_you: null, why_not_auto: null, what_to_do: "Pick an option.",
+    });
+  });
+
+  it("returns null when the only explanation carries just the canonical five fields", () => {
+    const sigs = [{ explanation: { human_question: "q?", what_failed: "x", why_gave_up: "y" } }];
+    expect(deriveExplanation(sigs)).toBeNull();
+  });
+
+  it("returns null when no signal carries an explanation, and for an empty array", () => {
+    expect(deriveExplanation([{ status: "running" }])).toBeNull();
+    expect(deriveExplanation([])).toBeNull();
+  });
+
+  it("ignores non-object / null entries and non-string sub-fields without throwing", () => {
+    const sigs = [null, "bogus", 42, { explanation: { call_to_action: 123, outcome: "ok" } }];
+    expect(deriveExplanation(sigs)).toEqual({
+      call_to_action: null, outcome: "ok", problem: null,
+      why_you: null, why_not_auto: null, what_to_do: null,
+    });
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -157,6 +157,22 @@ export interface BoardTicket {
   /** CTL-1066: reason a stalled/failed phase gave up, from the surfaced phase
    *  signal's stalledReason/failureReason. null unless status is stalled/failed. */
   failureReason?: string | null;
+  /** CTL-1110: extended escalation explanation for the needs-human detail-pane
+   *  card. null/absent unless attention is needs-human and a signal carried the
+   *  extended fields. */
+  explanation?: BoardEscalationExplanation | null;
+}
+
+/** CTL-1110: the six extended escalation-explanation fields, surfaced as a nested
+ *  object for the detail pane's CTA-led card. Each field is null when the signal
+ *  omitted it (rendered absent, never fabricated). */
+export interface BoardEscalationExplanation {
+  call_to_action: string | null;
+  outcome: string | null;
+  problem: string | null;
+  why_you: string | null;
+  why_not_auto: string | null;
+  what_to_do: string | null;
 }
 
 export interface BoardQueueItem {

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -724,6 +724,36 @@ export function deriveHumanQuestion(phaseSigs) {
   return null;
 }
 
+/** CTL-1110: the six extended escalation-explanation fields, surfaced as a
+ *  cohesive nested object so the detail pane can render a CTA-led card. Distinct
+ *  from deriveHumanQuestion (the canonical human_question sub-label). */
+const EXPLANATION_RENDER_FIELDS = [
+  "call_to_action", "outcome", "problem", "why_you", "why_not_auto", "what_to_do",
+];
+
+/** CTL-1110: extract the six extended explanation fields from the most-recent
+ *  phase signal whose explanation carries at least one of them (scanned
+ *  newest-first, same as deriveHumanQuestion). Absent sub-fields are projected to
+ *  null (the pane renders them absent, never fabricated). Returns null when no
+ *  signal carries any extended field. */
+export function deriveExplanation(phaseSigs) {
+  for (let i = phaseSigs.length - 1; i >= 0; i--) {
+    const sig = phaseSigs[i];
+    if (!sig || typeof sig !== "object") continue;
+    const expl = sig.explanation;
+    if (!expl || typeof expl !== "object") continue;
+    const out = {};
+    let any = false;
+    for (const k of EXPLANATION_RENDER_FIELDS) {
+      const v = expl[k];
+      if (typeof v === "string" && v !== "") { out[k] = v; any = true; }
+      else { out[k] = null; }
+    }
+    if (any) return out;
+  }
+  return null;
+}
+
 // CTL-1041: the TITLE is the outcome line and must lead on every surface (slot
 // cards, inbox detail, holding rows). The triage `summary` is the DESCRIPTION
 // (e.g. "Live probe confirmed the unified event log…") and must NEVER stand in
@@ -1253,6 +1283,9 @@ export async function assembleBoard() {
       // CTL-1065: human_question from the most-recent phase signal's explanation,
       // surfaced as the inbox sub-label for needs-human rows.
       humanQuestion: deriveHumanQuestion(phaseSigs),
+      // CTL-1110: the six extended explanation fields surfaced for the detail
+      // pane's CTA-led card (distinct from humanQuestion, the list-row sub-label).
+      explanation: deriveExplanation(phaseSigs),
       // CTL-729: the single needs-attention bucket — 'waiting-on-you' (live
       // blocked bg job) | 'needs-human' (escalation label/marker) | null, with an
       // ISO attentionSince anchor (or null, never fabricated). Drives the ONE

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/reading-pane-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/reading-pane-model.ts
@@ -17,7 +17,7 @@
 // yield an empty list, and a missing session id HIDES View-in-Claude rather than
 // emitting a dead link.
 
-import type { BoardWorker } from "./types";
+import type { BoardEscalationExplanation, BoardWorker } from "./types";
 import { isNeedsYouSection, type InboxRow } from "./home-inbox";
 
 /** The kind of hero "What's needed now" block a needs-you item shows:
@@ -134,6 +134,43 @@ export function accentFor(row: InboxRow): PaneAccent {
   if (kind === "blocked") return "red";
   if (kind === "decision") return "amber";
   return "none";
+}
+
+/** CTL-1110: the needs-human escalation card view-model — a highlighted CTA plus
+ *  the labelled explanation sections, top to bottom. Each field is null when the
+ *  payload omitted it (rendered absent, never fabricated). */
+export interface EscalationExplanationView {
+  callToAction: string | null;
+  outcome: string | null;
+  problem: string | null;
+  whyYou: string | null;
+  whyNotAuto: string | null;
+  whatToDo: string | null;
+}
+
+const nz = (s: string | null | undefined): string | null =>
+  s != null && s !== "" ? s : null;
+
+/**
+ * The needs-human escalation explanation for the hero card, or null when the row
+ * is not escalated, carries no explanation, or every field is empty (the pane
+ * then falls back to the bare hero). Keyed on `attention === "needs-human"` so
+ * waiting-on-you decision rows are untouched.
+ */
+export function escalationExplanationFor(row: InboxRow): EscalationExplanationView | null {
+  if (row.ticket.attention !== "needs-human") return null;
+  const e = row.ticket.explanation as BoardEscalationExplanation | null | undefined;
+  if (e == null) return null;
+  const view: EscalationExplanationView = {
+    callToAction: nz(e.call_to_action),
+    outcome: nz(e.outcome),
+    problem: nz(e.problem),
+    whyYou: nz(e.why_you),
+    whyNotAuto: nz(e.why_not_auto),
+    whatToDo: nz(e.what_to_do),
+  };
+  if (Object.values(view).every((v) => v == null)) return null;
+  return view;
 }
 
 /**

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
@@ -158,6 +158,10 @@ export interface BoardTicket {
   /** CTL-1066: reason a stalled/failed phase gave up; drives the "Stalled — gave
    *  up" holding bucket copy. null/absent unless status is stalled/failed. */
   failureReason?: string | null;
+  /** CTL-1110: extended escalation explanation for the needs-human detail-pane
+   *  card. null/absent unless attention is needs-human and a signal carried the
+   *  extended fields. */
+  explanation?: BoardEscalationExplanation | null;
   // ── CTL-902 (HOME4): the reading-pane CONTENT fields ─────────────────────
   // The "What's needed now" hero + the About block read these. They are NOT in
   // the board payload today — they derive from the ticket's AI summary + the
@@ -187,6 +191,19 @@ export interface DecisionOption {
   label: string;
   /** The one-line trade-off for choosing this option. */
   detail: string;
+}
+
+/** CTL-1110: the six extended escalation-explanation fields, surfaced as a nested
+ *  object for the detail pane's CTA-led card. Each field is null when the payload
+ *  omitted it (rendered absent, never fabricated). Field names stay snake_case to
+ *  match the wire payload exactly (no transform). */
+export interface BoardEscalationExplanation {
+  call_to_action: string | null;
+  outcome: string | null;
+  problem: string | null;
+  why_you: string | null;
+  why_not_auto: string | null;
+  what_to_do: string | null;
 }
 
 export interface WorkflowSubStep {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/inbox-summary-data.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/inbox-summary-data.test.ts
@@ -147,4 +147,13 @@ describe("mergeSummaryIntoTicket", () => {
     expect(merged).not.toBe(BASE_TICKET);
     expect(BASE_TICKET.ask).toBeUndefined();
   });
+
+  test("CTL-1110: preserves the explanation field across the summary merge", () => {
+    const expl = { call_to_action: "Decide.", outcome: null, problem: "X.",
+                   why_you: null, why_not_auto: null, what_to_do: null };
+    const ticket = makeTicket({ attention: "needs-human" as const, explanation: expl });
+    const merged = mergeSummaryIntoTicket(ticket, { enabled: true, ask: "new ask", summary: null });
+    expect(merged.explanation).toEqual(expl);
+    expect(merged.ask).toBe("new ask");
+  });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
@@ -54,6 +54,7 @@ import {
   accentFor,
   askFor,
   blockerFor,
+  escalationExplanationFor,
   heroKindFor,
   optionsFor,
   viewInClaudeFor,
@@ -229,6 +230,57 @@ function WhatsNeededNow({
   if (kind == null) return null; // neutral (running/done) sets carry no hero.
 
   const accent = accentFor(row);
+  const escalation = escalationExplanationFor(row);
+
+  // CTL-1110: needs-human rows with a structured explanation use the CTA-led card.
+  if (escalation != null) {
+    return (
+      <section
+        data-pane-hero="escalation"
+        data-pane-accent="amber"
+        data-pane-escalation
+        className={cn("mt-4 rounded-sm py-3 pr-4 pl-4", accentClasses("amber"))}
+      >
+        <p className="text-[11px] font-medium uppercase tracking-wide text-muted">
+          What's needed now
+        </p>
+
+        {/* CTA row: imperative call-to-action + the Respond control. */}
+        <div className="mt-1.5 flex flex-wrap items-start gap-3">
+          {escalation.callToAction != null && (
+            <p
+              data-escalation-cta
+              className="flex-1 text-[14px] font-medium leading-snug text-fg"
+            >
+              {escalation.callToAction}
+            </p>
+          )}
+          <PaneVerb row={row} onAct={onAct} respondStatus={respondStatus} />
+        </div>
+
+        {/* Labelled explanation sections — each rendered only when non-null. */}
+        {(
+          [
+            ["What this delivers", escalation.outcome, "outcome"],
+            ["The problem", escalation.problem, "problem"],
+            ["Why this needs you", escalation.whyYou, "why_you"],
+            ["Why it couldn't self-heal", escalation.whyNotAuto, "why_not_auto"],
+            ["What to do", escalation.whatToDo, "what_to_do"],
+          ] as const
+        )
+          .filter(([, value]) => value != null)
+          .map(([label, value, field]) => (
+            <div key={field} className="mt-3" data-escalation-field={field}>
+              <p className="text-[11px] font-medium uppercase tracking-wide text-muted">
+                {label}
+              </p>
+              <p className="mt-0.5 text-[13px] leading-relaxed text-fg/90">{value}</p>
+            </div>
+          ))}
+      </section>
+    );
+  }
+
   const ask = askFor(row);
   const options = optionsFor(row);
   const blocker = blockerFor(row);


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-13T23:00:00Z -->
<!-- Last updated: 2026-06-13T23:00:00Z -->
<!-- PR: #1957 -->
<!-- Previous commits: 09ae54ef74e43b451547c06612d7bba4ccf17583 -->

## Summary

Surfaces the six extended escalation-explanation fields from phase signal files
into the orch-monitor board payload and renders them as a CTA-led card in the
needs-human ticket detail pane.

- Adds `deriveExplanation()` to `board-data.mjs` — scans phase signals
  newest-first for `call_to_action`, `outcome`, `problem`, `why_you`,
  `why_not_auto`, `what_to_do`; returns a cohesive object or `null` when none
  are present.
- Extends `BoardTicket` with an optional `explanation: BoardEscalationExplanation`
  field (type declared in `board-data.d.mts`).
- Adds `escalationExplanationFor()` to `reading-pane-model.ts` — pure, testable
  getter that camelCases the six fields for the view layer; returns `null` for
  any ticket that is not `attention === "needs-human"` or has no explanation data.
- Updates `WhatsNeededNow` in `reading-pane.tsx` to render the CTA-led card when
  explanation data is present: highlighted call-to-action at top, inline Respond
  control, then four labelled sections (problem / why you / why not auto / what to
  do); gracefully degrades to the existing bare hero when explanation is absent.
- All new behaviour is gated on `attention === "needs-human"` — `waiting-on-you`
  and `blocked` rows are untouched.
- No AI-provider dependency; reads pre-existing explanation data written by prior
  tickets.

## Changes Made

### Backend / Board Data

- **`lib/board-data.mjs`** — `deriveExplanation(phaseSigs)` exported function;
  scans newest-first, projects absent sub-fields to `null`, returns `null` when no
  signal carries any extended field.
- **`lib/board-data.d.mts`** — `BoardEscalationExplanation` interface + optional
  `explanation` field on `BoardTicket`.
- **`lib/board-data-explanation.test.mjs`** (new) — 6 unit tests covering: full
  extraction, newest-first scan order, graceful partial, canonical-only signals,
  empty arrays, and non-object entries.

### Frontend / Reading Pane

- **`ui/src/board/types.ts`** — `EscalationExplanation` view-model type (camelCase).
- **`ui/src/board/reading-pane-model.ts`** — `escalationExplanationFor()` getter;
  maps snake_case signal fields to camelCase view-model; null when not applicable.
- **`ui/src/board/reading-pane.tsx`** — `WhatsNeededNow` renders
  `EscalationExplanationCard` (highlighted CTA + labelled sections) when
  `escalationExplanationFor(row)` is non-null.
- **`ui/src/components/home/inbox-summary-data.test.ts`** — merge-preservation
  regression guard (1 new test).
- **`__tests__/reading-pane-model.test.ts`** — 5 new tests for
  `escalationExplanationFor`: full view-model, graceful partial, absent explanation,
  all-null explanation, non-escalated row.

## How to Verify It

- [x] `bun test lib/board-data-explanation.test.mjs` — 6 pass ✅
- [x] `bun test __tests__/reading-pane-model.test.ts` — 30 pass ✅
- [x] `bun test ui/src/components/home/inbox-summary-data.test.ts` — 17 pass ✅
- [x] `tsc --noEmit` — no new errors in changed files ✅
- [x] CI quality gate — pass ✅
- [x] CI audit-references — pass ✅
- [x] CI validate — pass ✅
- [ ] Manual: open a needs-human ticket (e.g. CTL-1092) in orch-monitor; verify
  the detail pane shows the CTA-led card with all four labelled sections and the
  Respond control at top.
- [ ] Manual: open a needs-human ticket with no explanation data; verify the bare
  hero (Respond button only) still renders without errors.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1110

## Changelog Entry

```
feat(dev): CTL-1110 — escalated ticket detail pane CTA-led explanation card
```

Surfaces phase-signal explanation fields to the orch-monitor board and renders
them as a CTA-led card for needs-human tickets: highlighted call-to-action at top
with Respond control, followed by labelled problem / why-you / why-not-auto /
what-to-do sections. Degrades gracefully when explanation is absent.

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1092
