### PR TITLE
fix(dev): CTL-1176 — wire reasoningRecoveryPass into scheduler as autonomous Pass 0r

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -762,6 +762,37 @@ export function isThrottled(lastRunMs, intervalMs, nowMs) {
   return (nowMs - lastRunMs) < intervalMs;
 }
 
+// CTL-1176: Pass 0r — LLM reasoning recovery pass config reader.
+// Mirrors readUnstuckSweepConfig exactly: env (CATALYST_RECOVERY_PASS) overrides
+// Layer-2 config (.catalyst.recovery.pass.mode), which overrides the safe
+// default of 'off'. Ships off (ADR-023); operators opt in to shadow then enforce.
+const RECOVERY_PASS_MODES = new Set(["off", "shadow", "enforce"]);
+
+function readLayer2RecoveryPass() {
+  try {
+    const rp = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.recovery?.pass;
+    return rp && typeof rp === "object" ? rp : {};
+  } catch { return {}; }
+}
+
+export function readRecoveryPassConfig() {
+  const l2 = readLayer2RecoveryPass();
+  // CATALYST_RECOVERY_PASS is the single operator knob:
+  //   "0" → off (kill-switch), off|shadow|enforce → that mode, anything else → off.
+  const env = process.env.CATALYST_RECOVERY_PASS;
+  let mode;
+  if (env === "0") {
+    mode = "off";
+  } else if (typeof env === "string" && RECOVERY_PASS_MODES.has(env)) {
+    mode = env;
+  } else if (typeof l2.mode === "string" && RECOVERY_PASS_MODES.has(l2.mode)) {
+    mode = l2.mode;
+  } else {
+    mode = "off"; // safe default: off — operators opt into shadow then enforce
+  }
+  return { mode };
+}
+
 // --- Governance snapshot for operator visibility (CTL-1062/CTL-1084) ---
 // READ-ONLY, NEVER load-bearing. Recomputes each governance value the same way
 // its per-tick gate site does so the heartbeat payload and the

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -184,12 +184,15 @@ import {
   defaultCollectUnstuckCandidates,
   emitUnstuckEvent,
 } from "./unstuck-sweep.mjs";
+// CTL-1176: Pass 0r — LLM reasoning recovery pass. Ships off by default (ADR-023);
+// operators opt in via CATALYST_RECOVERY_PASS=shadow then =enforce.
+import { reasoningRecoveryPass } from "./recovery-reasoning.mjs";
 // CTL-1219: the per-category enforcement seam registry (dirty-tree /
 // source-conflict / orphan-stale / stale-label). Pure-cored + injectable; bound
 // to production deps at the unstuckSweep wiring point below. Wiring this does NOT
 // flip enforce on — the mode gate stays at its safe 'off' default (ADR-023).
 import { buildUnstuckActSeams } from "./unstuck-act-seams.mjs";
-import { readUnstuckSweepConfig, isThrottled } from "./config.mjs";
+import { readUnstuckSweepConfig, readRecoveryPassConfig, isThrottled } from "./config.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
 // module (best-effort — every write swallows its own failures).
@@ -2665,6 +2668,11 @@ export function schedulerTick(
       postComment: _unstuckPostComment = undefined,
       nowMs: _unstuckNowMs = undefined,
     } = {},
+    // CTL-1176: Pass 0r — recovery-reasoning pass seams. Default undefined keeps
+    // a bare tick fully inert. Production passes mode from env > Layer-2.
+    recoveryPass: {
+      mode: _recoveryPassMode = undefined,
+    } = {},
     // CTL-1095: drain gate — node-level refusal of new-work admission. Default
     // reads the drain flag file from orchDir; tests inject a stub.
     isDraining = () => isDrainingDefault(orchDir),
@@ -3319,6 +3327,51 @@ export function schedulerTick(
         log.warn(
           { step: "unstuck-sweep", err: err.message },
           "scheduler: unstuck-sweep pass failed — continuing tick (CTL-1064)"
+        );
+      }
+    }
+  }
+
+  // CTL-1176: Pass 0r — LLM reasoning recovery pass. Low-frequency autonomous
+  // triage of the stalled/failed/needs-human/UNKNOWN backlog. Mode resolves from
+  // readRecoveryPassConfig() (env CATALYST_RECOVERY_PASS > Layer-2
+  // .catalyst.recovery.pass.mode > 'off'). Ships off by default (ADR-023);
+  // operators opt in via CATALYST_RECOVERY_PASS=shadow then =enforce.
+  {
+    const rcfg = readRecoveryPassConfig();
+    const rMode = _recoveryPassMode ?? rcfg.mode;
+    if (rMode !== "off") {
+      try {
+        const rItems = readWorkerSignals(orchDir)
+          .filter(
+            (sig) =>
+              sig.status === "needs-human" ||
+              sig.status === "failed" ||
+              sig.status === "stalled" ||
+              resolveTicketType(orchDir, sig.ticket) === "unknown"
+          )
+          .map((sig) => ({
+            ticket: sig.ticket,
+            phase: sig.phase,
+            evidence: sig.raw ?? {},
+          }));
+        if (rItems.length > 0) {
+          const rResult = reasoningRecoveryPass(rItems, { mode: rMode });
+          if (rResult.processed > 0) {
+            log.info(
+              {
+                mode: rMode,
+                processed: rResult.processed,
+                results: rResult.results.length,
+              },
+              "scheduler: recovery-reasoning pass (CTL-1176)"
+            );
+          }
+        }
+      } catch (err) {
+        log.warn(
+          { step: "recovery-pass", err: err.message },
+          "scheduler: recovery-reasoning pass failed — continuing tick (CTL-1176)"
         );
       }
     }


### PR DESCRIPTION
Wires the CTL-1176 LLM reasoning recovery pass into the execution-core scheduler tick as Pass 0r, running after deterministic Pass 0u (unstuck-sweep) and before the CTL-644 approval poll. Ships mode=off (ADR-023). Set CATALYST_RECOVERY_PASS=shadow or =enforce to activate.

## Changes

**`config.mjs`** — adds `readRecoveryPassConfig()` mirroring `readUnstuckSweepConfig()` exactly:
- Reads `CATALYST_RECOVERY_PASS` env var (kill-switch "0" forces off)
- Falls through to Layer-2 `.catalyst.recovery.pass.mode`
- Safe default: `"off"` — operators opt into shadow then enforce

**`scheduler.mjs`** — imports `readRecoveryPassConfig`; replaces the preliminary Pass 0r stub with the full implementation:
- Mode resolves via `_recoveryPassMode ?? readRecoveryPassConfig().mode`
- Census from `readWorkerSignals(orchDir)` filtered for `signalStatus ∈ {needs-human, failed, stalled}` or `resolveTicketType(orchDir, ticket) === "unknown"` (classification=UNKNOWN)
- Calls `reasoningRecoveryPass(items, { mode: rMode })`
- try/catch with `log.warn` on error — mirrors Pass 0u shape exactly
- Positioned between Pass 0u closing brace and CTL-644 `processApprovedResumes`

## Test results

4161 pass, 6 fail — the 6 failures are pre-existing on `origin/main` (verified by running the same test files against the base branch before applying changes).