### PR TITLE
CTL-1123: broker emits catalyst.alert.* topics (alert-emit foundation)

### DIFF
--- a/docs/orchestrator-overview.md
+++ b/docs/orchestrator-overview.md
@@ -397,6 +397,18 @@ while a worker is in-flight (a fresh non-terminal `worker_state` row), so an idl
 never false-alarms. Linear is deferred (its bot-skip guard makes the source quiet even
 during active work). See the configuration reference for the env knobs.
 
+**On top of the detector, the broker is the alert-policy layer (CTL-1123).** The
+`catalyst.ingestion.*` events above are low-level; the broker promotes the
+operator-actionable subset into a stable `catalyst.alert.{raised,cleared}` topic
+(`event.label` = the alert kind). `system_down` is promoted from a critical source's
+sustained `catalyst.ingestion.stale` (a dead monitor); `needs_human_pileup` is a level
+alert over the count of active, non-terminal tickets carrying a `needs-human`/`needs-input`
+label in `filter-state.db` (debounced by threshold + persistence + cooldown). These alert
+events ride the same event log → `otel-forward` → OTel collector → fan-out (Loki, dash0),
+where a downstream alert rule routes them to a channel. **Delivery is a separate concern**
+— the broker emits intent only; no channel or credential lives in the daemon, so the
+alerter survives a monitor death without depending on it.
+
 **The execution-core daemon reaper (CTL-649) is the second producer-and-consumer.**
 It consumes the reap-intent requests appended by the reap-intent producers
 (`lib/emit-reap-intent.sh`, `execution-core/reap-intent.mjs`) — `phase.<kind>.reap-requested`,

--- a/plugins/dev/scripts/broker/alert-emit-wiring.test.mjs
+++ b/plugins/dev/scripts/broker/alert-emit-wiring.test.mjs
@@ -1,0 +1,176 @@
+// alert-emit-wiring.test.mjs — CTL-1123. The broker-side wiring of the alert-emit
+// foundation: system_down promoted from a critical source's recency edge, and the
+// needs_human_pileup level alert from the filter-state.db label count. The pure
+// envelope + machines are covered in alert-emit.test.mjs; this asserts the
+// runWatchdogTick wiring + the filter-state.db count scoping.
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { getEventLogPath } from "./config.mjs";
+import {
+  runWatchdogTick,
+  __clearIngestionRecencyForTest,
+  __setLastSeenForTest,
+  __clearAlertStateForTest,
+  __setPileupStateForTest,
+  __getPileupStateForTest,
+} from "./router.mjs";
+import { GITHUB_SERVICE_NAME } from "./ingestion-recency.mjs";
+import { GITHUB_RECENCY_DOWN_MS } from "./config.mjs";
+import {
+  openBrokerStateDb,
+  closeBrokerStateDb,
+  upsertTicketDescriptor,
+  upsertWorkerState,
+} from "./broker-state.mjs";
+import { clearInterests, clearLastHeartbeat, __resetBrokerStartedAtForTest } from "./state.mjs";
+
+const TEN_MIN = 10 * 60_000;
+
+function readAlertEvents(logPath) {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l))
+    .filter((e) => String(e?.attributes?.["event.name"] ?? "").startsWith("catalyst.alert."));
+}
+const byLabel = (evs, label) => evs.filter((e) => e.attributes["event.label"] === label);
+
+let dir;
+let prevCatalystDir;
+beforeEach(() => {
+  prevCatalystDir = process.env.CATALYST_DIR;
+  dir = mkdtempSync(join(tmpdir(), "alert-wiring-"));
+  process.env.CATALYST_DIR = dir;
+  closeBrokerStateDb();
+  openBrokerStateDb(join(dir, "broker-state.db"));
+  __clearIngestionRecencyForTest();
+  __clearAlertStateForTest();
+  clearInterests();
+  clearLastHeartbeat();
+  __resetBrokerStartedAtForTest();
+});
+afterEach(() => {
+  closeBrokerStateDb();
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("system_down alert rides the monitor recency edge (CTL-1123)", () => {
+  test("monitor sustained-stale → catalyst.alert.raised(system_down)", () => {
+    __setLastSeenForTest("catalyst.monitor", { ts: Date.now() - (TEN_MIN + 60_000), id: "beat-old" });
+    runWatchdogTick();
+    const raised = byLabel(readAlertEvents(getEventLogPath()), "system_down").filter(
+      (e) => e.attributes["event.name"] === "catalyst.alert.raised",
+    );
+    expect(raised).toHaveLength(1);
+    expect(raised[0].severityText).toBe("ERROR");
+    expect(raised[0].body.payload.source).toBe("catalyst.monitor");
+    // edge-triggered: a second stale tick does not re-raise
+    runWatchdogTick();
+    expect(
+      byLabel(readAlertEvents(getEventLogPath()), "system_down").filter(
+        (e) => e.attributes["event.name"] === "catalyst.alert.raised",
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("monitor recovers → catalyst.alert.cleared(system_down)", () => {
+    __setLastSeenForTest("catalyst.monitor", { ts: Date.now() - (TEN_MIN + 60_000), id: "beat-old" });
+    runWatchdogTick(); // raised
+    __setLastSeenForTest("catalyst.monitor", { ts: Date.now(), id: "beat-fresh" });
+    runWatchdogTick(); // cleared
+    const cleared = byLabel(readAlertEvents(getEventLogPath()), "system_down").filter(
+      (e) => e.attributes["event.name"] === "catalyst.alert.cleared",
+    );
+    expect(cleared).toHaveLength(1);
+    expect(cleared[0].severityText).toBe("INFO");
+  });
+
+  test("github stale does NOT raise system_down (alertKind null)", () => {
+    // a fresh in-flight worker opens the github gate so github classifies stale
+    upsertWorkerState({
+      orchestrator: "o", ticket: "CTL-9", status: "implement", eventId: "e1", eventTs: new Date().toISOString(),
+    });
+    __setLastSeenForTest(GITHUB_SERVICE_NAME, { ts: Date.now() - (GITHUB_RECENCY_DOWN_MS + 60_000), id: "gh-old" });
+    runWatchdogTick();
+    expect(readAlertEvents(getEventLogPath())).toHaveLength(0);
+  });
+
+  test("kill-switch FILTER_ALERT_ENABLED=0 → no alert despite monitor stale", () => {
+    const prev = process.env.FILTER_ALERT_ENABLED;
+    process.env.FILTER_ALERT_ENABLED = "0";
+    try {
+      __setLastSeenForTest("catalyst.monitor", { ts: Date.now() - (TEN_MIN + 60_000), id: "beat-old" });
+      runWatchdogTick();
+      expect(readAlertEvents(getEventLogPath())).toHaveLength(0);
+    } finally {
+      if (prev === undefined) delete process.env.FILTER_ALERT_ENABLED;
+      else process.env.FILTER_ALERT_ENABLED = prev;
+    }
+  });
+});
+
+describe("needs_human_pileup alert from the filter-state.db label count (CTL-1123)", () => {
+  function seedTicket(ticket, state, labels) {
+    upsertTicketDescriptor({ ticket, state, labels });
+  }
+  // persistence satisfied: aboveSince far in the past so one tick can raise.
+  const persisted = () => __setPileupStateForTest({ aboveSince: 1 });
+
+  test("3 active needs-human tickets, persisted → catalyst.alert.raised(needs_human_pileup, count 3)", () => {
+    seedTicket("CTL-1", "Implement", ["needs-human"]);
+    seedTicket("CTL-2", "Backlog", ["needs-input"]);
+    seedTicket("CTL-3", "Plan", ["needs-human", "feature"]);
+    persisted();
+    runWatchdogTick();
+    const raised = byLabel(readAlertEvents(getEventLogPath()), "needs_human_pileup").filter(
+      (e) => e.attributes["event.name"] === "catalyst.alert.raised",
+    );
+    expect(raised).toHaveLength(1);
+    expect(raised[0].body.payload.count).toBe(3);
+    expect(raised[0].body.payload.threshold).toBe(3);
+    expect(__getPileupStateForTest().raised).toBe(true);
+  });
+
+  test("count EXCLUDES Done/Canceled + removed tickets (cache-drift scoping)", () => {
+    seedTicket("CTL-1", "Implement", ["needs-human"]); // counts
+    seedTicket("CTL-2", "Backlog", ["needs-input"]); // counts
+    seedTicket("CTL-3", "Done", ["needs-human"]); // excluded (terminal)
+    seedTicket("CTL-4", "Canceled", ["needs-human"]); // excluded (terminal)
+    upsertTicketDescriptor({ ticket: "CTL-5", state: "Implement", labels: ["needs-human"], removed: true }); // excluded
+    persisted();
+    runWatchdogTick();
+    // only 2 active → below threshold 3 → no raise (proves the 3 excluded weren't counted)
+    expect(readAlertEvents(getEventLogPath())).toHaveLength(0);
+  });
+
+  test("pile-up clears when the active count drops below threshold", () => {
+    seedTicket("CTL-1", "Implement", ["needs-human"]);
+    seedTicket("CTL-2", "Implement", ["needs-human"]);
+    seedTicket("CTL-3", "Implement", ["needs-human"]);
+    persisted();
+    runWatchdogTick(); // raised
+    // two get resolved (labels cleared) → count drops to 1
+    upsertTicketDescriptor({ ticket: "CTL-2", labels: [] });
+    upsertTicketDescriptor({ ticket: "CTL-3", labels: [] });
+    runWatchdogTick(); // cleared
+    const cleared = byLabel(readAlertEvents(getEventLogPath()), "needs_human_pileup").filter(
+      (e) => e.attributes["event.name"] === "catalyst.alert.cleared",
+    );
+    expect(cleared).toHaveLength(1);
+    expect(cleared[0].body.payload.count).toBe(1);
+    expect(__getPileupStateForTest().raised).toBe(false);
+  });
+
+  test("below threshold → no alert", () => {
+    seedTicket("CTL-1", "Implement", ["needs-human"]);
+    persisted();
+    runWatchdogTick();
+    expect(readAlertEvents(getEventLogPath())).toHaveLength(0);
+  });
+});

--- a/plugins/dev/scripts/broker/alert-emit.mjs
+++ b/plugins/dev/scripts/broker/alert-emit.mjs
@@ -1,0 +1,188 @@
+// alert-emit.mjs — CTL-1123. The broker's alert-POLICY layer: promote detector
+// signals into a stable, operator-facing `catalyst.alert.*` topic and append it
+// to the event log. The broker is the surviving process; otel-forward ships the
+// log to the OTel collector which fans out to {Loki, dash0, …}, where a separate
+// "brain" (alert rule → channel) does delivery. This module emits intent ONLY —
+// no channels, no credentials.
+//
+// Pairs with broker/ingestion-recency.mjs (the CTL-1122 detector). system_down
+// rides that detector's already-edge-triggered/holddown'd stale/recovered edges,
+// so it needs NO new debounce. needs_human_pileup is a LEVEL signal (a count),
+// so it has its own pure threshold + persistence + cooldown machine here.
+//
+// Envelope mirrors buildIngestionRecencyEnvelope (hand-built — the broker's
+// buildCanonicalEnvelope can't carry event.entity/action/label).
+
+import { mkdirSync, appendFileSync } from "node:fs";
+import { dirname } from "node:path";
+import {
+  generateEventId,
+  severityNumber,
+  hostName,
+  hostId,
+} from "../orch-monitor/lib/canonical-event-shared.ts";
+import { getEventLogPath, log } from "./config.mjs";
+
+// The alert event names — a stable `catalyst.alert.*` namespace deliberately
+// decoupled from the low-level detector event names (catalyst.ingestion.*) so the
+// downstream alert contract survives detector refactors.
+export const ALERT_RAISED = "catalyst.alert.raised";
+export const ALERT_CLEARED = "catalyst.alert.cleared";
+
+// Alert KINDS (event.label). Extend here as new policies are added.
+export const ALERT_KIND_SYSTEM_DOWN = "system_down";
+export const ALERT_KIND_NEEDS_HUMAN_PILEUP = "needs_human_pileup";
+
+// The needs-human label taxonomy. Canonical source is board-data.mjs
+// (ATTENTION_LABEL_NEEDS_HUMAN/NEEDS_INPUT) — but that is a monitor-tree module
+// that pulls linear-cache-reader/estimate-fallback, so importing it into the
+// surviving broker at runtime would couple the broker to monitor code (and erode
+// dashboard-independence). We define the strings locally and pin them to the
+// canonical source with a parity test (alert-emit.test.mjs) so a taxonomy rename
+// (CTL-995) cannot silently drift the broker's pile-up count.
+export const NEEDS_HUMAN_LABELS = ["needs-human", "needs-input"];
+
+/**
+ * buildAlertEnvelope — assemble the canonical OTel envelope for a
+ * catalyst.alert.{raised,cleared} event. resource.service.name=catalyst.broker
+ * (the surviving emitter). Pure (modulo the random id + timestamp); no I/O.
+ *
+ * @param {object} i
+ * @param {"raised"|"cleared"} i.action
+ * @param {string} i.kind        the alert KIND → event.label (system_down | needs_human_pileup)
+ * @param {string} [i.reason]    short human-readable reason
+ * @param {string|null} [i.source]   the silent/recovered source (system_down)
+ * @param {number|null} [i.count]    the pile-up count (needs_human_pileup)
+ * @param {number|null} [i.threshold] the pile-up threshold that was crossed
+ * @param {number|null} [i.sinceMs]  ms the condition has held (raised) / lasted (cleared)
+ * @param {string|null} [i.causedBy] forensic link (event id) → caused_by
+ * @param {object} [opts]
+ * @param {Function} [opts.now]   injectable ISO-timestamp fn (tests)
+ * @returns {object} the envelope
+ */
+export function buildAlertEnvelope(
+  { action, kind, reason = null, source = null, count = null, threshold = null, sinceMs = null, causedBy = null } = {},
+  { now } = {},
+) {
+  const ts = now ? now() : new Date().toISOString();
+  const raised = action === "raised";
+  const eventName = raised ? ALERT_RAISED : ALERT_CLEARED;
+  // A raised alert is operator-actionable (ERROR); a cleared alert is INFO.
+  const severity = raised ? "ERROR" : "INFO";
+  return {
+    ts,
+    id: generateEventId(),
+    observedTs: ts,
+    severityText: severity,
+    severityNumber: severityNumber(severity),
+    traceId: null,
+    spanId: null,
+    caused_by: causedBy ?? null,
+    resource: {
+      // the broker is the emitter — the surviving process that raised the alert.
+      "service.name": "catalyst.broker",
+      "service.namespace": "catalyst",
+      "host.name": hostName(),
+      "host.id": hostId(),
+    },
+    attributes: {
+      "event.name": eventName,
+      "event.entity": "alert",
+      "event.action": action,
+      // the alert KIND — what the downstream brain filters/routes on.
+      "event.label": kind,
+    },
+    body: {
+      payload: { kind, reason, source, count, threshold, sinceMs },
+    },
+  };
+}
+
+/**
+ * emitAlertEvent — build + append one alert envelope to the event log.
+ * Best-effort: returns true on success, false on any failure, NEVER throws — a
+ * telemetry append must never wedge the broker watchdog. Mirrors
+ * emitIngestionRecencyEvent.
+ *
+ * @param {object} input  buildAlertEnvelope input
+ * @param {object} [opts]
+ * @param {string} [opts.logPath]
+ * @param {Function} [opts.now]
+ * @returns {boolean}
+ */
+export function emitAlertEvent(input, { logPath = getEventLogPath(), now } = {}) {
+  const line = `${JSON.stringify(buildAlertEnvelope(input, { now }))}\n`;
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, line);
+    return true;
+  } catch (err) {
+    log.warn({ err: err?.message }, "alert-emit: event append failed");
+    return false;
+  }
+}
+
+/**
+ * initialPileupState — per-kind level-alarm state for the needs_human_pileup
+ * count. `raised` latches a fired-and-not-yet-cleared pile-up; `aboveSince` is
+ * the persistence clock; `clearedAt` arms the post-clear cooldown.
+ */
+export function initialPileupState() {
+  return { raised: false, raisedAt: null, aboveSince: null, clearedAt: null };
+}
+
+/**
+ * nextPileupAlarmState — PURE threshold + persistence + cooldown machine for a
+ * LEVEL signal (a count). Returns { state, emit } where emit ∈ "raised" |
+ * "cleared" | null.
+ *
+ *  - count >= threshold sustained for >= persistenceMs  → emit "raised" (once),
+ *    UNLESS within cooldownMs of the last clear (flap guard → deferred, re-checked).
+ *  - count < threshold while raised                     → emit "cleared", arm cooldown.
+ *
+ * The persistence window stops a single-tick spike from paging; the cooldown
+ * stops a flapping count from storming. Mirrors nextRecencyAlarmState's
+ * pure-then-emit shape.
+ *
+ * @param {object} prev  prior state (initialPileupState shape)
+ * @param {object} i
+ * @param {number} i.count
+ * @param {number} i.threshold
+ * @param {number} i.nowMs
+ * @param {number} [i.persistenceMs]  ms the count must stay >= threshold before raising
+ * @param {number} [i.cooldownMs]     min ms between a clear and the next raise (flap guard)
+ * @returns {{state: object, emit: "raised"|"cleared"|null}}
+ */
+export function nextPileupAlarmState(
+  prev,
+  { count, threshold, nowMs, persistenceMs = 300_000, cooldownMs = 3_600_000 } = {},
+) {
+  const s = { ...prev };
+  let emit = null;
+
+  if (count >= threshold) {
+    if (s.aboveSince === null) s.aboveSince = nowMs; // start the persistence clock
+    if (!s.raised && nowMs - s.aboveSince >= persistenceMs) {
+      // Flap guard: suppress a NEW raise within cooldownMs of the last clear.
+      const cooldownOk = s.clearedAt === null || nowMs - s.clearedAt >= cooldownMs;
+      if (cooldownOk) {
+        emit = "raised";
+        s.raised = true;
+        s.raisedAt = nowMs;
+      }
+      // else: DEFER — leave raised false so the next tick re-checks and raises
+      // the moment the cooldown expires (a sustained pile-up is never masked).
+    }
+  } else {
+    // below threshold → reset the persistence clock; clear any open pile-up.
+    s.aboveSince = null;
+    if (s.raised) {
+      emit = "cleared";
+      s.raised = false;
+      s.raisedAt = null;
+      s.clearedAt = nowMs;
+    }
+  }
+
+  return { state: s, emit };
+}

--- a/plugins/dev/scripts/broker/alert-emit.test.mjs
+++ b/plugins/dev/scripts/broker/alert-emit.test.mjs
@@ -1,0 +1,162 @@
+// Unit tests for the CTL-1123 broker alert-emit foundation. Run:
+//   bun test plugins/dev/scripts/broker/alert-emit.test.mjs
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ALERT_RAISED,
+  ALERT_CLEARED,
+  ALERT_KIND_SYSTEM_DOWN,
+  ALERT_KIND_NEEDS_HUMAN_PILEUP,
+  NEEDS_HUMAN_LABELS,
+  buildAlertEnvelope,
+  emitAlertEvent,
+  initialPileupState,
+  nextPileupAlarmState,
+} from "./alert-emit.mjs";
+// Parity: the canonical taxonomy source (monitor-tree; imported in TEST only).
+import {
+  ATTENTION_LABEL_NEEDS_HUMAN,
+  ATTENTION_LABEL_NEEDS_INPUT,
+} from "../orch-monitor/lib/board-data.mjs";
+
+const NOW = () => "2026-06-18T20:00:00.000Z";
+
+describe("buildAlertEnvelope (CTL-1123)", () => {
+  test("raised → catalyst.alert.raised, entity/action/label, ERROR, broker emitter", () => {
+    const e = buildAlertEnvelope(
+      { action: "raised", kind: ALERT_KIND_SYSTEM_DOWN, reason: "monitor silent", source: "catalyst.monitor", causedBy: "beat-1" },
+      { now: NOW },
+    );
+    expect(e.attributes["event.name"]).toBe(ALERT_RAISED);
+    expect(e.attributes["event.entity"]).toBe("alert");
+    expect(e.attributes["event.action"]).toBe("raised");
+    expect(e.attributes["event.label"]).toBe("system_down");
+    expect(e.severityText).toBe("ERROR");
+    expect(e.resource["service.name"]).toBe("catalyst.broker");
+    expect(e.caused_by).toBe("beat-1");
+    expect(e.body.payload).toMatchObject({ kind: "system_down", source: "catalyst.monitor", reason: "monitor silent" });
+  });
+
+  test("cleared → catalyst.alert.cleared, INFO, count/threshold in payload", () => {
+    const e = buildAlertEnvelope(
+      { action: "cleared", kind: ALERT_KIND_NEEDS_HUMAN_PILEUP, count: 0, threshold: 3, sinceMs: 600000 },
+      { now: NOW },
+    );
+    expect(e.attributes["event.name"]).toBe(ALERT_CLEARED);
+    expect(e.attributes["event.action"]).toBe("cleared");
+    expect(e.attributes["event.label"]).toBe("needs_human_pileup");
+    expect(e.severityText).toBe("INFO");
+    expect(e.body.payload).toMatchObject({ kind: "needs_human_pileup", count: 0, threshold: 3, sinceMs: 600000 });
+  });
+});
+
+describe("emitAlertEvent (CTL-1123)", () => {
+  test("appends one JSON line and returns true", () => {
+    const dir = mkdtempSync(join(tmpdir(), "alert-emit-"));
+    try {
+      const logPath = join(dir, "events", "2026-06.jsonl");
+      const ok = emitAlertEvent(
+        { action: "raised", kind: ALERT_KIND_SYSTEM_DOWN, source: "catalyst.monitor" },
+        { logPath, now: NOW },
+      );
+      expect(ok).toBe(true);
+      expect(existsSync(logPath)).toBe(true);
+      const line = JSON.parse(readFileSync(logPath, "utf8").trim());
+      expect(line.attributes["event.name"]).toBe(ALERT_RAISED);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("append failure returns false and never throws (unwritable path)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "alert-emit-"));
+    try {
+      // a FILE where the events dir should be → mkdir/append ENOTDIR
+      const filePath = join(dir, "blocker");
+      writeFileSync(filePath, "x");
+      const logPath = join(filePath, "nested", "2026-06.jsonl");
+      let ok;
+      expect(() => {
+        ok = emitAlertEvent({ action: "raised", kind: ALERT_KIND_SYSTEM_DOWN }, { logPath, now: NOW });
+      }).not.toThrow();
+      expect(ok).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("nextPileupAlarmState — level debounce (CTL-1123)", () => {
+  const T = 3; // threshold
+  const P = 300_000; // persistence 5m
+  const C = 3_600_000; // cooldown 1h
+  const step = (prev, count, nowMs) => nextPileupAlarmState(prev, { count, threshold: T, nowMs, persistenceMs: P, cooldownMs: C });
+
+  test("below threshold → never raises", () => {
+    const r = step(initialPileupState(), 2, 1_000);
+    expect(r.emit).toBeNull();
+    expect(r.state.raised).toBe(false);
+  });
+
+  test("at/above threshold but within persistence window → no raise yet", () => {
+    let s = initialPileupState();
+    let r = step(s, 5, 0); // aboveSince=0, not yet persisted
+    expect(r.emit).toBeNull();
+    r = step(r.state, 5, P - 1); // still inside window
+    expect(r.emit).toBeNull();
+    expect(r.state.raised).toBe(false);
+  });
+
+  test("sustained past persistence → raises exactly once (edge-triggered)", () => {
+    let r = step(initialPileupState(), 5, 0);
+    r = step(r.state, 5, P); // persistence elapsed → raise
+    expect(r.emit).toBe("raised");
+    expect(r.state.raised).toBe(true);
+    r = step(r.state, 6, P + 60_000); // still above → no re-emit
+    expect(r.emit).toBeNull();
+  });
+
+  test("drop below threshold while raised → clears and arms cooldown", () => {
+    let r = step(initialPileupState(), 5, 0);
+    r = step(r.state, 5, P); // raised
+    r = step(r.state, 1, P + 1000); // drop → cleared
+    expect(r.emit).toBe("cleared");
+    expect(r.state.raised).toBe(false);
+    expect(r.state.clearedAt).toBe(P + 1000);
+  });
+
+  test("re-raise within cooldown is deferred, then fires once cooldown expires", () => {
+    let r = step(initialPileupState(), 5, 0);
+    r = step(r.state, 5, P); // raised
+    const clearAt = P + 1000;
+    r = step(r.state, 0, clearAt); // cleared, cooldown armed
+    // count climbs again immediately and persists, but we are inside cooldown
+    r = step(r.state, 5, clearAt + 10); // aboveSince set
+    r = step(r.state, 5, clearAt + P + 10); // persisted but still < cooldown after clear
+    expect(r.emit).toBeNull(); // deferred by cooldown
+    expect(r.state.raised).toBe(false);
+    // once cooldown has elapsed since the clear, the sustained pile-up raises
+    r = step(r.state, 5, clearAt + C + 1);
+    expect(r.emit).toBe("raised");
+  });
+
+  test("a one-tick spike (above then immediately below) never raises", () => {
+    let r = step(initialPileupState(), 9, 0); // spike, aboveSince=0
+    r = step(r.state, 0, 1000); // gone before persistence
+    expect(r.emit).toBeNull();
+    expect(r.state.raised).toBe(false);
+    expect(r.state.aboveSince).toBeNull();
+  });
+});
+
+describe("needs-human label taxonomy parity (CTL-1123)", () => {
+  test("NEEDS_HUMAN_LABELS matches board-data's canonical ATTENTION_LABEL_* constants", () => {
+    // Guards against a silent taxonomy drift (CTL-995): if board-data renames the
+    // labels, this fails so the broker's pile-up count is updated in lockstep.
+    expect(new Set(NEEDS_HUMAN_LABELS)).toEqual(
+      new Set([ATTENTION_LABEL_NEEDS_HUMAN, ATTENTION_LABEL_NEEDS_INPUT]),
+    );
+  });
+});

--- a/plugins/dev/scripts/broker/config.mjs
+++ b/plugins/dev/scripts/broker/config.mjs
@@ -119,6 +119,25 @@ export const INGESTION_RECENCY_HOLDDOWN_MS = parseInt(
 export const INGESTION_SEED_BYTES = parseInt(
   process.env.FILTER_INGESTION_SEED_BYTES ?? String(16 * 1024 * 1024), 10);
 
+// CTL-1123: broker alert-emit. The broker promotes detector signals into a stable
+// catalyst.alert.{raised,cleared} topic in the event log (otel-forward ships it to
+// the collector → Loki/dash0, where a separate "brain" routes to channels). Emit
+// is default-on with a call-time kill-switch (parity with isIngestionRecencyEnabled
+// — flip without a broker restart). system_down rides the CTL-1122 recency edges;
+// needs_human_pileup is a LEVEL count debounced by threshold + persistence + cooldown.
+export function isAlertEmitEnabled() {
+  return process.env.FILTER_ALERT_ENABLED !== "0";
+}
+// needs_human_pileup: how many active/non-terminal tickets must carry a
+// needs-human/needs-input label, for how long, before one alert fires; and the
+// minimum gap after a clear before it can re-fire (flap guard).
+export const PILEUP_THRESHOLD = parseInt(
+  process.env.FILTER_PILEUP_THRESHOLD ?? "3", 10);
+export const PILEUP_PERSISTENCE_MS = parseInt(
+  process.env.FILTER_PILEUP_PERSISTENCE_MS ?? "300000", 10);
+export const PILEUP_COOLDOWN_MS = parseInt(
+  process.env.FILTER_PILEUP_COOLDOWN_MS ?? "3600000", 10);
+
 // --- Event log ---
 export function getEventLogPath() {
   const now = new Date();

--- a/plugins/dev/scripts/broker/config.mjs
+++ b/plugins/dev/scripts/broker/config.mjs
@@ -128,15 +128,26 @@ export const INGESTION_SEED_BYTES = parseInt(
 export function isAlertEmitEnabled() {
   return process.env.FILTER_ALERT_ENABLED !== "0";
 }
+// Parse an int env knob with a default + lower bound, warning (not silently
+// degrading) on a malformed value. Without this a fat-fingered
+// FILTER_PILEUP_THRESHOLD=abc → NaN → `count >= NaN` is always false → the
+// detector silently never fires; =0 → always true → a spurious pile-up on an
+// empty board. A bad value falls back to the default and is logged loudly.
+function parseIntKnob(envVal, dflt, { min }) {
+  if (envVal === undefined) return dflt;
+  const n = parseInt(envVal, 10);
+  if (!Number.isFinite(n) || n < min) {
+    log.warn({ envVal, dflt, min }, "alert config: invalid knob value — using default");
+    return dflt;
+  }
+  return n;
+}
 // needs_human_pileup: how many active/non-terminal tickets must carry a
 // needs-human/needs-input label, for how long, before one alert fires; and the
 // minimum gap after a clear before it can re-fire (flap guard).
-export const PILEUP_THRESHOLD = parseInt(
-  process.env.FILTER_PILEUP_THRESHOLD ?? "3", 10);
-export const PILEUP_PERSISTENCE_MS = parseInt(
-  process.env.FILTER_PILEUP_PERSISTENCE_MS ?? "300000", 10);
-export const PILEUP_COOLDOWN_MS = parseInt(
-  process.env.FILTER_PILEUP_COOLDOWN_MS ?? "3600000", 10);
+export const PILEUP_THRESHOLD = parseIntKnob(process.env.FILTER_PILEUP_THRESHOLD, 3, { min: 1 });
+export const PILEUP_PERSISTENCE_MS = parseIntKnob(process.env.FILTER_PILEUP_PERSISTENCE_MS, 300000, { min: 0 });
+export const PILEUP_COOLDOWN_MS = parseIntKnob(process.env.FILTER_PILEUP_COOLDOWN_MS, 3600000, { min: 0 });
 
 // --- Event log ---
 export function getEventLogPath() {

--- a/plugins/dev/scripts/broker/ingestion-recency-wiring.test.mjs
+++ b/plugins/dev/scripts/broker/ingestion-recency-wiring.test.mjs
@@ -19,6 +19,7 @@ import {
   __getLastSeenByServiceForTest,
   __getMonitorRecencyAlarmForTest,
   __getRecencyAlarmForTest,
+  __clearAlertStateForTest,
 } from "./router.mjs";
 import { GITHUB_SERVICE_NAME, LINEAR_SERVICE_NAME } from "./ingestion-recency.mjs";
 import {
@@ -47,6 +48,7 @@ beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), "ingestion-wiring-"));
   process.env.CATALYST_DIR = dir; // getEventLogPath re-reads this per call
   __clearIngestionRecencyForTest();
+  __clearAlertStateForTest(); // CTL-1123: reset the shared pile-up module global
   clearInterests();
   clearLastHeartbeat();
   __resetBrokerStartedAtForTest(); // uptime 0 → no spurious broker.daemon.degraded

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -379,6 +379,10 @@ let _pileupState = initialPileupState();
 // CTL-1123: terminal Linear states excluded from the needs-human pile-up count —
 // a Done/Canceled ticket can still carry a stale needs-human label in the cache
 // (cache-drift, CTL-1161), which would pin the count above threshold forever.
+// These mirror the stateMap done/canceled mappings in .catalyst/config.json; if
+// the team renames those Linear states, update here too (config-drives-behavior —
+// a drift would silently stop excluding terminal tickets → a never-clearing
+// false pile-up). Review #10.
 const TERMINAL_LINEAR_STATES = new Set(["Done", "Canceled"]);
 
 // CTL-1122 PR2: per-source alarm state. PR1 keyed a single _monitorRecencyAlarm;
@@ -603,9 +607,13 @@ function checkSourceRecency(source, now) {
     // state. Only fires once the ingestion emit above SUCCEEDED, keeping the two
     // streams paired.
     if (source.alertKind && isAlertEmitEnabled()) {
-      emitAlertEvent({
+      const alertOk = emitAlertEvent({
         action: recovered ? "cleared" : "raised",
         kind: source.alertKind,
+        // NOTE (CTL-1123 review #9): if a GATED source is ever given an alertKind,
+        // distinguish a gate-driven recovery (beatDrivenRecovery===false → a null
+        // forensicSeen) from a real one before asserting "recovered" here. The
+        // monitor source is ungated, so today recovered always means a fresh beat.
         reason: recovered
           ? `${source.serviceName} ingestion recovered`
           : `${source.serviceName} ingestion silent past ${source.downAfterMs}ms`,
@@ -613,6 +621,20 @@ function checkSourceRecency(source, now) {
         sinceMs: ageMs,
         causedBy: forensicSeen?.id ?? null,
       });
+      if (!alertOk) {
+        // KNOWN GAP (CTL-1123 review #7): the recency alarm has already latched
+        // (downEmitted) and we deliberately do NOT couple the alert back into that
+        // latch (re-running would risk re-appending the ingestion event), so this
+        // promotion is not retried for this edge — a failed raise means no
+        // system_down until recovery. Acceptable while catalyst.alert.* has no
+        // pairing consumer; when the alert "brain" lands, add a per-source
+        // alert-pending retry that re-attempts the promotion alone. Logged so the
+        // gap is visible meanwhile (vs the silent discard the review flagged).
+        log.warn(
+          { source: source.serviceName, kind: source.alertKind, action: recovered ? "cleared" : "raised" },
+          "alert-emit: catalyst.alert append failed; promotion skipped for this edge",
+        );
+      }
     }
   }
   _recencyAlarmByService.set(source.serviceName, state);

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -29,6 +29,10 @@ import {
   ORCH_STATUS_REPLAY_STALE_MS,
   DETERMINISTIC_INTEREST_TYPES,
   isIngestionRecencyEnabled,
+  isAlertEmitEnabled,
+  PILEUP_THRESHOLD,
+  PILEUP_PERSISTENCE_MS,
+  PILEUP_COOLDOWN_MS,
   MONITOR_RECENCY_DEGRADED_MS,
   MONITOR_RECENCY_DOWN_MS,
   GITHUB_RECENCY_DEGRADED_MS,
@@ -75,6 +79,7 @@ import {
   upsertWaitingSession,
   clearWaitingSession,
   hasActiveWorkers,
+  getAllTicketDescriptors,
 } from "./broker-state.mjs";
 import { sessionLiveness } from "./session-liveness.mjs";
 import {
@@ -112,6 +117,16 @@ import {
   nextRecencyAlarmState,
   emitIngestionRecencyEvent,
 } from "./ingestion-recency.mjs";
+// CTL-1123: the broker alert-emit foundation — promote detector signals into a
+// stable catalyst.alert.* topic in the event log (delivery is a separate story).
+import {
+  ALERT_KIND_SYSTEM_DOWN,
+  ALERT_KIND_NEEDS_HUMAN_PILEUP,
+  NEEDS_HUMAN_LABELS,
+  emitAlertEvent,
+  initialPileupState,
+  nextPileupAlarmState,
+} from "./alert-emit.mjs";
 import { scanEventsChunked } from "../execution-core/event-tail.mjs";
 
 // Identity-stable aliases for the shared maps — the router mutates these; the
@@ -357,6 +372,15 @@ export function __clearEmittedWakeCacheForTest() {
 // it can never observe its own death.
 const _lastSeenByService = new Map(); // service.name -> { ts: epochMs, id: string|null }
 
+// CTL-1123: the needs_human_pileup LEVEL-alarm state (a single broker-wide count,
+// not per-source). Advanced each watchdog tick by checkNeedsHumanPileup.
+let _pileupState = initialPileupState();
+
+// CTL-1123: terminal Linear states excluded from the needs-human pile-up count —
+// a Done/Canceled ticket can still carry a stale needs-human label in the cache
+// (cache-drift, CTL-1161), which would pin the count above threshold forever.
+const TERMINAL_LINEAR_STATES = new Set(["Done", "Canceled"]);
+
 // CTL-1122 PR2: per-source alarm state. PR1 keyed a single _monitorRecencyAlarm;
 // the watchdog now judges several sources (monitor + the activity-gated
 // github/linear webhook ingestion), each with its own edge-trigger/holddown
@@ -374,12 +398,18 @@ const RECENCY_SOURCES = [
     degradedAfterMs: MONITOR_RECENCY_DEGRADED_MS,
     downAfterMs: MONITOR_RECENCY_DOWN_MS,
     gated: false,
+    // CTL-1123: the monitor going sustained-stale IS a stack-health outage — the
+    // broker promotes that recency edge to a catalyst.alert.* system_down topic.
+    alertKind: ALERT_KIND_SYSTEM_DOWN,
   },
   {
     serviceName: GITHUB_SERVICE_NAME,
     degradedAfterMs: GITHUB_RECENCY_DEGRADED_MS,
     downAfterMs: GITHUB_RECENCY_DOWN_MS,
     gated: true,
+    // github silence is a degraded-ingestion signal, not "system down" — no alert
+    // promotion for now (a future kind, e.g. ingestion_degraded, can set this).
+    alertKind: null,
   },
   // linear (catalyst.linear) is DEFERRED in PR2 (fork a): the linear-webhook
   // bot-skip guard suppresses bot-authored issue events before they reach the
@@ -565,8 +595,97 @@ function checkSourceRecency(source, now) {
       // recovered from pairing against a stale that was never appended.)
       return null;
     }
+    // CTL-1123: promote a CRITICAL source's recency edge to a catalyst.alert.*
+    // topic (e.g. the monitor going sustained-stale = a stack-health outage).
+    // Rides the already-debounced ingestion edge (one raised per outage, one
+    // cleared per recovery) — no extra debounce. Best-effort + kill-switched; an
+    // alert-emit failure never affects the (already-appended + latched) recency
+    // state. Only fires once the ingestion emit above SUCCEEDED, keeping the two
+    // streams paired.
+    if (source.alertKind && isAlertEmitEnabled()) {
+      emitAlertEvent({
+        action: recovered ? "cleared" : "raised",
+        kind: source.alertKind,
+        reason: recovered
+          ? `${source.serviceName} ingestion recovered`
+          : `${source.serviceName} ingestion silent past ${source.downAfterMs}ms`,
+        source: source.serviceName,
+        sinceMs: ageMs,
+        causedBy: forensicSeen?.id ?? null,
+      });
+    }
   }
   _recencyAlarmByService.set(source.serviceName, state);
+  return emit;
+}
+
+// countNeedsHumanTickets — the surviving-process pile-up signal: how many
+// active/non-terminal tickets carry a needs-human/needs-input label in the
+// broker's OWN filter-state.db. Reads the SAME label source as deriveAttention
+// (board-data.mjs) but does NOT fork it — it deliberately omits the monitor-only
+// prStuck/phaseFailed signals (not in filter-state.db), so this UNDERCOUNTS the
+// dashboard inbox. Scoped to non-removed, non-terminal tickets so a stale
+// needs-human label on a Done/Canceled ticket (cache-drift, CTL-1161) can't pin
+// the count above threshold forever. Best-effort: a db read failure → 0 (no false
+// pile-up alert), consistent with the detector's no-false-alarm posture.
+function countNeedsHumanTickets() {
+  try {
+    let n = 0;
+    for (const d of getAllTicketDescriptors()) {
+      if (d.removed) continue;
+      if (d.state && TERMINAL_LINEAR_STATES.has(d.state)) continue;
+      const labels = Array.isArray(d.labels) ? d.labels : [];
+      if (labels.some((l) => NEEDS_HUMAN_LABELS.includes(l))) n += 1;
+    }
+    return n;
+  } catch {
+    return 0;
+  }
+}
+
+// checkNeedsHumanPileup — one watchdog-tick evaluation of the needs-human pile-up
+// LEVEL signal → edge-triggered catalyst.alert.{raised,cleared}. Kill-switched
+// (isAlertEmitEnabled). The threshold + persistence + cooldown debounce lives in
+// nextPileupAlarmState; this wires the broker count into it and emits. Returns the
+// emit decision for the wiring test.
+function checkNeedsHumanPileup(now) {
+  if (!isAlertEmitEnabled()) return null;
+  const count = countNeedsHumanTickets();
+  const prev = _pileupState;
+  const { state, emit } = nextPileupAlarmState(prev, {
+    count,
+    threshold: PILEUP_THRESHOLD,
+    nowMs: now,
+    persistenceMs: PILEUP_PERSISTENCE_MS,
+    cooldownMs: PILEUP_COOLDOWN_MS,
+  });
+  if (emit) {
+    const raised = emit === "raised";
+    // raised: how long the count had been above threshold; cleared: how long the
+    // alert had been open. Read from prev (pre-advance) so it reflects the elapsed
+    // condition, clamped against clock skew.
+    const sinceMs = raised
+      ? prev.aboveSince != null
+        ? Math.max(0, now - prev.aboveSince)
+        : null
+      : prev.raisedAt != null
+        ? Math.max(0, now - prev.raisedAt)
+        : null;
+    const ok = emitAlertEvent({
+      action: raised ? "raised" : "cleared",
+      kind: ALERT_KIND_NEEDS_HUMAN_PILEUP,
+      reason: raised
+        ? `${count} active tickets need a human (>= ${PILEUP_THRESHOLD})`
+        : `needs-human pile-up cleared (${count} < ${PILEUP_THRESHOLD})`,
+      count,
+      threshold: PILEUP_THRESHOLD,
+      sinceMs,
+    });
+    // Append failed → do NOT advance the level-alarm state; the next tick
+    // re-attempts (a sustained pile-up is never reduced to one lost line).
+    if (!ok) return null;
+  }
+  _pileupState = state;
   return emit;
 }
 
@@ -603,6 +722,20 @@ export function __getMonitorRecencyAlarmForTest() {
 // PR2: per-source accessor for the github/linear isolation tests.
 export function __getRecencyAlarmForTest(serviceName) {
   return recencyAlarmFor(serviceName);
+}
+// CTL-1123: needs-human pile-up alert-state seams.
+export function __clearAlertStateForTest() {
+  _pileupState = initialPileupState();
+}
+export function __getPileupStateForTest() {
+  return _pileupState;
+}
+// Lets the wiring test position the level machine at an edge (e.g. pre-set
+// aboveSince in the past so persistence is satisfied) without driving real
+// wall-clock time through runWatchdogTick — the timing logic itself is covered by
+// the pure nextPileupAlarmState unit tests.
+export function __setPileupStateForTest(state) {
+  _pileupState = { ...initialPileupState(), ...state };
 }
 
 // CTL-357: one-shot startup event. If the Groq prose path is gated off (the
@@ -1959,6 +2092,11 @@ export function runWatchdogTick({ liveness = sessionLiveness } = {}) {
   // the surviving-process observation the 11h silent outage proved we were
   // missing. PR1 = monitor heartbeat; PR2 = activity-gated github webhooks.
   for (const source of RECENCY_SOURCES) checkSourceRecency(source, now);
+
+  // CTL-1123: needs-human pile-up → catalyst.alert.{raised,cleared}. A LEVEL
+  // signal (a count) with its own threshold + persistence + cooldown debounce —
+  // distinct from the per-source recency edges above.
+  checkNeedsHumanPileup(now);
 
   let watchdogWoke = false;
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -258,3 +258,14 @@ The broker tails every event, so it is the surviving process that can notice whe
 - `FILTER_INGESTION_RECENCY_HOLDDOWN_MS` (default `600000`) — flap guard: minimum gap between a recovery and the next stale alarm. A sustained outage that begins inside the window is deferred (re-checked each tick), never dropped.
 
 Linear (`catalyst.linear`) recency is intentionally **not** wired: the linear-webhook bot-skip guard suppresses bot-authored events before they reach the log, so the source goes quiet even during active work. Its knobs (`FILTER_LINEAR_RECENCY_*`) are reserved for when a non-flaky threshold is found.
+
+### Out-of-band alert topics (CTL-1123)
+
+The detector above only emits low-level `catalyst.ingestion.*` events. CTL-1123 adds an **alert-policy** layer in the broker: it promotes the operator-actionable subset into a stable, intentional **`catalyst.alert.{raised,cleared}`** topic (`event.entity=alert`, `event.label` = the alert *kind*). Those events flow through the event log → `otel-forward` → the OTel collector → fan-out (Loki, dash0), where a downstream alert rule routes them to a channel. **Delivery is deliberately out of scope** — the broker emits intent only; no channel or credential lives in the daemon. These knobs are env vars on the `catalyst-broker` process:
+
+- `FILTER_ALERT_ENABLED` (default on; set `0` to disable) — master kill-switch for alert emission, read at call time (toggles without a broker restart).
+- The **`system_down`** alert is promoted from a *critical* source's sustained `catalyst.ingestion.stale` (currently `catalyst.monitor` — a dead monitor). It rides that already-debounced recency edge, so it has no thresholds of its own; raised on stale, cleared on recovered.
+- The **`needs_human_pileup`** alert is a level signal: how many **active, non-terminal** tickets carry a `needs-human`/`needs-input` label in the broker's `filter-state.db` (Done/Canceled and removed tickets are excluded so a stale cached label can't pin the count). Knobs:
+  - `FILTER_PILEUP_THRESHOLD` (default `3`) — minimum labelled-ticket count to alert.
+  - `FILTER_PILEUP_PERSISTENCE_MS` (default `300000`) — the count must stay at/above the threshold this long before one alert fires (spike guard).
+  - `FILTER_PILEUP_COOLDOWN_MS` (default `3600000`) — minimum gap after a clear before it can re-fire (flap guard).


### PR DESCRIPTION
## What

The surviving **broker** promotes operator-actionable detector signals into a stable **`catalyst.alert.{raised,cleared}`** topic in the event log. `otel-forward` ships it to the OTel collector → fan-out (Loki, dash0), where a separate "brain" (alert rule → channel) does delivery. **The broker emits intent only** — no channel, no credential in the daemon — so the alerter survives a monitor death without depending on it.

This is the **emit foundation** of CTL-1123, reframed from the original "out-of-band escalation" goal: delivery (channel + alert-rule brain — dash0 / Grafana-Loki / Catalyst-native `/api/otel/uptime`, TBN) is a **separate story**.

## Contract (the API everything keys off)

```
event.name   = catalyst.alert.raised | catalyst.alert.cleared
event.entity = alert
event.label  = "system_down" | "needs_human_pileup"      # the alert KIND
severity     = ERROR (raised) / INFO (cleared)
resource."service.name" = catalyst.broker                 # the surviving emitter
body.payload = { kind, reason, source?, count?, threshold?, sinceMs? }
```

## How

- **`broker/alert-emit.mjs`** — `buildAlertEnvelope` (hand-built canonical, mirrors CTL-1122's `buildIngestionRecencyEnvelope`), `emitAlertEvent` (best-effort, never throws), and the pure `nextPileupAlarmState` level machine (threshold + persistence + cooldown). `NEEDS_HUMAN_LABELS` defined **locally** (no runtime monitor coupling) + a **parity test** vs `board-data`'s `ATTENTION_LABEL_*` so a taxonomy rename (CTL-995) can't silently drift the count.
- **`system_down`** — promoted from a *critical* source's sustained `catalyst.ingestion.stale` (the monitor; `alertKind` on `RECENCY_SOURCES`). Rides CTL-1122's already-debounced edge — no new debounce. raised on stale, cleared on recovered, only after the ingestion emit succeeds (paired). github stays unpromoted (`alertKind: null`).
- **`needs_human_pileup`** — count of `needs-human`/`needs-input` labels in the broker's own `filter-state.db` via `getAllTicketDescriptors`, **scoped to active/non-terminal** tickets (excludes Done/Canceled + removed, so cache-drift can't pin it — CTL-1161). Reads the **same label source** as `deriveAttention` **without forking it** (honestly undercounts `prStuck`/`phaseFailed`).
- Both kill-switched (`FILTER_ALERT_ENABLED`), fired in `runWatchdogTick`. Config: `FILTER_PILEUP_{THRESHOLD,PERSISTENCE_MS,COOLDOWN_MS}` (NaN/min-guarded).
- docs: configuration reference + orchestrator-overview alert-policy note.

## Adversarial review

Ran a 4-lens review workflow (survivability, pile-up correctness, system_down wiring, reuse/drift) + a verify pass. **Verdict: ready to PR, zero must-fix** — all findings are accurate but *latent* (no `catalyst.alert.*` consumer exists yet, so the ledger-pairing gaps have nothing to mishandle). Applied the cheap net-positive items in `5531b9eb`: config NaN/zero clamp, append-fail visibility + a documented deferred retry for when the brain lands, drift notes, and a test-state reset.

## Tests
+19 (envelope/emit, pure pile-up machine incl. persistence+cooldown, label parity; wiring: system_down raised/cleared, github-no-promote, kill-switch, pile-up raised/cleared/scoping/below-threshold). **Full broker suite 696 pass.**

## Out of scope (separate story, brain TBN)
Channel selection; dash0/Grafana alert rules; Catalyst-native uptime/alerting API; persisting alert dedup state across broker restart.