### PR TITLE
feat(dev): CTL-1154 — Add & Delete Project Lifecycle (M3)

### DIFF
--- a/plugins/dev/scripts/execution-core/registry-delete.test.mjs
+++ b/plugins/dev/scripts/execution-core/registry-delete.test.mjs
@@ -1,0 +1,138 @@
+// Unit tests for deleteProjectEntry (CTL-1154).
+// Run: cd plugins/dev/scripts/execution-core && bun test registry-delete.test.mjs
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { getRegistryPath } from "./config.mjs";
+import { deleteProjectEntry, listProjects, upsertProjectEntry } from "./registry.mjs";
+
+let catalystDir;
+let registryDir;
+let prevCatalystDir;
+
+beforeEach(() => {
+  prevCatalystDir = process.env.CATALYST_DIR;
+  catalystDir = mkdtempSync(join(tmpdir(), "exec-core-registry-delete-"));
+  process.env.CATALYST_DIR = catalystDir;
+  registryDir = join(catalystDir, "execution-core");
+});
+
+afterEach(() => {
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+  rmSync(catalystDir, { recursive: true, force: true });
+});
+
+function writeRegistry(obj) {
+  mkdirSync(registryDir, { recursive: true });
+  writeFileSync(
+    getRegistryPath(),
+    typeof obj === "string" ? obj : JSON.stringify(obj, null, 2)
+  );
+}
+
+describe("deleteProjectEntry (CTL-1154)", () => {
+  it("removes the matching team and preserves all others (atomic rewrite)", () => {
+    writeRegistry({
+      projects: [
+        { team: "CTL", repoRoot: "/repos/ctl", eligibleQuery: null },
+        { team: "ADV", repoRoot: "/repos/adv", eligibleQuery: null },
+        { team: "EVR", repoRoot: "/repos/evr", eligibleQuery: null },
+      ],
+    });
+    const result = deleteProjectEntry({ team: "ADV" });
+    expect(result).toEqual({ team: "ADV", deleted: true });
+    const projects = listProjects();
+    expect(projects).toHaveLength(2);
+    expect(projects.map((p) => p.team).sort()).toEqual(["CTL", "EVR"]);
+  });
+
+  it("is idempotent: deleting an absent team is a no-op and returns { deleted: false }", () => {
+    writeRegistry({
+      projects: [{ team: "CTL", repoRoot: "/repos/ctl", eligibleQuery: null }],
+    });
+    const result = deleteProjectEntry({ team: "ZZZ" });
+    expect(result).toEqual({ team: "ZZZ", deleted: false });
+    // original entry preserved
+    expect(listProjects()).toHaveLength(1);
+    expect(listProjects()[0].team).toBe("CTL");
+  });
+
+  it("on a missing registry file returns { deleted: false } and does not create one", () => {
+    // no registry file seeded
+    expect(existsSync(getRegistryPath())).toBe(false);
+    const result = deleteProjectEntry({ team: "CTL" });
+    expect(result).toEqual({ team: "CTL", deleted: false });
+    expect(existsSync(getRegistryPath())).toBe(false);
+  });
+
+  it("throws when team is missing/falsy", () => {
+    expect(() => deleteProjectEntry({})).toThrow();
+    expect(() => deleteProjectEntry({ team: "" })).toThrow();
+    expect(() => deleteProjectEntry()).toThrow();
+  });
+
+  it("writes atomically (no .tmp left behind on success)", () => {
+    writeRegistry({
+      projects: [
+        { team: "CTL", repoRoot: "/repos/ctl", eligibleQuery: null },
+        { team: "ADV", repoRoot: "/repos/adv", eligibleQuery: null },
+      ],
+    });
+    deleteProjectEntry({ team: "ADV" });
+    expect(readdirSync(registryDir).some((f) => f.endsWith(".tmp"))).toBe(false);
+  });
+
+  it("round-trips with upsertProjectEntry: add then delete returns to prior state", () => {
+    writeRegistry({
+      projects: [{ team: "CTL", repoRoot: "/repos/ctl", eligibleQuery: null }],
+    });
+    upsertProjectEntry({ team: "TMP", repoRoot: "/repos/tmp", eligibleQuery: null });
+    expect(listProjects()).toHaveLength(2);
+    deleteProjectEntry({ team: "TMP" });
+    const projects = listProjects();
+    expect(projects).toHaveLength(1);
+    expect(projects[0].team).toBe("CTL");
+  });
+});
+
+describe("CLI: registry.mjs delete (CTL-1154)", () => {
+  const registryCli = join(import.meta.dir, "registry.mjs");
+
+  function runCli(args) {
+    return execFileSync(process.execPath, [registryCli, ...args], {
+      env: { ...process.env, CATALYST_DIR: catalystDir },
+      encoding: "utf8",
+    });
+  }
+
+  it("delete --team T removes the entry and exits 0", () => {
+    runCli(["upsert", "--team", "CTL", "--repo-root", "/repos/ctl"]);
+    runCli(["upsert", "--team", "TMP", "--repo-root", "/repos/tmp"]);
+    const out = JSON.parse(runCli(["delete", "--team", "TMP"]));
+    expect(out.deleted).toBe(true);
+    expect(out.team).toBe("TMP");
+    const projects = listProjects();
+    expect(projects).toHaveLength(1);
+    expect(projects[0].team).toBe("CTL");
+  });
+
+  it("delete --team absent exits 0 and returns { deleted: false }", () => {
+    runCli(["upsert", "--team", "CTL", "--repo-root", "/repos/ctl"]);
+    const out = JSON.parse(runCli(["delete", "--team", "ZZZ"]));
+    expect(out.deleted).toBe(false);
+    // original preserved
+    expect(listProjects()).toHaveLength(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/registry.mjs
+++ b/plugins/dev/scripts/execution-core/registry.mjs
@@ -124,10 +124,40 @@ export function upsertProjectEntry({ team, repoRoot, eligibleQuery } = {}) {
   return entry;
 }
 
+// deleteProjectEntry — idempotently remove a team's registry entry. Reads the
+// current list, drops the matching `team`, atomically rewrites (tmp + renameSync,
+// mirroring upsertProjectEntry). A missing file or absent team is a no-op:
+// returns { deleted: false } so callers can distinguish removal from no-op.
+// Throws on a falsy `team`.
+export function deleteProjectEntry({ team } = {}) {
+  if (!team) throw new Error("deleteProjectEntry: team is required");
+  const file = getRegistryPath();
+  if (!existsSync(file)) return { team, deleted: false };
+  const before = listProjects();
+  const projects = before.filter((p) => p.team !== team);
+  if (projects.length === before.length) return { team, deleted: false };
+
+  mkdirSync(dirname(file), { recursive: true });
+  const tmp = `${file}.tmp`;
+  try {
+    writeFileSync(tmp, JSON.stringify({ projects }, null, 2));
+    renameSync(tmp, file);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* tmp already gone */
+    }
+    throw err;
+  }
+  return { team, deleted: true };
+}
+
 // --- CLI ---------------------------------------------------------------------
 // `registry.mjs list`                              → JSON array of entries
 // `registry.mjs get <team>`                        → JSON object or empty
 // `registry.mjs upsert --team T --repo-root R --eligible-query JSON`
+// `registry.mjs delete --team T`                   → JSON { team, deleted }
 //
 // The setup tooling (setup-execution-core-states.sh) invokes this CLI rather
 // than hand-writing registry JSON, keeping the D9 seam single.
@@ -184,10 +214,17 @@ function main(argv) {
       process.stdout.write(`${JSON.stringify(entry, null, 2)}\n`);
       return 0;
     }
+    case "delete": {
+      const flags = parseFlags(rest);
+      const result = deleteProjectEntry({ team: flags.team });
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
     default: {
       process.stderr.write(
         "registry.mjs: usage — list | get <team> | " +
-          "upsert --team T --repo-root R [--eligible-query JSON]\n"
+          "upsert --team T --repo-root R [--eligible-query JSON] | " +
+          "delete --team T\n"
       );
       return 1;
     }

--- a/plugins/dev/scripts/orch-monitor/config-writer.test.ts
+++ b/plugins/dev/scripts/orch-monitor/config-writer.test.ts
@@ -1,0 +1,198 @@
+// Unit tests for lib/config-writer.ts (CTL-1154).
+// Run: cd plugins/dev/scripts/orch-monitor && bun test config-writer.test.ts
+
+import { describe, it, expect } from "bun:test";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { addTeamEntry, removeTeamEntry } from "./lib/config-writer";
+
+// Helpers
+function makeTmp(): string {
+  return mkdtempSync(join(tmpdir(), "config-writer-test-"));
+}
+
+function writeConfig(dir: string, teams: unknown[]): string {
+  const configPath = join(dir, "config.json");
+  writeFileSync(
+    configPath,
+    JSON.stringify(
+      {
+        projectKey: "catalyst",
+        catalyst: {
+          monitor: {
+            linear: { teams },
+            github: { repoColors: { ctl: "#ff0000" } },
+          },
+        },
+      },
+      null,
+      2
+    )
+  );
+  return configPath;
+}
+
+function readTeams(configPath: string): unknown[] {
+  const parsed: unknown = JSON.parse(readFileSync(configPath, "utf8"));
+  if (typeof parsed !== "object" || parsed === null) return [];
+  const p = parsed as Record<string, unknown>;
+  const catalyst = p.catalyst;
+  if (typeof catalyst !== "object" || catalyst === null) return [];
+  const monitor = (catalyst as Record<string, unknown>).monitor;
+  if (typeof monitor !== "object" || monitor === null) return [];
+  const linear = (monitor as Record<string, unknown>).linear;
+  if (typeof linear !== "object" || linear === null) return [];
+  const teams = (linear as Record<string, unknown>).teams;
+  return Array.isArray(teams) ? teams : [];
+}
+
+describe("addTeamEntry (CTL-1154)", () => {
+  it("appends a new team and preserves sibling config keys + repoColors", () => {
+    const dir = makeTmp();
+    try {
+      const configPath = writeConfig(dir, [
+        { key: "CTL", vcsRepo: "coalesce-labs/catalyst" },
+      ]);
+      addTeamEntry(configPath, { key: "EVR", vcsRepo: "coalesce-labs/evergreen" });
+
+      const teams = readTeams(configPath);
+      expect(teams).toHaveLength(2);
+      const keys = (teams as { key: string }[]).map((t) => t.key).sort();
+      expect(keys).toEqual(["CTL", "EVR"]);
+
+      // sibling keys must survive
+      const parsed: unknown = JSON.parse(readFileSync(configPath, "utf8"));
+      const p = parsed as Record<string, unknown>;
+      expect(p.projectKey).toBe("catalyst");
+      const cat = p.catalyst as Record<string, unknown>;
+      const mon = cat.monitor as Record<string, unknown>;
+      const gh = mon.github as Record<string, unknown>;
+      const colors = gh.repoColors as Record<string, unknown>;
+      expect(colors.ctl).toBe("#ff0000");
+
+      // must be valid JSON with 2-space indent
+      const raw = readFileSync(configPath, "utf8");
+      expect(raw).toMatch(/^ {2}"/m); // 2-space indent
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("is idempotent on an existing key: updates vcsRepo in place, never duplicates", () => {
+    const dir = makeTmp();
+    try {
+      const configPath = writeConfig(dir, [
+        { key: "EVR", vcsRepo: "coalesce-labs/old-repo" },
+      ]);
+      addTeamEntry(configPath, { key: "EVR", vcsRepo: "coalesce-labs/evergreen" });
+
+      const teams = readTeams(configPath) as { key: string; vcsRepo: string }[];
+      expect(teams).toHaveLength(1);
+      expect(teams[0].vcsRepo).toBe("coalesce-labs/evergreen");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a blank key", () => {
+    const dir = makeTmp();
+    try {
+      const configPath = writeConfig(dir, []);
+      expect(() => addTeamEntry(configPath, { key: "", vcsRepo: "x/y" })).toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a vcsRepo without '/'", () => {
+    const dir = makeTmp();
+    try {
+      const configPath = writeConfig(dir, []);
+      expect(() =>
+        addTeamEntry(configPath, { key: "EVR", vcsRepo: "noslash" })
+      ).toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates the catalyst.monitor.linear.teams path if absent", () => {
+    const dir = makeTmp();
+    try {
+      const configPath = join(dir, "config.json");
+      writeFileSync(configPath, JSON.stringify({ projectKey: "x" }, null, 2));
+
+      addTeamEntry(configPath, { key: "EVR", vcsRepo: "coalesce-labs/evergreen" });
+
+      const teams = readTeams(configPath) as { key: string }[];
+      expect(teams).toHaveLength(1);
+      expect(teams[0].key).toBe("EVR");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes atomically: no .tmp left behind", () => {
+    const dir = makeTmp();
+    try {
+      const configPath = writeConfig(dir, []);
+      addTeamEntry(configPath, { key: "EVR", vcsRepo: "coalesce-labs/evergreen" });
+      expect(existsSync(configPath + ".tmp")).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("removeTeamEntry (CTL-1154)", () => {
+  it("removes the matching key and preserves the rest", () => {
+    const dir = makeTmp();
+    try {
+      const configPath = writeConfig(dir, [
+        { key: "CTL", vcsRepo: "coalesce-labs/catalyst" },
+        { key: "EVR", vcsRepo: "coalesce-labs/evergreen" },
+      ]);
+      const removed = removeTeamEntry(configPath, "EVR");
+      expect(removed).toBe(true);
+      const teams = readTeams(configPath) as { key: string }[];
+      expect(teams).toHaveLength(1);
+      expect(teams[0].key).toBe("CTL");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("is a no-op for an absent key (returns false), config unchanged", () => {
+    const dir = makeTmp();
+    try {
+      const configPath = writeConfig(dir, [
+        { key: "CTL", vcsRepo: "coalesce-labs/catalyst" },
+      ]);
+      const before = readFileSync(configPath, "utf8");
+      const removed = removeTeamEntry(configPath, "ZZZ");
+      expect(removed).toBe(false);
+      expect(readFileSync(configPath, "utf8")).toBe(before);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns true when an entry was removed", () => {
+    const dir = makeTmp();
+    try {
+      const configPath = writeConfig(dir, [
+        { key: "CTL", vcsRepo: "coalesce-labs/catalyst" },
+      ]);
+      expect(removeTeamEntry(configPath, "CTL")).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/config-writer.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/config-writer.ts
@@ -1,0 +1,95 @@
+// config-writer.ts — CTL-1154: atomic writer for catalyst.monitor.linear.teams[].
+// The identity authority for the project roster (see project-roster.ts readTeams).
+// Mirrors upsertProjectEntry()'s atomic tmp+rename so a concurrent reader never
+// sees a torn config. Pairs with project-roster.ts's readTeams() (same nesting
+// tolerance: tolerates both `{ catalyst: { monitor } }` and bare `{ monitor }`).
+import { readFileSync, writeFileSync, renameSync, unlinkSync } from "fs";
+
+export interface TeamEntry {
+  key: string;
+  vcsRepo: string;
+}
+
+function readConfig(configPath: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(readFileSync(configPath, "utf8"));
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("config-writer: config root is not an object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function atomicWrite(configPath: string, cfg: unknown): void {
+  const tmp = `${configPath}.tmp`;
+  try {
+    writeFileSync(tmp, `${JSON.stringify(cfg, null, 2)}\n`);
+    renameSync(tmp, configPath);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* already gone */
+    }
+    throw err;
+  }
+}
+
+// Navigate (and create if absent) the catalyst.monitor.linear.teams[] path.
+// Returns the teams array (mutable in-place). Mutates cfg so the whole tree
+// can be serialized back by the caller.
+function ensureTeams(cfg: Record<string, unknown>): TeamEntry[] {
+  // Tolerate bare { monitor } root (no `catalyst` wrapper) same as readTeams().
+  // For writes, we always produce the canonical { catalyst: { monitor: ... } } form.
+  const root = cfg;
+  if (typeof root.catalyst !== "object" || root.catalyst === null) {
+    root.catalyst = {};
+  }
+  const catalyst = root.catalyst as Record<string, unknown>;
+  if (typeof catalyst.monitor !== "object" || catalyst.monitor === null) {
+    catalyst.monitor = {};
+  }
+  const monitor = catalyst.monitor as Record<string, unknown>;
+  if (typeof monitor.linear !== "object" || monitor.linear === null) {
+    monitor.linear = {};
+  }
+  const linear = monitor.linear as Record<string, unknown>;
+  if (!Array.isArray(linear.teams)) {
+    linear.teams = [];
+  }
+  return linear.teams as TeamEntry[];
+}
+
+export function addTeamEntry(configPath: string, entry: TeamEntry): void {
+  if (!entry?.key?.trim()) {
+    throw new Error(
+      "config-writer.addTeamEntry: key is required and must be non-blank"
+    );
+  }
+  if (!entry?.vcsRepo?.includes("/")) {
+    throw new Error(
+      "config-writer.addTeamEntry: vcsRepo must be in owner/repo form"
+    );
+  }
+  const cfg = readConfig(configPath);
+  const teams = ensureTeams(cfg);
+  const next = teams.filter((t) => t.key !== entry.key.trim());
+  next.push({ key: entry.key.trim(), vcsRepo: entry.vcsRepo.trim() });
+  // Write the updated array back into the same slot ensureTeams navigated to.
+  const linear = (
+    (cfg.catalyst as Record<string, unknown>).monitor as Record<string, unknown>
+  ).linear as Record<string, unknown>;
+  linear.teams = next;
+  atomicWrite(configPath, cfg);
+}
+
+export function removeTeamEntry(configPath: string, key: string): boolean {
+  const cfg = readConfig(configPath);
+  const teams = ensureTeams(cfg);
+  const next = teams.filter((t) => t.key !== key);
+  if (next.length === teams.length) return false;
+  const linear = (
+    (cfg.catalyst as Record<string, unknown>).monitor as Record<string, unknown>
+  ).linear as Record<string, unknown>;
+  linear.teams = next;
+  atomicWrite(configPath, cfg);
+  return true;
+}

--- a/plugins/dev/scripts/orch-monitor/lib/project-setup.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/project-setup.ts
@@ -1,0 +1,207 @@
+// project-setup.ts — CTL-1154: ensure a project's server-side setup (Linear
+// state contract + registry upsert) by driving setup-execution-core-states.sh,
+// and map its exit codes into a typed ValidationReport for the API + UI. The
+// script runner is injectable (tests pass a fake; production spawns the real
+// script with a timeout) so the handler is never load-bearing on a hung
+// subprocess (learning: audit-proxy-must-not-be-load-bearing).
+//
+// Exit codes from setup-execution-core-states.sh:
+//   0 — ok
+//   1 — prereq missing (jq/curl/LINEAR_API_KEY)
+//   2 — Linear API error
+//   3 — states partially created
+//   4 — registry upsert failed
+import { existsSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+
+export type StepStatus = "ok" | "failed" | "skipped";
+
+export interface ValidationStep {
+  id: string;
+  label: string;
+  status: StepStatus;
+  detail?: string;
+}
+
+export interface ValidationReport {
+  ready: boolean;
+  exitCode: number | null;
+  steps: ValidationStep[];
+}
+
+export interface ProjectSetupRunResult {
+  exitCode: number;
+  stdout: string;
+}
+
+export type ProjectSetupRunner = (
+  args: string[]
+) => Promise<ProjectSetupRunResult>;
+
+export interface RunProjectSetupOpts {
+  configPath: string;
+  key: string;
+  vcsRepo: string;
+  repoRoot: string;
+  eligibleQuery?: unknown;
+  runner?: ProjectSetupRunner;
+  scriptPath?: string;
+  timeoutMs?: number;
+}
+
+function resolveScriptPath(): string {
+  // From orch-monitor/lib/, the setup script is two levels up at
+  // plugins/dev/scripts/setup-execution-core-states.sh.
+  const dir =
+    typeof import.meta.dir === "string"
+      ? import.meta.dir
+      : fileURLToPath(new URL(".", import.meta.url));
+  const candidates = [
+    join(dir, "..", "..", "setup-execution-core-states.sh"),
+    join(dir, "..", "setup-execution-core-states.sh"),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  return candidates[0]; // fallback; spawn will error descriptively
+}
+
+function defaultSetupRunner(timeoutMs = 120_000): ProjectSetupRunner {
+  return async (args: string[]): Promise<ProjectSetupRunResult> => {
+    const proc = Bun.spawn(args, {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const timeoutHandle = setTimeout(() => {
+      proc.kill();
+    }, timeoutMs);
+    try {
+      const chunks: Uint8Array[] = [];
+      const reader = proc.stdout;
+      for await (const chunk of reader) {
+        chunks.push(chunk as Uint8Array);
+      }
+      const stdout = Buffer.concat(chunks).toString("utf8");
+      const exitCode = await proc.exited;
+      return { exitCode: exitCode ?? 1, stdout };
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+  };
+}
+
+// Pure mapper: exit code + stdout → ValidationReport steps.
+// Kept as a standalone function so it is testable in isolation.
+export function mapExitToReport(
+  exitCode: number,
+  _stdout: string,
+  priorSteps: ValidationStep[]
+): ValidationReport {
+  const steps = [...priorSteps];
+  switch (exitCode) {
+    case 0:
+      steps.push(
+        { id: "prereq", label: "Prerequisites satisfied", status: "ok" },
+        { id: "api", label: "Linear API reachable", status: "ok" },
+        { id: "states", label: "Linear state contract", status: "ok" },
+        { id: "registry", label: "Registry entry upserted", status: "ok" }
+      );
+      return { ready: true, exitCode, steps };
+    case 1:
+      steps.push({
+        id: "prereq",
+        label: "Prerequisites satisfied",
+        status: "failed",
+        detail:
+          "A prerequisite is missing — check that LINEAR_API_KEY (or token file) is set and that jq/curl are on PATH.",
+      });
+      return { ready: false, exitCode, steps };
+    case 2:
+      steps.push(
+        { id: "prereq", label: "Prerequisites satisfied", status: "ok" },
+        {
+          id: "api",
+          label: "Linear API reachable",
+          status: "failed",
+          detail: "Linear API returned an error during state creation.",
+        }
+      );
+      return { ready: false, exitCode, steps };
+    case 3:
+      steps.push(
+        { id: "prereq", label: "Prerequisites satisfied", status: "ok" },
+        { id: "api", label: "Linear API reachable", status: "ok" },
+        {
+          id: "states",
+          label: "Linear state contract",
+          status: "failed",
+          detail:
+            "One or more required Linear states could not be created. Check API permissions.",
+        },
+        { id: "registry", label: "Registry entry upserted", status: "skipped" }
+      );
+      return { ready: false, exitCode, steps };
+    case 4:
+      steps.push(
+        { id: "prereq", label: "Prerequisites satisfied", status: "ok" },
+        { id: "api", label: "Linear API reachable", status: "ok" },
+        { id: "states", label: "Linear state contract", status: "ok" },
+        {
+          id: "registry",
+          label: "Registry entry upserted",
+          status: "failed",
+          detail: "Registry upsert failed — check disk permissions on ~/catalyst/execution-core/.",
+        }
+      );
+      return { ready: false, exitCode, steps };
+    default:
+      steps.push({
+        id: "setup",
+        label: "Setup script ran",
+        status: "failed",
+        detail: `Setup script exited with unexpected code ${exitCode}.`,
+      });
+      return { ready: false, exitCode, steps };
+  }
+}
+
+export async function runProjectSetup(
+  opts: RunProjectSetupOpts
+): Promise<ValidationReport> {
+  const steps: ValidationStep[] = [];
+
+  // Pre-flight: verify repoRoot exists before ever invoking the script.
+  if (!opts.repoRoot || !existsSync(opts.repoRoot)) {
+    steps.push({
+      id: "repoRoot",
+      label: "Repository path reachable",
+      status: "failed",
+      detail: `repoRoot not found on disk: ${opts.repoRoot}`,
+    });
+    return { ready: false, exitCode: null, steps };
+  }
+  steps.push({
+    id: "repoRoot",
+    label: "Repository path reachable",
+    status: "ok",
+  });
+
+  const runner = opts.runner ?? defaultSetupRunner(opts.timeoutMs);
+  const scriptPath = opts.scriptPath ?? resolveScriptPath();
+
+  let res: ProjectSetupRunResult;
+  try {
+    res = await runner([scriptPath, "--config", opts.configPath, "--json"]);
+  } catch (err) {
+    steps.push({
+      id: "setup",
+      label: "Setup script ran",
+      status: "failed",
+      detail: err instanceof Error ? err.message : String(err),
+    });
+    return { ready: false, exitCode: null, steps };
+  }
+
+  return mapExitToReport(res.exitCode, res.stdout, steps);
+}

--- a/plugins/dev/scripts/orch-monitor/project-setup.test.ts
+++ b/plugins/dev/scripts/orch-monitor/project-setup.test.ts
@@ -1,0 +1,173 @@
+// Unit tests for lib/project-setup.ts (CTL-1154).
+// Run: cd plugins/dev/scripts/orch-monitor && bun test project-setup.test.ts
+
+import { describe, it, expect } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runProjectSetup } from "./lib/project-setup";
+
+const okRunner = () => Promise.resolve({ exitCode: 0, stdout: "{}" });
+
+describe("runProjectSetup (CTL-1154)", () => {
+  it("pre-flight: a repoRoot that does not exist → ready=false with a failed repoRoot step, runner NOT called", async () => {
+    let called = false;
+    const r = await runProjectSetup({
+      configPath: "/x/config.json",
+      key: "EVR",
+      vcsRepo: "coalesce-labs/evergreen",
+      repoRoot: "/no/such/path/should/not/exist",
+      runner: () => {
+        called = true;
+        return Promise.resolve({ exitCode: 0, stdout: "" });
+      },
+    });
+    expect(r.ready).toBe(false);
+    const repoRootStep = r.steps.find((s) => s.id === "repoRoot");
+    expect(repoRootStep).toBeDefined();
+    expect(repoRootStep?.status).toBe("failed");
+    expect(called).toBe(false);
+  });
+
+  it("exit 0 → ready=true, all steps ok", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "project-setup-test-"));
+    try {
+      const r = await runProjectSetup({
+        configPath: "/x/config.json",
+        key: "EVR",
+        vcsRepo: "coalesce-labs/evergreen",
+        repoRoot: dir,
+        runner: okRunner,
+      });
+      expect(r.ready).toBe(true);
+      expect(r.exitCode).toBe(0);
+      expect(r.steps.every((s) => s.status === "ok")).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("exit 3 (states partial) → ready=false, states step failed, others ok", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "project-setup-test-"));
+    try {
+      const r = await runProjectSetup({
+        configPath: "/x/config.json",
+        key: "EVR",
+        vcsRepo: "coalesce-labs/evergreen",
+        repoRoot: dir,
+        runner: () => Promise.resolve({ exitCode: 3, stdout: "" }),
+      });
+      expect(r.ready).toBe(false);
+      const statesStep = r.steps.find((s) => s.id === "states");
+      expect(statesStep?.status).toBe("failed");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("exit 4 (registry upsert failed) → ready=false, registry step failed", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "project-setup-test-"));
+    try {
+      const r = await runProjectSetup({
+        configPath: "/x/config.json",
+        key: "EVR",
+        vcsRepo: "coalesce-labs/evergreen",
+        repoRoot: dir,
+        runner: () => Promise.resolve({ exitCode: 4, stdout: "" }),
+      });
+      expect(r.ready).toBe(false);
+      const regStep = r.steps.find((s) => s.id === "registry");
+      expect(regStep?.status).toBe("failed");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("exit 1 (prereq/token missing) → ready=false, prereq step failed with a hint", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "project-setup-test-"));
+    try {
+      const r = await runProjectSetup({
+        configPath: "/x/config.json",
+        key: "EVR",
+        vcsRepo: "coalesce-labs/evergreen",
+        repoRoot: dir,
+        runner: () => Promise.resolve({ exitCode: 1, stdout: "" }),
+      });
+      expect(r.ready).toBe(false);
+      const prereqStep = r.steps.find((s) => s.id === "prereq");
+      expect(prereqStep?.status).toBe("failed");
+      expect(prereqStep?.detail).toMatch(/token|prerequisite/i);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("exit 2 (Linear API error) → ready=false, api step failed", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "project-setup-test-"));
+    try {
+      const r = await runProjectSetup({
+        configPath: "/x/config.json",
+        key: "EVR",
+        vcsRepo: "coalesce-labs/evergreen",
+        repoRoot: dir,
+        runner: () => Promise.resolve({ exitCode: 2, stdout: "" }),
+      });
+      expect(r.ready).toBe(false);
+      const apiStep = r.steps.find((s) => s.id === "api");
+      expect(apiStep?.status).toBe("failed");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("invokes the runner with --config <path> and --json args", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "project-setup-test-"));
+    try {
+      let capturedArgs: string[] = [];
+      const r = await runProjectSetup({
+        configPath: "/x/config.json",
+        key: "EVR",
+        vcsRepo: "coalesce-labs/evergreen",
+        repoRoot: dir,
+        runner: (args) => {
+          capturedArgs = args;
+          return Promise.resolve({ exitCode: 0, stdout: "{}" });
+        },
+      });
+      expect(r.ready).toBe(true);
+      expect(capturedArgs).toContain("--config");
+      expect(capturedArgs).toContain("/x/config.json");
+      expect(capturedArgs).toContain("--json");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("a runner that throws → ready=false with a setup step failed (fail-open, never throws)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "project-setup-test-"));
+    try {
+      let threw = false;
+      let r;
+      try {
+        r = await runProjectSetup({
+          configPath: "/x/config.json",
+          key: "EVR",
+          vcsRepo: "coalesce-labs/evergreen",
+          repoRoot: dir,
+          runner: () => {
+            throw new Error("runner exploded");
+          },
+        });
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBe(false);
+      expect(r?.ready).toBe(false);
+      const setupStep = r?.steps.find((s) => s.id === "setup");
+      expect(setupStep?.status).toBe("failed");
+      expect(setupStep?.detail).toMatch(/runner exploded/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `POST /api/projects` adds a project (writes config `teams[]` + registry, runs setup validator)
- `DELETE /api/projects/:key` removes a project (config + registry only, no Linear/GitHub mutation)  
- Sidebar empty state and Projects heading offer a create dialog; configured rows have a remove action

## Checklist
- [x] Phase 1: `deleteProjectEntry()` in registry.mjs
- [ ] Phase 2: `lib/config-writer.ts` — atomic `teams[]` add/remove
- [ ] Phase 3: `lib/project-setup.ts` — script runner + ValidationReport
- [ ] Phase 4: POST/DELETE HTTP handlers + GET method gate + configPath injection
- [ ] Phase 5: UI — create dialog + empty-state/heading/row affordances

🤖 Generated with [Claude Code](https://claude.com/claude-code)