### PR TITLE
CTL-1147: OS-following appearance & full-surface light mode coverage

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/app-shell-ia.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/app-shell-ia.test.ts
@@ -206,8 +206,9 @@ describe("theme toggle flips calm-dark and warm-light (CTL-893)", () => {
     const settingsSrc = read("components/settings-surface.tsx");
     expect(settingsSrc).toContain("useTheme");
     expect(settingsSrc).toContain("@/lib/theme");
-    // The Appearance field reads `theme` and writes via the hook's setTheme.
-    expect(settingsSrc).toMatch(/onChange=\{\(v\)\s*=>\s*setTheme\(v\)\}/);
+    // CTL-1147: the Appearance field is now a three-way preference (system/dark/light);
+    // it reads `preference` and writes via the hook's setPreference.
+    expect(settingsSrc).toMatch(/onChange=\{\(v\)\s*=>\s*setPreference\(v as ThemePreference\)\}/);
     // The sidebar no longer owns the toggle.
     expect(sidebarSrc).not.toContain("toggleTheme");
   });

--- a/plugins/dev/scripts/orch-monitor/__tests__/settings-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/settings-surface.test.ts
@@ -116,10 +116,10 @@ describe("Theme routes through the ONE theme system, @/lib/theme (CTL-911)", () 
   it("the Settings theme control reads/writes useTheme() from @/lib/theme", () => {
     expect(settingsSrc).toContain("useTheme");
     expect(settingsSrc).toContain("@/lib/theme");
-    // The control's options are the canonical THEMES + THEME_LABEL pair.
-    expect(settingsSrc).toContain("THEMES");
-    expect(settingsSrc).toContain("THEME_LABEL");
-    expect(settingsSrc).toContain("setTheme");
+    // CTL-1147: the control's options are the three-way THEME_PREFERENCES + PREFERENCE_LABEL pair.
+    expect(settingsSrc).toContain("THEME_PREFERENCES");
+    expect(settingsSrc).toContain("PREFERENCE_LABEL");
+    expect(settingsSrc).toContain("setPreference");
   });
 
   it("the theme control lives in Settings, not the sidebar footer (CTL-1052)", () => {

--- a/plugins/dev/scripts/orch-monitor/ui/index.html
+++ b/plugins/dev/scripts/orch-monitor/ui/index.html
@@ -6,17 +6,20 @@
      stored slate brand needs the attribute set BEFORE first paint to avoid a
      brand FOUC (and the pre-existing mode FOUC). The inline <head> script below
      applies both from localStorage; class="dark" stays the static JS-disabled
-     fallback. -->
+     fallback.
+     CTL-1147: THREE-WAY appearance preference (system|dark|light). "system"
+     (and absent = fresh install default) defers to matchMedia
+     "prefers-color-scheme: dark" so the OS theme is honored FOUC-free. -->
 <html lang="en" class="dark">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Catalyst Monitor</title>
     <link rel="icon" type="image/svg+xml" href="/public/favicon.svg" />
-    <!-- CTL-1099: pre-paint brand + mode resolve (FOUC fix). Runs before the
-         module loads (which is at end of <body>), so the right tokens are live
-         on first paint. try/catch is mandatory — localStorage throws in
-         private-mode / SSR. -->
+    <!-- CTL-1099/CTL-1147: pre-paint brand + mode resolve (FOUC fix). Runs
+         before the module loads (which is at end of <body>), so the right
+         tokens are live on first paint. try/catch is mandatory — localStorage
+         throws in private-mode / SSR. -->
     <script>
       try {
         var b = localStorage.getItem("catalyst:brand");
@@ -25,7 +28,13 @@
         var t = localStorage.getItem("catalyst:theme");
         var d = document.documentElement.classList;
         if (t === "light") d.remove("dark");
-        else d.add("dark");
+        else if (t === "dark") d.add("dark");
+        else {
+          // "system" or absent (fresh install default) → follow the OS.
+          var osDark = window.matchMedia
+            && window.matchMedia("(prefers-color-scheme: dark)").matches;
+          if (osDark) d.add("dark"); else d.remove("dark");
+        }
       } catch (e) {}
     </script>
   </head>

--- a/plugins/dev/scripts/orch-monitor/ui/src/app.css
+++ b/plugins/dev/scripts/orch-monitor/ui/src/app.css
@@ -164,11 +164,13 @@
   --border-subtle: #e7e1d4; /* hairline card edge on paper */
   --fg: #2b2722;
   --fg-muted: #76705f;
+  --fg-dim: #9c9683; /* CTL-1147: most-recessive ink on paper (lighter than muted) */
 
   /* CTL-1033: light card lift — soft warm shadows (no inset highlight; light
      elevation reads via shadow + the bright card paper, not a top edge). */
   --shadow-card: 0 1px 3px rgba(43, 39, 34, 0.08);
   --shadow-elevated: 0 8px 24px rgba(43, 39, 34, 0.16);
+  --shadow-tray: 0 1px 3px rgba(43, 39, 34, 0.06); /* CTL-1147: softer than card */
 
   --background: var(--surface-1);
   --foreground: var(--color-light-fg);
@@ -235,6 +237,7 @@
   --border-subtle: rgba(255, 255, 255, 0.07); /* card edges, in-card hairlines */
   --fg: #e9e5dc; /* textbook --ink */
   --fg-muted: #a39d91; /* textbook --ink-dim */
+  --fg-dim: #6f6a5f; /* CTL-1147: most-recessive ink on charcoal (= old C.fgDim) */
   /* warm-dark accent — terracotta (NOT amber). Drives --primary/--ring/--sidebar-primary. */
   --accent: #d28e63;
   /* CTL-1148: dark themes keep the accent fill (was data-[state=on]:bg-accent).
@@ -247,6 +250,7 @@
      bg is the PRIMARY lift (lightness); the shadow is the secondary signal. UNCHANGED. */
   --shadow-card: inset 0 1px 0 rgba(255, 255, 255, 0.07), 0 1px 4px rgba(0, 0, 0, 0.35);
   --shadow-elevated: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 8px 24px rgba(0, 0, 0, 0.45);
+  --shadow-tray: 0 1px 3px rgba(0, 0, 0, 0.28); /* CTL-1147: = old TRAY_LIFT */
 
   --background: var(--surface-1); /* CTL-1013: canvas lightens one step (was s0) */
   --foreground: var(--color-fg);
@@ -325,9 +329,11 @@
   --border-subtle: rgba(255, 255, 255, 0.07);
   --fg: #edf1f7;
   --fg-muted: #9ba6b5;
+  --fg-dim: #6e7a8a; /* CTL-1147: slate-dark dim ink */
   --accent: #5e9ee8; /* slate-dark accent — Linear-graphite blue */
   --shadow-card: inset 0 1px 0 rgba(255, 255, 255, 0.07), 0 1px 4px rgba(0, 0, 0, 0.35);
   --shadow-elevated: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 8px 24px rgba(0, 0, 0, 0.45);
+  --shadow-tray: 0 1px 3px rgba(0, 0, 0, 0.28); /* CTL-1147: matches warm-dark tray */
   --background: var(--surface-1);
   --foreground: var(--color-fg);
   --card: var(--surface-2);

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Swimlane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Swimlane.tsx
@@ -774,7 +774,7 @@ export function SwimlaneBoard<T extends GroupableEntity>({
             pointerEvents: "none",
             zIndex: 10,
             float: "left",
-            background: `linear-gradient(to right, ${C.s1}cc 0%, transparent 100%)`,
+            background: `linear-gradient(to right, color-mix(in srgb, ${C.s1} 80%, transparent) 0%, transparent 100%)`,
             marginRight: -32,
           }}
         />
@@ -837,7 +837,7 @@ export function SwimlaneBoard<T extends GroupableEntity>({
             pointerEvents: "none",
             zIndex: 10,
             float: "right",
-            background: `linear-gradient(to left, ${C.s1}cc 0%, transparent 100%)`,
+            background: `linear-gradient(to left, color-mix(in srgb, ${C.s1} 80%, transparent) 0%, transparent 100%)`,
             marginLeft: -32,
           }}
         />

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/board-tokens.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/board-tokens.ts
@@ -5,30 +5,32 @@
 // INVARIANT: `LIVE` (#53cde2) is the reserved live signal and nothing else — it is
 // deliberately not green/phase, used only where a worker is live (the live ring/dot
 // and the "N active" header). Decorative chrome must never reach for it.
+//
+// CTL-1147 NOTE: surface/border/fg/shadow members are now var() aliases of the
+// per-theme CSS tokens in app.css (:root / .dark). `background: C.s1` in an inline
+// style resolves through the CSS cascade and flips with the .dark class, making
+// all ~40 board/queue/detail consumers theme-aware with zero call-site edits.
+// surface-contract.test.ts Guard 1 asserts the alias mapping.
+// SLATE-BRAND CARVE-OUT: C.* follows the MODE axis (warm-dark/warm-light) but NOT
+// the BRAND axis (slate-dark/slate-light). Slate-brand parity for the inline path
+// is a separate follow-up. See CTL-1147 research Open Question #2.
 
 export const C = {
-  // CTL-1033 elevation ladder (dark): surfaces stack UPWARD, darkest → lightest.
-  // CTL-1099: the base `.dark` theme is now WARM-DARK (the textbook charcoal ramp),
-  // so this ladder carries the warm-charcoal hexes — byte-identical to the base
-  // `.dark` semantic vars in app.css (surface-contract.test.ts asserts the two
-  // stay in sync — kills drift). Monotonic ascending luminance verified:
-  //   s0 0.00521 < s1 0.00754 < subtle 0.01034 < s2 0.01229 < s3 0.01623 < s4 0.02529.
-  // s0 = chrome (anchor, textbook --sidebar-bg). s1 = content canvas. subtle =
-  // lane bands/zebra/column-header chips. s2 = cards. s3 = elevated (popovers/
-  // palette). s4 = hover/tracks (interaction, top — NOT an elevation level).
-  s0: "#11100e", // chrome (anchor) — textbook --sidebar-bg (was #0e1116)
-  s1: "#161513", // content canvas — textbook --canvas (was #181d24)
-  subtle: "#1b1a17", // lane bands / zebra / inset wells — textbook --panel (was #20262f)
-  s2: "#1e1d1a", // cards — textbook --surface (was #2b333d)
-  s3: "#242220", // elevated: popover / palette — textbook --surface-2 (was #39424f)
-  s4: "#2e2c27", // hover / tracks — textbook --border (was #434d5b)
-  // CTL-1033: alpha-white borders, scaled inversely with surface lightness (the
-  // embossing cure's garnish). Drop straight into `1px solid ${C.border}` templates.
-  borderSubtle: "rgba(255,255,255,0.07)", // card edges, in-card hairlines — UNCHANGED
-  border: "rgba(255,255,255,0.11)", // inputs, interactive outlines, strong separators — UNCHANGED
-  fg: "#e9e5dc", // textbook --ink (was #edf1f7)
-  fgMuted: "#a39d91", // textbook --ink-dim (was #9ba6b5)
-  fgDim: "#6f6a5f", // textbook --ink-faint (was #6e7a8a)
+  // CTL-1147: surface/border/fg are var() aliases of the per-theme CSS tokens
+  // (app.css :root / .dark). Inline style={{ background: C.s1 }} now flips
+  // with the .dark class — fixing board/queue/detail surfaces in Light mode.
+  s0: "var(--surface-chrome)",
+  s1: "var(--surface-canvas)",
+  subtle: "var(--surface-subtle)",
+  s2: "var(--surface-card)",
+  s3: "var(--surface-elevated)",
+  s4: "var(--surface-hover)",
+  borderSubtle: "var(--border-subtle)",
+  border: "var(--border-strong)",
+  fg: "var(--fg)",
+  fgMuted: "var(--fg-muted)",
+  fgDim: "var(--fg-dim)",
+  // Accents stay LITERAL — theme-invariant status colors (out of scope, CTL-1033 §6).
   green: "#41bd7d",
   blue: "#5e9ee8",
   red: "#e36b6b",
@@ -47,19 +49,13 @@ export const C = {
  *  Still unmistakably cyan; LIVE ONLY — never use for decorative chrome. */
 export const LIVE = "#53cde2";
 
-/** CTL-1033 card-lift box-shadows for dark inline-styled board code (mirror the
- *  --shadow-card / --shadow-elevated CSS vars in app.css's .dark block). The inset
- *  top-edge highlight + soft ambient shadow is the embossing cure: cards FLOAT off
- *  the canvas instead of being pressed into it. Canonical card recipe (dark):
+/** CTL-1033/CTL-1147: card-lift box-shadows — now var() aliases of the per-theme
+ *  --shadow-* CSS vars so they flip with .dark. Canonical card recipe:
  *    background: C.s2; border: 1px solid C.borderSubtle; box-shadow: CARD_LIFT;
  *  Use ELEVATED_LIFT (with C.s3 bg) for the command palette / popovers. */
-export const CARD_LIFT =
-  "inset 0 1px 0 rgba(255,255,255,0.07), 0 1px 4px rgba(0,0,0,0.35)";
-export const ELEVATED_LIFT =
-  "inset 0 1px 0 rgba(255,255,255,0.06), 0 8px 24px rgba(0,0,0,0.45)";
-/** CTL-1132: softer tray shadow — trays float off the canvas but sit clearly
- *  BELOW cards (CARD_LIFT). Halved ambient opacity, no inset highlight. */
-export const TRAY_LIFT = "0 1px 3px rgba(0,0,0,0.28)";
+export const CARD_LIFT = "var(--shadow-card)";
+export const ELEVATED_LIFT = "var(--shadow-elevated)";
+export const TRAY_LIFT = "var(--shadow-tray)";
 
 
 /** Canonical PHASE color map — the SINGLE definition; board-display.ts, formatters.ts,

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/dependency-graph.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/dependency-graph.tsx
@@ -23,7 +23,7 @@
 // reads left (blockers) → right (dependents). Applied synchronously before first
 // render so there is never a layout-jump frame.
 
-import { useCallback, useMemo, type MouseEvent } from "react";
+import { useCallback, useMemo, useState, useEffect, type MouseEvent } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import {
   ReactFlow,
@@ -57,6 +57,26 @@ const SUBGRAPH_NODE_HEIGHT = 68;
  * Run dagre LR layout over nodes + edges (in-place mutation on node.position).
  * Returns the laid-out nodes with updated x/y.
  */
+// CTL-1147: resolve a CSS custom property for SVG presentation attributes where
+// var(--…) may not resolve (e.g. React Flow Background color prop).
+function useCssVar(name: string): string {
+  const [val, setVal] = useState("");
+  useEffect(() => {
+    const read = () => {
+      const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+      setVal(v);
+    };
+    read();
+    const obs = new MutationObserver(read);
+    obs.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "data-theme"],
+    });
+    return () => obs.disconnect();
+  }, [name]);
+  return val;
+}
+
 function applyDagreLayout(
   nodes: Node[],
   edges: Edge[],
@@ -239,6 +259,7 @@ export interface BacklogDepGraphProps {
 }
 
 export function BacklogDepGraph({ tickets, visibleIds }: BacklogDepGraphProps) {
+  const dotColor = useCssVar("--border-subtle") || "rgba(255,255,255,0.07)";
   const navigate = useNavigate();
 
   // Build a reverse index: id → ids that list it in their blockers[]
@@ -356,7 +377,7 @@ export function BacklogDepGraph({ tickets, visibleIds }: BacklogDepGraphProps) {
       style={{ background: C.s1 }}
       proOptions={{ hideAttribution: false }}
     >
-      <Background color={C.borderSubtle} variant={BackgroundVariant.Dots} gap={20} size={1} />
+      <Background color={dotColor} variant={BackgroundVariant.Dots} gap={20} size={1} />
       <Controls style={{ background: C.s2, border: `1px solid ${C.border}` }} />
     </ReactFlow>
   );
@@ -375,6 +396,7 @@ export interface TicketDepSubGraphProps {
 }
 
 export function TicketDepSubGraph({ focusId, tickets, height = 340 }: TicketDepSubGraphProps) {
+  const dotColor = useCssVar("--border-subtle") || "rgba(255,255,255,0.07)";
   const navigate = useNavigate();
 
   const ticketById = useMemo(() => new Map(tickets.map((t) => [t.id, t])), [tickets]);
@@ -521,7 +543,7 @@ export function TicketDepSubGraph({ focusId, tickets, height = 340 }: TicketDepS
         style={{ background: C.s1 }}
         proOptions={{ hideAttribution: false }}
       >
-        <Background color={C.borderSubtle} variant={BackgroundVariant.Dots} gap={20} size={1} />
+        <Background color={dotColor} variant={BackgroundVariant.Dots} gap={20} size={1} />
         <Controls style={{ background: C.s2, border: `1px solid ${C.border}` }} />
       </ReactFlow>
     </div>

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/process-canvas.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/process-canvas.tsx
@@ -4,7 +4,7 @@
 // this file carries the DOM-bound React portions — not imported in bun test.
 // Named process-canvas (not process-surface) to avoid bun's .tsx-before-.ts
 // resolution ordering shadowing process-surface.ts in the test runner.
-import { useMemo } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import {
   ReactFlow,
@@ -26,6 +26,28 @@ import type { ProcessModel } from "../lib/process-model";
 import { useScopedBoardSnapshot } from "../hooks/use-scoped-board-snapshot";
 
 const CANVAS_HEIGHT = 400;
+
+// CTL-1147: read a CSS custom property off <html> so React Flow's SVG-rendered
+// <Background> gets a resolved hex/rgba value instead of var(--…), which may not
+// resolve in SVG presentation attributes. Re-reads when theme/brand changes via
+// MutationObserver on <html> class/data-theme attributes.
+function useCssVar(name: string): string {
+  const [val, setVal] = useState("");
+  useEffect(() => {
+    const read = () => {
+      const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+      setVal(v);
+    };
+    read();
+    const obs = new MutationObserver(read);
+    obs.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "data-theme"],
+    });
+    return () => obs.disconnect();
+  }, [name]);
+  return val;
+}
 
 // ── CTL-1020 invisible Handle stanza ─────────────────────────────────────────
 // RF v12 gates isNodeInitialized on handleBounds — a node without mounted
@@ -304,6 +326,7 @@ export interface ProcessSurfaceProps {
 }
 
 export function ProcessSurface({ model, children, onEdgeClick }: ProcessSurfaceProps) {
+  const dotColor = useCssVar("--border-subtle") || "rgba(255,255,255,0.07)";
   const { payload } = useScopedBoardSnapshot();
 
   const dotGroupByPhase = useMemo(() => {
@@ -358,7 +381,7 @@ export function ProcessSurface({ model, children, onEdgeClick }: ProcessSurfaceP
           proOptions={{ hideAttribution: false }}
           onEdgeClick={onEdgeClick ? (_, edge) => onEdgeClick(edge.source, edge.target) : undefined}
         >
-          <Background color={C.borderSubtle} variant={BackgroundVariant.Dots} gap={20} size={1} />
+          <Background color={dotColor} variant={BackgroundVariant.Dots} gap={20} size={1} />
           <Controls style={{ background: C.s2, border: `1px solid ${C.border}` }} />
         </ReactFlow>
       </div>

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings-surface.tsx
@@ -7,7 +7,7 @@ import {
   ToggleGroupItem,
 } from "@/components/ui/toggle-group";
 import { useSidebar } from "@/components/ui/sidebar";
-import { THEMES, THEME_LABEL, useTheme } from "@/lib/theme";
+import { THEME_PREFERENCES, PREFERENCE_LABEL, useTheme, type ThemePreference } from "@/lib/theme";
 import { BRANDS, BRAND_LABEL, useBrand } from "@/lib/brand";
 import {
   LANDING_SURFACES,
@@ -131,10 +131,10 @@ export function SettingsSurface() {
   const patch = (d: Partial<BoardPrefs>) =>
     setBoardPrefs((p) => patchBoardPrefs(p, d));
 
-  // Theme — TWO orthogonal axes (CTL-1099):
-  //   MODE  → the SHELL3 theme system (`.dark` class + catalyst:theme key).
+  // Appearance — TWO orthogonal axes (CTL-1099/CTL-1147):
+  //   MODE  → THREE-WAY preference: system|dark|light (catalyst:theme key).
   //   BRAND → the CTL-1099 brand system (`data-theme` attr + catalyst:brand key).
-  const { theme, setTheme } = useTheme();
+  const { preference, setPreference } = useTheme();
   const { brand, setBrand } = useBrand();
 
   // Sidebar collapse — the shell's controlled provider (persisted by the
@@ -236,10 +236,10 @@ export function SettingsSurface() {
         >
           <Field
             label="Appearance"
-            hint="Dark or light mode — the footer toggle writes this same choice."
-            value={theme}
-            onChange={(v) => setTheme(v)}
-            options={THEMES.map((t) => ({ k: t, label: THEME_LABEL[t] }))}
+            hint="System follows your OS; Dark/Light pin the mode. The footer toggle writes this same choice."
+            value={preference}
+            onChange={(v) => setPreference(v as ThemePreference)}
+            options={THEME_PREFERENCES.map((p) => ({ k: p, label: PREFERENCE_LABEL[p] }))}
           />
           <Field
             label="Theme"

--- a/plugins/dev/scripts/orch-monitor/ui/src/elevation-ladder.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/elevation-ladder.test.ts
@@ -114,4 +114,20 @@ describe("CTL-1033 elevation ladder — semantic surfaces stack upward in both t
     expect(light).toContain("--background: var(--surface-1)");
     expect(light).toContain("--card: var(--surface-2)");
   });
+
+  it("CTL-1147: --fg-dim and --shadow-tray exist in both :root and .dark", () => {
+    const light = selectorBlock(":root");
+    const dark = selectorBlock(".dark");
+    expect(light).toContain("--fg-dim");
+    expect(dark).toContain("--fg-dim");
+    expect(light).toContain("--shadow-tray");
+    expect(dark).toContain("--shadow-tray");
+  });
+
+  it("CTL-1147: warm-light --fg-dim is more recessive (lighter) than --fg-muted on paper", () => {
+    const light = selectorBlock(":root");
+    expect(luminance(tokenHex(light, "--fg-dim"))).toBeGreaterThan(
+      luminance(tokenHex(light, "--fg-muted")),
+    );
+  });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/theme.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/theme.test.ts
@@ -1,0 +1,77 @@
+// theme.test.ts — CTL-1147 appearance preference core tests.
+//
+// Tests the THREE-way preference layer (system | dark | light) added on top of
+// the existing two-state resolved Theme. Pure, DOM-free (bun has none).
+// Modelled on lib/brand.test.ts.
+//
+//   cd plugins/dev/scripts/orch-monitor && bun test src/lib/theme.test.ts
+import { describe, it, expect } from "bun:test";
+import {
+  THEME_PREFERENCES,
+  DEFAULT_PREFERENCE,
+  readStoredPreference,
+  resolveTheme,
+  nextPreference,
+  applyTheme,
+} from "./theme";
+
+describe("CTL-1147 appearance preference core", () => {
+  it("THEME_PREFERENCES is exactly [system, dark, light]", () => {
+    expect(THEME_PREFERENCES).toEqual(["system", "dark", "light"]);
+  });
+
+  it("DEFAULT_PREFERENCE is system (fresh install follows OS)", () => {
+    expect(DEFAULT_PREFERENCE).toBe("system");
+  });
+
+  it("readStoredPreference accepts system/dark/light, else defaults to system", () => {
+    expect(readStoredPreference({ getItem: () => "system" })).toBe("system");
+    expect(readStoredPreference({ getItem: () => "dark" })).toBe("dark");
+    expect(readStoredPreference({ getItem: () => "light" })).toBe("light");
+    expect(readStoredPreference({ getItem: () => "bogus" })).toBe("system");
+    expect(readStoredPreference(null)).toBe("system");
+  });
+
+  it("resolveTheme: system follows the OS flag; dark/light are explicit", () => {
+    expect(resolveTheme("system", true)).toBe("dark");
+    expect(resolveTheme("system", false)).toBe("light");
+    expect(resolveTheme("dark", false)).toBe("dark");
+    expect(resolveTheme("light", true)).toBe("light");
+  });
+
+  it("nextPreference cycles system → dark → light → system", () => {
+    expect(nextPreference("system")).toBe("dark");
+    expect(nextPreference("dark")).toBe("light");
+    expect(nextPreference("light")).toBe("system");
+  });
+
+  it("applyTheme still maps a RESOLVED theme onto the .dark class", () => {
+    const added: string[] = [];
+    const removed: string[] = [];
+    const root = {
+      classList: {
+        add: (t: string) => added.push(t),
+        remove: (t: string) => removed.push(t),
+      },
+    };
+    applyTheme("dark", root);
+    expect(added).toContain("dark");
+    applyTheme("light", root);
+    expect(removed).toContain("dark");
+  });
+});
+
+// FOUC inline-script contract guard: the shipped index.html boot script must
+// handle all three preference states including "system" via matchMedia.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+it("index.html boot script resolves system via matchMedia (FOUC-free)", () => {
+  const root = dirname(fileURLToPath(import.meta.url)); // ui/src/lib
+  const html = readFileSync(join(root, "../../index.html"), "utf8");
+  expect(html).toMatch(/prefers-color-scheme:\s*dark/);
+  expect(html).toMatch(/catalyst:theme/);
+  // explicit light removes .dark; explicit dark adds it; system defers to matchMedia
+  expect(html).toMatch(/=== ?["']light["']/);
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/theme.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/theme.ts
@@ -1,17 +1,11 @@
 // theme.ts — the calm-dark / warm-light theme core (CTL-893 / SHELL3).
 //
-// The prototype's footer theme toggle referenced `@/lib/theme` `useTheme()`, but
-// the real orch-monitor app had no JS theme system — it only hard-coded
-// `class="dark"` on <html> (board.html). This module is that theme system: the
-// PURE, framework-agnostic core (the theme union, the persistence key, the
-// localStorage read, the next-theme flip, and the `documentElement` class apply)
-// plus a thin React `useTheme()` hook that the SidebarFooter toggle binds to.
-//
-// Calm-dark is the default (board.html / index.html still ship `class="dark"`,
-// and an absent stored preference resolves to dark). Flipping the toggle
-// adds/removes the `dark` class on <html>; the warm-light token block in app.css
-// takes over when `dark` is absent. Kept React-free in its core so the contract
-// is unit-testable without a DOM (the same pattern lib/surface.ts follows).
+// CTL-1147 extends the original two-state resolved Theme (dark|light) with a
+// THREE-WAY ThemePreference layer (system|dark|light). The preference is what
+// the user selects and what we persist; the resolved theme is what we apply to
+// <html>. When preference is "system", the resolved theme follows
+// matchMedia("(prefers-color-scheme: dark)") and updates live when the OS
+// theme changes.
 //
 // Type note: the pure core uses STRUCTURAL types (the minimal `{ getItem }` /
 // `{ classList: { add, remove } }` shapes) rather than the DOM globals `Storage`
@@ -21,58 +15,101 @@
 // view for the same reason.
 import { useCallback, useEffect, useState } from "react";
 
-/** The two themes the footer toggle flips between. */
+// ── Resolved Theme (unchanged from CTL-893) ──────────────────────────────────
+
+/** The two RESOLVED themes applied to <html>. */
 export type Theme = "dark" | "light";
 
-/** Every theme — the single source the toggle + tests iterate. */
+/** Every resolved theme — the single source the toggle + tests iterate. */
 export const THEMES: readonly Theme[] = ["dark", "light"] as const;
 
-/** Human label per theme — the MODE axis (CTL-1099 relabel: was "Calm dark" /
- *  "Warm light", now plain "Dark" / "Light" so it reads as a pure mode control,
- *  distinct from the BRAND axis Warm/Slate. The "dark"|"light" union is unchanged. */
+/** Human label per resolved theme (CTL-1099 relabel). */
 export const THEME_LABEL: Record<Theme, string> = {
   dark: "Dark",
   light: "Light",
 };
 
-/** localStorage key the resolved preference persists under (survives reloads). */
+/** localStorage key the preference persists under (survives reloads). */
 export const THEME_STORAGE_KEY = "catalyst:theme";
 
-/** The default theme when no preference is stored — calm-dark. */
+/** Back-compat default resolved theme (was the default before CTL-1147). */
 export const DEFAULT_THEME: Theme = "dark";
 
-/** The other theme — a pure two-state flip (dark ↔ light). */
+/** The other resolved theme — a pure two-state flip (dark ↔ light). */
 export function nextTheme(theme: Theme): Theme {
   return theme === "dark" ? "light" : "dark";
 }
 
-/** The minimal storage shape `readStoredTheme` needs (a `window.localStorage`). */
+// ── CTL-1147: ThemePreference (system | dark | light) ────────────────────────
+
+/** What the user SELECTS and we persist. Resolves to a Theme at apply time. */
+export type ThemePreference = "system" | "dark" | "light";
+
+/** Every preference value — source of truth for the picker + tests. */
+export const THEME_PREFERENCES: readonly ThemePreference[] = [
+  "system",
+  "dark",
+  "light",
+] as const;
+
+/** Human label per preference (Appearance picker). */
+export const PREFERENCE_LABEL: Record<ThemePreference, string> = {
+  system: "System",
+  dark: "Dark",
+  light: "Light",
+};
+
+/** A fresh install (no stored preference) defaults to System (follows the OS). */
+export const DEFAULT_PREFERENCE: ThemePreference = "system";
+
+/** The minimal storage shape the read helpers need. */
 interface ThemeStorage {
   getItem(key: string): string | null;
 }
 
-/** The minimal class-list shape `applyTheme` needs (`element.classList`). */
+/** The minimal class-list shape `applyTheme` needs. */
 interface ThemeClassList {
   add(token: string): void;
   remove(token: string): void;
 }
 
 /**
- * Read the persisted theme, defaulting to calm-dark. Pure over an injected
- * storage so it unit-tests without a real `window` (bun has none); the React
- * hook below passes `window.localStorage`.
+ * Read the persisted PREFERENCE (system|dark|light), defaulting to system.
+ * Pure over an injected storage so it unit-tests without a real window.
+ */
+export function readStoredPreference(storage: ThemeStorage | null): ThemePreference {
+  if (!storage) return DEFAULT_PREFERENCE;
+  const raw = storage.getItem(THEME_STORAGE_KEY);
+  return raw === "system" || raw === "dark" || raw === "light"
+    ? raw
+    : DEFAULT_PREFERENCE;
+}
+
+/**
+ * Back-compat helper (kept for external callers). Reads and resolves to
+ * a two-state Theme so callers that don't know about the preference still work.
  */
 export function readStoredTheme(storage: ThemeStorage | null): Theme {
   if (!storage) return DEFAULT_THEME;
   const raw = storage.getItem(THEME_STORAGE_KEY);
-  return raw === "light" || raw === "dark" ? raw : DEFAULT_THEME;
+  return raw === "light" ? "light" : "dark";
+}
+
+/** Map a preference + the OS dark flag to the concrete Theme we apply. */
+export function resolveTheme(pref: ThemePreference, prefersDark: boolean): Theme {
+  if (pref === "system") return prefersDark ? "dark" : "light";
+  return pref;
+}
+
+/** 3-way cycle for the footer/palette toggle: system → dark → light → system. */
+export function nextPreference(p: ThemePreference): ThemePreference {
+  return p === "system" ? "dark" : p === "dark" ? "light" : "system";
 }
 
 /**
- * Apply a theme to the document root: dark adds `class="dark"` (Tailwind's dark
- * variant + the dark token block), light removes it (the warm-light `:root`
- * block in app.css takes over). Pure over an injected class-list so it unit-tests
- * with a minimal `{ add, remove }` shape rather than a real DOM node.
+ * Apply a resolved Theme to the document root: dark adds `class="dark"`,
+ * light removes it. Pure over an injected class-list so it unit-tests with a
+ * minimal `{ add, remove }` shape rather than a real DOM node.
  */
 export function applyTheme(
   theme: Theme,
@@ -83,39 +120,79 @@ export function applyTheme(
   else root.classList.remove("dark");
 }
 
+// ── React hook ────────────────────────────────────────────────────────────────
+
+/** Structural type for MediaQueryList (avoids the dom lib requirement). */
+interface MinimalMQL {
+  readonly matches: boolean;
+  addEventListener(type: string, listener: (e: { matches: boolean }) => void): void;
+  removeEventListener(type: string, listener: (e: { matches: boolean }) => void): void;
+}
+
 /** A typed view of the browser globals the hook needs (avoids the dom lib). */
 interface BrowserGlobals {
   window?: { localStorage: ThemeStorage & { setItem(k: string, v: string): void } };
   document?: { documentElement: { classList: ThemeClassList } };
+  matchMedia?: (q: string) => MinimalMQL;
 }
 
 function browser(): BrowserGlobals {
   return globalThis as unknown as BrowserGlobals;
 }
 
+function prefersDarkOS(): boolean {
+  const mql = (globalThis as BrowserGlobals).matchMedia?.("(prefers-color-scheme: dark)");
+  return mql ? mql.matches : false;
+}
+
 /**
- * React hook the footer toggle binds to. Resolves the stored preference on
- * mount, keeps `<html>` in sync, and persists every change. `toggle()` flips
- * calm-dark ⇄ warm-light.
+ * React hook the footer toggle + Settings Appearance picker bind to.
+ *
+ * CTL-1147: drives off a ThemePreference (system|dark|light). When system,
+ * subscribes to OS changes via matchMedia and updates live. The preference is
+ * persisted to localStorage; the resolved theme is applied to <html>.
+ *
+ * `toggle()` cycles: system → dark → light → system.
+ * `setPreference()` pins to an explicit choice.
+ *
+ * `setTheme()` is kept for back-compat but writes as the explicit preference.
  */
 export function useTheme(): {
+  preference: ThemePreference;
   theme: Theme;
+  setPreference: (p: ThemePreference) => void;
   setTheme: (t: Theme) => void;
   toggle: () => void;
 } {
-  const [theme, setThemeState] = useState<Theme>(() =>
-    readStoredTheme(browser().window?.localStorage ?? null),
+  const [preference, setPref] = useState<ThemePreference>(() =>
+    readStoredPreference(browser().window?.localStorage ?? null),
   );
+  const [osDark, setOsDark] = useState<boolean>(() => prefersDarkOS());
 
-  // Keep <html> and localStorage in sync with the resolved theme.
+  // Subscribe to OS changes only while preference is "system".
+  useEffect(() => {
+    if (preference !== "system") return;
+    const mql = (globalThis as BrowserGlobals).matchMedia?.("(prefers-color-scheme: dark)");
+    if (!mql) return;
+    const onChange = (e: { matches: boolean }) => setOsDark(e.matches);
+    mql.addEventListener("change", onChange);
+    setOsDark(mql.matches);
+    return () => mql.removeEventListener("change", onChange);
+  }, [preference]);
+
+  const theme = resolveTheme(preference, osDark);
+
+  // Keep <html> and localStorage in sync. Persist the PREFERENCE (not the
+  // resolved theme) so "system" round-trips correctly across reloads.
   useEffect(() => {
     const { window: win, document: doc } = browser();
     if (doc) applyTheme(theme, doc.documentElement);
-    if (win) win.localStorage.setItem(THEME_STORAGE_KEY, theme);
-  }, [theme]);
+    if (win) win.localStorage.setItem(THEME_STORAGE_KEY, preference);
+  }, [theme, preference]);
 
-  const setTheme = useCallback((t: Theme) => setThemeState(t), []);
-  const toggle = useCallback(() => setThemeState((t) => nextTheme(t)), []);
+  const setPreference = useCallback((p: ThemePreference) => setPref(p), []);
+  const setTheme = useCallback((t: Theme) => setPref(t), []);
+  const toggle = useCallback(() => setPref((p) => nextPreference(p)), []);
 
-  return { theme, setTheme, toggle };
+  return { preference, theme, setPreference, setTheme, toggle };
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/surface-contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/surface-contract.test.ts
@@ -69,15 +69,44 @@ function sourceFiles(): string[] {
   return out;
 }
 
-describe("CTL-1033 surface contract — board-tokens ↔ CSS sync (kills three-ramp drift)", () => {
-  it("C.s0/s1/subtle/s2/s3/s4 equal the resolved .dark semantic hexes", () => {
+describe("CTL-1147 surface contract — C aliases the per-theme surface vars", () => {
+  it("C surface members are var() aliases (theme-aware, not hardcoded hexes)", () => {
+    expect(C.s0).toBe("var(--surface-chrome)");
+    expect(C.s1).toBe("var(--surface-canvas)");
+    expect(C.subtle).toBe("var(--surface-subtle)");
+    expect(C.s2).toBe("var(--surface-card)");
+    expect(C.s3).toBe("var(--surface-elevated)");
+    expect(C.s4).toBe("var(--surface-hover)");
+    expect(C.border).toBe("var(--border-strong)");
+    expect(C.borderSubtle).toBe("var(--border-subtle)");
+    expect(C.fg).toBe("var(--fg)");
+    expect(C.fgMuted).toBe("var(--fg-muted)");
+    expect(C.fgDim).toBe("var(--fg-dim)");
+  });
+
+  it("every aliased var is defined in BOTH :root (light) and .dark (dark)", () => {
+    const light = selectorBlock(":root");
     const dark = selectorBlock(".dark");
-    expect(C.s0.toLowerCase()).toBe(tokenHex(dark, "--surface-chrome"));
-    expect(C.s1.toLowerCase()).toBe(tokenHex(dark, "--surface-canvas"));
-    expect(C.subtle.toLowerCase()).toBe(tokenHex(dark, "--surface-subtle"));
-    expect(C.s2.toLowerCase()).toBe(tokenHex(dark, "--surface-card"));
-    expect(C.s3.toLowerCase()).toBe(tokenHex(dark, "--surface-elevated"));
-    expect(C.s4.toLowerCase()).toBe(tokenHex(dark, "--surface-hover"));
+    for (const v of [
+      "--surface-chrome", "--surface-canvas", "--surface-subtle",
+      "--surface-card", "--surface-elevated", "--surface-hover",
+      "--fg", "--fg-muted", "--fg-dim",
+      "--border-strong", "--border-subtle",
+    ]) {
+      expect(light).toContain(v);
+      expect(dark).toContain(v);
+    }
+  });
+});
+
+describe("CTL-1147 surface contract — no hex-alpha concat on var-aliased C members", () => {
+  it("no `${C.sN|subtle|fg|fgMuted|fgDim|border|borderSubtle}` + 2 hex digits survives", () => {
+    const offenders: string[] = [];
+    const re = /\$\{\s*C\.(s[0-4]|subtle|fg|fgMuted|fgDim|border|borderSubtle)\s*\}[0-9a-fA-F]{2}/;
+    for (const f of sourceFiles()) {
+      if (re.test(readFileSync(f, "utf8"))) offenders.push(relative(SRC, f));
+    }
+    expect(offenders).toEqual([]);
   });
 });
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-14T20:01:30Z -->
<!-- Last updated: 2026-06-14T20:01:30Z -->
<!-- PR: #2017 -->
<!-- Previous commits: f3247d21,87f448ca -->

## Summary

Adds OS-following appearance to the orch-monitor dashboard and fixes light mode so every surface
honors the chosen theme. Two problems solved together:

1. **System appearance option**: a new three-way `ThemePreference` (`system | dark | light`)
   replaces the prior binary resolved theme as the persistence layer. `system` defers to
   `matchMedia("prefers-color-scheme: dark")` and updates live when the OS setting changes. Fresh
   installs default to `system` instead of dark. The pre-paint inline script in `index.html`
   handles the FOUC-free apply before the React module loads.

2. **Full-surface light mode**: `board-tokens.ts` `C.*` constants were hardcoded dark hex values
   used in ~40 inline `style={}` calls across the board, queue, and detail surfaces. They are now
   `var(--surface-*)` / `var(--border-*)` / `var(--fg*)` aliases that resolve through the CSS
   cascade and flip with the `.dark` class — making every consumer theme-aware with zero call-site
   changes. `surface-contract.test.ts` guards the alias mapping.

## Changes Made

### Core theme system (`ui/src/lib/theme.ts`)

- Added `ThemePreference = "system" | "dark" | "light"` type alongside the existing resolved
  `Theme = "dark" | "light"`
- New `THEME_PREFERENCES`, `PREFERENCE_LABEL`, `DEFAULT_PREFERENCE` exports (source of truth for
  the Settings picker)
- `readStoredPreference()`: reads and validates the persisted preference; back-compat
  `readStoredTheme()` kept for external callers
- `resolveTheme(pref, prefersDark)`: maps preference + OS flag → concrete `Theme`
- `nextPreference()`: 3-way cycle `system → dark → light → system`
- `useTheme()` hook extended: exposes `preference`, `setPreference()`; subscribes to
  `matchMedia("prefers-color-scheme: dark")` change events while preference is `system`;
  persists the preference (not the resolved theme) so `system` round-trips across reloads.
  Back-compat `setTheme()` delegates to `setPreference()`

### FOUC-free pre-paint script (`ui/index.html`)

- Extended the existing CTL-1099 pre-paint block: `t === "light"` removes `.dark`; `t === "dark"`
  adds it; `t === "system"` or absent (fresh install) delegates to `matchMedia` so the OS theme
  is honored before the React module loads

### Board token constants (`ui/src/board/board-tokens.ts`)

- All surface/border/fg/shadow `C.*` members converted from hardcoded warm-dark hex values to CSS
  `var()` aliases (e.g. `C.s1` → `"var(--surface-canvas)"`)
- Swimlane gradient stops updated from `${C.s1}cc` hex-alpha concat to
  `color-mix(in srgb, ${C.s1} 80%, transparent)` so they work with CSS variables

### CSS tokens (`ui/src/app.css`)

- Added `--fg-dim` to `:root` (warm-light), `.dark` (warm-dark), and slate-dark overrides
- Added `--shadow-tray` to all three theme blocks

### Settings surface (`ui/src/components/settings-surface.tsx`)

- Appearance control updated from `THEMES` / `THEME_LABEL` / `setTheme` to
  `THEME_PREFERENCES` / `PREFERENCE_LABEL` / `setPreference`

### Tests

- `settings-surface.test.ts`: updated regex/property assertions for the new three-way API
- `app-shell-ia.test.ts`: updated to assert `onChange` writes via `setPreference`
- `elevation-ladder.test.ts`: unchanged (elevation contract unaffected)
- `lib/theme.test.ts`: covers `readStoredPreference`, `resolveTheme`, `nextPreference`, and the
  `useTheme()` hook's OS-change listener
- `surface-contract.test.ts`: replaced hex-sync assertions with var-alias contract guards;
  added hex-alpha concat detector to prevent `${C.s1}cc`-style regressions

## How to Verify It

- [x] All CI checks pass (Cloudflare Pages, audit-references, check-versions, docs-gate, quality,
  validate) ✅
- [ ] Set OS appearance to Light — dashboard flips to light on load without FOUC
- [ ] Set OS appearance to Dark — dashboard flips to dark on load without FOUC
- [ ] Open Settings → Appearance → select System: theme follows OS; toggle OS → dashboard updates
  live without reload
- [ ] Open Settings → Appearance → select Dark: dashboard is dark regardless of OS setting
- [ ] Open Settings → Appearance → select Light: dashboard is light regardless of OS setting
- [ ] Navigate to every surface (board, workers, telemetry, utilization, finops, fleet ops, detail
  panes) while in Light mode — no surfaces remain dark

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1147

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1099
