### PR TITLE
fix(dev): CTL-1258 — render resolved project icon (glyph|favicon) consistently across all orch-monitor surfaces

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/ticket-rail.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ticket-rail.test.ts
@@ -113,28 +113,32 @@ describe("ticket-rail.tsx — floating cards + readable relations (CTL-1003)", (
   });
 });
 
-// ── CTL-1012: the rail rows orient by the project icon ───────────────────────
-describe("ticket-rail.tsx — Repo/Team/Project rows carry the project icon (CTL-1012)", () => {
+// ── CTL-1012 → CTL-1258: the rail rows orient by the project MARK (glyph|favicon) ─
+// CTL-1258 migrated the rail from a favicon-only `iconSrc: string|null` to the
+// `mark: ProjectMark` union (glyph | favicon | none), rendered via <ProjectMarkIcon>
+// instead of a raw <img>. These assertions track the new wiring (the dedicated
+// board/detail-rail-marks.test.ts covers the same surface from the ui/ side).
+describe("ticket-rail.tsx — Repo/Team/Project rows carry the project mark (CTL-1012/CTL-1258)", () => {
   it("resolves the project mark from the resident ticket's repo via the shared icon context", () => {
     expect(railSrc).toContain("useRepoIconMap");
-    expect(railSrc).toContain("resolveEntityIcon(ticket?.repo, icons)");
+    expect(railSrc).toContain("resolveEntityMark(ticket?.repo, icons)");
   });
 
-  it("the Properties Repo + Team rows carry the resolved iconSrc", () => {
-    // both rows pass the iconSrc through to PropRow (the same brand the lanes show).
-    expect(railSrc).toMatch(/label: "Repo", value: ticket\.repo, iconSrc/);
-    expect(railSrc).toMatch(/label: "Team", value: ticket\.team, iconSrc/);
+  it("the Properties Repo + Team rows carry the resolved mark", () => {
+    // both rows pass the mark through to PropRow (the same brand the lanes show).
+    expect(railSrc).toMatch(/label: "Repo", value: ticket\.repo, mark/);
+    expect(railSrc).toMatch(/label: "Team", value: ticket\.team, mark/);
   });
 
-  it("PropRow renders a 14px icon before the value when iconSrc + a real value are present", () => {
-    // guarded so the icon never shows beside a dimmed em-dash placeholder.
-    expect(railSrc).toContain("row.iconSrc != null && row.value != null");
-    expect(railSrc).toMatch(/width: 14, height: 14, borderRadius: 3, objectFit: "contain"/);
+  it("PropRow renders a ProjectMarkIcon before the value when a real mark + value are present", () => {
+    // guarded (mark present AND not "none") so the icon never shows beside a dimmed em-dash.
+    expect(railSrc).toContain('row.mark != null && row.mark.kind !== "none" && row.value != null');
+    expect(railSrc).toContain("<ProjectMarkIcon");
   });
 
-  it("the Project card prefers the project icon, falling back to the Box glyph", () => {
-    // fail-open: an undiscovered icon (iconSrc null) keeps the generic Box.
-    expect(railSrc).toContain("iconSrc != null ? (");
+  it("the Project card prefers the project mark, falling back to the Box glyph", () => {
+    // fail-open: a "none" mark (no icon discovered) keeps the generic Box.
+    expect(railSrc).toContain('mark.kind !== "none" ? (');
     expect(railSrc).toContain('<Box className="size-3.5 text-muted-foreground" />');
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/BoardList.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/BoardList.tsx
@@ -95,8 +95,10 @@ import {
 } from "./list-group-data";
 import type { Lane } from "./board-grouping";
 import { useRepoIconMap } from "./repo-icon-context";
-import { laneIconSrc } from "./entity-icon";
+import { laneMark } from "./entity-icon";
 import { laneDisplayName } from "@/lib/nav-model";
+import { ProjectMarkIcon } from "@/components/project-mark-icon";
+import type { ProjectMark } from "@/lib/project-mark";
 
 // ── collapse state (CTL-955) ─────────────────────────────────────────────────
 // Jotai atom: a Map<navKind → Set<groupKey>> of collapsed group keys. Atom lives
@@ -525,7 +527,7 @@ function ListTable<E extends { id?: string; name?: string; team?: string | null;
                     // CTL-1012: swimlane lanes carry the spelled-out brand name
                     // ("Adva (ADV)") + project icon (team→repo bridge via meta.repo);
                     // the default stage/activity groups (swimlane="none") keep their
-                    // verbatim label + accent dot (laneDisplayName/laneIconSrc no-op).
+                    // verbatim label + accent dot (laneDisplayName/laneMark no-op).
                     label={laneDisplayName(swimlane, meta.key, meta.label, meta.repo)}
                     count={sorted.length}
                     live={meta.live}
@@ -534,7 +536,7 @@ function ListTable<E extends { id?: string; name?: string; team?: string | null;
                     collapsed={collapsed}
                     onToggle={() => toggleCollapse(meta.key)}
                     hint={hint}
-                    iconSrc={laneIconSrc(swimlane, meta.repo, icons)}
+                    mark={laneMark(swimlane, meta.repo, icons)}
                     laneBg={swimlane !== "none" ? laneSurfaceBg(meta.repo, laneColors) : undefined}
                   />
                   {/* CTL-952: AnimatePresence enables enter/exit for rows that
@@ -651,7 +653,7 @@ function GroupHeaderRow({
   collapsed,
   onToggle,
   hint,
-  iconSrc,
+  mark,
   laneBg,
 }: {
   label: string;
@@ -663,7 +665,7 @@ function GroupHeaderRow({
   collapsed: boolean;
   onToggle: () => void;
   hint?: string | null;
-  iconSrc?: string | null;
+  mark?: ProjectMark;
   /** CTL-1027: per-project tinted background for swimlane group rows. */
   laneBg?: string;
 }) {
@@ -700,10 +702,10 @@ function GroupHeaderRow({
           >
             ▼
           </span>
-          {iconSrc ? (
-            // CTL-1012: 16px project mark (up from CTL-998's 14px favicon).
-            <img src={iconSrc} alt="" aria-hidden
-              style={{ width: 16, height: 16, borderRadius: 4, objectFit: "contain" }} />
+          {mark && mark.kind !== "none" ? (
+            // CTL-1258 / CTL-1208: 16px project mark — glyph (tinted SVG) or favicon (<img>),
+            // mirroring Swimlane.tsx's kanban lane header. Falls back to the live-dot / Dot.
+            <ProjectMarkIcon mark={mark} color={dotColor ?? C.fg} size={16} />
           ) : live === "live" ? (
             <span className="catalyst-live-dot" style={{ width: 8, height: 8, borderRadius: "50%", background: dotColor, display: "inline-block" }} />
           ) : (

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Shell.tsx
@@ -34,6 +34,8 @@ import {
   type PagerState,
 } from "./detail-chrome";
 import { C } from "./board-tokens";
+import type { ProjectMark } from "@/lib/project-mark";
+import { ProjectMarkIcon } from "@/components/project-mark-icon";
 import {
   cheatsheetOpenAtom,
   listContextAtom,
@@ -80,10 +82,10 @@ export interface PropertyRow {
   /** A plumbed value (string), a plumbed-but-empty value (null), or an unplumbed
    *  field (undefined → dimmed placeholder, never fabricated). */
   value: string | null | undefined;
-  /** CTL-1012: an optional project-icon data URL rendered before the value (the
-   *  Repo/Team rows orient by the same brand the lane headers show). null/absent →
+  /** CTL-1012/CTL-1258: an optional project mark rendered before the value (the
+   *  Repo/Team rows orient by the same brand the lane headers show). absent/none →
    *  no icon. The icon is suppressed when the value is unplumbed/empty. */
-  iconSrc?: string | null;
+  mark?: ProjectMark;
 }
 
 export interface ShellProps {
@@ -338,9 +340,9 @@ function PropertiesRail({ rows, extra }: { rows: PropertyRow[]; extra?: ReactNod
     >
       {rows.map((r) => {
         const unplumbed = r.value === undefined;
-        // CTL-1012: show the project mark only when both the icon AND a real value
+        // CTL-1258: show the project mark only when both the mark AND a real value
         // are present (never beside a dimmed "—").
-        const showIcon = r.iconSrc != null && r.value != null;
+        const showIcon = r.mark != null && r.mark.kind !== "none" && r.value != null;
         return (
           <div
             key={r.label}
@@ -363,14 +365,7 @@ function PropertiesRail({ rows, extra }: { rows: PropertyRow[]; extra?: ReactNod
                 whiteSpace: "nowrap",
               }}
             >
-              {showIcon && (
-                <img
-                  src={r.iconSrc ?? undefined}
-                  alt=""
-                  aria-hidden
-                  style={{ width: 14, height: 14, borderRadius: 3, objectFit: "contain", flex: "0 0 auto" }}
-                />
-              )}
+              {showIcon && <ProjectMarkIcon mark={r.mark!} color={C.fg} size={14} />}
               {/* unplumbed → dimmed em-dash placeholder, NEVER a fabricated value;
                   a plumbed-but-null value (e.g. no project) reads "—" too but lit. */}
               <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/detail-rail-marks.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/detail-rail-marks.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "bun:test";
+const SHELL  = await Bun.file(new URL("./Shell.tsx",        import.meta.url)).text();
+const DROUTE = await Bun.file(new URL("./detail-route.tsx", import.meta.url)).text();
+const TRAIL  = await Bun.file(new URL("./ticket-rail.tsx",  import.meta.url)).text();
+
+describe("Shell PropertyRow renders ProjectMarkIcon, not raw <img> (GAP B, CTL-1258)", () => {
+  it("PropertyRow carries a ProjectMark, not iconSrc", () => {
+    expect(SHELL).toMatch(/mark\??:\s*ProjectMark/);
+    expect(SHELL).not.toMatch(/iconSrc\?:\s*string \| null/);
+  });
+  it("renders <ProjectMarkIcon> and no longer renders a raw favicon <img src={r.iconSrc", () => {
+    expect(SHELL).toContain("<ProjectMarkIcon");
+    expect(SHELL).not.toMatch(/<img\s+src=\{r\.iconSrc/);
+  });
+});
+
+describe("worker detail rail resolves a ProjectMark (GAP B, CTL-1258)", () => {
+  it("uses resolveEntityMark, not resolveEntityIcon", () => {
+    expect(DROUTE).toContain("resolveEntityMark");
+    expect(DROUTE).not.toContain("resolveEntityIcon");
+  });
+});
+
+describe("ticket rail rows + Project card render ProjectMarkIcon (GAP B, CTL-1258)", () => {
+  it("uses resolveEntityMark + ProjectMarkIcon, drops resolveEntityIcon + raw <img>", () => {
+    expect(TRAIL).toContain("resolveEntityMark");
+    expect(TRAIL).toContain("<ProjectMarkIcon");
+    expect(TRAIL).not.toContain("resolveEntityIcon");
+    expect(TRAIL).not.toMatch(/<img\s+src=\{(row\.iconSrc|iconSrc)\b/);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/detail-route.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/detail-route.tsx
@@ -30,7 +30,7 @@ import { WorkerRailExtra } from "./worker-rail-extra";
 import { useWorkerDetailModel } from "./use-worker-detail-model";
 import { readWorkerScalars } from "./worker-detail-data";
 import { useRepoIconMap } from "./repo-icon-context";
-import { resolveEntityIcon } from "./entity-icon";
+import { resolveEntityMark } from "./entity-icon";
 
 // ── resident payload subscription (same transport as Board.tsx) ─────────────
 function useBoardPayload(): { payload: BoardPayload | null; health: StreamHealth } {
@@ -72,16 +72,16 @@ function useBoardPayload(): { payload: BoardPayload | null; health: StreamHealth
 // CTL-1003 §B1: the TICKET property rows moved into ticket-rail.tsx's Properties
 // card (the floating rail). Only the WORKER rows remain here (the worker page
 // keeps the flat Shell PropertiesRail).
-function workerRows(w: BoardWorker | undefined, iconSrc: string | null): PropertyRow[] {
+function workerRows(w: BoardWorker | undefined, mark: ReturnType<typeof resolveEntityMark>): PropertyRow[] {
   // CTL-914 (DETAIL3): the worker rail's BoardWorker scalar fallbacks — every
   // value is the resident AVAILABLE-NOW field or an honest null/dimmed marker.
   const scalars = readWorkerScalars(w);
   return [
     { label: "Status", value: w ? activeLabel(w.activeState, w.working) : undefined },
     { label: "Phase", value: w?.phase },
-    // CTL-1012: Repo + Team orient by the project mark (resolved from the repo).
-    { label: "Repo", value: w?.repo, iconSrc },
-    { label: "Team", value: w?.team, iconSrc },
+    // CTL-1258: Repo + Team orient by the project mark (glyph or favicon).
+    { label: "Repo", value: w?.repo, mark },
+    { label: "Team", value: w?.team, mark },
     { label: "Runtime", value: w?.runtimeMs != null ? fmtDuration(w.runtimeMs) : w ? null : undefined },
     { label: "Cost", value: scalars.costUSD != null ? `$${scalars.costUSD.toFixed(2)}` : w ? null : undefined },
     // CTL-915 (DETAIL4 / BFF6 P7): the OS pid of the bg worker. null when the
@@ -202,10 +202,10 @@ export function WorkerDetailRoute({ id, search }: { id: string; search: DetailSe
   // it never sets railExtra).
   const model = useWorkerDetailModel(worker);
 
-  // CTL-1012: the project mark for the rail Repo/Team rows, resolved from the
+  // CTL-1258: the project mark for the rail Repo/Team rows, resolved from the
   // worker's repo (the shared icon context mounted by the AppShell route tree).
   const icons = useRepoIconMap();
-  const iconSrc = resolveEntityIcon(worker?.repo, icons);
+  const mark = resolveEntityMark(worker?.repo, icons);
 
   return (
     <>
@@ -216,7 +216,7 @@ export function WorkerDetailRoute({ id, search }: { id: string; search: DetailSe
         listIds={listIds}
         live={{ working: worker?.working ?? false, activeState: worker?.activeState ?? null }}
         title={worker?.name ?? id}
-        properties={workerRows(worker, iconSrc)}
+        properties={workerRows(worker, mark)}
         railExtra={
           <WorkerRailExtra
             worker={worker}

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/list-lane-mark.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/list-lane-mark.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "bun:test";
+const SRC = await Bun.file(new URL("./BoardList.tsx", import.meta.url)).text();
+
+describe("BoardList GroupHeaderRow renders ProjectMarkIcon (GAP B Surface 4, CTL-1258)", () => {
+  it("imports laneMark and ProjectMarkIcon, drops laneIconSrc", () => {
+    expect(SRC).toContain("laneMark");
+    expect(SRC).toContain("ProjectMarkIcon");
+    expect(SRC).not.toContain("laneIconSrc");
+  });
+  it("passes a mark (not iconSrc) to GroupHeaderRow", () => {
+    expect(SRC).toMatch(/mark=\{laneMark\(swimlane, meta\.repo, icons\)\}/);
+    expect(SRC).not.toMatch(/iconSrc=\{laneIconSrc\(/);
+  });
+  it("GroupHeaderRow no longer renders a raw favicon <img src={iconSrc", () => {
+    expect(SRC).not.toMatch(/<img src=\{iconSrc\}/);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/ticket-rail.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/ticket-rail.tsx
@@ -35,7 +35,9 @@ import { TicketDepSubGraph } from "./dependency-graph";
 import { RelationStateIcon } from "@/components/relation-state-icon";
 import { PriorityIcon } from "./Board";
 import { useRepoIconMap } from "./repo-icon-context";
-import { resolveEntityIcon } from "./entity-icon";
+import { resolveEntityMark } from "./entity-icon";
+import type { ProjectMark } from "@/lib/project-mark";
+import { ProjectMarkIcon } from "@/components/project-mark-icon";
 import {
   relationHiddenCount,
   RELATION_GROUP_LIMIT,
@@ -103,18 +105,18 @@ function DimDash() {
 
 // ── Properties card ──────────────────────────────────────────────────────────
 /** A shared cheap Property row: undefined value → dimmed, null → "—" lit.
- *  CTL-1012: an optional `iconSrc` renders the 14px project mark before the value
+ *  CTL-1258: an optional `mark` renders the 14px project mark before the value
  *  (Repo/Team rows orient by the same brand the lane headers show). */
 interface RailPropRow {
   label: string;
   value: string | null | undefined;
-  /** CTL-1012: project-icon data URL beside the value; null/absent → no icon. */
-  iconSrc?: string | null;
+  /** CTL-1258: project mark beside the value; absent/none → no icon. */
+  mark?: ProjectMark;
 }
 
 function PropRow({ row }: { row: RailPropRow }) {
   const unplumbed = row.value === undefined;
-  const showIcon = row.iconSrc != null && row.value != null;
+  const showIcon = row.mark != null && row.mark.kind !== "none" && row.value != null;
   return (
     <div
       data-rail-prop={row.label}
@@ -136,14 +138,7 @@ function PropRow({ row }: { row: RailPropRow }) {
           whiteSpace: "nowrap",
         }}
       >
-        {showIcon && (
-          <img
-            src={row.iconSrc ?? undefined}
-            alt=""
-            aria-hidden
-            style={{ width: 14, height: 14, borderRadius: 3, objectFit: "contain", flex: "0 0 auto" }}
-          />
-        )}
+        {showIcon && <ProjectMarkIcon mark={row.mark!} color={C.fg} size={14} />}
         <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
           {row.value == null ? "—" : row.value}
         </span>
@@ -167,15 +162,15 @@ function activeLabel(state: BoardTicket["activeState"], working: boolean): strin
 function ticketRailRows(
   ticket: BoardTicket | undefined,
   linear: LinearTicketState,
-  iconSrc: string | null,
+  mark: ProjectMark,
 ): RailPropRow[] {
   if (ticket) {
     return [
       { label: "Status", value: `${ticket.linearState} · ${activeLabel(ticket.activeState, ticket.working)}` },
       { label: "Phase", value: ticket.phase },
-      // CTL-1012: Repo + Team orient by the project mark (resolved from the repo).
-      { label: "Repo", value: ticket.repo, iconSrc },
-      { label: "Team", value: ticket.team, iconSrc },
+      // CTL-1258: Repo + Team orient by the project mark (glyph or favicon).
+      { label: "Repo", value: ticket.repo, mark },
+      { label: "Team", value: ticket.team, mark },
       { label: "Updated", value: ticket.updatedAt },
       { label: "PR", value: ticket.pr != null ? `#${ticket.pr}` : null },
       { label: "Model (current phase)", value: ticket.model ?? null },
@@ -196,13 +191,13 @@ function ticketRailRows(
 function PropertiesCard({
   ticket,
   linear,
-  iconSrc,
+  mark,
 }: {
   ticket: BoardTicket | undefined;
   linear: LinearTicketState;
-  iconSrc: string | null;
+  mark: ProjectMark;
 }) {
-  const rows = ticketRailRows(ticket, linear, iconSrc);
+  const rows = ticketRailRows(ticket, linear, mark);
   return (
     <RailCard id="properties" title="Properties">
       <div data-rail-properties>
@@ -254,7 +249,7 @@ function LabelsCard({ labels }: { labels: LinearLabel[] | null }) {
 // ── Project card ─────────────────────────────────────────────────────────────
 // CTL-1012: orient by the project mark — the 14px icon (resolved from the ticket's
 // repo) when discovered, else the generic Box glyph as the fail-open fallback.
-function ProjectCard({ project, iconSrc }: { project: string | null; iconSrc: string | null }) {
+function ProjectCard({ project, mark }: { project: string | null; mark: ProjectMark }) {
   return (
     <RailCard id="project" title="Project">
       <div data-rail-project style={{ display: "inline-flex", alignItems: "center", gap: 7 }}>
@@ -262,13 +257,8 @@ function ProjectCard({ project, iconSrc }: { project: string | null; iconSrc: st
           <DimDash />
         ) : (
           <>
-            {iconSrc != null ? (
-              <img
-                src={iconSrc}
-                alt=""
-                aria-hidden
-                style={{ width: 14, height: 14, borderRadius: 3, objectFit: "contain", flex: "0 0 auto" }}
-              />
+            {mark.kind !== "none" ? (
+              <ProjectMarkIcon mark={mark} color={C.fg} size={14} />
             ) : (
               <Box className="size-3.5 text-muted-foreground" />
             )}
@@ -451,10 +441,10 @@ export function TicketRailCards({
 }) {
   // Resident project wins; off-board falls back to the live Linear project.
   const project = ticket ? (ticket.project ?? null) : (linear.project ?? null);
-  // CTL-1012: the project mark for the Properties Repo/Team rows + the Project card,
-  // resolved from the resident ticket's repo (off-board has no repo → null → fallback).
+  // CTL-1258: the project mark for the Properties Repo/Team rows + the Project card,
+  // resolved from the resident ticket's repo (off-board has no repo → none fallback).
   const icons = useRepoIconMap();
-  const iconSrc = resolveEntityIcon(ticket?.repo, icons);
+  const mark = resolveEntityMark(ticket?.repo, icons);
   return (
     // CTL-1048: the floating card rail is a plain flex column inside the Shell's
     // single scrolling body row — it no longer owns its own `overflowY:auto`
@@ -473,9 +463,9 @@ export function TicketRailCards({
         gap: 10,
       }}
     >
-      <PropertiesCard ticket={ticket} linear={linear} iconSrc={iconSrc} />
+      <PropertiesCard ticket={ticket} linear={linear} mark={mark} />
       <LabelsCard labels={linear.labels} />
-      <ProjectCard project={project} iconSrc={iconSrc} />
+      <ProjectCard project={project} mark={mark} />
       <RelationsCard relations={linear.relations} loaded={linear.loaded} />
       {ticket && tickets.length > 0 && (
         <DependenciesCard ticket={ticket} tickets={tickets} />

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.test.tsx
@@ -1,6 +1,22 @@
 import { describe, it, expect } from "bun:test";
 const SRC = await Bun.file(new URL("./app-shell.tsx", import.meta.url)).text();
 
+describe("AppShell feeds RepoIconProvider the observed∪roster repo union (GAP A, CTL-1258)", () => {
+  it("imports mergeIconRepos and useProjects", () => {
+    expect(SRC).toMatch(/import \{[^}]*\bmergeIconRepos\b[^}]*\} from "@\/lib\/project-settings-model"/s);
+    expect(SRC).toMatch(/import \{[^}]*\buseProjects\b[^}]*\} from "@\/hooks\/use-projects"/s);
+  });
+  it("computes the provider repos via mergeIconRepos(payload?.repos, projects)", () => {
+    expect(SRC).toMatch(/mergeIconRepos\(\s*payload\?\.repos \?\? \[\]\s*,\s*projects\s*\)/);
+  });
+  it("still mounts <RepoIconProvider repos={repos}>", () => {
+    expect(SRC).toContain("<RepoIconProvider repos={repos}>");
+  });
+  it("no longer feeds the bare observed-work set to the provider repos var", () => {
+    expect(SRC).not.toMatch(/const repos = payload\?\.repos \?\? \[\];/);
+  });
+});
+
 describe("AppShell provides ServiceHealthContext (5th provider, CTL-945)", () => {
   it("imports the hook + context", () => {
     expect(SRC).toMatch(

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
@@ -59,6 +59,8 @@ import { ticketDetailHref } from "@/board/detail-nav";
 import { useTheme } from "@/lib/theme";
 import { useBrand } from "@/lib/brand";
 import { useBoardSnapshot } from "@/hooks/use-board-snapshot";
+import { useProjects } from "@/hooks/use-projects";
+import { mergeIconRepos } from "@/lib/project-settings-model";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -150,7 +152,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   }, [scopeSearch, repoScope, setRepoScope]);
   // Repos from the board snapshot for palette navigation group construction.
   const { payload } = useBoardSnapshot();
-  const repos = payload?.repos ?? [];
+  const { projects } = useProjects();
+  const repos = useMemo(
+    () => mergeIconRepos(payload?.repos ?? [], projects),
+    [payload?.repos, projects],
+  );
   // CTL-945: single subscription point for nav + cluster signals. AppSidebar and
   // AppFooter consume NavSignalContext / ClusterSignalContext instead of calling
   // these hooks independently, reducing persistent EventSources from 6 → 4.


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-18T16:20:30Z -->
<!-- Last updated: 2026-06-18T16:20:30Z -->
<!-- PR: #2225 -->
<!-- Previous commits: 7f31f4fd1b20ea0aeb34b415fcc0fb14c89fce2a,6e3c3a4e97b00beb7c84c1cc06756999161e3c00 -->

## Summary

Fixes two independent gaps that caused project icons (custom glyph or repo favicon) to render inconsistently across orch-monitor surfaces:

- **GAP A** (`app-shell.tsx`): Feed `RepoIconProvider` the union of the observed-work repo set and the full project roster via `mergeIconRepos(payload?.repos ?? [], projects)` + `useProjects()`, so idle/queued/waiting projects get `/api/repo-icon/:repo` fetched and their favicons resolve everywhere (mirrors the CTL-1253 `mergeIconRepos` pattern from `settings-surface.tsx`).
- **GAP B — detail rails** (`Shell.tsx`, `detail-route.tsx`, `ticket-rail.tsx`): Migrate `PropertyRow` / `RailPropRow` from `iconSrc: string | null` to `mark: ProjectMark`; swap `resolveEntityIcon` → `resolveEntityMark`; replace raw `<img src={iconSrc}>` with `<ProjectMarkIcon mark={...} color={C.fg} size={14} />` for Repo/Team rows and the Project card.
- **GAP B — list lane header** (`BoardList.tsx`): Swap `laneIconSrc` → `laneMark`, `GroupHeaderRow.iconSrc` → `mark`, replace raw `<img>` with `<ProjectMarkIcon>`, mirroring `Swimlane.tsx`'s kanban lane header.

## Changes Made

### UI — Data layer (GAP A)

- `ui/src/components/app-shell.tsx`: call `useProjects()` and pass `mergeIconRepos(payload?.repos ?? [], projects)` into `<RepoIconProvider>` so the provider's `useRepoIcons` hook fetches favicon URLs for every project in the roster, not just those with active board work

### UI — Render layer (GAP B)

- `ui/src/board/Shell.tsx` / `ui/src/board/detail-route.tsx`: migrate `PropertyRow` from `iconSrc: string | null` to `mark: ProjectMark`; use `resolveEntityMark` + `<ProjectMarkIcon>`
- `ui/src/board/ticket-rail.tsx`: migrate `RailPropRow` likewise; replace the Project-card `<Box>` / raw-img fallback with `<ProjectMarkIcon>`
- `ui/src/board/BoardList.tsx`: rename `laneIconSrc` → `laneMark` on `GroupHeaderRow`; replace raw `<img>` with `<ProjectMarkIcon>`

### Tests

- `ui/src/components/app-shell.test.tsx`: 4 new assertions verify the `mergeIconRepos` union wiring (GAP A)
- `ui/src/board/detail-rail-marks.test.ts` (new): static-source wiring assertions for `Shell.tsx` + `detail-route.tsx` + `ticket-rail.tsx` GAP B surfaces
- `ui/src/board/list-lane-mark.test.ts` (new): 3 assertions for `BoardList.tsx` GAP B lane-header wiring
- `__tests__/ticket-rail.test.ts`: update 4 stale CTL-1012 assertions from the removed `iconSrc`/`resolveEntityIcon` API to the new `mark`/`resolveEntityMark`/`ProjectMarkIcon` wiring (test-only fix, commit 6e3c3a4e)

## How to Verify It

- [x] `bun test ui/src/components/app-shell.test.tsx` — 7 pass (4 new GAP A assertions) ✅
- [x] `bun test ui/src/board/detail-rail-marks.test.ts` — 4 pass (new GAP B assertions) ✅
- [x] `bun test ui/src/board/list-lane-mark.test.ts` — 3 pass (new GAP B Surface 4 assertions) ✅
- [x] `bun test ui/src/board/entity-icon.test.ts` — no regressions ✅
- [x] `bunx tsc --noEmit -p ui/tsconfig.json` — clean ✅
- [x] `bunx knip` — no new unused exports flagged ✅
- [ ] Live: open orch-monitor, confirm a favicon-only project (e.g. ADV/SLI/OTL) shows its favicon in the dispatch queue rather than a gray dot
- [ ] Live: open a CTL ticket's detail page, confirm Repo/Team rows and Project card show the CTL glyph

## Pre-merge Verification (from verify phase)

- **Regression risk**: 2 / 10
- **typecheck**: pass — root tsc exit 0; ui app-source in diff has 0 type errors
- **tests**: pass — bun test 5811 pass; 4 stale iconSrc assertions fixed and committed (6e3c3a4e); remaining 15 failures are host-environmental baseline not in the diff
- **lint**: pass — eslint exit 0; ui/** is eslint-ignored, so diff ui files not linted by root eslint
- **knip**: pass — no unused exports/deps; `resolveEntityIcon`/`laneIconSrc` retained but still used internally
- **reward-hacking**: pass — no `as-any`/`@ts-ignore`/`eslint-disable` in added lines; 2 guarded `mark!` assertions safe behind `showIcon` narrowing
- **security**: pass — pure UI refactor; no new deps, secrets, network, or SQL surface

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1258
- Related to #2222 (CTL-1253 — detected repo favicons in the project icon picker, same `mergeIconRepos` pattern)

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1012
skip CTL-1253
