### PR TITLE
feat(dev): CTL-1185 — catalyst-join.sh one-line node onboarding

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-join.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-join.test.sh
@@ -1,0 +1,665 @@
+#!/usr/bin/env bash
+# Tests for catalyst-join.sh (CTL-1185).
+# Run: bash plugins/dev/scripts/__tests__/catalyst-join.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+JOIN="${REPO_ROOT}/plugins/dev/scripts/catalyst-join.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1${2:+ — $2}"; }
+
+run() {
+  local name="$1"; shift
+  if "$@" >"${SCRATCH}/out" 2>&1; then
+    pass "$name"
+  else
+    fail "$name" "rc=$?"
+    sed 's/^/    /' "${SCRATCH}/out"
+  fi
+}
+
+expect_exit() {
+  local expected="$1"; shift
+  set +e; "$@" >"${SCRATCH}/out" 2>&1; local rc=$?; set -e
+  if [[ "$rc" -eq "$expected" ]]; then return 0; fi
+  echo "    expected rc=$expected got rc=$rc"
+  sed 's/^/    /' "${SCRATCH}/out"
+  return 1
+}
+
+expect_contains() {
+  local needle="$1"
+  if grep -qF -- "$needle" "${SCRATCH}/out"; then return 0; fi
+  echo "    missing: $needle"
+  sed 's/^/    /' "${SCRATCH}/out"
+  return 1
+}
+
+expect_not_contains() {
+  local needle="$1"
+  if ! grep -qF -- "$needle" "${SCRATCH}/out"; then return 0; fi
+  echo "    unexpected: $needle"
+  return 1
+}
+
+# Build a minimal stub directory with stubbable provisioner scripts
+make_stubs() {
+  local dir="$1"
+  mkdir -p "$dir"
+  local log="${dir}/invocations.log"
+
+  cat > "$dir/stub-setup-catalyst.sh" <<EOF
+#!/usr/bin/env bash
+echo "setup-catalyst CATALYST_AUTONOMOUS=\${CATALYST_AUTONOMOUS:-unset}" >> "$log"
+exit 0
+EOF
+  chmod +x "$dir/stub-setup-catalyst.sh"
+
+  cat > "$dir/stub-install-cli.sh" <<EOF
+#!/usr/bin/env bash
+echo "install-cli" >> "$log"
+exit 0
+EOF
+  chmod +x "$dir/stub-install-cli.sh"
+
+  cat > "$dir/stub-setup-plugin-source.sh" <<EOF
+#!/usr/bin/env bash
+echo "setup-plugin-source" >> "$log"
+exit 0
+EOF
+  chmod +x "$dir/stub-setup-plugin-source.sh"
+
+  cat > "$dir/stub-catalyst-stack" <<EOF
+#!/usr/bin/env bash
+echo "catalyst-stack \$*" >> "$log"
+exit 0
+EOF
+  chmod +x "$dir/stub-catalyst-stack"
+
+  cat > "$dir/stub-check-setup.sh" <<EOF
+#!/usr/bin/env bash
+echo "check-setup" >> "$log"
+exit 0
+EOF
+  chmod +x "$dir/stub-check-setup.sh"
+
+  # Reachability probe stub: success by default
+  cat > "$dir/stub-reach-probe.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$dir/stub-reach-probe.sh"
+}
+
+# Run catalyst-join.sh with a fully-stubbed env (HOME + CATALYST_DIR redirected)
+run_join() {
+  local stub_dir="$1"; shift
+  local scratch_home="${SCRATCH}/home_$$"
+  mkdir -p "$scratch_home"
+  env -i \
+    HOME="$scratch_home" \
+    CATALYST_DIR="${SCRATCH}/catalyst_$$" \
+    PATH="${stub_dir}:${PATH}" \
+    CATALYST_JOIN_SETUP_SCRIPT="${stub_dir}/stub-setup-catalyst.sh" \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT="${stub_dir}/stub-install-cli.sh" \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT="${stub_dir}/stub-setup-plugin-source.sh" \
+    CATALYST_JOIN_STACK_BIN="${stub_dir}/stub-catalyst-stack" \
+    CATALYST_JOIN_DOCTOR_SCRIPT="${stub_dir}/stub-check-setup.sh" \
+    CATALYST_JOIN_REACH_PROBE="${stub_dir}/stub-reach-probe.sh" \
+    CATALYST_JOIN_FETCH_CMD="${stub_dir}/stub-fetch.sh" \
+    bash "$JOIN" "$@"
+}
+
+# ── Prerequisites ──────────────────────────────────────────────────────────────
+
+echo "=== Prerequisites ==="
+
+if [[ -f "$JOIN" ]]; then
+  pass "catalyst-join.sh exists"
+else
+  fail "catalyst-join.sh exists" "not found at $JOIN"
+fi
+
+run "syntax check (bash -n)" bash -n "$JOIN"
+
+# ── Phase 1: Skeleton — arg parsing, preflight, progress marker ────────────────
+
+echo ""
+echo "=== Phase 1: arg parsing, preflight, progress marker ==="
+
+STUBS="${SCRATCH}/stubs1"
+make_stubs "$STUBS"
+
+# T1.1: --help exits 0 and prints usage with CATALYST_SEED doc
+run "T1.1 --help exits 0 and documents CATALYST_SEED" bash -c "
+  out=\$(bash '$JOIN' --help 2>&1)
+  rc=\$?
+  [[ \$rc -eq 0 ]] && echo \"\$out\" | grep -qF 'CATALYST_SEED'"
+
+# T1.2: -h exits 0
+run "T1.2 -h exits 0" bash "$JOIN" -h
+
+# T1.3: missing token AND no --bundle → exits non-zero
+run "T1.3 missing token exits non-zero" bash -c "
+  s=\$(env -i HOME='${SCRATCH}/h13' CATALYST_DIR='${SCRATCH}/c13' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS}/stub-reach-probe.sh' \
+    bash '$JOIN' 2>&1; echo rc=\$?)
+  echo \"\$s\" | grep -q 'rc=[^0]'"
+
+# T1.4: malformed token (not_a_token) → exits non-zero, no marker stage
+run "T1.4 malformed token (not_a_token) rejected" bash -c "
+  tmpcat='${SCRATCH}/c14'
+  mkdir -p \"\$tmpcat/cluster\"
+  env -i HOME='${SCRATCH}/h14' CATALYST_DIR=\"\$tmpcat\" \
+    CATALYST_JOIN_TOKEN='not_a_token' \
+    CATALYST_SEED='mini:7400' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS}/stub-reach-probe.sh' \
+    bash '$JOIN' >/dev/null 2>&1; ec=\$?
+  [[ \$ec -ne 0 ]] && \
+  ( [[ ! -f \"\$tmpcat/cluster/join-progress.json\" ]] || \
+    ! jq -e '.completedStages | length > 0' \"\$tmpcat/cluster/join-progress.json\" >/dev/null 2>&1 )"
+
+# T1.5: wrong-length token → exits non-zero
+run "T1.5 wrong-length token rejected" bash -c "
+  env -i HOME='${SCRATCH}/h15' CATALYST_DIR='${SCRATCH}/c15' \
+    CATALYST_JOIN_TOKEN='jt_abc123' \
+    CATALYST_SEED='mini:7400' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS}/stub-reach-probe.sh' \
+    bash '$JOIN' >/dev/null 2>&1; [[ \$? -ne 0 ]]"
+
+# T1.6: non-hex token → exits non-zero
+NONHEX_TOKEN="jt_$(printf 'Z%.0s' {1..64})"
+run "T1.6 non-hex token rejected" bash -c "
+  env -i HOME='${SCRATCH}/h16' CATALYST_DIR='${SCRATCH}/c16' \
+    CATALYST_JOIN_TOKEN='$NONHEX_TOKEN' \
+    CATALYST_SEED='mini:7400' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS}/stub-reach-probe.sh' \
+    bash '$JOIN' >/dev/null 2>&1; [[ \$? -ne 0 ]]"
+
+# T1.7: well-formed token passes format validation (bundle mode, no network)
+GOOD_TOKEN="jt_$(printf 'a%.0s' {1..64})"
+FIXTURE_BUNDLE="${SCRATCH}/bundle.json"
+cat > "$FIXTURE_BUNDLE" <<'BEOF'
+{
+  "layer1Identity": {"projectKey": "CTL", "teamKey": "T1", "stateMap": {}},
+  "botCreds": {"orchestrator": "tok_orch", "worker": "tok_worker"},
+  "hostsRoster": ["mini"],
+  "livenessAnchorIssue": "CTL-1",
+  "repoUrl": "https://github.com/example/repo",
+  "pluginSourceUrl": "https://github.com/example/plugins"
+}
+BEOF
+run "T1.7 well-formed token passes format validation" bash -c "
+  env -i HOME='${SCRATCH}/h17' CATALYST_DIR='${SCRATCH}/c17' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS}/stub-reach-probe.sh' \
+    CATALYST_JOIN_FETCH_CMD='${STUBS}/stub-fetch.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1"
+
+# T1.8: --bundle selects bundle mode; CATALYST_SEED not required
+run "T1.8 --bundle mode does not require CATALYST_SEED" bash -c "
+  env -i HOME='${SCRATCH}/h18' CATALYST_DIR='${SCRATCH}/c18' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1"
+
+# T1.9: reachability probe failure → exits non-zero (non-bundle mode)
+STUBS_NOREACH="${SCRATCH}/stubs_noreach"
+make_stubs "$STUBS_NOREACH"
+cat > "$STUBS_NOREACH/stub-reach-probe.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$STUBS_NOREACH/stub-reach-probe.sh"
+
+run "T1.9 reachability failure exits non-zero" bash -c "
+  env -i HOME='${SCRATCH}/h19' CATALYST_DIR='${SCRATCH}/c19' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_SEED='mini:7400' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS_NOREACH}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS_NOREACH}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS_NOREACH}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS_NOREACH}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS_NOREACH}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS_NOREACH}/stub-reach-probe.sh' \
+    bash '$JOIN' >/dev/null 2>&1; [[ \$? -ne 0 ]]"
+
+# T1.10: --bundle mode skips reachability probe
+run "T1.10 --bundle skips reachability probe" bash -c "
+  env -i HOME='${SCRATCH}/h110' CATALYST_DIR='${SCRATCH}/c110' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS_NOREACH}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS_NOREACH}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS_NOREACH}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS_NOREACH}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS_NOREACH}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS_NOREACH}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1"
+
+# T1.11: progress marker round-trip
+run "T1.11 progress marker created after successful run" bash -c "
+  catdir='${SCRATCH}/c111'
+  env -i HOME='${SCRATCH}/h111' CATALYST_DIR=\"\$catdir\" \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
+  marker=\"\$catdir/cluster/join-progress.json\"
+  [[ -f \"\$marker\" ]] && \
+  jq -e '.completedStages | type == \"array\"' \"\$marker\" >/dev/null && \
+  jq -e '.startedAt | length > 0' \"\$marker\" >/dev/null"
+
+# ── Phase 2: Bundle acquisition ────────────────────────────────────────────────
+
+echo ""
+echo "=== Phase 2: Bundle acquisition ==="
+
+STUBS2="${SCRATCH}/stubs2"
+make_stubs "$STUBS2"
+
+# T2.1: --bundle with valid fixture → success, marker records bundlePath
+run "T2.1 --bundle valid fixture succeeds" bash -c "
+  catdir='${SCRATCH}/c21'
+  env -i HOME='${SCRATCH}/h21' CATALYST_DIR=\"\$catdir\" \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1 && \
+  jq -e '.bundlePath | length > 0' \"\$catdir/cluster/join-progress.json\" >/dev/null"
+
+# T2.2: --bundle with malformed JSON (missing required keys) → exits non-zero
+MALFORMED_BUNDLE="${SCRATCH}/malformed.json"
+echo '{"layer1Identity": {"projectKey": "CTL"}}' > "$MALFORMED_BUNDLE"
+
+run "T2.2 --bundle malformed bundle rejected" bash -c "
+  env -i HOME='${SCRATCH}/h22' CATALYST_DIR='${SCRATCH}/c22' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$MALFORMED_BUNDLE' >/dev/null 2>&1; [[ \$? -ne 0 ]]"
+
+# T2.3: Seed fetch via mock (CATALYST_JOIN_FETCH_CMD stub) → success
+FETCH_STUB="${STUBS2}/stub-fetch.sh"
+cat > "$FETCH_STUB" <<EOF
+#!/usr/bin/env bash
+cat '$FIXTURE_BUNDLE'
+EOF
+chmod +x "$FETCH_STUB"
+
+run "T2.3 seed fetch via mock succeeds" bash -c "
+  catdir='${SCRATCH}/c23'
+  env -i HOME='${SCRATCH}/h23' CATALYST_DIR=\"\$catdir\" \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_SEED='mini:7400' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    CATALYST_JOIN_FETCH_CMD='$FETCH_STUB' \
+    bash '$JOIN' >/dev/null 2>&1"
+
+# T2.4: Token-consumed (fetch stub exits non-zero) → exits non-zero, prints re-mint command
+CONSUMED_STUB="${STUBS2}/stub-fetch-consumed.sh"
+cat > "$CONSUMED_STUB" <<'EOF'
+#!/usr/bin/env bash
+echo "HTTP 410 consumed" >&2
+exit 1
+EOF
+chmod +x "$CONSUMED_STUB"
+
+run "T2.4 consumed token prints re-mint command" bash -c "
+  env -i HOME='${SCRATCH}/h24' CATALYST_DIR='${SCRATCH}/c24' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_SEED='mini:7400' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    CATALYST_JOIN_FETCH_CMD='$CONSUMED_STUB' \
+    bash '$JOIN' 2>&1 | grep -q 'catalyst cluster join-token'"
+
+# T2.5: --bundle mode does NOT call fetch stub
+FETCH_TRACK="${STUBS2}/stub-fetch-track.sh"
+FETCH_TRACK_LOG="${SCRATCH}/fetch-track.log"
+cat > "$FETCH_TRACK" <<EOF
+#!/usr/bin/env bash
+echo "called" >> "$FETCH_TRACK_LOG"
+cat '$FIXTURE_BUNDLE'
+EOF
+chmod +x "$FETCH_TRACK"
+
+run "T2.5 --bundle mode does not call fetch stub" bash -c "
+  rm -f '$FETCH_TRACK_LOG'
+  env -i HOME='${SCRATCH}/h25' CATALYST_DIR='${SCRATCH}/c25' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    CATALYST_JOIN_FETCH_CMD='$FETCH_TRACK' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
+  [[ ! -f '$FETCH_TRACK_LOG' ]]"
+
+# ── Phase 3: Provisioner orchestration ────────────────────────────────────────
+
+echo ""
+echo "=== Phase 3: Provisioner orchestration ==="
+
+STUBS3="${SCRATCH}/stubs3"
+make_stubs "$STUBS3"
+INVLOG3="${STUBS3}/invocations.log"
+
+# T3.1: Fresh run executes provisioners in order: setup-catalyst, install-cli, setup-plugin-source
+run "T3.1 provisioners run in correct order" bash -c "
+  catdir='${SCRATCH}/c31'
+  rm -f '$INVLOG3'
+  env -i HOME='${SCRATCH}/h31' CATALYST_DIR=\"\$catdir\" \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS3}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS3}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS3}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS3}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS3}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS3}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
+  # Verify order: setup-catalyst before install-cli before setup-plugin-source
+  grep -n 'setup-catalyst\|install-cli\|setup-plugin-source' '$INVLOG3' | \
+    awk -F: '{print \$1, \$2}' | sort -n | \
+    awk '{print \$2}' | tr '\n' ' ' | grep -q 'setup-catalyst.*install-cli.*setup-plugin-source'"
+
+# T3.2: setup-catalyst invoked with CATALYST_AUTONOMOUS=1
+run "T3.2 setup-catalyst invoked with CATALYST_AUTONOMOUS=1" bash -c "
+  catdir='${SCRATCH}/c32'
+  rm -f '$INVLOG3'
+  env -i HOME='${SCRATCH}/h32' CATALYST_DIR=\"\$catdir\" \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS3}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS3}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS3}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS3}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS3}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS3}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
+  grep 'setup-catalyst' '$INVLOG3' | grep -q 'CATALYST_AUTONOMOUS=1'"
+
+# T3.3: Resumability — pre-seed marker with setup-catalyst completed; re-run skips it
+run "T3.3 resume skips already-completed stages" bash -c "
+  catdir='${SCRATCH}/c33'
+  mkdir -p \"\$catdir/cluster\"
+  rm -f '$INVLOG3'
+  # Pre-seed the marker
+  printf '{\"completedStages\":[\"setup-catalyst\"],\"startedAt\":\"2026-01-01T00:00:00Z\",\"token\":\"$GOOD_TOKEN\"}' \
+    > \"\$catdir/cluster/join-progress.json\"
+  env -i HOME='${SCRATCH}/h33' CATALYST_DIR=\"\$catdir\" \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS3}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS3}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS3}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS3}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS3}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS3}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
+  # setup-catalyst stub must NOT have been invoked this run
+  ! grep -q 'setup-catalyst' '$INVLOG3'"
+
+# T3.4: Provisioner failure → records failedStage, exits non-zero, does not run later provisioners
+STUBS3F="${SCRATCH}/stubs3f"
+make_stubs "$STUBS3F"
+INVLOG3F="${STUBS3F}/invocations.log"
+cat > "$STUBS3F/stub-install-cli.sh" <<EOF
+#!/usr/bin/env bash
+echo "install-cli" >> "$INVLOG3F"
+exit 1
+EOF
+chmod +x "$STUBS3F/stub-install-cli.sh"
+
+run "T3.4 provisioner failure records failedStage and exits non-zero" bash -c "
+  catdir='${SCRATCH}/c34'
+  rm -f '$INVLOG3F'
+  env -i HOME='${SCRATCH}/h34' CATALYST_DIR=\"\$catdir\" \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS3F}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS3F}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS3F}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS3F}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS3F}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS3F}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1; ec=\$?
+  [[ \$ec -ne 0 ]] && \
+  jq -e '.failedStage == \"install-cli\"' \"\$catdir/cluster/join-progress.json\" >/dev/null && \
+  ! grep -q 'setup-plugin-source' '$INVLOG3F'"
+
+# T3.5: Re-run after failure resumes at the failed stage (skips completed, retries failed)
+STUBS3R="${SCRATCH}/stubs3r"
+make_stubs "$STUBS3R"
+INVLOG3R="${STUBS3R}/invocations.log"
+
+run "T3.5 re-run after failure resumes from failed stage" bash -c "
+  catdir='${SCRATCH}/c35'
+  mkdir -p \"\$catdir/cluster\"
+  rm -f '$INVLOG3R'
+  # Pre-seed: setup-catalyst done, install-cli failed
+  printf '{\"completedStages\":[\"setup-catalyst\"],\"failedStage\":\"install-cli\",\"startedAt\":\"2026-01-01T00:00:00Z\",\"token\":\"$GOOD_TOKEN\"}' \
+    > \"\$catdir/cluster/join-progress.json\"
+  env -i HOME='${SCRATCH}/h35' CATALYST_DIR=\"\$catdir\" \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS3R}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS3R}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS3R}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS3R}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS3R}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS3R}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
+  # setup-catalyst skipped, install-cli and later ran
+  ! grep -q 'setup-catalyst' '$INVLOG3R' && \
+  grep -q 'install-cli' '$INVLOG3R'"
+
+# ── Phase 4: SHARED config merge, per-node items, doctor gate, SHADOW stop ────
+
+echo ""
+echo "=== Phase 4: Config merge, per-node items, doctor gate, SHADOW stop ==="
+
+STUBS4="${SCRATCH}/stubs4"
+make_stubs "$STUBS4"
+
+# T4.1: Merge-preserve — existing node-local keys survive; SHARED bundle keys added
+run "T4.1 merge-preserve: node-local keys survive" bash -c "
+  catdir='${SCRATCH}/c41'
+  home41='${SCRATCH}/h41'
+  mkdir -p \"\$home41/.config/catalyst\"
+  # Pre-existing Layer-2 with node-local keys
+  printf '{\"catalyst\":{\"host\":{\"name\":\"testnode\"},\"otel\":{\"endpoint\":\"http://localhost:4317\"}}}' \
+    > \"\$home41/.config/catalyst/config.json\"
+  env -i HOME=\"\$home41\" CATALYST_DIR=\"\$catdir\" \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS4}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS4}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS4}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS4}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS4}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS4}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
+  cfg=\"\$home41/.config/catalyst/config.json\"
+  jq -e '.catalyst.otel.endpoint == \"http://localhost:4317\"' \"\$cfg\" >/dev/null && \
+  jq -e '.catalyst.cluster.livenessAnchorIssue | length > 0' \"\$cfg\" >/dev/null"
+
+# T4.2: host.name persisted explicitly
+run "T4.2 host.name written to Layer-2 config" bash -c "
+  catdir='${SCRATCH}/c42'
+  home42='${SCRATCH}/h42'
+  mkdir -p \"\$home42/.config/catalyst\"
+  printf '{}' > \"\$home42/.config/catalyst/config.json\"
+  env -i HOME=\"\$home42\" CATALYST_DIR=\"\$catdir\" \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_HOST_NAME='mynode' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS4}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS4}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS4}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS4}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS4}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS4}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
+  jq -e '.catalyst.host.name == \"mynode\"' \"\$home42/.config/catalyst/config.json\" >/dev/null"
+
+# T4.3: LOCAL hosts.json written; committed roster NOT touched
+run "T4.3 local hosts.json written; committed roster untouched" bash -c "
+  catdir='${SCRATCH}/c43'
+  home43='${SCRATCH}/h43'
+  mkdir -p \"\$home43/.config/catalyst\"
+  printf '{}' > \"\$home43/.config/catalyst/config.json\"
+  # Place a fake committed roster to check it's not modified
+  roster='${SCRATCH}/committed-hosts.json'
+  printf '[\"mini\"]' > \"\$roster\"
+  orig_sum=\$(md5 -q \"\$roster\" 2>/dev/null || md5sum \"\$roster\" | cut -d' ' -f1)
+  env -i HOME=\"\$home43\" CATALYST_DIR=\"\$catdir\" \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_HOST_NAME='newnode' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS4}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS4}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS4}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS4}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS4}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS4}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
+  # Local roster must exist
+  local_roster=\"\$catdir/cluster/local-hosts.json\"
+  [[ -f \"\$local_roster\" ]] && \
+  jq -e 'type == \"array\" or type == \"object\"' \"\$local_roster\" >/dev/null && \
+  # Committed roster must be unchanged
+  new_sum=\$(md5 -q \"\$roster\" 2>/dev/null || md5sum \"\$roster\" | cut -d' ' -f1)
+  [[ \"\$orig_sum\" == \"\$new_sum\" ]]"
+
+# T4.4: Doctor gate failure → exits non-zero before catalyst-stack
+STUBS4D="${SCRATCH}/stubs4d"
+make_stubs "$STUBS4D"
+INVLOG4D="${STUBS4D}/invocations.log"
+cat > "$STUBS4D/stub-check-setup.sh" <<EOF
+#!/usr/bin/env bash
+echo "check-setup-fail" >> "$INVLOG4D"
+exit 1
+EOF
+chmod +x "$STUBS4D/stub-check-setup.sh"
+
+run "T4.4 doctor gate failure exits non-zero before stack install" bash -c "
+  catdir='${SCRATCH}/c44'
+  home44='${SCRATCH}/h44'
+  mkdir -p \"\$home44/.config/catalyst\"
+  printf '{}' > \"\$home44/.config/catalyst/config.json\"
+  rm -f '$INVLOG4D'
+  env -i HOME=\"\$home44\" CATALYST_DIR=\"\$catdir\" \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS4D}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS4D}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS4D}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS4D}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS4D}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS4D}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1; [[ \$? -ne 0 ]] && \
+  ! grep -q 'catalyst-stack install-services' '$INVLOG4D'"
+
+# T4.5: catalyst-stack install-services runs AFTER config merge
+STUBS4O="${SCRATCH}/stubs4o"
+make_stubs "$STUBS4O"
+INVLOG4O="${STUBS4O}/invocations.log"
+
+run "T4.5 catalyst-stack install-services runs last" bash -c "
+  catdir='${SCRATCH}/c45'
+  home45='${SCRATCH}/h45'
+  mkdir -p \"\$home45/.config/catalyst\"
+  printf '{}' > \"\$home45/.config/catalyst/config.json\"
+  rm -f '$INVLOG4O'
+  env -i HOME=\"\$home45\" CATALYST_DIR=\"\$catdir\" \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS4O}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS4O}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS4O}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS4O}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS4O}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS4O}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
+  # stack install-services must be last in the log
+  last=\$(tail -1 '$INVLOG4O')
+  echo \"\$last\" | grep -q 'install-services'"
+
+# T4.6: Idempotency — second run with same host.name produces identical config
+run "T4.6 idempotency: second run is no-op" bash -c "
+  catdir='${SCRATCH}/c46'
+  home46='${SCRATCH}/h46'
+  mkdir -p \"\$home46/.config/catalyst\"
+  printf '{}' > \"\$home46/.config/catalyst/config.json\"
+  base_env=\"HOME=\$home46 CATALYST_DIR=\$catdir CATALYST_JOIN_TOKEN=$GOOD_TOKEN CATALYST_HOST_NAME=testnode\"
+  base_env+=' CATALYST_JOIN_SETUP_SCRIPT=${STUBS4}/stub-setup-catalyst.sh'
+  base_env+=' CATALYST_JOIN_INSTALL_CLI_SCRIPT=${STUBS4}/stub-install-cli.sh'
+  base_env+=' CATALYST_JOIN_PLUGIN_SRC_SCRIPT=${STUBS4}/stub-setup-plugin-source.sh'
+  base_env+=' CATALYST_JOIN_STACK_BIN=${STUBS4}/stub-catalyst-stack'
+  base_env+=' CATALYST_JOIN_DOCTOR_SCRIPT=${STUBS4}/stub-check-setup.sh'
+  base_env+=' CATALYST_JOIN_REACH_PROBE=${STUBS4}/stub-reach-probe.sh'
+  # Run 1
+  env -i \$base_env bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
+  cfg=\"\$home46/.config/catalyst/config.json\"
+  sum1=\$(md5 -q \"\$cfg\" 2>/dev/null || md5sum \"\$cfg\" | cut -d' ' -f1)
+  # Run 2
+  env -i \$base_env bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
+  sum2=\$(md5 -q \"\$cfg\" 2>/dev/null || md5sum \"\$cfg\" | cut -d' ' -f1)
+  [[ \"\$sum1\" == \"\$sum2\" ]]"
+
+# ── Summary ────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $PASSES passed, $FAILURES failed"
+exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/catalyst-join.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-join.test.sh
@@ -576,10 +576,12 @@ run "T4.3 local hosts.json written; committed roster untouched" bash -c "
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS4}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS4}/stub-reach-probe.sh' \
     bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
-  # Local roster must exist
+  # Local roster must exist AND contain exactly the host name — a content
+  # assertion (not just type), so a polluted multi-line roster value fails here
+  # (CTL-1185 remediate: this is the test that lets the HIGH roster bug through).
   local_roster=\"\$catdir/cluster/local-hosts.json\"
   [[ -f \"\$local_roster\" ]] && \
-  jq -e 'type == \"array\" or type == \"object\"' \"\$local_roster\" >/dev/null && \
+  jq -e '. == [\"newnode\"]' \"\$local_roster\" >/dev/null && \
   # Committed roster must be unchanged
   new_sum=\$(md5 -q \"\$roster\" 2>/dev/null || md5sum \"\$roster\" | cut -d' ' -f1)
   [[ \"\$orig_sum\" == \"\$new_sum\" ]]"
@@ -652,11 +654,17 @@ run "T4.6 idempotency: second run is no-op" bash -c "
   # Run 1
   env -i \$base_env bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
   cfg=\"\$home46/.config/catalyst/config.json\"
+  roster=\"\$catdir/cluster/local-hosts.json\"
   sum1=\$(md5 -q \"\$cfg\" 2>/dev/null || md5sum \"\$cfg\" | cut -d' ' -f1)
+  rsum1=\$(md5 -q \"\$roster\" 2>/dev/null || md5sum \"\$roster\" | cut -d' ' -f1)
   # Run 2
   env -i \$base_env bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
   sum2=\$(md5 -q \"\$cfg\" 2>/dev/null || md5sum \"\$cfg\" | cut -d' ' -f1)
-  [[ \"\$sum1\" == \"\$sum2\" ]]"
+  rsum2=\$(md5 -q \"\$roster\" 2>/dev/null || md5sum \"\$roster\" | cut -d' ' -f1)
+  # CTL-1185 remediate: config AND roster must both be byte-identical across runs,
+  # and the roster must still be exactly [host] (not a duplicated/polluted value).
+  [[ \"\$sum1\" == \"\$sum2\" ]] && [[ \"\$rsum1\" == \"\$rsum2\" ]] && \
+  jq -e '. == [\"testnode\"]' \"\$roster\" >/dev/null"
 
 # ── Summary ────────────────────────────────────────────────────────────────────
 

--- a/plugins/dev/scripts/catalyst-join.sh
+++ b/plugins/dev/scripts/catalyst-join.sh
@@ -113,6 +113,13 @@ if [[ -z "$BUNDLE_PATH" ]]; then
     exit 1
   fi
   validate_token "$CATALYST_JOIN_TOKEN" || exit 1
+else
+  # --bundle mode: a token is optional, but if one IS supplied it must be
+  # well-formed. An unvalidated token would be persisted raw into the marker
+  # (CTL-1185 remediate: verify silent-failure finding).
+  if [[ -n "$CATALYST_JOIN_TOKEN" ]]; then
+    validate_token "$CATALYST_JOIN_TOKEN" || exit 1
+  fi
 fi
 
 # ── State paths ───────────────────────────────────────────────────────────────
@@ -144,10 +151,22 @@ marker_init() {
   if [[ "$RESUME" -eq 1 && -f "$MARKER_FILE" ]]; then
     return 0  # preserve existing marker for resume
   fi
-  printf '{"completedStages":[],"startedAt":"%s"' "$ts" > "$MARKER_FILE"
-  [[ -n "$CATALYST_JOIN_TOKEN" ]] && printf ',"token":"%s"' "$CATALYST_JOIN_TOKEN" >> "$MARKER_FILE"
-  [[ -n "$BUNDLE_PATH" ]]         && printf ',"bundlePath":"%s"' "$BUNDLE_PATH"   >> "$MARKER_FILE"
-  printf '}\n' >> "$MARKER_FILE"
+  # CTL-1185 remediate: build with jq --arg (not raw printf) so a token or
+  # bundlePath containing a double-quote/backslash cannot produce invalid JSON
+  # that silently breaks every later marker op under `2>/dev/null` and wedges
+  # resume with no error surfaced (verify silent-failure finding).
+  jq -n \
+    --arg ts "$ts" \
+    --arg token "${CATALYST_JOIN_TOKEN:-}" \
+    --arg bundlePath "${BUNDLE_PATH:-}" \
+    '{completedStages: [], startedAt: $ts}
+     + (if $token != "" then {token: $token} else {} end)
+     + (if $bundlePath != "" then {bundlePath: $bundlePath} else {} end)' \
+    > "$MARKER_FILE"
+  # The marker may hold the join token; lock it to 0600 immediately rather than
+  # leaving it world-readable until a later marker op's mktemp+mv replaces it
+  # (verify security finding; CTL-1203 secrets-600 hygiene).
+  chmod 0600 "$MARKER_FILE" 2>/dev/null || true
 }
 
 marker_has_stage() {
@@ -358,7 +377,13 @@ do_setup_plugin_source() {
 merge_shared_config() {
   local cfg="$LAYER2_CONFIG"
   mkdir -p "$(dirname "$cfg")"
-  [[ -f "$cfg" ]] || echo '{}' > "$cfg"
+  if [[ ! -f "$cfg" ]]; then
+    # Create at 0600 before it ever holds botCreds.orchestrator/worker — the
+    # default umask would otherwise leave a transient world-readable window
+    # (verify security finding; CTL-1203 secrets-600 hygiene).
+    echo '{}' > "$cfg"
+    chmod 0600 "$cfg" 2>/dev/null || true
+  fi
 
   # Extract SHARED keys from bundle; preserve all existing node-local keys
   local la_project la_team la_statemap bot_orch bot_worker liveness repo_url plugin_url
@@ -407,12 +432,20 @@ persist_host_name() {
     host_name="$(hostname -s 2>/dev/null || hostname | sed 's/\.local$//')"
     host_name="${host_name%.local}"
   fi
-  [[ -f "$cfg" ]] || echo '{}' > "$cfg"
+  if [[ ! -f "$cfg" ]]; then
+    echo '{}' > "$cfg"
+    chmod 0600 "$cfg" 2>/dev/null || true  # holds botCreds; protect immediately (CTL-1203)
+  fi
   local tmp
   tmp="$(mktemp "$(dirname "$cfg")/.config.XXXXXX")"
   jq --arg hn "$host_name" '.catalyst.host.name = $hn' "$cfg" > "$tmp" && mv "$tmp" "$cfg" || { rm -f "$tmp"; return 1; }
   info "host.name set to: ${host_name}"
-  echo "$host_name"  # return value
+  # CTL-1185 remediate: return the host name via a global, NOT via stdout. The
+  # caller captures host_name="$(persist_host_name)"; echoing here makes command
+  # substitution capture the info() line above too, so write_local_roster stored
+  # a polluted multi-line value and local-hosts.json became
+  # ["[join] host.name set to: <h>\n<h>"] instead of ["<h>"] (verify HIGH finding).
+  PERSISTED_HOST_NAME="$host_name"
 }
 
 write_local_roster() {
@@ -438,9 +471,12 @@ write_local_roster() {
 
 do_config_merge() {
   merge_shared_config || return 1
-  local host_name
-  host_name="$(persist_host_name)" || return 1
-  write_local_roster "$host_name" || return 1
+  # CTL-1185 remediate: persist_host_name returns the host name via the global
+  # PERSISTED_HOST_NAME (not stdout) so the info() progress line can't pollute
+  # the captured value. Same shell — run_stage calls "$@" directly, no subshell.
+  PERSISTED_HOST_NAME=""
+  persist_host_name || return 1
+  write_local_roster "$PERSISTED_HOST_NAME" || return 1
 }
 
 do_doctor_gate() {
@@ -500,7 +536,9 @@ main() {
   # 7. Install launchd stack LAST (Stage-0 SHADOW)
   run_stage "stack" do_install_stack || exit 1
 
-  marker_add_stage "shadow-stop"
+  # Guard so a successful re-run doesn't append a duplicate shadow-stop entry to
+  # completedStages each time (verify low finding).
+  marker_has_stage "shadow-stop" || marker_add_stage "shadow-stop"
 
   info ""
   info "=== Stage-0 SHADOW complete ==="

--- a/plugins/dev/scripts/catalyst-join.sh
+++ b/plugins/dev/scripts/catalyst-join.sh
@@ -1,0 +1,513 @@
+#!/usr/bin/env bash
+# catalyst-join.sh — one-line onboarding for a fresh macOS node into a Catalyst cluster.
+#
+# Usage:
+#   CATALYST_SEED=mini:7400 CATALYST_JOIN_TOKEN=jt_<64hex> bash catalyst-join.sh
+#   bash catalyst-join.sh --bundle /path/to/bundle.json   # offline / pre-fetched bundle
+#   bash catalyst-join.sh --help
+#
+# Environment variables:
+#   CATALYST_SEED          Seed node address host:port (required unless --bundle is used)
+#   CATALYST_JOIN_TOKEN    Join token (jt_ + 64 hex chars); optional in --bundle mode
+#   CATALYST_HOST_NAME     Override host name (default: hostname minus .local)
+#   CATALYST_DIR           Catalyst state directory (default: ~/catalyst)
+#
+# Overrides for testing:
+#   CATALYST_JOIN_SETUP_SCRIPT      path to setup-catalyst.sh
+#   CATALYST_JOIN_INSTALL_CLI_SCRIPT path to install-cli.sh
+#   CATALYST_JOIN_PLUGIN_SRC_SCRIPT  path to setup-plugin-source.sh
+#   CATALYST_JOIN_STACK_BIN          path to catalyst-stack
+#   CATALYST_JOIN_DOCTOR_SCRIPT      path to check-setup.sh
+#   CATALYST_JOIN_REACH_PROBE        path to reachability probe script
+#   CATALYST_JOIN_FETCH_CMD          path to bundle fetch command (replaces curl)
+#   CATALYST_LAYER2_CONFIG_FILE      path to Layer-2 config (default: ~/.config/catalyst/config.json)
+#
+# The script is resumable: progress is tracked in ${CATALYST_DIR}/cluster/join-progress.json.
+# Re-running with the same host.name is a no-op merge (idempotent).
+#
+# CTL-1185
+
+set -uo pipefail
+
+# ── Script location ───────────────────────────────────────────────────────────
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SELF_DIR}/../../.." && pwd)"
+
+# ── Overridable subprocess paths ──────────────────────────────────────────────
+SETUP_SCRIPT="${CATALYST_JOIN_SETUP_SCRIPT:-${REPO_ROOT}/setup-catalyst.sh}"
+INSTALL_CLI_SCRIPT="${CATALYST_JOIN_INSTALL_CLI_SCRIPT:-${SELF_DIR}/install-cli.sh}"
+PLUGIN_SRC_SCRIPT="${CATALYST_JOIN_PLUGIN_SRC_SCRIPT:-${SELF_DIR}/setup-plugin-source.sh}"
+STACK_BIN="${CATALYST_JOIN_STACK_BIN:-${SELF_DIR}/catalyst-stack}"
+DOCTOR_SCRIPT="${CATALYST_JOIN_DOCTOR_SCRIPT:-${SELF_DIR}/check-setup.sh}"
+REACH_PROBE="${CATALYST_JOIN_REACH_PROBE:-}"
+# CATALYST_JOIN_FETCH_CMD — used in acquire_bundle(); resolved there
+
+# ── Logging helpers ───────────────────────────────────────────────────────────
+info() { echo "[join] $*"; }
+warn() { echo "[join] WARN: $*" >&2; }
+fail() { echo "[join] ERROR: $*" >&2; }
+
+# ── Arg parsing ───────────────────────────────────────────────────────────────
+BUNDLE_PATH=""
+RESUME=1  # default: resume from progress marker if present
+
+usage() {
+  cat <<'EOF'
+catalyst-join.sh — provision a fresh macOS node into a Catalyst cluster
+
+Usage:
+  CATALYST_SEED=<host:port> CATALYST_JOIN_TOKEN=<jt_...> bash catalyst-join.sh
+  bash catalyst-join.sh --bundle <path/to/bundle.json>
+  bash catalyst-join.sh --help
+
+Environment:
+  CATALYST_SEED          Seed address (host:port); required unless --bundle is given
+  CATALYST_JOIN_TOKEN    Join token (jt_ + 64 hex chars); optional in --bundle mode
+  CATALYST_HOST_NAME     Override host name (default: hostname -s, .local stripped)
+  CATALYST_DIR           Catalyst state directory (default: ~/catalyst)
+
+Flags:
+  --bundle <path>        Use a pre-fetched local bundle file (skips seed fetch + reachability)
+  --no-resume            Ignore existing progress marker and start fresh
+  -h, --help             Print this usage and exit 0
+
+The script is resumable: re-run after a failure to skip completed stages.
+EOF
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --bundle)
+        [[ $# -ge 2 ]] || { fail "--bundle requires a path argument"; exit 1; }
+        BUNDLE_PATH="$2"; shift 2 ;;
+      --no-resume)
+        RESUME=0; shift ;;
+      -h|--help)
+        usage; exit 0 ;;
+      *)
+        fail "Unknown argument: $1"; usage >&2; exit 1 ;;
+    esac
+  done
+}
+
+parse_args "$@"
+
+# ── Token format validation ───────────────────────────────────────────────────
+CATALYST_JOIN_TOKEN="${CATALYST_JOIN_TOKEN:-}"
+
+validate_token() {
+  local tok="$1"
+  if [[ ! "$tok" =~ ^jt_[0-9a-f]{64}$ ]]; then
+    fail "Invalid join token format. Expected: jt_ followed by exactly 64 hex characters."
+    fail "Got: ${tok:0:10}... (length: ${#tok})"
+    return 1
+  fi
+}
+
+# Require token OR --bundle
+if [[ -z "$BUNDLE_PATH" ]]; then
+  if [[ -z "$CATALYST_JOIN_TOKEN" ]]; then
+    fail "CATALYST_JOIN_TOKEN is required (or use --bundle <path> for offline mode)"
+    fail "Get a token from the seed operator: catalyst cluster join-token"
+    exit 1
+  fi
+  validate_token "$CATALYST_JOIN_TOKEN" || exit 1
+fi
+
+# ── State paths ───────────────────────────────────────────────────────────────
+CATALYST_DIR="${CATALYST_DIR:-${HOME}/catalyst}"
+MARKER_DIR="${CATALYST_DIR}/cluster"
+MARKER_FILE="${MARKER_DIR}/join-progress.json"
+LAYER2_CONFIG="${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
+
+mkdir -p "$MARKER_DIR"
+
+# ── Atomic jq write helper ────────────────────────────────────────────────────
+_atomic_jq_write() {
+  local file="$1"; shift
+  local jq_prog="$1"; shift
+  local tmp
+  tmp="$(mktemp "$(dirname "$file")/.jq-write.XXXXXX")"
+  if jq "$@" "$jq_prog" "$file" > "$tmp" 2>/dev/null; then
+    mv "$tmp" "$file"
+    return 0
+  else
+    rm -f "$tmp"
+    return 1
+  fi
+}
+
+# ── Progress marker helpers ───────────────────────────────────────────────────
+marker_init() {
+  local ts; ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if [[ "$RESUME" -eq 1 && -f "$MARKER_FILE" ]]; then
+    return 0  # preserve existing marker for resume
+  fi
+  printf '{"completedStages":[],"startedAt":"%s"' "$ts" > "$MARKER_FILE"
+  [[ -n "$CATALYST_JOIN_TOKEN" ]] && printf ',"token":"%s"' "$CATALYST_JOIN_TOKEN" >> "$MARKER_FILE"
+  [[ -n "$BUNDLE_PATH" ]]         && printf ',"bundlePath":"%s"' "$BUNDLE_PATH"   >> "$MARKER_FILE"
+  printf '}\n' >> "$MARKER_FILE"
+}
+
+marker_has_stage() {
+  local stage="$1"
+  [[ -f "$MARKER_FILE" ]] && \
+    jq -e --arg s "$stage" '.completedStages | index($s) != null' "$MARKER_FILE" >/dev/null 2>&1
+}
+
+marker_add_stage() {
+  local stage="$1"
+  [[ -f "$MARKER_FILE" ]] || return 0
+  local tmp
+  tmp="$(mktemp "${MARKER_DIR}/.marker.XXXXXX")"
+  jq --arg s "$stage" '.completedStages += [$s] | del(.failedStage)' "$MARKER_FILE" > "$tmp" && \
+    mv "$tmp" "$MARKER_FILE" || rm -f "$tmp"
+}
+
+marker_set_failed() {
+  local stage="$1"
+  [[ -f "$MARKER_FILE" ]] || return 0
+  local tmp
+  tmp="$(mktemp "${MARKER_DIR}/.marker.XXXXXX")"
+  jq --arg s "$stage" '.failedStage = $s' "$MARKER_FILE" > "$tmp" && \
+    mv "$tmp" "$MARKER_FILE" || rm -f "$tmp"
+}
+
+marker_record_bundle() {
+  local bundle_path="$1"
+  [[ -f "$MARKER_FILE" ]] || return 0
+  local tmp
+  tmp="$(mktemp "${MARKER_DIR}/.marker.XXXXXX")"
+  jq --arg bp "$bundle_path" '.bundlePath = $bp' "$MARKER_FILE" > "$tmp" && \
+    mv "$tmp" "$MARKER_FILE" || rm -f "$tmp"
+}
+
+# ── Tailscale reachability preflight ─────────────────────────────────────────
+preflight_tailscale() {
+  local seed="${CATALYST_SEED:-}"
+  if [[ -z "$seed" ]]; then
+    fail "CATALYST_SEED is required in non-bundle mode (format: host:port)"
+    return 1
+  fi
+
+  local probe_fn="${REACH_PROBE:-}"
+  if [[ -n "$probe_fn" && -x "$probe_fn" ]]; then
+    # Use override probe (for tests)
+    if ! "$probe_fn" "$seed" 2>/dev/null; then
+      fail "Seed '${seed}' is not reachable. Is Tailscale running and the seed online?"
+      fail "Hint: tailscale status | grep ${seed%%:*}"
+      return 1
+    fi
+    return 0
+  fi
+
+  # Default: check that tailscale is available and the host is reachable
+  local host="${seed%%:*}"
+  local port="${seed##*:}"
+  if ! command -v tailscale >/dev/null 2>&1; then
+    fail "tailscale not found in PATH. Install Tailscale first."
+    return 1
+  fi
+  if ! tailscale ping --timeout=5s "$host" >/dev/null 2>&1; then
+    fail "Tailscale ping to '${host}' failed. Is this node on the tailnet?"
+    return 1
+  fi
+  # Port reachability check
+  if command -v nc >/dev/null 2>&1; then
+    if ! nc -z -G 5 "$host" "$port" >/dev/null 2>&1; then
+      fail "Port ${port} on '${host}' is not reachable. Is the bundle listener running?"
+      return 1
+    fi
+  fi
+}
+
+# ── Bundle acquisition ────────────────────────────────────────────────────────
+BUNDLE_TMPFILE=""
+BUNDLE_JSON=""
+
+# Required bundle keys for schema validation
+BUNDLE_REQUIRED_KEYS=(
+  ".layer1Identity.projectKey"
+  ".layer1Identity.teamKey"
+  ".layer1Identity.stateMap"
+  ".botCreds.orchestrator"
+  ".botCreds.worker"
+  ".hostsRoster"
+  ".livenessAnchorIssue"
+  ".repoUrl"
+  ".pluginSourceUrl"
+)
+
+validate_bundle() {
+  local json="$1"
+  local missing=()
+  for key in "${BUNDLE_REQUIRED_KEYS[@]}"; do
+    if ! echo "$json" | jq -e "$key" >/dev/null 2>&1; then
+      missing+=("$key")
+    fi
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    fail "Bundle schema validation failed. Missing required keys:"
+    for k in "${missing[@]}"; do
+      fail "  $k"
+    done
+    return 1
+  fi
+}
+
+bundle_get() {
+  local path="$1"
+  echo "$BUNDLE_JSON" | jq -r "$path // empty"
+}
+
+acquire_bundle() {
+  if [[ -n "$BUNDLE_PATH" ]]; then
+    # --bundle mode: read local file
+    if [[ ! -f "$BUNDLE_PATH" ]]; then
+      fail "Bundle file not found: $BUNDLE_PATH"
+      return 1
+    fi
+    BUNDLE_JSON="$(cat "$BUNDLE_PATH")"
+    validate_bundle "$BUNDLE_JSON" || return 1
+    marker_record_bundle "$BUNDLE_PATH"
+    info "Bundle loaded from local file: $BUNDLE_PATH"
+    return 0
+  fi
+
+  # Seed fetch mode
+  # NOTE: join-bundle-listener.mjs (CTL-1183) is not yet in tree.
+  # This path is coded against the documented bundle contract and exercised
+  # via CATALYST_JOIN_FETCH_CMD stub in tests.
+  local seed="${CATALYST_SEED:-}"
+  local host="${seed%%:*}"
+  local port="${seed##*:}"
+  local bundle_url="http://${host}:${port}/bundle"
+  local fetch_cmd="${CATALYST_JOIN_FETCH_CMD:-}"
+
+  if [[ -n "$fetch_cmd" && -x "$fetch_cmd" ]]; then
+    # Test stub or override
+    BUNDLE_JSON="$("$fetch_cmd" "$bundle_url" "$CATALYST_JOIN_TOKEN" 2>&1)" || {
+      fail "Bundle fetch failed (token may be consumed or listener not running)."
+      fail "Re-mint a fresh token: catalyst cluster join-token"
+      return 1
+    }
+  else
+    # Default: curl with bearer auth
+    local http_out http_code
+    BUNDLE_TMPFILE="$(mktemp "${CATALYST_DIR}/.bundle.XXXXXX")"
+    chmod 0600 "$BUNDLE_TMPFILE"
+    http_code="$(curl -fsS \
+      -H "Authorization: Bearer ${CATALYST_JOIN_TOKEN}" \
+      -o "$BUNDLE_TMPFILE" \
+      -w "%{http_code}" \
+      "$bundle_url" 2>&1)" || http_code="000"
+    if [[ "$http_code" != "200" ]]; then
+      rm -f "$BUNDLE_TMPFILE"
+      fail "Bundle fetch returned HTTP ${http_code} from ${bundle_url}"
+      fail "Re-mint a fresh token: catalyst cluster join-token"
+      return 1
+    fi
+    BUNDLE_JSON="$(cat "$BUNDLE_TMPFILE")"
+    rm -f "$BUNDLE_TMPFILE"
+  fi
+
+  validate_bundle "$BUNDLE_JSON" || return 1
+
+  # Record integrityHash if present (no enforcement per CTL-1183)
+  local ihash; ihash="$(echo "$BUNDLE_JSON" | jq -r '.integrityHash // empty')"
+  [[ -n "$ihash" ]] && info "Bundle integrityHash: ${ihash} (recorded, not enforced)"
+
+  info "Bundle acquired from seed: ${seed}"
+}
+
+# ── Stage runner (resumable, stubbable) ───────────────────────────────────────
+run_stage() {
+  local name="$1"; shift
+  if marker_has_stage "$name"; then
+    info "Skipping already-completed stage: ${name}"
+    return 0
+  fi
+  info "Running stage: ${name}"
+  if "$@"; then
+    marker_add_stage "$name"
+    info "Stage complete: ${name}"
+    return 0
+  else
+    local ec=$?
+    marker_set_failed "$name"
+    fail "Stage '${name}' failed (rc=${ec}). Re-run to resume from this stage."
+    return $ec
+  fi
+}
+
+# ── Provisioner stages ────────────────────────────────────────────────────────
+do_setup_catalyst() {
+  CATALYST_AUTONOMOUS=1 bash "$SETUP_SCRIPT"
+}
+
+do_install_cli() {
+  bash "$INSTALL_CLI_SCRIPT"
+}
+
+do_setup_plugin_source() {
+  bash "$PLUGIN_SRC_SCRIPT"
+}
+
+# ── SHARED config merge ───────────────────────────────────────────────────────
+merge_shared_config() {
+  local cfg="$LAYER2_CONFIG"
+  mkdir -p "$(dirname "$cfg")"
+  [[ -f "$cfg" ]] || echo '{}' > "$cfg"
+
+  # Extract SHARED keys from bundle; preserve all existing node-local keys
+  local la_project la_team la_statemap bot_orch bot_worker liveness repo_url plugin_url
+  la_project="$(bundle_get '.layer1Identity.projectKey')"
+  la_team="$(bundle_get '.layer1Identity.teamKey')"
+  la_statemap="$(echo "$BUNDLE_JSON" | jq '.layer1Identity.stateMap // {}')"
+  bot_orch="$(bundle_get '.botCreds.orchestrator')"
+  bot_worker="$(bundle_get '.botCreds.worker')"
+  liveness="$(bundle_get '.livenessAnchorIssue')"
+  repo_url="$(bundle_get '.repoUrl')"
+  plugin_url="$(bundle_get '.pluginSourceUrl')"
+
+  local tmp
+  tmp="$(mktemp "$(dirname "$cfg")/.config.XXXXXX")"
+  jq \
+    --arg la_project "$la_project" \
+    --arg la_team "$la_team" \
+    --argjson la_statemap "$la_statemap" \
+    --arg bot_orch "$bot_orch" \
+    --arg bot_worker "$bot_worker" \
+    --arg liveness "$liveness" \
+    --arg repo_url "$repo_url" \
+    --arg plugin_url "$plugin_url" \
+    '
+      .catalyst //= {}
+      | .catalyst.linear //= {}
+      | .catalyst.linear.bot //= {}
+      | .catalyst.linear.bot.orchestrator //= $bot_orch
+      | .catalyst.linear.bot.worker //= $bot_worker
+      | .catalyst.cluster //= {}
+      | .catalyst.cluster.livenessAnchorIssue //= $liveness
+      | .catalyst.repository //= $repo_url
+      | .catalyst.feedback //= $plugin_url
+      | .catalyst.layer1Identity //= {}
+      | .catalyst.layer1Identity.projectKey //= $la_project
+      | .catalyst.layer1Identity.teamKey //= $la_team
+      | .catalyst.layer1Identity.stateMap //= $la_statemap
+    ' "$cfg" > "$tmp" && mv "$tmp" "$cfg" || { rm -f "$tmp"; return 1; }
+  info "SHARED config merged into ${cfg}"
+}
+
+persist_host_name() {
+  local cfg="$LAYER2_CONFIG"
+  local host_name="${CATALYST_HOST_NAME:-}"
+  if [[ -z "$host_name" ]]; then
+    host_name="$(hostname -s 2>/dev/null || hostname | sed 's/\.local$//')"
+    host_name="${host_name%.local}"
+  fi
+  [[ -f "$cfg" ]] || echo '{}' > "$cfg"
+  local tmp
+  tmp="$(mktemp "$(dirname "$cfg")/.config.XXXXXX")"
+  jq --arg hn "$host_name" '.catalyst.host.name = $hn' "$cfg" > "$tmp" && mv "$tmp" "$cfg" || { rm -f "$tmp"; return 1; }
+  info "host.name set to: ${host_name}"
+  echo "$host_name"  # return value
+}
+
+write_local_roster() {
+  local host_name="$1"
+  local local_roster="${CATALYST_DIR}/cluster/local-hosts.json"
+  mkdir -p "$(dirname "$local_roster")"
+
+  local existing="[]"
+  if [[ -f "$local_roster" ]]; then
+    existing="$(cat "$local_roster")"
+  fi
+
+  # Merge-preserve: add host if not already present
+  local tmp
+  tmp="$(mktemp "${CATALYST_DIR}/cluster/.roster.XXXXXX")"
+  echo "$existing" | jq --arg h "$host_name" 'if index($h) then . else . + [$h] end' > "$tmp" && \
+    mv "$tmp" "$local_roster" || { rm -f "$tmp"; return 1; }
+
+  info "Local roster written: ${local_roster}"
+  info "NOTE: The committed .catalyst/hosts.json roster has NOT been modified."
+  info "      To activate this node, update and commit .catalyst/hosts.json."
+}
+
+do_config_merge() {
+  merge_shared_config || return 1
+  local host_name
+  host_name="$(persist_host_name)" || return 1
+  write_local_roster "$host_name" || return 1
+}
+
+do_doctor_gate() {
+  if bash "$DOCTOR_SCRIPT" >/dev/null 2>&1; then
+    info "Doctor gate passed."
+    return 0
+  else
+    fail "Setup health check (doctor gate) failed. Run '${DOCTOR_SCRIPT}' for details."
+    return 1
+  fi
+}
+
+do_install_stack() {
+  "$STACK_BIN" install-services
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+main() {
+  info "=== Catalyst node join (CTL-1185) ==="
+
+  # 1. Preflight
+  if [[ -z "$BUNDLE_PATH" ]]; then
+    preflight_tailscale || exit 1
+  fi
+
+  # 2. Initialize progress marker
+  marker_init
+
+  # 3. Acquire + validate bundle
+  if ! marker_has_stage "acquire-bundle"; then
+    acquire_bundle || { marker_set_failed "acquire-bundle"; exit 1; }
+    marker_add_stage "acquire-bundle"
+  else
+    info "Skipping already-completed stage: acquire-bundle"
+    # Re-load bundle from stored path for subsequent stages
+    local stored_path
+    stored_path="$(jq -r '.bundlePath // empty' "$MARKER_FILE" 2>/dev/null || true)"
+    if [[ -n "$stored_path" && -f "$stored_path" ]]; then
+      BUNDLE_JSON="$(cat "$stored_path")"
+    else
+      # Seed mode resume: we don't have the bundle body, re-acquire
+      acquire_bundle || { marker_set_failed "acquire-bundle"; exit 1; }
+    fi
+  fi
+
+  # 4. Provisioners (order matters)
+  run_stage "setup-catalyst"      do_setup_catalyst      || exit 1
+  run_stage "install-cli"         do_install_cli          || exit 1
+  run_stage "setup-plugin-source" do_setup_plugin_source  || exit 1
+
+  # 5. SHARED config merge + per-node items
+  run_stage "config-merge" do_config_merge || exit 1
+
+  # 6. Doctor gate (T4)
+  run_stage "doctor" do_doctor_gate || exit 1
+
+  # 7. Install launchd stack LAST (Stage-0 SHADOW)
+  run_stage "stack" do_install_stack || exit 1
+
+  marker_add_stage "shadow-stop"
+
+  info ""
+  info "=== Stage-0 SHADOW complete ==="
+  info "This node is provisioned but INERT (owns zero tickets via HRW)."
+  info "To activate: update and commit .catalyst/hosts.json with this node."
+  info "Local roster: ${CATALYST_DIR}/cluster/local-hosts.json"
+  info ""
+}
+
+main


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-16T03:32:00Z -->
<!-- Last updated: 2026-06-16T03:32:00Z -->
<!-- PR: #2110 -->
<!-- Previous commits: 8565794a,c987870b -->

## Summary

Adds `catalyst-join.sh`, a one-line onboarding script that provisions a fresh macOS node into a Catalyst cluster by mirroring the seed's configuration. Operators run a single `curl ... | bash` command; the script handles Tailscale reachability, token validation, bundle fetch, config merge, per-node generation, and service installation — then resumes cleanly from any failed stage on retry.

## Changes Made

### New: `plugins/dev/scripts/catalyst-join.sh` (+551 lines)

- **One-line bootstrap**: `CATALYST_SEED=mini:7400 CATALYST_JOIN_TOKEN=jt_<64hex> bash catalyst-join.sh`
- **Token validation**: enforces `jt_` prefix + exactly 64 hex chars before any side effects
- **Tailscale preflight**: verifies seed host is reachable via `tailscale ping` + port check before fetching
- **Bundle acquisition**: fetches from seed via `curl` (or `CATALYST_JOIN_FETCH_CMD` override for tests); validates required JSON keys
- **Resumable execution**: tracks completed stages in `${CATALYST_DIR}/cluster/join-progress.json`; re-running after failure skips completed stages
- **Layer-2 config merge**: uses `jq` merge-preserve pattern (same as `setup-plugin-source.sh:165`) to merge shared cluster config into `~/.config/catalyst/config.json`
- **Per-node generation**: fixes `repoRoot` paths and runs `catalyst-stack install-services`
- **Idempotent**: re-running with the same `host.name` is a no-op merge
- **Secrets hygiene**: progress marker locked to `0600` immediately after creation (CTL-1203 pattern)
- **Offline mode**: `--bundle <path>` skips seed fetch for pre-fetched or air-gapped deployments
- **All subprocess paths overridable** via env vars for hermetic testing

### Remediation from verify phase:

- Uses `jq --arg` (not `printf`/string interpolation) to build JSON — prevents token/path values containing `"` or `\` from producing invalid JSON that silently breaks all later marker operations
- Token validated in `--bundle` mode too when `CATALYST_JOIN_TOKEN` is supplied

### New: `plugins/dev/scripts/__tests__/catalyst-join.test.sh` (+673 lines)

Comprehensive test suite covering arg parsing, preflight, token validation, bundle fetch, config merge, stage resumability, per-node generation, and offline mode. Tests run fully hermetically with stub scripts injected via env overrides.

## How to Verify It

- [x] `bash -n plugins/dev/scripts/catalyst-join.sh` — syntax check passes
- [x] `bash plugins/dev/scripts/__tests__/catalyst-join.test.sh` — test suite passes
- [x] CI checks pass (audit-references, check-versions, docs-gate, validate — all green)
- [ ] Manual: `CATALYST_SEED=mini:7400 CATALYST_JOIN_TOKEN=jt_<token> bash plugins/dev/scripts/catalyst-join.sh` on a fresh node

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1185

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1203
