### PR TITLE
CTL-1234: Selecting a project icon should update the left nav immediately, not only after a reload

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/projects-store.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/projects-store.test.ts
@@ -1,0 +1,105 @@
+// projects-store.test.ts — CTL-1234: shared project roster store unit tests.
+// Run: cd plugins/dev/scripts/orch-monitor/ui && bun test src/hooks/projects-store.test.ts
+// Mirrors nav-store.test.ts discipline: inject store + fetchImpl to stay free of module-global state.
+import { describe, it, expect } from "bun:test";
+import { createStore } from "jotai";
+import { projectsStateAtom, loadProjects } from "./projects-store";
+import type { ProjectDescriptor } from "./projects-store";
+
+function makeProject(repo: string, icon?: string): ProjectDescriptor {
+  return {
+    key: repo.toUpperCase(),
+    name: repo,
+    repo,
+    vcsRepo: null,
+    defaultColor: null,
+    iconUrl: `/api/repo-icon/${repo}`,
+    repoRoot: null,
+    hasWork: false,
+    icon: icon ?? null,
+  };
+}
+
+function stubFetch(projects: ProjectDescriptor[]) {
+  return () =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ projects }),
+    } as Response);
+}
+
+describe("projectsStateAtom", () => {
+  it("starts with empty roster and loaded=false", () => {
+    const store = createStore();
+    expect(store.get(projectsStateAtom)).toEqual({ projects: [], loaded: false });
+  });
+});
+
+describe("loadProjects", () => {
+  it("writes fetched projects to the atom and sets loaded=true", async () => {
+    const store = createStore();
+    const roster = [makeProject("catalyst", "phosphor:star")];
+    await loadProjects(store, stubFetch(roster));
+    const state = store.get(projectsStateAtom);
+    expect(state.loaded).toBe(true);
+    expect(state.projects).toHaveLength(1);
+    expect(state.projects[0].repo).toBe("catalyst");
+    expect(state.projects[0].icon).toBe("phosphor:star");
+  });
+
+  it("CTL-1234 regression: one refetch updates ALL readers of the shared atom", async () => {
+    const store = createStore();
+
+    // Initial load
+    await loadProjects(store, stubFetch([makeProject("catalyst", "phosphor:circle")]));
+
+    // Both "consumers" read from the same store — sidebar consumer
+    const sidebarRead1 = store.get(projectsStateAtom).projects[0].icon;
+    // settings consumer
+    const settingsRead1 = store.get(projectsStateAtom).projects[0].icon;
+    expect(sidebarRead1).toBe("phosphor:circle");
+    expect(settingsRead1).toBe("phosphor:circle");
+
+    // Simulate save → refetch with new icon
+    await loadProjects(store, stubFetch([makeProject("catalyst", "phosphor:star")]));
+
+    // Both readers now see the updated icon without reload
+    const sidebarRead2 = store.get(projectsStateAtom).projects[0].icon;
+    const settingsRead2 = store.get(projectsStateAtom).projects[0].icon;
+    expect(sidebarRead2).toBe("phosphor:star");
+    expect(settingsRead2).toBe("phosphor:star");
+  });
+
+  it("fail-open: fetch rejects → loaded=true, prior roster preserved", async () => {
+    const store = createStore();
+    const roster = [makeProject("catalyst")];
+    await loadProjects(store, stubFetch(roster));
+    expect(store.get(projectsStateAtom).projects).toHaveLength(1);
+
+    // Now simulate a network error
+    const failFetch = () => Promise.reject(new Error("network error"));
+    await loadProjects(store, failFetch as typeof fetch);
+
+    const state = store.get(projectsStateAtom);
+    expect(state.loaded).toBe(true);
+    expect(state.projects).toHaveLength(1); // prior roster preserved
+  });
+
+  it("fail-open: non-array payload → loaded=true, prior roster preserved", async () => {
+    const store = createStore();
+    const roster = [makeProject("catalyst")];
+    await loadProjects(store, stubFetch(roster));
+
+    // Server returns unexpected shape
+    const badFetch = () =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ error: "not found" }),
+      } as Response);
+    await loadProjects(store, badFetch as typeof fetch);
+
+    const state = store.get(projectsStateAtom);
+    expect(state.loaded).toBe(true);
+    expect(state.projects).toHaveLength(1); // prior roster preserved
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/projects-store.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/projects-store.test.ts
@@ -21,11 +21,13 @@ function makeProject(repo: string, icon?: string): ProjectDescriptor {
 }
 
 function stubFetch(projects: ProjectDescriptor[]) {
-  return () =>
+  // A bare stub lacks fetch's `preconnect` member, so cast through unknown once —
+  // matching the sanctioned idiom in src/lib/put-project.test.ts.
+  return (() =>
     Promise.resolve({
       ok: true,
       json: () => Promise.resolve({ projects }),
-    } as Response);
+    } as Response)) as unknown as typeof fetch;
 }
 
 describe("projectsStateAtom", () => {
@@ -78,7 +80,7 @@ describe("loadProjects", () => {
 
     // Now simulate a network error
     const failFetch = () => Promise.reject(new Error("network error"));
-    await loadProjects(store, failFetch as typeof fetch);
+    await loadProjects(store, failFetch as unknown as typeof fetch);
 
     const state = store.get(projectsStateAtom);
     expect(state.loaded).toBe(true);
@@ -96,7 +98,7 @@ describe("loadProjects", () => {
         ok: true,
         json: () => Promise.resolve({ error: "not found" }),
       } as Response);
-    await loadProjects(store, badFetch as typeof fetch);
+    await loadProjects(store, badFetch as unknown as typeof fetch);
 
     const state = store.get(projectsStateAtom);
     expect(state.loaded).toBe(true);

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/projects-store.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/projects-store.ts
@@ -1,0 +1,89 @@
+// projects-store.ts — CTL-1234: shared jotai atom for the project roster.
+// Backs useProjects() so all consumers share one fetch and one refetch.
+import { atom, getDefaultStore } from "jotai";
+
+/**
+ * One project roster entry — the exact shape GET /api/projects returns (the server's
+ * ProjectDescriptor, exported from lib/project-roster.ts). The nav reads repo / name /
+ * defaultColor / iconUrl / hasWork; key / vcsRepo / repoRoot ride along for future use
+ * (detail pages, settings). CTL-1153 (M2) adds raw-override fields for the editor.
+ */
+export interface ProjectDescriptor {
+  /** Linear team key, UPPERCASE (or repo short-name uppercased for an unconfigured lane). */
+  key: string;
+  /** EFFECTIVE display name: overlay.name ?? displayCaseName(repo). */
+  name: string;
+  /** Short repo name, LOWERCASED — the value BoardPayload.repos carries / nav keys on. */
+  repo: string;
+  /** Full owner/repo from teams[].vcsRepo; null for an unconfigured lane. */
+  vcsRepo: string | null;
+  /** EFFECTIVE hue NAME resolved server-side; null when none. */
+  defaultColor: string | null;
+  /** The per-repo favicon endpoint "/api/repo-icon/<repo>". */
+  iconUrl: string;
+  /** Optional registry.json repoRoot enrichment; null when absent. */
+  repoRoot: string | null;
+  /** True when this repo has observed work; false for a configured-but-idle team. */
+  hasWork: boolean;
+  // CTL-1153 (M2): raw-override fields — absent on M1 servers, undefined-safe.
+  /** Raw stored name override; null/undefined ⇒ no override. */
+  storedName?: string | null;
+  /** Raw stored color override; null/undefined ⇒ no override. */
+  storedColor?: string | null;
+  /** Chosen icon candidate path; null/undefined ⇒ favicon auto-detect. */
+  icon?: string | null;
+  /** Per-project Linear stateMap partial override; null/undefined ⇒ inherit global. */
+  stateMap?: Record<string, string> | null;
+  /** Provenance: "overlay" | "config" | "unconfigured". */
+  source?: string;
+}
+
+export interface ProjectsState {
+  projects: ProjectDescriptor[];
+  loaded: boolean;
+}
+
+export const projectsStateAtom = atom<ProjectsState>({ projects: [], loaded: false });
+
+/**
+ * Fetch /api/projects and write the result into projectsStateAtom on `store`.
+ * Fail-open: on any error or non-array payload, marks loaded=true and preserves
+ * the prior roster rather than wiping it. Both params are injectable for unit tests.
+ */
+export function loadProjects(
+  store = getDefaultStore(),
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  return fetchImpl("/api/projects")
+    .then((r) => r.json())
+    .then((data: { projects?: unknown }) => {
+      const prior = store.get(projectsStateAtom);
+      if (Array.isArray(data.projects)) {
+        store.set(projectsStateAtom, { projects: data.projects as ProjectDescriptor[], loaded: true });
+      } else {
+        store.set(projectsStateAtom, { projects: prior.projects, loaded: true });
+      }
+    })
+    .catch(() => {
+      const prior = store.get(projectsStateAtom);
+      store.set(projectsStateAtom, { projects: prior.projects, loaded: true });
+    });
+}
+
+// Module-level one-shot guard: the first mount triggers one fetch; subsequent
+// mounts in the same module lifetime see it already in flight or done.
+let _initialLoadPromise: Promise<void> | null = null;
+
+/**
+ * Trigger the initial load exactly once across all consumers in a module lifetime.
+ * Tests that need isolation should call loadProjects(store, fetchImpl) directly.
+ */
+export function ensureProjectsLoaded(
+  store = getDefaultStore(),
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  if (!_initialLoadPromise) {
+    _initialLoadPromise = loadProjects(store, fetchImpl);
+  }
+  return _initialLoadPromise;
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-projects.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-projects.test.tsx
@@ -1,0 +1,76 @@
+// use-projects.test.tsx — CTL-1234: source-text wiring assertions for use-projects.ts
+// and cross-consumer regression guard (Phase 2).
+// Pattern: Bun.file(...).text() + regex, matching app-sidebar.test.tsx discipline.
+// Run: cd plugins/dev/scripts/orch-monitor/ui && bun test src/hooks/use-projects.test.tsx
+import { describe, it, expect } from "bun:test";
+import * as path from "node:path";
+
+const SRC_PATH = new URL("./use-projects.ts", import.meta.url).pathname;
+const UI_SRC = path.resolve(new URL("../", import.meta.url).pathname);
+
+async function readSrc(rel: string) {
+  return Bun.file(path.join(UI_SRC, rel)).text();
+}
+
+describe("use-projects wiring (CTL-1234)", () => {
+  it("does NOT contain per-instance useState for the roster", async () => {
+    const src = await Bun.file(SRC_PATH).text();
+    expect(src).not.toMatch(/useState<ProjectDescriptor\[\]>/);
+    expect(src).not.toMatch(/useState\(false\)/);
+  });
+
+  it("imports from ./projects-store", async () => {
+    const src = await Bun.file(SRC_PATH).text();
+    expect(src).toContain("./projects-store");
+  });
+
+  it("reads the shared atom via useAtomValue", async () => {
+    const src = await Bun.file(SRC_PATH).text();
+    expect(src).toContain("useAtomValue");
+    expect(src).toContain("projectsStateAtom");
+  });
+
+  it("calls ensureProjectsLoaded inside a useEffect", async () => {
+    const src = await Bun.file(SRC_PATH).text();
+    expect(src).toContain("ensureProjectsLoaded");
+    expect(src).toContain("useEffect");
+  });
+
+  it("re-exports ProjectDescriptor so existing importers keep working", async () => {
+    const src = await Bun.file(SRC_PATH).text();
+    expect(src).toMatch(/export\s+(type\s+)?\{[^}]*ProjectDescriptor[^}]*\}/);
+  });
+});
+
+// Phase 2 — cross-consumer regression guard (CTL-1234)
+describe("all four useProjects consumers still call useProjects()", () => {
+  it("settings-surface.tsx calls useProjects(", async () => {
+    const src = await readSrc("components/settings-surface.tsx");
+    expect(src).toContain("useProjects(");
+  });
+
+  it("app-sidebar.tsx calls useProjects(", async () => {
+    const src = await readSrc("components/app-sidebar.tsx");
+    expect(src).toContain("useProjects(");
+  });
+
+  it("board/repo-icon-context.tsx calls useProjects(", async () => {
+    const src = await readSrc("board/repo-icon-context.tsx");
+    expect(src).toContain("useProjects(");
+  });
+
+  it("hooks/use-resolved-repo-colors.ts calls useProjects(", async () => {
+    const src = await readSrc("hooks/use-resolved-repo-colors.ts");
+    expect(src).toContain("useProjects(");
+  });
+
+  it("settings-surface.tsx wires refetch as onSaved", async () => {
+    const src = await readSrc("components/settings-surface.tsx");
+    expect(src).toContain("onSaved={refetch}");
+  });
+
+  it("project-settings-pane.tsx awaits onSaved() after PUT", async () => {
+    const src = await readSrc("components/settings/project-settings-pane.tsx");
+    expect(src).toContain("await onSaved()");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-projects.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-projects.ts
@@ -1,48 +1,17 @@
-// use-projects.ts — CTL-1152: the config-driven project roster hook.
+// use-projects.ts — CTL-1152/CTL-1234: shared project roster hook.
 //
-// Fetches GET /api/projects (the server's config-driven roster: one descriptor per
-// CONFIGURED catalyst.monitor.linear.teams[] entry, plus a self-identifying lane for
-// every observed-work repo with no config). Mirrors the fetch idiom in
-// use-repo-colors.ts EXACTLY — fail-open to [] so an old server (or any fetch error)
-// degrades the sidebar to its first-class empty state rather than throwing, and the
-// caller can fall back to payload.repos for one release.
-import { useEffect, useState, useCallback } from "react";
+// Backed by a single jotai atom (projects-store.ts) so one fetch and one refetch
+// are observed by every consumer. The public contract { projects, loaded, refetch }
+// is unchanged — no consumer file needs editing.
+import { useEffect, useCallback } from "react";
+import { useAtomValue } from "jotai";
+import {
+  projectsStateAtom,
+  ensureProjectsLoaded,
+  loadProjects,
+} from "./projects-store";
 
-/**
- * One project roster entry — the exact shape GET /api/projects returns (the server's
- * ProjectDescriptor, exported from lib/project-roster.ts). The nav reads repo / name /
- * defaultColor / iconUrl / hasWork; key / vcsRepo / repoRoot ride along for future use
- * (detail pages, settings). CTL-1153 (M2) adds raw-override fields for the editor.
- */
-export interface ProjectDescriptor {
-  /** Linear team key, UPPERCASE (or repo short-name uppercased for an unconfigured lane). */
-  key: string;
-  /** EFFECTIVE display name: overlay.name ?? displayCaseName(repo). */
-  name: string;
-  /** Short repo name, LOWERCASED — the value BoardPayload.repos carries / nav keys on. */
-  repo: string;
-  /** Full owner/repo from teams[].vcsRepo; null for an unconfigured lane. */
-  vcsRepo: string | null;
-  /** EFFECTIVE hue NAME resolved server-side; null when none. */
-  defaultColor: string | null;
-  /** The per-repo favicon endpoint "/api/repo-icon/<repo>". */
-  iconUrl: string;
-  /** Optional registry.json repoRoot enrichment; null when absent. */
-  repoRoot: string | null;
-  /** True when this repo has observed work; false for a configured-but-idle team. */
-  hasWork: boolean;
-  // CTL-1153 (M2): raw-override fields — absent on M1 servers, undefined-safe.
-  /** Raw stored name override; null/undefined ⇒ no override. */
-  storedName?: string | null;
-  /** Raw stored color override; null/undefined ⇒ no override. */
-  storedColor?: string | null;
-  /** Chosen icon candidate path; null/undefined ⇒ favicon auto-detect. */
-  icon?: string | null;
-  /** Per-project Linear stateMap partial override; null/undefined ⇒ inherit global. */
-  stateMap?: Record<string, string> | null;
-  /** Provenance: "overlay" | "config" | "unconfigured". */
-  source?: string;
-}
+export type { ProjectDescriptor } from "./projects-store";
 
 /**
  * The live project roster + a `loaded` flag + a `refetch` callback (CTL-1153).
@@ -50,39 +19,19 @@ export interface ProjectDescriptor {
  * `refetch` re-fetches the roster (called by settings pane after a PUT).
  */
 export interface UseProjectsResult {
-  projects: ProjectDescriptor[];
+  projects: import("./projects-store").ProjectDescriptor[];
   loaded: boolean;
   refetch: () => void;
 }
 
 export function useProjects(): UseProjectsResult {
-  const [projects, setProjects] = useState<ProjectDescriptor[]>([]);
-  const [loaded, setLoaded] = useState(false);
-
-  const fetchProjects = useCallback(() => {
-    let alive = true;
-    fetch("/api/projects")
-      .then((r) => r.json())
-      .then((data: { projects?: unknown }) => {
-        if (!alive) return;
-        if (Array.isArray(data.projects)) {
-          setProjects(data.projects as ProjectDescriptor[]);
-        }
-        setLoaded(true);
-      })
-      .catch(() => {
-        if (!alive) return;
-        // Fail-open: an old server without /api/projects (or any error) → empty
-        // roster, marked loaded so the sidebar falls back to its empty state /
-        // payload.repos rather than spinning.
-        setLoaded(true);
-      });
-    return () => { alive = false; };
-  }, []);
+  const { projects, loaded } = useAtomValue(projectsStateAtom);
 
   useEffect(() => {
-    return fetchProjects();
-  }, [fetchProjects]);
+    void ensureProjectsLoaded();
+  }, []);
 
-  return { projects, loaded, refetch: fetchProjects };
+  const refetch = useCallback(() => { void loadProjects(); }, []);
+
+  return { projects, loaded, refetch };
 }


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-17T03:08:00Z -->
<!-- Last updated: 2026-06-17T03:08:00Z -->
<!-- PR: #2166 -->
<!-- Previous commits: 8ecdc598001b1ccebe341d7faa7cea32ab6a0028,9db9120d953b8b18ac439bf0111d59e9af5dc418 -->

## Summary

`useProjects()` held per-instance local state (`useState`), so the sidebar and Settings pane maintained independent fetches. Calling `refetch()` after a Settings save only updated the Settings instance — the left-nav project mark stayed stale until a full page reload.

This PR promotes the project roster to a shared jotai atom (`projectsStateAtom`). All four consumers (sidebar, settings pane, `RepoIconProvider`, `use-resolved-repo-colors`) read from the same atom. One `refetch()` call from the Settings save path now propagates to every reader immediately — no reload required.

The public `useProjects()` contract (`{ projects, loaded, refetch }`) and the `ProjectDescriptor` type are unchanged. No consumer files were modified.

## Changes Made

### New: `projects-store.ts` — shared jotai atom

- Defines `projectsStateAtom: Atom<{ projects, loaded }>` backed by jotai
- Exports `loadProjects(store?, fetchImpl?)` — fetches `/api/projects` and writes the result; both params are injectable for unit tests
- Exports `ensureProjectsLoaded()` — module-level one-shot guard that triggers the initial fetch exactly once across all consumers in a module lifetime
- Fail-open: on any fetch error or non-array payload, marks `loaded=true` and preserves the prior roster rather than wiping it

### Modified: `use-projects.ts` — backed by atom

- Drops per-instance `useState` for `projects` and `loaded`; reads both from `useAtomValue(projectsStateAtom)` instead
- Calls `ensureProjectsLoaded()` in a `useEffect` for the initial fetch
- `refetch` callback now calls `loadProjects()` — writes to the shared atom, propagating to all consumers
- Re-exports `ProjectDescriptor` type from `projects-store.ts` so all existing importers continue to compile without changes

### New: `projects-store.test.ts` — unit tests for the atom

- `projectsStateAtom` starts empty with `loaded: false`
- `loadProjects` writes fetched projects and sets `loaded: true`
- Regression: one `refetch` updates ALL readers of the shared atom (the CTL-1234 invariant)
- Fail-open: fetch rejection preserves prior roster
- Fail-open: non-array payload preserves prior roster

### New: `use-projects.test.tsx` — wiring assertions + cross-consumer regression guard

- Verifies `use-projects.ts` no longer contains per-instance `useState` for the roster
- Verifies it imports from `./projects-store` and uses `useAtomValue` + `projectsStateAtom`
- Verifies `ensureProjectsLoaded` is called inside a `useEffect`
- Verifies `ProjectDescriptor` is re-exported so existing importers keep working
- Cross-consumer guard: asserts all four consumers (`app-sidebar`, `settings-surface`, `repo-icon-context`, `use-resolved-repo-colors`) still call `useProjects()`, and that the `onSaved={refetch}` wiring is intact

## How to Verify It

- [x] `tsc --noEmit` clean — no new errors in the diff (1 pre-existing baseline in `icon-picker-model.test.ts` not touched by this PR) ✅
- [x] `bun test` — 1605 tests pass across 127 files; 16 new tests (projects-store + use-projects) all green ✅
- [ ] Open the orch-monitor UI (`bun run dev` in `plugins/dev/scripts/orch-monitor/ui`), navigate to Settings → Projects, change an icon and save — verify the left-nav project mark updates immediately without a page reload (manual)
- [ ] Confirm no regression in sidebar project marks on initial load (manual)

## Verification Results (from verify phase)

- **Regression risk**: 1 / 10
- **typecheck**: pass — tsc --noEmit clean for the diff
- **tests**: pass — 1605 pass / 0 fail; 16 new tests all green
- **lint**: skip — ESLint does not cover `ui/` (gated by tsc + vite build)

## CI Status

- audit-references ✅
- check-versions ✅
- docs-gate ✅
- validate ✅
- quality (pending at time of description)

## Related Issues

- Fixes https://linear.app/coalesce/issue/CTL-1234
