### PR TITLE
feat(dev): CTL-1263 — install + register + auto-start the Alloy log-shipper per host

### DIFF
--- a/plugins/dev/scripts/catalyst-join.sh
+++ b/plugins/dev/scripts/catalyst-join.sh
@@ -414,6 +414,18 @@ do_setup_catalyst() {
 
 do_install_cli() {
   bash "$INSTALL_CLI_SCRIPT"
+  # CTL-1263: install-cli.sh's ensure_alloy provisions the Grafana Alloy
+  # log-shipper binary as part of this stage, so a joined node inherits the
+  # shipper with no extra wiring (do_install_stack's launchd agent then auto-
+  # starts it via `catalyst-stack start`). Surface a LOUD but NON-FATAL warning
+  # if the binary did not land (e.g. a headless Linux box with no brew and a
+  # flaky GitHub download) — install-cli warn+continues by design, so the join
+  # must not hard-fail here. The shipper is optional infra; start_shipper warns
+  # again at start time so the gap is never silent.
+  if ! command -v alloy >/dev/null 2>&1; then
+    warn "alloy not installed by install-cli — log-shipper will not start on this node (install Grafana Alloy manually, then 'catalyst-stack start')"
+  fi
+  return 0
 }
 
 do_setup_plugin_source() {

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # catalyst-stack — bring the catalyst stack up (or down) on this host.
 #
-# Order on start: mitmproxy → broker → monitor → execution-core
-#               (broker → monitor → exec-core is the dependency order;
+# Order on start: mitmproxy → monitor → broker → execution-core → otel-forward
+#               → log-shipper
+#               (monitor → broker → exec-core is the dependency order;
 #                mitmproxy is independent + first so the proxy env vars
-#                set below have somewhere to forward to)
+#                set below have somewhere to forward to; the log-shipper is
+#                LAST — it only tails the daemons' .log files, CTL-1263)
 # Order on stop: reverse.
 #
 # Idempotent. If a service is already up, it is logged and left alone.
@@ -88,6 +90,19 @@ MITM_CA="${HOME}/.mitmproxy/mitmproxy-ca-cert.pem"
 MITM_ADDON="${HOME}/catalyst/mitm_linear_addon.py"
 MITM_LOG="${HOME}/catalyst/mitm.log"
 
+# ─── Log-shipper (Grafana Alloy) env (CTL-1263) ──────────────────────────────
+# The shipper tails the daemon .log files and ships them OTLP/HTTP to the shared
+# collector (config: log-shipper/config.alloy, CTL-1261). Alloy has no CLI
+# manager, so catalyst-stack owns its pid/log/storage inline (mirroring the
+# mitmproxy primitives below). config.alloy ships beside this script: SCRIPT_DIR
+# is the symlink-walked scripts/ dir (cache/checkout) even via the version-auto
+# wrapper, so log-shipper/config.alloy is always next to it.
+SHIPPER_PID="${CATALYST_DIR:-$HOME/catalyst}/alloy.pid"
+SHIPPER_LOG="${CATALYST_DIR:-$HOME/catalyst}/alloy.log"
+SHIPPER_STORAGE="${CATALYST_DIR:-$HOME/catalyst}/alloy-data"
+SHIPPER_CONFIG="${SCRIPT_DIR}/log-shipper/config.alloy"
+SHIPPER_LAUNCHER="${SCRIPT_DIR}/log-shipper/launch.sh"
+
 # ─── Helpers ────────────────────────────────────────────────────────────────
 log()  { printf '[catalyst-stack] %s\n' "$*"; }
 warn() { printf '[catalyst-stack] WARN: %s\n' "$*" >&2; }
@@ -166,6 +181,92 @@ stop_mitmproxy() {
   else
     log "mitmproxy not running"
   fi
+}
+
+# ─── Log-shipper (Grafana Alloy) primitives (CTL-1263) ───────────────────────
+# shipper_pid — print the live alloy pid recorded in SHIPPER_PID, or nothing.
+# Validates BOTH that the pid is alive AND that the process is actually alloy
+# (guards against pid reuse after a crash + a fresh unrelated process grabbing
+# the same pid). A stale/dead/non-alloy pidfile prints nothing, so start_shipper
+# falls through to a self-healing restart.
+shipper_pid() {
+  local pid
+  [[ -f "$SHIPPER_PID" ]] || return 0
+  pid="$(cat "$SHIPPER_PID" 2>/dev/null || true)"
+  [[ -n "$pid" ]] || return 0
+  pid_alive "$pid" || return 0
+  # Confirm the live pid is actually an alloy process (not pid reuse).
+  if ps -p "$pid" -o command= 2>/dev/null | grep -q alloy; then
+    printf '%s\n' "$pid"
+  fi
+}
+
+start_shipper() {
+  # 1. IDEMPOTENT — never double-start a running shipper.
+  local pid; pid="$(shipper_pid)"
+  if pid_alive "$pid"; then
+    log "log-shipper (alloy) already running (pid $pid)"
+    return 0
+  fi
+
+  # 2. MISSING-BINARY LOUD FAIL — emit to stderr (warn) so the CTL-1166 launchd
+  #    self-heal log surfaces it and can never silently no-op. Non-fatal
+  #    (return 1, not exit) so a missing shipper never blocks the daemons —
+  #    matches start_mitmproxy's posture.
+  if ! command -v alloy >/dev/null 2>&1; then
+    warn "alloy not found — log-shipper NOT started. Install: bash \"${SCRIPT_DIR}/install-cli.sh\" (installs Grafana Alloy), or 'brew install grafana-alloy'"
+    return 1
+  fi
+
+  # 3. Config presence guard.
+  if [[ ! -f "$SHIPPER_CONFIG" ]]; then
+    warn "log-shipper config missing at $SHIPPER_CONFIG — skipping"
+    return 1
+  fi
+
+  # 4. Resolve + export the stable node name (getHostName() semantics; NEVER the
+  #    Tailscale device name). When launchd pins CATALYST_HOST_NAME in the plist
+  #    env, catalyst_host_name returns it verbatim; otherwise it falls back
+  #    through Layer-2 config then the OS hostname's first DNS label.
+  if [[ -f "${SCRIPT_DIR}/lib/host-identity.sh" ]]; then
+    # shellcheck source=lib/host-identity.sh
+    . "${SCRIPT_DIR}/lib/host-identity.sh"
+    local _hn; _hn="$(catalyst_host_name)"
+    export CATALYST_HOST_NAME="$_hn"
+  fi
+
+  # 5. Launch detached. Prefer the launcher (resolves node name + daemon log
+  #    paths in one place); fall back to a bare `alloy run` if it's absent.
+  log "starting log-shipper (alloy) (config: $SHIPPER_CONFIG, log: $SHIPPER_LOG, node: ${CATALYST_HOST_NAME:-<os-hostname>})"
+  mkdir -p "$SHIPPER_STORAGE"
+  if [[ -f "$SHIPPER_LAUNCHER" ]]; then
+    nohup bash "$SHIPPER_LAUNCHER" --config "$SHIPPER_CONFIG" --storage "$SHIPPER_STORAGE" >"$SHIPPER_LOG" 2>&1 &
+  else
+    nohup alloy run "$SHIPPER_CONFIG" --storage.path "$SHIPPER_STORAGE" >"$SHIPPER_LOG" 2>&1 &
+  fi
+  echo $! > "$SHIPPER_PID"
+  disown $! 2>/dev/null || true
+  sleep 1
+  pid="$(shipper_pid)"
+  if pid_alive "$pid"; then
+    log "  → log-shipper started (pid $pid)"
+  else
+    warn "alloy failed to start — see $SHIPPER_LOG"
+    return 1
+  fi
+}
+
+stop_shipper() {
+  local pid; pid="$(shipper_pid)"
+  if pid_alive "$pid"; then
+    log "stopping log-shipper (alloy) (pid $pid)"
+    kill "$pid" 2>/dev/null
+    sleep 1
+    pid_alive "$pid" && kill -9 "$pid" 2>/dev/null || true
+  else
+    log "log-shipper not running"
+  fi
+  rm -f "$SHIPPER_PID"
 }
 
 start_broker()   { catalyst-broker start 2>&1 | sed 's/^/  /'; }
@@ -453,6 +554,13 @@ cmd_start() {
   start_broker
   start_daemon "$use_proxy"
   start_forward
+  # CTL-1263: the log-shipper comes up LAST — it only tails the daemons' .log
+  # files, so it should start after the daemons it observes. start_shipper is
+  # idempotent + non-fatal (warns loudly on a missing binary, returns 1) so the
+  # CTL-1166 launchd keep-alive resurrects a crashed shipper on its interval
+  # without disturbing the other (already-running, independently-idempotent)
+  # daemons.
+  start_shipper || warn "continuing without log-shipper (daemon logs won't be shipped to Loki)"
 
   log ""
   log "stack up — current state:"
@@ -460,6 +568,8 @@ cmd_start() {
 }
 
 cmd_stop() {
+  # Reverse of start order: the shipper started last, so stop it first.
+  stop_shipper
   stop_daemon
   stop_forward
   stop_monitor
@@ -499,6 +609,8 @@ cmd_status() {
   echo -n "  monitor          "; catalyst-monitor status 2>&1 | head -1
   echo -n "  execution-core   "; catalyst-execution-core status 2>&1 | head -1
   echo -n "  otel-forward     "; catalyst-monitor forward-status 2>&1 | head -1
+  local sp; sp="$(shipper_pid)"
+  if pid_alive "$sp"; then echo "  log-shipper      running  pid=$sp"; else echo "  log-shipper      stopped"; fi
 
   # CTL-1084: governance section from the last node.boot event.
   local boot_json

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -69,6 +69,7 @@ OPT_TOOLS=(
     "direnv:direnv"
     "smee:smee-client (webhook tunnel)"
     "mitmproxy:mitmproxy (optional — only needed for catalyst-stack --proxy)"
+    "alloy:Grafana Alloy (log-shipper — installed by install-cli.sh)"
 )
 
 for spec in "${OPT_TOOLS[@]}"; do
@@ -490,6 +491,47 @@ else
     else
         info "Start with: bash plugins/dev/scripts/catalyst-monitor.sh start"
     fi
+fi
+
+# ─── 7b2. Log Shipper (Grafana Alloy) (optional) ───────────────────────────
+# CTL-1263: verify the off-the-shelf Alloy daemon-log shipper is installed +
+# configured + (best-effort) running, consistent with the other daemon checks.
+# Warn/info-level only so a fresh node / non-running shipper never reds the
+# whole health check.
+
+header "Log Shipper (Alloy)"
+
+# Config present — resolve the same way the monitor launcher above is resolved.
+SHIPPER_CONFIG_PATH=""
+if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -f "${CLAUDE_PLUGIN_ROOT}/scripts/log-shipper/config.alloy" ]]; then
+    SHIPPER_CONFIG_PATH="${CLAUDE_PLUGIN_ROOT}/scripts/log-shipper/config.alloy"
+elif [[ -f "plugins/dev/scripts/log-shipper/config.alloy" ]]; then
+    SHIPPER_CONFIG_PATH="plugins/dev/scripts/log-shipper/config.alloy"
+fi
+if [[ -n "$SHIPPER_CONFIG_PATH" ]]; then
+    pass "Shipper config present ($SHIPPER_CONFIG_PATH)"
+else
+    warn "Shipper config (log-shipper/config.alloy) not found — set CLAUDE_PLUGIN_ROOT or run from the repo root"
+fi
+
+# Binary present.
+if command -v alloy &>/dev/null; then
+    pass "alloy installed ($(command -v alloy))"
+else
+    warn "alloy not found — run install-cli.sh (installs Grafana Alloy)"
+fi
+
+# Running (best-effort) — read catalyst-stack's pid file.
+SHIPPER_PID_FILE="$CATALYST_DIR/alloy.pid"
+if [[ -f "$SHIPPER_PID_FILE" ]]; then
+    SHIPPER_PID_VAL="$(cat "$SHIPPER_PID_FILE" 2>/dev/null || true)"
+    if [[ -n "$SHIPPER_PID_VAL" ]] && kill -0 "$SHIPPER_PID_VAL" 2>/dev/null; then
+        pass "log-shipper running (pid $SHIPPER_PID_VAL)"
+    else
+        info "log-shipper not running — starts with: catalyst-stack start"
+    fi
+else
+    info "log-shipper not running — starts with: catalyst-stack start"
 fi
 
 # ─── 7c. Execution-core Daemon Env / Proxy Audit (optional) ────────────────

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -148,6 +148,78 @@ done
 
 BIN_DIR="$(resolve_bin_dir)"
 
+# ensure_alloy — install the Grafana Alloy binary when absent (CTL-1263).
+#
+# Alloy is the off-the-shelf daemon-log shipper (config at
+# plugins/dev/scripts/log-shipper/config.alloy, CTL-1261). catalyst-stack's
+# start_shipper step launches it; this function makes sure the binary is present
+# on every host install-cli runs on (every node — install-cli is a join stage).
+#
+# Mirrors catalyst-join.sh's ensure_gh exactly: brew on Darwin, GitHub-release
+# download otherwise (arch/OS detect → ~/.local/bin → verify on PATH). It is
+# IDEMPOTENT (no-op if alloy is already on PATH) and WARN+CONTINUE: it never
+# returns non-zero to its caller, because install-cli must never exit non-zero
+# just because the optional log-shipper binary could not be installed (e.g. a
+# headless Linux box with no brew and a flaky GitHub download).
+ensure_alloy() {
+  command -v alloy >/dev/null 2>&1 && return 0
+
+  # Prefer brew on Darwin (matches the log-shipper README's documented install).
+  if [[ "$(uname -s)" == "Darwin" ]] && command -v brew >/dev/null 2>&1; then
+    echo "  Installing Grafana Alloy via brew (log-shipper binary, CTL-1263)…"
+    if brew install grafana-alloy >/dev/null 2>&1 && command -v alloy >/dev/null 2>&1; then
+      echo "  Installed alloy ($(command -v alloy))"
+      return 0
+    fi
+    echo "  warning: 'brew install grafana-alloy' failed — log-shipper will not start until alloy is installed" >&2
+    return 0
+  fi
+
+  # Non-Darwin (or no brew): direct GitHub-release download, mirroring ensure_gh.
+  if ! { command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; }; then
+    echo "  warning: cannot install alloy (need curl + jq) — log-shipper will not start until alloy is installed" >&2
+    return 0
+  fi
+  local os arch alloy_os ver tmp asset url
+  os="$(uname -s)"; arch="$(uname -m)"
+  case "$arch" in arm64 | aarch64) arch="arm64" ;; x86_64 | amd64) arch="amd64" ;; esac
+  case "$os" in Darwin) alloy_os="darwin" ;; Linux) alloy_os="linux" ;; *) alloy_os="" ;; esac
+  if [[ -z "$alloy_os" ]]; then
+    echo "  warning: unsupported OS for alloy auto-install ($os) — install Grafana Alloy manually" >&2
+    return 0
+  fi
+  ver="$(curl -fsSL https://api.github.com/repos/grafana/alloy/releases/latest 2>/dev/null | jq -r '.tag_name // empty')"
+  if [[ -z "$ver" ]]; then
+    echo "  warning: could not resolve latest Grafana Alloy release — log-shipper will not start until alloy is installed" >&2
+    return 0
+  fi
+  mkdir -p "$HOME/.local/bin"; tmp="$(mktemp -d)"
+  # Alloy release assets are named alloy-<os>-<arch>; darwin ships zipped, linux gzipped.
+  echo "  Installing Grafana Alloy ${ver} → ~/.local/bin (log-shipper binary, CTL-1263)…"
+  if [[ "$alloy_os" == "darwin" ]]; then
+    asset="alloy-darwin-${arch}.zip"
+    url="https://github.com/grafana/alloy/releases/download/${ver}/${asset}"
+    if curl -fsSL "$url" -o "$tmp/alloy.zip" 2>/dev/null && unzip -q "$tmp/alloy.zip" -d "$tmp" 2>/dev/null; then
+      cp "$tmp/alloy-darwin-${arch}" "$HOME/.local/bin/alloy" 2>/dev/null || true
+    fi
+  else
+    asset="alloy-linux-${arch}.zip"
+    url="https://github.com/grafana/alloy/releases/download/${ver}/${asset}"
+    if curl -fsSL "$url" -o "$tmp/alloy.zip" 2>/dev/null && unzip -q "$tmp/alloy.zip" -d "$tmp" 2>/dev/null; then
+      cp "$tmp/alloy-linux-${arch}" "$HOME/.local/bin/alloy" 2>/dev/null || true
+    fi
+  fi
+  chmod +x "$HOME/.local/bin/alloy" 2>/dev/null || true
+  rm -rf "$tmp"
+  export PATH="$HOME/.local/bin:$PATH"
+  if command -v alloy >/dev/null 2>&1; then
+    echo "  Installed alloy ($(command -v alloy))"
+  else
+    echo "  warning: alloy install failed (download/extract) — log-shipper will not start until alloy is installed" >&2
+  fi
+  return 0
+}
+
 if [[ "$mode" = "uninstall" ]]; then
   if [[ -d "$BIN_DIR" ]]; then
     for entry in "${CLI_ENTRIES[@]}"; do
@@ -433,6 +505,12 @@ EOF
 }
 
 detect_stale_aliases
+
+# Provision the Grafana Alloy log-shipper binary (CTL-1263). Non-fatal by design
+# (warn+continue): a missing/failed Alloy install must never make install-cli
+# exit non-zero, since the shipper is optional infra and catalyst-stack's
+# start_shipper degrades loudly-but-gracefully when alloy is absent.
+ensure_alloy || true
 
 # PATH bootstrap — if BIN_DIR is not on PATH, append an export line to the
 # user's shell rc file. Idempotent: a marker comment guards against duplicate

--- a/plugins/dev/scripts/log-shipper/launch.sh
+++ b/plugins/dev/scripts/log-shipper/launch.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# log-shipper/launch.sh — resolve the per-host environment and exec Grafana Alloy
+# against config.alloy (CTL-1263, launcher for the CTL-1261 shipper config).
+#
+# WHY A LAUNCHER
+#   config.alloy (CTL-1261) is a stock Alloy config that tails the four Catalyst
+#   daemon .log files and ships them OTLP/HTTP to the shared collector. It reads
+#   its node identity + per-file paths from environment variables because River
+#   cannot read the Layer-2 JSON config or compute the first-DNS-label reduction
+#   itself. This launcher is the one place that resolves them — using the EXACT
+#   getHostName() precedence — and then exec's Alloy.
+#
+#   catalyst-stack's start_shipper step calls this launcher (it owns the pid file,
+#   log redirection, and idempotency). You can also run it by hand for a smoke
+#   test; it exec's Alloy in the foreground.
+#
+# NODE NAME (load-bearing — see config.alloy "HOST TAGGING")
+#   CATALYST_HOST_NAME is resolved via lib/host-identity.sh's catalyst_host_name():
+#       CATALYST_HOST_NAME env
+#         -> catalyst.host.name in Layer-2 ~/.config/catalyst/config.json
+#         -> os.hostname() reduced to its first DNS label
+#   This is getHostName() semantics exactly and is NEVER the Tailscale device
+#   name (RyansMini250233 != mini). config.alloy reads CATALYST_HOST_NAME for its
+#   catalyst.host.name resource attribute.
+#
+# Usage:
+#   log-shipper/launch.sh [--storage <dir>] [--config <path>] [-- <extra alloy args>]
+#
+# Env (all optional; sensible defaults):
+#   CATALYST_DIR              catalyst home (default ~/catalyst)
+#   CATALYST_HOST_NAME        stable node name (else resolved as above)
+#   CATALYST_OTLP_ENDPOINT    collector OTLP/HTTP base (config.alloy default applies)
+#   CATALYST_ALLOY_STORAGE    Alloy storage.path (default $CATALYST_DIR/alloy-data)
+#   CATALYST_ALLOY_CONFIG     config path (default this dir's config.alloy)
+
+set -uo pipefail
+
+# ─── SCRIPT_DIR (symlink-walking) ────────────────────────────────────────────
+_SRC="${BASH_SOURCE[0]}"
+while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
+SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
+unset _SRC
+
+log()  { printf '[log-shipper] %s\n' "$*"; }
+warn() { printf '[log-shipper] WARN: %s\n' "$*" >&2; }
+fail() { printf '[log-shipper] ERROR: %s\n' "$*" >&2; exit 1; }
+
+CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
+
+# ─── Arg parsing ─────────────────────────────────────────────────────────────
+STORAGE="${CATALYST_ALLOY_STORAGE:-${CATALYST_DIR}/alloy-data}"
+CONFIG="${CATALYST_ALLOY_CONFIG:-${SCRIPT_DIR}/config.alloy}"
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --storage) STORAGE="${2:?--storage needs a value}"; shift 2 ;;
+    --config)  CONFIG="${2:?--config needs a value}"; shift 2 ;;
+    --)        shift; EXTRA_ARGS=("$@"); break ;;
+    -h | --help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) fail "unknown arg: $1 (try: --storage <dir> | --config <path> | -- <extra alloy args>)" ;;
+  esac
+done
+
+# ─── Preflight ───────────────────────────────────────────────────────────────
+command -v alloy >/dev/null 2>&1 \
+  || fail "alloy not found on PATH — install it: bash \"${SCRIPT_DIR}/../install-cli.sh\" (installs Grafana Alloy), or 'brew install grafana-alloy'"
+[[ -f "$CONFIG" ]] || fail "config not found at $CONFIG"
+
+# ─── Resolve the stable node name (getHostName() semantics) ──────────────────
+# shellcheck source=../lib/host-identity.sh
+if [[ -f "${SCRIPT_DIR}/../lib/host-identity.sh" ]]; then
+  . "${SCRIPT_DIR}/../lib/host-identity.sh"
+  _hn="$(catalyst_host_name)"
+  export CATALYST_HOST_NAME="$_hn"
+else
+  warn "lib/host-identity.sh missing — config.alloy will fall back to the OS hostname for catalyst.host.name"
+fi
+
+# ─── Export the absolute, $HOME-resolved daemon log paths (config defaults are a
+#     last-resort fallback; the launcher is the authoritative source). ─────────
+export CATALYST_BROKER_LOG="${CATALYST_BROKER_LOG:-${CATALYST_DIR}/broker.log}"
+export CATALYST_DAEMON_LOG="${CATALYST_DAEMON_LOG:-${CATALYST_DIR}/execution-core/daemon.log}"
+export CATALYST_OTEL_FORWARD_LOG="${CATALYST_OTEL_FORWARD_LOG:-${CATALYST_DIR}/otel-forward.log}"
+export CATALYST_MONITOR_LOG="${CATALYST_MONITOR_LOG:-${CATALYST_DIR}/monitor.log}"
+
+mkdir -p "$STORAGE"
+
+log "starting alloy (node=${CATALYST_HOST_NAME:-<os-hostname>}, config=$CONFIG, storage=$STORAGE)"
+exec alloy run "$CONFIG" --storage.path "$STORAGE" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}


### PR DESCRIPTION
## Summary
Integrates the off-the-shelf **Grafana Alloy** daemon-log shipper (config from CTL-1261 / #2243, `log-shipper/config.alloy`) into the per-host daemon lifecycle so it is **installed, registered, and auto-started on every node** — including mini and mini-2 — **with no disruptive full-stack restart**.

Closes the gap from the CTL-1261 config-only PR: that added the config; this makes it actually install + run.

## What changed
- **`install-cli.sh`** — `ensure_alloy` installs the Alloy binary when absent (brew on Darwin, GitHub-release download otherwise; arch/OS detect; idempotent; warn+continue, never hard-fails). install-cli is a join stage → every joined node gets the binary.
- **`catalyst-stack`** — `start_shipper` launches Alloy via `log-shipper/launch.sh` with its own pid/log/storage; **idempotent** (pid-reuse-guarded, never double-starts, self-heals a crash) so the CTL-1166 launchd stack-agent brings it up on boot + on its interval **without restarting the other daemons**; **loud-fails** with the install command if the binary is missing.
- **`check-setup.sh`** — a Log Shipper (Alloy) section verifies binary + config (warn-level).
- **`catalyst-join.sh`** — a joined node inherits the shipper via `ensure_alloy`; warns if absent.
- **`log-shipper/launch.sh`** (new) — resolves the stable node name via `lib/host-identity.sh` (`getHostName()` precedence, never the Tailscale device name) and exec's Alloy against `config.alloy`.

## Fence
Touches **none** of the cluster-membership/liveness files under active parallel work (`scheduler.mjs`, `server.ts`, `cluster-*`, etc.).

## How to verify on a host
1. `install-cli.sh` (or `catalyst-join.sh`) → `alloy` on PATH.
2. `catalyst-stack start` → `alloy.pid` live, `alloy.log` healthy; re-running `start` is a no-op (idempotent), other daemons untouched.
3. Loki shows `{service_name=~"catalyst.*"}` **log** streams from the daemon `.log` files, tagged with `host.name` + `catalyst.host.name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)