### PR TITLE
feat(dev): CTL-1174 — delegate read-side claim gate + broker cache + eligible-set contentKey

### DIFF
--- a/plugins/dev/scripts/broker/broker-state.d.mts
+++ b/plugins/dev/scripts/broker/broker-state.d.mts
@@ -21,6 +21,8 @@ export interface TicketDescriptor {
   estimate: number | null;
   resolution: string | null;
   assignee: string | null;
+  /** CTL-1174: Linear delegate UUID (app-user/bot) from broker cache. null = unset. */
+  delegate: string | null;
   uuid: string | null;
   removed: boolean;
   removedAt: string | null;
@@ -44,6 +46,8 @@ export interface UpsertTicketDescriptorInput {
   estimate?: number | null;
   resolution?: string | null;
   assignee?: string | null;
+  /** CTL-1174: delegate UUID (key-presence: absent = keep). */
+  delegate?: string | null;
   uuid?: string | null;
   removed?: boolean;
 }

--- a/plugins/dev/scripts/broker/broker-state.mjs
+++ b/plugins/dev/scripts/broker/broker-state.mjs
@@ -121,6 +121,7 @@ export function openBrokerStateDb(dbPath = DEFAULT_DB_PATH) {
     "estimate INTEGER",
     "resolution TEXT",
     "assignee TEXT",
+    "delegate TEXT",
     "uuid TEXT",
     "removed_at TEXT",
     "owner_host TEXT",
@@ -529,6 +530,7 @@ const DESCRIPTOR_COLUMNS = {
   estimate: "estimate",
   resolution: "resolution",
   assignee: "assignee",
+  delegate: "delegate",
   uuid: "uuid",
 };
 
@@ -612,6 +614,7 @@ function rowToTicketDescriptor(row) {
     estimate: typeof row.estimate === "number" ? row.estimate : null,
     resolution: row.resolution ?? null,
     assignee: row.assignee ?? null,
+    delegate: row.delegate ?? null,
     uuid: row.uuid ?? null,
     removed: row.removed_at != null,
     removedAt: row.removed_at ?? null,

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -1046,6 +1046,22 @@ function foldLinearIssueDescriptor(name, detail, eventTicket) {
         (Array.isArray(detail.updatedFromKeys) && detail.updatedFromKeys.includes("assigneeId"));
       if (changeEvidenced) descriptor.assignee = v;
     }
+    if ("toDelegateId" in detail) {
+      const v = detail.toDelegateId ?? null;
+      // CTL-1174: mirror the CTL-821 assignee guard — a bare null CLEARS only
+      // when the change is evidenced, else it is "unknown" and KEEPS (a partial
+      // Linear payload must never spuriously un-delegate a bot-owned ticket →
+      // re-claim). Accept BOTH updatedFrom key spellings since Linear's exact
+      // key is unverified (Open Question #2) — accepting both fails toward KEEP.
+      const changeEvidenced =
+        v !== null ||
+        name === "linear.issue.delegate_changed" ||
+        detail.action === "create" ||
+        (Array.isArray(detail.updatedFromKeys) &&
+          (detail.updatedFromKeys.includes("delegateId") ||
+            detail.updatedFromKeys.includes("delegate")));
+      if (changeEvidenced) descriptor.delegate = v;
+    }
     if (detail.toLabels != null) descriptor.labels = detail.toLabels;
     if (uuid) descriptor.uuid = uuid;
     upsertTicketDescriptor(descriptor);

--- a/plugins/dev/scripts/execution-core/eligible-set.mjs
+++ b/plugins/dev/scripts/execution-core/eligible-set.mjs
@@ -82,6 +82,11 @@ function contentKey(tickets) {
       t.parent ?? null,
       t.estimate ?? null,
       relationsSignature(t),
+      // CTL-1174: delegate in the signature so an out-of-band delegate change
+      // forces a projection rewrite (the CONTENTKEY PROJECTION TRAP). `?? null`
+      // collapses undefined/null identically — a batch outage leaves delegate
+      // unset and must not churn the set on the next successful poll.
+      t.delegate ?? null,
     ]),
   );
 }

--- a/plugins/dev/scripts/execution-core/eligible-set.test.mjs
+++ b/plugins/dev/scripts/execution-core/eligible-set.test.mjs
@@ -232,6 +232,59 @@ describe("setProjectEligible", () => {
     });
     expect(existsSync(projFile("alpha"))).toBe(true);
   });
+
+  test("CTL-1174: a delegate-only delta DOES rewrite the file (delegate is in the content key)", async () => {
+    // Pre-CTL-1174 projection has no delegate; reconcile now carries delegate UUID.
+    // Without delegate in contentKey, the rewrite would be skipped → silent starvation
+    // (a foreign delegate would never trigger the claim guard refresh).
+    setProjectEligible("alpha", [{ identifier: "A-1", state: "Todo", priority: 1, delegate: null }], {
+      source: "reconcile",
+      query: {},
+    });
+    const mtime1 = statSync(projFile("alpha")).mtimeMs;
+    await sleep(15);
+    setProjectEligible(
+      "alpha",
+      [{ identifier: "A-1", state: "Todo", priority: 1, delegate: "bot-uuid-ff78d890" }],
+      { source: "reconcile", query: {} },
+    );
+    expect(statSync(projFile("alpha")).mtimeMs).toBeGreaterThan(mtime1);
+    const doc = JSON.parse(readFileSync(projFile("alpha"), "utf8"));
+    expect(doc.tickets[0].delegate).toBe("bot-uuid-ff78d890");
+  });
+
+  test("CTL-1174: unchanged delegate does NOT rewrite the file (no spurious churn)", async () => {
+    setProjectEligible(
+      "alpha",
+      [{ identifier: "A-1", state: "Todo", priority: 1, delegate: "bot-uuid-ff78d890" }],
+      { source: "reconcile", query: {} },
+    );
+    const mtime1 = statSync(projFile("alpha")).mtimeMs;
+    await sleep(15);
+    // Same delegate — no rewrite expected.
+    setProjectEligible(
+      "alpha",
+      [{ identifier: "A-1", state: "Todo", priority: 1, delegate: "bot-uuid-ff78d890" }],
+      { source: "reconcile", query: {} },
+    );
+    expect(statSync(projFile("alpha")).mtimeMs).toBe(mtime1);
+  });
+
+  test("CTL-1174: undefined delegate treated as null in contentKey (no spurious churn vs null)", async () => {
+    // A ticket freshly read via linearis has no delegate field → undefined → normalized to null.
+    // A second reconcile with delegate:null must NOT trigger a rewrite.
+    setProjectEligible("alpha", [{ identifier: "A-1", state: "Todo", priority: 1 }], {
+      source: "reconcile",
+      query: {},
+    });
+    const mtime1 = statSync(projFile("alpha")).mtimeMs;
+    await sleep(15);
+    setProjectEligible("alpha", [{ identifier: "A-1", state: "Todo", priority: 1, delegate: null }], {
+      source: "reconcile",
+      query: {},
+    });
+    expect(statSync(projFile("alpha")).mtimeMs).toBe(mtime1);
+  });
 });
 
 describe("removeTicket", () => {

--- a/plugins/dev/scripts/execution-core/gateway-read.mjs
+++ b/plugins/dev/scripts/execution-core/gateway-read.mjs
@@ -76,6 +76,7 @@ export function createGatewayReader({ dbPath = defaultDbPath() } = {}) {
         priority: row.priority ?? null,
         resolution: row.resolution ?? null,
         assignee: row.assignee ?? null,
+        delegate: row.delegate ?? null,
         uuid: row.uuid ?? null,
         removed: row.removed_at != null,
         removedAt: row.removed_at ?? null,

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -110,6 +110,9 @@ function normalizeTicket(node) {
     parent: node.parent?.identifier ?? node.parent ?? null,
     relations: node.relations ?? { nodes: [] },
     inverseRelations: node.inverseRelations ?? { nodes: [] },
+    // CTL-1174: delegate defaults null from linearis (linearis cannot read delegate).
+    // The batched GraphQL enrichment in runEligibleQuery overwrites this.
+    delegate: node.delegate?.id ?? node.delegate ?? null,
   };
 }
 
@@ -479,15 +482,42 @@ export function classifyTicketResolution(
 // fetchTicketAssignee — the CTL-781 respect-assignment read: the ticket's
 // current assignee UUID (or null = unassigned), gateway-first so the hot
 // new-work predicate is rate-free, live `linearis issues read` on a miss.
-// Tri-state return so callers can distinguish "known unassigned" from
-// "couldn't read": { known: true, assignee: string|null } | { known: false }.
-// A not-removed descriptor is trusted regardless of age (the assignment gate
-// is rate-free by design; a stale miss is corrected by the future Reconciler).
-export function fetchTicketAssignee(identifier, { exec = defaultExec, gateway } = {}) {
+// CTL-1174: extends the return shape to include `delegate` when a gateway is
+// provided. Gateway hit: { known:true, assignee, delegate } (delegate coerced
+// undefined→null for pre-Phase-1 DBs). Gateway miss: live assignee read +
+// injected fetchDelegate (default fetchTicketDelegate) — a failed delegate read
+// returns { known:false } (HOLD) so an unknown delegate never triggers a
+// claim. Cost bound: fetchDelegate is NOT called when the assignee read fails.
+// When no gateway is provided the old { known, assignee } shape is returned
+// (back-compat for callers that do not wire the gateway, e.g. CLI tools).
+export function fetchTicketAssignee(
+  identifier,
+  { exec = defaultExec, gateway, fetchDelegate = fetchTicketDelegate } = {}
+) {
   if (gateway) {
     const d = gateway.getDescriptor(identifier);
-    if (d && !d.removed) return { known: true, assignee: d.assignee ?? null };
+    if (d && !d.removed) {
+      return {
+        known: true,
+        assignee: d.assignee ?? null,
+        delegate: d.delegate === undefined ? null : d.delegate,
+      };
+    }
+    // Gateway miss: live read for assignee, then delegate.
+    const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
+    if (code !== 0) return { known: false };
+    let assignee;
+    try {
+      const node = JSON.parse(stdout);
+      assignee = node?.assignee?.id ?? null;
+    } catch {
+      return { known: false };
+    }
+    const dr = fetchDelegate(identifier);
+    if (!dr.known) return { known: false };
+    return { known: true, assignee, delegate: dr.delegate ?? null };
   }
+  // No gateway: old behavior — live read only, no delegate (back-compat).
   const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
   if (code !== 0) return { known: false };
   try {
@@ -505,6 +535,18 @@ export function fetchTicketAssignee(identifier, { exec = defaultExec, gateway } 
 export function isAssigneeClaimable(assignee, botUserIds) {
   if (assignee == null) return true;
   return botUserIds instanceof Set && botUserIds.has(assignee);
+}
+
+// isClaimable — CTL-1174 delegate-aware claim predicate. A ticket is ours iff
+// BOTH the assignee and the delegate gates pass. Model: assignee = human
+// responsibility (back off); delegate = bot ownership (ours).
+//   claimable iff (assignee ∈ {null,bot}) AND (delegate ∈ {null,bot})
+// undefined delegate is coerced to null (back-compat: old {known,assignee}
+// shape from no-gateway callers treats absent delegate as "unset" = claimable).
+export function isClaimable(assignee, delegate, botUserIds) {
+  const d = delegate === undefined ? null : delegate;
+  const inBots = (id) => id == null || (botUserIds instanceof Set && botUserIds.has(id));
+  return isAssigneeClaimable(assignee, botUserIds) && inBots(d);
 }
 
 // CTL-1173: raw GraphQL read for Issue.delegate.id — Linear routes an app-user
@@ -567,11 +609,120 @@ export function fetchTicketDelegate(identifier, { runQuery = runDelegateOnce } =
   return { known: true, delegate: nodes[0]?.delegate?.id ?? null };
 }
 
+// CTL-1174: batched delegate fetch for the eligible-set enrichment path.
+// One GraphQL POST per ≤250-ticket chunk, team-scoped via team key + ticket
+// numbers. Mirrors the CTL-784 BATCH_QUERY / defaultBatchExec pattern.
+// Open Question #2: `number: { in: [...] }` is unverified — if unsupported,
+// exec returns null and the fail-safe collapses to an empty Map (AC#2 not met
+// but no crash, no churn). Confirm via the Phase 10 live-API check.
+const DELEGATE_BATCH_QUERY = `query CtlDelegateBatch($team: String!, $nums: [Float!]) {
+  issues(filter: { team: { key: { eq: $team } }, number: { in: $nums } }, first: ${BATCH_CHUNK_SIZE}) {
+    nodes { identifier delegate { id } }
+  }
+}`;
+
+// buildDelegateBatchCurlArgs — same curl argv skeleton as buildBatchCurlArgs;
+// payload uses team + numeric ticket numbers parsed from identifiers.
+export function buildDelegateBatchCurlArgs(team, identifiers, { token = "", ca } = {}) {
+  const nums = (identifiers ?? [])
+    .map((id) => { const m = /^([A-Za-z][A-Za-z0-9]*)-(\d+)$/.exec(id ?? ""); return m ? Number(m[2]) : null; })
+    .filter((n) => n !== null);
+  const payload = JSON.stringify({ query: DELEGATE_BATCH_QUERY, variables: { team, nums } });
+  const caArgs = ca && existsSync(ca) ? ["--cacert", ca] : [];
+  const args = [
+    "-sS",
+    "--max-time",
+    "30",
+    ...caArgs,
+    "-X",
+    "POST",
+    LINEAR_GRAPHQL_ENDPOINT,
+    "-H",
+    `Authorization: ${authHeader(token)}`,
+    "-H",
+    "Content-Type: application/json",
+    "-w",
+    "\n%{http_code}",
+    "--data",
+    "@-",
+  ];
+  return { args, payload };
+}
+
+function runDelegateBatchOnce(team, identifiers) {
+  const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
+  const { args, payload } = buildDelegateBatchCurlArgs(team, identifiers, {
+    token,
+    ca: process.env.NODE_EXTRA_CA_CERTS,
+  });
+  const res = spawnSync("curl", args, { input: payload, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+  if (res.status !== 0) {
+    return { nodes: null, auth: false, ratelimit: false, curlFailed: true };
+  }
+  const out = res.stdout ?? "";
+  const nl = out.lastIndexOf("\n");
+  const httpCode = Number(out.slice(nl + 1).trim());
+  const body = out.slice(0, Math.max(0, nl));
+  if (httpCode === 401) return { nodes: null, auth: true, ratelimit: false, curlFailed: false };
+  if (httpCode === 429) return { nodes: null, auth: false, ratelimit: true, curlFailed: false };
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return { nodes: null, auth: false, ratelimit: false, curlFailed: false };
+  }
+  if (parsed?.errors) {
+    const auth = isBatchAuthError(parsed.errors);
+    const ratelimit = !auth && isBatchRateLimited(parsed.errors);
+    return { nodes: null, auth, ratelimit, curlFailed: false };
+  }
+  return { nodes: parsed?.data?.issues?.nodes ?? [], auth: false, ratelimit: false, curlFailed: false };
+}
+
+// defaultDelegateBatchExec — CTL-1174. Clone of defaultBatchExec for the
+// delegate-batch path: same linearBreaker short-circuit, same auth-retry via
+// linearReminter, same 429 → recordRateLimited. Returns nodes[] or null.
+function defaultDelegateBatchExec(team, identifiers) {
+  if (linearBreaker.isOpen()) return null;
+  let r = runDelegateBatchOnce(team, identifiers);
+  if (r.auth && linearReminter.attempt()) r = runDelegateBatchOnce(team, identifiers);
+  if (r.ratelimit) { linearBreaker.recordRateLimited(); return null; }
+  if (r.nodes == null) return null;
+  linearBreaker.recordSuccess();
+  return r.nodes;
+}
+
+// fetchTicketsDelegateBatch — CTL-1174. Resolve `delegate.id` for a set of
+// identifiers in one or more batched GraphQL POSTs. Returns
+// Map<identifier, string|null>. Absent (not returned) ids are NOT in the Map
+// so callers can distinguish "no delegate found" from "delegate is null".
+// Fail-safe: a null chunk result keeps those ids absent; never throws.
+export function fetchTicketsDelegateBatch(team, identifiers, { exec = defaultDelegateBatchExec } = {}) {
+  const ids = [...new Set((identifiers ?? []).filter(Boolean))];
+  const result = new Map();
+  if (!team || ids.length === 0) return result;
+  for (let i = 0; i < ids.length; i += BATCH_CHUNK_SIZE) {
+    const chunk = ids.slice(i, i + BATCH_CHUNK_SIZE);
+    const nodes = exec(team, chunk);
+    if (!nodes) continue; // fail-safe: these ids stay absent from the Map
+    for (const node of nodes) {
+      if (node?.identifier) {
+        result.set(node.identifier, node.delegate?.id ?? null);
+      }
+    }
+  }
+  return result;
+}
+
 // runEligibleQuery — run the query, parse + normalize, apply the priority
 // floor. A non-zero linearis exit THROWS (never a silent []): a silent empty
 // would let one failed poll flatten a project's eligible set to zero. The
 // caller (Phase 4 reconcile) catches the throw and preserves the prior set.
-export function runEligibleQuery(query, { exec = defaultExec } = {}) {
+// CTL-1174: `delegateExec` is the exec seam for the best-effort delegate
+// batch enrichment. Wrapped in try/catch so a delegate hiccup never blocks
+// the state/priority/relations refresh. An absent key (batch miss) leaves
+// the ticket's delegate field unset; `?? null` in contentKey collapses it.
+export function runEligibleQuery(query, { exec = defaultExec, delegateExec = defaultDelegateBatchExec } = {}) {
   const { code, stdout, stderr } = exec("linearis", buildLinearisArgs(query));
   if (code !== 0) {
     throw new Error(`linearis issues list failed (exit ${code}): ${(stderr || "").trim()}`);
@@ -587,6 +738,23 @@ export function runEligibleQuery(query, { exec = defaultExec } = {}) {
   // (1=Urgent … 4=Low). 0 ("No priority") is always below any floor.
   if (query.priority != null) {
     tickets = tickets.filter((t) => t.priority >= 1 && t.priority <= query.priority);
+  }
+  // CTL-1174: best-effort delegate enrichment from a single batched GraphQL POST.
+  // Never throws — a delegate hiccup must not block the state/priority refresh.
+  if (tickets.length > 0) {
+    try {
+      const dmap = fetchTicketsDelegateBatch(
+        query.team,
+        tickets.map((t) => t.identifier),
+        { exec: delegateExec }
+      );
+      for (const t of tickets) {
+        const d = dmap.get(t.identifier);
+        if (d !== undefined) t.delegate = d;
+      }
+    } catch {
+      /* best-effort: a delegate hiccup never blocks the state/priority/relations refresh */
+    }
   }
   return tickets;
 }

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -17,8 +17,11 @@ import {
   classifyTicketResolution,
   fetchTicketAssignee,
   isAssigneeClaimable,
+  isClaimable,
   buildDelegateCurlArgs,
   fetchTicketDelegate,
+  buildDelegateBatchCurlArgs,
+  fetchTicketsDelegateBatch,
 } from "./linear-query.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 
@@ -1018,35 +1021,40 @@ describe("fetchTicketState — gateway state-freshness boundary (CTL-823)", () =
 describe("fetchTicketAssignee (CTL-781)", () => {
   const BOT = "ff78d890-7906-4c22-b2f5-020bd150c790";
 
-  test("gateway descriptor present + !removed → {known:true, assignee:<uuid>}, zero exec", () => {
+  test("gateway descriptor present + !removed → {known:true, assignee:<uuid>, delegate:null}, zero exec", () => {
     const exec = fakeExec({ code: 0, stdout: "{}" });
+    // CTL-1174: gateway hit now returns delegate from descriptor (undefined→null for pre-Phase-1 DBs)
     const gateway = fakeGateway({ ticket: "CTL-1", assignee: BOT, removed: false, updatedAt: FRESH() });
     const r = fetchTicketAssignee("CTL-1", { exec, gateway });
-    expect(r).toEqual({ known: true, assignee: BOT });
+    expect(r).toEqual({ known: true, assignee: BOT, delegate: null });
     expect(exec.calls.length).toBe(0);
   });
 
-  test("gateway descriptor present with assignee null → {known:true, assignee:null}, zero exec", () => {
+  test("gateway descriptor present with assignee null → {known:true, assignee:null, delegate:null}, zero exec", () => {
     const exec = fakeExec({ code: 0, stdout: "{}" });
     const gateway = fakeGateway({ ticket: "CTL-2", assignee: null, removed: false, updatedAt: FRESH() });
     const r = fetchTicketAssignee("CTL-2", { exec, gateway });
-    expect(r).toEqual({ known: true, assignee: null });
+    expect(r).toEqual({ known: true, assignee: null, delegate: null });
     expect(exec.calls.length).toBe(0);
   });
 
-  test("gateway descriptor removed → falls through to live read", () => {
+  test("gateway descriptor removed → falls through to live read (CTL-1174: injects fetchDelegate)", () => {
     const exec = fakeExec({ code: 0, stdout: JSON.stringify({ assignee: { id: BOT } }) });
     const gateway = fakeGateway({ ticket: "CTL-3", assignee: BOT, removed: true, updatedAt: FRESH() });
-    const r = fetchTicketAssignee("CTL-3", { exec, gateway });
-    expect(r).toEqual({ known: true, assignee: BOT });
+    // CTL-1174: gateway miss now also fetches delegate; inject to avoid real curl
+    const fetchDelegate = () => ({ known: true, delegate: null });
+    const r = fetchTicketAssignee("CTL-3", { exec, gateway, fetchDelegate });
+    expect(r).toEqual({ known: true, assignee: BOT, delegate: null });
     expect(exec.calls.length).toBe(1);
   });
 
-  test("gateway absent/miss (getDescriptor null) → live read parses assignee.id", () => {
+  test("gateway absent/miss (getDescriptor null) → live read parses assignee.id (CTL-1174: injects fetchDelegate)", () => {
     const exec = fakeExec({ code: 0, stdout: JSON.stringify({ assignee: { id: BOT } }) });
     const gateway = fakeGateway(null);
-    const r = fetchTicketAssignee("CTL-4", { exec, gateway });
-    expect(r).toEqual({ known: true, assignee: BOT });
+    // CTL-1174: gateway miss now also fetches delegate; inject to avoid real curl
+    const fetchDelegate = () => ({ known: true, delegate: null });
+    const r = fetchTicketAssignee("CTL-4", { exec, gateway, fetchDelegate });
+    expect(r).toEqual({ known: true, assignee: BOT, delegate: null });
     expect(exec.calls.length).toBe(1);
   });
 
@@ -1153,5 +1161,190 @@ describe("fetchTicketDelegate (CTL-1173)", () => {
   test("empty nodes array → { known:true, delegate:null }", () => {
     const runQuery = () => ({ nodes: [] });
     expect(fetchTicketDelegate("CTL-1", { runQuery })).toEqual({ known: true, delegate: null });
+  });
+});
+
+// ── isClaimable (CTL-1174) ────────────────────────────────────────────────────
+
+describe("isClaimable (CTL-1174)", () => {
+  const BOT = "bot-uuid-ff78d890";
+  const HUMAN = "human-uuid-abcd1234";
+  const bots = new Set([BOT]);
+
+  test("(null, null, botSet) → true: unassigned + undelegated is always claimable", () => {
+    expect(isClaimable(null, null, bots)).toBe(true);
+  });
+
+  test("(null, null, empty Set) → true: no bots registered, no foreign owner", () => {
+    expect(isClaimable(null, null, new Set())).toBe(true);
+  });
+
+  test("(null, null, undefined) → true: no botUserIds at all", () => {
+    expect(isClaimable(null, null, undefined)).toBe(true);
+  });
+
+  test("(null, BOT, botSet) → true: our bot holds the delegate slot", () => {
+    expect(isClaimable(null, BOT, bots)).toBe(true);
+  });
+
+  test("(null, 'foreign', botSet) → false: foreign delegate blocks the claim (AC#1)", () => {
+    expect(isClaimable(null, "foreign-uuid-xyz", bots)).toBe(false);
+  });
+
+  test("(BOT, BOT, botSet) → true: bot owns both assignee and delegate", () => {
+    expect(isClaimable(BOT, BOT, bots)).toBe(true);
+  });
+
+  test("(HUMAN, null, botSet) → false: human assignee always blocks regardless of delegate", () => {
+    expect(isClaimable(HUMAN, null, bots)).toBe(false);
+  });
+
+  test("(HUMAN, BOT, botSet) → false: human assignee wins even with our bot delegate", () => {
+    expect(isClaimable(HUMAN, BOT, bots)).toBe(false);
+  });
+
+  test("(null, undefined, botSet) → true: undefined coerced to null (back-compat no-gateway shape)", () => {
+    expect(isClaimable(null, undefined, bots)).toBe(true);
+  });
+
+  test("(BOT, undefined, botSet) → true: undefined coerced to null, bot assignee passes", () => {
+    expect(isClaimable(BOT, undefined, bots)).toBe(true);
+  });
+});
+
+// ── buildDelegateBatchCurlArgs (CTL-1174) ────────────────────────────────────
+
+describe("buildDelegateBatchCurlArgs (CTL-1174)", () => {
+  test("POSTs to the GraphQL endpoint", () => {
+    const { args } = buildDelegateBatchCurlArgs("CTL", ["CTL-1"], { token: "lin_oauth_x" });
+    expect(args).toContain("https://api.linear.app/graphql");
+    expect(args[args.indexOf("-X") + 1]).toBe("POST");
+  });
+
+  test("reads payload from stdin (--data @-)", () => {
+    const { args } = buildDelegateBatchCurlArgs("CTL", ["CTL-1"], { token: "lin_oauth_x" });
+    expect(args[args.indexOf("--data") + 1]).toBe("@-");
+  });
+
+  test("variables include team and parsed ticket numbers", () => {
+    const { payload } = buildDelegateBatchCurlArgs("CTL", ["CTL-1", "CTL-42"], { token: "lin_oauth_x" });
+    const vars = JSON.parse(payload).variables;
+    expect(vars.team).toBe("CTL");
+    expect(vars.nums).toEqual([1, 42]);
+  });
+
+  test("query projects identifier and delegate fields", () => {
+    const { payload } = buildDelegateBatchCurlArgs("CTL", ["CTL-1"], { token: "lin_oauth_x" });
+    const q = JSON.parse(payload).query;
+    expect(q).toContain("identifier");
+    expect(q).toContain("delegate");
+  });
+
+  test("malformed identifiers are excluded from nums (not NaN)", () => {
+    const { payload } = buildDelegateBatchCurlArgs("CTL", ["CTL-1", "NOTANID"], { token: "tok" });
+    const vars = JSON.parse(payload).variables;
+    expect(vars.nums).toEqual([1]);
+  });
+});
+
+// ── fetchTicketsDelegateBatch (CTL-1174) ─────────────────────────────────────
+
+describe("fetchTicketsDelegateBatch (CTL-1174)", () => {
+  const BOT = "bot-uuid-ff78d890";
+
+  test("empty identifiers → empty Map, exec NOT called", () => {
+    const calls = [];
+    const exec = (...a) => { calls.push(a); return []; };
+    const result = fetchTicketsDelegateBatch("CTL", [], { exec });
+    expect(result.size).toBe(0);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("null team → empty Map, exec NOT called", () => {
+    const calls = [];
+    const exec = (...a) => { calls.push(a); return []; };
+    const result = fetchTicketsDelegateBatch(null, ["CTL-1"], { exec });
+    expect(result.size).toBe(0);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("nodes with delegate id → Map<identifier, delegateId>", () => {
+    const exec = () => [
+      { identifier: "CTL-1", delegate: { id: BOT } },
+      { identifier: "CTL-2", delegate: null },
+    ];
+    const result = fetchTicketsDelegateBatch("CTL", ["CTL-1", "CTL-2"], { exec });
+    expect(result.get("CTL-1")).toBe(BOT);
+    expect(result.get("CTL-2")).toBeNull();
+  });
+
+  test("exec returns null → fail-safe empty Map (no crash)", () => {
+    const exec = () => null;
+    expect(() => fetchTicketsDelegateBatch("CTL", ["CTL-1"], { exec })).not.toThrow();
+    expect(fetchTicketsDelegateBatch("CTL", ["CTL-1"], { exec }).size).toBe(0);
+  });
+
+  test("deduplicates identifiers before passing to exec", () => {
+    const calls = [];
+    const exec = (team, ids) => { calls.push(ids.slice()); return []; };
+    fetchTicketsDelegateBatch("CTL", ["CTL-1", "CTL-1", "CTL-2"], { exec });
+    expect(calls[0]).toHaveLength(2);
+    expect(calls[0]).toContain("CTL-1");
+    expect(calls[0]).toContain("CTL-2");
+  });
+
+  test("absent id from exec result stays absent from Map (not mapped to null)", () => {
+    const exec = () => [{ identifier: "CTL-1", delegate: { id: BOT } }];
+    const result = fetchTicketsDelegateBatch("CTL", ["CTL-1", "CTL-2"], { exec });
+    expect(result.has("CTL-1")).toBe(true);
+    expect(result.has("CTL-2")).toBe(false);
+  });
+});
+
+// ── runEligibleQuery — delegate enrichment (CTL-1174) ─────────────────────────
+
+describe("runEligibleQuery — delegate enrichment (CTL-1174)", () => {
+  const query = { team: "CTL", status: "Todo", project: null, label: null, priority: null };
+  const BOT = "bot-uuid-ff78d890";
+
+  test("normalizeTicket defaults delegate to null when linearis omits it", () => {
+    const exec = fakeExec({ stdout: ticketsJson([{ identifier: "CTL-1", state: { name: "Todo" } }]) });
+    // delegateExec miss → null → delegate stays null
+    const delegateExec = () => null;
+    const tickets = runEligibleQuery(query, { exec, delegateExec });
+    expect(tickets[0].delegate).toBeNull();
+  });
+
+  test("delegate hydrated from batch when id returned", () => {
+    const exec = fakeExec({ stdout: ticketsJson([{ identifier: "CTL-1", state: { name: "Todo" } }]) });
+    const delegateExec = () => [{ identifier: "CTL-1", delegate: { id: BOT } }];
+    const tickets = runEligibleQuery(query, { exec, delegateExec });
+    expect(tickets[0].delegate).toBe(BOT);
+  });
+
+  test("delegate null when batch returns node with null delegate (explicit clear)", () => {
+    const exec = fakeExec({ stdout: ticketsJson([{ identifier: "CTL-1", state: { name: "Todo" } }]) });
+    const delegateExec = () => [{ identifier: "CTL-1", delegate: null }];
+    const tickets = runEligibleQuery(query, { exec, delegateExec });
+    expect(tickets[0].delegate).toBeNull();
+  });
+
+  test("batch failure → delegate stays null, no throw (best-effort fail-safe)", () => {
+    const exec = fakeExec({ stdout: ticketsJson([{ identifier: "CTL-1", state: { name: "Todo" } }]) });
+    const delegateExec = () => { throw new Error("network failure"); };
+    let tickets;
+    expect(() => { tickets = runEligibleQuery(query, { exec, delegateExec }); }).not.toThrow();
+    expect(tickets[0].delegate).toBeNull();
+  });
+
+  test("skips delegate batch entirely when zero tickets survive priority floor", () => {
+    // priority: 4 (Low) tickets filtered by floor 2 → 0 survive → no batch call
+    const exec = fakeExec({
+      stdout: ticketsJson([{ identifier: "CTL-1", state: { name: "Todo" }, priority: 4 }]),
+    });
+    const calls = [];
+    const delegateExec = (...a) => { calls.push(a); return null; };
+    runEligibleQuery({ ...query, priority: 2 }, { exec, delegateExec });
+    expect(calls).toHaveLength(0);
   });
 });

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -41,7 +41,13 @@ import {
 import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
 import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS
 import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry.mjs";
-import { runEligibleQuery, fetchTicketAssignee, isAssigneeClaimable } from "./linear-query.mjs";
+import {
+  runEligibleQuery,
+  fetchTicketAssignee,
+  isAssigneeClaimable,
+  isClaimable,
+  fetchTicketsDelegateBatch,
+} from "./linear-query.mjs";
 import {
   setProjectEligible,
   removeTicket,
@@ -131,6 +137,14 @@ export function parseIssueUpdatedEvent(event) {
     descriptionChanged: payload.descriptionChanged === true, // CTL-749
     actorId: payload.actorId ?? null, // CTL-749
     actorName: payload.actorName ?? null, // CTL-749
+    // CTL-1174: delegate tri-state (KEY-PRESENCE mirrors toEstimate).
+    // string → bot UUID set; null → explicitly cleared; undefined → absent (keep).
+    toDelegate:
+      typeof payload.toDelegateId === "string"
+        ? payload.toDelegateId
+        : "toDelegateId" in payload
+          ? null
+          : undefined,
   };
 }
 
@@ -197,6 +211,9 @@ export function handleIssueUpdatedEvent(
       // CTL-957: forward estimate into the eligible projection when present
       // (undefined = absent from payload = keep stored value).
       if (parsed.toEstimate !== undefined) upd.estimate = parsed.toEstimate;
+      // CTL-1174: forward delegate into the eligible projection when present
+      // (undefined = absent from payload = keep stored value).
+      if (parsed.toDelegate !== undefined) upd.delegate = parsed.toDelegate;
       upsertTicket(query.team, upd);
     } else {
       removeTicket(query.team, parsed.identifier);
@@ -251,7 +268,7 @@ const knownProjects = new Set();
 // `monitor.reconcile.failing.<TEAM>` event onto the unified event log so the
 // orch-monitor dashboard surfaces the silently-starving team, and a recovering
 // poll clears the alert. `appendHealthEvent` is an injectable test seam.
-export function reconcileProject(team, { exec, appendHealthEvent } = {}) {
+export function reconcileProject(team, { exec, delegateExec, appendHealthEvent } = {}) {
   const entry = getProjectConfig(team);
   if (!entry) {
     log.warn({ team }, "reconcile: no registry entry for team — skipping");
@@ -260,7 +277,7 @@ export function reconcileProject(team, { exec, appendHealthEvent } = {}) {
   const query = resolveEligibleQuery(entry);
   let tickets;
   try {
-    tickets = runEligibleQuery(query, { exec });
+    tickets = runEligibleQuery(query, { exec, delegateExec });
   } catch (err) {
     log.error({ team, err: err.message }, "reconcile poll failed — preserving prior eligible set");
     // CTL-867: escalate persistent failures beyond the buried log line.
@@ -295,10 +312,10 @@ export function reconcileProject(team, { exec, appendHealthEvent } = {}) {
 // reconcileAll — full reconcile of every registered team (the missed-webhook
 // backstop). Re-reads registry.json each call so a team added to the registry
 // is picked up and one removed is dropped within one tick.
-export function reconcileAll({ exec, appendHealthEvent } = {}) {
+export function reconcileAll({ exec, delegateExec, appendHealthEvent } = {}) {
   const projects = listProjects();
   const seen = new Set(projects.map((p) => p.team));
-  for (const p of projects) reconcileProject(p.team, { exec, appendHealthEvent });
+  for (const p of projects) reconcileProject(p.team, { exec, delegateExec, appendHealthEvent });
   for (const stale of knownProjects) {
     if (!seen.has(stale)) {
       dropProject(stale);
@@ -593,16 +610,22 @@ function dispatchTriage(
     );
     return false;
   }
-  // CTL-781: respect-assignment gate — a →Triage/→Todo ticket assigned to a
-  // non-bot is a human's; never claim it. Gateway-first, live read on miss;
-  // unknown holds (sweepMissingTriage retries next reconcile). Empty/absent
-  // botUserIds disables the gate (CTL-749 fail-open convention).
+  // CTL-781/CTL-1174: respect-assignment + delegate gate. A →Triage/→Todo
+  // ticket assigned to a human, or delegated to a non-bot, is not ours.
+  // Gateway-first, live read on miss; unknown holds (sweepMissingTriage
+  // retries next reconcile). Empty/absent botUserIds disables the gate
+  // (CTL-749 fail-open convention).
   if (botUserIds instanceof Set && botUserIds.size > 0) {
     const a = fetchAssignee(identifier, { gateway });
-    if (!a.known || !isAssigneeClaimable(a.assignee, botUserIds)) {
+    if (!a.known || !isClaimable(a.assignee, a.delegate, botUserIds)) {
       log.info(
-        { identifier, known: a.known, assignee: a.known ? (a.assignee ?? null) : undefined },
-        "monitor: triage dispatch skipped — respect-assignment (CTL-781)"
+        {
+          identifier,
+          known: a.known,
+          assignee: a.known ? (a.assignee ?? null) : undefined,
+          delegate: a.known ? (a.delegate ?? null) : undefined,
+        },
+        "monitor: triage dispatch skipped — respect-assignment/delegate (CTL-1174)"
       );
       return false;
     }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -69,6 +69,7 @@ import {
   classifyTicketResolution,
   fetchTicketAssignee,
   isAssigneeClaimable,
+  isClaimable,
   readTicketLabels,
 } from "./linear-query.mjs";
 import { gatewayLabelsHit } from "./gateway-read.mjs"; // CTL-1079
@@ -4523,24 +4524,25 @@ export function schedulerTick(
     // CTL-671: circuit breaker — stop re-dispatching a new-work ticket that has
     // failed its entry-phase dispatch THRESHOLD times in a row.
     if (maybeTripCircuitBreaker(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE)) continue;
-    // CTL-781: respect-assignment gate — claim only assignee ∈ {null, bot}.
-    // Gateway-first (rate-free); live read only on a miss. An unreadable
-    // assignee HOLDS the candidate this tick (fail-safe) — it is not a dispatch
-    // failure, so no cooldown marker and no failure event. Empty/absent
-    // botUserIds disables the gate (CTL-749 fail-open convention).
+    // CTL-781/CTL-1174: respect-assignment + delegate gate.
+    // Claim only when assignee ∈ {null,bot} AND delegate ∈ {null,bot}.
+    // Gateway-first (rate-free); live read on a miss. An unreadable
+    // assignee or delegate HOLDS the candidate this tick (fail-safe) — no
+    // cooldown marker, no failure event. Empty/absent botUserIds disables
+    // the gate (CTL-749 fail-open convention).
     if (botUserIds instanceof Set && botUserIds.size > 0) {
       const a = fetchAssignee(t.identifier, { gateway, exec });
       if (!a.known) {
         log.debug(
           { ticket: t.identifier },
-          "ctl-781: assignee unreadable — holding candidate this tick"
+          "ctl-781: assignee/delegate unreadable — holding candidate this tick"
         );
         continue;
       }
-      if (!isAssigneeClaimable(a.assignee, botUserIds)) {
+      if (!isClaimable(a.assignee, a.delegate, botUserIds)) {
         log.debug(
-          { ticket: t.identifier, assignee: a.assignee },
-          "ctl-781: candidate assigned to a non-bot — skipping (respect-assignment)"
+          { ticket: t.identifier, assignee: a.assignee, delegate: a.delegate },
+          "ctl-1174: candidate not claimable (assignee/delegate respect-gate) — skipping"
         );
         continue;
       }

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
@@ -777,3 +777,100 @@ describe("parseLinearWebhookEvent — issueCommentMention", () => {
     expect(result.kind).toBe("ignored");
   });
 });
+
+// ── CTL-1174: toDelegateId extraction + delegate_changed topic ────────────────
+
+describe("parseLinearWebhookEvent — Issue toDelegateId (CTL-1174)", () => {
+  const BOT = "bot-uuid-ff78d890";
+
+  it("extracts toDelegateId from data.delegate.id when present", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        updatedFrom: { delegateId: "old-delegate" },
+        data: {
+          id: "i1",
+          identifier: "CTL-210",
+          team: { key: "CTL" },
+          delegate: { id: BOT },
+        },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.toDelegateId).toBe(BOT);
+  });
+
+  it("toDelegateId is undefined when data.delegate key is absent (KEY-PRESENCE: keep stored value)", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({ updatedFrom: { stateId: "old-state" } })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.toDelegateId).toBeUndefined();
+  });
+
+  it("toDelegateId is null when data.delegate key is present but null (explicit clear)", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        updatedFrom: { delegateId: "old-delegate" },
+        data: {
+          id: "i1",
+          identifier: "CTL-210",
+          team: { key: "CTL" },
+          delegate: null,
+        },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.toDelegateId).toBeNull();
+  });
+
+  it("updatedFrom.delegateId → topic 'linear.issue.delegate_changed'", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        updatedFrom: { delegateId: "old-delegate" },
+        data: { id: "i1", identifier: "CTL-210", team: { key: "CTL" }, delegate: { id: BOT } },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.topic).toBe("linear.issue.delegate_changed");
+  });
+
+  it("delegate_changed is lower priority than assignee_changed", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        updatedFrom: { assigneeId: "old-user", delegateId: "old-delegate" },
+        data: {
+          id: "i1",
+          identifier: "CTL-210",
+          team: { key: "CTL" },
+          assignee: { id: "new-user", name: "Alice" },
+          delegate: { id: BOT },
+        },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.topic).toBe("linear.issue.assignee_changed");
+  });
+
+  it("assignee-only webhook leaves toDelegateId undefined (real-world safety: no fabricated clear)", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        updatedFrom: { assigneeId: "old-user" },
+        data: {
+          id: "i1",
+          identifier: "CTL-210",
+          team: { key: "CTL" },
+          assignee: { id: "new-user", name: "Alice" },
+        },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.toDelegateId).toBeUndefined();
+    expect(ev.topic).toBe("linear.issue.assignee_changed");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
@@ -1157,3 +1157,61 @@ describe("buildLinearEventLogEnvelope — agent_session and mention", () => {
     expect(env).toBeNull();
   });
 });
+
+// ── CTL-1174: toDelegateId forwarded in body.payload ─────────────────────────
+
+describe("buildLinearEventLogEnvelope — toDelegateId (CTL-1174)", () => {
+  const BOT = "bot-uuid-ff78d890";
+
+  function delegateIssueEvent(
+    toDelegateId: string | null | undefined
+  ): Parameters<typeof buildLinearEventLogEnvelope>[0] {
+    return {
+      kind: "issue" as const,
+      action: "update" as const,
+      topic: "linear.issue.delegate_changed",
+      ticket: "CTL-1174",
+      teamKey: "CTL",
+      data: {},
+      updatedFromKeys: ["delegateId"],
+      issueId: null,
+      actorId: null,
+      actorName: null,
+      toState: null,
+      toPriority: null,
+      toAssigneeId: null,
+      toAssigneeName: null,
+      toLabels: null,
+      toProject: null,
+      toProjectId: null,
+      previousFromValues: {},
+      description: null,
+      descriptionChanged: false,
+      toDelegateId,
+    };
+  }
+
+  it("toDelegateId: BOT → forwarded as non-null in body.payload", () => {
+    const env = buildLinearEventLogEnvelope(delegateIssueEvent(BOT), TS);
+    expect(env).not.toBeNull();
+    const payload = env!.body.payload as Record<string, unknown>;
+    expect(payload.toDelegateId).toBe(BOT);
+  });
+
+  it("toDelegateId: null → serializes as null in body.payload (explicit clear)", () => {
+    const env = buildLinearEventLogEnvelope(delegateIssueEvent(null), TS);
+    expect(env).not.toBeNull();
+    const payload = env!.body.payload as Record<string, unknown>;
+    expect(payload.toDelegateId).toBeNull();
+    expect("toDelegateId" in payload).toBe(true);
+  });
+
+  it("toDelegateId: undefined → key DROPPED from body.payload JSON (key-presence: fold keeps stored value)", () => {
+    const env = buildLinearEventLogEnvelope(delegateIssueEvent(undefined), TS);
+    expect(env).not.toBeNull();
+    // undefined serializes as absent in JSON — check via round-trip, as the broker fold
+    // reads from the event log (JSON), not the in-memory JS object.
+    const jsonPayload = JSON.parse(JSON.stringify(env!.body.payload)) as Record<string, unknown>;
+    expect("toDelegateId" in jsonPayload).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/ticket-detail-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ticket-detail-reader.test.ts
@@ -32,6 +32,7 @@ function descriptor(partial: Partial<TicketDescriptor>): TicketDescriptor {
     fencePhase: partial.fencePhase ?? null,
     claimedAt: partial.claimedAt ?? null,
     heldSince: partial.heldSince ?? null,
+    delegate: partial.delegate ?? null, // CTL-1174
     updatedAt: partial.updatedAt ?? "2026-06-08T12:00:00.000Z",
   };
 }

--- a/plugins/dev/scripts/orch-monitor/__tests__/ticket-search-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ticket-search-reader.test.ts
@@ -30,6 +30,7 @@ function descriptor(partial: Partial<TicketDescriptor>): TicketDescriptor {
     fencePhase: null,
     claimedAt: null,
     heldSince: null,
+    delegate: null, // CTL-1174
     updatedAt: "2026-06-08T12:00:00.000Z",
   };
 }

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
@@ -81,6 +81,15 @@ export type LinearWebhookEvent =
        * in the webhook payload — KEY-PRESENCE: absent → keep stored value. CTL-957.
        */
       toEstimate?: number | null;
+      /**
+       * CTL-1174: Current delegate UUID from data.delegate.id. undefined when the
+       * `delegate` key is absent from the payload (KEY-PRESENCE: absent → keep);
+       * null when the key is present but cleared (explicit un-delegate). DEFENSIVE:
+       * Linear does NOT reliably carry delegate in Issue webhooks (routes to
+       * AgentSessionEvent) — this field is dormant scaffolding that activates if
+       * Linear ever surfaces it.
+       */
+      toDelegateId?: string | null;
     }
   | {
       kind: "comment";
@@ -161,7 +170,10 @@ function actionLabel(value: unknown): string {
  * Pick the topic for an Issue event based on action and (for updates) the
  * fields changed in updatedFrom.
  *
- * Priority for updates: state > priority > assignee > generic.
+ * Priority for updates: state > priority > assignee > delegate > generic.
+ * CTL-1174: delegate_changed is lower priority than assignee. The exact
+ * updatedFrom key Linear uses for delegate is unverified ("delegateId" is the
+ * likely key by analogy with "assigneeId"); we check both spellings defensively.
  */
 function issueTopic(action: "create" | "update" | "remove", updatedFromKeys: string[]): string {
   if (action === "create") return "linear.issue.created";
@@ -169,6 +181,9 @@ function issueTopic(action: "create" | "update" | "remove", updatedFromKeys: str
   if (updatedFromKeys.includes("stateId")) return "linear.issue.state_changed";
   if (updatedFromKeys.includes("priority")) return "linear.issue.priority_changed";
   if (updatedFromKeys.includes("assigneeId")) return "linear.issue.assignee_changed";
+  if (updatedFromKeys.includes("delegateId") || updatedFromKeys.includes("delegate")) {
+    return "linear.issue.delegate_changed";
+  }
   return "linear.issue.updated";
 }
 
@@ -214,6 +229,14 @@ function parseIssue(payload: Record<string, unknown>): LinearWebhookEvent {
   const toEstimate = "estimate" in data
     ? (typeof data.estimate === "number" ? data.estimate : null)
     : undefined; // absent → keep stored value
+  // CTL-1174: delegate UUID — KEY-PRESENCE so the broker fold can distinguish
+  // "payload said nothing about delegate" (absent key → keep) from "delegate
+  // was explicitly cleared" (key present, value null). DEFENSIVE: Linear does
+  // NOT reliably emit delegate in Issue webhooks; this is dormant scaffolding.
+  const delegateObj = isObject(data.delegate) ? data.delegate : null;
+  const toDelegateId = "delegate" in data
+    ? (delegateObj !== null ? getOptStr(delegateObj, "id") : null)
+    : undefined; // absent → key-presence KEEP
   return {
     kind: "issue",
     action,
@@ -236,6 +259,7 @@ function parseIssue(payload: Record<string, unknown>): LinearWebhookEvent {
     description,
     descriptionChanged,
     toEstimate,
+    toDelegateId,
   };
 }
 

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
@@ -158,6 +158,7 @@ export function buildLinearEventLogEnvelope(
           description: event.description,           // CTL-749
           descriptionChanged: event.descriptionChanged, // CTL-749
           toEstimate: event.toEstimate,            // CTL-957
+          toDelegateId: event.toDelegateId,        // CTL-1174 (undefined drops key from JSON)
         },
       });
     }


### PR DESCRIPTION
## Summary

- **Arc A (broker cache)**: `delegate TEXT` column in broker SQLite; `TicketDescriptor` type extended; `getDescriptor` projection and router `foldLinearIssueDescriptor` fold it with KEY-PRESENCE semantics.
- **Arc B (claim gate)**: `fetchTicketAssignee` now returns `{known, assignee, delegate}` (gateway-first, live fallback via injected `fetchTicketDelegate`); new `isClaimable(assignee, delegate, botUserIds)` = AND of both fields; scheduler + monitor dispatch gate upgraded.
- **Arc C (eligible-set)**: `contentKey` gains 7th slot (`delegate ?? null`) — a delegate-only change now triggers a projection rewrite; `runEligibleQuery` does best-effort batch delegate enrichment via `fetchTicketsDelegateBatch`.
- **Webhook scaffolding**: `toDelegateId?` (KEY-PRESENCE) in `LinearWebhookEvent`; `delegate_changed` topic; handler forwards `toDelegateId` with undefined→absent-from-JSON semantics.

**⚠️ HUMAN-REVIEW-GATE — do NOT auto-merge. High blast radius: modifies the daemon's new-work pull + triage claim gate.**

## Test plan

- [x] `cd plugins/dev/scripts/execution-core && bun test linear-query.test.mjs eligible-set.test.mjs` — 167 pass, 0 fail
- [x] `cd plugins/dev/scripts/orch-monitor && bun test __tests__/linear-webhook-events.test.ts __tests__/linear-webhook-handler.test.ts __tests__/ticket-detail-reader.test.ts __tests__/ticket-search-reader.test.ts` — 141 pass, 0 fail
- [x] `bunx tsc --noEmit` — 0 errors in `lib/` and `__tests__/`; 6 pre-existing errors in `ui/src/` (missing optional deps, unrelated)
- [x] Pre-existing test failures verified as environmental (port-7400 EADDRINUSE, UI build, pino) — not caused by this diff
- [ ] Live API validation: confirm `number:{in:[...]}` filter works in DELEGATE_BATCH_QUERY (Phase 10 open question)

🤖 Generated with [Claude Code](https://claude.com/claude-code)