### PR TITLE
fix(dev): CTL-1165 — bound the execution-core fleet (reap-leak fix, 5 drivers)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -117,6 +117,8 @@ jobs:
             event-cursor.test.mjs \
             event-scan.test.mjs \
             event-tail.test.mjs \
+            fleet-health-event.test.mjs \
+            fleet-health-probe.test.mjs \
             gateway-read.test.mjs \
             halt-on-complete.test.mjs \
             heartbeat-event.test.mjs \
@@ -124,6 +126,7 @@ jobs:
             integration-ctl-701.test.mjs \
             integration-ctl-705.test.mjs \
             integration.test.mjs \
+            job-dir-gc.test.mjs \
             label-guard.test.mjs \
             linear-breaker.test.mjs \
             linear-cache.test.mjs \
@@ -137,6 +140,7 @@ jobs:
             memory-sampler.test.mjs \
             merge-state.test.mjs \
             orphan-reaper-timer.test.mjs \
+            proc-reaper.test.mjs \
             ratelimit-event.test.mjs \
             ratelimit-poller.test.mjs \
             reap-intent.test.mjs \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -598,6 +598,38 @@ Edit `.catalyst/config.json`:
 }
 ```
 
+### "Tune (or disable) the `~/.claude/jobs` directory GC"
+
+The orphan reaper also garbage-collects stale `~/.claude/jobs/<id>` directories
+on its periodic cadence (CTL-1165). The sweep is **fail-closed** — if `claude
+agents` cannot be read it deletes nothing — and only removes a job directory when
+it is not a live or registered session, not the controlling session, and older
+than `retentionSeconds` (default 24h). It deletes the job directory alone (never
+`claude rm`), capped at `batchCap` per sweep with the remainder draining on the
+next tick. Edit `.catalyst/config.json`:
+
+```json
+{
+  "catalyst": {
+    "orchestration": {
+      "orphanReaper": {
+        "jobGc": {
+          "enabled": true,
+          "retentionSeconds": 86400,
+          "batchCap": 200
+        }
+      }
+    }
+  }
+}
+```
+
+Set `"enabled": false` to disable only the directory GC (the orphan-reaper sweep
+still runs). The env vars `CATALYST_JOB_GC_RETENTION_SECONDS` and
+`CATALYST_JOB_GC_BATCH_CAP` override the corresponding fields. See
+[`catalyst-config.schema.json`](./schemas/catalyst-config.schema.json) for the
+canonical field reference.
+
 ### "Change the Linear state the daemon polls for new work"
 
 Edit `~/catalyst/execution-core/registry.json` directly or re-run the enrollment script:

--- a/docs/schemas/catalyst-config.schema.json
+++ b/docs/schemas/catalyst-config.schema.json
@@ -352,6 +352,53 @@
                   }
                 }
               }
+            },
+            "fleetHealth": {
+              "type": "object",
+              "description": "CTL-1165 D5: the pre-exhaustion fleet-health guardrail. Every intervalMs it samples four steady-state degradation signals (the ~/.claude/jobs dir count, the live background-agent count, the resident node/bun worker-process count, and macOS swap-used MB) and, when any crosses its threshold, emits a single fleet.health.degraded event. selfHealEnabled is OFF by default (emit-only); when enabled it eagerly fires the same gated reap intents the 600s orphan-reaper timer emits — it gains no new kill authority.",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "When false, the fleet-health probe is disabled. Env CATALYST_FLEET_HEALTH=0 also disables it."
+                },
+                "intervalMs": {
+                  "type": "number",
+                  "default": 120000,
+                  "description": "How often (in milliseconds) the probe samples the four signals. Env EXECUTION_CORE_FLEET_HEALTH_INTERVAL_MS overrides."
+                },
+                "jobsThreshold": {
+                  "type": "number",
+                  "default": 500,
+                  "description": "Emit fleet.health.degraded when the ~/.claude/jobs dir count reaches this value. Env EXECUTION_CORE_FLEET_JOBS_THRESHOLD overrides."
+                },
+                "swapUsedMbThreshold": {
+                  "type": "number",
+                  "default": 4096,
+                  "description": "Emit when macOS swap-used MB reaches this value. Env EXECUTION_CORE_FLEET_SWAP_MB_THRESHOLD overrides."
+                },
+                "agentsThreshold": {
+                  "type": "number",
+                  "default": 12,
+                  "description": "Emit when the live background-agent count reaches this value. Env EXECUTION_CORE_FLEET_AGENTS_THRESHOLD overrides."
+                },
+                "procsThreshold": {
+                  "type": "number",
+                  "default": 40,
+                  "description": "Emit when the resident node/bun worker-process count reaches this value. Env EXECUTION_CORE_FLEET_PROCS_THRESHOLD overrides."
+                },
+                "selfHealEnabled": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "When true, a sustained breach eagerly fires the orphan-reaper + phase-reconcile + proc-orphan reap intents (each gated by its own reaper; the proc-orphan sweep is shadow by default). DEFAULT OFF — the first ship is a pure alert. Env EXECUTION_CORE_FLEET_SELF_HEAL=1 also enables it."
+                },
+                "sustainedTicks": {
+                  "type": "number",
+                  "default": 2,
+                  "description": "Number of consecutive degraded ticks before self-heal fires (once per breach episode, re-armed after a healthy tick)."
+                }
+              }
             }
           }
         },

--- a/docs/schemas/catalyst-config.schema.json
+++ b/docs/schemas/catalyst-config.schema.json
@@ -295,6 +295,28 @@
                   "type": "number",
                   "default": 120,
                   "description": "Minimum number of seconds a worker's signal file must be unmodified before the reaper considers it a candidate for reclaim."
+                },
+                "jobGc": {
+                  "type": "object",
+                  "description": "CTL-1165 D3: garbage-collection of stale ~/.claude/jobs/<id> directories, run on the same cadence as the orphan-reaper sweep. Fail-closed (skips the whole sweep if `claude agents` is unreadable); deletes only the job directory (never `claude rm`), and only when it is not a live/registered session, not the controlling session, and older than retentionSeconds.",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "When false, the job-dir GC is disabled (the orphan-reaper sweep still runs)."
+                    },
+                    "retentionSeconds": {
+                      "type": "number",
+                      "default": 86400,
+                      "description": "Minimum age (in seconds) of a job directory before it is eligible for deletion. Default 24h — far longer than any phase duration. Env CATALYST_JOB_GC_RETENTION_SECONDS overrides."
+                    },
+                    "batchCap": {
+                      "type": "number",
+                      "default": 200,
+                      "description": "Maximum number of job directories deleted per sweep; the remainder drains on the next tick. Env CATALYST_JOB_GC_BATCH_CAP overrides."
+                    }
+                  }
                 }
               }
             }

--- a/docs/schemas/catalyst-config.schema.json
+++ b/docs/schemas/catalyst-config.schema.json
@@ -317,6 +317,39 @@
                       "description": "Maximum number of job directories deleted per sweep; the remainder drains on the next tick. Env CATALYST_JOB_GC_BATCH_CAP overrides."
                     }
                   }
+                },
+                "procReaper": {
+                  "type": "object",
+                  "description": "CTL-1165 D2: the orphan child-process reaper, run on the same cadence as the orphan-reaper sweep. `claude stop` deregisters a worker's claude agent but leaves its reparented node/bun grandchildren (MCP servers, sub-agent tooling, bun-test runners) running — the bulk of the resident-memory leak. It refuses to act unless every signal corroborates: a successful `claude agents` read this cycle (a failed read aborts the whole sweep, killing nothing), the process is reparented and outside the entire live-agent process tree, command and working directory match, and it has persisted across two consecutive sweeps. A hard never-kill allowlist always protects the daemon, broker, monitor, the live-agent tree, Tailscale, pid 1, and any foreign-uid process.",
+                  "additionalProperties": false,
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "enum": ["off", "shadow", "enforce"],
+                      "default": "shadow",
+                      "description": "off disables the reaper; shadow (the default) logs procOrphans.would-reap for each eligible orphan but kills nothing; enforce SIGTERMs then (after grace, if still alive) SIGKILLs. Ships in shadow so the allowlist + live-tree correlation can be audited on real hosts before any enforce flip."
+                    },
+                    "graceMs": {
+                      "type": "number",
+                      "default": 5000,
+                      "description": "Milliseconds to wait after SIGTERM before re-probing and (only if still alive) SIGKILLing, so node/bun can flush."
+                    },
+                    "minEtimeSec": {
+                      "type": "number",
+                      "default": 900,
+                      "description": "A process must have run at least this long (elapsed seconds) to be eligible — corroboration only, never the sole gate."
+                    },
+                    "worktreeRoot": {
+                      "type": "string",
+                      "description": "Only orphans whose working directory is under this root are reapable. Defaults to ~/catalyst/wt."
+                    },
+                    "allowlistPatterns": {
+                      "type": "array",
+                      "items": { "type": "string" },
+                      "default": [],
+                      "description": "Extra case-insensitive argv substrings to never kill, on top of the built-in allowlist (daemon, broker/index.mjs, orch-monitor/server.ts, the live-agent tree, Tailscale, pid 1, foreign-uid processes)."
+                    }
+                  }
                 }
               }
             }

--- a/plugins/dev/scripts/execution-core/claude-agents.mjs
+++ b/plugins/dev/scripts/execution-core/claude-agents.mjs
@@ -14,7 +14,7 @@
 import { execFile, execFileSync, spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { shortIdFromSessionId } from "./claude-ids.mjs";
+import { shortIdFromSessionId, isSelfSession } from "./claude-ids.mjs";
 import { getJobsRoot } from "./config.mjs";
 
 const CLAUDE_BIN = process.env.CATALYST_DISPATCH_CLAUDE_BIN || "claude";
@@ -432,9 +432,29 @@ export function defaultStatJobState(shortId) {
 // Terminal ghost sessions (state ∈ TERMINAL_JOB_STATES or firstTerminalAt set)
 // and dir-gone sessions are excluded so they cannot starve the admission gate.
 // The `statJob` seam (defaulting to defaultStatJobState) is injectable for tests.
-export function countBackgroundAgents({ agents, now, statJob = defaultStatJobState } = {}) {
+//
+// CTL-1165 (D1): exclude the daemon's OWN controlling background session from the
+// admission count. The scheduler's in-flight count IS this live `claude agents`
+// background count (scheduler.mjs:4247), so counting the daemon's own session
+// against maxParallel is a starve-by-1 (safe direction, but wrong). The self-skip
+// is the FIRST filter clause — a self session must never reach the kind/liveness
+// gates — and is keyed off CLAUDE_CODE_SESSION_ID via isSelfSession, which fails
+// CLOSED (env unset / malformed id → isSelf false → the session is still counted),
+// so the worst case stays the safe over-count direction. The `excludeSelf`/`env`
+// seams are injectable for tests; default behavior excludes self.
+export function countBackgroundAgents({
+  agents,
+  now,
+  statJob = defaultStatJobState,
+  env = process.env,
+  excludeSelf = true,
+  isSelf = isSelfSession,
+} = {}) {
   const list = agents ?? getAgentsCached(now ? { now } : {}).agents;
   return list.filter((a) => {
+    // CTL-1165: drop the controlling/self session FIRST — before kind/liveness —
+    // so the daemon's own background session never occupies an admission slot.
+    if (excludeSelf && a?.sessionId && isSelf(a.sessionId, env)) return false;
     if (a?.kind !== "background") return false; // unchanged: interactive/unknown excluded
     // CTL-1055: count only if the bg job is alive.
     let shortId;

--- a/plugins/dev/scripts/execution-core/claude-agents.test.mjs
+++ b/plugins/dev/scripts/execution-core/claude-agents.test.mjs
@@ -334,6 +334,107 @@ describe("countBackgroundAgents", () => {
   });
 });
 
+// --- CTL-1165 D1: concurrency self-exclusion + live-count invariant fence ----
+//
+// The scheduler's in-flight count is the LIVE `claude agents` background count
+// (scheduler.mjs:4247 inFlightCount = liveCount). countBackgroundAgents must
+// therefore (a) NOT count the daemon's own controlling background session
+// against maxParallel (a self-count is a starve-by-1, safe direction but wrong),
+// and (b) keep counting a leaked-but-running / status:null zombie as occupying a
+// slot — the safe "never over-dispatch on top of a live worker" invariant that a
+// future "skip unknown status" optimization must never silently break. D1 adds
+// the self-exclusion + fences both invariants; it makes NO dispatch-arithmetic
+// change (that lives in the scheduler, unchanged).
+describe("countBackgroundAgents — D1 self-exclusion + live-count invariant (CTL-1165)", () => {
+  const allAlive = () => ({ state: "working", firstTerminalAt: null });
+  // hex-prefixed UUID so shortIdFromSessionId(/^[0-9a-f]{8}-/) parses it.
+  const bg = (id, extra = {}) => ({
+    sessionId: `${id}-0000-0000-0000-000000000000`,
+    kind: "background",
+    ...extra,
+  });
+
+  test("excludes the self/controlling session even when background + alive (short-id env)", () => {
+    const env = { CLAUDE_CODE_SESSION_ID: "aaaaaaaa" };
+    expect(
+      countBackgroundAgents({
+        agents: [bg("aaaaaaaa"), bg("bbbbbbbb")],
+        statJob: allAlive,
+        env,
+      }),
+    ).toBe(1);
+  });
+
+  test("env unset → counts all background sessions (back-compat, fails closed/over-count-safe)", () => {
+    // No CLAUDE_CODE_SESSION_ID → isSelfSession is false for everything → count all.
+    expect(
+      countBackgroundAgents({
+        agents: [bg("aaaaaaaa"), bg("bbbbbbbb")],
+        statJob: allAlive,
+        env: {},
+      }),
+    ).toBe(2);
+  });
+
+  test("full-UUID env self id still drops the matching short-id session", () => {
+    const env = { CLAUDE_CODE_SESSION_ID: "aaaaaaaa-0000-0000-0000-000000000000" };
+    expect(
+      countBackgroundAgents({
+        agents: [bg("aaaaaaaa"), bg("bbbbbbbb")],
+        statJob: allAlive,
+        env,
+      }),
+    ).toBe(1);
+  });
+
+  test("counts a leaked-but-running worker so the scheduler cannot over-dispatch on top of it", () => {
+    // 1 alive bg session whose signal would read terminal — the live-count design
+    // (scheduler.mjs:4242) counts the PROCESS, not the signal scan. Pins it.
+    expect(countBackgroundAgents({ agents: [bg("a1111111")], statJob: allAlive })).toBe(1);
+  });
+
+  test("interactive never counted; unknown/absent kind fails low; interactive self still excluded", () => {
+    const env = { CLAUDE_CODE_SESSION_ID: "cccccccc" };
+    const mixed = [
+      bg("a1111111"), // background, counts
+      { sessionId: "bbbbbbbb-0000-0000-0000-000000000000", kind: "interactive" }, // not counted
+      { sessionId: "dddddddd-0000-0000-0000-000000000000" }, // no kind → fail-low
+      { sessionId: "cccccccc-0000-0000-0000-000000000000", kind: "interactive" }, // self + interactive
+    ];
+    expect(countBackgroundAgents({ agents: mixed, statJob: allAlive, env })).toBe(1);
+  });
+
+  test("self-exclusion is the FIRST gate: a self session is dropped even if its job dir is gone (never throws, never counts)", () => {
+    const env = { CLAUDE_CODE_SESSION_ID: "aaaaaaaa" };
+    // statJob would classify it dead anyway, but the point is self is dropped up-front.
+    expect(
+      countBackgroundAgents({ agents: [bg("aaaaaaaa")], statJob: () => null, env }),
+    ).toBe(0);
+  });
+
+  test("per-ticket duplicate workers each counted (two bg sessions, same ticket)", () => {
+    expect(
+      countBackgroundAgents({ agents: [bg("a1111111"), bg("a2222222")], statJob: allAlive }),
+    ).toBe(2);
+  });
+
+  test("reboot-survivor status:null background zombie is counted-as-occupying (working job dir)", () => {
+    // A status:null background session whose job dir is still present + working
+    // holds a real slot — it MUST count (the invariant a 'skip unknown status'
+    // optimization could silently break into over-dispatch).
+    const statJob = () => ({ state: "working", firstTerminalAt: null });
+    expect(
+      countBackgroundAgents({ agents: [bg("a1111111", { status: null })], statJob }),
+    ).toBe(1);
+  });
+
+  test("status:null zombie whose job dir is GONE → 0 (CTL-1055 ghost exclusion, regression fence)", () => {
+    expect(
+      countBackgroundAgents({ agents: [bg("a1111111", { status: null })], statJob: () => null }),
+    ).toBe(0);
+  });
+});
+
 describe("claudeStop", () => {
   test("issues `claude stop <shortId>` and reports ok on rc 0", () => {
     const calls = [];

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -401,6 +401,102 @@ export function readMemorySamplerConfig() {
   };
 }
 
+// CTL-1165 D5 — pre-exhaustion fleet-health guardrail config. Re-reads from
+// process.env on every call (mirrors readMemorySamplerConfig) so tests mutate
+// env freely. Three-layer precedence per knob: env > Layer-1
+// (catalyst.orchestration.fleetHealth in .catalyst/config.json) > code default.
+// `selfHealEnabled` DEFAULTS OFF — the first ship is a pure alert; nothing is
+// reaped until an operator opts in via EXECUTION_CORE_FLEET_SELF_HEAL.
+const FLEET_HEALTH_DEFAULTS = Object.freeze({
+  enabled: true,
+  intervalMs: 120_000,
+  jobsThreshold: 500,
+  swapUsedMbThreshold: 4096,
+  agentsThreshold: 12,
+  procsThreshold: 40,
+  selfHealEnabled: false,
+  sustainedTicks: 2,
+});
+
+// readFleetHealthConfigLayer1 — pull catalyst.orchestration.fleetHealth out of a
+// project's .catalyst/config.json. Returns {} for a null/missing/unparseable
+// file or absent key so callers fall back to env/defaults. Never throws.
+export function readFleetHealthConfigLayer1(configPath) {
+  if (!configPath) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(configPath, "utf8"));
+    const fh = parsed?.catalyst?.orchestration?.fleetHealth;
+    return fh && typeof fh === "object" ? fh : {};
+  } catch (err) {
+    if (err?.code !== "ENOENT") {
+      log.warn({ configPath, err: err.message }, "fleet-health: Layer-1 config unreadable; using defaults");
+    }
+    return {};
+  }
+}
+
+function fleetHealthNumber(envVal, l1Val, def) {
+  for (const v of [envVal, l1Val]) {
+    if (v === undefined || v === null || v === "") continue;
+    const n = Number(v);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  return def;
+}
+
+export function readFleetHealthConfig(configPath) {
+  const l1 = readFleetHealthConfigLayer1(configPath);
+  return {
+    // env=0 disables; otherwise Layer-1 enabled===false disables; else default-on.
+    enabled:
+      process.env.CATALYST_FLEET_HEALTH === "0"
+        ? false
+        : l1.enabled === false
+          ? false
+          : FLEET_HEALTH_DEFAULTS.enabled,
+    intervalMs: fleetHealthNumber(
+      process.env.EXECUTION_CORE_FLEET_HEALTH_INTERVAL_MS,
+      l1.intervalMs,
+      FLEET_HEALTH_DEFAULTS.intervalMs,
+    ),
+    jobsThreshold: fleetHealthNumber(
+      process.env.EXECUTION_CORE_FLEET_JOBS_THRESHOLD,
+      l1.jobsThreshold,
+      FLEET_HEALTH_DEFAULTS.jobsThreshold,
+    ),
+    swapUsedMbThreshold: fleetHealthNumber(
+      process.env.EXECUTION_CORE_FLEET_SWAP_MB_THRESHOLD,
+      l1.swapUsedMbThreshold,
+      FLEET_HEALTH_DEFAULTS.swapUsedMbThreshold,
+    ),
+    agentsThreshold: fleetHealthNumber(
+      process.env.EXECUTION_CORE_FLEET_AGENTS_THRESHOLD,
+      l1.agentsThreshold,
+      FLEET_HEALTH_DEFAULTS.agentsThreshold,
+    ),
+    procsThreshold: fleetHealthNumber(
+      process.env.EXECUTION_CORE_FLEET_PROCS_THRESHOLD,
+      l1.procsThreshold,
+      FLEET_HEALTH_DEFAULTS.procsThreshold,
+    ),
+    // Self-heal: env=1 enables; otherwise Layer-1 selfHealEnabled===true enables;
+    // else DEFAULT OFF (emit-only).
+    selfHealEnabled:
+      process.env.EXECUTION_CORE_FLEET_SELF_HEAL === "1"
+        ? true
+        : process.env.EXECUTION_CORE_FLEET_SELF_HEAL === "0"
+          ? false
+          : l1.selfHealEnabled === true
+            ? true
+            : FLEET_HEALTH_DEFAULTS.selfHealEnabled,
+    sustainedTicks: fleetHealthNumber(
+      process.env.EXECUTION_CORE_FLEET_SUSTAINED_TICKS,
+      l1.sustainedTicks,
+      FLEET_HEALTH_DEFAULTS.sustainedTicks,
+    ),
+  };
+}
+
 // CTL-787 — account-level Claude rate-limit usage poller. Re-reads from
 // process.env on every call so tests can manipulate env vars freely (mirrors
 // readMemorySamplerConfig). The poller floors intervalMs at 180s internally;

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -409,7 +409,9 @@ export function startDaemon({
   // by a config knob (default-on, CATALYST_FLEET_HEALTH=0 disables) like the
   // memory sampler. The probe is EMIT-ONLY by default (self-heal default OFF).
   startFleetHealthProbe = realStartFleetHealthProbe,
-  enableFleetHealth = readFleetHealthConfig().enabled,
+  // undefined → resolve from config (env + Layer-1 via configPath) in the boot
+  // body below; tests may force true/false and that wins via `??`.
+  enableFleetHealth = undefined,
   // CTL-787: account-level rate-limit usage poller. Injectable for tests; gated
   // by a config knob (default-on, CATALYST_RATELIMIT_POLLER=0 disables) like the
   // memory sampler.
@@ -651,9 +653,14 @@ export function startDaemon({
 
     // CTL-1165 D5: start the pre-exhaustion fleet-health probe. EMIT-ONLY by
     // default (self-heal default OFF — first ship is a pure alert). Inside the
-    // same try/catch so a throw triggers PID-file cleanup via stopDaemon.
-    if (enableFleetHealth) {
-      _fleetHealthProbe = startFleetHealthProbe({ orchDir });
+    // same try/catch so a throw triggers PID-file cleanup via stopDaemon. The
+    // config is resolved WITH configPath (mirroring readOrphanReaperConfig) so
+    // the documented Layer-1 catalyst.orchestration.fleetHealth knobs — enable,
+    // thresholds, and selfHealEnabled — actually take effect in production, and
+    // is passed to the probe so it reads the SAME resolved thresholds.
+    const fleetHealthConfig = readFleetHealthConfig(configPath);
+    if (enableFleetHealth ?? fleetHealthConfig.enabled) {
+      _fleetHealthProbe = startFleetHealthProbe({ orchDir, config: fleetHealthConfig });
     }
 
     // CTL-787: start the account-level rate-limit usage poller. Inside the same

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -63,6 +63,7 @@ import {
 import { Reaper, defaultReadActivePhaseSignal, defaultReadSignalBgJobId } from "./reaper.mjs";
 import { startOrphanReaperTimer, readOrphanReaperConfig } from "./orphan-reaper-timer.mjs";
 import { sweepJobDirs } from "./job-dir-gc.mjs"; // CTL-1165 D3: ~/.claude/jobs/<id> dir GC
+import { ProcReaper } from "./proc-reaper.mjs"; // CTL-1165 D2: orphan child-process reaper (default shadow)
 import {
   startWorktreeRefreshTimer,
   readWorktreeRefreshConfig,
@@ -729,10 +730,33 @@ function startReaperAndTimer({
   // CTL-661: bind the per-ticket reconciler's canonical-owner reader to this
   // daemon's orchDir so the sweep resolves the authoritative active-phase
   // bg_job_id (falling back to newest-by-last_seen when no signal is found).
+  // CTL-1165 D2: construct the production orphan child-process reaper and inject
+  // it into the Reaper. DEFAULT mode:"shadow" (emits procOrphans.would-reap, kills
+  // NOTHING) so the allowlist + LIVE_TREE correlation bakes on mini before any
+  // enforce flip — exactly like stall-janitor (CTL-1004) and cost-cap (CTL-1137).
+  // mode/graceMs/worktreeRoot/allowlistPatterns come from
+  // orphanReaper.procReaper; the daemon's own pid is on the never-kill list
+  // (selfPid defaults to process.pid; broker/monitor are covered by the argv
+  // allowlist patterns). A disabled config ("off") makes every sweep an empty
+  // no-op.
+  const procCfg = orphanReaperConfig?.procReaper ?? {};
+  const procReaper = new ProcReaper({
+    mode: procCfg.mode ?? "shadow",
+    ...(procCfg.graceMs != null ? { graceMs: Number(procCfg.graceMs) } : {}),
+    ...(procCfg.minEtimeSec != null ? { minEtimeSec: Number(procCfg.minEtimeSec) } : {}),
+    ...(procCfg.worktreeRoot ? { worktreeRoot: procCfg.worktreeRoot } : {}),
+    ...(Array.isArray(procCfg.allowlistPatterns)
+      ? { allowlistPatterns: procCfg.allowlistPatterns }
+      : {}),
+    daemonPids: [process.pid],
+    log,
+  });
+
   _reaper = makeReaper({
     minIdleMs: (orphanReaperConfig?.minIdleSeconds ?? 900) * 1000,
     readActivePhaseSignal: (ticket) => defaultReadActivePhaseSignal(orchDir, ticket),
     readSignalBgJobId: (ticket, phase) => defaultReadSignalBgJobId(orchDir, ticket, phase),
+    procReaper,
   });
 
   // Boot replay: cover for any intents that landed while the daemon was down.

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -33,6 +33,7 @@ import {
   getExecutionCoreDir,
   getRegistryPath,
   getEventLogPath,
+  getJobsRoot,      // CTL-1165 D3: job-dir GC root
   log,
   EVENT_DEBOUNCE_MS,
   TAILER_POLL_INTERVAL_MS,
@@ -61,6 +62,7 @@ import {
 } from "./index.mjs";
 import { Reaper, defaultReadActivePhaseSignal, defaultReadSignalBgJobId } from "./reaper.mjs";
 import { startOrphanReaperTimer, readOrphanReaperConfig } from "./orphan-reaper-timer.mjs";
+import { sweepJobDirs } from "./job-dir-gc.mjs"; // CTL-1165 D3: ~/.claude/jobs/<id> dir GC
 import {
   startWorktreeRefreshTimer,
   readWorktreeRefreshConfig,
@@ -96,7 +98,7 @@ import { removeLabel as defaultRemoveLabel } from "./linear-write.mjs"; // CTL-5
 // so the phantom worker-dir validity sweep is operative in production.
 import { classifyTicketResolution } from "./linear-query.mjs";
 import { createGatewayReader } from "./gateway-read.mjs";
-import { isBgJobAlive, refreshAgents } from "./claude-agents.mjs";
+import { isBgJobAlive, refreshAgents, listClaudeAgentsResult } from "./claude-agents.mjs"; // CTL-1165 D3: fail-closed liveness reader for job-dir GC
 
 const DEFAULT_MAX_PARALLEL = 3;
 
@@ -774,9 +776,29 @@ function startReaperAndTimer({
   }
 
   const cfg = orphanReaperConfig ?? {};
+  // CTL-1165 D3: bind the real ~/.claude/jobs/<id> dir GC onto the same 600s
+  // orphan-reaper cadence (no new daemon timer). Default-on; an operator can
+  // disable via .catalyst → orphanReaper.jobGc.enabled:false. retention/batchCap
+  // come from config (env still wins inside sweepJobDirs's defaults). A no-op
+  // async closure is bound when disabled so the timer's Promise.all stays
+  // uniform.
+  const jobGcCfg = cfg.jobGc ?? {};
+  const jobGcEnabled = jobGcCfg.enabled !== false;
+  const jobGc = jobGcEnabled
+    ? () =>
+        sweepJobDirs({
+          jobsRoot: getJobsRoot(),
+          readAgents: () => listClaudeAgentsResult(),
+          ...(jobGcCfg.retentionSeconds != null
+            ? { retentionMs: Number(jobGcCfg.retentionSeconds) * 1000 }
+            : {}),
+          ...(jobGcCfg.batchCap != null ? { batchCap: Number(jobGcCfg.batchCap) } : {}),
+        })
+    : async () => {};
   _orphanTimer = startOrphanReaperTimer({
     enabled: cfg.enabled !== false,
     intervalSeconds: cfg.intervalSeconds ?? 600,
+    jobGc,
   });
 
   // CTL-707: start the periodic worktree-refresh timer.

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -39,6 +39,7 @@ import {
   TAILER_POLL_INTERVAL_MS,
   readWaitWatcherConfig,
   readMemorySamplerConfig,
+  readFleetHealthConfig, // CTL-1165 D5: fleet-health guardrail config (selfHeal default OFF)
   readRatelimitPollerConfig,
   getHostName,      // CTL-862
   getClusterHosts,  // CTL-862
@@ -46,6 +47,7 @@ import {
 import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
 import { startWaitWatcher as realStartWaitWatcher } from "./wait-watcher.mjs";
 import { startMemorySampler as realStartMemorySampler } from "./memory-sampler.mjs";
+import { startFleetHealthProbe as realStartFleetHealthProbe } from "./fleet-health-probe.mjs"; // CTL-1165 D5: pre-exhaustion fleet-health guardrail
 import { startRatelimitPoller as realStartRatelimitPoller } from "./ratelimit-poller.mjs";
 import { listProjects as realListProjects } from "./registry.mjs"; // CTL-854: boot health check
 import { startHeartbeat as realStartHeartbeat } from "./heartbeat-event.mjs"; // CTL-859: node.heartbeat emitter
@@ -119,6 +121,8 @@ let _stalePrRescueTimer = null;
 let _waitWatcher = null;
 // CTL-685: per-worker memory sampler handle.
 let _memorySampler = null;
+// CTL-1165 D5: pre-exhaustion fleet-health probe handle.
+let _fleetHealthProbe = null;
 // CTL-787: account-level rate-limit usage poller handle.
 let _ratelimitPoller = null;
 // CTL-859: node-heartbeat emitter handle (distributed-coordination foundation).
@@ -401,6 +405,11 @@ export function startDaemon({
   // knob (default-on, CATALYST_MEMORY_SAMPLER=0 disables) like the wait-watcher.
   startMemorySampler = realStartMemorySampler,
   enableMemorySampler = readMemorySamplerConfig().enabled,
+  // CTL-1165 D5: pre-exhaustion fleet-health probe. Injectable for tests; gated
+  // by a config knob (default-on, CATALYST_FLEET_HEALTH=0 disables) like the
+  // memory sampler. The probe is EMIT-ONLY by default (self-heal default OFF).
+  startFleetHealthProbe = realStartFleetHealthProbe,
+  enableFleetHealth = readFleetHealthConfig().enabled,
   // CTL-787: account-level rate-limit usage poller. Injectable for tests; gated
   // by a config knob (default-on, CATALYST_RATELIMIT_POLLER=0 disables) like the
   // memory sampler.
@@ -638,6 +647,13 @@ export function startDaemon({
     // a throw triggers PID-file cleanup via stopDaemon.
     if (enableMemorySampler) {
       _memorySampler = startMemorySampler();
+    }
+
+    // CTL-1165 D5: start the pre-exhaustion fleet-health probe. EMIT-ONLY by
+    // default (self-heal default OFF — first ship is a pure alert). Inside the
+    // same try/catch so a throw triggers PID-file cleanup via stopDaemon.
+    if (enableFleetHealth) {
+      _fleetHealthProbe = startFleetHealthProbe({ orchDir });
     }
 
     // CTL-787: start the account-level rate-limit usage poller. Inside the same
@@ -1036,6 +1052,15 @@ export function stopDaemon() {
       log.warn({ err: err?.message }, "stopDaemon: memory-sampler stop failed");
     }
     _memorySampler = null;
+  }
+  // CTL-1165 D5: stop the pre-exhaustion fleet-health probe.
+  if (_fleetHealthProbe) {
+    try {
+      _fleetHealthProbe.stop();
+    } catch (err) {
+      log.warn({ err: err?.message }, "stopDaemon: fleet-health-probe stop failed");
+    }
+    _fleetHealthProbe = null;
   }
   // CTL-787: stop the account-level rate-limit usage poller.
   if (_ratelimitPoller) {

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -653,6 +653,61 @@ describe("startDaemon", () => {
     expect(() => stopDaemon()).not.toThrow();
     expect(stopped).toBe(1);
   });
+
+  // CTL-1165 D5: the pre-exhaustion fleet-health probe is started from
+  // startDaemon (default-on), gated by enableFleetHealth, and stopped in
+  // stopDaemon — mirroring the CTL-685 memory-sampler wiring exactly.
+  test("starts the fleet-health probe when enabled (CTL-1165 D5)", () => {
+    let started = 0;
+    startDaemon({
+      recover: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+      startFleetHealthProbe: () => {
+        started++;
+        return { stop: () => {} };
+      },
+      enableFleetHealth: true,
+    });
+    expect(started).toBe(1);
+  });
+
+  test("skips the fleet-health probe when disabled (CTL-1165 D5)", () => {
+    let started = 0;
+    startDaemon({
+      recover: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+      startFleetHealthProbe: () => {
+        started++;
+        return { stop: () => {} };
+      },
+      enableFleetHealth: false,
+    });
+    expect(started).toBe(0);
+  });
+
+  test("stopDaemon stops the fleet-health probe and swallows a throwing stop() (CTL-1165 D5)", () => {
+    let stopped = 0;
+    startDaemon({
+      recover: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+      startFleetHealthProbe: () => ({
+        stop: () => {
+          stopped++;
+          throw new Error("simulated probe stop failure");
+        },
+      }),
+      enableFleetHealth: true,
+    });
+    // Must not throw even though stop() throws
+    expect(() => stopDaemon()).not.toThrow();
+    expect(stopped).toBe(1);
+  });
 });
 
 // CTL-678 — main()-side resolver: pre-merge Layer-1 (committed seed) under

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -982,6 +982,40 @@ describe("startReaperAndTimer — poll fallback drains reap-intents (CTL-769)", 
   });
 });
 
+// CTL-1165 D2: the daemon constructs the production orphan child-process reaper
+// (ProcReaper, DEFAULT mode:"shadow") and injects it into the Reaper via the
+// makeReaper opts, so reaper.mjs's procOrphans.reap-requested case has a real
+// sweeper to drive (no-op until injected).
+describe("startReaperAndTimer — injects a production ProcReaper (CTL-1165 D2)", () => {
+  test("makeReaper receives a procReaper whose sweep is a function, defaulting to shadow mode", () => {
+    let capturedOpts = null;
+    const fakeReaper = {
+      handle: () => Promise.resolve(),
+      bootReplay: () => Promise.resolve(),
+    };
+    startDaemon({
+      recover: () => {},
+      reconcileBoot: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+      enableReaper: true,
+      makeReaper: (opts) => {
+        capturedOpts = opts;
+        return fakeReaper;
+      },
+      pollMs: 0, // no poll interval needed for this assertion
+      debounceMs: 600_000,
+    });
+    expect(capturedOpts).not.toBeNull();
+    expect(capturedOpts.procReaper).toBeTruthy();
+    expect(typeof capturedOpts.procReaper.sweep).toBe("function");
+    // Default-safe: shadow mode emits would-reap, kills nothing.
+    expect(capturedOpts.procReaper.mode).toBe("shadow");
+    stopDaemon();
+  });
+});
+
 // CTL-701 Phase 3: boot marker exists when recover() (detectColdStart) reads it
 describe("startDaemon — writeBootMarker ordering (CTL-701)", () => {
   test("daemon-boot.json written BEFORE recover() runs", () => {

--- a/plugins/dev/scripts/execution-core/fleet-health-event.mjs
+++ b/plugins/dev/scripts/execution-core/fleet-health-event.mjs
@@ -1,0 +1,92 @@
+// fleet-health-event.mjs — CTL-1165 D5. Fleet-health event builder + best-effort
+// appender. Mirrors memory-event.mjs / heartbeat-event.mjs's shape (OTel
+// envelope, appendFileSync, never throws) so orch-monitor/HUD parsers treat
+// these events identically.
+//
+// One event name:
+//   fleet.health.degraded — WARN, emitted once per tick while a steady-state
+//   degradation signal (jobs-dir count, live bg-agent count, resident
+//   worker-proc count, macOS swap pressure) is over threshold.
+//
+// The host lives in the `resource` block (host.name / host.id), NOT in the
+// dotted event name — the monitor composes `fleet.health.degraded.<host>` by
+// reading the resource, exactly as it does for every other execution-core
+// emitter. Encoding the host into the event name would fragment the stream.
+
+import { mkdirSync, appendFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getEventLogPath, log } from "./config.mjs";
+import { hostName, hostId } from "./lib/host-identity.mjs";
+
+export const FLEET_HEALTH_DEGRADED = "fleet.health.degraded";
+
+/**
+ * buildFleetHealthEnvelope — assemble the canonical OTel envelope for a
+ * fleet.health.degraded event. Pure (modulo random id + timestamp); no I/O.
+ *
+ * @param {object} payload  { jobsCount, agentsCount, procsCount, swapUsedMb, tripped, sustained_n }
+ * @param {object} [opts]
+ * @param {Function} [opts.now]  injectable timestamp fn (returns ISO string)
+ * @returns {object} the envelope object
+ */
+export function buildFleetHealthEnvelope(payload = {}, { now } = {}) {
+  const ts = now ? now() : new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const {
+    jobsCount = null,
+    agentsCount = null,
+    procsCount = null,
+    swapUsedMb = null,
+    tripped = [],
+    sustained_n = null,
+  } = payload;
+
+  return {
+    ts,
+    id: randomBytes(8).toString("hex"),
+    observedTs: ts,
+    severityText: "WARN",
+    severityNumber: 13,
+    traceId: null,
+    spanId: null,
+    resource: {
+      "service.name": "catalyst.execution-core",
+      "service.namespace": "catalyst",
+      "host.name": hostName(),
+      "host.id": hostId(),
+    },
+    attributes: {
+      "event.name": FLEET_HEALTH_DEGRADED,
+      "event.entity": "fleet",
+      "event.action": "degraded",
+      "event.label": Array.isArray(tripped) && tripped.length ? tripped.join(",") : "fleet",
+    },
+    body: {
+      payload: {
+        jobsCount,
+        agentsCount,
+        procsCount,
+        swapUsedMb,
+        tripped,
+        sustained_n,
+      },
+    },
+  };
+}
+
+/**
+ * emitFleetHealthEvent — build + append one envelope line to the event log.
+ * Returns true on success, false on any failure (best-effort; NEVER throws — the
+ * guardrail must never wedge the daemon). `logPath` is injectable for tests.
+ */
+export function emitFleetHealthEvent(payload, { logPath = getEventLogPath(), now } = {}) {
+  const line = `${JSON.stringify(buildFleetHealthEnvelope(payload, { now }))}\n`;
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, line);
+    return true;
+  } catch (err) {
+    log.warn({ err: err?.message }, "fleet-health-event: event append failed");
+    return false;
+  }
+}

--- a/plugins/dev/scripts/execution-core/fleet-health-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/fleet-health-event.test.mjs
@@ -1,0 +1,122 @@
+// fleet-health-event.test.mjs — CTL-1165 D5. OTel fleet-health event builder +
+// best-effort appender. buildFleetHealthEnvelope is asserted without touching
+// the FS; emitFleetHealthEvent is exercised against a temp event log. Mirrors
+// memory-event.test.mjs / heartbeat-event.test.mjs.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test fleet-health-event.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildFleetHealthEnvelope,
+  emitFleetHealthEvent,
+  FLEET_HEALTH_DEGRADED,
+} from "./fleet-health-event.mjs";
+
+const basePayload = {
+  jobsCount: 750,
+  agentsCount: 14,
+  procsCount: 52,
+  swapUsedMb: 5000,
+  tripped: ["jobs", "agents"],
+  sustained_n: 1,
+};
+
+describe("buildFleetHealthEnvelope", () => {
+  test("degraded event has WARN severity and the canonical event name", () => {
+    const env = buildFleetHealthEnvelope(basePayload);
+    expect(env.severityText).toBe("WARN");
+    expect(env.severityNumber).toBe(13);
+    expect(env.attributes["event.name"]).toBe(FLEET_HEALTH_DEGRADED);
+    expect(env.attributes["event.action"]).toBe("degraded");
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+  });
+
+  test("host lives in the resource block, NOT in the dotted event name", () => {
+    const env = buildFleetHealthEnvelope(basePayload);
+    // The monitor composes fleet.health.degraded.<host> from resource; the
+    // emitted event.name stays the bare 'fleet.health.degraded'.
+    expect(env.attributes["event.name"]).toBe("fleet.health.degraded");
+    expect(env.attributes["event.name"]).not.toMatch(/fleet\.health\.degraded\./);
+    expect(typeof env.resource["host.name"]).toBe("string");
+    expect("host.id" in env.resource).toBe(true);
+  });
+
+  test("body.payload carries all four readings + tripped + sustained_n", () => {
+    const env = buildFleetHealthEnvelope(basePayload);
+    expect(env.body.payload).toMatchObject({
+      jobsCount: 750,
+      agentsCount: 14,
+      procsCount: 52,
+      swapUsedMb: 5000,
+      tripped: ["jobs", "agents"],
+      sustained_n: 1,
+    });
+  });
+
+  test("null/sentinel readings survive into the payload untouched", () => {
+    const env = buildFleetHealthEnvelope({
+      jobsCount: null,
+      agentsCount: null,
+      procsCount: null,
+      swapUsedMb: 0,
+      tripped: [],
+      sustained_n: 1,
+    });
+    expect(env.body.payload.jobsCount).toBe(null);
+    expect(env.body.payload.swapUsedMb).toBe(0);
+    expect(env.body.payload.tripped).toEqual([]);
+  });
+
+  test("ts is a Z-suffixed timestamp with no millisecond fraction", () => {
+    const env = buildFleetHealthEnvelope(basePayload);
+    expect(env.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  test("injectable now() overrides the timestamp", () => {
+    const fixed = "2026-06-14T12:00:00Z";
+    const env = buildFleetHealthEnvelope(basePayload, { now: () => fixed });
+    expect(env.ts).toBe(fixed);
+    expect(env.observedTs).toBe(fixed);
+  });
+
+  test("envelope has id random hex field", () => {
+    const env = buildFleetHealthEnvelope(basePayload);
+    expect(env.id).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+describe("emitFleetHealthEvent", () => {
+  test("appends exactly one valid WARN JSON line and returns true", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1165-fhe-"));
+    const logPath = join(dir, "2026-06.jsonl");
+    const ok = emitFleetHealthEvent(basePayload, { logPath });
+    expect(ok).toBe(true);
+    const lines = readFileSync(logPath, "utf8").trim().split("\n");
+    expect(lines.length).toBe(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.attributes["event.name"]).toBe(FLEET_HEALTH_DEGRADED);
+    expect(parsed.severityText).toBe("WARN");
+    expect(parsed.body.payload.jobsCount).toBe(750);
+  });
+
+  test("creates the parent directory when missing (never throws)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1165-fhe-"));
+    const logPath = join(dir, "nested", "deep", "2026-06.jsonl");
+    expect(emitFleetHealthEvent(basePayload, { logPath })).toBe(true);
+    const lines = readFileSync(logPath, "utf8").trim().split("\n");
+    expect(lines.length).toBe(1);
+  });
+
+  test("returns false and does not throw for an unwritable logPath", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1165-fhe-bad-"));
+    let result;
+    expect(() => {
+      // logPath is the dir itself (not a file) — appendFileSync throws EISDIR
+      result = emitFleetHealthEvent(basePayload, { logPath: dir });
+    }).not.toThrow();
+    expect(result).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/fleet-health-probe.mjs
+++ b/plugins/dev/scripts/execution-core/fleet-health-probe.mjs
@@ -1,0 +1,278 @@
+// fleet-health-probe.mjs — CTL-1165 D5. Pre-exhaustion fleet-health guardrail.
+//
+// Every ~120s it reads four steady-state degradation signals — the
+// ~/.claude/jobs dir count, the live background-agent count, the resident
+// worker-proc count, and macOS swap-used MB — each wrapped in safe() so a read
+// failure returns a NON-CROSSING sentinel rather than crashing the tick or
+// faking a healthy reading. A pure classifyFleetHealth decides whether any
+// signal crossed its threshold; on a breach it emits ONE fleet.health.degraded
+// event (host in the OTel resource, not the dotted name).
+//
+// Self-heal is DEFAULT OFF (selfHealEnabled): the first ship is a pure alert.
+// When enabled, it fires the SAME two reap intents the 600s orphan-reaper timer
+// emits (orphans.reap-requested + phase.reconcile.reap-requested) plus a bounded
+// ppid===1 node/bun child sweep — ONCE per sustained breach episode, re-armed
+// only after a healthy tick (hysteresis). It never gains new reaping authority.
+//
+// All side effects are injected (clock, readers, emit, triggerSelfHeal) so
+// tick() is fully unit-testable with no real timer, sysctl, ps, or kill. Models
+// memory-sampler.mjs byte-for-byte.
+
+import { execFileSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { getAgentsCached } from "./claude-agents.mjs";
+import { getJobsRoot, readFleetHealthConfig, log } from "./config.mjs";
+import { emitFleetHealthEvent } from "./fleet-health-event.mjs";
+import { emitReapIntent } from "./reap-intent.mjs";
+
+const FLEET_REAP_CHILD_CAP = 25; // bound the self-heal child sweep
+
+function realClock() {
+  return {
+    setInterval: (fn, ms) => setInterval(fn, ms),
+    clearInterval: (handle) => clearInterval(handle),
+  };
+}
+
+// safe() — run a reader, returning its value, or the supplied NON-CROSSING
+// sentinel on any throw. The sentinel must be a value that can never trip a
+// threshold (null for counts; 0 for swap), so an unreadable signal can only
+// cause the guardrail to UNDER-react — never to over-react / over-reap.
+function safe(fn, sentinel) {
+  try {
+    const v = fn();
+    return v === undefined || v === null ? sentinel : v;
+  } catch {
+    return sentinel;
+  }
+}
+
+// defaultReadJobsCount — count of ~/.claude/jobs/<id> dirs. try/catch → null
+// (non-crossing) so a missing/unreadable jobs root never trips the guardrail.
+export function defaultReadJobsCount() {
+  try {
+    return readdirSync(getJobsRoot()).length;
+  } catch {
+    return null;
+  }
+}
+
+// defaultPsLines — `ps -axo pid=,ppid=,command=` lines. Best-effort `[]` on
+// failure. command= (not comm=) preserves the full argv so node/bun detection
+// in the proc count + child sweep is exact.
+export function defaultPsLines() {
+  try {
+    const out = execFileSync("ps", ["-axo", "pid=,ppid=,command="], {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return out.split("\n");
+  } catch {
+    return [];
+  }
+}
+
+// defaultReadProcsCount — count resident node/bun worker processes from the ps
+// snapshot. A null/empty snapshot yields 0 (non-crossing safe sentinel handled
+// by the caller's safe()).
+export function defaultReadProcsCount(psLines = defaultPsLines) {
+  const lines = psLines() ?? [];
+  let n = 0;
+  for (const line of lines) {
+    const m = line.trim().match(/^(\d+)\s+(\d+)\s+(.*)$/);
+    if (!m) continue;
+    const command = m[3];
+    if (/\b(?:node|bun)\b/.test(command)) n++;
+  }
+  return n;
+}
+
+// defaultReadSwapUsedMb — parse macOS `sysctl -n vm.swapusage`'s `used = N.NNM`
+// field → integer MB. Non-darwin / parse-error / throw → 0 (safe sentinel,
+// non-crossing). run/platform are injectable for tests.
+export function defaultReadSwapUsedMb({
+  platform = process.platform,
+  run = () => execFileSync("sysctl", ["-n", "vm.swapusage"], { encoding: "utf8" }),
+} = {}) {
+  if (platform !== "darwin") return 0;
+  let out;
+  try {
+    out = run();
+  } catch {
+    return 0;
+  }
+  const m = /used\s*=\s*([\d.]+)M/.exec(out ?? "");
+  if (!m) return 0;
+  const mb = Number(m[1]);
+  return Number.isFinite(mb) ? Math.round(mb) : 0;
+}
+
+// defaultReapOrphanChildren — NET-NEW bounded sweep. Kills ONLY reparented
+// (ppid===1) node/bun processes, capped at maxPerSweep, never the daemon's own
+// pid(s). Best-effort: a throwing kill is swallowed. Returns the count reaped.
+// (D2's proc-reaper.mjs is the corroboration-heavy enforcement path; this is the
+// guardrail's last-resort bounded backstop.)
+export function defaultReapOrphanChildren({
+  psLines = defaultPsLines,
+  kill = process.kill,
+  daemonPids = [],
+  maxPerSweep = FLEET_REAP_CHILD_CAP,
+} = {}) {
+  const lines = psLines() ?? [];
+  const skip = new Set(daemonPids.map((p) => Number(p)));
+  let reaped = 0;
+  for (const line of lines) {
+    if (reaped >= maxPerSweep) break;
+    const m = line.trim().match(/^(\d+)\s+(\d+)\s+(.*)$/);
+    if (!m) continue;
+    const pid = Number(m[1]);
+    const ppid = Number(m[2]);
+    const command = m[3];
+    if (ppid !== 1) continue; // only reparented orphans
+    if (!/\b(?:node|bun)\b/.test(command)) continue; // only node/bun
+    if (skip.has(pid)) continue; // never the daemon's own tree
+    try {
+      kill(pid, "SIGTERM");
+      reaped++;
+    } catch {
+      /* ESRCH / EPERM — best-effort */
+    }
+  }
+  return reaped;
+}
+
+// defaultTriggerSelfHeal — fire the SAME two reap intents the 600s orphan-reaper
+// timer emits, then run the bounded child sweep. All best-effort; NEVER throws
+// (the guardrail must never wedge the daemon). Each step is independently
+// guarded so a failing emit cannot suppress the sweep.
+export async function defaultTriggerSelfHeal({
+  emitIntent = emitReapIntent,
+  reapChildren = defaultReapOrphanChildren,
+  daemonPids = [],
+} = {}) {
+  try {
+    await emitIntent("orphans.reap-requested", {});
+  } catch {
+    /* best-effort */
+  }
+  try {
+    await emitIntent("phase.reconcile.reap-requested", {});
+  } catch {
+    /* best-effort */
+  }
+  try {
+    reapChildren({ daemonPids });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * classifyFleetHealth — pure classifier from four readings + thresholds to a
+ * degraded verdict + the ordered list of tripped signals. Boundary-exact: a
+ * reading >= its threshold trips (mirrors classifyMemPressure). null/sentinel
+ * readings never trip (`null >= n` is false; swap's 0 sentinel is well below any
+ * realistic threshold).
+ *
+ * @param {object} readings  { jobsCount, agentsCount, procsCount, swapUsedMb }
+ * @param {object} thresholds { jobsThreshold, agentsThreshold, procsThreshold, swapUsedMbThreshold }
+ * @returns {{ degraded:boolean, tripped:string[] }}
+ */
+export function classifyFleetHealth(readings, thresholds) {
+  const { jobsCount, agentsCount, procsCount, swapUsedMb } = readings ?? {};
+  const { jobsThreshold, agentsThreshold, procsThreshold, swapUsedMbThreshold } =
+    thresholds ?? {};
+  const tripped = [];
+  if (jobsCount != null && jobsCount >= jobsThreshold) tripped.push("jobs");
+  if (agentsCount != null && agentsCount >= agentsThreshold) tripped.push("agents");
+  if (procsCount != null && procsCount >= procsThreshold) tripped.push("procs");
+  if (swapUsedMb != null && swapUsedMb >= swapUsedMbThreshold) tripped.push("swap");
+  return { degraded: tripped.length > 0, tripped };
+}
+
+/**
+ * startFleetHealthProbe — arm the periodic fleet-health tick. Returns { stop, tick }.
+ *
+ * @param {object} opts
+ * @param {object}   [opts.clock=realClock()]               fake-clock seam
+ * @param {object}   [opts.config=readFleetHealthConfig()]  thresholds + cadence + selfHeal knobs
+ * @param {Function} [opts.readJobsCount]                   ~/.claude/jobs dir count (sync)
+ * @param {Function} [opts.listAgents]                      live-session enumerator (sync)
+ * @param {Function} [opts.psLines]                         `ps -axo pid=,ppid=,command=` lines
+ * @param {Function} [opts.readSwapUsedMb]                  macOS swap-used MB
+ * @param {Function} [opts.emit]                            fleet.health.degraded emitter
+ * @param {Function} [opts.triggerSelfHeal]                 self-heal action (default OFF via config)
+ * @param {string}   [opts.orchDir]                         (reserved) daemon orch dir
+ */
+export function startFleetHealthProbe({
+  clock = realClock(),
+  config = readFleetHealthConfig(),
+  readJobsCount = defaultReadJobsCount,
+  // CTL-731: read the warm, never-blocking snapshot (mirrors memory-sampler).
+  listAgents = () => getAgentsCached().agents,
+  psLines = defaultPsLines,
+  readSwapUsedMb = defaultReadSwapUsedMb,
+  emit = emitFleetHealthEvent,
+  triggerSelfHeal = defaultTriggerSelfHeal,
+  orchDir = null,
+} = {}) {
+  const {
+    intervalMs,
+    selfHealEnabled,
+    sustainedTicks,
+    jobsThreshold,
+    agentsThreshold,
+    procsThreshold,
+    swapUsedMbThreshold,
+  } = config;
+  void orchDir;
+
+  let sustained = 0; // consecutive degraded ticks
+  let fired = false; // self-heal already fired this breach episode (re-armed on a healthy tick)
+
+  function tick() {
+    // Each signal read is wrapped so a throw yields a NON-CROSSING sentinel,
+    // never a faked-healthy reading and never a crash.
+    const jobsCount = safe(() => readJobsCount(), null);
+    const agentsCount = safe(() => (listAgents() ?? []).length, null);
+    const procsCount = safe(() => defaultReadProcsCount(psLines), null);
+    const swapUsedMb = safe(() => readSwapUsedMb(), 0);
+
+    const readings = { jobsCount, agentsCount, procsCount, swapUsedMb };
+    const { degraded, tripped } = classifyFleetHealth(readings, {
+      jobsThreshold,
+      agentsThreshold,
+      procsThreshold,
+      swapUsedMbThreshold,
+    });
+
+    if (!degraded) {
+      // Healthy tick: reset the sustained counter and re-arm the self-heal.
+      sustained = 0;
+      fired = false;
+      return;
+    }
+
+    sustained += 1;
+    try {
+      emit({ ...readings, tripped, sustained_n: sustained });
+    } catch (err) {
+      log.warn({ err: err?.message }, "fleet-health-probe: emit failed");
+    }
+
+    // Self-heal fires ONCE per sustained breach episode, boundary-exact at
+    // sustained === sustainedTicks, and only when explicitly enabled.
+    if (selfHealEnabled && !fired && sustained >= sustainedTicks) {
+      fired = true;
+      try {
+        triggerSelfHeal();
+      } catch (err) {
+        log.warn({ err: err?.message }, "fleet-health-probe: self-heal failed");
+      }
+    }
+  }
+
+  const handle = clock.setInterval(tick, intervalMs);
+  if (typeof handle?.unref === "function") handle.unref();
+  return { stop: () => clock.clearInterval(handle), tick };
+}

--- a/plugins/dev/scripts/execution-core/fleet-health-probe.mjs
+++ b/plugins/dev/scripts/execution-core/fleet-health-probe.mjs
@@ -9,10 +9,15 @@
 // event (host in the OTel resource, not the dotted name).
 //
 // Self-heal is DEFAULT OFF (selfHealEnabled): the first ship is a pure alert.
-// When enabled, it fires the SAME two reap intents the 600s orphan-reaper timer
-// emits (orphans.reap-requested + phase.reconcile.reap-requested) plus a bounded
-// ppid===1 node/bun child sweep — ONCE per sustained breach episode, re-armed
-// only after a healthy tick (hysteresis). It never gains new reaping authority.
+// When enabled, it fires the SAME reap intents the 600s orphan-reaper timer
+// emits — orphans.reap-requested + phase.reconcile.reap-requested (claude-session
+// sweeps) AND procOrphans.reap-requested (the orphan child-process sweep, routed
+// through D2's fully-gated, shadow-default proc-reaper) — ONCE per sustained
+// breach episode, re-armed only after a healthy tick (hysteresis). It gains NO
+// new reaping authority: a child process dies only if proc-reaper.mode is ALSO
+// 'enforce'. There is deliberately NO crude direct child-kill here — an
+// empty-skip-set ppid===1 node/bun sweep would SIGTERM the daemon/broker/monitor
+// themselves (they run as nohup'd node/bun reparented to launchd).
 //
 // All side effects are injected (clock, readers, emit, triggerSelfHeal) so
 // tick() is fully unit-testable with no real timer, sysctl, ps, or kill. Models
@@ -24,8 +29,6 @@ import { getAgentsCached } from "./claude-agents.mjs";
 import { getJobsRoot, readFleetHealthConfig, log } from "./config.mjs";
 import { emitFleetHealthEvent } from "./fleet-health-event.mjs";
 import { emitReapIntent } from "./reap-intent.mjs";
-
-const FLEET_REAP_CHILD_CAP = 25; // bound the self-heal child sweep
 
 function realClock() {
   return {
@@ -107,63 +110,28 @@ export function defaultReadSwapUsedMb({
   return Number.isFinite(mb) ? Math.round(mb) : 0;
 }
 
-// defaultReapOrphanChildren — NET-NEW bounded sweep. Kills ONLY reparented
-// (ppid===1) node/bun processes, capped at maxPerSweep, never the daemon's own
-// pid(s). Best-effort: a throwing kill is swallowed. Returns the count reaped.
-// (D2's proc-reaper.mjs is the corroboration-heavy enforcement path; this is the
-// guardrail's last-resort bounded backstop.)
-export function defaultReapOrphanChildren({
-  psLines = defaultPsLines,
-  kill = process.kill,
-  daemonPids = [],
-  maxPerSweep = FLEET_REAP_CHILD_CAP,
-} = {}) {
-  const lines = psLines() ?? [];
-  const skip = new Set(daemonPids.map((p) => Number(p)));
-  let reaped = 0;
-  for (const line of lines) {
-    if (reaped >= maxPerSweep) break;
-    const m = line.trim().match(/^(\d+)\s+(\d+)\s+(.*)$/);
-    if (!m) continue;
-    const pid = Number(m[1]);
-    const ppid = Number(m[2]);
-    const command = m[3];
-    if (ppid !== 1) continue; // only reparented orphans
-    if (!/\b(?:node|bun)\b/.test(command)) continue; // only node/bun
-    if (skip.has(pid)) continue; // never the daemon's own tree
+// defaultTriggerSelfHeal — fire the SAME reap intents the 600s orphan-reaper
+// timer emits: orphans.reap-requested + phase.reconcile.reap-requested (the
+// claude-session sweeps) AND procOrphans.reap-requested (the orphan
+// child-process sweep). The last routes through D2's proc-reaper, which carries
+// the full kill gate (LIVE_TREE / allowlist / cwd-under-worktree / etime floor /
+// CATASTROPHE GUARD) and is shadow-by-default — so self-heal gains ZERO new kill
+// authority and a child process dies only if proc-reaper.mode is ALSO 'enforce'.
+// There is deliberately NO crude direct child-kill here (a bare ppid===1 node/bun
+// SIGTERM with an empty skip set would take down the daemon/broker/monitor).
+// All best-effort; NEVER throws (the guardrail must never wedge the daemon); each
+// emit is independently guarded so one failure cannot suppress the others.
+export async function defaultTriggerSelfHeal({ emitIntent = emitReapIntent } = {}) {
+  for (const type of [
+    "orphans.reap-requested",
+    "phase.reconcile.reap-requested",
+    "procOrphans.reap-requested",
+  ]) {
     try {
-      kill(pid, "SIGTERM");
-      reaped++;
+      await emitIntent(type, {});
     } catch {
-      /* ESRCH / EPERM — best-effort */
+      /* best-effort — never wedge the daemon */
     }
-  }
-  return reaped;
-}
-
-// defaultTriggerSelfHeal — fire the SAME two reap intents the 600s orphan-reaper
-// timer emits, then run the bounded child sweep. All best-effort; NEVER throws
-// (the guardrail must never wedge the daemon). Each step is independently
-// guarded so a failing emit cannot suppress the sweep.
-export async function defaultTriggerSelfHeal({
-  emitIntent = emitReapIntent,
-  reapChildren = defaultReapOrphanChildren,
-  daemonPids = [],
-} = {}) {
-  try {
-    await emitIntent("orphans.reap-requested", {});
-  } catch {
-    /* best-effort */
-  }
-  try {
-    await emitIntent("phase.reconcile.reap-requested", {});
-  } catch {
-    /* best-effort */
-  }
-  try {
-    reapChildren({ daemonPids });
-  } catch {
-    /* best-effort */
   }
 }
 

--- a/plugins/dev/scripts/execution-core/fleet-health-probe.test.mjs
+++ b/plugins/dev/scripts/execution-core/fleet-health-probe.test.mjs
@@ -12,7 +12,6 @@ import {
   classifyFleetHealth,
   startFleetHealthProbe,
   defaultReadSwapUsedMb,
-  defaultReapOrphanChildren,
   defaultTriggerSelfHeal,
 } from "./fleet-health-probe.mjs";
 import { FLEET_HEALTH_DEGRADED } from "./fleet-health-event.mjs";
@@ -259,86 +258,42 @@ describe("defaultReadSwapUsedMb", () => {
   });
 });
 
-// ─── defaultReapOrphanChildren ───────────────────────────────────────────────
-
-describe("defaultReapOrphanChildren", () => {
-  test("selects only reparented (ppid===1) node/bun pids, never the daemon's own tree", () => {
-    const lines = [
-      "201 1 node /some/worker.mjs", // orphan node → kill
-      "202 1 bun run test", // orphan bun → kill
-      "203 555 node /child.mjs", // not reparented → spare
-      "204 1 ruby script.rb", // not node/bun → spare
-      "999 1 node /daemon.mjs", // daemon pid → spare
-    ];
-    const kills = [];
-    const reaped = defaultReapOrphanChildren({
-      psLines: () => lines,
-      kill: (pid, sig) => kills.push({ pid, sig }),
-      daemonPids: [999],
-    });
-    const killedPids = kills.map((k) => k.pid).sort((a, b) => a - b);
-    expect(killedPids).toEqual([201, 202]);
-    expect(reaped).toBe(2);
-  });
-
-  test("respects maxPerSweep cap (25)", () => {
-    const lines = Array.from({ length: 60 }, (_, i) => `${1000 + i} 1 node x`);
-    const kills = [];
-    const reaped = defaultReapOrphanChildren({
-      psLines: () => lines,
-      kill: (pid) => kills.push(pid),
-      maxPerSweep: 25,
-    });
-    expect(kills.length).toBe(25);
-    expect(reaped).toBe(25);
-  });
-
-  test("never throws when kill throws (best-effort)", () => {
-    const lines = ["201 1 node worker"];
-    expect(() =>
-      defaultReapOrphanChildren({
-        psLines: () => lines,
-        kill: () => {
-          throw new Error("ESRCH");
-        },
-      }),
-    ).not.toThrow();
-  });
-});
-
 // ─── defaultTriggerSelfHeal ──────────────────────────────────────────────────
 
 describe("defaultTriggerSelfHeal", () => {
-  test("emits both reap intents then sweeps children, never throws", async () => {
+  test("emits the three gated reap intents (incl procOrphans.reap-requested) and never kills directly", async () => {
     const intents = [];
-    const swept = [];
     await expect(
       defaultTriggerSelfHeal({
         emitIntent: async (name) => intents.push(name),
-        reapChildren: () => {
-          swept.push(true);
-          return 0;
-        },
       }),
     ).resolves.toBeUndefined();
-    expect(intents).toContain("orphans.reap-requested");
-    expect(intents).toContain("phase.reconcile.reap-requested");
-    expect(swept.length).toBe(1);
+    // CTL-1165 (hardened): self-heal routes the child sweep through the gated,
+    // shadow-default proc-reaper via procOrphans.reap-requested — it gains NO new
+    // kill authority and has NO direct ppid===1 node/bun SIGTERM path of its own
+    // (a bare sweep with an empty skip set would take down the daemon itself).
+    expect(intents).toEqual([
+      "orphans.reap-requested",
+      "phase.reconcile.reap-requested",
+      "procOrphans.reap-requested",
+    ]);
   });
 
-  test("a throwing emitIntent does not prevent the child sweep and never throws", async () => {
-    let swept = false;
+  test("a throwing emitIntent does not prevent the remaining intents and never throws", async () => {
+    const intents = [];
     await expect(
       defaultTriggerSelfHeal({
-        emitIntent: async () => {
-          throw new Error("event log unwritable");
-        },
-        reapChildren: () => {
-          swept = true;
-          return 0;
+        emitIntent: async (name) => {
+          intents.push(name);
+          if (name === "orphans.reap-requested") throw new Error("event log unwritable");
         },
       }),
     ).resolves.toBeUndefined();
-    expect(swept).toBe(true);
+    // All three are attempted even though the first throws (independent guards).
+    expect(intents).toEqual([
+      "orphans.reap-requested",
+      "phase.reconcile.reap-requested",
+      "procOrphans.reap-requested",
+    ]);
   });
 });

--- a/plugins/dev/scripts/execution-core/fleet-health-probe.test.mjs
+++ b/plugins/dev/scripts/execution-core/fleet-health-probe.test.mjs
@@ -233,10 +233,13 @@ describe("startFleetHealthProbe tick", () => {
 // ─── defaultReadSwapUsedMb ───────────────────────────────────────────────────
 
 describe("defaultReadSwapUsedMb", () => {
+  // platform:"darwin" is pinned explicitly — the default reads process.platform,
+  // which is "linux" on CI, where the function short-circuits to 0 (sysctl is a
+  // macOS-only signal). Pinning darwin exercises the real parse path everywhere.
   test("parses the used field from sysctl vm.swapusage output", () => {
     const sample =
       "total = 8192.00M  used = 4500.06M  free = 3691.94M  (encrypted)";
-    expect(defaultReadSwapUsedMb({ run: () => sample })).toBe(4500);
+    expect(defaultReadSwapUsedMb({ platform: "darwin", run: () => sample })).toBe(4500);
   });
 
   test("off-darwin / non-darwin platform → 0 safe sentinel", () => {
@@ -246,6 +249,7 @@ describe("defaultReadSwapUsedMb", () => {
   test("throwing sysctl → 0 safe sentinel", () => {
     expect(
       defaultReadSwapUsedMb({
+        platform: "darwin",
         run: () => {
           throw new Error("sysctl missing");
         },
@@ -254,7 +258,9 @@ describe("defaultReadSwapUsedMb", () => {
   });
 
   test("no-match output → 0 safe sentinel", () => {
-    expect(defaultReadSwapUsedMb({ run: () => "garbage no used field" })).toBe(0);
+    expect(
+      defaultReadSwapUsedMb({ platform: "darwin", run: () => "garbage no used field" }),
+    ).toBe(0);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/fleet-health-probe.test.mjs
+++ b/plugins/dev/scripts/execution-core/fleet-health-probe.test.mjs
@@ -1,0 +1,344 @@
+// fleet-health-probe.test.mjs — CTL-1165 D5. The pre-exhaustion fleet-health
+// guardrail core: classifyFleetHealth (pure), the four safe()-wrapped signal
+// reads with NON-CROSSING sentinels, single-event-per-breach emit, hysteresis
+// re-arm, selfHealEnabled default-OFF, and the bounded ppid===1 node/bun child
+// sweep. All dependencies injected; tick() called directly — no real timer,
+// sysctl, ps, or kill. Mirrors memory-sampler.test.mjs.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test fleet-health-probe.test.mjs
+
+import { test, expect, describe } from "bun:test";
+import {
+  classifyFleetHealth,
+  startFleetHealthProbe,
+  defaultReadSwapUsedMb,
+  defaultReapOrphanChildren,
+  defaultTriggerSelfHeal,
+} from "./fleet-health-probe.mjs";
+import { FLEET_HEALTH_DEGRADED } from "./fleet-health-event.mjs";
+
+// Recording fake clock — same shape as memory-sampler.test.mjs
+function recordingClock() {
+  const handle = { id: Symbol("interval") };
+  let cleared = false;
+  return {
+    setInterval: () => handle,
+    clearInterval: (h) => {
+      if (h === handle) cleared = true;
+    },
+    handle,
+    wasCleared: () => cleared,
+  };
+}
+
+const THRESHOLDS = {
+  jobsThreshold: 500,
+  agentsThreshold: 12,
+  procsThreshold: 40,
+  swapUsedMbThreshold: 4096,
+};
+
+function baseConfig(over = {}) {
+  return {
+    enabled: true,
+    intervalMs: 120_000,
+    selfHealEnabled: false,
+    sustainedTicks: 2,
+    ...THRESHOLDS,
+    ...over,
+  };
+}
+
+// Build a probe harness with injected readers + spies.
+function harness({
+  config = baseConfig(),
+  jobs = 0,
+  agents = 0,
+  procs = 0,
+  swap = 0,
+  throwAll = false,
+} = {}) {
+  const refs = { jobs, agents, procs, swap };
+  const emitted = [];
+  const selfHeals = [];
+  const clock = recordingClock();
+  const p = startFleetHealthProbe({
+    clock,
+    config,
+    readJobsCount: () => {
+      if (throwAll) throw new Error("jobs read failed");
+      return refs.jobs;
+    },
+    listAgents: () => {
+      if (throwAll) throw new Error("agents read failed");
+      return Array.from({ length: refs.agents }, (_, i) => ({ pid: 100 + i }));
+    },
+    psLines: () => {
+      if (throwAll) throw new Error("ps read failed");
+      return Array.from({ length: refs.procs }, (_, i) => `${200 + i} 1 node`);
+    },
+    readSwapUsedMb: () => {
+      if (throwAll) throw new Error("swap read failed");
+      return refs.swap;
+    },
+    emit: (payload) => emitted.push(payload),
+    triggerSelfHeal: () => selfHeals.push(Date.now()),
+  });
+  return { p, refs, emitted, selfHeals, clock };
+}
+
+// ─── classifyFleetHealth (pure) ──────────────────────────────────────────────
+
+describe("classifyFleetHealth (pure)", () => {
+  test("jobs over threshold → degraded, tripped=['jobs']", () => {
+    const r = classifyFleetHealth(
+      { jobsCount: 600, agentsCount: 1, procsCount: 1, swapUsedMb: 0 },
+      THRESHOLDS,
+    );
+    expect(r.degraded).toBe(true);
+    expect(r.tripped).toEqual(["jobs"]);
+  });
+
+  test("boundary jobsCount===threshold also degraded (>=)", () => {
+    const r = classifyFleetHealth(
+      { jobsCount: 500, agentsCount: 1, procsCount: 1, swapUsedMb: 0 },
+      THRESHOLDS,
+    );
+    expect(r.degraded).toBe(true);
+    expect(r.tripped).toContain("jobs");
+  });
+
+  test("all four signals can trip together (stable order)", () => {
+    const r = classifyFleetHealth(
+      { jobsCount: 600, agentsCount: 20, procsCount: 50, swapUsedMb: 5000 },
+      THRESHOLDS,
+    );
+    expect(r.degraded).toBe(true);
+    expect(r.tripped).toEqual(["jobs", "agents", "procs", "swap"]);
+  });
+
+  test("below all thresholds → not degraded, empty tripped", () => {
+    const r = classifyFleetHealth(
+      { jobsCount: 10, agentsCount: 1, procsCount: 1, swapUsedMb: 0 },
+      THRESHOLDS,
+    );
+    expect(r.degraded).toBe(false);
+    expect(r.tripped).toEqual([]);
+  });
+
+  test("null/sentinel readings never trip", () => {
+    const r = classifyFleetHealth(
+      { jobsCount: null, agentsCount: null, procsCount: null, swapUsedMb: 0 },
+      THRESHOLDS,
+    );
+    expect(r.degraded).toBe(false);
+    expect(r.tripped).toEqual([]);
+  });
+});
+
+// ─── Probe tick behaviour ────────────────────────────────────────────────────
+
+describe("startFleetHealthProbe tick", () => {
+  test("threshold-cross emits exactly one event with all four readings + tripped + sustained_n=1", () => {
+    const { p, emitted } = harness({ jobs: 600, agents: 3, procs: 5, swap: 100 });
+    p.tick();
+    expect(emitted.length).toBe(1);
+    const e = emitted[0];
+    expect(e.jobsCount).toBe(600);
+    expect(e.agentsCount).toBe(3);
+    expect(e.procsCount).toBe(5);
+    expect(e.swapUsedMb).toBe(100);
+    expect(e.tripped).toEqual(["jobs"]);
+    expect(e.sustained_n).toBe(1);
+  });
+
+  test("below-threshold is silent (0 events, 0 self-heal, counter stays 0)", () => {
+    const { p, emitted, selfHeals } = harness({
+      config: baseConfig({ selfHealEnabled: true }),
+      jobs: 10,
+      agents: 1,
+      procs: 1,
+      swap: 0,
+    });
+    p.tick();
+    p.tick();
+    expect(emitted.length).toBe(0);
+    expect(selfHeals.length).toBe(0);
+  });
+
+  test("self-heal fires ONCE on sustained breach (sustainedTicks=2)", () => {
+    const { p, emitted, selfHeals } = harness({
+      config: baseConfig({ selfHealEnabled: true, sustainedTicks: 2 }),
+      jobs: 600,
+    });
+    p.tick(); // sustained_n=1, below sustainedTicks
+    expect(selfHeals.length).toBe(0);
+    p.tick(); // sustained_n=2 === sustainedTicks → fires once
+    expect(selfHeals.length).toBe(1);
+    p.tick(); // sustained_n=3, already fired this episode → still 1
+    p.tick(); // sustained_n=4 → still 1
+    expect(selfHeals.length).toBe(1);
+    // every degraded tick still emits an event
+    expect(emitted.length).toBe(4);
+  });
+
+  test("hysteresis re-arms only after a healthy tick", () => {
+    const { p, refs, selfHeals } = harness({
+      config: baseConfig({ selfHealEnabled: true, sustainedTicks: 2 }),
+      jobs: 600,
+    });
+    p.tick(); // n=1
+    p.tick(); // n=2 → fire #1
+    expect(selfHeals.length).toBe(1);
+    // recover
+    refs.jobs = 10;
+    p.tick(); // healthy → resets counter + re-arms
+    // fresh sustained run
+    refs.jobs = 600;
+    p.tick(); // n=1
+    expect(selfHeals.length).toBe(1);
+    p.tick(); // n=2 → fire #2
+    expect(selfHeals.length).toBe(2);
+  });
+
+  test("reader failure degrades safe — all readers throw → sentinels, 0 events, 0 self-heal", () => {
+    const { p, emitted, selfHeals } = harness({
+      config: baseConfig({ selfHealEnabled: true, sustainedTicks: 1 }),
+      throwAll: true,
+    });
+    expect(() => p.tick()).not.toThrow();
+    expect(emitted.length).toBe(0);
+    expect(selfHeals.length).toBe(0);
+  });
+
+  test("selfHealEnabled=false (default) → emits every tick but never sweeps", () => {
+    const { p, emitted, selfHeals } = harness({
+      config: baseConfig({ selfHealEnabled: false, sustainedTicks: 2 }),
+      jobs: 600,
+    });
+    p.tick();
+    p.tick();
+    p.tick();
+    expect(emitted.length).toBe(3);
+    expect(selfHeals.length).toBe(0);
+  });
+
+  test("stop() calls clock.clearInterval with the registered handle", () => {
+    const { p, clock } = harness();
+    expect(clock.wasCleared()).toBe(false);
+    p.stop();
+    expect(clock.wasCleared()).toBe(true);
+  });
+});
+
+// ─── defaultReadSwapUsedMb ───────────────────────────────────────────────────
+
+describe("defaultReadSwapUsedMb", () => {
+  test("parses the used field from sysctl vm.swapusage output", () => {
+    const sample =
+      "total = 8192.00M  used = 4500.06M  free = 3691.94M  (encrypted)";
+    expect(defaultReadSwapUsedMb({ run: () => sample })).toBe(4500);
+  });
+
+  test("off-darwin / non-darwin platform → 0 safe sentinel", () => {
+    expect(defaultReadSwapUsedMb({ platform: "linux" })).toBe(0);
+  });
+
+  test("throwing sysctl → 0 safe sentinel", () => {
+    expect(
+      defaultReadSwapUsedMb({
+        run: () => {
+          throw new Error("sysctl missing");
+        },
+      }),
+    ).toBe(0);
+  });
+
+  test("no-match output → 0 safe sentinel", () => {
+    expect(defaultReadSwapUsedMb({ run: () => "garbage no used field" })).toBe(0);
+  });
+});
+
+// ─── defaultReapOrphanChildren ───────────────────────────────────────────────
+
+describe("defaultReapOrphanChildren", () => {
+  test("selects only reparented (ppid===1) node/bun pids, never the daemon's own tree", () => {
+    const lines = [
+      "201 1 node /some/worker.mjs", // orphan node → kill
+      "202 1 bun run test", // orphan bun → kill
+      "203 555 node /child.mjs", // not reparented → spare
+      "204 1 ruby script.rb", // not node/bun → spare
+      "999 1 node /daemon.mjs", // daemon pid → spare
+    ];
+    const kills = [];
+    const reaped = defaultReapOrphanChildren({
+      psLines: () => lines,
+      kill: (pid, sig) => kills.push({ pid, sig }),
+      daemonPids: [999],
+    });
+    const killedPids = kills.map((k) => k.pid).sort((a, b) => a - b);
+    expect(killedPids).toEqual([201, 202]);
+    expect(reaped).toBe(2);
+  });
+
+  test("respects maxPerSweep cap (25)", () => {
+    const lines = Array.from({ length: 60 }, (_, i) => `${1000 + i} 1 node x`);
+    const kills = [];
+    const reaped = defaultReapOrphanChildren({
+      psLines: () => lines,
+      kill: (pid) => kills.push(pid),
+      maxPerSweep: 25,
+    });
+    expect(kills.length).toBe(25);
+    expect(reaped).toBe(25);
+  });
+
+  test("never throws when kill throws (best-effort)", () => {
+    const lines = ["201 1 node worker"];
+    expect(() =>
+      defaultReapOrphanChildren({
+        psLines: () => lines,
+        kill: () => {
+          throw new Error("ESRCH");
+        },
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ─── defaultTriggerSelfHeal ──────────────────────────────────────────────────
+
+describe("defaultTriggerSelfHeal", () => {
+  test("emits both reap intents then sweeps children, never throws", async () => {
+    const intents = [];
+    const swept = [];
+    await expect(
+      defaultTriggerSelfHeal({
+        emitIntent: async (name) => intents.push(name),
+        reapChildren: () => {
+          swept.push(true);
+          return 0;
+        },
+      }),
+    ).resolves.toBeUndefined();
+    expect(intents).toContain("orphans.reap-requested");
+    expect(intents).toContain("phase.reconcile.reap-requested");
+    expect(swept.length).toBe(1);
+  });
+
+  test("a throwing emitIntent does not prevent the child sweep and never throws", async () => {
+    let swept = false;
+    await expect(
+      defaultTriggerSelfHeal({
+        emitIntent: async () => {
+          throw new Error("event log unwritable");
+        },
+        reapChildren: () => {
+          swept = true;
+          return 0;
+        },
+      }),
+    ).resolves.toBeUndefined();
+    expect(swept).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/job-dir-gc.mjs
+++ b/plugins/dev/scripts/execution-core/job-dir-gc.mjs
@@ -1,0 +1,184 @@
+// job-dir-gc.mjs — CTL-1165 D3. Garbage-collect stale ~/.claude/jobs/<id> dirs.
+//
+// THE LEAK: every reference to a job dir in the codebase is READ-ONLY
+// (session-resolve.mjs, recovery.mjs defaultStatJob, claude-agents.mjs
+// defaultStatJobState). Nothing ever deletes them — so on a long-uptime host
+// ~1798 dirs (864 MB) accumulated and helped exhaust RAM + swap on mini.
+//
+// THE FIX: a filesystem-only, fail-CLOSED sweep that deletes a job dir ONLY
+// when THREE independent gates ALL pass:
+//   (0) fail-closed liveness FIRST — if `claude agents` can't be read
+//       ({ ok:false }), ABORT the whole sweep and delete nothing. Treating a
+//       read failure as an empty fleet would collapse the live-set and authorize
+//       deleting a LIVE worker's dir (mirrors defaultAssessWorktreeRemoval's
+//       fail-closed liveness, reaper.mjs).
+//   (1) basename ∉ liveShortIds — the dir's 8-char short-id is not a currently
+//       registered `claude agents` session.
+//   (2) NOT the self/controlling session (isSelfSession).
+//   (3) mtime age >= retention (default 24h ≫ any phase duration).
+//
+// DELETE PRIMITIVE: plain fs.rm(dir, {recursive, force}) of the JOB DIR ALONE —
+// NOT `claude rm`. `claude rm` also tears down the worktree (claude-ids.mjs); a
+// dead unregistered dir has nothing to deregister, and a short-id collision with
+// a live worktree would be catastrophic. We reclaim DISK only — a still-
+// registered status:null zombie's dir is PRESERVED by the liveness gate; its
+// eviction is D4's job.
+
+import { readdirSync, statSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { getJobsRoot, log as defaultLog } from "./config.mjs";
+import { listClaudeAgentsResult } from "./claude-agents.mjs";
+import { shortIdFromSessionId, isSelfSession } from "./claude-ids.mjs";
+import { emitReapIntent } from "./reap-intent.mjs";
+
+// Defaults are config/env-driven (no magic numbers): 24h retention, 200/batch.
+const DEFAULT_RETENTION_SECONDS = 86_400; // 24h
+const DEFAULT_BATCH_CAP = 200;
+
+/**
+ * sweepJobDirs — GC stale ~/.claude/jobs/<id> dirs. Fail-closed, fail-safe,
+ * bounded. Every IO/clock/emit primitive is an injected, defaulted seam so the
+ * unit test never reads the real jobs root, calls real rmSync, or spawns claude.
+ *
+ * @returns {Promise<{reclaimed, scanned, skippedLive, skippedRecent, errors, batchCapped, skipped?}>}
+ */
+export async function sweepJobDirs({
+  jobsRoot = getJobsRoot(),
+  readDir = readdirSync,
+  statDir = (p) => statSync(p),
+  rm = rmSync,
+  readAgents = listClaudeAgentsResult,
+  now = () => Date.now(),
+  retentionMs = (Number(process.env.CATALYST_JOB_GC_RETENTION_SECONDS) || DEFAULT_RETENTION_SECONDS) * 1000,
+  batchCap = Number(process.env.CATALYST_JOB_GC_BATCH_CAP) || DEFAULT_BATCH_CAP,
+  emit = emitReapIntent,
+  env = process.env,
+  log = defaultLog,
+} = {}) {
+  // Gate 0 — fail-closed liveness FIRST. A FAILED `claude agents` read
+  // ({ ok:false }) is NOT a genuinely-empty fleet: deleting on a read failure
+  // would authorize evicting a live worker's dir. Abort, delete nothing.
+  let agentsResult;
+  try {
+    agentsResult = readAgents();
+  } catch {
+    agentsResult = { ok: false, agents: [] };
+  }
+  if (!agentsResult || agentsResult.ok !== true) {
+    log.warn(
+      { jobsRoot },
+      "job-dir-gc: `claude agents` unreadable — aborting sweep (fail-closed), deleting nothing"
+    );
+    return {
+      reclaimed: 0,
+      scanned: 0,
+      skippedLive: 0,
+      skippedRecent: 0,
+      errors: 0,
+      batchCapped: false,
+      skipped: "agents-unreadable",
+    };
+  }
+
+  // Build the live short-id set from the (confirmed-good) agents snapshot.
+  // A malformed/empty sessionId → null → filtered, so a bad row can never
+  // accidentally PROTECT or AUTHORIZE deletion of an unrelated basename.
+  const liveShortIds = new Set();
+  for (const a of agentsResult.agents ?? []) {
+    let short = null;
+    try {
+      short = shortIdFromSessionId(a?.sessionId);
+    } catch {
+      short = null;
+    }
+    if (short) liveShortIds.add(short);
+  }
+
+  // Enumerate the jobs root. ENOENT (root absent) → [] (mirrors detectColdStart
+  // recovery.mjs). Any other read error → degrade safe: nothing to sweep.
+  let basenames;
+  try {
+    basenames = readDir(jobsRoot);
+  } catch (err) {
+    if (err?.code !== "ENOENT") {
+      log.warn({ jobsRoot, err: err?.message }, "job-dir-gc: jobs root unreadable; skipping sweep");
+    }
+    return {
+      reclaimed: 0,
+      scanned: 0,
+      skippedLive: 0,
+      skippedRecent: 0,
+      errors: 0,
+      batchCapped: false,
+    };
+  }
+
+  const nowMs = now();
+  let reclaimed = 0;
+  let scanned = 0;
+  let skippedLive = 0;
+  let skippedRecent = 0;
+  let errors = 0;
+  let batchCapped = false;
+
+  for (const basename of basenames) {
+    scanned++;
+
+    // Gate 1 — not a live registered session (string compare of 8-char ids).
+    if (liveShortIds.has(basename)) {
+      skippedLive++;
+      continue;
+    }
+
+    // Gate 2 — never the self/controlling session.
+    if (isSelfSession(basename, env)) {
+      skippedLive++;
+      continue;
+    }
+
+    // Gate 3 — mtime age >= retention. Per-dir stat failure (e.g. ENOENT
+    // because the dir vanished between readdir and stat) → errors++, continue;
+    // never throw, never abort the batch.
+    const dir = join(jobsRoot, basename);
+    let st;
+    try {
+      st = statDir(dir);
+    } catch {
+      errors++;
+      continue;
+    }
+    const mtimeMs = st?.mtimeMs ?? nowMs; // unknown mtime → treat as recent (spare)
+    if (nowMs - mtimeMs < retentionMs) {
+      skippedRecent++;
+      continue;
+    }
+
+    // batchCap — stop reclaiming once we would exceed the cap; the remainder
+    // drains on the next tick. We mark batchCapped and break so a single sweep
+    // can never rm an unbounded number of dirs.
+    if (reclaimed >= batchCap) {
+      batchCapped = true;
+      break;
+    }
+
+    // All gates passed — delete the JOB DIR ALONE (never `claude rm`).
+    try {
+      rm(dir, { recursive: true, force: true });
+      reclaimed++;
+    } catch {
+      errors++;
+    }
+  }
+
+  // Best-effort flag emit (never throws; emitReapIntent returns false on a
+  // write failure). Only emit when we actually reclaimed something.
+  if (reclaimed > 0) {
+    try {
+      await emit("jobs.gc.swept", { reclaimed, scanned });
+    } catch (err) {
+      log.warn({ err: err?.message }, "job-dir-gc: jobs.gc.swept emit failed");
+    }
+  }
+
+  return { reclaimed, scanned, skippedLive, skippedRecent, errors, batchCapped };
+}

--- a/plugins/dev/scripts/execution-core/job-dir-gc.test.mjs
+++ b/plugins/dev/scripts/execution-core/job-dir-gc.test.mjs
@@ -1,0 +1,205 @@
+// job-dir-gc.test.mjs — CTL-1165 D3. GC of stale ~/.claude/jobs/<id> dirs.
+//
+// Every fs/agents/clock/emit primitive is an injected, defaulted constructor
+// param (mirrors detectColdStart + Reaper). NO test reads the real jobs root,
+// calls real rmSync, or spawns `claude`.
+
+import { describe, it, expect } from "bun:test";
+import { join } from "node:path";
+import { sweepJobDirs } from "./job-dir-gc.mjs";
+
+const HOUR = 3600_000;
+const RETENTION_24H = 24 * HOUR;
+
+// Recording rm spy: records every (path, opts) tuple, never touches disk.
+function rmSpy() {
+  const calls = [];
+  const fn = (p, opts) => calls.push({ path: p, opts });
+  fn.calls = calls;
+  return fn;
+}
+
+// Recording emit spy: records (eventType, fields) tuples, resolves true.
+function emitSpy() {
+  const calls = [];
+  const fn = async (eventType, fields) => {
+    calls.push({ eventType, fields });
+    return true;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+// Recording log spy with warn().
+function logSpy() {
+  const warn = [];
+  return {
+    warn: (...args) => warn.push(args),
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+    _warn: warn,
+  };
+}
+
+// A live agent row: claude agents --json shape. Only sessionId matters for GC.
+const agent = (sessionId, extra = {}) => ({ sessionId, status: "idle", kind: "background", ...extra });
+
+const ROOT = "/fake/.claude/jobs";
+
+describe("sweepJobDirs", () => {
+  it("deletes an old non-live dir", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    const emit = emitSpy();
+    const res = await sweepJobDirs({
+      jobsRoot: ROOT,
+      readDir: () => ["deadbeef"],
+      statDir: () => ({ mtimeMs: now - 25 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit,
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(1);
+    expect(rm.calls[0].path).toBe(join(ROOT, "deadbeef"));
+    expect(rm.calls[0].opts).toEqual({ recursive: true, force: true });
+    expect(res.reclaimed).toBe(1);
+    const swept = emit.calls.find((c) => c.eventType === "jobs.gc.swept");
+    expect(swept).toBeTruthy();
+    expect(swept.fields.reclaimed).toBe(1);
+  });
+
+  it("preserves a live registered session", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    const res = await sweepJobDirs({
+      jobsRoot: ROOT,
+      readDir: () => ["abc12345"],
+      statDir: () => ({ mtimeMs: now - 25 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [agent("abc12345-0000-0000-0000-000000000000")] }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit: emitSpy(),
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(0);
+    expect(res.skippedLive).toBe(1);
+    expect(res.reclaimed).toBe(0);
+  });
+
+  it("preserves a recent dir", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    const res = await sweepJobDirs({
+      jobsRoot: ROOT,
+      readDir: () => ["recent01"],
+      statDir: () => ({ mtimeMs: now - 1 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit: emitSpy(),
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(0);
+    expect(res.skippedRecent).toBe(1);
+    expect(res.reclaimed).toBe(0);
+  });
+
+  it("fail-closed on agents-unreadable", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    const emit = emitSpy();
+    const log = logSpy();
+    const res = await sweepJobDirs({
+      jobsRoot: ROOT,
+      readDir: () => ["deadbeef"],
+      statDir: () => ({ mtimeMs: now - 25 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: false, agents: [] }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit,
+      env: {},
+      log,
+    });
+    expect(rm.calls.length).toBe(0);
+    expect(res.reclaimed).toBe(0);
+    expect(log._warn.length).toBe(1);
+    // No delete (jobs.gc.swept) emit on a fail-closed abort.
+    expect(emit.calls.find((c) => c.eventType === "jobs.gc.swept")).toBeUndefined();
+  });
+
+  it("tolerates an un-stattable dir (ENOENT) without throwing", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    const res = await sweepJobDirs({
+      jobsRoot: ROOT,
+      readDir: () => ["gone0001"],
+      statDir: () => {
+        const e = new Error("ENOENT: no such file");
+        e.code = "ENOENT";
+        throw e;
+      },
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit: emitSpy(),
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(0);
+    expect(res.errors).toBe(1);
+    expect(res.reclaimed).toBe(0);
+  });
+
+  it("honors the batch cap", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    const basenames = Array.from({ length: 300 }, (_, i) => `dead${String(i).padStart(4, "0")}`);
+    const res = await sweepJobDirs({
+      jobsRoot: ROOT,
+      readDir: () => basenames,
+      statDir: () => ({ mtimeMs: now - 25 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      batchCap: 200,
+      emit: emitSpy(),
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(200);
+    expect(res.reclaimed).toBe(200);
+    expect(res.batchCapped).toBe(true);
+  });
+
+  it("never deletes the self/controlling session dir", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    // basename is a valid 8-char hex short-id matching the env session prefix.
+    const res = await sweepJobDirs({
+      jobsRoot: ROOT,
+      readDir: () => ["5e1f0001"],
+      statDir: () => ({ mtimeMs: now - 25 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit: emitSpy(),
+      env: { CLAUDE_CODE_SESSION_ID: "5e1f0001-0000-0000-0000-000000000000" },
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(0);
+    expect(res.reclaimed).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/orphan-reaper-timer.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-reaper-timer.mjs
@@ -67,13 +67,19 @@ export function startOrphanReaperTimer({
       // fires both even when the producer is async.
       //
       // CTL-1165 D3: piggyback the ~/.claude/jobs/<id> dir GC on the same 600s
-      // cadence (no new daemon timer). All three promises start synchronously
-      // (the emits before any await) and share THIS try/catch, so a rejecting
-      // jobGc cannot suppress the two reap emits — the emit calls have already
-      // run by the time jobGc's rejection surfaces in the shared catch.
+      // cadence (no new daemon timer). All promises start synchronously (the
+      // emits before any await) and share THIS try/catch, so a rejecting jobGc
+      // cannot suppress the reap emits — the emit calls have already run by the
+      // time jobGc's rejection surfaces in the shared catch.
+      //
+      // CTL-1165 D2: fire the orphan child-process reaper trigger on the same
+      // tick. reaper.mjs routes procOrphans.reap-requested to its injected
+      // ProcReaper.sweep (a no-op when no ProcReaper is injected). The ProcReaper
+      // DEFAULTS to mode:"shadow" (emits would-reap, kills nothing).
       await Promise.all([
         emit("orphans.reap-requested", {}),
         emit("phase.reconcile.reap-requested", {}),
+        emit("procOrphans.reap-requested", {}),
         jobGc(),
       ]);
     } catch (err) {

--- a/plugins/dev/scripts/execution-core/orphan-reaper-timer.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-reaper-timer.mjs
@@ -4,6 +4,7 @@
 
 import { readFileSync } from "node:fs";
 import { emitReapIntent } from "./reap-intent.mjs";
+import { sweepJobDirs } from "./job-dir-gc.mjs";
 import { log } from "./config.mjs";
 
 /**
@@ -44,12 +45,14 @@ function realClock() {
  * @param {boolean} [opts.enabled=true]            disable to no-op the timer
  * @param {number}  [opts.intervalSeconds=600]     default 10 minutes
  * @param {Function}[opts.emit=emitReapIntent]     emitter seam for tests
+ * @param {Function}[opts.jobGc=()=>sweepJobDirs()] CTL-1165 D3: job-dir GC seam
  * @param {object}  [opts.clock=realClock()]       fake-clock seam for tests
  */
 export function startOrphanReaperTimer({
   enabled = true,
   intervalSeconds = 600,
   emit = emitReapIntent,
+  jobGc = () => sweepJobDirs(),
   clock = realClock(),
 } = {}) {
   if (!enabled) return { stop: () => {} };
@@ -62,9 +65,16 @@ export function startOrphanReaperTimer({
       // emits per-session phase.reconcile.reap-requested intents WITH a target.
       // Both emits are issued synchronously (before any await) so a single tick
       // fires both even when the producer is async.
+      //
+      // CTL-1165 D3: piggyback the ~/.claude/jobs/<id> dir GC on the same 600s
+      // cadence (no new daemon timer). All three promises start synchronously
+      // (the emits before any await) and share THIS try/catch, so a rejecting
+      // jobGc cannot suppress the two reap emits — the emit calls have already
+      // run by the time jobGc's rejection surfaces in the shared catch.
       await Promise.all([
         emit("orphans.reap-requested", {}),
         emit("phase.reconcile.reap-requested", {}),
+        jobGc(),
       ]);
     } catch (err) {
       // CTL-649: a persistently-unwritable event log would make every tick

--- a/plugins/dev/scripts/execution-core/orphan-reaper-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-reaper-timer.test.mjs
@@ -30,17 +30,22 @@ function fakeClock() {
 }
 
 describe("startOrphanReaperTimer", () => {
-  it("emits orphans + reconcile reap-requested every interval (CTL-661)", () => {
+  it("emits orphans + reconcile + procOrphans reap-requested every interval (CTL-661 / CTL-1165 D2)", () => {
     const emitted = [];
     const clock = fakeClock();
     startOrphanReaperTimer({ intervalSeconds: 600, emit: (e) => emitted.push(e), clock });
     clock.advance(600_000);
-    // CTL-661: each tick now drives BOTH the orphan sweep and the per-ticket
-    // reconcile sweep (the bare reconcile event is the sweep trigger).
-    expect(emitted).toEqual(["orphans.reap-requested", "phase.reconcile.reap-requested"]);
+    // CTL-661: each tick drives the orphan sweep AND the per-ticket reconcile
+    // sweep. CTL-1165 D2: it also fires the orphan child-process reaper trigger.
+    expect(emitted).toEqual([
+      "orphans.reap-requested",
+      "phase.reconcile.reap-requested",
+      "procOrphans.reap-requested",
+    ]);
     clock.advance(600_000);
     expect(emitted.filter((e) => e === "orphans.reap-requested").length).toBe(2);
     expect(emitted.filter((e) => e === "phase.reconcile.reap-requested").length).toBe(2);
+    expect(emitted.filter((e) => e === "procOrphans.reap-requested").length).toBe(2);
   });
 
   it("honors a config-overridden interval", () => {

--- a/plugins/dev/scripts/execution-core/orphan-reaper-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-reaper-timer.test.mjs
@@ -79,6 +79,48 @@ describe("startOrphanReaperTimer", () => {
     clock.advance(600_000);
     expect(emitted.length).toBe(0);
   });
+
+  // CTL-1165 D3: the job-dir GC runs on the same 600s cadence, sharing the
+  // tick's try/catch with the two reap emits.
+  it("runs jobGc on the same tick as the two reap emits (CTL-1165 D3)", async () => {
+    const emitted = [];
+    let jobGcCalls = 0;
+    const clock = fakeClock();
+    startOrphanReaperTimer({
+      intervalSeconds: 600,
+      emit: async (e) => emitted.push(e),
+      jobGc: async () => {
+        jobGcCalls++;
+      },
+      clock,
+    });
+    clock.advance(600_000);
+    // flush the async tick body
+    await new Promise((r) => setTimeout(r, 0));
+    expect(emitted.filter((e) => e === "orphans.reap-requested").length).toBe(1);
+    expect(emitted.filter((e) => e === "phase.reconcile.reap-requested").length).toBe(1);
+    expect(jobGcCalls).toBe(1);
+  });
+
+  // CTL-1165 D3: a rejecting jobGc must NOT suppress the two reap emits —
+  // they share the tick's try/catch, so the emits run first (synchronously,
+  // before any await) and a jobGc rejection is swallowed by the same catch.
+  it("a rejecting jobGc does not suppress the two reap emits (CTL-1165 D3)", async () => {
+    const emitted = [];
+    const clock = fakeClock();
+    startOrphanReaperTimer({
+      intervalSeconds: 600,
+      emit: async (e) => emitted.push(e),
+      jobGc: async () => {
+        throw new Error("job-gc boom");
+      },
+      clock,
+    });
+    clock.advance(600_000);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(emitted.filter((e) => e === "orphans.reap-requested").length).toBe(1);
+    expect(emitted.filter((e) => e === "phase.reconcile.reap-requested").length).toBe(1);
+  });
 });
 
 describe("readOrphanReaperConfig", () => {

--- a/plugins/dev/scripts/execution-core/proc-reaper.mjs
+++ b/plugins/dev/scripts/execution-core/proc-reaper.mjs
@@ -30,7 +30,7 @@
 // DEFAULT mode:"shadow" — emits procOrphans.would-reap, kills NOTHING. Bakes on
 // mini before any enforce flip (like stall-janitor CTL-1004 + cost-cap CTL-1137).
 //
-// ALL IO is injected (psLister/lsofCwd/liveAgents/agentsResult/killProc/sleep/now)
+// ALL IO is injected (psLister/lsofCwd/agentsResult/killProc/sleep/now)
 // so the unit tests never spawn a subprocess, run ps/lsof, touch ~/.claude, or
 // signal a real pid.
 
@@ -38,7 +38,7 @@ import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { basename } from "node:path";
 import { emitReapIntent } from "./reap-intent.mjs";
-import { getAgentsCached, listClaudeAgentsResult } from "./claude-agents.mjs";
+import { listClaudeAgentsResult } from "./claude-agents.mjs";
 import { log as defaultLog } from "./config.mjs";
 
 // The hard never-kill argv-substring allowlist (case-insensitive). Config-
@@ -323,7 +323,6 @@ export class ProcReaper {
     killableCommands = new Set(["node", "bun"]),
     psLister = defaultPsLister,
     lsofCwd = defaultLsofCwd,
-    liveAgents = () => getAgentsCached().agents,
     agentsResult = () => listClaudeAgentsResult(),
     killProc = defaultKillProc,
     sleep = realSleep,
@@ -341,7 +340,6 @@ export class ProcReaper {
     this.killableCommands = killableCommands;
     this.psLister = psLister;
     this.lsofCwd = lsofCwd;
-    this.liveAgents = liveAgents;
     this.agentsResult = agentsResult;
     this.killProc = killProc;
     this.sleep = sleep;
@@ -406,14 +404,13 @@ export class ProcReaper {
       childrenByPpid.get(r.ppid).push(r.pid);
     }
 
-    // Live-agent correlation: pid roots → LIVE_TREE subtree; cwd set.
-    const liveAgents = (() => {
-      try {
-        return this.liveAgents() ?? [];
-      } catch {
-        return [];
-      }
-    })();
+    // Live-agent correlation: pid roots → LIVE_TREE subtree; cwd set. These
+    // derive from the SAME fresh, ok-verified read that just passed the
+    // catastrophe guard — NOT a separate cached snapshot. Keeping the guard and
+    // the correlation on one source means a cold/stale cache returning [] while
+    // the fresh read succeeds can never shrink the live-agent cwd set out from
+    // under the kill gate.
+    const liveAgents = Array.isArray(agentsRes.agents) ? agentsRes.agents : [];
     const liveAgentSubtreePids = collectLiveAgentSubtree(liveAgents, byPid, childrenByPpid);
     const liveAgentCwds = new Set();
     for (const a of liveAgents) if (a?.cwd) liveAgentCwds.add(a.cwd);

--- a/plugins/dev/scripts/execution-core/proc-reaper.mjs
+++ b/plugins/dev/scripts/execution-core/proc-reaper.mjs
@@ -243,8 +243,18 @@ export function classifyProc(row, ctx) {
   const cwd = cwdForPid(row.pid);
   if (cwd === null || cwd === undefined) return { action: "spare", reason: "cwd-unknown" };
 
-  // (6) cwd matching a live-agent cwd → live-agent-owned, spare.
-  if (liveAgentCwds.has(cwd)) return { action: "spare", reason: "live-agent-owned" };
+  // (6) cwd AT OR UNDER any live-agent cwd → a live worker's own (possibly
+  //     reparented) child, spare. PREFIX-aware, not byte-exact: an MCP server /
+  //     bun-test / bun-install grandchild typically runs from a package SUBDIR
+  //     under the agent's worktree, and once its intermediate parent exits it
+  //     reparents to launchd (leaving LIVE_TREE) — the shared cwd prefix is what
+  //     still ties it to the live worker. Erring toward spare is the safe
+  //     direction (a live worker's tooling is never yanked mid-run).
+  for (const liveCwd of liveAgentCwds) {
+    if (cwdUnderWorktreeRoot(cwd, liveCwd)) {
+      return { action: "spare", reason: "live-agent-owned" };
+    }
+  }
 
   // (7) cwd must be under the worktree root (an interactive claude / dev shell
   //     outside ~/catalyst/wt is never reaped — the under-wt signal is REQUIRED).
@@ -349,9 +359,11 @@ export class ProcReaper {
     this.allowlistPatterns = allowlistPatterns;
     this.log = log;
     this.emit = emit;
-    // Two-sweep persistence: pid → { command, seen } seen on the PREVIOUS sweep.
-    // A candidate must be orphaned-and-killable on two CONSECUTIVE sweeps (and
-    // its command must match across both, guarding pid-reuse) before any kill.
+    // Two-sweep persistence: pid → full argv seen on the PREVIOUS sweep. A
+    // candidate must be orphaned-and-killable on two CONSECUTIVE sweeps AND its
+    // full argv must match across both — keying on argv (not the node/bun
+    // basename) is what actually guards pid-reuse: a recycled pid hosting a
+    // different node/bun process has a different argv and is spared.
     this._priorCandidates = new Map();
   }
 
@@ -440,7 +452,7 @@ export class ProcReaper {
     for (const row of rows) {
       const v = classifyProc(row, ctx);
       verdicts.push({ row, v });
-      if (v.action === "kill") thisSweepCandidates.set(row.pid, row.command);
+      if (v.action === "kill") thisSweepCandidates.set(row.pid, row.args);
     }
 
     // Two-sweep persistence: act only on a candidate seen orphaned-and-killable
@@ -451,8 +463,8 @@ export class ProcReaper {
         continue;
       }
       const prior = this._priorCandidates.get(row.pid);
-      if (!prior || prior !== row.command) {
-        // First sweep this candidate is seen (or pid reused under a new command):
+      if (!prior || prior !== row.args) {
+        // First sweep this candidate is seen (or pid reused under a new argv):
         // spare it this pass; the persistence map below records it for next time.
         report.spared.push({ pid: row.pid, command: row.command, reason: "awaiting-second-sweep" });
         continue;
@@ -492,12 +504,14 @@ export class ProcReaper {
     // Re-probe: signal 0 returns true (alive) / false (gone or foreign-uid).
     const stillAlive = this.killProc(row.pid, 0);
     if (!stillAlive) return true; // exited under SIGTERM (or vanished) — done.
-    // Re-match argv just before SIGKILL to dodge pid-reuse: re-snapshot.
+    // Re-match FULL argv just before SIGKILL to dodge pid-reuse: re-snapshot. A
+    // pid recycled into a different process during the grace window has a
+    // different argv (or is absent) → stillSame false → no SIGKILL.
     let stillSame = true;
     try {
       const fresh = parsePsRows(this.psLister());
       const cur = fresh.find((r) => r.pid === row.pid);
-      stillSame = !!cur && cur.command === row.command;
+      stillSame = !!cur && cur.args === row.args;
     } catch {
       stillSame = false; // can't re-confirm → do NOT SIGKILL (degrade safe).
     }

--- a/plugins/dev/scripts/execution-core/proc-reaper.mjs
+++ b/plugins/dev/scripts/execution-core/proc-reaper.mjs
@@ -1,0 +1,531 @@
+// proc-reaper.mjs — CTL-1165 D2. The orphan child-process reaper (HIGHEST RISK).
+//
+// `claude stop` deregisters the claude AGENT but never reaps the reparented
+// node/bun grandchildren (MCP servers, sub-agent tooling, bun-test runners) it
+// spawned — the RSS bulk of the leak (on mini, 74 of 81 orphans by RSS were
+// node/bun, many 150–550 MB). There was no process-layer reaper before this.
+//
+// HARD SAFETY RECIPE (R-process-kill-safety, macOS 26.4.1 live-verified):
+//   • macOS env-read is DEAD (`ps eww` prints zero env, no /proc), so CATALYST_*
+//     env markers are NOT part of the kill gate. `claude agents --json` already
+//     returns {pid, cwd, kind, sessionId, status} authoritatively — that is the
+//     primary correlation signal.
+//   • LIVE_TREE correlation is the primary guard: L = {agent.pid}, then
+//     LIVE_TREE = DFS-descendants(L) over the ps children-map. A pid is killable
+//     ONLY if NOT in LIVE_TREE and NOT a live root. Walking DOWN from live roots
+//     (not just checking the candidate's ppid) is what prevents killing a live
+//     worker's MCP/bun-test grandchildren.
+//   • KILL-GATE — ALL must hold else SPARE (classifyProc): orphaned (ppid===1 or
+//     vanished worktree) AND command∈{node,bun} AND not allowlisted (pid OR argv)
+//     AND not in LIVE_TREE / live-agent cwd AND cwd known AND cwd under the
+//     worktree root AND etime ≥ minEtimeSec AND (sweep-level) the agents read
+//     SUCCEEDED AND the orphan persisted across ≥2 consecutive sweeps.
+//   • CATASTROPHE GUARD: a FAILED `claude agents` read (agentsResult.ok===false)
+//     ABORTS the whole sweep — kill nothing. Treating read-failure as
+//     agents-absent would collapse LIVE_TREE to empty and authorize a host-wide
+//     kill. listClaudeAgentsResult returns {ok:false} for exactly this case.
+//   • SIGTERM → wait graceMs → re-probe kill(pid,0) → SIGKILL only if still alive.
+//     Never SIGKILL first (let node/bun flush).
+//
+// DEFAULT mode:"shadow" — emits procOrphans.would-reap, kills NOTHING. Bakes on
+// mini before any enforce flip (like stall-janitor CTL-1004 + cost-cap CTL-1137).
+//
+// ALL IO is injected (psLister/lsofCwd/liveAgents/agentsResult/killProc/sleep/now)
+// so the unit tests never spawn a subprocess, run ps/lsof, touch ~/.claude, or
+// signal a real pid.
+
+import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
+import { basename } from "node:path";
+import { emitReapIntent } from "./reap-intent.mjs";
+import { getAgentsCached, listClaudeAgentsResult } from "./claude-agents.mjs";
+import { log as defaultLog } from "./config.mjs";
+
+// The hard never-kill argv-substring allowlist (case-insensitive). Config-
+// extensible via orphanReaper.procReaper.allowlistPatterns. Tailscale's helper
+// procs (Tailscale.app / IPNExtension) are launchd-parented but must NEVER die.
+const DEFAULT_ALLOWLIST_PATTERNS = Object.freeze([
+  "execution-core/daemon.mjs",
+  "broker/index.mjs",
+  "orch-monitor/server.ts",
+  "tailscale",
+  "ipnextension",
+]);
+
+// ─── Pure: ps parsing (pid ppid rss etime command) ───────────────────────────
+
+// The 3 leading numeric fields (pid ppid rss) + the etime token are whitespace-
+// free; group 5 is the variable command tail (argv, may contain spaces).
+const PS_ROW_RE = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(.*)$/;
+
+/**
+ * parseEtime — ps `etime` (elapsed time) → seconds. Forms:
+ *   MM:SS  /  HH:MM:SS  /  DD-HH:MM:SS
+ * Malformed / empty → 0 (a 0-age process can never satisfy the etime floor, so
+ * a parse failure degrades SAFE: the proc is spared as too-young).
+ */
+export function parseEtime(etime) {
+  if (typeof etime !== "string" || !etime) return 0;
+  let days = 0;
+  let rest = etime;
+  const dash = etime.indexOf("-");
+  if (dash !== -1) {
+    days = Number(etime.slice(0, dash));
+    rest = etime.slice(dash + 1);
+    if (!Number.isFinite(days)) return 0;
+  }
+  const parts = rest.split(":").map((p) => Number(p));
+  if (parts.some((n) => !Number.isFinite(n))) return 0;
+  let secs;
+  if (parts.length === 2) secs = parts[0] * 60 + parts[1];
+  else if (parts.length === 3) secs = parts[0] * 3600 + parts[1] * 60 + parts[2];
+  else return 0;
+  return days * 86400 + secs;
+}
+
+/**
+ * parsePsRows — parse `ps -axo pid=,ppid=,rss=,etime=,command=` lines into row
+ * objects { pid, ppid, rssKb, etimeSec, command, args }. `command` is the
+ * basename (lowercased) of argv[0]; `args` is the full command line, kept for
+ * allowlist substring matching (`command=` carries the FULL path, NOT the
+ * truncated `comm`). Pure; never throws on a malformed line (it is skipped).
+ */
+export function parsePsRows(lines = []) {
+  const rows = [];
+  for (const raw of lines) {
+    if (typeof raw !== "string") continue;
+    const line = raw.replace(/\s+$/, "");
+    if (!line.trim()) continue;
+    const m = PS_ROW_RE.exec(line);
+    if (!m) continue;
+    const pid = Number(m[1]);
+    const ppid = Number(m[2]);
+    const rssKb = Number(m[3]);
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
+    const etimeSec = parseEtime(m[4]);
+    const args = m[5].trim();
+    const argv0 = args.split(/\s+/)[0] || "";
+    const command = basename(argv0).toLowerCase() || null;
+    rows.push({ pid, ppid, rssKb: Number.isFinite(rssKb) ? rssKb : null, etimeSec, command, args });
+  }
+  return rows;
+}
+
+// ─── Pure: cwd boundary ──────────────────────────────────────────────────────
+
+/**
+ * cwdUnderWorktreeRoot — boundary-safe "is cwd inside root?" (reuse reaper.mjs
+ * cwdUnder semantics so `/wt/CTL-64` never matches a sibling `/wt/CTL-649`).
+ */
+export function cwdUnderWorktreeRoot(cwd, root) {
+  if (!cwd || !root || typeof cwd !== "string" || typeof root !== "string") return false;
+  const r = root.length > 1 && root.endsWith("/") ? root.slice(0, -1) : root;
+  return cwd === r || cwd.startsWith(r + "/");
+}
+
+// ─── Pure: orphan detection ──────────────────────────────────────────────────
+
+/**
+ * isOrphaned — a process is orphaned when it was reparented to launchd
+ * (ppid===1) OR its parent is not present in the ps snapshot (vanished). A
+ * present, non-init parent means a live ancestor still owns it → NOT orphaned.
+ */
+export function isOrphaned(row, byPid) {
+  if (!row) return false;
+  if (row.ppid === 1) return true;
+  // parent present in snapshot → live ancestor → not orphaned.
+  if (byPid && byPid.has(row.ppid)) return false;
+  // parent absent (vanished) AND not init → treat as orphaned (its owner is gone).
+  return true;
+}
+
+// ─── Pure: LIVE_TREE construction ────────────────────────────────────────────
+
+/**
+ * collectLiveAgentSubtree — DFS-descendants of every live claude-agent pid. The
+ * returned Set is the LIVE_TREE: every live root plus every descendant. A pid in
+ * this set is a live worker's own MCP/bun-test/tooling child and must NEVER be
+ * killed. Reuses the rssTotalForPid walk shape (cli/sessions.mjs).
+ */
+export function collectLiveAgentSubtree(liveAgents, byPid, childrenByPpid) {
+  const subtree = new Set();
+  const roots = [];
+  for (const a of liveAgents ?? []) {
+    const pid = Number(a?.pid);
+    if (Number.isFinite(pid) && pid > 0) roots.push(pid);
+  }
+  const stack = [...roots];
+  const seen = new Set();
+  while (stack.length) {
+    const p = stack.pop();
+    if (seen.has(p)) continue;
+    seen.add(p);
+    subtree.add(p);
+    for (const c of childrenByPpid?.get(p) ?? []) stack.push(c);
+  }
+  return subtree;
+}
+
+// ─── Pure: allowlist ─────────────────────────────────────────────────────────
+
+/**
+ * buildAllowlist — the hard never-kill set. Combines a pid set (self + daemon +
+ * the whole LIVE_TREE) and an argv-substring pattern list (default + operator-
+ * configured, lowercased). A candidate is allowlisted if its pid is in the set
+ * OR its lowercased argv contains any pattern.
+ */
+export function buildAllowlist({
+  selfPid,
+  daemonPids = [],
+  liveAgentSubtreePids = new Set(),
+  allowlistPatterns = [],
+} = {}) {
+  const pids = new Set();
+  if (Number.isFinite(Number(selfPid))) pids.add(Number(selfPid));
+  for (const p of daemonPids) {
+    const n = Number(p);
+    if (Number.isFinite(n) && n > 0) pids.add(n);
+  }
+  for (const p of liveAgentSubtreePids) pids.add(p);
+  const patterns = [
+    ...DEFAULT_ALLOWLIST_PATTERNS,
+    ...allowlistPatterns.map((s) => String(s).toLowerCase()),
+  ];
+  return { pids, patterns };
+}
+
+function isArgvAllowlisted(args, patterns) {
+  const lower = String(args || "").toLowerCase();
+  return patterns.some((p) => p && lower.includes(p));
+}
+
+// ─── Pure: the kill gate ─────────────────────────────────────────────────────
+
+/**
+ * classifyProc — PURE kill-gate. Returns { action:'kill'|'spare', reason }.
+ * ALL conditions must hold for 'kill', else SPARE with the first failing reason.
+ * The ordering puts the never-kill allowlist + LIVE_TREE FIRST (so an
+ * allowlisted/live proc is never even probed), then orphan/command/cwd/etime.
+ */
+export function classifyProc(row, ctx) {
+  const {
+    byPid,
+    liveAgentCwds,
+    liveAgentSubtreePids,
+    allowlist,
+    worktreeRoot,
+    killableCommands,
+    minEtimeSec,
+    cwdForPid,
+    worktreePath,
+  } = ctx;
+
+  // (1) hard never-kill: pid in allowlist set (self/daemon/LIVE_TREE) OR argv pattern.
+  if (allowlist.pids.has(row.pid)) return { action: "spare", reason: "allowlisted" };
+  if (isArgvAllowlisted(row.args, allowlist.patterns)) {
+    return { action: "spare", reason: "allowlisted" };
+  }
+
+  // (2) LIVE_TREE: the candidate is (a descendant of) a live claude agent.
+  if (liveAgentSubtreePids.has(row.pid)) {
+    return { action: "spare", reason: "live-agent-owned" };
+  }
+
+  // (3) command must be killable (node/bun) — anything else is never ours to kill.
+  if (!killableCommands.has(row.command)) {
+    return { action: "spare", reason: "command-not-killable" };
+  }
+
+  // (4) must be orphaned (reparented to launchd / vanished parent).
+  if (!isOrphaned(row, byPid)) return { action: "spare", reason: "has-live-ancestor" };
+
+  // (5) cwd must be resolvable; unknown cwd → SPARE (degrade safe).
+  const cwd = cwdForPid(row.pid);
+  if (cwd === null || cwd === undefined) return { action: "spare", reason: "cwd-unknown" };
+
+  // (6) cwd matching a live-agent cwd → live-agent-owned, spare.
+  if (liveAgentCwds.has(cwd)) return { action: "spare", reason: "live-agent-owned" };
+
+  // (7) cwd must be under the worktree root (an interactive claude / dev shell
+  //     outside ~/catalyst/wt is never reaped — the under-wt signal is REQUIRED).
+  if (!cwdUnderWorktreeRoot(cwd, worktreeRoot)) {
+    return { action: "spare", reason: "not-under-worktree-root" };
+  }
+
+  // (8) targeted teardown sweep: scope to one worktree path (boundary-safe).
+  if (worktreePath && !cwdUnderWorktreeRoot(cwd, worktreePath)) {
+    return { action: "spare", reason: "outside-target-worktree" };
+  }
+
+  // (9) etime corroboration floor (never a SOLE gate — all the above ran first).
+  if ((row.etimeSec ?? 0) < minEtimeSec) return { action: "spare", reason: "too-young" };
+
+  return { action: "kill", reason: "orphan-node-under-worktree" };
+}
+
+// ─── Default IO seams (replaced wholesale in tests) ──────────────────────────
+
+function defaultPsLister() {
+  try {
+    const out = execFileSync("ps", ["-axo", "pid=,ppid=,rss=,etime=,command="], {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return out.split("\n");
+  } catch {
+    return [];
+  }
+}
+
+function defaultLsofCwd(pid) {
+  try {
+    const out = execFileSync("lsof", ["-a", "-p", String(pid), "-d", "cwd", "-Fn"], {
+      encoding: "utf8",
+    });
+    // -Fn output: lines like `pPID`, `fcwd`, `n/abs/path`. The cwd path line
+    // starts with 'n'.
+    for (const line of out.split("\n")) {
+      if (line.startsWith("n")) return line.slice(1) || null;
+    }
+    return null; // unknown → spare
+  } catch {
+    return null; // unreadable → spare (degrade safe)
+  }
+}
+
+// defaultKillProc — wraps process.kill; never throws. Returns true when the call
+// succeeded (signal delivered, or a 0-probe found the proc alive), false on
+// ESRCH/EPERM (gone, or alive-but-foreign → NEVER our kill). Signal 0 is the
+// liveness probe; a foreign-uid proc throws EPERM here and is treated as "not
+// ours" (false) so the SIGKILL re-probe spares it.
+function defaultKillProc(pid, signal) {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const realSleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * ProcReaper — the orphan child-process reaper. Constructed once by the daemon
+ * and driven by the orphan-reaper timer's procOrphans.reap-requested event
+ * (routed through reaper.mjs _handleProcOrphansSweep). All IO injected.
+ */
+export class ProcReaper {
+  constructor({
+    mode = "shadow",
+    worktreeRoot = `${homedir()}/catalyst/wt`,
+    graceMs = 5000,
+    minEtimeSec = 900,
+    killableCommands = new Set(["node", "bun"]),
+    psLister = defaultPsLister,
+    lsofCwd = defaultLsofCwd,
+    liveAgents = () => getAgentsCached().agents,
+    agentsResult = () => listClaudeAgentsResult(),
+    killProc = defaultKillProc,
+    sleep = realSleep,
+    now = () => Date.now(),
+    selfPid = process.pid,
+    daemonPids = [],
+    allowlistPatterns = [],
+    log = defaultLog,
+    emit = emitReapIntent,
+  } = {}) {
+    this.mode = mode;
+    this.worktreeRoot = worktreeRoot;
+    this.graceMs = graceMs;
+    this.minEtimeSec = minEtimeSec;
+    this.killableCommands = killableCommands;
+    this.psLister = psLister;
+    this.lsofCwd = lsofCwd;
+    this.liveAgents = liveAgents;
+    this.agentsResult = agentsResult;
+    this.killProc = killProc;
+    this.sleep = sleep;
+    this.now = now;
+    this.selfPid = selfPid;
+    this.daemonPids = daemonPids;
+    this.allowlistPatterns = allowlistPatterns;
+    this.log = log;
+    this.emit = emit;
+    // Two-sweep persistence: pid → { command, seen } seen on the PREVIOUS sweep.
+    // A candidate must be orphaned-and-killable on two CONSECUTIVE sweeps (and
+    // its command must match across both, guarding pid-reuse) before any kill.
+    this._priorCandidates = new Map();
+  }
+
+  /**
+   * sweep — one pass. Returns { reaped, wouldReap, spared }.
+   *   mode 'off'     → empty report, no emit, no kill.
+   *   mode 'shadow'  → emit procOrphans.would-reap for each persisted candidate;
+   *                    kill NOTHING.
+   *   mode 'enforce' → SIGTERM → grace → SIGKILL each persisted candidate; emit
+   *                    procOrphans.reaped.
+   */
+  async sweep({ worktreePath = null } = {}) {
+    const report = { reaped: [], wouldReap: [], spared: [] };
+    if (this.mode === "off") {
+      this._priorCandidates.clear();
+      return report;
+    }
+
+    // CATASTROPHE GUARD: a FAILED agents read aborts the WHOLE sweep, kills
+    // nothing. {ok:false} is distinct from a genuine empty list ({ok:true,[]}).
+    let agentsRes;
+    try {
+      agentsRes = this.agentsResult();
+    } catch {
+      agentsRes = { ok: false, agents: [] };
+    }
+    if (!agentsRes || agentsRes.ok !== true) {
+      this.log.warn(
+        {},
+        "proc-reaper: `claude agents` read FAILED — aborting sweep, killing nothing (CATASTROPHE GUARD)",
+      );
+      await this._safeEmit("procOrphans.spared", { reason: "agents-unreadable" });
+      this._priorCandidates.clear(); // a failed read invalidates persistence state
+      return report;
+    }
+
+    // Snapshot processes. An unreadable ps degrades safe (empty report).
+    let rows;
+    try {
+      rows = parsePsRows(this.psLister());
+    } catch (err) {
+      this.log.warn({ err: err?.message }, "proc-reaper: ps snapshot failed — skipping sweep");
+      return report;
+    }
+
+    const byPid = new Map(rows.map((r) => [r.pid, r]));
+    const childrenByPpid = new Map();
+    for (const r of rows) {
+      if (!childrenByPpid.has(r.ppid)) childrenByPpid.set(r.ppid, []);
+      childrenByPpid.get(r.ppid).push(r.pid);
+    }
+
+    // Live-agent correlation: pid roots → LIVE_TREE subtree; cwd set.
+    const liveAgents = (() => {
+      try {
+        return this.liveAgents() ?? [];
+      } catch {
+        return [];
+      }
+    })();
+    const liveAgentSubtreePids = collectLiveAgentSubtree(liveAgents, byPid, childrenByPpid);
+    const liveAgentCwds = new Set();
+    for (const a of liveAgents) if (a?.cwd) liveAgentCwds.add(a.cwd);
+
+    const allowlist = buildAllowlist({
+      selfPid: this.selfPid,
+      daemonPids: this.daemonPids,
+      liveAgentSubtreePids,
+      allowlistPatterns: this.allowlistPatterns,
+    });
+
+    const ctx = {
+      byPid,
+      liveAgentCwds,
+      liveAgentSubtreePids,
+      allowlist,
+      worktreeRoot: this.worktreeRoot,
+      killableCommands: this.killableCommands,
+      minEtimeSec: this.minEtimeSec,
+      cwdForPid: (pid) => this._safeCwd(pid),
+      worktreePath,
+    };
+
+    // Classify every row. Collect this-sweep kill candidates for persistence.
+    const thisSweepCandidates = new Map();
+    const verdicts = [];
+    for (const row of rows) {
+      const v = classifyProc(row, ctx);
+      verdicts.push({ row, v });
+      if (v.action === "kill") thisSweepCandidates.set(row.pid, row.command);
+    }
+
+    // Two-sweep persistence: act only on a candidate seen orphaned-and-killable
+    // on the PREVIOUS sweep too, with a matching command (pid-reuse guard).
+    for (const { row, v } of verdicts) {
+      if (v.action !== "kill") {
+        report.spared.push({ pid: row.pid, command: row.command, reason: v.reason });
+        continue;
+      }
+      const prior = this._priorCandidates.get(row.pid);
+      if (!prior || prior !== row.command) {
+        // First sweep this candidate is seen (or pid reused under a new command):
+        // spare it this pass; the persistence map below records it for next time.
+        report.spared.push({ pid: row.pid, command: row.command, reason: "awaiting-second-sweep" });
+        continue;
+      }
+      // Persisted across ≥2 sweeps → act.
+      if (this.mode === "shadow") {
+        report.wouldReap.push({ pid: row.pid, command: row.command });
+        await this._safeEmit("procOrphans.would-reap", {
+          pid: row.pid,
+          command: row.command,
+          worktreePath: this._safeCwd(row.pid),
+        });
+      } else if (this.mode === "enforce") {
+        const killed = await this._terminateWithGrace(row);
+        if (killed) {
+          report.reaped.push({ pid: row.pid, command: row.command });
+          await this._safeEmit("procOrphans.reaped", {
+            pid: row.pid,
+            command: row.command,
+            worktreePath: this._safeCwd(row.pid),
+          });
+        }
+      }
+    }
+
+    // Roll persistence forward: remember THIS sweep's candidates for the next.
+    this._priorCandidates = thisSweepCandidates;
+    return report;
+  }
+
+  // SIGTERM → wait graceMs → re-probe kill(pid,0) → SIGKILL only if still alive.
+  // Never SIGKILL first (let node/bun flush). Returns true if the proc is gone
+  // (whether it exited under SIGTERM or SIGKILL).
+  async _terminateWithGrace(row) {
+    this.killProc(row.pid, "SIGTERM");
+    await this.sleep(this.graceMs);
+    // Re-probe: signal 0 returns true (alive) / false (gone or foreign-uid).
+    const stillAlive = this.killProc(row.pid, 0);
+    if (!stillAlive) return true; // exited under SIGTERM (or vanished) — done.
+    // Re-match argv just before SIGKILL to dodge pid-reuse: re-snapshot.
+    let stillSame = true;
+    try {
+      const fresh = parsePsRows(this.psLister());
+      const cur = fresh.find((r) => r.pid === row.pid);
+      stillSame = !!cur && cur.command === row.command;
+    } catch {
+      stillSame = false; // can't re-confirm → do NOT SIGKILL (degrade safe).
+    }
+    if (!stillSame) {
+      this.log.warn({ pid: row.pid }, "proc-reaper: pid no longer matches argv — skipping SIGKILL");
+      return false;
+    }
+    this.killProc(row.pid, "SIGKILL");
+    return true;
+  }
+
+  _safeCwd(pid) {
+    try {
+      return this.lsofCwd(pid);
+    } catch {
+      return null;
+    }
+  }
+
+  async _safeEmit(type, fields) {
+    try {
+      return await this.emit(type, fields);
+    } catch (err) {
+      this.log.warn({ err: err?.message, type }, "proc-reaper: emit failed");
+      return false;
+    }
+  }
+}

--- a/plugins/dev/scripts/execution-core/proc-reaper.test.mjs
+++ b/plugins/dev/scripts/execution-core/proc-reaper.test.mjs
@@ -448,6 +448,40 @@ describe("ProcReaper.sweep — allowlist + live-tree sparing", () => {
     expect(killProc.calls.filter(([, s]) => s !== 0)).toHaveLength(0);
   });
 
+  it("live-agent cwd protection (gate 7) uses the fresh agents read, not a stale cache", async () => {
+    // An ORPHANED node (pid 250, ppid 1) sharing a live agent's worktree cwd.
+    // isOrphaned does NOT save it (reparented to launchd), so it is spared ONLY
+    // by the cwd gate — and that live-agent cwd set must come from the
+    // catastrophe-guard's fresh agentsResult, NOT a stale/cold cache. With the
+    // pre-hardening code (LIVE_TREE/cwds from a separate cached liveAgents that
+    // returned []), this orphan would have been killed.
+    const psLines = [
+      psLine({ pid: 250, ppid: 1, etime: "99:00", command: "node leftover.mjs" }),
+    ];
+    const emit = recordingEmit();
+    const killProc = recordingKill({ alive: new Set([250]) });
+    const reaper = new ProcReaper({
+      mode: "enforce",
+      worktreeRoot: WT_ROOT,
+      psLister: () => psLines,
+      lsofCwd: () => `${WT_ROOT}/CTL-X`,
+      liveAgents: () => [], // a stale/cold cache — MUST be ignored now
+      agentsResult: () => ({ ok: true, agents: [{ pid: 100, cwd: `${WT_ROOT}/CTL-X` }] }),
+      killProc,
+      sleep: async () => {},
+      now: () => 0,
+      selfPid: 1,
+      daemonPids: [],
+      emit,
+      log: silentLog(),
+    });
+    await reaper.sweep({});
+    const r2 = await reaper.sweep({});
+    expect(r2.reaped).toHaveLength(0);
+    expect(r2.spared.some((s) => s.reason === "live-agent-owned")).toBe(true);
+    expect(killProc.calls.filter(([, s]) => s !== 0)).toHaveLength(0);
+  });
+
   it("interactive claude + children spared (cwd NOT under worktree root)", async () => {
     const psLines = [
       psLine({ pid: 300, ppid: 1, etime: "99:00", command: "node tool.mjs" }),

--- a/plugins/dev/scripts/execution-core/proc-reaper.test.mjs
+++ b/plugins/dev/scripts/execution-core/proc-reaper.test.mjs
@@ -1,0 +1,567 @@
+// proc-reaper.test.mjs — CTL-1165 D2. The orphan child-process reaper (HIGHEST
+// RISK). DEFAULT mode:"shadow" (emits would-reap, kills NOTHING). All IO is
+// injected — no test spawns a subprocess, runs ps/lsof, touches ~/.claude, or
+// signals a real pid. The CATASTROPHE GUARD (agents read {ok:false} → abort the
+// sweep, kill nothing) is a first-class test.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test proc-reaper.test.mjs
+
+import { describe, it, test, expect, mock } from "bun:test";
+import {
+  ProcReaper,
+  classifyProc,
+  isOrphaned,
+  cwdUnderWorktreeRoot,
+  buildAllowlist,
+  collectLiveAgentSubtree,
+  parsePsRows,
+  parseEtime,
+} from "./proc-reaper.mjs";
+
+const WT_ROOT = "/Users/test/catalyst/wt";
+
+function silentLog() {
+  return { info: () => {}, warn: () => {}, error: () => {} };
+}
+
+// recordingKill — records every (pid, signal) tuple; NEVER calls process.kill.
+// Mirrors the killProc seam contract (the production defaultKillProc wraps
+// process.kill and NEVER throws): returns a boolean. For the signal-0 liveness
+// re-probe it returns true (alive) only when the pid is in `alive`, else false
+// (gone or foreign-uid) — exactly what defaultKillProc returns for ESRCH/EPERM.
+function recordingKill({ alive = new Set() } = {}) {
+  const calls = [];
+  const fn = (pid, signal) => {
+    calls.push([pid, signal]);
+    if (signal === 0) return alive.has(pid);
+    return true;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+// recordingEmit — collects (type, fields) tuples.
+function recordingEmit() {
+  const calls = [];
+  const fn = mock((type, fields) => {
+    calls.push({ type, fields });
+    return Promise.resolve(true);
+  });
+  fn.calls = calls;
+  return fn;
+}
+
+// A canned ps snapshot builder for the 5-field `pid ppid rss etime command` spec.
+function psLine({ pid, ppid, rss = 100000, etime = "10:00", command }) {
+  return `${pid} ${ppid} ${rss} ${etime} ${command}`;
+}
+
+// ─── parseEtime ──────────────────────────────────────────────────────────────
+
+describe("parseEtime", () => {
+  test("MM:SS", () => expect(parseEtime("00:42")).toBe(42));
+  test("HH:MM:SS", () => expect(parseEtime("01:02:03")).toBe(3723));
+  test("DD-HH:MM:SS", () => expect(parseEtime("17-06:09:43")).toBe(1490983));
+  test("malformed → 0", () => {
+    expect(parseEtime("")).toBe(0);
+    expect(parseEtime("garbage")).toBe(0);
+    expect(parseEtime(undefined)).toBe(0);
+  });
+});
+
+// ─── parsePsRows ─────────────────────────────────────────────────────────────
+
+describe("parsePsRows", () => {
+  test("parses pid/ppid/rss/etime/command and skips malformed", () => {
+    const lines = [
+      "  4321  4000 524288    10:00 /usr/local/bin/node server.mjs --port 8080",
+      "  5000     1 100000 01:02:03 bun test foo.test.mjs",
+      "", // blank skipped
+      "not-a-row", // malformed skipped
+    ];
+    const rows = parsePsRows(lines);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      pid: 4321,
+      ppid: 4000,
+      rssKb: 524288,
+      etimeSec: 600,
+      command: "node",
+    });
+    // full argv kept for allowlist substring matching
+    expect(rows[0].args).toBe("/usr/local/bin/node server.mjs --port 8080");
+    expect(rows[1]).toMatchObject({ pid: 5000, ppid: 1, etimeSec: 3723, command: "bun" });
+  });
+
+  test("linux natural-width command column", () => {
+    const rows = parsePsRows(["1234 1 50000 5-00:00:00 node /home/x/daemon.mjs"]);
+    expect(rows[0]).toMatchObject({ pid: 1234, ppid: 1, etimeSec: 432000, command: "node" });
+    expect(rows[0].args).toBe("node /home/x/daemon.mjs");
+  });
+});
+
+// ─── cwdUnderWorktreeRoot (boundary-safe) ────────────────────────────────────
+
+describe("cwdUnderWorktreeRoot", () => {
+  test("exact + descendant match", () => {
+    expect(cwdUnderWorktreeRoot(`${WT_ROOT}/CTL-X`, WT_ROOT)).toBe(true);
+    expect(cwdUnderWorktreeRoot(`${WT_ROOT}/CTL-X/sub`, WT_ROOT)).toBe(true);
+    expect(cwdUnderWorktreeRoot(WT_ROOT, WT_ROOT)).toBe(true);
+  });
+  test("sibling boundary is NOT a match (/wt/CTL-64 ≠ /wt/CTL-649)", () => {
+    expect(cwdUnderWorktreeRoot("/wt/CTL-649", "/wt/CTL-64")).toBe(false);
+  });
+  test("null/empty → false", () => {
+    expect(cwdUnderWorktreeRoot(null, WT_ROOT)).toBe(false);
+    expect(cwdUnderWorktreeRoot(`${WT_ROOT}/x`, null)).toBe(false);
+  });
+});
+
+// ─── collectLiveAgentSubtree ─────────────────────────────────────────────────
+
+describe("collectLiveAgentSubtree", () => {
+  test("DFS-descends from every live-agent root", () => {
+    // tree: agent root 100 → 200 → 300 ; agent root 500 → 600
+    const rows = [
+      { pid: 100, ppid: 1, command: "claude" },
+      { pid: 200, ppid: 100, command: "node" },
+      { pid: 300, ppid: 200, command: "node" },
+      { pid: 500, ppid: 1, command: "claude" },
+      { pid: 600, ppid: 500, command: "bun" },
+      { pid: 900, ppid: 1, command: "node" }, // unrelated orphan
+    ];
+    const byPid = new Map(rows.map((r) => [r.pid, r]));
+    const childrenByPpid = new Map();
+    for (const r of rows) {
+      if (!childrenByPpid.has(r.ppid)) childrenByPpid.set(r.ppid, []);
+      childrenByPpid.get(r.ppid).push(r.pid);
+    }
+    const liveAgents = [{ pid: 100 }, { pid: 500 }];
+    const subtree = collectLiveAgentSubtree(liveAgents, byPid, childrenByPpid);
+    expect(subtree.has(100)).toBe(true);
+    expect(subtree.has(200)).toBe(true);
+    expect(subtree.has(300)).toBe(true);
+    expect(subtree.has(500)).toBe(true);
+    expect(subtree.has(600)).toBe(true);
+    expect(subtree.has(900)).toBe(false); // unrelated orphan never in LIVE_TREE
+  });
+});
+
+// ─── buildAllowlist ──────────────────────────────────────────────────────────
+
+describe("buildAllowlist", () => {
+  test("includes selfPid + daemonPids + whole LIVE_TREE subtree pids", () => {
+    const allow = buildAllowlist({
+      selfPid: 42,
+      daemonPids: [7, 8],
+      liveAgentSubtreePids: new Set([100, 200]),
+    });
+    expect(allow.pids.has(42)).toBe(true);
+    expect(allow.pids.has(7)).toBe(true);
+    expect(allow.pids.has(8)).toBe(true);
+    expect(allow.pids.has(100)).toBe(true);
+    expect(allow.pids.has(200)).toBe(true);
+  });
+  test("carries the default + extra argv patterns (lowercased)", () => {
+    const allow = buildAllowlist({ allowlistPatterns: ["MyCustomThing"] });
+    expect(allow.patterns).toContain("execution-core/daemon.mjs");
+    expect(allow.patterns).toContain("broker/index.mjs");
+    expect(allow.patterns).toContain("orch-monitor/server.ts");
+    expect(allow.patterns).toContain("tailscale");
+    expect(allow.patterns).toContain("mycustomthing"); // case-insensitive
+  });
+});
+
+// ─── isOrphaned ──────────────────────────────────────────────────────────────
+
+describe("isOrphaned", () => {
+  test("ppid===1 (reparented to launchd) → orphaned", () => {
+    const row = { pid: 10, ppid: 1 };
+    expect(isOrphaned(row, new Map())).toBe(true);
+  });
+  test("a live ancestor (ppid !== 1, parent present) → NOT orphaned", () => {
+    const parent = { pid: 5, ppid: 100 };
+    const row = { pid: 10, ppid: 5 };
+    const byPid = new Map([[5, parent]]);
+    expect(isOrphaned(row, byPid)).toBe(false);
+  });
+});
+
+// ─── classifyProc (pure kill-gate) ───────────────────────────────────────────
+
+function ctx(overrides = {}) {
+  return {
+    byPid: new Map(),
+    liveAgentCwds: new Set(),
+    liveAgentSubtreePids: new Set(),
+    allowlist: buildAllowlist({ selfPid: 1, daemonPids: [] }),
+    worktreeRoot: WT_ROOT,
+    killableCommands: new Set(["node", "bun"]),
+    minEtimeSec: 900,
+    cwdForPid: () => `${WT_ROOT}/CTL-X`, // lsof cwd resolver; default = under wt
+    worktreePath: null,
+    ...overrides,
+  };
+}
+
+describe("classifyProc kill-gate (ALL must hold else SPARE)", () => {
+  test("orphan node under a worktree, not in LIVE_TREE, old enough → kill", () => {
+    const row = { pid: 10, ppid: 1, command: "node", etimeSec: 1000, args: "node x.mjs" };
+    const c = ctx();
+    const v = classifyProc(row, c);
+    expect(v.action).toBe("kill");
+  });
+  test("allowlisted argv (daemon) → spare(reason allowlisted)", () => {
+    const row = {
+      pid: 10,
+      ppid: 1,
+      command: "node",
+      etimeSec: 1000,
+      args: "node /x/execution-core/daemon.mjs --pid-file /y",
+    };
+    const v = classifyProc(row, ctx());
+    expect(v.action).toBe("spare");
+    expect(v.reason).toBe("allowlisted");
+  });
+  test("pid in allowlist.pids (self/daemon/LIVE_TREE) → spare(reason allowlisted)", () => {
+    const row = { pid: 100, ppid: 1, command: "node", etimeSec: 1000, args: "node x.mjs" };
+    const v = classifyProc(row, ctx({ allowlist: buildAllowlist({ selfPid: 100 }) }));
+    expect(v.action).toBe("spare");
+    expect(v.reason).toBe("allowlisted");
+  });
+  test("pid in LIVE_TREE subtree → spare(reason live-agent-owned)", () => {
+    const row = { pid: 222, ppid: 100, command: "node", etimeSec: 1000, args: "node x.mjs" };
+    const c = ctx({
+      liveAgentSubtreePids: new Set([222]),
+      byPid: new Map([[100, { pid: 100, ppid: 1 }]]),
+    });
+    const v = classifyProc(row, c);
+    expect(v.action).toBe("spare");
+    expect(v.reason).toBe("live-agent-owned");
+  });
+  test("cwd matches a live-agent cwd → spare(reason live-agent-owned)", () => {
+    const row = { pid: 10, ppid: 1, command: "node", etimeSec: 1000, args: "node x.mjs" };
+    const c = ctx({
+      liveAgentCwds: new Set([`${WT_ROOT}/CTL-X`]),
+      cwdForPid: () => `${WT_ROOT}/CTL-X`,
+    });
+    const v = classifyProc(row, c);
+    expect(v.action).toBe("spare");
+    expect(v.reason).toBe("live-agent-owned");
+  });
+  test("command not in killableCommands → spare(reason command-not-killable)", () => {
+    const row = { pid: 10, ppid: 1, command: "python", etimeSec: 1000, args: "python x.py" };
+    const v = classifyProc(row, ctx());
+    expect(v.action).toBe("spare");
+    expect(v.reason).toBe("command-not-killable");
+  });
+  test("not orphaned (has live ancestor) → spare(reason has-live-ancestor)", () => {
+    const row = { pid: 10, ppid: 5, command: "node", etimeSec: 1000, args: "node x.mjs" };
+    const c = ctx({ byPid: new Map([[5, { pid: 5, ppid: 100 }]]), cwdForPid: () => null });
+    const v = classifyProc(row, c);
+    expect(v.action).toBe("spare");
+    expect(v.reason).toBe("has-live-ancestor");
+  });
+  test("lsof cwd unknown (null) → spare(reason cwd-unknown)", () => {
+    const row = { pid: 10, ppid: 1, command: "node", etimeSec: 1000, args: "node x.mjs" };
+    const v = classifyProc(row, ctx({ cwdForPid: () => null }));
+    expect(v.action).toBe("spare");
+    expect(v.reason).toBe("cwd-unknown");
+  });
+  test("cwd NOT under worktree root (interactive claude region) → spare(reason not-under-worktree-root)", () => {
+    const row = { pid: 10, ppid: 1, command: "node", etimeSec: 1000, args: "node x.mjs" };
+    const v = classifyProc(row, ctx({ cwdForPid: () => "/Users/test/somewhere-else" }));
+    expect(v.action).toBe("spare");
+    expect(v.reason).toBe("not-under-worktree-root");
+  });
+  test("etime below minEtimeSec → spare(reason too-young)", () => {
+    const row = { pid: 10, ppid: 1, command: "node", etimeSec: 100, args: "node x.mjs" };
+    const v = classifyProc(row, ctx({ minEtimeSec: 900 }));
+    expect(v.action).toBe("spare");
+    expect(v.reason).toBe("too-young");
+  });
+  test("targeted worktreePath scopes the kill (boundary-safe: CTL-X ≠ CTL-X9)", () => {
+    const row = { pid: 10, ppid: 1, command: "node", etimeSec: 1000, args: "node x.mjs" };
+    // candidate cwd under CTL-X9, sweep targets CTL-X → spared (out of scope)
+    const c = ctx({
+      worktreePath: `${WT_ROOT}/CTL-X`,
+      cwdForPid: () => `${WT_ROOT}/CTL-X9`,
+    });
+    const v = classifyProc(row, c);
+    expect(v.action).toBe("spare");
+    expect(v.reason).toBe("outside-target-worktree");
+  });
+});
+
+// ─── ProcReaper.sweep ────────────────────────────────────────────────────────
+
+// Build a reaper with the canonical "one orphan node under a worktree" fixture.
+function orphanFixture({ mode = "shadow", killAlive, agentsOk = true, extra = {} } = {}) {
+  const ORPHAN_PID = 4242;
+  const psLines = [
+    psLine({ pid: ORPHAN_PID, ppid: 1, etime: "20:00", command: "node /x/foo.mjs" }),
+  ];
+  const emit = recordingEmit();
+  const killProc = recordingKill({ alive: killAlive ?? new Set([ORPHAN_PID]) });
+  const reaper = new ProcReaper({
+    mode,
+    worktreeRoot: WT_ROOT,
+    graceMs: 5000,
+    minEtimeSec: 900,
+    psLister: () => psLines,
+    lsofCwd: () => `${WT_ROOT}/CTL-X`,
+    liveAgents: () => [],
+    agentsResult: () => ({ ok: agentsOk, agents: [] }),
+    killProc,
+    sleep: async () => {},
+    now: () => 0,
+    selfPid: 1,
+    daemonPids: [],
+    emit,
+    log: silentLog(),
+    ...extra,
+  });
+  return { reaper, emit, killProc, ORPHAN_PID };
+}
+
+describe("ProcReaper.sweep — kill path (enforce)", () => {
+  it("two-sweep persistence: first sweep spares, second sweep kills (SIGTERM→grace→SIGKILL)", async () => {
+    const { reaper, emit, killProc, ORPHAN_PID } = orphanFixture({ mode: "enforce" });
+    // Sweep 1: orphan seen once → NOT yet persisted across 2 sweeps → spared.
+    const r1 = await reaper.sweep({});
+    expect(r1.reaped).toHaveLength(0);
+    expect(killProc.calls.filter(([, s]) => s !== 0)).toHaveLength(0);
+
+    // Sweep 2: now persisted across 2 consecutive sweeps → killed.
+    const r2 = await reaper.sweep({});
+    expect(r2.reaped.map((x) => x.pid)).toContain(ORPHAN_PID);
+    // SIGTERM first, then (re-probe alive) SIGKILL — never SIGKILL first.
+    const signals = killProc.calls.map(([, s]) => s);
+    expect(signals[0]).toBe("SIGTERM");
+    expect(signals).toContain("SIGKILL");
+    expect(signals.indexOf("SIGTERM")).toBeLessThan(signals.indexOf("SIGKILL"));
+    const reapedEmits = emit.calls.filter((c) => c.type === "procOrphans.reaped");
+    expect(reapedEmits.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("if the proc is gone after grace, SIGKILL is NOT sent", async () => {
+    // killAlive empty → the post-grace re-probe (signal 0) throws ESRCH = gone.
+    const { reaper, killProc, ORPHAN_PID } = orphanFixture({
+      mode: "enforce",
+      killAlive: new Set(), // gone after SIGTERM
+    });
+    await reaper.sweep({}); // sweep 1 (persist)
+    const r2 = await reaper.sweep({}); // sweep 2 (act)
+    const signals = killProc.calls.map(([, s]) => s);
+    expect(signals).toContain("SIGTERM");
+    expect(signals).not.toContain("SIGKILL");
+    // It exited under SIGTERM → still counts as reaped.
+    expect(r2.reaped.map((x) => x.pid)).toContain(ORPHAN_PID);
+  });
+});
+
+describe("ProcReaper.sweep — shadow (default) + off", () => {
+  it("shadow mode emits would-reap but kills NOTHING", async () => {
+    const { reaper, emit, killProc, ORPHAN_PID } = orphanFixture({ mode: "shadow" });
+    await reaper.sweep({}); // persist
+    const r2 = await reaper.sweep({}); // would act
+    expect(killProc.calls.filter(([, s]) => s !== 0)).toHaveLength(0);
+    expect(r2.reaped).toHaveLength(0);
+    expect(r2.wouldReap.map((x) => x.pid)).toContain(ORPHAN_PID);
+    expect(emit.calls.some((c) => c.type === "procOrphans.would-reap")).toBe(true);
+  });
+
+  it("default mode is shadow (constructed without mode)", () => {
+    const reaper = new ProcReaper({ psLister: () => [], log: silentLog() });
+    expect(reaper.mode).toBe("shadow");
+  });
+
+  it("off mode → empty report, no emit, no kill", async () => {
+    const { reaper, emit, killProc } = orphanFixture({ mode: "off" });
+    await reaper.sweep({});
+    const r2 = await reaper.sweep({});
+    expect(r2.reaped).toHaveLength(0);
+    expect(r2.wouldReap).toHaveLength(0);
+    expect(killProc.calls).toHaveLength(0);
+    expect(emit.calls).toHaveLength(0);
+  });
+});
+
+describe("ProcReaper.sweep — allowlist + live-tree sparing", () => {
+  it("allowlisted daemon/broker/monitor/self NEVER killed even when they look orphaned", async () => {
+    const psLines = [
+      psLine({ pid: 11, ppid: 1, etime: "99:00", command: "node /x/execution-core/daemon.mjs" }),
+      psLine({ pid: 12, ppid: 1, etime: "99:00", command: "node /x/broker/index.mjs" }),
+      psLine({ pid: 13, ppid: 1, etime: "99:00", command: "bun /x/orch-monitor/server.ts" }),
+      psLine({ pid: 14, ppid: 1, etime: "99:00", command: "node selfproc.mjs" }), // pid === selfPid
+    ];
+    const emit = recordingEmit();
+    const killProc = recordingKill({ alive: new Set([11, 12, 13, 14]) });
+    const reaper = new ProcReaper({
+      mode: "enforce",
+      worktreeRoot: WT_ROOT,
+      psLister: () => psLines,
+      lsofCwd: () => `${WT_ROOT}/CTL-X`,
+      liveAgents: () => [],
+      agentsResult: () => ({ ok: true, agents: [] }),
+      killProc,
+      sleep: async () => {},
+      now: () => 0,
+      selfPid: 14,
+      daemonPids: [],
+      emit,
+      log: silentLog(),
+    });
+    await reaper.sweep({});
+    const r2 = await reaper.sweep({});
+    expect(r2.reaped).toHaveLength(0);
+    expect(killProc.calls.filter(([, s]) => s !== 0)).toHaveLength(0);
+    expect(r2.spared.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("live-agent-owned process tree spared (cwd match OR subtree pid)", async () => {
+    // ps: a node child (pid 250) of a live agent root (pid 100).
+    const psLines = [
+      psLine({ pid: 100, ppid: 1, etime: "99:00", command: "claude --bg" }),
+      psLine({ pid: 250, ppid: 100, etime: "99:00", command: "node mcp.mjs" }),
+    ];
+    const emit = recordingEmit();
+    const killProc = recordingKill({ alive: new Set([250]) });
+    const reaper = new ProcReaper({
+      mode: "enforce",
+      worktreeRoot: WT_ROOT,
+      psLister: () => psLines,
+      lsofCwd: () => `${WT_ROOT}/CTL-X`,
+      liveAgents: () => [{ pid: 100, cwd: `${WT_ROOT}/CTL-X` }],
+      agentsResult: () => ({ ok: true, agents: [{ pid: 100, cwd: `${WT_ROOT}/CTL-X` }] }),
+      killProc,
+      sleep: async () => {},
+      now: () => 0,
+      selfPid: 1,
+      daemonPids: [],
+      emit,
+      log: silentLog(),
+    });
+    await reaper.sweep({});
+    const r2 = await reaper.sweep({});
+    expect(r2.reaped).toHaveLength(0);
+    expect(killProc.calls.filter(([, s]) => s !== 0)).toHaveLength(0);
+  });
+
+  it("interactive claude + children spared (cwd NOT under worktree root)", async () => {
+    const psLines = [
+      psLine({ pid: 300, ppid: 1, etime: "99:00", command: "node tool.mjs" }),
+    ];
+    const emit = recordingEmit();
+    const killProc = recordingKill({ alive: new Set([300]) });
+    const reaper = new ProcReaper({
+      mode: "enforce",
+      worktreeRoot: WT_ROOT,
+      psLister: () => psLines,
+      // cwd is the user's home, NOT under ~/catalyst/wt → the under-wt signal is REQUIRED.
+      lsofCwd: () => "/Users/test/projects/myapp",
+      liveAgents: () => [],
+      agentsResult: () => ({ ok: true, agents: [] }),
+      killProc,
+      sleep: async () => {},
+      now: () => 0,
+      selfPid: 1,
+      daemonPids: [],
+      emit,
+      log: silentLog(),
+    });
+    await reaper.sweep({});
+    const r2 = await reaper.sweep({});
+    expect(r2.reaped).toHaveLength(0);
+    expect(r2.spared.some((s) => s.reason === "not-under-worktree-root")).toBe(true);
+  });
+});
+
+describe("ProcReaper.sweep — degrade-safe + CATASTROPHE GUARD", () => {
+  it("CATASTROPHE GUARD: agents read {ok:false} ABORTS the whole sweep, kills nothing", async () => {
+    const { reaper, emit, killProc } = orphanFixture({ mode: "enforce", agentsOk: false });
+    await reaper.sweep({});
+    const r2 = await reaper.sweep({});
+    expect(killProc.calls.filter(([, s]) => s !== 0)).toHaveLength(0);
+    expect(r2.reaped).toHaveLength(0);
+    expect(r2.wouldReap).toHaveLength(0);
+    // distinct from a genuine empty list — emit a degraded-skip flag.
+    expect(emit.calls.some((c) => c.type === "procOrphans.spared")).toBe(true);
+    const degraded = emit.calls.find((c) => c.type === "procOrphans.spared");
+    expect(degraded.fields.reason).toBe("agents-unreadable");
+  });
+
+  it("a genuine empty agents list ({ok:true, agents:[]}) is NOT a catastrophe — sweep proceeds", async () => {
+    // The canonical orphan fixture already uses agents:[] ok:true; it kills on sweep 2.
+    const { reaper, killProc, ORPHAN_PID } = orphanFixture({ mode: "enforce", agentsOk: true });
+    await reaper.sweep({});
+    const r2 = await reaper.sweep({});
+    expect(r2.reaped.map((x) => x.pid)).toContain(ORPHAN_PID);
+  });
+
+  it("lsof cwd null (ambiguous) → spared cwd-unknown, never killed", async () => {
+    const { reaper, killProc } = orphanFixture({
+      mode: "enforce",
+      extra: { lsofCwd: () => null },
+    });
+    await reaper.sweep({});
+    const r2 = await reaper.sweep({});
+    expect(killProc.calls.filter(([, s]) => s !== 0)).toHaveLength(0);
+    expect(r2.spared.some((s) => s.reason === "cwd-unknown")).toBe(true);
+  });
+
+  it("an unreadable ps snapshot degrades safe (empty report, no kill)", async () => {
+    const killProc = recordingKill();
+    const reaper = new ProcReaper({
+      mode: "enforce",
+      worktreeRoot: WT_ROOT,
+      psLister: () => {
+        throw new Error("ps boom");
+      },
+      lsofCwd: () => `${WT_ROOT}/CTL-X`,
+      liveAgents: () => [],
+      agentsResult: () => ({ ok: true, agents: [] }),
+      killProc,
+      sleep: async () => {},
+      now: () => 0,
+      selfPid: 1,
+      emit: recordingEmit(),
+      log: silentLog(),
+    });
+    const r = await reaper.sweep({});
+    expect(r.reaped).toHaveLength(0);
+    expect(killProc.calls).toHaveLength(0);
+  });
+});
+
+describe("ProcReaper.sweep — targeted teardown sweep", () => {
+  it("sweep({worktreePath}) scopes to one worktree (CTL-X ≠ CTL-X9), sibling untouched", async () => {
+    const psLines = [
+      psLine({ pid: 700, ppid: 1, etime: "99:00", command: "node a.mjs" }), // under CTL-X
+      psLine({ pid: 800, ppid: 1, etime: "99:00", command: "node b.mjs" }), // under CTL-X9
+    ];
+    const cwdMap = { 700: `${WT_ROOT}/CTL-X`, 800: `${WT_ROOT}/CTL-X9` };
+    const emit = recordingEmit();
+    const killProc = recordingKill({ alive: new Set([700, 800]) });
+    const reaper = new ProcReaper({
+      mode: "enforce",
+      worktreeRoot: WT_ROOT,
+      psLister: () => psLines,
+      lsofCwd: (pid) => cwdMap[pid] ?? null,
+      liveAgents: () => [],
+      agentsResult: () => ({ ok: true, agents: [] }),
+      killProc,
+      sleep: async () => {},
+      now: () => 0,
+      selfPid: 1,
+      emit,
+      log: silentLog(),
+    });
+    await reaper.sweep({ worktreePath: `${WT_ROOT}/CTL-X` });
+    const r2 = await reaper.sweep({ worktreePath: `${WT_ROOT}/CTL-X` });
+    expect(r2.reaped.map((x) => x.pid)).toContain(700);
+    expect(r2.reaped.map((x) => x.pid)).not.toContain(800); // sibling untouched
+    expect(killProc.calls.some(([pid]) => pid === 800 && killProc.calls)).toBe(false);
+    expect(killProc.calls.filter(([pid, s]) => pid === 800 && s !== 0)).toHaveLength(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/proc-reaper.test.mjs
+++ b/plugins/dev/scripts/execution-core/proc-reaper.test.mjs
@@ -482,6 +482,73 @@ describe("ProcReaper.sweep — allowlist + live-tree sparing", () => {
     expect(killProc.calls.filter(([, s]) => s !== 0)).toHaveLength(0);
   });
 
+  it("spares a reparented grandchild running from a SUBDIR under a live agent's worktree (prefix cwd guard)", async () => {
+    // An orphaned (ppid 1) node whose cwd is a SUBDIR of a live agent's worktree
+    // — a reparented MCP-server / bun-test grandchild. Byte-exact cwd matching
+    // would kill it (it left LIVE_TREE and its exact cwd isn't an agent's cwd);
+    // the prefix-aware gate 6 spares it as live-agent-owned.
+    const psLines = [
+      psLine({ pid: 260, ppid: 1, etime: "99:00", command: "node mcp-server.mjs" }),
+    ];
+    const emit = recordingEmit();
+    const killProc = recordingKill({ alive: new Set([260]) });
+    const reaper = new ProcReaper({
+      mode: "enforce",
+      worktreeRoot: WT_ROOT,
+      psLister: () => psLines,
+      lsofCwd: () => `${WT_ROOT}/CTL-X/plugins/dev/scripts/execution-core`,
+      agentsResult: () => ({ ok: true, agents: [{ pid: 100, cwd: `${WT_ROOT}/CTL-X` }] }),
+      killProc,
+      sleep: async () => {},
+      now: () => 0,
+      selfPid: 1,
+      daemonPids: [],
+      emit,
+      log: silentLog(),
+    });
+    await reaper.sweep({});
+    const r2 = await reaper.sweep({});
+    expect(r2.reaped).toHaveLength(0);
+    expect(r2.spared.some((s) => s.reason === "live-agent-owned")).toBe(true);
+    expect(killProc.calls.filter(([, s]) => s !== 0)).toHaveLength(0);
+  });
+
+  it("does NOT SIGKILL when the pid is reused under a different argv during the grace window", async () => {
+    // A killable orphan persists two sweeps → enforce SIGTERMs it. During the
+    // grace window the pid is recycled into a DIFFERENT node/bun process (new
+    // argv). The pre-SIGKILL re-match keys on FULL argv, so the innocent reused
+    // pid must NOT be SIGKILL'd.
+    const orphanLine = psLine({ pid: 270, ppid: 1, etime: "99:00", command: "node worker-a.mjs" });
+    const reusedLine = psLine({ pid: 270, ppid: 1, etime: "00:05", command: "bun unrelated.mjs" });
+    let psCall = 0;
+    const psLister = () => {
+      psCall += 1;
+      // sweep1 snapshot (1) + sweep2 snapshot (2) → original; grace re-snapshot (3) → reused
+      return psCall <= 2 ? [orphanLine] : [reusedLine];
+    };
+    const emit = recordingEmit();
+    const killProc = recordingKill({ alive: new Set([270]) });
+    const reaper = new ProcReaper({
+      mode: "enforce",
+      worktreeRoot: WT_ROOT,
+      psLister,
+      lsofCwd: () => `${WT_ROOT}/CTL-X`,
+      agentsResult: () => ({ ok: true, agents: [] }),
+      killProc,
+      sleep: async () => {},
+      now: () => 0,
+      selfPid: 1,
+      daemonPids: [],
+      emit,
+      log: silentLog(),
+    });
+    await reaper.sweep({}); // sweep 1: first sighting → awaiting-second
+    const r2 = await reaper.sweep({}); // sweep 2: persisted → SIGTERM, grace, re-match fails → NO SIGKILL
+    expect(killProc.calls.filter(([, s]) => s === "SIGTERM")).toHaveLength(1);
+    expect(killProc.calls.filter(([, s]) => s === "SIGKILL")).toHaveLength(0);
+    expect(r2.reaped).toHaveLength(0);
+  });
+
   it("interactive claude + children spared (cwd NOT under worktree root)", async () => {
     const psLines = [
       psLine({ pid: 300, ppid: 1, etime: "99:00", command: "node tool.mjs" }),

--- a/plugins/dev/scripts/execution-core/reap-intent.mjs
+++ b/plugins/dev/scripts/execution-core/reap-intent.mjs
@@ -38,6 +38,18 @@ export const REAP_INTENT_TYPES = Object.freeze([
   // is already done); it is registered here ONLY so the emitter does not throw
   // "unknown reap-intent event type" and silently drop the count.
   "jobs.gc.swept",
+  // CTL-1165 D2: the orphan child-process reaper (proc-reaper.mjs). The periodic
+  // orphan-reaper timer emits the TRIGGER `procOrphans.reap-requested` (routed by
+  // reaper.mjs _handleProcOrphansSweep → procReaper.sweep); the ProcReaper itself
+  // emits the per-process FLAGs `procOrphans.reaped` (enforce kill),
+  // `procOrphans.would-reap` (shadow — the DEFAULT, kills nothing), and
+  // `procOrphans.spared` (corroboration-failed / catastrophe-guard skip). Only
+  // the `.reap-requested` trigger has a handle() case; the FLAGs are registered
+  // here ONLY so the emitter does not throw "unknown reap-intent event type".
+  "procOrphans.reap-requested",
+  "procOrphans.reaped",
+  "procOrphans.would-reap",
+  "procOrphans.spared",
   // CTL-695: terminal-worker reap — a phase signal reached failed/stalled, or the
   // final monitor-deploy phase completed, with no successor dispatch to trigger the
   // happy-path predecessor reap. Routed to the single-target (busy-OK) reap path.
@@ -72,6 +84,9 @@ const FIELD_MAP = {
   dominantPhase: "dominant_phase",
   quietMs: "quiet_ms",
   orchId: "orch_id",
+  // CTL-1165 D2: proc-reaper process-level fields (already snake_case identity).
+  pid: "pid",
+  command: "command",
 };
 
 /**

--- a/plugins/dev/scripts/execution-core/reap-intent.mjs
+++ b/plugins/dev/scripts/execution-core/reap-intent.mjs
@@ -32,6 +32,12 @@ export const REAP_INTENT_TYPES = Object.freeze([
   "worktree.presweep.reap-requested",
   "pr.merged.cleanup-requested",
   "orphans.reap-requested",
+  // CTL-1165 D3: the ~/.claude/jobs/<id> dir GC (job-dir-gc.mjs) emits this FLAG
+  // after a sweep so the reclaim is auditable in the event log. A FLAG class —
+  // the reaper has no handle() case for it (it is not a reap REQUEST, the work
+  // is already done); it is registered here ONLY so the emitter does not throw
+  // "unknown reap-intent event type" and silently drop the count.
+  "jobs.gc.swept",
   // CTL-695: terminal-worker reap — a phase signal reached failed/stalled, or the
   // final monitor-deploy phase completed, with no successor dispatch to trigger the
   // happy-path predecessor reap. Routed to the single-target (busy-OK) reap path.

--- a/plugins/dev/scripts/execution-core/reap-intent.test.mjs
+++ b/plugins/dev/scripts/execution-core/reap-intent.test.mjs
@@ -46,12 +46,13 @@ describe("emitReapIntent", () => {
     await expect(emitReapIntent("bogus.event", {})).rejects.toThrow(/unknown/);
   });
 
-  it("exposes REAP_INTENT_TYPES with 18 entries", async () => {
+  it("exposes REAP_INTENT_TYPES with 19 entries", async () => {
     const { REAP_INTENT_TYPES } = await freshModule();
-    expect(REAP_INTENT_TYPES.length).toBe(18);
+    expect(REAP_INTENT_TYPES.length).toBe(19);
     expect(REAP_INTENT_TYPES).toContain("phase.yield.reap-requested");
     expect(REAP_INTENT_TYPES).toContain("pr.merged.cleanup-requested");
     expect(REAP_INTENT_TYPES).toContain("orphans.reap-requested");
+    expect(REAP_INTENT_TYPES).toContain("jobs.gc.swept"); // CTL-1165 D3
     expect(REAP_INTENT_TYPES).toContain("worktree.cleanup-deferred"); // CTL-791
     // CTL-1004 stall-janitor (shadow-first) event vocabulary.
     expect(REAP_INTENT_TYPES).toContain("janitor.worktree.deferred");
@@ -91,6 +92,16 @@ describe("emitReapIntent", () => {
       expect(last.event).toBe(type);
       expect(last.ticket).toBe("CTL-1005");
     }
+  });
+
+  it("accepts jobs.gc.swept end-to-end (CTL-1165 D3)", async () => {
+    const { emitReapIntent, REAP_INTENT_TYPES } = await freshModule();
+    expect(REAP_INTENT_TYPES).toContain("jobs.gc.swept");
+    const ok = await emitReapIntent("jobs.gc.swept", { reclaimed: 3 });
+    expect(ok).toBe(true);
+    const last = JSON.parse(readFileSync(LOG_PATH, "utf8").trim().split("\n").pop());
+    expect(last.event).toBe("jobs.gc.swept");
+    expect(last.reclaimed).toBe(3);
   });
 
   it("accepts phase.terminal.reap-requested (CTL-695)", async () => {

--- a/plugins/dev/scripts/execution-core/reap-intent.test.mjs
+++ b/plugins/dev/scripts/execution-core/reap-intent.test.mjs
@@ -46,14 +46,19 @@ describe("emitReapIntent", () => {
     await expect(emitReapIntent("bogus.event", {})).rejects.toThrow(/unknown/);
   });
 
-  it("exposes REAP_INTENT_TYPES with 19 entries", async () => {
+  it("exposes REAP_INTENT_TYPES with 23 entries", async () => {
     const { REAP_INTENT_TYPES } = await freshModule();
-    expect(REAP_INTENT_TYPES.length).toBe(19);
+    expect(REAP_INTENT_TYPES.length).toBe(23);
     expect(REAP_INTENT_TYPES).toContain("phase.yield.reap-requested");
     expect(REAP_INTENT_TYPES).toContain("pr.merged.cleanup-requested");
     expect(REAP_INTENT_TYPES).toContain("orphans.reap-requested");
     expect(REAP_INTENT_TYPES).toContain("jobs.gc.swept"); // CTL-1165 D3
     expect(REAP_INTENT_TYPES).toContain("worktree.cleanup-deferred"); // CTL-791
+    // CTL-1165 D2: the orphan child-process reaper vocabulary.
+    expect(REAP_INTENT_TYPES).toContain("procOrphans.reap-requested");
+    expect(REAP_INTENT_TYPES).toContain("procOrphans.reaped");
+    expect(REAP_INTENT_TYPES).toContain("procOrphans.would-reap");
+    expect(REAP_INTENT_TYPES).toContain("procOrphans.spared");
     // CTL-1004 stall-janitor (shadow-first) event vocabulary.
     expect(REAP_INTENT_TYPES).toContain("janitor.worktree.deferred");
     expect(REAP_INTENT_TYPES).toContain("janitor.would.reap-request");
@@ -102,6 +107,28 @@ describe("emitReapIntent", () => {
     const last = JSON.parse(readFileSync(LOG_PATH, "utf8").trim().split("\n").pop());
     expect(last.event).toBe("jobs.gc.swept");
     expect(last.reclaimed).toBe(3);
+  });
+
+  it("accepts the procOrphans.* types end-to-end with pid/command fields (CTL-1165 D2)", async () => {
+    const { emitReapIntent, REAP_INTENT_TYPES } = await freshModule();
+    for (const type of [
+      "procOrphans.reap-requested",
+      "procOrphans.reaped",
+      "procOrphans.would-reap",
+      "procOrphans.spared",
+    ]) {
+      expect(REAP_INTENT_TYPES).toContain(type);
+      const ok = await emitReapIntent(type, {
+        pid: 4242,
+        command: "node",
+        reason: "orphan-node-under-worktree",
+      });
+      expect(ok).toBe(true);
+      const last = JSON.parse(readFileSync(LOG_PATH, "utf8").trim().split("\n").pop());
+      expect(last.event).toBe(type);
+      expect(last.pid).toBe(4242);
+      expect(last.command).toBe("node");
+    }
   });
 
   it("accepts phase.terminal.reap-requested (CTL-695)", async () => {

--- a/plugins/dev/scripts/execution-core/reaper.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.mjs
@@ -157,6 +157,11 @@ export class Reaper {
     // Returns the raw bg_job_id string or null (fail-open: skips the reap).
     // Tests inject a stub; the daemon injects a real orchDir-backed reader.
     readSignalBgJobId = () => null,
+    // CTL-1165 D2 — the orphan child-process reaper (proc-reaper.mjs). DEFAULT
+    // null so all pre-D2 reaper behavior is unchanged: _handleProcOrphansSweep
+    // is a no-op when no ProcReaper is injected. The daemon constructs the
+    // production ProcReaper (DEFAULT mode:"shadow") and injects it here.
+    procReaper = null,
   } = {}) {
     this.executorReap = executorReap;
     this.executorRmForce = executorRmForce;
@@ -174,6 +179,7 @@ export class Reaper {
     this.now = now;
     this.log = logger;
     this.readSignalBgJobId = readSignalBgJobId;
+    this.procReaper = procReaper;
     this._inflight = new Map(); // key → expiresAt
   }
 
@@ -247,6 +253,12 @@ export class Reaper {
           break;
         case "orphans.reap-requested":
           await this._handleOrphansSweep(event);
+          break;
+        // CTL-1165 D2: the orphan child-process sweep trigger (emitted by the
+        // 600s orphan-reaper timer). Routed to the injected ProcReaper — a no-op
+        // when none is injected, so all pre-D2 behavior is unchanged.
+        case "procOrphans.reap-requested":
+          await this._handleProcOrphansSweep(event);
           break;
         default:
           this.log.warn({ event: event.event }, "reaper: unknown reap-intent event");
@@ -541,6 +553,20 @@ export class Reaper {
       return;
     }
     await this.scanOrphans();
+  }
+
+  /**
+   * _handleProcOrphansSweep — CTL-1165 D2. Run one orphan child-process sweep via
+   * the injected ProcReaper (proc-reaper.mjs). The ProcReaper reaps reparented
+   * node/bun grandchildren that `claude stop` orphaned (the RSS bulk of the
+   * leak), gated by a hard never-kill allowlist + LIVE_TREE correlation + a
+   * CATASTROPHE GUARD (a failed `claude agents` read aborts the sweep). It
+   * DEFAULTS to mode:"shadow" (emits would-reap, kills nothing). A null
+   * procReaper makes this a complete no-op, so the case is inert until the daemon
+   * injects a production ProcReaper — every pre-D2 reaper test is unaffected.
+   */
+  async _handleProcOrphansSweep(_event) {
+    await this.procReaper?.sweep({});
   }
 
   /**

--- a/plugins/dev/scripts/execution-core/reaper.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.mjs
@@ -35,6 +35,21 @@ const CLAUDE_BIN = process.env.CATALYST_DISPATCH_CLAUDE_BIN || "claude";
 const DEDUPE_WINDOW_MS = Number(process.env.REAPER_DEDUPE_WINDOW_MS) || 60_000;
 const DEFAULT_MIN_IDLE_MS = 15 * 60 * 1000; // 15 min
 
+/**
+ * isSweepReapableStatus — CTL-1165 D4. The periodic orphan sweep's status gate.
+ * Returns true for a session status the sweep is willing to CONSIDER reaping:
+ * `'idle'`, plus the null-like states (`null`/`undefined`/`''`). A reboot-survivor
+ * `status:null` background zombie (the 6 mini incidents) was hard-skipped by the
+ * pre-D4 `status !== "idle"` gate and so was never considered. Any other truthy
+ * status string (`'busy'`/`'active'`/future states) is NOT sweep-reapable — the
+ * busy-spare is never weakened. Eligibility here only means "consider"; the
+ * background-only, cwd-vanished, and recency gates still run afterward.
+ */
+export function isSweepReapableStatus(status) {
+  if (status === null || status === undefined || status === "") return true;
+  return status === "idle";
+}
+
 // CTL-661 Phase 5 — the per-ticket reconciler's spawn-grace window. A revive or
 // advance reassigns a ticket's bg_job_id to a fresh successor; for a brief
 // window two background sessions co-exist by design while the new one takes
@@ -103,6 +118,11 @@ export async function defaultAssessWorktreeRemoval(event, readAgents = () => lis
 export class Reaper {
   constructor({
     executorReap = defaultExecutorReap,
+    // CTL-1165 D4: the stuck-registration escalation seam. `claude stop` no-ops
+    // on the reboot-survivor zombies on mini; when stop fails AND a fresh agents()
+    // re-read still lists the shortId, _handleBgReap escalates to `claude rm`.
+    // Same {ok,error} contract as executorReap; tests inject a recording mock.
+    executorRmForce = defaultExecutorRmForce,
     agents = defaultAgents,
     emit = defaultEmit,
     gitWorktreeRemove = defaultGitWorktreeRemove,
@@ -139,6 +159,7 @@ export class Reaper {
     readSignalBgJobId = () => null,
   } = {}) {
     this.executorReap = executorReap;
+    this.executorRmForce = executorRmForce;
     this.agents = agents;
     this.emit = emit;
     this.gitWorktreeRemove = gitWorktreeRemove;
@@ -303,14 +324,75 @@ export class Reaper {
       return;
     }
     const result = await this.executorReap(shortId);
-    const echoSuffix = result.ok ? "reap-complete" : "reap-failed";
-    const echoEvent = event.event.replace("reap-requested", echoSuffix);
-    await this.emit(echoEvent, {
+
+    // Happy path — `claude stop` succeeded → emit reap-complete, no escalation.
+    if (result.ok) {
+      await this.emit(event.event.replace("reap-requested", "reap-complete"), {
+        ticket: event.ticket,
+        phase: event.phase,
+        bgJobId,
+        worktreePath: event.worktree_path,
+      });
+      return;
+    }
+
+    // CTL-1165 D4: stop NON-OK. The reboot-survivor `status:null` zombies on mini
+    // no-op `claude stop` ("background service may be restarting"). Escalate to
+    // `claude rm <shortId>` ONLY after a CONFIRMING fresh agents() re-read still
+    // lists the same shortId — if the session is gone now, there is nothing to rm
+    // (a successful-but-async stop, or it exited on its own); surface reap-failed
+    // with the original stop error and let the next tick no-op. We re-read because
+    // `claude rm` ALSO tears down state and must not fire on a guess.
+    let stillRegistered = false;
+    try {
+      const reread = await this.agents();
+      stillRegistered = reread.some((a) => {
+        try {
+          return shortIdFromSessionId(a.sessionId) === shortId;
+        } catch {
+          return false;
+        }
+      });
+    } catch {
+      stillRegistered = false; // unreadable fleet → degrade safe, do NOT rm
+    }
+
+    if (!stillRegistered) {
+      await this.emit(event.event.replace("reap-requested", "reap-failed"), {
+        ticket: event.ticket,
+        phase: event.phase,
+        bgJobId,
+        worktreePath: event.worktree_path,
+        ...(result.error ? { reason: result.error } : {}),
+      });
+      return;
+    }
+
+    // Confirmed-stuck registration — escalate stop → rm.
+    const rm = await this.executorRmForce(shortId);
+    if (rm.ok) {
+      await this.emit(event.event.replace("reap-requested", "reap-complete"), {
+        ticket: event.ticket,
+        phase: event.phase,
+        bgJobId,
+        worktreePath: event.worktree_path,
+      });
+      return;
+    }
+
+    // stop no-op THEN rm no-op → loudly flag the stuck registration ONCE. The
+    // handle() per-event de-dupe (:189-190) drops a re-delivered identical event,
+    // so this never loops; the *.reap-failed is a terminal FLAG, not a re-trigger.
+    this.log.warn(
+      { bgJobId, shortId, stopError: result.error, rmError: rm.error },
+      "reaper: stuck-registration — claude stop AND claude rm both no-op'd",
+    );
+    await this.emit(event.event.replace("reap-requested", "reap-failed"), {
       ticket: event.ticket,
       phase: event.phase,
       bgJobId,
       worktreePath: event.worktree_path,
-      ...(result.error ? { reason: result.error } : {}),
+      reason: "stop-and-rm-noop",
     });
   }
 
@@ -472,7 +554,12 @@ export class Reaper {
     for (const a of live) {
       if (!a.sessionId || !a.cwd) continue;
       if (isSelfSession(a.sessionId)) continue;
-      if (a.status !== "idle") continue;
+      // CTL-1165 D4: consider idle AND null-like statuses (the reboot-survivor
+      // `status:null` zombies). The pre-D4 `status !== "idle"` skip never even
+      // looked at them. Busy/active are still spared — isSweepReapableStatus is
+      // false for any other truthy string. (Self-skip above + background-only,
+      // cwd-vanished, and recency gates below all still run, unchanged.)
+      if (!isSweepReapableStatus(a.status)) continue;
       // CTL-649 kind guard: the periodic sweep enumerates ALL live sessions —
       // it can see the user's interactive windows — so it is strict
       // background-ONLY. Skip interactive AND unknown/null kinds: never
@@ -795,6 +882,25 @@ async function defaultExecutorReap(shortId) {
     });
     if ((res.status ?? 0) === 0) return { ok: true };
     return { ok: false, error: res.stderr?.trim() || `claude stop rc=${res.status}` };
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+}
+
+// CTL-1165 D4: the stuck-registration escalation wrapper. `claude rm <shortId>`
+// force-deregisters a session whose `claude stop` no-op'd. Same never-throw
+// {ok,error} contract as defaultExecutorReap. Only ever called by _handleBgReap
+// AFTER a failed stop AND a confirming live re-read of the same shortId, so it
+// never fires on a guess. Takes the same 8-char short id (claude-ids.mjs:8: rm
+// rejects full UUIDs).
+async function defaultExecutorRmForce(shortId) {
+  try {
+    const res = spawnSync(CLAUDE_BIN, ["rm", shortId], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if ((res.status ?? 0) === 0) return { ok: true };
+    return { ok: false, error: res.stderr?.trim() || `claude rm rc=${res.status}` };
   } catch (err) {
     return { ok: false, error: err.message };
   }

--- a/plugins/dev/scripts/execution-core/reaper.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.mjs
@@ -355,21 +355,31 @@ export class Reaper {
     // (a successful-but-async stop, or it exited on its own); surface reap-failed
     // with the original stop error and let the next tick no-op. We re-read because
     // `claude rm` ALSO tears down state and must not fire on a guess.
-    let stillRegistered = false;
+    let rereadTarget = null;
     try {
       const reread = await this.agents();
-      stillRegistered = reread.some((a) => {
-        try {
-          return shortIdFromSessionId(a.sessionId) === shortId;
-        } catch {
-          return false;
-        }
-      });
+      rereadTarget =
+        reread.find((a) => {
+          try {
+            return shortIdFromSessionId(a.sessionId) === shortId;
+          } catch {
+            return false;
+          }
+        }) ?? null;
     } catch {
-      stillRegistered = false; // unreadable fleet → degrade safe, do NOT rm
+      rereadTarget = null; // unreadable fleet → degrade safe, do NOT rm
     }
 
-    if (!stillRegistered) {
+    // CTL-1165 D4 (hardened): escalate to `claude rm` ONLY for a confirmed-stuck
+    // ZOMBIE — still registered AND its status is sweep-reapable (idle / null /
+    // undefined: the reboot-survivor class `claude stop` can't clear). A BUSY (or
+    // any other non-reapable) re-read means `claude stop` failed TRANSIENTLY on a
+    // still-LIVE worker ("background service may be restarting") — and `claude rm`
+    // deletes the session AND its worktree (often the SAME ticket worktree a live
+    // successor runs in), so we must NOT escalate. Emit reap-failed and let the
+    // periodic orphan sweep retry once the worker actually goes idle. An
+    // unreadable re-read (rereadTarget === null) also degrades safe (no rm).
+    if (!rereadTarget || !isSweepReapableStatus(rereadTarget.status)) {
       await this.emit(event.event.replace("reap-requested", "reap-failed"), {
         ticket: event.ticket,
         phase: event.phase,

--- a/plugins/dev/scripts/execution-core/reaper.test.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.test.mjs
@@ -274,6 +274,35 @@ describe("Reaper._handleBgReap", () => {
     expect(executorRmForce).toHaveBeenCalledWith("abc12345");
   });
 
+  it("does NOT escalate to `claude rm` when the re-read shows the session is BUSY (transient stop failure on a live worker)", async () => {
+    // CTL-1165 D4 hardened: `claude stop` failed ("background service may be
+    // restarting") but the re-read shows the target is BUSY — a still-LIVE worker,
+    // NOT a stuck zombie. `claude rm` would delete its (often shared) worktree, so
+    // we must NOT escalate; emit reap-failed and let the periodic sweep retry once
+    // the worker goes idle.
+    const executorReap = mock(() =>
+      Promise.resolve({ ok: false, error: "background service may be restarting" }),
+    );
+    const executorRmForce = mock(() => Promise.resolve({ ok: true }));
+    const emitted = [];
+    const r = new Reaper({
+      executorReap,
+      executorRmForce,
+      agents: agentsFixture([
+        { sessionId: "abc12345-aaaa-bbbb-cccc-dddddddddddd", status: "busy", cwd: "/wt/x", kind: "background" },
+      ]),
+      emit: (evt, fields) => {
+        emitted.push({ evt, fields });
+        return Promise.resolve();
+      },
+      log: silentLog(),
+    });
+    await r.handle({ event: "phase.abort.reap-requested", bg_job_id: "abc12345" });
+    expect(executorReap).toHaveBeenCalledTimes(1);
+    expect(executorRmForce).not.toHaveBeenCalled();
+    expect(emitted.find((e) => e.evt === "phase.abort.reap-failed")).toBeTruthy();
+  });
+
   it("does NOT escalate to `claude rm` when stop succeeds (emits reap-complete)", async () => {
     const executorReap = mock(() => Promise.resolve({ ok: true }));
     const executorRmForce = mock(() => Promise.resolve({ ok: true }));

--- a/plugins/dev/scripts/execution-core/reaper.test.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.test.mjs
@@ -1321,3 +1321,51 @@ describe("defaultReadSignalBgJobId (CTL-778)", () => {
     expect(defaultReadSignalBgJobId("/orch", "CTL-1", null)).toBeNull();
   });
 });
+
+// CTL-1165 D2: the orphan child-process reaper seam. reaper.mjs gains a
+// `procReaper=null` constructor arg + a `procOrphans.reap-requested` switch case
+// (`_handleProcOrphansSweep`) that delegates to procReaper.sweep — a NO-OP when
+// no ProcReaper is injected, so all pre-D2 reaper tests are unaffected.
+describe("Reaper.handle procOrphans.reap-requested (CTL-1165 D2)", () => {
+  it("routes procOrphans.reap-requested to the injected procReaper.sweep", async () => {
+    let swept = 0;
+    const fakeProcReaper = {
+      sweep: async () => {
+        swept++;
+        return { reaped: [], wouldReap: [], spared: [] };
+      },
+    };
+    const r = new Reaper({
+      agents: agentsFixture([]),
+      emit: mock(() => Promise.resolve()),
+      log: silentLog(),
+      procReaper: fakeProcReaper,
+    });
+    await r.handle({ event: "procOrphans.reap-requested" });
+    expect(swept).toBe(1);
+  });
+
+  it("is a SAFE no-op when no procReaper is injected (default null) — does not throw", async () => {
+    const r = new Reaper({
+      agents: agentsFixture([]),
+      emit: mock(() => Promise.resolve()),
+      log: silentLog(),
+    });
+    // No procReaper → the case must not throw and must not touch any executor.
+    await expect(r.handle({ event: "procOrphans.reap-requested" })).resolves.toBeUndefined();
+  });
+
+  it("a throwing procReaper.sweep is swallowed by handle()'s try/catch (never wedges the loop)", async () => {
+    const r = new Reaper({
+      agents: agentsFixture([]),
+      emit: mock(() => Promise.resolve()),
+      log: silentLog(),
+      procReaper: {
+        sweep: async () => {
+          throw new Error("sweep boom");
+        },
+      },
+    });
+    await expect(r.handle({ event: "procOrphans.reap-requested" })).resolves.toBeUndefined();
+  });
+});

--- a/plugins/dev/scripts/execution-core/reaper.test.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.test.mjs
@@ -9,6 +9,7 @@ import {
   defaultAgents,
   defaultAssessWorktreeRemoval,
   defaultReadSignalBgJobId,
+  isSweepReapableStatus,
 } from "./reaper.mjs";
 import {
   refreshAgents,
@@ -143,6 +144,10 @@ describe("Reaper._handleBgReap", () => {
     const emitted = [];
     const r = new Reaper({
       executorReap: () => Promise.resolve({ ok: false, error: "boom" }),
+      // CTL-1165 D4: a non-ok stop now re-reads agents() and (since the target is
+      // still listed) escalates to executorRmForce. Inject a fake so the test
+      // never spawns a real `claude rm`; rm also no-ops → terminal reap-failed.
+      executorRmForce: () => Promise.resolve({ ok: false, error: "rm boom" }),
       agents: agentsFixture([
         { sessionId: "abc12345-aaaa-bbbb-cccc-dddddddddddd", status: "idle", cwd: "/wt/x" },
       ]),
@@ -242,6 +247,103 @@ describe("Reaper._handleBgReap", () => {
     await r.handle({ event: "phase.yield.reap-requested", bg_job_id: "abc12345" });
     await r.handle({ event: "phase.yield.reap-requested", bg_job_id: "abc12345" });
     expect(executor).toHaveBeenCalledTimes(1);
+  });
+
+  // ─── CTL-1165 D4: claude stop → claude rm escalation for stuck registrations ──
+  // On mini, 6 reboot-survivor `status:null` sessions no-op'd `claude stop`. When
+  // stop fails AND a fresh agents() re-read still lists the same shortId, escalate
+  // to `claude rm <shortId>`. If rm also no-ops, emit *.reap-failed reason
+  // stop-and-rm-noop ONCE (the handle() de-dupe drops a re-delivered identical event).
+  it("escalates to `claude rm` when stop is non-ok and the session is still registered", async () => {
+    const executorReap = mock(() => Promise.resolve({ ok: false, error: "background service may be restarting" }));
+    const executorRmForce = mock(() => Promise.resolve({ ok: true }));
+    const r = new Reaper({
+      executorReap,
+      executorRmForce,
+      // agents() lists the target on BOTH the initial find AND the post-stop re-read.
+      agents: agentsFixture([
+        { sessionId: "abc12345-aaaa-bbbb-cccc-dddddddddddd", status: null, cwd: "/wt/x", kind: "background" },
+      ]),
+      emit: mock(() => Promise.resolve()),
+      log: silentLog(),
+    });
+    await r.handle({ event: "phase.abort.reap-requested", bg_job_id: "abc12345" });
+    expect(executorReap).toHaveBeenCalledTimes(1);
+    expect(executorReap).toHaveBeenCalledWith("abc12345");
+    expect(executorRmForce).toHaveBeenCalledTimes(1);
+    expect(executorRmForce).toHaveBeenCalledWith("abc12345");
+  });
+
+  it("does NOT escalate to `claude rm` when stop succeeds (emits reap-complete)", async () => {
+    const executorReap = mock(() => Promise.resolve({ ok: true }));
+    const executorRmForce = mock(() => Promise.resolve({ ok: true }));
+    const emitted = [];
+    const r = new Reaper({
+      executorReap,
+      executorRmForce,
+      agents: agentsFixture([
+        { sessionId: "abc12345-aaaa-bbbb-cccc-dddddddddddd", status: null, cwd: "/wt/x", kind: "background" },
+      ]),
+      emit: (evt, fields) => { emitted.push({ evt, fields }); return Promise.resolve(); },
+      log: silentLog(),
+    });
+    await r.handle({ event: "phase.abort.reap-requested", bg_job_id: "abc12345" });
+    expect(executorRmForce).not.toHaveBeenCalled();
+    expect(emitted.find((e) => e.evt === "phase.abort.reap-complete")).toBeTruthy();
+  });
+
+  it("does NOT escalate when stop fails but a fresh re-read shows the session gone", async () => {
+    // stop returned non-ok but the session disappeared from the re-read → nothing
+    // to rm; surface reap-failed without an rm call (next tick is a no-op).
+    let call = 0;
+    const executorReap = mock(() => Promise.resolve({ ok: false, error: "rc=1" }));
+    const executorRmForce = mock(() => Promise.resolve({ ok: true }));
+    const r = new Reaper({
+      executorReap,
+      executorRmForce,
+      // First agents() (the find) lists the target; the post-stop re-read is empty.
+      agents: mock(() => {
+        call += 1;
+        return Promise.resolve(
+          call === 1
+            ? [{ sessionId: "abc12345-aaaa-bbbb-cccc-dddddddddddd", status: null, cwd: "/wt/x", kind: "background" }]
+            : [],
+        );
+      }),
+      emit: mock(() => Promise.resolve()),
+      log: silentLog(),
+    });
+    await r.handle({ event: "phase.abort.reap-requested", bg_job_id: "abc12345" });
+    expect(executorRmForce).not.toHaveBeenCalled();
+  });
+
+  it("stop-noop then rm-noop logs + emits reap-failed reason stop-and-rm-noop ONCE (no loop)", async () => {
+    const executorReap = mock(() => Promise.resolve({ ok: false, error: "stop noop" }));
+    const executorRmForce = mock(() => Promise.resolve({ ok: false, error: "rm noop" }));
+    const emitted = [];
+    const warns = [];
+    const logger = { info: () => {}, warn: (o) => warns.push(o), error: () => {} };
+    const r = new Reaper({
+      executorReap,
+      executorRmForce,
+      // The stuck session is listed on every agents() read.
+      agents: agentsFixture([
+        { sessionId: "abc12345-aaaa-bbbb-cccc-dddddddddddd", status: null, cwd: "/wt/x", kind: "background" },
+      ]),
+      emit: (evt, fields) => { emitted.push({ evt, fields }); return Promise.resolve(); },
+      log: logger,
+    });
+    const ev = { event: "phase.abort.reap-requested", bg_job_id: "abc12345" };
+    await r.handle(ev);
+    const failed = emitted.filter((e) => e.evt === "phase.abort.reap-failed");
+    expect(failed.length).toBe(1);
+    expect(failed[0].fields.reason).toBe("stop-and-rm-noop");
+    expect(warns.length).toBe(1);
+    // A second identical handle() is dropped by the per-event de-dupe — no loop.
+    await r.handle(ev);
+    expect(executorReap).toHaveBeenCalledTimes(1);
+    expect(executorRmForce).toHaveBeenCalledTimes(1);
+    expect(emitted.filter((e) => e.evt === "phase.abort.reap-failed").length).toBe(1);
   });
 });
 
@@ -643,6 +745,105 @@ describe("Reaper.scanOrphans", () => {
     await r.scanOrphans();
     expect(emitted.length).toBe(1);
     expect(emitted[0].bgJobId).toBe("11111111");
+  });
+
+  // ─── CTL-1165 D4: status:null sweep gap ────────────────────────────────────
+  // The 6 reboot-survivor zombies on mini are `kind:"background"` `status:null`
+  // sessions whose cwd vanished. Pre-D4 scanOrphans hard-skipped at
+  // `if (a.status !== "idle") continue;`, so they were NEVER considered. D4 swaps
+  // that gate to `isSweepReapableStatus(a.status)` so idle|null|undefined|"" are
+  // all eligible-to-consider (still subject to the background-only + cwd-vanished
+  // + recency gates).
+  it("reaps a null-status background orphan whose cwd vanished (CTL-1165 D4 — THE RED CASE)", async () => {
+    const emitted = [];
+    const r = new Reaper({
+      agents: agentsFixture([
+        { sessionId: "11111111-aaaa-bbbb-cccc-dddddddddddd", cwd: "/wt/missing", status: null, kind: "background" },
+      ]),
+      cwdExists: () => Promise.resolve(false),
+      lastSeenMs: () => null,
+      emit: (evt, fields) => { emitted.push({ evt, ...fields }); return Promise.resolve(); },
+      log: silentLog(),
+    });
+    await r.scanOrphans();
+    expect(emitted.length).toBe(1);
+    expect(emitted[0].evt).toBe("phase.abort.reap-requested");
+    expect(emitted[0].bgJobId).toBe("11111111");
+    expect(emitted[0].reason).toBe("orphan-cwd-missing");
+  });
+
+  it("still reaps an idle background orphan whose cwd vanished (regression guard)", async () => {
+    const emitted = [];
+    const r = new Reaper({
+      agents: agentsFixture([
+        { sessionId: "11111111-aaaa-bbbb-cccc-dddddddddddd", cwd: "/wt/missing", status: "idle", kind: "background" },
+      ]),
+      cwdExists: () => Promise.resolve(false),
+      lastSeenMs: () => null,
+      emit: (evt, fields) => { emitted.push({ evt, ...fields }); return Promise.resolve(); },
+      log: silentLog(),
+    });
+    await r.scanOrphans();
+    expect(emitted.length).toBe(1);
+    expect(emitted[0].bgJobId).toBe("11111111");
+  });
+
+  it("still spares a busy session even with a vanished cwd (never weaken busy-spare)", async () => {
+    const emitted = [];
+    const r = new Reaper({
+      agents: agentsFixture([
+        { sessionId: "11111111-aaaa-bbbb-cccc-dddddddddddd", cwd: "/wt/missing", status: "busy", kind: "background" },
+      ]),
+      cwdExists: () => Promise.resolve(false),
+      lastSeenMs: () => null,
+      emit: (evt, fields) => { emitted.push({ evt, ...fields }); return Promise.resolve(); },
+      log: silentLog(),
+    });
+    await r.scanOrphans();
+    expect(emitted.length).toBe(0);
+  });
+
+  it("spares a null-status background orphan whose cwd STILL exists", async () => {
+    const emitted = [];
+    const r = new Reaper({
+      agents: agentsFixture([
+        { sessionId: "11111111-aaaa-bbbb-cccc-dddddddddddd", cwd: "/wt/present", status: null, kind: "background" },
+      ]),
+      cwdExists: () => Promise.resolve(true), // cwd still on disk → not an orphan
+      lastSeenMs: () => null,
+      emit: (evt, fields) => { emitted.push({ evt, ...fields }); return Promise.resolve(); },
+      log: silentLog(),
+    });
+    await r.scanOrphans();
+    expect(emitted.length).toBe(0);
+  });
+
+  it("spares a recently-active null-status orphan (lastSeenMs < minIdleMs)", async () => {
+    const emitted = [];
+    const r = new Reaper({
+      minIdleMs: 15 * 60 * 1000,
+      agents: agentsFixture([
+        { sessionId: "11111111-aaaa-bbbb-cccc-dddddddddddd", cwd: "/wt/missing", status: null, kind: "background" },
+      ]),
+      cwdExists: () => Promise.resolve(false),
+      lastSeenMs: () => 60_000, // touched 1 min ago — still in use
+      emit: (evt, fields) => { emitted.push({ evt, ...fields }); return Promise.resolve(); },
+      log: silentLog(),
+    });
+    await r.scanOrphans();
+    expect(emitted.length).toBe(0);
+  });
+});
+
+// ─── CTL-1165 D4: isSweepReapableStatus pure predicate ───────────────────────
+describe("isSweepReapableStatus (CTL-1165 D4)", () => {
+  it("treats idle/null/undefined/'' as eligible-to-consider, busy/active as not", () => {
+    expect(isSweepReapableStatus("idle")).toBe(true);
+    expect(isSweepReapableStatus(null)).toBe(true);
+    expect(isSweepReapableStatus(undefined)).toBe(true);
+    expect(isSweepReapableStatus("")).toBe(true); // empty string → null-like
+    expect(isSweepReapableStatus("busy")).toBe(false);
+    expect(isSweepReapableStatus("active")).toBe(false);
   });
 });
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -90,6 +90,13 @@ The `orchestration.dispatchMode` key picks how Catalyst runs each ticket:
 | `orchestration.stalePrRescue.behindThreshold` | `10` | BEHIND-commit count that triggers a rebase rescue (commits-behind below this are skipped). |
 | `orchestration.stalePrRescue.maxAttempts` | `1` | Max rescue attempts per ticket. After exhaustion, the ticket is escalated to `needs-human`. |
 | `orchestration.stalePrRescue.maxConflictFiles` | `5` | Max conflicting files before a DIRTY PR is deemed unresolvable and escalated instead of dispatched. |
+| `orchestration.orphanReaper.procReaper.mode` | `shadow` | Orphan child-process reaper mode. `off` disables it; `shadow` (the default) logs `procOrphans.would-reap` for each orphaned reparented `node`/`bun` grandchild a dead worker left behind but **kills nothing**; `enforce` actually `SIGTERM`→grace→`SIGKILL`s them. Ships in `shadow` so the never-kill allowlist + live-agent process-tree correlation can be audited on real hosts before any `enforce` flip. |
+| `orchestration.orphanReaper.procReaper.graceMs` | `5000` | Milliseconds to wait after `SIGTERM` before re-probing and (only if still alive) `SIGKILL`ing, so `node`/`bun` can flush. |
+| `orchestration.orphanReaper.procReaper.minEtimeSec` | `900` | A process must have run at least this long (elapsed time) before it is eligible — corroboration only, never the sole gate. |
+| `orchestration.orphanReaper.procReaper.worktreeRoot` | `~/catalyst/wt` | Only orphans whose working directory is under this root are reapable; an interactive `claude` or dev shell outside it is never touched. |
+| `orchestration.orphanReaper.procReaper.allowlistPatterns` | `[]` | Extra case-insensitive argv substrings to never kill, on top of the built-in allowlist (the daemon, `broker/index.mjs`, `orch-monitor/server.ts`, the entire live-agent process tree, Tailscale, pid 1, and any foreign-uid process). |
+
+The orphan child-process reaper is the corroboration-heavy companion to the session-level reaper: `claude stop` deregisters a worker's claude agent but leaves its reparented `node`/`bun` grandchildren (MCP servers, sub-agent tooling, `bun test` runners) running — the bulk of the resident-memory leak. It runs on the same 600-second cadence as the orphan-session sweep and refuses to act unless every signal corroborates: a successful `claude agents` read this cycle (a failed read aborts the whole sweep), the process is reparented and outside the live-agent process tree, its command and working directory match, and it has persisted across two consecutive sweeps.
 
 For `execution-core` mode, the number of workers comes from a separate committed block, `orchestration.executionCore.maxParallel` (default `4`). One daemon runs per machine and serves all your projects.
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -95,8 +95,18 @@ The `orchestration.dispatchMode` key picks how Catalyst runs each ticket:
 | `orchestration.orphanReaper.procReaper.minEtimeSec` | `900` | A process must have run at least this long (elapsed time) before it is eligible — corroboration only, never the sole gate. |
 | `orchestration.orphanReaper.procReaper.worktreeRoot` | `~/catalyst/wt` | Only orphans whose working directory is under this root are reapable; an interactive `claude` or dev shell outside it is never touched. |
 | `orchestration.orphanReaper.procReaper.allowlistPatterns` | `[]` | Extra case-insensitive argv substrings to never kill, on top of the built-in allowlist (the daemon, `broker/index.mjs`, `orch-monitor/server.ts`, the entire live-agent process tree, Tailscale, pid 1, and any foreign-uid process). |
+| `orchestration.fleetHealth.enabled` | `true` | Whether the pre-exhaustion fleet-health probe runs. Set `false` (or `CATALYST_FLEET_HEALTH=0`) to disable it entirely. |
+| `orchestration.fleetHealth.intervalMs` | `120000` | How often the probe samples the four steady-state signals (milliseconds). |
+| `orchestration.fleetHealth.jobsThreshold` | `500` | `~/.claude/jobs` dir count at or above which the `jobs` signal trips. |
+| `orchestration.fleetHealth.agentsThreshold` | `12` | Live background-agent count at or above which the `agents` signal trips. |
+| `orchestration.fleetHealth.procsThreshold` | `40` | Resident `node`/`bun` worker-process count at or above which the `procs` signal trips. |
+| `orchestration.fleetHealth.swapUsedMbThreshold` | `4096` | macOS swap-used MB at or above which the `swap` signal trips. |
+| `orchestration.fleetHealth.selfHealEnabled` | `false` | Whether a sustained breach triggers self-heal (the two orphan-reaper intents plus a bounded `ppid==1` `node`/`bun` child sweep). **Default OFF** — the first ship is a pure alert. Enable with `EXECUTION_CORE_FLEET_SELF_HEAL=1`. |
+| `orchestration.fleetHealth.sustainedTicks` | `2` | Consecutive degraded ticks required before self-heal fires (once per breach episode; re-armed only after a healthy tick). |
 
 The orphan child-process reaper is the corroboration-heavy companion to the session-level reaper: `claude stop` deregisters a worker's claude agent but leaves its reparented `node`/`bun` grandchildren (MCP servers, sub-agent tooling, `bun test` runners) running — the bulk of the resident-memory leak. It runs on the same 600-second cadence as the orphan-session sweep and refuses to act unless every signal corroborates: a successful `claude agents` read this cycle (a failed read aborts the whole sweep), the process is reparented and outside the live-agent process tree, its command and working directory match, and it has persisted across two consecutive sweeps.
+
+The fleet-health probe is the steady-state guardrail that ties the reapers together: it samples four degradation signals (the `~/.claude/jobs` dir count, the live background-agent count, the resident `node`/`bun` worker-process count, and macOS swap-used MB), each read fail-safe so an unreadable signal can only cause the probe to under-react. On a threshold breach it emits one `fleet.health.degraded` event (the host lives in the OTel `resource` block, so the monitor composes `fleet.health.degraded.<host>`). Self-heal is **default OFF** — the first ship is pure observability. When enabled it fires the same two reap intents the 600-second timer emits plus a capped (25-process) `node`/`bun` child sweep, once per sustained breach, re-armed only after the fleet recovers to healthy.
 
 For `execution-core` mode, the number of workers comes from a separate committed block, `orchestration.executionCore.maxParallel` (default `4`). One daemon runs per machine and serves all your projects.
 


### PR DESCRIPTION
## CTL-1165 — bound the execution-core fleet so it runs for months without a restart

After 16 days uptime, mini's execution-core leaked never-reaped `claude --bg` workers (~1,798 `~/.claude/jobs` dirs / 864 MB; 45 node + 29 bun + 7 claude orphan procs) until RAM + all 17 GB of swap were exhausted and every HTTP service hung. Reboot recovered it; this PR fixes the root causes.

### Corrected root cause
The three original CTL-657 bugs are **already fixed** in current code (verified: no idle-gate on single-target stop, kill is `claude stop` not a pid-file, predecessor reap fires). The leak recurred for **five different reasons**, each addressed here:

| Driver | Gap | Fix |
|---|---|---|
| **D3** | nothing ever deleted `~/.claude/jobs/<id>` dirs | `job-dir-gc.mjs` — fail-closed, 3-gate, batch-capped GC on the 600s timer (deletes the dir alone, never `claude rm`) |
| **D4** | `scanOrphans` skipped `status:null` sessions (the reboot-survivor zombies) | `isSweepReapableStatus` (idle/null/undefined) + a `claude stop → claude rm` escalation **gated on a sweep-reapable re-read** |
| **D1** | `countBackgroundAgents` didn't exclude the controlling session | self-exclusion (fails closed = starve-safe) + a fence of tests pinning the already-landed live-count gate |
| **D2** | `claude stop` leaves reparented node/bun grandchildren (the RSS bulk) | `proc-reaper.mjs` — orphan child-process reaper, **default `mode:shadow`** (kills nothing), LIVE_TREE + allowlist + cwd + etime + 2-sweep gates, catastrophe guard |
| **D5** | nothing warned before swap exhaustion | `fleet-health-probe.mjs` — emits `fleet.health.degraded`; **self-heal default OFF** (emit-only), routes any sweep through D2's gated reaper |

### Safety posture (first deploy is observe-only)
- proc-reaper defaults to **shadow** — emits `procOrphans.would-reap`, kills nothing — so the allowlist + LIVE_TREE correlation can be audited on real hosts before any `enforce` flip.
- fleet self-heal defaults **OFF** — pure alert.
- A child process dies only if proc-reaper.mode **and** self-heal are *both* turned on — two independent gates.

### Verification
- Built design→implement→verify under multi-agent workflows. An adversarial review (9 dimensions incl. a process-kill red-team) returned **fix-first**; all 4 must-fixes + 2 hardenings were applied and re-verified via **mutation testing** (each fix's regression test fails when the fix is reverted).
- Key remediations: deleted D5's crude child-kill (empty skip-set would've SIGTERM'd the daemon itself); D4 `claude rm` can no longer tear down a *busy* worker's shared worktree; D2 spares reparented MCP/bun grandchildren in worktree subdirs; the 4 new suites added to the required CI gate.
- Full execution-core suite: **3,760 pass**, only the 3 known pre-existing flakes (CTL-587/716 timing, heartbeat host.name pollution).

### Rollout
Merge → deploy to mini → restart stack → observe shadow logs (`procOrphans.would-reap`, `jobs.gc.swept`, `fleet.health.degraded`) → only then flip `procReaper.mode:enforce` once the shadow log is clean.

Closes CTL-1165. Reopens/supersedes CTL-657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
