### PR TITLE
CTL-1122 PR2: activity-gated github ingestion-silence detection

### DIFF
--- a/docs/orchestrator-overview.md
+++ b/docs/orchestrator-overview.md
@@ -385,6 +385,18 @@ on read (belt-and-suspenders fallback also drops names prefixed `filter.` or
 `(source_event_id, interest_id)`) deduplicates wakes when `fs.watch` fires twice
 on the same append.
 
+**The broker is also the ingestion-silence detector (CTL-1122).** Because it tails
+every event, the broker is the surviving process that can judge whether an upstream
+ingestion source has gone quiet — the out-of-process check the monitor can't do for
+itself (the SPOF behind a 2026-06-14 11h silent outage). Each watchdog tick it
+evaluates per-source event recency and edge-triggers `catalyst.ingestion.{stale,recovered}`
+(emit-only; CTL-1123 consumes them). The `catalyst.monitor` heartbeat is judged on a
+tight fixed cadence (3m/10m, ungated). The `catalyst.github` webhook source is judged
+on a wide threshold (15m/30m) **gated on fleet activity** — github silence only alarms
+while a worker is in-flight (a fresh non-terminal `worker_state` row), so an idle fleet
+never false-alarms. Linear is deferred (its bot-skip guard makes the source quiet even
+during active work). See the configuration reference for the env knobs.
+
 **The execution-core daemon reaper (CTL-649) is the second producer-and-consumer.**
 It consumes the reap-intent requests appended by the reap-intent producers
 (`lib/emit-reap-intent.sh`, `execution-core/reap-intent.mjs`) — `phase.<kind>.reap-requested`,

--- a/plugins/dev/scripts/broker/broker-state.mjs
+++ b/plugins/dev/scripts/broker/broker-state.mjs
@@ -896,3 +896,40 @@ export function getStaleWorkers(thresholdMs, nowIso = new Date().toISOString()) 
     )
     .all(cutoff, ...terminal);
 }
+
+// Freshness window for hasActiveWorkers (CTL-1122 PR2). A non-terminal worker
+// whose last event is older than this is treated as crashed/idle, NOT active —
+// so a never-terminal crashed row cannot pin the github/linear ingestion-recency
+// activity-gate open during a dead-fleet lull (plan risk #4). 30 min comfortably
+// absorbs the longest legitimately-quiet phase (a worker mid-implement emits
+// phase events well inside it) while still timing out a genuinely dead worker.
+export const ACTIVE_WORKER_FRESHNESS_MS = 30 * 60 * 1000;
+
+// hasActiveWorkers — is the fleet actually working right now? Returns true iff
+// ≥1 worker_state row is non-terminal (status IS NULL OR NOT IN terminal) AND
+// has emitted an event within `freshnessMs` of `nowIso`. This is the activity
+// gate for the github/linear ingestion-silence detector (CTL-1122 PR2): webhook
+// silence only matters when a worker is in-flight and therefore SHOULD be
+// producing traffic. Freshness-bounded (the complement of getStaleWorkers'
+// predicate among non-terminal rows, AT-cutoff resolving to active) rather than
+// raw non-terminal, so a crashed row that never reached a terminal status does
+// not hold the gate open forever. Single EXISTS — no JS table scan.
+export function hasActiveWorkers(
+  nowIso = new Date().toISOString(),
+  freshnessMs = ACTIVE_WORKER_FRESHNESS_MS
+) {
+  const cutoff = new Date(new Date(nowIso).getTime() - freshnessMs).toISOString();
+  const terminal = [...WORKER_TERMINAL_STATUSES];
+  const placeholders = terminal.map(() => "?").join(", ");
+  const row = ensure()
+    .prepare(
+      `SELECT EXISTS(
+         SELECT 1 FROM worker_state
+         WHERE last_event_ts IS NOT NULL
+           AND last_event_ts >= ?
+           AND (status IS NULL OR status NOT IN (${placeholders}))
+       ) AS active`
+    )
+    .get(cutoff, ...terminal);
+  return row.active === 1;
+}

--- a/plugins/dev/scripts/broker/config.mjs
+++ b/plugins/dev/scripts/broker/config.mjs
@@ -91,6 +91,21 @@ export const MONITOR_RECENCY_DEGRADED_MS = parseInt(
   process.env.FILTER_MONITOR_RECENCY_DEGRADED_MS ?? "180000", 10);
 export const MONITOR_RECENCY_DOWN_MS = parseInt(
   process.env.FILTER_MONITOR_RECENCY_DOWN_MS ?? "600000", 10);
+// CTL-1122 PR2: github webhook recency. Unlike the monitor's fixed cadence,
+// github traffic idles organically, so these are activity-gated (only judged
+// while a worker is in-flight — see hasActiveWorkers) AND wide: a worker can be
+// mid-implement for many minutes with zero github traffic (work is local before
+// a push), so the gate removes idle-fleet false alarms while the threshold
+// absorbs active-but-pre-push quiet. 15m degraded / 30m down.
+export const GITHUB_RECENCY_DEGRADED_MS = parseInt(
+  process.env.FILTER_GITHUB_RECENCY_DEGRADED_MS ?? "900000", 10);
+export const GITHUB_RECENCY_DOWN_MS = parseInt(
+  process.env.FILTER_GITHUB_RECENCY_DOWN_MS ?? "1800000", 10);
+// linear (catalyst.linear) recency is DEFERRED in PR2 (fork a): the
+// linear-webhook bot-skip guard suppresses bot-authored events pre-log, so the
+// source goes quiet even during active work. Its knobs
+// (FILTER_LINEAR_RECENCY_{DEGRADED,DOWN}_MS) are intentionally not defined until
+// a non-flaky threshold is found and linear is wired into RECENCY_SOURCES.
 // Flap guard: minimum gap between a recovery and the next stale alarm. A death
 // that begins within this window is DEFERRED (re-checked each tick), never
 // dropped — see nextRecencyAlarmState.

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -37,6 +37,8 @@ export {
   getProjectionMeta,
   setProjectionMeta,
   getStaleWorkers,
+  hasActiveWorkers,
+  ACTIVE_WORKER_FRESHNESS_MS,
 } from "./broker-state.mjs";
 import { formatMissingKeyWarning, formatLoadedKeyInfo, probeGroq } from "../lib/api-key-health.mjs";
 import {

--- a/plugins/dev/scripts/broker/ingestion-recency-wiring.test.mjs
+++ b/plugins/dev/scripts/broker/ingestion-recency-wiring.test.mjs
@@ -322,6 +322,25 @@ describe("github/linear activity-gated recency (CTL-1122 PR2)", () => {
     expect(rec.attributes["event.label"]).toBe(GITHUB_SERVICE_NAME);
     expect(rec.body.payload.thresholdMs).toBeNull();
     expect(rec.body.payload.ageMs).toBeGreaterThanOrEqual(0); // outage duration
+    // gate-driven clear: no fresh beat cleared it, so the forensic link is null
+    // (not the stale pre-silence beat) — the recovered contract for CTL-1123.
+    expect(rec.caused_by).toBeNull();
+    expect(rec.body.payload.lastSeenAt).toBeNull();
+  });
+
+  test("(c') beat-driven recovery (a fresh github event while gated-open) → recovered names the fresh beat", () => {
+    dispatchActiveWorker();
+    __setLastSeenForTest(GITHUB_SERVICE_NAME, { ts: Date.now() - staleGithubMs, id: "gh-old" });
+    runWatchdogTick(); // → stale
+    // a fresh github webhook arrives while the fleet is still working
+    __setLastSeenForTest(GITHUB_SERVICE_NAME, { ts: Date.now(), id: "gh-fresh" });
+    runWatchdogTick(); // → recovered, beat-driven
+    const rec = readIngestionEvents(getEventLogPath()).find(
+      (e) => e.attributes["event.name"] === "catalyst.ingestion.recovered",
+    );
+    expect(rec).toBeDefined();
+    expect(rec.caused_by).toBe("gh-fresh");
+    expect(rec.body.payload.ageMs).toBeGreaterThanOrEqual(0);
   });
 
   test("(d) linear is DEFERRED — a stale catalyst.linear with active work does not alarm", () => {

--- a/plugins/dev/scripts/broker/ingestion-recency-wiring.test.mjs
+++ b/plugins/dev/scripts/broker/ingestion-recency-wiring.test.mjs
@@ -9,7 +9,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { getEventLogPath, getPrevMonthEventLogPath } from "./config.mjs";
+import { getEventLogPath, getPrevMonthEventLogPath, GITHUB_RECENCY_DOWN_MS } from "./config.mjs";
 import {
   runWatchdogTick,
   processEvent,
@@ -18,7 +18,14 @@ import {
   __setLastSeenForTest,
   __getLastSeenByServiceForTest,
   __getMonitorRecencyAlarmForTest,
+  __getRecencyAlarmForTest,
 } from "./router.mjs";
+import { GITHUB_SERVICE_NAME, LINEAR_SERVICE_NAME } from "./ingestion-recency.mjs";
+import {
+  openBrokerStateDb,
+  closeBrokerStateDb,
+  upsertWorkerState,
+} from "./broker-state.mjs";
 import { clearInterests, clearLastHeartbeat, __resetBrokerStartedAtForTest } from "./state.mjs";
 
 function readIngestionEvents(logPath) {
@@ -224,6 +231,128 @@ describe("boot-seed → first watchdog tick, end-to-end (CTL-1122)", () => {
     );
     expect(evs).toHaveLength(1);
     expect(evs[0].caused_by).toBe("prev-month-beat");
+  });
+});
+
+describe("github/linear activity-gated recency (CTL-1122 PR2)", () => {
+  // These tests open the broker-state DB so hasActiveWorkers (the gate input) is
+  // backed by real worker_state rows. The github source is in RECENCY_SOURCES
+  // with gated:true; linear is deferred. The file-level beforeEach already set
+  // CATALYST_DIR and cleared the recency map.
+  beforeEach(() => {
+    closeBrokerStateDb(); // defensively close any leaked handle
+    openBrokerStateDb(join(dir, "broker-state.db"));
+  });
+  afterEach(() => {
+    closeBrokerStateDb();
+  });
+
+  // staleGithubMs: just past the github down threshold.
+  const staleGithubMs = GITHUB_RECENCY_DOWN_MS + 60_000;
+
+  function dispatchActiveWorker(ticket = "CTL-1") {
+    // a fresh, non-terminal worker row → hasActiveWorkers() === true (gate open)
+    upsertWorkerState({
+      orchestrator: "orch-1",
+      ticket,
+      status: "implement",
+      eventId: `e-${ticket}`,
+      eventTs: new Date().toISOString(),
+    });
+  }
+  function finishWorker(ticket = "CTL-1") {
+    // advance the same row to a terminal status → gate closes
+    upsertWorkerState({
+      orchestrator: "orch-1",
+      ticket,
+      status: "done",
+      eventId: `done-${ticket}`,
+      eventTs: new Date().toISOString(),
+    });
+  }
+
+  test("(a) github silent + worker in-flight → one catalyst.ingestion.stale (label catalyst.github)", () => {
+    dispatchActiveWorker();
+    __setLastSeenForTest(GITHUB_SERVICE_NAME, { ts: Date.now() - staleGithubMs, id: "gh-old" });
+    runWatchdogTick();
+    const evs = readIngestionEvents(getEventLogPath());
+    expect(evs).toHaveLength(1);
+    expect(evs[0].attributes["event.name"]).toBe("catalyst.ingestion.stale");
+    expect(evs[0].attributes["event.label"]).toBe(GITHUB_SERVICE_NAME);
+    expect(evs[0].caused_by).toBe("gh-old");
+    expect(evs[0].body.payload.thresholdMs).toBe(GITHUB_RECENCY_DOWN_MS);
+
+    // edge-triggered: a second tick while still stale + gated-open does not re-emit
+    runWatchdogTick();
+    expect(readIngestionEvents(getEventLogPath())).toHaveLength(1);
+  });
+
+  test("(b) github silent + NO worker in-flight → gate closed, no emit", () => {
+    // no worker rows at all → hasActiveWorkers() false → severity forced up
+    __setLastSeenForTest(GITHUB_SERVICE_NAME, { ts: Date.now() - staleGithubMs, id: "gh-old" });
+    runWatchdogTick();
+    expect(readIngestionEvents(getEventLogPath())).toHaveLength(0);
+    expect(__getRecencyAlarmForTest(GITHUB_SERVICE_NAME).downEmitted).toBe(false);
+  });
+
+  test("(b') only terminal workers → gate closed, no github emit", () => {
+    finishWorker("DONE"); // a terminal row is not active
+    __setLastSeenForTest(GITHUB_SERVICE_NAME, { ts: Date.now() - staleGithubMs, id: "gh-old" });
+    runWatchdogTick();
+    expect(readIngestionEvents(getEventLogPath())).toHaveLength(0);
+  });
+
+  test("(c) github stale gated-open, then work finishes (gate closes) → paired recovered with duration", () => {
+    dispatchActiveWorker();
+    __setLastSeenForTest(GITHUB_SERVICE_NAME, { ts: Date.now() - staleGithubMs, id: "gh-old" });
+    runWatchdogTick(); // → stale (gate open)
+    expect(
+      readIngestionEvents(getEventLogPath()).filter(
+        (e) => e.attributes["event.name"] === "catalyst.ingestion.stale",
+      ),
+    ).toHaveLength(1);
+
+    // work finishes → gate closes; github last-seen is left UNCHANGED (still old)
+    finishWorker();
+    runWatchdogTick(); // gate closed → severity up → recovered
+    const rec = readIngestionEvents(getEventLogPath()).find(
+      (e) => e.attributes["event.name"] === "catalyst.ingestion.recovered",
+    );
+    expect(rec).toBeDefined();
+    expect(rec.attributes["event.label"]).toBe(GITHUB_SERVICE_NAME);
+    expect(rec.body.payload.thresholdMs).toBeNull();
+    expect(rec.body.payload.ageMs).toBeGreaterThanOrEqual(0); // outage duration
+  });
+
+  test("(d) linear is DEFERRED — a stale catalyst.linear with active work does not alarm", () => {
+    dispatchActiveWorker();
+    // even far past any plausible threshold, linear is not in RECENCY_SOURCES
+    __setLastSeenForTest(LINEAR_SERVICE_NAME, { ts: Date.now() - 3 * 60 * 60_000, id: "lin-old" });
+    runWatchdogTick();
+    const labels = readIngestionEvents(getEventLogPath()).map((e) => e.attributes["event.label"]);
+    expect(labels).not.toContain(LINEAR_SERVICE_NAME);
+  });
+
+  test("(e) per-source isolation — monitor and github alarms don't cross-contaminate", () => {
+    dispatchActiveWorker();
+    __setLastSeenForTest("catalyst.monitor", { ts: Date.now() - (TEN_MIN + 60_000), id: "mon-old" });
+    __setLastSeenForTest(GITHUB_SERVICE_NAME, { ts: Date.now() - staleGithubMs, id: "gh-old" });
+    runWatchdogTick();
+    const stale = readIngestionEvents(getEventLogPath()).filter(
+      (e) => e.attributes["event.name"] === "catalyst.ingestion.stale",
+    );
+    const labels = stale.map((e) => e.attributes["event.label"]).sort();
+    expect(labels).toEqual([GITHUB_SERVICE_NAME, "catalyst.monitor"].sort());
+    // each alarm latched in its own per-source state
+    expect(__getMonitorRecencyAlarmForTest().downEmitted).toBe(true);
+    expect(__getRecencyAlarmForTest(GITHUB_SERVICE_NAME).downEmitted).toBe(true);
+  });
+
+  test("(f) github gate open but fresh → no alarm (gating is necessary, not sufficient)", () => {
+    dispatchActiveWorker();
+    __setLastSeenForTest(GITHUB_SERVICE_NAME, { ts: Date.now() - 60_000, id: "gh-fresh" });
+    runWatchdogTick();
+    expect(readIngestionEvents(getEventLogPath())).toHaveLength(0);
   });
 });
 

--- a/plugins/dev/scripts/broker/ingestion-recency.mjs
+++ b/plugins/dev/scripts/broker/ingestion-recency.mjs
@@ -42,6 +42,13 @@ import { getEventLogPath, log } from "./config.mjs";
 // are not a calibratable freshness signal.
 export const MONITOR_SERVICE_NAME = "catalyst.monitor";
 
+// CTL-1122 PR2: the github webhook source identity (orch-monitor
+// webhook-handler.ts emits resource["service.name"]=catalyst.github). Activity-
+// gated in RECENCY_SOURCES. The linear identity (catalyst.linear) is deferred —
+// see the RECENCY_SOURCES note in router.mjs.
+export const GITHUB_SERVICE_NAME = "catalyst.github";
+export const LINEAR_SERVICE_NAME = "catalyst.linear";
+
 // The alarm event names. New namespace `catalyst.ingestion.*` (the documented
 // CTL-1123 contract). stale = ingestion has gone silent past threshold;
 // recovered = a fresh event has been observed again.

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -507,12 +507,16 @@ function checkSourceRecency(source, now) {
   if (!isIngestionRecencyEnabled()) return null;
   const seen = _lastSeenByService.get(source.serviceName);
   const prevAlarm = recencyAlarmFor(source.serviceName);
-  let { severity } = evaluateSource({
+  // The source's OWN freshness, before any gate override — used below to decide
+  // whether a recovery was actually beat-driven (a fresh event arrived) or
+  // gate-driven (the fleet went idle while the source was still silent).
+  const { severity: ungatedSeverity } = evaluateSource({
     lastSeenTs: seen?.ts ?? null,
     nowMs: now,
     degradedAfterMs: source.degradedAfterMs,
     downAfterMs: source.downAfterMs,
   });
+  let severity = ungatedSeverity;
   if (source.gated && !fleetIsActive(now)) {
     // Gate closed: the fleet isn't working, so webhook silence is expected, not
     // a fault. Force "up" → no stale, and a clean clear of any open outage.
@@ -525,6 +529,12 @@ function checkSourceRecency(source, now) {
   });
   if (emit) {
     const recovered = emit === "recovered";
+    // A recovery is beat-driven iff the source itself sees a fresh event
+    // (ungated severity up). A gate-driven recovery — the fleet went idle while
+    // the source was still silent — has NO fresh beat that cleared it, so the
+    // forensic link is null rather than the stale pre-silence beat (which would
+    // contradict the recovered contract CTL-1123 reads).
+    const beatDrivenRecovery = recovered && ungatedSeverity === "up";
     // stale describes the silence (age since the last beat, vs the down
     // threshold); recovered describes the outage it CLEARED (its duration, no
     // threshold). ageMs is clamped so clock skew (a future beat) can never emit
@@ -536,15 +546,16 @@ function checkSourceRecency(source, now) {
       : seen
         ? Math.max(0, now - seen.ts)
         : null;
+    // stale: the last beat before silence. recovered: the fresh beat that
+    // cleared it (beat-driven only) — null for a gate-driven clear.
+    const forensicSeen = recovered ? (beatDrivenRecovery ? seen : null) : seen;
     const ok = emitIngestionRecencyEvent({
       action: emit,
       sourceName: source.serviceName,
       ageMs,
       thresholdMs: recovered ? null : source.downAfterMs,
-      lastSeenAt: seen ? new Date(seen.ts).toISOString() : null,
-      // the forensic link: the last beat before silence (stale) / the fresh
-      // beat that cleared it (recovered).
-      causedBy: seen?.id ?? null,
+      lastSeenAt: forensicSeen ? new Date(forensicSeen.ts).toISOString() : null,
+      causedBy: forensicSeen?.id ?? null,
     });
     if (!ok) {
       // The append FAILED (e.g. transient ENOSPC/EACCES — conditions correlated

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -31,6 +31,8 @@ import {
   isIngestionRecencyEnabled,
   MONITOR_RECENCY_DEGRADED_MS,
   MONITOR_RECENCY_DOWN_MS,
+  GITHUB_RECENCY_DEGRADED_MS,
+  GITHUB_RECENCY_DOWN_MS,
   INGESTION_RECENCY_HOLDDOWN_MS,
   INGESTION_SEED_BYTES,
   getPrevMonthEventLogPath,
@@ -72,6 +74,7 @@ import {
   clearTicketHeldSince,
   upsertWaitingSession,
   clearWaitingSession,
+  hasActiveWorkers,
 } from "./broker-state.mjs";
 import { sessionLiveness } from "./session-liveness.mjs";
 import {
@@ -104,6 +107,7 @@ import {
 import { evaluateSource } from "../lib/ingestion-recency.mjs";
 import {
   MONITOR_SERVICE_NAME,
+  GITHUB_SERVICE_NAME,
   initialRecencyAlarmState,
   nextRecencyAlarmState,
   emitIngestionRecencyEvent,
@@ -352,7 +356,49 @@ export function __clearEmittedWakeCacheForTest() {
 // the monitor's own kind:"self" probe reports `up` iff the monitor answers, so
 // it can never observe its own death.
 const _lastSeenByService = new Map(); // service.name -> { ts: epochMs, id: string|null }
-let _monitorRecencyAlarm = initialRecencyAlarmState();
+
+// CTL-1122 PR2: per-source alarm state. PR1 keyed a single _monitorRecencyAlarm;
+// the watchdog now judges several sources (monitor + the activity-gated
+// github/linear webhook ingestion), each with its own edge-trigger/holddown
+// state. service.name -> alarmState (initialRecencyAlarmState shape).
+const _recencyAlarmByService = new Map();
+
+// RECENCY_SOURCES — one descriptor per ingestion source the watchdog evaluates
+// each tick. `gated:true` sources are activity-gated: their silence only alarms
+// while the fleet is actually working (hasActiveWorkers), because they idle
+// organically. The monitor heartbeat is a fixed ~30s cadence → ungated, with
+// PR1's tight 3m/10m thresholds unchanged.
+const RECENCY_SOURCES = [
+  {
+    serviceName: MONITOR_SERVICE_NAME,
+    degradedAfterMs: MONITOR_RECENCY_DEGRADED_MS,
+    downAfterMs: MONITOR_RECENCY_DOWN_MS,
+    gated: false,
+  },
+  {
+    serviceName: GITHUB_SERVICE_NAME,
+    degradedAfterMs: GITHUB_RECENCY_DEGRADED_MS,
+    downAfterMs: GITHUB_RECENCY_DOWN_MS,
+    gated: true,
+  },
+  // linear (catalyst.linear) is DEFERRED in PR2 (fork a): the linear-webhook
+  // bot-skip guard suppresses bot-authored issue events before they reach the
+  // log, so catalyst.linear goes quiet even while a worker is in-flight — an
+  // irreducible false-alarm risk. When a non-flaky threshold is found, it is a
+  // one-line add here ({ serviceName: LINEAR_SERVICE_NAME, ..., gated: true }).
+];
+
+// recencyAlarmFor — lazily materialize (and store) a source's alarm state so a
+// never-ticked source still reads as the initial fail-open state via the test
+// seams. The stored object is what subsequent ticks advance.
+function recencyAlarmFor(serviceName) {
+  let state = _recencyAlarmByService.get(serviceName);
+  if (!state) {
+    state = initialRecencyAlarmState();
+    _recencyAlarmByService.set(serviceName, state);
+  }
+  return state;
+}
 
 // recordLastSeen — fold one ingested event into the per-service last-seen map.
 // Keyed on the canonical resource["service.name"]; legacy flat events (no
@@ -445,21 +491,33 @@ export function seedLastSeenByService({
   }
 }
 
-// checkMonitorRecency — one watchdog-tick evaluation of the monitor heartbeat's
+// checkSourceRecency — one watchdog-tick evaluation of ONE source's ingestion
 // freshness → edge-triggered catalyst.ingestion.{stale,recovered}. Fail-open: a
-// never-seen monitor classifies "unknown" and never alarms. The emit is
+// never-seen source classifies "unknown" and never alarms. The emit is
 // best-effort (emitIngestionRecencyEvent never throws). Returns the emit
 // decision so the wiring test can assert it without parsing the log.
-function checkMonitorRecency(now) {
+//
+// CTL-1122 PR2: generalizes PR1's monitor-only checkMonitorRecency. A `gated`
+// source's silence only matters when the fleet is in-flight — with no active
+// worker, severity is forced to "up" BEFORE the edge-trigger machine, so the
+// source never fires stale and any latched outage clears as a paired recovered
+// (fork c — keeps the stale/recovered ledger balanced for CTL-1123). The gate
+// is a pre-classify override; the alarm machine itself is untouched.
+function checkSourceRecency(source, now) {
   if (!isIngestionRecencyEnabled()) return null;
-  const seen = _lastSeenByService.get(MONITOR_SERVICE_NAME);
-  const prevAlarm = _monitorRecencyAlarm;
-  const { severity } = evaluateSource({
+  const seen = _lastSeenByService.get(source.serviceName);
+  const prevAlarm = recencyAlarmFor(source.serviceName);
+  let { severity } = evaluateSource({
     lastSeenTs: seen?.ts ?? null,
     nowMs: now,
-    degradedAfterMs: MONITOR_RECENCY_DEGRADED_MS,
-    downAfterMs: MONITOR_RECENCY_DOWN_MS,
+    degradedAfterMs: source.degradedAfterMs,
+    downAfterMs: source.downAfterMs,
   });
+  if (source.gated && !fleetIsActive(now)) {
+    // Gate closed: the fleet isn't working, so webhook silence is expected, not
+    // a fault. Force "up" → no stale, and a clean clear of any open outage.
+    severity = "up";
+  }
   const { state, emit } = nextRecencyAlarmState(prevAlarm, {
     severity,
     nowMs: now,
@@ -480,9 +538,9 @@ function checkMonitorRecency(now) {
         : null;
     const ok = emitIngestionRecencyEvent({
       action: emit,
-      sourceName: MONITOR_SERVICE_NAME,
+      sourceName: source.serviceName,
       ageMs,
-      thresholdMs: recovered ? null : MONITOR_RECENCY_DOWN_MS,
+      thresholdMs: recovered ? null : source.downAfterMs,
       lastSeenAt: seen ? new Date(seen.ts).toISOString() : null,
       // the forensic link: the last beat before silence (stale) / the fresh
       // beat that cleared it (recovered).
@@ -497,14 +555,28 @@ function checkMonitorRecency(now) {
       return null;
     }
   }
-  _monitorRecencyAlarm = state;
+  _recencyAlarmByService.set(source.serviceName, state);
   return emit;
+}
+
+// fleetIsActive — the activity-gate input for gated recency sources. Defensive
+// wrapper around hasActiveWorkers: a watchdog tick must NEVER throw, and the
+// broker-state DB read could fail (e.g. closed handle in an isolated unit test,
+// or a transient error). On failure, fail the gate CLOSED (treat as no active
+// work) — the no-false-alarm safe default, consistent with the detector's
+// fail-open-to-"up" philosophy.
+function fleetIsActive(now) {
+  try {
+    return hasActiveWorkers(new Date(now).toISOString());
+  } catch {
+    return false;
+  }
 }
 
 // Test seams (CTL-1122) — mirror the _emittedWakeCache __…ForTest pattern.
 export function __clearIngestionRecencyForTest() {
   _lastSeenByService.clear();
-  _monitorRecencyAlarm = initialRecencyAlarmState();
+  _recencyAlarmByService.clear();
 }
 export function __setLastSeenForTest(serviceName, entry) {
   _lastSeenByService.set(serviceName, entry);
@@ -512,8 +584,14 @@ export function __setLastSeenForTest(serviceName, entry) {
 export function __getLastSeenByServiceForTest() {
   return _lastSeenByService;
 }
+// PR1's monitor-scoped accessor, preserved verbatim for the existing wiring
+// tests; reads the monitor entry out of the per-source map.
 export function __getMonitorRecencyAlarmForTest() {
-  return _monitorRecencyAlarm;
+  return recencyAlarmFor(MONITOR_SERVICE_NAME);
+}
+// PR2: per-source accessor for the github/linear isolation tests.
+export function __getRecencyAlarmForTest(serviceName) {
+  return recencyAlarmFor(serviceName);
 }
 
 // CTL-357: one-shot startup event. If the Groq prose path is gated off (the
@@ -1866,9 +1944,10 @@ export function runWatchdogTick({ liveness = sessionLiveness } = {}) {
     setDegradedEmittedAt(null);
   }
 
-  // CTL-1122: judge the orch-monitor's liveness from its heartbeat recency — the
-  // surviving-process observation the 11h silent outage proved we were missing.
-  checkMonitorRecency(now);
+  // CTL-1122: judge each ingestion source's liveness from its event recency —
+  // the surviving-process observation the 11h silent outage proved we were
+  // missing. PR1 = monitor heartbeat; PR2 = activity-gated github webhooks.
+  for (const source of RECENCY_SOURCES) checkSourceRecency(source, now);
 
   let watchdogWoke = false;
 

--- a/plugins/dev/scripts/broker/worker-state-projection.test.mjs
+++ b/plugins/dev/scripts/broker/worker-state-projection.test.mjs
@@ -22,6 +22,8 @@ import {
   getProjectionMeta,
   setProjectionMeta,
   getStaleWorkers,
+  hasActiveWorkers,
+  ACTIVE_WORKER_FRESHNESS_MS,
   reduceWorkerStateEvent,
   projectWorkerStateEvent,
   replayWorkerStateProjection,
@@ -334,6 +336,138 @@ describe("worker_state store helpers (CTL-532)", () => {
     meta = getProjectionMeta();
     expect(meta.lastEventId).toBe("e10");
     expect(meta.eventsFolded).toBe(99);
+  });
+});
+
+// ─── hasActiveWorkers: the activity gate (CTL-1122 PR2) ──────────────────────
+// True iff ≥1 non-terminal worker_state row has emitted an event within the
+// freshness window. Freshness-bounded (NOT raw non-terminal) so a crashed
+// never-terminal row can't pin the github/linear ingestion-recency gate open
+// during a dead-fleet lull (PR2 fork b / plan risk #4). The freshness bound is
+// the complement of getStaleWorkers' predicate among non-terminal rows.
+
+describe("hasActiveWorkers (CTL-1122 PR2)", () => {
+  const now = "2026-05-21T10:00:00.000Z";
+  const fresh = "2026-05-21T09:59:00.000Z"; // 1 min ago, within 30-min window
+  const stale = "2026-05-21T09:00:00.000Z"; // 60 min ago, past 30-min window
+
+  test("no rows → false", () => {
+    expect(hasActiveWorkers(now)).toBe(false);
+  });
+
+  test("one fresh non-terminal (running) row → true", () => {
+    upsertWorkerState({
+      orchestrator: "orch-1",
+      ticket: "CTL-1",
+      status: "implement",
+      eventId: "e1",
+      eventTs: fresh,
+    });
+    expect(hasActiveWorkers(now)).toBe(true);
+  });
+
+  test("one fresh null-status row → true (dispatched, no status yet)", () => {
+    upsertWorkerState({
+      orchestrator: "orch-1",
+      ticket: "CTL-1",
+      phase: "research",
+      eventId: "e1",
+      eventTs: fresh,
+    });
+    expect(getWorkerState("orch-1", "CTL-1").status).toBeNull();
+    expect(hasActiveWorkers(now)).toBe(true);
+  });
+
+  test("only terminal rows (done/failed/complete), even if fresh → false", () => {
+    for (const [t, status] of [
+      ["A", "done"],
+      ["B", "failed"],
+      ["C", "complete"],
+    ]) {
+      upsertWorkerState({
+        orchestrator: "orch-1",
+        ticket: t,
+        status,
+        eventId: `e-${t}`,
+        eventTs: fresh,
+      });
+    }
+    expect(hasActiveWorkers(now)).toBe(false);
+  });
+
+  test("a STALE non-terminal row (crashed, never terminal) → false (fork b)", () => {
+    upsertWorkerState({
+      orchestrator: "orch-1",
+      ticket: "CRASHED",
+      status: "implement",
+      eventId: "e1",
+      eventTs: stale,
+    });
+    // getStaleWorkers would return it; hasActiveWorkers must NOT count it.
+    expect(getStaleWorkers(30 * 60 * 1000, now).map((r) => r.ticket)).toContain("CRASHED");
+    expect(hasActiveWorkers(now)).toBe(false);
+  });
+
+  test("mixed: one terminal-fresh + one non-terminal-fresh → true", () => {
+    upsertWorkerState({
+      orchestrator: "orch-1",
+      ticket: "DONE",
+      status: "done",
+      eventId: "e1",
+      eventTs: fresh,
+    });
+    upsertWorkerState({
+      orchestrator: "orch-1",
+      ticket: "LIVE",
+      status: "verify",
+      eventId: "e2",
+      eventTs: fresh,
+    });
+    expect(hasActiveWorkers(now)).toBe(true);
+  });
+
+  test("non-terminal row with NULL last_event_ts → false (no confirmed beat)", () => {
+    // upsert with no eventTs leaves last_event_ts NULL; getStaleWorkers also
+    // excludes these (IS NOT NULL), so the gate stays consistent with it.
+    upsertWorkerState({
+      orchestrator: "orch-1",
+      ticket: "NOTS",
+      status: "implement",
+      eventId: "e1",
+    });
+    expect(getWorkerState("orch-1", "NOTS").last_event_ts).toBeNull();
+    expect(hasActiveWorkers(now)).toBe(false);
+  });
+
+  test("boundary: a row exactly at the freshness cutoff counts as active", () => {
+    // 30-min window ⇒ cutoff is 09:30:00. A beat AT the cutoff is >= cutoff ⇒
+    // active (the complement of getStaleWorkers, where AT-cutoff is excluded).
+    upsertWorkerState({
+      orchestrator: "orch-1",
+      ticket: "AT",
+      status: "implement",
+      eventId: "e1",
+      eventTs: "2026-05-21T09:30:00.000Z",
+    });
+    expect(hasActiveWorkers(now)).toBe(true);
+    expect(getStaleWorkers(30 * 60 * 1000, now).map((r) => r.ticket)).not.toContain("AT");
+  });
+
+  test("custom freshnessMs is honored (tighter window excludes an otherwise-fresh row)", () => {
+    upsertWorkerState({
+      orchestrator: "orch-1",
+      ticket: "CTL-1",
+      status: "implement",
+      eventId: "e1",
+      eventTs: "2026-05-21T09:50:00.000Z", // 10 min ago
+    });
+    expect(hasActiveWorkers(now, 30 * 60 * 1000)).toBe(true); // within 30 min
+    expect(hasActiveWorkers(now, 5 * 60 * 1000)).toBe(false); // outside 5 min
+  });
+
+  test("ACTIVE_WORKER_FRESHNESS_MS default is exported and positive", () => {
+    expect(typeof ACTIVE_WORKER_FRESHNESS_MS).toBe("number");
+    expect(ACTIVE_WORKER_FRESHNESS_MS).toBeGreaterThan(0);
   });
 });
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -247,3 +247,14 @@ The execution-core scheduler protects itself against a single ticket dominating 
 - `SCHEDULER_RUNAWAY_WINDOW_MS` (default `600000`, 10 min) — rolling window for the runaway-rate alert and its once-per-window suppression marker.
 
 The **phantom worker-dir validity sweep** quarantines a `workers/<ticket>/` dir only when all three hold: the ticket is definitively **not-found** in Linear (a clean exit-0 not-found body — a nonzero exit or transient outage classifies as `unknown` and is never quarantined), it is **not in the eligible set**, and it has **no live bg worker**. This conjunction guarantees a transient Linear outage can never quarantine a healthy, resolvable, in-flight ticket. `SCHEDULER_CIRCUIT_BREAKER_THRESHOLD` is the Linear-independent backstop; the runaway knobs are observability only.
+
+### Ingestion-silence detector (CTL-1122)
+
+The broker tails every event, so it is the surviving process that can notice when an upstream ingestion source has gone silent — the out-of-process check the monitor cannot do for itself (its own health probe reports `up` iff it answers, so it can never observe its own death). Each watchdog tick the broker judges per-source event recency and edge-triggers `catalyst.ingestion.{stale,recovered}` (emit-only — it takes no corrective action; CTL-1123 is the consumer). These knobs are env vars on the `catalyst-broker` process:
+
+- `CATALYST_INGESTION_RECENCY` (default on; set `0` to disable) — master kill-switch, read at call time so it toggles without a broker restart.
+- `FILTER_MONITOR_RECENCY_DEGRADED_MS` / `FILTER_MONITOR_RECENCY_DOWN_MS` (defaults `180000` / `600000`) — the `catalyst.monitor` heartbeat thresholds. The monitor beats on a fixed ~30s cadence, so these are tight (3m degraded / 10m down) and **ungated**.
+- `FILTER_GITHUB_RECENCY_DEGRADED_MS` / `FILTER_GITHUB_RECENCY_DOWN_MS` (defaults `900000` / `1800000`) — the `catalyst.github` webhook thresholds. GitHub traffic idles organically, so these are wide (15m / 30m) **and activity-gated**: github silence only alarms while a worker is in-flight (a non-terminal `worker_state` row that has emitted an event within the last 30 min). With no active worker the source is forced healthy, so an idle fleet never false-alarms.
+- `FILTER_INGESTION_RECENCY_HOLDDOWN_MS` (default `600000`) — flap guard: minimum gap between a recovery and the next stale alarm. A sustained outage that begins inside the window is deferred (re-checked each tick), never dropped.
+
+Linear (`catalyst.linear`) recency is intentionally **not** wired: the linear-webhook bot-skip guard suppresses bot-authored events before they reach the log, so the source goes quiet even during active work. Its knobs (`FILTER_LINEAR_RECENCY_*`) are reserved for when a non-flaky threshold is found.


### PR DESCRIPTION
## What

Extends the PR1 broker ingestion-silence detector (`be4fa5fb`, monitor heartbeat) to **github webhooks**, gated on whether the fleet is actually working. Silence only matters when a worker is in-flight and therefore *should* be producing webhook traffic — so an idle fleet never false-alarms despite github's organic 2–13h idle gaps.

Builds on `thoughts/shared/plans/2026-06-17-ctl-1122-pr2-activity-gated-recency.md`.

## How

- **`broker-state.mjs`** — new `hasActiveWorkers(nowIso?, freshnessMs?)`: single `EXISTS` over `worker_state`, true iff a non-terminal row emitted an event within the freshness window (default 30m). This is the *complement* of `getStaleWorkers` among non-terminal rows, so a crashed never-terminal worker can't pin the gate open during a dead-fleet lull.
- **`router.mjs`** — generalized PR1's monitor-only `checkMonitorRecency` into `checkSourceRecency(source, now)` driven by a `RECENCY_SOURCES` table, with per-source alarm state (`_recencyAlarmByService` Map). The activity gate is a **pre-classify severity override** (force `up` when a gated source has no active worker), leaving the edge-trigger/holddown machine untouched. The watchdog tick iterates the table. The gate read **fails closed** defensively — a watchdog tick never throws.
- **`config.mjs`** — `FILTER_GITHUB_RECENCY_{DEGRADED,DOWN}_MS` (15m/30m: wide, since a worker can be mid-implement with zero github traffic before a push).
- **`ingestion-recency.mjs`** — `GITHUB_SERVICE_NAME` / `LINEAR_SERVICE_NAME` constants.

### Design forks (ratified)
- **(a) github-only; linear deferred.** The linear-webhook bot-skip guard suppresses bot-authored events pre-log, so `catalyst.linear` goes quiet even during active work — irreducible false-alarm risk. One-line add to `RECENCY_SOURCES` when a non-flaky threshold is found.
- **(b) freshness-bounded gate** (not raw non-terminal) — excludes crashed workers (plan risk #4).
- **(c) gate-close mid-outage emits a paired `recovered`** — keeps the stale/recovered ledger balanced for the CTL-1123 consumer.

### Monitor path unchanged
The monitor descriptor keeps PR1's exact 3m/10m thresholds, `gated:false` — a pure refactor. The existing monitor wiring tests pass **verbatim**.

## Adversarial review
Ran the PR1 method (which caught 12 issues). No high/medium bugs; all 6 risk areas verified sound (alarm-state aliasing, append-fail latch, per-source isolation, fail-closed gate, SQL boundary partition, no double-emit). One **low** finding fixed in `2b01b953`: a *gate-driven* `recovered` was carrying the stale beat's `caused_by`/`lastSeenAt` — now nulled (forensic link names a fresh beat only for a beat-driven recovery).

## Tests
+19 tests (gate semantics; github stale/gated/beat-driven-recovered/gate-driven-recovered/isolation; linear-deferred). **Full broker suite: 677 pass.**

## Rollout
Additive, emit-only (no enforcement) — same posture as PR1. Activation is the merge-reload that respawns the broker onto new code on Mini.