### PR TITLE
fix(dev): CTL-1243 route source_conflict stall to bounded-LLM; add linearTerminal guard

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -175,4 +175,6 @@ jobs:
             work-done-probes.test.mjs \
             worktree-refresh-timer.test.mjs \
             worktree-safety.test.mjs \
-            worktree.test.mjs
+            worktree.test.mjs \
+            recovery-reasoning.test.mjs \
+            unstuck-act-seams.test.mjs

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -134,6 +134,13 @@ export function reasoningRecoveryPass(items, opts = {}) {
       continue;
     }
 
+    // CTL-1243: never post the give-up comment on tickets that are already terminal.
+    // Mirrors classifyStalledTicket's linearTerminal skip (unstuck-sweep.mjs:95-97).
+    if (item.evidence?.linearTerminal) {
+      log(`recovery-reasoning: ${item.ticket} skipped (linear-terminal)`);
+      continue;
+    }
+
     // DIAGNOSE: reuse diagnostician evidence. If the caller didn't attach
     // logsOutput, capture it read-only now (claude logs + bg job state). This is
     // a pure collector — no env gate, no side effects (CTL-937 captureEvidence).
@@ -461,6 +468,17 @@ export function checkBoundedLlmFixes(logsOutput, jobState, signal) {
   const logs = String(logsOutput || "").toLowerCase();
   const details = jobState?.detail || "";
   const signalFailure = signal?.failureReason || "";
+
+  // CTL-1243: stalled tickets carry stalledReason, not failureReason. The unstuck-sweep
+  // (STALL_CATEGORY_MAP) routes source_conflict_ctl708_unavailable to force-push-if-clean;
+  // the reasoning pass must classify it as a bounded-LLM FIX so it does NOT fall through
+  // to Rule 3 and post the legacy give-up comment on the same tick.
+  if (signal?.stalledReason === "source_conflict_ctl708_unavailable") {
+    return {
+      reason: "Source conflict (CTL-708 unavailable); agent should rebase and force-push-if-clean",
+      brief: generateRemediateBrief("merge-conflict"),
+    };
+  }
 
   // Bounded-LLM patterns: small fixes that are verifiable via one phase-remediate run.
   //

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -219,6 +219,17 @@ describe("checkBoundedLlmFixes", () => {
     const result = checkBoundedLlmFixes("mysterious error", null, {});
     expect(result).toBeNull();
   });
+
+  // CTL-1243: stalled tickets carry stalledReason, not failureReason
+  test("source_conflict stalledReason → bounded-LLM (not null)", () => {
+    const result = checkBoundedLlmFixes(
+      null,
+      null,
+      { stalledReason: "source_conflict_ctl708_unavailable" },
+    );
+    expect(result).not.toBeNull();
+    expect(result.brief).toContain("git rebase --continue");
+  });
 });
 
 describe("generateRemediateBrief", () => {
@@ -345,6 +356,17 @@ describe("defaultClassifyTicket", () => {
       logsOutput: "push rejected no workflow scope AND stale main",
     });
     expect(result.fix_class).toBe("push_rejected_no_workflow_scope");
+  });
+
+  // CTL-1243: source_conflict stall → decision:fix, fix_class:bounded-llm
+  test("defaultClassifyTicket: source_conflict stall → decision:fix, fix_class:bounded-llm", () => {
+    const result = defaultClassifyTicket({
+      logsOutput: null,
+      jobState: null,
+      signal: { stalledReason: "source_conflict_ctl708_unavailable" },
+    });
+    expect(result.decision).toBe("fix");
+    expect(result.fix_class).toBe("bounded-llm");
   });
 });
 
@@ -524,6 +546,34 @@ describe("reasoningRecoveryPass", () => {
     expect(comments[0]).toContain("CTL-1176 Diagnosis");
     expect(comments[0]).toContain("Decision:");
     expect(comments[0]).toContain("bounded-llm");
+  });
+
+  // CTL-1243: never post the give-up comment on tickets that are already terminal
+  test("linearTerminal:true item is skipped — no comment, no escalation", () => {
+    const posted = [];
+    const events = [];
+    const result = reasoningRecoveryPass(
+      [
+        {
+          ticket: "CTL-999",
+          phase: "implement",
+          evidence: {
+            linearTerminal: true,
+            signal: { stalledReason: "source_conflict_ctl708_unavailable" },
+          },
+        },
+      ],
+      {
+        mode: "enforce",
+        postComment: (t, body) => posted.push({ t, body }),
+        emitEvent: (event) => events.push(event),
+        recordIntent: () => {},
+        invokeRemediateCapped: () => ({ success: true, reason: "fixed", details: {} }),
+      },
+    );
+    expect(posted.length).toBe(0);
+    const r = result.results.find((r) => r.ticket === "CTL-999");
+    expect(r?.decision).not.toBe("escalate");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/unstuck-act-seams.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-act-seams.mjs
@@ -229,7 +229,7 @@ export function buildSourceConflictActSeam(deps = {}) {
       commitSubjects,
       headIsDescendant,
       liveSessionInWorktree: false,
-      linearTerminal: false,
+      linearTerminal: candidate.evidence?.linearTerminal ?? false,
       alreadyPushed: false,
     });
     if (decision.action !== "force-push") {

--- a/plugins/dev/scripts/execution-core/unstuck-act-seams.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-act-seams.test.mjs
@@ -358,6 +358,26 @@ describe("buildSourceConflictActSeam (CTL-1219)", () => {
     expect(gitCalls.some((a) => a.includes("push"))).toBe(false);
   });
 
+  // CTL-1243: hardcoded linearTerminal:false bypasses the guard in classifyCleanRebaseForcePush
+  test("buildSourceConflictActSeam honors candidate.evidence.linearTerminal", () => {
+    const gitCalls = [];
+    const seam = buildSourceConflictActSeam(
+      makeStubDeps({
+        runGit: (args) => {
+          gitCalls.push(args);
+          return { status: 0, stdout: "", stderr: "" };
+        },
+      }),
+    );
+    expect(() =>
+      seam(
+        sourceConflictCandidate({ linearTerminal: true, evidence: { linearTerminal: true, reason: "source_conflict_ctl708_unavailable", ticket: "CTL-2", phase: "implement" } }),
+        { category: "source-conflict", action: "force-push-if-clean" },
+      ),
+    ).toThrow(/linear-terminal/);
+    expect(gitCalls.some((a) => a.includes("push"))).toBe(false);
+  });
+
   test("writes the marker after a successful push", () => {
     const markers = [];
     const seam = buildSourceConflictActSeam(


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-17T15:40:00Z -->
<!-- Last updated: 2026-06-17T15:40:00Z -->
<!-- PR: #2208 -->
<!-- Previous commits: 9fc1e3b0b0843bc1c98efcb4b3b2de66995f9b39 -->

## Summary

Three surgical fixes to the execution-core's recovery-reasoning and unstuck-act-seams logic that close a class of bugs where `source_conflict_ctl708_unavailable` stalled tickets were being double-handled — simultaneously routed to the bounded-LLM force-push path by `unstuck-sweep` AND falling through to the legacy give-up comment path in `reasoningRecoveryPass`. Additionally, tickets already in a Linear terminal state could receive spurious give-up comments, and `buildSourceConflictActSeam` hardcoded `linearTerminal: false`, bypassing the existing guard in `classifyCleanRebaseForcePush`.

## Changes Made

### Execution-Core: `recovery-reasoning.mjs`

- **`checkBoundedLlmFixes`**: Added early-return for `signal.stalledReason === "source_conflict_ctl708_unavailable"` so the reasoning pass classifies it as a bounded-LLM FIX (`decision: fix`, `fix_class: bounded-llm`). Without this, `stalledReason` (set on stalled tickets) was never checked — only `failureReason` — so the call returned `null` and fell through to Rule 3, which posted the legacy give-up comment on the same tick the force-push-if-clean seam was already acting.

- **`reasoningRecoveryPass`**: Added `linearTerminal` guard before the diagnose loop. Mirrors `classifyStalledTicket`'s guard (`unstuck-sweep.mjs:95–97`). A ticket that is already Done/terminal in Linear should never receive the engineer-voiced give-up comment.

### Execution-Core: `unstuck-act-seams.mjs`

- **`buildSourceConflictActSeam`**: Removed hardcoded `linearTerminal: false`. Now forwards `candidate.evidence?.linearTerminal ?? false` so `classifyCleanRebaseForcePush`'s existing guard fires correctly on direct seam invocations, not just on the sweep path.

### CI: `.github/workflows/execution-core-tests.yml`

- Added `recovery-reasoning.test.mjs` and `unstuck-act-seams.test.mjs` to the CI allowlist so the new assertions run in CI from now on.

### Tests

- **`recovery-reasoning.test.mjs`**: 3 new tests
  - `source_conflict stalledReason → bounded-LLM (not null)` — verifies `checkBoundedLlmFixes` returns a non-null fix for the stalled-reason path
  - `defaultClassifyTicket: source_conflict stall → decision:fix, fix_class:bounded-llm` — end-to-end classification
  - `linearTerminal:true item is skipped — no comment, no escalation` — verifies the new guard in `reasoningRecoveryPass`

- **`unstuck-act-seams.test.mjs`**: 1 new test
  - `buildSourceConflictActSeam honors candidate.evidence.linearTerminal` — verifies the seam throws on terminal tickets and does not push

All changes red→green TDD; 4 new tests, 0 new failures.

## How to Verify It

- [x] TypeScript/ESM syntax valid — no build step; modules load cleanly
- [x] New tests pass: `bun test recovery-reasoning.test.mjs unstuck-act-seams.test.mjs` in `plugins/dev/scripts/execution-core/`
- [x] CI execution-core-unit-tests workflow runs both new test files (pending in CI at PR open)
- [ ] Manual: confirm a stalled `source_conflict_ctl708_unavailable` ticket is routed to the bounded-LLM seam and does NOT receive a legacy give-up comment on the next recovery sweep tick

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1243
