### PR TITLE
feat(dev): CTL-1240 wire gateway tier into scheduler tick (Linear read-hammer fix)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -131,6 +131,7 @@ jobs:
             hrw.test.mjs \
             integration-ctl-701.test.mjs \
             integration-ctl-705.test.mjs \
+            integration-ctl-1240.test.mjs \
             integration.test.mjs \
             job-dir-gc.test.mjs \
             label-guard.test.mjs \

--- a/plugins/dev/scripts/execution-core/integration-ctl-1240.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-1240.test.mjs
@@ -1,0 +1,241 @@
+// integration-ctl-1240.test.mjs — CTL-1240: wire gateway tier into startScheduler tick.
+//
+// Five sites in scheduler.mjs silently drop the `gateway` reader that the daemon
+// correctly threads into startScheduler. These tests drive startScheduler (the
+// real production path) and assert the gateway spy is consulted on the initial
+// synchronous tick — proving the threading is live, not dead.
+//
+// Test structure mirrors the CTL-537 forwarding test (scheduler.test.mjs:6808) and
+// the CTL-1191 terminal-filter test (scheduler.test.mjs:8906).
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  startScheduler,
+  stopScheduler,
+  __resetForTests,
+} from "./scheduler.mjs";
+
+let orchDir;
+let prevCatalystDir;
+let catalystDir;
+
+beforeEach(() => {
+  __resetForTests();
+  orchDir = mkdtempSync(join(tmpdir(), "ctl1240-int-"));
+  // Redirect CATALYST_DIR so getEventLogPath() resolves under a fixture (mirrors scheduler.test.mjs)
+  prevCatalystDir = process.env.CATALYST_DIR;
+  catalystDir = mkdtempSync(join(tmpdir(), "ctl1240-cat-"));
+  process.env.CATALYST_DIR = catalystDir;
+  // Ensure no ambient env vars bleed in from the outer shell
+  delete process.env.CATALYST_RECOVERY_PASS;
+  delete process.env.CATALYST_UNSTUCK_SWEEP;
+});
+
+afterEach(() => {
+  stopScheduler();
+  __resetForTests();
+  rmSync(orchDir, { recursive: true, force: true });
+  rmSync(catalystDir, { recursive: true, force: true });
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+  delete process.env.CATALYST_RECOVERY_PASS;
+  delete process.env.CATALYST_UNSTUCK_SWEEP;
+});
+
+// ── Helpers ──
+
+function writeSignal(ticket, phase, status, extra = {}) {
+  const dir = join(orchDir, "workers", ticket);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `phase-${phase}.json`),
+    JSON.stringify({ ticket, phase, status, ...extra }),
+  );
+}
+
+function fakeDispatch({ code = 0 } = {}) {
+  const calls = [];
+  const fn = (opts) => {
+    calls.push(opts);
+    return { code, stdout: "", stderr: "" };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+// Recording gateway spy: tracks every getDescriptor call.
+function makeGatewaySpy(descriptors = {}) {
+  const calls = [];
+  const spy = {
+    getDescriptor: (id) => {
+      calls.push(id);
+      return descriptors[id] ?? null;
+    },
+    get calls() { return calls; },
+  };
+  return spy;
+}
+
+// Minimal writeStatus that prevents any real Linear write from firing during the tick.
+const noopWriteStatus = {
+  applyPhaseStatus: () => {},
+  applyTerminalDone: () => {},
+  applyLabel: () => ({ applied: true }),
+  removeLabel: () => ({ removed: true }),
+  runTransition: () => ({ applied: false }),
+};
+
+// Recovery-intent marker path (mirrors CTL-1191 test at scheduler.test.mjs:8903).
+const recoveryIntentMarker = (ticket) =>
+  join(orchDir, ".recovery-intents", `${ticket}.json`);
+
+// ── Phase 1 ────────────────────────────────────────────────────────────────────
+//
+// Drives ONE synchronous startScheduler tick with CATALYST_RECOVERY_PASS=shadow.
+// The Pass 0r terminal filter (scheduler.mjs:3464–3471) resolves Linear state via
+// fetchTicketState(id, { cache, gateway }) using the in-scope schedulerTick gateway.
+//
+// PRE-FIX: gateway is dropped at startScheduler → spy.getDescriptor never called,
+//          and the Done ticket is NOT filtered (linearis exec falls through to null
+//          → fail-open non-terminal → both tickets processed).
+// POST-FIX: spy consulted; Done ticket filtered (terminal), In-Progress ticket kept.
+
+describe("CTL-1240 Phase 1 — gateway threaded through startScheduler spine", () => {
+  const DONE_TICKET = "CTL-1240-DONE";
+  const LIVE_TICKET = "CTL-1240-LIVE";
+
+  test("startScheduler threads gateway into the reasoning-pass terminal filter", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal(DONE_TICKET, "implement", "stalled");
+    writeSignal(LIVE_TICKET, "implement", "stalled");
+
+    const fresh = new Date().toISOString(); // within the 60s gateway-fresh window
+    const gateway = makeGatewaySpy({
+      [DONE_TICKET]: { state: "Done", removed: false, updatedAt: fresh },
+      [LIVE_TICKET]: { state: "In Progress", removed: false, updatedAt: fresh },
+    });
+
+    process.env.CATALYST_RECOVERY_PASS = "shadow";
+
+    startScheduler({
+      orchDir,
+      dispatch: fakeDispatch({ code: 0 }),
+      readEligible: () => [],
+      gateway,
+      liveBackgroundCount: () => 0,
+      tickIntervalMs: 60_000,
+      debounceMs: 5,
+      writeStatus: noopWriteStatus,
+    });
+
+    // Threading proof: the gateway spy must be consulted on the initial synchronous tick.
+    // PRE-FIX: gateway is dropped at startScheduler → this assertion fails (calls.length === 0).
+    expect(gateway.calls.length).toBeGreaterThan(0);
+
+    // Behavioral proof: Done ticket was filtered (terminal → no marker);
+    // In-Progress ticket was processed (non-terminal → marker written).
+    expect(existsSync(recoveryIntentMarker(LIVE_TICKET))).toBe(true);
+    expect(existsSync(recoveryIntentMarker(DONE_TICKET))).toBe(false);
+  });
+});
+
+// ── Phase 2 ────────────────────────────────────────────────────────────────────
+//
+// Sites 4 and 5: the default census closures in runTick call fetchTicketState(id)
+// bare (no cache, no gateway). After the fix they pass { cache, gateway }.
+
+describe("CTL-1240 Phase 2 — census closures use { cache, gateway }", () => {
+  // ── Site 4: default stall-clear census (scheduler.mjs:5334–5345) ─────────────
+  //
+  // Seed a prior-artifact-retry-exhausted stalled signal so the DEFAULT
+  // collectStallClearCandidates closure fires and calls isLinearTerminal(ticket).
+  //
+  // PRE-FIX: isLinearTerminal closure calls fetchTicketState(id) bare →
+  //          gateway spy never consulted.
+  // POST-FIX: fetchTicketState(id, { cache: runningOpts.cache, gateway: runningOpts.gateway })
+  //           → spy consulted.
+
+  test("default stall-clear census uses { cache, gateway } via runningOpts", () => {
+    const STALL_TICKET = "CTL-1240-STALL";
+
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    // Seed the stalled signal — stalledReason triggers the J3 isLinearTerminal probe.
+    writeSignal(STALL_TICKET, "implement", "stalled", {
+      stalledReason: "prior-artifact-retry-exhausted",
+      dispatchFailureCode: 2,
+    });
+    // Prior-phase done signal required by defaultCollectStallClearCandidates
+    // to check priorDoneSignalPresent (CTL-1045 Bug 3).
+    writeSignal(STALL_TICKET, "plan", "done");
+
+    const fresh = new Date().toISOString();
+    const gateway = makeGatewaySpy({
+      [STALL_TICKET]: { state: "Done", removed: false, updatedAt: fresh },
+    });
+
+    startScheduler({
+      orchDir,
+      dispatch: fakeDispatch({ code: 0 }),
+      readEligible: () => [],
+      gateway,
+      liveBackgroundCount: () => 0,
+      tickIntervalMs: 60_000,
+      debounceMs: 5,
+      writeStatus: noopWriteStatus,
+    });
+
+    // The stall-clear census isLinearTerminal closure must have consulted the gateway.
+    // PRE-FIX: fetchTicketState(id) bare → spy never called → assertion fails.
+    expect(gateway.calls).toContain(STALL_TICKET);
+  });
+
+  // ── Site 5: default unstuck census (scheduler.mjs:5356–5361) ─────────────────
+  //
+  // Set CATALYST_UNSTUCK_SWEEP=shadow to arm Pass 0u, then seed a stalled worker
+  // so defaultCollectUnstuckCandidates calls isLinearTerminal(ticket).
+  //
+  // PRE-FIX: isLinearTerminal closure calls fetchTicketState(id) bare →
+  //          gateway spy never consulted.
+  // POST-FIX: fetchTicketState(id, { cache: runningOpts.cache, gateway: runningOpts.gateway })
+  //           → spy consulted.
+
+  test("default unstuck census uses { cache, gateway } via runningOpts", () => {
+    const STUCK_TICKET = "CTL-1240-STUCK";
+
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal(STUCK_TICKET, "implement", "stalled", {
+      stalledReason: "work-not-done-after-stale-bg",
+    });
+
+    const fresh = new Date().toISOString();
+    const gateway = makeGatewaySpy({
+      [STUCK_TICKET]: { state: "In Progress", removed: false, updatedAt: fresh },
+    });
+
+    process.env.CATALYST_UNSTUCK_SWEEP = "shadow";
+
+    startScheduler({
+      orchDir,
+      dispatch: fakeDispatch({ code: 0 }),
+      readEligible: () => [],
+      gateway,
+      liveBackgroundCount: () => 0,
+      tickIntervalMs: 60_000,
+      debounceMs: 5,
+      writeStatus: noopWriteStatus,
+    });
+
+    // The unstuck census isLinearTerminal closure must have consulted the gateway.
+    // PRE-FIX: fetchTicketState(id) bare → spy never called → assertion fails.
+    expect(gateway.calls).toContain(STUCK_TICKET);
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5338,10 +5338,13 @@ function runTick() {
             projects: listProjects(),
             agents: getAgentsCached().agents,
             isLinearTerminal: (id) => {
-              // fetchTicketState with no gateway behaves as the plain cache-first
-              // read (the daemon's runTick does not thread a gateway, matching the
-              // CTL-642 terminal short-circuit at the reconcile backstop).
-              const state = fetchTicketState(id);
+              // CTL-1240: 3-tier read (cache → gateway/filter-state.db → live linearis),
+              // matching the reclaim + reasoning-pass paths. TTL/gateway hits suppress
+              // the live `linearis issues read` storm this census otherwise caused.
+              const state = fetchTicketState(id, {
+                cache: runningOpts.cache,
+                gateway: runningOpts.gateway,
+              });
               return state != null && isLinearTerminal(state);
             },
           }),
@@ -5358,7 +5361,12 @@ function runTick() {
             orchDir: runningOpts.orchDir,
             agentsSnapshot: getAgentsCached().agents,
             isLinearTerminal: (id) => {
-              const state = fetchTicketState(id);
+              // CTL-1240: 3-tier read (cache → gateway → live linearis). Matches
+              // the stall-clear census path above and the reclaim/reasoning paths.
+              const state = fetchTicketState(id, {
+                cache: runningOpts.cache,
+                gateway: runningOpts.gateway,
+              });
               return state != null && isLinearTerminal(state);
             },
             // CTL-1064: thread the worktree resolver from each worker's signal so

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5255,6 +5255,7 @@ function runTick() {
       exec: runningOpts.exec,
       writeStatus: runningOpts.writeStatus,
       cache: runningOpts.cache, // CTL-634: shared out-of-set blocker state cache
+      gateway: runningOpts.gateway, // CTL-1240/823: enables tier-2 reads in reclaim + reasoning filter
       concurrency, // CTL-665 + CTL-676: per-tick re-read, then threaded into readMaxParallel
       // CTL-676: forward the optional liveBackgroundCount seam (test-only) so
       // a unit test can drive freeSlots deterministically without shelling
@@ -5531,6 +5532,7 @@ export function startScheduler({
   exec,
   writeStatus,
   cache, // CTL-634: shared out-of-set blocker state cache (from startDaemon)
+  gateway, // CTL-1240/823: durable filter-state.db reader; threaded into runningOpts → schedulerTick
   concurrency = {}, // CTL-665 + CTL-676: boot-captured executionCore knobs. When
   // `configPath` is also set (production wiring), runTick re-reads the live
   // file every tick and ignores this object; the boot-captured value is the
@@ -5597,6 +5599,7 @@ export function startScheduler({
     exec,
     writeStatus,
     cache,
+    gateway, // CTL-1240: thread the durable descriptor reader into the per-tick options
     concurrency,
     configPath, // CTL-676: per-tick Layer-1 re-read source
     layer2Path, // CTL-678: per-tick Layer-2 re-read source (host-wide override)


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-17T15:54:00Z -->
<!-- Last updated: 2026-06-17T15:54:00Z -->
<!-- PR: #2209 -->
<!-- Previous commits: dbe34c71c9e11abf8c5f29c91f0abd74c5f64ee3,cd101464b66a188fa242afd83e5853f5a788d0d1 -->

## Summary

Wires the durable `gateway` (filter-state.db) reader — built in CTL-823 but silently dropped by `startScheduler` — into the scheduler's hot path. Before this fix, every scheduler tick resolved Linear state via the 60-second in-process TTL only; TTL misses fell straight to live `linearis issues read` calls. The five-site threading fix enables the 3-tier lookup (cache → gateway/filter-state.db → live linearis) in the reclaim sweep, the recovery-pass terminal filter, and the two default census closures (stall-clear and unstuck), eliminating the `GetIssueByIdentifier` storm that was responsible for ~87% of live Linear reads under load.

## Changes Made

### Execution-Core: `scheduler.mjs`

Five surgical wiring sites (~10 lines total):

- **Site 1 — `startScheduler` param list** (`5540`): Added `gateway` to the destructured parameter so the argument passed from `daemon.mjs` is no longer silently dropped by JS destructuring.
- **Site 2 — `runningOpts` assignment** (`5607`): Stored `gateway` in `runningOpts` so all downstream consumers can read it from the shared options object.
- **Site 3 — `schedulerTick(...)` call** (`5258`): Forwarded `gateway: runningOpts.gateway` so the reclaim sweep and reasoning-pass terminal filter inside `schedulerTick` receive a live descriptor reader, not `undefined`.
- **Site 4 — `collectStallClearCandidates` `isLinearTerminal` closure** (`5344`): Changed `fetchTicketState(id)` to `fetchTicketState(id, { cache: runningOpts.cache, gateway: runningOpts.gateway })` — the stall-clear census now uses the 3-tier read to decide whether a stalled ticket is Linear-terminal before clearing it.
- **Site 5 — `collectUnstuckCandidates` `isLinearTerminal` closure** (`5361`): Same change as Site 4, for symmetry with the stall-clear path.

### Integration Tests: `integration-ctl-1240.test.mjs`

241-line integration test driving `startScheduler` directly (the real production path), structured in two phases mirroring the ticket:

- **Phase 1** — `startScheduler` threads `gateway` into the reasoning-pass terminal filter: seeds a Done ticket and a live ticket, passes a recording `makeGatewaySpy`, and asserts (a) the spy is consulted on the initial synchronous tick (`gateway.calls.length > 0`), and (b) only the live ticket receives a recovery-intent marker (Done ticket is filtered as terminal).
- **Phase 2** — Census closures use `{ cache, gateway }`:
  - Site 4 (stall-clear): seeds a `prior-artifact-retry-exhausted` stalled ticket with a Done descriptor; asserts spy consulted.
  - Site 5 (unstuck): seeds a stalled ticket whose `stalledReason` triggers the unstuck pass; asserts spy consulted with the correct ticket ID.

All 3 tests pass in 349 ms. 5 `expect()` calls, 0 failures.

### CI: `.github/workflows/execution-core-tests.yml`

Added `integration-ctl-1240.test.mjs` to the `execution-core-unit-tests` test allowlist so the new assertions run on every push from here on.

## How to Verify It

- [x] New integration tests pass: `bun test integration-ctl-1240.test.mjs` — 3 pass, 0 fail (349 ms)
- [x] ESM syntax valid — modules load cleanly (no build step)
- [ ] CI execution-core-tests workflow: `integration-ctl-1240.test.mjs` runs green (pending at PR open)
- [ ] Manual: observe `rl_remaining` in the proxy log before/after — live `linearis issues read` volume should drop sharply under a running daemon once the PR is merged

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1240

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-823
