### PR TITLE
feat(dev): CTL-1225 — first-click Save + confirmation + cross-project reset (Project Settings)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/settings-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/settings-surface.test.ts
@@ -281,6 +281,27 @@ describe("CTL-1212 three-tier nav scaffolding", () => {
   });
 });
 
+// ── CTL-1225: icon picker must not swallow the first outside click (Save) ──────
+describe("CTL-1225 icon picker preserves the first outside click", () => {
+  const pickerSrc = read("components/settings/icon-picker-popover.tsx");
+  it("overrides Radix onPointerDownOutside so the paired click reaches Save", () => {
+    expect(pickerSrc).toContain("onPointerDownOutside");
+    expect(pickerSrc).toMatch(/onPointerDownOutside=\{[^}]*preventDefault\(\)/);
+  });
+  it("prevents focus theft on close so the underlying click target keeps focus", () => {
+    expect(pickerSrc).toContain("onCloseAutoFocus");
+  });
+});
+
+// ── CTL-1225: per-project pane resets on project switch ───────────────────────
+describe("CTL-1225 project pane keys on the selected project", () => {
+  it("mounts ProjectSettingsPane with a key bound to the project key", () => {
+    // Without a key, React reuses the instance across project switches and the
+    // pane shows the previous project's edited name/color/icon (stale useState).
+    expect(settingsSrc).toMatch(/<ProjectSettingsPane[\s\S]*?key=\{settingsView\.project\.key\}/);
+  });
+});
+
 // ── CTL-1212: one-click project settings affordance ───────────────────────────
 describe("CTL-1212 one-click project settings affordance", () => {
   it("each project header has a one-click settings button wired to goSettings", () => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings-surface.tsx
@@ -208,6 +208,7 @@ export function SettingsSurface() {
           {settingsView.kind === "project" ? (
             /* ── Per-project editor pane ──────────────────────────────────── */
             <ProjectSettingsPane
+              key={settingsView.project.key}
               project={settingsView.project}
               candidates={iconMap[settingsView.project.repo]?.candidates ?? []}
               onSaved={refetch}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-popover.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-popover.tsx
@@ -65,7 +65,12 @@ export function IconPickerPopover({ value, onChange, candidates, hue }: IconPick
           <ChevronDownIcon className="size-3 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-72 p-0" align="start">
+      <PopoverContent
+        className="w-72 p-0"
+        align="start"
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
         <Command>
           <CommandInput placeholder="Search icons…" className="h-9 text-xs" />
           <CommandList className="max-h-72">

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/project-settings-pane.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/project-settings-pane.test.tsx
@@ -133,6 +133,25 @@ describe("ProjectSettingsPaneContent — CTL-1212 sections", () => {
   });
 });
 
+// ── CTL-1225: save confirmation ───────────────────────────────────────────────
+describe("CTL-1225 save confirmation", () => {
+  it("renders the default Save label when idle", () => {
+    const el = ProjectSettingsPaneContent({ project, name: "", color: "auto", icon: null, candidates: [], stateMapEdits: {}, saving: false, error: null, onNameChange: () => {}, onColorChange: () => {}, onIconChange: () => {}, onStateMapChange: () => {}, onSave: () => {} });
+    expect(containsText(el, "Save")).toBe(true);
+    expect(containsText(el, "Saved")).toBe(false);
+  });
+
+  it("renders a Saved confirmation when saved is true", () => {
+    const el = ProjectSettingsPaneContent({ project, name: "", color: "auto", icon: null, candidates: [], stateMapEdits: {}, saving: false, saved: true, error: null, onNameChange: () => {}, onColorChange: () => {}, onIconChange: () => {}, onStateMapChange: () => {}, onSave: () => {} });
+    expect(containsText(el, "Saved")).toBe(true);
+  });
+
+  it("prefers the Saving label over Saved while a save is in flight", () => {
+    const el = ProjectSettingsPaneContent({ project, name: "", color: "auto", icon: null, candidates: [], stateMapEdits: {}, saving: true, saved: true, error: null, onNameChange: () => {}, onColorChange: () => {}, onIconChange: () => {}, onStateMapChange: () => {}, onSave: () => {} });
+    expect(containsText(el, "Saving")).toBe(true);
+  });
+});
+
 describe("buildProjectPatch", () => {
   const base = {
     key: "CTL", name: "Catalyst", repo: "catalyst",

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/project-settings-pane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/project-settings-pane.tsx
@@ -2,7 +2,7 @@
 //
 // Split into a pure renderer (ProjectSettingsPaneContent — tree-walk testable)
 // and a stateful wrapper (ProjectSettingsPane — the public component).
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -31,6 +31,7 @@ export interface ProjectSettingsPaneContentProps {
   icon: string | null;
   stateMapEdits: Record<string, string>;
   saving: boolean;
+  saved?: boolean;
   error: string | null;
   candidates: IconCandidate[];
   onNameChange: (v: string) => void;
@@ -41,7 +42,7 @@ export interface ProjectSettingsPaneContentProps {
 }
 
 export function ProjectSettingsPaneContent({
-  project, name, color, icon, candidates, stateMapEdits, saving, error,
+  project, name, color, icon, candidates, stateMapEdits, saving, saved = false, error,
   onNameChange, onColorChange, onIconChange, onStateMapChange, onSave,
 }: ProjectSettingsPaneContentProps) {
   // Resolve the current hue for glyph previews (the project's effective color).
@@ -188,7 +189,7 @@ export function ProjectSettingsPaneContent({
 
       <div className="flex items-center gap-3">
         <Button onClick={onSave} disabled={saving} size="sm">
-          {saving ? "Saving…" : "Save"}
+          {saving ? "Saving…" : saved ? "Saved ✓" : "Save"}
         </Button>
       </div>
     </div>
@@ -237,15 +238,26 @@ export function ProjectSettingsPane({ project, candidates = [], onSaved }: Proje
   );
 
   const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Clear the transient "Saved ✓" confirmation; cleanup covers the CTL-1225
+  // remount-on-project-switch so a pending timer never fires post-unmount.
+  useEffect(() => {
+    if (!saved) return;
+    const t = setTimeout(() => setSaved(false), 2000);
+    return () => clearTimeout(t);
+  }, [saved]);
 
   async function handleSave() {
     setSaving(true);
     setError(null);
+    setSaved(false);
     try {
       const patch = buildProjectPatch(project, { name, color, stateMapEdits, icon });
       await putProject(project.key, patch);
       await onSaved();
+      setSaved(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Save failed");
     } finally {
@@ -262,6 +274,7 @@ export function ProjectSettingsPane({ project, candidates = [], onSaved }: Proje
       candidates={candidates}
       stateMapEdits={stateMapEdits}
       saving={saving}
+      saved={saved}
       error={error}
       onNameChange={setName}
       onColorChange={setColor}


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-16T19:29:30Z -->
<!-- Last updated: 2026-06-16T19:29:30Z -->
<!-- PR: #2144 -->
<!-- Previous commits: 911296ead6664a23cb8748d3da73dd3155341489 -->

## Summary

Fixes three bugs in the Project Settings pane (orch-monitor UI):

1. **First physical click on Save was swallowed** — the Radix icon picker popover's `DismissableLayer` consumed the pointer-down event before it reached the Save button, so only synthetic/programmatic clicks worked.
2. **No save confirmation** — `handleSave` set no success state after a successful save, so saves appeared as no-ops to the user.
3. **Cross-project state leak** — switching projects in the settings nav reused the `ProjectSettingsPane` React instance, leaving stale edited values (name/color/icon) from the previous project.

All three bugs are covered by new unit tests.

## Changes Made

### `icon-picker-popover.tsx`

- Added `onPointerDownOutside={(e) => e.preventDefault()}` and `onCloseAutoFocus={(e) => e.preventDefault()}` to `PopoverContent`.
- Prevents Radix's `DismissableLayer` from consuming the pointer event and stealing focus, so the first click outside the popover (onto the Save button) reaches its target.

### `project-settings-pane.tsx`

- Added optional `saved?: boolean` prop to `ProjectSettingsPaneContent`; button label cycles `"Save"` → `"Saving…"` → `"Saved ✓"` → `"Save"`.
- Added `saved` state and a `useEffect` in `ProjectSettingsPane` that auto-clears the confirmation after 2 seconds; cleanup cancels the timer on unmount (covers the CTL-1225 remount-on-project-switch path so no post-unmount state update fires).
- `handleSave` sets `saved(true)` on success.

### `settings-surface.tsx`

- Added `key={settingsView.project.key}` to the `<ProjectSettingsPane>` mount so React remounts (rather than reconciles) when the user switches projects, re-running `useState` initializers and clearing stale edits.

### Tests

- **`settings-surface.test.ts`** — 2 new tests: icon picker overrides `onPointerDownOutside`/`onCloseAutoFocus`; pane is keyed on the project key.
- **`project-settings-pane.test.tsx`** — 3 new tests: default Save label, Saved confirmation when `saved=true`, Saving label takes priority over Saved when `saving=true`.

## How to Verify It

- [x] `audit-references` CI check passed
- [x] `check-versions` CI check passed
- [x] `docs-gate` CI check passed
- [x] `validate` CI check passed
- [ ] `quality` CI check (pending)
- [ ] Cloudflare Pages preview (pending)
- [ ] Open the monitor UI, open Project Settings for any project, open the icon picker, select an icon, close the picker, click Save once — the save persists on the first click (verify via network/`GET /api/projects`)
- [ ] After a successful save, the button briefly shows "Saved ✓" and returns to "Save"
- [ ] Switch to a different project in the settings nav — the second project's pane shows its own values, not the edits made to the first project

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1225
