### PR TITLE
fix(dev): CTL-1169 — daemon-health hysteresis (stop the degraded↔healthy notification flap)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/nav-signal.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/nav-signal.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from "bun:test";
 import {
   deriveNavSignal,
   deriveDaemonHealth,
+  DEFAULT_DAEMON_HEALTHY_WINDOW_MS,
 } from "../lib/nav-signal.mjs";
 import type {
   BoardPayload,
@@ -210,8 +211,37 @@ describe("nav-signal projection (CTL-896 / SHELL6)", () => {
     });
 
     it("a stale-but-grace local heartbeat → degraded", () => {
-      const last = { "mac-mini": "2026-06-08T11:58:00.000Z" }; // 2min ago (> 30s, < 5min)
+      const last = { "mac-mini": "2026-06-08T11:58:00.000Z" }; // 2min ago (> 90s window, < 5min)
       expect(deriveDaemonHealth(last, "mac-mini", { now })).toBe("degraded");
+    });
+
+    // CTL-1169 hysteresis: a beat that is late by more than one 30s interval but
+    // within the healthy window must NOT flap to degraded — this is the jitter
+    // (median ~35s, spikes to ~60–90s) that was storming the desktop with
+    // "daemon degraded" notifications.
+    it("a heartbeat 45s ago (one missed beat) stays healthy — no flap", () => {
+      const last = { "mac-mini": "2026-06-08T11:59:15.000Z" }; // 45s ago
+      expect(deriveDaemonHealth(last, "mac-mini", { now })).toBe("healthy");
+    });
+
+    it("the healthy window is wider than one 30s heartbeat interval (hysteresis)", () => {
+      expect(DEFAULT_DAEMON_HEALTHY_WINDOW_MS).toBeGreaterThan(30_000);
+      // a beat exactly at the window edge is still healthy; just past it degrades
+      const edge = now - DEFAULT_DAEMON_HEALTHY_WINDOW_MS;
+      const past = now - DEFAULT_DAEMON_HEALTHY_WINDOW_MS - 1;
+      expect(
+        deriveDaemonHealth({ "mac-mini": new Date(edge).toISOString() }, "mac-mini", { now }),
+      ).toBe("healthy");
+      expect(
+        deriveDaemonHealth({ "mac-mini": new Date(past).toISOString() }, "mac-mini", { now }),
+      ).toBe("degraded");
+    });
+
+    it("an explicit intervalMs override still wins (env-tunable path)", () => {
+      const last = { "mac-mini": "2026-06-08T11:59:15.000Z" }; // 45s ago
+      // a tight 30s override reproduces the old behavior — proves the server's
+      // MONITOR_DAEMON_HEALTHY_WINDOW_MS override reaches the classifier.
+      expect(deriveDaemonHealth(last, "mac-mini", { now, intervalMs: 30_000 })).toBe("degraded");
     });
 
     it("a very old local heartbeat → offline", () => {

--- a/plugins/dev/scripts/orch-monitor/lib/nav-signal.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/nav-signal.d.mts
@@ -5,6 +5,13 @@ import type { HostLivenessStatus, LivenessThresholds } from "./node-liveness.mjs
 /** The footer daemon-health vocabulary (mapped from node-liveness status). */
 export type DaemonHealth = "healthy" | "degraded" | "offline";
 
+/**
+ * CTL-1169: the default "healthy" window for the daemon-health dot — wider than
+ * one raw heartbeat interval (hysteresis) so normal heartbeat jitter does not flap
+ * the footer dot / fire spurious notifications.
+ */
+export const DEFAULT_DAEMON_HEALTHY_WINDOW_MS: number;
+
 /** The single nav-signal projection that feeds the rail's live badges/dots. */
 export interface NavSignal {
   /** Active execution-core workers — the Workers nav badge. */

--- a/plugins/dev/scripts/orch-monitor/lib/nav-signal.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/nav-signal.mjs
@@ -20,7 +20,26 @@
 // is a later cluster concern (BFF3); here the daemon dot reflects the local daemon
 // and nothing else.
 
-import { classifyHostLiveness } from "./node-liveness.mjs";
+import {
+  classifyHostLiveness,
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+} from "./node-liveness.mjs";
+
+// CTL-1169: hysteresis for the daemon-health DOT/notification path.
+//
+// classifyHostLiveness calls a host "live" only while its last heartbeat is ≤ one
+// 30s interval old — but the daemon emits on that SAME 30s cadence, so real-world
+// jitter (measured gaps: median ~35s, spikes to 60–100s) routinely pushes the age
+// just past 30s before the next (late) beat lands. With the desktop app firing a
+// notification on every healthy↔degraded transition, that boundary-flap becomes a
+// notification storm. So the daemon-health classification uses a wider "healthy"
+// window than the raw cluster-liveness overlay: ~3 missed beats. This is ONLY the
+// nav daemon-health projection — the cluster overlay (overlayClusterLiveness) keeps
+// the tight 30s/5min eviction window. A genuinely overdue daemon still degrades
+// (≥3 missed beats) and still goes offline at the 5min grace. Tune via the server
+// env override (MONITOR_DAEMON_HEALTHY_WINDOW_MS); the real fix for the >60s gaps is
+// CTL-1170 (stop the event-loop stalls), after which this window can shrink.
+export const DEFAULT_DAEMON_HEALTHY_WINDOW_MS = 3 * DEFAULT_HEARTBEAT_INTERVAL_MS;
 
 /**
  * @typedef {"healthy" | "degraded" | "offline"} DaemonHealth
@@ -90,12 +109,16 @@ export function deriveNavSignal(board, { daemon, liveness } = {}) {
  * @param {Record<string, string>} lastSeenByHost  readClusterHeartbeats output
  * @param {string} localHostName  the local node's name (config.getHostName / hostName())
  * @param {{ now?: number, intervalMs?: number, graceMs?: number }} [opts]
+ *   `intervalMs` is the "healthy" window and defaults to
+ *   DEFAULT_DAEMON_HEALTHY_WINDOW_MS (CTL-1169 hysteresis), NOT one raw heartbeat
+ *   interval — so normal heartbeat jitter does not flap the footer dot. Pass an
+ *   explicit value (e.g. from MONITOR_DAEMON_HEALTHY_WINDOW_MS) to override.
  * @returns {DaemonHealth}
  */
 export function deriveDaemonHealth(
   lastSeenByHost,
   localHostName,
-  { now = Date.now(), intervalMs, graceMs } = {},
+  { now = Date.now(), intervalMs = DEFAULT_DAEMON_HEALTHY_WINDOW_MS, graceMs } = {},
 ) {
   const seen =
     lastSeenByHost && typeof lastSeenByHost === "object" ? lastSeenByHost : {};

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1286,7 +1286,15 @@ export function createServer(opts: CreateServerOptions): BunServer {
       // event-log path itself (config.getEventLogPath, UTC YYYY-MM) so the read
       // path matches exactly what the daemon writes — no format drift here.
       const lastSeen = deps.readClusterHeartbeats({});
-      return deps.deriveDaemonHealth(lastSeen, deps.getHostName());
+      // CTL-1169: the daemon-health dot uses a hysteresis window (default ~3
+      // heartbeat intervals, set in nav-signal.mjs) so normal heartbeat jitter
+      // doesn't flap healthy↔degraded and storm the desktop notifications.
+      // MONITOR_DAEMON_HEALTHY_WINDOW_MS overrides it; unset → the module default.
+      const healthyWindowMs =
+        Number(process.env.MONITOR_DAEMON_HEALTHY_WINDOW_MS) || undefined;
+      return deps.deriveDaemonHealth(lastSeen, deps.getHostName(), {
+        intervalMs: healthyWindowMs,
+      });
     } catch {
       return "offline";
     }


### PR DESCRIPTION
## CTL-1169 — stop the "daemon degraded" notification storm

The desktop app fires a notification on **every** healthy↔degraded transition of the nav `daemon` field, and that field was flapping constantly → a stream of *"Catalyst — daemon degraded"* toasts.

### Root cause: a threshold with no hysteresis (not a circuit breaker)
`deriveDaemonHealth` (nav-signal.mjs) classified **healthy** only while the last `node.heartbeat` was **≤ one 30s interval** old (`classifyHostLiveness` default) — but the daemon **emits on that same 30s cadence**. Measured gaps on mini: **median ~35s, spiking to 66–102s**. So the heartbeat is chronically a few seconds late vs the 30s line; whenever the reactive nav recompute lands in that window it reports `degraded`, and the next (late) beat resets it to `healthy`. Each crossing = one notification.

### Fix
Widen the daemon-health "healthy" window past one raw heartbeat interval:
- `DEFAULT_DAEMON_HEALTHY_WINDOW_MS = 3 × 30s = 90s` (~3 missed beats), env-tunable via `MONITOR_DAEMON_HEALTHY_WINDOW_MS`.
- **Scoped to the nav daemon-health dot only** — the cluster-liveness overlay (`overlayClusterLiveness`) keeps its tight 30s/5min eviction window.
- A genuinely overdue daemon **still degrades** (≥3 missed beats) and **still goes offline at 5min** — a 2-minute silence is still `degraded`. Only the jitter-flap is removed.

90s (not 120s) keeps a real 2-min stall visible as `degraded` while covering the dominant jitter band.

### Why it flaps that much
The 60–102s heartbeat gaps mean the daemon event loop occasionally stalls — a real signal, tracked separately as **CTL-1170** (likely the CTL-1165 sweeps doing sync work on the main loop). After that lands this window can shrink. Hysteresis is still warranted regardless (jitter always crosses 30s occasionally).

### Tests
`nav-signal.test.ts` gains hysteresis guards: a 45s-old beat (one missed beat) stays `healthy`; the window edge is `healthy` vs just-past is `degraded`; an explicit `intervalMs` override still wins (proves the env path reaches the classifier). `tsc` + `eslint` clean; nav-signal + nav-signal-endpoints + key-nav suites green.

Takes effect on the next monitor deploy — no desktop app update needed.

Closes CTL-1169. Related: CTL-1170 (event-loop stalls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)