### PR TITLE
CTL-1202: Pin CATALYST_HOST_NAME in launchd plist and add Layer-2 config fallback to host-identity runtimes

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
@@ -401,6 +401,29 @@ run "rendered plist passes plutil lint (macOS)" bash -c "
   fi
 "
 
+# ── CTL-1202: install-services pins CATALYST_HOST_NAME from Layer-2 config ────
+HOSTCFG_HOME="${SCRATCH}/host_home"
+mkdir -p "${HOSTCFG_HOME}/.config/catalyst"
+printf '{"catalyst":{"host":{"name":"mini"}}}' > "${HOSTCFG_HOME}/.config/catalyst/config.json"
+
+run "install-services --print pins CATALYST_HOST_NAME key" bash -c "
+  HOME='${HOSTCFG_HOME}' '${STACK}' install-services --print 2>&1 | grep -q '<key>CATALYST_HOST_NAME</key>'
+"
+
+run "install-services --print pins configured host name value" bash -c "
+  HOME='${HOSTCFG_HOME}' '${STACK}' install-services --print 2>&1 | grep -A1 'CATALYST_HOST_NAME' | grep -q '<string>mini</string>'
+"
+
+run "install-services --print honors CATALYST_LAYER2_CONFIG_FILE" bash -c "
+  CATALYST_LAYER2_CONFIG_FILE='${HOSTCFG_HOME}/.config/catalyst/config.json' '${STACK}' install-services --print 2>&1 | grep -A1 'CATALYST_HOST_NAME' | grep -q '<string>mini</string>'
+"
+
+run "install-services --print omits key when host.name unset" bash -c "
+  emptyhome=\$(mktemp -d);
+  out=\$(HOME=\"\$emptyhome\" '${STACK}' install-services --print 2>/dev/null);
+  printf '%s' \"\$out\" | grep -q 'ai.coalesce.catalyst-stack' && ! printf '%s' \"\$out\" | grep -q '<key>CATALYST_HOST_NAME</key>'
+"
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 TOTAL=$((PASSES + FAILURES))

--- a/plugins/dev/scripts/__tests__/host-identity.test.sh
+++ b/plugins/dev/scripts/__tests__/host-identity.test.sh
@@ -111,6 +111,26 @@ else
   echo "  SKIP: cross-stack test (node not available or lib missing: $EC_LIB)"
 fi
 
+# CTL-1202: Layer-2 config fallback (catalyst.host.name) when env unset
+TMP_CFG_DIR="$(mktemp -d)"
+TMP_CFG="${TMP_CFG_DIR}/config.json"
+printf '{"catalyst":{"host":{"name":"mini"}}}' > "$TMP_CFG"
+
+expect_eq "Layer-2 config name used when env unset" \
+  "mini" "$(CATALYST_HOST_NAME='' CATALYST_LAYER2_CONFIG_FILE="$TMP_CFG" catalyst_host_name)"
+
+expect_eq "env wins over Layer-2 config" \
+  "alias-1" "$(CATALYST_HOST_NAME='alias-1' CATALYST_LAYER2_CONFIG_FILE="$TMP_CFG" catalyst_host_name)"
+
+# malformed/missing config falls through to real hostname (non-empty, no crash)
+MISSING="$(CATALYST_HOST_NAME='' CATALYST_LAYER2_CONFIG_FILE='/nonexistent/config.json' catalyst_host_name)"
+[[ -n "$MISSING" ]] && ok "missing Layer-2 file falls through" || fail "missing Layer-2 fallthrough" "got empty"
+
+# host.id reflects Layer-2 name == direct derivation
+expect_eq "Layer-2 name flows to host.id" \
+  "$(__host_id_from 'mini')" "$(CATALYST_HOST_NAME='' CATALYST_LAYER2_CONFIG_FILE="$TMP_CFG" catalyst_host_id)"
+rm -rf "$TMP_CFG_DIR"
+
 echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES"
 exit "$FAILURES"

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -622,7 +622,9 @@ cmd_install_services() {
 
   local cmd; cmd="$(_resolve_stack_cmd)"
   local host_name; host_name="$(_stack_host_name)"
-  [[ -z "$host_name" ]] && log "warning: catalyst.host.name not set in Layer-2 config; CATALYST_HOST_NAME will not be pinned (telemetry/scheduler identity may split)"
+  # Warning goes to stderr: log() writes stdout, and --print emits the plist to
+  # stdout — a stdout warning would corrupt `--print` output (CTL-1202 review).
+  [[ -z "$host_name" ]] && log "warning: catalyst.host.name not set in Layer-2 config; CATALYST_HOST_NAME will not be pinned (telemetry/scheduler identity may split)" >&2
   if [[ "$print_only" == "yes" ]]; then
     render_stack_plist "$cmd" "$interval" "$host_name"
     return 0

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -535,17 +535,34 @@ _resolve_stack_cmd() {
   fi
 }
 
+# _stack_host_name — resolve catalyst.host.name from Layer-2 config for plist pinning.
+# Honors CATALYST_LAYER2_CONFIG_FILE then ~/.config/catalyst/config.json. Empty when
+# unset/unreadable (caller omits the CATALYST_HOST_NAME key).
+_stack_host_name() {
+  local cfg="${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
+  if [[ -r "$cfg" ]] && command -v jq >/dev/null 2>&1; then
+    jq -r '.catalyst.host.name // empty' "$cfg" 2>/dev/null || true
+  fi
+}
+
 # _stack_agent_path — PATH for the launchd job so it finds the catalyst CLIs,
 # bun/node, and git in launchd's otherwise-minimal environment.
 _stack_agent_path() {
   printf '%s\n' "${HOME}/.catalyst/bin:${HOME}/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 }
 
-# render_stack_plist <cmd> <interval> — emit the LaunchAgent plist XML to stdout.
+# render_stack_plist <cmd> <interval> [host_name] — emit the LaunchAgent plist XML to stdout.
 # Pure: no filesystem or launchctl side effects, so it is unit-testable and the
-# `--print` flag can show exactly what would be installed.
+# `--print` flag can show exactly what would be installed. host_name is optional;
+# when non-empty, CATALYST_HOST_NAME is pinned in EnvironmentVariables (CTL-1202).
 render_stack_plist() {
-  local cmd="$1" interval="$2"
+  local cmd="$1" interval="$2" host_name="${3:-}"
+  local host_env=""
+  if [[ -n "$host_name" ]]; then
+    host_env="
+    <key>CATALYST_HOST_NAME</key>
+    <string>${host_name}</string>"
+  fi
   cat <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -579,7 +596,7 @@ render_stack_plist() {
     <key>PATH</key>
     <string>$(_stack_agent_path)</string>
     <key>HOME</key>
-    <string>${HOME}</string>
+    <string>${HOME}</string>${host_env}
   </dict>
 
   <key>StandardOutPath</key>
@@ -604,8 +621,10 @@ cmd_install_services() {
   [[ "$interval" =~ ^[0-9]+$ ]] || fail "--interval must be an integer (seconds), got: $interval"
 
   local cmd; cmd="$(_resolve_stack_cmd)"
+  local host_name; host_name="$(_stack_host_name)"
+  [[ -z "$host_name" ]] && log "warning: catalyst.host.name not set in Layer-2 config; CATALYST_HOST_NAME will not be pinned (telemetry/scheduler identity may split)"
   if [[ "$print_only" == "yes" ]]; then
-    render_stack_plist "$cmd" "$interval"
+    render_stack_plist "$cmd" "$interval" "$host_name"
     return 0
   fi
 
@@ -613,7 +632,7 @@ cmd_install_services() {
   command -v launchctl >/dev/null 2>&1 || fail "launchctl not found"
 
   mkdir -p "${HOME}/Library/LaunchAgents" "${HOME}/catalyst"
-  render_stack_plist "$cmd" "$interval" > "$STACK_AGENT_PLIST"
+  render_stack_plist "$cmd" "$interval" "$host_name" > "$STACK_AGENT_PLIST"
   log "wrote $STACK_AGENT_PLIST (exec: $cmd start, keep-alive ${interval}s)"
 
   local guid; guid="gui/$(id -u)"

--- a/plugins/dev/scripts/execution-core/__tests__/host-identity.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/host-identity.test.mjs
@@ -3,6 +3,9 @@
 
 import { describe, test, expect } from "bun:test";
 import { createHash } from "node:crypto";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { hostName, hostId } from "../lib/host-identity.mjs";
 
 function sha256Hex(input) {
@@ -41,6 +44,53 @@ describe("hostName", () => {
 
   test("result has no .local suffix by default", () => {
     expect(hostName()).not.toMatch(/\.local$/);
+  });
+});
+
+function withLayer2(name, fn) {
+  const dir = mkdtempSync(join(tmpdir(), "ctl1202-"));
+  const cfg = join(dir, "config.json");
+  writeFileSync(cfg, JSON.stringify({ catalyst: { host: { name } } }));
+  const origCfg = process.env.CATALYST_LAYER2_CONFIG_FILE;
+  const origEnv = process.env.CATALYST_HOST_NAME;
+  delete process.env.CATALYST_HOST_NAME;
+  process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+  try { return fn(); } finally {
+    if (origCfg === undefined) delete process.env.CATALYST_LAYER2_CONFIG_FILE;
+    else process.env.CATALYST_LAYER2_CONFIG_FILE = origCfg;
+    // Always restore CATALYST_HOST_NAME to pre-withLayer2 state (fn may have set it)
+    if (origEnv === undefined) delete process.env.CATALYST_HOST_NAME;
+    else process.env.CATALYST_HOST_NAME = origEnv;
+  }
+}
+
+describe("Layer-2 config fallback", () => {
+  test("Layer-2 catalyst.host.name is used when env unset", () => {
+    withLayer2("mini", () => expect(hostName()).toBe("mini"));
+  });
+  test("env var wins over Layer-2 config", () => {
+    withLayer2("mini", () => {
+      process.env.CATALYST_HOST_NAME = "env-alias";
+      expect(hostName()).toBe("env-alias");
+    });
+  });
+  test("explicit raw injection bypasses Layer-2 config read", () => {
+    withLayer2("mini", () => expect(hostName({ raw: "injected.local" })).toBe("injected"));
+  });
+  test("missing/malformed Layer-2 file falls through to os.hostname()", () => {
+    const orig = process.env.CATALYST_LAYER2_CONFIG_FILE;
+    const origEnv = process.env.CATALYST_HOST_NAME;
+    delete process.env.CATALYST_HOST_NAME;
+    process.env.CATALYST_LAYER2_CONFIG_FILE = "/nonexistent/path/config.json";
+    try { expect(hostName().length).toBeGreaterThan(0); }
+    finally {
+      if (orig === undefined) delete process.env.CATALYST_LAYER2_CONFIG_FILE;
+      else process.env.CATALYST_LAYER2_CONFIG_FILE = orig;
+      if (origEnv !== undefined) process.env.CATALYST_HOST_NAME = origEnv;
+    }
+  });
+  test("hostId reflects Layer-2 name", () => {
+    withLayer2("mini", () => expect(hostId()).toBe(sha256Hex("mini").slice(0, 16)));
   });
 });
 

--- a/plugins/dev/scripts/execution-core/lib/host-identity.mjs
+++ b/plugins/dev/scripts/execution-core/lib/host-identity.mjs
@@ -6,24 +6,39 @@
 //
 // Algorithm:
 //   host.name = CATALYST_HOST_NAME  (if set and non-empty)
+//               else catalyst.host.name from Layer-2 config  (if readable and non-empty)
 //               else os.hostname() with trailing ".local" stripped
 //   host.id   = sha256(host.name)[:16]   // 16 hex chars, same shape as spanId
 
 import { createHash } from "node:crypto";
-import { hostname } from "node:os";
+import { hostname, homedir } from "node:os";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
-// Memoize at module load — hostname does not change within a process.
-let _cachedHostName = null;
+// Layer-2 (machine-local) config — mirrors config.mjs getLayer2ConfigPath()/getHostName().
+function layer2HostName() {
+  const path = process.env.CATALYST_LAYER2_CONFIG_FILE ||
+    resolve(homedir(), ".config", "catalyst", "config.json");
+  try {
+    const name = JSON.parse(readFileSync(path, "utf8"))?.catalyst?.host?.name;
+    if (typeof name === "string" && name.length > 0) return name;
+  } catch { /* missing/malformed → caller falls through */ }
+  return null;
+}
 
 /**
  * Resolve the effective host name.
  * @param {{ raw?: string, override?: string }} [opts]
- *   raw      — injected hostname string (used in tests)
+ *   raw      — injected hostname string (used in tests; skips Layer-2 config read)
  *   override — explicit override (wins over CATALYST_HOST_NAME env)
  */
 export function hostName({ raw, override } = {}) {
   const o = override ?? process.env.CATALYST_HOST_NAME;
   if (o) return o;
+  if (raw === undefined) {
+    const cfg = layer2HostName();
+    if (cfg) return cfg;
+  }
   const base = raw ?? hostname();
   return base.replace(/\.local$/, "");
 }

--- a/plugins/dev/scripts/lib/host-identity.sh
+++ b/plugins/dev/scripts/lib/host-identity.sh
@@ -8,6 +8,7 @@
 #
 # Algorithm:
 #   host.name = CATALYST_HOST_NAME  (if set and non-empty)
+#               else catalyst.host.name from Layer-2 config  (if readable and non-empty)
 #               else os.hostname() with trailing ".local" stripped
 #   host.id   = sha256(host.name)[:16]   # 16 hex chars, same shape as spanId
 #
@@ -19,11 +20,20 @@ _CATALYST_HOST_IDENTITY_SH_LOADED=1
 __host_name_from() { printf '%s' "${1%.local}"; }
 
 # catalyst_host_name — resolve the effective host name.
-# Honors CATALYST_HOST_NAME override for multi-host alias scenarios.
+# Honors CATALYST_HOST_NAME override, then Layer-2 config, then os hostname.
 catalyst_host_name() {
   if [[ -n "${CATALYST_HOST_NAME:-}" ]]; then
     printf '%s' "$CATALYST_HOST_NAME"
     return
+  fi
+  local _cfg="${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
+  if [[ -r "$_cfg" ]] && command -v jq >/dev/null 2>&1; then
+    local _n
+    _n="$(jq -r '.catalyst.host.name // empty' "$_cfg" 2>/dev/null || true)"
+    if [[ -n "$_n" ]]; then
+      printf '%s' "$_n"
+      return
+    fi
   fi
   __host_name_from "$(hostname 2>/dev/null || uname -n)"
 }

--- a/plugins/dev/scripts/orch-monitor/__tests__/host-identity.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/host-identity.test.ts
@@ -2,6 +2,9 @@
 // Run: cd plugins/dev/scripts/orch-monitor && bun test host-identity
 
 import { describe, test, expect } from "bun:test";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { hostName, hostId, sha256Hex } from "../lib/canonical-event-shared";
 
 describe("hostName", () => {
@@ -47,6 +50,53 @@ describe("hostName", () => {
 
   test("result has no .local suffix by default", () => {
     expect(hostName()).not.toMatch(/\.local$/);
+  });
+});
+
+function withLayer2(name: string, fn: () => void) {
+  const dir = mkdtempSync(join(tmpdir(), "ctl1202-"));
+  const cfg = join(dir, "config.json");
+  writeFileSync(cfg, JSON.stringify({ catalyst: { host: { name } } }));
+  const origCfg = process.env.CATALYST_LAYER2_CONFIG_FILE;
+  const origEnv = process.env.CATALYST_HOST_NAME;
+  delete process.env.CATALYST_HOST_NAME;
+  process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+  try { return fn(); } finally {
+    if (origCfg === undefined) delete process.env.CATALYST_LAYER2_CONFIG_FILE;
+    else process.env.CATALYST_LAYER2_CONFIG_FILE = origCfg;
+    // Always restore CATALYST_HOST_NAME to pre-withLayer2 state (fn may have set it)
+    if (origEnv === undefined) delete process.env.CATALYST_HOST_NAME;
+    else process.env.CATALYST_HOST_NAME = origEnv;
+  }
+}
+
+describe("Layer-2 config fallback", () => {
+  test("Layer-2 catalyst.host.name is used when env unset", () => {
+    withLayer2("mini", () => expect(hostName()).toBe("mini"));
+  });
+  test("env var wins over Layer-2 config", () => {
+    withLayer2("mini", () => {
+      process.env.CATALYST_HOST_NAME = "env-alias";
+      expect(hostName()).toBe("env-alias");
+    });
+  });
+  test("explicit raw injection bypasses Layer-2 config read", () => {
+    withLayer2("mini", () => expect(hostName({ raw: "injected.local" })).toBe("injected"));
+  });
+  test("missing/malformed Layer-2 file falls through to os.hostname()", () => {
+    const orig = process.env.CATALYST_LAYER2_CONFIG_FILE;
+    const origEnv = process.env.CATALYST_HOST_NAME;
+    delete process.env.CATALYST_HOST_NAME;
+    process.env.CATALYST_LAYER2_CONFIG_FILE = "/nonexistent/path/config.json";
+    try { expect(hostName().length).toBeGreaterThan(0); }
+    finally {
+      if (orig === undefined) delete process.env.CATALYST_LAYER2_CONFIG_FILE;
+      else process.env.CATALYST_LAYER2_CONFIG_FILE = orig;
+      if (origEnv !== undefined) process.env.CATALYST_HOST_NAME = origEnv;
+    }
+  });
+  test("hostId reflects Layer-2 name", () => {
+    withLayer2("mini", () => expect(hostId()).toBe(sha256Hex("mini").slice(0, 16)));
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/lib/canonical-event-shared.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/canonical-event-shared.ts
@@ -11,7 +11,9 @@
  */
 
 import { createHash, randomUUID } from "node:crypto";
-import { hostname } from "node:os";
+import { hostname, homedir } from "node:os";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 export type Severity = "DEBUG" | "INFO" | "WARN" | "ERROR";
 
@@ -81,6 +83,18 @@ export function generateEventId(): string {
   return randomUUID();
 }
 
+// Layer-2 (machine-local) config — mirrors config.mjs getLayer2ConfigPath()/getHostName().
+function layer2HostName(): string | null {
+  const path = process.env.CATALYST_LAYER2_CONFIG_FILE ??
+    resolve(homedir(), ".config", "catalyst", "config.json");
+  try {
+    const name = (JSON.parse(readFileSync(path, "utf8")) as
+      { catalyst?: { host?: { name?: unknown } } })?.catalyst?.host?.name;
+    if (typeof name === "string" && name.length > 0) return name;
+  } catch { /* missing/malformed → caller falls through */ }
+  return null;
+}
+
 /**
  * Resolve the effective host name.
  * Mirrors lib/host-identity.sh (bash) and execution-core/lib/host-identity.mjs (MJS).
@@ -88,11 +102,16 @@ export function generateEventId(): string {
  * Precedence:
  *   1. explicit override param
  *   2. CATALYST_HOST_NAME env var
- *   3. os.hostname() with trailing ".local" stripped
+ *   3. catalyst.host.name from Layer-2 config
+ *   4. os.hostname() with trailing ".local" stripped
  */
 export function hostName(opts: { raw?: string; override?: string } = {}): string {
   const override = opts.override ?? process.env.CATALYST_HOST_NAME;
   if (override) return override;
+  if (opts.raw === undefined) {
+    const cfg = layer2HostName();
+    if (cfg) return cfg;
+  }
   return (opts.raw ?? hostname()).replace(/\.local$/, "");
 }
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-16T02:36:30Z -->
<!-- Last updated: 2026-06-16T02:36:30Z -->
<!-- PR: #2102 -->
<!-- Previous commits: 8af79340,c8fc7cdf,d0efc839 -->

## CTL-1202: Pin CATALYST_HOST_NAME in launchd plist; add Layer-2 config fallback to all host-identity runtimes

Host identity was split between two resolution paths that didn't agree: the scheduler (`config.mjs getHostName()`) read `catalyst.host.name` from Layer-2 config, but the three telemetry runtimes (bash `host-identity.sh`, ESM `host-identity.mjs`, TypeScript `canonical-event-shared.ts`) went directly to `os.hostname()`. On a machine where `os.hostname()` flips between wired/wireless network names, events emitted under two different `host.id` values — silently. Live evidence on `mini`: ~8,000 events showed 49 under `host.name=mini` (config-reading heartbeat) vs 679 under `host.name=RyansMini250233.rozich` (everything else).

This PR fixes both layers:

**Phase 1 — Layer-2 config fallback in the three host-identity libs**

All three runtimes now apply the same precedence chain:
1. `CATALYST_HOST_NAME` env var (existing, unchanged)
2. `catalyst.host.name` from Layer-2 config (`~/.config/catalyst/config.json` or `$CATALYST_LAYER2_CONFIG_FILE`) — **new**
3. `os.hostname()` minus trailing `.local` (existing fallback)

Files changed:
- `plugins/dev/scripts/lib/host-identity.sh` — added `jq`-based Layer-2 read in `catalyst_host_name()`
- `plugins/dev/scripts/execution-core/lib/host-identity.mjs` — added `layer2HostName()` called when `raw` is not injected
- `plugins/dev/scripts/orch-monitor/lib/canonical-event-shared.ts` — same pattern in TypeScript, mirrors the JS implementation

**Phase 2 — Pin CATALYST_HOST_NAME in launchd plist via catalyst-stack**

`catalyst-stack install-services` now reads `catalyst.host.name` from Layer-2 config (via new `_stack_host_name()`) and embeds `CATALYST_HOST_NAME` as a static `EnvironmentVariables` entry in the generated plist. All child processes (monitor, broker, execution-core, and their emitters) inherit it from launchd at startup, making identity immune to network hostname changes between restarts.

- `_stack_host_name()` helper added to `catalyst-stack`
- `render_stack_plist` accepts optional `host_name` arg; emits the `<key>CATALYST_HOST_NAME</key>` block when non-empty
- `cmd_install_services` passes the resolved name; warns to stderr when unset so stdout (`--print`) is not corrupted

**Phase-review remediations**

- Redirect `log()` warning to stderr in `install-services` to keep `--print` stdout clean (CTL-1202 review finding)

## Changes Made

### Bash (`host-identity.sh`)

- Added `jq`-based Layer-2 config read between the `CATALYST_HOST_NAME` check and the `hostname` fallback in `catalyst_host_name()`
- Honors `CATALYST_LAYER2_CONFIG_FILE` override for testability; gracefully no-ops when `jq` is absent or the file is missing/malformed

### ESM (`execution-core/lib/host-identity.mjs`)

- Added `layer2HostName()` that reads and JSON-parses the Layer-2 config; called in `hostName()` when `raw` is not injected (test-isolation path is unaffected)

### TypeScript (`orch-monitor/lib/canonical-event-shared.ts`)

- Added identical `layer2HostName()` pattern; integrated into `hostName()` at precedence level 3
- Updated JSDoc to document the new four-step precedence chain

### `catalyst-stack`

- `_stack_host_name()` — resolves `catalyst.host.name` from Layer-2 config using `jq`
- `render_stack_plist()` — optional `host_name` arg; conditionally emits `CATALYST_HOST_NAME` env block
- `cmd_install_services()` — calls `_stack_host_name()`, passes result to `render_stack_plist`, warns to stderr when empty

### Tests

- `__tests__/host-identity.test.sh` — 4 new bats-style cases: Layer-2 name used, env wins, missing file falls through, host.id flows from Layer-2 name
- `__tests__/host-identity.test.mjs` — `withLayer2()` helper + 5 new Bun tests covering the same matrix
- `orch-monitor/__tests__/host-identity.test.ts` — same withLayer2 helper + 5 parallel TypeScript tests
- `__tests__/catalyst-stack.test.sh` — 4 new tests: `--print` emits the key+value, honors `CATALYST_LAYER2_CONFIG_FILE`, omits key when host.name unset

## How to Verify It

- [x] TypeScript typecheck: `tsc --noEmit` ✅
- [x] Tests: all host-identity and catalyst-stack test suites ✅
- [x] Lint ✅
- [x] Test coverage ✅
- [ ] After merging: run `catalyst-stack install-services` on `mini` and confirm `CATALYST_HOST_NAME=mini` appears in the plist; restart the stack and confirm all events carry `host.name=mini`

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1202

## Changelog Entry

**feat(dev): pin CATALYST_HOST_NAME in launchd plist; add Layer-2 config fallback to all host-identity runtimes (CTL-1202)**

- Three host-identity runtimes (bash, ESM, TypeScript) now fall back to `catalyst.host.name` in Layer-2 config before `os.hostname()`, keeping all emitters in sync with the scheduler
- `catalyst-stack install-services` pins `CATALYST_HOST_NAME` in the generated plist so all child daemons inherit a stable identity at launchd startup
