### PR TITLE
fix(dev): CTL-1273 — one roster source of truth (no reader/writer divergence)

### DIFF
--- a/plugins/dev/scripts/execution-core/cli-cluster.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli-cluster.test.mjs
@@ -1,7 +1,7 @@
 // cli-cluster.test.mjs — CTL-1188. Unit tests for cli/cluster.mjs.
 // Run: cd plugins/dev/scripts/execution-core && bun test cli-cluster.test.mjs
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -11,7 +11,10 @@ import {
   renameHost,
   setAnchor,
   tune,
+  runAdd,
+  runRemove,
 } from "./cli/cluster.mjs";
+import { getClusterHosts } from "./config.mjs";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -311,5 +314,73 @@ describe("tune", () => {
     expect(tune("maxParallelCeiling", "8", { writeLayer2: (o) => writes.push(o) }).code).toBe(0);
     expect(writes[0]).toMatchObject({ catalyst: { orchestration: { executionCore: { minParallel: 2 } } } });
     expect(writes[1]).toMatchObject({ catalyst: { orchestration: { executionCore: { maxParallelCeiling: 8 } } } });
+  });
+});
+
+// ── reader/writer agree end-to-end (CTL-1273) ──────────────────────────────
+// The acceptance proof: a `cluster add` (runAdd → getCatalystRepoDirHostsPath →
+// project hosts.json) is immediately visible to the daemon's roster reader
+// (getClusterHosts), through the SAME env-driven path resolution. The writer
+// target stays the project hosts.json; the union reader always honors it, so a
+// stale/absent cluster.json can no longer silently shadow the add.
+
+describe("reader/writer agree end-to-end (CTL-1273)", () => {
+  const ENVS = [
+    "CATALYST_CONFIG_FILE",
+    "CATALYST_CLUSTER_DIR",
+    "CATALYST_HOST_NAME",
+    "CATALYST_LAYER2_CONFIG_FILE",
+    "CATALYST_LIVENESS_ANCHOR_ISSUE",
+    "CATALYST_DIR",
+  ];
+  let saved = {};
+  let repo, clusterDir, catalystDir;
+
+  beforeEach(() => {
+    for (const k of ENVS) { saved[k] = process.env[k]; delete process.env[k]; }
+    repo = mkdtempSync(join(tmpdir(), "ctl1273-e2e-repo-"));
+    clusterDir = mkdtempSync(join(tmpdir(), "ctl1273-e2e-cluster-"));
+    catalystDir = mkdtempSync(join(tmpdir(), "ctl1273-e2e-catalyst-"));
+    mkdirSync(join(repo, ".catalyst"), { recursive: true });
+    process.env.CATALYST_CONFIG_FILE = join(repo, ".catalyst", "config.json");
+    // Default-miss cluster source (mirrors the live fleet: no cluster clone).
+    process.env.CATALYST_CLUSTER_DIR = join(clusterDir, "no-such-cluster");
+    process.env.CATALYST_HOST_NAME = "mini";
+    // No liveness anchor → addHost's default readPeers() degrades to {} (the
+    // peer-heartbeat read fails gracefully without a real subprocess result).
+    process.env.CATALYST_DIR = catalystDir;
+  });
+
+  afterEach(() => {
+    for (const k of ENVS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; }
+    saved = {};
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(clusterDir, { recursive: true, force: true });
+    rmSync(catalystDir, { recursive: true, force: true });
+  });
+
+  const seedProject = (arr) => writeFileSync(join(repo, ".catalyst", "hosts.json"), JSON.stringify(arr) + "\n");
+
+  test("a cluster add is immediately visible to the daemon's roster reader", () => {
+    seedProject(["mini"]);
+    expect(runAdd(["mini-2", "--no-commit"])).toBe(0);
+    expect(getClusterHosts()).toEqual(["mini", "mini-2"]);
+  });
+
+  test("an add with a stale cluster.json present is still visible to the reader", () => {
+    // Point CATALYST_CLUSTER_DIR at a real dir containing a stale single-node
+    // cluster.json — the pre-CTL-1273 precedence would shadow the add entirely.
+    process.env.CATALYST_CLUSTER_DIR = clusterDir;
+    writeFileSync(join(clusterDir, "cluster.json"), JSON.stringify({ schemaVersion: 1, roster: ["mini"] }));
+    seedProject(["mini"]);
+    expect(runAdd(["mini-2", "--no-commit"])).toBe(0);
+    expect(getClusterHosts()).toContain("mini-2");
+  });
+
+  test("runRemove then read reflects the removal in the union", () => {
+    seedProject(["mini", "mini-2"]);
+    // self is "mini"; remove the non-self "mini-2" so the in-flight guard is moot.
+    expect(runRemove(["mini-2", "--no-commit"])).toBe(0);
+    expect(getClusterHosts()).not.toContain("mini-2");
   });
 });

--- a/plugins/dev/scripts/execution-core/cli/cluster.mjs
+++ b/plugins/dev/scripts/execution-core/cli/cluster.mjs
@@ -118,6 +118,10 @@ export function addHost(name, {
 export function runAdd(argv = []) {
   const noCommit = argv.includes("--no-commit");
   const name = argv.filter((a) => !a.startsWith("-"))[0];
+  // CTL-1273: the project hosts.json (getCatalystRepoDirHostsPath) is the single
+  // canonical write target; getClusterHosts() now UNIONs it with any cluster.json
+  // roster, so the add is always honored by the reader and can never be silently
+  // shadowed by a stale/absent control-plane copy.
   const res = addHost(name, {
     hostsPath: getCatalystRepoDirHostsPath(),
     self: getHostName(),

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -211,38 +211,78 @@ export function getHostName() {
   return dot === -1 ? base : base.slice(0, dot);
 }
 
-// getClusterHosts — read the committed cluster roster from
-// <repoRoot>/.catalyst/hosts.json (a JSON array of host names). When the file
-// is absent, unreadable, malformed, or not a non-empty array of strings, fall
-// back to the single-host default ([getHostName()]) — the safe behavior for the
-// current single-primary deployment. Never throws.
+// getClusterHosts — resolve the active enrollment roster from ONE reconciled
+// source. The roster is the union of two enrollment sources:
+//   1. the control-plane repo's cluster.json.roster (CTL-1211), and
+//   2. the project repo's committed .catalyst/hosts.json (the CLI write target).
+// When neither source yields a non-empty roster, fall back to the single-host
+// default ([getHostName()]). Never throws.
+//
+// CTL-1273 — one roster source of truth (no reader/writer divergence). The
+// previous cluster-FIRST-replace precedence let a stale or absent cluster.json
+// silently SHADOW the project roster: every writer (cli/cluster.mjs add/remove
+// via getCatalystRepoDirHostsPath) only ever writes the project hosts.json, so
+// once a cluster clone appeared, a `cluster add` was silently dropped and a
+// stale cluster.json (e.g. ["mini"]) silently re-broke a two-node cluster
+// fleet-wide. Reconciling the two by UNION (instead of replace) means:
+//   - the CLI write target is ALWAYS honored by the reader (no silent shadow),
+//   - no enrollment source can silently SUBTRACT a node (degrade-safe).
+// The CLI write target stays the project hosts.json on purpose — that keeps the
+// reader and writer structurally unable to diverge.
+//
+// Trade-off (deliberate): the union is ADDITIVE — a node intentionally removed
+// from cluster.json but still lingering in a stale project hosts.json would be
+// re-added. Under the enrollment-vs-liveness redesign, "node offline" is
+// liveness (handled separately), NOT a roster edit, so over-inclusion is
+// harmless (HRW just routes to an offline host whose work re-homes). Authoritative
+// subtraction is a separate decision (CTL-1214 fleet-config), out of scope here.
+//
+// Schema policy preserved: a cluster.json whose schemaVersion is newer than this
+// stack supports contributes NOTHING to the union (degrade to the project
+// roster) rather than being trusted blindly.
 export function getClusterHosts() {
-  // CTL-1211: cluster-repo-first. Prefer the control-plane repo's roster
-  // (cluster.json.roster); fall back to the project repo's committed hosts.json;
-  // then the single-host default. A cluster.json whose schemaVersion is newer
-  // than this stack supports is ignored here (degrade to the project roster)
-  // rather than trusted blindly. getCatalystRepoDirHostsPath (the CLI write
-  // target) is deliberately NOT changed, so add/remove writes still land on the
-  // project repo and the reader/writer can never silently diverge.
+  const filterHosts = (arr) =>
+    Array.isArray(arr) ? arr.filter((h) => typeof h === "string" && h.length > 0) : [];
+
+  // Source 1: control-plane cluster.json.roster (gated by schema compat).
   const cluster = readClusterConfig();
-  if (
-    cluster &&
-    schemaCompat(cluster.schemaVersion) !== "too-new" &&
-    Array.isArray(cluster.roster)
-  ) {
-    const hosts = cluster.roster.filter((h) => typeof h === "string" && h.length > 0);
-    if (hosts.length > 0) return hosts;
-  }
+  const clusterRoster =
+    cluster && schemaCompat(cluster.schemaVersion) !== "too-new"
+      ? filterHosts(cluster.roster)
+      : [];
+
+  // Source 2: project-repo committed hosts.json (the CLI write target).
+  let projectRoster = [];
   try {
-    const raw = readFileSync(resolve(getCatalystRepoDir(), "hosts.json"), "utf8");
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) {
-      const hosts = parsed.filter((h) => typeof h === "string" && h.length > 0);
-      if (hosts.length > 0) return hosts;
-    }
+    projectRoster = filterHosts(JSON.parse(readFileSync(resolve(getCatalystRepoDir(), "hosts.json"), "utf8")));
   } catch {
-    /* absent/malformed roster → single-host default */
+    /* absent/malformed project roster → empty (contributes nothing) */
   }
+
+  // Union, preserving first-seen order (cluster entries first, then project-only
+  // additions), de-duplicated. Either source contributing nothing is a no-op.
+  const active = [...new Set([...clusterRoster, ...projectRoster])];
+
+  // Make divergence VISIBLE, not silent: when both sources are non-empty and
+  // disagree (as sets), warn once per call. Strictly non-load-bearing — no throw,
+  // no behavior change — so an operator can spot a stale/un-pulled enrollment
+  // copy. Gated so identical sources (the common case) never warn.
+  if (clusterRoster.length > 0 && projectRoster.length > 0) {
+    const cs = new Set(clusterRoster);
+    const ps = new Set(projectRoster);
+    const differ =
+      clusterRoster.length !== projectRoster.length ||
+      clusterRoster.some((h) => !ps.has(h)) ||
+      projectRoster.some((h) => !cs.has(h));
+    if (differ) {
+      log.warn(
+        { cluster: clusterRoster, project: projectRoster, active },
+        "cluster roster divergence: cluster.json.roster and project hosts.json disagree; using their union",
+      );
+    }
+  }
+
+  if (active.length > 0) return active;
   return [getHostName()];
 }
 

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -30,6 +30,7 @@ import {
   isDraining,
   getLivenessAnchorIssue,
   LIVENESS_PUBLISH_INTERVAL_MS,
+  log,
 } from "./config.mjs";
 
 const PREV = process.env.CATALYST_WAIT_WATCHER;
@@ -405,6 +406,96 @@ describe("getClusterHosts cluster-repo-first (CTL-1211)", () => {
   test("unversioned cluster.json is treated as v1 and read", () => {
     writeCluster({ roster: ["mini", "mini-2"] });
     expect(getClusterHosts()).toEqual(["mini", "mini-2"]);
+  });
+});
+
+describe("getClusterHosts roster reconcile (CTL-1273)", () => {
+  // Reader/writer agree on ONE enrollment source. getClusterHosts() UNIONs the
+  // cluster.json roster with the project hosts.json (the CLI write target), so a
+  // stale/absent cluster copy can never silently DROP a node and a project-only
+  // `cluster add` is never silently shadowed. Reuse the CTL-1211 repo+cluster
+  // tmpdir + ENV save/restore harness.
+  const ENVS = ["CATALYST_CONFIG_FILE", "CATALYST_HOST_NAME", "CATALYST_LAYER2_CONFIG_FILE", "CATALYST_CLUSTER_DIR"];
+  let saved = {};
+  let repo, cluster;
+
+  beforeEach(() => {
+    for (const k of ENVS) { saved[k] = process.env[k]; delete process.env[k]; }
+    repo = mkdtempSync(join(tmpdir(), "ctl1273-repo-"));
+    cluster = mkdtempSync(join(tmpdir(), "ctl1273-cluster-"));
+    mkdirSync(join(repo, ".catalyst"), { recursive: true });
+    process.env.CATALYST_CONFIG_FILE = join(repo, ".catalyst", "config.json");
+    process.env.CATALYST_CLUSTER_DIR = cluster;
+  });
+
+  afterEach(() => {
+    for (const k of ENVS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; }
+    saved = {};
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(cluster, { recursive: true, force: true });
+  });
+
+  const writeCluster = (obj) => writeFileSync(join(cluster, "cluster.json"), JSON.stringify(obj));
+  const writeProject = (arr) => writeFileSync(join(repo, ".catalyst", "hosts.json"), JSON.stringify(arr));
+
+  test("a stale cluster.json does not silently drop a node present in the project roster", () => {
+    // The live landmine: pre-CTL-1273 this returned ["mini"] (cluster-first
+    // replace) and dropped mini-2 fleet-wide. The union must keep mini-2.
+    writeCluster({ schemaVersion: 1, roster: ["mini"] });
+    writeProject(["mini", "mini-2"]);
+    expect(getClusterHosts()).toEqual(["mini", "mini-2"]);
+  });
+
+  test("a node added only to the project roster is visible even when a cluster.json exists", () => {
+    writeCluster({ schemaVersion: 1, roster: ["mini"] });
+    writeProject(["mini", "mini-2"]);
+    expect(getClusterHosts()).toContain("mini-2");
+  });
+
+  test("union is order-stable (cluster first) and de-duplicated across the two sources", () => {
+    writeCluster({ schemaVersion: 1, roster: ["mini", "mini-2"] });
+    writeProject(["mini-2", "mac-studio"]);
+    expect(getClusterHosts()).toEqual(["mini", "mini-2", "mac-studio"]);
+  });
+
+  test("a too-new cluster.json contributes NOTHING to the union; the project roster stands alone", () => {
+    writeCluster({ schemaVersion: 999, roster: ["only-cluster"] });
+    writeProject(["mini", "mini-2"]);
+    expect(getClusterHosts()).toEqual(["mini", "mini-2"]);
+  });
+
+  test("absent cluster + absent project still returns the single-host default [getHostName()]", () => {
+    process.env.CATALYST_HOST_NAME = "solo-host";
+    expect(getClusterHosts()).toEqual(["solo-host"]);
+  });
+
+  test("divergent sources emit a visible warn (non-load-bearing)", () => {
+    writeCluster({ schemaVersion: 1, roster: ["mini"] });
+    writeProject(["mini", "mini-2"]);
+    const seen = [];
+    const orig = log.warn;
+    log.warn = (...args) => { seen.push(args); };
+    try {
+      const result = getClusterHosts();
+      expect(result).toEqual(["mini", "mini-2"]);
+      expect(seen.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      log.warn = orig;
+    }
+  });
+
+  test("identical sources do NOT warn (no false divergence)", () => {
+    writeCluster({ schemaVersion: 1, roster: ["mini", "mini-2"] });
+    writeProject(["mini", "mini-2"]);
+    const seen = [];
+    const orig = log.warn;
+    log.warn = (...args) => { seen.push(args); };
+    try {
+      expect(getClusterHosts()).toEqual(["mini", "mini-2"]);
+      expect(seen.length).toBe(0);
+    } finally {
+      log.warn = orig;
+    }
   });
 });
 


### PR DESCRIPTION
## CTL-1273 — one roster source of truth

Collapses the cluster roster reader/writer divergence so a stale or absent secondary copy can never silently drop a node or shadow a `cluster add`.

### Problem
`getClusterHosts()` (`config.mjs`) read the control-plane `cluster.json.roster` **first** and **else** the project `hosts.json`, while every writer (`cli/cluster.mjs` add/remove via `getCatalystRepoDirHostsPath`) only ever wrote the project `hosts.json`. Nothing in the codebase writes `cluster.json.roster` — it arrives only via `cluster-sync` git pull. So the two were structurally divergent: once a cluster clone existed, a `cluster add` was silently shadowed, and a stale `cluster.json` (`["mini"]`) silently dropped `mini-2` fleet-wide.

### Fix (degrade-safe option b from the design doc)
Reconcile the two enrollment sources with a **UNION** instead of cluster-first-replace: the active roster = enrolled in `cluster.json` OR the project `hosts.json`. The CLI write target stays the project `hosts.json` on purpose, so it is now **always** honored by the reader and no source can silently subtract a node. Divergence between the two is made **visible** via a single non-load-bearing `log.warn` (gated to both-non-empty-and-differ, so identical sources never warn). The `schemaVersion` too-new degrade is preserved (a too-new `cluster.json` contributes nothing to the union).

### Live-fleet safety
No-op on the running fleet: the cluster clone is absent on both hosts, so `clusterRoster=[]` and the active roster stays the project `hosts.json` = `["mini","mini-2"]`, byte-identical to today.

### Trade-off (documented in the function comment)
The union is additive — a node removed from `cluster.json` but lingering in a stale project `hosts.json` is re-added. This is deliberate: under the enrollment-vs-liveness redesign, "node offline" is liveness (CTL-L), not a roster edit, so over-inclusion is harmless. Authoritative subtraction is a separate decision (CTL-1214).

### Tests
- `config.test.mjs`: new `getClusterHosts roster reconcile (CTL-1273)` suite (stale-drop, project-only-visible, union order+dedup, too-new contributes nothing, empty-everything default, divergence warn, identical-no-warn). The existing CTL-1211 cluster-repo-first suite stays green unchanged (backward-compatible).
- `cli-cluster.test.mjs`: new `reader/writer agree end-to-end (CTL-1273)` suite proving a `runAdd` is immediately visible to `getClusterHosts` even with a stale `cluster.json` present.
- `bun test config.test.mjs cli-cluster.test.mjs` → 141 pass / 0 fail. `doctor.test.mjs` → 46/0 green.

Notes: autonomous wave-1 impl, **NEEDS REVIEW before merge**. References CTL-1273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)