### PR TITLE
chore(meta): untrack personal thoughts/ symlinks (per-machine via humanlayer init)

### DIFF
--- a/thoughts/global
+++ b/thoughts/global
@@ -1,1 +1,0 @@
-/Users/ryanrozich/code-repos/github/coalesce-labs/thoughts/global

--- a/thoughts/ryan
+++ b/thoughts/ryan
@@ -1,1 +1,0 @@
-/Users/ryanrozich/code-repos/github/coalesce-labs/thoughts/repos/catalyst-workspace/ryan

--- a/thoughts/shared
+++ b/thoughts/shared
@@ -1,1 +1,0 @@
-/Users/ryanrozich/code-repos/github/coalesce-labs/thoughts/repos/catalyst-workspace/shared


### PR DESCRIPTION
## What
`git rm --cached` the three `thoughts/{global,ryan,shared}` symlinks so they are no longer tracked.

## Why
They were committed from a host with `$HOME=/Users/ryanrozich`, so on every checkout / `git reset --hard origin/main` they were restored as **dangling** links on hosts where `$HOME=/Users/ryan` — silently cutting off **all** `thoughts/` access (skills, phase agents, daemons, the orch-monitor inbox). This is also a repo-rule violation (CLAUDE.md: "do not commit personal thoughts user").

## Durability
- `.gitignore` already excludes `thoughts/` (line 23); humanlayer's pre-commit hook blocks re-adding it. These three predate both.
- Symlinks are regenerated per-machine by `humanlayer thoughts init` (the correct mechanism).
- **Until this merges, a `git reset --hard origin/main` on any host re-creates the broken links** — merge to fully propagate (laptop ✓ fixed locally; mini + plugin-source need this on origin/main).

## Follow-up (not in this PR)
- `create-worktree.sh` should run `humanlayer thoughts init` for new worktrees (so untracked symlinks are regenerated rather than inherited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)