### PR TITLE
feat(dev): CTL-1103 — Governance Rulebook textbook surface

### DIFF
--- a/plugins/dev/scripts/execution-core/beliefs/compiler/annotations.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/compiler/annotations.mjs
@@ -20,7 +20,7 @@
  * parseAnnotations(ruleBlock) — parse annotation tags from a rule/extern block string.
  *
  * @param {string} ruleBlock — text of a single rule or extern block
- * @returns {{ feeds:string[], cfg:string[], severity:string, since:string, ticket:string, examples:Array }}
+ * @returns {{ feeds:string[], cfg:string[], severity:string, since:string, ticket:string, description:string, examples:Array }}
  */
 export function parseAnnotations(ruleBlock) {
   const feeds = [];
@@ -28,6 +28,7 @@ export function parseAnnotations(ruleBlock) {
   let severity = "";
   let since = "";
   let ticket = "";
+  let description = "";
   const examples = [];
 
   // Split into lines for easier processing
@@ -52,6 +53,9 @@ export function parseAnnotations(ruleBlock) {
     } else if (line.startsWith("@ticket ")) {
       ticket = line.slice("@ticket ".length).trim();
       i++;
+    } else if (line.startsWith("@description ")) {
+      description = line.slice("@description ".length).trim();
+      i++;
     } else if (line === "@example") {
       // Collect all lines until the next @-tag at the start of a trimmed line
       i++;
@@ -69,7 +73,7 @@ export function parseAnnotations(ruleBlock) {
     }
   }
 
-  return { feeds, cfg, severity, since, ticket, examples };
+  return { feeds, cfg, severity, since, ticket, description, examples };
 }
 
 /**

--- a/plugins/dev/scripts/execution-core/beliefs/compiler/annotations.test.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/compiler/annotations.test.mjs
@@ -1,0 +1,36 @@
+// annotations.test.mjs — CTL-1103 Phase 1
+// Unit tests for @description annotation parsing.
+
+import { describe, it, expect } from "bun:test";
+import { parseAnnotations } from "./annotations.mjs";
+
+describe("parseAnnotations — @description (CTL-1103)", () => {
+  it("parses a single-line @description value", () => {
+    const block = `rule R1 session_registered
+@description The signal's bg job appears in the agents listing — the session is registered.
+@severity info`;
+    const result = parseAnnotations(block);
+    expect(result.description).toBe(
+      "The signal's bg job appears in the agents listing — the session is registered.",
+    );
+  });
+
+  it("absent @description yields empty string (back-compat)", () => {
+    const block = `rule R2 turn_started\n@severity info`;
+    const result = parseAnnotations(block);
+    expect(result.description).toBe("");
+  });
+
+  it("last-wins when @description appears more than once", () => {
+    const block = `rule R1 x\n@description first\n@description second`;
+    expect(parseAnnotations(block).description).toBe("second");
+  });
+
+  it("@description does not affect other fields", () => {
+    const block = `rule R1 x\n@description Some text.\n@severity warn\n@feeds R10`;
+    const result = parseAnnotations(block);
+    expect(result.severity).toBe("warn");
+    expect(result.feeds).toEqual(["R10"]);
+    expect(result.description).toBe("Some text.");
+  });
+});

--- a/plugins/dev/scripts/execution-core/beliefs/compiler/manifest.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/compiler/manifest.mjs
@@ -3,12 +3,14 @@
 //
 // RULE_MANIFEST shape:
 // {
+//   preface: {problem: string, datalog_primer: string},
 //   strata: [{id:1, label:'S1 ground correlations', prose:'...'},...],  // 6 entries
 //   rules: [{
 //     rule_id: string,       // 'R1', 'R10' (merged R10a+R10b)
 //     name: string,
 //     stratum: number,
 //     extern: boolean,       // true for R3/R8/R13/R14/R15/R16/R17
+//     description: string,   // plain-English explanation (@description annotation)
 //     feeds: string[],       // @feeds annotation
 //     reads: string[],       // derived from SQL: belief table names
 //     negates: string[],     // derived: belief names under NOT EXISTS
@@ -42,6 +44,31 @@ const STRATA_META = [
   { id: 5, label: "S5 recursive dependency beliefs",  prose: "Transitive blocker closure (WITH RECURSIVE); derive blocker_rank, cycle_detected, and ready." },
   { id: 6, label: "S6 FSM advancement prediction",    prose: "Derive advance_to and cycle_exhausted from obs_signal/obs_verdict/obs_cycle; no negation over beliefs." },
 ];
+
+const PREFACE = Object.freeze({
+  problem:
+    "The daemon must decide — continuously, automatically, and auditably — which workers are " +
+    "alive, which are wedged, which should be retried, and which require human attention. " +
+    "A simple 'is the process running?' check is insufficient: a process can be running but " +
+    "making no progress (stalled-alive), or registered but never started a turn (never-started " +
+    "wedge), or producing output but on a board state that disagrees with Linear (board drift). " +
+    "The belief engine encodes these distinctions as a stratified rule set — 17 rules across " +
+    "6 strata — where each rule derives a named belief from observed facts. Every conclusion is " +
+    "inspectable: the derivation tree traces exactly which facts triggered which rule, making " +
+    "the system's reasoning legible to the operators who must trust it.",
+  datalog_primer:
+    "Datalog is a logic programming language where rules derive new facts from existing ones. " +
+    "A rule has the form: conclusion :- premise1, premise2, ... (read: conclusion holds if all " +
+    "premises hold). The belief engine organises its rules into strata — layers where each " +
+    "stratum's rules may only read beliefs produced by earlier strata. This stratification " +
+    "makes negation safe: a rule can say 'not lease_valid' only after all lease_valid beliefs " +
+    "have been fully computed (stratum 2 reads stratum 1). Each rule compiles to one or more " +
+    "SQL INSERT statements that are executed in stratum order; the belief table accumulates " +
+    "conclusions. Extern rules embed hand-authored SQL (for aggregates and WITH RECURSIVE " +
+    "queries that the compiler cannot generate); rule blocks use a higher-level Datalog syntax " +
+    "that the compiler translates to SQL automatically.",
+});
+
 
 /**
  * Extract belief names read (joined) in the SQL.
@@ -118,7 +145,7 @@ function extractAnnotations(source, ruleId) {
   // Find the block for this rule (up to the next rule/extern keyword)
   const startPattern = new RegExp(`\\b(?:rule|extern)\\s+${ruleId}\\b`);
   const startMatch = startPattern.exec(source);
-  if (!startMatch) return { feeds: [], cfg: [], severity: "", since: "", ticket: "", examples: [] };
+  if (!startMatch) return { feeds: [], cfg: [], severity: "", since: "", ticket: "", description: "", examples: [] };
 
   const startIdx = startMatch.index;
   // Find end: next rule/extern declaration
@@ -184,6 +211,7 @@ export function buildManifest(ir, dlSource) {
         if (!annot.severity && extraAnnot.severity) annot.severity = extraAnnot.severity;
         if (!annot.since && extraAnnot.since) annot.since = extraAnnot.since;
         if (!annot.ticket && extraAnnot.ticket) annot.ticket = extraAnnot.ticket;
+        if (!annot.description && extraAnnot.description) annot.description = extraAnnot.description;
         annot.examples.push(...extraAnnot.examples);
       }
     }
@@ -206,6 +234,7 @@ export function buildManifest(ir, dlSource) {
       name: firstIr.name,
       stratum: firstIr.stratum,
       extern: isExtern,
+      description: annot.description ?? "",
       feeds: Object.freeze(annot.feeds),
       reads: Object.freeze(reads),
       negates: Object.freeze(negates),
@@ -220,6 +249,7 @@ export function buildManifest(ir, dlSource) {
   }
 
   const manifest = Object.freeze({
+    preface: PREFACE,
     strata: Object.freeze(STRATA_META.map(s => Object.freeze({ ...s }))),
     rules: Object.freeze(rules),
   });

--- a/plugins/dev/scripts/execution-core/beliefs/rules.dl
+++ b/plugins/dev/scripts/execution-core/beliefs/rules.dl
@@ -2,6 +2,7 @@
 
 extern R3 progress_evidence
 stratum 1
+@description The most recent positive evidence of work, taken as the max over heartbeat, transcript, and signal timestamps.
 @feeds R5
 @feeds R6
 @severity info
@@ -42,6 +43,7 @@ GROUP BY e.subject"""
 
 rule R1 session_registered
 stratum 1
+@description The signal's background job shows up in the live agents listing — the session is registered.
 @severity info
 @since 2026-06-09
 @ticket CTL-933
@@ -61,6 +63,7 @@ value: json_object('session_id', a.session_id, 'short_id', a.short_id)
 
 rule R2 turn_started
 stratum 1
+@description The session has produced a transcript, so its prompt actually became a running turn.
 @feeds R4
 @severity info
 @since 2026-06-09
@@ -76,6 +79,7 @@ value: json_object('session_id', a.session_id, 'bytes', tr.bytes)
 
 extern R7 worker_dead
 stratum 1
+@description Claude's own durable verdict that the worker is dead — the job is gone or in a terminal state.
 @feeds R4
 @feeds R5
 @feeds R6
@@ -104,6 +108,7 @@ WHERE t.tick_id = :tick
 
 rule R4 wedged_never_started
 stratum 2
+@description A running phase whose session registered but never started a turn within never_started_ms — a never-started wedge.
 @feeds R10
 @cfg never_started_ms
 @severity warn
@@ -130,6 +135,7 @@ subject: s.ticket || '/' || s.phase
 
 extern R5 lease_valid
 stratum 2
+@description The phase has progress evidence inside its freshness window, so its lease is still valid.
 @feeds R6
 @cfg lease_window_doc_ms
 @cfg lease_window_build_ms
@@ -156,6 +162,7 @@ WHERE t.tick_id = :tick
 
 extern R6 lease_expired
 stratum 2
+@description A running phase with no valid lease and not dead — its lease has expired (stalled-alive).
 @feeds R10
 @severity warn
 @since 2026-06-09
@@ -174,6 +181,7 @@ WHERE t.tick_id = :tick
 
 extern R9 board_drift
 stratum 2
+@description The Linear board state disagrees with what the running phase is actually doing — board drift.
 @severity warn
 @since 2026-06-09
 @ticket CTL-933
@@ -204,6 +212,7 @@ WHERE t.tick_id = :tick
 
 extern R8 free_slots
 stratum 3
+@description Free capacity for a host: parallel slots and session slots not currently consumed by valid leases.
 @cfg max_parallel
 @cfg session_cap
 @severity info
@@ -239,6 +248,7 @@ WHERE t.tick_id = :tick"""
 
 extern R10a wake_diagnostician
 stratum 4
+@description Wake the diagnostician for a never-started wedge (no cooldown intent in the window).
 @feeds R11
 @feeds R12
 @cfg diag_cooldown_ms
@@ -261,6 +271,7 @@ WHERE t.tick_id = :tick
 
 extern R10b wake_diagnostician_stalled_alive
 stratum 4
+@description Wake the diagnostician for a stalled-alive phase whose job is still in the working state.
 @feeds R11
 @feeds R12
 @cfg diag_cooldown_ms
@@ -288,6 +299,7 @@ WHERE t.tick_id = :tick
 
 extern R11 action_ineffective
 stratum 4
+@description An intent has exhausted its max_attempts with no outcome — the action proved ineffective.
 @feeds R12
 @cfg max_attempts
 @severity warn
@@ -305,6 +317,7 @@ WHERE t.tick_id = :tick"""
 
 extern R12 escalate_human
 stratum 4
+@description The diagnostician was woken and the action was ineffective, so the work escalates to a human.
 @severity error
 @since 2026-06-09
 @ticket CTL-933
@@ -323,6 +336,7 @@ WHERE t.tick_id = :tick"""
 
 extern R13 blocker_rank
 stratum 5
+@description A ticket's transitive blocker count, computed over the full dependency closure.
 @severity info
 @since 2026-06-09
 @ticket CTL-965
@@ -359,6 +373,7 @@ GROUP BY cl.dependent"""
 
 extern R14 cycle_detected
 stratum 5
+@description A dependency cycle exists (A blocks B blocks A) in the relations graph.
 @severity error
 @since 2026-06-09
 @ticket CTL-965
@@ -401,6 +416,7 @@ FROM self_cycle sc"""
 
 extern R15 ready
 stratum 5
+@description A ticket is in an eligible state with every blocker done — it is ready to start.
 @cfg eligible_state
 @severity info
 @since 2026-06-09
@@ -441,6 +457,7 @@ WHERE t.tick_id = :tick
 
 extern R16 advance_to
 stratum 6
+@description The predicted next phase: the normal FSM edge, or the verify-to-remediate detour when verification fails.
 @severity info
 @since 2026-06-09
 @ticket CTL-966
@@ -518,6 +535,7 @@ SELECT ls.tick_id, 6, 'advance_to', ls.ticket,
 
 extern R17 cycle_exhausted
 stratum 6
+@description The remediate count has reached its cap — no more retries; the cycle is exhausted.
 @severity error
 @since 2026-06-09
 @ticket CTL-966

--- a/plugins/dev/scripts/execution-core/beliefs/rules.generated.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/rules.generated.mjs
@@ -446,7 +446,7 @@ SELECT ls.tick_id, 6, 'cycle_exhausted', ls.ticket,
    AND COALESCE((SELECT c.remediate_count FROM obs_cycle c
                   WHERE c.tick_id = ls.tick_id AND c.ticket = ls.ticket LIMIT 1), 0) >= 3`;
 
-export const RULES_SHA = '9b408c424db45681';
+export const RULES_SHA = '68a5a8dbeb2f54da';
 
 
 // Deep-freeze helper for RULE_MANIFEST (CTL-1063 Phase 5).
@@ -458,6 +458,10 @@ function _deepFreeze(o) {
 }
 
 export const RULE_MANIFEST = _deepFreeze({
+  "preface": {
+    "problem": "The daemon must decide — continuously, automatically, and auditably — which workers are alive, which are wedged, which should be retried, and which require human attention. A simple 'is the process running?' check is insufficient: a process can be running but making no progress (stalled-alive), or registered but never started a turn (never-started wedge), or producing output but on a board state that disagrees with Linear (board drift). The belief engine encodes these distinctions as a stratified rule set — 17 rules across 6 strata — where each rule derives a named belief from observed facts. Every conclusion is inspectable: the derivation tree traces exactly which facts triggered which rule, making the system's reasoning legible to the operators who must trust it.",
+    "datalog_primer": "Datalog is a logic programming language where rules derive new facts from existing ones. A rule has the form: conclusion :- premise1, premise2, ... (read: conclusion holds if all premises hold). The belief engine organises its rules into strata — layers where each stratum's rules may only read beliefs produced by earlier strata. This stratification makes negation safe: a rule can say 'not lease_valid' only after all lease_valid beliefs have been fully computed (stratum 2 reads stratum 1). Each rule compiles to one or more SQL INSERT statements that are executed in stratum order; the belief table accumulates conclusions. Extern rules embed hand-authored SQL (for aggregates and WITH RECURSIVE queries that the compiler cannot generate); rule blocks use a higher-level Datalog syntax that the compiler translates to SQL automatically."
+  },
   "strata": [
     {
       "id": 1,
@@ -496,6 +500,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "session_registered",
       "stratum": 1,
       "extern": false,
+      "description": "The signal's background job shows up in the live agents listing — the session is registered.",
       "feeds": [],
       "reads": [],
       "negates": [],
@@ -505,7 +510,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-933",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 43
+        "line": 44
       },
       "arms": [
         {
@@ -550,6 +555,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "turn_started",
       "stratum": 1,
       "extern": false,
+      "description": "The session has produced a transcript, so its prompt actually became a running turn.",
       "feeds": [
         "R4"
       ],
@@ -561,7 +567,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-933",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 62
+        "line": 64
       },
       "arms": [
         {
@@ -577,6 +583,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "wedged_never_started",
       "stratum": 2,
       "extern": false,
+      "description": "A running phase whose session registered but never started a turn within never_started_ms — a never-started wedge.",
       "feeds": [
         "R10"
       ],
@@ -597,7 +604,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-933",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 105
+        "line": 109
       },
       "arms": [
         {
@@ -649,6 +656,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "progress_evidence",
       "stratum": 1,
       "extern": true,
+      "description": "The most recent positive evidence of work, taken as the max over heartbeat, transcript, and signal timestamps.",
       "feeds": [
         "R5",
         "R6"
@@ -677,6 +685,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "worker_dead",
       "stratum": 1,
       "extern": true,
+      "description": "Claude's own durable verdict that the worker is dead — the job is gone or in a terminal state.",
       "feeds": [
         "R4",
         "R5",
@@ -690,7 +699,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-933",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 77
+        "line": 80
       },
       "arms": [
         {
@@ -706,6 +715,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "lease_valid",
       "stratum": 2,
       "extern": true,
+      "description": "The phase has progress evidence inside its freshness window, so its lease is still valid.",
       "feeds": [
         "R6"
       ],
@@ -725,7 +735,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-933",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 131
+        "line": 136
       },
       "arms": [
         {
@@ -741,6 +751,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "lease_expired",
       "stratum": 2,
       "extern": true,
+      "description": "A running phase with no valid lease and not dead — its lease has expired (stalled-alive).",
       "feeds": [
         "R10"
       ],
@@ -758,7 +769,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-933",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 157
+        "line": 163
       },
       "arms": [
         {
@@ -774,6 +785,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "board_drift",
       "stratum": 2,
       "extern": true,
+      "description": "The Linear board state disagrees with what the running phase is actually doing — board drift.",
       "feeds": [],
       "reads": [],
       "negates": [],
@@ -783,7 +795,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-933",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 175
+        "line": 182
       },
       "arms": [
         {
@@ -799,6 +811,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "free_slots",
       "stratum": 3,
       "extern": true,
+      "description": "Free capacity for a host: parallel slots and session slots not currently consumed by valid leases.",
       "feeds": [],
       "reads": [],
       "negates": [],
@@ -811,7 +824,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-933",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 205
+        "line": 213
       },
       "arms": [
         {
@@ -827,6 +840,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "wake_diagnostician",
       "stratum": 4,
       "extern": true,
+      "description": "Wake the diagnostician for a never-started wedge (no cooldown intent in the window).",
       "feeds": [
         "R11",
         "R12"
@@ -847,7 +861,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-933",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 240
+        "line": 249
       },
       "arms": [
         {
@@ -868,6 +882,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "action_ineffective",
       "stratum": 4,
       "extern": true,
+      "description": "An intent has exhausted its max_attempts with no outcome — the action proved ineffective.",
       "feeds": [
         "R12"
       ],
@@ -881,7 +896,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-933",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 289
+        "line": 300
       },
       "arms": [
         {
@@ -897,6 +912,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "escalate_human",
       "stratum": 4,
       "extern": true,
+      "description": "The diagnostician was woken and the action was ineffective, so the work escalates to a human.",
       "feeds": [],
       "reads": [
         "wake_diagnostician",
@@ -909,7 +925,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-933",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 306
+        "line": 318
       },
       "arms": [
         {
@@ -925,6 +941,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "blocker_rank",
       "stratum": 5,
       "extern": true,
+      "description": "A ticket's transitive blocker count, computed over the full dependency closure.",
       "feeds": [],
       "reads": [],
       "negates": [],
@@ -934,7 +951,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-965",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 324
+        "line": 337
       },
       "arms": [
         {
@@ -950,6 +967,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "cycle_detected",
       "stratum": 5,
       "extern": true,
+      "description": "A dependency cycle exists (A blocks B blocks A) in the relations graph.",
       "feeds": [],
       "reads": [],
       "negates": [],
@@ -959,7 +977,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-965",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 360
+        "line": 374
       },
       "arms": [
         {
@@ -975,6 +993,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "ready",
       "stratum": 5,
       "extern": true,
+      "description": "A ticket is in an eligible state with every blocker done — it is ready to start.",
       "feeds": [],
       "reads": [],
       "negates": [],
@@ -986,7 +1005,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-965",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 402
+        "line": 417
       },
       "arms": [
         {
@@ -1002,6 +1021,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "advance_to",
       "stratum": 6,
       "extern": true,
+      "description": "The predicted next phase: the normal FSM edge, or the verify-to-remediate detour when verification fails.",
       "feeds": [],
       "reads": [],
       "negates": [],
@@ -1011,7 +1031,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-966",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 442
+        "line": 458
       },
       "arms": [
         {
@@ -1027,6 +1047,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "name": "cycle_exhausted",
       "stratum": 6,
       "extern": true,
+      "description": "The remediate count has reached its cap — no more retries; the cycle is exhausted.",
       "feeds": [],
       "reads": [],
       "negates": [],
@@ -1036,7 +1057,7 @@ export const RULE_MANIFEST = _deepFreeze({
       "ticket": "CTL-966",
       "src": {
         "file": "beliefs/rules.dl",
-        "line": 519
+        "line": 536
       },
       "arms": [
         {

--- a/plugins/dev/scripts/orch-monitor/__tests__/app-shell.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/app-shell.test.ts
@@ -303,6 +303,7 @@ test("SURFACES round-trips the Surface union", () => {
     finops: false,
     fleetops: false,
     devops: false,
+    rulebook: false,
   };
   for (const s of SURFACES) seen[s] = true;
   expect(Object.values(seen).every(Boolean)).toBe(true);

--- a/plugins/dev/scripts/orch-monitor/__tests__/app-shell.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/app-shell.test.ts
@@ -52,6 +52,7 @@ describe("surface contract (CTL-891)", () => {
   it("declares the OPERATE surfaces then the OBSERVE surfaces in nav order", () => {
     // OBS-5: the five OBSERVE analytics surfaces follow the three OPERATE surfaces.
     // CTL-1016: the queue surface is retired — its control tower folded into Workers.
+    // CTL-1103: rulebook is the first REASON surface, appended last.
     expect([...SURFACES]).toEqual([
       "home",
       "board",
@@ -61,12 +62,14 @@ describe("surface contract (CTL-891)", () => {
       "finops",
       "fleetops",
       "devops",
+      "rulebook",
     ]);
   });
 
-  it("maps a g-chord key to every surface (OPERATE h/b/w + OBSERVE t/u/f/o/d)", () => {
+  it("maps a g-chord key to every surface (OPERATE h/b/w + OBSERVE t/u/f/o/d + REASON r)", () => {
     // OBS-5: OBSERVE chords pick keys that don't collide with h/b/w —
     // t(elemetry) / u(tilization) / f(inops) / o(=fleetOps) / d(evops).
+    // CTL-1103: r(ulebook) is the first REASON chord.
     expect(SURFACE_CHORD).toEqual({
       h: "home",
       b: "board",
@@ -76,6 +79,7 @@ describe("surface contract (CTL-891)", () => {
       f: "finops",
       o: "fleetops",
       d: "devops",
+      r: "rulebook",
     });
     // Every surface is reachable by some chord, and every chord targets a real surface.
     const chordTargets = new Set(Object.values(SURFACE_CHORD));

--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-rules-manifest.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-rules-manifest.contract.test.ts
@@ -90,3 +90,24 @@ describe("GET /api/beliefs/rules — anti-stub guards", () => {
     expect(hasSql).toBe(true);
   });
 });
+
+// ─── 3. Rulebook copy fields (CTL-1103) ─────────────────────────────────────
+
+describe("GET /api/beliefs/rules — Rulebook copy fields (CTL-1103)", () => {
+  it("every rule has a non-empty plain-English description", async () => {
+    const body = await fetchRules() as { rules: Array<{ rule_id: string; description?: string }> };
+    for (const r of body.rules) {
+      expect(typeof r.description, `${r.rule_id} description must be a string`).toBe("string");
+      expect(r.description!.length, `${r.rule_id} description must be non-empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it("manifest carries a top-level preface with problem and datalog_primer", async () => {
+    const body = await fetchRules() as { preface?: { problem?: string; datalog_primer?: string } };
+    expect(body.preface).toBeDefined();
+    expect(typeof body.preface!.problem).toBe("string");
+    expect(body.preface!.problem!.length).toBeGreaterThan(0);
+    expect(typeof body.preface!.datalog_primer).toBe("string");
+    expect(body.preface!.datalog_primer!.length).toBeGreaterThan(0);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -324,6 +324,7 @@ const APP_SURFACE_PATHS: ReadonlySet<string> = new Set([
   "/fleetops",
   "/devops",
   "/settings",
+  "/rules",
 ]);
 export function isAppRoute(pathname: string): boolean {
   if (APP_SURFACE_PATHS.has(pathname)) return true;

--- a/plugins/dev/scripts/orch-monitor/ui/src/app-router.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/app-router.tsx
@@ -248,6 +248,16 @@ const devopsRoute = createRoute({
   ),
 });
 
+const rulebookRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/rules",
+  component: () => (
+    <S>
+      <RulebookSurface />
+    </S>
+  ),
+});
+
 const settingsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/settings",
@@ -310,6 +320,7 @@ const routeTree = rootRoute.addChildren([
   finopsRoute,
   fleetopsRoute,
   devopsRoute,
+  rulebookRoute,
   settingsRoute,
   ticketRoute,
   workerRoute,

--- a/plugins/dev/scripts/orch-monitor/ui/src/app-router.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/app-router.tsx
@@ -90,6 +90,11 @@ const DashboardSurface = lazy(() =>
     default: m.DashboardSurface,
   })),
 );
+const RulebookSurface = lazy(() =>
+  import("./components/rulebook/rulebook-surface").then((m) => ({
+    default: m.RulebookSurface,
+  })),
+);
 
 // ── detail routes (code-split — the entry-split that forced board.html to ship
 //    them eagerly is gone, so split them now to keep the main bundle lean) ─────

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/nav-sections.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/nav-sections.test.ts
@@ -7,7 +7,7 @@
 // Run from the ui package:  `cd ui && bun test src/board/nav-sections.test.ts`.
 import { describe, it, expect, beforeEach } from "bun:test";
 import { createStore } from "jotai";
-import { navOverallOpenAtom, navObserveOpenAtom } from "./nav-store";
+import { navOverallOpenAtom, navObserveOpenAtom, navReasonOpenAtom } from "./nav-store";
 
 // Minimal in-memory localStorage so atomWithStorage's default storage (which
 // reads `window.localStorage`) has a backing store under bun (no `window` in
@@ -106,5 +106,21 @@ describe("CTL-1034 — section collapse persists across reloads", () => {
     const unsub2 = store2.sub(navObserveOpenAtom, () => {});
     expect(store2.get(navObserveOpenAtom)).toBe(true);
     unsub2();
+  });
+});
+
+// ── CTL-1103: Reason sidebar group ──────────────────────────────────────────
+describe("CTL-1103 — Reason section open-state", () => {
+  it("the Reason section defaults OPEN (true)", () => {
+    const store = createStore();
+    expect(store.get(navReasonOpenAtom)).toBe(true);
+  });
+
+  it("collapsing Reason persists to localStorage", () => {
+    const store = createStore();
+    const unsub = store.sub(navReasonOpenAtom, () => {});
+    store.set(navReasonOpenAtom, false);
+    expect(readLs("catalyst-nav-reason-v1")).toBe(JSON.stringify(false));
+    unsub();
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/nav-store.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/nav-store.ts
@@ -88,6 +88,10 @@ export const navObserveOpenAtom = atomWithStorage<boolean>(
   "catalyst-nav-observe-v1",
   true,
 );
+export const navReasonOpenAtom = atomWithStorage<boolean>(
+  "catalyst-nav-reason-v1",
+  true,
+);
 
 // ── list context (the resolved walk list) ───────────────────────────────────
 /**

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useAtom } from "jotai";
 import {
   ActivityIcon,
+  BookOpenIcon,
   ChevronRightIcon,
   CodeIcon,
   GaugeIcon,
@@ -48,6 +49,7 @@ import {
   navGroupsOpenAtom,
   navOverallOpenAtom,
   navObserveOpenAtom,
+  navReasonOpenAtom,
 } from "@/board/nav-store";
 import { useBoardSnapshot } from "@/hooks/use-board-snapshot";
 // CTL-961: per-project icon auto-detection (favicon from GitHub) + manual override.
@@ -191,6 +193,11 @@ const OBSERVE_SOON = [
   { label: "DevOps", icon: CodeIcon },
 ] as const;
 
+// ── REASON items (CTL-1103) ──────────────────────────────────────────────────
+const REASON_LIVE: Array<{ surface: Surface; label: string; icon: typeof InboxIcon }> = [
+  { surface: "rulebook", label: "Rulebook", icon: BookOpenIcon },
+];
+
 // ── OPERATE items per scope ───────────────────────────────────────────────────
 const OPERATE_ITEMS: Array<{ surface: Surface; label: string; icon: typeof InboxIcon }> = [
   { surface: "home", label: "Inbox", icon: InboxIcon },
@@ -247,6 +254,7 @@ export function AppSidebar() {
   // open; a section force-renders open when it contains the active surface.
   const [overallOpen, setOverallOpen] = useAtom(navOverallOpenAtom);
   const [observeOpen, setObserveOpen] = useAtom(navObserveOpenAtom);
+  const [reasonOpen, setReasonOpen] = useAtom(navReasonOpenAtom);
   // CTL-945: consume from AppShell's shared contexts — no new EventSources opened.
   // CTL-896 / SHELL6 — the live nav signal off the read-model SSE projection.
   const nav = useNavSignalContext();
@@ -304,6 +312,9 @@ export function AppSidebar() {
 
   // OBS-5: force the OBSERVE group open while a live OBSERVE surface is active.
   const observeContainsActive = OBSERVE_LIVE.some(
+    (item) => item.surface === surface,
+  );
+  const reasonContainsActive = REASON_LIVE.some(
     (item) => item.surface === surface,
   );
 
@@ -717,6 +728,52 @@ export function AppSidebar() {
                       </SidebarMenuBadge>
                     </SidebarMenuItem>
                   ))}
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </CollapsibleContent>
+          </SidebarGroup>
+        </Collapsible>
+
+        {/* ── REASON group (CTL-1103): Rulebook ──────────────────────────── */}
+        <Collapsible
+          open={reasonOpen || reasonContainsActive}
+          onOpenChange={(open) => {
+            if (!reasonContainsActive) setReasonOpen(open);
+          }}
+          className="group/reason"
+        >
+          <SidebarGroup className="px-1 pt-0">
+            <CollapsibleTrigger className={cn(GROUP_TRIGGER_BASE, "gap-1")}>
+              Reason
+              <ChevronRightIcon className="size-3 flex-shrink-0 transition-transform duration-200 group-data-[state=open]/reason:rotate-90" />
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  {REASON_LIVE.map((item) => {
+                    const active = surface === item.surface;
+                    const reasonKb = surfaceKeybinding(item.surface);
+                    return (
+                      <SidebarMenuItem key={item.surface}>
+                        <SidebarMenuButton
+                          isActive={active}
+                          tooltip={reasonKb ? `${item.label} · ${reasonKb}` : item.label}
+                          onClick={() => go(item.surface)}
+                          data-keybinding={reasonKb || undefined}
+                          className={cn(
+                            active
+                              ? "text-sidebar-primary"
+                              : "font-medium text-sidebar-foreground/72 hover:text-sidebar-foreground",
+                          )}
+                        >
+                          <span className="relative flex shrink-0 items-center justify-center">
+                            <item.icon className="size-4 shrink-0" />
+                          </span>
+                          <span>{item.label}</span>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    );
+                  })}
                 </SidebarMenu>
               </SidebarGroupContent>
             </CollapsibleContent>

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/derivations-rail-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/derivations-rail-model.ts
@@ -1,0 +1,6 @@
+// derivations-rail-model.ts — CTL-1103 Phase 4: pure helper for the rail.
+export function subjectToTicket(subject: string): string | null {
+  if (!subject.includes("/")) return null;
+  const ticket = subject.split("/")[0];
+  return ticket.length > 0 ? ticket : null;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/derivations-rail.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/derivations-rail.test.ts
@@ -1,0 +1,27 @@
+// derivations-rail.test.ts — CTL-1103 Phase 4: pure logic tests for the
+// derivations rail (subject→ticket extraction). No DOM. Run from ui/:
+//   cd ui && bun test src/components/rulebook/derivations-rail.test.ts
+import { describe, it, expect } from "bun:test";
+import { subjectToTicket } from "./derivations-rail-model";
+
+describe("subjectToTicket", () => {
+  it("parses ticket from subject 'CTL-1/plan'", () => {
+    expect(subjectToTicket("CTL-1/plan")).toBe("CTL-1");
+  });
+
+  it("parses ticket from subject 'CTL-999/implement'", () => {
+    expect(subjectToTicket("CTL-999/implement")).toBe("CTL-999");
+  });
+
+  it("returns null for subjects without a slash", () => {
+    expect(subjectToTicket("no-slash")).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(subjectToTicket("")).toBeNull();
+  });
+
+  it("handles multi-segment subjects by returning the ticket part", () => {
+    expect(subjectToTicket("CTL-42/verify/retry")).toBe("CTL-42");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/derivations-rail.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/derivations-rail.tsx
@@ -12,18 +12,80 @@ interface EntityRowProps {
   onOpenSource?: (ruleId: string) => void;
 }
 
+// CTL-1103 remediate: an explicit, discriminated row state. Previously a single
+// `trace: TraceResult | null` conflated three outcomes — (a) a 500/network
+// failure, (b) a genuinely empty trace, and (c) still loading — all rendering
+// the same "Loading…"/"No derivation available." text. In a governance audit
+// tool that falsely implied a firing rule had no traceable cause while masking a
+// real backend error. The states below keep those distinct.
+type RowState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "loaded"; trace: TraceResult };
+
 function EntityRow({ subject, onOpenSource }: EntityRowProps) {
   const [expanded, setExpanded] = useState(false);
-  const [trace, setTrace] = useState<TraceResult | null>(null);
+  const [state, setState] = useState<RowState>({ status: "idle" });
   const ticket = subjectToTicket(subject);
 
   useEffect(() => {
-    if (!expanded || !ticket) return;
-    fetch(`/api/beliefs/why?ticket=${encodeURIComponent(ticket)}`)
-      .then((r) => (r.ok ? (r.json() as Promise<unknown>) : null))
-      .then((d) => setTrace(isTraceResult(d) ? d : emptyTrace(ticket ?? "")))
-      .catch(() => setTrace(emptyTrace(ticket ?? "")));
+    // Reset to loading state on (re)expand so a re-expand never flashes the
+    // previous subject's trace; collapse resets back to idle.
+    if (!expanded || !ticket) {
+      setState({ status: "idle" });
+      return;
+    }
+    const controller = new AbortController();
+    let ignore = false;
+    setState({ status: "loading" });
+    fetch(`/api/beliefs/why?ticket=${encodeURIComponent(ticket)}`, {
+      signal: controller.signal,
+    })
+      .then(async (r) => {
+        if (!r.ok) {
+          throw new Error(`status ${r.status}`);
+        }
+        const d: unknown = await r.json();
+        if (ignore) return;
+        setState(
+          isTraceResult(d)
+            ? { status: "loaded", trace: d }
+            : { status: "loaded", trace: emptyTrace(ticket) },
+        );
+      })
+      .catch((e: unknown) => {
+        // AbortError fires on unmount/collapse — not a real failure to surface.
+        if (ignore || (e instanceof DOMException && e.name === "AbortError")) {
+          return;
+        }
+        setState({
+          status: "error",
+          message: e instanceof Error ? e.message : "request failed",
+        });
+      });
+    return () => {
+      ignore = true;
+      controller.abort();
+    };
   }, [expanded, ticket]);
+
+  // CTL-1103 remediate: a subject with no parseable ticket (no '/') can never be
+  // fetched — the old code left it stuck on a perpetual "Loading…" spinner.
+  // Surface that it is not addressable instead of pretending to load.
+  if (ticket === null) {
+    return (
+      <div className="border-b last:border-0">
+        <div className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs opacity-60">
+          <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+          <span className="font-mono text-xs">{subject}</span>
+          <span className="ml-auto text-[10px] text-muted-foreground">
+            not addressable (no ticket)
+          </span>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="border-b last:border-0">
@@ -41,12 +103,16 @@ function EntityRow({ subject, onOpenSource }: EntityRowProps) {
       </button>
       {expanded && (
         <div className="px-3 pb-2">
-          {trace === null ? (
+          {state.status === "loading" || state.status === "idle" ? (
             <p className="text-xs text-muted-foreground">Loading…</p>
-          ) : trace.beliefs.length === 0 ? (
+          ) : state.status === "error" ? (
+            <p className="text-xs text-destructive">
+              Failed to load derivation ({state.message}).
+            </p>
+          ) : state.trace.beliefs.length === 0 ? (
             <p className="text-xs text-muted-foreground">No derivation available.</p>
           ) : (
-            <DerivationTree trace={trace} onOpenSource={onOpenSource} />
+            <DerivationTree trace={state.trace} onOpenSource={onOpenSource} />
           )}
         </div>
       )}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/derivations-rail.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/derivations-rail.tsx
@@ -1,0 +1,83 @@
+// derivations-rail.tsx — CTL-1103 Phase 4: per-rule entity list + derivation trees.
+// Shown when the operator selects a firing rule. Each entity expands to a
+// /api/beliefs/why trace rendered via <DerivationTree/>.
+import { useEffect, useState } from "react";
+import { DerivationTree } from "@/components/governance/derivation-tree";
+import { type TraceResult, isTraceResult, emptyTrace } from "@/lib/why-model";
+import { subjectToTicket } from "./derivations-rail-model";
+import { ChevronRight, ChevronDown } from "lucide-react";
+
+interface EntityRowProps {
+  subject: string;
+  onOpenSource?: (ruleId: string) => void;
+}
+
+function EntityRow({ subject, onOpenSource }: EntityRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [trace, setTrace] = useState<TraceResult | null>(null);
+  const ticket = subjectToTicket(subject);
+
+  useEffect(() => {
+    if (!expanded || !ticket) return;
+    fetch(`/api/beliefs/why?ticket=${encodeURIComponent(ticket)}`)
+      .then((r) => (r.ok ? (r.json() as Promise<unknown>) : null))
+      .then((d) => setTrace(isTraceResult(d) ? d : emptyTrace(ticket ?? "")))
+      .catch(() => setTrace(emptyTrace(ticket ?? "")));
+  }, [expanded, ticket]);
+
+  return (
+    <div className="border-b last:border-0">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs hover:bg-muted/50 transition-colors"
+        onClick={() => setExpanded((e) => !e)}
+      >
+        {expanded ? (
+          <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+        )}
+        <span className="font-mono text-xs">{subject}</span>
+      </button>
+      {expanded && (
+        <div className="px-3 pb-2">
+          {trace === null ? (
+            <p className="text-xs text-muted-foreground">Loading…</p>
+          ) : trace.beliefs.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No derivation available.</p>
+          ) : (
+            <DerivationTree trace={trace} onOpenSource={onOpenSource} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface DerivationsRailProps {
+  ruleId: string;
+  subjects: string[];
+  onOpenSource?: (ruleId: string) => void;
+}
+
+export function DerivationsRail({ ruleId, subjects, onOpenSource }: DerivationsRailProps) {
+  if (subjects.length === 0) {
+    return (
+      <div className="rounded-lg border bg-card p-4 text-xs text-muted-foreground">
+        <span className="font-mono">{ruleId}</span> — not currently firing.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border bg-card overflow-hidden">
+      <div className="border-b px-3 py-2 text-xs font-medium text-muted-foreground">
+        <span className="font-mono">{ruleId}</span> — {subjects.length} subject
+        {subjects.length !== 1 ? "s" : ""} firing
+      </div>
+      {subjects.map((subject) => (
+        <EntityRow key={subject} subject={subject} onOpenSource={onOpenSource} />
+      ))}
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/live-indicator.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/live-indicator.tsx
@@ -1,0 +1,18 @@
+// live-indicator.tsx — CTL-1103 Phase 4: per-rule firing count badge.
+// Renders nothing (muted) when count is 0 (recording off or rule not firing).
+interface LiveIndicatorProps {
+  count: number;
+}
+
+export function LiveIndicator({ count }: LiveIndicatorProps) {
+  if (count === 0) return null;
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-semibold text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300">
+      <span
+        className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse"
+        aria-hidden
+      />
+      {count}
+    </span>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/live-indicator.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/live-indicator.tsx
@@ -5,24 +5,50 @@ import { liveIndicatorTone } from "@/lib/rulebook-theme";
 
 interface LiveIndicatorProps {
   count: number;
+  // CTL-1103 remediate: when provided, the badge becomes the dedicated
+  // rule-selection affordance (opens the derivations rail). Previously the WHOLE
+  // RuleCard was wrapped in a <button>, which nested the card's own Tabs buttons
+  // and feed/cfg anchors inside a button (invalid HTML) and made tab-switching /
+  // in-page nav double as rule selection. Scoping the click to this badge keeps
+  // the affordance accessible without nesting interactive elements.
+  onSelect?: () => void;
 }
 
-export function LiveIndicator({ count }: LiveIndicatorProps) {
+export function LiveIndicator({ count, onSelect }: LiveIndicatorProps) {
   if (count === 0) return null;
   const liveColor = liveIndicatorTone(true);
-  return (
+  const badgeClass =
+    "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold";
+  const badgeStyle = {
+    background: `color-mix(in srgb, ${liveColor} 15%, transparent)`,
+    color: liveColor,
+  } as const;
+  const dot = (
     <span
-      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold"
-      style={{
-        background: `color-mix(in srgb, ${liveColor} 15%, transparent)`,
-        color: liveColor,
-      }}
-    >
-      <span
-        className="inline-block h-1.5 w-1.5 rounded-full animate-pulse"
-        style={{ background: liveColor }}
-        aria-hidden
-      />
+      className="inline-block h-1.5 w-1.5 rounded-full animate-pulse"
+      style={{ background: liveColor }}
+      aria-hidden
+    />
+  );
+
+  if (onSelect) {
+    return (
+      <button
+        type="button"
+        className={`${badgeClass} cursor-pointer hover:brightness-110 transition`}
+        style={badgeStyle}
+        onClick={onSelect}
+        aria-label={`Show derivations — ${count} firing`}
+      >
+        {dot}
+        {count}
+      </button>
+    );
+  }
+
+  return (
+    <span className={badgeClass} style={badgeStyle}>
+      {dot}
       {count}
     </span>
   );

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/live-indicator.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/live-indicator.tsx
@@ -1,15 +1,26 @@
-// live-indicator.tsx — CTL-1103 Phase 4: per-rule firing count badge.
-// Renders nothing (muted) when count is 0 (recording off or rule not firing).
+// live-indicator.tsx — CTL-1103 Phase 4+5: per-rule firing count badge.
+// Uses the --color-live token (distinct from strata + severity per Phase 5).
+// Renders nothing when count is 0 (recording off or rule not firing).
+import { liveIndicatorTone } from "@/lib/rulebook-theme";
+
 interface LiveIndicatorProps {
   count: number;
 }
 
 export function LiveIndicator({ count }: LiveIndicatorProps) {
   if (count === 0) return null;
+  const liveColor = liveIndicatorTone(true);
   return (
-    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-semibold text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300">
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold"
+      style={{
+        background: `color-mix(in srgb, ${liveColor} 15%, transparent)`,
+        color: liveColor,
+      }}
+    >
       <span
-        className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse"
+        className="inline-block h-1.5 w-1.5 rounded-full animate-pulse"
+        style={{ background: liveColor }}
         aria-hidden
       />
       {count}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/preface-section.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/preface-section.test.ts
@@ -1,0 +1,33 @@
+// preface-section.test.ts — CTL-1103 Phase 3: verifies the preface data
+// model used by PrefaceSection. Pure logic; no DOM rendering.
+// Run: cd ui && bun test src/components/rulebook/preface-section.test.ts
+import { describe, it, expect } from "bun:test";
+import { prefaceIsComplete, type Preface } from "../../lib/rulebook-model";
+
+const FULL_PREFACE: Preface = {
+  problem:
+    "The daemon must decide — continuously — which workers are alive.",
+  datalog_primer:
+    "Datalog is a logic programming language where rules derive new facts.",
+};
+
+describe("prefaceIsComplete", () => {
+  it("returns true when both problem and datalog_primer are non-empty", () => {
+    expect(prefaceIsComplete(FULL_PREFACE)).toBe(true);
+  });
+
+  it("returns false when problem is empty", () => {
+    expect(prefaceIsComplete({ ...FULL_PREFACE, problem: "" })).toBe(false);
+  });
+
+  it("returns false when datalog_primer is empty", () => {
+    expect(
+      prefaceIsComplete({ ...FULL_PREFACE, datalog_primer: "" }),
+    ).toBe(false);
+  });
+
+  it("returns false for a null/undefined preface (no throw)", () => {
+    expect(prefaceIsComplete(null as unknown as Preface)).toBe(false);
+    expect(prefaceIsComplete(undefined as unknown as Preface)).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/preface-section.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/preface-section.tsx
@@ -1,0 +1,19 @@
+// preface-section.tsx — CTL-1103 Phase 3: renders the Rulebook's opening card.
+import type { Preface } from "@/lib/rulebook-model";
+
+export function PrefaceSection({ preface }: { preface: Preface }) {
+  return (
+    <div className="mb-6 rounded-lg border bg-card p-6 space-y-4">
+      <h2 className="text-base font-semibold">Why does this engine exist?</h2>
+      <p className="text-sm leading-relaxed text-foreground">{preface.problem}</p>
+      <div className="border-t pt-4">
+        <p className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Datalog primer
+        </p>
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          {preface.datalog_primer}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card-model.ts
@@ -1,6 +1,6 @@
 // rule-card.ts — CTL-1103 Phase 3: pure tab-data helper for RuleCard.
 // Exported for tests; imported by rule-card.tsx.
-import type { RuleManifestRule } from "../../lib/rulebook-model";
+import type { RuleArm, RuleManifestRule } from "../../lib/rulebook-model";
 
 export interface RuleCardTab {
   label: "Plain English" | "Datalog" | "SQL";
@@ -9,9 +9,29 @@ export interface RuleCardTab {
   isExtern: boolean;
 }
 
+// CTL-1103 remediate: a rule can have multiple arms (e.g. R10 = R10a + R10b),
+// each with distinct Datalog/SQL. Reading only arms[0] silently dropped every
+// later arm, presenting partial governance logic as complete. Concatenate all
+// arms for the field, prefixing each with an `arm_id` comment heading when there
+// is more than one arm. A single-arm rule renders exactly that arm's source (no
+// heading) so the common case is unchanged. Returns null only when EVERY arm's
+// field is null (the extern case for Datalog).
+function joinArms(arms: RuleArm[], field: "datalog" | "sql"): string | null {
+  const present = arms.filter((a) => a[field] != null);
+  if (present.length === 0) return null;
+  if (present.length === 1 && arms.length === 1) {
+    return present[0][field] as string;
+  }
+  // Datalog comments start with `//` (Soufflé); SQL comments with `--`.
+  const marker = field === "datalog" ? "//" : "--";
+  return present
+    .map((a) => `${marker} ${a.arm_id}\n${a[field] as string}`)
+    .join("\n\n");
+}
+
 export function ruleCardTabs(rule: RuleManifestRule): RuleCardTab[] {
-  const datalog = rule.arms[0]?.datalog ?? null;
-  const sql = rule.arms[0]?.sql ?? null;
+  const datalog = joinArms(rule.arms, "datalog");
+  const sql = joinArms(rule.arms, "sql");
   return [
     {
       label: "Plain English",

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card-model.ts
@@ -1,4 +1,4 @@
-// rule-card.ts — CTL-1103 Phase 3: pure tab-data helper for RuleCard.
+// rule-card-model.ts — CTL-1103 Phase 3: pure tab-data helper for RuleCard.
 // Exported for tests; imported by rule-card.tsx.
 import type { RuleArm, RuleManifestRule } from "../../lib/rulebook-model";
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card-model.ts
@@ -1,0 +1,35 @@
+// rule-card.ts — CTL-1103 Phase 3: pure tab-data helper for RuleCard.
+// Exported for tests; imported by rule-card.tsx.
+import type { RuleManifestRule } from "../../lib/rulebook-model";
+
+export interface RuleCardTab {
+  label: "Plain English" | "Datalog" | "SQL";
+  content: string | null;
+  isCode: boolean;
+  isExtern: boolean;
+}
+
+export function ruleCardTabs(rule: RuleManifestRule): RuleCardTab[] {
+  const datalog = rule.arms[0]?.datalog ?? null;
+  const sql = rule.arms[0]?.sql ?? null;
+  return [
+    {
+      label: "Plain English",
+      content: rule.description,
+      isCode: false,
+      isExtern: false,
+    },
+    {
+      label: "Datalog",
+      content: datalog,
+      isCode: true,
+      isExtern: datalog === null,
+    },
+    {
+      label: "SQL",
+      content: sql,
+      isCode: true,
+      isExtern: false,
+    },
+  ];
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card.test.ts
@@ -1,0 +1,82 @@
+// rule-card.test.ts — CTL-1103 Phase 3: verifies the tab data model that
+// RuleCard surfaces. Pure logic; no DOM rendering required.
+// Run: cd ui && bun test src/components/rulebook/rule-card.test.ts
+import { describe, it, expect } from "bun:test";
+import { ruleCardTabs, type RuleCardTab } from "./rule-card-model";
+import type { RuleManifestRule } from "../../lib/rulebook-model";
+
+const BASE_RULE: RuleManifestRule = {
+  rule_id: "R1",
+  name: "session_registered",
+  stratum: 1,
+  extern: false,
+  description: "The session is registered.",
+  feeds: [],
+  reads: [],
+  negates: [],
+  cfg_keys: [],
+  severity: "info",
+  arms: [
+    {
+      arm_id: "R1",
+      datalog: "session_registered :- obs_signal(S), obs_agent(A).",
+      sql: "INSERT OR IGNORE INTO belief SELECT ...",
+    },
+  ],
+};
+
+const EXTERN_RULE: RuleManifestRule = {
+  ...BASE_RULE,
+  rule_id: "R8",
+  name: "free_slots",
+  extern: true,
+  arms: [
+    {
+      arm_id: "R8",
+      datalog: null,
+      sql: "INSERT INTO belief WITH RECURSIVE free_slots AS (...) SELECT ...",
+    },
+  ],
+};
+
+describe("ruleCardTabs", () => {
+  it("returns exactly three tabs: Plain English, Datalog, SQL", () => {
+    const tabs = ruleCardTabs(BASE_RULE);
+    const labels = tabs.map((t: RuleCardTab) => t.label);
+    expect(labels).toEqual(["Plain English", "Datalog", "SQL"]);
+  });
+
+  it("Plain English tab content equals the rule description", () => {
+    const tabs = ruleCardTabs(BASE_RULE);
+    const english = tabs.find((t: RuleCardTab) => t.label === "Plain English");
+    expect(english?.content).toBe(BASE_RULE.description);
+    expect(english?.isCode).toBe(false);
+  });
+
+  it("SQL tab content equals arms[0].sql", () => {
+    const tabs = ruleCardTabs(BASE_RULE);
+    const sql = tabs.find((t: RuleCardTab) => t.label === "SQL");
+    expect(sql?.content).toBe(BASE_RULE.arms[0].sql);
+    expect(sql?.isCode).toBe(true);
+  });
+
+  it("Datalog tab content equals arms[0].datalog when present", () => {
+    const tabs = ruleCardTabs(BASE_RULE);
+    const datalog = tabs.find((t: RuleCardTab) => t.label === "Datalog");
+    expect(datalog?.content).toBe(BASE_RULE.arms[0].datalog);
+    expect(datalog?.isCode).toBe(true);
+  });
+
+  it("Datalog tab is marked extern when datalog is null", () => {
+    const tabs = ruleCardTabs(EXTERN_RULE);
+    const datalog = tabs.find((t: RuleCardTab) => t.label === "Datalog");
+    expect(datalog?.isExtern).toBe(true);
+    expect(datalog?.content).toBeNull();
+  });
+
+  it("SQL tab is always present even for extern rules", () => {
+    const tabs = ruleCardTabs(EXTERN_RULE);
+    const sql = tabs.find((t: RuleCardTab) => t.label === "SQL");
+    expect(sql?.content).toBe(EXTERN_RULE.arms[0].sql);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card.test.ts
@@ -79,4 +79,53 @@ describe("ruleCardTabs", () => {
     const sql = tabs.find((t: RuleCardTab) => t.label === "SQL");
     expect(sql?.content).toBe(EXTERN_RULE.arms[0].sql);
   });
+
+  // CTL-1103 remediate: multi-arm rules (e.g. R10 = R10a + R10b) must render
+  // EVERY arm, not just arms[0] — previously later arms were silently dropped,
+  // presenting partial governance logic as complete.
+  const MULTI_ARM_RULE: RuleManifestRule = {
+    ...BASE_RULE,
+    rule_id: "R10",
+    name: "wedged_or_stalled",
+    arms: [
+      {
+        arm_id: "R10a",
+        datalog: "wedged :- never_started(T).",
+        sql: "INSERT INTO belief SELECT 'wedged' ...",
+      },
+      {
+        arm_id: "R10b",
+        datalog: "stalled :- stalled_alive(T).",
+        sql: "INSERT INTO belief SELECT 'stalled' ...",
+      },
+    ],
+  };
+
+  it("SQL tab includes every arm for a multi-arm rule", () => {
+    const tabs = ruleCardTabs(MULTI_ARM_RULE);
+    const sql = tabs.find((t: RuleCardTab) => t.label === "SQL");
+    expect(sql?.content).toContain("R10a");
+    expect(sql?.content).toContain("R10b");
+    expect(sql?.content).toContain(MULTI_ARM_RULE.arms[0].sql as string);
+    expect(sql?.content).toContain(MULTI_ARM_RULE.arms[1].sql as string);
+  });
+
+  it("Datalog tab includes every arm for a multi-arm rule", () => {
+    const tabs = ruleCardTabs(MULTI_ARM_RULE);
+    const datalog = tabs.find((t: RuleCardTab) => t.label === "Datalog");
+    expect(datalog?.content).toContain("R10a");
+    expect(datalog?.content).toContain("R10b");
+    expect(datalog?.content).toContain(MULTI_ARM_RULE.arms[0].datalog as string);
+    expect(datalog?.content).toContain(MULTI_ARM_RULE.arms[1].datalog as string);
+    expect(datalog?.isExtern).toBe(false);
+  });
+
+  it("single-arm rules render the arm source verbatim (no heading)", () => {
+    const tabs = ruleCardTabs(BASE_RULE);
+    const sql = tabs.find((t: RuleCardTab) => t.label === "SQL");
+    const datalog = tabs.find((t: RuleCardTab) => t.label === "Datalog");
+    // Exactly the arm's content — no `-- arm_id` heading injected.
+    expect(sql?.content).toBe(BASE_RULE.arms[0].sql);
+    expect(datalog?.content).toBe(BASE_RULE.arms[0].datalog);
+  });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card.tsx
@@ -1,0 +1,129 @@
+// rule-card.tsx — CTL-1103 Phase 3: tri-lingual card (Plain English | Datalog | SQL).
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from "@/components/ui/tabs";
+import { ruleCardTabs } from "./rule-card-model";
+import { severityTone } from "@/lib/rulebook-model";
+import { stratumColorForId } from "./strata-ladder";
+import type { RuleManifestRule } from "@/lib/rulebook-model";
+
+export function RuleCard({
+  rule,
+  liveSlot,
+}: {
+  rule: RuleManifestRule;
+  liveSlot?: React.ReactNode;
+}) {
+  const [tab, setTab] = useState<string>("english");
+  const tabs = ruleCardTabs(rule);
+  const sevClass = severityTone(rule.severity);
+  const stratumClass = stratumColorForId(rule.stratum);
+
+  return (
+    <div
+      id={`rule-${rule.rule_id}`}
+      className={cn(
+        "rounded-lg border bg-card mb-4 overflow-hidden border-l-4",
+        stratumClass.split(" ")[0], // border-color token only
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-start gap-3 px-4 pt-3 pb-2">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-mono text-xs text-muted-foreground shrink-0">
+              {rule.rule_id}
+            </span>
+            <span className="font-medium text-sm truncate">{rule.name}</span>
+            {rule.extern && (
+              <Badge variant="outline" className="text-[10px] h-4 px-1 shrink-0">
+                extern
+              </Badge>
+            )}
+            {rule.severity && (
+              <span className={cn("text-xs font-medium shrink-0", sevClass)}>
+                {rule.severity}
+              </span>
+            )}
+          </div>
+          {rule.feeds.length > 0 && (
+            <div className="mt-1 flex items-center gap-1 flex-wrap">
+              <span className="text-[10px] text-muted-foreground">feeds:</span>
+              {rule.feeds.map((f) => (
+                <a
+                  key={f}
+                  href={`#rule-${f}`}
+                  className="text-[10px] font-mono text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  {f}
+                </a>
+              ))}
+            </div>
+          )}
+          {rule.cfg_keys.length > 0 && (
+            <div className="mt-0.5 flex items-center gap-1 flex-wrap">
+              <span className="text-[10px] text-muted-foreground">cfg:</span>
+              {rule.cfg_keys.map((k) => (
+                <a
+                  key={k}
+                  href={`#cfg-${k}`}
+                  className="text-[10px] font-mono text-muted-foreground hover:underline"
+                >
+                  {k}
+                </a>
+              ))}
+            </div>
+          )}
+        </div>
+        {/* Phase 4 live indicator slot */}
+        {liveSlot && <div className="shrink-0">{liveSlot}</div>}
+      </div>
+
+      {/* Tri-lingual tabs */}
+      <Tabs value={tab} onValueChange={setTab} className="px-4 pb-3">
+        <TabsList className="h-7 mb-2">
+          <TabsTrigger value="english" className="text-[11px] px-2">
+            Plain English
+          </TabsTrigger>
+          <TabsTrigger value="datalog" className="text-[11px] px-2">
+            Datalog
+          </TabsTrigger>
+          <TabsTrigger value="sql" className="text-[11px] px-2">
+            SQL
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="english" className="mt-0">
+          <p className="text-sm leading-relaxed text-foreground">
+            {tabs[0].content ?? "No description available."}
+          </p>
+        </TabsContent>
+
+        <TabsContent value="datalog" className="mt-0">
+          {tabs[1].isExtern ? (
+            <p className="text-xs text-muted-foreground italic">
+              This rule embeds hand-authored SQL (an <em>extern</em> block) — no
+              Datalog source is compiled for it.
+            </p>
+          ) : (
+            <pre className="rounded bg-muted px-3 py-2 text-[11px] font-mono leading-relaxed overflow-x-auto whitespace-pre-wrap">
+              {tabs[1].content}
+            </pre>
+          )}
+        </TabsContent>
+
+        <TabsContent value="sql" className="mt-0">
+          <pre className="rounded bg-muted px-3 py-2 text-[11px] font-mono leading-relaxed overflow-x-auto whitespace-pre-wrap">
+            {tabs[2].content ?? "-- SQL unavailable"}
+          </pre>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card.tsx
@@ -1,4 +1,6 @@
-// rule-card.tsx — CTL-1103 Phase 3: tri-lingual card (Plain English | Datalog | SQL).
+// rule-card.tsx — CTL-1103 Phase 3+5: tri-lingual card (Plain English | Datalog | SQL).
+// Border color uses strataTone() CSS variable; severity chip uses severityTone()
+// CSS class; both are distinct from liveIndicatorTone() (Phase 5 contract).
 import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
@@ -23,15 +25,13 @@ export function RuleCard({
   const [tab, setTab] = useState<string>("english");
   const tabs = ruleCardTabs(rule);
   const sevClass = severityTone(rule.severity);
-  const stratumClass = stratumColorForId(rule.stratum);
+  const stratumColor = stratumColorForId(rule.stratum); // CSS var e.g. "var(--chart-1)"
 
   return (
     <div
       id={`rule-${rule.rule_id}`}
-      className={cn(
-        "rounded-lg border bg-card mb-4 overflow-hidden border-l-4",
-        stratumClass.split(" ")[0], // border-color token only
-      )}
+      className={cn("rounded-lg border bg-card mb-4 overflow-hidden border-l-4")}
+      style={{ borderLeftColor: stratumColor }}
     >
       {/* Header */}
       <div className="flex items-start gap-3 px-4 pt-3 pb-2">

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rulebook-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rulebook-surface.tsx
@@ -1,7 +1,7 @@
-// rulebook-surface.tsx — CTL-1103 Phase 3: full static textbook surface.
+// rulebook-surface.tsx — CTL-1103 Phase 3+4: full static textbook + live margins.
 // Renders preface → strata ladder → per-stratum rule cards → thresholds.
-// Data: one /api/beliefs/rules fetch; no dependence on belief recording.
-// SSE dedup contract: use useBeliefsContext(), NEVER useBeliefs().
+// Live firing counts come from useBeliefsContext() (the already-open shared SSE
+// — zero new EventSources, SSE dedup contract CTL-945).
 import { useEffect, useState } from "react";
 import { useBeliefsContext } from "@/hooks/use-beliefs";
 import {
@@ -10,15 +10,29 @@ import {
   type RuleManifest,
   type StratumGroup,
 } from "@/lib/rulebook-model";
+import { countFiringByRule, subjectsForRule } from "@/lib/rulebook-live";
 import { PrefaceSection } from "./preface-section";
 import { StrataLadder, stratumColorForId } from "./strata-ladder";
 import { RuleCard } from "./rule-card";
+import { LiveIndicator } from "./live-indicator";
+import { DerivationsRail } from "./derivations-rail";
 import { ThresholdsAppendix } from "./thresholds-appendix";
 import { cn } from "@/lib/utils";
+import type { RuleManifestRule } from "@/lib/rulebook-model";
 
-function StratumSection({ group }: { group: StratumGroup }) {
+function StratumSection({
+  group,
+  firingCounts,
+  selectedRuleId,
+  onSelectRule,
+}: {
+  group: StratumGroup;
+  firingCounts: Map<string, number>;
+  selectedRuleId: string | null;
+  onSelectRule: (id: string) => void;
+}) {
   const colorClass = stratumColorForId(group.stratum.id);
-  const borderClass = colorClass.split(" ")[0]; // border-* token only
+  const borderClass = colorClass.split(" ")[0];
   return (
     <section id={`stratum-${group.stratum.id}`} className="mb-8">
       <div
@@ -35,9 +49,23 @@ function StratumSection({ group }: { group: StratumGroup }) {
           — {group.stratum.prose}
         </span>
       </div>
-      {group.rules.map((rule) => (
-        <RuleCard key={rule.rule_id} rule={rule} />
-      ))}
+      {group.rules.map((rule) => {
+        const count = firingCounts.get(rule.rule_id) ?? 0;
+        return (
+          <div key={rule.rule_id}>
+            <button
+              type="button"
+              className="w-full text-left"
+              onClick={() => count > 0 && onSelectRule(rule.rule_id)}
+            >
+              <RuleCard
+                rule={rule}
+                liveSlot={<LiveIndicator count={count} />}
+              />
+            </button>
+          </div>
+        );
+      })}
     </section>
   );
 }
@@ -53,11 +81,13 @@ function LoadingSkeleton() {
 }
 
 export function RulebookSurface() {
-  useBeliefsContext(); // dedup contract: consume context, never useBeliefs()
+  const beliefs = useBeliefsContext(); // dedup contract: never useBeliefs()
+  const firingCounts = countFiringByRule(beliefs.store);
 
   const [manifest, setManifest] = useState<RuleManifest | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [groups, setGroups] = useState<StratumGroup[]>([]);
+  const [selectedRuleId, setSelectedRuleId] = useState<string | null>(null);
 
   useEffect(() => {
     fetchRuleManifest()
@@ -70,6 +100,11 @@ export function RulebookSurface() {
       });
   }, []);
 
+  const selectedRule: RuleManifestRule | null =
+    selectedRuleId && manifest
+      ? (manifest.rules.find((r) => r.rule_id === selectedRuleId) ?? null)
+      : null;
+
   if (error) {
     return (
       <div className="p-6 text-sm text-destructive">
@@ -79,31 +114,67 @@ export function RulebookSurface() {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto">
-      <div className="mx-auto max-w-3xl px-6 py-6">
-        <div className="mb-6">
-          <h1 className="text-xl font-bold">Belief Engine Rulebook</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            17 rules · 6 strata · compiled from{" "}
-            <span className="font-mono">beliefs/rules.dl</span>
-          </p>
+    <div className="flex flex-1 overflow-hidden">
+      {/* Main textbook column */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-3xl px-6 py-6">
+          <div className="mb-6">
+            <h1 className="text-xl font-bold">Belief Engine Rulebook</h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              17 rules · 6 strata · compiled from{" "}
+              <span className="font-mono">beliefs/rules.dl</span>
+            </p>
+          </div>
+
+          {manifest === null ? (
+            <LoadingSkeleton />
+          ) : (
+            <>
+              <PrefaceSection preface={manifest.preface} />
+              <StrataLadder groups={groups} />
+
+              {groups.map((group) => (
+                <StratumSection
+                  key={group.stratum.id}
+                  group={group}
+                  firingCounts={firingCounts}
+                  selectedRuleId={selectedRuleId}
+                  onSelectRule={setSelectedRuleId}
+                />
+              ))}
+
+              <ThresholdsAppendix />
+            </>
+          )}
         </div>
-
-        {manifest === null ? (
-          <LoadingSkeleton />
-        ) : (
-          <>
-            <PrefaceSection preface={manifest.preface} />
-            <StrataLadder groups={groups} />
-
-            {groups.map((group) => (
-              <StratumSection key={group.stratum.id} group={group} />
-            ))}
-
-            <ThresholdsAppendix />
-          </>
-        )}
       </div>
+
+      {/* Derivations rail — shown when a firing rule is selected */}
+      {selectedRule && (
+        <div className="w-80 shrink-0 border-l overflow-y-auto p-4">
+          <div className="mb-3 flex items-center justify-between">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Derivations
+            </span>
+            <button
+              type="button"
+              className="text-xs text-muted-foreground hover:text-foreground"
+              onClick={() => setSelectedRuleId(null)}
+            >
+              ×
+            </button>
+          </div>
+          <DerivationsRail
+            ruleId={selectedRule.rule_id}
+            subjects={subjectsForRule(beliefs.store, selectedRule.rule_id)}
+            onOpenSource={(ruleId) => {
+              document
+                .getElementById(`rule-${ruleId}`)
+                ?.scrollIntoView({ behavior: "smooth" });
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rulebook-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rulebook-surface.tsx
@@ -1,0 +1,7 @@
+// rulebook-surface.tsx — CTL-1103 Phase 2 (placeholder; full UI in Phase 3–5)
+import { useBeliefsContext } from "@/hooks/use-beliefs";
+
+export function RulebookSurface() {
+  useBeliefsContext(); // dedup contract: consume context, never useBeliefs()
+  return <div className="p-6 text-muted-foreground">Rulebook — coming soon</div>;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rulebook-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rulebook-surface.tsx
@@ -48,18 +48,25 @@ function StratumSection({
       </div>
       {group.rules.map((rule) => {
         const count = firingCounts.get(rule.rule_id) ?? 0;
+        // CTL-1103 remediate: selection is scoped to the LiveIndicator badge (the
+        // dedicated header affordance) rather than wrapping the whole card in a
+        // <button>. That wrapper nested the card's Tabs buttons + feed/cfg anchors
+        // inside a button (invalid HTML) and let tab/anchor clicks bubble out as
+        // unintended rule selections. The badge only renders when count > 0, so
+        // selection stays gated on a firing rule exactly as before.
         return (
           <div key={rule.rule_id}>
-            <button
-              type="button"
-              className="w-full text-left"
-              onClick={() => count > 0 && onSelectRule(rule.rule_id)}
-            >
-              <RuleCard
-                rule={rule}
-                liveSlot={<LiveIndicator count={count} />}
-              />
-            </button>
+            <RuleCard
+              rule={rule}
+              liveSlot={
+                <LiveIndicator
+                  count={count}
+                  onSelect={
+                    count > 0 ? () => onSelectRule(rule.rule_id) : undefined
+                  }
+                />
+              }
+            />
           </div>
         );
       })}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rulebook-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rulebook-surface.tsx
@@ -1,7 +1,109 @@
-// rulebook-surface.tsx — CTL-1103 Phase 2 (placeholder; full UI in Phase 3–5)
+// rulebook-surface.tsx — CTL-1103 Phase 3: full static textbook surface.
+// Renders preface → strata ladder → per-stratum rule cards → thresholds.
+// Data: one /api/beliefs/rules fetch; no dependence on belief recording.
+// SSE dedup contract: use useBeliefsContext(), NEVER useBeliefs().
+import { useEffect, useState } from "react";
 import { useBeliefsContext } from "@/hooks/use-beliefs";
+import {
+  fetchRuleManifest,
+  groupRulesByStratum,
+  type RuleManifest,
+  type StratumGroup,
+} from "@/lib/rulebook-model";
+import { PrefaceSection } from "./preface-section";
+import { StrataLadder, stratumColorForId } from "./strata-ladder";
+import { RuleCard } from "./rule-card";
+import { ThresholdsAppendix } from "./thresholds-appendix";
+import { cn } from "@/lib/utils";
+
+function StratumSection({ group }: { group: StratumGroup }) {
+  const colorClass = stratumColorForId(group.stratum.id);
+  const borderClass = colorClass.split(" ")[0]; // border-* token only
+  return (
+    <section id={`stratum-${group.stratum.id}`} className="mb-8">
+      <div
+        className={cn(
+          "flex items-baseline gap-2 mb-3 pb-2 border-b-2",
+          borderClass,
+        )}
+      >
+        <span className="font-mono text-xs text-muted-foreground">
+          S{group.stratum.id}
+        </span>
+        <h3 className="text-sm font-semibold">{group.stratum.label}</h3>
+        <span className="text-xs text-muted-foreground hidden sm:inline">
+          — {group.stratum.prose}
+        </span>
+      </div>
+      {group.rules.map((rule) => (
+        <RuleCard key={rule.rule_id} rule={rule} />
+      ))}
+    </section>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="space-y-4 animate-pulse">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="h-24 rounded-lg bg-muted" />
+      ))}
+    </div>
+  );
+}
 
 export function RulebookSurface() {
   useBeliefsContext(); // dedup contract: consume context, never useBeliefs()
-  return <div className="p-6 text-muted-foreground">Rulebook — coming soon</div>;
+
+  const [manifest, setManifest] = useState<RuleManifest | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [groups, setGroups] = useState<StratumGroup[]>([]);
+
+  useEffect(() => {
+    fetchRuleManifest()
+      .then((m) => {
+        setManifest(m);
+        setGroups(groupRulesByStratum(m));
+      })
+      .catch((e: unknown) => {
+        setError(e instanceof Error ? e.message : "Failed to load manifest");
+      });
+  }, []);
+
+  if (error) {
+    return (
+      <div className="p-6 text-sm text-destructive">
+        Could not load rulebook: {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-3xl px-6 py-6">
+        <div className="mb-6">
+          <h1 className="text-xl font-bold">Belief Engine Rulebook</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            17 rules · 6 strata · compiled from{" "}
+            <span className="font-mono">beliefs/rules.dl</span>
+          </p>
+        </div>
+
+        {manifest === null ? (
+          <LoadingSkeleton />
+        ) : (
+          <>
+            <PrefaceSection preface={manifest.preface} />
+            <StrataLadder groups={groups} />
+
+            {groups.map((group) => (
+              <StratumSection key={group.stratum.id} group={group} />
+            ))}
+
+            <ThresholdsAppendix />
+          </>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rulebook-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rulebook-surface.tsx
@@ -31,15 +31,12 @@ function StratumSection({
   selectedRuleId: string | null;
   onSelectRule: (id: string) => void;
 }) {
-  const colorClass = stratumColorForId(group.stratum.id);
-  const borderClass = colorClass.split(" ")[0];
+  const color = stratumColorForId(group.stratum.id); // CSS var e.g. "var(--chart-1)"
   return (
     <section id={`stratum-${group.stratum.id}`} className="mb-8">
       <div
-        className={cn(
-          "flex items-baseline gap-2 mb-3 pb-2 border-b-2",
-          borderClass,
-        )}
+        className={cn("flex items-baseline gap-2 mb-3 pb-2 border-b-2")}
+        style={{ borderBottomColor: color }}
       >
         <span className="font-mono text-xs text-muted-foreground">
           S{group.stratum.id}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/strata-ladder.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/strata-ladder.tsx
@@ -1,0 +1,52 @@
+// strata-ladder.tsx — CTL-1103 Phase 3: vertical ladder of the 6 belief strata.
+// Each rung anchors to its section in the rule-card list below.
+import { cn } from "@/lib/utils";
+import type { StratumGroup } from "@/lib/rulebook-model";
+
+const STRATA_COLORS = [
+  "border-blue-500 text-blue-700 dark:text-blue-400",
+  "border-cyan-500 text-cyan-700 dark:text-cyan-400",
+  "border-teal-500 text-teal-700 dark:text-teal-400",
+  "border-amber-500 text-amber-700 dark:text-amber-400",
+  "border-orange-500 text-orange-700 dark:text-orange-400",
+  "border-rose-500 text-rose-700 dark:text-rose-400",
+];
+
+function stratumColor(idx: number): string {
+  return STRATA_COLORS[idx % STRATA_COLORS.length];
+}
+
+export function StrataLadder({ groups }: { groups: StratumGroup[] }) {
+  return (
+    <div className="mb-6 rounded-lg border bg-card p-4">
+      <p className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Strata
+      </p>
+      <ol className="space-y-2">
+        {groups.map((g, idx) => (
+          <li key={g.stratum.id}>
+            <a
+              href={`#stratum-${g.stratum.id}`}
+              className={cn(
+                "flex items-start gap-3 rounded-md border-l-2 px-3 py-2 text-sm hover:bg-muted/50 transition-colors",
+                stratumColor(idx),
+              )}
+            >
+              <span className="shrink-0 font-mono text-xs font-semibold mt-0.5">
+                S{g.stratum.id}
+              </span>
+              <span>
+                <span className="font-medium">{g.stratum.label}</span>
+                <span className="ml-2 text-muted-foreground">{g.stratum.prose}</span>
+              </span>
+            </a>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+export function stratumColorForId(stratumId: number): string {
+  return STRATA_COLORS[(stratumId - 1) % STRATA_COLORS.length];
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/strata-ladder.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/strata-ladder.tsx
@@ -1,19 +1,12 @@
-// strata-ladder.tsx — CTL-1103 Phase 3: vertical ladder of the 6 belief strata.
-// Each rung anchors to its section in the rule-card list below.
-import { cn } from "@/lib/utils";
+// strata-ladder.tsx — CTL-1103 Phase 3+5: vertical ladder of the 6 belief strata.
+// Uses strataTone() from rulebook-theme.ts (--chart-N tokens; distinct from
+// severity and live-indicator per Phase 5 contract).
 import type { StratumGroup } from "@/lib/rulebook-model";
+import { strataTone } from "@/lib/rulebook-theme";
 
-const STRATA_COLORS = [
-  "border-blue-500 text-blue-700 dark:text-blue-400",
-  "border-cyan-500 text-cyan-700 dark:text-cyan-400",
-  "border-teal-500 text-teal-700 dark:text-teal-400",
-  "border-amber-500 text-amber-700 dark:text-amber-400",
-  "border-orange-500 text-orange-700 dark:text-orange-400",
-  "border-rose-500 text-rose-700 dark:text-rose-400",
-];
-
-function stratumColor(idx: number): string {
-  return STRATA_COLORS[idx % STRATA_COLORS.length];
+/** CSS variable string for a stratum id — used by rule-card and rulebook-surface. */
+export function stratumColorForId(id: number): string {
+  return strataTone(id);
 }
 
 export function StrataLadder({ groups }: { groups: StratumGroup[] }) {
@@ -23,30 +16,31 @@ export function StrataLadder({ groups }: { groups: StratumGroup[] }) {
         Strata
       </p>
       <ol className="space-y-2">
-        {groups.map((g, idx) => (
-          <li key={g.stratum.id}>
-            <a
-              href={`#stratum-${g.stratum.id}`}
-              className={cn(
-                "flex items-start gap-3 rounded-md border-l-2 px-3 py-2 text-sm hover:bg-muted/50 transition-colors",
-                stratumColor(idx),
-              )}
-            >
-              <span className="shrink-0 font-mono text-xs font-semibold mt-0.5">
-                S{g.stratum.id}
-              </span>
-              <span>
-                <span className="font-medium">{g.stratum.label}</span>
-                <span className="ml-2 text-muted-foreground">{g.stratum.prose}</span>
-              </span>
-            </a>
-          </li>
-        ))}
+        {groups.map((g) => {
+          const color = strataTone(g.stratum.id);
+          return (
+            <li key={g.stratum.id}>
+              <a
+                href={`#stratum-${g.stratum.id}`}
+                className="flex items-start gap-3 rounded-md px-3 py-2 text-sm hover:bg-muted/50 transition-colors border-l-2"
+                style={{ borderLeftColor: color, color }}
+              >
+                <span className="shrink-0 font-mono text-xs font-semibold mt-0.5">
+                  S{g.stratum.id}
+                </span>
+                <span>
+                  <span className="font-medium" style={{ color }}>
+                    {g.stratum.label}
+                  </span>
+                  <span className="ml-2 text-muted-foreground">
+                    {g.stratum.prose}
+                  </span>
+                </span>
+              </a>
+            </li>
+          );
+        })}
       </ol>
     </div>
   );
-}
-
-export function stratumColorForId(stratumId: number): string {
-  return STRATA_COLORS[(stratumId - 1) % STRATA_COLORS.length];
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/thresholds-appendix.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/thresholds-appendix.tsx
@@ -1,0 +1,71 @@
+// thresholds-appendix.tsx — CTL-1103 Phase 3: fetches /api/beliefs/cfg and
+// renders the threshold key/value table. Degrades quietly on fetch failure.
+import { useEffect, useState } from "react";
+
+interface CfgRow {
+  key: string;
+  value_int: number | null;
+  value_text: string | null;
+}
+
+function CfgValue({ row }: { row: CfgRow }) {
+  const v = row.value_int != null ? String(row.value_int) : row.value_text;
+  return <span className="font-mono text-xs">{v ?? "—"}</span>;
+}
+
+export function ThresholdsAppendix() {
+  const [rows, setRows] = useState<CfgRow[] | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/beliefs/cfg")
+      .then((r) => {
+        if (!r.ok) throw new Error(`${r.status}`);
+        return r.json() as Promise<{ cfg: CfgRow[] }>;
+      })
+      .then((d) => setRows(d.cfg))
+      .catch(() => setUnavailable(true));
+  }, []);
+
+  return (
+    <div id="thresholds" className="mt-8 rounded-lg border bg-card p-4">
+      <p className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Thresholds (cfg)
+      </p>
+      {unavailable ? (
+        <p className="text-xs text-muted-foreground">Thresholds unavailable.</p>
+      ) : rows === null ? (
+        <p className="text-xs text-muted-foreground">Loading…</p>
+      ) : rows.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No thresholds configured.</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b">
+              <th className="pb-2 text-left font-medium text-muted-foreground text-xs">
+                Key
+              </th>
+              <th className="pb-2 text-right font-medium text-muted-foreground text-xs">
+                Value
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr
+                key={row.key}
+                id={`cfg-${row.key}`}
+                className="border-b last:border-0"
+              >
+                <td className="py-1.5 font-mono text-xs">{row.key}</td>
+                <td className="py-1.5 text-right">
+                  <CfgValue row={row} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/prefs.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/prefs.test.ts
@@ -1,0 +1,75 @@
+// prefs.test.ts — CTL-1103 remediate (coverage): pin the LANDING_SURFACES
+// membership contract. Phase 5 changed the filter to also exclude 'rulebook'
+// (it must not be offered as a landing default), but nothing asserted the
+// resulting set — a regression that re-added 'rulebook' or dropped a valid
+// OPERATE surface would have gone uncaught. Pure; no DOM.
+// Run: cd ui && bun test src/lib/prefs.test.ts
+import { describe, it, expect } from "bun:test";
+import {
+  LANDING_SURFACES,
+  DEFAULT_LANDING_SURFACE,
+  normalizeLandingSurface,
+  readStoredLandingSurface,
+  LANDING_SURFACE_STORAGE_KEY,
+} from "./prefs";
+import type { Surface } from "./surface";
+
+describe("LANDING_SURFACES", () => {
+  it("includes the valid OPERATE landing surfaces", () => {
+    for (const surface of ["home", "board", "workers", "telemetry"] as const) {
+      expect(LANDING_SURFACES).toContain(surface);
+    }
+  });
+
+  it("excludes rulebook (never a landing default)", () => {
+    expect(LANDING_SURFACES).not.toContain("rulebook");
+  });
+
+  it("excludes the nav-disabled OBSERVE surfaces", () => {
+    for (const surface of [
+      "utilization",
+      "finops",
+      "fleetops",
+      "devops",
+    ] as const) {
+      expect(LANDING_SURFACES).not.toContain(surface);
+    }
+  });
+
+  it("is exactly the four eligible landing surfaces", () => {
+    const expected: Surface[] = ["board", "home", "telemetry", "workers"];
+    expect([...LANDING_SURFACES].sort()).toEqual(expected.sort());
+  });
+
+  it("the Home default is itself a valid landing surface", () => {
+    expect(LANDING_SURFACES).toContain(DEFAULT_LANDING_SURFACE);
+  });
+});
+
+describe("normalizeLandingSurface", () => {
+  it("clamps junk / null to the Home default", () => {
+    expect(normalizeLandingSurface(null)).toBe(DEFAULT_LANDING_SURFACE);
+    expect(normalizeLandingSurface("not-a-surface")).toBe(
+      DEFAULT_LANDING_SURFACE,
+    );
+    expect(normalizeLandingSurface(42)).toBe(DEFAULT_LANDING_SURFACE);
+  });
+
+  it("passes a valid surface through unchanged", () => {
+    expect(normalizeLandingSurface("workers")).toBe("workers");
+  });
+});
+
+describe("readStoredLandingSurface", () => {
+  it("returns the Home default when storage is null", () => {
+    expect(readStoredLandingSurface(null)).toBe(DEFAULT_LANDING_SURFACE);
+  });
+
+  it("reads and normalizes the stored value", () => {
+    const storage = {
+      getItem: (key: string) =>
+        key === LANDING_SURFACE_STORAGE_KEY ? "telemetry" : null,
+    };
+    expect(readStoredLandingSurface(storage)).toBe("telemetry");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/prefs.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/prefs.ts
@@ -28,7 +28,8 @@ export const LANDING_SURFACES: readonly Surface[] = SURFACES.filter(
     s !== "utilization" &&
     s !== "finops" &&
     s !== "fleetops" &&
-    s !== "devops",
+    s !== "devops" &&
+    s !== "rulebook",
 );
 
 /** localStorage key the landing-surface preference persists under. Named in the

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/route-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/route-surface.test.ts
@@ -100,3 +100,14 @@ describe("detailPathSurface", () => {
     expect(detailPathSurface("recent")).toBe("board");
   });
 });
+
+// ── CTL-1103: rulebook surface ───────────────────────────────────────────────
+describe("CTL-1103 — rulebook surface path", () => {
+  it("surfaceToPath maps rulebook to /rules", () => {
+    expect(surfaceToPath("rulebook" as Surface)).toBe("/rules");
+  });
+
+  it("pathnameToSurface maps /rules to rulebook", () => {
+    expect(pathnameToSurface("/rules")).toBe("rulebook");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/route-surface.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/route-surface.ts
@@ -31,6 +31,7 @@ export const SURFACE_PATH: Record<Surface, string> = {
   finops: "/finops",
   fleetops: "/fleetops",
   devops: "/devops",
+  rulebook: "/rules",
 };
 
 /** The Settings path — Settings is a footer destination, NOT one of the surface

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-live.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-live.test.ts
@@ -75,6 +75,16 @@ describe("countFiringByRule", () => {
     expect(counts.has("R10a")).toBe(false);
     expect(counts.has("R10b")).toBe(false);
   });
+
+  it("counts distinct subjects, not frames, when arms share a subject", () => {
+    // R10a and R10b both fire on the same subject — that is ONE firing subject
+    // for logical R10, not two.
+    const store = makeStore([
+      { rule_id: "R10a", subject: "CTL-1/plan" },
+      { rule_id: "R10b", subject: "CTL-1/plan" },
+    ]);
+    expect(countFiringByRule(store).get("R10")).toBe(1);
+  });
 });
 
 // ── subjectsForRule ───────────────────────────────────────────────────────────
@@ -102,6 +112,14 @@ describe("subjectsForRule", () => {
     const subjects = subjectsForRule(store, "R10");
     expect(subjects).toContain("CTL-1/plan");
     expect(subjects).toContain("CTL-2/plan");
+  });
+
+  it("dedups subjects shared across arms (no duplicate React keys)", () => {
+    const store = makeStore([
+      { rule_id: "R10a", subject: "CTL-1/plan" },
+      { rule_id: "R10b", subject: "CTL-1/plan" },
+    ]);
+    expect(subjectsForRule(store, "R10")).toEqual(["CTL-1/plan"]);
   });
 
   it("returns empty array from empty store", () => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-live.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-live.test.ts
@@ -1,0 +1,110 @@
+// rulebook-live.test.ts — CTL-1103 Phase 4: pure selectors for the live
+// Rulebook margin data derived from BeliefsState. No DOM. Run from ui/:
+//   cd ui && bun test src/lib/rulebook-live.test.ts
+import { describe, it, expect } from "bun:test";
+import {
+  countFiringByRule,
+  subjectsForRule,
+} from "./rulebook-live";
+import { EMPTY_BELIEFS_STATE, type BeliefStore } from "./beliefs-model";
+import type { BeliefFrame } from "./beliefs-model";
+
+// ── fixture helpers ───────────────────────────────────────────────────────────
+
+let _seq = 1;
+function makeFrame(rule_id: string, subject: string): BeliefFrame {
+  const id = _seq++;
+  return {
+    belief_id: id,
+    tick_id: 1,
+    rule_id,
+    name: rule_id.toLowerCase(),
+    subject,
+    value: null,
+    source_fact_ids: "[]",
+    stratum: 1,
+    ts_ms: null,
+    host: null,
+    rules_sha: null,
+  };
+}
+
+function makeStore(
+  entries: Array<{ rule_id: string; subject: string }>,
+): BeliefStore {
+  const store: BeliefStore = new Map();
+  for (const e of entries) {
+    const frame = makeFrame(e.rule_id, e.subject);
+    const key = `${frame.rule_id} ${frame.subject}`;
+    store.set(key, frame);
+  }
+  return store;
+}
+
+// ── countFiringByRule ─────────────────────────────────────────────────────────
+
+describe("countFiringByRule", () => {
+  it("groups store entries by rule_id", () => {
+    const store = makeStore([
+      { rule_id: "R1", subject: "CTL-1/plan" },
+      { rule_id: "R1", subject: "CTL-2/plan" },
+      { rule_id: "R6", subject: "CTL-3/impl" },
+    ]);
+    const counts = countFiringByRule(store);
+    expect(counts.get("R1")).toBe(2);
+    expect(counts.get("R6")).toBe(1);
+  });
+
+  it("returns an empty map for the empty store (recording off)", () => {
+    expect(countFiringByRule(EMPTY_BELIEFS_STATE.store).size).toBe(0);
+  });
+
+  it("handles a store with a single entry", () => {
+    const store = makeStore([{ rule_id: "R5", subject: "CTL-99/verify" }]);
+    expect(countFiringByRule(store).get("R5")).toBe(1);
+  });
+
+  it("maps arm rule_ids R10a/R10b to logical R10", () => {
+    const store = makeStore([
+      { rule_id: "R10a", subject: "CTL-1/plan" },
+      { rule_id: "R10b", subject: "CTL-2/plan" },
+    ]);
+    const counts = countFiringByRule(store);
+    expect(counts.get("R10")).toBe(2);
+    // arm ids should not appear as top-level keys
+    expect(counts.has("R10a")).toBe(false);
+    expect(counts.has("R10b")).toBe(false);
+  });
+});
+
+// ── subjectsForRule ───────────────────────────────────────────────────────────
+
+describe("subjectsForRule", () => {
+  it("returns subjects for a given rule_id", () => {
+    const store = makeStore([
+      { rule_id: "R1", subject: "CTL-1/plan" },
+      { rule_id: "R1", subject: "CTL-2/plan" },
+      { rule_id: "R6", subject: "CTL-3/impl" },
+    ]);
+    expect(subjectsForRule(store, "R1")).toEqual(["CTL-1/plan", "CTL-2/plan"]);
+  });
+
+  it("returns an empty array for a rule with no firing subjects", () => {
+    const store = makeStore([{ rule_id: "R1", subject: "CTL-1/plan" }]);
+    expect(subjectsForRule(store, "R99")).toEqual([]);
+  });
+
+  it("resolves arm rule_ids (R10a→R10) when querying by logical id", () => {
+    const store = makeStore([
+      { rule_id: "R10a", subject: "CTL-1/plan" },
+      { rule_id: "R10b", subject: "CTL-2/plan" },
+    ]);
+    const subjects = subjectsForRule(store, "R10");
+    expect(subjects).toContain("CTL-1/plan");
+    expect(subjects).toContain("CTL-2/plan");
+  });
+
+  it("returns empty array from empty store", () => {
+    expect(subjectsForRule(EMPTY_BELIEFS_STATE.store, "R1")).toEqual([]);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-live.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-live.ts
@@ -9,21 +9,34 @@ function toLogicalId(rule_id: string): string {
 
 /** Count distinct firing subjects per logical rule_id. */
 export function countFiringByRule(store: BeliefStore): Map<string, number> {
-  const counts = new Map<string, number>();
+  // Multi-arm rules (R10a/R10b) collapse to one logical id and can both fire on
+  // the same subject; count distinct subjects per logical rule, not raw frames.
+  const subjectsById = new Map<string, Set<string>>();
   for (const frame of store.values()) {
     const id = toLogicalId(frame.rule_id);
-    counts.set(id, (counts.get(id) ?? 0) + 1);
+    let subjects = subjectsById.get(id);
+    if (subjects === undefined) {
+      subjects = new Set<string>();
+      subjectsById.set(id, subjects);
+    }
+    subjects.add(frame.subject);
+  }
+  const counts = new Map<string, number>();
+  for (const [id, subjects] of subjectsById) {
+    counts.set(id, subjects.size);
   }
   return counts;
 }
 
 /** List unique subjects currently satisfying a logical rule. */
 export function subjectsForRule(store: BeliefStore, ruleId: string): string[] {
-  const subjects: string[] = [];
+  // Dedup: multi-arm rules (R10a/R10b → R10) can fire on the same subject across
+  // arms, which would otherwise yield duplicate React keys in the derivations rail.
+  const subjects = new Set<string>();
   for (const frame of store.values()) {
     if (toLogicalId(frame.rule_id) === ruleId) {
-      subjects.push(frame.subject);
+      subjects.add(frame.subject);
     }
   }
-  return subjects;
+  return [...subjects];
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-live.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-live.ts
@@ -1,0 +1,29 @@
+// rulebook-live.ts — CTL-1103 Phase 4: pure selectors for live rule firing
+// data derived from BeliefsState. No DOM, no fetches.
+import type { BeliefStore } from "./beliefs-model";
+
+// Multi-arm rule logical id mapping: R10a/R10b → R10.
+function toLogicalId(rule_id: string): string {
+  return rule_id.replace(/^(R\d+)[a-z]$/, "$1");
+}
+
+/** Count distinct firing subjects per logical rule_id. */
+export function countFiringByRule(store: BeliefStore): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const frame of store.values()) {
+    const id = toLogicalId(frame.rule_id);
+    counts.set(id, (counts.get(id) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/** List unique subjects currently satisfying a logical rule. */
+export function subjectsForRule(store: BeliefStore, ruleId: string): string[] {
+  const subjects: string[] = [];
+  for (const frame of store.values()) {
+    if (toLogicalId(frame.rule_id) === ruleId) {
+      subjects.push(frame.subject);
+    }
+  }
+  return subjects;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-model.test.ts
@@ -1,0 +1,181 @@
+// rulebook-model.test.ts — CTL-1103 Phase 3: pure model tests for the Rulebook
+// surface data layer. No DOM; run from the ui package:
+//   cd ui && bun test src/lib/rulebook-model.test.ts
+import { describe, it, expect } from "bun:test";
+import {
+  groupRulesByStratum,
+  severityTone,
+  isRuleManifest,
+  type RuleManifest,
+} from "./rulebook-model";
+
+// ── Fixture ───────────────────────────────────────────────────────────────────
+
+const MANIFEST_FIXTURE: RuleManifest = {
+  preface: {
+    problem: "Test problem description.",
+    datalog_primer: "Datalog primer text.",
+  },
+  strata: [
+    { id: 1, label: "S1 ground correlations", prose: "Stratum 1 prose." },
+    { id: 2, label: "S2 liveness verdicts", prose: "Stratum 2 prose." },
+    { id: 3, label: "S3 capacity aggregation", prose: "Stratum 3 prose." },
+  ],
+  rules: [
+    {
+      rule_id: "R1",
+      name: "session_registered",
+      stratum: 1,
+      extern: false,
+      description: "The session is registered.",
+      feeds: [],
+      reads: [],
+      negates: [],
+      cfg_keys: [],
+      severity: "info",
+      arms: [
+        {
+          arm_id: "R1",
+          datalog: "SELECT 1",
+          sql: "INSERT INTO belief SELECT ...",
+        },
+      ],
+    },
+    {
+      rule_id: "R2",
+      name: "turn_started",
+      stratum: 1,
+      extern: false,
+      description: "A turn has started.",
+      feeds: ["R4"],
+      reads: [],
+      negates: [],
+      cfg_keys: [],
+      severity: "info",
+      arms: [
+        {
+          arm_id: "R2",
+          datalog: "SELECT 2",
+          sql: "INSERT INTO belief SELECT ...",
+        },
+      ],
+    },
+    {
+      rule_id: "R5",
+      name: "lease_valid",
+      stratum: 2,
+      extern: false,
+      description: "The lease is valid.",
+      feeds: [],
+      reads: ["R1"],
+      negates: [],
+      cfg_keys: ["lease_ms"],
+      severity: "info",
+      arms: [
+        {
+          arm_id: "R5",
+          datalog: "SELECT 5",
+          sql: "INSERT INTO belief SELECT ...",
+        },
+      ],
+    },
+    {
+      rule_id: "R8",
+      name: "free_slots",
+      stratum: 3,
+      extern: true,
+      description: "Aggregate free slots across hosts.",
+      feeds: [],
+      reads: [],
+      negates: [],
+      cfg_keys: [],
+      severity: "info",
+      arms: [
+        {
+          arm_id: "R8",
+          datalog: null,
+          sql: "INSERT INTO belief WITH RECURSIVE ...",
+        },
+      ],
+    },
+  ],
+};
+
+// ── groupRulesByStratum ───────────────────────────────────────────────────────
+
+describe("groupRulesByStratum", () => {
+  it("returns one group per stratum, in ascending stratum order", () => {
+    const grouped = groupRulesByStratum(MANIFEST_FIXTURE);
+    expect(grouped.map((g) => g.stratum.id)).toEqual([1, 2, 3]);
+  });
+
+  it("places rules into their correct stratum group", () => {
+    const grouped = groupRulesByStratum(MANIFEST_FIXTURE);
+    expect(grouped[0].rules.every((r) => r.stratum === 1)).toBe(true);
+    expect(grouped[1].rules.every((r) => r.stratum === 2)).toBe(true);
+    expect(grouped[2].rules.every((r) => r.stratum === 3)).toBe(true);
+  });
+
+  it("attaches the stratum metadata from manifest.strata", () => {
+    const grouped = groupRulesByStratum(MANIFEST_FIXTURE);
+    expect(grouped[0].stratum.label).toBe("S1 ground correlations");
+    expect(grouped[0].stratum.prose).toBe("Stratum 1 prose.");
+  });
+
+  it("places both S1 rules in stratum group 1", () => {
+    const grouped = groupRulesByStratum(MANIFEST_FIXTURE);
+    expect(grouped[0].rules.map((r) => r.rule_id)).toEqual(["R1", "R2"]);
+  });
+
+  it("handles a manifest with no rules without throwing", () => {
+    const empty: RuleManifest = { ...MANIFEST_FIXTURE, rules: [] };
+    const grouped = groupRulesByStratum(empty);
+    expect(grouped.every((g) => g.rules.length === 0)).toBe(true);
+  });
+});
+
+// ── severityTone ──────────────────────────────────────────────────────────────
+
+describe("severityTone", () => {
+  it("returns distinct CSS token strings for info, warn, error", () => {
+    expect(severityTone("info")).not.toBe(severityTone("warn"));
+    expect(severityTone("warn")).not.toBe(severityTone("error"));
+    expect(severityTone("info")).not.toBe(severityTone("error"));
+  });
+
+  it("returns a non-empty string for every known severity", () => {
+    for (const sev of ["info", "warn", "error", ""] as const) {
+      expect(typeof severityTone(sev)).toBe("string");
+      // empty string severity → muted/default token is allowed (non-null)
+    }
+  });
+
+  it("returns a string for unknown/empty severity (no throw)", () => {
+    expect(() => severityTone("" as never)).not.toThrow();
+  });
+});
+
+// ── isRuleManifest ────────────────────────────────────────────────────────────
+
+describe("isRuleManifest", () => {
+  it("returns false for null", () => {
+    expect(isRuleManifest(null)).toBe(false);
+  });
+
+  it("returns false for an empty object", () => {
+    expect(isRuleManifest({})).toBe(false);
+  });
+
+  it("returns false when strata or rules are missing", () => {
+    expect(isRuleManifest({ preface: {}, rules: [] })).toBe(false);
+    expect(isRuleManifest({ preface: {}, strata: [] })).toBe(false);
+  });
+
+  it("returns true for a valid manifest shape", () => {
+    expect(isRuleManifest(MANIFEST_FIXTURE)).toBe(true);
+  });
+
+  it("returns false for non-array rules", () => {
+    expect(isRuleManifest({ preface: {}, strata: [], rules: {} })).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-model.ts
@@ -76,7 +76,11 @@ export function groupRulesByStratum(manifest: RuleManifest): StratumGroup[] {
 
 const SEVERITY_TOKENS: Record<string, string> = {
   error: "text-destructive",
-  warn: "text-warning",
+  // CTL-1103 remediate: `text-warning` had no backing --warning/--color-warning
+  // token in app.css or the Tailwind theme, so warn-severity labels rendered
+  // colorless. Use the amber utility pair (mirrors the info token's blue pair) —
+  // a real, resolvable color distinct from error (destructive) and info (blue).
+  warn: "text-amber-600 dark:text-amber-400",
   info: "text-blue-600 dark:text-blue-400",
   "": "text-muted-foreground",
 };

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-model.ts
@@ -1,0 +1,108 @@
+// rulebook-model.ts — CTL-1103 Phase 3: types and pure helpers for the
+// Rulebook surface. Mirror the /api/beliefs/rules manifest shape.
+
+export interface Preface {
+  problem: string;
+  datalog_primer: string;
+}
+
+export interface RuleArm {
+  arm_id: string;
+  datalog: string | null;
+  sql: string | null;
+}
+
+export interface RuleManifestStratum {
+  id: number;
+  label: string;
+  prose: string;
+}
+
+export interface RuleManifestRule {
+  rule_id: string;
+  name: string;
+  stratum: number;
+  extern: boolean;
+  description: string;
+  feeds: string[];
+  reads: string[];
+  negates: string[];
+  cfg_keys: string[];
+  severity: string;
+  arms: RuleArm[];
+}
+
+export interface RuleManifest {
+  preface: Preface;
+  strata: RuleManifestStratum[];
+  rules: RuleManifestRule[];
+}
+
+export interface StratumGroup {
+  stratum: RuleManifestStratum;
+  rules: RuleManifestRule[];
+}
+
+// ── Type guard ────────────────────────────────────────────────────────────────
+
+export function isRuleManifest(v: unknown): v is RuleManifest {
+  if (!v || typeof v !== "object") return false;
+  const m = v as Record<string, unknown>;
+  return (
+    Array.isArray(m["strata"]) &&
+    Array.isArray(m["rules"]) &&
+    m["preface"] != null
+  );
+}
+
+// ── Grouping ──────────────────────────────────────────────────────────────────
+
+export function groupRulesByStratum(manifest: RuleManifest): StratumGroup[] {
+  const byId = new Map<number, RuleManifestRule[]>();
+  for (const stratum of manifest.strata) {
+    byId.set(stratum.id, []);
+  }
+  for (const rule of manifest.rules) {
+    const bucket = byId.get(rule.stratum);
+    if (bucket) bucket.push(rule);
+  }
+  return manifest.strata
+    .slice()
+    .sort((a, b) => a.id - b.id)
+    .map((stratum) => ({ stratum, rules: byId.get(stratum.id) ?? [] }));
+}
+
+// ── Severity tone ─────────────────────────────────────────────────────────────
+
+const SEVERITY_TOKENS: Record<string, string> = {
+  error: "text-destructive",
+  warn: "text-warning",
+  info: "text-blue-600 dark:text-blue-400",
+  "": "text-muted-foreground",
+};
+
+export function severityTone(severity: string): string {
+  return SEVERITY_TOKENS[severity] ?? "text-muted-foreground";
+}
+
+// ── Preface guard ─────────────────────────────────────────────────────────────
+
+export function prefaceIsComplete(preface: Preface): boolean {
+  if (!preface || typeof preface !== "object") return false;
+  return (
+    typeof preface.problem === "string" &&
+    preface.problem.length > 0 &&
+    typeof preface.datalog_primer === "string" &&
+    preface.datalog_primer.length > 0
+  );
+}
+
+// ── Manifest fetch ────────────────────────────────────────────────────────────
+
+export async function fetchRuleManifest(): Promise<RuleManifest> {
+  const res = await fetch("/api/beliefs/rules");
+  if (!res.ok) throw new Error(`/api/beliefs/rules: ${res.status}`);
+  const data: unknown = await res.json();
+  if (!isRuleManifest(data)) throw new Error("Unexpected manifest shape");
+  return data;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-theme.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-theme.test.ts
@@ -1,0 +1,62 @@
+// rulebook-theme.test.ts — CTL-1103 Phase 5: verifies the three visual channels
+// (strata, severity, live indicator) are mutually distinct. Pure; no DOM.
+// Run: cd ui && bun test src/lib/rulebook-theme.test.ts
+import { describe, it, expect } from "bun:test";
+import {
+  strataTone,
+  severityTone,
+  liveIndicatorTone,
+} from "./rulebook-theme";
+
+describe("strataTone", () => {
+  it("returns a non-empty string for each of the 6 strata", () => {
+    for (const id of [1, 2, 3, 4, 5, 6]) {
+      expect(typeof strataTone(id)).toBe("string");
+      expect(strataTone(id).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("all 6 strata tones are pairwise distinct", () => {
+    const tones = [1, 2, 3, 4, 5, 6].map(strataTone);
+    expect(new Set(tones).size).toBe(6);
+  });
+});
+
+describe("severityTone", () => {
+  it("returns distinct tokens for info, warn, error", () => {
+    expect(severityTone("info")).not.toBe(severityTone("warn"));
+    expect(severityTone("warn")).not.toBe(severityTone("error"));
+    expect(severityTone("info")).not.toBe(severityTone("error"));
+  });
+});
+
+describe("liveIndicatorTone", () => {
+  it("returns a non-empty string for both firing and not-firing", () => {
+    expect(typeof liveIndicatorTone(true)).toBe("string");
+    expect(typeof liveIndicatorTone(false)).toBe("string");
+    expect(liveIndicatorTone(true).length).toBeGreaterThan(0);
+  });
+});
+
+describe("three visual channels are mutually distinct", () => {
+  it("strata, severity, and live indicator each produce a distinct token", () => {
+    const strata = strataTone(1);
+    const sev = severityTone("info");
+    const live = liveIndicatorTone(true);
+    expect(new Set([strata, sev, live]).size).toBe(3);
+  });
+
+  it("strata tone for every id differs from severity(info)", () => {
+    const sevToken = severityTone("info");
+    for (const id of [1, 2, 3, 4, 5, 6]) {
+      expect(strataTone(id)).not.toBe(sevToken);
+    }
+  });
+
+  it("strata tone for every id differs from liveIndicatorTone(true)", () => {
+    const liveToken = liveIndicatorTone(true);
+    for (const id of [1, 2, 3, 4, 5, 6]) {
+      expect(strataTone(id)).not.toBe(liveToken);
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-theme.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-theme.test.ts
@@ -36,6 +36,20 @@ describe("liveIndicatorTone", () => {
     expect(typeof liveIndicatorTone(false)).toBe("string");
     expect(liveIndicatorTone(true).length).toBeGreaterThan(0);
   });
+
+  it("firing and not-firing tokens are distinct", () => {
+    expect(liveIndicatorTone(true)).not.toBe(liveIndicatorTone(false));
+  });
+
+  it("not-firing token does not alias any stratum or severity token", () => {
+    const notFiring = liveIndicatorTone(false);
+    for (const id of [1, 2, 3, 4, 5, 6]) {
+      expect(strataTone(id)).not.toBe(notFiring);
+    }
+    for (const sev of ["info", "warn", "error"]) {
+      expect(severityTone(sev)).not.toBe(notFiring);
+    }
+  });
 });
 
 describe("three visual channels are mutually distinct", () => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-theme.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-theme.test.ts
@@ -20,6 +20,24 @@ describe("strataTone", () => {
     const tones = [1, 2, 3, 4, 5, 6].map(strataTone);
     expect(new Set(tones).size).toBe(6);
   });
+
+  // CTL-1103 remediate (coverage): pin the modulo-wrap branch — tests previously
+  // only exercised ids 1–6 (the non-wrapping range), leaving the (id - 1) % 6
+  // wraparound for id > 6 and the defensive id <= 0 path unasserted.
+  it("wraps id 7 back to id 1 (modulo over the 6 strata)", () => {
+    expect(strataTone(7)).toBe(strataTone(1));
+    expect(strataTone(8)).toBe(strataTone(2));
+    expect(strataTone(12)).toBe(strataTone(6));
+  });
+
+  it("still returns a valid token for out-of-range ids", () => {
+    // The non-negative modulo keeps strataTone total: a bare `(id - 1) % 6`
+    // yields a negative index (→ undefined) for id <= 0. The contract is that
+    // strataTone always returns a token string, never undefined.
+    expect(typeof strataTone(0)).toBe("string");
+    expect(strataTone(0).length).toBeGreaterThan(0);
+    expect(typeof strataTone(-5)).toBe("string");
+  });
 });
 
 describe("severityTone", () => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-theme.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-theme.ts
@@ -16,9 +16,15 @@ const STRATA_VAR = [
   "var(--chart-6)",
 ] as const;
 
-/** CSS variable string for stratum id (1–6). Wraps --chart-N tokens. */
+/** CSS variable string for stratum id (1–6). Wraps --chart-N tokens.
+ *  CTL-1103 remediate: use a non-negative modulo so the helper is total — the
+ *  bare `(id - 1) % length` returned `undefined` for id <= 0 (JS yields a
+ *  negative index), breaking the "always a token" contract for defensive
+ *  callers. Real strata are 1–6; this just keeps unexpected ids from producing
+ *  `undefined`. */
 export function strataTone(id: number): string {
-  return STRATA_VAR[(id - 1) % STRATA_VAR.length];
+  const n = STRATA_VAR.length;
+  return STRATA_VAR[(((id - 1) % n) + n) % n];
 }
 
 /** CSS variable string for the live-indicator badge. Distinct from strata + severity. */

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-theme.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-theme.ts
@@ -1,0 +1,27 @@
+// rulebook-theme.ts — CTL-1103 Phase 5: single source of truth for the three
+// distinct visual channels in the Rulebook surface.
+//  1. strataTone(id)           — one of 6 distinct chart-* CSS tokens.
+//  2. severityTone(severity)   — semantic severity token (re-exported from rulebook-model).
+//  3. liveIndicatorTone(firing) — the reserved LIVE color token when firing.
+// Contract: all three channels are mutually distinct (pinned by rulebook-theme.test.ts).
+
+export { severityTone } from "./rulebook-model";
+
+const STRATA_VAR = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+] as const;
+
+/** CSS variable string for stratum id (1–6). Wraps --chart-N tokens. */
+export function strataTone(id: number): string {
+  return STRATA_VAR[(id - 1) % STRATA_VAR.length];
+}
+
+/** CSS variable string for the live-indicator badge. Distinct from strata + severity. */
+export function liveIndicatorTone(firing: boolean): string {
+  return firing ? "var(--color-live)" : "transparent";
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-constants.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-constants.ts
@@ -10,7 +10,8 @@ export type Surface =
   | "utilization"
   | "finops"
   | "fleetops"
-  | "devops";
+  | "devops"
+  | "rulebook";
 
 export const SURFACES: readonly Surface[] = [
   "home",
@@ -21,6 +22,7 @@ export const SURFACES: readonly Surface[] = [
   "finops",
   "fleetops",
   "devops",
+  "rulebook",
 ] as const;
 
 export const SURFACE_LABEL: Record<Surface, string> = {
@@ -32,6 +34,7 @@ export const SURFACE_LABEL: Record<Surface, string> = {
   finops: "FinOps",
   fleetops: "Fleet Ops",
   devops: "DevOps",
+  rulebook: "Rulebook",
 };
 
 export const SURFACE_CHORD: Record<string, Surface> = {
@@ -43,6 +46,7 @@ export const SURFACE_CHORD: Record<string, Surface> = {
   f: "finops",
   o: "fleetops",
   d: "devops",
+  r: "rulebook",
 };
 
 export const SURFACE_BREADCRUMB: Record<Surface, string[]> = {
@@ -54,4 +58,5 @@ export const SURFACE_BREADCRUMB: Record<Surface, string[]> = {
   finops: ["Observe", "FinOps"],
   fleetops: ["Observe", "Fleet Ops"],
   devops: ["Observe", "DevOps"],
+  rulebook: ["Reason", "Rulebook"],
 };

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.test.ts
@@ -64,7 +64,8 @@ describe("surfaceContentKind", () => {
         s !== "telemetry" &&
         s !== "finops" &&
         s !== "utilization" &&
-        s !== "fleetops",
+        s !== "fleetops" &&
+        s !== "rulebook",
     );
     for (const s of stillDashboard) {
       expect(surfaceContentKind(s)).toBe("dashboard");
@@ -80,9 +81,14 @@ describe("surfaceContentKind", () => {
         "finops",
         "utilization",
         "fleetops",
+        "rulebook",
         "dashboard",
       ]).toContain(surfaceContentKind(s));
     }
+  });
+
+  it("routes the Rulebook surface to its own content kind (CTL-1103)", () => {
+    expect(surfaceContentKind("rulebook" as Surface)).toBe("rulebook");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/surface-content.ts
@@ -42,6 +42,7 @@ export type SurfaceContentKind =
   | "finops"
   | "utilization"
   | "fleetops"
+  | "rulebook"
   | "dashboard";
 
 /**
@@ -67,6 +68,8 @@ export function surfaceContentKind(surface: Surface): SurfaceContentKind {
   // remaining surface (devops) stays on the dashboard fall-through (nav-disabled
   // "soon") until its own OBS ticket lands.
   if (surface === "fleetops") return "fleetops";
+  // CTL-1103: Rulebook is the first REASON surface.
+  if (surface === "rulebook") return "rulebook";
   return "dashboard";
 }
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-14T01:59:45Z -->
<!-- Last updated: 2026-06-14T01:59:45Z -->
<!-- PR: #1972 -->
<!-- Previous commits: d3319180,f3808e71,fc50e730,5e017f59,2d8da857,4a78019d,3bb4ee56,233c35f2,7ac4616b -->

## Summary

Adds the **Governance Rulebook** (`/rules`) — a live textbook of the belief engine's 17 rules across 6 strata, readable in Plain English, Datalog, and the exact SQL the engine executes. Operators can now read, understand, and trust every rule that drives live/wedged/retry/escalation conclusions, with firing-rate badges and expandable derivation trees that show exactly which facts drove each conclusion.

**Delivered across 5 phases:**

- **Phase 1** — manifest copy layer: `fetchRuleManifest()` pulls from `/api/beliefs/rules`, with `annotations.mjs` enriching each rule with Plain English summaries sourced from the Datalog source comments
- **Phase 2** — surface registration: `rulebook` added to Surface union, SURFACES array, SURFACE_CHORD (`g r`), breadcrumb (`Reason / Rulebook`), and TanStack lazy route at `/rules`; new "Reason" collapsible sidebar group with `navReasonOpenAtom` persisted in localStorage
- **Phase 3** — static textbook: preface → strata ladder → per-stratum rule cards with tri-lingual Tabs (Plain English | Datalog | SQL) → thresholds appendix; fully readable from the static manifest alone
- **Phase 4** — live margins: wires `useBeliefsContext()` (the dedupe SSE client from CTL-1100, zero new EventSources) to fire-count badges and a derivations side rail; `countFiringByRule` normalizes `R10a/R10b` → `R10`
- **Phase 5** — visual theming: `strataTone()` / `liveIndicatorTone()` / `severityTone()` via CSS vars (`--chart-1..6`, `--color-live`); the three channels are pinned pairwise-distinct by contract tests

## Changes Made

### Belief engine / manifest layer

- **`plugins/dev/scripts/execution-core/beliefs/compiler/annotations.mjs`** — new file; enriches compiled rules with Plain English summaries extracted from Datalog comment annotations
- **`plugins/dev/scripts/execution-core/beliefs/compiler/manifest.mjs`** — updated to invoke `annotations.mjs` and expose full rule metadata via `/api/beliefs/rules`
- **`plugins/dev/scripts/execution-core/beliefs/rules.dl`** — annotated with Plain English descriptions for all 17 rules
- **`plugins/dev/scripts/execution-core/beliefs/rules.generated.mjs`** — regenerated from the annotated Datalog

### Surface registration / routing

- **`plugins/dev/scripts/orch-monitor/ui/src/lib/surface-constants.ts`** — `rulebook` added to Surface union, SURFACES, SURFACE_CHORD, SURFACE_BREADCRUMB, SURFACE_PATH
- **`plugins/dev/scripts/orch-monitor/ui/src/lib/route-surface.ts`** — lazy TanStack route for `/rules`
- **`plugins/dev/scripts/orch-monitor/ui/src/board/nav-store.ts`** — `navReasonOpenAtom` (localStorage-persisted) for the "Reason" sidebar group
- **`plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx`** — new "Reason" collapsible group (below Observe) with Rulebook entry
- **`plugins/dev/scripts/orch-monitor/ui/src/app-router.tsx`** — `/rules` route wired

### Rulebook UI components

- **`ui/src/components/rulebook/rulebook-surface.tsx`** — top-level surface: preface → strata ladder → rule-card grid → thresholds appendix
- **`ui/src/components/rulebook/preface-section.tsx`** — problem statement + Datalog primer for external readers
- **`ui/src/components/rulebook/strata-ladder.tsx`** — visual 6-stratum ladder with per-stratum rule counts
- **`ui/src/components/rulebook/rule-card.tsx`** — per-rule card with tri-lingual Tabs; extern rules show "no Datalog" note
- **`ui/src/components/rulebook/thresholds-appendix.tsx`** — table of configurable thresholds read from `/api/beliefs/cfg`
- **`ui/src/components/rulebook/live-indicator.tsx`** — firing badge shown on rule cards when belief recording is active
- **`ui/src/components/rulebook/derivations-rail.tsx`** — side rail listing entities a rule is concluding about, with expandable derivation trees

### Library / model files

- **`ui/src/lib/rulebook-model.ts`** — `RuleManifest`, `StratumGroup`, `RuleEntry` types; `fetchRuleManifest()`, `groupByStratum()`, `countFiringByRule()` (normalizes R10a/R10b → R10)
- **`ui/src/lib/rulebook-live.ts`** — wires `useBeliefsContext()` SSE stream to firing-rate data; zero new EventSources
- **`ui/src/lib/rulebook-theme.ts`** — `strataTone()`, `liveIndicatorTone()`, `severityTone()` CSS-var helpers
- **`ui/src/lib/prefs.ts`** — extended to persist `navReasonOpen` preference
- **`ui/src/lib/surface-content.ts`** — updated with Rulebook entry

### Test files (13 test files)

- `annotations.test.mjs`, `governance-rules-manifest.contract.test.ts`, `app-shell.test.ts`
- `nav-sections.test.ts`, `rulebook-live.test.ts`, `rulebook-model.test.ts`, `rulebook-theme.test.ts`
- `preface-section.test.ts`, `rule-card.test.ts`, `derivations-rail.test.ts`
- `prefs.test.ts`, `route-surface.test.ts`, `surface-content.test.ts`

## How to Verify It

- [x] `bun test plugins/dev/scripts/orch-monitor/` — CTL-1103's 123 tests all pass; 9 full-suite failures are all pre-existing baseline (7 reproduce on origin/main, 2 governance-journey tests pass in isolation)
- [x] `bun run typecheck` from `plugins/dev/scripts/orch-monitor/ui/` — clean; UI-tsconfig errors are baseline bun:test/node:* noise, zero in new rulebook source
- [x] `eslint` — 0 errors, 53 warnings (all pre-existing non-null-assertions + 2 baseline security warnings in server.ts/preview-status.ts)
- [ ] Navigate to `/rules` — Rulebook surface loads with preface, strata ladder, 17 rule cards across 6 strata
- [ ] Each card's Datalog and SQL tabs render correctly; extern rules (no Datalog) show the note
- [ ] Press `g` then `r` — jumps to `/rules` surface
- [ ] "Reason" sidebar group collapses/expands and persists across reload
- [ ] With belief recording active: firing rule cards show live count badge; clicking opens the derivations rail with entity list and expandable derivation trees
- [ ] With belief recording off: textbook renders fully from static manifest; live margins are quiet (no errors)

## Related Issues

- Fixes https://linear.app/coalesce/issue/CTL-1103

Refs: CTL-1103

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1100
