### PR TITLE
feat(dev): CTL-1205 — worker-dir GC to prevent per-tick I/O blowup

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -65,6 +65,7 @@ import {
 import { Reaper, defaultReadActivePhaseSignal, defaultReadSignalBgJobId } from "./reaper.mjs";
 import { startOrphanReaperTimer, readOrphanReaperConfig } from "./orphan-reaper-timer.mjs";
 import { sweepJobDirs } from "./job-dir-gc.mjs"; // CTL-1165 D3: ~/.claude/jobs/<id> dir GC
+import { sweepWorkerDirs } from "./worker-dir-gc.mjs"; // CTL-1205: execution-core/workers/<TICKET>/ GC
 import { ProcReaper } from "./proc-reaper.mjs"; // CTL-1165 D2: orphan child-process reaper (default shadow)
 import {
   startWorktreeRefreshTimer,
@@ -852,10 +853,29 @@ function startReaperAndTimer({
           ...(jobGcCfg.batchCap != null ? { batchCap: Number(jobGcCfg.batchCap) } : {}),
         })
     : async () => {};
+  // CTL-1205: bind the real execution-core/workers/<TICKET>/ dir GC onto the same
+  // 600s orphan-reaper cadence (no new daemon timer). Default-on; disable via
+  // .catalyst → orphanReaper.workerGc.enabled:false. retention/batchCap come from
+  // config (env CATALYST_WORKER_GC_RETENTION_SECONDS / CATALYST_WORKER_GC_BATCH_CAP
+  // still win inside sweepWorkerDirs's defaults).
+  const workerGcCfg = cfg.workerGc ?? {};
+  const workerGcEnabled = workerGcCfg.enabled !== false;
+  const workerGc = workerGcEnabled
+    ? () =>
+        sweepWorkerDirs({
+          orchDir,
+          readAgents: () => listClaudeAgentsResult(),
+          ...(workerGcCfg.retentionSeconds != null
+            ? { retentionMs: Number(workerGcCfg.retentionSeconds) * 1000 }
+            : {}),
+          ...(workerGcCfg.batchCap != null ? { batchCap: Number(workerGcCfg.batchCap) } : {}),
+        })
+    : async () => {};
   _orphanTimer = startOrphanReaperTimer({
     enabled: cfg.enabled !== false,
     intervalSeconds: cfg.intervalSeconds ?? 600,
     jobGc,
+    workerGc,
   });
 
   // CTL-707: start the periodic worktree-refresh timer.

--- a/plugins/dev/scripts/execution-core/orphan-reaper-timer.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-reaper-timer.mjs
@@ -5,6 +5,7 @@
 import { readFileSync } from "node:fs";
 import { emitReapIntent } from "./reap-intent.mjs";
 import { sweepJobDirs } from "./job-dir-gc.mjs";
+import { sweepWorkerDirs } from "./worker-dir-gc.mjs"; // CTL-1205: worker-dir GC
 import { log } from "./config.mjs";
 
 /**
@@ -45,14 +46,16 @@ function realClock() {
  * @param {boolean} [opts.enabled=true]            disable to no-op the timer
  * @param {number}  [opts.intervalSeconds=600]     default 10 minutes
  * @param {Function}[opts.emit=emitReapIntent]     emitter seam for tests
- * @param {Function}[opts.jobGc=()=>sweepJobDirs()] CTL-1165 D3: job-dir GC seam
- * @param {object}  [opts.clock=realClock()]       fake-clock seam for tests
+ * @param {Function}[opts.jobGc=()=>sweepJobDirs()]     CTL-1165 D3: job-dir GC seam
+ * @param {Function}[opts.workerGc=async()=>{}]         CTL-1205: worker-dir GC seam
+ * @param {object}  [opts.clock=realClock()]             fake-clock seam for tests
  */
 export function startOrphanReaperTimer({
   enabled = true,
   intervalSeconds = 600,
   emit = emitReapIntent,
   jobGc = () => sweepJobDirs(),
+  workerGc = async () => {}, // CTL-1205: worker-dir GC seam (no-op default)
   clock = realClock(),
 } = {}) {
   if (!enabled) return { stop: () => {} };
@@ -81,6 +84,7 @@ export function startOrphanReaperTimer({
         emit("phase.reconcile.reap-requested", {}),
         emit("procOrphans.reap-requested", {}),
         jobGc(),
+        workerGc(), // CTL-1205
       ]);
     } catch (err) {
       // CTL-649: a persistently-unwritable event log would make every tick

--- a/plugins/dev/scripts/execution-core/orphan-reaper-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-reaper-timer.test.mjs
@@ -126,6 +126,57 @@ describe("startOrphanReaperTimer", () => {
     expect(emitted.filter((e) => e === "orphans.reap-requested").length).toBe(1);
     expect(emitted.filter((e) => e === "phase.reconcile.reap-requested").length).toBe(1);
   });
+
+  // CTL-1205: workerGc seam is invoked each tick alongside emits + jobGc.
+  it("calls workerGc on the same tick as the reap emits (CTL-1205)", async () => {
+    const emitted = [];
+    let workerGcCalls = 0;
+    const clock = fakeClock();
+    startOrphanReaperTimer({
+      intervalSeconds: 600,
+      emit: async (e) => emitted.push(e),
+      workerGc: async () => { workerGcCalls++; },
+      clock,
+    });
+    clock.advance(600_000);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(emitted.filter((e) => e === "orphans.reap-requested").length).toBe(1);
+    expect(emitted.filter((e) => e === "phase.reconcile.reap-requested").length).toBe(1);
+    expect(workerGcCalls).toBe(1);
+  });
+
+  // CTL-1205: a rejecting workerGc must NOT suppress the reap emits.
+  it("a rejecting workerGc does not suppress the reap emits (CTL-1205)", async () => {
+    const emitted = [];
+    const clock = fakeClock();
+    startOrphanReaperTimer({
+      intervalSeconds: 600,
+      emit: async (e) => emitted.push(e),
+      workerGc: async () => { throw new Error("worker-gc boom"); },
+      clock,
+    });
+    clock.advance(600_000);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(emitted.filter((e) => e === "orphans.reap-requested").length).toBe(1);
+    expect(emitted.filter((e) => e === "phase.reconcile.reap-requested").length).toBe(1);
+  });
+
+  // CTL-1205: workerGc fires twice when two intervals elapse.
+  it("calls workerGc on every tick, not just the first (CTL-1205)", async () => {
+    let workerGcCalls = 0;
+    const clock = fakeClock();
+    startOrphanReaperTimer({
+      intervalSeconds: 600,
+      emit: async () => {},
+      workerGc: async () => { workerGcCalls++; },
+      clock,
+    });
+    clock.advance(600_000);
+    await new Promise((r) => setTimeout(r, 0));
+    clock.advance(600_000);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(workerGcCalls).toBe(2);
+  });
 });
 
 describe("readOrphanReaperConfig", () => {

--- a/plugins/dev/scripts/execution-core/worker-dir-gc.mjs
+++ b/plugins/dev/scripts/execution-core/worker-dir-gc.mjs
@@ -1,0 +1,216 @@
+// worker-dir-gc.mjs — CTL-1205. GC stale execution-core/workers/<TICKET>/ dirs.
+//
+// THE LEAK: phase-teardown archives workers/<T>/ to ~/catalyst/archives/<T>/ (cp -R)
+// but never deletes the original; reaper/stall-janitor only remove worktrees and
+// ghost sessions. Dirs accumulate (137 at the 2026-06-16 incident), taxing every
+// scheduler tick with N readdirSync/readFileSync and aging the liveness snapshot
+// past the CTL-731 30s hold threshold.
+//
+// THE FIX: a fail-CLOSED, bounded sweep that deletes a worker dir ONLY when ALL gates pass:
+//   (0) fail-closed liveness — `claude agents` unreadable ({ok:false}) → ABORT, delete nothing.
+//   (1) terminal — has ≥1 phase signal AND !isTicketInFlight(statuses).
+//   (2) idle — none of the dir's recorded bg_job_id/sessionId short-ids ∈ live short-ids.
+//   (3) mtime age >= retention (default 24h ≫ any pipeline duration).
+//   + batchCap bound; best-effort `workers.gc.swept` emit.
+//
+// DELETE PRIMITIVE: fs.rm(dir, {recursive, force}) of the WORKER DIR ALONE — never `claude rm`
+// (that tears down the worktree). teardown already archived; we reclaim the state dir only.
+
+import { readdir, stat, readFile, rm as rmAsync } from "node:fs/promises";
+import { join } from "node:path";
+import { log as defaultLog } from "./config.mjs";
+import { listClaudeAgentsResult } from "./claude-agents.mjs";
+import { shortIdFromSessionId, isSelfSession } from "./claude-ids.mjs";
+import { isTicketInFlight } from "./scheduler.mjs";
+import { emitReapIntent } from "./reap-intent.mjs";
+
+const DEFAULT_RETENTION_SECONDS = 86_400; // 24h
+const DEFAULT_BATCH_CAP = 100;
+
+// defaultReadWorkerMeta — read one ticket's phase-*.json: {statuses, shortIds}.
+// statuses feeds the terminal gate; shortIds (bg_job_id + sessionId short forms)
+// feed the idle/liveness gate.
+async function defaultReadWorkerMeta(workersRoot, ticket, { readDir, readFileFn } = {}) {
+  const dir = join(workersRoot, ticket);
+  const statuses = {};
+  const shortIds = new Set();
+  let files;
+  try {
+    files = await readDir(dir);
+  } catch {
+    return { statuses, shortIds };
+  }
+  for (const f of files) {
+    const m = /^phase-(.+)\.json$/.exec(f);
+    if (!m || m[1].includes("-yield-")) continue; // skip CTL-702 yield tombstones
+    try {
+      const sig = JSON.parse(await readFileFn(join(dir, f), "utf8"));
+      statuses[m[1]] = sig?.status ?? null;
+      if (sig?.bg_job_id) shortIds.add(String(sig.bg_job_id).slice(0, 8));
+      if (sig?.catalystSessionId) {
+        let s = null;
+        try { s = shortIdFromSessionId(sig.catalystSessionId); } catch { s = null; }
+        if (s) shortIds.add(s);
+      }
+    } catch { /* unreadable/malformed → treated as absent */ }
+  }
+  return { statuses, shortIds };
+}
+
+/**
+ * sweepWorkerDirs — GC stale execution-core/workers/<TICKET>/ dirs. Fail-closed,
+ * fail-safe, bounded. Every IO/clock/emit primitive is an injected, defaulted seam
+ * so the unit test never reads real disk or spawns `claude`.
+ *
+ * @returns {Promise<{reclaimed, scanned, skippedInFlight, skippedLive, skippedRecent, errors, batchCapped, skipped?}>}
+ */
+export async function sweepWorkerDirs({
+  orchDir,
+  readDir = (p, opts) => readdir(p, opts),
+  statDir = (p) => stat(p),
+  readFileFn = (p, enc) => readFile(p, enc),
+  rm = (p, opts) => rmAsync(p, opts),
+  readAgents = listClaudeAgentsResult,
+  readWorkerMeta,
+  now = () => Date.now(),
+  retentionMs = (Number(process.env.CATALYST_WORKER_GC_RETENTION_SECONDS) ||
+    DEFAULT_RETENTION_SECONDS) * 1000,
+  batchCap = Number(process.env.CATALYST_WORKER_GC_BATCH_CAP) || DEFAULT_BATCH_CAP,
+  emit = emitReapIntent,
+  env = process.env,
+  log = defaultLog,
+} = {}) {
+  const workersRoot = join(orchDir, "workers");
+  const metaReader = readWorkerMeta
+    ? readWorkerMeta
+    : (ticket) => defaultReadWorkerMeta(workersRoot, ticket, { readDir, readFileFn });
+
+  // Gate 0 — fail-closed liveness FIRST. A failed `claude agents` read ({ok:false})
+  // is NOT a genuinely-empty fleet: deleting on a read failure would authorize
+  // evicting a live worker's dir. Abort, delete nothing.
+  let agentsResult;
+  try {
+    agentsResult = readAgents();
+  } catch {
+    agentsResult = { ok: false, agents: [] };
+  }
+  if (!agentsResult || agentsResult.ok !== true) {
+    log.warn(
+      { orchDir },
+      "worker-dir-gc: `claude agents` unreadable — aborting sweep (fail-closed)"
+    );
+    return {
+      reclaimed: 0,
+      scanned: 0,
+      skippedInFlight: 0,
+      skippedLive: 0,
+      skippedRecent: 0,
+      errors: 0,
+      batchCapped: false,
+      skipped: "agents-unreadable",
+    };
+  }
+
+  const liveShortIds = new Set();
+  for (const a of agentsResult.agents ?? []) {
+    let s = null;
+    try { s = shortIdFromSessionId(a?.sessionId); } catch { s = null; }
+    if (s) liveShortIds.add(s);
+  }
+
+  let tickets;
+  try {
+    tickets = (await readDir(workersRoot, { withFileTypes: true }))
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+  } catch (err) {
+    if (err?.code !== "ENOENT") {
+      log.warn(
+        { workersRoot, err: err?.message },
+        "worker-dir-gc: workers root unreadable; skipping sweep"
+      );
+    }
+    return {
+      reclaimed: 0,
+      scanned: 0,
+      skippedInFlight: 0,
+      skippedLive: 0,
+      skippedRecent: 0,
+      errors: 0,
+      batchCapped: false,
+    };
+  }
+
+  const nowMs = now();
+  let reclaimed = 0;
+  let scanned = 0;
+  let skippedInFlight = 0;
+  let skippedLive = 0;
+  let skippedRecent = 0;
+  let errors = 0;
+  let batchCapped = false;
+
+  for (const ticket of tickets) {
+    scanned++;
+    const { statuses, shortIds } = await metaReader(ticket);
+
+    // Gate 1 — terminal: must have ≥1 signal AND not be in-flight.
+    if (Object.keys(statuses).length === 0 || isTicketInFlight(statuses)) {
+      skippedInFlight++;
+      continue;
+    }
+
+    // Gate 2 — idle: no recorded id of this dir is a live session; never self.
+    let live = false;
+    for (const id of shortIds) {
+      if (liveShortIds.has(id) || isSelfSession(id, env)) {
+        live = true;
+        break;
+      }
+    }
+    if (live) {
+      skippedLive++;
+      continue;
+    }
+
+    // Gate 3 — mtime age >= retention. Per-dir stat failure (e.g. ENOENT because
+    // the dir vanished between readdir and stat) → errors++, continue; never throw.
+    const dir = join(workersRoot, ticket);
+    let st;
+    try {
+      st = await statDir(dir);
+    } catch {
+      errors++;
+      continue;
+    }
+    const mtimeMs = st?.mtimeMs ?? nowMs; // unknown mtime → treat as recent (spare)
+    if (nowMs - mtimeMs < retentionMs) {
+      skippedRecent++;
+      continue;
+    }
+
+    if (reclaimed >= batchCap) {
+      batchCapped = true;
+      break;
+    }
+
+    // All gates passed — delete the WORKER DIR ALONE (never `claude rm`).
+    try {
+      await rm(dir, { recursive: true, force: true });
+      reclaimed++;
+    } catch {
+      errors++;
+    }
+  }
+
+  // Best-effort flag emit; only when we actually reclaimed something.
+  if (reclaimed > 0) {
+    try {
+      await emit("workers.gc.swept", { reclaimed, scanned });
+    } catch (err) {
+      log.warn({ err: err?.message }, "worker-dir-gc: workers.gc.swept emit failed");
+    }
+  }
+
+  return { reclaimed, scanned, skippedInFlight, skippedLive, skippedRecent, errors, batchCapped };
+}

--- a/plugins/dev/scripts/execution-core/worker-dir-gc.test.mjs
+++ b/plugins/dev/scripts/execution-core/worker-dir-gc.test.mjs
@@ -1,0 +1,482 @@
+// worker-dir-gc.test.mjs — CTL-1205. GC of stale execution-core/workers/<TICKET>/ dirs.
+//
+// Every fs/agents/clock/emit primitive is an injected, defaulted constructor
+// param (mirrors job-dir-gc.test.mjs). NO test reads real disk or spawns `claude`.
+
+import { describe, it, expect } from "bun:test";
+import { join } from "node:path";
+import { sweepWorkerDirs } from "./worker-dir-gc.mjs";
+
+const HOUR = 3600_000;
+const RETENTION_24H = 24 * HOUR;
+const ORCH = "/fake/execution-core";
+const WORKERS = join(ORCH, "workers");
+
+// Recording rm spy: records every (path, opts) tuple, never touches disk.
+function rmSpy() {
+  const calls = [];
+  const fn = async (p, opts) => { calls.push({ path: p, opts }); };
+  fn.calls = calls;
+  return fn;
+}
+
+// Recording emit spy: records (eventType, fields) tuples, resolves true.
+function emitSpy() {
+  const calls = [];
+  const fn = async (eventType, fields) => {
+    calls.push({ eventType, fields });
+    return true;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+// Recording log spy with warn().
+function logSpy() {
+  const warn = [];
+  return {
+    warn: (...args) => warn.push(args),
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+    _warn: warn,
+  };
+}
+
+// A live agent row matching claude agents --json shape.
+const agent = (sessionId) => ({ sessionId, status: "idle", kind: "background" });
+
+// Fake readDir that returns an array of dir entries (with isDirectory).
+function fakeDirs(names) {
+  return async () => names.map((n) => ({ name: n, isDirectory: () => true }));
+}
+
+// Build a fake readWorkerMeta returning {statuses, shortIds} for a ticket.
+function fakeWorkerMeta(map) {
+  return async (ticket) => map[ticket] ?? { statuses: {}, shortIds: new Set() };
+}
+
+describe("sweepWorkerDirs", () => {
+  it("deletes a terminal, idle, aged worker dir", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    const emit = emitSpy();
+    const res = await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: fakeDirs(["CTL-9000"]),
+      statDir: async () => ({ mtimeMs: now - 25 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      readWorkerMeta: fakeWorkerMeta({
+        "CTL-9000": {
+          statuses: { teardown: "done" },
+          shortIds: new Set(["deadbeef"]),
+        },
+      }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit,
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(1);
+    expect(rm.calls[0].path).toBe(join(WORKERS, "CTL-9000"));
+    expect(rm.calls[0].opts).toEqual({ recursive: true, force: true });
+    expect(res.reclaimed).toBe(1);
+    expect(res.scanned).toBe(1);
+    const swept = emit.calls.find((c) => c.eventType === "workers.gc.swept");
+    expect(swept).toBeTruthy();
+    expect(swept.fields.reclaimed).toBe(1);
+  });
+
+  it("fails closed when `claude agents` is unreadable", async () => {
+    const rm = rmSpy();
+    const emit = emitSpy();
+    const log = logSpy();
+    const res = await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: fakeDirs(["CTL-9000"]),
+      statDir: async () => ({ mtimeMs: 0 }),
+      rm,
+      readAgents: () => ({ ok: false, agents: [] }),
+      readWorkerMeta: fakeWorkerMeta({
+        "CTL-9000": { statuses: { teardown: "done" }, shortIds: new Set() },
+      }),
+      now: () => 1_000_000_000_000,
+      retentionMs: RETENTION_24H,
+      emit,
+      env: {},
+      log,
+    });
+    expect(rm.calls.length).toBe(0);
+    expect(res.reclaimed).toBe(0);
+    expect(res.skipped).toBe("agents-unreadable");
+    expect(log._warn.length).toBeGreaterThanOrEqual(1);
+    expect(emit.calls.find((c) => c.eventType === "workers.gc.swept")).toBeUndefined();
+  });
+
+  it("fails closed when `claude agents` throws", async () => {
+    const rm = rmSpy();
+    const res = await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: fakeDirs(["CTL-9000"]),
+      statDir: async () => ({ mtimeMs: 0 }),
+      rm,
+      readAgents: () => { throw new Error("exec failed"); },
+      readWorkerMeta: fakeWorkerMeta({
+        "CTL-9000": { statuses: { teardown: "done" }, shortIds: new Set() },
+      }),
+      now: () => 1_000_000_000_000,
+      retentionMs: RETENTION_24H,
+      emit: emitSpy(),
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(0);
+    expect(res.reclaimed).toBe(0);
+    expect(res.skipped).toBe("agents-unreadable");
+  });
+
+  it("never deletes an in-flight dir (has signals, still running)", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    const res = await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: fakeDirs(["CTL-9001"]),
+      statDir: async () => ({ mtimeMs: now - 25 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      readWorkerMeta: fakeWorkerMeta({
+        // implement running — not terminal
+        "CTL-9001": { statuses: { implement: "running" }, shortIds: new Set() },
+      }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit: emitSpy(),
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(0);
+    expect(res.reclaimed).toBe(0);
+    expect(res.skippedInFlight).toBe(1);
+  });
+
+  it("never deletes a dir with no phase signals (empty statuses)", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    const res = await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: fakeDirs(["CTL-9002"]),
+      statDir: async () => ({ mtimeMs: now - 25 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      readWorkerMeta: fakeWorkerMeta({
+        "CTL-9002": { statuses: {}, shortIds: new Set() },
+      }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit: emitSpy(),
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(0);
+    expect(res.reclaimed).toBe(0);
+    expect(res.skippedInFlight).toBe(1);
+  });
+
+  it("never deletes a dir whose session is still live", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    // teardown done = terminal, but bg_job_id is still in live agents
+    const res = await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: fakeDirs(["CTL-9003"]),
+      statDir: async () => ({ mtimeMs: now - 25 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [agent("abc12345-0000-0000-0000-000000000000")] }),
+      readWorkerMeta: fakeWorkerMeta({
+        "CTL-9003": {
+          statuses: { teardown: "done" },
+          shortIds: new Set(["abc12345"]),
+        },
+      }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit: emitSpy(),
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(0);
+    expect(res.reclaimed).toBe(0);
+    expect(res.skippedLive).toBe(1);
+  });
+
+  it("never deletes a dir younger than retention", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    const res = await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: fakeDirs(["CTL-9004"]),
+      statDir: async () => ({ mtimeMs: now - 1 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      readWorkerMeta: fakeWorkerMeta({
+        "CTL-9004": { statuses: { teardown: "done" }, shortIds: new Set() },
+      }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit: emitSpy(),
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(0);
+    expect(res.reclaimed).toBe(0);
+    expect(res.skippedRecent).toBe(1);
+  });
+
+  it("bounds deletions to batchCap and drains the rest next tick", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    const tickets = Array.from({ length: 20 }, (_, i) => `CTL-${9100 + i}`);
+    const metaMap = Object.fromEntries(
+      tickets.map((t) => [t, { statuses: { teardown: "done" }, shortIds: new Set() }])
+    );
+    const res = await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: fakeDirs(tickets),
+      statDir: async () => ({ mtimeMs: now - 25 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      readWorkerMeta: fakeWorkerMeta(metaMap),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      batchCap: 5,
+      emit: emitSpy(),
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(5);
+    expect(res.reclaimed).toBe(5);
+    expect(res.batchCapped).toBe(true);
+  });
+
+  it("counts a vanished dir as an error and continues", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    const res = await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: fakeDirs(["CTL-9010"]),
+      statDir: async () => {
+        const e = new Error("ENOENT: no such file");
+        e.code = "ENOENT";
+        throw e;
+      },
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      readWorkerMeta: fakeWorkerMeta({
+        "CTL-9010": { statuses: { teardown: "done" }, shortIds: new Set() },
+      }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit: emitSpy(),
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(0);
+    expect(res.errors).toBe(1);
+    expect(res.reclaimed).toBe(0);
+  });
+
+  it("emits workers.gc.swept only after a real reclaim", async () => {
+    const now = 1_000_000_000_000;
+    const emit = emitSpy();
+    // All dirs are recent — nothing to reclaim
+    await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: fakeDirs(["CTL-9011"]),
+      statDir: async () => ({ mtimeMs: now - 1 * HOUR }),
+      rm: rmSpy(),
+      readAgents: () => ({ ok: true, agents: [] }),
+      readWorkerMeta: fakeWorkerMeta({
+        "CTL-9011": { statuses: { teardown: "done" }, shortIds: new Set() },
+      }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit,
+      env: {},
+      log: logSpy(),
+    });
+    expect(emit.calls.length).toBe(0);
+
+    // Now reclaim one
+    const emit2 = emitSpy();
+    await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: fakeDirs(["CTL-9012"]),
+      statDir: async () => ({ mtimeMs: now - 25 * HOUR }),
+      rm: rmSpy(),
+      readAgents: () => ({ ok: true, agents: [] }),
+      readWorkerMeta: fakeWorkerMeta({
+        "CTL-9012": { statuses: { teardown: "done" }, shortIds: new Set() },
+      }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit: emit2,
+      env: {},
+      log: logSpy(),
+    });
+    expect(emit2.calls.length).toBe(1);
+    expect(emit2.calls[0].eventType).toBe("workers.gc.swept");
+  });
+
+  it("rm's the worker dir alone with recursive+force", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: fakeDirs(["CTL-9020"]),
+      statDir: async () => ({ mtimeMs: now - 25 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      readWorkerMeta: fakeWorkerMeta({
+        "CTL-9020": { statuses: { teardown: "done" }, shortIds: new Set() },
+      }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit: emitSpy(),
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(1);
+    expect(rm.calls[0].path).toBe(join(WORKERS, "CTL-9020"));
+    expect(rm.calls[0].opts).toEqual({ recursive: true, force: true });
+  });
+
+  it("never deletes a dir matching the self/controlling session", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    const res = await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: fakeDirs(["CTL-9030"]),
+      statDir: async () => ({ mtimeMs: now - 25 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      readWorkerMeta: fakeWorkerMeta({
+        "CTL-9030": {
+          statuses: { teardown: "done" },
+          shortIds: new Set(["5e1f0001"]),
+        },
+      }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit: emitSpy(),
+      env: { CLAUDE_CODE_SESSION_ID: "5e1f0001-0000-0000-0000-000000000000" },
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(0);
+    expect(res.skippedLive).toBe(1);
+  });
+
+  it("handles teardown skipped as terminal (not in-flight, CTL-512 pattern)", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    // teardown: "skipped" is terminal per the CTL-512 skipped-as-done pattern on TERMINAL_PHASE
+    const res = await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: fakeDirs(["CTL-9040"]),
+      statDir: async () => ({ mtimeMs: now - 25 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      readWorkerMeta: fakeWorkerMeta({
+        "CTL-9040": {
+          statuses: { "monitor-deploy": "skipped", teardown: "skipped" },
+          shortIds: new Set(),
+        },
+      }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit: emitSpy(),
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(1);
+    expect(res.reclaimed).toBe(1);
+  });
+
+  it("keeps a dir with only monitor-deploy skipped (teardown still pending)", async () => {
+    const now = 1_000_000_000_000;
+    const rm = rmSpy();
+    // monitor-deploy: "skipped" alone is still in-flight — teardown has not run yet
+    const res = await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: fakeDirs(["CTL-9041"]),
+      statDir: async () => ({ mtimeMs: now - 25 * HOUR }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      readWorkerMeta: fakeWorkerMeta({
+        "CTL-9041": {
+          statuses: { "monitor-deploy": "skipped" },
+          shortIds: new Set(),
+        },
+      }),
+      now: () => now,
+      retentionMs: RETENTION_24H,
+      emit: emitSpy(),
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(0);
+    expect(res.skippedInFlight).toBe(1);
+  });
+
+  it("handles failed/stalled/aborted tickets as terminal (deletable)", async () => {
+    const now = 1_000_000_000_000;
+    for (const status of ["failed", "stalled", "aborted"]) {
+      const rm = rmSpy();
+      const res = await sweepWorkerDirs({
+        orchDir: ORCH,
+        readDir: fakeDirs([`CTL-90${status}`]),
+        statDir: async () => ({ mtimeMs: now - 25 * HOUR }),
+        rm,
+        readAgents: () => ({ ok: true, agents: [] }),
+        readWorkerMeta: fakeWorkerMeta({
+          [`CTL-90${status}`]: {
+            statuses: { implement: status },
+            shortIds: new Set(),
+          },
+        }),
+        now: () => now,
+        retentionMs: RETENTION_24H,
+        emit: emitSpy(),
+        env: {},
+        log: logSpy(),
+      });
+      expect(rm.calls.length).toBe(1);
+      expect(res.reclaimed).toBe(1);
+    }
+  });
+
+  it("handles an unreadable workers root gracefully (returns zeros)", async () => {
+    const rm = rmSpy();
+    const res = await sweepWorkerDirs({
+      orchDir: ORCH,
+      readDir: async (p) => {
+        // workers root throws ENOENT; ticket subdir readDir never called
+        const e = new Error("ENOENT");
+        e.code = "ENOENT";
+        throw e;
+      },
+      statDir: async () => ({ mtimeMs: 0 }),
+      rm,
+      readAgents: () => ({ ok: true, agents: [] }),
+      now: () => 1_000_000_000_000,
+      retentionMs: RETENTION_24H,
+      emit: emitSpy(),
+      env: {},
+      log: logSpy(),
+    });
+    expect(rm.calls.length).toBe(0);
+    expect(res.reclaimed).toBe(0);
+    expect(res.scanned).toBe(0);
+  });
+});

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -94,6 +94,12 @@ The `orchestration.dispatchMode` key picks how Catalyst runs each ticket:
 | `orchestration.orphanPrSweep.intervalSeconds` | `600` | How often the orphan-PR sweep ticks (seconds). |
 | `orchestration.orphanPrSweep.stableSeconds` | `300` | How long an orphan must hold a blocker state before a Needs-You row is raised. |
 | `orchestration.orphanPrSweep.repo` | _(auto-detected)_ | The `org/repo` slug to pass to `gh pr list`. Falls back to top-level `.catalyst/config.json` repo fields, then `gh repo view`. Set this explicitly when auto-detection is unreliable. |
+| `orchestration.orphanReaper.jobGc.enabled` | `true` | Enable periodic GC of stale `~/.claude/jobs/<id>` dirs (CTL-1165 D3). Set `false` to disable. |
+| `orchestration.orphanReaper.jobGc.retentionSeconds` | `86400` | Delete a job dir only if its mtime is older than this many seconds (default 24 h). Env `CATALYST_JOB_GC_RETENTION_SECONDS` overrides. |
+| `orchestration.orphanReaper.jobGc.batchCap` | `200` | Max dirs deleted per sweep tick. Remaining dirs drain on subsequent ticks. Env `CATALYST_JOB_GC_BATCH_CAP` overrides. |
+| `orchestration.orphanReaper.workerGc.enabled` | `true` | Enable periodic GC of stale `execution-core/workers/<TICKET>/` dirs (CTL-1205). Set `false` to disable. |
+| `orchestration.orphanReaper.workerGc.retentionSeconds` | `86400` | Delete a worker dir only if its mtime is older than this many seconds (default 24 h). Env `CATALYST_WORKER_GC_RETENTION_SECONDS` overrides. |
+| `orchestration.orphanReaper.workerGc.batchCap` | `100` | Max worker dirs deleted per sweep tick. Env `CATALYST_WORKER_GC_BATCH_CAP` overrides. |
 | `orchestration.orphanReaper.procReaper.mode` | `shadow` | Orphan child-process reaper mode. `off` disables it; `shadow` (the default) logs `procOrphans.would-reap` for each orphaned reparented `node`/`bun` grandchild a dead worker left behind but **kills nothing**; `enforce` actually `SIGTERM`→grace→`SIGKILL`s them. Ships in `shadow` so the never-kill allowlist + live-agent process-tree correlation can be audited on real hosts before any `enforce` flip. |
 | `orchestration.orphanReaper.procReaper.graceMs` | `5000` | Milliseconds to wait after `SIGTERM` before re-probing and (only if still alive) `SIGKILL`ing, so `node`/`bun` can flush. |
 | `orchestration.orphanReaper.procReaper.minEtimeSec` | `900` | A process must have run at least this long (elapsed time) before it is eligible — corroboration only, never the sole gate. |


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-16T04:19:00Z -->
<!-- Last updated: 2026-06-16T04:19:00Z -->
<!-- PR: #2112 -->
<!-- Previous commits: 9b701aab2512e97d0b87e0fec19534685a83a501 -->

## Summary

- Adds `worker-dir-gc.mjs`: fail-closed, bounded sweep that deletes terminal+idle+aged `execution-core/workers/<TICKET>/` dirs
- Wires `workerGc` default-on into the existing 600s `startOrphanReaperTimer` alongside `jobGc` (no new daemon timer)
- Documents config keys `orphanReaper.workerGc.{enabled,retentionSeconds,batchCap}` and env overrides

## Problem

`execution-core/workers/<TICKET>/` dirs accumulate with no automated cleanup (137 dirs at the 2026-06-16 incident). `phase-teardown` archives but never deletes. Every scheduler tick reads all dirs synchronously (`readdirSync` + N×K `readFileSync`), aging the liveness snapshot past the CTL-731 30s hold threshold and starving new-work dispatch.

## Solution

Mirrors `job-dir-gc.mjs` (CTL-1165 D3) exactly. Four gates: agents readable (fail-closed), terminal, no live session, mtime ≥ 24h. Batch-capped at 100/tick.

## Changes Made

### New Files

- **`worker-dir-gc.mjs`** (216 lines) — GC sweep with four safety gates: `agents.json` readable (fail-closed), terminal signal state, no live Claude session (`~/.claude/jobs/`), mtime ≥ `retentionSeconds` (default 86400s). Batch-capped at `batchCap` (default 100/tick). Logs each deletion.
- **`worker-dir-gc.test.mjs`** (482 lines) — 16 unit tests covering all gate conditions, batch cap, retention window, and edge cases.

### Modified Files

- **`orphan-reaper-timer.mjs`** — wires `workerGc` into `startOrphanReaperTimer` alongside `jobGc`; same 600s interval, default-on
- **`orphan-reaper-timer.test.mjs`** — 4 new CTL-1205 tests (14 total green)
- **`daemon.mjs`** — passes `workerGc` config to the reaper timer
- **`website/src/content/docs/reference/configuration.md`** — documents `orphanReaper.workerGc.{enabled,retentionSeconds,batchCap}` and `CATALYST_WORKER_GC_*` env overrides

## How to Verify It

- [x] `bun test plugins/dev/scripts/execution-core/worker-dir-gc.test.mjs` — 16 tests green
- [x] `bun test plugins/dev/scripts/execution-core/orphan-reaper-timer.test.mjs` — 14 tests green (4 new CTL-1205 tests)
- [x] Full execution-core suite: 3971 pass, 14 pre-existing failures (unchanged)
- [x] No module-load cycle confirmed
- [x] All CI checks pass (Cloudflare Pages, audit-references, check-versions, docs-gate, execution-core-unit-tests, validate)

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1205

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1165
skip CTL-731
