### PR TITLE
feat(dev): CTL-1188 — catalyst cluster CLI (status/add/remove/rename/set-anchor/drain/tune)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-cluster-cli.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-cluster-cli.test.sh
@@ -68,6 +68,37 @@ else
   FAIL=$((FAIL+1)); echo "FAIL: --help (got: ${out})"
 fi
 
+# CTL-1188: new verbs
+
+# 7. usage lists all seven verbs
+out="$("$CLUSTER" --help 2>&1 || true)"
+for v in status add remove rename set-anchor drain tune; do
+  if echo "$out" | grep -q " $v"; then
+    PASS=$((PASS+1)); echo "PASS: usage lists $v"
+  else
+    FAIL=$((FAIL+1)); echo "FAIL: usage lists $v (got: $(echo "$out" | head -5))"
+  fi
+done
+
+# 8. status routes via JS (smoke: CATALYST_CONFIG_FILE points at a temp .catalyst)
+tmp="$(mktemp -d)"; mkdir -p "$tmp/.catalyst"; printf '["mini"]' > "$tmp/.catalyst/hosts.json"
+out="$(CATALYST_CONFIG_FILE="$tmp/.catalyst/config.json" CATALYST_HOST_NAME=mini \
+       "$CLUSTER" status --json 2>&1 || true)"
+rm -rf "$tmp"
+if echo "$out" | grep -q '"hosts"'; then
+  PASS=$((PASS+1)); echo "PASS: status --json routes and returns hosts field"
+else
+  FAIL=$((FAIL+1)); echo "FAIL: status --json (got: ${out})"
+fi
+
+# 9. drain rejects a host argument (remote drain is T13 / out of scope)
+rc=0; out="$("$CLUSTER" drain some-host 2>&1)" || rc=$?
+if echo "$out" | grep -q "T13" && [[ $rc -ne 0 ]]; then
+  PASS=$((PASS+1)); echo "PASS: drain rejects host arg with T13 pointer"
+else
+  FAIL=$((FAIL+1)); echo "FAIL: drain with host arg (rc=${rc}, out=${out})"
+fi
+
 echo ""
 echo "catalyst-cluster-cli: ${PASS} passed, ${FAIL} failed"
 [[ $FAIL -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/catalyst-cluster
+++ b/plugins/dev/scripts/catalyst-cluster
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
-# catalyst-cluster — seed-side cluster operations (CTL-1184 + CTL-1183).
+# catalyst-cluster — cluster administration (CTL-1184 + CTL-1183 + CTL-1188).
 #
 # Verbs:
 #   join-token   Mint a one-time, short-TTL join token (jt_<hex>) and ARM the
 #                single-use bundle listener (CTL-1183) so exactly one bundle
 #                fetch succeeds (consume-on-first-200, then it exits). Re-run to
 #                mint a fresh token (re-arms). Optional: --port N --ttl MIN.
-#
-# Future verbs (CTL-1188): status | add | remove | rename | set-anchor | drain | tune
+#   status       Show cluster roster and live heartbeat state          [live]
+#   add          Add a host to the roster                              [live]
+#   remove       Remove a host from the roster                         [live]
+#   rename       Rename this host (requires catalyst-stack restart)    [restart]
+#   set-anchor   Set the liveness anchor ticket (requires restart)     [restart]
+#   drain        Toggle the local drain flag                           [live]
+#   tune         Write a concurrency param to Layer-2                  [live]
 #
 # The token is a bearer secret: printed once to stdout, written to a 0600 store
 # under ${CATALYST_DIR:-~/catalyst}/cluster/join-token.json. Never logged to a
@@ -20,6 +25,8 @@ _SRC="${BASH_SOURCE[0]}"; while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")";
 SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"; unset _SRC
 STORE_MJS="${SCRIPT_DIR}/execution-core/join-token-store.mjs"
 LISTENER_MJS="${SCRIPT_DIR}/execution-core/join-listener.mjs"
+CLI_MJS="${SCRIPT_DIR}/execution-core/cli/cluster.mjs"
+EXEC_CORE="${SCRIPT_DIR}/catalyst-execution-core"
 CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
 
 # Resolve a JS runtime (bun preferred, node fallback) — matches sibling .mjs CLIs.
@@ -31,6 +38,18 @@ usage: catalyst cluster <verb>
   join-token [--port N] [--ttl MIN]   Mint a one-time join token and arm the
                                       single-use join-bundle listener
                                       (consume-on-first-200, then it exits)
+  status [--json]                     Show cluster roster + live heartbeat state
+                                      [takes effect: live]
+  add <name> [--no-commit]            Add a host to the roster                  [live]
+  remove <name> [--no-commit]         Remove a host from the roster             [live]
+  rename <newname> [--no-commit]      Rename this host in Layer-2 + roster
+                                      [requires: catalyst-stack restart]
+  set-anchor <ticket>                 Set the cross-host liveness anchor ticket
+                                      [requires: catalyst-stack restart]
+  drain [--off]                       Toggle the local drain flag               [live]
+                                      (remote-host drain: T13 — not yet implemented)
+  tune <param> <value>                Write a concurrency param to Layer-2      [live]
+                                      params: maxParallel, minParallel, maxParallelCeiling
   -h, --help                          Show this help
 EOF
 }
@@ -101,6 +120,18 @@ EOF
 
 case "${1:-}" in
   join-token) shift; cmd_join_token "$@" ;;
+  status|add|remove|rename|set-anchor|tune)
+    [[ -n "$JS_RUN" ]] || { echo "catalyst cluster: no bun/node runtime found" >&2; exit 1; }
+    [[ -f "$CLI_MJS" ]] || { echo "catalyst cluster: missing $CLI_MJS" >&2; exit 1; }
+    exec "$JS_RUN" "$CLI_MJS" "$@" ;;
+  drain)
+    shift
+    # Local-only; a non-flag host argument means remote drain (T13) which is unimplemented.
+    if [[ -n "${1:-}" && "${1:0:1}" != "-" ]]; then
+      echo "catalyst cluster drain: remote-host drain is not implemented (T13); drains the local host only" >&2
+      exit 2
+    fi
+    exec "$EXEC_CORE" drain "$@" ;;
   ""|-h|--help|help)
     usage
     [[ "${1:-}" == "" ]] && exit 1 || exit 0 ;;

--- a/plugins/dev/scripts/execution-core/cli-cluster.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli-cluster.test.mjs
@@ -1,0 +1,315 @@
+// cli-cluster.test.mjs — CTL-1188. Unit tests for cli/cluster.mjs.
+// Run: cd plugins/dev/scripts/execution-core && bun test cli-cluster.test.mjs
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildStatus,
+  addHost,
+  removeHost,
+  renameHost,
+  setAnchor,
+  tune,
+} from "./cli/cluster.mjs";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeTmp() {
+  return mkdtempSync(join(tmpdir(), "cl-test-"));
+}
+
+function withRoster(initial, fn) {
+  const dir = makeTmp();
+  const p = join(dir, "hosts.json");
+  writeFileSync(p, JSON.stringify(initial) + "\n");
+  try {
+    return fn(p, () => JSON.parse(readFileSync(p, "utf8")));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── buildStatus ────────────────────────────────────────────────────────────
+
+describe("buildStatus (CTL-1188)", () => {
+  test("single-host roster, no anchor → one self row, not live", () => {
+    const out = buildStatus({
+      roster: ["mini"],
+      self: "mini",
+      peers: {},
+      draining: false,
+    });
+    expect(out.hosts).toHaveLength(1);
+    expect(out.hosts[0]).toMatchObject({ name: "mini", self: true, live: false });
+    expect(out.draining).toBe(false);
+  });
+
+  test("multi-host merges live heartbeats and flags stale roster members", () => {
+    const out = buildStatus({
+      roster: ["mini", "mac-studio"],
+      self: "mini",
+      peers: {
+        mini: { host: "mini", last_seen: "2026-06-16T12:10:00Z", in_flight_tickets: ["CTL-1"] },
+      },
+      draining: false,
+    });
+    const mac = out.hosts.find((h) => h.name === "mac-studio");
+    expect(mac.live).toBe(false);
+    expect(out.hosts.find((h) => h.name === "mini").inFlight).toEqual(["CTL-1"]);
+  });
+
+  test("--json shape is stable (roster, draining, hosts[])", () => {
+    const out = buildStatus({ roster: ["mini"], self: "mini", peers: {}, draining: true });
+    expect(out).toHaveProperty("hosts");
+    expect(out).toHaveProperty("draining", true);
+    expect(out).toHaveProperty("roster");
+    expect(out).toHaveProperty("self", "mini");
+  });
+
+  test("live peer present → live=true", () => {
+    const out = buildStatus({
+      roster: ["mini"],
+      self: "mini",
+      peers: { mini: { last_seen: "2026-06-16T12:00:00Z", in_flight_tickets: [] } },
+      draining: false,
+    });
+    expect(out.hosts[0].live).toBe(true);
+  });
+
+  test("peer in_flight_tickets is empty array when absent from peers", () => {
+    const out = buildStatus({ roster: ["mini"], self: "mini", peers: {}, draining: false });
+    expect(out.hosts[0].inFlight).toEqual([]);
+  });
+});
+
+// ── addHost ────────────────────────────────────────────────────────────────
+
+describe("addHost", () => {
+  test("appends a new name and commits", () => {
+    withRoster(["mini"], (hostsPath, read) => {
+      const committed = [];
+      const r = addHost("mac-studio", {
+        hostsPath,
+        self: "mini",
+        readPeers: () => ({}),
+        git: (args) => committed.push(args),
+        commit: true,
+      });
+      expect(r.code).toBe(0);
+      expect(read()).toEqual(["mini", "mac-studio"]);
+      expect(committed.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  test("idempotent: name already in roster → code 2, no write", () => {
+    withRoster(["mini"], (hostsPath, read) => {
+      const r = addHost("mini", { hostsPath, self: "mini", readPeers: () => ({}) });
+      expect(r.code).toBe(2);
+      expect(read()).toEqual(["mini"]);
+    });
+  });
+
+  test("refuses a name already publishing a live heartbeat", () => {
+    withRoster(["mini"], (hostsPath, read) => {
+      const r = addHost("ghost", {
+        hostsPath,
+        self: "mini",
+        readPeers: () => ({ ghost: { host: "ghost", last_seen: "2026-06-16T12:00:00Z" } }),
+      });
+      expect(r.code).toBe(2);
+      expect(read()).toEqual(["mini"]);
+    });
+  });
+
+  test("--no-commit writes but does not invoke git", () => {
+    withRoster(["mini"], (hostsPath, read) => {
+      const git = () => { throw new Error("should not commit"); };
+      const r = addHost("mac-studio", {
+        hostsPath,
+        self: "mini",
+        readPeers: () => ({}),
+        git,
+        commit: false,
+      });
+      expect(r.code).toBe(0);
+      expect(read()).toEqual(["mini", "mac-studio"]);
+    });
+  });
+
+  test("missing name → code 2", () => {
+    withRoster(["mini"], (hostsPath) => {
+      const r = addHost("", { hostsPath, self: "mini", readPeers: () => ({}) });
+      expect(r.code).toBe(2);
+    });
+  });
+});
+
+// ── removeHost ─────────────────────────────────────────────────────────────
+
+describe("removeHost", () => {
+  test("removes a non-self name and commits", () => {
+    withRoster(["mini", "mac-studio"], (hostsPath, read) => {
+      const r = removeHost("mac-studio", {
+        hostsPath,
+        self: "mini",
+        inFlightCount: () => 0,
+        git: () => {},
+        commit: true,
+      });
+      expect(r.code).toBe(0);
+      expect(read()).toEqual(["mini"]);
+    });
+  });
+
+  test("refuses removing self while in-flight > 0", () => {
+    withRoster(["mini", "mac-studio"], (hostsPath, read) => {
+      const r = removeHost("mini", {
+        hostsPath,
+        self: "mini",
+        inFlightCount: () => 2,
+      });
+      expect(r.code).toBe(2);
+      expect(read()).toEqual(["mini", "mac-studio"]);
+    });
+  });
+
+  test("allows removing self when in-flight === 0", () => {
+    withRoster(["mini", "mac-studio"], (hostsPath, read) => {
+      const r = removeHost("mini", {
+        hostsPath,
+        self: "mini",
+        inFlightCount: () => 0,
+        git: () => {},
+        commit: false,
+      });
+      expect(r.code).toBe(0);
+      expect(read()).toEqual(["mac-studio"]);
+    });
+  });
+
+  test("name not in roster → code 2", () => {
+    withRoster(["mini"], (hostsPath) => {
+      const r = removeHost("nope", { hostsPath, self: "mini", inFlightCount: () => 0 });
+      expect(r.code).toBe(2);
+    });
+  });
+
+  test("missing name → code 2", () => {
+    withRoster(["mini"], (hostsPath) => {
+      const r = removeHost("", { hostsPath, self: "mini", inFlightCount: () => 0 });
+      expect(r.code).toBe(2);
+    });
+  });
+});
+
+// ── renameHost ─────────────────────────────────────────────────────────────
+
+describe("renameHost", () => {
+  test("writes Layer-2 host.name, swaps roster entry, signals restart-required", () => {
+    withRoster(["mini", "mac-studio"], (hostsPath, read) => {
+      const writes = [];
+      const r = renameHost("mini-2", {
+        hostsPath,
+        self: "mini",
+        writeLayer2: (obj) => writes.push(obj),
+        git: () => {},
+        commit: true,
+      });
+      expect(r.code).toBe(0);
+      expect(r.restartRequired).toBe(true);
+      expect(read()).toEqual(["mini-2", "mac-studio"]);
+      expect(writes[0]).toMatchObject({ catalyst: { host: { name: "mini-2" } } });
+    });
+  });
+
+  test("refuses if newname already in roster", () => {
+    withRoster(["mini", "mac-studio"], (hostsPath) => {
+      const r = renameHost("mac-studio", {
+        hostsPath,
+        self: "mini",
+        writeLayer2: () => {},
+      });
+      expect(r.code).toBe(2);
+    });
+  });
+
+  test("missing newname → code 2", () => {
+    withRoster(["mini"], (hostsPath) => {
+      const r = renameHost("", { hostsPath, self: "mini", writeLayer2: () => {} });
+      expect(r.code).toBe(2);
+    });
+  });
+
+  test("still writes Layer-2 even when self not in roster", () => {
+    withRoster(["other"], (hostsPath, read) => {
+      const writes = [];
+      const r = renameHost("ghost-2", {
+        hostsPath,
+        self: "ghost",
+        writeLayer2: (obj) => writes.push(obj),
+        git: () => {},
+        commit: false,
+      });
+      expect(r.code).toBe(0);
+      expect(writes[0]).toMatchObject({ catalyst: { host: { name: "ghost-2" } } });
+      expect(read()).toEqual(["other"]);
+    });
+  });
+});
+
+// ── setAnchor ──────────────────────────────────────────────────────────────
+
+describe("setAnchor", () => {
+  test("writes Layer-2 livenessAnchorIssue, signals restart-required", () => {
+    const writes = [];
+    const r = setAnchor("CTL-1090", { writeLayer2: (obj) => writes.push(obj) });
+    expect(r.code).toBe(0);
+    expect(r.restartRequired).toBe(true);
+    expect(writes[0]).toMatchObject({
+      catalyst: { cluster: { livenessAnchorIssue: "CTL-1090" } },
+    });
+  });
+
+  test("rejects empty ticket arg", () => {
+    const r = setAnchor("", { writeLayer2: () => {} });
+    expect(r.code).toBe(2);
+  });
+});
+
+// ── tune ───────────────────────────────────────────────────────────────────
+
+describe("tune", () => {
+  test("writes a numeric executionCore param to Layer-2 (live)", () => {
+    const writes = [];
+    const r = tune("maxParallel", "4", { writeLayer2: (o) => writes.push(o) });
+    expect(r.code).toBe(0);
+    expect(r.restartRequired).toBeFalsy();
+    expect(writes[0]).toMatchObject({
+      catalyst: { orchestration: { executionCore: { maxParallel: 4 } } },
+    });
+  });
+
+  test("rejects unknown param", () => {
+    const r = tune("bogus", "4", { writeLayer2: () => {} });
+    expect(r.code).toBe(2);
+  });
+
+  test("rejects non-numeric value", () => {
+    const r = tune("maxParallel", "lots", { writeLayer2: () => {} });
+    expect(r.code).toBe(2);
+  });
+
+  test("rejects non-positive integer", () => {
+    const r = tune("maxParallel", "0", { writeLayer2: () => {} });
+    expect(r.code).toBe(2);
+  });
+
+  test("accepts minParallel and maxParallelCeiling", () => {
+    const writes = [];
+    expect(tune("minParallel", "2", { writeLayer2: (o) => writes.push(o) }).code).toBe(0);
+    expect(tune("maxParallelCeiling", "8", { writeLayer2: (o) => writes.push(o) }).code).toBe(0);
+    expect(writes[0]).toMatchObject({ catalyst: { orchestration: { executionCore: { minParallel: 2 } } } });
+    expect(writes[1]).toMatchObject({ catalyst: { orchestration: { executionCore: { maxParallelCeiling: 8 } } } });
+  });
+});

--- a/plugins/dev/scripts/execution-core/cli/cluster.mjs
+++ b/plugins/dev/scripts/execution-core/cli/cluster.mjs
@@ -1,0 +1,289 @@
+// cli/cluster.mjs — CTL-1188. `catalyst cluster <verb>` data verbs.
+// Pure functions (buildStatus, addHost, removeHost, renameHost, setAnchor, tune)
+// take injectable deps for unit testing; runX() wires real config/heartbeat/git;
+// main() dispatches. drain + join-token are handled in the bash front end.
+import { writeFileSync, renameSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  getClusterHosts,
+  getHostName,
+  getLivenessAnchorIssue,
+  getCatalystRepoDirHostsPath,
+  getLayer2ConfigPath,
+  isDraining,
+  getExecutionCoreDir,
+} from "../config.mjs";
+import { readPeerHeartbeatsSync } from "../cluster-heartbeat-sync.mjs";
+import { writeSecretConfig } from "../write-secret-config.mjs";
+import { listInFlightTickets } from "../scheduler.mjs";
+
+// ── Roster I/O helpers (shared across all mutating verbs) ──────────────────
+
+function readRoster(hostsPath) {
+  try {
+    const parsed = JSON.parse(readFileSync(hostsPath, "utf8"));
+    if (Array.isArray(parsed)) return parsed.filter((h) => typeof h === "string" && h.length > 0);
+  } catch { /* absent/malformed */ }
+  return [];
+}
+
+function writeRosterAtomic(hostsPath, roster) {
+  const tmp = `${hostsPath}.tmp.${process.pid}`;
+  writeFileSync(tmp, JSON.stringify(roster, null, 0) + "\n");
+  renameSync(tmp, hostsPath);
+}
+
+const defaultGit = (args) => execFileSync("git", args, { encoding: "utf8" });
+
+function gitCommitRoster(git, hostsPath, message) {
+  try {
+    git(["add", hostsPath]);
+    git(["commit", "-m", message, "--", hostsPath]);
+  } catch { /* surface but non-fatal: the write already landed */ }
+}
+
+// ── buildStatus — pure merge of roster ⊕ live heartbeats ⊕ drain ──────────
+
+export function buildStatus({ roster, self, peers, draining }) {
+  const hosts = roster.map((name) => {
+    const rec = peers[name];
+    return {
+      name,
+      self: name === self,
+      live: Boolean(rec && rec.last_seen),
+      lastSeen: rec?.last_seen ?? null,
+      inFlight: Array.isArray(rec?.in_flight_tickets) ? rec.in_flight_tickets : [],
+    };
+  });
+  return { roster, self, draining, hosts };
+}
+
+function renderStatus(s) {
+  const lines = [`Cluster roster (${s.hosts.length} host${s.hosts.length === 1 ? "" : "s"}):`];
+  for (const h of s.hosts) {
+    const tags = [];
+    if (h.self) tags.push("self");
+    if (h.live) tags.push("live");
+    if (s.draining && h.self) tags.push("draining");
+    const inFlight = h.inFlight.length > 0 ? ` [${h.inFlight.join(", ")}]` : "";
+    lines.push(`  ${h.name}${tags.length ? " (" + tags.join(", ") + ")" : ""}${inFlight}`);
+  }
+  if (!s.hosts.some((h) => h.live)) lines.push("  (no live heartbeats — liveness anchor may be unset)");
+  return lines.join("\n") + "\n";
+}
+
+export function runStatus(argv = []) {
+  const anchor = getLivenessAnchorIssue();
+  const status = buildStatus({
+    roster: getClusterHosts(),
+    self: getHostName(),
+    peers: anchor ? readPeerHeartbeatsSync({ anchorIssue: anchor }) : {},
+    draining: isDraining(getExecutionCoreDir()),
+  });
+  if (argv.includes("--json")) {
+    process.stdout.write(JSON.stringify(status) + "\n");
+  } else {
+    process.stdout.write(renderStatus(status));
+  }
+  return 0;
+}
+
+// ── addHost — append a name to the roster ──────────────────────────────────
+
+export function addHost(name, {
+  hostsPath,
+  self,
+  readPeers = () => readPeerHeartbeatsSync({ anchorIssue: getLivenessAnchorIssue() }),
+  git = defaultGit,
+  commit = true,
+} = {}) {
+  if (!name) return { code: 2, msg: "add requires <name>" };
+  const roster = readRoster(hostsPath);
+  if (roster.includes(name)) return { code: 2, msg: `'${name}' already in roster` };
+  const peers = readPeers();
+  if (peers[name]?.last_seen) {
+    return { code: 2, msg: `'${name}' is already publishing a live heartbeat` };
+  }
+  const next = [...roster, name];
+  writeRosterAtomic(hostsPath, next);
+  if (commit) gitCommitRoster(git, hostsPath, `chore(cluster): add ${name} to roster`);
+  const anchorUnset = Object.keys(peers).length === 0 && !getLivenessAnchorIssue();
+  return { code: 0, roster: next, anchorUnset };
+}
+
+export function runAdd(argv = []) {
+  const noCommit = argv.includes("--no-commit");
+  const name = argv.filter((a) => !a.startsWith("-"))[0];
+  const res = addHost(name, {
+    hostsPath: getCatalystRepoDirHostsPath(),
+    self: getHostName(),
+    commit: !noCommit,
+  });
+  if (res.code !== 0) {
+    process.stderr.write(`catalyst cluster add: ${res.msg}\n`);
+    return res.code;
+  }
+  process.stdout.write(`Added '${name}' to roster: [${res.roster.join(", ")}]\n`);
+  process.stdout.write("Takes effect live (next scheduler tick).\n");
+  if (res.anchorUnset) {
+    process.stderr.write(
+      "warn: liveness anchor is unset — set it with 'catalyst cluster set-anchor <ticket>'\n"
+    );
+  }
+  return 0;
+}
+
+// ── removeHost — remove a name from the roster ────────────────────────────
+
+export function removeHost(name, {
+  hostsPath,
+  self,
+  inFlightCount = () => 0,
+  git = defaultGit,
+  commit = true,
+} = {}) {
+  if (!name) return { code: 2, msg: "remove requires <name>" };
+  const roster = readRoster(hostsPath);
+  if (!roster.includes(name)) return { code: 2, msg: `'${name}' not in roster` };
+  const count = inFlightCount();
+  if (name === self && count > 0) {
+    return { code: 2, msg: `refusing to remove self while ${count} ticket(s) in flight` };
+  }
+  const next = roster.filter((h) => h !== name);
+  writeRosterAtomic(hostsPath, next);
+  if (commit) gitCommitRoster(git, hostsPath, `chore(cluster): remove ${name} from roster`);
+  return { code: 0, roster: next };
+}
+
+export function runRemove(argv = []) {
+  const noCommit = argv.includes("--no-commit");
+  const name = argv.filter((a) => !a.startsWith("-"))[0];
+  const orchDir = getExecutionCoreDir();
+  const res = removeHost(name, {
+    hostsPath: getCatalystRepoDirHostsPath(),
+    self: getHostName(),
+    inFlightCount: () => listInFlightTickets(orchDir).size,
+    commit: !noCommit,
+  });
+  if (res.code !== 0) {
+    process.stderr.write(`catalyst cluster remove: ${res.msg}\n`);
+    return res.code;
+  }
+  process.stdout.write(`Removed '${name}' from roster: [${res.roster.join(", ")}]\n`);
+  process.stdout.write("Takes effect live (next scheduler tick).\n");
+  return 0;
+}
+
+// ── renameHost — write Layer-2 host.name + swap roster entry ──────────────
+
+export function renameHost(newName, {
+  hostsPath,
+  self,
+  writeLayer2 = (obj) => writeSecretConfig(getLayer2ConfigPath(), obj),
+  git = defaultGit,
+  commit = true,
+} = {}) {
+  if (!newName) return { code: 2, msg: "rename requires <newname>" };
+  const roster = readRoster(hostsPath);
+  if (roster.includes(newName)) return { code: 2, msg: `'${newName}' already in roster` };
+  writeLayer2({ catalyst: { host: { name: newName } } });
+  if (roster.includes(self)) {
+    const next = roster.map((h) => (h === self ? newName : h));
+    writeRosterAtomic(hostsPath, next);
+    if (commit) gitCommitRoster(git, hostsPath, `chore(cluster): rename ${self} → ${newName}`);
+  }
+  return { code: 0, restartRequired: true };
+}
+
+export function runRename(argv = []) {
+  const noCommit = argv.includes("--no-commit");
+  const newName = argv.filter((a) => !a.startsWith("-"))[0];
+  const self = getHostName();
+  const res = renameHost(newName, {
+    hostsPath: getCatalystRepoDirHostsPath(),
+    self,
+    commit: !noCommit,
+  });
+  if (res.code !== 0) {
+    process.stderr.write(`catalyst cluster rename: ${res.msg}\n`);
+    return res.code;
+  }
+  process.stdout.write(`catalyst.host.name → '${newName}'. Run 'catalyst-stack restart' to activate (HRW identity is captured at startup).\n`);
+  return 0;
+}
+
+// ── setAnchor — write Layer-2 livenessAnchorIssue ────────────────────────
+
+export function setAnchor(ticket, {
+  writeLayer2 = (obj) => writeSecretConfig(getLayer2ConfigPath(), obj),
+} = {}) {
+  if (!ticket) return { code: 2, msg: "set-anchor requires <ticket>" };
+  writeLayer2({ catalyst: { cluster: { livenessAnchorIssue: ticket } } });
+  return { code: 0, restartRequired: true };
+}
+
+export function runSetAnchor(argv = []) {
+  const ticket = argv.filter((a) => !a.startsWith("-"))[0];
+  const res = setAnchor(ticket);
+  if (res.code !== 0) {
+    process.stderr.write(`catalyst cluster set-anchor: ${res.msg}\n`);
+    return res.code;
+  }
+  process.stdout.write(`catalyst.cluster.livenessAnchorIssue → '${ticket}'. Run 'catalyst-stack restart' to activate.\n`);
+  return 0;
+}
+
+// ── tune — write a live executionCore concurrency param to Layer-2 ─────────
+
+const TUNE_PARAMS = new Set(["maxParallel", "minParallel", "maxParallelCeiling"]);
+
+export function tune(param, value, {
+  writeLayer2 = (obj) => writeSecretConfig(getLayer2ConfigPath(), obj),
+} = {}) {
+  if (!TUNE_PARAMS.has(param)) {
+    return { code: 2, msg: `unknown tune param '${param}' (one of ${[...TUNE_PARAMS].join(", ")})` };
+  }
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    return { code: 2, msg: `tune ${param} requires a positive integer` };
+  }
+  writeLayer2({ catalyst: { orchestration: { executionCore: { [param]: n } } } });
+  return { code: 0, param, value: n };
+}
+
+export function runTune(argv = []) {
+  const [param, value] = argv.filter((a) => !a.startsWith("-"));
+  const res = tune(param, value);
+  if (res.code !== 0) {
+    process.stderr.write(`catalyst cluster tune: ${res.msg}\n`);
+    return res.code;
+  }
+  process.stdout.write(`catalyst.orchestration.executionCore.${res.param} → ${res.value}\n`);
+  process.stdout.write("Takes effect live (next scheduler tick — no restart required).\n");
+  return 0;
+}
+
+// ── main — dispatch ───────────────────────────────────────────────────────
+
+export function main(argv = process.argv.slice(2)) {
+  const [verb, ...rest] = argv;
+  let code;
+  switch (verb) {
+    case "status":    code = runStatus(rest); break;
+    case "add":       code = runAdd(rest); break;
+    case "remove":    code = runRemove(rest); break;
+    case "rename":    code = runRename(rest); break;
+    case "set-anchor": code = runSetAnchor(rest); break;
+    case "tune":      code = runTune(rest); break;
+    default:
+      process.stderr.write(`catalyst cluster: unknown verb '${verb ?? ""}'\n`);
+      code = 2;
+  }
+  process.exitCode = code ?? 0;
+}
+
+const isEntry =
+  import.meta.main === true ||
+  (typeof import.meta.url === "string" && fileURLToPath(import.meta.url) === process.argv[1]);
+if (isEntry) main();

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -145,7 +145,7 @@ export function getEventLogPath() {
 // Layer-2 (machine-local) config path. Mirrors daemon.mjs main()'s resolution:
 // CATALYST_LAYER2_CONFIG_FILE || ~/.config/catalyst/config.json. Each host's
 // Layer-2 file differs, so this is the right home for a per-host name.
-function getLayer2ConfigPath() {
+export function getLayer2ConfigPath() {
   return (
     process.env.CATALYST_LAYER2_CONFIG_FILE ||
     resolve(homedir(), ".config", "catalyst", "config.json")
@@ -201,6 +201,14 @@ export function getClusterHosts() {
     /* absent/malformed roster → single-host default */
   }
   return [getHostName()];
+}
+
+// getCatalystRepoDirHostsPath — absolute path to the committed cluster roster.
+// Exported so cli/cluster.mjs and its unit tests share one source of truth
+// (avoids drift between the writer and the reader that live in different files).
+// Redirectable via CATALYST_CONFIG_FILE (same as getCatalystRepoDir).
+export function getCatalystRepoDirHostsPath() {
+  return resolve(getCatalystRepoDir(), "hosts.json");
 }
 
 // CTL-1057: a multi-host roster that does NOT include this host means every


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-16T12:57:00Z -->
<!-- Last updated: 2026-06-16T12:57:00Z -->
<!-- PR: #2116 -->
<!-- Previous commits: 12ab51df8315e2291e1b8c6cf98e569a75589277 -->

## Summary

Adds seven cluster-administration verbs to `catalyst cluster`: `status`, `add`, `remove`, `rename`, `set-anchor`, `drain`, and `tune`. Previously these operations required hand-edits to `.catalyst/hosts.json` and Layer-2 config, which silently misbehaved on typos; the new CLI validates `host.name ∈ roster` on every write and encodes the correct live-vs-restart semantics per verb.

Implementation follows the `cli/drain.mjs` shape: a new `cli/cluster.mjs` module with pure, dependency-injectable functions (unit-testable without a live cluster), a `main()` dispatcher, and the existing bash front-end routing each verb. Two shared path-helper exports (`getCatalystRepoDirHostsPath`, `getLayer2ConfigPath`) are added to `config.mjs` so the module and its tests share one source of truth.

53 tests total: 26 new unit tests (`cli-cluster.test.mjs`) + 27 regression (`cluster-heartbeat-sync.test.mjs`, `drain-event.test.mjs`) + 16 bash CLI tests (`catalyst-cluster-cli.test.sh`).

## Changes Made

### New module: `execution-core/cli/cluster.mjs` (+289 lines)

- `buildStatus(deps)` — merges the static roster with live heartbeat data; returns `{roster, self, hosts[], draining}` with per-host `{name, self, live, inFlight, lastSeen}` fields
- `addHost(name, deps)` — reads live heartbeats to refuse a name already publishing; atomically appends to `hosts.json`; optionally auto-commits via `gitCommitRoster`
- `removeHost(name, deps)` — guards self-remove while in-flight tickets exist; atomically removes from roster
- `renameHost(newName, deps)` — updates `catalyst.host.name` in Layer-2 + matching roster entry; prints restart prompt (HRW identity captured at startup)
- `setAnchor(ticket, deps)` — writes `livenessAnchorIssue` to Layer-2; prints restart prompt (publisher binds anchor at arm time)
- `tune(param, value, deps)` — writes `maxParallel`/`minParallel`/`maxParallelCeiling` to Layer-2 live (re-read per tick); validates param name
- All write paths use atomic roster mutation (`readRoster` → mutate → `writeRoster`) and fail with distinct exit codes: 0 success, 2 user-error (unknown verb, invalid arg), 1 unexpected failure

### New test: `execution-core/cli-cluster.test.mjs` (+315 lines)

26 unit tests covering all verbs including validation and idempotency paths via injectable deps (no real filesystem or live cluster required).

### Modified: `scripts/catalyst-cluster` (+34/-3)

- Added `CLI_MJS` and `EXEC_CORE` bindings
- Expanded usage block documenting all seven verbs with `[live]`/`[restart]` tags
- `case` dispatch: `status|add|remove|rename|set-anchor|tune` → `exec $JS_RUN $CLI_MJS "$@"`; `drain` → guards non-flag host arg (T13) then delegates to `catalyst-execution-core drain`

### Modified: `execution-core/config.mjs` (+9/-1)

- Exported `getCatalystRepoDirHostsPath()` and `getLayer2ConfigPath()` as shared path helpers (previously inline in callers)

### Modified: `__tests__/catalyst-cluster-cli.test.sh` (+31/-0)

- +9 new bash assertions: verb listing (`--help` shows all seven), `status --json` smoke (returns `"hosts"` field), `drain` T13 guard (rejects host argument with non-zero exit + T13 pointer)
- Total: 16 pass

## How to Verify It

- [x] `cd plugins/dev/scripts/execution-core && bun test cli-cluster.test.mjs` — 26 pass
- [x] `bash plugins/dev/scripts/__tests__/catalyst-cluster-cli.test.sh` — 16 pass
- [x] Regression: `bun test cluster-heartbeat-sync.test.mjs drain-event.test.mjs` — 27 pass
- [x] CI: all checks pass (audit-references, check-versions, docs-gate, execution-core-unit-tests, validate)
- [ ] Manual smoke: `catalyst cluster status` on single-host install

## Changelog Entry

```
feat(dev): CTL-1188 — catalyst cluster CLI (status/add/remove/rename/set-anchor/drain/tune)

Adds seven cluster-admin verbs to `catalyst cluster` via new cli/cluster.mjs
(DI-injectable pure functions, drain.mjs shape). Exports getCatalystRepoDirHostsPath
and getLayer2ConfigPath from config.mjs. 53 tests: 26 unit + 27 regression + 16 bash.
```

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1188

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-623
skip CTL-633
