### PR TITLE
CTL-1182: Every phase should record its outcome on the ticket, including failures

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -399,6 +399,30 @@ project's Layer-1 `.catalyst/config.json` at the flat path `catalyst.monitor.lin
 the system can't distinguish the two, so it is the self-echo / loop-prevention guard for the
 Linear channel. See `docs/configuration.md` for how to obtain and set the value.
 
+### Linear comment strategy (CTL-1182)
+
+Phase agents post to Linear through a **two-tier** helper
+(`plugins/dev/scripts/lib/linear-comment-post.sh`):
+
+1. **App-actor** — mints an OAuth client-credentials token, resolves the issue UUID, and calls the
+   Linear GraphQL `commentCreate` mutation. This is the default path for all success mirrors.
+2. **`linearis` fallback** — when the app-actor path fails for any reason (invalid scope, missing
+   credentials, network error), the helper attempts `linearis issues discuss "$TICKET" --body "$BODY"`.
+   Both paths use the same function interface; exit 0 means the comment posted via one of them.
+
+**Failure-path comments** are centralized in `phase-agent-emit-complete`. When it transitions a
+phase to `failed` or `park`, it calls `lib/phase-failure-comment.sh` (after the canonical event
+emit and signal flip so the lifecycle record is already durable). That helper reads
+`.explanation.call_to_action` from the signal file (written by escalation helpers such as
+`escalate-workflow-scope.sh`) and posts it to Linear via the two-tier helper. This means
+`escalate-workflow-scope.sh` requires **no changes** to surface its `call_to_action` on the ticket:
+the post happens automatically at the `emit-complete` chokepoint every failure exits through.
+
+The post is gated by `CATALYST_FAILURE_COMMENT=1`, injected into every dispatched worker by
+`phase-agent-dispatch`'s `compose_worker_settings_json`. Default `OFF` keeps unit tests clean — no
+live Linear calls unless the env var is set. Idempotency is enforced via a
+`.linear-failure-mirror-${PHASE}` marker file alongside the success `.linear-mirror-${PHASE}`.
+
 ### `shouldSkipEvent` self-filter
 
 Because the broker both **reads** and **writes** the same JSONL log, it would otherwise re-ingest

--- a/plugins/dev/scripts/__tests__/linear-comment-post.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-comment-post.test.sh
@@ -75,6 +75,15 @@ trap 'rm -rf "$TMPDIR_TEST"' EXIT
 BIN_DIR="${TMPDIR_TEST}/bin"
 mkdir -p "$BIN_DIR"
 
+# Default linearis stub: fails. Tests that expect linearis to succeed override this
+# individually (CTL-1182: fallback contract). Having a failing stub ensures Tests
+# 6, 7, 8, etc. still assert non-zero when the app-actor path also fails.
+cat >"${BIN_DIR}/linearis" <<'LINEOF'
+#!/usr/bin/env bash
+exit 1
+LINEOF
+chmod +x "${BIN_DIR}/linearis"
+
 # Test 4: exits 0 when curl stub returns valid token + issue UUID + comment success
 cat >"${BIN_DIR}/curl" <<'CURLEOF'
 #!/usr/bin/env bash
@@ -99,7 +108,9 @@ PATH="${BIN_DIR}:$PATH" assert_exit_zero \
   "exits 0 on successful token + comment post" \
   bash "$HELPER" "CTL-550" "Hello from test"
 
-# Test 5: exits non-zero when token mint fails (curl returns error body, no access_token)
+# Test 5 (CTL-1182): when token mint fails but linearis fallback is available →
+# helper now exits 0 (expectation flipped from non-zero). Add a working linearis
+# stub and assert it was invoked with `issues discuss CTL-550`.
 cat >"${BIN_DIR}/curl" <<'CURLEOF'
 #!/usr/bin/env bash
 if printf '%s\n' "$@" | grep -q "oauth/token"; then
@@ -109,9 +120,33 @@ exit 0
 CURLEOF
 chmod +x "${BIN_DIR}/curl"
 
-PATH="${BIN_DIR}:$PATH" assert_exit_nonzero \
-  "exits non-zero when token mint returns no access_token" \
+LINEARIS_ARGS5="${TMPDIR_TEST}/linearis-args-5.txt"
+rm -f "$LINEARIS_ARGS5"
+cat >"${BIN_DIR}/linearis" <<LINEOF
+#!/usr/bin/env bash
+printf '%s\n' "\$@" >"${LINEARIS_ARGS5}"
+exit 0
+LINEOF
+chmod +x "${BIN_DIR}/linearis"
+
+PATH="${BIN_DIR}:$PATH" assert_exit_zero \
+  "exits 0 when token mint fails but linearis fallback succeeds (CTL-1182)" \
   bash "$HELPER" "CTL-550" "body"
+
+if grep -q "discuss" "${LINEARIS_ARGS5}" 2>/dev/null && grep -q "CTL-550" "${LINEARIS_ARGS5}" 2>/dev/null; then
+  echo "PASS: linearis invoked with 'issues discuss' and ticket"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: linearis not invoked correctly (args: $(cat "${LINEARIS_ARGS5}" 2>/dev/null || echo none))"
+  FAIL=$((FAIL+1))
+fi
+
+# Reset linearis to fail so subsequent tests keep their non-zero expectations.
+cat >"${BIN_DIR}/linearis" <<'LINEOF'
+#!/usr/bin/env bash
+exit 1
+LINEOF
+chmod +x "${BIN_DIR}/linearis"
 
 # Test 6: exits non-zero when issue UUID resolution fails (empty nodes)
 cat >"${BIN_DIR}/curl" <<'CURLEOF'
@@ -151,14 +186,16 @@ PATH="${BIN_DIR}:$PATH" assert_exit_nonzero \
   "exits non-zero when commentCreate returns success=false" \
   bash "$HELPER" "CTL-550" "body"
 
-# Test 8: exits non-zero when CATALYST_LINEAR_AGENT_CLIENT_ID not set and no config
+# Test 8: exits non-zero when CATALYST_LINEAR_AGENT_CLIENT_ID not set and no config.
+# Use PATH="${BIN_DIR}:$PATH" so the failing linearis stub (set above) shadows any
+# real linearis installation — ensuring both the app-actor AND linearis paths fail
+# and the exit is still non-zero (CTL-1182: only exit 0 when either path succeeds).
 unset CATALYST_LINEAR_AGENT_CLIENT_ID
 unset CATALYST_LINEAR_AGENT_CLIENT_SECRET
 
-# Run from a dir with no .catalyst/config.json ancestry
-assert_exit_nonzero \
-  "exits non-zero when no creds and no config file" \
-  bash -c "cd /tmp && bash '$HELPER' CTL-550 body"
+PATH="${BIN_DIR}:$PATH" assert_exit_nonzero \
+  "exits non-zero when no creds, no config, and linearis unavailable" \
+  bash -c "cd /tmp && PATH='${BIN_DIR}:${PATH}' bash '$HELPER' CTL-550 body"
 
 # Reinstate the success curl stub for the file-resolution back-compat tests.
 cat >"${BIN_DIR}/curl" <<'CURLEOF'
@@ -233,8 +270,11 @@ else
   FAIL=$((FAIL+1))
 fi
 
-# Test 12 (CTL-835): a 400 invalid_scope mint emits EXACTLY ONE diagnostic line,
-# and that line carries the real cause (invalid_scope) — no longer silent.
+# Test 12 (CTL-835): a 400 invalid_scope mint emits a diagnostic carrying the real
+# cause (invalid_scope) — no longer silent. With the CTL-1182 fallback in place,
+# both the app-actor diagnostic AND the linearis fallback diagnostic may appear, so
+# we drop the strict "exactly one line" count and assert only that invalid_scope is
+# present and a fallback diagnostic appears (BIN_DIR/linearis exits 1 = both fail).
 cat >"${BIN_DIR}/curl" <<'CURLEOF'
 #!/usr/bin/env bash
 ARGS_STR="$*"
@@ -248,19 +288,20 @@ CURLEOF
 chmod +x "${BIN_DIR}/curl"
 
 STDERR_OUT="$(PATH="${BIN_DIR}:$PATH" bash "$HELPER" "CTL-550" "body" 2>&1 1>/dev/null || true)"
-DIAG_LINES="$(printf '%s' "$STDERR_OUT" | grep -c .)"
-if [[ "$DIAG_LINES" -eq 1 ]]; then
-  echo "PASS: invalid_scope mint emits exactly one diagnostic line"
-  PASS=$((PASS+1))
-else
-  echo "FAIL: invalid_scope mint emitted ${DIAG_LINES} diagnostic line(s), expected 1 (out: ${STDERR_OUT})"
-  FAIL=$((FAIL+1))
-fi
 if printf '%s' "$STDERR_OUT" | grep -q "invalid_scope"; then
-  echo "PASS: diagnostic surfaces the invalid_scope cause"
+  echo "PASS: diagnostic surfaces the invalid_scope cause (CTL-835)"
   PASS=$((PASS+1))
 else
   echo "FAIL: diagnostic did not surface invalid_scope (out: ${STDERR_OUT})"
+  FAIL=$((FAIL+1))
+fi
+# CTL-1182: with fallback, stderr also contains a linearis-fallback diagnostic
+# (BIN_DIR/linearis exits 1 → both paths fail → fallback diagnostic appears).
+if printf '%s' "$STDERR_OUT" | grep -q "linearis"; then
+  echo "PASS: fallback diagnostic present in stderr when linearis fails (CTL-1182)"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: no linearis fallback diagnostic in stderr (out: ${STDERR_OUT})"
   FAIL=$((FAIL+1))
 fi
 
@@ -325,6 +366,91 @@ if printf '%s' "$HK_STDERR" | grep -qi "no projectKey"; then
 else
   echo "PASS: no drift warning when projectKey resolves correctly"
   PASS=$((PASS+1))
+fi
+
+# ─── CTL-1182: new fallback contract tests ──────────────────────────────────
+
+# Test 15: both app-actor AND linearis fail → exit non-zero
+export CATALYST_LINEAR_AGENT_CLIENT_ID="test-cid"
+export CATALYST_LINEAR_AGENT_CLIENT_SECRET="test-csec"
+cat >"${BIN_DIR}/curl" <<'CURLEOF'
+#!/usr/bin/env bash
+if printf '%s\n' "$@" | grep -q "oauth/token"; then
+  printf '{"error":"invalid_client"}'
+fi
+exit 0
+CURLEOF
+chmod +x "${BIN_DIR}/curl"
+# BIN_DIR/linearis already exits 1 (reset after Test 5).
+PATH="${BIN_DIR}:$PATH" assert_exit_nonzero \
+  "exits non-zero when both app-actor and linearis fail (CTL-1182)" \
+  bash "$HELPER" "CTL-550" "body"
+
+# Test 16: no linearis on PATH (only curl, which fails) → exit non-zero, app-actor
+# diagnostic still present.
+NOLIN_BIN="${TMPDIR_TEST}/nolin-bin"
+mkdir -p "$NOLIN_BIN"
+cat >"${NOLIN_BIN}/curl" <<'CURLEOF'
+#!/usr/bin/env bash
+if printf '%s\n' "$@" | grep -q "oauth/token"; then
+  printf '{"error":"invalid_scope","error_description":"missing scope"}\n400'
+fi
+exit 0
+CURLEOF
+chmod +x "${NOLIN_BIN}/curl"
+# No linearis in NOLIN_BIN.
+NOLIN_STDERR="$(PATH="${NOLIN_BIN}:/usr/bin:/bin:/usr/local/bin" \
+  bash "$HELPER" "CTL-550" "body" 2>&1 1>/dev/null || true)"
+NOLIN_EXIT=0
+PATH="${NOLIN_BIN}:/usr/bin:/bin:/usr/local/bin" \
+  bash "$HELPER" "CTL-550" "body" >/dev/null 2>/dev/null || NOLIN_EXIT=$?
+if [[ "$NOLIN_EXIT" -ne 0 ]]; then
+  echo "PASS: exits non-zero when no linearis on PATH and app-actor fails (CTL-1182)"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: expected non-zero, got 0 (linearis may unexpectedly be on PATH)"
+  FAIL=$((FAIL+1))
+fi
+if printf '%s' "$NOLIN_STDERR" | grep -q "invalid_scope"; then
+  echo "PASS: app-actor diagnostic still present when linearis unavailable (CTL-1182)"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: app-actor diagnostic missing when linearis unavailable (stderr: ${NOLIN_STDERR})"
+  FAIL=$((FAIL+1))
+fi
+
+# Test 17: app-actor succeeds → linearis NOT called (no double-post).
+cat >"${BIN_DIR}/curl" <<'CURLEOF'
+#!/usr/bin/env bash
+ARGS_STR="$*"
+if printf '%s' "$ARGS_STR" | grep -q "oauth/token"; then
+  printf '{"access_token":"test_token","token_type":"Bearer"}'
+elif printf '%s' "$ARGS_STR" | grep -q "commentCreate"; then
+  printf '{"data":{"commentCreate":{"success":true}}}'
+else
+  printf '{"data":{"issues":{"nodes":[{"id":"issue-uuid-123"}]}}}'
+fi
+exit 0
+CURLEOF
+chmod +x "${BIN_DIR}/curl"
+LINEARIS_RECORD17="${TMPDIR_TEST}/linearis-record-17.txt"
+rm -f "$LINEARIS_RECORD17"
+cat >"${BIN_DIR}/linearis" <<LINEOF
+#!/usr/bin/env bash
+touch "${LINEARIS_RECORD17}"
+exit 0
+LINEOF
+chmod +x "${BIN_DIR}/linearis"
+
+PATH="${BIN_DIR}:$PATH" assert_exit_zero \
+  "app-actor success exits 0 (baseline for double-post check, CTL-1182)" \
+  bash "$HELPER" "CTL-550" "body"
+if [[ ! -f "$LINEARIS_RECORD17" ]]; then
+  echo "PASS: linearis NOT called when app-actor succeeds — no double-post (CTL-1182)"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: linearis was called even though app-actor succeeded"
+  FAIL=$((FAIL+1))
 fi
 
 echo ""

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -2130,6 +2130,12 @@ T67_BG_ISO=$(echo "$DRY_OUT_T67" | jq -r '.settings.worktree.bgIsolation // empt
 assert_eq "none" "$T67_BG_ISO" "dry-run .settings.worktree.bgIsolation = none"
 
 echo ""
+echo "Test 68 (CTL-1182): compose_worker_settings_json includes CATALYST_FAILURE_COMMENT=1 in .env"
+# Reuse the same settings captured for T65 (dry-run with project config in place)
+T68_FAILURE_COMMENT=$(echo "$SETTINGS_T65" | jq -r '.env.CATALYST_FAILURE_COMMENT // empty' 2>/dev/null)
+assert_eq "1" "$T68_FAILURE_COMMENT" '.settings.env.CATALYST_FAILURE_COMMENT = "1"'
+
+echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"
 if [[ $FAILURES -gt 0 ]]; then

--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -699,6 +699,79 @@ REASON=$(echo "$LINE" | jq -r '.body.payload.failure_reason' 2>/dev/null || echo
 assert_eq "phase.plan.failed.CTL-1097" "$EVENT_NAME" "genuine miss in worktreePath → failed"
 assert_eq "artifact_not_gate_visible" "$REASON" "genuine miss preserves artifact_not_gate_visible reason"
 
+# ─── CTL-1182 Phase 2: failure-comment integration in emit-complete ───────────
+# Tests 46-48 verify that emit-complete calls phase-failure-comment.sh when
+# CATALYST_FAILURE_COMMENT=1 and --status failed, but NOT on complete or when
+# the env is unset. Uses CATALYST_COMMENT_POST_HELPER pointing at a recording
+# stub so no live Linear calls are made.
+
+# Recording stub for CATALYST_COMMENT_POST_HELPER
+STUB_1182="${SCRATCH}/linear-post-stub-1182.sh"
+STUB_1182_INVOCATIONS="${SCRATCH}/stub-1182-invocations.txt"
+STUB_1182_BODY="${SCRATCH}/stub-1182-body.txt"
+cat >"$STUB_1182" <<STUBEOF
+#!/usr/bin/env bash
+printf '%s\n' "\$1" >> "${STUB_1182_INVOCATIONS}"
+printf '%s' "\$2" > "${STUB_1182_BODY}"
+exit 0
+STUBEOF
+chmod +x "$STUB_1182"
+
+reset_stub_1182() {
+  rm -f "${STUB_1182_INVOCATIONS}" "${STUB_1182_BODY}"
+}
+
+stub_1182_count() {
+  wc -l < "${STUB_1182_INVOCATIONS}" 2>/dev/null | tr -d ' ' || echo 0
+}
+
+echo ""
+echo "Test 46 (CTL-1182): --status failed + CATALYST_FAILURE_COMMENT=1 calls failure-comment helper"
+fresh_env t46
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"research"}' >"$SIGNAL"
+reset_stub_1182
+CATALYST_FAILURE_COMMENT=1 \
+  CATALYST_COMMENT_POST_HELPER="$STUB_1182" \
+  "$EMIT_SCRIPT" --phase research --ticket CTL-100 --status failed \
+    --reason "tests_red" >/dev/null 2>&1
+LINE=$(read_event_line)
+EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
+assert_eq "phase.research.failed.CTL-100" "$EVENT_NAME" "event still emitted on failed (regression-lock Test 34)"
+if [[ "$(stub_1182_count)" -ge 1 ]]; then
+  pass "failure-comment helper invoked on --status failed"
+else
+  fail "failure-comment helper NOT invoked on --status failed"
+fi
+if grep -q "CTL-100" "${STUB_1182_INVOCATIONS}" 2>/dev/null; then
+  pass "helper called with correct ticket"
+else
+  fail "helper not called with ticket CTL-100"
+fi
+
+echo ""
+echo "Test 47 (CTL-1182): --status complete does NOT call failure-comment helper"
+fresh_env t47
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-verify.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"verify"}' >"$SIGNAL"
+reset_stub_1182
+CATALYST_FAILURE_COMMENT=1 \
+  CATALYST_COMMENT_POST_HELPER="$STUB_1182" \
+  "$EMIT_SCRIPT" --phase verify --ticket CTL-100 --status complete >/dev/null 2>&1
+assert_eq "0" "$(stub_1182_count)" "failure-comment NOT called on --status complete"
+
+echo ""
+echo "Test 48 (CTL-1182): default (env unset) makes no failure comment post"
+fresh_env t48
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"research"}' >"$SIGNAL"
+reset_stub_1182
+env -u CATALYST_FAILURE_COMMENT \
+  CATALYST_COMMENT_POST_HELPER="$STUB_1182" \
+  "$EMIT_SCRIPT" --phase research --ticket CTL-100 --status failed \
+    --reason "some_reason" >/dev/null 2>&1
+assert_eq "0" "$(stub_1182_count)" "failure-comment NOT called when CATALYST_FAILURE_COMMENT unset (test-isolation contract)"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/lib/__tests__/escalate-emitters.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/escalate-emitters.test.sh
@@ -245,35 +245,6 @@ else
 fi
 rm -rf "$S11C_SCRATCH"
 
-# 11d: comment-post is called with the ticket and a non-empty body containing the CTA
-echo "11d: comment-post invoked with non-empty body containing the CTA"
-S11D_SCRATCH="$(run_s11 0 0 true true)"
-CP_OUT_D="${S11D_SCRATCH}/cp.out"
-if [[ -s "$CP_OUT_D" ]]; then
-  CP_TICKET="$(head -1 "$CP_OUT_D" | cut -f1)"
-  CP_BODY="$(head -1 "$CP_OUT_D" | cut -f2-)"
-  assert_eq "CTL-S11" "$CP_TICKET" "11d: comment-post called with correct ticket"
-  if [[ -n "$CP_BODY" && "$CP_BODY" == *"Workflow scope push blocked"* ]]; then
-    pass "11d: comment body contains the escalation header"
-  else
-    fail "11d: comment body missing expected text — got: $(printf '%q' "$CP_BODY")"
-  fi
-else
-  fail "11d: comment-post was not invoked (cp.out is empty or missing)"
-fi
-rm -rf "$S11D_SCRATCH"
-
-# 11e: comment-post is NOT invoked when the CTA is empty
-echo "11e: comment-post NOT invoked when call_to_action is empty"
-S11E_SCRATCH="$(run_s11 0 0 true false)"
-CP_OUT_E="${S11E_SCRATCH}/cp.out"
-if [[ -s "$CP_OUT_E" ]]; then
-  fail "11e: comment-post was called despite empty CTA — got: $(cat "$CP_OUT_E")"
-else
-  pass "11e: comment-post not called when CTA is empty"
-fi
-rm -rf "$S11E_SCRATCH"
-
 # 11f: the helper is fail-open — a failing linearis does not abort the function
 echo "11f: failing linearis does not abort _escalate_workflow_scope_push"
 S11F_SCRATCH="$(run_s11 1 0 true true)"

--- a/plugins/dev/scripts/lib/__tests__/escalate-emitters.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/escalate-emitters.test.sh
@@ -280,6 +280,94 @@ S11F_SCRATCH="$(run_s11 1 0 true true)"
 S11F_STATUS="$(jq -r '.status' "${S11F_SCRATCH}/phase-implement.json" 2>/dev/null || echo "missing")"
 assert_eq "failed" "$S11F_STATUS" "11f: signal still set to failed even when linearis exits 1"
 rm -rf "$S11F_SCRATCH"
+# ── 12. End-to-end: escalate → emit-complete stub → phase-failure-comment → poster (CTL-1182) ──
+echo "12. escalate-workflow-scope end-to-end: call_to_action reaches Linear poster (CTL-1182)"
+E2E_WFSCOPE="${EMITTER_DIR}/escalate-workflow-scope.sh"
+E2E_PFC="${EMITTER_DIR}/phase-failure-comment.sh"
+if [[ -f "$E2E_WFSCOPE" && -f "$E2E_PFC" && -x "$E2E_PFC" ]]; then
+  E2E_SCRATCH="$(mktemp -d)"
+  E2E_TICKET="CTL-E2E5"
+  E2E_PHASE="pr"
+  E2E_ORCH="${E2E_SCRATCH}/orch"
+  mkdir -p "${E2E_ORCH}/workers/${E2E_TICKET}"
+  E2E_SIGNAL="${E2E_ORCH}/workers/${E2E_TICKET}/phase-${E2E_PHASE}.json"
+  printf '{"ticket":"%s","phase":"%s","status":"pending"}\n' "$E2E_TICKET" "$E2E_PHASE" >"$E2E_SIGNAL"
+
+  # Recording poster stub (injected via CATALYST_COMMENT_POST_HELPER)
+  E2E_INVOCATIONS="${E2E_SCRATCH}/invocations.txt"
+  E2E_BODY="${E2E_SCRATCH}/body.txt"
+  E2E_POSTER="${E2E_SCRATCH}/poster.sh"
+  cat >"$E2E_POSTER" <<PSTUBEOF
+#!/usr/bin/env bash
+printf '%s\n' "\$1" >> "${E2E_INVOCATIONS}"
+printf '%s' "\$2" > "${E2E_BODY}"
+exit 0
+PSTUBEOF
+  chmod +x "$E2E_POSTER"
+
+  # Fake PLUGIN_ROOT: real escalation-explain.mjs (needed by _escalate_workflow_scope_push)
+  # + stub phase-agent-emit-complete that calls the real phase-failure-comment.sh.
+  E2E_FAKE_ROOT="${E2E_SCRATCH}/fake-plugin"
+  mkdir -p "${E2E_FAKE_ROOT}/scripts/execution-core"
+  REAL_EXPLAIN="${PLUGIN_ROOT}/scripts/execution-core/escalation-explain.mjs"
+  [[ -f "$REAL_EXPLAIN" ]] && ln -s "$REAL_EXPLAIN" \
+    "${E2E_FAKE_ROOT}/scripts/execution-core/escalation-explain.mjs"
+
+  # Stub emit-complete: forwards --status failed to phase-failure-comment.sh
+  # (tests the emit-complete → phase-failure-comment portion of the chain)
+  cat >"${E2E_FAKE_ROOT}/scripts/phase-agent-emit-complete" <<ESTUBEOF
+#!/usr/bin/env bash
+_T=""; _P=""; _R=""; _S=""
+while [[ \$# -gt 0 ]]; do
+  case "\$1" in
+    --ticket) _T="\$2"; shift 2;;
+    --phase)  _P="\$2"; shift 2;;
+    --reason) _R="\$2"; shift 2;;
+    --status) _S="\$2"; shift 2;;
+    *)        shift;;
+  esac
+done
+if [[ "\$_S" == "failed" || "\$_S" == "park" ]] && [[ -n "\$_T" ]]; then
+  "${E2E_PFC}" --ticket "\$_T" --phase "\$_P" --reason "\$_R" \
+    --orch-dir "${E2E_ORCH}" >/dev/null 2>&1 || true
+fi
+exit 0
+ESTUBEOF
+  chmod +x "${E2E_FAKE_ROOT}/scripts/phase-agent-emit-complete"
+
+  # Run escalation in a subshell with overridden PLUGIN_ROOT
+  (
+    export PLUGIN_ROOT="${E2E_FAKE_ROOT}"
+    export SIGNAL_FILE="$E2E_SIGNAL"
+    export TICKET="$E2E_TICKET"
+    export PHASE="$E2E_PHASE"
+    export ORCH_ID="orch-e2e"
+    export COMMS=""
+    export CATALYST_FAILURE_COMMENT=1
+    export CATALYST_COMMENT_POST_HELPER="$E2E_POSTER"
+    # shellcheck source=/dev/null
+    source "$E2E_WFSCOPE" 2>/dev/null
+    _escalate_workflow_scope_push "CTL-E2E5-branch" 2>/dev/null || true
+  ) || true
+
+  # Assert poster was invoked exactly once
+  E2E_COUNT=0
+  [[ -f "$E2E_INVOCATIONS" ]] && E2E_COUNT="$(wc -l <"$E2E_INVOCATIONS" | tr -d ' ')"
+  assert_eq "1" "$E2E_COUNT" "e2e: Linear poster invoked exactly once"
+
+  # Assert body contains workflow-scope call_to_action text
+  if [[ -f "$E2E_BODY" ]] && grep -qi "workflow" "$E2E_BODY" 2>/dev/null; then
+    echo "  PASS: e2e: body contains workflow-scope call_to_action"
+    (( PASSES++ )) || true
+  else
+    echo "  FAIL: e2e: body missing workflow-scope text (got: $(head -3 "${E2E_BODY}" 2>/dev/null))"
+    (( FAILURES++ )) || true
+  fi
+
+  rm -rf "$E2E_SCRATCH"
+else
+  echo "  SKIP: escalate-workflow-scope.sh or phase-failure-comment.sh not found"
+fi
 
 echo ""
 echo "results: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/lib/__tests__/phase-failure-comment.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/phase-failure-comment.test.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# phase-failure-comment.test.sh — unit tests for lib/phase-failure-comment.sh (CTL-1182 Phase 2).
+#
+# Strategy: inject CATALYST_COMMENT_POST_HELPER → recording stub so no live
+# Linear calls are made. CATALYST_FAILURE_COMMENT=1 is the opt-in; tests verify
+# that the default (env unset) is a no-op (test-isolation boundary).
+#
+# Run: bash plugins/dev/scripts/lib/__tests__/phase-failure-comment.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../phase-failure-comment.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$expected" == "$actual" ]]; then pass "$label"
+  else fail "$label — expected=$(printf '%q' "$expected") actual=$(printf '%q' "$actual")"
+  fi
+}
+
+if [[ ! -f "$HELPER" ]]; then
+  echo "FATAL: $HELPER not found" >&2
+  exit 1
+fi
+if [[ ! -x "$HELPER" ]]; then
+  echo "FATAL: $HELPER not executable" >&2
+  exit 1
+fi
+
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+make_worker_dir() {
+  local ticket="$1"
+  mkdir -p "${SCRATCH}/orch/workers/${ticket}"
+  echo "${SCRATCH}/orch/workers/${ticket}"
+}
+
+make_signal() {
+  local dir="$1" ticket="$2" phase="$3"
+  cat >"${dir}/phase-${phase}.json" <<EOF
+{"ticket":"${ticket}","phase":"${phase}","status":"failed"}
+EOF
+}
+
+# ─── Stub helper ──────────────────────────────────────────────────────────────
+STUB="${SCRATCH}/stub-poster.sh"
+STUB_INVOCATIONS="${SCRATCH}/stub-invocations.txt"
+STUB_BODY_FILE="${SCRATCH}/stub-body.txt"
+cat >"$STUB" <<STUBEOF
+#!/usr/bin/env bash
+# Recording stub for CATALYST_COMMENT_POST_HELPER
+TICKET_ARG="\$1"
+BODY_ARG="\$2"
+printf '%s\n' "\$TICKET_ARG" >> "${STUB_INVOCATIONS}"
+printf '%s' "\$BODY_ARG" > "${STUB_BODY_FILE}"
+exit 0
+STUBEOF
+chmod +x "$STUB"
+
+reset_stub() {
+  rm -f "$STUB_INVOCATIONS" "$STUB_BODY_FILE"
+}
+
+stub_invocation_count() {
+  [[ -f "$STUB_INVOCATIONS" ]] || { echo 0; return; }
+  wc -l < "$STUB_INVOCATIONS" | tr -d ' '
+}
+
+FAIL_STUB="${SCRATCH}/fail-poster.sh"
+cat >"$FAIL_STUB" <<'FSTUBEOF'
+#!/usr/bin/env bash
+exit 1
+FSTUBEOF
+chmod +x "$FAIL_STUB"
+
+# ─── Test 1: posts on failure when CATALYST_FAILURE_COMMENT=1 ─────────────────
+echo "Test 1: posts on failure when enabled (call_to_action from explanation)"
+reset_stub
+WORKER_DIR="$(make_worker_dir CTL-T1)"
+make_signal "$WORKER_DIR" CTL-T1 implement
+jq '. + {explanation:{problem:"push rejected",call_to_action:"Grant workflow scope or push manually"}}' \
+  "${WORKER_DIR}/phase-implement.json" > "${WORKER_DIR}/phase-implement.json.tmp" && \
+  mv "${WORKER_DIR}/phase-implement.json.tmp" "${WORKER_DIR}/phase-implement.json"
+
+CATALYST_FAILURE_COMMENT=1 \
+  CATALYST_COMMENT_POST_HELPER="$STUB" \
+  "$HELPER" --ticket CTL-T1 --phase implement --reason "push_rejected" \
+    --orch-dir "${SCRATCH}/orch" >/dev/null 2>&1
+assert_eq "1" "$(stub_invocation_count)" "stub invoked exactly once"
+assert_eq "CTL-T1" "$(cat "${STUB_INVOCATIONS}" 2>/dev/null | head -1)" "stub called with correct ticket"
+if grep -q "call_to_action\|Grant workflow scope" "${STUB_BODY_FILE}" 2>/dev/null; then
+  pass "body contains call_to_action text"
+else
+  fail "body missing call_to_action (body: $(cat "${STUB_BODY_FILE}" 2>/dev/null))"
+fi
+if grep -q "implement\|CTL-T1" "${STUB_BODY_FILE}" 2>/dev/null; then
+  pass "body contains phase/ticket header"
+else
+  fail "body missing phase/ticket header"
+fi
+
+# ─── Test 2: reason fallback when no .explanation in signal ───────────────────
+echo "Test 2: uses --reason when signal has no .explanation"
+reset_stub
+WORKER_DIR="$(make_worker_dir CTL-T2)"
+make_signal "$WORKER_DIR" CTL-T2 verify
+
+CATALYST_FAILURE_COMMENT=1 \
+  CATALYST_COMMENT_POST_HELPER="$STUB" \
+  "$HELPER" --ticket CTL-T2 --phase verify --reason "tests_red_after_3_attempts" \
+    --orch-dir "${SCRATCH}/orch" >/dev/null 2>&1
+assert_eq "1" "$(stub_invocation_count)" "stub invoked once (reason fallback)"
+if grep -q "tests_red_after_3_attempts" "${STUB_BODY_FILE}" 2>/dev/null; then
+  pass "body contains --reason text"
+else
+  fail "body missing reason text (body: $(cat "${STUB_BODY_FILE}" 2>/dev/null))"
+fi
+
+# ─── Test 3: idempotent (marker prevents double-post) ─────────────────────────
+echo "Test 3: idempotent — second invocation with marker present does NOT invoke stub"
+reset_stub
+WORKER_DIR="$(make_worker_dir CTL-T3)"
+make_signal "$WORKER_DIR" CTL-T3 plan
+
+# First invocation: posts, creates marker
+CATALYST_FAILURE_COMMENT=1 \
+  CATALYST_COMMENT_POST_HELPER="$STUB" \
+  "$HELPER" --ticket CTL-T3 --phase plan --reason "artifact_not_gate_visible" \
+    --orch-dir "${SCRATCH}/orch" >/dev/null 2>&1
+MARKER="${SCRATCH}/orch/workers/CTL-T3/.linear-failure-mirror-plan"
+if [[ -f "$MARKER" ]]; then
+  pass "marker file created after first invocation"
+else
+  fail "marker file not created"
+fi
+reset_stub
+# Second invocation: should be no-op
+CATALYST_FAILURE_COMMENT=1 \
+  CATALYST_COMMENT_POST_HELPER="$STUB" \
+  "$HELPER" --ticket CTL-T3 --phase plan --reason "artifact_not_gate_visible" \
+    --orch-dir "${SCRATCH}/orch" >/dev/null 2>&1
+assert_eq "0" "$(stub_invocation_count)" "stub NOT called on second invocation (idempotent)"
+
+# ─── Test 4: disabled by default (CATALYST_FAILURE_COMMENT unset) ─────────────
+echo "Test 4: disabled by default — no post when env unset"
+reset_stub
+WORKER_DIR="$(make_worker_dir CTL-T4)"
+make_signal "$WORKER_DIR" CTL-T4 research
+
+env -u CATALYST_FAILURE_COMMENT \
+  CATALYST_COMMENT_POST_HELPER="$STUB" \
+  "$HELPER" --ticket CTL-T4 --phase research --reason "artifact_not_gate_visible" \
+    --orch-dir "${SCRATCH}/orch" >/dev/null 2>&1
+assert_eq "0" "$(stub_invocation_count)" "stub NOT called when CATALYST_FAILURE_COMMENT unset"
+
+# ─── Test 5: best-effort — helper stub exits 1 → phase-failure-comment exits 0 ──
+echo "Test 5: best-effort — stub exits 1 does NOT propagate to caller"
+reset_stub
+WORKER_DIR="$(make_worker_dir CTL-T5)"
+make_signal "$WORKER_DIR" CTL-T5 implement
+
+RC=0
+CATALYST_FAILURE_COMMENT=1 \
+  CATALYST_COMMENT_POST_HELPER="$FAIL_STUB" \
+  "$HELPER" --ticket CTL-T5 --phase implement --reason "some_failure" \
+    --orch-dir "${SCRATCH}/orch" >/dev/null 2>&1 || RC=$?
+assert_eq "0" "$RC" "helper exits 0 even when poster stub fails (best-effort)"
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "phase-failure-comment: ${PASS} passed, ${FAIL} failed"
+[[ "$FAIL" -eq 0 ]]

--- a/plugins/dev/scripts/lib/escalate-workflow-scope.sh
+++ b/plugins/dev/scripts/lib/escalate-workflow-scope.sh
@@ -32,6 +32,9 @@ _escalate_workflow_scope_push() {
     "$SIGNAL_FILE" > "$tmp" && mv "$tmp" "$SIGNAL_FILE" || true
   local emit="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
   if [[ -x "$emit" ]]; then
+    # emit-complete → lib/phase-failure-comment.sh posts the Linear comment when
+    # CATALYST_FAILURE_COMMENT=1 (injected by phase-agent-dispatch). No duplicate
+    # post needed here (CTL-1182).
     "$emit" --phase "$PHASE" --ticket "$TICKET" --status failed \
       --reason "push_rejected_no_workflow_scope"
   fi

--- a/plugins/dev/scripts/lib/escalate-workflow-scope.sh
+++ b/plugins/dev/scripts/lib/escalate-workflow-scope.sh
@@ -57,17 +57,4 @@ _escalate_workflow_scope_push() {
     mkdir -p "$(dirname "$_nh_marker")" 2>/dev/null || true
     : > "$_nh_marker" 2>/dev/null || true
   fi
-
-  # Post call_to_action to Linear as a comment so the operator sees the CTA.
-  local _cta
-  _cta="$(printf '%s' "$expl_json" | jq -r '.call_to_action // empty' 2>/dev/null || true)"
-  local _comment_post="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
-  if [[ -z "${_comment_post:-}" || ! -x "${_comment_post:-}" ]]; then
-    _comment_post="$(command -v linear-comment-post.sh 2>/dev/null || true)"
-  fi
-  if [[ -n "${_cta:-}" && -n "${_comment_post:-}" && -x "${_comment_post:-}" ]]; then
-    local _cta_body
-    _cta_body="$(printf '**Workflow scope push blocked — operator action required**\n\n%s\n\n_Posted automatically by phase-pr escalation (CTL-1181)._' "${_cta}")"
-    "$_comment_post" "${TICKET}" "${_cta_body}" >/dev/null 2>&1 || true
-  fi
 }

--- a/plugins/dev/scripts/lib/linear-comment-post.sh
+++ b/plugins/dev/scripts/lib/linear-comment-post.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# linear-comment-post.sh — Post a Linear comment using the app-actor identity.
+# linear-comment-post.sh — Post a Linear comment, with a two-tier strategy (CTL-1182):
+#   1. App-actor: client_credentials token mint → UUID resolve → commentCreate
+#   2. linearis CLI fallback: `linearis issues discuss "$TICKET" --body "$BODY"`
+# Exit 0 if either path posts successfully; non-zero only when both fail.
 #
 # Usage: linear-comment-post.sh <ticket-identifier> <comment-body>
 # E.g.:  linear-comment-post.sh CTL-550 "Hello from Catalyst agent"
@@ -51,100 +54,136 @@ _find_layer2_config() {
   echo "$HOME/.config/catalyst/config.json"
 }
 
-CLIENT_ID="${CATALYST_LINEAR_AGENT_CLIENT_ID:-}"
-CLIENT_SECRET="${CATALYST_LINEAR_AGENT_CLIENT_SECRET:-}"
+# ── Tier 1: post via the app-actor (client_credentials) identity ─────────────
+#
+# Self-contained: resolves credentials, mints the token, resolves the UUID, and
+# posts the comment. Returns 1 (not exit 1) at each failure point so the caller
+# can fall through to the linearis tier without exiting the process (CTL-1182).
+_post_via_app_actor() {
+  local client_id="${CATALYST_LINEAR_AGENT_CLIENT_ID:-}"
+  local client_secret="${CATALYST_LINEAR_AGENT_CLIENT_SECRET:-}"
 
-if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]]; then
-  GLOBAL_CONFIG="$HOME/.config/catalyst/config.json"
-  LAYER2_CONFIG="$(_find_layer2_config)"
+  if [[ -z "$client_id" || -z "$client_secret" ]]; then
+    local global_config="$HOME/.config/catalyst/config.json"
+    local layer2_config
+    layer2_config="$(_find_layer2_config)"
 
-  # 1. NEW global path (~/.config/catalyst/config.json):
-  #    catalyst.linear.bot.worker.{clientId,clientSecret}
-  if [[ -f "$GLOBAL_CONFIG" ]]; then
-    CLIENT_ID=$(jq -r '.catalyst.linear.bot.worker.clientId // empty' "$GLOBAL_CONFIG" 2>/dev/null)
-    CLIENT_SECRET=$(jq -r '.catalyst.linear.bot.worker.clientSecret // empty' "$GLOBAL_CONFIG" 2>/dev/null)
+    # 1. NEW global path (~/.config/catalyst/config.json):
+    #    catalyst.linear.bot.worker.{clientId,clientSecret}
+    if [[ -f "$global_config" ]]; then
+      client_id=$(jq -r '.catalyst.linear.bot.worker.clientId // empty' "$global_config" 2>/dev/null)
+      client_secret=$(jq -r '.catalyst.linear.bot.worker.clientSecret // empty' "$global_config" 2>/dev/null)
+    fi
+
+    # 2. OLD per-team path fallback (config-<key>.json, resolved above):
+    #    catalyst.linear.agent.{clientId,clientSecret}. During the transition the
+    #    worker creds may still live in the per-team file under the legacy key.
+    if [[ -z "$client_id" || -z "$client_secret" ]] && [[ -f "$layer2_config" ]]; then
+      client_id=$(jq -r '.catalyst.linear.agent.clientId // empty' "$layer2_config" 2>/dev/null)
+      client_secret=$(jq -r '.catalyst.linear.agent.clientSecret // empty' "$layer2_config" 2>/dev/null)
+    fi
+
+    # 3. OLD global path fallback: legacy catalyst.linear.agent.* in the global
+    #    config.json (covers a global-only legacy layout when no per-team file
+    #    exists or the resolver already pointed at config.json).
+    if [[ -z "$client_id" || -z "$client_secret" ]] && [[ -f "$global_config" ]]; then
+      client_id=$(jq -r '.catalyst.linear.agent.clientId // empty' "$global_config" 2>/dev/null)
+      client_secret=$(jq -r '.catalyst.linear.agent.clientSecret // empty' "$global_config" 2>/dev/null)
+    fi
+
+    if [[ -z "$client_id" || -z "$client_secret" ]]; then
+      echo "linear-comment-post: catalyst.linear.bot.worker.{clientId,clientSecret} (global) or legacy catalyst.linear.agent.* (per-team $layer2_config / global $global_config) not found" >&2
+      return 1
+    fi
   fi
 
-  # 2. OLD per-team path fallback (config-<key>.json, resolved above):
-  #    catalyst.linear.agent.{clientId,clientSecret}. During the transition the
-  #    worker creds may still live in the per-team file under the legacy key.
-  if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]] && [[ -f "$LAYER2_CONFIG" ]]; then
-    CLIENT_ID=$(jq -r '.catalyst.linear.agent.clientId // empty' "$LAYER2_CONFIG" 2>/dev/null)
-    CLIENT_SECRET=$(jq -r '.catalyst.linear.agent.clientSecret // empty' "$LAYER2_CONFIG" 2>/dev/null)
+  # 1. Mint app-actor token via client_credentials grant.
+  #    Capture the body + HTTP status WITHOUT -f so a 400 (e.g. invalid_scope)
+  #    surfaces the real error JSON instead of being discarded — the single
+  #    diagnostic line below then carries the actual cause (CTL-835).
+  local token_http
+  token_http=$(curl -s -w '\n%{http_code}' -X POST "${LINEAR_API}/oauth/token" \
+    -d "grant_type=client_credentials" \
+    -d "client_id=${client_id}" \
+    -d "client_secret=${client_secret}" \
+    -d "scope=${MINT_SCOPE}" \
+    -d "actor=app" \
+    -H "Content-Type: application/x-www-form-urlencoded" 2>/dev/null) || {
+    echo "linear-comment-post: token mint request failed (curl error)" >&2
+    return 1
+  }
+  local token_code="${token_http##*$'\n'}"
+  local token_response="${token_http%$'\n'*}"
+  local access_token
+  access_token=$(printf '%s' "$token_response" | jq -r '.access_token // empty' 2>/dev/null)
+  if [[ -z "$access_token" ]]; then
+    # One clear diagnostic carrying the HTTP status + Linear's error/description so
+    # invalid_scope (and any future mint rejection) is no longer silent.
+    local err_detail
+    err_detail=$(printf '%s' "$token_response" | jq -r '[.error, .error_description] | map(select(. != null and . != "")) | join(": ") // empty' 2>/dev/null)
+    echo "linear-comment-post: token mint failed (HTTP ${token_code:-?}${err_detail:+; }${err_detail}) — comment NOT posted" >&2
+    return 1
   fi
 
-  # 3. OLD global path fallback: legacy catalyst.linear.agent.* in the global
-  #    config.json (covers a global-only legacy layout when no per-team file
-  #    exists or the resolver already pointed at config.json).
-  if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]] && [[ -f "$GLOBAL_CONFIG" ]]; then
-    CLIENT_ID=$(jq -r '.catalyst.linear.agent.clientId // empty' "$GLOBAL_CONFIG" 2>/dev/null)
-    CLIENT_SECRET=$(jq -r '.catalyst.linear.agent.clientSecret // empty' "$GLOBAL_CONFIG" 2>/dev/null)
+  # 2. Resolve ticket identifier → issue UUID.
+  local issue_query
+  issue_query=$(jq -nc \
+    --arg q 'query($id:String!){issues(filter:{identifier:{eq:$id}}){nodes{id}}}' \
+    --arg id "$TICKET" \
+    '{query: $q, variables: {id: $id}}')
+  local issue_response
+  issue_response=$(curl -sf -X POST "${LINEAR_API}/graphql" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${access_token}" \
+    -d "$issue_query" 2>/dev/null) || {
+    echo "linear-comment-post: issue identifier resolution failed" >&2
+    return 1
+  }
+  local issue_uuid
+  issue_uuid=$(printf '%s' "$issue_response" | jq -r '.data.issues.nodes[0].id // empty' 2>/dev/null)
+  if [[ -z "$issue_uuid" ]]; then
+    echo "linear-comment-post: no issue found for identifier $TICKET" >&2
+    return 1
   fi
 
-  if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]]; then
-    echo "linear-comment-post: catalyst.linear.bot.worker.{clientId,clientSecret} (global) or legacy catalyst.linear.agent.* (per-team $LAYER2_CONFIG / global $GLOBAL_CONFIG) not found" >&2
-    exit 1
+  # 3. Post the comment.
+  local mutation
+  mutation=$(jq -nc \
+    --arg q 'mutation($input:CommentCreateInput!){commentCreate(input:$input){success}}' \
+    --arg issueId "$issue_uuid" \
+    --arg body "$BODY" \
+    '{query: $q, variables: {input: {issueId: $issueId, body: $body}}}')
+  local comment_response
+  comment_response=$(curl -sf -X POST "${LINEAR_API}/graphql" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${access_token}" \
+    -d "$mutation" 2>/dev/null) || {
+    echo "linear-comment-post: comment mutation request failed" >&2
+    return 1
+  }
+  local success
+  success=$(printf '%s' "$comment_response" | jq -r '.data.commentCreate.success // false' 2>/dev/null)
+  if [[ "$success" != "true" ]]; then
+    echo "linear-comment-post: commentCreate returned success=false" >&2
+    return 1
   fi
-fi
-
-# 1. Mint app-actor token via client_credentials grant.
-#    Capture the body + HTTP status WITHOUT -f so a 400 (e.g. invalid_scope)
-#    surfaces the real error JSON instead of being discarded — the single
-#    diagnostic line below then carries the actual cause (CTL-835).
-TOKEN_HTTP=$(curl -s -w '\n%{http_code}' -X POST "${LINEAR_API}/oauth/token" \
-  -d "grant_type=client_credentials" \
-  -d "client_id=${CLIENT_ID}" \
-  -d "client_secret=${CLIENT_SECRET}" \
-  -d "scope=${MINT_SCOPE}" \
-  -d "actor=app" \
-  -H "Content-Type: application/x-www-form-urlencoded" 2>/dev/null) || {
-  echo "linear-comment-post: token mint request failed (curl error)" >&2
-  exit 1
 }
-TOKEN_CODE="${TOKEN_HTTP##*$'\n'}"
-TOKEN_RESPONSE="${TOKEN_HTTP%$'\n'*}"
-ACCESS_TOKEN=$(printf '%s' "$TOKEN_RESPONSE" | jq -r '.access_token // empty' 2>/dev/null)
-if [[ -z "$ACCESS_TOKEN" ]]; then
-  # One clear diagnostic carrying the HTTP status + Linear's error/description so
-  # invalid_scope (and any future mint rejection) is no longer silent.
-  ERR_DETAIL=$(printf '%s' "$TOKEN_RESPONSE" | jq -r '[.error, .error_description] | map(select(. != null and . != "")) | join(": ") // empty' 2>/dev/null)
-  echo "linear-comment-post: token mint failed (HTTP ${TOKEN_CODE:-?}${ERR_DETAIL:+; }${ERR_DETAIL}) — comment NOT posted" >&2
-  exit 1
-fi
 
-# 2. Resolve ticket identifier → issue UUID.
-ISSUE_QUERY=$(jq -nc \
-  --arg q 'query($id:String!){issues(filter:{identifier:{eq:$id}}){nodes{id}}}' \
-  --arg id "$TICKET" \
-  '{query: $q, variables: {id: $id}}')
-ISSUE_RESPONSE=$(curl -sf -X POST "${LINEAR_API}/graphql" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-  -d "$ISSUE_QUERY" 2>/dev/null) || {
-  echo "linear-comment-post: issue identifier resolution failed" >&2
-  exit 1
+# ── Tier 2: linearis CLI fallback ─────────────────────────────────────────────
+_post_via_linearis() {
+  command -v linearis >/dev/null 2>&1 || {
+    echo "linear-comment-post: linearis not found on PATH — fallback unavailable" >&2
+    return 1
+  }
+  linearis issues discuss "$TICKET" --body "$BODY" >/dev/null 2>&1 || {
+    echo "linear-comment-post: linearis fallback failed" >&2
+    return 1
+  }
 }
-ISSUE_UUID=$(printf '%s' "$ISSUE_RESPONSE" | jq -r '.data.issues.nodes[0].id // empty' 2>/dev/null)
-if [[ -z "$ISSUE_UUID" ]]; then
-  echo "linear-comment-post: no issue found for identifier $TICKET" >&2
-  exit 1
-fi
 
-# 3. Post the comment.
-MUTATION=$(jq -nc \
-  --arg q 'mutation($input:CommentCreateInput!){commentCreate(input:$input){success}}' \
-  --arg issueId "$ISSUE_UUID" \
-  --arg body "$BODY" \
-  '{query: $q, variables: {input: {issueId: $issueId, body: $body}}}')
-COMMENT_RESPONSE=$(curl -sf -X POST "${LINEAR_API}/graphql" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-  -d "$MUTATION" 2>/dev/null) || {
-  echo "linear-comment-post: comment mutation request failed" >&2
-  exit 1
-}
-SUCCESS=$(printf '%s' "$COMMENT_RESPONSE" | jq -r '.data.commentCreate.success // false' 2>/dev/null)
-if [[ "$SUCCESS" != "true" ]]; then
-  echo "linear-comment-post: commentCreate returned success=false" >&2
-  exit 1
-fi
+# ── Main flow ─────────────────────────────────────────────────────────────────
+if _post_via_app_actor; then exit 0; fi
+echo "linear-comment-post: app-actor post failed — attempting linearis fallback" >&2
+if _post_via_linearis; then exit 0; fi
+echo "linear-comment-post: linearis fallback unavailable or failed — comment NOT posted" >&2
+exit 1

--- a/plugins/dev/scripts/lib/phase-failure-comment.sh
+++ b/plugins/dev/scripts/lib/phase-failure-comment.sh
@@ -33,11 +33,11 @@ SIGNAL_FILE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --ticket)     TICKET="$2";      shift 2 ;;
-    --phase)      PHASE="$2";       shift 2 ;;
-    --reason)     REASON="$2";      shift 2 ;;
-    --orch-dir)   ORCH_DIR="$2";    shift 2 ;;
-    --signal-file) SIGNAL_FILE="$2"; shift 2 ;;
+    --ticket)      TICKET="${2:-}";      shift 2 || true ;;
+    --phase)       PHASE="${2:-}";       shift 2 || true ;;
+    --reason)      REASON="${2:-}";      shift 2 || true ;;
+    --orch-dir)    ORCH_DIR="${2:-}";    shift 2 || true ;;
+    --signal-file) SIGNAL_FILE="${2:-}"; shift 2 || true ;;
     *) shift ;;
   esac
 done
@@ -101,9 +101,12 @@ POSTER="${CATALYST_COMMENT_POST_HELPER:-${SCRIPT_DIR}/linear-comment-post.sh}"
 # Post — timeout-bounded so a hung network call cannot delay teardown.
 # Wrap in || true: best-effort, never fails the caller.
 if [[ -x "$POSTER" ]]; then
-  # `timeout` is GNU coreutils (gtimeout on macOS); fall back to direct exec.
+  # Prefer `timeout` (GNU coreutils), then `gtimeout` (Homebrew coreutils on macOS),
+  # then fall back to a direct (unbounded) exec.
   if command -v timeout >/dev/null 2>&1; then
     timeout 20 "$POSTER" "$TICKET" "$BODY" >/dev/null 2>&1 || true
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout 20 "$POSTER" "$TICKET" "$BODY" >/dev/null 2>&1 || true
   else
     "$POSTER" "$TICKET" "$BODY" >/dev/null 2>&1 || true
   fi

--- a/plugins/dev/scripts/lib/phase-failure-comment.sh
+++ b/plugins/dev/scripts/lib/phase-failure-comment.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# phase-failure-comment.sh — Best-effort Linear comment on phase failure (CTL-1182 Phase 2).
+#
+# Called by phase-agent-emit-complete after --status failed or park. Posts the
+# phase's .explanation.call_to_action (or --reason) to Linear exactly once,
+# gated by CATALYST_FAILURE_COMMENT=1 (injected by phase-agent-dispatch so
+# dispatched workers always post; default OFF keeps unit tests clean).
+#
+# Usage:
+#   phase-failure-comment.sh \
+#     --ticket <id> \
+#     --phase  <name> \
+#     [--reason <text>] \
+#     [--orch-dir <path>] \
+#     [--signal-file <path>]
+#
+# Always exits 0 — never blocks the caller's lifecycle.
+set -euo pipefail
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+
+TICKET=""
+PHASE=""
+REASON=""
+ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR:-}"
+SIGNAL_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ticket)     TICKET="$2";      shift 2 ;;
+    --phase)      PHASE="$2";       shift 2 ;;
+    --reason)     REASON="$2";      shift 2 ;;
+    --orch-dir)   ORCH_DIR="$2";    shift 2 ;;
+    --signal-file) SIGNAL_FILE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+# Gate: only post when explicitly enabled (default OFF = test-isolation boundary).
+[[ "${CATALYST_FAILURE_COMMENT:-}" == "1" ]] || exit 0
+
+[[ -n "$TICKET" ]] || exit 0
+[[ -n "$PHASE"  ]] || exit 0
+
+# Idempotency marker — mirrors the success .linear-mirror-${PHASE} convention.
+MARKER=""
+if [[ -n "$ORCH_DIR" ]]; then
+  MARKER="${ORCH_DIR}/workers/${TICKET}/.linear-failure-mirror-${PHASE}"
+  [[ -e "$MARKER" ]] && exit 0
+fi
+
+# Resolve signal file.
+if [[ -z "$SIGNAL_FILE" && -n "$ORCH_DIR" ]]; then
+  SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+fi
+
+# Build the comment body.
+BODY=""
+if [[ -f "${SIGNAL_FILE:-}" ]] && command -v jq >/dev/null 2>&1; then
+  CALL_TO_ACTION="$(jq -r '.explanation.call_to_action // empty' "$SIGNAL_FILE" 2>/dev/null || true)"
+  PROBLEM="$(jq -r '.explanation.problem // empty' "$SIGNAL_FILE" 2>/dev/null || true)"
+  if [[ -n "$CALL_TO_ACTION" ]]; then
+    BODY="**Phase ${PHASE} failed** (${TICKET})"
+    [[ -n "$PROBLEM" ]] && BODY="${BODY}
+
+${PROBLEM}"
+    BODY="${BODY}
+
+_${CALL_TO_ACTION}_"
+  fi
+fi
+
+if [[ -z "$BODY" ]]; then
+  BODY="**Phase ${PHASE} failed** (${TICKET}): ${REASON:-unknown failure}"
+fi
+
+# Append phase-mirror footer if available (consistency with success mirrors).
+FOOTER_SCRIPT="${SCRIPT_DIR}/phase-mirror-footer.sh"
+if [[ -x "$FOOTER_SCRIPT" && -n "$ORCH_DIR" ]]; then
+  FOOTER="$("$FOOTER_SCRIPT" --orch-dir "$ORCH_DIR" --ticket "$TICKET" --phase "$PHASE" 2>/dev/null || true)"
+  [[ -n "$FOOTER" ]] && BODY="${BODY}
+${FOOTER}"
+fi
+
+# Truncate to stay within Linear's comment limits.
+if [[ ${#BODY} -gt 30000 ]]; then
+  BODY="${BODY:0:30000}
+
+_... (truncated)_"
+fi
+
+# Resolve the comment-post helper (injectable via CATALYST_COMMENT_POST_HELPER for tests).
+POSTER="${CATALYST_COMMENT_POST_HELPER:-${SCRIPT_DIR}/linear-comment-post.sh}"
+
+# Post — timeout-bounded so a hung network call cannot delay teardown.
+# Wrap in || true: best-effort, never fails the caller.
+if [[ -x "$POSTER" ]]; then
+  # `timeout` is GNU coreutils (gtimeout on macOS); fall back to direct exec.
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 20 "$POSTER" "$TICKET" "$BODY" >/dev/null 2>&1 || true
+  else
+    "$POSTER" "$TICKET" "$BODY" >/dev/null 2>&1 || true
+  fi
+  # Write idempotency marker (whether the post succeeded or not — prevents
+  # a storm of duplicate posts on restart).
+  [[ -n "$MARKER" ]] && : >"$MARKER" || true
+fi
+
+exit 0

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -805,7 +805,8 @@ compose_worker_settings_json() {
          {
            "CLAUDE_CODE_ENABLE_TELEMETRY": $enable_telemetry,
            "OTEL_METRICS_EXPORTER": $metrics_exporter,
-           "OTEL_LOGS_EXPORTER": $logs_exporter
+           "OTEL_LOGS_EXPORTER": $logs_exporter,
+           "CATALYST_FAILURE_COMMENT": "1"
          }
          + (if $otlp_endpoint == "" then {} else { "OTEL_EXPORTER_OTLP_ENDPOINT": $otlp_endpoint } end)
          + (if $otlp_protocol == "" then {} else { "OTEL_EXPORTER_OTLP_PROTOCOL": $otlp_protocol } end)
@@ -846,6 +847,8 @@ DISPATCH_ENV=(
 	# CTL-864: cross-host cluster fencing token (distinct from the host-local
 	# CATALYST_GENERATION above). Empty on single-host → worker performs no check.
 	"CATALYST_CLUSTER_GENERATION=${CATALYST_CLUSTER_GENERATION-}"
+	# CTL-1182: failure-path Linear comment opt-in (always-on for dispatched workers).
+	"CATALYST_FAILURE_COMMENT=1"
 )
 [[ -n $OTEL_RES_ATTRS ]] &&
 	DISPATCH_ENV+=("OTEL_RESOURCE_ATTRIBUTES=${OTEL_RES_ATTRS}")

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -419,6 +419,19 @@ if [[ -n $ORCH_DIR && $NO_SIGNAL_UPDATE -eq 0 ]]; then
 	fi
 fi
 
+# ─── 2b. Failure-path Linear comment (CTL-1182) ─────────────────────────────
+#
+# Post the failure explanation (or --reason) to Linear exactly once, gated by
+# CATALYST_FAILURE_COMMENT=1 (injected by phase-agent-dispatch). Best-effort:
+# a failing or absent helper never aborts the caller. Runs AFTER the signal
+# flip so the outcome is recorded before any network I/O. Also fires on the
+# artifact_not_gate_visible downgrade above (desirable — surfaces the stall).
+if [[ ( $STATUS == failed || $STATUS == park ) && -n ${TICKET-} ]]; then
+	"${SCRIPT_DIR}/lib/phase-failure-comment.sh" \
+		--ticket "$TICKET" --phase "$PHASE" --reason "$REASON" \
+		--orch-dir "${ORCH_DIR:-}" >/dev/null 2>&1 || true
+fi
+
 # ─── 3. End catalyst-session ────────────────────────────────────────────────
 
 if [[ -n $SESSION_ID ]] && [[ -x "${SCRIPT_DIR}/catalyst-session.sh" ]]; then


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-15T22:41:00Z -->
<!-- Last updated: 2026-06-15T22:41:00Z -->
<!-- PR: #2072 -->
<!-- Previous commits: 1268aae8d6d1396ad1331d3dafa60604bc9808bd,8971eb745c75a0cd818306ef374356765fdf79d9,9c89252c415bd579fc52e53241baa211d724875a,1e950405fb743ec00dc1abfa849383d9d620e25b -->

## Summary

Every phase — including failed ones — now records its outcome on the Linear ticket. Prior to this
change, the single app-actor mirror (`lib/linear-comment-post.sh`) had no codified fallback: when
the OAuth path failed, comments were silently dropped. Failed phases never posted at all because
they exited before their success-path mirror block.

This PR implements a three-phase fix:

- **Phase 1**: `linear-comment-post.sh` gains a deterministic `linearis issues discuss` fallback —
  exit 0 if either tier posts; non-zero only when both fail. Closes the silent-mirror gap.
- **Phase 2**: New `lib/phase-failure-comment.sh` helper posts each phase's
  `explanation.call_to_action` (or `--reason` fallback) to Linear whenever a phase emits
  `failed` or `park`, wired into `phase-agent-emit-complete`. Idempotent via a per-phase marker
  file; always exits 0 so it never blocks caller lifecycle.
- **Phase 3**: `phase-agent-dispatch` injects `CATALYST_FAILURE_COMMENT=1` into every dispatched
  worker's environment so the failure-path comment fires in production without any per-skill opt-in.
  Escalation (`escalate-workflow-scope.sh`) updated to note that the Linear post now routes through
  `emit-complete → phase-failure-comment` (no duplicate post needed). Architecture docs updated.

## Changes Made

### Scripts

- **`plugins/dev/scripts/lib/linear-comment-post.sh`** — Refactored into `_post_via_app_actor()`
  (return 1 at each failure) + `_post_via_linearis()` + two-tier main flow. +124 / -85 lines.
- **`plugins/dev/scripts/lib/phase-failure-comment.sh`** *(new)* — Best-effort, timeout-bounded
  helper for failure/park Linear comments. Reads `CATALYST_FAILURE_COMMENT`, `explanation.call_to_action`
  from the signal file, posts via `linear-comment-post.sh`, marks with a per-phase idempotency
  marker. +118 lines.
- **`plugins/dev/scripts/phase-agent-emit-complete`** — Calls `lib/phase-failure-comment.sh` after
  signal flip on `failed`/`park`. `CATALYST_COMMENT_POST_HELPER` injectable for testing. +13 lines.
- **`plugins/dev/scripts/phase-agent-dispatch`** — Adds `CATALYST_FAILURE_COMMENT=1` to
  `compose_worker_settings_json` and `DISPATCH_ENV`. +4 / -1 lines.
- **`plugins/dev/scripts/lib/escalate-workflow-scope.sh`** — Notes that Linear post routes through
  `emit-complete → phase-failure-comment`; no duplicate post needed. +3 lines.

### Tests

- **`plugins/dev/scripts/__tests__/linear-comment-post.test.sh`** — Flip Test 5 expectation (exit
  0 when linearis fallback succeeds); update Test 8 (explicit PATH with failing linearis stub);
  update Test 12 (drop strict 1-line count); add Tests 15–17 for both-fail / no-linearis /
  no-double-post. +143 / -17 lines. Total: 23 assertions (was 17).
- **`plugins/dev/scripts/lib/__tests__/phase-failure-comment.test.sh`** *(new)* — 10 tests covering
  disabled-by-default, marker idempotency, linearis-not-found, timeout bounds, arg parser, gtimeout
  fallback. +179 lines.
- **`plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh`** — Tests 46–48 cover
  failure-path comment injection via `CATALYST_COMMENT_POST_HELPER`. +73 lines.
- **`plugins/dev/scripts/lib/__tests__/escalate-emitters.test.sh`** — End-to-end escalation test:
  `_escalate_workflow_scope_push` → stub emit-complete → `phase-failure-comment.sh` → recording
  stub; asserts the workflow-scope `call_to_action` reaches the Linear poster. +89 lines.
- **`plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh`** — Test 68 asserts
  `CATALYST_FAILURE_COMMENT` appears in the dispatched `settings.env`. +6 lines.

### Docs

- **`docs/architecture.md`** — Documents the two-tier Linear post strategy and failure-path
  centralization in the Phase-Agent Communication section. +24 lines.

## How to Verify It

- [x] `plugins/dev/scripts/__tests__/linear-comment-post.test.sh` — 23 assertions pass ✅
- [x] `plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh` — Tests 46–48 pass ✅
- [x] `plugins/dev/scripts/lib/__tests__/phase-failure-comment.test.sh` — 10 assertions pass ✅
- [x] `plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh` — Test 68 passes ✅
- [x] `plugins/dev/scripts/lib/__tests__/escalate-emitters.test.sh` — escalation e2e passes ✅
- [x] CI: audit-references, check-versions, docs-gate, validate — all pass ✅
- [ ] Smoke test: deploy with bad app-actor creds + working `linearis` → phase comment posted, exit 0
- [ ] Smoke test: force a phase to `failed` state → `explanation.call_to_action` appears on the Linear ticket

## Reviewer Notes

The failure-path comment is **disabled by default** (requires `CATALYST_FAILURE_COMMENT=1`), which
means existing tests are unaffected. The dispatch injection (Phase 3) enables it for real workers.
The per-phase marker file ensures idempotency across revives.

Security hardening (`fix(dev)` commit): the arg parser now uses `${2:-} + shift 2 || true` to
prevent `set -e` exit on a flag without a value; `gtimeout` (Homebrew coreutils) is tried after
`timeout` fails on macOS so the 20-second bound holds on machines without `gnubin` on PATH.

## Changelog Entry

**feat(dev)**: Codify a deterministic two-tier Linear comment strategy — app-actor OAuth first,
`linearis issues discuss` fallback — so every phase records its outcome on the ticket even when
the primary mirror fails. Add `phase-failure-comment.sh` and wire `CATALYST_FAILURE_COMMENT=1`
into dispatched workers so failed/parked phases post their `call_to_action` without per-skill
opt-in. Hardened `phase-failure-comment.sh` arg parser and `timeout`/`gtimeout` fallback for macOS.

## Related Issues/PRs

- Fixes https://linear.app/coalesce/issue/CTL-1182
