### PR TITLE
feat(dev): CTL-1167 — PWA push notifications for orch-monitor

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/notification-filter.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/notification-filter.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "bun:test";
+import {
+  shouldNotify,
+  createNotificationProjector,
+} from "../lib/notification-filter";
+
+describe("shouldNotify (template parity with lib.rs)", () => {
+  it("needs-human ticket → '{id} needs your decision' + humanQuestion body + deep link", () => {
+    expect(
+      shouldNotify({
+        kind: "ticket",
+        id: "CTL-9",
+        attention: "needs-human",
+        humanQuestion: "Approve plan?",
+        title: "T",
+      }),
+    ).toEqual({
+      title: "CTL-9 needs your decision",
+      body: "Approve plan?",
+      deepLink: "/?ticket=CTL-9",
+    });
+  });
+
+  it("waiting-on-you ticket → '{id} is waiting on you'", () => {
+    expect(
+      shouldNotify({
+        kind: "ticket",
+        id: "CTL-9",
+        attention: "waiting-on-you",
+        humanQuestion: "",
+        title: "Fix the thing",
+      }),
+    ).toEqual({
+      title: "CTL-9 is waiting on you",
+      body: "Fix the thing",
+      deepLink: "/?ticket=CTL-9",
+    });
+  });
+
+  it("body falls back humanQuestion → title → 'needs your attention'", () => {
+    expect(
+      shouldNotify({
+        kind: "ticket",
+        id: "CTL-9",
+        attention: "needs-human",
+        humanQuestion: "",
+        title: "",
+      })?.body,
+    ).toBe("needs your attention");
+  });
+
+  it("attention === null ticket → null (not notify-worthy)", () => {
+    expect(
+      shouldNotify({ kind: "ticket", id: "CTL-9", attention: null }),
+    ).toBeNull();
+  });
+
+  it("daemon → healthy → 'Catalyst — daemon recovered'", () => {
+    expect(shouldNotify({ kind: "daemon", to: "healthy" })).toEqual({
+      title: "Catalyst — daemon recovered",
+      body: "Fleet daemon is healthy again",
+      deepLink: "/",
+    });
+  });
+
+  it("daemon → degraded/offline → 'Catalyst — daemon degraded' + 'Daemon state: {to}'", () => {
+    expect(shouldNotify({ kind: "daemon", to: "offline" })).toEqual({
+      title: "Catalyst — daemon degraded",
+      body: "Daemon state: offline",
+      deepLink: "/",
+    });
+  });
+
+  it("anomaly rising → 'Catalyst — board anomaly'", () => {
+    expect(shouldNotify({ kind: "anomaly" })).toEqual({
+      title: "Catalyst — board anomaly",
+      body: "A board anomaly was detected — take a look",
+      deepLink: "/",
+    });
+  });
+});
+
+describe("createNotificationProjector (edge detection + dedup)", () => {
+  const board = (over: Record<string, unknown> = {}) => ({
+    tickets: [] as Array<{
+      id: string;
+      attention: "needs-human" | "waiting-on-you" | null;
+      attentionSince?: string | null;
+      humanQuestion?: string;
+      title?: string;
+    }>,
+    daemon: "healthy" as "healthy" | "degraded" | "offline",
+    anomaly: false,
+    generatedAt: "t0",
+    ...over,
+  });
+
+  it("first frame: emits attention tickets but NO daemon/anomaly events (no prior state)", () => {
+    const p = createNotificationProjector();
+    const out = p.project(
+      board({
+        tickets: [
+          { id: "CTL-1", attention: "needs-human", attentionSince: "s1" },
+        ],
+      }),
+    );
+    expect(out.map((n) => n.title)).toEqual(["CTL-1 needs your decision"]);
+  });
+
+  it("does not re-fire the same ticket attention episode", () => {
+    const p = createNotificationProjector();
+    const t = [
+      { id: "CTL-1", attention: "needs-human" as const, attentionSince: "s1" },
+    ];
+    p.project(board({ tickets: t }));
+    expect(p.project(board({ tickets: t }))).toEqual([]);
+  });
+
+  it("re-fires when attentionSince changes (new episode)", () => {
+    const p = createNotificationProjector();
+    p.project(
+      board({
+        tickets: [{ id: "CTL-1", attention: "needs-human", attentionSince: "s1" }],
+      }),
+    );
+    const out = p.project(
+      board({
+        tickets: [{ id: "CTL-1", attention: "needs-human", attentionSince: "s2" }],
+      }),
+    );
+    expect(out).toHaveLength(1);
+  });
+
+  it("daemon transition healthy→offline fires once, not on the steady state", () => {
+    const p = createNotificationProjector();
+    p.project(board({ daemon: "healthy" })); // establishes prev
+    const a = p.project(board({ daemon: "offline" }));
+    const b = p.project(board({ daemon: "offline" }));
+    expect(a).toHaveLength(1);
+    expect(b).toEqual([]);
+  });
+
+  it("anomaly fires only on the false→true rising edge", () => {
+    const p = createNotificationProjector();
+    p.project(board({ anomaly: false }));
+    expect(p.project(board({ anomaly: true }))).toHaveLength(1);
+    expect(p.project(board({ anomaly: true }))).toEqual([]); // stays true: no re-fire
+    p.project(board({ anomaly: false }));
+    expect(p.project(board({ anomaly: true }))).toHaveLength(1); // new rising edge
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/notifications-stream.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/notifications-stream.test.ts
@@ -1,0 +1,67 @@
+// notifications-stream.test.ts — CTL-1167 phase 4 route tests
+// GET /api/notifications/stream — SSE endpoint that emits `notification` events.
+// Model: nav-signal-endpoints.test.ts SSE tests.
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "notif-stream-test-"));
+  const wtDir = join(tmpDir, "wt");
+  mkdirSync(wtDir, { recursive: true });
+  server = createServer({
+    port: 0,
+    wtDir,
+    catalystDir: tmpDir,
+    startWatcher: false,
+    pushBridge: false,
+    pushSubscriptionsDbPath: join(tmpDir, "push.db"),
+    vapidKeysPath: join(tmpDir, "vapid.json"),
+    annotationsDbPath: join(tmpDir, "annotations.db"),
+    daemonHealthReader: () => "healthy",
+  });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  void server?.stop(true);
+  if (tmpDir) {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+describe("GET /api/notifications/stream (CTL-1167)", () => {
+  it("returns 200 with text/event-stream content-type", async () => {
+    const res = await fetch(`${baseUrl}/api/notifications/stream`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    await res.body?.cancel();
+  });
+
+  it("sends Cache-Control: no-cache and Connection: keep-alive headers", async () => {
+    const res = await fetch(`${baseUrl}/api/notifications/stream`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toContain("no-cache");
+    await res.body?.cancel();
+  });
+
+  it("stream can be opened and cancelled without error (disconnect unsubscribes)", async () => {
+    const res = await fetch(`${baseUrl}/api/notifications/stream`);
+    expect(res.status).toBe(200);
+    const reader = res.body?.getReader();
+    expect(reader).toBeTruthy();
+    if (reader) {
+      await reader.cancel();
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/notifications-subscribe-endpoints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/notifications-subscribe-endpoints.test.ts
@@ -1,0 +1,130 @@
+// notifications-subscribe-endpoints.test.ts — CTL-1167 phase 3 route tests
+// GET /api/notifications/vapid-public-key and POST /api/notifications/subscribe.
+// Model: nav-signal-endpoints.test.ts (createServer integration through port 0).
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "notif-subscribe-test-"));
+  const wtDir = join(tmpDir, "wt");
+  mkdirSync(wtDir, { recursive: true });
+  server = createServer({
+    port: 0,
+    wtDir,
+    catalystDir: tmpDir,
+    startWatcher: false,
+    pushBridge: false,
+    pushSubscriptionsDbPath: join(tmpDir, "push.db"),
+    vapidKeysPath: join(tmpDir, "vapid.json"),
+    annotationsDbPath: join(tmpDir, "annotations.db"),
+  });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  void server?.stop(true);
+  if (tmpDir) {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+describe("GET /api/notifications/vapid-public-key (CTL-1167)", () => {
+  it("returns 200 with text/plain content-type", async () => {
+    const res = await fetch(`${baseUrl}/api/notifications/vapid-public-key`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/plain");
+  });
+
+  it("returns a non-empty base64url public key", async () => {
+    const res = await fetch(`${baseUrl}/api/notifications/vapid-public-key`);
+    const key = await res.text();
+    expect(key.length).toBeGreaterThan(0);
+    expect(key).toMatch(/^[A-Za-z0-9\-_]+$/);
+  });
+
+  it("returns the SAME key on repeated calls (idempotent key generation)", async () => {
+    const first = await (
+      await fetch(`${baseUrl}/api/notifications/vapid-public-key`)
+    ).text();
+    const second = await (
+      await fetch(`${baseUrl}/api/notifications/vapid-public-key`)
+    ).text();
+    expect(first).toBe(second);
+  });
+});
+
+describe("POST /api/notifications/subscribe (CTL-1167)", () => {
+  const validSub = {
+    endpoint: "https://push.example/test",
+    keys: { p256dh: "ABC123", auth: "DEF456" },
+  };
+
+  it("returns 201 for a valid subscription", async () => {
+    const res = await fetch(`${baseUrl}/api/notifications/subscribe`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validSub),
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it("returns 400 for a body missing keys.p256dh", async () => {
+    const res = await fetch(`${baseUrl}/api/notifications/subscribe`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        endpoint: "https://push.example/bad",
+        keys: { auth: "A" },
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for a body missing endpoint", async () => {
+    const res = await fetch(`${baseUrl}/api/notifications/subscribe`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ keys: { p256dh: "P", auth: "A" } }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    const res = await fetch(`${baseUrl}/api/notifications/subscribe`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("is idempotent — re-subscribing the same endpoint returns 201", async () => {
+    const sub = {
+      endpoint: "https://push.example/idem",
+      keys: { p256dh: "P1", auth: "A1" },
+    };
+    const first = await fetch(`${baseUrl}/api/notifications/subscribe`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(sub),
+    });
+    const second = await fetch(`${baseUrl}/api/notifications/subscribe`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(sub),
+    });
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/push-bridge.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/push-bridge.test.ts
@@ -51,8 +51,9 @@ describe("createPushBridge", () => {
 
   beforeEach(() => {
     sendCalls = [];
-    send = async (sub, n) => {
+    send = (sub, n): Promise<void> => {
       sendCalls.push({ sub, n });
+      return Promise.resolve();
     };
   });
 
@@ -83,9 +84,7 @@ describe("createPushBridge", () => {
   it("prunes the subscription when send rejects with statusCode: 410", async () => {
     const store = makeStore([SUB_A]);
     const err410 = Object.assign(new Error("Gone"), { statusCode: 410 });
-    const failSend = async () => {
-      throw err410;
-    };
+    const failSend = (): Promise<void> => Promise.reject(err410);
     const bridge = createPushBridge({ store, projector: createNotificationProjector(), send: failSend });
     await bridge.onBoard(NEEDS_HUMAN_BOARD);
     expect(store.deleted).toContain(SUB_A.endpoint);
@@ -95,9 +94,7 @@ describe("createPushBridge", () => {
   it("retains subscription when send rejects with a non-410 error", async () => {
     const store = makeStore([SUB_A]);
     const err500 = Object.assign(new Error("Server Error"), { statusCode: 500 });
-    const failSend = async () => {
-      throw err500;
-    };
+    const failSend = (): Promise<void> => Promise.reject(err500);
     const bridge = createPushBridge({
       store,
       projector: createNotificationProjector(),

--- a/plugins/dev/scripts/orch-monitor/__tests__/push-bridge.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/push-bridge.test.ts
@@ -1,0 +1,124 @@
+// push-bridge.test.ts — CTL-1167 phase 5 unit tests.
+// Drive createPushBridge with an injected send spy — no real Web Push network.
+import { describe, it, expect, beforeEach } from "bun:test";
+import { createPushBridge } from "../lib/push-bridge";
+import type { PushSubscriptionRecord } from "../lib/push-subscriptions";
+import type { PushNotification, ProjectorBoard } from "../lib/notification-filter";
+import { createNotificationProjector } from "../lib/notification-filter";
+
+interface FakeStore {
+  subs: PushSubscriptionRecord[];
+  deleted: string[];
+  listSubscriptions(): PushSubscriptionRecord[];
+  deleteSubscription(endpoint: string): void;
+}
+
+function makeStore(subs: PushSubscriptionRecord[] = []): FakeStore {
+  const store: FakeStore = {
+    subs: [...subs],
+    deleted: [],
+    listSubscriptions() {
+      return this.subs;
+    },
+    deleteSubscription(endpoint: string) {
+      this.deleted.push(endpoint);
+      this.subs = this.subs.filter((s) => s.endpoint !== endpoint);
+    },
+  };
+  return store;
+}
+
+const SUB_A: PushSubscriptionRecord = {
+  endpoint: "https://push.example/a",
+  keys: { p256dh: "P", auth: "A" },
+};
+const SUB_B: PushSubscriptionRecord = {
+  endpoint: "https://push.example/b",
+  keys: { p256dh: "Q", auth: "B" },
+};
+
+const NEEDS_HUMAN_BOARD: ProjectorBoard = {
+  tickets: [
+    { id: "CTL-1", attention: "needs-human", attentionSince: "s1", humanQuestion: "Approve?" },
+  ],
+  daemon: "healthy",
+  anomaly: false,
+};
+
+describe("createPushBridge", () => {
+  let sendCalls: Array<{ sub: PushSubscriptionRecord; n: PushNotification }>;
+  let send: (sub: PushSubscriptionRecord, n: PushNotification) => Promise<void>;
+
+  beforeEach(() => {
+    sendCalls = [];
+    send = async (sub, n) => {
+      sendCalls.push({ sub, n });
+    };
+  });
+
+  it("calls send once per stored subscription for a new needs-human ticket", async () => {
+    const store = makeStore([SUB_A, SUB_B]);
+    const bridge = createPushBridge({
+      store,
+      projector: createNotificationProjector(),
+      send,
+    });
+    await bridge.onBoard(NEEDS_HUMAN_BOARD);
+    expect(sendCalls).toHaveLength(2);
+    expect(sendCalls[0].sub.endpoint).toBe(SUB_A.endpoint);
+    expect(sendCalls[1].sub.endpoint).toBe(SUB_B.endpoint);
+    expect(sendCalls[0].n.title).toBe("CTL-1 needs your decision");
+  });
+
+  it("does NOT call send on a steady-state repeat board (projector dedup)", async () => {
+    const store = makeStore([SUB_A]);
+    const projector = createNotificationProjector();
+    const bridge = createPushBridge({ store, projector, send });
+    await bridge.onBoard(NEEDS_HUMAN_BOARD);
+    sendCalls = [];
+    await bridge.onBoard(NEEDS_HUMAN_BOARD); // same episode, same attentionSince
+    expect(sendCalls).toHaveLength(0);
+  });
+
+  it("prunes the subscription when send rejects with statusCode: 410", async () => {
+    const store = makeStore([SUB_A]);
+    const err410 = Object.assign(new Error("Gone"), { statusCode: 410 });
+    const failSend = async () => {
+      throw err410;
+    };
+    const bridge = createPushBridge({ store, projector: createNotificationProjector(), send: failSend });
+    await bridge.onBoard(NEEDS_HUMAN_BOARD);
+    expect(store.deleted).toContain(SUB_A.endpoint);
+    expect(store.subs).toHaveLength(0);
+  });
+
+  it("retains subscription when send rejects with a non-410 error", async () => {
+    const store = makeStore([SUB_A]);
+    const err500 = Object.assign(new Error("Server Error"), { statusCode: 500 });
+    const failSend = async () => {
+      throw err500;
+    };
+    const bridge = createPushBridge({
+      store,
+      projector: createNotificationProjector(),
+      send: failSend,
+    });
+    await bridge.onBoard(NEEDS_HUMAN_BOARD);
+    expect(store.deleted).toHaveLength(0);
+    expect(store.subs).toHaveLength(1);
+  });
+
+  it("emits no sends when zero subscriptions are stored", async () => {
+    const store = makeStore([]);
+    const bridge = createPushBridge({ store, projector: createNotificationProjector(), send });
+    await bridge.onBoard(NEEDS_HUMAN_BOARD);
+    expect(sendCalls).toHaveLength(0);
+  });
+
+  it("emits no sends when the board has no notify-worthy events", async () => {
+    const store = makeStore([SUB_A]);
+    const bridge = createPushBridge({ store, projector: createNotificationProjector(), send });
+    await bridge.onBoard({ tickets: [], daemon: "healthy", anomaly: false });
+    expect(sendCalls).toHaveLength(0);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/push-subscriptions.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/push-subscriptions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";

--- a/plugins/dev/scripts/orch-monitor/__tests__/push-subscriptions.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/push-subscriptions.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import * as store from "../lib/push-subscriptions";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "push-subs-"));
+  store.openDb(join(dir, "push.db"));
+});
+afterEach(() => {
+  store.closeDb();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const SUB = {
+  endpoint: "https://push.example/abc",
+  keys: { p256dh: "P", auth: "A" },
+};
+
+it("upsert then list returns the subscription", () => {
+  store.upsertSubscription(SUB);
+  expect(store.listSubscriptions()).toHaveLength(1);
+});
+
+it("upsert is idempotent on endpoint (PRIMARY KEY)", () => {
+  store.upsertSubscription(SUB);
+  store.upsertSubscription(SUB);
+  expect(store.listSubscriptions()).toHaveLength(1);
+});
+
+it("prune removes the endpoint", () => {
+  store.upsertSubscription(SUB);
+  store.deleteSubscription(SUB.endpoint);
+  expect(store.listSubscriptions()).toHaveLength(0);
+});
+
+it("ensureDb throws before openDb", () => {
+  store.closeDb();
+  expect(() => store.listSubscriptions()).toThrow();
+});
+
+it("list returns correct p256dh and auth keys", () => {
+  store.upsertSubscription(SUB);
+  const subs = store.listSubscriptions();
+  expect(subs[0]).toEqual(SUB);
+});
+
+it("upsert updates keys when endpoint already exists (ON CONFLICT DO UPDATE)", () => {
+  store.upsertSubscription(SUB);
+  const updated = { endpoint: SUB.endpoint, keys: { p256dh: "P2", auth: "A2" } };
+  store.upsertSubscription(updated);
+  const subs = store.listSubscriptions();
+  expect(subs).toHaveLength(1);
+  expect(subs[0].keys.p256dh).toBe("P2");
+  expect(subs[0].keys.auth).toBe("A2");
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/pwa-assets.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/pwa-assets.test.ts
@@ -74,6 +74,11 @@ describe("service-worker.js (committed artifact)", () => {
     expect(sw).toContain("/events");
     expect(sw).toContain("text/event-stream");
   });
+
+  it("registers the push + notificationclick handlers (CTL-1167)", () => {
+    expect(sw).toContain('addEventListener("push"');
+    expect(sw).toContain('addEventListener("notificationclick"');
+  });
 });
 
 // ── Served from the root (integration through createServer) ───────────────────

--- a/plugins/dev/scripts/orch-monitor/__tests__/vapid.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/vapid.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { loadOrCreateVapidKeys } from "../lib/vapid";
+
+describe("loadOrCreateVapidKeys", () => {
+  let dir: string;
+
+  const setup = () => {
+    dir = mkdtempSync(join(tmpdir(), "vapid-test-"));
+    return join(dir, "vapid.json");
+  };
+  const teardown = () => {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  };
+
+  it("generates a keypair on first call and writes it to disk", () => {
+    const path = setup();
+    try {
+      const keys = loadOrCreateVapidKeys(path);
+      expect(typeof keys.publicKey).toBe("string");
+      expect(keys.publicKey.length).toBeGreaterThan(0);
+      expect(typeof keys.privateKey).toBe("string");
+      expect(keys.privateKey.length).toBeGreaterThan(0);
+      expect(existsSync(path)).toBe(true);
+    } finally {
+      teardown();
+    }
+  });
+
+  it("returns the SAME keys on a second call (no regeneration)", () => {
+    const path = setup();
+    try {
+      const first = loadOrCreateVapidKeys(path);
+      const second = loadOrCreateVapidKeys(path);
+      expect(second.publicKey).toBe(first.publicKey);
+      expect(second.privateKey).toBe(first.privateKey);
+    } finally {
+      teardown();
+    }
+  });
+
+  it("public key is a non-empty base64url string", () => {
+    const path = setup();
+    try {
+      const { publicKey } = loadOrCreateVapidKeys(path);
+      // base64url chars: A-Z a-z 0-9 - _  (no + / =)
+      expect(publicKey).toMatch(/^[A-Za-z0-9\-_]+$/);
+    } finally {
+      teardown();
+    }
+  });
+
+  it("written file is mode 0o600 (owner-read/write only)", () => {
+    const path = setup();
+    try {
+      loadOrCreateVapidKeys(path);
+      const mode = statSync(path).mode & 0o777;
+      expect(mode).toBe(0o600);
+    } finally {
+      teardown();
+    }
+  });
+
+  it("written JSON is parseable and has publicKey + privateKey fields", () => {
+    const path = setup();
+    try {
+      loadOrCreateVapidKeys(path);
+      const raw: unknown = JSON.parse(readFileSync(path, "utf8"));
+      expect(raw).toBeTruthy();
+      const obj = raw as Record<string, unknown>;
+      expect(typeof obj.publicKey).toBe("string");
+      expect(typeof obj.privateKey).toBe("string");
+    } finally {
+      teardown();
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/bun.lock
+++ b/plugins/dev/scripts/orch-monitor/bun.lock
@@ -7,6 +7,7 @@
         "ink": "^5.2.1",
         "react": "^18.3.1",
         "smee-client": "^5.0.0",
+        "web-push": "^3.6.7",
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -184,6 +185,8 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
@@ -194,13 +197,19 @@
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "asn1.js": ["asn1.js@5.4.1", "", { "dependencies": { "bn.js": "^4.0.0", "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0", "safer-buffer": "^2.1.0" } }, "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA=="],
+
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
     "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
@@ -231,6 +240,8 @@
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -298,6 +309,10 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
+    "http_ece": ["http_ece@1.2.0", "", {}, "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
@@ -305,6 +320,8 @@
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ink": ["ink@5.2.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.1.3", "ansi-escapes": "^7.0.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^4.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.22.0", "indent-string": "^5.0.0", "is-in-ci": "^1.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.29.0", "scheduler": "^0.23.0", "signal-exit": "^3.0.7", "slice-ansi": "^7.1.0", "stack-utils": "^2.0.6", "string-width": "^7.2.0", "type-fest": "^4.27.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=18.0.0", "react": ">=18.0.0", "react-devtools-core": "^4.19.1" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg=="],
 
@@ -332,6 +349,10 @@
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "knip": ["knip@6.4.1", "", { "dependencies": { "@nodelib/fs.walk": "^1.2.3", "fast-glob": "^3.3.3", "formatly": "^0.3.0", "get-tsconfig": "4.13.7", "jiti": "^2.6.0", "minimist": "^1.2.8", "oxc-parser": "^0.121.0", "oxc-resolver": "^11.19.1", "picocolors": "^1.1.1", "picomatch": "^4.0.1", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "unbash": "^2.2.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-Ry+ywmDFSZvKp/jx7LxMgsZWRTs931alV84e60lh0Stf6kSRYqSIUTkviyyDFRcSO3yY1Kpbi83OirN+4lA2Xw=="],
@@ -349,6 +370,8 @@
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
+    "minimalistic-assert": ["minimalistic-assert@1.0.1", "", {}, "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="],
 
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
@@ -404,7 +427,11 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "safe-regex": ["safe-regex@2.1.1", "", { "dependencies": { "regexp-tree": "~0.1.1" } }, "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
@@ -457,6 +484,8 @@
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
+
+    "web-push": ["web-push@3.6.7", "", { "dependencies": { "asn1.js": "^5.3.0", "http_ece": "1.2.0", "https-proxy-agent": "^7.0.0", "jws": "^4.0.0", "minimist": "^1.2.5" }, "bin": { "web-push": "src/cli.js" } }, "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/plugins/dev/scripts/orch-monitor/bun.lock
+++ b/plugins/dev/scripts/orch-monitor/bun.lock
@@ -13,6 +13,7 @@
         "@eslint/js": "^10.0.1",
         "@types/bun": "^1.3.14",
         "@types/react": "^18.3.12",
+        "@types/web-push": "^3.6.4",
         "eslint": "^9",
         "eslint-plugin-security": "^4.0.0",
         "globals": "^17.5.0",
@@ -160,6 +161,8 @@
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
 
     "@types/react": ["@types/react@18.3.28", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw=="],
+
+    "@types/web-push": ["@types/web-push@3.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.2", "@typescript-eslint/type-utils": "8.58.2", "@typescript-eslint/utils": "8.58.2", "@typescript-eslint/visitor-keys": "8.58.2", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.2", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw=="],
 

--- a/plugins/dev/scripts/orch-monitor/lib/notification-filter.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/notification-filter.ts
@@ -1,0 +1,128 @@
+import type { BoardAttention } from "./board-data.d.mts";
+
+export type NotificationEvent =
+  | {
+      kind: "ticket";
+      id: string;
+      attention: BoardAttention;
+      humanQuestion?: string;
+      title?: string;
+    }
+  | { kind: "daemon"; to: "healthy" | "degraded" | "offline" }
+  | { kind: "anomaly" };
+
+export interface PushNotification {
+  title: string;
+  body: string;
+  deepLink: string;
+}
+
+// Notification template strings — single source of truth for all five categories
+// (service worker, push bridge, SSE). Change here, propagates everywhere.
+const TMPL = {
+  TICKET_NEEDS_DECISION: "needs your decision",
+  TICKET_WAITING: "is waiting on you",
+  TICKET_FALLBACK_BODY: "needs your attention",
+  DAEMON_RECOVERED_TITLE: "Catalyst — daemon recovered",
+  DAEMON_RECOVERED_BODY: "Fleet daemon is healthy again",
+  DAEMON_DEGRADED_TITLE: "Catalyst — daemon degraded",
+  ANOMALY_TITLE: "Catalyst — board anomaly",
+  ANOMALY_BODY: "A board anomaly was detected — take a look",
+} as const;
+
+export function shouldNotify(ev: NotificationEvent): PushNotification | null {
+  if (ev.kind === "ticket") {
+    if (ev.attention === null) return null;
+    const label =
+      ev.attention === "needs-human"
+        ? TMPL.TICKET_NEEDS_DECISION
+        : TMPL.TICKET_WAITING;
+    const body =
+      (ev.humanQuestion && ev.humanQuestion.length > 0
+        ? ev.humanQuestion
+        : undefined) ??
+      (ev.title && ev.title.length > 0 ? ev.title : undefined) ??
+      TMPL.TICKET_FALLBACK_BODY;
+    return { title: `${ev.id} ${label}`, body, deepLink: `/?ticket=${ev.id}` };
+  }
+  if (ev.kind === "daemon") {
+    return ev.to === "healthy"
+      ? {
+          title: TMPL.DAEMON_RECOVERED_TITLE,
+          body: TMPL.DAEMON_RECOVERED_BODY,
+          deepLink: "/",
+        }
+      : {
+          title: TMPL.DAEMON_DEGRADED_TITLE,
+          body: `Daemon state: ${ev.to}`,
+          deepLink: "/",
+        };
+  }
+  // kind === "anomaly"
+  return {
+    title: TMPL.ANOMALY_TITLE,
+    body: TMPL.ANOMALY_BODY,
+    deepLink: "/",
+  };
+}
+
+// Minimal board shape consumed by the projector — a structural subset of
+// BoardPayload + NavSignal so no runtime .mjs dep is needed in tests.
+export interface ProjectorBoard {
+  tickets?: Array<{
+    id: string;
+    attention: BoardAttention;
+    attentionSince?: string | null;
+    humanQuestion?: string;
+    title?: string;
+  }>;
+  daemon?: "healthy" | "degraded" | "offline";
+  anomaly?: boolean;
+}
+
+export function createNotificationProjector() {
+  let prevDaemon: "healthy" | "degraded" | "offline" | undefined;
+  let prevAnomaly: boolean | undefined;
+  const fired = new Set<string>();
+
+  return {
+    project(board: ProjectorBoard): PushNotification[] {
+      const out: PushNotification[] = [];
+
+      for (const t of board.tickets ?? []) {
+        if (!t.attention) continue;
+        const key = `ticket:${t.id}:${t.attentionSince ?? ""}`;
+        if (fired.has(key)) continue;
+        const n = shouldNotify({
+          kind: "ticket",
+          id: t.id,
+          attention: t.attention,
+          humanQuestion: t.humanQuestion,
+          title: t.title,
+        });
+        if (n) {
+          out.push(n);
+          fired.add(key);
+        }
+      }
+
+      if (board.daemon !== undefined) {
+        if (prevDaemon !== undefined && prevDaemon !== board.daemon) {
+          const n = shouldNotify({ kind: "daemon", to: board.daemon });
+          if (n) out.push(n);
+        }
+        prevDaemon = board.daemon;
+      }
+
+      if (board.anomaly !== undefined) {
+        if (prevAnomaly === false && board.anomaly === true) {
+          const n = shouldNotify({ kind: "anomaly" });
+          if (n) out.push(n);
+        }
+        prevAnomaly = board.anomaly;
+      }
+
+      return out;
+    },
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/lib/push-bridge.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/push-bridge.ts
@@ -1,0 +1,56 @@
+import webpush from "web-push";
+import type { PushSubscriptionRecord } from "./push-subscriptions";
+import type { PushNotification, ProjectorBoard } from "./notification-filter";
+
+interface PushStore {
+  listSubscriptions(): PushSubscriptionRecord[];
+  deleteSubscription(endpoint: string): void;
+}
+
+interface Projector {
+  project(board: ProjectorBoard): PushNotification[];
+}
+
+type SendFn = (
+  sub: PushSubscriptionRecord,
+  notification: PushNotification,
+) => Promise<void>;
+
+interface PushBridgeOptions {
+  store: PushStore;
+  projector: Projector;
+  send?: SendFn;
+}
+
+const defaultSend: SendFn = async (sub, notification) => {
+  await webpush.sendNotification(
+    {
+      endpoint: sub.endpoint,
+      keys: sub.keys,
+    },
+    JSON.stringify(notification),
+  );
+};
+
+export function createPushBridge({ store, projector, send = defaultSend }: PushBridgeOptions) {
+  return {
+    async onBoard(board: ProjectorBoard): Promise<void> {
+      const notifications = projector.project(board);
+      if (notifications.length === 0) return;
+      const subs = store.listSubscriptions();
+      for (const n of notifications) {
+        for (const sub of subs) {
+          try {
+            await send(sub, n);
+          } catch (err) {
+            if ((err as { statusCode?: number }).statusCode === 410) {
+              store.deleteSubscription(sub.endpoint);
+            } else {
+              console.error("[push-bridge] send failed (retained):", err);
+            }
+          }
+        }
+      }
+    },
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/lib/push-subscriptions.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/push-subscriptions.ts
@@ -34,7 +34,7 @@ export function closeDb(): void {
 }
 
 function ensureDb(): Database {
-  if (!db) throw new Error("push-subscriptions: openDb() first");
+  if (!db) throw new Error("Database not opened — call openDb() first");
   return db;
 }
 
@@ -61,9 +61,3 @@ export function deleteSubscription(endpoint: string): void {
   ]);
 }
 
-export function touchLastUsed(endpoint: string): void {
-  ensureDb().run(
-    `UPDATE push_subscriptions SET last_used_at = ? WHERE endpoint = ?`,
-    [new Date().toISOString(), endpoint],
-  );
-}

--- a/plugins/dev/scripts/orch-monitor/lib/push-subscriptions.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/push-subscriptions.ts
@@ -1,0 +1,69 @@
+import { Database } from "bun:sqlite";
+
+export interface PushSubscriptionRecord {
+  endpoint: string;
+  keys: { p256dh: string; auth: string };
+}
+
+let db: Database | null = null;
+
+const DEFAULT_DB_DIR =
+  process.env.CATALYST_DIR ?? `${process.env.HOME}/catalyst`;
+
+export function openDb(
+  dbPath: string = `${DEFAULT_DB_DIR}/push-subscriptions.db`,
+): Database {
+  if (db) return db;
+  db = new Database(dbPath, { create: true });
+  db.run("PRAGMA journal_mode=WAL");
+  db.run(`CREATE TABLE IF NOT EXISTS push_subscriptions (
+    endpoint    TEXT PRIMARY KEY,
+    p256dh      TEXT NOT NULL,
+    auth        TEXT NOT NULL,
+    created_at  TEXT NOT NULL,
+    last_used_at TEXT
+  )`);
+  return db;
+}
+
+export function closeDb(): void {
+  if (db) {
+    db.close();
+    db = null;
+  }
+}
+
+function ensureDb(): Database {
+  if (!db) throw new Error("push-subscriptions: openDb() first");
+  return db;
+}
+
+export function upsertSubscription(sub: PushSubscriptionRecord): void {
+  ensureDb().run(
+    `INSERT INTO push_subscriptions (endpoint, p256dh, auth, created_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(endpoint) DO UPDATE SET p256dh=excluded.p256dh, auth=excluded.auth`,
+    [sub.endpoint, sub.keys.p256dh, sub.keys.auth, new Date().toISOString()],
+  );
+}
+
+export function listSubscriptions(): PushSubscriptionRecord[] {
+  return (
+    ensureDb()
+      .query(`SELECT endpoint, p256dh, auth FROM push_subscriptions`)
+      .all() as Array<{ endpoint: string; p256dh: string; auth: string }>
+  ).map((r) => ({ endpoint: r.endpoint, keys: { p256dh: r.p256dh, auth: r.auth } }));
+}
+
+export function deleteSubscription(endpoint: string): void {
+  ensureDb().run(`DELETE FROM push_subscriptions WHERE endpoint = ?`, [
+    endpoint,
+  ]);
+}
+
+export function touchLastUsed(endpoint: string): void {
+  ensureDb().run(
+    `UPDATE push_subscriptions SET last_used_at = ? WHERE endpoint = ?`,
+    [new Date().toISOString(), endpoint],
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/lib/vapid.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/vapid.ts
@@ -1,5 +1,12 @@
 import webpush from "web-push";
-import { existsSync, readFileSync, writeFileSync, chmodSync } from "fs";
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  chmodSync,
+  mkdirSync,
+} from "fs";
+import { dirname } from "path";
 
 export interface VapidKeys {
   publicKey: string;
@@ -20,6 +27,9 @@ export function loadOrCreateVapidKeys(path: string): VapidKeys {
     return parsed as VapidKeys;
   }
   const keys = webpush.generateVAPIDKeys();
+  // Ensure the parent dir exists (e.g. a fresh host where ~/catalyst has not
+  // been created yet) so the first write does not throw ENOENT.
+  mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(keys), { mode: 0o600 });
   // Explicitly chmod after write in case the process umask widened permissions.
   chmodSync(path, 0o600);

--- a/plugins/dev/scripts/orch-monitor/lib/vapid.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/vapid.ts
@@ -8,7 +8,16 @@ export interface VapidKeys {
 
 export function loadOrCreateVapidKeys(path: string): VapidKeys {
   if (existsSync(path)) {
-    return JSON.parse(readFileSync(path, "utf8")) as VapidKeys;
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof (parsed as Record<string, unknown>).publicKey !== "string" ||
+      typeof (parsed as Record<string, unknown>).privateKey !== "string"
+    ) {
+      throw new Error(`vapid.ts: malformed VAPID key file at ${path}`);
+    }
+    return parsed as VapidKeys;
   }
   const keys = webpush.generateVAPIDKeys();
   writeFileSync(path, JSON.stringify(keys), { mode: 0o600 });

--- a/plugins/dev/scripts/orch-monitor/lib/vapid.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/vapid.ts
@@ -1,0 +1,18 @@
+import webpush from "web-push";
+import { existsSync, readFileSync, writeFileSync, chmodSync } from "fs";
+
+export interface VapidKeys {
+  publicKey: string;
+  privateKey: string;
+}
+
+export function loadOrCreateVapidKeys(path: string): VapidKeys {
+  if (existsSync(path)) {
+    return JSON.parse(readFileSync(path, "utf8")) as VapidKeys;
+  }
+  const keys = webpush.generateVAPIDKeys();
+  writeFileSync(path, JSON.stringify(keys), { mode: 0o600 });
+  // Explicitly chmod after write in case the process umask widened permissions.
+  chmodSync(path, 0o600);
+  return keys;
+}

--- a/plugins/dev/scripts/orch-monitor/package.json
+++ b/plugins/dev/scripts/orch-monitor/package.json
@@ -26,6 +26,7 @@
     "@eslint/js": "^10.0.1",
     "@types/bun": "^1.3.14",
     "@types/react": "^18.3.12",
+    "@types/web-push": "^3.6.4",
     "eslint": "^9",
     "eslint-plugin-security": "^4.0.0",
     "globals": "^17.5.0",

--- a/plugins/dev/scripts/orch-monitor/package.json
+++ b/plugins/dev/scripts/orch-monitor/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "ink": "^5.2.1",
     "react": "^18.3.1",
-    "smee-client": "^5.0.0"
+    "smee-client": "^5.0.0",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/plugins/dev/scripts/orch-monitor/public/service-worker.js
+++ b/plugins/dev/scripts/orch-monitor/public/service-worker.js
@@ -10,7 +10,44 @@
 //   - everything else, and crucially /api/* + /events + SSE streams → straight
 //     to network, never cached (stale fleet state would be worse than useless).
 //
-// CTL-1167 will add `push` + `notificationclick` handlers here on top of this.
+// CTL-1167: push + notificationclick handlers for Web Push notifications.
+
+self.addEventListener("push", (event) => {
+  let payload = {};
+  try {
+    payload = event.data ? event.data.json() : {};
+  } catch {
+    payload = {};
+  }
+  const title = payload.title || "Catalyst";
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body: payload.body || "",
+      data: { deepLink: payload.deepLink || "/" },
+      icon: "/icon-192.png",
+      badge: "/icon-192.png",
+    }),
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const deepLink =
+    (event.notification.data && event.notification.data.deepLink) || "/";
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((wins) => {
+        for (const w of wins) {
+          if ("focus" in w) {
+            w.navigate?.(deepLink);
+            return w.focus();
+          }
+        }
+        return self.clients.openWindow(deepLink);
+      }),
+  );
+});
 
 const CACHE = "catalyst-shell-v1";
 

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -2,7 +2,7 @@ import { join, resolve as resolvePath, sep, dirname, basename } from "path";
 import { realpathSync, readFileSync, writeFileSync, unlinkSync, existsSync, mkdirSync } from "fs";
 // CTL-1167: PWA push notifications — VAPID key loader + subscription store
 // + notification filter (shared with the SSE stream + push bridge).
-import { loadOrCreateVapidKeys } from "./lib/vapid";
+import { loadOrCreateVapidKeys, type VapidKeys } from "./lib/vapid";
 import webpush from "web-push";
 import * as pushStore from "./lib/push-subscriptions";
 import {
@@ -837,16 +837,30 @@ export function createServer(opts: CreateServerOptions): BunServer {
   }
 
   // CTL-1167: VAPID keys + push-subscriptions store init.
-  const pushSubsDbPath =
-    pushSubscriptionsDbPath ?? `${CATALYST_DIR}/push-subscriptions.db`;
-  const vapidPath = vapidKeysPath ?? `${CATALYST_DIR}/vapid-keys.json`;
-  const vapidKeys = loadOrCreateVapidKeys(vapidPath);
-  pushStore.openDb(pushSubsDbPath);
-  webpush.setVapidDetails(
-    "mailto:catalyst@localhost",
-    vapidKeys.publicKey,
-    vapidKeys.privateKey,
-  );
+  // Gated so push only initializes when the caller has actually configured it:
+  // either the server-side bridge is enabled (the default for the real monitor)
+  // or the caller supplied explicit push paths (the push-endpoint tests). The
+  // many createServer callers that pass no push options at all (most route
+  // tests) skip this entirely — they neither write a vapid-keys.json into a
+  // possibly-missing CATALYST_DIR nor open the module-level push-subscriptions
+  // singleton, which would otherwise leak across tests in one `bun test` run.
+  const pushConfigured =
+    pushBridgeOpt !== false ||
+    vapidKeysPath != null ||
+    pushSubscriptionsDbPath != null;
+  let vapidKeys: VapidKeys | null = null;
+  if (pushConfigured) {
+    const pushSubsDbPath =
+      pushSubscriptionsDbPath ?? `${CATALYST_DIR}/push-subscriptions.db`;
+    const vapidPath = vapidKeysPath ?? `${CATALYST_DIR}/vapid-keys.json`;
+    vapidKeys = loadOrCreateVapidKeys(vapidPath);
+    pushStore.openDb(pushSubsDbPath);
+    webpush.setVapidDetails(
+      "mailto:catalyst@localhost",
+      vapidKeys.publicKey,
+      vapidKeys.privateKey,
+    );
+  }
 
   // CTL-1100: in-process LRU cache for /api/beliefs/rates (keyed by max tick_id,
   // cap RATES_LRU_CAP=64; beliefs are insert-only so the cached value per max tick
@@ -3985,8 +3999,12 @@ export function createServer(opts: CreateServerOptions): BunServer {
         }
 
         // CTL-1167: serve the VAPID public key so the browser can build the
-        // applicationServerKey for pushManager.subscribe().
+        // applicationServerKey for pushManager.subscribe(). 503 when push was
+        // never initialized for this server instance (push not configured).
         if (url.pathname === "/api/notifications/vapid-public-key") {
+          if (!vapidKeys) {
+            return new Response("push not configured", { status: 503 });
+          }
           return new Response(vapidKeys.publicKey, {
             headers: { "Content-Type": "text/plain" },
           });
@@ -3996,6 +4014,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
         // serialised PushSubscription JSON from the browser). Returns 201 on
         // success; 400 on missing/invalid fields.
         if (url.pathname === "/api/notifications/subscribe" && req.method === "POST") {
+          if (!vapidKeys) {
+            return new Response("push not configured", { status: 503 });
+          }
           let body: unknown;
           try {
             body = await req.json();
@@ -4051,10 +4072,31 @@ export function createServer(opts: CreateServerOptions): BunServer {
           };
           const notifStream = new ReadableStream<Uint8Array>({
             async start(controller) {
-              unsubNotif = boardSnapshot.subscribe((snap) => {
-                void toProjectorBoard(snap).then((pb) =>
-                  emitNotifications(controller, pb),
+              // Emit an immediate `open` frame so the connection is live even
+              // when the fleet yields no notifications. Without a first chunk,
+              // Bun does not resolve fetch()'s response headers (the client —
+              // and the route tests — would hang). Mirrors /api/beliefs/stream.
+              try {
+                controller.enqueue(
+                  encoder.encode(
+                    `event: open\ndata: ${JSON.stringify({ source: "notifications" })}\n\n`,
+                  ),
                 );
+              } catch {
+                closedNotif = true;
+                return;
+              }
+              unsubNotif = boardSnapshot.subscribe((snap) => {
+                // Fire-and-forget projection: a rejected chain here would become
+                // an unhandled rejection (and stall bun:test), so swallow it.
+                void toProjectorBoard(snap)
+                  .then((pb) => emitNotifications(controller, pb))
+                  .catch((err) => {
+                    console.error(
+                      `[server] notifications stream projection failed:`,
+                      err,
+                    );
+                  });
               });
               try {
                 emitNotifications(
@@ -4478,9 +4520,19 @@ export function createServer(opts: CreateServerOptions): BunServer {
       store: pushStore,
       projector: createNotificationProjector(),
     });
-    boardSnapshot.subscribe((snap) => {
-      void toProjectorBoard(snap).then((pb) => bridge.onBoard(pb));
-    });
+    // Register the unsubscribe so server.stop() tears the bridge down BEFORE it
+    // calls pushStore.closeDb(). Otherwise an orphaned board subscription on the
+    // process-global event bus fires after the singleton db is closed and throws
+    // "Database not opened" as an unhandled rejection (it would stall bun:test).
+    unsubscribers.push(
+      boardSnapshot.subscribe((snap) => {
+        void toProjectorBoard(snap)
+          .then((pb) => bridge.onBoard(pb))
+          .catch((err) => {
+            console.error("[server] push bridge onBoard failed:", err);
+          });
+      }),
+    );
   }
 
   if (webhookConfig && webhookHandler) {

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1,5 +1,15 @@
 import { join, resolve as resolvePath, sep, dirname, basename } from "path";
 import { realpathSync, readFileSync, writeFileSync, unlinkSync, existsSync, mkdirSync } from "fs";
+// CTL-1167: PWA push notifications — VAPID key loader + subscription store
+// + notification filter (shared with the SSE stream + push bridge).
+import { loadOrCreateVapidKeys } from "./lib/vapid";
+import webpush from "web-push";
+import * as pushStore from "./lib/push-subscriptions";
+import {
+  createNotificationProjector,
+  type ProjectorBoard,
+} from "./lib/notification-filter";
+import { createPushBridge } from "./lib/push-bridge";
 import { subscribe, emit } from "./lib/event-bus";
 import {
   buildSnapshot,
@@ -482,6 +492,13 @@ export interface CreateServerOptions {
      * events. Empty / absent = no enrichment (pre-CTL-362 behaviour). */
     linearTeams?: Array<{ key: string; vcsRepo: string }>;
   } | null;
+  // CTL-1167: PWA push notifications
+  /** false disables the server-side push bridge startup task (useful in tests). Default: true. */
+  pushBridge?: boolean;
+  /** Override for push-subscriptions.db path. Defaults to ${catalystDir}/push-subscriptions.db. */
+  pushSubscriptionsDbPath?: string;
+  /** Override for vapid-keys.json path. Defaults to ${catalystDir}/vapid-keys.json. */
+  vapidKeysPath?: string;
 }
 
 const DEFAULT_PORT = 7400;
@@ -792,6 +809,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
     clusterReader: clusterReaderOpt,
     screenLogsExec: screenLogsExecOpt,
     screenPollMs = SCREEN_POLL_MS,
+    pushBridge: pushBridgeOpt = true,
+    pushSubscriptionsDbPath,
+    vapidKeysPath,
   } = opts;
 
   const buildOpts: BuildSnapshotOptions = { dbPath, runsDir };
@@ -815,6 +835,18 @@ export function createServer(opts: CreateServerOptions): BunServer {
       { cause: err },
     );
   }
+
+  // CTL-1167: VAPID keys + push-subscriptions store init.
+  const pushSubsDbPath =
+    pushSubscriptionsDbPath ?? `${CATALYST_DIR}/push-subscriptions.db`;
+  const vapidPath = vapidKeysPath ?? `${CATALYST_DIR}/vapid-keys.json`;
+  const vapidKeys = loadOrCreateVapidKeys(vapidPath);
+  pushStore.openDb(pushSubsDbPath);
+  webpush.setVapidDetails(
+    "mailto:catalyst@localhost",
+    vapidKeys.publicKey,
+    vapidKeys.privateKey,
+  );
 
   // CTL-1100: in-process LRU cache for /api/beliefs/rates (keyed by max tick_id,
   // cap RATES_LRU_CAP=64; beliefs are insert-only so the cached value per max tick
@@ -1386,6 +1418,23 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // synchronous per-request scan of the source signal files.
   const assembleNavSignal = async (board: BoardPayload): Promise<NavSignal> =>
     deriveNavSignal(board, { daemon: await readDaemonHealth() });
+
+  // CTL-1167: adapt a BoardPayload to the ProjectorBoard shape needed by the
+  // notification projector (shared by the SSE stream + the push bridge).
+  const toProjectorBoard = async (board: BoardPayload): Promise<ProjectorBoard> => {
+    const nav = await assembleNavSignal(board);
+    return {
+      tickets: board.tickets.map((t) => ({
+        id: t.id,
+        attention: t.attention,
+        attentionSince: t.attentionSince,
+        humanQuestion: t.humanQuestion ?? undefined,
+        title: t.title,
+      })),
+      daemon: nav.daemon,
+      anomaly: nav.anomaly,
+    };
+  };
 
   // CTL-898 (SHELL8): the per-node cluster-health projection for the footer +
   // node filter. The cluster VIEW (owner_host grouping + heartbeat liveness
@@ -3934,6 +3983,45 @@ export function createServer(opts: CreateServerOptions): BunServer {
           });
         }
 
+        // CTL-1167: serve the VAPID public key so the browser can build the
+        // applicationServerKey for pushManager.subscribe().
+        if (url.pathname === "/api/notifications/vapid-public-key") {
+          return new Response(vapidKeys.publicKey, {
+            headers: { "Content-Type": "text/plain" },
+          });
+        }
+
+        // CTL-1167: persist a browser push subscription (POST body is the
+        // serialised PushSubscription JSON from the browser). Returns 201 on
+        // success; 400 on missing/invalid fields.
+        if (url.pathname === "/api/notifications/subscribe" && req.method === "POST") {
+          let body: unknown;
+          try {
+            body = await req.json();
+          } catch {
+            return new Response("invalid JSON", { status: 400 });
+          }
+          const sub = body as Record<string, unknown>;
+          const keys = sub?.keys as Record<string, unknown> | undefined;
+          if (
+            typeof sub?.endpoint !== "string" ||
+            !sub.endpoint ||
+            typeof keys?.p256dh !== "string" ||
+            !keys.p256dh ||
+            typeof keys?.auth !== "string" ||
+            !keys.auth
+          ) {
+            return new Response("missing endpoint, keys.p256dh or keys.auth", {
+              status: 400,
+            });
+          }
+          pushStore.upsertSubscription({
+            endpoint: sub.endpoint as string,
+            keys: { p256dh: keys.p256dh as string, auth: keys.auth as string },
+          });
+          return new Response(null, { status: 201 });
+        }
+
         // CTL-967 (N5): read-only SSE feed of new belief rows from
         // ~/catalyst/beliefs.db, tailed by a BeliefTail cursor. Each SSE
         // event carries a single belief row (joined with tick.ts_ms/host) in
@@ -4321,6 +4409,21 @@ export function createServer(opts: CreateServerOptions): BunServer {
     serviceHealth.start();
   }
 
+  // CTL-1167: start the server-side push bridge. Gated on pushBridgeOpt so
+  // tests can disable it with { pushBridge: false }. The bridge subscribes to
+  // boardSnapshot in-process (subscriber-gated — zero cost when no subscriptions
+  // are stored) and sends Web Push to every stored subscription for each novel
+  // notification the projector yields.
+  if (pushBridgeOpt !== false) {
+    const bridge = createPushBridge({
+      store: pushStore,
+      projector: createNotificationProjector(),
+    });
+    boardSnapshot.subscribe((snap) => {
+      void toProjectorBoard(snap).then((pb) => bridge.onBoard(pb));
+    });
+  }
+
   if (webhookConfig && webhookHandler) {
     const tunnelTarget =
       webhookConfig.target ?? `http://localhost:${server.port}/api/webhook`;
@@ -4417,6 +4520,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     void webhookTunnel?.stop();
     void linearWebhookTunnel?.stop();
     closeDb();
+    pushStore.closeDb();
     sseClients.clear();
     clearInterval(titleDescSweepTimer);
     if (anchorPollTimer) clearInterval(anchorPollTimer); // CTL-1251 anchor poll

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1428,7 +1428,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
         id: t.id,
         attention: t.attention,
         attentionSince: t.attentionSince,
-        humanQuestion: t.humanQuestion ?? undefined,
+        // humanQuestion lives in explanation.call_to_action (CTL-1130).
+        humanQuestion: t.explanation?.call_to_action ?? undefined,
         title: t.title,
       })),
       daemon: nav.daemon,
@@ -4016,8 +4017,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
             });
           }
           pushStore.upsertSubscription({
-            endpoint: sub.endpoint as string,
-            keys: { p256dh: keys.p256dh as string, auth: keys.auth as string },
+            endpoint: sub.endpoint,
+            keys: { p256dh: keys.p256dh, auth: keys.auth },
           });
           return new Response(null, { status: 201 });
         }

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -4022,6 +4022,64 @@ export function createServer(opts: CreateServerOptions): BunServer {
           return new Response(null, { status: 201 });
         }
 
+        // CTL-1167: SSE stream of novel push-worthy notifications. Mirrors
+        // /api/nav/stream: one per-connection projector, subscribe-first, emit on
+        // every board recompute that yields new notifications. Each event:
+        //   event: notification\ndata: {title,body,deepLink}\n\n
+        if (url.pathname === "/api/notifications/stream") {
+          let unsubNotif: (() => void) | null = null;
+          let closedNotif = false;
+          const notifProjector = createNotificationProjector();
+          const emitNotifications = (
+            controller: ReadableStreamDefaultController<Uint8Array>,
+            pb: ProjectorBoard,
+          ) => {
+            if (closedNotif) return;
+            for (const n of notifProjector.project(pb)) {
+              try {
+                controller.enqueue(
+                  encoder.encode(
+                    `event: notification\ndata: ${JSON.stringify(n)}\n\n`,
+                  ),
+                );
+              } catch {
+                unsubNotif?.();
+                unsubNotif = null;
+              }
+            }
+          };
+          const notifStream = new ReadableStream<Uint8Array>({
+            async start(controller) {
+              unsubNotif = boardSnapshot.subscribe((snap) => {
+                void toProjectorBoard(snap).then((pb) =>
+                  emitNotifications(controller, pb),
+                );
+              });
+              try {
+                emitNotifications(
+                  controller,
+                  await toProjectorBoard(await boardSnapshot.getLatest()),
+                );
+              } catch (err) {
+                console.error(`[server] notifications stream initial emit failed:`, err);
+              }
+            },
+            cancel() {
+              closedNotif = true;
+              unsubNotif?.();
+              unsubNotif = null;
+            },
+          });
+          return new Response(notifStream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+              "Access-Control-Allow-Origin": "*",
+            },
+          });
+        }
+
         // CTL-967 (N5): read-only SSE feed of new belief rows from
         // ~/catalyst/beliefs.db, tailed by a BeliefTail cursor. Each SSE
         // event carries a single belief row (joined with tick.ts_ms/host) in

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-footer.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-footer.test.tsx
@@ -119,7 +119,7 @@ mock.module("@/hooks/use-push-subscription", () => {
     base64UrlToUint8Array,
     usePushSubscription: () => ({
       supported: false,
-      permission: "default" as const,
+      permission: "default" as "default",
       subscribed: false,
       enable: async () => {},
       error: null,

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-footer.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-footer.test.tsx
@@ -100,6 +100,33 @@ mock.module("@/components/ui/tooltip", () => ({
   TooltipProvider: passThrough,
 }));
 
+// CTL-1167: push subscription hook — stub usePushSubscription so AppFooter()
+// doesn't call useState (no React dispatcher in direct-call tests). Re-export
+// the real base64UrlToUint8Array so use-push-subscription.test.ts is unaffected
+// when bun runs both files in the same worker thread (mock.module persists in the
+// module registry until afterAll → mock.restore() fires).
+mock.module("@/hooks/use-push-subscription", () => {
+  function base64UrlToUint8Array(base64UrlString: string): Uint8Array {
+    const base64 = base64UrlString.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+    const raw = atob(padded);
+    const bytes = new Uint8Array(raw.length);
+    for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+    return bytes;
+  }
+  return {
+    PUSH_SUPPORTED: false,
+    base64UrlToUint8Array,
+    usePushSubscription: () => ({
+      supported: false,
+      permission: "default" as const,
+      subscribed: false,
+      enable: async () => {},
+      error: null,
+    }),
+  };
+});
+
 // Restore module mocks after the file finishes — prevents mock.module from
 // leaking into other test files running in the same bun worker thread.
 afterAll(() => { mock.restore(); });

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-footer.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-footer.tsx
@@ -40,6 +40,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { C, LIVE } from "@/board/board-tokens";
+// CTL-1167: PWA push notification enable control
+import { usePushSubscription } from "@/hooks/use-push-subscription";
 
 const RIGHT_LABEL: Record<ServiceSeverity, string> = {
   up: "HEALTHY",
@@ -53,6 +55,7 @@ export function AppFooter() {
   const nav = useNavSignalContext();
   const cluster = useClusterSignalContext();
   const { services, unavailable } = useServiceHealthContext();
+  const push = usePushSubscription();
 
   const isLive = status === "connected";
 
@@ -153,6 +156,21 @@ export function AppFooter() {
             </span>
           )}
         </span>
+      )}
+
+      {/* CTL-1167: push notifications enable button — visible only when
+          supported (installed PWA) and not yet subscribed. iOS requires a
+          user gesture; this satisfies that requirement. */}
+      {push.supported && !push.subscribed && push.permission !== "denied" && (
+        <button
+          type="button"
+          onClick={() => void push.enable()}
+          className="font-mono text-[10px] tracking-widest"
+          style={{ color: C.fgMuted }}
+          title="Enable push notifications for this dashboard"
+        >
+          ENABLE NOTIFS
+        </button>
       )}
 
       {/* Spacer */}

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-push-subscription.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-push-subscription.test.ts
@@ -1,0 +1,54 @@
+// use-push-subscription.test.ts — CTL-1167 phase 7 unit tests.
+// Guard-logic tests for the push subscription hook: feature-detect, permission
+// checks, and API call assertions, all without touching real browser APIs.
+import { describe, it, expect } from "bun:test";
+import {
+  PUSH_SUPPORTED,
+  base64UrlToUint8Array,
+} from "./use-push-subscription";
+
+describe("PUSH_SUPPORTED (feature detection constant)", () => {
+  it("is a boolean", () => {
+    expect(typeof PUSH_SUPPORTED).toBe("boolean");
+  });
+
+  it("is false in a bun test environment (no browser APIs)", () => {
+    // In the bun test environment there is no Notification / serviceWorker /
+    // PushManager — so the hook must detect absence and report unsupported.
+    expect(PUSH_SUPPORTED).toBe(false);
+  });
+});
+
+describe("base64UrlToUint8Array", () => {
+  it("converts a known base64url string to the expected byte sequence", () => {
+    // "AQID" = base64url for [0x01, 0x02, 0x03]
+    const result = base64UrlToUint8Array("AQID");
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result[0]).toBe(1);
+    expect(result[1]).toBe(2);
+    expect(result[2]).toBe(3);
+  });
+
+  it("handles base64url padding-free strings", () => {
+    // "AA" → base64url for [0x00] (with stripped trailing ==)
+    const result = base64UrlToUint8Array("AA");
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result[0]).toBe(0);
+  });
+
+  it("converts - to + and _ to / before decoding (base64url → base64)", () => {
+    // "-_" → base64url → "+/" → base64 bytes [0xfb, 0xff]
+    const result = base64UrlToUint8Array("-_0");
+    // Just verify it doesn't throw and returns a Uint8Array
+    expect(result).toBeInstanceOf(Uint8Array);
+  });
+
+  it("decodes a sample VAPID public key to the expected byte length", () => {
+    // A real web-push generated key is 65 bytes (uncompressed P-256 point).
+    // BNrt… is a 65-byte key in base64url (87 chars + stripped padding).
+    const key65 = "BNrterG7WkJLCHqbgJJtNRhPFqFMzB5v3JtWNxkbWxd2uZ1jGOcO6hzDdSIoLh0dUhxhJI7K5rG5mQhK8QN5Bbc";
+    const result = base64UrlToUint8Array(key65);
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBe(65);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-push-subscription.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-push-subscription.ts
@@ -24,12 +24,18 @@ export const PUSH_SUPPORTED: boolean =
 
 // Co-located with the hook; not exported from the barrel so knip is satisfied
 // by the test import.
-export function base64UrlToUint8Array(base64UrlString: string): Uint8Array {
+// Returns a Uint8Array explicitly backed by a (non-shared) ArrayBuffer so it
+// satisfies BufferSource for PushManager.subscribe's applicationServerKey under
+// TS 5.8+'s generic typed-array lib (Uint8Array<ArrayBufferLike> would not be
+// assignable, since ArrayBufferLike admits SharedArrayBuffer).
+export function base64UrlToUint8Array(
+  base64UrlString: string,
+): Uint8Array<ArrayBuffer> {
   // base64url → base64: replace URL-safe chars, then pad to a multiple of 4.
   const base64 = base64UrlString.replace(/-/g, "+").replace(/_/g, "/");
   const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
   const raw = atob(padded);
-  const bytes = new Uint8Array(raw.length);
+  const bytes = new Uint8Array(new ArrayBuffer(raw.length));
   for (let i = 0; i < raw.length; i++) {
     bytes[i] = raw.charCodeAt(i);
   }
@@ -38,18 +44,18 @@ export function base64UrlToUint8Array(base64UrlString: string): Uint8Array {
 
 // ── Hook ──────────────────────────────────────────────────────────────────────
 
-export type PushPushNotificationPermission = "default" | "granted" | "denied";
+export type PushNotificationPermission = "default" | "granted" | "denied";
 
 export interface UsePushSubscriptionResult {
   supported: boolean;
-  permission: PushPushNotificationPermission;
+  permission: PushNotificationPermission;
   subscribed: boolean;
   enable(): Promise<void>;
   error: string | null;
 }
 
 export function usePushSubscription(): UsePushSubscriptionResult {
-  const [permission, setPermission] = useState<PushPushNotificationPermission>(
+  const [permission, setPermission] = useState<PushNotificationPermission>(
     PUSH_SUPPORTED
       ? (Notification.permission as PushNotificationPermission)
       : "default",

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-push-subscription.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-push-subscription.ts
@@ -38,20 +38,20 @@ export function base64UrlToUint8Array(base64UrlString: string): Uint8Array {
 
 // ── Hook ──────────────────────────────────────────────────────────────────────
 
-export type NotificationPermission = "default" | "granted" | "denied";
+export type PushPushNotificationPermission = "default" | "granted" | "denied";
 
 export interface UsePushSubscriptionResult {
   supported: boolean;
-  permission: NotificationPermission;
+  permission: PushPushNotificationPermission;
   subscribed: boolean;
   enable(): Promise<void>;
   error: string | null;
 }
 
 export function usePushSubscription(): UsePushSubscriptionResult {
-  const [permission, setPermission] = useState<NotificationPermission>(
+  const [permission, setPermission] = useState<PushPushNotificationPermission>(
     PUSH_SUPPORTED
-      ? (Notification.permission as NotificationPermission)
+      ? (Notification.permission as PushNotificationPermission)
       : "default",
   );
   const [subscribed, setSubscribed] = useState(false);
@@ -69,7 +69,7 @@ export function usePushSubscription(): UsePushSubscriptionResult {
       }
       if (Notification.permission !== "granted") {
         const result = await Notification.requestPermission();
-        setPermission(result as NotificationPermission);
+        setPermission(result as PushNotificationPermission);
         if (result !== "granted") return;
       }
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-push-subscription.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-push-subscription.ts
@@ -1,0 +1,109 @@
+// CTL-1167: React hook for PWA Web Push subscription lifecycle.
+//
+// Feature-detects Notification + serviceWorker + PushManager, prompts once for
+// permission on an explicit user gesture (enable()), subscribes via the VAPID
+// key fetched from /api/notifications/vapid-public-key, and POSTs the serialised
+// PushSubscription to /api/notifications/subscribe.
+//
+// iOS 16.4+ home-screen installs: push works only from the installed PWA — a
+// plain Safari tab lacks PushManager. The supported flag surfaces this to the UI
+// so the "Enable notifications" control can be hidden on plain-tab visits.
+import { useState, useCallback } from "react";
+
+// ── Feature detection ─────────────────────────────────────────────────────────
+
+// Evaluated once at module load (not per render) so it's a stable constant.
+// false in the bun test environment (no Notification / serviceWorker / PushManager).
+export const PUSH_SUPPORTED: boolean =
+  typeof window !== "undefined" &&
+  "Notification" in window &&
+  "serviceWorker" in navigator &&
+  "PushManager" in window;
+
+// ── base64url → Uint8Array helper (for applicationServerKey) ─────────────────
+
+// Co-located with the hook; not exported from the barrel so knip is satisfied
+// by the test import.
+export function base64UrlToUint8Array(base64UrlString: string): Uint8Array {
+  // base64url → base64: replace URL-safe chars, then pad to a multiple of 4.
+  const base64 = base64UrlString.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+  const raw = atob(padded);
+  const bytes = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) {
+    bytes[i] = raw.charCodeAt(i);
+  }
+  return bytes;
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+export type NotificationPermission = "default" | "granted" | "denied";
+
+export interface UsePushSubscriptionResult {
+  supported: boolean;
+  permission: NotificationPermission;
+  subscribed: boolean;
+  enable(): Promise<void>;
+  error: string | null;
+}
+
+export function usePushSubscription(): UsePushSubscriptionResult {
+  const [permission, setPermission] = useState<NotificationPermission>(
+    PUSH_SUPPORTED
+      ? (Notification.permission as NotificationPermission)
+      : "default",
+  );
+  const [subscribed, setSubscribed] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const enable = useCallback(async () => {
+    if (!PUSH_SUPPORTED) return;
+    setError(null);
+
+    try {
+      // 1. Request permission on the user gesture.
+      if (Notification.permission === "denied") {
+        setPermission("denied");
+        return;
+      }
+      if (Notification.permission !== "granted") {
+        const result = await Notification.requestPermission();
+        setPermission(result as NotificationPermission);
+        if (result !== "granted") return;
+      }
+
+      // 2. Get the service worker registration.
+      const registration = await navigator.serviceWorker.ready;
+
+      // 3. Fetch the VAPID public key.
+      const keyRes = await fetch("/api/notifications/vapid-public-key");
+      if (!keyRes.ok) throw new Error("Failed to fetch VAPID key");
+      const vapidPublicKey = await keyRes.text();
+
+      // 4. Subscribe (or reuse existing subscription).
+      let subscription = await registration.pushManager.getSubscription();
+      if (!subscription) {
+        subscription = await registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: base64UrlToUint8Array(vapidPublicKey),
+        });
+      }
+
+      // 5. POST the serialised subscription to the server.
+      const subJson = subscription.toJSON();
+      const postRes = await fetch("/api/notifications/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(subJson),
+      });
+      if (!postRes.ok) throw new Error(`Subscribe failed: ${postRes.status}`);
+
+      setSubscribed(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
+  return { supported: PUSH_SUPPORTED, permission, subscribed, enable, error };
+}


### PR DESCRIPTION
## Summary
- Phase-agent implement worker for CTL-1167 (PWA Push Notifications)
- Adds `lib/notification-filter.ts` (pure projector), `lib/push-subscriptions.ts` (SQLite store), `lib/vapid.ts` (VAPID key loader), `lib/push-bridge.ts` (server-side fan-out)
- Extends `server.ts` with VAPID/subscribe/notifications-stream endpoints and the push bridge startup task
- Adds `push` + `notificationclick` service-worker handlers
- Adds `ui/src/hooks/use-push-subscription.ts` React hook + footer "Enable notifications" button

## Test plan
- [ ] `bun test notification-filter` — 12 unit tests pass
- [ ] `bun test push-subscriptions` — CRUD + ensureDb-throws pass
- [ ] `bun test vapid` — idempotence test pass
- [ ] `bun test notifications-subscribe-endpoints` — HTTP route integration tests pass
- [ ] `bun test notifications-stream` — SSE endpoint integration tests pass
- [ ] `bun test push-bridge` — fan-out + 410 prune mocked tests pass
- [ ] `bun test pwa-assets` — extended assertions for push/notificationclick handlers pass
- [ ] `bun run check` — full gate (tsc + lint + knip + audit + test) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)