### PR TITLE
CTL-1183: cluster join-bundle armed listener (seed side)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-cluster-cli.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-cluster-cli.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# catalyst-cluster-cli.test.sh — CTL-1183 Phase 3 CLI registration + dispatch tests.
+# Asserts: (1) install-cli registers catalyst-cluster; (2) the dispatcher exists,
+# is executable, prints usage on no args, and rejects unknown sub-commands;
+# (3) join-token mints a 64-hex token and prints an armed URL.
+# Run: bash plugins/dev/scripts/__tests__/catalyst-cluster-cli.test.sh
+
+set -uo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+INSTALL_CLI="${REPO_ROOT}/plugins/dev/scripts/install-cli.sh"
+CLUSTER="${REPO_ROOT}/plugins/dev/scripts/catalyst-cluster"
+PASS=0; FAIL=0
+
+assert() {
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    echo "PASS: ${desc}"
+  else
+    FAIL=$((FAIL+1))
+    echo "FAIL: ${desc} (cmd: $*)"
+  fi
+}
+
+# 1. registered in the CLI_ENTRIES allowlist
+assert "install-cli registers catalyst-cluster" \
+  grep -q '"catalyst-cluster:catalyst-cluster"' "$INSTALL_CLI"
+
+# 2. dispatcher exists and is executable
+assert "catalyst-cluster is executable" test -x "$CLUSTER"
+
+# 3. usage printed on no args (exit != 0 is allowed — grep only checks stdout+stderr)
+out="$("$CLUSTER" 2>&1 || true)"
+if echo "$out" | grep -qi "usage"; then
+  PASS=$((PASS+1)); echo "PASS: usage on no args"
+else
+  FAIL=$((FAIL+1)); echo "FAIL: usage on no args (got: ${out})"
+fi
+
+# 4. unknown sub-command prints 'unknown' and exits non-zero
+rc=0; out="$("$CLUSTER" bogus 2>&1)" || rc=$?
+if echo "$out" | grep -qi "unknown" && [[ $rc -ne 0 ]]; then
+  PASS=$((PASS+1)); echo "PASS: unknown sub-command"
+else
+  FAIL=$((FAIL+1)); echo "FAIL: unknown sub-command (rc=${rc}, out=${out})"
+fi
+
+# 5. join-token mints a jt_<64-hex> token + prints the armed URL; listener stubbed via env hook
+#    (token format is the CTL-1184 store form: jt_ + 64 hex — see join-token-store.mjs)
+out="$(CATALYST_JOIN_LISTENER_CMD=true "$CLUSTER" join-token --port 7401 --ttl 1 2>&1 || true)"
+if echo "$out" | grep -Eq 'Join token: jt_[0-9a-f]{64}'; then
+  PASS=$((PASS+1)); echo "PASS: join-token prints jt_<64-hex> token"
+else
+  FAIL=$((FAIL+1)); echo "FAIL: join-token jt_<64-hex> token (got: ${out})"
+fi
+
+if echo "$out" | grep -q '/join-bundle'; then
+  PASS=$((PASS+1)); echo "PASS: join-token prints /join-bundle URL"
+else
+  FAIL=$((FAIL+1)); echo "FAIL: join-token /join-bundle URL (got: ${out})"
+fi
+
+# 6. --help flag is accepted (same as no args)
+rc=0; out="$("$CLUSTER" --help 2>&1)" || rc=$?
+if echo "$out" | grep -qi "usage"; then
+  PASS=$((PASS+1)); echo "PASS: --help prints usage"
+else
+  FAIL=$((FAIL+1)); echo "FAIL: --help (got: ${out})"
+fi
+
+echo ""
+echo "catalyst-cluster-cli: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/catalyst-cluster
+++ b/plugins/dev/scripts/catalyst-cluster
@@ -1,31 +1,63 @@
 #!/usr/bin/env bash
-# catalyst-cluster — seed-side cluster operations (CTL-1184).
+# catalyst-cluster — seed-side cluster operations (CTL-1184 + CTL-1183).
 #
 # Verbs:
 #   join-token   Mint a one-time, short-TTL join token (jt_<hex>) and ARM the
-#                separate bundle listener (CTL-1183) so exactly one bundle
-#                fetch succeeds. Re-run to mint a fresh token (re-arms).
+#                single-use bundle listener (CTL-1183) so exactly one bundle
+#                fetch succeeds (consume-on-first-200, then it exits). Re-run to
+#                mint a fresh token (re-arms). Optional: --port N --ttl MIN.
 #
 # Future verbs (CTL-1188): status | add | remove | rename | set-anchor | drain | tune
 #
 # The token is a bearer secret: printed once to stdout, written to a 0600 store
 # under ${CATALYST_DIR:-~/catalyst}/cluster/join-token.json. Never logged to a
-# file by this script; never committed.
+# file by this script; never committed. The same minted token is handed to the
+# listener via env (never argv → not visible in `ps`).
 set -uo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve through symlinks so SCRIPT_DIR points at the real scripts/ dir.
+_SRC="${BASH_SOURCE[0]}"; while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
+SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"; unset _SRC
 STORE_MJS="${SCRIPT_DIR}/execution-core/join-token-store.mjs"
-LISTENER_MJS="${SCRIPT_DIR}/execution-core/join-bundle-listener.mjs"  # CTL-1183, may not exist yet
+LISTENER_MJS="${SCRIPT_DIR}/execution-core/join-listener.mjs"
+CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
 
 # Resolve a JS runtime (bun preferred, node fallback) — matches sibling .mjs CLIs.
 JS_RUN="$(command -v bun || command -v node || true)"
 
+usage() {
+  cat >&2 <<'EOF'
+usage: catalyst cluster <verb>
+  join-token [--port N] [--ttl MIN]   Mint a one-time join token and arm the
+                                      single-use join-bundle listener
+                                      (consume-on-first-200, then it exits)
+  -h, --help                          Show this help
+EOF
+}
+
 cmd_join_token() {
+  local port="${CATALYST_JOIN_LISTENER_PORT:-7401}" ttl=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --port) port="$2"; shift 2 ;;
+      --ttl) ttl="$2"; shift 2 ;;
+      *) echo "catalyst cluster: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+
   [[ -n "$JS_RUN" ]] || { echo "catalyst cluster: no bun/node runtime found" >&2; return 1; }
   [[ -f "$STORE_MJS" ]] || { echo "catalyst cluster: missing $STORE_MJS" >&2; return 1; }
 
+  # Mint via the shared store (CTL-1184): writes the 0600 join-token.json and
+  # returns {token, ttlMs, expiresAt}. A --ttl override (minutes) is passed to
+  # the store as ms so the store record and the listener TTL stay consistent.
   local rec token ttl_ms expires_at
-  rec="$("$JS_RUN" "$STORE_MJS" mint)" || { echo "catalyst cluster: mint failed" >&2; return 1; }
+  if [[ -n "$ttl" ]]; then
+    rec="$(CATALYST_JOIN_TOKEN_TTL_MS=$(( ttl * 60000 )) "$JS_RUN" "$STORE_MJS" mint)" \
+      || { echo "catalyst cluster: mint failed" >&2; return 1; }
+  else
+    rec="$("$JS_RUN" "$STORE_MJS" mint)" || { echo "catalyst cluster: mint failed" >&2; return 1; }
+  fi
   token="$(printf '%s' "$rec" | jq -r '.token')"
   ttl_ms="$(printf '%s' "$rec" | jq -r '.ttlMs')"
   expires_at="$(printf '%s' "$rec" | jq -r '.expiresAt')"
@@ -33,33 +65,44 @@ cmd_join_token() {
 
   local ttl_min=$(( ttl_ms / 60000 ))
 
-  # Arm the listener: store write already happened (mint). Best-effort spawn of
-  # CTL-1183's listener if present; otherwise note it will arm from the store.
+  # Arm the single-use listener (CTL-1183). The minted token is passed via env
+  # (never argv → not in `ps`); the listener validates it with timingSafeEqual
+  # and serves the SHARED bundle exactly once before exiting.
+  # CATALYST_JOIN_LISTENER_CMD lets tests stub the actual process launch.
   local armed_note
-  if [[ -x "$LISTENER_MJS" || -f "$LISTENER_MJS" ]]; then
-    ( "$JS_RUN" "$LISTENER_MJS" >/dev/null 2>&1 & ) || true
+  local launch="${CATALYST_JOIN_LISTENER_CMD:-}"
+  if [[ -n "$launch" ]]; then
+    CATALYST_JOIN_TOKEN="$token" CATALYST_JOIN_LISTENER_PORT="$port" \
+      CATALYST_JOIN_TTL_MIN="$ttl_min" "$launch" >/dev/null 2>&1 &
+    armed_note="bundle listener spawned (stub)"
+  elif [[ -f "$LISTENER_MJS" ]]; then
+    mkdir -p "$CATALYST_DIR"
+    CATALYST_JOIN_TOKEN="$token" CATALYST_JOIN_LISTENER_PORT="$port" \
+      CATALYST_JOIN_TTL_MIN="$ttl_min" nohup "$JS_RUN" run "$LISTENER_MJS" \
+      >"$CATALYST_DIR/join-bundle-listener.log" 2>&1 &
+    disown
     armed_note="bundle listener spawned (auto-expires with token TTL)"
   else
     armed_note="listener not yet installed (CTL-1183) — it will arm from the token store on start"
   fi
 
-  # Operator-facing contract. The token line is machine-parseable (eval-able).
+  # Operator-facing contract. The CATALYST_JOIN_TOKEN line is machine-parseable
+  # (eval-able); the "Join token" / armed-URL lines are human-facing.
   cat <<EOF
 CATALYST_JOIN_TOKEN=${token}
 # TTL: ${ttl_min} min  (expires at epoch-ms ${expires_at})
 # Single-use: consumed on the first successful bundle fetch; a re-join needs a fresh mint.
 # Integrity: verify the bundle's integrityHash returned by the listener (CTL-1183) before trusting it.
 # Armed: ${armed_note}
+Armed join-bundle listener on http://0.0.0.0:${port}/join-bundle  (TTL ${ttl_min}m, single-use)
+Join token: ${token}  (give this to the joining node)
 EOF
 }
 
 case "${1:-}" in
   join-token) shift; cmd_join_token "$@" ;;
   ""|-h|--help|help)
-    cat >&2 <<'EOF'
-usage: catalyst cluster <verb>
-  join-token   mint a one-time join token and arm the bundle listener
-EOF
+    usage
     [[ "${1:-}" == "" ]] && exit 1 || exit 0 ;;
   *)
     echo "catalyst cluster: unknown verb '${1}'" >&2

--- a/plugins/dev/scripts/execution-core/join-bundle.mjs
+++ b/plugins/dev/scripts/execution-core/join-bundle.mjs
@@ -1,0 +1,88 @@
+// join-bundle.mjs — CTL-1183. Assembles the SHARED-only cluster join-bundle
+// from Layer-1 + Layer-2 config. Pure function — no network, no side effects.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
+import { getClusterHosts, getLivenessAnchorIssue } from "./config.mjs";
+
+export const JOIN_BUNDLE_SCHEMA_VERSION = 1;
+
+function layer2Path() {
+  return (
+    process.env.CATALYST_LAYER2_CONFIG_FILE ||
+    resolve(homedir(), ".config", "catalyst", "config.json")
+  );
+}
+
+function layer1Path() {
+  return (
+    process.env.CATALYST_CONFIG_FILE ||
+    resolve(process.cwd(), ".catalyst", "config.json")
+  );
+}
+
+function readJson(p) {
+  try {
+    return JSON.parse(readFileSync(p, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function resolvePluginSourceUrl(l2) {
+  const dirs = l2?.catalyst?.orchestration?.pluginDirs;
+  const dir = Array.isArray(dirs) ? dirs[0] : dirs;
+  if (typeof dir === "string" && dir) {
+    try {
+      return (
+        execFileSync("git", ["-C", dir, "remote", "get-url", "origin"], {
+          encoding: "utf8",
+          stdio: ["pipe", "pipe", "pipe"],
+        }).trim() || null
+      );
+    } catch {
+      /* fall through to repoUrl */
+    }
+  }
+  return null;
+}
+
+export function assembleJoinBundle() {
+  const l1 = readJson(layer1Path());
+  const l2 = readJson(layer2Path());
+  const bot = l2?.catalyst?.linear?.bot ?? {};
+  const repo = l2?.catalyst?.repository ?? {};
+  const repoUrl = repo.org && repo.name ? `${repo.org}/${repo.name}` : null;
+
+  return {
+    schemaVersion: JOIN_BUNDLE_SCHEMA_VERSION,
+    hostsRoster: getClusterHosts(),
+    livenessAnchorIssue: getLivenessAnchorIssue(),
+    botCreds: {
+      orchestrator: bot.orchestrator ?? null,
+      worker: bot.worker ?? null,
+    },
+    otlpEndpointHint:
+      process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||
+      l2?.catalyst?.cluster?.otlpEndpointHint ||
+      null,
+    layer1Identity: {
+      projectKey: l1?.catalyst?.projectKey ?? null,
+      teamKey: l1?.catalyst?.linear?.teamKey ?? null,
+      teamId: l1?.catalyst?.linear?.teamId ?? null,
+      stateMap: l1?.catalyst?.linear?.stateMap ?? null,
+    },
+    repoUrl,
+    pluginSourceUrl: resolvePluginSourceUrl(l2) || repoUrl,
+  };
+}
+
+// Deep-redact secrets for logging. NEVER log assembleJoinBundle() output directly.
+export function redactBundleForLog(bundle) {
+  const out = { ...bundle };
+  // Replace the entire botCreds subtree — these are keys-to-the-kingdom.
+  out.botCreds = "[REDACTED]";
+  return out;
+}

--- a/plugins/dev/scripts/execution-core/join-bundle.test.mjs
+++ b/plugins/dev/scripts/execution-core/join-bundle.test.mjs
@@ -1,0 +1,179 @@
+// join-bundle.test.mjs — Phase 1 unit tests for CTL-1183 bundle assembler.
+// Run: cd plugins/dev/scripts/execution-core && bun test join-bundle.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  assembleJoinBundle,
+  redactBundleForLog,
+  JOIN_BUNDLE_SCHEMA_VERSION,
+} from "./join-bundle.mjs";
+
+const BUNDLE_ENVS = [
+  "CATALYST_CONFIG_FILE",
+  "CATALYST_LAYER2_CONFIG_FILE",
+  "CATALYST_HOST_NAME",
+  "OTEL_EXPORTER_OTLP_ENDPOINT",
+  "CATALYST_LIVENESS_ANCHOR_ISSUE",
+];
+
+let saved = {};
+let repoDir;
+let layer2File;
+
+function writeLayer1(cfg) {
+  writeFileSync(join(repoDir, ".catalyst", "config.json"), JSON.stringify(cfg));
+}
+function writeHosts(arr) {
+  writeFileSync(join(repoDir, ".catalyst", "hosts.json"), JSON.stringify(arr));
+}
+function writeLayer2(cfg) {
+  writeFileSync(layer2File, JSON.stringify(cfg));
+}
+
+const LAYER1_FIXTURE = {
+  catalyst: {
+    projectKey: "catalyst-workspace",
+    linear: {
+      teamKey: "CTL",
+      teamId: "team-uuid-1234",
+      stateMap: { Todo: "state-1", "In Progress": "state-2" },
+    },
+  },
+};
+
+const LAYER2_FIXTURE = {
+  catalyst: {
+    linear: {
+      bot: {
+        orchestrator: { accessToken: "lin_oauth_orch" },
+        worker: { accessToken: "lin_oauth_worker", clientSecret: "secret-worker" },
+      },
+    },
+    cluster: {
+      livenessAnchorIssue: "CTL-1090",
+    },
+    repository: { org: "coalesce-labs", name: "catalyst" },
+    orchestration: { pluginDirs: ["/nonexistent-for-test"] },
+  },
+};
+
+beforeEach(() => {
+  for (const k of BUNDLE_ENVS) { saved[k] = process.env[k]; delete process.env[k]; }
+
+  repoDir = mkdtempSync(join(tmpdir(), "jb-test-"));
+  mkdirSync(join(repoDir, ".catalyst"), { recursive: true });
+  layer2File = join(repoDir, "layer2.json");
+
+  process.env.CATALYST_CONFIG_FILE = join(repoDir, ".catalyst", "config.json");
+  process.env.CATALYST_LAYER2_CONFIG_FILE = layer2File;
+  process.env.CATALYST_HOST_NAME = "mini";
+
+  writeLayer1(LAYER1_FIXTURE);
+  writeHosts(["mini", "studio"]);
+  writeLayer2(LAYER2_FIXTURE);
+});
+
+afterEach(() => {
+  for (const k of BUNDLE_ENVS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  saved = {};
+  rmSync(repoDir, { recursive: true, force: true });
+});
+
+describe("assembleJoinBundle", () => {
+  test("assembles all SHARED fields from layer-1 + layer-2 fixtures", () => {
+    const b = assembleJoinBundle();
+    expect(b.schemaVersion).toBe(JOIN_BUNDLE_SCHEMA_VERSION);
+    expect(b.hostsRoster).toEqual(["mini", "studio"]);
+    expect(b.livenessAnchorIssue).toBe("CTL-1090");
+    expect(b.layer1Identity).toEqual({
+      projectKey: "catalyst-workspace",
+      teamKey: "CTL",
+      teamId: "team-uuid-1234",
+      stateMap: expect.any(Object),
+    });
+    expect(b.repoUrl).toBe("coalesce-labs/catalyst");
+    expect(b.pluginSourceUrl).toBeTruthy(); // falls back to repoUrl
+    expect(b.otlpEndpointHint).toBeNull(); // not set in fixture
+  });
+
+  test("botCreds carry accessToken for both bots, read from GLOBAL config", () => {
+    const b = assembleJoinBundle();
+    expect(b.botCreds.orchestrator.accessToken).toBe("lin_oauth_orch");
+    expect(b.botCreds.worker.accessToken).toBe("lin_oauth_worker");
+  });
+
+  test("bundle contains NO per-node items", () => {
+    const b = assembleJoinBundle();
+    expect(b).not.toHaveProperty("host");
+    expect(b).not.toHaveProperty("repoRoots");
+    expect(b).not.toHaveProperty("eventLog");
+    expect(JSON.stringify(b)).not.toContain('"host.name"');
+  });
+
+  test("livenessAnchorIssue is null when unset (single-host)", () => {
+    writeLayer2({
+      ...LAYER2_FIXTURE,
+      catalyst: { ...LAYER2_FIXTURE.catalyst, cluster: {} },
+    });
+    expect(assembleJoinBundle().livenessAnchorIssue).toBeNull();
+  });
+
+  test("OTEL_EXPORTER_OTLP_ENDPOINT env overrides layer2 hint", () => {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "http://otel.test:4318";
+    const b = assembleJoinBundle();
+    expect(b.otlpEndpointHint).toBe("http://otel.test:4318");
+  });
+
+  test("layer2 cluster.otlpEndpointHint used when env is absent", () => {
+    writeLayer2({
+      ...LAYER2_FIXTURE,
+      catalyst: {
+        ...LAYER2_FIXTURE.catalyst,
+        cluster: { ...LAYER2_FIXTURE.catalyst.cluster, otlpEndpointHint: "http://from-l2:4318" },
+      },
+    });
+    const b = assembleJoinBundle();
+    expect(b.otlpEndpointHint).toBe("http://from-l2:4318");
+  });
+
+  test("missing layer2 produces null/empty fields without throwing", () => {
+    process.env.CATALYST_LAYER2_CONFIG_FILE = join(repoDir, "absent.json");
+    const b = assembleJoinBundle();
+    expect(b.schemaVersion).toBe(JOIN_BUNDLE_SCHEMA_VERSION);
+    expect(b.botCreds.orchestrator).toBeNull();
+    expect(b.botCreds.worker).toBeNull();
+  });
+
+  test("missing layer1 produces null layer1Identity fields without throwing", () => {
+    process.env.CATALYST_CONFIG_FILE = join(repoDir, ".catalyst", "absent.json");
+    const b = assembleJoinBundle();
+    expect(b.layer1Identity.projectKey).toBeNull();
+    expect(b.layer1Identity.teamKey).toBeNull();
+  });
+});
+
+describe("redactBundleForLog", () => {
+  test("replaces botCreds entirely with sentinel string", () => {
+    const r = redactBundleForLog(assembleJoinBundle());
+    expect(r.botCreds).toBe("[REDACTED]");
+  });
+
+  test("serialized log contains no token values", () => {
+    const r = redactBundleForLog(assembleJoinBundle());
+    expect(JSON.stringify(r)).not.toContain("lin_oauth_");
+    expect(JSON.stringify(r)).not.toContain("secret-worker");
+  });
+
+  test("non-secret fields survive redaction", () => {
+    const r = redactBundleForLog(assembleJoinBundle());
+    expect(r.schemaVersion).toBe(JOIN_BUNDLE_SCHEMA_VERSION);
+    expect(r.hostsRoster).toEqual(["mini", "studio"]);
+    expect(r.repoUrl).toBe("coalesce-labs/catalyst");
+  });
+});

--- a/plugins/dev/scripts/execution-core/join-listener.integration.test.mjs
+++ b/plugins/dev/scripts/execution-core/join-listener.integration.test.mjs
@@ -1,0 +1,116 @@
+// join-listener.integration.test.mjs — Phase 2 integration tests for CTL-1183.
+// Binds an ephemeral port; exercises arm → fetch → consume → replay-refused.
+// Run: cd plugins/dev/scripts/execution-core && bun test join-listener.integration.test.mjs
+
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startArmedListener } from "./join-listener.mjs";
+
+let repoDir;
+let layer2File;
+
+// Set up minimal config fixtures so assembleJoinBundle() doesn't throw.
+beforeAll(() => {
+  repoDir = mkdtempSync(join(tmpdir(), "jl-int-"));
+  mkdirSync(join(repoDir, ".catalyst"), { recursive: true });
+  layer2File = join(repoDir, "layer2.json");
+
+  process.env.CATALYST_CONFIG_FILE = join(repoDir, ".catalyst", "config.json");
+  process.env.CATALYST_LAYER2_CONFIG_FILE = layer2File;
+  process.env.CATALYST_HOST_NAME = "test-node";
+
+  writeFileSync(
+    process.env.CATALYST_CONFIG_FILE,
+    JSON.stringify({
+      catalyst: {
+        projectKey: "test-project",
+        linear: { teamKey: "TST", teamId: "t-1", stateMap: {} },
+      },
+    }),
+  );
+  writeFileSync(
+    layer2File,
+    JSON.stringify({
+      catalyst: {
+        linear: {
+          bot: {
+            orchestrator: { accessToken: "orch-tok" },
+            worker: { accessToken: "worker-tok" },
+          },
+        },
+        repository: { org: "test-org", name: "test-repo" },
+      },
+    }),
+  );
+});
+
+afterAll(() => {
+  delete process.env.CATALYST_CONFIG_FILE;
+  delete process.env.CATALYST_LAYER2_CONFIG_FILE;
+  delete process.env.CATALYST_HOST_NAME;
+  rmSync(repoDir, { recursive: true, force: true });
+});
+
+test("arm → fetch (200) → consume → replay refused (server down)", async () => {
+  const { url, token, stop, pidFile } = startArmedListener({
+    port: 0,
+    hostname: "127.0.0.1",
+    token: "t0k-integration",
+    ttlMs: 60_000,
+    pidFile: join(repoDir, "listener-1.pid"),
+  });
+
+  // First fetch: should succeed and consume the token.
+  const ok = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  expect(ok.status).toBe(200);
+  const body = await ok.json();
+  expect(body.schemaVersion).toBeDefined();
+  expect(body.botCreds).toBeDefined();
+
+  // Allow the consume-on-first-200 microtask to run and server to stop.
+  await Bun.sleep(50);
+
+  // Second fetch: server should be down (connection refused → fetch rejects).
+  await expect(
+    fetch(url, { headers: { Authorization: `Bearer ${token}` } }),
+  ).rejects.toBeDefined();
+
+  // PID file removed on shutdown.
+  expect(existsSync(pidFile)).toBe(false);
+
+  stop(); // idempotent
+});
+
+test("TTL-expired token → 401 before bundle served, listener stays up", async () => {
+  const { url, token, stop } = startArmedListener({
+    port: 0,
+    hostname: "127.0.0.1",
+    token: "exp-tok",
+    ttlMs: 1, // effectively immediate expiry (1ms)
+    pidFile: join(repoDir, "listener-2.pid"),
+  });
+
+  await Bun.sleep(10); // let TTL expire
+
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  expect([401, 403]).toContain(res.status);
+
+  stop();
+});
+
+test("no token → 401, listener stays up", async () => {
+  const { url, stop } = startArmedListener({
+    port: 0,
+    hostname: "127.0.0.1",
+    token: "unused",
+    ttlMs: 60_000,
+    pidFile: join(repoDir, "listener-3.pid"),
+  });
+
+  const res = await fetch(url);
+  expect(res.status).toBe(401);
+
+  stop();
+});

--- a/plugins/dev/scripts/execution-core/join-listener.mjs
+++ b/plugins/dev/scripts/execution-core/join-listener.mjs
@@ -1,0 +1,139 @@
+// join-listener.mjs — CTL-1183. Armed single-use join-bundle listener.
+// Security core: one-time bearer token, TTL, consume-on-first-200, PID-file lifecycle.
+
+import { writeFileSync, unlinkSync } from "node:fs";
+import { timingSafeEqual } from "node:crypto";
+import { assembleJoinBundle } from "./join-bundle.mjs";
+
+export const JOIN_ROUTE = "/join-bundle";
+
+export function makeListenerState({ token, ttlMs, nowMs }) {
+  return { token, expiresAt: nowMs + ttlMs, consumed: false };
+}
+
+// timingSafeEqual requires same-length buffers; pad shorter to avoid length leak.
+function tokenMatches(presented, expected) {
+  if (typeof presented !== "string" || typeof expected !== "string") return false;
+  // Use the longer length to avoid length-based oracle.
+  const len = Math.max(presented.length, expected.length, 1);
+  const ba = Buffer.alloc(len);
+  const bb = Buffer.alloc(len);
+  Buffer.from(presented).copy(ba);
+  Buffer.from(expected).copy(bb);
+  return timingSafeEqual(ba, bb) && presented.length === expected.length;
+}
+
+// Pure: returns { status, response, consume, ranAssembler, logFields }.
+// Never logs the response body or the raw token.
+export function handleJoinRequest(req, state, nowMs) {
+  const url = new URL(req.url);
+  const authHeader = req.headers.get("authorization") || "";
+  const presented = authHeader.replace(/^Bearer\s+/i, "");
+  const logFields = (status) => ({
+    method: req.method,
+    path: url.pathname,
+    status,
+    token: "[REDACTED]",
+  });
+
+  if (url.pathname !== JOIN_ROUTE) {
+    return {
+      status: 404,
+      response: new Response("not found", { status: 404 }),
+      consume: false,
+      ranAssembler: false,
+      logFields: logFields(404),
+    };
+  }
+
+  if (
+    state.consumed ||
+    nowMs >= state.expiresAt ||
+    !tokenMatches(presented, state.token)
+  ) {
+    return {
+      status: 401,
+      response: new Response("unauthorized", { status: 401 }),
+      consume: false,
+      ranAssembler: false,
+      logFields: logFields(401),
+    };
+  }
+
+  // Single-use latch set BEFORE assembling the bundle.
+  state.consumed = true;
+  const bundle = assembleJoinBundle();
+  return {
+    status: 200,
+    response: new Response(JSON.stringify(bundle), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+    consume: true,
+    ranAssembler: true,
+    logFields: logFields(200),
+  };
+}
+
+// Thin runner. Returns { url, token, pidFile, stop }.
+export function startArmedListener({
+  port = 7401,
+  hostname = "0.0.0.0",
+  token,
+  ttlMs = 15 * 60_000,
+  pidFile = `${process.env.CATALYST_DIR || `${process.env.HOME}/catalyst`}/join-bundle-listener.pid`,
+  log = console.error,
+} = {}) {
+  const state = makeListenerState({ token, ttlMs, nowMs: Date.now() });
+  let stopped = false;
+
+  const stop = () => {
+    if (stopped) return;
+    stopped = true;
+    try {
+      unlinkSync(pidFile);
+    } catch {
+      /* already gone */
+    }
+    server.stop(true);
+  };
+
+  const server = Bun.serve({
+    port,
+    hostname,
+    idleTimeout: 0,
+    fetch(req) {
+      const r = handleJoinRequest(req, state, Date.now());
+      log(JSON.stringify(r.logFields));
+      if (r.consume) setTimeout(() => stop(), 50);
+      return r.response;
+    },
+  });
+
+  writeFileSync(pidFile, `${process.pid}\n`);
+
+  for (const sig of ["SIGTERM", "SIGINT"]) {
+    process.on(sig, () => {
+      stop();
+      process.exit(0);
+    });
+  }
+
+  const listenHost = hostname === "0.0.0.0" ? "127.0.0.1" : hostname;
+  return {
+    url: `http://${listenHost}:${server.port}${JOIN_ROUTE}`,
+    token,
+    pidFile,
+    stop,
+  };
+}
+
+// CLI entrypoint: `bun run join-listener.mjs` reads token/ttl/port from env.
+if (import.meta.main) {
+  const { url } = startArmedListener({
+    port: Number(process.env.CATALYST_JOIN_LISTENER_PORT) || 7401,
+    token: process.env.CATALYST_JOIN_TOKEN,
+    ttlMs: (Number(process.env.CATALYST_JOIN_TTL_MIN) || 15) * 60_000,
+  });
+  console.error(`armed join-bundle listener: ${url}`);
+}

--- a/plugins/dev/scripts/execution-core/join-listener.test.mjs
+++ b/plugins/dev/scripts/execution-core/join-listener.test.mjs
@@ -1,0 +1,82 @@
+// join-listener.test.mjs — Phase 2 unit tests for CTL-1183 armed listener.
+// Tests pure handleJoinRequest() without binding a port.
+// Run: cd plugins/dev/scripts/execution-core && bun test join-listener.test.mjs
+
+import { test, expect } from "bun:test";
+import { handleJoinRequest, makeListenerState, JOIN_ROUTE } from "./join-listener.mjs";
+
+const armed = () => makeListenerState({ token: "good", ttlMs: 60_000, nowMs: 1_000 });
+const req = (tok, path = JOIN_ROUTE) =>
+  new Request(`http://x${path}`, {
+    headers: tok ? { Authorization: `Bearer ${tok}` } : {},
+  });
+
+test("valid token on the join route → 200 + full bundle JSON", async () => {
+  const s = armed();
+  const r = handleJoinRequest(req("good"), s, 1_500);
+  expect(r.status).toBe(200);
+  const body = await r.response.json();
+  expect(body.schemaVersion).toBeDefined();
+  expect(body.botCreds).toBeDefined();
+  expect(r.consume).toBe(true);
+});
+
+test("second presentation of a consumed token → 401, assembler NOT run", () => {
+  const s = armed();
+  handleJoinRequest(req("good"), s, 1_500); // consumes
+  const r = handleJoinRequest(req("good"), s, 1_600);
+  expect([401, 403]).toContain(r.status);
+  expect(r.ranAssembler).toBe(false);
+});
+
+test("expired token → rejected, assembler NOT run", () => {
+  const s = makeListenerState({ token: "good", ttlMs: 1_000, nowMs: 0 });
+  const r = handleJoinRequest(req("good"), s, 5_000); // past TTL
+  expect([401, 403]).toContain(r.status);
+  expect(r.ranAssembler).toBe(false);
+});
+
+test("missing token → 401, no bundle, no consume", () => {
+  const s = armed();
+  const r = handleJoinRequest(req(null), s, 1_500);
+  expect(r.status).toBe(401);
+  expect(r.consume).toBe(false);
+  expect(s.consumed).toBe(false);
+});
+
+test("wrong token → 401, no consume", () => {
+  const s = armed();
+  const r = handleJoinRequest(req("nope"), s, 1_500);
+  expect(r.status).toBe(401);
+  expect(s.consumed).toBe(false);
+});
+
+test("wrong path with valid token → 404, token not consumed", () => {
+  const s = armed();
+  const r = handleJoinRequest(req("good", "/secrets"), s, 1_500);
+  expect(r.status).toBe(404);
+  expect(s.consumed).toBe(false);
+});
+
+test("log fields for a served request redact token and omit body", () => {
+  const s = armed();
+  const r = handleJoinRequest(req("good"), s, 1_500);
+  expect(JSON.stringify(r.logFields)).not.toContain("good");
+  expect(r.logFields).not.toHaveProperty("responseBody");
+  expect(r.logFields.token).toBe("[REDACTED]");
+});
+
+test("log fields for rejected request also redact token", () => {
+  const s = armed();
+  const r = handleJoinRequest(req("nope"), s, 1_500);
+  expect(JSON.stringify(r.logFields)).not.toContain("nope");
+  expect(r.logFields.token).toBe("[REDACTED]");
+});
+
+test("timing-safe token comparison prevents timing attacks", () => {
+  // Tokens of different lengths or values must both return 401 without short-circuit.
+  const s = armed();
+  expect(handleJoinRequest(req("x"), s, 1_500).status).toBe(401);
+  expect(handleJoinRequest(req(""), s, 1_500).status).toBe(401);
+  expect(handleJoinRequest(req("good" + "x".repeat(100)), s, 1_500).status).toBe(401);
+});

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -34,6 +34,7 @@ set -uo pipefail
 # Keep this in sync with check-setup.sh's "Catalyst CLI Install" section.
 CLI_ENTRIES=(
   "catalyst-broker:catalyst-broker"
+  "catalyst-cluster:catalyst-cluster"
   "catalyst-comms:catalyst-comms"
   "catalyst-events:catalyst-events"
   "catalyst-execution-core:catalyst-execution-core"
@@ -53,7 +54,6 @@ CLI_ENTRIES=(
   "catalyst-hud:catalyst-hud"
   "catalyst-hud-classic.sh:catalyst-hud-classic"
   "catalyst-stack:catalyst-stack"
-  "catalyst-cluster:catalyst-cluster"
   "catalyst-doctor:catalyst-doctor"
   "../hooks/emit-lifecycle-event.sh:emit-lifecycle-event"
 )


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-16T01:43:00Z -->
<!-- Last updated: 2026-06-16T01:43:00Z -->
<!-- PR: #2098 -->
<!-- Previous commits: 4689aa3b4895d4e9fac1153b4a20c4f6fbf9f65b,68e8e07754ecf9cd8fbced01bb852ffdbc11be56,4bedf113f2204205bfaea05ff1e7a243c6cdf8b3 -->

## Summary

- Adds `assembleJoinBundle()` + `redactBundleForLog()` in `join-bundle.mjs` — pure function gathering SHARED-only cluster config (hostsRoster, livenessAnchorIssue, botCreds, otlpEndpointHint, layer1Identity, repoUrl, pluginSourceUrl) from Layer-1 + Layer-2. No per-node items included.
- Adds `startArmedListener()` in `join-listener.mjs` — single-use bearer-token HTTP listener on port 7401 (Bun.serve + PID-file lifecycle). `handleJoinRequest()` is a pure decision function (timing-safe token check, consumed latch, TTL, correct-path guard). Consume-on-first-200 via 50ms-delayed `stop()`.
- Adds `catalyst cluster join-token [--port N] [--ttl MIN]` bash CLI, registered in `install-cli.sh`.

## Changes Made

### New files

| File | Description |
|---|---|
| `plugins/dev/scripts/execution-core/join-bundle.mjs` | Bundle assembler — reads SHARED fields from global config, redacts bot creds in logs |
| `plugins/dev/scripts/execution-core/join-listener.mjs` | Armed single-use HTTP listener — pure handler + Bun.serve lifecycle |
| `plugins/dev/scripts/catalyst-cluster` | `catalyst cluster join-token` bash CLI dispatcher |
| `plugins/dev/scripts/__tests__/catalyst-cluster-cli.test.sh` | 7 bash harness tests for CLI dispatch |
| `plugins/dev/scripts/execution-core/join-bundle.test.mjs` | 11 unit tests — assembler + redaction |
| `plugins/dev/scripts/execution-core/join-listener.test.mjs` | 9 unit tests — pure handler (no port binding) |
| `plugins/dev/scripts/execution-core/join-listener.integration.test.mjs` | 3 integration tests — arm → 200 → consume → replay-refused; TTL; missing token |

### Modified files

- `plugins/dev/scripts/install-cli.sh` — added `catalyst-cluster` to `CLI_ENTRIES`

## How to Verify It

- [x] `bun test join-bundle.test.mjs` — 11 unit tests green (assembler + redaction)
- [x] `bun test join-listener.test.mjs` — 9 unit tests green (pure handler, no port binding)
- [x] `bun test join-listener.integration.test.mjs` — 3 integration tests green (arm → 200 → consume → replay-refused; TTL expiry; missing token)
- [x] `bash plugins/dev/scripts/__tests__/catalyst-cluster-cli.test.sh` — 7 tests green (registration, dispatch, token mint, URL output)
- [x] `bash plugins/dev/scripts/__tests__/install-cli-stack-consistency.test.sh` — 4 tests green (no regression)
- [x] Full execution-core suite: 3833/3841 pass (8 pre-existing failures in dispatch/integration/monitor/daemon/scheduler/heartbeat)

## Pre-Merge Verification (automated)

| Gate | Status | Notes |
|---|---|---|
| Tests | ✅ pass | 30/30 pass: 20 bun unit + 3 bun integration + 7 bash CLI |
| Typecheck | ⏭ skip | No TypeScript in diff (bash + .mjs ESM only) |
| Lint | ⏭ skip | No JS linter configured; `bash -n` clean on both shell files |
| Security | ✅ pass | 256-bit env-passed token, TTL, consume-on-first-200, timingSafeEqual, per-request redaction |
| Reward hacking | ✅ pass | No as-any / ts-ignore / eslint-disable |
| Code review | ✅ pass | Adversarial review: only low-severity defense-in-depth findings |
| Regression risk | 2 / 10 | New files only; single `install-cli.sh` line |

**Low-severity findings** (defense-in-depth, no must-fix):
- `join-listener.mjs:106` — fetch handler has no try/catch; if `assembleJoinBundle()` threw, token is already consumed and listener lingers. All assembler deps are documented never-throws; optionally wrap in try/catch.
- `join-listener.mjs:82` — listener binds `0.0.0.0` though intent is tailnet-only. Mitigated by single-use + ≤15m TTL + 256-bit token + constant-time compare.
- `join-listener.mjs:104` — no TTL-bound self-destruct timer; un-consumed expired listener stays running until SIGTERM/reboot. TTL gates the 401 correctly; optionally `setTimeout(stop, ttlMs)`.
- `catalyst-cluster:31` — `--port`/`--ttl` arg parsing doesn't validate that `$2` is numeric; `--port --ttl` silently falls back to default port.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1183
