### PR TITLE
fix(dev): CTL-1235 — clean metric names (drop _ratio suffix on build_info/commits_behind)

### DIFF
--- a/plugins/dev/scripts/catalyst-agent/version.mjs
+++ b/plugins/dev/scripts/catalyst-agent/version.mjs
@@ -45,8 +45,12 @@ export async function sampleVersion({
     // build_info: a constant 1 whose labels carry the build identity. The commit
     // is the only label not already on the shared resource (service.version is).
     otlpMetric({
+      // Unit MUST be empty: the OTel→Prometheus mapping appends a unit suffix
+      // (unit "1" → "_ratio"), which would yield the wrong name
+      // `catalyst_build_info_ratio`. Empty unit → the conventional
+      // `catalyst_build_info`.
       name: "catalyst.build.info",
-      unit: "1",
+      unit: "",
       description: "Running Catalyst build identity (value always 1); labels carry the commit revision.",
       kind: "gauge",
       points: [{ value: 1, attrs: { "vcs.ref.head.revision": revision }, timeUnixNano: t }],
@@ -54,8 +58,10 @@ export async function sampleVersion({
     // commits-behind drift. otlpMetric drops the point when behind is null, so
     // the metric is simply absent on a host that can't resolve it (no false 0).
     otlpMetric({
+      // Empty unit (a plain count): unit "1" would append "_ratio" →
+      // `catalyst_vcs_commits_behind_ratio`. Empty → `catalyst_vcs_commits_behind`.
       name: "catalyst.vcs.commits_behind",
-      unit: "1",
+      unit: "",
       description: "Commits HEAD is behind origin/main (0 = up to date with main).",
       kind: "gauge",
       points: [{ value: behind, timeUnixNano: t }],

--- a/plugins/dev/scripts/catalyst-agent/version.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/version.test.mjs
@@ -37,6 +37,9 @@ describe("sampleVersion — build-identity metric set", () => {
     const info = byName(captured, "catalyst.build.info");
     expect(info).toBeTruthy();
     expect(info.gauge.dataPoints[0].asDouble).toBe(1);
+    // Unit MUST be empty so Prometheus does NOT append "_ratio" (CTL-1235): the
+    // metric must land as `catalyst_build_info`, not `catalyst_build_info_ratio`.
+    expect(info.unit).toBe("");
     expect(attrMap(info)["vcs.ref.head.revision"]).toBe("abc1234");
     // service.version is NOT a build_info label — it rides the shared resource.
     expect(attrMap(info)["service.version"]).toBeUndefined();


### PR DESCRIPTION
Follow-up to #2169. The OTel→Prometheus unit-suffix rule renamed the new gauges to `catalyst_build_info_ratio` / `catalyst_vcs_commits_behind_ratio` (unit "1" → "_ratio"). Set unit "" → conventional `catalyst_build_info` / `catalyst_vcs_commits_behind`. Data verified correct on live Prometheus (version=12.10.0, commit=73fe804e, behind=0); only the names needed fixing. Test asserts unit "".

🤖 Generated with [Claude Code](https://claude.com/claude-code)