### PR TITLE
feat(dev): CTL-1226 — searchable icon grid picker backed by full Phosphor set

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/components/project-mark-icon.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/project-mark-icon.tsx
@@ -1,6 +1,6 @@
 // project-mark-icon.tsx — renders a ProjectMark as a tinted Phosphor glyph or favicon
 // img. Used on cards, lane headers, and the sidebar (CTL-1208).
-import { GLYPH_COMPONENTS } from "@/lib/project-glyph-set";
+import { resolvePhosphorIcon } from "@/lib/phosphor-icons";
 import type { ProjectMark } from "@/lib/project-mark";
 
 interface ProjectMarkIconProps {
@@ -18,7 +18,7 @@ interface ProjectMarkIconProps {
  */
 export function ProjectMarkIcon({ mark, color, size = 14 }: ProjectMarkIconProps) {
   if (mark.kind === "glyph") {
-    const G = GLYPH_COMPONENTS[mark.name];
+    const G = resolvePhosphorIcon(mark.name);
     if (!G) return null;
     return (
       <G

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-model.test.ts
@@ -1,4 +1,4 @@
-// icon-picker-model.test.ts — unit tests for the glyph-aware icon picker model (CTL-1208).
+// icon-picker-model.test.ts — unit tests for the glyph-aware icon picker model (CTL-1208, CTL-1226).
 // No DOM, no React — pure function tests.
 import { describe, it, expect } from "bun:test";
 import { buildIconPickerItems, resolveActiveIconLabel } from "./icon-picker-model";
@@ -12,44 +12,76 @@ const CANDS: IconCandidate[] = [
 
 describe("buildIconPickerItems", () => {
   it("yields Auto as the first item with value null", () => {
-    const items = buildIconPickerItems(CANDS, PHOSPHOR_GLYPH_NAMES);
+    const items = buildIconPickerItems(CANDS);
     expect(items[0]).toMatchObject({ value: null, label: "Auto", group: "auto" });
   });
 
   it("yields one item per candidate with the candidate path as value", () => {
-    const items = buildIconPickerItems(CANDS, PHOSPHOR_GLYPH_NAMES);
+    const items = buildIconPickerItems(CANDS);
     const favItems = items.filter((i) => i.group === "favicon");
     expect(favItems).toHaveLength(2);
     expect(favItems[0].value).toBe("public/favicon.svg");
     expect(favItems[1].value).toBe("favicon.ico");
   });
 
-  it("yields one glyph item per curated glyph name with phosphor: value", () => {
-    const items = buildIconPickerItems(CANDS, PHOSPHOR_GLYPH_NAMES);
-    const glyphItems = items.filter((i) => i.group === "glyph");
-    expect(glyphItems).toHaveLength(PHOSPHOR_GLYPH_NAMES.length);
-    for (const item of glyphItems) {
-      expect(item.value).toMatch(/^phosphor:/);
+  it("featured glyph items match the curated list (featured: true)", () => {
+    const items = buildIconPickerItems(CANDS);
+    const featured = items.filter((i) => i.group === "glyph" && i.featured === true);
+    expect(featured).toHaveLength(PHOSPHOR_GLYPH_NAMES.length);
+    for (const item of featured) {
+      expect(PHOSPHOR_GLYPH_NAMES).toContain(item.name);
     }
   });
 
-  it("first glyph item is phosphor:git-fork (first in the curated list)", () => {
-    const items = buildIconPickerItems(CANDS, PHOSPHOR_GLYPH_NAMES);
+  it("non-featured glyph items cover the full icon set beyond the curated list", () => {
+    const items = buildIconPickerItems(CANDS);
+    const allGlyphs = items.filter((i) => i.group === "glyph");
+    expect(allGlyphs.length).toBeGreaterThan(1000);
+    const nonFeatured = allGlyphs.filter((i) => !i.featured);
+    expect(nonFeatured.length).toBeGreaterThan(1000 - PHOSPHOR_GLYPH_NAMES.length);
+  });
+
+  it("featured items come before non-featured items in the glyph group", () => {
+    const items = buildIconPickerItems(CANDS);
+    const glyphItems = items.filter((i) => i.group === "glyph");
+    let seenNonFeatured = false;
+    for (const item of glyphItems) {
+      if (!item.featured) seenNonFeatured = true;
+      if (seenNonFeatured) expect(item.featured).toBeFalsy();
+    }
+  });
+
+  it("first featured glyph is phosphor:git-fork (curated order preserved)", () => {
+    const items = buildIconPickerItems(CANDS);
     const firstGlyph = items.find((i) => i.group === "glyph");
     expect(firstGlyph?.value).toBe("phosphor:git-fork");
     expect(firstGlyph?.name).toBe("git-fork");
+    expect(firstGlyph?.featured).toBe(true);
+  });
+
+  it("no duplicate glyph values (curated names appear exactly once)", () => {
+    const items = buildIconPickerItems(CANDS);
+    const values = items.filter((i) => i.group === "glyph").map((i) => i.value);
+    expect(new Set(values).size).toBe(values.length);
+    // Each curated name appears exactly once
+    for (const name of PHOSPHOR_GLYPH_NAMES) {
+      const count = values.filter((v) => v === `phosphor:${name}`).length;
+      expect(count).toBe(1);
+    }
   });
 
   it("works with no candidates (only Auto + glyphs)", () => {
-    const items = buildIconPickerItems([], PHOSPHOR_GLYPH_NAMES);
+    const items = buildIconPickerItems([]);
     expect(items[0].group).toBe("auto");
     expect(items.filter((i) => i.group === "favicon")).toHaveLength(0);
-    expect(items.filter((i) => i.group === "glyph")).toHaveLength(PHOSPHOR_GLYPH_NAMES.length);
+    expect(items.filter((i) => i.group === "glyph").length).toBeGreaterThan(100);
   });
 
-  it("total item count is 1 + candidates.length + glyphs.length", () => {
-    const items = buildIconPickerItems(CANDS, PHOSPHOR_GLYPH_NAMES);
-    expect(items).toHaveLength(1 + CANDS.length + PHOSPHOR_GLYPH_NAMES.length);
+  it("total item count is 1 + candidates + full glyph set (> 1000 glyphs)", () => {
+    const items = buildIconPickerItems(CANDS);
+    const glyphCount = items.filter((i) => i.group === "glyph").length;
+    expect(items).toHaveLength(1 + CANDS.length + glyphCount);
+    expect(glyphCount).toBeGreaterThan(1000);
   });
 });
 
@@ -61,6 +93,10 @@ describe("resolveActiveIconLabel", () => {
   it("returns a human-readable glyph label for a phosphor: ref (hyphens → spaces)", () => {
     const label = resolveActiveIconLabel("phosphor:git-fork");
     expect(label).toBe("git fork");
+  });
+
+  it("returns a label for a non-curated full-set ref (airplane)", () => {
+    expect(resolveActiveIconLabel("phosphor:airplane")).toBe("airplane");
   });
 
   it("returns a favicon label for a path string", () => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-model.ts
@@ -2,6 +2,7 @@
 // in ProjectSettingsPane (CTL-1208). No React, no side effects — fully unit-testable.
 import type { IconCandidate } from "@/lib/repo-icons";
 import { PHOSPHOR_GLYPH_NAMES, formatGlyphRef, parseGlyphRef } from "@/lib/project-glyph-set";
+import { enumeratePhosphorGlyphNames } from "@/lib/phosphor-icons";
 
 export type IconPickerGroup = "auto" | "favicon" | "glyph";
 
@@ -19,15 +20,16 @@ export interface IconPickerItem {
   name?: string;
   /** Favicon data URL (only set when group === "favicon"). */
   dataUrl?: string | null;
+  /** True for curated Featured icons; false for the rest of the full set. Only set when group === "glyph". */
+  featured?: boolean;
 }
 
 /**
  * Build the flat list of icon picker items for a project.
- * Order: Auto → favicon candidates → curated glyphs.
+ * Order: Auto → favicon candidates → Featured glyphs (curated 36) → All icons (full set remainder).
  */
 export function buildIconPickerItems(
   candidates: readonly IconCandidate[],
-  glyphNames: readonly string[] = PHOSPHOR_GLYPH_NAMES,
 ): IconPickerItem[] {
   const items: IconPickerItem[] = [];
 
@@ -49,17 +51,32 @@ export function buildIconPickerItems(
       group: "favicon",
       dataUrl: c.dataUrl,
     });
-    void ext; // suppress unused warning
+    void ext;
   }
 
-  // 3. Curated Phosphor glyphs
-  for (const name of glyphNames) {
+  // 3. Featured (curated) glyphs first, in curated order
+  const featuredSet = new Set(PHOSPHOR_GLYPH_NAMES);
+  for (const name of PHOSPHOR_GLYPH_NAMES) {
     items.push({
       value: formatGlyphRef(name),
       label: name.replace(/-/g, " "),
       searchKey: name,
       group: "glyph",
       name,
+      featured: true,
+    });
+  }
+
+  // 4. Remaining full-set icons (sorted, excluding curated names to avoid duplicates)
+  for (const name of enumeratePhosphorGlyphNames()) {
+    if (featuredSet.has(name)) continue;
+    items.push({
+      value: formatGlyphRef(name),
+      label: name.replace(/-/g, " "),
+      searchKey: name,
+      group: "glyph",
+      name,
+      featured: false,
     });
   }
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-popover.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-popover.tsx
@@ -1,5 +1,5 @@
-// icon-picker-popover.tsx — searchable glyph+favicon picker for Project Settings (CTL-1208).
-// Popover + shadcn Command (cmdk): Auto | Detected favicons | Curated Phosphor set.
+// icon-picker-popover.tsx — searchable glyph+favicon picker for Project Settings (CTL-1208, CTL-1226).
+// Popover + shadcn Command (cmdk): Auto | Detected favicons | Featured grid | All icons grid.
 import { useState } from "react";
 import { ChevronDownIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -20,6 +20,7 @@ import {
 import { NAMED_COLORS } from "@/lib/color-palette";
 import { ProjectMarkIcon } from "@/components/project-mark-icon";
 import { buildIconPickerItems, resolveActiveIconLabel } from "./icon-picker-model";
+import type { IconPickerItem } from "./icon-picker-model";
 import type { IconCandidate } from "@/lib/repo-icons";
 
 interface IconPickerPopoverProps {
@@ -32,12 +33,40 @@ interface IconPickerPopoverProps {
   hue: string | null;
 }
 
+function GlyphGridCell({
+  item,
+  currentValue,
+  accentColor,
+  onSelect,
+}: {
+  item: IconPickerItem;
+  currentValue: string | null;
+  accentColor: string;
+  onSelect: () => void;
+}) {
+  return (
+    <CommandItem
+      value={`glyph ${item.searchKey}`}
+      onSelect={onSelect}
+      className="p-0.5 h-8 w-8 justify-center flex-none"
+      data-active={currentValue === item.value ? true : undefined}
+      aria-label={item.label}
+      title={item.label}
+    >
+      <ProjectMarkIcon mark={{ kind: "glyph", name: item.name! }} color={accentColor} size={18} />
+    </CommandItem>
+  );
+}
+
 export function IconPickerPopover({ value, onChange, candidates, hue }: IconPickerPopoverProps) {
   const [open, setOpen] = useState(false);
 
   const items = buildIconPickerItems(candidates);
   const accentColor = (hue && NAMED_COLORS[hue]?.text) || "currentColor";
   const triggerLabel = resolveActiveIconLabel(value);
+
+  const featuredGlyphs = items.filter((i) => i.group === "glyph" && i.featured);
+  const allGlyphs = items.filter((i) => i.group === "glyph" && !i.featured);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -65,7 +94,7 @@ export function IconPickerPopover({ value, onChange, candidates, hue }: IconPick
           <ChevronDownIcon className="size-3 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-72 p-0" align="start">
+      <PopoverContent className="w-80 p-0" align="start">
         <Command>
           <CommandInput placeholder="Search icons…" className="h-9 text-xs" />
           <CommandList className="max-h-72">
@@ -116,27 +145,36 @@ export function IconPickerPopover({ value, onChange, candidates, hue }: IconPick
               </>
             )}
 
-            {/* Curated glyph set */}
+            {/* Featured glyph grid */}
             <CommandSeparator />
-            <CommandGroup heading="Icons">
-              {items
-                .filter((i) => i.group === "glyph")
-                .map((item) => (
-                  <CommandItem
+            <CommandGroup heading="Featured">
+              <div className="grid grid-cols-8 gap-1 p-1">
+                {featuredGlyphs.map((item) => (
+                  <GlyphGridCell
                     key={item.value}
-                    value={`glyph ${item.searchKey}`}
+                    item={item}
+                    currentValue={value}
+                    accentColor={accentColor}
                     onSelect={() => { onChange(item.value); setOpen(false); }}
-                    className="text-xs gap-2"
-                    data-active={value === item.value ? true : undefined}
-                  >
-                    <ProjectMarkIcon
-                      mark={{ kind: "glyph", name: item.name! }}
-                      color={accentColor}
-                      size={14}
-                    />
-                    <span className="truncate">{item.label}</span>
-                  </CommandItem>
+                  />
                 ))}
+              </div>
+            </CommandGroup>
+
+            {/* All icons glyph grid */}
+            <CommandSeparator />
+            <CommandGroup heading="All icons">
+              <div className="grid grid-cols-8 gap-1 p-1">
+                {allGlyphs.map((item) => (
+                  <GlyphGridCell
+                    key={item.value}
+                    item={item}
+                    currentValue={value}
+                    accentColor={accentColor}
+                    onSelect={() => { onChange(item.value); setOpen(false); }}
+                  />
+                ))}
+              </div>
             </CommandGroup>
           </CommandList>
         </Command>

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/phosphor-icons.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/phosphor-icons.test.ts
@@ -1,0 +1,109 @@
+// phosphor-icons.test.ts — unit tests for the universal Phosphor resolver (CTL-1226).
+import { describe, it, expect } from "bun:test";
+import * as PhosphorIcons from "@phosphor-icons/react";
+import {
+  pascalToKebab,
+  kebabToPascal,
+  resolvePhosphorIcon,
+  enumeratePhosphorGlyphNames,
+} from "./phosphor-icons";
+import { PHOSPHOR_GLYPH_NAMES } from "./project-glyph-set";
+
+describe("pascalToKebab", () => {
+  it("converts GitFork to git-fork", () => {
+    expect(pascalToKebab("GitFork")).toBe("git-fork");
+  });
+
+  it("converts TerminalWindow to terminal-window", () => {
+    expect(pascalToKebab("TerminalWindow")).toBe("terminal-window");
+  });
+
+  it("converts Tree to tree", () => {
+    expect(pascalToKebab("Tree")).toBe("tree");
+  });
+
+  it("converts HardDrives to hard-drives", () => {
+    expect(pascalToKebab("HardDrives")).toBe("hard-drives");
+  });
+});
+
+describe("kebabToPascal", () => {
+  it("converts git-fork to GitFork", () => {
+    expect(kebabToPascal("git-fork")).toBe("GitFork");
+  });
+
+  it("converts terminal-window to TerminalWindow", () => {
+    expect(kebabToPascal("terminal-window")).toBe("TerminalWindow");
+  });
+
+  it("converts tree to Tree", () => {
+    expect(kebabToPascal("tree")).toBe("Tree");
+  });
+});
+
+describe("round-trip stability over the full exported set", () => {
+  it("pascalToKebab and kebabToPascal are inverses for all icon exports", () => {
+    const registry = PhosphorIcons as unknown as Record<string, unknown>;
+    const allPascalNames = Object.keys(registry).filter(
+      (k) => !k.endsWith("Icon") && `${k}Icon` in registry,
+    );
+    expect(allPascalNames.length).toBeGreaterThan(1000);
+    for (const p of allPascalNames) {
+      expect(kebabToPascal(pascalToKebab(p))).toBe(p);
+    }
+  });
+});
+
+describe("resolvePhosphorIcon", () => {
+  it("returns a component for a curated name (git-fork)", () => {
+    expect(resolvePhosphorIcon("git-fork")).toBeTruthy();
+  });
+
+  it("returns a component for another curated name (tree)", () => {
+    expect(resolvePhosphorIcon("tree")).toBeTruthy();
+  });
+
+  it("returns a component for a non-curated full-set name (airplane)", () => {
+    expect(resolvePhosphorIcon("airplane")).toBeTruthy();
+  });
+
+  it("returns null for a non-existent name", () => {
+    expect(resolvePhosphorIcon("not-a-real-icon-xyz")).toBeNull();
+  });
+});
+
+describe("enumeratePhosphorGlyphNames", () => {
+  it("returns more than 1000 icons", () => {
+    expect(enumeratePhosphorGlyphNames().length).toBeGreaterThan(1000);
+  });
+
+  it("includes every curated name from PHOSPHOR_GLYPH_NAMES", () => {
+    const allNames = new Set(enumeratePhosphorGlyphNames());
+    for (const name of PHOSPHOR_GLYPH_NAMES) {
+      expect(allNames.has(name)).toBe(true);
+    }
+  });
+
+  it("has no duplicates", () => {
+    const names = enumeratePhosphorGlyphNames();
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("all names resolve to a component", () => {
+    for (const name of enumeratePhosphorGlyphNames()) {
+      expect(resolvePhosphorIcon(name)).toBeTruthy();
+    }
+  });
+
+  it("all names are round-trip stable (kebab→pascal→kebab)", () => {
+    for (const name of enumeratePhosphorGlyphNames()) {
+      expect(pascalToKebab(kebabToPascal(name))).toBe(name);
+    }
+  });
+
+  it("returns the same array on repeated calls (memoized)", () => {
+    const a = enumeratePhosphorGlyphNames();
+    const b = enumeratePhosphorGlyphNames();
+    expect(a).toBe(b);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/phosphor-icons.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/phosphor-icons.ts
@@ -1,0 +1,59 @@
+// phosphor-icons.ts — universal synchronous Phosphor resolver (CTL-1226).
+// Replaces the 36-name GLYPH_COMPONENTS static map with a namespace-import resolver
+// that covers the full ~1,500-icon set. Both the picker and ProjectMarkIcon use it.
+// The namespace cast (Record<string,unknown>) is intentional: the @phosphor-icons/react
+// namespace mixes Icon components and utility re-exports; we discriminate at runtime.
+import * as PhosphorIcons from "@phosphor-icons/react";
+import type { Icon } from "@phosphor-icons/react";
+
+const REGISTRY = PhosphorIcons as unknown as Record<string, unknown>;
+
+/** Insert a hyphen before each uppercase letter (except the first), then lowercase all. */
+export function pascalToKebab(pascal: string): string {
+  return pascal.replace(/[A-Z]/g, (char, offset: number) =>
+    offset === 0 ? char.toLowerCase() : `-${char.toLowerCase()}`,
+  );
+}
+
+/** Capitalize the first letter of each hyphen-separated segment, join without hyphens. */
+export function kebabToPascal(kebab: string): string {
+  return kebab
+    .split("-")
+    .map((s) => (s.length > 0 ? s[0].toUpperCase() + s.slice(1) : ""))
+    .join("");
+}
+
+/** Synchronous resolve: kebab name → Phosphor Icon component, or null. */
+export function resolvePhosphorIcon(name: string): Icon | null {
+  const C = REGISTRY[kebabToPascal(name)];
+  // typeof null === "object" in JS; the ?? null coalesces that case to null.
+  return typeof C === "object" || typeof C === "function" ? (C as Icon) ?? null : null;
+}
+
+let _cachedGlyphNames: string[] | null = null;
+
+/**
+ * Every renderable icon name (kebab), round-trip-stable, sorted.
+ * Uses the XIcon-twin filter: Phosphor exports every icon as both X and XIcon;
+ * utility exports (IconBase, IconContext, etc.) lack the XIcon twin and are excluded.
+ * Any name that fails the kebab↔Pascal round-trip is also excluded.
+ * Result is memoized after the first call.
+ */
+export function enumeratePhosphorGlyphNames(): string[] {
+  if (_cachedGlyphNames !== null) return _cachedGlyphNames;
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const pascal of Object.keys(REGISTRY)) {
+    if (pascal.endsWith("Icon")) continue;
+    if (!(`${pascal}Icon` in REGISTRY)) continue;
+    const kebab = pascalToKebab(pascal);
+    if (seen.has(kebab)) continue;
+    if (kebabToPascal(kebab) !== pascal) continue;
+    if (resolvePhosphorIcon(kebab) === null) continue;
+    seen.add(kebab);
+    names.push(kebab);
+  }
+  names.sort();
+  _cachedGlyphNames = names;
+  return names;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/project-glyph-set.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/project-glyph-set.test.ts
@@ -1,9 +1,8 @@
-// project-glyph-set.test.ts — unit tests for the curated Phosphor glyph set (CTL-1208).
+// project-glyph-set.test.ts — unit tests for the curated Phosphor glyph set (CTL-1208, CTL-1226).
 // No DOM, no React — pure function tests.
 import { describe, it, expect } from "bun:test";
 import {
   PHOSPHOR_GLYPH_NAMES,
-  GLYPH_COMPONENTS,
   isGlyphRef,
   parseGlyphRef,
   formatGlyphRef,
@@ -17,25 +16,6 @@ describe("PHOSPHOR_GLYPH_NAMES", () => {
   it("has no duplicates", () => {
     const set = new Set(PHOSPHOR_GLYPH_NAMES);
     expect(set.size).toBe(PHOSPHOR_GLYPH_NAMES.length);
-  });
-});
-
-describe("GLYPH_COMPONENTS", () => {
-  it("has an entry for every PHOSPHOR_GLYPH_NAMES entry", () => {
-    for (const name of PHOSPHOR_GLYPH_NAMES) {
-      expect(GLYPH_COMPONENTS[name]).toBeDefined();
-    }
-  });
-
-  it("has no extra keys beyond PHOSPHOR_GLYPH_NAMES", () => {
-    const names = new Set(PHOSPHOR_GLYPH_NAMES);
-    for (const key of Object.keys(GLYPH_COMPONENTS)) {
-      expect(names.has(key)).toBe(true);
-    }
-  });
-
-  it("GLYPH_COMPONENTS keys match PHOSPHOR_GLYPH_NAMES exactly", () => {
-    expect(Object.keys(GLYPH_COMPONENTS).sort()).toEqual([...PHOSPHOR_GLYPH_NAMES].sort());
   });
 });
 
@@ -54,11 +34,15 @@ describe("parseGlyphRef", () => {
     expect(parseGlyphRef("phosphor:git-fork")).toEqual({ set: "phosphor", name: "git-fork" });
   });
 
+  it("parses a non-curated but valid full-set ref (airplane)", () => {
+    expect(parseGlyphRef("phosphor:airplane")).toEqual({ set: "phosphor", name: "airplane" });
+  });
+
   it("returns null for a favicon path", () => {
     expect(parseGlyphRef("public/favicon.svg")).toBeNull();
   });
 
-  it("returns null for an uncurated phosphor name", () => {
+  it("returns null for a non-existent phosphor name", () => {
     expect(parseGlyphRef("phosphor:unknown-glyph-xyz")).toBeNull();
   });
 
@@ -74,6 +58,10 @@ describe("parseGlyphRef", () => {
     expect(parseGlyphRef(undefined)).toBeNull();
   });
 
+  it("returns null for bare phosphor: prefix with no name", () => {
+    expect(parseGlyphRef("phosphor:")).toBeNull();
+  });
+
   it("parses all curated names correctly", () => {
     for (const name of PHOSPHOR_GLYPH_NAMES) {
       const ref = `phosphor:${name}`;
@@ -87,12 +75,16 @@ describe("isGlyphRef", () => {
     expect(isGlyphRef("phosphor:git-fork")).toBe(true);
   });
 
+  it("returns true for a non-curated but valid full-set ref (airplane)", () => {
+    expect(isGlyphRef("phosphor:airplane")).toBe(true);
+  });
+
   it("returns false for a favicon path", () => {
     expect(isGlyphRef("public/favicon.svg")).toBe(false);
   });
 
-  it("returns false for an uncurated phosphor name", () => {
-    expect(isGlyphRef("phosphor:not-in-set")).toBe(false);
+  it("returns false for a non-existent phosphor name", () => {
+    expect(isGlyphRef("phosphor:not-a-real-icon")).toBe(false);
   });
 
   it("returns false for null", () => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/project-glyph-set.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/project-glyph-set.ts
@@ -1,49 +1,12 @@
 // project-glyph-set.ts — curated Phosphor fill-weight glyph set for project icons (CTL-1208).
-// Pure data + pure functions — no React, no DOM. Tree-shakes cleanly (individual imports).
-import type { Icon } from "@phosphor-icons/react";
-import {
-  GitFork,
-  Rocket,
-  Cube,
-  Stack,
-  Cpu,
-  TerminalWindow,
-  Lightning,
-  Globe,
-  Database,
-  HardDrives,
-  Shield,
-  Sparkle,
-  Star,
-  Flame,
-  Leaf,
-  ChartBar,
-  Flask,
-  Bug,
-  Package,
-  Cloud,
-  Gear,
-  Compass,
-  Target,
-  Tree,
-  Boat,
-  Mountains,
-  Flower,
-  Hexagon,
-  Diamond,
-  Crown,
-  Robot,
-  Alien,
-  Cat,
-  Dog,
-  Bird,
-  Fish,
-} from "@phosphor-icons/react";
+// Static imports and GLYPH_COMPONENTS removed in CTL-1226; resolution delegates to
+// the universal resolver in phosphor-icons.ts which covers the full icon set.
+import { resolvePhosphorIcon } from "./phosphor-icons";
 
 /** Prefix for all curated glyph references stored in the server icon field. */
 export const GLYPH_SET_PREFIX = "phosphor";
 
-/** Curated subset of Phosphor icon names (fill weight) legible at 14–16px. */
+/** Curated subset of Phosphor icon names (fill weight) legible at 14–16px. Shown first in the picker. */
 export const PHOSPHOR_GLYPH_NAMES: readonly string[] = [
   "git-fork",
   "rocket",
@@ -83,52 +46,15 @@ export const PHOSPHOR_GLYPH_NAMES: readonly string[] = [
   "fish",
 ] as const;
 
-/** Map from curated glyph name to the corresponding Phosphor React component. */
-export const GLYPH_COMPONENTS: Record<string, Icon> = {
-  "git-fork": GitFork,
-  "rocket": Rocket,
-  "cube": Cube,
-  "stack": Stack,
-  "cpu": Cpu,
-  "terminal-window": TerminalWindow,
-  "lightning": Lightning,
-  "globe": Globe,
-  "database": Database,
-  "hard-drives": HardDrives,
-  "shield": Shield,
-  "sparkle": Sparkle,
-  "star": Star,
-  "flame": Flame,
-  "leaf": Leaf,
-  "chart-bar": ChartBar,
-  "flask": Flask,
-  "bug": Bug,
-  "package": Package,
-  "cloud": Cloud,
-  "gear": Gear,
-  "compass": Compass,
-  "target": Target,
-  "tree": Tree,
-  "boat": Boat,
-  "mountains": Mountains,
-  "flower": Flower,
-  "hexagon": Hexagon,
-  "diamond": Diamond,
-  "crown": Crown,
-  "robot": Robot,
-  "alien": Alien,
-  "cat": Cat,
-  "dog": Dog,
-  "bird": Bird,
-  "fish": Fish,
-};
-
 /** Format a glyph name into a set reference string (e.g. "git-fork" → "phosphor:git-fork"). */
 export function formatGlyphRef(name: string): string {
   return `${GLYPH_SET_PREFIX}:${name}`;
 }
 
-/** Parse a set reference string. Returns null if not a curated glyph ref. */
+/**
+ * Parse a set reference string. Returns null if not a valid glyph ref
+ * (i.e. no real Phosphor component exists for the given name).
+ */
 export function parseGlyphRef(
   s: string | null | undefined,
 ): { set: "phosphor"; name: string } | null {
@@ -137,11 +63,11 @@ export function parseGlyphRef(
   if (!s.startsWith(prefix)) return null;
   const name = s.slice(prefix.length);
   if (!name) return null;
-  if (!(PHOSPHOR_GLYPH_NAMES as readonly string[]).includes(name)) return null;
+  if (resolvePhosphorIcon(name) === null) return null;
   return { set: "phosphor", name };
 }
 
-/** True iff `s` is a valid curated glyph reference (phosphor:<name> with a known name). */
+/** True iff `s` is a valid glyph reference (phosphor:<name> with a real Phosphor component). */
 export function isGlyphRef(s: string | null | undefined): boolean {
   return parseGlyphRef(s) !== null;
 }


### PR DESCRIPTION
## Summary

- New `phosphor-icons.ts` module with universal sync resolver — `resolvePhosphorIcon`, `enumeratePhosphorGlyphNames`, `pascalToKebab`/`kebabToPascal` — backed by a namespace import of `@phosphor-icons/react` and XIcon-twin filter for round-trip-stable enumeration of ~1,512 icons
- `project-glyph-set.ts`: removes 36 static imports + `GLYPH_COMPONENTS`; `parseGlyphRef`/`isGlyphRef` widen to accept any real Phosphor component (not just the curated 36)
- `project-mark-icon.tsx`: resolves glyphs via `resolvePhosphorIcon` instead of static map
- `icon-picker-model.ts`: builds Featured (36 curated, `featured:true`) + full-set items from `enumeratePhosphorGlyphNames()`; no duplicate values
- `icon-picker-popover.tsx`: `w-80`, 8-col grid layout, two groups ("Featured" + "All icons"), `GlyphGridCell` with `aria-label`/`title`, unchanged Auto/Detected paths

## Test plan

- [ ] `bun test src/lib/phosphor-icons.test.ts src/lib/project-glyph-set.test.ts src/components/settings/icon-picker-model.test.ts` — 53 tests pass (18 new phosphor-icons + 22 updated glyph-set + 13 model)
- [ ] `bun run build:ui` — vite build succeeds (large chunk warning is pre-existing/accepted trade-off per plan)
- [ ] `bun run knip` — exit 0, no dead-code errors
- [ ] Open Project Settings → icon picker: Featured grid (36) + All icons grid (~1,476) appear
- [ ] Typing in search filters both groups; non-curated icon selects and persists; existing curated values still render on cards/sidebar
- [ ] `phosphor:rocket`, `phosphor:database` still render unchanged (back-compat check)
- [ ] Performance: opening picker with ~1,512 cells is responsive

Refs: CTL-1226