### PR TITLE
CTL-1246: route Catalyst thoughts to coalesce-labs — pollution audit, zero-loss migration + clean-config guard

### DIFF
--- a/plugins/dev/scripts/__tests__/audit-thoughts-pollution.test.sh
+++ b/plugins/dev/scripts/__tests__/audit-thoughts-pollution.test.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Tests for audit-thoughts-pollution.sh (CTL-1246, Phase 1).
+# Hermetic — builds fixture thoughts checkouts with mktemp -d + `git init`, no
+# network, no real `gh`. Asserts the path-prefix classification (MOVE / LEAVE /
+# REVERSE) and the JSONL manifest schema. The discriminator under test is the
+# `repos/<subdir>/` PATH PREFIX, never content keywords (CTL- / catalyst / ADV-).
+#
+# Run: bash plugins/dev/scripts/__tests__/audit-thoughts-pollution.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+AUDIT="${SCRIPTS_DIR}/audit-thoughts-pollution.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+assert_eq() {
+  local label="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    PASSES=$((PASSES + 1)); echo "  PASS: $label"
+  else
+    FAILURES=$((FAILURES + 1)); echo "  FAIL: $label"
+    echo "    expected: $expected"; echo "    actual:   $actual"
+  fi
+}
+assert_grep() {
+  local label="$1" output="$2" pattern="$3"
+  if grep -qF -- "$pattern" <<<"$output"; then
+    PASSES=$((PASSES + 1)); echo "  PASS: $label"
+  else
+    FAILURES=$((FAILURES + 1)); echo "  FAIL: $label"
+    echo "    expected substring: $pattern"
+    echo "$output" | head -40 | sed 's/^/      /'
+  fi
+}
+assert_not_grep() {
+  local label="$1" output="$2" pattern="$3"
+  if grep -qF -- "$pattern" <<<"$output"; then
+    FAILURES=$((FAILURES + 1)); echo "  FAIL: $label (unexpected pattern found)"
+    echo "    unexpected substring: $pattern"
+  else
+    PASSES=$((PASSES + 1)); echo "  PASS: $label"
+  fi
+}
+
+# Local git that never touches the user's config / signing / hooks.
+git_q() { git -c init.defaultBranch=main -c user.email=t@t -c user.name=t \
+            -c commit.gpgsign=false "$@"; }
+
+# Build a thoughts checkout at $1 with a set of "path<TAB>content" rows (stdin),
+# then commit. Returns the repo dir.
+build_repo() {
+  local dir="$1"; shift
+  mkdir -p "$dir"
+  git_q -C "$dir" init -q
+  while IFS=$'\t' read -r relpath content; do
+    [[ -z "$relpath" ]] && continue
+    mkdir -p "$dir/$(dirname "$relpath")"
+    printf '%s\n' "$content" > "$dir/$relpath"
+  done
+  git_q -C "$dir" add -A
+  git_q -C "$dir" commit -q -m "seed"
+}
+
+echo "=== audit-thoughts-pollution.sh hermetic tests ==="
+echo "SCRIPT: $AUDIT"
+echo "SCRATCH: $SCRATCH"
+echo ""
+
+# ─── Fixture A — a rightsite-cloud (NON coalesce-labs) thoughts checkout ──────
+echo "=== Fixture A: rightsite-cloud checkout — catalyst subdirs are MOVE ==="
+REPO_A="$SCRATCH/rightsite-cloud/thoughts"
+build_repo "$REPO_A" <<EOF
+repos/Adva/shared/friction/ADV-1263.md	legit Adva work but mentions CTL-999 and catalyst in the body
+repos/Adva/shared/handoffs/o-adv-1.md	legit Adva handoff
+repos/catalyst-workspace/shared/plans/p.md	TRUE misroute — catalyst plan in the wrong repo
+repos/catalyst/shared/research/r.md	TRUE misroute — catalyst research in the wrong repo
+EOF
+
+A_OUT="$("$AUDIT" --root "$REPO_A" --org rightsite-cloud 2>/dev/null)"
+A_ERR="$("$AUDIT" --root "$REPO_A" --org rightsite-cloud 2>&1 >/dev/null)"
+
+# Exactly the two repos/catalyst*/ files are MOVE.
+A_MOVE_PATHS="$(jq -r 'select(.classification=="MOVE") | .path' <<<"$A_OUT" | sort | tr '\n' ' ')"
+assert_eq "A: exactly the two catalyst-subdir files are MOVE" \
+  "$A_MOVE_PATHS" \
+  "repos/catalyst-workspace/shared/plans/p.md repos/catalyst/shared/research/r.md "
+
+A_MOVE_COUNT="$(jq -rs '[.[] | select(.classification=="MOVE")] | length' <<<"$A_OUT")"
+assert_eq "A: MOVE count is exactly 2" "$A_MOVE_COUNT" "2"
+
+# Adva files (even with CTL-/catalyst content) are NEVER MOVE.
+assert_not_grep "A: repos/Adva/.../ADV-1263.md never classified MOVE" \
+  "$A_OUT" 'repos/Adva/shared/friction/ADV-1263.md","classification":"MOVE"'
+A_ADVA_MOVE="$(jq -rs '[.[] | select(.classification=="MOVE") | select(.path|test("repos/Adva/"))] | length' <<<"$A_OUT")"
+assert_eq "A: zero Adva files in the MOVE set despite CTL-/catalyst keywords" "$A_ADVA_MOVE" "0"
+
+# JSONL schema: every record has {path, classification, repo, org, reason}.
+A_SCHEMA_OK="$(jq -rs 'all(.[]; has("path") and has("classification") and has("repo") and has("org") and has("reason")) ' <<<"$A_OUT")"
+assert_eq "A: every JSONL record has the full schema {path,classification,repo,org,reason}" \
+  "$A_SCHEMA_OK" "true"
+assert_eq "A: repo field is the repos/<subdir> segment" \
+  "$(jq -r 'select(.path=="repos/catalyst-workspace/shared/plans/p.md") | .repo' <<<"$A_OUT")" \
+  "catalyst-workspace"
+assert_eq "A: org field echoes the audited org" \
+  "$(jq -rs '.[0].org' <<<"$A_OUT")" "rightsite-cloud"
+
+# Read-only on the source: git status stays clean, no manifest written into tree.
+A_STATUS="$(git_q -C "$REPO_A" status --porcelain)"
+assert_eq "A: audit is read-only — source git status stays clean" "$A_STATUS" ""
+
+# ─── Fixture B — a coalesce-labs thoughts checkout — Adva subdir is REVERSE ────
+echo ""
+echo "=== Fixture B: coalesce-labs checkout — repos/Adva is REVERSE ==="
+REPO_B="$SCRATCH/coalesce-labs/thoughts"
+build_repo "$REPO_B" <<EOF
+repos/catalyst-workspace/shared/plans/ok.md	correctly-homed catalyst plan
+repos/Adva/x.md	Adva content sitting under coalesce-labs (reverse misroute)
+shared/pm/adva/ADV-9.md	legit catalyst PM work ABOUT Adva, not under repos/
+EOF
+
+B_OUT="$("$AUDIT" --root "$REPO_B" --org coalesce-labs 2>/dev/null)"
+
+assert_eq "B: repos/Adva/x.md classified REVERSE" \
+  "$(jq -r 'select(.path=="repos/Adva/x.md") | .classification' <<<"$B_OUT")" \
+  "REVERSE"
+B_MOVE_COUNT="$(jq -rs '[.[] | select(.classification=="MOVE")] | length' <<<"$B_OUT")"
+assert_eq "B: zero MOVE in the correct (coalesce-labs) repo" "$B_MOVE_COUNT" "0"
+# correctly-homed catalyst content is NOT flagged.
+assert_not_grep "B: correctly-homed repos/catalyst-workspace is not in the manifest as MOVE/REVERSE" \
+  "$B_OUT" 'repos/catalyst-workspace/shared/plans/ok.md'
+# shared/pm/adva path (ADV- keyword, NOT under repos/) is never flagged.
+assert_not_grep "B: shared/pm/adva/ADV-9.md (not under repos/) is never flagged" \
+  "$B_OUT" 'shared/pm/adva/ADV-9.md'
+
+# ─── Empty / clean tree ───────────────────────────────────────────────────────
+echo ""
+echo "=== Empty/clean tree → zero MOVE, exit 0, summary says 0 true misroutes ==="
+REPO_C="$SCRATCH/clean/thoughts"
+build_repo "$REPO_C" <<EOF
+global/notes.md	just a global note, no repos/ subtree
+shared/learnings/x.md	a learning
+EOF
+
+C_OUT="$("$AUDIT" --root "$REPO_C" --org rightsite-cloud 2>/dev/null)"; C_RC=$?
+C_ERR="$("$AUDIT" --root "$REPO_C" --org rightsite-cloud 2>&1 >/dev/null)"
+assert_eq "clean: exit 0" "$C_RC" "0"
+C_MOVE_COUNT="$(jq -rs '[.[] | select(.classification=="MOVE")] | length' <<<"$C_OUT" 2>/dev/null || echo 0)"
+assert_eq "clean: zero MOVE records" "$C_MOVE_COUNT" "0"
+assert_grep "clean: summary says 0 true misroutes" "$C_ERR" "0 true misroutes"
+
+# ─── Auto org-derivation from the git remote ──────────────────────────────────
+echo ""
+echo "=== Auto org-derivation from git remote (groundworkapp → rightsite-cloud) ==="
+REPO_D="$SCRATCH/auto/thoughts"
+build_repo "$REPO_D" <<EOF
+repos/catalyst/shared/plans/p.md	misroute discovered via auto-derived org
+EOF
+# groundworkapp remote must normalize to rightsite-cloud → catalyst subdir = MOVE.
+git_q -C "$REPO_D" remote add origin "https://github.com/groundworkapp/thoughts.git"
+D_OUT="$("$AUDIT" --root "$REPO_D" 2>/dev/null)"
+assert_eq "auto: org derived + normalized to rightsite-cloud" \
+  "$(jq -rs '.[0].org' <<<"$D_OUT")" "rightsite-cloud"
+assert_eq "auto: catalyst subdir is MOVE under the derived non-coalesce-labs org" \
+  "$(jq -r 'select(.path=="repos/catalyst/shared/plans/p.md") | .classification' <<<"$D_OUT")" \
+  "MOVE"
+
+# ─── Bad/missing --root → non-zero with a clear message ───────────────────────
+echo ""
+echo "=== Bad/missing --root → non-zero exit, clear message ==="
+MISS_ERR="$("$AUDIT" --org rightsite-cloud 2>&1)"; MISS_RC=$?
+assert_eq "missing --root: non-zero exit" "$([[ $MISS_RC -ne 0 ]] && echo nonzero || echo zero)" "nonzero"
+assert_grep "missing --root: message mentions root" "$MISS_ERR" "root"
+
+BAD_ERR="$("$AUDIT" --root "$SCRATCH/does-not-exist" --org rightsite-cloud 2>&1)"; BAD_RC=$?
+assert_eq "nonexistent --root: non-zero exit" "$([[ $BAD_RC -ne 0 ]] && echo nonzero || echo zero)" "nonzero"
+
+# ─── --help exits 0 ───────────────────────────────────────────────────────────
+"$AUDIT" --help >/dev/null 2>&1
+assert_eq "--help exits 0" "$?" "0"
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASSES"
+echo "FAIL: $FAILURES"
+echo ""
+echo "audit-thoughts-pollution.test.sh: ${PASSES} passed, ${FAILURES} failed"
+exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/migrate-thoughts-pollution.test.sh
+++ b/plugins/dev/scripts/__tests__/migrate-thoughts-pollution.test.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Tests for migrate-thoughts-pollution.sh (CTL-1246, Phase 2).
+# Hermetic — `git init` a real repo with commit history per fixture, no network.
+# The migration consumes a Phase-1 manifest, defaults to --dry-run, pre-checks
+# collisions, and `git mv`s the MOVE set preserving history. Zero-loss + idempotent.
+#
+# Fixture model: source-root and target-root are two subtrees of ONE git repo so
+# `git mv` preserves history and `git log --follow` resolves the rename (mirrors
+# the same-repo move-and-rereference.sh template the migration is modeled on).
+#
+# Run: bash plugins/dev/scripts/__tests__/migrate-thoughts-pollution.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MIGRATE="${SCRIPTS_DIR}/migrate-thoughts-pollution.sh"
+AUDIT="${SCRIPTS_DIR}/audit-thoughts-pollution.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+assert_eq() {
+  local label="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    PASSES=$((PASSES + 1)); echo "  PASS: $label"
+  else
+    FAILURES=$((FAILURES + 1)); echo "  FAIL: $label"
+    echo "    expected: $expected"; echo "    actual:   $actual"
+  fi
+}
+assert_grep() {
+  local label="$1" output="$2" pattern="$3"
+  if grep -qF -- "$pattern" <<<"$output"; then
+    PASSES=$((PASSES + 1)); echo "  PASS: $label"
+  else
+    FAILURES=$((FAILURES + 1)); echo "  FAIL: $label"
+    echo "    expected substring: $pattern"; echo "$output" | head -30 | sed 's/^/      /'
+  fi
+}
+
+git_q() { git -c init.defaultBranch=main -c user.email=t@t -c user.name=t \
+            -c commit.gpgsign=false "$@"; }
+
+# Build a one-repo fixture: $1/source/<tree> + an empty $1/target/. Commits the
+# source tree so history exists. Rows are "relpath<TAB>content" on stdin, relpath
+# is relative to source-root (i.e. repos/<subdir>/...).
+build_fixture() {
+  local repo="$1"; shift
+  mkdir -p "$repo/source" "$repo/target"
+  git_q -C "$repo" init -q
+  # target/ needs to be inside the repo; seed a keep file so it is tracked terrain.
+  printf 'keep\n' > "$repo/target/.keep"
+  while IFS=$'\t' read -r relpath content; do
+    [[ -z "$relpath" ]] && continue
+    mkdir -p "$repo/source/$(dirname "$relpath")"
+    printf '%s\n' "$content" > "$repo/source/$relpath"
+  done
+  git_q -C "$repo" add -A
+  git_q -C "$repo" commit -q -m "seed"
+}
+
+# Count files present under <root> whose relative path is in the MOVE set list ($2..).
+count_present() {
+  local root="$1"; shift
+  local n=0 p
+  for p in "$@"; do [[ -e "$root/$p" ]] && n=$((n + 1)); done
+  echo "$n"
+}
+
+echo "=== migrate-thoughts-pollution.sh hermetic tests ==="
+echo "SCRIPT: $MIGRATE"
+echo "SCRATCH: $SCRATCH"
+echo ""
+
+# ─── Main fixture: audit → migrate integration ────────────────────────────────
+echo "=== --dry-run (default) changes nothing; --execute moves the MOVE set ==="
+REPO="$SCRATCH/main"
+build_fixture "$REPO" <<EOF
+repos/catalyst-workspace/shared/plans/p.md	catalyst plan misrouted into rightsite-cloud
+repos/catalyst/shared/research/r.md	catalyst research misrouted
+repos/Adva/shared/friction/ADV-1.md	legit Adva — must be LEFT
+EOF
+SRC="$REPO/source"; TGT="$REPO/target"
+MANIFEST="$SCRATCH/main-manifest.jsonl"
+# Generate the manifest with the real Phase-1 audit (true integration).
+"$AUDIT" --root "$SRC" --org rightsite-cloud --out "$MANIFEST" 2>/dev/null
+MOVE_A="repos/catalyst-workspace/shared/plans/p.md"
+MOVE_B="repos/catalyst/shared/research/r.md"
+LEAVE_X="repos/Adva/shared/friction/ADV-1.md"
+ORIG_MOVE=2
+
+# --dry-run (default): prints "would", touches nothing.
+DRY_OUT="$("$MIGRATE" --manifest "$MANIFEST" --source-root "$SRC" --target-root "$TGT" 2>&1)"; DRY_RC=$?
+assert_eq "dry-run: exit 0" "$DRY_RC" "0"
+assert_grep "dry-run: prints a 'would' line" "$DRY_OUT" "would"
+assert_eq "dry-run: source git status stays clean" "$(git_q -C "$REPO" status --porcelain)" ""
+assert_eq "dry-run: MOVE files still in source (2)" "$(count_present "$SRC" "$MOVE_A" "$MOVE_B")" "2"
+assert_eq "dry-run: nothing copied into target (0)" "$(count_present "$TGT" "$MOVE_A" "$MOVE_B")" "0"
+
+# --execute: moves the 2 MOVE files, leaves the Adva file.
+EXEC_OUT="$("$MIGRATE" --manifest "$MANIFEST" --source-root "$SRC" --target-root "$TGT" --execute 2>&1)"; EXEC_RC=$?
+assert_eq "execute: exit 0" "$EXEC_RC" "0"
+assert_eq "execute: MOVE files now in target (2)" "$(count_present "$TGT" "$MOVE_A" "$MOVE_B")" "2"
+assert_eq "execute: MOVE files gone from source (0)" "$(count_present "$SRC" "$MOVE_A" "$MOVE_B")" "0"
+assert_eq "execute: LEAVE (Adva) file untouched in source" \
+  "$([[ -e "$SRC/$LEAVE_X" ]] && echo present || echo gone)" "present"
+assert_eq "execute: LEAVE (Adva) file NOT copied to target" \
+  "$([[ -e "$TGT/$LEAVE_X" ]] && echo present || echo gone)" "gone"
+
+# Zero-loss invariant: target + source MOVE counts == original, at this step.
+assert_eq "zero-loss: target+source MOVE count equals original" \
+  "$(( $(count_present "$TGT" "$MOVE_A" "$MOVE_B") + $(count_present "$SRC" "$MOVE_A" "$MOVE_B") ))" \
+  "$ORIG_MOVE"
+
+# History preserved: commit the staged move, then git log --follow shows the seed.
+git_q -C "$REPO" commit -q -m "migrate moves"
+FOLLOW="$(git_q -C "$REPO" log --follow --format=%s -- "target/$MOVE_A")"
+assert_grep "history: git log --follow on the moved file shows the original seed commit" \
+  "$FOLLOW" "seed"
+
+# Idempotency: a second --execute (source drained) is a clean no-op.
+IDEM_OUT="$("$MIGRATE" --manifest "$MANIFEST" --source-root "$SRC" --target-root "$TGT" --execute 2>&1)"; IDEM_RC=$?
+assert_eq "idempotent: second --execute exits 0" "$IDEM_RC" "0"
+assert_eq "idempotent: target still has exactly the 2 moved files" \
+  "$(count_present "$TGT" "$MOVE_A" "$MOVE_B")" "2"
+assert_grep "idempotent: reports already-migrated / nothing to do" "$IDEM_OUT" "skip"
+# A no-op second run must not create new staged changes.
+assert_eq "idempotent: working tree clean after second --execute" \
+  "$(git_q -C "$REPO" status --porcelain)" ""
+
+# ─── Collision pre-check ──────────────────────────────────────────────────────
+echo ""
+echo "=== Collision: target exists & differs → abort before moving anything ==="
+REPOC="$SCRATCH/collide"
+build_fixture "$REPOC" <<EOF
+repos/catalyst/shared/plans/c.md	source content
+EOF
+SRCC="$REPOC/source"; TGTC="$REPOC/target"
+MANC="$SCRATCH/collide-manifest.jsonl"
+"$AUDIT" --root "$SRCC" --org rightsite-cloud --out "$MANC" 2>/dev/null
+# Pre-seed a DIFFERING target file at the collision path.
+mkdir -p "$TGTC/repos/catalyst/shared/plans"
+printf 'DIFFERENT target content\n' > "$TGTC/repos/catalyst/shared/plans/c.md"
+git_q -C "$REPOC" add -A; git_q -C "$REPOC" commit -q -m "pre-seed target collision"
+
+COL_OUT="$("$MIGRATE" --manifest "$MANC" --source-root "$SRCC" --target-root "$TGTC" --execute 2>&1)"; COL_RC=$?
+assert_eq "collision: non-zero exit" "$([[ $COL_RC -ne 0 ]] && echo nonzero || echo zero)" "nonzero"
+assert_grep "collision: reports the conflicting path" "$COL_OUT" "repos/catalyst/shared/plans/c.md"
+assert_eq "collision: source file untouched (move nothing on abort)" \
+  "$([[ -e "$SRCC/repos/catalyst/shared/plans/c.md" ]] && echo present || echo gone)" "present"
+assert_eq "collision: target file content unchanged" \
+  "$(cat "$TGTC/repos/catalyst/shared/plans/c.md")" "DIFFERENT target content"
+
+# ─── Untracked file in MOVE set → plain mv ────────────────────────────────────
+echo ""
+echo "=== Untracked file in MOVE set → plain mv (not git mv) ==="
+REPOU="$SCRATCH/untracked"
+build_fixture "$REPOU" <<EOF
+repos/catalyst/shared/plans/tracked.md	tracked content
+EOF
+SRCU="$REPOU/source"; TGTU="$REPOU/target"
+# Add an UNTRACKED file under source and hand-write a manifest that lists it MOVE.
+mkdir -p "$SRCU/repos/catalyst/shared/notes"
+printf 'untracked content\n' > "$SRCU/repos/catalyst/shared/notes/u.md"
+MANU="$SCRATCH/untracked-manifest.jsonl"
+{
+  jq -nc '{path:"repos/catalyst/shared/plans/tracked.md",classification:"MOVE",repo:"catalyst",org:"rightsite-cloud",reason:"tracked"}'
+  jq -nc '{path:"repos/catalyst/shared/notes/u.md",classification:"MOVE",repo:"catalyst",org:"rightsite-cloud",reason:"untracked"}'
+} > "$MANU"
+
+UNT_OUT="$("$MIGRATE" --manifest "$MANU" --source-root "$SRCU" --target-root "$TGTU" --execute 2>&1)"; UNT_RC=$?
+assert_eq "untracked: exit 0" "$UNT_RC" "0"
+assert_eq "untracked: untracked file moved to target" \
+  "$([[ -e "$TGTU/repos/catalyst/shared/notes/u.md" ]] && echo present || echo gone)" "present"
+assert_eq "untracked: untracked file gone from source" \
+  "$([[ -e "$SRCU/repos/catalyst/shared/notes/u.md" ]] && echo present || echo gone)" "gone"
+assert_eq "untracked: tracked file also moved" \
+  "$([[ -e "$TGTU/repos/catalyst/shared/plans/tracked.md" ]] && echo present || echo gone)" "present"
+
+# ─── Empty manifest / zero MOVE records → exit 0, nothing to migrate ──────────
+echo ""
+echo "=== Empty manifest → exit 0, 'nothing to migrate' ==="
+REPOE="$SCRATCH/empty"
+build_fixture "$REPOE" <<EOF
+repos/Adva/x.md	only Adva content, no MOVE records
+EOF
+SRCE="$REPOE/source"; TGTE="$REPOE/target"
+MANE="$SCRATCH/empty-manifest.jsonl"
+"$AUDIT" --root "$SRCE" --org rightsite-cloud --out "$MANE" 2>/dev/null  # yields 0 MOVE
+EMP_OUT="$("$MIGRATE" --manifest "$MANE" --source-root "$SRCE" --target-root "$TGTE" --execute 2>&1)"; EMP_RC=$?
+assert_eq "empty: exit 0" "$EMP_RC" "0"
+assert_grep "empty: 'nothing to migrate'" "$EMP_OUT" "nothing to migrate"
+
+# ─── Missing required args ────────────────────────────────────────────────────
+echo ""
+echo "=== Missing required args → non-zero ==="
+BAD_OUT="$("$MIGRATE" --source-root "$SRC" --target-root "$TGT" --execute 2>&1)"; BAD_RC=$?
+assert_eq "missing --manifest: non-zero exit" "$([[ $BAD_RC -ne 0 ]] && echo nonzero || echo zero)" "nonzero"
+"$MIGRATE" --help >/dev/null 2>&1
+assert_eq "--help exits 0" "$?" "0"
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASSES"
+echo "FAIL: $FAILURES"
+echo ""
+echo "migrate-thoughts-pollution.test.sh: ${PASSES} passed, ${FAILURES} failed"
+exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/migrate-thoughts-pollution.test.sh
+++ b/plugins/dev/scripts/__tests__/migrate-thoughts-pollution.test.sh
@@ -194,6 +194,29 @@ EMP_OUT="$("$MIGRATE" --manifest "$MANE" --source-root "$SRCE" --target-root "$T
 assert_eq "empty: exit 0" "$EMP_RC" "0"
 assert_grep "empty: 'nothing to migrate'" "$EMP_OUT" "nothing to migrate"
 
+# ─── Path-traversal guard ─────────────────────────────────────────────────────
+echo ""
+echo "=== Poisoned manifest (.. / absolute path) → abort, move nothing ==="
+REPOT="$SCRATCH/traversal"
+build_fixture "$REPOT" <<EOF
+repos/catalyst/shared/plans/safe.md	safe content
+EOF
+SRCT="$REPOT/source"; TGTT="$REPOT/target"
+# A canary the traversal path would clobber if the guard were absent.
+printf 'do not touch\n' > "$SCRATCH/canary.md"
+MANT="$SCRATCH/traversal-manifest.jsonl"
+{
+  jq -nc '{path:"repos/catalyst/shared/plans/safe.md",classification:"MOVE",repo:"catalyst",org:"rightsite-cloud",reason:"safe"}'
+  jq -nc '{path:"../../../canary.md",classification:"MOVE",repo:"catalyst",org:"rightsite-cloud",reason:"poison"}'
+} > "$MANT"
+
+TRV_OUT="$("$MIGRATE" --manifest "$MANT" --source-root "$SRCT" --target-root "$TGTT" --execute 2>&1)"; TRV_RC=$?
+assert_eq "traversal: non-zero exit on '..' path" "$([[ $TRV_RC -ne 0 ]] && echo nonzero || echo zero)" "nonzero"
+assert_grep "traversal: reports the unsafe path" "$TRV_OUT" "unsafe manifest path"
+assert_eq "traversal: canary outside the roots is untouched" "$(cat "$SCRATCH/canary.md")" "do not touch"
+assert_eq "traversal: safe sibling NOT moved (abort before moving anything)" \
+  "$([[ -e "$SRCT/repos/catalyst/shared/plans/safe.md" ]] && echo present || echo gone)" "present"
+
 # ─── Missing required args ────────────────────────────────────────────────────
 echo ""
 echo "=== Missing required args → non-zero ==="

--- a/plugins/dev/scripts/__tests__/provision-thoughts-invariant.test.sh
+++ b/plugins/dev/scripts/__tests__/provision-thoughts-invariant.test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Regression guard for the clean-config invariant (CTL-1246, Phase 3).
+#
+# The groundworkapp-fallback bug (CTL-1214 bug #6) was fixed in
+# provision-thoughts.sh — write_config() now writes a coalesce-labs global
+# thoughtsRepo + defaultProfile and normalizes groundworkapp → rightsite-cloud.
+# This suite LOCKS that invariant so it cannot silently regress: it drives the
+# script's hermetic --dry-run payload-print seam against a registry that contains
+# a groundworkapp/Adva repoRoot and asserts the printed .thoughts payload can
+# NEVER reintroduce a groundworkapp global fallback.
+#
+# No production behavior change — provision-thoughts.sh already satisfies these.
+# If any assertion fails, fix write_config() (provision-thoughts.sh:114-165) /
+# normalize_org() (:44) to restore the invariant.
+#
+# Run: bash plugins/dev/scripts/__tests__/provision-thoughts-invariant.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PROVISION="${SCRIPTS_DIR}/provision-thoughts.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+HL_CONFIG_FILE="$SCRATCH/humanlayer.json"
+
+assert_eq() {
+  local label="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    PASSES=$((PASSES + 1)); echo "  PASS: $label"
+  else
+    FAILURES=$((FAILURES + 1)); echo "  FAIL: $label"
+    echo "    expected: $expected"; echo "    actual:   $actual"
+  fi
+}
+assert_not_grep() {
+  local label="$1" output="$2" pattern="$3"
+  if grep -qF -- "$pattern" <<<"$output"; then
+    FAILURES=$((FAILURES + 1)); echo "  FAIL: $label (unexpected pattern found)"
+    echo "    unexpected substring: $pattern"
+    echo "$output" | head -40 | sed 's/^/      /'
+  else
+    PASSES=$((PASSES + 1)); echo "  PASS: $label"
+  fi
+}
+
+run_provision() {
+  env -i PATH="$PATH" HOME="$SCRATCH/home" USER="testnode" \
+    HLT_ROOT="$SCRATCH/hlt" HL_CONFIG="$HL_CONFIG_FILE" \
+    bash "$PROVISION" --dry-run --no-clone "$@" 2>&1
+}
+extract_json() {
+  awk '/DRY-RUN humanlayer.json .thoughts would be:/{found=1; next} found{print}' <<<"$1" \
+    | jq -c . 2>/dev/null
+}
+
+echo "=== provision-thoughts clean-config invariant guard (CTL-1246) ==="
+echo "SCRIPT: $PROVISION"
+echo ""
+
+# A registry whose ONLY repoRoot is the groundworkapp (Adva) code repo — the exact
+# shape that used to produce the global groundworkapp fallback.
+REG_GW="$SCRATCH/registry-gw.json"
+cat > "$REG_GW" <<EOF
+{"projects":[{"repoRoot":"$SCRATCH/github/groundworkapp/groundwork","team":"ADV"}]}
+EOF
+
+OUT="$(run_provision --registry "$REG_GW")"
+JSON="$(extract_json "$OUT")"
+
+# 1. Global fallback thoughtsRepo is the coalesce-labs HLT path, never groundworkapp.
+assert_eq "global thoughtsRepo ends with /coalesce-labs/thoughts" \
+  "$(jq -r '.thoughtsRepo' <<<"$JSON")" "$SCRATCH/hlt/coalesce-labs/thoughts"
+assert_not_grep "global thoughtsRepo never contains 'groundworkapp'" \
+  "$(jq -r '.thoughtsRepo' <<<"$JSON")" "groundworkapp"
+
+# 2. defaultProfile is coalesce-labs.
+assert_eq "defaultProfile == coalesce-labs" "$(jq -r '.defaultProfile' <<<"$JSON")" "coalesce-labs"
+
+# 3. NO profile thoughtsRepo path contains groundworkapp.
+assert_not_grep "no profile.thoughtsRepo contains 'groundworkapp'" \
+  "$(jq -r '.profiles[].thoughtsRepo' <<<"$JSON")" "groundworkapp"
+
+# 4. No THOUGHTS path or profile mentions groundworkapp. (The repoMappings KEY is
+#    the local source-code repoRoot — e.g. /github/groundworkapp/groundwork — and
+#    legitimately contains the org dir name; that is the code repo path, not a
+#    thoughts path. Strip the keys and assert the rest is groundworkapp-free, plus
+#    assert the repoMapping VALUES (repo/profile) are clean too.)
+assert_not_grep "no thoughts path / profile contains 'groundworkapp' (repoMapping keys excluded)" \
+  "$(jq -c 'del(.repoMappings)' <<<"$JSON")" "groundworkapp"
+assert_not_grep "repoMapping values (.repo/.profile) are groundworkapp-free" \
+  "$(jq -r '.repoMappings[] | "\(.repo) \(.profile)"' <<<"$JSON")" "groundworkapp"
+
+# 5. The Adva (groundworkapp) repoRoot normalizes to profile 'adva' → rightsite-cloud HLT.
+assert_eq "groundworkapp repoRoot resolves to profile 'adva' (normalize_org applied)" \
+  "$(jq -r --arg p "$SCRATCH/github/groundworkapp/groundwork" '.repoMappings[$p].profile // "MISSING"' <<<"$JSON")" \
+  "adva"
+assert_eq "the 'adva' profile points at the rightsite-cloud HLT path" \
+  "$(jq -r '.profiles["adva"].thoughtsRepo // "MISSING"' <<<"$JSON")" \
+  "$SCRATCH/hlt/rightsite-cloud/thoughts"
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASSES"
+echo "FAIL: $FAILURES"
+echo ""
+echo "provision-thoughts-invariant.test.sh: ${PASSES} passed, ${FAILURES} failed"
+exit "$FAILURES"

--- a/plugins/dev/scripts/audit-thoughts-pollution.sh
+++ b/plugins/dev/scripts/audit-thoughts-pollution.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# audit-thoughts-pollution.sh — classify the files in a thoughts checkout by their
+# `repos/<subdir>/` PATH PREFIX and emit a misroute manifest. (CTL-1246, §6 of the
+# cluster HLT thoughts-model design, CTL-1214.)
+#
+# The reliable discriminator is the path prefix, NOT content keywords (CTL- /
+# catalyst / ADV-): an Adva friction note that mentions a CTL ticket is still legit
+# Adva work and must stay put. Classifications:
+#
+#   MOVE     catalyst content (repos/{catalyst,catalyst-workspace,catalyst-otel}/…)
+#            sitting in a NON-coalesce-labs thoughts repo — a true misroute.
+#   REVERSE  Adva content (repos/Adva/…) sitting UNDER the coalesce-labs thoughts
+#            repo — the reverse misroute; flagged, not auto-moved (operator call).
+#   LEAVE    everything else: Adva content in the Adva repo, correctly-homed
+#            catalyst content, and anything not under repos/<subdir>/.
+#
+# Read-only on --root. Pairs with migrate-thoughts-pollution.sh, which consumes the
+# MOVE records from this manifest.
+#
+# Usage:
+#   audit-thoughts-pollution.sh --root <thoughts-checkout> [--org <name>]
+#                               [--out <manifest.jsonl>] [--format jsonl|md]
+#
+#   --root    REQUIRED. A thoughts checkout (git working tree).
+#   --org     Org identity of the checkout. Auto-derived from the `origin` git
+#             remote when omitted (groundworkapp normalizes to rightsite-cloud).
+#   --out     Manifest destination (default: stdout).
+#   --format  jsonl (default) — one record per non-LEAVE file; or md — a summary
+#             table. A human-readable summary line always goes to stderr.
+#
+# Exit codes: 0 success · 1 bad/missing --root, undetermined org, or missing dep.
+set -euo pipefail
+
+info() { echo "[audit-thoughts] $*" >&2; }
+fail() { echo "[audit-thoughts] ERROR: $*" >&2; }
+
+usage() { sed -n '2,30p' "$0" >&2; }
+
+# Adva code lives under groundworkapp/ locally but its THOUGHTS repo is
+# rightsite-cloud — mirror provision-thoughts.sh:44 so org identity matches.
+normalize_org() { case "$1" in groundworkapp) echo "rightsite-cloud" ;; *) echo "$1" ;; esac; }
+
+ROOT=""; ORG=""; OUT=""; FORMAT="jsonl"
+while [[ $# -gt 0 ]]; do case "$1" in
+  --root)   ROOT="${2:-}"; shift 2 ;;
+  --org)    ORG="${2:-}"; shift 2 ;;
+  --out)    OUT="${2:-}"; shift 2 ;;
+  --format) FORMAT="${2:-}"; shift 2 ;;
+  -h|--help) usage; exit 0 ;;
+  *) fail "unknown arg: $1"; usage; exit 1 ;;
+esac; done
+
+command -v jq  >/dev/null || { fail "jq required";  exit 1; }
+command -v git >/dev/null || { fail "git required"; exit 1; }
+
+[[ -n "$ROOT" ]]   || { fail "--root is required (a thoughts checkout)"; exit 1; }
+[[ -d "$ROOT" ]]   || { fail "--root does not exist or is not a directory: $ROOT"; exit 1; }
+git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || { fail "--root is not a git working tree: $ROOT"; exit 1; }
+
+# Derive + normalize the org from the origin remote when not given explicitly.
+if [[ -z "$ORG" ]]; then
+  remote="$(git -C "$ROOT" remote get-url origin 2>/dev/null || true)"
+  org_raw="$(sed -nE 's#.*github\.com[:/]([^/]+)/.*#\1#p' <<<"$remote" | head -1)"
+  ORG="$(normalize_org "$org_raw")"
+fi
+[[ -n "$ORG" ]] || { fail "could not determine --org (pass --org or add a github origin remote)"; exit 1; }
+
+# Catalyst thoughts subdirs (research Area 5: path-prefix boundary, NOT keywords).
+is_catalyst_subdir() { case "$1" in catalyst|catalyst-workspace|catalyst-otel) return 0 ;; *) return 1 ;; esac; }
+
+# Classify a single tracked path. Echoes "CLASSIFICATION<TAB>repo<TAB>reason".
+classify() {
+  local path="$1" sub
+  if [[ "$path" == repos/*/* ]]; then
+    sub="${path#repos/}"; sub="${sub%%/*}"
+    if [[ "$ORG" != "coalesce-labs" ]] && is_catalyst_subdir "$sub"; then
+      printf 'MOVE\t%s\tcatalyst content (repos/%s) in non-coalesce-labs thoughts repo %s\n' "$sub" "$sub" "$ORG"
+      return
+    fi
+    if [[ "$ORG" == "coalesce-labs" && "$sub" == "Adva" ]]; then
+      printf 'REVERSE\t%s\tAdva content (repos/Adva) under the coalesce-labs thoughts repo\n' "$sub"
+      return
+    fi
+    printf 'LEAVE\t%s\tcorrectly-homed or non-catalyst content under repos/%s\n' "$sub" "$sub"
+    return
+  fi
+  printf 'LEAVE\t-\tnot under repos/<subdir>/ (shared/global content)\n'
+}
+
+# ── Walk the tracked file set, classify, accumulate records ───────────────────
+RECORDS=""           # JSONL, one record per non-LEAVE file
+move_count=0; reverse_count=0; leave_count=0
+declare -a ID_HITS=()
+
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  IFS=$'\t' read -r cls repo reason < <(classify "$path")
+  case "$cls" in
+    MOVE)    move_count=$((move_count + 1)) ;;
+    REVERSE) reverse_count=$((reverse_count + 1)) ;;
+    *)       leave_count=$((leave_count + 1)); continue ;;  # LEAVE not emitted
+  esac
+  rec="$(jq -nc --arg path "$path" --arg cls "$cls" --arg repo "$repo" \
+               --arg org "$ORG" --arg reason "$reason" \
+               '{path:$path, classification:$cls, repo:$repo, org:$org, reason:$reason}')"
+  RECORDS+="${rec}"$'\n'
+  # Informational only: collect any CTL-/ADV- IDs from the path (NOT used to classify).
+  while IFS= read -r id; do [[ -n "$id" ]] && ID_HITS+=("$id"); done \
+    < <(grep -oE 'CTL-[0-9]+|ADV-[0-9]+' <<<"$path" || true)
+done < <(git -C "$ROOT" ls-files)
+
+# Distinct IDs (informational).
+distinct_ids=""
+if ((${#ID_HITS[@]})); then
+  distinct_ids="$(printf '%s\n' "${ID_HITS[@]}" | sort -u | tr '\n' ' ')"
+fi
+
+# ── Emit ──────────────────────────────────────────────────────────────────────
+emit_jsonl() { printf '%s' "$RECORDS"; }
+emit_md() {
+  printf '# Thoughts pollution manifest — %s\n\n' "$ORG"
+  printf '| classification | count |\n|---|---|\n'
+  printf '| MOVE | %d |\n| REVERSE | %d |\n| LEAVE | %d |\n\n' "$move_count" "$reverse_count" "$leave_count"
+  printf 'Distinct CTL/ADV IDs (informational): %s\n\n' "${distinct_ids:-none}"
+  if [[ -n "$RECORDS" ]]; then
+    printf '| path | classification | repo |\n|---|---|---|\n'
+    while IFS= read -r rec; do
+      [[ -z "$rec" ]] && continue
+      printf '| %s | %s | %s |\n' \
+        "$(jq -r .path <<<"$rec")" "$(jq -r .classification <<<"$rec")" "$(jq -r .repo <<<"$rec")"
+    done <<<"$RECORDS"
+  fi
+}
+
+render() { case "$FORMAT" in
+  jsonl) emit_jsonl ;;
+  md)    emit_md ;;
+  *) fail "unknown --format: $FORMAT (want jsonl|md)"; exit 1 ;;
+esac; }
+
+if [[ -n "$OUT" ]]; then
+  mkdir -p "$(dirname "$OUT")"
+  render > "$OUT"
+  info "manifest written: $OUT"
+else
+  render
+fi
+
+# Summary line (always stderr; "0 true misroutes" is the clean-tree signal).
+if [[ "$move_count" -eq 0 ]]; then
+  info "org=$ORG  MOVE=0 REVERSE=$reverse_count LEAVE=$leave_count — 0 true misroutes"
+else
+  info "org=$ORG  MOVE=$move_count REVERSE=$reverse_count LEAVE=$leave_count — $move_count true misroutes"
+fi
+exit 0

--- a/plugins/dev/scripts/migrate-thoughts-pollution.sh
+++ b/plugins/dev/scripts/migrate-thoughts-pollution.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# migrate-thoughts-pollution.sh — consume a Phase-1 audit manifest and move every
+# MOVE-classified file from a (misrouted) source thoughts checkout into the
+# coalesce-labs thoughts checkout, preserving the repos/<subdir>/… layout.
+# (CTL-1246, §6 of the cluster HLT thoughts-model design, CTL-1214.)
+#
+# Defaults to --dry-run. Pre-checks collisions and aborts BEFORE moving anything if
+# any target exists with differing content. Uses `git mv` for tracked files (plain
+# `mv` for untracked) — when source and target live in the same repo this preserves
+# `git log --follow` history (modeled on plugins/meta/scripts/move-and-rereference.sh
+# :215-286). Idempotent: a record whose source is already drained and whose target
+# is present is a safe no-op, so re-running --execute never duplicates or loses a
+# file. The script stages the moves; committing/pushing is left to the operator.
+#
+# Usage:
+#   migrate-thoughts-pollution.sh --manifest <file.jsonl>
+#                                 --source-root <checkout>
+#                                 --target-root <coalesce-labs checkout>
+#                                 [--dry-run | --execute]
+#
+#   --manifest     REQUIRED. JSONL manifest from audit-thoughts-pollution.sh.
+#   --source-root  REQUIRED. The checkout the MOVE paths are relative to.
+#   --target-root  REQUIRED. The coalesce-labs checkout to move them into.
+#   --dry-run      Default. Print the planned moves, change nothing.
+#   --execute      Perform the moves (after the collision pre-check passes).
+#
+# Exit codes: 0 success / clean no-op · 1 bad args, missing files, or a collision.
+set -euo pipefail
+
+info() { echo "[migrate-thoughts] $*" >&2; }
+fail() { echo "[migrate-thoughts] ERROR: $*" >&2; }
+usage() { sed -n '2,30p' "$0" >&2; }
+
+MANIFEST=""; SOURCE_ROOT=""; TARGET_ROOT=""; MODE="dry-run"
+while [[ $# -gt 0 ]]; do case "$1" in
+  --manifest)    MANIFEST="${2:-}"; shift 2 ;;
+  --source-root) SOURCE_ROOT="${2:-}"; shift 2 ;;
+  --target-root) TARGET_ROOT="${2:-}"; shift 2 ;;
+  --dry-run)     MODE="dry-run"; shift ;;
+  --execute)     MODE="execute"; shift ;;
+  -h|--help)     usage; exit 0 ;;
+  *) fail "unknown arg: $1"; usage; exit 1 ;;
+esac; done
+
+command -v jq  >/dev/null || { fail "jq required";  exit 1; }
+command -v git >/dev/null || { fail "git required"; exit 1; }
+
+[[ -n "$MANIFEST" ]]    || { fail "--manifest is required"; exit 1; }
+[[ -f "$MANIFEST" ]]    || { fail "manifest not found: $MANIFEST"; exit 1; }
+[[ -n "$SOURCE_ROOT" ]] || { fail "--source-root is required"; exit 1; }
+[[ -d "$SOURCE_ROOT" ]] || { fail "--source-root does not exist: $SOURCE_ROOT"; exit 1; }
+[[ -n "$TARGET_ROOT" ]] || { fail "--target-root is required"; exit 1; }
+[[ -d "$TARGET_ROOT" ]] || { fail "--target-root does not exist: $TARGET_ROOT"; exit 1; }
+
+# Absolute roots so `git mv` (which is repo-relative-aware but path-literal) works
+# regardless of the caller's cwd.
+SOURCE_ROOT="$(cd "$SOURCE_ROOT" && pwd)"
+TARGET_ROOT="$(cd "$TARGET_ROOT" && pwd)"
+
+# ── Select the MOVE set from the manifest ─────────────────────────────────────
+declare -a MOVE_PATHS=()
+while IFS= read -r p; do
+  [[ -n "$p" ]] && MOVE_PATHS+=("$p")
+done < <(jq -r 'select(.classification=="MOVE") | .path' "$MANIFEST" 2>/dev/null)
+
+if ((${#MOVE_PATHS[@]} == 0)); then
+  info "nothing to migrate (0 MOVE records in manifest)"
+  exit 0
+fi
+
+# ── Collision pre-check (move-and-rereference.sh:215-286 behavior) ────────────
+# A collision is a target that already exists with DIFFERING content. An identical
+# target is treated as already-migrated (idempotent), not a conflict. Collect ALL
+# conflicts and abort before touching anything.
+declare -a CONFLICTS=()
+for rel in "${MOVE_PATHS[@]}"; do
+  src="$SOURCE_ROOT/$rel"; tgt="$TARGET_ROOT/$rel"
+  if [[ -e "$src" && -e "$tgt" ]] && ! cmp -s "$src" "$tgt"; then
+    CONFLICTS+=("$rel")
+  fi
+done
+if ((${#CONFLICTS[@]})); then
+  fail "collision: ${#CONFLICTS[@]} target path(s) already exist with differing content — aborting, moved nothing:"
+  for c in "${CONFLICTS[@]}"; do echo "  CONFLICT: $c" >&2; done
+  exit 1
+fi
+
+# ── Plan / execute ────────────────────────────────────────────────────────────
+move_one() {
+  local src="$1" tgt="$2"
+  local src_dir tgt_dir src_repo tgt_repo
+  src_dir="$(dirname "$src")"
+  tgt_dir="$(dirname "$tgt")"
+  mkdir -p "$tgt_dir"
+  src_repo="$(git -C "$src_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+  tgt_repo="$(git -C "$tgt_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+
+  if [[ -n "$src_repo" ]] && git -C "$src_repo" ls-files --error-unmatch "$src" >/dev/null 2>&1; then
+    # Tracked source.
+    if [[ -n "$tgt_repo" && "$src_repo" == "$tgt_repo" ]]; then
+      git -C "$src_repo" mv "$src" "$tgt"           # same repo → history preserved
+    else
+      mv "$src" "$tgt"                              # cross-repo: bytes preserved
+      [[ -n "$tgt_repo" ]] && git -C "$tgt_repo" add "$tgt" >/dev/null 2>&1 || true
+      git -C "$src_repo" add -A "$src_dir" >/dev/null 2>&1 || true  # stage deletion
+    fi
+  else
+    # Untracked source → plain mv (stage in the target repo if there is one).
+    mv "$src" "$tgt"
+    [[ -n "$tgt_repo" ]] && git -C "$tgt_repo" add "$tgt" >/dev/null 2>&1 || true
+  fi
+}
+
+planned=0; moved=0; skipped=0
+for rel in "${MOVE_PATHS[@]}"; do
+  src="$SOURCE_ROOT/$rel"; tgt="$TARGET_ROOT/$rel"
+  if [[ ! -e "$src" && -e "$tgt" ]]; then
+    info "skip (already migrated): $rel"
+    skipped=$((skipped + 1)); continue
+  fi
+  if [[ ! -e "$src" && ! -e "$tgt" ]]; then
+    info "skip (source absent, target absent — already migrated or out of scope): $rel"
+    skipped=$((skipped + 1)); continue
+  fi
+  # source exists (target absent, or identical — pre-check cleared differing ones).
+  if [[ -e "$tgt" ]]; then
+    # identical target (cmp passed pre-check): leave both, do not duplicate.
+    info "skip (target already identical): $rel"
+    skipped=$((skipped + 1)); continue
+  fi
+  planned=$((planned + 1))
+  if [[ "$MODE" == "execute" ]]; then
+    move_one "$src" "$tgt"
+    moved=$((moved + 1))
+    info "moved: $rel → target"
+  else
+    info "[dry-run] would git mv: $rel → target"
+  fi
+done
+
+if [[ "$MODE" == "execute" ]]; then
+  info "migrate summary: planned=$planned moved=$moved skipped(idempotent)=$skipped"
+else
+  info "migrate summary (dry-run): would-move=$planned skipped(idempotent)=$skipped — re-run with --execute to apply"
+fi
+exit 0

--- a/plugins/dev/scripts/migrate-thoughts-pollution.sh
+++ b/plugins/dev/scripts/migrate-thoughts-pollution.sh
@@ -68,6 +68,18 @@ if ((${#MOVE_PATHS[@]} == 0)); then
   exit 0
 fi
 
+# Path-traversal guard: manifest paths must be REPO-RELATIVE with no `..` segment
+# and no leading `/`. The audit only ever emits repos/<subdir>/… paths, but the
+# manifest is external input — refuse anything that could escape --source-root /
+# --target-root (which would otherwise mv files outside the checkout). Abort the
+# whole run; never partially move on a poisoned manifest (zero-loss discipline).
+for rel in "${MOVE_PATHS[@]}"; do
+  if [[ "$rel" == /* || "$rel" == ".." || "$rel" == "../"* || "$rel" == *"/../"* || "$rel" == *"/.." ]]; then
+    fail "unsafe manifest path (absolute or contains '..'): $rel — aborting, moved nothing"
+    exit 1
+  fi
+done
+
 # ── Collision pre-check (move-and-rereference.sh:215-286 behavior) ────────────
 # A collision is a target that already exists with DIFFERING content. An identical
 # target is treated as already-migrated (idempotent), not a conflict. Collect ALL

--- a/plugins/dev/scripts/provision-thoughts.sh
+++ b/plugins/dev/scripts/provision-thoughts.sh
@@ -50,7 +50,9 @@ HL_CONFIG="${HL_CONFIG:-$HOME/.config/humanlayer/humanlayer.json}"
 REGISTRY="${CATALYST_REGISTRY:-}"
 ORGS_CSV=""
 DRY_RUN=0; NO_CLONE=0; VERIFY_ONLY=0
-PRIMARY_ORG="coalesce-labs"   # global fallback + defaultProfile target
+PRIMARY_ORG="coalesce-labs"   # global fallback + defaultProfile target (CTL-1246: this clean-config
+                              # invariant — never a groundworkapp global fallback — is locked by
+                              # __tests__/provision-thoughts-invariant.test.sh; keep it coalesce-labs)
 
 while [[ $# -gt 0 ]]; do case "$1" in
   --node-user) NODE_USER="$2"; shift 2 ;;


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-17T14:18:57Z -->
<!-- Last updated: 2026-06-17T14:18:57Z -->
<!-- PR: #2201 -->
<!-- Previous commits: 73c6abb3,dc4357f2,b7f2c640,aa28da36 -->

## Summary

Catalyst thoughts must route to the **coalesce-labs** thoughts repo so cluster
research isn't polluted by misrouted documents (and vice-versa). This PR adds the
tooling to detect and safely correct that pollution, plus a regression guard on
the clean-config invariant.

The reliable discriminator is the `repos/<subdir>/` **path prefix**, never content
keywords — an Adva friction note that mentions a `CTL-` ticket is still legitimate
Adva work and must stay put. Three pieces ship together:

1. A read-only **audit/manifest generator** that classifies every file in a thoughts
   checkout as `MOVE` / `REVERSE` / `LEAVE` and emits a JSONL manifest.
2. A **zero-loss, idempotent migration** that consumes the manifest's `MOVE` records
   and relocates them with `git mv` (history-preserving), defaulting to `--dry-run`.
3. A **clean-config invariant test** locking the `coalesce-labs` global fallback in
   `provision-thoughts.sh` so it can never silently regress to a groundworkapp default.

A **path-traversal security guard** rejects any manifest path that is absolute or
contains a `..` segment before a single file is moved.

## Changes Made

### New: `audit-thoughts-pollution.sh` (Phase 1)

- Classifies thoughts-checkout files by their `repos/<subdir>/` path prefix:
  - `MOVE` — catalyst content (`repos/{catalyst,catalyst-workspace,catalyst-otel}/…`)
    sitting in a **non-coalesce-labs** thoughts repo (a true misroute).
  - `REVERSE` — Adva content (`repos/Adva/…`) sitting **under** coalesce-labs (the
    reverse misroute; flagged for an operator call, not auto-moved).
  - `LEAVE` — everything else (correctly-homed content, anything not under `repos/`).
- Emits one JSONL record per non-`LEAVE` file with the full schema
  `{path, classification, repo, org, reason}`; `--format md` produces a summary table.
- Org identity auto-derives from the `origin` git remote when `--org` is omitted,
  normalizing `groundworkapp → rightsite-cloud` to match `provision-thoughts.sh`.
- Strictly **read-only** on `--root`.

### New: `migrate-thoughts-pollution.sh` (Phase 2)

- Consumes the Phase-1 manifest's `MOVE` records and relocates them.
- **Defaults to `--dry-run`** (prints the planned moves, changes nothing); `--execute`
  applies them.
- **Collision pre-check**: aborts before moving anything if any target already exists
  with differing content (identical content is treated as an already-migrated no-op).
- Uses `git mv` for tracked files (history preserved; `git log --follow` resolves the
  rename) and plain `mv` for untracked files.
- **Zero-loss + idempotent**: re-running `--execute` after a drained source is a clean
  no-op — never duplicates or loses a file.

### Security: path-traversal guard on the migration manifest

- Manifest paths must be repo-relative with no `..` segment. Absolute paths or any
  `..` (`..`, `../x`, `x/../y`, `x/..`) are rejected up front — the migration aborts
  and moves nothing.

### Regression guard: `provision-thoughts.sh` clean-config invariant (Phase 3)

- `PRIMARY_ORG` (global fallback + defaultProfile target) is documented and locked to
  `coalesce-labs` — never a groundworkapp global fallback — enforced by a new test.

### Tests (hermetic, no network)

- `__tests__/audit-thoughts-pollution.test.sh` — path-prefix classification, JSONL
  schema, read-only invariant, auto org-derivation, error handling.
- `__tests__/migrate-thoughts-pollution.test.sh` — audit→migrate integration, dry-run
  vs execute, zero-loss, history preservation, idempotency, collision pre-check,
  untracked-file handling.
- `__tests__/provision-thoughts-invariant.test.sh` — locks the `coalesce-labs`
  clean-config invariant.

## How to Verify It

- [x] Audit suite passes: `bash plugins/dev/scripts/__tests__/audit-thoughts-pollution.test.sh` ✅ (21 passed, 0 failed)
- [x] Migrate suite passes: `bash plugins/dev/scripts/__tests__/migrate-thoughts-pollution.test.sh` ✅ (32 passed, 0 failed)
- [x] Invariant suite passes: `bash plugins/dev/scripts/__tests__/provision-thoughts-invariant.test.sh` ✅ (8 passed, 0 failed)

## Changelog Entry

- Add path-prefix thoughts-pollution audit/manifest generator and a zero-loss,
  idempotent migration (with a path-traversal guard), plus a regression test locking
  the `coalesce-labs` clean-config invariant in `provision-thoughts.sh`.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1246

Refs: CTL-1246
