### PR TITLE
feat(dev): CTL-1206 — flat board per-column scroll restoration

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Swimlane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Swimlane.tsx
@@ -64,6 +64,7 @@
 // the lanes into one CSS grid. Hand-rolled inline styles per DESIGN.md, reusing
 // the shared `C` token object + the `.catalyst-live-dot` pulse.
 import { Fragment, useEffect, useLayoutEffect, useRef, useState, type ReactNode, type RefObject } from "react";
+import { useColScrollState } from "../hooks/use-col-scroll-state";
 import { AnimatePresence } from "motion/react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { C, LIVE, TRAY_LIFT } from "./board-tokens";
@@ -300,6 +301,7 @@ function FlatColumnsBoard({
   cells: LaneCell[];
   bumpRef: RefObject<HTMLDivElement | null>;
 }) {
+  useColScrollState(bumpRef); // CTL-1206
   return (
     <div
       ref={bumpRef}
@@ -339,6 +341,7 @@ function FlatColumnsBoard({
             <div
               className="cat-overlay-scroll"
               data-flat-col-scroll="true"
+              data-col-key={col.key}
               style={{
                 flex: 1,
                 minHeight: 0,

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/col-scroll-contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/col-scroll-contract.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const swimlaneSrc = readFileSync(join(__dirname, "Swimlane.tsx"), "utf8");
+const hookSrc = readFileSync(join(__dirname, "..", "hooks", "use-col-scroll-state.ts"), "utf8");
+
+describe("CTL-1206 — flat per-column scroll restoration is wired", () => {
+  it("each flat-column viewport exposes its stable col.key as data-col-key", () => {
+    // the viewport carrying data-flat-col-scroll must also carry data-col-key={col.key}
+    expect(swimlaneSrc).toMatch(/data-flat-col-scroll="true"/);
+    expect(swimlaneSrc).toMatch(/data-col-key=\{col\.key\}/);
+  });
+
+  it("FlatColumnsBoard invokes the column scroll-state hook", () => {
+    expect(swimlaneSrc).toMatch(/useColScrollState\s*\(/);
+  });
+
+  it("the hook saves/restores against the per-entry colScrollY map", () => {
+    expect(hookSrc).toMatch(/colScrollY|setColScroll|colScrollFor/);
+    expect(hookSrc).toMatch(/data-flat-col-scroll/);
+    expect(hookSrc).toMatch(/data-col-key/);
+    // restore happens after paint (rAF), mirroring the Shell.tsx detail precedent
+    expect(hookSrc).toMatch(/requestAnimationFrame/);
+    // save is debounced and reads the per-entry key
+    expect(hookSrc).toMatch(/useDetailEntryKey|useDetailEntryState/);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/detail-entry-state.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/detail-entry-state.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "bun:test";
+import {
+  freshEntryState,
+  DETAIL_ENTRY_DEFAULTS,
+  colScrollFor,
+  setColScroll,
+} from "./detail-entry-state";
+
+describe("CTL-1206 — per-column scroll map on the entry state", () => {
+  it("freshEntryState starts with an empty colScrollY map", () => {
+    expect(freshEntryState().colScrollY).toEqual({});
+  });
+
+  it("DETAIL_ENTRY_DEFAULTS includes an empty colScrollY map", () => {
+    expect(DETAIL_ENTRY_DEFAULTS.colScrollY).toEqual({});
+  });
+
+  it("each freshEntryState returns an independent colScrollY object", () => {
+    const a = freshEntryState();
+    a.colScrollY["PR"] = 42;
+    expect(freshEntryState().colScrollY).toEqual({}); // no shared reference
+  });
+
+  it("colScrollFor returns 0 for an unseen column", () => {
+    expect(colScrollFor(freshEntryState(), "PR")).toBe(0);
+  });
+
+  it("colScrollFor returns the stored offset for a known column", () => {
+    const s = setColScroll(freshEntryState(), "PR", 120);
+    expect(colScrollFor(s, "PR")).toBe(120);
+  });
+
+  it("setColScroll is immutable and scoped to the one key", () => {
+    const base = setColScroll(freshEntryState(), "PR", 10);
+    const next = setColScroll(base, "Implement", 30);
+    expect(base.colScrollY).toEqual({ PR: 10 });            // base untouched
+    expect(next.colScrollY).toEqual({ PR: 10, Implement: 30 });
+    expect(next).not.toBe(base);
+  });
+
+  it("setColScroll overwrites an existing column offset", () => {
+    const s = setColScroll(setColScroll(freshEntryState(), "PR", 10), "PR", 80);
+    expect(s.colScrollY).toEqual({ PR: 80 });
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/detail-entry-state.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/detail-entry-state.ts
@@ -35,6 +35,12 @@ export interface DetailEntryState {
    *  (`data-shell-scroll`). 0 on a fresh push (top); a real offset on a traversed
    *  entry (back/forward restoration). */
   scrollY: number;
+  /** Saved vertical scrollTop per flat-board column, keyed by `col.key` (CTL-1206).
+   *  Only populated when the flat (ungrouped) board is active. An absent key means
+   *  0 (top); a present value is the last saved scrollTop for that column. Rides
+   *  inside the same per-entry atom that is already LRU-bounded, so no new unbounded
+   *  growth. */
+  colScrollY: Record<string, number>;
 }
 
 /** The fresh-push defaults: Spec tab, ALL rail sections expanded, scrolled to top.
@@ -44,12 +50,13 @@ export const DETAIL_ENTRY_DEFAULTS: DetailEntryState = {
   activeTab: "spec",
   railExpanded: {},
   scrollY: 0,
+  colScrollY: {},
 };
 
 /** A fresh, independent copy of the defaults (never share the object reference —
  *  each entry's atom owns its own mutable snapshot). */
 export function freshEntryState(): DetailEntryState {
-  return { activeTab: "spec", railExpanded: {}, scrollY: 0 };
+  return { activeTab: "spec", railExpanded: {}, scrollY: 0, colScrollY: {} };
 }
 
 /** Resolve whether a rail section is expanded for an entry: an explicit stored
@@ -68,6 +75,22 @@ export function setRailSection(
   expanded: boolean,
 ): DetailEntryState {
   return { ...state, railExpanded: { ...state.railExpanded, [sectionId]: expanded } };
+}
+
+/** The saved vertical scrollTop for a flat-board column, keyed by `col.key`
+ *  (CTL-1206). Absent column → 0 (top), the fresh default. */
+export function colScrollFor(state: DetailEntryState, colKey: string): number {
+  return state.colScrollY[colKey] ?? 0;
+}
+
+/** Return a new state with `colKey`'s saved scrollTop set to `y` (immutable
+ *  update — the jotai setter replaces the atom value). CTL-1206. */
+export function setColScroll(
+  state: DetailEntryState,
+  colKey: string,
+  y: number,
+): DetailEntryState {
+  return { ...state, colScrollY: { ...state.colScrollY, [colKey]: y } };
 }
 
 // ── bounded memory (LRU over live entry keys) ────────────────────────────────

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-col-scroll-state.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-col-scroll-state.ts
@@ -1,0 +1,70 @@
+// use-col-scroll-state.ts — CTL-1206. Saves/restores the flat (ungrouped) board's
+// per-column vertical scroll against the board's own per-history-entry atom, so an
+// Escape-back from a ticket lands the operator exactly where they were INSIDE a
+// column. Mirrors the CTL-1049 detail-scroll precedent (Shell.tsx:471-500), but the
+// flat board has N independent viewports (one per column) instead of one, so we
+// iterate `[data-flat-col-scroll][data-col-key]` within the board container and key
+// the saved offsets by `data-col-key` (= col.key).
+import { useEffect, useRef, type RefObject } from "react";
+import { useDetailEntryState } from "./use-detail-entry-state";
+import { colScrollFor, setColScroll } from "../board/detail-entry-state";
+
+const COL_SAVE_DEBOUNCE_MS = 120; // parity with Shell.tsx detail-scroll save
+
+export function useColScrollState(containerRef: RefObject<HTMLElement | null>): void {
+  const { key: entryKey, state, setState } = useDetailEntryState();
+
+  // Snapshot the restore target map ONCE per entry key, so the restore effect
+  // doesn't fight the live scroll writes that follow (mirrors Shell.tsx:461-466).
+  const restoreRef = useRef<{ key: string; map: Record<string, number> } | null>(null);
+  if (restoreRef.current?.key !== entryKey) {
+    restoreRef.current = { key: entryKey, map: state.colScrollY };
+  }
+
+  // Restore each column's saved offset after paint (rAF → real scrollHeight).
+  useEffect(() => {
+    const container = containerRef.current;
+    const snap = restoreRef.current;
+    if (!container || !snap) return;
+    const raf = requestAnimationFrame(() => {
+      const els = container.querySelectorAll<HTMLElement>("[data-flat-col-scroll][data-col-key]");
+      els.forEach((el) => {
+        const colKey = el.getAttribute("data-col-key");
+        if (!colKey) return;
+        const y = snap.map[colKey] ?? 0;
+        if (y > 0) el.scrollTop = y;
+      });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [entryKey, containerRef]);
+
+  // Save each column's offset on scroll-idle (debounced) into THIS entry's state.
+  // scroll events don't bubble, so we listen in the CAPTURE phase on the container
+  // to catch every descendant viewport with one listener (robust to columns
+  // mounting/unmounting as grouping/filters change).
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const timers = new Map<string, ReturnType<typeof setTimeout>>();
+    const onScroll = (e: Event) => {
+      const el = e.target as HTMLElement | null;
+      if (!el || !el.matches?.("[data-flat-col-scroll][data-col-key]")) return;
+      const colKey = el.getAttribute("data-col-key");
+      if (!colKey) return;
+      const prevTimer = timers.get(colKey);
+      if (prevTimer) clearTimeout(prevTimer);
+      timers.set(
+        colKey,
+        setTimeout(() => {
+          const y = el.scrollTop;
+          setState((prev) => (colScrollFor(prev, colKey) === y ? prev : setColScroll(prev, colKey, y)));
+        }, COL_SAVE_DEBOUNCE_MS),
+      );
+    };
+    container.addEventListener("scroll", onScroll, { passive: true, capture: true });
+    return () => {
+      container.removeEventListener("scroll", onScroll, { capture: true } as EventListenerOptions);
+      timers.forEach((t) => clearTimeout(t));
+    };
+  }, [entryKey, containerRef, setState]);
+}


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-16T04:40:00Z -->
<!-- Last updated: 2026-06-16T04:40:00Z -->
<!-- PR: #2113 -->
<!-- Previous commits: ba862e26f897538b528e7e9b489662637eca8dac -->

## Summary

Adds per-column scroll restoration to the flat (ungrouped) orch-monitor board. When an operator scrolls within a column, opens a ticket detail, and presses Escape to return, the column now restores to exactly the same vertical scroll position — so they land back where they were reading, not at the top.

The implementation mirrors the existing CTL-1049 detail-scroll pattern (Jotai per-entry atom + rAF restore + debounced capture-phase save), extended to handle N independent column viewports instead of one.

## Changes Made

### State model

- Extended `DetailEntryState` with `colScrollY: Record<string, number>` — a map from `col.key` to saved scrollTop, owned by the same per-entry LRU-bounded atom that already holds tab/rail/scrollY state
- Added pure helpers `colScrollFor(state, colKey)` and `setColScroll(state, colKey, y)` for immutable reads/writes

### Hook

- Added `use-col-scroll-state.ts` — wires save and restore for the flat board:
  - **Restore**: `useEffect` on entry-key change → `requestAnimationFrame` → queries `[data-flat-col-scroll][data-col-key]` within the board container and sets each `scrollTop` from the saved map
  - **Save**: capture-phase scroll listener on the container, debounced 120 ms (parity with the detail-scroll save), writes `setColScroll` into the entry atom only on real changes

### Wiring

- `FlatColumnsBoard` in `Swimlane.tsx` now calls `useColScrollState(bumpRef)`
- Each per-column viewport `<div data-flat-col-scroll>` now also carries `data-col-key={col.key}` — the stable key the hook uses to associate a scroll offset with the right column

### Tests

- `col-scroll-contract.test.ts` — source-level contract tests asserting the viewport carries `data-col-key`, `FlatColumnsBoard` invokes the hook, and the hook reads/writes the expected attributes and APIs
- `detail-entry-state.test.ts` — unit tests for `colScrollFor`, `setColScroll`, immutability, independence of `freshEntryState()` instances

## How to Verify It

- [ ] `bun test` passes under `ui/` (contract + unit suites)
- [ ] **Manual — flat board (ungrouped)**:
  1. Open [http://mini.rozich.com:7400](http://mini.rozich.com:7400) with at least one active ticket
  2. Select the flat (ungrouped) board
  3. Scroll one column down past several cards
  4. Open a ticket detail by clicking a card
  5. Press Escape to return — the column should be at the same vertical position, not reset to the top
- [ ] **Manual — walking cards**: open card → Escape → open next card → Escape; each return should restore the column scroll, not reset it

## Changelog Entry

```
feat(dev): CTL-1206 — flat board per-column scroll restoration

Extends DetailEntryState with colScrollY (col.key → scrollTop) plus
colScrollFor/setColScroll pure helpers; wires useColScrollState into
FlatColumnsBoard to save (120ms debounce, capture-phase) and restore
(rAF) each column's scroll against the board's own per-entry atom.
```

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1206

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1049
