### PR TITLE
fix(dev): CTL-1111 — _find_layer2_config drift warning + phase skill stderr pass-through

### DIFF
--- a/plugins/dev/scripts/__tests__/linear-comment-post.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-comment-post.test.sh
@@ -264,6 +264,69 @@ else
   FAIL=$((FAIL+1))
 fi
 
+# --- Test 13 (CTL-1111): projectKey-absent path emits a loud warning AND still
+#     posts via branch 1 (global bot.worker). The warning must name the missing
+#     projectKey and go to stderr; it must NOT corrupt the resolved path. ---
+NOKEY_HOME="${TMPDIR_TEST}/home-nokey"
+mkdir -p "${NOKEY_HOME}/.config/catalyst" "${NOKEY_HOME}/work/sub"
+# Global config carries bot.worker so the post still succeeds (branch 1 wins).
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":{"clientId":"nk-cid","clientSecret":"nk-csec"}}}}}' \
+  >"${NOKEY_HOME}/.config/catalyst/config.json"
+unset CATALYST_LINEAR_AGENT_CLIENT_ID CATALYST_LINEAR_AGENT_CLIENT_SECRET 2>/dev/null || true
+# Reinstate success curl stub for this test.
+cat >"${BIN_DIR}/curl" <<'CURLEOF'
+#!/usr/bin/env bash
+ARGS_STR="$*"
+if printf '%s' "$ARGS_STR" | grep -q "oauth/token"; then
+  printf '{"access_token":"test_token","token_type":"Bearer"}'
+elif printf '%s' "$ARGS_STR" | grep -q "commentCreate"; then
+  printf '{"data":{"commentCreate":{"success":true}}}'
+else
+  printf '{"data":{"issues":{"nodes":[{"id":"issue-uuid-123"}]}}}'
+fi
+exit 0
+CURLEOF
+chmod +x "${BIN_DIR}/curl"
+NK_STDERR="$(PATH="${BIN_DIR}:$PATH" env HOME="${NOKEY_HOME}" \
+  bash -c "cd '${NOKEY_HOME}/work/sub' && bash '$HELPER' CTL-550 body" 2>&1 1>/dev/null || true)"
+NK_EXIT=0
+PATH="${BIN_DIR}:$PATH" env HOME="${NOKEY_HOME}" \
+  bash -c "cd '${NOKEY_HOME}/work/sub' && bash '$HELPER' CTL-550 body" >/dev/null 2>/dev/null || NK_EXIT=$?
+if printf '%s' "$NK_STDERR" | grep -qi "no projectKey"; then
+  echo "PASS: projectKey-absent path emits a loud warning naming the missing key"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: projectKey-absent path emitted no warning (stderr: ${NK_STDERR})"
+  FAIL=$((FAIL+1))
+fi
+if [[ "$NK_EXIT" -eq 0 ]]; then
+  echo "PASS: projectKey-absent path still posts via global bot.worker (back-compat)"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: projectKey-absent path broke back-compat post (exit $NK_EXIT)"
+  FAIL=$((FAIL+1))
+fi
+
+# --- Test 14 (CTL-1111): projectKey-PRESENT path must NOT emit the drift warning
+#     (guards against the warning over-firing on correctly-configured worktrees). ---
+HASKEY_HOME="${TMPDIR_TEST}/home-haskey"
+mkdir -p "${HASKEY_HOME}/.config/catalyst" "${HASKEY_HOME}/repo/.catalyst"
+printf '%s' '{"catalyst":{"linear":{"bot":{"orchestrator":{"clientId":"orch-only"}}}}}' \
+  >"${HASKEY_HOME}/.config/catalyst/config.json"
+printf '%s' '{"catalyst":{"linear":{"agent":{"clientId":"hk-cid","clientSecret":"hk-csec"}}}}' \
+  >"${HASKEY_HOME}/.config/catalyst/config-catalyst-workspace.json"
+printf '%s' '{"catalyst":{"projectKey":"catalyst-workspace"}}' \
+  >"${HASKEY_HOME}/repo/.catalyst/config.json"
+HK_STDERR="$(PATH="${BIN_DIR}:$PATH" env HOME="${HASKEY_HOME}" \
+  bash -c "cd '${HASKEY_HOME}/repo' && bash '$HELPER' CTL-550 body" 2>&1 1>/dev/null || true)"
+if printf '%s' "$HK_STDERR" | grep -qi "no projectKey"; then
+  echo "FAIL: drift warning over-fired on a projectKey-present worktree (stderr: ${HK_STDERR})"
+  FAIL=$((FAIL+1))
+else
+  echo "PASS: no drift warning when projectKey resolves correctly"
+  PASS=$((PASS+1))
+fi
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [[ "$FAIL" -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/phase-skill-stderr-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-skill-stderr-guard.test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# phase-skill-stderr-guard.test.sh — CTL-1111 regression guard.
+# Asserts no phase skill swallows the linear-comment-post helper's stderr on its
+# comment-post invocation (the `>/dev/null 2>&1` pattern that hid the 2026-06-13 P1).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILLS_DIR="$(cd "${SCRIPT_DIR}/../../skills" && pwd)"
+PASS=0
+FAIL=0
+
+# Match a comment-post invocation line (the helper called with TICKET + a *BODY var)
+# that still redirects stderr to /dev/null.
+OFFENDERS="$(grep -rnE 'COMMENT_POST" "\$\{TICKET\}" "\$\{(MIRROR_BODY|COMMENT_BODY)\}".*2>&1' \
+  "${SKILLS_DIR}"/phase-*/SKILL.md 2>/dev/null || true)"
+
+if [[ -z "$OFFENDERS" ]]; then
+  echo "PASS: no phase skill swallows linear-comment-post stderr (no >/dev/null 2>&1 on invocation)"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: phase skill(s) still swallow comment-post stderr:"
+  printf '%s\n' "$OFFENDERS"
+  FAIL=$((FAIL+1))
+fi
+
+# Sanity: each phase skill that posts a mirror still discards stdout (>/dev/null
+# present on the invocation) so success stays quiet.
+DISCARD_COUNT="$(grep -rlE 'COMMENT_POST" "\$\{TICKET\}" "\$\{(MIRROR_BODY|COMMENT_BODY)\}".*>/dev/null' \
+  "${SKILLS_DIR}"/phase-*/SKILL.md 2>/dev/null | wc -l | tr -d ' ')"
+if [[ "$DISCARD_COUNT" -ge 11 ]]; then
+  echo "PASS: all 11 phase skills still discard comment-post stdout"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: expected >=11 skills discarding stdout, found ${DISCARD_COUNT}"
+  FAIL=$((FAIL+1))
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[[ "$FAIL" -eq 0 ]]

--- a/plugins/dev/scripts/lib/linear-comment-post.sh
+++ b/plugins/dev/scripts/lib/linear-comment-post.sh
@@ -42,6 +42,12 @@ _find_layer2_config() {
     fi
     dir="$(dirname "$dir")"
   done
+  # CTL-1111: no projectKey found anywhere in the ancestry. Make the drift LOUD
+  # instead of silently aliasing to the global config — name what's missing so an
+  # operator can see why the per-team config-<key>.json was not consulted. Still
+  # return the global path so branch 1 (global bot.worker) back-compat keeps
+  # working. Warning goes to stderr; stdout remains the resolved path.
+  echo "linear-comment-post: no projectKey in any .catalyst/config.json from $PWD upward — per-team config-<key>.json NOT resolved; falling back to global config.json" >&2
   echo "$HOME/.config/catalyst/config.json"
 }
 

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -286,7 +286,7 @@ _... (truncated)_"
   fi
   COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
   if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
-  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
     echo "phase-implement: linear-comment-post failed (continuing)" >&2

--- a/plugins/dev/skills/phase-monitor-deploy/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-deploy/SKILL.md
@@ -316,7 +316,7 @@ ${MIRROR_FOOTER}"
   "${__PM_REPO_ROOT}/plugins/dev/scripts/lib/cluster-fence-guard.sh" --phase "${CATALYST_PHASE:-monitor-deploy}" --ticket "$TICKET" || exit 10
   COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
   if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
-  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
     echo "phase-monitor-deploy: linear-comment-post failed (continuing)" >&2

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -326,7 +326,7 @@ _... (truncated)_"
   fi
   COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
   if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
-  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
     echo "phase-monitor-merge: linear-comment-post failed (continuing)" >&2

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -215,7 +215,7 @@ EOF
 ${MIRROR_FOOTER}"
   COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
   if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
-  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
     echo "phase-plan: linear-comment-post failed (continuing)" >&2

--- a/plugins/dev/skills/phase-pr/SKILL.md
+++ b/plugins/dev/skills/phase-pr/SKILL.md
@@ -355,7 +355,7 @@ _... (truncated)_"
   fi
   COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
   if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
-  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
     echo "phase-pr: linear-comment-post failed (continuing)" >&2

--- a/plugins/dev/skills/phase-remediate/SKILL.md
+++ b/plugins/dev/skills/phase-remediate/SKILL.md
@@ -276,7 +276,7 @@ _... (truncated)_"
   fi
   COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
   if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
-  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
     echo "phase-remediate: linear-comment-post failed (continuing)" >&2

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -236,7 +236,7 @@ EOF
 ${MIRROR_FOOTER}"
   COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
   if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
-  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
     echo "phase-research: linear-comment-post failed (continuing)" >&2

--- a/plugins/dev/skills/phase-review/SKILL.md
+++ b/plugins/dev/skills/phase-review/SKILL.md
@@ -281,7 +281,7 @@ _... (truncated)_"
   fi
   COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
   if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
-  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
     echo "phase-review: linear-comment-post failed (continuing)" >&2

--- a/plugins/dev/skills/phase-teardown/SKILL.md
+++ b/plugins/dev/skills/phase-teardown/SKILL.md
@@ -318,7 +318,7 @@ ${MIRROR_FOOTER}"
     COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"
   fi
   if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && \
-     "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
+     "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
     echo "phase-teardown: linear-comment-post failed (continuing)" >&2

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -276,7 +276,7 @@ fi
 "${__PT_REPO_ROOT}/plugins/dev/scripts/lib/cluster-fence-guard.sh" --phase "${CATALYST_PHASE:-triage}" --ticket "$TICKET" || exit 10
 __PT_COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${__PT_REPO_ROOT}/plugins/dev/scripts/lib/linear-comment-post.sh}"
 if [[ ! -x "$__PT_COMMENT_POST" ]]; then __PT_COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
-if [[ -n "$__PT_COMMENT_POST" && -x "$__PT_COMMENT_POST" ]] && "$__PT_COMMENT_POST" "${TICKET}" "${COMMENT_BODY}" >/dev/null 2>&1; then
+if [[ -n "$__PT_COMMENT_POST" && -x "$__PT_COMMENT_POST" ]] && "$__PT_COMMENT_POST" "${TICKET}" "${COMMENT_BODY}" >/dev/null; then
   true
 else
   echo "phase-triage: linear-comment-post failed (continuing)" >&2

--- a/plugins/dev/skills/phase-verify/SKILL.md
+++ b/plugins/dev/skills/phase-verify/SKILL.md
@@ -342,7 +342,7 @@ _... (truncated)_"
   fi
   COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
   if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
-  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1; then
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null; then
     : > "${LINEAR_MIRROR_MARKER}"
   else
     echo "phase-verify: linear-comment-post failed (continuing)" >&2


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-14T00:43:00Z -->
<!-- Last updated: 2026-06-14T00:43:00Z -->
<!-- PR: #1969 -->
<!-- Previous commits: 2da8d90aaa7075640275c8d28c991b734b29e82c -->

## Summary

Fixes two latent defects in the Linear mirror comment system that made comment-post failures silent and hard to diagnose — the root cause of the 2026-06-13 P1 incident where phase workers were silently dropping Linear mirror comments.

**Defect 1 — `_find_layer2_config` silent wrong-config fallback:** When a worktree's `.catalyst/config.json` has no `projectKey`, `_find_layer2_config()` was silently returning the global `~/.config/catalyst/config.json` instead of the per-team `config-<projectKey>.json`. This caused the wrong credentials to be loaded, failing the comment post with no diagnostic. Now emits a loud, named stderr warning identifying the missing key while preserving the back-compat global fallback.

**Defect 2 — stderr swallow across all 11 phase skills:** Every phase skill's comment-post block ran the helper with `>/dev/null 2>&1`, discarding CTL-835's specific diagnostic line (`invalid_scope`, `mint failure`, `wrong-config`, etc.). The `2>&1` is dropped from all 11 invocations so diagnostics surface in the phase log.

## Changes Made

### `plugins/dev/scripts/lib/linear-comment-post.sh`

- `_find_layer2_config()`: Added a loud `stderr` warning when `projectKey` is absent from the entire `.catalyst/config.json` ancestry. Names the missing key and the current `$PWD` so operators can identify the drift at a glance. Back-compat chain (global `config.json` fallback) unchanged.

### Phase skill SKILL.md files (11 files)

Removed `2>&1` from the `"$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null 2>&1` invocation across all phase skills:

- `phase-implement`, `phase-monitor-deploy`, `phase-monitor-merge`, `phase-plan`
- `phase-pr`, `phase-remediate`, `phase-research`, `phase-review`
- `phase-teardown`, `phase-triage`, `phase-verify`

Stdout is still discarded (`>/dev/null` remains) so success is quiet. Stderr now flows through to the phase log.

### Tests

- **`plugins/dev/scripts/__tests__/linear-comment-post.test.sh`** — Tests 13–14 added:
  - Test 13: projectKey-absent path emits a warning naming the missing key AND still posts via global `bot.worker` back-compat.
  - Test 14: projectKey-present path does NOT emit the drift warning (guards against over-firing).
- **`plugins/dev/scripts/__tests__/phase-skill-stderr-guard.test.sh`** — New regression guard that asserts no phase skill can re-introduce the `>/dev/null 2>&1` swallow on the comment-post invocation.

## How to Verify It

- [x] `bash plugins/dev/scripts/__tests__/linear-comment-post.test.sh` — all 14 tests pass
- [x] `bash plugins/dev/scripts/__tests__/phase-skill-stderr-guard.test.sh` — regression guard passes (0 offenders)
- [ ] Trigger a phase worker run on a worktree with a missing `projectKey` — verify `linear-comment-post: no projectKey in any .catalyst/config.json` appears in the phase log
- [ ] Trigger a failing comment-post scenario — verify the specific error code (`invalid_scope`/`mint`/`wrong-config`) appears in the phase log rather than being swallowed

## Related Issues

- Fixes https://linear.app/coalesce/issue/CTL-1111

Refs: CTL-1111
