### PR TITLE
fix(dev): CTL-1176 — raise escalation bar: merge conflicts → BOUNDED-LLM, not HUMAN

### DIFF
--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -262,33 +262,37 @@ export function defaultClassifyTicket(evidence, opts = {}) {
 
 // Check for deterministic errors that have registered seams
 export function checkDeterministicErrors(logsOutput, failureReason) {
+  // Check failureReason shortcuts first (no log scan needed)
+  if (failureReason === "orphan-sweep-stale") {
+    return {
+      fix_class: "orphan_stale",
+      seam_id: "orphan-reconcile",
+      reason: "Orphan PR reconciliation needed",
+    };
+  }
+  // Merge-conflict and rebase-failed via failureReason → bounded-LLM, not a seam stub.
+  // These are handled by checkBoundedLlmFixes; signal here so the caller can short-circuit
+  // without a log scan when the signal file already contains the structured reason.
+  if (failureReason === "merge-conflict" || failureReason === "rebase-failed") {
+    return null; // fall through to bounded-LLM
+  }
+
   if (!logsOutput) {
-    // Check failureReason as fallback
-    if (failureReason === "orphan-sweep-stale") {
-      return {
-        fix_class: "orphan_stale",
-        seam_id: "orphan-reconcile",
-        reason: "Orphan PR reconciliation needed",
-      };
-    }
     return null;
   }
 
   const logs = String(logsOutput).toLowerCase();
 
-  // Known deterministic patterns (stub; real implementation would check seam registry CTL-1219)
+  // Known deterministic patterns (stub; real implementation would check seam registry CTL-1219).
+  // NOTE: merge_conflict is intentionally absent here. Real git conflicts ("CONFLICT (content):",
+  // "rebase conflict", "could not apply") are resolvable by an agent reading both sides —
+  // they belong in checkBoundedLlmFixes, not in a seam stub that always returns success:false.
   const patterns = [
     {
       pattern: "push.*rejected.*no.*workflow.*scope",
       fix_class: "push_rejected_no_workflow_scope",
       seam_id: "workflow-token-fallback",
       reason: "Push rejected: GitHub workflow scope missing",
-    },
-    {
-      pattern: "conflict.*merge.*tree",
-      fix_class: "merge_conflict",
-      seam_id: "force-rebase",
-      reason: "Merge conflict detected; rebase and retry",
     },
     {
       pattern: "unknown.*command",
@@ -308,46 +312,68 @@ export function checkDeterministicErrors(logsOutput, failureReason) {
     }
   }
 
-  // Fallback: check failureReason if provided
-  if (failureReason === "orphan-sweep-stale") {
-    return {
-      fix_class: "orphan_stale",
-      seam_id: "orphan-reconcile",
-      reason: "Orphan PR reconciliation needed",
-    };
-  }
-
   return null;
 }
 
 // Check for bounded-LLM fixes (small, verifiable)
 export function checkBoundedLlmFixes(logsOutput, jobState, signal) {
-  if (!logsOutput && !jobState) return null;
+  if (!logsOutput && !jobState && !signal) return null;
 
   const logs = String(logsOutput || "").toLowerCase();
   const details = jobState?.detail || "";
+  const signalFailure = signal?.failureReason || "";
 
-  // Bounded-LLM patterns: small fixes that are verifiable via one phase-remediate run
+  // Bounded-LLM patterns: small fixes that are verifiable via one phase-remediate run.
+  //
+  // Escalation bar is HIGH. An agent with full tool access can resolve most merge conflicts
+  // if it reads both sides carefully. Only escalate when the conflict is a genuine design
+  // incompatibility (two features that cannot coexist as shipped), requires approval (deleting
+  // a merged feature), or the agent explicitly cannot determine which approach is correct after
+  // trying. NOT reasons to escalate: conflict in a file, CI failure after rebase, stale branch.
   const patterns = [
+    // ── Merge / rebase conflicts ──────────────────────────────────────────────────────────
+    // Real git conflict output: "CONFLICT (content):", "merge conflict in", "could not apply",
+    // "rebase conflict", "conflict merge tree". All are BOUNDED-LLM: read both sides, pick the
+    // change consistent with this ticket's goal, only escalate if fix would delete another
+    // ticket's already-merged feature or if the conflict spans a load-bearing API boundary.
     {
-      pattern: "stale.*main",
+      pattern: "conflict.*merge.*tree|merge conflict in|conflict \\(content\\)|could not apply|rebase.*conflict",
+      reason: "Merge/rebase conflict detected; agent should read both sides and resolve",
+      brief: generateRemediateBrief("merge-conflict"),
+      failureReasons: ["merge-conflict", "rebase-failed"],
+    },
+    // ── Stale branch / stale PR ───────────────────────────────────────────────────────────
+    {
+      pattern: "stale.*main|branch.*diverged|your branch is behind",
       reason: "Working tree diverged from origin/main; rebase needed",
-      brief: "Rebase against origin/main and retry",
+      brief: generateRemediateBrief("stale-branch"),
+      failureReasons: ["stale-pr"],
     },
+    // ── CI failure after rebase ───────────────────────────────────────────────────────────
     {
-      pattern: "bun.*install",
-      reason: "Package dependencies out of sync",
-      brief: "Run bun install in affected packages and retry",
+      pattern: "ci.*fail|check.*fail|test.*fail|lint.*fail",
+      reason: "CI failure detected after rebase or push; agent should read logs and fix",
+      brief: generateRemediateBrief("ci-failure"),
+      failureReasons: ["ci-failure-after-rebase"],
     },
+    // ── Package dependency issues ─────────────────────────────────────────────────────────
+    {
+      pattern: "bun.*install|cannot find package",
+      reason: "Package dependencies out of sync",
+      brief: generateRemediateBrief("bun-install"),
+    },
+    // ── TypeScript errors ─────────────────────────────────────────────────────────────────
     {
       pattern: "typescript.*error|ts.*error",
       reason: "TypeScript errors detected",
-      brief: "Review and fix type errors, retry phase",
+      brief: generateRemediateBrief("typescript-error"),
     },
   ];
 
   for (const p of patterns) {
-    if (new RegExp(p.pattern).test(logs) || new RegExp(p.pattern).test(details)) {
+    const logMatch = new RegExp(p.pattern, "i").test(logs) || new RegExp(p.pattern, "i").test(details);
+    const signalMatch = p.failureReasons?.includes(signalFailure);
+    if (logMatch || signalMatch) {
       return {
         reason: p.reason,
         brief: p.brief,
@@ -356,6 +382,36 @@ export function checkBoundedLlmFixes(logsOutput, jobState, signal) {
   }
 
   return null;
+}
+
+// Generate a structured brief for phase-remediate that includes explicit instruction
+// on escalation bar: only return HUMAN if the fix would delete another ticket's merged feature.
+export function generateRemediateBrief(category) {
+  const briefs = {
+    "merge-conflict": [
+      "Read both sides of every conflicting hunk (git diff HEAD...MERGE_HEAD or git log --merge).",
+      "Keep the changes consistent with this ticket's stated goal.",
+      "If the conflict is purely additive (both sides add different things), keep both.",
+      "Only return HUMAN if: (a) resolving would delete another ticket's already-merged feature,",
+      "  (b) the conflict spans a load-bearing API boundary where the right choice is a design decision,",
+      "  or (c) you have tried and genuinely cannot determine which approach is correct.",
+      "After resolving: git add, git rebase --continue, push, re-trigger the failed phase.",
+    ].join(" "),
+    "stale-branch": [
+      "Rebase against origin/main: git fetch origin && git rebase --autostash origin/main.",
+      "If rebase produces conflicts, treat as merge-conflict brief.",
+      "Force-push the rebased branch and re-trigger the CI check.",
+    ].join(" "),
+    "ci-failure": [
+      "Read the CI failure logs (gh run view --log-failed).",
+      "Fix the root cause (type error, lint, test failure).",
+      "Commit the fix and push to re-trigger CI.",
+      "Only escalate if the failure requires a design decision that is out of scope for this ticket.",
+    ].join(" "),
+    "bun-install": "Run bun install in affected packages and retry the phase.",
+    "typescript-error": "Review and fix type errors reported by the compiler, then retry the phase.",
+  };
+  return briefs[category] ?? `Resolve the ${category} issue and retry the phase.`;
 }
 
 // Determine escalation reason (human decision)

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -9,6 +9,7 @@ import {
   checkDeterministicErrors,
   checkBoundedLlmFixes,
   determineEscalationReason,
+  generateRemediateBrief,
 } from "./recovery-reasoning.mjs";
 
 describe("checkDeterministicErrors", () => {
@@ -22,19 +23,47 @@ describe("checkDeterministicErrors", () => {
     expect(result.seam_id).toBe("workflow-token-fallback");
   });
 
-  test("detects merge_conflict pattern", () => {
+  // Merge conflicts are NO LONGER deterministic (seam stub always returned success:false).
+  // They are now BOUNDED-LLM so the agent reads both sides and resolves them.
+  test("does NOT classify merge_conflict as deterministic (falls to bounded-LLM)", () => {
     const result = checkDeterministicErrors(
       "Merge conflict detected in merge tree analysis",
       null,
     );
-    expect(result).not.toBeNull();
-    expect(result.fix_class).toBe("merge_conflict");
+    expect(result).toBeNull();
+  });
+
+  test("does NOT classify CONFLICT (content): output as deterministic", () => {
+    const result = checkDeterministicErrors(
+      "CONFLICT (content): Merge conflict in src/foo.ts",
+      null,
+    );
+    expect(result).toBeNull();
+  });
+
+  test("does NOT classify rebase conflict output as deterministic", () => {
+    const result = checkDeterministicErrors(
+      "error: could not apply abc1234... feat: add thing",
+      null,
+    );
+    expect(result).toBeNull();
   });
 
   test("detects orphan-sweep-stale via failureReason", () => {
     const result = checkDeterministicErrors(null, "orphan-sweep-stale");
     expect(result).not.toBeNull();
     expect(result.fix_class).toBe("orphan_stale");
+  });
+
+  // merge-conflict / rebase-failed failureReasons fall through to bounded-LLM
+  test("returns null for merge-conflict failureReason (falls to bounded-LLM)", () => {
+    const result = checkDeterministicErrors(null, "merge-conflict");
+    expect(result).toBeNull();
+  });
+
+  test("returns null for rebase-failed failureReason (falls to bounded-LLM)", () => {
+    const result = checkDeterministicErrors(null, "rebase-failed");
+    expect(result).toBeNull();
   });
 
   test("returns null for unknown errors", () => {
@@ -44,12 +73,91 @@ describe("checkDeterministicErrors", () => {
 });
 
 describe("checkBoundedLlmFixes", () => {
+  // ── Merge / rebase conflict patterns ───────────────────────────────────────
+  test("detects conflict.*merge.*tree log pattern as bounded-LLM", () => {
+    const result = checkBoundedLlmFixes("Merge conflict detected in merge tree analysis", null, {});
+    expect(result).not.toBeNull();
+    expect(result.reason).toContain("Merge/rebase conflict");
+    expect(result.brief).toContain("Read both sides");
+  });
+
+  test("detects CONFLICT (content): git output as bounded-LLM", () => {
+    const result = checkBoundedLlmFixes(
+      "CONFLICT (content): Merge conflict in src/app/server.ts",
+      null,
+      {},
+    );
+    expect(result).not.toBeNull();
+    expect(result.reason).toContain("Merge/rebase conflict");
+  });
+
+  test("detects 'merge conflict in' git output as bounded-LLM", () => {
+    const result = checkBoundedLlmFixes(
+      "Auto-merging src/foo.ts\nmerge conflict in src/foo.ts",
+      null,
+      {},
+    );
+    expect(result).not.toBeNull();
+    expect(result.reason).toContain("Merge/rebase conflict");
+  });
+
+  test("detects 'could not apply' rebase failure as bounded-LLM", () => {
+    const result = checkBoundedLlmFixes(
+      "error: could not apply abc1234... feat: add thing",
+      null,
+      {},
+    );
+    expect(result).not.toBeNull();
+    expect(result.reason).toContain("Merge/rebase conflict");
+  });
+
+  test("detects rebase.*conflict pattern as bounded-LLM", () => {
+    const result = checkBoundedLlmFixes("rebase conflict encountered during merge", null, {});
+    expect(result).not.toBeNull();
+    expect(result.reason).toContain("Merge/rebase conflict");
+  });
+
+  test("detects merge-conflict failureReason via signal as bounded-LLM", () => {
+    const result = checkBoundedLlmFixes(null, null, { failureReason: "merge-conflict" });
+    expect(result).not.toBeNull();
+    expect(result.reason).toContain("Merge/rebase conflict");
+  });
+
+  test("detects rebase-failed failureReason via signal as bounded-LLM", () => {
+    const result = checkBoundedLlmFixes(null, null, { failureReason: "rebase-failed" });
+    expect(result).not.toBeNull();
+    expect(result.reason).toContain("Merge/rebase conflict");
+  });
+
+  // ── Stale branch / stale PR ────────────────────────────────────────────────
   test("detects stale main pattern", () => {
     const result = checkBoundedLlmFixes("Your branch is stale with respect to main", null, {});
     expect(result).not.toBeNull();
     expect(result.reason).toContain("diverged from origin/main");
+    expect(result.brief).toContain("git fetch origin");
   });
 
+  test("detects stale-pr failureReason via signal", () => {
+    const result = checkBoundedLlmFixes(null, null, { failureReason: "stale-pr" });
+    expect(result).not.toBeNull();
+    expect(result.reason).toContain("diverged from origin/main");
+  });
+
+  // ── CI failure after rebase ────────────────────────────────────────────────
+  test("detects CI failure pattern as bounded-LLM", () => {
+    const result = checkBoundedLlmFixes("Check suite failed: CI tests failed on push", null, {});
+    expect(result).not.toBeNull();
+    expect(result.reason).toContain("CI failure");
+    expect(result.brief).toContain("gh run view");
+  });
+
+  test("detects ci-failure-after-rebase failureReason via signal", () => {
+    const result = checkBoundedLlmFixes(null, null, { failureReason: "ci-failure-after-rebase" });
+    expect(result).not.toBeNull();
+    expect(result.reason).toContain("CI failure");
+  });
+
+  // ── Package / TypeScript ───────────────────────────────────────────────────
   test("detects bun install pattern", () => {
     const result = checkBoundedLlmFixes(
       "Cannot find package pino; bun install required",
@@ -78,6 +186,37 @@ describe("checkBoundedLlmFixes", () => {
   test("returns null for unknown fixes", () => {
     const result = checkBoundedLlmFixes("mysterious error", null, {});
     expect(result).toBeNull();
+  });
+});
+
+describe("generateRemediateBrief", () => {
+  test("merge-conflict brief instructs agent to read both sides", () => {
+    const brief = generateRemediateBrief("merge-conflict");
+    expect(brief).toContain("Read both sides");
+    expect(brief).toContain("Only return HUMAN if");
+    expect(brief).toContain("already-merged feature");
+  });
+
+  test("stale-branch brief instructs rebase", () => {
+    const brief = generateRemediateBrief("stale-branch");
+    expect(brief).toContain("git fetch origin");
+    expect(brief).toContain("git rebase");
+  });
+
+  test("ci-failure brief instructs reading CI logs", () => {
+    const brief = generateRemediateBrief("ci-failure");
+    expect(brief).toContain("gh run view");
+  });
+
+  test("bun-install brief is concise", () => {
+    const brief = generateRemediateBrief("bun-install");
+    expect(brief).toContain("bun install");
+  });
+
+  test("unknown category returns fallback string", () => {
+    const brief = generateRemediateBrief("totally-unknown");
+    expect(brief).toContain("totally-unknown");
+    expect(brief).toContain("retry the phase");
   });
 });
 
@@ -114,9 +253,46 @@ describe("defaultClassifyTicket", () => {
     expect(result.fix_class).toBe("push_rejected_no_workflow_scope");
   });
 
-  test("classifies bounded-LLM as fix", () => {
+  test("classifies stale-main as bounded-LLM fix", () => {
     const result = defaultClassifyTicket({
       logsOutput: "Your branch is stale with respect to main",
+    });
+    expect(result.decision).toBe("fix");
+    expect(result.fix_class).toBe("bounded-llm");
+  });
+
+  // CTL-1176: merge conflicts → BOUNDED-LLM, not HUMAN
+  test("classifies merge conflict log output as bounded-LLM fix (not escalate)", () => {
+    const result = defaultClassifyTicket({
+      logsOutput: "CONFLICT (content): Merge conflict in src/server.ts",
+    });
+    expect(result.decision).toBe("fix");
+    expect(result.fix_class).toBe("bounded-llm");
+    expect(result.details.brief).toContain("Read both sides");
+  });
+
+  test("classifies merge-conflict failureReason as bounded-LLM fix", () => {
+    const result = defaultClassifyTicket({
+      logsOutput: null,
+      signal: { failureReason: "merge-conflict" },
+    });
+    expect(result.decision).toBe("fix");
+    expect(result.fix_class).toBe("bounded-llm");
+  });
+
+  test("classifies rebase-failed failureReason as bounded-LLM fix", () => {
+    const result = defaultClassifyTicket({
+      logsOutput: null,
+      signal: { failureReason: "rebase-failed" },
+    });
+    expect(result.decision).toBe("fix");
+    expect(result.fix_class).toBe("bounded-llm");
+  });
+
+  test("classifies ci-failure-after-rebase as bounded-LLM fix", () => {
+    const result = defaultClassifyTicket({
+      logsOutput: null,
+      signal: { failureReason: "ci-failure-after-rebase" },
     });
     expect(result.decision).toBe("fix");
     expect(result.fix_class).toBe("bounded-llm");


### PR DESCRIPTION
## Summary

- Merge conflicts, rebase failures, CI failures after rebase, and stale PRs now route to **BOUNDED-LLM** (agent reads both sides and resolves) instead of immediately escalating to human
- Removes `merge_conflict` from deterministic patterns — the `force-rebase` seam was a stub that always returned `success: false`, meaning every conflict hit emitted `recovery.fix-failed` without ever trying anything
- Broadens conflict detection to real git output: `CONFLICT (content):`, `merge conflict in`, `could not apply`, `rebase.*conflict` — not just the narrow `conflict.*merge.*tree` phrase
- Adds `failureReason` shortcuts: `merge-conflict`, `rebase-failed`, `stale-pr`, `ci-failure-after-rebase` all route to BOUNDED-LLM via the signal object (no log scan needed)
- Adds `generateRemediateBrief(category)` — builds a structured brief for phase-remediate with an explicit escalation bar per category. For merge conflicts: "Only return HUMAN if the fix would delete another ticket's already-merged feature or the conflict spans a load-bearing API boundary."

## Escalation bar (philosophy encoded in the briefs)

**NOT a reason to escalate:**
- Merge conflict in a file → BOUNDED-LLM (agent reads both sides, picks the change consistent with this ticket's goal)
- CI failure after rebase → BOUNDED-LLM (agent reads CI logs, fixes)
- Stale branch → BOUNDED-LLM (git fetch + rebase)
- "I'm not sure which way to go" without trying → push harder

**Legitimate reasons to escalate:**
- Conflict requires deleting another ticket's already-merged feature
- Conflict spans a load-bearing API boundary where the right choice is a genuine design decision
- Agent tried and explicitly cannot determine which approach is correct

## Test plan

- [ ] `bun test recovery-reasoning.test.mjs` → 48 pass (was 25)
- [ ] `CONFLICT (content):` git output routes to bounded-LLM, not escalate
- [ ] `merge-conflict` failureReason via signal routes to bounded-LLM
- [ ] `ci-failure-after-rebase` failureReason via signal routes to bounded-LLM
- [ ] `push rejected no workflow scope` still routes deterministic (seam)
- [ ] Unknown errors still escalate to human
- [ ] `generateRemediateBrief("merge-conflict")` contains explicit HUMAN threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)