### PR TITLE
feat(dev): recovery-pass — context/mode script (signals+log+Linear-cache, HRW-filtered) + sweep SOP

### DIFF
--- a/plugins/dev/scripts/execution-core/recovery-pass-context.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-pass-context.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env bun
+// recovery-pass-context.mjs — read-only mode/context resolver for the
+// recovery-pass skill (CTL-1176 rung 3). The skill runs this FIRST, then reads
+// its banner to decide which path to take. It makes NO direct Linear API calls —
+// it reads only local on-disk state (worker signals, the unified event log, and
+// the webhook-fed Linear cache in filter-state.db).
+//
+// MODE=dispatched  → a single ticket is named (--ticket or $CATALYST_TICKET).
+//                    Print the recovery-pass.json brief (the eyes+hands output).
+//                    If the brief is missing, fall through to a ticket-scoped
+//                    sweep so the agent still has something to act on.
+// MODE=sweep       → no ticket. Enumerate the stuck set from THREE local sources,
+//                    dedupe by ticket key, HRW-filter to this host, and print.
+//
+// The three sweep sources (union, dedupe by ticket key):
+//   1. Worker signals    — ${ORCH_DIR}/workers/*/phase-*.json, status ∈
+//                          {needs-human, failed, stalled}.
+//   2. Unified event log  — recovery.escalated / recovery.would-escalate lines.
+//   3. The local Linear cache (filter-state.db ticket_state) — tickets whose
+//      cached labels intersect the stuck-label set, or whose linearState is a
+//      non-terminal stuck-ish state. NO direct Linear API — getAllTicketDescriptors
+//      is a pure read of the webhook-fed cache. Fail-open to empty if the db is
+//      absent/unreadable (e.g. run under node where bun:sqlite is unavailable).
+//
+// Run under bun (broker-state uses bun:sqlite). Under node, source 3 degrades to
+// "(linear cache unavailable under this runtime)" and the other two still run.
+
+import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
+import { join, basename, dirname } from "node:path";
+
+import { ownedBy } from "./hrw.mjs";
+import { getClusterHosts, getHostName } from "./config.mjs";
+
+// ── arg parsing ──────────────────────────────────────────────────────────────
+function parseArgs(argv) {
+  const out = { ticket: "", orchDir: "" };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--ticket") out.ticket = argv[++i] || "";
+    else if (a === "--orch-dir") out.orchDir = argv[++i] || "";
+  }
+  return out;
+}
+
+const STUCK_SIGNAL_STATUSES = new Set(["needs-human", "failed", "stalled"]);
+
+// Cached Linear labels that mean "a human is needed / this is parked".
+const STUCK_LABELS = new Set(["needs-human", "blocked", "waiting", "escalated", "stuck"]);
+
+// Cached non-terminal Linear states that read as stuck-ish. Terminal states
+// (Done/Canceled/Merged/Released) and the normal in-flight states are excluded.
+const STUCK_LINEAR_STATES = new Set([
+  "needs-human",
+  "blocked",
+  "waiting",
+  "escalated",
+  "stuck",
+  "on hold",
+  "paused",
+]);
+
+// ── JSON helpers (never throw — context-gather must always produce a banner) ──
+function readJsonSafe(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+// ── source 1: worker signals ─────────────────────────────────────────────────
+function collectWorkerSignals(orchDir) {
+  const items = [];
+  const workersDir = join(orchDir, "workers");
+  let entries;
+  try {
+    entries = readdirSync(workersDir, { withFileTypes: true });
+  } catch {
+    return items; // no workers dir → nothing to enumerate
+  }
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    const dir = join(workersDir, ent.name);
+    let files;
+    try {
+      files = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const f of files) {
+      if (!/^phase-.*\.json$/.test(f)) continue;
+      const sig = readJsonSafe(join(dir, f));
+      if (!sig || typeof sig !== "object") continue;
+      const status = sig.status;
+      if (!STUCK_SIGNAL_STATUSES.has(status)) continue;
+      const ticket = sig.ticket || ent.name;
+      items.push({
+        ticket,
+        source: "signals",
+        signalStatus: status,
+        signalPath: join(dir, f),
+        reason: sig.failureReason || "-",
+      });
+    }
+  }
+  return items;
+}
+
+// ── source 2: unified event log (recovery escalations) ───────────────────────
+function eventLogPath() {
+  const eventsDir =
+    process.env.CATALYST_EVENTS_DIR ||
+    join(process.env.CATALYST_DIR || join(process.env.HOME || "", "catalyst"), "events");
+  const ym = new Date().toISOString().slice(0, 7); // YYYY-MM
+  return join(eventsDir, `${ym}.jsonl`);
+}
+
+function collectEventLog() {
+  const items = [];
+  const path = eventLogPath();
+  if (!existsSync(path)) return items;
+  let raw;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return items;
+  }
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const evt = (() => {
+      try {
+        return JSON.parse(trimmed);
+      } catch {
+        return null;
+      }
+    })();
+    if (!evt) continue;
+    const name = evt?.attributes?.["event.name"] || "";
+    if (!/^recovery\.(escalated|would-escalate)$/.test(name)) continue;
+    const ticket = evt?.body?.payload?.ticket || evt?.attributes?.["event.label"] || "";
+    if (!ticket) continue;
+    items.push({
+      ticket,
+      source: "log",
+      eventName: name,
+      reason: evt?.body?.payload?.reason || "-",
+    });
+  }
+  return items;
+}
+
+// ── source 3: the webhook-fed Linear cache (NO direct Linear API) ─────────────
+async function collectLinearCache() {
+  // getAllTicketDescriptors imports bun:sqlite. Under node that import throws;
+  // catch it and signal cache-unavailable rather than aborting the whole gather.
+  let getAll;
+  try {
+    ({ getAllTicketDescriptors: getAll } = await importBrokerState());
+  } catch {
+    return { unavailable: true, items: [] };
+  }
+  let rows;
+  try {
+    rows = getAll({ includeRemoved: false });
+  } catch {
+    // db absent/unreadable → fail-open to empty (still "available", just nothing)
+    return { unavailable: false, items: [] };
+  }
+  const items = [];
+  for (const row of rows || []) {
+    const ticket = row?.ticket;
+    if (!ticket) continue;
+    const state = row?.state ?? row?.linearState ?? null;
+    const labels = Array.isArray(row?.labels) ? row.labels : [];
+    const labelHit = labels.some(
+      (l) => typeof l === "string" && STUCK_LABELS.has(l.toLowerCase())
+    );
+    const stateHit = typeof state === "string" && STUCK_LINEAR_STATES.has(state.toLowerCase());
+    if (!labelHit && !stateHit) continue;
+    items.push({
+      ticket,
+      source: "cache",
+      linearState: state || "-",
+      labels,
+      reason: stateHit ? `linear-state=${state}` : `labels=${labels.join(",")}`,
+    });
+  }
+  return { unavailable: false, items };
+}
+
+// Indirect (non-literal) dynamic import so esbuild/Node never statically follow
+// the bun:sqlite-bearing module graph at analysis time (the vite.config bun:sqlite
+// trap, PR #1561). The specifier is computed, so it is resolved purely at runtime.
+async function importBrokerState() {
+  const spec = ["..", "broker", "broker-state.mjs"].join("/");
+  return import(new URL(spec, import.meta.url).href);
+}
+
+// ── union + dedupe + HRW filter ──────────────────────────────────────────────
+function unionDedupe(...lists) {
+  const byTicket = new Map();
+  for (const list of lists) {
+    for (const item of list) {
+      const key = item.ticket;
+      if (!byTicket.has(key)) {
+        byTicket.set(key, { ...item, sources: new Set([item.source]) });
+      } else {
+        const merged = byTicket.get(key);
+        merged.sources.add(item.source);
+        // Prefer a concrete signal status / reason when one source has it.
+        if (!merged.signalStatus && item.signalStatus) merged.signalStatus = item.signalStatus;
+        if (!merged.signalPath && item.signalPath) merged.signalPath = item.signalPath;
+        if (!merged.linearState && item.linearState) merged.linearState = item.linearState;
+        if (!merged.labels && item.labels) merged.labels = item.labels;
+        if (!merged.eventName && item.eventName) merged.eventName = item.eventName;
+        if ((!merged.reason || merged.reason === "-") && item.reason && item.reason !== "-")
+          merged.reason = item.reason;
+      }
+    }
+  }
+  return [...byTicket.values()];
+}
+
+// ── output formatting ─────────────────────────────────────────────────────────
+function formatSweepItem(item) {
+  const parts = [];
+  if (item.signalStatus) parts.push(`signal-status=${item.signalStatus}`);
+  if (item.linearState && item.linearState !== "-") parts.push(`linear-state=${item.linearState}`);
+  if (item.labels && item.labels.length) parts.push(`labels=${item.labels.join(",")}`);
+  parts.push(`source=${[...item.sources].sort().join("/")}`);
+  return `STUCK ${item.ticket} [${parts.join(" | ")}] reason=${item.reason || "-"}`;
+}
+
+function printDispatchedBrief(ticket, orchDir) {
+  console.log(`MODE=dispatched ticket=${ticket}`);
+  const briefPath = join(orchDir, "workers", ticket, "recovery-pass.json");
+  const brief = existsSync(briefPath) ? readJsonSafe(briefPath) : null;
+  if (!brief) {
+    console.log(`(no brief at ${briefPath} — reconstruct the diagnosis yourself)`);
+    console.log("--- falling through to a ticket-scoped sweep ---");
+    return false; // caller does the scoped sweep
+  }
+  console.log(`brief=${briefPath}`);
+  console.log("--- failure reason ---");
+  console.log(brief.failureReason || "(none)");
+  console.log("--- diagnosis (eyes) ---");
+  console.log(brief?.diagnosis?.reason || "(none)");
+  console.log("--- deterministic seams already tried (hands — do NOT redo) ---");
+  const seams = Array.isArray(brief.deterministicSeamsTried) ? brief.deterministicSeamsTried : [];
+  if (seams.length === 0) {
+    console.log("(none recorded)");
+  } else {
+    for (const s of seams) {
+      console.log(`- ${s.category}: ${s.outcome}${s.marker ? ` (${s.marker})` : ""}`);
+    }
+  }
+  console.log("--- guidance ---");
+  console.log(brief.guidance || "(none)");
+  console.log("--- recent log buffer (tail 40) ---");
+  const logs = brief?.diagnosis?.logsOutput || "(no logs captured)";
+  const tail = String(logs).split("\n").slice(-40).join("\n");
+  console.log(tail);
+  return true;
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const ticket = args.ticket || process.env.CATALYST_TICKET || "";
+  const orchDir =
+    args.orchDir ||
+    process.env.CATALYST_ORCHESTRATOR_DIR ||
+    join(process.env.HOME || "", "catalyst", "execution-core");
+
+  // HRW context (identity no-op at N=1).
+  let roster, self, multiHost;
+  try {
+    roster = getClusterHosts();
+    self = getHostName();
+    multiHost = Array.isArray(roster) && roster.length > 1;
+  } catch {
+    roster = [];
+    self = "";
+    multiHost = false;
+  }
+
+  if (ticket) {
+    const hadBrief = printDispatchedBrief(ticket, orchDir);
+    if (hadBrief) return;
+    // Brief missing → ticket-scoped sweep so the agent still has the stuck context.
+    const all = unionDedupe(
+      collectWorkerSignals(orchDir),
+      collectEventLog(),
+      (await collectLinearCache()).items
+    ).filter((it) => it.ticket === ticket);
+    console.log("--- ticket-scoped stuck context ---");
+    for (const it of all) console.log(formatSweepItem(it));
+    console.log(`TOTAL: ${all.length} items (ticket-scoped)`);
+    return;
+  }
+
+  // ── MODE=sweep ──────────────────────────────────────────────────────────────
+  console.log("MODE=sweep");
+  const signals = collectWorkerSignals(orchDir);
+  const events = collectEventLog();
+  const cache = await collectLinearCache();
+  if (cache.unavailable) {
+    console.log("(linear cache unavailable under this runtime)");
+  }
+
+  let union = unionDedupe(signals, events, cache.items);
+
+  // HRW filter — identity at N=1. Drop tickets this host does not own.
+  let dropped = 0;
+  if (multiHost) {
+    const before = union.length;
+    union = union.filter((it) => ownedBy(it.ticket, roster, self));
+    dropped = before - union.length;
+  }
+
+  union.sort((a, b) => a.ticket.localeCompare(b.ticket));
+  for (const it of union) console.log(formatSweepItem(it));
+
+  if (multiHost && dropped > 0) {
+    console.log(
+      `(HRW: dropped ${dropped} item(s) owned by another host; roster=${roster.join(",")} self=${self})`
+    );
+  }
+  console.log(`TOTAL: ${union.length} items (HRW-owned)`);
+}
+
+main().catch((err) => {
+  // Never crash the context gather — print a degraded banner and exit 0 so the
+  // skill still proceeds (it can reconstruct from logs/gh directly).
+  console.log("MODE=sweep");
+  console.log(`(context-gather error: ${err?.message || err}; proceed manually)`);
+  console.log("TOTAL: 0 items (HRW-owned)");
+});

--- a/plugins/dev/scripts/execution-core/recovery-pass-context.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-pass-context.mjs
@@ -10,7 +10,11 @@
 //                    If the brief is missing, fall through to a ticket-scoped
 //                    sweep so the agent still has something to act on.
 // MODE=sweep       → no ticket. Enumerate the stuck set from THREE local sources,
-//                    dedupe by ticket key, HRW-filter to this host, and print.
+//                    dedupe by ticket key, and print. HRW is a SOFT owner-signal
+//                    here, NOT a hard filter: items are KEPT and ANNOTATED YOURS
+//                    (you own it — act) vs CONTEXT (another host owns it — awareness
+//                    only; a sibling you don't own may explain your conflict). At
+//                    N=1 every item is YOURS (identity).
 //
 // The three sweep sources (union, dedupe by ticket key):
 //   1. Worker signals    — ${ORCH_DIR}/workers/*/phase-*.json, status ∈
@@ -25,10 +29,10 @@
 // Run under bun (broker-state uses bun:sqlite). Under node, source 3 degrades to
 // "(linear cache unavailable under this runtime)" and the other two still run.
 
-import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
-import { join, basename, dirname } from "node:path";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
 
-import { ownedBy } from "./hrw.mjs";
+import { ownerForTicket } from "./hrw.mjs";
 import { getClusterHosts, getHostName } from "./config.mjs";
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
@@ -223,13 +227,18 @@ function unionDedupe(...lists) {
 }
 
 // ── output formatting ─────────────────────────────────────────────────────────
-function formatSweepItem(item) {
+// `tag` is "YOURS" (act on it) or "CONTEXT" (another host owns it — awareness
+// only). For CONTEXT items the owning host is annotated. Plain "STUCK …" (no
+// tag) is used in the ticket-scoped fall-through where ownership is moot.
+function formatSweepItem(item, tag) {
   const parts = [];
   if (item.signalStatus) parts.push(`signal-status=${item.signalStatus}`);
   if (item.linearState && item.linearState !== "-") parts.push(`linear-state=${item.linearState}`);
   if (item.labels && item.labels.length) parts.push(`labels=${item.labels.join(",")}`);
+  if (tag === "CONTEXT" && item.owner) parts.push(`owner=${item.owner}`);
   parts.push(`source=${[...item.sources].sort().join("/")}`);
-  return `STUCK ${item.ticket} [${parts.join(" | ")}] reason=${item.reason || "-"}`;
+  const prefix = tag ? `STUCK ${tag}` : "STUCK";
+  return `${prefix} ${item.ticket} [${parts.join(" | ")}] reason=${item.reason || "-"}`;
 }
 
 function printDispatchedBrief(ticket, orchDir) {
@@ -309,25 +318,34 @@ async function main() {
     console.log("(linear cache unavailable under this runtime)");
   }
 
-  let union = unionDedupe(signals, events, cache.items);
+  const union = unionDedupe(signals, events, cache.items);
 
-  // HRW filter — identity at N=1. Drop tickets this host does not own.
-  let dropped = 0;
-  if (multiHost) {
-    const before = union.length;
-    union = union.filter((it) => ownedBy(it.ticket, roster, self));
-    dropped = before - union.length;
+  // HRW is a SOFT owner-signal, NOT a hard filter (a sibling ticket you don't own
+  // may explain YOUR conflict). KEEP the whole stuck set; ANNOTATE each item with
+  // its owner + whether it's mine. At N=1 every item is mine (identity).
+  for (const it of union) {
+    it.owner = ownerForTicket(it.ticket, roster);
+    it.mine = !multiHost || it.owner === self;
   }
-
   union.sort((a, b) => a.ticket.localeCompare(b.ticket));
-  for (const it of union) console.log(formatSweepItem(it));
 
-  if (multiHost && dropped > 0) {
+  const yours = union.filter((it) => it.mine);
+  const context = union.filter((it) => !it.mine);
+
+  // YOURS first — these are the items to act on.
+  for (const it of yours) console.log(formatSweepItem(it, "YOURS"));
+
+  // CONTEXT group — only when multiHost and there are non-owned items. Awareness
+  // only; another host owns these. Do NOT act on them (avoid cross-host
+  // double-action) — they may explain a conflict or dependency in YOUR items.
+  if (multiHost && context.length > 0) {
     console.log(
-      `(HRW: dropped ${dropped} item(s) owned by another host; roster=${roster.join(",")} self=${self})`
+      `--- CONTEXT (owned by another host — awareness only, do NOT act; roster=${roster.join(",")} self=${self}) ---`
     );
+    for (const it of context) console.log(formatSweepItem(it, "CONTEXT"));
   }
-  console.log(`TOTAL: ${union.length} items (HRW-owned)`);
+
+  console.log(`TOTAL: ${union.length} items (${yours.length} yours, ${context.length} context)`);
 }
 
 main().catch((err) => {
@@ -335,5 +353,5 @@ main().catch((err) => {
   // skill still proceeds (it can reconstruct from logs/gh directly).
   console.log("MODE=sweep");
   console.log(`(context-gather error: ${err?.message || err}; proceed manually)`);
-  console.log("TOTAL: 0 items (HRW-owned)");
+  console.log("TOTAL: 0 items (0 yours, 0 context)");
 });

--- a/plugins/dev/scripts/execution-core/recovery-pass-context.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-pass-context.test.mjs
@@ -10,7 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 
-import { ownedBy } from "./hrw.mjs";
+import { ownerForTicket } from "./hrw.mjs";
 
 const SCRIPT = join(import.meta.dir, "recovery-pass-context.mjs");
 
@@ -21,20 +21,91 @@ function runScript(args, env = {}) {
   });
 }
 
-describe("HRW filter — identity at N=1", () => {
-  it("a single-host roster owns every ticket (filter is a no-op)", () => {
+// Build an env that pins a deterministic roster + self host so the sweep's
+// soft HRW tagging is testable end-to-end. The roster lives in
+// <repoRoot>/.catalyst/hosts.json (resolved via CATALYST_CONFIG_FILE); the
+// cluster repo is pointed at an empty dir so getClusterHosts falls through to
+// hosts.json; CATALYST_HOST_NAME pins self.
+function rosterEnv(baseDir, roster, self) {
+  const catalystCfgDir = join(baseDir, ".catalyst");
+  mkdirSync(catalystCfgDir, { recursive: true });
+  writeFileSync(join(catalystCfgDir, "config.json"), JSON.stringify({}));
+  writeFileSync(join(catalystCfgDir, "hosts.json"), JSON.stringify(roster));
+  const emptyCluster = join(baseDir, "empty-cluster");
+  mkdirSync(emptyCluster, { recursive: true });
+  return {
+    CATALYST_CONFIG_FILE: join(catalystCfgDir, "config.json"),
+    CATALYST_CLUSTER_DIR: emptyCluster,
+    CATALYST_HOST_NAME: self,
+  };
+}
+
+describe("HRW soft owner-signal — pure ownership sanity", () => {
+  it("a single-host roster owns every ticket (every item is YOURS)", () => {
     for (const t of ["CTL-1", "CTL-842", "OTL-7", "ADV-99"]) {
-      expect(ownedBy(t, ["only-host"], "only-host")).toBe(true);
+      expect(ownerForTicket(t, ["only-host"])).toBe("only-host");
     }
   });
 
-  it("a multi-host roster splits ownership (so the filter can drop)", () => {
-    const roster = ["mini", "mac-studio", "macbook"];
-    // Every ticket is owned by exactly one host; the sum of per-host ownership is 1.
-    for (const t of ["CTL-842", "CTL-1188", "CTL-1190", "OTL-7"]) {
-      const owners = roster.filter((h) => ownedBy(t, roster, h));
-      expect(owners.length).toBe(1);
+  it("a multi-host roster assigns exactly one owner per ticket", () => {
+    const roster = ["alpha", "beta", "gamma"];
+    for (const t of ["CTL-100", "CTL-101", "CTL-1190", "OTL-7"]) {
+      expect(roster).toContain(ownerForTicket(t, roster));
     }
+  });
+});
+
+describe("sweep — HRW tags (YOURS vs CONTEXT), does NOT drop non-owned", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "rpc-hrw-"));
+  });
+  afterEach(() => {
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  function writeSignal(ticket, status, reason) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-recovery-pass.json"),
+      JSON.stringify({ ticket, status, failureReason: reason })
+    );
+  }
+
+  it("multi-host: non-owned items are PRESENT and tagged CONTEXT (not dropped); owned items YOURS", () => {
+    // roster [alpha,beta,gamma], self=beta:
+    //   CTL-100 owner=beta  → YOURS
+    //   CTL-101 owner=gamma → CONTEXT
+    writeSignal("CTL-100", "needs-human", "review blocked");
+    writeSignal("CTL-101", "failed", "tsc error");
+    const env = rosterEnv(orchDir, ["alpha", "beta", "gamma"], "beta");
+    const out = runScript(["--orch-dir", orchDir], {
+      ...env,
+      CATALYST_EVENTS_DIR: join(orchDir, "no-events"),
+    });
+    expect(out).toContain("MODE=sweep");
+    // owned → YOURS
+    expect(out).toMatch(/STUCK YOURS CTL-100/);
+    // non-owned → PRESENT (not dropped) and tagged CONTEXT with its owner
+    expect(out).toMatch(/STUCK CONTEXT CTL-101 .*owner=gamma/);
+    expect(out).toContain("awareness only");
+    // 2 items total, split 1 yours / 1 context
+    expect(out).toContain("TOTAL: 2 items (1 yours, 1 context)");
+  });
+
+  it("N=1 (single host): every item is YOURS, no CONTEXT group", () => {
+    writeSignal("CTL-100", "needs-human", "review blocked");
+    writeSignal("CTL-101", "failed", "tsc error");
+    const env = rosterEnv(orchDir, ["solo"], "solo");
+    const out = runScript(["--orch-dir", orchDir], {
+      ...env,
+      CATALYST_EVENTS_DIR: join(orchDir, "no-events"),
+    });
+    expect(out).toMatch(/STUCK YOURS CTL-100/);
+    expect(out).toMatch(/STUCK YOURS CTL-101/);
+    expect(out).not.toContain("CONTEXT");
+    expect(out).toContain("TOTAL: 2 items (2 yours, 0 context)");
   });
 });
 
@@ -63,16 +134,19 @@ describe("sweep — worker-signal enumeration", () => {
     writeSignal("CTL-103", "running", "in flight"); // must NOT appear
     writeSignal("CTL-104", "complete", "done"); // must NOT appear
 
+    // Pin a single-host roster so every kept item is deterministically YOURS.
+    const env = rosterEnv(orchDir, ["solo"], "solo");
     const out = runScript(["--orch-dir", orchDir], {
+      ...env,
       CATALYST_EVENTS_DIR: join(orchDir, "no-events"),
     });
     expect(out).toContain("MODE=sweep");
-    expect(out).toContain("STUCK CTL-100");
-    expect(out).toContain("STUCK CTL-101");
-    expect(out).toContain("STUCK CTL-102");
+    expect(out).toContain("STUCK YOURS CTL-100");
+    expect(out).toContain("STUCK YOURS CTL-101");
+    expect(out).toContain("STUCK YOURS CTL-102");
     expect(out).not.toContain("CTL-103");
     expect(out).not.toContain("CTL-104");
-    expect(out).toContain("TOTAL: 3 items");
+    expect(out).toContain("TOTAL: 3 items (3 yours, 0 context)");
   });
 });
 
@@ -107,15 +181,16 @@ describe("sweep — union dedupe across signals + event log", () => {
     };
     writeFileSync(join(eventsDir, `${ym}.jsonl`), JSON.stringify(evt) + "\n" + JSON.stringify(evt2) + "\n");
 
-    const out = runScript(["--orch-dir", orchDir], { CATALYST_EVENTS_DIR: eventsDir });
+    const env = rosterEnv(orchDir, ["solo"], "solo");
+    const out = runScript(["--orch-dir", orchDir], { ...env, CATALYST_EVENTS_DIR: eventsDir });
     // CTL-200: union — exactly one STUCK line, both sources noted
-    const ctl200Lines = out.split("\n").filter((l) => l.includes("STUCK CTL-200"));
+    const ctl200Lines = out.split("\n").filter((l) => l.includes("CTL-200"));
     expect(ctl200Lines.length).toBe(1);
     expect(ctl200Lines[0]).toContain("source=log/signals");
     // CTL-201: only on the event log
-    expect(out).toContain("STUCK CTL-201");
+    expect(out).toContain("CTL-201");
     expect(out).toContain("source=log");
-    expect(out).toContain("TOTAL: 2 items");
+    expect(out).toContain("TOTAL: 2 items (2 yours, 0 context)");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery-pass-context.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-pass-context.test.mjs
@@ -1,0 +1,184 @@
+// recovery-pass-context.test.mjs — the read-only mode/context resolver for the
+// recovery-pass skill (CTL-1176 rung 3). The script itself shells out to the
+// real broker-state cache + event log, so the unit surface here is the pure
+// pieces: sweep union/dedupe, HRW identity at N=1, cache fail-open, and the
+// dispatched-mode brief read. The end-to-end no-throw behavior is covered by the
+// PR's smoke run (sweep over a nonexistent orch-dir prints MODE=sweep / TOTAL: 0).
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { ownedBy } from "./hrw.mjs";
+
+const SCRIPT = join(import.meta.dir, "recovery-pass-context.mjs");
+
+function runScript(args, env = {}) {
+  return execFileSync("bun", [SCRIPT, ...args], {
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  });
+}
+
+describe("HRW filter — identity at N=1", () => {
+  it("a single-host roster owns every ticket (filter is a no-op)", () => {
+    for (const t of ["CTL-1", "CTL-842", "OTL-7", "ADV-99"]) {
+      expect(ownedBy(t, ["only-host"], "only-host")).toBe(true);
+    }
+  });
+
+  it("a multi-host roster splits ownership (so the filter can drop)", () => {
+    const roster = ["mini", "mac-studio", "macbook"];
+    // Every ticket is owned by exactly one host; the sum of per-host ownership is 1.
+    for (const t of ["CTL-842", "CTL-1188", "CTL-1190", "OTL-7"]) {
+      const owners = roster.filter((h) => ownedBy(t, roster, h));
+      expect(owners.length).toBe(1);
+    }
+  });
+});
+
+describe("sweep — worker-signal enumeration", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "rpc-sweep-"));
+  });
+  afterEach(() => {
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  function writeSignal(ticket, status, reason) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, `phase-recovery-pass.json`),
+      JSON.stringify({ ticket, status, failureReason: reason })
+    );
+  }
+
+  it("enumerates only stuck statuses (needs-human/failed/stalled), not running", () => {
+    writeSignal("CTL-100", "needs-human", "review blocked");
+    writeSignal("CTL-101", "failed", "tsc error");
+    writeSignal("CTL-102", "stalled", "bg dead");
+    writeSignal("CTL-103", "running", "in flight"); // must NOT appear
+    writeSignal("CTL-104", "complete", "done"); // must NOT appear
+
+    const out = runScript(["--orch-dir", orchDir], {
+      CATALYST_EVENTS_DIR: join(orchDir, "no-events"),
+    });
+    expect(out).toContain("MODE=sweep");
+    expect(out).toContain("STUCK CTL-100");
+    expect(out).toContain("STUCK CTL-101");
+    expect(out).toContain("STUCK CTL-102");
+    expect(out).not.toContain("CTL-103");
+    expect(out).not.toContain("CTL-104");
+    expect(out).toContain("TOTAL: 3 items");
+  });
+});
+
+describe("sweep — union dedupe across signals + event log", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "rpc-union-"));
+  });
+  afterEach(() => {
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  it("a ticket present in BOTH signal and event log appears ONCE with both sources", () => {
+    // signal
+    const dir = join(orchDir, "workers", "CTL-200");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-recovery-pass.json"),
+      JSON.stringify({ ticket: "CTL-200", status: "needs-human", failureReason: "stuck" })
+    );
+    // event log under a temp CATALYST_EVENTS_DIR
+    const eventsDir = join(orchDir, "events");
+    mkdirSync(eventsDir, { recursive: true });
+    const ym = new Date().toISOString().slice(0, 7);
+    const evt = {
+      attributes: { "event.name": "recovery.escalated" },
+      body: { payload: { ticket: "CTL-200", reason: "value judgment" } },
+    };
+    const evt2 = {
+      attributes: { "event.name": "recovery.would-escalate" },
+      body: { payload: { ticket: "CTL-201", reason: "arch change" } },
+    };
+    writeFileSync(join(eventsDir, `${ym}.jsonl`), JSON.stringify(evt) + "\n" + JSON.stringify(evt2) + "\n");
+
+    const out = runScript(["--orch-dir", orchDir], { CATALYST_EVENTS_DIR: eventsDir });
+    // CTL-200: union — exactly one STUCK line, both sources noted
+    const ctl200Lines = out.split("\n").filter((l) => l.includes("STUCK CTL-200"));
+    expect(ctl200Lines.length).toBe(1);
+    expect(ctl200Lines[0]).toContain("source=log/signals");
+    // CTL-201: only on the event log
+    expect(out).toContain("STUCK CTL-201");
+    expect(out).toContain("source=log");
+    expect(out).toContain("TOTAL: 2 items");
+  });
+});
+
+describe("dispatched mode — brief read", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "rpc-brief-"));
+  });
+  afterEach(() => {
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  it("prints the brief block when recovery-pass.json exists", () => {
+    const dir = join(orchDir, "workers", "CTL-300");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "recovery-pass.json"),
+      JSON.stringify({
+        failureReason: "merge conflict in eligible-set.mjs",
+        diagnosis: { reason: "branch diverged from main", logsOutput: "line1\nline2\nline3" },
+        deterministicSeamsTried: [
+          { category: "source-conflict", outcome: "no-op", marker: "source-conflict" },
+        ],
+        guidance: "resolve the conflict and rebase",
+      })
+    );
+    const out = runScript(["--ticket", "CTL-300", "--orch-dir", orchDir]);
+    expect(out).toContain("MODE=dispatched ticket=CTL-300");
+    expect(out).toContain("merge conflict in eligible-set.mjs");
+    expect(out).toContain("branch diverged from main");
+    expect(out).toContain("source-conflict: no-op");
+    expect(out).toContain("resolve the conflict and rebase");
+    expect(out).toContain("line3");
+  });
+
+  it("falls through to a ticket-scoped sweep when the brief is missing", () => {
+    const out = runScript(["--ticket", "CTL-301", "--orch-dir", orchDir]);
+    expect(out).toContain("MODE=dispatched ticket=CTL-301");
+    expect(out).toContain("no brief");
+    expect(out).toContain("ticket-scoped");
+  });
+});
+
+describe("cache fail-open — db absent never aborts the gather", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "rpc-failopen-"));
+  });
+  afterEach(() => {
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  it("with no signals, no events, and an isolated empty CATALYST_DIR → MODE=sweep / TOTAL: 0, exit 0", () => {
+    // Point CATALYST_DIR (which derives the broker filter-state.db path) at a
+    // fresh empty temp dir so the cache read opens a brand-new empty schema —
+    // it must not throw the gather, and with no other sources TOTAL is 0.
+    const isolatedDir = join(orchDir, "catalyst-home");
+    mkdirSync(isolatedDir, { recursive: true });
+    const out = runScript(["--orch-dir", join(orchDir, "nope")], {
+      CATALYST_DIR: isolatedDir,
+      CATALYST_EVENTS_DIR: join(orchDir, "no-events"),
+    });
+    expect(out).toContain("MODE=sweep");
+    expect(out).toContain("TOTAL: 0 items");
+  });
+});

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -152,8 +152,9 @@ fi
 # dispatched mode it reads the recovery-pass.json brief (the eyes+hands output —
 # CONSUME it, do NOT re-run the diagnostician or the seams); in sweep mode it
 # unions THREE local sources — worker signals + the unified event log + the
-# webhook-fed Linear cache — deduped by ticket and HRW-filtered to this host.
-# Read its output; the MODE line drives which path you take below.
+# webhook-fed Linear cache — deduped by ticket and HRW-TAGGED (a soft owner
+# signal, NOT a hard filter): YOURS = act on it; CONTEXT = another host owns it,
+# awareness only. Read its output; the MODE line drives which path you take below.
 node "${EXEC_CORE}/recovery-pass-context.mjs" ${TICKET:+--ticket "$TICKET"} --orch-dir "$ORCH_DIR"
 ```
 
@@ -162,14 +163,20 @@ The script's banner is your context:
 - `MODE=dispatched` → the brief block + tail-of-logs is printed; you own that ONE
   ticket. Go to the Step-0..4 fix loop. (Brief missing → it falls through to a
   ticket-scoped sweep and you reconstruct the diagnosis yourself.)
-- `MODE=sweep` → a `STUCK <ticket> [...] reason=…` line per item and a `TOTAL: N`
-  summary. Each printed ticket is a per-item context; walk them all. There is no
-  pre-written brief — see the **Sweep SOP** section below for how to reconstruct
-  each item's diagnosis yourself.
+- `MODE=sweep` → a `STUCK YOURS <ticket> [...]` line per owned item, then (when
+  multiHost) a `CONTEXT` group of items another host owns, and a
+  `TOTAL: N items (M yours, K context)` summary. ACT on the YOURS items — walk
+  them all. The CONTEXT items are situational awareness ONLY: do NOT act on them
+  (that host owns them — acting would cause cross-host double-action), but they
+  may explain a conflict or dependency in one of your items (e.g. "CTL-1190 also
+  touched this file"). At N=1 every item is YOURS. There is no pre-written brief —
+  see the **Sweep SOP** section below for how to reconstruct each item's
+  diagnosis yourself.
 
 > **Sweep-mode binding.** In the sweep there is NO dispatcher `CATALYST_TICKET`.
-> Each `STUCK <ticket>` line the context script printed is one per-item context.
-> When you walk an item in Steps 0–4 below, FIRST bind `TICKET` (and re-resolve
+> Each `STUCK YOURS <ticket>` line the context script printed is one per-item
+> context to act on (CONTEXT lines are awareness only — never bind TICKET to one).
+> When you walk a YOURS item in Steps 0–4 below, FIRST bind `TICKET` (and re-resolve
 > `BRIEF` / `SIGNAL_FILE` from it) to that item's ticket before authoring anything
 > — the authoring shims (`escalation-explain.mjs --ticket`, `recovery-emit.mjs
 > escalated --ticket`) reject an empty `--ticket`, so an escalation with `TICKET`
@@ -223,6 +230,15 @@ When the context script printed `MODE=sweep`, there is NO pre-written brief: no
 diagnostician ran ahead of you, so YOU reconstruct each item's diagnosis from the
 local sources before you act. This is the one place you read logs directly. A
 minimal senior-engineer onboarding to the machine you are operating:
+
+**Act on YOURS, not CONTEXT.** The script tags each item `YOURS` (you own it under
+HRW — act on it) or `CONTEXT` (another host owns it — `owner=<host>`). HRW is a
+SOFT signal here: CONTEXT items are kept so you have situational awareness — a
+sibling ticket you don't own may explain a conflict or dependency in one of your
+items ("CTL-1190 also rewrote this file"). But when multiHost you must NOT act on
+a CONTEXT item — that node owns it, and acting would cause cross-host
+double-action. Reconstruct + fix only the YOURS items; read CONTEXT items for
+context. At N=1 every item is YOURS.
 
 **The pipeline model.** Catalyst ships work through a 9-phase pipeline — triage →
 research → plan → implement → verify → review → pr → monitor-merge →
@@ -436,15 +452,17 @@ node "${EXEC_CORE}/recovery-emit.mjs" fixed \
 
 ### Iterate
 
-In sweep mode, repeat Steps 0–4 for every enumerated `SWEEP_ITEMS` entry,
+In sweep mode, repeat Steps 0–4 for every `STUCK YOURS <ticket>` item the context
+script printed (skip CONTEXT items — those are another host's, awareness only),
 printing a resolution line each. **Bind `TICKET` to the CURRENT item's ticket at
 the top of each iteration** (it is NOT the dispatcher var — that is empty in the
 sweep) and re-resolve `SIGNAL_FILE` /the per-item brief from it, so Step 4's
 `escalation-explain.mjs --ticket "$TICKET"` and `recovery-emit.mjs escalated
 --ticket "$TICKET"` carry the real ticket — an empty `--ticket` is rejected (exit
 2) and would leave the item neither FIXED nor ESCALATED, so the goal would never
-go TRUE. The goal stays FALSE while any item is "still stuck, not yet escalated",
-so keep going. Stop only when every item is UNSTUCK or legitimately ESCALATED.
+go TRUE. The goal stays FALSE while any YOURS item is "still stuck, not yet
+escalated", so keep going. Stop only when every YOURS item is UNSTUCK or
+legitimately ESCALATED.
 
 ## Mid-flight inbox check (CTL-749)
 

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -56,6 +56,24 @@ move genuinely requires Ryan, author a clear executive briefing and hand it off.
 > is the diagnostician + unstuck output, and its actions are git/gh/dispatch, not
 > just Edit/Write. Do not narrow yourself to one ticket's review findings.
 
+## What you're walking into
+
+1. **What's been done before.** The eyes (the diagnostician) and the hands (the
+   deterministic unstuck seams) already ran on this — and failed to clear it. You
+   are the rung above them; the mechanical fixes were not enough.
+2. **What you know.** Router-dispatched: the `recovery-pass.json` brief (the
+   eyes+hands output). Sweep: the discovered stuck-set printed by the context
+   script (`recovery-pass-context.mjs`) — worker signals + the event log + the
+   Linear cache.
+3. **Your goal.** Get every stuck item MOVING again. Not "fix one review finding"
+   — keep the pipeline flowing.
+4. **Your mandate.** You are a senior engineer with full tool access; Ryan is your
+   executive PM. Default to ACTING: resolve conflicts, rebase, force-push, merge
+   green PRs, re-dispatch stalled phases — autonomously.
+5. **Your escalation cases.** Bring Ryan ONLY the genuine value-judgment /
+   degrades-other-functionality / real-cost-benefit / serious-architecture / ADR
+   cases (the Step-3 checklist). A mere conflict or failed check is never one.
+
 ## Two invocation modes
 
 1. **Router-dispatched (the bounded-LLM recovery path).** The scheduler's recovery
@@ -126,79 +144,57 @@ if [[ -n "$TICKET" ]]; then
     ' "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
   fi
 
-  # Read the BRIEF — the eyes + hands output. This is the prior-phase artifact the
-  # dispatcher gated on. CONSUME it; do NOT re-run the diagnostician or the seams.
-  BRIEF="${ORCH_DIR}/workers/${TICKET}/recovery-pass.json"
-  if [[ -f "$BRIEF" ]]; then
-    echo "recovery-pass: brief = ${BRIEF}"
-    echo "--- failure reason ---";        jq -r '.failureReason // "(none)"' "$BRIEF"
-    echo "--- diagnosis (eyes) ---";       jq -r '.diagnosis.reason // "(none)"' "$BRIEF"
-    echo "--- deterministic seams already tried (hands — do NOT redo) ---"
-    jq -r '.deterministicSeamsTried[]? | "- \(.category): \(.outcome) (\(.marker))"' "$BRIEF" || true
-    echo "--- guidance ---";               jq -r '.guidance // "(none)"' "$BRIEF"
-    echo "--- recent log buffer (truncated) ---"
-    jq -r '.diagnosis.logsOutput // "(no logs captured)"' "$BRIEF" | tail -40
-  else
-    echo "recovery-pass: no brief at ${BRIEF}; reconstructing from signal + logs" >&2
-  fi
-
-# ── Operator-sweep mode: enumerate the stuck set ─────────────────────────────
-else
-  echo "recovery-pass: operator sweep — enumerating the stuck/failed/needs-human set"
-  # Worker signals carrying a non-terminal stuck status. Capture each item's
-  # ticket + signal path so Steps 0–4 below can BIND a per-item TICKET (the sweep
-  # has no dispatcher CATALYST_TICKET — each enumerated item supplies its own).
-  SWEEP_ITEMS=()   # "TICKET<TAB>SIGNAL_FILE<TAB>status<TAB>reason" per stuck item
-  for s in "${ORCH_DIR}"/workers/*/phase-*.json; do
-    [[ -f "$s" ]] || continue
-    st="$(jq -r '.status // empty' "$s" 2>/dev/null || true)"
-    case "$st" in
-      needs-human|failed|stalled)
-        it="$(jq -r '.ticket // empty' "$s" 2>/dev/null || true)"
-        [[ -n "$it" ]] || it="$(basename "$(dirname "$s")")"
-        rsn="$(jq -r '.failureReason // "-"' "$s" 2>/dev/null || echo -)"
-        echo "STUCK $it $(basename "$s") status=$st reason=$rsn"
-        SWEEP_ITEMS+=("${it}	${s}	${st}	${rsn}")
-        ;;
-    esac
-  done
-  # Recovery escalations + would-escalates on the unified log (audit trail of what
-  # the deterministic/bounded passes punted) — surfacing the set the narrow sweeps
-  # couldn't get past, so the sweep also covers items whose signal was already
-  # cleared. Read the monthly JSONL DIRECTLY (catalyst-events `tail` is a
-  # long-running follower with a jq `--filter`, not a one-shot history reader);
-  # match the canonical envelope shape (`attributes["event.name"]` is the event
-  # name; `body.payload.ticket` / `.reason` carry the CTL key + reason).
-  EVENTS_FILE="${CATALYST_EVENTS_DIR:-${CATALYST_DIR:-$HOME/catalyst}/events}/$(date -u +%Y-%m).jsonl"
-  if [[ -f "$EVENTS_FILE" ]]; then
-    echo "--- recovery escalations / would-escalates on the unified log (this month) ---"
-    jq -rc 'select((.attributes["event.name"] // "")
-              | test("^recovery\\.(escalated|would-escalate)$"))
-            | "WOULD-ESCALATE \(.body.payload.ticket // .attributes["event.label"] // "?") \(.attributes["event.name"]) reason=\(.body.payload.reason // "-")"' \
-      "$EVENTS_FILE" 2>/dev/null | sort -u \
-      || echo "(no recovery escalations on the log)"
-  fi
 fi
+
+# ── Context / mode resolution (BOTH modes) ───────────────────────────────────
+# Run the read-only context resolver FIRST. It prints a MODE banner + the stuck
+# set, and makes NO direct Linear API calls (local on-disk state only): in
+# dispatched mode it reads the recovery-pass.json brief (the eyes+hands output —
+# CONSUME it, do NOT re-run the diagnostician or the seams); in sweep mode it
+# unions THREE local sources — worker signals + the unified event log + the
+# webhook-fed Linear cache — deduped by ticket and HRW-filtered to this host.
+# Read its output; the MODE line drives which path you take below.
+node "${EXEC_CORE}/recovery-pass-context.mjs" ${TICKET:+--ticket "$TICKET"} --orch-dir "$ORCH_DIR"
 ```
 
+The script's banner is your context:
+
+- `MODE=dispatched` → the brief block + tail-of-logs is printed; you own that ONE
+  ticket. Go to the Step-0..4 fix loop. (Brief missing → it falls through to a
+  ticket-scoped sweep and you reconstruct the diagnosis yourself.)
+- `MODE=sweep` → a `STUCK <ticket> [...] reason=…` line per item and a `TOTAL: N`
+  summary. Each printed ticket is a per-item context; walk them all. There is no
+  pre-written brief — see the **Sweep SOP** section below for how to reconstruct
+  each item's diagnosis yourself.
+
 > **Sweep-mode binding.** In the sweep there is NO dispatcher `CATALYST_TICKET`.
-> Each entry in `SWEEP_ITEMS` is the per-item context. When you walk an item in
-> Steps 0–4 below, FIRST bind `TICKET` (and re-resolve `BRIEF` /
-> `SIGNAL_FILE` from it) to that item's ticket before authoring anything — the
-> authoring shims (`escalation-explain.mjs --ticket`, `recovery-emit.mjs
+> Each `STUCK <ticket>` line the context script printed is one per-item context.
+> When you walk an item in Steps 0–4 below, FIRST bind `TICKET` (and re-resolve
+> `BRIEF` / `SIGNAL_FILE` from it) to that item's ticket before authoring anything
+> — the authoring shims (`escalation-explain.mjs --ticket`, `recovery-emit.mjs
 > escalated --ticket`) reject an empty `--ticket`, so an escalation with `TICKET`
 > still empty would silently no-op and leave the goal FALSE. There is no
 > pre-written `recovery-pass.json` brief in the sweep — reconstruct the diagnosis
 > from the item's signal + `claude logs` yourself (this is the one place the sweep
 > re-reads logs, because no diagnostician ran ahead of it).
 
-## /goal condition
+## /goal condition — your self-evaluated stop condition
 
-Transcript-evaluable (the `/goal` evaluator sees ONLY printed text, never the
-filesystem), so the work block must PRINT a per-item resolution line carrying the
-proof signal. The goal is the fleet condition — keep iterating until it reads
-unequivocally TRUE. No turn-cap self-stop language (CTL-748) — the bounded
-envelope is enforced daemon-side.
+This is your **self-evaluated stop condition. There is no `/goal` command, and
+none can be invoked from a skill or a `claude --bg` session (verified — `/goal`
+is not a real Catalyst command, and slash commands do not nest inside a running
+skill or a background worker).** Read the block below as a plain-English success
+criterion that YOU check your own printed resolution lines against — it is not
+handed to any evaluator. (Repo-wide consistency note: any other skill text that
+implies a `/goal` evaluator reads printed text is using the same loose shorthand;
+treat the success criterion as self-checked there too. Do not edit those skills
+from here.)
+
+So PRINT a per-item resolution line carrying the proof signal — that is your own
+audit record of the goal being met, and the artifact a later reviewer reads. The
+goal is the fleet condition — keep iterating until it reads unequivocally TRUE.
+No turn-cap self-stop language (CTL-748) — the bounded envelope is enforced
+daemon-side.
 
 ```
 /goal "Every item that was stuck/failed/needs-human at the start of this pass is
@@ -221,11 +217,48 @@ envelope is enforced daemon-side.
        NEVER an acceptable escalation — those are (a) and I must resolve them."
 ```
 
+## Sweep SOP — diagnose Catalyst yourself (no brief)
+
+When the context script printed `MODE=sweep`, there is NO pre-written brief: no
+diagnostician ran ahead of you, so YOU reconstruct each item's diagnosis from the
+local sources before you act. This is the one place you read logs directly. A
+minimal senior-engineer onboarding to the machine you are operating:
+
+**The pipeline model.** Catalyst ships work through a 9-phase pipeline — triage →
+research → plan → implement → verify → review → pr → monitor-merge →
+monitor-deploy. Each phase runs as one short-lived `claude --bg` worker. A worker
+writes its state to a signal file at `${ORCH_DIR}/workers/<ticket>/phase-*.json`
+(`status`, `failureReason`, `bg_job_id`). A ticket is "stuck" when a phase signal
+sits at `needs-human`/`failed`/`stalled`, or its worker died with the signal frozen.
+
+**Where to look (per item).**
+
+- **The worker signal** — `${ORCH_DIR}/workers/<ticket>/phase-*.json`: which phase,
+  its `status`, its `failureReason`, and the `bg_job_id`.
+- **The worker transcript** — `claude logs <shortId>` (the first 8 chars of the
+  signal's `bg_job_id`): what the worker actually did and where it stopped.
+- **The unified event log** — `~/catalyst/events/YYYY-MM.jsonl`: the surrounding
+  phase/recovery events for this ticket (escalations, dispatches, completions).
+- **The worktree** — `~/catalyst/wt/catalyst-workspace/<ticket>`: the live branch
+  state — `git status`, `git log`, conflict markers, a half-finished rebase.
+- **The PR** — `gh pr list --search <ticket>` then `gh pr view <n> --json
+  mergeable,mergeStateStatus,reviewDecision,statusCheckRollup`: is there a PR, is
+  it green, is it BEHIND/CONFLICTING, is it just sitting there mergeable.
+- **The Linear cache** — the `linear-state=…` / `labels=…` the context script
+  printed for the item (from the webhook-fed cache; no direct Linear call needed).
+
+**Then diagnose like a senior engineer.** From those: what phase is it in? what
+failed — a conflict, a failed check, a dead worker, an un-merged green PR, a
+stalled dispatch? Is there a PR and what state is it in? Write yourself the
+one-line diagnosis the brief would have carried, then drop into the Step-1/2 fix
+loop below (skip Step 0's "consume the brief" — you just built it yourself).
+
 ## Phase-specific work — the senior-engineer unstick loop
 
 Think hard. You are a senior engineer; Ryan is your executive product manager.
 Default to ACTING. For each stuck item, walk the decision checklist top-to-bottom;
-first match wins. Print a resolution line for every item so `/goal` has signal.
+first match wins. Print a per-item resolution line for every item (your own
+self-checked record of the goal — see the /goal condition section).
 
 ### Step 0 — Consume the eyes + hands output (do NOT redo it)
 
@@ -281,8 +314,9 @@ escalate them:
   scoped to the diff), retry the phase.
 
 After each action, PRINT the action + its success signal (the `exit 0`, the
-`mergeable: "MERGEABLE"`, the merged SHA, the re-dispatch event id) so `/goal`
-can see it. Use `gh` and `git` directly; delegate a deeper code fix to
+`mergeable: "MERGEABLE"`, the merged SHA, the re-dispatch event id) as the
+per-item resolution line you check the goal against. Use `gh` and `git`
+directly; delegate a deeper code fix to
 `/catalyst-dev:phase-remediate` or `/catalyst-dev:merge-pr` via the Task tool
 when one fits, but YOU own the cross-pipeline moves.
 
@@ -322,6 +356,12 @@ owns*, that is the tell that it belongs in the FIX path — re-check Step 2.
 This is the part that genuinely differs from phase-remediate. You author what Ryan
 sees in the Needs-You inbox AND in the push notification. Two surfaces, ONE
 payload, executive-voiced (you are the senior engineer reporting up to the PM).
+
+> **Required on escalation:** the inbox row (summary / ask / options / blocker)
+> AND the push notification CTA are BOTH authored via `recovery-emit.mjs` (one
+> `escalated` call writes both surfaces off the one payload). An escalation
+> without both is INCOMPLETE — the item is not yet terminal and the goal stays
+> FALSE.
 
 **Voice (from the `writing:ryan-writing-style` skill — Mode 1 / Mode 2):**
 answer-first (lead with the decision needed), plain language (NO stack traces,
@@ -381,8 +421,8 @@ You do NOT call web-push yourself — the curation layer
 (`deriveAttention`/`deriveNavSignal` → `shouldNotify` → `/api/notifications/stream`)
 gates the push off the `needs-human` + WARN signals you just wrote. The native/PWA
 app is a thin transport over that same shared filter; there is no second filter to
-satisfy. Print that both the event and the signal explanation were written so
-`/goal` sees the escalation landed.
+satisfy. Print that both the event and the signal explanation were written — that
+printed line is your record that the escalation landed (the goal's branch (b)).
 
 **On an autonomous FIX, record the win for the audit trail** (INFO, no push — the
 recovered lane, not a needs-you row). Write a plain past-tense changelog, NOT
@@ -417,7 +457,7 @@ with what's done, or failed on abort). Archive what you absorb.
 
 In router-dispatched mode, emit the terminal event so the scheduler advances and
 the bg job is reaped. (In bare sweep mode there is no signal envelope to close —
-the printed `/goal` resolution lines are the record.)
+the printed per-item resolution lines are the record.)
 
 ```bash
 if [[ -n "$TICKET" ]]; then


### PR DESCRIPTION
Adds recovery-pass-context.mjs: a read-only mode/context resolver the skill runs first. MODE=dispatched reads the brief; MODE=sweep enumerates the stuck set from THREE local sources — worker signals + unified event log + the webhook-fed Linear cache (getAllTicketDescriptors, NO direct Linear API) — deduped and HRW-filtered (ownedBy, identity at N=1). Plus skill edits: a 5-part 'what you're walking into' frame, a 'Sweep SOP' for diagnosing Catalyst with no brief, and a fix to the /goal section (it's a self-evaluated stop condition — /goal is NOT a real command and can't be nested, verified). FOR AUDIT — do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)