### PR TITLE
CTL-1187: Operator cluster config mirror contract + quota field-name reference

### DIFF
--- a/plugins/dev/scripts/execution-core/config-mirror-xref.test.sh
+++ b/plugins/dev/scripts/execution-core/config-mirror-xref.test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# config-mirror-xref.test.sh — CTL-1187. Asserts discoverability + §8 correction.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+RESEARCH="${REPO_ROOT}/thoughts/shared/research/2026-06-15-multi-node-cluster-setup.md"
+REMOTE="${REPO_ROOT}/website/src/content/docs/getting-started/remote-and-unattended-hosts.md"
+PASSES=0; FAILURES=0
+pass(){ echo "  PASS: $1"; (( PASSES++ )) || true; }
+fail(){ echo "  FAIL: $1"; (( FAILURES++ )) || true; }
+
+# (a) §8 of prior research carries a correction pointing readers at the canonical page
+grep -qiE "CTL-1187|cluster-config-mirror|correction" "$RESEARCH" \
+  && pass "research §8 correction note present" || fail "research §8 correction missing"
+grep -qiE "bot.*OAuth.*(SHARED|machine-global)" "$RESEARCH" \
+  && pass "research notes bot OAuth is SHARED/machine-global" || fail "bot OAuth correction text missing"
+
+# (b) remote-hosts getting-started page links to the canonical reference
+grep -qF "cluster-config-mirror" "$REMOTE" \
+  && pass "remote-hosts page links to canonical reference" || fail "remote-hosts link missing"
+
+echo "── ${PASSES} passed, ${FAILURES} failed ──"
+[[ "$FAILURES" -eq 0 ]]

--- a/plugins/dev/scripts/execution-core/quota-field-doc-drift.test.sh
+++ b/plugins/dev/scripts/execution-core/quota-field-doc-drift.test.sh
@@ -26,7 +26,7 @@ done
 # Exclude ratelimit.sampled — it appears as a suffix of the event NAME
 # "account.ratelimit.sampled", not as an emitted attribute key.
 for d in $(grep -oE 'ratelimit\.[a-z_]+' "$DOC" | grep -v '^ratelimit\.sampled$' | sort -u); do
-  grep -qF "$d" <<<"$KEYS" && pass "doc key $d backed by source" || fail "doc invents key $d"
+  grep -qxF "$d" <<<"$KEYS" && pass "doc key $d backed by source" || fail "doc invents key $d"
 done
 
 # (d) event name + binding-limit + camelCase-internal note documented

--- a/plugins/dev/scripts/execution-core/quota-field-doc-drift.test.sh
+++ b/plugins/dev/scripts/execution-core/quota-field-doc-drift.test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# quota-field-doc-drift.test.sh — CTL-1187. Asserts the canonical reference page
+# documents EXACTLY the quota field names emitted by ratelimit-event.mjs, and
+# carries the config-mirror contract + corrected bot-OAuth classification.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SRC="${SCRIPT_DIR}/ratelimit-event.mjs"
+DOC="${REPO_ROOT}/website/src/content/docs/reference/cluster-config-mirror.md"
+PASSES=0; FAILURES=0
+pass(){ echo "  PASS: $1"; (( PASSES++ )) || true; }
+fail(){ echo "  FAIL: $1"; (( FAILURES++ )) || true; }
+
+# (a) page exists
+[[ -f "$DOC" ]] && pass "reference page exists" || fail "reference page missing: $DOC"
+
+# (b) every dotted ratelimit.* / subscription.type / rate_limit.tier key emitted by the
+#     source is present verbatim in the doc (drift guard — derive list FROM source).
+KEYS="$(grep -oE 'put\("(ratelimit|subscription|rate_limit)[a-z_.]*"' "$SRC" \
+        | sed -E 's/put\("//; s/"$//')"
+for k in $KEYS; do
+  grep -qF "$k" "$DOC" && pass "doc lists emitted key $k" || fail "doc missing emitted key $k"
+done
+
+# (c) doc lists no INVENTED ratelimit.* key absent from source (reverse-drift).
+# Exclude ratelimit.sampled — it appears as a suffix of the event NAME
+# "account.ratelimit.sampled", not as an emitted attribute key.
+for d in $(grep -oE 'ratelimit\.[a-z_]+' "$DOC" | grep -v '^ratelimit\.sampled$' | sort -u); do
+  grep -qF "$d" <<<"$KEYS" && pass "doc key $d backed by source" || fail "doc invents key $d"
+done
+
+# (d) event name + binding-limit + camelCase-internal note documented
+grep -qF "account.ratelimit.sampled" "$DOC" && pass "event name present" || fail "event name missing"
+grep -qiE "seven_day_opus_pct.*(binding|Max 20x)|Max 20x.*seven_day_opus_pct" "$DOC" \
+  && pass "binding-limit note present" || fail "binding-limit note missing"
+grep -qiE "camelCase|internal[- ]only|ratelimit-poller" "$DOC" \
+  && pass "internal-only camelCase note present" || fail "internal-only note missing"
+
+# (e) config-mirror contract: both classes + corrected bot-OAuth placement
+grep -qE "\bSHARED\b" "$DOC" && grep -qE "\bPER-NODE\b" "$DOC" \
+  && pass "SHARED and PER-NODE classes present" || fail "contract classes missing"
+# bot OAuth must be SHARED and in machine-global config.json (NOT config-<key>.json)
+grep -qE "catalyst\.linear\.bot" "$DOC" && pass "bot OAuth row present" || fail "bot OAuth row missing"
+grep -qE "config-<key>\.json.*bot|bot.*config-<key>\.json" "$DOC" \
+  && fail "bot OAuth wrongly tied to per-project config-<key>.json" \
+  || pass "bot OAuth not tied to per-project secrets"
+
+echo "── ${PASSES} passed, ${FAILURES} failed ──"
+[[ "$FAILURES" -eq 0 ]]

--- a/website/src/content/docs/getting-started/remote-and-unattended-hosts.md
+++ b/website/src/content/docs/getting-started/remote-and-unattended-hosts.md
@@ -78,3 +78,11 @@ catalyst-execution-core daemon status
 
 See [configuration reference](/reference/configuration/) for details on the registry and
 eligible-query format.
+
+## Mirroring config to another node
+
+When adding a second host to a cluster, some config items must be copied verbatim from the seed
+node (SHARED) and others must be regenerated on the new host (PER-NODE). See
+[Cluster config mirror contract](/reference/cluster-config-mirror/) for the full classification
+table, correct file locations for bot OAuth credentials, and the quota field-name schema consumed
+by monitoring and heartbeat code.

--- a/website/src/content/docs/reference/cluster-config-mirror.md
+++ b/website/src/content/docs/reference/cluster-config-mirror.md
@@ -59,7 +59,8 @@ everything marked **PER-NODE**. The classification is encoded in
 
 ## Canonical quota field-name schema
 
-**Single source of truth:** [`ratelimit-event.mjs:62-70`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/ratelimit-event.mjs#L62-L70).
+**Single source of truth:** [`ratelimit-event.mjs:63-70`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/ratelimit-event.mjs#L63-L70)
+(line 62 emits the `account.email` identity key, which is not part of the quota schema below).
 
 Event name: `account.ratelimit.sampled` (severity INFO, emitted every poll tick).
 

--- a/website/src/content/docs/reference/cluster-config-mirror.md
+++ b/website/src/content/docs/reference/cluster-config-mirror.md
@@ -1,0 +1,113 @@
+---
+title: Cluster config mirror contract
+description: Canonical SHARED vs PER-NODE classification for every config item, plus the quota field-name schema consumed by heartbeat and monitoring code.
+sidebar:
+  order: 20
+---
+
+This page is the single source of truth for two contracts consumed by cluster setup and
+monitoring code (M1 mirror tickets, CTL-1192 heartbeat quota):
+
+1. **Config-mirror contract** — every config item classified SHARED (copy verbatim to a new node)
+   or PER-NODE (regenerate on each host), with exact file and key locations.
+2. **Quota field-name schema** — the dotted event-log keys emitted by `ratelimit-event.mjs`,
+   pinned here so heartbeat and quota consumers (CTL-1192) share one field-name contract.
+
+For the two-layer config model (`.catalyst/config.json` vs `~/.config/catalyst/config-{key}.json`)
+see the [configuration reference](/reference/configuration/).
+
+---
+
+## Config-mirror contract
+
+When you provision a second node, copy everything marked **SHARED** verbatim and regenerate
+everything marked **PER-NODE**. The classification is encoded in
+[`config.mjs:174-185`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/config.mjs#L174-L185)
+(`getHostName`, PER-NODE),
+[`config.mjs:192-204`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/config.mjs#L192-L204)
+(`getClusterHosts`, SHARED), and
+[`config.mjs:221-238`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/config.mjs#L221-L238)
+(`getLivenessAnchorIssue`, SHARED).
+
+| Config item | File / key | Class | On mirror |
+|---|---|---|---|
+| Bot OAuth orchestrator token | `~/.config/catalyst/config.json` → `catalyst.linear.bot.orchestrator.*` | **SHARED** | Copy the whole `catalyst.linear.bot` block (one Linear app per workspace; identical across nodes) |
+| Bot OAuth worker token | `~/.config/catalyst/config.json` → `catalyst.linear.bot.worker.*` | **SHARED** | Same block — worker and orchestrator tokens are workspace-scoped, not host-scoped |
+| Cluster roster | `.catalyst/hosts.json` | **SHARED** | Committed to git; add the new node's name and push |
+| Layer-1 project config | `.catalyst/config.json` | **SHARED** | Committed to git; present after `git clone` |
+| Liveness anchor issue | `~/.config/catalyst/config.json` → `catalyst.cluster.livenessAnchorIssue` | **SHARED** | Copy from the seed node; one Linear ticket identifier per fleet |
+| Plugin source | `~/catalyst/plugin-source/` | **SHARED** | Pull from the same git remote; `setup-plugin-source.sh` does this |
+| Linear team/state map | Layer-1 `catalyst.linear.teamKey` / `stateMap` | **SHARED** | Present after `git clone` via `.catalyst/config.json` |
+| `catalyst.host.name` | `~/.config/catalyst/config.json` → `catalyst.host.name` | **PER-NODE** | Set to the new node's unique roster entry (must match an entry in `hosts.json`) |
+| `repoRoot` | `~/catalyst/execution-core/registry.json` → `repoRoot` | **PER-NODE** | The absolute path on the new host; written by `catalyst-execution-core register` |
+| Claude Code account login | macOS Keychain or `~/.claude/.credentials.json` | **PER-NODE** | Run `claude` interactively on the new host; each node uses its own account |
+| OTel endpoints | `~/.config/catalyst/config.json` → OTel keys | **PER-NODE** | Tailscale addresses differ per node; set in Layer-2 on each host |
+| `execution-core.env` | `~/catalyst/execution-core/execution-core.env` | **PER-NODE** | Proxy / tuning overrides are host-specific |
+| Event log | `~/catalyst/events/YYYY-MM.jsonl` | **PER-NODE** | Each node writes to its own log; nodes never share log files |
+| SQLite databases | `~/catalyst/*.db` (4 files) | **PER-NODE** | Host-local state; not replicated |
+| Worktree trust | `~/.claude.json` per worktree path | **PER-NODE** | Paths differ; re-trust on each host |
+| Linear personal token | `~/.config/catalyst/config-<key>.json` → `linear.apiKey` | **PER-NODE** | Personal token is user-scoped; each operator provides their own |
+| Webhook secrets | `~/.config/catalyst/config-<key>.json` → webhook keys | **PER-NODE** | Regenerate or copy securely; not managed by the mirror process |
+
+> **Why bot OAuth is SHARED:** `catalyst.linear.bot.orchestrator` and `catalyst.linear.bot.worker`
+> are credentials for a Linear OAuth application that is registered once per workspace. Every node in
+> the fleet acts on behalf of the same app. The tokens live in machine-global
+> `~/.config/catalyst/config.json` (not in the per-project `config-<key>.json`) so all nodes can
+> share them without per-project duplication.
+
+---
+
+## Canonical quota field-name schema
+
+**Single source of truth:** [`ratelimit-event.mjs:62-70`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/ratelimit-event.mjs#L62-L70).
+
+Event name: `account.ratelimit.sampled` (severity INFO, emitted every poll tick).
+
+The table below documents the eight dotted attribute keys emitted by `buildRatelimitEnvelope`.
+Consumers (orch-monitor, HUD, CTL-1192 heartbeat quota) **must** reference these names, not the
+camelCase params used internally by `ratelimit-poller.mjs`.
+
+| Attribute key | Type | Meaning |
+|---|---|---|
+| `ratelimit.five_hour_pct` | number | 5-hour rolling usage as a percentage of the window limit (0–100+) |
+| `ratelimit.seven_day_pct` | number | 7-day rolling usage as a percentage of the window limit |
+| `ratelimit.five_hour_resets_at` | string (ISO-8601) | When the 5-hour window resets |
+| `ratelimit.seven_day_resets_at` | string (ISO-8601) | When the 7-day window resets |
+| `ratelimit.seven_day_opus_pct` | number | 7-day Opus usage as a percentage — the **binding limit on Max 20x plans** (exhausts before `ratelimit.seven_day_pct` on Opus-heavy allocations) |
+| `ratelimit.seven_day_sonnet_pct` | number | 7-day Sonnet usage as a percentage |
+| `subscription.type` | string | Claude subscription tier (e.g. `"max"`) |
+| `rate_limit.tier` | string | API rate-limit tier identifier |
+
+All eight keys are conditional: a key is omitted from the attributes map when its source value is
+`null` or `undefined`. Consumers must treat absent keys as unknown, not as zero.
+
+### Internal-only camelCase params
+
+[`ratelimit-poller.mjs:257-262`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/ratelimit-poller.mjs#L257-L262)
+passes values to `emitRatelimitEvent` using camelCase parameter names (`fiveHourPct`,
+`sevenDayPct`, `opusPct`, `sonnetPct`, etc.). These camelCase names are **internal-only** and must
+not appear in consumer code or heartbeat schemas. The dotted keys in the table above are the
+contract; the camelCase params are an implementation detail of the emitter.
+
+### CTL-1192 heartbeat `quota{}` shape (proposed)
+
+When CTL-1192 extends the heartbeat Linear attachment with a `quota{}` block, it should map the
+dotted event keys directly:
+
+```json
+{
+  "quota": {
+    "five_hour_pct": 42,
+    "seven_day_pct": 18,
+    "seven_day_opus_pct": 67,
+    "seven_day_sonnet_pct": 12,
+    "five_hour_resets_at": "2026-06-16T06:00:00Z",
+    "seven_day_resets_at": "2026-06-20T00:00:00Z",
+    "subscription_type": "max",
+    "rate_limit_tier": "usage_tier_2"
+  }
+}
+```
+
+Use the snake_case field names (strip the `ratelimit.` prefix) so the heartbeat attachment stays
+human-readable. The source event keys remain the canonical names — this shape is a derived view.


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-16T01:26:00Z -->
<!-- Last updated: 2026-06-16T01:26:00Z -->
<!-- PR: #2096 -->
<!-- Previous commits: be096f7d,e2bb2858,a9b7c5fa -->

## Summary

Adds the canonical SHARED-vs-PER-NODE config mirror contract and quota field-name schema as a reference doc, wires a cross-reference from the getting-started guide, and adds two regression-guard tests to prevent doc/source drift.

This closes the operator documentation gap identified in CTL-1187: before this PR there was no single-source-of-truth page documenting which config items must be copied verbatim when provisioning a second node vs. which must be regenerated. It also corrects the §8 finding from the research phase — bot OAuth credentials are SHARED (machine-global `~/.config/catalyst/config.json`), not per-project secrets.

## Changes Made

### Documentation

- **`website/src/content/docs/reference/cluster-config-mirror.md`** (new, 114 lines) — canonical reference page with:
  - Full SHARED/PER-NODE classification table for every config item (bot OAuth tokens, cluster roster, liveness anchor, plugin source, host name, repoRoot, Claude account, OTel, event log, SQLite DBs, worktree trust, personal tokens, webhook secrets)
  - Explicit callout that bot OAuth lives in machine-global `~/.config/catalyst/config.json` (not per-project `config-<key>.json`)
  - Canonical quota field-name schema table (8 dotted attribute keys emitted by `ratelimit-event.mjs`)
  - CTL-1192 heartbeat `quota{}` shape proposal with snake_case field names
  - Notes on internal-only camelCase params in `ratelimit-poller.mjs`

- **`website/src/content/docs/getting-started/remote-and-unattended-hosts.md`** (appended) — new "Mirroring config to another node" section linking to the canonical reference page

### Tests (regression guards)

- **`plugins/dev/scripts/execution-core/config-mirror-xref.test.sh`** (new, 23 lines) — asserts:
  - Research doc §8 carries a correction pointing to the canonical page
  - Remote-hosts getting-started page links to `cluster-config-mirror`

- **`plugins/dev/scripts/execution-core/quota-field-doc-drift.test.sh`** (new, 49 lines) — asserts:
  - Every dotted key emitted by `ratelimit-event.mjs` appears verbatim in the reference doc
  - The doc introduces no keys absent from source (reverse-drift check)
  - Event name, binding-limit note, internal-only camelCase note, and bot-OAuth placement all verified

**Test results:** 24/24 pass ✅

## How to Verify It

- [x] `bash plugins/dev/scripts/execution-core/config-mirror-xref.test.sh` — 3 passed ✅
- [x] `bash plugins/dev/scripts/execution-core/quota-field-doc-drift.test.sh` — 21 passed ✅
- [ ] Website builds without errors: `cd website && bun run build` (manual — Astro/Starlight site)
- [ ] Reference page renders correctly at `/reference/cluster-config-mirror/`
- [ ] Cross-reference link from remote-hosts page resolves to the new page

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1187

## Changelog Entry

```
feat(dev): add cluster-config-mirror reference page and quota field-name schema (CTL-1187)

- Canonical SHARED vs PER-NODE classification table for all config items
- Corrects bot OAuth placement: SHARED, machine-global config.json (not per-project)
- Pins 8 dotted ratelimit.* attribute keys from ratelimit-event.mjs as the field-name contract
- Proposes CTL-1192 heartbeat quota{} shape
- Cross-reference added to remote-and-unattended-hosts.md
- Two regression-guard tests prevent doc/source drift
```

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1192
