### PR TITLE
fix(analytics): catalyst-agent reads Claude token from credentials file, not just Keychain

### DIFF
--- a/plugins/dev/scripts/catalyst-agent/accounts.mjs
+++ b/plugins/dev/scripts/catalyst-agent/accounts.mjs
@@ -2,8 +2,9 @@
 // should sample rate-limit usage for: the locally-active account plus any
 // claude-swap backups.
 //
-// On most hosts there is exactly ONE account — the active one read from the
-// macOS Keychain (or ~/.claude/.credentials.json on other platforms). When the
+// On most hosts there is exactly ONE account — the active one read from
+// ~/.claude/.credentials.json (the file current Claude Code writes everywhere),
+// with the macOS Keychain tried first as a legacy fallback. When the
 // operator uses claude-swap (cswap), each swapped-out account is persisted as a
 // JSON file under ~/.claude-swap-backup/credentials/ with the same
 // { claudeAiOauth: { accessToken, refreshToken } } shape. Those backup tokens
@@ -40,30 +41,55 @@ function backupCredentialsDir() {
   return resolve(homedir(), ".claude-swap-backup", "credentials");
 }
 
-// defaultReadActiveToken — resolve the locally-active OAuth access token. On
-// macOS this reads the Keychain generic password; other platforms read
-// ~/.claude/.credentials.json. Both paths parse the same JSON blob and pull
-// .claudeAiOauth.accessToken. Returns null on ANY error — never throws, never
-// logs the token. (Copied verbatim in spirit from
-// execution-core/ratelimit-poller.mjs's defaultReadToken so the standalone
-// agent stays dependency-free.)
-export function defaultReadActiveToken() {
-  try {
-    let raw;
-    if (process.platform === "darwin") {
-      raw = execFileSync(
+// defaultReadActiveToken — resolve the locally-active OAuth access token. The
+// token blob ({ claudeAiOauth: { accessToken } }) lives in one of two places:
+//   • ~/.claude/.credentials.json — the FILE that current Claude Code (2.1.x)
+//     writes on EVERY platform, macOS included. This is the source of truth on
+//     modern installs.
+//   • the macOS Keychain generic password "Claude Code-credentials" — where
+//     OLDER Claude Code stored it on macOS. Some hosts still carry this entry.
+// On macOS we therefore try the Keychain FIRST (legacy hosts) and fall back to
+// the file; everywhere else we read the file directly. Previously macOS read
+// ONLY the Keychain, so a node whose token lived solely in the file (the modern
+// default) reported "no active OAuth token" and emitted no quota telemetry.
+// Returns null on ANY error — never throws, never logs the token. All I/O seams
+// are injectable so the keychain-hit / keychain-miss→file / file-only paths are
+// unit-testable with no real keychain, fs, or platform.
+export function defaultReadActiveToken({
+  platform = process.platform,
+  exec = execFileSync,
+  readFile = readFileSync,
+  home = homedir(),
+} = {}) {
+  const parseToken = (raw) => {
+    try {
+      return JSON.parse(raw)?.claudeAiOauth?.accessToken || null;
+    } catch {
+      return null;
+    }
+  };
+  const fromFile = () => {
+    try {
+      return parseToken(readFile(resolve(home, ".claude", ".credentials.json"), "utf8"));
+    } catch {
+      return null;
+    }
+  };
+  if (platform === "darwin") {
+    try {
+      const raw = exec(
         "security",
         ["find-generic-password", "-s", "Claude Code-credentials", "-w"],
         { encoding: "utf8" },
       );
-    } else {
-      raw = readFileSync(resolve(homedir(), ".claude", ".credentials.json"), "utf8");
+      const token = parseToken(raw);
+      if (token) return token;
+    } catch {
+      /* Keychain item absent (current Claude on macOS) → fall through to the file */
     }
-    const token = JSON.parse(raw)?.claudeAiOauth?.accessToken;
-    return token || null;
-  } catch {
-    return null;
+    return fromFile();
   }
+  return fromFile();
 }
 
 // defaultListBackups — enumerate the claude-swap backup credential files,

--- a/plugins/dev/scripts/catalyst-agent/accounts.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/accounts.test.mjs
@@ -16,9 +16,77 @@ import {
   enumerateAccounts,
   defaultListBackups,
   defaultRefreshToken,
+  defaultReadActiveToken,
 } from "./accounts.mjs";
 
 const ACTIVE_TOKEN = "FAKE-active-access-token-never-logged";
+
+// ─── defaultReadActiveToken: Keychain ↔ credentials-file resolution ──────────
+
+describe("defaultReadActiveToken — keychain/file fallback", () => {
+  const blob = (token) => JSON.stringify({ claudeAiOauth: { accessToken: token } });
+  const throwing = () => {
+    throw new Error("absent");
+  };
+
+  test("macOS: Keychain hit wins and the file is never read", () => {
+    let fileRead = false;
+    const token = defaultReadActiveToken({
+      platform: "darwin",
+      exec: () => blob("FAKE-keychain-token"),
+      readFile: () => {
+        fileRead = true;
+        return blob("FAKE-file-token");
+      },
+    });
+    expect(token).toBe("FAKE-keychain-token");
+    expect(fileRead).toBe(false);
+  });
+
+  test("macOS: Keychain item absent (throws) → falls back to the credentials file", () => {
+    const token = defaultReadActiveToken({
+      platform: "darwin",
+      exec: throwing, // SecKeychainSearchCopyNext: item not found
+      readFile: () => blob("FAKE-file-token"),
+    });
+    expect(token).toBe("FAKE-file-token");
+  });
+
+  test("macOS: Keychain blob without a token → falls back to the file", () => {
+    const token = defaultReadActiveToken({
+      platform: "darwin",
+      exec: () => JSON.stringify({ claudeAiOauth: {} }),
+      readFile: () => blob("FAKE-file-token"),
+    });
+    expect(token).toBe("FAKE-file-token");
+  });
+
+  test("non-macOS: reads the credentials file directly, never the Keychain", () => {
+    let execCalled = false;
+    const token = defaultReadActiveToken({
+      platform: "linux",
+      exec: () => {
+        execCalled = true;
+        return blob("FAKE-keychain-token");
+      },
+      readFile: () => blob("FAKE-file-token"),
+    });
+    expect(token).toBe("FAKE-file-token");
+    expect(execCalled).toBe(false);
+  });
+
+  test("neither Keychain nor file → null (never throws)", () => {
+    expect(
+      defaultReadActiveToken({ platform: "darwin", exec: throwing, readFile: throwing }),
+    ).toBeNull();
+  });
+
+  test("unparseable credentials file → null", () => {
+    expect(
+      defaultReadActiveToken({ platform: "linux", exec: throwing, readFile: () => "not json" }),
+    ).toBeNull();
+  });
+});
 
 // ─── active account ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem
`catalyst-agent/accounts.mjs` `defaultReadActiveToken()` read the active Claude OAuth token from the **macOS Keychain only** on darwin, falling back to `~/.claude/.credentials.json` only on *non*-macOS. But current Claude Code (2.1.179) writes the token to that **file** on macOS too. So any node whose token lives only in the file (the modern default) logs `accounts: no active OAuth token available` and emits **zero `account.ratelimit.sampled` quota telemetry** — defeating per-node quota visibility, the whole point of multi-host.

Found while activating mini-2: fresh valid token in `~/.claude/.credentials.json` (`{accessToken,refreshToken,rateLimitTier,expiresAt}`) after a clean re-login, but `security dump-keychain` shows **no Claude item**. mini works only because it carries a legacy Keychain entry.

## Fix
On macOS, try the Keychain first (legacy hosts) then **fall back to the credentials file** (same `{claudeAiOauth:{accessToken}}` shape already parsed). I/O seams (`platform`/`exec`/`readFile`/`home`) made injectable; added tests for keychain-hit, keychain-miss→file, keychain-blob-without-token→file, file-only (non-macOS), neither→null, and unparseable file. Per-node logins are fully preserved — each node reads its own local file.

28/28 accounts tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)