### PR TITLE
feat(dev): CTL-1235 — emit running version + commit + drift-from-main (agent telemetry)

### DIFF
--- a/plugins/dev/scripts/catalyst-agent/build-info.mjs
+++ b/plugins/dev/scripts/catalyst-agent/build-info.mjs
@@ -1,0 +1,74 @@
+// build-info.mjs (CTL-1235) — resolve the RUNNING Catalyst build identity for
+// telemetry. Three signals:
+//   service.version          semver from the agent's own plugin.json (OTel
+//                            semconv `service.version`; the running artifact)
+//   vcs.ref.head.revision    git commit short-SHA of the agent's checkout (OTel
+//                            semconv VCS `vcs.ref.head.revision`)
+//   commits-behind-main      how far HEAD is behind origin/main (drift)
+//
+// version + commit are IMMUTABLE for the process lifetime, so they are resolved
+// ONCE and cached. commits-behind changes as main advances, so it is recomputed
+// per call (with an optional network fetch). All resolvers degrade to null on
+// any error (missing git, detached checkout, offline) — telemetry must never
+// crash the agent.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import { execFileSync } from "node:child_process";
+
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+
+// Run a git command in the agent's own checkout (git -C walks up to the repo
+// root). Returns trimmed stdout, or null on any failure.
+function git(args) {
+  try {
+    const out = execFileSync("git", ["-C", MODULE_DIR, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 15000,
+    });
+    return out.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+let _version; // undefined = unresolved · null = resolved-absent · string = value
+/** OTel semconv `service.version` — semver from the agent's plugin.json. Cached. */
+export function serviceVersion() {
+  if (_version !== undefined) return _version;
+  try {
+    const p = new URL("../../.claude-plugin/plugin.json", import.meta.url);
+    _version = JSON.parse(readFileSync(p, "utf8")).version ?? null;
+  } catch {
+    _version = null;
+  }
+  return _version;
+}
+
+let _rev;
+/** OTel semconv `vcs.ref.head.revision` — git short-SHA of the running checkout. Cached. */
+export function vcsRevision() {
+  if (_rev !== undefined) return _rev;
+  _rev = git(["rev-parse", "--short", "HEAD"]);
+  return _rev;
+}
+
+/**
+ * commitsBehindMain — how many commits HEAD is behind origin/main. Fetches first
+ * (network) unless {fetch:false}. Returns a non-negative integer, or null when
+ * git / the remote / the network is unavailable (omit the gauge rather than lie).
+ */
+export function commitsBehindMain({ fetch = true } = {}) {
+  if (fetch) git(["fetch", "--quiet", "origin", "main"]);
+  const n = git(["rev-list", "--count", "HEAD..origin/main"]);
+  if (n === null) return null;
+  const v = Number(n);
+  return Number.isFinite(v) && v >= 0 ? v : null;
+}
+
+// Test-only: clear the version/commit caches so a test can re-resolve.
+export function __resetCaches() {
+  _version = undefined;
+  _rev = undefined;
+}

--- a/plugins/dev/scripts/catalyst-agent/catalyst-agent.mjs
+++ b/plugins/dev/scripts/catalyst-agent/catalyst-agent.mjs
@@ -7,6 +7,7 @@
 //   1. account.ratelimit.sampled  (CATALYST_AGENT_USAGE)
 //   2. host.metrics.sampled       (CATALYST_AGENT_HOST)
 //   3. host.process.sampled       (CATALYST_AGENT_PROCESS, one event per top-N proc)
+//   4. catalyst.build.info + catalyst.vcs.commits_behind  (CATALYST_AGENT_VERSION)
 //
 // Modes:
 //   --once     run one tick of each enabled domain, then exit 0 (launchd path)
@@ -36,6 +37,7 @@ Domains (each emits OTel envelopes; toggle with env, default on):
   account.ratelimit.sampled   CATALYST_AGENT_USAGE=0    to disable
   host.metrics.sampled        CATALYST_AGENT_HOST=0     to disable
   host.process.sampled        CATALYST_AGENT_PROCESS=0  to disable
+  catalyst.build.info/vcs     CATALYST_AGENT_VERSION=0  to disable
 
 Emit (CATALYST_AGENT_EMIT, default eventlog):
   eventlog   append JSONL to ~/catalyst/events/<YYYY-MM>.jsonl
@@ -159,6 +161,15 @@ export function defaultImporters(pending = []) {
           await processes.sampleProcesses({ topN: config.topN });
         },
       })),
+    // Domain 4 (CTL-1235) — catalyst.build.info + catalyst.vcs.commits_behind.
+    // Emits the running version/commit + drift-from-main as OTLP gauges. Uses its
+    // own config-aware metric emit (like host), so nothing is collected here.
+    version: () =>
+      import(new URL("./version.mjs", import.meta.url).href).then((version) => ({
+        runOnce: async () => {
+          await version.sampleVersion();
+        },
+      })),
   };
 }
 
@@ -182,6 +193,9 @@ export async function runOnce({ config = readAgentConfig(), importers } = {}) {
   }
   if (config.processEnabled) {
     results.process = await runDomain({ name: "process", importer: useImporters.process, config });
+  }
+  if (config.versionEnabled) {
+    results.version = await runDomain({ name: "version", importer: useImporters.version, config });
   }
   // Await every OTLP POST kicked off this tick before resolving — the load-
   // bearing fix for the --once telemetry-drop. No-op in eventlog mode / when a

--- a/plugins/dev/scripts/catalyst-agent/config.mjs
+++ b/plugins/dev/scripts/catalyst-agent/config.mjs
@@ -119,6 +119,7 @@ export function readAgentConfig() {
     usageEnabled: process.env.CATALYST_AGENT_USAGE !== "0",
     hostEnabled: process.env.CATALYST_AGENT_HOST !== "0",
     processEnabled: process.env.CATALYST_AGENT_PROCESS !== "0",
+    versionEnabled: process.env.CATALYST_AGENT_VERSION !== "0",
   };
 }
 

--- a/plugins/dev/scripts/catalyst-agent/emit.mjs
+++ b/plugins/dev/scripts/catalyst-agent/emit.mjs
@@ -25,6 +25,7 @@ import { dirname } from "node:path";
 import { randomBytes } from "node:crypto";
 import { hostname } from "node:os";
 import { hostName, hostId } from "../execution-core/lib/host-identity.mjs";
+import { serviceVersion } from "./build-info.mjs";
 
 // shortHostname — os.hostname() with the macOS-appended ".local" suffix
 // stripped, matching the hostname Claude Code's native OTel emits
@@ -295,13 +296,19 @@ export async function drainPending(pending) {
 // metricResource — the same host/service identity the log envelope carries, so
 // metrics and events share one resource on the dashboards.
 export function metricResource() {
-  return {
+  const res = {
     "service.name": "catalyst.agent",
     "service.namespace": "catalyst",
     hostname: shortHostname(),
     "host.name": hostName(),
     "host.id": hostId(),
   };
+  // CTL-1235: stamp the running semver (OTel semconv `service.version`) on the
+  // shared metric resource so EVERY agent metric can be grouped/filtered by the
+  // version that emitted it. Omitted when unresolvable (no empty label).
+  const v = serviceVersion();
+  if (v) res["service.version"] = v;
+  return res;
 }
 
 // dropNullAttrs — the put() pattern for metric data-point attributes: an attr is

--- a/plugins/dev/scripts/catalyst-agent/emit.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/emit.test.mjs
@@ -517,6 +517,9 @@ describe("sendOtlpMetrics — OTLP /v1/metrics POST", () => {
     expect(r["service.name"]).toBe("catalyst.agent");
     expect(r["service.namespace"]).toBe("catalyst");
     expect(typeof r.hostname).toBe("string");
+    // CTL-1235: the running semver rides the shared metric resource (semconv
+    // service.version) when resolvable, so any metric can be grouped by version.
+    expect(r["service.version"]).toMatch(/^\d+\.\d+\.\d+/);
   });
 });
 

--- a/plugins/dev/scripts/catalyst-agent/version.mjs
+++ b/plugins/dev/scripts/catalyst-agent/version.mjs
@@ -1,0 +1,73 @@
+// version.mjs (CTL-1235) — Domain 4: the build-identity sampler. Emits OTLP
+// gauges so dashboards can (a) group ANY metric by the running version
+// (service.version rides the shared metric resource — see emit.mjs), (b) audit
+// what code (version+commit) ran on which host and when, and (c) see how far
+// each host is behind origin/main.
+//
+// Metrics emitted (custom catalyst.* namespace; "commits behind main" has no
+// OTel-semconv equivalent):
+//   catalyst.build.info        gauge=1, labels: vcs.ref.head.revision (commit)
+//                              — the classic *_build_info anchor; service.version
+//                                + host.name come from the shared resource.
+//   catalyst.vcs.commits_behind gauge=N — commits HEAD is behind origin/main
+//                              (0 = on the latest main). Omitted when unresolvable.
+import { otlpMetric, emitMetrics } from "./emit.mjs";
+import { readAgentConfig, log } from "./config.mjs";
+import {
+  serviceVersion as defaultServiceVersion,
+  vcsRevision as defaultVcsRevision,
+  commitsBehindMain as defaultCommitsBehindMain,
+} from "./build-info.mjs";
+
+// defaultEmitMetrics — config-aware OTLP metric emit (mirrors host.mjs). A no-op
+// when no metrics endpoint is resolvable (eventlog-only hosts).
+async function defaultEmitMetrics(metrics) {
+  return await emitMetrics(metrics, readAgentConfig());
+}
+
+/**
+ * sampleVersion — emit the build-identity metric set for one tick. All inputs
+ * are injectable for tests; production defaults resolve from build-info.mjs and
+ * the config-aware metric emit.
+ */
+export async function sampleVersion({
+  serviceVersion = defaultServiceVersion,
+  vcsRevision = defaultVcsRevision,
+  commitsBehindMain = defaultCommitsBehindMain,
+  emitMetricsFn = defaultEmitMetrics,
+  nowMs = () => Date.now(),
+} = {}) {
+  const t = String(nowMs() * 1_000_000); // ms → unix-nanos
+  const revision = vcsRevision();
+  const behind = commitsBehindMain();
+
+  const metrics = [
+    // build_info: a constant 1 whose labels carry the build identity. The commit
+    // is the only label not already on the shared resource (service.version is).
+    otlpMetric({
+      name: "catalyst.build.info",
+      unit: "1",
+      description: "Running Catalyst build identity (value always 1); labels carry the commit revision.",
+      kind: "gauge",
+      points: [{ value: 1, attrs: { "vcs.ref.head.revision": revision }, timeUnixNano: t }],
+    }),
+    // commits-behind drift. otlpMetric drops the point when behind is null, so
+    // the metric is simply absent on a host that can't resolve it (no false 0).
+    otlpMetric({
+      name: "catalyst.vcs.commits_behind",
+      unit: "1",
+      description: "Commits HEAD is behind origin/main (0 = up to date with main).",
+      kind: "gauge",
+      points: [{ value: behind, timeUnixNano: t }],
+    }),
+  ];
+
+  try {
+    await emitMetricsFn(metrics);
+  } catch (err) {
+    log.warn({ err: err?.message }, "catalyst-agent: version domain metric emit failed");
+  }
+
+  // Returned for tests / the --once result map; not used in production.
+  return { version: serviceVersion(), revision, commitsBehind: behind };
+}

--- a/plugins/dev/scripts/catalyst-agent/version.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/version.test.mjs
@@ -1,0 +1,95 @@
+// version.test.mjs (CTL-1235) — Domain 4: the build-identity sampler.
+//
+// sampleVersion is exercised through injected seams (serviceVersion /
+// vcsRevision / commitsBehindMain / emitMetricsFn) so there is no real git or
+// network. Covers: the build_info gauge shape + commit label, the commits_behind
+// gauge value, null-degradation (drift unresolvable → metric dropped, no false
+// 0), and emit-failure resilience. A light real-resolver check confirms
+// build-info.mjs reads the actual plugin.json + git.
+//
+// Run: cd plugins/dev/scripts/catalyst-agent && bun test version.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { sampleVersion } from "./version.mjs";
+import { serviceVersion, vcsRevision } from "./build-info.mjs";
+
+// Pull the single data point's attributes into a plain {key:value} map.
+function attrMap(metric) {
+  const out = {};
+  for (const a of metric?.gauge?.dataPoints?.[0]?.attributes ?? []) {
+    out[a.key] = a.value?.stringValue ?? a.value?.asDouble ?? a.value?.asInt;
+  }
+  return out;
+}
+const byName = (metrics, name) => metrics.find((m) => m?.name === name);
+
+describe("sampleVersion — build-identity metric set", () => {
+  const stubs = {
+    serviceVersion: () => "9.9.9",
+    vcsRevision: () => "abc1234",
+    commitsBehindMain: () => 0,
+    nowMs: () => 1000,
+  };
+
+  test("emits catalyst.build.info = 1 with the commit as vcs.ref.head.revision", async () => {
+    let captured = [];
+    await sampleVersion({ ...stubs, emitMetricsFn: async (m) => (captured = m.filter(Boolean)) });
+    const info = byName(captured, "catalyst.build.info");
+    expect(info).toBeTruthy();
+    expect(info.gauge.dataPoints[0].asDouble).toBe(1);
+    expect(attrMap(info)["vcs.ref.head.revision"]).toBe("abc1234");
+    // service.version is NOT a build_info label — it rides the shared resource.
+    expect(attrMap(info)["service.version"]).toBeUndefined();
+  });
+
+  test("emits catalyst.vcs.commits_behind with the drift count", async () => {
+    let captured = [];
+    await sampleVersion({ ...stubs, commitsBehindMain: () => 7, emitMetricsFn: async (m) => (captured = m.filter(Boolean)) });
+    const behind = byName(captured, "catalyst.vcs.commits_behind");
+    expect(behind).toBeTruthy();
+    expect(behind.gauge.dataPoints[0].asDouble).toBe(7);
+  });
+
+  test("timeUnixNano is ms→nanos", async () => {
+    let captured = [];
+    await sampleVersion({ ...stubs, emitMetricsFn: async (m) => (captured = m.filter(Boolean)) });
+    expect(byName(captured, "catalyst.build.info").gauge.dataPoints[0].timeUnixNano).toBe("1000000000");
+  });
+
+  test("commits_behind unresolvable (null) → metric dropped, no false 0", async () => {
+    let captured = [];
+    await sampleVersion({ ...stubs, commitsBehindMain: () => null, emitMetricsFn: async (m) => (captured = m.filter(Boolean)) });
+    expect(byName(captured, "catalyst.vcs.commits_behind")).toBeUndefined();
+    // build_info still emits — the build identity is independent of drift.
+    expect(byName(captured, "catalyst.build.info")).toBeTruthy();
+  });
+
+  test("a null commit still emits build_info (revision label simply omitted)", async () => {
+    let captured = [];
+    await sampleVersion({ ...stubs, vcsRevision: () => null, emitMetricsFn: async (m) => (captured = m.filter(Boolean)) });
+    const info = byName(captured, "catalyst.build.info");
+    expect(info).toBeTruthy();
+    expect(attrMap(info)["vcs.ref.head.revision"]).toBeUndefined();
+  });
+
+  test("an emit failure does not throw (telemetry never crashes the agent)", async () => {
+    await expect(
+      sampleVersion({ ...stubs, emitMetricsFn: async () => { throw new Error("boom"); } }),
+    ).resolves.toBeTruthy();
+  });
+
+  test("returns the resolved identity for the --once result map", async () => {
+    const r = await sampleVersion({ ...stubs, commitsBehindMain: () => 2, emitMetricsFn: async () => {} });
+    expect(r).toEqual({ version: "9.9.9", revision: "abc1234", commitsBehind: 2 });
+  });
+});
+
+describe("build-info.mjs — real resolvers (no injection)", () => {
+  test("serviceVersion reads a semver-shaped string from plugin.json", () => {
+    expect(serviceVersion()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+  test("vcsRevision returns a short git sha (or null off a git checkout)", () => {
+    const r = vcsRevision();
+    expect(r === null || /^[0-9a-f]{7,}$/.test(r)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What
Adds a build-identity domain to `catalyst-agent` so per-host dashboards can show **what version/commit each host runs**, group **any** metric by version, and see **how far behind main** a host is.

- **`service.version`** (OTel semconv) on the shared metric resource → rides every agent metric. Group any panel by `service_version`.
- **`catalyst.build.info`** = 1, label **`vcs.ref.head.revision`** (commit) → the audit-timeline anchor (what ran where/when).
- **`catalyst.vcs.commits_behind`** = N → drift from origin/main (0 = current; omitted when unresolvable, never a false 0).

## Semconv
`service.version` + `vcs.ref.head.revision` are the OTel-conformant homes for version/commit (semconv explicitly allows semver or git hash for `service.version`). "Commits behind main" has no semconv metric, so it uses the custom `catalyst.*` namespace.

## How it resolves
`build-info.mjs`: semver from the agent's own `plugin.json`; commit via `git rev-parse` in the agent's checkout (cached); commits-behind via a per-tick `git fetch` + `rev-list --count HEAD..origin/main`. All degrade to null on error — telemetry never crashes the agent.

## Tests / effect
236 agent tests pass (new `version.test.mjs` + `build-info` real-resolver checks). The agent runs `--once` per 300s from plugin-source, so the effect lands on the **next tick (≤5min)** after a plugin-source pull — no restart. Pairs with CTL-1237 (host.name on bg workers) for complete per-host dashboards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)