### PR TITLE
fix(dev): CTL-1191 — HRW-gate the 3 recovery passes over the surviving roster + terminal-state filter

### DIFF
--- a/plugins/dev/scripts/execution-core/diagnostician.mjs
+++ b/plugins/dev/scripts/execution-core/diagnostician.mjs
@@ -209,10 +209,20 @@ export function processDiagnosticianWakes(db, tickId, opts = {}) {
     return { skipped: "disabled" };
   }
 
+  // CTL-1191: HRW ownership gate over the surviving roster. The caller (runTick)
+  // injects `ownsSubject(subject)` so on a multi-host cluster only the node that
+  // OWNS a stalled subject diagnoses + escalates it — otherwise two nodes both
+  // capture evidence and double-page needs-human for the same ticket. Default is
+  // own-everything (() => true) so the single-host install and every existing
+  // diagnostician test are an EXACT no-op (no behavior change unless wired).
+  const ownsSubject =
+    typeof opts.ownsSubject === "function" ? opts.ownsSubject : () => true;
+
   const ran = [];
   const cooled = [];
   const escalated = []; // CTL-962: subjects whose R12 fired, with captured evidence
   const errors = [];
+  const skippedNotOwned = []; // CTL-1191: subjects another node owns this tick
 
   try {
     // Read the current tick's now_ms for cooldown arithmetic
@@ -239,6 +249,16 @@ export function processDiagnosticianWakes(db, tickId, opts = {}) {
 
     for (const wb of wakeBeliefs) {
       const subject = wb.subject;
+
+      // CTL-1191: HRW ownership gate — skip a subject another node owns this tick
+      // (over the surviving roster). Runs BEFORE evidence capture / escalation so
+      // a non-owner does nothing: no captureEvidence, no recordWakeIntent, no
+      // R12 page. Single-host / unwired callers own everything (no-op).
+      if (!ownsSubject(subject)) {
+        skippedNotOwned.push(subject);
+        continue;
+      }
+
       const reason = (() => {
         try {
           return JSON.parse(wb.value ?? "{}").reason ?? "unknown";
@@ -293,7 +313,15 @@ export function processDiagnosticianWakes(db, tickId, opts = {}) {
     errors.push({ phase: "outer", err: String(err?.message ?? err) });
   }
 
-  return { ran, cooled, escalated, errors: errors.length ? errors : undefined };
+  return {
+    ran,
+    cooled,
+    escalated,
+    // CTL-1191: surface non-owned skips only when the gate actually fired, so the
+    // single-host / unwired return shape is byte-identical to before.
+    ...(skippedNotOwned.length ? { skippedNotOwned } : {}),
+    errors: errors.length ? errors : undefined,
+  };
 }
 
 // ── extractShortId — resolve the bg_job_id / short_id for a subject ──────

--- a/plugins/dev/scripts/execution-core/diagnostician.test.mjs
+++ b/plugins/dev/scripts/execution-core/diagnostician.test.mjs
@@ -28,6 +28,7 @@ import {
   processDiagnosticianWakes,
   __resetDiagnosticianForTests,
 } from "./diagnostician.mjs";
+import { ownedBy } from "./hrw.mjs"; // CTL-1191: HRW ownership for the diagnostician gate test
 
 // ── frozen time ───────────────────────────────────────────────────────────
 const NOW = 1781030108000; // 2026-06-09T18:35:08Z
@@ -570,5 +571,101 @@ describe("multiple subjects in one tick", () => {
     // CTL-B/implement processed on tickId
     expect(result.ran).toHaveLength(1);
     expect(result.ran[0].subject).toBe("CTL-B/implement");
+  });
+});
+
+// ── CTL-1191: HRW ownership gate (multi-host) ───────────────────────────────
+//
+// On a multi-host cluster the diagnostician must only diagnose + escalate the
+// stalled subjects THIS node owns by HRW — otherwise two nodes both capture
+// evidence and double-page needs-human for the same ticket. The caller (runTick)
+// injects ownsSubject; here we drive it directly. Under roster
+// ["mini","mac-studio"]: CTL-A is owned by mini, CTL-B by mac-studio.
+describe("CTL-1191 — HRW ownership gate (ownsSubject)", () => {
+  const ROSTER = ["mini", "mac-studio"];
+  // Build the same predicate the scheduler builds: own a subject iff this host
+  // is its HRW owner over the (surviving) roster.
+  const ownsSubjectFor = (survivors, self) => (subject) =>
+    survivors.length <= 1 || ownedBy(String(subject).split("/")[0], survivors, self);
+
+  test("default (no ownsSubject) is an EXACT no-op — every owned subject runs", () => {
+    const { tickId } = seedNeverStartedTick({ ticket: "CTL-A", phase: "plan" });
+    const result = processDiagnosticianWakes(db, tickId, {
+      env: { CATALYST_DIAGNOSTICIAN: "1" },
+      captureLogs: fakeCaptureLogs,
+      readJobState: fakeReadJobState,
+      // intentionally NO ownsSubject — must behave exactly as before CTL-1191
+    });
+    expect(result.ran).toHaveLength(1);
+    expect(result.ran[0].subject).toBe("CTL-A/plan");
+    expect(result.skippedNotOwned).toBeUndefined(); // return shape unchanged
+  });
+
+  test("multi-host: a subject this node owns is diagnosed; one another node owns is SKIPPED", () => {
+    // Two stuck workers on one tick: CTL-A (owned by mini), CTL-B (owned by mac-studio).
+    const tickId = insertTick(NOW);
+    insertSignal(tickId, {
+      ticket: "CTL-A",
+      phase: "plan",
+      bg_job_id: "aaashort",
+      started_at_ms: NOW - 10 * MIN,
+      updated_at_ms: NOW - 10 * MIN,
+    });
+    insertAgent(tickId, { session_id: "aaashort-sess", short_id: "aaashort", kind: "background" });
+    insertJob(tickId, { bg_job_id: "aaashort", state: "working", tempo: "blocked" });
+    insertSignal(tickId, {
+      ticket: "CTL-B",
+      phase: "implement",
+      bg_job_id: "bbbshort",
+      started_at_ms: NOW - 10 * MIN,
+      updated_at_ms: NOW - 10 * MIN,
+    });
+    insertAgent(tickId, { session_id: "bbbshort-sess", short_id: "bbbshort", kind: "background" });
+    insertJob(tickId, { bg_job_id: "bbbshort", state: "working", tempo: "blocked" });
+    evaluateBeliefs(db, tickId);
+
+    const result = processDiagnosticianWakes(db, tickId, {
+      env: { CATALYST_DIAGNOSTICIAN: "1" },
+      captureLogs: fakeCaptureLogs,
+      readJobState: fakeReadJobState,
+      ownsSubject: ownsSubjectFor(ROSTER, "mini"), // this host = mini
+    });
+
+    // Only the mini-owned subject ran; the mac-studio-owned one was skipped
+    // BEFORE any evidence capture / escalation.
+    expect(result.ran.map((r) => r.subject)).toEqual(["CTL-A/plan"]);
+    expect(result.skippedNotOwned).toEqual(["CTL-B/implement"]);
+  });
+
+  test("dead-owner failover: when the owning node is dead, the survivor diagnoses its subject", () => {
+    // CTL-B is owned by mac-studio in the full roster. mac-studio is DEAD, so
+    // the surviving roster is just [mini] — under which mini owns CTL-B and must
+    // pick up its diagnosis instead of it stranding.
+    const tickId = insertTick(NOW);
+    insertSignal(tickId, {
+      ticket: "CTL-B",
+      phase: "implement",
+      bg_job_id: "bbbshort",
+      started_at_ms: NOW - 10 * MIN,
+      updated_at_ms: NOW - 10 * MIN,
+    });
+    insertAgent(tickId, { session_id: "bbbshort-sess", short_id: "bbbshort", kind: "background" });
+    insertJob(tickId, { bg_job_id: "bbbshort", state: "working", tempo: "blocked" });
+    evaluateBeliefs(db, tickId);
+
+    // Sanity: in the FULL roster mini would NOT own CTL-B (so without failover
+    // this subject would strand on a dead owner).
+    expect(ownedBy("CTL-B", ROSTER, "mini")).toBe(false);
+
+    const survivors = ["mini"]; // mac-studio dead
+    const result = processDiagnosticianWakes(db, tickId, {
+      env: { CATALYST_DIAGNOSTICIAN: "1" },
+      captureLogs: fakeCaptureLogs,
+      readJobState: fakeReadJobState,
+      ownsSubject: ownsSubjectFor(survivors, "mini"),
+    });
+
+    expect(result.ran.map((r) => r.subject)).toEqual(["CTL-B/implement"]);
+    expect(result.skippedNotOwned).toBeUndefined();
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -131,6 +131,12 @@ import { emitReapIntent } from "./reap-intent.mjs";
 import {
   reclaimDeadWorkIfPossible as defaultReclaimDeadWork,
   reclaimDeadHostWork,
+  // CTL-1191: surviving-roster primitives so the recovery passes (unstuck /
+  // reasoning / diagnostician) HRW-gate over the SURVIVING roster — a dead
+  // node's stuck work fails over to a live owner instead of stranding.
+  readClusterHeartbeats,
+  deadHosts,
+  survivingRoster,
   defaultAppendDispatchFailedEvent,
   defaultAppendDispatchRequestedEvent,
   defaultAppendDispatchLaunchedEvent,
@@ -225,7 +231,10 @@ import { resolveTicketType } from "./ticket-type.mjs"; // CTL-1023: work-type di
 // ({Done,Canceled} — its OWN set) backs both the reconcile-backstop's
 // "live state !terminal" check and the recovery short-circuit threaded into
 // reclaimOpts below.
-import { isLinearTerminal } from "./terminal-state.mjs";
+// CTL-1191: isTicketTerminalOrMerged — used by the recovery-reasoning pass (Pass
+// 0r) to stop reasoning over a ticket already finished (terminal Linear state or
+// merged PR), per the PR #2163 verify flag.
+import { isLinearTerminal, isTicketTerminalOrMerged } from "./terminal-state.mjs";
 // CTL-638: labelOnce moved out of this file into a shared leaf module so the
 // recovery-sweep escalation path can use the same once-marker guard. Keeping
 // labelOnce here would force recovery.mjs → scheduler.mjs to import it, but
@@ -242,10 +251,11 @@ import {
   getClusterHosts,
   hostMembershipWarning,
   isDraining as isDrainingDefault,
+  HEARTBEAT_GRACE_MS, // CTL-1191: dead-host grace for surviving-roster recovery gate
 } from "./config.mjs";
 import { emitDrainedEvent as defaultEmitDrainedEvent } from "./drain-event.mjs"; // CTL-1095: drained sentinel
 import { defaultCheckSequencing } from "./sequencing.mjs"; // CTL-537
-import { ownedBy } from "./hrw.mjs"; // CTL-850: HRW ownership filter
+import { ownedBy } from "./hrw.mjs"; // CTL-850: HRW ownership filter (CTL-1191 also uses it for the diagnostician gate)
 import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-850: cross-host claim soft-CAS
 // CTL-954: team estimation method — lazy-cached from Linear, used to expand
 // the allowed estimate point set beyond the hard-coded Fibonacci values.
@@ -287,6 +297,29 @@ import {
 // not collapse with this set — see the CTL-565 cross-reference comment on
 // isTicketInFlight).
 const TERMINAL_SIGNAL_STATUSES = new Set(["failed", "stalled", "aborted"]);
+
+// CTL-1191: computeSurvivingRoster — the roster minus hosts whose heartbeat is
+// older than the grace window. SHARED by both recovery-pass HRW gates
+// (schedulerTick's ownsForRecovery and runTick's diagnostician ownsSubject) so
+// the two never disagree about who is alive. Mirrors reclaimDeadHostWork's
+// survivor computation (recovery.mjs:2979-2983) exactly.
+//
+// FAIL-SAFE: a thrown heartbeat read, or a roster where EVERY host looks dead
+// (e.g. an empty/garbled event log), degrades to the FULL roster — each node
+// then owns only its own HRW slice (NEVER double-acts) and we merely forgo the
+// dead-owner failover for this tick (no worse than the pre-CTL-1191 strand).
+// Single-host (roster.length <= 1) returns the roster unchanged with no read.
+function computeSurvivingRoster(roster, { readHeartbeats = readClusterHeartbeats, nowMs = Date.now() } = {}) {
+  if (!Array.isArray(roster) || roster.length <= 1) return roster;
+  try {
+    const lastSeen = readHeartbeats({ roster });
+    const dead = deadHosts({ lastSeen, roster, graceMs: HEARTBEAT_GRACE_MS, nowMs });
+    const alive = survivingRoster(roster, dead);
+    return alive.length > 0 ? alive : roster;
+  } catch {
+    return roster;
+  }
+}
 
 // CTL-1004/CTL-1056 Bug 2: dispatchFailureDiag — extract the diagnostic fields
 // from a dispatch result (r = { code, stderr, spawnError, signal }) for the
@@ -2624,6 +2657,12 @@ export function schedulerTick(
     hosts = undefined,
     hostName = undefined,
     claimDispatch = claimDispatchSync,
+    // CTL-1191: injectable surviving-roster computation for the recovery-pass HRW
+    // gate (ownsForRecovery). Default undefined → computeSurvivingRoster(roster),
+    // which reads heartbeats from the (test-redirected) event log. Tests inject a
+    // fixed survivor set to drive the dead-owner-failover path deterministically
+    // without writing heartbeat events. Single-host is still a no-op regardless.
+    recoverySurvivingRoster = undefined,
     // CTL-729: progress-watchdog seams. Defaults keep every existing bare unit
     // tick inert (null silence probe → predicate no-ops via "no-transcript").
     watchdog: {
@@ -2726,6 +2765,39 @@ export function schedulerTick(
     globalThis.__ctl1057_scheduler_warned = true;
     log.warn({ roster, self }, _smw);
   }
+
+  // CTL-1191: ownsForRecovery — the HRW ownership predicate for the three
+  // recovery passes (Pass 0u unstuck-sweep, Pass 0r reasoning, diagnostician).
+  // These passes classify-then-ACT (escalate / FIX / re-dispatch / comment) over
+  // the stalled/failed/needs-human backlog. Before CTL-1191 they had NO ownership
+  // gate, so on a 2-node cluster BOTH nodes acted on EVERY stalled ticket
+  // (duplicate escalations, double Linear comments, racing re-dispatch).
+  //
+  // STRICT no-op at N=1: when !multiHost this is an identity (returns true for
+  // every ticket) — the lone host keeps acting on all of its work exactly as
+  // before. The surviving-roster read below NEVER runs single-host.
+  //
+  // DEAD-OWNER FAILOVER: at N>1 the HRW hash is computed over the SURVIVING
+  // roster (roster minus dead hosts), NOT the raw roster. So when the ticket's
+  // original owner has died, ownership re-homes to a LIVE survivor and that node
+  // picks up the dead owner's stuck work instead of it stranding. Mirrors
+  // reclaimDeadHostWork's `ownerForTicket(ticket, survivors)` gate exactly
+  // (recovery.mjs:2983-2989) so the dispatch-side and recovery-side agree on who
+  // owns a dead node's tickets.
+  //
+  // Computed lazily + memoized once per tick via the shared computeSurvivingRoster
+  // helper: the heartbeat read only fires the first time a recovery pass actually
+  // has candidates, and only when multiHost.
+  let _survivorRoster = null;
+  const _survivors = () => {
+    if (_survivorRoster) return _survivorRoster;
+    _survivorRoster = Array.isArray(recoverySurvivingRoster)
+      ? recoverySurvivingRoster
+      : computeSurvivingRoster(roster);
+    return _survivorRoster;
+  };
+  const ownsForRecovery = (ticket) =>
+    !multiHost || ownedBy(ticket, _survivors(), self);
   // CTL-757: emitStateWrite — caller-emit the canonical linear.state.write audit
   // event for ONE scheduler write site. `writerResult` is the runTransition return
   // ({applied, reason, from_state, to_state, ...}) from applyPhaseStatus /
@@ -3255,7 +3327,13 @@ export function schedulerTick(
       try {
         const ureport = runUnstuckSweepPass({
           mode: uMode,
-          collectCandidates: _collectUnstuckCandidates,
+          // CTL-1191: HRW-gate the unstuck candidate census over the SURVIVING
+          // roster. The unstuck pass escalates / acts on stalled tickets; on a
+          // 2-node cluster only the owning node should act so two nodes don't
+          // both post escalation comments / race a clear on the same ticket. A
+          // dead owner's stuck tickets re-home to a live survivor. STRICT no-op
+          // at N=1 (ownsForRecovery is identity → the census is unchanged).
+          collectCandidates: () => (_collectUnstuckCandidates() ?? []).filter((c) => ownsForRecovery(c.ticket)),
           actByCategory: _unstuckActByCategory ?? {},
           escalate: _unstuckEscalate ?? (() => {}),
           emit: _unstuckEmit,
@@ -3365,6 +3443,28 @@ export function schedulerTick(
               sig.status === "failed" ||
               sig.status === "stalled" ||
               resolveTicketType(orchDir, sig.ticket) === "unknown"
+          )
+          // CTL-1191: HRW ownership gate over the SURVIVING roster. On a 2-node
+          // cluster only the node that OWNS a stalled ticket reasons over it, so
+          // the pass no longer double-acts (duplicate escalations / racing
+          // re-dispatch). A dead owner's tickets re-home to a live survivor.
+          // STRICT identity at N=1 (ownsForRecovery → !multiHost short-circuit).
+          .filter((sig) => ownsForRecovery(sig.ticket))
+          // CTL-1191: terminal-state filter (PR #2163 verify flag). Stop reasoning
+          // over a ticket that already reached a terminal Linear state or whose PR
+          // already merged — the pipeline (or a human) finished it; reasoning over
+          // it just burns cooldown + re-posts diagnoses. Cheap-first cached Linear
+          // read; fail-open (a thrown/unreadable read → NOT terminal → kept).
+          // Threads the SAME per-tick TTL state cache + gateway the reclaim/advance
+          // paths use (≤1 Linear read per ticket per tick).
+          .filter(
+            (sig) =>
+              !isTicketTerminalOrMerged({
+                ticket: sig.ticket,
+                signal: sig,
+                cache,
+                fetchState: (id, o = {}) => fetchTicketState(id, { ...o, cache, gateway }),
+              }).terminal
           )
           .map((sig) => ({
             ticket: sig.ticket,
@@ -5045,7 +5145,19 @@ function runTick() {
           // same R12 escalate_human beliefs exactly once.
           // CTL-1065: capture the result so escalated[].evidence can be threaded
           // into executeEscalations as evidenceBySubject.
-          diagResult = processDiagnosticianWakes(diagDb, beliefsRes.tickId, {});
+          // CTL-1191: HRW-gate the diagnostician over the surviving roster — on a
+          // multi-host cluster only the node that OWNS a stalled subject captures
+          // evidence + escalates it, so two nodes don't double-page needs-human.
+          // STRICT no-op at N=1: a single-host roster makes ownedBy an identity
+          // (the lone host owns everything), so ownsSubject is always true.
+          const diagRoster = getClusterHosts();
+          const diagSelf = getHostName();
+          const diagSurvivors =
+            diagRoster.length > 1 ? computeSurvivingRoster(diagRoster) : diagRoster;
+          const ownsSubject = (subject) =>
+            diagRoster.length <= 1 ||
+            ownedBy(String(subject).split("/")[0], diagSurvivors, diagSelf);
+          diagResult = processDiagnosticianWakes(diagDb, beliefsRes.tickId, { ownsSubject });
         }
       } catch (diagErr) {
         try {

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -8771,6 +8771,179 @@ describe("CTL-850 — HRW ownership + claim-on-dispatch (schedulerTick new-work)
   });
 });
 
+// ── CTL-1191: HRW-gate the recovery passes over the surviving roster ──────────
+//
+// The recovery passes (Pass 0u unstuck-sweep, Pass 0r reasoning, diagnostician)
+// classify-then-ACT over the stalled backlog. Before CTL-1191 they had NO
+// ownership gate, so a 2-node cluster double-acted on every stalled ticket. These
+// tests drive Pass 0u (the cleanest injectable seam) to assert:
+//   • N=1 is a STRICT no-op (every candidate acted — would break live mini if not)
+//   • N=2 acts ONLY on the candidates THIS node owns by HRW
+//   • a DEAD owner's candidates fail over to the surviving owner (gate hashes over
+//     the SURVIVING roster, not the raw roster)
+describe("CTL-1191 — recovery passes HRW-gated over the surviving roster (Pass 0u)", () => {
+  const ROSTER = ["mini", "mac-studio"];
+  // CTL-A → mini, CTL-B → mac-studio (deterministic under this roster).
+  const T_MINI = "CTL-A";
+  const T_STUDIO = "CTL-B";
+  // Sanity-anchor the fixtures to the real HRW math so the test can't silently
+  // drift if hrw.mjs changes.
+  expect(ownerForTicket(T_MINI, ROSTER)).toBe("mini");
+  expect(ownerForTicket(T_STUDIO, ROSTER)).toBe("mac-studio");
+
+  // Two stalled candidates with empty evidence → classifyStalledTicket returns
+  // { category:"unknown", action:"escalate" }, so each fires the escalate seam.
+  const twoCandidates = () => [
+    { ticket: T_MINI, phase: "implement", evidence: {} },
+    { ticket: T_STUDIO, phase: "implement", evidence: {} },
+  ];
+  // Recorder for the escalate seam: captures every ticket it was called for.
+  const recordEscalate = () => {
+    const tickets = [];
+    const fn = (c) => tickets.push(c.ticket);
+    fn.tickets = tickets;
+    return fn;
+  };
+  // unstuckSweep opts that force the pass to RUN (intervalMs:0 defeats the
+  // per-run throttle regardless of module-global carryover) with a recorder.
+  const unstuckOpts = (escalate) => ({
+    mode: "enforce",
+    intervalMs: 0,
+    nowMs: () => 9_000_000,
+    collectCandidates: twoCandidates,
+    escalate,
+    emit: () => true, // swallow events
+    postComment: () => {},
+  });
+
+  test("single-host roster is a STRICT no-op: BOTH stalled candidates are acted on", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const escalate = recordEscalate();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch({ code: 0 }),
+      hosts: ["solo"],
+      hostName: "solo",
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 9_000_000,
+      unstuckSweep: unstuckOpts(escalate),
+    });
+    expect(escalate.tickets.sort()).toEqual([T_MINI, T_STUDIO].sort());
+  });
+
+  test("multi-host: only the candidate THIS node owns by HRW is acted on", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const escalate = recordEscalate();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch({ code: 0 }),
+      hosts: ROSTER,
+      hostName: "mini",
+      // Both hosts alive → survivors = full roster. mini owns only CTL-A.
+      recoverySurvivingRoster: ROSTER,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 9_000_000,
+      unstuckSweep: unstuckOpts(escalate),
+    });
+    expect(escalate.tickets).toEqual([T_MINI]); // CTL-B (mac-studio's) filtered out
+  });
+
+  test("dead-owner failover: a dead node's stalled candidate fails over to the survivor", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const escalate = recordEscalate();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch({ code: 0 }),
+      hosts: ROSTER,
+      hostName: "mini",
+      // mac-studio is DEAD → survivors = [mini]. Under [mini], mini owns BOTH
+      // tickets (HRW over a 1-host survivor set is an identity), so the
+      // mac-studio-owned CTL-B fails over to mini instead of stranding.
+      recoverySurvivingRoster: ["mini"],
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 9_000_000,
+      unstuckSweep: unstuckOpts(escalate),
+    });
+    expect(escalate.tickets.sort()).toEqual([T_MINI, T_STUDIO].sort());
+  });
+
+  test("multi-host: the OTHER node acts on the complementary candidate (no ticket stranded)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const escalate = recordEscalate();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch({ code: 0 }),
+      hosts: ROSTER,
+      hostName: "mac-studio", // the other node
+      recoverySurvivingRoster: ROSTER,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 9_000_000,
+      unstuckSweep: unstuckOpts(escalate),
+    });
+    // Across the two nodes (this test + the owned-only test) every candidate is
+    // covered exactly once — mac-studio handles CTL-B.
+    expect(escalate.tickets).toEqual([T_STUDIO]);
+  });
+});
+
+// ── CTL-1191: Pass 0r reasoning — terminal-state filter (PR #2163 verify flag) ──
+//
+// The reasoning pass must NOT reason over a ticket already finished (terminal
+// Linear state / merged PR) — doing so burns cooldown + re-posts diagnoses on a
+// Done ticket. The pass writes a per-ticket marker under .recovery-intents/ for
+// every item it processes (shadow mode), so the marker's presence/absence is the
+// observable. Single-host so the ownership gate is identity (we isolate the
+// terminal filter). A gateway descriptor supplies the Linear state without any
+// network — "Done" ⇒ terminal ⇒ filtered; "In Progress" ⇒ kept.
+describe("CTL-1191 — reasoning pass skips terminal tickets (Pass 0r terminal-state filter)", () => {
+  const recoveryIntentMarker = (ticket) =>
+    join(orchDir, ".recovery-intents", `${ticket}.json`);
+
+  test("a Done ticket is filtered out; an in-flight stalled ticket is processed", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    // Two stalled workers: CTL-DONE (Linear=Done) and CTL-LIVE (Linear=In Progress).
+    writeSignal("CTL-DONE", "implement", "stalled");
+    writeSignal("CTL-LIVE", "implement", "stalled");
+
+    const fresh = new Date().toISOString(); // within the 60s gateway-fresh window
+    const gateway = {
+      getDescriptor: (id) => {
+        if (id === "CTL-DONE") return { state: "Done", removed: false, updatedAt: fresh };
+        if (id === "CTL-LIVE") return { state: "In Progress", removed: false, updatedAt: fresh };
+        return null;
+      },
+    };
+
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch({ code: 0 }),
+      hosts: ["solo"],
+      hostName: "solo",
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 9_000_000,
+      gateway,
+      // No-op the Linear write seam so the stalled-signal terminal sweep doesn't
+      // shell out to `linearis` (unrelated to the filter under test).
+      writeStatus: {
+        applyPhaseStatus: () => {},
+        applyTerminalDone: () => {},
+        applyLabel: () => ({ applied: true }),
+      },
+      recoveryPass: { mode: "shadow" }, // shadow still writes the cooldown marker
+    });
+
+    // The in-flight ticket was reasoned over (marker written); the Done ticket
+    // was filtered BEFORE the pass (no marker — never processed).
+    expect(existsSync(recoveryIntentMarker("CTL-LIVE"))).toBe(true);
+    expect(existsSync(recoveryIntentMarker("CTL-DONE"))).toBe(false);
+  });
+});
+
 // ── CTL-864 remediation: advancement + revive sweeps re-inject the fence token ──
 //
 // The HIGH verify finding: the 5 guarded skills run as LATER phases dispatched by


### PR DESCRIPTION
Makes recovery safe at N=2: each recovery pass (Pass 0r reasoning, Pass 0u unstuck, diagnostician) now only acts on tickets THIS node owns by HRW — computed over the SURVIVING roster so a dead node's stuck work fails over to a live node instead of stranding. Also adds the isTicketTerminalOrMerged filter PR #2163's verify flagged (stop reasoning over Done tickets). STRICT no-op at N=1 (gated on multiHost). New-work dispatch filter unchanged (separate concern). Cross-host soft-CAS claim in the recovery act path = noted follow-up.

## What changed

- `scheduler.mjs` — new `computeSurvivingRoster()` helper (roster minus dead hosts, mirrors `reclaimDeadHostWork`'s survivor math) shared by both gates. `ownsForRecovery(ticket)` predicate threaded into:
  - **Pass 0u unstuck-sweep** — census filtered to owned candidates.
  - **Pass 0r reasoning** — items filtered to owned + non-terminal (new `isTicketTerminalOrMerged` filter, cheap-first cached Linear read, fail-open).
  - **diagnostician** — `processDiagnosticianWakes` now takes an `ownsSubject` predicate (default own-everything → exact no-op for existing callers/tests); `runTick` wires it over the surviving roster.
- All three are a **strict no-op at N=1** (single-host roster makes `ownedBy` an identity / short-circuits before any heartbeat read).
- **Fail-safe**: a thrown heartbeat read or an all-dead roster degrades to the full roster — each node owns only its own HRW slice (never double-acts), only forgoing failover for that tick.

## Tests

- `diagnostician.test.mjs` — +3: default no-op, multi-host owned-vs-skipped, dead-owner failover.
- `scheduler.test.mjs` — +5: Pass 0u N=1 strict no-op (both acted), multi-host owned-only, dead-owner failover, complementary other-node coverage, and the Pass 0r terminal-state filter (Done filtered, in-flight kept).
- Target suites green: `scheduler` + `unstuck-sweep` + `recovery-reasoning` = 629 pass / 0 fail. `diagnostician` 14 pass.
- Full execution-core suite regression-checked: the only failures are pre-existing environmental/timing flakes (hermetic-CATALYST_DIR preload-CWD, host.name os.hostname, CTL-587/CTL-716 timeout flakes, CTL-768) — all reproduce identically on pristine origin/main with zero CTL-1191 changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)