### PR TITLE
feat(dev): CTL-1131 — durable needsHumanSince anchor + escalation signal persistence (Phases 1–2)

### DIFF
--- a/plugins/dev/scripts/execution-core/beliefs/escalate.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/escalate.mjs
@@ -57,7 +57,9 @@ import { log } from "../config.mjs";
 import { buildExplanation, coerceExplanation, tierProducer } from "../escalation-explanation.mjs";
 
 function firstLine(s) {
-  return String(s ?? "").split(/\r?\n/)[0].slice(0, 200);
+  return String(s ?? "")
+    .split(/\r?\n/)[0]
+    .slice(0, 200);
 }
 
 // ── executeEscalations — per-tick executor for R12 escalate_human beliefs.
@@ -87,7 +89,7 @@ export function executeEscalations(
     labelOnceFn = labelOnce,
     env = process.env,
     evidenceBySubject = {},
-  } = {},
+  } = {}
 ) {
   let escalated = 0; // subjects whose intent we flipped to 'escalated'
   let paged = 0; // subjects we FRESHLY applied needs-human for (first apply only — CTL-962)
@@ -111,7 +113,7 @@ export function executeEscalations(
     `UPDATE intent SET outcome = 'escalated'
       WHERE kind = 'wake-diagnostician' AND subject = ?
         AND outcome IS NULL
-        AND attempts >= (SELECT value_int FROM cfg WHERE key = 'max_attempts')`,
+        AND attempts >= (SELECT value_int FROM cfg WHERE key = 'max_attempts')`
   );
 
   for (const row of beliefs) {
@@ -128,7 +130,10 @@ export function executeEscalations(
       if (enforce !== true) {
         // SHADOW: record-only. No label, no flip, no emit.
         skipped++;
-        log.debug({ subject, ticket, why }, "escalate: would escalate (shadow) — no label, no flip");
+        log.debug(
+          { subject, ticket, why },
+          "escalate: would escalate (shadow) — no label, no flip"
+        );
         continue;
       }
 
@@ -161,7 +166,8 @@ export function executeEscalations(
             // captureEvidence does not emit these today → production defaults AUTHORIZATION.
             const evType = typeof ev.escalation_type === "string" ? ev.escalation_type : null;
             const evCanExecute = typeof ev.canExecute === "boolean" ? ev.canExecute : undefined;
-            const evBlocked = typeof ev.blockedCapability === "string" ? ev.blockedCapability : undefined;
+            const evBlocked =
+              typeof ev.blockedCapability === "string" ? ev.blockedCapability : undefined;
             const evProblem = ev.logsOutput
               ? `${phaseName ?? "phase"} failed: ${firstLine(ev.logsOutput)}`
               : `${phaseName ?? "phase"} escalated (${why ?? "no diagnosis"})`;
@@ -171,11 +177,15 @@ export function executeEscalations(
               explanationFields = {
                 escalation_type: "decision",
                 problem: evProblem,
-                call_to_action: ev.humanQuestion ?? `decide next action for ${ticket} ${phaseName ?? "phase"}`,
-                options: Array.isArray(ev.options) && ev.options.length >= 2 ? ev.options : [
-                  { label: "retry", tradeoff: "may hit the same failure" },
-                  { label: "abandon / re-scope", tradeoff: "loses partial progress" },
-                ],
+                call_to_action:
+                  ev.humanQuestion ?? `decide next action for ${ticket} ${phaseName ?? "phase"}`,
+                options:
+                  Array.isArray(ev.options) && ev.options.length >= 2
+                    ? ev.options
+                    : [
+                        { label: "retry", tradeoff: "may hit the same failure" },
+                        { label: "abandon / re-scope", tradeoff: "loses partial progress" },
+                      ],
                 why_you: ev.why_you ?? `priority call for ${ticket} ${phaseName ?? "phase"}`,
               };
             } else if (evCanExecute === false || evBlocked) {
@@ -183,11 +193,14 @@ export function executeEscalations(
               explanationFields = {
                 escalation_type: "manual",
                 problem: evProblem,
-                call_to_action: ev.humanQuestion ?? `restore ${evBlocked ?? "required capability"} and re-run phase`,
+                call_to_action:
+                  ev.humanQuestion ??
+                  `restore ${evBlocked ?? "required capability"} and re-run phase`,
                 blocked_capability: evBlocked ?? "required capability unavailable",
-                instructions: Array.isArray(ev.instructions) && ev.instructions.length > 0
-                  ? ev.instructions
-                  : ["check the required credential or scope"],
+                instructions:
+                  Array.isArray(ev.instructions) && ev.instructions.length > 0
+                    ? ev.instructions
+                    : ["check the required credential or scope"],
                 remediation_then_retry: `re-run ${ticket} ${phaseName ?? "phase"} after restoring access`,
                 why_not_auto: `capability boundary: ${evBlocked ?? "required capability unavailable"}`,
               };
@@ -196,23 +209,32 @@ export function executeEscalations(
               explanationFields = {
                 escalation_type: "authorization",
                 problem: evProblem,
-                call_to_action: ev.humanQuestion ?? `authorize ${ticket}/${phaseName ?? "phase"} to continue — review and decide?`,
+                call_to_action:
+                  ev.humanQuestion ??
+                  `authorize ${ticket}/${phaseName ?? "phase"} to continue — review and decide?`,
                 recommendation: `re-run ${phaseName ?? "phase"} for ${ticket} with diagnostician output`,
-                risk: why ? `unresolved diagnostician signal: ${why}` : `${phaseName ?? "phase"} escalated with no specific diagnostics`,
+                risk: why
+                  ? `unresolved diagnostician signal: ${why}`
+                  : `${phaseName ?? "phase"} escalated with no specific diagnostics`,
                 why_asking: "risk-authority gate, not a capability gap",
                 could_higher_tier_resolve: tierProducer(ev.jobState?.model),
                 authorize_label: `retry ${ticket}/${phaseName ?? "phase"}`,
               };
             }
             // Passthrough observed/attempts (D1)
-            if (ev.jobState && typeof ev.jobState === "object") explanationFields.observed = ev.jobState;
+            if (ev.jobState && typeof ev.jobState === "object")
+              explanationFields.observed = ev.jobState;
             if (Array.isArray(ev.attempts)) explanationFields.attempts = ev.attempts;
 
             let explanation;
             try {
               explanation = buildExplanation(explanationFields);
             } catch {
-              explanation = coerceExplanation(explanationFields, { ticket, phase: phaseName, canExecute: evCanExecute });
+              explanation = coerceExplanation(explanationFields, {
+                ticket,
+                phase: phaseName,
+                canExecute: evCanExecute,
+              });
             }
             appendEvent({
               "event.name": "escalate.human",
@@ -237,7 +259,11 @@ export function executeEscalations(
                 writeFileSync(tmp, `${JSON.stringify(updated, null, 2)}\n`);
                 renameSync(tmp, sigPath);
               } catch (sigErr) {
-                errors.push({ subject, phase: "signalWrite", err: String(sigErr?.message ?? sigErr) });
+                errors.push({
+                  subject,
+                  phase: "signalWrite",
+                  err: String(sigErr?.message ?? sigErr),
+                });
               }
             }
           } catch (evtErr) {
@@ -253,9 +279,15 @@ export function executeEscalations(
       if (info?.changes > 0) escalated++;
 
       if (firstPage) {
-        log.warn({ subject, ticket, why }, "escalate: paged operator (needs-human) and flipped intent → escalated");
+        log.warn(
+          { subject, ticket, why },
+          "escalate: paged operator (needs-human) and flipped intent → escalated"
+        );
       } else {
-        log.debug({ subject, ticket, why }, "escalate: needs-human already applied — re-arm suppressed (no new event/page)");
+        log.debug(
+          { subject, ticket, why },
+          "escalate: needs-human already applied — re-arm suppressed (no new event/page)"
+        );
       }
     } catch (err) {
       errors.push({ subject, phase: "escalate", err: String(err?.message ?? err) });

--- a/plugins/dev/scripts/execution-core/beliefs/escalate.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/escalate.mjs
@@ -50,6 +50,8 @@
 //     needs-human label once via labelOnce, and flip the matching capped
 //     wake-diagnostician intent(s) to 'escalated'.
 
+import { readFileSync, writeFileSync, renameSync } from "node:fs";
+import { join } from "node:path";
 import { labelOnce } from "../label-guard.mjs";
 import { log } from "../config.mjs";
 import { buildExplanation, coerceExplanation, tierProducer } from "../escalation-explanation.mjs";
@@ -216,6 +218,28 @@ export function executeEscalations(
               "event.name": "escalate.human",
               payload: { subject, ticket, why, explanation },
             });
+
+            // CTL-1131: the board reads the SIGNAL, not the event log — persist
+            // the explanation + a durable needsHumanSince so the detail-pane card
+            // renders and the waiting-age anchor is real. Best-effort; a write
+            // failure is recorded but never aborts the escalation (the label/page
+            // already landed).
+            if (orchDir && phaseName) {
+              try {
+                const sigPath = join(orchDir, "workers", ticket, `phase-${phaseName}.json`);
+                const cur = JSON.parse(readFileSync(sigPath, "utf8"));
+                const updated = {
+                  ...cur,
+                  explanation,
+                  needsHumanSince: cur.needsHumanSince ?? new Date().toISOString(),
+                };
+                const tmp = `${sigPath}.tmp.${process.pid}`;
+                writeFileSync(tmp, `${JSON.stringify(updated, null, 2)}\n`);
+                renameSync(tmp, sigPath);
+              } catch (sigErr) {
+                errors.push({ subject, phase: "signalWrite", err: String(sigErr?.message ?? sigErr) });
+              }
+            }
           } catch (evtErr) {
             errors.push({ subject, phase: "appendEvent", err: String(evtErr?.message ?? evtErr) });
           }

--- a/plugins/dev/scripts/execution-core/beliefs/escalate.test.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/escalate.test.mjs
@@ -71,15 +71,18 @@ function insertEscalateHuman(tickId, subject, why = "stalled-alive") {
   db.run(
     `INSERT INTO belief (tick_id, stratum, name, subject, value, rule_id, source_fact_ids)
      VALUES (?, 4, 'escalate_human', ?, ?, 'R12', '[]')`,
-    [tickId, subject, JSON.stringify({ why })],
+    [tickId, subject, JSON.stringify({ why })]
   );
 }
 // Insert a wake-diagnostician intent row directly (UNIT tests).
 function insertWakeIntent(tickId, subject, { attempts = 2, outcome = null } = {}) {
-  db.run(
-    "INSERT INTO intent (tick_id, kind, subject, attempts, outcome) VALUES (?, ?, ?, ?, ?)",
-    [tickId, "wake-diagnostician", subject, attempts, outcome],
-  );
+  db.run("INSERT INTO intent (tick_id, kind, subject, attempts, outcome) VALUES (?, ?, ?, ?, ?)", [
+    tickId,
+    "wake-diagnostician",
+    subject,
+    attempts,
+    outcome,
+  ]);
   return db.query("SELECT last_insert_rowid() AS id").get().id;
 }
 
@@ -192,7 +195,7 @@ describe("executeEscalations — enforce mode (enforce=true)", () => {
       labelOnceFn,
     });
     expect(db.query("SELECT outcome FROM intent WHERE intent_id = ?").get(intentId).outcome).toBe(
-      "escalated",
+      "escalated"
     );
 
     // Next tick: with the intent now 'escalated', R11 (outcome IS NULL) no longer
@@ -304,7 +307,9 @@ describe("executeEscalations — enforce mode (enforce=true)", () => {
     // We still page (R12 fired), but the uncapped intent stays open.
     expect(res.paged).toBe(1);
     expect(res.escalated).toBe(0);
-    expect(db.query("SELECT outcome FROM intent WHERE intent_id = ?").get(freshId).outcome).toBeNull();
+    expect(
+      db.query("SELECT outcome FROM intent WHERE intent_id = ?").get(freshId).outcome
+    ).toBeNull();
   });
 
   test("never throws — a writeStatus that throws is isolated per subject", () => {
@@ -509,7 +514,7 @@ describe("MULTI-TICK LADDER — R4 → R10 → R11 → R12 in real tick order, p
     // R12 provenance cites the wake belief AND the action_ineffective belief
     const wd = beliefRows(t3.tickId, "wake_diagnostician")[0];
     expect(JSON.parse(r12[0].source_fact_ids).sort()).toEqual(
-      [`b${wd.belief_id}`, `b${r11[0].belief_id}`].sort(),
+      [`b${wd.belief_id}`, `b${r11[0].belief_id}`].sort()
     );
     // executor pages ONCE this tick
     expect(t3.esc.paged).toBe(1);
@@ -673,13 +678,16 @@ describe("CTL-1131: executeEscalations (enforce) writes explanation + needsHuman
   }
 
   function readSignal(orchDir, ticket, phase) {
-    return JSON.parse(readFileSync(join(orchDir, "workers", ticket, `phase-${phase}.json`), "utf8"));
+    return JSON.parse(
+      readFileSync(join(orchDir, "workers", ticket, `phase-${phase}.json`), "utf8")
+    );
   }
 
   test("first page: signal gains explanation + needsHumanSince; prior fields preserved", () => {
     seedCfg("max_attempts", 2);
     const t = insertTick(NOW);
-    const ticket = "CTL-1131x", phase = "implement";
+    const ticket = "CTL-1131x",
+      phase = "implement";
     const subject = `${ticket}/${phase}`;
     insertEscalateHuman(t, subject, "stalled-alive");
     insertWakeIntent(t, subject, { attempts: 2, outcome: null });
@@ -711,7 +719,8 @@ describe("CTL-1131: executeEscalations (enforce) writes explanation + needsHuman
   test("missing signal file: no throw, escalation still returns paged=1", () => {
     seedCfg("max_attempts", 2);
     const t = insertTick(NOW);
-    const ticket = "CTL-1131y", phase = "implement";
+    const ticket = "CTL-1131y",
+      phase = "implement";
     const subject = `${ticket}/${phase}`;
     insertEscalateHuman(t, subject, "stalled-alive");
     insertWakeIntent(t, subject, { attempts: 2, outcome: null });
@@ -733,7 +742,8 @@ describe("CTL-1131: executeEscalations (enforce) writes explanation + needsHuman
   test("re-arm (firstPage=false via labelOnceFn returning false): signal NOT rewritten", () => {
     seedCfg("max_attempts", 2);
     const t = insertTick(NOW);
-    const ticket = "CTL-1131z", phase = "implement";
+    const ticket = "CTL-1131z",
+      phase = "implement";
     const subject = `${ticket}/${phase}`;
     insertEscalateHuman(t, subject, "stalled-alive");
     insertWakeIntent(t, subject, { attempts: 2, outcome: null });

--- a/plugins/dev/scripts/execution-core/beliefs/escalate.test.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/escalate.test.mjs
@@ -13,7 +13,7 @@
 //        executor pages exactly once. Per-tick hand-computed expectations inline.
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -658,5 +658,102 @@ describe("CTL-1130: executeEscalations emits typed-union explanation", () => {
     expect(validateExplanation(expl).valid).toBe(true);
     expect(expl.escalation_type).not.toBe("manual");
     expect(expl.call_to_action).toContain("CTL-7");
+  });
+});
+
+// ─── CTL-1131: executeEscalations persists explanation + needsHumanSince to the phase signal ───
+describe("CTL-1131: executeEscalations (enforce) writes explanation + needsHumanSince to signal", () => {
+  const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+
+  function seedSignal(orchDir, ticket, phase, extra = {}) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    const sig = { ticket, phase, status: "running", ...extra };
+    writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify(sig, null, 2) + "\n");
+  }
+
+  function readSignal(orchDir, ticket, phase) {
+    return JSON.parse(readFileSync(join(orchDir, "workers", ticket, `phase-${phase}.json`), "utf8"));
+  }
+
+  test("first page: signal gains explanation + needsHumanSince; prior fields preserved", () => {
+    seedCfg("max_attempts", 2);
+    const t = insertTick(NOW);
+    const ticket = "CTL-1131x", phase = "implement";
+    const subject = `${ticket}/${phase}`;
+    insertEscalateHuman(t, subject, "stalled-alive");
+    insertWakeIntent(t, subject, { attempts: 2, outcome: null });
+
+    const orchDir = scratch();
+    seedSignal(orchDir, ticket, phase, { bg_job_id: "abc123" });
+
+    const events = [];
+    executeEscalations(db, t, {
+      orchDir,
+      writeStatus: { applyLabel: () => ({ applied: true }) },
+      appendEvent: (e) => events.push(e),
+      enforce: true,
+      labelOnceFn: () => {},
+    });
+
+    const sig = readSignal(orchDir, ticket, phase);
+    expect(sig.explanation).toBeTruthy();
+    expect(typeof sig.needsHumanSince).toBe("string");
+    expect(ISO_RE.test(sig.needsHumanSince)).toBe(true);
+    // prior fields preserved
+    expect(sig.status).toBe("running");
+    expect(sig.bg_job_id).toBe("abc123");
+    // explanation matches what was appended to the event
+    const ev = events.find((e) => e["event.name"] === "escalate.human");
+    expect(sig.explanation).toEqual(ev.payload.explanation);
+  });
+
+  test("missing signal file: no throw, escalation still returns paged=1", () => {
+    seedCfg("max_attempts", 2);
+    const t = insertTick(NOW);
+    const ticket = "CTL-1131y", phase = "implement";
+    const subject = `${ticket}/${phase}`;
+    insertEscalateHuman(t, subject, "stalled-alive");
+    insertWakeIntent(t, subject, { attempts: 2, outcome: null });
+
+    const orchDir = scratch(); // no signal file seeded → best-effort miss
+    const events = [];
+    const res = executeEscalations(db, t, {
+      orchDir,
+      writeStatus: { applyLabel: () => ({ applied: true }) },
+      appendEvent: (e) => events.push(e),
+      enforce: true,
+      labelOnceFn: () => {},
+    });
+
+    expect(res.paged).toBe(1);
+    expect(events).toHaveLength(1);
+  });
+
+  test("re-arm (firstPage=false via labelOnceFn returning false): signal NOT rewritten", () => {
+    seedCfg("max_attempts", 2);
+    const t = insertTick(NOW);
+    const ticket = "CTL-1131z", phase = "implement";
+    const subject = `${ticket}/${phase}`;
+    insertEscalateHuman(t, subject, "stalled-alive");
+    insertWakeIntent(t, subject, { attempts: 2, outcome: null });
+
+    const orchDir = scratch();
+    seedSignal(orchDir, ticket, phase, { needsHumanSince: "2026-06-14T01:00:00Z" });
+
+    // labelOnceFn returns false → firstPage=false → signal write must not run
+    executeEscalations(db, t, {
+      orchDir,
+      writeStatus: { applyLabel: () => ({ applied: true }) },
+      appendEvent: () => {},
+      enforce: true,
+      labelOnceFn: () => false,
+    });
+
+    const sig = readSignal(orchDir, ticket, phase);
+    // needsHumanSince must not be overwritten by the re-arm path
+    expect(sig.needsHumanSince).toBe("2026-06-14T01:00:00Z");
+    // explanation must not have been written by the re-arm path
+    expect(sig.explanation).toBeUndefined();
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1831,6 +1831,7 @@ export function escalateDispatchExhausted(
         dispatchFailureCode: code,   // CTL-1045 Bug 2: exit code that exhausted retries (2 = prior_artifact_missing)
         dispatchFailureCause: cause, // CTL-1045 Bug 2: human-readable reason (observability)
         explanation,
+        needsHumanSince: existing.needsHumanSince ?? new Date().toISOString(),  // CTL-1131: preserve prior stamp
         updatedAt: new Date().toISOString(),
       })
     );
@@ -1885,6 +1886,7 @@ function writeTerminalStalled(
         status: "stalled",
         stalledReason: reason,
         explanation,
+        needsHumanSince: cur.needsHumanSince ?? new Date().toISOString(),  // CTL-1131: preserve prior stamp
         updatedAt: new Date().toISOString(),
       })
     );

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -83,7 +83,11 @@ import { readWorkerSignals } from "./signal-reader.mjs";
 // CTL-937: getBeliefsDb exposes the module-level db handle for the diagnostician.
 import { collectBeliefsTick, getBeliefsDb } from "./beliefs/collector.mjs";
 // CTL-1045 Bug 1: kill-storm suppression guard for defaultJanitorKillIntentRecorder.
-import { isIntentEffective, getMaxAttempts, recordIntent as recordIntentBelief } from "./beliefs/intent.mjs";
+import {
+  isIntentEffective,
+  getMaxAttempts,
+  recordIntent as recordIntentBelief,
+} from "./beliefs/intent.mjs";
 // CTL-966 + CTL-935: the advancement shadow comparator — compares the procedural
 // deriveAdvancement oracle against the advance_to / cycle_exhausted beliefs and
 // logs disagreements. SHADOW ONLY (reads beliefs + computes oracle + logs; never
@@ -143,7 +147,12 @@ import { resolvePhaseSessionId as defaultResolveSession } from "./session-resolv
 import { evaluateHungWorker } from "./hung-detector.mjs";
 import { transcriptAgeMs as defaultTranscriptAgeMs } from "./transcript-silence.mjs";
 import { killHungWorker as defaultKillEscalate } from "./watchdog-action.mjs";
-import { readWatchdogConfig, phaseBudgetMs, readStallJanitorConfig, readCostCapConfig } from "./config.mjs";
+import {
+  readWatchdogConfig,
+  phaseBudgetMs,
+  readStallJanitorConfig,
+  readCostCapConfig,
+} from "./config.mjs";
 // CTL-1137: cost-cap watcher (Pass 0c) — out-of-process per-session $ preemption.
 import {
   shouldCheckNow,
@@ -172,10 +181,7 @@ import {
   defaultCollectUnstuckCandidates,
   emitUnstuckEvent,
 } from "./unstuck-sweep.mjs";
-import {
-  readUnstuckSweepConfig,
-  isThrottled,
-} from "./config.mjs";
+import { readUnstuckSweepConfig, isThrottled } from "./config.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
 // module (best-effort — every write swallows its own failures).
@@ -201,7 +207,15 @@ import { isLinearTerminal } from "./terminal-state.mjs";
 import { labelOnce, clearStalledLabel } from "./label-guard.mjs";
 import { processApprovedResumes } from "./boot-resume.mjs"; // CTL-644: per-tick approval poll
 import { countReapOutcomes } from "./reaper-metrics.mjs";
-import { log, getEligibleDir, getEventLogPath, getHostName, getClusterHosts, hostMembershipWarning, isDraining as isDrainingDefault } from "./config.mjs";
+import {
+  log,
+  getEligibleDir,
+  getEventLogPath,
+  getHostName,
+  getClusterHosts,
+  hostMembershipWarning,
+  isDraining as isDrainingDefault,
+} from "./config.mjs";
 import { emitDrainedEvent as defaultEmitDrainedEvent } from "./drain-event.mjs"; // CTL-1095: drained sentinel
 import { defaultCheckSequencing } from "./sequencing.mjs"; // CTL-537
 import { ownedBy } from "./hrw.mjs"; // CTL-850: HRW ownership filter
@@ -1328,15 +1342,17 @@ export function maybeEscalateRemediateExhausted(
     if (cur.status === "stalled") return true; // idempotent
     let remediateSummary;
     if (typeof summarizeHistory === "function") {
-      try { remediateSummary = summarizeHistory(ticket); } catch { /* best-effort */ }
+      try {
+        remediateSummary = summarizeHistory(ticket);
+      } catch {
+        /* best-effort */
+      }
     }
     // CTL-1108: source the operator-facing explanation from the verify.json that
     // still exists on disk at cap-exhaustion time (HIGH findings + regression_risk).
     let verifyJson = null;
     try {
-      verifyJson = JSON.parse(
-        readFile(join(orchDir, "workers", ticket, "verify.json"), "utf8")
-      );
+      verifyJson = JSON.parse(readFile(join(orchDir, "workers", ticket, "verify.json"), "utf8"));
     } catch {
       // verify.json absent/unreadable → mapper degrades to a valid generic explanation
     }
@@ -1502,7 +1518,11 @@ export function convergeHeldLabel(
 // "team-mismatch": CTL-1085 split it out of "missing-label" in classifyLabelFailure;
 // it MUST stay in this set or convergeHeldLabel loses its cool-down on cross-team
 // (ADV) label failures and re-introduces the CTL-834 per-tick retry storm.
-const UNRECOVERABLE_LABEL_REASONS = new Set(["missing-label", "exclusive-conflict", "team-mismatch"]);
+const UNRECOVERABLE_LABEL_REASONS = new Set([
+  "missing-label",
+  "exclusive-conflict",
+  "team-mismatch",
+]);
 
 // CTL-1068 — convergeStartedHeldLabels: retract orphaned held labels for a STARTED
 // (already-admitted) ticket. The admission A.7 loop only converges the pre-pickup
@@ -1828,10 +1848,10 @@ export function escalateDispatchExhausted(
         phase,
         status: "stalled",
         stalledReason: "prior-artifact-retry-exhausted",
-        dispatchFailureCode: code,   // CTL-1045 Bug 2: exit code that exhausted retries (2 = prior_artifact_missing)
+        dispatchFailureCode: code, // CTL-1045 Bug 2: exit code that exhausted retries (2 = prior_artifact_missing)
         dispatchFailureCause: cause, // CTL-1045 Bug 2: human-readable reason (observability)
         explanation,
-        needsHumanSince: existing.needsHumanSince ?? new Date().toISOString(),  // CTL-1131: preserve prior stamp
+        needsHumanSince: existing.needsHumanSince ?? new Date().toISOString(), // CTL-1131: preserve prior stamp
         updatedAt: new Date().toISOString(),
       })
     );
@@ -1873,10 +1893,9 @@ function writeTerminalStalled(
   // CTL-1130: every terminal stall carries a typed-union explanation so the inbox
   // shows a meaningful call_to_action. Callers may pass a richer typed explanation
   // via extra.explanation; fall back to a coerced decision generic.
-  const explanation = extra.explanation ?? coerceExplanation(
-    { problem: `${phase} phase stalled: ${reason}` },
-    { ticket, phase }
-  );
+  const explanation =
+    extra.explanation ??
+    coerceExplanation({ problem: `${phase} phase stalled: ${reason}` }, { ticket, phase });
   try {
     writeFile(
       p,
@@ -1886,7 +1905,7 @@ function writeTerminalStalled(
         status: "stalled",
         stalledReason: reason,
         explanation,
-        needsHumanSince: cur.needsHumanSince ?? new Date().toISOString(),  // CTL-1131: preserve prior stamp
+        needsHumanSince: cur.needsHumanSince ?? new Date().toISOString(), // CTL-1131: preserve prior stamp
         updatedAt: new Date().toISOString(),
       })
     );
@@ -2304,15 +2323,20 @@ function defaultJanitorKillIntentRecorder(intentDb, killBgJob = defaultKillBgJob
     // own. Fail-open when intentDb is null.
     if (intentDb) {
       try {
-        if (!isIntentEffective(intentDb, "kill", subject, { maxAttempts: getMaxAttempts(intentDb) })) {
+        if (
+          !isIntentEffective(intentDb, "kill", subject, { maxAttempts: getMaxAttempts(intentDb) })
+        ) {
           log.warn(
             { subject, bgJobId },
-            "stall-janitor: kill intent ineffective — skipping claude stop (CTL-1045 storm prevention)",
+            "stall-janitor: kill intent ineffective — skipping claude stop (CTL-1045 storm prevention)"
           );
           return false;
         }
       } catch (err) {
-        log.warn({ subject, err: err?.message }, "stall-janitor: isIntentEffective threw — continuing kill (CTL-1045)");
+        log.warn(
+          { subject, err: err?.message },
+          "stall-janitor: isIntentEffective threw — continuing kill (CTL-1045)"
+        );
       }
     }
     // Issue the real stop FIRST so a record-failure can never swallow the kill
@@ -2323,7 +2347,9 @@ function defaultJanitorKillIntentRecorder(intentDb, killBgJob = defaultKillBgJob
       try {
         // Skip the INSERT if an open kill-intent already exists (idempotent).
         const open = intentDb
-          .query("SELECT 1 FROM intent WHERE kind = 'kill' AND subject = ? AND outcome IS NULL LIMIT 1")
+          .query(
+            "SELECT 1 FROM intent WHERE kind = 'kill' AND subject = ? AND outcome IS NULL LIMIT 1"
+          )
           .get(subject);
         const tickRow = open
           ? null
@@ -2336,19 +2362,25 @@ function defaultJanitorKillIntentRecorder(intentDb, killBgJob = defaultKillBgJob
               tickRow.tick_id,
               subject,
               JSON.stringify({ kind: "kill", subject, bgJobId, sessionNotRegistered: true }),
-            ],
+            ]
           );
           recorded = true;
         }
       } catch (err) {
-        log.warn({ subject, err: err?.message }, "stall-janitor: recordKillIntent threw — continuing kill (CTL-1004)");
+        log.warn(
+          { subject, err: err?.message },
+          "stall-janitor: recordKillIntent threw — continuing kill (CTL-1004)"
+        );
       }
     }
     // Execute the stop — the actual ghost-session reap (mirrors intentAwareKill).
     try {
       killBgJob({ bgJobId });
     } catch (err) {
-      log.warn({ subject, bgJobId, err: err?.message }, "stall-janitor: killBgJob threw (CTL-1004)");
+      log.warn(
+        { subject, bgJobId, err: err?.message },
+        "stall-janitor: killBgJob threw (CTL-1004)"
+      );
       return recorded;
     }
     return true;
@@ -2383,7 +2415,10 @@ export function defaultClearStall(orchDir, writeStatus) {
     try {
       rmSync(join(workerDir, `phase-${phase}.json`), { force: true });
     } catch (err) {
-      log.warn({ ticket, phase, err: err?.message }, "stall-janitor: stalled-signal delete failed (CTL-1005)");
+      log.warn(
+        { ticket, phase, err: err?.message },
+        "stall-janitor: stalled-signal delete failed (CTL-1005)"
+      );
     }
     // 2. clear the needs-human label; write the once-marker ONLY on confirmed removal
     //    (CTL-1045 Bug 4 — a failed clear must NOT disarm future escalations).
@@ -2395,17 +2430,25 @@ export function defaultClearStall(orchDir, writeStatus) {
             // One clear per ticket per phase per worker-dir lifetime (CTL-1045 Bug 5).
             writeFileSync(join(workerDir, `.janitor-cleared-${phase}.applied`), "");
           } catch (err) {
-            log.warn({ ticket, phase, err: err?.message }, "stall-janitor: cleared-marker write failed (CTL-1005)");
+            log.warn(
+              { ticket, phase, err: err?.message },
+              "stall-janitor: cleared-marker write failed (CTL-1005)"
+            );
           }
         },
       });
     } catch (err) {
-      log.warn({ ticket, phase, err: err?.message }, "stall-janitor: needs-human clear failed (CTL-1005)");
+      log.warn(
+        { ticket, phase, err: err?.message },
+        "stall-janitor: needs-human clear failed (CTL-1005)"
+      );
     }
     // 3. delete .orphan-detected.applied so a future stall re-emits (CTL-868).
     try {
       rmSync(join(workerDir, ".orphan-detected.applied"), { force: true });
-    } catch { /* best-effort */ }
+    } catch {
+      /* best-effort */
+    }
     return true;
   };
 }
@@ -2569,7 +2612,7 @@ export function schedulerTick(
     // table. Mode resolves from readCostCapConfig() (env > Layer-2 > shadow) unless
     // overridden here.
     costCap: {
-      mode: _costCapMode = undefined,        // resolved inside the pass
+      mode: _costCapMode = undefined, // resolved inside the pass
       fetchCost: _costCapFetch = fetchSessionCostUsd,
       now: _costCapNow = Date.now,
       markFailed: _costCapMarkFailed = markPhaseSignalFailed,
@@ -2942,9 +2985,15 @@ export function schedulerTick(
             progress = _progressMark({ ticket: sig.ticket, phase: sig.phase, repoRoot, orchDir });
           }
           const decision = evaluateHungWorker({
-            ticket: sig.ticket, phase: sig.phase, status: sig.status,
-            nowMs: _watchdogNow(), startedAtMs, transcriptAgeMs: ageMs,
-            progressMark: progress, silenceMs, budgetMs,
+            ticket: sig.ticket,
+            phase: sig.phase,
+            status: sig.status,
+            nowMs: _watchdogNow(),
+            startedAtMs,
+            transcriptAgeMs: ageMs,
+            progressMark: progress,
+            silenceMs,
+            budgetMs,
           });
           if (decision.action !== "kill-escalate") continue;
           if (wdMode === "shadow") {
@@ -2957,9 +3006,11 @@ export function schedulerTick(
           }
           // enforce: fire-and-forget (async kill, sync tick continues)
           void _killEscalate(orchDir, sig.ticket, sig, {
-            elapsedMin: decision.elapsedMin, commitCount: progress,
+            elapsedMin: decision.elapsedMin,
+            commitCount: progress,
             reviveBudget: wcfg.reviveBudget,
-            now: _watchdogNow, emit: _watchdogEmit,
+            now: _watchdogNow,
+            emit: _watchdogEmit,
             writeStatus,
             // CTL-729 remediate: real revive dispatcher. The prior wiring passed
             // claimDispatch — the cross-host Linear claim soft-CAS, NOT a worker
@@ -2973,10 +3024,12 @@ export function schedulerTick(
               const resumeSession = bgJobId ? (resolveSession(bgJobId) ?? undefined) : undefined;
               return dispatchTicket(orchDir, rt, rp, { dispatch, resumeSession, attempt });
             },
-          }).catch((err) => log.warn(
-            { ticket: sig.ticket, phase: sig.phase, err: err.message },
-            "scheduler: watchdog kill threw (CTL-729)"
-          ));
+          }).catch((err) =>
+            log.warn(
+              { ticket: sig.ticket, phase: sig.phase, err: err.message },
+              "scheduler: watchdog kill threw (CTL-729)"
+            )
+          );
           // CTL-729 remediate: watchdogKilled counts kill-attempts DISPATCHED this
           // tick, not confirmed kills. The kill is fire-and-forget (the sync tick
           // cannot await), so the resolved outcome — "escalated" vs "revived"
@@ -2987,7 +3040,12 @@ export function schedulerTick(
           // regardless; only this reporting field is attempt-granular.
           watchdogKilled.push({ ticket: sig.ticket, phase: sig.phase });
           log.warn(
-            { ticket: sig.ticket, phase: sig.phase, reason: decision.reason, elapsedMin: decision.elapsedMin },
+            {
+              ticket: sig.ticket,
+              phase: sig.phase,
+              reason: decision.reason,
+              elapsedMin: decision.elapsedMin,
+            },
             "scheduler: progress-watchdog kill dispatched for hung worker (CTL-729)"
           );
         } catch (err) {
@@ -3029,13 +3087,25 @@ export function schedulerTick(
         // never blocks. checkWorkerCost does fetch → decide → shadow-log | enforce-preempt
         // (terminal-write + reap). Any rejection fails OPEN (logged, no abort).
         void checkWorkerCost({
-          orchDir, ticket, phase, status, sessionId, bgJobId,
-          mode: ccMode, capUsd: ccfg.capUsd, promBaseUrl: ccfg.promBaseUrl,
-          fetchCost: _costCapFetch, markFailed: _costCapMarkFailed, reap: _costCapReap, log,
-        }).catch((err) => log.warn(
-          { ticket, step: "cost-cap", err: err?.message },
-          "scheduler: per-worker cost-cap step failed — continuing (CTL-1137, fail-open)",
-        ));
+          orchDir,
+          ticket,
+          phase,
+          status,
+          sessionId,
+          bgJobId,
+          mode: ccMode,
+          capUsd: ccfg.capUsd,
+          promBaseUrl: ccfg.promBaseUrl,
+          fetchCost: _costCapFetch,
+          markFailed: _costCapMarkFailed,
+          reap: _costCapReap,
+          log,
+        }).catch((err) =>
+          log.warn(
+            { ticket, step: "cost-cap", err: err?.message },
+            "scheduler: per-worker cost-cap step failed — continuing (CTL-1137, fail-open)"
+          )
+        );
       }
     }
   }
@@ -3105,8 +3175,12 @@ export function schedulerTick(
         janitorStallsCleared = jreport.stallsCleared;
         janitorWouldClear = jreport.wouldClear;
         if (
-          janitorReaped.length || janitorKillIntents.length || janitorWouldReap.length ||
-          janitorWouldKill.length || janitorStallsCleared.length || janitorWouldClear.length
+          janitorReaped.length ||
+          janitorKillIntents.length ||
+          janitorWouldReap.length ||
+          janitorWouldKill.length ||
+          janitorStallsCleared.length ||
+          janitorWouldClear.length
         ) {
           log.info(
             {
@@ -3161,7 +3235,9 @@ export function schedulerTick(
                   // scheduler.mjs:2199-2206). Without this, every pass would insert
                   // a duplicate intent row for the same subject (CTL-1064).
                   const open = intentDb
-                    .query("SELECT 1 FROM intent WHERE kind = ? AND subject = ? AND outcome IS NULL LIMIT 1")
+                    .query(
+                      "SELECT 1 FROM intent WHERE kind = ? AND subject = ? AND outcome IS NULL LIMIT 1"
+                    )
                     .get(kind, subject);
                   if (open) return;
                   // intent.tick_id is NOT NULL — the prior tickId:null always
@@ -3178,7 +3254,9 @@ export function schedulerTick(
                     subject,
                     postcondition: { kind: "unstuck-sweep", subject },
                   });
-                } catch { /* best-effort */ }
+                } catch {
+                  /* best-effort */
+                }
               }
             : () => {},
           // CTL-1064: the driver gate is act-once-then-skip (unstuck-sweep.mjs:257
@@ -3194,10 +3272,14 @@ export function schedulerTick(
             ? (kind, subject) => {
                 try {
                   const open = intentDb
-                    .query("SELECT 1 FROM intent WHERE kind = ? AND subject = ? AND outcome IS NULL LIMIT 1")
+                    .query(
+                      "SELECT 1 FROM intent WHERE kind = ? AND subject = ? AND outcome IS NULL LIMIT 1"
+                    )
                     .get(kind, subject);
                   return open != null;
-                } catch { return false; }
+                } catch {
+                  return false;
+                }
               }
             : () => false,
           postComment: _unstuckPostComment ?? (() => {}),
@@ -3207,8 +3289,10 @@ export function schedulerTick(
         unstuckEscalated = ureport.escalated;
         unstuckWouldEscalate = ureport.wouldEscalate;
         if (
-          ureport.acted.length || ureport.wouldAct.length ||
-          ureport.escalated.length || ureport.wouldEscalate.length
+          ureport.acted.length ||
+          ureport.wouldAct.length ||
+          ureport.escalated.length ||
+          ureport.wouldEscalate.length
         ) {
           log.info(
             {
@@ -4283,9 +4367,10 @@ export function schedulerTick(
   // subtracting heldStopCount removed that slot a SECOND time, over-suppressing
   // genuinely-free capacity at maxParallel>=2 (a transient single-tick throughput
   // loss; the slot frees naturally next tick via getAgentsCached deregistration).
-  const freeSlots = (livenessFresh && !draining)
-    ? Math.max(0, computeFreeSlots(maxParallel, inFlightCount) - resumedCount - promotedCount)
-    : 0;
+  const freeSlots =
+    livenessFresh && !draining
+      ? Math.max(0, computeFreeSlots(maxParallel, inFlightCount) - resumedCount - promotedCount)
+      : 0;
   if (!livenessFresh) {
     log.warn(
       { maxParallel, inFlightCount, resumedCount, promotedCount, heldStopCount },
@@ -4302,11 +4387,19 @@ export function schedulerTick(
   if (draining) {
     if (listInFlightTickets(orchDir).size === 0 && !existsSync(drainedMarker)) {
       emitDrained();
-      try { writeFileSync(drainedMarker, ""); } catch { /* best-effort */ }
+      try {
+        writeFileSync(drainedMarker, "");
+      } catch {
+        /* best-effort */
+      }
       log.info({}, "scheduler: node drained — all in-flight work landed (CTL-1095)");
     }
   } else if (existsSync(drainedMarker)) {
-    try { rmSync(drainedMarker, { force: true }); } catch { /* best-effort */ }
+    try {
+      rmSync(drainedMarker, { force: true });
+    } catch {
+      /* best-effort */
+    }
   }
   // CTL-1150: resolve injectable seams before Pass 2 selection + dispatch loop.
   // _hasTriageArtifact: default reads filesystem (mirroring monitor.mjs:667-669).
@@ -4316,8 +4409,7 @@ export function schedulerTick(
   //   (which creates workers/<ticket>/) inject `() => new Set()` to prevent the
   //   seeded ticket from being excluded by dir-existence before the guard fires.
   const _hasTriageArtifact =
-    hasTriageArtifact ??
-    ((dir, ticket) => existsSync(join(dir, "workers", ticket, "triage.json")));
+    hasTriageArtifact ?? ((dir, ticket) => existsSync(join(dir, "workers", ticket, "triage.json")));
   const _listStartedTickets = listStartedTicketsOpt ?? listStartedTickets;
 
   // CTL-706: per-project caps + reserves gate selection AFTER ranking. With
@@ -4671,18 +4763,18 @@ export function schedulerTick(
     noProgressStopped,
     escalated,
     quarantinedPhantoms, // CTL-671 — phantom worker dirs stalled this tick
-    watchdogKilled,      // CTL-729 — kill-attempts DISPATCHED this tick (enforce mode); not confirmed kills (see Pass 0w)
-    watchdogWouldKill,   // CTL-729 — workers that WOULD be killed (shadow mode)
-    janitorReaped,       // CTL-1004 — targeted orphan reap-requests EMITTED this tick (enforce)
-    janitorWouldReap,    // CTL-1004 — orphan worktrees that WOULD be reap-requested (shadow)
-    janitorKillIntents,  // CTL-1004 — ghost-session kill-intents RECORDED this tick (enforce)
-    janitorWouldKill,    // CTL-1004 — ghost sessions that WOULD get a kill-intent (shadow)
-    janitorDeferred,     // CTL-1004 — dirty worktrees deferred (no removal, no queue)
+    watchdogKilled, // CTL-729 — kill-attempts DISPATCHED this tick (enforce mode); not confirmed kills (see Pass 0w)
+    watchdogWouldKill, // CTL-729 — workers that WOULD be killed (shadow mode)
+    janitorReaped, // CTL-1004 — targeted orphan reap-requests EMITTED this tick (enforce)
+    janitorWouldReap, // CTL-1004 — orphan worktrees that WOULD be reap-requested (shadow)
+    janitorKillIntents, // CTL-1004 — ghost-session kill-intents RECORDED this tick (enforce)
+    janitorWouldKill, // CTL-1004 — ghost sessions that WOULD get a kill-intent (shadow)
+    janitorDeferred, // CTL-1004 — dirty worktrees deferred (no removal, no queue)
     janitorStallsCleared, // CTL-1005 — prior-artifact-retry-exhausted stalls CLEARED this tick (enforce)
-    janitorWouldClear,   // CTL-1005 — stalls that WOULD be cleared (shadow)
-    unstuckActed,        // CTL-1064 — Pass 0u actions taken this tick (enforce)
-    unstuckWouldAct,     // CTL-1064 — Pass 0u would-act (shadow)
-    unstuckEscalated,    // CTL-1064 — Pass 0u escalations this tick (enforce)
+    janitorWouldClear, // CTL-1005 — stalls that WOULD be cleared (shadow)
+    unstuckActed, // CTL-1064 — Pass 0u actions taken this tick (enforce)
+    unstuckWouldAct, // CTL-1064 — Pass 0u would-act (shadow)
+    unstuckEscalated, // CTL-1064 — Pass 0u escalations this tick (enforce)
     unstuckWouldEscalate, // CTL-1064 — Pass 0u would-escalate (shadow)
     advanced,
     dispatched,
@@ -4863,7 +4955,7 @@ function runTick() {
           const evidenceBySubject = Object.fromEntries(
             (diagResult?.escalated ?? [])
               .filter((x) => x?.subject)
-              .map((x) => [x.subject, x.evidence ?? {}]),
+              .map((x) => [x.subject, x.evidence ?? {}])
           );
           executeEscalations(escDb, beliefsRes.tickId, {
             orchDir: runningOpts.orchDir,
@@ -5056,9 +5148,10 @@ function runTick() {
         // comment) unless an operator injects runningOpts.unstuckPostComment —
         // defaultPostUnstuckComment is NOT closed over orchDir here. Mirrors the
         // intentional actByCategory no-op above.
-        postComment: typeof runningOpts.unstuckPostComment === "function"
-          ? runningOpts.unstuckPostComment
-          : undefined,
+        postComment:
+          typeof runningOpts.unstuckPostComment === "function"
+            ? runningOpts.unstuckPostComment
+            : undefined,
       },
       // CTL-1150: thread the triage-artifact predicate (undefined → inline
       // existsSync default in schedulerTick; test seam via startScheduler).

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1889,6 +1889,63 @@ describe("CTL-1108: writeTerminalStalled explanation coverage", () => {
   });
 });
 
+// ─── CTL-1131: needsHumanSince stamped at terminal-stall write sites ───
+describe("CTL-1131: escalateDispatchExhausted stamps needsHumanSince", () => {
+  const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+
+  test("new signal: carries a needsHumanSince ISO string and preserves explanation", () => {
+    expect(escalateDispatchExhausted(orchDir, "CTL-1131a", "pr")).toBe(true);
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", "CTL-1131a", "phase-pr.json"), "utf8")
+    );
+    expect(typeof sig.needsHumanSince).toBe("string");
+    expect(ISO_RE.test(sig.needsHumanSince)).toBe(true);
+    expect(sig.explanation).toBeTruthy();
+  });
+
+  test("existing signal with needsHumanSince: preserves the prior stamp (does not reset age)", () => {
+    const p = join(orchDir, "workers", "CTL-1131b", "phase-pr.json");
+    mkdirSync(join(orchDir, "workers", "CTL-1131b"), { recursive: true });
+    writeFileSync(p, JSON.stringify({
+      ticket: "CTL-1131b", phase: "pr", status: "running",
+      needsHumanSince: "2026-06-14T00:00:00Z",
+    }));
+    escalateDispatchExhausted(orchDir, "CTL-1131b", "pr");
+    const sig = JSON.parse(readFileSync(p, "utf8"));
+    expect(sig.needsHumanSince).toBe("2026-06-14T00:00:00Z");
+  });
+});
+
+describe("CTL-1131: writeTerminalStalled (via maybeTripCircuitBreaker) stamps needsHumanSince", () => {
+  const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+
+  test("stalled signal carries a needsHumanSince ISO string", () => {
+    const t = "CTL-1131c", phase = "implement";
+    writeSignal(t, phase, "running");
+    for (let i = 1; i <= CIRCUIT_BREAKER_THRESHOLD; i++)
+      recordDispatchFailure(orchDir, t, phase, 1, i * 1000);
+    expect(maybeTripCircuitBreaker(orchDir, t, phase)).toBe(true);
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", t, `phase-${phase}.json`), "utf8")
+    );
+    expect(typeof sig.needsHumanSince).toBe("string");
+    expect(ISO_RE.test(sig.needsHumanSince)).toBe(true);
+  });
+
+  test("existing needsHumanSince is preserved (does not reset age)", () => {
+    const t = "CTL-1131d", phase = "verify";
+    writeSignal(t, phase, "running");
+    const p = join(orchDir, "workers", t, `phase-${phase}.json`);
+    const cur = JSON.parse(readFileSync(p, "utf8"));
+    writeFileSync(p, JSON.stringify({ ...cur, needsHumanSince: "2026-06-14T05:00:00Z" }));
+    for (let i = 1; i <= CIRCUIT_BREAKER_THRESHOLD; i++)
+      recordDispatchFailure(orchDir, t, phase, 1, i * 1000);
+    maybeTripCircuitBreaker(orchDir, t, phase);
+    const sig = JSON.parse(readFileSync(p, "utf8"));
+    expect(sig.needsHumanSince).toBe("2026-06-14T05:00:00Z");
+  });
+});
+
 // ─── CTL-712: dispatch retry ceiling wired into schedulerTick ───
 describe("CTL-712: dispatch retry ceiling (schedulerTick)", () => {
   let prevMax;

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1717,14 +1717,22 @@ describe("CTL-653: maybeEscalateRemediateExhausted", () => {
       })
     );
     expect(
-      maybeEscalateRemediateExhausted(orchDir, "CTL-1108a", { verify: "done" }, "fail", REMEDIATE_CYCLE_CAP)
+      maybeEscalateRemediateExhausted(
+        orchDir,
+        "CTL-1108a",
+        { verify: "done" },
+        "fail",
+        REMEDIATE_CYCLE_CAP
+      )
     ).toBe(true);
     const sig = JSON.parse(readFileSync(join(wdir, "phase-verify.json"), "utf8"));
     expect(sig.status).toBe("stalled");
     expect(sig.stalledReason).toBe("remediate-cycle-cap-exhausted");
     expect(sig.explanation).toBeTruthy();
     expect(typeof sig.explanation.call_to_action).toBe("string");
-    expect(sig.explanation.call_to_action).toContain("verify keeps failing on broker/router.mjs:352");
+    expect(sig.explanation.call_to_action).toContain(
+      "verify keeps failing on broker/router.mjs:352"
+    );
   });
 
   test("CTL-1108: missing verify.json → still stalls with a (degraded) explanation, never throws", () => {
@@ -1736,7 +1744,13 @@ describe("CTL-653: maybeEscalateRemediateExhausted", () => {
     );
     // no verify.json on disk
     expect(
-      maybeEscalateRemediateExhausted(orchDir, "CTL-1108b", { verify: "done" }, "fail", REMEDIATE_CYCLE_CAP)
+      maybeEscalateRemediateExhausted(
+        orchDir,
+        "CTL-1108b",
+        { verify: "done" },
+        "fail",
+        REMEDIATE_CYCLE_CAP
+      )
     ).toBe(true);
     const sig = JSON.parse(readFileSync(join(wdir, "phase-verify.json"), "utf8"));
     expect(sig.status).toBe("stalled");
@@ -1756,7 +1770,13 @@ describe("CTL-653: maybeEscalateRemediateExhausted", () => {
     };
     writeFileSync(join(wdir, "phase-verify.json"), JSON.stringify(existing));
     expect(
-      maybeEscalateRemediateExhausted(orchDir, "CTL-1108c", { verify: "done" }, "fail", REMEDIATE_CYCLE_CAP)
+      maybeEscalateRemediateExhausted(
+        orchDir,
+        "CTL-1108c",
+        { verify: "done" },
+        "fail",
+        REMEDIATE_CYCLE_CAP
+      )
     ).toBe(true);
     const sig = JSON.parse(readFileSync(join(wdir, "phase-verify.json"), "utf8"));
     expect(sig.explanation.call_to_action).toBe("original question");
@@ -1811,8 +1831,13 @@ describe("CTL-712: escalateDispatchExhausted — retry ceiling → stalled", () 
   // tell the benign prior-artifact-missing case (code 2) from verify_failed (0)
   // or crash (≠ 2). A legacy signal without code stays operator-owned.
   test("CTL-1045 Bug 2: persists dispatchFailureCode + dispatchFailureCause when provided", () => {
-    escalateDispatchExhausted(orchDir, "CTL-712", "pr", { code: 2, cause: "prior_artifact_missing:research_doc" });
-    const sig = JSON.parse(readFileSync(join(orchDir, "workers", "CTL-712", "phase-pr.json"), "utf8"));
+    escalateDispatchExhausted(orchDir, "CTL-712", "pr", {
+      code: 2,
+      cause: "prior_artifact_missing:research_doc",
+    });
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", "CTL-712", "phase-pr.json"), "utf8")
+    );
     expect(sig.stalledReason).toBe("prior-artifact-retry-exhausted");
     expect(sig.dispatchFailureCode).toBe(2);
     expect(sig.dispatchFailureCause).toBe("prior_artifact_missing:research_doc");
@@ -1820,7 +1845,9 @@ describe("CTL-712: escalateDispatchExhausted — retry ceiling → stalled", () 
 
   test("CTL-1045 Bug 2: defaults dispatchFailureCode / dispatchFailureCause to null when omitted (back-compat)", () => {
     escalateDispatchExhausted(orchDir, "CTL-712", "pr");
-    const sig = JSON.parse(readFileSync(join(orchDir, "workers", "CTL-712", "phase-pr.json"), "utf8"));
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", "CTL-712", "phase-pr.json"), "utf8")
+    );
     expect(sig.dispatchFailureCode).toBeNull();
     expect(sig.dispatchFailureCause).toBeNull();
   });
@@ -1841,7 +1868,8 @@ describe("CTL-712: escalateDispatchExhausted — retry ceiling → stalled", () 
 // ─── CTL-1108: writeTerminalStalled explanation coverage ───
 describe("CTL-1108: writeTerminalStalled explanation coverage", () => {
   test("dispatch-circuit-breaker stall carries an explanation", () => {
-    const t = "CTL-1108f", phase = "research";
+    const t = "CTL-1108f",
+      phase = "research";
     writeSignal(t, phase, "running");
     for (let i = 1; i <= CIRCUIT_BREAKER_THRESHOLD; i++)
       recordDispatchFailure(orchDir, t, phase, 1, i * 1000);
@@ -1860,9 +1888,17 @@ describe("CTL-1108: writeTerminalStalled explanation coverage", () => {
     {
       const wdir = join(orchDir, "workers", "CTL-1108g");
       mkdirSync(wdir, { recursive: true });
-      writeFileSync(join(wdir, "phase-verify.json"),
-        JSON.stringify({ ticket: "CTL-1108g", phase: "verify", status: "done" }));
-      maybeEscalateRemediateExhausted(orchDir, "CTL-1108g", { verify: "done" }, "fail", REMEDIATE_CYCLE_CAP);
+      writeFileSync(
+        join(wdir, "phase-verify.json"),
+        JSON.stringify({ ticket: "CTL-1108g", phase: "verify", status: "done" })
+      );
+      maybeEscalateRemediateExhausted(
+        orchDir,
+        "CTL-1108g",
+        { verify: "done" },
+        "fail",
+        REMEDIATE_CYCLE_CAP
+      );
       const sig = JSON.parse(readFileSync(join(wdir, "phase-verify.json"), "utf8"));
       expect(sig.explanation?.call_to_action?.trim()).toBeTruthy();
     }
@@ -1876,7 +1912,8 @@ describe("CTL-1108: writeTerminalStalled explanation coverage", () => {
     }
     // dispatch-circuit-breaker (maybeTripCircuitBreaker → writeTerminalStalled)
     {
-      const t = "CTL-1108i", phase = "implement";
+      const t = "CTL-1108i",
+        phase = "implement";
       writeSignal(t, phase, "running");
       for (let i = 1; i <= CIRCUIT_BREAKER_THRESHOLD; i++)
         recordDispatchFailure(orchDir, t, phase, 1, i * 1000);
@@ -1906,10 +1943,15 @@ describe("CTL-1131: escalateDispatchExhausted stamps needsHumanSince", () => {
   test("existing signal with needsHumanSince: preserves the prior stamp (does not reset age)", () => {
     const p = join(orchDir, "workers", "CTL-1131b", "phase-pr.json");
     mkdirSync(join(orchDir, "workers", "CTL-1131b"), { recursive: true });
-    writeFileSync(p, JSON.stringify({
-      ticket: "CTL-1131b", phase: "pr", status: "running",
-      needsHumanSince: "2026-06-14T00:00:00Z",
-    }));
+    writeFileSync(
+      p,
+      JSON.stringify({
+        ticket: "CTL-1131b",
+        phase: "pr",
+        status: "running",
+        needsHumanSince: "2026-06-14T00:00:00Z",
+      })
+    );
     escalateDispatchExhausted(orchDir, "CTL-1131b", "pr");
     const sig = JSON.parse(readFileSync(p, "utf8"));
     expect(sig.needsHumanSince).toBe("2026-06-14T00:00:00Z");
@@ -1920,7 +1962,8 @@ describe("CTL-1131: writeTerminalStalled (via maybeTripCircuitBreaker) stamps ne
   const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
 
   test("stalled signal carries a needsHumanSince ISO string", () => {
-    const t = "CTL-1131c", phase = "implement";
+    const t = "CTL-1131c",
+      phase = "implement";
     writeSignal(t, phase, "running");
     for (let i = 1; i <= CIRCUIT_BREAKER_THRESHOLD; i++)
       recordDispatchFailure(orchDir, t, phase, 1, i * 1000);
@@ -1933,7 +1976,8 @@ describe("CTL-1131: writeTerminalStalled (via maybeTripCircuitBreaker) stamps ne
   });
 
   test("existing needsHumanSince is preserved (does not reset age)", () => {
-    const t = "CTL-1131d", phase = "verify";
+    const t = "CTL-1131d",
+      phase = "verify";
     writeSignal(t, phase, "running");
     const p = join(orchDir, "workers", t, `phase-${phase}.json`);
     const cur = JSON.parse(readFileSync(p, "utf8"));
@@ -2637,8 +2681,12 @@ describe("schedulerTick — CTL-1150 triage-artifact guard", () => {
     expect(r.dispatched).toEqual([]);
     // No spurious phase events emitted for CTL-1150.
     const events = readEventLog();
-    expect(events.filter((e) => e.ticket === "CTL-1150" && e.event?.startsWith("phase.research.failed"))).toHaveLength(0);
-    expect(events.filter((e) => e.ticket === "CTL-1150" && e.event?.startsWith("phase.dispatch.failed"))).toHaveLength(0);
+    expect(
+      events.filter((e) => e.ticket === "CTL-1150" && e.event?.startsWith("phase.research.failed"))
+    ).toHaveLength(0);
+    expect(
+      events.filter((e) => e.ticket === "CTL-1150" && e.event?.startsWith("phase.dispatch.failed"))
+    ).toHaveLength(0);
     // No cooldown marker written (silent hold, not a dispatch failure).
     expect(existsSync(dispatchCooldownPath(orchDir, "CTL-1150", "research"))).toBe(false);
   });
@@ -4246,7 +4294,11 @@ describe("schedulerTick — label write-back (CTL-558)", () => {
 describe("schedulerTick — retraction sweep uses gateway cache (CTL-1079)", () => {
   const TICKET = "CTL-1079T";
 
-  function makeExecSpy(labelsJson = JSON.stringify({ labels: { nodes: [{ name: "needs-human" }, { name: "feature" }] } })) {
+  function makeExecSpy(
+    labelsJson = JSON.stringify({
+      labels: { nodes: [{ name: "needs-human" }, { name: "feature" }] },
+    })
+  ) {
     const calls = [];
     const exec = (cmd, args) => {
       calls.push({ cmd, args });
@@ -4264,7 +4316,8 @@ describe("schedulerTick — retraction sweep uses gateway cache (CTL-1079)", () 
   }
 
   const isLiveRead = (c) => c.cmd === "linearis" && c.args[0] === "issues" && c.args[1] === "read";
-  const isOverwrite = (c) => c.cmd === "linearis" && c.args[0] === "issues" && c.args[1] === "update";
+  const isOverwrite = (c) =>
+    c.cmd === "linearis" && c.args[0] === "issues" && c.args[1] === "update";
 
   function makeWriteStatus(execSpy) {
     return {
@@ -9609,7 +9662,12 @@ describe("CTL-1068: convergeStartedHeldLabels (unit)", () => {
     const removed = [];
     return {
       removed,
-      ws: { removeLabel: (ticket, label) => { removed.push({ ticket, label }); return { removed: true }; } },
+      ws: {
+        removeLabel: (ticket, label) => {
+          removed.push({ ticket, label });
+          return { removed: true };
+        },
+      },
     };
   }
 
@@ -9686,10 +9744,17 @@ describe("CTL-1068: convergeStartedHeldLabels (unit)", () => {
     seedWorker("CTL-906");
     writeFileSync(markerPath("CTL-906", "waiting", "applied"), "");
     let rearms = 0;
-    convergeStartedHeldLabels(orchDir, "CTL-906", { removeLabel: () => ({ removed: true }) }, {
-      multiHost: false,
-      onRetract: () => { rearms += 1; },
-    });
+    convergeStartedHeldLabels(
+      orchDir,
+      "CTL-906",
+      { removeLabel: () => ({ removed: true }) },
+      {
+        multiHost: false,
+        onRetract: () => {
+          rearms += 1;
+        },
+      }
+    );
     expect(rearms).toBe(1);
   });
 });
@@ -9704,7 +9769,7 @@ describe("CTL-1068: schedulerTick — admitted-then-failed held-label retraction
 
   test("admitted-then-failed ticket drains its stale 'waiting' label", () => {
     writeSignal("CTL-764", "triage", "done");
-    writeSignal("CTL-764", "research", "done");   // admitted: has research+; pre-pickup gate excludes it
+    writeSignal("CTL-764", "research", "done"); // admitted: has research+; pre-pickup gate excludes it
     writeSignal("CTL-764", "implement", "failed");
     writeFileSync(join(orchDir, "workers", "CTL-764", ".linear-label-waiting.applied"), "");
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
@@ -9712,11 +9777,16 @@ describe("CTL-1068: schedulerTick — admitted-then-failed held-label retraction
     const writeStatus = {
       ...noWrites(),
       applyLabel: () => ({}),
-      removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; },
+      removeLabel: (t, l) => {
+        removed.push({ t, l });
+        return { removed: true };
+      },
     };
     schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
     expect(removed).toContainEqual({ t: "CTL-764", l: "waiting" });
-    expect(existsSync(join(orchDir, "workers", "CTL-764", ".linear-label-waiting.applied"))).toBe(false);
+    expect(existsSync(join(orchDir, "workers", "CTL-764", ".linear-label-waiting.applied"))).toBe(
+      false
+    );
   });
 
   test("pre-pickup triaged ticket is NOT retracted by the started-sweep", () => {
@@ -9728,7 +9798,10 @@ describe("CTL-1068: schedulerTick — admitted-then-failed held-label retraction
     const writeStatus = {
       ...noWrites(),
       applyLabel: () => ({}),
-      removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; },
+      removeLabel: (t, l) => {
+        removed.push({ t, l });
+        return { removed: true };
+      },
     };
     schedulerTick(orchDir, {
       readEligible: () => [],
@@ -9738,7 +9811,9 @@ describe("CTL-1068: schedulerTick — admitted-then-failed held-label retraction
     });
     // The started-sweep gate excluded CTL-7; the marker must be untouched.
     expect(removed.filter((r) => r.t === "CTL-7" && r.l === "waiting")).toHaveLength(0);
-    expect(existsSync(join(orchDir, "workers", "CTL-7", ".linear-label-waiting.applied"))).toBe(true);
+    expect(existsSync(join(orchDir, "workers", "CTL-7", ".linear-label-waiting.applied"))).toBe(
+      true
+    );
   });
 
   test("started ticket with no held marker makes zero held removeLabel calls", () => {
@@ -9749,7 +9824,10 @@ describe("CTL-1068: schedulerTick — admitted-then-failed held-label retraction
     const writeStatus = {
       ...noWrites(),
       applyLabel: () => ({}),
-      removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; },
+      removeLabel: (t, l) => {
+        removed.push({ t, l });
+        return { removed: true };
+      },
     };
     schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
     expect(removed.filter((r) => r.l === "blocked" || r.l === "waiting")).toHaveLength(0);
@@ -9757,7 +9835,7 @@ describe("CTL-1068: schedulerTick — admitted-then-failed held-label retraction
 
   test("retraction emits a held-label-orphaned-in-flight state-write event", () => {
     writeSignal("CTL-764", "triage", "done");
-    writeSignal("CTL-764", "research", "done");   // admitted; pre-pickup gate excludes it
+    writeSignal("CTL-764", "research", "done"); // admitted; pre-pickup gate excludes it
     writeSignal("CTL-764", "implement", "failed");
     writeFileSync(join(orchDir, "workers", "CTL-764", ".linear-label-waiting.applied"), "");
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
@@ -9799,13 +9877,15 @@ describe("CTL-1068: marker-hygiene and re-arm (Phase 3 regression)", () => {
       removeLabel: () => ({ removed: true }),
     };
     schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
-    expect(existsSync(join(orchDir, "workers", "CTL-810", ".linear-label-blocked.applied"))).toBe(false);
+    expect(existsSync(join(orchDir, "workers", "CTL-810", ".linear-label-blocked.applied"))).toBe(
+      false
+    );
   });
 
   test("retraction clears lastHeldEmitState so a future genuine hold re-emits", () => {
     // Tick A: admitted-then-failed with marker → retract + onRetract deletes lastHeldEmitState entry.
     writeSignal("CTL-907", "triage", "done");
-    writeSignal("CTL-907", "research", "done");   // admitted; pre-pickup gate excludes it
+    writeSignal("CTL-907", "research", "done"); // admitted; pre-pickup gate excludes it
     writeSignal("CTL-907", "implement", "failed");
     writeFileSync(join(orchDir, "workers", "CTL-907", ".linear-label-waiting.applied"), "");
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
@@ -9813,12 +9893,17 @@ describe("CTL-1068: marker-hygiene and re-arm (Phase 3 regression)", () => {
     const writeStatus = {
       ...noWrites(),
       applyLabel: () => ({}),
-      removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; },
+      removeLabel: (t, l) => {
+        removed.push({ t, l });
+        return { removed: true };
+      },
     };
     schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
     // Marker must be gone after Tick A retraction.
     expect(removed).toContainEqual({ t: "CTL-907", l: "waiting" });
-    expect(existsSync(join(orchDir, "workers", "CTL-907", ".linear-label-waiting.applied"))).toBe(false);
+    expect(existsSync(join(orchDir, "workers", "CTL-907", ".linear-label-waiting.applied"))).toBe(
+      false
+    );
     // The onRetract callback clears lastHeldEmitState for this ticket — no further assertion
     // needed here beyond confirming the retraction fired (the internal Map reset is exercised
     // by the unit test in Phase 1).

--- a/plugins/dev/scripts/execution-core/watchdog-action.mjs
+++ b/plugins/dev/scripts/execution-core/watchdog-action.mjs
@@ -127,6 +127,7 @@ export async function killHungWorker(
       status: "failed",
       failureReason,
       explanation,
+      needsHumanSince: cur.needsHumanSince ?? new Date(now()).toISOString(),  // CTL-1131: preserve prior stamp
       failedAt: new Date(now()).toISOString(),
     };
     const tmp = `${sigPath}.tmp.${process.pid}`;

--- a/plugins/dev/scripts/execution-core/watchdog-action.mjs
+++ b/plugins/dev/scripts/execution-core/watchdog-action.mjs
@@ -52,7 +52,7 @@ export async function killHungWorker(
     writeStatus,
     emit = emitReapIntent,
     reviveDispatch,
-  } = {},
+  } = {}
 ) {
   const phase = signal.phase;
   if (SETTLED.has(signal.status)) return { outcome: "already-terminal" };
@@ -65,7 +65,10 @@ export async function killHungWorker(
     const attempt = used + 1;
     if (bgJobId) {
       void emit("phase.terminal.reap-requested", {
-        ticket, phase, bgJobId, reason: `${failureReason}:revive`,
+        ticket,
+        phase,
+        bgJobId,
+        reason: `${failureReason}:revive`,
       }).catch((err) => log.warn({ ticket, phase, err }, "ctl-729: revive reap emit failed"));
     }
     try {
@@ -80,7 +83,7 @@ export async function killHungWorker(
     try {
       writeFileSync(
         join(orchDir, "workers", ticket, `.watchdog-revive-${phase}.${attempt}`),
-        new Date(now()).toISOString(),
+        new Date(now()).toISOString()
       );
     } catch (err) {
       // CTL-729 remediate: this marker is the SOLE persistence backing
@@ -89,7 +92,7 @@ export async function killHungWorker(
       // again (potentially unbounded), so make the failure observable.
       log.warn(
         { ticket, phase, attempt, err: err.message },
-        "ctl-729: revive-marker write failed — revive cap may not hold",
+        "ctl-729: revive-marker write failed — revive cap may not hold"
       );
     }
     log.warn({ ticket, phase, attempt, reviveBudget }, "ctl-729: hung worker revived (budget)");
@@ -127,7 +130,7 @@ export async function killHungWorker(
       status: "failed",
       failureReason,
       explanation,
-      needsHumanSince: cur.needsHumanSince ?? new Date(now()).toISOString(),  // CTL-1131: preserve prior stamp
+      needsHumanSince: cur.needsHumanSince ?? new Date(now()).toISOString(), // CTL-1131: preserve prior stamp
       failedAt: new Date(now()).toISOString(),
     };
     const tmp = `${sigPath}.tmp.${process.pid}`;
@@ -140,7 +143,11 @@ export async function killHungWorker(
   // (2) Fire-and-forget reap-intent → reaper._handleBgReap → claude stop <shortId>.
   if (bgJobId) {
     void emit("phase.terminal.reap-requested", {
-      ticket, phase, bgJobId, worktreePath: signal.raw?.worktreePath, reason: failureReason,
+      ticket,
+      phase,
+      bgJobId,
+      worktreePath: signal.raw?.worktreePath,
+      reason: failureReason,
     }).catch((err) => log.warn({ ticket, phase, err }, "ctl-729: reap-intent emit failed"));
   }
 
@@ -150,7 +157,7 @@ export async function killHungWorker(
 
   log.warn(
     { ticket, phase, elapsedMin, commitCount },
-    "ctl-729: hung worker force-killed + escalated",
+    "ctl-729: hung worker force-killed + escalated"
   );
   return { outcome: "escalated" };
 }

--- a/plugins/dev/scripts/execution-core/watchdog-action.test.mjs
+++ b/plugins/dev/scripts/execution-core/watchdog-action.test.mjs
@@ -214,3 +214,33 @@ describe("CTL-1065: killHungWorker writes signal.explanation alongside failureRe
     expect(onDisk.explanation).toBeUndefined();
   });
 });
+
+// ─── CTL-1131: killHungWorker stamps needsHumanSince ───
+describe("CTL-1131: killHungWorker stamps needsHumanSince on failed signal", () => {
+  const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+
+  test("escalated path: failed signal carries a needsHumanSince ISO string", async () => {
+    const sig = writeSignal("running");
+    await killHungWorker(orchDir, T, sig, {
+      elapsedMin: 1080, commitCount: 0,
+      writeStatus: { applyLabel: recorder({ applied: true }) },
+      emit: recorder(Promise.resolve(true)),
+      now: () => 1_000_000,
+    });
+    const onDisk = JSON.parse(readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8"));
+    expect(typeof onDisk.needsHumanSince).toBe("string");
+    expect(ISO_RE.test(onDisk.needsHumanSince)).toBe(true);
+  });
+
+  test("existing needsHumanSince is preserved (does not reset age)", async () => {
+    const sig = writeSignal("running", { needsHumanSince: "2026-06-14T06:00:00Z" });
+    await killHungWorker(orchDir, T, sig, {
+      elapsedMin: 1080, commitCount: 0,
+      writeStatus: { applyLabel: recorder({ applied: true }) },
+      emit: recorder(Promise.resolve(true)),
+      now: () => 1_000_000,
+    });
+    const onDisk = JSON.parse(readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8"));
+    expect(onDisk.needsHumanSince).toBe("2026-06-14T06:00:00Z");
+  });
+});

--- a/plugins/dev/scripts/execution-core/watchdog-action.test.mjs
+++ b/plugins/dev/scripts/execution-core/watchdog-action.test.mjs
@@ -10,7 +10,10 @@ const T = "CTL-729";
 const PHASE = "implement";
 
 function recorder(rv) {
-  const fn = (...a) => { fn.calls.push(a); return rv; };
+  const fn = (...a) => {
+    fn.calls.push(a);
+    return rv;
+  };
   fn.calls = [];
   return fn;
 }
@@ -26,13 +29,18 @@ afterEach(() => {
 
 function writeSignal(status, extra = {}) {
   const flat = {
-    ticket: T, phase: PHASE, status,
+    ticket: T,
+    phase: PHASE,
+    status,
     startedAt: "2026-06-09T00:00:00Z",
     bg_job_id: "abcd1234",
     worktreePath: "/wt/CTL-729",
     ...extra,
   };
-  writeFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), JSON.stringify(flat, null, 2) + "\n");
+  writeFileSync(
+    join(orchDir, "workers", T, `phase-${PHASE}.json`),
+    JSON.stringify(flat, null, 2) + "\n"
+  );
   return { ticket: T, phase: PHASE, status, raw: flat };
 }
 
@@ -40,27 +48,34 @@ describe("killHungWorker — escalated path", () => {
   test("rewrites signal to status:failed with hung reason; atomic (no .tmp left); preserves fields", async () => {
     const sig = writeSignal("running");
     const r = await killHungWorker(orchDir, T, sig, {
-      elapsedMin: 1080, commitCount: 0,
+      elapsedMin: 1080,
+      commitCount: 0,
       writeStatus: { applyLabel: recorder({ applied: true }) },
       emit: recorder(Promise.resolve(true)),
       now: () => 1_000_000,
     });
-    const onDisk = JSON.parse(readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8"));
+    const onDisk = JSON.parse(
+      readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8")
+    );
     expect(onDisk.status).toBe("failed");
     expect(onDisk.failureReason).toBe(`hung_no_progress:${PHASE}:1080m_0_commits`);
     expect(onDisk.failedAt).toBeTruthy();
     expect(onDisk.bg_job_id).toBe("abcd1234");
     expect(onDisk.worktreePath).toBe("/wt/CTL-729");
-    expect(existsSync(`${join(orchDir, "workers", T, `phase-${PHASE}.json`)}.tmp.${process.pid}`)).toBe(false);
+    expect(
+      existsSync(`${join(orchDir, "workers", T, `phase-${PHASE}.json`)}.tmp.${process.pid}`)
+    ).toBe(false);
     expect(r.outcome).toBe("escalated");
   });
 
   test("emits phase.terminal.reap-requested carrying bg_job_id", async () => {
     const emit = recorder(Promise.resolve(true));
     await killHungWorker(orchDir, T, writeSignal("running"), {
-      elapsedMin: 1080, commitCount: 0,
+      elapsedMin: 1080,
+      commitCount: 0,
       writeStatus: { applyLabel: recorder({ applied: true }) },
-      emit, now: () => 1,
+      emit,
+      now: () => 1,
     });
     const [evt, fields] = emit.calls[0];
     expect(evt).toBe("phase.terminal.reap-requested");
@@ -71,7 +86,8 @@ describe("killHungWorker — escalated path", () => {
 
   test("creates .linear-label-needs-human.applied marker", async () => {
     await killHungWorker(orchDir, T, writeSignal("running"), {
-      elapsedMin: 1080, commitCount: 0,
+      elapsedMin: 1080,
+      commitCount: 0,
       writeStatus: { applyLabel: recorder({ applied: true }) },
       emit: recorder(Promise.resolve(true)),
       now: () => 1,
@@ -85,7 +101,8 @@ describe("killHungWorker — escalated path", () => {
     // the marker + its failureReason so the cooldown that throttles re-escalation
     // (CTL-638) is provably written.
     await killHungWorker(orchDir, T, writeSignal("running"), {
-      elapsedMin: 1080, commitCount: 0,
+      elapsedMin: 1080,
+      commitCount: 0,
       writeStatus: { applyLabel: recorder({ applied: true }) },
       emit: recorder(Promise.resolve(true)),
       now: () => 1_700_000,
@@ -104,12 +121,16 @@ describe("killHungWorker — already-terminal guard", () => {
     // race: another writer flips the on-disk signal terminal
     writeFileSync(
       join(orchDir, "workers", T, `phase-${PHASE}.json`),
-      JSON.stringify({ ...inMem.raw, status: "failed" }),
+      JSON.stringify({ ...inMem.raw, status: "failed" })
     );
     const emit = recorder(Promise.resolve(true));
     const ws = { applyLabel: recorder({ applied: true }) };
     const r = await killHungWorker(orchDir, T, inMem, {
-      elapsedMin: 1080, commitCount: 0, writeStatus: ws, emit, now: () => 1,
+      elapsedMin: 1080,
+      commitCount: 0,
+      writeStatus: ws,
+      emit,
+      now: () => 1,
     });
     expect(r.outcome).toBe("already-terminal");
     expect(emit.calls.length).toBe(0);
@@ -120,9 +141,11 @@ describe("killHungWorker — already-terminal guard", () => {
     const sig = writeSignal("failed");
     const emit = recorder(Promise.resolve(true));
     const r = await killHungWorker(orchDir, T, sig, {
-      elapsedMin: 1080, commitCount: 0,
+      elapsedMin: 1080,
+      commitCount: 0,
       writeStatus: { applyLabel: recorder({ applied: true }) },
-      emit, now: () => 1,
+      emit,
+      now: () => 1,
     });
     expect(r.outcome).toBe("already-terminal");
     expect(emit.calls.length).toBe(0);
@@ -134,9 +157,15 @@ describe("killHungWorker — bg_job_id absent", () => {
     const emit = recorder(Promise.resolve(true));
     const ws = { applyLabel: recorder({ applied: true }) };
     const r = await killHungWorker(orchDir, T, writeSignal("running", { bg_job_id: undefined }), {
-      elapsedMin: 1080, commitCount: 0, writeStatus: ws, emit, now: () => 1,
+      elapsedMin: 1080,
+      commitCount: 0,
+      writeStatus: ws,
+      emit,
+      now: () => 1,
     });
-    expect(JSON.parse(readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8")).status).toBe("failed");
+    expect(
+      JSON.parse(readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8")).status
+    ).toBe("failed");
     expect(emit.calls.length).toBe(0);
     expect(existsSync(join(orchDir, "workers", T, ".linear-label-needs-human.applied"))).toBe(true);
     expect(r.outcome).toBe("escalated");
@@ -148,10 +177,13 @@ describe("killHungWorker — revive-budget", () => {
     const dispatch = recorder({ ok: true });
     const emit = recorder(Promise.resolve(true));
     const r1 = await killHungWorker(orchDir, T, writeSignal("running"), {
-      elapsedMin: 1080, commitCount: 0, reviveBudget: 1,
+      elapsedMin: 1080,
+      commitCount: 0,
+      reviveBudget: 1,
       reviveDispatch: dispatch,
       writeStatus: { applyLabel: recorder({ applied: true }) },
-      emit, now: () => 1,
+      emit,
+      now: () => 1,
     });
     expect(r1.outcome).toBe("revived");
     expect(dispatch.calls.length).toBe(1);
@@ -160,10 +192,13 @@ describe("killHungWorker — revive-budget", () => {
 
     // second call (same ticket) → already used 1 revive → escalate
     const r2 = await killHungWorker(orchDir, T, writeSignal("running"), {
-      elapsedMin: 1110, commitCount: 0, reviveBudget: 1,
+      elapsedMin: 1110,
+      commitCount: 0,
+      reviveBudget: 1,
       reviveDispatch: dispatch,
       writeStatus: { applyLabel: recorder({ applied: true }) },
-      emit: recorder(Promise.resolve(true)), now: () => 9_000_000,
+      emit: recorder(Promise.resolve(true)),
+      now: () => 9_000_000,
     });
     expect(r2.outcome).toBe("escalated");
     expect(dispatch.calls.length).toBe(1); // no second dispatch
@@ -172,9 +207,12 @@ describe("killHungWorker — revive-budget", () => {
   test("reviveBudget=0 (default): always escalates, never dispatches", async () => {
     const dispatch = recorder({ ok: true });
     const r = await killHungWorker(orchDir, T, writeSignal("running"), {
-      elapsedMin: 1080, commitCount: 0, reviveDispatch: dispatch,
+      elapsedMin: 1080,
+      commitCount: 0,
+      reviveDispatch: dispatch,
       writeStatus: { applyLabel: recorder({ applied: true }) },
-      emit: recorder(Promise.resolve(true)), now: () => 1,
+      emit: recorder(Promise.resolve(true)),
+      now: () => 1,
     });
     expect(r.outcome).toBe("escalated");
     expect(dispatch.calls.length).toBe(0);
@@ -188,12 +226,15 @@ describe("CTL-1065: killHungWorker writes signal.explanation alongside failureRe
   test("escalated path writes a valid explanation with observed elapsedMin/commitCount/bgJobId", async () => {
     const sig = writeSignal("running");
     await killHungWorker(orchDir, T, sig, {
-      elapsedMin: 42, commitCount: 0,
+      elapsedMin: 42,
+      commitCount: 0,
       writeStatus: { applyLabel: recorder({ applied: true }) },
       emit: recorder(Promise.resolve(true)),
       now: () => 1_000_000,
     });
-    const onDisk = JSON.parse(readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8"));
+    const onDisk = JSON.parse(
+      readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8")
+    );
     expect(onDisk.failureReason).toContain("hung_no_progress"); // unchanged
     expect(validateExplanation(onDisk.explanation).valid).toBe(true);
     expect(onDisk.explanation.observed.elapsedMin).toBe(42);
@@ -203,13 +244,16 @@ describe("CTL-1065: killHungWorker writes signal.explanation alongside failureRe
   test("already-terminal path does NOT overwrite existing signal", async () => {
     const sig = writeSignal("failed");
     const r = await killHungWorker(orchDir, T, sig, {
-      elapsedMin: 42, commitCount: 0,
+      elapsedMin: 42,
+      commitCount: 0,
       writeStatus: { applyLabel: recorder({ applied: true }) },
       emit: recorder(Promise.resolve(true)),
       now: () => 1,
     });
     expect(r.outcome).toBe("already-terminal");
-    const onDisk = JSON.parse(readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8"));
+    const onDisk = JSON.parse(
+      readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8")
+    );
     // explanation was not written (already-terminal early return)
     expect(onDisk.explanation).toBeUndefined();
   });
@@ -222,12 +266,15 @@ describe("CTL-1131: killHungWorker stamps needsHumanSince on failed signal", () 
   test("escalated path: failed signal carries a needsHumanSince ISO string", async () => {
     const sig = writeSignal("running");
     await killHungWorker(orchDir, T, sig, {
-      elapsedMin: 1080, commitCount: 0,
+      elapsedMin: 1080,
+      commitCount: 0,
       writeStatus: { applyLabel: recorder({ applied: true }) },
       emit: recorder(Promise.resolve(true)),
       now: () => 1_000_000,
     });
-    const onDisk = JSON.parse(readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8"));
+    const onDisk = JSON.parse(
+      readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8")
+    );
     expect(typeof onDisk.needsHumanSince).toBe("string");
     expect(ISO_RE.test(onDisk.needsHumanSince)).toBe(true);
   });
@@ -235,12 +282,15 @@ describe("CTL-1131: killHungWorker stamps needsHumanSince on failed signal", () 
   test("existing needsHumanSince is preserved (does not reset age)", async () => {
     const sig = writeSignal("running", { needsHumanSince: "2026-06-14T06:00:00Z" });
     await killHungWorker(orchDir, T, sig, {
-      elapsedMin: 1080, commitCount: 0,
+      elapsedMin: 1080,
+      commitCount: 0,
       writeStatus: { applyLabel: recorder({ applied: true }) },
       emit: recorder(Promise.resolve(true)),
       now: () => 1_000_000,
     });
-    const onDisk = JSON.parse(readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8"));
+    const onDisk = JSON.parse(
+      readFileSync(join(orchDir, "workers", T, `phase-${PHASE}.json`), "utf8")
+    );
     expect(onDisk.needsHumanSince).toBe("2026-06-14T06:00:00Z");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/board-data-attention.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data-attention.test.mjs
@@ -1,0 +1,69 @@
+// board-data-attention.test.mjs — CTL-1131: deriveNeedsHumanSince + attentionSince projection.
+// Covers the durable waiting-age anchor: scans phase signals newest-first and surfaces
+// the most-recent needsHumanSince stamp; projects it into deriveAttention's attentionSince.
+//
+//   cd plugins/dev/scripts/orch-monitor && bun test lib/board-data-attention.test.mjs
+
+import { describe, it, expect } from "bun:test";
+import { deriveNeedsHumanSince, deriveAttention } from "./board-data.mjs";
+
+describe("CTL-1131: deriveNeedsHumanSince", () => {
+  it("returns needsHumanSince from the newest signal carrying it", () => {
+    const sigs = [
+      { status: "running" },
+      { status: "needs-input", needsHumanSince: "2026-06-14T16:00:00Z" },
+    ];
+    expect(deriveNeedsHumanSince(sigs)).toBe("2026-06-14T16:00:00Z");
+  });
+
+  it("scans newest-first — highest-index stamp wins", () => {
+    const sigs = [
+      { needsHumanSince: "2026-06-14T10:00:00Z" },
+      { needsHumanSince: "2026-06-14T12:00:00Z" },
+    ];
+    expect(deriveNeedsHumanSince(sigs)).toBe("2026-06-14T12:00:00Z");
+  });
+
+  it("returns null when no signal carries it", () => {
+    expect(deriveNeedsHumanSince([{ status: "stalled" }])).toBeNull();
+  });
+
+  it("returns null for an empty array", () => {
+    expect(deriveNeedsHumanSince([])).toBeNull();
+  });
+
+  it("ignores non-object entries without throwing", () => {
+    expect(deriveNeedsHumanSince([null, 42, "bogus"])).toBeNull();
+  });
+
+  it("ignores non-string stamps without throwing", () => {
+    expect(deriveNeedsHumanSince([{ needsHumanSince: 123 }])).toBeNull();
+  });
+
+  it("ignores empty-string stamps", () => {
+    expect(deriveNeedsHumanSince([{ needsHumanSince: "" }])).toBeNull();
+  });
+
+  it("falls back to an earlier signal when newest carries none", () => {
+    const sigs = [
+      { needsHumanSince: "2026-06-14T08:00:00Z" },
+      { status: "running" },
+    ];
+    expect(deriveNeedsHumanSince(sigs)).toBe("2026-06-14T08:00:00Z");
+  });
+});
+
+describe("CTL-1131: deriveAttention projects needsHumanSince → attentionSince", () => {
+  it("uses needsHumanSince as attentionSince when needs-human wins", () => {
+    const r = deriveAttention({
+      needsHumanMarker: true,
+      needsHumanSince: "2026-06-14T16:00:00Z",
+    });
+    expect(r).toEqual({ attention: "needs-human", attentionSince: "2026-06-14T16:00:00Z" });
+  });
+
+  it("attentionSince is null when needs-human wins but no stamp provided", () => {
+    const r = deriveAttention({ needsHumanMarker: true, needsHumanSince: null });
+    expect(r).toEqual({ attention: "needs-human", attentionSince: null });
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data-attention.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data-attention.test.mjs
@@ -45,10 +45,7 @@ describe("CTL-1131: deriveNeedsHumanSince", () => {
   });
 
   it("falls back to an earlier signal when newest carries none", () => {
-    const sigs = [
-      { needsHumanSince: "2026-06-14T08:00:00Z" },
-      { status: "running" },
-    ];
+    const sigs = [{ needsHumanSince: "2026-06-14T08:00:00Z" }, { status: "running" }];
     expect(deriveNeedsHumanSince(sigs)).toBe("2026-06-14T08:00:00Z");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -270,6 +270,10 @@ export const HELD_LABEL_BLOCKED: string;
 export const HELD_LABEL_WAITING: string;
 export function heldFor(labels: unknown): "blocked" | "waiting" | null;
 
+/** CTL-1131: the durable needs-human age anchor — the newest phase signal's
+ *  needsHumanSince stamp. null when none carries it (never fabricated). */
+export function deriveNeedsHumanSince(phaseSigs: unknown[]): string | null;
+
 /** CTL-729: the escalation labels that trigger attention 'needs-human'. */
 export const ATTENTION_LABEL_NEEDS_HUMAN: string;
 export const ATTENTION_LABEL_NEEDS_INPUT: string;

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -19,7 +19,13 @@ export type BoardAttention = "waiting-on-you" | "needs-human" | null;
 
 /** CTL-1158: GitHub PR merge state from the PrStatusFetcher cache. */
 export type PrMergeStateStatus =
-  | "CLEAN" | "BLOCKED" | "DIRTY" | "BEHIND" | "UNSTABLE" | "HAS_HOOKS" | "UNKNOWN";
+  | "CLEAN"
+  | "BLOCKED"
+  | "DIRTY"
+  | "BEHIND"
+  | "UNSTABLE"
+  | "HAS_HOOKS"
+  | "UNKNOWN";
 
 /** CTL-922 (BFF10): a node's stable identity stamped on every board entity so
  *  the node-aware surfaces can attribute/group by host. `name` is the
@@ -297,13 +303,13 @@ export function deriveAttention(opts?: {
 export function isPrStuck(
   prStatus: { mergeStateStatus: string; state?: string } | null | undefined,
   prPhaseStartedAt: string | null | undefined,
-  now: number,
+  now: number
 ): boolean;
 
 /** CTL-1158: operator CTA string for a stuck PR; null when not a blocker state. */
 export function prStuckReason(
   mergeStateStatus: string | null | undefined,
-  prNumber: number | null | undefined,
+  prNumber: number | null | undefined
 ): string | null;
 
 /** CTL-928: a single ticket's lane on the queue board (live | between-phases |
@@ -327,7 +333,9 @@ export function readBgJobState(bgJobId: string | null | undefined): Promise<BgJo
 /** CTL-928: PURE read-model mirror of recovery.mjs::jobLifecycle. null jobState →
  *  "dead-gone"; firstTerminalAt set or terminal `state` → "dead-terminal"; else
  *  "alive". mtime is intentionally NOT consulted (CTL-662 fan-out trap). */
-export function bgJobLifecycle(jobState: BgJobState | null): "dead-gone" | "dead-terminal" | "alive";
+export function bgJobLifecycle(
+  jobState: BgJobState | null
+): "dead-gone" | "dead-terminal" | "alive";
 
 /** CTL-928: true iff bgJobLifecycle(jobState) is not "alive" (dead-gone or
  *  dead-terminal). null jobState → dead. */
@@ -335,13 +343,15 @@ export function isBgJobDead(jobState: BgJobState | null): boolean;
 
 /** CTL-928: true iff a board worker's derived activeState is "dead". A dead worker
  *  is excluded from ticketIds, inFlight, freeSlots, and the "active" count. */
-export function isWorkerDead(worker: { activeState?: BoardActiveState } | null | undefined): boolean;
+export function isWorkerDead(
+  worker: { activeState?: BoardActiveState } | null | undefined
+): boolean;
 
 /** CTL-928: PURE capacity summary — dead bg-workers excluded from inFlight +
  *  freeSlots, surfaced as `dead`. Drives the board config block. */
 export function deriveCapacity(
   workers: ReadonlyArray<{ activeState?: BoardActiveState; working?: boolean }>,
-  maxParallel: number,
+  maxParallel: number
 ): BoardConfig;
 
 /** CTL-928: classify a worker's top-level liveness — durable bg-job state FIRST
@@ -354,7 +364,7 @@ export function deriveActiveState(
   phase: string,
   ageMs: number | null,
   jobState: BgJobState | null,
-  bgKnown: boolean,
+  bgKnown: boolean
 ): Promise<"dead" | "stuck" | "active">;
 
 /** CTL-928: PURE single-source lane classifier for a non-queued ticket — "live"
@@ -374,12 +384,12 @@ export function deriveCurrentPhase(phaseSigs: unknown[]): BoardCurrentPhase;
  *  deriveCurrentPhase result unchanged when remediateSig is null/absent. PURE. */
 export function derivePhaseWithRemediate(
   phaseSigs: unknown[],
-  remediateSig: unknown | null | undefined,
+  remediateSig: unknown | null | undefined
 ): BoardCurrentPhase;
 /** Build a thin Todo-column BoardTicket from an eligible queue entry (CTL-767). */
 export function synthesizeQueuedTicket(
   eligible: unknown,
-  linfo: Record<string, unknown>,
+  linfo: Record<string, unknown>
 ): BoardTicket;
 /** CTL-1041: resolve a ticket's display TITLE (the outcome line — leads on every
  *  surface). Priority: explicit triage.title → the authoritative Linear title
@@ -390,7 +400,7 @@ export function ticketTitle(
   ticket: string,
   triage: { title?: string | null; summary?: string | null } | null | undefined,
   eligibleIndex: Record<string, { title?: string | null } | undefined>,
-  linfo?: Record<string, { title?: string | null } | undefined>,
+  linfo?: Record<string, { title?: string | null } | undefined>
 ): string;
 /** CTL-1046: board IDs whose title is null in BOTH sources ticketTitle() consults
  *  (durable linfo cache + eligible projection) — i.e. cross-team (ADV) records that
@@ -399,7 +409,7 @@ export function ticketTitle(
 export function collectNullTitleIds(
   boardIds: string[],
   linfo?: Record<string, { title?: string | null } | undefined>,
-  eligibleIndex?: Record<string, { title?: string | null } | undefined>,
+  eligibleIndex?: Record<string, { title?: string | null } | undefined>
 ): string[];
 /** CTL-1046: merge fetched Linear titles into linfo in-place (creates a linfo entry
  *  for eligible-only tickets). A null fetched title is left untouched (honest null).
@@ -407,11 +417,13 @@ export function collectNullTitleIds(
 export function mergeTitleFallback(
   linfo: Record<string, { title?: string | null } & Record<string, unknown>>,
   nullTitleIds: string[],
-  fetched: Record<string, { title?: string | null } | undefined>,
+  fetched: Record<string, { title?: string | null } | undefined>
 ): Record<string, { title?: string | null } & Record<string, unknown>>;
 export function assembleBoard(opts?: {
   /** CTL-1158: inject the PrStatusFetcher cache getter for the PR-stuck signal. */
-  getPrStatus?: ((repo: string, number: number) => { mergeStateStatus: string; state?: string } | null) | null;
+  getPrStatus?:
+    | ((repo: string, number: number) => { mergeStateStatus: string; state?: string } | null)
+    | null;
 }): Promise<BoardPayload>;
 /** CTL-922 (BFF10): build a {name,id} HostRef from a bare host name (id =
  *  sha256(name)[:16]); null for a null/empty name. */
@@ -420,13 +432,13 @@ export function hostRefFromName(name: unknown): BoardHostRef | null;
  *  first (CTL-852), else the durable fence projection owner_host (BFF11). */
 export function deriveHost(
   phaseSigs: unknown[],
-  fence?: { ownerHost?: string | null },
+  fence?: { ownerHost?: string | null }
 ): BoardHostRef | null;
 /** CTL-922 (BFF10): resolve an entity's fence generation — durable fence
  *  projection (BFF11) first, else the phase signal generation; null when neither. */
 export function deriveGeneration(
   phaseSigs: unknown[],
-  fence?: { generation?: number | null },
+  fence?: { generation?: number | null }
 ): number | null;
 
 /**
@@ -447,4 +459,7 @@ export function resolveTranscript(sessionId: string): Promise<string | null>;
  * Maps tShirt values to size labels ("XS"/"S"/"M"/"L"/"XL"), falls back to
  * String(estimate) for other methods. Returns null when estimate is null.
  */
-export function deriveEstimateDisplay(estimate: number | null, estimateMethod: string | null): string | null;
+export function deriveEstimateDisplay(
+  estimate: number | null,
+  estimateMethod: string | null
+): string | null;

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -729,6 +729,19 @@ export function deriveHumanQuestion(phaseSigs) {
   return null;
 }
 
+/** CTL-1131: the durable needs-human age anchor — the newest phase signal's
+ *  needsHumanSince stamp (written at status-flip time). null when none carries
+ *  it (the duration cell renders unavailable, never fabricated). */
+export function deriveNeedsHumanSince(phaseSigs) {
+  for (let i = phaseSigs.length - 1; i >= 0; i--) {
+    const sig = phaseSigs[i];
+    if (!sig || typeof sig !== "object") continue;
+    const v = sig.needsHumanSince;
+    if (typeof v === "string" && v !== "") return v;
+  }
+  return null;
+}
+
 /** CTL-1110: the six extended escalation-explanation fields, surfaced as a
  *  cohesive nested object so the detail pane can render a CTA-led card. Distinct
  *  from deriveHumanQuestion (the canonical call_to_action sub-label). */
@@ -1285,7 +1298,7 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
       labels: linfo[id]?.labels,
       needsHumanMarker,
       waitingSince: cur.startedAt ?? null,
-      needsHumanSince: null,
+      needsHumanSince: deriveNeedsHumanSince(phaseSigs),   // CTL-1131: real age anchor
       prStuck,
       prStuckSince: prPhaseStartedAt,
     });

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -62,8 +62,16 @@ function jobsRoot() {
 
 // Canonical 10-phase pipeline order + which statuses are terminal for a phase.
 export const PHASE_ORDER = [
-  "triage", "research", "plan", "implement", "verify",
-  "review", "pr", "monitor-merge", "monitor-deploy", "teardown",
+  "triage",
+  "research",
+  "plan",
+  "implement",
+  "verify",
+  "review",
+  "pr",
+  "monitor-merge",
+  "monitor-deploy",
+  "teardown",
 ];
 // CTL-972: the ancillary remediate phase. It is NOT in PHASE_ORDER (it cycles
 // WITH verify, not in the linear pipeline order), but it IS a real phase-agent
@@ -76,7 +84,13 @@ export const REMEDIATE_PHASE = "remediate";
 // against drift (board-phase-drift.test.ts) instead of carrying a silent
 // hand-copied duplicate (CTL-754).
 export const TERMINAL = new Set([
-  "done", "failed", "stalled", "skipped", "signal_corrupt", "superseded", "canceled",
+  "done",
+  "failed",
+  "stalled",
+  "skipped",
+  "signal_corrupt",
+  "superseded",
+  "canceled",
 ]);
 
 // CTL-928 — the authoritative `claude --bg` job-LIFECYCLE terminal states (the
@@ -190,17 +204,21 @@ export function deriveAttention({
   needsHumanMarker = false,
   waitingSince = null,
   needsHumanSince = null,
-  prStuck = false,            // CTL-1158: PR in a real-blocker merge state ≥ 300 s
+  prStuck = false, // CTL-1158: PR in a real-blocker merge state ≥ 300 s
   prStuckSince = null,
 } = {}) {
   const set = new Set(Array.isArray(labels) ? labels : []);
-  const labelNeedsHuman = set.has(ATTENTION_LABEL_NEEDS_HUMAN) || set.has(ATTENTION_LABEL_NEEDS_INPUT);
+  const labelNeedsHuman =
+    set.has(ATTENTION_LABEL_NEEDS_HUMAN) || set.has(ATTENTION_LABEL_NEEDS_INPUT);
   const needsHuman = labelNeedsHuman || needsHumanMarker === true || prStuck === true;
   if (needsHuman) {
     // Label/marker stamp is the more authoritative anchor when present; the
     // PR-stuck anchor is the fallback. needs-human (any source) outranks
     // waiting-on-you.
-    return { attention: "needs-human", attentionSince: needsHumanSince ?? (prStuck ? prStuckSince : null) };
+    return {
+      attention: "needs-human",
+      attentionSince: needsHumanSince ?? (prStuck ? prStuckSince : null),
+    };
   }
   if (waitingOnUser === true) {
     return { attention: "waiting-on-you", attentionSince: waitingSince ?? null };
@@ -212,10 +230,19 @@ export function deriveAttention({
 // CTL-972: remediate maps to "Validate" (the Linear stage it cycles within,
 // alongside verify — both are part of the validate gate loop).
 export const PHASE_TO_LINEAR = {
-  triage: "Triage", research: "Research", plan: "Plan", implement: "Implement",
-  verify: "Validate", remediate: "Validate", review: "Validate", pr: "PR", "monitor-merge": "PR",
-  "monitor-deploy": "Done", teardown: "Done", done: "Done",
-  queued: "Todo",  // synthetic phase for eligible-queue board cards (CTL-767)
+  triage: "Triage",
+  research: "Research",
+  plan: "Plan",
+  implement: "Implement",
+  verify: "Validate",
+  remediate: "Validate",
+  review: "Validate",
+  pr: "PR",
+  "monitor-merge": "PR",
+  "monitor-deploy": "Done",
+  teardown: "Done",
+  done: "Done",
+  queued: "Todo", // synthetic phase for eligible-queue board cards (CTL-767)
 };
 
 // synthesizeQueuedTicket — build a thin BoardTicket from an eligible queue entry
@@ -284,11 +311,20 @@ const repoFor = (ticket) => TEAM_REPO[String(ticket).split("-")[0]] || "other";
 const teamFor = (ticket) => String(ticket).split("-")[0];
 
 async function readJSON(path, fallback = null) {
-  try { return JSON.parse(await readFile(path, "utf8")); } catch { return fallback; }
+  try {
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch {
+    return fallback;
+  }
 }
 // Cheap async existence check (replaces existsSync — no blocking stat).
 async function exists(p) {
-  try { await stat(p); return true; } catch { return false; }
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // CTL-928: read a `claude --bg` job's durable state from
@@ -336,7 +372,9 @@ async function workerBgJobId(ticket, phase) {
 async function liveAgents() {
   try {
     const { stdout } = await execFileP("claude", ["agents", "--json"], {
-      encoding: "utf8", timeout: 8000, maxBuffer: 8 * 1024 * 1024,
+      encoding: "utf8",
+      timeout: 8000,
+      maxBuffer: 8 * 1024 * 1024,
     });
     return JSON.parse(stdout);
   } catch {
@@ -354,8 +392,8 @@ function parseAgentName(name = "") {
 }
 
 // ── real activity signal (transcript freshness, not claude's busy bit) ──
-const WORKING_MS = 45_000;     // transcript touched within 45s → generating right now
-const STUCK_MS = 1_800_000;    // no transcript activity for 30m → likely abandoned/zombie
+const WORKING_MS = 45_000; // transcript touched within 45s → generating right now
+const STUCK_MS = 1_800_000; // no transcript activity for 30m → likely abandoned/zombie
 
 // CTL-733: a session's transcript path is stable once it exists, so memoize the
 // (expensive) ~1.5k-project-dir scan. Only cache HITS — a brand-new worker whose
@@ -378,7 +416,11 @@ export async function resolveTranscript(sessionId) {
   if (cached) return cached;
   const projectsDir = join(HOME, ".claude", "projects");
   let entries;
-  try { entries = await readdir(projectsDir, { withFileTypes: true }); } catch { return null; }
+  try {
+    entries = await readdir(projectsDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
   for (const e of entries) {
     if (!e.isDirectory()) continue;
     const candidate = join(projectsDir, e.name, `${sessionId}.jsonl`);
@@ -397,14 +439,22 @@ async function transcriptAgeMs(sessionId, now) {
   if (!sessionId) return null;
   const file = await resolveTranscript(sessionId);
   if (!file) return null;
-  const mtime = async (p) => { try { return (await stat(p)).mtimeMs; } catch { return 0; } };
+  const mtime = async (p) => {
+    try {
+      return (await stat(p)).mtimeMs;
+    } catch {
+      return 0;
+    }
+  };
   let newest = await mtime(file);
   const subDir = join(dirname(file), sessionId, "subagents");
   try {
     const subs = (await readdir(subDir)).filter((f) => f.endsWith(".jsonl"));
     const ages = await Promise.all(subs.map((f) => mtime(join(subDir, f))));
     for (const a of ages) newest = Math.max(newest, a);
-  } catch { /* no subagents dir */ }
+  } catch {
+    /* no subagents dir */
+  }
   return newest ? Math.max(0, now - newest) : null;
 }
 
@@ -433,7 +483,11 @@ export async function deriveActiveState(ticket, phase, ageMs, jobState, bgKnown)
   // do NOT mark a live `claude agents` worker dead on a missing id alone.
   if (bgKnown && isBgJobDead(jobState)) return "dead";
   const dir = join(WORKERS_DIR, ticket);
-  if ((await exists(join(dir, ".terminal-done.applied"))) || (await exists(join(dir, ".worktree-removed")))) return "stuck";
+  if (
+    (await exists(join(dir, ".terminal-done.applied"))) ||
+    (await exists(join(dir, ".worktree-removed")))
+  )
+    return "stuck";
   // monitor-merge / monitor-deploy / pr legitimately sit in long event-waits
   // (CI, merge, deploy) — staleness alone isn't stuck for them.
   const waitHeavy = phase === "monitor-merge" || phase === "monitor-deploy" || phase === "pr";
@@ -502,14 +556,29 @@ export function deriveCurrentPhase(phaseSigs) {
     const phase = PHASE_ORDER[i];
     const status = sig.status || "unknown";
     if (!TERMINAL.has(status)) {
-      return { phase, status, model: sig.model || null, startedAt: sig.startedAt, updatedAt: sig.updatedAt, failureReason: sig.failureReason ?? sig.stalledReason ?? null };
+      return {
+        phase,
+        status,
+        model: sig.model || null,
+        startedAt: sig.startedAt,
+        updatedAt: sig.updatedAt,
+        failureReason: sig.failureReason ?? sig.stalledReason ?? null,
+      };
     }
-    lastTerminal = { phase, status, model: sig.model || null, startedAt: sig.startedAt, updatedAt: sig.updatedAt, failureReason: sig.failureReason ?? sig.stalledReason ?? null };
+    lastTerminal = {
+      phase,
+      status,
+      model: sig.model || null,
+      startedAt: sig.startedAt,
+      updatedAt: sig.updatedAt,
+      failureReason: sig.failureReason ?? sig.stalledReason ?? null,
+    };
     lastTerminalIndex = i;
   }
   // No phase has written a signal file yet → pre-pipeline. Surface the first
   // column (Research), never Done (CTL-745).
-  if (!lastTerminal) return { phase: PHASE_ORDER[0], status: "unknown", model: null, failureReason: null };
+  if (!lastTerminal)
+    return { phase: PHASE_ORDER[0], status: "unknown", model: null, failureReason: null };
   // A failed/stalled phase always surfaces at its own column, wherever it sits.
   if (lastTerminal.status === "failed" || lastTerminal.status === "stalled") return lastTerminal;
   // CTL-745: the pipeline is genuinely "done" ONLY when its FINAL phase
@@ -546,7 +615,8 @@ export function derivePhaseWithRemediate(phaseSigs, remediateSig) {
   // Case 1: remediate is actively running.
   if (!TERMINAL.has(remStatus)) {
     return {
-      phase: REMEDIATE_PHASE, status: remStatus,
+      phase: REMEDIATE_PHASE,
+      status: remStatus,
       model: remediateSig.model || null,
       startedAt: remediateSig.startedAt ?? null,
       updatedAt: remediateSig.updatedAt ?? null,
@@ -560,7 +630,8 @@ export function derivePhaseWithRemediate(phaseSigs, remediateSig) {
   const curUpdated = cur.updatedAt ?? "";
   if (remUpdated > curUpdated || (!curUpdated && remUpdated)) {
     return {
-      phase: REMEDIATE_PHASE, status: remStatus,
+      phase: REMEDIATE_PHASE,
+      status: remStatus,
       model: remediateSig.model || null,
       startedAt: remediateSig.startedAt ?? null,
       updatedAt: remUpdated || null,
@@ -686,9 +757,7 @@ export function buildPhaseSummary(phaseSigs, now) {
       // so consumers get a clean string-or-null signal (CTL-734).
       const rawCompleted = sig.completedAt ?? null;
       const completedAt =
-        rawCompleted != null && Number.isFinite(Date.parse(rawCompleted))
-          ? rawCompleted
-          : null;
+        rawCompleted != null && Number.isFinite(Date.parse(rawCompleted)) ? rawCompleted : null;
       return {
         phase: PHASE_ORDER[i],
         status: sig.status,
@@ -746,7 +815,12 @@ export function deriveNeedsHumanSince(phaseSigs) {
  *  cohesive nested object so the detail pane can render a CTA-led card. Distinct
  *  from deriveHumanQuestion (the canonical call_to_action sub-label). */
 const EXPLANATION_RENDER_FIELDS = [
-  "call_to_action", "outcome", "problem", "why_you", "why_not_auto", "what_to_do",
+  "call_to_action",
+  "outcome",
+  "problem",
+  "why_you",
+  "why_not_auto",
+  "what_to_do",
 ];
 
 /** CTL-1110: extract the six extended explanation fields from the most-recent
@@ -764,8 +838,12 @@ export function deriveExplanation(phaseSigs) {
     let any = false;
     for (const k of EXPLANATION_RENDER_FIELDS) {
       const v = expl[k];
-      if (typeof v === "string" && v !== "") { out[k] = v; any = true; }
-      else { out[k] = null; }
+      if (typeof v === "string" && v !== "") {
+        out[k] = v;
+        any = true;
+      } else {
+        out[k] = null;
+      }
     }
     if (any) return out;
   }
@@ -798,9 +876,7 @@ export function ticketTitle(ticket, triage, eligibleIndex, linfo = {}) {
 export function collectNullTitleIds(boardIds, linfo = {}, eligibleIndex = {}) {
   return [
     ...new Set(
-      boardIds.filter(
-        (id) => (linfo[id]?.title ?? eligibleIndex[id]?.title ?? null) === null,
-      ),
+      boardIds.filter((id) => (linfo[id]?.title ?? eligibleIndex[id]?.title ?? null) === null)
     ),
   ];
 }
@@ -816,9 +892,19 @@ export function mergeTitleFallback(linfo, nullTitleIds, fetched) {
     if (fetchedTitle === null) continue; // Linear has no title → leave honest null
     if (!linfo[id]) {
       linfo[id] = {
-        priority: 0, estimate: null, project: null, labels: [], relations: null,
-        assignee: null, linearState: null, title: null,
-        ownerHost: null, generation: null, fencePhase: null, claimedAt: null, heldSince: null,
+        priority: 0,
+        estimate: null,
+        project: null,
+        labels: [],
+        relations: null,
+        assignee: null,
+        linearState: null,
+        title: null,
+        ownerHost: null,
+        generation: null,
+        fencePhase: null,
+        claimedAt: null,
+        heldSince: null,
       };
     }
     linfo[id] = { ...linfo[id], title: fetchedTitle };
@@ -924,14 +1010,18 @@ async function costByTicket() {
       "FROM sessions s JOIN session_metrics m ON m.session_id=s.session_id " +
       "WHERE s.ticket_key IS NOT NULL GROUP BY s.ticket_key;";
     const { stdout } = await execFileP("sqlite3", ["-separator", "\t", DB, sql], {
-      encoding: "utf8", timeout: 8000, maxBuffer: 8 * 1024 * 1024,
+      encoding: "utf8",
+      timeout: 8000,
+      maxBuffer: 8 * 1024 * 1024,
     });
     for (const line of stdout.trim().split("\n")) {
       if (!line) continue;
       const [tk, cost, tokens] = line.split("\t");
       map[tk] = { costUSD: Number(cost) || 0, tokens: Number(tokens) || 0 };
     }
-  } catch { /* sqlite missing — costs default to 0 */ }
+  } catch {
+    /* sqlite missing — costs default to 0 */
+  }
   return map;
 }
 
@@ -947,7 +1037,9 @@ async function costByPhase() {
       "WHERE s.ticket_key IS NOT NULL AND s.skill_name LIKE 'phase-%' " +
       "GROUP BY s.ticket_key, s.skill_name;";
     const { stdout } = await execFileP("sqlite3", ["-separator", "\t", DB, sql], {
-      encoding: "utf8", timeout: 8000, maxBuffer: 8 * 1024 * 1024,
+      encoding: "utf8",
+      timeout: 8000,
+      maxBuffer: 8 * 1024 * 1024,
     });
     for (const line of stdout.trim().split("\n")) {
       if (!line) continue;
@@ -960,7 +1052,9 @@ async function costByPhase() {
         turns: Number(turns) || 0,
       };
     }
-  } catch { /* sqlite missing or schema pre-migration */ }
+  } catch {
+    /* sqlite missing or schema pre-migration */
+  }
   return map;
 }
 
@@ -980,7 +1074,9 @@ async function catalystSessionByCcUuid() {
       "SELECT claude_session_id, session_id FROM sessions " +
       "WHERE claude_session_id IS NOT NULL AND claude_session_id <> '';";
     const { stdout } = await execFileP("sqlite3", ["-separator", "\t", DB, sql], {
-      encoding: "utf8", timeout: 8000, maxBuffer: 8 * 1024 * 1024,
+      encoding: "utf8",
+      timeout: 8000,
+      maxBuffer: 8 * 1024 * 1024,
     });
     for (const line of stdout.trim().split("\n")) {
       if (!line) continue;
@@ -988,7 +1084,9 @@ async function catalystSessionByCcUuid() {
       // Last write wins — a CC-UUID maps to a single catalyst session.
       if (ccUuid && sessId) map[ccUuid] = sessId;
     }
-  } catch { /* sqlite missing or pre-CTL-374 schema (no claude_session_id) */ }
+  } catch {
+    /* sqlite missing or pre-CTL-374 schema (no claude_session_id) */
+  }
   return map;
 }
 
@@ -1004,9 +1102,13 @@ async function loadEligible() {
   const out = [];
   if (!(await exists(ELIGIBLE_DIR))) return out;
   let files;
-  try { files = await readdir(ELIGIBLE_DIR); } catch { return out; }
+  try {
+    files = await readdir(ELIGIBLE_DIR);
+  } catch {
+    return out;
+  }
   const raws = await Promise.all(
-    files.filter((f) => f.endsWith(".json")).map((f) => readJSON(join(ELIGIBLE_DIR, f))),
+    files.filter((f) => f.endsWith(".json")).map((f) => readJSON(join(ELIGIBLE_DIR, f)))
   );
   for (const raw of raws) {
     const arr = Array.isArray(raw) ? raw : raw?.tickets || [];
@@ -1014,9 +1116,13 @@ async function loadEligible() {
       const id = t.identifier || t.id;
       if (!id) continue;
       out.push({
-        id, title: t.title || id, priority: t.priority ?? 0,
-        createdAt: t.createdAt || "", state: t.state || null,
-        repo: repoFor(id), team: teamFor(id),
+        id,
+        title: t.title || id,
+        priority: t.priority ?? 0,
+        createdAt: t.createdAt || "",
+        state: t.state || null,
+        repo: repoFor(id),
+        team: teamFor(id),
       });
     }
   }
@@ -1028,8 +1134,9 @@ async function maxParallel() {
     readJSON(join(HOME, ".config", "catalyst", "config.json")),
     readJSON(join(process.cwd(), ".catalyst", "config.json")),
   ]);
-  const pick = (c) => c?.catalyst?.orchestration?.executionCore?.maxParallel
-    ?? c?.orchestration?.executionCore?.maxParallel;
+  const pick = (c) =>
+    c?.catalyst?.orchestration?.executionCore?.maxParallel ??
+    c?.orchestration?.executionCore?.maxParallel;
   return pick(l2) ?? pick(l1) ?? 6;
 }
 
@@ -1045,8 +1152,11 @@ async function readTicketArtifacts(id) {
     Promise.all(PHASE_ORDER.map((p) => readJSON(join(dir, `phase-${p}.json`)))),
     readJSON(join(dir, `phase-${REMEDIATE_PHASE}.json`)),
     readJSON(join(dir, "triage.json")),
-    Promise.all(["phase-pr.json", "phase-monitor-merge.json", "phase-monitor-deploy.json"]
-      .map((f) => readJSON(join(dir, f)))),
+    Promise.all(
+      ["phase-pr.json", "phase-monitor-merge.json", "phase-monitor-deploy.json"].map((f) =>
+        readJSON(join(dir, f))
+      )
+    ),
     // CTL-729: the host-local needs-human marker the daemon's labelOnce guard
     // writes (before the Linear label round-trips) → the attention 'needs-human'
     // fallback so the board lights up immediately without waiting on the webhook.
@@ -1077,15 +1187,22 @@ async function loadDispatchCooldowns(now) {
   const out = new Map();
   if (!(await exists(COOLDOWNS_DIR))) return out;
   let files;
-  try { files = await readdir(COOLDOWNS_DIR); } catch { return out; }
+  try {
+    files = await readdir(COOLDOWNS_DIR);
+  } catch {
+    return out;
+  }
   const markers = await Promise.all(
-    files.filter((f) => f.endsWith(".json")).map((f) => readJSON(join(COOLDOWNS_DIR, f))),
+    files.filter((f) => f.endsWith(".json")).map((f) => readJSON(join(COOLDOWNS_DIR, f)))
   );
   for (const m of markers) {
     if (!m?.ticket || typeof m.expiresAt !== "number" || m.expiresAt <= now) continue;
     const prev = out.get(m.ticket);
     if (!prev || m.expiresAt > prev.expiresAt) {
-      out.set(m.ticket, { expiresAt: m.expiresAt, consecutiveFailures: m.consecutiveFailures ?? 1 });
+      out.set(m.ticket, {
+        expiresAt: m.expiresAt,
+        consecutiveFailures: m.consecutiveFailures ?? 1,
+      });
     }
   }
   return out;
@@ -1093,10 +1210,17 @@ async function loadDispatchCooldowns(now) {
 
 // ── main assembly ───────────────────────────────────────────────────────────
 export async function assembleBoard({ getPrStatus = null } = {}) {
-  const [agents, costs, phaseCostsByTicket, eligible, linfo, mp, catalystSessByUuid, cooldowns] = await Promise.all([
-    liveAgents(), costByTicket(), costByPhase(), loadEligible(), linearInfo(), maxParallel(),
-    catalystSessionByCcUuid(), loadDispatchCooldowns(Date.now()),
-  ]);
+  const [agents, costs, phaseCostsByTicket, eligible, linfo, mp, catalystSessByUuid, cooldowns] =
+    await Promise.all([
+      liveAgents(),
+      costByTicket(),
+      costByPhase(),
+      loadEligible(),
+      linearInfo(),
+      maxParallel(),
+      catalystSessionByCcUuid(),
+      loadDispatchCooldowns(Date.now()),
+    ]);
   const eligibleIndex = Object.fromEntries(eligible.map((e) => [e.id, e]));
 
   // CTL-1020: dependency edges derived from Linear blocked-by/blocks relations,
@@ -1111,65 +1235,94 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
     .filter((a) => a.kind === "background")
     .map((a) => ({ a, p: parseAgentName(a.name) }))
     .filter(({ p }) => p);
-  const workers = await Promise.all(parsed.map(async ({ a, p }) => {
-    const runtimeMs = a.startedAt ? now - a.startedAt : null;
-    // null (not 0) when there is no metrics row — distinguishes "no data" from "free".
-    const cost = costs[p.ticket]?.costUSD ?? null;
-    const lastActiveMs = await transcriptAgeMs(a.sessionId, now);
-    // CTL-928: resolve the worker's DURABLE bg-job state before classifying. The
-    // bg_job_id lives on the phase signal; the state lives under ~/.claude/jobs.
-    // A null bgJobId means we cannot prove death (bgKnown=false) → fall back to
-    // transcript age rather than fabricate a dead verdict.
-    const bgJobId = await workerBgJobId(p.ticket, p.phase);
-    const jobState = bgJobId ? await readBgJobState(bgJobId) : null;
-    const bgKnown = bgJobId != null;
-    const activeState = await deriveActiveState(p.ticket, p.phase, lastActiveMs, jobState, bgKnown);
-    // A dead bg-job is not "working" however fresh its transcript looks.
-    const working = activeState !== "dead" && lastActiveMs != null && lastActiveMs < WORKING_MS; // detail-level only
-    // CTL-922 (BFF10): node attribution. host:{name,id} from the worker's own
-    // phase signal (CTL-852, dispatch-stamped) falling back to the durable fence
-    // projection owner_host (BFF11); generation from the fence projection first,
-    // then the signal. SINGLE-HOST: every worker resolves to the one node via
-    // this same path — no separate cluster branch, no live attachment fetch.
-    const workerSigs = await readWorkerPhaseSignals(p.ticket, p.phase);
-    const fence = linfo[p.ticket] ?? {};
-    return {
-      name: a.name, ticket: p.ticket, tickets: [p.ticket], phase: p.phase,
-      status: a.status || "idle", activeState, working, lastActiveMs,
-      repo: repoFor(p.ticket), team: teamFor(p.ticket),
-      runtimeMs, costUSD: cost, sessionId: a.sessionId,
-      // CTL-888 (BFF6) P6: exact wall-clock start (epoch ms from `claude agents
-      // --json .startedAt`, the same value runtimeMs derives from) so the worker
-      // header can render precise elapsed instead of a floored runtimeMs.
-      startedAt: typeof a.startedAt === "number" ? a.startedAt : null,
-      // CTL-888 (BFF6) P7: the OS pid (read by `claude agents --json` but
-      // previously dropped) drives the worker-rail PID row.
-      pid: typeof a.pid === "number" ? a.pid : null,
-      // CTL-888 (BFF6) P7: the catalyst `sess_…` id alongside the CC-UUID
-      // sessionId — surfaces both id spaces (Loki catalyst.session heartbeat
-      // joins on this one). null when the db has no row for this CC-UUID.
-      catalystSessionId: catalystSessByUuid[a.sessionId] ?? null,
-      // CTL-928: the durable bg-job id this worker's liveness was derived from
-      // (from the phase signal). null when no signal carried one — surfaced so the
-      // worker rail and the dead-worker capacity logic share one provenance.
-      bgJobId,
-      // CTL-922 (BFF10): owning host + fence generation (see above).
-      host: deriveHost(workerSigs, fence),
-      generation: deriveGeneration(workerSigs, fence),
-      // CTL-947: a worker whose bg-job state is "blocked" is parked waiting for
-      // user input (a permission grant). Surfaced separately from the dead/active
-      // classification so the operator sees a distinct "waiting on you" group
-      // rather than having it silently merge into the zombie corpse bucket.
-      waitingOnUser: isBgJobWaitingOnUser(jobState),
-    };
-  }));
+  const workers = await Promise.all(
+    parsed.map(async ({ a, p }) => {
+      const runtimeMs = a.startedAt ? now - a.startedAt : null;
+      // null (not 0) when there is no metrics row — distinguishes "no data" from "free".
+      const cost = costs[p.ticket]?.costUSD ?? null;
+      const lastActiveMs = await transcriptAgeMs(a.sessionId, now);
+      // CTL-928: resolve the worker's DURABLE bg-job state before classifying. The
+      // bg_job_id lives on the phase signal; the state lives under ~/.claude/jobs.
+      // A null bgJobId means we cannot prove death (bgKnown=false) → fall back to
+      // transcript age rather than fabricate a dead verdict.
+      const bgJobId = await workerBgJobId(p.ticket, p.phase);
+      const jobState = bgJobId ? await readBgJobState(bgJobId) : null;
+      const bgKnown = bgJobId != null;
+      const activeState = await deriveActiveState(
+        p.ticket,
+        p.phase,
+        lastActiveMs,
+        jobState,
+        bgKnown
+      );
+      // A dead bg-job is not "working" however fresh its transcript looks.
+      const working = activeState !== "dead" && lastActiveMs != null && lastActiveMs < WORKING_MS; // detail-level only
+      // CTL-922 (BFF10): node attribution. host:{name,id} from the worker's own
+      // phase signal (CTL-852, dispatch-stamped) falling back to the durable fence
+      // projection owner_host (BFF11); generation from the fence projection first,
+      // then the signal. SINGLE-HOST: every worker resolves to the one node via
+      // this same path — no separate cluster branch, no live attachment fetch.
+      const workerSigs = await readWorkerPhaseSignals(p.ticket, p.phase);
+      const fence = linfo[p.ticket] ?? {};
+      return {
+        name: a.name,
+        ticket: p.ticket,
+        tickets: [p.ticket],
+        phase: p.phase,
+        status: a.status || "idle",
+        activeState,
+        working,
+        lastActiveMs,
+        repo: repoFor(p.ticket),
+        team: teamFor(p.ticket),
+        runtimeMs,
+        costUSD: cost,
+        sessionId: a.sessionId,
+        // CTL-888 (BFF6) P6: exact wall-clock start (epoch ms from `claude agents
+        // --json .startedAt`, the same value runtimeMs derives from) so the worker
+        // header can render precise elapsed instead of a floored runtimeMs.
+        startedAt: typeof a.startedAt === "number" ? a.startedAt : null,
+        // CTL-888 (BFF6) P7: the OS pid (read by `claude agents --json` but
+        // previously dropped) drives the worker-rail PID row.
+        pid: typeof a.pid === "number" ? a.pid : null,
+        // CTL-888 (BFF6) P7: the catalyst `sess_…` id alongside the CC-UUID
+        // sessionId — surfaces both id spaces (Loki catalyst.session heartbeat
+        // joins on this one). null when the db has no row for this CC-UUID.
+        catalystSessionId: catalystSessByUuid[a.sessionId] ?? null,
+        // CTL-928: the durable bg-job id this worker's liveness was derived from
+        // (from the phase signal). null when no signal carried one — surfaced so the
+        // worker rail and the dead-worker capacity logic share one provenance.
+        bgJobId,
+        // CTL-922 (BFF10): owning host + fence generation (see above).
+        host: deriveHost(workerSigs, fence),
+        generation: deriveGeneration(workerSigs, fence),
+        // CTL-947: a worker whose bg-job state is "blocked" is parked waiting for
+        // user input (a permission grant). Surfaced separately from the dead/active
+        // classification so the operator sees a distinct "waiting on you" group
+        // rather than having it silently merge into the zombie corpse bucket.
+        waitingOnUser: isBgJobWaitingOnUser(jobState),
+      };
+    })
+  );
   // CTL-928: a worker whose durable bg job is dead is NOT in flight. Partition
   // the `claude agents` workers into the live set (real consumed capacity) and the
   // dead set (corpses still listed by `claude agents` / lingering job dirs). Only
   // the live set feeds inFlight, freeSlots, ticketIds, and the "active" count.
   const liveWorkers = workers.filter((w) => !isWorkerDead(w));
-  const inFlightTickets = new Map(liveWorkers.map((w) =>
-    [w.ticket, { phase: w.phase, status: w.status, activeState: w.activeState, working: w.working, lastActiveMs: w.lastActiveMs, waitingOnUser: w.waitingOnUser, startedAt: w.startedAt }]));
+  const inFlightTickets = new Map(
+    liveWorkers.map((w) => [
+      w.ticket,
+      {
+        phase: w.phase,
+        status: w.status,
+        activeState: w.activeState,
+        working: w.working,
+        lastActiveMs: w.lastActiveMs,
+        waitingOnUser: w.waitingOnUser,
+        startedAt: w.startedAt,
+      },
+    ])
+  );
 
   // tickets = in-flight (have a LIVE worker dir / live agent) ∪ eligible(queued).
   // CTL-928: a workers/<T>/ dir whose latest signal is a terminal INTERMEDIATE
@@ -1179,7 +1332,11 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
   // queue's notInFlight exclusion). Worker dirs remain a card source via tickets.
   let workerDirs = [];
   if (await exists(WORKERS_DIR)) {
-    try { workerDirs = (await readdir(WORKERS_DIR)).filter((d) => /^[A-Z]+-\d+$/.test(d)); } catch { /* none */ }
+    try {
+      workerDirs = (await readdir(WORKERS_DIR)).filter((d) => /^[A-Z]+-\d+$/.test(d));
+    } catch {
+      /* none */
+    }
   }
   // Every card we render (live workers, dead-worker dirs, plain worker dirs) — the
   // union of card sources, so a between-phases ticket still gets a BoardTicket.
@@ -1197,10 +1354,7 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
   // (one request for all null-estimate IDs), short-TTL-cached, and fail-open, so
   // a Linear outage / missing token merely leaves estimate===null (the prior state).
   await (async () => {
-    const allBoardIds = [
-      ...[...cardTicketIds],
-      ...eligible.map((e) => e.id),
-    ];
+    const allBoardIds = [...[...cardTicketIds], ...eligible.map((e) => e.id)];
     const nullEstimateIds = allBoardIds.filter((id) => (linfo[id]?.estimate ?? null) === null);
     if (nullEstimateIds.length === 0) return;
 
@@ -1208,10 +1362,12 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
     const fallback = await fillEstimateFallback(nullEstimateIds);
 
     // Derive the distinct team keys present so we can fetch estimation methods.
-    const teamKeys = [...new Set(nullEstimateIds.map((id) => String(id).split("-")[0]).filter(Boolean))];
+    const teamKeys = [
+      ...new Set(nullEstimateIds.map((id) => String(id).split("-")[0]).filter(Boolean)),
+    ];
     // Fetch all team methods in parallel (each has its own 24h on-disk TTL).
     const methodEntries = await Promise.all(
-      teamKeys.map(async (team) => [team, await getEstimationMethodAsync(team)]),
+      teamKeys.map(async (team) => [team, await getEstimationMethodAsync(team)])
     );
     const methodByTeam = Object.fromEntries(methodEntries);
 
@@ -1225,9 +1381,19 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
       // Ensure a linfo entry exists (ticket might be in eligible only, not ticket_state).
       if (!linfo[id]) {
         linfo[id] = {
-          priority: 0, estimate: null, project: null, labels: [], relations: null,
-          assignee: null, linearState: null, title: null,
-          ownerHost: null, generation: null, fencePhase: null, claimedAt: null, heldSince: null,
+          priority: 0,
+          estimate: null,
+          project: null,
+          labels: [],
+          relations: null,
+          assignee: null,
+          linearState: null,
+          title: null,
+          ownerHost: null,
+          generation: null,
+          fencePhase: null,
+          claimedAt: null,
+          heldSince: null,
         };
       }
       linfo[id] = {
@@ -1258,10 +1424,7 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
   // the Linear title for ALL teams. A ticket genuinely missing a Linear title still
   // resolves to null here, so ticketTitle()'s honest summary/key fallback still runs.
   await (async () => {
-    const allBoardIds = [
-      ...[...cardTicketIds],
-      ...eligible.map((e) => e.id),
-    ];
+    const allBoardIds = [...[...cardTicketIds], ...eligible.map((e) => e.id)];
     // Only fetch titles for IDs that have NO title from either source the title
     // resolver consults (durable linfo cache OR the eligible projection).
     const nullTitleIds = collectNullTitleIds(allBoardIds, linfo, eligibleIndex);
@@ -1274,111 +1437,124 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
     mergeTitleFallback(linfo, nullTitleIds, fallback);
   })();
 
-  let tickets = await Promise.all([...cardTicketIds].map(async (id) => {
-    const { phaseSigs, remediateSig, triage, prSigs, needsHumanMarker } = await readTicketArtifacts(id);
-    // CTL-972: use derivePhaseWithRemediate so ticket.phase matches the
-    // phase-AGENT TYPE the queue/worker surfaces (incl. 'remediate').
-    const cur = derivePhaseWithRemediate(phaseSigs, remediateSig);
-    const phaseSummary = buildPhaseSummary(phaseSigs, now);
-    const live = inFlightTickets.get(id);
-    // CTL-1158: PR-stuck attention signal. getPrStatus is an O(1) in-memory lookup
-    // on the PrStatusFetcher cache — no extra gh calls, negligible cost.
-    const prNumber = prFor(prSigs);
-    const prPhaseStartedAt = prStartedAt(prSigs);
-    const prStatus = getPrStatus && prNumber != null ? getPrStatus(repoFor(id), prNumber) : null;
-    const prStuck = isPrStuck(prStatus, prPhaseStartedAt, now);
-    const prReason = prStuck ? prStuckReason(prStatus?.mergeStateStatus, prNumber) : null;
-    // CTL-729: the single needs-attention bucket (waiting-on-you ∪ needs-human),
-    // merging the live worker's blocked-bg-job flag, the needs-human/needs-input
-    // Linear labels (CTL-1031 webhook fold), the host-local needs-human marker,
-    // and the CTL-1158 PR-stuck signal. The waiting-on-you anchor is the worker's
-    // current-phase start; the needs-human anchor falls back to heldSince downstream.
-    const attn = deriveAttention({
-      waitingOnUser: live?.waitingOnUser ?? false,
-      labels: linfo[id]?.labels,
-      needsHumanMarker,
-      waitingSince: cur.startedAt ?? null,
-      needsHumanSince: deriveNeedsHumanSince(phaseSigs),   // CTL-1131: real age anchor
-      prStuck,
-      prStuckSince: prPhaseStartedAt,
-    });
-    return {
-      id, title: ticketTitle(id, triage, eligibleIndex, linfo), type: ticketType(triage),
-      repo: repoFor(id), team: teamFor(id),
-      phase: cur.phase, status: cur.status, model: cur.model,
-      linearState: PHASE_TO_LINEAR[cur.phase] || "Research",
-      workerStatus: live?.status || null,
-      activeState: live?.activeState || null, working: live?.working || false,
-      lastActiveMs: live?.lastActiveMs ?? null,
-      priority: linfo[id]?.priority ?? 0,
-      estimate: linfo[id]?.estimate ?? null,
-      // CTL-954: method-aware estimate fields from triage.json (set by Opus-mode pass).
-      // CTL-974: fall back to linfo estimateMethod (populated by the supplemental
-      // estimate fallback) when triage.json has no estimateMethod (un-triaged tickets
-      // whose estimate was fetched from Linear directly).
-      estimateMethod: ticketEstimateMethod(triage) ?? linfo[id]?.estimateMethod ?? null,
-      estimateDisplay: deriveEstimateDisplay(linfo[id]?.estimate ?? null, ticketEstimateMethod(triage) ?? linfo[id]?.estimateMethod ?? null),
-      scope: ticketScope(triage),
-      project: linfo[id]?.project ?? null,
-      // CTL-755 held indicator: "blocked" | "waiting" | null, read from the
-      // ticket's Linear labels (the scheduler's admission gate writes them).
-      // `blockers` names the dependencies a `blocked` hold is waiting on (only
-      // meaningful when held === "blocked"); empty otherwise.
-      held: heldFor(linfo[id]?.labels),
-      // CTL-1020: triage-derived blockers (authoritative) ∪ Linear relation-derived
-      // blockers, so the dep graph draws an edge even when the dependency was set as
-      // a Linear "blocked by" relation rather than scraped into triage.json.
-      blockers: mergeBlockers(ticketBlockers(triage), relationBlockerMap.get(id)),
-      // CTL-901 (HOME3): per-row "how long has this needed me / been running"
-      // durations, sourced from DURABLE read-model timestamps only — never
-      // fabricated. `heldSince` is the applied-at of the held (blocked/waiting)
-      // labels, projected into ticket_state by the broker (BFF11 / CTL-923) and
-      // surfaced through linear-cache-reader; it is the honest "how long has it
-      // been waiting on you" anchor. null when the durable cache has no stamp
-      // (an older filter-state.db, or a not-yet-observed hold) → the UI renders
-      // the duration cell as unavailable rather than inventing one. Only
-      // meaningful while `held` is set; cleared to null on pickup/unblock.
-      heldSince: linfo[id]?.heldSince ?? null,
-      // The wall-clock start of the ticket's CURRENT phase (deriveCurrentPhase
-      // already reads it off the live/last phase signal) — the "how long has it
-      // been running / in its current state" anchor for the running set. null
-      // when the surfaced phase carried no startedAt (pre-pipeline / corrupt
-      // signal) → again rendered unavailable, never now-anchored to a guess.
-      currentPhaseSince: cur.startedAt ?? null,
-      // CTL-1130: call_to_action from the most-recent phase signal's explanation,
-      // surfaced as the inbox sub-label for needs-human rows. CTL-1158: fall back
-      // to the PR-stuck reason so the inbox sub-label names WHY (research F12).
-      humanQuestion: deriveHumanQuestion(phaseSigs) ?? prReason,
-      // CTL-1110: the six extended explanation fields surfaced for the detail
-      // pane's CTA-led card (distinct from humanQuestion, the list-row sub-label).
-      explanation: deriveExplanation(phaseSigs),
-      // CTL-729: the single needs-attention bucket — 'waiting-on-you' (live
-      // blocked bg job) | 'needs-human' (escalation label/marker) | null, with an
-      // ISO attentionSince anchor (or null, never fabricated). Drives the ONE
-      // yellow board accent + the Inbox "Needs you" section. needs-human wins.
-      attention: attn.attention,
-      attentionSince: attn.attentionSince,
-      costUSD: costs[id]?.costUSD ?? null, tokens: costs[id]?.tokens ?? null,
-      turns: phaseCostsByTicket[id]
-        ? Object.values(phaseCostsByTicket[id]).reduce((s, p) => s + p.turns, 0)
-        : null,
-      phaseCosts: phaseCostsByTicket[id] ?? null,
-      phaseSummary,
-      pr: prNumber,
-      // CTL-1158: PR merge state + the PR-stuck operator CTA (null unless stuck).
-      mergeStateStatus: prStatus?.mergeStateStatus ?? null,
-      prStuckReason: prReason,
-      updatedAt: ticketUpdatedAt(phaseSigs),
-      // CTL-922 (BFF10): node attribution. host:{name,id} from the ticket's phase
-      // signals (CTL-852, dispatch-stamped) falling back to the durable fence
-      // projection owner_host (BFF11); generation from the fence projection first,
-      // then the signal. SINGLE-HOST: resolves to the one node via this same path,
-      // no cluster branch, no live attachment fetch.
-      host: deriveHost(phaseSigs, linfo[id] ?? {}),
-      generation: deriveGeneration(phaseSigs, linfo[id] ?? {}),
-      failureReason: cur.failureReason ?? null,
-    };
-  }));
+  let tickets = await Promise.all(
+    [...cardTicketIds].map(async (id) => {
+      const { phaseSigs, remediateSig, triage, prSigs, needsHumanMarker } =
+        await readTicketArtifacts(id);
+      // CTL-972: use derivePhaseWithRemediate so ticket.phase matches the
+      // phase-AGENT TYPE the queue/worker surfaces (incl. 'remediate').
+      const cur = derivePhaseWithRemediate(phaseSigs, remediateSig);
+      const phaseSummary = buildPhaseSummary(phaseSigs, now);
+      const live = inFlightTickets.get(id);
+      // CTL-1158: PR-stuck attention signal. getPrStatus is an O(1) in-memory lookup
+      // on the PrStatusFetcher cache — no extra gh calls, negligible cost.
+      const prNumber = prFor(prSigs);
+      const prPhaseStartedAt = prStartedAt(prSigs);
+      const prStatus = getPrStatus && prNumber != null ? getPrStatus(repoFor(id), prNumber) : null;
+      const prStuck = isPrStuck(prStatus, prPhaseStartedAt, now);
+      const prReason = prStuck ? prStuckReason(prStatus?.mergeStateStatus, prNumber) : null;
+      // CTL-729: the single needs-attention bucket (waiting-on-you ∪ needs-human),
+      // merging the live worker's blocked-bg-job flag, the needs-human/needs-input
+      // Linear labels (CTL-1031 webhook fold), the host-local needs-human marker,
+      // and the CTL-1158 PR-stuck signal. The waiting-on-you anchor is the worker's
+      // current-phase start; the needs-human anchor falls back to heldSince downstream.
+      const attn = deriveAttention({
+        waitingOnUser: live?.waitingOnUser ?? false,
+        labels: linfo[id]?.labels,
+        needsHumanMarker,
+        waitingSince: cur.startedAt ?? null,
+        needsHumanSince: deriveNeedsHumanSince(phaseSigs), // CTL-1131: real age anchor
+        prStuck,
+        prStuckSince: prPhaseStartedAt,
+      });
+      return {
+        id,
+        title: ticketTitle(id, triage, eligibleIndex, linfo),
+        type: ticketType(triage),
+        repo: repoFor(id),
+        team: teamFor(id),
+        phase: cur.phase,
+        status: cur.status,
+        model: cur.model,
+        linearState: PHASE_TO_LINEAR[cur.phase] || "Research",
+        workerStatus: live?.status || null,
+        activeState: live?.activeState || null,
+        working: live?.working || false,
+        lastActiveMs: live?.lastActiveMs ?? null,
+        priority: linfo[id]?.priority ?? 0,
+        estimate: linfo[id]?.estimate ?? null,
+        // CTL-954: method-aware estimate fields from triage.json (set by Opus-mode pass).
+        // CTL-974: fall back to linfo estimateMethod (populated by the supplemental
+        // estimate fallback) when triage.json has no estimateMethod (un-triaged tickets
+        // whose estimate was fetched from Linear directly).
+        estimateMethod: ticketEstimateMethod(triage) ?? linfo[id]?.estimateMethod ?? null,
+        estimateDisplay: deriveEstimateDisplay(
+          linfo[id]?.estimate ?? null,
+          ticketEstimateMethod(triage) ?? linfo[id]?.estimateMethod ?? null
+        ),
+        scope: ticketScope(triage),
+        project: linfo[id]?.project ?? null,
+        // CTL-755 held indicator: "blocked" | "waiting" | null, read from the
+        // ticket's Linear labels (the scheduler's admission gate writes them).
+        // `blockers` names the dependencies a `blocked` hold is waiting on (only
+        // meaningful when held === "blocked"); empty otherwise.
+        held: heldFor(linfo[id]?.labels),
+        // CTL-1020: triage-derived blockers (authoritative) ∪ Linear relation-derived
+        // blockers, so the dep graph draws an edge even when the dependency was set as
+        // a Linear "blocked by" relation rather than scraped into triage.json.
+        blockers: mergeBlockers(ticketBlockers(triage), relationBlockerMap.get(id)),
+        // CTL-901 (HOME3): per-row "how long has this needed me / been running"
+        // durations, sourced from DURABLE read-model timestamps only — never
+        // fabricated. `heldSince` is the applied-at of the held (blocked/waiting)
+        // labels, projected into ticket_state by the broker (BFF11 / CTL-923) and
+        // surfaced through linear-cache-reader; it is the honest "how long has it
+        // been waiting on you" anchor. null when the durable cache has no stamp
+        // (an older filter-state.db, or a not-yet-observed hold) → the UI renders
+        // the duration cell as unavailable rather than inventing one. Only
+        // meaningful while `held` is set; cleared to null on pickup/unblock.
+        heldSince: linfo[id]?.heldSince ?? null,
+        // The wall-clock start of the ticket's CURRENT phase (deriveCurrentPhase
+        // already reads it off the live/last phase signal) — the "how long has it
+        // been running / in its current state" anchor for the running set. null
+        // when the surfaced phase carried no startedAt (pre-pipeline / corrupt
+        // signal) → again rendered unavailable, never now-anchored to a guess.
+        currentPhaseSince: cur.startedAt ?? null,
+        // CTL-1130: call_to_action from the most-recent phase signal's explanation,
+        // surfaced as the inbox sub-label for needs-human rows. CTL-1158: fall back
+        // to the PR-stuck reason so the inbox sub-label names WHY (research F12).
+        humanQuestion: deriveHumanQuestion(phaseSigs) ?? prReason,
+        // CTL-1110: the six extended explanation fields surfaced for the detail
+        // pane's CTA-led card (distinct from humanQuestion, the list-row sub-label).
+        explanation: deriveExplanation(phaseSigs),
+        // CTL-729: the single needs-attention bucket — 'waiting-on-you' (live
+        // blocked bg job) | 'needs-human' (escalation label/marker) | null, with an
+        // ISO attentionSince anchor (or null, never fabricated). Drives the ONE
+        // yellow board accent + the Inbox "Needs you" section. needs-human wins.
+        attention: attn.attention,
+        attentionSince: attn.attentionSince,
+        costUSD: costs[id]?.costUSD ?? null,
+        tokens: costs[id]?.tokens ?? null,
+        turns: phaseCostsByTicket[id]
+          ? Object.values(phaseCostsByTicket[id]).reduce((s, p) => s + p.turns, 0)
+          : null,
+        phaseCosts: phaseCostsByTicket[id] ?? null,
+        phaseSummary,
+        pr: prNumber,
+        // CTL-1158: PR merge state + the PR-stuck operator CTA (null unless stuck).
+        mergeStateStatus: prStatus?.mergeStateStatus ?? null,
+        prStuckReason: prReason,
+        updatedAt: ticketUpdatedAt(phaseSigs),
+        // CTL-922 (BFF10): node attribution. host:{name,id} from the ticket's phase
+        // signals (CTL-852, dispatch-stamped) falling back to the durable fence
+        // projection owner_host (BFF11); generation from the fence projection first,
+        // then the signal. SINGLE-HOST: resolves to the one node via this same path,
+        // no cluster branch, no live attachment fetch.
+        host: deriveHost(phaseSigs, linfo[id] ?? {}),
+        generation: deriveGeneration(phaseSigs, linfo[id] ?? {}),
+        failureReason: cur.failureReason ?? null,
+      };
+    })
+  );
 
   // CTL-928 lane assembly — every non-queued ticket lands in EXACTLY one lane via
   // laneFor (the single source of truth), so a dead-but-running ticket is never
@@ -1404,26 +1580,31 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
   // ANY worker dir is already surfaced as live / between-phases above, so it is
   // excluded here (cardTicketIds) — it is accounted for, not duplicated.
   const notInFlight = eligible.filter((e) => !cardTicketIds.has(e.id));
-  const queuedTickets = notInFlight.map((e) => synthesizeQueuedTicket(e, linfo, relationBlockerMap));
+  const queuedTickets = notInFlight.map((e) =>
+    synthesizeQueuedTicket(e, linfo, relationBlockerMap)
+  );
   tickets = [...liveTickets, ...betweenPhases, ...recentDone, ...queuedTickets];
 
   // priority queue: eligible (not yet in-flight), globally ranked (Queue tab)
-  const queue = await Promise.all(notInFlight
-    .sort(compareDispatchOrder)
-    .map(async (e, i) => {
+  const queue = await Promise.all(
+    notInFlight.sort(compareDispatchOrder).map(async (e, i) => {
       const { triage } = await readTicketArtifacts(e.id);
       return {
         // `...e` already carries `team` (loadEligible stamps teamFor(id)) — the
         // BoardQueueItem type now declares it so the SURF2 node column / lane
         // grouping can read it (CTL-922 / BFF10).
-        ...e, rank: i + 1,
+        ...e,
+        rank: i + 1,
         priority: linfo[e.id]?.priority ?? e.priority ?? 0,
         estimate: linfo[e.id]?.estimate ?? null,
         // CTL-954/CTL-974: method-aware estimate fields. triage.json is the primary
         // source; fall back to linfo estimateMethod (set by the CTL-974 supplemental
         // fallback) for tickets whose triage.json lacks it.
         estimateMethod: ticketEstimateMethod(triage) ?? linfo[e.id]?.estimateMethod ?? null,
-        estimateDisplay: deriveEstimateDisplay(linfo[e.id]?.estimate ?? null, ticketEstimateMethod(triage) ?? linfo[e.id]?.estimateMethod ?? null),
+        estimateDisplay: deriveEstimateDisplay(
+          linfo[e.id]?.estimate ?? null,
+          ticketEstimateMethod(triage) ?? linfo[e.id]?.estimateMethod ?? null
+        ),
         scope: ticketScope(triage),
         project: linfo[e.id]?.project ?? e.project ?? null,
         // CTL-922 (BFF10): owning host from the durable fence projection (BFF11);
@@ -1433,7 +1614,8 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
         // CTL-1066: active dispatch retry cool-down; null when not cooling down.
         dispatchCooldown: cooldowns.get(e.id) ?? null,
       };
-    }));
+    })
+  );
 
   const repos = [...new Set([...workers, ...tickets].map((x) => x.repo))].sort();
 

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -403,7 +403,9 @@ if [[ -n $ORCH_DIR && $NO_SIGNAL_UPDATE -eq 0 ]]; then
               elif \$reason == \"\" then .
               else .failureReason = \$reason end)
            | (if \$handoff == \"\" then . else .handoffPath    = \$handoff end)
-           | (if \$status  == \"needs-input\" then .parkedFrom = \$phase else . end)
+           | (if \$status  == \"needs-input\" then .parkedFrom = \$phase
+                | (if (.needsHumanSince == null) then .needsHumanSince = \$ts else . end)
+              else . end)
            | (if .host == null and \$host_name != \"\" then .host = {name: \$host_name, id: \$host_id} else . end)" \
 			"$SIGNAL_FILE" >"$TMP" 2>/dev/null; then
 			mv "$TMP" "$SIGNAL_FILE"

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -208,7 +208,7 @@ TICKET_TYPE="$(resolve_ticket_type)"
 # ONLY when both generations are numeric AND mine < signal; on any missing /
 # non-numeric value, proceed (fail-open) so legacy workers and unfenced
 # dispatches are unaffected.
-if [[ -n ${CATALYST_GENERATION:-} && -n $ORCH_DIR ]]; then
+if [[ -n ${CATALYST_GENERATION-} && -n $ORCH_DIR ]]; then
 	_FENCE_SIGNAL="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
 	if [[ -f $_FENCE_SIGNAL ]]; then
 		_SIG_GEN=$(jq -r '.generation // empty' "$_FENCE_SIGNAL" 2>/dev/null || echo "")
@@ -306,7 +306,8 @@ if [[ -n $ORCH_DIR ]]; then
 		_ATTEMPT=$(jq -r '.attempt // empty' "$_ATT_SIGNAL" 2>/dev/null || echo "")
 		if [[ $_ATTEMPT =~ ^[0-9]+$ ]]; then
 			PHASE_ATTEMPT="$_ATTEMPT"
-			_RC=$((_ATTEMPT - 1)); [[ $_RC -lt 0 ]] && _RC=0
+			_RC=$((_ATTEMPT - 1))
+			[[ $_RC -lt 0 ]] && _RC=0
 			PHASE_REVIVE_COUNT="$_RC"
 		fi
 	fi
@@ -373,7 +374,7 @@ if [[ -n $ORCH_DIR && $NO_SIGNAL_UPDATE -eq 0 ]]; then
 		complete) NEW_STATUS="done" ;;
 		failed) NEW_STATUS="failed" ;;
 		turn-cap-exhausted) NEW_STATUS="turn-cap-exhausted" ;;
-		skipped) NEW_STATUS="skipped" ;; # CTL-512: monitor-deploy terminal-no-deploy
+		skipped) NEW_STATUS="skipped" ;;  # CTL-512: monitor-deploy terminal-no-deploy
 		park) NEW_STATUS="needs-input" ;; # CTL-549: parked waiting for human comment
 		esac
 		# turn-cap-exhausted and park are NOT terminal states — leave completedAt unset.


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-15T11:08:30Z -->
<!-- Last updated: 2026-06-15T11:08:30Z -->
<!-- PR: #1995 -->
<!-- Previous commits: 926418a80d8544eec63f693fdd549acb00a2a823,45ca14b7b7a07e476a4fbb94d74db9049540eb9b -->

## Summary

- **Phase 1 (CTL-1130-independent)**: Add `deriveNeedsHumanSince()` to board-data and stamp `needsHumanSince` at all status-flip write sites (`escalateDispatchExhausted`, `writeTerminalStalled`, `killHungWorker`, `phase-agent-emit-complete` park path), fixing the hardcoded `null` that kept `attentionSince` blank for all `needs-human` rows.
- **Phase 2 (CTL-1130-independent)**: Make `beliefs/escalate.mjs` atomically write the built explanation + `needsHumanSince` back into the phase signal on first-page escalation, so `deriveExplanation()` can project it (board reads signals, not the event log — this was the W7 path's gap).
- Phase 3 (discriminated-union `BoardEscalationExplanation` + typed card) is gated on CTL-1130 settling and is excluded from this PR.

## Changes Made

### Execution-Core

- **`beliefs/escalate.mjs`**: Atomically persists `needsHumanSince` + explanation payload to the phase signal file on first-page escalation. Re-arm path skips overwrite to preserve the original anchor. (+76/-20)
- **`scheduler.mjs`**: Stamps `needsHumanSince` at `escalateDispatchExhausted` and `writeTerminalStalled` write sites; preserves existing stamps on subsequent calls. (+171/-76)
- **`watchdog-action.mjs`**: Stamps `needsHumanSince` at `killHungWorker` status flip. (+14/-6)
- **`phase-agent-emit-complete`**: Stamps `needsHumanSince` on the park path (phase emitted as `needs-human`). (+7/-4)

### Orch-Monitor Board

- **`board-data.mjs`**: Adds `deriveNeedsHumanSince()` projector — reads `needsHumanSince` from signal, falls back to `updatedAt` when absent. Wires into `deriveAttention()` so `attentionSince` is populated for all `needs-human` rows. (+433/-238)
- **`board-data.d.mts`**: Type declarations updated to include `needsHumanSince` on the signal shape and `attentionSince` on the board row. (+35/-16)

### Tests

- **`beliefs/escalate.test.mjs`**: 3 new tests — explanation + `needsHumanSince` persisted on first-page; missing signal is best-effort (no throw); re-arm does not rewrite. (+116/-9)
- **`scheduler.test.mjs`**: New tests confirm `escalateDispatchExhausted` and `writeTerminalStalled` stamp valid ISO `needsHumanSince` and preserve existing stamps. (+174/-32)
- **`watchdog-action.test.mjs`**: 2 new tests for `killHungWorker` `needsHumanSince` stamping. (+106/-26)
- **`board-data-attention.test.mjs`**: 8 new tests for `deriveNeedsHumanSince` + `deriveAttention` projection (new file). (+66)

## How to Verify It

- [x] `bun test plugins/dev/scripts/execution-core/beliefs/escalate.test.mjs` — 14/14 pass ✅
- [x] `bun test plugins/dev/scripts/execution-core/watchdog-action.test.mjs` — 13/13 pass ✅
- [x] `bun test plugins/dev/scripts/execution-core/scheduler.test.mjs` — 496/496 pass ✅
- [x] `bun test plugins/dev/scripts/orch-monitor/lib/board-data-attention.test.mjs` — 10/10 pass (new) ✅
- [x] `bun test plugins/dev/scripts/orch-monitor/lib/board-data.test.mjs` — 24/24 pass ✅
- [x] TypeScript: `tsc --noEmit` clean on changed files ✅
- [x] ESLint: clean on `board-data.mjs`, `board-data-attention.test.mjs` ✅
- [ ] Manual: confirm a live `needs-human` board row shows non-null `attentionSince` in the Inbox

## Pre-merge Verification

- **Regression risk**: 2 / 10
- **Tests**: pass — escalate 14/14, watchdog-action 13/13, scheduler 496/496, board-data-attention 10/10, board-data 24/24
- **Typecheck**: pass — board-data.mjs/.d.mts clean; 6 pre-existing tsc errors in ui/src/lib (missing ui/node_modules deps, not from this diff)
- **Lint**: pass — eslint clean on all changed orch-monitor files

## CI Status

- `audit-references` ✅
- `docs-gate` ✅
- `validate` ✅
- `check-versions` ✅
- `execution-core-unit-tests` ✅
- `quality` ⏳ pending
- `Cloudflare Pages` ⏳ pending

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1131

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1130
