### PR TITLE
CTL-1104: Operators should see which governance modes each host is running right on FleetOps

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-governance.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-governance.test.ts
@@ -5,7 +5,7 @@
 // host liveness.
 
 import { describe, it, expect, afterAll } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {

--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-governance.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-governance.test.ts
@@ -1,0 +1,214 @@
+// CTL-1104: cluster-governance.mjs — per-host governance snapshot reader.
+// Uses fixture JSONL written to a tmp file; all thresholds are injected.
+// The drift-guard test imports classifyHostLiveness and asserts the reader
+// classifies identically so governance freshness can never diverge from
+// host liveness.
+
+import { describe, it, expect, afterAll } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  classifyHostLiveness,
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  DEFAULT_LIVENESS_GRACE_MS,
+} from "../lib/node-liveness.mjs";
+
+const clusterGov = await import("../lib/cluster-governance.mjs");
+const { readClusterGovernance } = clusterGov as {
+  readClusterGovernance: (opts?: {
+    logPath?: string;
+    roster?: string[];
+    now?: number;
+    intervalMs?: number;
+    graceMs?: number;
+  }) => {
+    singleHost: boolean;
+    generatedAt: string;
+    nodes: Array<{
+      host: string;
+      governance: Record<string, unknown> | null;
+      reportedAt: string | null;
+      ageMs: number | null;
+      status: "live" | "degraded" | "offline";
+    }>;
+  };
+};
+
+const INTERVAL = DEFAULT_HEARTBEAT_INTERVAL_MS;
+const GRACE = DEFAULT_LIVENESS_GRACE_MS;
+
+const SAMPLE_GOV = {
+  beliefsShadow: true,
+  diagnostician: false,
+  intentsEnforce: false,
+  advanceShadowSummary: false,
+  stallJanitor: { mode: "enforce" },
+  watchdog: { mode: "shadow" },
+  unstuckSweep: { mode: "off" },
+};
+
+function makeHeartbeatLine(host: string, ts: string, gov: Record<string, unknown> | null = SAMPLE_GOV) {
+  return JSON.stringify({
+    ts,
+    id: "aabbccdd",
+    attributes: { "event.name": "node.heartbeat" },
+    resource: { "host.name": host },
+    body: {
+      payload: {
+        "host.name": host,
+        ...(gov ? { governance: gov } : {}),
+        epoch: Date.parse(ts),
+      },
+    },
+  });
+}
+
+let tmpDir: string;
+let logPath: string;
+
+// Create a fresh temp dir + logPath for each describe block sharing setup.
+function setup(lines: string[]): string {
+  tmpDir = mkdtempSync(join(tmpdir(), "ctl1104-"));
+  const p = join(tmpDir, "events.jsonl");
+  writeFileSync(p, lines.join("\n") + "\n");
+  return p;
+}
+
+afterAll(() => {
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const NOW = Date.parse("2026-06-13T12:00:00.000Z");
+const at = (msAgo: number) => new Date(NOW - msAgo).toISOString();
+
+describe("readClusterGovernance — basic roster extraction", () => {
+  it("returns one node per roster host, newest heartbeat wins", () => {
+    const lp = setup([
+      makeHeartbeatLine("host-A", at(5_000)),
+      makeHeartbeatLine("host-A", at(60_000)),  // older — should NOT win
+      makeHeartbeatLine("host-B", at(10_000)),
+    ]);
+    const result = readClusterGovernance({ logPath: lp, roster: ["host-A", "host-B"], now: NOW, intervalMs: INTERVAL, graceMs: GRACE });
+    expect(result.nodes).toHaveLength(2);
+    const a = result.nodes.find((n) => n.host === "host-A")!;
+    expect(a.reportedAt).toBe(at(5_000));
+    expect(a.governance).toEqual(SAMPLE_GOV);
+  });
+
+  it("extracts body.payload.governance verbatim", () => {
+    const lp = setup([makeHeartbeatLine("host-A", at(5_000), { beliefsShadow: false, intentsEnforce: true })]);
+    const result = readClusterGovernance({ logPath: lp, roster: ["host-A"], now: NOW });
+    expect(result.nodes[0].governance).toEqual({ beliefsShadow: false, intentsEnforce: true });
+  });
+
+  it("sets reportedAt from ts and ageMs = now − Date.parse(ts)", () => {
+    const ts = at(15_000);
+    const lp = setup([makeHeartbeatLine("host-A", ts)]);
+    const result = readClusterGovernance({ logPath: lp, roster: ["host-A"], now: NOW });
+    expect(result.nodes[0].reportedAt).toBe(ts);
+    expect(result.nodes[0].ageMs).toBe(15_000);
+  });
+});
+
+describe("readClusterGovernance — staleness via classifyHostLiveness drift guard", () => {
+  const CASES: Array<{ msAgo: number; expected: "live" | "degraded" | "offline" }> = [
+    { msAgo: INTERVAL - 1, expected: "live" },
+    { msAgo: INTERVAL,     expected: "live" },          // boundary inclusive
+    { msAgo: INTERVAL + 1, expected: "degraded" },
+    { msAgo: GRACE,        expected: "degraded" },      // grace boundary inclusive
+    { msAgo: GRACE + 1,    expected: "offline" },
+    { msAgo: 30 * 60_000,  expected: "offline" },
+  ];
+
+  for (const { msAgo, expected } of CASES) {
+    it(`ageMs ${msAgo}ms → status "${expected}" (matches classifyHostLiveness)`, () => {
+      const ts = at(msAgo);
+      const lp = setup([makeHeartbeatLine("host-A", ts)]);
+      const result = readClusterGovernance({ logPath: lp, roster: ["host-A"], now: NOW, intervalMs: INTERVAL, graceMs: GRACE });
+      const node = result.nodes[0];
+      expect(node.status).toBe(expected);
+      // Drift guard: must match classifyHostLiveness identically
+      expect(node.status).toBe(classifyHostLiveness(ts, NOW, { intervalMs: INTERVAL, graceMs: GRACE }));
+    });
+  }
+});
+
+describe("readClusterGovernance — missing / never-heard host", () => {
+  it("a roster host with no heartbeat → governance null, reportedAt null, ageMs null, status offline", () => {
+    const lp = setup([makeHeartbeatLine("other-host", at(5_000))]);
+    const result = readClusterGovernance({ logPath: lp, roster: ["host-A"], now: NOW });
+    const node = result.nodes[0];
+    expect(node.governance).toBeNull();
+    expect(node.reportedAt).toBeNull();
+    expect(node.ageMs).toBeNull();
+    expect(node.status).toBe("offline");
+  });
+});
+
+describe("readClusterGovernance — robustness", () => {
+  it("missing log file → all-offline signal, never throws", () => {
+    expect(() => {
+      const result = readClusterGovernance({
+        logPath: "/tmp/does-not-exist-ctl1104.jsonl",
+        roster: ["host-A", "host-B"],
+        now: NOW,
+      });
+      expect(result.nodes.every((n) => n.status === "offline")).toBe(true);
+    }).not.toThrow();
+  });
+
+  it("garbage / partial JSON line is skipped", () => {
+    const lp = setup([
+      "{invalid-json",
+      makeHeartbeatLine("host-A", at(5_000)),
+    ]);
+    const result = readClusterGovernance({ logPath: lp, roster: ["host-A"], now: NOW });
+    expect(result.nodes[0].reportedAt).toBe(at(5_000));
+  });
+
+  it("non-node.heartbeat line is ignored", () => {
+    const lp = setup([
+      JSON.stringify({ ts: at(5_000), attributes: { "event.name": "phase.start" }, body: { payload: { "host.name": "host-A", governance: SAMPLE_GOV } } }),
+      makeHeartbeatLine("host-A", at(10_000)),
+    ]);
+    const result = readClusterGovernance({ logPath: lp, roster: ["host-A"], now: NOW });
+    // Only the heartbeat line should be picked up
+    expect(result.nodes[0].reportedAt).toBe(at(10_000));
+  });
+
+  it("heartbeat with no governance field → host classifies on ts but governance is null", () => {
+    const lp = setup([makeHeartbeatLine("host-A", at(5_000), null)]);
+    const result = readClusterGovernance({ logPath: lp, roster: ["host-A"], now: NOW });
+    const node = result.nodes[0];
+    expect(node.governance).toBeNull();
+    expect(node.status).toBe("live");
+  });
+
+  it("future-dated ts (clock skew) → ageMs 0, status live", () => {
+    const futurTs = new Date(NOW + 5_000).toISOString();
+    const lp = setup([makeHeartbeatLine("host-A", futurTs)]);
+    const result = readClusterGovernance({ logPath: lp, roster: ["host-A"], now: NOW, intervalMs: INTERVAL, graceMs: GRACE });
+    expect(result.nodes[0].ageMs).toBe(0);
+    expect(result.nodes[0].status).toBe("live");
+  });
+});
+
+describe("readClusterGovernance — singleHost + generatedAt", () => {
+  it("singleHost true when roster.length <= 1", () => {
+    const lp = setup([makeHeartbeatLine("host-A", at(5_000))]);
+    expect(readClusterGovernance({ logPath: lp, roster: [], now: NOW }).singleHost).toBe(true);
+    expect(readClusterGovernance({ logPath: lp, roster: ["host-A"], now: NOW }).singleHost).toBe(true);
+  });
+
+  it("singleHost false when roster.length > 1", () => {
+    const lp = setup([makeHeartbeatLine("host-A", at(5_000))]);
+    expect(readClusterGovernance({ logPath: lp, roster: ["host-A", "host-B"], now: NOW }).singleHost).toBe(false);
+  });
+
+  it("generatedAt is the injected now as ISO", () => {
+    const lp = setup([]);
+    const result = readClusterGovernance({ logPath: lp, roster: [], now: NOW });
+    expect(result.generatedAt).toBe(new Date(NOW).toISOString());
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-governance.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-governance.d.mts
@@ -1,0 +1,35 @@
+// cluster-governance.d.mts — CTL-1104 type declarations for cluster-governance.mjs.
+// Mirrors governance-reader.d.mts and cluster-view.d.mts conventions.
+
+/** One host's latest governance snapshot from the heartbeat event log. */
+export interface ClusterGovernanceNode {
+  host: string;
+  /** The raw governance modes from body.payload.governance, or null if never heard. */
+  governance: Record<string, unknown> | null;
+  /** The ISO timestamp from the latest heartbeat ts field, or null if never heard. */
+  reportedAt: string | null;
+  /** Milliseconds since the heartbeat (clamped to 0 for clock skew), or null if never heard. */
+  ageMs: number | null;
+  /** Liveness classification matching classifyHostLiveness. */
+  status: "live" | "degraded" | "offline";
+}
+
+/** The full cluster governance wire shape returned by /api/cluster/governance. */
+export interface ClusterGovernanceSignal {
+  /** True when roster.length <= 1 (single-host identity no-op). */
+  singleHost: boolean;
+  /** ISO timestamp of when this signal was generated (injected `now`). */
+  generatedAt: string;
+  /** One entry per roster host, in roster order. */
+  nodes: ClusterGovernanceNode[];
+}
+
+export interface ReadClusterGovernanceOpts {
+  logPath?: string;
+  roster?: string[];
+  now?: number;
+  intervalMs?: number;
+  graceMs?: number;
+}
+
+export function readClusterGovernance(opts?: ReadClusterGovernanceOpts): ClusterGovernanceSignal;

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-governance.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-governance.mjs
@@ -1,0 +1,103 @@
+// cluster-governance.mjs — CTL-1104. Per-host governance snapshot reader.
+// Generalizes execution-core/cli/governance.mjs::readLatestGovernance (single-
+// host, CLI-only) to the full cluster roster. Pure + injectable; no bun:sqlite.
+//
+// SINGLE-HOST IDENTITY NO-OP: roster length <= 1 sets singleHost:true.
+// Mirrors the classifyHostLiveness drift-guard pattern from node-liveness.mjs —
+// tests import both and assert identical classification so governance freshness
+// can never diverge from host liveness.
+//
+// Cross-reference: execution-core/cli/governance.mjs does the same per-host
+// parse loop for a single host; both are intentionally kept separate to avoid
+// dragging the CLI module into the monitor's import graph.
+
+import { readFileSync } from "node:fs";
+import {
+  classifyHostLiveness,
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  DEFAULT_LIVENESS_GRACE_MS,
+} from "./node-liveness.mjs";
+
+// Lazy-load the execution-core config (VITE-GRAPH GUARD, CTL-883): the config
+// module pulls pino + Node deps that break esbuild/vite browser bundling if they
+// appear in any static import chain. We compute the specifier at module-eval so
+// vite's static analysis never sees it as a resolvable import. Best-effort: if
+// the module is absent (e.g. running in a stripped test environment without
+// execution-core), we degrade to empty defaults.
+const CONFIG_SPECIFIER = ["../execution-core/config.mjs"].join("");
+let _config = null;
+try {
+  _config = await import(CONFIG_SPECIFIER);
+} catch {
+  // config unavailable — callers that pass logPath + roster explicitly are unaffected
+}
+
+const HEARTBEAT_EVENT = "node.heartbeat";
+
+/**
+ * readClusterGovernance — scan the event log for the latest node.heartbeat per
+ * roster host and return each host's governance snapshot + staleness metadata.
+ *
+ * @param {object} [opts]
+ * @param {string}   [opts.logPath]    path to the unified event log (default: config)
+ * @param {string[]} [opts.roster]     cluster host list (default: config)
+ * @param {number}   [opts.now]        epoch ms, injectable for tests (default: Date.now())
+ * @param {number}   [opts.intervalMs] heartbeat cadence threshold
+ * @param {number}   [opts.graceMs]    liveness grace window
+ * @returns {{ singleHost: boolean, generatedAt: string, nodes: ClusterGovernanceNode[] }}
+ */
+export function readClusterGovernance({
+  logPath = _config?.getEventLogPath?.() ?? "",
+  roster = _config?.getClusterHosts?.() ?? [],
+  now = Date.now(),
+  intervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS,
+  graceMs = DEFAULT_LIVENESS_GRACE_MS,
+} = {}) {
+  const hosts = Array.isArray(roster) ? roster : [];
+
+  // Single pass over the log: keep the latest heartbeat ts + governance per host.
+  /** @type {Map<string, { ts: string, governance: Record<string, unknown> | null }>} */
+  const best = new Map();
+
+  let raw = "";
+  try {
+    raw = readFileSync(logPath, "utf8");
+  } catch {
+    // Missing log → all hosts will be offline (empty best map).
+  }
+
+  for (const line of raw.split("\n")) {
+    if (!line || !line.includes(HEARTBEAT_EVENT)) continue;
+    let evt;
+    try { evt = JSON.parse(line); } catch { continue; }
+    if (evt?.attributes?.["event.name"] !== HEARTBEAT_EVENT) continue;
+    const host = evt?.body?.payload?.["host.name"] ?? evt?.resource?.["host.name"];
+    if (typeof host !== "string" || host.length === 0) continue;
+    const ts = evt?.ts;
+    if (typeof ts !== "string" || ts.length === 0) continue;
+    const gov = evt?.body?.payload?.governance ?? null;
+    const current = best.get(host);
+    if (!current || ts > current.ts) {
+      best.set(host, { ts, governance: gov });
+    }
+  }
+
+  // Map roster to nodes.
+  const nodes = hosts.map((host) => {
+    const entry = best.get(host);
+    if (!entry) {
+      return { host, governance: null, reportedAt: null, ageMs: null, status: /** @type {"offline"} */ ("offline") };
+    }
+    const reportedAt = entry.ts;
+    const parsed = Date.parse(reportedAt);
+    const ageMs = Number.isFinite(parsed) ? Math.max(0, now - parsed) : null;
+    const status = classifyHostLiveness(reportedAt, now, { intervalMs, graceMs });
+    return { host, governance: entry.governance, reportedAt, ageMs, status };
+  });
+
+  return {
+    singleHost: hosts.length <= 1,
+    generatedAt: new Date(now).toISOString(),
+    nodes,
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -3768,6 +3768,22 @@ export function createServer(opts: CreateServerOptions): BunServer {
         // Inserted between the /api/beliefs/stream block and the 404 fallthrough.
         // Re-locate by grep after each insertion — line numbers shift.
 
+        // GET /api/cluster/governance — per-host governance snapshot from the
+        // heartbeat event log (CTL-1104). Separate from /api/governance (local
+        // config snapshot, CTL-1100) — see plan §open-question 3. DO NOT inline
+        // the specifier (VITE-GRAPH GUARD, CTL-883).
+        if (url.pathname === "/api/cluster/governance") {
+          const govSpecifier = ["./lib/cluster-governance.mjs"].join("");
+          try {
+            const { readClusterGovernance } = await import(govSpecifier) as {
+              readClusterGovernance: () => Record<string, unknown>;
+            };
+            return Response.json(readClusterGovernance());
+          } catch {
+            return Response.json({ singleHost: true, nodes: [], generatedAt: "" });
+          }
+        }
+
         // GET /api/governance — current daemon governance config snapshot.
         // DO NOT inline the specifier (computed import, VITE-GRAPH GUARD, CTL-883).
         if (url.pathname === "/api/governance") {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/governance/governance-flags-chip.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/governance/governance-flags-chip.tsx
@@ -1,6 +1,8 @@
-// governance-flags-chip.tsx — CTL-1100 Phase 6: governance mode status chips.
-// Fetches /api/governance once with capped retry. Degrades to placeholder when
-// absent or unavailable. Modeled on Board.tsx ScopeChip/StatusBadge pattern.
+// governance-flags-chip.tsx — CTL-1100 Phase 6 + CTL-1104 Phase 2.
+// Renders the 7 governance mode badges. Two modes:
+//   • Self-fetch (no props): fetches /api/governance once with capped retry.
+//   • Data-driven (snapshot prop): renders from provided props, no fetch.
+// Backward-compatible — existing zero-prop consumers are unchanged.
 import { useEffect, useState } from "react";
 import {
   isGovernanceSnapshot,
@@ -8,41 +10,20 @@ import {
   modeTone,
   GOVERNANCE_FLAG_LABELS,
   type GovernanceSnapshot,
+  type GovernanceSnapshotModes,
 } from "../../lib/governance-model";
 
 const MAX_RETRIES = 3;
 
-export function GovernanceFlagsChip() {
-  const [snapshot, setSnapshot] = useState<GovernanceSnapshot | null>(null);
-  const [retries, setRetries] = useState(0);
+const BOOL_FLAGS = ["beliefsShadow", "diagnostician", "intentsEnforce", "advanceShadowSummary"] as const;
+const MODE_FLAGS = ["stallJanitor", "watchdog", "unstuckSweep"] as const;
 
-  useEffect(() => {
-    if (retries > MAX_RETRIES) return;
-    let cancelled = false;
-    fetch("/api/governance")
-      .then((r) => r.json())
-      .then((body) => {
-        if (cancelled) return;
-        if (isGovernanceSnapshot(body)) setSnapshot(body);
-        else setRetries((r) => r + 1);
-      })
-      .catch(() => {
-        if (!cancelled) setRetries((r) => r + 1);
-      });
-    return () => { cancelled = true; };
-  }, [retries]);
-
-  if (!snapshot || !snapshot.available) {
-    return <span className="text-muted-foreground text-xs">governance —</span>;
-  }
-
-  const boolFlags = ["beliefsShadow", "diagnostician", "intentsEnforce", "advanceShadowSummary"] as const;
-  const modeFlags = ["stallJanitor", "watchdog", "unstuckSweep"] as const;
-
+/** The mode badges JSX — shared between self-fetch and prop-driven paths. */
+function ModeBadges({ modes }: { modes: GovernanceSnapshotModes }) {
   return (
     <div className="flex flex-wrap gap-1">
-      {boolFlags.map((key) => {
-        const val = snapshot[key] ?? false;
+      {BOOL_FLAGS.map((key) => {
+        const val = (modes as Record<string, unknown>)[key] as boolean ?? false;
         const tone = flagTone(val);
         return (
           <span
@@ -54,8 +35,8 @@ export function GovernanceFlagsChip() {
           </span>
         );
       })}
-      {modeFlags.map((key) => {
-        const val = (snapshot[key] as { mode?: string } | undefined)?.mode ?? "off";
+      {MODE_FLAGS.map((key) => {
+        const val = ((modes as Record<string, unknown>)[key] as { mode?: string } | undefined)?.mode ?? "off";
         const tone = modeTone(val);
         return (
           <span
@@ -69,4 +50,67 @@ export function GovernanceFlagsChip() {
       })}
     </div>
   );
+}
+
+export interface GovernanceFlagsChipProps {
+  /** When provided, renders from this snapshot without fetching (CTL-1104). */
+  snapshot?: GovernanceSnapshotModes | null;
+  /** Human-readable age label, e.g. "5s ago". Shown when snapshot is provided. */
+  reportedAtLabel?: string;
+  /** When true, appends a stale badge (CTL-1104). */
+  stale?: boolean;
+}
+
+export function GovernanceFlagsChip({ snapshot, reportedAtLabel, stale }: GovernanceFlagsChipProps = {}) {
+  // Self-fetch path — only active when no snapshot prop is provided.
+  const [fetchedSnapshot, setFetchedSnapshot] = useState<GovernanceSnapshot | null>(null);
+  const [retries, setRetries] = useState(0);
+
+  const isPropDriven = snapshot !== undefined;
+
+  useEffect(() => {
+    if (isPropDriven) return;
+    if (retries > MAX_RETRIES) return;
+    let cancelled = false;
+    fetch("/api/governance")
+      .then((r) => r.json())
+      .then((body) => {
+        if (cancelled) return;
+        if (isGovernanceSnapshot(body)) setFetchedSnapshot(body);
+        else setRetries((r) => r + 1);
+      })
+      .catch(() => {
+        if (!cancelled) setRetries((r) => r + 1);
+      });
+    return () => { cancelled = true; };
+  }, [retries, isPropDriven]);
+
+  // ── Prop-driven path (CTL-1104) ─────────────────────────────────────────
+  if (isPropDriven) {
+    if (!snapshot) {
+      return <span className="text-muted-foreground text-xs">governance —</span>;
+    }
+    return (
+      <div className="flex flex-col gap-1">
+        <ModeBadges modes={snapshot} />
+        <div className="flex items-center gap-1.5">
+          {reportedAtLabel && (
+            <span className="text-muted-foreground text-[10px]">{reportedAtLabel}</span>
+          )}
+          {stale && (
+            <span className="rounded bg-amber-100 px-1 py-0.5 text-[10px] font-mono text-amber-700 dark:bg-amber-900 dark:text-amber-200">
+              stale
+            </span>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Self-fetch path (unchanged CTL-1100 behavior) ────────────────────────
+  if (!fetchedSnapshot || !fetchedSnapshot.available) {
+    return <span className="text-muted-foreground text-xs">governance —</span>;
+  }
+
+  return <ModeBadges modes={fetchedSnapshot} />;
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/governance/governance-flags-chip.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/governance/governance-flags-chip.tsx
@@ -77,10 +77,10 @@ export function GovernanceFlagsChip({ snapshot, reportedAtLabel, stale }: Govern
       .then((body) => {
         if (cancelled) return;
         if (isGovernanceSnapshot(body)) setFetchedSnapshot(body);
-        else setRetries((r) => r + 1);
+        else setRetries((prev) => prev + 1);
       })
       .catch(() => {
-        if (!cancelled) setRetries((r) => r + 1);
+        if (!cancelled) setRetries((prev) => prev + 1);
       });
     return () => { cancelled = true; };
   }, [retries, isPropDriven]);

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/fleetops-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/fleetops-surface.tsx
@@ -30,10 +30,15 @@ import { HostMatrix } from "@/components/observe/host-matrix";
 import { StuckDeadReap } from "@/components/observe/stuck-dead-reap";
 import { fleetHero, reapList } from "@/components/observe/fleetops-kit";
 import { ServiceHealthStrip } from "@/components/observe/service-health-strip";
+import { GovernanceModesStrip } from "@/components/observe/governance-modes-strip";
 import type {
   ServiceHealthSnapshotView,
   ServiceStatusView,
 } from "@/components/observe/service-health-kit";
+import {
+  isClusterGovernanceSignal,
+  type ClusterGovernanceNode,
+} from "@/lib/governance-model";
 
 /** A zero-capacity board config stand-in for first paint (before /api/board lands)
  *  — renders an honest 0/0 rather than NaN. */
@@ -63,6 +68,11 @@ export function FleetOpsSurface() {
   // fetch failure so the strip renders the honest grey line (never green).
   const [services, setServices] = useState<ServiceStatusView[] | null>(null);
   const [servicesUnavailable, setServicesUnavailable] = useState<boolean>(false);
+  // CTL-1104: per-host governance snapshot for the GOVERNANCE strip. null until
+  // the first /api/cluster/governance lands; `governanceUnavailable` flips on
+  // failure so the strip renders the honest grey line (never fabricates green).
+  const [governanceNodes, setGovernanceNodes] = useState<ClusterGovernanceNode[] | null>(null);
+  const [governanceUnavailable, setGovernanceUnavailable] = useState<boolean>(false);
   // Ticks every refresh so the board-freshness (broker) cell + reap idle ages
   // recompute against a current `now` without a per-cell timer.
   const [now, setNow] = useState<number>(() => Date.now());
@@ -122,14 +132,36 @@ export function FleetOpsSurface() {
       }
     }
 
+    // CTL-1104: per-host governance snapshot from the heartbeat event log.
+    async function loadGovernance() {
+      try {
+        const resp = await fetch("/api/cluster/governance");
+        if (!resp.ok || !alive) {
+          if (alive) setGovernanceUnavailable(true);
+          return;
+        }
+        const body = await resp.json();
+        if (alive && isClusterGovernanceSignal(body)) {
+          setGovernanceNodes(body.nodes);
+          setGovernanceUnavailable(false);
+        } else if (alive) {
+          setGovernanceUnavailable(true);
+        }
+      } catch {
+        if (alive) setGovernanceUnavailable(true);
+      }
+    }
+
     void loadCluster();
     void loadBoard();
     void loadServices();
+    void loadGovernance();
     const id = setInterval(() => {
       setNow(Date.now());
       void loadCluster();
       void loadBoard();
       void loadServices();
+      void loadGovernance();
     }, REFRESH_MS);
     return () => {
       alive = false;
@@ -180,6 +212,15 @@ export function FleetOpsSurface() {
       <ServiceHealthStrip
         services={services}
         unavailable={servicesUnavailable}
+        now={now}
+      />
+
+      {/* CTL-1104 GOVERNANCE STRIP — full-width shrink-0 block (not inside the
+          grid wrapper — ChartCard flex-collapse rule). One row per roster host:
+          host name + mode chips + age label + stale marker. */}
+      <GovernanceModesStrip
+        nodes={governanceNodes}
+        unavailable={governanceUnavailable}
         now={now}
       />
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/governance-modes-strip.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/governance-modes-strip.tsx
@@ -1,0 +1,54 @@
+// governance-modes-strip.tsx — CTL-1104 Phase 3. Fleet Ops GOVERNANCE strip.
+// Full-width shrink-0 block (NOT inside the grid wrapper — ChartCard flex-collapse
+// rule, fleetops-surface.tsx:186-187). One row per roster host: host name +
+// GovernanceFlagsChip (data-driven) + age label + stale marker.
+// Degrades to honest grey "governance status unavailable" when nodes is null
+// or unavailable — never fabricates a green state.
+
+import { Panel, PanelHeader, SectionLabel } from "@/components/ui/panel";
+import { GovernanceFlagsChip } from "@/components/governance/governance-flags-chip";
+import { buildGovernanceRows } from "@/components/observe/governance-strip-kit";
+import type { ClusterGovernanceNode } from "@/lib/governance-model";
+
+export interface GovernanceModesStripProps {
+  nodes: ClusterGovernanceNode[] | null;
+  unavailable: boolean;
+  now: number;
+}
+
+export function GovernanceModesStrip({ nodes, unavailable }: GovernanceModesStripProps) {
+  const rows = nodes !== null ? buildGovernanceRows(nodes) : [];
+
+  return (
+    <Panel className="shrink-0">
+      <PanelHeader className="flex items-center justify-between gap-2">
+        <SectionLabel>Governance</SectionLabel>
+        <span className="font-mono text-[10px] tracking-wide text-muted/70">
+          [heartbeat]
+        </span>
+      </PanelHeader>
+      <div className="p-2">
+        {unavailable || nodes === null ? (
+          <div className="px-1 py-1 text-[12px] text-muted">
+            governance status unavailable
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2 px-1 py-1">
+            {rows.map((row) => (
+              <div key={row.host} className="flex items-start gap-3">
+                <span className="shrink-0 font-mono text-[11px] text-muted-foreground/80 pt-0.5 min-w-[120px]">
+                  {row.host}
+                </span>
+                <GovernanceFlagsChip
+                  snapshot={row.modes}
+                  reportedAtLabel={row.ageLabel}
+                  stale={row.stale}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Panel>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/governance-strip-kit.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/governance-strip-kit.test.ts
@@ -1,0 +1,78 @@
+// governance-strip-kit.test.ts — CTL-1104 Phase 3: pure logic for GovernanceModesStrip.
+// All functions are pure (no React); mirrors service-health-kit.test.ts pattern.
+
+import { describe, it, expect } from "bun:test";
+import {
+  buildGovernanceRows,
+  type GovernanceRow,
+} from "./governance-strip-kit";
+import type { ClusterGovernanceNode } from "@/lib/governance-model";
+
+const MODES = {
+  beliefsShadow: true,
+  diagnostician: false,
+  intentsEnforce: false,
+  advanceShadowSummary: false,
+  stallJanitor: { mode: "enforce" },
+  watchdog: { mode: "shadow" },
+  unstuckSweep: { mode: "off" },
+};
+
+function node(partial: Partial<ClusterGovernanceNode> & { host: string }): ClusterGovernanceNode {
+  return {
+    governance: MODES,
+    reportedAt: "2026-06-13T12:00:00.000Z",
+    ageMs: 5_000,
+    status: "live",
+    ...partial,
+  };
+}
+
+describe("buildGovernanceRows — basic projection", () => {
+  it("returns one row per node in roster order", () => {
+    const nodes = [node({ host: "host-A" }), node({ host: "host-B" })];
+    const rows = buildGovernanceRows(nodes);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].host).toBe("host-A");
+    expect(rows[1].host).toBe("host-B");
+  });
+
+  it("single-host signal → one row", () => {
+    const rows = buildGovernanceRows([node({ host: "host-A" })]);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("computes ageLabel via governanceAgeLabel for a live node", () => {
+    const rows = buildGovernanceRows([node({ host: "host-A", ageMs: 5_000 })]);
+    expect(rows[0].ageLabel).toBe("5s ago");
+  });
+
+  it("uses '—' ageLabel when ageMs is null", () => {
+    const rows = buildGovernanceRows([node({ host: "host-A", ageMs: null })]);
+    expect(rows[0].ageLabel).toBe("—");
+  });
+});
+
+describe("buildGovernanceRows — stale flag", () => {
+  it("live node → stale false", () => {
+    const rows = buildGovernanceRows([node({ host: "h", status: "live" })]);
+    expect(rows[0].stale).toBe(false);
+  });
+
+  it("degraded node → stale true", () => {
+    const rows = buildGovernanceRows([node({ host: "h", status: "degraded" })]);
+    expect(rows[0].stale).toBe(true);
+  });
+
+  it("offline node → stale true", () => {
+    const rows = buildGovernanceRows([node({ host: "h", status: "offline" })]);
+    expect(rows[0].stale).toBe(true);
+  });
+});
+
+describe("buildGovernanceRows — null/missing governance", () => {
+  it("node with null governance → modes is null", () => {
+    const rows = buildGovernanceRows([node({ host: "h", governance: null })]);
+    expect(rows[0].modes).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/governance-strip-kit.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/governance-strip-kit.ts
@@ -1,0 +1,31 @@
+// governance-strip-kit.ts — CTL-1104 Phase 3. Pure helpers for GovernanceModesStrip.
+// All label/stale/tone logic lives here; the strip component is a thin skin.
+// Mirrors service-health-kit.ts separation pattern.
+
+import {
+  governanceAgeLabel,
+  isGovernanceStale,
+  type ClusterGovernanceNode,
+  type GovernanceSnapshotModes,
+} from "@/lib/governance-model";
+
+/** The per-row data the strip component consumes. */
+export interface GovernanceRow {
+  host: string;
+  modes: GovernanceSnapshotModes | null;
+  ageLabel: string;
+  stale: boolean;
+}
+
+/**
+ * buildGovernanceRows — project ClusterGovernanceNode[] into strip rows.
+ * Preserves roster order (stable per-host rendering).
+ */
+export function buildGovernanceRows(nodes: ClusterGovernanceNode[]): GovernanceRow[] {
+  return nodes.map((n) => ({
+    host: n.host,
+    modes: n.governance as GovernanceSnapshotModes | null,
+    ageLabel: governanceAgeLabel(n.ageMs),
+    stale: isGovernanceStale(n.status),
+  }));
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/governance-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/governance-model.test.ts
@@ -1,4 +1,4 @@
-// governance-model.test.ts — CTL-1100 Phase 6
+// governance-model.test.ts — CTL-1100 Phase 6 + CTL-1104 Phase 2
 
 import { describe, it, expect } from "bun:test";
 import {
@@ -6,6 +6,10 @@ import {
   flagTone,
   modeTone,
   GOVERNANCE_FLAG_LABELS,
+  isClusterGovernanceSignal,
+  decodeClusterGovernanceFrame,
+  governanceAgeLabel,
+  isGovernanceStale,
 } from "./governance-model";
 
 describe("isGovernanceSnapshot", () => {
@@ -49,4 +53,64 @@ describe("GOVERNANCE_FLAG_LABELS", () => {
     expect("beliefsShadow" in GOVERNANCE_FLAG_LABELS).toBe(true);
     expect("stallJanitor" in GOVERNANCE_FLAG_LABELS).toBe(true);
   });
+});
+
+// ── CTL-1104 Phase 2: cluster-governance wire model ────────────────────────
+
+const VALID_SIGNAL = {
+  singleHost: true,
+  generatedAt: "2026-06-13T12:00:00.000Z",
+  nodes: [
+    {
+      host: "mac-mini",
+      governance: { beliefsShadow: true, stallJanitor: { mode: "enforce" } },
+      reportedAt: "2026-06-13T11:59:55.000Z",
+      ageMs: 5_000,
+      status: "live" as const,
+    },
+  ],
+};
+
+describe("isClusterGovernanceSignal", () => {
+  it("accepts a minimal empty-nodes signal", () => {
+    expect(isClusterGovernanceSignal({ singleHost: true, generatedAt: "", nodes: [] })).toBe(true);
+  });
+  it("accepts a fully-populated signal", () => {
+    expect(isClusterGovernanceSignal(VALID_SIGNAL)).toBe(true);
+  });
+  it("rejects null", () => expect(isClusterGovernanceSignal(null)).toBe(false));
+  it("rejects missing nodes", () => expect(isClusterGovernanceSignal({ singleHost: true, generatedAt: "" })).toBe(false));
+  it("rejects non-array nodes", () => expect(isClusterGovernanceSignal({ singleHost: true, generatedAt: "", nodes: "oops" })).toBe(false));
+  it("rejects a node missing host", () => {
+    expect(isClusterGovernanceSignal({ singleHost: true, generatedAt: "", nodes: [{ governance: null, status: "offline" }] })).toBe(false);
+  });
+});
+
+describe("decodeClusterGovernanceFrame", () => {
+  it("parses valid JSON into the signal", () => {
+    const frame = JSON.stringify(VALID_SIGNAL);
+    const result = decodeClusterGovernanceFrame(frame);
+    expect(result).not.toBeNull();
+    expect(result?.nodes[0].host).toBe("mac-mini");
+  });
+  it("returns null on garbage input", () => {
+    expect(decodeClusterGovernanceFrame("{bad json")).toBeNull();
+    expect(decodeClusterGovernanceFrame("null")).toBeNull();
+    expect(decodeClusterGovernanceFrame("{}")).toBeNull();
+  });
+});
+
+describe("governanceAgeLabel", () => {
+  it("< 1000ms → 'just now'", () => expect(governanceAgeLabel(500)).toBe("just now"));
+  it("0ms → 'just now'", () => expect(governanceAgeLabel(0)).toBe("just now"));
+  it("5s → '5s ago'", () => expect(governanceAgeLabel(5_000)).toBe("5s ago"));
+  it("90s → '1m ago'", () => expect(governanceAgeLabel(90_000)).toBe("1m ago"));
+  it("3600s → '1h ago'", () => expect(governanceAgeLabel(3_600_000)).toBe("1h ago"));
+  it("null → '—'", () => expect(governanceAgeLabel(null)).toBe("—"));
+});
+
+describe("isGovernanceStale", () => {
+  it("live → false", () => expect(isGovernanceStale("live")).toBe(false));
+  it("degraded → true", () => expect(isGovernanceStale("degraded")).toBe(true));
+  it("offline → true", () => expect(isGovernanceStale("offline")).toBe(true));
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/governance-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/governance-model.ts
@@ -1,4 +1,4 @@
-// governance-model.ts — CTL-1100 Phase 6: /api/governance snapshot model.
+// governance-model.ts — CTL-1100 Phase 6 + CTL-1104 Phase 2.
 // Pure; no DOM dependency.
 
 /** Shape returned by GET /api/governance (mirrors readGovernanceConfig). */
@@ -40,4 +40,63 @@ export function modeTone(mode: string): "green" | "yellow" | "muted" {
   if (mode === "enforce") return "green";
   if (mode === "shadow")  return "yellow";
   return "muted";
+}
+
+// ── CTL-1104 Phase 2: cluster-governance wire model ────────────────────────
+
+/** The bare 7-field governance modes shape (extracted from GovernanceSnapshot
+ *  so GovernanceFlagsChip and GovernanceModesStrip can take either form). */
+export type GovernanceSnapshotModes = Omit<GovernanceSnapshot, "available">;
+
+/** One host's governance snapshot from /api/cluster/governance. */
+export interface ClusterGovernanceNode {
+  host: string;
+  governance: GovernanceSnapshotModes | null;
+  reportedAt: string | null;
+  ageMs: number | null;
+  status: "live" | "degraded" | "offline";
+}
+
+/** The full wire shape for GET /api/cluster/governance. */
+export interface ClusterGovernanceSignal {
+  singleHost: boolean;
+  nodes: ClusterGovernanceNode[];
+  generatedAt: string;
+}
+
+export function isClusterGovernanceSignal(v: unknown): v is ClusterGovernanceSignal {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  if (!Array.isArray(r.nodes)) return false;
+  for (const node of r.nodes as unknown[]) {
+    if (!node || typeof node !== "object") return false;
+    if (typeof (node as Record<string, unknown>).host !== "string") return false;
+  }
+  return true;
+}
+
+export function decodeClusterGovernanceFrame(data: string): ClusterGovernanceSignal | null {
+  try {
+    const parsed = JSON.parse(data);
+    return isClusterGovernanceSignal(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Human-friendly age label for a governance snapshot. */
+export function governanceAgeLabel(ageMs: number | null): string {
+  if (ageMs === null) return "—";
+  if (ageMs < 1_000) return "just now";
+  const secs = Math.floor(ageMs / 1_000);
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  return `${hrs}h ago`;
+}
+
+/** True when the governance report should be marked stale. */
+export function isGovernanceStale(status: ClusterGovernanceNode["status"]): boolean {
+  return status !== "live";
 }


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-13T23:34:00Z -->
<!-- Last updated: 2026-06-13T23:34:00Z -->
<!-- PR: #1958 -->
<!-- Previous commits: ca9a6fc3ea8c00a42c02acb0d8e06cd263e1e051,b542299065d652f5bcdce9e54e6a1c1971129965,ac85f8d23d307236aa0555d59efe2bdfec04ad34,566050b87fe8ce82ba391bf13baed638cde0120b -->

## Summary

Adds a Governance strip to the FleetOps surface so operators can see which
governance modes each cluster host is running without grepping process env.

- Implements `readClusterGovernance()` — a per-host governance snapshot reader
  that scans the unified heartbeat event log and classifies each host's freshness
  with the same `classifyHostLiveness` drift guard used by the host-liveness system.
- Exposes a new `GET /api/cluster/governance` server endpoint (separate from
  `/api/governance` which reflects the local daemon config).
- Extends the `governance-model` with cluster-level types and display helpers
  (`ClusterGovernanceNode`, `ClusterGovernanceSignal`, `governanceAgeLabel`,
  `isGovernanceStale`, `isClusterGovernanceSignal`).
- Refactors `GovernanceFlagsChip` to support a data-driven mode (snapshot prop
  supplied by parent) while keeping the existing zero-prop self-fetch path
  backward-compatible.
- Adds `GovernanceModesStrip` — a full-width FleetOps panel that renders one row
  per roster host: hostname, mode chips, age label, and stale marker.
- Wires `GovernanceModesStrip` into `FleetOpsSurface` with the same refresh
  cadence as other strips (`loadGovernance()` polled every `REFRESH_MS`).

## Changes Made

### Backend / Server

- **`lib/cluster-governance.mjs`** (new) — `readClusterGovernance(opts)`: pure,
  injectable single-pass reader over the event log; produces `ClusterGovernanceSignal`.
  Lazy-loads execution-core config via the VITE-GRAPH GUARD pattern (CTL-883).
  Degrades gracefully when the log file is absent (all-offline signal).
- **`lib/cluster-governance.d.mts`** (new) — TypeScript declarations:
  `ClusterGovernanceNode`, `ClusterGovernanceSignal`, `ReadClusterGovernanceOpts`.
- **`server.ts`** — `GET /api/cluster/governance` route: uses computed import
  (VITE-GRAPH GUARD) to serve the cluster snapshot; degrades to empty signal on
  import failure.

### Frontend / Model

- **`ui/src/lib/governance-model.ts`** — added `GovernanceSnapshotModes` type,
  `ClusterGovernanceNode` and `ClusterGovernanceSignal` interfaces, `isClusterGovernanceSignal`,
  `decodeClusterGovernanceFrame`, `governanceAgeLabel`, and `isGovernanceStale`.

### Frontend / Components

- **`ui/src/components/governance/governance-flags-chip.tsx`** — refactored to
  dual-mode: added `GovernanceFlagsChipProps` interface (`snapshot?`, `reportedAtLabel?`,
  `stale?`); extracted `ModeBadges` as an inner pure component; prop-driven path
  renders stale badge and age label; zero-prop self-fetch path is unchanged.
- **`ui/src/components/observe/governance-strip-kit.ts`** (new) — pure helpers
  for `GovernanceModesStrip`: `buildGovernanceRows()` projects
  `ClusterGovernanceNode[]` into `GovernanceRow[]` (host, modes, ageLabel, stale).
- **`ui/src/components/observe/governance-modes-strip.tsx`** (new) — full-width
  FleetOps panel; renders one row per roster host via `GovernanceFlagsChip` in
  data-driven mode; degrades to honest grey when `nodes` is null or `unavailable`.
- **`ui/src/components/observe/fleetops-surface.tsx`** — added `governanceNodes` /
  `governanceUnavailable` state; added `loadGovernance()` async function and wired
  it into both the initial load and the `setInterval` refresh.

### Tests

- **`__tests__/cluster-governance.test.ts`** (new) — 14 test cases covering:
  roster extraction, newest-heartbeat-wins, ageMs/reportedAt, drift-guard alignment
  with `classifyHostLiveness`, missing-host (offline), robustness (missing log,
  garbage lines, non-heartbeat events, missing governance field, clock-skew).
- **`ui/src/lib/governance-model.test.ts`** — extended with 13 new tests for
  `isClusterGovernanceSignal`, `decodeClusterGovernanceFrame`, `governanceAgeLabel`,
  and `isGovernanceStale`.
- **`ui/src/components/observe/governance-strip-kit.test.ts`** (new) — 7 tests
  covering `buildGovernanceRows`: projection, single-host, age labels, stale flag
  (live/degraded/offline), and null governance passthrough.

## How to Verify It

- [x] TypeScript: 0 new errors; 6 pre-existing baseline errors are unrelated to this diff ✅
- [x] Tests: 4572 pass / 33 fail / 23 errors — delta 0 vs origin/main baseline; 56 new feature tests all pass ✅
- [x] Lint: 0 errors / 53 warnings — matches baseline ✅
- [x] Security: read-only event-log reader, no new deps, no secrets, no shell ✅
- [x] Reward-hacking scan: no HIGH-severity patterns; all casts runtime-guarded ✅
- [ ] Manual: start orch-monitor dev server and verify the Governance strip appears on FleetOps
- [ ] Manual: confirm stale badge appears when a host heartbeat is older than the liveness threshold
- [ ] Manual: confirm "governance status unavailable" renders when `/api/cluster/governance` is unreachable

## Pre-merge Verification (from verify phase)

- **Regression risk**: 1 / 10
- **typecheck**: pass — 6 tsc errors are 100% pre-existing baseline; 0 errors attributable to this diff
- **tests**: pass — full suite delta 0 vs baseline; 56 feature tests all pass
- **lint**: pass — 0 errors, matches baseline (unused import fixed in-phase, commit 566050b8)
- **security**: pass — read-only, no new deps, no secrets
- **reward_hacking**: pass — no HIGH-severity patterns
- **code_review**: pass — field paths verified end-to-end; classifyHostLiveness drift-guarded
- **coverage**: pass — pure logic modules have direct unit tests
- **silent_failures**: pass — catch blocks are intentional honest-empty degradation

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1104

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-883
