### PR TITLE
fix(dev): CTL-1107 — guard empty start_args array in cmd_restart under bash 3.2

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
@@ -159,6 +159,28 @@ run "restart exits 0" bash -c "
   PATH='${STUBDIR}:${REAL_PATH}' '${STACK}' restart >/dev/null 2>&1
 "
 
+# CTL-1107: restart with no args must not crash on empty-array expansion under
+# bash 3.2 (macOS system shell). The plain "restart exits 0" test above passes
+# on bash 5.x regardless, so pin the system bash explicitly to guard the fix.
+if [[ -x /bin/bash ]]; then
+  run "restart exits 0 under system bash (3.2)" /bin/bash -c "
+    set +e
+    PATH='${STUBDIR}:${REAL_PATH}' /bin/bash '${STACK}' restart >'${SCRATCH}/sysbash.out' 2>&1
+    rc=\$?
+    set -e
+    if [[ \$rc -ne 0 ]]; then
+      echo 'restart crashed under system bash:'; cat '${SCRATCH}/sysbash.out'
+      exit 1
+    fi
+    if grep -q 'unbound variable' '${SCRATCH}/sysbash.out'; then
+      echo 'restart emitted unbound-variable error:'; cat '${SCRATCH}/sysbash.out'
+      exit 1
+    fi
+  "
+else
+  echo "  SKIP: /bin/bash not present — cannot pin bash 3.2 regression"
+fi
+
 # ── CTL-946: proxy env-injection assertions ───────────────────────────────────
 # A stub that records its env to a file, so we can assert what the daemon sees.
 

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -463,7 +463,7 @@ cmd_restart() {
   # Pass through all flags except --hotpatch (already applied above)
   local start_args=()
   for a in "$@"; do [[ "$a" != "--hotpatch" ]] && start_args+=("$a"); done
-  cmd_start "${start_args[@]}"
+  cmd_start "${start_args[@]+"${start_args[@]}"}"
 }
 
 # CTL-1084: read the latest node.boot payload from the unified event log.


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-14T03:40:30Z -->
<!-- Last updated: 2026-06-14T03:40:30Z -->
<!-- PR: #1976 -->
<!-- Previous commits: ee4bf8208caffc0a2790271e4c98db7268608056 -->

## Summary

`catalyst-stack restart` with no extra flags crashed mid-restart under bash 3.2 (macOS system
shell) — stopping every component and then failing before starting them back up, leaving the
entire fleet DOWN. The crash: `start_args[@]: unbound variable` triggered by `set -u` when
the array was empty. This fixes the expansion to use the canonical codebase guard form and
adds a regression test that pins `/bin/bash` (3.2) explicitly so the fix is verified against
the shell that actually fails.

## Changes Made

### Bug Fix

- **`plugins/dev/scripts/catalyst-stack`** — replace `"${start_args[@]}"` with
  `"${start_args[@]+"${start_args[@]}"}"`  in `cmd_restart` (line 466). The
  guarded form is the codebase-canonical idiom for optional array expansion under `set -u`;
  it evaluates to nothing (not an error) when `start_args` is empty.

### Tests

- **`plugins/dev/scripts/__tests__/catalyst-stack.test.sh`** — adds a new test case
  `"restart exits 0 under system bash (3.2)"` that re-runs the restart path via `/bin/bash`
  explicitly. The existing `"restart exits 0"` test ran under the outer runner (bash 5.x on
  most CI hosts) and would have passed regardless; the new test pins the system shell so the
  regression is caught even when CI uses a modern bash. Checks both exit code and absence of
  `unbound variable` in stderr.

## How to Verify It

- [x] `validate` CI check passes ✅
- [x] `audit-references` CI check passes ✅
- [x] `check-versions` CI check passes ✅
- [x] `docs-gate` CI check passes ✅
- [ ] Manual: run `catalyst-stack restart` with no extra args on macOS (system bash 3.2) and
      confirm the stack comes fully back up — no `unbound variable` error, no components
      left stopped.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1107
