### PR TITLE
feat(dev): CTL-1132 — tickets board visual polish (column fill, tray lift, band separation, sidebar gap)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Swimlane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Swimlane.tsx
@@ -65,7 +65,7 @@
 import { Fragment, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import { AnimatePresence } from "motion/react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { C, LIVE } from "./board-tokens";
+import { C, LIVE, TRAY_LIFT } from "./board-tokens";
 import { laneSurfaceBg } from "./lane-surface";
 import {
   buildLanes,
@@ -145,9 +145,9 @@ const PAD_X = 16;
 // (header content + its vertical padding + the 1px rule ≈ 44px).
 const HEADER_H = 44;
 // CTL-1010: vertical chrome a LaneCardsRow adds around its cells — the row's
-// `padding: 2px top + 16px bottom`. Subtracted per lane when computing the
+// `padding: 6px top + 16px bottom`. Subtracted per lane when computing the
 // available cell-area height so the water-fill budget is exact (no magic fudge).
-export const ROW_PAD_V = 18;
+export const ROW_PAD_V = 22;
 // CTL-958: CSS variable name for the per-cell max-height knob.
 // CTL-1010: this var/default is now ONLY the PRE-MEASUREMENT fallback applied on
 // the very first frame before useLaneCellHeights has measured the lanes; the real
@@ -187,7 +187,7 @@ function ColumnHeaderRow({ columns }: { columns: SharedColumn[] }) {
       data-board-colheader="true"
       style={{
         display: "grid",
-        gridTemplateColumns: `repeat(${columns.length}, ${COL_W}px)`,
+        gridTemplateColumns: `repeat(${columns.length}, minmax(${COL_W}px, 1fr))`,
         gap: COL_GAP,
         padding: `8px ${PAD_X}px 10px`,
         position: "sticky",
@@ -197,7 +197,7 @@ function ColumnHeaderRow({ columns }: { columns: SharedColumn[] }) {
         // ABOVE the canvas and clearly above the chrome (was C.s0 == sidebar dark).
         background: C.subtle,
         borderBottom: `1px solid ${C.borderSubtle}`,
-        width: "max-content",
+        width: "100%",
       }}
     >
       {columns.map((col) => (
@@ -236,6 +236,7 @@ function GroupLabelRow({
   hint,
   iconSrc,
   laneBg,
+  isFirst,
 }: {
   label: string;
   count: number;
@@ -243,6 +244,7 @@ function GroupLabelRow({
   hint: string | null;
   iconSrc?: string | null;
   laneBg?: string;
+  isFirst?: boolean;
 }) {
   const isLive = live === "live";
   const dotColor = isLive ? LIVE : live === "degraded" ? C.yellow : live === "offline" ? C.fgDim : C.blue;
@@ -264,6 +266,9 @@ function GroupLabelRow({
         background: bg,
         width: "max-content",
         minWidth: "100%",
+        // CTL-1132: hairline between consecutive project bands (skip first to
+        // avoid doubling the sticky column-header's bottom border).
+        ...(!isFirst ? { borderTop: `1px solid ${C.borderSubtle}` } : {}),
       }}
     >
       {/* Inner chip: ALSO sticky-LEFT:0 — pins the label to the board's left edge
@@ -354,11 +359,11 @@ function LaneCardsRow({
       data-lane-key={laneKey}
       style={{
         display: "grid",
-        gridTemplateColumns: `repeat(${cells.length}, ${COL_W}px)`,
+        gridTemplateColumns: `repeat(${cells.length}, minmax(${COL_W}px, 1fr))`,
         gap: COL_GAP,
-        padding: `2px ${PAD_X}px 16px`,
+        padding: `6px ${PAD_X}px 16px`,
         alignItems: "start",
-        width: "max-content",
+        width: "100%",
       }}
     >
       {cells.map((cell, i) => (
@@ -381,6 +386,7 @@ function LaneCardsRow({
             background: laneBg ?? C.subtle,
             borderRadius: 10,
             border: `1px solid ${C.borderSubtle}`,
+            boxShadow: TRAY_LIFT,
             padding: 8,
             // CTL-958 / CTL-1010: per-cell constrained height with overscroll
             // chaining. Only applied when multiple groups are present
@@ -755,7 +761,7 @@ export function SwimlaneBoard<T extends GroupableEntity>({
             lane, no group label. Real axis → a sticky group-label divider per lane,
             its cards laid into the SAME shared column grid below it. */}
         {chrome ? (
-          lanes.map((lane) => {
+          lanes.map((lane, laneIdx) => {
             const cells = deriveLane(lane.items);
             // CTL-1027: resolve the per-lane tint from the project's hue bg hex.
             const laneBg = laneSurfaceBg(lane.repo, laneColors);
@@ -771,6 +777,7 @@ export function SwimlaneBoard<T extends GroupableEntity>({
                   hint={lanes.length === 1 ? singleLaneHint(groupBy, lane, entityNoun) : null}
                   iconSrc={laneIconSrc(groupBy, lane.repo, icons)}
                   laneBg={laneBg}
+                  isFirst={laneIdx === 0}
                 />
                 {/* CTL-1010: cellMax = this lane's measured water-fill share
                     (allocs is null on the first frame → undefined → var() fallback). */}

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/board-tokens.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/board-tokens.ts
@@ -57,6 +57,9 @@ export const CARD_LIFT =
   "inset 0 1px 0 rgba(255,255,255,0.07), 0 1px 4px rgba(0,0,0,0.35)";
 export const ELEVATED_LIFT =
   "inset 0 1px 0 rgba(255,255,255,0.06), 0 8px 24px rgba(0,0,0,0.45)";
+/** CTL-1132: softer tray shadow — trays float off the canvas but sit clearly
+ *  BELOW cards (CARD_LIFT). Halved ambient opacity, no inset highlight. */
+export const TRAY_LIFT = "0 1px 3px rgba(0,0,0,0.28)";
 
 
 /** Canonical PHASE color map — the SINGLE definition; board-display.ts, formatters.ts,
@@ -105,7 +108,7 @@ export const NODE_ACCENTS = [
 
 /** CTL-1027: the barely-there per-project lane tint strength (%). Tuned to keep
  *  lanes distinguishable without breaking the Linear-calm aesthetic. */
-export const LANE_TINT_PCT = 5;
+export const LANE_TINT_PCT = 6;
 
 /**
  * Compose a project hue over a base surface as a perceptually-even oklab tint.

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
@@ -428,7 +428,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               the routed surface (a Board root with flex:1/height:100%) can fill
               the full height of the inset content area (the board-height fix
               chain — completed in Pass B). */}
-          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden pl-3">
             <RepoIconProvider repos={repos}>
               {children}
             </RepoIconProvider>


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-14T16:51:00Z -->
<!-- Last updated: 2026-06-14T16:51:00Z -->
<!-- PR: #2005 -->
<!-- Previous commits: 8bca46fde3f54222e192cd21d99d2993fba3cce5 -->

## Summary

Visual polish pass on the orch-monitor `/board` kanban view. Four independent CSS-level changes make the board feel calmer and more spatially intentional: columns now fill the viewport instead of locking to fixed 300px tracks, column trays have a soft shadow lift, project-band rows have a hairline separator, and the sidebar-to-board gap is balanced.

## Changes Made

### `plugins/dev/scripts/orch-monitor/ui/src/board/Swimlane.tsx`

- **Column tracks**: `gridTemplateColumns` changed from `repeat(n, 300px)` to `repeat(n, minmax(300px, 1fr))` in both `ColumnHeaderRow` and `LaneCardsRow`; `width` changed from `max-content` to `100%`. Columns now fill the available horizontal space on wide viewports; horizontal scroll appears only when content genuinely exceeds the viewport. Header and card-row grids updated in tandem so column alignment is preserved.
- **Tray elevation**: `ROW_PAD_V` updated 18→22 (top padding 2px→6px) so the tray seam is visible. `TRAY_LIFT` shadow applied to each tray cell. Elevation order remains header < tray < card.
- **Project-band separation**: `GroupLabelRow` receives an `isFirst` prop (wired from `laneIdx === 0`). A `borderTop: 1px solid ${C.borderSubtle}` hairline is applied to all project-band rows except the first, avoiding a double-line with the sticky column-header's bottom border.

### `plugins/dev/scripts/orch-monitor/ui/src/board/board-tokens.ts`

- Added `TRAY_LIFT = "0 1px 3px rgba(0,0,0,0.28)"` — a softer shadow than `CARD_LIFT` so trays float visibly above the canvas while cards remain the top elevation layer.
- `LANE_TINT_PCT` bumped 5→6 (within the `[3,6]` guard-test contract) for slightly more per-project band distinction.

### `plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx`

- `pl-3` added to the `SidebarInset` content wrapper so the board content sits at a comfortable distance from the left nav.

## How to Verify It

- [x] `tsc --noEmit` clean (root + `ui/`) — no TypeScript errors in changed files
- [x] ESLint 0 errors, 53 pre-existing warnings (none in changed files)
- [x] 614 board UI tests pass (0 fail)
- [x] `bun run build:ui` succeeds
- [ ] Open the orch-monitor `/board` route on a wide viewport and confirm:
  - Columns fill the available width instead of leaving empty canvas
  - Column trays have a subtle shadow (distinct from card elevation)
  - Project-band rows (Adva / Catalyst) show a hairline separator between them (not above the first band)
  - The board content sits at a comfortable distance from the left sidebar

**CI status**: `docs-gate` ✅, `audit-references` ✅, `check-versions` ✅, `validate` ✅, `quality` pending, `Cloudflare Pages` pending.

**Test suite note**: 9 failures in the full bun test run are pre-existing host-environmental issues (live-fleet leak, port conflicts, SQLITE temp-db) — none touch the board UI. Not a regression from this diff.

## Pre-merge Verification Gates

| Gate | Status |
|------|--------|
| typecheck | ✅ pass |
| lint | ✅ pass |
| reward-hacking | ✅ pass |
| security | ✅ pass |
| code-review | ✅ pass |
| coverage | ✅ pass |
| silent-failures | ✅ pass |
| tests | ⚠️ 9 env failures (pre-existing, not regressions) |

Regression risk: **2 / 10**

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-1132
