### PR TITLE
fix(dev): cluster-heartbeat publish actually works + newest-wins liveness merge (CTL-1255)

### DIFF
--- a/plugins/dev/scripts/execution-core/cluster-heartbeat.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat.mjs
@@ -52,13 +52,21 @@ async function defaultPost(query, variables) {
 
 // ─── identifier → issue UUID ─────────────────────────────────────────────────
 
+// CTL-1255: resolve via the `issue(id:)` query, which accepts the human
+// identifier ("CTL-1217") directly and returns the UUID. The previous
+// `issues(filter:{identifier:{eq}})` form was a hard 400 — IssueFilter has no
+// `identifier` field ("Field identifier is not defined by type IssueFilter") —
+// so resolveIssueId ALWAYS returned null and every publish aborted with "no
+// issue found". This is why cross-host liveness never published (CTL-1251).
+// READ_ATTACHMENTS_QUERY below already uses `issue(id:)`, which is why reads
+// worked while writes silently failed.
 const RESOLVE_ISSUE_QUERY = `query ResolveIssueId($id: String!) {
-  issues(filter: { identifier: { eq: $id } }) { nodes { id } }
+  issue(id: $id) { id }
 }`;
 
 export async function resolveIssueId(ticket, { post = defaultPost } = {}) {
   const data = await post(RESOLVE_ISSUE_QUERY, { id: ticket });
-  return data?.issues?.nodes?.[0]?.id ?? null;
+  return data?.issue?.id ?? null;
 }
 
 // ─── read ────────────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat.test.mjs
@@ -65,7 +65,7 @@ describe("publishHeartbeat", () => {
     const calls = [];
     const post = async (q, v) => {
       calls.push({ q, v });
-      if (q.includes("ResolveIssue")) return { issues: { nodes: [{ id: "uuid-anchor" }] } };
+      if (q.includes("ResolveIssue")) return { issue: { id: "uuid-anchor" } };
       return { attachmentCreate: { success: true, attachment: { id: "a1" } } };
     };
     const rec = await publishHeartbeat(
@@ -81,15 +81,36 @@ describe("publishHeartbeat", () => {
   });
 
   test("throws when the anchor issue cannot be resolved", async () => {
-    const post = async () => ({ issues: { nodes: [] } });
+    const post = async () => ({ issue: null });
     await expect(
       publishHeartbeat({ anchorIssue: "CTL-9999", host: "mini" }, { post }),
     ).rejects.toThrow(/no issue found/);
   });
 
+  // CTL-1255 regression guard: the resolve query MUST use issue(id:) — the human
+  // identifier accessor Linear accepts — not issues(filter:{identifier}), which is
+  // a hard 400 (IssueFilter has no identifier field). The old fakes returned the
+  // wrong {issues:{nodes}} shape and so masked the live failure for the whole
+  // CTL-1090 → CTL-1251 window.
+  test("resolve query targets issue(id:) and reads issue.id (not issues.nodes)", async () => {
+    let resolveQ = "";
+    const post = async (q) => {
+      if (q.includes("issue(id:") && !q.includes("attachmentCreate")) {
+        resolveQ = q;
+        return { issue: { id: "uuid-anchor" } };
+      }
+      // a fake that ONLY answers the issue(id:) shape — if the code still used
+      // issues(filter:), issueId would be null and this would throw "no issue found"
+      return { attachmentCreate: { success: true, attachment: {} } };
+    };
+    await publishHeartbeat({ anchorIssue: "CTL-9999", host: "mini" }, { post });
+    expect(resolveQ).toContain("issue(id: $id)");
+    expect(resolveQ).not.toContain("identifier");
+  });
+
   test("throws when attachmentCreate returns success:false", async () => {
     const post = async (q) => {
-      if (q.includes("ResolveIssue")) return { issues: { nodes: [{ id: "uuid-x" }] } };
+      if (q.includes("ResolveIssue")) return { issue: { id: "uuid-x" } };
       return { attachmentCreate: { success: false } };
     };
     await expect(
@@ -99,7 +120,7 @@ describe("publishHeartbeat", () => {
 
   test("defaults inFlightTickets to [] when omitted", async () => {
     const post = async (q) => {
-      if (q.includes("ResolveIssue")) return { issues: { nodes: [{ id: "uuid-x" }] } };
+      if (q.includes("ResolveIssue")) return { issue: { id: "uuid-x" } };
       return { attachmentCreate: { success: true, attachment: {} } };
     };
     const rec = await publishHeartbeat(
@@ -160,7 +181,7 @@ describe("readPeerHeartbeats", () => {
 describe("runCli", () => {
   test("publish: prints one JSON line and exits 0", async () => {
     const post = async (q) => {
-      if (q.includes("ResolveIssue")) return { issues: { nodes: [{ id: "uuid-x" }] } };
+      if (q.includes("ResolveIssue")) return { issue: { id: "uuid-x" } };
       return { attachmentCreate: { success: true, attachment: {} } };
     };
     const { code, out } = await captureStdout(() =>
@@ -178,7 +199,7 @@ describe("runCli", () => {
 
   test("publish: empty ticketsCsv passes empty in_flight_tickets", async () => {
     const post = async (q) => {
-      if (q.includes("ResolveIssue")) return { issues: { nodes: [{ id: "uuid-x" }] } };
+      if (q.includes("ResolveIssue")) return { issue: { id: "uuid-x" } };
       return { attachmentCreate: { success: true, attachment: {} } };
     };
     const { code, out } = await captureStdout(() =>

--- a/plugins/dev/scripts/orch-monitor/lib/node-liveness.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/node-liveness.d.mts
@@ -36,3 +36,8 @@ export function overlayClusterLiveness(
   lastSeenByHost: Record<string, string>,
   opts?: { now?: number } & LivenessThresholds,
 ): ClusterNodeLiveness[];
+
+/** CTL-1255: merge { host: lastSeenISO } maps keeping the newer timestamp per host. */
+export function mergeHeartbeatsNewestWins(
+  ...maps: Array<Record<string, string> | null | undefined>
+): Record<string, string>;

--- a/plugins/dev/scripts/orch-monitor/lib/node-liveness.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/node-liveness.mjs
@@ -62,6 +62,42 @@ export function classifyHostLiveness(
 }
 
 /**
+ * mergeHeartbeatsNewestWins — merge any number of { host: lastSeenISO } maps,
+ * keeping the NEWER timestamp per host (CTL-1255). The monitor folds the
+ * cross-host LIVENESS ANCHOR heartbeats (coarse ~2-min cadence) over the LOCAL
+ * event-log heartbeats (~30s). A plain spread ({...local, ...anchor}) let the
+ * anchor's older timestamp CLOBBER the fresher local heartbeat for the self
+ * host, so a live local node displayed "degraded". Newest-wins fixes that while
+ * still surfacing peers that exist only in the anchor. An unparseable timestamp
+ * loses to any parseable one; never throws.
+ *
+ * @param {...Record<string, string>} maps
+ * @returns {Record<string, string>}
+ */
+export function mergeHeartbeatsNewestWins(...maps) {
+  const out = {};
+  for (const m of maps) {
+    if (!m || typeof m !== "object") continue;
+    for (const [host, ts] of Object.entries(m)) {
+      if (typeof ts !== "string" || ts.length === 0) continue;
+      const prev = out[host];
+      if (prev === undefined) {
+        out[host] = ts;
+        continue;
+      }
+      const prevMs = Date.parse(prev);
+      const tsMs = Date.parse(ts);
+      if (!Number.isFinite(prevMs)) {
+        out[host] = ts; // any later value beats an unparseable earlier one
+      } else if (Number.isFinite(tsMs) && tsMs > prevMs) {
+        out[host] = ts;
+      }
+    }
+  }
+  return out;
+}
+
+/**
  * overlayClusterLiveness — overlay liveness across an entire roster. Returns one
  * node entry per roster host (stable roster order), carrying its status and the
  * lastSeen timestamp the overlay classified (null when the host was never heard).

--- a/plugins/dev/scripts/orch-monitor/lib/node-liveness.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/node-liveness.test.mjs
@@ -1,0 +1,31 @@
+
+import { mergeHeartbeatsNewestWins } from "./node-liveness.mjs";
+
+describe("mergeHeartbeatsNewestWins (CTL-1255)", () => {
+  test("self host keeps the FRESHER local timestamp over a stale anchor one", () => {
+    const local = { mini: "2026-06-13T00:01:00Z" };  // fresh local log
+    const anchor = { mini: "2026-06-13T00:00:00Z" };  // older anchor publish
+    expect(mergeHeartbeatsNewestWins(local, anchor).mini).toBe("2026-06-13T00:01:00Z");
+  });
+
+  test("anchor wins when it is newer than local", () => {
+    const local = { mini: "2026-06-13T00:00:00Z" };
+    const anchor = { mini: "2026-06-13T00:05:00Z" };
+    expect(mergeHeartbeatsNewestWins(local, anchor).mini).toBe("2026-06-13T00:05:00Z");
+  });
+
+  test("peer present only in the anchor is surfaced", () => {
+    const out = mergeHeartbeatsNewestWins({ mini: "2026-06-13T00:00:00Z" }, { "mini-2": "2026-06-13T00:00:05Z" });
+    expect(Object.keys(out).sort()).toEqual(["mini", "mini-2"]);
+  });
+
+  test("ignores empty / non-string timestamps and bad maps", () => {
+    const out = mergeHeartbeatsNewestWins({ a: "" }, null, { b: 42 }, { c: "2026-06-13T00:00:00Z" });
+    expect(out).toEqual({ c: "2026-06-13T00:00:00Z" });
+  });
+
+  test("a parseable timestamp beats an unparseable earlier one", () => {
+    const out = mergeHeartbeatsNewestWins({ x: "not-a-date" }, { x: "2026-06-13T00:00:00Z" });
+    expect(out.x).toBe("2026-06-13T00:00:00Z");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/node-liveness.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/node-liveness.test.mjs
@@ -1,4 +1,8 @@
+// node-liveness.test.mjs — CTL-1255. mergeHeartbeatsNewestWins coverage.
+//
+// Run: cd plugins/dev/scripts/orch-monitor && bun test lib/node-liveness.test.mjs
 
+import { describe, test, expect } from "bun:test";
 import { mergeHeartbeatsNewestWins } from "./node-liveness.mjs";
 
 describe("mergeHeartbeatsNewestWins (CTL-1255)", () => {

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -27,6 +27,7 @@ import type { NavSignal, DaemonHealth } from "./lib/nav-signal.mjs";
 // is an exact identity no-op (one node — the local daemon).
 import { createClusterEntity } from "./lib/cluster-view.mjs";
 import type { ClusterView } from "./lib/cluster-view.mjs";
+import { mergeHeartbeatsNewestWins } from "./lib/node-liveness.mjs";
 import { deriveClusterSignal } from "./lib/cluster-signal.mjs";
 import type { ClusterSignal } from "./lib/cluster-signal.mjs";
 // CTL-886 (BFF4): run→worker identity — surface every phase-*.json signal as a
@@ -1380,7 +1381,10 @@ export function createServer(opts: CreateServerOptions): BunServer {
       } catch {
         /* fail-open: anchor cache alone still drives the overlay */
       }
-      return { ...local, ...anchorHeartbeatCache.map };
+      // CTL-1255: newest-wins, NOT anchor-clobbers-local — the anchor's coarse
+      // ~2-min cadence must not make a live self-host (fresh ~30s local log)
+      // display as degraded.
+      return mergeHeartbeatsNewestWins(local, anchorHeartbeatCache.map);
     },
   });
   const readClusterView = async (board: BoardPayload): Promise<ClusterView> => {


### PR DESCRIPTION
## Summary
Follow-up to CTL-1251, found during its **live validation**: cross-host liveness never published because the publish path had a hard Linear GraphQL bug.

### 1. Resolve query was a guaranteed 400 (the real root cause)
\`cluster-heartbeat.mjs\` resolved the anchor via \`issues(filter:{identifier:{eq:\$id}})\` — but \`IssueFilter\` has **no \`identifier\` field**, so Linear returned HTTP 400 every time → \`resolveIssueId\` always \`null\` → **every publish aborted with "no issue found."** This is why heartbeats never reached the anchor across the whole CTL-1090 → CTL-1251 window. Fixed to \`issue(id: $id){id}\` (the human-identifier accessor Linear accepts — the *read* query already used it, which is why reads worked while writes silently failed). **Verified live: corrected resolve + attachmentCreate return 200.**

### 2. Tests masked the bug
The existing fakes returned the wrong \`{issues:{nodes}}\` shape, so they passed against broken code. Updated to \`{issue:{id}}\` + added a regression guard asserting the query targets \`issue(id:)\` and never \`identifier\`.

### 3. Merge mis-ordering (CTL-1251 follow-up)
The monitor merged anchor over local via spread, so the anchor's coarse ~2-min cadence **clobbered** the fresher ~30s local heartbeat and the self-host displayed \`degraded\`. New \`mergeHeartbeatsNewestWins\` (pure, in node-liveness.mjs, 5 tests) keeps the newer timestamp per host.

> The "missing attachment title" I flagged mid-investigation was a **false alarm** from a hand-written probe — main already has the title. No change there.

## Validation
- \`cluster-heartbeat\` 16/16 (incl. new resolve-shape guard), \`node-liveness\`+\`cluster-view\`+contract suites 31/31 (incl. 5 merge tests). tsc clean.
- **Live (pre-fix):** \`/api/cluster\` showed both nodes once heartbeats were on the anchor (proving CTL-1251's dashboard aggregation). This PR makes the daemon's *own* publish path reach the anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)