### PR TITLE
feat(dev): cross-host liveness → single control plane (CTL-1251)

### DIFF
--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
@@ -59,6 +59,7 @@ export function startLivenessPublisher({
   orchDir,
   ownedTickets = () => localInFlightTickets(self, { orchDir }),
   publish = (args) => publishHeartbeatSync(args),
+  logger = log, // CTL-1251: injectable so tests can assert publish-outcome logging
 } = {}) {
   // Single-host no-op (no network, no publish, zero cost).
   if (!Array.isArray(roster) || roster.length <= 1) {
@@ -67,7 +68,7 @@ export function startLivenessPublisher({
 
   // Multi-host but no anchor configured: warn once, return inert handle.
   if (!anchorIssue) {
-    log.warn(
+    logger.warn(
       { roster },
       "cluster-heartbeat-publisher: CATALYST_LIVENESS_ANCHOR_ISSUE not configured — " +
         "cross-host liveness channel is disabled. Set catalyst.cluster.livenessAnchorIssue " +
@@ -76,9 +77,33 @@ export function startLivenessPublisher({
     return { stop() {} };
   }
 
+  // CTL-1251: a publish failure used to vanish into fail-open silence, so a
+  // multi-host daemon that "isn't publishing" gave no diagnostic. We now LOG the
+  // outcome: warn on failure (with the reason from publishHeartbeatSync), but
+  // throttle to once-per-CONSECUTIVE-failure-run so a sustained Linear outage
+  // doesn't spam the log every interval. The first success after failures logs
+  // an info recovery line. Still fail-open — logging never throws.
+  let consecutiveFailures = 0;
   const tick = () => {
     try {
-      publish({ anchorIssue, host: self, inFlightTickets: ownedTickets() });
+      const result = publish({ anchorIssue, host: self, inFlightTickets: ownedTickets() });
+      if (result && result.ok === false) {
+        if (consecutiveFailures === 0) {
+          logger.warn(
+            { host: self, anchorIssue, error: result.error },
+            "cluster-heartbeat-publisher: publish to liveness anchor FAILED — peers will look stale",
+          );
+        }
+        consecutiveFailures += 1;
+      } else {
+        if (consecutiveFailures > 0) {
+          logger.info(
+            { host: self, anchorIssue, afterFailures: consecutiveFailures },
+            "cluster-heartbeat-publisher: publish recovered",
+          );
+        }
+        consecutiveFailures = 0;
+      }
     } catch {
       // fail-open: a Linear hiccup must never crash the daemon
     }

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.test.mjs
@@ -107,4 +107,114 @@ describe("startLivenessPublisher (CTL-1090)", () => {
     expect(typeof h.stop).toBe("function");
     h.stop();
   });
+
+  // CTL-1251: a publish failure must be LOGGED (was previously silent), so an
+  // operator can diagnose why a multi-host daemon isn't publishing.
+  function fakeLogger() {
+    const warns = [];
+    const infos = [];
+    return { logger: { warn: (o, m) => warns.push({ o, m }), info: (o, m) => infos.push({ o, m }) }, warns, infos };
+  }
+
+  test("publish returning {ok:false,error} logs a warn with the reason", () => {
+    const { logger, warns } = fakeLogger();
+    const h = startLivenessPublisher({
+      roster: ["mini", "laptop"],
+      anchorIssue: "CTL-9",
+      self: "mini",
+      ownedTickets: () => [],
+      publish: () => ({ ok: false, error: "exit 1: Linear 401" }),
+      logger,
+      intervalMs: 60_000,
+    });
+    h.stop();
+    expect(warns.length).toBe(1);
+    expect(warns[0].o.error).toBe("exit 1: Linear 401");
+    expect(warns[0].o.host).toBe("mini");
+  });
+
+  test("sustained failures warn ONCE per failure-run (throttled), not every tick", async () => {
+    const { logger, warns } = fakeLogger();
+    const h = startLivenessPublisher({
+      roster: ["mini", "laptop"],
+      anchorIssue: "CTL-9",
+      self: "mini",
+      ownedTickets: () => [],
+      publish: () => ({ ok: false, error: "still down" }),
+      logger,
+      intervalMs: 10,
+    });
+    await new Promise((r) => setTimeout(r, 55)); // several ticks fire
+    h.stop();
+    expect(warns.length).toBe(1); // throttled: one warn for the whole failure run
+  });
+
+  test("recovery after failures logs an info line", async () => {
+    const { logger, warns, infos } = fakeLogger();
+    let ok = false;
+    const h = startLivenessPublisher({
+      roster: ["mini", "laptop"],
+      anchorIssue: "CTL-9",
+      self: "mini",
+      ownedTickets: () => [],
+      publish: () => (ok ? { ok: true } : { ok: false, error: "down" }),
+      logger,
+      intervalMs: 10,
+    });
+    await new Promise((r) => setTimeout(r, 25));
+    ok = true; // flip to healthy
+    await new Promise((r) => setTimeout(r, 25));
+    h.stop();
+    expect(warns.length).toBe(1);
+    expect(infos.length).toBe(1);
+    expect(infos[0].o.afterFailures).toBeGreaterThanOrEqual(1);
+  });
+
+  test("ok publish does NOT log (no warn, no info on the happy path)", () => {
+    const { logger, warns, infos } = fakeLogger();
+    const h = startLivenessPublisher({
+      roster: ["mini", "laptop"],
+      anchorIssue: "CTL-9",
+      self: "mini",
+      ownedTickets: () => [],
+      publish: () => ({ ok: true }),
+      logger,
+      intervalMs: 60_000,
+    });
+    h.stop();
+    expect(warns.length).toBe(0);
+    expect(infos.length).toBe(0);
+  });
+
+  test("legacy publish returning undefined is treated as success (no log)", () => {
+    const { logger, warns, infos } = fakeLogger();
+    const h = startLivenessPublisher({
+      roster: ["mini", "laptop"],
+      anchorIssue: "CTL-9",
+      self: "mini",
+      ownedTickets: () => [],
+      publish: () => undefined, // pre-CTL-1251 shape
+      logger,
+      intervalMs: 60_000,
+    });
+    h.stop();
+    expect(warns.length).toBe(0);
+    expect(infos.length).toBe(0);
+  });
+
+  test("missing anchor warn uses the injected logger", () => {
+    const { logger, warns } = fakeLogger();
+    const h = startLivenessPublisher({
+      roster: ["mini", "laptop"],
+      anchorIssue: null,
+      self: "mini",
+      ownedTickets: () => [],
+      publish: () => ({ ok: true }),
+      logger,
+      intervalMs: 60_000,
+    });
+    h.stop();
+    expect(warns.length).toBe(1);
+    expect(warns[0].m).toContain("not configured");
+  });
 });

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.mjs
@@ -30,7 +30,12 @@ const LIVENESS_TIMEOUT_MS =
   Number(process.env.EXECUTION_CORE_LIVENESS_TIMEOUT_MS) || 15_000;
 
 // publishHeartbeatSync — publish this host's liveness record synchronously.
-// Returns { ok: true } on success, { ok: false } on any failure (fail-open).
+// Returns { ok: true } on success, { ok: false, error } on any failure (fail-open).
+// CTL-1251: the failure path now carries a short `error` reason (exit code +
+// stderr tail / spawn error / timeout / unparseable) so the publisher tick can
+// LOG why a publish failed — previously every failure was a silent { ok: false }
+// and a post-restart non-publish was undiagnosable. Callers must still treat any
+// non-ok as fail-open and never throw.
 // `spawn`/`nodeBin`/`cli`/`env`/`timeout` are injectable for unit tests.
 export function publishHeartbeatSync(
   { anchorIssue, host, inFlightTickets = [] },
@@ -49,13 +54,30 @@ export function publishHeartbeatSync(
       env,
       timeout,
     });
-    if (!res || res.status !== 0 || typeof res.stdout !== "string") return { ok: false };
+    if (!res || res.status !== 0 || typeof res.stdout !== "string") {
+      return { ok: false, error: describeSpawnFailure(res) };
+    }
     const line = res.stdout.trim().split("\n").filter(Boolean).pop();
     JSON.parse(line); // validate parseable; value not needed
     return { ok: true };
-  } catch {
-    return { ok: false };
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) };
   }
+}
+
+// describeSpawnFailure — render a short, log-safe reason from a spawnSync result
+// (CTL-1251). Covers the three non-throwing failure shapes: a timeout/spawn error
+// (res.error set, status null), a non-zero exit (status + stderr tail), and a
+// missing/!string stdout. Truncates stderr so a noisy subprocess can't bloat the
+// daemon log line. A heartbeat publish carries no secret, so stderr is safe to log.
+function describeSpawnFailure(res) {
+  if (!res) return "no spawn result";
+  if (res.error) return `spawn error: ${res.error.message || String(res.error)}`;
+  const stderr = typeof res.stderr === "string" ? res.stderr.trim().slice(-200) : "";
+  if (res.status !== 0) {
+    return `exit ${res.status}${stderr ? `: ${stderr}` : ""}`;
+  }
+  return "missing stdout";
 }
 
 // readPeerHeartbeatsSync — read all peer liveness records synchronously.

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.test.mjs
@@ -93,6 +93,42 @@ describe("publishHeartbeatSync — argv + fail-open contract", () => {
     const csvArg = capturedArgs[capturedArgs.length - 1];
     expect(csvArg).toBe("");
   });
+
+  // CTL-1251: failures now carry a diagnostic `error` reason (still fail-open).
+  test("non-zero exit surfaces exit code + stderr tail in error", () => {
+    const spawn = () => ({ status: 2, stdout: "", stderr: "Linear 401 Unauthorized\n" });
+    const r = publishHeartbeatSync({ anchorIssue: "CTL-9", host: "mini" }, { spawn });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("exit 2");
+    expect(r.error).toContain("401 Unauthorized");
+  });
+
+  test("timeout (status null, res.error set) surfaces the spawn error", () => {
+    const spawn = () => ({ status: null, error: new Error("ETIMEDOUT"), stdout: null });
+    const r = publishHeartbeatSync({ anchorIssue: "CTL-9", host: "mini" }, { spawn });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("ETIMEDOUT");
+  });
+
+  test("spawn throw surfaces the thrown message in error", () => {
+    const spawn = () => { throw new Error("EACCES"); };
+    const r = publishHeartbeatSync({ anchorIssue: "CTL-9", host: "mini" }, { spawn });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("EACCES");
+  });
+
+  test("unparseable stdout → ok:false with an error reason", () => {
+    const spawn = () => ({ status: 0, stdout: "not json" });
+    const r = publishHeartbeatSync({ anchorIssue: "CTL-9", host: "mini" }, { spawn });
+    expect(r.ok).toBe(false);
+    expect(typeof r.error).toBe("string");
+  });
+
+  test("stderr is truncated so a noisy subprocess can't bloat the log line", () => {
+    const spawn = () => ({ status: 1, stdout: "", stderr: "x".repeat(5000) });
+    const r = publishHeartbeatSync({ anchorIssue: "CTL-9", host: "mini" }, { spawn });
+    expect(r.error.length).toBeLessThan(260); // ~200 stderr tail + "exit 1: " prefix
+  });
 });
 
 describe("readPeerHeartbeatsSync — parsing + fail-open contract", () => {

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
@@ -19,13 +19,22 @@
 //
 // SINGLE-HOST IDENTITY NO-OP (the load-bearing operator constraint):
 //   When the roster is absent or length 1 (config.mjs::getClusterHosts returns
-//   [getHostName()] when .catalyst/hosts.json is absent), the cluster view is an
-//   EXACT identity no-op: ONE node carrying ALL board tickets in board order
-//   (un-fenced tickets included — on a 1-node fleet there is no "other" owner),
-//   the local daemon's own heartbeat as its liveness, and ZERO added latency
-//   (one local-log read, no per-peer fan-out, no cross-node transport — that is
-//   BFF3's concern). The N>1 grouping/unassigned-bucket branch below is exercised
-//   ONLY once a real multi-host roster exists.
+//   [getHostName()] when .catalyst/hosts.json is absent) AND no OTHER host is
+//   currently publishing a heartbeat, the cluster view is an EXACT identity
+//   no-op: ONE node carrying ALL board tickets in board order (un-fenced tickets
+//   included — on a 1-node fleet there is no "other" owner), the local daemon's
+//   own heartbeat as its liveness, and ZERO added latency.
+//
+// CTL-1251 (the deferred BFF3 cross-node transport): the `heartbeats` the server
+//   injects now carry BOTH the local event log AND the cross-host LIVENESS ANCHOR
+//   peers (the server polls readPeerHeartbeats into a cache and merges it in). A
+//   host that is publishing a live heartbeat but is NOT in the committed roster is
+//   a real node — a Stage-0 SHADOW node that owns zero tickets, or a roster-
+//   lagging peer — so the view SURFACES it (while it is non-offline) instead of
+//   hiding it. That is what makes the dashboard a true single control plane: it
+//   shows every node currently alive on the anchor, decoupled from the dispatch
+//   roster. Stale anchor attachments from decommissioned nodes classify offline
+//   and are dropped; roster hosts are always shown regardless of status.
 
 import { overlayClusterLiveness } from "./node-liveness.mjs";
 
@@ -75,19 +84,29 @@ export function assembleClusterView({
   drainReader = null,
 }) {
   const roster = Array.isArray(hosts) && hosts.length > 0 ? hosts : [];
-  // SINGLE-HOST: roster absent or length 1 → identity no-op. Everything belongs
-  // to the one host; there is no "other" owner to group away.
-  const singleHost = roster.length <= 1;
   const tickets = Array.isArray(board?.tickets) ? board.tickets : [];
 
-  // Resolve liveness ONCE — read the local event log a single time (the reader is
-  // injected so tests don't touch fs; the read-model passes the real one). On a
-  // single node this is the ONE local log; there is no per-peer fan-out.
+  // Resolve liveness ONCE. `lastSeen` ({host: lastSeenISO}) carries BOTH the local
+  // event-log heartbeats AND the cross-host anchor peers the server merges in
+  // (CTL-1251). The DISPLAY host set = roster ∪ (anchor hosts currently alive):
+  // a host publishing a live/degraded heartbeat but absent from the roster is a
+  // real node (a Stage-0 SHADOW node or a roster-lagging peer) and is surfaced;
+  // a stale anchor attachment (offline) from a decommissioned node is dropped.
+  // Roster hosts are ALWAYS shown, whatever their status.
   const lastSeen =
     heartbeats && typeof heartbeats === "object"
       ? heartbeats
       : heartbeatReader({ logPath });
-  const liveness = overlayClusterLiveness(roster, lastSeen, { now, intervalMs, graceMs });
+  const heartbeatHosts = lastSeen && typeof lastSeen === "object" ? Object.keys(lastSeen) : [];
+  const allHosts = [...new Set([...roster, ...heartbeatHosts])];
+  const rosterSet = new Set(roster);
+  const liveness = overlayClusterLiveness(allHosts, lastSeen, { now, intervalMs, graceMs }).filter(
+    (n) => rosterSet.has(n.host) || n.status !== "offline",
+  );
+  const displayHosts = liveness.map((n) => n.host);
+  // SINGLE-HOST: one displayed node → identity no-op. Everything belongs to the
+  // one host; there is no "other" owner to group away.
+  const singleHost = displayHosts.length <= 1;
   const livenessByHost = new Map(liveness.map((n) => [n.host, n]));
 
   // CTL-1095: resolve drain state per host — fail-open on error or absent reader.
@@ -108,7 +127,7 @@ export function assembleClusterView({
   const makeTicket = (t, host) => ({ ...t, ownerHost: host });
 
   if (singleHost) {
-    const host = roster[0] ?? null;
+    const host = displayHosts[0] ?? null;
     const node = livenessByHost.get(host) ?? { host, status: host ? "offline" : null, lastSeen: null };
     return {
       generatedAt: board?.generatedAt ?? new Date(now).toISOString(),
@@ -129,7 +148,9 @@ export function assembleClusterView({
 
   // ── multi-host (N>1): group by the durable owner_host key ───────────────────
   const byHost = new Map(); // host (string | null) → ticket[]
-  for (const host of roster) byHost.set(host, []); // stable roster order, even if empty
+  // Seed with the DISPLAY hosts (roster ∪ live anchor peers) in stable order, so a
+  // live SHADOW node that owns zero tickets still appears as its own empty group.
+  for (const host of displayHosts) byHost.set(host, []);
   for (const t of tickets) {
     const raw = ownerHostById[t.id];
     const host = typeof raw === "string" && raw.length > 0 ? raw : null;

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.test.mjs
@@ -81,3 +81,61 @@ describe("assembleClusterView — drain display (CTL-1095)", () => {
     expect(node.inFlightCount).toBe(0);
   });
 });
+
+describe("assembleClusterView — cross-host anchor peers / shadow nodes (CTL-1251)", () => {
+  test("a live anchor peer NOT in the roster is surfaced as a shadow node (0 tickets)", () => {
+    const view = assembleClusterView({
+      board: { generatedAt: "2026-06-13T00:00:00Z", tickets: [{ id: "T1" }] },
+      ownerHostById: { T1: "mini" }, // T1 fenced to mini → no unassigned bucket
+      hosts: ["mini"], // committed roster is single-host
+      heartbeats: { mini: "2026-06-13T00:00:00Z", "mini-2": "2026-06-13T00:00:05Z" },
+      now: NOW,
+    });
+    // roster ∪ live anchor peers = {mini, mini-2} → multi-host view
+    expect(view.singleHost).toBe(false);
+    const hosts = view.nodes.map((n) => n.host).sort();
+    expect(hosts).toEqual(["mini", "mini-2"]);
+    const shadow = view.nodes.find((n) => n.host === "mini-2");
+    expect(shadow.status).toBe("live");
+    expect(shadow.tickets).toEqual([]); // owns zero tickets — pure liveness
+    expect(view.nodes.find((n) => n.host === "mini").tickets).toHaveLength(1);
+  });
+
+  test("a stale anchor attachment (offline, not in roster) is DROPPED", () => {
+    const view = assembleClusterView({
+      board,
+      hosts: ["mini"],
+      heartbeats: {
+        mini: "2026-06-13T00:00:00Z",
+        "decommissioned": "2026-06-12T00:00:00Z", // >24h stale → offline
+      },
+      now: NOW,
+    });
+    expect(view.singleHost).toBe(true);
+    expect(view.nodes.map((n) => n.host)).toEqual(["mini"]);
+  });
+
+  test("a roster host that is offline is STILL shown (roster always displayed)", () => {
+    const view = assembleClusterView({
+      board,
+      hosts: ["mini", "laptop"],
+      heartbeats: { mini: "2026-06-13T00:00:00Z" }, // laptop never heard → offline
+      now: NOW,
+    });
+    expect(view.singleHost).toBe(false);
+    const laptop = view.nodes.find((n) => n.host === "laptop");
+    expect(laptop.status).toBe("offline");
+  });
+
+  test("single-host identity no-op preserved when no other host publishes", () => {
+    const view = assembleClusterView({
+      board: { generatedAt: "2026-06-13T00:00:00Z", tickets: [{ id: "T1" }, { id: "T2" }] },
+      hosts: ["mini"],
+      heartbeats: { mini: "2026-06-13T00:00:00Z" },
+      now: NOW,
+    });
+    expect(view.singleHost).toBe(true);
+    expect(view.nodes).toHaveLength(1);
+    expect(view.nodes[0].tickets).toHaveLength(2); // all board tickets on the one host
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1163,9 +1163,19 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // and resolved ONCE under Bun. Every step is best-effort: an import or read
   // failure degrades to "offline" rather than throwing out of a nav request
   // (the read-model never fabricates health for a daemon it cannot hear).
+  // CTL-1251: this loader also exposes the roster (getClusterHosts), the liveness
+  // anchor id (getLivenessAnchorIssue), and the synchronous anchor peer-reader
+  // (readPeerHeartbeatsSync) so the cluster view can overlay CROSS-HOST liveness,
+  // not just the local event log. readPeerHeartbeatsSync is the same subprocess
+  // the working `catalyst cluster status` CLI uses, so Linear creds resolve
+  // identically (LINEAR_API_TOKEN in the process env).
+  type AnchorPeerRec = { host?: string; last_seen?: string; in_flight_tickets?: string[] };
   let daemonDepsPromise: Promise<{
     readClusterHeartbeats: (opts: { logPath?: string }) => Record<string, string>;
     getHostName: () => string;
+    getClusterHosts: () => string[];
+    getLivenessAnchorIssue: () => string | null;
+    readPeerHeartbeatsSync: (args: { anchorIssue: string }) => Record<string, AnchorPeerRec>;
     deriveDaemonHealth: typeof import("./lib/nav-signal.mjs").deriveDaemonHealth;
   } | null> | null = null;
   const loadDaemonDeps = () => {
@@ -1174,14 +1184,25 @@ export function createServer(opts: CreateServerOptions): BunServer {
         try {
           const recoveryMod = ["..", "execution-core", "recovery.mjs"].join("/");
           const configMod = ["..", "execution-core", "config.mjs"].join("/");
-          const [recovery, config, navSignal] = await Promise.all([
+          const heartbeatSyncMod = ["..", "execution-core", "cluster-heartbeat-sync.mjs"].join("/");
+          const [recovery, config, heartbeatSync, navSignal] = await Promise.all([
             import(recoveryMod) as Promise<{ readClusterHeartbeats: (opts: { logPath?: string }) => Record<string, string> }>,
-            import(configMod) as Promise<{ getHostName: () => string }>,
+            import(configMod) as Promise<{
+              getHostName: () => string;
+              getClusterHosts: () => string[];
+              getLivenessAnchorIssue: () => string | null;
+            }>,
+            import(heartbeatSyncMod) as Promise<{
+              readPeerHeartbeatsSync: (args: { anchorIssue: string }) => Record<string, AnchorPeerRec>;
+            }>,
             import("./lib/nav-signal.mjs"),
           ]);
           return {
             readClusterHeartbeats: recovery.readClusterHeartbeats,
             getHostName: config.getHostName,
+            getClusterHosts: config.getClusterHosts,
+            getLivenessAnchorIssue: config.getLivenessAnchorIssue,
+            readPeerHeartbeatsSync: heartbeatSync.readPeerHeartbeatsSync,
             deriveDaemonHealth: navSignal.deriveDaemonHealth,
           };
         } catch {
@@ -1299,7 +1320,69 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // identity no-op when the execution-core roster/recovery deps are unavailable.
   // The view is then projected to the tiny footer signal. Tests inject
   // `clusterReaderOpt` so the routes don't touch the live event log/roster.
-  const clusterEntity = createClusterEntity();
+  // CTL-1251: cross-host liveness for the dashboard (the deferred BFF3 transport).
+  // The cluster view's liveness overlay must see PEER heartbeats — published to the
+  // Linear liveness anchor — not just the LOCAL event log, or the dashboard can
+  // never show another node (the gap the handoff found: CLI shows peers, dashboard
+  // doesn't). We keep the read-model's "spawns nothing per request" contract by
+  // reading the anchor in a low-frequency BACKGROUND poll into an in-memory cache;
+  // per-request reads merge that cache over the local-log heartbeats synchronously.
+  // Production-only: tests inject clusterReaderOpt and never start the poller.
+  const anchorHeartbeatCache: { map: Record<string, string> } = { map: {} };
+  let execCoreDeps: Awaited<ReturnType<typeof loadDaemonDeps>> = null;
+  let anchorPollTimer: ReturnType<typeof setInterval> | null = null;
+  const pollAnchorHeartbeats = (): void => {
+    try {
+      if (!execCoreDeps) return;
+      const anchor = execCoreDeps.getLivenessAnchorIssue();
+      if (!anchor) {
+        anchorHeartbeatCache.map = {}; // no anchor configured → no peers
+        return;
+      }
+      const peers = execCoreDeps.readPeerHeartbeatsSync({ anchorIssue: anchor });
+      const next: Record<string, string> = {};
+      for (const [host, rec] of Object.entries(peers)) {
+        if (rec && typeof rec.last_seen === "string" && rec.last_seen.length > 0) {
+          next[host] = rec.last_seen;
+        }
+      }
+      anchorHeartbeatCache.map = next;
+    } catch {
+      // fail-open: keep the last cache; stale entries age out via node-liveness
+    }
+  };
+  if (clusterReaderOpt == null) {
+    void loadDaemonDeps().then((d) => {
+      execCoreDeps = d;
+      pollAnchorHeartbeats(); // prime immediately once deps resolve
+    });
+    const anchorPollMs = Number(process.env.MONITOR_ANCHOR_POLL_MS) || 60_000;
+    anchorPollTimer = setInterval(pollAnchorHeartbeats, anchorPollMs);
+    anchorPollTimer.unref?.();
+  }
+
+  // Inject BOTH the roster and a MERGED heartbeat reader (local event log ∪ the
+  // anchor peer cache). createClusterEntity then surfaces any node currently live
+  // on the anchor — including a Stage-0 SHADOW node that owns zero tickets —
+  // decoupled from the dispatch roster (see cluster-view.mjs CTL-1251 header).
+  const clusterEntity = createClusterEntity({
+    rosterProvider: () => {
+      try {
+        return execCoreDeps?.getClusterHosts() ?? [];
+      } catch {
+        return [];
+      }
+    },
+    heartbeatReader: (opts) => {
+      let local: Record<string, string> = {};
+      try {
+        local = execCoreDeps?.readClusterHeartbeats(opts) ?? {};
+      } catch {
+        /* fail-open: anchor cache alone still drives the overlay */
+      }
+      return { ...local, ...anchorHeartbeatCache.map };
+    },
+  });
   const readClusterView = async (board: BoardPayload): Promise<ClusterView> => {
     if (clusterReaderOpt != null) return clusterReaderOpt(board);
     return clusterEntity.project(board);
@@ -4262,6 +4345,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     closeDb();
     sseClients.clear();
     clearInterval(titleDescSweepTimer);
+    if (anchorPollTimer) clearInterval(anchorPollTimer); // CTL-1251 anchor poll
     eventRing.stop();
     if (pidFile) {
       try {


### PR DESCRIPTION
## Summary

Closes the two independent gaps that kept the cluster "single control plane" dark (CTL-1251). The CLI (\`catalyst cluster status\`) could already read peer heartbeats off the Linear liveness anchor, but the **dashboard could not** — and publish failures were silently swallowed so a non-publishing daemon was undiagnosable.

### Phase A — publish observability (`d41f9b2e`)
- \`publishHeartbeatSync\` now returns \`{ok:false, error}\` with a short, log-safe reason (exit code + truncated stderr / spawn error / timeout / unparseable). Still fail-open, never throws.
- The publisher \`tick()\` logs the outcome: **warn-once-per-failure-run** (throttled), info on recovery. Logger injectable.
- Diagnostic only — does not change dispatch or the roster≤1 no-op.

### Phase B — dashboard aggregates anchor heartbeats (`49c69e8d`)
- \`server.ts\`: a low-frequency **background poll** reads the anchor via \`readPeerHeartbeatsSync\` (the same subprocess the working CLI uses → identical creds) into an in-memory cache. Per-request reads merge that cache over the local-log heartbeats — the read-model's "spawns nothing per request" contract is preserved. Production-only; fail-open; timer cleared in \`server.stop()\`.
- \`cluster-view.mjs\`: the **display host set = roster ∪ (anchor hosts currently alive)**. A node publishing a live heartbeat but absent from the committed roster is surfaced as a **SHADOW node** (owns zero tickets) — so the dashboard is a true single control plane, decoupled from the dispatch roster. Stale (offline) attachments dropped; roster hosts always shown.

## Why this is low-risk to merge
- The single-host identity no-op is preserved when no other host publishes.
- Every layer is fail-open; the background poller is \`unref\`'d and try/caught — it cannot crash the monitor.
- The new display path only activates when the anchor actually has peers. The publisher is still a no-op at the current roster \`["mini"]\`, so **behavior is observably unchanged until a peer publishes**.

## Validation
- Unit: \`cluster-heartbeat-sync\` + \`cluster-heartbeat-publisher\` (34/34), \`cluster-view\` + \`node-liveness\` (9/9), cluster contract suites (26/26).
- Full orch-monitor suite: **no new failures** (base vs branch identical pre-existing set; +4 new tests).
- **Live (post-merge, planned):** manual one-shot publishes from mini + mini-2 to anchor CTL-1217, then confirm both \`catalyst cluster status\` AND \`/api/cluster\` show 2 live hosts — **no roster change, zero dispatch risk** (mini-2 stays Stage-0 SHADOW).

## Not in this PR (deliberately)
- Roster flip to auto-activate publishing on mini-2 (operator-gated, drain-first).
- CTL-1252 host double-count (\`<host>\` vs \`<host>.rozich\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)