### PR TITLE
fix(dev): CTL-1271 — deterministic roster path + loud boot assertion

### DIFF
--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -166,6 +166,28 @@ cmd_start() {
 		fi
 		unset _ocid _ocsec _otok
 	fi
+	# CTL-1271: pin a DETERMINISTIC roster anchor before nohup so the daemon's
+	# cwd can NEVER decide the cluster roster. The daemon resolves its roster from
+	# <repoRoot>/.catalyst/hosts.json; if it is launched from the wrong directory
+	# with no CATALYST_CONFIG_FILE, it silently falls back to a one-node cluster
+	# and disables HRW work-sharing with no error (this is how mini-2 was knocked
+	# out of the fleet). Derive the canonical config path from the registry's first
+	# enrolled project repoRoot and export it (plus CATALYST_REPO_ROOT as a
+	# secondary anchor). Best-effort: a failed derivation must NEVER block launch —
+	# the daemon's resolveDaemonConfigPath repeats this derivation and warns loudly
+	# if it cannot resolve deterministically. Honor any value already set.
+	if [[ -z "${CATALYST_CONFIG_FILE-}" ]]; then
+		local _registry="$EC_DIR/registry.json" _repo_root
+		_repo_root="$(jq -r '.projects[0].repoRoot // empty' "$_registry" 2>/dev/null)"
+		if [[ -n "$_repo_root" && -d "$_repo_root/.catalyst" ]]; then
+			export CATALYST_CONFIG_FILE="$_repo_root/.catalyst/config.json"
+			export CATALYST_REPO_ROOT="$_repo_root"
+			echo "catalyst-execution-core: pinned roster anchor CATALYST_CONFIG_FILE=$CATALYST_CONFIG_FILE (CTL-1271)" >&2
+		else
+			echo "catalyst-execution-core: WARNING could not derive a canonical CATALYST_CONFIG_FILE from $_registry — daemon will assert its roster source at boot (CTL-1271)" >&2
+		fi
+		unset _registry _repo_root
+	fi
 	nohup "$runtime" "$DAEMON_SCRIPT" --pid-file "$PID_FILE" >"$LOG_FILE" 2>&1 &
 	local server_pid=$!
 	disown "$server_pid" 2>/dev/null || true

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -157,17 +157,37 @@ export function getLayer2ConfigPath() {
   );
 }
 
-// The repo root that owns the committed cluster roster (.catalyst/hosts.json).
-// CATALYST_CONFIG_FILE points at <repoRoot>/.catalyst/config.json (mirrors the
-// reaper-config resolution in daemon.mjs main()); otherwise fall back to the
-// daemon's cwd. Re-resolved per call so tests can redirect via the env var.
-function getCatalystRepoDir() {
+// getCatalystRepoDir — the <repoRoot>/.catalyst directory that owns the committed
+// cluster roster (hosts.json). CTL-1271: this must resolve from a DETERMINISTIC
+// anchor, never bare process.cwd(), or a daemon launched from the wrong directory
+// silently reads a wrong/absent hosts.json and shrinks to a one-node cluster with
+// no error and no log (exactly how mini-2 was knocked out of the fleet).
+//
+// Precedence (re-resolved per call so tests redirect via the env vars):
+//   1. CATALYST_CONFIG_FILE → resolve(cfgFile, "..")  (the daemon's normal path:
+//      CATALYST_CONFIG_FILE points at <repoRoot>/.catalyst/config.json, and
+//      daemon.mjs main() back-writes it before getClusterHosts runs — CTL-862).
+//   2. CATALYST_REPO_ROOT  → resolve(repoRoot, ".catalyst")  (an explicit repo
+//      anchor for launchers/tests that prefer to name the repo, not the config).
+//   3. allowCwd === true   → resolve(process.cwd(), ".catalyst")  (ONLY the CLI
+//      WRITE target opts in — cluster add/remove always runs from inside a repo;
+//      see getCatalystRepoDirHostsPath).
+//   4. otherwise           → null  (UNRESOLVED sentinel). The roster READER
+//      (getClusterHosts) treats null as "no project roster" → single-host
+//      default, and the daemon boot path uses the null/cwd distinction to warn
+//      loudly instead of silently single-hosting (daemon.mjs boot assertion).
+export function getCatalystRepoDir({ allowCwd = false } = {}) {
   const cfgFile = process.env.CATALYST_CONFIG_FILE;
   if (cfgFile) {
     // <repoRoot>/.catalyst/config.json → <repoRoot>/.catalyst
     return resolve(cfgFile, "..");
   }
-  return resolve(process.cwd(), ".catalyst");
+  const repoRoot = process.env.CATALYST_REPO_ROOT;
+  if (typeof repoRoot === "string" && repoRoot.length > 0) {
+    return resolve(repoRoot, ".catalyst");
+  }
+  if (allowCwd) return resolve(process.cwd(), ".catalyst");
+  return null;
 }
 
 // CTL-1211: the cluster control-plane repo (catalyst-cluster) — a pristine clone
@@ -233,15 +253,20 @@ export function getClusterHosts() {
     const hosts = cluster.roster.filter((h) => typeof h === "string" && h.length > 0);
     if (hosts.length > 0) return hosts;
   }
-  try {
-    const raw = readFileSync(resolve(getCatalystRepoDir(), "hosts.json"), "utf8");
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) {
-      const hosts = parsed.filter((h) => typeof h === "string" && h.length > 0);
-      if (hosts.length > 0) return hosts;
+  // CTL-1271: only read the project-repo roster when the anchor resolved
+  // deterministically (null = unresolved → never read a cwd-relative hosts.json).
+  const repoDir = getCatalystRepoDir();
+  if (repoDir) {
+    try {
+      const raw = readFileSync(resolve(repoDir, "hosts.json"), "utf8");
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        const hosts = parsed.filter((h) => typeof h === "string" && h.length > 0);
+        if (hosts.length > 0) return hosts;
+      }
+    } catch {
+      /* absent/malformed roster → single-host default */
     }
-  } catch {
-    /* absent/malformed roster → single-host default */
   }
   return [getHostName()];
 }
@@ -249,9 +274,13 @@ export function getClusterHosts() {
 // getCatalystRepoDirHostsPath — absolute path to the committed cluster roster.
 // Exported so cli/cluster.mjs and its unit tests share one source of truth
 // (avoids drift between the writer and the reader that live in different files).
-// Redirectable via CATALYST_CONFIG_FILE (same as getCatalystRepoDir).
+// Redirectable via CATALYST_CONFIG_FILE / CATALYST_REPO_ROOT (same as
+// getCatalystRepoDir). CTL-1271: this is the CLI WRITE target — `cluster
+// add`/`remove` always runs from inside a repo, so it opts into the cwd anchor
+// (allowCwd) to preserve its existing behavior. The READER (getClusterHosts)
+// does NOT, so a mis-launched daemon can never silently write/read from cwd.
 export function getCatalystRepoDirHostsPath() {
-  return resolve(getCatalystRepoDir(), "hosts.json");
+  return resolve(getCatalystRepoDir({ allowCwd: true }), "hosts.json");
 }
 
 // CTL-1057: a multi-host roster that does NOT include this host means every

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -24,6 +24,8 @@ import {
   AUTOTUNE_ENABLED,
   getHostName,
   getClusterHosts,
+  getCatalystRepoDir,
+  getCatalystRepoDirHostsPath,
   HEARTBEAT_INTERVAL_MS,
   hostMembershipWarning,
   getDrainFlagPath,
@@ -405,6 +407,104 @@ describe("getClusterHosts cluster-repo-first (CTL-1211)", () => {
   test("unversioned cluster.json is treated as v1 and read", () => {
     writeCluster({ roster: ["mini", "mini-2"] });
     expect(getClusterHosts()).toEqual(["mini", "mini-2"]);
+  });
+});
+
+describe("getCatalystRepoDir deterministic anchor (CTL-1271)", () => {
+  // CTL-1271: the daemon's roster reader must resolve <repoRoot>/.catalyst from a
+  // DETERMINISTIC anchor (CATALYST_CONFIG_FILE, else CATALYST_REPO_ROOT), never
+  // bare process.cwd(). A wrong cwd must NOT silently pick up a wrong/decoy
+  // hosts.json and shrink the daemon to a one-node cluster. These cases save/
+  // restore the roster envs AND the cwd (we process.chdir into a decoy dir),
+  // mirroring the strict save/restore in getClusterHosts above.
+  const ROSTER_ENVS = [
+    "CATALYST_CONFIG_FILE",
+    "CATALYST_REPO_ROOT",
+    "CATALYST_HOST_NAME",
+    "CATALYST_LAYER2_CONFIG_FILE",
+    "CATALYST_CLUSTER_DIR",
+  ];
+  let saved = {};
+  let repo, decoy, prevCwd;
+
+  beforeEach(() => {
+    for (const k of ROSTER_ENVS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    prevCwd = process.cwd();
+    repo = mkdtempSync(join(tmpdir(), "ctl1271-repo-"));
+    mkdirSync(join(repo, ".catalyst"), { recursive: true });
+    // A decoy repo whose .catalyst/hosts.json must NEVER be read just because the
+    // daemon happens to be launched from this directory.
+    decoy = mkdtempSync(join(tmpdir(), "ctl1271-decoy-"));
+    mkdirSync(join(decoy, ".catalyst"), { recursive: true });
+    writeFileSync(join(decoy, ".catalyst", "hosts.json"), JSON.stringify(["decoy-host"]));
+    // Pin the cluster-repo path at a deterministic miss so the project-repo /
+    // anchor path is exercised in isolation (same discipline as CTL-1211 above).
+    process.env.CATALYST_CLUSTER_DIR = join(repo, "no-such-cluster");
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    for (const k of ROSTER_ENVS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    saved = {};
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(decoy, { recursive: true, force: true });
+  });
+
+  test("resolves <repoRoot>/.catalyst from CATALYST_CONFIG_FILE when set (unchanged contract)", () => {
+    process.env.CATALYST_CONFIG_FILE = join(repo, ".catalyst", "config.json");
+    expect(getCatalystRepoDir()).toBe(join(repo, ".catalyst"));
+  });
+
+  test("does NOT fall back to process.cwd() when CATALYST_CONFIG_FILE is unset (decoy cwd never read)", () => {
+    delete process.env.CATALYST_CONFIG_FILE;
+    delete process.env.CATALYST_REPO_ROOT;
+    process.env.CATALYST_HOST_NAME = "solo-host";
+    process.chdir(decoy);
+    // The decoy's hosts.json (["decoy-host"]) lives in cwd — it must NOT leak in.
+    expect(getClusterHosts()).not.toEqual(["decoy-host"]);
+    expect(getClusterHosts()).toEqual(["solo-host"]);
+  });
+
+  test("CATALYST_REPO_ROOT is the deterministic fallback anchor when CATALYST_CONFIG_FILE is unset", () => {
+    delete process.env.CATALYST_CONFIG_FILE;
+    process.env.CATALYST_REPO_ROOT = repo;
+    writeFileSync(join(repo, ".catalyst", "hosts.json"), JSON.stringify(["mini", "mini-2"]));
+    process.chdir(decoy); // cwd points at the decoy, but the anchor must win.
+    expect(getCatalystRepoDir()).toBe(join(repo, ".catalyst"));
+    expect(getClusterHosts()).toEqual(["mini", "mini-2"]);
+  });
+
+  test("with neither CATALYST_CONFIG_FILE nor CATALYST_REPO_ROOT, resolution is unresolved (null), not the cwd roster", () => {
+    delete process.env.CATALYST_CONFIG_FILE;
+    delete process.env.CATALYST_REPO_ROOT;
+    process.env.CATALYST_HOST_NAME = "solo-host";
+    process.chdir(decoy);
+    // The contract: an unresolved anchor returns the sentinel (null), and is
+    // explicitly NOT resolve(cwd, ".catalyst"). This is what lets the daemon's
+    // boot path detect a degraded/non-deterministic resolution loudly.
+    expect(getCatalystRepoDir()).toBeNull();
+    expect(getCatalystRepoDir()).not.toBe(join(decoy, ".catalyst"));
+    // And the reader degrades to the single-host default, never the decoy roster.
+    expect(getClusterHosts()).toEqual(["solo-host"]);
+  });
+
+  test("getCatalystRepoDirHostsPath (CLI writer) keeps its cwd-relative target for in-repo CLI use", () => {
+    // The reader is deterministic, but the CLI write target (cluster add/remove,
+    // always run from inside a repo) must keep resolving against cwd so the
+    // reader/writer divergence guard (CTL-1211) is preserved. Anchor unset →
+    // the writer falls back to <cwd>/.catalyst/hosts.json.
+    delete process.env.CATALYST_CONFIG_FILE;
+    delete process.env.CATALYST_REPO_ROOT;
+    process.chdir(repo);
+    // Compare against process.cwd() (not the raw mkdtemp path) — macOS
+    // canonicalizes /var/folders → /private/var/folders on chdir.
+    expect(getCatalystRepoDirHostsPath()).toBe(join(process.cwd(), ".catalyst", "hosts.json"));
   });
 });
 

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -43,6 +43,7 @@ import {
   readRatelimitPollerConfig,
   getHostName,      // CTL-862
   getClusterHosts,  // CTL-862
+  getCatalystRepoDir, // CTL-1271: deterministic roster-source path for the boot log
 } from "./config.mjs";
 import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
 import { startWaitWatcher as realStartWaitWatcher } from "./wait-watcher.mjs";
@@ -448,6 +449,11 @@ export function startDaemon({
   // once before the scheduler starts and never re-reads. Null in tests that
   // never resolve a config path.
   configPath = null,
+  // CTL-1271: how configPath was resolved by main()'s resolveDaemonConfigPath —
+  // "env" | "registry" | "cwd". "cwd" means a non-deterministic (legacy) anchor;
+  // the boot assertion warns loudly in that case. null in tests that don't drive
+  // main(); the boot path treats null as "not non-deterministic".
+  configResolutionSource = null,
   // CTL-678: machine-canonical Layer-2 path (~/.config/catalyst/config.json).
   // Threaded into startScheduler alongside configPath so the per-tick re-read
   // can apply Layer-2's per-field override on every tick (hot-reload of the
@@ -466,6 +472,15 @@ export function startDaemon({
   readAllEligible = readAllEligibleTickets,
   bootHosts = undefined,
   bootHostName = undefined,
+  // CTL-1271: boot-assertion seams. bootSourcePath = the resolved roster-source
+  // file (production: getCatalystRepoDir()/hosts.json, or "<unresolved>");
+  // bootResolutionSource = how that source resolved ("env"|"registry"|"cwd"),
+  // defaulting to configResolutionSource; expectedMultiHost = an explicit signal
+  // that this deployment intends to be multi-host (so a length-1 roster is a
+  // degradation worth a loud warn, not a legitimate single-primary host).
+  bootSourcePath = undefined,
+  bootResolutionSource = undefined,
+  expectedMultiHost = undefined,
 } = {}) {
   const orchDir = getExecutionCoreDir();
   ensureState(orchDir);
@@ -718,9 +733,26 @@ export function startDaemon({
   const bootSelf = bootHostName ?? getHostName();
   const bootEligible = readAllEligible();
   const bootOwns = bootEligible.filter((t) => ownedBy(t.identifier, bootRoster, bootSelf)).length;
-  // CTL-1084: emit a structured node.boot event so catalyst-stack status can
-  // prove what the restart did (version, effective flags, adopted/cleared/rewalk counts).
-  // Fail-open — emitBootEvent never throws. Kept alongside the pino log (not replacing it).
+
+  // CTL-1271: resolve the boot-assertion inputs.
+  //  - sourcePath: WHERE the roster came from. Production derives it from the
+  //    deterministic anchor (getCatalystRepoDir() → <dir>/hosts.json); a null
+  //    anchor means the roster could not be resolved deterministically.
+  //  - resolutionSource: how the config/roster anchor resolved (from main()).
+  //    "cwd" is the non-deterministic legacy path.
+  //  - multiHost: whether HRW work-sharing is actually on (roster length > 1).
+  const resolvedRepoDir = (() => {
+    try { return getCatalystRepoDir(); } catch { return null; }
+  })();
+  const bootSourcePathResolved =
+    bootSourcePath ?? (resolvedRepoDir ? resolve(resolvedRepoDir, "hosts.json") : "<unresolved>");
+  const bootResolutionSourceResolved = bootResolutionSource ?? configResolutionSource ?? null;
+  const bootMultiHost = Array.isArray(bootRoster) && bootRoster.length > 1;
+
+  // CTL-862/CTL-1084: emit a structured node.boot event so catalyst-stack status
+  // can prove what the restart did (version, effective flags, adopted/cleared/
+  // rewalk counts). Fail-open — emitBootEvent never throws. Kept alongside the
+  // pino log (not replacing it).
   emitBootEvent({
     summary: {
       adoptedWorkers:   _bootReport?.workers?.running?.length ?? 0,
@@ -729,8 +761,47 @@ export function startDaemon({
       rewalkDispatched: _bootResume?.dispatched ?? 0,
     },
   });
+
+  // CTL-1271: BOOT ASSERTION. A daemon must never SILENTLY shrink to a one-node
+  // cluster. Warn loudly (fail-open — never throw mid-boot) when either:
+  //   (a) the config/roster anchor resolved non-deterministically (cwd fallback),
+  //       which is the cwd-dependence bug that knocked mini-2 out of the fleet; OR
+  //   (b) the roster degraded to single-host while this deployment expected
+  //       multi-host (expectedMultiHost === true).
+  // A legitimately single-host deployment (deterministic resolution, no
+  // multi-host expectation) stays SILENT — mirroring hostMembershipWarning's
+  // length<=1 → null discipline so the assertion never becomes noise.
+  const nonDeterministic = bootResolutionSourceResolved === "cwd";
+  const degradedSingleHost = expectedMultiHost === true && !bootMultiHost;
+  if (nonDeterministic || degradedSingleHost) {
+    log.warn(
+      {
+        roster: bootRoster,
+        sourcePath: bootSourcePathResolved,
+        resolutionSource: bootResolutionSourceResolved,
+        multiHost: bootMultiHost,
+        host: bootSelf,
+      },
+      degradedSingleHost
+        ? `execution-core daemon: roster degraded to a single node [${(bootRoster ?? []).join(", ")}] ` +
+            `(source: ${bootSourcePathResolved}) while multi-host was expected — HRW work-sharing is OFF. ` +
+            `This daemon now owns every ticket and shares nothing. Check the roster source and CATALYST_CONFIG_FILE.`
+        : `execution-core daemon: roster resolved NON-DETERMINISTICALLY from cwd ` +
+            `(source: ${bootSourcePathResolved}, roster [${(bootRoster ?? []).join(", ")}]) — a wrong launch ` +
+            `directory can silently single-host the daemon. Export CATALYST_CONFIG_FILE / CATALYST_REPO_ROOT at launch.`
+    );
+  }
+
   log.info(
-    { orchDir, host: bootSelf, owns: bootOwns, eligible: bootEligible.length, roster: bootRoster },
+    {
+      orchDir,
+      host: bootSelf,
+      owns: bootOwns,
+      eligible: bootEligible.length,
+      roster: bootRoster,
+      sourcePath: bootSourcePathResolved, // CTL-1271
+      multiHost: bootMultiHost,           // CTL-1271
+    },
     "execution-core daemon started"
   );
 }
@@ -1203,16 +1274,62 @@ export function resolveBootConcurrency({ layer1Path, layer2Path }) {
   return mergeExecutionCoreConcurrency(layer1, layer2);
 }
 
+// resolveDaemonConfigPath — CTL-1271. Resolve the daemon's config path from a
+// DETERMINISTIC anchor, never bare process.cwd(). Pure helper (env + registry +
+// cwd injected) so it is unit-testable and main() never re-implements it.
+//
+// Precedence:
+//   1. CATALYST_CONFIG_FILE  → verbatim, resolutionSource "env" (the launcher /
+//      the CTL-862 back-write virtually always set this in production).
+//   2. first registry project repoRoot → <repoRoot>/.catalyst/config.json,
+//      resolutionSource "registry" (the registry is the daemon's source of
+//      truth for enrolled projects — a stable anchor independent of cwd).
+//   3. <cwd>/.catalyst/config.json, resolutionSource "cwd" — the LEGACY path,
+//      kept only as a last resort and FLAGGED so the boot path can warn loudly
+//      instead of silently shrinking to a one-node cluster.
+//
+// Returns { configPath, resolutionSource }.
+export function resolveDaemonConfigPath({
+  env = process.env,
+  listProjects = realListProjects,
+  cwd = () => process.cwd(),
+} = {}) {
+  const explicit = env.CATALYST_CONFIG_FILE;
+  if (typeof explicit === "string" && explicit.length > 0) {
+    return { configPath: explicit, resolutionSource: "env" };
+  }
+  let projects = [];
+  try {
+    projects = listProjects() || [];
+  } catch {
+    /* unreadable registry → fall through to the cwd last resort */
+  }
+  const repoRoot = projects.find((p) => typeof p?.repoRoot === "string" && p.repoRoot.length > 0)?.repoRoot;
+  if (repoRoot) {
+    return {
+      configPath: resolve(repoRoot, ".catalyst", "config.json"),
+      resolutionSource: "registry",
+    };
+  }
+  return {
+    configPath: resolve(cwd(), ".catalyst", "config.json"),
+    resolutionSource: "cwd",
+  };
+}
+
 function main() {
   const idx = process.argv.indexOf("--pid-file");
   const pidFile = idx >= 0 ? process.argv[idx + 1] : null;
 
-  // CTL-649 Phase 9: thread the periodic-reaper config from .catalyst/config.json
-  // into the timer. Path is env-overridable (CATALYST_CONFIG_FILE); otherwise
-  // the daemon reads the launch-cwd's config. Absent/partial config falls back
-  // to the built-in defaults (enabled, 600s) inside startReaperAndTimer.
-  const configPath =
-    process.env.CATALYST_CONFIG_FILE || resolve(process.cwd(), ".catalyst", "config.json");
+  // CTL-649 Phase 9 / CTL-1271: thread the periodic-reaper config from
+  // .catalyst/config.json into the timer. Path is resolved from a DETERMINISTIC
+  // anchor (CATALYST_CONFIG_FILE → registry repoRoot → cwd last resort), never
+  // bare process.cwd() — a wrong cwd must not silently pick up a wrong config /
+  // roster (CTL-1271). resolutionSource is carried into startDaemon so the boot
+  // path can warn loudly when resolution degraded to the cwd fallback.
+  // Absent/partial config falls back to the built-in defaults inside
+  // startReaperAndTimer.
+  const { configPath, resolutionSource: configResolutionSource } = resolveDaemonConfigPath();
   const orphanReaperConfig = readOrphanReaperConfig(configPath);
   // CTL-707: read the worktree-refresh config from the same config file.
   const worktreeRefreshConfig = readWorktreeRefreshConfig(configPath);
@@ -1246,7 +1363,7 @@ function main() {
   process.on("unhandledRejection", fatal("unhandled rejection"));
 
   try {
-    startDaemon({ pidFile, orphanReaperConfig, worktreeRefreshConfig, stalePrRescueConfig, orphanPrSweepConfig, concurrency, configPath, layer2Path }); // CTL-676 + CTL-678 + CTL-707 + CTL-782 + CTL-1175
+    startDaemon({ pidFile, orphanReaperConfig, worktreeRefreshConfig, stalePrRescueConfig, orphanPrSweepConfig, concurrency, configPath, configResolutionSource, layer2Path }); // CTL-676 + CTL-678 + CTL-707 + CTL-782 + CTL-1175 + CTL-1271
   } catch (err) {
     log.error({ err }, "execution-core daemon: failed to start");
     process.exit(1);

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -24,6 +24,7 @@ import {
   consumeEventTail,
   parseEventTailChunk,
   resolveBootConcurrency,
+  resolveDaemonConfigPath,
   handleCommentWake,
   __resetEventTailCursorForTest,
   __getEventTailLeftoverForTest,
@@ -1875,6 +1876,42 @@ describe("CTL-862 — daemon CATALYST_CONFIG_FILE propagation", () => {
       else process.env.CATALYST_CONFIG_FILE = prev;
     }
   });
+
+  // CTL-1271: main()'s configPath resolution must NOT depend on process.cwd().
+  // resolveDaemonConfigPath is the extracted pure helper main() now uses; it is
+  // unit-tested directly with an injected env + registry + cwd so the resolution
+  // is deterministic and the cwd path is only a flagged last resort.
+  test("CTL-1271: resolveDaemonConfigPath uses the first registry repoRoot, not process.cwd(), when CATALYST_CONFIG_FILE is unset", () => {
+    const res = resolveDaemonConfigPath({
+      env: {}, // CATALYST_CONFIG_FILE unset
+      listProjects: () => [{ team: "CTL", repoRoot: "/srv/catalyst" }],
+      cwd: () => "/some/wrong/dir",
+    });
+    expect(res.configPath).toBe(join("/srv/catalyst", ".catalyst", "config.json"));
+    expect(res.resolutionSource).toBe("registry");
+    expect(res.configPath).not.toBe(join("/some/wrong/dir", ".catalyst", "config.json"));
+  });
+
+  test("CTL-1271: resolveDaemonConfigPath honors CATALYST_CONFIG_FILE when set (env wins over registry/cwd)", () => {
+    const res = resolveDaemonConfigPath({
+      env: { CATALYST_CONFIG_FILE: "/explicit/.catalyst/config.json" },
+      listProjects: () => [{ team: "CTL", repoRoot: "/srv/catalyst" }],
+      cwd: () => "/some/wrong/dir",
+    });
+    expect(res.configPath).toBe("/explicit/.catalyst/config.json");
+    expect(res.resolutionSource).toBe("env");
+  });
+
+  test("CTL-1271: resolveDaemonConfigPath falls back to cwd only as a flagged last resort (no env, empty registry)", () => {
+    const res = resolveDaemonConfigPath({
+      env: {},
+      listProjects: () => [],
+      cwd: () => "/launch/cwd",
+    });
+    expect(res.configPath).toBe(join("/launch/cwd", ".catalyst", "config.json"));
+    // The flag is what lets the boot path warn loudly instead of single-hosting silently.
+    expect(res.resolutionSource).toBe("cwd");
+  });
 });
 
 describe("CTL-862 — daemon boot-log ownership context", () => {
@@ -1916,6 +1953,112 @@ describe("CTL-862 — daemon boot-log ownership context", () => {
       expect(obj.owns).toBeLessThanOrEqual(eligible.length);
     } finally {
       infoSpy.mockRestore();
+    }
+  });
+
+  // CTL-1271: the boot log must additionally state WHERE the roster came from
+  // (sourcePath) and whether multi-host is on (multiHost), so a degraded or
+  // single-host resolution is operator-visible at boot rather than silent.
+  test("CTL-1271: boot log carries sourcePath and multiHost fields", () => {
+    const infoSpy = spyOn(log, "info");
+    const ROSTER = ["mini", "mac-studio"];
+    try {
+      startDaemon({
+        ...baseOpts(),
+        readAllEligible: () => [{ identifier: "ENG-1" }],
+        bootHosts: ROSTER,
+        bootHostName: "mini",
+        bootSourcePath: "/srv/catalyst/.catalyst/hosts.json",
+        bootResolutionSource: "env",
+      });
+      const bootCall = infoSpy.mock.calls.find(
+        (c) => typeof c[1] === "string" && c[1].includes("daemon started")
+      );
+      expect(bootCall).toBeDefined();
+      const obj = bootCall[0];
+      expect(typeof obj.sourcePath).toBe("string");
+      expect(obj.sourcePath.length).toBeGreaterThan(0);
+      expect(obj.multiHost).toBe(true);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  // CTL-1271: the core regression guard. A daemon that meant to be multi-host but
+  // resolved to a single-host roster (or resolved non-deterministically from cwd)
+  // must emit ONE loud warn naming the degraded roster + sourcePath — never a
+  // silent single-node start (exactly how mini-2 was knocked out of the fleet).
+  test("CTL-1271: single-host fallback with a multi-host expectation emits a LOUD warn", () => {
+    const warnSpy = spyOn(log, "warn");
+    try {
+      startDaemon({
+        ...baseOpts(),
+        readAllEligible: () => [{ identifier: "ENG-1" }],
+        bootHosts: ["mini"], // degraded to one node
+        bootHostName: "mini",
+        bootSourcePath: "/launch/cwd/.catalyst/hosts.json",
+        bootResolutionSource: "env",
+        expectedMultiHost: true,
+      });
+      const degradedWarn = warnSpy.mock.calls.find(
+        (c) => typeof c[1] === "string" && /roster/i.test(c[1]) && /single|degrad|one-node|one node/i.test(c[1])
+      );
+      expect(degradedWarn).toBeDefined();
+      // The warn payload names the degraded roster + the resolved source.
+      const obj = degradedWarn[0];
+      expect(Array.isArray(obj.roster)).toBe(true);
+      expect(obj.roster).toEqual(["mini"]);
+      expect(typeof obj.sourcePath).toBe("string");
+      expect(obj.sourcePath.length).toBeGreaterThan(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  // CTL-1271: a non-deterministic resolution (cwd fallback) is ALSO loud, even
+  // without an explicit multi-host expectation — the cwd anchor is the bug.
+  test("CTL-1271: a cwd-resolved boot emits a LOUD warn about non-deterministic resolution", () => {
+    const warnSpy = spyOn(log, "warn");
+    try {
+      startDaemon({
+        ...baseOpts(),
+        readAllEligible: () => [{ identifier: "ENG-1" }],
+        bootHosts: ["mini"],
+        bootHostName: "mini",
+        bootSourcePath: "/launch/cwd/.catalyst/hosts.json",
+        bootResolutionSource: "cwd", // non-deterministic
+      });
+      const degradedWarn = warnSpy.mock.calls.find(
+        (c) => typeof c[1] === "string" && /roster/i.test(c[1])
+      );
+      expect(degradedWarn).toBeDefined();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  // CTL-1271: a legitimately single-host deployment (deterministic resolution, no
+  // multi-host expectation) must STAY SILENT — the loud assertion must not become
+  // noise on real single-primary hosts (mirrors hostMembershipWarning's
+  // length<=1 → null discipline).
+  test("CTL-1271: a legitimately single-host deployment does NOT warn about the roster", () => {
+    const warnSpy = spyOn(log, "warn");
+    try {
+      startDaemon({
+        ...baseOpts(),
+        readAllEligible: () => [{ identifier: "ENG-1" }],
+        bootHosts: ["mini"],
+        bootHostName: "mini",
+        bootSourcePath: "/srv/catalyst/.catalyst/hosts.json",
+        bootResolutionSource: "env", // deterministic
+        expectedMultiHost: false,
+      });
+      const degradedWarn = warnSpy.mock.calls.find(
+        (c) => typeof c[1] === "string" && /roster/i.test(c[1]) && /single|degrad|one-node|one node|non-deterministic|cwd/i.test(c[1])
+      );
+      expect(degradedWarn).toBeUndefined();
+    } finally {
+      warnSpy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## CTL-1271 — deterministic roster path + loud boot assertion

Hardens the execution-core daemon so it can **never silently shrink to a one-node cluster** when it can't find its real roster (this is how mini-2 was knocked out of the fleet). Conservative: changes WHERE the roster file is found, not the roster-precedence logic.

### Three coordinated changes
1. **`config.mjs` `getCatalystRepoDir()`** stops trusting bare `process.cwd()`. Resolves `<repoRoot>/.catalyst` from a deterministic anchor: `CATALYST_CONFIG_FILE` → `CATALYST_REPO_ROOT` → (CLI-writer only) cwd → `null` sentinel. `getClusterHosts()` treats `null` as "no project roster" → single-host default, so a mis-launched daemon never silently reads a decoy `hosts.json`. `getCatalystRepoDirHostsPath()` (the CLI write target, always run in-repo) opts into the cwd anchor to preserve its behavior unchanged.
2. **`daemon.mjs` `main()`** resolves `configPath` via a new exported pure helper `resolveDaemonConfigPath({env, listProjects, cwd})` (env → first registry repoRoot → flagged cwd last resort), never bare `process.cwd()`. The boot path adds `{roster, sourcePath, multiHost}` to the `daemon started` log and emits a single **LOUD `log.warn`** (fail-open, never throws mid-boot) when resolution was non-deterministic (cwd) OR the roster degraded to single-host while multi-host was expected. A legitimately single-host deployment stays silent.
3. **`catalyst-execution-core` `cmd_start`** pins a canonical `CATALYST_CONFIG_FILE` / `CATALYST_REPO_ROOT` (derived from the registry's first `repoRoot`) before `nohup`, so cwd can never decide the roster. Best-effort: a failed derivation warns but never blocks launch.

### Scope discipline
Strictly avoids `getClusterHosts()` precedence (**CTL-1273**) and `hostMembershipWarning` internals (**CTL-1272**) — only reads them.

### Tests
- `config.test.mjs`: new `getCatalystRepoDir deterministic anchor (CTL-1271)` describe — cwd-decoy never read, `CATALYST_REPO_ROOT` anchor wins over cwd, unresolved → `null` sentinel (not the cwd roster), CLI-writer cwd target preserved.
- `daemon.test.mjs`: extends the CTL-862 blocks — `resolveDaemonConfigPath` (registry/env/cwd) cases; boot log carries `sourcePath`+`multiHost`; single-host-with-multi-host-expectation **warns loudly**; cwd resolution **warns loudly**; legitimate single-host does **NOT** warn. All pre-existing CTL-862/CTL-1211 tests preserved.

**Test command:** `cd plugins/dev/scripts/execution-core && bun test config.test.mjs daemon.test.mjs` → **220 pass, 0 fail**. Dependent suites (`cli-cluster`, `join-bundle`, `doctor`, `cluster-ownership`, `cluster-heartbeat-publisher`, `recovery-pass-context`) → **113 pass, 0 fail**.

Design: `thoughts/shared/plans/2026-06-18-cluster-membership-liveness-redesign.md` (concern B). References CTL-1271.

> Note: autonomous wave-1 implementation. **NEEDS REVIEW before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)