### PR TITLE
feat(dev): recovery-pass skill — goal-driven senior-engineer pipeline-unstick agent

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-goal-no-turn-caps.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-goal-no-turn-caps.test.sh
@@ -19,6 +19,7 @@ SKILLS=(
   "plugins/dev/skills/phase-pr/SKILL.md"
   "plugins/dev/skills/phase-monitor-merge/SKILL.md"
   "plugins/dev/skills/phase-remediate/SKILL.md"
+  "plugins/dev/skills/recovery-pass/SKILL.md"
 )
 
 FAILURES=0; PASSES=0

--- a/plugins/dev/scripts/execution-core/event-scan.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.mjs
@@ -45,6 +45,11 @@ import { getEventLogPath } from "./config.mjs";
 // `phase.remediate.complete.` or `phase.revive.reap-requested`.)
 const REVIVE_NAME_RE = /^phase\.[^.]+\.revive\./;
 const REMEDIATE_NAME_PREFIX = "phase.remediate.complete.";
+// CTL-1176 rung 3: the recovery-pass dispatch budget, analogous to the
+// remediate verdict-cycle budget. One completed recovery-pass sweep ==
+// one phase.recovery-pass.complete.<ticket> event. Durable (survives signal
+// resets), so the cap holds across ticks/restarts.
+const RECOVERY_PASS_NAME_PREFIX = "phase.recovery-pass.complete.";
 
 // CTL-802 — countTicketEventsInWindow (the CTL-671 runaway detector) used to scan
 // the WHOLE log from offset 0 on every call — and it is called once per in-flight
@@ -195,6 +200,16 @@ export function countReviveEvents({ ticket, orchId, since, path = getEventLogPat
 export function countRemediateCycles({ ticket, orchId, since, path = getEventLogPath() } = {}) {
   if (!ticket) throw new Error("countRemediateCycles: ticket required");
   return countByExactName(`${REMEDIATE_NAME_PREFIX}${ticket}`, { orchId, since, path });
+}
+
+// countRecoveryPassCycles — number of phase.recovery-pass.complete.<ticket>
+// envelopes (CTL-1176 rung 3). The event-counted recovery-pass dispatch budget,
+// mirroring countRemediateCycles. Used by defaultInvokeRecoveryPass to refuse a
+// re-dispatch once the per-target cap is spent (the cap holds even after the
+// per-cycle signal reset, because events are durable).
+export function countRecoveryPassCycles({ ticket, orchId, since, path = getEventLogPath() } = {}) {
+  if (!ticket) throw new Error("countRecoveryPassCycles: ticket required");
+  return countByExactName(`${RECOVERY_PASS_NAME_PREFIX}${ticket}`, { orchId, since, path });
 }
 
 // countDistinctRevivingTickets — unique tickets that have any revive event

--- a/plugins/dev/scripts/execution-core/event-scan.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.test.mjs
@@ -16,6 +16,7 @@ import {
   countReviveEvents,
   countDistinctRevivingTickets,
   countRemediateCycles,
+  countRecoveryPassCycles,
   hasCompleteEvent,
   __resetEventScanIndexForTest,
   __phaseEventsLengthForTest,
@@ -236,6 +237,33 @@ describe("CTL-653: countRemediateCycles", () => {
 
   test("throws without ticket", () => {
     expect(() => countRemediateCycles({})).toThrow();
+  });
+});
+
+// ─── CTL-1176 rung 3: countRecoveryPassCycles — the recovery-pass dispatch budget ─
+// Mirrors countRemediateCycles; one completed sweep == one
+// phase.recovery-pass.complete.<ticket>. The hyphen in "recovery-pass" is matched
+// by COMPLETE_NAME_RE's [^.]+ phase segment, so the complete event is indexed.
+
+describe("CTL-1176: countRecoveryPassCycles", () => {
+  test("missing event log returns 0 (cold start)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evtscan-"));
+    expect(countRecoveryPassCycles({ ticket: "CTL-1176", path: join(dir, "events.jsonl") })).toBe(0);
+  });
+
+  test("counts only phase.recovery-pass.complete.<ticket> envelopes", () => {
+    const { path } = tempLog([
+      makeEvent({ phase: "recovery-pass", action: "complete", ticket: "CTL-1176", ts: "2026-06-16T00:00:00Z" }), // match
+      makeEvent({ phase: "recovery-pass", action: "complete", ticket: "CTL-1176", ts: "2026-06-16T00:01:00Z" }), // match
+      makeEvent({ phase: "remediate", action: "complete", ticket: "CTL-1176", ts: "2026-06-16T00:02:00Z" }), // diff phase
+      makeEvent({ phase: "recovery-pass", action: "complete", ticket: "CTL-999", ts: "2026-06-16T00:03:00Z" }), // diff ticket
+      "not json", // skipped
+    ]);
+    expect(countRecoveryPassCycles({ ticket: "CTL-1176", path })).toBe(2);
+  });
+
+  test("throws without ticket", () => {
+    expect(() => countRecoveryPassCycles({})).toThrow();
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery-emit.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-emit.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// recovery-emit.mjs — CTL-1176 rung 3 CLI shim for the recovery-pass SKILL.
+//
+// The recovery-pass skill runs as a short-lived `claude --bg` worker (or a bare
+// operator sweep), so it cannot import the scheduler's in-process emit/intent
+// helpers. This shim is the auditable, reusable bridge: it lets the skill record
+// a recovery outcome to the SAME two sinks the in-process router writes to, so
+// the orch-monitor read-model (board-data.mjs:loadRecoveryOutcomes +
+// deriveAttention) surfaces it identically whether the daemon dispatched the
+// skill or Ryan invoked it by hand.
+//
+// Two subcommands:
+//
+//   fixed   --ticket CTL-N --reason "<plain past-tense changelog>" [--details JSON]
+//     Emits recovery.fixed (INFO). board-data folds it into autoFixed:true — the
+//     recovered lane, NOT a needs-you row. No push. (Use this when the skill
+//     resolved the item autonomously: rebased / merged / resolved a conflict /
+//     re-dispatched a phase.)
+//
+//   escalated --ticket CTL-N --escalation <EscalationPayload JSON> [--orch-dir D] [--phase P]
+//     The ONLY path that pages Ryan. It does THREE things, in order:
+//       1. Emits recovery.escalated (WARN, severityNumber 13) carrying the rich
+//          EscalationPayload (the composer-ready tagged union — manual /
+//          authorization / decision) so notification-composer.ts can derive the
+//          push short_text (≤140) + the inbox full_briefing.
+//       2. Writes/merges that EscalationPayload as the `explanation` block on the
+//          recovery-pass signal file (phase-recovery-pass.json) so the board's
+//          deriveExplanation / deriveHumanQuestion / deriveEscalationType lift it
+//          onto the BoardTicket and deriveAttention flips attention:"needs-human"
+//          → the Needs-You inbox row + nav dot + the push gate (shouldNotify).
+//          MERGES into the existing signal (never overwrites — drops bg_job_id).
+//       3. Latches the host-local escalated intent so the router's shouldSkipItem
+//          treats the escalation as terminal and stops re-acting (hands off to Ryan).
+//
+// The skill builds the EscalationPayload with escalation-explain.mjs (CTL-1130 —
+// the banned-tautology gate) so "needs a human" can never reach the operator.
+//
+// Best-effort everywhere: a sink failure logs to stderr and continues; the skill
+// must never crash on an emit. Exits 0 unless its args are unparseable.
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  existsSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  buildRecoveryEnvelope,
+  defaultEmitEvent,
+  defaultRecordIntent,
+} from "./recovery-reasoning.mjs";
+
+const argv = process.argv.slice(2);
+const sub = argv[0];
+
+function get(flag) {
+  const i = argv.indexOf(flag);
+  return i >= 0 ? argv[i + 1] : undefined;
+}
+function getJson(flag, fallback) {
+  const raw = get(flag);
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+function resolveOrchDir() {
+  return get("--orch-dir") ?? process.env.CATALYST_ORCHESTRATOR_DIR ?? null;
+}
+
+// mergeExplanationIntoSignal — write the EscalationPayload as the signal's
+// `explanation` block WITHOUT clobbering bg_job_id / status / the rest of the
+// envelope (the signal-overwrite-drops-fields hazard). Read-modify-write, atomic.
+function mergeExplanationIntoSignal(orchDir, ticket, phase, escalation) {
+  if (!orchDir || !ticket) return false;
+  const p = join(orchDir, "workers", ticket, `phase-${phase}.json`);
+  let sig = {};
+  try {
+    if (existsSync(p)) sig = JSON.parse(readFileSync(p, "utf8")) ?? {};
+  } catch {
+    sig = {};
+  }
+  sig.explanation = escalation;
+  sig.status = "needs-human"; // load-bearing for deriveAttention + the push gate
+  if (!sig.needsHumanSince) sig.needsHumanSince = new Date().toISOString();
+  sig.updatedAt = new Date().toISOString();
+  try {
+    mkdirSync(dirname(p), { recursive: true });
+    const tmp = `${p}.tmp.${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(sig, null, 2));
+    renameSync(tmp, p);
+    return true;
+  } catch (err) {
+    process.stderr.write(`recovery-emit: signal merge failed: ${err.message}\n`);
+    return false;
+  }
+}
+
+if (sub === "fixed") {
+  const ticket = get("--ticket");
+  const reason = get("--reason") ?? null;
+  const details = getJson("--details", {});
+  if (!ticket) {
+    process.stderr.write("recovery-emit fixed: --ticket required\n");
+    process.exit(2);
+  }
+  defaultEmitEvent({ type: "recovery.fixed", ticket, reason, details });
+  process.stdout.write(`recovery.fixed emitted for ${ticket}\n`);
+  process.exit(0);
+}
+
+if (sub === "escalated") {
+  const ticket = get("--ticket");
+  const phase = get("--phase") ?? "recovery-pass";
+  const orchDir = resolveOrchDir();
+  const escalation = getJson("--escalation", null);
+  if (!ticket || !escalation || !escalation.escalation_type) {
+    process.stderr.write(
+      "recovery-emit escalated: --ticket and a valid --escalation EscalationPayload required\n",
+    );
+    process.exit(2);
+  }
+  const reason =
+    escalation.problem ?? escalation.call_to_action ?? "recovery-pass escalation";
+
+  // (1) Emit recovery.escalated (WARN) with the rich, composer-ready payload.
+  defaultEmitEvent({ type: "recovery.escalated", ticket, reason, escalation });
+
+  // (2) Merge the explanation onto the signal → inbox row + push gate.
+  mergeExplanationIntoSignal(orchDir, ticket, phase, escalation);
+
+  // (3) Latch the escalated intent (terminal — router stops re-acting).
+  try {
+    defaultRecordIntent(
+      ticket,
+      { type: "recovery-pass", decision: "escalate", escalated: true, escalation },
+      { orchDir },
+    );
+  } catch (err) {
+    process.stderr.write(`recovery-emit: intent latch failed: ${err.message}\n`);
+  }
+
+  process.stdout.write(
+    `recovery.escalated emitted for ${ticket} (type=${escalation.escalation_type})\n`,
+  );
+  process.exit(0);
+}
+
+process.stderr.write(
+  "recovery-emit: usage: recovery-emit.mjs <fixed|escalated> --ticket CTL-N ...\n",
+);
+process.exit(2);

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -73,6 +73,17 @@ export function reasoningRecoveryPass(items, opts = {}) {
     classifyTicket = defaultClassifyTicket,
     invokeSeam = defaultInvokeSeam,
     invokeRemediateCapped = defaultInvokeRemediateCapped,
+    // CTL-1176 rung 3 (recovery-pass): the goal-driven senior-engineer dispatcher
+    // for the bounded-LLM path. Replaces the phase-remediate detour — instead of
+    // disguising a pipeline-recovery brief as a fake verify finding and squeezing
+    // it through a single-ticket verify⇄remediate worker, it writes a first-class
+    // recovery-pass.json brief (diagnostician evidence + which deterministic seams
+    // already failed) and dispatches the `recovery-pass` skill, which resolves
+    // conflicts / rebases / merges / re-dispatches autonomously and authors the
+    // inbox+push messages on escalation. The scheduler binds this to the tick's
+    // orchDir. Injectable for tests; falls back to invokeRemediateCapped when a
+    // caller (or a legacy test) only wired the remediate path (see below).
+    invokeRecoveryPass: injectedInvokeRecoveryPass,
     recordIntent = defaultRecordIntent,
     postComment = defaultPostComment,
     emitEvent = defaultEmitEvent,
@@ -88,6 +99,24 @@ export function reasoningRecoveryPass(items, opts = {}) {
     // them up. Prevents a 19-item storm in one sweep. Default 3, env-overridable.
     maxFixesPerTick = Number(process.env.CATALYST_RECOVERY_MAX_FIXES_PER_TICK) || 3,
   } = opts;
+
+  // CTL-1176 rung 3: resolve the effective bounded-LLM dispatcher. Precedence:
+  //   1. an explicitly-injected invokeRecoveryPass (new wiring / new tests);
+  //   2. an explicitly-injected invokeRemediateCapped WITHOUT a recovery-pass
+  //      override (legacy tests that stub the remediate dispatch directly — keep
+  //      them green; the brief/evidence shape is forward-compatible);
+  //   3. the new default (defaultInvokeRecoveryPass) — production dispatches the
+  //      recovery-pass skill, replacing the phase-remediate detour. All of this
+  //      stays behind the existing CATALYST_RECOVERY_PASS flag: at mode=off
+  //      NOTHING here runs (the early return above), so there is no live behavior
+  //      change until an operator opts into shadow/enforce.
+  const callerOverrodeRemediate = Object.prototype.hasOwnProperty.call(
+    opts,
+    "invokeRemediateCapped",
+  );
+  const effectiveInvokeRecoveryPass =
+    injectedInvokeRecoveryPass ??
+    (callerOverrodeRemediate ? invokeRemediateCapped : defaultInvokeRecoveryPass);
 
   if (mode === "off") {
     log("recovery-reasoning: mode=off, skipping");
@@ -220,7 +249,11 @@ export function reasoningRecoveryPass(items, opts = {}) {
 
         const fixOutcome = attemptFix(item, classification, {
           invokeSeam,
-          invokeRemediateCapped,
+          invokeRecoveryPass: effectiveInvokeRecoveryPass,
+          // CTL-1176 rung 3: thread the DIAGNOSE evidence into the fix so the
+          // recovery-pass brief carries it (the bounded-LLM dispatcher consumes
+          // the eyes' output rather than re-diagnosing from scratch).
+          evidence,
           log,
         });
         actionLog = fixOutcome.actionLog;
@@ -545,32 +578,45 @@ export function determineEscalationReason(logsOutput, jobState, signal, beliefSt
 
 // ─── Act phase (guarded fix: seam or remediate cap) ────────────────────────
 
-function attemptFix(item, classification, { invokeSeam, invokeRemediateCapped, log }) {
+function attemptFix(item, classification, { invokeSeam, invokeRecoveryPass, evidence, log }) {
   const { ticket } = item;
   const { fix_class, details } = classification;
   const actionLog = [];
 
   if (fix_class === "bounded-llm") {
-    // Invoke capped remediate
+    // CTL-1176 rung 3: dispatch the recovery-pass skill (goal-driven senior
+    // engineer) instead of squeezing a pipeline-recovery brief through a
+    // single-ticket phase-remediate worker. The brief carries the diagnostician
+    // evidence + the failure reason + the guidance; the dispatcher additionally
+    // reads which deterministic seams already ran/failed off disk so the skill
+    // does NOT redo the narrow hands-work.
     try {
-      const remediateResult = invokeRemediateCapped(ticket, {
+      const recoveryResult = invokeRecoveryPass(ticket, {
         brief: details.brief,
         reason: details.reason,
+        evidence,
+        phase: item.phase ?? null,
+        bgJobId: item.bgJobId ?? null,
+        failureReason:
+          evidence?.failureReason ??
+          evidence?.signal?.failureReason ??
+          item.evidence?.failureReason ??
+          null,
       });
 
-      const remediateStatus = remediateResult.success ? "success" : "failed";
-      actionLog.push(`remediate invoked: ${remediateStatus}`);
+      const recoveryStatus = recoveryResult.success ? "success" : "failed";
+      actionLog.push(`recovery-pass dispatched: ${recoveryStatus}`);
 
       return {
-        success: remediateResult.success,
-        reason: remediateResult.reason,
-        attempts: remediateResult.attempts || 1,
+        success: recoveryResult.success,
+        reason: recoveryResult.reason,
+        attempts: recoveryResult.attempts || 1,
         actionLog,
-        details: remediateResult.details || {},
+        details: recoveryResult.details || {},
       };
     } catch (err) {
-      log(`recovery-reasoning: ${ticket} remediate failed: ${err.message}`);
-      actionLog.push(`remediate error: ${err.message}`);
+      log(`recovery-reasoning: ${ticket} recovery-pass dispatch failed: ${err.message}`);
+      actionLog.push(`recovery-pass error: ${err.message}`);
       return {
         success: false,
         reason: err.message,
@@ -656,14 +702,58 @@ Reasoning pass determined this requires human judgment.
 This ticket is now marked for human review.`;
 }
 
+// buildEscalationPayload — the composer-ready EscalationPayload for the router's
+// OWN escalations (Rule-3 "human" classification, which never reaches the skill).
+// CTL-1221's notification-composer.ts and board-data.mjs's deriveEscalationType /
+// deriveHumanQuestion read this tagged union ({escalation_type, problem,
+// call_to_action, ...}) to render the push short_text + the inbox briefing — so a
+// thin {diagnosis, flags} blob renders nothing. This emits a valid `manual`-type
+// payload with CONCRETE, non-tautological fields (NEVER "needs a human"):
+// the recovery pass tried its registered seams + bounded-LLM fix and could not
+// classify the stuck state, so a human must look. The skill's OWN escalations
+// (richer — decision options, authorization risk) override this whenever the
+// recovery-pass skill authors them and threads them back via the intent/event.
+// The audit fields (observed/attempts) are preserved as passthrough.
 function buildEscalationPayload(item, classification) {
   const evidence = item.evidence || {};
+  const ticket = item.ticket;
+  const reason = classification?.details?.reason || "unclassified stuck state";
+  // If the skill already authored a rich escalation (CTL-1176 rung 3) and threaded
+  // it onto the item/classification, prefer it verbatim — it carries the
+  // executive-voiced summary/ask/options the operator should see.
+  const authored =
+    classification?.details?.escalation || item.authoredEscalation || null;
+  if (authored && authored.escalation_type) {
+    return {
+      ...authored,
+      observed: {
+        ...(authored.observed ?? {}),
+        diagnosis: reason,
+        logs_available: !!evidence.logsOutput,
+        job_state_available: !!evidence.jobState,
+        belief_state: evidence.beliefState ?? null,
+      },
+    };
+  }
   return {
-    diagnosis: classification.details.reason,
-    evidence: {
+    escalation_type: "manual",
+    problem: `${ticket} is stuck and the recovery pass could not classify it for an autonomous fix: ${reason}`,
+    call_to_action: `Look at ${ticket}'s worker log and decide whether it should be re-dispatched, abandoned, or fixed by hand`,
+    blocked_capability:
+      "automatic classification of this stuck state into a registered seam or bounded-LLM fix",
+    instructions: [
+      `Read the worker evidence for ${ticket} (claude logs + the failed phase signal)`,
+      "Decide the correct next move (re-dispatch the phase, fix the branch by hand, or close the ticket)",
+    ],
+    remediation_then_retry:
+      "Once the stuck state is resolved by hand, the next scheduler tick re-evaluates the ticket",
+    why_not_auto:
+      "neither a deterministic act-seam nor a bounded-LLM fix matched this failure signature, so the pass has no safe action to take",
+    observed: {
+      diagnosis: reason,
       logs_available: !!evidence.logsOutput,
       job_state_available: !!evidence.jobState,
-      belief_state: evidence.beliefState,
+      belief_state: evidence.beliefState ?? null,
     },
     timestamp: new Date().toISOString(),
   };
@@ -730,7 +820,7 @@ export function buildRecoveryEnvelope(event, { now } = {}) {
   };
 }
 
-function defaultEmitEvent(event, { logPath = getEventLogPath(), now } = {}) {
+export function defaultEmitEvent(event, { logPath = getEventLogPath(), now } = {}) {
   try {
     mkdirSync(dirname(logPath), { recursive: true });
     appendFileSync(logPath, JSON.stringify(buildRecoveryEnvelope(event, { now })) + "\n");
@@ -989,6 +1079,192 @@ export function defaultInvokeRemediateCapped(ticket, { brief, reason } = {}, dep
         phase: REMEDIATE_PHASE,
         bg_job_id: r.signal?.bg_job_id ?? null,
         worktreePath: r.worktreePath ?? null,
+      },
+    };
+  }
+  return {
+    success: false,
+    dispatched: false,
+    attempts,
+    reason: r?.stderr ? `dispatch failed: ${String(r.stderr).trim()}` : "dispatch failed",
+    details: { code: r?.code ?? null },
+  };
+}
+
+// ── (4b) defaultInvokeRecoveryPass — ONE capped recovery-pass --bg (CTL-1176) ──
+//
+// The replacement for the bounded-LLM phase-remediate detour. Where remediate
+// disguises a pipeline-recovery brief as a synthetic high-severity verify finding
+// (injectBriefIntoVerify) and re-enters the single-ticket verify⇄remediate cycle,
+// recovery-pass writes a FIRST-CLASS brief file (recovery-pass.json) carrying the
+// diagnostician evidence + the failure reason + the deterministic seams that
+// already ran/failed, then dispatches the `recovery-pass` skill — a goal-driven
+// senior engineer that may rebase / resolve conflicts / merge / re-dispatch
+// across the pipeline and authors the operator inbox+push on a legitimate
+// escalation. Fire-and-forget (dispatched, not fixed); the host-local cooldown +
+// the event-counted cap prevent a re-dispatch before the sweep lands.
+//
+// The recovery-pass cap (event-counted phase.recovery-pass.complete.<ticket>) is
+// enforced HERE, mirroring the remediate cap — phase-agent-dispatch does not.
+export const RECOVERY_PASS_PHASE = "recovery-pass";
+export const RECOVERY_PASS_CYCLE_CAP =
+  Number(process.env.CATALYST_RECOVERY_PASS_CYCLE_CAP) || 3;
+
+// readUnstuckSeamsTried — read the deterministic act-seam idempotency markers the
+// hands (unstuck-act-seams.mjs) leave under workers/<ticket>/ so the brief can
+// tell the skill "these narrow seams already ran — do NOT redo them". A present
+// marker means the seam fired this lifetime; the ticket is STILL in the recovery
+// backlog, so it fired and did not unstick the item. Best-effort, pure-read.
+function readUnstuckSeamsTried(orchDir, ticket, phase) {
+  if (!orchDir || !ticket) return [];
+  const ph = phase ?? "pr";
+  const dir = join(orchDir, "workers", ticket);
+  // (markerName → human category). Mirrors unstuck-act-seams.mjs markerPath():
+  //   .unstuck-cleared-<phase>.applied      (dirty-tree seam)
+  //   .unstuck-force-pushed-<phase>.applied (source-conflict seam)
+  //   .unstuck-orphan-merge-<phase>.applied (orphan-stale seam)
+  const seams = [
+    { marker: `.unstuck-cleared-${ph}.applied`, category: "dirty-tree" },
+    { marker: `.unstuck-force-pushed-${ph}.applied`, category: "source-conflict" },
+    { marker: `.unstuck-orphan-merge-${ph}.applied`, category: "orphan-stale" },
+  ];
+  const tried = [];
+  for (const s of seams) {
+    try {
+      if (existsSync(join(dir, s.marker))) {
+        tried.push({ category: s.category, marker: s.marker, outcome: "ran-did-not-clear" });
+      }
+    } catch {
+      /* best-effort — a stat error just omits the seam */
+    }
+  }
+  return tried;
+}
+
+// writeRecoveryBrief — atomic tmp+rename of recovery-pass.json, the prior-phase
+// artifact the skill reads (resolved from its --orch-dir + ticket, exactly like
+// every other phase agent resolves its upstream artifact). NOT verify.json, NOT
+// env — a brief file keyed in the worker dir is the auditable, reusable channel
+// (env leaks the wrong ticket/phase to phase skills — operator memory).
+function writeRecoveryBrief(orchDir, ticket, brief) {
+  const p = join(orchDir, "workers", ticket, "recovery-pass.json");
+  mkdirSync(dirname(p), { recursive: true });
+  const tmp = `${p}.tmp.${process.pid}`;
+  writeFileSync(tmp, JSON.stringify(brief, null, 2));
+  renameSync(tmp, p); // atomic
+}
+
+export function defaultInvokeRecoveryPass(ticket, briefObj = {}, deps = {}) {
+  const orchDir = deps.orchDir ?? resolveOrchDir();
+  if (!orchDir) {
+    return { success: false, dispatched: false, attempts: 0, reason: "no orchDir", details: {} };
+  }
+
+  const { brief, reason, evidence, phase, bgJobId, failureReason } = briefObj;
+
+  // Lazy imports — same rationale as defaultInvokeRemediateCapped (avoid loading
+  // the dispatch graph on the off/shadow paths; no import cycle).
+  let dispatchTicket, countRecoveryPassCycles;
+  try {
+    ({ dispatchTicket } = deps.dispatchMod ?? requireSync("./dispatch.mjs"));
+    ({ countRecoveryPassCycles } = deps.eventScanMod ?? requireSync("./event-scan.mjs"));
+  } catch (err) {
+    return {
+      success: false,
+      dispatched: false,
+      attempts: 0,
+      reason: `recovery-pass module load failed: ${err.message}`,
+      details: { error: err.message },
+    };
+  }
+
+  const countCycles = deps.countCycles ?? countRecoveryPassCycles;
+  const dispatch = deps.dispatchTicket ?? dispatchTicket;
+  const cap = deps.cap ?? RECOVERY_PASS_CYCLE_CAP;
+
+  // (1) Enforce the recovery-pass dispatch cap.
+  const attempts = countCycles({ ticket });
+  if (attempts >= cap) {
+    return {
+      success: false,
+      dispatched: false,
+      attempts,
+      reason: "recovery-pass-cycle-cap-exhausted",
+      details: { cap },
+    };
+  }
+
+  // (2) Assemble + write the first-class brief the skill consumes. It carries the
+  //     eyes' output (diagnostician evidence) and the hands' history (which
+  //     deterministic seams already ran), so the skill picks up where the narrow
+  //     passes failed instead of redoing them.
+  const seamsTried = readUnstuckSeamsTried(orchDir, ticket, phase);
+  const recoveryBrief = {
+    schema: "recovery-pass-brief/v1",
+    ticket,
+    phase: phase ?? null,
+    bgJobId: bgJobId ?? null,
+    failureReason: failureReason ?? null,
+    // The DIAGNOSE output (read-only): claude logs buffer + bg job state + signal
+    // + belief state. The skill reads this instead of re-diagnosing from scratch.
+    diagnosis: {
+      reason: reason ?? null,
+      logsOutput: evidence?.logsOutput ?? null,
+      jobState: evidence?.jobState ?? null,
+      signal: evidence?.signal ?? null,
+      beliefState: evidence?.beliefState ?? null,
+    },
+    // The hands' history: deterministic seams that already ran and did NOT clear
+    // it. The skill must NOT redo these — it does the harder cross-pipeline moves.
+    deterministicSeamsTried: seamsTried,
+    // The remediation guidance (generateRemediateBrief output) + the autonomy
+    // boundary. The skill body owns the full senior-engineer decision checklist;
+    // this is the per-item hint, not the policy.
+    guidance: brief ?? null,
+    attempt: attempts + 1,
+    maxAttempts: cap,
+    writtenAt: new Date().toISOString(),
+  };
+  try {
+    writeRecoveryBrief(orchDir, ticket, recoveryBrief);
+  } catch (err) {
+    return {
+      success: false,
+      dispatched: false,
+      attempts,
+      reason: `recovery-pass.json brief write failed: ${err.message}`,
+      details: { error: err.message },
+    };
+  }
+
+  // (3) Dispatch the recovery-pass skill through the JS seam (worktree
+  //     provisioning, claim, OTEL, signal envelope). The dispatcher resolves the
+  //     phase `recovery-pass` to /catalyst-dev:recovery-pass (skill_for_phase).
+  let r;
+  try {
+    r = dispatch(orchDir, ticket, RECOVERY_PASS_PHASE);
+  } catch (err) {
+    return {
+      success: false,
+      dispatched: false,
+      attempts,
+      reason: `dispatch threw: ${err.message}`,
+      details: { error: err.message },
+    };
+  }
+
+  if (r && r.code === 0) {
+    // Fire-and-forget: dispatched, not fixed. Cooldown prevents re-dispatch.
+    return {
+      success: true,
+      dispatched: true,
+      attempts: 1,
+      reason: "recovery-pass dispatched",
+      details: {
+        phase: RECOVERY_PASS_PHASE,
+        bg_job_id: r.signal?.bg_job_id ?? null,
+        worktreePath: r.worktreePath ?? null,
+        seamsTriedCount: seamsTried.length,
       },
     };
   }

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -14,10 +14,13 @@ import {
   defaultRecordIntent,
   defaultShouldSkipItem,
   defaultInvokeRemediateCapped,
+  defaultInvokeRecoveryPass,
+  RECOVERY_PASS_CYCLE_CAP,
+  RECOVERY_PASS_PHASE,
   RECOVERY_MAX_ATTEMPTS,
   RECOVERY_COOLDOWN_MS,
 } from "./recovery-reasoning.mjs";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { join as pathJoin } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -983,5 +986,171 @@ describe("reasoningRecoveryPass shadow cooldown wiring (CTL-1176)", () => {
     });
     expect(r2.processed).toBe(0); // skipped via cooldown — NO re-spam
     expect(comments2.length).toBe(0); // zero new comments on the 2nd tick
+  });
+});
+
+// ─── CTL-1176 rung 3: defaultInvokeRecoveryPass (the phase-remediate replacement) ─
+//
+// The bounded-LLM path now dispatches the goal-driven recovery-pass skill instead
+// of disguising a brief as a fake verify finding. These pin the contract: cap
+// enforcement, the FIRST-CLASS recovery-pass.json brief (with diagnosis + the
+// failed-seam history off disk), and the dispatch of phase `recovery-pass`.
+describe("defaultInvokeRecoveryPass (CTL-1176 rung 3)", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(pathJoin(tmpdir(), "rec-pass-"));
+  });
+  afterEach(() => {
+    try {
+      rmSync(orchDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  test("refuses dispatch when recovery-pass cycle count is already at cap", () => {
+    const result = defaultInvokeRecoveryPass(
+      "CTL-500",
+      { brief: "unstick it", reason: "merge-conflict" },
+      {
+        orchDir,
+        eventScanMod: { countRecoveryPassCycles: () => RECOVERY_PASS_CYCLE_CAP },
+        dispatchMod: { dispatchTicket: () => ({ code: 0 }) },
+      },
+    );
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe("recovery-pass-cycle-cap-exhausted");
+    expect(result.dispatched).toBe(false);
+  });
+
+  test("dispatches phase `recovery-pass` (NOT remediate) and writes a first-class brief", () => {
+    // Seed two unstuck idempotency markers so the brief's deterministicSeamsTried
+    // proves it consumed the hands' history off disk.
+    const wdir = pathJoin(orchDir, "workers", "CTL-501");
+    mkdirSync(wdir, { recursive: true });
+    writeFileSync(pathJoin(wdir, ".unstuck-cleared-pr.applied"), "");
+    writeFileSync(pathJoin(wdir, ".unstuck-force-pushed-pr.applied"), "");
+
+    let dispatchedPhase = null;
+    const result = defaultInvokeRecoveryPass(
+      "CTL-501",
+      {
+        brief: "read both sides of the conflict and resolve",
+        reason: "merge-conflict",
+        evidence: { logsOutput: "CONFLICT (content): foo.ts", beliefState: { x: 1 } },
+        phase: "pr",
+        bgJobId: "bg501",
+        failureReason: "merge-conflict",
+      },
+      {
+        orchDir,
+        eventScanMod: { countRecoveryPassCycles: () => 0 },
+        dispatchMod: {
+          dispatchTicket: (od, ticket, phase) => {
+            dispatchedPhase = phase;
+            return { code: 0, worktreePath: "/tmp/wt", signal: { bg_job_id: "bg501" } };
+          },
+        },
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.dispatched).toBe(true);
+    expect(dispatchedPhase).toBe(RECOVERY_PASS_PHASE); // "recovery-pass", NOT "remediate"
+    expect(result.details.seamsTriedCount).toBe(2);
+
+    // The first-class brief was written (NOT verify.json).
+    const briefPath = pathJoin(wdir, "recovery-pass.json");
+    expect(existsSync(briefPath)).toBe(true);
+    const brief = JSON.parse(readFileSync(briefPath, "utf8"));
+    expect(brief.schema).toBe("recovery-pass-brief/v1");
+    expect(brief.ticket).toBe("CTL-501");
+    expect(brief.failureReason).toBe("merge-conflict");
+    expect(brief.diagnosis.logsOutput).toContain("CONFLICT");
+    expect(brief.diagnosis.beliefState).toEqual({ x: 1 });
+    // Consumed the hands' history — the two markers, not redone.
+    const categories = brief.deterministicSeamsTried.map((s) => s.category).sort();
+    expect(categories).toEqual(["dirty-tree", "source-conflict"]);
+    expect(brief.guidance).toContain("resolve");
+    // No verify.json fake-finding injection.
+    expect(existsSync(pathJoin(wdir, "verify.json"))).toBe(false);
+  });
+
+  test("dispatch failure (non-zero code) → success:false, dispatched:false", () => {
+    const result = defaultInvokeRecoveryPass(
+      "CTL-502",
+      { brief: "x", reason: "stale-branch" },
+      {
+        orchDir,
+        eventScanMod: { countRecoveryPassCycles: () => 0 },
+        dispatchMod: { dispatchTicket: () => ({ code: 1, stderr: "boom" }) },
+      },
+    );
+    expect(result.success).toBe(false);
+    expect(result.dispatched).toBe(false);
+    expect(result.reason).toContain("boom");
+  });
+
+  test("no orchDir → returns success:false without dispatching", () => {
+    const result = defaultInvokeRecoveryPass("CTL-503", { brief: "x" }, { orchDir: null });
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe("no orchDir");
+  });
+});
+
+// CTL-1176 rung 3: the bounded-LLM branch dispatches recovery-pass (the injected
+// invokeRecoveryPass), and threads the diagnostician evidence into it.
+describe("reasoningRecoveryPass bounded-LLM → recovery-pass dispatch (CTL-1176)", () => {
+  test("enforce mode calls invokeRecoveryPass with the evidence threaded in", () => {
+    const items = [
+      {
+        ticket: "CTL-600",
+        phase: "pr",
+        bgJobId: "bg600",
+        evidence: { logsOutput: "merge conflict in foo.ts", beliefState: { r: 1 } },
+      },
+    ];
+    const calls = [];
+    const events = [];
+    const result = reasoningRecoveryPass(items, {
+      mode: "enforce",
+      invokeRecoveryPass: (ticket, briefObj) => {
+        calls.push({ ticket, briefObj });
+        return { success: true, reason: "recovery-pass dispatched", details: {} };
+      },
+      recordIntent: () => {},
+      postComment: () => {},
+      emitEvent: (e) => events.push(e),
+    });
+
+    expect(result.results[0].decision).toBe("fix");
+    expect(result.results[0].fix_class).toBe("bounded-llm");
+    expect(calls.length).toBe(1);
+    expect(calls[0].ticket).toBe("CTL-600");
+    // Evidence threaded through (the eyes' output the skill consumes).
+    expect(calls[0].briefObj.evidence.logsOutput).toContain("merge conflict");
+    expect(calls[0].briefObj.phase).toBe("pr");
+    expect(calls[0].briefObj.bgJobId).toBe("bg600");
+    expect(events.some((e) => e.type === "recovery.fixed")).toBe(true);
+  });
+
+  test("back-compat: a caller that injects only invokeRemediateCapped still drives the fix", () => {
+    // Legacy wiring/tests that stub the remediate dispatch directly must stay green.
+    const items = [
+      { ticket: "CTL-601", phase: "pr", bgJobId: "bg601", evidence: { logsOutput: "stale main" } },
+    ];
+    let remediateCalled = false;
+    const result = reasoningRecoveryPass(items, {
+      mode: "enforce",
+      invokeRemediateCapped: () => {
+        remediateCalled = true;
+        return { success: true, reason: "fixed", details: {} };
+      },
+      recordIntent: () => {},
+      postComment: () => {},
+      emitEvent: () => {},
+    });
+    expect(remediateCalled).toBe(true);
+    expect(result.results[0].decision).toBe("fix");
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -207,7 +207,11 @@ import {
   defaultShouldSkipItem as recoveryShouldSkipItem,
   defaultRecordIntent as recoveryRecordIntent,
   defaultInvokeSeam as recoveryInvokeSeam,
-  defaultInvokeRemediateCapped as recoveryInvokeRemediateCapped,
+  // CTL-1176 rung 3: the bounded-LLM path now dispatches the goal-driven
+  // recovery-pass skill (replacing the phase-remediate detour). Bound to the
+  // tick's orchDir at the call site. Still entirely behind CATALYST_RECOVERY_PASS
+  // (mode=off ⇒ the pass never runs), so no live behavior change until opt-in.
+  defaultInvokeRecoveryPass as recoveryInvokeRecoveryPass,
 } from "./recovery-reasoning.mjs";
 // CTL-1219: the per-category enforcement seam registry (dirty-tree /
 // source-conflict / orphan-stale / stale-label). Pure-cored + injectable; bound
@@ -3489,8 +3493,10 @@ export function schedulerTick(
               recoveryRecordIntent(ticket, intent, { orchDir }),
             invokeSeam: (ticket, seamId, brief) =>
               recoveryInvokeSeam(ticket, seamId, brief, { orchDir }),
-            invokeRemediateCapped: (ticket, briefObj) =>
-              recoveryInvokeRemediateCapped(ticket, briefObj, { orchDir }),
+            // CTL-1176 rung 3: dispatch the recovery-pass skill for the
+            // bounded-LLM path (was recoveryInvokeRemediateCapped → phase-remediate).
+            invokeRecoveryPass: (ticket, briefObj) =>
+              recoveryInvokeRecoveryPass(ticket, briefObj, { orchDir }),
           });
           if (rResult.processed > 0) {
             log.info(

--- a/plugins/dev/scripts/lib/phase-artifact-gate.sh
+++ b/plugins/dev/scripts/lib/phase-artifact-gate.sh
@@ -43,6 +43,11 @@ prior_artifact_for_phase() {
 	monitor-merge) echo "signal:phase-pr.json" ;;
 	monitor-deploy) echo "signal:phase-monitor-merge.json" ;;
 	remediate) echo "signal:verify.json" ;;
+	# recovery-pass (CTL-1176 rung 3): its brief is recovery-pass.json — the
+	# evidence envelope + failed-seam list the wire-in writes before dispatch
+	# (the analogue of verify.json for remediate). The skill reads it as its
+	# prior-phase artifact.
+	recovery-pass) echo "signal:recovery-pass.json" ;;
 	teardown) echo "signal:phase-monitor-deploy.json" ;;
 	*) echo "" ;;
 	esac

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -108,8 +108,26 @@ phase_default_turn_cap() {
 	monitor-merge) echo 50 ;;
 	monitor-deploy) echo 30 ;;
 	remediate) echo 40 ;; # CTL-653: fix-scoped — smaller than implement's 75
+	# recovery-pass (CTL-1176 rung 3): a goal-driven senior-engineer sweep that
+	# resolves conflicts / rebases / merges / re-dispatches across the pipeline.
+	# Higher than remediate's fix-scoped 40 because it iterates to a fleet goal,
+	# but still bounded daemon-side (CTL-748). No self-stop prose in its /goal.
+	recovery-pass) echo 60 ;;
 	teardown) echo 15 ;;
 	*) echo "$DEFAULT_TURN_CAP" ;;
+	esac
+}
+
+# skill_for_phase — maps a dispatch phase name to the SKILL it resolves. The
+# default convention is phase-<PHASE> (every 9-phase worker). The recovery-pass
+# rung (CTL-1176) is the one exception: its skill is named `recovery-pass`
+# (Ryan's chosen name — it is also a standalone operator sweep `/recovery-pass`,
+# not strictly a pipeline phase), so the prompt resolves to /catalyst-dev:recovery-pass
+# rather than /catalyst-dev:phase-recovery-pass. Keep this list tiny and explicit.
+skill_for_phase() {
+	case "$1" in
+	recovery-pass) echo "recovery-pass" ;;
+	*) echo "phase-$1" ;;
 	esac
 }
 
@@ -718,7 +736,7 @@ fi
 
 # ─── Build prompt + spawn claude --bg ──────────────────────────────────────
 
-PROMPT="/catalyst-dev:phase-${PHASE} ${TICKET} --orch-dir ${ORCH_DIR}"
+PROMPT="/catalyst-dev:$(skill_for_phase "${PHASE}") ${TICKET} --orch-dir ${ORCH_DIR}"
 
 # Pass the resolved env through so the phase agent inherits orchestrator
 # context + the humanlayer-friendly thoughts repo location. The dispatch

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -1,0 +1,502 @@
+---
+name: recovery-pass
+description: |
+  Goal-driven senior-engineer pipeline-unstick sweep (CTL-1176 rung 3). Given the
+  stuck/failed/needs-human set (or ONE ticket handed by the recovery router), its
+  GOAL is to get the pipeline MOVING again — not to fix one ticket's review
+  findings (that is phase-remediate). It runs AFTER the eyes (diagnostician
+  evidence) and the hands (deterministic unstuck-sweep seams) have already tried,
+  and it CONSUMES their output from a recovery-pass.json brief rather than
+  re-diagnosing or redoing their narrow work. It acts like a senior engineer with
+  full tool access — it resolves merge conflicts, rebases, force-pushes, merges
+  green PRs, and re-dispatches stalled phases AUTONOMOUSLY — and escalates to Ryan
+  ONLY for a genuine value judgment / something that degrades other functionality
+  / a real cost-benefit trade-off / a serious architecture change / an ADR
+  conflict. On escalation it AUTHORS the operator inbox row + the push
+  notification (executive-voiced). Dispatched as a `claude --bg` job by
+  phase-agent-dispatch via slash command, AND invocable bare by Ryan as a sweep —
+  hence `user-invocable: true`. Ships behind CATALYST_RECOVERY_PASS (off by
+  default — no live behavior change until shadow/enforce).
+user-invocable: true
+disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Edit
+  - Write
+  - Task
+---
+
+# recovery-pass
+
+The agentic top rung of the self-healing recovery ladder (ADR-025 / CTL-1176).
+Below it sit two deterministic rungs that have already run:
+
+- **The eyes** — `diagnostician.mjs` `captureEvidence`: the `claude logs` buffer +
+  the bg job `state.json` + the worker signal + the belief state, packaged as a
+  read-only evidence envelope. It SEES; it does not act.
+- **The hands** — `unstuck-sweep.mjs` (Pass 0u) + `unstuck-act-seams.mjs`: a
+  narrow, mechanical classify-then-act over four typed categories (dirty-tree,
+  source-conflict, orphan-stale, stale-label). It takes ONE mechanical action per
+  category.
+
+**recovery-pass is what runs when a thing is STILL stuck after the eyes and hands
+tried.** Its job is the cross-pipeline, judgment-bearing moves the narrow passes
+cannot make: read both sides of a real merge conflict and resolve it, rebase a
+diverged branch and force-push, merge a green PR that is just sitting there,
+re-dispatch a phase that died, reconcile an orphan-merged PR — and, only when a
+move genuinely requires Ryan, author a clear executive briefing and hand it off.
+
+> **This is NOT phase-remediate.** phase-remediate fixes ONE ticket whose
+> `verify` verdict failed, from `verify.json.findings[]`, editing source files in
+> place and handing back to a fresh `verify` (cap 3). recovery-pass keeps the
+> WHOLE pipeline moving — its scope is the stuck/failed/needs-human set, its input
+> is the diagnostician + unstuck output, and its actions are git/gh/dispatch, not
+> just Edit/Write. Do not narrow yourself to one ticket's review findings.
+
+## Two invocation modes
+
+1. **Router-dispatched (the bounded-LLM recovery path).** The scheduler's recovery
+   pass (CTL-1176, gated by `CATALYST_RECOVERY_PASS`) classifies a stuck ticket as
+   `bounded-llm` and dispatches you via `phase-agent-dispatch` with
+   `CATALYST_TICKET` set and a `recovery-pass.json` brief already written into the
+   worker dir. You own that ONE ticket; resolve it and emit complete.
+
+2. **Operator sweep (Ryan invokes `/catalyst-dev:recovery-pass`).** No dispatcher,
+   no `CATALYST_*` env, no pre-written brief. You enumerate the stuck set yourself
+   from the worker signals + the unified event log, then walk it. Ryan's words:
+   *"Go look at all the things stuck/failed/needing-human and think very hard
+   about how to unstick them."*
+
+The body below handles both. Tolerate a missing dispatcher env — do NOT
+`: "${CATALYST_TICKET:?}"`-hard-fail the bare sweep.
+
+## Prelude (copy into the running session, adapted per mode)
+
+```bash
+set -uo pipefail   # NOT -e: a single ticket's failure must not abort the sweep
+
+# ── Resolve the runtime context, tolerating bare invocation ──────────────────
+ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR:-$HOME/catalyst/execution-core}"
+ORCH_ID="${CATALYST_ORCHESTRATOR_ID:-recovery-pass}"
+PHASE="${CATALYST_PHASE:-recovery-pass}"
+TICKET="${CATALYST_TICKET:-}"   # set when router-dispatched; empty for the sweep
+CHANNEL="orch-${ORCH_ID}"
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+[[ -n "$PLUGIN_ROOT" ]] || PLUGIN_ROOT="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]:-$0}" 2>/dev/null || echo .)")")")"
+EXEC_CORE="${PLUGIN_ROOT}/scripts/execution-core"
+
+# ── Router-dispatched mode: run the phase-agent envelope ─────────────────────
+if [[ -n "$TICKET" ]]; then
+  SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+
+  # CTL-615 yield: if the signal's bg_job_id names a DIFFERENT live bg job, we are
+  # a redispatch duplicate of a still-running worker — bow out (exit 0), no emit.
+  YIELD_CHECK="${PLUGIN_ROOT}/scripts/phase-agent-yield-check.sh"
+  if [[ -f "$SIGNAL_FILE" && -x "$YIELD_CHECK" ]] && bash "$YIELD_CHECK" \
+       --signal "$SIGNAL_FILE" --phase "$PHASE" \
+       --worker-dir "$(dirname "$SIGNAL_FILE")"; then
+    echo "recovery-pass: yielding to canonical worker (CTL-615)" >&2
+    exit 0
+  fi
+
+  # Join comms + start a cost session + flip the signal to running (best-effort).
+  COMMS="${PLUGIN_ROOT}/scripts/catalyst-comms"
+  [[ -x "$COMMS" ]] || COMMS="$(command -v catalyst-comms 2>/dev/null || true)"
+  if [[ -n "$COMMS" && -x "$COMMS" ]]; then
+    "$COMMS" join "$CHANNEL" --as "$TICKET" --capabilities "recovery-pass: ${TICKET}" \
+      --orch "$ORCH_ID" --parent orchestrator --ttl 3600 >/dev/null 2>&1 || true
+    "$COMMS" send "$CHANNEL" "recovery-pass started" --as "$TICKET" --type info \
+      --orch "$ORCH_ID" >/dev/null 2>&1 || true
+  fi
+  SESSION_SCRIPT="${PLUGIN_ROOT}/scripts/catalyst-session.sh"
+  if [[ -x "$SESSION_SCRIPT" ]]; then
+    CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start --skill "recovery-pass" \
+      --ticket "$TICKET" --workflow "${CATALYST_SESSION_ID:-}")
+    export CATALYST_SESSION_ID
+  fi
+  if [[ -f "$SIGNAL_FILE" ]]; then
+    TS=$(date -u +%Y-%m-%dT%H:%M:%SZ); TMP="${SIGNAL_FILE}.tmp.$$"
+    jq --arg ts "$TS" --arg sid "${CATALYST_SESSION_ID:-}" '
+      .status = "running" | .updatedAt = $ts
+      | if $sid != "" then .catalystSessionId = $sid else . end
+    ' "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+  fi
+
+  # Read the BRIEF — the eyes + hands output. This is the prior-phase artifact the
+  # dispatcher gated on. CONSUME it; do NOT re-run the diagnostician or the seams.
+  BRIEF="${ORCH_DIR}/workers/${TICKET}/recovery-pass.json"
+  if [[ -f "$BRIEF" ]]; then
+    echo "recovery-pass: brief = ${BRIEF}"
+    echo "--- failure reason ---";        jq -r '.failureReason // "(none)"' "$BRIEF"
+    echo "--- diagnosis (eyes) ---";       jq -r '.diagnosis.reason // "(none)"' "$BRIEF"
+    echo "--- deterministic seams already tried (hands — do NOT redo) ---"
+    jq -r '.deterministicSeamsTried[]? | "- \(.category): \(.outcome) (\(.marker))"' "$BRIEF" || true
+    echo "--- guidance ---";               jq -r '.guidance // "(none)"' "$BRIEF"
+    echo "--- recent log buffer (truncated) ---"
+    jq -r '.diagnosis.logsOutput // "(no logs captured)"' "$BRIEF" | tail -40
+  else
+    echo "recovery-pass: no brief at ${BRIEF}; reconstructing from signal + logs" >&2
+  fi
+
+# ── Operator-sweep mode: enumerate the stuck set ─────────────────────────────
+else
+  echo "recovery-pass: operator sweep — enumerating the stuck/failed/needs-human set"
+  # Worker signals carrying a non-terminal stuck status. Capture each item's
+  # ticket + signal path so Steps 0–4 below can BIND a per-item TICKET (the sweep
+  # has no dispatcher CATALYST_TICKET — each enumerated item supplies its own).
+  SWEEP_ITEMS=()   # "TICKET<TAB>SIGNAL_FILE<TAB>status<TAB>reason" per stuck item
+  for s in "${ORCH_DIR}"/workers/*/phase-*.json; do
+    [[ -f "$s" ]] || continue
+    st="$(jq -r '.status // empty' "$s" 2>/dev/null || true)"
+    case "$st" in
+      needs-human|failed|stalled)
+        it="$(jq -r '.ticket // empty' "$s" 2>/dev/null || true)"
+        [[ -n "$it" ]] || it="$(basename "$(dirname "$s")")"
+        rsn="$(jq -r '.failureReason // "-"' "$s" 2>/dev/null || echo -)"
+        echo "STUCK $it $(basename "$s") status=$st reason=$rsn"
+        SWEEP_ITEMS+=("${it}	${s}	${st}	${rsn}")
+        ;;
+    esac
+  done
+  # Recovery escalations + would-escalates on the unified log (audit trail of what
+  # the deterministic/bounded passes punted) — surfacing the set the narrow sweeps
+  # couldn't get past, so the sweep also covers items whose signal was already
+  # cleared. Read the monthly JSONL DIRECTLY (catalyst-events `tail` is a
+  # long-running follower with a jq `--filter`, not a one-shot history reader);
+  # match the canonical envelope shape (`attributes["event.name"]` is the event
+  # name; `body.payload.ticket` / `.reason` carry the CTL key + reason).
+  EVENTS_FILE="${CATALYST_EVENTS_DIR:-${CATALYST_DIR:-$HOME/catalyst}/events}/$(date -u +%Y-%m).jsonl"
+  if [[ -f "$EVENTS_FILE" ]]; then
+    echo "--- recovery escalations / would-escalates on the unified log (this month) ---"
+    jq -rc 'select((.attributes["event.name"] // "")
+              | test("^recovery\\.(escalated|would-escalate)$"))
+            | "WOULD-ESCALATE \(.body.payload.ticket // .attributes["event.label"] // "?") \(.attributes["event.name"]) reason=\(.body.payload.reason // "-")"' \
+      "$EVENTS_FILE" 2>/dev/null | sort -u \
+      || echo "(no recovery escalations on the log)"
+  fi
+fi
+```
+
+> **Sweep-mode binding.** In the sweep there is NO dispatcher `CATALYST_TICKET`.
+> Each entry in `SWEEP_ITEMS` is the per-item context. When you walk an item in
+> Steps 0–4 below, FIRST bind `TICKET` (and re-resolve `BRIEF` /
+> `SIGNAL_FILE` from it) to that item's ticket before authoring anything — the
+> authoring shims (`escalation-explain.mjs --ticket`, `recovery-emit.mjs
+> escalated --ticket`) reject an empty `--ticket`, so an escalation with `TICKET`
+> still empty would silently no-op and leave the goal FALSE. There is no
+> pre-written `recovery-pass.json` brief in the sweep — reconstruct the diagnosis
+> from the item's signal + `claude logs` yourself (this is the one place the sweep
+> re-reads logs, because no diagnostician ran ahead of it).
+
+## /goal condition
+
+Transcript-evaluable (the `/goal` evaluator sees ONLY printed text, never the
+filesystem), so the work block must PRINT a per-item resolution line carrying the
+proof signal. The goal is the fleet condition — keep iterating until it reads
+unequivocally TRUE. No turn-cap self-stop language (CTL-748) — the bounded
+envelope is enforced daemon-side.
+
+```
+/goal "Every item that was stuck/failed/needs-human at the start of this pass is
+       now in ONE of two terminal states, and I have PRINTED a per-item line
+       proving it:
+         (a) UNSTUCK — I resolved it autonomously (rebased / resolved the merge
+             conflict / merged the green PR / re-dispatched the stalled phase /
+             reconciled the orphan PR) and printed the resolving action AND its
+             success signal (e.g. `gh pr view --json mergeable,state` showing
+             CLEAN/MERGED with `exit 0`, or the re-dispatch event id, or
+             `git rebase --continue` + push succeeding); OR
+         (b) ESCALATED — it meets a legitimate escalation bar (genuine value
+             judgment / removes-or-degrades other functionality / real
+             cost-benefit trade-off / serious architecture change / conflicts
+             with an ADR / I genuinely cannot determine the correct resolution
+             after trying), AND I authored the inbox row + the push notification
+             for Ryan via recovery-emit.mjs and printed both being written.
+       No item remains in an in-between 'still stuck, not yet escalated' state. A
+       mere merge conflict / CI failure / stale branch / unmerged-but-green PR is
+       NEVER an acceptable escalation — those are (a) and I must resolve them."
+```
+
+## Phase-specific work — the senior-engineer unstick loop
+
+Think hard. You are a senior engineer; Ryan is your executive product manager.
+Default to ACTING. For each stuck item, walk the decision checklist top-to-bottom;
+first match wins. Print a resolution line for every item so `/goal` has signal.
+
+### Step 0 — Consume the eyes + hands output (do NOT redo it)
+
+Read the brief's `diagnosis` (the diagnostician evidence) and
+`deterministicSeamsTried` (which seams the hands already ran and that did NOT
+clear it). You are picking up where the narrow passes failed — do NOT re-run the
+diagnostician and do NOT re-run a seam that is listed as already-tried. If a seam
+ran and didn't clear it, the mechanical fix wasn't enough; that's your cue to do
+the harder, judgment-bearing move.
+
+### Step 1 — Can a REGISTERED SEAM clear it? (deterministic → FIX, no further work)
+
+If the brief shows a typed mechanical case that did NOT already run its seam,
+let the seam handle it. (Orphan PR / stale-sweep → orphan-reconcile; push rejected
+no workflow scope → workflow-token-redispatch; sibling conflict CTL-855; orphan/
+duplicate PR CTL-1175/1159/1160; ADR-024 hygiene cleaners.) Do not duplicate a
+seam that is in `deterministicSeamsTried`.
+
+> **`deterministicSeamsTried` is NOT exhaustive.** It is reconstructed from the
+> three on-disk unstuck markers only — `dirty-tree`, `source-conflict`,
+> `orphan-stale`. Seams WITHOUT a marker (e.g. `workflow-token-redispatch`, the
+> CTL-855 sibling-conflict seam, the ADR-024 cleaners) will NEVER appear there
+> even if they ran, so do not read an absence as "this seam has not been tried."
+> For those, judge from the diagnosis + the live git/gh state whether the
+> mechanical action already took effect (e.g. the branch is already pushed, the
+> PR already reconciled) before re-firing — they are idempotent-ish and the
+> per-tick/cycle caps bound re-firing, but check first rather than trusting the
+> list as complete.
+
+### Step 2 — Resolve it MYSELF with bounded engineering (BOUNDED-LLM → FIX)
+
+You have full tool access. These are ALL things you do autonomously — never
+escalate them:
+
+- **Merge / rebase conflict** → read BOTH sides (`git log --merge`,
+  `git diff`, the two conflicting hunks). Pick the resolution consistent with this
+  ticket's stated goal. If the conflict is purely additive (both sides add
+  different things), keep both. `git add`, `git rebase --continue` (or
+  `git commit`), then push.
+- **Stale / diverged branch** → `git fetch origin && git rebase --autostash
+  origin/main`; if it conflicts, treat as the conflict case above; force-push.
+- **CI failure after rebase/push** → `gh run view --log-failed`, fix the root
+  cause (type error / lint / test), commit, push to re-trigger.
+- **A green PR just sitting there** → verify it is CLEAN
+  (`gh pr view <n> --json mergeable,mergeStateStatus,reviewDecision`), then
+  `gh pr merge <n> --squash --delete-branch`.
+- **A stalled phase that died mid-flight** → re-dispatch it
+  (`phase-agent-dispatch --phase <phase> --ticket <T> --orch-dir <ORCH_DIR>`),
+  or re-arm its signal (failed→pending) and wake the scheduler.
+- **bun install / cannot find package** → `bun install` in the affected package,
+  retry.
+- **TypeScript / lint error** → fix it (`/catalyst-dev:validate-type-safety`
+  scoped to the diff), retry the phase.
+
+After each action, PRINT the action + its success signal (the `exit 0`, the
+`mergeable: "MERGEABLE"`, the merged SHA, the re-dispatch event id) so `/goal`
+can see it. Use `gh` and `git` directly; delegate a deeper code fix to
+`/catalyst-dev:phase-remediate` or `/catalyst-dev:merge-pr` via the Task tool
+when one fits, but YOU own the cross-pipeline moves.
+
+### Step 3 — Escalate ONLY IF one of these is genuinely true
+
+Walk the checklist. If NONE are checked, it is NOT an escalation — go back to
+Step 1/2 and FIX it.
+
+```
+[ ] Value judgment — a product / priority / UX call only Ryan can make
+    (which of two valid behaviors is "right", whether it's worth doing at all).
+[ ] Affects / removes / degrades other functionality — the fix would delete,
+    break, or regress another ticket's already-merged feature; delivering X
+    means undelivering Y.
+[ ] Real cost-benefit trade-off — a genuine functionality / performance / cost
+    trade only Ryan can own.
+[ ] Serious architecture change — a load-bearing API boundary or structural
+    decision, not a local edit.
+[ ] Flies in the face of an ADR — the only-correct path contradicts an accepted
+    ADR, or is something we've explicitly decided NOT to do autonomously.
+[ ] Genuinely cannot do it autonomously after trying — I cannot determine the
+    correct resolution, or an external approval/credential I do not hold is
+    required.
+```
+
+**EXPLICIT RULE (Ryan's direction).** Do NOT escalate a mere merge conflict. A
+conflict in a file, a CI failure after rebase, a stale branch, a lockfile drift,
+or "the PR is just sitting there mergeable" are NEVER escalations. You ARE allowed
+and EXPECTED to resolve conflicts, rebase, merge PRs, and re-trigger CI
+autonomously. Bring Ryan only the genuine value / architecture / trade-off / ADR
+decisions. If the message you would write to Ryan describes a *mechanical state*
+(conflict, failed check, stale branch, unmerged PR) rather than a *decision Ryan
+owns*, that is the tell that it belongs in the FIX path — re-check Step 2.
+
+### Step 4 — On a legitimate escalation: AUTHOR the two operator messages
+
+This is the part that genuinely differs from phase-remediate. You author what Ryan
+sees in the Needs-You inbox AND in the push notification. Two surfaces, ONE
+payload, executive-voiced (you are the senior engineer reporting up to the PM).
+
+**Voice (from the `writing:ryan-writing-style` skill — Mode 1 / Mode 2):**
+answer-first (lead with the decision needed), plain language (NO stack traces,
+seam_ids, signal paths, exit codes, "bg job" in the operator text — translate
+mechanics into consequences), name specific things ("CTL-1188 and CTL-1190 both
+rewrote `eligible-set.mjs`" beats "a conflict in a shared file"), and STATE WHY
+you're asking and not just doing it (the senior-engineer default is to resolve
+conflicts/rebases/merges yourself, so justify the exception).
+
+**Pick the escalation type:**
+
+- `decision` — two+ coexisting valid paths; Ryan picks. REQUIRES `options[]`.
+- `authorization` — you have a recommendation, but the action removes/degrades
+  functionality or carries a real risk Ryan must approve.
+- `manual` — a capability/credential/value-judgment only a human has (no clean
+  A/B). Prefer `decision`/`authorization` when you actually have a recommendation —
+  "needs a human" with no recommendation is the anti-pattern.
+
+**Build the payload with the CTL-1130 shim** (it rejects tautology copy — no
+"needs a human", no bare "involves trade-offs"; write the specific question + the
+concrete risk):
+
+```bash
+EXPL_JSON="$(node "${EXEC_CORE}/escalation-explain.mjs" \
+  --ticket "$TICKET" --phase "recovery-pass" \
+  --type decision \
+  --problem "CTL-1188 and CTL-1190 both rewrote the eligible-set dispatch path; only one shape can ship." \
+  --call-to-action "Which dispatch shape should win — per-host pinning or quota-aware?" \
+  --options '[{"label":"Keep CTL-1188 per-host pinning","tradeoff":"CTL-1190 quota-aware load balancing must be re-derived on top"},{"label":"Keep CTL-1190 quota-aware","tradeoff":"loses CTL-1188 host pinning that shipped Tuesday"}]' \
+  --why-you "both are valid architectures; the choice is a product-priority call, not an engineering one" \
+  --observed "$(jq -nc --argjson b "$(cat "$BRIEF" 2>/dev/null || echo '{}')" '$b.diagnosis // {}')" \
+  2>/dev/null || echo '{}')"
+[ -n "$EXPL_JSON" ] || EXPL_JSON='{}'
+```
+
+> **Bash gotcha (CTL-1130).** Guard `EXPL_JSON` on its OWN line and pass the bare
+> variable. NEVER inline `${EXPL_JSON:-{}}` — bash closes the expansion at the
+> first `}`, corrupting the JSON.
+
+**Emit the escalation through the recovery-emit shim.** It does three things at
+once: emits `recovery.escalated` (WARN, severityNumber 13) carrying the rich
+payload so the monitor's `notification-composer.ts` (in
+`scripts/orch-monitor/lib/`, NOT `${EXEC_CORE}` — the skill never invokes it; the
+curation layer does) derives the push `short_text` (≤140) + the inbox
+`full_briefing`; merges the payload as the `explanation` block on your signal
+(→ `deriveAttention` flips `needs-human` → the inbox row + nav dot + the push gate
+`shouldNotify`); and latches the host-local escalated intent (terminal — the
+router stops re-acting and hands off to Ryan):
+
+```bash
+node "${EXEC_CORE}/recovery-emit.mjs" escalated \
+  --ticket "$TICKET" --orch-dir "$ORCH_DIR" --phase "recovery-pass" \
+  --escalation "$EXPL_JSON"
+```
+
+You do NOT call web-push yourself — the curation layer
+(`deriveAttention`/`deriveNavSignal` → `shouldNotify` → `/api/notifications/stream`)
+gates the push off the `needs-human` + WARN signals you just wrote. The native/PWA
+app is a thin transport over that same shared filter; there is no second filter to
+satisfy. Print that both the event and the signal explanation were written so
+`/goal` sees the escalation landed.
+
+**On an autonomous FIX, record the win for the audit trail** (INFO, no push — the
+recovered lane, not a needs-you row). Write a plain past-tense changelog, NOT
+engineer chatter:
+
+```bash
+node "${EXEC_CORE}/recovery-emit.mjs" fixed \
+  --ticket "$TICKET" \
+  --reason "Resolved the rebase conflict in eligible-set.mjs by keeping both additions; force-pushed; CI green; merged #2163."
+```
+
+### Iterate
+
+In sweep mode, repeat Steps 0–4 for every enumerated `SWEEP_ITEMS` entry,
+printing a resolution line each. **Bind `TICKET` to the CURRENT item's ticket at
+the top of each iteration** (it is NOT the dispatcher var — that is empty in the
+sweep) and re-resolve `SIGNAL_FILE` /the per-item brief from it, so Step 4's
+`escalation-explain.mjs --ticket "$TICKET"` and `recovery-emit.mjs escalated
+--ticket "$TICKET"` carry the real ticket — an empty `--ticket` is rejected (exit
+2) and would leave the item neither FIXED nor ESCALATED, so the goal would never
+go TRUE. The goal stays FALSE while any item is "still stuck, not yet escalated",
+so keep going. Stop only when every item is UNSTUCK or legitimately ESCALATED.
+
+## Mid-flight inbox check (CTL-749)
+
+Before each item and after long actions, read
+`${ORCH_DIR}/workers/${TICKET}/inbox.jsonl` (when present): a `directive` answers a
+prior question (use it and proceed); a `pause`/`abort` halts you (emit complete
+with what's done, or failed on abort). Archive what you absorb.
+
+## End block (router-dispatched mode — terminal emit)
+
+In router-dispatched mode, emit the terminal event so the scheduler advances and
+the bg job is reaped. (In bare sweep mode there is no signal envelope to close —
+the printed `/goal` resolution lines are the record.)
+
+```bash
+if [[ -n "$TICKET" ]]; then
+  EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
+  # complete = "I finished the recovery pass on this item" (unstuck OR escalated
+  # with the inbox+push authored). The OUTCOME (fixed vs escalated) lives in the
+  # recovery.* event + the signal explanation, not in the phase status — mirroring
+  # phase-remediate's always-complete-on-a-normal-run semantics. Reserve
+  # --status failed for the pass ITSELF breaking (the failure block below).
+  if [[ -x "$EMIT" ]]; then
+    "$EMIT" --phase "recovery-pass" --ticket "$TICKET" --status complete
+  fi
+  # Self-halt to avoid a zombie (CTL-778).
+  if [[ -f "${ORCH_DIR}/workers/${TICKET}/phase-recovery-pass.json" ]]; then
+    _SELF_BG=$(jq -r '.bg_job_id // empty' \
+      "${ORCH_DIR}/workers/${TICKET}/phase-recovery-pass.json" 2>/dev/null || true)
+    [[ -n "$_SELF_BG" ]] && claude stop "${_SELF_BG:0:8}" >/dev/null 2>&1 || true
+  fi
+  [[ -n "${COMMS:-}" && -x "$COMMS" ]] && "$COMMS" done "$CHANNEL" --as "$TICKET" >/dev/null 2>&1 || true
+fi
+```
+
+## Failure handling (the pass ITSELF broke)
+
+Only when the recovery pass cannot run (not when a single item is a legitimate
+escalation — that goes through Step 4). Author a CTL-1130 explanation, then emit
+`failed` with `--status failed`:
+
+```bash
+if [[ -n "$TICKET" ]]; then
+  REASON="${1:-recovery-pass failed}"
+  EXPL_JSON="$(node "${EXEC_CORE}/escalation-explain.mjs" \
+    --ticket "$TICKET" --phase "recovery-pass" \
+    --type authorization \
+    --problem "the recovery pass could not run on ${TICKET}: ${REASON}" \
+    --call-to-action "should ${TICKET} be re-dispatched, fixed by hand, or closed?" \
+    --recommendation "re-run the recovery pass after the underlying tooling failure clears" \
+    --risk "the ticket stays stuck and consumes attention until someone looks" \
+    --why-asking "tooling failure, not a value judgment" \
+    --authorize-label "re-run recovery on ${TICKET}" --can-execute true \
+    2>/dev/null || echo '{}')"
+  [ -n "$EXPL_JSON" ] || EXPL_JSON='{}'
+  node "${EXEC_CORE}/recovery-emit.mjs" escalated \
+    --ticket "$TICKET" --orch-dir "$ORCH_DIR" --phase "recovery-pass" --escalation "$EXPL_JSON" || true
+  "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+    --phase "recovery-pass" --ticket "$TICKET" --status failed --reason "$REASON"
+  exit 1
+fi
+```
+
+## How this plugs in under the router's guardrails
+
+recovery-pass is the WORKER; the router (`reasoningRecoveryPass` +
+`defaultInvokeRecoveryPass` + the scheduler binding) keeps every guardrail and
+this skill plugs in beneath them — exactly where the phase-remediate dispatch sat:
+
+- **Mode gate** — `off | shadow | enforce` from `readRecoveryPassConfig()`
+  (`CATALYST_RECOVERY_PASS`). At `off` (the default) the pass never runs, so this
+  skill is never dispatched — **no live behavior change until an operator opts in.**
+- **Backlog filter** — only `needs-human | failed | stalled | unknown`, HRW
+  ownership, and the terminal/merged drop. You never see a finished ticket.
+- **Caps** — the per-tick fix cap (`maxFixesPerTick`, default 3) and the
+  event-counted per-target recovery-pass cycle cap
+  (`countRecoveryPassCycles ≥ RECOVERY_PASS_CYCLE_CAP`, default 3) both live in the
+  router; you are not re-dispatched past them.
+- **Cooldown + escalated-latch** — the host-local intent ledger
+  (`shouldSkipItem` / `recordIntent`, 30-min cooldown, max-attempts 2, escalated
+  terminal). Your Step-4 escalation latches it via `recovery-emit.mjs`.
+- **Decide/act bright line (ADR-022/023/025)** — the router DERIVES the
+  classification and owns the cooldown/cap; you ACT (resolve/rebase/merge/
+  re-dispatch) and emit the result back to the log. You select among real moves;
+  you never spawn an open-ended fixer loop.
+
+## Why recovery-pass is the right name (and not phase-remediate)
+
+phase-remediate (CTL-653) is the in-pipeline verify⇄remediate fixer for one
+ticket. recovery-pass (CTL-1176 rung 3) is the goal-driven operator/authoring
+layer on top of the deterministic `recovery-reasoning` ladder — it consumes the
+diagnostician + unstuck-sweep output, acts across the pipeline, and authors the
+operator messages. The dispatcher resolves the phase `recovery-pass` to
+`/catalyst-dev:recovery-pass` (the one `skill_for_phase` exception), so the same
+skill is both the router's bounded-LLM worker AND Ryan's standalone sweep.


### PR DESCRIPTION
NEW skill (NOT phase-remediate). Replaces the phase-remediate dispatch in the recovery router's bounded-LLM path with a goal-driven senior-engineer agent that unsticks the pipeline: resolves merge conflicts, rebases, merges green PRs, re-dispatches phases — escalating ONLY genuine judgment calls (value judgment / affects-other-functionality / cost-benefit / serious-architecture / ADR-conflict). Consumes the diagnostician (eyes) + unstuck-sweep (hands) output instead of redoing their narrow work. On escalate it AUTHORS the inbox message + push notification in Ryan's executive voice. Ships behind the existing recovery flags (default off — no behavior change).

## FOR AUDIT — do not auto-merge; Ryan reviews the skill + design doc first.

## What's here
- **`plugins/dev/skills/recovery-pass/SKILL.md`** — the new skill (router-dispatched worker AND bare operator sweep `/catalyst-dev:recovery-pass`).
- **`recovery-emit.mjs`** (new CLI shim) — `fixed` (INFO changelog) / `escalated` (WARN + merges the explanation onto the signal → inbox row + push gate + latches the escalated intent).
- **Wire-in** — `recovery-reasoning.mjs` (`defaultInvokeRecoveryPass` replaces the phase-remediate detour in the bounded-LLM path; first-class `recovery-pass.json` brief, no more fake verify findings; `buildEscalationPayload` upgraded to the composer-ready tagged union; back-compat resolution kept), `event-scan.mjs` (`countRecoveryPassCycles` budget), `scheduler.mjs` (binding), `phase-agent-dispatch` (`skill_for_phase` + turn cap), `phase-artifact-gate.sh` (brief as prior-phase artifact).
- **Design doc** lives in the thoughts repo (gitignored): `thoughts/shared/plans/recovery-pass-skill-design.md`.

## Review fixes applied to the original draft
1. **Sweep-mode escalation dead-end** — in the bare sweep `TICKET` was empty, and the authoring shims reject an empty `--ticket` (exit 2), so a real escalation silently no-oped and the goal never went TRUE. Sweep now enumerates `SWEEP_ITEMS` and binds a per-item `TICKET` before Steps 0–4.
2. **Dangling `EVENTS=`** — the sweep's event-log enumeration was assigned but unused. Now reads the monthly unified JSONL directly (catalyst-events `tail` is a follower, not a one-shot reader) for `recovery.escalated`/`recovery.would-escalate` against the real envelope shape.
3. **`notification-composer.ts` path hint** — clarified it lives in `orch-monitor/lib/`, not `${EXEC_CORE}`.
4. **`deterministicSeamsTried` non-exhaustive** — only the 3 marker'd seams (dirty-tree/source-conflict/orphan-stale) appear; added a caveat to check live git/gh state before re-firing unmarked seams (workflow-token-redispatch, CTL-855, ADR-024 cleaners).

## Safety
Entirely behind `CATALYST_RECOVERY_PASS` (default `off`). At `off` the recovery pass never runs and this skill is never dispatched — zero live behavior change until an operator opts into shadow/enforce.

## Tests
- `recovery-reasoning.test.mjs` — 83 pass / 0 fail (new `defaultInvokeRecoveryPass` suite + bounded-LLM → recovery-pass dispatch + back-compat)
- `event-scan.test.mjs` — 46 pass / 0 fail (`countRecoveryPassCycles`)
- `phase-goal-no-turn-caps.test.sh` — 10 pass / 0 fail (recovery-pass added; no turn-cap self-stop language)
- All bash blocks `bash -n` clean; modules import cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)