### PR TITLE
CTL-1273: The fleet roster lives on the Linear cluster anchor (single source)

### DIFF
--- a/plugins/dev/scripts/execution-core/cli-cluster.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli-cluster.test.mjs
@@ -85,13 +85,14 @@ describe("buildStatus (CTL-1188)", () => {
 
 // ── addHost ────────────────────────────────────────────────────────────────
 
-describe("addHost", () => {
+describe("addHost (legacy hosts-fallback path, anchor:null)", () => {
   test("appends a new name and commits", () => {
     withRoster(["mini"], (hostsPath, read) => {
       const committed = [];
       const r = addHost("mac-studio", {
         hostsPath,
         self: "mini",
+        anchor: null,
         readPeers: () => ({}),
         git: (args) => committed.push(args),
         commit: true,
@@ -104,7 +105,7 @@ describe("addHost", () => {
 
   test("idempotent: name already in roster → code 2, no write", () => {
     withRoster(["mini"], (hostsPath, read) => {
-      const r = addHost("mini", { hostsPath, self: "mini", readPeers: () => ({}) });
+      const r = addHost("mini", { hostsPath, self: "mini", anchor: null, readPeers: () => ({}) });
       expect(r.code).toBe(2);
       expect(read()).toEqual(["mini"]);
     });
@@ -115,6 +116,7 @@ describe("addHost", () => {
       const r = addHost("ghost", {
         hostsPath,
         self: "mini",
+        anchor: null,
         readPeers: () => ({ ghost: { host: "ghost", last_seen: "2026-06-16T12:00:00Z" } }),
       });
       expect(r.code).toBe(2);
@@ -128,6 +130,7 @@ describe("addHost", () => {
       const r = addHost("mac-studio", {
         hostsPath,
         self: "mini",
+        anchor: null,
         readPeers: () => ({}),
         git,
         commit: false,
@@ -139,7 +142,62 @@ describe("addHost", () => {
 
   test("missing name → code 2", () => {
     withRoster(["mini"], (hostsPath) => {
-      const r = addHost("", { hostsPath, self: "mini", readPeers: () => ({}) });
+      const r = addHost("", { hostsPath, self: "mini", anchor: null, readPeers: () => ({}) });
+      expect(r.code).toBe(2);
+    });
+  });
+});
+
+// CTL-1273: the anchor writer path — add/remove write the catalyst://node/<name>
+// enrollment record on the SAME anchor the resolver reads. registerNode /
+// deregisterNode are injected so nothing touches Linear.
+describe("addHost (anchor writer path, CTL-1273)", () => {
+  test("registers the node on the anchor and does NOT touch hosts.json", () => {
+    withRoster(["mini"], (hostsPath, read) => {
+      const calls = [];
+      const r = addHost("mini-2", {
+        hostsPath,
+        self: "mini",
+        anchor: "CTL-1090",
+        address: "mini-2.rozich.com",
+        registerNode: (args) => {
+          calls.push(args);
+          return { ok: true };
+        },
+        readPeers: () => ({}),
+        git: () => { throw new Error("anchor path must not git-commit hosts.json"); },
+      });
+      expect(r.code).toBe(0);
+      expect(r.source).toBe("anchor");
+      expect(calls[0]).toEqual({ anchorIssue: "CTL-1090", name: "mini-2", address: "mini-2.rozich.com" });
+      // hosts.json untouched — the anchor is the single source of truth
+      expect(read()).toEqual(["mini"]);
+    });
+  });
+
+  test("registerNode failure → code 1 with a diagnostic message", () => {
+    withRoster(["mini"], (hostsPath) => {
+      const r = addHost("mini-2", {
+        hostsPath,
+        self: "mini",
+        anchor: "CTL-1090",
+        registerNode: () => ({ ok: false, error: "exit 1: Linear 401" }),
+        readPeers: () => ({}),
+      });
+      expect(r.code).toBe(1);
+      expect(r.msg).toContain("401");
+    });
+  });
+
+  test("still refuses a name already publishing a live heartbeat on the anchor path", () => {
+    withRoster(["mini"], (hostsPath) => {
+      const r = addHost("ghost", {
+        hostsPath,
+        self: "mini",
+        anchor: "CTL-1090",
+        registerNode: () => { throw new Error("must not register a live-heartbeat name"); },
+        readPeers: () => ({ ghost: { host: "ghost", last_seen: "2026-06-16T12:00:00Z" } }),
+      });
       expect(r.code).toBe(2);
     });
   });
@@ -147,12 +205,13 @@ describe("addHost", () => {
 
 // ── removeHost ─────────────────────────────────────────────────────────────
 
-describe("removeHost", () => {
+describe("removeHost (legacy hosts-fallback path, anchor:null)", () => {
   test("removes a non-self name and commits", () => {
     withRoster(["mini", "mac-studio"], (hostsPath, read) => {
       const r = removeHost("mac-studio", {
         hostsPath,
         self: "mini",
+        anchor: null,
         inFlightCount: () => 0,
         git: () => {},
         commit: true,
@@ -167,6 +226,7 @@ describe("removeHost", () => {
       const r = removeHost("mini", {
         hostsPath,
         self: "mini",
+        anchor: null,
         inFlightCount: () => 2,
       });
       expect(r.code).toBe(2);
@@ -179,6 +239,7 @@ describe("removeHost", () => {
       const r = removeHost("mini", {
         hostsPath,
         self: "mini",
+        anchor: null,
         inFlightCount: () => 0,
         git: () => {},
         commit: false,
@@ -190,14 +251,77 @@ describe("removeHost", () => {
 
   test("name not in roster → code 2", () => {
     withRoster(["mini"], (hostsPath) => {
-      const r = removeHost("nope", { hostsPath, self: "mini", inFlightCount: () => 0 });
+      const r = removeHost("nope", { hostsPath, self: "mini", anchor: null, inFlightCount: () => 0 });
       expect(r.code).toBe(2);
     });
   });
 
   test("missing name → code 2", () => {
     withRoster(["mini"], (hostsPath) => {
-      const r = removeHost("", { hostsPath, self: "mini", inFlightCount: () => 0 });
+      const r = removeHost("", { hostsPath, self: "mini", anchor: null, inFlightCount: () => 0 });
+      expect(r.code).toBe(2);
+    });
+  });
+});
+
+describe("removeHost (anchor writer path, CTL-1273)", () => {
+  test("deregisters the node on the anchor and does NOT touch hosts.json", () => {
+    withRoster(["mini", "mini-2"], (hostsPath, read) => {
+      const calls = [];
+      const r = removeHost("mini-2", {
+        hostsPath,
+        self: "mini",
+        anchor: "CTL-1090",
+        deregisterNode: (args) => {
+          calls.push(args);
+          return { ok: true, removed: true };
+        },
+        inFlightCount: () => 0,
+        git: () => { throw new Error("anchor path must not git-commit hosts.json"); },
+      });
+      expect(r.code).toBe(0);
+      expect(r.source).toBe("anchor");
+      expect(calls[0]).toEqual({ anchorIssue: "CTL-1090", name: "mini-2" });
+      expect(read()).toEqual(["mini", "mini-2"]); // hosts.json untouched
+    });
+  });
+
+  test("absent node on the anchor → code 2 (not in roster)", () => {
+    withRoster(["mini"], (hostsPath) => {
+      const r = removeHost("ghost", {
+        hostsPath,
+        self: "mini",
+        anchor: "CTL-1090",
+        deregisterNode: () => ({ ok: true, removed: false }),
+        inFlightCount: () => 0,
+      });
+      expect(r.code).toBe(2);
+    });
+  });
+
+  test("deregisterNode failure → code 1 with a diagnostic message", () => {
+    withRoster(["mini"], (hostsPath) => {
+      const r = removeHost("mini-2", {
+        hostsPath,
+        self: "mini",
+        anchor: "CTL-1090",
+        deregisterNode: () => ({ ok: false, error: "exit 1: boom" }),
+        inFlightCount: () => 0,
+      });
+      expect(r.code).toBe(1);
+      expect(r.msg).toContain("boom");
+    });
+  });
+
+  test("still refuses removing self while in-flight > 0 on the anchor path", () => {
+    withRoster(["mini"], (hostsPath) => {
+      const r = removeHost("mini", {
+        hostsPath,
+        self: "mini",
+        anchor: "CTL-1090",
+        deregisterNode: () => { throw new Error("must not deregister self with in-flight work"); },
+        inFlightCount: () => 3,
+      });
       expect(r.code).toBe(2);
     });
   });

--- a/plugins/dev/scripts/execution-core/cli/cluster.mjs
+++ b/plugins/dev/scripts/execution-core/cli/cluster.mjs
@@ -17,6 +17,7 @@ import {
   readClusterConfig,
 } from "../config.mjs";
 import { readPeerHeartbeatsSync } from "../cluster-heartbeat-sync.mjs";
+import { registerNodeSync, deregisterNodeSync } from "../node-roster-sync.mjs"; // CTL-1273: anchor writer
 import { writeSecretConfig } from "../write-secret-config.mjs";
 import { listInFlightTickets } from "../scheduler.mjs";
 import { clusterSync } from "../cluster-sync.mjs";
@@ -97,37 +98,62 @@ export function runStatus(argv = []) {
 export function addHost(name, {
   hostsPath,
   self,
+  // CTL-1273: when an anchor is configured the node enrollment record is written
+  // to the SAME anchor the resolver reads (getClusterHosts → resolveClusterHosts
+  // 'anchor' source) — reader and writer share one source, so the old
+  // reader/writer divergence is structurally impossible. When no anchor is set,
+  // fall back to the legacy committed .catalyst/hosts.json (migration fallback).
+  anchor = getLivenessAnchorIssue(),
+  address = null,
+  registerNode = registerNodeSync,
   readPeers = () => readPeerHeartbeatsSync({ anchorIssue: getLivenessAnchorIssue() }),
   git = defaultGit,
   commit = true,
 } = {}) {
   if (!name) return { code: 2, msg: "add requires <name>" };
-  const roster = readRoster(hostsPath);
-  if (roster.includes(name)) return { code: 2, msg: `'${name}' already in roster` };
   const peers = readPeers();
   if (peers[name]?.last_seen) {
     return { code: 2, msg: `'${name}' is already publishing a live heartbeat` };
   }
+
+  // Anchor path: upsert the catalyst://node/<name> enrollment record.
+  if (anchor) {
+    const res = registerNode({ anchorIssue: anchor, name, address });
+    if (!res?.ok) {
+      return { code: 1, msg: `failed to register '${name}' on anchor ${anchor}: ${res?.error ?? "unknown"}` };
+    }
+    return { code: 0, name, source: "anchor", anchorUnset: false };
+  }
+
+  // Legacy fallback: append to the committed .catalyst/hosts.json.
+  const roster = readRoster(hostsPath);
+  if (roster.includes(name)) return { code: 2, msg: `'${name}' already in roster` };
   const next = [...roster, name];
   writeRosterAtomic(hostsPath, next);
   if (commit) gitCommitRoster(git, hostsPath, `chore(cluster): add ${name} to roster`);
-  const anchorUnset = Object.keys(peers).length === 0 && !getLivenessAnchorIssue();
-  return { code: 0, roster: next, anchorUnset };
+  return { code: 0, roster: next, source: "hosts-fallback", anchorUnset: true };
 }
 
 export function runAdd(argv = []) {
   const noCommit = argv.includes("--no-commit");
-  const name = argv.filter((a) => !a.startsWith("-"))[0];
+  const positional = argv.filter((a) => !a.startsWith("-"));
+  const name = positional[0];
+  const address = positional[1] ?? null; // optional <address> for HRW re-homing
   const res = addHost(name, {
     hostsPath: getCatalystRepoDirHostsPath(),
     self: getHostName(),
+    address,
     commit: !noCommit,
   });
   if (res.code !== 0) {
     process.stderr.write(`catalyst cluster add: ${res.msg}\n`);
     return res.code;
   }
-  process.stdout.write(`Added '${name}' to roster: [${res.roster.join(", ")}]\n`);
+  if (res.source === "anchor") {
+    process.stdout.write(`Enrolled '${name}' on the cluster anchor.\n`);
+  } else {
+    process.stdout.write(`Added '${name}' to roster: [${res.roster.join(", ")}]\n`);
+  }
   process.stdout.write("Takes effect live (next scheduler tick).\n");
   if (res.anchorUnset) {
     process.stderr.write(
@@ -142,21 +168,38 @@ export function runAdd(argv = []) {
 export function removeHost(name, {
   hostsPath,
   self,
+  // CTL-1273: delete the enrollment record from the SAME anchor the resolver
+  // reads when one is configured; else fall back to the legacy committed
+  // .catalyst/hosts.json (migration fallback).
+  anchor = getLivenessAnchorIssue(),
+  deregisterNode = deregisterNodeSync,
   inFlightCount = () => 0,
   git = defaultGit,
   commit = true,
 } = {}) {
   if (!name) return { code: 2, msg: "remove requires <name>" };
-  const roster = readRoster(hostsPath);
-  if (!roster.includes(name)) return { code: 2, msg: `'${name}' not in roster` };
   const count = inFlightCount();
   if (name === self && count > 0) {
     return { code: 2, msg: `refusing to remove self while ${count} ticket(s) in flight` };
   }
+
+  // Anchor path: delete the catalyst://node/<name> enrollment record.
+  if (anchor) {
+    const res = deregisterNode({ anchorIssue: anchor, name });
+    if (!res?.ok) {
+      return { code: 1, msg: `failed to deregister '${name}' on anchor ${anchor}: ${res?.error ?? "unknown"}` };
+    }
+    if (!res.removed) return { code: 2, msg: `'${name}' not in roster` };
+    return { code: 0, name, source: "anchor" };
+  }
+
+  // Legacy fallback: remove from the committed .catalyst/hosts.json.
+  const roster = readRoster(hostsPath);
+  if (!roster.includes(name)) return { code: 2, msg: `'${name}' not in roster` };
   const next = roster.filter((h) => h !== name);
   writeRosterAtomic(hostsPath, next);
   if (commit) gitCommitRoster(git, hostsPath, `chore(cluster): remove ${name} from roster`);
-  return { code: 0, roster: next };
+  return { code: 0, roster: next, source: "hosts-fallback" };
 }
 
 export function runRemove(argv = []) {
@@ -173,7 +216,11 @@ export function runRemove(argv = []) {
     process.stderr.write(`catalyst cluster remove: ${res.msg}\n`);
     return res.code;
   }
-  process.stdout.write(`Removed '${name}' from roster: [${res.roster.join(", ")}]\n`);
+  if (res.source === "anchor") {
+    process.stdout.write(`Deregistered '${name}' from the cluster anchor.\n`);
+  } else {
+    process.stdout.write(`Removed '${name}' from roster: [${res.roster.join(", ")}]\n`);
+  }
   process.stdout.write("Takes effect live (next scheduler tick).\n");
   return 0;
 }

--- a/plugins/dev/scripts/execution-core/config-pino-fallback.test.mjs
+++ b/plugins/dev/scripts/execution-core/config-pino-fallback.test.mjs
@@ -42,6 +42,10 @@ function stageScratch() {
   // (The point of the fixture is that PINO is unresolvable; local siblings must
   // still resolve, so any new sibling import config.mjs gains belongs here.)
   cpSync(resolve(__dirname, "config-schema.mjs"), join(scratch, "config-schema.mjs"));
+  // CTL-1273: config.mjs now also imports the dep-free sibling node-roster-sync.mjs
+  // (node: built-ins only; it path-computes node-roster.mjs but never imports it at
+  // load), so the scratch fixture must resolve that sibling too.
+  cpSync(resolve(__dirname, "node-roster-sync.mjs"), join(scratch, "node-roster-sync.mjs"));
   // type:module + no deps -> pino unresolvable from this directory tree.
   writeFileSync(
     join(scratch, "package.json"),

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -14,6 +14,10 @@ import { readFileSync, existsSync } from "node:fs";
 // dep-free sibling leaf, so this import cannot reintroduce the bun-install crash
 // risk the pino try/catch below guards against.
 import { schemaCompat } from "./config-schema.mjs";
+// CTL-1273: synchronous cluster-anchor roster reader. node-roster-sync.mjs imports
+// only Node builtins (it spawnSync's the async node-roster CLI), so it is a
+// dep-free sibling leaf — same no-bun-install-risk property as config-schema.mjs.
+import { readNodeNamesSync } from "./node-roster-sync.mjs";
 
 // --- Logger (CTL-578) ---
 // Pino is the daemon's runtime logger. A worktree checkout that hasn't run
@@ -211,25 +215,45 @@ export function getHostName() {
   return dot === -1 ? base : base.slice(0, dot);
 }
 
-// getClusterHosts — read the committed cluster roster from
-// <repoRoot>/.catalyst/hosts.json (a JSON array of host names). When the file
-// is absent, unreadable, malformed, or not a non-empty array of strings, fall
-// back to the single-host default ([getHostName()]) — the safe behavior for the
-// current single-primary deployment. Never throws.
-export function getClusterHosts() {
-  // CTL-1211: cluster-repo-first. Prefer the control-plane repo's roster
-  // (cluster.json.roster); fall back to the project repo's committed hosts.json;
-  // then the single-host default. A cluster.json whose schemaVersion is newer
-  // than this stack supports is ignored here (degrade to the project roster)
-  // rather than trusted blindly. getCatalystRepoDirHostsPath (the CLI write
-  // target) is deliberately NOT changed, so add/remove writes still land on the
-  // project repo and the reader/writer can never silently diverge.
+// getStaticRoster — the `static` escape-hatch roster (CTL-1273). A multi-host
+// operator who does NOT want the Linear anchor can pin an explicit node list in
+// the Layer-2 machine-local config under catalyst.cluster.staticRoster (a JSON
+// array of host names). Returns the filtered non-empty array, or null when
+// unset/empty/malformed. Never throws. CATALYST_STATIC_ROSTER (a comma-separated
+// list) overrides for tests. NOT committed (machine-local per CLAUDE.md).
+export function getStaticRoster() {
+  const env = process.env.CATALYST_STATIC_ROSTER;
+  if (typeof env === "string" && env.length > 0) {
+    const hosts = env
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (hosts.length > 0) return hosts;
+  }
+  try {
+    const raw = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))
+      ?.catalyst?.cluster?.staticRoster;
+    if (Array.isArray(raw)) {
+      const hosts = raw.filter((h) => typeof h === "string" && h.length > 0);
+      if (hosts.length > 0) return hosts;
+    }
+  } catch {
+    /* missing/malformed → null */
+  }
+  return null;
+}
+
+// readHostsFallbackRoster — the LEGACY migration-fallback roster (CTL-1273): the
+// CTL-1211 cluster-repo cluster.json.roster, then the per-repo
+// .catalyst/hosts.json. This is the lowest-priority real source — the safety net
+// until a later ticket deletes the files + adds the guard. Returns the filtered
+// non-empty array, or null when neither yields a roster. Never throws.
+function readHostsFallbackRoster() {
+  // CTL-1211: cluster-repo-first within the fallback. A cluster.json whose
+  // schemaVersion is newer than this stack supports is ignored (degrade to the
+  // project roster) rather than trusted blindly.
   const cluster = readClusterConfig();
-  if (
-    cluster &&
-    schemaCompat(cluster.schemaVersion) !== "too-new" &&
-    Array.isArray(cluster.roster)
-  ) {
+  if (cluster && schemaCompat(cluster.schemaVersion) !== "too-new" && Array.isArray(cluster.roster)) {
     const hosts = cluster.roster.filter((h) => typeof h === "string" && h.length > 0);
     if (hosts.length > 0) return hosts;
   }
@@ -241,9 +265,63 @@ export function getClusterHosts() {
       if (hosts.length > 0) return hosts;
     }
   } catch {
-    /* absent/malformed roster → single-host default */
+    /* absent/malformed roster → null */
   }
-  return [getHostName()];
+  return null;
+}
+
+// resolveClusterHosts — the single roster-resolution seam (CTL-1273). Returns
+// { hosts, source, multiHost } so callers (getClusterHosts + the daemon boot
+// assertion) share ONE precedence. Precedence:
+//   1. 'anchor'         — the Linear cluster anchor's node-registration records,
+//                         when an anchor is configured (getLivenessAnchorIssue)
+//                         AND the read succeeds with a non-empty roster.
+//   2. 'static'         — an explicit catalyst.cluster.staticRoster in Layer-2.
+//   3. 'hosts-fallback' — the legacy cluster.json / .catalyst/hosts.json
+//                         (MIGRATION FALLBACK — kept until a later ticket removes
+//                         the files + adds the guard).
+//   4. 'single-host'    — [getHostName()] when nothing else resolves.
+// FAIL-OPEN: an anchor read error (sync.ok === false) falls through to the next
+// source — it NEVER empties the roster (which would mass-evict the fleet under
+// HRW). A single-host install with no anchor + no static + no hosts file makes
+// NO Linear call. Re-read per call so a live add/remove is honored next tick.
+// `readNodeNames` is injectable for hermetic tests (no spawnSync in unit tests).
+export function resolveClusterHosts({ readNodeNames = readNodeNamesSync } = {}) {
+  // 1. Linear cluster anchor (standard multi-host). Only consulted when an
+  //    anchor is configured — a single-host install pays zero Linear cost.
+  const anchor = getLivenessAnchorIssue();
+  if (anchor) {
+    const res = readNodeNames({ anchorIssue: anchor });
+    // FAIL-OPEN: res.ok === false (Linear unreadable) → fall through, do NOT
+    // empty the roster. res.ok === true with names → use them.
+    if (res && res.ok && Array.isArray(res.names) && res.names.length > 0) {
+      const hosts = res.names.filter((h) => typeof h === "string" && h.length > 0);
+      if (hosts.length > 0) return { hosts, source: "anchor", multiHost: hosts.length > 1 };
+    }
+  }
+
+  // 2. static explicit list (escape hatch for multi-host without the anchor).
+  const staticRoster = getStaticRoster();
+  if (staticRoster) {
+    return { hosts: staticRoster, source: "static", multiHost: staticRoster.length > 1 };
+  }
+
+  // 3. legacy hosts.json / cluster.json migration fallback.
+  const fallback = readHostsFallbackRoster();
+  if (fallback) {
+    return { hosts: fallback, source: "hosts-fallback", multiHost: fallback.length > 1 };
+  }
+
+  // 4. single-host default — no roster source resolved.
+  return { hosts: [getHostName()], source: "single-host", multiHost: false };
+}
+
+// getClusterHosts — resolve this daemon's cluster roster (the membership keys HRW
+// hashes over). Delegates to resolveClusterHosts and returns just the hosts array
+// (the existing callers' contract; CTL-1273 moved the precedence into the
+// resolver so the boot assertion and the reader can never diverge). Never throws.
+export function getClusterHosts() {
+  return resolveClusterHosts().hosts;
 }
 
 // getCatalystRepoDirHostsPath — absolute path to the committed cluster roster.

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -30,6 +30,8 @@ import {
   isDraining,
   getLivenessAnchorIssue,
   LIVENESS_PUBLISH_INTERVAL_MS,
+  getStaticRoster,
+  resolveClusterHosts,
 } from "./config.mjs";
 
 const PREV = process.env.CATALYST_WAIT_WATCHER;
@@ -405,6 +407,165 @@ describe("getClusterHosts cluster-repo-first (CTL-1211)", () => {
   test("unversioned cluster.json is treated as v1 and read", () => {
     writeCluster({ roster: ["mini", "mini-2"] });
     expect(getClusterHosts()).toEqual(["mini", "mini-2"]);
+  });
+});
+
+// CTL-1273: the roster resolver — anchor → static → hosts-fallback → single-host.
+// All Linear reads are injected (readNodeNames), so these tests are hermetic.
+describe("getStaticRoster (CTL-1273)", () => {
+  const ENVS = ["CATALYST_LAYER2_CONFIG_FILE", "CATALYST_STATIC_ROSTER"];
+  let saved = {};
+  let tmp, cfg;
+
+  beforeEach(() => {
+    for (const k of ENVS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    tmp = mkdtempSync(join(tmpdir(), "ctl1273-static-"));
+    cfg = join(tmp, "config.json");
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+  });
+
+  afterEach(() => {
+    for (const k of ENVS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    saved = {};
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("reads catalyst.cluster.staticRoster from Layer-2", () => {
+    writeFileSync(cfg, JSON.stringify({ catalyst: { cluster: { staticRoster: ["mini", "mini-2"] } } }));
+    expect(getStaticRoster()).toEqual(["mini", "mini-2"]);
+  });
+
+  test("filters non-string / empty entries", () => {
+    writeFileSync(cfg, JSON.stringify({ catalyst: { cluster: { staticRoster: ["mini", 42, "", "x"] } } }));
+    expect(getStaticRoster()).toEqual(["mini", "x"]);
+  });
+
+  test("unset / empty array / malformed → null", () => {
+    writeFileSync(cfg, JSON.stringify({ catalyst: { cluster: {} } }));
+    expect(getStaticRoster()).toBe(null);
+    writeFileSync(cfg, JSON.stringify({ catalyst: { cluster: { staticRoster: [] } } }));
+    expect(getStaticRoster()).toBe(null);
+    writeFileSync(cfg, "{ not json");
+    expect(getStaticRoster()).toBe(null);
+  });
+
+  test("CATALYST_STATIC_ROSTER env override (comma-separated)", () => {
+    process.env.CATALYST_STATIC_ROSTER = "mini, mini-2 ,";
+    expect(getStaticRoster()).toEqual(["mini", "mini-2"]);
+  });
+});
+
+describe("resolveClusterHosts (CTL-1273)", () => {
+  const ENVS = [
+    "CATALYST_CONFIG_FILE",
+    "CATALYST_HOST_NAME",
+    "CATALYST_LAYER2_CONFIG_FILE",
+    "CATALYST_CLUSTER_DIR",
+    "CATALYST_LIVENESS_ANCHOR_ISSUE",
+    "CATALYST_STATIC_ROSTER",
+  ];
+  let saved = {};
+  let repo, cfg;
+
+  beforeEach(() => {
+    for (const k of ENVS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    repo = mkdtempSync(join(tmpdir(), "ctl1273-resolve-"));
+    mkdirSync(join(repo, ".catalyst"), { recursive: true });
+    cfg = join(repo, "layer2.json");
+    process.env.CATALYST_CONFIG_FILE = join(repo, ".catalyst", "config.json");
+    process.env.CATALYST_CLUSTER_DIR = join(repo, "no-such-cluster");
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    process.env.CATALYST_HOST_NAME = "solo-host";
+  });
+
+  afterEach(() => {
+    for (const k of ENVS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    saved = {};
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  const writeHosts = (arr) => writeFileSync(join(repo, ".catalyst", "hosts.json"), JSON.stringify(arr));
+  const writeLayer2 = (obj) => writeFileSync(cfg, JSON.stringify(obj));
+
+  test("anchor source wins when configured and the read succeeds", () => {
+    process.env.CATALYST_LIVENESS_ANCHOR_ISSUE = "CTL-1090";
+    writeHosts(["legacy-should-lose"]); // present but lower priority
+    const readNodeNames = () => ({ ok: true, names: ["mini", "mini-2"] });
+    expect(resolveClusterHosts({ readNodeNames })).toEqual({
+      hosts: ["mini", "mini-2"],
+      source: "anchor",
+      multiHost: true,
+    });
+  });
+
+  test("FAIL-OPEN: anchor read error falls through to the next source (never empties)", () => {
+    process.env.CATALYST_LIVENESS_ANCHOR_ISSUE = "CTL-1090";
+    writeHosts(["mini", "mac-studio"]);
+    const readNodeNames = () => ({ ok: false, names: [] }); // Linear unreadable
+    const r = resolveClusterHosts({ readNodeNames });
+    expect(r.hosts).toEqual(["mini", "mac-studio"]);
+    expect(r.source).toBe("hosts-fallback");
+  });
+
+  test("anchor configured but empty roster falls through (not an empty fleet)", () => {
+    process.env.CATALYST_LIVENESS_ANCHOR_ISSUE = "CTL-1090";
+    writeLayer2({ catalyst: { cluster: { staticRoster: ["static-a", "static-b"] } } });
+    const readNodeNames = () => ({ ok: true, names: [] });
+    const r = resolveClusterHosts({ readNodeNames });
+    expect(r.source).toBe("static");
+    expect(r.hosts).toEqual(["static-a", "static-b"]);
+  });
+
+  test("NO anchor configured → readNodeNames is NEVER called (zero Linear cost)", () => {
+    // anchor env unset; only single-host default expected, no anchor read.
+    let called = false;
+    const readNodeNames = () => {
+      called = true;
+      return { ok: true, names: ["should-not-be-used"] };
+    };
+    const r = resolveClusterHosts({ readNodeNames });
+    expect(called).toBe(false);
+    expect(r).toEqual({ hosts: ["solo-host"], source: "single-host", multiHost: false });
+  });
+
+  test("static source when no anchor, before the legacy hosts fallback", () => {
+    writeLayer2({ catalyst: { cluster: { staticRoster: ["a", "b"] } } });
+    writeHosts(["legacy"]);
+    const r = resolveClusterHosts({ readNodeNames: () => ({ ok: false, names: [] }) });
+    expect(r).toEqual({ hosts: ["a", "b"], source: "static", multiHost: true });
+  });
+
+  test("hosts-fallback (legacy .catalyst/hosts.json) when no anchor + no static", () => {
+    writeHosts(["mini", "mac-studio"]);
+    const r = resolveClusterHosts({ readNodeNames: () => ({ ok: false, names: [] }) });
+    expect(r).toEqual({ hosts: ["mini", "mac-studio"], source: "hosts-fallback", multiHost: true });
+  });
+
+  test("single-host default when no anchor, no static, no hosts file", () => {
+    const r = resolveClusterHosts({ readNodeNames: () => ({ ok: false, names: [] }) });
+    expect(r).toEqual({ hosts: ["solo-host"], source: "single-host", multiHost: false });
+  });
+
+  test("single-host anchor roster reports multiHost:false", () => {
+    process.env.CATALYST_LIVENESS_ANCHOR_ISSUE = "CTL-1090";
+    const readNodeNames = () => ({ ok: true, names: ["mini"] });
+    expect(resolveClusterHosts({ readNodeNames })).toEqual({
+      hosts: ["mini"],
+      source: "anchor",
+      multiHost: false,
+    });
   });
 });
 

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -43,6 +43,9 @@ import {
   readRatelimitPollerConfig,
   getHostName,      // CTL-862
   getClusterHosts,  // CTL-862
+  resolveClusterHosts, // CTL-1273/CTL-1271: roster + source + multiHost for the boot assertion
+  getLivenessAnchorIssue, // CTL-1271: "multi-host was configured" detector
+  getStaticRoster,        // CTL-1271: "multi-host was configured" detector
 } from "./config.mjs";
 import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
 import { startWaitWatcher as realStartWaitWatcher } from "./wait-watcher.mjs";
@@ -466,6 +469,11 @@ export function startDaemon({
   readAllEligible = readAllEligibleTickets,
   bootHosts = undefined,
   bootHostName = undefined,
+  // CTL-1271: injectable roster-resolution seam for the boot assertion. Tests
+  // inject a fixed { hosts, source, multiHost }; production resolves it from the
+  // real config (resolveClusterHosts). Kept separate from bootHosts so the
+  // CTL-862 ownership-log tests (which inject bootHosts directly) still pass.
+  bootResolve = undefined,
 } = {}) {
   const orchDir = getExecutionCoreDir();
   ensureState(orchDir);
@@ -713,11 +721,53 @@ export function startDaemon({
     log.warn({ err }, "execution-core daemon: registry health check failed (continuing)");
   }
 
-  // CTL-862: report HRW ownership at boot for multi-host observability.
-  const bootRoster = bootHosts ?? getClusterHosts();
+  // CTL-862 / CTL-1271: resolve + ANNOUNCE the cluster roster at boot. The
+  // daemon partitions work by this roster, so it must state what it resolved AND
+  // where that came from — and NEVER silently degrade to a one-node cluster (the
+  // bug that quietly evicted mini-2). resolveClusterHosts returns the single
+  // precedence (anchor → static → hosts-fallback → single-host) shared with
+  // getClusterHosts, so the boot announcement can never disagree with what the
+  // scheduler actually uses.
+  //
+  // bootHosts (the CTL-862 ownership-log test seam) wins when injected; bootResolve
+  // is the CTL-1271 seam for asserting source/multiHost; otherwise resolve for real.
+  const resolved =
+    bootResolve ??
+    (bootHosts
+      ? { hosts: bootHosts, source: "injected", multiHost: bootHosts.length > 1 }
+      : resolveClusterHosts());
+  const bootRoster = resolved.hosts;
+  const bootSource = resolved.source;
+  const bootMultiHost = resolved.multiHost;
   const bootSelf = bootHostName ?? getHostName();
   const bootEligible = readAllEligible();
   const bootOwns = bootEligible.filter((t) => ownedBy(t.identifier, bootRoster, bootSelf)).length;
+
+  // CTL-1271: a multi-host configuration that resolves to a single-host roster is
+  // a SILENT eviction — every peer drops out of HRW and this node owns the whole
+  // fleet's work. Detect "multi-host was EXPECTED" (an anchor or a static roster
+  // is configured) but the resolution yielded single-host, and warn LOUDLY (not a
+  // hard refuse — a transient Linear blip must not block boot; FAIL-OPEN already
+  // kept the prior roster on the read seam). A legitimately single-host install
+  // (no anchor, no static) stays SILENT — single-host is a valid, expected state.
+  const anchorConfigured = Boolean(getLivenessAnchorIssue());
+  const staticConfigured = Boolean(getStaticRoster());
+  const multiHostExpected = anchorConfigured || staticConfigured;
+  if (multiHostExpected && !bootMultiHost) {
+    log.warn(
+      {
+        roster: bootRoster,
+        source: bootSource,
+        anchorConfigured,
+        staticConfigured,
+        host: bootSelf,
+      },
+      "execution-core daemon: multi-host was configured (cluster anchor / static roster) " +
+        "but the roster resolved to a SINGLE host — this node will own the ENTIRE fleet's " +
+        "work under HRW. Check the cluster anchor is reachable and enrolled " +
+        "(`catalyst cluster status`).",
+    );
+  }
   // CTL-1084: emit a structured node.boot event so catalyst-stack status can
   // prove what the restart did (version, effective flags, adopted/cleared/rewalk counts).
   // Fail-open — emitBootEvent never throws. Kept alongside the pino log (not replacing it).
@@ -729,8 +779,18 @@ export function startDaemon({
       rewalkDispatched: _bootResume?.dispatched ?? 0,
     },
   });
+  // CTL-1271: announce roster + source + multiHost at boot so an operator can
+  // always read what the daemon resolved and where it came from.
   log.info(
-    { orchDir, host: bootSelf, owns: bootOwns, eligible: bootEligible.length, roster: bootRoster },
+    {
+      orchDir,
+      host: bootSelf,
+      owns: bootOwns,
+      eligible: bootEligible.length,
+      roster: bootRoster,
+      source: bootSource,
+      multiHost: bootMultiHost,
+    },
     "execution-core daemon started"
   );
 }

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -1919,3 +1919,139 @@ describe("CTL-862 — daemon boot-log ownership context", () => {
     }
   });
 });
+
+// ── CTL-1271: daemon boot announces roster + source + multiHost, and warns
+// LOUDLY (not refuses) when multi-host was configured but resolution went
+// single-host — never a SILENT one-node cluster.
+describe("CTL-1271 — daemon boot roster announcement + silent-single-host guard", () => {
+  const ANCHOR_ENVS = ["CATALYST_LIVENESS_ANCHOR_ISSUE", "CATALYST_STATIC_ROSTER", "CATALYST_LAYER2_CONFIG_FILE"];
+  let savedEnv = {};
+
+  const baseOpts = () => ({
+    recover: () => ({}),
+    reconcileBoot: () => {},
+    startMonitor: () => {},
+    startScheduler: () => {},
+    stopMonitor: () => {},
+    stopScheduler: () => {},
+    reconcile: () => {},
+    startAutoTuner: () => () => {},
+    watchRegistry: false,
+    listProjects: () => [],
+    readAllEligible: () => [],
+  });
+
+  beforeEach(() => {
+    for (const k of ANCHOR_ENVS) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+    // point Layer-2 at a guaranteed-absent file so getLivenessAnchorIssue /
+    // getStaticRoster don't read the host's real ~/.config/catalyst/config.json
+    process.env.CATALYST_LAYER2_CONFIG_FILE = join(catalystDir, "no-such-layer2.json");
+  });
+
+  afterEach(() => {
+    for (const k of ANCHOR_ENVS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    savedEnv = {};
+  });
+
+  test("boot log states roster + source: 'anchor' + multiHost: true", () => {
+    const infoSpy = spyOn(log, "info");
+    process.env.CATALYST_LIVENESS_ANCHOR_ISSUE = "CTL-1090";
+    try {
+      startDaemon({
+        ...baseOpts(),
+        bootHostName: "mini",
+        bootResolve: { hosts: ["mini", "mini-2"], source: "anchor", multiHost: true },
+      });
+      const bootCall = infoSpy.mock.calls.find(
+        (c) => typeof c[1] === "string" && c[1].includes("daemon started")
+      );
+      expect(bootCall).toBeDefined();
+      expect(bootCall[0].source).toBe("anchor");
+      expect(bootCall[0].multiHost).toBe(true);
+      expect(bootCall[0].roster).toEqual(["mini", "mini-2"]);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test("LOUD warn when an anchor is configured but the roster resolved single-host", () => {
+    const warnSpy = spyOn(log, "warn");
+    process.env.CATALYST_LIVENESS_ANCHOR_ISSUE = "CTL-1090"; // multi-host EXPECTED
+    try {
+      startDaemon({
+        ...baseOpts(),
+        bootHostName: "mini",
+        // resolution degraded to single-host (anchor unreadable, fail-open)
+        bootResolve: { hosts: ["mini"], source: "single-host", multiHost: false },
+      });
+      const warnCall = warnSpy.mock.calls.find(
+        (c) => typeof c[1] === "string" && c[1].includes("multi-host was configured")
+      );
+      expect(warnCall).toBeDefined();
+      expect(warnCall[0].anchorConfigured).toBe(true);
+      expect(warnCall[0].source).toBe("single-host");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("LOUD warn when a static roster is configured but resolved single-host", () => {
+    const warnSpy = spyOn(log, "warn");
+    process.env.CATALYST_STATIC_ROSTER = "mini,mini-2"; // multi-host EXPECTED
+    try {
+      startDaemon({
+        ...baseOpts(),
+        bootHostName: "mini",
+        bootResolve: { hosts: ["mini"], source: "single-host", multiHost: false },
+      });
+      const warnCall = warnSpy.mock.calls.find(
+        (c) => typeof c[1] === "string" && c[1].includes("multi-host was configured")
+      );
+      expect(warnCall).toBeDefined();
+      expect(warnCall[0].staticConfigured).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("SILENT (no warn) for a legitimate single-host install — no anchor, no static", () => {
+    const warnSpy = spyOn(log, "warn");
+    try {
+      startDaemon({
+        ...baseOpts(),
+        bootHostName: "solo",
+        bootResolve: { hosts: ["solo"], source: "single-host", multiHost: false },
+      });
+      const warnCall = warnSpy.mock.calls.find(
+        (c) => typeof c[1] === "string" && c[1].includes("multi-host was configured")
+      );
+      expect(warnCall).toBeUndefined();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("NO silent-single-host warn when an anchor resolved a genuine multi-host roster", () => {
+    const warnSpy = spyOn(log, "warn");
+    process.env.CATALYST_LIVENESS_ANCHOR_ISSUE = "CTL-1090";
+    try {
+      startDaemon({
+        ...baseOpts(),
+        bootHostName: "mini",
+        bootResolve: { hosts: ["mini", "mini-2"], source: "anchor", multiHost: true },
+      });
+      const warnCall = warnSpy.mock.calls.find(
+        (c) => typeof c[1] === "string" && c[1].includes("multi-host was configured")
+      );
+      expect(warnCall).toBeUndefined();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/plugins/dev/scripts/execution-core/node-roster-sync.mjs
+++ b/plugins/dev/scripts/execution-core/node-roster-sync.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// node-roster-sync.mjs — synchronous bridge over the async node-roster CLI
+// (CTL-1273).
+//
+// Why this exists: getClusterHosts() in config.mjs is SYNCHRONOUS and called
+// per scheduler tick, but the cluster-anchor roster source is async (fetch-based,
+// in node-roster.mjs). Rather than make the hot path async, we drive the roster
+// read through spawnSync of `node node-roster.mjs …` — the same sync-subprocess
+// convention as cluster-heartbeat-sync.mjs.
+//
+// FAIL-OPEN contract: ANY failure — spawn error, timeout, non-zero exit, or
+// unparseable stdout — is reported as { ok: false, names: [] }. A Linear hiccup
+// must NEVER empty the roster: the resolver treats ok:false as "fall back to the
+// next source" (static → hosts.json → single-host), never as an empty fleet that
+// would mass-evict every peer under HRW.
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+// NODE_ROSTER_CLI — absolute path to the CLI, resolved relative to this module so
+// it works regardless of the daemon's cwd.
+const NODE_ROSTER_CLI = fileURLToPath(new URL("./node-roster.mjs", import.meta.url));
+
+// ROSTER_TIMEOUT_MS — hard cap on the read subprocess. 15s is generous for a
+// healthy API and bounds a hung call. Overridable for tests / slow networks.
+const ROSTER_TIMEOUT_MS = Number(process.env.EXECUTION_CORE_ROSTER_TIMEOUT_MS) || 15_000;
+
+// readNodeNamesSync — read the enrolled node names from the anchor synchronously.
+// Returns { ok: true, names } on a successful read (names may be []), or
+// { ok: false, names: [] } on any failure (fail-open). `ok` lets the resolver
+// distinguish "anchor unreadable" from "anchor read OK".
+// `spawn`/`nodeBin`/`cli`/`env`/`timeout` are injectable for unit tests.
+export function readNodeNamesSync(
+  { anchorIssue },
+  {
+    spawn = spawnSync,
+    nodeBin = process.execPath,
+    cli = NODE_ROSTER_CLI,
+    env = process.env,
+    timeout = ROSTER_TIMEOUT_MS,
+  } = {}
+) {
+  try {
+    const res = spawn(nodeBin, [cli, "names", anchorIssue], {
+      encoding: "utf8",
+      env,
+      timeout,
+    });
+    if (!res || res.status !== 0 || typeof res.stdout !== "string") {
+      return { ok: false, names: [] };
+    }
+    const line = res.stdout.trim().split("\n").filter(Boolean).pop();
+    if (!line) return { ok: false, names: [] };
+    const parsed = JSON.parse(line);
+    if (!Array.isArray(parsed)) return { ok: false, names: [] };
+    const names = parsed.filter((n) => typeof n === "string" && n.length > 0);
+    return { ok: true, names };
+  } catch {
+    return { ok: false, names: [] };
+  }
+}
+
+// registerNodeSync — upsert a node enrollment record on the anchor synchronously.
+// Returns { ok: true } on success, { ok: false, error } on any failure. Unlike
+// the read path, the CLI writer surfaces the error so the operator sees it.
+export function registerNodeSync(
+  { anchorIssue, name, address = null },
+  {
+    spawn = spawnSync,
+    nodeBin = process.execPath,
+    cli = NODE_ROSTER_CLI,
+    env = process.env,
+    timeout = ROSTER_TIMEOUT_MS,
+  } = {}
+) {
+  try {
+    const args = [cli, "register", anchorIssue, name];
+    if (address) args.push(address);
+    const res = spawn(nodeBin, args, { encoding: "utf8", env, timeout });
+    if (!res || res.status !== 0 || typeof res.stdout !== "string") {
+      return { ok: false, error: describeSpawnFailure(res) };
+    }
+    const line = res.stdout.trim().split("\n").filter(Boolean).pop();
+    JSON.parse(line); // validate parseable; value not needed
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) };
+  }
+}
+
+// deregisterNodeSync — delete a node enrollment record from the anchor
+// synchronously. Returns { ok: true, removed } on success, { ok: false, error }
+// on any failure.
+export function deregisterNodeSync(
+  { anchorIssue, name },
+  {
+    spawn = spawnSync,
+    nodeBin = process.execPath,
+    cli = NODE_ROSTER_CLI,
+    env = process.env,
+    timeout = ROSTER_TIMEOUT_MS,
+  } = {}
+) {
+  try {
+    const res = spawn(nodeBin, [cli, "deregister", anchorIssue, name], {
+      encoding: "utf8",
+      env,
+      timeout,
+    });
+    if (!res || res.status !== 0 || typeof res.stdout !== "string") {
+      return { ok: false, error: describeSpawnFailure(res) };
+    }
+    const line = res.stdout.trim().split("\n").filter(Boolean).pop();
+    const parsed = JSON.parse(line);
+    return { ok: true, removed: Boolean(parsed?.removed) };
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) };
+  }
+}
+
+// describeSpawnFailure — render a short, log-safe reason from a spawnSync result.
+// Mirrors cluster-heartbeat-sync.mjs. Truncates stderr so a noisy subprocess can't
+// bloat a log line.
+function describeSpawnFailure(res) {
+  if (!res) return "no spawn result";
+  if (res.error) return `spawn error: ${res.error.message || String(res.error)}`;
+  const stderr = typeof res.stderr === "string" ? res.stderr.trim().slice(-200) : "";
+  if (res.status !== 0) {
+    return `exit ${res.status}${stderr ? `: ${stderr}` : ""}`;
+  }
+  return "missing stdout";
+}

--- a/plugins/dev/scripts/execution-core/node-roster-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/node-roster-sync.test.mjs
@@ -1,0 +1,160 @@
+// node-roster-sync.test.mjs — synchronous bridge over the node-roster CLI
+// (CTL-1273). Every test injects a fake `spawn` so nothing forks a process.
+// Mirrors cluster-heartbeat-sync.test.mjs in structure and fail-open contract.
+import { describe, test, expect } from "bun:test";
+import { readNodeNamesSync, registerNodeSync, deregisterNodeSync } from "./node-roster-sync.mjs";
+
+describe("readNodeNamesSync — argv + fail-open contract", () => {
+  test("ok:true with the parsed names array", () => {
+    const spawn = () => ({ status: 0, stdout: JSON.stringify(["mini", "mini-2"]) + "\n" });
+    expect(readNodeNamesSync({ anchorIssue: "CTL-9" }, { spawn })).toEqual({
+      ok: true,
+      names: ["mini", "mini-2"],
+    });
+  });
+
+  test("ok:true with [] when the anchor is readable but empty", () => {
+    const spawn = () => ({ status: 0, stdout: "[]\n" });
+    expect(readNodeNamesSync({ anchorIssue: "CTL-9" }, { spawn })).toEqual({
+      ok: true,
+      names: [],
+    });
+  });
+
+  test("builds the right argv: <node> <cli> names <anchor>", () => {
+    let capturedBin, capturedArgs;
+    const spawn = (bin, args) => {
+      capturedBin = bin;
+      capturedArgs = args;
+      return { status: 0, stdout: "[]\n" };
+    };
+    readNodeNamesSync(
+      { anchorIssue: "CTL-9" },
+      { spawn, nodeBin: "/usr/bin/node", cli: "/x/node-roster.mjs" }
+    );
+    expect(capturedBin).toBe("/usr/bin/node");
+    expect(capturedArgs).toEqual(["/x/node-roster.mjs", "names", "CTL-9"]);
+  });
+
+  test("filters non-string / empty entries", () => {
+    const spawn = () => ({ status: 0, stdout: JSON.stringify(["mini", 42, "", "mini-2"]) + "\n" });
+    expect(readNodeNamesSync({ anchorIssue: "CTL-9" }, { spawn }).names).toEqual([
+      "mini",
+      "mini-2",
+    ]);
+  });
+
+  test("FAIL-OPEN: non-zero exit → ok:false (never throws)", () => {
+    const spawn = () => ({ status: 1, stdout: "" });
+    expect(readNodeNamesSync({ anchorIssue: "CTL-9" }, { spawn })).toEqual({
+      ok: false,
+      names: [],
+    });
+  });
+
+  test("FAIL-OPEN: spawn throws → ok:false", () => {
+    const spawn = () => {
+      throw new Error("EACCES");
+    };
+    expect(readNodeNamesSync({ anchorIssue: "CTL-9" }, { spawn })).toEqual({
+      ok: false,
+      names: [],
+    });
+  });
+
+  test("FAIL-OPEN: unparseable stdout → ok:false", () => {
+    const spawn = () => ({ status: 0, stdout: "not json" });
+    expect(readNodeNamesSync({ anchorIssue: "CTL-9" }, { spawn })).toEqual({
+      ok: false,
+      names: [],
+    });
+  });
+
+  test("FAIL-OPEN: non-array stdout → ok:false", () => {
+    const spawn = () => ({ status: 0, stdout: '{"mini":{}}\n' });
+    expect(readNodeNamesSync({ anchorIssue: "CTL-9" }, { spawn })).toEqual({
+      ok: false,
+      names: [],
+    });
+  });
+
+  test("FAIL-OPEN: timeout (status null) → ok:false", () => {
+    const spawn = () => ({ status: null, error: new Error("ETIMEDOUT"), stdout: null });
+    expect(readNodeNamesSync({ anchorIssue: "CTL-9" }, { spawn })).toEqual({
+      ok: false,
+      names: [],
+    });
+  });
+});
+
+describe("registerNodeSync", () => {
+  test("ok:true and forwards anchor/name/address to the CLI", () => {
+    let captured;
+    const spawn = (bin, args) => {
+      captured = args;
+      return { status: 0, stdout: JSON.stringify({ name: "mini-2", address: "h" }) + "\n" };
+    };
+    const r = registerNodeSync({ anchorIssue: "CTL-9", name: "mini-2", address: "h" }, { spawn });
+    expect(r.ok).toBe(true);
+    expect(captured).toContain("register");
+    expect(captured).toContain("CTL-9");
+    expect(captured).toContain("mini-2");
+    expect(captured).toContain("h");
+  });
+
+  test("omits the address arg when none is given", () => {
+    let captured;
+    const spawn = (bin, args) => {
+      captured = args;
+      return { status: 0, stdout: JSON.stringify({ name: "mini", address: null }) + "\n" };
+    };
+    registerNodeSync({ anchorIssue: "CTL-9", name: "mini" }, { spawn });
+    // [cli, register, anchor, name] — exactly 4, no trailing address
+    expect(captured).toEqual([captured[0], "register", "CTL-9", "mini"]);
+  });
+
+  test("fail-open: non-zero exit → ok:false with diagnostic error", () => {
+    const spawn = () => ({ status: 2, stdout: "", stderr: "Linear 401 Unauthorized\n" });
+    const r = registerNodeSync({ anchorIssue: "CTL-9", name: "mini" }, { spawn });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("exit 2");
+    expect(r.error).toContain("401 Unauthorized");
+  });
+
+  test("fail-open: spawn throws → ok:false", () => {
+    const spawn = () => {
+      throw new Error("EACCES");
+    };
+    const r = registerNodeSync({ anchorIssue: "CTL-9", name: "mini" }, { spawn });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("EACCES");
+  });
+});
+
+describe("deregisterNodeSync", () => {
+  test("ok:true and surfaces { removed } from the CLI", () => {
+    let captured;
+    const spawn = (bin, args) => {
+      captured = args;
+      return { status: 0, stdout: JSON.stringify({ removed: true }) + "\n" };
+    };
+    const r = deregisterNodeSync({ anchorIssue: "CTL-9", name: "mini" }, { spawn });
+    expect(r).toEqual({ ok: true, removed: true });
+    expect(captured).toEqual([captured[0], "deregister", "CTL-9", "mini"]);
+  });
+
+  test("removed:false flows through", () => {
+    const spawn = () => ({ status: 0, stdout: JSON.stringify({ removed: false }) + "\n" });
+    expect(deregisterNodeSync({ anchorIssue: "CTL-9", name: "ghost" }, { spawn })).toEqual({
+      ok: true,
+      removed: false,
+    });
+  });
+
+  test("fail-open: non-zero exit → ok:false", () => {
+    const spawn = () => ({ status: 1, stdout: "", stderr: "boom" });
+    const r = deregisterNodeSync({ anchorIssue: "CTL-9", name: "mini" }, { spawn });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("exit 1");
+  });
+});

--- a/plugins/dev/scripts/execution-core/node-roster.mjs
+++ b/plugins/dev/scripts/execution-core/node-roster.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+// node-roster.mjs — cluster ENROLLMENT channel (CTL-1273).
+//
+// STUB — minimal anchor for the CTL-1273/CTL-1271 keystone build. The full
+// node-registration read/write machinery (persistent `catalyst://node/<name>`
+// attachments on the Linear cluster anchor, mirroring cluster-heartbeat.mjs)
+// lands in the next commit on this branch.
+
+export const NODE_URL_PREFIX = "catalyst://node/";
+
+// nodeUrl — the per-node enrollment attachment url; the unique key Linear
+// upserts on.
+export function nodeUrl(name) {
+  return `${NODE_URL_PREFIX}${name}`;
+}

--- a/plugins/dev/scripts/execution-core/node-roster.mjs
+++ b/plugins/dev/scripts/execution-core/node-roster.mjs
@@ -1,15 +1,255 @@
 #!/usr/bin/env node
 // node-roster.mjs — cluster ENROLLMENT channel (CTL-1273).
 //
-// STUB — minimal anchor for the CTL-1273/CTL-1271 keystone build. The full
-// node-registration read/write machinery (persistent `catalyst://node/<name>`
-// attachments on the Linear cluster anchor, mirroring cluster-heartbeat.mjs)
-// lands in the next commit on this branch.
+// The fleet roster — who BELONGS to the cluster — lives in ONE place: the Linear
+// "cluster anchor" issue (the coordination substrate the orchestrator already
+// requires). Each enrolled node is a PERSISTENT attachment `catalyst://node/<name>`
+// carrying { name, address }. This is the single source of truth: the daemon
+// READS it to resolve its roster, and `catalyst cluster add/remove` WRITES it —
+// reader and writer share one anchor, so divergence is structurally impossible
+// (the bug the per-repo hosts.json caused).
+//
+// Distinct from cluster-heartbeat.mjs (liveness/TRANSIENT `catalyst://heartbeat/<host>`
+// records): enrollment is persistent, so the roster knows OFFLINE nodes' names +
+// addresses (needed for deterministic HRW re-homing). Kept as a SEPARATE module
+// so the two concerns never entangle.
+//
+// Pure + injectable (the `post` seam; no cross-module imports beyond Node
+// builtins), exactly like cluster-heartbeat.mjs, so it is PR-order-independent and
+// every test injects a fake GraphQL client (no real network / linearis in the
+// hot path).
+//
+// FAIL-OPEN contract: readNodeRoster NEVER throws — a Linear read error returns
+// {}. The roster resolver in config.mjs treats {} as "anchor unreadable" and
+// falls back to the next source (static → hosts.json → single-host), so a Linear
+// hiccup can never silently empty the roster and mass-evict the fleet.
+//
+// Shared GraphQL constants (RESOLVE_ISSUE_QUERY, READ_ATTACHMENTS_QUERY,
+// WRITE_ATTACHMENT_MUTATION, defaultPost, authHeader, resolveIssueId) mirror
+// cluster-heartbeat.mjs per the no-cross-module-import rule: each lib stays pure
+// and PR-order-independent.
 
-export const NODE_URL_PREFIX = "catalyst://node/";
+const NODE_URL_PREFIX = "catalyst://node/";
+const NODE_ATTACHMENT_TITLE = "catalyst-node";
+const LINEAR_GRAPHQL_ENDPOINT = "https://api.linear.app/graphql";
+
+export { NODE_URL_PREFIX };
 
 // nodeUrl — the per-node enrollment attachment url; the unique key Linear
 // upserts on.
 export function nodeUrl(name) {
   return `${NODE_URL_PREFIX}${name}`;
+}
+
+// authHeader — mirror cluster-heartbeat.mjs (keep local, PR-order-independent).
+export function authHeader(token = "") {
+  return /^lin_oauth/i.test(token) ? `Bearer ${token}` : token;
+}
+
+// defaultPost — the production GraphQL POST. Injectable via `post` on every
+// public function so tests never touch the network.
+async function defaultPost(query, variables) {
+  const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
+  const res = await fetch(LINEAR_GRAPHQL_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: authHeader(token),
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) throw new Error(`linear graphql http ${res.status}`);
+  const json = await res.json();
+  if (json?.errors) throw new Error(`linear graphql errors: ${JSON.stringify(json.errors)}`);
+  return json?.data ?? {};
+}
+
+// ─── identifier → issue UUID ─────────────────────────────────────────────────
+
+// CTL-1255: resolve via issue(id:), which accepts the human identifier ("CTL-1217")
+// directly and returns the UUID. The previous issues(filter:{identifier}) form was
+// a hard 400 (IssueFilter has no identifier field). See cluster-heartbeat.mjs.
+const RESOLVE_ISSUE_QUERY = `query ResolveIssueId($id: String!) {
+  issue(id: $id) { id }
+}`;
+
+export async function resolveIssueId(ticket, { post = defaultPost } = {}) {
+  const data = await post(RESOLVE_ISSUE_QUERY, { id: ticket });
+  return data?.issue?.id ?? null;
+}
+
+// ─── read ────────────────────────────────────────────────────────────────────
+
+const READ_ATTACHMENTS_QUERY = `query ReadNodes($id: String!) {
+  issue(id: $id) { attachments { nodes { id url metadata } } }
+}`;
+
+// parseNodeMetadata — normalise an attachment's metadata into the flat node
+// record callers consume. `address` is normalised to a string or null.
+// Exported for unit coverage.
+export function parseNodeMetadata(metadata) {
+  const m = metadata ?? {};
+  const name = typeof m.name === "string" && m.name.length > 0 ? m.name : null;
+  const address = typeof m.address === "string" && m.address.length > 0 ? m.address : null;
+  return { name, address };
+}
+
+// readNodeRoster — read all `catalyst://node/*` enrollment attachments from the
+// anchor issue. Returns { [name]: { name, address } }. FAIL-OPEN: a
+// missing/erroring anchor yields {} (NOT a throw) — the resolver treats {} as
+// "fall back to the next source" so a Linear hiccup never mass-evicts the fleet.
+export async function readNodeRoster({ anchorIssue }, { post = defaultPost } = {}) {
+  let data;
+  try {
+    data = await post(READ_ATTACHMENTS_QUERY, { id: anchorIssue });
+  } catch {
+    return {};
+  }
+  const nodes = data?.issue?.attachments?.nodes ?? [];
+  const out = {};
+  for (const n of nodes) {
+    if (typeof n?.url !== "string" || !n.url.startsWith(NODE_URL_PREFIX)) continue;
+    const rec = parseNodeMetadata(n.metadata);
+    if (rec.name) out[rec.name] = rec;
+  }
+  return out;
+}
+
+// readNodeNames — the roster as a sorted, deterministic array of node names.
+// The shape getClusterHosts() consumes. FAIL-OPEN ⇒ [] on any error.
+export async function readNodeNames({ anchorIssue }, { post = defaultPost } = {}) {
+  const map = await readNodeRoster({ anchorIssue }, { post });
+  return Object.keys(map).sort();
+}
+
+// ─── write / upsert ──────────────────────────────────────────────────────────
+
+const WRITE_ATTACHMENT_MUTATION = `mutation UpsertNode($input: AttachmentCreateInput!) {
+  attachmentCreate(input: $input) { success attachment { id url metadata } }
+}`;
+
+// registerNode — upsert the `catalyst://node/<name>` enrollment attachment on the
+// anchor issue. Single-writer (the operator's CLI) ⇒ no CAS, just upsert. Mirrors
+// publishHeartbeat. Returns the parsed node record written; throws on a
+// resolution miss or success:false (the CLI surfaces the error).
+export async function registerNode(
+  { anchorIssue, name, address = null },
+  { post = defaultPost } = {}
+) {
+  if (!name) throw new Error("node-roster: registerNode requires a name");
+  const issueId = await resolveIssueId(anchorIssue, { post });
+  if (!issueId) throw new Error(`node-roster: no issue found for anchor ${anchorIssue}`);
+  const metadata = { name, address: address ?? null };
+  const data = await post(WRITE_ATTACHMENT_MUTATION, {
+    input: {
+      issueId,
+      title: NODE_ATTACHMENT_TITLE,
+      url: nodeUrl(name),
+      metadata,
+    },
+  });
+  if (!data?.attachmentCreate?.success) {
+    throw new Error(`node-roster: attachmentCreate success=false for ${name}`);
+  }
+  return parseNodeMetadata(metadata);
+}
+
+// ─── delete ────────────────────────────────────────────────────────────────
+
+const DELETE_ATTACHMENT_MUTATION = `mutation DeleteNode($id: String!) {
+  attachmentDelete(id: $id) { success }
+}`;
+
+// findNodeAttachmentId — read the anchor's attachments and return the id of the
+// `catalyst://node/<name>` attachment, or null when absent. Internal helper for
+// deregisterNode (Linear deletes attachments by their UUID, not by url).
+async function findNodeAttachmentId(anchorIssue, name, post) {
+  const data = await post(READ_ATTACHMENTS_QUERY, { id: anchorIssue });
+  const nodes = data?.issue?.attachments?.nodes ?? [];
+  const target = nodeUrl(name);
+  for (const n of nodes) {
+    if (n?.url === target && typeof n.id === "string") return n.id;
+  }
+  return null;
+}
+
+// deregisterNode — delete the `catalyst://node/<name>` enrollment attachment from
+// the anchor issue. Returns { removed: true } when an attachment was deleted,
+// { removed: false } when no matching attachment existed (idempotent remove).
+// Throws on a delete that reports success:false. Mirrors registerNode's error
+// surface so the CLI can report it.
+export async function deregisterNode({ anchorIssue, name }, { post = defaultPost } = {}) {
+  if (!name) throw new Error("node-roster: deregisterNode requires a name");
+  const id = await findNodeAttachmentId(anchorIssue, name, post);
+  if (!id) return { removed: false };
+  const data = await post(DELETE_ATTACHMENT_MUTATION, { id });
+  if (!data?.attachmentDelete?.success) {
+    throw new Error(`node-roster: attachmentDelete success=false for ${name}`);
+  }
+  return { removed: true };
+}
+
+// ─── CLI ─────────────────────────────────────────────────────────────────────
+// A thin argv shim so a SYNCHRONOUS caller (config.mjs / cli/cluster.mjs) can
+// drive these async functions through spawnSync — the same convention
+// cluster-heartbeat.mjs uses (node-roster-sync.mjs is the in-process wrapper).
+//
+//   read <anchor>                       → stdout JSON map { name: {name,address} }; exit 0
+//   names <anchor>                      → stdout JSON array of sorted names; exit 0
+//   register <anchor> <name> [address]  → stdout JSON record; exit 0
+//   deregister <anchor> <name>          → stdout JSON { removed }; exit 0
+export async function runCli(argv, { post = defaultPost } = {}) {
+  const [cmd, ...rest] = argv;
+  switch (cmd) {
+    case "read": {
+      const [anchor] = rest;
+      const map = await readNodeRoster({ anchorIssue: anchor }, { post });
+      process.stdout.write(JSON.stringify(map) + "\n");
+      return 0;
+    }
+    case "names": {
+      const [anchor] = rest;
+      const names = await readNodeNames({ anchorIssue: anchor }, { post });
+      process.stdout.write(JSON.stringify(names) + "\n");
+      return 0;
+    }
+    case "register": {
+      const [anchor, name, address] = rest;
+      const rec = await registerNode(
+        { anchorIssue: anchor, name, address: address || null },
+        { post }
+      );
+      process.stdout.write(JSON.stringify(rec) + "\n");
+      return 0;
+    }
+    case "deregister": {
+      const [anchor, name] = rest;
+      const res = await deregisterNode({ anchorIssue: anchor, name }, { post });
+      process.stdout.write(JSON.stringify(res) + "\n");
+      return 0;
+    }
+    default:
+      process.stderr.write(
+        `node-roster.mjs: unknown subcommand: ${cmd ?? "(none)"}\n` +
+          "usage: node-roster.mjs <read <anchor> | names <anchor> | " +
+          "register <anchor> <name> [address] | deregister <anchor> <name>>\n"
+      );
+      return 1;
+  }
+}
+
+function isMain() {
+  return (
+    process.argv[1] &&
+    (process.argv[1].endsWith("/node-roster.mjs") || process.argv[1].endsWith("node-roster.mjs"))
+  );
+}
+
+if (isMain()) {
+  runCli(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(`node-roster.mjs: ${err?.message ?? err}\n`);
+      process.exit(1);
+    });
 }

--- a/plugins/dev/scripts/execution-core/node-roster.test.mjs
+++ b/plugins/dev/scripts/execution-core/node-roster.test.mjs
@@ -1,0 +1,344 @@
+// node-roster.test.mjs — cluster ENROLLMENT channel (CTL-1273).
+// Every test injects a fake GraphQL `post` so nothing touches the network.
+// Mirrors cluster-heartbeat.test.mjs in structure and pattern.
+import { describe, test, expect } from "bun:test";
+import {
+  nodeUrl,
+  NODE_URL_PREFIX,
+  parseNodeMetadata,
+  readNodeRoster,
+  readNodeNames,
+  registerNode,
+  deregisterNode,
+  runCli,
+} from "./node-roster.mjs";
+
+async function captureStdout(fn) {
+  const chunks = [];
+  const orig = process.stdout.write;
+  process.stdout.write = (s) => {
+    chunks.push(typeof s === "string" ? s : s.toString());
+    return true;
+  };
+  try {
+    const code = await fn();
+    return { code, out: chunks.join("") };
+  } finally {
+    process.stdout.write = orig;
+  }
+}
+
+describe("nodeUrl", () => {
+  test("namespaces per node name", () => {
+    expect(nodeUrl("mini")).toBe("catalyst://node/mini");
+    expect(nodeUrl("mini-2")).toBe("catalyst://node/mini-2");
+  });
+  test("prefix is the persistent-enrollment namespace (distinct from heartbeat)", () => {
+    expect(NODE_URL_PREFIX).toBe("catalyst://node/");
+  });
+});
+
+describe("parseNodeMetadata", () => {
+  test("normalises a full record", () => {
+    expect(parseNodeMetadata({ name: "mini", address: "mini.rozich.com" })).toEqual({
+      name: "mini",
+      address: "mini.rozich.com",
+    });
+  });
+  test("missing address → null", () => {
+    expect(parseNodeMetadata({ name: "mini" })).toEqual({ name: "mini", address: null });
+  });
+  test("missing/null metadata → all-null record", () => {
+    expect(parseNodeMetadata(undefined)).toEqual({ name: null, address: null });
+    expect(parseNodeMetadata(null)).toEqual({ name: null, address: null });
+  });
+  test("non-string / empty values are nulled", () => {
+    expect(parseNodeMetadata({ name: 42, address: "" })).toEqual({ name: null, address: null });
+  });
+});
+
+describe("readNodeRoster", () => {
+  test("returns one entry per node attachment, keyed by name", async () => {
+    const post = async () => ({
+      issue: {
+        attachments: {
+          nodes: [
+            {
+              id: "a1",
+              url: "catalyst://node/mini",
+              metadata: { name: "mini", address: "mini.rozich.com" },
+            },
+            {
+              id: "a2",
+              url: "catalyst://node/mini-2",
+              metadata: { name: "mini-2", address: "mini-2.rozich.com" },
+            },
+            // heartbeat (transient) records are NOT enrollment — must be ignored
+            { id: "h1", url: "catalyst://heartbeat/mini", metadata: { host: "mini" } },
+            { id: "x1", url: "https://github.com/x/y/pull/1", metadata: {} },
+          ],
+        },
+      },
+    });
+    const map = await readNodeRoster({ anchorIssue: "CTL-9999" }, { post });
+    expect(Object.keys(map).sort()).toEqual(["mini", "mini-2"]);
+    expect(map.mini.address).toBe("mini.rozich.com");
+    expect(map["mini-2"].address).toBe("mini-2.rozich.com");
+  });
+
+  test("FAIL-OPEN: a post error returns {} (never throws → never mass-evicts)", async () => {
+    const post = async () => {
+      throw new Error("network error");
+    };
+    expect(await readNodeRoster({ anchorIssue: "CTL-9999" }, { post })).toEqual({});
+  });
+
+  test("missing anchor / empty attachments → {}", async () => {
+    expect(await readNodeRoster({ anchorIssue: "CTL-9999" }, { post: async () => ({}) })).toEqual(
+      {}
+    );
+    expect(
+      await readNodeRoster(
+        { anchorIssue: "CTL-9999" },
+        { post: async () => ({ issue: { attachments: { nodes: [] } } }) }
+      )
+    ).toEqual({});
+  });
+
+  test("skips a node attachment whose metadata has no name", async () => {
+    const post = async () => ({
+      issue: { attachments: { nodes: [{ id: "a1", url: "catalyst://node/ghost", metadata: {} }] } },
+    });
+    expect(await readNodeRoster({ anchorIssue: "CTL-9999" }, { post })).toEqual({});
+  });
+});
+
+describe("readNodeNames", () => {
+  test("returns sorted, deterministic node names", async () => {
+    const post = async () => ({
+      issue: {
+        attachments: {
+          nodes: [
+            { id: "a2", url: "catalyst://node/mini-2", metadata: { name: "mini-2" } },
+            { id: "a1", url: "catalyst://node/mini", metadata: { name: "mini" } },
+          ],
+        },
+      },
+    });
+    expect(await readNodeNames({ anchorIssue: "CTL-9999" }, { post })).toEqual(["mini", "mini-2"]);
+  });
+
+  test("FAIL-OPEN: a post error returns []", async () => {
+    const post = async () => {
+      throw new Error("boom");
+    };
+    expect(await readNodeNames({ anchorIssue: "CTL-9999" }, { post })).toEqual([]);
+  });
+});
+
+describe("registerNode", () => {
+  test("upserts the per-node attachment with name + address", async () => {
+    const calls = [];
+    const post = async (q, v) => {
+      calls.push({ q, v });
+      if (q.includes("ResolveIssue")) return { issue: { id: "uuid-anchor" } };
+      return { attachmentCreate: { success: true, attachment: { id: "a1" } } };
+    };
+    const rec = await registerNode(
+      { anchorIssue: "CTL-9999", name: "mini-2", address: "mini-2.rozich.com" },
+      { post }
+    );
+    expect(rec).toEqual({ name: "mini-2", address: "mini-2.rozich.com" });
+    const write = calls.find((c) => c.q.includes("attachmentCreate"));
+    expect(write.v.input.url).toBe("catalyst://node/mini-2");
+    expect(write.v.input.metadata).toEqual({ name: "mini-2", address: "mini-2.rozich.com" });
+    expect(write.v.input.title).toBe("catalyst-node");
+  });
+
+  test("address defaults to null when omitted", async () => {
+    const post = async (q) => {
+      if (q.includes("ResolveIssue")) return { issue: { id: "uuid-x" } };
+      return { attachmentCreate: { success: true, attachment: {} } };
+    };
+    const rec = await registerNode({ anchorIssue: "CTL-9999", name: "mini" }, { post });
+    expect(rec).toEqual({ name: "mini", address: null });
+  });
+
+  // CTL-1255 regression guard: resolve MUST use issue(id:), not issues(filter:{identifier}).
+  test("resolve query targets issue(id:) and reads issue.id (not issues.nodes)", async () => {
+    let resolveQ = "";
+    const post = async (q) => {
+      if (q.includes("issue(id:") && !q.includes("attachmentCreate")) {
+        resolveQ = q;
+        return { issue: { id: "uuid-anchor" } };
+      }
+      return { attachmentCreate: { success: true, attachment: {} } };
+    };
+    await registerNode({ anchorIssue: "CTL-9999", name: "mini" }, { post });
+    expect(resolveQ).toContain("issue(id: $id)");
+    expect(resolveQ).not.toContain("identifier");
+  });
+
+  test("throws when the anchor issue cannot be resolved", async () => {
+    const post = async () => ({ issue: null });
+    await expect(registerNode({ anchorIssue: "CTL-9999", name: "mini" }, { post })).rejects.toThrow(
+      /no issue found/
+    );
+  });
+
+  test("throws when attachmentCreate returns success:false", async () => {
+    const post = async (q) => {
+      if (q.includes("ResolveIssue")) return { issue: { id: "uuid-x" } };
+      return { attachmentCreate: { success: false } };
+    };
+    await expect(registerNode({ anchorIssue: "CTL-9999", name: "mini" }, { post })).rejects.toThrow(
+      /success=false/
+    );
+  });
+
+  test("throws when name is missing", async () => {
+    await expect(
+      registerNode({ anchorIssue: "CTL-9999", name: "" }, { post: async () => ({}) })
+    ).rejects.toThrow(/requires a name/);
+  });
+});
+
+describe("deregisterNode", () => {
+  test("finds the attachment by url and deletes it by id", async () => {
+    const calls = [];
+    const post = async (q, v) => {
+      calls.push({ q, v });
+      if (q.includes("ReadNodes")) {
+        return {
+          issue: {
+            attachments: {
+              nodes: [
+                { id: "a1", url: "catalyst://node/mini", metadata: { name: "mini" } },
+                { id: "a2", url: "catalyst://node/mini-2", metadata: { name: "mini-2" } },
+              ],
+            },
+          },
+        };
+      }
+      return { attachmentDelete: { success: true } };
+    };
+    const res = await deregisterNode({ anchorIssue: "CTL-9999", name: "mini-2" }, { post });
+    expect(res).toEqual({ removed: true });
+    const del = calls.find((c) => c.q.includes("attachmentDelete"));
+    expect(del.v.id).toBe("a2");
+  });
+
+  test("idempotent: removing an absent node returns { removed: false } (no delete call)", async () => {
+    const calls = [];
+    const post = async (q, v) => {
+      calls.push({ q, v });
+      if (q.includes("ReadNodes")) {
+        return {
+          issue: {
+            attachments: {
+              nodes: [{ id: "a1", url: "catalyst://node/mini", metadata: { name: "mini" } }],
+            },
+          },
+        };
+      }
+      return { attachmentDelete: { success: true } };
+    };
+    const res = await deregisterNode({ anchorIssue: "CTL-9999", name: "ghost" }, { post });
+    expect(res).toEqual({ removed: false });
+    expect(calls.some((c) => c.q.includes("attachmentDelete"))).toBe(false);
+  });
+
+  test("throws when attachmentDelete returns success:false", async () => {
+    const post = async (q) => {
+      if (q.includes("ReadNodes")) {
+        return {
+          issue: {
+            attachments: {
+              nodes: [{ id: "a1", url: "catalyst://node/mini", metadata: { name: "mini" } }],
+            },
+          },
+        };
+      }
+      return { attachmentDelete: { success: false } };
+    };
+    await expect(
+      deregisterNode({ anchorIssue: "CTL-9999", name: "mini" }, { post })
+    ).rejects.toThrow(/success=false/);
+  });
+
+  test("throws when name is missing", async () => {
+    await expect(
+      deregisterNode({ anchorIssue: "CTL-9999", name: "" }, { post: async () => ({}) })
+    ).rejects.toThrow(/requires a name/);
+  });
+});
+
+describe("runCli", () => {
+  test("read: prints JSON map and exits 0", async () => {
+    const post = async () => ({
+      issue: {
+        attachments: {
+          nodes: [
+            { id: "a1", url: "catalyst://node/mini", metadata: { name: "mini", address: "h" } },
+          ],
+        },
+      },
+    });
+    const { code, out } = await captureStdout(() => runCli(["read", "CTL-9999"], { post }));
+    expect(code).toBe(0);
+    expect(JSON.parse(out).mini).toEqual({ name: "mini", address: "h" });
+  });
+
+  test("names: prints sorted JSON array and exits 0", async () => {
+    const post = async () => ({
+      issue: {
+        attachments: {
+          nodes: [
+            { id: "a2", url: "catalyst://node/mini-2", metadata: { name: "mini-2" } },
+            { id: "a1", url: "catalyst://node/mini", metadata: { name: "mini" } },
+          ],
+        },
+      },
+    });
+    const { code, out } = await captureStdout(() => runCli(["names", "CTL-9999"], { post }));
+    expect(code).toBe(0);
+    expect(JSON.parse(out)).toEqual(["mini", "mini-2"]);
+  });
+
+  test("register: prints the JSON record and exits 0", async () => {
+    const post = async (q) => {
+      if (q.includes("ResolveIssue")) return { issue: { id: "uuid-x" } };
+      return { attachmentCreate: { success: true, attachment: {} } };
+    };
+    const { code, out } = await captureStdout(() =>
+      runCli(["register", "CTL-9999", "mini-2", "mini-2.rozich.com"], { post })
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(out)).toEqual({ name: "mini-2", address: "mini-2.rozich.com" });
+  });
+
+  test("deregister: prints { removed } and exits 0", async () => {
+    const post = async (q) => {
+      if (q.includes("ReadNodes")) {
+        return {
+          issue: {
+            attachments: {
+              nodes: [{ id: "a1", url: "catalyst://node/mini", metadata: { name: "mini" } }],
+            },
+          },
+        };
+      }
+      return { attachmentDelete: { success: true } };
+    };
+    const { code, out } = await captureStdout(() =>
+      runCli(["deregister", "CTL-9999", "mini"], { post })
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(out)).toEqual({ removed: true });
+  });
+
+  test("unknown subcommand exits 1", async () => {
+    const { code } = await captureStdout(() => runCli(["bogus"], {}));
+    expect(code).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Keystone of catalyst's cluster-membership redesign. Two coupled tickets, one branch/PR:

- **CTL-1273** — the fleet roster lives on the Linear **cluster anchor** issue (single source of truth: persistent `catalyst://node/<name>` attachments carrying `{name, address}`), never in a per-repo file.
- **CTL-1271** — the daemon announces its resolved roster + source at boot and never silently runs as a one-node cluster.

## Design

Roster resolver precedence in `getClusterHosts()`:
1. **Linear cluster anchor** — node-registration attachments when an anchor is configured (`getLivenessAnchorIssue()`).
2. **`static`** explicit node list from machine-local Layer-2 config (`catalyst.cluster.staticRoster`).
3. **Legacy `.catalyst/hosts.json`** — MIGRATION FALLBACK only (lowest priority).
4. **Single-host default** `[getHostName()]` — no Linear call when no anchor/static/hosts.json.

New module `node-roster.mjs` (enrollment/persistent) parallels `cluster-heartbeat.mjs` (liveness/transient). Injectable Linear client for hermetic tests; **FAIL-OPEN** (a Linear read error falls back to the next source, never silently empties the roster → mass-eviction).

CLI writer (`cli/cluster.mjs add/remove`) writes/deletes the node attachment on the **same anchor** the reader reads (structurally kills reader/writer divergence).

CTL-1271 boot assertion logs `{ roster, source, multiHost }`; loud operator-visible warn (not hard-refuse) when multi-host was expected but resolution yielded single-host; silent when single-host is the intent.

## Scope notes

- **Additive** — `.catalyst/hosts.json` is KEPT as a migration fallback. Deletion of the files + the CI guard that prevents reintroduction are an explicit follow-up, NOT this PR.
- Does not touch scheduler dispatch (CTL-1091) or liveness/cluster-heartbeat (CTL-1272, parked).

🤖 autonomous build — **NEEDS REVIEW**

🤖 Generated with [Claude Code](https://claude.com/claude-code)