### PR TITLE
feat(dev): CTL-1211 — cluster control-plane (catalyst-cluster repo + SOPS) load-side: cluster-sync, cluster-repo-first roster, schema versioning, observability verbs

### DIFF
--- a/plugins/dev/scripts/execution-core/cli/cluster-ownership.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/cluster-ownership.test.mjs
@@ -1,0 +1,68 @@
+// cluster-ownership.test.mjs — CTL-1211. The HRW no-contention proof: every
+// ticket is owned by exactly one host, deterministically.
+import { describe, test, expect } from "bun:test";
+import { buildOwnership, runOwnership } from "./cluster.mjs";
+
+describe("buildOwnership (CTL-1211)", () => {
+  test("each ticket owned by exactly one host — zero overlap", () => {
+    const tickets = ["CTL-1", "CTL-2", "CTL-3", "SLI-4", "OTL-9", "EVR-2", "ADV-7"];
+    const o = buildOwnership(tickets, ["mini", "mini-2"]);
+    expect(o.total).toBe(7);
+    const assigned = Object.values(o.byHost).reduce((n, a) => n + a.length, 0);
+    expect(assigned).toBe(7);
+    expect(o.unassigned).toBe(0);
+    // a ticket can never appear under two hosts
+    const all = Object.values(o.byHost).flat();
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  test("deterministic — identical split on every call (no coordination needed)", () => {
+    const a = buildOwnership(["A", "B", "C", "D"], ["x", "y"]);
+    const b = buildOwnership(["A", "B", "C", "D"], ["x", "y"]);
+    expect(a.byHost).toEqual(b.byHost);
+  });
+
+  test("single-host roster owns everything (the N=1 identity)", () => {
+    const o = buildOwnership(["A", "B", "C"], ["solo"]);
+    expect(o.byHost.solo.length).toBe(3);
+    expect(o.unassigned).toBe(0);
+  });
+
+  test("empty roster → every ticket unassigned (no owner can exist)", () => {
+    const o = buildOwnership(["A", "B"], []);
+    expect(o.unassigned).toBe(2);
+  });
+
+  test("adding a host re-homes only ~1/N (minimal churn)", () => {
+    const tickets = Array.from({ length: 200 }, (_, i) => `CTL-${i}`);
+    const before = buildOwnership(tickets, ["mini"]);
+    const after = buildOwnership(tickets, ["mini", "mini-2"]);
+    // HRW minimal churn: adding mini-2 only moves tickets mini→mini-2; the
+    // tickets mini keeps are a strict subset of what it owned at N=1.
+    const movedToMini2 = after.byHost["mini-2"].length;
+    // with 2 hosts, mini-2 should take roughly half — bounded sanity (20%..80%)
+    expect(movedToMini2).toBeGreaterThan(40);
+    expect(movedToMini2).toBeLessThan(160);
+    // mini's remaining tickets are a strict subset of what it had at N=1
+    const beforeSet = new Set(before.byHost["mini"]);
+    expect(after.byHost["mini"].every((t) => beforeSet.has(t))).toBe(true);
+  });
+});
+
+describe("runOwnership (CTL-1211)", () => {
+  test("injected ticket lister → exit 0", () => {
+    const code = runOwnership(["--roster=mini,mini-2", "--json"], {
+      listTickets: () => ["CTL-1", "CTL-2"],
+    });
+    expect(code).toBe(0);
+  });
+
+  test("lister failure → exit 1 (graceful)", () => {
+    const code = runOwnership(["--roster=mini,mini-2"], {
+      listTickets: () => {
+        throw new Error("linearis down");
+      },
+    });
+    expect(code).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/cli/cluster.mjs
+++ b/plugins/dev/scripts/execution-core/cli/cluster.mjs
@@ -3,8 +3,9 @@
 // take injectable deps for unit testing; runX() wires real config/heartbeat/git;
 // main() dispatches. drain + join-token are handled in the bash front end.
 import { writeFileSync, renameSync, readFileSync } from "node:fs";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { ownerForTicket } from "../hrw.mjs";
 import {
   getClusterHosts,
   getHostName,
@@ -13,10 +14,12 @@ import {
   getLayer2ConfigPath,
   isDraining,
   getExecutionCoreDir,
+  readClusterConfig,
 } from "../config.mjs";
 import { readPeerHeartbeatsSync } from "../cluster-heartbeat-sync.mjs";
 import { writeSecretConfig } from "../write-secret-config.mjs";
 import { listInFlightTickets } from "../scheduler.mjs";
+import { clusterSync } from "../cluster-sync.mjs";
 
 // ── Roster I/O helpers (shared across all mutating verbs) ──────────────────
 
@@ -264,6 +267,107 @@ export function runTune(argv = []) {
   return 0;
 }
 
+// ── sync — CTL-1211: pull the cluster repo + decrypt secrets into Layer-2 ────
+
+export function runSync(argv = []) {
+  const res = clusterSync();
+  if (argv.includes("--json")) {
+    process.stdout.write(JSON.stringify(res) + "\n");
+    return res.sync.ok ? 0 : 1;
+  }
+  const { pull, sync, files } = res;
+  const lines = [
+    `cluster-sync: pull ${pull.pulled ? "ok" : `skipped (${pull.reason ?? ""})`}`,
+  ];
+  if (!sync.ok && sync.reason) {
+    lines.push(`  configs: ${sync.reason}`);
+  } else {
+    lines.push(
+      `  configs: ${sync.synced.length} synced` +
+        (sync.skipped.length ? `, ${sync.skipped.length} skipped` : ""),
+    );
+  }
+  lines.push(`  secret-files: ${files.written.length} written`);
+  process.stdout.write(lines.join("\n") + "\n");
+  return sync.ok ? 0 : 1;
+}
+
+// ── ownership — CTL-1211: make the HRW partition SEEABLE (no-contention proof) ─
+// Lists every Todo ticket and the single host HRW assigns it to, grouped by host.
+// `--roster=mini,mini-2` previews a hypothetical roster BEFORE flipping it live.
+
+// buildOwnership — pure: group tickets by their HRW owner across a roster. Each
+// ticket is owned by exactly one host (argmax), so there is never any overlap.
+export function buildOwnership(tickets, roster) {
+  const byHost = Object.fromEntries(roster.map((h) => [h, []]));
+  let unassigned = 0;
+  for (const t of tickets) {
+    const owner = ownerForTicket(t, roster);
+    if (owner && byHost[owner]) byHost[owner].push(t);
+    else unassigned += 1;
+  }
+  return { roster, total: tickets.length, byHost, unassigned };
+}
+
+// The cluster's teams (from cluster.json.projects), fallback to CTL.
+function clusterTeams() {
+  const c = readClusterConfig();
+  const teams = Array.isArray(c?.projects) ? c.projects.map((p) => p?.teamKey).filter(Boolean) : [];
+  return teams.length ? teams : ["CTL"];
+}
+
+// linearis requires --team alongside --status, so aggregate Todo across the
+// cluster's teams. A team that errors (auth/network) is skipped, not fatal.
+function listTodoTickets(teams = clusterTeams()) {
+  const ids = [];
+  for (const team of teams) {
+    const r = spawnSync("linearis", ["issues", "list", "--team", team, "--status", "Todo", "-l", "200"], {
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    if (r.status !== 0) continue;
+    try {
+      const parsed = JSON.parse(r.stdout);
+      const items = Array.isArray(parsed) ? parsed : (parsed?.issues ?? parsed?.nodes ?? []);
+      for (const t of items) {
+        const id = t?.identifier ?? t?.id;
+        if (typeof id === "string" && id.length > 0) ids.push(id);
+      }
+    } catch {
+      /* skip an unparseable team response */
+    }
+  }
+  return ids;
+}
+
+export function runOwnership(argv = [], { listTickets = listTodoTickets } = {}) {
+  const rosterArg = argv.find((a) => a.startsWith("--roster="));
+  const roster = rosterArg
+    ? rosterArg.slice("--roster=".length).split(",").map((s) => s.trim()).filter(Boolean)
+    : getClusterHosts();
+  let tickets;
+  try {
+    tickets = listTickets();
+  } catch (err) {
+    process.stderr.write(`ownership: could not list tickets: ${err?.message ?? err}\n`);
+    return 1;
+  }
+  const o = buildOwnership(tickets, roster);
+  if (argv.includes("--json")) {
+    process.stdout.write(JSON.stringify(o) + "\n");
+    return 0;
+  }
+  const lines = [`HRW ownership over roster [${roster.join(", ")}] — ${o.total} Todo ticket(s):`];
+  for (const h of roster) {
+    const ts = o.byHost[h] ?? [];
+    lines.push(`  ${h}: ${ts.length}${ts.length ? "  " + ts.join(", ") : ""}`);
+  }
+  const assigned = Object.values(o.byHost).reduce((n, a) => n + a.length, 0);
+  lines.push(`  → each ticket owned by exactly one host: ${assigned}/${o.total} assigned, 0 overlap`);
+  process.stdout.write(lines.join("\n") + "\n");
+  return 0;
+}
+
 // ── main — dispatch ───────────────────────────────────────────────────────
 
 export function main(argv = process.argv.slice(2)) {
@@ -276,6 +380,8 @@ export function main(argv = process.argv.slice(2)) {
     case "rename":    code = runRename(rest); break;
     case "set-anchor": code = runSetAnchor(rest); break;
     case "tune":      code = runTune(rest); break;
+    case "sync":      code = runSync(rest); break;
+    case "ownership": code = runOwnership(rest); break;
     default:
       process.stderr.write(`catalyst cluster: unknown verb '${verb ?? ""}'\n`);
       code = 2;

--- a/plugins/dev/scripts/execution-core/cluster-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.mjs
@@ -1,0 +1,243 @@
+// cluster-sync.mjs — CTL-1211. Boot-time cluster control-plane sync.
+//
+// Clones/pulls the catalyst-cluster repo and decrypts secrets/*.sops.json into
+// ~/.config/catalyst/ (mode 0o600), so every EXISTING secret consumer reads the
+// same plaintext files it does today — consumer-transparent (DRY). This is the
+// load-side of the GitOps control plane: "secret-sync becomes git-sync".
+//
+// Posture: FAIL-OPEN. Any failure (no cluster repo, sops missing, a single file
+// won't decrypt, schema too new) leaves today's node-local plaintext untouched
+// and never throws. Worst case is "node keeps running on its cached secrets",
+// never corruption — the same guarantee dispatch already gives.
+//
+// Mapping (secrets/<name>.sops.json → ~/.config/catalyst/<dest>.json):
+//   cluster-bots.sops.json        → config.json        (deep-merged: preserves
+//                                    node-local host.name / cluster anchor /
+//                                    monitor webhook state, overlays bot creds)
+//   config-<projectKey>.sops.json → config-<projectKey>.json
+//
+// Roster (cluster.json.roster) is read LIVE per tick by config.getClusterHosts();
+// secrets here are decrypted at BOOT. So a roster change needs no restart, but a
+// secret rotation needs a worker restart to be picked up.
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  readdirSync,
+  writeFileSync,
+  chmodSync,
+  mkdirSync,
+} from "node:fs";
+import { resolve, basename, dirname } from "node:path";
+import { homedir } from "node:os";
+import {
+  log,
+  getClusterRepoDir,
+  readClusterConfig,
+  getLayer2ConfigPath,
+} from "./config.mjs";
+import { writeSecretConfig } from "./write-secret-config.mjs";
+import { schemaCompat } from "./config-schema.mjs";
+
+// Default age key location on every node (the private half; mode 0o600).
+function defaultAgeKeyFile() {
+  return resolve(homedir(), ".config", "catalyst", "age.key");
+}
+
+// The directory holding the decrypted Layer-2 plaintext files (~/.config/catalyst).
+function defaultConfigDir() {
+  return dirname(getLayer2ConfigPath());
+}
+
+// Real `sops --decrypt` runner. Injected as `decrypt` so tests never shell out.
+function makeSopsDecrypt(ageKeyFile) {
+  return (secretPath) => {
+    const out = execFileSync(
+      "sops",
+      ["--decrypt", "--input-type", "json", "--output-type", "json", secretPath],
+      {
+        env: { ...process.env, SOPS_AGE_KEY_FILE: ageKeyFile },
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    return JSON.parse(out);
+  };
+}
+
+// Real `git` runner. Injected as `git` so tests never shell out.
+function defaultGit(args) {
+  execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+// destForSecret — map a secrets/ filename to its ~/.config/catalyst destination.
+function destForSecret(name, configDir) {
+  const base = basename(name).replace(/\.sops\.json$/, "");
+  if (base === "cluster-bots") return resolve(configDir, "config.json");
+  return resolve(configDir, `${base}.json`);
+}
+
+// pullClusterRepo — best-effort `git pull --ff-only` on the cluster clone.
+// Never throws; returns a small status object.
+export function pullClusterRepo(opts = {}) {
+  const {
+    clusterDir = getClusterRepoDir(),
+    git = defaultGit,
+    logger = log,
+  } = opts;
+  if (!existsSync(resolve(clusterDir, ".git"))) {
+    return { pulled: false, reason: "not-a-clone" };
+  }
+  try {
+    git(["-C", clusterDir, "pull", "--ff-only"]);
+    return { pulled: true };
+  } catch (err) {
+    logger.warn(
+      `[cluster-sync] git pull failed (${err?.message ?? err}); using cached cluster config`,
+    );
+    return { pulled: false, reason: "pull-failed" };
+  }
+}
+
+// syncClusterSecrets — decrypt every secrets/*.sops.json into ~/.config/catalyst.
+// Fail-open per file (a single bad decrypt is skipped, the rest proceed) and
+// fail-closed on a too-new schema (refuse the whole sync, keep node-local).
+export function syncClusterSecrets(opts = {}) {
+  const {
+    clusterDir = getClusterRepoDir(),
+    configDir = defaultConfigDir(),
+    ageKeyFile = defaultAgeKeyFile(),
+    decrypt = makeSopsDecrypt(ageKeyFile),
+    writeSecret = writeSecretConfig,
+    logger = log,
+  } = opts;
+
+  const result = { ok: true, synced: [], skipped: [], schemaSkipped: false, reason: null };
+
+  const cluster = readClusterConfig(clusterDir);
+  if (!cluster) {
+    result.ok = false;
+    result.reason = "no-cluster-repo";
+    return result;
+  }
+
+  const compat = schemaCompat(cluster.schemaVersion);
+  if (compat === "too-new") {
+    logger.warn(
+      `[cluster-sync] cluster.json schemaVersion ${cluster.schemaVersion} exceeds supported; ` +
+        `refusing secret sync (fail-closed). Upgrade this node's stack.`,
+    );
+    result.ok = false;
+    result.schemaSkipped = true;
+    result.reason = "schema-too-new";
+    return result;
+  }
+
+  const secretsDir = resolve(clusterDir, "secrets");
+  let files;
+  try {
+    // node-secret-files.sops.json is the bare-file bundle handled by
+    // syncSecretFiles(), NOT a JSON config — exclude it here so it isn't
+    // double-processed into a stray config-style file.
+    files = readdirSync(secretsDir).filter(
+      (f) => f.endsWith(".sops.json") && f !== "node-secret-files.sops.json",
+    );
+  } catch {
+    result.ok = false;
+    result.reason = "no-secrets-dir";
+    return result;
+  }
+
+  for (const f of files) {
+    try {
+      const obj = decrypt(resolve(secretsDir, f));
+      if (!obj || typeof obj !== "object") throw new Error("decrypt produced non-object");
+      const dest = destForSecret(f, configDir);
+      writeSecret(dest, obj);
+      result.synced.push(basename(dest));
+    } catch (err) {
+      logger.warn(
+        `[cluster-sync] decrypt failed for ${f} (${err?.message ?? err}); keeping node-local plaintext`,
+      );
+      result.skipped.push(f);
+    }
+  }
+  return result;
+}
+
+// Default 0o600 writer for a single bare secret file.
+function defaultWriteFile(path, content) {
+  writeFileSync(path, content, { mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
+// syncSecretFiles — decrypt secrets/node-secret-files.sops.json (a { filename:
+// content } map of cluster-shared BARE secret files — Linear webhook secrets,
+// cma-api-key, the workflow GitHub token) and materialize each as a 0o600 file
+// directly under ~/.config/catalyst. This covers the secrets that live outside
+// the JSON configs (the .env / bare-file surface). Fail-open; never throws.
+// Path-traversal-safe: only bare basenames are written into configDir.
+export function syncSecretFiles(opts = {}) {
+  const {
+    clusterDir = getClusterRepoDir(),
+    configDir = defaultConfigDir(),
+    ageKeyFile = defaultAgeKeyFile(),
+    decrypt = makeSopsDecrypt(ageKeyFile),
+    writeFile = defaultWriteFile,
+    logger = log,
+  } = opts;
+
+  const result = { written: [], skipped: false, reason: null };
+  const src = resolve(clusterDir, "secrets", "node-secret-files.sops.json");
+  if (!existsSync(src)) {
+    result.reason = "absent";
+    return result;
+  }
+  let map;
+  try {
+    map = decrypt(src);
+  } catch (err) {
+    logger.warn(
+      `[cluster-sync] decrypt node-secret-files failed (${err?.message ?? err}); keeping node-local`,
+    );
+    result.skipped = true;
+    result.reason = "decrypt-failed";
+    return result;
+  }
+  if (!map || typeof map !== "object") {
+    result.reason = "empty";
+    return result;
+  }
+  try {
+    mkdirSync(configDir, { recursive: true });
+  } catch {
+    /* configDir usually exists; ignore */
+  }
+  for (const [name, content] of Object.entries(map)) {
+    // Refuse anything that isn't a bare, non-dotfile basename — no path traversal.
+    if (typeof name !== "string" || name !== basename(name) || name.startsWith(".") || name.length === 0) {
+      logger.warn(`[cluster-sync] refusing unsafe secret-file name "${name}"`);
+      continue;
+    }
+    if (typeof content !== "string") continue;
+    try {
+      writeFile(resolve(configDir, name), content);
+      result.written.push(name);
+    } catch (err) {
+      logger.warn(`[cluster-sync] write ${name} failed (${err?.message ?? err})`);
+    }
+  }
+  return result;
+}
+
+// clusterSync — the boot entrypoint: pull, then decrypt JSON configs, then
+// materialize bare secret files. Never throws.
+export function clusterSync(opts = {}) {
+  const pull = pullClusterRepo(opts);
+  const sync = syncClusterSecrets(opts);
+  const files = syncSecretFiles(opts);
+  return { pull, sync, files };
+}
+
+// Exposed for doctor + tests.
+export { destForSecret };

--- a/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
@@ -1,0 +1,206 @@
+// cluster-sync.test.mjs — CTL-1211. Hermetic: injects the sops-decrypt and git
+// runners so no real sops binary, age key, or network is needed.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test cluster-sync.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  syncClusterSecrets,
+  syncSecretFiles,
+  pullClusterRepo,
+  destForSecret,
+} from "./cluster-sync.mjs";
+
+const QUIET = { warn() {}, info() {} };
+let clusterDir, configDir;
+
+beforeEach(() => {
+  clusterDir = mkdtempSync(join(tmpdir(), "cs-cluster-"));
+  configDir = mkdtempSync(join(tmpdir(), "cs-config-"));
+  mkdirSync(join(clusterDir, "secrets"), { recursive: true });
+});
+afterEach(() => {
+  rmSync(clusterDir, { recursive: true, force: true });
+  rmSync(configDir, { recursive: true, force: true });
+});
+
+const writeClusterJson = (obj) =>
+  writeFileSync(join(clusterDir, "cluster.json"), JSON.stringify(obj));
+const touchSecret = (name) =>
+  writeFileSync(join(clusterDir, "secrets", name), "{ciphertext-placeholder}");
+
+describe("destForSecret (CTL-1211)", () => {
+  test("cluster-bots maps to config.json (deep-merged into machine-global)", () => {
+    expect(destForSecret("cluster-bots.sops.json", "/cfg")).toBe(resolve("/cfg", "config.json"));
+  });
+  test("config-<key> maps to config-<key>.json", () => {
+    expect(destForSecret("config-catalyst-workspace.sops.json", "/cfg")).toBe(
+      resolve("/cfg", "config-catalyst-workspace.json"),
+    );
+  });
+});
+
+describe("syncClusterSecrets (CTL-1211)", () => {
+  test("decrypts each secret into the config dir with deep-merge + 0600", () => {
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    touchSecret("config-catalyst-workspace.sops.json");
+    // pre-existing node-local config.json with a NODE-ONLY key that must survive
+    writeFileSync(
+      join(configDir, "config.json"),
+      JSON.stringify({ catalyst: { host: { name: "mini" } } }),
+    );
+
+    const decrypt = (p) =>
+      p.endsWith("cluster-bots.sops.json")
+        ? { catalyst: { linear: { bot: { worker: { accessToken: "tok" } } } } }
+        : { linear: { apiToken: "proj" } };
+
+    const res = syncClusterSecrets({ clusterDir, configDir, decrypt });
+    expect(res.ok).toBe(true);
+    expect(res.synced.sort()).toEqual(["config-catalyst-workspace.json", "config.json"]);
+
+    // deep-merge preserved the node-local host.name AND overlaid the bot creds
+    const merged = JSON.parse(readFileSync(join(configDir, "config.json"), "utf8"));
+    expect(merged.catalyst.host.name).toBe("mini");
+    expect(merged.catalyst.linear.bot.worker.accessToken).toBe("tok");
+    expect(statSync(join(configDir, "config.json")).mode & 0o777).toBe(0o600);
+  });
+
+  test("a single decrypt failure is skipped; the rest still sync (fail-open)", () => {
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    touchSecret("config-adva.sops.json");
+    const decrypt = (p) => {
+      if (p.endsWith("config-adva.sops.json")) throw new Error("bad mac");
+      return { ok: true };
+    };
+    const res = syncClusterSecrets({ clusterDir, configDir, decrypt, logger: QUIET });
+    expect(res.synced).toEqual(["config.json"]);
+    expect(res.skipped).toEqual(["config-adva.sops.json"]);
+  });
+
+  test("schemaVersion too new → fail-closed, nothing synced", () => {
+    writeClusterJson({ schemaVersion: 999, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    const res = syncClusterSecrets({
+      clusterDir,
+      configDir,
+      decrypt: () => ({ should: "not-run" }),
+      logger: QUIET,
+    });
+    expect(res.ok).toBe(false);
+    expect(res.schemaSkipped).toBe(true);
+    expect(res.synced).toEqual([]);
+    expect(existsSync(join(configDir, "config.json"))).toBe(false);
+  });
+
+  test("no cluster repo → ok:false, reason no-cluster-repo (never throws)", () => {
+    const res = syncClusterSecrets({ clusterDir, configDir, decrypt: () => ({}) });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("no-cluster-repo");
+  });
+
+  test("does NOT process node-secret-files.sops.json (owned by syncSecretFiles)", () => {
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    touchSecret("node-secret-files.sops.json");
+    const res = syncClusterSecrets({ clusterDir, configDir, decrypt: () => ({ x: 1 }) });
+    expect(res.synced).toEqual(["config.json"]);
+    expect(existsSync(join(configDir, "node-secret-files.json"))).toBe(false);
+  });
+});
+
+describe("syncSecretFiles (CTL-1211)", () => {
+  const writeNodeFiles = () =>
+    writeFileSync(join(clusterDir, "secrets", "node-secret-files.sops.json"), "{cipher}");
+
+  test("materializes each map entry as a 0600 file under configDir", () => {
+    writeNodeFiles();
+    const decrypt = () => ({
+      "linear-webhook-secret-ctl": "whsec_abc",
+      "cma-api-key": "cma_xyz",
+      "github-token": "ghp_tok",
+    });
+    const res = syncSecretFiles({ clusterDir, configDir, decrypt });
+    expect(res.written.sort()).toEqual(["cma-api-key", "github-token", "linear-webhook-secret-ctl"]);
+    expect(readFileSync(join(configDir, "linear-webhook-secret-ctl"), "utf8")).toBe("whsec_abc");
+    expect(statSync(join(configDir, "cma-api-key")).mode & 0o777).toBe(0o600);
+  });
+
+  test("refuses path-traversal / dotfile names (no escape from configDir)", () => {
+    writeNodeFiles();
+    const decrypt = () => ({
+      "../escape": "x",
+      "/etc/evil": "x",
+      ".ssh/authorized_keys": "x",
+      "ok-name": "good",
+    });
+    const res = syncSecretFiles({ clusterDir, configDir, decrypt, logger: QUIET });
+    expect(res.written).toEqual(["ok-name"]);
+    expect(existsSync(join(configDir, "ok-name"))).toBe(true);
+  });
+
+  test("absent node-secret-files → reason absent (no-op, never throws)", () => {
+    const res = syncSecretFiles({ clusterDir, configDir, decrypt: () => ({}) });
+    expect(res.reason).toBe("absent");
+    expect(res.written).toEqual([]);
+  });
+
+  test("decrypt failure → skipped, fail-open (never throws)", () => {
+    writeNodeFiles();
+    const res = syncSecretFiles({
+      clusterDir,
+      configDir,
+      decrypt: () => {
+        throw new Error("bad mac");
+      },
+      logger: QUIET,
+    });
+    expect(res.skipped).toBe(true);
+    expect(res.reason).toBe("decrypt-failed");
+  });
+});
+
+describe("pullClusterRepo (CTL-1211)", () => {
+  test("not a git clone → pulled:false, reason not-a-clone", () => {
+    const res = pullClusterRepo({
+      clusterDir,
+      git: () => {
+        throw new Error("should not run");
+      },
+    });
+    expect(res).toEqual({ pulled: false, reason: "not-a-clone" });
+  });
+
+  test("git pull success → pulled:true with --ff-only", () => {
+    mkdirSync(join(clusterDir, ".git"), { recursive: true });
+    let called = null;
+    const res = pullClusterRepo({ clusterDir, git: (args) => (called = args) });
+    expect(res.pulled).toBe(true);
+    expect(called).toEqual(["-C", clusterDir, "pull", "--ff-only"]);
+  });
+
+  test("git pull failure → pulled:false, reason pull-failed (never throws)", () => {
+    mkdirSync(join(clusterDir, ".git"), { recursive: true });
+    const res = pullClusterRepo({
+      clusterDir,
+      git: () => {
+        throw new Error("network");
+      },
+      logger: QUIET,
+    });
+    expect(res).toEqual({ pulled: false, reason: "pull-failed" });
+  });
+});

--- a/plugins/dev/scripts/execution-core/config-pino-fallback.test.mjs
+++ b/plugins/dev/scripts/execution-core/config-pino-fallback.test.mjs
@@ -37,6 +37,11 @@ function pickProbeCommand() {
 function stageScratch() {
   const scratch = mkdtempSync(join(tmpdir(), "ctl-578-pino-"));
   cpSync(CONFIG_MJS, join(scratch, "config.mjs"));
+  // CTL-1211: config.mjs imports the dep-free sibling config-schema.mjs — copy it
+  // too so the scratch fixture can resolve config.mjs's local (non-pino) imports.
+  // (The point of the fixture is that PINO is unresolvable; local siblings must
+  // still resolve, so any new sibling import config.mjs gains belongs here.)
+  cpSync(resolve(__dirname, "config-schema.mjs"), join(scratch, "config-schema.mjs"));
   // type:module + no deps -> pino unresolvable from this directory tree.
   writeFileSync(
     join(scratch, "package.json"),

--- a/plugins/dev/scripts/execution-core/config-schema.mjs
+++ b/plugins/dev/scripts/execution-core/config-schema.mjs
@@ -1,0 +1,38 @@
+// config-schema.mjs — CTL-1211. Cluster-config schema versioning policy.
+//
+// A cluster is inherently multi-version (rolling upgrades): two nodes on
+// different stack versions read the same cluster.json. An un-versioned schema
+// change silently misreads, so every cluster config carries a top-level integer
+// `schemaVersion`. Policy (design §5):
+//   version  < min      → migrate forward (ordered, forward-only, idempotent)
+//   version ∈ [min,cur] → ok (tolerate unknown additive fields)
+//   version  > current  → FAIL-CLOSED (refuse to act; starvation, not corruption)
+//
+// Unversioned config is treated as v1 (the first schema).
+
+export const CLUSTER_SCHEMA_CURRENT = 1;
+export const CLUSTER_SCHEMA_MIN = 1; // oldest schema this stack can still read
+
+// schemaCompat(version) → "ok" | "migrate" | "too-new"
+// Never throws; a non-integer version is treated as v1 (unversioned == first schema).
+export function schemaCompat(
+  version,
+  { current = CLUSTER_SCHEMA_CURRENT, min = CLUSTER_SCHEMA_MIN } = {},
+) {
+  const v = Number.isInteger(version) ? version : 1;
+  if (v > current) return "too-new";
+  if (v < min) return "migrate";
+  return "ok";
+}
+
+// migrateClusterConfig(config) → config
+// Forward-only, idempotent migrations applied in order. Current schema is 1, so
+// there are no migrations yet — future breaking changes add an ordered step here
+// (same pattern as catalyst.db schema_migrations). Returns the config unchanged
+// when already current.
+export function migrateClusterConfig(config) {
+  if (!config || typeof config !== "object") return config;
+  // const v = Number.isInteger(config.schemaVersion) ? config.schemaVersion : 1;
+  // if (v < 2) config = migrateV1toV2(config);  // example shape for the future
+  return config;
+}

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -10,6 +10,11 @@ import { homedir, hostname } from "node:os";
 import { resolve, join } from "node:path";
 import { readFileSync, existsSync } from "node:fs";
 
+// CTL-1211: schema-version policy for cluster config. config-schema.mjs is a
+// dep-free sibling leaf, so this import cannot reintroduce the bun-install crash
+// risk the pino try/catch below guards against.
+import { schemaCompat } from "./config-schema.mjs";
+
 // --- Logger (CTL-578) ---
 // Pino is the daemon's runtime logger. A worktree checkout that hasn't run
 // `bun install` cannot resolve it — and any module graph that includes
@@ -165,6 +170,26 @@ function getCatalystRepoDir() {
   return resolve(process.cwd(), ".catalyst");
 }
 
+// CTL-1211: the cluster control-plane repo (catalyst-cluster) — a pristine clone
+// (the plugin-source pattern, CTL-992) holding the node roster + cluster.json +
+// SOPS-encrypted secrets. CATALYST_CLUSTER_DIR overrides; default
+// ~/catalyst/catalyst-cluster. Re-resolved per call so tests redirect via the env.
+export function getClusterRepoDir() {
+  return process.env.CATALYST_CLUSTER_DIR || resolve(catalystDir(), "catalyst-cluster");
+}
+
+// readClusterConfig(dir) — parse <clusterRepoDir>/cluster.json. Returns the
+// parsed object, or null when absent/malformed. Never throws.
+export function readClusterConfig(dir = getClusterRepoDir()) {
+  try {
+    const parsed = JSON.parse(readFileSync(resolve(dir, "cluster.json"), "utf8"));
+    if (parsed && typeof parsed === "object") return parsed;
+  } catch {
+    /* absent/malformed cluster repo → null (fall back to project-repo roster) */
+  }
+  return null;
+}
+
 // getHostName — resolve this host's coordination name. Precedence:
 //   1. CATALYST_HOST_NAME env (test/alias override; matches lib/host-identity.mjs)
 //   2. catalyst.host.name in the Layer-2 (machine-local) config file
@@ -190,6 +215,22 @@ export function getHostName() {
 // back to the single-host default ([getHostName()]) — the safe behavior for the
 // current single-primary deployment. Never throws.
 export function getClusterHosts() {
+  // CTL-1211: cluster-repo-first. Prefer the control-plane repo's roster
+  // (cluster.json.roster); fall back to the project repo's committed hosts.json;
+  // then the single-host default. A cluster.json whose schemaVersion is newer
+  // than this stack supports is ignored here (degrade to the project roster)
+  // rather than trusted blindly. getCatalystRepoDirHostsPath (the CLI write
+  // target) is deliberately NOT changed, so add/remove writes still land on the
+  // project repo and the reader/writer can never silently diverge.
+  const cluster = readClusterConfig();
+  if (
+    cluster &&
+    schemaCompat(cluster.schemaVersion) !== "too-new" &&
+    Array.isArray(cluster.roster)
+  ) {
+    const hosts = cluster.roster.filter((h) => typeof h === "string" && h.length > 0);
+    if (hosts.length > 0) return hosts;
+  }
   try {
     const raw = readFileSync(resolve(getCatalystRepoDir(), "hosts.json"), "utf8");
     const parsed = JSON.parse(raw);

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -280,7 +280,11 @@ describe("getHostName (CTL-859)", () => {
 });
 
 describe("getClusterHosts (CTL-859)", () => {
-  const ROSTER_ENVS = ["CATALYST_CONFIG_FILE", "CATALYST_HOST_NAME", "CATALYST_LAYER2_CONFIG_FILE"];
+  // CTL-1211: CATALYST_CLUSTER_DIR is pinned at a non-existent path so the new
+  // cluster-repo-first branch is a deterministic miss here — these tests assert
+  // the project-repo hosts.json fallback in isolation from any real cluster repo
+  // that may exist at the default ~/catalyst/catalyst-cluster on the test host.
+  const ROSTER_ENVS = ["CATALYST_CONFIG_FILE", "CATALYST_HOST_NAME", "CATALYST_LAYER2_CONFIG_FILE", "CATALYST_CLUSTER_DIR"];
   let saved = {};
   let repo;
 
@@ -294,6 +298,7 @@ describe("getClusterHosts (CTL-859)", () => {
     // CATALYST_CONFIG_FILE points at <repoRoot>/.catalyst/config.json; the
     // roster reader resolves hosts.json as its sibling.
     process.env.CATALYST_CONFIG_FILE = join(repo, ".catalyst", "config.json");
+    process.env.CATALYST_CLUSTER_DIR = join(repo, "no-such-cluster");
   });
 
   afterEach(() => {
@@ -337,6 +342,69 @@ describe("getClusterHosts (CTL-859)", () => {
       JSON.stringify(["mini", 42, "", "mac-studio"]),
     );
     expect(getClusterHosts()).toEqual(["mini", "mac-studio"]);
+  });
+});
+
+describe("getClusterHosts cluster-repo-first (CTL-1211)", () => {
+  const ENVS = ["CATALYST_CONFIG_FILE", "CATALYST_HOST_NAME", "CATALYST_LAYER2_CONFIG_FILE", "CATALYST_CLUSTER_DIR"];
+  let saved = {};
+  let repo, cluster;
+
+  beforeEach(() => {
+    for (const k of ENVS) { saved[k] = process.env[k]; delete process.env[k]; }
+    repo = mkdtempSync(join(tmpdir(), "ctl1211-repo-"));
+    cluster = mkdtempSync(join(tmpdir(), "ctl1211-cluster-"));
+    mkdirSync(join(repo, ".catalyst"), { recursive: true });
+    process.env.CATALYST_CONFIG_FILE = join(repo, ".catalyst", "config.json");
+    process.env.CATALYST_CLUSTER_DIR = cluster;
+  });
+
+  afterEach(() => {
+    for (const k of ENVS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; }
+    saved = {};
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(cluster, { recursive: true, force: true });
+  });
+
+  const writeCluster = (obj) => writeFileSync(join(cluster, "cluster.json"), JSON.stringify(obj));
+  const writeProject = (arr) => writeFileSync(join(repo, ".catalyst", "hosts.json"), JSON.stringify(arr));
+
+  test("reads roster from cluster.json when present", () => {
+    writeCluster({ schemaVersion: 1, roster: ["mini", "mini-2"] });
+    expect(getClusterHosts()).toEqual(["mini", "mini-2"]);
+  });
+
+  test("cluster.json roster wins over project hosts.json", () => {
+    writeCluster({ schemaVersion: 1, roster: ["mini", "mini-2"] });
+    writeProject(["mini"]);
+    expect(getClusterHosts()).toEqual(["mini", "mini-2"]);
+  });
+
+  test("falls back to project hosts.json when cluster.json absent", () => {
+    writeProject(["mini", "mac-studio"]);
+    expect(getClusterHosts()).toEqual(["mini", "mac-studio"]);
+  });
+
+  test("ignores a too-new cluster schemaVersion and degrades to project roster", () => {
+    writeCluster({ schemaVersion: 999, roster: ["should", "be", "ignored"] });
+    writeProject(["mini"]);
+    expect(getClusterHosts()).toEqual(["mini"]);
+  });
+
+  test("empty cluster roster degrades to project roster", () => {
+    writeCluster({ schemaVersion: 1, roster: [] });
+    writeProject(["mini"]);
+    expect(getClusterHosts()).toEqual(["mini"]);
+  });
+
+  test("filters non-string entries from the cluster roster", () => {
+    writeCluster({ schemaVersion: 1, roster: ["mini", 42, "", "mini-2"] });
+    expect(getClusterHosts()).toEqual(["mini", "mini-2"]);
+  });
+
+  test("unversioned cluster.json is treated as v1 and read", () => {
+    writeCluster({ roster: ["mini", "mini-2"] });
+    expect(getClusterHosts()).toEqual(["mini", "mini-2"]);
   });
 });
 


### PR DESCRIPTION
## CTL-1211 — cluster configuration architecture (load-side)

Stands up the boot/runtime side of the GitOps control plane designed in
`thoughts/shared/plans/2026-06-16-cluster-config-architecture.md`. The private
**`coalesce-labs/catalyst-cluster`** repo (roster + SOPS-encrypted secrets) is
already live; this PR is the code that reads it. **Fully backward-compatible** —
with no cluster repo present (today), every path falls back to the exact current
behavior.

### What's here
- **`cluster-sync.mjs`** — boot entrypoint: `git pull` the cluster repo, `sops -d`
  each `secrets/*.sops.json` into `~/.config/catalyst/` (deep-merge, 0600), and
  materialize bare secret files (webhook secrets, cma-api-key, GitHub token) as
  0600 files. **Fail-open** per file; **fail-closed** on a too-new schema; never throws.
- **`config.mjs getClusterHosts`** — cluster-repo-first (`cluster.json.roster`),
  else project `hosts.json`, else `[hostname]`. The CLI write target
  (`getCatalystRepoDirHostsPath`) is deliberately unchanged so reader/writer can't
  diverge.
- **`config-schema.mjs`** — `schemaVersion` policy (`ok`/`migrate`/`too-new`) +
  forward-only migration runner (unversioned == v1).
- **`catalyst cluster sync`** — invoke the sync. **`catalyst cluster ownership`** —
  make the HRW partition *seeable*: lists every Todo ticket and the one host that
  owns it (`--roster=mini,mini-2` previews a roster before flipping). `buildOwnership`
  is pure: each ticket owned by exactly one host, **0 overlap**.

### Testing
- Hermetic unit tests (inject sops/git — no binary/key/network): `cluster-sync.test.mjs`,
  `cli/cluster-ownership.test.mjs`, `config.test.mjs` cluster-first cases.
- **Real e2e** against the live `catalyst-cluster` repo: clone → decrypt with the
  laptop age key → 7 config files + 9 bare secret files written, all 0600, structure intact.
- mini-2 + escrow + laptop all verified to decrypt the real ciphertext.
- Plaintext-leak guard: 36 token values confirmed absent from all ciphertext.

### Scope / follow-ups (not in this PR)
- `clone-cluster-repo` join stage + bundle deploy-key vending (durable onboarding).
- `doctor` schema/drift/sops-installed asserts.
- The §13 repo-config slim (machine tuning + `monitor.linear.teams` roster still
  committed in `.catalyst/config.json`) — supervised, touches live daemon reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)