### PR TITLE
feat(dev): CTL-1219 — wire unstuck-sweep deterministic act-seams (ships off/inert)

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -184,6 +184,11 @@ import {
   defaultCollectUnstuckCandidates,
   emitUnstuckEvent,
 } from "./unstuck-sweep.mjs";
+// CTL-1219: the per-category enforcement seam registry (dirty-tree /
+// source-conflict / orphan-stale / stale-label). Pure-cored + injectable; bound
+// to production deps at the unstuckSweep wiring point below. Wiring this does NOT
+// flip enforce on — the mode gate stays at its safe 'off' default (ADR-023).
+import { buildUnstuckActSeams } from "./unstuck-act-seams.mjs";
 import { readUnstuckSweepConfig, isThrottled } from "./config.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
@@ -5162,12 +5167,59 @@ function runTick() {
               return null;
             },
           }),
-        // actByCategory: production seams undefined → no-op (escalate handles
-        // all whitelisted categories in the initial shadow rollout). Operators
-        // enable per-category enforcement via Layer-2 config. Pass 0u ships
-        // shadow-/escalate-only: catA-D mechanical enforcement is DEFERRED and
-        // actByCategory:{} is an intentional no-op (no real act seams exist yet).
-        actByCategory: runningOpts.unstuckActByCategory ?? {},
+        // CTL-1219: wire the real per-category enforcement seams. These act ONLY
+        // when the unstuck-sweep mode resolves to 'enforce' (the driver looks up
+        // actByCategory[decision.category] solely on the enforce branch); the mode
+        // gate (readUnstuckSweepConfig, default 'off') is UNTOUCHED, so production
+        // stays inert until an operator opts in — enforce is an operator decision
+        // per ADR-023. Operators can still fully override via
+        // runningOpts.unstuckActByCategory (e.g. a partial registry during staged
+        // rollout, or {} to preserve the prior shadow-/escalate-only posture); the
+        // ?? precedence keeps every existing scheduler test that injects
+        // unstuckActByCategory:{} working unchanged. The seams are pure-cored +
+        // injectable; here we bind the production deps already in scope.
+        actByCategory: runningOpts.unstuckActByCategory ?? buildUnstuckActSeams({
+          orchDir: runningOpts.orchDir,
+          // re-arm seam: deletes the stalled signal so the phase re-dispatches.
+          clearStall: defaultClearStall(runningOpts.orchDir, runningOpts.writeStatus ?? linearWrite),
+          // label-removal seam for the stale-label category.
+          writeStatus: runningOpts.writeStatus ?? linearWrite,
+          // resolvePrState: normalize the live PR view ("MERGED" | other) for the
+          // orphan-stale gate. Reuses the SAME prAdapter the recovery short-circuit
+          // + reconcile backstop use (built once at boot, gh only fires inside
+          // prView). Inert when no prAdapter / PR number is wired.
+          resolvePrState: (ticket) => {
+            const adapter = runningOpts.prAdapter;
+            if (!adapter || typeof adapter.prView !== "function") return null;
+            let pr = null;
+            for (const sig of readWorkerSignals(runningOpts.orchDir)) {
+              if (sig.ticket === ticket) {
+                pr = sig.raw?.pr ?? sig.pr ?? null;
+                if (pr?.number) break;
+              }
+            }
+            if (!pr?.number) return null;
+            try {
+              const view = adapter.prView(ticket, pr);
+              if (view && (view.state === "MERGED" || view.mergedAt != null)) return "MERGED";
+              return view?.state ?? null;
+            } catch {
+              return null; // fail-closed: a gh error is never treated as MERGED.
+            }
+          },
+          // jobLifecycle: the same bg-liveness probe the reclaim sweep uses; bound
+          // to the warm agents snapshot. Inert (→ not-alive) without isBgJobAlive.
+          jobLifecycle: (bgJobId) => {
+            if (typeof runningOpts.isBgJobAlive !== "function" || !bgJobId) return false;
+            try {
+              return Boolean(runningOpts.isBgJobAlive(bgJobId, { agents: getAgentsCached().agents }));
+            } catch {
+              return false;
+            }
+          },
+          // runGit / fs primitives / emitPhaseComplete fall back to real defaults
+          // inside unstuck-act-seams.mjs (git, node:fs, phase-agent-emit-complete).
+        }),
         // emit: the dedicated unstuck unified-log emitter (NOT emitReapIntent,
         // whose closed vocabulary throws on unstuck.* — CTL-1064). Explicit here
         // so the production wiring does not silently depend on the schedulerTick

--- a/plugins/dev/scripts/execution-core/unstuck-act-seams.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-act-seams.mjs
@@ -1,0 +1,394 @@
+// unstuck-act-seams.mjs — CTL-1219 deterministic act-seam registry for the
+// unstuck-sweep Pass 0u driver (unstuck-sweep.mjs:runUnstuckSweepPass).
+//
+// Pass 0u classifies the stalled/needs-human ticket backlog into four typed
+// categories (dirty-tree, source-conflict, orphan-stale, stale-label). The
+// classifiers are PURE and already shipped + tested (dirty-tree-classifier.mjs,
+// catB-force-with-lease.mjs, unstuck-orphan-merge.mjs, unstuck-stale-label.mjs).
+// This module supplies the MECHANICAL act seams the driver invokes once per
+// candidate when mode === 'enforce'.
+//
+// Driver seam contract (unstuck-sweep.mjs:405-440 — frozen, do not deviate):
+//   • actByCategory[decision.category](candidate, decision) — return value IGNORED.
+//   • THROW on hard failure → the driver records report.failed and skips all
+//     post-act bookkeeping (intent / comment / event).
+//   • Return normally (incl. undefined) → success → the driver records the intent,
+//     posts the Linear audit comment, and fires the enforce event.
+//   • The seam MUST NOT call recordIntent / postComment / emit / fire itself —
+//     the driver owns ALL post-act bookkeeping.
+//
+// Every seam is the thin ORCHESTRATION over an existing PURE classifier; the
+// safety decision is re-validated against the LIVE worktree at act time (not the
+// stale census evidence). Every IO operation (git, fs, label removal, event
+// append, signal re-arm) is an injected dependency with a real default, so the
+// unit tests drive each seam with stub deps — zero real git / fs / Linear.
+//
+// Ships gated behind the three-layer mode gate (config.mjs:readUnstuckSweepConfig)
+// which defaults to 'off'. Wiring this registry into the scheduler does NOT flip
+// enforce on — enforce is an operator decision per ADR-023 (CTL-1219).
+
+import { existsSync, unlinkSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { log as defaultLog } from "./config.mjs";
+import { filterMachineLocalDirt, isNodeModulesDeletion } from "./dirty-tree-classifier.mjs";
+import { classifyCleanRebaseForcePush } from "./catB-force-with-lease.mjs";
+import { classifyOrphanMergedReconcile } from "./unstuck-orphan-merge.mjs";
+import { clearStalledLabel, inRemovalBackoff } from "./label-guard.mjs";
+
+// phase-agent-emit-complete sits two directories up from execution-core/
+// (mirrors recovery.mjs:86 — the canonical synthetic-complete emitter).
+const EMIT_COMPLETE_BIN = fileURLToPath(new URL("../phase-agent-emit-complete", import.meta.url));
+
+// ─── default IO seams ───────────────────────────────────────────────────────
+// Each is overridable via deps; the production defaults shell to real git / fs /
+// the emit-complete script. The classifier/collector pattern of this subsystem
+// (collectForcePushCandidates' runGit, clearStalledLabel's writeStatus).
+
+function defaultRunGit(args) {
+  return spawnSync("git", args, { encoding: "utf8" });
+}
+
+function defaultReadPorcelain(worktreePath, runGit) {
+  // Non-zero exit / spawn error → null so the classifier fails closed (never
+  // auto-acts on an unknown tree state — mirrors collectForcePushCandidates).
+  const res = runGit(["-C", worktreePath, "status", "--porcelain"]);
+  if (res?.error || (res?.status ?? 1) !== 0) return null;
+  return res.stdout ?? "";
+}
+
+function defaultMarkerExists(p) {
+  return existsSync(p);
+}
+
+function defaultWriteMarker(p) {
+  try {
+    mkdirSync(join(p, ".."), { recursive: true });
+  } catch {
+    /* best-effort dir create */
+  }
+  writeFileSync(p, "");
+}
+
+function defaultUnlink(p) {
+  try {
+    unlinkSync(p);
+  } catch {
+    /* best-effort — already gone is success */
+  }
+}
+
+// defaultEmitPhaseComplete — emit a synthetic phase.<phase>.complete.<ticket>
+// canonical event via the phase-agent-emit-complete script (matching how
+// recovery.mjs's reclaim path emits synthetic completes). --no-signal-update so
+// we only WAKE the orchestrator with the event; the seam does not own the signal
+// flip. Returns true on a zero exit, false otherwise (the seam throws on false).
+function defaultEmitPhaseComplete({ ticket, phase, orchDir }, { spawn = spawnSync } = {}) {
+  const args = ["--phase", phase, "--ticket", ticket, "--status", "complete", "--no-signal-update"];
+  if (orchDir) args.push("--orch-dir", orchDir, "--orch-id", ticket);
+  const res = spawn(EMIT_COMPLETE_BIN, args, { encoding: "utf8" });
+  if (res?.error) return false;
+  return (res?.status ?? 1) === 0;
+}
+
+// markerPath — the per-(ticket, phase) idempotency once-marker under workers/<T>/.
+function markerPath(orchDir, ticket, phase, name) {
+  return join(orchDir ?? ".", "workers", ticket, `.unstuck-${name}-${phase}.applied`);
+}
+
+// ─── Phase 1: dirty-tree act seam ─────────────────────────────────────────────
+//
+// Clears machine-local rebase noise (REBASE_NOISE_PATHS + deleted node_modules)
+// from the worktree, then re-arms the worker (clearStall deletes the stalled
+// signal so the phase re-dispatches next tick). FAIL-CLOSED: throws if the tree
+// carries real work (filterMachineLocalDirt non-empty), if the worktree path is
+// null, or if the tree is still dirty after the clear. Idempotent via the
+// .unstuck-cleared-<phase>.applied marker.
+export function buildDirtyTreeActSeam(deps = {}) {
+  const {
+    runGit = defaultRunGit,
+    readPorcelain = (wt) => defaultReadPorcelain(wt, runGit),
+    unlink = defaultUnlink,
+    writeMarker = defaultWriteMarker,
+    markerExists = defaultMarkerExists,
+    clearStall = () => true,
+    orchDir = null,
+    log = defaultLog,
+  } = deps;
+
+  return function dirtyTreeActSeam(candidate, _decision) {
+    const { ticket, phase, worktreePath } = candidate;
+    if (!worktreePath) throw new Error(`dirty-tree: no-worktree (${ticket})`);
+
+    const marker = markerPath(orchDir, ticket, phase, "cleared");
+    if (markerExists(marker)) return; // idempotent — already cleared this lifetime.
+
+    const porcelain = readPorcelain(worktreePath);
+    // Fail-closed on unreadable porcelain (never auto-clear an unknown state).
+    if (porcelain === null || porcelain === undefined) {
+      throw new Error(`dirty-tree: unreadable-porcelain (${ticket})`);
+    }
+
+    const lines = porcelain.split("\n").filter((l) => l.trim().length > 0);
+    const realDirt = filterMachineLocalDirt(lines);
+    if (realDirt.length > 0) {
+      // Real uncommitted work present → never auto-clear (fail-closed, mirrors
+      // classifyDirtyTreeRecoverable's escalate/real-dirt-present).
+      throw new Error(`dirty-tree: real-dirt-present (${ticket}): ${realDirt.length} line(s)`);
+    }
+
+    // Only noise + deleted node_modules remain → clear each path mechanically.
+    for (const line of lines) {
+      const xy = line.slice(0, 2);
+      const path = line.slice(3).trim().replace(/^"|"$/g, "");
+      if (!path) continue;
+      if (xy.startsWith("??")) {
+        // Untracked noise → remove from disk.
+        unlink(join(worktreePath, path));
+      } else if (isNodeModulesDeletion(line)) {
+        // A deleted (tracked) node_modules path → restore from index.
+        runGit(["-C", worktreePath, "checkout", "--", path]);
+      } else {
+        // Tracked noise modification → restore from index.
+        runGit(["-C", worktreePath, "checkout", "--", path]);
+      }
+    }
+
+    // Re-read porcelain and re-verify the tree is clean of real work after the
+    // clear (fail-closed: never re-arm a worker on a tree we could not clean).
+    const after = readPorcelain(worktreePath);
+    if (after === null || after === undefined) {
+      throw new Error(`dirty-tree: unreadable-porcelain-after-clear (${ticket})`);
+    }
+    const afterLines = after.split("\n").filter((l) => l.trim().length > 0);
+    if (filterMachineLocalDirt(afterLines).length > 0) {
+      throw new Error(`dirty-tree: real-dirt-after-clear (${ticket})`);
+    }
+
+    // Write the idempotency marker, then re-arm the worker (delete the stalled
+    // signal so the scheduler's normal path re-dispatches the phase).
+    writeMarker(marker);
+    const ok = clearStall({ ticket, phase });
+    if (ok === false) {
+      log.warn({ ticket, phase }, "unstuck-act: clearStall returned false (CTL-1219)");
+    }
+  };
+}
+
+// ─── Phase 2: source-conflict act seam (force-push-with-lease, clean only) ────
+//
+// Force-pushes the feature branch ONLY when the LIVE worktree passes the full
+// three-gate classifyCleanRebaseForcePush safety check at act time (clean tree,
+// ours-only commits, strict descendant of origin/main). The decision is re-run
+// against the LIVE tree here (not stale census evidence) — the whole point of
+// --force-with-lease. THROWS on any failed gate or a non-zero push exit so the
+// driver records report.failed (and never marks success / emits pushed). Reuses
+// collectForcePushCandidates' probe shape so the gate stays single-sourced.
+export function buildSourceConflictActSeam(deps = {}) {
+  const {
+    runGit = defaultRunGit,
+    writeMarker = defaultWriteMarker,
+    markerExists = defaultMarkerExists,
+    orchDir = null,
+  } = deps;
+
+  return function sourceConflictActSeam(candidate, _decision) {
+    const { ticket, phase, worktreePath } = candidate;
+    if (!worktreePath) throw new Error(`source-conflict: no-worktree (${ticket})`);
+
+    const marker = markerPath(orchDir, ticket, phase, "force-pushed");
+    if (markerExists(marker)) return; // idempotent — already pushed this lifetime.
+
+    // Re-run the three git probes against the LIVE tree (mirrors
+    // collectForcePushCandidates probe shape — single-sourced gate logic).
+    let porcelain = null;
+    const pRes = runGit(["-C", worktreePath, "status", "--porcelain"]);
+    if (!pRes?.error && (pRes?.status ?? 1) === 0) porcelain = pRes.stdout ?? "";
+
+    let commitSubjects = [];
+    const lRes = runGit([
+      "-C",
+      worktreePath,
+      "log",
+      "--no-merges",
+      "--format=%s",
+      "origin/main..HEAD",
+    ]);
+    if (!lRes?.error && (lRes?.status ?? 1) === 0) {
+      commitSubjects = (lRes.stdout ?? "").split("\n").filter((s) => s.trim().length > 0);
+    }
+
+    const mRes = runGit(["-C", worktreePath, "merge-base", "--is-ancestor", "origin/main", "HEAD"]);
+    const headIsDescendant = !mRes?.error && (mRes?.status ?? 1) === 0;
+
+    const decision = classifyCleanRebaseForcePush({
+      stalledReason: "source_conflict_ctl708_unavailable",
+      ticket,
+      porcelain,
+      commitSubjects,
+      headIsDescendant,
+      liveSessionInWorktree: false,
+      linearTerminal: false,
+      alreadyPushed: false,
+    });
+    if (decision.action !== "force-push") {
+      throw new Error(`source-conflict: ${decision.reason ?? "gate-failed"} (${ticket})`);
+    }
+
+    // Disable hooks for the push (mechanical action; no local hook side-effects).
+    const push = runGit([
+      "-C",
+      worktreePath,
+      "-c",
+      "core.hooksPath=/dev/null",
+      "push",
+      "--force-with-lease",
+      "-u",
+      "origin",
+      "HEAD",
+    ]);
+    if (push?.error || (push?.status ?? 1) !== 0) {
+      throw new Error(
+        `source-conflict: push-failed (${ticket}): ${push?.stderr ?? push?.error?.message ?? "non-zero"}`
+      );
+    }
+
+    writeMarker(marker);
+  };
+}
+
+// ─── Phase 3: orphan-stale act seam (emit synthetic phase-complete if merged) ──
+//
+// Emits a synthetic phase.<phase>.complete.<ticket> event so teardown advances,
+// ONLY when classifyOrphanMergedReconcile confirms the orphan-merge precondition
+// against LIVE evidence (PR MERGED, bg job dead, signal stale past the cutoff, no
+// terminal-done marker). THROWS on any failed gate or a failed emit so the driver
+// records report.failed (and never marks success). Idempotent via the
+// .unstuck-orphan-merge-<phase>.applied marker.
+export function buildOrphanStaleActSeam(deps = {}) {
+  const {
+    resolvePrState = () => null,
+    jobLifecycle = () => false,
+    emitPhaseComplete = (a) => defaultEmitPhaseComplete({ ...a, orchDir }),
+    markerExists = defaultMarkerExists,
+    writeMarker = defaultWriteMarker,
+    nowMs = () => Date.now(),
+    orchDir = null,
+  } = deps;
+
+  return function orphanStaleActSeam(candidate, _decision) {
+    const { ticket, phase, signal } = candidate;
+
+    const marker = markerPath(orchDir, ticket, phase, "orphan-merge");
+    if (markerExists(marker)) return; // idempotent — already emitted this lifetime.
+
+    const terminalDoneApplied = markerExists(
+      join(orchDir ?? ".", "workers", ticket, ".terminal-done.applied")
+    );
+
+    // Resolve LIVE evidence the way defaultCollectOrphanMergedCandidates does.
+    let prState = null;
+    try {
+      const r = resolvePrState(ticket);
+      prState = r && typeof r.then === "function" ? null : r;
+    } catch {
+      prState = null;
+    }
+
+    const bgJobId = signal?.bg_job_id ?? null;
+    let bgJobAlive = false;
+    try {
+      bgJobAlive = bgJobId != null ? Boolean(jobLifecycle(bgJobId)) : false;
+    } catch {
+      bgJobAlive = false;
+    }
+
+    let signalUpdatedAt = null;
+    try {
+      if (signal?.updatedAt) signalUpdatedAt = new Date(signal.updatedAt).getTime();
+    } catch {
+      signalUpdatedAt = null;
+    }
+
+    const decision = classifyOrphanMergedReconcile({
+      ticket,
+      phase,
+      prState,
+      bgJobAlive,
+      signalUpdatedAt,
+      nowMs: nowMs(),
+      alreadyEmitted: false, // marker already gated above
+      terminalDoneApplied,
+      linearTerminal: candidate.linearTerminal ?? false,
+    });
+    if (decision.action !== "emit-complete") {
+      throw new Error(`orphan-stale: ${decision.reason ?? "gate-failed"} (${ticket})`);
+    }
+
+    const ok = emitPhaseComplete({ ticket, phase });
+    if (ok === false) {
+      throw new Error(`orphan-stale: emit-failed (${ticket})`);
+    }
+
+    writeMarker(marker);
+  };
+}
+
+// ─── Phase 4: stale-label act seam (clear the stale attention label) ──────────
+//
+// Removes the stale attention label from a terminal ticket. Thin wrapper over
+// clearStalledLabel (label-guard.mjs), which is best-effort + never throws — so
+// the seam must inspect the OUTCOME and THROW on non-removal to satisfy the
+// driver's fail-loud contract (report.failed → no cleared.stale-label event).
+// Handles: the CTL-1078 back-off short-circuit (no real removal attempted), a
+// removeLabel removed:false / thrown result, and a missing decision.label.
+export function buildStaleLabelActSeam(deps = {}) {
+  const {
+    writeStatus = { removeLabel: () => ({ removed: true }) },
+    orchDir = null,
+    nowMs = () => Date.now(),
+    // injectable for the back-off test; defaults to the real label-guard primitive.
+    inRemovalBackoff: backoff = inRemovalBackoff,
+    clearStalledLabel: clearLabel = clearStalledLabel,
+  } = deps;
+
+  return function staleLabelActSeam(candidate, decision) {
+    const { ticket } = candidate;
+    const label = decision?.label;
+    if (!label) throw new Error(`stale-label: no-label (${ticket})`);
+
+    // CTL-1078 back-off: clearStalledLabel short-circuits silently in back-off,
+    // which would otherwise look like success. Detect it up front and fail loud.
+    if (backoff(orchDir, ticket, label, nowMs())) {
+      throw new Error(`stale-label: in-backoff (${ticket}/${label})`);
+    }
+
+    let removed = false;
+    clearLabel(orchDir, ticket, label, writeStatus, {
+      onRemoved: () => {
+        removed = true;
+      },
+      now: nowMs,
+    });
+    // clearStalledLabel runs onRemoved synchronously only for a confirmed removal.
+    if (!removed) {
+      throw new Error(`stale-label: not-removed (${ticket}/${label})`);
+    }
+  };
+}
+
+// ─── buildUnstuckActSeams — registry factory ──────────────────────────────────
+//
+// Returns the frozen { category → seam fn } registry the scheduler passes to
+// runUnstuckSweepPass as actByCategory. Keys are EXACTLY the four enforceable
+// category strings (the escalate-only remediate-cap/unknown route to the separate
+// escalate seam, NOT this registry). Every seam is pure-cored + injectable.
+export function buildUnstuckActSeams(deps = {}) {
+  return Object.freeze({
+    "dirty-tree": buildDirtyTreeActSeam(deps),
+    "source-conflict": buildSourceConflictActSeam(deps),
+    "orphan-stale": buildOrphanStaleActSeam(deps),
+    "stale-label": buildStaleLabelActSeam(deps),
+  });
+}

--- a/plugins/dev/scripts/execution-core/unstuck-act-seams.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-act-seams.test.mjs
@@ -1,0 +1,652 @@
+// unstuck-act-seams.test.mjs — CTL-1219 unit tests for the four deterministic
+// act seams + the buildUnstuckActSeams() registry factory.
+//
+// Every seam is driven by injected stub deps — zero shelling out, zero real git,
+// zero real Linear, no tmp dirs for the pure seams. Mirrors the stub-dep idiom of
+// dirty-tree-classifier.test.mjs / catB-force-with-lease.test.mjs.
+
+import { describe, test, expect } from "bun:test";
+import {
+  buildUnstuckActSeams,
+  buildDirtyTreeActSeam,
+  buildSourceConflictActSeam,
+  buildOrphanStaleActSeam,
+  buildStaleLabelActSeam,
+} from "./unstuck-act-seams.mjs";
+import { STALL_CATEGORY_MAP } from "./unstuck-sweep.mjs";
+import { STALE_WORKER_CUTOFF_MS } from "./unstuck-orphan-merge.mjs";
+
+// makeStubDeps — single shared stub-dep factory (plan §"Test fixtures").
+// Each test overrides only the deps it exercises. Defaults describe the
+// "would succeed" happy path; tests flip specific deps to drive failures.
+function makeStubDeps(overrides = {}) {
+  return {
+    // git seam: (args) → {status, stdout, stderr}. Override per-test.
+    runGit: () => ({ status: 0, stdout: "", stderr: "" }),
+    // porcelain reader: (worktreePath) → string ("" = clean).
+    readPorcelain: () => "",
+    unlink: () => {},
+    writeMarker: () => {},
+    markerExists: () => false,
+    clearStall: () => true,
+    // label writeStatus: removeLabel(ticket, label) → {removed:bool, reason?}.
+    writeStatus: { removeLabel: () => ({ removed: true }) },
+    resolvePrState: () => "MERGED",
+    jobLifecycle: () => false,
+    emitPhaseComplete: () => true,
+    inRemovalBackoff: () => false,
+    nowMs: () => Date.now(),
+    orchDir: "/tmp/orch",
+    log: { warn() {}, error() {}, info() {} },
+    ...overrides,
+  };
+}
+
+// A canonical dirty-tree candidate (driver shape from defaultCollectUnstuckCandidates).
+function dirtyTreeCandidate(overrides = {}) {
+  return {
+    ticket: "CTL-1",
+    phase: "implement",
+    signal: { phase: "implement", status: "stalled", stalledReason: "rebase_refused_dirty_tree" },
+    workerDir: "/tmp/orch/workers/CTL-1",
+    worktreePath: "/wt/CTL-1",
+    liveSessionInWorktree: false,
+    linearTerminal: false,
+    evidence: { reason: "rebase_refused_dirty_tree", ticket: "CTL-1", phase: "implement" },
+    ...overrides,
+  };
+}
+
+function sourceConflictCandidate(overrides = {}) {
+  return {
+    ticket: "CTL-2",
+    phase: "implement",
+    signal: {
+      phase: "implement",
+      status: "stalled",
+      stalledReason: "source_conflict_ctl708_unavailable",
+    },
+    workerDir: "/tmp/orch/workers/CTL-2",
+    worktreePath: "/wt/CTL-2",
+    liveSessionInWorktree: false,
+    linearTerminal: false,
+    evidence: { reason: "source_conflict_ctl708_unavailable", ticket: "CTL-2", phase: "implement" },
+    ...overrides,
+  };
+}
+
+function orphanStaleCandidate(overrides = {}) {
+  return {
+    ticket: "CTL-3",
+    phase: "monitor-merge",
+    signal: {
+      phase: "monitor-merge",
+      status: "failed",
+      failureReason: "orphan-sweep-stale",
+      bg_job_id: "job-abc",
+      updatedAt: "2020-01-01T00:00:00Z",
+    },
+    workerDir: "/tmp/orch/workers/CTL-3",
+    worktreePath: "/wt/CTL-3",
+    liveSessionInWorktree: false,
+    linearTerminal: false,
+    evidence: { reason: "orphan-sweep-stale", ticket: "CTL-3", phase: "monitor-merge" },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 — dirty-tree act seam
+// ---------------------------------------------------------------------------
+describe("buildDirtyTreeActSeam (CTL-1219)", () => {
+  test("clears each machine-local noise path from the worktree then re-arms the worker", () => {
+    const gitCalls = [];
+    const cleared = [];
+    // porcelain holds ONLY noise: a tracked .catalyst/config.json + a trunk dir.
+    let porcelainReads = 0;
+    const seam = buildDirtyTreeActSeam(
+      makeStubDeps({
+        readPorcelain: () => {
+          porcelainReads++;
+          // first read returns noise; second read (post-clear) is clean.
+          if (porcelainReads === 1) return " M .catalyst/config.json\n?? .trunk/out/x";
+          return "";
+        },
+        runGit: (args) => {
+          gitCalls.push(args);
+          return { status: 0, stdout: "", stderr: "" };
+        },
+        unlink: (p) => {
+          cleared.push({ unlink: p });
+        },
+        clearStall: (arg) => {
+          cleared.push({ clearStall: arg });
+          return true;
+        },
+      })
+    );
+    expect(() =>
+      seam(dirtyTreeCandidate(), { category: "dirty-tree", action: "clear-noise-and-retry" })
+    ).not.toThrow();
+    // at least one git invocation against the worktree to clear the tracked noise
+    expect(gitCalls.some((a) => a.includes("-C") && a.includes("/wt/CTL-1"))).toBe(true);
+    // clearStall called exactly once with {ticket, phase}
+    const clearStallCalls = cleared.filter((c) => c.clearStall);
+    expect(clearStallCalls).toHaveLength(1);
+    expect(clearStallCalls[0].clearStall).toEqual({ ticket: "CTL-1", phase: "implement" });
+  });
+
+  test("throws when the worktree is still dirty with REAL work (fail-closed)", () => {
+    const cleared = [];
+    const seam = buildDirtyTreeActSeam(
+      makeStubDeps({
+        // real dirt present → must never clear/re-arm.
+        readPorcelain: () => " M src/app.ts",
+        clearStall: () => {
+          cleared.push(1);
+          return true;
+        },
+      })
+    );
+    expect(() =>
+      seam(dirtyTreeCandidate(), { category: "dirty-tree", action: "clear-noise-and-retry" })
+    ).toThrow(/real-dirt/);
+    expect(cleared).toHaveLength(0);
+  });
+
+  test("throws when worktreePath is null", () => {
+    const seam = buildDirtyTreeActSeam(makeStubDeps());
+    expect(() =>
+      seam(dirtyTreeCandidate({ worktreePath: null }), {
+        category: "dirty-tree",
+        action: "clear-noise-and-retry",
+      })
+    ).toThrow(/no-worktree/);
+  });
+
+  test("idempotent — marker present → no-op (no git, no clearStall)", () => {
+    const gitCalls = [];
+    const cleared = [];
+    const seam = buildDirtyTreeActSeam(
+      makeStubDeps({
+        markerExists: () => true,
+        runGit: (a) => {
+          gitCalls.push(a);
+          return { status: 0 };
+        },
+        clearStall: () => {
+          cleared.push(1);
+          return true;
+        },
+      })
+    );
+    expect(() =>
+      seam(dirtyTreeCandidate(), { category: "dirty-tree", action: "clear-noise-and-retry" })
+    ).not.toThrow();
+    expect(gitCalls).toHaveLength(0);
+    expect(cleared).toHaveLength(0);
+  });
+
+  test("writes the idempotency marker after a successful clear", () => {
+    const markers = [];
+    let porcelainReads = 0;
+    const seam = buildDirtyTreeActSeam(
+      makeStubDeps({
+        readPorcelain: () => (++porcelainReads === 1 ? " M .catalyst/config.json" : ""),
+        writeMarker: (p) => {
+          markers.push(p);
+        },
+      })
+    );
+    seam(dirtyTreeCandidate(), { category: "dirty-tree", action: "clear-noise-and-retry" });
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toContain(".unstuck-cleared-implement.applied");
+  });
+
+  test("re-uses filterMachineLocalDirt: only noise + deleted node_modules are cleared; a real line throws", () => {
+    const seam = buildDirtyTreeActSeam(
+      makeStubDeps({
+        // mixes noise (.trunk), node_modules deletion, and a REAL change → throws.
+        readPorcelain: () => "?? .trunk/out/x\n D node_modules/foo\n M src/real.ts",
+      })
+    );
+    expect(() =>
+      seam(dirtyTreeCandidate(), { category: "dirty-tree", action: "clear-noise-and-retry" })
+    ).toThrow(/real-dirt/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 2 — source-conflict act seam (force-push-with-lease, clean only)
+// ---------------------------------------------------------------------------
+describe("buildSourceConflictActSeam (CTL-1219)", () => {
+  // git probe responder that simulates a CLEAN, rebased, ours-only branch.
+  function cleanBranchGit(pushResult = { status: 0, stdout: "", stderr: "" }) {
+    return (args) => {
+      const a = args.join(" ");
+      if (a.includes("status --porcelain")) return { status: 0, stdout: "", stderr: "" };
+      if (a.includes("log") && a.includes("origin/main..HEAD"))
+        return { status: 0, stdout: "CTL-2: fix the thing\n", stderr: "" };
+      if (a.includes("merge-base") && a.includes("--is-ancestor"))
+        return { status: 0, stdout: "", stderr: "" };
+      if (a.includes("push")) return pushResult;
+      return { status: 0, stdout: "", stderr: "" };
+    };
+  }
+
+  test("force-pushes with --force-with-lease when worktree is clean + ours + descends origin/main", () => {
+    const gitCalls = [];
+    const seam = buildSourceConflictActSeam(
+      makeStubDeps({
+        runGit: (args) => {
+          gitCalls.push(args);
+          return cleanBranchGit()(args);
+        },
+      })
+    );
+    expect(() =>
+      seam(sourceConflictCandidate(), {
+        category: "source-conflict",
+        action: "force-push-if-clean",
+      })
+    ).not.toThrow();
+    const pushCall = gitCalls.find((a) => a.includes("push"));
+    expect(pushCall).toBeDefined();
+    expect(pushCall).toContain("--force-with-lease");
+  });
+
+  test("throws (no push) when the worktree is dirty with real work", () => {
+    const gitCalls = [];
+    const seam = buildSourceConflictActSeam(
+      makeStubDeps({
+        runGit: (args) => {
+          gitCalls.push(args);
+          if (args.join(" ").includes("status --porcelain"))
+            return { status: 0, stdout: " M src/real.ts", stderr: "" };
+          return { status: 0, stdout: "", stderr: "" };
+        },
+      })
+    );
+    expect(() =>
+      seam(sourceConflictCandidate(), {
+        category: "source-conflict",
+        action: "force-push-if-clean",
+      })
+    ).toThrow(/dirty-worktree/);
+    expect(gitCalls.some((a) => a.includes("push"))).toBe(false);
+  });
+
+  test("throws when a foreign commit is present (no push)", () => {
+    const gitCalls = [];
+    const seam = buildSourceConflictActSeam(
+      makeStubDeps({
+        runGit: (args) => {
+          gitCalls.push(args);
+          const a = args.join(" ");
+          if (a.includes("status --porcelain")) return { status: 0, stdout: "", stderr: "" };
+          if (a.includes("log") && a.includes("origin/main..HEAD"))
+            return { status: 0, stdout: "CTL-2: ours\nCTL-999: foreign\n", stderr: "" };
+          if (a.includes("merge-base")) return { status: 0 };
+          return { status: 0 };
+        },
+      })
+    );
+    expect(() =>
+      seam(sourceConflictCandidate(), {
+        category: "source-conflict",
+        action: "force-push-if-clean",
+      })
+    ).toThrow(/foreign-commits/);
+    expect(gitCalls.some((a) => a.includes("push"))).toBe(false);
+  });
+
+  test("throws when HEAD is not a strict descendant of origin/main (no push)", () => {
+    const gitCalls = [];
+    const seam = buildSourceConflictActSeam(
+      makeStubDeps({
+        runGit: (args) => {
+          gitCalls.push(args);
+          const a = args.join(" ");
+          if (a.includes("status --porcelain")) return { status: 0, stdout: "", stderr: "" };
+          if (a.includes("log") && a.includes("origin/main..HEAD"))
+            return { status: 0, stdout: "CTL-2: ours\n", stderr: "" };
+          if (a.includes("merge-base") && a.includes("--is-ancestor")) return { status: 1 }; // not ancestor
+          return { status: 0 };
+        },
+      })
+    );
+    expect(() =>
+      seam(sourceConflictCandidate(), {
+        category: "source-conflict",
+        action: "force-push-if-clean",
+      })
+    ).toThrow(/not-descendant/);
+    expect(gitCalls.some((a) => a.includes("push"))).toBe(false);
+  });
+
+  test("throws when the push command itself fails (non-zero git exit)", () => {
+    const seam = buildSourceConflictActSeam(
+      makeStubDeps({
+        runGit: cleanBranchGit({ status: 1, stdout: "", stderr: "! [rejected]" }),
+      })
+    );
+    expect(() =>
+      seam(sourceConflictCandidate(), {
+        category: "source-conflict",
+        action: "force-push-if-clean",
+      })
+    ).toThrow(/push-failed/);
+  });
+
+  test("idempotent via the force-pushed marker — early no-op, push never called", () => {
+    const gitCalls = [];
+    const seam = buildSourceConflictActSeam(
+      makeStubDeps({
+        markerExists: () => true,
+        runGit: (a) => {
+          gitCalls.push(a);
+          return { status: 0 };
+        },
+      })
+    );
+    expect(() =>
+      seam(sourceConflictCandidate(), {
+        category: "source-conflict",
+        action: "force-push-if-clean",
+      })
+    ).not.toThrow();
+    expect(gitCalls.some((a) => a.includes("push"))).toBe(false);
+  });
+
+  test("writes the marker after a successful push", () => {
+    const markers = [];
+    const seam = buildSourceConflictActSeam(
+      makeStubDeps({
+        runGit: cleanBranchGit(),
+        writeMarker: (p) => {
+          markers.push(p);
+        },
+      })
+    );
+    seam(sourceConflictCandidate(), { category: "source-conflict", action: "force-push-if-clean" });
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toContain(".unstuck-force-pushed-implement.applied");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 3 — orphan-stale act seam (emit synthetic phase-complete if merged)
+// ---------------------------------------------------------------------------
+describe("buildOrphanStaleActSeam (CTL-1219)", () => {
+  test("emits a synthetic phase.<phase>.complete.<ticket> when the orphan-merge precondition holds", () => {
+    const emits = [];
+    const seam = buildOrphanStaleActSeam(
+      makeStubDeps({
+        resolvePrState: () => "MERGED",
+        jobLifecycle: () => false,
+        nowMs: () => Date.parse("2020-01-01T01:00:00Z"), // 1h after a stale signal
+        emitPhaseComplete: (arg) => {
+          emits.push(arg);
+          return true;
+        },
+      })
+    );
+    expect(() =>
+      seam(orphanStaleCandidate(), {
+        category: "orphan-stale",
+        action: "emit-phase-complete-if-merged",
+      })
+    ).not.toThrow();
+    expect(emits).toHaveLength(1);
+    expect(emits[0]).toEqual({ ticket: "CTL-3", phase: "monitor-merge" });
+  });
+
+  test("throws when the PR is not MERGED (no emit)", () => {
+    const emits = [];
+    const seam = buildOrphanStaleActSeam(
+      makeStubDeps({
+        resolvePrState: () => "OPEN",
+        emitPhaseComplete: (a) => {
+          emits.push(a);
+          return true;
+        },
+      })
+    );
+    expect(() =>
+      seam(orphanStaleCandidate(), {
+        category: "orphan-stale",
+        action: "emit-phase-complete-if-merged",
+      })
+    ).toThrow(/pr-not-merged/);
+    expect(emits).toHaveLength(0);
+  });
+
+  test("throws when the bg job is still alive (no emit)", () => {
+    const emits = [];
+    const seam = buildOrphanStaleActSeam(
+      makeStubDeps({
+        jobLifecycle: () => true,
+        emitPhaseComplete: (a) => {
+          emits.push(a);
+          return true;
+        },
+      })
+    );
+    expect(() =>
+      seam(orphanStaleCandidate(), {
+        category: "orphan-stale",
+        action: "emit-phase-complete-if-merged",
+      })
+    ).toThrow(/bg-job-alive/);
+    expect(emits).toHaveLength(0);
+  });
+
+  test("throws when the signal is fresh (within STALE_WORKER_CUTOFF_MS) (no emit)", () => {
+    const emits = [];
+    const updatedAt = "2020-01-01T00:00:00Z";
+    const seam = buildOrphanStaleActSeam(
+      makeStubDeps({
+        nowMs: () => Date.parse(updatedAt) + STALE_WORKER_CUTOFF_MS - 1000, // still fresh
+        emitPhaseComplete: (a) => {
+          emits.push(a);
+          return true;
+        },
+      })
+    );
+    expect(() =>
+      seam(
+        orphanStaleCandidate({
+          signal: { phase: "monitor-merge", bg_job_id: "job-abc", updatedAt },
+        }),
+        { category: "orphan-stale", action: "emit-phase-complete-if-merged" }
+      )
+    ).toThrow(/signal-fresh/);
+    expect(emits).toHaveLength(0);
+  });
+
+  test("throws when .terminal-done.applied is present (teardown owns it; no emit)", () => {
+    const emits = [];
+    const seam = buildOrphanStaleActSeam(
+      makeStubDeps({
+        // markerExists returns true ONLY for the terminal-done marker.
+        markerExists: (p) => /\.terminal-done\.applied$/.test(p),
+        emitPhaseComplete: (a) => {
+          emits.push(a);
+          return true;
+        },
+      })
+    );
+    expect(() =>
+      seam(orphanStaleCandidate(), {
+        category: "orphan-stale",
+        action: "emit-phase-complete-if-merged",
+      })
+    ).toThrow(/terminal-done/);
+    expect(emits).toHaveLength(0);
+  });
+
+  test("idempotent via the orphan-merge marker — no-op, no emit", () => {
+    const emits = [];
+    const seam = buildOrphanStaleActSeam(
+      makeStubDeps({
+        // markerExists true ONLY for the unstuck-orphan-merge marker.
+        markerExists: (p) => /\.unstuck-orphan-merge-/.test(p),
+        emitPhaseComplete: (a) => {
+          emits.push(a);
+          return true;
+        },
+      })
+    );
+    expect(() =>
+      seam(orphanStaleCandidate(), {
+        category: "orphan-stale",
+        action: "emit-phase-complete-if-merged",
+      })
+    ).not.toThrow();
+    expect(emits).toHaveLength(0);
+  });
+
+  test("throws when emitPhaseComplete itself fails (no marker written)", () => {
+    const markers = [];
+    const seam = buildOrphanStaleActSeam(
+      makeStubDeps({
+        nowMs: () => Date.parse("2020-01-01T01:00:00Z"),
+        emitPhaseComplete: () => false, // emit failed
+        writeMarker: (p) => {
+          markers.push(p);
+        },
+      })
+    );
+    expect(() =>
+      seam(orphanStaleCandidate(), {
+        category: "orphan-stale",
+        action: "emit-phase-complete-if-merged",
+      })
+    ).toThrow(/emit-failed/);
+    expect(markers).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 4 — stale-label act seam (clear the stale attention label)
+// ---------------------------------------------------------------------------
+describe("buildStaleLabelActSeam (CTL-1219)", () => {
+  function staleLabelCandidate(overrides = {}) {
+    return {
+      ticket: "CTL-4",
+      phase: "none",
+      evidence: {
+        ticket: "CTL-4",
+        phase: "none",
+        linearState: "Done",
+        attentionLabels: ["needs-human"],
+      },
+      ...overrides,
+    };
+  }
+
+  test("removes the stale attention label from a terminal ticket", () => {
+    const removed = [];
+    const seam = buildStaleLabelActSeam(
+      makeStubDeps({
+        writeStatus: {
+          removeLabel: (t, l) => {
+            removed.push({ t, l });
+            return { removed: true };
+          },
+        },
+      })
+    );
+    expect(() =>
+      seam(staleLabelCandidate(), {
+        category: "stale-label",
+        action: "clear-label",
+        label: "needs-human",
+      })
+    ).not.toThrow();
+    expect(removed).toHaveLength(1);
+    expect(removed[0]).toEqual({ t: "CTL-4", l: "needs-human" });
+  });
+
+  test("throws when removeLabel reports failure (driver → report.failed)", () => {
+    const seam = buildStaleLabelActSeam(
+      makeStubDeps({
+        writeStatus: { removeLabel: () => ({ removed: false, reason: "auth-failed" }) },
+      })
+    );
+    expect(() =>
+      seam(staleLabelCandidate(), {
+        category: "stale-label",
+        action: "clear-label",
+        label: "needs-human",
+      })
+    ).toThrow(/not-removed/);
+  });
+
+  test("respects the CTL-1078 removal back-off — throws in-backoff rather than reporting false success", () => {
+    const removed = [];
+    const seam = buildStaleLabelActSeam(
+      makeStubDeps({
+        inRemovalBackoff: () => true,
+        writeStatus: {
+          removeLabel: (t, l) => {
+            removed.push({ t, l });
+            return { removed: true };
+          },
+        },
+      })
+    );
+    expect(() =>
+      seam(staleLabelCandidate(), {
+        category: "stale-label",
+        action: "clear-label",
+        label: "needs-human",
+      })
+    ).toThrow(/in-backoff/);
+    // back-off short-circuits before any real removal attempt
+    expect(removed).toHaveLength(0);
+  });
+
+  test("throws when the decision carries no label (defensive)", () => {
+    const seam = buildStaleLabelActSeam(makeStubDeps());
+    expect(() =>
+      seam(staleLabelCandidate(), { category: "stale-label", action: "clear-label" })
+    ).toThrow(/no-label/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 5 — buildUnstuckActSeams registry factory
+// ---------------------------------------------------------------------------
+describe("buildUnstuckActSeams — registry factory (CTL-1219)", () => {
+  test("returns an object keyed by exactly the four enforceable category strings", () => {
+    const seams = buildUnstuckActSeams(makeStubDeps());
+    expect(Object.keys(seams).sort()).toEqual([
+      "dirty-tree",
+      "orphan-stale",
+      "source-conflict",
+      "stale-label",
+    ]);
+  });
+
+  test("every value is a function of arity 2 (candidate, decision)", () => {
+    const seams = buildUnstuckActSeams(makeStubDeps());
+    for (const key of Object.keys(seams)) {
+      expect(typeof seams[key]).toBe("function");
+      expect(seams[key].length).toBe(2);
+    }
+  });
+
+  test("keys cover every non-escalate category in STALL_CATEGORY_MAP", () => {
+    const seams = buildUnstuckActSeams(makeStubDeps());
+    for (const { category, action } of Object.values(STALL_CATEGORY_MAP)) {
+      if (action === "escalate") continue; // remediate-cap/unknown route to escalate, NOT the registry
+      expect(Object.keys(seams)).toContain(category);
+    }
+  });
+
+  test("the registry object is frozen (no accidental mutation of wired seams)", () => {
+    const seams = buildUnstuckActSeams(makeStubDeps());
+    expect(Object.isFrozen(seams)).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
@@ -15,6 +15,7 @@ import {
   defaultPostUnstuckComment,
   emitUnstuckEvent,
 } from "./unstuck-sweep.mjs";
+import { buildUnstuckActSeams } from "./unstuck-act-seams.mjs";
 
 // ---------------------------------------------------------------------------
 // classifyStalledTicket — pure top-level router (CTL-1064)
@@ -551,5 +552,205 @@ describe("buildAuditComment — three-section assembler (CTL-1064)", () => {
   test("falls back to _unavailable_ for missing sections", () => {
     const out = buildAuditComment({});
     expect(out.match(/_unavailable_/g)).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CTL-1219 — the wired act-seam registry plugs into the real driver
+// ---------------------------------------------------------------------------
+describe("CTL-1219 — buildUnstuckActSeams wired into runUnstuckSweepPass", () => {
+  // candidate builders with the driver shape (defaultCollectUnstuckCandidates).
+  function dirtyTreeCandidate() {
+    return {
+      ticket: "CTL-1",
+      phase: "implement",
+      signal: { phase: "implement", status: "stalled", stalledReason: "rebase_refused_dirty_tree" },
+      worktreePath: "/wt/CTL-1",
+      evidence: { reason: "rebase_refused_dirty_tree", ticket: "CTL-1", phase: "implement", liveSessionInWorktree: false, linearTerminal: false },
+    };
+  }
+  function sourceConflictCandidate(porcelainDirty = false) {
+    return {
+      ticket: "CTL-2",
+      phase: "implement",
+      signal: { phase: "implement", status: "stalled", stalledReason: "source_conflict_ctl708_unavailable" },
+      worktreePath: "/wt/CTL-2",
+      evidence: { reason: "source_conflict_ctl708_unavailable", ticket: "CTL-2", phase: "implement", liveSessionInWorktree: false, linearTerminal: false, _dirty: porcelainDirty },
+    };
+  }
+  function orphanStaleCandidate() {
+    return {
+      ticket: "CTL-3",
+      phase: "monitor-merge",
+      signal: { phase: "monitor-merge", status: "failed", failureReason: "orphan-sweep-stale", bg_job_id: "job-abc", updatedAt: "2020-01-01T00:00:00Z" },
+      worktreePath: "/wt/CTL-3",
+      evidence: { reason: "orphan-sweep-stale", ticket: "CTL-3", phase: "monitor-merge", liveSessionInWorktree: false, linearTerminal: false },
+    };
+  }
+  function remediateCapCandidate() {
+    return {
+      ticket: "CTL-9",
+      phase: "verify",
+      evidence: { reason: "remediate-cycle-cap-exhausted", ticket: "CTL-9", phase: "verify", liveSessionInWorktree: false, linearTerminal: false },
+    };
+  }
+
+  // a clean rebased branch git responder (for source-conflict success).
+  function cleanBranchGit(args) {
+    const a = args.join(" ");
+    if (a.includes("status --porcelain")) return { status: 0, stdout: "", stderr: "" };
+    if (a.includes("log") && a.includes("origin/main..HEAD")) return { status: 0, stdout: "CTL-2: fix\n", stderr: "" };
+    if (a.includes("merge-base") && a.includes("--is-ancestor")) return { status: 0, stdout: "", stderr: "" };
+    if (a.includes("push")) return { status: 0, stdout: "", stderr: "" };
+    return { status: 0, stdout: "", stderr: "" };
+  }
+
+  test("enforce + dirty-tree + wired registry → fires unstuck.cleared.noise + records intent", () => {
+    const emitted = [];
+    const intents = [];
+    let porcelainReads = 0;
+    const registry = buildUnstuckActSeams({
+      orchDir: "/tmp/orch",
+      markerExists: () => false,
+      writeMarker: () => {},
+      runGit: () => ({ status: 0, stdout: "", stderr: "" }),
+      readPorcelain: () => (++porcelainReads === 1 ? " M .catalyst/config.json" : ""),
+      clearStall: () => true,
+    });
+    const report = runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [dirtyTreeCandidate()],
+      actByCategory: registry,
+      emit: (type) => { emitted.push(type); },
+      recordIntent: (kind, subject) => { intents.push({ kind, subject }); },
+      postComment: () => {},
+      isIntentEffective: () => false,
+    });
+    expect(emitted).toContain("unstuck.cleared.noise");
+    expect(report.acted).toHaveLength(1);
+    expect(intents).toHaveLength(1);
+    expect(intents[0]).toEqual({ kind: UNSTUCK_SWEEP_INTENT_KIND, subject: "CTL-1/implement" });
+  });
+
+  test("enforce + source-conflict on a CLEAN rebased branch → fires unstuck.pushed.force-with-lease", () => {
+    const emitted = [];
+    const registry = buildUnstuckActSeams({
+      orchDir: "/tmp/orch",
+      markerExists: () => false,
+      writeMarker: () => {},
+      runGit: cleanBranchGit,
+    });
+    const report = runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [sourceConflictCandidate()],
+      actByCategory: registry,
+      emit: (type) => { emitted.push(type); },
+      isIntentEffective: () => false,
+    });
+    expect(emitted).toContain("unstuck.pushed.force-with-lease");
+    expect(report.acted).toHaveLength(1);
+  });
+
+  test("enforce + source-conflict on a DIRTY branch → seam throws → report.failed, NO push event", () => {
+    const emitted = [];
+    const registry = buildUnstuckActSeams({
+      orchDir: "/tmp/orch",
+      markerExists: () => false,
+      writeMarker: () => {},
+      runGit: (args) => {
+        if (args.join(" ").includes("status --porcelain")) return { status: 0, stdout: " M src/real.ts", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+    const report = runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [sourceConflictCandidate(true)],
+      actByCategory: registry,
+      emit: (type) => { emitted.push(type); },
+      isIntentEffective: () => false,
+    });
+    expect(emitted).not.toContain("unstuck.pushed.force-with-lease");
+    expect(report.acted).toHaveLength(0);
+    expect(report.failed).toHaveLength(1);
+    expect(report.failed[0].category).toBe("source-conflict");
+  });
+
+  test("enforce + orphan-stale MERGED → fires unstuck.emitted.phase-complete", () => {
+    const emitted = [];
+    const phaseCompletes = [];
+    const registry = buildUnstuckActSeams({
+      orchDir: "/tmp/orch",
+      markerExists: () => false,
+      writeMarker: () => {},
+      resolvePrState: () => "MERGED",
+      jobLifecycle: () => false,
+      nowMs: () => Date.parse("2020-01-01T01:00:00Z"),
+      emitPhaseComplete: (a) => { phaseCompletes.push(a); return true; },
+    });
+    const report = runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [orphanStaleCandidate()],
+      actByCategory: registry,
+      emit: (type) => { emitted.push(type); },
+      isIntentEffective: () => false,
+    });
+    expect(emitted).toContain("unstuck.emitted.phase-complete");
+    expect(report.acted).toHaveLength(1);
+    expect(phaseCompletes).toEqual([{ ticket: "CTL-3", phase: "monitor-merge" }]);
+  });
+
+  test("shadow + any wired category → emits ONLY the would-* twin; no seam fn invoked", () => {
+    const emitted = [];
+    const called = [];
+    // a registry whose dirty-tree fn records its invocation.
+    const registry = {
+      ...buildUnstuckActSeams({ orchDir: "/tmp/orch" }),
+      "dirty-tree": () => { called.push("dirty-tree"); },
+    };
+    runUnstuckSweepPass({
+      mode: "shadow",
+      collectCandidates: () => [dirtyTreeCandidate()],
+      actByCategory: registry,
+      emit: (type) => { emitted.push(type); },
+    });
+    expect(called).toHaveLength(0);
+    expect(emitted).toContain("unstuck.would.clear-noise");
+    expect(emitted).not.toContain("unstuck.cleared.noise");
+  });
+
+  test("unknown / remediate-cap → escalate seam (NOT the registry); registry fns never called", () => {
+    const escalated = [];
+    const called = [];
+    const registry = {
+      "dirty-tree": () => { called.push(1); },
+      "source-conflict": () => { called.push(1); },
+      "orphan-stale": () => { called.push(1); },
+      "stale-label": () => { called.push(1); },
+    };
+    const report = runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [remediateCapCandidate()],
+      actByCategory: registry,
+      escalate: (c) => { escalated.push(c.ticket); },
+      emit: () => {},
+    });
+    expect(called).toHaveLength(0);
+    expect(report.escalated).toHaveLength(1);
+    expect(escalated).toContain("CTL-9");
+  });
+
+  test("off mode + wired registry → fully inert (no seam, no event)", () => {
+    const emitted = [];
+    const called = [];
+    const registry = { ...buildUnstuckActSeams({ orchDir: "/tmp/orch" }), "dirty-tree": () => { called.push(1); } };
+    const report = runUnstuckSweepPass({
+      mode: "off",
+      collectCandidates: () => [dirtyTreeCandidate()],
+      actByCategory: registry,
+      emit: (type) => { emitted.push(type); },
+    });
+    expect(called).toHaveLength(0);
+    expect(emitted).toHaveLength(0);
+    expect(report.acted).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## What

Wires unstuck-sweep's deterministic act-seams (rung 1 of the **Self-Healing Recovery & Executive Escalation** project) into the production `actByCategory` registry — which until now was a hardcoded `{}` no-op (`scheduler.mjs:5141`). With this, typed/mechanical stalls (`dirty-tree`, `source-conflict`, `orphan-stale`, `stale-label`) can self-resolve via registered seams instead of escalating to a human. This is the exact class of stall (rebase_refused_dirty_tree / source-conflict) that gummed the board on 2026-06-16.

## Changes

- **NEW `unstuck-act-seams.mjs`** — `buildUnstuckActSeams(deps)` factory returning the frozen 4-key registry. Each seam is thin orchestration over the existing pure classifiers (`filterMachineLocalDirt`, `classifyCleanRebaseForcePush`, `classifyOrphanMergedReconcile`, `clearStalledLabel`), re-validates against the live worktree at act time, fail-closed (throws on hard failure → driver records `report.failed`), idempotent via once-markers, all IO injected.
- **`scheduler.mjs`** — import + replace `actByCategory: … ?? {}` with `?? buildUnstuckActSeams({…})`; operator-override precedence preserved (existing `{}`-injecting tests stay green).

## Ships inert (safe)

Default mode stays `off` (`config.mjs:749` untouched); seams are only invoked on the `enforce` branch. Wiring the registry does **not** flip enforce — that's an operator decision per ADR-023 (shadow→enforce discipline).

## Tests

- `unstuck-act-seams`: 28 pass · `unstuck-sweep` (incl. 7 new integration): 51 pass · full unstuck/label suite: 251 pass · scheduler suites: 520 pass · lint clean.
- Full execution-core suite: 4110 pass / 4–5 fail — all pre-existing env/flaky (heartbeat `host.name=laptop`, CTL-587/716/768 timing); none import the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)