### PR TITLE
feat(dev): CTL-1011 — make applyAssignee self-assign loud (config-missing & scope-failure)

### DIFF
--- a/docs/orchestrator-overview.md
+++ b/docs/orchestrator-overview.md
@@ -561,3 +561,62 @@ If a HUD button later writes the same sentinel it requires no logic changes —
 - [ADR-006](adrs.md) — global state JSON design
 - [ADR-008](adrs.md) — SQLite session store
 - [ADR-014](adrs.md) — worker owns full PR lifecycle (no more `gh pr merge --auto`)
+
+## Self-assign activation runbook (CTL-1011)
+
+The execution-core daemon writes the Catalyst bot as the Linear assignee on every ticket it claims (`applyAssignee`, CTL-781). The mechanism is always invoked — when `botUserId` is absent or the token lacks scope, one deduped `warn` surfaces the gap instead of a silent skip.
+
+### Before you start
+
+Two prerequisites block the board-visibility outcome (assigned agent visible in Linear):
+
+1. **OAuth decision** — choose Path A or Path B:
+   - **Path A**: grant `app:assignable` scope to the existing Catalyst Orchestrator app (`ff78d890-7906-4c22-b2f5-020bd150c790`). The simplest path if your workspace already has the app installed.
+   - **Path B**: create a dedicated bot member account, add it to your Linear workspace, and use its `viewer.id` as the `botUserId`. The preferred path for fine-grained control.
+
+2. **Token scope** — the OAuth access token stored under `catalyst.linear.bot.orchestrator.accessToken` must include `app:assignable`. Re-mint the token after granting the scope (step 4 below).
+
+### Activation steps
+
+1. **Decide Path A or B** (see above). For Path A, go to your Linear workspace settings → API → OAuth apps → Catalyst Orchestrator → grant `app:assignable`.
+
+2. **Re-mint the access token**:
+   ```bash
+   # Uses the client credentials flow (requires clientId + clientSecret already in global config)
+   catalyst-execution-core remint-token --actor orchestrator
+   # or manually via the OAuth endpoint
+   ```
+
+3. **Capture `viewer.id`** for the app actor:
+   ```bash
+   TOKEN=$(jq -r '.catalyst.linear.bot.orchestrator.accessToken' ~/.config/catalyst/config.json)
+   BOT_ID=$(curl -s -X POST https://api.linear.app/graphql \
+     -H "Authorization: Bearer $TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"query":"query{viewer{id name}}"}' | jq -r .data.viewer.id)
+   echo "botUserId = $BOT_ID"
+   ```
+
+4. **Set `botUserId` in Layer-2 on all hosts** (never committed — lives in `~/.config/catalyst/config.json`):
+   ```bash
+   jq --arg id "$BOT_ID" '.catalyst.linear.bot.orchestrator.botUserId = $id' \
+     ~/.config/catalyst/config.json > /tmp/cfg.json && mv /tmp/cfg.json ~/.config/catalyst/config.json
+   ```
+   Repeat on every host that runs the execution-core daemon.
+
+5. **Restart the daemon** — `botUserId` is read only at startup:
+   ```bash
+   catalyst-execution-core restart
+   ```
+
+6. **Smoke-test** — let one ticket enter Triage and confirm the Catalyst bot appears as assignee in Linear. The CTL-1011 Phase 1/2 guards make a misstep loud: a missing `botUserId` prints one `warn` ("self-assign disabled") and a scope error prints one `warn` per Linear team ("app-actor lacks assignee scope") — both include the remedy.
+
+7. **Backfill** (CTL-827) and enable the CTL-1159 ownership gate after the smoke-test passes.
+
+### Diagnostic signals
+
+| Symptom | Cause | Remedy |
+|---------|-------|--------|
+| `linear-write: self-assign disabled — botUserId not configured` (once per process) | `catalyst.linear.bot.orchestrator.botUserId` is null/absent | Steps 3–5 above |
+| `linear-write: assignee write rejected — app-actor lacks assignee scope for team` (once per team) | Token missing `app:assignable` | Steps 1–2 + 5 |
+| `applyAssignee` returns `reason: "verify-failed"` | Write succeeded but read-back mismatch (Linear eventual consistency lag) | Usually self-correcting; check if another user is reassigning the ticket |

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -459,18 +459,49 @@ export function applyEstimate({ ticket, estimate, exec = defaultExec, fetchLabel
   }
 }
 
+// CTL-1011: dedup Sets so a misconfigured host says so once, not once per claim.
+// Process-global (mirrors scheduler.warnedPerProjectConfigs). Reset seam for tests.
+const _warnedSelfAssignDisabled = new Set();
+const _warnedScopeFailureTeams = new Set();
+export function _resetAssigneeWarnDedup() {
+  _warnedSelfAssignDisabled.clear();
+  _warnedScopeFailureTeams.clear();
+}
+
+// Identifies the OAuth-scope failure so it can be surfaced once per team.
+const _SCOPE_ERR_RE = /lack(s|ed)?\s+the\s+required\s+scope|app user not valid/i;
+
 // applyAssignee — write the Catalyst bot as the Linear assignee on a claimed
 // ticket (CTL-781). Mirrors applyLabel: try/catch, log.warn, tagged
 // {applied, reason} return, CTL-587-style read-back so applied:true means a
 // follow-up read confirmed the assignee landed. Never throws.
-// reason values: null | "invalid-user" | "transient" | "verify-failed".
+// reason values: null | "invalid-user" | "transient" | "scope" | "verify-failed".
 export function applyAssignee({ ticket, userId, exec = defaultExec }) {
   if (typeof userId !== "string" || userId.length === 0) {
+    if (!_warnedSelfAssignDisabled.has("invalid-user")) {
+      _warnedSelfAssignDisabled.add("invalid-user");
+      log.warn(
+        { ticket, remedy: "set catalyst.linear.bot.orchestrator.botUserId in ~/.config/catalyst/config.json" },
+        "linear-write: self-assign disabled — botUserId not configured (CTL-1011); claim left unassigned"
+      );
+    }
     return { applied: false, reason: "invalid-user" };
   }
   try {
     const writeRes = exec("linearis", ["issues", "update", ticket, "--assignee", userId]);
     if (writeRes.code !== 0) {
+      if (_SCOPE_ERR_RE.test(writeRes.stderr ?? "")) {
+        const team = teamOf(ticket) ?? "unknown";
+        if (!_warnedScopeFailureTeams.has(team)) {
+          _warnedScopeFailureTeams.add(team);
+          log.warn(
+            { ticket, team, userId, code: writeRes.code,
+              remedy: "re-mint the app-actor OAuth token with scope app:mentionable,app:assignable" },
+            "linear-write: assignee write rejected — app-actor lacks assignee scope for team (CTL-1011); surfaced once/team"
+          );
+        }
+        return { applied: false, reason: "scope" };
+      }
       log.warn(
         { ticket, userId, code: writeRes.code, stderr: writeRes.stderr },
         "linear-write: assignee write failed (exit non-zero)"

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -1,6 +1,6 @@
 // linear-write.test.mjs — execution-core Linear status write-back (CTL-558).
 // Run: cd plugins/dev/scripts/execution-core && bun test linear-write.test.mjs
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, spyOn, beforeEach } from "bun:test";
 import {
   applyPhaseStatus,
   applyTerminalDone,
@@ -12,7 +12,9 @@ import {
   applyAssignee,
   teamOf,
   classifyLabelFailure,
+  _resetAssigneeWarnDedup,
 } from "./linear-write.mjs";
+import { log } from "./config.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 
 const okExec = (calls) => (cmd, args) => {
@@ -1082,5 +1084,47 @@ describe("applyAssignee (CTL-781)", () => {
     expect(applyAssignee({ ticket: "CTL-1", userId: null, exec })).toEqual({ applied: false, reason: "invalid-user" });
     expect(applyAssignee({ ticket: "CTL-1", exec })).toEqual({ applied: false, reason: "invalid-user" });
     expect(calls).toHaveLength(0);
+  });
+
+  describe("CTL-1011: deduped warns", () => {
+    beforeEach(() => { _resetAssigneeWarnDedup(); });
+
+    test("invalid-user → warns once with remedy, deduped across calls, still 0 exec calls", () => {
+      const warn = spyOn(log, "warn");
+      const calls = [];
+      const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0 }; };
+      expect(applyAssignee({ ticket: "CTL-D1", userId: null, exec })).toEqual({ applied: false, reason: "invalid-user" });
+      expect(applyAssignee({ ticket: "CTL-D2", userId: "", exec })).toEqual({ applied: false, reason: "invalid-user" });
+      expect(applyAssignee({ ticket: "CTL-D3", exec })).toEqual({ applied: false, reason: "invalid-user" });
+      expect(calls).toHaveLength(0);
+      const idWarns = warn.mock.calls.filter((c) =>
+        JSON.stringify(c).includes("botUserId") || JSON.stringify(c).includes("self-assign disabled"));
+      expect(idWarns.length).toBe(1);
+      warn.mockRestore();
+    });
+
+    test("scope-error stderr → reason 'scope', warned once per team with remedy", () => {
+      const warn = spyOn(log, "warn");
+      const exec = (_cmd, args) =>
+        args[1] === "update"
+          ? { code: 1, stdout: "", stderr: "App user not valid - One or more app users lack the required scope." }
+          : { code: 127 };
+      expect(applyAssignee({ ticket: "CTL-S1", userId: BOT, exec })).toEqual({ applied: false, reason: "scope" });
+      expect(applyAssignee({ ticket: "CTL-S2", userId: BOT, exec })).toEqual({ applied: false, reason: "scope" });
+      const ctlScopeWarns = warn.mock.calls.filter((c) =>
+        JSON.stringify(c).includes("scope") && JSON.stringify(c).includes("CTL"));
+      expect(ctlScopeWarns.length).toBe(1);
+      // a different team warns again
+      expect(applyAssignee({ ticket: "ADV-1", userId: BOT, exec })).toEqual({ applied: false, reason: "scope" });
+      const advScopeWarns = warn.mock.calls.filter((c) =>
+        JSON.stringify(c).includes("scope") && JSON.stringify(c).includes("ADV"));
+      expect(advScopeWarns.length).toBe(1);
+      warn.mockRestore();
+    });
+
+    test("non-scope exit-non-zero keeps reason 'transient' (back-compat)", () => {
+      const exec = () => ({ code: 1, stdout: "", stderr: "update-failed" });
+      expect(applyAssignee({ ticket: "CTL-T1", userId: BOT, exec })).toEqual({ applied: false, reason: "transient" });
+    });
   });
 });

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -650,13 +650,13 @@ function dispatchTriage(
     applied: res.applied,
     reason: res.reason,
   });
-  // CTL-781: self-assign the bot on claim — best-effort, never blocks triage.
-  if (botWriteId) {
-    try {
-      applyAssignee({ ticket: identifier, userId: botWriteId });
-    } catch (err) {
-      log.warn({ identifier, err: err.message }, "monitor: self-assign threw — continuing");
-    }
+  // CTL-781 + CTL-1011: self-assign the bot on claim — always invoked so a
+  // missing botUserId surfaces the deduped config-missing warn (invalid-user)
+  // instead of silently skipping. Best-effort, never blocks triage.
+  try {
+    applyAssignee({ ticket: identifier, userId: botWriteId });
+  } catch (err) {
+    log.warn({ identifier, err: err.message }, "monitor: self-assign threw — continuing");
   }
   return true;
 }

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -1792,6 +1792,25 @@ describe("dispatchTriage — CTL-781 respect-assignment + self-assign", () => {
     expect(applyTriageStatus).toHaveBeenCalledTimes(1);
     expect(appendEvent).toHaveBeenCalledTimes(1);
   });
+
+  test("botWriteId absent → applyAssignee still called with userId:undefined (loud-no-op, CTL-1011)", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const applyAssignee = mock(() => ({ applied: false, reason: "invalid-user" }));
+    const fetchAssignee = () => ({ known: true, assignee: null });
+    handleStateChangedEvent(toTriageEvent("ENG-NU1"), {
+      dispatch,
+      orchDir,
+      botUserIds: new Set([BOT]),
+      // botWriteId intentionally absent
+      fetchAssignee,
+      applyAssignee,
+      triageBudget: { remaining: 5 },
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(applyAssignee).toHaveBeenCalledTimes(1);
+    expect(applyAssignee.mock.calls[0][0]).toMatchObject({ ticket: "ENG-NU1", userId: undefined });
+  });
 });
 
 describe("sweepMissingTriage — CTL-781 threading", () => {

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4522,15 +4522,13 @@ export function schedulerTick(
         },
         { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE }
       );
-      // CTL-781: self-assign the Catalyst bot so the claim is visible in
-      // Linear. Best-effort (safeWrite) — an assignment failure never blocks
-      // the pipeline; the read-back inside applyAssignee logs the gap.
-      if (botWriteId) {
-        safeWrite(() => writeStatus.applyAssignee?.({ ticket: t.identifier, userId: botWriteId }), {
-          ticket: t.identifier,
-          phase: "assignment",
-        });
-      }
+      // CTL-781 + CTL-1011: self-assign the Catalyst bot. Always invoked so a
+      // null botWriteId surfaces the deduped config-missing warn instead of a
+      // silent skip. Best-effort (safeWrite) — never blocks the pipeline.
+      safeWrite(() => writeStatus.applyAssignee?.({ ticket: t.identifier, userId: botWriteId }), {
+        ticket: t.identifier,
+        phase: "assignment",
+      });
     }
   }
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -8212,7 +8212,7 @@ describe("schedulerTick — CTL-781 respect-assignment + self-assign", () => {
     expect(fetchAssigneeCalls).toHaveLength(0);
   });
 
-  test("botWriteId absent → dispatch proceeds, NO applyAssignee call (predicate may still gate)", () => {
+  test("botWriteId absent → dispatch proceeds, applyAssignee called with userId:undefined (loud-no-op, CTL-1011)", () => {
     const dispatch = fakeDispatch();
     const assigneeCalls = [];
     const writeStatus = {
@@ -8221,7 +8221,7 @@ describe("schedulerTick — CTL-781 respect-assignment + self-assign", () => {
       applyLabel: () => {},
       applyAssignee: (a) => {
         assigneeCalls.push(a);
-        return { applied: true, reason: null };
+        return { applied: false, reason: "invalid-user" };
       },
     };
     const gateway = gatewayStub({ "CTL-WI1": null });
@@ -8236,7 +8236,10 @@ describe("schedulerTick — CTL-781 respect-assignment + self-assign", () => {
       hasTriageArtifact: () => true, // CTL-1150: bypass triage gate, subject is botWriteId-absent
     });
     expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-WI1"]);
-    expect(assigneeCalls).toHaveLength(0);
+    // CTL-1011: applyAssignee is now always invoked; the deduped invalid-user
+    // branch handles the null/undefined botWriteId instead of silently skipping.
+    expect(assigneeCalls).toHaveLength(1);
+    expect(assigneeCalls[0]).toMatchObject({ ticket: "CTL-WI1", userId: undefined });
   });
 
   test("applyAssignee failure (applied:false) does not fail the dispatch — ticket still advances", () => {

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -153,9 +153,11 @@ Each carries a `botUserId` (the Linear user UUID of that app actor). The daemon 
 
 | Key | What it does |
 | --- | --- |
-| `catalyst.linear.bot.worker.botUserId` | Linear user UUID of the worker app actor. Suppresses self-echo on the worker's own mirror comments / description updates |
-| `catalyst.linear.bot.orchestrator.botUserId` | Linear user UUID of the orchestrator app actor. Suppresses self-echo on orchestrator-posted updates |
+| `catalyst.linear.bot.worker.botUserId` | Linear user UUID of the worker app actor. Suppresses self-echo on mirror comments / description updates. Also the read ID for the daemon's self-echo filter. |
+| `catalyst.linear.bot.orchestrator.botUserId` | Linear user UUID of the orchestrator app actor. **Also drives self-assign on claim (CTL-1011)** — the daemon writes this UUID as the Linear assignee when it claims a ticket. When absent, `applyAssignee` emits a single deduped `warn` and leaves the ticket unassigned. Daemon reads it **only at startup** — restart required after changing. |
 | `catalyst.linear.bot.worker.{clientId,clientSecret,webhookSecret,accessToken}` | OAuth app-actor credentials for the worker identity. Secrets — keep in the un-committed global config |
+
+> **Self-assign activation:** `catalyst.linear.bot.orchestrator.botUserId` must be set AND the app-actor token must carry the `app:assignable` OAuth scope for the assignee write to succeed. If the token lacks scope, a deduped `warn` is emitted once per Linear team with the re-mint remedy. See [Self-assign activation runbook](/reference/configuration#self-assign-activation-runbook) below.
 
 ### Back-compat (transition period)
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-15T05:00:00Z -->
<!-- Last updated: 2026-06-15T05:00:00Z -->
<!-- PR: #2046 -->
<!-- Previous commits: 1de58199ff20103fff1955d8d3e6ccbdd560fc09 -->

## Summary

`applyAssignee` was silently doing nothing when `botUserId` was absent or when the app-actor token lacked the assignee-write scope — both are misconfiguration conditions that should be visible. This PR makes both failure modes loud (once-per-process / once-per-team) with actionable remedies, and adds documentation so the self-assign feature is actually activatable.

- **Phase 1** — `applyAssignee` now emits a single deduped `warn` when `botUserId` is absent (the `invalid-user` branch), instead of silently skipping. The `if (botWriteId)` guard removed from `monitor.mjs` and `scheduler.mjs` so the loud-once branch actually fires.
- **Phase 2** — Scope-failure stderr (`"App user ... lacks the required scope"`) is classified separately: warns once per Linear team with the re-mint remedy and returns `reason:"scope"`. Non-scope exit-non-zero keeps `reason:"transient"` (back-compat preserved).
- **Phase 3** — `configuration.md` table extended with self-assign role + startup-restart note; self-assign activation runbook (steps 1–7 + diagnostics table) appended to `orchestrator-overview.md`.
- `_resetAssigneeWarnDedup()` exported for test isolation; 5 new tests covering dedup, scope classifier, back-compat, and call-site guard removal.

## Changes Made

### Execution-core (`plugins/dev/scripts/execution-core/`)

**`linear-write.mjs`** (+32/-1)
- Add `_warnedSelfAssignDisabled` Set: single deduped `warn` when `botUserId` is absent (invalid-user branch). Previously silent-per-claim.
- Add `_SCOPE_ERR_RE` regex + `_warnedScopeFailureTeams` Set: classify OAuth scope-error stderr, warn once per Linear team with re-mint remedy, return `reason:"scope"`.
- Export `_resetAssigneeWarnDedup()` for test isolation.

**`monitor.mjs`** (+7/-7)
- Remove `if (botWriteId)` guard — `applyAssignee` now called unconditionally; the loud no-op handles null internally.

**`scheduler.mjs`** (+7/-9)
- Same guard removal as `monitor.mjs`. Pre-existing circuit-breaker timing failure fixed as side-effect.

### Tests

**`linear-write.test.mjs`** (+45/-1)
- 3 new CTL-1011 tests: deduped invalid-user warn (exactly 1 across 3 calls), scope-error per-team dedup, non-scope transient back-compat.

**`monitor.test.mjs`** (+19/-0)
- Call-site guard removal covered (applyAssignee called with `userId:undefined`).

**`scheduler.test.mjs`** (+6/-3)
- botWriteId-absent test updated: expects `applyAssignee` called with `userId:undefined` (loud-no-op contract).

### Documentation

**`website/src/content/docs/reference/configuration.md`** (+4/-2)
- `botUserId` table row extended with self-assign role description and startup-restart note.

**`docs/orchestrator-overview.md`** (+59/-0)
- Self-assign activation runbook appended: steps 1–7, diagnostic signals table, Path A vs B decision guide.

## How to Verify It

- [x] `bun test linear-write.test.mjs` — 92 pass (was 89), 0 fail: 3 new CTL-1011 tests green ✅
- [x] `bun test monitor.test.mjs` — 126 pass (was 125), 1 pre-existing fail (CTL-716 burst budget timing, unrelated) ✅
- [x] `bun test scheduler.test.mjs` — 492 pass (was 491), 0 fail: circuit-breaker timing pre-existing failure fixed as side-effect ✅
- [x] Full suite: `bun test` — 3762 pass, 8 fail (all pre-existing, none from changed files) ✅
- [x] Non-scope transient back-compat: `reason:"transient"` still asserted for stderr `"update-failed"` ✅
- [x] CI: Cloudflare Pages, audit-references, check-versions, docs-gate, execution-core-unit-tests, validate — all pass ✅
- [ ] **Manual**: Configure `botUserId` in `.catalyst/config.json`, restart daemon, claim a ticket — verify board shows agent as assignee within one claim cycle
- [ ] **Manual**: Confirm missing-config warn appears exactly once in daemon logs (not once-per-claim)
- [ ] **Manual** (scope path): On a team with scope-restricted token, confirm warn appears once with re-mint remedy

## Related Issues/PRs

- Fixes https://linear.app/adva/issue/CTL-1011

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-716
