### PR TITLE
feat(dev): CTL-1214 — durable cluster-node installer (PATH-B #1–#6 + adversarially-verified hardening)

### DIFF
--- a/docs/cluster-onboarding.md
+++ b/docs/cluster-onboarding.md
@@ -4,21 +4,37 @@ This document describes how to onboard a fresh macOS node into a Catalyst cluste
 
 ## Quick Start
 
-From mini (the seed host), run:
+As of CTL-1214, `catalyst-join` provisions a node end-to-end on its own — thoughts
+clone + clean `humanlayer.json`, GitHub auth, the daemon stack, and the Stage-0
+SHADOW gate are all baked in. The canonical flow is two commands:
 
 ```bash
-cd ~/catalyst/hlt-dev
-./cluster-node-onboard.sh mini mini-2
+# 1. On the seed (mini): mint a single-use token + arm the bundle listener
+catalyst cluster join-token
+
+# 2. On the fresh node: run the one-liner. Pass a GitHub token so the node can
+#    clone the private thoughts repos without an interactive `gh auth login`.
+CATALYST_JOIN_GITHUB_TOKEN=<ghp_…> \
+  bash catalyst-join.sh --seed mini:7401 --token <jt_…>
+#    (offline / seed-unreachable variant: --bundle ~/catalyst/join-bundle.json)
 ```
 
-This automates:
-1. Thoughts repo provisioning (3 orgs: coalesce-labs, rightsite-cloud, ryanrozich)
-2. HumanLayer configuration
-3. Claude Code settings (OTel telemetry + host identity)
-4. catalyst-join completion (Stage-0 SHADOW)
-5. Catalyst stack auto-start via launchd
+`catalyst-join` walks resumable stages: preflight → acquire-bundle → **github-auth**
+→ **provision-thoughts** → setup-catalyst → install-cli → setup-plugin-source →
+config-merge → **doctor** (the CTL-1186 `catalyst-doctor` gate) → stack. It is
+idempotent — re-run after any failure and it resumes from the failed stage.
 
-**Result:** mini-2 is provisioned and running, but owns zero tickets (SHADOW mode). No further action needed for now.
+**Result:** the node is provisioned and the stack is running under launchd, but the
+committed `.catalyst/hosts.json` is untouched, so it owns **zero tickets** (Stage-0
+SHADOW). Activation (adding it to the roster) is a deliberate later step — see
+[Activation](#activation-m2--future).
+
+### Convenience wrapper (seed-driven)
+
+`~/catalyst/hlt-dev/cluster-node-onboard.sh mini <target>` is an operator helper
+that SSHes the above into a target node and also copies the seed's
+`~/.claude/settings.json` (OTel identity). It is laptop ops glue, not part of the
+installer — the durable provisioning lives in `catalyst-join` itself.
 
 ## Prerequisites
 
@@ -40,14 +56,21 @@ This automates:
 
 ## Step-by-Step Setup
 
-### Phase 1: Prepare GitHub Authentication
+### Phase 1: GitHub Authentication (built into the `github-auth` stage)
 
-The automation script fetches the GitHub PAT (Personal Access Token) from the seed host's environment. This token is used for HTTPS git push auth (thoughts sync).
+Cluster nodes have no SSH keys, so thoughts clone+push uses HTTPS + a token. The
+`github-auth` stage establishes this two ways, in order:
 
-**Why:** cluster nodes have no SSH keys; HTTPS + token is the auth model.
+1. **`CATALYST_JOIN_GITHUB_TOKEN`** (recommended for headless joins) → written to a
+   `0600 ~/.netrc`. gh is not required; git uses `.netrc` for both clone and push.
+2. Otherwise the stage installs the `gh` CLI binary (if absent) and uses an
+   existing `gh auth login` credential helper.
 
-- [ ] Verify seed's token: `ssh mini env | grep GITHUB_TOKEN`
-- [ ] Token must have `repo` + `workflow` scopes
+The token needs `repo` scope (and `workflow` if the node will push workflow files).
+A Stage-0 SHADOW node owns zero tickets and the thoughts **sync-gate only activates
+at roster>1**, so missing push auth is non-fatal at join time but is the explicit
+precondition for [Activation](#activation-m2--future) — verify `humanlayer thoughts
+sync` round-trips before adding the node to the committed roster.
 
 ### Phase 2: Provision Thoughts Repositories
 

--- a/plugins/dev/scripts/__tests__/catalyst-join.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-join.test.sh
@@ -330,7 +330,9 @@ if command -v nc >/dev/null 2>&1; then
   # use a short bounded wait loop on the port becoming connectable).
   T112_READY=0
   for _i in 1 2 3 4 5 6 7 8 9 10; do
-    if nc -z -G 1 127.0.0.1 "$T112_PORT" >/dev/null 2>&1; then T112_READY=1; break; fi
+    # `-w` (portable BSD/OpenBSD/GNU) NOT `-G` (BSD-only) so this readiness probe
+    # works on Linux too, matching the production fix.
+    if nc -z -w 1 127.0.0.1 "$T112_PORT" >/dev/null 2>&1; then T112_READY=1; break; fi
   done
 
   run "T1.12 default preflight succeeds via nc/curl fallback (tailscale absent, port open)" bash -c "
@@ -346,9 +348,11 @@ if command -v nc >/dev/null 2>&1; then
       CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
       CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
       bash '$JOIN' 2>&1)
-    # The default preflight must NOT emit a reachability/port failure. (The run may
-    # later stop in another stage; we only assert preflight passed.)
-    ! echo \"\$out\" | grep -qiE 'not reachable|Tailscale ping'"
+    # The default preflight must NOT emit a reachability/port failure NOR the
+    # pre-fix 'tailscale not found in PATH' abort (including that string makes this
+    # a real regression guard — the unfixed source emits it and would fail here).
+    # (The run may later stop in another stage; we only assert preflight passed.)
+    ! echo \"\$out\" | grep -qiE 'not reachable|Tailscale ping|tailscale not found'"
 
   # Reap the listener if it's still alive.
   kill "$T112_LPID" >/dev/null 2>&1 || true
@@ -570,6 +574,34 @@ run "T2.7b structurally-missing required key still rejected" bash -c "
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
     bash '$JOIN' --bundle '$MISSING_ANCHOR_BUNDLE' >/dev/null 2>&1; [[ \$? -ne 0 ]]"
+
+# T2.7c: (CTL-1214 verify) a structurally-COMPLETE bundle whose IDENTITY keys are
+# null (the residual fail-open from bug #3's best-effort registry resolution) must
+# be REJECTED — identity/credential keys are non-null-required, NOT existence-only.
+# Guards against silently enrolling a node with an empty Linear team/projectKey.
+NULL_IDENTITY_BUNDLE="${SCRATCH}/null-identity.json"
+cat > "$NULL_IDENTITY_BUNDLE" <<'BEOF'
+{
+  "layer1Identity": {"projectKey": null, "teamKey": null, "stateMap": null},
+  "botCreds": {"orchestrator": "tok_orch", "worker": "tok_worker"},
+  "hostsRoster": ["mini"],
+  "livenessAnchorIssue": null,
+  "repoUrl": "https://github.com/example/repo",
+  "pluginSourceUrl": "https://github.com/example/plugins"
+}
+BEOF
+
+run "T2.7c null IDENTITY keys (projectKey/teamKey/stateMap=null) rejected (no fail-open)" bash -c "
+  env -i HOME='${SCRATCH}/h27c' CATALYST_DIR='${SCRATCH}/c27c' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$NULL_IDENTITY_BUNDLE' >/dev/null 2>&1; [[ \$? -ne 0 ]]"
 
 # ── Phase 3: Provisioner orchestration ────────────────────────────────────────
 

--- a/plugins/dev/scripts/__tests__/catalyst-join.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-join.test.sh
@@ -76,6 +76,16 @@ exit 0
 EOF
   chmod +x "$dir/stub-setup-plugin-source.sh"
 
+  # CTL-1214 (PATH-B #6): provision-thoughts is a new pre-setup-catalyst stage.
+  # Stub it (mirror of setup-plugin-source) so the real provision-thoughts.sh
+  # never runs and aborts the hermetic flow.
+  cat > "$dir/stub-provision-thoughts.sh" <<EOF
+#!/usr/bin/env bash
+echo "provision-thoughts" >> "$log"
+exit 0
+EOF
+  chmod +x "$dir/stub-provision-thoughts.sh"
+
   cat > "$dir/stub-catalyst-stack" <<EOF
 #!/usr/bin/env bash
 echo "catalyst-stack \$*" >> "$log"
@@ -110,6 +120,7 @@ run_join() {
     CATALYST_JOIN_SETUP_SCRIPT="${stub_dir}/stub-setup-catalyst.sh" \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT="${stub_dir}/stub-install-cli.sh" \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT="${stub_dir}/stub-setup-plugin-source.sh" \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT="${stub_dir}/stub-provision-thoughts.sh" \
     CATALYST_JOIN_STACK_BIN="${stub_dir}/stub-catalyst-stack" \
     CATALYST_JOIN_DOCTOR_SCRIPT="${stub_dir}/stub-check-setup.sh" \
     CATALYST_JOIN_REACH_PROBE="${stub_dir}/stub-reach-probe.sh" \
@@ -152,6 +163,7 @@ run "T1.3 missing token exits non-zero" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS}/stub-reach-probe.sh' \
@@ -168,6 +180,7 @@ run "T1.4 malformed token (not_a_token) rejected" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS}/stub-reach-probe.sh' \
@@ -184,6 +197,7 @@ run "T1.5 wrong-length token rejected" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS}/stub-reach-probe.sh' \
@@ -198,6 +212,7 @@ run "T1.6 non-hex token rejected" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS}/stub-reach-probe.sh' \
@@ -222,6 +237,7 @@ run "T1.7 well-formed token passes format validation" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS}/stub-reach-probe.sh' \
@@ -235,6 +251,7 @@ run "T1.8 --bundle mode does not require CATALYST_SEED" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS}/stub-reach-probe.sh' \
@@ -256,6 +273,7 @@ run "T1.9 reachability failure exits non-zero" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS_NOREACH}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS_NOREACH}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS_NOREACH}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS_NOREACH}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS_NOREACH}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS_NOREACH}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS_NOREACH}/stub-reach-probe.sh' \
@@ -268,6 +286,7 @@ run "T1.10 --bundle skips reachability probe" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS_NOREACH}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS_NOREACH}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS_NOREACH}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS_NOREACH}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS_NOREACH}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS_NOREACH}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS_NOREACH}/stub-reach-probe.sh' \
@@ -281,6 +300,7 @@ run "T1.11 progress marker created after successful run" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS}/stub-reach-probe.sh' \
@@ -289,6 +309,70 @@ run "T1.11 progress marker created after successful run" bash -c "
   [[ -f \"\$marker\" ]] && \
   jq -e '.completedStages | type == \"array\"' \"\$marker\" >/dev/null && \
   jq -e '.startedAt | length > 0' \"\$marker\" >/dev/null"
+
+# T1.12: (PATH-B #2) DEFAULT preflight (no CATALYST_JOIN_REACH_PROBE override) with the
+# `tailscale` CLI absent from PATH falls back to the nc/curl TCP probe:
+#  - a reachable local TCP port → preflight SUCCEEDS (join proceeds, fails later in a
+#    benign stage; we assert it gets PAST preflight, i.e. no reachability fail message)
+#  - a CLOSED port → preflight FAILS (non-zero, with the reachability fail message)
+# PATH is /usr/bin:/bin so nc/curl/jq/bash resolve but `tailscale` does NOT (not installed).
+# A throwaway `nc -l` listener provides the open port; an unbound port provides the closed case.
+T112_PATH="/usr/bin:/bin"
+if command -v nc >/dev/null 2>&1; then
+  # Pick a high port unlikely to be in use; bind a one-shot listener to it.
+  T112_PORT=53999
+  # Open-port case: background keep-open (-k) listener so the readiness probe and the
+  # script's own preflight probe both find the port bound (a plain `nc -l` accepts a
+  # SINGLE connection and exits, so the readiness check would consume it).
+  ( nc -k -l 127.0.0.1 "$T112_PORT" >/dev/null 2>&1 ) &
+  T112_LPID=$!
+  # Give the listener a moment to bind (no foreground sleep allowed by harness rules;
+  # use a short bounded wait loop on the port becoming connectable).
+  T112_READY=0
+  for _i in 1 2 3 4 5 6 7 8 9 10; do
+    if nc -z -G 1 127.0.0.1 "$T112_PORT" >/dev/null 2>&1; then T112_READY=1; break; fi
+  done
+
+  run "T1.12 default preflight succeeds via nc/curl fallback (tailscale absent, port open)" bash -c "
+    [[ '$T112_READY' -eq 1 ]] || { echo 'listener never came up'; exit 1; }
+    out=\$(env -i HOME='${SCRATCH}/h112' CATALYST_DIR='${SCRATCH}/c112' \
+      PATH='$T112_PATH' \
+      CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+      CATALYST_SEED='127.0.0.1:$T112_PORT' \
+      CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
+      CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
+      CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+      CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS}/stub-provision-thoughts.sh' \
+      CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
+      CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
+      bash '$JOIN' 2>&1)
+    # The default preflight must NOT emit a reachability/port failure. (The run may
+    # later stop in another stage; we only assert preflight passed.)
+    ! echo \"\$out\" | grep -qiE 'not reachable|Tailscale ping'"
+
+  # Reap the listener if it's still alive.
+  kill "$T112_LPID" >/dev/null 2>&1 || true
+  wait "$T112_LPID" 2>/dev/null || true
+
+  # Closed-port case: a port with nothing bound → preflight must FAIL.
+  T112_CLOSED_PORT=53997
+  run "T1.12b default preflight fails when port is closed (nc/curl fallback, tailscale absent)" bash -c "
+    out=\$(env -i HOME='${SCRATCH}/h112b' CATALYST_DIR='${SCRATCH}/c112b' \
+      PATH='$T112_PATH' \
+      CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+      CATALYST_SEED='127.0.0.1:$T112_CLOSED_PORT' \
+      CATALYST_JOIN_SETUP_SCRIPT='${STUBS}/stub-setup-catalyst.sh' \
+      CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS}/stub-install-cli.sh' \
+      CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS}/stub-setup-plugin-source.sh' \
+      CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS}/stub-provision-thoughts.sh' \
+      CATALYST_JOIN_STACK_BIN='${STUBS}/stub-catalyst-stack' \
+      CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS}/stub-check-setup.sh' \
+      bash '$JOIN' 2>&1); ec=\$?
+    [[ \$ec -ne 0 ]] && echo \"\$out\" | grep -qiE 'not reachable'"
+else
+  fail "T1.12 default preflight nc/curl fallback" "nc not available to build the local listener"
+  fail "T1.12b default preflight closed-port fallback" "nc not available"
+fi
 
 # ── Phase 2: Bundle acquisition ────────────────────────────────────────────────
 
@@ -306,6 +390,7 @@ run "T2.1 --bundle valid fixture succeeds" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
@@ -322,6 +407,7 @@ run "T2.2 --bundle malformed bundle rejected" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
@@ -343,6 +429,7 @@ run "T2.3 seed fetch via mock succeeds" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
@@ -365,6 +452,7 @@ run "T2.4 consumed token prints re-mint command" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
@@ -388,12 +476,100 @@ run "T2.5 --bundle mode does not call fetch stub" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
     CATALYST_JOIN_FETCH_CMD='$FETCH_TRACK' \
     bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
   [[ ! -f '$FETCH_TRACK_LOG' ]]"
+
+# T2.6: (PATH-B #1) seed-fetch bundle_url path ends in /join-bundle AND that literal
+# matches JOIN_ROUTE in execution-core/join-listener.mjs. Two assertions:
+#  (a) runtime: the fetch stub receives a URL ending in /join-bundle as $1, and
+#  (b) contract: the .sh literal and the .mjs JOIN_ROUTE literal are byte-identical.
+JOIN_LISTENER="${REPO_ROOT}/plugins/dev/scripts/execution-core/join-listener.mjs"
+URL_CAPTURE="${SCRATCH}/t26-url.log"
+URL_STUB="${STUBS2}/stub-fetch-url.sh"
+cat > "$URL_STUB" <<EOF
+#!/usr/bin/env bash
+echo "\$1" > "$URL_CAPTURE"
+cat '$FIXTURE_BUNDLE'
+EOF
+chmod +x "$URL_STUB"
+
+run "T2.6 seed-fetch bundle_url ends in /join-bundle and matches JOIN_ROUTE" bash -c "
+  rm -f '$URL_CAPTURE'
+  env -i HOME='${SCRATCH}/h26' CATALYST_DIR='${SCRATCH}/c26' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_SEED='mini:7400' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    CATALYST_JOIN_FETCH_CMD='$URL_STUB' \
+    bash '$JOIN' >/dev/null 2>&1
+  # (a) runtime URL the seed-fetch built ends in /join-bundle
+  [[ -f '$URL_CAPTURE' ]] && grep -qE '/join-bundle\$' '$URL_CAPTURE' && \
+  # (b) the catalyst-join.sh literal is /join-bundle (PATH-B #1, not the old /bundle)
+  grep -qF 'bundle_url=\"http://\${host}:\${port}/join-bundle\"' '$JOIN' && \
+  # (c) join-listener.mjs JOIN_ROUTE is exactly \"/join-bundle\" — the contract both sides pin
+  grep -qE 'JOIN_ROUTE\s*=\s*\"/join-bundle\"' '$JOIN_LISTENER'"
+
+# T2.7: (PATH-B #4) a bundle whose .livenessAnchorIssue is literal null (all other
+# required keys present) is ACCEPTED — validate_bundle asserts key EXISTENCE, not
+# truthiness. A STRUCTURALLY-missing key still fails.
+NULL_ANCHOR_BUNDLE="${SCRATCH}/null-anchor.json"
+cat > "$NULL_ANCHOR_BUNDLE" <<'BEOF'
+{
+  "layer1Identity": {"projectKey": "CTL", "teamKey": "T1", "stateMap": {}},
+  "botCreds": {"orchestrator": "tok_orch", "worker": "tok_worker"},
+  "hostsRoster": ["mini"],
+  "livenessAnchorIssue": null,
+  "repoUrl": "https://github.com/example/repo",
+  "pluginSourceUrl": "https://github.com/example/plugins"
+}
+BEOF
+
+run "T2.7 null-valued required key (livenessAnchorIssue=null) is accepted" bash -c "
+  env -i HOME='${SCRATCH}/h27' CATALYST_DIR='${SCRATCH}/c27' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$NULL_ANCHOR_BUNDLE' >/dev/null 2>&1"
+
+# T2.7b: a structurally-MISSING required key (.livenessAnchorIssue absent entirely)
+# still fails — confirms the existence assertion didn't become a no-op.
+MISSING_ANCHOR_BUNDLE="${SCRATCH}/missing-anchor.json"
+cat > "$MISSING_ANCHOR_BUNDLE" <<'BEOF'
+{
+  "layer1Identity": {"projectKey": "CTL", "teamKey": "T1", "stateMap": {}},
+  "botCreds": {"orchestrator": "tok_orch", "worker": "tok_worker"},
+  "hostsRoster": ["mini"],
+  "repoUrl": "https://github.com/example/repo",
+  "pluginSourceUrl": "https://github.com/example/plugins"
+}
+BEOF
+
+run "T2.7b structurally-missing required key still rejected" bash -c "
+  env -i HOME='${SCRATCH}/h27b' CATALYST_DIR='${SCRATCH}/c27b' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$MISSING_ANCHOR_BUNDLE' >/dev/null 2>&1; [[ \$? -ne 0 ]]"
 
 # ── Phase 3: Provisioner orchestration ────────────────────────────────────────
 
@@ -404,7 +580,9 @@ STUBS3="${SCRATCH}/stubs3"
 make_stubs "$STUBS3"
 INVLOG3="${STUBS3}/invocations.log"
 
-# T3.1: Fresh run executes provisioners in order: setup-catalyst, install-cli, setup-plugin-source
+# T3.1: Fresh run executes provisioners in order: provision-thoughts, setup-catalyst,
+# install-cli, setup-plugin-source. (github-auth runs first but logs nothing when
+# gh is absent from the env -i PATH — do_github_auth returns 0 with no invocation.)
 run "T3.1 provisioners run in correct order" bash -c "
   catdir='${SCRATCH}/c31'
   rm -f '$INVLOG3'
@@ -413,14 +591,18 @@ run "T3.1 provisioners run in correct order" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS3}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS3}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS3}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS3}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS3}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS3}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS3}/stub-reach-probe.sh' \
     bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
-  # Verify order: setup-catalyst before install-cli before setup-plugin-source
-  grep -n 'setup-catalyst\|install-cli\|setup-plugin-source' '$INVLOG3' | \
+  # Verify order: provision-thoughts before setup-catalyst before install-cli
+  # before setup-plugin-source. The grep alternation pins each provisioner's
+  # first log line; their stable order in invocations.log is the assertion.
+  grep -n 'provision-thoughts\|setup-catalyst\|install-cli\|setup-plugin-source' '$INVLOG3' | \
     awk -F: '{print \$1, \$2}' | sort -n | \
-    awk '{print \$2}' | tr '\n' ' ' | grep -q 'setup-catalyst.*install-cli.*setup-plugin-source'"
+    awk '{print \$2}' | tr '\n' ' ' | \
+    grep -q 'provision-thoughts.*setup-catalyst.*install-cli.*setup-plugin-source'"
 
 # T3.2: setup-catalyst invoked with CATALYST_AUTONOMOUS=1
 run "T3.2 setup-catalyst invoked with CATALYST_AUTONOMOUS=1" bash -c "
@@ -431,6 +613,7 @@ run "T3.2 setup-catalyst invoked with CATALYST_AUTONOMOUS=1" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS3}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS3}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS3}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS3}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS3}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS3}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS3}/stub-reach-probe.sh' \
@@ -450,6 +633,7 @@ run "T3.3 resume skips already-completed stages" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS3}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS3}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS3}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS3}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS3}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS3}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS3}/stub-reach-probe.sh' \
@@ -476,6 +660,7 @@ run "T3.4 provisioner failure records failedStage and exits non-zero" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS3F}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS3F}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS3F}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS3F}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS3F}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS3F}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS3F}/stub-reach-probe.sh' \
@@ -501,6 +686,7 @@ run "T3.5 re-run after failure resumes from failed stage" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS3R}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS3R}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS3R}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS3R}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS3R}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS3R}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS3R}/stub-reach-probe.sh' \
@@ -508,6 +694,33 @@ run "T3.5 re-run after failure resumes from failed stage" bash -c "
   # setup-catalyst skipped, install-cli and later ran
   ! grep -q 'setup-catalyst' '$INVLOG3R' && \
   grep -q 'install-cli' '$INVLOG3R'"
+
+# T3.6: (PATH-B #6 wiring) the provision-thoughts stage is invoked (appears in
+# invocations.log) AND runs BEFORE setup-catalyst — setup-catalyst's thoughts-init
+# binds the checkout to the repos provision-thoughts cloned, so order matters.
+STUBS36="${SCRATCH}/stubs36"
+make_stubs "$STUBS36"
+INVLOG36="${STUBS36}/invocations.log"
+
+run "T3.6 provision-thoughts invoked and runs before setup-catalyst" bash -c "
+  catdir='${SCRATCH}/c36'
+  rm -f '$INVLOG36'
+  env -i HOME='${SCRATCH}/h36' CATALYST_DIR=\"\$catdir\" \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS36}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS36}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS36}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS36}/stub-provision-thoughts.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS36}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS36}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS36}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
+  # (a) provision-thoughts ran at all
+  grep -q 'provision-thoughts' '$INVLOG36' && \
+  # (b) its log line precedes setup-catalyst's (lower line number)
+  pt_line=\$(grep -n 'provision-thoughts' '$INVLOG36' | head -1 | cut -d: -f1) && \
+  sc_line=\$(grep -n 'setup-catalyst' '$INVLOG36' | head -1 | cut -d: -f1) && \
+  [[ -n \"\$pt_line\" && -n \"\$sc_line\" && \"\$pt_line\" -lt \"\$sc_line\" ]]"
 
 # ── Phase 4: SHARED config merge, per-node items, doctor gate, SHADOW stop ────
 
@@ -530,6 +743,7 @@ run "T4.1 merge-preserve: node-local keys survive" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS4}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS4}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS4}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS4}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS4}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS4}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS4}/stub-reach-probe.sh' \
@@ -550,6 +764,7 @@ run "T4.2 host.name written to Layer-2 config" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS4}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS4}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS4}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS4}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS4}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS4}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS4}/stub-reach-probe.sh' \
@@ -572,6 +787,7 @@ run "T4.3 local hosts.json written; committed roster untouched" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS4}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS4}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS4}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS4}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS4}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS4}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS4}/stub-reach-probe.sh' \
@@ -608,6 +824,7 @@ run "T4.4 doctor gate failure exits non-zero before stack install" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS4D}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS4D}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS4D}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS4D}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS4D}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS4D}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS4D}/stub-reach-probe.sh' \
@@ -630,6 +847,7 @@ run "T4.5 catalyst-stack install-services runs last" bash -c "
     CATALYST_JOIN_SETUP_SCRIPT='${STUBS4O}/stub-setup-catalyst.sh' \
     CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS4O}/stub-install-cli.sh' \
     CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS4O}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS4O}/stub-provision-thoughts.sh' \
     CATALYST_JOIN_STACK_BIN='${STUBS4O}/stub-catalyst-stack' \
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS4O}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS4O}/stub-reach-probe.sh' \
@@ -648,6 +866,7 @@ run "T4.6 idempotency: second run is no-op" bash -c "
   base_env+=' CATALYST_JOIN_SETUP_SCRIPT=${STUBS4}/stub-setup-catalyst.sh'
   base_env+=' CATALYST_JOIN_INSTALL_CLI_SCRIPT=${STUBS4}/stub-install-cli.sh'
   base_env+=' CATALYST_JOIN_PLUGIN_SRC_SCRIPT=${STUBS4}/stub-setup-plugin-source.sh'
+  base_env+=' CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT=${STUBS4}/stub-provision-thoughts.sh'
   base_env+=' CATALYST_JOIN_STACK_BIN=${STUBS4}/stub-catalyst-stack'
   base_env+=' CATALYST_JOIN_DOCTOR_SCRIPT=${STUBS4}/stub-check-setup.sh'
   base_env+=' CATALYST_JOIN_REACH_PROBE=${STUBS4}/stub-reach-probe.sh'

--- a/plugins/dev/scripts/__tests__/provision-thoughts.test.sh
+++ b/plugins/dev/scripts/__tests__/provision-thoughts.test.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# Tests for provision-thoughts.sh (CTL-1214 / bug #6).
+# Hermetic — exercises only the dry-run / no-clone / verify-only seams plus the
+# HLT_ROOT / HL_CONFIG / CATALYST_REGISTRY env overrides. NO real git clone, NO
+# network, NO real gh. Asserts the would-be humanlayer.json .thoughts payload the
+# script prints under --dry-run.
+#
+# Covered:
+#  1. --orgs derivation → global fallback (.thoughts.thoughtsRepo) is the
+#     coalesce-labs HLT path (NEVER groundworkapp), defaultProfile coalesce-labs,
+#     and a profile entry per org.
+#  2. --registry derivation → org set from registry repoRoots, and the bug-#1 fix:
+#     repoMapping 'repo' comes from each repoRoot's .catalyst/config.json
+#     .thoughts.directory (not the basename) when present.
+#  3. --orgs CSV overrides registry derivation.
+#  4. Primary org (coalesce-labs) is force-included even when absent from --orgs.
+#
+# Run: bash plugins/dev/scripts/__tests__/provision-thoughts.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PROVISION="${SCRIPTS_DIR}/provision-thoughts.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# A throwaway HL_CONFIG so nothing ever touches the real ~/.config/humanlayer.
+# (--dry-run never writes, but we point at scratch as defense-in-depth.)
+HL_CONFIG_FILE="$SCRATCH/humanlayer.json"
+
+assert_eq() {
+  local label="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    PASSES=$((PASSES + 1))
+    echo "  PASS: $label"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+assert_grep() {
+  local label="$1" output="$2" pattern="$3"
+  if grep -qF -- "$pattern" <<<"$output"; then
+    PASSES=$((PASSES + 1))
+    echo "  PASS: $label"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $label"
+    echo "    expected substring: $pattern"
+    echo "    actual output:"
+    echo "$output" | head -40 | sed 's/^/      /'
+  fi
+}
+
+assert_not_grep() {
+  local label="$1" output="$2" pattern="$3"
+  if grep -qF -- "$pattern" <<<"$output"; then
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $label (unexpected pattern found)"
+    echo "    unexpected substring: $pattern"
+    echo "    actual output:"
+    echo "$output" | head -40 | sed 's/^/      /'
+  else
+    PASSES=$((PASSES + 1))
+    echo "  PASS: $label"
+  fi
+}
+
+# Run provision-thoughts.sh hermetically. Always --dry-run --no-clone so it never
+# touches the network/git, with HL_CONFIG forced at a scratch file and an empty
+# CATALYST_REGISTRY unless explicitly passed.
+run_provision() {
+  env -i PATH="$PATH" HOME="$SCRATCH/home" USER="testnode" \
+    HLT_ROOT="$SCRATCH/hlt" HL_CONFIG="$HL_CONFIG_FILE" \
+    bash "$PROVISION" --dry-run --no-clone "$@" 2>&1
+}
+
+# Extract just the printed dry-run .thoughts JSON object from script output.
+# The script prints "DRY-RUN humanlayer.json .thoughts would be:" then `jq .`
+# pretty output. Slice from the first '{' after that banner to EOF and let jq
+# re-parse the (single) object.
+extract_json() {
+  local out="$1"
+  awk '/DRY-RUN humanlayer.json .thoughts would be:/{found=1; next} found{print}' <<<"$out" \
+    | jq -c . 2>/dev/null
+}
+
+echo "=== provision-thoughts.sh hermetic tests ==="
+echo "SCRIPT: $PROVISION"
+echo "SCRATCH: $SCRATCH"
+echo ""
+
+# ─── Phase 1: --orgs derivation, global fallback + profiles ──────────────────
+echo "=== Phase 1: --orgs derivation (global fallback never groundworkapp) ==="
+
+ORGS_OUT="$(run_provision --orgs coalesce-labs,rightsite-cloud,ryanrozich)"
+ORGS_JSON="$(extract_json "$ORGS_OUT")"
+
+assert_grep "dry-run prints the would-be humanlayer.json banner" "$ORGS_OUT" \
+  "DRY-RUN humanlayer.json .thoughts would be:"
+
+# Global fallback thoughtsRepo MUST be the coalesce-labs HLT path.
+tr_val="$(jq -r '.thoughtsRepo' <<<"$ORGS_JSON")"
+assert_eq "global fallback thoughtsRepo is coalesce-labs HLT path" \
+  "$tr_val" "$SCRATCH/hlt/coalesce-labs/thoughts"
+
+# And NEVER groundworkapp anywhere in the payload.
+assert_not_grep "no groundworkapp anywhere in dry-run thoughts payload" "$ORGS_JSON" \
+  "groundworkapp"
+
+# defaultProfile == coalesce-labs.
+dp_val="$(jq -r '.defaultProfile' <<<"$ORGS_JSON")"
+assert_eq "defaultProfile is coalesce-labs" "$dp_val" "coalesce-labs"
+
+# A profile entry for each org (mapped through org_profile: rightsite-cloud→adva).
+assert_eq "profile entry exists for coalesce-labs" \
+  "$(jq -r '.profiles["coalesce-labs"].thoughtsRepo // "MISSING"' <<<"$ORGS_JSON")" \
+  "$SCRATCH/hlt/coalesce-labs/thoughts"
+assert_eq "profile entry exists for rightsite-cloud (profile key 'adva')" \
+  "$(jq -r '.profiles["adva"].thoughtsRepo // "MISSING"' <<<"$ORGS_JSON")" \
+  "$SCRATCH/hlt/rightsite-cloud/thoughts"
+assert_eq "profile entry exists for ryanrozich" \
+  "$(jq -r '.profiles["ryanrozich"].thoughtsRepo // "MISSING"' <<<"$ORGS_JSON")" \
+  "$SCRATCH/hlt/ryanrozich/thoughts"
+assert_eq "exactly 3 profiles for the 3-org CSV" \
+  "$(jq -r '.profiles | length' <<<"$ORGS_JSON")" "3"
+
+# ─── Phase 2: --registry derivation + bug-#1 repoMapping repo field ──────────
+echo ""
+echo "=== Phase 2: --registry derivation + repoMapping .thoughts.directory ==="
+
+# Synthetic registries covering: (2a) a config-bearing repoRoot maps to its
+# declared .thoughts.directory; (2b) a config-LESS repoRoot maps to its basename
+# WITHOUT crashing even when it is first in the registry; (2c) a mix where the
+# config-less repo correctly uses its OWN basename and does not inherit the
+# prior repo's directory. (2b/2c previously documented two write_config bugs —
+# a `set -u` crash and a cross-iteration `local sub` leak — now fixed by
+# defaulting `sub` to the basename unconditionally before the config branch.)
+REPO_CL="$SCRATCH/github/coalesce-labs/catalyst"           # HAS .thoughts.directory
+REPO_GW="$SCRATCH/github/groundworkapp/groundwork"         # NO config.json
+mkdir -p "$REPO_CL/.catalyst" "$REPO_GW"
+cat > "$REPO_CL/.catalyst/config.json" <<'EOF'
+{"thoughts":{"directory":"catalyst-workspace"}}
+EOF
+
+# (2a) bug-#1 fixture: a single config-bearing repoRoot. repoMapping repo must be
+# the config.json .thoughts.directory ("catalyst-workspace"), NOT basename "catalyst".
+REG_CL="$SCRATCH/registry-cl.json"
+cat > "$REG_CL" <<EOF
+{"projects":[{"repoRoot":"$REPO_CL","team":"CTL"}]}
+EOF
+
+REG_OUT="$(run_provision --registry "$REG_CL")"
+REG_JSON="$(extract_json "$REG_OUT")"
+
+assert_grep "registry derivation logs the registry path" "$REG_OUT" \
+  "Deriving orgs from registry"
+
+# Org set derived from the repoRoot: coalesce-labs (also the forced primary).
+assert_eq "registry-derived: coalesce-labs profile present" \
+  "$(jq -r '.profiles["coalesce-labs"].thoughtsRepo // "MISSING"' <<<"$REG_JSON")" \
+  "$SCRATCH/hlt/coalesce-labs/thoughts"
+
+# bug-#1 fix: repoMapping repo == config.json .thoughts.directory, NOT basename.
+cl_repo="$(jq -r --arg p "$REPO_CL" '.repoMappings[$p].repo // "MISSING"' <<<"$REG_JSON")"
+assert_eq "repoMapping repo comes from .catalyst/config.json .thoughts.directory" \
+  "$cl_repo" "catalyst-workspace"
+assert_not_grep "repoMapping repo is NOT the repoRoot basename when config present" \
+  "$cl_repo" "catalyst\""
+assert_eq "repoMapping for coalesce-labs repo has profile coalesce-labs" \
+  "$(jq -r --arg p "$REPO_CL" '.repoMappings[$p].profile // "MISSING"' <<<"$REG_JSON")" \
+  "coalesce-labs"
+
+# (2b) org normalization is independent of the config.json: even though this
+# config-LESS, groundworkapp-only registry hits a second source bug in the
+# config phase (below), the clone-phase org derivation runs first and correctly
+# normalizes groundworkapp → rightsite-cloud (and force-includes coalesce-labs).
+# Assert on the clone-phase "Node org set" log line + the "WOULD clone" lines,
+# which are emitted before the crash.
+REG_GW="$SCRATCH/registry-gw.json"
+cat > "$REG_GW" <<EOF
+{"projects":[{"repoRoot":"$REPO_GW","team":"ADV"}]}
+EOF
+
+GW_OUT="$(run_provision --registry "$REG_GW")"
+
+assert_grep "isolated config-less: org set normalizes groundworkapp → rightsite-cloud" \
+  "$GW_OUT" "Node org set: coalesce-labs rightsite-cloud"
+assert_grep "isolated config-less: would clone rightsite-cloud (normalized) thoughts" \
+  "$GW_OUT" "rightsite-cloud/thoughts"
+assert_not_grep "isolated config-less: never derives a groundworkapp HLT dir" \
+  "$GW_OUT" "hlt/groundworkapp"
+
+# (2b-fix) A registry whose FIRST repoRoot has no .catalyst/config.json must NOT
+# crash: write_config defaults `sub` to the basename unconditionally before the
+# config branch, so there is no `set -u` unbound-variable abort and the DRY-RUN
+# payload is printed. The config-less repo maps to its basename ("groundwork").
+assert_not_grep "config-less-first: no 'sub: unbound variable' crash" \
+  "$GW_OUT" "sub: unbound variable"
+assert_grep "config-less-first: DRY-RUN payload IS printed (config phase completes)" \
+  "$GW_OUT" "DRY-RUN humanlayer.json .thoughts would be:"
+GW_JSON="$(extract_json "$GW_OUT")"
+assert_eq "config-less repo maps to its repoRoot basename" \
+  "$(jq -r --arg p "$REPO_GW" '.repoMappings[$p].repo // "MISSING"' <<<"$GW_JSON")" \
+  "groundwork"
+
+# (2c) Combined registry, config-bearing repo FIRST. The config-bearing repo maps
+# to its .thoughts.directory, and the following config-LESS repo correctly uses
+# its OWN basename ("groundwork") — NOT the prior repo's directory. This is the
+# regression guard for the fixed cross-iteration `local sub` leak.
+REG_BOTH="$SCRATCH/registry-both.json"
+cat > "$REG_BOTH" <<EOF
+{"projects":[
+  {"repoRoot":"$REPO_CL","team":"CTL"},
+  {"repoRoot":"$REPO_GW","team":"ADV"}
+]}
+EOF
+
+BOTH_OUT="$(run_provision --registry "$REG_BOTH")"
+BOTH_JSON="$(extract_json "$BOTH_OUT")"
+
+assert_eq "combined: config-bearing repo maps to its .thoughts.directory" \
+  "$(jq -r --arg p "$REPO_CL" '.repoMappings[$p].repo // "MISSING"' <<<"$BOTH_JSON")" \
+  "catalyst-workspace"
+assert_eq "combined: config-less repo uses its OWN basename (no cross-iteration leak)" \
+  "$(jq -r --arg p "$REPO_GW" '.repoMappings[$p].repo // "MISSING"' <<<"$BOTH_JSON")" \
+  "groundwork"
+assert_eq "combined: exactly 2 repoMappings (one per registry repoRoot)" \
+  "$(jq -r '.repoMappings | length' <<<"$BOTH_JSON")" "2"
+
+# ─── Phase 3: --orgs CSV overrides registry derivation ───────────────────────
+echo ""
+echo "=== Phase 3: --orgs overrides --registry ==="
+
+# Pass BOTH --orgs and --registry; --orgs must win (registry-only repoRoots'
+# orgs that aren't in the CSV must not appear as profiles). Use a CSV that
+# excludes rightsite-cloud/adva entirely.
+OVR_OUT="$(run_provision --orgs coalesce-labs,ryanrozich --registry "$REG_BOTH")"
+OVR_JSON="$(extract_json "$OVR_OUT")"
+
+# org set comes from CSV → exactly coalesce-labs + ryanrozich (no adva profile).
+assert_eq "override: profile count is exactly 2 (CSV-derived)" \
+  "$(jq -r '.profiles | length' <<<"$OVR_JSON")" "2"
+assert_eq "override: coalesce-labs profile present" \
+  "$(jq -r '.profiles["coalesce-labs"].thoughtsRepo // "MISSING"' <<<"$OVR_JSON")" \
+  "$SCRATCH/hlt/coalesce-labs/thoughts"
+assert_eq "override: ryanrozich profile present" \
+  "$(jq -r '.profiles["ryanrozich"].thoughtsRepo // "MISSING"' <<<"$OVR_JSON")" \
+  "$SCRATCH/hlt/ryanrozich/thoughts"
+assert_eq "override: adva profile ABSENT (registry org not in CSV)" \
+  "$(jq -r '.profiles["adva"].thoughtsRepo // "ABSENT"' <<<"$OVR_JSON")" \
+  "ABSENT"
+# But repoMappings still seed from the registry regardless of org override.
+assert_eq "override: repoMappings still seeded from registry (2 entries)" \
+  "$(jq -r '.repoMappings | length' <<<"$OVR_JSON")" "2"
+
+# ─── Phase 4: primary org force-included even when absent from --orgs ─────────
+echo ""
+echo "=== Phase 4: primary org (coalesce-labs) force-included ==="
+
+NOPRIM_OUT="$(run_provision --orgs ryanrozich)"
+NOPRIM_JSON="$(extract_json "$NOPRIM_OUT")"
+
+# coalesce-labs must be force-prepended → profile present + still the default/fallback.
+assert_eq "force-include: coalesce-labs profile present though absent from --orgs" \
+  "$(jq -r '.profiles["coalesce-labs"].thoughtsRepo // "MISSING"' <<<"$NOPRIM_JSON")" \
+  "$SCRATCH/hlt/coalesce-labs/thoughts"
+assert_eq "force-include: defaultProfile still coalesce-labs" \
+  "$(jq -r '.defaultProfile' <<<"$NOPRIM_JSON")" "coalesce-labs"
+assert_eq "force-include: global thoughtsRepo still coalesce-labs HLT path" \
+  "$(jq -r '.thoughtsRepo' <<<"$NOPRIM_JSON")" \
+  "$SCRATCH/hlt/coalesce-labs/thoughts"
+assert_eq "force-include: ryanrozich also present (2 profiles total)" \
+  "$(jq -r '.profiles | length' <<<"$NOPRIM_JSON")" "2"
+
+# Sanity: the real HL config file was never created (dry-run is side-effect-free).
+assert_eq "HL_CONFIG file never written under --dry-run" \
+  "$([[ -e "$HL_CONFIG_FILE" ]] && echo EXISTS || echo ABSENT)" "ABSENT"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASSES"
+echo "FAIL: $FAILURES"
+echo ""
+echo "provision-thoughts.test.sh: ${PASSES} passed, ${FAILURES} failed"
+
+exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/provision-thoughts.test.sh
+++ b/plugins/dev/scripts/__tests__/provision-thoughts.test.sh
@@ -143,11 +143,15 @@ echo "=== Phase 2: --registry derivation + repoMapping .thoughts.directory ==="
 # prior repo's directory. (2b/2c previously documented two write_config bugs —
 # a `set -u` crash and a cross-iteration `local sub` leak — now fixed by
 # defaulting `sub` to the basename unconditionally before the config branch.)
-REPO_CL="$SCRATCH/github/coalesce-labs/catalyst"           # HAS .thoughts.directory
+REPO_CL="$SCRATCH/github/coalesce-labs/catalyst"           # HAS .catalyst.thoughts.directory
 REPO_GW="$SCRATCH/github/groundworkapp/groundwork"         # NO config.json
 mkdir -p "$REPO_CL/.catalyst" "$REPO_GW"
+# Real Layer-1 schema nests the key under the top-level "catalyst" object —
+# .catalyst.thoughts.directory (NOT top-level .thoughts.directory). Using the
+# real shape here is what makes this a genuine regression guard for the jq-path
+# fix in provision-thoughts.sh (CTL-1214 verify).
 cat > "$REPO_CL/.catalyst/config.json" <<'EOF'
-{"thoughts":{"directory":"catalyst-workspace"}}
+{"catalyst":{"thoughts":{"directory":"catalyst-workspace"}}}
 EOF
 
 # (2a) bug-#1 fixture: a single config-bearing repoRoot. repoMapping repo must be
@@ -283,6 +287,38 @@ assert_eq "force-include: ryanrozich also present (2 profiles total)" \
 # Sanity: the real HL config file was never created (dry-run is side-effect-free).
 assert_eq "HL_CONFIG file never written under --dry-run" \
   "$([[ -e "$HL_CONFIG_FILE" ]] && echo EXISTS || echo ABSENT)" "ABSENT"
+
+# ─── Phase 5: empty/unrecognized registry must not crash (set -u, bash 3.2) ──
+echo ""
+echo "=== Phase 5: registry yielding zero recognized orgs ==="
+# A registry whose repoRoots match no /github/<org>/<repo> path → ORGS empty
+# during derivation. Under `set -u`, macOS system bash 3.2 aborts on an empty
+# "${ORGS[@]}" expansion; the script must instead fall back to the primary org.
+REG_NONE="$SCRATCH/registry-none.json"
+cat > "$REG_NONE" <<EOF
+{"projects":[{"repoRoot":"/var/tmp/not-a-github-path/repo","team":"X"}]}
+EOF
+
+NONE_OUT="$(run_provision --registry "$REG_NONE")"
+assert_not_grep "zero-recognized-org registry does not crash (no unbound variable)" \
+  "$NONE_OUT" "unbound variable"
+NONE_JSON="$(extract_json "$NONE_OUT")"
+assert_eq "zero-recognized-org registry falls back to primary coalesce-labs" \
+  "$(jq -r '.defaultProfile // "MISSING"' <<<"$NONE_JSON")" "coalesce-labs"
+
+# Explicitly exercise the bash-3.2 set -u path when the system bash is 3.x
+# (macOS). On Linux / bash 5 this is skipped (the empty-array trap is bash-3.2
+# specific); bash 5 tolerates the expansion, so the assertion above is the
+# cross-platform guard and this is the platform-specific reproduction.
+if [[ -x /bin/bash ]] && /bin/bash -c '[[ ${BASH_VERSINFO[0]} -lt 4 ]]' 2>/dev/null; then
+  B32_OUT="$(env -i PATH="$PATH" HOME="$SCRATCH/home" USER="testnode" \
+    HLT_ROOT="$SCRATCH/hlt" HL_CONFIG="$HL_CONFIG_FILE" \
+    /bin/bash "$PROVISION" --dry-run --no-clone --registry "$REG_NONE" 2>&1)"
+  assert_not_grep "bash 3.2: zero-recognized-org registry does not abort with unbound variable" \
+    "$B32_OUT" "unbound variable"
+else
+  echo "  SKIP: system bash is not 3.x (no bash-3.2 empty-array repro on this host)"
+fi
 
 # ─── Summary ─────────────────────────────────────────────────────────────────
 echo ""

--- a/plugins/dev/scripts/__tests__/setup-catalyst-installers.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-installers.test.sh
@@ -173,6 +173,20 @@ ZSHENV_CONTENT=$(cat "$SCRATCH/home/.zshenv" 2>/dev/null || true)
 LINE_COUNT=$(grep -c '.local/bin' <<<"$ZSHENV_CONTENT" || true)
 assert_eq "ensure_local_bin is idempotent (PATH line written exactly once)" "$LINE_COUNT" "1"
 
+# CTL-1214: ensure_local_bin must also persist ~/.local/node/bin so a fresh login
+# shell can find humanlayer/linearis (npm -g installs land in the no-sudo node
+# prefix, not covered by the node/npm/npx symlinks in ~/.local/bin).
+fresh_dirs
+run_sourced "ensure_local_bin"
+NODEBIN_ZSHENV=$(cat "$SCRATCH/home/.zshenv" 2>/dev/null || true)
+assert_grep "ensure_local_bin persists ~/.local/node/bin to ~/.zshenv" "$NODEBIN_ZSHENV" '.local/node/bin'
+
+# Idempotent on a second call: the ~/.local/node/bin line is written exactly once.
+run_sourced "ensure_local_bin; ensure_local_bin"
+NODEBIN_ZSHENV=$(cat "$SCRATCH/home/.zshenv" 2>/dev/null || true)
+NODEBIN_LINE_COUNT=$(grep -c '.local/node/bin' <<<"$NODEBIN_ZSHENV" || true)
+assert_eq "ensure_local_bin ~/.local/node/bin PATH line idempotent" "$NODEBIN_LINE_COUNT" "1"
+
 # ─── Phase 1: offer_install_jq (no-sudo binary fallback) ─────────────────────
 
 echo ""

--- a/plugins/dev/scripts/__tests__/setup-catalyst-noninteractive.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-noninteractive.test.sh
@@ -144,6 +144,84 @@ rc=$?
 [[ $rc -eq 0 && "$out" == *"Usage:"* ]] && pass "--help prints usage, exit 0" || fail "--help prints usage, exit 0" "rc=$rc"
 
 echo ""
+echo "=== Phase 5: CATALYST_NI_AUTOINSTALL guard (CTL-1214 PATH-B #5) ==="
+
+# T23: with NON_INTERACTIVE=1 CATALYST_NI_AUTOINSTALL=1, the override forces a
+# "y" answer even when the explicit ni_answer arg is "n" → returns 0. This is the
+# path check_prerequisites uses to auto-accept a CRITICAL prereq install headlessly.
+run_sourced 'NON_INTERACTIVE=1; CATALYST_NI_AUTOINSTALL=1; ask_yes_no "x?" "y" "n"' </dev/null 2>/dev/null \
+  && pass "NI autoinstall override forces accept (returns 0)" \
+  || fail "NI autoinstall override forces accept (returns 0)"
+
+# T24: WITHOUT the override, plain NON_INTERACTIVE=1 still honors the ni_answer
+# "n" and DECLINES (returns non-0) — the install offers must not silently flip on.
+# This keeps the existing T16 (line 113) decline guard valid.
+run_sourced 'NON_INTERACTIVE=1; ask_yes_no "x?" "y" "n"' </dev/null 2>/dev/null \
+  && fail "plain NI still declines without override" \
+  || pass "plain NI still declines without override"
+
+# T25: the override only affects NI mode — it must NOT short-circuit the source
+# guard / change the default ni_answer for unrelated prompts (default y stays y).
+run_sourced 'NON_INTERACTIVE=1; CATALYST_NI_AUTOINSTALL=1; ask_yes_no "x?" "n"' </dev/null 2>/dev/null \
+  && pass "NI autoinstall override beats default ni_answer n" \
+  || fail "NI autoinstall override beats default ni_answer n"
+
+# T26: check_prerequisites wraps the humanlayer install with the autoinstall env
+# so an autonomous catalyst-join auto-accepts the critical HumanLayer prereq.
+grep -qF 'CATALYST_NI_AUTOINSTALL=1 offer_install_humanlayer' "$SETUP" \
+  && pass "check_prerequisites wraps humanlayer install with CATALYST_NI_AUTOINSTALL=1" \
+  || fail "check_prerequisites wraps humanlayer install with CATALYST_NI_AUTOINSTALL=1"
+
+# T27: gh install offer is likewise wrapped with the autoinstall env in NI mode
+# (node HTTPS git auth / thoughts sync precondition).
+grep -qF 'CATALYST_NI_AUTOINSTALL=1 offer_install_gh_cli' "$SETUP" \
+  && pass "check_prerequisites wraps gh install with CATALYST_NI_AUTOINSTALL=1" \
+  || fail "check_prerequisites wraps gh install with CATALYST_NI_AUTOINSTALL=1"
+
+echo ""
+echo "=== Phase 6: setup_project_config thoughts block (CTL-1214) ==="
+
+# T28: after setup_project_config runs in a scratch repo (ORG_NAME/REPO_NAME set),
+# .catalyst/config.json carries non-empty .catalyst.thoughts.{directory,profile}
+# == {REPO_NAME, ORG_NAME} (drift-gate input). Hermetic: env -i + scratch HOME/dir,
+# NON_INTERACTIVE so prompt_value returns defaults without touching stdin.
+spc_scratch=$(mktemp -d)
+spc_out=$(env -i HOME="$spc_scratch/home" PATH="/usr/bin:/bin" bash -c "
+  source '$SETUP'
+  NON_INTERACTIVE=1
+  ORG_NAME=acme-org
+  REPO_NAME=acme-repo
+  PROJECT_KEY=acme-org
+  PROJECT_DIR='$spc_scratch/proj'
+  mkdir -p \"\$PROJECT_DIR\"
+  setup_project_config >/dev/null 2>&1
+  jq -r '.catalyst.thoughts.directory + \"|\" + .catalyst.thoughts.profile' \"\$PROJECT_DIR/.catalyst/config.json\"
+" 2>/dev/null)
+rm -rf "$spc_scratch"
+[[ "$spc_out" == "acme-repo|acme-org" ]] \
+  && pass "setup_project_config writes thoughts.{directory=REPO_NAME,profile=ORG_NAME}" \
+  || fail "setup_project_config writes thoughts.{directory,profile}" "$spc_out"
+
+# T29: both thoughts fields are non-empty / non-null (a null-valued required key
+# would fail the validate_bundle existence assertion downstream).
+spc_scratch=$(mktemp -d)
+spc_nonempty=$(env -i HOME="$spc_scratch/home" PATH="/usr/bin:/bin" bash -c "
+  source '$SETUP'
+  NON_INTERACTIVE=1
+  ORG_NAME=acme-org
+  REPO_NAME=acme-repo
+  PROJECT_KEY=acme-org
+  PROJECT_DIR='$spc_scratch/proj'
+  mkdir -p \"\$PROJECT_DIR\"
+  setup_project_config >/dev/null 2>&1
+  jq -r '(.catalyst.thoughts.directory != null and .catalyst.thoughts.directory != \"\" and .catalyst.thoughts.profile != null and .catalyst.thoughts.profile != \"\")' \"\$PROJECT_DIR/.catalyst/config.json\"
+" 2>/dev/null)
+rm -rf "$spc_scratch"
+[[ "$spc_nonempty" == "true" ]] \
+  && pass "setup_project_config thoughts.directory/profile non-empty" \
+  || fail "setup_project_config thoughts.directory/profile non-empty" "$spc_nonempty"
+
+echo ""
 echo "=== Phase 4: Documentation shape ==="
 
 # T18: usage header documents the new flags

--- a/plugins/dev/scripts/catalyst-join.sh
+++ b/plugins/dev/scripts/catalyst-join.sh
@@ -458,11 +458,21 @@ ensure_gh() {
 do_github_auth() {
   # (1) Operator-supplied token → HTTPS credentials via ~/.netrc (no gh needed).
   if [[ -n "${CATALYST_JOIN_GITHUB_TOKEN:-}" ]]; then
-    ( umask 077
+    local netrc="$HOME/.netrc"
+    # Don't clobber a pre-existing ~/.netrc that already configures github.com —
+    # the operator's own credentials win; we only WRITE when there's nothing for
+    # github.com yet (and preserve any other machine stanzas).
+    if [[ -f "$netrc" ]] && grep -qiE '^[[:space:]]*machine[[:space:]]+github\.com\b' "$netrc"; then
+      info "~/.netrc already has a github.com entry — leaving it unchanged."
+    else
+      # Create at 0600 from the start (no world-readable window), preserving any
+      # existing non-github stanzas by appending.
+      [[ -f "$netrc" ]] || { : > "$netrc"; chmod 600 "$netrc" 2>/dev/null || true; }
+      chmod 600 "$netrc" 2>/dev/null || true
       printf 'machine github.com\nlogin %s\npassword %s\n' \
-        "${CATALYST_JOIN_GITHUB_USER:-x-access-token}" "$CATALYST_JOIN_GITHUB_TOKEN" > "$HOME/.netrc" )
-    chmod 600 "$HOME/.netrc" 2>/dev/null || true
-    info "GitHub HTTPS auth configured via ~/.netrc (0600)."
+        "${CATALYST_JOIN_GITHUB_USER:-x-access-token}" "$CATALYST_JOIN_GITHUB_TOKEN" >> "$netrc"
+      info "GitHub HTTPS auth configured via ~/.netrc (0600)."
+    fi
     return 0
   fi
   # (2) gh credential helper — install gh if absent (private thoughts clone needs it).

--- a/plugins/dev/scripts/catalyst-join.sh
+++ b/plugins/dev/scripts/catalyst-join.sh
@@ -244,10 +244,13 @@ preflight_tailscale() {
   fi
 
   # TCP reachability to the seed port (works with or without the tailscale CLI).
-  # Prefer nc (protocol-agnostic) on macOS; fall back to curl (a 404 from the
-  # listener still proves the port is reachable — curl without -f exits 0).
+  # Prefer nc (protocol-agnostic); fall back to curl (a 404 from the listener
+  # still proves the port is reachable — curl without -f exits 0).
+  # NOTE: use `-w` (connect timeout) NOT `-G` — `-G` is a BSD/macOS-only flag and
+  # OpenBSD/GNU nc on Linux error out on it even when the port is open. `-w secs`
+  # is understood by BSD, OpenBSD, and GNU nc alike (CTL-1214 verify finding).
   if command -v nc >/dev/null 2>&1; then
-    if ! nc -z -G 5 "$host" "$port" >/dev/null 2>&1; then
+    if ! nc -z -w 5 "$host" "$port" >/dev/null 2>&1; then
       fail "Port ${port} on '${host}' is not reachable. Is this node on the tailnet and the bundle listener running?"
       fail "Hint: confirm Tailscale is connected (GUI app or CLI) and the seed armed 'catalyst cluster join-token'."
       return 1
@@ -266,7 +269,10 @@ preflight_tailscale() {
 BUNDLE_TMPFILE=""
 BUNDLE_JSON=""
 
-# Required bundle keys for schema validation
+# Required bundle keys that must be PRESENT and NON-NULL — identity, bot
+# credentials, roster, and URLs. A null here means a broken/misresolved seed
+# config (e.g. the listener read the wrong Layer-1); fail FAST rather than
+# silently enrol the node with an empty Linear team/projectKey (CTL-1214 verify).
 BUNDLE_REQUIRED_KEYS=(
   ".layer1Identity.projectKey"
   ".layer1Identity.teamKey"
@@ -274,20 +280,30 @@ BUNDLE_REQUIRED_KEYS=(
   ".botCreds.orchestrator"
   ".botCreds.worker"
   ".hostsRoster"
-  ".livenessAnchorIssue"
   ".repoUrl"
   ".pluginSourceUrl"
+)
+
+# Required keys that must EXIST but may legitimately be null — e.g.
+# .livenessAnchorIssue is null until an anchor ticket is set (CTL-1214 #4).
+BUNDLE_EXISTENCE_KEYS=(
+  ".livenessAnchorIssue"
 )
 
 validate_bundle() {
   local json="$1"
   local missing=()
+  # Non-null assertion for identity/credential/url keys: `jq -e "$key"` exits
+  # non-zero on null/false, so an all-null layer1Identity is rejected here.
   for key in "${BUNDLE_REQUIRED_KEYS[@]}"; do
-    # CTL-1214 (PATH-B #4): assert the key EXISTS, not that its value is truthy.
-    # `jq -e "$key"` exits non-zero when a key is present but null/false, so a
-    # legitimately-null required key (e.g. .livenessAnchorIssue before an anchor
-    # is set) would wrongly fail a structurally-complete bundle. Test path
-    # existence via `any(paths; . == <split path>)` instead.
+    if ! echo "$json" | jq -e "$key" >/dev/null 2>&1; then
+      missing+=("$key")
+    fi
+  done
+  # Existence-only assertion (CTL-1214 #4): the key must be present but its value
+  # may be null. Test path existence via `any(paths; …)` — a null value passes,
+  # a structurally-absent key still fails.
+  for key in "${BUNDLE_EXISTENCE_KEYS[@]}"; do
     if ! echo "$json" | jq -e --arg key "$key" \
         '($key | ltrimstr(".") | split(".")) as $p | any(paths; . == $p)' \
         >/dev/null 2>&1; then
@@ -404,31 +420,63 @@ do_setup_plugin_source() {
   bash "$PLUGIN_SRC_SCRIPT"
 }
 
-# Establish GitHub HTTPS push auth for thoughts sync WITHOUT embedding a PAT in
-# the repo. Mirrors mini's model: the node uses its OWN gh credential. If
-# CATALYST_JOIN_GITHUB_TOKEN is exported (operator-supplied), log gh in with it;
-# otherwise assume `gh auth login` was already run. Non-blocking: a Stage-0
-# SHADOW node owns zero tickets and the thoughts sync-gate only activates at
-# roster>1, so missing push auth is a clearly-flagged M2 precondition, not a
-# join blocker. (PATH-B: mini-2 had to install gh + build a ~/.netrc by hand.)
+# Install the GitHub CLI binary into ~/.local/bin when absent. provision-thoughts
+# clones PRIVATE org thoughts repos and runs BEFORE setup-catalyst installs gh, so
+# the join can't rely on setup-catalyst's prereq step for it. Idempotent; returns
+# non-zero only if the install genuinely failed.
+ensure_gh() {
+  command -v gh >/dev/null 2>&1 && return 0
+  command -v jq >/dev/null 2>&1 && command -v curl >/dev/null 2>&1 || {
+    warn "cannot install gh (need curl + jq)"; return 1; }
+  local os arch ghver tmp
+  os="$(uname -s)"; arch="$(uname -m)"
+  case "$arch" in arm64 | aarch64) arch="arm64" ;; x86_64 | amd64) arch="amd64" ;; esac
+  ghver="$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest 2>/dev/null | jq -r '.tag_name // empty' | sed 's/^v//')"
+  [[ -n "$ghver" ]] || { warn "could not resolve latest gh version"; return 1; }
+  mkdir -p "$HOME/.local/bin"; tmp="$(mktemp -d)"
+  info "Installing GitHub CLI gh ${ghver} → ~/.local/bin (needed for thoughts auth)…"
+  if [[ "$os" == "Darwin" ]]; then
+    curl -fsSL "https://github.com/cli/cli/releases/download/v${ghver}/gh_${ghver}_macOS_${arch}.zip" -o "$tmp/gh.zip" \
+      && unzip -q "$tmp/gh.zip" -d "$tmp" && cp "$tmp"/gh_*/bin/gh "$HOME/.local/bin/gh"
+  else
+    curl -fsSL "https://github.com/cli/cli/releases/download/v${ghver}/gh_${ghver}_linux_${arch}.tar.gz" | tar xz -C "$tmp" \
+      && cp "$tmp"/gh_*/bin/gh "$HOME/.local/bin/gh"
+  fi
+  chmod +x "$HOME/.local/bin/gh" 2>/dev/null || true
+  rm -rf "$tmp"
+  export PATH="$HOME/.local/bin:$PATH"
+  command -v gh >/dev/null 2>&1 || { warn "gh install failed"; return 1; }
+}
+
+# Establish GitHub HTTPS auth for the thoughts clone+push WITHOUT embedding a PAT
+# in the repo. Two mechanisms, in order: (1) CATALYST_JOIN_GITHUB_TOKEN → a 0600
+# ~/.netrc (gh-free — the reliable headless path mini-2 used; git uses it for
+# clone AND push); (2) an existing or freshly-installed `gh` credential helper.
+# provision-thoughts (next stage) clones PRIVATE org repos, so SOME auth must
+# exist by then — but a Stage-0 SHADOW node owns zero tickets and the sync-gate
+# only activates at roster>1, so this stage is non-fatal and flags the gap.
 do_github_auth() {
-  if ! command -v gh >/dev/null 2>&1; then
-    warn "gh not found — thoughts push auth cannot be configured here."
-    warn "Install gh + run 'gh auth login' before M2 activation (thoughts sync gate)."
+  # (1) Operator-supplied token → HTTPS credentials via ~/.netrc (no gh needed).
+  if [[ -n "${CATALYST_JOIN_GITHUB_TOKEN:-}" ]]; then
+    ( umask 077
+      printf 'machine github.com\nlogin %s\npassword %s\n' \
+        "${CATALYST_JOIN_GITHUB_USER:-x-access-token}" "$CATALYST_JOIN_GITHUB_TOKEN" > "$HOME/.netrc" )
+    chmod 600 "$HOME/.netrc" 2>/dev/null || true
+    info "GitHub HTTPS auth configured via ~/.netrc (0600)."
     return 0
   fi
-  if [[ -n "${CATALYST_JOIN_GITHUB_TOKEN:-}" ]] && ! gh auth status >/dev/null 2>&1; then
-    printf '%s' "$CATALYST_JOIN_GITHUB_TOKEN" | gh auth login --with-token >/dev/null 2>&1 \
-      || warn "gh auth login --with-token failed; falling back to existing gh state."
+  # (2) gh credential helper — install gh if absent (private thoughts clone needs it).
+  if ! ensure_gh; then
+    warn "No CATALYST_JOIN_GITHUB_TOKEN and gh unavailable — the thoughts clone may fail."
+    warn "Provide CATALYST_JOIN_GITHUB_TOKEN or run 'gh auth login', then re-run the join."
+    return 0
   fi
   if gh auth status >/dev/null 2>&1; then
-    if gh auth setup-git >/dev/null 2>&1; then
-      info "GitHub HTTPS credential helper configured for thoughts push auth."
-    else
-      warn "gh auth setup-git failed — thoughts push may not work until fixed."
-    fi
+    gh auth setup-git >/dev/null 2>&1 \
+      && info "GitHub HTTPS credential helper configured via gh." \
+      || warn "gh auth setup-git failed — thoughts push may not work until fixed."
   else
-    warn "gh is not authenticated — run 'gh auth login' before M2 activation (thoughts sync gate)."
+    warn "gh is installed but not authenticated — set CATALYST_JOIN_GITHUB_TOKEN or run 'gh auth login', then re-run."
   fi
   return 0
 }
@@ -449,21 +497,28 @@ do_provision_thoughts() {
   if [[ -f "$registry" ]]; then
     args+=(--registry "$registry")
   else
-    local org; org="$(bundle_get '.repoUrl')"; org="${org%%/*}"
+    # First-join fallback: registry isn't written yet, so derive the primary org
+    # from the bundle's repoUrl. repoUrl is "<org>/<repo>" (join-bundle.mjs); also
+    # tolerate a full https URL. (A bare `${url%%/*}` would yield "https:".)
+    local repo_url org
+    repo_url="$(bundle_get '.repoUrl')"
+    org="$(sed -nE 's#^(https?://[^/]+/)?([^/]+)/.*#\2#p' <<<"$repo_url")"
     [[ -n "$org" ]] && args+=(--orgs "$org")
   fi
   if bash "$pt" "${args[@]}"; then
     return 0
   fi
   # provision-thoughts failed — usually push-auth (an M2 precondition), not the
-  # clone. If the primary thoughts repo cloned (read OK), a Stage-0 SHADOW node
-  # can proceed; push auth must be verified-green before M2 activation. Else fail.
-  if [[ -d "${CATALYST_DIR:-$HOME/catalyst}/hlt/coalesce-labs/thoughts/.git" ]]; then
+  # clone. If the primary thoughts repo is present AND has a usable HEAD (a real
+  # read-OK clone, not a partial/interrupted one), a Stage-0 SHADOW node can
+  # proceed; push auth must be verified-green before M2 activation. Else fail.
+  local primary="${CATALYST_DIR:-$HOME/catalyst}/hlt/coalesce-labs/thoughts"
+  if [[ -d "$primary/.git" ]] && git -C "$primary" rev-parse --verify -q HEAD >/dev/null 2>&1; then
     warn "provision-thoughts: clone OK but push-auth/verify incomplete — acceptable for Stage-0 SHADOW."
-    warn "Configure 'gh auth login' (or CATALYST_JOIN_GITHUB_TOKEN) and re-run before M2 activation."
+    warn "Configure CATALYST_JOIN_GITHUB_TOKEN (or 'gh auth login') and re-run before M2 activation."
     return 0
   fi
-  fail "provision-thoughts failed before cloning the primary thoughts repo. Check gh auth / network."
+  fail "provision-thoughts failed before a usable primary thoughts clone. Check GitHub auth / network."
   return 1
 }
 
@@ -633,6 +688,14 @@ main() {
   run_stage "setup-catalyst"      do_setup_catalyst       || exit 1
   run_stage "install-cli"         do_install_cli          || exit 1
   run_stage "setup-plugin-source" do_setup_plugin_source  || exit 1
+
+  # setup-catalyst installs node/bun into ~/.local/node/bin + ~/.bun/bin in a
+  # CHILD shell, so the parent join shell's PATH doesn't see them. The doctor
+  # gate (catalyst-doctor needs a bun/node runtime) and the stack stage run in
+  # THIS shell — prepend the install bins + hash -r so they resolve on a truly
+  # fresh node where the launching shell had no node/bun (CTL-1214 verify).
+  export PATH="$HOME/.local/node/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH"
+  hash -r 2>/dev/null || true
 
   # 5. SHARED config merge + per-node items
   run_stage "config-merge" do_config_merge || exit 1

--- a/plugins/dev/scripts/catalyst-join.sh
+++ b/plugins/dev/scripts/catalyst-join.sh
@@ -16,8 +16,9 @@
 #   CATALYST_JOIN_SETUP_SCRIPT      path to setup-catalyst.sh
 #   CATALYST_JOIN_INSTALL_CLI_SCRIPT path to install-cli.sh
 #   CATALYST_JOIN_PLUGIN_SRC_SCRIPT  path to setup-plugin-source.sh
+#   CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT path to provision-thoughts.sh
 #   CATALYST_JOIN_STACK_BIN          path to catalyst-stack
-#   CATALYST_JOIN_DOCTOR_SCRIPT      path to check-setup.sh
+#   CATALYST_JOIN_DOCTOR_SCRIPT      path to catalyst-doctor (CTL-1186 activation gate)
 #   CATALYST_JOIN_REACH_PROBE        path to reachability probe script
 #   CATALYST_JOIN_FETCH_CMD          path to bundle fetch command (replaces curl)
 #   CATALYST_LAYER2_CONFIG_FILE      path to Layer-2 config (default: ~/.config/catalyst/config.json)
@@ -37,8 +38,13 @@ REPO_ROOT="$(cd "${SELF_DIR}/../../.." && pwd)"
 SETUP_SCRIPT="${CATALYST_JOIN_SETUP_SCRIPT:-${REPO_ROOT}/setup-catalyst.sh}"
 INSTALL_CLI_SCRIPT="${CATALYST_JOIN_INSTALL_CLI_SCRIPT:-${SELF_DIR}/install-cli.sh}"
 PLUGIN_SRC_SCRIPT="${CATALYST_JOIN_PLUGIN_SRC_SCRIPT:-${SELF_DIR}/setup-plugin-source.sh}"
+PROVISION_THOUGHTS_SCRIPT="${CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT:-${SELF_DIR}/provision-thoughts.sh}"
 STACK_BIN="${CATALYST_JOIN_STACK_BIN:-${SELF_DIR}/catalyst-stack}"
-DOCTOR_SCRIPT="${CATALYST_JOIN_DOCTOR_SCRIPT:-${SELF_DIR}/check-setup.sh}"
+# CTL-1186 fail-closed activation gate (NOT the full-workstation check-setup.sh,
+# which is cwd-relative + asserts a fully-provisioned dev box and so exits nonzero
+# on a fresh SHADOW node). catalyst-doctor exits 0 iff zero FAIL checks; warns are
+# expected on a fresh node. Overridable for tests via CATALYST_JOIN_DOCTOR_SCRIPT.
+DOCTOR_SCRIPT="${CATALYST_JOIN_DOCTOR_SCRIPT:-${SELF_DIR}/catalyst-doctor}"
 REACH_PROBE="${CATALYST_JOIN_REACH_PROBE:-}"
 # CATALYST_JOIN_FETCH_CMD — used in acquire_bundle(); resolved there
 
@@ -221,23 +227,38 @@ preflight_tailscale() {
     return 0
   fi
 
-  # Default: check that tailscale is available and the host is reachable
+  # Default: confirm the seed host:port is reachable.
   local host="${seed%%:*}"
   local port="${seed##*:}"
-  if ! command -v tailscale >/dev/null 2>&1; then
-    fail "tailscale not found in PATH. Install Tailscale first."
-    return 1
-  fi
-  if ! tailscale ping --timeout=5s "$host" >/dev/null 2>&1; then
-    fail "Tailscale ping to '${host}' failed. Is this node on the tailnet?"
-    return 1
-  fi
-  # Port reachability check
-  if command -v nc >/dev/null 2>&1; then
-    if ! nc -z -G 5 "$host" "$port" >/dev/null 2>&1; then
-      fail "Port ${port} on '${host}' is not reachable. Is the bundle listener running?"
+
+  # CTL-1214 (PATH-B #2): the `tailscale` CLI is NOT required. A node can be
+  # fully on the tailnet via the GUI app with no CLI on PATH (mini-2's case).
+  # When the CLI is present, use `tailscale ping` as a tailnet liveness check;
+  # the signal that actually matters is a TCP connect to the seed port, which
+  # nc/curl provide with or without the CLI.
+  if command -v tailscale >/dev/null 2>&1; then
+    if ! tailscale ping --timeout=5s "$host" >/dev/null 2>&1; then
+      fail "Tailscale ping to '${host}' failed. Is this node on the tailnet?"
       return 1
     fi
+  fi
+
+  # TCP reachability to the seed port (works with or without the tailscale CLI).
+  # Prefer nc (protocol-agnostic) on macOS; fall back to curl (a 404 from the
+  # listener still proves the port is reachable — curl without -f exits 0).
+  if command -v nc >/dev/null 2>&1; then
+    if ! nc -z -G 5 "$host" "$port" >/dev/null 2>&1; then
+      fail "Port ${port} on '${host}' is not reachable. Is this node on the tailnet and the bundle listener running?"
+      fail "Hint: confirm Tailscale is connected (GUI app or CLI) and the seed armed 'catalyst cluster join-token'."
+      return 1
+    fi
+  elif command -v curl >/dev/null 2>&1; then
+    if ! curl -sS -o /dev/null --connect-timeout 5 "http://${host}:${port}/" >/dev/null 2>&1; then
+      fail "Seed '${host}:${port}' is not reachable. Is this node on the tailnet and the bundle listener running?"
+      return 1
+    fi
+  else
+    warn "No reachability probe tool (nc/curl) available; skipping TCP preflight."
   fi
 }
 
@@ -262,7 +283,14 @@ validate_bundle() {
   local json="$1"
   local missing=()
   for key in "${BUNDLE_REQUIRED_KEYS[@]}"; do
-    if ! echo "$json" | jq -e "$key" >/dev/null 2>&1; then
+    # CTL-1214 (PATH-B #4): assert the key EXISTS, not that its value is truthy.
+    # `jq -e "$key"` exits non-zero when a key is present but null/false, so a
+    # legitimately-null required key (e.g. .livenessAnchorIssue before an anchor
+    # is set) would wrongly fail a structurally-complete bundle. Test path
+    # existence via `any(paths; . == <split path>)` instead.
+    if ! echo "$json" | jq -e --arg key "$key" \
+        '($key | ltrimstr(".") | split(".")) as $p | any(paths; . == $p)' \
+        >/dev/null 2>&1; then
       missing+=("$key")
     fi
   done
@@ -301,7 +329,10 @@ acquire_bundle() {
   local seed="${CATALYST_SEED:-}"
   local host="${seed%%:*}"
   local port="${seed##*:}"
-  local bundle_url="http://${host}:${port}/bundle"
+  # CTL-1214 (PATH-B #1): the armed listener serves ONLY /join-bundle
+  # (execution-core/join-listener.mjs JOIN_ROUTE); any other path 404s, so the
+  # seed-fetch join can never succeed with "/bundle". Must match JOIN_ROUTE.
+  local bundle_url="http://${host}:${port}/join-bundle"
   local fetch_cmd="${CATALYST_JOIN_FETCH_CMD:-}"
 
   if [[ -n "$fetch_cmd" && -x "$fetch_cmd" ]]; then
@@ -371,6 +402,69 @@ do_install_cli() {
 
 do_setup_plugin_source() {
   bash "$PLUGIN_SRC_SCRIPT"
+}
+
+# Establish GitHub HTTPS push auth for thoughts sync WITHOUT embedding a PAT in
+# the repo. Mirrors mini's model: the node uses its OWN gh credential. If
+# CATALYST_JOIN_GITHUB_TOKEN is exported (operator-supplied), log gh in with it;
+# otherwise assume `gh auth login` was already run. Non-blocking: a Stage-0
+# SHADOW node owns zero tickets and the thoughts sync-gate only activates at
+# roster>1, so missing push auth is a clearly-flagged M2 precondition, not a
+# join blocker. (PATH-B: mini-2 had to install gh + build a ~/.netrc by hand.)
+do_github_auth() {
+  if ! command -v gh >/dev/null 2>&1; then
+    warn "gh not found — thoughts push auth cannot be configured here."
+    warn "Install gh + run 'gh auth login' before M2 activation (thoughts sync gate)."
+    return 0
+  fi
+  if [[ -n "${CATALYST_JOIN_GITHUB_TOKEN:-}" ]] && ! gh auth status >/dev/null 2>&1; then
+    printf '%s' "$CATALYST_JOIN_GITHUB_TOKEN" | gh auth login --with-token >/dev/null 2>&1 \
+      || warn "gh auth login --with-token failed; falling back to existing gh state."
+  fi
+  if gh auth status >/dev/null 2>&1; then
+    if gh auth setup-git >/dev/null 2>&1; then
+      info "GitHub HTTPS credential helper configured for thoughts push auth."
+    else
+      warn "gh auth setup-git failed — thoughts push may not work until fixed."
+    fi
+  else
+    warn "gh is not authenticated — run 'gh auth login' before M2 activation (thoughts sync gate)."
+  fi
+  return 0
+}
+
+# Provision the HumanLayer thoughts system (PATH-B #6): clone each served org's
+# thoughts repo into ~/catalyst/hlt/<org>/thoughts, write a clean humanlayer.json
+# (global fallback → coalesce-labs, deterministic repoMappings), verify auth.
+# Orgs are derived data-driven from the node's execution-core registry when
+# present, else from the bundle's repoUrl org (coalesce-labs primary) — never a
+# hardcoded list. MUST run before setup-catalyst, whose thoughts-init binds the
+# checkout to these repos + humanlayer.json.
+do_provision_thoughts() {
+  local pt="$PROVISION_THOUGHTS_SCRIPT"
+  [[ -x "$pt" ]] || { fail "provision-thoughts.sh not found/executable at $pt"; return 1; }
+  local args=(--node-user "${USER:-$(whoami)}")
+  local registry="${CATALYST_DIR}/execution-core/registry.json"
+  [[ -f "$registry" ]] || registry="${CATALYST_DIR}/plugin-source/plugins/dev/scripts/execution-core/registry.json"
+  if [[ -f "$registry" ]]; then
+    args+=(--registry "$registry")
+  else
+    local org; org="$(bundle_get '.repoUrl')"; org="${org%%/*}"
+    [[ -n "$org" ]] && args+=(--orgs "$org")
+  fi
+  if bash "$pt" "${args[@]}"; then
+    return 0
+  fi
+  # provision-thoughts failed — usually push-auth (an M2 precondition), not the
+  # clone. If the primary thoughts repo cloned (read OK), a Stage-0 SHADOW node
+  # can proceed; push auth must be verified-green before M2 activation. Else fail.
+  if [[ -d "${CATALYST_DIR:-$HOME/catalyst}/hlt/coalesce-labs/thoughts/.git" ]]; then
+    warn "provision-thoughts: clone OK but push-auth/verify incomplete — acceptable for Stage-0 SHADOW."
+    warn "Configure 'gh auth login' (or CATALYST_JOIN_GITHUB_TOKEN) and re-run before M2 activation."
+    return 0
+  fi
+  fail "provision-thoughts failed before cloning the primary thoughts repo. Check gh auth / network."
+  return 1
 }
 
 # ── SHARED config merge ───────────────────────────────────────────────────────
@@ -480,11 +574,18 @@ do_config_merge() {
 }
 
 do_doctor_gate() {
-  if bash "$DOCTOR_SCRIPT" >/dev/null 2>&1; then
-    info "Doctor gate passed."
+  # catalyst-doctor (CTL-1186) is the fail-closed activation gate: exit 0 iff zero
+  # FAIL-level checks (warns/info are expected on a fresh SHADOW node — no Linear
+  # token, no liveness anchor, single-host roster). --dry-run is a documented
+  # no-op (all checks are read-only); we pass it to make the intent explicit.
+  # Gate strictly on [$? -eq 0] per the doctor contract. This replaces the old
+  # default of check-setup.sh, a cwd-relative full-workstation check that exits
+  # nonzero on a fresh node (the reason mini-2's join needed a manual marker poke).
+  if bash "$DOCTOR_SCRIPT" --dry-run >/dev/null 2>&1; then
+    info "Doctor gate passed (catalyst-doctor: 0 FAIL checks)."
     return 0
   else
-    fail "Setup health check (doctor gate) failed. Run '${DOCTOR_SCRIPT}' for details."
+    fail "Activation gate (catalyst-doctor) reported FAIL check(s). Run '${DOCTOR_SCRIPT}' for details."
     return 1
   fi
 }
@@ -523,7 +624,13 @@ main() {
   fi
 
   # 4. Provisioners (order matters)
-  run_stage "setup-catalyst"      do_setup_catalyst      || exit 1
+  # github-auth + provision-thoughts MUST precede setup-catalyst: setup-catalyst's
+  # thoughts-init binds the checkout to the cloned thoughts repos + humanlayer.json
+  # that provision-thoughts creates (CTL-1214 PATH-B #6). Stages are append-only in
+  # the resume marker, so a re-run skips completed stages by name.
+  run_stage "github-auth"         do_github_auth          || exit 1
+  run_stage "provision-thoughts"  do_provision_thoughts   || exit 1
+  run_stage "setup-catalyst"      do_setup_catalyst       || exit 1
   run_stage "install-cli"         do_install_cli          || exit 1
   run_stage "setup-plugin-source" do_setup_plugin_source  || exit 1
 

--- a/plugins/dev/scripts/execution-core/join-bundle.mjs
+++ b/plugins/dev/scripts/execution-core/join-bundle.mjs
@@ -1,7 +1,7 @@
 // join-bundle.mjs — CTL-1183. Assembles the SHARED-only cluster join-bundle
 // from Layer-1 + Layer-2 config. Pure function — no network, no side effects.
 
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
@@ -21,12 +21,28 @@ function layer2Path() {
 // daemon's authoritative team→repoRoot map — rather than process.cwd().
 // CTL-1183 / PATH-B #3: `catalyst cluster join-token` arms this listener
 // detached (nohup, cwd=HOME), so a cwd-relative .catalyst/config.json is
-// absent and every layer1Identity field comes back null. The first registry
-// project's repoRoot owns the committed .catalyst/{config,hosts}.json.
+// absent and every layer1Identity field comes back null.
+//
+// The identity-owning repo is the one carrying the committed cluster roster
+// (.catalyst/hosts.json), NOT simply projects[0] — on a multi-team seed (CTL/
+// OTL/EVR/ADV/SLI) the registry order is insertion order and [0] could be a
+// non-coordination team, shipping the WRONG team's identity + roster. Prefer
+// the roster-owner; fall back to [0] only for a single-project registry.
 function registryRepoRoot() {
   try {
-    const first = listProjects()[0];
-    return first?.repoRoot || null;
+    const projects = listProjects();
+    if (!projects.length) return null;
+    const owner = projects.find(
+      (p) => p?.repoRoot && existsSync(resolve(p.repoRoot, ".catalyst", "hosts.json")),
+    );
+    if (owner) return owner.repoRoot;
+    if (projects.length === 1) return projects[0].repoRoot || null;
+    // Multiple projects, none carrying a roster — refuse to guess silently.
+    process.stderr.write(
+      "[join-bundle] WARN: multiple registry projects and none own .catalyst/hosts.json; " +
+        "cannot determine the cluster identity repo. Set CATALYST_CONFIG_FILE explicitly.\n",
+    );
+    return null;
   } catch {
     return null;
   }

--- a/plugins/dev/scripts/execution-core/join-bundle.mjs
+++ b/plugins/dev/scripts/execution-core/join-bundle.mjs
@@ -6,6 +6,7 @@ import { resolve } from "node:path";
 import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { getClusterHosts, getLivenessAnchorIssue } from "./config.mjs";
+import { listProjects } from "./registry.mjs";
 
 export const JOIN_BUNDLE_SCHEMA_VERSION = 1;
 
@@ -16,11 +17,26 @@ function layer2Path() {
   );
 }
 
+// Resolve the seed's own repoRoot from the execution-core registry — the
+// daemon's authoritative team→repoRoot map — rather than process.cwd().
+// CTL-1183 / PATH-B #3: `catalyst cluster join-token` arms this listener
+// detached (nohup, cwd=HOME), so a cwd-relative .catalyst/config.json is
+// absent and every layer1Identity field comes back null. The first registry
+// project's repoRoot owns the committed .catalyst/{config,hosts}.json.
+function registryRepoRoot() {
+  try {
+    const first = listProjects()[0];
+    return first?.repoRoot || null;
+  } catch {
+    return null;
+  }
+}
+
 function layer1Path() {
-  return (
-    process.env.CATALYST_CONFIG_FILE ||
-    resolve(process.cwd(), ".catalyst", "config.json")
-  );
+  if (process.env.CATALYST_CONFIG_FILE) return process.env.CATALYST_CONFIG_FILE;
+  const root = registryRepoRoot();
+  if (root) return resolve(root, ".catalyst", "config.json");
+  return resolve(process.cwd(), ".catalyst", "config.json");
 }
 
 function readJson(p) {
@@ -50,6 +66,16 @@ function resolvePluginSourceUrl(l2) {
 }
 
 export function assembleJoinBundle() {
+  // Pin CATALYST_CONFIG_FILE to the registry repoRoot for the rest of assembly
+  // so the OTHER cwd-dependent read — getClusterHosts() via config.mjs
+  // getCatalystRepoDir() — also resolves <repoRoot>/.catalyst/hosts.json instead
+  // of falling back to the single-host default when this listener runs detached
+  // (PATH-B #3). Guarded so an explicit override (and tests) always win.
+  if (!process.env.CATALYST_CONFIG_FILE) {
+    const root = registryRepoRoot();
+    if (root)
+      process.env.CATALYST_CONFIG_FILE = resolve(root, ".catalyst", "config.json");
+  }
   const l1 = readJson(layer1Path());
   const l2 = readJson(layer2Path());
   const bot = l2?.catalyst?.linear?.bot ?? {};

--- a/plugins/dev/scripts/execution-core/join-bundle.test.mjs
+++ b/plugins/dev/scripts/execution-core/join-bundle.test.mjs
@@ -17,6 +17,11 @@ const BUNDLE_ENVS = [
   "CATALYST_HOST_NAME",
   "OTEL_EXPORTER_OTLP_ENDPOINT",
   "CATALYST_LIVENESS_ANCHOR_ISSUE",
+  // CTL-1214 PATH-B #3: the registry-path override (controls where listProjects()
+  // resolves repoRoot) MUST be saved/restored — the detached-listener test below
+  // sets it, and assembleJoinBundle() MUTATES CATALYST_CONFIG_FILE as a side
+  // effect, so a leak would corrupt later tests.
+  "CATALYST_DIR",
 ];
 
 let saved = {};
@@ -155,6 +160,76 @@ describe("assembleJoinBundle", () => {
     const b = assembleJoinBundle();
     expect(b.layer1Identity.projectKey).toBeNull();
     expect(b.layer1Identity.teamKey).toBeNull();
+  });
+
+  // CTL-1214 PATH-B #3 (bug #3): the detached `nohup` join-listener runs with
+  // cwd=HOME and NO CATALYST_CONFIG_FILE in its env. Before the fix, layer1Path()
+  // and getClusterHosts() both resolved <cwd>/.catalyst/* → null projectKey/
+  // teamKey/stateMap and a single-host roster default. The fix resolves both from
+  // the execution-core registry's first project repoRoot (listProjects()[0]).
+  //
+  // The existing beforeEach masks this because it always sets CATALYST_CONFIG_FILE.
+  // This test reproduces the real detached environment: delete the override, chdir
+  // to a non-repo tmp dir, and point the registry (via CATALYST_DIR) at a fixture
+  // repo that owns the committed Layer-1 config + multi-host roster.
+  test("detached listener (no CATALYST_CONFIG_FILE, cwd=non-repo) resolves layer1 + multi-host roster from registry repoRoot", () => {
+    // A scratch repoRoot OTHER than repoDir, carrying the committed .catalyst tree.
+    const fixtureRepo = mkdtempSync(join(tmpdir(), "jb-registry-repo-"));
+    const cwdSandbox = mkdtempSync(join(tmpdir(), "jb-nonrepo-cwd-"));
+    const catalystDir = mkdtempSync(join(tmpdir(), "jb-catalyst-dir-"));
+    const originalCwd = process.cwd();
+    try {
+      mkdirSync(join(fixtureRepo, ".catalyst"), { recursive: true });
+      writeFileSync(
+        join(fixtureRepo, ".catalyst", "config.json"),
+        JSON.stringify(LAYER1_FIXTURE),
+      );
+      const MULTI_HOST_ROSTER = ["mini", "studio", "mini-2"];
+      writeFileSync(
+        join(fixtureRepo, ".catalyst", "hosts.json"),
+        JSON.stringify(MULTI_HOST_ROSTER),
+      );
+
+      // Layer-2 is still resolved via CATALYST_LAYER2_CONFIG_FILE (set in
+      // beforeEach), so the bot creds / liveness anchor remain available; only
+      // the cwd-relative Layer-1 + roster reads are under test here.
+
+      // Point the execution-core registry at the fixture repoRoot. getRegistryPath()
+      // = <CATALYST_DIR>/execution-core/registry.json.
+      process.env.CATALYST_DIR = catalystDir;
+      mkdirSync(join(catalystDir, "execution-core"), { recursive: true });
+      writeFileSync(
+        join(catalystDir, "execution-core", "registry.json"),
+        JSON.stringify({
+          projects: [{ team: "CTL", repoRoot: fixtureRepo, eligibleQuery: null }],
+        }),
+      );
+
+      // Reproduce the detached listener environment.
+      delete process.env.CATALYST_CONFIG_FILE;
+      process.chdir(cwdSandbox);
+
+      const b = assembleJoinBundle();
+
+      // Layer-1 identity must be POPULATED from the registry repoRoot, not null.
+      expect(b.layer1Identity.projectKey).toBe("catalyst-workspace");
+      expect(b.layer1Identity.teamKey).toBe("CTL");
+      expect(b.layer1Identity.teamId).toBe("team-uuid-1234");
+      expect(b.layer1Identity.stateMap).toEqual({ Todo: "state-1", "In Progress": "state-2" });
+
+      // Roster must be the committed MULTI-host list, NOT the single-host default.
+      expect(b.hostsRoster).toEqual(MULTI_HOST_ROSTER);
+      expect(b.hostsRoster.length).toBeGreaterThan(1);
+    } finally {
+      process.chdir(originalCwd);
+      // assembleJoinBundle() MUTATES CATALYST_CONFIG_FILE when it was unset — wipe
+      // it here too (afterEach restores from `saved`, which holds the pre-test
+      // value; this prevents the mutation leaking inside this test's own teardown).
+      delete process.env.CATALYST_CONFIG_FILE;
+      rmSync(fixtureRepo, { recursive: true, force: true });
+      rmSync(cwdSandbox, { recursive: true, force: true });
+      rmSync(catalystDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/plugins/dev/scripts/provision-thoughts.sh
+++ b/plugins/dev/scripts/provision-thoughts.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# provision-thoughts.sh — lay down a clean HLT (HumanLayer Thoughts) layout for a Catalyst NODE.
+#
+# Purpose (CTL-1214 / bug #6): make the thoughts system a PROVISIONED, VERIFIED part of a node so a
+# fresh box (or server-side install) gets the right per-org thoughts repos, a clean humanlayer.json
+# (no groundworkapp global fallback, deterministic repoMappings for headless bg agents), and working
+# bidirectional sync — BEFORE the node is added to the roster (the sync-gate activates at roster>1).
+#
+# DESIGN: thoughts/shared/plans/2026-06-16-cluster-hlt-thoughts-model.md
+#
+# This script is for NODES (fresh clean layout under $HLT). It does NOT relocate existing embedded
+# clones on a dev laptop / live seed (100+ worktree symlinks point at them) — those keep their layout
+# and only get the config fixes applied out-of-band.
+#
+# Usage:
+#   provision-thoughts.sh [--node-user NAME] [--hlt-root DIR] [--config FILE] [--orgs a,b,c]
+#                         [--registry FILE] [--dry-run] [--no-clone] [--verify-only]
+#
+# Env overrides (for sandbox testing):
+#   HLT_ROOT          default ${CATALYST_DIR:-$HOME/catalyst}/hlt
+#   HL_CONFIG         default $HOME/.config/humanlayer/humanlayer.json
+#   CATALYST_REGISTRY default $HOME/catalyst/registry.json  (or execution-core/registry.json)
+#
+set -uo pipefail
+
+info() { echo "[provision-thoughts] $*"; }
+warn() { echo "[provision-thoughts] WARN: $*" >&2; }
+fail() { echo "[provision-thoughts] ERROR: $*" >&2; }
+
+# ── Canonical org → {profile, thoughts remote} catalog ────────────────────────
+# Standardized on GitHub ORG names (Q-DIRNAME: rightsite-cloud, not groundworkapp).
+# profile name is the HumanLayer profile key; remote is the HTTPS git URL (node auth = gh + HTTPS).
+org_profile() { case "$1" in
+  coalesce-labs)   echo "coalesce-labs" ;;
+  rightsite-cloud) echo "adva" ;;
+  ryanrozich)      echo "ryanrozich" ;;
+  *)               echo "$1" ;;  # default: profile == org
+esac; }
+org_remote() { echo "https://github.com/$1/thoughts.git"; }
+
+# Map a registry repoRoot path → its GitHub org (…github/<org>/<repo>). Empty if unrecognized.
+repo_root_org() { sed -nE 's|.*/github/([^/]+)/[^/]+/?.*|\1|p' <<<"$1" | head -1; }
+# Adva code repo lives under groundworkapp/ locally but its THOUGHTS repo is rightsite-cloud.
+normalize_org() { case "$1" in groundworkapp) echo "rightsite-cloud" ;; *) echo "$1" ;; esac; }
+
+# ── Defaults / args ───────────────────────────────────────────────────────────
+NODE_USER="${USER:-$(whoami)}"
+HLT_ROOT="${HLT_ROOT:-${CATALYST_DIR:-$HOME/catalyst}/hlt}"
+HL_CONFIG="${HL_CONFIG:-$HOME/.config/humanlayer/humanlayer.json}"
+REGISTRY="${CATALYST_REGISTRY:-}"
+ORGS_CSV=""
+DRY_RUN=0; NO_CLONE=0; VERIFY_ONLY=0
+PRIMARY_ORG="coalesce-labs"   # global fallback + defaultProfile target
+
+while [[ $# -gt 0 ]]; do case "$1" in
+  --node-user) NODE_USER="$2"; shift 2 ;;
+  --hlt-root)  HLT_ROOT="$2"; shift 2 ;;
+  --config)    HL_CONFIG="$2"; shift 2 ;;
+  --orgs)      ORGS_CSV="$2"; shift 2 ;;
+  --registry)  REGISTRY="$2"; shift 2 ;;
+  --dry-run)   DRY_RUN=1; shift ;;
+  --no-clone)  NO_CLONE=1; shift ;;
+  --verify-only) VERIFY_ONLY=1; shift ;;
+  -h|--help)   grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  *) fail "unknown arg: $1"; exit 2 ;;
+esac; done
+
+command -v jq >/dev/null || { fail "jq required"; exit 1; }
+command -v git >/dev/null || { fail "git required"; exit 1; }
+
+# ── Derive the org set ────────────────────────────────────────────────────────
+declare -a ORGS=()
+if [[ -n "$ORGS_CSV" ]]; then
+  IFS=',' read -r -a ORGS <<<"$ORGS_CSV"
+elif [[ -n "$REGISTRY" && -f "$REGISTRY" ]]; then
+  info "Deriving orgs from registry: $REGISTRY"
+  while IFS= read -r root; do
+    [[ -z "$root" ]] && continue
+    o="$(normalize_org "$(repo_root_org "$root")")"
+    [[ -n "$o" ]] && ORGS+=("$o")
+  done < <(jq -r '(.projects // [])[].repoRoot // empty' "$REGISTRY" 2>/dev/null)
+  # de-dupe
+  IFS=$'\n' ORGS=($(printf '%s\n' "${ORGS[@]}" | awk '!seen[$0]++')); unset IFS
+else
+  warn "no --orgs and no readable --registry; defaulting to primary only ($PRIMARY_ORG)"
+  ORGS=("$PRIMARY_ORG")
+fi
+[[ " ${ORGS[*]} " == *" $PRIMARY_ORG "* ]] || ORGS=("$PRIMARY_ORG" "${ORGS[@]}")
+info "Node org set: ${ORGS[*]}"
+info "HLT root: $HLT_ROOT   config: $HL_CONFIG   user: $NODE_USER"
+[[ "$DRY_RUN" -eq 1 ]] && info "DRY-RUN: will not clone or write config"
+
+# ── 1. Clone each org's thoughts repo into $HLT/<org>/thoughts ─────────────────
+clone_org() {
+  local org="$1" dest="$HLT_ROOT/$1/thoughts" remote; remote="$(org_remote "$org")"
+  if [[ -d "$dest/.git" ]]; then info "  $org: already present at $dest"; return 0; fi
+  if [[ "$DRY_RUN" -eq 1 || "$NO_CLONE" -eq 1 ]]; then info "  $org: WOULD clone $remote → $dest"; return 0; fi
+  mkdir -p "$(dirname "$dest")"
+  info "  $org: cloning $remote → $dest"
+  git clone -q "$remote" "$dest" || { fail "clone failed for $org ($remote)"; return 1; }
+}
+
+# ── 2. Write a clean humanlayer.json ──────────────────────────────────────────
+write_config() {
+  local profiles="{}" pname dest
+  for org in "${ORGS[@]}"; do
+    pname="$(org_profile "$org")"; dest="$HLT_ROOT/$org/thoughts"
+    profiles="$(jq --arg p "$pname" --arg r "$dest" \
+      '. + {($p): {thoughtsRepo:$r, reposDir:"repos", globalDir:"global"}}' <<<"$profiles")"
+  done
+  local primary_repo="$HLT_ROOT/$PRIMARY_ORG/thoughts"
+  local primary_profile; primary_profile="$(org_profile "$PRIMARY_ORG")"
+  # seed repoMappings from registry repoRoots (deterministic — bg agents resolve w/o direnv)
+  local mappings="{}"
+  if [[ -n "$REGISTRY" && -f "$REGISTRY" ]]; then
+    while IFS=$'\t' read -r root team; do
+      [[ -z "$root" ]] && continue
+      local o p sub; o="$(normalize_org "$(repo_root_org "$root")")"; p="$(org_profile "$o")"
+      # read .thoughts.directory from the repo's Layer-1 config if available; fall back to basename
+      if [[ -f "$root/.catalyst/config.json" ]]; then
+        sub="$(jq -r '.thoughts.directory // empty' "$root/.catalyst/config.json" 2>/dev/null)"
+      fi
+      [[ -z "$sub" ]] && sub="$(basename "$root")"
+      mappings="$(jq --arg path "$root" --arg repo "$sub" --arg prof "$p" \
+        '. + {($path): {repo:$repo, profile:$prof}}' <<<"$mappings")"
+    done < <(jq -r '(.projects // [])[] | "\(.repoRoot)\t\(.team)"' "$REGISTRY" 2>/dev/null)
+  fi
+
+  local new_thoughts
+  new_thoughts="$(jq -n \
+    --arg tr "$primary_repo" --arg dp "$primary_profile" --arg user "$NODE_USER" \
+    --argjson profiles "$profiles" --argjson mappings "$mappings" \
+    '{thoughtsRepo:$tr, defaultProfile:$dp, reposDir:"repos", globalDir:"global",
+      user:$user, profiles:$profiles, repoMappings:$mappings}')"
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    info "DRY-RUN humanlayer.json .thoughts would be:"; echo "$new_thoughts" | jq .
+    return 0
+  fi
+  mkdir -p "$(dirname "$HL_CONFIG")"
+  local base="{}"; [[ -f "$HL_CONFIG" ]] && base="$(cat "$HL_CONFIG")"
+  local tmp; tmp="$(mktemp "$(dirname "$HL_CONFIG")/.hl.XXXXXX")"
+  jq --argjson t "$new_thoughts" '.thoughts = $t' <<<"$base" > "$tmp" && mv "$tmp" "$HL_CONFIG"
+  chmod 600 "$HL_CONFIG"
+  info "Wrote clean .thoughts into $HL_CONFIG (0600)"
+}
+
+# ── 3. Verify read + push auth + resolution ───────────────────────────────────
+verify() {
+  local ok=1
+  for org in "${ORGS[@]}"; do
+    local dest="$HLT_ROOT/$org/thoughts" remote; remote="$(org_remote "$org")"
+    printf '[provision-thoughts]   %-16s ' "$org:"
+    if [[ ! -d "$dest/.git" ]]; then echo "MISSING (not cloned)"; ok=0; continue; fi
+    if git -C "$dest" ls-remote --heads origin main >/dev/null 2>&1; then printf 'read:OK '; else printf 'read:FAIL '; ok=0; fi
+    # push auth probe: dry-run push (exercises credentials without writing)
+    # non-ff is OK (means auth works), only real auth errors = FAIL
+    local push_out push_rc
+    push_out="$(git -C "$dest" push --dry-run origin main 2>&1)" || push_rc=$?
+    if [[ -z "${push_rc:-}" ]] || grep -q 'non-fast-forward\|up to date' <<<"$push_out"; then echo "push:OK"; else echo "push:FAIL (gh auth / HTTPS creds needed)"; ok=0; fi
+  done
+  [[ "$ok" -eq 1 ]] && info "VERIFY: all orgs read+push OK" || warn "VERIFY: one or more orgs failed (see above)"
+  return $((1-ok))
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+if [[ "$VERIFY_ONLY" -eq 0 ]]; then
+  info "== clone phase =="
+  for org in "${ORGS[@]}"; do clone_org "$org" || true; done
+  info "== config phase =="
+  write_config
+fi
+info "== verify phase =="
+verify

--- a/plugins/dev/scripts/provision-thoughts.sh
+++ b/plugins/dev/scripts/provision-thoughts.sh
@@ -79,13 +79,23 @@ elif [[ -n "$REGISTRY" && -f "$REGISTRY" ]]; then
     o="$(normalize_org "$(repo_root_org "$root")")"
     [[ -n "$o" ]] && ORGS+=("$o")
   done < <(jq -r '(.projects // [])[].repoRoot // empty' "$REGISTRY" 2>/dev/null)
-  # de-dupe
-  IFS=$'\n' ORGS=($(printf '%s\n' "${ORGS[@]}" | awk '!seen[$0]++')); unset IFS
+  # de-dupe — guard the empty-array expansion: under `set -u`, macOS system bash
+  # 3.2 (the default on a fresh box before Homebrew) aborts on "${ORGS[@]}" when
+  # ORGS is empty (e.g. a registry whose repoRoots match no /github/<org>/ path).
+  if ((${#ORGS[@]})); then
+    IFS=$'\n' ORGS=($(printf '%s\n' "${ORGS[@]}" | awk '!seen[$0]++')); unset IFS
+  fi
 else
   warn "no --orgs and no readable --registry; defaulting to primary only ($PRIMARY_ORG)"
   ORGS=("$PRIMARY_ORG")
 fi
-[[ " ${ORGS[*]} " == *" $PRIMARY_ORG "* ]] || ORGS=("$PRIMARY_ORG" "${ORGS[@]}")
+# Ensure the primary org is always present (and ORGS is never empty before the
+# expansions below — bash 3.2 + set -u safety).
+if ((${#ORGS[@]} == 0)); then
+  ORGS=("$PRIMARY_ORG")
+elif [[ " ${ORGS[*]} " != *" $PRIMARY_ORG "* ]]; then
+  ORGS=("$PRIMARY_ORG" "${ORGS[@]}")
+fi
 info "Node org set: ${ORGS[*]}"
 info "HLT root: $HLT_ROOT   config: $HL_CONFIG   user: $NODE_USER"
 [[ "$DRY_RUN" -eq 1 ]] && info "DRY-RUN: will not clone or write config"
@@ -123,10 +133,11 @@ write_config() {
       # (a) crash under `set -u` when the first repoRoot lacks a config, and
       # (b) leak the prior iteration's value to a later config-less repoRoot.
       sub="$(basename "$root")"
-      # Prefer the repo's declared thoughts subdir (.thoughts.directory) when present
-      # — e.g. catalyst's Layer-1 config maps repoRoot "catalyst" → "catalyst-workspace".
+      # Prefer the repo's declared thoughts subdir when present — e.g. catalyst's
+      # Layer-1 config maps repoRoot "catalyst" → "catalyst-workspace". The key is
+      # nested under the top-level "catalyst" object: .catalyst.thoughts.directory.
       if [[ -f "$root/.catalyst/config.json" ]]; then
-        d="$(jq -r '.thoughts.directory // empty' "$root/.catalyst/config.json" 2>/dev/null)"
+        d="$(jq -r '.catalyst.thoughts.directory // empty' "$root/.catalyst/config.json" 2>/dev/null)"
         [[ -n "$d" ]] && sub="$d"
       fi
       mappings="$(jq --arg path "$root" --arg repo "$sub" --arg prof "$p" \
@@ -161,9 +172,13 @@ verify() {
     printf '[provision-thoughts]   %-16s ' "$org:"
     if [[ ! -d "$dest/.git" ]]; then echo "MISSING (not cloned)"; ok=0; continue; fi
     if git -C "$dest" ls-remote --heads origin main >/dev/null 2>&1; then printf 'read:OK '; else printf 'read:FAIL '; ok=0; fi
-    # push auth probe: dry-run push (exercises credentials without writing)
-    # non-ff is OK (means auth works), only real auth errors = FAIL
-    local push_out push_rc
+    # push auth probe: dry-run push (exercises credentials without writing).
+    # non-ff is OK (means auth works), only real auth errors = FAIL.
+    # Reset push_rc/push_out EVERY iteration: bash does not clear a same-named
+    # `local` across loop iterations, and `... || push_rc=$?` only assigns on
+    # failure — so a stale rc from a prior org would leak and mis-report later
+    # orgs as push:FAIL (CTL-1214 verify finding).
+    local push_out="" push_rc=""
     push_out="$(git -C "$dest" push --dry-run origin main 2>&1)" || push_rc=$?
     if [[ -z "${push_rc:-}" ]] || grep -q 'non-fast-forward\|up to date' <<<"$push_out"; then echo "push:OK"; else echo "push:FAIL (gh auth / HTTPS creds needed)"; ok=0; fi
   done

--- a/plugins/dev/scripts/provision-thoughts.sh
+++ b/plugins/dev/scripts/provision-thoughts.sh
@@ -115,12 +115,20 @@ write_config() {
   if [[ -n "$REGISTRY" && -f "$REGISTRY" ]]; then
     while IFS=$'\t' read -r root team; do
       [[ -z "$root" ]] && continue
-      local o p sub; o="$(normalize_org "$(repo_root_org "$root")")"; p="$(org_profile "$o")"
-      # read .thoughts.directory from the repo's Layer-1 config if available; fall back to basename
+      local o p sub d
+      o="$(normalize_org "$(repo_root_org "$root")")"; p="$(org_profile "$o")"
+      # Default the thoughts subdir name to the repoRoot basename, ALWAYS — must be
+      # set unconditionally before any branch: bash preserves a same-named `local`
+      # across loop iterations, so leaving `sub` unset in the no-config branch would
+      # (a) crash under `set -u` when the first repoRoot lacks a config, and
+      # (b) leak the prior iteration's value to a later config-less repoRoot.
+      sub="$(basename "$root")"
+      # Prefer the repo's declared thoughts subdir (.thoughts.directory) when present
+      # — e.g. catalyst's Layer-1 config maps repoRoot "catalyst" → "catalyst-workspace".
       if [[ -f "$root/.catalyst/config.json" ]]; then
-        sub="$(jq -r '.thoughts.directory // empty' "$root/.catalyst/config.json" 2>/dev/null)"
+        d="$(jq -r '.thoughts.directory // empty' "$root/.catalyst/config.json" 2>/dev/null)"
+        [[ -n "$d" ]] && sub="$d"
       fi
-      [[ -z "$sub" ]] && sub="$(basename "$root")"
       mappings="$(jq --arg path "$root" --arg repo "$sub" --arg prof "$p" \
         '. + {($path): {repo:$repo, profile:$prof}}' <<<"$mappings")"
     done < <(jq -r '(.projects // [])[] | "\(.repoRoot)\t\(.team)"' "$REGISTRY" 2>/dev/null)

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -1326,6 +1326,20 @@ setup_project_config() {
 	echo ""
 	project_name=$(prompt_value "Enter project name [${REPO_NAME}]:" "${REPO_NAME}")
 
+	# Thoughts subdir/profile: default to REPO_NAME/ORG_NAME but PRESERVE an
+	# existing committed value (CTL-1214) — e.g. the catalyst repo's canonical
+	# .catalyst.thoughts.directory is "catalyst-workspace", NOT the repo name
+	# "catalyst"; regenerating the config must not clobber it and fragment the
+	# node's thoughts subtree away from the fleet's.
+	local thoughts_directory="${REPO_NAME}" thoughts_profile="${ORG_NAME}"
+	if [[ -f "$config_file" ]]; then
+		local _existing_dir _existing_prof
+		_existing_dir=$(jq -r '.catalyst.thoughts.directory // empty' "$config_file" 2>/dev/null)
+		_existing_prof=$(jq -r '.catalyst.thoughts.profile // empty' "$config_file" 2>/dev/null)
+		[[ -n "$_existing_dir" ]] && thoughts_directory="$_existing_dir"
+		[[ -n "$_existing_prof" ]] && thoughts_profile="$_existing_prof"
+	fi
+
 	# Create/update config
 	cat >"$config_file" <<EOF
 {
@@ -1354,8 +1368,8 @@ setup_project_config() {
     },
     "thoughts": {
       "user": null,
-      "directory": "${REPO_NAME}",
-      "profile": "${ORG_NAME}"
+      "directory": "${thoughts_directory}",
+      "profile": "${thoughts_profile}"
     }
   }
 }

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -90,8 +90,14 @@ ask_yes_no() {
 	local REPLY
 
 	# Non-interactive mode (HEAD/sibling feature): answer with ni_answer
-	# without touching stdin.
+	# without touching stdin. CTL-1214 (PATH-B #5): when check_prerequisites is
+	# auto-installing a CRITICAL tool headlessly it sets CATALYST_NI_AUTOINSTALL=1
+	# to force-accept the install offer — otherwise the optional-style ni_answer
+	# of "n" aborts an autonomous catalyst-join on the HumanLayer/gh prereq gate.
+	# The default ni_answer is preserved for every other prompt (tests assert the
+	# install offers still decline in plain NI mode).
 	if [[ ${NON_INTERACTIVE:-0} -eq 1 ]]; then
+		if [[ ${CATALYST_NI_AUTOINSTALL:-0} -eq 1 ]]; then ni_answer="y"; fi
 		echo "$prompt $suffix → ${ni_answer} (non-interactive)" >&2
 		[[ $ni_answer == "y" ]]
 		return
@@ -597,10 +603,16 @@ persist_path_line() {
 }
 
 # Create ~/.local/bin and persist it on PATH via the shell rc files. Idempotent.
+# Also persist ~/.local/node/bin: the no-sudo Node install lives at ~/.local/node
+# and `npm install -g humanlayer linearis` puts their bins in that node prefix
+# (~/.local/node/bin), which is NOT covered by the node/npm/npx symlinks in
+# ~/.local/bin — without this line fresh login shells cannot find humanlayer or
+# linearis (CTL-1214 / mini-2 onboarding: "PATH must include ~/.local/node/bin").
 ensure_local_bin() {
 	mkdir -p "$LOCAL_BIN"
 	persist_path_line 'export PATH="$HOME/.local/bin:$PATH"'
-	export PATH="$LOCAL_BIN:$PATH"
+	persist_path_line 'export PATH="$HOME/.local/node/bin:$PATH"'
+	export PATH="$LOCAL_BIN:$HOME/.local/node/bin:$PATH"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -671,15 +683,25 @@ check_prerequisites() {
 	# Critical: humanlayer (for thoughts system)
 	if ! check_command_exists "humanlayer"; then
 		print_warning "HumanLayer CLI not found (required for thoughts system)"
-		offer_install_humanlayer || missing_critical=true
+		# CTL-1214 (PATH-B #5): force-accept the install offer in headless mode so
+		# an autonomous catalyst-join does not abort on this critical prereq. The
+		# offer helper's own NI default ("n") is preserved for direct/test calls.
+		CATALYST_NI_AUTOINSTALL=1 offer_install_humanlayer || missing_critical=true
 	else
 		print_success "HumanLayer CLI installed"
 	fi
 
-	# Optional: gh (for Linear, GitHub backup)
+	# gh: required on a cluster NODE for HTTPS git push auth (gh auth git-credential)
+	# — thoughts sync pushes over HTTPS, mirroring the seed. Optional for a plain
+	# workstation install. CTL-1214: auto-install it in headless mode so a node
+	# join is not left without push credentials (mini-2 needed a manual download).
 	if ! check_command_exists "gh"; then
-		print_warning "GitHub CLI not found (optional, for Linear integration)"
-		offer_install_gh_cli || missing_optional=true
+		print_warning "GitHub CLI not found (needed for node HTTPS git auth / thoughts sync)"
+		if [[ ${NON_INTERACTIVE:-0} -eq 1 ]]; then
+			CATALYST_NI_AUTOINSTALL=1 offer_install_gh_cli || missing_optional=true
+		else
+			offer_install_gh_cli || missing_optional=true
+		fi
 	else
 		print_success "GitHub CLI installed"
 	fi
@@ -1331,7 +1353,9 @@ setup_project_config() {
       }
     },
     "thoughts": {
-      "user": null
+      "user": null,
+      "directory": "${REPO_NAME}",
+      "profile": "${ORG_NAME}"
     }
   }
 }


### PR DESCRIPTION
## CTL-1214 — durable cluster-node installer (make a fresh `catalyst-join` a real one-liner)

mini-2 was onboarded by **manually working around 6 "PATH-B" bugs**; this PR bakes
the fixes into the actual installer so the *next* node joins cleanly. mini-2 itself
already runs — this changes the join path, not any running daemon (nothing is
deployed/restarted here).

### What was broken (all fixed)
| Bug | Symptom | Fix |
|-----|---------|-----|
| #1 bundle path | seed-fetch hit `/bundle`, listener serves `/join-bundle` → 404, seed-mode join impossible | match `JOIN_ROUTE` |
| #2 tailscale preflight | hard-required the `tailscale` CLI; a GUI-app tailnet node aborted | TCP `nc`/`curl` fallback (portable `-w`, not BSD-only `-G`) |
| #3 listener cwd | detached `nohup` listener (cwd=HOME) shipped null projectKey/teamKey/roster | resolve Layer-1 + roster from the registry roster-owner repoRoot |
| #4 validate_bundle | `jq -e` rejected a legitimately-null `livenessAnchorIssue` | split: identity/creds **non-null**, anchor **existence-only** |
| #5 headless prereqs | NI mode declined the critical HumanLayer/gh install → join aborted | `CATALYST_NI_AUTOINSTALL` guard auto-installs criticals |
| #6 no thoughts | join never provisioned the thoughts system setup-catalyst hard-requires | new `github-auth` + `provision-thoughts` stages; `provision-thoughts.sh` landed in-repo |

Plus: the doctor gate now uses the CTL-1186 fail-closed **`catalyst-doctor`** (cwd-independent; passes on a fresh SHADOW node) instead of the cwd-relative `check-setup.sh` — removing the manual `join-progress.json` marker poke mini-2 needed; setup-catalyst writes `.catalyst.thoughts.{directory,profile}` and persists `~/.local/node/bin` on PATH.

### Auth model
`github-auth` establishes HTTPS auth for the private thoughts clone via
`CATALYST_JOIN_GITHUB_TOKEN` → `0600 ~/.netrc` (gh-free; preserves any existing
netrc), or installs + uses `gh`. Non-blocking for Stage-0 SHADOW; verified-green
thoughts sync is the explicit M2 activation precondition.

### How this was built (multi-agent, adversarial)
- **8-agent analysis** mapped every bug site + the git state (the "stray docs commit" turned out to already be on main via the CTL-1221 squash — no surgery needed).
- **4-agent test authoring** wrote regression guards and **caught a real bug in the bug-#1 fix** (a `local`-scoping leak / `set -u` crash).
- **6-agent adversarial verification** then found **8 high-severity defects** in the first cut — `nc -G` Linux false-FAIL, a **fail-open** validation accepting null identity, a **wrong jq path** that made bug-#1 silently no-op, a gh-before-install ordering abort, a doctor-gate PATH gap, a bash-3.2 crash, and a stale-`push_rc` mis-report. All remediated; a final focused re-verify came back clean.

### Tests
**227 green** (catalyst-join 36, provision-thoughts 35, setup-catalyst 132, execution-core bun 24) — incl. null-identity rejection, the `/join-bundle` contract, tailscale TCP fallback, bash-3.2 empty-registry, and the real nested `.catalyst.thoughts.directory` schema. Regression guards proven to fail against pre-fix source.

### Known follow-ups (deliberately out of scope)
- `doctor.mjs` host-membership/roster-file read two resolvers (pre-existing; not introduced here).
- Resume of a node onboarded with the *old* stage set re-runs provisioning after binding (affects only an already-onboarded node like mini-2; fresh joins are correct).
- Wire these shell suites + `join-bundle.test.mjs` into CI (currently macOS-local only).
- First-join provisions the single primary org; full multi-org mirror materializes once the registry exists (consistent with Stage-0 SHADOW).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
