### PR TITLE
fix(dev): CTL-1171 — broker liveness heartbeat (stop the idle-broker false-down)

### DIFF
--- a/plugins/dev/scripts/broker/barrel-exports.test.mjs
+++ b/plugins/dev/scripts/broker/barrel-exports.test.mjs
@@ -11,7 +11,8 @@
 // CTL-1077 remediate added 2 more — BROKER_HANDOFF_MAX_AGE_MS and the extracted
 // parseBootHandoff boot seam; CTL-1161 added 6 — isDaemonLocalMergeSignal,
 // refreshAllPluginCheckouts, startPluginDriftCheck, PLUGIN_DRIFT_CHECK_INTERVAL_MS
-// from plugin-refresh.mjs, and startDriftCheckWatcher from router.mjs).
+// from plugin-refresh.mjs, and startDriftCheckWatcher from router.mjs; CTL-1171
+// added 2 — BROKER_HEARTBEAT_INTERVAL_MS and buildBrokerHeartbeatEvent).
 // The count is the length of the enumerated REQUIRED_EXPORTS list below —
 // `grep -cE '^export '` undercounts because most re-exports are multi-name
 // `export { … } from` blocks.
@@ -122,14 +123,17 @@ const REQUIRED_EXPORTS = [
   // CTL-1077 remediate: handoff freshness budget + extracted boot-parse seam (index.mjs)
   "BROKER_HANDOFF_MAX_AGE_MS",
   "parseBootHandoff",
+  // CTL-1171: broker liveness heartbeat (cadence const + pure event factory)
+  "BROKER_HEARTBEAT_INTERVAL_MS",
+  "buildBrokerHeartbeatEvent",
 ];
 
 describe("CTL-529 barrel contract", () => {
-  test("all 90 public symbols re-export from ./index.mjs", () => {
+  test("all 92 public symbols re-export from ./index.mjs", () => {
     for (const name of REQUIRED_EXPORTS) {
       expect(typeof barrel[name], `missing export: ${name}`).not.toBe("undefined");
     }
-    expect(REQUIRED_EXPORTS.length).toBe(90);
+    expect(REQUIRED_EXPORTS.length).toBe(92);
   });
 
   test("singleton getters return identity-stable live references", () => {

--- a/plugins/dev/scripts/broker/broker-heartbeat.test.mjs
+++ b/plugins/dev/scripts/broker/broker-heartbeat.test.mjs
@@ -1,0 +1,45 @@
+// broker-heartbeat.test.mjs — CTL-1171.
+//
+// The broker emits a periodic liveness heartbeat so an idle broker (no registered
+// interests, no webhooks) does NOT false-report "down" in the monitor, which
+// classifies broker health purely by event-log recency (service.name=catalyst.broker:
+// degraded > 3m, down > 10m). These guards pin the pure event factory's shape and
+// the cadence invariant; the setInterval wiring in main() is a one-liner over them.
+import { describe, test, expect } from "bun:test";
+import {
+  buildBrokerHeartbeatEvent,
+  BROKER_HEARTBEAT_INTERVAL_MS,
+} from "./index.mjs";
+
+describe("CTL-1171 broker liveness heartbeat", () => {
+  test("buildBrokerHeartbeatEvent emits a catalyst.broker lifecycle beat", () => {
+    const ev = buildBrokerHeartbeatEvent({ pid: 4242, activeInterests: 0 });
+    // The monitor keys off the event NAME recency under service.name=catalyst.broker
+    // (appendEvent stamps the resource); broker:true marks it a daemon lifecycle event.
+    expect(ev.event).toBe("broker.daemon.heartbeat");
+    expect(ev.detail.broker).toBe(true);
+    expect(ev.severity).toBe("INFO");
+  });
+
+  test("carries pid + active-interest count for at-a-glance liveness", () => {
+    const ev = buildBrokerHeartbeatEvent({ pid: 99, activeInterests: 3 });
+    expect(ev.detail.pid).toBe(99);
+    expect(ev.detail.active_interests).toBe(3);
+    // it is an unattributed daemon-level event (not orchestrator/worker scoped)
+    expect(ev.orchestrator).toBeNull();
+    expect(ev.worker).toBeNull();
+  });
+
+  test("the beat is an INFO heartbeat, NOT a degraded/warn signal", () => {
+    // Regression guard: an idle broker beat must never read as degraded — that was
+    // the whole false-down problem. Severity stays INFO regardless of interest count.
+    expect(buildBrokerHeartbeatEvent({ pid: 1, activeInterests: 0 }).severity).toBe("INFO");
+  });
+
+  test("cadence stays comfortably under the monitor's 3-minute degraded threshold", () => {
+    // Monitor: degraded > 3m, down > 10m (orch-monitor service-health.ts). A beat
+    // well under 3m guarantees recency never crosses degraded while the broker lives.
+    expect(BROKER_HEARTBEAT_INTERVAL_MS).toBeGreaterThan(0);
+    expect(BROKER_HEARTBEAT_INTERVAL_MS).toBeLessThan(3 * 60_000);
+  });
+});

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -208,6 +208,28 @@ export {
  */
 export const BROKER_HANDOFF_MAX_AGE_MS = 5 * 60_000;
 
+// CTL-1171: cadence for the broker's own periodic liveness heartbeat. The monitor
+// classifies broker health by event-log recency (service.name=catalyst.broker:
+// degraded > 3m, down > 10m), but the broker otherwise emits events ONLY on
+// activity/state-change — so an idle broker (no registered interests, no webhooks)
+// goes silent and false-reports "down". A 60s heartbeat keeps recency fresh with a
+// comfortable margin under the 3m degraded line. Env-tunable.
+export const BROKER_HEARTBEAT_INTERVAL_MS =
+  Number(process.env.BROKER_HEARTBEAT_INTERVAL_MS) || 60_000;
+
+// buildBrokerHeartbeatEvent — pure factory for the periodic liveness beat. Kept
+// minimal: appendEvent stamps resource.service.name=catalyst.broker (what the
+// monitor's service-health keys off), so the recency signal is all that matters.
+export function buildBrokerHeartbeatEvent({ pid, activeInterests }) {
+  return {
+    event: "broker.daemon.heartbeat",
+    orchestrator: null,
+    worker: null,
+    severity: "INFO",
+    detail: { pid, active_interests: activeInterests, broker: true },
+  };
+}
+
 export function resolveBootByteOffset({ handoff, logPath, eofSize, now = Date.now(), maxAgeMs = BROKER_HANDOFF_MAX_AGE_MS }) {
   if (!handoff) return eofSize;
   if (handoff.logPath !== logPath) return eofSize;
@@ -474,6 +496,20 @@ function main() {
   startTailing();
   const watchdogId = startWatchdog();
   const driftCheckId = startDriftCheckWatcher();
+  // CTL-1171: periodic liveness heartbeat so an idle broker doesn't false-report
+  // "down" in the monitor (which keys off catalyst.broker event recency). Beat
+  // immediately so the broker is fresh the moment it boots, then every interval.
+  const emitBrokerHeartbeat = () => {
+    try {
+      appendEvent(
+        buildBrokerHeartbeatEvent({ pid: process.pid, activeInterests: interests.size }),
+      );
+    } catch {
+      // Best-effort telemetry — never crash the broker on a heartbeat emit.
+    }
+  };
+  emitBrokerHeartbeat();
+  const heartbeatId = setInterval(emitBrokerHeartbeat, BROKER_HEARTBEAT_INTERVAL_MS);
   log.info(
     {
       pid: process.pid,
@@ -495,6 +531,7 @@ function main() {
   const shutdown = (signal) => {
     stopTailing();
     clearInterval(watchdogId);
+    clearInterval(heartbeatId); // CTL-1171: stop the liveness heartbeat
     clearInterval(driftCheckId); // CTL-1161: drift-check backstop timer
     // CTL-529: the debounce timer handles are router module-internal.
     clearDebounceTimers();


### PR DESCRIPTION
## CTL-1171 — the Broker "down" you keep seeing is a false-down

The monitor classifies broker health by **event-log recency** (`service.name=catalyst.broker`: degraded > 3m, **down > 10m**). But the broker emits events **only on activity / state change** — `startup`, `shutdown`, `gc`, and a one-shot `degraded` ("no registered interests") ~5 min after each start. So when the fleet is idle the broker goes **silent**, and ~10 min later the monitor marks it **down** — even though the process is alive and healthy. Confirmed live 2026-06-15: broker up **3h49m**, monitor strip red, `/api/health/services` = `"no recent emission"`.

(execution-core never has this problem because it emits `node.heartbeat` every 30s — the broker just had no equivalent.)

## Fix

Add a periodic **`broker.daemon.heartbeat`** (default 60s, env `BROKER_HEARTBEAT_INTERVAL_MS`): beat immediately at boot, then every interval, cleared on shutdown. `appendEvent` stamps `resource.service.name=catalyst.broker`, so the monitor's recency check stays fresh while the broker lives — keeping the passive, cross-host, no-active-probe design the monitor relies on (CTL-1050). 60s gives a comfortable 3-miss margin under the 3-min degraded line. A genuinely dead/wedged broker still surfaces (no heartbeat → degraded > 3m, down > 10m as today).

The emit goes through a pure, exported `buildBrokerHeartbeatEvent` factory and is best-effort (a heartbeat emit can never crash the broker).

## Tests
`broker-heartbeat.test.mjs`: event shape (`broker.daemon.heartbeat`, `broker:true`, pid + active-interest count), the **INFO-not-degraded** invariant (an idle beat must never read as degraded — that was the whole false-down), and the sub-3-min cadence invariant. Barrel contract updated (+2 exports → 92). `index` + `canonical-events` regression green (220 pass).

## Rollout
Broker-side change → on merge, CTL-1077 stack-reload self-reloads the broker with the new code (gap-free handoff), and it starts beating → the monitor's Broker dot goes green. Pairs with **CTL-1172** (footer surfaces the aggregate service health).

Closes CTL-1171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)