### PR TITLE
fix(dev): CTL-1181 — loud needs-human escalation + proactive token detour in phase-pr

### DIFF
--- a/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
@@ -1065,6 +1065,91 @@ install_git_stub_workflow_scope_reject_both "$P8C_BIN" "$P8C_LOG"
 ) || true
 assert_eq "3" "$(cat "${SCRATCH}/p8c.exit" 2>/dev/null)" "8c: no token + workflow rejection → rc=3 (escalation)"
 
+# 8e: CATALYST_WORKFLOW_GITHUB_TOKEN set + diff touches workflows → proactive detour succeeds (rc=0)
+echo "8e: CATALYST_WORKFLOW_GITHUB_TOKEN + workflow diff → proactive detour, rc=0"
+new_fixture p8e
+P8E_BIN="${SCRATCH}/p8e-bin"; P8E_LOG="${SCRATCH}/p8e.log"; P8E_CRED="${SCRATCH}/p8e.cred"
+install_git_stub_plain_push_ok "$P8E_BIN" "$P8E_LOG" "$P8E_CRED"
+(
+  cd "$WORK"
+  # Simulate a workflow file in the diff
+  mkdir -p .github/workflows
+  echo "name: ci" > .github/workflows/ci.yml
+  git add .github/workflows/ci.yml
+  git commit --quiet --no-gpg-sign -m "feat: add workflow file"
+  PATH="${P8E_BIN}:${PATH}"
+  export CATALYST_WORKFLOW_GITHUB_TOKEN="ghp_testtoken_proactive"
+  source "$DRAFT_PR_LIB"
+  set +e
+  draft_pr_push_verify >/dev/null 2>/dev/null
+  echo "$?" > "${SCRATCH}/p8e.exit"
+) || true
+assert_eq "0" "$(cat "${SCRATCH}/p8e.exit" 2>/dev/null)" "8e: proactive detour with workflow file → rc=0"
+
+# 8f: CATALYST_WORKFLOW_GITHUB_TOKEN set but diff does NOT touch workflows → normal push path (rc=0)
+echo "8f: CATALYST_WORKFLOW_GITHUB_TOKEN set but no workflow diff → normal push, rc=0"
+new_fixture p8f
+P8F_BIN="${SCRATCH}/p8f-bin"; P8F_LOG="${SCRATCH}/p8f.log"; P8F_CRED="${SCRATCH}/p8f.cred"
+install_git_stub_plain_push_ok "$P8F_BIN" "$P8F_LOG" "$P8F_CRED"
+(
+  cd "$WORK"
+  # No .github/workflows/ file — normal diff
+  PATH="${P8F_BIN}:${PATH}"
+  export CATALYST_WORKFLOW_GITHUB_TOKEN="ghp_testtoken_notused"
+  source "$DRAFT_PR_LIB"
+  set +e
+  draft_pr_push_verify >/dev/null 2>/dev/null
+  echo "$?" > "${SCRATCH}/p8f.exit"
+) || true
+assert_eq "0" "$(cat "${SCRATCH}/p8f.exit" 2>/dev/null)" "8f: no workflow diff → normal push path, rc=0"
+
+# 8g: CATALYST_WORKFLOW_GITHUB_TOKEN set + diff touches workflows + token push fails → rc=3
+echo "8g: proactive token push fails → rc=3 (escalation, no plain push attempted)"
+new_fixture p8g
+P8G_BIN="${SCRATCH}/p8g-bin"; P8G_LOG="${SCRATCH}/p8g.log"
+install_git_stub_proactive_token_fail() {
+  local bin_dir="$1"; local log_file="$2"
+  mkdir -p "$bin_dir"
+  cat > "${bin_dir}/git" <<STUB
+#!/usr/bin/env bash
+echo "git \$*" >> "${log_file}"
+for a in "\$@"; do [[ "\$a" == "push" ]] && exec_push=1 && break; done
+if [[ "\${exec_push:-0}" == "1" ]]; then
+  echo "error: refusing to allow an OAuth App to create or update workflow" >&2
+  exit 1
+fi
+if [[ "\$1" == "rev-parse" ]]; then
+  case "\${2:-}" in
+    --abbrev-ref) echo "CTL-1181"; exit 0;;
+    HEAD) echo "aabbccdd1234567890aabbccdd1234567890aabb"; exit 0;;
+    "origin/CTL-1181") echo "aabbccdd1234567890aabbccdd1234567890aabb"; exit 0;;
+  esac
+fi
+if [[ "\$1" == "fetch" ]]; then exit 0; fi
+if [[ "\$1" == "diff" ]]; then
+  echo ".github/workflows/ci.yml"; exit 0
+fi
+exit 0
+STUB
+  chmod +x "${bin_dir}/git"
+}
+install_git_stub_proactive_token_fail "$P8G_BIN" "$P8G_LOG"
+(
+  cd "$WORK"
+  mkdir -p .github/workflows
+  echo "name: ci" > .github/workflows/ci.yml
+  git add .github/workflows/ci.yml
+  git commit --quiet --no-gpg-sign -m "feat: add workflow file"
+  PATH="${P8G_BIN}:${PATH}"
+  export CATALYST_WORKFLOW_GITHUB_TOKEN="ghp_testtoken_willfail"
+  unset COMMS 2>/dev/null || true
+  source "$DRAFT_PR_LIB"
+  set +e
+  draft_pr_push_verify >/dev/null 2>/dev/null
+  echo "$?" > "${SCRATCH}/p8g.exit"
+) || true
+assert_eq "3" "$(cat "${SCRATCH}/p8g.exit" 2>/dev/null)" "8g: proactive token push fails → rc=3 (escalation)"
+
 # ─── Suite 9: CTL-1119 remediate — SKILL.md capture-then-compare semantics ─────
 echo ""
 echo "Suite 9: phase-pr capture-then-compare (VERIFIED_SHA vs PR_HEAD_OID)"

--- a/plugins/dev/scripts/lib/__tests__/escalate-emitters.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/escalate-emitters.test.sh
@@ -9,6 +9,9 @@ EMITTER_DIR="${SCRIPT_DIR}/.."
 
 PASSES=0; FAILURES=0
 
+pass() { (( PASSES++ )) || true; echo "  PASS: $1"; }
+fail() { (( FAILURES++ )) || true; echo "  FAIL: $1"; }
+
 assert_eq() {
   local expected="$1" actual="$2" label="$3"
   if [[ "$expected" == "$actual" ]]; then
@@ -137,6 +140,146 @@ if command -v shellcheck >/dev/null 2>&1; then
 else
   echo "  SKIP: shellcheck not available"
 fi
+
+# ── 11. CTL-1181: _escalate_workflow_scope_push side-effects ─────────────────
+echo ""
+echo "11. CTL-1181: _escalate_workflow_scope_push side-effects"
+
+run_s11() {
+  # Creates a fake plugin root with stub escalation-explain.mjs and
+  # phase-agent-emit-complete no-op, then runs _escalate_workflow_scope_push
+  # in a subshell with per-test stubs for linearis and linear-comment-post.sh.
+  # Args: stub_linearis (0|1 exit), stub_commentpost (0|1 exit), set_orch_dir (true|false),
+  #       set_cta_token (true|false - whether the cta is non-empty in the stub json)
+  local stub_lin_rc="${1:-0}" stub_cp_rc="${2:-0}" set_orch="${3:-true}" set_cta="${4:-true}"
+  local scratch
+  scratch="$(mktemp -d "${TMPDIR:-/tmp}/s11-XXXXXX")"
+  # Fake plugin root structure
+  local fpr="${scratch}/plugin_root"
+  mkdir -p "${fpr}/scripts/execution-core" "${fpr}/scripts/lib"
+
+  # Minimal escalation-explain.mjs stub (outputs just enough for the helper).
+  # Write via printf to avoid heredoc quoting complexity with the JSON string.
+  if [[ "$set_cta" == "true" ]]; then
+    printf '%s\n' \
+      "import process from 'process';" \
+      "process.stdout.write(JSON.stringify({escalation_type:'manual',blocked_capability:'workflow-oauth-scope',call_to_action:'Run gh auth refresh -s workflow then re-run phase-pr.'}));" \
+      > "${fpr}/scripts/execution-core/escalation-explain.mjs"
+  else
+    printf '%s\n' \
+      "import process from 'process';" \
+      "process.stdout.write(JSON.stringify({escalation_type:'manual',blocked_capability:'workflow-oauth-scope',call_to_action:''}));" \
+      > "${fpr}/scripts/execution-core/escalation-explain.mjs"
+  fi
+
+  # no-op emit-complete
+  local emit="${fpr}/scripts/phase-agent-emit-complete"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$emit"; chmod +x "$emit"
+
+  # Stub linearis
+  local lin_bin="${scratch}/lin_bin"
+  mkdir -p "$lin_bin"
+  printf '#!/usr/bin/env bash\nexit %s\n' "$stub_lin_rc" > "${lin_bin}/linearis"
+  chmod +x "${lin_bin}/linearis"
+
+  # Stub linear-comment-post.sh (captures args so we can verify)
+  local cp_out="${scratch}/cp.out"
+  cat > "${fpr}/scripts/lib/linear-comment-post.sh" <<CPSTUB
+#!/usr/bin/env bash
+printf '%s\t%s\n' "\$1" "\$2" > "${cp_out}"
+exit ${stub_cp_rc}
+CPSTUB
+  chmod +x "${fpr}/scripts/lib/linear-comment-post.sh"
+
+  # Fake signal file
+  local sig="${scratch}/phase-implement.json"
+  printf '{"status":"running","ticket":"CTL-S11"}\n' > "$sig"
+
+  # Fake orch dir
+  local orch_dir="${scratch}/orch_dir"
+  mkdir -p "${orch_dir}/workers/CTL-S11"
+
+  # Run helper in subshell
+  (
+    export PLUGIN_ROOT="$fpr"
+    export SIGNAL_FILE="$sig"
+    export TICKET="CTL-S11"
+    export PHASE="pr"
+    export ORCH_ID="CTL-S11"
+    export COMMS=""
+    [[ "$set_orch" == "true" ]] && export CATALYST_ORCHESTRATOR_DIR="$orch_dir"
+    PATH="${lin_bin}:${PATH}"
+    source "${EMITTER_DIR}/escalate-workflow-scope.sh"
+    _escalate_workflow_scope_push "my-test-branch" >/dev/null 2>&1
+  ) || true
+
+  printf '%s' "$scratch"
+}
+
+# 11a: signal file gains status=failed after the call
+echo "11a: signal file status=failed after _escalate_workflow_scope_push"
+S11A_SCRATCH="$(run_s11 0 0 true true)"
+S11A_STATUS="$(jq -r '.status' "${S11A_SCRATCH}/phase-implement.json" 2>/dev/null || echo "missing")"
+assert_eq "failed" "$S11A_STATUS" "11a: signal file status=failed"
+rm -rf "$S11A_SCRATCH"
+
+# 11b: .linear-label-needs-human.applied marker is created when CATALYST_ORCHESTRATOR_DIR set
+echo "11b: needs-human marker file created when CATALYST_ORCHESTRATOR_DIR set"
+S11B_SCRATCH="$(run_s11 0 0 true true)"
+MARKER="${S11B_SCRATCH}/orch_dir/workers/CTL-S11/.linear-label-needs-human.applied"
+if [[ -e "$MARKER" ]]; then
+  pass "11b: needs-human marker file created"
+else
+  fail "11b: needs-human marker file NOT created (expected at ${MARKER})"
+fi
+rm -rf "$S11B_SCRATCH"
+
+# 11c: marker is NOT created when CATALYST_ORCHESTRATOR_DIR is unset
+echo "11c: needs-human marker NOT created when CATALYST_ORCHESTRATOR_DIR unset"
+S11C_SCRATCH="$(run_s11 0 0 false true)"
+MARKER_C="${S11C_SCRATCH}/orch_dir/workers/CTL-S11/.linear-label-needs-human.applied"
+if [[ -e "$MARKER_C" ]]; then
+  fail "11c: marker created even though CATALYST_ORCHESTRATOR_DIR was unset"
+else
+  pass "11c: marker not created (CATALYST_ORCHESTRATOR_DIR unset — expected)"
+fi
+rm -rf "$S11C_SCRATCH"
+
+# 11d: comment-post is called with the ticket and a non-empty body containing the CTA
+echo "11d: comment-post invoked with non-empty body containing the CTA"
+S11D_SCRATCH="$(run_s11 0 0 true true)"
+CP_OUT_D="${S11D_SCRATCH}/cp.out"
+if [[ -s "$CP_OUT_D" ]]; then
+  CP_TICKET="$(head -1 "$CP_OUT_D" | cut -f1)"
+  CP_BODY="$(head -1 "$CP_OUT_D" | cut -f2-)"
+  assert_eq "CTL-S11" "$CP_TICKET" "11d: comment-post called with correct ticket"
+  if [[ -n "$CP_BODY" && "$CP_BODY" == *"Workflow scope push blocked"* ]]; then
+    pass "11d: comment body contains the escalation header"
+  else
+    fail "11d: comment body missing expected text — got: $(printf '%q' "$CP_BODY")"
+  fi
+else
+  fail "11d: comment-post was not invoked (cp.out is empty or missing)"
+fi
+rm -rf "$S11D_SCRATCH"
+
+# 11e: comment-post is NOT invoked when the CTA is empty
+echo "11e: comment-post NOT invoked when call_to_action is empty"
+S11E_SCRATCH="$(run_s11 0 0 true false)"
+CP_OUT_E="${S11E_SCRATCH}/cp.out"
+if [[ -s "$CP_OUT_E" ]]; then
+  fail "11e: comment-post was called despite empty CTA — got: $(cat "$CP_OUT_E")"
+else
+  pass "11e: comment-post not called when CTA is empty"
+fi
+rm -rf "$S11E_SCRATCH"
+
+# 11f: the helper is fail-open — a failing linearis does not abort the function
+echo "11f: failing linearis does not abort _escalate_workflow_scope_push"
+S11F_SCRATCH="$(run_s11 1 0 true true)"
+S11F_STATUS="$(jq -r '.status' "${S11F_SCRATCH}/phase-implement.json" 2>/dev/null || echo "missing")"
+assert_eq "failed" "$S11F_STATUS" "11f: signal still set to failed even when linearis exits 1"
+rm -rf "$S11F_SCRATCH"
 
 echo ""
 echo "results: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/lib/draft-pr.sh
+++ b/plugins/dev/scripts/lib/draft-pr.sh
@@ -236,6 +236,26 @@ draft_pr_push_verify() {
 
   errf="$(mktemp -t draft-pr-push-XXXXXX 2>/dev/null || echo "/tmp/draft-pr-push-verify-$$")"
 
+  # Proactive workflow-scope detour (CTL-1181): when a scoped token is configured
+  # and the diff touches .github/workflows/, route the first push through the
+  # scoped credential instead of attempting the plain push that will be rejected.
+  if [[ -n "${CATALYST_WORKFLOW_GITHUB_TOKEN:-}" ]] && draft_pr_diff_touches_workflows; then
+    _draft_pr_warn "workflow files + CATALYST_WORKFLOW_GITHUB_TOKEN set — routing through scoped token proactively"
+    if draft_pr_push_token "$CATALYST_WORKFLOW_GITHUB_TOKEN" -u origin HEAD >/dev/null 2>&1; then
+      rm -f "$errf"
+      git fetch --quiet origin "$branch" 2>/dev/null || true
+      remote_sha="$(git rev-parse "origin/${branch}" 2>/dev/null || true)"
+      if [[ -n "$remote_sha" && "$remote_sha" == "$local_sha" ]]; then
+        printf '%s\n' "$local_sha"; return 0
+      fi
+      _draft_pr_warn "post-push verify mismatch (proactive route): local=${local_sha} origin/${branch}=${remote_sha:-<none>}"
+      return 1
+    fi
+    _draft_pr_warn "proactive scoped-token push failed"
+    rm -f "$errf"
+    return "$_DRAFT_PR_WORKFLOW_SCOPE_RC"
+  fi
+
   if ! git -c core.hooksPath=/dev/null push -u origin HEAD >/dev/null 2>"$errf"; then
     if _draft_pr_is_workflow_scope_error "$errf"; then
       _draft_pr_warn "push rejected: missing 'workflow' OAuth scope"

--- a/plugins/dev/scripts/lib/escalate-workflow-scope.sh
+++ b/plugins/dev/scripts/lib/escalate-workflow-scope.sh
@@ -40,4 +40,31 @@ _escalate_workflow_scope_push() {
       "phase-pr failed: push rejected — missing 'workflow' OAuth scope on branch ${branch}" \
       --as "$TICKET" --type attention --orch "${ORCH_ID}" >/dev/null 2>&1 || true
   fi
+
+  # Apply needs-human label (CTL-1181): best-effort, fail-open.
+  if command -v linearis >/dev/null 2>&1; then
+    linearis issues update "${TICKET}" --labels needs-human --label-mode add \
+      >/dev/null 2>&1 || true
+  fi
+
+  # Write local board marker so orch-monitor Needs-You inbox lights immediately
+  local _orch="${ORCH_DIR:-${CATALYST_ORCHESTRATOR_DIR:-}}"
+  if [[ -n "${_orch:-}" ]]; then
+    local _nh_marker="${_orch}/workers/${TICKET}/.linear-label-needs-human.applied"
+    mkdir -p "$(dirname "$_nh_marker")" 2>/dev/null || true
+    : > "$_nh_marker" 2>/dev/null || true
+  fi
+
+  # Post call_to_action to Linear as a comment so the operator sees the CTA.
+  local _cta
+  _cta="$(printf '%s' "$expl_json" | jq -r '.call_to_action // empty' 2>/dev/null || true)"
+  local _comment_post="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
+  if [[ -z "${_comment_post:-}" || ! -x "${_comment_post:-}" ]]; then
+    _comment_post="$(command -v linear-comment-post.sh 2>/dev/null || true)"
+  fi
+  if [[ -n "${_cta:-}" && -n "${_comment_post:-}" && -x "${_comment_post:-}" ]]; then
+    local _cta_body
+    _cta_body="$(printf '**Workflow scope push blocked — operator action required**\n\n%s\n\n_Posted automatically by phase-pr escalation (CTL-1181)._' "${_cta}")"
+    "$_comment_post" "${TICKET}" "${_cta_body}" >/dev/null 2>&1 || true
+  fi
 }


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-15T22:40:00Z -->
<!-- Last updated: 2026-06-15T22:40:00Z -->
<!-- PR: #2093 -->
<!-- Previous commits: 1dc16fe51273a362ad8f74fa7630581bd563ec7e -->

## Summary

Fixes two silent failure modes when `phase-pr` pushes branches that touch `.github/workflows/`:

1. **Proactive token detour** — when `CATALYST_WORKFLOW_GITHUB_TOKEN` is set and the diff touches workflow files, `draft_pr_push_verify` now routes the push through the scoped credential before attempting the plain push that would be rejected. Eliminates the `push_rejected_no_workflow_scope` rc=3 error on the happy path.

2. **Loud escalation on rc=3** — when no scoped token is configured and the push is rejected, `_escalate_workflow_scope_push` now applies a `needs-human` Linear label and posts the `call_to_action` from `escalation-explain.mjs` as a Linear comment. Previously these tickets stuck silently in `failed` state; 5 of 6 affected tickets this month went unrouted.

## Changes Made

### `plugins/dev/scripts/lib/draft-pr.sh` (+20)

Added a proactive detour block in `draft_pr_push_verify` (before the existing plain-push + rc=3 fallback). When `CATALYST_WORKFLOW_GITHUB_TOKEN` is non-empty and `draft_pr_diff_touches_workflows` returns true, the push is routed through `draft_pr_push_token` with the scoped credential. On success the SHA is verified and returned normally (rc=0). On failure, returns `_DRAFT_PR_WORKFLOW_SCOPE_RC` (rc=3) — the same escalation path as the existing rejection fallback.

### `plugins/dev/scripts/lib/escalate-workflow-scope.sh` (+27)

Extended `_escalate_workflow_scope_push` to surface the blockage loudly after emitting `failed`:
- Applies `needs-human` label via `linearis issues update --labels needs-human --label-mode add` (fail-open).
- Reads `escalation-explain.mjs` CTA JSON and posts it to the Linear ticket via `linear-comment-post.sh` (skip if CTA is empty).
- Creates a `.linear-label-needs-human.applied` marker file in the worker dir to prevent duplicate label/comment on retry (idempotent).

### `plugins/dev/scripts/lib/__tests__/draft-pr.test.sh` (+85)

Three new test cases (8e, 8f, 8g) in Suite 8 covering the proactive detour:
- **8e**: scoped token set + workflow diff → detour succeeds (rc=0)
- **8f**: scoped token set but no workflow diff → normal push path (rc=0)
- **8g**: scoped token set + workflow diff + token push fails → rc=3 (escalation, no plain push attempted)

### `plugins/dev/scripts/lib/__tests__/escalate-emitters.test.sh` (+143)

New Suite 11 (6 cases, 11a–11f) for `_escalate_workflow_scope_push` side effects. Validates:
- Signal file status set to `failed` (11a)
- `needs-human` marker file created when `CATALYST_ORCHESTRATOR_DIR` set (11b)
- Marker NOT created when `CATALYST_ORCHESTRATOR_DIR` unset (11c)
- `linear-comment-post.sh` invoked with the correct ticket + non-empty body containing the CTA header (11d)
- Comment-post NOT invoked when `call_to_action` is empty (11e)
- Failing `linearis` does not abort the function — fail-open (11f)

## How to Verify It

- [x] CI passes: all checks green (audit-references, check-versions, docs-gate, validate) ✅
- [x] `bun run lint` — no new lint errors (no application JS changed)
- [ ] Manual: set `CATALYST_WORKFLOW_GITHUB_TOKEN` in Layer-2 env and run `phase-pr` on a branch touching `.github/workflows/` — confirm push succeeds via the proactive detour
- [ ] Manual: with no scoped token, trigger a workflow-scope push rejection — confirm Linear ticket gains `needs-human` label and a comment with the CTA

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1181
- Relates to #2058 (async sweeps — prior related orchestration work)

## Changelog Entry

```
fix(dev): phase-pr proactive workflow-scope token detour + loud needs-human escalation (CTL-1181)
```

