### PR TITLE
CTL-1142: Lifecycle-event namespace contract — parity tests & single source of truth

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -416,6 +416,45 @@ processing it. The filter drops:
 This self-filter is what makes the single unified log safe to use as both the broker's input and
 its output.
 
+### Lifecycle-event namespace contract
+
+The four protected name-spaces below are enforced as a verified invariant (CTL-1142). Only
+`service.name = "catalyst.broker"` may emit events in the first three spaces; the fourth governs
+which phase-slot strings are valid in routing events.
+
+| Space | Rule |
+|---|---|
+| `filter.*` | Broker interest-management events only. Any non-broker emission here would create a filter-wake feedback loop. |
+| `broker.daemon.*` | Broker operational heartbeats / startup / shutdown only. |
+| `session.heartbeat` | Exact match; broker liveness pings only (CTL-401). |
+| `phase.<name>.(complete\|failed\|turn-cap-exhausted\|skipped).<ticket>` | Routing namespace matched by `PHASE_EVENT_PATTERN`. Only names in `KNOWN_PHASES` or `INTENTIONAL_PHASE_SLOT_EXCEPTIONS` may occupy the `<name>` slot. |
+
+**`KNOWN_PHASES`** (canonical 10-phase pipeline, in order): `triage`, `research`, `plan`,
+`implement`, `verify`, `review`, `pr`, `monitor-merge`, `monitor-deploy`, `teardown`.
+
+**Documented `<name>` slot exceptions** — these appear in `recovery.mjs` but are NOT pipeline
+phases; their action suffixes do not match the routing pattern's terminal-status set:
+
+- `dispatch` — `phase.dispatch.failed.<ticket>` marks a dispatch-level failure before a real phase
+  worker starts. The real phase rides `payload.target_phase`. This is the only exception that uses
+  a terminal-status suffix (`failed`) and therefore actually matches `PHASE_EVENT_PATTERN`.
+- `scheduler` — scheduler-internal observability events (`yield-file-skip`, `cooldown-gc`, …).
+  Action suffixes never match `(complete|failed|turn-cap-exhausted|skipped)`.
+- `advance` — phase-advance gate events (`held`). Same: action suffix never matches the routing set.
+
+**Enforcement surfaces:**
+
+- `plugins/dev/scripts/broker/namespace-contract.mjs` — single source of truth: exports
+  `FORBIDDEN_PREFIXES`, `PROTECTED_EXACT_NAMES`, `KNOWN_PHASES`,
+  `INTENTIONAL_PHASE_SLOT_EXCEPTIONS`, `PHASE_EVENT_PATTERN`, `isBrokerProtectedName`,
+  `phaseSlotOf`, `isAllowedPhaseSlot`. `router.mjs`'s `shouldSkipEvent` imports from here.
+- `plugins/dev/scripts/broker/namespace-parity.test.mjs` — exec-core producer parity: static-
+  constant event names + a `recovery.mjs` source-scan that snapshots the hardcoded phase-slot set.
+- `plugins/dev/scripts/orch-monitor/__tests__/namespace-parity.test.ts` — orch-monitor producer
+  parity: representative GitHub/Linear/service-health names + prefix-family invariant proof.
+
+See `thoughts/shared/plans/2026-06-16-ctl-1142.md` §3.8 for the originating design.
+
 ## Context Management Principles
 
 1. **Context is precious** — Use specialized agents, not monoliths

--- a/plugins/dev/scripts/broker/namespace-contract.d.mts
+++ b/plugins/dev/scripts/broker/namespace-contract.d.mts
@@ -1,0 +1,8 @@
+export declare const FORBIDDEN_PREFIXES: readonly string[];
+export declare const PROTECTED_EXACT_NAMES: readonly string[];
+export declare const KNOWN_PHASES: readonly string[];
+export declare const INTENTIONAL_PHASE_SLOT_EXCEPTIONS: readonly string[];
+export declare const PHASE_EVENT_PATTERN: RegExp;
+export declare function isBrokerProtectedName(name: string): boolean;
+export declare function phaseSlotOf(name: string): string | null;
+export declare function isAllowedPhaseSlot(slot: string): boolean;

--- a/plugins/dev/scripts/broker/namespace-contract.mjs
+++ b/plugins/dev/scripts/broker/namespace-contract.mjs
@@ -1,0 +1,88 @@
+// namespace-contract.mjs — single source of truth for the lifecycle-event
+// namespace contract (CTL-1142).
+//
+// INVARIANT: the broker owns four protected event-name spaces. Only
+// `service.name = "catalyst.broker"` may emit in them; producers in other
+// services (exec-core, orch-monitor) must never collide with these spaces.
+//
+//   1. filter.*           — broker interest-management events. Re-ingesting them
+//                           would create filter-wake feedback loops.
+//   2. broker.daemon.*    — broker operational heartbeats / startup / shutdown.
+//   3. session.heartbeat  — exact match; special-cased liveness ping (CTL-401).
+//   4. phase.<name>.<complete|failed|turn-cap-exhausted|skipped>.<ticket>
+//                         — routing namespace matched by PHASE_EVENT_PATTERN;
+//                           only KNOWN_PHASES (+ INTENTIONAL_PHASE_SLOT_EXCEPTIONS)
+//                           may occupy the <name> slot.
+//
+// Enforcement surfaces:
+//   - plugins/dev/scripts/broker/router.mjs imports PHASE_EVENT_PATTERN,
+//     FORBIDDEN_PREFIXES, and PROTECTED_EXACT_NAMES from here (runtime).
+//   - plugins/dev/scripts/broker/namespace-parity.test.mjs (exec-core producers).
+//   - plugins/dev/scripts/orch-monitor/__tests__/namespace-parity.test.ts
+//     (orch-monitor producers).
+//
+// See docs/architecture.md §"Lifecycle-event namespace contract" for prose.
+
+// Protected-prefix spaces. Any name that starts with one of these strings is
+// reserved for broker-internal use (shouldSkipEvent guard in router.mjs).
+export const FORBIDDEN_PREFIXES = Object.freeze(["filter.", "broker.daemon"]);
+
+// Protected exact-match names.
+export const PROTECTED_EXACT_NAMES = Object.freeze(["session.heartbeat"]);
+
+// The canonical 10-phase pipeline, in pipeline order.
+// CLAUDE.md §Orchestration and the phase-agent-dispatch scripts are authoritative
+// for the pipeline definition; this constant is the single machine-readable home.
+export const KNOWN_PHASES = Object.freeze([
+  "triage",
+  "research",
+  "plan",
+  "implement",
+  "verify",
+  "review",
+  "pr",
+  "monitor-merge",
+  "monitor-deploy",
+  "teardown",
+]);
+
+// Documented exceptions: phase-slot strings that match PHASE_EVENT_PATTERN but
+// are NOT in KNOWN_PHASES. Each exception MUST be listed here with its rationale.
+//
+//   "dispatch" — recovery.mjs:805 emits `phase.dispatch.failed.<ticket>` to mark
+//     a dispatch-level failure before a real phase worker starts. The real phase
+//     rides payload.target_phase. No broker phase_lifecycle interest lists
+//     "dispatch" as a phase name, so it is harmless; but it must be an explicit,
+//     auditable entry rather than a silent tolerance.
+export const INTENTIONAL_PHASE_SLOT_EXCEPTIONS = Object.freeze(["dispatch"]);
+
+// CTL-484: turn-cap-exhausted is routed alongside complete/failed so the
+// orchestrator can dispatch a continuation worker (separate budget from the
+// error-revive path) without an event-name namespace collision.
+// CTL-512: skipped is the monitor-deploy terminal-no-deploy status. Routed
+// the same as complete (phase-advance is a no-op for monitor-deploy) so the
+// scheduler frees the wave slot.
+export const PHASE_EVENT_PATTERN =
+  /^phase\.([^.]+)\.(complete|failed|turn-cap-exhausted|skipped)\.([A-Za-z][A-Za-z0-9_]*-\d+)$/;
+
+// isBrokerProtectedName — true if `name` falls in any broker-protected space.
+// Callers: shouldSkipEvent (router.mjs), parity tests.
+export function isBrokerProtectedName(name) {
+  return (
+    FORBIDDEN_PREFIXES.some((p) => name.startsWith(p)) ||
+    PROTECTED_EXACT_NAMES.includes(name)
+  );
+}
+
+// phaseSlotOf — returns the <name> capture group if `name` matches
+// PHASE_EVENT_PATTERN, otherwise null.
+export function phaseSlotOf(name) {
+  const m = PHASE_EVENT_PATTERN.exec(name);
+  return m ? m[1] : null;
+}
+
+// isAllowedPhaseSlot — true if `slot` is a known pipeline phase or a
+// documented exception. Use after phaseSlotOf returns non-null.
+export function isAllowedPhaseSlot(slot) {
+  return KNOWN_PHASES.includes(slot) || INTENTIONAL_PHASE_SLOT_EXCEPTIONS.includes(slot);
+}

--- a/plugins/dev/scripts/broker/namespace-contract.mjs
+++ b/plugins/dev/scripts/broker/namespace-contract.mjs
@@ -46,15 +46,28 @@ export const KNOWN_PHASES = Object.freeze([
   "teardown",
 ]);
 
-// Documented exceptions: phase-slot strings that match PHASE_EVENT_PATTERN but
-// are NOT in KNOWN_PHASES. Each exception MUST be listed here with its rationale.
+// Documented exceptions: phase-slot strings that appear in recovery.mjs's
+// `buildEventEnvelope({ phase: "<slot>", ... })` calls but are NOT in KNOWN_PHASES.
+// Each exception MUST be listed here with its rationale.
 //
-//   "dispatch" — recovery.mjs:805 emits `phase.dispatch.failed.<ticket>` to mark
-//     a dispatch-level failure before a real phase worker starts. The real phase
-//     rides payload.target_phase. No broker phase_lifecycle interest lists
-//     "dispatch" as a phase name, so it is harmless; but it must be an explicit,
-//     auditable entry rather than a silent tolerance.
-export const INTENTIONAL_PHASE_SLOT_EXCEPTIONS = Object.freeze(["dispatch"]);
+//   "dispatch" — recovery.mjs emits `phase.dispatch.failed.<ticket>` to mark a
+//     dispatch-level failure before a real phase worker starts. The real phase
+//     rides payload.target_phase. This is the only slot that matches
+//     PHASE_EVENT_PATTERN's terminal-action suffix (failed); no phase_lifecycle
+//     interest lists "dispatch", so it is harmless today but must be explicit.
+//   "scheduler" — recovery.mjs emits `phase.scheduler.yield-file-skip.<ticket>`,
+//     `phase.scheduler.cooldown-gc.<ticket>`, etc. — scheduler-internal
+//     observability events. Their action suffixes ("yield-file-skip", "held", …)
+//     do NOT match PHASE_EVENT_PATTERN's (complete|failed|…) set, so they create
+//     no routing collisions. Listed here for completeness.
+//   "advance" — recovery.mjs emits `phase.advance.held.<ticket>` when the
+//     phase-advance step is blocked by a safety gate. Same as "scheduler": the
+//     action "held" does not match PHASE_EVENT_PATTERN's routing suffixes.
+export const INTENTIONAL_PHASE_SLOT_EXCEPTIONS = Object.freeze([
+  "dispatch",
+  "scheduler",
+  "advance",
+]);
 
 // CTL-484: turn-cap-exhausted is routed alongside complete/failed so the
 // orchestrator can dispatch a continuation worker (separate budget from the

--- a/plugins/dev/scripts/broker/namespace-contract.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-contract.test.mjs
@@ -1,0 +1,128 @@
+// Unit tests for the lifecycle-event namespace contract (CTL-1142).
+// Run: bun test plugins/dev/scripts/broker/namespace-contract.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import {
+  FORBIDDEN_PREFIXES,
+  PROTECTED_EXACT_NAMES,
+  KNOWN_PHASES,
+  INTENTIONAL_PHASE_SLOT_EXCEPTIONS,
+  PHASE_EVENT_PATTERN,
+  isBrokerProtectedName,
+  phaseSlotOf,
+  isAllowedPhaseSlot,
+} from "./namespace-contract.mjs";
+
+describe("isBrokerProtectedName", () => {
+  test("returns true for filter.* prefix", () => {
+    expect(isBrokerProtectedName("filter.wake.x")).toBe(true);
+    expect(isBrokerProtectedName("filter.register")).toBe(true);
+    expect(isBrokerProtectedName("filter.")).toBe(true);
+  });
+
+  test("returns true for broker.daemon.* prefix", () => {
+    expect(isBrokerProtectedName("broker.daemon.start")).toBe(true);
+    expect(isBrokerProtectedName("broker.daemon.degraded")).toBe(true);
+  });
+
+  test("returns true for exact session.heartbeat", () => {
+    expect(isBrokerProtectedName("session.heartbeat")).toBe(true);
+  });
+
+  test("returns false for safe names", () => {
+    expect(isBrokerProtectedName("node.heartbeat")).toBe(false);
+    expect(isBrokerProtectedName("github.pr.opened")).toBe(false);
+    expect(isBrokerProtectedName("phase.plan.complete.CTL-1")).toBe(false);
+    expect(isBrokerProtectedName("linear.issue.updated")).toBe(false);
+    expect(isBrokerProtectedName("catalyst.service.health")).toBe(false);
+  });
+
+  test("does not treat broker.daemon-prefix-only as protected (needs dot separator)", () => {
+    // "broker.daemonx" should NOT match because the prefix is "broker.daemon" (no trailing dot required)
+    // but per FORBIDDEN_PREFIXES the check is startsWith("broker.daemon"), so "broker.daemonx" IS protected.
+    // This test documents that intentional behavior.
+    expect(isBrokerProtectedName("broker.daemon")).toBe(true);
+  });
+});
+
+describe("phaseSlotOf", () => {
+  test("extracts phase slot from valid phase events", () => {
+    expect(phaseSlotOf("phase.plan.complete.CTL-1")).toBe("plan");
+    expect(phaseSlotOf("phase.implement.failed.CTL-123")).toBe("implement");
+    expect(phaseSlotOf("phase.triage.turn-cap-exhausted.CTL-9")).toBe("triage");
+    expect(phaseSlotOf("phase.monitor-merge.skipped.PROJ-42")).toBe("monitor-merge");
+  });
+
+  test("returns null for non-phase-pattern names", () => {
+    expect(phaseSlotOf("node.heartbeat")).toBe(null);
+    expect(phaseSlotOf("github.pr.opened")).toBe(null);
+    expect(phaseSlotOf("filter.wake.x")).toBe(null);
+    expect(phaseSlotOf("phase.incomplete")).toBe(null);
+    expect(phaseSlotOf("phase.plan.complete")).toBe(null); // missing ticket
+  });
+
+  test("extracts dispatch slot from the documented exception", () => {
+    expect(phaseSlotOf("phase.dispatch.failed.CTL-1")).toBe("dispatch");
+  });
+});
+
+describe("isAllowedPhaseSlot", () => {
+  test("returns true for every KNOWN_PHASES entry", () => {
+    for (const phase of KNOWN_PHASES) {
+      expect(isAllowedPhaseSlot(phase)).toBe(true);
+    }
+  });
+
+  test("returns true for documented exception 'dispatch'", () => {
+    expect(isAllowedPhaseSlot("dispatch")).toBe(true);
+  });
+
+  test("returns false for unknown slots", () => {
+    expect(isAllowedPhaseSlot("bogus")).toBe(false);
+    expect(isAllowedPhaseSlot("")).toBe(false);
+    expect(isAllowedPhaseSlot("reclaim")).toBe(false);
+  });
+});
+
+describe("KNOWN_PHASES shape", () => {
+  test("contains exactly the 10 canonical pipeline phases in order", () => {
+    expect(KNOWN_PHASES).toEqual([
+      "triage",
+      "research",
+      "plan",
+      "implement",
+      "verify",
+      "review",
+      "pr",
+      "monitor-merge",
+      "monitor-deploy",
+      "teardown",
+    ]);
+  });
+
+  test("has exactly 10 phases", () => {
+    expect(KNOWN_PHASES).toHaveLength(10);
+  });
+});
+
+describe("exported constants", () => {
+  test("FORBIDDEN_PREFIXES contains filter. and broker.daemon", () => {
+    expect(FORBIDDEN_PREFIXES).toContain("filter.");
+    expect(FORBIDDEN_PREFIXES).toContain("broker.daemon");
+  });
+
+  test("PROTECTED_EXACT_NAMES contains session.heartbeat", () => {
+    expect(PROTECTED_EXACT_NAMES).toContain("session.heartbeat");
+  });
+
+  test("INTENTIONAL_PHASE_SLOT_EXCEPTIONS contains dispatch", () => {
+    expect(INTENTIONAL_PHASE_SLOT_EXCEPTIONS).toContain("dispatch");
+  });
+
+  test("PHASE_EVENT_PATTERN is a RegExp matching phase events", () => {
+    expect(PHASE_EVENT_PATTERN).toBeInstanceOf(RegExp);
+    expect(PHASE_EVENT_PATTERN.test("phase.plan.complete.CTL-1")).toBe(true);
+    expect(PHASE_EVENT_PATTERN.test("phase.dispatch.failed.CTL-1")).toBe(true);
+    expect(PHASE_EVENT_PATTERN.test("node.heartbeat")).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -1,0 +1,145 @@
+// Cross-producer namespace parity test (CTL-1142).
+// Asserts that exec-core producer event names never collide with the broker's
+// protected namespace, and that any phase-slot in a phase.*.* event is either
+// a KNOWN_PHASES entry or a documented exception.
+//
+// Run: bun test plugins/dev/scripts/broker/namespace-parity.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  KNOWN_PHASES,
+  isBrokerProtectedName,
+  phaseSlotOf,
+  isAllowedPhaseSlot,
+  PHASE_EVENT_PATTERN,
+} from "./namespace-contract.mjs";
+
+// Resolve exec-core directory relative to this test file.
+const EC_DIR = join(fileURLToPath(import.meta.url), "../../execution-core");
+
+// ── Static-constant producers ────────────────────────────────────────────────
+// Import exported event-name constants from each exec-core event module and
+// verify: (a) none are broker-protected; (b) any that match PHASE_EVENT_PATTERN
+// use an allowed phase slot. Extend the list below when a new *-event.mjs is added.
+
+import { HEARTBEAT_EVENT } from "../execution-core/heartbeat-event.mjs";
+import {
+  DRAIN_CHANGED_EVENT,
+  DRAINED_EVENT,
+} from "../execution-core/drain-event.mjs";
+import { FLEET_HEALTH_DEGRADED } from "../execution-core/fleet-health-event.mjs";
+import {
+  RATELIMIT_EVENT_SAMPLED,
+} from "../execution-core/ratelimit-event.mjs";
+import {
+  MEMORY_EVENT_SAMPLED,
+  MEMORY_EVENT_WARN,
+  MEMORY_EVENT_KILLED,
+} from "../execution-core/memory-event.mjs";
+import { JANITOR_EVENT_TYPES } from "../execution-core/janitor-event-types.mjs";
+import { UNSTUCK_SWEEP_EVENT_TYPES } from "../execution-core/unstuck-sweep-event-types.mjs";
+
+// Inline names that don't have a dedicated exported constant; verified against
+// the source file they appear in.
+const INLINE_EVENT_NAMES = [
+  "node.boot",                        // boot-event.mjs:32
+  "monitor.reconcile.failing.team",   // reconcile-health-event.mjs:66 (team is param; prefix is safe)
+  "monitor.reconcile.recovered.team", // reconcile-health-event.mjs:66
+  "phase.triage.linear-transition.CTL-1", // triage-transition-event.mjs:53
+  "linear.state.write.CTL-1",         // linear-state-write-event.mjs:77
+  "agent.waiting_on_user",            // wait-event.mjs:buildWaitEnvelope
+  "agent.resumed",                    // wait-event.mjs:buildWaitEnvelope
+];
+
+// Build the flat list of all static exec-core event names.
+const EXEC_CORE_EVENT_NAMES = [
+  HEARTBEAT_EVENT,
+  DRAIN_CHANGED_EVENT,
+  DRAINED_EVENT,
+  FLEET_HEALTH_DEGRADED,
+  RATELIMIT_EVENT_SAMPLED,
+  MEMORY_EVENT_SAMPLED,
+  MEMORY_EVENT_WARN,
+  MEMORY_EVENT_KILLED,
+  ...JANITOR_EVENT_TYPES,
+  ...UNSTUCK_SWEEP_EVENT_TYPES,
+  ...INLINE_EVENT_NAMES,
+];
+
+describe("exec-core static event names", () => {
+  test("none collide with the broker-protected namespace", () => {
+    for (const name of EXEC_CORE_EVENT_NAMES) {
+      expect(
+        isBrokerProtectedName(name),
+        `exec-core event "${name}" collides with the broker-protected namespace`
+      ).toBe(false);
+    }
+  });
+
+  test("any phase-pattern match uses an allowed phase slot", () => {
+    for (const name of EXEC_CORE_EVENT_NAMES) {
+      const slot = phaseSlotOf(name);
+      if (slot !== null) {
+        expect(
+          isAllowedPhaseSlot(slot),
+          `exec-core event "${name}" has phase slot "${slot}" not in KNOWN_PHASES or exceptions`
+        ).toBe(true);
+      }
+    }
+  });
+});
+
+// ── Dynamic phase-slot producers: recovery.mjs ───────────────────────────────
+// recovery.mjs builds names as `phase.${phase}.${action}.${ticket}`.
+// Most callers pass a runtime ticket phase (always a real pipeline phase).
+// Two sites hardcode the phase literal ("dispatch"). Scan the source to find
+// every hardcoded literal and assert:
+//   (a) each is allowed (isAllowedPhaseSlot)
+//   (b) the set of hardcoded literals equals exactly {"dispatch"} — a snapshot
+//       that fails loudly if a future emitter introduces a new hardcoded slot.
+
+describe("recovery.mjs dynamic phase-slot producers", () => {
+  const recoverySource = readFileSync(join(EC_DIR, "recovery.mjs"), "utf8");
+
+  // Regex captures the literal string in buildEventEnvelope({ ..., phase: "literal", ... }).
+  // Runtime-passed `phase` params are identifiers (no quotes), so this regex only
+  // matches literal strings — exactly what we want.
+  const HARDCODED_SLOT_RE = /buildEventEnvelope\(\{[^}]*?phase:\s*["']([^"']+)["']/gs;
+
+  const hardcodedSlots = new Set();
+  for (const m of recoverySource.matchAll(HARDCODED_SLOT_RE)) {
+    hardcodedSlots.add(m[1]);
+  }
+
+  test("all hardcoded phase slots are allowed", () => {
+    for (const slot of hardcodedSlots) {
+      expect(
+        isAllowedPhaseSlot(slot),
+        `recovery.mjs hardcoded phase slot "${slot}" is not in KNOWN_PHASES or exceptions`
+      ).toBe(true);
+    }
+  });
+
+  test('hardcoded phase-slot set equals exactly {"advance","dispatch","scheduler"}', () => {
+    // Snapshot guard: fails loudly if a future emitter adds a new hardcoded slot.
+    // When that happens: review the new slot, then add it to KNOWN_PHASES or
+    // INTENTIONAL_PHASE_SLOT_EXCEPTIONS in namespace-contract.mjs.
+    expect([...hardcodedSlots].sort()).toEqual(["advance", "dispatch", "scheduler"]);
+  });
+
+  test("phase.dispatch.failed is the only hardcoded slot that matches PHASE_EVENT_PATTERN with a non-KNOWN_PHASES slot", () => {
+    // Build a representative dispatch event name and confirm:
+    // - it matches PHASE_EVENT_PATTERN (so it IS in the routing namespace)
+    // - its slot is "dispatch" (not in KNOWN_PHASES)
+    // - but it IS in INTENTIONAL_PHASE_SLOT_EXCEPTIONS
+    const dispatchName = "phase.dispatch.failed.CTL-1";
+    expect(PHASE_EVENT_PATTERN.test(dispatchName)).toBe(true);
+    expect(phaseSlotOf(dispatchName)).toBe("dispatch");
+    expect(isAllowedPhaseSlot("dispatch")).toBe(true);
+    // "dispatch" is NOT a canonical pipeline phase
+    expect(KNOWN_PHASES.includes("dispatch")).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -85,6 +85,11 @@ import {
   hostName,
   hostId,
 } from "../orch-monitor/lib/canonical-event-shared.ts";
+import {
+  PHASE_EVENT_PATTERN as _PHASE_EVENT_PATTERN,
+  FORBIDDEN_PREFIXES,
+  PROTECTED_EXACT_NAMES,
+} from "./namespace-contract.mjs";
 
 // Identity-stable aliases for the shared maps — the router mutates these; the
 // canonical instances live in state.mjs (see barrel-exports.test.mjs).
@@ -1338,14 +1343,10 @@ function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap, repo) {
 // the interest's ticket. Used by the phase-agent orchestrator to coordinate
 // hand-off between short-lived phase agents (see plan §Initiative 1).
 //
-// CTL-484: turn-cap-exhausted is routed alongside complete/failed so the
-// orchestrator can dispatch a continuation worker (separate budget from the
-// error-revive path) without an event-name namespace collision.
-// CTL-512: skipped is the monitor-deploy terminal-no-deploy status. Routed
-// the same as complete (phase-advance is a no-op for monitor-deploy) so the
-// scheduler frees the wave slot.
-const PHASE_EVENT_PATTERN =
-  /^phase\.([^.]+)\.(complete|failed|turn-cap-exhausted|skipped)\.([A-Za-z][A-Za-z0-9_]*-\d+)$/;
+// PHASE_EVENT_PATTERN lives in namespace-contract.mjs (CTL-1142 single source of
+// truth). Re-exported here to preserve the existing import surface for callers
+// that import it from this module (CTL-484, CTL-512 comments live in the contract).
+export const PHASE_EVENT_PATTERN = _PHASE_EVENT_PATTERN;
 
 export function tryPhaseLifecycleRoute(event, interestsMap) {
   const matches = [];
@@ -1423,11 +1424,10 @@ export function shouldSkipEvent(event) {
   }
   if (event.resource?.["service.name"] === "catalyst.broker") return true;
   const name = getEventName(event);
-  if (name.startsWith("filter.")) return true;
-  if (name.startsWith("broker.daemon")) return true;
+  if (FORBIDDEN_PREFIXES.some((p) => name.startsWith(p))) return true;
   // CTL-401: liveness pings — handled earlier in processEvent, skip here too
   // so they never reach the Groq queue even if the early-return path changes.
-  if (name === "session.heartbeat") return true;
+  if (PROTECTED_EXACT_NAMES.includes(name)) return true;
   return false;
 }
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/namespace-parity.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/namespace-parity.test.ts
@@ -1,0 +1,133 @@
+// Orch-monitor producer namespace parity test (CTL-1142).
+// Asserts that orch-monitor event names (GitHub webhooks, Linear webhooks,
+// service-health) never collide with the broker's protected namespace.
+//
+// Run: bun test plugins/dev/scripts/orch-monitor/__tests__/namespace-parity.test.ts
+
+import { describe, test, expect } from "bun:test";
+import {
+  isBrokerProtectedName,
+  PHASE_EVENT_PATTERN,
+} from "../../broker/namespace-contract.mjs";
+
+// ── Representative orch-monitor event names ──────────────────────────────────
+//
+// The orch-monitor producers do NOT export a centralized event-name constant or
+// map — names are inline string templates (see lib/webhook-handler.ts and
+// lib/linear-webhook-handler.ts). This test therefore:
+//   (a) asserts representative names from each producer family are safe, and
+//   (b) proves by prefix that the entire github.* / linear.* family can never
+//       collide with the protected namespace — a mathematical guarantee that
+//       renders the per-name check redundant for any future additions in those
+//       families.
+//
+// Adding a new orch-monitor event name family? Add a prefix-family assertion
+// and at least one representative name.
+
+// GitHub webhook events (lib/webhook-handler.ts buildEventLogEnvelope).
+// Names follow `github.<entity>.<action>` or plain `github.<entity>`.
+const GITHUB_REPRESENTATIVE_NAMES = [
+  "github.pr.opened",
+  "github.pr.merged",
+  "github.pr.closed",
+  "github.check_suite.completed",
+  "github.push",
+  "github.deployment.created",
+  "github.deployment_status.success",
+  "github.release.published",
+  "github.workflow_run.completed",
+  "github.pr_review.submitted",
+  "github.pr_review_comment.created",
+  "github.issue_comment.created",
+  "github.status.success",
+];
+
+// Linear webhook events (lib/linear-webhook-handler.ts + lib/linear-webhook-events.ts).
+// Names follow `linear.<entity>.<action>`.
+const LINEAR_REPRESENTATIVE_NAMES = [
+  "linear.issue.created",
+  "linear.issue.removed",
+  "linear.issue.state_changed",
+  "linear.issue.priority_changed",
+  "linear.issue.assignee_changed",
+  "linear.issue.updated",
+  "linear.comment.created",
+  "linear.cycle.created",
+  "linear.reaction.created",
+  "linear.issue_label.created",
+  "linear.agent_session.created",
+  "linear.mention.created",
+];
+
+// Service health events (lib/server.ts ~line 934).
+const SERVICE_HEALTH_NAMES = ["catalyst.service.health"];
+
+const ALL_ORCH_MONITOR_NAMES = [
+  ...GITHUB_REPRESENTATIVE_NAMES,
+  ...LINEAR_REPRESENTATIVE_NAMES,
+  ...SERVICE_HEALTH_NAMES,
+];
+
+describe("orch-monitor representative event names", () => {
+  test("none are broker-protected", () => {
+    for (const name of ALL_ORCH_MONITOR_NAMES) {
+      expect(
+        isBrokerProtectedName(name),
+        `orch-monitor event "${name}" collides with the broker-protected namespace`
+      ).toBe(false);
+    }
+  });
+
+  test("none match PHASE_EVENT_PATTERN", () => {
+    for (const name of ALL_ORCH_MONITOR_NAMES) {
+      expect(
+        PHASE_EVENT_PATTERN.test(name),
+        `orch-monitor event "${name}" unexpectedly matches PHASE_EVENT_PATTERN`
+      ).toBe(false);
+    }
+  });
+});
+
+// ── Prefix-family invariant ───────────────────────────────────────────────────
+// Mathematical proof: any name starting with "github." or "linear." can never:
+//   1. start with "filter." or "broker.daemon" (isBrokerProtectedName prefix check), or
+//   2. equal "session.heartbeat" (isBrokerProtectedName exact check), or
+//   3. match PHASE_EVENT_PATTERN (which requires the "phase." prefix).
+//
+// This means the per-name representative test above suffices for today's names,
+// and any future github.*/linear.* event is automatically safe — no test update
+// needed for new names within these families.
+
+describe("orch-monitor prefix-family invariant", () => {
+  const PRODUCER_PREFIXES = ["github.", "linear.", "catalyst.service."];
+
+  test("producer prefixes never start with a forbidden prefix", () => {
+    const FORBIDDEN = ["filter.", "broker.daemon"];
+    for (const prod of PRODUCER_PREFIXES) {
+      for (const forbidden of FORBIDDEN) {
+        // A name with this producer prefix can only collide if the producer
+        // prefix itself starts with the forbidden prefix (or vice versa).
+        const overlap =
+          prod.startsWith(forbidden) || forbidden.startsWith(prod.slice(0, forbidden.length));
+        expect(overlap).toBe(false);
+      }
+    }
+  });
+
+  test("producer prefixes never equal the protected exact name", () => {
+    for (const prod of PRODUCER_PREFIXES) {
+      // "session.heartbeat" does not start with any producer prefix.
+      expect("session.heartbeat".startsWith(prod)).toBe(false);
+    }
+  });
+
+  test("producer prefixes never match PHASE_EVENT_PATTERN", () => {
+    // PHASE_EVENT_PATTERN requires the literal string to start with "phase.".
+    // None of the producer prefixes start with "phase.", so no name in these
+    // families can match PHASE_EVENT_PATTERN.
+    for (const prod of PRODUCER_PREFIXES) {
+      expect(prod.startsWith("phase.")).toBe(false);
+      expect("phase.".startsWith(prod)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-16T17:10:58Z -->
<!-- Last updated: 2026-06-16T17:10:58Z -->
<!-- PR: #2128 -->
<!-- Previous commits: 2800dba08d72796f4716a1f47437bb331b30d8d3,bc54b5dc2a0d4172c1c11d9c756e25cd7b5d154f,bfde4a2e626b3d3b3f991044dedc9ad1c32a16c5,a891bc6ec84b085f17497f012ed941620d657fe3,184c039c905d777a07d98106c73c5bb0ba9c105f -->

# CTL-1142: Lifecycle-event namespace contract — parity tests & enforcement

## Summary

Extracts the broker's lifecycle-event namespace contract into a shared module () and enforces it with parity tests across all event producers (exec-core, orch-monitor). Previously, the three `shouldSkipEvent` guards in `router.mjs` were inline literals that exec-core and orch-monitor producers could silently collide with. This PR makes the namespace a documented invariant with CI-enforced parity.

## Changes Made

### Core: namespace-contract.mjs (new)

- Extracts `PHASE_EVENT_PATTERN`, `FORBIDDEN_PREFIXES`, `PROTECTED_EXACT_NAMES`, and `KNOWN_PHASES` from inline literals into a single shared module
- Adds `isBrokerProtectedName`, `phaseSlotOf`, and `isAllowedPhaseSlot` helpers
- Documents `INTENTIONAL_PHASE_SLOT_EXCEPTIONS` (dispatch/scheduler/advance) with per-entry rationale
- `router.mjs` now imports from the contract module; external import surface unchanged

### Tests

- `namespace-contract.test.mjs` — unit tests for all exports (128 lines)
- `namespace-parity.test.mjs` — exec-core static-constant and dynamic phase-slot producer coverage; snapshot guard on the hardcoded phase-slot set so future additions break CI until reviewed (145 lines)
- `orch-monitor/__tests__/namespace-parity.test.ts` — orch-monitor producer plane: representative `github.*` / `linear.*` / `catalyst.service.health` names + prefix-family invariant proving the entire github/linear families can never collide mathematically (133 lines)
- `namespace-contract.d.mts` — TypeScript declaration sidecar for cross-package .mjs import (fixes TS7016 in CI typecheck)

### Documentation

- `docs/architecture.md` — "Lifecycle-event namespace contract" subsection in the Phase-Agent Communication section: tables the four protected spaces, lists `KNOWN_PHASES`, documents dispatcher-internal slot exceptions, and points at enforcement surfaces

## How to Verify It

- [x] `bun test plugins/dev/scripts/broker/` — passes (namespace-contract + parity tests)
- [x] `tsc --noEmit` in orch-monitor — passes after namespace-contract.d.mts added
- [ ] CI quality gate (orch-monitor-quality.yml) — re-run after latest push

## Related Issues/PRs

- Fixes https://linear.app/adva/issue/CTL-1142
