### PR TITLE
fix(dev): monitor repoOwners from registry, not stale committed roster (§13 — fixes Adva icon 404)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/repo-icon-fetcher.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/repo-icon-fetcher.test.ts
@@ -158,11 +158,16 @@ describe("buildRepoOwnerMap", () => {
 describe("loadMonitorConfig — repoOwners extraction (CTL-961)", () => {
   let tmpDir: string;
   let configPath: string;
+  // §13: loadMonitorConfig now also reads the registry; these config-only cases
+  // point at a nonexistent registry so they stay deterministic regardless of the
+  // host machine's real ~/catalyst/execution-core/registry.json.
+  let noRegistry: string;
 
   beforeEach(() => {
     tmpDir = join(tmpdir(), `ctl-961-test-${Date.now()}`);
     mkdirSync(tmpDir, { recursive: true });
     configPath = join(tmpDir, "config.json");
+    noRegistry = join(tmpDir, "no-registry.json");
   });
 
   afterEach(() => {
@@ -183,7 +188,7 @@ describe("loadMonitorConfig — repoOwners extraction (CTL-961)", () => {
         },
       },
     }));
-    const cfg = loadMonitorConfig(configPath);
+    const cfg = loadMonitorConfig(configPath, noRegistry);
     expect(cfg.repoOwners).toEqual({
       catalyst: "coalesce-labs/catalyst",
       adva: "coalesce-labs/adva",
@@ -199,18 +204,18 @@ describe("loadMonitorConfig — repoOwners extraction (CTL-961)", () => {
         },
       },
     }));
-    const cfg = loadMonitorConfig(configPath);
+    const cfg = loadMonitorConfig(configPath, noRegistry);
     expect(cfg.repoOwners).toEqual({});
   });
 
   it("returns empty repoOwners when monitor section is absent", () => {
     writeFileSync(configPath, JSON.stringify({ catalyst: {} }));
-    const cfg = loadMonitorConfig(configPath);
+    const cfg = loadMonitorConfig(configPath, noRegistry);
     expect(cfg.repoOwners).toEqual({});
   });
 
   it("returns empty repoOwners when config file is missing", () => {
-    const cfg = loadMonitorConfig(join(tmpDir, "does-not-exist.json"));
+    const cfg = loadMonitorConfig(join(tmpDir, "does-not-exist.json"), noRegistry);
     expect(cfg.repoOwners).toEqual({});
   });
 
@@ -225,7 +230,7 @@ describe("loadMonitorConfig — repoOwners extraction (CTL-961)", () => {
         },
       },
     }));
-    const cfg = loadMonitorConfig(configPath);
+    const cfg = loadMonitorConfig(configPath, noRegistry);
     expect(cfg.repoColors["coalesce-labs/catalyst"]).toBe("green");
     expect(cfg.repoOwners.catalyst).toBe("coalesce-labs/catalyst");
   });
@@ -241,8 +246,46 @@ describe("loadMonitorConfig — repoOwners extraction (CTL-961)", () => {
         },
       },
     }));
-    const cfg = loadMonitorConfig(configPath);
+    const cfg = loadMonitorConfig(configPath, noRegistry);
     expect(cfg.repoOwners["adva"]).toBe("rightsite-cloud/Adva");
     expect(cfg.repoOwners["Adva"]).toBeUndefined();
+  });
+
+  // §13: the machine-level registry corrects a STALE committed roster.
+  it("registry repoRoot OVERRIDES a stale config vcsRepo (ADV → groundworkapp/Adva)", () => {
+    writeFileSync(configPath, JSON.stringify({
+      catalyst: { monitor: { linear: { teams: [
+        { key: "CTL", vcsRepo: "coalesce-labs/catalyst" },
+        { key: "ADV", vcsRepo: "coalesce-labs/adva" }, // stale 404
+      ] } } },
+    }));
+    const registryPath = join(tmpDir, "registry.json");
+    writeFileSync(registryPath, JSON.stringify({ projects: [
+      { team: "CTL", repoRoot: "/Users/x/code-repos/github/coalesce-labs/catalyst" },
+      { team: "ADV", repoRoot: "/Users/x/code-repos/github/groundworkapp/Adva" },
+    ] }));
+    const cfg = loadMonitorConfig(configPath, registryPath);
+    expect(cfg.repoOwners["adva"]).toBe("groundworkapp/Adva"); // registry wins
+    expect(cfg.repoOwners["catalyst"]).toBe("coalesce-labs/catalyst");
+  });
+
+  it("derives repoOwners from the registry even when config has no teams", () => {
+    writeFileSync(configPath, JSON.stringify({ catalyst: { monitor: {} } }));
+    const registryPath = join(tmpDir, "registry.json");
+    writeFileSync(registryPath, JSON.stringify({ projects: [
+      { team: "ADV", repoRoot: "/home/ci/code-repos/github/groundworkapp/Adva" },
+    ] }));
+    const cfg = loadMonitorConfig(configPath, registryPath);
+    expect(cfg.repoOwners["adva"]).toBe("groundworkapp/Adva");
+  });
+
+  it("ignores a registry repoRoot with no /github/<owner>/<repo> segment", () => {
+    writeFileSync(configPath, JSON.stringify({ catalyst: { monitor: {} } }));
+    const registryPath = join(tmpDir, "registry.json");
+    writeFileSync(registryPath, JSON.stringify({ projects: [
+      { team: "X", repoRoot: "/some/local/path/no-github" },
+    ] }));
+    const cfg = loadMonitorConfig(configPath, registryPath);
+    expect(cfg.repoOwners).toEqual({});
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/monitor-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/monitor-config.ts
@@ -1,4 +1,6 @@
 import { readFileSync } from "fs";
+import { join, basename } from "path";
+import { homedir } from "os";
 
 export type HudColumnId =
   | "status"
@@ -54,43 +56,69 @@ function isRecord(x: unknown): x is Record<string, unknown> {
  *     }
  *   }
  */
-export function loadMonitorConfig(configPath: string): MonitorConfig {
-  let raw: string;
-  try {
-    raw = readFileSync(configPath, "utf8");
-  } catch {
-    return { repoColors: {}, repoOwners: {} };
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return { repoColors: {}, repoOwners: {} };
-  }
-  if (!isRecord(parsed) || !isRecord(parsed.catalyst)) return { repoColors: {}, repoOwners: {} };
-  const monitor = parsed.catalyst.monitor;
-  if (!isRecord(monitor)) return { repoColors: {}, repoOwners: {} };
+// repoSlugFromRoot — derive a GitHub "owner/repo" slug from a registry repoRoot
+// path (…/code-repos/github/groundworkapp/Adva → groundworkapp/Adva). Returns null
+// when there is no /github/<owner>/<repo> segment. §13 — the registry's repoRoot is
+// the machine-level source of truth for which repo a team actually lives in.
+function repoSlugFromRoot(repoRoot: string): string | null {
+  const m = repoRoot.match(/\/github\/([^/]+\/[^/]+?)\/?$/);
+  return m ? m[1] : null;
+}
 
-  // repoColors from catalyst.monitor.github.repoColors
-  const github = monitor.github;
+export function loadMonitorConfig(configPath: string, registryPath?: string): MonitorConfig {
   const repoColors: Record<string, string> = {};
-  if (isRecord(github) && isRecord(github.repoColors)) {
-    for (const [repo, color] of Object.entries(github.repoColors)) {
-      if (typeof color === "string") repoColors[repo] = color;
-    }
-  }
-
-  // CTL-961: repoOwners from catalyst.monitor.linear.teams (repo short-name → owner/repo)
-  // CTL-979: key is lowercased so /api/repo-icon/adva resolves vcsRepo "rightsite-cloud/Adva".
   const repoOwners: Record<string, string> = {};
-  const linear = monitor.linear;
-  if (isRecord(linear) && Array.isArray(linear.teams)) {
-    for (const team of linear.teams) {
-      if (isRecord(team) && typeof team.vcsRepo === "string" && team.vcsRepo.includes("/")) {
-        const shortName = team.vcsRepo.split("/").at(-1);
-        if (shortName) repoOwners[shortName.toLowerCase()] = team.vcsRepo;
+
+  // --- config-derived: repoColors + FALLBACK repoOwners (catalyst.monitor.*) ---
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(configPath, "utf8"));
+    if (isRecord(parsed) && isRecord(parsed.catalyst) && isRecord(parsed.catalyst.monitor)) {
+      const monitor = parsed.catalyst.monitor;
+      // repoColors from catalyst.monitor.github.repoColors
+      const github = monitor.github;
+      if (isRecord(github) && isRecord(github.repoColors)) {
+        for (const [repo, color] of Object.entries(github.repoColors)) {
+          if (typeof color === "string") repoColors[repo] = color;
+        }
+      }
+      // CTL-961: repoOwners from catalyst.monitor.linear.teams (short-name → owner/repo).
+      // §13: this is now the FALLBACK — the committed roster can be stale (e.g. ADV →
+      // coalesce-labs/adva, a 404). The registry override below corrects it.
+      const linear = monitor.linear;
+      if (isRecord(linear) && Array.isArray(linear.teams)) {
+        for (const team of linear.teams) {
+          if (isRecord(team) && typeof team.vcsRepo === "string" && team.vcsRepo.includes("/")) {
+            const shortName = team.vcsRepo.split("/").at(-1);
+            if (shortName) repoOwners[shortName.toLowerCase()] = team.vcsRepo;
+          }
+        }
       }
     }
+  } catch {
+    /* config absent/malformed → registry-derived owners (below) still apply */
+  }
+
+  // --- registry-derived repoOwners OVERRIDE (§13) ---
+  // The machine-level execution-core/registry.json carries the CORRECT team→repoRoot,
+  // which can DIVERGE from the stale committed monitor.linear.teams (ADV: registry
+  // groundworkapp/Adva vs config coalesce-labs/adva — a dead 404 that breaks repo
+  // icons). Derive the slug from repoRoot and let the registry WIN so icons/links
+  // resolve the real repo. The committed config stays only as a fallback.
+  const regPath =
+    registryPath ??
+    join(process.env.CATALYST_DIR ?? join(homedir(), "catalyst"), "execution-core", "registry.json");
+  try {
+    const reg: unknown = JSON.parse(readFileSync(regPath, "utf8"));
+    if (isRecord(reg) && Array.isArray(reg.projects)) {
+      for (const p of reg.projects) {
+        if (isRecord(p) && typeof p.repoRoot === "string") {
+          const slug = repoSlugFromRoot(p.repoRoot);
+          if (slug) repoOwners[basename(slug).toLowerCase()] = slug;
+        }
+      }
+    }
+  } catch {
+    /* no registry → config-derived owners stand */
   }
 
   return { repoColors, repoOwners };


### PR DESCRIPTION
## Problem (confirmed)
The monitor's `/api/repo-icon` resolves team→repo via `loadMonitorConfig` → `repoOwners`, built from the **committed `.catalyst/config.json` `monitor.linear.teams[]`** — which still maps `ADV → coalesce-labs/adva` (a **404**). So Adva repo icons fail to load. The machine-level `execution-core/registry.json` already has the truth: `groundworkapp/Adva`.

This is §13 of `2026-06-16-cluster-config-architecture.md` — the repo-roster relocation that was marked Done under CTL-1214 but **never landed** (CTL-1214's commit `fd85d211` never touched `.catalyst/config.json`; §13 was explicitly deferred in CTL-1211).

## Fix
`loadMonitorConfig` now derives `repoOwners` from the **registry `repoRoot`** (`…/github/<owner>/<repo>` → `<owner>/<repo>`) and lets the registry **override** the committed config. The committed `monitor.linear.teams[]` stays only as a fallback (external single-host before enroll). Non-breaking: no registry → config-derived owners stand.

## Tests
`repo-icon-fetcher.test.ts`: registry override (ADV→groundworkapp/Adva wins over the stale config), registry-only derivation, `/github/` slug edge case. Existing config-only cases isolated against the host's real registry. 31/0 pass.

## Deploy note
Takes effect once mini's monitor restarts on the merged code (monitor-only restart, safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)