### PR TITLE
fix(dev): CTL-1176 — real recovery actuators (emit/post/seam/remediate/cooldown) + DIAGNOSE evidence + inbox reader

### DIFF
--- a/plugins/dev/scripts/execution-core/diagnostician.mjs
+++ b/plugins/dev/scripts/execution-core/diagnostician.mjs
@@ -80,7 +80,10 @@ export function __resetDiagnosticianForTests() {
 //
 // Both sources are injectable for tests (no real process spawning in tests).
 // The 'Unknown command' banner in logsOutput is the 2026-06-09 root cause.
-function captureEvidence(subject, bgJobId, { captureLogs, readJobState } = {}) {
+//
+// CTL-1176: exported so recovery-reasoning's DIAGNOSE step can populate
+// {logsOutput, jobState} read-only before classifying a ticket.
+export function captureEvidence(subject, bgJobId, { captureLogs, readJobState } = {}) {
   const shortId = bgJobId; // subject's short ID (already resolved by the caller)
 
   // claude logs output — the screen buffer that reveals WHY the session is idle

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -25,7 +25,25 @@
 // • R11 action_ineffective + max_attempts=2 → R12 forces escalate
 // • Decide/act bright line: Datalog derives; this pass + seams act and emit back
 
-import { log as defaultLog } from "./config.mjs";
+import {
+  mkdirSync,
+  appendFileSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  renameSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import {
+  log as defaultLog,
+  getEventLogPath,
+} from "./config.mjs";
+import { hostName, hostId } from "./lib/host-identity.mjs";
+import { captureEvidence } from "./diagnostician.mjs";
 
 // Wrap defaultLog to ensure it's a function (config.mjs may export an object)
 const defaultLogFn = typeof defaultLog === "function" ? defaultLog : (msg) => {
@@ -35,6 +53,17 @@ const defaultLogFn = typeof defaultLog === "function" ? defaultLog : (msg) => {
     console.log(msg);
   }
 };
+
+// linear-comment-post.sh — the app-actor OAuth comment helper (CTL-1182 path).
+const LINEAR_COMMENT_POST_BIN = fileURLToPath(
+  new URL("../lib/linear-comment-post.sh", import.meta.url),
+);
+
+// phase-agent-emit-complete — the canonical wake/synthetic-complete emitter, used
+// by the CTL-1186 phase-pr re-dispatch to nudge the scheduler after re-arming.
+const EMIT_COMPLETE_BIN = fileURLToPath(
+  new URL("../phase-agent-emit-complete", import.meta.url),
+);
 
 // ─── Main entry point ──────────────────────────────────────────────────────
 
@@ -48,7 +77,16 @@ export function reasoningRecoveryPass(items, opts = {}) {
     postComment = defaultPostComment,
     emitEvent = defaultEmitEvent,
     shouldSkipItem = defaultShouldSkipItem,
+    // CTL-1176: DIAGNOSE evidence-collector. Read-only — populates an item's
+    // {logsOutput, jobState} from `claude logs` + the bg job state when the
+    // caller didn't already attach them. Injectable for tests.
+    captureEvidenceFn = captureEvidence,
     log = defaultLogFn,
+    // CTL-1176: per-tick fix cap. Once this many FIX-actions have been ACTED on
+    // in this single enforce invocation, the rest fall through to a lightweight
+    // "deferred" outcome — no action, no cooldown burn — so the next tick picks
+    // them up. Prevents a 19-item storm in one sweep. Default 3, env-overridable.
+    maxFixesPerTick = Number(process.env.CATALYST_RECOVERY_MAX_FIXES_PER_TICK) || 3,
   } = opts;
 
   if (mode === "off") {
@@ -57,6 +95,8 @@ export function reasoningRecoveryPass(items, opts = {}) {
   }
 
   const results = [];
+  // CTL-1176: count of FIX-actions actually taken this invocation (enforce only).
+  let fixesThisTick = 0;
 
   for (const item of items) {
     // Check cooldown / already-escalated
@@ -65,8 +105,22 @@ export function reasoningRecoveryPass(items, opts = {}) {
       continue;
     }
 
-    // DIAGNOSE: reuse diagnostician evidence
-    const evidence = item.evidence || {};
+    // DIAGNOSE: reuse diagnostician evidence. If the caller didn't attach
+    // logsOutput, capture it read-only now (claude logs + bg job state). This is
+    // a pure collector — no env gate, no side effects (CTL-937 captureEvidence).
+    let evidence = item.evidence || {};
+    if (!evidence.logsOutput && item.bgJobId) {
+      try {
+        const captured = captureEvidenceFn(`${item.ticket}/${item.phase ?? ""}`, item.bgJobId, {});
+        evidence = {
+          ...evidence,
+          logsOutput: captured.logsOutput ?? evidence.logsOutput ?? null,
+          jobState: captured.jobState ?? evidence.jobState ?? null,
+        };
+      } catch (err) {
+        log(`recovery-reasoning: ${item.ticket} evidence capture failed: ${err.message}`);
+      }
+    }
 
     // PROPOSE: classify per CTL-828
     let classification;
@@ -121,10 +175,49 @@ export function reasoningRecoveryPass(items, opts = {}) {
         actionLog.push("emitted recovery.would-escalate");
       }
 
+      // CTL-1176: shadow STILL burns the cooldown ledger. Without a marker write,
+      // shadow re-posts a diagnosis comment + re-emits a .would-* event for EVERY
+      // qualifying item on EVERY tick (~14s) forever — 19 items × every tick is a
+      // Linear/OAuth/fork storm. Recording a "shadow" intent makes the next tick's
+      // shouldSkipItem honor the cooldown window exactly like enforce, so shadow is
+      // a rate-limited dry-run, not an unconditional spammer. Latches escalated for
+      // a would-escalate so a shadow escalation is terminal (mirrors enforce).
+      try {
+        recordIntent(item.ticket, {
+          type: "recovery-pass",
+          decision: decision === "escalate" ? "escalate" : "shadow",
+          fix_class: decision === "fix" ? fix_class : null,
+          escalated: decision === "escalate",
+        });
+        actionLog.push("recorded shadow intent (cooldown marker)");
+      } catch (err) {
+        log(`recovery-reasoning: ${item.ticket} shadow intent record failed: ${err.message}`);
+      }
+
       outcome = { decision, fix_class, actionLog, mode: "shadow" };
     } else if (mode === "enforce") {
       // Enforce mode: actually invoke seams / remediate, record intent
       if (decision === "fix") {
+        // CTL-1176: per-tick fix cap. Once maxFixesPerTick FIX-actions have been
+        // taken this invocation, defer the rest — no action, no cooldown burn —
+        // so the next scheduler tick processes them. Bounds a one-sweep storm.
+        if (fixesThisTick >= maxFixesPerTick) {
+          actionLog.push(`deferred: per-tick fix cap (${maxFixesPerTick}) reached`);
+          log(
+            `recovery-reasoning: ${item.ticket} deferred — per-tick fix cap ${maxFixesPerTick} reached`,
+          );
+          results.push({
+            ticket: item.ticket,
+            decision: "deferred",
+            fix_class,
+            reason: `per-tick fix cap (${maxFixesPerTick}) reached`,
+            actionLog,
+            mode: "enforce",
+          });
+          continue;
+        }
+        fixesThisTick += 1;
+
         const fixOutcome = attemptFix(item, classification, {
           invokeSeam,
           invokeRemediateCapped,
@@ -268,6 +361,19 @@ export function checkDeterministicErrors(logsOutput, failureReason) {
       fix_class: "orphan_stale",
       seam_id: "orphan-reconcile",
       reason: "Orphan PR reconciliation needed",
+    };
+  }
+  // CTL-1186: phase-pr push rejected because the GitHub token lacked workflow
+  // scope. The token now has the scope, so the deterministic FIX is to re-arm
+  // phase-pr (reset its failed signal → pending + wake the scheduler) and let it
+  // re-run. This shortcut classifies CTL-1186 as FIX (re-dispatch), not escalate,
+  // even when no `claude logs` buffer is available — the signal failureReason is
+  // enough. Routed to the workflow-token-redispatch seam (defaultInvokeSeam).
+  if (failureReason === "push_rejected_no_workflow_scope") {
+    return {
+      fix_class: "push_rejected_no_workflow_scope",
+      seam_id: "workflow-token-redispatch",
+      reason: "Push rejected (no workflow scope); re-arm phase-pr to re-run with the scoped token",
     };
   }
   // Merge-conflict and rebase-failed via failureReason → bounded-LLM, not a seam stub.
@@ -565,38 +671,439 @@ function buildEscalationPayload(item, classification) {
 
 // ─── Default injectable implementations ─────────────────────────────────────
 
-function defaultInvokeSeam(ticket, seamId, brief) {
-  // Stub: would invoke unstuck-sweep seam registry (CTL-1219)
+// Resolve the orchestrator runtime dir for host-local markers/seams. Mirrors
+// the scheduler's CATALYST_ORCHESTRATOR_DIR convention (execution-core: one dir).
+function resolveOrchDir() {
+  return process.env.CATALYST_ORCHESTRATOR_DIR ?? null;
+}
+
+// ── (1) defaultEmitEvent — append a real OTel envelope to the unified log ─────
+//
+// Mirrors the *-event.mjs pattern (ratelimit-event.mjs / drain-event.mjs):
+// build a pure OTel envelope, then one best-effort appendFileSync. NEVER throws —
+// recovery correctness never branches on the emit succeeding.
+//
+// The flat event.type becomes attributes["event.name"] VERBATIM and the CTL key
+// becomes attributes["event.label"] (mirrored in body.payload.ticket) — exactly
+// what board-data.mjs:loadRecoveryOutcomes matches on. This is the load-bearing
+// half of the emit↔read contract.
+
+// buildRecoveryEnvelope — pure. Assembles the canonical envelope for a
+// recovery.* event. Exported so tests can assert the contract shape directly.
+export function buildRecoveryEnvelope(event, { now } = {}) {
+  const ts = now ? now() : new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const {
+    type,
+    ticket = null,
+    fix_class = null,
+    reason = null,
+    details = null,
+    escalation = null,
+  } = event;
+  // Escalations carry WARN severity; fixes/triage carry INFO.
+  const escalated = type === "recovery.would-escalate" || type === "recovery.escalated";
   return {
-    success: false,
-    reason: `seam ${seamId} not implemented (stub)`,
-    details: {},
+    ts,
+    id: randomBytes(8).toString("hex"),
+    observedTs: ts,
+    severityText: escalated ? "WARN" : "INFO",
+    severityNumber: escalated ? 13 : 9,
+    traceId: null,
+    spanId: null,
+    resource: {
+      "service.name": "catalyst.execution-core",
+      "service.namespace": "catalyst",
+      "host.name": hostName(),
+      "host.id": hostId(),
+    },
+    attributes: {
+      // ← THE canonical name. The board reader matches attributes["event.name"].
+      "event.name": type,
+      "event.entity": "ticket",
+      "event.action": String(type).replace(/^recovery\./, ""),
+      // ← the CTL key — what loadRecoveryOutcomes keys its outcome map on.
+      "event.label": ticket,
+      ...(fix_class != null ? { "recovery.fix_class": fix_class } : {}),
+    },
+    // human-readable mirror; also the reader's fallback ticket-key source.
+    body: { payload: { ticket, type, fix_class, reason, details, escalation } },
   };
 }
 
-function defaultInvokeRemediateCapped(ticket, brief) {
-  // Stub: would invoke phase-remediate with hard cycle cap (CTL-653)
+function defaultEmitEvent(event, { logPath = getEventLogPath(), now } = {}) {
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, JSON.stringify(buildRecoveryEnvelope(event, { now })) + "\n");
+    return true;
+  } catch {
+    return false; // best-effort, matches all *-event.mjs appenders
+  }
+}
+
+// ── (2) defaultPostComment — app-actor Linear comment, fail-open ──────────────
+//
+// Invokes lib/linear-comment-post.sh with the markdown as a single argv element
+// (never via stdin — multi-line is preserved because shell:false). The helper
+// fails CLOSED (exit 1) on any error; we catch that here and never throw past a
+// logged warning so a comment-post failure never wedges the recovery tick.
+function defaultPostComment(ticket, markdown, opts = {}) {
+  const log = opts.log ?? defaultLogFn;
+  try {
+    const res = spawnSync(LINEAR_COMMENT_POST_BIN, [ticket, markdown], {
+      cwd: opts.cwd ?? process.cwd(), // must resolve projectKey from cwd ancestry
+      env: { ...process.env, ...(opts.env ?? {}) },
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    if (res.status === 0) {
+      return { ok: true, via: "app-actor" };
+    }
+    log(
+      `recovery-reasoning: ${ticket} comment post failed (status ${res.status}): ` +
+        `${(res.stderr || res.error?.message || "unknown").toString().trim().split("\n").pop()}`,
+    );
+    return { ok: false, via: "app-actor", status: res.status };
+  } catch (err) {
+    log(`recovery-reasoning: ${ticket} comment post threw: ${err.message}`);
+    return { ok: false, error: err.message };
+  }
+}
+
+// ── (3) defaultInvokeSeam — invoke the CTL-1219 act-seam registry ─────────────
+//
+// Builds buildUnstuckActSeams(deps) and invokes the named seam by category. The
+// recovery seam_id vocabulary maps to the frozen registry's category keys. The
+// seam contract is throw=fail / return=success; we translate that into
+// {success, reason, details}. The recovery pass owns all emit/post/intent.
+//
+// CTL-1186: "workflow-token-redispatch" / "workflow-token-fallback" have NO
+// registry seam — they re-arm phase-pr by deleting its failed signal so the
+// scheduler re-dispatches, then wake the loop via phase-agent-emit-complete.
+//
+// scheduler.mjs imports recovery-reasoning.mjs, so importing scheduler statically
+// would be a CYCLE. defaultClearStall + buildUnstuckActSeams are therefore
+// loaded lazily here (only at act-time, in enforce mode) via dynamic import.
+const SEAM_ID_TO_CATEGORY = {
+  "orphan-reconcile": "orphan-stale",
+};
+
+export function defaultInvokeSeam(ticket, seamId, brief = {}, deps = {}) {
+  // CTL-1186 / CTL-1219: the two workflow-token classifications re-arm phase-pr
+  // (reset its failed signal → pending) then wake the scheduler. Fully
+  // synchronous — the file ops + emit are synchronous spawnSync underneath.
+  if (seamId === "workflow-token-redispatch" || seamId === "workflow-token-fallback") {
+    const orchDir = deps.orchDir ?? resolveOrchDir();
+    if (!orchDir) {
+      return { success: false, reason: "no orchDir for phase-pr re-dispatch", details: {} };
+    }
+    const phase = deps.phase ?? "pr";
+    const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
+    try {
+      if (existsSync(signalPath)) {
+        let sig = {};
+        try {
+          sig = JSON.parse(readFileSync(signalPath, "utf8"));
+        } catch {
+          sig = {};
+        }
+        sig.status = "pending";
+        delete sig.failureReason;
+        const tmp = `${signalPath}.tmp.${process.pid}`;
+        writeFileSync(tmp, JSON.stringify(sig, null, 2));
+        renameSync(tmp, signalPath);
+      }
+      const res = spawnSync(
+        EMIT_COMPLETE_BIN,
+        [
+          "--phase", "review",
+          "--ticket", ticket,
+          "--status", "complete",
+          "--no-signal-update",
+          "--orch-dir", orchDir,
+          "--orch-id", ticket,
+        ],
+        { encoding: "utf8" },
+      );
+      return {
+        success: res.status === 0 || res.status == null,
+        reason: "re-armed phase-pr (reset failed→pending) and woke the scheduler",
+        details: { phase, signalPath, wakeStatus: res.status ?? null, seam_id: seamId },
+      };
+    } catch (err) {
+      return { success: false, reason: err.message, details: { error: err.message } };
+    }
+  }
+
+  // Map recovery seam_id → frozen-registry category.
+  const category = SEAM_ID_TO_CATEGORY[seamId];
+  if (!category) {
+    return { success: false, reason: `no registry seam for ${seamId}`, details: {} };
+  }
+
+  // Build the CTL-1219 frozen registry. unstuck-act-seams.mjs has NO transitive
+  // import of scheduler/recovery-reasoning (verified), so a static import is safe
+  // — no cycle. Production deps (clearStall, resolvePrState, jobLifecycle) fall
+  // back to the module's real defaults; the scheduler can inject richer deps via
+  // deps.actByCategory (a pre-built registry) when it already has them in scope.
+  let registry = deps.actByCategory;
+  if (!registry) {
+    try {
+      const { buildUnstuckActSeams } = requireSync("./unstuck-act-seams.mjs");
+      registry = buildUnstuckActSeams({ orchDir: deps.orchDir ?? resolveOrchDir() });
+    } catch (err) {
+      return {
+        success: false,
+        reason: `registry build failed: ${err.message}`,
+        details: { error: err.message },
+      };
+    }
+  }
+  if (typeof registry[category] !== "function") {
+    return {
+      success: false,
+      reason: `registry seam '${category}' unavailable`,
+      details: {},
+    };
+  }
+
+  const seam = registry[category];
+  const candidate = { ticket, ...(deps.candidate ?? {}) };
+  const decision = deps.decision ?? { category, ...(brief ?? {}) };
+  try {
+    seam(candidate, decision); // return ignored; throws on hard failure
+    return { success: true, reason: brief?.reason ?? `${category} seam applied`, details: {} };
+  } catch (err) {
+    return { success: false, reason: err.message, details: { error: err.message } };
+  }
+}
+
+// ── (4) defaultInvokeRemediateCapped — ONE capped phase-remediate --bg ────────
+//
+// Dispatches a single phase-remediate worker, fire-and-forget. The structured
+// brief reaches the worker ONLY through verify.json.findings[] (the SKILL reads
+// that file), so we inject the brief as a synthetic high-severity finding before
+// dispatching. The CTL-653 cap (3) is event-counted — we refuse a dispatch when
+// the count is already at the cap. On a successful launch we return
+// {success:true, dispatched:true, attempts:1} — "dispatched", NOT "fixed". The
+// fix verdict only exists later in the re-run verify.json; the dispatch cooldown +
+// event-counted cap prevent re-dispatch before it lands.
+function injectBriefIntoVerify(orchDir, ticket, { brief, reason }) {
+  const p = join(orchDir, "workers", ticket, "verify.json");
+  let verify;
+  try {
+    verify = existsSync(p)
+      ? JSON.parse(readFileSync(p, "utf8"))
+      : { regression_risk: 5, findings: [], tests_attempted: 0 };
+  } catch {
+    verify = { regression_risk: 5, findings: [], tests_attempted: 0 };
+  }
+  verify.findings = Array.isArray(verify.findings) ? verify.findings : [];
+  verify.findings.push({
+    severity: "high", // high → remediate is REQUIRED to address it
+    kind: "review",
+    file: null,
+    line: null,
+    message: reason ?? "recovery-injected remediation brief",
+    recommendation: brief ?? "Resolve the issue and retry the phase.",
+  });
+  mkdirSync(dirname(p), { recursive: true }); // worker dir exists in prod; be safe
+  const tmp = `${p}.tmp.${process.pid}`;
+  writeFileSync(tmp, JSON.stringify(verify, null, 2));
+  renameSync(tmp, p); // atomic
+}
+
+export function defaultInvokeRemediateCapped(ticket, { brief, reason } = {}, deps = {}) {
+  const orchDir = deps.orchDir ?? resolveOrchDir();
+  if (!orchDir) {
+    return { success: false, dispatched: false, attempts: 0, reason: "no orchDir", details: {} };
+  }
+
+  // Lazy imports — dispatch.mjs / event-scan.mjs / phase-fsm.mjs do NOT import
+  // recovery-reasoning, so these are safe, but we keep them here to avoid loading
+  // the dispatch graph for the off/shadow paths.
+  let dispatchTicket, countRemediateCycles, REMEDIATE_PHASE, REMEDIATE_CYCLE_CAP;
+  try {
+    ({ dispatchTicket } = deps.dispatchMod ?? requireSync("./dispatch.mjs"));
+    ({ countRemediateCycles } = deps.eventScanMod ?? requireSync("./event-scan.mjs"));
+    ({ REMEDIATE_PHASE, REMEDIATE_CYCLE_CAP } = deps.fsmMod ?? requireSync("../lib/phase-fsm.mjs"));
+  } catch (err) {
+    return {
+      success: false,
+      dispatched: false,
+      attempts: 0,
+      reason: `remediate module load failed: ${err.message}`,
+      details: { error: err.message },
+    };
+  }
+
+  const countCycles = deps.countCycles ?? countRemediateCycles;
+  const dispatch = deps.dispatchTicket ?? dispatchTicket;
+
+  // (1) Enforce the CTL-653 hard cap HERE — phase-agent-dispatch does not.
+  const attempts = countCycles({ ticket });
+  if (attempts >= REMEDIATE_CYCLE_CAP) {
+    return {
+      success: false,
+      dispatched: false,
+      attempts,
+      reason: "remediate-cycle-cap-exhausted",
+      details: { cap: REMEDIATE_CYCLE_CAP },
+    };
+  }
+
+  // (2) Write the brief into the channel the worker reads.
+  try {
+    injectBriefIntoVerify(orchDir, ticket, { brief, reason });
+  } catch (err) {
+    return {
+      success: false,
+      dispatched: false,
+      attempts,
+      reason: `verify.json brief injection failed: ${err.message}`,
+      details: { error: err.message },
+    };
+  }
+
+  // (3) Dispatch through the JS seam (worktree provisioning, claim, OTEL).
+  let r;
+  try {
+    r = dispatch(orchDir, ticket, REMEDIATE_PHASE);
+  } catch (err) {
+    return {
+      success: false,
+      dispatched: false,
+      attempts,
+      reason: `dispatch threw: ${err.message}`,
+      details: { error: err.message },
+    };
+  }
+
+  if (r && r.code === 0) {
+    // Fire-and-forget: dispatched, not fixed. Cooldown prevents re-dispatch.
+    return {
+      success: true,
+      dispatched: true,
+      attempts: 1,
+      reason: "phase-remediate dispatched",
+      details: {
+        phase: REMEDIATE_PHASE,
+        bg_job_id: r.signal?.bg_job_id ?? null,
+        worktreePath: r.worktreePath ?? null,
+      },
+    };
+  }
   return {
     success: false,
-    reason: "remediate not implemented (stub)",
-    attempts: 1,
-    details: {},
+    dispatched: false,
+    attempts,
+    reason: r?.stderr ? `dispatch failed: ${String(r.stderr).trim()}` : "dispatch failed",
+    details: { code: r?.code ?? null },
   };
 }
 
-function defaultRecordIntent(ticket, intent) {
-  // Stub: would write to intention ledger (label-guard.mjs pattern)
+// requireSync — synchronous module access for the dispatch graph. The recovery
+// pass calls invokeRemediateCapped synchronously; createRequire gives us a sync
+// loader for these ESM siblings (Bun resolves .mjs through require). Throws on
+// failure so the caller's try/catch surfaces a load error rather than a silent stub.
+const _require = createRequire(import.meta.url);
+function requireSync(spec) {
+  return _require(spec);
 }
 
-function defaultPostComment(ticket, comment, opts) {
-  // Stub: would use linearis or direct GraphQL
+// ── (5) Host-local cooldown + intent ledger (CTL-638 / CTL-1078 pattern) ──────
+//
+// HOST-LOCAL: this ledger lives at ~/catalyst/execution-core/.recovery-intents/
+// (one file per ticket). ~/catalyst is per-host, so a second host running its
+// own daemon keeps a SEPARATE ledger — the cooldown/max-attempts/escalated-latch
+// guarantees are scoped to ONE machine. Cross-host claim (a durable lease on the
+// ticket itself, e.g. a Linear field/label so every daemon sees it) is a SEPARATE
+// follow-up for the dormant multi-host layer, out of scope here. Correct and
+// complete for the single-host (mini) topology in production today.
+
+// Cooldown window: 30-min default, env-overridable. NaN*x and 0*x are both falsy
+// → fall through to the default (matches label-guard's Number(env) || default).
+export const RECOVERY_COOLDOWN_MS =
+  Number(process.env.CATALYST_RECOVERY_COOLDOWN_MIN) * 60 * 1000 || 30 * 60 * 1000;
+
+// max_attempts: recovery passes before we stop self-healing. Env-overridable, default 2.
+export const RECOVERY_MAX_ATTEMPTS =
+  Number(process.env.CATALYST_RECOVERY_MAX_ATTEMPTS) || 2;
+
+function recoveryIntentPath(orchDir, ticket) {
+  return join(orchDir, ".recovery-intents", `${ticket}.json`);
 }
 
-function defaultEmitEvent(event) {
-  // Stub: would append to event log
+// defaultRecordIntent — append/upgrade a recovery-intent ledger entry.
+// Read-modify-write: preserve first-action ts, accrue attempts, latch escalated.
+export function defaultRecordIntent(ticket, intent, opts = {}) {
+  const orchDir = opts.orchDir ?? resolveOrchDir();
+  if (!orchDir) return null;
+  const now = opts.now ?? (() => Date.now());
+  const log = opts.log ?? defaultLogFn;
+  const dir = join(orchDir, ".recovery-intents");
+  const p = recoveryIntentPath(orchDir, ticket);
+  const ts = now();
+
+  let prior = {};
+  try {
+    prior = JSON.parse(readFileSync(p, "utf8")) ?? {};
+  } catch {
+    prior = {}; // absent / malformed → start fresh
+  }
+
+  const escalated =
+    Boolean(prior.escalated) ||
+    Boolean(intent.escalated) ||
+    intent.decision === "escalate"; // an escalate-pass latches escalated
+
+  const entry = {
+    ticket,
+    ts: typeof prior.ts === "number" ? prior.ts : ts, // first-action timestamp
+    lastTs: ts, // most-recent action timestamp (drives the cooldown window)
+    decision: intent.decision,
+    fix_class: intent.fix_class ?? prior.fix_class ?? null,
+    attempts:
+      typeof intent.attempts === "number"
+        ? intent.attempts
+        : (typeof prior.attempts === "number" ? prior.attempts : 0) + 1,
+    escalated,
+  };
+
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(p, JSON.stringify(entry));
+  } catch (err) {
+    // Never let a marker write crash the tick — worst case the next tick re-acts.
+    log(`recovery-reasoning: ${ticket} intent ledger write failed: ${err.message}`);
+  }
+  return entry;
 }
 
-function defaultShouldSkipItem(ticket) {
-  // Stub: would check cooldown + escalation history
+// defaultShouldSkipItem — true when recovery should NOT act this pass. Fail-OPEN
+// on absent/malformed ledger (returns false → recovery proceeds). Evaluation
+// order: escalated (terminal) → attempts (terminal) → cooldown (transient).
+export function defaultShouldSkipItem(ticket, opts = {}) {
+  const orchDir = opts.orchDir ?? resolveOrchDir();
+  if (!orchDir) return false;
+  const now = opts.now ?? (() => Date.now());
+  const p = recoveryIntentPath(orchDir, ticket);
+
+  let data;
+  try {
+    data = JSON.parse(readFileSync(p, "utf8"));
+  } catch {
+    return false; // no ledger / malformed → never acted → don't skip
+  }
+
+  // (c) already escalated → terminal, hand off to human, stop acting.
+  if (data?.escalated === true) return true;
+
+  // (b) attempts exhausted → stop self-healing.
+  if (typeof data?.attempts === "number" && data.attempts >= RECOVERY_MAX_ATTEMPTS) return true;
+
+  // (a) acted within the cooldown window → too soon, skip this pass.
+  const last = typeof data?.lastTs === "number" ? data.lastTs : data?.ts;
+  if (typeof last === "number" && now() - last < RECOVERY_COOLDOWN_MS) return true;
+
   return false;
 }

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -2,7 +2,7 @@
 //
 // Run: cd plugins/dev/scripts/execution-core && bun test recovery-reasoning.test.mjs
 
-import { describe, test, expect, beforeEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import {
   reasoningRecoveryPass,
   defaultClassifyTicket,
@@ -10,7 +10,16 @@ import {
   checkBoundedLlmFixes,
   determineEscalationReason,
   generateRemediateBrief,
+  buildRecoveryEnvelope,
+  defaultRecordIntent,
+  defaultShouldSkipItem,
+  defaultInvokeRemediateCapped,
+  RECOVERY_MAX_ATTEMPTS,
+  RECOVERY_COOLDOWN_MS,
 } from "./recovery-reasoning.mjs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join as pathJoin } from "node:path";
+import { tmpdir } from "node:os";
 
 describe("checkDeterministicErrors", () => {
   test("detects push_rejected_no_workflow_scope", () => {
@@ -53,6 +62,26 @@ describe("checkDeterministicErrors", () => {
     const result = checkDeterministicErrors(null, "orphan-sweep-stale");
     expect(result).not.toBeNull();
     expect(result.fix_class).toBe("orphan_stale");
+  });
+
+  // CTL-1186: the push_rejected_no_workflow_scope failureReason shortcut must
+  // classify as FIX (re-dispatch via the workflow-token-redispatch seam) even
+  // when there is NO log buffer — the signal failureReason alone is enough.
+  test("detects push_rejected_no_workflow_scope via failureReason (no logs)", () => {
+    const result = checkDeterministicErrors(null, "push_rejected_no_workflow_scope");
+    expect(result).not.toBeNull();
+    expect(result.fix_class).toBe("push_rejected_no_workflow_scope");
+    expect(result.seam_id).toBe("workflow-token-redispatch");
+  });
+
+  test("push_rejected_no_workflow_scope failureReason → classifyTicket decision=fix", () => {
+    const result = defaultClassifyTicket({
+      logsOutput: null,
+      failureReason: "push_rejected_no_workflow_scope",
+    });
+    expect(result.decision).toBe("fix");
+    expect(result.fix_class).toBe("push_rejected_no_workflow_scope");
+    expect(result.details.seam_id).toBe("workflow-token-redispatch");
   });
 
   // merge-conflict / rebase-failed failureReasons fall through to bounded-LLM
@@ -406,6 +435,7 @@ describe("reasoningRecoveryPass", () => {
       mode: "enforce",
       recordIntent: (ticket, intent) => intents.push({ ticket, intent }),
       emitEvent: (event) => events.push(event),
+      postComment: () => {}, // no-op: avoid real linear-comment-post.sh shell-out
     });
 
     expect(result.processed).toBe(1);
@@ -462,6 +492,7 @@ describe("reasoningRecoveryPass", () => {
     const result = reasoningRecoveryPass(items, {
       mode: "shadow",
       emitEvent: (event) => events.push(event),
+      postComment: () => {}, // no-op: avoid real linear-comment-post.sh shell-out
     });
 
     expect(result.processed).toBe(3);
@@ -490,5 +521,467 @@ describe("reasoningRecoveryPass", () => {
     expect(comments[0]).toContain("CTL-1176 Diagnosis");
     expect(comments[0]).toContain("Decision:");
     expect(comments[0]).toContain("bounded-llm");
+  });
+});
+
+// ─── CTL-1176: per-tick fix cap (anti-storm) ────────────────────────────────
+describe("reasoningRecoveryPass maxFixesPerTick cap", () => {
+  // Build N fixable items (bounded-llm stale-main) so each would be a FIX action.
+  function fixableItems(n) {
+    return Array.from({ length: n }, (_, i) => ({
+      ticket: `CTL-${100 + i}`,
+      evidence: { logsOutput: "stale main" },
+    }));
+  }
+
+  test("caps fix-actions at maxFixesPerTick; rest are deferred (no action)", () => {
+    let remediateCalls = 0;
+    const result = reasoningRecoveryPass(fixableItems(5), {
+      mode: "enforce",
+      maxFixesPerTick: 2,
+      invokeRemediateCapped: () => {
+        remediateCalls += 1;
+        return { success: true, dispatched: true, attempts: 1, reason: "dispatched", details: {} };
+      },
+      recordIntent: () => {},
+      postComment: () => {},
+      emitEvent: () => {},
+    });
+
+    expect(result.processed).toBe(5);
+    // Only 2 actually invoked the remediate seam.
+    expect(remediateCalls).toBe(2);
+    // The remaining 3 are deferred — no action, no cooldown burn.
+    const deferred = result.results.filter((r) => r.decision === "deferred");
+    expect(deferred.length).toBe(3);
+    expect(deferred[0].reason).toContain("per-tick fix cap");
+  });
+
+  test("deferred items do NOT record intent (no cooldown burn)", () => {
+    const intents = [];
+    reasoningRecoveryPass(fixableItems(4), {
+      mode: "enforce",
+      maxFixesPerTick: 1,
+      invokeRemediateCapped: () => ({ success: true, dispatched: true, attempts: 1, details: {} }),
+      recordIntent: (ticket, intent) => intents.push({ ticket, intent }),
+      postComment: () => {},
+      emitEvent: () => {},
+    });
+    // Only the 1 acted item records an intent; the 3 deferred do not.
+    expect(intents.length).toBe(1);
+  });
+
+  test("env CATALYST_RECOVERY_MAX_FIXES_PER_TICK is honored by default", () => {
+    const prev = process.env.CATALYST_RECOVERY_MAX_FIXES_PER_TICK;
+    process.env.CATALYST_RECOVERY_MAX_FIXES_PER_TICK = "1";
+    try {
+      let calls = 0;
+      const result = reasoningRecoveryPass(fixableItems(3), {
+        mode: "enforce",
+        invokeRemediateCapped: () => {
+          calls += 1;
+          return { success: true, dispatched: true, attempts: 1, details: {} };
+        },
+        recordIntent: () => {},
+        postComment: () => {},
+        emitEvent: () => {},
+      });
+      expect(calls).toBe(1);
+      expect(result.results.filter((r) => r.decision === "deferred").length).toBe(2);
+    } finally {
+      if (prev === undefined) delete process.env.CATALYST_RECOVERY_MAX_FIXES_PER_TICK;
+      else process.env.CATALYST_RECOVERY_MAX_FIXES_PER_TICK = prev;
+    }
+  });
+});
+
+// ─── CTL-1176: cooldown skip (injected shouldSkipItem) ──────────────────────
+describe("reasoningRecoveryPass cooldown skip", () => {
+  test("a ticket in cooldown is skipped and takes NO action", () => {
+    const events = [];
+    let acted = false;
+    const result = reasoningRecoveryPass(
+      [{ ticket: "CTL-9", evidence: { logsOutput: "stale main" } }],
+      {
+        mode: "enforce",
+        shouldSkipItem: (ticket) => ticket === "CTL-9",
+        invokeRemediateCapped: () => {
+          acted = true;
+          return { success: true, dispatched: true, attempts: 1, details: {} };
+        },
+        emitEvent: (e) => events.push(e),
+        recordIntent: () => {},
+        postComment: () => {},
+      },
+    );
+    expect(result.processed).toBe(0);
+    expect(acted).toBe(false);
+    expect(events.length).toBe(0);
+  });
+});
+
+// ─── CTL-1176: DIAGNOSE evidence capture wiring ─────────────────────────────
+describe("reasoningRecoveryPass DIAGNOSE capture", () => {
+  test("captures evidence via captureEvidenceFn when logsOutput is missing", () => {
+    const captured = [];
+    reasoningRecoveryPass([{ ticket: "CTL-7", bgJobId: "abc123", evidence: {} }], {
+      mode: "shadow",
+      captureEvidenceFn: (subject, bgJobId) => {
+        captured.push({ subject, bgJobId });
+        return { logsOutput: "stale main", jobState: { detail: "idle" } };
+      },
+      postComment: () => {},
+      emitEvent: () => {},
+    });
+    expect(captured.length).toBe(1);
+    expect(captured[0].bgJobId).toBe("abc123");
+    expect(captured[0].subject).toContain("CTL-7");
+  });
+
+  test("does NOT capture when logsOutput already present", () => {
+    let called = false;
+    reasoningRecoveryPass(
+      [{ ticket: "CTL-7", bgJobId: "abc123", evidence: { logsOutput: "stale main" } }],
+      {
+        mode: "shadow",
+        captureEvidenceFn: () => {
+          called = true;
+          return {};
+        },
+        postComment: () => {},
+        emitEvent: () => {},
+      },
+    );
+    expect(called).toBe(false);
+  });
+
+  test("captured logsOutput drives classification (stale-main → bounded-llm fix)", () => {
+    const result = reasoningRecoveryPass(
+      [{ ticket: "CTL-7", bgJobId: "abc123", evidence: {} }],
+      {
+        mode: "shadow",
+        captureEvidenceFn: () => ({ logsOutput: "stale main", jobState: null }),
+        postComment: () => {},
+        emitEvent: () => {},
+      },
+    );
+    expect(result.results[0].decision).toBe("fix");
+    expect(result.results[0].fix_class).toBe("bounded-llm");
+  });
+});
+
+// ─── CTL-1220: emit shape matches the board reader contract ─────────────────
+describe("buildRecoveryEnvelope (emit↔read contract)", () => {
+  test("recovery.fixed → event.name + event.label, INFO severity", () => {
+    const env = buildRecoveryEnvelope(
+      { type: "recovery.fixed", ticket: "CTL-50", fix_class: "x", reason: "r", details: {} },
+      { now: () => "2026-06-16T00:00:00Z" },
+    );
+    expect(env.attributes["event.name"]).toBe("recovery.fixed");
+    expect(env.attributes["event.label"]).toBe("CTL-50");
+    expect(env.body.payload.ticket).toBe("CTL-50"); // reader fallback key
+    expect(env.severityText).toBe("INFO");
+    expect(env.ts).toBe("2026-06-16T00:00:00Z");
+    expect(env.attributes["recovery.fix_class"]).toBe("x");
+  });
+
+  test("recovery.would-fix → INFO; recovery.escalated → WARN", () => {
+    const wouldFix = buildRecoveryEnvelope({ type: "recovery.would-fix", ticket: "CTL-51" });
+    expect(wouldFix.severityText).toBe("INFO");
+    const escal = buildRecoveryEnvelope({ type: "recovery.escalated", ticket: "CTL-52" });
+    expect(escal.severityText).toBe("WARN");
+    expect(escal.severityNumber).toBe(13);
+  });
+
+  test("event.action strips the recovery. prefix", () => {
+    const env = buildRecoveryEnvelope({ type: "recovery.would-escalate", ticket: "CTL-53" });
+    expect(env.attributes["event.action"]).toBe("would-escalate");
+  });
+
+  test("omits recovery.fix_class when fix_class is null", () => {
+    const env = buildRecoveryEnvelope({ type: "recovery.escalated", ticket: "CTL-54" });
+    expect(env.attributes["recovery.fix_class"]).toBeUndefined();
+  });
+
+  test("carries OTel resource (service.name execution-core)", () => {
+    const env = buildRecoveryEnvelope({ type: "recovery.fixed", ticket: "CTL-55" });
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(env.resource["host.name"]).toBeDefined();
+    expect(typeof env.id).toBe("string");
+  });
+});
+
+// ─── CTL-1176: host-local cooldown + intent ledger ──────────────────────────
+describe("recovery-intent ledger (cooldown + max-attempts + escalated)", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(pathJoin(tmpdir(), "rec-intent-"));
+  });
+  afterEach(() => {
+    try {
+      rmSync(orchDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  test("record then shouldSkip within cooldown window → skip", () => {
+    const now = 1_000_000_000_000;
+    defaultRecordIntent("CTL-300", { decision: "fix", fix_class: "bounded-llm" }, {
+      orchDir,
+      now: () => now,
+    });
+    // 1 minute later — well inside the 30-min default window.
+    expect(defaultShouldSkipItem("CTL-300", { orchDir, now: () => now + 60_000 })).toBe(true);
+  });
+
+  test("after cooldown window elapses → no skip (attempts still under cap)", () => {
+    const now = 1_000_000_000_000;
+    defaultRecordIntent("CTL-301", { decision: "fix", fix_class: "x" }, {
+      orchDir,
+      now: () => now,
+    });
+    const after = now + RECOVERY_COOLDOWN_MS + 1;
+    expect(defaultShouldSkipItem("CTL-301", { orchDir, now: () => after })).toBe(false);
+  });
+
+  test("attempts >= max_attempts → skip (terminal, stops self-healing)", () => {
+    const now = 1_000_000_000_000;
+    // Record max_attempts passes (each call accrues +1).
+    for (let i = 0; i < RECOVERY_MAX_ATTEMPTS; i++) {
+      defaultRecordIntent("CTL-302", { decision: "fix", fix_class: "x" }, {
+        orchDir,
+        now: () => now + i,
+      });
+    }
+    // Far past the cooldown window — attempts cap is what skips it now.
+    const after = now + RECOVERY_COOLDOWN_MS * 10;
+    expect(defaultShouldSkipItem("CTL-302", { orchDir, now: () => after })).toBe(true);
+  });
+
+  test("escalate decision latches escalated → skip forever", () => {
+    const now = 1_000_000_000_000;
+    defaultRecordIntent("CTL-303", { decision: "escalate" }, { orchDir, now: () => now });
+    const after = now + RECOVERY_COOLDOWN_MS * 100;
+    expect(defaultShouldSkipItem("CTL-303", { orchDir, now: () => after })).toBe(true);
+  });
+
+  test("escalated latch survives a later fix-pass write", () => {
+    const now = 1_000_000_000_000;
+    defaultRecordIntent("CTL-304", { decision: "escalate" }, { orchDir, now: () => now });
+    // A subsequent fix-pass must NOT un-latch escalated.
+    const entry = defaultRecordIntent("CTL-304", { decision: "fix", fix_class: "x" }, {
+      orchDir,
+      now: () => now + 1,
+    });
+    expect(entry.escalated).toBe(true);
+  });
+
+  test("first-action ts preserved across writes; attempts accrue", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-305", { decision: "fix", fix_class: "x" }, {
+      orchDir,
+      now: () => t0,
+    });
+    const second = defaultRecordIntent("CTL-305", { decision: "fix", fix_class: "x" }, {
+      orchDir,
+      now: () => t0 + 5000,
+    });
+    expect(second.ts).toBe(t0); // first-action timestamp preserved
+    expect(second.lastTs).toBe(t0 + 5000); // most-recent action
+    expect(second.attempts).toBe(2);
+  });
+
+  test("fail-open: no ledger → shouldSkip returns false", () => {
+    expect(defaultShouldSkipItem("CTL-999", { orchDir, now: () => Date.now() })).toBe(false);
+  });
+
+  test("no orchDir → record no-ops, shouldSkip fail-open false", () => {
+    // resolveOrchDir() returns null when CATALYST_ORCHESTRATOR_DIR is unset and
+    // none is injected. Force that by passing orchDir: null explicitly.
+    expect(defaultRecordIntent("CTL-998", { decision: "fix" }, { orchDir: null })).toBeNull();
+    expect(defaultShouldSkipItem("CTL-998", { orchDir: null })).toBe(false);
+  });
+});
+
+// ─── CTL-1176: capped remediate dispatch (cap enforcement) ──────────────────
+describe("defaultInvokeRemediateCapped cap enforcement", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(pathJoin(tmpdir(), "rec-rem-"));
+  });
+  afterEach(() => {
+    try {
+      rmSync(orchDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  test("refuses dispatch when remediate cycle count is already at cap", () => {
+    const result = defaultInvokeRemediateCapped(
+      "CTL-400",
+      { brief: "fix it", reason: "ci-failure" },
+      {
+        orchDir,
+        // Inject module stubs so no real dispatch graph is loaded.
+        eventScanMod: { countRemediateCycles: () => 3 },
+        fsmMod: { REMEDIATE_PHASE: "remediate", REMEDIATE_CYCLE_CAP: 3 },
+        dispatchMod: { dispatchTicket: () => ({ code: 0 }) },
+      },
+    );
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe("remediate-cycle-cap-exhausted");
+    expect(result.dispatched).toBe(false);
+  });
+
+  test("dispatches ONE remediate and returns dispatched:true, attempts:1", () => {
+    let dispatchCalls = 0;
+    const result = defaultInvokeRemediateCapped(
+      "CTL-401",
+      { brief: "fix it", reason: "ci-failure" },
+      {
+        orchDir,
+        eventScanMod: { countRemediateCycles: () => 0 },
+        fsmMod: { REMEDIATE_PHASE: "remediate", REMEDIATE_CYCLE_CAP: 3 },
+        dispatchMod: {
+          dispatchTicket: (od, ticket, phase) => {
+            dispatchCalls += 1;
+            return { code: 0, worktreePath: "/tmp/wt", signal: { bg_job_id: "bg1" } };
+          },
+        },
+      },
+    );
+    expect(dispatchCalls).toBe(1);
+    expect(result.success).toBe(true);
+    expect(result.dispatched).toBe(true);
+    expect(result.attempts).toBe(1);
+    expect(result.details.bg_job_id).toBe("bg1");
+  });
+
+  test("dispatch failure (non-zero code) → success:false, dispatched:false", () => {
+    const result = defaultInvokeRemediateCapped(
+      "CTL-402",
+      { brief: "fix it", reason: "ci-failure" },
+      {
+        orchDir,
+        eventScanMod: { countRemediateCycles: () => 0 },
+        fsmMod: { REMEDIATE_PHASE: "remediate", REMEDIATE_CYCLE_CAP: 3 },
+        dispatchMod: { dispatchTicket: () => ({ code: 1, stderr: "boom" }) },
+      },
+    );
+    expect(result.success).toBe(false);
+    expect(result.dispatched).toBe(false);
+    expect(result.reason).toContain("boom");
+  });
+
+  test("no orchDir → returns success:false without dispatching", () => {
+    const result = defaultInvokeRemediateCapped("CTL-403", { brief: "x" }, { orchDir: null });
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe("no orchDir");
+  });
+});
+
+// ─── CTL-1176: storm-guard wiring (shadow burns the cooldown ledger) ─────────
+//
+// The production bug: shadow mode posted a diagnosis comment + emitted a .would-*
+// event for every qualifying item, but NEVER recorded an intent — so the cooldown
+// marker was never written and the SAME items re-spammed every ~14s tick forever.
+// Combined with the daemon never setting CATALYST_ORCHESTRATOR_DIR (so the bare
+// default ledger resolved orchDir=null and skipped nothing), shadow was an
+// unconditional 19-comments-per-tick spammer. These tests pin the fix: shadow now
+// writes a real cooldown intent through the SAME default ledger the scheduler
+// binds to the tick's orchDir, so a second tick within the cooldown window skips.
+describe("reasoningRecoveryPass shadow cooldown wiring (CTL-1176)", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(pathJoin(tmpdir(), "rec-shadow-"));
+  });
+  afterEach(() => {
+    try {
+      rmSync(orchDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  test("shadow mode records a cooldown intent for each acted item", () => {
+    const intents = [];
+    const result = reasoningRecoveryPass(
+      [
+        {
+          ticket: "CTL-1",
+          evidence: { logsOutput: "stale main" },
+        },
+      ],
+      {
+        mode: "shadow",
+        recordIntent: (ticket, intent) => intents.push({ ticket, intent }),
+        postComment: () => {}, // no real shell-out
+        emitEvent: () => {},
+      },
+    );
+    expect(result.processed).toBe(1);
+    // The headline fix: shadow now writes a cooldown marker.
+    expect(intents.length).toBe(1);
+    expect(intents[0].ticket).toBe("CTL-1");
+    expect(intents[0].intent.type).toBe("recovery-pass");
+    expect(intents[0].intent.decision).toBe("shadow"); // fix-class item → "shadow"
+  });
+
+  test("shadow escalation records a terminal (escalated) intent", () => {
+    const intents = [];
+    reasoningRecoveryPass(
+      [
+        {
+          ticket: "CTL-2",
+          evidence: { logsOutput: "unknown error", beliefState: { escalate_human: true } },
+        },
+      ],
+      {
+        mode: "shadow",
+        recordIntent: (ticket, intent) => intents.push({ ticket, intent }),
+        postComment: () => {},
+        emitEvent: () => {},
+      },
+    );
+    expect(intents.length).toBe(1);
+    expect(intents[0].intent.decision).toBe("escalate");
+    expect(intents[0].intent.escalated).toBe(true);
+  });
+
+  test("two consecutive shadow ticks: 2nd skips via the real default ledger (orchDir bound)", () => {
+    // This is the production scenario: the scheduler BINDS the default ledger to
+    // the tick's orchDir. Tick 1 acts + records; tick 2 within the cooldown window
+    // must skip — proving the storm guard is real, not inert.
+    const t0 = Date.now();
+    const items = [{ ticket: "CTL-3", evidence: { logsOutput: "stale main" } }];
+
+    const comments1 = [];
+    const r1 = reasoningRecoveryPass(items, {
+      mode: "shadow",
+      // Bind exactly like scheduler.mjs does — orchDir threaded into the defaults.
+      shouldSkipItem: (ticket) => defaultShouldSkipItem(ticket, { orchDir, now: () => t0 }),
+      recordIntent: (ticket, intent) =>
+        defaultRecordIntent(ticket, intent, { orchDir, now: () => t0 }),
+      postComment: (ticket, c) => comments1.push(c),
+      emitEvent: () => {},
+    });
+    expect(r1.processed).toBe(1);
+    expect(comments1.length).toBe(1); // tick 1 posts a diagnosis
+
+    // Tick 2: 1 second later, well inside the 30-min cooldown window.
+    const t1 = t0 + 1000;
+    const comments2 = [];
+    const r2 = reasoningRecoveryPass(items, {
+      mode: "shadow",
+      shouldSkipItem: (ticket) => defaultShouldSkipItem(ticket, { orchDir, now: () => t1 }),
+      recordIntent: (ticket, intent) =>
+        defaultRecordIntent(ticket, intent, { orchDir, now: () => t1 }),
+      postComment: (ticket, c) => comments2.push(c),
+      emitEvent: () => {},
+    });
+    expect(r2.processed).toBe(0); // skipped via cooldown — NO re-spam
+    expect(comments2.length).toBe(0); // zero new comments on the 2nd tick
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -186,7 +186,23 @@ import {
 } from "./unstuck-sweep.mjs";
 // CTL-1176: Pass 0r — LLM reasoning recovery pass. Ships off by default (ADR-023);
 // operators opt in via CATALYST_RECOVERY_PASS=shadow then =enforce.
-import { reasoningRecoveryPass } from "./recovery-reasoning.mjs";
+//
+// The host-local cooldown / intent ledger and the act-seams resolve their
+// orchDir from process.env.CATALYST_ORCHESTRATOR_DIR — which the daemon NEVER
+// sets on its own process (that env var is exported only onto CHILD phase-agent
+// processes by dispatch.mjs / phase-agent-dispatch). So the bare defaults would
+// resolve orchDir=null in the daemon, making the cooldown / max-attempts /
+// escalated-latch all inert and turning shadow into an unconditional spammer.
+// We import the defaults explicitly and BIND them to the tick's real orchDir at
+// the call site (the scheduler already has orchDir in scope) so the storm guard
+// is real in production, not just in unit tests that inject orchDir by hand.
+import {
+  reasoningRecoveryPass,
+  defaultShouldSkipItem as recoveryShouldSkipItem,
+  defaultRecordIntent as recoveryRecordIntent,
+  defaultInvokeSeam as recoveryInvokeSeam,
+  defaultInvokeRemediateCapped as recoveryInvokeRemediateCapped,
+} from "./recovery-reasoning.mjs";
 // CTL-1219: the per-category enforcement seam registry (dirty-tree /
 // source-conflict / orphan-stale / stale-label). Pure-cored + injectable; bound
 // to production deps at the unstuckSweep wiring point below. Wiring this does NOT
@@ -3353,10 +3369,29 @@ export function schedulerTick(
           .map((sig) => ({
             ticket: sig.ticket,
             phase: sig.phase,
+            // CTL-1176: thread the worker's bg_job_id so the recovery pass's
+            // DIAGNOSE step can capture `claude logs` evidence read-only when the
+            // signal didn't already carry logsOutput.
+            bgJobId: sig.raw?.bg_job_id ?? null,
             evidence: sig.raw ?? {},
           }));
         if (rItems.length > 0) {
-          const rResult = reasoningRecoveryPass(rItems, { mode: rMode });
+          // CTL-1176: BIND the host-local ledger + act-seams to THIS tick's real
+          // orchDir. Without this the defaults call resolveOrchDir() →
+          // process.env.CATALYST_ORCHESTRATOR_DIR, which the daemon never sets on
+          // its own process → orchDir=null → cooldown/max-attempts/escalated-latch
+          // all inert and shadow re-posts every item every tick. orchDir is the
+          // tick's first arg (schedulerTick(orchDir, …)), so it's already in scope.
+          const rResult = reasoningRecoveryPass(rItems, {
+            mode: rMode,
+            shouldSkipItem: (ticket) => recoveryShouldSkipItem(ticket, { orchDir }),
+            recordIntent: (ticket, intent) =>
+              recoveryRecordIntent(ticket, intent, { orchDir }),
+            invokeSeam: (ticket, seamId, brief) =>
+              recoveryInvokeSeam(ticket, seamId, brief, { orchDir }),
+            invokeRemediateCapped: (ticket, briefObj) =>
+              recoveryInvokeRemediateCapped(ticket, briefObj, { orchDir }),
+          });
           if (rResult.processed > 0) {
             log.info(
               {

--- a/plugins/dev/scripts/orch-monitor/lib/board-data-recovery.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data-recovery.test.mjs
@@ -1,0 +1,132 @@
+// board-data-recovery.test.mjs — CTL-1220: loadRecoveryOutcomes parses the
+// unified event log's recovery.* events into per-ticket {autoFixed,triaged,
+// recoveredAt} flags. This is the read half of the emit↔read contract whose
+// emit side lives in execution-core/recovery-reasoning.mjs:defaultEmitEvent.
+//
+//   cd plugins/dev/scripts/orch-monitor && bun test lib/board-data-recovery.test.mjs
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadRecoveryOutcomes } from "./board-data.mjs";
+import { buildRecoveryEnvelope } from "../../execution-core/recovery-reasoning.mjs";
+
+const dirs = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+});
+
+function writeLog(lines) {
+  const dir = mkdtempSync(join(tmpdir(), "rec-out-"));
+  dirs.push(dir);
+  const p = join(dir, "2026-06.jsonl");
+  writeFileSync(
+    p,
+    lines.map((l) => (typeof l === "string" ? l : JSON.stringify(l))).join("\n") + "\n",
+  );
+  return p;
+}
+
+describe("CTL-1220: loadRecoveryOutcomes", () => {
+  it("maps recovery.fixed → autoFixed:true + recoveredAt:ts", () => {
+    const p = writeLog([
+      buildRecoveryEnvelope(
+        { type: "recovery.fixed", ticket: "CTL-100", fix_class: "x", reason: "r", details: {} },
+        { now: () => "2026-06-16T01:00:00Z" },
+      ),
+    ]);
+    const map = loadRecoveryOutcomes(p);
+    expect(map.get("CTL-100")).toEqual({
+      autoFixed: true,
+      triaged: false,
+      recoveredAt: "2026-06-16T01:00:00Z",
+    });
+  });
+
+  it("maps recovery.would-fix → triaged:true (shadow)", () => {
+    const p = writeLog([
+      buildRecoveryEnvelope({ type: "recovery.would-fix", ticket: "CTL-200" }),
+    ]);
+    const map = loadRecoveryOutcomes(p);
+    expect(map.get("CTL-200").triaged).toBe(true);
+    expect(map.get("CTL-200").autoFixed).toBe(false);
+  });
+
+  it("ignores recovery.escalated and recovery.would-escalate", () => {
+    const p = writeLog([
+      buildRecoveryEnvelope({ type: "recovery.escalated", ticket: "CTL-300", reason: "r" }),
+      buildRecoveryEnvelope({ type: "recovery.would-escalate", ticket: "CTL-301", reason: "r" }),
+    ]);
+    const map = loadRecoveryOutcomes(p);
+    expect(map.get("CTL-300")).toBeUndefined();
+    expect(map.get("CTL-301")).toBeUndefined();
+    expect(map.size).toBe(0);
+  });
+
+  it("keys on attributes['event.label'] (the CTL id)", () => {
+    const p = writeLog([
+      buildRecoveryEnvelope({ type: "recovery.fixed", ticket: "CTL-400" }),
+    ]);
+    const map = loadRecoveryOutcomes(p);
+    expect(map.has("CTL-400")).toBe(true);
+  });
+
+  it("falls back to body.payload.ticket when event.label is absent", () => {
+    // Hand-craft an envelope missing the event.label attribute.
+    const env = buildRecoveryEnvelope({ type: "recovery.fixed", ticket: "CTL-500" });
+    delete env.attributes["event.label"];
+    const p = writeLog([env]);
+    const map = loadRecoveryOutcomes(p);
+    expect(map.has("CTL-500")).toBe(true);
+  });
+
+  it("fails open (empty Map) on ENOENT", () => {
+    const map = loadRecoveryOutcomes(join(tmpdir(), "definitely-not-a-file-xyz.jsonl"));
+    expect(map.size).toBe(0);
+  });
+
+  it("skips torn / malformed lines without throwing", () => {
+    const p = writeLog([
+      "{ not valid json",
+      buildRecoveryEnvelope({ type: "recovery.fixed", ticket: "CTL-600" }),
+      "",
+      "another torn line }",
+    ]);
+    const map = loadRecoveryOutcomes(p);
+    expect(map.get("CTL-600").autoFixed).toBe(true);
+    expect(map.size).toBe(1);
+  });
+
+  it("last-write-wins: would-fix then fixed → both flags accrue per ticket", () => {
+    const p = writeLog([
+      buildRecoveryEnvelope({ type: "recovery.would-fix", ticket: "CTL-700" }),
+      buildRecoveryEnvelope(
+        { type: "recovery.fixed", ticket: "CTL-700" },
+        { now: () => "2026-06-16T02:00:00Z" },
+      ),
+    ]);
+    const map = loadRecoveryOutcomes(p);
+    expect(map.get("CTL-700")).toEqual({
+      autoFixed: true,
+      triaged: true,
+      recoveredAt: "2026-06-16T02:00:00Z",
+    });
+  });
+
+  it("ignores unrelated event names", () => {
+    const p = writeLog([
+      { attributes: { "event.name": "account.ratelimit.sampled", "event.label": "CTL-800" } },
+      buildRecoveryEnvelope({ type: "recovery.fixed", ticket: "CTL-801" }),
+    ]);
+    const map = loadRecoveryOutcomes(p);
+    expect(map.has("CTL-800")).toBe(false);
+    expect(map.has("CTL-801")).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -41,6 +41,10 @@ import { buildBlockerMapFromRelations, mergeBlockers } from "./relation-blockers
 // execution-core/scheduler-rank.mjs compareTickets, parity-tested). The queue's
 // global rank is exactly the order the scheduler dispatches in.
 import { compareDispatchOrder } from "./dispatch-rank.mjs";
+// CTL-1220: the UTC YYYY-MM event-log resolver — the SAME path the recovery
+// sweep's defaultEmitEvent writes to (execution-core/config.mjs:133). Read here
+// so recovery.fixed / recovery.would-fix outcomes fold into the board.
+import { getEventLogPath } from "../../execution-core/config.mjs";
 
 const execFileP = promisify(execFile);
 
@@ -1106,6 +1110,51 @@ function readOrphanPrState() {
   } catch { return {}; } // torn file: fail-open, zero orphan rows
 }
 
+// loadRecoveryOutcomes — CTL-1220: scan the unified event log for the recovery
+// sweep's outcome events and fold them into per-ticket flags. This is the half
+// CTL-1220 left hollow: the emit side (recovery-reasoning.mjs:defaultEmitEvent)
+// lands recovery.fixed / recovery.would-fix into ~/catalyst/events/YYYY-MM.jsonl;
+// this reader matches them by attributes["event.name"], keys on the CTL id at
+// attributes["event.label"] (mirrored in body.payload.ticket), and builds
+// Map<ticketKey, {autoFixed, triaged, recoveredAt}>.
+//
+//   recovery.fixed     (enforce success)        → autoFixed:true, recoveredAt:ts
+//   recovery.would-fix (shadow identified-fixable) → triaged:true
+//   recovery.escalated / would-escalate         → ignored (surface via attention)
+//
+// Fail-OPEN: {} on ENOENT (no events yet), skip torn lines, never throws —
+// mirrors readOrphanPrState above + the envelope read in event-log-reader.ts.
+export function loadRecoveryOutcomes(eventLogPath = getEventLogPath()) {
+  let text;
+  try {
+    text = readFileSync(eventLogPath, "utf8");
+  } catch {
+    return new Map(); // ENOENT: no events yet
+  }
+  const out = new Map();
+  for (const line of text.split("\n")) {
+    if (!line) continue;
+    let evt;
+    try {
+      evt = JSON.parse(line);
+    } catch {
+      continue; // torn line: skip, fail-open
+    }
+    const name = evt?.attributes?.["event.name"];
+    if (name !== "recovery.fixed" && name !== "recovery.would-fix") continue;
+    const key = evt?.attributes?.["event.label"] ?? evt?.body?.payload?.ticket;
+    if (!key) continue;
+    const prev = out.get(key) ?? { autoFixed: false, triaged: false, recoveredAt: null };
+    if (name === "recovery.fixed") {
+      prev.autoFixed = true;
+      prev.recoveredAt = evt.ts ?? prev.recoveredAt;
+    }
+    if (name === "recovery.would-fix") prev.triaged = true;
+    out.set(key, prev); // last-write-wins per ticket
+  }
+  return out;
+}
+
 // synthesizeOrphanTickets — pure helper: one BoardTicket-shaped card per
 // notified orphan, reusing CTL-1158 attention derivation path. Exported so
 // unit tests can exercise it without the filesystem reads of assembleBoard.
@@ -1371,6 +1420,11 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
   // Tickets without a triage.json (queued / relation-only) get their blockers[]
   // from here so the dep graph can draw their edges.
   const relationBlockerMap = buildBlockerMapFromRelations(linfo);
+
+  // CTL-1220: per-ticket recovery-sweep outcomes, read once from the unified
+  // event log. Map<ticketKey, {autoFixed, triaged, recoveredAt}>. Synchronous +
+  // fail-open (empty Map on any error) so it never blocks board assembly.
+  const recoveryByTicket = loadRecoveryOutcomes();
 
   // workers (live background agents that map to a ticket:phase)
   const now = Date.now();
@@ -1684,6 +1738,11 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
         // yellow board accent + the Inbox "Needs you" section. needs-human wins.
         attention: attn.attention,
         attentionSince: attn.attentionSince,
+        // CTL-1220: recovery-sweep outcome flags, read from the unified event
+        // log. id is the CTL key — exactly what attributes["event.label"] carries.
+        autoFixed: recoveryByTicket.get(id)?.autoFixed ?? false,
+        triaged: recoveryByTicket.get(id)?.triaged ?? false,
+        recoveredAt: recoveryByTicket.get(id)?.recoveredAt ?? null,
         costUSD: costs[id]?.costUSD ?? null,
         tokens: costs[id]?.tokens ?? null,
         turns: phaseCostsByTicket[id]

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/home-inbox.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/home-inbox.ts
@@ -340,8 +340,12 @@ export function deriveInbox(payload: BoardPayload): InboxModel {
     blocked: buckets.blocked.length,
     waiting: buckets.waiting.length,
     running: buckets.running.length,
-    autoFixed: 0, // CTL-1220: to be populated by the monitor
-    triaged: 0, // CTL-1220: to be populated by the monitor
+    // CTL-1220: recovery-sweep counts, folded over every ticket (the safe
+    // denominator for the "Done while you were away" reassurance copy — these
+    // are independent of section bucketing). Fields populated by board-data.mjs
+    // from the unified event log (loadRecoveryOutcomes).
+    autoFixed: payload.tickets.filter((t) => t.autoFixed).length, // was 0
+    triaged: payload.tickets.filter((t) => t.triaged).length, // was 0
     awareness: buckets.awareness.length,
     done: buckets.done.length,
     // CTL-729: the single "N need you" figure absorbs the attention bucket.


### PR DESCRIPTION
Turns the recovery pass from a classify-only no-op into a real actor: real `defaultEmitEvent`/`postComment`/`invokeSeam`/`invokeRemediateCapped`/`recordIntent`/`shouldSkipItem`, DIAGNOSE via `diagnostician.captureEvidence`, the `push_rejected_no_workflow_scope` shortcut (CTL-1186), the `maxFixesPerTick` storm cap, a host-local cooldown ledger, AND the `loadRecoveryOutcomes` inbox reader CTL-1220 left hollow. Ships behind `CATALYST_RECOVERY_PASS` (default off; mini=shadow).

## Adversarial review fixes (storm/spam guard now real)

**CRITICAL — cooldown ledger was inert in production.** The host-local cooldown / intent ledger and the act-seams resolve `orchDir` from `process.env.CATALYST_ORCHESTRATOR_DIR`, which the daemon **never sets on its own process** — that env var is exported only onto **child** phase-agent processes by `dispatch.mjs` / `phase-agent-dispatch`. So the bare defaults resolved `orchDir=null` in the daemon → `defaultRecordIntent` wrote nothing, `defaultShouldSkipItem` failed open (never skipped), and the cooldown / max-attempts / escalated-latch were all inert. Shadow mode would then re-post a diagnosis comment + re-emit a `.would-*` event for **every** qualifying item on **every** ~14s tick, forever.

Fix: the scheduler now **binds** `defaultShouldSkipItem` / `defaultRecordIntent` / `defaultInvokeSeam` / `defaultInvokeRemediateCapped` to the tick's real `orchDir` at the Pass-0r call site (`orchDir` is `schedulerTick`'s first arg, already in scope). The guard is now real in production, not just in unit tests that injected `orchDir` by hand.

**Shadow re-spam.** Shadow mode previously only posted + emitted, never recording an intent, so even with `orchDir` fixed it would re-spam every tick. Shadow now writes a cooldown intent marker (and latches `escalated` for a would-escalate, mirroring enforce), making it a rate-limited dry-run.

Other review findings were verified false alarms / confirmations: the emit↔inbox contract matches end-to-end (single writer `defaultEmitEvent` → single reader `loadRecoveryOutcomes`, both through `buildRecoveryEnvelope`), CTL-1186 classifies as FIX before the `logsOutput` guard, and DIAGNOSE `captureEvidence` is read-only and triple-guarded against a missing `bgJobId`.

## Tests
- `recovery-reasoning.test.mjs` 77/77 (added shadow-cooldown wiring + 2-tick skip proving the storm guard is real)
- `scheduler.test.mjs` 496/496
- `board-data-recovery.test.mjs` 9/9 (emit↔read contract via the real envelope+reader)
- `diagnostician.test.mjs` 11/11

Cross-host claim (a durable lease on the ticket itself) remains a noted follow-up for the dormant multi-host layer — the ledger is host-local by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)