### PR TITLE
fix(dev): CTL-1253 — show detected repo favicons in the project icon picker

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings-surface.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useAtom } from "jotai";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 
@@ -44,7 +44,7 @@ import {
 } from "@/lib/repo-color-picks-store";
 // CTL-1153 Phase 5: project rail + per-project settings pane.
 import { useProjects } from "@/hooks/use-projects";
-import { buildProjectRailRows, resolveSettingsView } from "@/lib/project-settings-model";
+import { buildProjectRailRows, mergeIconRepos, resolveSettingsView } from "@/lib/project-settings-model";
 import { SETTINGS_PATH } from "@/lib/route-surface";
 import { ProjectRail } from "@/components/settings/project-rail";
 import { ProjectSettingsPane } from "@/components/settings/project-settings-pane";
@@ -153,10 +153,26 @@ export function SettingsSurface() {
   // through on change (it only takes effect on the next load).
   const [landing, setLanding] = useState<Surface>(readLandingSurface);
 
-  // Project icons — per-repo candidate picker (CTL-997).
+  // CTL-1153: project rail — server roster + URL-backed selection. Read BEFORE the
+  // icon fetch (CTL-1253): the per-project picker keys its candidate lookup on
+  // settingsView.project.repo, which comes from THIS roster — including
+  // configured-but-idle teams (hasWork: false) that are absent from the board
+  // snapshot's observed-work repos.
+  const { projects, refetch } = useProjects();
+
+  // Project icons — per-repo candidate picker (CTL-997, CTL-1253).
   const { payload } = useBoardSnapshot();
   const payloadLoaded = payload != null;
-  const repos = payload?.repos ?? [];
+  // CTL-1253: fetch icons for the UNION of board-observed repos and EVERY roster
+  // project's repo, so the selected project's repo key always has an iconMap entry
+  // (an idle configured project was never in payload.repos → candidates were []
+  // → the picker's "Detected" group never rendered). useRepoIcons stabilizes on
+  // repos.join(","), so this MUST be a memoized stable reference or the effect
+  // refetches every render.
+  const repos = useMemo(
+    () => mergeIconRepos(payload?.repos ?? [], projects),
+    [payload?.repos, projects],
+  );
   const iconMap = useRepoIcons(repos);
   const [iconPicks, setIconPicks] = useAtom(repoIconPicksAtom);
   const iconPickerRows = buildIconPickerRows(repos, iconMap, iconPicks);
@@ -166,8 +182,6 @@ export function SettingsSurface() {
   const [colorPicks, setColorPicks] = useAtom(repoColorPicksAtom);
   const colorPickerRows = repos;
 
-  // CTL-1153: project rail — server roster + URL-backed selection.
-  const { projects, refetch } = useProjects();
   const navigate = useNavigate();
   const { project: paramKey } = useSearch({ from: SETTINGS_PATH });
   const [selectedKey, setSelectedKey] = useState<string | null>(

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-model.test.ts
@@ -64,6 +64,37 @@ describe("buildBasePickerItems", () => {
   });
 });
 
+// ── CTL-1253: the "Detected" favicon group is purely candidate-driven ──────────
+// IconPickerPopover renders the "Detected" CommandGroup iff filteredFavicons.length > 0,
+// where filteredFavicons = buildBasePickerItems(candidates).filter(group === "favicon").
+// These pin that contract: candidates threaded into the pane → favicon items appear;
+// no candidates → the Detected group is never rendered (the pre-fix symptom).
+describe("Detected favicon group gate (CTL-1253)", () => {
+  const adva: IconCandidate[] = [
+    { path: "apps/web/public/favicon.svg", format: "svg", downloadUrl: "u", dataUrl: "data:image/svg+xml;base64,xxx" },
+    { path: "apps/web/public/favicon.ico", format: "ico", downloadUrl: "u2", dataUrl: "data:image/x-icon;base64,yyy" },
+  ];
+
+  function detectedItems(candidates: IconCandidate[]) {
+    return buildBasePickerItems(candidates).filter((i) => i.group === "favicon");
+  }
+
+  it("renders one Detected favicon item per candidate, carrying its dataUrl", () => {
+    const detected = detectedItems(adva);
+    expect(detected).toHaveLength(adva.length);
+    expect(detected.map((i) => i.value)).toEqual([
+      "apps/web/public/favicon.svg",
+      "apps/web/public/favicon.ico",
+    ]);
+    expect(detected[0].dataUrl).toBe("data:image/svg+xml;base64,xxx");
+    expect(detected.every((i) => Boolean(i.dataUrl))).toBe(true);
+  });
+
+  it("renders NO Detected items for an empty candidate list (the pre-fix symptom)", () => {
+    expect(detectedItems([])).toHaveLength(0);
+  });
+});
+
 describe("buildAllGlyphItems", () => {
   it("maps loaded names minus featured into non-featured glyph items", () => {
     const items = buildAllGlyphItems(["airplane", "git-fork", "zz-fake"]);

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/project-settings-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/project-settings-model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   STATE_MAP_KEYS,
   buildProjectRailRows,
+  mergeIconRepos,
   resolveSelectedProject,
   diffStateMap,
   SETTINGS_PENDING_SECTIONS,
@@ -53,6 +54,33 @@ describe("buildProjectRailRows", () => {
 
   it("returns empty array for empty projects", () => {
     expect(buildProjectRailRows([])).toEqual([]);
+  });
+});
+
+describe("mergeIconRepos (CTL-1253)", () => {
+  it("includes an idle configured project's repo absent from observed-work repos", () => {
+    // The bug: observed-work repos (board snapshot) miss the idle ADV team's repo,
+    // so its favicon candidates were never fetched and the Detected group stayed empty.
+    const merged = mergeIconRepos(["ctl"], [{ repo: "ctl" }, { repo: "adva" }]);
+    expect(merged).toContain("adva");
+    expect(merged).toEqual(["ctl", "adva"]);
+  });
+
+  it("dedupes a repo present in BOTH sources", () => {
+    expect(mergeIconRepos(["ctl"], [{ repo: "ctl" }])).toEqual(["ctl"]);
+  });
+
+  it("keeps observed-work repos first, then appends new roster repos", () => {
+    const merged = mergeIconRepos(["ctl", "otl"], [{ repo: "adva" }, { repo: "ctl" }]);
+    expect(merged).toEqual(["ctl", "otl", "adva"]);
+  });
+
+  it("returns the observed repos unchanged when the roster is empty", () => {
+    expect(mergeIconRepos(["ctl"], [])).toEqual(["ctl"]);
+  });
+
+  it("returns roster repos when there is no observed work yet", () => {
+    expect(mergeIconRepos([], [{ repo: "adva" }, { repo: "ctl" }])).toEqual(["adva", "ctl"]);
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/project-settings-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/project-settings-model.ts
@@ -54,6 +54,26 @@ export function buildProjectRailRows(
 }
 
 /**
+ * Union the board-snapshot's observed-work repos with the roster's per-project
+ * repos (CTL-1253). The icon picker keys its candidate lookup on the SELECTED
+ * project's `repo`, which comes from the project roster (/api/projects) and
+ * INCLUDES configured-but-idle teams (hasWork: false). Those idle repos are
+ * absent from BoardPayload.repos (board-data derives it from observed
+ * workers/tickets only), so feeding only the board's repos to useRepoIcons
+ * never fetches /api/repo-icon for an idle project — its Detected favicon group
+ * silently stays empty. Unifying the two sources guarantees every roster
+ * project's repo is fetched. Deduped, order-stable (observed repos first).
+ */
+export function mergeIconRepos(
+  observedRepos: readonly string[],
+  projects: readonly Pick<ProjectDescriptor, "repo">[],
+): string[] {
+  return Array.from(
+    new Set([...observedRepos, ...projects.map((p) => p.repo)]),
+  );
+}
+
+/**
  * Find a project descriptor by team key. Returns null for an unknown/undefined key
  * so the settings surface can fall back to the global sections. Generic so the caller
  * gets back the full descriptor type it passed in, not a narrowed Pick.


### PR DESCRIPTION
## Problem

In orch-monitor Settings → a project → the **Icon** picker, the "Detected" favicon group never appeared for a configured-but-idle project. The picker only offered `[Auto, Featured, All icons]` and 0 favicon thumbnails, even though the repo's favicons were discoverable (e.g. `GET /api/repo-icon/adva` returns `found:true` with 4 candidates, each carrying a `dataUrl`).

## Root cause

A **data-source mismatch** in `settings-surface.tsx`. The icon fetch was keyed on the WRONG repo set:

- `useRepoIcons(repos)` was fed `payload.repos` from `useBoardSnapshot()` — repos derived server-side (`board-data.mjs`) from **observed work only** (live workers/tickets).
- But the per-project pane reads `iconMap[settingsView.project.repo]`, where `settingsView.project` comes from the **project roster** (`/api/projects`), which ALSO includes configured-but-idle teams (`hasWork: false`) that are **absent** from `payload.repos`.

So for an idle project, `useRepoIcons` never fetched `/api/repo-icon/<repo>`, `iconMap[repo]` was `undefined`, `candidates` resolved to `[]`, `buildBasePickerItems` produced zero `favicon` items, and the popover's `filteredFavicons.length > 0` gate never rendered the "Detected" group.

The candidate pipeline itself (API → `parseIconCandidates` → `IconCandidate` → `buildBasePickerItems` → "Detected" `CommandGroup`) was already correct and unit-covered — the break was purely the repo set fed to the fetch.

## Fix

Client-side only — `board-data.mjs`'s observed-work definition is correct and untouched. Thread the favicon candidates from the **same source the picker keys on**:

- New pure helper `mergeIconRepos(observedRepos, projects)` in `project-settings-model.ts` — the deduped, order-stable UNION of board-observed repos and every roster project's `repo`.
- `settings-surface.tsx` now fetches icons for that union (wrapped in `useMemo` so the array is a **stable reference** — `useRepoIcons` stabilizes its effect/memo on `repos.join(",")`, so an inline array would refetch every render). `useProjects()` is moved above the icon fetch accordingly.

`buildIconPickerRows` still omits repos with zero candidates, so the legacy "Project icons" section and the sidebar marks are unaffected — the change only **widens** the fetched set, never drops an observed-work entry.

## Test

- `mergeIconRepos` unit tests directly encode the observed-work-vs-roster divergence: idle `adva` is included, dedup, order-stable (observed first), and the empty-source edge cases.
- A `CTL-1253` block in the picker-model suite pins the "Detected" group's candidate-driven contract: candidates → one favicon item each (value = path, `dataUrl` carried); `[]` → zero favicon items (the pre-fix symptom).
- `bun test src/components/settings/ src/lib/` → **539 pass / 0 fail**.
- `bunx vite build` → succeeds (`settings-surface` chunk builds clean).
- Parent `__tests__/settings-surface.test.ts` (the contract test importing this module) → 25 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)