### PR TITLE
CTL-1248: Operators can drag-reorder project groups in monitor navigation

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/project-reorder.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/project-reorder.test.ts
@@ -49,13 +49,11 @@ describe("CTL-1248 Phase 2 — order atom + reconcile wired into AppSidebar", ()
   it("the per-project render loop iterates orderedRepos.map, not repos.map", () => {
     // orderedRepos.map must appear in the file
     expect(sidebarCode).toMatch(/orderedRepos\.map\s*\(/);
-    // The raw repos.map loop should NOT be the per-project iterator anymore.
-    // (repos.map may still appear in comments or the repoIconDataUrls build loop —
-    // but not as the Collapsible render loop's iterator.)
-    // We check that the Collapsible render is driven by orderedRepos:
-    const collapsibleIdx = sidebarCode.indexOf("<Collapsible");
-    const orderedReposIdx = sidebarCode.lastIndexOf("orderedRepos.map", collapsibleIdx);
-    expect(orderedReposIdx).toBeGreaterThan(-1);
+    // The JSX usage <SortableProjectGroup must appear after orderedRepos.map
+    const orderedMapIdx = sidebarCode.indexOf("orderedRepos.map");
+    const sortableGroupJsxIdx = sidebarCode.indexOf("<SortableProjectGroup", orderedMapIdx);
+    expect(orderedMapIdx).toBeGreaterThan(-1);
+    expect(sortableGroupJsxIdx).toBeGreaterThan(-1);
   });
 });
 
@@ -136,7 +134,8 @@ describe("CTL-1248 Phase 3 — dnd-kit sortable wired into AppSidebar", () => {
 
   it("Observe block appears AFTER </SortableContext> in source (Observe is not sortable)", () => {
     const closeSc = sidebarCode.lastIndexOf("</SortableContext>");
-    const observeIdx = sidebarCode.indexOf("navObserveOpenAtom", closeSc);
+    // Use "group/observe" className which appears ONLY in the Observe render section
+    const observeIdx = sidebarCode.indexOf("group/observe", closeSc);
     expect(closeSc).toBeGreaterThan(-1);
     expect(observeIdx).toBeGreaterThan(-1);
   });

--- a/plugins/dev/scripts/orch-monitor/__tests__/project-reorder.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/project-reorder.test.ts
@@ -1,0 +1,152 @@
+// project-reorder.test.ts — CTL-1248 wiring guards.
+//
+// Static-source assertions that the drag-reorder feature is correctly wired in
+// app-sidebar.tsx: the persisted order atom and pure reconcile helper are imported
+// and used, the per-project loop iterates orderedRepos, dnd-kit sortable context
+// wraps the loop, and the structural groups (Overall/Observe) are outside it.
+//
+// DOM-free, no jotai runtime needed. Rides in `bun run check` alongside
+// app-shell-ia.test.ts and observe-nav.test.ts.
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const UI_SRC = join(HERE, "..", "ui", "src");
+const read = (rel: string) => readFileSync(join(UI_SRC, rel), "utf8");
+const readMonRoot = (rel: string) => readFileSync(join(HERE, "..", rel), "utf8");
+
+const sidebarSrc = read("components/app-sidebar.tsx");
+const packageJson = readMonRoot("ui/package.json");
+
+/** Strip JS/JSX comments so structural assertions can't be tripped by prose. */
+function stripComments(src: string): string {
+  return src
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+const sidebarCode = stripComments(sidebarSrc);
+
+// ── Phase 2: atom + reconcile imported and wired ──────────────────────────────
+
+describe("CTL-1248 Phase 2 — order atom + reconcile wired into AppSidebar", () => {
+  it("imports navProjectOrderAtom from nav-store", () => {
+    expect(sidebarSrc).toContain("navProjectOrderAtom");
+  });
+
+  it("imports reconcileProjectOrder from nav-model", () => {
+    expect(sidebarSrc).toContain("reconcileProjectOrder");
+  });
+
+  it("derives orderedRepos using reconcileProjectOrder and the atom value", () => {
+    expect(sidebarCode).toMatch(/reconcileProjectOrder\s*\(/);
+    expect(sidebarCode).toContain("orderedRepos");
+  });
+
+  it("the per-project render loop iterates orderedRepos.map, not repos.map", () => {
+    // orderedRepos.map must appear in the file
+    expect(sidebarCode).toMatch(/orderedRepos\.map\s*\(/);
+    // The raw repos.map loop should NOT be the per-project iterator anymore.
+    // (repos.map may still appear in comments or the repoIconDataUrls build loop —
+    // but not as the Collapsible render loop's iterator.)
+    // We check that the Collapsible render is driven by orderedRepos:
+    const collapsibleIdx = sidebarCode.indexOf("<Collapsible");
+    const orderedReposIdx = sidebarCode.lastIndexOf("orderedRepos.map", collapsibleIdx);
+    expect(orderedReposIdx).toBeGreaterThan(-1);
+  });
+});
+
+// ── Phase 3: dnd-kit sortable integration ────────────────────────────────────
+
+describe("CTL-1248 Phase 3 — dnd-kit sortable wired into AppSidebar", () => {
+  it("imports @dnd-kit/sortable symbols", () => {
+    expect(sidebarSrc).toContain("@dnd-kit/sortable");
+    expect(sidebarSrc).toContain("SortableContext");
+    expect(sidebarSrc).toContain("useSortable");
+    expect(sidebarSrc).toContain("arrayMove");
+    expect(sidebarSrc).toContain("verticalListSortingStrategy");
+  });
+
+  it("imports @dnd-kit/core symbols (DndContext, PointerSensor, KeyboardSensor)", () => {
+    expect(sidebarSrc).toContain("DndContext");
+    expect(sidebarSrc).toContain("PointerSensor");
+    expect(sidebarSrc).toContain("KeyboardSensor");
+    expect(sidebarSrc).toContain("sortableKeyboardCoordinates");
+  });
+
+  it("imports restrictToVerticalAxis from @dnd-kit/modifiers", () => {
+    expect(sidebarSrc).toContain("restrictToVerticalAxis");
+  });
+
+  it("imports GripVertical from lucide-react", () => {
+    expect(sidebarSrc).toContain("GripVertical");
+  });
+
+  it("SortableContext wraps orderedRepos.map and uses verticalListSortingStrategy", () => {
+    const scIdx = sidebarCode.indexOf("<SortableContext");
+    expect(scIdx).toBeGreaterThan(-1);
+    const afterSc = sidebarCode.slice(scIdx);
+    // orderedRepos.map must appear inside the SortableContext opening
+    const mapIdx = afterSc.indexOf("orderedRepos.map");
+    expect(mapIdx).toBeGreaterThan(-1);
+    expect(sidebarCode).toContain("verticalListSortingStrategy");
+  });
+
+  it("modifiers={[restrictToVerticalAxis]} is present on DndContext", () => {
+    expect(sidebarCode).toMatch(/modifiers=\{\[restrictToVerticalAxis\]\}/);
+  });
+
+  it("the grip button carries {...attributes} and {...listeners} with aria-label", () => {
+    expect(sidebarCode).toContain("{...attributes}");
+    expect(sidebarCode).toContain("{...listeners}");
+    // aria-label on the grip (reorder-related)
+    expect(sidebarCode).toMatch(/aria-label=.*[Rr]eorder/);
+  });
+
+  it("{...listeners} does NOT appear on the CollapsibleTrigger", () => {
+    // Listeners must only be on the grip button, never on CollapsibleTrigger
+    const ctIdx = sidebarCode.indexOf("CollapsibleTrigger");
+    expect(ctIdx).toBeGreaterThan(-1);
+    // Look for the pattern: CollapsibleTrigger ... {...listeners} on the SAME element
+    // Strategy: find the CollapsibleTrigger open tag and check there's no listeners spread before the next >
+    const ctTag = sidebarCode.slice(ctIdx, sidebarCode.indexOf(">", ctIdx + 20));
+    expect(ctTag).not.toContain("{...listeners}");
+  });
+
+  it("onDragEnd uses setProjectOrder(arrayMove(...))", () => {
+    expect(sidebarCode).toContain("setProjectOrder");
+    expect(sidebarCode).toMatch(/arrayMove\s*\(/);
+  });
+
+  it("useSensors includes PointerSensor with activationConstraint and KeyboardSensor", () => {
+    expect(sidebarCode).toContain("activationConstraint");
+    expect(sidebarCode).toContain("useSensors");
+  });
+
+  it("Overall block appears BEFORE SortableContext in source (Overall is not sortable)", () => {
+    const overallIdx = sidebarCode.indexOf("navOverallOpenAtom");
+    const scIdx = sidebarCode.indexOf("<SortableContext");
+    expect(overallIdx).toBeGreaterThan(-1);
+    expect(scIdx).toBeGreaterThan(-1);
+    expect(overallIdx).toBeLessThan(scIdx);
+  });
+
+  it("Observe block appears AFTER </SortableContext> in source (Observe is not sortable)", () => {
+    const closeSc = sidebarCode.lastIndexOf("</SortableContext>");
+    const observeIdx = sidebarCode.indexOf("navObserveOpenAtom", closeSc);
+    expect(closeSc).toBeGreaterThan(-1);
+    expect(observeIdx).toBeGreaterThan(-1);
+  });
+
+  it("ui/package.json has @dnd-kit/sortable ^8.x, core stays ^6.3.1, modifiers ^9.0.0", () => {
+    expect(packageJson).toMatch(/"@dnd-kit\/sortable":\s*"\^8\./);
+    expect(packageJson).toMatch(/"@dnd-kit\/core":\s*"\^6\.3\.1"/);
+    expect(packageJson).toMatch(/"@dnd-kit\/modifiers":\s*"\^9\.0\.0"/);
+    // Negative: sortable must NOT be ^9 or ^10 (would require core ^7)
+    expect(packageJson).not.toMatch(/"@dnd-kit\/sortable":\s*"\^9\./);
+    expect(packageJson).not.toMatch(/"@dnd-kit\/sortable":\s*"\^10\./);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/bun.lock
+++ b/plugins/dev/scripts/orch-monitor/ui/bun.lock
@@ -8,6 +8,8 @@
         "@dagrejs/dagre": "^3.0.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@phosphor-icons/react": "^2.1.10",
         "@tanstack/react-router": "^1.170.15",
         "@tanstack/react-table": "^8.21.3",
@@ -94,6 +96,8 @@
     "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
 
     "@dnd-kit/modifiers": ["@dnd-kit/modifiers@9.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@8.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.1.0", "react": ">=16.8.0" } }, "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g=="],
 
     "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 

--- a/plugins/dev/scripts/orch-monitor/ui/package.json
+++ b/plugins/dev/scripts/orch-monitor/ui/package.json
@@ -11,6 +11,8 @@
     "@dagrejs/dagre": "^3.0.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@phosphor-icons/react": "^2.1.10",
     "@tanstack/react-router": "^1.170.15",
     "@tanstack/react-table": "^8.21.3",

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/nav-store.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/nav-store.test.ts
@@ -19,6 +19,7 @@ import {
   recentlyViewedAtom,
   recordRecentAtom,
   RECENTLY_VIEWED_KEY,
+  navProjectOrderAtom,
 } from "./nav-store";
 
 // Minimal in-memory localStorage so atomWithStorage's default storage — which
@@ -133,5 +134,46 @@ describe("nav-store — recentlyViewedAtom persistence (survives a reload)", () 
     const unsub2 = store2.sub(recentlyViewedAtom, () => {});
     expect(store2.get(recentlyViewedAtom)).toEqual(["CTL-831", "CTL-845"]);
     unsub2();
+  });
+});
+
+// ── CTL-1248: navProjectOrderAtom ────────────────────────────────────────────
+
+describe("nav-store — navProjectOrderAtom (CTL-1248)", () => {
+  it("defaults to an empty array", () => {
+    const store = createStore();
+    expect(store.get(navProjectOrderAtom)).toEqual([]);
+  });
+
+  it("round-trips a project order array (set + get)", () => {
+    const store = createStore();
+    const unsub = store.sub(navProjectOrderAtom, () => {});
+    store.set(navProjectOrderAtom, ["catalyst", "adva"]);
+    expect(store.get(navProjectOrderAtom)).toEqual(["catalyst", "adva"]);
+    unsub();
+  });
+
+  it("persists to localStorage under the catalyst-nav-project-order-v1 key", () => {
+    const store = createStore();
+    const unsub = store.sub(navProjectOrderAtom, () => {});
+    store.set(navProjectOrderAtom, ["adva", "catalyst"]);
+    const raw = (globalThis as unknown as { window: { localStorage: Storage } }).window.localStorage.getItem(
+      "catalyst-nav-project-order-v1",
+    );
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!)).toEqual(["adva", "catalyst"]);
+    unsub();
+  });
+
+  it("does not collide with the catalyst-nav-groups-v1 key", () => {
+    const store = createStore();
+    const unsub = store.sub(navProjectOrderAtom, () => {});
+    store.set(navProjectOrderAtom, ["catalyst"]);
+    const groupsRaw = (globalThis as unknown as { window: { localStorage: Storage } }).window.localStorage.getItem(
+      "catalyst-nav-groups-v1",
+    );
+    // groups key should NOT be set by the order atom
+    expect(groupsRaw).toBeNull();
+    unsub();
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/nav-store.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/nav-store.ts
@@ -63,6 +63,14 @@ export const navGroupsOpenAtom = atomWithStorage<Record<string, boolean>>(
   {},
 );
 
+// CTL-1248: operator's preferred per-project nav order (repo short-names, in order).
+// Membership stays roster-driven; this atom is authoritative for ORDER only.
+// Default [] === "no saved order" → reconcile returns the live roster verbatim.
+export const navProjectOrderAtom = atomWithStorage<string[]>(
+  "catalyst-nav-project-order-v1",
+  [],
+);
+
 // ── section open-state for the Overall + Observe groups (CTL-1034) ───────────
 /**
  * CTL-1034: EVERY top-level sidebar section is collapsible — not just the

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar-nav-v3.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar-nav-v3.test.ts
@@ -179,7 +179,9 @@ describe("CTL-980 nav proportion v3 — Projects section heading", () => {
 
   it("Projects heading appears before the per-project map block", () => {
     const projectsHeadingIdx = src.indexOf(">Projects<");
-    const reposMapIdx = src.indexOf("{repos.map(");
+    // CTL-1248: the per-project render loop was renamed `repos.map` -> `orderedRepos.map`
+    // (drag-to-reorder). Track the new literal; the ordering assertion below is unchanged.
+    const reposMapIdx = src.indexOf("{orderedRepos.map(");
     expect(projectsHeadingIdx).toBeGreaterThan(-1);
     expect(reposMapIdx).toBeGreaterThan(-1);
     // Heading must come BEFORE the map (higher up in the source)

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
@@ -1,11 +1,29 @@
-import { useEffect, useMemo } from "react";
-import { useAtom, useAtomValue } from "jotai";
+import { useCallback, useEffect, useMemo } from "react";
+import { useAtom } from "jotai";
+import {
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import {
   ActivityIcon,
   BookOpenIcon,
   ChevronRightIcon,
   CodeIcon,
   GaugeIcon,
+  GripVertical,
   InboxIcon,
   LayoutGridIcon,
   ServerIcon,
@@ -259,6 +277,37 @@ const PROJECT_CHILD_GUIDE = cn(
   "ml-3.5 border-l border-sidebar-border pl-2.5",
 );
 
+// CTL-1248: wrapper that makes each project group a sortable item. Spreads
+// {attributes} + {listeners} ONLY on the grip button (not on the CollapsibleTrigger
+// or ContextMenuTrigger) to preserve all three existing header interactions.
+function SortableProjectGroup({
+  repo,
+  children,
+}: { repo: string; children: React.ReactNode }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: repo });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 1 : undefined,
+    opacity: isDragging ? 0.85 : undefined,
+  };
+  return (
+    <div ref={setNodeRef} style={style} className={cn("group/reorder relative", isDragging && "cursor-grabbing")}>
+      <button
+        type="button"
+        aria-label={`Reorder ${repo}`}
+        className="absolute left-0 top-1 z-10 cursor-grab touch-none opacity-0 group-hover/reorder:opacity-100 focus-visible:opacity-100"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="size-3" />
+      </button>
+      {children}
+    </div>
+  );
+}
+
 export function AppSidebar() {
   // CTL-989 — surface + settingsOpen are READ from the route (useSurface derives
   // them from location.pathname). Nav WRITES go through router.navigate below.
@@ -285,9 +334,8 @@ export function AppSidebar() {
   // CHANGES are written onto the URL via navigate({search:{scope}}) in `go`.
   const [repoScope] = useAtom(repoScopeAtom);
   const [groupsOpen, setGroupsOpen] = useAtom(navGroupsOpenAtom);
-  // CTL-1248: operator's saved project order (repo short-names). Read-only in
-  // Phase 2; Phase 3 switches to useAtom when setProjectOrder is needed.
-  const projectOrder = useAtomValue(navProjectOrderAtom);
+  // CTL-1248: operator's saved project order (repo short-names).
+  const [projectOrder, setProjectOrder] = useAtom(navProjectOrderAtom);
 
   // CTL-1152: the project LIST now comes from the config-driven roster (GET
   // /api/projects), NOT the raw board snapshot's observed-repo set. The roster
@@ -314,6 +362,24 @@ export function AppSidebar() {
   const orderedRepos = useMemo(
     () => reconcileProjectOrder(projectOrder, repos),
     [projectOrder, repos],
+  );
+
+  // CTL-1248: dnd-kit sensors — PointerSensor with distance constraint (mirrors
+  // the Gantt's distance:10) + KeyboardSensor for a11y.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const from = orderedRepos.indexOf(String(active.id));
+      const to = orderedRepos.indexOf(String(over.id));
+      if (from === -1 || to === -1) return;
+      setProjectOrder(arrayMove(orderedRepos, from, to));
+    },
+    [orderedRepos, setProjectOrder],
   );
 
   // CTL-961: auto-detect repo favicons from GitHub + manual overrides. Keyed by the
@@ -648,6 +714,10 @@ export function AppSidebar() {
             </SidebarGroupContent>
           </SidebarGroup>
         )}
+        {/* CTL-1248: DndContext + SortableContext wrap only the per-project loop.
+            Overall / Reason / Observe are outside this context and never sortable. */}
+        <DndContext sensors={sensors} modifiers={[restrictToVerticalAxis]} onDragEnd={handleDragEnd}>
+          <SortableContext items={orderedRepos} strategy={verticalListSortingStrategy}>
         {/* CTL-1034 §2: Title-Cased repo name (displayCaseName) at heading weight/size
             (PROJECT_HEADER_TRIGGER), favicon stays LEFT of the label. §1: twistie is
             RIGHT-aligned (ml-auto) per CTL-977. §3: children indented under a guide line.
@@ -679,8 +749,8 @@ export function AppSidebar() {
           // CTL-1034 §4: a collapsed project rolls its child signal up onto the header.
           const repoSignal = sectionSignal(repo);
           return (
+            <SortableProjectGroup key={repo} repo={repo}>
             <Collapsible
-              key={repo}
               open={isOpen}
               onOpenChange={(open) => {
                 if (!forceOpen) {
@@ -773,8 +843,11 @@ export function AppSidebar() {
                 </CollapsibleContent>
               </SidebarGroup>
             </Collapsible>
+            </SortableProjectGroup>
           );
         })}
+          </SortableContext>
+        </DndContext>
 
         {/* ── REASON — collapsible, defaults open — "Process" + "Rulebook" ─── */}
         {/* CTL-1101: the REASON tier groups the two analytical/governance surfaces

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-import { useAtom } from "jotai";
+import { useEffect, useMemo } from "react";
+import { useAtom, useAtomValue } from "jotai";
 import {
   ActivityIcon,
   BookOpenIcon,
@@ -44,6 +44,7 @@ import {
   overallWorkerCount,
   overallQueueDepth,
   inboxAttentionCount,
+  reconcileProjectOrder,
 } from "@/lib/nav-model";
 import {
   repoScopeAtom,
@@ -51,6 +52,7 @@ import {
   navOverallOpenAtom,
   navReasonOpenAtom,
   navObserveOpenAtom,
+  navProjectOrderAtom,
 } from "@/board/nav-store";
 import { useBoardSnapshot } from "@/hooks/use-board-snapshot";
 // CTL-961: per-project icon auto-detection (favicon from GitHub) + manual override.
@@ -283,6 +285,9 @@ export function AppSidebar() {
   // CHANGES are written onto the URL via navigate({search:{scope}}) in `go`.
   const [repoScope] = useAtom(repoScopeAtom);
   const [groupsOpen, setGroupsOpen] = useAtom(navGroupsOpenAtom);
+  // CTL-1248: operator's saved project order (repo short-names). Read-only in
+  // Phase 2; Phase 3 switches to useAtom when setProjectOrder is needed.
+  const projectOrder = useAtomValue(navProjectOrderAtom);
 
   // CTL-1152: the project LIST now comes from the config-driven roster (GET
   // /api/projects), NOT the raw board snapshot's observed-repo set. The roster
@@ -302,6 +307,14 @@ export function AppSidebar() {
     projects.length > 0 || projectsLoaded
       ? projects.map((p) => p.repo)
       : (payload?.repos ?? []);
+
+  // CTL-1248: apply the operator's saved order against the live roster. Membership
+  // is always roster-driven (repos); the atom is authoritative only for ORDER.
+  // New repos append to the end; removed repos drop out automatically.
+  const orderedRepos = useMemo(
+    () => reconcileProjectOrder(projectOrder, repos),
+    [projectOrder, repos],
+  );
 
   // CTL-961: auto-detect repo favicons from GitHub + manual overrides. Keyed by the
   // SAME short repo name the roster carries.
@@ -639,7 +652,7 @@ export function AppSidebar() {
             (PROJECT_HEADER_TRIGGER), favicon stays LEFT of the label. §1: twistie is
             RIGHT-aligned (ml-auto) per CTL-977. §3: children indented under a guide line.
             §4: a collapsed project with live children shows a signal dot on its header. */}
-        {repos.map((repo) => {
+        {orderedRepos.map((repo) => {
           // navGroups has the per-repo group; get its dotColor + iconDataUrl (CTL-961)
           const navGroup = navGroups.find((g) => g.scope === repo);
           const dotColor = navGroup?.dotColor;

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/nav-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/nav-model.test.ts
@@ -15,6 +15,7 @@ import {
   isActiveWorker,
   displayCaseName,
   laneDisplayName,
+  reconcileProjectOrder,
   type NavGroup,
   type NavProjectDescriptor,
 } from "./nav-model";
@@ -475,5 +476,78 @@ describe("nav-model — laneDisplayName", () => {
     expect(laneDisplayName("team", "__catalyst_unassigned__", "No team", null)).toBe("No team");
     expect(laneDisplayName("repo", "__catalyst_unassigned__", "Unassigned", null)).toBe("Unassigned");
     expect(laneDisplayName("project", "__catalyst_unassigned__", "Unassigned", null)).toBe("Unassigned");
+  });
+});
+
+// ── CTL-1248: reconcileProjectOrder ──────────────────────────────────────────
+
+describe("nav-model — reconcileProjectOrder (CTL-1248)", () => {
+  it("preserves saved order when roster set matches", () => {
+    expect(reconcileProjectOrder(
+      ["catalyst", "adva", "otel"],
+      ["adva", "otel", "catalyst"],
+    )).toEqual(["catalyst", "adva", "otel"]);
+  });
+
+  it("appends a single new roster repo to the end", () => {
+    expect(reconcileProjectOrder(
+      ["catalyst", "adva"],
+      ["catalyst", "adva", "newrepo"],
+    )).toEqual(["catalyst", "adva", "newrepo"]);
+  });
+
+  it("appends multiple new repos in roster order", () => {
+    expect(reconcileProjectOrder(
+      ["catalyst"],
+      ["catalyst", "alpha", "beta"],
+    )).toEqual(["catalyst", "alpha", "beta"]);
+  });
+
+  it("drops a roster-removed repo from saved order", () => {
+    expect(reconcileProjectOrder(
+      ["catalyst", "gone", "adva"],
+      ["catalyst", "adva"],
+    )).toEqual(["catalyst", "adva"]);
+  });
+
+  it("empty saved order returns roster as-is (a copy, not same reference)", () => {
+    const roster = ["adva", "catalyst"];
+    const result = reconcileProjectOrder([], roster);
+    expect(result).toEqual(["adva", "catalyst"]);
+    expect(result).not.toBe(roster);
+  });
+
+  it("empty roster returns []", () => {
+    expect(reconcileProjectOrder(["catalyst", "adva"], [])).toEqual([]);
+  });
+
+  it("de-dupes duplicate entries in saved (first occurrence wins)", () => {
+    expect(reconcileProjectOrder(
+      ["catalyst", "adva", "catalyst"],
+      ["catalyst", "adva"],
+    )).toEqual(["catalyst", "adva"]);
+  });
+
+  it("de-dupes duplicate entries in roster on append", () => {
+    expect(reconcileProjectOrder(
+      [],
+      ["catalyst", "adva", "catalyst"],
+    )).toEqual(["catalyst", "adva"]);
+  });
+
+  it("is idempotent: reconcile(reconcile(saved, roster), roster) === reconcile(saved, roster)", () => {
+    const saved = ["catalyst", "adva"];
+    const roster = ["adva", "catalyst", "newrepo"];
+    const once = reconcileProjectOrder(saved, roster);
+    const twice = reconcileProjectOrder(once, roster);
+    expect(twice).toEqual(once);
+  });
+
+  it("does not mutate inputs", () => {
+    const saved = Object.freeze(["catalyst", "adva"]) as readonly string[];
+    const roster = Object.freeze(["adva", "catalyst", "newrepo"]) as readonly string[];
+    expect(() => reconcileProjectOrder(saved, roster)).not.toThrow();
+    expect(saved).toEqual(["catalyst", "adva"]);
+    expect(roster).toEqual(["adva", "catalyst", "newrepo"]);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/nav-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/nav-model.ts
@@ -395,6 +395,27 @@ export function overallQueueDepth(payload: BoardPayload): number {
   return payload.queue.length;
 }
 
+// ── reconcileProjectOrder (CTL-1248) ─────────────────────────────────────────
+
+/**
+ * CTL-1248: reconcile the operator's saved project order against the live roster.
+ * Keeps saved order for repos still present, drops removed repos, appends new repos
+ * (roster order) to the end, and de-dupes against malformed input. Output is always a
+ * duplicate-free subset of `roster` in the final display order. Pure + idempotent.
+ */
+export function reconcileProjectOrder(
+  saved: readonly string[],
+  roster: readonly string[],
+): string[] {
+  const rosterSet = new Set(roster);
+  const seen = new Set<string>();
+  const kept = saved.filter(
+    (r) => rosterSet.has(r) && !seen.has(r) && (seen.add(r), true),
+  );
+  const appended = roster.filter((r) => !seen.has(r) && (seen.add(r), true));
+  return [...kept, ...appended];
+}
+
 /**
  * The "needs you" attention count for a scope (CTL-1037 inbox-badge addendum).
  * This is the SAME number the inbox header reports ("N needs you") — the union of


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-17T18:31:00Z -->
<!-- Last updated: 2026-06-17T18:31:00Z -->
<!-- PR: #2217 -->
<!-- Previous commits: 63cbeaee5398ff89ba19cfa7b7532940720ba2f1,8307bd8b8cd8fa2a372e0aee62ef4df22804e7b8,5a1939206ead59c1fc29df40a5e2e1680591e42c,d8e35d6a0763b5baaf6c42bd7ed831fa1ed8794c -->

## Summary

Operators can now drag-reorder the per-project groups in the monitor sidebar. The chosen order persists to `localStorage` under `catalyst-nav-project-order-v1` and survives page reloads. Overall / Reason / Observe stay pinned and are never draggable.

## Changes Made

**Phase 1 — Data layer** (`nav-store.ts`, `nav-model.ts`):
- New `navProjectOrderAtom` (`atomWithStorage<string[]>`, key `catalyst-nav-project-order-v1`) stores operator's preferred project order
- New `reconcileProjectOrder(saved, roster)` pure helper: keeps saved order for present repos, drops removed ones, appends new repos (roster order) to end; de-dupes; idempotent

**Phase 2 — Read path** (`app-sidebar.tsx`):
- Imports `navProjectOrderAtom` + `reconcileProjectOrder`; derives `orderedRepos = useMemo(reconcileProjectOrder(projectOrder, repos), [...])` so the per-project render loop uses operator-preferred order

**Phase 3 — Drag + keyboard a11y** (`app-sidebar.tsx`, `ui/package.json`):
- Adds `@dnd-kit/sortable@^8.0.0` + `@dnd-kit/utilities@^3.2.2` (core `^6.3.1` unchanged)
- `SortableProjectGroup` subcomponent with `GripVertical` handle; `{...attributes}` + `{...listeners}` **only** on the grip — preserves click-to-collapse, settings gear, right-click "Project settings"
- `DndContext` (`restrictToVerticalAxis`) + `SortableContext` wrap `orderedRepos.map`; `PointerSensor` (`distance:8`) + `KeyboardSensor` (`sortableKeyboardCoordinates`); `handleDragEnd` → `setProjectOrder(arrayMove(...))`

**Remediation** — Static-source wiring guard updated to track `repos.map` → `orderedRepos.map` rename

## How to Verify It

- [x] Static-source test suite: `bun test __tests__/project-reorder.test.ts` — 17 pass ✅
- [x] Unit tests: `bun test src/lib/nav-model.test.ts src/board/nav-store.test.ts` — 64 pass ✅
- [x] Typecheck: root + ui tsc `--noEmit` clean ✅
- [x] Lint: eslint 0 errors ✅
- [x] Knip: no unused exports/deps ✅
- [x] Security review: no injection, no prototype-pollution surface ✅
- [x] Audit: 4 pre-existing toolchain vulns (ws, brace-expansion, js-yaml) — none from diff's deps ✅
- [ ] Manual: drag a project group's grip up/down → order updates without collapsing the group
- [ ] Manual: reload → reordered sequence persists; `localStorage['catalyst-nav-project-order-v1']` holds repo short-names only
- [ ] Manual: single-click header → still expands/collapses; gear → project settings; right-click → ContextMenu
- [ ] Manual: Overall / Reason / Observe never move, no grip handle
- [ ] Manual: keyboard — Tab to grip, Space/Enter to lift, Arrow keys to move, Space/Enter to drop

## Pre-merge Verification Summary

| Gate | Status |
|------|--------|
| Typecheck | ✅ pass |
| Lint | ✅ pass |
| Tests | ✅ pass (103/103 diff-relevant) |
| Knip | ✅ pass |
| Reward-hacking scan | ✅ pass |
| Code review (6-dimension adversarial) | ✅ pass |
| Security review | ✅ pass |
| Audit | ⚠️ 4 pre-existing toolchain vulns (non-regression baseline) |
| **Regression risk** | **1 / 10** |

## Related Issues/PRs

- Fixes https://linear.app/getadva/issue/CTL-1248
