### PR TITLE
fix(dev): CTL-1242 — reap stale signals + needs-human fix for terminal/merged tickets

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -25,7 +25,10 @@ import {
   closeBrokerStateDb,
   getActiveWaitingSessions,
   deleteFilterState,
+  getAllTicketDescriptors,
+  upsertTicketDescriptor,
 } from "./broker-state.mjs";
+import { startTerminalNeedsHumanReconcile } from "./terminal-needs-human-reconcile.mjs";
 // CTL-532: re-export the worker-state store helpers through the barrel.
 export {
   upsertWorkerState,
@@ -518,6 +521,37 @@ function main() {
   startTailing();
   const watchdogId = startWatchdog();
   const driftCheckId = startDriftCheckWatcher();
+  // CTL-1242 (corrected scope): broker-side terminal needs-human cache reconcile.
+  // The board reads ticket_state.labels (not live Linear); a missed label-removed
+  // webhook leaves a stale `needs-human` cache label on a terminal ticket and the
+  // board keeps flagging a finished ticket. The broker is the sole ticket_state
+  // writer, so it strips the stale label here. Deterministic + idempotent +
+  // terminal-only — ships ENFORCE by default with the CATALYST_TERMINAL_NEEDS_HUMAN_RECONCILE
+  // kill-switch (=off | =shadow). Runs at boot + every interval; clears on shutdown.
+  const terminalNeedsHumanReconcileId = startTerminalNeedsHumanReconcile({
+    getAll: () => getAllTicketDescriptors(),
+    upsert: (input) => upsertTicketDescriptor(input),
+    log,
+    emit: (summary) => {
+      try {
+        appendEvent({
+          event: "broker.terminal-needs-human.reconciled",
+          orchestrator: null,
+          worker: null,
+          severity: "INFO",
+          detail: {
+            broker: true,
+            mode: summary.mode,
+            scanned: summary.scanned,
+            stripped: summary.stripped,
+            tickets: summary.items.map((i) => i.ticket),
+          },
+        });
+      } catch {
+        // Best-effort audit telemetry — never crash the broker on an emit.
+      }
+    },
+  });
   // CTL-1171: periodic liveness heartbeat so an idle broker doesn't false-report
   // "down" in the monitor (which keys off catalyst.broker event recency). Beat
   // immediately so the broker is fresh the moment it boots, then every interval.
@@ -560,6 +594,7 @@ function main() {
     clearInterval(heartbeatId); // CTL-1171: stop the liveness heartbeat
     clearInterval(driftCheckId); // CTL-1161: drift-check backstop timer
     if (cacheReconcileId) clearInterval(cacheReconcileId); // CTL-1277: cache reconcile
+    clearInterval(terminalNeedsHumanReconcileId); // CTL-1242: stop the needs-human reconcile
     // CTL-529: the debounce timer handles are router module-internal.
     clearDebounceTimers();
     // CTL-351: emit a parallel shutdown event so subscribers can pair

--- a/plugins/dev/scripts/broker/terminal-needs-human-reconcile.mjs
+++ b/plugins/dev/scripts/broker/terminal-needs-human-reconcile.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env bun
+// terminal-needs-human-reconcile.mjs — CTL-1242 (corrected scope): the
+// BROKER-side half of the needs-human terminal reap.
+//
+// WHY THIS EXISTS. The orch-monitor board derives its "needs-human" attention
+// badge from the LOCAL filter-state.db cache (ticket_state.labels, via
+// board-data.mjs deriveAttention) — NOT from live Linear. When a ticket reaches
+// a terminal Linear state (Done / Canceled / Duplicate) but the cache MISSES the
+// subsequent "label-removed" webhook (the CTL-1161 drift), the stale
+// `needs-human` cache label survives and the board keeps flagging a finished
+// ticket for attention (e.g. CTL-1186 "stuck 40h", CTL-1248).
+//
+// The execution-core terminal sweep (scheduler.mjs, CTL-1242 Phase 1) clears the
+// LINEAR label + the host-local `.linear-label-needs-human` marker, and the J4
+// janitor GCs the stale worker dir. But the broker is the SOLE writer of
+// ticket_state (execution-core opens filter-state.db read-only via
+// gateway-read.mjs), so only the broker can strip the CACHE label — and the
+// cache label is the one the board actually reads.
+//
+// This module is the durable form of the hand-run reconcile:
+//   UPDATE ticket_state SET labels = (labels − 'needs-human')
+//   WHERE linear_state IN (terminal) AND labels LIKE '%needs-human%';
+// It is deterministic, idempotent, and terminal-only. It keys off the cache's
+// OWN linear_state, so it can never contradict what the board renders from the
+// same row — no Linear fetch, no LLM. The cache-drift ROOT cause (re-syncing the
+// full label set from Linear on a missed webhook) is a SEPARATE fix
+// (CTL-1161 drift-check); this strips only the one stale escalation label that
+// leaks a finished ticket into needs-you.
+//
+// The pure decision helpers are exported for unit testing; the DB writes and the
+// interval wiring are exercised at runtime from index.mjs.
+
+// ── Pure helpers (unit-tested) ──────────────────────────────────────────────
+
+// TERMINAL_STATES — Linear workflow states a finished ticket settles into.
+// Mirrors backfill-ticket-labels.mjs's predicate (case-insensitive match against
+// the cached linear_state). A merged PR lands the ticket on `Done`, so the merged
+// case is covered by Done — no filter_state join needed.
+export const TERMINAL_STATES = new Set(["done", "canceled", "cancelled", "duplicate"]);
+
+export function isTerminalState(state) {
+  return typeof state === "string" && TERMINAL_STATES.has(state.toLowerCase());
+}
+
+// The escalation label the board's deriveAttention reads for the needs-human
+// bucket (board-data.mjs ATTENTION_LABEL_NEEDS_HUMAN). A terminal ticket never
+// legitimately carries it — once shipped/closed there is nothing to escalate.
+export const STALE_TERMINAL_LABEL = "needs-human";
+
+// decideTerminalNeedsHumanStrip — PURE decision for ONE descriptor. Returns
+// { strip, labels, reason }:
+//   • strip:true  only when the ticket is terminal AND its cached labels contain
+//     needs-human; `labels` is the new array (order-preserved, needs-human gone).
+//   • strip:false for a non-terminal ticket, a terminal ticket without the label,
+//     or an unusable labels field — `labels` is the stored value, untouched.
+// Idempotent: re-running on an already-stripped row returns strip:false.
+export function decideTerminalNeedsHumanStrip(descriptor) {
+  const state = descriptor?.state;
+  const labels = Array.isArray(descriptor?.labels) ? descriptor.labels : null;
+  if (!isTerminalState(state)) {
+    return { strip: false, labels, reason: "not terminal" };
+  }
+  if (!labels || !labels.includes(STALE_TERMINAL_LABEL)) {
+    return { strip: false, labels, reason: "no stale needs-human label" };
+  }
+  const next = labels.filter((l) => l !== STALE_TERMINAL_LABEL);
+  return {
+    strip: true,
+    labels: next,
+    reason: `terminal (${state}) — strip needs-human: ${JSON.stringify(labels)} → ${JSON.stringify(next)}`,
+  };
+}
+
+// MODES / readReconcileMode — the single operator knob. CTL-1242 corrected scope
+// ships ENFORCE by default (the board must stop flagging finished tickets), with
+// a kill-switch — UNLIKE the recovery passes (which ship off → shadow → enforce),
+// because this reconcile is deterministic, idempotent, and terminal-only:
+//   "0" | "off" → off, "shadow" → log-only, "enforce" → write, unset/other → enforce.
+export const MODES = new Set(["off", "shadow", "enforce"]);
+export function readReconcileMode(env = process.env) {
+  const v = env.CATALYST_TERMINAL_NEEDS_HUMAN_RECONCILE;
+  if (v === "0" || v === "off") return "off";
+  if (typeof v === "string" && MODES.has(v)) return v;
+  return "enforce"; // CTL-1242: default-on kill-switch
+}
+
+// ── Runtime sweep ───────────────────────────────────────────────────────────
+
+// reconcileTerminalNeedsHuman — ONE pass over the whole ticket_state cache. The
+// seams (getAll / upsert / emit / log / mode) are injected so the pass is
+// unit-testable without a real DB. Returns a summary
+// { mode, scanned, stripped, items:[{ticket, from, to}] }.
+//
+// Fail-soft throughout: a getAll throw aborts the pass (returns the empty
+// summary); a per-row upsert throw is logged and that row rolled back out of the
+// summary so the next pass retries it. Never throws to the caller.
+export function reconcileTerminalNeedsHuman({
+  getAll,
+  upsert,
+  emit = () => {},
+  log = console,
+  mode = readReconcileMode(),
+} = {}) {
+  const summary = { mode, scanned: 0, stripped: 0, items: [] };
+  if (mode === "off") return summary;
+
+  let descriptors;
+  try {
+    descriptors = getAll() ?? [];
+  } catch (err) {
+    log?.warn?.({ err: String(err) }, "terminal-needs-human-reconcile: getAll failed");
+    return summary;
+  }
+
+  for (const d of descriptors) {
+    summary.scanned++;
+    const decision = decideTerminalNeedsHumanStrip(d);
+    if (!decision.strip) continue;
+
+    if (mode === "shadow") {
+      summary.stripped++;
+      summary.items.push({ ticket: d.ticket, from: d.labels, to: decision.labels });
+      log?.info?.(
+        { ticket: d.ticket, reason: decision.reason },
+        "terminal-needs-human-reconcile: WOULD strip needs-human (shadow)"
+      );
+      continue;
+    }
+
+    // enforce — write the stripped label set back. KEY-PRESENCE upsert: only
+    // `labels` (+ updated_at) changes; every other column is left untouched.
+    try {
+      upsert({ ticket: d.ticket, labels: decision.labels });
+      summary.stripped++;
+      summary.items.push({ ticket: d.ticket, from: d.labels, to: decision.labels });
+      log?.info?.(
+        { ticket: d.ticket, reason: decision.reason },
+        "terminal-needs-human-reconcile: stripped stale needs-human (terminal)"
+      );
+    } catch (err) {
+      log?.warn?.(
+        { ticket: d.ticket, err: String(err) },
+        "terminal-needs-human-reconcile: upsert failed — leaving for next pass"
+      );
+    }
+  }
+
+  if (summary.stripped > 0) {
+    emit(summary);
+  }
+  return summary;
+}
+
+// startTerminalNeedsHumanReconcile — setInterval wrapper mirroring startWatchdog
+// (router.mjs). Runs once immediately so a stale label clears at boot, then on
+// the interval. Returns the timer handle; the caller clearInterval's it on
+// shutdown (index.mjs). The tick is fully guarded so a throw never crashes the
+// broker. `unref()` keeps the timer from holding the event loop open.
+export const RECONCILE_INTERVAL_MS = 60_000;
+export function startTerminalNeedsHumanReconcile(opts = {}) {
+  const tick = () => {
+    try {
+      reconcileTerminalNeedsHuman(opts);
+    } catch (err) {
+      (opts.log ?? console)?.warn?.(
+        { err: String(err) },
+        "terminal-needs-human-reconcile: tick threw"
+      );
+    }
+  };
+  tick(); // boot pass
+  const id = setInterval(tick, opts.intervalMs ?? RECONCILE_INTERVAL_MS);
+  if (typeof id?.unref === "function") id.unref();
+  return id;
+}

--- a/plugins/dev/scripts/broker/terminal-needs-human-reconcile.test.mjs
+++ b/plugins/dev/scripts/broker/terminal-needs-human-reconcile.test.mjs
@@ -1,0 +1,216 @@
+// Unit tests for terminal-needs-human-reconcile.mjs (CTL-1242 corrected scope).
+// Pure decision helpers + the mode reader + the seam-injected runtime sweep.
+// Run: bun test plugins/dev/scripts/broker/terminal-needs-human-reconcile.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import {
+  TERMINAL_STATES,
+  isTerminalState,
+  STALE_TERMINAL_LABEL,
+  decideTerminalNeedsHumanStrip,
+  readReconcileMode,
+  reconcileTerminalNeedsHuman,
+} from "./terminal-needs-human-reconcile.mjs";
+
+const silentLog = { info: () => {}, warn: () => {} };
+
+describe("isTerminalState", () => {
+  test("TERMINAL_STATES = done/canceled/cancelled/duplicate", () => {
+    expect([...TERMINAL_STATES].sort()).toEqual(
+      ["canceled", "cancelled", "done", "duplicate"].sort()
+    );
+  });
+  test("case-insensitive match on the terminal set", () => {
+    expect(isTerminalState("Done")).toBe(true);
+    expect(isTerminalState("DONE")).toBe(true);
+    expect(isTerminalState("Canceled")).toBe(true);
+    expect(isTerminalState("Duplicate")).toBe(true);
+  });
+  test("non-terminal states are false", () => {
+    expect(isTerminalState("In Progress")).toBe(false);
+    expect(isTerminalState("Triage")).toBe(false);
+    expect(isTerminalState("In Review")).toBe(false);
+  });
+  test("null / non-string → false", () => {
+    expect(isTerminalState(null)).toBe(false);
+    expect(isTerminalState(undefined)).toBe(false);
+    expect(isTerminalState(42)).toBe(false);
+  });
+});
+
+describe("decideTerminalNeedsHumanStrip", () => {
+  test("the stale label is needs-human", () => {
+    expect(STALE_TERMINAL_LABEL).toBe("needs-human");
+  });
+
+  test("terminal + needs-human present → strip, label removed, others kept", () => {
+    const d = { ticket: "CTL-1248", state: "Done", labels: ["monitor", "feature", "needs-human"] };
+    const out = decideTerminalNeedsHumanStrip(d);
+    expect(out.strip).toBe(true);
+    expect(out.labels).toEqual(["monitor", "feature"]);
+    expect(out.reason).toContain("strip needs-human");
+  });
+
+  test("terminal but no needs-human → no strip (labels untouched)", () => {
+    const d = { ticket: "CTL-1", state: "Done", labels: ["monitor", "feature"] };
+    const out = decideTerminalNeedsHumanStrip(d);
+    expect(out.strip).toBe(false);
+    expect(out.labels).toEqual(["monitor", "feature"]);
+  });
+
+  test("non-terminal WITH needs-human → no strip (a live escalation is preserved)", () => {
+    const d = { ticket: "CTL-1204", state: "In Progress", labels: ["needs-human"] };
+    const out = decideTerminalNeedsHumanStrip(d);
+    expect(out.strip).toBe(false);
+    expect(out.labels).toEqual(["needs-human"]);
+  });
+
+  test("canceled / duplicate are terminal too", () => {
+    expect(decideTerminalNeedsHumanStrip({ state: "Canceled", labels: ["needs-human"] }).strip).toBe(true);
+    expect(decideTerminalNeedsHumanStrip({ state: "Duplicate", labels: ["needs-human"] }).strip).toBe(true);
+  });
+
+  test("idempotent: re-running on an already-stripped row is a no-op", () => {
+    const first = decideTerminalNeedsHumanStrip({ state: "Done", labels: ["x", "needs-human"] });
+    expect(first.strip).toBe(true);
+    const second = decideTerminalNeedsHumanStrip({ state: "Done", labels: first.labels });
+    expect(second.strip).toBe(false);
+  });
+
+  test("null / missing labels → no strip, no throw", () => {
+    expect(decideTerminalNeedsHumanStrip({ state: "Done", labels: null }).strip).toBe(false);
+    expect(decideTerminalNeedsHumanStrip({ state: "Done" }).strip).toBe(false);
+    expect(decideTerminalNeedsHumanStrip(null).strip).toBe(false);
+  });
+
+  test("stripping the only label yields an empty array (not null)", () => {
+    const out = decideTerminalNeedsHumanStrip({ state: "Done", labels: ["needs-human"] });
+    expect(out.strip).toBe(true);
+    expect(out.labels).toEqual([]);
+  });
+});
+
+describe("readReconcileMode — CTL-1242 ships ENFORCE by default with a kill-switch", () => {
+  test("unset → enforce (the default-on differentiator)", () => {
+    expect(readReconcileMode({})).toBe("enforce");
+  });
+  test('"0" and "off" → off (kill-switch)', () => {
+    expect(readReconcileMode({ CATALYST_TERMINAL_NEEDS_HUMAN_RECONCILE: "0" })).toBe("off");
+    expect(readReconcileMode({ CATALYST_TERMINAL_NEEDS_HUMAN_RECONCILE: "off" })).toBe("off");
+  });
+  test('"shadow" → shadow, "enforce" → enforce', () => {
+    expect(readReconcileMode({ CATALYST_TERMINAL_NEEDS_HUMAN_RECONCILE: "shadow" })).toBe("shadow");
+    expect(readReconcileMode({ CATALYST_TERMINAL_NEEDS_HUMAN_RECONCILE: "enforce" })).toBe("enforce");
+  });
+  test("unrecognized value → enforce (fail toward the default)", () => {
+    expect(readReconcileMode({ CATALYST_TERMINAL_NEEDS_HUMAN_RECONCILE: "garbage" })).toBe("enforce");
+  });
+});
+
+describe("reconcileTerminalNeedsHuman — runtime sweep", () => {
+  const cache = () => [
+    { ticket: "CTL-1248", state: "Done", labels: ["monitor", "feature", "needs-human"] }, // strip
+    { ticket: "CTL-1186", state: "Done", labels: ["needs-human"] }, // strip → []
+    { ticket: "CTL-1204", state: "In Progress", labels: ["needs-human"] }, // KEEP (live)
+    { ticket: "CTL-2", state: "Done", labels: ["chore"] }, // nothing to strip
+  ];
+
+  test("enforce: writes the stripped set only for terminal+labelled rows", () => {
+    const writes = [];
+    const summary = reconcileTerminalNeedsHuman({
+      getAll: cache,
+      upsert: (input) => writes.push(input),
+      mode: "enforce",
+      log: silentLog,
+    });
+    expect(summary.scanned).toBe(4);
+    expect(summary.stripped).toBe(2);
+    expect(writes).toEqual([
+      { ticket: "CTL-1248", labels: ["monitor", "feature"] },
+      { ticket: "CTL-1186", labels: [] },
+    ]);
+    // The live (non-terminal) escalation is NOT touched.
+    expect(writes.find((w) => w.ticket === "CTL-1204")).toBeUndefined();
+  });
+
+  test("shadow: counts what it WOULD strip, writes nothing", () => {
+    const writes = [];
+    const summary = reconcileTerminalNeedsHuman({
+      getAll: cache,
+      upsert: (input) => writes.push(input),
+      mode: "shadow",
+      log: silentLog,
+    });
+    expect(summary.stripped).toBe(2);
+    expect(writes).toEqual([]);
+  });
+
+  test("off: scans nothing, writes nothing", () => {
+    const writes = [];
+    const summary = reconcileTerminalNeedsHuman({
+      getAll: cache,
+      upsert: (input) => writes.push(input),
+      mode: "off",
+      log: silentLog,
+    });
+    expect(summary.scanned).toBe(0);
+    expect(summary.stripped).toBe(0);
+    expect(writes).toEqual([]);
+  });
+
+  test("emit fires once with the stripped tickets when anything changed", () => {
+    const emitted = [];
+    reconcileTerminalNeedsHuman({
+      getAll: cache,
+      upsert: () => {},
+      emit: (s) => emitted.push(s),
+      mode: "enforce",
+      log: silentLog,
+    });
+    expect(emitted.length).toBe(1);
+    expect(emitted[0].tickets ?? emitted[0].items.map((i) => i.ticket)).toEqual([
+      "CTL-1248",
+      "CTL-1186",
+    ]);
+  });
+
+  test("emit does NOT fire when nothing was stripped", () => {
+    const emitted = [];
+    reconcileTerminalNeedsHuman({
+      getAll: () => [{ ticket: "CTL-2", state: "Done", labels: ["chore"] }],
+      upsert: () => {},
+      emit: (s) => emitted.push(s),
+      mode: "enforce",
+      log: silentLog,
+    });
+    expect(emitted).toEqual([]);
+  });
+
+  test("a per-row upsert throw is rolled back out of the summary, others still applied", () => {
+    const writes = [];
+    const summary = reconcileTerminalNeedsHuman({
+      getAll: cache,
+      upsert: (input) => {
+        if (input.ticket === "CTL-1248") throw new Error("db locked");
+        writes.push(input);
+      },
+      mode: "enforce",
+      log: silentLog,
+    });
+    expect(summary.stripped).toBe(1); // only CTL-1186 succeeded
+    expect(writes).toEqual([{ ticket: "CTL-1186", labels: [] }]);
+  });
+
+  test("getAll throw → empty summary, never throws to caller", () => {
+    const summary = reconcileTerminalNeedsHuman({
+      getAll: () => {
+        throw new Error("db unavailable");
+      },
+      upsert: () => {},
+      mode: "enforce",
+      log: silentLog,
+    });
+    expect(summary.scanned).toBe(0);
+    expect(summary.stripped).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/integration-ctl-1004.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-1004.test.mjs
@@ -442,3 +442,85 @@ describe("CTL-1045 Bug 1 — J2 kill-storm: ineffective-intent suppression in de
     expect(killed).toEqual(["ghostjob"]);
   });
 });
+
+// ── CTL-1242 J4 integration — real emitter end-to-end ────────────────────
+// Mirrors the CTL-1005/CTL-1056 J3 integration test: drives schedulerTick
+// with the REAL reap-intent emitter (emit NOT injected) to verify that
+// "janitor.would.gc" and "janitor.signals.gc" are registered in the
+// REAP_INTENT_TYPES closed vocabulary and don't throw.
+describe("CTL-1242 J4 integration — real emitter accepts janitor.signals.gc / janitor.would.gc", () => {
+  const gcCandidate = (ticket = "CTL-1242J4") => ({
+    ticket,
+    linearTerminalOrMerged: true,
+    liveSessionInWorktree: false,
+    inFlight: false,
+    alreadyGcd: false,
+  });
+
+  function realEmitterGcOpts({ mode, candidate, gcTerminalSignals = () => true }) {
+    return {
+      readEligible: () => [],
+      dispatch: () => ({ status: "dispatched" }),
+      exec: () => ({ code: null }),
+      reclaimDeadWork: () => ({ class: "alive-suppressed" }),
+      writeStatus: {
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+        runTransition: () => ({ applied: false }),
+      },
+      now: () => NOW,
+      watchdog: { mode: "off" },
+      stallJanitor: {
+        mode,
+        collectTerminalSignalGcCandidates: () => [candidate],
+        gcTerminalSignals,
+        // emit + recordKillIntent intentionally NOT injected → production seams.
+      },
+    };
+  }
+
+  function readEvents() {
+    const ym = new Date(NOW).toISOString().slice(0, 7);
+    const logPath = join(orchDir, "events", `${ym}.jsonl`);
+    if (!existsSync(logPath)) return [];
+    return readFileSync(logPath, "utf8")
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l));
+  }
+
+  let prevCatalystDir;
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = orchDir;
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+  });
+
+  test("shadow: janitor.would.gc is emitted WITHOUT throwing 'unknown reap-intent event type'", () => {
+    const result = schedulerTick(orchDir, realEmitterGcOpts({ mode: "shadow", candidate: gcCandidate() }));
+    expect(result.janitorWouldGc).toEqual([{ ticket: "CTL-1242J4" }]);
+    const ev = readEvents().find((e) => e.event === "janitor.would.gc");
+    expect(ev).toBeDefined();
+    expect(ev.ticket).toBe("CTL-1242J4");
+  });
+
+  test("enforce: janitor.signals.gc is emitted WITHOUT throwing", () => {
+    let gcd = null;
+    const result = schedulerTick(
+      orchDir,
+      realEmitterGcOpts({
+        mode: "enforce",
+        candidate: gcCandidate("CTL-1242J4K"),
+        gcTerminalSignals: ({ ticket }) => { gcd = ticket; return true; },
+      }),
+    );
+    expect(gcd).toBe("CTL-1242J4K");
+    expect(result.janitorSignalsGcd).toEqual([{ ticket: "CTL-1242J4K" }]);
+    const ev = readEvents().find((e) => e.event === "janitor.signals.gc");
+    expect(ev).toBeDefined();
+    expect(ev.ticket).toBe("CTL-1242J4K");
+  });
+});

--- a/plugins/dev/scripts/execution-core/janitor-event-types.mjs
+++ b/plugins/dev/scripts/execution-core/janitor-event-types.mjs
@@ -32,4 +32,7 @@ export const JANITOR_EVENT_TYPES = Object.freeze([
   // ---- J3 (prior-artifact-retry-exhausted stalls, CTL-1005) ------------------
   "janitor.stall.cleared", // enforce: a stall was auto-cleared once
   "janitor.would.clear", // shadow twin of janitor.stall.cleared
+  // ---- J4 (terminal/merged signal dir GC, CTL-1242) --------------------------
+  "janitor.signals.gc", // enforce: workers/<T>/ dir removed for a terminal ticket
+  "janitor.would.gc", // shadow twin of janitor.signals.gc
 ]);

--- a/plugins/dev/scripts/execution-core/reap-intent.test.mjs
+++ b/plugins/dev/scripts/execution-core/reap-intent.test.mjs
@@ -46,9 +46,9 @@ describe("emitReapIntent", () => {
     await expect(emitReapIntent("bogus.event", {})).rejects.toThrow(/unknown/);
   });
 
-  it("exposes REAP_INTENT_TYPES with 23 entries", async () => {
+  it("exposes REAP_INTENT_TYPES with 25 entries", async () => {
     const { REAP_INTENT_TYPES } = await freshModule();
-    expect(REAP_INTENT_TYPES.length).toBe(23);
+    expect(REAP_INTENT_TYPES.length).toBe(25); // +2 for CTL-1242 J4 (janitor.signals.gc, janitor.would.gc)
     expect(REAP_INTENT_TYPES).toContain("phase.yield.reap-requested");
     expect(REAP_INTENT_TYPES).toContain("pr.merged.cleanup-requested");
     expect(REAP_INTENT_TYPES).toContain("orphans.reap-requested");
@@ -69,6 +69,9 @@ describe("emitReapIntent", () => {
     // emitter and was silently lost: CTL-1004/CTL-1056).
     expect(REAP_INTENT_TYPES).toContain("janitor.stall.cleared");
     expect(REAP_INTENT_TYPES).toContain("janitor.would.clear");
+    // CTL-1242 J4 terminal/merged signal dir GC vocabulary.
+    expect(REAP_INTENT_TYPES).toContain("janitor.signals.gc");
+    expect(REAP_INTENT_TYPES).toContain("janitor.would.gc");
   });
 
   // CTL-1004/CTL-1056 regression guard: every event type the stall-janitor

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -32,6 +32,7 @@ import {
   writeFileSync,
   existsSync,
   renameSync,
+  unlinkSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { randomBytes } from "node:crypto";
@@ -1498,4 +1499,25 @@ export function defaultShouldSkipItem(ticket, opts = {}) {
   if (typeof last === "number" && now() - last < RECOVERY_COOLDOWN_MS) return true;
 
   return false;
+}
+
+// defaultForgetIntent — delete a ticket's recovery-intent ledger entry. The
+// inverse of defaultRecordIntent. CTL-1242 (corrected scope): when the execution-
+// core terminal sweep observes a ticket reach a terminal/merged state, it forgets
+// the host-local escalated/cooldown latch so the ledger does not accumulate stale
+// `.recovery-intents/<ticket>.json` files for finished tickets (which inflate the
+// lifetime-escalation count and keep a closed ticket in the host-local ledger).
+// The recovery router already drops terminal tickets via its backlog filter, so
+// this is hygiene — not a functional gate. Idempotent: a missing file is a no-op.
+// Returns true when a file was removed, false otherwise. Never throws.
+export function defaultForgetIntent(ticket, opts = {}) {
+  const orchDir = opts.orchDir ?? resolveOrchDir();
+  if (!orchDir || !ticket) return false;
+  const p = recoveryIntentPath(orchDir, ticket);
+  try {
+    unlinkSync(p);
+    return true;
+  } catch {
+    return false; // absent (ENOENT) or unremovable → nothing to forget
+  }
 }

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -13,6 +13,7 @@ import {
   buildRecoveryEnvelope,
   defaultRecordIntent,
   defaultShouldSkipItem,
+  defaultForgetIntent,
   defaultInvokeRemediateCapped,
   defaultInvokeRecoveryPass,
   RECOVERY_PASS_CYCLE_CAP,
@@ -952,6 +953,30 @@ describe("recovery-intent ledger (cooldown + max-attempts + escalated)", () => {
     // none is injected. Force that by passing orchDir: null explicitly.
     expect(defaultRecordIntent("CTL-998", { decision: "fix" }, { orchDir: null })).toBeNull();
     expect(defaultShouldSkipItem("CTL-998", { orchDir: null })).toBe(false);
+  });
+
+  // CTL-1242 (corrected scope): forget the latch when a ticket goes terminal.
+  test("forgetIntent removes the ledger entry → a later shouldSkip is false", () => {
+    const now = 1_000_000_000_000;
+    defaultRecordIntent("CTL-306", { decision: "escalate" }, { orchDir, now: () => now });
+    // Escalated latch would skip forever…
+    expect(defaultShouldSkipItem("CTL-306", { orchDir, now: () => now + 1 })).toBe(true);
+    // …until the terminal sweep forgets it.
+    expect(defaultForgetIntent("CTL-306", { orchDir })).toBe(true);
+    expect(defaultShouldSkipItem("CTL-306", { orchDir, now: () => now + 2 })).toBe(false);
+  });
+
+  test("forgetIntent on an absent ledger → false (idempotent no-op, never throws)", () => {
+    expect(defaultForgetIntent("CTL-307", { orchDir })).toBe(false);
+    // Re-running after a real forget is also a no-op.
+    defaultRecordIntent("CTL-308", { decision: "fix", fix_class: "x" }, { orchDir, now: () => 1 });
+    expect(defaultForgetIntent("CTL-308", { orchDir })).toBe(true);
+    expect(defaultForgetIntent("CTL-308", { orchDir })).toBe(false);
+  });
+
+  test("forgetIntent with no orchDir / no ticket → false (fail-soft)", () => {
+    expect(defaultForgetIntent("CTL-309", { orchDir: null })).toBe(false);
+    expect(defaultForgetIntent("", { orchDir })).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -184,6 +184,8 @@ import {
   defaultCollectOrphanCandidates,
   defaultCollectGhostCandidates,
   defaultCollectStallClearCandidates, // CTL-1005 J3
+  defaultCollectTerminalSignalGcCandidates, // CTL-1242 J4
+  defaultGcTerminalSignals, // CTL-1242 J4
 } from "./stall-janitor.mjs";
 // CTL-1064: unstuck-sweep (Pass 0u) — throttled classify-then-act sweep for
 // the stalled/needs-human ticket backlog. Pure classifiers + action driver in
@@ -2709,6 +2711,11 @@ export function schedulerTick(
       // below. Tests inject stubs to drive J3 in isolation.
       collectStallClearCandidates: _collectStallClearCandidates = undefined,
       clearStall: _clearStall = undefined,
+      // CTL-1242 J4: terminal/merged signal dir GC seams. Defaults undefined →
+      // inert (bare unit tick has no census → skip cleanly); production wires
+      // defaultCollectTerminalSignalGcCandidates + defaultGcTerminalSignals below.
+      collectTerminalSignalGcCandidates: _collectTerminalSignalGcCandidates = undefined,
+      gcTerminalSignals: _gcTerminalSignals = undefined,
       emit: _janitorEmit = emitReapIntent,
       recordKillIntent: _recordKillIntent = undefined,
     } = {},
@@ -3250,6 +3257,8 @@ export function schedulerTick(
   let janitorDeferred = [];
   let janitorStallsCleared = [];
   let janitorWouldClear = [];
+  let janitorSignalsGcd = [];
+  let janitorWouldGc = [];
   // CTL-1064: Pass 0u report arrays (populated below if the pass runs).
   let unstuckActed = [];
   let unstuckWouldAct = [];
@@ -3262,7 +3271,8 @@ export function schedulerTick(
     // startScheduler, or a test injecting it). A bare tick has none → skip cleanly.
     if (
       jMode !== "off" &&
-      (_collectOrphanCandidates || _collectGhostCandidates || _collectStallClearCandidates)
+      (_collectOrphanCandidates || _collectGhostCandidates || _collectStallClearCandidates ||
+        _collectTerminalSignalGcCandidates)
     ) {
       try {
         const jreport = runStallJanitorPass({
@@ -3277,6 +3287,9 @@ export function schedulerTick(
           // .janitor-cleared-<phase>.applied once-marker, and lets the scheduler's
           // normal path re-dispatch. writeStatus carries the removeLabel seam.
           clearStall: _clearStall ?? defaultClearStall(orchDir, writeStatus),
+          // CTL-1242 J4: terminal/merged signal dir GC.
+          collectTerminalSignalGcCandidates: _collectTerminalSignalGcCandidates ?? (() => []),
+          gcTerminalSignals: _gcTerminalSignals ?? (() => false),
           emit: _janitorEmit,
           // Default kill seam: BOTH issues killBgJob AND records the pinned
           // intent (mirrors recovery.mjs intentAwareKill). CTL-1004 J2-enforce
@@ -3293,13 +3306,17 @@ export function schedulerTick(
         janitorDeferred = jreport.deferred;
         janitorStallsCleared = jreport.stallsCleared;
         janitorWouldClear = jreport.wouldClear;
+        janitorSignalsGcd = jreport.signalsGcd;
+        janitorWouldGc = jreport.wouldGc;
         if (
           janitorReaped.length ||
           janitorKillIntents.length ||
           janitorWouldReap.length ||
           janitorWouldKill.length ||
           janitorStallsCleared.length ||
-          janitorWouldClear.length
+          janitorWouldClear.length ||
+          janitorSignalsGcd.length ||
+          janitorWouldGc.length
         ) {
           log.info(
             {
@@ -3311,8 +3328,10 @@ export function schedulerTick(
               deferred: janitorDeferred.length,
               stallsCleared: janitorStallsCleared.length,
               wouldClear: janitorWouldClear.length,
+              signalsGcd: janitorSignalsGcd.length,
+              wouldGc: janitorWouldGc.length,
             },
-            "scheduler: stall-janitor pass (CTL-1004/CTL-1005)"
+            "scheduler: stall-janitor pass (CTL-1004/CTL-1005/CTL-1242)"
           );
         }
       } catch (err) {
@@ -5034,6 +5053,8 @@ export function schedulerTick(
     janitorDeferred, // CTL-1004 — dirty worktrees deferred (no removal, no queue)
     janitorStallsCleared, // CTL-1005 — prior-artifact-retry-exhausted stalls CLEARED this tick (enforce)
     janitorWouldClear, // CTL-1005 — stalls that WOULD be cleared (shadow)
+    janitorSignalsGcd, // CTL-1242 — terminal signal dirs GC'd this tick (enforce)
+    janitorWouldGc, // CTL-1242 — signal dirs that WOULD be GC'd (shadow)
     unstuckActed, // CTL-1064 — Pass 0u actions taken this tick (enforce)
     unstuckWouldAct, // CTL-1064 — Pass 0u would-act (shadow)
     unstuckEscalated, // CTL-1064 — Pass 0u escalations this tick (enforce)
@@ -5398,6 +5419,23 @@ function runTick() {
             },
           }),
         clearStall: defaultClearStall(runningOpts.orchDir, runningOpts.writeStatus ?? linearWrite),
+        // CTL-1242 J4: wire the read-only GC census + the production rmSync seam.
+        // The census only probes tickets whose workers/<T>/ dir exists AND whose
+        // Linear state is provably terminal (Done/Canceled). Same closure shape
+        // as J3's isLinearTerminal — cache-first, no extra subprocess.
+        // Mode is the existing jMode (readStallJanitorConfig() → default 'shadow')
+        // so J4 runs in shadow by default; no new config knob needed.
+        collectTerminalSignalGcCandidates: () =>
+          defaultCollectTerminalSignalGcCandidates({
+            orchDir: runningOpts.orchDir,
+            agents: getAgentsCached().agents,
+            inFlightTickets: listInFlightTickets(runningOpts.orchDir),
+            isLinearTerminalOrMerged: (id) => {
+              const state = fetchTicketState(id);
+              return state != null && isLinearTerminal(state);
+            },
+          }),
+        gcTerminalSignals: defaultGcTerminalSignals(runningOpts.orchDir),
       },
       // CTL-1064: wire the unstuck-sweep census (Pass 0u). The census collects
       // stalled/failed workers lazily; the pass only runs when mode !== 'off'

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -212,6 +212,10 @@ import {
   reasoningRecoveryPass,
   defaultShouldSkipItem as recoveryShouldSkipItem,
   defaultRecordIntent as recoveryRecordIntent,
+  // CTL-1242 (corrected scope): forget the host-local recovery-intent latch when
+  // a ticket goes terminal so the ledger doesn't accumulate stale finished-ticket
+  // files (called from the terminal-sweep clear branch below).
+  defaultForgetIntent as recoveryForgetIntent,
   defaultInvokeSeam as recoveryInvokeSeam,
   // CTL-1176 rung 3: the bounded-LLM path now dispatches the goal-driven
   // recovery-pass skill (replacing the phase-remediate detour). Bound to the
@@ -4969,6 +4973,10 @@ export function schedulerTick(
         if (existsSync(`${base}.applied`) || existsSync(`${base}.skipped`)) {
           clearStalledLabel(orchDir, ticket, "needs-human", retractionWriteStatus);
         }
+        // CTL-1242 (corrected scope): also forget the host-local recovery-intent
+        // latch so a finished ticket's escalated/cooldown ledger entry doesn't
+        // linger (hygiene — the recovery router already drops terminal tickets).
+        recoveryForgetIntent(ticket, { orchDir });
       } else {
         // Non-terminal stalled/failed ticket → apply the belief-aware needs-human
         // label (CTL-1241: skipped when the belief engine owns the reclaim).

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4932,17 +4932,41 @@ export function schedulerTick(
     // above; never (re)apply for a genuinely-shipped ticket (the Done false positive).
     const pipelineDone = signals[TERMINAL_PHASE] === "done";
     if ((anyStalled || anyFailed) && !pipelineDone) {
-      if (fenceGuard({ ticket, orchDir, multiHost })) {
-        labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, writeStatus, { env, site: "terminal-sweep", log });
+      // CTL-1242: a merged/terminal-Linear ticket that skipped teardown must NOT be
+      // re-flagged needs-human. Cheap-first terminal probe (cached Linear read, then
+      // optional gh PR view) runs ONLY on this narrow stalled/failed-not-done set, so
+      // the steady-state-zero-writes invariant holds.
+      const term = isTicketTerminalOrMerged({
+        ticket,
+        signal: signalByTicket.get(ticket),
+        fetchState: (id, o = {}) => fetchTicketState(id, { ...o, cache, gateway }),
+        cache,
+        prAdapter,
+      });
+      if (term.terminal) {
+        // Terminal/merged but teardown never ran → clear the marker+label instead of
+        // re-applying. Marker-guarded so a no-marker terminal ticket fires zero API calls.
+        const base = join(orchDir, "workers", ticket, ".linear-label-needs-human");
+        if (existsSync(`${base}.applied`) || existsSync(`${base}.skipped`)) {
+          clearStalledLabel(orchDir, ticket, "needs-human", retractionWriteStatus);
+        }
       } else {
-        log.warn(
-          { ticket },
-          "ctl-863: stale fence — suppressing labelOnce(needs-human/failed-or-stalled) write (zombie guard)"
-        );
+        // Non-terminal stalled/failed ticket → apply the belief-aware needs-human
+        // label (CTL-1241: skipped when the belief engine owns the reclaim).
+        if (fenceGuard({ ticket, orchDir, multiHost })) {
+          labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, writeStatus, { env, site: "terminal-sweep", log });
+        } else {
+          log.warn(
+            { ticket },
+            "ctl-863: stale fence — suppressing labelOnce(needs-human/failed-or-stalled) write (zombie guard)"
+          );
+        }
+        // CTL-868 route (B): emit a canonical orphan-detected event (once) so a
+        // non-terminal stalled/failed-no-recovery ticket is visible on the dashboard
+        // (runs regardless of fence, matching main; the terminal branch above is
+        // excluded so a finished ticket is never re-surfaced as an orphan).
+        emitOrphanDetectedOnce(orchDir, ticket, signals, appendOrphanDetectedEvent);
       }
-      // CTL-868 route (B): also emit a canonical orphan-detected event (once) so a
-      // stalled/failed-no-recovery ticket is visible on the dashboard, not just label-flagged.
-      emitOrphanDetectedOnce(orchDir, ticket, signals, appendOrphanDetectedEvent);
     } else {
       // No failed/stalled phase (or pipeline done) → clear the ratchet if the marker exists.
       // Guard on marker presence so a no-stall/no-fail, no-marker tick fires zero

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -4286,6 +4286,193 @@ describe("schedulerTick — label write-back (CTL-558)", () => {
   });
 });
 
+// ── CTL-1242: terminal-sweep needs-human clear for merge-without-teardown ───
+//
+// A ticket that reaches Linear Done / merged-PR WITHOUT teardown completing
+// was being re-flagged needs-human every tick because the anyStalled/anyFailed
+// branch ran before any terminal-or-merged probe. These tests drive the fix:
+// isTicketTerminalOrMerged runs ONLY on the narrow stalled/failed-not-done set
+// and clears (never re-applies) needs-human for terminal/merged tickets.
+//
+// Gateway controls fetchTicketState without any network calls. The fresh
+// timestamp is within the 60 s GATEWAY_STATE_FRESH_MS window.
+
+describe("schedulerTick — terminal-sweep needs-human clear (CTL-1242)", () => {
+  const FRESH = new Date().toISOString(); // within 60 s gateway-fresh window
+
+  const noWrites1242 = () => ({
+    applyPhaseStatus() {},
+    applyTerminalDone() {},
+  });
+
+  // T1: merge-without-teardown + failed signal → clears, never re-applies
+  test("CTL-1242 T1: failed signal + Linear Done → clears needs-human, does not re-apply", () => {
+    const TICKET = "CTL-1242-T1";
+    writeSignal(TICKET, "implement", "failed");
+    // Pre-seed the .applied marker (simulates a prior tick that already applied it)
+    const base = join(orchDir, "workers", TICKET, ".linear-label-needs-human");
+    writeFileSync(`${base}.applied`, "");
+
+    const removed = [];
+    const applied = [];
+    const writeStatus = {
+      ...noWrites1242(),
+      applyLabel: (a) => { applied.push(a); return { applied: true }; },
+      removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; },
+    };
+    const gateway = {
+      getDescriptor: (id) =>
+        id === TICKET
+          ? { state: "Done", removed: false, updatedAt: FRESH }
+          : null,
+    };
+
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus,
+      gateway,
+    });
+
+    // removeLabel called for needs-human
+    expect(removed.some((r) => r.t === TICKET && r.l === "needs-human")).toBe(true);
+    // applyLabel must NOT have been called for needs-human
+    expect(applied.some((a) => a.ticket === TICKET && a.label === "needs-human")).toBe(false);
+    // marker deleted
+    expect(existsSync(`${base}.applied`)).toBe(false);
+  });
+
+  // T2: merged PR (Linear non-terminal) → clears
+  test("CTL-1242 T2: failed signal + merged PR (Linear non-terminal) → clears needs-human", () => {
+    const TICKET = "CTL-1242-T2";
+    // Seed a failed signal that carries a PR number.
+    // parseSignal stores the full file JSON as signal.raw, so signal.raw.pr
+    // reads the TOP-LEVEL pr field in the file — not a nested raw.pr key.
+    const dir = join(orchDir, "workers", TICKET);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-implement.json"),
+      JSON.stringify({ ticket: TICKET, phase: "implement", status: "failed", pr: { number: 99 } })
+    );
+    const base = join(orchDir, "workers", TICKET, ".linear-label-needs-human");
+    writeFileSync(`${base}.applied`, "");
+
+    const removed = [];
+    const applied = [];
+    const writeStatus = {
+      ...noWrites1242(),
+      applyLabel: (a) => { applied.push(a); return { applied: true }; },
+      removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; },
+    };
+    // Linear state is non-terminal; PR is merged → terminal via pr-merged path
+    const gateway = {
+      getDescriptor: (id) =>
+        id === TICKET
+          ? { state: "In Review", removed: false, updatedAt: FRESH }
+          : null,
+    };
+    const prAdapter = { prView: () => ({ state: "MERGED", mergedAt: "2026-06-17T00:00:00Z" }) };
+
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus,
+      gateway,
+      prAdapter,
+    });
+
+    expect(removed.some((r) => r.t === TICKET && r.l === "needs-human")).toBe(true);
+    expect(applied.some((a) => a.ticket === TICKET && a.label === "needs-human")).toBe(false);
+    expect(existsSync(`${base}.applied`)).toBe(false);
+  });
+
+  // T3: non-terminal + stalled signal → still re-applies (regression guard)
+  // (emitOrphanDetectedOnce only fires for stalled phases; failed-only tickets still
+  // apply needs-human but skip the orphan event — use stalled to hit both assertions.)
+  test("CTL-1242 T3: stalled signal + non-terminal Linear + no merged PR → still applies needs-human", () => {
+    const TICKET = "CTL-1242-T3";
+    writeSignal(TICKET, "implement", "stalled");
+
+    const applied = [];
+    const removed = [];
+    const writeStatus = {
+      ...noWrites1242(),
+      applyLabel: (a) => { applied.push(a); return { applied: true }; },
+      removeLabel: (t, l) => { removed.push({ t, l }); return { removed: true }; },
+    };
+    const gateway = {
+      getDescriptor: (id) =>
+        id === TICKET
+          ? { state: "In Progress", removed: false, updatedAt: FRESH }
+          : null,
+    };
+    const orphans = [];
+    const appendOrphanDetectedEvent = (e) => { orphans.push(e); return true; };
+
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus,
+      gateway,
+      appendOrphanDetectedEvent,
+    });
+
+    expect(applied.some((a) => a.ticket === TICKET && a.label === "needs-human")).toBe(true);
+    expect(removed.filter((r) => r.t === TICKET && r.l === "needs-human")).toHaveLength(0);
+    expect(orphans.some((o) => o.ticket === TICKET)).toBe(true);
+  });
+
+  // T4: steady-state-zero-writes — no stalled/failed, no marker → zero needs-human writes
+  // (The terminal-or-merged probe only runs inside the anyStalled||anyFailed branch, so a
+  // ticket with only done/running phases must produce zero needs-human label API calls.)
+  test("CTL-1242 T4: no stalled/failed signal → zero needs-human label writes (zero-writes invariant)", () => {
+    const TICKET = "CTL-1242-T4";
+    // Only a done implement signal — no stalled/failed, no teardown (no .terminal-done.applied
+    // marker written, so the reconcile backstop never probes the gateway for this ticket).
+    writeSignal(TICKET, "implement", "done");
+
+    const nhWrites = [];
+    const writeStatus = {
+      ...noWrites1242(),
+      applyLabel: (a) => { if (a.label === "needs-human") nhWrites.push({ kind: "apply", ...a }); return { applied: true }; },
+      removeLabel: (t, l) => { if (l === "needs-human") nhWrites.push({ kind: "remove", t, l }); return { removed: true }; },
+    };
+
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus,
+    });
+
+    // Zero needs-human label writes for this non-stalled ticket
+    expect(nhWrites.filter((w) => (w.ticket ?? w.t) === TICKET)).toHaveLength(0);
+  });
+
+  // T5: fail-safe — fetchTicketState returns null + no PR → re-applies (never false clear)
+  test("CTL-1242 T5: fetchTicketState returns null + no PR → fail-safe re-applies needs-human", () => {
+    const TICKET = "CTL-1242-T5";
+    writeSignal(TICKET, "implement", "stalled");
+
+    const applied = [];
+    const writeStatus = {
+      ...noWrites1242(),
+      applyLabel: (a) => { applied.push(a); return { applied: true }; },
+      removeLabel: () => ({ removed: true }),
+    };
+    // gateway returns null → fetchTicketState returns null → non-terminal (D5 fail-safe)
+    const gateway = { getDescriptor: () => null };
+
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus,
+      gateway,
+    });
+
+    expect(applied.some((a) => a.ticket === TICKET && a.label === "needs-human")).toBe(true);
+  });
+});
+
 // ── CTL-1079: retraction sweep reads from broker cache instead of live API ──
 // These tests use an exec spy + the real removeLabel (from linear-write.mjs)
 // to verify that gateway cache hits suppress the live `linearis issues read`

--- a/plugins/dev/scripts/execution-core/stall-janitor.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.mjs
@@ -34,7 +34,7 @@
 // classifyGhostSession — all evidence injected, no IO) + an action driver
 // (runStallJanitorPass — every side-effect seam injected).
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { log } from "./config.mjs";
@@ -64,6 +64,8 @@ const JANITOR_EVENT = Object.freeze({
   wouldKillIntent: JANITOR_EVENT_TYPES[3], // "janitor.would.kill-intent"
   stallCleared: JANITOR_EVENT_TYPES[4], // "janitor.stall.cleared"
   wouldClear: JANITOR_EVENT_TYPES[5], // "janitor.would.clear"
+  signalsGcd: JANITOR_EVENT_TYPES[6], // "janitor.signals.gc"
+  wouldGc: JANITOR_EVENT_TYPES[7], // "janitor.would.gc"
 });
 
 // classifyOrphanWorktree (J1) — PURE. Given the fully-resolved evidence for one
@@ -187,6 +189,27 @@ export function classifyStallClear(ctx = {}) {
   return { action: "clear", reason: "prior-artifact-now-complete" };
 }
 
+// classifyTerminalSignalGc (J4, CTL-1242) — PURE. Given a ticket that has been
+// identified as terminal/merged, decide whether its workers/<T>/ signal dir can
+// be GC'd this tick. Safety fences first, then positive "gc" verdict:
+//   "gc"   — ticket is terminal/merged, no live session, not in-flight, not already GC'd.
+//   "skip" — anything ambiguous, live, in-flight, or already removed.
+//
+// ctx fields:
+//   linearTerminalOrMerged — ticket is terminal via Linear state OR merged PR.
+//   liveSessionInWorktree  — a live session has its cwd inside the ticket's worktree.
+//   inFlight               — the ticket has an active (non-terminal) phase worker.
+//   alreadyGcd             — a .janitor-gc.applied marker is present in the worker dir,
+//                            meaning a prior GC write started but the dir wasn't removed
+//                            (e.g., EACCES). Prevents infinite retry.
+export function classifyTerminalSignalGc(ctx = {}) {
+  if (!ctx.linearTerminalOrMerged) return { action: "skip", reason: "not-terminal-or-merged" };
+  if (ctx.liveSessionInWorktree) return { action: "skip", reason: "live-session-in-worktree" };
+  if (ctx.inFlight) return { action: "skip", reason: "in-flight" };
+  if (ctx.alreadyGcd) return { action: "skip", reason: "already-gc'd" };
+  return { action: "gc", reason: "terminal-or-merged-no-live-session" };
+}
+
 // runStallJanitorPass — the action driver. Enumerates the terminal-Done orphan
 // candidates + ghost-session candidates (injected census seams), classifies each,
 // and either ACTS (enforce) or SHADOWS (would.*). Returns a per-tick report:
@@ -225,6 +248,9 @@ export function runStallJanitorPass({
   collectOrphanCandidates = () => [],
   collectGhostCandidates = () => [],
   collectStallClearCandidates = () => [],
+  // CTL-1242 J4: terminal/merged signal dir GC census + action seam.
+  collectTerminalSignalGcCandidates = () => [],
+  gcTerminalSignals = () => false,
   emit = async () => true,
   recordKillIntent = () => false,
   clearStall = () => false,
@@ -232,6 +258,7 @@ export function runStallJanitorPass({
   const report = {
     reaped: [], wouldReap: [], killIntents: [], wouldKill: [], deferred: [],
     stallsCleared: [], wouldClear: [],
+    signalsGcd: [], wouldGc: [],
   };
 
   // off → skip the pass entirely: no census, no events, no intents.
@@ -381,6 +408,47 @@ export function runStallJanitorPass({
       log.warn(
         { ticket: c?.ticket, err: err?.message },
         "stall-janitor: per-stall-clear step failed — continuing (CTL-1005)",
+      );
+    }
+  }
+
+  // ---- J4: terminal/merged signal dir GC → remove workers/<T>/ (CTL-1242) ---
+  // A ticket that reached a terminal Linear state (Done/Canceled) or whose PR
+  // merged without a teardown phase retains stale phase-*.json signal files
+  // forever, keeping the ticket in dead/stale views and in listStartedTickets.
+  // In enforce the gcTerminalSignals seam removes the entire workers/<T>/ dir;
+  // in shadow it emits janitor.would.gc and mutates nothing.
+  let gcCandidates = [];
+  try {
+    gcCandidates = collectTerminalSignalGcCandidates() ?? [];
+  } catch (err) {
+    log.warn({ err: err?.message }, "stall-janitor: gc census threw — skipping J4 (CTL-1242)");
+    gcCandidates = [];
+  }
+  for (const c of gcCandidates) {
+    try {
+      const decision = classifyTerminalSignalGc(c);
+      if (decision.action !== "gc") continue;
+      if (enforce) {
+        gcTerminalSignals({ ticket: c.ticket });
+        fire(
+          JANITOR_EVENT.signalsGcd,
+          { ticket: c.ticket, reason: decision.reason },
+          c.ticket,
+        );
+        report.signalsGcd.push({ ticket: c.ticket });
+      } else {
+        fire(
+          JANITOR_EVENT.wouldGc,
+          { ticket: c.ticket, reason: decision.reason },
+          c.ticket,
+        );
+        report.wouldGc.push({ ticket: c.ticket });
+      }
+    } catch (err) {
+      log.warn(
+        { ticket: c?.ticket, err: err?.message },
+        "stall-janitor: per-gc step failed — continuing (CTL-1242)",
       );
     }
   }
@@ -744,6 +812,79 @@ export function defaultCollectStallClearCandidates({
       });
     } catch (err) {
       log.warn({ ticket, err: err?.message }, "stall-janitor: stall-clear candidate probe threw — skipping (CTL-1005)");
+    }
+  }
+  return out;
+}
+
+// defaultGcTerminalSignals (CTL-1242 J4) — returns the J4 action seam: a
+// function that removes the entire workers/<T>/ signal dir for a terminal
+// ticket. Best-effort (never throws — a failed rmSync is caught and logged).
+// Called by runStallJanitorPass in enforce mode after classifyTerminalSignalGc
+// returns "gc". The dir removal clears the ticket from listStartedTickets
+// and from all dead/stale views in the next tick.
+export function defaultGcTerminalSignals(orchDir) {
+  return ({ ticket }) => {
+    try {
+      rmSync(join(orchDir, "workers", ticket), { recursive: true, force: true });
+      return true;
+    } catch (err) {
+      log.warn({ ticket, err: err?.message }, "stall-janitor: J4 gc rmSync failed — skipping (CTL-1242)");
+      return false;
+    }
+  };
+}
+
+// defaultCollectTerminalSignalGcCandidates (CTL-1242 J4) — read-only census
+// that builds a J4 classify ctx for every ticket with a workers/<T>/ dir.
+// Probes: isLinearTerminalOrMerged (injected), liveSessionInWorktree (warm
+// agents snapshot + optional worktree resolution), inFlight (inFlightTickets
+// set), alreadyGcd (.janitor-gc.applied marker). Any throw per-candidate is
+// caught and skipped — the janitor never escalates on unreadable probes.
+export function defaultCollectTerminalSignalGcCandidates({
+  orchDir,
+  agents = [],
+  inFlightTickets = new Set(),
+  isLinearTerminalOrMerged = () => false,
+  // resolveWorktreePath(ticket) → worktree path or null. Optional: when
+  // omitted, liveSessionInWorktree is always false (conservative).
+  resolveWorktreePath = () => null,
+} = {}) {
+  const out = [];
+  let workerDirs;
+  try {
+    workerDirs = readdirSync(join(orchDir, "workers"), { withFileTypes: true });
+  } catch {
+    return out;
+  }
+
+  for (const d of workerDirs) {
+    if (!d.isDirectory()) continue;
+    const ticket = d.name;
+    try {
+      const workerDir = join(orchDir, "workers", ticket);
+
+      // Pre-filter: only include tickets that are provably terminal/merged.
+      // Non-terminal tickets are never candidates for J4 GC.
+      let terminalOrMerged = false;
+      try { terminalOrMerged = isLinearTerminalOrMerged(ticket) === true; } catch { /* skip */ }
+      if (!terminalOrMerged) continue;
+
+      const worktreePath = (() => { try { return resolveWorktreePath(ticket); } catch { return null; } })();
+      const liveSessionInWorktree =
+        !!worktreePath &&
+        Array.isArray(agents) &&
+        agents.some((a) => cwdUnder(a?.cwd, worktreePath));
+
+      const inFlight = inFlightTickets instanceof Set
+        ? inFlightTickets.has(ticket)
+        : false;
+
+      const alreadyGcd = existsSync(join(workerDir, ".janitor-gc.applied"));
+
+      out.push({ ticket, linearTerminalOrMerged: true, liveSessionInWorktree, inFlight, alreadyGcd });
+    } catch (err) {
+      log.warn({ ticket, err: err?.message }, "stall-janitor: J4 gc candidate probe threw — skipping (CTL-1242)");
     }
   }
   return out;

--- a/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
@@ -12,17 +12,20 @@
 // CTL-729 watchdog split (hung-detector.mjs decision + watchdog-action.mjs effects).
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   classifyOrphanWorktree,
   classifyGhostSession,
   classifyStallClear,
+  classifyTerminalSignalGc,
   runStallJanitorPass,
   defaultCollectOrphanCandidates,
   defaultCollectGhostCandidates,
   defaultCollectStallClearCandidates,
+  defaultCollectTerminalSignalGcCandidates,
+  defaultGcTerminalSignals,
   defaultTicketFromCwd,
 } from "./stall-janitor.mjs";
 
@@ -851,5 +854,253 @@ describe("defaultCollectStallClearCandidates (CTL-1005 J3)", () => {
     });
     // The marker file survives the restart — alreadyCleared reads true from disk.
     expect(out[0].alreadyCleared).toBe(true);
+  });
+});
+
+// ===========================================================================
+// J4 (CTL-1242) — GC stale signal dirs for provably terminal/merged tickets
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// J4 classifier — classifyTerminalSignalGc (PURE)
+// ---------------------------------------------------------------------------
+describe("classifyTerminalSignalGc (CTL-1242 J4)", () => {
+  const base = {
+    linearTerminalOrMerged: true,
+    liveSessionInWorktree: false,
+    inFlight: false,
+    alreadyGcd: false,
+  };
+
+  test("gc when linear terminal + no live session + not in-flight + not already gc'd", () => {
+    expect(classifyTerminalSignalGc(base).action).toBe("gc");
+  });
+
+  test("skip when not terminal/merged", () => {
+    const d = classifyTerminalSignalGc({ ...base, linearTerminalOrMerged: false });
+    expect(d.action).toBe("skip");
+    expect(d.reason).toBe("not-terminal-or-merged");
+  });
+
+  test("skip when live session in worktree", () => {
+    const d = classifyTerminalSignalGc({ ...base, liveSessionInWorktree: true });
+    expect(d.action).toBe("skip");
+    expect(d.reason).toBe("live-session-in-worktree");
+  });
+
+  test("skip when in-flight (active worker signal)", () => {
+    const d = classifyTerminalSignalGc({ ...base, inFlight: true });
+    expect(d.action).toBe("skip");
+    expect(d.reason).toBe("in-flight");
+  });
+
+  test("skip when already GC'd this worker-dir lifetime", () => {
+    const d = classifyTerminalSignalGc({ ...base, alreadyGcd: true });
+    expect(d.action).toBe("skip");
+    expect(d.reason).toBe("already-gc'd");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// J4 driver — runStallJanitorPass (gcTerminalSignals seam injected)
+// ---------------------------------------------------------------------------
+function makeGcWorld(overrides = {}) {
+  return {
+    orphanCandidates: [],
+    ghostCandidates: [],
+    stallCandidates: [],
+    gcCandidates: [
+      {
+        ticket: "CTL-1242-J4",
+        linearTerminalOrMerged: true,
+        liveSessionInWorktree: false,
+        inFlight: false,
+        alreadyGcd: false,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeGcOpts(world, { mode, events = [], gcd = [] } = {}) {
+  return {
+    mode,
+    collectOrphanCandidates: () => world.orphanCandidates,
+    collectGhostCandidates: () => world.ghostCandidates,
+    collectStallClearCandidates: () => world.stallCandidates,
+    collectTerminalSignalGcCandidates: () => world.gcCandidates,
+    emit: (type, fields) => {
+      events.push({ type, ...fields });
+      return Promise.resolve(true);
+    },
+    gcTerminalSignals: ({ ticket }) => {
+      gcd.push(ticket);
+      return true;
+    },
+  };
+}
+
+describe("runStallJanitorPass — J4 enforce (CTL-1242)", () => {
+  test("gc: calls gcTerminalSignals + emits janitor.signals.gc", async () => {
+    const events = [];
+    const gcd = [];
+    const res = await runStallJanitorPass(makeGcOpts(makeGcWorld(), { mode: "enforce", events, gcd }));
+    expect(gcd).toEqual(["CTL-1242-J4"]);
+    const ev = events.find((e) => e.type === "janitor.signals.gc");
+    expect(ev).toBeDefined();
+    expect(ev.ticket).toBe("CTL-1242-J4");
+    expect(res.signalsGcd).toEqual([{ ticket: "CTL-1242-J4" }]);
+    expect(res.wouldGc).toEqual([]);
+  });
+
+  test("non-terminal ticket: gcTerminalSignals NOT called, no gc event", async () => {
+    const gcd = [];
+    const world = makeGcWorld({
+      gcCandidates: [{ ...makeGcWorld().gcCandidates[0], linearTerminalOrMerged: false }],
+    });
+    const res = await runStallJanitorPass(makeGcOpts(world, { mode: "enforce", gcd }));
+    expect(gcd).toEqual([]);
+    expect(res.signalsGcd).toEqual([]);
+  });
+
+  test("live-session: gcTerminalSignals NOT called", async () => {
+    const gcd = [];
+    const world = makeGcWorld({
+      gcCandidates: [{ ...makeGcWorld().gcCandidates[0], liveSessionInWorktree: true }],
+    });
+    await runStallJanitorPass(makeGcOpts(world, { mode: "enforce", gcd }));
+    expect(gcd).toEqual([]);
+  });
+});
+
+describe("runStallJanitorPass — J4 shadow (CTL-1242)", () => {
+  test("shadow: emits janitor.would.gc, never calls gcTerminalSignals", async () => {
+    const events = [];
+    const gcd = [];
+    const res = await runStallJanitorPass(makeGcOpts(makeGcWorld(), { mode: "shadow", events, gcd }));
+    expect(gcd).toEqual([]);
+    expect(events.filter((e) => e.type === "janitor.signals.gc")).toHaveLength(0);
+    const would = events.find((e) => e.type === "janitor.would.gc");
+    expect(would).toBeDefined();
+    expect(would.ticket).toBe("CTL-1242-J4");
+    expect(res.wouldGc).toEqual([{ ticket: "CTL-1242-J4" }]);
+    expect(res.signalsGcd).toEqual([]);
+  });
+});
+
+describe("runStallJanitorPass — J4 off (CTL-1242)", () => {
+  test("mode:off → J4 census never collected, no gc", async () => {
+    let collected = false;
+    const gcd = [];
+    const world = makeGcWorld();
+    const opts = makeGcOpts(world, { mode: "off", gcd });
+    opts.collectTerminalSignalGcCandidates = () => {
+      collected = true;
+      return world.gcCandidates;
+    };
+    const res = await runStallJanitorPass(opts);
+    expect(collected).toBe(false);
+    expect(gcd).toEqual([]);
+    expect(res.signalsGcd).toEqual([]);
+    expect(res.wouldGc).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// J4 production seams — defaultGcTerminalSignals + defaultCollectTerminalSignalGcCandidates
+// ---------------------------------------------------------------------------
+describe("defaultGcTerminalSignals (CTL-1242 J4 integration)", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "ctl1242-gc-"));
+  });
+  afterEach(() => rmSync(orchDir, { recursive: true, force: true }));
+
+  test("removes the workers/<T>/ dir and returns true", () => {
+    const workerDir = join(orchDir, "workers", "CTL-1242-GC");
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, "phase-implement.json"), JSON.stringify({ status: "failed" }));
+
+    const gc = defaultGcTerminalSignals(orchDir);
+    const result = gc({ ticket: "CTL-1242-GC" });
+
+    expect(result).toBe(true);
+    expect(existsSync(workerDir)).toBe(false);
+  });
+
+  test("never throws on ENOENT (already removed)", () => {
+    const gc = defaultGcTerminalSignals(orchDir);
+    expect(() => gc({ ticket: "CTL-1242-GONE" })).not.toThrow();
+  });
+});
+
+describe("defaultCollectTerminalSignalGcCandidates (CTL-1242 J4)", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "ctl1242-cen-"));
+  });
+  afterEach(() => rmSync(orchDir, { recursive: true, force: true }));
+
+  function mkWorkerSignal(ticket, status = "failed") {
+    const d = join(orchDir, "workers", ticket);
+    mkdirSync(d, { recursive: true });
+    writeFileSync(join(d, "phase-implement.json"), JSON.stringify({ ticket, status }));
+    return d;
+  }
+
+  test("includes a terminal ticket with a failed signal", () => {
+    mkWorkerSignal("CTL-1242-A");
+    const out = defaultCollectTerminalSignalGcCandidates({
+      orchDir,
+      isLinearTerminalOrMerged: (id) => id === "CTL-1242-A",
+    });
+    expect(out.some((c) => c.ticket === "CTL-1242-A")).toBe(true);
+    const c = out.find((c) => c.ticket === "CTL-1242-A");
+    expect(c.linearTerminalOrMerged).toBe(true);
+    expect(c.inFlight).toBe(false);
+    expect(c.liveSessionInWorktree).toBe(false);
+  });
+
+  test("excludes non-terminal tickets", () => {
+    mkWorkerSignal("CTL-1242-B");
+    const out = defaultCollectTerminalSignalGcCandidates({
+      orchDir,
+      isLinearTerminalOrMerged: () => false,
+    });
+    expect(out.some((c) => c.ticket === "CTL-1242-B")).toBe(false);
+  });
+
+  test("excludes in-flight tickets", () => {
+    mkWorkerSignal("CTL-1242-C");
+    const out = defaultCollectTerminalSignalGcCandidates({
+      orchDir,
+      isLinearTerminalOrMerged: () => true,
+      inFlightTickets: new Set(["CTL-1242-C"]),
+    });
+    const c = out.find((o) => o.ticket === "CTL-1242-C");
+    expect(c?.inFlight).toBe(true);
+  });
+
+  test("live-session-in-worktree sets liveSessionInWorktree:true", () => {
+    mkWorkerSignal("CTL-1242-D");
+    const out = defaultCollectTerminalSignalGcCandidates({
+      orchDir,
+      isLinearTerminalOrMerged: () => true,
+      agents: [{ cwd: "/wt/CTL-1242-D/subdir" }],
+      resolveWorktreePath: () => "/wt/CTL-1242-D",
+    });
+    const c = out.find((o) => o.ticket === "CTL-1242-D");
+    expect(c?.liveSessionInWorktree).toBe(true);
+  });
+
+  test("alreadyGcd:true when .janitor-gc.applied marker present", () => {
+    const d = mkWorkerSignal("CTL-1242-E");
+    writeFileSync(join(d, ".janitor-gc.applied"), "");
+    const out = defaultCollectTerminalSignalGcCandidates({
+      orchDir,
+      isLinearTerminalOrMerged: () => true,
+    });
+    const c = out.find((o) => o.ticket === "CTL-1242-E");
+    expect(c?.alreadyGcd).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

CTL-1242 — reap stale needs-human on terminal/merged tickets across all three
surfaces a stuck ticket leaks into. The board derives its needs-human badge from
the **local filter-state.db cache** (ticket_state.labels), so clearing only the
Linear label/marker (Phase 1/2) wasn't enough — Phase 3 strips the stale **cache**
label, which is the one the board actually reads.

- **Phase 1** — Fix "needs-you leak": the terminal-sweep in `scheduler.mjs`
  re-applied the `needs-human` Linear label every tick for merged/terminal tickets
  that still had stalled/failed signals. Fix: probe `isTicketTerminalOrMerged`
  inside the `(anyStalled||anyFailed) && !pipelineDone` branch and clear the label
  (+ markers) instead of re-applying. Also forgets the host-local recovery-intent
  latch (`defaultForgetIntent`) so a finished ticket's ledger entry doesn't linger.

- **Phase 2** — Fix "dead/stale signal dir leak": J4 janitor pass in
  `runStallJanitorPass` GCs `workers/<T>/` dirs for provably terminal/merged
  tickets. Runs in **shadow** by default (same `jMode` as J1–J3).

- **Phase 3 (corrected scope)** — Fix the **board's stale needs-human**: the
  board reads `ticket_state.labels` from the broker cache, not live Linear. A
  missed "label-removed" webhook leaves a stale `needs-human` cache label on a
  terminal ticket (CTL-1186, CTL-1248) and the board keeps flagging it. Execution-
  core opens filter-state.db **read-only** (`gateway-read.mjs`), so the **broker**
  — the sole `ticket_state` writer — strips it. New
  `broker/terminal-needs-human-reconcile.mjs`: deterministic, idempotent,
  terminal-only sweep (the durable form of the hand-run sqlite reconcile), wired
  into the broker's periodic loop at boot + interval. Ships **enforce** by default
  with a kill-switch (`CATALYST_TERMINAL_NEEDS_HUMAN_RECONCILE=off|shadow`).

## Changes

- `scheduler.mjs` — terminal probe inside the stalled-label path; recovery-intent
  latch clear; J4 seams wired through `startScheduler`
- `stall-janitor.mjs` — `classifyTerminalSignalGc`, `defaultGcTerminalSignals`,
  `defaultCollectTerminalSignalGcCandidates`
- `janitor-event-types.mjs` — `janitor.signals.gc` / `janitor.would.gc` event types
- `recovery-reasoning.mjs` — `defaultForgetIntent` (inverse of `defaultRecordIntent`)
- `broker/terminal-needs-human-reconcile.mjs` — the broker-side cache reconcile (new)
- `broker/index.mjs` — start/stop the reconcile watcher + audit event emit
- Tests: 5 CTL-1242 scheduler tests; 17 + 2 janitor/integration tests;
  reap-intent count 23→25; 3 `defaultForgetIntent` tests; 23 broker reconcile tests

## Test plan

- [x] `bun test scheduler.test.mjs` — 506 pass (conflict-resolution regression check)
- [x] `bun test recovery-reasoning.test.mjs` — 92 pass (incl. forgetIntent)
- [x] `bun test stall-janitor.test.mjs reap-intent.test.mjs` — 87 pass
- [x] `bun test terminal-needs-human-reconcile.test.mjs` — 23 pass
- [x] `bun test broker-state.test.mjs` — 19 pass
- [ ] Full suite regression in CI (local `pino` is uninstalled — pre-existing, affects index/config-importing suites only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)