### PR TITLE
feat(dev): CTL-1223 broker runs bun install after pull when deps changed; surface silent vite-build failures

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-monitor-bootstrap.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-monitor-bootstrap.test.sh
@@ -108,6 +108,322 @@ else
   fail "catalyst-monitor.sh should mkdir -p \$CATALYST_DIR/wt"
 fi
 
+# ─── Phase 2 (CTL-1223): ui/bun.lock staleness check ────────────────────────
+#
+# bootstrap() must run `bun install` in ui/ when ui/bun.lock is NEWER than
+# ui/node_modules (lockfile-staleness check), not only when node_modules is
+# absent. This mirrors the server-package check directly above it.
+
+echo ""
+echo "Test (CTL-1223): ui/bun.lock newer than ui/node_modules → ui install runs"
+ROOT="$(mktemp -d)"
+mkdir -p "$ROOT/catalyst/wt" "$ROOT/srv/node_modules"
+: > "$ROOT/srv/server.ts"
+mkdir -p "$ROOT/srv/ui/node_modules"
+: > "$ROOT/srv/ui/package.json"
+# Create bun.lock then touch node_modules first so lockfile is older (control)
+touch "$ROOT/srv/ui/node_modules"
+sleep 1
+touch "$ROOT/srv/ui/bun.lock"   # lockfile is NEWER than node_modules
+BUN_LOG="$ROOT/bun-calls.log"
+FAKE_BUN_DIR="$ROOT/fake-bin"
+mkdir -p "$FAKE_BUN_DIR"
+cat > "$FAKE_BUN_DIR/bun" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$(pwd)" >> "$BUN_LOG"
+exit 0
+EOF
+chmod +x "$FAKE_BUN_DIR/bun"
+cat > "$FAKE_BUN_DIR/bunx" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BUN_DIR/bunx"
+RESULT="$(
+  BUN_LOG="$BUN_LOG" CATALYST_DIR="$ROOT/catalyst" MONITOR_SERVER_SCRIPT="$ROOT/srv/server.ts" \
+  MONITOR_UI_DIST_DIR="$ROOT/dist" MONITOR_SKIP_BOOTSTRAP="" \
+  PATH="$FAKE_BUN_DIR:$PATH" \
+  bash -c '
+    source "'"$MONITOR_SH"'" url >/dev/null 2>&1
+    bootstrap >/dev/null 2>&1; echo "rc=$?"
+  '
+)"
+UI_DIR="$ROOT/srv/ui"
+if grep -qF "$UI_DIR" "$BUN_LOG" 2>/dev/null; then
+  pass "CTL-1223 Phase 2: ui install ran when bun.lock newer than node_modules"
+else
+  fail "CTL-1223 Phase 2: ui install should run when bun.lock newer than node_modules (bun-calls: $(cat "$BUN_LOG" 2>/dev/null || echo none))"
+fi
+rm -rf "$ROOT"
+
+echo ""
+echo "Test (CTL-1223): ui/node_modules newer than ui/bun.lock → ui install does NOT run"
+ROOT="$(mktemp -d)"
+mkdir -p "$ROOT/catalyst/wt" "$ROOT/srv/node_modules"
+: > "$ROOT/srv/server.ts"
+mkdir -p "$ROOT/srv/ui"
+: > "$ROOT/srv/ui/package.json"
+touch "$ROOT/srv/ui/bun.lock"    # lockfile is OLDER
+sleep 1
+mkdir -p "$ROOT/srv/ui/node_modules"  # node_modules is NEWER
+BUN_LOG="$ROOT/bun-calls.log"
+FAKE_BUN_DIR="$ROOT/fake-bin"
+mkdir -p "$FAKE_BUN_DIR"
+cat > "$FAKE_BUN_DIR/bun" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$(pwd)" >> "$BUN_LOG"
+exit 0
+EOF
+chmod +x "$FAKE_BUN_DIR/bun"
+cat > "$FAKE_BUN_DIR/bunx" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BUN_DIR/bunx"
+RESULT="$(
+  BUN_LOG="$BUN_LOG" CATALYST_DIR="$ROOT/catalyst" MONITOR_SERVER_SCRIPT="$ROOT/srv/server.ts" \
+  MONITOR_UI_DIST_DIR="$ROOT/dist" MONITOR_SKIP_BOOTSTRAP="" \
+  PATH="$FAKE_BUN_DIR:$PATH" \
+  bash -c '
+    source "'"$MONITOR_SH"'" url >/dev/null 2>&1
+    bootstrap >/dev/null 2>&1; echo "rc=$?"
+  '
+)"
+UI_DIR="$ROOT/srv/ui"
+if grep -qF "$UI_DIR" "$BUN_LOG" 2>/dev/null; then
+  fail "CTL-1223 Phase 2: ui install should NOT run when node_modules is newer than bun.lock"
+else
+  pass "CTL-1223 Phase 2: ui install skipped when node_modules is up to date"
+fi
+rm -rf "$ROOT"
+
+echo ""
+echo "Test (CTL-1223): ui/node_modules absent → ui install still runs (existing behavior)"
+ROOT="$(mktemp -d)"
+mkdir -p "$ROOT/catalyst/wt" "$ROOT/srv/node_modules"
+: > "$ROOT/srv/server.ts"
+mkdir -p "$ROOT/srv/ui"
+: > "$ROOT/srv/ui/package.json"
+: > "$ROOT/srv/ui/bun.lock"
+# Do NOT create ui/node_modules — should trigger install regardless
+BUN_LOG="$ROOT/bun-calls.log"
+FAKE_BUN_DIR="$ROOT/fake-bin"
+mkdir -p "$FAKE_BUN_DIR"
+cat > "$FAKE_BUN_DIR/bun" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$(pwd)" >> "$BUN_LOG"
+exit 0
+EOF
+chmod +x "$FAKE_BUN_DIR/bun"
+cat > "$FAKE_BUN_DIR/bunx" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BUN_DIR/bunx"
+RESULT="$(
+  BUN_LOG="$BUN_LOG" CATALYST_DIR="$ROOT/catalyst" MONITOR_SERVER_SCRIPT="$ROOT/srv/server.ts" \
+  MONITOR_UI_DIST_DIR="$ROOT/dist" MONITOR_SKIP_BOOTSTRAP="" \
+  PATH="$FAKE_BUN_DIR:$PATH" \
+  bash -c '
+    source "'"$MONITOR_SH"'" url >/dev/null 2>&1
+    bootstrap >/dev/null 2>&1; echo "rc=$?"
+  '
+)"
+UI_DIR="$ROOT/srv/ui"
+if grep -qF "$UI_DIR" "$BUN_LOG" 2>/dev/null; then
+  pass "CTL-1223 Phase 2: ui install runs when node_modules absent (existing behavior preserved)"
+else
+  fail "CTL-1223 Phase 2: ui install should run when node_modules is absent (bun-calls: $(cat "$BUN_LOG" 2>/dev/null || echo none))"
+fi
+rm -rf "$ROOT"
+
+echo ""
+echo "Test (CTL-1223): source guard — ui/ block references bun.lock staleness"
+if grep -q 'ui/bun\.lock.*-nt.*ui/node_modules\|ui/node_modules.*-nt.*ui/bun\.lock' "$MONITOR_SH"; then
+  pass "CTL-1223 Phase 2: catalyst-monitor.sh ui/ block references bun.lock staleness"
+else
+  fail "CTL-1223 Phase 2: catalyst-monitor.sh ui/ block should reference bun.lock staleness check"
+fi
+
+# ─── Phase 3 (CTL-1223): monitor.ui.build_failed structured event ─────────────
+#
+# When the production vite build fails, bootstrap() must emit a structured
+# monitor.ui.build_failed event into the unified event log (in addition to
+# the existing stderr warning), so the failure is no longer invisible.
+
+echo ""
+echo "Test (CTL-1223): build failure still prints stderr warning (regression guard)"
+ROOT="$(mktemp -d)"
+mkdir -p "$ROOT/catalyst/wt" "$ROOT/srv/node_modules"
+: > "$ROOT/srv/server.ts"
+mkdir -p "$ROOT/srv/ui/node_modules" "$ROOT/srv/public" "$ROOT/dist" "$ROOT/events"
+: > "$ROOT/srv/ui/package.json"
+: > "$ROOT/srv/ui/bun.lock"
+FAKE_BUN_DIR="$ROOT/fake-bin"
+mkdir -p "$FAKE_BUN_DIR"
+cat > "$FAKE_BUN_DIR/bun" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BUN_DIR/bun"
+# bunx fails (vite build failure)
+cat > "$FAKE_BUN_DIR/bunx" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$FAKE_BUN_DIR/bunx"
+STDERR_OUT="$(
+  CATALYST_DIR="$ROOT/catalyst" MONITOR_SERVER_SCRIPT="$ROOT/srv/server.ts" \
+  MONITOR_UI_DIST_DIR="$ROOT/dist" CATALYST_EVENTS_DIR="$ROOT/events" \
+  MONITOR_SKIP_BOOTSTRAP="" \
+  PATH="$FAKE_BUN_DIR:$PATH" \
+  bash -c '
+    source "'"$MONITOR_SH"'" url >/dev/null 2>&1
+    bootstrap 2>&1 >/dev/null
+  '
+)"
+if echo "$STDERR_OUT" | grep -q 'serving previous dist'; then
+  pass "CTL-1223 Phase 3: stderr warning still printed on build failure"
+else
+  fail "CTL-1223 Phase 3: stderr warning missing on build failure (got: $STDERR_OUT)"
+fi
+rm -rf "$ROOT"
+
+echo ""
+echo "Test (CTL-1223): build failure emits monitor.ui.build_failed event"
+ROOT="$(mktemp -d)"
+mkdir -p "$ROOT/catalyst/wt" "$ROOT/srv/node_modules"
+: > "$ROOT/srv/server.ts"
+mkdir -p "$ROOT/srv/ui/node_modules" "$ROOT/srv/public" "$ROOT/dist" "$ROOT/events"
+: > "$ROOT/srv/ui/package.json"
+: > "$ROOT/srv/ui/bun.lock"
+FAKE_BUN_DIR="$ROOT/fake-bin"
+mkdir -p "$FAKE_BUN_DIR"
+cat > "$FAKE_BUN_DIR/bun" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BUN_DIR/bun"
+cat > "$FAKE_BUN_DIR/bunx" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$FAKE_BUN_DIR/bunx"
+cat > "$FAKE_BUN_DIR/jq" <<'EOF'
+#!/usr/bin/env bash
+exec /usr/bin/jq "$@"
+EOF
+chmod +x "$FAKE_BUN_DIR/jq"
+(
+  CATALYST_DIR="$ROOT/catalyst" MONITOR_SERVER_SCRIPT="$ROOT/srv/server.ts" \
+  MONITOR_UI_DIST_DIR="$ROOT/dist" CATALYST_EVENTS_DIR="$ROOT/events" \
+  MONITOR_SKIP_BOOTSTRAP="" \
+  PATH="$FAKE_BUN_DIR:$PATH" \
+  bash -c '
+    source "'"$MONITOR_SH"'" url >/dev/null 2>&1
+    bootstrap >/dev/null 2>&1
+  '
+) || true
+EVENT_FOUND=""
+for f in "$ROOT/events"/*.jsonl; do
+  [[ -f "$f" ]] || continue
+  if grep -q '"monitor.ui.build_failed"' "$f" 2>/dev/null; then
+    EVENT_FOUND="yes"
+    break
+  fi
+done
+if [[ -n "$EVENT_FOUND" ]]; then
+  pass "CTL-1223 Phase 3: monitor.ui.build_failed event emitted on build failure"
+else
+  fail "CTL-1223 Phase 3: monitor.ui.build_failed event missing (events dir: $(ls "$ROOT/events/" 2>/dev/null || echo empty))"
+fi
+rm -rf "$ROOT"
+
+echo ""
+echo "Test (CTL-1223): build failure does NOT write .source-sha (retry preserved)"
+ROOT="$(mktemp -d)"
+mkdir -p "$ROOT/catalyst/wt" "$ROOT/srv/node_modules"
+: > "$ROOT/srv/server.ts"
+mkdir -p "$ROOT/srv/ui/node_modules" "$ROOT/srv/public" "$ROOT/dist" "$ROOT/events"
+: > "$ROOT/srv/ui/package.json"
+: > "$ROOT/srv/ui/bun.lock"
+FAKE_BUN_DIR="$ROOT/fake-bin"
+mkdir -p "$FAKE_BUN_DIR"
+cat > "$FAKE_BUN_DIR/bun" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BUN_DIR/bun"
+cat > "$FAKE_BUN_DIR/bunx" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$FAKE_BUN_DIR/bunx"
+(
+  CATALYST_DIR="$ROOT/catalyst" MONITOR_SERVER_SCRIPT="$ROOT/srv/server.ts" \
+  MONITOR_UI_DIST_DIR="$ROOT/dist" CATALYST_EVENTS_DIR="$ROOT/events" \
+  MONITOR_SKIP_BOOTSTRAP="" \
+  PATH="$FAKE_BUN_DIR:$PATH" \
+  bash -c '
+    source "'"$MONITOR_SH"'" url >/dev/null 2>&1
+    bootstrap >/dev/null 2>&1
+  '
+) || true
+if [[ ! -f "$ROOT/dist/.source-sha" ]]; then
+  pass "CTL-1223 Phase 3: .source-sha not written on build failure (retry next restart)"
+else
+  fail "CTL-1223 Phase 3: .source-sha must not be written on build failure"
+fi
+rm -rf "$ROOT"
+
+echo ""
+echo "Test (CTL-1223): build success → NO monitor.ui.build_failed event emitted"
+ROOT="$(mktemp -d)"
+mkdir -p "$ROOT/catalyst/wt" "$ROOT/srv/node_modules"
+: > "$ROOT/srv/server.ts"
+mkdir -p "$ROOT/srv/ui/node_modules" "$ROOT/srv/public" "$ROOT/dist" "$ROOT/events"
+: > "$ROOT/srv/ui/package.json"
+: > "$ROOT/srv/ui/bun.lock"
+FAKE_BUN_DIR="$ROOT/fake-bin"
+mkdir -p "$FAKE_BUN_DIR"
+cat > "$FAKE_BUN_DIR/bun" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BUN_DIR/bun"
+# bunx succeeds, creates index.html
+cat > "$FAKE_BUN_DIR/bunx" <<'SCRIPT'
+#!/usr/bin/env bash
+DIST="${MONITOR_UI_DIST_DIR:-/tmp/dist}"
+touch "$DIST/index.html"
+exit 0
+SCRIPT
+chmod +x "$FAKE_BUN_DIR/bunx"
+(
+  CATALYST_DIR="$ROOT/catalyst" MONITOR_SERVER_SCRIPT="$ROOT/srv/server.ts" \
+  MONITOR_UI_DIST_DIR="$ROOT/dist" CATALYST_EVENTS_DIR="$ROOT/events" \
+  MONITOR_SKIP_BOOTSTRAP="" \
+  PATH="$FAKE_BUN_DIR:$PATH" \
+  bash -c '
+    source "'"$MONITOR_SH"'" url >/dev/null 2>&1
+    bootstrap >/dev/null 2>&1
+  '
+) || true
+BAD_EVENT=""
+for f in "$ROOT/events"/*.jsonl; do
+  [[ -f "$f" ]] || continue
+  if grep -q '"monitor.ui.build_failed"' "$f" 2>/dev/null; then
+    BAD_EVENT="yes"
+    break
+  fi
+done
+if [[ -z "$BAD_EVENT" ]]; then
+  pass "CTL-1223 Phase 3: no monitor.ui.build_failed event on build success"
+else
+  fail "CTL-1223 Phase 3: monitor.ui.build_failed must NOT be emitted on build success"
+fi
+rm -rf "$ROOT"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "catalyst-monitor-bootstrap: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/broker/plugin-refresh.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.mjs
@@ -96,6 +96,45 @@ function defaultGitFn(root, args) {
   }).trim();
 }
 
+// Dep install can take longer than a git op (lockfile resolution); generous ceiling.
+const BUN_INSTALL_TIMEOUT_MS =
+  Number(process.env.CATALYST_PLUGIN_REFRESH_BUN_TIMEOUT_MS) || 180_000;
+
+// defaultBunInstallFn — run `bun install` in a package dir. Frozen first (the
+// checkout was just reset to origin/main, so the lockfile is authoritative);
+// fall back to a plain install if frozen rejects. Throws on non-zero exit, which
+// the caller catches and surfaces as deps_install_failed (non-fatal).
+function defaultBunInstallFn(pkgDir) {
+  try {
+    execFileSync("bun", ["install", "--frozen-lockfile"], {
+      cwd: pkgDir, encoding: "utf8", timeout: BUN_INSTALL_TIMEOUT_MS,
+      killSignal: "SIGKILL", env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    });
+  } catch {
+    execFileSync("bun", ["install"], {
+      cwd: pkgDir, encoding: "utf8", timeout: BUN_INSTALL_TIMEOUT_MS,
+      killSignal: "SIGKILL", env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    });
+  }
+}
+
+// Files whose change means deps may need (re)installing in their containing dir.
+const DEP_MANIFEST_RE = /(^|\/)(package\.json|bun\.lock)$/;
+
+// changedPackageDirs — pure helper: map a `git diff --name-only` output to
+// unique absolute package dirs that need `bun install`. Exported for direct
+// unit testing (no I/O — path/dedup logic only).
+export function changedPackageDirs(root, diffOutput) {
+  const dirs = new Set();
+  for (const line of String(diffOutput || "").split("\n")) {
+    const rel = line.trim();
+    if (!rel || !DEP_MANIFEST_RE.test(rel)) continue;
+    const dir = rel.includes("/") ? rel.slice(0, rel.lastIndexOf("/")) : ".";
+    dirs.add(dir === "." ? root : resolve(root, dir));
+  }
+  return [...dirs];
+}
+
 // defaultGitToplevelFn — map a pluginDirs entry (<checkout>/plugins/dev) to its
 // git toplevel checkout root, or null when it is not inside a git checkout.
 function defaultGitToplevelFn(pluginDir) {
@@ -303,6 +342,7 @@ export function refreshPluginCheckout({
   root,
   now = Date.now(),
   gitFn = defaultGitFn,
+  bunInstallFn = defaultBunInstallFn,
   emitFn,
   loadedCommit = null,
   loadedCommitRoot = null,
@@ -389,6 +429,31 @@ export function refreshPluginCheckout({
     (loadedCommitRoot == null || loadedCommitRoot === root);
 
   _clearLagState(root);
+
+  // CTL-1223: diff the pulled range to find changed package.json/bun.lock dirs
+  // and run `bun install` in each before emitting plugin.checkout.updated (which
+  // triggers the monitor restart). Install failures are surfaced as WARN events
+  // and never block the checkout-updated signal (reset already succeeded).
+  const depsInstalled = [];
+  if (oldSha) {
+    let diffOut = "";
+    try { diffOut = gitFn(root, ["diff", "--name-only", oldSha, newSha]); } catch { diffOut = ""; }
+    for (const pkgDir of changedPackageDirs(root, diffOut)) {
+      try {
+        bunInstallFn(pkgDir);
+        depsInstalled.push(pkgDir);
+      } catch (err) {
+        emitFn({
+          event: "plugin.checkout.deps_install_failed",
+          orchestrator: null,
+          worker: null,
+          severity: "WARN",
+          detail: { checkout: root, package_dir: pkgDir, error: err?.message ?? String(err) },
+        });
+      }
+    }
+  }
+
   emitFn({
     event: "plugin.checkout.updated",
     orchestrator: null,
@@ -399,6 +464,7 @@ export function refreshPluginCheckout({
       new_sha: newSha,
       loaded_commit: loadedCommit,
       restart_needed: restartNeeded,
+      deps_installed: depsInstalled,
     },
   });
   return { pulled: true, throttled: false, changed: true, failed: false, root, oldSha, newSha, restartNeeded };

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -28,6 +28,7 @@ import {
   refreshAllPluginCheckouts,
   startPluginDriftCheck,
   handlePluginRefreshEvent,
+  changedPackageDirs,
   PLUGIN_REFRESH_THROTTLE_MS,
   PLUGIN_DRIFT_CHECK_INTERVAL_MS,
   __clearThrottleForTest,
@@ -1158,5 +1159,257 @@ describe("coalescing — three triggers in one throttle window", () => {
     refreshAllPluginCheckouts({ ...baseArgs, now: PLUGIN_REFRESH_THROTTLE_MS - 1 });
 
     expect(fetchCount).toBe(1);
+  });
+});
+
+// ─── changedPackageDirs (CTL-1223) ───────────────────────────────────────────
+
+describe("changedPackageDirs", () => {
+  test("returns the dir when ui/package.json changed", () => {
+    const dirs = changedPackageDirs("/repo", "plugins/dev/scripts/orch-monitor/ui/package.json\n");
+    expect(dirs).toEqual(["/repo/plugins/dev/scripts/orch-monitor/ui"]);
+  });
+
+  test("returns the dir when only bun.lock changed", () => {
+    const dirs = changedPackageDirs("/repo", "plugins/dev/scripts/orch-monitor/ui/bun.lock\n");
+    expect(dirs).toEqual(["/repo/plugins/dev/scripts/orch-monitor/ui"]);
+  });
+
+  test("dedupes package.json AND bun.lock in the same dir → exactly one install", () => {
+    const diff =
+      "plugins/dev/scripts/orch-monitor/ui/package.json\n" +
+      "plugins/dev/scripts/orch-monitor/ui/bun.lock\n";
+    const dirs = changedPackageDirs("/repo", diff);
+    expect(dirs).toHaveLength(1);
+    expect(dirs[0]).toBe("/repo/plugins/dev/scripts/orch-monitor/ui");
+  });
+
+  test("multiple distinct package dirs changed → one dir per unique package", () => {
+    const diff =
+      "plugins/dev/scripts/orch-monitor/ui/package.json\n" +
+      "plugins/dev/scripts/orch-monitor/bun.lock\n";
+    const dirs = changedPackageDirs("/repo", diff);
+    expect(dirs).toHaveLength(2);
+    expect(new Set(dirs)).toEqual(
+      new Set([
+        "/repo/plugins/dev/scripts/orch-monitor/ui",
+        "/repo/plugins/dev/scripts/orch-monitor",
+      ])
+    );
+  });
+
+  test("no dependency-manifest change → empty array", () => {
+    const diff = "plugins/dev/scripts/broker/router.mjs\nsrc/index.ts\n";
+    const dirs = changedPackageDirs("/repo", diff);
+    expect(dirs).toEqual([]);
+  });
+
+  test("empty diff → empty array", () => {
+    expect(changedPackageDirs("/repo", "")).toEqual([]);
+    expect(changedPackageDirs("/repo", null)).toEqual([]);
+  });
+
+  test("root-level package.json maps to root", () => {
+    const dirs = changedPackageDirs("/repo", "package.json\n");
+    expect(dirs).toEqual(["/repo"]);
+  });
+});
+
+// ─── refreshPluginCheckout — bun install seam (CTL-1223) ─────────────────────
+
+describe("refreshPluginCheckout — bunInstallFn seam (CTL-1223)", () => {
+  beforeEach(() => __clearThrottleForTest());
+
+  // makeGitFnWithDiff: extends makeGitFn to support `diff --name-only` stubbing.
+  function makeGitFnWithDiff({ before = "aaaa", after = "bbbb", diffOutput = "" } = {}) {
+    const calls = [];
+    const gitFn = (root, args) => {
+      calls.push({ root, args });
+      const sub = args[0];
+      if (sub === "rev-parse") {
+        const seen = calls.filter((c) => c.args[0] === "rev-parse").length;
+        return seen === 1 ? before : after;
+      }
+      if (sub === "fetch") return "";
+      if (sub === "reset") return "";
+      if (sub === "diff") return diffOutput;
+      return "";
+    };
+    gitFn.calls = calls;
+    return gitFn;
+  }
+
+  test("installs in the package dir when ui/package.json changed", () => {
+    const installed = [];
+    const gitFn = makeGitFnWithDiff({
+      diffOutput: "plugins/dev/scripts/orch-monitor/ui/package.json\n",
+    });
+    refreshPluginCheckout({
+      root: "/repo",
+      now: 0,
+      gitFn,
+      emitFn: () => {},
+      bunInstallFn: (dir) => { installed.push(dir); },
+    });
+    expect(installed).toEqual(["/repo/plugins/dev/scripts/orch-monitor/ui"]);
+  });
+
+  test("installs when only bun.lock changed", () => {
+    const installed = [];
+    const gitFn = makeGitFnWithDiff({
+      diffOutput: "plugins/dev/scripts/orch-monitor/ui/bun.lock\n",
+    });
+    refreshPluginCheckout({
+      root: "/repo",
+      now: 0,
+      gitFn,
+      emitFn: () => {},
+      bunInstallFn: (dir) => { installed.push(dir); },
+    });
+    expect(installed).toEqual(["/repo/plugins/dev/scripts/orch-monitor/ui"]);
+  });
+
+  test("dedupes: package.json AND bun.lock in same dir → exactly one install", () => {
+    const installed = [];
+    const gitFn = makeGitFnWithDiff({
+      diffOutput:
+        "plugins/dev/scripts/orch-monitor/ui/package.json\n" +
+        "plugins/dev/scripts/orch-monitor/ui/bun.lock\n",
+    });
+    refreshPluginCheckout({
+      root: "/repo",
+      now: 0,
+      gitFn,
+      emitFn: () => {},
+      bunInstallFn: (dir) => { installed.push(dir); },
+    });
+    expect(installed).toHaveLength(1);
+  });
+
+  test("multiple distinct package dirs → one install per unique dir", () => {
+    const installed = [];
+    const gitFn = makeGitFnWithDiff({
+      diffOutput:
+        "plugins/dev/scripts/orch-monitor/ui/package.json\n" +
+        "plugins/dev/scripts/orch-monitor/bun.lock\n",
+    });
+    refreshPluginCheckout({
+      root: "/repo",
+      now: 0,
+      gitFn,
+      emitFn: () => {},
+      bunInstallFn: (dir) => { installed.push(dir); },
+    });
+    expect(installed).toHaveLength(2);
+  });
+
+  test("no dependency-manifest change → bunInstallFn NOT called, updated event still emitted", () => {
+    const installed = [];
+    const emitted = [];
+    const gitFn = makeGitFnWithDiff({ diffOutput: "src/index.ts\n" });
+    refreshPluginCheckout({
+      root: "/repo",
+      now: 0,
+      gitFn,
+      emitFn: (e) => emitted.push(e),
+      bunInstallFn: (dir) => { installed.push(dir); },
+    });
+    expect(installed).toHaveLength(0);
+    expect(emitted.some((e) => e.event === "plugin.checkout.updated")).toBe(true);
+  });
+
+  test("HEAD unchanged → no diff, no install, no updated event", () => {
+    const installed = [];
+    const emitted = [];
+    const gitFn = makeGitFnWithDiff({ before: "same", after: "same" });
+    refreshPluginCheckout({
+      root: "/repo",
+      now: 0,
+      gitFn,
+      emitFn: (e) => emitted.push(e),
+      bunInstallFn: (dir) => { installed.push(dir); },
+    });
+    expect(installed).toHaveLength(0);
+    expect(emitted).toHaveLength(0);
+  });
+
+  test("throttled call → no install", () => {
+    const installed = [];
+    const gitFn = makeGitFnWithDiff({
+      diffOutput: "plugins/dev/scripts/orch-monitor/ui/package.json\n",
+    });
+    // First call to set throttle
+    refreshPluginCheckout({ root: "/repo", now: 0, gitFn, emitFn: () => {}, bunInstallFn: () => {} });
+    // Throttled second call
+    refreshPluginCheckout({
+      root: "/repo",
+      now: PLUGIN_REFRESH_THROTTLE_MS - 1,
+      gitFn,
+      emitFn: () => {},
+      bunInstallFn: (dir) => { installed.push(dir); },
+    });
+    expect(installed).toHaveLength(0);
+  });
+
+  test("oldSha null (rev-parse failed) → bunInstallFn NOT called, updated still emitted", () => {
+    const installed = [];
+    const emitted = [];
+    let parseCount = 0;
+    const gitFn = (root, args) => {
+      if (args[0] === "rev-parse") {
+        parseCount++;
+        if (parseCount === 1) throw new Error("not a git repo");
+        return "newsha";
+      }
+      if (args[0] === "fetch" || args[0] === "reset") return "";
+      return "";
+    };
+    refreshPluginCheckout({
+      root: "/repo",
+      now: 0,
+      gitFn,
+      emitFn: (e) => emitted.push(e),
+      bunInstallFn: (dir) => { installed.push(dir); },
+    });
+    expect(installed).toHaveLength(0);
+    expect(emitted.some((e) => e.event === "plugin.checkout.updated")).toBe(true);
+  });
+
+  test("bunInstallFn throws → emits deps_install_failed (WARN), still emits updated, result.failed=false", () => {
+    const emitted = [];
+    const gitFn = makeGitFnWithDiff({
+      diffOutput: "plugins/dev/scripts/orch-monitor/ui/package.json\n",
+    });
+    const res = refreshPluginCheckout({
+      root: "/repo",
+      now: 0,
+      gitFn,
+      emitFn: (e) => emitted.push(e),
+      bunInstallFn: () => { throw new Error("bun install exploded"); },
+    });
+    const failEv = emitted.find((e) => e.event === "plugin.checkout.deps_install_failed");
+    expect(failEv).toBeDefined();
+    expect(failEv.severity).toBe("WARN");
+    expect(failEv.detail.package_dir).toBe("/repo/plugins/dev/scripts/orch-monitor/ui");
+    expect(emitted.some((e) => e.event === "plugin.checkout.updated")).toBe(true);
+    expect(res.failed).toBe(false);
+  });
+
+  test("plugin.checkout.updated detail carries deps_installed on the happy path", () => {
+    const emitted = [];
+    const gitFn = makeGitFnWithDiff({
+      diffOutput: "plugins/dev/scripts/orch-monitor/ui/package.json\n",
+    });
+    refreshPluginCheckout({
+      root: "/repo",
+      now: 0,
+      gitFn,
+      emitFn: (e) => emitted.push(e),
+      bunInstallFn: () => {},
+    });
+    const updEv = emitted.find((e) => e.event === "plugin.checkout.updated");
+    expect(updEv).toBeDefined();
+    expect(Array.isArray(updEv.detail.deps_installed)).toBe(true);
+    expect(updEv.detail.deps_installed).toContain("/repo/plugins/dev/scripts/orch-monitor/ui");
   });
 });

--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -46,6 +46,11 @@ MONITOR_DIR="$(cd "$(dirname "$SERVER_SCRIPT")" && pwd)"
 # CTL-1088: default out-of-repo dist dir for the vite build (single definition
 # used by both bootstrap and cmd_start).
 MONITOR_UI_DIST_DIR="${MONITOR_UI_DIST_DIR:-$CATALYST_DIR/monitor-ui-dist}"
+
+# CTL-1223: structured-event emission for silent vite-build failures. Best-effort.
+EVENTS_DIR="${CATALYST_EVENTS_DIR:-$CATALYST_DIR/events}"
+# shellcheck source=lib/canonical-event.sh
+[[ -f "$SCRIPT_DIR/lib/canonical-event.sh" ]] && source "$SCRIPT_DIR/lib/canonical-event.sh" || true
 FORWARD_PID_FILE="${CATALYST_DIR}/otel-forward.pid"
 FORWARD_LOG="${CATALYST_DIR}/otel-forward.log"
 FORWARD_SCRIPT="${SCRIPT_DIR}/otel-forward/index.ts"
@@ -197,7 +202,7 @@ bootstrap() {
       (cd "$MONITOR_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)
     fi
 
-    if [[ -d "$MONITOR_DIR/ui" && ! -d "$MONITOR_DIR/ui/node_modules" ]]; then
+    if [[ -d "$MONITOR_DIR/ui" ]] && { [[ ! -d "$MONITOR_DIR/ui/node_modules" ]] || [[ "$MONITOR_DIR/ui/bun.lock" -nt "$MONITOR_DIR/ui/node_modules" ]]; }; then
       echo "Installing orch-monitor UI dependencies..."
       (cd "$MONITOR_DIR/ui" && bun install --frozen-lockfile 2>/dev/null || bun install)
     fi
@@ -232,6 +237,21 @@ bootstrap() {
           [[ -n "$ui_source_sha" ]] && printf '%s\n' "$ui_source_sha" > "$built_sha_file"
         else
           echo "warning: orch-monitor vite build failed — serving previous dist (will retry next restart)" >&2
+          if declare -f build_canonical_line >/dev/null 2>&1; then
+            _bf_line="$(build_canonical_line \
+              --ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              --severity WARN \
+              --service catalyst.monitor \
+              --event-name "monitor.ui.build_failed" \
+              --entity monitor --action ui_build_failed \
+              --label "${rebuild_reason:-build_failed}" \
+              --payload-json "$(jq -cn --arg dir "$MONITOR_DIR" --arg sha "${ui_source_sha:-}" \
+                --arg built "${built_sha:-}" --arg reason "${rebuild_reason:-}" \
+                '{monitor_dir:$dir,ui_source_sha:$sha,built_sha:$built,rebuild_reason:$reason}' \
+                2>/dev/null || echo '{}')" \
+              2>/dev/null)" || _bf_line=""
+            [[ -n "$_bf_line" ]] && canonical_jsonl_append "$EVENTS_DIR" "$_bf_line" || true
+          fi
         fi
       fi
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-17T16:09:45Z -->
<!-- Last updated: 2026-06-17T16:09:45Z -->
<!-- PR: #2210 -->
<!-- Previous commits: ef8cd8b238e9570c2d24182d7a8c849008ced5ad -->

## Summary

Fixes a silent, recurring failure mode where the live orch-monitor UI freezes after any PR that adds or bumps an npm dependency. The broker's CTL-993 auto-pull (`plugin-refresh.mjs`) was pulling source but never running `bun install`, so missing deps caused the vite build to fail silently on every restart — the UI kept serving a stale bundle with no visible error.

Two complementary fixes:

1. **Broker-side**: `plugin-refresh.mjs` now diffs `package.json`/`bun.lock` between the old and new SHA after each pull, then runs `bun install` in every affected package directory before emitting the `plugin.checkout.updated` event.
2. **Monitor-side**: `catalyst-monitor.sh bootstrap()` now checks `ui/bun.lock` staleness (not just absent `node_modules`), and emits a structured `monitor.ui.build_failed` event to the unified event log when the vite build fails — making the failure visible to the broker/HUD instead of a silent stderr warning.

## Changes Made

### `plugins/dev/scripts/broker/plugin-refresh.mjs` (+66)

- Added `changedPackageDirs(repoRoot, diffOutput)` — parses a `git diff --name-only` result to find unique package directories that had `package.json` or `bun.lock` changed. Deduplicates multiple matches in the same dir.
- Extended `refreshPluginCheckout()` with a `bunInstallFn` injection seam (defaults to `bun install --frozen-lockfile || bun install`). After each successful pull where the HEAD advanced, it calls `changedPackageDirs()` on the `oldSha..newSha` diff and invokes `bunInstallFn` for each affected dir.
- Install failures emit `plugin.checkout.deps_install_failed` at `WARN` severity and do **not** fail the checkout (non-fatal, `result.failed` stays `false`). The `plugin.checkout.updated` event still fires and its `detail.deps_installed` array records which dirs were installed.
- If `oldSha` is null (e.g., rev-parse failed), the diff is skipped and install is not attempted.

### `plugins/dev/scripts/catalyst-monitor.sh` (+21/-1)

- **`ui/bun.lock` staleness check**: changed the `ui/node_modules` guard from `! -d` (absent only) to `! -d ... || bun.lock -nt node_modules`. This matches the existing server-package check directly above it and ensures installs run after any lockfile bump, not just on a fresh checkout.
- **Structured build-failure event**: when vite build fails, `bootstrap()` now sources `lib/canonical-event.sh` (best-effort, no-op if absent) and appends a `monitor.ui.build_failed` WARN event to `$CATALYST_EVENTS_DIR`. Fields: `monitor_dir`, `ui_source_sha`, `built_sha`, `rebuild_reason`. The existing stderr warning is preserved as a regression guard.

### `plugins/dev/scripts/broker/plugin-refresh.test.mjs` (+253)

Full unit-test coverage for the new seam:

- `changedPackageDirs`: package.json only, bun.lock only, both in same dir (deduped), multiple distinct dirs, no dependency-manifest change, empty/null diff, root-level package.json.
- `refreshPluginCheckout — bunInstallFn seam`: install runs on package.json/bun.lock change, dedupes, throttled call skips install, `oldSha` null skips install, `bunInstallFn` throws → `deps_install_failed` WARN + `updated` still emits + `result.failed=false`, `updated` event carries `deps_installed` array on happy path.

### `plugins/dev/scripts/__tests__/catalyst-monitor-bootstrap.test.sh` (+316)

Integration tests for the monitor-side changes (Phase 2 + Phase 3):

- Phase 2 (bun.lock staleness): `bun.lock` newer than `node_modules` → install runs; `node_modules` newer → install skipped; `node_modules` absent → install runs (existing behavior preserved); source guard verifies the staleness check is present in the script.
- Phase 3 (build-failure event): vite build failure still prints stderr warning (regression guard); vite build failure emits `monitor.ui.build_failed` event to the events dir.

## How to Verify It

- [x] CI passes: audit-references ✅, check-versions ✅, docs-gate ✅, validate ✅
- [ ] On a host running the broker: merge a PR that adds an npm dep to `orch-monitor/ui/package.json` → confirm broker runs `bun install` in that dir (event log shows `plugin.checkout.updated` with `deps_installed`) and the UI rebuilds with the new dep
- [ ] Simulate a vite build failure (e.g., with a broken import) and confirm the `monitor.ui.build_failed` WARN event appears in `~/catalyst/events/YYYY-MM.jsonl`

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1223

_Root cause incident: CTL-1208 added `@phosphor-icons/react` to `orch-monitor/ui/package.json`; the broker deployed source without installing the dep, the vite build failed silently on every restart, and the UI served a ~1.5-day-stale bundle until a manual `bun install` + `MONITOR_FORCE_BUILD=1` restart._

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1208
skip CTL-993
