### PR TITLE
fix(dev): remove CSS Size Containment from virtualizer scroll container (CTL-1254)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-model.test.ts
@@ -8,6 +8,8 @@ import {
   filterPickerItems,
   resolveActiveIconLabel,
   resolveAllIconsViewState,
+  GLYPH_GRID_SCROLL_CLASS,
+  GLYPH_GRID_SCROLL_STYLE,
 } from "./icon-picker-model";
 import type { IconCandidate } from "@/lib/repo-icons";
 import { PHOSPHOR_GLYPH_NAMES } from "@/lib/project-glyph-set";
@@ -142,6 +144,23 @@ describe("resolveAllIconsViewState", () => {
   });
   it("error precedence over no-matches", () => {
     expect(resolveAllIconsViewState({ namesEmpty: true, queryActive: true, filteredCount: 0 })).toBe("error");
+  });
+});
+
+describe("VirtualGlyphGrid scroll container (CTL-1254)", () => {
+  it("does NOT apply CSS Size Containment (which collapses clientHeight to 0)", () => {
+    const contain = GLYPH_GRID_SCROLL_STYLE.contain;
+    expect(contain).not.toContain("size");
+    expect(contain).not.toBe("strict"); // strict implies size
+  });
+
+  it("still applies paint isolation (preserves the CTL-1233 virtualization perf intent)", () => {
+    expect(GLYPH_GRID_SCROLL_STYLE.contain).toContain("paint");
+  });
+
+  it("keeps a scrollable, height-capped container", () => {
+    expect(GLYPH_GRID_SCROLL_CLASS).toContain("overflow-y-auto");
+    expect(GLYPH_GRID_SCROLL_CLASS).toContain("max-h-72");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-model.ts
@@ -118,6 +118,22 @@ export function resolveAllIconsViewState(input: {
   return "results";
 }
 
+/**
+ * Tailwind classes for the virtualized "All icons" scroll container.
+ * `overflow-y-auto` + `max-h-72` cap the box at 288 px and let it scroll; the inner
+ * total-size spacer drives the actual height in normal block layout.
+ */
+export const GLYPH_GRID_SCROLL_CLASS = "overflow-y-auto max-h-72";
+
+/**
+ * Inline style for the virtualized "All icons" scroll container.
+ * CTL-1254: uses `contain: "layout paint"` — NOT `strict`/`size`. CSS Size Containment
+ * (`contain: size`, included in `strict`) sized this box from an empty subtree, collapsing it
+ * to clientHeight: 0 so the virtualizer rendered 0 rows. `layout paint` keeps the isolation
+ * benefit without sizing the container from its (intentionally empty until scrolled) descendants.
+ */
+export const GLYPH_GRID_SCROLL_STYLE = { contain: "layout paint" } as const;
+
 /** Return a short label for the picker trigger button based on the current value. */
 export function resolveActiveIconLabel(value: string | null | undefined): string {
   if (!value) return "Auto";

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-popover.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-popover.tsx
@@ -34,6 +34,8 @@ import {
   filterPickerItems,
   resolveActiveIconLabel,
   resolveAllIconsViewState,
+  GLYPH_GRID_SCROLL_CLASS,
+  GLYPH_GRID_SCROLL_STYLE,
 } from "./icon-picker-model";
 import type { IconPickerItem } from "./icon-picker-model";
 import type { IconCandidate } from "@/lib/repo-icons";
@@ -127,8 +129,8 @@ function VirtualGlyphGrid({
   return (
     <div
       ref={parentRef}
-      className="overflow-y-auto max-h-72"
-      style={{ contain: "strict" }}
+      className={GLYPH_GRID_SCROLL_CLASS}
+      style={GLYPH_GRID_SCROLL_STYLE}
     >
       <div
         style={{


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-17T16:03:00Z -->
<!-- Last updated: 2026-06-17T16:03:00Z -->
<!-- PR: #2211 -->
<!-- Previous commits: 47f43f978aa3860e76a634b63a4b03008f1fcda4 -->

## Summary

Fixes the "All icons" virtualizer scroll container in the icon picker collapsing to `clientHeight: 0`.
The root cause was `contain: "strict"` — CSS Size Containment sizes a box from its descendants, but the virtualizer's scroll container has an intentionally empty DOM until the user scrolls, so the box collapsed to zero height and the virtualizer rendered 0 rows.

The fix replaces `contain: "strict"` with `contain: "layout paint"`, which preserves the paint-isolation benefit from CTL-1233 without the size-containment side effect. The scroll class and style are extracted to named constants in the model layer and covered by unit tests.

## Changes Made

### Frontend — `icon-picker-model.ts`
- Exported `GLYPH_GRID_SCROLL_CLASS = "overflow-y-auto max-h-72"` — Tailwind classes for the virtualizer scroll container
- Exported `GLYPH_GRID_SCROLL_STYLE = { contain: "layout paint" } as const` — inline style that avoids CSS Size Containment

### Frontend — `icon-picker-popover.tsx`
- `VirtualGlyphGrid` scroll `<div>` now uses `GLYPH_GRID_SCROLL_CLASS` / `GLYPH_GRID_SCROLL_STYLE` instead of hardcoded `"overflow-y-auto max-h-72"` / `{ contain: "strict" }`

### Tests — `icon-picker-model.test.ts`
- Added `VirtualGlyphGrid scroll container (CTL-1254)` describe block with 3 assertions:
  - `contain` does NOT include `"size"` and is not `"strict"`
  - `contain` still includes `"paint"` (preserves CTL-1233 intent)
  - scroll container class includes `overflow-y-auto` and `max-h-72`

## How to Verify It

- [x] TypeScript: `tsc --noEmit` clean ✅
- [x] Tests: `bun test` — 1626 pass / 0 fail (26 pass in target file) ✅
- [x] Lint: covered by tsc + vite build (ui/ excluded from repo eslint) ✅
- [x] Reward-hacking scan: no `as any` / `@ts-ignore` / `forEach(async` in added lines ✅
- [x] Security: no new deps or secrets ✅
- [x] Coverage: new constants fully covered by 3 new assertions ✅
- [ ] Manual: open the orch-monitor icon picker → "All icons" tab → verify grid renders icons and scrolls through the full set _(manual verification required)_
- [ ] Manual: type "fire" in the search → verify results from the full library appear _(manual verification required)_

## Changelog Entry

```
fix(dev): remove CSS Size Containment from virtualizer scroll container (CTL-1254)
```

- **What**: `contain: "strict"` in the icon picker's VirtualGlyphGrid scroll div collapsed `clientHeight` to 0, preventing the virtualizer from rendering any rows. Replaced with `contain: "layout paint"`.
- **Impact**: "All icons" grid in the orch-monitor icon picker now renders correctly.
- **Scope**: `orch-monitor/ui` only — no server, no orchestration logic.

## Related Issues/PRs

- Fixes https://linear.app/rozich/issue/CTL-1254/icon-picker-all-icons-is-empty-unsearchable-virtualizer-scroll
- Related to #2209 (CTL-1240 scheduler tick), #2208 (CTL-1243 stall routing) — sibling work in the same release
- CTL-1249 introduced the virtualized grid (fixed load hang); this PR fixes the resulting render collapse
- CTL-1233 introduced `contain: strict` for paint isolation — preserved as `contain: layout paint`

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1233
skip CTL-1240
skip CTL-1243
skip CTL-1249
