### PR TITLE
feat(dev): CTL-1144 — tickets board polish (balanced columns, card elevation, full-height bands, total count)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
@@ -97,6 +97,7 @@ import { laneColumns, visibleColumnDefs, PHASE_COLUMNS, type BoardColumnDef } fr
 import { C, LIVE, PHASE, TYPE as TYPE_MAP, NODE_ACCENTS, CARD_LIFT } from "./board-tokens";
 import { typeSymbol } from "./type-icon";
 import { SwimlaneBoard, type SharedColumn, type LaneCell } from "./Swimlane";
+import { formatIssueCount } from "./board-counts";
 import { useResolvedRepoColors } from "@/hooks/use-resolved-repo-colors";
 // ── BOARD4 / CTL-908: the dense List layout ────────────────────────────────────
 // When the BOARD2 popover's Layout toggle is "list", the Tickets body renders the
@@ -1024,6 +1025,15 @@ export function Board({
             SINGLE app-shell header row (the breadcrumb bar already names the
             surface). One header per surface; behavior + persistence unchanged. */}
         <HeaderActions>
+          {/* CTL-1144: combined board total — quiet, mono, no accent color. */}
+          {view === "tickets" && data && (
+            <span style={{
+              fontFamily: C.mono, fontVariantNumeric: "tabular-nums", fontSize: 12,
+              fontWeight: 600, color: C.fg, whiteSpace: "nowrap",
+            }}>
+              {formatIssueCount(fTickets.length)}
+            </span>
+          )}
           {/* CTL-972: lens-aware tagline + quiet active-lens indicator. Muted, and
               hidden on narrow widths so the header stays calm. */}
           <span className="hidden text-[12px] text-muted-foreground lg:inline">

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Swimlane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Swimlane.tsx
@@ -141,6 +141,20 @@ export function swipeBlockDirection(
 }
 const COL_GAP = 16;
 const PAD_X = 16;
+
+/** CTL-1144: the board's intrinsic minimum width — N column tracks at COL_W,
+ *  (N-1) inter-column gaps at COL_GAP, plus the row's left+right PAD_X. Drives
+ *  the scroll inner container's min-width so columns hold COL_W and the board
+ *  scrolls on narrow viewports, while still filling (1fr) on wide ones. */
+export function boardMinWidth(
+  columnCount: number,
+  colW = COL_W,
+  gap = COL_GAP,
+  padX = PAD_X,
+): number {
+  if (columnCount <= 0) return 2 * padX;
+  return columnCount * colW + (columnCount - 1) * gap + 2 * padX;
+}
 // Sticky offset for the group-label row — it pins just below the column header
 // (header content + its vertical padding + the 1px rule ≈ 44px).
 const HEADER_H = 44;
@@ -189,19 +203,26 @@ function ColumnHeaderRow({ columns }: { columns: SharedColumn[] }) {
         display: "grid",
         gridTemplateColumns: `repeat(${columns.length}, minmax(${COL_W}px, 1fr))`,
         gap: COL_GAP,
-        padding: `8px ${PAD_X}px 10px`,
+        // CTL-1144: top padding increased to 16px for comfortable board breathing room.
+        padding: `16px ${PAD_X}px 0`,
         position: "sticky",
         top: 0,
         zIndex: 3,
-        // CTL-1033: kanban column-header chips sit on `subtle` — a visible step
-        // ABOVE the canvas and clearly above the chrome (was C.s0 == sidebar dark).
-        background: C.subtle,
-        borderBottom: `1px solid ${C.borderSubtle}`,
+        // CTL-1144: continuous row background removed; each header cell gets its own
+        // tray surface so the canvas gutter shows between headers (matching columns).
         width: "100%",
       }}
     >
       {columns.map((col) => (
-        <div key={col.key} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        // CTL-1144: each header cell is the rounded top cap of its column tray.
+        <div key={col.key} style={{
+          display: "flex", alignItems: "center", gap: 8,
+          background: C.s1,
+          borderRadius: "10px 10px 0 0",
+          border: `1px solid ${C.borderSubtle}`,
+          borderBottom: "none",
+          padding: "8px 10px 10px",
+        }}>
           <span style={{ width: 9, height: 9, borderRadius: "50%", background: col.c, flex: "0 0 auto" }} />
           <span style={{ fontSize: 13, fontWeight: 600, color: C.fg, letterSpacing: 0.2 }}>{col.label}</span>
           <span style={{ fontFamily: C.mono, fontVariantNumeric: "tabular-nums", fontSize: 11, color: C.fgMuted, background: C.s3, padding: "1px 7px", borderRadius: 9 }}>{col.count}</span>
@@ -248,7 +269,7 @@ function GroupLabelRow({
 }) {
   const isLive = live === "live";
   const dotColor = isLive ? LIVE : live === "degraded" ? C.yellow : live === "offline" ? C.fgDim : C.blue;
-  const bg = laneBg ?? C.subtle;
+  const bg = laneBg ?? C.s1;
   return (
     // Outer band: sticky-TOP only — holds its row position during vertical scroll;
     // scrolls horizontally with the column grid so the background fills the full width.
@@ -260,15 +281,15 @@ function GroupLabelRow({
         position: "sticky",
         top: HEADER_H,
         zIndex: 2,
-        // CTL-1033: swimlane group bands sit on `subtle` — visibly lighter than
-        // the sidebar chrome (the ticket bug: rows sat at sidebar darkness).
+        // CTL-1033: swimlane group bands.
         // CTL-1027: tinted when the lane's project has a resolved hue.
+        // CTL-1144: re-based from subtle to s1; inset by PAD_X for rounded edges.
         background: bg,
-        width: "max-content",
-        minWidth: "100%",
-        // CTL-1132: hairline between consecutive project bands (skip first to
-        // avoid doubling the sticky column-header's bottom border).
-        ...(!isFirst ? { borderTop: `1px solid ${C.borderSubtle}` } : {}),
+        borderRadius: 10,
+        marginLeft: PAD_X,
+        marginRight: PAD_X,
+        // CTL-1144: real vertical separation above non-first bands (replaces hairline).
+        ...(!isFirst ? { marginTop: 12 } : {}),
       }}
     >
       {/* Inner chip: ALSO sticky-LEFT:0 — pins the label to the board's left edge
@@ -282,11 +303,14 @@ function GroupLabelRow({
           gap: 8,
           padding: `10px ${PAD_X}px 8px`,
           position: "sticky",
-          left: 0,
+          // CTL-1144: band is inset by PAD_X; align chip to band's rounded left edge.
+          left: PAD_X,
           zIndex: 3,
-          // CTL-1033: the dual-sticky chip paints over the band — same `subtle`.
+          // CTL-1033: the dual-sticky chip paints over the band — same surface.
           // CTL-1027: tinted to match the outer band when the lane has a hue.
           background: bg,
+          borderTopLeftRadius: 10,
+          borderBottomLeftRadius: 10,
         }}
       >
         {iconSrc ? (
@@ -362,7 +386,11 @@ function LaneCardsRow({
         gridTemplateColumns: `repeat(${cells.length}, minmax(${COL_W}px, 1fr))`,
         gap: COL_GAP,
         padding: `6px ${PAD_X}px 16px`,
-        alignItems: "start",
+        // CTL-1144: flexGrow:1 lets this row expand to fill leftover vertical space
+        // (full-height lane cells, Phase 3); stretch fills the taller row height.
+        // flexGrow is inert when content overflows — water-fill caps still govern.
+        flexGrow: 1,
+        alignItems: "stretch",
         width: "100%",
       }}
     >
@@ -376,14 +404,12 @@ function LaneCardsRow({
             flexDirection: "column",
             gap: 8,
             minWidth: 0,
-            // CTL-1033 column-tray: each column's track is its OWN `subtle`-level
-            // surface (one step ABOVE the canvas) so columns read as discrete
-            // trays, not one continuous slab. The COL_GAP between grid tracks is the
-            // visible canvas-colored gutter that separates adjacent columns; cards
-            // (C.s2) sit one further step above this tray. The dashed-edge well + 8px
-            // internal padding give the tray a Linear-style enclosed feel.
+            // CTL-1033 column-tray: each column's track is its OWN surface so
+            // columns read as discrete trays, not one continuous slab. The COL_GAP
+            // between grid tracks is the visible canvas-colored gutter.
             // CTL-1027: tinted when the lane's project has a resolved hue.
-            background: laneBg ?? C.subtle,
+            // CTL-1144: re-based from subtle to s1 so cards (s2) read as elevated.
+            background: laneBg ?? C.s1,
             borderRadius: 10,
             border: `1px solid ${C.borderSubtle}`,
             boxShadow: TRAY_LIFT,
@@ -753,9 +779,13 @@ export function SwimlaneBoard<T extends GroupableEntity>({
           }}
         />
       )}
-      {/* the inner block sizes to the full column run (max-content) so the single
-          overflow-x container scrolls the header + every lane together. */}
-      <div ref={bumpRef} style={{ width: "max-content", minWidth: "100%" }}>
+      {/* CTL-1144: min-width driven by column count so tracks never compete for
+          negative space; flex column + minHeight:100% lets lane rows divide the
+          leftover vertical space (Phase 3 full-height cells). */}
+      <div ref={bumpRef} style={{
+        width: `max(100%, ${boardMinWidth(columns.length)}px)`,
+        display: "flex", flexDirection: "column", minHeight: "100%",
+      }}>
         <ColumnHeaderRow columns={columns} />
         {/* axis="none" (and the empty-on-a-real-axis fallthrough) → one synthetic
             lane, no group label. Real axis → a sticky group-label divider per lane,

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/board-counts.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/board-counts.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "bun:test";
+import { formatIssueCount } from "./board-counts";
+
+describe("formatIssueCount", () => {
+  it("groups thousands and pluralizes", () => {
+    expect(formatIssueCount(2433)).toBe("2,433 issues");
+    expect(formatIssueCount(1)).toBe("1 issue");
+    expect(formatIssueCount(0)).toBe("0 issues");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/board-counts.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/board-counts.ts
@@ -1,0 +1,4 @@
+/** CTL-1144: board-header total count, thousands-grouped + pluralized. */
+export function formatIssueCount(n: number): string {
+  return `${n.toLocaleString("en-US")} issue${n === 1 ? "" : "s"}`;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/lane-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/lane-surface.test.ts
@@ -5,14 +5,14 @@ import { C, LANE_TINT_PCT } from "./board-tokens";
 const COLORS = { "owner/a": "#3a2a5a" };
 
 describe("laneSurfaceBg", () => {
-  it("tints a lane whose repo has a resolved color", () => {
+  it("tints a lane whose repo has a resolved color over s1", () => {
     expect(laneSurfaceBg("owner/a", COLORS)).toBe(
-      `color-mix(in oklab, #3a2a5a ${LANE_TINT_PCT}%, ${C.subtle})`,
+      `color-mix(in oklab, #3a2a5a ${LANE_TINT_PCT}%, ${C.s1})`,
     );
   });
-  it("leaves a lane with no color exactly C.subtle", () => {
-    expect(laneSurfaceBg("owner/b", COLORS)).toBe(C.subtle);
-    expect(laneSurfaceBg(null, COLORS)).toBe(C.subtle);
-    expect(laneSurfaceBg("owner/a", {})).toBe(C.subtle);
+  it("leaves a lane with no color exactly C.s1", () => {
+    expect(laneSurfaceBg("owner/b", COLORS)).toBe(C.s1);
+    expect(laneSurfaceBg(null, COLORS)).toBe(C.s1);
+    expect(laneSurfaceBg("owner/a", {})).toBe(C.s1);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/lane-surface.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/lane-surface.ts
@@ -1,11 +1,12 @@
 import { C, laneTint } from "./board-tokens";
 
-/** Resolve a swimlane surface background: tint over C.subtle when the lane's repo
- *  has a resolved hue, else plain C.subtle. (repoKey → hue `.bg` hex.) */
+/** Resolve a swimlane surface background: tint over C.s1 when the lane's repo
+ *  has a resolved hue, else plain C.s1. (repoKey → hue `.bg` hex.)
+ *  CTL-1144: tray bases on s1 so cards (s2) read as elevated. */
 export function laneSurfaceBg(
   repo: string | null | undefined,
   laneColors: Record<string, string>,
-  base: string = C.subtle,
+  base: string = C.s1,
 ): string {
   return laneTint(repo ? laneColors[repo] : undefined, base);
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/swimlane-geometry.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/swimlane-geometry.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+import { boardMinWidth } from "./Swimlane";
+
+describe("boardMinWidth", () => {
+  it("sums tracks + gaps + side padding", () => {
+    expect(boardMinWidth(5)).toBe(5 * 300 + 4 * 16 + 2 * 16); // 1596
+    expect(boardMinWidth(1)).toBe(1 * 300 + 0 * 16 + 2 * 16); // 332
+  });
+  it("never goes negative for 0 columns", () => {
+    expect(boardMinWidth(0)).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-14T18:22:00Z -->
<!-- Last updated: 2026-06-14T18:22:00Z -->
<!-- PR: #2008 -->
<!-- Previous commits: 4bd8866334a11f21278514510b9b39614a64af40 -->

## Summary

- **Phase 1 — Card elevation**: re-bases column/band tray surface from `C.subtle` to `C.s1` so cards (`C.s2`) are visibly elevated above the tray; hue tint still reads against the new base
- **Phase 2 — Balanced columns + header caps**: exports `boardMinWidth(n)` and drives `bumpRef` with `max(100%, boardMinWidth(n)px)` fixing the CTL-1132 regression where the leftmost column ballooned; restyles each header cell as the top-rounded cap of its column tray (canvas gutter shows between headers)
- **Phase 3 — Full-height lane cells**: `bumpRef` becomes a flex column with `minHeight:100%`; `LaneCardsRow` gets `flexGrow:1` + `alignItems:stretch` so short-content lanes fill the board height without a dead band at the bottom
- **Phase 4 — Band rounding + separation**: project bands are inset by `PAD_X` with `borderRadius:10` and real `marginTop:12` above non-first bands (replaces hairline); dual-sticky chip `left` aligned to band's rounded edge
- **Phase 5 — Board total + top padding**: new `formatIssueCount()` in `board-counts.ts` renders "`N issues`" in the `HeaderActions` header; top padding increased from 8px to 16px

## Changes Made

### Files Changed (7)

- `Board.tsx` — layout: `bumpRef` flex column + full-height stretching, board total count in header
- `Swimlane.tsx` — lane cards row flex growth, band rounding/inset/margin, column header as tray cap
- `board-counts.ts` — new `formatIssueCount()` utility + `boardMinWidth(n)` export
- `board-counts.test.ts` — tests for `formatIssueCount()` edge cases (0, 1, plural)
- `lane-surface.ts` — `C.subtle` → `C.s1` base surface for column trays
- `lane-surface.test.ts` — updated surface assertions for new base color
- `swimlane-geometry.test.ts` — `boardMinWidth()` geometry tests

## Test Plan

- [x] `bun test lane-surface board-counts` — both new/flipped assertions pass
- [x] `bunx tsc --noEmit` — clean (0 errors in changed files)
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [x] `bun run build:ui` — succeeds
- [x] CI quality gate — all checks passing (audit-references, check-versions, docs-gate, quality, validate)
- [ ] Live screenshot of `/board` at wide + narrow viewport confirming all 5 scenarios (column balance, elevation, full-height bands, total count, top padding)

## Related Issues

- Fixes https://linear.app/coalesce/issue/CTL-1144

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1132
