### PR TITLE
CTL-1280: each long-running daemon emits a periodic heartbeat log line for deterministic liveness

### DIFF
--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -110,6 +110,7 @@ import {
 // execution-core deps — reused instead of re-reading the whole multi-hundred-MB
 // log per the design-review D2 blocker).
 import { evaluateSource } from "../lib/ingestion-recency.mjs";
+import { logDaemonHeartbeat } from "../lib/daemon-heartbeat.mjs";
 import {
   MONITOR_SERVICE_NAME,
   GITHUB_SERVICE_NAME,
@@ -2081,6 +2082,13 @@ function queueEvent(event) {
 // the legacy heartbeat-ts staleness below, so behavior is unchanged for those.
 export function runWatchdogTick({ liveness = sessionLiveness } = {}) {
   const now = Date.now();
+
+  // CTL-1280: deterministic liveness heartbeat. One fixed-cadence line to
+  // broker.log every watchdog tick (~60s) so an Alloy→Loki liveness check can
+  // watch for the heartbeat marker instead of relying on incidental log volume (a
+  // quiet-but-healthy daemon would otherwise read as silent/down). Rides the
+  // Alloy .log stream → independent of the otel-forward event pipeline.
+  logDaemonHeartbeat(log, "broker");
 
   // CTL-352: empty-interests observability. Warn on every tick when the table
   // is empty so a silently-dead broker is loud in broker.log, and emit a

--- a/plugins/dev/scripts/execution-core/heartbeat-event.mjs
+++ b/plugins/dev/scripts/execution-core/heartbeat-event.mjs
@@ -24,6 +24,7 @@ import {
   readGovernanceConfig,
 } from "./config.mjs";
 import { hostName, hostId } from "./lib/host-identity.mjs";
+import { logDaemonHeartbeat } from "../lib/daemon-heartbeat.mjs";
 
 export const HEARTBEAT_EVENT = "node.heartbeat";
 
@@ -107,7 +108,14 @@ export async function emitHeartbeatEvent({ logPath = getEventLogPath(), now, epo
  * @param {string} [opts.logPath]     event-log path (injectable for tests)
  */
 export function startHeartbeat({ intervalMs = HEARTBEAT_INTERVAL_MS, logPath } = {}) {
-  const tick = () => emitHeartbeatEvent({ logPath }).catch(() => {});
+  const tick = () => {
+    // CTL-1280: deterministic liveness heartbeat to daemon.log (Alloy→Loki),
+    // riding the same cadence as the node.heartbeat event but on the .log stream
+    // so a liveness check can watch the heartbeat marker independent of the
+    // otel-forward event pipeline (a quiet-but-healthy daemon must still prove it).
+    logDaemonHeartbeat(log, "execution-core");
+    return emitHeartbeatEvent({ logPath }).catch(() => {});
+  };
   const started = tick(); // emit once at boot; Promise for callers that need to await it
   const timer = setInterval(tick, intervalMs);
   timer.unref?.();

--- a/plugins/dev/scripts/lib/daemon-heartbeat.d.mts
+++ b/plugins/dev/scripts/lib/daemon-heartbeat.d.mts
@@ -1,0 +1,8 @@
+// Types for daemon-heartbeat.mjs (CTL-1280) — the runtime stays .mjs so the
+// broker/execution-core .mjs daemons import it unchanged; this gives the TS
+// consumers (orch-monitor/server.ts, otel-forward/index.ts) proper types.
+export const DAEMON_HEARTBEAT_MSG: string;
+export function logDaemonHeartbeat(
+  log: { info: (obj: unknown, msg: string) => void },
+  component: string,
+): void;

--- a/plugins/dev/scripts/lib/daemon-heartbeat.mjs
+++ b/plugins/dev/scripts/lib/daemon-heartbeat.mjs
@@ -1,0 +1,15 @@
+// daemon-heartbeat.mjs — CTL-1280. The single source of the daemon-liveness
+// heartbeat marker. Every long-running daemon logs this line on its periodic loop
+// to its .log file (broker.log / execution-core/daemon.log / otel-forward.log /
+// monitor.log), which Alloy ships to Loki. A liveness check counts this EXACT line
+// per service_name × catalyst_node_name over a short window — so the marker must
+// stay in lockstep across all daemons AND the Loki query. Defining it once here
+// prevents drift (a renamed marker on one daemon would silently read as "down").
+export const DAEMON_HEARTBEAT_MSG = "daemon heartbeat";
+
+// logDaemonHeartbeat — emit the heartbeat via a pino-style logger (broker,
+// execution-core, otel-forward). The monitor writes to a plain console stream, so
+// it uses DAEMON_HEARTBEAT_MSG directly instead of this helper.
+export function logDaemonHeartbeat(log, component) {
+  log.info({ hb: true, component }, DAEMON_HEARTBEAT_MSG);
+}

--- a/plugins/dev/scripts/lib/daemon-heartbeat.test.mjs
+++ b/plugins/dev/scripts/lib/daemon-heartbeat.test.mjs
@@ -1,0 +1,29 @@
+// Unit tests for the shared daemon-liveness heartbeat marker (CTL-1280).
+// Run: bun test plugins/dev/scripts/lib/daemon-heartbeat.test.mjs
+import { describe, test, expect } from "bun:test";
+import { DAEMON_HEARTBEAT_MSG, logDaemonHeartbeat } from "./daemon-heartbeat.mjs";
+
+describe("daemon heartbeat marker (CTL-1280)", () => {
+  test("DAEMON_HEARTBEAT_MSG is the exact string the Loki liveness query matches", () => {
+    // If this string changes, the Gatus + Grafana liveness queries (|= "daemon
+    // heartbeat") must change in lockstep — otherwise every daemon reads as down.
+    expect(DAEMON_HEARTBEAT_MSG).toBe("daemon heartbeat");
+  });
+
+  test("logDaemonHeartbeat emits info with the marker, component, and hb flag", () => {
+    const calls = [];
+    const fakeLog = { info: (obj, msg) => calls.push({ obj, msg }) };
+    logDaemonHeartbeat(fakeLog, "broker");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].msg).toBe(DAEMON_HEARTBEAT_MSG);
+    expect(calls[0].obj).toEqual({ hb: true, component: "broker" });
+  });
+
+  test("component is carried through verbatim for each daemon", () => {
+    for (const c of ["broker", "execution-core", "otel-forward"]) {
+      const calls = [];
+      logDaemonHeartbeat({ info: (obj, msg) => calls.push({ obj, msg }) }, c);
+      expect(calls[0].obj.component).toBe(c);
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -11,6 +11,7 @@ import {
 } from "./lib/state-reader";
 import { readSessionStore } from "./lib/session-store";
 import { readReconcileHealth } from "./lib/reconcile-health-reader"; // CTL-867
+import { DAEMON_HEARTBEAT_MSG } from "../lib/daemon-heartbeat.mjs"; // CTL-1280
 import type { BoardPayload } from "./lib/board-data.mjs";
 import { assembleBoard, _getTranscriptCacheSize } from "./lib/board-data.mjs";
 import { createBoardSnapshotManager } from "./lib/board-snapshot.mjs";
@@ -932,6 +933,11 @@ export function createServer(opts: CreateServerOptions): BunServer {
         // tick or a dead process stops the heartbeat, which the broker's recency check
         // then catches. (No self-descriptor flip → the in-monitor UI is unchanged.)
         void serviceHealthEventLog.append(buildMonitorHeartbeatEvent(new Date().toISOString()));
+        // CTL-1280: deterministic liveness heartbeat to monitor.log (Alloy→Loki),
+        // on the same ~30s tick. monitor.log is the console stream Alloy ships, so a
+        // liveness check can watch for the shared heartbeat marker independent of the
+        // otel-forward event pipeline (the heartbeat EVENT above rides otel-forward).
+        console.info(`${DAEMON_HEARTBEAT_MSG} (monitor)`);
       },
     });
 

--- a/plugins/dev/scripts/otel-forward/index.ts
+++ b/plugins/dev/scripts/otel-forward/index.ts
@@ -8,6 +8,7 @@ import { loadForwarderConfig } from "./lib/config.ts";
 import { readCheckpoint, writeCheckpoint } from "./lib/checkpoint.ts";
 import { createTailer } from "./lib/tail.ts";
 import { log } from "./lib/logger.ts";
+import { logDaemonHeartbeat } from "../lib/daemon-heartbeat.mjs";
 import { OtlpSender } from "./lib/destinations/otlp.ts";
 import { PosthogSender } from "./lib/destinations/posthog.ts";
 import { CloudflareAESender } from "./lib/destinations/cloudflare-ae.ts";
@@ -117,6 +118,12 @@ const senders = {
 };
 
 function emitLag(): void {
+  // CTL-1280: deterministic liveness heartbeat to otel-forward.log (Alloy→Loki),
+  // emitted UNCONDITIONALLY each tick — BEFORE the cold-start skip below — so an
+  // idle/quiet forwarder still proves it is alive (it previously wrote only a
+  // startup line then went silent, reading as down). Rides the Alloy .log stream,
+  // independent of the event pipeline this daemon itself ships.
+  logDaemonHeartbeat(log, "otel-forward");
   // Skip on cold start before any event has been processed or delivered
   if (!lastLocalTs && !lastForwardedTs) return;
   try {


### PR DESCRIPTION
## What

Liveness monitoring (the home Gatus status page + the Grafana "Liveness — daemon × node" panel) counts each daemon's Alloy-shipped `.log` lines per node; **0 lines in the window = "down."** That conflates *down* with *quiet*: `otel-forward` and `monitor` write only a startup line then go silent (their ongoing signal is *events*, not logs), so a healthy daemon shows red. This makes liveness **deterministic** — every long-running daemon logs a fixed-cadence `"daemon heartbeat"` line to its `.log` on its existing loop. Liveness becomes "saw a heartbeat in N minutes," and because it rides the **Alloy `.log` stream** it's independent of the `otel-forward` event pipeline.

## How

- **`lib/daemon-heartbeat.mjs`** — single source of the marker (`DAEMON_HEARTBEAT_MSG`) + `logDaemonHeartbeat(log, component)`, so the string can't drift from the Loki query that matches it. A co-located `.d.mts` types the TS consumers; the runtime stays `.mjs` for the `.mjs` daemons.
- **broker** — `runWatchdogTick` (~60s). **execution-core** — `startHeartbeat` tick (same cadence as `node.heartbeat`, but to `daemon.log`). **monitor** — `onTick` (~30s, `console` → `monitor.log`). **otel-forward** — `emitLag`, *before* its cold-start skip so an idle forwarder still beats.

## Why this matters
It fixes two real reds on the status page that are false: `otel-forward@mini` and `monitor@mini-2` are actually up (verified — otel-forward is forwarding, the alert pipeline reaches Loki) but weren't logging on a cadence.

## Tests
+3 unit (marker / helper / per-component). Broker **696 pass**, otel-forward **75 pass**, execution-core 16 pass (1 pre-existing env-dependent hostname test, unrelated — fails identically on base main). orch-monitor + otel-forward typecheck clean.

## Follow-up (out of band)
Tighten the Gatus + Grafana liveness query to `count_over_time({service_name="catalyst.<svc>"} | catalyst_node_name="<node>" |= "daemon heartbeat" [5m]) > 0` once deployed. Also: reap the duplicate `otel-forward` process on mini.