### PR TITLE
feat(dev): CTL-1262 — tag otel-forward events with stable catalyst.node.name resource attr

### DIFF
--- a/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
+++ b/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
@@ -12,8 +12,8 @@ Do **not** edit this file directly.
 | --- | --- |
 | ✓ Conforming | 20 |
 | → Rename-to | 37 |
-| ● Legitimately Custom | 26 |
-| **Total** | 83 |
+| ● Legitimately Custom | 27 |
+| **Total** | 84 |
 
 ## Classification by Emitter
 
@@ -21,6 +21,7 @@ Do **not** edit this file directly.
 
 | Key | Source | Classification | Target | Cluster | Note |
 | --- | --- | --- | --- | --- | --- |
+| `catalyst.node.name` | `canonical-event.ts:55` | ● custom |  |  | CTL-1262 |
 | `catalyst.orchestration` | `canonical-event.ts:54` | ● custom |  |  |  |
 | `catalyst.orchestrator.id` | `canonical-event.ts:67` | ● custom |  |  |  |
 | `catalyst.phase` | `canonical-event.ts:70` | ● custom |  |  |  |

--- a/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
@@ -46,6 +46,13 @@ export interface Resource {
   // CTL-852: host identity fields, always present on canonical events.
   "host.name": string;
   "host.id": string;
+  // CTL-1262: stable Catalyst node name, distinct from the OS hostname
+  // (host.name). Resolved the same way as getHostName() / hostName()
+  // (CATALYST_HOST_NAME env -> catalyst.host.name Layer-2 config ->
+  // os.hostname() first DNS label) and NEVER derived from a Tailscale device
+  // name. Optional so external (webhook/broker-daemon) events that build a bare
+  // resource block remain valid; the otel-forward event path always sets it.
+  "catalyst.node.name"?: string;
   // CTL-636: optional orchestration-context resource keys. Present only when
   // the event carries the corresponding data; omitted otherwise so external
   // (webhook / broker-daemon) events keep the bare 3-key block.

--- a/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
@@ -26,6 +26,8 @@ export const AUDIT_MANIFEST: AttributeAuditEntry[] = [
   { key: "service.version",   emitter: "ts", source: "canonical-event.ts:45", classification: "conforming" },
   { key: "host.name",         emitter: "ts", source: "canonical-event.ts:47", classification: "conforming" },
   { key: "host.id",           emitter: "ts", source: "canonical-event.ts:48", classification: "conforming" },
+  // CTL-1262: stable Catalyst node name (distinct from the OS host.name) — catalyst.* custom
+  { key: "catalyst.node.name",      emitter: "ts", source: "canonical-event.ts:55", classification: "legitimately-custom", note: "CTL-1262" },
   // CTL-636 optional resource context
   { key: "project",                 emitter: "ts", source: "canonical-event.ts:52", classification: "rename-to",            targetName: "catalyst.project",        remediationCluster: "H", where: "both" },
   { key: "linear.key",              emitter: "ts", source: "canonical-event.ts:53", classification: "legitimately-custom" },

--- a/plugins/dev/scripts/otel-forward/lib/canonical.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/canonical.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir, hostname } from "node:os";
+import { join } from "node:path";
+
+import { buildCanonicalEnvelope, nodeName } from "./canonical.ts";
+import { buildOtlpPayload } from "./destinations/otlp.ts";
+
+// CTL-1262: node-name resource tag on the otel-forward event path.
+//
+// nodeName() / hostName() resolution precedence (must match
+// execution-core/config.mjs getHostName()):
+//   1. CATALYST_HOST_NAME env
+//   2. catalyst.host.name in the Layer-2 config (CATALYST_LAYER2_CONFIG_FILE)
+//   3. os.hostname() reduced to its first DNS label
+//
+// hostName() reads the Layer-2 file via CATALYST_LAYER2_CONFIG_FILE, so the
+// tests point it at a temp file rather than touching the real machine config.
+
+const ENV_KEYS = ["CATALYST_HOST_NAME", "CATALYST_LAYER2_CONFIG_FILE"] as const;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+function osLabel(): string {
+  const base = hostname();
+  const dot = base.indexOf(".");
+  return dot === -1 ? base : base.slice(0, dot);
+}
+
+describe("nodeName() resolution (mirrors getHostName())", () => {
+  test("precedence 1: CATALYST_HOST_NAME env wins", () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    expect(nodeName()).toBe("mini");
+  });
+
+  test("precedence 2: catalyst.host.name from Layer-2 config when env unset", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1262-"));
+    const cfg = join(dir, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { host: { name: "mini-2" } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    try {
+      expect(nodeName()).toBe("mini-2");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("precedence 3: falls back to os.hostname() first DNS label", () => {
+    // env unset (beforeEach) and Layer-2 file points nowhere
+    process.env.CATALYST_LAYER2_CONFIG_FILE = join(tmpdir(), "ctl1262-missing-xyz.json");
+    expect(nodeName()).toBe(osLabel());
+  });
+
+  test("node name is NOT a Tailscale device name (no embedded device suffix)", () => {
+    // Tailscale device names look like "RyansMini250233"; the env override is the
+    // stable coordination name, which is what we must use.
+    process.env.CATALYST_HOST_NAME = "mini";
+    expect(nodeName()).toBe("mini");
+    expect(nodeName()).not.toMatch(/\d{4,}$/);
+  });
+
+  test("resolution never throws on a malformed Layer-2 config", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1262-bad-"));
+    const cfg = join(dir, "config.json");
+    writeFileSync(cfg, "{ not valid json");
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    try {
+      expect(() => nodeName()).not.toThrow();
+      expect(nodeName()).toBe(osLabel());
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("buildCanonicalEnvelope carries catalyst.node.name distinctly", () => {
+  test("resource has a distinct catalyst.node.name attribute", () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    const ev = buildCanonicalEnvelope({
+      serviceName: "catalyst.otel-forward",
+      eventName: "test.event",
+    });
+    expect(ev.resource["catalyst.node.name"]).toBe("mini");
+  });
+
+  test("catalyst.node.name is keyed distinctly from host.name (separate keys)", () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    const ev = buildCanonicalEnvelope({
+      serviceName: "catalyst.otel-forward",
+      eventName: "test.event",
+    });
+    const resourceKeys = Object.keys(ev.resource);
+    expect(resourceKeys).toContain("host.name");
+    expect(resourceKeys).toContain("catalyst.node.name");
+    // host.name resolves via hostName() too, but the two are SEPARATE keys.
+    expect(ev.resource["catalyst.node.name"]).toBe(ev.resource["host.name"]);
+  });
+
+  test("node name resolves from Layer-2 config on the envelope", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1262-env-"));
+    const cfg = join(dir, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { host: { name: "laptop" } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    try {
+      const ev = buildCanonicalEnvelope({
+        serviceName: "catalyst.otel-forward",
+        eventName: "test.event",
+      });
+      expect(ev.resource["catalyst.node.name"]).toBe("laptop");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("catalyst.node.name is exported on the OTLP wire (no otlp.ts change)", () => {
+  test("appears in resourceLogs[].resource.attributes", () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    const ev = buildCanonicalEnvelope({
+      serviceName: "catalyst.otel-forward",
+      eventName: "test.event",
+    });
+    const payload = buildOtlpPayload([ev]) as {
+      resourceLogs: { resource: { attributes: { key: string; value: { stringValue?: string } }[] } }[];
+    };
+    const attrs = payload.resourceLogs[0].resource.attributes;
+    const nodeAttr = attrs.find((a) => a.key === "catalyst.node.name");
+    expect(nodeAttr).toBeDefined();
+    expect(nodeAttr?.value.stringValue).toBe("mini");
+    // host.name remains its own attribute on the wire — distinct from node name.
+    expect(attrs.find((a) => a.key === "host.name")).toBeDefined();
+  });
+});

--- a/plugins/dev/scripts/otel-forward/lib/canonical.ts
+++ b/plugins/dev/scripts/otel-forward/lib/canonical.ts
@@ -1,6 +1,20 @@
 import type { CanonicalEvent } from "../../orch-monitor/lib/canonical-event.ts";
 import { hostName, hostId } from "../../orch-monitor/lib/canonical-event-shared.ts";
 
+// CTL-1262: stable Catalyst node name. Identical resolution to
+// execution-core/config.mjs getHostName(): CATALYST_HOST_NAME env ->
+// catalyst.host.name in the Layer-2 (~/.config/catalyst/config.json) config ->
+// os.hostname() reduced to its first DNS label. The shared hostName() helper
+// already implements exactly this precedence and never throws, so we delegate
+// to it. It is deliberately a SEPARATE function from the OS-hostname concept:
+// host.name is the OS identity, catalyst.node.name is the stable coordination
+// name HRW / the delegate key off, and they are kept as distinct resource keys
+// even though the helper currently resolves them through the same code path.
+// The node name is NEVER derived from a Tailscale device name.
+export function nodeName(): string {
+  return hostName();
+}
+
 // Shared canonical-envelope builder for in-process event emission.
 // Mirrors the structure of broker/router.mjs:buildCanonicalEnvelope so all
 // internally-generated events (normalize.ts flat→canonical, Phase 4 failure
@@ -48,6 +62,17 @@ export function buildCanonicalEnvelope(opts: BuildOpts): CanonicalEvent {
       "service.version": opts.serviceVersion ?? "0.0.0",
       "host.name": hostName(),
       "host.id": hostId(),
+      // CTL-1262: stable Catalyst node name as a DISTINCT resource attribute so
+      // dashboards / the delegate can attribute signals per node. Resolved the
+      // SAME way as execution-core/config.mjs getHostName() — the shared
+      // hostName() helper applies the identical precedence (CATALYST_HOST_NAME
+      // env -> catalyst.host.name in Layer-2 config -> os.hostname() first DNS
+      // label) and never throws, falling back safely. NOT the Tailscale device
+      // name. Keyed distinctly from the OS hostname (host.name); when the two
+      // resolve to the same value today they remain semantically separate keys.
+      // buildOtlpPayload's generic toAttrArray serializes the whole resource, so
+      // this lands on the OTLP wire with no otlp.ts change.
+      "catalyst.node.name": nodeName(),
     },
     attributes: {
       "event.name": opts.eventName,


### PR DESCRIPTION
## What

Adds a distinct `catalyst.node.name` resource attribute to every canonical event built on the **otel-forward event path**, so operators (dashboards) and the delegate can attribute signals **per Catalyst node** — kept separate from the OS hostname (`host.name`).

Closes CTL-1262.

## Why

`host.name` is the OS hostname; the stable Catalyst **node** name is the coordination identity HRW / the delegate key off. Today only `host.name` reaches Loki/Prometheus, so per-node attribution collapses onto the OS hostname. This surfaces the stable node name as its own resource key. It is resolved the **same way** as `execution-core/config.mjs getHostName()` and is **never** derived from the Tailscale device name (which differs, e.g. `RyansMini250233` != `mini`).

## How

- **`otel-forward/lib/canonical.ts`** — new `nodeName()` helper delegating to the shared `hostName()`, which already implements the exact `getHostName()` precedence (`CATALYST_HOST_NAME` env → `catalyst.host.name` in the Layer-2 `~/.config/catalyst/config.json` → `os.hostname()` reduced to its first DNS label) and never throws. `buildCanonicalEnvelope` now sets `resource["catalyst.node.name"] = nodeName()`, keyed distinctly from `host.name`.
- **`orch-monitor/lib/canonical-event.ts`** — add the optional `"catalyst.node.name"` key to the unfenced `Resource` interface so it typechecks while bare external/broker-daemon resource blocks stay valid.
- **`otel-forward/lib/canonical.test.ts`** — new test file covering resolution precedence, safe fallback on missing/malformed Layer-2 config (never throws), distinct keying from `host.name`, Tailscale-name avoidance, and OTLP-wire serialization.

No `otlp.ts` change required: `buildOtlpPayload`'s generic `toAttrArray` already serializes the whole resource block, so `catalyst.node.name` flows onto the wire automatically. Scope is the event path only — the daemon-log shipper is untouched by this ticket.

## How to verify

Local:
```
cd plugins/dev/scripts/otel-forward
bun install
bun test lib/canonical.test.ts   # 9 pass
bun run typecheck                 # clean
```
Full otel-forward suite: `bun test` → 75 pass, 0 fail.

Live (operator step — do NOT run in CI):
1. Deploy the new otel-forward to a host (cache-sync rsync + restart per the mini live-test loop), e.g. on `mini`.
2. Emit/forward any event, then query Loki for the resource attribute:
   - In Grafana (otel.rozich.com) run a LogQL query against a `catalyst.*` stream and confirm `catalyst_node_name="mini"` appears as a structured-metadata label alongside `host_name`.
   - The value must be the **stable node name** (`mini` / `mini-2` / `laptop`), NOT a Tailscale device name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)