### PR TITLE
fix(dev): surface recovery-pass/remediate explanation in inbox row + detail card

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/board-pr-stuck.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-pr-stuck.test.ts
@@ -52,7 +52,10 @@ describe("CTL-1158: assembleBoard wiring — PR-stuck attention signal", () => {
   });
 
   test("humanQuestion falls back to prReason when no phase-signal CTA", () => {
-    expect(boardDataSrc).toContain("deriveHumanQuestion(phaseSigs) ?? prReason");
+    // CTL-1239: the scan array is now explSigs (canonical PHASE_ORDER signals +
+    // ancillary remediate/recovery-pass), so recovery-pass CTAs surface. The
+    // prReason fallback is unchanged.
+    expect(boardDataSrc).toContain("deriveHumanQuestion(explSigs) ?? prReason");
   });
 
   test("ticket object carries mergeStateStatus from prStatus", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-recovery-pass-explanation.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-recovery-pass-explanation.test.ts
@@ -1,0 +1,141 @@
+// board-recovery-pass-explanation.test.ts — CTL-1239: the recovery-pass /
+// remediate explanation must surface in the inbox row (deriveHumanQuestion),
+// the escalation_type passthrough (deriveEscalationType), and the detail card
+// (deriveExplanation).
+//
+// The bug: the explanation derivers were fed the PHASE_ORDER-aligned `phaseSigs`
+// array only. recovery-pass and remediate are NOT in PHASE_ORDER, so a ticket
+// whose ONLY structured explanation lived in phase-recovery-pass.json surfaced a
+// bare "Respond" with no message. The fix assembles an explanation-scan array
+// (canonical PHASE_ORDER signals first, then ancillary remediate, then
+// recovery-pass LAST so it wins the newest-first scan) via explanationScan().
+//
+//   cd plugins/dev/scripts/orch-monitor && bun test __tests__/board-recovery-pass-explanation.test.ts
+
+import { describe, it, expect } from "bun:test";
+import {
+  explanationScan,
+  deriveHumanQuestion,
+  deriveEscalationType,
+  deriveExplanation,
+  PHASE_ORDER,
+  ANCILLARY_EXPLANATION_PHASES,
+  REMEDIATE_PHASE,
+  RECOVERY_PASS_PHASE,
+} from "../lib/board-data.mjs";
+
+// A fully-empty PHASE_ORDER-aligned signal array (no canonical phase wrote a
+// structured explanation) — the recovery-pass-only escalation case.
+const emptyCanonical = () => PHASE_ORDER.map(() => null);
+
+// A recovery-pass escalation signal as recovery-emit writes it: status
+// needs-human + a rich structured explanation.
+const recoveryPassSig = {
+  status: "needs-human",
+  needsHumanSince: "2026-06-17T10:00:00.000Z",
+  updatedAt: "2026-06-17T10:00:00.000Z",
+  explanation: {
+    escalation_type: "decision",
+    problem: "CTL-9 has been stuck at implement for 90 minutes with no commits",
+    call_to_action: "Re-dispatch implement on a clean checkout, or abandon and re-scope?",
+    options: [
+      { label: "re-dispatch", tradeoff: "may re-hit the same wedge" },
+      { label: "abandon", tradeoff: "loses partial progress" },
+    ],
+  },
+};
+
+const remediateSig = {
+  status: "needs-human",
+  updatedAt: "2026-06-17T09:00:00.000Z",
+  explanation: {
+    escalation_type: "authorization",
+    problem: "remediate cap reached after 3 verify cycles",
+    call_to_action: "Authorize the known fix despite the blast-radius risk?",
+  },
+};
+
+describe("CTL-1239: ANCILLARY_EXPLANATION_PHASES ordering", () => {
+  it("is [remediate, recovery-pass] so recovery-pass is the newest scanned", () => {
+    expect(ANCILLARY_EXPLANATION_PHASES).toEqual([REMEDIATE_PHASE, RECOVERY_PASS_PHASE]);
+    expect(REMEDIATE_PHASE).toBe("remediate");
+    expect(RECOVERY_PASS_PHASE).toBe("recovery-pass");
+  });
+
+  it("does NOT mutate PHASE_ORDER (ancillary phases stay out of the pipeline order)", () => {
+    expect(PHASE_ORDER).not.toContain("recovery-pass");
+    expect(PHASE_ORDER).not.toContain("remediate");
+  });
+});
+
+describe("CTL-1239: recovery-pass-only explanation surfaces in all three consumers", () => {
+  // ancillarySigs in run order: [remediateSig=null, recoveryPassSig].
+  const scan = explanationScan(emptyCanonical(), [null, recoveryPassSig]);
+
+  it("deriveHumanQuestion surfaces the recovery-pass call_to_action (was null — the regression)", () => {
+    expect(deriveHumanQuestion(scan)).toBe(recoveryPassSig.explanation.call_to_action);
+    // Regression proof: the PHASE_ORDER-aligned array alone returns null.
+    expect(deriveHumanQuestion(emptyCanonical())).toBeNull();
+  });
+
+  it("deriveEscalationType surfaces the recovery-pass escalation_type", () => {
+    expect(deriveEscalationType(scan)).toBe("decision");
+    expect(deriveEscalationType(emptyCanonical())).toBeNull();
+  });
+
+  it("deriveExplanation surfaces the recovery-pass detail-card fields", () => {
+    const expl = deriveExplanation(scan);
+    expect(expl).not.toBeNull();
+    expect(expl?.call_to_action).toBe(recoveryPassSig.explanation.call_to_action);
+    expect(expl?.problem).toBe(recoveryPassSig.explanation.problem);
+    expect(deriveExplanation(emptyCanonical())).toBeNull();
+  });
+});
+
+describe("CTL-1239: remediate-only explanation surfaces too", () => {
+  const scan = explanationScan(emptyCanonical(), [remediateSig, null]);
+
+  it("deriveHumanQuestion surfaces the remediate call_to_action", () => {
+    expect(deriveHumanQuestion(scan)).toBe(remediateSig.explanation.call_to_action);
+  });
+
+  it("deriveEscalationType surfaces the remediate escalation_type", () => {
+    expect(deriveEscalationType(scan)).toBe("authorization");
+  });
+});
+
+describe("CTL-1239: recovery-pass wins over an earlier canonical-phase explanation", () => {
+  // A failed verify phase wrote an explanation; recovery-pass ran AFTER it.
+  const canonical = emptyCanonical();
+  canonical[PHASE_ORDER.indexOf("verify")] = {
+    status: "failed",
+    explanation: {
+      escalation_type: "manual",
+      call_to_action: "an OLDER question from verify",
+    },
+  } as never;
+  const scan = explanationScan(canonical, [null, recoveryPassSig]);
+
+  it("recovery-pass (newest) wins the newest-first scan", () => {
+    expect(deriveHumanQuestion(scan)).toBe(recoveryPassSig.explanation.call_to_action);
+    expect(deriveEscalationType(scan)).toBe("decision");
+  });
+});
+
+describe("CTL-1239: fail-open on missing/corrupt ancillary signals", () => {
+  it("a fully-empty ancillary set does not throw and yields null derivers", () => {
+    const scan = explanationScan(emptyCanonical(), [null, null]);
+    expect(deriveHumanQuestion(scan)).toBeNull();
+    expect(deriveEscalationType(scan)).toBeNull();
+    expect(deriveExplanation(scan)).toBeNull();
+  });
+
+  it("a non-object ancillary entry (corrupt parse fallback) is skipped, not thrown", () => {
+    const scan = explanationScan(emptyCanonical(), [null, recoveryPassSig]);
+    // splice in a junk entry to mimic a corrupt readJSON result mixed in
+    const junky = [...scan, "not-an-object" as never, 42 as never];
+    expect(() => deriveHumanQuestion(junky)).not.toThrow();
+    // recovery-pass still wins (the junk entries carry no explanation.call_to_action)
+    expect(deriveHumanQuestion(junky)).toBe(recoveryPassSig.explanation.call_to_action);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -270,6 +270,18 @@ export const PHASE_ORDER: string[];
  *  verify), but a real phase-agent type. Used by derivePhaseWithRemediate to
  *  unify ticket.phase with the worker/queue's phase-agent-type value. */
 export const REMEDIATE_PHASE: string;
+/** CTL-1239: the ancillary recovery-pass phase — not in PHASE_ORDER (runs LAST
+ *  when the recovery sweep escalates a stuck ticket). Its signal carries the rich
+ *  structured escalation explanation surfaced by the explanation derivers. */
+export const RECOVERY_PASS_PHASE: string;
+/** CTL-1239: ancillary phase signals appended (in run order: remediate, then
+ *  recovery-pass) to the explanation-derivation scan AFTER the PHASE_ORDER-aligned
+ *  canonical signals, so the newest-first scan reads recovery-pass first. */
+export const ANCILLARY_EXPLANATION_PHASES: string[];
+/** CTL-1239: assemble the explanation-derivation scan array (canonical
+ *  PHASE_ORDER-aligned signals first, then ancillary signals as the newest
+ *  entries). Feeds ONLY the explanation derivers — never activePhase/phase-stage. */
+export function explanationScan(phaseSigs: unknown[], ancillarySigs: unknown[]): unknown[];
 export const PHASE_TO_LINEAR: Record<string, string>;
 export const TERMINAL: Set<string>;
 /** CTL-928: the `claude --bg` job-lifecycle terminal `state` values (distinct from
@@ -314,6 +326,17 @@ export function deriveAttention(opts?: {
 /** CTL-1180: scan phaseSigs newest-first for the first signal with an
  *  explanation.escalation_type string. Returns it or null. */
 export function deriveEscalationType(phaseSigs: unknown[]): string | null;
+
+/** CTL-1130: scan phaseSigs newest-first for the first signal whose explanation
+ *  carries a call_to_action string (the inbox row sub-label). null when none. */
+export function deriveHumanQuestion(phaseSigs: unknown[]): string | null;
+
+/** CTL-1110: scan phaseSigs newest-first for the first signal whose explanation
+ *  carries at least one of the extended render fields; returns the projected
+ *  object (absent fields → null) or null when no signal carries any. */
+export function deriveExplanation(
+  phaseSigs: unknown[]
+): Record<string, string | null> | null;
 
 /** CTL-1158: returns true when the PR has been in a real-blocker merge state
  *  (DIRTY/BLOCKED/UNSTABLE) for ≥ 300 s, anchored to prPhaseStartedAt. */

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -84,6 +84,19 @@ export const PHASE_ORDER = [
 // use it to override ticket.phase when remediate is the most-recently-active
 // phase — so the board column and the queue agree on the ticket's current agent type.
 export const REMEDIATE_PHASE = "remediate";
+// CTL-1239: the ancillary recovery-pass phase. Like remediate, it is NOT in
+// PHASE_ORDER — it runs LAST (after every canonical phase) when the recovery
+// sweep escalates a stuck ticket. Its phase-recovery-pass.json carries the RICH
+// structured explanation (escalation_type / problem / call_to_action / options)
+// that must surface in the inbox row + detail card. The explanation derivers scan
+// a separate, ordered array (see ANCILLARY_EXPLANATION_PHASES + the explanation
+// scan assembled in readTicketArtifacts) so this signal is read newest-first.
+export const RECOVERY_PASS_PHASE = "recovery-pass";
+// CTL-1239: ancillary phase signals appended to the explanation scan AFTER the
+// PHASE_ORDER-aligned canonical signals, in run order (remediate cycles with
+// verify; recovery-pass runs last). The explanation derivers iterate newest-first
+// (i = len-1 → 0), so recovery-pass — the last entry — wins the scan.
+export const ANCILLARY_EXPLANATION_PHASES = [REMEDIATE_PHASE, RECOVERY_PASS_PHASE];
 // Single source of truth for which phase statuses are terminal (no longer
 // running). Exported so the UI's PhaseStrip terminal-status list can be guarded
 // against drift (board-phase-drift.test.ts) instead of carrying a silent
@@ -1339,17 +1352,41 @@ async function maxParallel() {
   return pick(l2) ?? pick(l1) ?? 6;
 }
 
+// CTL-1239: assemble the explanation-derivation scan array — the PHASE_ORDER-
+// aligned canonical signals FIRST, then the ancillary phase signals (remediate,
+// then recovery-pass) appended as the NEWEST entries. The explanation derivers
+// (deriveHumanQuestion / deriveEscalationType / deriveExplanation) iterate
+// newest-first, so recovery-pass — the last appended — wins. PHASE_ORDER itself
+// is unchanged: this array feeds ONLY the explanation scan, never activePhase /
+// phase-stage rendering. Fail-open: a missing/corrupt ancillary signal is a
+// null/falsey entry the derivers already skip (`if (!sig) continue`).
+export function explanationScan(phaseSigs, ancillarySigs) {
+  return [...phaseSigs, ...ancillarySigs];
+}
+
 // Read a ticket's worker-dir artifacts once (phase signals + triage + PR signals).
 // CTL-972: also reads phase-remediate.json separately (it is NOT in PHASE_ORDER,
 // so derivePhaseWithRemediate overlays it on top of the PHASE_ORDER-based result).
+// CTL-1239: also reads the ancillary phase signals (remediate + recovery-pass) for
+// the explanation scan — recovery-pass authors the rich escalation explanation but
+// is not in PHASE_ORDER, so the PHASE_ORDER-aligned phaseSigs scan never saw it.
 async function readTicketArtifacts(id) {
   const dir = join(WORKERS_DIR, id);
   if (!(await exists(dir))) {
-    return { phaseSigs: [], remediateSig: null, triage: null, prSigs: [], needsHumanMarker: false };
+    return {
+      phaseSigs: [],
+      remediateSig: null,
+      ancillarySigs: [],
+      triage: null,
+      prSigs: [],
+      needsHumanMarker: false,
+    };
   }
-  const [phaseSigs, remediateSig, triage, prSigs, needsHumanMarker] = await Promise.all([
+  const [phaseSigs, ancillarySigs, triage, prSigs, needsHumanMarker] = await Promise.all([
     Promise.all(PHASE_ORDER.map((p) => readJSON(join(dir, `phase-${p}.json`)))),
-    readJSON(join(dir, `phase-${REMEDIATE_PHASE}.json`)),
+    // CTL-1239: ancillary signals in run order (remediate, recovery-pass). Each
+    // fail-opens to null via readJSON on a missing/corrupt file.
+    Promise.all(ANCILLARY_EXPLANATION_PHASES.map((p) => readJSON(join(dir, `phase-${p}.json`)))),
     readJSON(join(dir, "triage.json")),
     Promise.all(
       ["phase-pr.json", "phase-monitor-merge.json", "phase-monitor-deploy.json"].map((f) =>
@@ -1361,7 +1398,11 @@ async function readTicketArtifacts(id) {
     // fallback so the board lights up immediately without waiting on the webhook.
     exists(join(dir, ".linear-label-needs-human.applied")),
   ]);
-  return { phaseSigs, remediateSig, triage, prSigs, needsHumanMarker };
+  // The remediate signal stays a standalone field for derivePhaseWithRemediate
+  // (CTL-972 phase overlay); it is ALSO included in ancillarySigs for the
+  // explanation scan. ANCILLARY_EXPLANATION_PHASES[0] === REMEDIATE_PHASE.
+  const remediateSig = ancillarySigs[0] ?? null;
+  return { phaseSigs, remediateSig, ancillarySigs, triage, prSigs, needsHumanMarker };
 }
 
 // CTL-922 (BFF10): read a single worker's own phase signal, positioned into a
@@ -1636,8 +1677,15 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
 
   let tickets = await Promise.all(
     [...cardTicketIds].map(async (id) => {
-      const { phaseSigs, remediateSig, triage, prSigs, needsHumanMarker } =
+      const { phaseSigs, remediateSig, ancillarySigs, triage, prSigs, needsHumanMarker } =
         await readTicketArtifacts(id);
+      // CTL-1239: the explanation-derivation scan = canonical PHASE_ORDER signals
+      // FIRST, then ancillary signals (remediate, then recovery-pass) appended as
+      // the newest entries. The explanation derivers iterate newest-first, so
+      // recovery-pass's rich escalation explanation (which is NOT in PHASE_ORDER)
+      // wins. Used ONLY by the three explanation consumers below — NOT by
+      // activePhase / phase-stage logic, which keeps the PHASE_ORDER-aligned phaseSigs.
+      const explSigs = explanationScan(phaseSigs, ancillarySigs);
       // CTL-972: use derivePhaseWithRemediate so ticket.phase matches the
       // phase-AGENT TYPE the queue/worker surfaces (incl. 'remediate').
       const cur = derivePhaseWithRemediate(phaseSigs, remediateSig);
@@ -1656,6 +1704,13 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
       const phaseFailed =
         cur.phase !== PIPELINE_DONE_PHASE &&
         phaseSigs.some((s) => TERMINAL_FAILURE.has(s?.status));
+      // CTL-1180 / CTL-1239: the escalation_type passthrough for the reading pane.
+      // Scan the FULL explanation array (incl. recovery-pass + remediate) so a
+      // recovery-pass escalation — which lands needs-human via the marker/label,
+      // NOT a failed canonical phase — still carries its escalation_type. Only the
+      // needs-human attention branch surfaces it (deriveAttention), so it is safe
+      // to derive unconditionally here.
+      const escalationType = deriveEscalationType(explSigs);
       const failedEscalationType = phaseFailed ? deriveEscalationType(phaseSigs) : null;
       // CTL-729: the single needs-attention bucket (waiting-on-you ∪ needs-human),
       // merging the live worker's blocked-bg-job flag, the needs-human/needs-input
@@ -1671,7 +1726,10 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
         prStuck,
         prStuckSince: prPhaseStartedAt,
         phaseFailed,
-        escalationType: failedEscalationType,
+        // CTL-1239: prefer the full-scan escalation_type (covers recovery-pass /
+        // remediate) and fall back to the failed-phase value. deriveAttention only
+        // surfaces this in the needs-human branch, so it stays null elsewhere.
+        escalationType: escalationType ?? failedEscalationType,
       });
       return {
         id,
@@ -1728,10 +1786,13 @@ export async function assembleBoard({ getPrStatus = null } = {}) {
         // CTL-1130: call_to_action from the most-recent phase signal's explanation,
         // surfaced as the inbox sub-label for needs-human rows. CTL-1158: fall back
         // to the PR-stuck reason so the inbox sub-label names WHY (research F12).
-        humanQuestion: deriveHumanQuestion(phaseSigs) ?? prReason,
+        // CTL-1239: scan explSigs (canonical + ancillary) so a recovery-pass
+        // call_to_action surfaces (it is not in PHASE_ORDER).
+        humanQuestion: deriveHumanQuestion(explSigs) ?? prReason,
         // CTL-1110: the six extended explanation fields surfaced for the detail
         // pane's CTA-led card (distinct from humanQuestion, the list-row sub-label).
-        explanation: deriveExplanation(phaseSigs),
+        // CTL-1239: same explSigs scan so the recovery-pass explanation card renders.
+        explanation: deriveExplanation(explSigs),
         // CTL-729: the single needs-attention bucket — 'waiting-on-you' (live
         // blocked bg job) | 'needs-human' (escalation label/marker) | null, with an
         // ISO attentionSince anchor (or null, never fabricated). Drives the ONE


### PR DESCRIPTION
## Problem

Recovery-pass escalations author a rich explanation (`escalation_type` / `problem` / `call_to_action` / `options`) into `phase-recovery-pass.json` via recovery-emit, but it never surfaced in the monitor inbox row or the detail "WHAT'S NEEDED NOW" card — SLI-17/OTL-13 showed a bare "Respond" with no message.

## Root cause

`deriveHumanQuestion`, `deriveEscalationType`, and `deriveExplanation` (the detail-card `EXPLANATION_RENDER_FIELDS` reader) all scan `phaseSigs` — an array built **PHASE_ORDER-aligned**. The ancillary phases `recovery-pass` and `remediate` are **not in PHASE_ORDER**, so their signals were never read by the explanation scan. recovery-emit writes the correct shape; the reader simply never opened that signal.

## Fix (`orch-monitor/lib/board-data.mjs`)

- `readTicketArtifacts` now also reads the ancillary phase signals (`phase-remediate.json`, `phase-recovery-pass.json`) via the new `ANCILLARY_EXPLANATION_PHASES` list, fail-open per signal.
- New `explanationScan(phaseSigs, ancillarySigs)` assembles the explanation-derivation array: canonical PHASE_ORDER signals **first**, then remediate, then recovery-pass **last (newest)**. The derivers iterate newest-first, so recovery-pass (which runs after every canonical phase) wins.
- All three explanation consumers now scan `explSigs`: `deriveHumanQuestion` (inbox row CTA), `deriveEscalationType` (escalation_type passthrough — decoupled from the `phaseFailed` gate so a recovery-pass escalation, which lands needs-human via marker/label rather than a failed canonical phase, still carries its type), and `deriveExplanation` (detail CTA-led card).
- **PHASE_ORDER is unchanged** — activePhase / phase-stage rendering still uses the PHASE_ORDER-aligned `phaseSigs`. Only the explanation scan additionally includes the ancillary signals.

## Event side (secondary check)

There are two `recovery.escalated` events per ticket (a generic router one and the rich skill one), both carrying an `escalation` payload. The board read-model **ignores** these events for explanation (board-data.mjs:1136 — surfaces via the signal). `notification-composer.ts`'s `composeNotification` (the only event-escalation consumer) has **no live caller** yet — it is an unwired transport layer. So no live surface picks the generic event over the rich one; the primary surfaces read the signal, which this fix handles. No change needed there.

## Tests

- New `__tests__/board-recovery-pass-explanation.test.ts`: a ticket whose ONLY structured explanation is in `phase-recovery-pass.json` now surfaces its `call_to_action` and `escalation_type` (the regression — previously null); remediate-only variant; recovery-pass-wins-over-canonical ordering; fail-open on missing/corrupt ancillary signals.
- Updated the `board-pr-stuck.test.ts` static-source wiring guard for the `phaseSigs` → `explSigs` rename.
- Parent `tsc --noEmit` clean; full `orch-monitor` suite green except two pre-existing `nav-signal-endpoints` server-timeout flakes (reproduce on clean origin/main with this diff stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)