### PR TITLE
fix(dev): CTL-1254 — stage+swap monitor UI build so dist chunks don't accumulate

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-monitor-bootstrap.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-monitor-bootstrap.test.sh
@@ -425,6 +425,47 @@ fi
 rm -rf "$ROOT"
 
 echo ""
+echo "Test (CTL-1254): rebuild swaps in a fresh dist and drops stale chunks (no accumulation)"
+ROOT="$(mktemp -d)"
+mkdir -p "$ROOT/catalyst/wt" "$ROOT/srv/node_modules"
+: > "$ROOT/srv/server.ts"
+mkdir -p "$ROOT/srv/ui/node_modules"
+: > "$ROOT/srv/ui/package.json"
+: > "$ROOT/srv/ui/bun.lock"
+# Pre-existing dist carrying a STALE hashed chunk (simulates prior accumulated builds).
+mkdir -p "$ROOT/dist/assets"
+: > "$ROOT/dist/assets/stale-OLDHASH.js"
+: > "$ROOT/dist/index.html"
+FAKE_BUN_DIR="$ROOT/fake-bin"
+mkdir -p "$FAKE_BUN_DIR"
+# Fake `bunx vite build` writes a fresh bundle into the (staging) MONITOR_UI_DIST_DIR.
+cat > "$FAKE_BUN_DIR/bunx" <<'EOF'
+#!/usr/bin/env bash
+mkdir -p "$MONITOR_UI_DIST_DIR/assets"
+: > "$MONITOR_UI_DIST_DIR/assets/main-NEWHASH.js"
+: > "$MONITOR_UI_DIST_DIR/index.html"
+exit 0
+EOF
+chmod +x "$FAKE_BUN_DIR/bunx"
+cat > "$FAKE_BUN_DIR/bun" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BUN_DIR/bun"
+(
+  CATALYST_DIR="$ROOT/catalyst" MONITOR_SERVER_SCRIPT="$ROOT/srv/server.ts" \
+  MONITOR_UI_DIST_DIR="$ROOT/dist" MONITOR_SKIP_BOOTSTRAP="" MONITOR_FORCE_BUILD=1 \
+  PATH="$FAKE_BUN_DIR:$PATH" \
+  bash -c 'source "'"$MONITOR_SH"'" url >/dev/null 2>&1; bootstrap >/dev/null 2>&1'
+)
+if [[ -f "$ROOT/dist/assets/main-NEWHASH.js" && ! -f "$ROOT/dist/assets/stale-OLDHASH.js" ]]; then
+  pass "CTL-1254: rebuild swapped in fresh dist and removed the stale chunk"
+else
+  fail "CTL-1254: stale chunk survived rebuild (accumulation) or fresh build missing"
+fi
+rm -rf "$ROOT"
+
+echo ""
 echo "─────────────────────────────────────────────"
 echo "catalyst-monitor-bootstrap: ${PASSES} passed, ${FAILURES} failed"
 if [[ $FAILURES -gt 0 ]]; then

--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -232,10 +232,24 @@ bootstrap() {
 
       if [[ -n "$rebuild_reason" ]]; then
         echo "Building orch-monitor frontend → $MONITOR_UI_DIST_DIR ($rebuild_reason) ..."
-        if (cd "$MONITOR_DIR/ui" && bunx vite build); then
+        # CTL-1254: build into a staging dir and atomically swap on success. vite.config
+        # sets emptyOutDir:false for this out-of-repo outDir, so building in place piled
+        # stale hashed chunks across every rebuild (observed 5759 vs the ~1522 a clean
+        # build emits). The served bundle then referenced per-glyph icon chunks that no
+        # longer matched → silent 404s → icon-picker glyphs stuck as placeholders, plus
+        # unbounded disk growth. Staging keeps the previous dist intact as a fallback if
+        # the build fails (preserving the warn-and-serve-previous behaviour below).
+        _ui_stage="${MONITOR_UI_DIST_DIR%/}.staging.$$"
+        rm -rf "$_ui_stage"
+        if (cd "$MONITOR_DIR/ui" && MONITOR_UI_DIST_DIR="$_ui_stage" bunx vite build); then
+          # Swap fresh build into place (drops ALL stale chunks); the static-asset copy
+          # step below re-populates PWA manifest/sw/icons. mv is atomic on one filesystem.
+          rm -rf "$MONITOR_UI_DIST_DIR"
+          mv "$_ui_stage" "$MONITOR_UI_DIST_DIR"
           # Record the built source SHA ONLY on success so a failed build retries next start.
           [[ -n "$ui_source_sha" ]] && printf '%s\n' "$ui_source_sha" > "$built_sha_file"
         else
+          rm -rf "$_ui_stage"
           echo "warning: orch-monitor vite build failed — serving previous dist (will retry next restart)" >&2
           if declare -f build_canonical_line >/dev/null 2>&1; then
             _bf_line="$(build_canonical_line \


### PR DESCRIPTION
## Problem
The icon picker's "All icons" tier rendered empty/placeholder glyphs and search returned nothing (CTL-1226/1233/1249 each appeared to fix one facet and break another). Root cause was **not** the picker code — it was the build/deploy:

`vite.config.ts` sets `emptyOutDir: false` for the out-of-repo `MONITOR_UI_DIST_DIR`, so every `MONITOR_FORCE_BUILD`/source-change rebuild piled fresh hashed chunks on top of the old ones. The mini's dist had grown to **5759 chunks** (vs ~1522 from a clean build), with multiple hash-versions of `main` and every per-glyph icon chunk. The served bundle then referenced per-glyph chunks whose hashes no longer matched what was on disk → those dynamic imports **404'd silently** (`loadGlyph`'s catch only sets internal state) → placeholder glyphs, empty grid, dead search. Also unbounded disk growth.

A clean rebuild on the mini (5759 → 1522 chunks) immediately fixed it — "fire" now returns real fire/flame/campfire glyphs. This PR makes that durable.

## Fix
Build into a staging dir and atomically `mv` it into place on success, so each rebuild's dist contains only that build's chunks. If the build fails, the previous dist is left untouched (preserves the existing warn-and-serve-previous fallback).

## Test
Adds a `catalyst-monitor-bootstrap` test asserting a rebuild swaps in the fresh bundle and removes a pre-existing stale chunk. All 17 bootstrap + 21 dist-redirect tests pass.

## Verification
Live-verified on the mini after a clean rebuild: icon picker "All icons" renders real glyphs, search "fire" → 5 results (campfire/fire/fire-extinguisher/flame/fire-truck), 101 per-glyph chunks load 200 OK, 0 placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)