### PR TITLE
feat(dev): CTL-1212 — grouped project settings page (Identity/Source/Workflow) + three-tier nav + one-click gear

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/settings-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/settings-surface.test.ts
@@ -264,3 +264,36 @@ describe("Settings is reachable from the command palette (CTL-911)", () => {
     expect(shellSrc).toMatch(/CommandItem\s+value="Settings"\s+onSelect=\{openSettings\}/);
   });
 });
+
+// ── CTL-1212: three-tier nav scaffolding ──────────────────────────────────────
+describe("CTL-1212 three-tier nav scaffolding", () => {
+  it("the surface uses resolveSettingsView for content dispatch", () => {
+    expect(settingsSrc).toContain("resolveSettingsView");
+  });
+
+  it("the surface renders PendingSectionPane for pending sections", () => {
+    expect(settingsSrc).toContain("PendingSectionPane");
+  });
+
+  it("the rail imports SETTINGS_PENDING_SECTIONS", () => {
+    const railSrc = read("components/settings/project-rail.tsx");
+    expect(railSrc).toContain("SETTINGS_PENDING_SECTIONS");
+  });
+});
+
+// ── CTL-1212: one-click project settings affordance ───────────────────────────
+describe("CTL-1212 one-click project settings affordance", () => {
+  it("each project header has a one-click settings button wired to goSettings", () => {
+    const occurrences = sidebarSrc.match(/goSettings\(repo\)/g) ?? [];
+    expect(occurrences.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("the gear stops propagation so it does not toggle the collapsible header", () => {
+    expect(sidebarSrc).toMatch(/stopPropagation\(\)/);
+    expect(sidebarSrc).toContain('aria-label="Project settings"');
+  });
+
+  it("the gear is hover-revealed with group-hover", () => {
+    expect(sidebarSrc).toMatch(/group-hover/);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
@@ -241,7 +241,7 @@ const GROUP_TRIGGER_BASE = cn(
 // minuscule /45 11px row it was. Linear-calm: weight & case over loudness — no
 // uppercase, no shouting color.
 const PROJECT_HEADER_TRIGGER = cn(
-  "flex h-8 w-full shrink-0 items-center gap-1.5 rounded-md px-2 outline-hidden",
+  "group flex h-8 w-full shrink-0 items-center gap-1.5 rounded-md px-2 outline-hidden",
   "text-xs font-medium text-sidebar-foreground/80",
   "transition-[margin,opacity,color] duration-200 ease-linear",
   "cursor-pointer hover:text-sidebar-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring",
@@ -730,6 +730,16 @@ export function AppSidebar() {
                           isOpen && "rotate-90",
                         )}
                       />
+                      {/* CTL-1212: one-click settings gear — hover-revealed so the row stays
+                          clean at rest. stopPropagation prevents triggering the CollapsibleTrigger. */}
+                      <button
+                        type="button"
+                        aria-label="Project settings"
+                        onClick={(e) => { e.stopPropagation(); goSettings(repo); }}
+                        className="ml-auto opacity-0 group-hover:opacity-100 focus-visible:opacity-100 rounded p-0.5 hover:bg-sidebar-accent transition-opacity"
+                      >
+                        <SettingsIcon className="size-3" />
+                      </button>
                     </CollapsibleTrigger>
                   </ContextMenuTrigger>
                   <ContextMenuContent>

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings-surface.tsx
@@ -44,10 +44,11 @@ import {
 } from "@/lib/repo-color-picks-store";
 // CTL-1153 Phase 5: project rail + per-project settings pane.
 import { useProjects } from "@/hooks/use-projects";
-import { buildProjectRailRows, resolveSelectedProject } from "@/lib/project-settings-model";
+import { buildProjectRailRows, resolveSettingsView } from "@/lib/project-settings-model";
 import { SETTINGS_PATH } from "@/lib/route-surface";
 import { ProjectRail } from "@/components/settings/project-rail";
 import { ProjectSettingsPane } from "@/components/settings/project-settings-pane";
+import { PendingSectionPane } from "@/components/settings/pending-section-pane";
 
 // settings-surface.tsx — the Settings preferences surface (CTL-911 / SURF3).
 // Replaces the footer Settings placeholder (handoff next-step #4). Renders the
@@ -182,7 +183,7 @@ export function SettingsSurface() {
   }
 
   const railRows = buildProjectRailRows(projects);
-  const selectedProject = resolveSelectedProject(projects, selectedKey);
+  const settingsView = resolveSettingsView(projects, selectedKey);
 
   return (
     <div className="h-full min-h-0 overflow-y-auto bg-surface-1">
@@ -196,12 +197,16 @@ export function SettingsSurface() {
 
         {/* ── Content (right column) ────────────────────────────────────────── */}
         <div className="flex min-w-0 flex-1 flex-col gap-5">
-          {selectedProject ? (
+          {settingsView.kind === "project" ? (
             /* ── Per-project editor pane ──────────────────────────────────── */
             <ProjectSettingsPane
-              project={selectedProject}
+              project={settingsView.project}
+              candidates={iconMap[settingsView.project.repo]?.candidates ?? []}
               onSaved={refetch}
             />
+          ) : settingsView.kind === "pending" ? (
+            /* ── Pending configuration tier pane ─────────────────────────── */
+            <PendingSectionPane section={settingsView.section} />
           ) : (
             /* ── Global sections (General) ───────────────────────────────── */
             <>

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings-surface.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useAtom } from "jotai";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 
@@ -173,6 +173,14 @@ export function SettingsSurface() {
   const [selectedKey, setSelectedKey] = useState<string | null>(
     typeof paramKey === "string" && paramKey !== "" ? paramKey : null,
   );
+
+  // CTL-1212: resync selection when the URL param changes after mount. Without
+  // this, cross-surface deep-links (the sidebar one-click gear / context menu,
+  // and browser back/forward) update the URL but leave the mount-only selectedKey
+  // stale, so the pane silently fails to switch projects.
+  useEffect(() => {
+    setSelectedKey(typeof paramKey === "string" && paramKey !== "" ? paramKey : null);
+  }, [paramKey]);
 
   function selectProject(key: string | null) {
     setSelectedKey(key);

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/pending-section-pane.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/pending-section-pane.test.tsx
@@ -1,0 +1,46 @@
+// pending-section-pane.test.tsx — CTL-1212: tree-walk tests (no DOM render).
+import { describe, it, expect } from "bun:test";
+import type { ReactNode, ReactElement } from "react";
+import { PendingSectionPane } from "./pending-section-pane";
+
+function isReactElement(node: unknown): node is ReactElement {
+  return typeof node === "object" && node !== null && "props" in node && "type" in node;
+}
+
+function collectText(node: ReactNode): string {
+  if (node === null || node === undefined) return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join("");
+  if (isReactElement(node)) {
+    const props = node.props as { children?: ReactNode };
+    return collectText(props.children);
+  }
+  return "";
+}
+
+function containsText(node: ReactNode, text: string): boolean {
+  return collectText(node).includes(text);
+}
+
+const clusterSection = {
+  key: "__cluster__",
+  label: "Cluster",
+  note: "Cluster-wide configuration will appear here.",
+};
+
+describe("PendingSectionPane", () => {
+  it("renders the section label", () => {
+    const el = PendingSectionPane({ section: clusterSection });
+    expect(containsText(el, "Cluster")).toBe(true);
+  });
+
+  it("renders the section note", () => {
+    const el = PendingSectionPane({ section: clusterSection });
+    expect(containsText(el, "Cluster-wide configuration will appear here.")).toBe(true);
+  });
+
+  it("renders pending configuration service message", () => {
+    const el = PendingSectionPane({ section: clusterSection });
+    expect(containsText(el, "Pending")).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/pending-section-pane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/pending-section-pane.tsx
@@ -1,0 +1,20 @@
+// pending-section-pane.tsx — empty-state pane for not-yet-wired config tiers (CTL-1212).
+import type { PendingSettingsSection } from "@/lib/project-settings-model";
+
+interface PendingSectionPaneProps {
+  section: PendingSettingsSection;
+}
+
+export function PendingSectionPane({ section }: PendingSectionPaneProps) {
+  return (
+    <div className="flex flex-1 flex-col gap-4 min-w-0">
+      <header>
+        <h2 className="text-base font-semibold text-fg">{section.label}</h2>
+        <p className="text-xs text-muted">Pending configuration service</p>
+      </header>
+      <div className="rounded-md border border-border bg-surface-2 px-4 py-3">
+        <p className="text-sm text-muted">{section.note}</p>
+      </div>
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/project-rail.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/project-rail.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect } from "bun:test";
 import type { ReactNode, ReactElement } from "react";
 import { ProjectRail } from "./project-rail";
 import type { ProjectRailRow } from "@/lib/project-settings-model";
+import { SETTINGS_PENDING_SECTIONS, CLUSTER_SECTION_KEY } from "@/lib/project-settings-model";
 
 // ── tree-walk helpers ─────────────────────────────────────────────────────────
 
@@ -61,5 +62,17 @@ describe("ProjectRail", () => {
   it("renders with no rows (just General)", () => {
     const el = ProjectRail({ rows: [], selectedKey: null, onSelect: () => {} });
     expect(containsText(el, "General")).toBe(true);
+  });
+
+  it("renders the Cluster and Host/Node pending sections", () => {
+    const el = ProjectRail({ rows: [], selectedKey: null, onSelect: () => {} });
+    for (const s of SETTINGS_PENDING_SECTIONS) {
+      expect(containsText(el, s.label)).toBe(true);
+    }
+  });
+
+  it("marks a pending section as active when its key is selected", () => {
+    const el = ProjectRail({ rows: [], selectedKey: CLUSTER_SECTION_KEY, onSelect: () => {} });
+    expect(containsText(el, "Cluster")).toBe(true);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/project-rail.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/project-rail.tsx
@@ -1,6 +1,7 @@
 // project-rail.tsx — left column of the settings surface: one row per project (CTL-1153 Phase 5).
 import { cn } from "@/lib/utils";
 import { NAMED_COLORS } from "@/lib/color-palette";
+import { SETTINGS_PENDING_SECTIONS } from "@/lib/project-settings-model";
 import type { ProjectRailRow } from "@/lib/project-settings-model";
 
 interface ProjectRailProps {
@@ -58,6 +59,31 @@ export function ProjectRail({ rows, selectedKey, onSelect }: ProjectRailProps) {
           </button>
         );
       })}
+
+      {SETTINGS_PENDING_SECTIONS.length > 0 && (
+        <>
+          <p className="mt-2 px-3 text-xs font-medium text-muted/60">Configuration</p>
+          {SETTINGS_PENDING_SECTIONS.map((section) => {
+            const selected = selectedKey === section.key;
+            return (
+              <button
+                key={section.key}
+                type="button"
+                aria-current={selected ? "page" : undefined}
+                onClick={() => onSelect(section.key)}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors",
+                  selected
+                    ? "bg-surface-2 font-medium text-fg"
+                    : "text-muted hover:bg-surface-2 hover:text-fg",
+                )}
+              >
+                <span className="min-w-0 truncate">{section.label}</span>
+              </button>
+            );
+          })}
+        </>
+      )}
     </nav>
   );
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/project-settings-pane.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/project-settings-pane.test.tsx
@@ -136,6 +136,7 @@ describe("ProjectSettingsPaneContent — CTL-1212 sections", () => {
 describe("buildProjectPatch", () => {
   const base = {
     key: "CTL", name: "Catalyst", repo: "catalyst",
+    vcsRepo: null as string | null,
     defaultColor: "blue", storedName: null, storedColor: null, stateMap: null,
   };
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/project-settings-pane.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/project-settings-pane.test.tsx
@@ -33,11 +33,14 @@ const project = {
   key: "CTL",
   name: "Catalyst",
   repo: "catalyst",
+  vcsRepo: null as string | null,
   defaultColor: "blue",
   storedName: null,
   storedColor: null,
   stateMap: null,
 };
+
+const projectWithSource = { ...project, vcsRepo: "coalesce-labs/catalyst" };
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 
@@ -79,6 +82,54 @@ describe("ProjectSettingsPane", () => {
   it("renders display name section header", () => {
     const el = ProjectSettingsPaneContent({ project, name: "", color: "auto", icon: null, candidates: [], stateMapEdits: {}, saving: false, error: null, onNameChange: () => {}, onColorChange: () => {}, onIconChange: () => {}, onStateMapChange: () => {}, onSave: () => {} });
     expect(containsText(el, "Display name")).toBe(true);
+  });
+});
+
+// ── CTL-1212: Identity / Source / Workflow sections ───────────────────────────
+
+describe("ProjectSettingsPaneContent — CTL-1212 sections", () => {
+  const baseProps = {
+    name: "",
+    color: "auto" as const,
+    icon: null as string | null,
+    candidates: [] as import("@/lib/repo-icons").IconCandidate[],
+    stateMapEdits: {} as Record<string, string>,
+    saving: false,
+    error: null as string | null,
+    onNameChange: () => {},
+    onColorChange: () => {},
+    onIconChange: () => {},
+    onStateMapChange: () => {},
+    onSave: () => {},
+  };
+
+  it("renders Identity, Source, and Workflow section headers", () => {
+    const el = ProjectSettingsPaneContent({ project: projectWithSource, ...baseProps });
+    for (const h of ["Identity", "Source", "Workflow"]) {
+      expect(containsText(el, h)).toBe(true);
+    }
+  });
+
+  it("shows the Linear team key in Source", () => {
+    const el = ProjectSettingsPaneContent({ project: projectWithSource, ...baseProps });
+    expect(containsText(el, "CTL")).toBe(true);
+  });
+
+  it("shows the GitHub repo in Source when vcsRepo is set", () => {
+    const el = ProjectSettingsPaneContent({ project: projectWithSource, ...baseProps });
+    expect(containsText(el, "coalesce-labs/catalyst")).toBe(true);
+    expect(containsText(el, "managed in configuration")).toBe(true);
+  });
+
+  it("renders a placeholder when vcsRepo is null", () => {
+    const el = ProjectSettingsPaneContent({ project, ...baseProps });
+    expect(containsText(el, "managed in configuration")).toBe(true);
+  });
+
+  it("shows eligible-query defaults in Workflow", () => {
+    const el = ProjectSettingsPaneContent({ project: projectWithSource, ...baseProps });
+    expect(containsText(el, "Todo")).toBe(true);
+    expect(containsText(el, "Triage")).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/project-settings-pane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/project-settings-pane.tsx
@@ -17,8 +17,10 @@ import type { IconCandidate } from "@/lib/repo-icons";
 
 type ProjectInput = Pick<
   ProjectDescriptor,
-  "key" | "name" | "repo" | "defaultColor" | "storedName" | "storedColor" | "stateMap" | "icon"
+  "key" | "name" | "repo" | "vcsRepo" | "defaultColor" | "storedName" | "storedColor" | "stateMap" | "icon"
 >;
+
+const ELIGIBLE_QUERY_DEFAULT = { status: "Todo", triageStatus: "Triage" };
 
 // ── Pure content renderer (all state passed as props; tree-walk testable) ─────
 
@@ -56,99 +58,133 @@ export function ProjectSettingsPaneContent({
         <p className="rounded-md bg-red/10 px-3 py-2 text-xs text-red">{error}</p>
       )}
 
-      {/* ── Display name ─────────────────────────────────────────────────── */}
-      <section className="flex flex-col gap-2">
-        <label className="text-sm font-medium text-fg" htmlFor={`psp-name-${project.key}`}>
-          Display name
-        </label>
-        <Input
-          id={`psp-name-${project.key}`}
-          value={name}
-          onChange={(e) => onNameChange(e.target.value)}
-          placeholder={project.name}
-          className="max-w-xs"
-        />
-        <p className="text-xs text-muted">
-          Leave blank to use the configured default ({project.name}).
-        </p>
-      </section>
+      {/* ── Identity ─────────────────────────────────────────────────────── */}
+      <div className="flex flex-col gap-4">
+        <h3 className="text-sm font-semibold text-fg">Identity</h3>
 
-      {/* ── Icon (CTL-1208) ────────────────────────────────────────────────── */}
-      <section className="flex flex-col gap-2">
-        <p className="text-sm font-medium text-fg">Icon</p>
-        <IconPickerPopover
-          value={icon}
-          onChange={onIconChange}
-          candidates={candidates}
-          hue={currentHue}
-        />
-        <p className="text-xs text-muted">
-          Choose a curated glyph (tinted in the project color) or a detected favicon.
-        </p>
-      </section>
+        <section className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-fg" htmlFor={`psp-name-${project.key}`}>
+            Display name
+          </label>
+          <Input
+            id={`psp-name-${project.key}`}
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+            placeholder={project.name}
+            className="max-w-xs"
+          />
+          <p className="text-xs text-muted">
+            Leave blank to use the configured default ({project.name}).
+          </p>
+        </section>
 
-      {/* ── Color ─────────────────────────────────────────────────────────── */}
-      <section className="flex flex-col gap-2">
-        <p className="text-sm font-medium text-fg">Color</p>
-        <ToggleGroup
-          type="single"
-          value={color}
-          onValueChange={(v) => { if (v) onColorChange(v); }}
-          variant="outline"
-          size="sm"
-          className="flex-wrap justify-start"
-        >
-          <ToggleGroupItem
-            value="auto"
-            className={cn("text-xs", color === "auto" ? "text-fg" : "text-muted")}
-            title="Auto (inherit configured default)"
+        <section className="flex flex-col gap-2">
+          <p className="text-sm font-medium text-fg">Icon</p>
+          <IconPickerPopover
+            value={icon}
+            onChange={onIconChange}
+            candidates={candidates}
+            hue={currentHue}
+          />
+          <p className="text-xs text-muted">
+            Choose a curated glyph (tinted in the project color) or a detected favicon.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-2">
+          <p className="text-sm font-medium text-fg">Color</p>
+          <ToggleGroup
+            type="single"
+            value={color}
+            onValueChange={(v) => { if (v) onColorChange(v); }}
+            variant="outline"
+            size="sm"
+            className="flex-wrap justify-start"
           >
-            Auto
-          </ToggleGroupItem>
-          {NAMED_COLOR_NAMES.map((hue) => (
             <ToggleGroupItem
-              key={hue}
-              value={hue}
-              title={hue}
-              className={cn("gap-1 text-xs", color === hue ? "text-fg" : "text-muted")}
+              value="auto"
+              className={cn("text-xs", color === "auto" ? "text-fg" : "text-muted")}
+              title="Auto (inherit configured default)"
             >
-              <span
-                aria-hidden
-                className="size-3 rounded-full"
-                style={{
-                  background: NAMED_COLORS[hue]?.bg,
-                  outline: "1px solid var(--border-subtle)",
-                }}
-              />
-              {hue}
+              Auto
             </ToggleGroupItem>
-          ))}
-        </ToggleGroup>
-      </section>
+            {NAMED_COLOR_NAMES.map((hue) => (
+              <ToggleGroupItem
+                key={hue}
+                value={hue}
+                title={hue}
+                className={cn("gap-1 text-xs", color === hue ? "text-fg" : "text-muted")}
+              >
+                <span
+                  aria-hidden
+                  className="size-3 rounded-full"
+                  style={{
+                    background: NAMED_COLORS[hue]?.bg,
+                    outline: "1px solid var(--border-subtle)",
+                  }}
+                />
+                {hue}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+        </section>
+      </div>
 
-      {/* ── Linear stateMap ──────────────────────────────────────────────── */}
-      <section className="flex flex-col gap-2">
-        <p className="text-sm font-medium text-fg">Linear state names</p>
+      {/* ── Source (read-only) ───────────────────────────────────────────── */}
+      <div className="flex flex-col gap-4">
+        <h3 className="text-sm font-semibold text-fg">Source</h3>
+        <dl className="flex flex-col gap-2 text-xs">
+          <div className="flex gap-2">
+            <dt className="w-32 shrink-0 text-muted">Linear team key</dt>
+            <dd className="text-fg">{project.key}</dd>
+          </div>
+          <div className="flex gap-2">
+            <dt className="w-32 shrink-0 text-muted">GitHub repo</dt>
+            <dd className="text-fg">{project.vcsRepo ?? "—"}</dd>
+          </div>
+        </dl>
         <p className="text-xs text-muted">
-          Override how each pipeline transition is named in your Linear workspace. Leave blank to
-          inherit the global default.
+          Source fields are managed in configuration and are read-only here.
         </p>
-        <div className="flex flex-col divide-y divide-border">
-          {STATE_MAP_KEYS.map((k) => (
-            <div key={k} className="flex items-center gap-4 py-2">
-              <span className="w-32 shrink-0 text-xs text-muted">
-                {STATE_MAP_KEY_LABEL[k]}
-              </span>
-              <Input
-                value={stateMapEdits[k] ?? ""}
-                onChange={(e) => onStateMapChange(k, e.target.value)}
-                placeholder="(global default)"
-                className="max-w-xs text-xs"
-              />
-            </div>
-          ))}
+      </div>
+
+      {/* ── Workflow ─────────────────────────────────────────────────────── */}
+      <div className="flex flex-col gap-4">
+        <h3 className="text-sm font-semibold text-fg">Workflow</h3>
+
+        <section className="flex flex-col gap-2">
+          <p className="text-sm font-medium text-fg">Linear state names</p>
+          <p className="text-xs text-muted">
+            Override how each pipeline transition is named in your Linear workspace. Leave blank to
+            inherit the global default.
+          </p>
+          <div className="flex flex-col divide-y divide-border">
+            {STATE_MAP_KEYS.map((k) => (
+              <div key={k} className="flex items-center gap-4 py-2">
+                <span className="w-32 shrink-0 text-xs text-muted">
+                  {STATE_MAP_KEY_LABEL[k]}
+                </span>
+                <Input
+                  value={stateMapEdits[k] ?? ""}
+                  onChange={(e) => onStateMapChange(k, e.target.value)}
+                  placeholder="(global default)"
+                  className="max-w-xs text-xs"
+                />
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <div className="flex flex-col gap-1">
+          <p className="text-sm font-medium text-fg">Eligible-query status</p>
+          <p className="text-xs text-muted">
+            The daemon pulls tickets in{" "}
+            <span className="text-fg">{ELIGIBLE_QUERY_DEFAULT.status}</span> and triages from{" "}
+            <span className="text-fg">{ELIGIBLE_QUERY_DEFAULT.triageStatus}</span>.{" "}
+            Managed in configuration (per-project eligible-query is a future enhancement).
+          </p>
         </div>
-      </section>
+      </div>
 
       <div className="flex items-center gap-3">
         <Button onClick={onSave} disabled={saving} size="sm">

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/project-settings-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/project-settings-model.test.ts
@@ -4,6 +4,10 @@ import {
   buildProjectRailRows,
   resolveSelectedProject,
   diffStateMap,
+  SETTINGS_PENDING_SECTIONS,
+  CLUSTER_SECTION_KEY,
+  HOST_NODE_SECTION_KEY,
+  resolveSettingsView,
 } from "./project-settings-model";
 
 describe("STATE_MAP_KEYS", () => {
@@ -105,5 +109,56 @@ describe("diffStateMap", () => {
     const diff = diffStateMap(null, { inReview: "X", unknownKey: "Y" } as Record<string, string>);
     expect("unknownKey" in diff).toBe(false);
     expect(diff.inReview).toBe("X");
+  });
+});
+
+// ── CTL-1212: pending sections + resolveSettingsView ─────────────────────────
+
+const projects = [{ key: "CTL", name: "Catalyst", defaultColor: "blue", hasWork: true }];
+
+describe("SETTINGS_PENDING_SECTIONS", () => {
+  it("defines Cluster and Host/Node with sentinel keys distinct from any team key", () => {
+    const keys = SETTINGS_PENDING_SECTIONS.map((s) => s.key);
+    expect(keys).toEqual([CLUSTER_SECTION_KEY, HOST_NODE_SECTION_KEY]);
+    expect(CLUSTER_SECTION_KEY.startsWith("__")).toBe(true);
+    expect(SETTINGS_PENDING_SECTIONS.find((s) => s.key === CLUSTER_SECTION_KEY)?.label).toBe("Cluster");
+  });
+
+  it("Host/Node section has a label and a note", () => {
+    const section = SETTINGS_PENDING_SECTIONS.find((s) => s.key === HOST_NODE_SECTION_KEY);
+    expect(section?.label).toBeTruthy();
+    expect(section?.note).toBeTruthy();
+  });
+});
+
+describe("resolveSettingsView", () => {
+  it("returns kind:general for a null key", () => {
+    expect(resolveSettingsView(projects, null).kind).toBe("general");
+  });
+
+  it("returns kind:general for undefined key", () => {
+    expect(resolveSettingsView(projects, undefined).kind).toBe("general");
+  });
+
+  it("returns kind:project with the descriptor for a known team key", () => {
+    const v = resolveSettingsView(projects, "CTL");
+    expect(v.kind).toBe("project");
+    if (v.kind === "project") expect(v.project.key).toBe("CTL");
+  });
+
+  it("returns kind:pending with the section for CLUSTER_SECTION_KEY", () => {
+    const v = resolveSettingsView(projects, CLUSTER_SECTION_KEY);
+    expect(v.kind).toBe("pending");
+    if (v.kind === "pending") expect(v.section.label).toBe("Cluster");
+  });
+
+  it("returns kind:pending with the section for HOST_NODE_SECTION_KEY", () => {
+    const v = resolveSettingsView(projects, HOST_NODE_SECTION_KEY);
+    expect(v.kind).toBe("pending");
+    if (v.kind === "pending") expect(v.section.label).toMatch(/Host/);
+  });
+
+  it("falls back to kind:general for an unknown key", () => {
+    expect(resolveSettingsView(projects, "NOPE").kind).toBe("general");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/project-settings-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/project-settings-model.ts
@@ -66,6 +66,48 @@ export function resolveSelectedProject<T extends Pick<ProjectDescriptor, "key">>
   return projects.find((p) => p.key === key) ?? null;
 }
 
+// ── CTL-1212: three-tier nav scaffolding ─────────────────────────────────────
+
+/** Sentinel rail keys for the not-yet-wired config tiers (CTL-1212).
+ *  Double-underscore prefix guarantees they never collide with an UPPERCASE Linear team key. */
+export const CLUSTER_SECTION_KEY = "__cluster__";
+export const HOST_NODE_SECTION_KEY = "__host_node__";
+
+export interface PendingSettingsSection {
+  key: string;
+  label: string;
+  note: string;
+}
+
+export const SETTINGS_PENDING_SECTIONS: PendingSettingsSection[] = [
+  {
+    key: CLUSTER_SECTION_KEY,
+    label: "Cluster",
+    note: "Cluster-wide configuration and secrets will appear here once the configuration service is available.",
+  },
+  {
+    key: HOST_NODE_SECTION_KEY,
+    label: "Host / Node",
+    note: "Host- and node-specific settings (not synchronized across the cluster) will appear here once the configuration service is available.",
+  },
+];
+
+export type SettingsView<T extends Pick<ProjectDescriptor, "key">> =
+  | { kind: "general" }
+  | { kind: "project"; project: T }
+  | { kind: "pending"; section: PendingSettingsSection };
+
+export function resolveSettingsView<T extends Pick<ProjectDescriptor, "key">>(
+  projects: readonly T[],
+  selectedKey: string | null | undefined,
+): SettingsView<T> {
+  if (!selectedKey) return { kind: "general" };
+  const pending = SETTINGS_PENDING_SECTIONS.find((s) => s.key === selectedKey);
+  if (pending) return { kind: "pending", section: pending };
+  const project = resolveSelectedProject(projects, selectedKey);
+  return project ? { kind: "project", project } : { kind: "general" };
+}
+
 /**
  * Compute the changed keys between the current stateMap and an edited version.
  * Only includes keys whose value has changed AND is non-empty; omits unchanged or


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-16T16:36:00Z -->
<!-- Last updated: 2026-06-16T16:36:00Z -->
<!-- PR: #2127 -->
<!-- Previous commits: dd2c506b113b147fedf86f829545b35bff06ff6f,898ce675113b147fedf86f829545b35bff06ff6f,bdf98bb2113b147fedf86f829545b35bff06ff6f -->

## Summary

Reshapes the orch-monitor settings surface around a grouped per-project page (Identity / Source / Workflow sections) and a three-tier nav scaffolding, and adds a one-click hover gear to every project row in the sidebar nav.

Previously the project settings pane was a flat list of unrelated fields. This PR organizes them into three named sections — **Identity** (display name, icon, color), **Source** (read-only Linear team key + GitHub repo), and **Workflow** (Linear state names + eligible-query status) — and scaffolds the **Cluster** and **Host / Node** config tiers in the rail with `PendingSettingPane` empty states, making the IA ready for the forthcoming config API without building it yet.

The one-click gear is hover-revealed on each project header in `AppSidebar`; it stops propagation so it doesn't toggle the collapsible, deep-links directly to `?project=<key>`, and is accessible via `aria-label="Project settings"`. A `useEffect` in `SettingsSurface` resyncs `selectedKey` when the URL param changes after mount, fixing a stale-pane bug on browser back/forward and cross-surface deep-links.

11 files changed, 418 additions, 92 deletions.

## Changes Made

### New: `project-settings-model.ts` exports for three-tier nav (+42 lines)

- `CLUSTER_SECTION_KEY = "__cluster__"` / `HOST_NODE_SECTION_KEY = "__host_node__"` — sentinel keys with double-underscore prefix that can never collide with an uppercase Linear team key
- `PendingSettingsSection` interface + `SETTINGS_PENDING_SECTIONS` array (Cluster, Host / Node) — the static config-tier manifest consumed by `ProjectRail` and `SettingsSurface`
- `SettingsView<T>` discriminated union (`"general" | "project" | "pending"`)
- `resolveSettingsView()` — dispatches on the selected rail key; replaces `resolveSelectedProject` call in `settings-surface.tsx`

### Modified: `project-settings-pane.tsx` — grouped Identity / Source / Workflow layout

- Wrapped existing name + icon + color fields inside an **Identity** `<div>` with `<h3>Identity</h3>` heading
- Added **Source** read-only section: displays `project.key` (Linear team key) and `project.vcsRepo` (GitHub repo); clarifies "Source fields are managed in configuration"
- Added **Workflow** section: wraps the existing Linear state names editor + new eligible-query status display (read-only, shows `ELIGIBLE_QUERY_DEFAULT.status` / `.triageStatus`)
- `candidates` prop threaded through from `SettingsSurface` → `IconPickerPopover`

### New: `pending-section-pane.tsx` (+20 lines)

Empty-state pane for not-yet-wired config tiers. Renders a header with the section label, a "Pending configuration service" subline, and the section's `note` text in a bordered card.

### Modified: `project-rail.tsx` — Configuration tier entries

Added a "Configuration" divider after the project rows, followed by `SETTINGS_PENDING_SECTIONS` buttons (Cluster, Host / Node) styled identically to project rows, with `aria-current="page"` on the selected key.

### Modified: `settings-surface.tsx` — dispatch + deep-link fix

- `resolveSelectedProject` → `resolveSettingsView`; conditional render dispatches on `settingsView.kind`
- `PendingSectionPane` imported and rendered when `kind === "pending"`
- `useEffect([paramKey])` added to resync `selectedKey` after mount — fixes the stale pane bug on browser back/forward and deep-links initiated from outside the surface

### Modified: `app-sidebar.tsx` — one-click settings gear

- `PROJECT_HEADER_TRIGGER` class gains `group` so child can use `group-hover`
- Inline `<button>` with `SettingsIcon` inserted after the chevron: `onClick={(e) => { e.stopPropagation(); goSettings(repo); }}`, `opacity-0 group-hover:opacity-100 focus-visible:opacity-100`, `aria-label="Project settings"`

### Tests

- `settings-surface.test.ts`: three new suites — three-tier nav scaffolding (resolveSettingsView dispatch, PendingSectionPane usage, SETTINGS_PENDING_SECTIONS import) and one-click gear affordance (goSettings occurrences, stopPropagation, group-hover)
- `project-settings-model.test.ts`: SETTINGS_PENDING_SECTIONS suite (key format, labels, notes) + resolveSettingsView suite (6 cases: null, undefined, known project, cluster key, host/node key, unknown fallback)
- `project-rail.test.tsx`: Cluster/Host Node pending sections render; pending section active state
- `project-settings-pane.test.tsx`: `vcsRepo` prop added to test fixture
- `pending-section-pane.test.tsx`: new — label, note, "Pending" text rendered (tree-walk, no DOM)

## How to Verify It

- [x] `cd plugins/dev/scripts/orch-monitor && bun test` — all suites pass
- [x] `cd plugins/dev/scripts/orch-monitor/ui && bun run typecheck` — zero errors
- [ ] `cd plugins/dev/scripts/orch-monitor/ui && bun run dev` then open the orch-monitor; hover a project row in the sidebar — gear icon appears; click it — lands on that project's settings page
- [ ] In settings, verify Identity / Source / Workflow sections render; change display name + save; confirm it persists and syncs
- [ ] Click Cluster or Host/Node in the settings rail — PendingSectionPane renders with "Pending configuration service" subline
- [ ] Use browser back/forward between a project pane and General — pane switches correctly (useEffect resync)

## Changelog Entry

```
feat(dev): CTL-1212 — grouped project settings page (Identity/Source/Workflow) + three-tier nav + one-click gear

Reshapes orch-monitor settings surface: per-project pane gets Identity/Source/Workflow
sections; ProjectRail gains Cluster/Host-Node pending-section slots; AppSidebar gets
hover-revealed one-click settings gear; SettingsSurface fixes deep-link stale-pane bug
via useEffect resync. New PendingSectionPane empty-state component + resolveSettingsView
discriminated-union dispatch in project-settings-model. 418 additions, 92 deletions,
33 new tests.
```

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1212

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-623
skip CTL-633
