### PR TITLE
CTL-1232 — /debug/memory + /debug/heap-snapshot endpoints (+ full-read counters) to diagnose the monitor's ~6.5GB RSS

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/event-log-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/event-log-reader.test.ts
@@ -8,7 +8,13 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { readBacklog, tailEventLog, readTunnelEventStats } from "../lib/event-log-reader";
+import {
+  readBacklog,
+  tailEventLog,
+  readTunnelEventStats,
+  fullReadMetrics,
+  recordFullRead,
+} from "../lib/event-log-reader";
 import { createEventRing } from "../lib/event-ring";
 
 let workdir: string;
@@ -518,6 +524,52 @@ describe("readTunnelEventStats (ring fast-path)", () => {
       // fallback must still count the older-in-window event from the file
       expect(r.eventCount24h).toBe(2);
       expect(r.eventCount24hByRepo).toEqual({ "org/old": 1, "org/new": 1 });
+    } finally {
+      ring.stop();
+    }
+  });
+});
+
+// CTL-1232: profiling counters for the full-log readFileSync fallback paths.
+// These are the suspected driver of the monitor's high-water RSS — surfaced by
+// GET /debug/memory so the offending path + cadence are visible in live traffic.
+describe("full-read counters (CTL-1232)", () => {
+  it("recordFullRead increments count and records bytes/ms/ts per label", () => {
+    const label = "ctl1232-unit-test";
+    const before = fullReadMetrics[label]?.count ?? 0;
+    recordFullRead(label, 123, 4.5);
+    expect(fullReadMetrics[label].count).toBe(before + 1);
+    expect(fullReadMetrics[label].lastBytes).toBe(123);
+    expect(fullReadMetrics[label].lastMs).toBe(4.5);
+    expect(fullReadMetrics[label].lastTs.length).toBeGreaterThan(0);
+    recordFullRead(label, 456, 6.7);
+    expect(fullReadMetrics[label].count).toBe(before + 2);
+    expect(fullReadMetrics[label].lastBytes).toBe(456);
+  });
+
+  it("readTunnelEventStats records a 'tunnelStats' full read on the file-fallback path (no ring)", () => {
+    eventsDir();
+    const before = fullReadMetrics.tunnelStats?.count ?? 0;
+    readTunnelEventStats(workdir, undefined, () => new Date("2026-05-04T12:00:00Z"));
+    expect(fullReadMetrics.tunnelStats?.count ?? 0).toBe(before + 1);
+  });
+
+  it("readTunnelEventStats does NOT record a full read when the ring covers the window (fast-path)", () => {
+    eventsDir();
+    const now = new Date("2026-05-04T12:00:00Z");
+    const lines = [
+      // an event older than the 24h cutoff so the ring's oldestTs covers the window
+      makeGithubLine("org/old", "2026-05-03T09:00:00Z"),
+      makeGithubLine("org/a", "2026-05-04T10:00:00Z"),
+      makeGithubLine("org/b", "2026-05-04T11:00:00Z"),
+    ];
+    writeFileSync(join(workdir, "events", "2026-05.jsonl"), lines.join("\n") + "\n");
+    const ring = createEventRing({ catalystDir: workdir, now: () => now });
+    ring.start();
+    try {
+      const before = fullReadMetrics.tunnelStats?.count ?? 0;
+      readTunnelEventStats(workdir, ring, () => now); // ring fast-path → no file read
+      expect(fullReadMetrics.tunnelStats?.count ?? 0).toBe(before);
     } finally {
       ring.stop();
     }

--- a/plugins/dev/scripts/orch-monitor/__tests__/event-ring.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/event-ring.test.ts
@@ -103,6 +103,47 @@ describe("createEventRing", () => {
     }
   });
 
+  it("byteSize() reports the UTF-8 content bytes of retained lines; capacity() reports capLines (CTL-1232)", () => {
+    eventsDir();
+    const now = new Date("2026-06-04T00:00:00Z");
+    const lines = Array.from({ length: 5 }, (_, i) =>
+      line(`evt-${i}`, "2026-06-04T00:00:00Z"),
+    );
+    writeFileSync(monthFile(now), lines.join("\n") + "\n");
+
+    const ring = createEventRing({ catalystDir: workdir, capLines: 1234, now: () => now });
+    ring.start();
+    try {
+      // capacity reflects the configured cap, regardless of current fill.
+      expect(ring.capacity()).toBe(1234);
+      // byteSize equals the sum of UTF-8 byte lengths of exactly the retained lines.
+      const retained = ring.query({ limit: 10_000 });
+      const expectedBytes = retained.reduce(
+        (sum, l) => sum + Buffer.byteLength(l, "utf8"),
+        0,
+      );
+      expect(ring.byteSize()).toBe(expectedBytes);
+      expect(ring.byteSize()).toBeGreaterThan(0);
+    } finally {
+      ring.stop();
+    }
+  });
+
+  it("byteSize() is 0 and capacity() is the default for an empty ring (CTL-1232)", () => {
+    eventsDir();
+    const now = new Date("2026-06-04T00:00:00Z");
+    // No file written → cold-fill finds nothing → ring stays empty.
+    const ring = createEventRing({ catalystDir: workdir, now: () => now });
+    ring.start();
+    try {
+      expect(ring.size()).toBe(0);
+      expect(ring.byteSize()).toBe(0);
+      expect(ring.capacity()).toBe(50_000);
+    } finally {
+      ring.stop();
+    }
+  });
+
   it("picks up newly appended lines on the next poll tick", async () => {
     eventsDir();
     const now = new Date("2026-06-04T00:00:00Z");

--- a/plugins/dev/scripts/orch-monitor/lib/activity-briefing.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/activity-briefing.ts
@@ -5,6 +5,7 @@ import { getProvider, type SummarizeProvider } from "./summarize/providers";
 import { createCache, type Cache } from "./summarize/cache";
 import type { CanonicalEvent } from "./canonical-event";
 import type { EventRing } from "./event-ring";
+import { recordFullRead } from "./event-log-reader"; // CTL-1232 profiling counter
 
 export type ActivityWindow = "30m" | "1h" | "6h";
 
@@ -145,6 +146,8 @@ export function readActivityEvents(
   }
 
   // File fallback (no ring, or ring underflows the window).
+  const _t0 = performance.now();
+  let _fallbackBytes = 0;
   const currentPath = monthlyPath(catalystDir, now);
   const prevPath = monthlyPath(catalystDir, cutoff);
   const paths = currentPath === prevPath ? [currentPath] : [prevPath, currentPath];
@@ -158,6 +161,7 @@ export function readActivityEvents(
     } catch {
       continue;
     }
+    _fallbackBytes += text.length;
     for (const line of text.split("\n")) {
       if (!line.trim()) continue;
       const evt = projectCanonical(line);
@@ -167,6 +171,7 @@ export function readActivityEvents(
       }
     }
   }
+  recordFullRead("activityEvents", _fallbackBytes, performance.now() - _t0);
   return events;
 }
 

--- a/plugins/dev/scripts/orch-monitor/lib/event-log-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/event-log-reader.ts
@@ -21,6 +21,36 @@ import { join } from "node:path";
 import { createFilterStream } from "./event-filter";
 import type { EventRing } from "./event-ring";
 
+/**
+ * CTL-1232 (profiling): process-wide counters for the full-log `readFileSync`
+ * paths that survive the event-ring fast-path. The ring covers the common case;
+ * these count the FALLBACKS (the requested window underflows the ring → a
+ * whole-file read), the suspected driver of the monitor's high-water RSS. Each
+ * full read of the ~190 MB+ current-month file is a large transient that Bun/
+ * mimalloc rarely returns to the OS. Surfaced verbatim by GET /debug/memory so
+ * the offending path + cadence can be confirmed from live traffic.
+ */
+export interface FullReadMetric {
+  count: number;
+  lastBytes: number;
+  lastMs: number;
+  lastTs: string;
+  lastRssMB: number;
+}
+export const fullReadMetrics: Record<string, FullReadMetric> = {};
+export function recordFullRead(label: string, bytes: number, ms: number): void {
+  let m = fullReadMetrics[label];
+  if (!m) {
+    m = { count: 0, lastBytes: 0, lastMs: 0, lastTs: "", lastRssMB: 0 };
+    fullReadMetrics[label] = m;
+  }
+  m.count++;
+  m.lastBytes = bytes;
+  m.lastMs = ms;
+  m.lastTs = new Date().toISOString();
+  m.lastRssMB = Math.round(process.memoryUsage().rss / 1048576);
+}
+
 function monthlyPath(catalystDir: string, d: Date): string {
   const y = d.getUTCFullYear();
   const m = String(d.getUTCMonth() + 1).padStart(2, "0");
@@ -88,7 +118,9 @@ export async function readBacklog(opts: ReadBacklogOpts): Promise<string[]> {
   // Current monthly files are ~17MB at end-of-month; reading the whole file is
   // fast enough. If files grow significantly we can switch to chunked reads
   // from the end of the file.
+  const _t0 = performance.now();
   const text = readFileSync(path, "utf8");
+  recordFullRead("readBacklog", text.length, performance.now() - _t0);
   const allLines = text.split("\n").filter((l) => l.length > 0);
 
   if (!opts.predicate.trim()) {
@@ -260,6 +292,8 @@ export function readTunnelEventStats(
   }
 
   // File fallback (no ring, or ring underflows the 24h window).
+  const _t0 = performance.now();
+  let _fallbackBytes = 0;
   const currentPath = monthlyPath(catalystDir, nowDate);
   const prevPath = monthlyPath(catalystDir, cutoff24h);
   const paths = currentPath === prevPath ? [currentPath] : [prevPath, currentPath];
@@ -272,10 +306,12 @@ export function readTunnelEventStats(
     } catch {
       continue;
     }
+    _fallbackBytes += text.length;
     for (const line of text.split("\n")) {
       accumulateGithubStat(line, cutoffIso, acc);
     }
   }
+  recordFullRead("tunnelStats", _fallbackBytes, performance.now() - _t0);
 
   return acc;
 }

--- a/plugins/dev/scripts/orch-monitor/lib/event-ring.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/event-ring.ts
@@ -53,6 +53,10 @@ export interface EventRing {
   oldestTs(): string | null;
   /** Current retained line count. */
   size(): number;
+  /** Approx retained bytes (UTF-8 content length of all retained lines). CTL-1232. */
+  byteSize(): number;
+  /** Configured max retained line count (capLines). CTL-1232. */
+  capacity(): number;
   /**
    * CTL-1224: register a listener fired synchronously with each batch of
    * newly-appended raw lines from the LIVE tick (NOT cold-fill / start()).
@@ -259,6 +263,14 @@ export function createEventRing(opts: EventRingOpts): EventRing {
     },
     size(): number {
       return ring.length;
+    },
+    byteSize(): number {
+      let b = 0;
+      for (const l of ring) b += Buffer.byteLength(l, "utf8");
+      return b;
+    },
+    capacity(): number {
+      return capLines;
     },
     onAppend(listener: (lines: string[]) => void): () => void {
       appendListeners.add(listener);

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1,5 +1,5 @@
 import { join, resolve as resolvePath, sep, dirname, basename } from "path";
-import { realpathSync, readFileSync, writeFileSync, unlinkSync, existsSync } from "fs";
+import { realpathSync, readFileSync, writeFileSync, unlinkSync, existsSync, mkdirSync } from "fs";
 import { subscribe, emit } from "./lib/event-bus";
 import {
   buildSnapshot,
@@ -12,7 +12,7 @@ import {
 import { readSessionStore } from "./lib/session-store";
 import { readReconcileHealth } from "./lib/reconcile-health-reader"; // CTL-867
 import type { BoardPayload } from "./lib/board-data.mjs";
-import { assembleBoard } from "./lib/board-data.mjs";
+import { assembleBoard, _getTranscriptCacheSize } from "./lib/board-data.mjs";
 import { createBoardSnapshotManager } from "./lib/board-snapshot.mjs";
 // CTL-896 (SHELL6): the dedicated nav-signal projection — worker count, queue
 // depth, board anomaly, and the local daemon-health dot — derived off the SAME
@@ -195,7 +195,12 @@ import {
   type EventLogWriter,
 } from "./lib/event-log";
 import { validatePredicate, createFilterStream, type FilterStream } from "./lib/event-filter";
-import { readBacklog, readTunnelEventStats } from "./lib/event-log-reader";
+import {
+  readBacklog,
+  readTunnelEventStats,
+  fullReadMetrics, // CTL-1232: full-log readFileSync fallback counters for /debug/memory
+  recordFullRead,
+} from "./lib/event-log-reader";
 import { createEventRing } from "./lib/event-ring";
 import { readSubStepEvents } from "./lib/substep-reader";
 import { loadOtelConfig } from "./lib/otel-config";
@@ -3893,7 +3898,14 @@ export function createServer(opts: CreateServerOptions): BunServer {
             const { readClusterGovernance } = await import(govSpecifier) as {
               readClusterGovernance: () => Record<string, unknown>;
             };
-            return Response.json(readClusterGovernance());
+            // CTL-1232: readClusterGovernance() full-reads the current-month log
+            // (no ring, no cache) on every hit — the OBSERVE FleetOps surface
+            // polls this every 15s. Count it so /debug/memory can attribute the
+            // RSS ratchet to this path.
+            const _govT0 = performance.now();
+            const gov = readClusterGovernance();
+            recordFullRead("governance", 0, performance.now() - _govT0);
+            return Response.json(gov);
           } catch {
             return Response.json({ singleHost: true, nodes: [], generatedAt: "" });
           }
@@ -4042,6 +4054,99 @@ export function createServer(opts: CreateServerOptions): BunServer {
               degradedReason: err instanceof Error ? err.message : String(err),
             });
           }
+        }
+
+        // CTL-1232 (profiling): GET /debug/memory[?gc=1] — live memory breakdown.
+        // process.memoryUsage() (MB) + event-ring stats + cache sizes + the
+        // full-log readFileSync fallback counters (fullReadMetrics). With ?gc=1
+        // it forces a synchronous Bun.gc(true) and reports the freed deltas, to
+        // distinguish reclaimable JS-heap garbage from RSS-not-returned-to-the-OS
+        // (the sticky high-water from repeated large transient reads).
+        if (url.pathname === "/debug/memory") {
+          const toMB = (b: number): number => Math.round((b / 1048576) * 10) / 10;
+          const usageMB = (
+            u: ReturnType<typeof process.memoryUsage>,
+          ): Record<string, number> => ({
+            rss: toMB(u.rss),
+            heapTotal: toMB(u.heapTotal),
+            heapUsed: toMB(u.heapUsed),
+            external: toMB(u.external),
+            arrayBuffers: toMB(u.arrayBuffers),
+          });
+          const before = process.memoryUsage();
+          let afterGcMB: Record<string, number> | null = null;
+          let freedMB: Record<string, number> | null = null;
+          if (url.searchParams.get("gc") === "1") {
+            Bun.gc(true);
+            const after = process.memoryUsage();
+            afterGcMB = usageMB(after);
+            freedMB = {
+              rss: toMB(before.rss - after.rss),
+              heapTotal: toMB(before.heapTotal - after.heapTotal),
+              heapUsed: toMB(before.heapUsed - after.heapUsed),
+              external: toMB(before.external - after.external),
+              arrayBuffers: toMB(before.arrayBuffers - after.arrayBuffers),
+            };
+          }
+          const oldest = eventRing.oldestTs();
+          const spanHours =
+            oldest !== null
+              ? Math.round(((Date.now() - Date.parse(oldest)) / 3_600_000) * 100) / 100
+              : null;
+          return Response.json({
+            pid: process.pid,
+            uptimeSec: Math.round(process.uptime()),
+            memoryMB: usageMB(before),
+            ...(afterGcMB && freedMB ? { afterGcMB, freedMB } : {}),
+            ring: {
+              lineCount: eventRing.size(),
+              byteSizeMB: toMB(eventRing.byteSize()),
+              capacity: eventRing.capacity(),
+              oldestTs: oldest,
+              spanHours,
+              listenerCount: eventRing.listenerCount(),
+            },
+            caches: {
+              sseClients: sseClients.size,
+              transcriptPathCache: _getTranscriptCacheSize(),
+            },
+            fullReads: fullReadMetrics,
+          });
+        }
+
+        // CTL-1232 (profiling): GET /debug/heap-snapshot — write a Bun v8 heap
+        // snapshot (loadable in Chrome DevTools → Memory → Load profile) under
+        // ~/catalyst/heap-snapshots/. Heavy + blocking, so localhost-only (curl
+        // from the host) unless CATALYST_DEBUG_TOKEN is set and matched via
+        // ?token=. A small snapshot beside a large RSS confirms off-heap/native
+        // bloat rather than a JS-heap leak.
+        if (url.pathname === "/debug/heap-snapshot") {
+          const token = url.searchParams.get("token");
+          const required = process.env.CATALYST_DEBUG_TOKEN;
+          const ip = server.requestIP(req)?.address ?? "";
+          const isLocal =
+            ip === "127.0.0.1" || ip === "::1" || ip === "::ffff:127.0.0.1";
+          const allowed = required ? token === required : isLocal;
+          if (!allowed) {
+            return new Response(
+              "forbidden (localhost only, or pass ?token=$CATALYST_DEBUG_TOKEN)",
+              { status: 403 },
+            );
+          }
+          const dir = join(CATALYST_DIR, "heap-snapshots");
+          mkdirSync(dir, { recursive: true });
+          const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+          const snapPath = join(dir, `monitor-${process.pid}-${stamp}.heapsnapshot`);
+          const rssBeforeMB = Math.round(process.memoryUsage().rss / 1048576);
+          const snap = Bun.generateHeapSnapshot("v8", "arraybuffer");
+          const bytes = await Bun.write(snapPath, snap);
+          return Response.json({
+            path: snapPath,
+            snapshotBytes: bytes,
+            snapshotMB: Math.round((bytes / 1048576) * 10) / 10,
+            rssBeforeMB,
+            note: "load in Chrome DevTools → Memory → Load profile; small snapshot vs large RSS ⇒ off-heap/native bloat",
+          });
         }
 
         return new Response("Not Found", { status: 404 });


### PR DESCRIPTION
## Summary

After **CTL-1215** + **CTL-1224** routed `readBacklog` + the per-SSE path through the shared event-ring, the orch-monitor on mini still sits at **~6.5 GB RSS** and drives the host into swap. Two read-amplification fixes did not free the high-water mark, so — per decision — we **profile before shipping another fix**. This PR adds the instrumentation; the targeted fix is a follow-up.

A code audit (seam-map workflow) found the likely mechanism: **three full-log `readFileSync` paths still live**, each a ~400 MB transient on mini's ~190 MB log that ratchets Bun/mimalloc RSS upward (sticky high-water, rarely returned to the OS):

1. `/api/cluster/governance` → `cluster-governance.mjs` `readClusterGovernance()` — full read, **no ring, no cache**, polled **every 15 s** by the OBSERVE FleetOps surface (`fleetops-surface.tsx`). (The earlier "only tests call it" suspicion is refuted — `server.ts` is a live caller.)
2. `readTunnelEventStats` — ring cold-fill (~8 MB) underflows its 24 h window → full read each call.
3. `readActivityEvents` — 6 h window underflows the ring → full read.

No JS collection can hold 6.5 GB (every named cache is bounded), pointing the bloat off-heap — exactly what these endpoints will confirm.

## What's added

- **`GET /debug/memory[?gc=1]`** — `process.memoryUsage()` (MB) + event-ring stats (lineCount / byteSize / capacity / oldestTs / spanHours / listenerCount) + cache sizes (sseClients, transcriptPathCache) + the full-read fallback counters. `?gc=1` runs `Bun.gc(true)` and reports the freed deltas, distinguishing reclaimable JS-heap garbage from RSS-not-returned-to-the-OS.
- **`GET /debug/heap-snapshot`** — writes a Bun v8 heap snapshot (Chrome DevTools loadable) under `~/catalyst/heap-snapshots/`. Localhost-only unless `CATALYST_DEBUG_TOKEN` is set and matched via `?token=`. A small snapshot beside a large RSS confirms off-heap/native bloat.
- **event-ring**: `byteSize()` + `capacity()` getters.
- **event-log-reader**: `fullReadMetrics{}` + `recordFullRead()`, incremented at the `readBacklog`, `readTunnelEventStats`, `readActivityEvents`, and `/api/cluster/governance` full-read sites.

## Validation

- Booted the monitor locally (`MONITOR_PORT=7411 bun server.ts`) and hit all three endpoints — server boots clean, JSON shapes correct, heap snapshot written. (Local ring was 8 MB / 26 k lines / 7 h span — confirming the ring is *not* the culprit.)
- `tsc --noEmit` ✓, `eslint` ✓ (0 errors), affected suites (event-ring, event-log-reader, activity-briefing) ✓ — 71/71. Added 5 unit tests (ring `byteSize`/`capacity`, `recordFullRead` counter, fallback-records vs ring-fast-path-doesn't).

## Next (separate)

Capture on mini at the ~6.5 GB high-water mark (drive `/api/cluster/governance`, watch `fullReads.governance` + RSS), then ship the targeted fix (governance tail-read + short TTL; widen ring cold-fill / count from `onAppend`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)