### PR TITLE
feat(dev): CTL-1272 — Tailscale + peer-HTTP liveness source (additive)

### DIFF
--- a/plugins/dev/scripts/execution-core/node-presence.mjs
+++ b/plugins/dev/scripts/execution-core/node-presence.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+// node-presence.mjs — CTL-1272. NEW, ADDITIVE liveness source.
+//
+// Derives "is peer X up and healthy right now" from two real, already-running
+// fleet substrates — Tailscale device presence + a peer-HTTP /healthz check over
+// the tailnet — instead of the slow, rate-limited Linear-attachment heartbeat
+// (CTL-1090). Three tiers:
+//   1. reachable — Tailscale Online === true (network path exists)
+//   2. up        — the peer answers /healthz over the tailnet
+//   3. healthy   — that response reports a recent scheduler tick (not wedged)
+//
+// DORMANT in this ticket: this module has NO caller in the dispatch path. It is
+// the clean seam CTL-1091's liveness-roster.mjs (effectiveLiveRoster) will later
+// consume — swapping its input from readPeerHeartbeats to readLivePeers. The
+// existing Linear-attachment heartbeat (cluster-heartbeat*.mjs) is left intact so
+// nothing regresses; it may still feed the dashboard.
+//
+// HYSTERESIS (N-consecutive-observation flip) is OUT OF SCOPE here — it lives
+// downstream in CTL-1091's liveness-roster.mjs. This module exposes a single
+// point-in-time observation; the consumer wraps it with hysteresis.
+//
+// PURITY / INJECTABILITY (mirrors cluster-heartbeat.mjs / cluster-sync.mjs's
+// "default real runner, override in opts" convention): the Tailscale exec and
+// the HTTP fetch are both injectable so tests are hermetic — no real binary, no
+// real network. The ONLY config touch is getHostName() for self-exclusion in
+// readLivePeers (already env-redirectable via CATALYST_HOST_NAME). NO import of
+// scheduler.mjs / daemon.mjs.
+//
+// FAIL-OPEN (the highest-risk correctness boundary): a *probe-infrastructure*
+// error (tailscale binary missing / spawn failure / null status) must degrade to
+// "assume live" — never mass-evict the fleet over our own inability to see. A
+// *definitive negative*, however, is honored: a host present in Tailscale status
+// with Online===false, or a clean /healthz response reporting unhealthy, is a
+// real "not live".
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { getHostName } from "./config.mjs";
+
+// macOS ships the binary inside the app bundle; PATH `tailscale` is the fallback
+// (Linux/CLI installs). Both are overridable via the exec seam.
+const TAILSCALE_APP_BUNDLE_BIN =
+  "/Applications/Tailscale.app/Contents/MacOS/Tailscale";
+
+// The monitor HTTP port the /healthz probe hits over the tailnet.
+const DEFAULT_MONITOR_PORT = 7400;
+
+// "Recent scheduler tick" staleness bound. The /healthz lastTickAgeMs is derived
+// from node.heartbeat freshness (~30s cadence), so a generous default tolerates
+// normal heartbeat jitter while still catching a wedged daemon. Overridable.
+const DEFAULT_STALE_MS = 120_000;
+
+// defaultExec — the production Tailscale runner. Resolves the app-bundle binary
+// when present, else the PATH `tailscale`. Returns stdout as a string (the
+// execFileSync utf8 contract). Throws on spawn failure / non-zero exit, which
+// readTailscaleStatus catches and turns into null.
+function defaultExec(file, args) {
+  return execFileSync(file, args, { encoding: "utf8" });
+}
+
+function defaultTailscaleBin() {
+  return existsSync(TAILSCALE_APP_BUNDLE_BIN)
+    ? TAILSCALE_APP_BUNDLE_BIN
+    : "tailscale";
+}
+
+// ─── readTailscaleStatus ─────────────────────────────────────────────────────
+
+// Run `tailscale status --json` and parse it into { Self, Peer }. Returns null on
+// ANY error (binary missing, non-JSON stdout) — never throws. A null return is a
+// probe-infrastructure failure, which downstream fail-open treats as "assume
+// live", NOT as "everyone is offline".
+export function readTailscaleStatus({ exec = defaultExec, bin = defaultTailscaleBin() } = {}) {
+  try {
+    const stdout = exec(bin, ["status", "--json"]);
+    const parsed = JSON.parse(String(stdout));
+    if (!parsed || typeof parsed !== "object") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+// ─── tailscaleNameForRoster ──────────────────────────────────────────────────
+
+// firstDnsLabel — "mini.tail32996b.ts.net." → "mini". Strips the leading label
+// from a Tailscale DNSName (which may carry a trailing dot). Empty/garbage → "".
+function firstDnsLabel(dnsName) {
+  if (typeof dnsName !== "string" || dnsName.length === 0) return "";
+  const trimmed = dnsName.replace(/^\.+/, "");
+  const dot = trimmed.indexOf(".");
+  const label = dot === -1 ? trimmed : trimmed.slice(0, dot);
+  return label.trim();
+}
+
+// Map a Tailscale node (Self or a Peer entry) to its roster name. Precedence:
+//   1. nameMap[HostName] (explicit operator override; e.g. RyansMini250233→mini)
+//   2. DNSName first DNS label (mini.tail…→mini) — the working fallback, since
+//      Tags are null fleet-wide (verified 2026-06-18), so tag-based mapping is
+//      unusable this ticket. Tags are a future enhancement.
+//   3. HostName verbatim (mini-2 already matches its roster name)
+export function tailscaleNameForRoster(tsNode, { nameMap = {} } = {}) {
+  if (!tsNode || typeof tsNode !== "object") return "";
+  const hostName = typeof tsNode.HostName === "string" ? tsNode.HostName : "";
+  if (hostName && Object.prototype.hasOwnProperty.call(nameMap, hostName)) {
+    return nameMap[hostName];
+  }
+  const label = firstDnsLabel(tsNode.DNSName);
+  if (label) return label;
+  return hostName;
+}
+
+// ─── tailscaleOnline ─────────────────────────────────────────────────────────
+
+// allNodes — yield every node entry in a status (Self + each Peer value).
+function* allNodes(status) {
+  if (!status || typeof status !== "object") return;
+  if (status.Self) yield status.Self;
+  const peers = status.Peer;
+  if (peers && typeof peers === "object") {
+    for (const node of Object.values(peers)) yield node;
+  }
+}
+
+// True iff the roster host maps to a Tailscale node with Online===true. A host
+// absent from the status (not Self, not any Peer) → false. A null status → false.
+// NOTE: false here is "definitively not online" relative to a status we DID read;
+// the fail-open posture lives in isHostLive, which distinguishes a null status
+// (probe failure) from a status that simply lacks the host.
+export function tailscaleOnline(status, rosterHost, { nameMap = {} } = {}) {
+  if (!status) return false;
+  for (const node of allNodes(status)) {
+    if (tailscaleNameForRoster(node, { nameMap }) === rosterHost) {
+      return node.Online === true;
+    }
+  }
+  return false;
+}
+
+// ─── probePeerHealth ─────────────────────────────────────────────────────────
+
+// GET <baseUrl>/healthz over the tailnet and classify the three tiers. Shape:
+//   { reachable, up, healthy, daemonAlive, lastTickAgeMs }
+//   - reachable: a 2xx response came back (network path + HTTP up)
+//   - up:        the body parsed into a recognizable health object
+//   - healthy:   daemonAlive === true AND lastTickAgeMs <= staleMs (not wedged)
+// A fetch throw / non-2xx / unparseable body → { reachable:false, healthy:false }.
+// NEVER throws. `host` is the roster name (informational — baseUrl already
+// encodes the target); kept in the signature so callers read probePeerHealth(host,…)
+// symmetrically with isHostLive/tailscaleOnline. `lastTickAgeMs` is server-computed
+// (the /healthz endpoint reports the age), so no local clock is needed here.
+export async function probePeerHealth(
+  // eslint-disable-next-line no-unused-vars -- host documents the target (see header)
+  host,
+  { baseUrl, fetchImpl = fetch, staleMs = DEFAULT_STALE_MS } = {},
+) {
+  const notReachable = { reachable: false, up: false, healthy: false, daemonAlive: false, lastTickAgeMs: null };
+  let res;
+  try {
+    res = await fetchImpl(`${baseUrl}/healthz`, { method: "GET" });
+  } catch {
+    return notReachable;
+  }
+  if (!res || typeof res.status !== "number" || res.status < 200 || res.status >= 300) {
+    return notReachable;
+  }
+  let body;
+  try {
+    body = await res.json();
+  } catch {
+    // 2xx but the body isn't JSON — the network is reachable but the daemon
+    // isn't reporting a parseable health shape, so it is up-but-not-healthy.
+    return { reachable: true, up: false, healthy: false, daemonAlive: false, lastTickAgeMs: null };
+  }
+  if (!body || typeof body !== "object") {
+    return { reachable: true, up: false, healthy: false, daemonAlive: false, lastTickAgeMs: null };
+  }
+  const daemonAlive = body.daemonAlive === true;
+  const lastTickAgeMs =
+    typeof body.lastTickAgeMs === "number" ? body.lastTickAgeMs : null;
+  const fresh = lastTickAgeMs != null && lastTickAgeMs <= staleMs;
+  const healthy = daemonAlive && fresh;
+  return { reachable: true, up: true, healthy, daemonAlive, lastTickAgeMs };
+}
+
+// ─── isHostLive ──────────────────────────────────────────────────────────────
+
+// Combine Tailscale presence AND peer-HTTP health into a single observation:
+//   live = online (Tailscale Online===true) AND healthy (/healthz fresh tick).
+//
+// FAIL-OPEN: if reading the Tailscale status itself fails at the infra level
+// (exec spawn failure / null status), we cannot SEE the fleet → assume the host
+// is live rather than mass-evict (source:"fail-open"). Likewise, if Tailscale
+// says Online===true but the /healthz probe THROWS (network blip / fetch error,
+// reachable:false), we degrade to assume-live rather than evict a host the tailnet
+// believes is up. A DEFINITIVE negative is honored: Online===false (host present
+// in a status we read, reporting offline) → not live; a clean /healthz response
+// reporting unhealthy (reachable, parsed, but stale/dead daemon) → not live.
+export async function isHostLive(host, opts = {}) {
+  const {
+    nameMap = {},
+    exec = defaultExec,
+    bin = defaultTailscaleBin(),
+    baseUrl,
+    fetchImpl = fetch,
+    staleMs = DEFAULT_STALE_MS,
+  } = opts;
+
+  // Allow a pre-read status to be injected (so readLivePeers reads it ONCE);
+  // otherwise read it here. A read failure → null → fail-open.
+  const status =
+    "status" in opts ? opts.status : readTailscaleStatus({ exec, bin });
+
+  // FAIL-OPEN #1: we could not read presence at all → assume live.
+  if (status == null) {
+    return { live: true, online: null, reachable: null, healthy: null, lastTickAgeMs: null, source: "fail-open" };
+  }
+
+  const online = tailscaleOnline(status, host, { nameMap });
+
+  // DEFINITIVE negative: Tailscale read fine and the host is Online===false (or
+  // absent). Honor it — this is the signal that re-homes a dead host's work.
+  if (!online) {
+    return { live: false, online: false, reachable: false, healthy: false, lastTickAgeMs: null, source: "tailscale" };
+  }
+
+  // Online===true → probe /healthz.
+  const probe = await probePeerHealth(host, { baseUrl, fetchImpl, staleMs });
+
+  // FAIL-OPEN #2: Tailscale says Online but the probe couldn't even reach the
+  // peer (fetch threw / network blip). Don't evict a host the tailnet believes
+  // is up — degrade to assume-live.
+  if (!probe.reachable) {
+    return {
+      live: true,
+      online: true,
+      reachable: false,
+      healthy: null,
+      lastTickAgeMs: null,
+      source: "fail-open",
+    };
+  }
+
+  // Reachable: now the /healthz verdict is authoritative (clean response).
+  return {
+    live: probe.healthy,
+    online: true,
+    reachable: true,
+    healthy: probe.healthy,
+    lastTickAgeMs: probe.lastTickAgeMs,
+    source: "probe",
+  };
+}
+
+// ─── readLivePeers ───────────────────────────────────────────────────────────
+
+// Map isHostLive over the roster (MINUS self). Self is always treated live and
+// is NEVER probed against itself — the local daemon evaluates its own health
+// elsewhere, and the laptop's Tailscale HostName/DNSName don't match any roster
+// name anyway (so trying to self-match in the status would mis-classify it).
+//
+// Reads the Tailscale status ONCE and threads it into every per-host call, so a
+// roster of N peers costs one `tailscale status --json` + N /healthz GETs.
+//
+// Returns { [host]: { live, online, reachable, healthy, lastTickAgeMs|null, source } }.
+export async function readLivePeers(roster, opts = {}) {
+  const {
+    nameMap = {},
+    exec = defaultExec,
+    bin = defaultTailscaleBin(),
+    fetchImpl = fetch,
+    staleMs = DEFAULT_STALE_MS,
+    baseUrlFor = (host) => `http://${host}:${DEFAULT_MONITOR_PORT}`,
+    self = getHostName(),
+  } = opts;
+
+  const status =
+    "status" in opts ? opts.status : readTailscaleStatus({ exec, bin });
+
+  const out = {};
+  for (const host of Array.isArray(roster) ? roster : []) {
+    if (host === self) {
+      out[host] = {
+        live: true,
+        online: true,
+        reachable: true,
+        healthy: true,
+        lastTickAgeMs: null,
+        source: "self",
+      };
+      continue;
+    }
+    out[host] = await isHostLive(host, {
+      status,
+      nameMap,
+      baseUrl: baseUrlFor(host),
+      fetchImpl,
+      staleMs,
+    });
+  }
+  return out;
+}

--- a/plugins/dev/scripts/execution-core/node-presence.test.mjs
+++ b/plugins/dev/scripts/execution-core/node-presence.test.mjs
@@ -1,0 +1,397 @@
+// node-presence.test.mjs — CTL-1272. Hermetic tests for the NEW additive
+// liveness source (Tailscale device presence + peer-HTTP /healthz over the
+// tailnet). Everything is injected: a fake `exec` seam stands in for
+// `tailscale status --json` and a fake `fetchImpl` stands in for the /healthz
+// GET, so no real binary is spawned and no real network is touched.
+//
+// The fixture mirrors the REAL fleet shape captured this session (verified live
+// 2026-06-18): Self{HostName:"Ryan's MacBook Pro", DNSName:"ryans-macbook-pro…",
+// Online:true}; Peer{ RyansMini250233 → DNSName mini.tail…, Online:true; mini-2
+// → DNSName mini-2.tail…, Online:true; an Online:false entry } — Tags null
+// fleet-wide, so name-mapping (nameMap + DNSName-first-label fallback) is the
+// usable path, NOT tags.
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  readTailscaleStatus,
+  tailscaleNameForRoster,
+  tailscaleOnline,
+  probePeerHealth,
+  isHostLive,
+  readLivePeers,
+} from "./node-presence.mjs";
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+// Real-shaped `tailscale status --json` payload. RyansMini250233 maps to roster
+// "mini" via its DNSName first label; mini-2's HostName already matches roster.
+function fakeStatusJson() {
+  return JSON.stringify({
+    Self: {
+      HostName: "Ryan's MacBook Pro",
+      DNSName: "ryans-macbook-pro.tail32996b.ts.net.",
+      Online: true,
+      Tags: null,
+    },
+    Peer: {
+      "nodekey:aaa": {
+        HostName: "RyansMini250233",
+        DNSName: "mini.tail32996b.ts.net.",
+        Online: true,
+        LastSeen: "0001-01-01T00:00:00Z",
+        Tags: null,
+      },
+      "nodekey:bbb": {
+        HostName: "mini-2",
+        DNSName: "mini-2.tail32996b.ts.net.",
+        Online: true,
+        LastSeen: "0001-01-01T00:00:00Z",
+        Tags: null,
+      },
+      "nodekey:ccc": {
+        HostName: "studio",
+        DNSName: "studio.tail32996b.ts.net.",
+        Online: false,
+        LastSeen: "2026-06-02T11:57:13.1Z",
+        Tags: null,
+      },
+    },
+  });
+}
+
+// An exec seam that returns the fixture stdout (mirrors execFileSync's string
+// return). Records the binary + args it was asked to run.
+function fakeExec(stdout) {
+  const calls = [];
+  const exec = (file, args) => {
+    calls.push({ file, args });
+    return stdout;
+  };
+  exec.calls = calls;
+  return exec;
+}
+
+// An exec seam that throws (binary missing / spawn failure).
+function throwingExec(message = "spawn ENOENT") {
+  return () => {
+    throw new Error(message);
+  };
+}
+
+// A fetchImpl returning a canned /healthz Response. body is an object → JSON.
+function fakeFetch(status, body) {
+  return async () =>
+    new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+}
+
+// A fetchImpl that rejects (network down).
+function rejectingFetch(message = "fetch failed") {
+  return async () => {
+    throw new Error(message);
+  };
+}
+
+const NAME_MAP = { RyansMini250233: "mini" };
+
+// ─── env save/restore (self-exclusion in readLivePeers uses getHostName) ─────
+
+let savedHostName;
+beforeEach(() => {
+  savedHostName = process.env.CATALYST_HOST_NAME;
+});
+afterEach(() => {
+  if (savedHostName === undefined) delete process.env.CATALYST_HOST_NAME;
+  else process.env.CATALYST_HOST_NAME = savedHostName;
+});
+
+// ─── readTailscaleStatus ─────────────────────────────────────────────────────
+
+describe("readTailscaleStatus", () => {
+  it("parses `tailscale status --json` stdout into { Self, Peer } via the injected exec", () => {
+    const exec = fakeExec(fakeStatusJson());
+    const status = readTailscaleStatus({ exec });
+    expect(status).not.toBeNull();
+    expect(status.Self.HostName).toBe("Ryan's MacBook Pro");
+    expect(Object.keys(status.Peer)).toHaveLength(3);
+    // It actually invoked the seam (no real binary).
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0].args).toEqual(expect.arrayContaining(["status", "--json"]));
+  });
+
+  it("returns null (never throws) when the exec throws — binary missing / spawn error", () => {
+    const status = readTailscaleStatus({ exec: throwingExec() });
+    expect(status).toBeNull();
+  });
+
+  it("returns null on malformed / non-JSON stdout", () => {
+    const status = readTailscaleStatus({ exec: fakeExec("not json at all <<<") });
+    expect(status).toBeNull();
+  });
+});
+
+// ─── tailscaleNameForRoster ──────────────────────────────────────────────────
+
+describe("tailscaleNameForRoster", () => {
+  it("nameMap entry takes precedence (RyansMini250233 → mini)", () => {
+    const node = { HostName: "RyansMini250233", DNSName: "mini.tail32996b.ts.net." };
+    expect(tailscaleNameForRoster(node, { nameMap: NAME_MAP })).toBe("mini");
+  });
+
+  it("falls back to the DNSName first DNS label when no map matches", () => {
+    const node = { HostName: "RyansMini250233", DNSName: "mini.tail32996b.ts.net." };
+    expect(tailscaleNameForRoster(node, { nameMap: {} })).toBe("mini");
+  });
+
+  it("uses HostName verbatim when there is no map and no usable DNSName", () => {
+    const node = { HostName: "mini-2", DNSName: "" };
+    expect(tailscaleNameForRoster(node, {})).toBe("mini-2");
+  });
+});
+
+// ─── tailscaleOnline ─────────────────────────────────────────────────────────
+
+describe("tailscaleOnline", () => {
+  const status = JSON.parse(fakeStatusJson());
+
+  it("mapped peer with Online===true → true (RyansMini250233 → mini via nameMap)", () => {
+    expect(tailscaleOnline(status, "mini", { nameMap: NAME_MAP })).toBe(true);
+  });
+
+  it("peer present but Online===false → false (definitive offline)", () => {
+    expect(tailscaleOnline(status, "studio", { nameMap: NAME_MAP })).toBe(false);
+  });
+
+  it("host absent from status (not in Self/Peer) → false", () => {
+    expect(tailscaleOnline(status, "ghost", { nameMap: NAME_MAP })).toBe(false);
+  });
+
+  it("null status → false", () => {
+    expect(tailscaleOnline(null, "mini", { nameMap: NAME_MAP })).toBe(false);
+  });
+});
+
+// ─── probePeerHealth ─────────────────────────────────────────────────────────
+
+describe("probePeerHealth", () => {
+  it("200 with fresh tick → reachable + up + healthy", async () => {
+    const fetchImpl = fakeFetch(200, {
+      host: "mini",
+      daemonAlive: true,
+      lastTickAgeMs: 5_000,
+    });
+    const res = await probePeerHealth("mini", {
+      baseUrl: "http://mini:7400",
+      fetchImpl,
+      staleMs: 120_000,
+    });
+    expect(res.reachable).toBe(true);
+    expect(res.up).toBe(true);
+    expect(res.healthy).toBe(true);
+    expect(res.lastTickAgeMs).toBe(5_000);
+  });
+
+  it("200 but lastTickAgeMs > staleMs (wedged daemon) → up but NOT healthy", async () => {
+    const fetchImpl = fakeFetch(200, {
+      host: "mini",
+      daemonAlive: true,
+      lastTickAgeMs: 900_000,
+    });
+    const res = await probePeerHealth("mini", {
+      baseUrl: "http://mini:7400",
+      fetchImpl,
+      staleMs: 120_000,
+    });
+    expect(res.reachable).toBe(true);
+    expect(res.up).toBe(true);
+    expect(res.healthy).toBe(false);
+  });
+
+  it("fetch rejects (network down) → { reachable:false }, never throws", async () => {
+    const res = await probePeerHealth("mini", {
+      baseUrl: "http://mini:7400",
+      fetchImpl: rejectingFetch(),
+      staleMs: 120_000,
+    });
+    expect(res.reachable).toBe(false);
+    expect(res.healthy).toBe(false);
+  });
+
+  it("non-2xx (503) → reachable false / not healthy", async () => {
+    const res = await probePeerHealth("mini", {
+      baseUrl: "http://mini:7400",
+      fetchImpl: fakeFetch(503, { error: "down" }),
+      staleMs: 120_000,
+    });
+    expect(res.reachable).toBe(false);
+    expect(res.healthy).toBe(false);
+  });
+
+  it("200 but unparseable/garbage body → not healthy (does not throw)", async () => {
+    const res = await probePeerHealth("mini", {
+      baseUrl: "http://mini:7400",
+      fetchImpl: fakeFetch(200, "<<garbage not json>>"),
+      staleMs: 120_000,
+    });
+    expect(res.healthy).toBe(false);
+  });
+});
+
+// ─── isHostLive ──────────────────────────────────────────────────────────────
+
+describe("isHostLive", () => {
+  const status = JSON.parse(fakeStatusJson());
+
+  it("online AND healthy → live=true", async () => {
+    const res = await isHostLive("mini", {
+      status,
+      nameMap: NAME_MAP,
+      baseUrl: "http://mini:7400",
+      fetchImpl: fakeFetch(200, { host: "mini", daemonAlive: true, lastTickAgeMs: 5_000 }),
+      staleMs: 120_000,
+    });
+    expect(res.live).toBe(true);
+    expect(res.online).toBe(true);
+    expect(res.healthy).toBe(true);
+  });
+
+  it("Online===false (definitive) → live=false (work-rehome implied; online:false)", async () => {
+    const res = await isHostLive("studio", {
+      status,
+      nameMap: NAME_MAP,
+      baseUrl: "http://studio:7400",
+      fetchImpl: fakeFetch(200, { host: "studio", daemonAlive: true, lastTickAgeMs: 5_000 }),
+      staleMs: 120_000,
+    });
+    expect(res.online).toBe(false);
+    expect(res.live).toBe(false);
+  });
+
+  it("reachable-but-wedged (Online true, /healthz stale tick) → live=false (not merely reachable)", async () => {
+    const res = await isHostLive("mini", {
+      status,
+      nameMap: NAME_MAP,
+      baseUrl: "http://mini:7400",
+      fetchImpl: fakeFetch(200, { host: "mini", daemonAlive: true, lastTickAgeMs: 900_000 }),
+      staleMs: 120_000,
+    });
+    expect(res.online).toBe(true);
+    expect(res.reachable).toBe(true);
+    expect(res.healthy).toBe(false);
+    expect(res.live).toBe(false);
+  });
+
+  it("FAIL-OPEN: null tailscale status (probe infra error) → live=true (assume live, no mass-eviction)", async () => {
+    const res = await isHostLive("mini", {
+      status: null,
+      nameMap: NAME_MAP,
+      baseUrl: "http://mini:7400",
+      fetchImpl: fakeFetch(200, { host: "mini", daemonAlive: true, lastTickAgeMs: 5_000 }),
+      staleMs: 120_000,
+    });
+    expect(res.live).toBe(true);
+    expect(res.source).toBe("fail-open");
+  });
+
+  it("FAIL-OPEN: exec spawn failure (status read throws) → live=true", async () => {
+    const res = await isHostLive("mini", {
+      exec: throwingExec(),
+      nameMap: NAME_MAP,
+      baseUrl: "http://mini:7400",
+      fetchImpl: fakeFetch(200, { host: "mini", daemonAlive: true, lastTickAgeMs: 5_000 }),
+      staleMs: 120_000,
+    });
+    expect(res.live).toBe(true);
+    expect(res.source).toBe("fail-open");
+  });
+
+  it("FAIL-OPEN: /healthz fetch throws while Tailscale Online=true → degrade to assume-live", async () => {
+    const res = await isHostLive("mini", {
+      status,
+      nameMap: NAME_MAP,
+      baseUrl: "http://mini:7400",
+      fetchImpl: rejectingFetch(),
+      staleMs: 120_000,
+    });
+    expect(res.online).toBe(true);
+    expect(res.reachable).toBe(false);
+    expect(res.live).toBe(true);
+    expect(res.source).toBe("fail-open");
+  });
+});
+
+// ─── readLivePeers ───────────────────────────────────────────────────────────
+
+describe("readLivePeers", () => {
+  const status = JSON.parse(fakeStatusJson());
+
+  it("maps over a roster minus self; one online+healthy, one Online=false → correct per-host", async () => {
+    process.env.CATALYST_HOST_NAME = "laptop"; // self not in roster → both probed
+    // mini → online+healthy; studio → Online=false
+    const fetchImpl = async (url) => {
+      const u = String(url);
+      if (u.includes("mini")) {
+        return new Response(
+          JSON.stringify({ host: "mini", daemonAlive: true, lastTickAgeMs: 5_000 }),
+          { status: 200 },
+        );
+      }
+      return new Response(
+        JSON.stringify({ host: "studio", daemonAlive: true, lastTickAgeMs: 5_000 }),
+        { status: 200 },
+      );
+    };
+    const out = await readLivePeers(["mini", "studio"], {
+      status,
+      nameMap: NAME_MAP,
+      fetchImpl,
+      baseUrlFor: (host) => `http://${host}:7400`,
+      staleMs: 120_000,
+    });
+    expect(out.mini.live).toBe(true);
+    expect(out.mini.online).toBe(true);
+    expect(out.mini.healthy).toBe(true);
+    expect(out.studio.online).toBe(false);
+    expect(out.studio.live).toBe(false);
+  });
+
+  it("self is always live and never probed against itself", async () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    let selfProbed = false;
+    const fetchImpl = async (url) => {
+      if (String(url).includes("mini")) selfProbed = true; // self URL would contain "mini"
+      return new Response(
+        JSON.stringify({ host: "studio", daemonAlive: true, lastTickAgeMs: 5_000 }),
+        { status: 200 },
+      );
+    };
+    const out = await readLivePeers(["mini", "studio"], {
+      status,
+      nameMap: NAME_MAP,
+      fetchImpl,
+      baseUrlFor: (host) => `http://${host}:7400`,
+      staleMs: 120_000,
+    });
+    expect(out.mini.live).toBe(true);
+    expect(out.mini.source).toBe("self");
+    expect(out.mini.online).toBe(true);
+    // self (mini) was excluded from probing — only studio's URL was fetched.
+    expect(selfProbed).toBe(false);
+  });
+
+  it("name-mapping end-to-end: roster [mini] + nameMap {RyansMini250233:mini} + healthy /healthz → mini live", async () => {
+    process.env.CATALYST_HOST_NAME = "laptop";
+    const out = await readLivePeers(["mini"], {
+      status,
+      nameMap: NAME_MAP,
+      fetchImpl: fakeFetch(200, { host: "mini", daemonAlive: true, lastTickAgeMs: 5_000 }),
+      baseUrlFor: (host) => `http://${host}:7400`,
+      staleMs: 120_000,
+    });
+    expect(out.mini.live).toBe(true);
+    expect(out.mini.online).toBe(true);
+    expect(out.mini.healthy).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/healthz-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/healthz-endpoint.test.ts
@@ -1,0 +1,136 @@
+// healthz-endpoint.test.ts — CTL-1272. HTTP route-plumbing tests for the NEW
+// read-only GET /healthz endpoint the peer-HTTP liveness probe (node-presence.mjs)
+// hits over the tailnet. Validates the server.ts wiring — the route is mounted,
+// returns the { host, daemonAlive, lastTickAgeMs } HealthSnapshot from the
+// injected healthReader, and stays a 200 read-only health REPORT (never a 5xx)
+// even when it reports an unhealthy/offline daemon. The production health logic
+// (daemon-heartbeat freshness → daemonAlive) is exercised by the existing
+// daemon-health path; these prove the route is mounted, shaped, and hermetic via
+// the injected reader so it never touches the live event log/roster.
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+type ServerHandle = ReturnType<typeof createServer>;
+
+function isHealthSnapshot(v: unknown): boolean {
+  if (!v || typeof v !== "object") return false;
+  const s = v as Record<string, unknown>;
+  return (
+    typeof s.host === "string" &&
+    typeof s.daemonAlive === "boolean" &&
+    (s.lastTickAgeMs === null || typeof s.lastTickAgeMs === "number")
+  );
+}
+
+function makeTmpServer(opts: Parameters<typeof createServer>[0] extends infer T ? Partial<T> : never) {
+  const tmpDir = mkdtempSync(join(tmpdir(), "healthz-endpoint-"));
+  const wtDir = join(tmpDir, "wt");
+  mkdirSync(wtDir, { recursive: true });
+  const server = createServer({
+    port: 0,
+    wtDir,
+    catalystDir: tmpDir,
+    startWatcher: false,
+    ...opts,
+  });
+  return { server, tmpDir, baseUrl: `http://localhost:${server.port}` };
+}
+
+describe("GET /healthz (CTL-1272 — injected healthReader)", () => {
+  let server: ServerHandle;
+  let tmpDir: string;
+  let baseUrl: string;
+
+  beforeAll(() => {
+    ({ server, tmpDir, baseUrl } = makeTmpServer({
+      healthReader: () => ({ host: "mini", daemonAlive: true, lastTickAgeMs: 4_200 }),
+    }));
+  });
+
+  afterAll(() => {
+    void server?.stop(true);
+    if (tmpDir) {
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it("returns 200 with the { host, daemonAlive, lastTickAgeMs } shape", async () => {
+    const res = await fetch(`${baseUrl}/healthz`);
+    expect(res.status).toBe(200);
+    const body: unknown = await res.json();
+    expect(isHealthSnapshot(body)).toBe(true);
+  });
+
+  it("flows the injected reader's daemonAlive + small lastTickAgeMs through verbatim", async () => {
+    const res = await fetch(`${baseUrl}/healthz`);
+    const body = (await res.json()) as { host: string; daemonAlive: boolean; lastTickAgeMs: number | null };
+    expect(body.host).toBe("mini");
+    expect(body.daemonAlive).toBe(true);
+    expect(body.lastTickAgeMs).toBe(4_200);
+  });
+});
+
+describe("GET /healthz — reports an unhealthy daemon as 200, not 5xx", () => {
+  let server: ServerHandle;
+  let tmpDir: string;
+  let baseUrl: string;
+
+  beforeAll(() => {
+    ({ server, tmpDir, baseUrl } = makeTmpServer({
+      healthReader: () => ({ host: "mini", daemonAlive: false, lastTickAgeMs: null }),
+    }));
+  });
+
+  afterAll(() => {
+    void server?.stop(true);
+    if (tmpDir) {
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it("a reader reporting daemonAlive:false still returns 200 (read-only health report)", async () => {
+    const res = await fetch(`${baseUrl}/healthz`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { daemonAlive: boolean };
+    expect(body.daemonAlive).toBe(false);
+  });
+});
+
+describe("GET /healthz — production default (no healthReader injected)", () => {
+  let server: ServerHandle;
+  let tmpDir: string;
+  let baseUrl: string;
+
+  beforeAll(() => {
+    ({ server, tmpDir, baseUrl } = makeTmpServer({}));
+  });
+
+  afterAll(() => {
+    void server?.stop(true);
+    if (tmpDir) {
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it("route is still mounted and returns the production-shaped object without throwing (fail-open)", async () => {
+    const res = await fetch(`${baseUrl}/healthz`);
+    expect(res.status).toBe(200);
+    const body: unknown = await res.json();
+    expect(isHealthSnapshot(body)).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -347,6 +347,20 @@ export function isAppRoute(pathname: string): boolean {
   return isDetailDeepLinkPath(pathname);
 }
 
+/**
+ * CTL-1272: the read-only health report served at GET /healthz, hit by the
+ * peer-HTTP liveness probe (execution-core/node-presence.mjs) over the tailnet.
+ * `daemonAlive` mirrors the existing daemon-health classification (!== "offline")
+ * and `lastTickAgeMs` is the local node's `node.heartbeat` freshness (the
+ * daemon's liveness proxy — the heartbeat only emits while the scheduler loop
+ * runs), NOT a literal scheduler-tick counter. null age = no heartbeat heard.
+ */
+export interface HealthSnapshot {
+  host: string;
+  daemonAlive: boolean;
+  lastTickAgeMs: number | null;
+}
+
 export interface CreateServerOptions {
   port?: number;
   hostname?: string;
@@ -418,6 +432,15 @@ export interface CreateServerOptions {
    * inject a deterministic status so the routes don't read the live event log.
    */
   daemonHealthReader?: (() => DaemonHealth | Promise<DaemonHealth>) | null;
+  /**
+   * CTL-1272: override for the read-only GET /healthz reader hit by the peer-HTTP
+   * liveness probe (node-presence.mjs) over the tailnet. Production reuses the
+   * SAME loadDaemonDeps()/readClusterHeartbeats()/deriveDaemonHealth chain the
+   * footer health dot reads (productionDaemonHealth), turning it into a
+   * { host, daemonAlive, lastTickAgeMs } HealthSnapshot. Tests inject a
+   * deterministic snapshot so the route never touches the live event log.
+   */
+  healthReader?: (() => HealthSnapshot | Promise<HealthSnapshot>) | null;
   /**
    * CTL-898 (SHELL8): override for the per-node cluster-health reader that feeds
    * the footer's generalized per-node indicator + node filter (/api/cluster,
@@ -788,6 +811,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     webhookConfig,
     linearWebhookConfig,
     daemonHealthReader: daemonHealthReaderOpt,
+    healthReader: healthReaderOpt,
     clusterReader: clusterReaderOpt,
     screenLogsExec: screenLogsExecOpt,
     screenPollMs = SCREEN_POLL_MS,
@@ -1374,6 +1398,39 @@ export function createServer(opts: CreateServerOptions): BunServer {
       ? async () => daemonHealthReaderOpt()
       : productionDaemonHealth;
 
+  // CTL-1272: the read-only GET /healthz health report, hit by the peer-HTTP
+  // liveness probe (execution-core/node-presence.mjs) over the tailnet. Reuses
+  // the SAME loadDaemonDeps()/heartbeat-memo/deriveDaemonHealth chain the footer
+  // health dot reads — so `daemonAlive` mirrors deriveDaemonHealth !== "offline"
+  // and `lastTickAgeMs` is the local node's node.heartbeat freshness (the
+  // daemon's liveness proxy; the heartbeat only emits while the scheduler loop
+  // runs). FAIL-OPEN: any read failure / unavailable execution-core degrades to
+  // { daemonAlive:false, lastTickAgeMs:null } rather than throwing out of the
+  // route (a health endpoint must never 5xx).
+  const productionHealth = async (): Promise<HealthSnapshot> => {
+    try {
+      const deps = await loadDaemonDeps();
+      if (!deps) return { host: "", daemonAlive: false, lastTickAgeMs: null };
+      const host = deps.getHostName();
+      const lastSeen = heartbeatMemo.get(deps, {});
+      const healthyWindowMs =
+        Number(process.env.MONITOR_DAEMON_HEALTHY_WINDOW_MS) || undefined;
+      const health = deps.deriveDaemonHealth(lastSeen, host, {
+        intervalMs: healthyWindowMs,
+      });
+      const localLastSeen = lastSeen[host];
+      const parsed = localLastSeen ? Date.parse(localLastSeen) : NaN;
+      const lastTickAgeMs = Number.isNaN(parsed) ? null : Date.now() - parsed;
+      return { host, daemonAlive: health !== "offline", lastTickAgeMs };
+    } catch {
+      return { host: "", daemonAlive: false, lastTickAgeMs: null };
+    }
+  };
+  const readHealth: () => Promise<HealthSnapshot> =
+    healthReaderOpt != null
+      ? async () => healthReaderOpt()
+      : productionHealth;
+
   // assembleNavSignal — project the four nav signals off the board snapshot the
   // read-model already computed, layering the local daemon health. One board read
   // (the shared, reactively-cached snapshot) + one heartbeat classify; NO
@@ -1663,6 +1720,14 @@ export function createServer(opts: CreateServerOptions): BunServer {
 
         if (url.pathname === "/api/version") {
           return Response.json({ version: CATALYST_DEV_VERSION });
+        }
+
+        // CTL-1272: read-only liveness health report over the tailnet. Hit by a
+        // peer's node-presence.mjs probe to classify "daemon up + recent tick".
+        // Cheap (no board read, no Linear/GitHub call) and fail-open — readHealth
+        // never throws. Distinct from /api/health/* (those are namespaced).
+        if (url.pathname === "/healthz") {
+          return Response.json(await readHealth());
         }
 
         if (url.pathname === "/api/snapshot") {


### PR DESCRIPTION
## CTL-1272 — Tailscale + peer-HTTP liveness source (additive)

Builds a NEW, **additive** liveness source — Tailscale device presence + a peer-HTTP `/healthz` check over the tailnet — exported as a clean seam (`node-presence.mjs`) that **CTL-1091's** `liveness-roster.mjs` will later consume (swap its input from `readPeerHeartbeats` to this presence probe).

This ticket is dormant: it does **NOT** touch the dispatch path, HRW, the soft-CAS claim, or the existing Linear-attachment heartbeat (`cluster-heartbeat*.mjs` left intact so nothing regresses — it may stay for dashboard display). `node-presence.mjs` has **no caller** in this PR; only the new read-only `/healthz` route is live.

### Surfaces
- **`plugins/dev/scripts/execution-core/node-presence.mjs` (NEW)** — pure + injectable (exec + fetch seams, mirroring `cluster-heartbeat`/`cluster-sync`'s "default real runner, override in opts" convention). Exports `readTailscaleStatus`, `tailscaleNameForRoster`, `tailscaleOnline`, `probePeerHealth` (three-tier reachable/up/healthy), `isHostLive`, `readLivePeers`.
  - **Name-mapping**: `nameMap` > DNSName-first-label (`mini.tail…`→`mini`) > `HostName` verbatim. Tags are **null fleet-wide** (verified live 2026-06-18: `RyansMini250233`/DNSName `mini`), so tag-based mapping is unusable this ticket — documented as a future enhancement.
  - **FAIL-OPEN** (the highest-risk boundary): a probe-infra error (exec spawn failure / null status / `/healthz` fetch throw while Online=true) degrades to **assume-live**, never mass-evicts. A **definitive** negative (host present with `Online===false`, or a clean `/healthz` reporting unhealthy/stale) is honored as not-live.
  - **Self** is always live and never probed (excluded via `getHostName()` — the laptop's TS HostName doesn't match a roster name).
  - **Hysteresis** (N-consecutive flip) is OUT of scope — it lives downstream in CTL-1091.
- **`plugins/dev/scripts/orch-monitor/server.ts`** — additive read-only `GET /healthz` returning `{ host, daemonAlive, lastTickAgeMs }`, reusing the existing `loadDaemonDeps`/heartbeat-memo/`deriveDaemonHealth` chain. Wired via a new optional injectable `healthReader` on `CreateServerOptions` (mirrors `daemonHealthReader`/`clusterReader`), mounted next to `/api/version`. No board read, no Linear/GitHub call, fail-open (never 5xx). `lastTickAgeMs` is heartbeat-derived (the daemon's liveness proxy), not a literal scheduler-tick counter.

### Tests
- `node-presence.test.mjs` — 24 hermetic cases (fixture modeled on the real fleet shape). `cd plugins/dev/scripts/execution-core && bun test node-presence.test.mjs` → 24 pass.
- `__tests__/healthz-endpoint.test.ts` — 4 cases (injected `healthReader` + production default). `cd plugins/dev/scripts/orch-monitor && bun test __tests__/healthz-endpoint.test.ts` → 4 pass.
- `server.ts` lint clean; parent typecheck shows zero new errors in `server.ts` (the only typecheck errors are pre-existing `ui/` module-resolution noise from uninstalled ui deps in the worktree).

> Autonomous wave-1 implementation — **NEEDS REVIEW before merge.** Linear ticket CTL-1272 left in Backlog. References CTL-1272; blocks CTL-1091.

🤖 Generated with [Claude Code](https://claude.com/claude-code)