### PR TITLE
CTL-1241: Wire belief state into recovery evidence + make R12 the sing

### DIFF
--- a/plugins/dev/scripts/execution-core/beliefs/collector.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/collector.mjs
@@ -312,6 +312,39 @@ export function getBeliefsDb() {
   return _moduleDb;
 }
 
+// getEscalateHumanBelief — CTL-1241: read-only helper that returns the latest
+// escalate_human belief for a ticket from the current-tick beliefs.db.
+//
+// Query: most-recent (ORDER BY tick_id DESC LIMIT 1) row whose
+//   name = 'escalate_human' AND subject LIKE '<ticket>/%'
+// The '/' boundary ensures 'CTL-1241/x' matches 'CTL-1241' but 'CTL-12410/x'
+// does NOT.
+//
+// Returns { escalate_human: true, why, subject, tickId } or null.
+// Never throws — fail-open so a beliefs-disabled or broken daemon is a no-op.
+export function getEscalateHumanBelief(db, ticket) {
+  if (!db) return null;
+  try {
+    const row = db
+      .query(
+        `SELECT subject, value, tick_id FROM belief
+         WHERE name = 'escalate_human' AND subject LIKE ?
+         ORDER BY tick_id DESC LIMIT 1`
+      )
+      .get(`${ticket}/%`);
+    if (!row) return null;
+    let why = null;
+    try {
+      why = JSON.parse(row.value ?? "{}").why ?? null;
+    } catch {
+      // malformed JSON → why stays null; still return the belief
+    }
+    return { escalate_human: true, why, subject: row.subject, tickId: row.tick_id };
+  } catch {
+    return null; // db closed or query error → fail-open
+  }
+}
+
 // collectTickFacts — the hermetic core. All sources injectable; returns
 // { ok, tickId, errors } and NEVER throws.
 //

--- a/plugins/dev/scripts/execution-core/beliefs/collector.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/collector.mjs
@@ -108,7 +108,10 @@ function shortIdOf(value) {
 // recovery.mjs's statJob parses only {state, firstTerminalAt}; CTL-932 owns
 // that file, so the full-schema parse (tempo/detail/needs/cliVersion/
 // timestamps) lives here instead of extending it.
-export function defaultReadJobState(bgJobId, { jobsDir = join(homedir(), ".claude", "jobs") } = {}) {
+export function defaultReadJobState(
+  bgJobId,
+  { jobsDir = join(homedir(), ".claude", "jobs") } = {}
+) {
   const file = join(jobsDir, bgJobId, "state.json");
   let st;
   try {
@@ -217,7 +220,7 @@ function tailHeartbeats(db, eventLogPath, capBytes = HB_TAIL_CAP_BYTES) {
   }
 
   const insert = db.prepare(
-    "INSERT INTO obs_heartbeat (ticket, phase, generation, host, kind, ts_ms) VALUES (?, ?, ?, ?, ?, ?)",
+    "INSERT INTO obs_heartbeat (ticket, phase, generation, host, kind, ts_ms) VALUES (?, ?, ?, ?, ?, ?)"
   );
   for (const line of buf.toString("utf8", start, end + 1).split("\n")) {
     if (!line.trim()) continue;
@@ -238,10 +241,13 @@ function tailHeartbeats(db, eventLogPath, capBytes = HB_TAIL_CAP_BYTES) {
       p.generation ?? null,
       evt?.resource?.["host.name"] ?? p.host ?? null,
       p.kind ?? null,
-      tsMs,
+      tsMs
     );
   }
-  db.run("INSERT OR REPLACE INTO cfg (key, value_int) VALUES (?, ?)", [cursorKey, offset + end + 1]);
+  db.run("INSERT OR REPLACE INTO cfg (key, value_int) VALUES (?, ?)", [
+    cursorKey,
+    offset + end + 1,
+  ]);
 }
 
 // pruneRetention — spec §6 retention, driven entirely by the tick's `now`
@@ -261,7 +267,7 @@ function pruneRetention(db, now) {
   // belief/intent) so 7-day reports always have full data — NOT the 14d obs window.
   db.run(
     "DELETE FROM shadow_comparison WHERE tick_id IN (SELECT tick_id FROM tick WHERE now_ms < ?)",
-    [beliefCutoff],
+    [beliefCutoff]
   );
   for (const t of [
     "obs_agent",
@@ -294,7 +300,7 @@ function pruneRetention(db, now) {
        AND tick_id NOT IN (SELECT tick_id FROM belief)
        AND tick_id NOT IN (SELECT tick_id FROM intent)
        AND tick_id NOT IN (SELECT tick_id FROM shadow_comparison)`,
-    [obsCutoff],
+    [obsCutoff]
   );
 }
 
@@ -431,7 +437,7 @@ export function collectTickFacts({
             }
             db.run(
               "INSERT OR REPLACE INTO cfg (key, value_text) VALUES ('rules_sha_last_seen', ?)",
-              [RULES_SHA],
+              [RULES_SHA]
             );
           }
         } catch {
@@ -445,7 +451,7 @@ export function collectTickFacts({
         agents = getAgents?.() ?? [];
         const ins = db.prepare(
           `INSERT INTO obs_agent (tick_id, session_id, short_id, kind, status, state, cwd, name, pid, started_at_ms)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         );
         for (const a of agents) {
           const sid = a?.sessionId ?? a?.session_id;
@@ -460,7 +466,7 @@ export function collectTickFacts({
             a.cwd ?? null,
             a.name ?? null,
             a.pid ?? null,
-            toMs(a.startedAt ?? a.started_at_ms),
+            toMs(a.startedAt ?? a.started_at_ms)
           );
         }
       } catch (err) {
@@ -471,7 +477,7 @@ export function collectTickFacts({
       // ── obs_transcript — per listed session, via the resolver ──────────
       // A resolver FAILURE is an error, never the fact "transcript absent".
       const insTr = db.prepare(
-        "INSERT INTO obs_transcript (tick_id, session_id, exists_flag, mtime_ms, bytes) VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO obs_transcript (tick_id, session_id, exists_flag, mtime_ms, bytes) VALUES (?, ?, ?, ?, ?)"
       );
       for (const a of agents) {
         const sid = a?.sessionId ?? a?.session_id;
@@ -495,7 +501,7 @@ export function collectTickFacts({
         signals = readSignals?.() ?? [];
         const ins = db.prepare(
           `INSERT INTO obs_signal (tick_id, ticket, phase, status, bg_job_id, generation, started_at_ms, updated_at_ms)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
         );
         for (const s of signals) {
           if (!s?.ticket || s.phase == null) continue; // ticket+phase NOT NULL
@@ -508,7 +514,7 @@ export function collectTickFacts({
             bgJobId,
             s.raw?.generation ?? s.generation ?? null,
             toMs(s.raw?.startedAt ?? s.startedAt),
-            toMs(s.updatedAt ?? s.raw?.updatedAt),
+            toMs(s.updatedAt ?? s.raw?.updatedAt)
           );
         }
       } catch (err) {
@@ -520,7 +526,7 @@ export function collectTickFacts({
       try {
         const ins = db.prepare(
           `INSERT INTO obs_job (tick_id, bg_job_id, state, tempo, detail, needs, first_terminal_at, cli_version, created_at_ms, updated_at_ms, mtime_ms, exists_flag)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         );
         const seen = new Set();
         for (const s of signals) {
@@ -529,7 +535,20 @@ export function collectTickFacts({
           seen.add(bgJobId);
           const j = readJobState?.(bgJobId) ?? { exists: false };
           if (!j.exists) {
-            ins.run(tickId, String(bgJobId), null, null, null, null, null, null, null, null, null, 0);
+            ins.run(
+              tickId,
+              String(bgJobId),
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              0
+            );
           } else {
             ins.run(
               tickId,
@@ -543,7 +562,7 @@ export function collectTickFacts({
               toMs(j.createdAtMs),
               toMs(j.updatedAtMs),
               toMs(j.mtimeMs),
-              1,
+              1
             );
           }
         }
@@ -608,7 +627,7 @@ export function collectTickFacts({
       // while still re-inserting on subsequent ticks (insert-only-per-tick preserved).
       {
         const insRel = db.prepare(
-          "INSERT INTO obs_relation (tick_id, source_ticket, target_ticket, relation_type) VALUES (?, ?, ?, ?)",
+          "INSERT INTO obs_relation (tick_id, source_ticket, target_ticket, relation_type) VALUES (?, ?, ?, ?)"
         );
         const seenRel = new Set();
         const seenEdge = new Set();
@@ -630,7 +649,8 @@ export function collectTickFacts({
               if (!peer) continue;
               if (node.type === "blocks") addEdge(s.ticket, peer, "blocks");
               else if (node.type === "blocked_by") addEdge(peer, s.ticket, "blocks");
-              else if (node.type === "related" || node.type === "duplicate") addEdge(s.ticket, peer, node.type);
+              else if (node.type === "related" || node.type === "duplicate")
+                addEdge(s.ticket, peer, node.type);
             }
             for (const node of descriptor?.inverseRelations?.nodes ?? []) {
               const peer = node?.issue?.identifier;
@@ -654,7 +674,7 @@ export function collectTickFacts({
       try {
         if (orchDir) {
           const insV = db.prepare(
-            "INSERT INTO obs_verdict (tick_id, ticket, verdict) VALUES (?, ?, ?)",
+            "INSERT INTO obs_verdict (tick_id, ticket, verdict) VALUES (?, ?, ?)"
           );
           const seenV = new Set();
           for (const s of signals) {
@@ -680,7 +700,7 @@ export function collectTickFacts({
       // scheduler uses). Per-source try/catch.
       try {
         const insC = db.prepare(
-          "INSERT INTO obs_cycle (tick_id, ticket, remediate_count) VALUES (?, ?, ?)",
+          "INSERT INTO obs_cycle (tick_id, ticket, remediate_count) VALUES (?, ?, ?)"
         );
         const seenC = new Set();
         for (const s of signals) {
@@ -722,7 +742,10 @@ export function collectTickFacts({
           for (const a of agents) {
             const sid = a?.sessionId ?? a?.session_id;
             if (!sid) continue;
-            agentByShortId.set(shortIdOf(sid), { session_id: String(sid), short_id: shortIdOf(sid) });
+            agentByShortId.set(shortIdOf(sid), {
+              session_id: String(sid),
+              short_id: shortIdOf(sid),
+            });
           }
           // Map each signal's (ticket/phase) → its registered agent entry (or null).
           const m = new Map();
@@ -771,12 +794,17 @@ export function collectTickFacts({
 
         const maxAttempts = getMaxAttempts(db);
         const intentsEnforce = (env.CATALYST_INTENTS_ENFORCE ?? "0") === "1";
-        intentResult = reconcileIntents(db, tickId, { agentsBySubject, linearStateByTicket, signalStatusBySubject }, {
-          maxAttempts,
-          enforce: intentsEnforce,
-          appendEvent: typeof appendIntentEvent === "function" ? appendIntentEvent : null,
-          now,
-        });
+        intentResult = reconcileIntents(
+          db,
+          tickId,
+          { agentsBySubject, linearStateByTicket, signalStatusBySubject },
+          {
+            maxAttempts,
+            enforce: intentsEnforce,
+            appendEvent: typeof appendIntentEvent === "function" ? appendIntentEvent : null,
+            now,
+          }
+        );
       } catch (err) {
         fail("intents", err);
       }
@@ -844,7 +872,10 @@ export function collectBeliefsTick({
   } catch (err) {
     // Belt and braces: collectTickFacts never throws, but the wiring above could.
     try {
-      log.warn({ err: err?.message }, "beliefs: collector wrapper threw (shadow — tick unaffected)");
+      log.warn(
+        { err: err?.message },
+        "beliefs: collector wrapper threw (shadow — tick unaffected)"
+      );
     } catch {
       /* even logging must not break the tick */
     }

--- a/plugins/dev/scripts/execution-core/beliefs/collector.test.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/collector.test.mjs
@@ -13,6 +13,7 @@ import {
   collectTickFacts,
   collectBeliefsTick,
   __resetBeliefsCollectorForTests,
+  getEscalateHumanBelief,
 } from "./collector.mjs";
 import { RULES_SHA } from "./rules.mjs";
 import { computeReport } from "./report.mjs";
@@ -933,6 +934,86 @@ describe("collectBeliefsTick — daemon wrapper threads appendEvent (CTL-1063 re
     const db = openBeliefsDb({ path: dbPath });
     const row = db.query("SELECT value_text FROM cfg WHERE key = 'rules_sha_last_seen'").get();
     expect(row).toBeFalsy(); // one-shot signal NOT silently consumed
+    db.close();
+  });
+});
+
+// ─── CTL-1241: getEscalateHumanBelief ────────────────────────────────────────
+describe("getEscalateHumanBelief", () => {
+  // Helper: open an in-memory db seeded with a tick and optionally a belief row.
+  function makeDb({ subject = null, value = null, tickId = 1 } = {}) {
+    const db = openBeliefsDb({ path: ":memory:" });
+    db.run("INSERT INTO tick (tick_id, now_ms, host) VALUES (?, ?, 'h')", [tickId, NOW]);
+    if (subject !== null) {
+      db.run(
+        "INSERT INTO belief (tick_id, stratum, name, subject, value, rule_id, source_fact_ids) VALUES (?, 0, 'escalate_human', ?, ?, 'R12', '[]')",
+        [tickId, subject, value]
+      );
+    }
+    return db;
+  }
+
+  test("returns null when db handle is null", () => {
+    expect(getEscalateHumanBelief(null, "CTL-1241")).toBeNull();
+  });
+
+  test("returns null when no escalate_human row for the ticket", () => {
+    const db = makeDb();
+    expect(getEscalateHumanBelief(db, "CTL-1241")).toBeNull();
+    db.close();
+  });
+
+  test("returns belief object for a matching row", () => {
+    const db = makeDb({ subject: "CTL-1241/implement", value: JSON.stringify({ why: "R10+R11 co-occur" }) });
+    const r = getEscalateHumanBelief(db, "CTL-1241");
+    expect(r).not.toBeNull();
+    expect(r.escalate_human).toBe(true);
+    expect(r.why).toBe("R10+R11 co-occur");
+    expect(r.subject).toBe("CTL-1241/implement");
+    expect(typeof r.tickId).toBe("number");
+    db.close();
+  });
+
+  test("returns the MOST RECENT row (ORDER BY tick_id DESC LIMIT 1)", () => {
+    const db = openBeliefsDb({ path: ":memory:" });
+    db.run("INSERT INTO tick (tick_id, now_ms, host) VALUES (1, ?, 'h')", [NOW - 2000]);
+    db.run("INSERT INTO tick (tick_id, now_ms, host) VALUES (2, ?, 'h')", [NOW - 1000]);
+    db.run(
+      "INSERT INTO belief (tick_id, stratum, name, subject, value, rule_id, source_fact_ids) VALUES (1, 0, 'escalate_human', 'CTL-1241/triage', ?, 'R12', '[]')",
+      [JSON.stringify({ why: "older" })]
+    );
+    db.run(
+      "INSERT INTO belief (tick_id, stratum, name, subject, value, rule_id, source_fact_ids) VALUES (2, 0, 'escalate_human', 'CTL-1241/implement', ?, 'R12', '[]')",
+      [JSON.stringify({ why: "newer" })]
+    );
+    const r = getEscalateHumanBelief(db, "CTL-1241");
+    expect(r.why).toBe("newer");
+    expect(r.subject).toBe("CTL-1241/implement");
+    db.close();
+  });
+
+  test("does NOT match ticket with longer prefix (/ boundary)", () => {
+    // CTL-12410 must NOT match CTL-1241
+    const db = makeDb({ subject: "CTL-12410/implement", value: JSON.stringify({ why: "x" }) });
+    expect(getEscalateHumanBelief(db, "CTL-1241")).toBeNull();
+    db.close();
+  });
+
+  test("parses malformed JSON defensively — no throw, why is null", () => {
+    const db = makeDb({ subject: "CTL-1241/implement", value: "INVALID{{{" });
+    const r = getEscalateHumanBelief(db, "CTL-1241");
+    expect(r).not.toBeNull();
+    expect(r.escalate_human).toBe(true);
+    expect(r.why).toBeNull();
+    db.close();
+  });
+
+  test("handles missing value (null) defensively", () => {
+    const db = makeDb({ subject: "CTL-1241/implement", value: null });
+    const r = getEscalateHumanBelief(db, "CTL-1241");
+    expect(r).not.toBeNull();
+    expect(r.escalate_human).toBe(true);
+    expect(r.why).toBeNull();
     db.close();
   });
 });

--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -51,7 +51,11 @@ function labelMarkerBase(orchDir, ticket, label) {
 // stop the per-tick retry storm. "missing-label": the workspace lacks the label;
 // "exclusive-conflict": the label's exclusive-group sibling is already present;
 // "team-mismatch": name resolution used the wrong team's UUID context (CTL-1085).
-const UNRECOVERABLE_LABEL_REASONS = new Set(["missing-label", "exclusive-conflict", "team-mismatch"]);
+const UNRECOVERABLE_LABEL_REASONS = new Set([
+  "missing-label",
+  "exclusive-conflict",
+  "team-mismatch",
+]);
 
 // CTL-936: labelOnce now accepts an optional `appendEvent` seam. When provided
 // AND CATALYST_INTENTS_ENFORCE=1, an unrecoverable label-write failure emits an
@@ -65,7 +69,13 @@ const UNRECOVERABLE_LABEL_REASONS = new Set(["missing-label", "exclusive-conflic
 // terminal marker (.applied/.skipped) already exists → this call is a no-op;
 // `true` when this call performed the write attempt (the once-application).
 // Existing callers ignore the return value, so this is backward-compatible.
-export function labelOnce(orchDir, ticket, label, writeStatus, { appendEvent = null, env = process.env } = {}) {
+export function labelOnce(
+  orchDir,
+  ticket,
+  label,
+  writeStatus,
+  { appendEvent = null, env = process.env } = {}
+) {
   const base = labelMarkerBase(orchDir, ticket, label);
   if (existsSync(`${base}.applied`) || existsSync(`${base}.skipped`)) return false;
   try {
@@ -127,7 +137,13 @@ export function labelOnce(orchDir, ticket, label, writeStatus, { appendEvent = n
 // After REMOVAL_ESCALATION_THRESHOLD consecutive failures, activates a back-off
 // window (inRemovalBackoff) that short-circuits before calling removeLabel — the
 // storm-break. Escalates once with a log.error on the threshold trip.
-export function clearStalledLabel(orchDir, ticket, label, writeStatus, { onRemoved = null, now = () => Date.now() } = {}) {
+export function clearStalledLabel(
+  orchDir,
+  ticket,
+  label,
+  writeStatus,
+  { onRemoved = null, now = () => Date.now() } = {}
+) {
   const base = labelMarkerBase(orchDir, ticket, label);
   // CTL-1078: guard at entry — if we're in backoff, skip the doomed removeLabel.
   if (inRemovalBackoff(orchDir, ticket, label, now())) {
@@ -142,14 +158,25 @@ export function clearStalledLabel(orchDir, ticket, label, writeStatus, { onRemov
         clearRemovalFailures(orchDir, ticket, label);
         for (const suffix of [".applied", ".skipped"]) {
           const p = `${base}${suffix}`;
-          if (existsSync(p)) { try { unlinkSync(p); } catch { /* best-effort */ } }
+          if (existsSync(p)) {
+            try {
+              unlinkSync(p);
+            } catch {
+              /* best-effort */
+            }
+          }
         }
         // CTL-1045 Bug 4: run the caller's confirmed-removal hook ONLY when
         // removal is confirmed — e.g. the J3 once-marker write. A failed removal
         // must NOT disarm future genuine escalations via the once-marker.
         if (typeof onRemoved === "function") {
-          try { onRemoved(); } catch (err) {
-            log.warn({ ticket, label, err: err?.message }, "clearStalledLabel: onRemoved threw — continuing");
+          try {
+            onRemoved();
+          } catch (err) {
+            log.warn(
+              { ticket, label, err: err?.message },
+              "clearStalledLabel: onRemoved threw — continuing"
+            );
           }
         }
       } else if (r?.removed === false) {
@@ -164,8 +191,14 @@ export function clearStalledLabel(orchDir, ticket, label, writeStatus, { onRemov
       }
     };
     if (res && typeof res.then === "function") {
-      res.then(finalize).catch((err) =>
-        log.warn({ ticket, label, err: err?.message }, "clearStalledLabel: removeLabel rejected — continuing"));
+      res
+        .then(finalize)
+        .catch((err) =>
+          log.warn(
+            { ticket, label, err: err?.message },
+            "clearStalledLabel: removeLabel rejected — continuing"
+          )
+        );
     } else {
       finalize(res);
     }
@@ -184,8 +217,7 @@ export function clearStalledLabel(orchDir, ticket, label, writeStatus, { onRemov
 //
 // Marker lives under orchDir/.removal-failures/ (same rationale as
 // .escalation-cooldowns/ — outside workers/<T>/ to avoid manufacturing worker dirs).
-const REMOVAL_ESCALATION_THRESHOLD =
-  Number(process.env.REMOVAL_ESCALATION_THRESHOLD) || 3;
+const REMOVAL_ESCALATION_THRESHOLD = Number(process.env.REMOVAL_ESCALATION_THRESHOLD) || 3;
 
 function removalFailurePath(orchDir, ticket, label) {
   return join(orchDir, ".removal-failures", `${ticket}-${label}.json`);
@@ -205,9 +237,15 @@ export function recordRemovalFailure(orchDir, ticket, label, reason, now) {
       // absent or malformed → start fresh
     }
     mkdirSync(dir, { recursive: true });
-    writeFileSync(p, JSON.stringify({ ticket, label, count, firstFailedAt, lastReason: reason, lastFailedAt: now }));
+    writeFileSync(
+      p,
+      JSON.stringify({ ticket, label, count, firstFailedAt, lastReason: reason, lastFailedAt: now })
+    );
   } catch (err) {
-    log.warn({ ticket, label, err: err.message }, "label-guard: removal-failure marker write failed — continuing");
+    log.warn(
+      { ticket, label, err: err.message },
+      "label-guard: removal-failure marker write failed — continuing"
+    );
     return { count };
   }
   return { count };
@@ -218,7 +256,10 @@ export function clearRemovalFailures(orchDir, ticket, label) {
   try {
     if (existsSync(p)) unlinkSync(p);
   } catch (err) {
-    log.warn({ ticket, label, err: err.message }, "label-guard: removal-failure marker delete failed — continuing");
+    log.warn(
+      { ticket, label, err: err.message },
+      "label-guard: removal-failure marker delete failed — continuing"
+    );
   }
 }
 
@@ -307,14 +348,16 @@ export function beliefOwnsNeedsHuman(env = process.env) {
 //     site  : string                 (short site-id for the deferral log)
 //     log   : { info }              (the module's log instance)
 //   }
-export function labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, writeStatus, { env = process.env, site = "unknown", log: logArg = null } = {}) {
+export function labelNeedsHumanUnlessBeliefOwner(
+  orchDir,
+  ticket,
+  writeStatus,
+  { env = process.env, site = "unknown", log: logArg = null } = {}
+) {
   if (beliefOwnsNeedsHuman(env)) {
     // Defer to executeEscalations — R12 belief owner. Record, do not page.
     const logger = logArg ?? log;
-    logger.info(
-      { ticket, site },
-      "needs-human deferred to belief owner (CTL-1241)"
-    );
+    logger.info({ ticket, site }, "needs-human deferred to belief owner (CTL-1241)");
     return;
   }
   // Enforcement OFF (default): call labelOnce exactly as before.

--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -274,6 +274,53 @@ export function inEscalationCooldown(orchDir, ticket, phase, now) {
   return now - escalatedAt < ESCALATION_COOLDOWN_MS;
 }
 
+// ─── CTL-1241: belief-ownership deferral guard ────────────────────────────────
+//
+// When CATALYST_INTENTS_ENFORCE=1, the belief engine's executeEscalations
+// (beliefs/escalate.mjs) is the SINGLE owner of the needs-human label. The six
+// non-belief producers are gated through labelNeedsHumanUnlessBeliefOwner so
+// they defer to the belief owner instead of writing directly. With enforcement
+// OFF (the default), behavior is byte-for-byte unchanged.
+//
+// Enforcement flag: CATALYST_INTENTS_ENFORCE=1 (Layer-2 config / launchd env).
+// Flipping the flag is an operational rollout step (see CTL-1241 plan §Rollout)
+// — NOT a code default change. All code here is behavior-neutral while the flag
+// is OFF, matching the belief-engine shadow discipline (CTL-933, ADR-023).
+
+// beliefOwnsNeedsHuman — returns true when enforcement is ON and the belief
+// engine is the single owner of the needs-human label. Single source of truth
+// for the deferral predicate.
+export function beliefOwnsNeedsHuman(env = process.env) {
+  return (env ?? process.env).CATALYST_INTENTS_ENFORCE === "1";
+}
+
+// labelNeedsHumanUnlessBeliefOwner — the shared gate used by every non-belief
+// needs-human producer. Either defers to executeEscalations (enforcement ON) or
+// calls labelOnce exactly as before (enforcement OFF / default).
+//
+// Parameters match labelOnce's calling convention at each producer site:
+//   orchDir     — path to the orchestrator directory
+//   ticket      — ticket identifier
+//   writeStatus — { applyLabel } as passed to labelOnce
+//   opts        — {
+//     env   : Record<string,string>  (process.env in production)
+//     site  : string                 (short site-id for the deferral log)
+//     log   : { info }              (the module's log instance)
+//   }
+export function labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, writeStatus, { env = process.env, site = "unknown", log: logArg = null } = {}) {
+  if (beliefOwnsNeedsHuman(env)) {
+    // Defer to executeEscalations — R12 belief owner. Record, do not page.
+    const logger = logArg ?? log;
+    logger.info(
+      { ticket, site },
+      "needs-human deferred to belief owner (CTL-1241)"
+    );
+    return;
+  }
+  // Enforcement OFF (default): call labelOnce exactly as before.
+  labelOnce(orchDir, ticket, "needs-human", writeStatus);
+}
+
 export function recordEscalation(orchDir, ticket, phase, reason, now) {
   const dir = join(orchDir, ".escalation-cooldowns");
   try {

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -16,6 +16,8 @@ import {
   recordRemovalFailure,
   clearRemovalFailures,
   inRemovalBackoff,
+  beliefOwnsNeedsHuman,
+  labelNeedsHumanUnlessBeliefOwner,
 } from "./label-guard.mjs";
 
 let orchDir;
@@ -677,5 +679,84 @@ describe("clearStalledLabel — CTL-1078 storm-break", () => {
     writeFileSync(badOrchDir, ""); // this is a FILE, not a dir
     const ws = { removeLabel: () => ({ removed: false, reason: "transient" }) };
     expect(() => clearStalledLabel(badOrchDir, "CTL-S5", "needs-human", ws, { now: () => Date.now() })).not.toThrow();
+  });
+});
+
+// ─── CTL-1241: beliefOwnsNeedsHuman + labelNeedsHumanUnlessBeliefOwner ────────
+describe("beliefOwnsNeedsHuman (CTL-1241)", () => {
+  test("returns true when CATALYST_INTENTS_ENFORCE=1", () => {
+    expect(beliefOwnsNeedsHuman({ CATALYST_INTENTS_ENFORCE: "1" })).toBe(true);
+  });
+
+  test("returns false when CATALYST_INTENTS_ENFORCE is unset", () => {
+    expect(beliefOwnsNeedsHuman({})).toBe(false);
+  });
+
+  test("returns false when CATALYST_INTENTS_ENFORCE=0", () => {
+    expect(beliefOwnsNeedsHuman({ CATALYST_INTENTS_ENFORCE: "0" })).toBe(false);
+  });
+
+  test("returns false for any non-'1' value", () => {
+    expect(beliefOwnsNeedsHuman({ CATALYST_INTENTS_ENFORCE: "true" })).toBe(false);
+    expect(beliefOwnsNeedsHuman({ CATALYST_INTENTS_ENFORCE: "" })).toBe(false);
+  });
+
+  test("defaults to process.env when env is omitted", () => {
+    const prev = process.env.CATALYST_INTENTS_ENFORCE;
+    process.env.CATALYST_INTENTS_ENFORCE = "1";
+    try {
+      expect(beliefOwnsNeedsHuman()).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.CATALYST_INTENTS_ENFORCE;
+      else process.env.CATALYST_INTENTS_ENFORCE = prev;
+    }
+  });
+});
+
+describe("labelNeedsHumanUnlessBeliefOwner (CTL-1241)", () => {
+  function makeWS() {
+    const calls = [];
+    return {
+      applyLabel: (args) => { calls.push(args); return { applied: true }; },
+      calls,
+    };
+  }
+
+  test("with enforcement OFF: calls labelOnce (legacy behavior unchanged)", () => {
+    const ws = makeWS();
+    mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });
+    const deferred = [];
+    labelNeedsHumanUnlessBeliefOwner(orchDir, "CTL-1", ws, {
+      env: { CATALYST_INTENTS_ENFORCE: "0" },
+      site: "test-site",
+      log: { info: (obj) => deferred.push(obj) },
+    });
+    expect(ws.calls.length).toBe(1);
+    expect(ws.calls[0]).toMatchObject({ ticket: "CTL-1", label: "needs-human" });
+    expect(deferred.length).toBe(0);
+  });
+
+  test("with enforcement ON: does NOT call labelOnce, records deferral", () => {
+    const ws = makeWS();
+    const deferred = [];
+    labelNeedsHumanUnlessBeliefOwner(orchDir, "CTL-2", ws, {
+      env: { CATALYST_INTENTS_ENFORCE: "1" },
+      site: "test-site",
+      log: { info: (obj, _msg) => deferred.push(obj) },
+    });
+    expect(ws.calls.length).toBe(0); // no labelOnce call
+    expect(deferred.length).toBe(1);
+    expect(deferred[0]).toMatchObject({ ticket: "CTL-2", site: "test-site" });
+  });
+
+  test("with enforcement unset: calls labelOnce (default OFF)", () => {
+    const ws = makeWS();
+    mkdirSync(join(orchDir, "workers", "CTL-3"), { recursive: true });
+    labelNeedsHumanUnlessBeliefOwner(orchDir, "CTL-3", ws, {
+      env: {},
+      site: "test-site",
+      log: { info: () => {} },
+    });
+    expect(ws.calls.length).toBe(1);
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery-evidence.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-evidence.mjs
@@ -1,0 +1,40 @@
+// recovery-evidence.mjs — CTL-1241: pure, injectable helper for building the
+// recovery evidence items the scheduler passes to reasoningRecoveryPass.
+//
+// Extracted from the inline .map() in scheduler.mjs so the belief-attachment
+// logic is unit-testable without spinning a full tick.
+
+// buildRecoveryItems — maps filtered signals to recovery item objects.
+//
+// Parameters:
+//   signals   — array of signal objects from readWorkerSignals (already filtered
+//               to stalled/failed/needs-human/unknown). Each has .ticket,
+//               .phase, .raw (the raw JSON of the signal file or null).
+//   opts      — {
+//     db        : the current-tick beliefs.db handle (or null/undefined when
+//                 beliefs are disabled — believers-disabled path is a no-op)
+//     getBeliefs: (db, ticket) => belief | null  — injectable for tests;
+//                 defaults to the live getEscalateHumanBelief from collector.mjs
+//   }
+//
+// Returns an array of { ticket, phase, bgJobId, evidence } objects suitable
+// for reasoningRecoveryPass.
+export function buildRecoveryItems(signals, { db = null, getBeliefs = null } = {}) {
+  return signals.map((sig) => {
+    const raw = sig.raw ?? {};
+    const bgJobId = raw.bg_job_id ?? null;
+    let evidence = { ...raw };
+    if (typeof getBeliefs === "function") {
+      const beliefState = getBeliefs(db, sig.ticket);
+      if (beliefState != null) {
+        evidence = { ...evidence, beliefState };
+      }
+    }
+    return {
+      ticket: sig.ticket,
+      phase: sig.phase,
+      bgJobId,
+      evidence,
+    };
+  });
+}

--- a/plugins/dev/scripts/execution-core/recovery-evidence.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-evidence.test.mjs
@@ -1,0 +1,57 @@
+// recovery-evidence.test.mjs — CTL-1241: tests for buildRecoveryItems helper.
+//
+// Verifies that belief state is correctly attached to recovery evidence items
+// when getBeliefs returns a belief, and omitted when it does not.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test recovery-evidence.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { buildRecoveryItems } from "./recovery-evidence.mjs";
+
+describe("buildRecoveryItems (CTL-1241)", () => {
+  const sig = (ticket, raw = {}) => ({ ticket, phase: "implement", raw });
+
+  test("attaches beliefState when getBeliefs returns a belief", () => {
+    const belief = { escalate_human: true, why: "R10+R11 co-occur", subject: "CTL-1/implement", tickId: 5 };
+    const items = buildRecoveryItems(
+      [sig("CTL-1", { bg_job_id: "abc123" })],
+      { getBeliefs: (_db, ticket) => (ticket === "CTL-1" ? belief : null) }
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].evidence.beliefState).toEqual(belief);
+    expect(items[0].evidence.bg_job_id).toBe("abc123"); // raw fields preserved
+    expect(items[0].bgJobId).toBe("abc123");
+  });
+
+  test("does NOT attach beliefState when getBeliefs returns null", () => {
+    const items = buildRecoveryItems(
+      [sig("CTL-2")],
+      { getBeliefs: () => null }
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].evidence.beliefState).toBeUndefined();
+  });
+
+  test("handles multiple signals independently", () => {
+    const belief = { escalate_human: true, why: "R12", subject: "CTL-1/triage", tickId: 1 };
+    const items = buildRecoveryItems(
+      [sig("CTL-1"), sig("CTL-2")],
+      { getBeliefs: (_db, ticket) => (ticket === "CTL-1" ? belief : null) }
+    );
+    expect(items[0].evidence.beliefState).toBeDefined();
+    expect(items[1].evidence.beliefState).toBeUndefined();
+  });
+
+  test("is a no-op when getBeliefs is omitted (no beliefState ever)", () => {
+    const items = buildRecoveryItems([sig("CTL-X")], {});
+    expect(items[0].evidence.beliefState).toBeUndefined();
+  });
+
+  test("handles null raw gracefully — evidence is {} not null", () => {
+    const items = buildRecoveryItems(
+      [{ ticket: "CTL-3", phase: "triage", raw: null }],
+      { getBeliefs: () => null }
+    );
+    expect(items[0].evidence).toEqual({});
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -1204,3 +1204,31 @@ describe("reasoningRecoveryPass bounded-LLM → recovery-pass dispatch (CTL-1176
     expect(result.results[0].decision).toBe("fix");
   });
 });
+
+// ─── CTL-1241: R12 belief state → escalation reason text end-to-end ──────────
+describe("CTL-1241 — R12 escalate_human belief wired into recovery evidence", () => {
+  test("determineEscalationReason with beliefState.escalate_human=true includes R12 text", () => {
+    const reason = determineEscalationReason(
+      null,
+      null,
+      {},
+      { escalate_human: true, why: "R10+R11 co-occur" }
+    );
+    expect(reason).toContain("Rule belief R12 escalate_human fired");
+  });
+
+  test("determineEscalationReason without beliefState does NOT include R12 text", () => {
+    const reason = determineEscalationReason(null, null, {}, undefined);
+    expect(reason).not.toContain("R12");
+  });
+
+  test("defaultClassifyTicket with beliefState escalates and reason includes R12 text", () => {
+    const result = defaultClassifyTicket({
+      logsOutput: "some unknown stuck state",
+      beliefState: { escalate_human: true, why: "R10+R11 co-occur" },
+    });
+    expect(result.decision).toBe("escalate");
+    expect(result.fix_class).toBe("human");
+    expect(result.details.reason).toContain("Rule belief R12 escalate_human fired");
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -84,9 +84,7 @@ import {
 import { countReviveEvents as defaultCountReviveEvents, hasCompleteEvent } from "./event-scan.mjs";
 
 // phase-agent-emit-complete sits two directories up from execution-core/.
-const EMIT_COMPLETE_BIN = fileURLToPath(
-  new URL("../phase-agent-emit-complete", import.meta.url),
-);
+const EMIT_COMPLETE_BIN = fileURLToPath(new URL("../phase-agent-emit-complete", import.meta.url));
 
 // resolvePhaseSessionId — extracted to session-resolve.mjs (CTL-729) so
 // transcript-silence.mjs can import it without pulling in recovery.mjs's
@@ -221,7 +219,7 @@ export function reconstructWorkerState(orchDir, { statJob = defaultStatJob } = {
   if (buckets.dead.length || buckets.unknown.length) {
     log.warn(
       { dead: buckets.dead.length, unknown: buckets.unknown.length },
-      "recovery: workers need attention (dead = lost process, unknown = orphan dispatch)",
+      "recovery: workers need attention (dead = lost process, unknown = orphan dispatch)"
     );
   }
   return buckets;
@@ -251,11 +249,16 @@ export function reconstructWorkerState(orchDir, { statJob = defaultStatJob } = {
 
 function defaultEmitComplete({ orchDir, signal }, { spawn = spawnSync } = {}) {
   const args = [
-    "--phase", signal.phase,
-    "--ticket", signal.ticket,
-    "--status", "complete",
-    "--orch-dir", orchDir,
-    "--orch-id", signal.raw?.orchestrator ?? signal.ticket,
+    "--phase",
+    signal.phase,
+    "--ticket",
+    signal.ticket,
+    "--status",
+    "complete",
+    "--orch-dir",
+    orchDir,
+    "--orch-id",
+    signal.raw?.orchestrator ?? signal.ticket,
   ];
   const sessionId = signal.raw?.catalystSessionId;
   if (sessionId) {
@@ -275,7 +278,17 @@ function defaultEmitComplete({ orchDir, signal }, { spawn = spawnSync } = {}) {
 // `ticketType` is resolved by the caller from triage.json (resolveTicketType);
 // when omitted it defaults to UNKNOWN_TICKET_TYPE so the attribute is ALWAYS
 // present, never inconsistently missing (the gherkin contract).
-function buildEventEnvelope({ phase, ticket, orchId, action, reason, payloadExtras = {}, severityText = "WARN", severityNumber = 13, ticketType = UNKNOWN_TICKET_TYPE }) {
+function buildEventEnvelope({
+  phase,
+  ticket,
+  orchId,
+  action,
+  reason,
+  payloadExtras = {},
+  severityText = "WARN",
+  severityNumber = 13,
+  ticketType = UNKNOWN_TICKET_TYPE,
+}) {
   const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
   return (
     JSON.stringify({
@@ -372,7 +385,7 @@ export function defaultAppendReclaimEvent({
         body,
       },
     }),
-    "reclaim",
+    "reclaim"
   );
 }
 
@@ -399,7 +412,7 @@ export function defaultAppendOrphanDetectedEvent({
       reason,
       payloadExtras: { stalled_phases },
     }),
-    "orphan-detected",
+    "orphan-detected"
   );
 }
 
@@ -438,7 +451,7 @@ export function neverStartedAttemptsPath(orchDir, ticket, phase) {
 export function defaultReadNeverStartedAttempts(orchDir, ticket, phase) {
   try {
     const parsed = JSON.parse(
-      readFileSync(neverStartedAttemptsPath(orchDir, ticket, phase), "utf8"),
+      readFileSync(neverStartedAttemptsPath(orchDir, ticket, phase), "utf8")
     );
     const count = Number.isInteger(parsed?.count) && parsed.count > 0 ? parsed.count : 0;
     const captures = Array.isArray(parsed?.captures)
@@ -461,17 +474,17 @@ export function defaultRecordNeverStartedAttempt(orchDir, ticket, phase, capture
     mkdirSync(dirname(p), { recursive: true });
     const next = {
       count: prev.count + 1,
-      captures: [
-        ...prev.captures,
-        String(capture ?? "").slice(0, NEVER_STARTED_CAPTURE_CAP),
-      ],
+      captures: [...prev.captures, String(capture ?? "").slice(0, NEVER_STARTED_CAPTURE_CAP)],
       updatedAt: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
     };
     const tmp = `${p}.tmp.${process.pid}`;
     writeFileSync(tmp, JSON.stringify(next, null, 2));
     renameSync(tmp, p);
   } catch (err) {
-    log.warn({ ticket, phase, err: err.message }, "ctl-932: never-started attempt marker write failed");
+    log.warn(
+      { ticket, phase, err: err.message },
+      "ctl-932: never-started attempt marker write failed"
+    );
   }
 }
 
@@ -488,7 +501,10 @@ export function defaultClearNeverStartedAttempts(orchDir, ticket, phase, { rm = 
   try {
     rm(neverStartedAttemptsPath(orchDir, ticket, phase), { force: true });
   } catch (err) {
-    log.warn({ ticket, phase, err: err.message }, "ctl-932: never-started attempt marker clear failed");
+    log.warn(
+      { ticket, phase, err: err.message },
+      "ctl-932: never-started attempt marker clear failed"
+    );
   }
 }
 
@@ -555,7 +571,7 @@ export function defaultAppendWedgedNeverStartedEvent({
         body: `Worker for ${ticket} ${phase} registered but never started its first turn (no transcript; agents state=blocked). Stopped and replaced via the revive path. Captured screen:\n\n${captured_logs}`,
       },
     }),
-    "wedged-never-started",
+    "wedged-never-started"
   );
 }
 
@@ -571,17 +587,23 @@ export function defaultPostReclaimMirror(
     existsSync: exists = existsSync,
     writeMarker = (p) => writeFileSync(p, ""),
     runCommentPost = (t, bodyText) => {
-      const helperPath = join(dirname(fileURLToPath(import.meta.url)), "../lib/linear-comment-post.sh");
+      const helperPath = join(
+        dirname(fileURLToPath(import.meta.url)),
+        "../lib/linear-comment-post.sh"
+      );
       return spawnSync(helperPath, [t, bodyText], { encoding: "utf8" });
     },
     multiHost = false,
-  } = {},
+  } = {}
 ) {
   const marker = `${orchDir}/workers/${ticket}/.linear-mirror-${phase}`;
   if (exists(marker)) return; // first-writer-wins
   // CTL-863: zombie guard — a post-takeover paused host must not post a mirror comment.
   if (!fenceGuard({ ticket, orchDir, multiHost })) {
-    log.warn({ ticket, phase }, "ctl-863: stale fence — suppressing postReclaimMirror comment (zombie guard)");
+    log.warn(
+      { ticket, phase },
+      "ctl-863: stale fence — suppressing postReclaimMirror comment (zombie guard)"
+    );
     return;
   }
   const bodyText = [
@@ -610,7 +632,7 @@ export function defaultPostReclaimMirror(
         .pop();
       log.warn(
         { ticket, phase, status: r?.status, detail },
-        "reclaim-mirror: linear-comment-post failed (continuing)",
+        "reclaim-mirror: linear-comment-post failed (continuing)"
       );
     }
   } catch (err) {
@@ -636,7 +658,7 @@ export function defaultAppendBootResumeEvent({ phase, ticket, orchId }) {
       action: "boot-resume",
       reason: "cold-start-no-live-worker",
     }),
-    "boot-resume",
+    "boot-resume"
   );
 }
 
@@ -654,7 +676,7 @@ export function defaultAppendBootResumeGatedEvent({ phase, ticket, orchId }) {
       action: "boot-resume-gated",
       reason: "cold-start-expensive-phase-awaiting-approval",
     }),
-    "boot-resume-gated",
+    "boot-resume-gated"
   );
 }
 
@@ -669,7 +691,12 @@ export function defaultAppendBootResumeGatedEvent({ phase, ticket, orchId }) {
 // regression for operator forensics INSTEAD of spawning a fresh earlier-phase
 // worker. Exported so boot-resume.mjs imports it as the default appender seam and
 // the round-trip test can confirm the envelope shape.
-export function defaultAppendBootResumePhaseRegressionEvent({ phase, ticket, dominantPhase, orchId }) {
+export function defaultAppendBootResumePhaseRegressionEvent({
+  phase,
+  ticket,
+  dominantPhase,
+  orchId,
+}) {
   return appendEnvelopeBestEffort(
     buildEventEnvelope({
       phase,
@@ -679,7 +706,7 @@ export function defaultAppendBootResumePhaseRegressionEvent({ phase, ticket, dom
       reason: "later-terminal-phase-supersedes-resume-candidate",
       payloadExtras: { dominantPhase },
     }),
-    "boot-resume-phase-regression",
+    "boot-resume-phase-regression"
   );
 }
 
@@ -714,7 +741,7 @@ export function defaultAppendReviveEvent({
       ticketType: resolveTicketType(orchDir, ticket), // CTL-1023
       payloadExtras: { attempt, prev_state_json_mtime, prev_bg_job_id },
     }),
-    "revive",
+    "revive"
   );
 }
 
@@ -733,14 +760,21 @@ export function defaultAppendYieldFileSkipEvent({ ticket, orchId, filename }) {
       reason: "yield_tombstone_filtered",
       payloadExtras: { filename },
     }),
-    "yield-file-skip",
+    "yield-file-skip"
   );
 }
 
 // CTL-932: `extras` rides into the payload so an escalation can carry evidence
 // (the wedged-never-started cap escalation embeds the screen captures from all
 // attempts). Absent for every pre-existing caller — shape unchanged.
-function defaultAppendEscalatedEvent({ phase, ticket, orchId, reason, final_attempt_count, extras = {} }) {
+function defaultAppendEscalatedEvent({
+  phase,
+  ticket,
+  orchId,
+  reason,
+  final_attempt_count,
+  extras = {},
+}) {
   return appendEnvelopeBestEffort(
     buildEventEnvelope({
       phase,
@@ -750,7 +784,7 @@ function defaultAppendEscalatedEvent({ phase, ticket, orchId, reason, final_atte
       reason,
       payloadExtras: { final_attempt_count, ...extras },
     }),
-    "escalated",
+    "escalated"
   );
 }
 
@@ -773,7 +807,7 @@ function defaultAppendReviveSuppressedEvent({
       reason,
       payloadExtras: { window_distinct_tickets, window_ms: STORM_WINDOW_MS },
     }),
-    "revive-suppressed",
+    "revive-suppressed"
   );
 }
 
@@ -819,7 +853,7 @@ export function defaultAppendDispatchFailedEvent({
         ...(signal !== undefined && signal !== null && signal !== "" && { signal }),
       },
     }),
-    "dispatch-failed",
+    "dispatch-failed"
   );
 }
 
@@ -841,7 +875,7 @@ export function defaultAppendRunawayEvent({ ticket, orchId, count, window_ms }) 
       reason: "event-rate-domination",
       payloadExtras: { count, window_ms },
     }),
-    "runaway",
+    "runaway"
   );
 }
 
@@ -860,7 +894,13 @@ export function defaultAppendRunawayEvent({ ticket, orchId, count, window_ms }) 
 // defaultAppendDispatchRequestedEvent — phase.dispatch.requested.<TICKET>.
 // Emitted when the scheduler/recovery DECIDES to dispatch a phase, before the
 // `claude --bg` spawn. reason ∈ {new-work, advance, revive}.
-export function defaultAppendDispatchRequestedEvent({ orchId, orchDir, ticket, target_phase, reason }) {
+export function defaultAppendDispatchRequestedEvent({
+  orchId,
+  orchDir,
+  ticket,
+  target_phase,
+  reason,
+}) {
   return appendEnvelopeBestEffort(
     buildEventEnvelope({
       phase: "dispatch",
@@ -874,7 +914,7 @@ export function defaultAppendDispatchRequestedEvent({ orchId, orchDir, ticket, t
       // CTL-1023: resolves to "unknown" pre-triage (no triage.json yet) — correct.
       ticketType: resolveTicketType(orchDir, ticket),
     }),
-    "dispatch-requested",
+    "dispatch-requested"
   );
 }
 
@@ -902,7 +942,7 @@ export function defaultAppendDispatchLaunchedEvent({
       // CTL-1023: "unknown" until triage.json lands; full type post-triage.
       ticketType: resolveTicketType(orchDir, ticket),
     }),
-    "dispatch-launched",
+    "dispatch-launched"
   );
 }
 
@@ -921,7 +961,7 @@ export function defaultAppendPreemptedEvent({ orchId, ticket, phase, preemptedBy
       action: "preempted",
       payloadExtras: { preempted_by: preemptedBy, bg_job_id: bgJobId },
     }),
-    "preempted",
+    "preempted"
   );
 }
 
@@ -938,7 +978,7 @@ export function defaultAppendResumedAfterPreemptionEvent({ orchId, ticket, phase
       action: "resumed-after-preemption",
       payloadExtras: { resume_session: resumeSession ?? null },
     }),
-    "resumed-after-preemption",
+    "resumed-after-preemption"
   );
 }
 
@@ -947,9 +987,14 @@ export function defaultAppendResumedAfterPreemptionEvent({ orchId, ticket, phase
 // (CTL-768). bg_job_id preserved so the revive path resolves --resume. Never throws.
 export function defaultAppendHeldStoppedEvent({ orchId, ticket, phase, bgJobId }) {
   return appendEnvelopeBestEffort(
-    buildEventEnvelope({ phase, ticket, orchId, action: "held-stopped",
-      payloadExtras: { bg_job_id: bgJobId } }),
-    "held-stopped",
+    buildEventEnvelope({
+      phase,
+      ticket,
+      orchId,
+      action: "held-stopped",
+      payloadExtras: { bg_job_id: bgJobId },
+    }),
+    "held-stopped"
   );
 }
 
@@ -975,7 +1020,7 @@ export function defaultAppendPhaseAdvanceHeldEvent({ orchId, ticket, reason, blo
       reason,
       payloadExtras: { blockers: blockers ?? [] },
     }),
-    "advance-held",
+    "advance-held"
   );
 }
 
@@ -992,7 +1037,7 @@ export function defaultAppendCooldownGcEvent({ ticket, orchId, target_phase }) {
       reason: "expired-and-ineligible",
       payloadExtras: { target_phase },
     }),
-    "cooldown-gc",
+    "cooldown-gc"
   );
 }
 
@@ -1014,7 +1059,7 @@ export function defaultAppendCooldownEscalatedEvent({
       reason: "consecutive-dispatch-failures",
       payloadExtras: { target_phase, code, consecutiveFailures },
     }),
-    "cooldown-escalated",
+    "cooldown-escalated"
   );
 }
 
@@ -1037,9 +1082,16 @@ export function defaultAppendParallelismSampledEvent({
       orchId: label,
       action: "parallelism-sampled",
       reason: "sample",
-      payloadExtras: { load1, load5, load15, mem_free_pct: memFreePct, bg_count: bgCount, maxParallel_current: maxParallelCurrent },
+      payloadExtras: {
+        load1,
+        load5,
+        load15,
+        mem_free_pct: memFreePct,
+        bg_count: bgCount,
+        maxParallel_current: maxParallelCurrent,
+      },
     }),
-    "parallelism-sampled",
+    "parallelism-sampled"
   );
 }
 
@@ -1060,7 +1112,7 @@ export function defaultAppendParallelismAdjustedEvent({
       reason,
       payloadExtras: { old_maxParallel: oldMaxParallel, new_maxParallel: newMaxParallel },
     }),
-    "parallelism-adjusted",
+    "parallelism-adjusted"
   );
 }
 
@@ -1100,7 +1152,7 @@ export function defaultAppendAutotuneGaugeEvent({
         decision_reason: reason,
       },
     }),
-    "autotune-gauge",
+    "autotune-gauge"
   );
 }
 
@@ -1181,13 +1233,13 @@ export function defaultReviveDispatch(
     // on the revive path too (the failed path was already covered by CTL-611).
     appendRequested = defaultAppendDispatchRequestedEvent,
     appendLaunched = defaultAppendDispatchLaunchedEvent,
-  } = {},
+  } = {}
 ) {
   const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
   if (!existsSync(signalPath)) {
     log.warn(
       { ticket, phase, signalPath },
-      "revive: signal file missing — cannot reset to stalled, refusing dispatch",
+      "revive: signal file missing — cannot reset to stalled, refusing dispatch"
     );
     return { code: 1, stdout: "", stderr: "signal-missing" };
   }
@@ -1279,11 +1331,16 @@ export function defaultReviveDispatch(
 //     the audit-event + label-call pair entirely so the scheduler's own
 //     event-log fast path stops self-feeding.
 function defaultApplyStalledLabel({ orchDir, ticket }) {
-  return labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, { applyLabel: defaultApplyLabel }, {
-    env: process.env,
-    site: "recovery-stalled",
-    log: { info: () => {} },
-  });
+  return labelNeedsHumanUnlessBeliefOwner(
+    orchDir,
+    ticket,
+    { applyLabel: defaultApplyLabel },
+    {
+      env: process.env,
+      site: "recovery-stalled",
+      log: { info: () => {} },
+    }
+  );
 }
 
 // defaultKillBgJob — terminate a dead/abandoned bg worker (CTL-657). Pre-CTL-657
@@ -1376,7 +1433,10 @@ export function writeBootMarker(orchDir, { now = () => new Date().toISOString() 
     writeFileSync(tmp, JSON.stringify({ bootedAt: now() }));
     renameSync(tmp, p);
   } catch (err) {
-    log.warn({ err }, "ctl-655: failed to write daemon-boot.json (revive budget will not reset this run)");
+    log.warn(
+      { err },
+      "ctl-655: failed to write daemon-boot.json (revive budget will not reset this run)"
+    );
   }
 }
 
@@ -1509,7 +1569,7 @@ export function detectColdStart({
   readDir = readdirSync,
   statJob = defaultStatJob,
   readEpoch = defaultReadRuntimeEpoch,
-  orchDir = undefined,                       // CTL-701: enables exec-core epoch
+  orchDir = undefined, // CTL-701: enables exec-core epoch
   readExecCoreEpoch = readExecCoreBootEpoch, // CTL-701: injectable seam
 } = {}) {
   const { epoch: runtimeEpoch, epochSource: runtimeSource } = readEpoch();
@@ -1807,7 +1867,7 @@ export function reclaimDeadWorkIfPossible(
     // The intentDb is obtained from beliefs.db (CATALYST_BELIEFS_SHADOW=1 gate);
     // it is threaded in from the scheduler's reclaimOpts alongside fetchState/cache.
     intentDb = null,
-  } = {},
+  } = {}
 ) {
   const klass = classifyWorker(signal, { statJob });
   // CTL-662: terminal (phase finished) and unknown (no bg_job_id) still
@@ -1820,7 +1880,10 @@ export function reclaimDeadWorkIfPossible(
   // comment. Neither reclaim nor escalate — the comment-wake path in daemon.mjs
   // handles re-dispatch. Treat as noop so the per-tick sweep never interferes.
   if (signal?.status === "needs-input") {
-    log.debug({ ticket: signal.ticket }, "reclaimDeadWork: skipping needs-input (parked for human)");
+    log.debug(
+      { ticket: signal.ticket },
+      "reclaimDeadWork: skipping needs-input (parked for human)"
+    );
     return "noop";
   }
 
@@ -1847,7 +1910,9 @@ export function reclaimDeadWorkIfPossible(
     try {
       const cfgRow = intentDb.query("SELECT value_int FROM cfg WHERE key = 'max_attempts'").get();
       if (typeof cfgRow?.value_int === "number") maxAttempts = cfgRow.value_int;
-    } catch { /* fall through — use default */ }
+    } catch {
+      /* fall through — use default */
+    }
 
     // Enforce: suppress kill when the intent has already gone ineffective.
     if ((process.env.CATALYST_INTENTS_ENFORCE ?? "0") === "1") {
@@ -1858,13 +1923,13 @@ export function reclaimDeadWorkIfPossible(
               WHERE kind = 'kill' AND subject = ?
                 AND (outcome = 'ineffective'
                   OR (outcome IS NULL AND attempts >= ?))
-              LIMIT 1`,
+              LIMIT 1`
           )
           .get(subject, maxAttempts);
         if (ineffective) {
           log.warn(
             { ticket, phase, bgJobId: killBgJobId, subject },
-            "ctl-936: kill intent ineffective — skipping claude stop (stop-storm prevention)",
+            "ctl-936: kill intent ineffective — skipping claude stop (stop-storm prevention)"
           );
           return;
         }
@@ -1876,10 +1941,14 @@ export function reclaimDeadWorkIfPossible(
     // Record the intent if not already open.
     try {
       const open = intentDb
-        .query("SELECT 1 FROM intent WHERE kind = 'kill' AND subject = ? AND outcome IS NULL LIMIT 1")
+        .query(
+          "SELECT 1 FROM intent WHERE kind = 'kill' AND subject = ? AND outcome IS NULL LIMIT 1"
+        )
         .get(subject);
       if (!open) {
-        const tickRow = intentDb.query("SELECT tick_id FROM tick ORDER BY tick_id DESC LIMIT 1").get();
+        const tickRow = intentDb
+          .query("SELECT tick_id FROM tick ORDER BY tick_id DESC LIMIT 1")
+          .get();
         if (tickRow) {
           // CTL-936 H1: pin bgJobId so resolvePostcondition can distinguish
           // the targeted session from a newly-revived worker on the same
@@ -1888,12 +1957,24 @@ export function reclaimDeadWorkIfPossible(
           intentDb.run(
             `INSERT INTO intent (tick_id, kind, subject, belief_id, postcondition, attempts, outcome)
              VALUES (?, 'kill', ?, NULL, ?, 0, NULL)`,
-            [tickRow.tick_id, subject, JSON.stringify({ kind: "kill", subject, bgJobId: killBgJobId, sessionNotRegistered: true })],
+            [
+              tickRow.tick_id,
+              subject,
+              JSON.stringify({
+                kind: "kill",
+                subject,
+                bgJobId: killBgJobId,
+                sessionNotRegistered: true,
+              }),
+            ]
           );
         }
       }
     } catch (err) {
-      log.warn({ err: err?.message, ticket, phase }, "ctl-936: recordIntent threw — continuing kill");
+      log.warn(
+        { err: err?.message, ticket, phase },
+        "ctl-936: recordIntent threw — continuing kill"
+      );
     }
     killBgJob({ bgJobId: killBgJobId });
   }
@@ -1956,10 +2037,7 @@ export function reclaimDeadWorkIfPossible(
     // so a genuine escalation re-fires cleanly once the breaker closes). A
     // transient 429 is not a human-intervention condition.
     if (breaker.isOpen(now())) {
-      log.warn(
-        { ticket, phase, reason },
-        "ctl-679: escalation deferred — Linear breaker open"
-      );
+      log.warn({ ticket, phase, reason }, "ctl-679: escalation deferred — Linear breaker open");
       return "rate-limited-deferred";
     }
     if (inEscalationCooldownFn(orchDir, ticket, phase, now())) {
@@ -1971,36 +2049,45 @@ export function reclaimDeadWorkIfPossible(
     const escType = reasonToType(reason);
     const whyField = reasonToWhyField(reason, finalAttemptCount);
     let explanation;
-    const explanationFields = escType === "manual"
-      ? {
-          escalation_type: "manual",
-          problem: `${phase} escalated after ${finalAttemptCount} attempt(s): ${reason}`,
-          call_to_action: extras?.call_to_action ?? `grant the required capability and re-run ${ticket} ${phase}, or push manually?`,
-          blocked_capability: extras?.blockedCapability ?? "required OAuth scope or credential unavailable",
-          instructions: extras?.instructions ?? ["check CATALYST_WORKFLOW_GITHUB_TOKEN"],
-          remediation_then_retry: `re-run ${ticket} ${phase} after granting the capability`,
-          why_not_auto: whyField.value,
-          observed: { final_attempt_count: finalAttemptCount, ...(extras?.observed ?? {}) },
-          attempts: extras?.attempts ?? [],
-        }
-      : {
-          escalation_type: "authorization",
-          problem: `${phase} escalated after ${finalAttemptCount} attempt(s): ${reason}`,
-          call_to_action: extras?.call_to_action ?? `authorize ${ticket} ${phase} to retry or change approach?`,
-          recommendation: `retry ${ticket} ${phase} after investigating ${reason}`,
-          risk: `continued retries risk wasting budget; ${finalAttemptCount} attempt(s) already made`,
-          why_asking: whyField.value,
-          could_higher_tier_resolve: tierProducer(extras?.model ?? signal?.raw?.model),
-          authorize_label: `retry ${ticket} ${phase}`,
-          observed: { final_attempt_count: finalAttemptCount, ...(extras?.observed ?? {}) },
-          attempts: extras?.attempts ?? [],
-        };
+    const explanationFields =
+      escType === "manual"
+        ? {
+            escalation_type: "manual",
+            problem: `${phase} escalated after ${finalAttemptCount} attempt(s): ${reason}`,
+            call_to_action:
+              extras?.call_to_action ??
+              `grant the required capability and re-run ${ticket} ${phase}, or push manually?`,
+            blocked_capability:
+              extras?.blockedCapability ?? "required OAuth scope or credential unavailable",
+            instructions: extras?.instructions ?? ["check CATALYST_WORKFLOW_GITHUB_TOKEN"],
+            remediation_then_retry: `re-run ${ticket} ${phase} after granting the capability`,
+            why_not_auto: whyField.value,
+            observed: { final_attempt_count: finalAttemptCount, ...(extras?.observed ?? {}) },
+            attempts: extras?.attempts ?? [],
+          }
+        : {
+            escalation_type: "authorization",
+            problem: `${phase} escalated after ${finalAttemptCount} attempt(s): ${reason}`,
+            call_to_action:
+              extras?.call_to_action ?? `authorize ${ticket} ${phase} to retry or change approach?`,
+            recommendation: `retry ${ticket} ${phase} after investigating ${reason}`,
+            risk: `continued retries risk wasting budget; ${finalAttemptCount} attempt(s) already made`,
+            why_asking: whyField.value,
+            could_higher_tier_resolve: tierProducer(extras?.model ?? signal?.raw?.model),
+            authorize_label: `retry ${ticket} ${phase}`,
+            observed: { final_attempt_count: finalAttemptCount, ...(extras?.observed ?? {}) },
+            attempts: extras?.attempts ?? [],
+          };
     try {
       explanation = buildExplanation(explanationFields);
     } catch {
       // CTL-1130: degrade with the full assembled fields (not just { problem })
       // so observed/recommendation/risk (or the manual capability fields) survive.
-      explanation = coerceExplanation(explanationFields, { ticket, phase, canExecute: escType !== "manual" });
+      explanation = coerceExplanation(explanationFields, {
+        ticket,
+        phase,
+        canExecute: escType !== "manual",
+      });
     }
     const enrichedExtras = { ...(extras ?? {}), explanation };
     appendEscalatedEvent({
@@ -2062,12 +2149,12 @@ export function reclaimDeadWorkIfPossible(
     if (sc.code !== 0) {
       log.warn(
         { ticket, phase, code: sc.code, stderr: sc.stderr, reason: terminalCheck.reason },
-        "ctl-642: terminal short-circuit emit-complete failed; falling through to lifecycle path (retry next tick)",
+        "ctl-642: terminal short-circuit emit-complete failed; falling through to lifecycle path (retry next tick)"
       );
     } else {
       log.info(
         { ticket, phase, reason: terminalCheck.reason },
-        "ctl-642: terminal short-circuit — ticket already terminal/merged, signal flipped to done (no escalation)",
+        "ctl-642: terminal short-circuit — ticket already terminal/merged, signal flipped to done (no escalation)"
       );
       return "terminal-short-circuit";
     }
@@ -2137,7 +2224,7 @@ export function reclaimDeadWorkIfPossible(
       if (r.code !== 0) {
         log.warn(
           { ticket, phase, code: r.code, stderr: r.stderr },
-          "ctl-778 alive-probe-reclaim: emit-complete failed; will retry next tick",
+          "ctl-778 alive-probe-reclaim: emit-complete failed; will retry next tick"
         );
         return "reclaim-failed";
       }
@@ -2149,7 +2236,10 @@ export function reclaimDeadWorkIfPossible(
         probeChecked: describeProbe(phase),
         reclaimedBgJobId: prevBgJobId,
       });
-      log.info({ ticket, phase }, "ctl-778: alive-but-idle worker reclaimed (complete event + probe)");
+      log.info(
+        { ticket, phase },
+        "ctl-778: alive-but-idle worker reclaimed (complete event + probe)"
+      );
       return "reclaimed";
     }
 
@@ -2171,11 +2261,7 @@ export function reclaimDeadWorkIfPossible(
     // committed work is never touched here (existing paths own it). Dead
     // workers never reach this branch (lifecycle === "alive" only), and a
     // worker WITH a transcript falls through untouched.
-    if (
-      prevBgJobId &&
-      Number.isFinite(startedAtMs) &&
-      now() - startedAtMs > neverStartedMs
-    ) {
+    if (prevBgJobId && Number.isFinite(startedAtMs) && now() - startedAtMs > neverStartedMs) {
       let wedgeShortId = null;
       try {
         wedgeShortId = shortIdFromSessionId(prevBgJobId);
@@ -2229,8 +2315,17 @@ export function reclaimDeadWorkIfPossible(
                 }).catch(() => {});
                 intentAwareKill({ bgJobId: prevBgJobId });
                 log.warn(
-                  { ticket, phase, prevBgJobId, attempts: attempts.count, exhaustedProgress, tempo: jobStat?.tempo, detail: jobStat?.detail, needs: jobStat?.needs },
-                  "ctl-932: wedged-never-started replacement budget exhausted — escalating needs-human (not looping)",
+                  {
+                    ticket,
+                    phase,
+                    prevBgJobId,
+                    attempts: attempts.count,
+                    exhaustedProgress,
+                    tempo: jobStat?.tempo,
+                    detail: jobStat?.detail,
+                    needs: jobStat?.needs,
+                  },
+                  "ctl-932: wedged-never-started replacement budget exhausted — escalating needs-human (not looping)"
                 );
                 return escalateOnce("wedged-never-started-exhausted", attempts.count, {
                   bg_job_id: prevBgJobId,
@@ -2268,16 +2363,31 @@ export function reclaimDeadWorkIfPossible(
                 reason: "ctl-932-wedged-never-started",
               }).catch(() => {});
               intentAwareKill({ bgJobId: prevBgJobId });
-              const dr = reviveDispatch({ orchDir, ticket, phase, resumeSession: null, attempt: attempt + 1 });
+              const dr = reviveDispatch({
+                orchDir,
+                ticket,
+                phase,
+                resumeSession: null,
+                attempt: attempt + 1,
+              });
               if (dr.code === 0) {
                 log.warn(
-                  { ticket, phase, prevBgJobId, attempt, ageMs: now() - startedAtMs, tempo: jobStat?.tempo, detail: jobStat?.detail, needs: jobStat?.needs },
-                  "ctl-932: wedged-never-started worker stopped and replaced (no transcript + agents blocked)",
+                  {
+                    ticket,
+                    phase,
+                    prevBgJobId,
+                    attempt,
+                    ageMs: now() - startedAtMs,
+                    tempo: jobStat?.tempo,
+                    detail: jobStat?.detail,
+                    needs: jobStat?.needs,
+                  },
+                  "ctl-932: wedged-never-started worker stopped and replaced (no transcript + agents blocked)"
                 );
               } else {
                 log.warn(
                   { ticket, phase, attempt, code: dr.code, stderr: dr.stderr },
-                  "ctl-932: wedged replacement dispatch failed; will retry next tick",
+                  "ctl-932: wedged replacement dispatch failed; will retry next tick"
                 );
               }
               return "wedged-redispatched";
@@ -2292,7 +2402,7 @@ export function reclaimDeadWorkIfPossible(
       if (!workDone) {
         log.warn(
           { ticket, phase, prevBgJobId, aliveForMs: now() - startedAtMs },
-          "ctl-736: alive worker past BUSY_CEILING_MS with no committed work — escalating (never silent reclaim)",
+          "ctl-736: alive worker past BUSY_CEILING_MS with no committed work — escalating (never silent reclaim)"
         );
         return escalateOnce("busy-ceiling-exceeded", 0);
       }
@@ -2331,7 +2441,7 @@ export function reclaimDeadWorkIfPossible(
             ghostAbsent = true;
             log.warn(
               { ticket, phase, prevBgJobId, snapshotAgeMs: snap.ageMs },
-              "ctl-809: jobLifecycle-alive but ABSENT from fresh claude-agents snapshot — treating as dead (ghost breaker)",
+              "ctl-809: jobLifecycle-alive but ABSENT from fresh claude-agents snapshot — treating as dead (ghost breaker)"
             );
           }
         } else {
@@ -2355,7 +2465,7 @@ export function reclaimDeadWorkIfPossible(
             ghostAbsent = true;
             log.warn(
               { ticket, phase, prevBgJobId, staleForMs: now() - job.mtimeMs, mtimeFloorMs },
-              "ctl-868: jobLifecycle-alive but state.json mtime stale beyond zombie floor (no fresh agents snapshot) — treating as dead (zombie breaker)",
+              "ctl-868: jobLifecycle-alive but state.json mtime stale beyond zombie floor (no fresh agents snapshot) — treating as dead (zombie breaker)"
             );
           }
         }
@@ -2365,8 +2475,15 @@ export function reclaimDeadWorkIfPossible(
       // CTL-932: surface the supervisor's self-report (tempo/detail/needs) —
       // the fields that contained the 2026-06-09 diagnosis but were never read.
       log.info(
-        { ticket, phase, prevBgJobId, tempo: jobStat?.tempo, detail: jobStat?.detail, needs: jobStat?.needs },
-        "ctl-736: alive worker — reclaim suppressed",
+        {
+          ticket,
+          phase,
+          prevBgJobId,
+          tempo: jobStat?.tempo,
+          detail: jobStat?.detail,
+          needs: jobStat?.needs,
+        },
+        "ctl-736: alive worker — reclaim suppressed"
       );
       return "alive-suppressed";
     }
@@ -2489,7 +2606,7 @@ export function reclaimDeadWorkIfPossible(
     if (r.code !== 0) {
       log.warn(
         { ticket, phase, code: r.code, stderr: r.stderr },
-        "reclaim-dead-work: emit-complete failed; will retry next tick",
+        "reclaim-dead-work: emit-complete failed; will retry next tick"
       );
       return "reclaim-failed";
     }
@@ -2545,12 +2662,12 @@ export function reclaimDeadWorkIfPossible(
   // A signal with no parseable timestamp (legacy) falls through unchanged.
   const lastActiveMs = Math.max(
     Date.parse(signal.raw?.updatedAt ?? "") || 0,
-    Date.parse(signal.raw?.startedAt ?? "") || 0,
+    Date.parse(signal.raw?.startedAt ?? "") || 0
   );
   if (lastActiveMs > 0 && now() - lastActiveMs > reviveMaxAgeMs) {
     log.info(
       { ticket, phase, prevBgJobId, ageMs: now() - lastActiveMs, reviveMaxAgeMs },
-      "ctl-735: signal too old to revive — abandoned historical dir, inert",
+      "ctl-735: signal too old to revive — abandoned historical dir, inert"
     );
     return "inert-stale";
   }
@@ -2594,7 +2711,7 @@ export function reclaimDeadWorkIfPossible(
     }
     log.warn(
       { ticket, phase, prevBgJobId, currentProgress, lastProgress },
-      "ctl-736: no forward progress since last attempt — stopping, not respawning",
+      "ctl-736: no forward progress since last attempt — stopping, not respawning"
     );
     // needs-human (cool-down + breaker guarded). When the Linear breaker is open
     // the escalation defers — surface that so the scheduler does not record a
@@ -2626,10 +2743,7 @@ export function reclaimDeadWorkIfPossible(
   // defensive kill + fresh dispatch. Resolving here (after the budget/storm gates
   // pass) means only an actually-reviving worker pays the one state.json read.
   const resumeSession = prevBgJobId ? resolveSession(prevBgJobId) : null;
-  log.info(
-    { ticket, phase, prevBgJobId, resumeSession },
-    "ctl-658: revive resume id resolved",
-  );
+  log.info({ ticket, phase, prevBgJobId, resumeSession }, "ctl-658: revive resume id resolved");
 
   // Defensive stop: the worker is reclaim-eligible (absent or idle-confirmed),
   // so we stop it to free RAM and release any worktree lock before re-dispatch.
@@ -2681,7 +2795,7 @@ export function reclaimDeadWorkIfPossible(
   if (eventLanded === false) {
     log.error(
       { ticket, phase, attempt },
-      "ctl-587: revive event append failed — aborting dispatch to preserve budget counter (will retry next tick)",
+      "ctl-587: revive event append failed — aborting dispatch to preserve budget counter (will retry next tick)"
     );
     // Best-effort suppression audit so operators see SOMETHING in events.jsonl
     // (if the audit log is writeable for this kind even though the revive
@@ -2700,7 +2814,13 @@ export function reclaimDeadWorkIfPossible(
   // CTL-761: forward the DISPATCH ordinal (= revive ordinal + 1; cold=1, first
   // revive=2) so the revived worker's terminal event carries phase.attempt /
   // phase.revive_count. `attempt` here is the revive ordinal (priorRevives+1).
-  const dispatchRes = reviveDispatch({ orchDir, ticket, phase, resumeSession, attempt: attempt + 1 });
+  const dispatchRes = reviveDispatch({
+    orchDir,
+    ticket,
+    phase,
+    resumeSession,
+    attempt: attempt + 1,
+  });
   if (dispatchRes.code === 0) {
     writeReviveMarker({ orchDir, ticket, attempt });
     log.info({ ticket, phase, attempt }, "ctl-587: revived");
@@ -2710,7 +2830,7 @@ export function reclaimDeadWorkIfPossible(
     // revives" record (audit-vs-marker drift is fine: the event is the truth).
     log.warn(
       { ticket, phase, attempt, code: dispatchRes.code, stderr: dispatchRes.stderr },
-      "ctl-587: revive dispatch failed; will retry next tick",
+      "ctl-587: revive dispatch failed; will retry next tick"
     );
   }
   return "revived";
@@ -2797,8 +2917,7 @@ export function readClusterHeartbeats({
         continue; // partial/garbage line
       }
       if (evt?.attributes?.["event.name"] !== HEARTBEAT_EVENT) continue;
-      const host =
-        evt?.body?.payload?.["host.name"] ?? evt?.resource?.["host.name"];
+      const host = evt?.body?.payload?.["host.name"] ?? evt?.resource?.["host.name"];
       const ts = evt?.ts;
       if (typeof host !== "string" || host.length === 0) continue;
       if (typeof ts !== "string" || ts.length === 0) continue;
@@ -2845,7 +2964,7 @@ export function readClusterHeartbeats({
 export function phaseAlreadyComplete(
   ticket,
   phase,
-  { readLog = () => readFileSync(getEventLogPath(), "utf8") } = {},
+  { readLog = () => readFileSync(getEventLogPath(), "utf8") } = {}
 ) {
   const needle = `phase.${phase}.complete.${ticket}`;
   let raw;
@@ -2916,11 +3035,14 @@ export async function inferResumePhase(ticket, { probes = WORK_DONE_PROBES, cwd 
 // Fallback: scan the local worker signal directory for non-terminal signals
 // dispatched from the dead host (the original local-only behavior, unchanged).
 // `anchorIssue`/`readPeers` are injectable for unit tests.
-function defaultOwnedTicketsForHost(deadHost, {
-  orchDir,
-  anchorIssue = getLivenessAnchorIssue(),
-  readPeers = (anchor) => readPeerHeartbeatsSync({ anchorIssue: anchor }),
-} = {}) {
+function defaultOwnedTicketsForHost(
+  deadHost,
+  {
+    orchDir,
+    anchorIssue = getLivenessAnchorIssue(),
+    readPeers = (anchor) => readPeerHeartbeatsSync({ anchorIssue: anchor }),
+  } = {}
+) {
   if (anchorIssue) {
     try {
       const peerMap = readPeers(anchorIssue);
@@ -2928,7 +3050,9 @@ function defaultOwnedTicketsForHost(deadHost, {
       if (Array.isArray(rec?.in_flight_tickets) && rec.in_flight_tickets.length > 0) {
         return [...new Set(rec.in_flight_tickets)];
       }
-    } catch { /* fail-open → local scan */ }
+    } catch {
+      /* fail-open → local scan */
+    }
   }
   // Fallback: local signal scan (original behavior; also runs when anchor unset).
   const signals = readWorkerSignals(orchDir);
@@ -2974,7 +3098,7 @@ export async function reclaimDeadHostWork(
     thoughtsPull = (cwd) => defaultThoughtsPull(cwd),
     dispatch = (od, ticket, phase, cwd) =>
       dispatchTicket(od, ticket, phase, { dispatch: defaultDispatch }),
-  } = {},
+  } = {}
 ) {
   const taken = [];
 
@@ -3005,7 +3129,11 @@ export async function reclaimDeadHostWork(
       // takeover host sees the dead host's pushed research/plan docs.
       // Fail-open: a failed pull must not abort reclaim (worst case the probe
       // re-dispatches, the prior behavior).
-      try { thoughtsPull(wt.cwd); } catch { /* fail-open */ }
+      try {
+        thoughtsPull(wt.cwd);
+      } catch {
+        /* fail-open */
+      }
 
       // Infer the next phase to dispatch from durable artifacts.
       const phase = await inferResume(ticket, wt.cwd);

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -79,6 +79,7 @@ import {
   labelOnce,
   inEscalationCooldown as defaultInEscalationCooldown,
   recordEscalation as defaultRecordEscalation,
+  labelNeedsHumanUnlessBeliefOwner,
 } from "./label-guard.mjs";
 import { countReviveEvents as defaultCountReviveEvents, hasCompleteEvent } from "./event-scan.mjs";
 
@@ -1278,7 +1279,11 @@ export function defaultReviveDispatch(
 //     the audit-event + label-call pair entirely so the scheduler's own
 //     event-log fast path stops self-feeding.
 function defaultApplyStalledLabel({ orchDir, ticket }) {
-  return labelOnce(orchDir, ticket, "needs-human", { applyLabel: defaultApplyLabel });
+  return labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, { applyLabel: defaultApplyLabel }, {
+    env: process.env,
+    site: "recovery-stalled",
+    log: { info: () => {} },
+  });
 }
 
 // defaultKillBgJob — terminate a dead/abandoned bg worker (CTL-657). Pre-CTL-657

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2756,6 +2756,13 @@ export function schedulerTick(
     // creates workers/<ticket>/) inject `() => new Set()` so the seeded ticket
     // is not excluded from Pass 2 by dir-existence before the guard fires.
     listStartedTickets: listStartedTicketsOpt = undefined,
+    // CTL-1241: env binding for the three labelNeedsHumanUnlessBeliefOwner
+    // escalation sites (dependency-cycle 3825, ctl-925-cycle 4530, terminal-sweep
+    // 4913). Mirrors maybeEscalateDispatchFailures' `env = process.env` so the
+    // belief-owner guard is injectable for tests; without it schedulerTick threw
+    // `ReferenceError: env is not defined` and aborted the whole tick on any
+    // escalation branch.
+    env = process.env,
   } = {}
 ) {
   // CTL-850: resolve this host + the cluster roster ONCE per tick (cheap

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -247,7 +247,7 @@ import { isLinearTerminal, isTicketTerminalOrMerged } from "./terminal-state.mjs
 // labelOnce here would force recovery.mjs → scheduler.mjs to import it, but
 // scheduler.mjs already imports reclaimDeadWorkIfPossible from recovery.mjs —
 // a cycle. label-guard.mjs is the leaf module both can import.
-import { labelOnce, clearStalledLabel } from "./label-guard.mjs";
+import { labelOnce, clearStalledLabel, labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs";
 import { processApprovedResumes } from "./boot-resume.mjs"; // CTL-644: per-tick approval poll
 import { countReapOutcomes } from "./reaper-metrics.mjs";
 import {
@@ -1843,9 +1843,9 @@ export function gcDispatchCooldowns(orchDir, eligibleIdentifiers, now) {
 // CTL-713: consecutive-failure escalation. When a (ticket,phase) has failed N
 // times in a row with the same code, apply needs-human via labelOnce and emit
 // cooldown-escalated. labelOnce's .applied marker makes this idempotent.
-export function maybeEscalateDispatchFailures(orchDir, marker, { writeStatus, appendEvent }) {
+export function maybeEscalateDispatchFailures(orchDir, marker, { writeStatus, appendEvent, env = process.env } = {}) {
   if (!marker || marker.consecutiveFailures < DISPATCH_FAILURE_ESCALATION_THRESHOLD) return;
-  labelOnce(orchDir, marker.ticket, "needs-human", writeStatus);
+  labelNeedsHumanUnlessBeliefOwner(orchDir, marker.ticket, writeStatus, { env, site: "dispatch-failures", log });
   appendEvent({
     ticket: marker.ticket,
     orchId: marker.ticket,
@@ -3822,7 +3822,7 @@ export function schedulerTick(
           if (triagedWaiting.includes(member)) {
             cycleMembers.add(member);
             if (fenceGuard({ ticket: member, orchDir, multiHost })) {
-              labelOnce(orchDir, member, "needs-human", writeStatus);
+              labelNeedsHumanUnlessBeliefOwner(orchDir, member, writeStatus, { env, site: "dependency-cycle", log });
             } else {
               log.warn(
                 { ticket: member },
@@ -4527,7 +4527,7 @@ export function schedulerTick(
           // CTL-863 fence: external Linear write — a zombie host that lost its
           // claim must not label after takeover (mirrors the A.5 cycle site).
           if (fenceGuard({ ticket: member, orchDir, multiHost })) {
-            labelOnce(orchDir, member, "needs-human", writeStatus);
+            labelNeedsHumanUnlessBeliefOwner(orchDir, member, writeStatus, { env, site: "ctl-925-cycle", log });
           }
         }
       }
@@ -4910,7 +4910,7 @@ export function schedulerTick(
     const pipelineDone = signals[TERMINAL_PHASE] === "done";
     if ((anyStalled || anyFailed) && !pipelineDone) {
       if (fenceGuard({ ticket, orchDir, multiHost })) {
-        labelOnce(orchDir, ticket, "needs-human", writeStatus);
+        labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, writeStatus, { env, site: "terminal-sweep", log });
       } else {
         log.warn(
           { ticket },

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -81,7 +81,10 @@ import { getProjectConfig, listProjects } from "./registry.mjs";
 import { readWorkerSignals } from "./signal-reader.mjs";
 // CTL-933: shadow belief-store fact collector (opt-in CATALYST_BELIEFS_SHADOW=1).
 // CTL-937: getBeliefsDb exposes the module-level db handle for the diagnostician.
-import { collectBeliefsTick, getBeliefsDb } from "./beliefs/collector.mjs";
+// CTL-1241: getEscalateHumanBelief reads the latest escalate_human belief for the
+// recovery evidence attachment (revives the structurally-dead R12 branch).
+import { collectBeliefsTick, getBeliefsDb, getEscalateHumanBelief } from "./beliefs/collector.mjs";
+import { buildRecoveryItems } from "./recovery-evidence.mjs";
 // CTL-1045 Bug 1: kill-storm suppression guard for defaultJanitorKillIntentRecorder.
 import {
   isIntentEffective,
@@ -3440,7 +3443,7 @@ export function schedulerTick(
     const rMode = _recoveryPassMode ?? rcfg.mode;
     if (rMode !== "off") {
       try {
-        const rItems = readWorkerSignals(orchDir)
+        const rSigs = readWorkerSignals(orchDir)
           .filter(
             (sig) =>
               sig.status === "needs-human" ||
@@ -3469,16 +3472,15 @@ export function schedulerTick(
                 cache,
                 fetchState: (id, o = {}) => fetchTicketState(id, { ...o, cache, gateway }),
               }).terminal
-          )
-          .map((sig) => ({
-            ticket: sig.ticket,
-            phase: sig.phase,
-            // CTL-1176: thread the worker's bg_job_id so the recovery pass's
-            // DIAGNOSE step can capture `claude logs` evidence read-only when the
-            // signal didn't already carry logsOutput.
-            bgJobId: sig.raw?.bg_job_id ?? null,
-            evidence: sig.raw ?? {},
-          }));
+          );
+        // CTL-1241: buildRecoveryItems attaches the current-tick escalate_human
+        // belief (if any) as evidence.beliefState so the structurally-dead R12
+        // branch in recovery-reasoning.mjs is revived.
+        // getBeliefsDb() returns null when beliefs are disabled → no query.
+        const rItems = buildRecoveryItems(rSigs, {
+          db: getBeliefsDb(),
+          getBeliefs: getEscalateHumanBelief,
+        });
         if (rItems.length > 0) {
           // CTL-1176: BIND the host-local ledger + act-seams to THIS tick's real
           // orchDir. Without this the defaults call resolveOrchDir() →

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -20,7 +20,7 @@ import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { jobLifecycle } from "./recovery.mjs";
-import { labelOnce } from "./label-guard.mjs";
+import { labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs";
 import { fenceGuard } from "./fence-guard.mjs";
 import { appendFileSync } from "node:fs";
 import { log, getEventLogPath, getClusterHosts } from "./config.mjs";
@@ -285,10 +285,10 @@ function defaultDispatchRescue(ticket, opts) {
 // linearWrite defaults to the real linear-write module at the
 // startStalePrRescueTimer boundary; a null here means a caller explicitly
 // opted out, which leaves the ticket invisible to humans — say so loudly.
-export function defaultEscalate(ticket, detail, { orchDir, linearWrite, multiHost = false }) {
+export function defaultEscalate(ticket, detail, { orchDir, linearWrite, multiHost = false, env = process.env } = {}) {
   if (linearWrite) {
     if (fenceGuard({ ticket, orchDir, multiHost })) {
-      labelOnce(orchDir, ticket, "needs-human", linearWrite);
+      labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, linearWrite, { env, site: "stale-pr-rescue", log });
     } else {
       log.warn({ ticket }, "ctl-863: stale fence — suppressing stale-pr-rescue labelOnce write (zombie guard)");
     }

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -35,9 +35,7 @@ import * as linearWriteDefault from "./linear-write.mjs";
 // is the real linear-write transport (not null).
 export const defaultLinearWrite = linearWriteDefault;
 
-const ORCHESTRATE_REBASE_BIN = fileURLToPath(
-  new URL("../orchestrate-rebase", import.meta.url)
-);
+const ORCHESTRATE_REBASE_BIN = fileURLToPath(new URL("../orchestrate-rebase", import.meta.url));
 const RESCUE_PROMPT_TEMPLATE = fileURLToPath(
   new URL("../templates/rescue-rebase-prompt.md", import.meta.url)
 );
@@ -96,7 +94,9 @@ function readTicketPr(orchDir, ticket) {
       if (raw?.pr?.number && !prInfo) prInfo = raw.pr;
       if (raw?.worktreePath && !worktreePath) worktreePath = raw.worktreePath;
       if (raw?.orchestrator && !orchestrator) orchestrator = raw.orchestrator;
-    } catch { /* absent or unreadable */ }
+    } catch {
+      /* absent or unreadable */
+    }
   }
 
   if (!prInfo?.number) return null;
@@ -116,7 +116,9 @@ function anyPhaseJobAlive(orchDir, ticket, jobLifecycleFn) {
   let names;
   try {
     names = readdirSync(dir);
-  } catch { return false; }
+  } catch {
+    return false;
+  }
 
   for (const name of names) {
     if (!name.startsWith("phase-") || !name.endsWith(".json")) continue;
@@ -124,7 +126,9 @@ function anyPhaseJobAlive(orchDir, ticket, jobLifecycleFn) {
     try {
       const raw = JSON.parse(readFileSync(join(dir, name), "utf8"));
       if (raw?.bg_job_id && jobLifecycleFn(raw.bg_job_id) === "alive") return true;
-    } catch { /* skip */ }
+    } catch {
+      /* skip */
+    }
   }
   return false;
 }
@@ -140,7 +144,9 @@ function readRescueState(orchDir, ticket) {
   let raw;
   try {
     raw = readFileSync(path, "utf8");
-  } catch { return {}; } // ENOENT (or unreadable): treat as no prior state
+  } catch {
+    return {};
+  } // ENOENT (or unreadable): treat as no prior state
   try {
     return JSON.parse(raw);
   } catch (err) {
@@ -168,8 +174,15 @@ function writeRescueState(orchDir, ticket, state) {
 async function defaultPrView(slug, prNumber) {
   const res = spawnSync(
     "gh",
-    ["pr", "view", String(prNumber), "--repo", slug,
-      "--json", "state,mergeStateStatus,baseRefName,headRefName"],
+    [
+      "pr",
+      "view",
+      String(prNumber),
+      "--repo",
+      slug,
+      "--json",
+      "state,mergeStateStatus,baseRefName,headRefName",
+    ],
     { encoding: "utf8", timeout: 15_000 }
   );
   if (res.status !== 0) throw new Error(res.stderr || "gh pr view failed");
@@ -212,11 +225,10 @@ async function defaultCompareBehind(slug, base, head) {
 // against a stale origin/<base>.
 // Exported for the real-git integration test.
 export async function defaultMergeTree(worktreePath, base, head) {
-  const fetchRes = spawnSync(
-    "git",
-    ["-C", worktreePath, "fetch", "origin", base, head],
-    { encoding: "utf8", timeout: 30_000 }
-  );
+  const fetchRes = spawnSync("git", ["-C", worktreePath, "fetch", "origin", base, head], {
+    encoding: "utf8",
+    timeout: 30_000,
+  });
   if (fetchRes.status !== 0) {
     throw new Error(
       `git fetch origin ${base} ${head} failed (exit ${fetchRes.status}): ${fetchRes.stderr ?? ""}`
@@ -239,17 +251,27 @@ function defaultWorktreeExists(worktreePath) {
 // dispatch. Exported so a unit test can assert the arg vector carries a
 // non-empty --orch (orchestrate-rebase hard-exits on an empty one) without
 // spawning anything (verify finding, CTL-782).
-export function buildRescueDispatchArgs(ticket, { prNumber, orchId, orchDir, worktreePath, base, signalFile, headRef }) {
+export function buildRescueDispatchArgs(
+  ticket,
+  { prNumber, orchId, orchDir, worktreePath, base, signalFile, headRef }
+) {
   const args = [
     ORCHESTRATE_REBASE_BIN,
     ticket,
-    "--pr", String(prNumber),
-    "--orch", orchId,
-    "--orch-dir", orchDir,
-    "--worker-dir", worktreePath,
-    "--base-branch", base,
-    "--signal-file", signalFile,
-    "--prompt-template", RESCUE_PROMPT_TEMPLATE,
+    "--pr",
+    String(prNumber),
+    "--orch",
+    orchId,
+    "--orch-dir",
+    orchDir,
+    "--worker-dir",
+    worktreePath,
+    "--base-branch",
+    base,
+    "--signal-file",
+    signalFile,
+    "--prompt-template",
+    RESCUE_PROMPT_TEMPLATE,
   ];
   // PR head branch: execution-core branches are just <TICKET>, while
   // orchestrate-rebase's legacy default is <orch>-<TICKET> — without this
@@ -285,12 +307,23 @@ function defaultDispatchRescue(ticket, opts) {
 // linearWrite defaults to the real linear-write module at the
 // startStalePrRescueTimer boundary; a null here means a caller explicitly
 // opted out, which leaves the ticket invisible to humans — say so loudly.
-export function defaultEscalate(ticket, detail, { orchDir, linearWrite, multiHost = false, env = process.env } = {}) {
+export function defaultEscalate(
+  ticket,
+  detail,
+  { orchDir, linearWrite, multiHost = false, env = process.env } = {}
+) {
   if (linearWrite) {
     if (fenceGuard({ ticket, orchDir, multiHost })) {
-      labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, linearWrite, { env, site: "stale-pr-rescue", log });
+      labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, linearWrite, {
+        env,
+        site: "stale-pr-rescue",
+        log,
+      });
     } else {
-      log.warn({ ticket }, "ctl-863: stale fence — suppressing stale-pr-rescue labelOnce write (zombie guard)");
+      log.warn(
+        { ticket },
+        "ctl-863: stale fence — suppressing stale-pr-rescue labelOnce write (zombie guard)"
+      );
     }
   } else {
     log.warn(
@@ -298,10 +331,7 @@ export function defaultEscalate(ticket, detail, { orchDir, linearWrite, multiHos
       "stale-pr-rescue: no linearWrite transport — needs-human label NOT applied (log-only escalation)"
     );
   }
-  log.warn(
-    { ticket, ...detail },
-    "stale-pr-rescue: escalating to needs-human"
-  );
+  log.warn({ ticket, ...detail }, "stale-pr-rescue: escalating to needs-human");
 }
 
 // defaultEmit — append a bare event envelope to the event log.
@@ -310,7 +340,9 @@ function defaultEmit(name, payload) {
   try {
     const line = JSON.stringify({ name, ...payload, ts: new Date().toISOString() });
     appendFileSync(getEventLogPath(), line + "\n");
-  } catch { /* best-effort */ }
+  } catch {
+    /* best-effort */
+  }
 }
 
 /**
@@ -351,9 +383,19 @@ export function startStalePrRescueTimer({
   const handle = clock.setInterval(async () => {
     try {
       await runTick({
-        orchDir, orchId, cfg, linearWrite, multiHost,
-        jobLifecycleFn, prView, compareBehind, mergeTree,
-        worktreeExists, dispatchRescue, escalate, emit,
+        orchDir,
+        orchId,
+        cfg,
+        linearWrite,
+        multiHost,
+        jobLifecycleFn,
+        prView,
+        compareBehind,
+        mergeTree,
+        worktreeExists,
+        dispatchRescue,
+        escalate,
+        emit,
         nowMs: clock.now(),
       });
     } catch (err) {
@@ -366,23 +408,48 @@ export function startStalePrRescueTimer({
 }
 
 async function runTick({
-  orchDir, orchId, cfg, linearWrite, multiHost,
-  jobLifecycleFn, prView, compareBehind, mergeTree,
-  worktreeExists, dispatchRescue, escalate, emit, nowMs,
+  orchDir,
+  orchId,
+  cfg,
+  linearWrite,
+  multiHost,
+  jobLifecycleFn,
+  prView,
+  compareBehind,
+  mergeTree,
+  worktreeExists,
+  dispatchRescue,
+  escalate,
+  emit,
+  nowMs,
 }) {
   let ticketDirs;
   try {
     ticketDirs = readdirSync(join(orchDir, "workers"), { withFileTypes: true })
-      .filter(e => e.isDirectory())
-      .map(e => e.name);
-  } catch { return; }
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    return;
+  }
 
   for (const ticket of ticketDirs) {
     try {
       await processTicket({
-        ticket, orchDir, orchId, cfg, linearWrite, multiHost, nowMs,
-        jobLifecycleFn, prView, compareBehind, mergeTree,
-        worktreeExists, dispatchRescue, escalate, emit,
+        ticket,
+        orchDir,
+        orchId,
+        cfg,
+        linearWrite,
+        multiHost,
+        nowMs,
+        jobLifecycleFn,
+        prView,
+        compareBehind,
+        mergeTree,
+        worktreeExists,
+        dispatchRescue,
+        escalate,
+        emit,
       });
     } catch (err) {
       log.warn({ ticket, err: err.message }, "stale-pr-rescue: per-ticket error, continuing");
@@ -391,9 +458,21 @@ async function runTick({
 }
 
 async function processTicket({
-  ticket, orchDir, orchId, cfg, linearWrite, multiHost, nowMs,
-  jobLifecycleFn, prView, compareBehind, mergeTree,
-  worktreeExists, dispatchRescue, escalate, emit,
+  ticket,
+  orchDir,
+  orchId,
+  cfg,
+  linearWrite,
+  multiHost,
+  nowMs,
+  jobLifecycleFn,
+  prView,
+  compareBehind,
+  mergeTree,
+  worktreeExists,
+  dispatchRescue,
+  escalate,
+  emit,
 }) {
   // 1. Cheap skip: no PR info → nothing to rescue.
   const prInfo = readTicketPr(orchDir, ticket);
@@ -426,7 +505,9 @@ async function processTicket({
       let externalState = null;
       try {
         externalState = (await prView(slug, prInfo.number))?.state ?? null;
-      } catch { /* re-check unavailable — fall through to escalate */ }
+      } catch {
+        /* re-check unavailable — fall through to escalate */
+      }
       if (externalState === "MERGED" || externalState === "CLOSED") {
         log.info(
           { ticket, prState: externalState },
@@ -440,8 +521,15 @@ async function processTicket({
         return;
       }
     }
-    escalate(ticket, { reason: "rescue_worker_stalled", ...rescueState }, { orchDir, orchId: effectiveOrchId, linearWrite, multiHost });
-    writeRescueState(orchDir, ticket, { ...rescueState, escalatedAt: new Date(nowMs).toISOString() });
+    escalate(
+      ticket,
+      { reason: "rescue_worker_stalled", ...rescueState },
+      { orchDir, orchId: effectiveOrchId, linearWrite, multiHost }
+    );
+    writeRescueState(orchDir, ticket, {
+      ...rescueState,
+      escalatedAt: new Date(nowMs).toISOString(),
+    });
     emit(`phase.rescue.escalated.${ticket}`, { ticket, reason: "rescue_worker_stalled" });
     return;
   }
@@ -541,7 +629,10 @@ async function processTicket({
           lastDispatchAt: new Date(nowMs).toISOString(),
           lastDispatchError: result.error ?? "dispatch failed",
         });
-        emit(`phase.rescue.dispatch-failed.${ticket}`, { ticket, error: result.error ?? "dispatch failed" });
+        emit(`phase.rescue.dispatch-failed.${ticket}`, {
+          ticket,
+          error: result.error ?? "dispatch failed",
+        });
         return;
       }
       const newAttempts = (rescueState.rescueAttempts ?? 0) + 1;
@@ -556,7 +647,12 @@ async function processTicket({
     }
 
     case "escalate": {
-      escalate(ticket, decision.detail ?? {}, { orchDir, orchId: effectiveOrchId, linearWrite, multiHost });
+      escalate(ticket, decision.detail ?? {}, {
+        orchDir,
+        orchId: effectiveOrchId,
+        linearWrite,
+        multiHost,
+      });
       writeRescueState(orchDir, ticket, {
         ...rescueState,
         escalatedAt: new Date(nowMs).toISOString(),

--- a/plugins/dev/scripts/execution-core/watchdog-action.mjs
+++ b/plugins/dev/scripts/execution-core/watchdog-action.mjs
@@ -20,7 +20,7 @@ import { readFileSync, writeFileSync, renameSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { log } from "./config.mjs";
 import { emitReapIntent } from "./reap-intent.mjs";
-import { labelOnce, recordEscalation } from "./label-guard.mjs";
+import { labelNeedsHumanUnlessBeliefOwner, recordEscalation } from "./label-guard.mjs";
 import { buildExplanation, coerceExplanation, tierProducer } from "./escalation-explanation.mjs";
 
 const SETTLED = new Set(["done", "failed", "stalled", "aborted", "skipped", "complete"]);
@@ -52,6 +52,7 @@ export async function killHungWorker(
     writeStatus,
     emit = emitReapIntent,
     reviveDispatch,
+    env = process.env,
   } = {}
 ) {
   const phase = signal.phase;
@@ -152,7 +153,7 @@ export async function killHungWorker(
   }
 
   // (3) needs-human (idempotent via .applied marker) + escalation record.
-  labelOnce(orchDir, ticket, "needs-human", writeStatus);
+  labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, writeStatus, { env, site: "watchdog-kill", log });
   recordEscalation(orchDir, ticket, phase, failureReason, now());
 
   log.warn(

--- a/plugins/dev/scripts/execution-core/watchdog-action.mjs
+++ b/plugins/dev/scripts/execution-core/watchdog-action.mjs
@@ -153,7 +153,11 @@ export async function killHungWorker(
   }
 
   // (3) needs-human (idempotent via .applied marker) + escalation record.
-  labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, writeStatus, { env, site: "watchdog-kill", log });
+  labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, writeStatus, {
+    env,
+    site: "watchdog-kill",
+    log,
+  });
   recordEscalation(orchDir, ticket, phase, failureReason, now());
 
   log.warn(

--- a/plugins/dev/scripts/orch-monitor/lib/board-data-attention.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data-attention.test.mjs
@@ -64,3 +64,62 @@ describe("CTL-1131: deriveAttention projects needsHumanSince → attentionSince"
     expect(r).toEqual({ attention: "needs-human", attentionSince: null, escalationType: null });
   });
 });
+
+// ─── CTL-1241 Phase 3: board/recovery label agreement (regression pins) ───────
+//
+// Pins the contract that board.deriveAttention reads the same needs-human label
+// that executeEscalations (the R12 belief owner) applies. This is the source of
+// truth both surfaces share; a future producer change that diverges them would
+// break this test.
+describe("CTL-1241 — deriveAttention label agreement regression", () => {
+  it("ticket with needs-human label → board flags needsHuman (via labelNeedsHuman)", () => {
+    const r = deriveAttention({ labels: ["needs-human"] });
+    expect(r.attention).toBe("needs-human");
+  });
+
+  it("needs-human label alone is sufficient — phaseFailed and prStuck not required", () => {
+    const r = deriveAttention({
+      labels: ["needs-human"],
+      phaseFailed: false,
+      prStuck: false,
+      needsHumanMarker: false,
+    });
+    expect(r.attention).toBe("needs-human");
+  });
+
+  it("needs-human OUTRANKS waiting-on-you when both fire", () => {
+    const r = deriveAttention({ labels: ["needs-human"], waitingOnUser: true });
+    expect(r.attention).toBe("needs-human");
+  });
+
+  it("ticket WITHOUT needs-human label → board does NOT report needsHuman from label alone", () => {
+    const r = deriveAttention({
+      labels: [],
+      phaseFailed: false,
+      prStuck: false,
+      needsHumanMarker: false,
+    });
+    expect(r.attention).toBeNull();
+  });
+
+  it("cross-surface: recovery-escalated ticket (label applied) → board needsHuman true", () => {
+    // Simulate: recovery pass escalated ticket, executeEscalations applied the
+    // needs-human label. Board reads the label and reports needs-human — same
+    // source of truth as the recovery pass classification.
+    const boardResult = deriveAttention({ labels: ["needs-human"] });
+    expect(boardResult.attention).toBe("needs-human");
+  });
+
+  it("cross-surface: recovery FIX (no label applied) → board does NOT report needsHuman from label", () => {
+    // Simulate: recovery pass classified FIX — no needs-human label was applied.
+    // Board should NOT report needsHuman solely from a stale marker that was
+    // never applied (empty labels array, no marker).
+    const boardResult = deriveAttention({
+      labels: [],
+      needsHumanMarker: false,
+      phaseFailed: false,
+      prStuck: false,
+    });
+    expect(boardResult.attention).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-17T16:13:00Z -->
<!-- Last updated: 2026-06-17T16:13:00Z -->
<!-- PR: #2207 -->
<!-- Previous commits: aeb873c4,55cb5de5,2106e943,ed19543c,ac99880b -->

## Summary

The belief engine reconciles in shadow (`CATALYST_BELIEFS_SHADOW=1`, ~33k advance ticks/day) but the recovery pass never consumed it: `scheduler.mjs:3369-3377` set `evidence: sig.raw` only, so `evidence.beliefState` was structurally undefined and `determineEscalationReason`'s R12 branch (`recovery-reasoning.mjs:524-527`) was **dead in production**.

This PR wires beliefs into recovery evidence, makes `executeEscalations` (R12 / `escalate.mjs:130`) the **single owner** of the `needs-human` label, and adds cross-surface regression tests that pin both the board and recovery pass to the same label as the source of truth. All enforcement is behind `CATALYST_INTENTS_ENFORCE=1` (default OFF — behavior-neutral today).

## Changes Made

### Phase 1 — Wire belief state into recovery evidence
- Added `getEscalateHumanBelief(db, ticket)` to `beliefs/collector.mjs` — queries the most-recent `escalate_human` belief for a ticket (`ORDER BY tick_id DESC LIMIT 1`, `subject LIKE '<ticket>/%'` boundary), fail-open on null db or missing row.
- Extracted `buildRecoveryItems(signals, {db, getBeliefs})` into new `recovery-evidence.mjs` — pure injectable helper, decouples belief-attachment logic from scheduler for unit-testing.
- Wired into `scheduler.mjs`: replaces the inline `.map()` with `buildRecoveryItems`, passing `getBeliefsDb()` + `getEscalateHumanBelief`; the R12 branch in `determineEscalationReason` now fires when beliefs are enabled.
- Tests: `getEscalateHumanBelief` (null-handle, no-row, newest-wins, `/` boundary, malformed JSON); `buildRecoveryItems` (with/without belief, multi-signal, omitted `getBeliefs`, null raw); R12 reason text end-to-end.

### Phase 2 — Single needs-human owner guard
- Added `beliefOwnsNeedsHuman(env)` + `labelNeedsHumanUnlessBeliefOwner()` to `label-guard.mjs` as the shared deferral gate.
- All **6 non-belief `needs-human` producers** updated to route through the helper when `CATALYST_INTENTS_ENFORCE=1`:
  - `scheduler.mjs`: `maybeEscalateDispatchFailures`, dependency-cycle sweep, CTL-925 sweep-2, terminal sweep
  - `recovery.mjs`: `defaultApplyStalledLabel`
  - `watchdog-action.mjs`: `killHungWorker`
  - `stale-pr-rescue-timer.mjs`: `defaultEscalate`
- Enforcement OFF (default): byte-for-byte unchanged behavior.

### Phase 3 — Cross-surface label-agreement regression tests
- Added tests in `board-data-attention.test.mjs` pinning the agreed source of truth: both `deriveAttention` (board) and the recovery pass key off the same `needs-human` label written by `executeEscalations`. A future producer change that diverges them will break these tests.
- Covers: label-only attention, label sufficiency (no `phaseFailed`/`prStuck` required), label outranks `waiting-on-you`, absence of label → no flag, recovery-escalated → board `needsHuman=true`, recovery FIX (no label) → board does not flag.

### Fix — define env in schedulerTick scope
- Mirrored `maybeEscalateDispatchFailures`: added `env = process.env` to `schedulerTick`'s destructured options. Cleared 49 net-new bun-test failures that threw `ReferenceError: env is not defined` at the three label-guard call sites in `schedulerTick` (`dependency-cycle` ~3825, `ctl-925-cycle` ~4530, `terminal-sweep` ~4913).

## How to Verify It

- [x] Tests pass: all CTL-1241 modules green — `recovery-evidence`, `label-guard`, `collector` (107 tests), `board-data-attention` (16), R12 reasoning (3), `scheduler` (501), `recovery`/`stale-pr-rescue`/`watchdog` (327). 13 `recovery-reasoning` failures are pre-existing on `origin/main` (environmental, not a regression). ✅
- [x] Typecheck: skipped — pure `.mjs` JS project, no tsc configured ✅
- [x] Lint: no eslint config; prettier formatting cosmetically non-conforming at 4 new call sites in `scheduler.mjs`, matching pre-existing main state. Non-blocking. ✅
- [x] Security scan: no secrets/credentials in diff ✅
- [x] Reward-hacking scan: no forbidden patterns ✅
- [x] Silent-failure review: catch blocks are documented fail-open (`getEscalateHumanBelief`/`buildRecoveryItems`) — established codebase pattern ✅
- [x] Code review: behavior-neutral with `CATALYST_INTENTS_ENFORCE=0` (default + current env). `buildRecoveryItems` is equivalent to old map when beliefs disabled. `getEscalateHumanBelief` LIKE `<ticket>/%` boundary-safe. ✅
- [ ] Manual: flip `CATALYST_INTENTS_ENFORCE=1` + `CATALYST_DIAGNOSTICIAN=1` in a non-prod environment; verify recovery escalations cite belief state (R10/R11/R12) and that a single `needs-human` label write is observed per tick.

**Flags:** Code changes are behavior-neutral while `CATALYST_INTENTS_ENFORCE=0` (default). The enforcement flip is an operational step per the CTL-1241 rollout plan.

## Related Issues/PRs

- Fixes https://linear.app/issue/CTL-1241

Refs: CTL-1241

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-925
