### PR TITLE
feat(dev): CTL-1170 — async sweeps to unblock heartbeat event loop

### DIFF
--- a/plugins/dev/scripts/execution-core/fleet-health-probe.mjs
+++ b/plugins/dev/scripts/execution-core/fleet-health-probe.mjs
@@ -23,8 +23,8 @@
 // tick() is fully unit-testable with no real timer, sysctl, ps, or kill. Models
 // memory-sampler.mjs byte-for-byte.
 
-import { execFileSync } from "node:child_process";
-import { readdirSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { readdir } from "node:fs/promises";
 import { getAgentsCached } from "./claude-agents.mjs";
 import { getJobsRoot, readFleetHealthConfig, log } from "./config.mjs";
 import { emitFleetHealthEvent } from "./fleet-health-event.mjs";
@@ -37,10 +37,8 @@ function realClock() {
   };
 }
 
-// safe() — run a reader, returning its value, or the supplied NON-CROSSING
-// sentinel on any throw. The sentinel must be a value that can never trip a
-// threshold (null for counts; 0 for swap), so an unreadable signal can only
-// cause the guardrail to UNDER-react — never to over-react / over-reap.
+// safe() — run a sync reader, returning its value, or the supplied NON-CROSSING
+// sentinel on any throw. Used for the warm-cache listAgents read only.
 function safe(fn, sentinel) {
   try {
     const v = fn();
@@ -50,11 +48,29 @@ function safe(fn, sentinel) {
   }
 }
 
+function execFileAsync(bin, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(bin, args, { encoding: "utf8", ...opts }, (err, stdout) =>
+      err ? reject(err) : resolve(stdout)
+    );
+  });
+}
+
+// safeAsync() — await a reader, returning its value or the sentinel on any error.
+async function safeAsync(fn, sentinel) {
+  try {
+    const v = await fn();
+    return v === undefined || v === null ? sentinel : v;
+  } catch {
+    return sentinel;
+  }
+}
+
 // defaultReadJobsCount — count of ~/.claude/jobs/<id> dirs. try/catch → null
 // (non-crossing) so a missing/unreadable jobs root never trips the guardrail.
-export function defaultReadJobsCount() {
+export async function defaultReadJobsCount() {
   try {
-    return readdirSync(getJobsRoot()).length;
+    return (await readdir(getJobsRoot())).length;
   } catch {
     return null;
   }
@@ -63,10 +79,9 @@ export function defaultReadJobsCount() {
 // defaultPsLines — `ps -axo pid=,ppid=,command=` lines. Best-effort `[]` on
 // failure. command= (not comm=) preserves the full argv so node/bun detection
 // in the proc count + child sweep is exact.
-export function defaultPsLines() {
+export async function defaultPsLines() {
   try {
-    const out = execFileSync("ps", ["-axo", "pid=,ppid=,command="], {
-      encoding: "utf8",
+    const out = await execFileAsync("ps", ["-axo", "pid=,ppid=,command="], {
       maxBuffer: 16 * 1024 * 1024,
     });
     return out.split("\n");
@@ -77,9 +92,9 @@ export function defaultPsLines() {
 
 // defaultReadProcsCount — count resident node/bun worker processes from the ps
 // snapshot. A null/empty snapshot yields 0 (non-crossing safe sentinel handled
-// by the caller's safe()).
-export function defaultReadProcsCount(psLines = defaultPsLines) {
-  const lines = psLines() ?? [];
+// by the caller's safeAsync()).
+export async function defaultReadProcsCount(psLines = defaultPsLines) {
+  const lines = (await psLines()) ?? [];
   let n = 0;
   for (const line of lines) {
     const m = line.trim().match(/^(\d+)\s+(\d+)\s+(.*)$/);
@@ -93,14 +108,14 @@ export function defaultReadProcsCount(psLines = defaultPsLines) {
 // defaultReadSwapUsedMb — parse macOS `sysctl -n vm.swapusage`'s `used = N.NNM`
 // field → integer MB. Non-darwin / parse-error / throw → 0 (safe sentinel,
 // non-crossing). run/platform are injectable for tests.
-export function defaultReadSwapUsedMb({
+export async function defaultReadSwapUsedMb({
   platform = process.platform,
-  run = () => execFileSync("sysctl", ["-n", "vm.swapusage"], { encoding: "utf8" }),
+  run = () => execFileAsync("sysctl", ["-n", "vm.swapusage"]),
 } = {}) {
   if (platform !== "darwin") return 0;
   let out;
   try {
-    out = run();
+    out = await run();
   } catch {
     return 0;
   }
@@ -148,8 +163,7 @@ export async function defaultTriggerSelfHeal({ emitIntent = emitReapIntent } = {
  */
 export function classifyFleetHealth(readings, thresholds) {
   const { jobsCount, agentsCount, procsCount, swapUsedMb } = readings ?? {};
-  const { jobsThreshold, agentsThreshold, procsThreshold, swapUsedMbThreshold } =
-    thresholds ?? {};
+  const { jobsThreshold, agentsThreshold, procsThreshold, swapUsedMbThreshold } = thresholds ?? {};
   const tripped = [];
   if (jobsCount != null && jobsCount >= jobsThreshold) tripped.push("jobs");
   if (agentsCount != null && agentsCount >= agentsThreshold) tripped.push("agents");
@@ -198,13 +212,13 @@ export function startFleetHealthProbe({
   let sustained = 0; // consecutive degraded ticks
   let fired = false; // self-heal already fired this breach episode (re-armed on a healthy tick)
 
-  function tick() {
+  async function tick() {
     // Each signal read is wrapped so a throw yields a NON-CROSSING sentinel,
     // never a faked-healthy reading and never a crash.
-    const jobsCount = safe(() => readJobsCount(), null);
+    const jobsCount = await safeAsync(() => readJobsCount(), null);
     const agentsCount = safe(() => (listAgents() ?? []).length, null);
-    const procsCount = safe(() => defaultReadProcsCount(psLines), null);
-    const swapUsedMb = safe(() => readSwapUsedMb(), 0);
+    const procsCount = await safeAsync(() => defaultReadProcsCount(psLines), null);
+    const swapUsedMb = await safeAsync(() => readSwapUsedMb(), 0);
 
     const readings = { jobsCount, agentsCount, procsCount, swapUsedMb };
     const { degraded, tripped } = classifyFleetHealth(readings, {
@@ -240,7 +254,9 @@ export function startFleetHealthProbe({
     }
   }
 
-  const handle = clock.setInterval(tick, intervalMs);
+  const handle = clock.setInterval(() => {
+    tick().catch(() => {});
+  }, intervalMs);
   if (typeof handle?.unref === "function") handle.unref();
   return { stop: () => clock.clearInterval(handle), tick };
 }

--- a/plugins/dev/scripts/execution-core/fleet-health-probe.test.mjs
+++ b/plugins/dev/scripts/execution-core/fleet-health-probe.test.mjs
@@ -138,9 +138,9 @@ describe("classifyFleetHealth (pure)", () => {
 // ─── Probe tick behaviour ────────────────────────────────────────────────────
 
 describe("startFleetHealthProbe tick", () => {
-  test("threshold-cross emits exactly one event with all four readings + tripped + sustained_n=1", () => {
+  test("threshold-cross emits exactly one event with all four readings + tripped + sustained_n=1", async () => {
     const { p, emitted } = harness({ jobs: 600, agents: 3, procs: 5, swap: 100 });
-    p.tick();
+    await p.tick();
     expect(emitted.length).toBe(1);
     const e = emitted[0];
     expect(e.jobsCount).toBe(600);
@@ -151,7 +151,7 @@ describe("startFleetHealthProbe tick", () => {
     expect(e.sustained_n).toBe(1);
   });
 
-  test("below-threshold is silent (0 events, 0 self-heal, counter stays 0)", () => {
+  test("below-threshold is silent (0 events, 0 self-heal, counter stays 0)", async () => {
     const { p, emitted, selfHeals } = harness({
       config: baseConfig({ selfHealEnabled: true }),
       jobs: 10,
@@ -159,65 +159,65 @@ describe("startFleetHealthProbe tick", () => {
       procs: 1,
       swap: 0,
     });
-    p.tick();
-    p.tick();
+    await p.tick();
+    await p.tick();
     expect(emitted.length).toBe(0);
     expect(selfHeals.length).toBe(0);
   });
 
-  test("self-heal fires ONCE on sustained breach (sustainedTicks=2)", () => {
+  test("self-heal fires ONCE on sustained breach (sustainedTicks=2)", async () => {
     const { p, emitted, selfHeals } = harness({
       config: baseConfig({ selfHealEnabled: true, sustainedTicks: 2 }),
       jobs: 600,
     });
-    p.tick(); // sustained_n=1, below sustainedTicks
+    await p.tick(); // sustained_n=1, below sustainedTicks
     expect(selfHeals.length).toBe(0);
-    p.tick(); // sustained_n=2 === sustainedTicks → fires once
+    await p.tick(); // sustained_n=2 === sustainedTicks → fires once
     expect(selfHeals.length).toBe(1);
-    p.tick(); // sustained_n=3, already fired this episode → still 1
-    p.tick(); // sustained_n=4 → still 1
+    await p.tick(); // sustained_n=3, already fired this episode → still 1
+    await p.tick(); // sustained_n=4 → still 1
     expect(selfHeals.length).toBe(1);
     // every degraded tick still emits an event
     expect(emitted.length).toBe(4);
   });
 
-  test("hysteresis re-arms only after a healthy tick", () => {
+  test("hysteresis re-arms only after a healthy tick", async () => {
     const { p, refs, selfHeals } = harness({
       config: baseConfig({ selfHealEnabled: true, sustainedTicks: 2 }),
       jobs: 600,
     });
-    p.tick(); // n=1
-    p.tick(); // n=2 → fire #1
+    await p.tick(); // n=1
+    await p.tick(); // n=2 → fire #1
     expect(selfHeals.length).toBe(1);
     // recover
     refs.jobs = 10;
-    p.tick(); // healthy → resets counter + re-arms
+    await p.tick(); // healthy → resets counter + re-arms
     // fresh sustained run
     refs.jobs = 600;
-    p.tick(); // n=1
+    await p.tick(); // n=1
     expect(selfHeals.length).toBe(1);
-    p.tick(); // n=2 → fire #2
+    await p.tick(); // n=2 → fire #2
     expect(selfHeals.length).toBe(2);
   });
 
-  test("reader failure degrades safe — all readers throw → sentinels, 0 events, 0 self-heal", () => {
+  test("reader failure degrades safe — all readers throw → sentinels, 0 events, 0 self-heal", async () => {
     const { p, emitted, selfHeals } = harness({
       config: baseConfig({ selfHealEnabled: true, sustainedTicks: 1 }),
       throwAll: true,
     });
-    expect(() => p.tick()).not.toThrow();
+    await p.tick();
     expect(emitted.length).toBe(0);
     expect(selfHeals.length).toBe(0);
   });
 
-  test("selfHealEnabled=false (default) → emits every tick but never sweeps", () => {
+  test("selfHealEnabled=false (default) → emits every tick but never sweeps", async () => {
     const { p, emitted, selfHeals } = harness({
       config: baseConfig({ selfHealEnabled: false, sustainedTicks: 2 }),
       jobs: 600,
     });
-    p.tick();
-    p.tick();
-    p.tick();
+    await p.tick();
+    await p.tick();
+    await p.tick();
     expect(emitted.length).toBe(3);
     expect(selfHeals.length).toBe(0);
   });
@@ -228,6 +228,39 @@ describe("startFleetHealthProbe tick", () => {
     p.stop();
     expect(clock.wasCleared()).toBe(true);
   });
+
+  test("awaits async readers and emits degraded when a threshold trips", async () => {
+    const emitted = [];
+    const { tick } = startFleetHealthProbe({
+      clock: { setInterval: () => ({ unref() {} }), clearInterval() {} },
+      config: { intervalMs: 120000, selfHealEnabled: false, sustainedTicks: 1,
+        jobsThreshold: 1, agentsThreshold: 9999, procsThreshold: 9999, swapUsedMbThreshold: 999999 },
+      readJobsCount: async () => 5,
+      listAgents: () => [],
+      psLines: async () => [],
+      readSwapUsedMb: async () => 0,
+      emit: (r) => emitted.push(r),
+    });
+    await tick();
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].tripped).toContain("jobs");
+  });
+
+  test("a rejecting async reader yields the non-crossing sentinel (no crash, no trip)", async () => {
+    const emitted = [];
+    const { tick } = startFleetHealthProbe({
+      clock: { setInterval: () => ({ unref() {} }), clearInterval() {} },
+      config: { intervalMs: 120000, selfHealEnabled: false, sustainedTicks: 1,
+        jobsThreshold: 1, agentsThreshold: 1, procsThreshold: 1, swapUsedMbThreshold: 1 },
+      readJobsCount: async () => { throw new Error("readdir failed"); },
+      listAgents: () => { throw new Error("x"); },
+      psLines: async () => { throw new Error("ps failed"); },
+      readSwapUsedMb: async () => { throw new Error("sysctl failed"); },
+      emit: (r) => emitted.push(r),
+    });
+    await tick();
+    expect(emitted).toHaveLength(0);
+  });
 });
 
 // ─── defaultReadSwapUsedMb ───────────────────────────────────────────────────
@@ -236,19 +269,19 @@ describe("defaultReadSwapUsedMb", () => {
   // platform:"darwin" is pinned explicitly — the default reads process.platform,
   // which is "linux" on CI, where the function short-circuits to 0 (sysctl is a
   // macOS-only signal). Pinning darwin exercises the real parse path everywhere.
-  test("parses the used field from sysctl vm.swapusage output", () => {
+  test("parses the used field from sysctl vm.swapusage output", async () => {
     const sample =
       "total = 8192.00M  used = 4500.06M  free = 3691.94M  (encrypted)";
-    expect(defaultReadSwapUsedMb({ platform: "darwin", run: () => sample })).toBe(4500);
+    expect(await defaultReadSwapUsedMb({ platform: "darwin", run: () => sample })).toBe(4500);
   });
 
-  test("off-darwin / non-darwin platform → 0 safe sentinel", () => {
-    expect(defaultReadSwapUsedMb({ platform: "linux" })).toBe(0);
+  test("off-darwin / non-darwin platform → 0 safe sentinel", async () => {
+    expect(await defaultReadSwapUsedMb({ platform: "linux" })).toBe(0);
   });
 
-  test("throwing sysctl → 0 safe sentinel", () => {
+  test("throwing sysctl → 0 safe sentinel", async () => {
     expect(
-      defaultReadSwapUsedMb({
+      await defaultReadSwapUsedMb({
         platform: "darwin",
         run: () => {
           throw new Error("sysctl missing");
@@ -257,9 +290,9 @@ describe("defaultReadSwapUsedMb", () => {
     ).toBe(0);
   });
 
-  test("no-match output → 0 safe sentinel", () => {
+  test("no-match output → 0 safe sentinel", async () => {
     expect(
-      defaultReadSwapUsedMb({ platform: "darwin", run: () => "garbage no used field" }),
+      await defaultReadSwapUsedMb({ platform: "darwin", run: () => "garbage no used field" }),
     ).toBe(0);
   });
 });

--- a/plugins/dev/scripts/execution-core/heartbeat-event.mjs
+++ b/plugins/dev/scripts/execution-core/heartbeat-event.mjs
@@ -13,10 +13,16 @@
 // resource block carries host.name + host.id from lib/host-identity.mjs, the
 // same primitives every other execution-core MJS emitter uses.
 
-import { mkdirSync, appendFileSync } from "node:fs";
+import { mkdir, appendFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { randomBytes } from "node:crypto";
-import { getEventLogPath, getHostName, HEARTBEAT_INTERVAL_MS, log, readGovernanceConfig } from "./config.mjs";
+import {
+  getEventLogPath,
+  getHostName,
+  HEARTBEAT_INTERVAL_MS,
+  log,
+  readGovernanceConfig,
+} from "./config.mjs";
 import { hostName, hostId } from "./lib/host-identity.mjs";
 
 export const HEARTBEAT_EVENT = "node.heartbeat";
@@ -78,11 +84,11 @@ export function buildHeartbeatEnvelope({ now, epochFn, governanceFn } = {}) {
  * throws). `logPath` is injectable for tests; defaults to the same
  * getEventLogPath() every other emitter uses (no new log path).
  */
-export function emitHeartbeatEvent({ logPath = getEventLogPath(), now, epochFn } = {}) {
+export async function emitHeartbeatEvent({ logPath = getEventLogPath(), now, epochFn } = {}) {
   const line = `${JSON.stringify(buildHeartbeatEnvelope({ now, epochFn }))}\n`;
   try {
-    mkdirSync(dirname(logPath), { recursive: true });
-    appendFileSync(logPath, line);
+    await mkdir(dirname(logPath), { recursive: true });
+    await appendFile(logPath, line);
     return true;
   } catch (err) {
     log.warn({ err: err?.message }, "heartbeat-event: event append failed");
@@ -101,13 +107,14 @@ export function emitHeartbeatEvent({ logPath = getEventLogPath(), now, epochFn }
  * @param {string} [opts.logPath]     event-log path (injectable for tests)
  */
 export function startHeartbeat({ intervalMs = HEARTBEAT_INTERVAL_MS, logPath } = {}) {
-  const tick = () => emitHeartbeatEvent({ logPath });
-  tick(); // emit once at boot so liveness is visible immediately
+  const tick = () => emitHeartbeatEvent({ logPath }).catch(() => {});
+  const started = tick(); // emit once at boot; Promise for callers that need to await it
   const timer = setInterval(tick, intervalMs);
   timer.unref?.();
   return {
     stop() {
       clearInterval(timer);
     },
+    started, // resolves after the first heartbeat write attempt
   };
 }

--- a/plugins/dev/scripts/execution-core/heartbeat-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/heartbeat-event.test.mjs
@@ -89,9 +89,9 @@ describe("emitHeartbeatEvent (CTL-859)", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  test("appends one parseable node.heartbeat line to the event log", () => {
+  test("appends one parseable node.heartbeat line to the event log", async () => {
     process.env.CATALYST_HOST_NAME = "mini";
-    expect(emitHeartbeatEvent({ logPath })).toBe(true);
+    expect(await emitHeartbeatEvent({ logPath })).toBe(true);
     const lines = readFileSync(logPath, "utf8").trim().split("\n");
     expect(lines).toHaveLength(1);
     const evt = JSON.parse(lines[0]);
@@ -99,12 +99,28 @@ describe("emitHeartbeatEvent (CTL-859)", () => {
     expect(evt.body.payload["host.name"]).toBe("mini");
   });
 
-  test("returns false (never throws) when the log path is unwriteable", () => {
-    // A path whose parent is a file, not a dir → mkdirSync/appendFileSync fail.
+  test("returns false (never throws) when the log path is unwriteable", async () => {
+    // A path whose parent is a file, not a dir → mkdir/appendFile fail.
     const fileAsDir = join(tmp, "afile");
     appendFileSync(fileAsDir, "x");
     const bad = join(fileAsDir, "events.jsonl");
-    expect(emitHeartbeatEvent({ logPath: bad })).toBe(false);
+    expect(await emitHeartbeatEvent({ logPath: bad })).toBe(false);
+  });
+
+  test("appends the envelope via async fs and resolves true", async () => {
+    const tmp2 = `${tmpdir()}/ctl1170-hb-${process.pid}.jsonl`;
+    try {
+      const ok = await emitHeartbeatEvent({ logPath: tmp2 });
+      expect(ok).toBe(true);
+      expect(readFileSync(tmp2, "utf8")).toContain('"event.action":"heartbeat"');
+    } finally {
+      rmSync(tmp2, { force: true });
+    }
+  });
+
+  test("resolves false on a write failure (never throws)", async () => {
+    const ok = await emitHeartbeatEvent({ logPath: "/proc/nonexistent/cannot/write.jsonl" });
+    expect(ok).toBe(false);
   });
 });
 
@@ -121,10 +137,11 @@ describe("startHeartbeat (CTL-859)", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  test("emits once immediately and returns a stop handle", () => {
+  test("emits once immediately and returns a stop handle", async () => {
     process.env.CATALYST_HOST_NAME = "mini";
     const h = startHeartbeat({ intervalMs: 1_000_000, logPath });
     try {
+      await h.started;
       const lines = readFileSync(logPath, "utf8").trim().split("\n");
       expect(lines).toHaveLength(1);
       expect(JSON.parse(lines[0]).attributes["event.name"]).toBe("node.heartbeat");
@@ -194,9 +211,9 @@ describe("readClusterHeartbeats (CTL-859)", () => {
     });
   });
 
-  test("round-trips an emitHeartbeatEvent-produced line", () => {
+  test("round-trips an emitHeartbeatEvent-produced line", async () => {
     process.env.CATALYST_HOST_NAME = "mini";
-    emitHeartbeatEvent({ logPath });
+    await emitHeartbeatEvent({ logPath });
     const seen = readClusterHeartbeats({ logPath });
     expect(Object.keys(seen)).toEqual(["mini"]);
     expect(typeof seen.mini).toBe("string");

--- a/plugins/dev/scripts/execution-core/job-dir-gc.mjs
+++ b/plugins/dev/scripts/execution-core/job-dir-gc.mjs
@@ -24,7 +24,7 @@
 // registered status:null zombie's dir is PRESERVED by the liveness gate; its
 // eviction is D4's job.
 
-import { readdirSync, statSync, rmSync } from "node:fs";
+import { readdir, stat, rm as rmAsync } from "node:fs/promises";
 import { join } from "node:path";
 import { getJobsRoot, log as defaultLog } from "./config.mjs";
 import { listClaudeAgentsResult } from "./claude-agents.mjs";
@@ -44,12 +44,13 @@ const DEFAULT_BATCH_CAP = 200;
  */
 export async function sweepJobDirs({
   jobsRoot = getJobsRoot(),
-  readDir = readdirSync,
-  statDir = (p) => statSync(p),
-  rm = rmSync,
+  readDir = (p) => readdir(p),
+  statDir = (p) => stat(p),
+  rm = (p, opts) => rmAsync(p, opts),
   readAgents = listClaudeAgentsResult,
   now = () => Date.now(),
-  retentionMs = (Number(process.env.CATALYST_JOB_GC_RETENTION_SECONDS) || DEFAULT_RETENTION_SECONDS) * 1000,
+  retentionMs = (Number(process.env.CATALYST_JOB_GC_RETENTION_SECONDS) ||
+    DEFAULT_RETENTION_SECONDS) * 1000,
   batchCap = Number(process.env.CATALYST_JOB_GC_BATCH_CAP) || DEFAULT_BATCH_CAP,
   emit = emitReapIntent,
   env = process.env,
@@ -98,7 +99,7 @@ export async function sweepJobDirs({
   // recovery.mjs). Any other read error → degrade safe: nothing to sweep.
   let basenames;
   try {
-    basenames = readDir(jobsRoot);
+    basenames = await readDir(jobsRoot);
   } catch (err) {
     if (err?.code !== "ENOENT") {
       log.warn({ jobsRoot, err: err?.message }, "job-dir-gc: jobs root unreadable; skipping sweep");
@@ -142,7 +143,7 @@ export async function sweepJobDirs({
     const dir = join(jobsRoot, basename);
     let st;
     try {
-      st = statDir(dir);
+      st = await statDir(dir);
     } catch {
       errors++;
       continue;
@@ -163,7 +164,7 @@ export async function sweepJobDirs({
 
     // All gates passed — delete the JOB DIR ALONE (never `claude rm`).
     try {
-      rm(dir, { recursive: true, force: true });
+      await rm(dir, { recursive: true, force: true });
       reclaimed++;
     } catch {
       errors++;

--- a/plugins/dev/scripts/execution-core/job-dir-gc.test.mjs
+++ b/plugins/dev/scripts/execution-core/job-dir-gc.test.mjs
@@ -202,4 +202,38 @@ describe("sweepJobDirs", () => {
     expect(rm.calls.length).toBe(0);
     expect(res.reclaimed).toBe(0);
   });
+
+  it("awaits async readDir/statDir/rm seams and still reclaims stale dirs", async () => {
+    const removed = [];
+    const res = await sweepJobDirs({
+      jobsRoot: ROOT,
+      readAgents: () => ({ ok: true, agents: [] }),
+      readDir: async () => ["aaaaaaaa", "bbbbbbbb"],
+      statDir: async () => ({ mtimeMs: 0 }),
+      rm: async (dir) => { removed.push(dir); },
+      now: () => 10 * 86_400_000,
+      env: {},
+      emit: async () => true,
+      log: logSpy(),
+    });
+    expect(removed).toEqual([join(ROOT, "aaaaaaaa"), join(ROOT, "bbbbbbbb")]);
+    expect(res.reclaimed).toBe(2);
+  });
+
+  it("isolates a per-entry async statDir rejection (errors++, batch continues)", async () => {
+    let calls = 0;
+    const res = await sweepJobDirs({
+      jobsRoot: ROOT,
+      readAgents: () => ({ ok: true, agents: [] }),
+      readDir: async () => ["aaaaaaaa", "bbbbbbbb"],
+      statDir: async () => { calls++; if (calls === 1) throw new Error("ENOENT"); return { mtimeMs: 0 }; },
+      rm: async () => {},
+      now: () => 10 * 86_400_000,
+      env: {},
+      emit: async () => true,
+      log: logSpy(),
+    });
+    expect(res.errors).toBe(1);
+    expect(res.reclaimed).toBe(1);
+  });
 });

--- a/plugins/dev/scripts/execution-core/proc-reaper.mjs
+++ b/plugins/dev/scripts/execution-core/proc-reaper.mjs
@@ -34,7 +34,7 @@
 // so the unit tests never spawn a subprocess, run ps/lsof, touch ~/.claude, or
 // signal a real pid.
 
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { basename } from "node:path";
 import { emitReapIntent } from "./reap-intent.mjs";
@@ -207,7 +207,7 @@ function isArgvAllowlisted(args, patterns) {
  * The ordering puts the never-kill allowlist + LIVE_TREE FIRST (so an
  * allowlisted/live proc is never even probed), then orphan/command/cwd/etime.
  */
-export function classifyProc(row, ctx) {
+export async function classifyProc(row, ctx) {
   const {
     byPid,
     liveAgentCwds,
@@ -240,7 +240,7 @@ export function classifyProc(row, ctx) {
   if (!isOrphaned(row, byPid)) return { action: "spare", reason: "has-live-ancestor" };
 
   // (5) cwd must be resolvable; unknown cwd → SPARE (degrade safe).
-  const cwd = cwdForPid(row.pid);
+  const cwd = await cwdForPid(row.pid);
   if (cwd === null || cwd === undefined) return { action: "spare", reason: "cwd-unknown" };
 
   // (6) cwd AT OR UNDER any live-agent cwd → a live worker's own (possibly
@@ -275,10 +275,17 @@ export function classifyProc(row, ctx) {
 
 // ─── Default IO seams (replaced wholesale in tests) ──────────────────────────
 
-function defaultPsLister() {
+function execFileAsync(bin, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(bin, args, { encoding: "utf8", ...opts }, (err, stdout) =>
+      err ? reject(err) : resolve(stdout)
+    );
+  });
+}
+
+async function defaultPsLister() {
   try {
-    const out = execFileSync("ps", ["-axo", "pid=,ppid=,rss=,etime=,command="], {
-      encoding: "utf8",
+    const out = await execFileAsync("ps", ["-axo", "pid=,ppid=,rss=,etime=,command="], {
       maxBuffer: 16 * 1024 * 1024,
     });
     return out.split("\n");
@@ -287,11 +294,9 @@ function defaultPsLister() {
   }
 }
 
-function defaultLsofCwd(pid) {
+async function defaultLsofCwd(pid) {
   try {
-    const out = execFileSync("lsof", ["-a", "-p", String(pid), "-d", "cwd", "-Fn"], {
-      encoding: "utf8",
-    });
+    const out = await execFileAsync("lsof", ["-a", "-p", String(pid), "-d", "cwd", "-Fn"]);
     // -Fn output: lines like `pPID`, `fcwd`, `n/abs/path`. The cwd path line
     // starts with 'n'.
     for (const line of out.split("\n")) {
@@ -393,7 +398,7 @@ export class ProcReaper {
     if (!agentsRes || agentsRes.ok !== true) {
       this.log.warn(
         {},
-        "proc-reaper: `claude agents` read FAILED — aborting sweep, killing nothing (CATASTROPHE GUARD)",
+        "proc-reaper: `claude agents` read FAILED — aborting sweep, killing nothing (CATASTROPHE GUARD)"
       );
       await this._safeEmit("procOrphans.spared", { reason: "agents-unreadable" });
       this._priorCandidates.clear(); // a failed read invalidates persistence state
@@ -403,7 +408,7 @@ export class ProcReaper {
     // Snapshot processes. An unreadable ps degrades safe (empty report).
     let rows;
     try {
-      rows = parsePsRows(this.psLister());
+      rows = parsePsRows(await this.psLister());
     } catch (err) {
       this.log.warn({ err: err?.message }, "proc-reaper: ps snapshot failed — skipping sweep");
       return report;
@@ -450,7 +455,7 @@ export class ProcReaper {
     const thisSweepCandidates = new Map();
     const verdicts = [];
     for (const row of rows) {
-      const v = classifyProc(row, ctx);
+      const v = await classifyProc(row, ctx);
       verdicts.push({ row, v });
       if (v.action === "kill") thisSweepCandidates.set(row.pid, row.args);
     }
@@ -475,7 +480,7 @@ export class ProcReaper {
         await this._safeEmit("procOrphans.would-reap", {
           pid: row.pid,
           command: row.command,
-          worktreePath: this._safeCwd(row.pid),
+          worktreePath: await this._safeCwd(row.pid),
         });
       } else if (this.mode === "enforce") {
         const killed = await this._terminateWithGrace(row);
@@ -484,7 +489,7 @@ export class ProcReaper {
           await this._safeEmit("procOrphans.reaped", {
             pid: row.pid,
             command: row.command,
-            worktreePath: this._safeCwd(row.pid),
+            worktreePath: await this._safeCwd(row.pid),
           });
         }
       }
@@ -509,7 +514,7 @@ export class ProcReaper {
     // different argv (or is absent) → stillSame false → no SIGKILL.
     let stillSame = true;
     try {
-      const fresh = parsePsRows(this.psLister());
+      const fresh = parsePsRows(await this.psLister());
       const cur = fresh.find((r) => r.pid === row.pid);
       stillSame = !!cur && cur.args === row.args;
     } catch {
@@ -523,9 +528,9 @@ export class ProcReaper {
     return true;
   }
 
-  _safeCwd(pid) {
+  async _safeCwd(pid) {
     try {
-      return this.lsofCwd(pid);
+      return await this.lsofCwd(pid);
     } catch {
       return null;
     }

--- a/plugins/dev/scripts/execution-core/proc-reaper.test.mjs
+++ b/plugins/dev/scripts/execution-core/proc-reaper.test.mjs
@@ -205,13 +205,13 @@ function ctx(overrides = {}) {
 }
 
 describe("classifyProc kill-gate (ALL must hold else SPARE)", () => {
-  test("orphan node under a worktree, not in LIVE_TREE, old enough → kill", () => {
+  test("orphan node under a worktree, not in LIVE_TREE, old enough → kill", async () => {
     const row = { pid: 10, ppid: 1, command: "node", etimeSec: 1000, args: "node x.mjs" };
     const c = ctx();
-    const v = classifyProc(row, c);
+    const v = await classifyProc(row, c);
     expect(v.action).toBe("kill");
   });
-  test("allowlisted argv (daemon) → spare(reason allowlisted)", () => {
+  test("allowlisted argv (daemon) → spare(reason allowlisted)", async () => {
     const row = {
       pid: 10,
       ppid: 1,
@@ -219,75 +219,75 @@ describe("classifyProc kill-gate (ALL must hold else SPARE)", () => {
       etimeSec: 1000,
       args: "node /x/execution-core/daemon.mjs --pid-file /y",
     };
-    const v = classifyProc(row, ctx());
+    const v = await classifyProc(row, ctx());
     expect(v.action).toBe("spare");
     expect(v.reason).toBe("allowlisted");
   });
-  test("pid in allowlist.pids (self/daemon/LIVE_TREE) → spare(reason allowlisted)", () => {
+  test("pid in allowlist.pids (self/daemon/LIVE_TREE) → spare(reason allowlisted)", async () => {
     const row = { pid: 100, ppid: 1, command: "node", etimeSec: 1000, args: "node x.mjs" };
-    const v = classifyProc(row, ctx({ allowlist: buildAllowlist({ selfPid: 100 }) }));
+    const v = await classifyProc(row, ctx({ allowlist: buildAllowlist({ selfPid: 100 }) }));
     expect(v.action).toBe("spare");
     expect(v.reason).toBe("allowlisted");
   });
-  test("pid in LIVE_TREE subtree → spare(reason live-agent-owned)", () => {
+  test("pid in LIVE_TREE subtree → spare(reason live-agent-owned)", async () => {
     const row = { pid: 222, ppid: 100, command: "node", etimeSec: 1000, args: "node x.mjs" };
     const c = ctx({
       liveAgentSubtreePids: new Set([222]),
       byPid: new Map([[100, { pid: 100, ppid: 1 }]]),
     });
-    const v = classifyProc(row, c);
+    const v = await classifyProc(row, c);
     expect(v.action).toBe("spare");
     expect(v.reason).toBe("live-agent-owned");
   });
-  test("cwd matches a live-agent cwd → spare(reason live-agent-owned)", () => {
+  test("cwd matches a live-agent cwd → spare(reason live-agent-owned)", async () => {
     const row = { pid: 10, ppid: 1, command: "node", etimeSec: 1000, args: "node x.mjs" };
     const c = ctx({
       liveAgentCwds: new Set([`${WT_ROOT}/CTL-X`]),
       cwdForPid: () => `${WT_ROOT}/CTL-X`,
     });
-    const v = classifyProc(row, c);
+    const v = await classifyProc(row, c);
     expect(v.action).toBe("spare");
     expect(v.reason).toBe("live-agent-owned");
   });
-  test("command not in killableCommands → spare(reason command-not-killable)", () => {
+  test("command not in killableCommands → spare(reason command-not-killable)", async () => {
     const row = { pid: 10, ppid: 1, command: "python", etimeSec: 1000, args: "python x.py" };
-    const v = classifyProc(row, ctx());
+    const v = await classifyProc(row, ctx());
     expect(v.action).toBe("spare");
     expect(v.reason).toBe("command-not-killable");
   });
-  test("not orphaned (has live ancestor) → spare(reason has-live-ancestor)", () => {
+  test("not orphaned (has live ancestor) → spare(reason has-live-ancestor)", async () => {
     const row = { pid: 10, ppid: 5, command: "node", etimeSec: 1000, args: "node x.mjs" };
     const c = ctx({ byPid: new Map([[5, { pid: 5, ppid: 100 }]]), cwdForPid: () => null });
-    const v = classifyProc(row, c);
+    const v = await classifyProc(row, c);
     expect(v.action).toBe("spare");
     expect(v.reason).toBe("has-live-ancestor");
   });
-  test("lsof cwd unknown (null) → spare(reason cwd-unknown)", () => {
+  test("lsof cwd unknown (null) → spare(reason cwd-unknown)", async () => {
     const row = { pid: 10, ppid: 1, command: "node", etimeSec: 1000, args: "node x.mjs" };
-    const v = classifyProc(row, ctx({ cwdForPid: () => null }));
+    const v = await classifyProc(row, ctx({ cwdForPid: () => null }));
     expect(v.action).toBe("spare");
     expect(v.reason).toBe("cwd-unknown");
   });
-  test("cwd NOT under worktree root (interactive claude region) → spare(reason not-under-worktree-root)", () => {
+  test("cwd NOT under worktree root (interactive claude region) → spare(reason not-under-worktree-root)", async () => {
     const row = { pid: 10, ppid: 1, command: "node", etimeSec: 1000, args: "node x.mjs" };
-    const v = classifyProc(row, ctx({ cwdForPid: () => "/Users/test/somewhere-else" }));
+    const v = await classifyProc(row, ctx({ cwdForPid: () => "/Users/test/somewhere-else" }));
     expect(v.action).toBe("spare");
     expect(v.reason).toBe("not-under-worktree-root");
   });
-  test("etime below minEtimeSec → spare(reason too-young)", () => {
+  test("etime below minEtimeSec → spare(reason too-young)", async () => {
     const row = { pid: 10, ppid: 1, command: "node", etimeSec: 100, args: "node x.mjs" };
-    const v = classifyProc(row, ctx({ minEtimeSec: 900 }));
+    const v = await classifyProc(row, ctx({ minEtimeSec: 900 }));
     expect(v.action).toBe("spare");
     expect(v.reason).toBe("too-young");
   });
-  test("targeted worktreePath scopes the kill (boundary-safe: CTL-X ≠ CTL-X9)", () => {
+  test("targeted worktreePath scopes the kill (boundary-safe: CTL-X ≠ CTL-X9)", async () => {
     const row = { pid: 10, ppid: 1, command: "node", etimeSec: 1000, args: "node x.mjs" };
     // candidate cwd under CTL-X9, sweep targets CTL-X → spared (out of scope)
     const c = ctx({
       worktreePath: `${WT_ROOT}/CTL-X`,
       cwdForPid: () => `${WT_ROOT}/CTL-X9`,
     });
-    const v = classifyProc(row, c);
+    const v = await classifyProc(row, c);
     expect(v.action).toBe("spare");
     expect(v.reason).toBe("outside-target-worktree");
   });
@@ -632,6 +632,45 @@ describe("ProcReaper.sweep — degrade-safe + CATASTROPHE GUARD", () => {
     const r = await reaper.sweep({});
     expect(r.reaped).toHaveLength(0);
     expect(killProc.calls).toHaveLength(0);
+  });
+});
+
+describe("ProcReaper.sweep — async psLister / lsofCwd seams", () => {
+  it("awaits an async psLister snapshot (shadow mode would-reap path)", async () => {
+    const liveAgents = { ok: true, agents: [] };
+    const psLines = [
+      "1001 1 900000 20:00 node /Users/ryanrozich/catalyst/wt/CTL-999/x.mjs",
+    ];
+    const reaper = new ProcReaper({
+      mode: "shadow",
+      worktreeRoot: "/Users/ryanrozich/catalyst/wt",
+      minEtimeSec: 0,
+      agentsResult: () => liveAgents,
+      psLister: async () => psLines,
+      lsofCwd: async () => "/Users/ryanrozich/catalyst/wt/CTL-999",
+      emit: async () => true,
+      log: silentLog(),
+    });
+    await reaper.sweep();
+    const report = await reaper.sweep();
+    expect(report.wouldReap.map((r) => r.pid)).toContain(1001);
+  });
+
+  it("spares when async lsofCwd rejects (cwd-unknown → degrade safe)", async () => {
+    const reaper = new ProcReaper({
+      mode: "enforce",
+      worktreeRoot: "/Users/ryanrozich/catalyst/wt",
+      minEtimeSec: 0,
+      agentsResult: () => ({ ok: true, agents: [] }),
+      psLister: async () => ["1001 1 900000 20:00 node /x/y.mjs"],
+      lsofCwd: async () => { throw new Error("lsof failed"); },
+      killProc: () => { throw new Error("must not kill"); },
+      emit: async () => true,
+      log: silentLog(),
+    });
+    await reaper.sweep();
+    const report = await reaper.sweep();
+    expect(report.reaped).toEqual([]);
   });
 });
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-15T18:10:00Z -->
<!-- Last updated: 2026-06-15T18:10:00Z -->
<!-- PR: #2058 -->
<!-- Previous commits: b066b45a65b61dd39e7949ce331ffd977d8ce33d -->

## Summary

Converts synchronous I/O in three CTL-1165 sweep modules (`job-dir-gc`, `proc-reaper`, `fleet-health-probe`) and the `heartbeat-event` write path to their async equivalents, eliminating the event-loop blockage that was causing the 30 s heartbeat to gap out to 60–102 s under load.

The root cause: `readdirSync`, `execFileSync` (ps/lsof), and `appendFileSync` were called directly on the daemon's main event loop. Under load (large `~/.claude/jobs` dir, busy process table, or concurrent worker dispatch) these blocked for seconds, starving the heartbeat timer entirely.

## Changes Made

### `job-dir-gc.mjs`
- `readdirSync` → `readdir` (fs/promises); all three sweep call sites `await`-ed.

### `proc-reaper.mjs`
- `execFileSync` for `ps`/`lsof` → `execFileAsync` (wrapper around `execFile` callback).
- `classifyProc`, `_safeCwd`, and the main sweep loop made async; `psLister` + `classifyProc` awaited.

### `fleet-health-probe.mjs`
- `readdirSync` / `execFileSync` defaults for `readJobsCount`, `psLines`, `readProcsCount`, `readSwapUsedMb` all made async.
- New `execFileAsync` helper and `safeAsync` wrapper (mirrors the existing sync `safe()`).
- `tick()` made async; the `setInterval` handler now fire-and-forgets via `.catch(() => {})` so an error in one tick never crashes the probe.

### `heartbeat-event.mjs`
- `mkdirSync` / `appendFileSync` → `mkdir` / `appendFile` (fs/promises).
- `startHeartbeat` exposes a `started` promise for test synchronization.

### Tests (all four modules updated)
- `fleet-health-probe.test.mjs`: tick tests converted to async; added happy-path + rejection tests for all async readers.
- `heartbeat-event.test.mjs`: uses `started` promise to avoid races.
- `job-dir-gc.test.mjs`: 34 new lines covering async readdir paths.
- `proc-reaper.test.mjs`: async variants for psLister + classifyProc paths.

## How to Verify It

- [x] `bun test plugins/dev/scripts/execution-core/*.test.mjs` — 89 tests pass across the 4 changed modules ✅
- [x] Full suite: 3 779 pass / 8 fail — the 8 failures are pre-existing/environmental, identical profile on `origin/main` baseline ✅
- [x] CI checks (all 6): Cloudflare Pages, audit-references, check-versions, docs-gate, execution-core-unit-tests, validate — all **pass** ✅
- [ ] Manual: restart the execution-core daemon under load and observe `node.heartbeat` gaps stay ≤ ~35 s (p99 < 60 s)

## Changelog Entry

`fix(dev)`: async sweeps in `job-dir-gc`, `proc-reaper`, `fleet-health-probe`, and `heartbeat-event` eliminate event-loop blockage that caused `node.heartbeat` gaps of 60–102 s under load (CTL-1170).

## Related Issues / PRs

- Fixes https://linear.app/rozich/issue/CTL-1170
- Pairs with #2056 (CTL-1171 — broker liveness heartbeat) and #2052 (CTL-1169 — daemon-health hysteresis); keep the hysteresis regardless — jitter will always occasionally cross 30 s

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1165
skip CTL-1169
skip CTL-1171
