### PR TITLE
feat(dev): CTL-1245 — revive dead-but-running-signalled workers

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -474,6 +474,35 @@ export const ZOMBIE_STALE_FLOOR_MS =
 export const REVIVE_MAX_AGE_MS =
   Number(process.env.EXECUTION_CORE_REVIVE_MAX_AGE_MS) || 24 * 60 * 60_000;
 
+// CTL-1245 — dead-but-`running`-signalled doc-worker transcript-silence floor.
+//
+// THE GAP this closes: a `--bg` doc-phase worker (triage/research/plan/verify/
+// review) that dies WITHOUT Claude stamping its ~/.claude/jobs/<id>/state.json
+// terminal (SIGKILL/OOM/daemon-kill leaves it frozen at state:"working") reads
+// jobLifecycle === "alive" FOREVER. On the headless enforce host (mini), `claude
+// agents --json` is unreliable (CTL-829) so the CTL-809 fresh-snapshot ghost
+// breaker cannot fire, and the CTL-868 cold-snapshot mtime floor for these
+// doc phases is BUSY_CEILING_MS (6h) — so a genuinely-dead triage/plan corpse
+// sits "alive-suppressed" for up to 6h, starving slots (the 2026-06-17 evidence:
+// CTL-1240/1241/1242/1243 dead at plan/research, 4.5h+ no recovery).
+//
+// The corroborator: a LIVE doc worker mid in-process sub-agent fan-out keeps
+// writing its transcript (and its subagents' transcripts — transcriptAgeMs folds
+// those in), so a fresh transcript proves liveness; a transcript silent beyond
+// this floor on an `alive`-by-state.json worker is a corpse. This lets the
+// cold-snapshot doc-phase branch declare death in MINUTES instead of 6h while
+// staying CTL-662-safe (a busy fan-out is spared by its own transcript writes).
+//
+// Deliberately well above any plausible inter-turn / sub-agent gap (30 min):
+// a healthy doc worker writes its transcript far more often than this. Strictly
+// SUBORDINATE to a fresh agents snapshot (a LISTED worker is never reclaimed by
+// this floor) and to the death MODE gate below (off by default → strict no-op).
+// Env-overridable for tuning. A null transcript age (can't measure — no session,
+// no transcript file) is treated as NOT-silent: the worker is spared (fail to a
+// false-negative, never touch a possibly-live worker — the #1 invariant).
+export const DEAD_DOC_WORKER_TRANSCRIPT_SILENCE_MS =
+  Number(process.env.EXECUTION_CORE_DEAD_DOC_WORKER_SILENCE_MS) || 30 * 60_000;
+
 // CTL-650 — the push-based session wait-state watcher. Default ON; the daemon
 // continuously classifies live sessions and emits agent.waiting_on_user /
 // agent.resumed transition events. CATALYST_WAIT_WATCHER=0 disables it (the
@@ -893,6 +922,42 @@ export function readRecoveryPassConfig() {
   } else if (typeof env === "string" && RECOVERY_PASS_MODES.has(env)) {
     mode = env;
   } else if (typeof l2.mode === "string" && RECOVERY_PASS_MODES.has(l2.mode)) {
+    mode = l2.mode;
+  } else {
+    mode = "off"; // safe default: off — operators opt into shadow then enforce
+  }
+  return { mode };
+}
+
+// CTL-1245: dead-but-running doc-worker reclaim mode reader. Mirrors
+// readRecoveryPassConfig / readUnstuckSweepConfig exactly: env
+// (CATALYST_DEAD_DOC_WORKER_RECLAIM) overrides Layer-2 config
+// (.catalyst.recovery.deadDocWorker.mode), which overrides the safe default
+// 'off'. Ships off (ADR-023): the transcript-silence corroborator that lets the
+// cold-snapshot doc-phase ghost breaker fire in minutes (instead of the 6h busy
+// ceiling) is INERT until an operator opts into shadow then enforce.
+//   off     → strict no-op: behaviour byte-for-byte identical to pre-CTL-1245.
+//   shadow  → measure + LOG the would-be death verdict, take NO action.
+//   enforce → set ghostAbsent and fall through to the existing revive path
+//             (under the CTL-736 progress gate + O_EXCL claim + CTL-638 cooldown).
+const DEAD_DOC_WORKER_MODES = new Set(["off", "shadow", "enforce"]);
+
+function readLayer2DeadDocWorker() {
+  try {
+    const d = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.recovery?.deadDocWorker;
+    return d && typeof d === "object" ? d : {};
+  } catch { return {}; }
+}
+
+export function readDeadDocWorkerConfig() {
+  const l2 = readLayer2DeadDocWorker();
+  const env = process.env.CATALYST_DEAD_DOC_WORKER_RECLAIM;
+  let mode;
+  if (env === "0") {
+    mode = "off"; // kill-switch
+  } else if (typeof env === "string" && DEAD_DOC_WORKER_MODES.has(env)) {
+    mode = env;
+  } else if (typeof l2.mode === "string" && DEAD_DOC_WORKER_MODES.has(l2.mode)) {
     mode = l2.mode;
   } else {
     mode = "off"; // safe default: off — operators opt into shadow then enforce

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -33,6 +33,8 @@ import {
   getStaticRoster,
   resolveClusterHosts,
   CLUSTER_SYNC_INTERVAL_MS,
+  readDeadDocWorkerConfig,
+  DEAD_DOC_WORKER_TRANSCRIPT_SILENCE_MS,
 } from "./config.mjs";
 
 const PREV = process.env.CATALYST_WAIT_WATCHER;
@@ -749,5 +751,58 @@ describe("getLivenessAnchorIssue (CTL-1090)", () => {
 describe("LIVENESS_PUBLISH_INTERVAL_MS (CTL-1090)", () => {
   test("defaults to 120000ms (2 minutes)", () => {
     expect(LIVENESS_PUBLISH_INTERVAL_MS).toBe(120_000);
+  });
+});
+
+describe("readDeadDocWorkerConfig (CTL-1245)", () => {
+  const DD_ENVS = ["CATALYST_DEAD_DOC_WORKER_RECLAIM", "CATALYST_LAYER2_CONFIG_FILE"];
+  let saved = {}, tmp;
+  beforeEach(() => {
+    for (const k of DD_ENVS) { saved[k] = process.env[k]; delete process.env[k]; }
+    tmp = mkdtempSync(join(tmpdir(), "ctl1245-dd-"));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = join(tmp, "absent.json");
+  });
+  afterEach(() => {
+    for (const k of DD_ENVS) { saved[k] === undefined ? delete process.env[k] : (process.env[k] = saved[k]); }
+    saved = {}; rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("default: mode=off (ships inert — strict no-op)", () => {
+    expect(readDeadDocWorkerConfig().mode).toBe("off");
+  });
+  test("CATALYST_DEAD_DOC_WORKER_RECLAIM=0 maps to mode:off (kill-switch)", () => {
+    process.env.CATALYST_DEAD_DOC_WORKER_RECLAIM = "0";
+    expect(readDeadDocWorkerConfig().mode).toBe("off");
+  });
+  test("env shadow / enforce are honored", () => {
+    process.env.CATALYST_DEAD_DOC_WORKER_RECLAIM = "shadow";
+    expect(readDeadDocWorkerConfig().mode).toBe("shadow");
+    process.env.CATALYST_DEAD_DOC_WORKER_RECLAIM = "enforce";
+    expect(readDeadDocWorkerConfig().mode).toBe("enforce");
+  });
+  test("reads catalyst.recovery.deadDocWorker.mode from Layer-2", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { recovery: { deadDocWorker: { mode: "enforce" } } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    expect(readDeadDocWorkerConfig().mode).toBe("enforce");
+  });
+  test("env wins over Layer-2", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { recovery: { deadDocWorker: { mode: "enforce" } } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    process.env.CATALYST_DEAD_DOC_WORKER_RECLAIM = "0";
+    expect(readDeadDocWorkerConfig().mode).toBe("off");
+  });
+  test("invalid mode string → falls back to off", () => {
+    process.env.CATALYST_DEAD_DOC_WORKER_RECLAIM = "banana";
+    expect(readDeadDocWorkerConfig().mode).toBe("off");
+  });
+  test("malformed Layer-2 file → off (never throws)", () => {
+    const cfg = join(tmp, "config.json"); writeFileSync(cfg, "{ not json");
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    expect(readDeadDocWorkerConfig().mode).toBe("off");
+  });
+  test("transcript-silence floor defaults to 30 minutes", () => {
+    expect(DEAD_DOC_WORKER_TRANSCRIPT_SILENCE_MS).toBe(30 * 60_000);
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -39,7 +39,13 @@ import {
   HEARTBEAT_GRACE_MS,
   ZOMBIE_STALE_FLOOR_MS,
   NEVER_STARTED_MS,
+  DEAD_DOC_WORKER_TRANSCRIPT_SILENCE_MS,
+  readDeadDocWorkerConfig,
 } from "./config.mjs";
+// CTL-1245: transcript-silence corroborator. transcriptAgeMs folds in subagent
+// transcripts so a doc worker mid in-process fan-out is never judged silent
+// (CTL-662-safe). Used ONLY to break the cold-snapshot doc-phase 6h tie below.
+import { transcriptAgeMs as defaultTranscriptAgeMs } from "./transcript-silence.mjs";
 import { readPeerHeartbeatsSync } from "./cluster-heartbeat-sync.mjs";
 import { HEARTBEAT_EVENT } from "./heartbeat-event.mjs"; // CTL-859: node.heartbeat reader
 import { resolveTicketType, UNKNOWN_TICKET_TYPE } from "./ticket-type.mjs"; // CTL-1023: work-type dimension
@@ -1811,6 +1817,16 @@ export function reclaimDeadWorkIfPossible(
     // Subordinate to a fresh snapshot (a LISTED worker is busy, never reclaimed
     // here regardless of mtime — CTL-662-safe). Injectable; defaults to the const.
     zombieStaleFloorMs = ZOMBIE_STALE_FLOOR_MS,
+    // CTL-1245 — dead-but-running doc-worker corroborator seams. deadDocWorkerMode
+    // gates the whole feature (off → strict no-op; shadow → log only; enforce →
+    // set ghostAbsent). transcriptAgeMs measures the most-recent transcript write
+    // (subagents folded in) so a busy fan-out is spared; deadDocSilenceMs is the
+    // silence floor past which an `alive`-by-state.json doc worker with no fresh
+    // agents snapshot is a corpse. All injectable; production defaults read the
+    // env/Layer-2 mode and the real transcript primitive. INERT by default.
+    deadDocWorkerMode = readDeadDocWorkerConfig().mode,
+    transcriptAgeMs = defaultTranscriptAgeMs,
+    deadDocSilenceMs = DEAD_DOC_WORKER_TRANSCRIPT_SILENCE_MS,
     // CTL-735 — revival age ceiling. An absent/idle, work-not-done worker whose
     // signal has not been touched in this long is an abandoned historical dir,
     // not a fresh crash: treated as inert (no revive, no escalate). Injectable for
@@ -2467,6 +2483,43 @@ export function reclaimDeadWorkIfPossible(
               { ticket, phase, prevBgJobId, staleForMs: now() - job.mtimeMs, mtimeFloorMs },
               "ctl-868: jobLifecycle-alive but state.json mtime stale beyond zombie floor (no fresh agents snapshot) — treating as dead (zombie breaker)"
             );
+          } else if (
+            // CTL-1245 — dead-but-running doc-worker corroborator. The CTL-868
+            // mtime floor above is BUSY_CEILING_MS (6h) for doc phases
+            // (MTIME_ZOMBIE_EXEMPT_PHASES), so a genuinely-dead triage/research/
+            // plan/verify/review corpse with a frozen state:"working" sits
+            // alive-suppressed for up to 6h on the headless mini (no fresh
+            // agents snapshot to break it). Corroborate liveness with the
+            // TRANSCRIPT: a live worker (incl. a multi-minute in-process sub-agent
+            // fan-out — transcriptAgeMs folds subagent transcripts in) keeps
+            // writing it; a transcript silent past deadDocSilenceMs on an
+            // alive-by-state.json doc worker is a corpse. Conjunction (ALL
+            // required; any miss → spare the worker, the #1 invariant):
+            //   • feature enabled (mode shadow|enforce — off is a strict no-op);
+            //   • this is a doc/exempt phase (the only ones stuck at the 6h floor);
+            //   • mtime floor did NOT already fire (else ghostAbsent is set above);
+            //   • the transcript age is MEASURABLE (null = can't measure = spare)
+            //     AND older than deadDocSilenceMs.
+            deadDocWorkerMode !== "off" &&
+            MTIME_ZOMBIE_EXEMPT_PHASES.has(phase)
+          ) {
+            const tAge = transcriptAgeMs(signal, { now: now() });
+            const silent = Number.isFinite(tAge) && tAge > deadDocSilenceMs;
+            if (silent) {
+              if (deadDocWorkerMode === "enforce") {
+                ghostAbsent = true;
+                log.warn(
+                  { ticket, phase, prevBgJobId, transcriptAgeMs: tAge, deadDocSilenceMs, mode: deadDocWorkerMode },
+                  "ctl-1245: jobLifecycle-alive doc worker with transcript silent past floor (no fresh agents snapshot) — treating as dead (dead-doc-worker breaker)",
+                );
+              } else {
+                // shadow: measure + log the would-be verdict, take NO action.
+                log.info(
+                  { ticket, phase, prevBgJobId, transcriptAgeMs: tAge, deadDocSilenceMs, mode: deadDocWorkerMode },
+                  "ctl-1245 shadow: doc worker WOULD be reclaimed as dead (transcript silent past floor) — no action taken",
+                );
+              }
+            }
           }
         }
       }

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -1156,6 +1156,192 @@ describe("reclaimDeadWorkIfPossible", () => {
     expect(emit.calls.length).toBe(1);
   });
 
+  // CTL-1245 — DEAD-BUT-RUNNING DOC-WORKER BREAKER. A --bg doc worker
+  // (triage/research/plan/verify/review) that dies WITHOUT Claude stamping its
+  // state.json terminal (SIGKILL/OOM) reads jobLifecycle "alive" forever. On the
+  // headless mini (no fresh agents snapshot — CTL-829) the CTL-868 cold floor for
+  // these phases is the 6h busy ceiling, so a genuinely-dead triage/plan corpse
+  // sits alive-suppressed up to 6h, starving slots (the 2026-06-17 evidence).
+  // The corroborator: a LIVE doc worker keeps WRITING its transcript (subagents
+  // folded in by transcriptAgeMs → fan-out safe); a transcript silent past the
+  // floor on an alive-by-state.json doc worker is a corpse. Gated off-by-default.
+  //
+  // The conjunction (mode≠off ∧ doc phase ∧ mtime floor NOT already tripped ∧
+  // measurable transcript age > floor) sets ghostAbsent and the worker falls
+  // through to the existing branch-(C) revive under the CTL-736 progress gate.
+  const DEAD_DOC_SILENCE = 30 * 60_000; // 30min default
+  // A worker whose state.json mtime is RECENT (within the 2h zombie floor and far
+  // under the 6h doc ceiling) so the mtime-floor branch never fires — isolating
+  // the transcript corroborator as the sole death signal. now is 31min past start.
+  const docNow = STARTED_MS + 31 * 60_000;
+  // Full branch-(C) revive seams (work-not-done) so a corroborated-dead doc worker
+  // routes through the progress gate exactly like any other reclaim-eligible worker.
+  const docReviveSeams = (extra = {}) => ({
+    repoRoot: "/repo",
+    statJob: () => ({ exists: true, state: "working", mtimeMs: docNow - 60_000 }), // mtime fresh → mtime floor inert
+    probes: { research: () => false, plan: () => false, triage: () => false }, // work NOT done → branch (C)
+    emitComplete: recorder({ code: 0 }),
+    appendEvent: recorder(undefined),
+    appendReviveEvent: recorder(true),
+    appendEscalatedEvent: recorder(undefined),
+    appendReviveSuppressedEvent: recorder(undefined),
+    reviveDispatch: recorder({ code: 0 }),
+    applyStalledLabel: recorder({ applied: true }),
+    killBgJob: recorder(undefined),
+    countReviveEvents: recorder(0),
+    writeReviveMarker: recorder(undefined),
+    writeProgressMark: recorder(undefined),
+    resolveSession: () => null,
+    readBootSince: () => undefined,
+    inEscalationCooldownFn: () => false,
+    recordEscalationFn: recorder(undefined),
+    emitReapIntent: () => Promise.resolve(),
+    breaker: { isOpen: () => false },
+    agentsSnapshot: () => ({ agents: [], isFresh: false, ageMs: Infinity }), // mini: cold (CTL-829)
+    ghostGraceMs: GHOST_GRACE,
+    zombieStaleFloorMs: ZOMBIE_FLOOR,
+    busyCeilingMs: BUSY_CEILING,
+    deadDocSilenceMs: DEAD_DOC_SILENCE,
+    now: () => docNow,
+    ...extra,
+  });
+
+  test("CTL-1245: enforce — dead plan worker, transcript silent past floor, no fresh snapshot, work-not-done → REVIVED once (the core fix)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, docSignal("plan"), docReviveSeams({
+      deadDocWorkerMode: "enforce",
+      transcriptAgeMs: () => 45 * 60_000, // 45min silent > 30min floor → corpse
+      progressMark: () => 0,
+      readProgressMark: () => -1, // first death, no prior mark → one revive
+      reviveDispatch,
+    }));
+    expect(r).toBe("revived");
+    expect(reviveDispatch.calls.length).toBe(1);
+  });
+
+  test("CTL-1245: enforce — LIVE doc worker mid fan-out (FRESH transcript) → alive-suppressed, NEVER touched (#1 correctness case)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const killBgJob = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, docSignal("research"), docReviveSeams({
+      deadDocWorkerMode: "enforce",
+      transcriptAgeMs: () => 2 * 60_000, // 2min ago — sub-agent fan-out alive < 30min floor
+      reviveDispatch,
+      killBgJob,
+    }));
+    expect(r).toBe("alive-suppressed");
+    expect(reviveDispatch.calls.length).toBe(0);
+    expect(killBgJob.calls.length).toBe(0);
+  });
+
+  test("CTL-1245: mode=off (default) — dead doc worker with silent transcript → alive-suppressed (strict no-op, feature inert)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    let transcriptCalled = 0;
+    const r = reclaimDeadWorkIfPossible(orch, docSignal("triage"), docReviveSeams({
+      deadDocWorkerMode: "off",
+      transcriptAgeMs: () => { transcriptCalled++; return 99 * 60_000; }, // would be silent
+      reviveDispatch,
+    }));
+    expect(r).toBe("alive-suppressed");
+    expect(reviveDispatch.calls.length).toBe(0);
+    expect(transcriptCalled).toBe(0); // off short-circuits before measuring — strict no-op
+  });
+
+  test("CTL-1245: mode=shadow — dead doc worker with silent transcript → alive-suppressed (measures + logs, takes NO action)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    let transcriptCalled = 0;
+    const r = reclaimDeadWorkIfPossible(orch, docSignal("plan"), docReviveSeams({
+      deadDocWorkerMode: "shadow",
+      transcriptAgeMs: () => { transcriptCalled++; return 99 * 60_000; }, // silent
+      reviveDispatch,
+    }));
+    expect(r).toBe("alive-suppressed");
+    expect(reviveDispatch.calls.length).toBe(0);
+    expect(transcriptCalled).toBe(1); // shadow DOES measure (to log the would-be verdict)…
+    // …but takes no action: still suppressed.
+  });
+
+  test("CTL-1245: enforce — transcript age NULL (can't measure) → alive-suppressed (fail to false-negative, never touch a possibly-live worker)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, docSignal("research"), docReviveSeams({
+      deadDocWorkerMode: "enforce",
+      transcriptAgeMs: () => null, // no session / no transcript file → unmeasurable
+      reviveDispatch,
+    }));
+    expect(r).toBe("alive-suppressed");
+    expect(reviveDispatch.calls.length).toBe(0);
+  });
+
+  test("CTL-1245: enforce — NON-doc phase (implement) is untouched by the corroborator (it keeps the 2h mtime floor only)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, docSignal("implement"), docReviveSeams({
+      deadDocWorkerMode: "enforce",
+      probes: { implement: () => false },
+      transcriptAgeMs: () => 99 * 60_000, // silent, but implement is not a doc phase
+      reviveDispatch,
+    }));
+    expect(r).toBe("alive-suppressed"); // mtime fresh + not a doc phase → corroborator never runs
+    expect(reviveDispatch.calls.length).toBe(0);
+  });
+
+  test("CTL-1245: enforce — FRESH snapshot lists the worker → alive-suppressed even with a silent transcript (CTL-662: fresh-present wins)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, docSignal("plan", { bgJobId: "807b77bd" }), docReviveSeams({
+      deadDocWorkerMode: "enforce",
+      agentsSnapshot: () => ({
+        agents: [{ sessionId: "807b77bd-0000-0000-0000-000000000000" }], // listed → busy
+        isFresh: true,
+        ageMs: 1_000,
+      }),
+      transcriptAgeMs: () => 99 * 60_000, // silent, but a fresh-present verdict dominates
+      reviveDispatch,
+    }));
+    expect(r).toBe("alive-suppressed");
+    expect(reviveDispatch.calls.length).toBe(0);
+  });
+
+  test("CTL-1245: enforce — corroborated-dead worker that RE-DIES at zero progress hits the gate → no-progress-stopped, NEVER loops", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const appendEscalatedEvent = recorder(undefined);
+    const killBgJob = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, docSignal("plan"), docReviveSeams({
+      deadDocWorkerMode: "enforce",
+      transcriptAgeMs: () => 45 * 60_000, // silent → corpse, falls to branch (C)
+      progressMark: () => 0,
+      readProgressMark: () => 0, // first revive already recorded 0; still 0 → STOP (no second revive)
+      reviveDispatch,
+      appendEscalatedEvent,
+      killBgJob,
+    }));
+    expect(r).toBe("no-progress-stopped");
+    expect(reviveDispatch.calls.length).toBe(0); // the futile respawn is suppressed
+    expect(appendEscalatedEvent.calls[0][0].reason).toBe("no-progress");
+    expect(killBgJob.calls.length).toBe(1);
+  });
+
+  test("CTL-1245: storm — N corroborated-dead doc workers each route through the progress gate independently (no batch bypass)", () => {
+    // The fix admits dead doc workers ONE SIGNAL AT A TIME through the existing
+    // reclaim path: there is no new batch/queue, so the per-(ticket,phase) O_EXCL
+    // claim + progress gate bound each independently. A worker that progressed is
+    // revived; a flat one is stopped — exactly as the gate dictates, at any N.
+    const tickets = ["CTL-1240", "CTL-1241", "CTL-1242", "CTL-1243"];
+    const results = tickets.map((t, i) => {
+      const sig = docSignal("plan");
+      sig.ticket = t;
+      sig.raw.ticket = t;
+      sig.raw.orchestrator = t;
+      // even-index workers progressed (revive), odd-index flat (stop) — proving
+      // the gate, not a batch cap, decides each one.
+      const progressed = i % 2 === 0;
+      return reclaimDeadWorkIfPossible(orch, sig, docReviveSeams({
+        deadDocWorkerMode: "enforce",
+        transcriptAgeMs: () => 45 * 60_000,
+        progressMark: () => (progressed ? 3 : 0),
+        readProgressMark: () => (progressed ? 1 : 0),
+      }));
+    });
+    expect(results).toEqual(["revived", "no-progress-stopped", "revived", "no-progress-stopped"]);
+  });
+
   test("'noop' for an unknown signal (no bg_job_id)", () => {
     const sig = implementSignal();
     sig.liveness = { kind: "bg", value: null };


### PR DESCRIPTION
Closes the dominant board-stuck gap: a `--bg` doc-phase worker that dies leaving a stale `running`/`triage`/`research`/`plan` signal was invisible to recovery. On the headless mini (no fresh `claude agents` snapshot — CTL-829), the CTL-868 cold-snapshot mtime floor for doc phases is the 6h busy ceiling, so a genuinely-dead corpse with a frozen `state:"working"` state.json (SIGKILL/OOM) sat `alive-suppressed` for up to 6h, starving slots.

## The fix
Adds a **transcript-silence corroborator** to the cold-snapshot doc-phase branch of `reclaimDeadWorkIfPossible` (`recovery.mjs`). A live worker — including one mid in-process sub-agent fan-out (`transcriptAgeMs` folds subagent transcripts in) — keeps writing its transcript; a transcript silent past 30 min on an `alive`-by-state.json doc worker is a corpse → set `ghostAbsent` and fall through to the **existing** CTL-736 progress-gated revive path.

## Safety (conservative, conjunctive, fail-to-false-negative)
ALL must hold or the worker is spared (the #1 invariant — never touch a possibly-live worker):
- mode `shadow|enforce` (off → strict no-op, byte-identical to pre-CTL-1245)
- doc/exempt phase only (implement/remediate keep the 2h mtime floor, untouched)
- mtime floor did NOT already fire
- NO fresh `claude agents` snapshot (a fresh-present verdict dominates — CTL-662 fan-out safe)
- transcript age MEASURABLE (null → spare) AND > 30 min floor

No new revive path, no new dispatch, no batch/queue: dead doc workers are admitted **one signal at a time** through the unchanged reclaim path. A corroborated-dead worker that re-dies at flat progress hits the CTL-736 progress gate → `no-progress-stopped` (never respawn — no CTL-736 storm). The per-(ticket,phase) O_EXCL claim + fencing generation makes a duplicate spawn structurally impossible; CTL-638 escalation cooldown unchanged.

## Activation
Ships **off by default** (ADR-023). `CATALYST_DEAD_DOC_WORKER_RECLAIM` env (`shadow`/`enforce`/`0`=kill-switch) + Layer-2 `catalyst.recovery.deadDocWorker.mode`. Merging changes nothing on the live enforce daemon until an operator opts into shadow → enforce.

## Tests
`recovery.test.mjs` + `config.test.mjs` drive the real predicate (fixed startedAt, now=+31min, fresh statJob mtime to skip the mtime-floor branch, cold snapshot) — incl. the two no-touch cases (live-fresh-transcript, null-transcript), fresh-snapshot-wins, off/shadow no-op, non-doc-phase untouched, re-die → no-progress-stopped, and an N-worker storm routing each independently. **883 pass / 0 fail** across recovery + scheduler + config suites.

**FOR AUDIT — do not auto-merge; this is a live core-loop change.**

Handoff: `thoughts/shared/handoffs/CTL-1245/2026-06-17_08-17-28_dead-worker-revival-gap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)