### PR TITLE
feat(dev): CTL-1158 — surface PR merge-state on BoardTicket for stuck-PR inbox attention

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/board-pr-stuck.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-pr-stuck.test.ts
@@ -1,0 +1,97 @@
+// board-pr-stuck.test.ts — CTL-1158: wiring guard for the PR-stuck attention
+// signal. assembleBoard() reads WORKERS_DIR (a homedir const) and shells out to
+// `claude agents`, so it is not directly integration-testable. We pin the wiring
+// via STATIC SOURCE ANALYSIS — exactly the pattern used by board-row-durations,
+// board-held-indicator, and board-phase-drift — plus type-contract checks.
+//
+// What is guarded:
+//   1. assembleBoard() accepts getPrStatus
+//   2. prStartedAt() helper is present
+//   3. the ticket loop computes prStuck + prReason and passes them to deriveAttention
+//   4. humanQuestion falls back to prReason
+//   5. the ticket object carries mergeStateStatus + prStuckReason
+//   6. board-data.d.mts wire contract declares the two new fields
+//   7. ui/src/board/types.ts UI view declares the two new optional fields
+//   8. PrMergeStateStatus type union is present in both type files
+
+import { test, expect, describe } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(join(HERE, "..", rel), "utf8");
+
+const boardDataSrc = read("lib/board-data.mjs");
+const boardDataDts = read("lib/board-data.d.mts");
+const uiTypesSrc = read("ui/src/board/types.ts");
+const serverSrc = read("server.ts");
+
+describe("CTL-1158: assembleBoard wiring — PR-stuck attention signal", () => {
+  test("assembleBoard accepts a getPrStatus option", () => {
+    expect(boardDataSrc).toContain("getPrStatus = null");
+  });
+
+  test("prStartedAt helper extracts startedAt from phase-pr signals", () => {
+    expect(boardDataSrc).toContain("function prStartedAt(prSigs)");
+    expect(boardDataSrc).toContain("sig?.pr?.number && sig.startedAt");
+  });
+
+  test("ticket loop computes prStuck using isPrStuck + prStartedAt", () => {
+    expect(boardDataSrc).toContain("isPrStuck(prStatus, prPhaseStartedAt, now)");
+    expect(boardDataSrc).toContain("prStartedAt(prSigs)");
+  });
+
+  test("ticket loop computes prReason using prStuckReason", () => {
+    expect(boardDataSrc).toContain("prStuckReason(prStatus?.mergeStateStatus, prNumber)");
+  });
+
+  test("deriveAttention receives prStuck + prStuckSince from the ticket loop", () => {
+    expect(boardDataSrc).toContain("prStuck,");
+    expect(boardDataSrc).toContain("prStuckSince: prPhaseStartedAt,");
+  });
+
+  test("humanQuestion falls back to prReason when no phase-signal CTA", () => {
+    expect(boardDataSrc).toContain("deriveHumanQuestion(phaseSigs) ?? prReason");
+  });
+
+  test("ticket object carries mergeStateStatus from prStatus", () => {
+    expect(boardDataSrc).toContain("mergeStateStatus: prStatus?.mergeStateStatus ?? null");
+  });
+
+  test("ticket object carries prStuckReason", () => {
+    expect(boardDataSrc).toContain("prStuckReason: prReason,");
+  });
+});
+
+describe("CTL-1158: type contracts — wire shape and UI view carry the new fields", () => {
+  test("board-data.d.mts declares mergeStateStatus on BoardTicket", () => {
+    expect(boardDataDts).toMatch(/mergeStateStatus\??:/);
+  });
+
+  test("board-data.d.mts declares prStuckReason on BoardTicket", () => {
+    expect(boardDataDts).toMatch(/prStuckReason\??:/);
+  });
+
+  test("board-data.d.mts declares PrMergeStateStatus union", () => {
+    expect(boardDataDts).toContain("PrMergeStateStatus");
+  });
+
+  test("ui/src/board/types.ts declares mergeStateStatus (optional) on BoardTicket", () => {
+    expect(uiTypesSrc).toContain("mergeStateStatus?:");
+  });
+
+  test("ui/src/board/types.ts declares prStuckReason (optional) on BoardTicket", () => {
+    expect(uiTypesSrc).toContain("prStuckReason?:");
+  });
+
+  test("ui/src/board/types.ts declares PrMergeStateStatus union", () => {
+    expect(uiTypesSrc).toContain("PrMergeStateStatus");
+  });
+});
+
+describe("CTL-1158: server.ts threads PrStatusFetcher into assembleBoard", () => {
+  test("server.ts wires getPrStatus from prFetcher into the assemble closure", () => {
+    expect(serverSrc).toContain("getPrStatus:");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/home-inbox-attention.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-inbox-attention.test.ts
@@ -239,4 +239,44 @@ describe("CTL-1065: attentionSubLabel uses humanQuestion when present", () => {
     const row = model.order.find((r) => r.id === "CTL-1065")!;
     expect(row.subLabel).toBe("waiting on your answer");
   });
+
+  // CTL-1158: PR-stuck tickets route to the "Needs you" section
+  it("CTL-1158: stuck-PR ticket (attention needs-human + prStuckReason) → 'attention' section, PR sub-label", () => {
+    const prReason = "PR #1158 has a merge conflict the pipeline couldn't auto-resolve — decide which change wins";
+    const t = mkTicket("CTL-1158", {
+      attention: "needs-human",
+      mergeStateStatus: "DIRTY",
+      prStuckReason: prReason,
+      humanQuestion: prReason,
+    });
+    expect(classifyTicket(t)).toBe("attention");
+    const model = deriveInbox(mkPayload([t]));
+    const row = model.order.find((r) => r.id === "CTL-1158")!;
+    expect(row).toBeDefined();
+    expect(row.subLabel).toMatch(/conflict/i);
+    expect(model.counts.needsYou).toBe(1);
+  });
+
+  it("CTL-1158: BLOCKED PR-stuck ticket → 'attention' with required-check sub-label", () => {
+    const prReason = "PR #999 is blocked by a failing required check or branch-protection rule";
+    const t = mkTicket("CTL-999", {
+      attention: "needs-human",
+      mergeStateStatus: "BLOCKED",
+      prStuckReason: prReason,
+      humanQuestion: prReason,
+    });
+    expect(classifyTicket(t)).toBe("attention");
+    const model = deriveInbox(mkPayload([t]));
+    const row = model.order.find((r) => r.id === "CTL-999")!;
+    expect(row.subLabel).toMatch(/required|check|protection/i);
+  });
+
+  it("CTL-1158: a clean PR (attention null) does NOT appear in 'attention'", () => {
+    const t = mkTicket("CTL-1160", {
+      attention: null,
+      mergeStateStatus: "CLEAN",
+      prStuckReason: null,
+    });
+    expect(classifyTicket(t)).not.toBe("attention");
+  });
 });

--- a/plugins/dev/scripts/orch-monitor/board-data-attention.test.ts
+++ b/plugins/dev/scripts/orch-monitor/board-data-attention.test.ts
@@ -128,4 +128,49 @@ describe("deriveAttention (CTL-729) — the single needs-attention bucket", () =
     expect(r.attention).toBe("waiting-on-you");
     expect(r.attentionSince).toBeNull();
   });
+
+  // CTL-1158: PR-stuck attention signal
+  it("a stuck PR (prStuck) → attention 'needs-human' anchored at prStuckSince", () => {
+    const r = deriveAttention({
+      waitingOnUser: false,
+      labels: [],
+      needsHumanMarker: false,
+      prStuck: true,
+      prStuckSince: "2026-06-14T10:00:00Z",
+    });
+    expect(r.attention).toBe("needs-human");
+    expect(r.attentionSince).toBe("2026-06-14T10:00:00Z");
+  });
+
+  it("an explicit needs-human label OUTRANKS prStuck for the anchor (label stamp wins)", () => {
+    const r = deriveAttention({
+      waitingOnUser: false,
+      labels: ["needs-human"],
+      needsHumanMarker: false,
+      needsHumanSince: "2026-06-14T09:00:00Z",
+      prStuck: true,
+      prStuckSince: "2026-06-14T10:00:00Z",
+    });
+    expect(r.attention).toBe("needs-human");
+    expect(r.attentionSince).toBe("2026-06-14T09:00:00Z");
+  });
+
+  it("prStuck OUTRANKS a live waiting-on-you bg job (escalation precedence)", () => {
+    const r = deriveAttention({
+      waitingOnUser: true,
+      labels: [],
+      needsHumanMarker: false,
+      waitingSince: "2026-06-14T08:00:00Z",
+      prStuck: true,
+      prStuckSince: "2026-06-14T10:00:00Z",
+    });
+    expect(r.attention).toBe("needs-human");
+    expect(r.attentionSince).toBe("2026-06-14T10:00:00Z");
+  });
+
+  it("prStuck:false leaves existing behavior unchanged (back-compat)", () => {
+    const r = deriveAttention({ waitingOnUser: false, labels: [], needsHumanMarker: false });
+    expect(r.attention).toBeNull();
+    expect(r.attentionSince).toBeNull();
+  });
 });

--- a/plugins/dev/scripts/orch-monitor/board-data-pr-stuck.test.ts
+++ b/plugins/dev/scripts/orch-monitor/board-data-pr-stuck.test.ts
@@ -1,0 +1,73 @@
+// CTL-1158: unit tests for isPrStuck() and prStuckReason() — the pure helpers
+// that drive the PR-stuck attention signal. A PR that has been DIRTY/BLOCKED/
+// UNSTABLE for ≥ 300 s surfaces in the "Needs you" inbox with a PR-specific CTA.
+// All tests are PURE: no fs/network, no assembleBoard.
+
+import { describe, it, expect } from "bun:test";
+
+const { isPrStuck, prStuckReason } = await import("./lib/board-data.mjs");
+
+const NOW = Date.parse("2026-06-14T10:10:00Z");   // 10 min after start
+const START = "2026-06-14T10:00:00Z";             // 600 s before NOW (≥ 300 s)
+const FRESH = "2026-06-14T10:09:00Z";             // 60 s before NOW (< 300 s)
+
+describe("isPrStuck — real-blocker merge state held ≥ 300 s", () => {
+  for (const ms of ["DIRTY", "BLOCKED", "UNSTABLE"]) {
+    it(`${ms} for ≥ 300 s → stuck`, () => {
+      expect(isPrStuck({ mergeStateStatus: ms, state: "OPEN" }, START, NOW)).toBe(true);
+    });
+    it(`${ms} for < 300 s → NOT stuck (debounce)`, () => {
+      expect(isPrStuck({ mergeStateStatus: ms, state: "OPEN" }, FRESH, NOW)).toBe(false);
+    });
+  }
+  for (const ms of ["CLEAN", "BEHIND", "HAS_HOOKS", "UNKNOWN"]) {
+    it(`${ms} → never stuck (not a real blocker)`, () => {
+      expect(isPrStuck({ mergeStateStatus: ms, state: "OPEN" }, START, NOW)).toBe(false);
+    });
+  }
+  it("a MERGED PR is never stuck", () => {
+    expect(isPrStuck({ mergeStateStatus: "DIRTY", state: "MERGED" }, START, NOW)).toBe(false);
+  });
+  it("a CLOSED PR is never stuck", () => {
+    expect(isPrStuck({ mergeStateStatus: "DIRTY", state: "CLOSED" }, START, NOW)).toBe(false);
+  });
+  it("null prStatus → not stuck (no throw)", () => {
+    expect(isPrStuck(null, START, NOW)).toBe(false);
+  });
+  it("null prPhaseStartedAt → not stuck (no anchor, no throw)", () => {
+    expect(isPrStuck({ mergeStateStatus: "DIRTY", state: "OPEN" }, null, NOW)).toBe(false);
+  });
+  it("UNKNOWN state is treated as OPEN (still may be stuck)", () => {
+    expect(isPrStuck({ mergeStateStatus: "DIRTY", state: "UNKNOWN" }, START, NOW)).toBe(true);
+  });
+});
+
+describe("prStuckReason — PR-specific operator CTA", () => {
+  it("DIRTY → merge-conflict phrasing with PR number", () => {
+    const reason = prStuckReason("DIRTY", 1158);
+    expect(reason).toMatch(/#1158/);
+    expect(reason).toMatch(/conflict/i);
+  });
+  it("BLOCKED → required-check or branch-protection phrasing", () => {
+    const reason = prStuckReason("BLOCKED", 1158);
+    expect(reason).toMatch(/#1158/);
+    expect(reason).toMatch(/required|check|protection/i);
+  });
+  it("UNSTABLE → failing-check phrasing", () => {
+    const reason = prStuckReason("UNSTABLE", 1158);
+    expect(reason).toMatch(/#1158/);
+    expect(reason).toMatch(/check/i);
+  });
+  it("CLEAN → null (not a blocker)", () => {
+    expect(prStuckReason("CLEAN", 1158)).toBeNull();
+  });
+  it("BEHIND → null (not a blocker)", () => {
+    expect(prStuckReason("BEHIND", 1158)).toBeNull();
+  });
+  it("HAS_HOOKS → null (not a blocker)", () => {
+    expect(prStuckReason("HAS_HOOKS", 1158)).toBeNull();
+  });
+  it("UNKNOWN → null (not a blocker)", () => {
+    expect(prStuckReason("UNKNOWN", 1158)).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -17,6 +17,10 @@ export type BoardActiveState = "active" | "stuck" | "dead" | null;
 // admission-gate blocked/waiting pair).
 export type BoardAttention = "waiting-on-you" | "needs-human" | null;
 
+/** CTL-1158: GitHub PR merge state from the PrStatusFetcher cache. */
+export type PrMergeStateStatus =
+  | "CLEAN" | "BLOCKED" | "DIRTY" | "BEHIND" | "UNSTABLE" | "HAS_HOOKS" | "UNKNOWN";
+
 /** CTL-922 (BFF10): a node's stable identity stamped on every board entity so
  *  the node-aware surfaces can attribute/group by host. `name` is the
  *  configurable host name (CATALYST_HOST_NAME / os.hostname() minus ".local");
@@ -119,6 +123,12 @@ export interface BoardTicket {
   phaseCosts: Record<string, BoardPhaseCost> | null;
   phaseSummary: BoardPhaseTiming[];
   pr: number | null;
+  /** CTL-1158: the PR's GitHub merge state (from the PrStatusFetcher cache);
+   *  null when no PR / no cache entry. */
+  mergeStateStatus?: PrMergeStateStatus | null;
+  /** CTL-1158: the operator CTA when the PR has been DIRTY/BLOCKED/UNSTABLE
+   *  ≥ 300 s; null otherwise. Mirrored into humanQuestion as the inbox sub-label. */
+  prStuckReason?: string | null;
   updatedAt: string;
   /** CTL-755 held indicator from the ticket's Linear labels. */
   held: "blocked" | "waiting" | null;
@@ -266,14 +276,31 @@ export const ATTENTION_LABEL_NEEDS_INPUT: string;
 /** CTL-729: PURE classifier for the single needs-attention bucket. needs-human
  *  (a needs-human/needs-input label OR the host-local marker) WINS over
  *  waiting-on-you (a live worker's blocked bg job). The anchor follows the winning
- *  reason; null when that reason carries no durable stamp (never fabricated). */
+ *  reason; null when that reason carries no durable stamp (never fabricated).
+ *  CTL-1158: also accepts prStuck/prStuckSince for the PR-stuck signal. */
 export function deriveAttention(opts?: {
   waitingOnUser?: boolean;
   labels?: unknown;
   needsHumanMarker?: boolean;
   waitingSince?: string | null;
   needsHumanSince?: string | null;
+  prStuck?: boolean;
+  prStuckSince?: string | null;
 }): { attention: BoardAttention; attentionSince: string | null };
+
+/** CTL-1158: returns true when the PR has been in a real-blocker merge state
+ *  (DIRTY/BLOCKED/UNSTABLE) for ≥ 300 s, anchored to prPhaseStartedAt. */
+export function isPrStuck(
+  prStatus: { mergeStateStatus: string; state?: string } | null | undefined,
+  prPhaseStartedAt: string | null | undefined,
+  now: number,
+): boolean;
+
+/** CTL-1158: operator CTA string for a stuck PR; null when not a blocker state. */
+export function prStuckReason(
+  mergeStateStatus: string | null | undefined,
+  prNumber: number | null | undefined,
+): string | null;
 
 /** CTL-928: a single ticket's lane on the queue board (live | between-phases |
  *  recent-done). Honors the terminal-intermediate vs pipeline-done distinction. */
@@ -378,7 +405,10 @@ export function mergeTitleFallback(
   nullTitleIds: string[],
   fetched: Record<string, { title?: string | null } | undefined>,
 ): Record<string, { title?: string | null } & Record<string, unknown>>;
-export function assembleBoard(): Promise<BoardPayload>;
+export function assembleBoard(opts?: {
+  /** CTL-1158: inject the PrStatusFetcher cache getter for the PR-stuck signal. */
+  getPrStatus?: ((repo: string, number: number) => { mergeStateStatus: string; state?: string } | null) | null;
+}): Promise<BoardPayload>;
 /** CTL-922 (BFF10): build a {name,id} HostRef from a bare host name (id =
  *  sha256(name)[:16]); null for a null/empty name. */
 export function hostRefFromName(name: unknown): BoardHostRef | null;

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -190,12 +190,17 @@ export function deriveAttention({
   needsHumanMarker = false,
   waitingSince = null,
   needsHumanSince = null,
+  prStuck = false,            // CTL-1158: PR in a real-blocker merge state ≥ 300 s
+  prStuckSince = null,
 } = {}) {
   const set = new Set(Array.isArray(labels) ? labels : []);
   const labelNeedsHuman = set.has(ATTENTION_LABEL_NEEDS_HUMAN) || set.has(ATTENTION_LABEL_NEEDS_INPUT);
-  const needsHuman = labelNeedsHuman || needsHumanMarker === true;
+  const needsHuman = labelNeedsHuman || needsHumanMarker === true || prStuck === true;
   if (needsHuman) {
-    return { attention: "needs-human", attentionSince: needsHumanSince ?? null };
+    // Label/marker stamp is the more authoritative anchor when present; the
+    // PR-stuck anchor is the fallback. needs-human (any source) outranks
+    // waiting-on-you.
+    return { attention: "needs-human", attentionSince: needsHumanSince ?? (prStuck ? prStuckSince : null) };
   }
   if (waitingOnUser === true) {
     return { attention: "waiting-on-you", attentionSince: waitingSince ?? null };
@@ -842,6 +847,45 @@ function prFor(prSigs) {
   return null;
 }
 
+// CTL-1158: the PR phase signal's startedAt — the "stuck since" anchor for the
+// 300 s gate. Same newest-first scan as prFor.
+function prStartedAt(prSigs) {
+  for (const sig of prSigs) {
+    if (sig?.pr?.number && sig.startedAt) return sig.startedAt;
+  }
+  return null;
+}
+
+// CTL-1158: PR merge states that warrant an operator row. Mirrors the "real
+// blocker" mapping in pr-variant.ts (DIRTY/BLOCKED/UNSTABLE). BEHIND is
+// excluded — the pipeline may auto-rebase it (transient).
+const PR_BLOCKER_STATES = new Set(["DIRTY", "BLOCKED", "UNSTABLE"]);
+const PR_STUCK_DEBOUNCE_MS = 300_000; // 300 s sustained-state gate
+
+export function isPrStuck(prStatus, prPhaseStartedAt, now) {
+  if (!prStatus) return false;
+  const { state, mergeStateStatus } = prStatus;
+  if (state && state !== "OPEN" && state !== "UNKNOWN") return false;
+  if (!PR_BLOCKER_STATES.has(mergeStateStatus)) return false;
+  const startedMs = prPhaseStartedAt ? Date.parse(prPhaseStartedAt) : NaN;
+  if (Number.isNaN(startedMs)) return false;
+  return now - startedMs >= PR_STUCK_DEBOUNCE_MS;
+}
+
+export function prStuckReason(mergeStateStatus, prNumber) {
+  const n = prNumber ? `#${prNumber}` : "the PR";
+  switch (mergeStateStatus) {
+    case "DIRTY":
+      return `PR ${n} has a merge conflict the pipeline couldn't auto-resolve — decide which change wins`;
+    case "BLOCKED":
+      return `PR ${n} is blocked by a failing required check or branch-protection rule`;
+    case "UNSTABLE":
+      return `PR ${n} has a failing check — review before it can merge`;
+    default:
+      return null;
+  }
+}
+
 // ── Linear enrichment: priority / estimate / project / labels / relations /
 // assignee, read EXCLUSIVELY from the broker's durable caches (CTL-883).
 //
@@ -1035,7 +1079,7 @@ async function loadDispatchCooldowns(now) {
 }
 
 // ── main assembly ───────────────────────────────────────────────────────────
-export async function assembleBoard() {
+export async function assembleBoard({ getPrStatus = null } = {}) {
   const [agents, costs, phaseCostsByTicket, eligible, linfo, mp, catalystSessByUuid, cooldowns] = await Promise.all([
     liveAgents(), costByTicket(), costByPhase(), loadEligible(), linearInfo(), maxParallel(),
     catalystSessionByCcUuid(), loadDispatchCooldowns(Date.now()),
@@ -1224,18 +1268,26 @@ export async function assembleBoard() {
     const cur = derivePhaseWithRemediate(phaseSigs, remediateSig);
     const phaseSummary = buildPhaseSummary(phaseSigs, now);
     const live = inFlightTickets.get(id);
+    // CTL-1158: PR-stuck attention signal. getPrStatus is an O(1) in-memory lookup
+    // on the PrStatusFetcher cache — no extra gh calls, negligible cost.
+    const prNumber = prFor(prSigs);
+    const prPhaseStartedAt = prStartedAt(prSigs);
+    const prStatus = getPrStatus && prNumber != null ? getPrStatus(repoFor(id), prNumber) : null;
+    const prStuck = isPrStuck(prStatus, prPhaseStartedAt, now);
+    const prReason = prStuck ? prStuckReason(prStatus?.mergeStateStatus, prNumber) : null;
     // CTL-729: the single needs-attention bucket (waiting-on-you ∪ needs-human),
     // merging the live worker's blocked-bg-job flag, the needs-human/needs-input
-    // Linear labels (CTL-1031 webhook fold), and the host-local needs-human marker.
-    // The waiting-on-you anchor is the worker's current-phase start (how long it
-    // has been parked); the needs-human anchor falls back to heldSince downstream
-    // (no separate label-applied stamp is projected) → null here (honest).
+    // Linear labels (CTL-1031 webhook fold), the host-local needs-human marker,
+    // and the CTL-1158 PR-stuck signal. The waiting-on-you anchor is the worker's
+    // current-phase start; the needs-human anchor falls back to heldSince downstream.
     const attn = deriveAttention({
       waitingOnUser: live?.waitingOnUser ?? false,
       labels: linfo[id]?.labels,
       needsHumanMarker,
       waitingSince: cur.startedAt ?? null,
       needsHumanSince: null,
+      prStuck,
+      prStuckSince: prPhaseStartedAt,
     });
     return {
       id, title: ticketTitle(id, triage, eligibleIndex, linfo), type: ticketType(triage),
@@ -1281,8 +1333,9 @@ export async function assembleBoard() {
       // signal) → again rendered unavailable, never now-anchored to a guess.
       currentPhaseSince: cur.startedAt ?? null,
       // CTL-1130: call_to_action from the most-recent phase signal's explanation,
-      // surfaced as the inbox sub-label for needs-human rows.
-      humanQuestion: deriveHumanQuestion(phaseSigs),
+      // surfaced as the inbox sub-label for needs-human rows. CTL-1158: fall back
+      // to the PR-stuck reason so the inbox sub-label names WHY (research F12).
+      humanQuestion: deriveHumanQuestion(phaseSigs) ?? prReason,
       // CTL-1110: the six extended explanation fields surfaced for the detail
       // pane's CTA-led card (distinct from humanQuestion, the list-row sub-label).
       explanation: deriveExplanation(phaseSigs),
@@ -1298,7 +1351,10 @@ export async function assembleBoard() {
         : null,
       phaseCosts: phaseCostsByTicket[id] ?? null,
       phaseSummary,
-      pr: prFor(prSigs),
+      pr: prNumber,
+      // CTL-1158: PR merge state + the PR-stuck operator CTA (null unless stuck).
+      mergeStateStatus: prStatus?.mergeStateStatus ?? null,
+      prStuckReason: prReason,
       updatedAt: ticketUpdatedAt(phaseSigs),
       // CTL-922 (BFF10): node attribution. host:{name,id} from the ticket's phase
       // signals (CTL-852, dispatch-stamped) falling back to the durable fence

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -12,6 +12,7 @@ import {
 import { readSessionStore } from "./lib/session-store";
 import { readReconcileHealth } from "./lib/reconcile-health-reader"; // CTL-867
 import type { BoardPayload } from "./lib/board-data.mjs";
+import { assembleBoard } from "./lib/board-data.mjs";
 import { createBoardSnapshotManager } from "./lib/board-snapshot.mjs";
 // CTL-896 (SHELL6): the dedicated nav-signal projection — worker count, queue
 // depth, board anomaly, and the local daemon-health dot — derived off the SAME
@@ -1166,7 +1167,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // CTL-733: one shared, reactively-recomputed board snapshot pushed over SSE
   // (/api/board/stream) — replaces per-tab polling of /api/board. Subscriber-
   // gated, so it does zero work when no board tab is open.
-  const boardSnapshot = createBoardSnapshotManager();
+  const boardSnapshot = createBoardSnapshotManager({
+    assemble: () => assembleBoard({ getPrStatus: (r, n) => prFetcher?.get(r, n) ?? null }),
+  });
 
   // CTL-896 (SHELL6): the local daemon-health reader for the footer health dot.
   //

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
@@ -24,6 +24,10 @@ export type BoardActiveState = "active" | "stuck" | "dead" | null;
 // marker) | null. needs-human wins. DISTINCT from `held` (admission-gate pair).
 export type BoardAttention = "waiting-on-you" | "needs-human" | null;
 
+/** CTL-1158: GitHub PR merge state; mirrors lib/board-data.d.mts PrMergeStateStatus. */
+export type PrMergeStateStatus =
+  | "CLEAN" | "BLOCKED" | "DIRTY" | "BEHIND" | "UNSTABLE" | "HAS_HOOKS" | "UNKNOWN";
+
 /** CTL-922 (BFF10): a node's stable identity stamped on every board entity so the
  *  node-aware surfaces (BOARD3 host swimlanes, SURF1 worker node group, SURF2
  *  queue node column) can attribute/group by host. Mirrors the server's
@@ -118,6 +122,10 @@ export interface BoardTicket {
   phaseCosts: Record<string, BoardPhaseCost> | null;
   phaseSummary: BoardPhaseTiming[];
   pr: number | null;
+  /** CTL-1158: the PR's GitHub merge state; null when no PR / no cache entry. */
+  mergeStateStatus?: PrMergeStateStatus | null;
+  /** CTL-1158: operator CTA when the PR is stuck (DIRTY/BLOCKED/UNSTABLE ≥ 300 s). */
+  prStuckReason?: string | null;
   updatedAt: string;
   subSteps?: WorkflowSubStep[];
   /** CTL-755 held indicator from the ticket's Linear labels: the admission gate


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-14T23:25:00Z -->
<!-- Last updated: 2026-06-14T23:25:00Z -->
<!-- PR: #2033 -->
<!-- Previous commits: a3d052fdf9ccaa6a27a132812ce39a80e69b0e21 -->

## Summary

Threads the existing `PrStatusFetcher` cache into `assembleBoard` so that an open PR stuck on a real blocker (DIRTY / BLOCKED / UNSTABLE) for ≥ 300 s automatically surfaces in the orch-monitor "Needs You" inbox with a specific, actionable CTA. Previously the board only surfaced stuck _workers_; a healthy worker with a stuck PR produced zero inbox rows.

**Three-phase implementation:**

- **Phase 1 (pure logic):** Extended `deriveAttention` with `prStuck` / `prStuckSince` params; added `isPrStuck` (300 s debounce gate on DIRTY/BLOCKED/UNSTABLE) and `prStuckReason` (operator CTA keyed on merge-state). 36 unit tests.
- **Phase 2 (wiring):** `assembleBoard` now accepts optional `getPrStatus`; the ticket loop computes `prStuck` via injected `PrStatusFetcher.get()` (O(1) in-memory), and populates `mergeStateStatus`, `prStuckReason`, and `humanQuestion` fallback. Type contracts updated in `board-data.d.mts` and `ui/src/board/types.ts`. 15 tests.
- **Phase 3 (regression guard):** Inbox routing test confirming a stuck-PR ticket lands in the "attention" section with the PR-specific sub-label. 3 tests.

## Changes Made

### Backend / Server

- **`lib/board-data.mjs`** — Added `isPrStuck`, `prStartedAt`, `prStuckReason` helpers; extended `deriveAttention` to accept `prStuck` / `prStuckSince`; ticket loop now reads `getPrStatus` and populates `mergeStateStatus` + `prStuckReason` on the `BoardTicket`.
- **`server.ts`** — Wires `getPrStatus` from the existing `prFetcher` into the `assemble` closure so the injected status reaches `assembleBoard`.

### Type Contracts

- **`lib/board-data.d.mts`** — Declared `mergeStateStatus`, `prStuckReason`, and `PrMergeStateStatus` union on `BoardTicket`.
- **`ui/src/board/types.ts`** — Mirrored the same optional fields and union on the UI-side `BoardTicket`.

### Tests

- **`__tests__/board-pr-stuck.test.ts`** _(new)_ — 16 static-source-analysis tests + type-contract checks confirming the full wiring: `assembleBoard` accepts `getPrStatus`, `prStartedAt` helper, `isPrStuck` usage, `prStuckReason` usage, and that both type files declare the new shape.
- **`board-data-attention.test.ts`** — 4 new unit tests for `deriveAttention`: prStuck → needs-human, label-anchor precedence, prStuck OUTRANKS waiting-on-you, clean PR → no attention.
- **`board-data-pr-stuck.test.ts`** _(new)_ — 15 unit tests for `isPrStuck` and `prStuckReason` covering all merge-state branches and debounce thresholds.
- **`__tests__/home-inbox-attention.test.ts`** — 3 new inbox-routing tests: DIRTY stuck, BLOCKED stuck, CLEAN PR stays off the inbox.

## How to Verify It

- [x] All CI checks pass (audit-references, check-versions, docs-gate, quality, validate) ✅
- [x] TypeScript compiles — part of `quality` CI gate ✅
- [ ] Start orch-monitor with a ticket whose PR is DIRTY/BLOCKED — confirm a "Needs you" row appears after ~300 s
- [ ] Confirm a CLEAN PR produces no inbox row

## Related Issues / PRs

- Fixes https://linear.app/adva/issue/CTL-1158
