### PR TITLE
fix(dev): CTL-1252 collapse FQDN host names to first DNS label

### DIFF
--- a/plugins/dev/scripts/__tests__/host-identity.test.sh
+++ b/plugins/dev/scripts/__tests__/host-identity.test.sh
@@ -46,6 +46,18 @@ expect_eq "host_name strips .local" \
 expect_eq "host_name no-op without .local" \
   "my-mac" "$(__host_name_from 'my-mac')"
 
+# CTL-1252: __host_name_from strips non-.local domain suffix
+expect_eq "host_name strips .rozich domain suffix" \
+  "mini" "$(__host_name_from 'mini.rozich')"
+
+# CTL-1252: __host_name_from strips multi-label FQDN to first label
+expect_eq "host_name strips multi-label FQDN to first label" \
+  "host" "$(__host_name_from 'host.with.many.dots')"
+
+# CTL-1252: explicit CATALYST_HOST_NAME with a dot is returned verbatim
+expect_eq "host_name override with dot is verbatim" \
+  "alias.one" "$(CATALYST_HOST_NAME='alias.one' catalyst_host_name)"
+
 # CATALYST_HOST_NAME override wins
 expect_eq "CATALYST_HOST_NAME override" \
   "alias-1" "$(CATALYST_HOST_NAME='alias-1' catalyst_host_name)"

--- a/plugins/dev/scripts/execution-core/__tests__/config-host.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/config-host.test.mjs
@@ -1,0 +1,33 @@
+// config-host.test.mjs — tests for getHostName() in execution-core/config.mjs (CTL-1252)
+// Run: cd plugins/dev/scripts/execution-core && bun test config-host
+
+import { describe, test, expect } from "bun:test";
+import { getHostName } from "../config.mjs";
+
+describe("getHostName", () => {
+  test("CATALYST_HOST_NAME with a dot is returned verbatim", () => {
+    const orig = process.env.CATALYST_HOST_NAME;
+    process.env.CATALYST_HOST_NAME = "mini.rozich";
+    try {
+      expect(getHostName()).toBe("mini.rozich");
+    } finally {
+      if (orig === undefined) delete process.env.CATALYST_HOST_NAME;
+      else process.env.CATALYST_HOST_NAME = orig;
+    }
+  });
+
+  test("fallback collapses os.hostname() FQDN to the first label (no dot in result)", () => {
+    const orig = process.env.CATALYST_HOST_NAME;
+    const origCfg = process.env.CATALYST_LAYER2_CONFIG_FILE;
+    delete process.env.CATALYST_HOST_NAME;
+    process.env.CATALYST_LAYER2_CONFIG_FILE = "/nonexistent/config.json";
+    try {
+      expect(getHostName()).not.toContain(".");
+    } finally {
+      if (orig === undefined) delete process.env.CATALYST_HOST_NAME;
+      else process.env.CATALYST_HOST_NAME = orig;
+      if (origCfg === undefined) delete process.env.CATALYST_LAYER2_CONFIG_FILE;
+      else process.env.CATALYST_LAYER2_CONFIG_FILE = origCfg;
+    }
+  });
+});

--- a/plugins/dev/scripts/execution-core/__tests__/host-identity.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/host-identity.test.mjs
@@ -45,6 +45,29 @@ describe("hostName", () => {
   test("result has no .local suffix by default", () => {
     expect(hostName()).not.toMatch(/\.local$/);
   });
+
+  test("strips a non-.local domain suffix (mini.rozich → mini)", () => {
+    expect(hostName({ raw: "mini.rozich" })).toBe("mini");
+  });
+
+  test("strips multi-label FQDN to the first label", () => {
+    expect(hostName({ raw: "host.with.many.dots" })).toBe("host");
+  });
+
+  test("explicit override with a dot is returned verbatim (not truncated)", () => {
+    expect(hostName({ raw: "mini.rozich", override: "alias.one" })).toBe("alias.one");
+  });
+
+  test("CATALYST_HOST_NAME with a dot is returned verbatim", () => {
+    const orig = process.env.CATALYST_HOST_NAME;
+    process.env.CATALYST_HOST_NAME = "alias.one";
+    try {
+      expect(hostName({ raw: "mini.rozich" })).toBe("alias.one");
+    } finally {
+      if (orig === undefined) delete process.env.CATALYST_HOST_NAME;
+      else process.env.CATALYST_HOST_NAME = orig;
+    }
+  });
 });
 
 function withLayer2(name, fn) {

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -193,7 +193,7 @@ export function readClusterConfig(dir = getClusterRepoDir()) {
 // getHostName — resolve this host's coordination name. Precedence:
 //   1. CATALYST_HOST_NAME env (test/alias override; matches lib/host-identity.mjs)
 //   2. catalyst.host.name in the Layer-2 (machine-local) config file
-//   3. os.hostname() with a trailing ".local" stripped (the bare mDNS suffix)
+//   3. os.hostname() reduced to its first DNS label (strips .local, .rozich, etc.)
 // Never throws — an unreadable/malformed Layer-2 file falls through to the
 // hostname default. The result is the membership key HRW hashing will use.
 export function getHostName() {
@@ -206,7 +206,9 @@ export function getHostName() {
   } catch {
     /* missing/malformed Layer-2 file → hostname default */
   }
-  return hostname().replace(/\.local$/, "");
+  const base = hostname();
+  const dot = base.indexOf(".");
+  return dot === -1 ? base : base.slice(0, dot);
 }
 
 // getClusterHosts — read the committed cluster roster from

--- a/plugins/dev/scripts/execution-core/lib/host-identity.mjs
+++ b/plugins/dev/scripts/execution-core/lib/host-identity.mjs
@@ -7,7 +7,7 @@
 // Algorithm:
 //   host.name = CATALYST_HOST_NAME  (if set and non-empty)
 //               else catalyst.host.name from Layer-2 config  (if readable and non-empty)
-//               else os.hostname() with trailing ".local" stripped
+//               else os.hostname() reduced to its first DNS label
 //   host.id   = sha256(host.name)[:16]   // 16 hex chars, same shape as spanId
 
 import { createHash } from "node:crypto";
@@ -39,8 +39,12 @@ export function hostName({ raw, override } = {}) {
     const cfg = layer2HostName();
     if (cfg) return cfg;
   }
+  // Fallback only: a bare os.hostname() may be a FQDN (mini.rozich, mini.local).
+  // Canonical host names are short — take the first label. Explicit override /
+  // env / Layer-2 values above are returned verbatim. (CTL-1252)
   const base = raw ?? hostname();
-  return base.replace(/\.local$/, "");
+  const dot = base.indexOf(".");
+  return dot === -1 ? base : base.slice(0, dot);
 }
 
 /**

--- a/plugins/dev/scripts/lib/host-identity.sh
+++ b/plugins/dev/scripts/lib/host-identity.sh
@@ -9,15 +9,16 @@
 # Algorithm:
 #   host.name = CATALYST_HOST_NAME  (if set and non-empty)
 #               else catalyst.host.name from Layer-2 config  (if readable and non-empty)
-#               else os.hostname() with trailing ".local" stripped
+#               else os.hostname() reduced to its first DNS label
 #   host.id   = sha256(host.name)[:16]   # 16 hex chars, same shape as spanId
 #
 # Idempotent-source guard — safe to source multiple times.
 [[ -n "${_CATALYST_HOST_IDENTITY_SH_LOADED:-}" ]] && return 0
 _CATALYST_HOST_IDENTITY_SH_LOADED=1
 
-# __host_name_from RAW — strip trailing .local from a hostname string.
-__host_name_from() { printf '%s' "${1%.local}"; }
+# __host_name_from RAW — reduce a fallback hostname to its first DNS label
+# (strips .local, .rozich, or any domain suffix). CTL-1252.
+__host_name_from() { printf '%s' "${1%%.*}"; }
 
 # catalyst_host_name — resolve the effective host name.
 # Honors CATALYST_HOST_NAME override, then Layer-2 config, then os hostname.

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-node-attribution.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-node-attribution.test.ts
@@ -89,6 +89,33 @@ test("hostRefFromName derives the canonical sha256(name)[:16] id; null/empty →
   expect(hostRefFromName("")).toBeNull();
 });
 
+// ── Scenario: CTL-1252 — FQDN host names collapse to their first label ───────
+
+test("hostRefFromName collapses a FQDN fence ownerHost to the first label (CTL-1252)", () => {
+  const ref = hostRefFromName("mini.rozich");
+  expect(ref).toEqual({ name: "mini", id: expectedId("mini") });
+});
+
+test("hostRefFromName leaves a short name unchanged", () => {
+  expect(hostRefFromName("mini")?.name).toBe("mini");
+});
+
+test("deriveHost collapses a stale FQDN fence ownerHost (no signal host)", () => {
+  const host = deriveHost(sigs(), { ownerHost: "mini.rozich" });
+  expect(host?.name).toBe("mini");
+});
+
+test("deriveHost collapses a FQDN that slipped into the signal host.name", () => {
+  const s = sigs();
+  s[idx("implement")] = {
+    status: "running",
+    host: { name: "mini.rozich", id: "deadbeefdeadbeef" },
+  };
+  const host = deriveHost(s, {});
+  expect(host?.name).toBe("mini");
+  expect(host?.id).toBe(expectedId("mini"));
+});
+
 // ── Scenario: Generation is available for fence-aware writes ─────────────────
 
 test("deriveGeneration reads the durable fence projection generation first (BFF11)", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/host-identity.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/host-identity.test.ts
@@ -51,6 +51,29 @@ describe("hostName", () => {
   test("result has no .local suffix by default", () => {
     expect(hostName()).not.toMatch(/\.local$/);
   });
+
+  test("strips a non-.local domain suffix (mini.rozich → mini)", () => {
+    expect(hostName({ raw: "mini.rozich" })).toBe("mini");
+  });
+
+  test("strips multi-label FQDN to the first label", () => {
+    expect(hostName({ raw: "host.with.many.dots" })).toBe("host");
+  });
+
+  test("explicit override with a dot is returned verbatim (not truncated)", () => {
+    expect(hostName({ raw: "mini.rozich", override: "alias.one" })).toBe("alias.one");
+  });
+
+  test("CATALYST_HOST_NAME with a dot is returned verbatim", () => {
+    const orig = process.env.CATALYST_HOST_NAME;
+    process.env.CATALYST_HOST_NAME = "alias.one";
+    try {
+      expect(hostName({ raw: "mini.rozich" })).toBe("alias.one");
+    } finally {
+      if (orig === undefined) delete process.env.CATALYST_HOST_NAME;
+      else process.env.CATALYST_HOST_NAME = orig;
+    }
+  });
 });
 
 function withLayer2(name: string, fn: () => void) {

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -762,6 +762,16 @@ export function derivePhaseWithRemediate(phaseSigs, remediateSig) {
 // derivation, with zero added latency or chrome.
 
 // hostRefFromName — build a {name,id} HostRef from a bare host NAME, deriving the
+// normalizeHostName — reduce a board host name to its first DNS label so a stale
+// FQDN persisted in the fence (ticket_state.owner_host) or leaked onto a signal
+// collapses to the canonical short name used as the swimlane key. Mirrors the
+// Phase-1 source fix; belt-and-suspenders against already-persisted data. (CTL-1252)
+function normalizeHostName(name) {
+  if (typeof name !== "string" || name.length === 0) return name;
+  const dot = name.indexOf(".");
+  return dot === -1 ? name : name.slice(0, dot);
+}
+
 // id as sha256(name)[:16] — the canonical host-id shape shared by the bash
 // (lib/host-identity.sh), mjs (execution-core/lib/host-identity.mjs), and ts
 // (lib/canonical-event-shared.ts::hostId) primitives, so a name resolved from
@@ -769,7 +779,8 @@ export function derivePhaseWithRemediate(phaseSigs, remediateSig) {
 // name → null (no host attribution rather than a fabricated id).
 export function hostRefFromName(name) {
   if (typeof name !== "string" || name.length === 0) return null;
-  return { name, id: createHash("sha256").update(name).digest("hex").slice(0, 16) };
+  const norm = normalizeHostName(name);
+  return { name: norm, id: createHash("sha256").update(norm).digest("hex").slice(0, 16) };
 }
 
 // deriveHost — resolve a {name,id} HostRef for an entity. Precedence:
@@ -786,14 +797,16 @@ export function deriveHost(phaseSigs, fence = {}) {
   // host) so the host tracks the entity's current owner.
   const sigHost = currentSignalHost(phaseSigs);
   if (sigHost && typeof sigHost.name === "string" && sigHost.name.length > 0) {
+    const norm = normalizeHostName(sigHost.name);
+    const nameUnchanged = norm === sigHost.name;
     return {
-      name: sigHost.name,
-      // the dispatch signal already carries the canonical id; only derive it if
-      // a malformed signal somehow omitted it.
+      name: norm,
+      // trust the stamped id only when the name was already short (no FQDN was
+      // collapsed); otherwise recompute from the normalized name. (CTL-1252)
       id:
-        typeof sigHost.id === "string" && sigHost.id.length > 0
+        nameUnchanged && typeof sigHost.id === "string" && sigHost.id.length > 0
           ? sigHost.id
-          : (hostRefFromName(sigHost.name)?.id ?? null),
+          : (hostRefFromName(norm)?.id ?? null),
     };
   }
   return hostRefFromName(fence?.ownerHost ?? null);

--- a/plugins/dev/scripts/orch-monitor/lib/canonical-event-shared.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/canonical-event-shared.ts
@@ -103,7 +103,7 @@ function layer2HostName(): string | null {
  *   1. explicit override param
  *   2. CATALYST_HOST_NAME env var
  *   3. catalyst.host.name from Layer-2 config
- *   4. os.hostname() with trailing ".local" stripped
+ *   4. os.hostname() reduced to its first DNS label
  */
 export function hostName(opts: { raw?: string; override?: string } = {}): string {
   const override = opts.override ?? process.env.CATALYST_HOST_NAME;
@@ -112,7 +112,10 @@ export function hostName(opts: { raw?: string; override?: string } = {}): string
     const cfg = layer2HostName();
     if (cfg) return cfg;
   }
-  return (opts.raw ?? hostname()).replace(/\.local$/, "");
+  // Fallback only — collapse a FQDN os.hostname() to its first label (CTL-1252).
+  const base = opts.raw ?? hostname();
+  const dot = base.indexOf(".");
+  return dot === -1 ? base : base.slice(0, dot);
 }
 
 /**


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-17T18:00:00Z -->
<!-- Last updated: 2026-06-17T18:00:00Z -->
<!-- PR: #2218 -->
<!-- Previous commits: 457e95996b0d8c7367ae995e017216114cd8f731 -->

## Summary

Fixes host-swimlane double-counting on the orch-monitor board. When a machine's `os.hostname()` returns a FQDN (e.g. `mini.rozich`) rather than a bare short name, it was recorded as a distinct host from the canonical `CATALYST_HOST_NAME` (`mini`), causing one physical machine to appear as two swimlane rows.

The root cause: all three host-identity primitives (bash `lib/host-identity.sh`, JS `execution-core/lib/host-identity.mjs`, TS `orch-monitor/lib/canonical-event-shared.ts`) only stripped the `.local` mDNS suffix — any other domain suffix (`.rozich`, `.corp`, etc.) passed through unmodified. The board-data layer (`board-data.mjs`) also lacked normalization, so FQDNs already persisted in the fence or signal files would persist as a separate swimlane key.

## Changes Made

### Source-side — first-label collapse (all three host-identity primitives)

**`plugins/dev/scripts/lib/host-identity.sh`**
- `__host_name_from`: changed `${1%.local}` → `${1%%.*}` — bash double-percent strips everything from the first dot onward, collapsing any FQDN to its first label.

**`plugins/dev/scripts/execution-core/lib/host-identity.mjs`** and **`execution-core/config.mjs`**
- Fallback path (after explicit override / env / Layer-2 config): replaced `.replace(/\.local$/, "")` with `indexOf(".")` + `slice(0, dot)` — same semantics, no regex.

**`plugins/dev/scripts/orch-monitor/lib/canonical-event-shared.ts`**
- Same pattern applied to the TypeScript copy of the fallback.

Explicit overrides (`CATALYST_HOST_NAME`, Layer-2 `catalyst.host.name`, and the `override` param) are returned verbatim — only the final hostname-fallback collapses.

### Board-side — belt-and-suspenders normalization (`board-data.mjs`)

Added `normalizeHostName()` (private) to protect against already-persisted FQDNs in:
- `hostRefFromName()` — normalizes the name before hashing the canonical id
- `deriveHost()` — normalizes the signal `host.name`; recomputes the id when the name changed (pre-normalized id would hash a different string)

### Tests

New and expanded test cases across all four test suites:
- `__tests__/host-identity.test.sh` (+3 bash assertions)
- `execution-core/__tests__/host-identity.test.mjs` (+5 cases)
- `execution-core/__tests__/config-host.test.mjs` (new file — 2 cases for `getHostName()`)
- `orch-monitor/__tests__/host-identity.test.ts` (+5 cases)
- `orch-monitor/__tests__/board-node-attribution.test.ts` (+4 cases: `hostRefFromName` FQDN collapse, `deriveHost` via fence + signal)

## How to Verify It

- [x] Bash host-identity suite — 18/18 pass: `bash plugins/dev/scripts/__tests__/host-identity.test.sh` ✅
- [x] execution-core unit tests — 22/22 pass: `cd plugins/dev/scripts/execution-core && bun test` ✅
- [x] orch-monitor tests (board-node-attribution + host-identity) — 38/38 pass ✅
- [x] TypeScript type-check — clean ✅
- [x] ESLint — clean on all 4 changed orch-monitor files ✅
- [ ] Manual: confirm the orch-monitor board shows a single `mini` swimlane (not `mini` + `mini.rozich`) after a fresh run on the affected machine

## Related Issues/PRs

- Fixes https://linear.app/getadva/issue/CTL-1252

