### PR TITLE
feat(dev): CTL-1146 — card elevation (tray s1→s0) & band hue bump (6→9%)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Swimlane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Swimlane.tsx
@@ -214,10 +214,10 @@ function ColumnHeaderRow({ columns }: { columns: SharedColumn[] }) {
       }}
     >
       {columns.map((col) => (
-        // CTL-1144: each header cell is the rounded top cap of its column tray.
+        // CTL-1146: each header cell is the rounded top cap of its column tray (follows tray to s0).
         <div key={col.key} style={{
           display: "flex", alignItems: "center", gap: 8,
-          background: C.s1,
+          background: C.s0,
           borderRadius: "10px 10px 0 0",
           border: `1px solid ${C.borderSubtle}`,
           borderBottom: "none",
@@ -408,8 +408,8 @@ function LaneCardsRow({
             // columns read as discrete trays, not one continuous slab. The COL_GAP
             // between grid tracks is the visible canvas-colored gutter.
             // CTL-1027: tinted when the lane's project has a resolved hue.
-            // CTL-1144: re-based from subtle to s1 so cards (s2) read as elevated.
-            background: laneBg ?? C.s1,
+            // CTL-1146: re-based from s1 to s0 so cards (s2) read as clearly elevated.
+            background: laneBg ?? C.s0,
             borderRadius: 10,
             border: `1px solid ${C.borderSubtle}`,
             boxShadow: TRAY_LIFT,

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/board-tokens.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/board-tokens.test.ts
@@ -17,8 +17,8 @@ describe("laneTint", () => {
     expect(laneTint("#3a2a5a", C.subtle)).not.toContain("in srgb");
   });
 
-  it("keeps the tint barely-there (3–6%)", () => {
-    expect(LANE_TINT_PCT).toBeGreaterThanOrEqual(3);
-    expect(LANE_TINT_PCT).toBeLessThanOrEqual(6);
+  it("keeps the tint perceptible but calm (3–10%)", () => {
+    expect(LANE_TINT_PCT).toBeGreaterThanOrEqual(8);
+    expect(LANE_TINT_PCT).toBeLessThanOrEqual(10);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/board-tokens.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/board-tokens.ts
@@ -106,9 +106,9 @@ export const NODE_ACCENTS = [
   "#e0824f", // C.orange
 ] as const;
 
-/** CTL-1027: the barely-there per-project lane tint strength (%). Tuned to keep
- *  lanes distinguishable without breaking the Linear-calm aesthetic. */
-export const LANE_TINT_PCT = 6;
+/** CTL-1146: the per-project lane tint strength (%). Bumped 6 → 9 so the
+ *  project hue is perceptible at a glance while staying Linear-calm. */
+export const LANE_TINT_PCT = 9;
 
 /**
  * Compose a project hue over a base surface as a perceptually-even oklab tint.

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/lane-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/lane-surface.test.ts
@@ -5,14 +5,14 @@ import { C, LANE_TINT_PCT } from "./board-tokens";
 const COLORS = { "owner/a": "#3a2a5a" };
 
 describe("laneSurfaceBg", () => {
-  it("tints a lane whose repo has a resolved color over s1", () => {
+  it("tints a lane whose repo has a resolved color over s0", () => {
     expect(laneSurfaceBg("owner/a", COLORS)).toBe(
-      `color-mix(in oklab, #3a2a5a ${LANE_TINT_PCT}%, ${C.s1})`,
+      `color-mix(in oklab, #3a2a5a ${LANE_TINT_PCT}%, ${C.s0})`,
     );
   });
-  it("leaves a lane with no color exactly C.s1", () => {
-    expect(laneSurfaceBg("owner/b", COLORS)).toBe(C.s1);
-    expect(laneSurfaceBg(null, COLORS)).toBe(C.s1);
-    expect(laneSurfaceBg("owner/a", {})).toBe(C.s1);
+  it("leaves a lane with no color exactly C.s0", () => {
+    expect(laneSurfaceBg("owner/b", COLORS)).toBe(C.s0);
+    expect(laneSurfaceBg(null, COLORS)).toBe(C.s0);
+    expect(laneSurfaceBg("owner/a", {})).toBe(C.s0);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/lane-surface.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/lane-surface.ts
@@ -1,12 +1,12 @@
 import { C, laneTint } from "./board-tokens";
 
-/** Resolve a swimlane surface background: tint over C.s1 when the lane's repo
- *  has a resolved hue, else plain C.s1. (repoKey → hue `.bg` hex.)
- *  CTL-1144: tray bases on s1 so cards (s2) read as elevated. */
+/** Resolve a swimlane surface background: tint over C.s0 when the lane's repo
+ *  has a resolved hue, else plain C.s0. (repoKey → hue `.bg` hex.)
+ *  CTL-1146: tray bases on s0 (a step below canvas) so cards (s2) read as clearly elevated. */
 export function laneSurfaceBg(
   repo: string | null | undefined,
   laneColors: Record<string, string>,
-  base: string = C.s1,
+  base: string = C.s0,
 ): string {
   return laneTint(repo ? laneColors[repo] : undefined, base);
 }


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-14T19:22:30Z -->
<!-- Last updated: 2026-06-14T19:22:30Z -->
<!-- PR: #2016 -->
<!-- Previous commits: b56ae7cdad06ee0887c92927f3d6ff8fccc97b3c -->

## Summary

Two visual polish fixes for the orch-monitor tickets board, following up CTL-1144:

1. **Card elevation** — Column/tray background shifted from `C.s1` to `C.s0` (one step darker on the surface ladder). Cards remain at `C.s2`, so they now sit unmistakably elevated above the tray rather than blending into it.
2. **Band hue** — `LANE_TINT_PCT` bumped from 6 → 9% (oklab blend). Project-band color (Adva green, Catalyst purple) is now perceptible at a glance while staying within the Linear-calm aesthetic.

Both changes are purely visual — no behavior or data-flow changes.

## Changes Made

### Visual tokens (`board-tokens.ts`)

- `LANE_TINT_PCT`: 6 → 9 — slightly stronger per-project lane tint so the hue registers without shouting.

### Lane surface (`lane-surface.ts`)

- `laneSurfaceBg()` default base: `C.s1` → `C.s0` — tinted lane surfaces also anchor to the darker step, keeping relative contrast consistent between tinted and untinted lanes.

### Board layout (`Swimlane.tsx`)

- `ColumnHeaderRow` header cap background: `C.s1` → `C.s0` — the rounded header cap follows the tray.
- `LaneCardsRow` tray background: `C.s1` → `C.s0` — cards (s2) now clearly sit elevated above the column.

### Tests (`board-tokens.test.ts`, `lane-surface.test.ts`)

- Updated `LANE_TINT_PCT` bounds: 3–6% → 8–10%.
- Updated `laneSurfaceBg` baseline assertions: `C.s1` → `C.s0`.

## How to Verify It

- [ ] Run the orch-monitor board with a live fleet (`bun run dev` in `orch-monitor/ui/`) and open Rows=Team view
- [x] `bun test` passes in `orch-monitor/ui/` (board-tokens + lane-surface unit tests)
- [ ] On the tickets board, column trays visually read darker than card surfaces — cards appear elevated
- [ ] Per-project band tint is visible at a glance (Adva green / Catalyst purple bands register clearly)
- [ ] No regressions on other board views (Rows=Repo, Rows=None)

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1146

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1144
