### PR TITLE
fix(dev): CTL-1118 — SHA-aware rebuild guard for catalyst-monitor hot-reload

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-monitor-dist-redirect.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-monitor-dist-redirect.test.sh
@@ -52,11 +52,16 @@ make_sandbox() {
   # Stub binaries dir
   mkdir -p "$root/bin"
 
-  # Stub vite: writes marker files into $MONITOR_UI_DIST_DIR
+  # Stub vite: writes marker files into $MONITOR_UI_DIST_DIR.
+  # Honor STUB_VITE_FAIL=1 to exit non-zero without writing (Phase 2, Test 10).
   cat > "$root/bin/vite" <<'VITE'
 #!/usr/bin/env bash
 # Stub vite build — writes markers into $MONITOR_UI_DIST_DIR
 if [[ "${1:-}" == "build" ]]; then
+  if [[ "${STUB_VITE_FAIL:-}" == "1" ]]; then
+    echo "stub vite: forced failure" >&2
+    exit 1
+  fi
   DIST="${MONITOR_UI_DIST_DIR:-/tmp/stub-dist-missing}"
   mkdir -p "$DIST/assets"
   echo "stub-index" > "$DIST/index.html"
@@ -79,6 +84,21 @@ BUNX
 exit 0
 SQ
   chmod +x "$root/bin/sqlite3"
+
+  # Stub git: for any `log` subcommand, print the contents of $STUB_GIT_SHA_FILE
+  # (empty/absent → empty output). All other git subcommands succeed silently.
+  # CTL-1118: lets tests control the "current UI source SHA" without a real repo.
+  cat > "$root/bin/git" <<'GIT'
+#!/usr/bin/env bash
+for a in "$@"; do
+  if [[ "$a" == "log" ]]; then
+    cat "${STUB_GIT_SHA_FILE:-}" 2>/dev/null || true
+    exit 0
+  fi
+done
+exit 0
+GIT
+  chmod +x "$root/bin/git"
 
   echo "$root"
 }
@@ -262,6 +282,198 @@ if [[ -f "$ENV_CAPTURE" ]]; then
   fi
 else
   fail "stub bun did not capture env (cmd_start may not have launched the server)"
+fi
+rm -rf "$ROOT"
+
+# ─── Test 7: UI source SHA advanced → rebuild triggered ──────────────────────
+echo ""
+echo "Test 7: UI source SHA advanced → rebuild triggered even though index.html exists"
+ROOT="$(make_sandbox)"
+mkdir -p "$ROOT/dist"
+echo "already-built" > "$ROOT/dist/index.html"
+echo "sha-A" > "$ROOT/dist/.source-sha"
+STUB_GIT_SHA_FILE="$ROOT/.stub-ui-sha"
+echo "sha-B" > "$STUB_GIT_SHA_FILE"
+VITE_RAN_FILE="$ROOT/vite-ran-7"
+cat > "$ROOT/bin/vite" <<VITE7
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "build" ]]; then
+  touch "$VITE_RAN_FILE"
+  DIST="\${MONITOR_UI_DIST_DIR:-/tmp/stub-dist-missing}"
+  mkdir -p "\$DIST/assets"
+  echo "rebuilt" > "\$DIST/index.html"
+fi
+VITE7
+chmod +x "$ROOT/bin/vite"
+cat > "$ROOT/bin/bunx" <<BUNX7
+#!/usr/bin/env bash
+shift
+exec "$ROOT/bin/vite" "\$@"
+BUNX7
+chmod +x "$ROOT/bin/bunx"
+STUB_GIT_SHA_FILE="$STUB_GIT_SHA_FILE" run_bootstrap "$ROOT" >/dev/null 2>&1
+if [[ -f "$VITE_RAN_FILE" ]]; then
+  pass "stub vite re-run when UI source SHA advanced (sha-A → sha-B)"
+else
+  fail "stub vite NOT re-run on SHA mismatch — SHA-aware guard not implemented"
+fi
+if [[ -f "$ROOT/dist/.source-sha" ]]; then
+  WRITTEN_SHA="$(cat "$ROOT/dist/.source-sha")"
+  if [[ "$WRITTEN_SHA" == "sha-B" ]]; then
+    pass "dist/.source-sha updated to new SHA (sha-B) after rebuild"
+  else
+    fail "dist/.source-sha has wrong value: $WRITTEN_SHA (expected sha-B)"
+  fi
+else
+  fail "dist/.source-sha not written after rebuild"
+fi
+rm -rf "$ROOT"
+
+# ─── Test 8: UI source SHA unchanged → rebuild skipped ───────────────────────
+echo ""
+echo "Test 8: UI source SHA unchanged → rebuild skipped"
+ROOT="$(make_sandbox)"
+mkdir -p "$ROOT/dist"
+echo "already-built" > "$ROOT/dist/index.html"
+echo "sha-A" > "$ROOT/dist/.source-sha"
+STUB_GIT_SHA_FILE="$ROOT/.stub-ui-sha"
+echo "sha-A" > "$STUB_GIT_SHA_FILE"
+VITE_RAN_FILE="$ROOT/vite-ran-8"
+cat > "$ROOT/bin/vite" <<VITE8
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "build" ]]; then
+  touch "$VITE_RAN_FILE"
+fi
+VITE8
+chmod +x "$ROOT/bin/vite"
+cat > "$ROOT/bin/bunx" <<BUNX8
+#!/usr/bin/env bash
+shift
+exec "$ROOT/bin/vite" "\$@"
+BUNX8
+chmod +x "$ROOT/bin/bunx"
+STUB_GIT_SHA_FILE="$STUB_GIT_SHA_FILE" run_bootstrap "$ROOT" >/dev/null 2>&1
+if [[ ! -f "$VITE_RAN_FILE" ]]; then
+  pass "stub vite NOT re-run when SHA unchanged (sha-A == sha-A)"
+else
+  fail "stub vite was re-run despite SHA unchanged"
+fi
+rm -rf "$ROOT"
+
+# ─── Test 9: first start records .source-sha ─────────────────────────────────
+echo ""
+echo "Test 9: first start records .source-sha when dist is empty"
+ROOT="$(make_sandbox)"
+STUB_GIT_SHA_FILE="$ROOT/.stub-ui-sha"
+echo "sha-A" > "$STUB_GIT_SHA_FILE"
+STUB_GIT_SHA_FILE="$STUB_GIT_SHA_FILE" run_bootstrap "$ROOT" >/dev/null 2>&1
+if [[ -f "$ROOT/dist/.source-sha" ]]; then
+  WRITTEN_SHA="$(cat "$ROOT/dist/.source-sha")"
+  if [[ "$WRITTEN_SHA" == "sha-A" ]]; then
+    pass "dist/.source-sha written with correct SHA (sha-A) on first build"
+  else
+    fail "dist/.source-sha has wrong value: $WRITTEN_SHA (expected sha-A)"
+  fi
+else
+  fail "dist/.source-sha not written after first build"
+fi
+rm -rf "$ROOT"
+
+# ─── Test 10: build failure does NOT advance .source-sha ─────────────────────
+echo ""
+echo "Test 10: build failure does NOT advance .source-sha (retry preserved)"
+ROOT="$(make_sandbox)"
+mkdir -p "$ROOT/dist"
+echo "already-built" > "$ROOT/dist/index.html"
+echo "sha-A" > "$ROOT/dist/.source-sha"
+STUB_GIT_SHA_FILE="$ROOT/.stub-ui-sha"
+echo "sha-B" > "$STUB_GIT_SHA_FILE"
+cat > "$ROOT/bin/vite" <<'VITE10'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "build" ]]; then
+  if [[ "${STUB_VITE_FAIL:-}" == "1" ]]; then
+    echo "stub vite: forced failure" >&2
+    exit 1
+  fi
+  DIST="${MONITOR_UI_DIST_DIR:-/tmp/stub-dist-missing}"
+  mkdir -p "$DIST"
+  echo "rebuilt" > "$DIST/index.html"
+fi
+VITE10
+chmod +x "$ROOT/bin/vite"
+cat > "$ROOT/bin/bunx" <<BUNX10
+#!/usr/bin/env bash
+shift
+exec "$ROOT/bin/vite" "\$@"
+BUNX10
+chmod +x "$ROOT/bin/bunx"
+OUT10="$(STUB_GIT_SHA_FILE="$STUB_GIT_SHA_FILE" STUB_VITE_FAIL=1 run_bootstrap "$ROOT")"
+RC10="${OUT10##*rc=}"
+if [[ "$RC10" == "0" ]]; then
+  pass "bootstrap exits 0 even when vite build fails (serve stale)"
+else
+  fail "bootstrap returned non-zero on build failure (rc=$RC10) — should serve stale"
+fi
+if [[ -f "$ROOT/dist/.source-sha" ]]; then
+  REMAINING_SHA="$(cat "$ROOT/dist/.source-sha")"
+  if [[ "$REMAINING_SHA" == "sha-A" ]]; then
+    pass "dist/.source-sha still sha-A after failed build (retry preserved)"
+  else
+    fail "dist/.source-sha advanced to $REMAINING_SHA despite build failure (expected sha-A)"
+  fi
+else
+  fail "dist/.source-sha disappeared after failed build"
+fi
+rm -rf "$ROOT"
+
+# ─── Test 11: git unavailable / empty SHA → falls back to index.html-only guard
+echo ""
+echo "Test 11: git returns empty SHA → no spurious rebuild (index.html exists)"
+ROOT="$(make_sandbox)"
+mkdir -p "$ROOT/dist"
+echo "already-built" > "$ROOT/dist/index.html"
+STUB_GIT_SHA_FILE="$ROOT/.stub-ui-sha"
+# Empty control file → git stub prints nothing → ui_source_sha=""
+: > "$STUB_GIT_SHA_FILE"
+VITE_RAN_FILE="$ROOT/vite-ran-11"
+cat > "$ROOT/bin/vite" <<VITE11
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "build" ]]; then
+  touch "$VITE_RAN_FILE"
+fi
+VITE11
+chmod +x "$ROOT/bin/vite"
+cat > "$ROOT/bin/bunx" <<BUNX11
+#!/usr/bin/env bash
+shift
+exec "$ROOT/bin/vite" "\$@"
+BUNX11
+chmod +x "$ROOT/bin/bunx"
+STUB_GIT_SHA_FILE="$STUB_GIT_SHA_FILE" run_bootstrap "$ROOT" >/dev/null 2>&1
+if [[ ! -f "$VITE_RAN_FILE" ]]; then
+  pass "no spurious rebuild when git SHA is empty and index.html exists"
+else
+  fail "spurious rebuild triggered with empty git SHA (guard should fall back to index.html check)"
+fi
+rm -rf "$ROOT"
+
+# ─── Test 12: git unavailable on first start → still builds ──────────────────
+echo ""
+echo "Test 12: git returns empty SHA on first start → build still triggered (index.html missing)"
+ROOT="$(make_sandbox)"
+STUB_GIT_SHA_FILE="$ROOT/.stub-ui-sha"
+# Empty control file → empty git SHA; dist is empty (first start)
+: > "$STUB_GIT_SHA_FILE"
+STUB_GIT_SHA_FILE="$STUB_GIT_SHA_FILE" run_bootstrap "$ROOT" >/dev/null 2>&1
+if [[ -f "$ROOT/dist/index.html" ]]; then
+  pass "first-start build still fires with empty git SHA (index.html missing path)"
+else
+  fail "first-start build did not fire with empty git SHA"
+fi
+if [[ ! -f "$ROOT/dist/.source-sha" ]]; then
+  pass "dist/.source-sha NOT written when git SHA is empty (guarded write)"
+else
+  fail "dist/.source-sha written despite empty git SHA (should be skipped)"
 fi
 rm -rf "$ROOT"
 

--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -206,12 +206,33 @@ bootstrap() {
       mkdir -p "$MONITOR_UI_DIST_DIR"
       export MONITOR_UI_DIST_DIR
 
-      # CTL-1088: build only when the out-of-repo dist has no built index.html yet.
-      # The old guard (`! -d ui/dist`) was always true — vite never wrote there.
-      # Force a rebuild with MONITOR_FORCE_BUILD=1.
-      if [[ "${MONITOR_FORCE_BUILD:-}" == "1" || ! -f "$MONITOR_UI_DIST_DIR/index.html" ]]; then
-        echo "Building orch-monitor frontend → $MONITOR_UI_DIST_DIR ..."
-        (cd "$MONITOR_DIR/ui" && bunx vite build)
+      # CTL-1088: dist lives out-of-repo; first build happens when index.html is absent.
+      # CTL-1118: also rebuild when the UI source has advanced past the last-built
+      # commit. We record the SHA of the last commit touching ui/ next to the dist and
+      # rebuild on mismatch — this covers EVERY restart path (broker hot-reload and
+      # manual restart) with no broker-side plumbing. Escape hatch: MONITOR_FORCE_BUILD=1.
+      ui_source_sha="$(git -C "$MONITOR_DIR" log -1 --format='%H' -- ui/ 2>/dev/null || true)"
+      built_sha_file="$MONITOR_UI_DIST_DIR/.source-sha"
+      built_sha=""
+      [[ -f "$built_sha_file" ]] && built_sha="$(cat "$built_sha_file" 2>/dev/null || true)"
+
+      rebuild_reason=""
+      if [[ "${MONITOR_FORCE_BUILD:-}" == "1" ]]; then
+        rebuild_reason="MONITOR_FORCE_BUILD=1"
+      elif [[ ! -f "$MONITOR_UI_DIST_DIR/index.html" ]]; then
+        rebuild_reason="no built index.html"
+      elif [[ -n "$ui_source_sha" && "$ui_source_sha" != "$built_sha" ]]; then
+        rebuild_reason="ui source changed (${built_sha:-none} → $ui_source_sha)"
+      fi
+
+      if [[ -n "$rebuild_reason" ]]; then
+        echo "Building orch-monitor frontend → $MONITOR_UI_DIST_DIR ($rebuild_reason) ..."
+        if (cd "$MONITOR_DIR/ui" && bunx vite build); then
+          # Record the built source SHA ONLY on success so a failed build retries next start.
+          [[ -n "$ui_source_sha" ]] && printf '%s\n' "$ui_source_sha" > "$built_sha_file"
+        else
+          echo "warning: orch-monitor vite build failed — serving previous dist (will retry next restart)" >&2
+        fi
       fi
 
       # Complete the dist: copy non-vite static assets so the out-of-repo dir is a


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-14T00:41:00Z -->
<!-- Last updated: 2026-06-14T00:41:00Z -->
<!-- PR: #1968 -->
<!-- Previous commits: 04753f19ec89785f32487d15f0cfed70fc7d8b35 -->

## Summary

- Replaces the `index.html`-only rebuild guard in `catalyst-monitor.sh` with a SHA-aware guard that also rebuilds when the UI source has advanced since the last built dist
- Writes `dist/.source-sha` (last commit touching `orch-monitor/ui/`) after a successful build; rebuilds on mismatch; a failed build leaves the SHA unchanged so the next restart retries
- Covers all restart paths (broker hot-reload **and** manual `catalyst-monitor restart`) with zero broker changes

Fixes the bug where UI-source-only merges served stale JS after CTL-1077 hot-reload restarts, requiring operators to hand-run `MONITOR_FORCE_BUILD=1 catalyst-monitor restart`.

## Test plan

- [x] Tests 1–6 (CTL-1088 regression): all still pass
- [x] Test 7: SHA advance → rebuild triggered, `.source-sha` updated
- [x] Test 8: SHA unchanged → rebuild skipped
- [x] Test 9: first start records `.source-sha`
- [x] Test 10: failed build does NOT advance `.source-sha` (retry preserved)
- [x] Test 11: empty git SHA → falls back to `index.html`-only guard (no spurious rebuild)
- [x] Test 12: empty git SHA on first start → build still triggered
- [x] `bash -n` syntax check passes
- [x] Full suite: **21 passed, 0 failed**

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1118

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1077
skip CTL-1088
