### PR TITLE
CTL-1151: tickets board — continuous column lanes & 3-tier elevation

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Swimlane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Swimlane.tsx
@@ -237,6 +237,39 @@ function ColumnHeaderRow({ columns }: { columns: SharedColumn[] }) {
   );
 }
 
+// CTL-1151: one continuous full-height lane per column, painted ONCE behind all
+// bands/cards. Aligned to the same grid tracks as the content rows so strips sit
+// exactly under their columns. The header cap (ColumnHeaderRow, opaque s0, sticky)
+// occludes the strip top; strips round their BOTTOM corners.
+function LaneBackdrop({ count }: { count: number }) {
+  return (
+    <div
+      data-lane-backdrop="true"
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        inset: 0,
+        zIndex: 0,
+        pointerEvents: "none",
+        display: "grid",
+        gridTemplateColumns: `repeat(${count}, minmax(${COL_W}px, 1fr))`,
+        gap: COL_GAP,
+        padding: `0 ${PAD_X}px 16px`,
+      }}
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} style={{
+          background: C.s0,
+          borderRadius: "0 0 10px 10px",
+          border: `1px solid ${C.borderSubtle}`,
+          borderTop: "none",
+          boxShadow: TRAY_LIFT,
+        }} />
+      ))}
+    </div>
+  );
+}
+
 // ── a sticky group-label divider row ─────────────────────────────────────────
 // CTL-950: the outer band spans the full board width and is sticky-top (pins just
 // below the column header) so the group label holds position during vertical scroll.
@@ -370,13 +403,11 @@ function LaneCardsRow({
   laneKey,
   constrainCells = false,
   cellMax,
-  laneBg,
 }: {
   cells: LaneCell[];
   laneKey?: string;
   constrainCells?: boolean;
   cellMax?: number | null;
-  laneBg?: string;
 }) {
   return (
     <div
@@ -392,6 +423,10 @@ function LaneCardsRow({
         flexGrow: 1,
         alignItems: "stretch",
         width: "100%",
+        // CTL-1151: cards must sit above the zIndex:0 LaneBackdrop painted behind
+        // all rows; header (z:3) and band (z:2) already out-rank the backdrop.
+        position: "relative",
+        zIndex: 1,
       }}
     >
       {cells.map((cell, i) => (
@@ -404,15 +439,9 @@ function LaneCardsRow({
             flexDirection: "column",
             gap: 8,
             minWidth: 0,
-            // CTL-1033 column-tray: each column's track is its OWN surface so
-            // columns read as discrete trays, not one continuous slab. The COL_GAP
-            // between grid tracks is the visible canvas-colored gutter.
-            // CTL-1027: tinted when the lane's project has a resolved hue.
-            // CTL-1146: re-based from s1 to s0 so cards (s2) read as clearly elevated.
-            background: laneBg ?? C.s0,
-            borderRadius: 10,
-            border: `1px solid ${C.borderSubtle}`,
-            boxShadow: TRAY_LIFT,
+            // CTL-1151: column tray paint moved to LaneBackdrop (continuous lane
+            // backdrop). Cells are transparent flow containers; the lane surface
+            // (C.s0) renders once behind all bands via LaneBackdrop.
             padding: 8,
             // CTL-958 / CTL-1010: per-cell constrained height with overscroll
             // chaining. Only applied when multiple groups are present
@@ -785,7 +814,9 @@ export function SwimlaneBoard<T extends GroupableEntity>({
       <div ref={bumpRef} style={{
         width: `max(100%, ${boardMinWidth(columns.length)}px)`,
         display: "flex", flexDirection: "column", minHeight: "100%",
+        position: "relative",
       }}>
+        <LaneBackdrop count={columns.length} />
         <ColumnHeaderRow columns={columns} />
         {/* axis="none" (and the empty-on-a-real-axis fallthrough) → one synthetic
             lane, no group label. Real axis → a sticky group-label divider per lane,
@@ -816,7 +847,6 @@ export function SwimlaneBoard<T extends GroupableEntity>({
                   laneKey={lane.key}
                   constrainCells={constrainCells}
                   cellMax={allocs?.get(lane.key)}
-                  laneBg={laneBg}
                 />
               </Fragment>
             );

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/swimlane-structure.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/swimlane-structure.test.ts
@@ -1,0 +1,77 @@
+// swimlane-structure.test.ts — CTL-1151 source-contract suite.
+// Asserts the continuous-lane-backdrop structure:
+//   • A LaneBackdrop component paints ONE full-height column lane per column
+//     behind all bands/cards (replacing the per-cell tray paint).
+//   • LaneCardsRow cells are transparent flow containers (no tray paint).
+//   • The per-project hue rides the GroupLabelRow band overlay, not the lane.
+//
+//   cd ui && bun test src/board/swimlane-structure.test.ts
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, "Swimlane.tsx"), "utf8");
+
+// helper: isolate the function body by brace-matching from the signature
+function fnBody(name: string): string {
+  const start = src.indexOf(`function ${name}(`);
+  if (start < 0) throw new Error(`${name} not found`);
+  const open = src.indexOf("{", src.indexOf(")", start));
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}" && --depth === 0) return src.slice(open, i + 1);
+  }
+  throw new Error(`unbalanced ${name}`);
+}
+
+describe("CTL-1151 — continuous lane backdrop exists", () => {
+  it("renders a LaneBackdrop layer", () => {
+    expect(src).toMatch(/function LaneBackdrop\(/);
+    expect(src).toMatch(/data-lane-backdrop="true"/);
+  });
+  it("the backdrop layer is absolutely positioned and full-height", () => {
+    const body = fnBody("LaneBackdrop");
+    expect(body).toMatch(/position:\s*"absolute"/);
+    // inset:0 (or top/right/bottom/left) so it stretches to bumpRef's full height
+    expect(body).toMatch(/inset:\s*0|height:\s*"100%"/);
+    // one strip per column at the recessed lane surface
+    expect(body).toContain("C.s0");
+  });
+});
+
+describe("CTL-1151 — LaneCardsRow cells no longer paint a column tray", () => {
+  const body = fnBody("LaneCardsRow");
+  it("cell style carries no background (lane paint moved to backdrop)", () => {
+    // the cell <div> must not set `background: laneBg ?? C.s0`
+    expect(body).not.toMatch(/background:\s*laneBg\s*\?\?\s*C\.s0/);
+  });
+  it("cell style carries no per-cell borderRadius:10 / TRAY_LIFT (the chop)", () => {
+    expect(body).not.toMatch(/borderRadius:\s*10\b/);
+    expect(body).not.toContain("TRAY_LIFT");
+  });
+  it("preserves the water-fill measurement attributes", () => {
+    expect(body).toContain('data-lane-cell="true"');
+    expect(src).toMatch(/data-lane-key=\{laneKey\}/);
+  });
+});
+
+describe("CTL-1151 — hue on the band overlay, not the continuous lane", () => {
+  it("the lane backdrop strip is neutral C.s0 (no laneBg tint)", () => {
+    const body = fnBody("LaneBackdrop");
+    expect(body).not.toContain("laneBg");
+    expect(body).not.toContain("laneSurfaceBg");
+  });
+  it("GroupLabelRow still carries the per-project tint (laneBg)", () => {
+    const body = fnBody("GroupLabelRow");
+    expect(body).toMatch(/laneBg\s*\?\?\s*C\.s1/);
+  });
+  it("SwimlaneBoard passes laneBg to GroupLabelRow but NOT to LaneCardsRow", () => {
+    // LaneCardsRow no longer receives a laneBg prop (the lane paint is gone)
+    const board = src.slice(src.indexOf("function SwimlaneBoard"));
+    expect(board).toMatch(/<GroupLabelRow[\s\S]*?laneBg=\{laneBg\}/);
+    expect(board).not.toMatch(/<LaneCardsRow[\s\S]*?laneBg=\{laneBg\}/);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/elevation-ladder.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/elevation-ladder.test.ts
@@ -124,6 +124,13 @@ describe("CTL-1033 elevation ladder — semantic surfaces stack upward in both t
     expect(dark).toContain("--shadow-tray");
   });
 
+  it("CTL-1151: board lane(s0) is recessed below canvas(s1), card(s2) elevated above", () => {
+    const dark = selectorBlock(".dark");
+    const lum = (t: string) => luminance(tokenHex(dark, t));
+    expect(lum("--surface-chrome")).toBeLessThan(lum("--surface-canvas")); // lane < canvas
+    expect(lum("--surface-card")).toBeGreaterThan(lum("--surface-canvas")); // card > canvas
+  });
+
   it("CTL-1147: warm-light --fg-dim is more recessive (lighter) than --fg-muted on paper", () => {
     const light = selectorBlock(":root");
     expect(luminance(tokenHex(light, "--fg-dim"))).toBeGreaterThan(

--- a/plugins/dev/scripts/orch-monitor/ui/src/surface-contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/surface-contract.test.ts
@@ -175,6 +175,19 @@ describe("CTL-1033 surface contract — every route shell consumes the shared to
   }
 });
 
+describe("CTL-1151 surface contract — column lane is a continuous backdrop", () => {
+  const swim = readFileSync(join(SRC, "board/Swimlane.tsx"), "utf8");
+  it("a LaneBackdrop layer paints the column lane (not the per-cell tray)", () => {
+    expect(swim).toMatch(/data-lane-backdrop="true"/);
+  });
+  it("no LaneCardsRow cell re-introduces a column-tray background", () => {
+    const start = swim.indexOf("function LaneCardsRow(");
+    const body = swim.slice(start, swim.indexOf("function ", start + 1));
+    expect(body).not.toMatch(/background:\s*laneBg\s*\?\?\s*C\.s0/);
+    expect(body).not.toContain("TRAY_LIFT");
+  });
+});
+
 describe("CTL-1033 surface contract — single PHASE source", () => {
   it("PHASE_COLORS resolves the canonical PHASE map", () => {
     expect(PHASE_COLORS.research).toBe(PHASE.research);


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-15T00:00:00Z -->
<!-- Last updated: 2026-06-15T00:00:00Z -->
<!-- PR: #2032 -->
<!-- Previous commits: 11a60e546f46a05269a7780be0903cfaafd926cd -->

## Summary

- **Continuous lane backdrop**: Adds `LaneBackdrop` — a `position:absolute; inset:0` grid layer behind all content rows that paints one full-height `C.s0` strip per column, replacing the previous per-cell tray paint that produced "chopped" disconnected boxes per band.
- **3-tier elevation enforced structurally**: Canvas (gutter) > recessed lane (C.s0 backdrop) > elevated card (C.s2 + CARD_LIFT). `LaneCardsRow` cells become transparent flow containers (`position:relative; zIndex:1`) — the lane surface renders once behind all bands.
- **Hue on band, not lane**: Per-project oklab tint stays on `GroupLabelRow` only; `laneBg` prop dropped from `LaneCardsRow` entirely since a continuous lane spans multiple project bands.

## Files changed

| File | Change |
|---|---|
| `Swimlane.tsx` | Add `LaneBackdrop`; strip tray paint from `LaneCardsRow` cells; add `position:relative` to `bumpRef` |
| `swimlane-structure.test.ts` | **NEW** — 8 source-contract tests: backdrop existence, tray-paint removal, data attribute preservation, hue routing |
| `surface-contract.test.ts` | CTL-1151 guard: backdrop attribute present, no cell re-introduces TRAY_LIFT |
| `elevation-ladder.test.ts` | CTL-1151 assertion: lane(s0) < canvas(s1), card(s2) > canvas(s1) |

## Test plan

- [x] `bun test src/board/swimlane-structure.test.ts` — 8/8 pass
- [x] `bun test src/surface-contract.test.ts src/elevation-ladder.test.ts` — 26/26 pass
- [x] `bun test src/board/lane-heights.test.ts` — water-fill logic untouched
- [x] `bunx tsc --noEmit` — clean (exit 0)
- [x] CI: audit-references, check-versions, docs-gate, quality, validate — all pass ✅
- [ ] Manual screenshot: `Rows=Team` showing continuous lanes, recessed lane, elevated cards, per-band hue

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1151
