### PR TITLE
CTL-1221: Notification composer for executive escalations

### DIFF
--- a/docs/cluster-onboarding.md
+++ b/docs/cluster-onboarding.md
@@ -1,0 +1,210 @@
+# Cluster Node Onboarding (CTL-1214)
+
+This document describes how to onboard a fresh macOS node into a Catalyst cluster. It covers the automated setup process, prerequisites, and how to activate the node in the committed roster.
+
+## Quick Start
+
+From mini (the seed host), run:
+
+```bash
+cd ~/catalyst/hlt-dev
+./cluster-node-onboard.sh mini mini-2
+```
+
+This automates:
+1. Thoughts repo provisioning (3 orgs: coalesce-labs, rightsite-cloud, ryanrozich)
+2. HumanLayer configuration
+3. Claude Code settings (OTel telemetry + host identity)
+4. catalyst-join completion (Stage-0 SHADOW)
+5. Catalyst stack auto-start via launchd
+
+**Result:** mini-2 is provisioned and running, but owns zero tickets (SHADOW mode). No further action needed for now.
+
+## Prerequisites
+
+### On the target node (mini-2)
+- [ ] **Reachable via SSH** — `ssh mini-2.rozich.com` succeeds
+- [ ] **macOS 26.5+** — verified during setup
+- [ ] **Tailscale joined** — node on tailnet (100.x.x.x IP)
+- [ ] **Sleep disabled** — `sudo pmset -a sleep 0 disablesleep 1`
+- [ ] **Claude logged in** — `claude login` done with own Max account (not shared)
+- [ ] **Hostname set** — `hostname` returns `mini-2` or similar
+- [ ] **SSH key on seed** or **GitHub PAT available** — for HTTPS git auth
+
+### On the seed host (mini)
+- [ ] **catalyst-stack running** — `catalyst-stack status` returns running
+- [ ] **mini/plugin-source on merged main** — `git -C ~/catalyst/plugin-source log -1 --oneline`
+- [ ] **Join bundle prepared** — `ls -la ~/catalyst/join-bundle.json` (size ~500 bytes)
+- [ ] **GitHub CLI authenticated** — `gh auth status` (used for token fetch)
+- [ ] **Anchor ticket created** — one Linear issue for cluster liveness anchor (CTL-1217 or similar)
+
+## Step-by-Step Setup
+
+### Phase 1: Prepare GitHub Authentication
+
+The automation script fetches the GitHub PAT (Personal Access Token) from the seed host's environment. This token is used for HTTPS git push auth (thoughts sync).
+
+**Why:** cluster nodes have no SSH keys; HTTPS + token is the auth model.
+
+- [ ] Verify seed's token: `ssh mini env | grep GITHUB_TOKEN`
+- [ ] Token must have `repo` + `workflow` scopes
+
+### Phase 2: Provision Thoughts Repositories
+
+The `provision-thoughts.sh` script clones three org-specific thoughts repos and writes a clean `~/.config/humanlayer/humanlayer.json`.
+
+**Structure on the node:**
+```
+~/catalyst/hlt/
+  coalesce-labs/thoughts/     # CTL, OTL, EVR projects
+  rightsite-cloud/thoughts/   # ADV (Adva) project
+  ryanrozich/thoughts/        # SLI (Slides) project
+```
+
+**Config created (`~/.config/humanlayer/humanlayer.json`):**
+- Global fallback → `coalesce-labs` (primary, no groundworkapp)
+- `defaultProfile` → `coalesce-labs` (safe fallback for unmapped cwds)
+- `profiles` → deterministic per-org repos
+- `repoMappings` → seeded for registry repoRoots + worktrees (bg agents resolve without direnv)
+
+**Why:** Thoughts is critical cluster infra (research + plans + sync gates). Proper provisioning ensures bg agents (phase-triage, phase-research, etc.) resolve to the correct repo without direnv.
+
+### Phase 3: Provision Claude Code Settings
+
+Copies the seed's `~/.claude/settings.json` and updates:
+- `OTEL_RESOURCE_ATTRIBUTES=host.name=mini-2` — pinned node identity for telemetry
+- `CATALYST_HOST_NAME=mini-2` — used by all catalyst processes
+
+**Why:** Without this, Claude's OTel metrics and catalyst's host metrics label the node with its macOS ComputerName (e.g., `RYANS-MAC_MINI-M4`), breaking correlation in Grafana dashboards.
+
+### Phase 4: Resume catalyst-join
+
+Runs the final join stages:
+1. **doctor** — health check (warnings OK for SHADOW, all required checks pass)
+2. **stack** — installs launchd plist for auto-start
+
+**End state: Stage-0 SHADOW**
+- ✅ Catalyst stack running (auto-restart on reboot)
+- ✅ Thoughts synced (all 3 orgs verified)
+- ✅ Local roster entry created (mini-2 registered locally)
+- ❌ Committed roster untouched (`hosts.json` still `["mini"]`) — node owns zero tickets
+
+### Phase 5: Verification
+
+Check the onboard script's verification output:
+```
+[onboard] Checking stack status...
+  ✓ launchd plist installed
+[onboard] Checking thoughts repos...
+  ✓ 3 thoughts repos cloned
+[onboard] Checking humanlayer config...
+  ✓ humanlayer.json exists
+[onboard] Stage-0 SHADOW Status:
+  stack stage complete
+```
+
+## Activation (M2 — Future)
+
+To activate mini-2 and begin accepting work:
+
+1. **Add to committed roster:**
+   ```bash
+   cd ~/catalyst
+   jq '.hosts += ["mini-2"]' .catalyst/hosts.json > /tmp/hosts.json && mv /tmp/hosts.json .catalyst/hosts.json
+   git add .catalyst/hosts.json && git commit -m "feat: activate mini-2 to cluster roster (CTL-1217)"
+   git push
+   ```
+
+2. **Verify all nodes pull the update:**
+   ```bash
+   catalyst cluster status
+   ```
+
+3. **Watch for zero double-dispatch** — the moment mini-2 enters the roster, the sync gate activates (`roster>1`), and phase-research/phase-plan blocks on `humanlayer thoughts sync`. Verify:
+   - No duplicate phase-researchers spawned
+   - No tickets assigned twice
+   - All work completes on one node only
+
+4. **Monitor the reaper** — once activated, mini-2 worktrees are eligible for reaping (CTL-1218). Watch for safe signal+merge patterns before auto-reap.
+
+## Troubleshooting
+
+### Join script fails with "doctor gate failed"
+
+**Root cause:** Usually PATH issues or missing `.catalyst.thoughts` config.
+
+**Solution:**
+```bash
+# Ensure PATH includes node bins
+export PATH=~/.local/node/bin:~/.bun/bin:$PATH
+
+# Verify humanlayer is discoverable
+which humanlayer
+
+# Add thoughts config to .catalyst/config.json if missing
+cd ~/catalyst-join-bootstrap
+jq '.catalyst.thoughts = {directory: "catalyst", profile: "coalesce-labs"}' .catalyst/config.json > /tmp/config.json && mv /tmp/config.json .catalyst/config.json
+```
+
+### Git clone fails with "Device not configured"
+
+**Root cause:** git credential helper not configured.
+
+**Solution:**
+```bash
+# Use .netrc for HTTPS auth
+cat > ~/.netrc <<'EOF'
+machine github.com
+login ryanrozich
+password YOUR_GITHUB_PAT
+EOF
+chmod 600 ~/.netrc
+```
+
+### Thoughts sync fails with "no auth"
+
+**Root cause:** `gh` CLI or git credentials not configured on the node.
+
+**Solution:**
+- Verify `gh auth status` on the node
+- Verify `.netrc` exists and has correct PAT
+- Verify git is configured: `git config --global credential.helper store`
+
+### launchd plist not installing
+
+**Root cause:** catalyst-stack command not in PATH.
+
+**Solution:**
+```bash
+export PATH=~/.catalyst/bin:$PATH
+catalyst-stack install-services
+```
+
+## Architecture References
+
+- **Thoughts provisioning model:** `thoughts/shared/plans/2026-06-16-cluster-hlt-thoughts-model.md`
+- **Cluster config design:** `thoughts/shared/plans/2026-06-16-cluster-config-architecture.md`
+- **Join implementation:** `plugins/dev/scripts/catalyst-join.sh` (CTL-1185)
+- **Onboarding log:** `thoughts/shared/ops/mini-2-onboarding-log.md`
+
+## Key Decisions (Locked)
+
+- **Thoughts layout:** `~/catalyst/hlt/<org>/thoughts` (one per org, org = GitHub org name)
+- **Auth model:** `gh` + HTTPS (no SSH keys on cluster nodes)
+- **Node user:** local system user (ryan on mini, ryan on mini-2, etc.)
+- **HumanLayer global fallback:** `coalesce-labs` (primary org, never groundworkapp)
+- **Worktree location:** `~/catalyst/wt/catalyst-workspace/` (not ~/conductor)
+- **SHADOW mode:** nodes own zero tickets until added to committed `hosts.json`
+
+## Related Tickets
+
+- **CTL-1214** — This ticket (thoughts provisioning + mini-2 install)
+- **CTL-1217** — Cluster liveness anchor (one Linear ticket that must never be closed)
+- **CTL-1183–1188** — M1 install-critical path (seed→bundle endpoint, join-token, join installer, doctor gate, contract, cluster CLI)
+- **CTL-1228** — Process-by-role metrics (future: resource monitoring for each active role)
+- **CTL-1230** — Relocate observability config (project→machine config.json)
+- **CTL-1231** — Provision settings.json on every node (OTel env + host identity)
+
+---
+
+**Last updated:** 2026-06-16 | **Status:** Stage-0 SHADOW complete, ready for M2 activation

--- a/plugins/dev/scripts/orch-monitor/__tests__/home-inbox.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-inbox.test.ts
@@ -62,6 +62,9 @@ function mkTicket(id: string, over: Partial<BoardTicket> = {}): BoardTicket {
     updatedAt: "",
     held: null,
     blockers: [],
+    autoFixed: false,
+    triaged: false,
+    recoveredAt: null,
     ...over,
   };
 }
@@ -134,6 +137,8 @@ describe("deriveInbox — grouped sections + flat walk order (CTL-899)", () => {
       blocked: 1,
       waiting: 1,
       running: 2,
+      autoFixed: 0,
+      triaged: 0,
       awareness: 0,
       done: 1,
       needsYou: 2,
@@ -249,29 +254,29 @@ describe("rowById — the reading pane reads the selected row's full ticket", ()
 
 describe("calmHeaderSentence — ONE sentence, never a KPI grid (CTL-899)", () => {
   it('reads "N running on their own · M need you · …"', () => {
-    const s = calmHeaderSentence({ attention: 0, blocked: 0, waiting: 2, running: 4, awareness: 0, done: 0, needsYou: 2 });
+    const s = calmHeaderSentence({ attention: 0, blocked: 0, waiting: 2, running: 4, autoFixed: 0, triaged: 0, awareness: 0, done: 0, needsYou: 2 });
     expect(s).toBe("4 running on their own · 2 need you · nothing on fire");
     // It is ONE sentence: no newline, no metric-grid separators.
     expect(s).not.toContain("\n");
   });
 
   it("names the heat when something is genuinely blocked (never lies)", () => {
-    const s = calmHeaderSentence({ attention: 0, blocked: 1, waiting: 0, running: 6, awareness: 0, done: 3, needsYou: 1 });
+    const s = calmHeaderSentence({ attention: 0, blocked: 1, waiting: 0, running: 6, autoFixed: 0, triaged: 0, awareness: 0, done: 3, needsYou: 1 });
     expect(s).toBe("6 running on their own · 1 needs you · 1 blocked");
   });
 
   it("drops the needs-you clause when nothing needs you", () => {
-    const s = calmHeaderSentence({ attention: 0, blocked: 0, waiting: 0, running: 5, awareness: 0, done: 0, needsYou: 0 });
+    const s = calmHeaderSentence({ attention: 0, blocked: 0, waiting: 0, running: 5, autoFixed: 0, triaged: 0, awareness: 0, done: 0, needsYou: 0 });
     expect(s).toBe("5 running on their own · nothing on fire");
   });
 
   it("uses singular grammar for one running ticket", () => {
-    const s = calmHeaderSentence({ attention: 0, blocked: 0, waiting: 0, running: 1, awareness: 0, done: 0, needsYou: 0 });
+    const s = calmHeaderSentence({ attention: 0, blocked: 0, waiting: 0, running: 1, autoFixed: 0, triaged: 0, awareness: 0, done: 0, needsYou: 0 });
     expect(s).toBe("1 running on its own · nothing on fire");
   });
 
   it("collapses to the celebratory empty-state line when the inbox is empty", () => {
-    const s = calmHeaderSentence({ attention: 0, blocked: 0, waiting: 0, running: 0, awareness: 0, done: 0, needsYou: 0 });
+    const s = calmHeaderSentence({ attention: 0, blocked: 0, waiting: 0, running: 0, autoFixed: 0, triaged: 0, awareness: 0, done: 0, needsYou: 0 });
     expect(s).toBe("All clear — nothing needs you right now.");
   });
 });
@@ -375,6 +380,8 @@ const counts = (over: Partial<InboxCounts> = {}): InboxCounts => ({
   blocked: 0,
   waiting: 0,
   running: 0,
+  autoFixed: 0,
+  triaged: 0,
   awareness: 0,
   done: 0,
   needsYou: 0,

--- a/plugins/dev/scripts/orch-monitor/__tests__/nav-signal.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/nav-signal.test.ts
@@ -73,6 +73,7 @@ function ticket(id: string, overrides: Partial<BoardTicket> = {}): BoardTicket {
     blockers: [],
     host: null,
     generation: null,
+    autoFixed: false,
     ...overrides,
   };
 }

--- a/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
+++ b/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
@@ -10,10 +10,10 @@ Do **not** edit this file directly.
 
 | Classification | Count |
 | --- | --- |
-| ✓ Conforming | 14 |
+| ✓ Conforming | 20 |
 | → Rename-to | 37 |
-| ● Legitimately Custom | 20 |
-| **Total** | 71 |
+| ● Legitimately Custom | 26 |
+| **Total** | 83 |
 
 ## Classification by Emitter
 
@@ -76,8 +76,12 @@ Do **not** edit this file directly.
 | Key | Source | Classification | Target | Cluster | Note |
 | --- | --- | --- | --- | --- | --- |
 | `account.email` | `ratelimit-event.mjs:62` | → rename-to | → `catalyst.account.email` | Cluster B |  |
+| `catalyst.directory` | `host.mjs:457` | ● custom |  |  | CTL-1227: directory path indicator (wt for worktree) |
+| `catalyst.measurement` | `host.mjs:457` | ● custom |  |  | CTL-1227: measurement type (logical_du for APFS clone-inflated values) |
 | `host.cpu_count` | `host.mjs:274` | → rename-to | → `system.cpu.logical_count` | Cluster C |  |
 | `host.cpu_pct` | `host.mjs:273` | → rename-to | → `system.cpu.utilization` | Cluster C | unit: ÷100 → 0.0–1.0 |
+| `host.disk_avail_gb` | `host.mjs:554` | ● custom |  |  | CTL-1227: unit: GB (1 decimal), available disk space |
+| `host.disk_free_pct` | `host.mjs:555` | ● custom |  |  | CTL-1227: unit: ÷100 percentage 0–100, available disk pct |
 | `host.disk_total_gb` | `host.mjs:280` | → rename-to | → `system.filesystem.capacity` | Cluster C | unit: ×1073741824 → bytes |
 | `host.disk_used_gb` | `host.mjs:279` | → rename-to | → `system.filesystem.usage` | Cluster C | unit: ×1073741824 → bytes, state=used |
 | `host.disk_used_pct` | `host.mjs:281` | → rename-to | → `system.filesystem.utilization` | Cluster C | unit: ÷100 → 0.0–1.0 |
@@ -85,6 +89,9 @@ Do **not** edit this file directly.
 | `host.mem_total_mb` | `host.mjs:277` | → rename-to | → `system.memory.limit` | Cluster C | unit: ×1048576 → bytes |
 | `host.mem_used_mb` | `host.mjs:276` | → rename-to | → `system.memory.usage` | Cluster C | unit: ×1048576 → bytes, state=used |
 | `host.mem_used_pct` | `host.mjs:278` | → rename-to | → `system.memory.utilization` | Cluster C | unit: ÷100 → 0.0–1.0 |
+| `host.worktree_count` | `host.mjs:557` | ● custom |  |  | CTL-1227: count of active worktrees |
+| `host.worktree_used_gb` | `host.mjs:556` | ● custom |  |  | CTL-1227: unit: GB, logical (du) APFS-clone-inflated worktree usage |
+| `hw.type` | `host.mjs:473` | ✓ conforming |  |  | CTL-1227: hardware type (cpu for thermal) |
 | `process.command` | `processes.mjs:283` | ✓ conforming |  |  |  |
 | `process.cpu_pct` | `processes.mjs:284` | → rename-to | → `process.cpu.utilization` | Cluster D | unit: ÷100 → 0.0–1.0 |
 | `process.phase` | `processes.mjs:287` | → rename-to | → `catalyst.process.phase` | Cluster D |  |
@@ -98,6 +105,11 @@ Do **not** edit this file directly.
 | `ratelimit.seven_day_resets_at` | `ratelimit-event.mjs:67` | → rename-to | → `catalyst.ratelimit.seven_day_resets_at` | Cluster B |  |
 | `ratelimit.seven_day_sonnet_pct` | `ratelimit-event.mjs:69` | → rename-to | → `catalyst.ratelimit.seven_day_sonnet_pct` | Cluster B |  |
 | `subscription.type` | `ratelimit-event.mjs:70` | → rename-to | → `catalyst.subscription.type` | Cluster B |  |
+| `system.device` | `host.mjs:379` | ✓ conforming |  |  | CTL-1227: filesystem device identifier |
+| `system.filesystem.mountpoint` | `host.mjs:380` | ✓ conforming |  |  | CTL-1227: filesystem mount point path |
+| `system.filesystem.state` | `host.mjs:428` | ✓ conforming |  |  | CTL-1227: filesystem state dimension (used|free) |
+| `system.filesystem.type` | `host.mjs:381` | ✓ conforming |  |  | CTL-1227: filesystem type (ext4, apfs, etc) |
+| `system.memory.state` | `host.mjs:411` | ✓ conforming |  |  | CTL-1227: memory state dimension (used|free) |
 
 ### Legacy Bash (`emit-otel-event.sh`)
 

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -177,6 +177,12 @@ export interface BoardTicket {
    *  card. null/absent unless attention is needs-human and a signal carried the
    *  extended fields. */
   explanation?: BoardEscalationExplanation | null;
+  /** CTL-1220: true when this ticket was auto-fixed by the recovery sweep. */
+  autoFixed?: boolean | null;
+  /** CTL-1220: true when this ticket was triaged (identified as fixable) by the recovery sweep. */
+  triaged?: boolean | null;
+  /** CTL-1220: ISO timestamp when the ticket was recovered/auto-fixed. */
+  recoveredAt?: string | null;
 }
 
 /** CTL-1110: the six extended escalation-explanation fields, surfaced as a nested

--- a/plugins/dev/scripts/orch-monitor/lib/notification-composer.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/notification-composer.test.ts
@@ -173,18 +173,16 @@ describe("composeNotification — edge cases", () => {
   });
 
   it("returns null for missing escalation", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = composeNotification("CTL-1000", null as any);
+    const result = composeNotification("CTL-1000", undefined);
     expect(result).toBeNull();
   });
 
   it("returns null for unknown escalation_type", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result = composeNotification("CTL-1000", {
-      escalation_type: "unknown" as any,
+      escalation_type: "invalid",
       problem: "test",
       call_to_action: "test",
-    });
+    } as unknown as EscalationPayload);
     expect(result).toBeNull();
   });
 

--- a/plugins/dev/scripts/orch-monitor/lib/notification-composer.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/notification-composer.test.ts
@@ -9,11 +9,11 @@
  * - ticket key is always included
  */
 
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { describe, it, expect } from "bun:test";
 import {
   composeNotification,
   EscalationPayload,
-  NotificationComposition,
 } from "./notification-composer";
 
 describe("composeNotification — manual escalation", () => {

--- a/plugins/dev/scripts/orch-monitor/lib/notification-composer.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/notification-composer.test.ts
@@ -173,11 +173,13 @@ describe("composeNotification — edge cases", () => {
   });
 
   it("returns null for missing escalation", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result = composeNotification("CTL-1000", null as any);
     expect(result).toBeNull();
   });
 
   it("returns null for unknown escalation_type", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result = composeNotification("CTL-1000", {
       escalation_type: "unknown" as any,
       problem: "test",

--- a/plugins/dev/scripts/orch-monitor/lib/notification-composer.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/notification-composer.test.ts
@@ -1,0 +1,219 @@
+/**
+ * CTL-1221: Notification Composer Tests
+ *
+ * Unit tests for composing notifications from escalation payloads.
+ * Verifies:
+ * - short_text respects 140-char limit
+ * - full_briefing includes all required sections per type
+ * - markdown structure is well-formed
+ * - ticket key is always included
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  composeNotification,
+  EscalationPayload,
+  NotificationComposition,
+} from "./notification-composer";
+
+describe("composeNotification — manual escalation", () => {
+  const manual: EscalationPayload = {
+    escalation_type: "manual",
+    problem: "Database connection pool exhausted, cannot acquire a lock",
+    call_to_action: "Increase max pool size and redeploy, then retry",
+    blocked_capability: "database transaction",
+    instructions: [
+      "SSH into prod-db-01",
+      "Check current pool size: SELECT count(*) FROM pg_stat_activity",
+      "Increase max_connections in postgresql.conf",
+    ],
+    remediation_then_retry:
+      "Redeploy with new pool config and monitor for 5 min",
+    why_not_auto: "Pool sizing is a capacity decision that affects other services",
+  };
+
+  it("composes short_text under 140 chars", () => {
+    const result = composeNotification("CTL-1200", manual);
+    expect(result).toBeTruthy();
+    expect(result!.short_text.length).toBeLessThanOrEqual(140);
+    expect(result!.short_text).toContain("CTL-1200");
+    expect(result!.short_text).toContain("database transaction");
+  });
+
+  it("composes full_briefing with all sections", () => {
+    const result = composeNotification("CTL-1200", manual);
+    expect(result!.full_briefing).toContain("## CTL-1200");
+    expect(result!.full_briefing).toContain("### Background");
+    expect(result!.full_briefing).toContain("### Blocked Capability");
+    expect(result!.full_briefing).toContain("### Steps");
+    expect(result!.full_briefing).toContain("### Why Automation Can't Do This");
+    expect(result!.full_briefing).toContain("### Next Steps");
+  });
+
+  it("includes numbered steps", () => {
+    const result = composeNotification("CTL-1200", manual);
+    expect(result!.full_briefing).toContain("1. SSH");
+    expect(result!.full_briefing).toContain("2. Check current");
+    expect(result!.full_briefing).toContain("3. Increase max");
+  });
+
+  it("preserves ticket key and escalation_type", () => {
+    const result = composeNotification("CTL-1200", manual);
+    expect(result!.ticket).toBe("CTL-1200");
+    expect(result!.escalation_type).toBe("manual");
+  });
+});
+
+describe("composeNotification — authorization escalation", () => {
+  const auth: EscalationPayload = {
+    escalation_type: "authorization",
+    problem: "Phase verify still failing after 3 remediation cycles",
+    call_to_action: "Approve retry or mark as blocked?",
+    recommendation: "Retry verify with extended timeout (60s)",
+    risk: "Extended timeout may mask a real timing issue; could regress performance",
+    why_asking: "Risk threshold exceeded; agent cannot retry autonomously",
+    could_higher_tier_resolve: true,
+    authorize_label: "approve-verify-retry",
+  };
+
+  it("composes short_text asking for approval", () => {
+    const result = composeNotification("CTL-1205", auth);
+    expect(result).toBeTruthy();
+    expect(result!.short_text.length).toBeLessThanOrEqual(140);
+    expect(result!.short_text).toContain("Approve");
+  });
+
+  it("composes full_briefing with decision context", () => {
+    const result = composeNotification("CTL-1205", auth);
+    expect(result!.full_briefing).toContain("## CTL-1205");
+    expect(result!.full_briefing).toContain("### Background");
+    expect(result!.full_briefing).toContain("### Why We're Asking");
+    expect(result!.full_briefing).toContain("### Our Recommendation");
+    expect(result!.full_briefing).toContain("### Risk");
+    expect(result!.full_briefing).toContain("### Your Decision");
+  });
+
+  it("notes when higher tier could resolve", () => {
+    const result = composeNotification("CTL-1205", auth);
+    expect(result!.full_briefing).toContain("higher-tier model");
+  });
+
+  it("preserves ticket and escalation_type", () => {
+    const result = composeNotification("CTL-1205", auth);
+    expect(result!.ticket).toBe("CTL-1205");
+    expect(result!.escalation_type).toBe("authorization");
+  });
+});
+
+describe("composeNotification — decision escalation", () => {
+  const decision: EscalationPayload = {
+    escalation_type: "decision",
+    problem: "Merging this PR would break the public API for existing clients",
+    call_to_action:
+      "Choose: bump major version now, or revert the breaking change?",
+    why_you: "This is a business/API contract decision the agent cannot make",
+    options: [
+      {
+        label: "Bump major version",
+        tradeoff: "Forces clients to upgrade; clear signal but operational load",
+        risk: "May break integrations that pin to older versions",
+      },
+      {
+        label: "Revert breaking change",
+        tradeoff: "Keeps API stable; loses the feature benefit",
+        risk: "Delaying the feature may impact roadmap",
+      },
+      {
+        label: "Soft deprecation + grace period",
+        tradeoff: "Supports both old and new APIs; extra maintenance",
+        risk: "Complex transition; client confusion if not well-communicated",
+      },
+    ],
+  };
+
+  it("composes short_text summarizing options", () => {
+    const result = composeNotification("CTL-1210", decision);
+    expect(result).toBeTruthy();
+    expect(result!.short_text.length).toBeLessThanOrEqual(140);
+    expect(result!.short_text).toContain("Choose path");
+  });
+
+  it("composes full_briefing with options table", () => {
+    const result = composeNotification("CTL-1210", decision);
+    expect(result!.full_briefing).toContain("## CTL-1210");
+    expect(result!.full_briefing).toContain("### Background");
+    expect(result!.full_briefing).toContain("### Why You Decide");
+    expect(result!.full_briefing).toContain("### Options");
+    expect(result!.full_briefing).toContain("### Your Decision");
+  });
+
+  it("formats options as markdown table", () => {
+    const result = composeNotification("CTL-1210", decision);
+    expect(result!.full_briefing).toContain("| Option | Trade-off | Risk |");
+    expect(result!.full_briefing).toContain("Bump major version");
+    expect(result!.full_briefing).toContain("Revert breaking");
+    expect(result!.full_briefing).toContain("Soft deprecation");
+  });
+
+  it("preserves ticket and escalation_type", () => {
+    const result = composeNotification("CTL-1210", decision);
+    expect(result!.ticket).toBe("CTL-1210");
+    expect(result!.escalation_type).toBe("decision");
+  });
+});
+
+describe("composeNotification — edge cases", () => {
+  it("returns null for missing ticket", () => {
+    const result = composeNotification("", {
+      escalation_type: "manual",
+      problem: "test",
+      call_to_action: "test",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null for missing escalation", () => {
+    const result = composeNotification("CTL-1000", null as any);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for unknown escalation_type", () => {
+    const result = composeNotification("CTL-1000", {
+      escalation_type: "unknown" as any,
+      problem: "test",
+      call_to_action: "test",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("handles missing optional fields gracefully", () => {
+    const minimal: EscalationPayload = {
+      escalation_type: "manual",
+      problem: "Something went wrong",
+      call_to_action: "Fix it",
+    };
+
+    const result = composeNotification("CTL-1300", minimal);
+    expect(result).toBeTruthy();
+    expect(result!.short_text).toContain("CTL-1300");
+    expect(result!.full_briefing).toContain("Something went wrong");
+  });
+
+  it("truncates long short_text with ellipsis", () => {
+    const longPayload: EscalationPayload = {
+      escalation_type: "authorization",
+      problem:
+        "This is a very long problem statement that will definitely exceed the 140 character limit when combined with the ticket key and other text",
+      call_to_action: "test",
+      recommendation:
+        "This is also a long recommendation that should get truncated",
+      risk: "This is a risk",
+    };
+
+    const result = composeNotification("CTL-1400", longPayload);
+    expect(result!.short_text.length).toBeLessThanOrEqual(140);
+    if (result!.short_text.length === 140) {
+      expect(result!.short_text).toContain("…");
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/notification-composer.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/notification-composer.ts
@@ -101,9 +101,6 @@ export function composeNotification(
 
   const type = escalation.escalation_type;
 
-  let shortText = "";
-  let fullBriefing = "";
-
   if (type === "manual") {
     return composeManualNotification(ticket, escalation);
   } else if (type === "authorization") {

--- a/plugins/dev/scripts/orch-monitor/lib/notification-composer.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/notification-composer.ts
@@ -1,0 +1,262 @@
+/**
+ * CTL-1221: Notification Composer
+ *
+ * Transforms escalation payloads from the recovery pass into executive-framed
+ * notifications (background, trade-off, CTA) suitable for push and briefing channels.
+ *
+ * Three escalation types:
+ * - MANUAL: blocked_capability + instructions → "fix this + retry"
+ * - AUTHORIZATION: risk + recommendation → "approve this decision?"
+ * - DECISION: options[] with trade-offs → "choose between these paths"
+ *
+ * Each transforms into:
+ * - short_text (≤140 char): for push channel (PWA, native)
+ * - full_briefing: markdown, for UI modal/dashboard display
+ */
+
+export interface EscalationOption {
+  label: string;
+  tradeoff: string;
+  risk?: string;
+}
+
+export interface EscalationPayload {
+  escalation_type: "manual" | "authorization" | "decision";
+  problem: string;
+  call_to_action: string;
+
+  // MANUAL-specific
+  blocked_capability?: string;
+  instructions?: string[];
+  remediation_then_retry?: string;
+  why_not_auto?: string;
+
+  // AUTHORIZATION-specific
+  recommendation?: string;
+  risk?: string;
+  why_asking?: string;
+  could_higher_tier_resolve?: boolean;
+  authorize_label?: string;
+
+  // DECISION-specific
+  options?: EscalationOption[];
+  why_you?: string;
+
+  // Optional passthrough fields (for auditing)
+  observed?: Record<string, unknown>;
+  attempts?: unknown[];
+}
+
+export interface NotificationComposition {
+  short_text: string; // ≤140 char for push channel
+  full_briefing: string; // markdown for dashboard
+  ticket?: string;
+  escalation_type: string;
+}
+
+/**
+ * Truncates text to a max length, appending ellipsis if needed.
+ */
+function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.substring(0, maxLen - 1) + "…";
+}
+
+/**
+ * Formats options as a markdown table row.
+ */
+function formatOptionsTable(options: EscalationOption[]): string {
+  if (options.length === 0) return "";
+  const rows = [
+    "| Option | Trade-off | Risk |",
+    "|--------|-----------|------|",
+    ...options.map(
+      (opt) =>
+        `| ${opt.label} | ${opt.tradeoff} | ${opt.risk || "—"} |`
+    ),
+  ];
+  return rows.join("\n");
+}
+
+/**
+ * Composes a notification from an escalation payload.
+ * Returns {short_text, full_briefing, ticket, escalation_type}.
+ *
+ * Each type follows a distinct pattern:
+ *
+ * MANUAL: "CTL-NNN: {blocked_capability} required — {problem}"
+ *   Background → Blocked capability → Steps → Trade-off → CTA
+ *
+ * AUTHORIZATION: "CTL-NNN: Approve {recommendation}? Risk: {risk}"
+ *   Background → Why asking → Recommendation → Risk → CTA
+ *
+ * DECISION: "CTL-NNN: Choose path — {opt1} vs {opt2}"
+ *   Background → Context → Options table → CTA
+ */
+export function composeNotification(
+  ticket: string,
+  escalation: EscalationPayload
+): NotificationComposition | null {
+  if (!escalation || !ticket) return null;
+
+  const type = escalation.escalation_type;
+
+  let shortText = "";
+  let fullBriefing = "";
+
+  if (type === "manual") {
+    return composeManualNotification(ticket, escalation);
+  } else if (type === "authorization") {
+    return composeAuthorizationNotification(ticket, escalation);
+  } else if (type === "decision") {
+    return composeDecisionNotification(ticket, escalation);
+  }
+
+  return null;
+}
+
+function composeManualNotification(
+  ticket: string,
+  e: EscalationPayload
+): NotificationComposition {
+  const capability = e.blocked_capability || "action";
+  const instructions = Array.isArray(e.instructions) ? e.instructions : [];
+
+  // Short text: capability + problem, truncated to 140 chars
+  const shortText = truncate(
+    `${ticket}: ${capability} required — ${e.problem}`,
+    140
+  );
+
+  // Full briefing: professional, action-oriented
+  const fullBriefing = [
+    `## ${ticket}: ${capability} Required`,
+    "",
+    "### Background",
+    e.problem,
+    "",
+    "### Blocked Capability",
+    `**${capability}** is required to continue. This is beyond what the automation layer can handle.`,
+    "",
+    instructions.length > 0
+      ? [
+          "### Steps",
+          instructions
+            .map((instr, i) => `${i + 1}. ${instr}`)
+            .join("\n"),
+          "",
+        ].join("\n")
+      : "",
+    "### Why Automation Can't Do This",
+    e.why_not_auto ||
+      "This decision requires human judgment or external approval.",
+    "",
+    "### Next Steps",
+    `Once you've completed the steps above:\n\n${e.remediation_then_retry || "Retry the phase."}`,
+    "",
+    "**CTA**: " + e.call_to_action,
+  ]
+    .filter((s) => s !== "")
+    .join("\n");
+
+  return {
+    short_text: shortText,
+    full_briefing: fullBriefing,
+    ticket,
+    escalation_type: "manual",
+  };
+}
+
+function composeAuthorizationNotification(
+  ticket: string,
+  e: EscalationPayload
+): NotificationComposition {
+  const recommendation = e.recommendation || "retry this ticket";
+  const risk = e.risk || "unknown risk";
+
+  // Short text: ask + decision, truncated to 140 chars
+  const shortText = truncate(
+    `${ticket}: Approve "${recommendation}"? Risk: ${risk}`,
+    140
+  );
+
+  // Full briefing: why asking + recommendation + risk + CTA
+  const fullBriefing = [
+    `## ${ticket}: Authorization Required`,
+    "",
+    "### Background",
+    e.problem,
+    "",
+    "### Why We're Asking",
+    e.why_asking ||
+      "The agent has exhausted its autonomous capability and needs your decision.",
+    "",
+    "### Our Recommendation",
+    `**${recommendation}**`,
+    "",
+    "### Risk",
+    risk,
+    "",
+    e.could_higher_tier_resolve
+      ? "**Note**: A higher-tier model may be able to resolve this autonomously.\n"
+      : "",
+    "### Your Decision",
+    `**${e.call_to_action || "Approve or cancel?"}**`,
+  ]
+    .filter((s) => s !== "")
+    .join("\n");
+
+  return {
+    short_text: shortText,
+    full_briefing: fullBriefing,
+    ticket,
+    escalation_type: "authorization",
+  };
+}
+
+function composeDecisionNotification(
+  ticket: string,
+  e: EscalationPayload
+): NotificationComposition {
+  const options = Array.isArray(e.options) ? e.options : [];
+  const optionLabels = options.map((opt) => opt.label).slice(0, 2);
+  const optionSummary =
+    optionLabels.length >= 2
+      ? `${optionLabels[0]} vs ${optionLabels[1]}`
+      : optionLabels[0] || "options";
+
+  // Short text: "choose between", truncated to 140 chars
+  const shortText = truncate(
+    `${ticket}: Choose path — ${optionSummary}`,
+    140
+  );
+
+  // Full briefing: background → context → options table → CTA
+  const optionsTable =
+    options.length > 0 ? formatOptionsTable(options) : "";
+
+  const fullBriefing = [
+    `## ${ticket}: Decision Needed`,
+    "",
+    "### Background",
+    e.problem,
+    "",
+    "### Why You Decide",
+    e.why_you ||
+      "The agent cannot unilaterally choose between these paths. Your judgment is needed.",
+    "",
+    optionsTable ? ["### Options", optionsTable, ""].join("\n") : "",
+    "### Your Decision",
+    e.call_to_action ||
+      "Review the options above and choose the best path forward.",
+  ]
+    .filter((s) => s !== "")
+    .join("\n");
+
+  return {
+    short_text: shortText,
+    full_briefing: fullBriefing,
+    ticket,
+    escalation_type: "decision",
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/lib/notification-composer.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/notification-composer.ts
@@ -95,7 +95,7 @@ function formatOptionsTable(options: EscalationOption[]): string {
  */
 export function composeNotification(
   ticket: string,
-  escalation: EscalationPayload
+  escalation: EscalationPayload | null | undefined
 ): NotificationComposition | null {
   if (!escalation || !ticket) return null;
 

--- a/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
@@ -113,6 +113,20 @@ export const AUDIT_MANIFEST: AttributeAuditEntry[] = [
   { key: "host.disk_total_gb",emitter: "mjs", source: "host.mjs:280", classification: "rename-to", targetName: "system.filesystem.capacity",   remediationCluster: "C", where: "both", note: "unit: ×1073741824 → bytes" },
   { key: "host.disk_used_pct",emitter: "mjs", source: "host.mjs:281", classification: "rename-to", targetName: "system.filesystem.utilization",remediationCluster: "C", where: "both", note: "unit: ÷100 → 0.0–1.0" },
 
+  // CTL-1227: Host metrics attributes — OTel semconv dimensions + catalyst.* custom
+  { key: "system.device",               emitter: "mjs", source: "host.mjs:379", classification: "conforming", note: "CTL-1227: filesystem device identifier" },
+  { key: "system.filesystem.mountpoint",emitter: "mjs", source: "host.mjs:380", classification: "conforming", note: "CTL-1227: filesystem mount point path" },
+  { key: "system.filesystem.type",      emitter: "mjs", source: "host.mjs:381", classification: "conforming", note: "CTL-1227: filesystem type (ext4, apfs, etc)" },
+  { key: "system.memory.state",         emitter: "mjs", source: "host.mjs:411", classification: "conforming", note: "CTL-1227: memory state dimension (used|free)" },
+  { key: "system.filesystem.state",     emitter: "mjs", source: "host.mjs:428", classification: "conforming", note: "CTL-1227: filesystem state dimension (used|free)" },
+  { key: "catalyst.directory",          emitter: "mjs", source: "host.mjs:457", classification: "legitimately-custom", note: "CTL-1227: directory path indicator (wt for worktree)" },
+  { key: "catalyst.measurement",        emitter: "mjs", source: "host.mjs:457", classification: "legitimately-custom", note: "CTL-1227: measurement type (logical_du for APFS clone-inflated values)" },
+  { key: "hw.type",                     emitter: "mjs", source: "host.mjs:473", classification: "conforming", note: "CTL-1227: hardware type (cpu for thermal)" },
+  { key: "host.disk_avail_gb",          emitter: "mjs", source: "host.mjs:554", classification: "legitimately-custom", note: "CTL-1227: unit: GB (1 decimal), available disk space" },
+  { key: "host.disk_free_pct",          emitter: "mjs", source: "host.mjs:555", classification: "legitimately-custom", note: "CTL-1227: unit: ÷100 percentage 0–100, available disk pct" },
+  { key: "host.worktree_used_gb",       emitter: "mjs", source: "host.mjs:556", classification: "legitimately-custom", note: "CTL-1227: unit: GB, logical (du) APFS-clone-inflated worktree usage" },
+  { key: "host.worktree_count",         emitter: "mjs", source: "host.mjs:557", classification: "legitimately-custom", note: "CTL-1227: count of active worktrees" },
+
   // ── MJS emitter — catalyst-agent/processes.mjs ───────────────────────────
   // §4k: Process metrics — partially conforming, cluster D
   { key: "process.command",  emitter: "mjs", source: "processes.mjs:283", classification: "conforming" },

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/home-inbox.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/home-inbox.ts
@@ -113,6 +113,10 @@ export interface InboxCounts {
   blocked: number;
   waiting: number;
   running: number;
+  /** CTL-1220: tickets auto-fixed by the recovery sweep (enforce mode). */
+  autoFixed: number;
+  /** CTL-1220: tickets identified as fixable by the recovery sweep (shadow mode). */
+  triaged: number;
   /** CTL-1050: current service outages (the awareness section) — NOT a needs-you
    *  count and NOT folded into needsYou / the all-clear gate. */
   awareness: number;
@@ -336,6 +340,8 @@ export function deriveInbox(payload: BoardPayload): InboxModel {
     blocked: buckets.blocked.length,
     waiting: buckets.waiting.length,
     running: buckets.running.length,
+    autoFixed: 0, // CTL-1220: to be populated by the monitor
+    triaged: 0, // CTL-1220: to be populated by the monitor
     awareness: buckets.awareness.length,
     done: buckets.done.length,
     // CTL-729: the single "N need you" figure absorbs the attention bucket.

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
@@ -170,6 +170,12 @@ export interface BoardTicket {
    *  card. null/absent unless attention is needs-human and a signal carried the
    *  extended fields. */
   explanation?: BoardEscalationExplanation | null;
+  /** CTL-1220: true when this ticket was auto-fixed by the recovery sweep. */
+  autoFixed?: boolean | null;
+  /** CTL-1220: true when this ticket was triaged (identified as fixable) by the recovery sweep. */
+  triaged?: boolean | null;
+  /** CTL-1220: ISO timestamp when the ticket was recovered/auto-fixed. */
+  recoveredAt?: string | null;
   // ── CTL-902 (HOME4): the reading-pane CONTENT fields ─────────────────────
   // The "What's needed now" hero + the About block read these. They are NOT in
   // the board payload today — they derive from the ticket's AI summary + the


### PR DESCRIPTION
## Summary
Implements the notification composer for CTL-1221 — transforms escalation payloads from the recovery pass (CTL-1176) into executive-framed notifications suitable for push and briefing channels.

- **Composer module** (`notification-composer.ts`): Three escalation types (manual, authorization, decision) → {short_text ≤140 chars, full_briefing markdown}
- **Unit tests** (17 passing): Verifies short_text length, full_briefing structure, markdown well-formedness
- **Writing style**: Professional, action-oriented tone per Ryan's rules; lead with ask, use structured sections

## Escalation Types Supported
1. **MANUAL** (blocked_capability): "fix this + retry" — background → blocked → steps → trade-off → CTA
2. **AUTHORIZATION** (risk + recommendation): "approve this decision?" — background → why asking → recommendation → risk → CTA  
3. **DECISION** (options[]): "choose path" — background → context → options table → CTA

## Test Plan
- [x] All 17 unit tests pass
- [x] Verifies short_text ≤140 chars with ellipsis truncation
- [x] Verifies full_briefing has required sections per type
- [x] Edge cases: missing fields, null inputs, unknown types
- [ ] Integration with shouldNotify (CTL-1167) — follow-up
- [ ] Manual test: real escalation from recovery pass

## Next Steps
- Integrate `composeNotification()` into `notification-filter.ts`'s `shouldNotify()` (CTL-1167)
- Wire escalation payload into board-recompute cycle
- Test with real escalations from recovery pass

Blocks CTL-1222 (deep-link ticket). Unblocked by CTL-1176 (Done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)