### PR TITLE
feat(dev): CTL-1277 — periodic broker reconcile of board cache state+labels vs live Linear

### DIFF
--- a/plugins/dev/scripts/broker/cache-reconcile.mjs
+++ b/plugins/dev/scripts/broker/cache-reconcile.mjs
@@ -1,0 +1,255 @@
+// cache-reconcile.mjs — periodic broker-side reconcile of the board cache
+// (filter-state.db ticket_state) against LIVE Linear, for the fields the board
+// derives from: linear_state + labels (CTL-1277).
+//
+// WHY: ticket_state is webhook-fed (foldLinearIssueDescriptor). A single missed
+// linear.issue.* webhook leaves a row's state/labels wrong indefinitely — the
+// board then lies (proven: CTL-764 live=Implement but cache=Todo). Nothing
+// periodically re-syncs it. This generalizes the CTL-1031 label backfill from a
+// one-shot CLI into a periodic state+labels reconcile over the working set.
+//
+// This is the INTERIM bridge. The durable fix is the Pillar-1 cloud read-mirror;
+// its reconciler reuses exactly this delta-fetch+diff shape (the design doc
+// flags this as a port, not throwaway). RELATIONS are a separate ticket
+// (CTL-1278) — they need a full-poll-and-diff with delete-absent and have no
+// existing fetch path.
+//
+// The broker is the SOLE ticket_state writer (execution-core opens it read-only
+// via gateway-read). This module only ever writes via upsertTicketDescriptor's
+// KEY-PRESENCE contract: it passes ONLY the reconciled fields, so every other
+// column (assignee, priority, estimate, relations, fence projection) is left
+// untouched.
+
+import { spawnSync } from "node:child_process";
+import {
+  getAllTicketDescriptors,
+  upsertTicketDescriptor,
+} from "./broker-state.mjs";
+import { extractLabelNames } from "./backfill-ticket-labels.mjs";
+
+// Mode knob: env CATALYST_CACHE_RECONCILE overrides Layer-2 config; operators
+// opt in via =shadow (log would-write, touch nothing) then =enforce (write).
+// Default OFF — zero behaviour change until explicitly enabled.
+export function readCacheReconcileConfig(env = process.env) {
+  const raw = String(env.CATALYST_CACHE_RECONCILE ?? "off").toLowerCase();
+  const mode = raw === "shadow" || raw === "enforce" ? raw : "off";
+  const intervalMs = positiveIntOr(
+    env.CATALYST_CACHE_RECONCILE_INTERVAL_MS,
+    10 * 60_000, // 10 min — gentle on the per-host Linear key (self-constraint)
+  );
+  const perPassCap = positiveIntOr(env.CATALYST_CACHE_RECONCILE_CAP, 250);
+  return { mode, intervalMs, perPassCap };
+}
+
+function positiveIntOr(raw, fallback) {
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+// Linear states whose tickets we skip — once a ticket is terminal its board
+// state/labels no longer drive dispatch, and reading them every pass is wasted
+// API budget. (Terminal needs-human reap is a separate concern — CTL-1242.)
+const TERMINAL_STATES = new Set(["done", "canceled", "cancelled", "duplicate"]);
+
+function isTerminal(state) {
+  return TERMINAL_STATES.has(String(state ?? "").toLowerCase());
+}
+
+// extractState — pull the state NAME out of a `linearis issues read` JSON object.
+// linearis returns `state: { id, name }`. Returns the name string, or null when
+// state is absent/malformed (caller treats null as "unknown — do not touch").
+export function extractState(readJson) {
+  if (readJson === null || typeof readJson !== "object") return null;
+  const state = readJson.state;
+  if (state === null || typeof state !== "object" || Array.isArray(state)) return null;
+  const name = state.name;
+  return typeof name === "string" && name.length > 0 ? name : null;
+}
+
+function arraysEqualAsSets(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) return false;
+  if (a.length !== b.length) return false;
+  const sb = new Set(b);
+  return a.every((x) => sb.has(x));
+}
+
+// decideReconcile — pure per-ticket decision. Given the cached descriptor (or
+// null) and the freshly-fetched live state/labels (each null when the fetch was
+// unusable for that field), decide which fields drifted and must be written.
+// KEY-PRESENCE: only fields with writeX:true are sent to upsert — never the rest.
+export function decideReconcile({ current, fetchedState, fetchedLabels }) {
+  const storedState = current && typeof current.state === "string" ? current.state : null;
+  const storedLabels = current && Array.isArray(current.labels) ? current.labels : null;
+
+  // null fetch → unknown → leave untouched. A case-insensitive state match is
+  // "no drift" (Linear "Implement" vs a cache "implement" is the same column).
+  const writeState =
+    fetchedState !== null &&
+    (storedState === null ||
+      storedState.toLowerCase() !== fetchedState.toLowerCase());
+
+  const writeLabels =
+    fetchedLabels !== null &&
+    !(storedLabels !== null && arraysEqualAsSets(storedLabels, fetchedLabels));
+
+  const reasons = [];
+  if (writeState) reasons.push(`state ${JSON.stringify(storedState)} → ${JSON.stringify(fetchedState)}`);
+  if (writeLabels) reasons.push(`labels ${JSON.stringify(storedLabels)} → ${JSON.stringify(fetchedLabels)}`);
+
+  return {
+    writeState,
+    state: writeState ? fetchedState : undefined,
+    writeLabels,
+    labels: writeLabels ? fetchedLabels : undefined,
+    changed: writeState || writeLabels,
+    reason: reasons.length ? reasons.join("; ") : "already current",
+  };
+}
+
+// fetchLive — spawn `linearis issues read <ticket>` and parse its JSON.
+// linearis emits JSON by default (NO --json flag) and EATS STDIN in loops, so
+// we pass stdin "ignore". Returns { state, labels, error }: state/labels null on
+// any failure (fail-soft — leave the row for the next pass).
+function fetchLive(ticket) {
+  let res;
+  try {
+    res = spawnSync("linearis", ["issues", "read", ticket], {
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+  } catch (e) {
+    return { state: null, labels: null, error: String(e?.message ?? e) };
+  }
+  if (res.status !== 0 || !res.stdout) {
+    return { state: null, labels: null, error: (res.stderr || "").trim() || `exit ${res.status}` };
+  }
+  let json;
+  try {
+    json = JSON.parse(res.stdout);
+  } catch (e) {
+    return { state: null, labels: null, error: `unparseable JSON: ${String(e)}` };
+  }
+  return { state: extractState(json), labels: extractLabelNames(json), error: null };
+}
+
+// reconcileCacheState — one full pass over the working set. Injectable deps keep
+// it unit-testable with no spawn / no DB. Returns a summary {mode,scanned,changed,
+// failed,tickets[]} for the audit emit. NEVER throws — a per-ticket failure is
+// counted and skipped (fail-soft).
+export function reconcileCacheState({
+  mode = "off",
+  perPassCap = 250,
+  getAll = getAllTicketDescriptors,
+  fetch = fetchLive,
+  upsert = upsertTicketDescriptor,
+  log = () => {},
+} = {}) {
+  if (mode === "off") return { mode, scanned: 0, changed: 0, failed: 0, tickets: [] };
+
+  let descriptors;
+  try {
+    descriptors = getAll({ includeRemoved: false }) || [];
+  } catch (e) {
+    log("warn", { err: String(e?.message ?? e) }, "cache-reconcile: getAll failed — skipping pass");
+    return { mode, scanned: 0, changed: 0, failed: 0, tickets: [] };
+  }
+
+  const working = descriptors.filter((d) => d && d.ticket && !isTerminal(d.state)).slice(0, perPassCap);
+
+  let scanned = 0;
+  let changed = 0;
+  let failed = 0;
+  const tickets = [];
+
+  for (const current of working) {
+    const ticket = current.ticket;
+    scanned += 1;
+    let live;
+    try {
+      live = fetch(ticket);
+    } catch (e) {
+      live = { state: null, labels: null, error: String(e?.message ?? e) };
+    }
+    if (live.error || (live.state === null && live.labels === null)) {
+      failed += 1;
+      log("debug", { ticket, err: live.error }, "cache-reconcile: fetch unusable — left for next pass");
+      continue;
+    }
+
+    const decision = decideReconcile({
+      current,
+      fetchedState: live.state,
+      fetchedLabels: live.labels,
+    });
+    if (!decision.changed) continue;
+
+    changed += 1;
+    tickets.push({ ticket, reason: decision.reason });
+
+    if (mode === "shadow") {
+      log("info", { ticket, reason: decision.reason }, "ctl-1277 cache-reconcile [shadow] WOULD write");
+      continue;
+    }
+
+    // enforce: write ONLY the drifted fields (key-presence).
+    const patch = { ticket };
+    if (decision.writeState) patch.state = decision.state;
+    if (decision.writeLabels) patch.labels = decision.labels;
+    try {
+      upsert(patch);
+      log("info", { ticket, reason: decision.reason }, "ctl-1277 cache-reconcile wrote");
+    } catch (e) {
+      failed += 1;
+      changed -= 1;
+      tickets.pop();
+      log("warn", { ticket, err: String(e?.message ?? e) }, "cache-reconcile: upsert failed — left for next pass");
+    }
+  }
+
+  return { mode, scanned, changed, failed, tickets };
+}
+
+// startCacheReconcileTimer — wire the periodic pass into the broker. Returns the
+// interval id (caller clears it on shutdown), or null when mode=off (no timer).
+// `emit` records one audit event per pass; `log` is the broker logger.
+export function startCacheReconcileTimer({
+  config = readCacheReconcileConfig(),
+  reconcile = reconcileCacheState,
+  emit = () => {},
+  log = () => {},
+  setTimer = setInterval,
+} = {}) {
+  const { mode, intervalMs, perPassCap } = config;
+  if (mode === "off") {
+    log("info", { mode }, "ctl-1277 cache-reconcile: disabled (CATALYST_CACHE_RECONCILE=off)");
+    return null;
+  }
+  log("info", { mode, intervalMs, perPassCap }, "ctl-1277 cache-reconcile: enabled");
+
+  const runPass = () => {
+    let summary;
+    try {
+      summary = reconcile({ mode, perPassCap, log });
+    } catch (e) {
+      log("warn", { err: String(e?.message ?? e) }, "cache-reconcile: pass threw — caught (fail-soft)");
+      return;
+    }
+    try {
+      emit({
+        kind: "cache.reconcile",
+        mode: summary.mode,
+        scanned: summary.scanned,
+        changed: summary.changed,
+        failed: summary.failed,
+      });
+    } catch {
+      // emit is best-effort — never let telemetry break the pass.
+    }
+    if (summary.changed > 0 || summary.failed > 0) {
+      log("info", summary, "ctl-1277 cache-reconcile: pass complete");
+    }
+  };
+
+  return setTimer(runPass, intervalMs);
+}

--- a/plugins/dev/scripts/broker/cache-reconcile.test.mjs
+++ b/plugins/dev/scripts/broker/cache-reconcile.test.mjs
@@ -1,0 +1,233 @@
+// cache-reconcile.test.mjs — CTL-1277 broker-side state+labels reconcile.
+// Pure decision + injectable IO: no linearis spawn, no DB.
+
+import { describe, test, expect } from "bun:test";
+import {
+  extractState,
+  decideReconcile,
+  reconcileCacheState,
+  readCacheReconcileConfig,
+  startCacheReconcileTimer,
+} from "./cache-reconcile.mjs";
+
+describe("extractState", () => {
+  test("pulls state.name from a linearis read object", () => {
+    expect(extractState({ state: { id: "x", name: "Implement" } })).toBe("Implement");
+  });
+  test("returns null for absent/malformed/blank state", () => {
+    expect(extractState({})).toBeNull();
+    expect(extractState({ state: null })).toBeNull();
+    expect(extractState({ state: [] })).toBeNull();
+    expect(extractState({ state: { name: "" } })).toBeNull();
+    expect(extractState(null)).toBeNull();
+  });
+});
+
+describe("decideReconcile — pure drift decision", () => {
+  test("drifted state → writeState, carries the new value", () => {
+    const d = decideReconcile({ current: { state: "Todo" }, fetchedState: "Implement", fetchedLabels: null });
+    expect(d.writeState).toBe(true);
+    expect(d.state).toBe("Implement");
+    expect(d.changed).toBe(true);
+    expect(d.writeLabels).toBe(false);
+  });
+
+  test("case-insensitive state match is NOT a write", () => {
+    const d = decideReconcile({ current: { state: "Implement" }, fetchedState: "implement", fetchedLabels: null });
+    expect(d.writeState).toBe(false);
+    expect(d.changed).toBe(false);
+  });
+
+  test("drifted labels → writeLabels (order-insensitive)", () => {
+    const d = decideReconcile({
+      current: { state: "Todo", labels: ["a", "b"] },
+      fetchedState: "Todo",
+      fetchedLabels: ["b", "c"],
+    });
+    expect(d.writeLabels).toBe(true);
+    expect(d.labels).toEqual(["b", "c"]);
+    expect(d.writeState).toBe(false);
+  });
+
+  test("same label set (reordered) is NOT a write", () => {
+    const d = decideReconcile({
+      current: { state: "Todo", labels: ["a", "b"] },
+      fetchedState: "Todo",
+      fetchedLabels: ["b", "a"],
+    });
+    expect(d.writeLabels).toBe(false);
+    expect(d.changed).toBe(false);
+  });
+
+  test("null fetched fields leave everything untouched (unknown)", () => {
+    const d = decideReconcile({ current: { state: "Todo", labels: ["a"] }, fetchedState: null, fetchedLabels: null });
+    expect(d.changed).toBe(false);
+    expect(d.writeState).toBe(false);
+    expect(d.writeLabels).toBe(false);
+  });
+
+  test("KEY-PRESENCE: only drifted fields are present in the decision", () => {
+    const d = decideReconcile({ current: { state: "Todo", labels: ["a"] }, fetchedState: "Implement", fetchedLabels: ["a"] });
+    expect(d.writeState).toBe(true);
+    expect(d.writeLabels).toBe(false);
+    expect(d.state).toBe("Implement");
+    expect(d.labels).toBeUndefined();
+  });
+});
+
+const desc = (over = {}) => ({ ticket: "CTL-1", state: "Todo", labels: [], ...over });
+
+describe("reconcileCacheState — full pass", () => {
+  test("mode=off is a no-op (never fetches or writes)", () => {
+    let fetched = 0;
+    const out = reconcileCacheState({
+      mode: "off",
+      getAll: () => [desc()],
+      fetch: () => { fetched++; return { state: "Implement", labels: [] }; },
+      upsert: () => { throw new Error("must not write"); },
+    });
+    expect(out.scanned).toBe(0);
+    expect(fetched).toBe(0);
+  });
+
+  test("enforce writes ONLY the drifted field (key-presence)", () => {
+    const writes = [];
+    const out = reconcileCacheState({
+      mode: "enforce",
+      getAll: () => [desc({ ticket: "CTL-764", state: "Todo", labels: ["x"] })],
+      fetch: () => ({ state: "Implement", labels: ["x"] }),
+      upsert: (p) => writes.push(p),
+    });
+    expect(out.scanned).toBe(1);
+    expect(out.changed).toBe(1);
+    expect(writes).toEqual([{ ticket: "CTL-764", state: "Implement" }]);
+    expect("labels" in writes[0]).toBe(false); // labels matched → not written
+  });
+
+  test("shadow counts the change but writes nothing", () => {
+    let wrote = false;
+    const out = reconcileCacheState({
+      mode: "shadow",
+      getAll: () => [desc({ state: "Todo" })],
+      fetch: () => ({ state: "Implement", labels: [] }),
+      upsert: () => { wrote = true; },
+    });
+    expect(out.changed).toBe(1);
+    expect(wrote).toBe(false);
+  });
+
+  test("idempotent: no drift → no write", () => {
+    const writes = [];
+    const out = reconcileCacheState({
+      mode: "enforce",
+      getAll: () => [desc({ state: "Implement", labels: ["a"] })],
+      fetch: () => ({ state: "Implement", labels: ["a"] }),
+      upsert: (p) => writes.push(p),
+    });
+    expect(out.changed).toBe(0);
+    expect(writes).toEqual([]);
+  });
+
+  test("terminal tickets are skipped (not fetched)", () => {
+    let fetched = 0;
+    const out = reconcileCacheState({
+      mode: "enforce",
+      getAll: () => [desc({ ticket: "CTL-D", state: "Done" }), desc({ ticket: "CTL-C", state: "Canceled" })],
+      fetch: () => { fetched++; return { state: "Implement", labels: [] }; },
+      upsert: () => {},
+    });
+    expect(out.scanned).toBe(0);
+    expect(fetched).toBe(0);
+  });
+
+  test("fail-soft: a fetch error counts as failed and never throws", () => {
+    const out = reconcileCacheState({
+      mode: "enforce",
+      getAll: () => [desc({ ticket: "CTL-A" }), desc({ ticket: "CTL-B", state: "Todo" })],
+      fetch: (t) => (t === "CTL-A" ? { state: null, labels: null, error: "exit 1" } : { state: "Implement", labels: [] }),
+      upsert: () => {},
+    });
+    expect(out.scanned).toBe(2);
+    expect(out.failed).toBe(1);
+    expect(out.changed).toBe(1);
+  });
+
+  test("an upsert throw is fail-soft (counted failed, not changed)", () => {
+    const out = reconcileCacheState({
+      mode: "enforce",
+      getAll: () => [desc({ state: "Todo" })],
+      fetch: () => ({ state: "Implement", labels: [] }),
+      upsert: () => { throw new Error("db locked"); },
+    });
+    expect(out.failed).toBe(1);
+    expect(out.changed).toBe(0);
+  });
+
+  test("perPassCap bounds the work", () => {
+    const many = Array.from({ length: 10 }, (_, i) => desc({ ticket: `CTL-${i}`, state: "Todo" }));
+    let fetched = 0;
+    const out = reconcileCacheState({
+      mode: "enforce",
+      perPassCap: 3,
+      getAll: () => many,
+      fetch: () => { fetched++; return { state: "Implement", labels: [] }; },
+      upsert: () => {},
+    });
+    expect(out.scanned).toBe(3);
+    expect(fetched).toBe(3);
+  });
+});
+
+describe("readCacheReconcileConfig", () => {
+  test("defaults to off", () => {
+    expect(readCacheReconcileConfig({}).mode).toBe("off");
+  });
+  test("honors shadow/enforce, rejects garbage", () => {
+    expect(readCacheReconcileConfig({ CATALYST_CACHE_RECONCILE: "shadow" }).mode).toBe("shadow");
+    expect(readCacheReconcileConfig({ CATALYST_CACHE_RECONCILE: "enforce" }).mode).toBe("enforce");
+    expect(readCacheReconcileConfig({ CATALYST_CACHE_RECONCILE: "yolo" }).mode).toBe("off");
+  });
+  test("interval + cap parse with sane fallbacks", () => {
+    const c = readCacheReconcileConfig({ CATALYST_CACHE_RECONCILE_INTERVAL_MS: "60000", CATALYST_CACHE_RECONCILE_CAP: "5" });
+    expect(c.intervalMs).toBe(60000);
+    expect(c.perPassCap).toBe(5);
+    expect(readCacheReconcileConfig({ CATALYST_CACHE_RECONCILE_INTERVAL_MS: "nope" }).intervalMs).toBeGreaterThan(0);
+  });
+});
+
+describe("startCacheReconcileTimer", () => {
+  test("mode=off → no timer (returns null)", () => {
+    let armed = false;
+    const id = startCacheReconcileTimer({
+      config: { mode: "off", intervalMs: 1000, perPassCap: 10 },
+      setTimer: () => { armed = true; return 1; },
+    });
+    expect(id).toBeNull();
+    expect(armed).toBe(false);
+  });
+
+  test("enabled arms a timer; its pass emits an audit event", () => {
+    let pass;
+    const emits = [];
+    startCacheReconcileTimer({
+      config: { mode: "enforce", intervalMs: 1000, perPassCap: 10 },
+      reconcile: () => ({ mode: "enforce", scanned: 2, changed: 1, failed: 0, tickets: [] }),
+      emit: (e) => emits.push(e),
+      setTimer: (fn) => { pass = fn; return 42; },
+    });
+    expect(typeof pass).toBe("function");
+    pass();
+    expect(emits).toEqual([{ kind: "cache.reconcile", mode: "enforce", scanned: 2, changed: 1, failed: 0 }]);
+  });
+
+  test("a throwing pass is caught (fail-soft) and emit failure never propagates", () => {
+    let pass;
+    startCacheReconcileTimer({
+      config: { mode: "enforce", intervalMs: 1000, perPassCap: 10 },
+      reconcile: () => { throw new Error("boom"); },
+      emit: () => { throw new Error("emit boom"); },
+      setTimer: (fn) => { pass = fn; return 1; },
+    });
+    expect(() => pass()).not.toThrow();
+  });
+});

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -81,6 +81,7 @@ import {
   seedLastSeenByService,
 } from "./router.mjs";
 import { seedTailer, startTailing, stopTailing, loadExistingRegistrations } from "./tailer.mjs";
+import { startCacheReconcileTimer } from "./cache-reconcile.mjs";
 import { gcStaleInterests } from "./gc-startup.mjs";
 import { getExecutionCoreDir, getRunsRoot } from "../execution-core/config.mjs";
 import { defaultStatJob } from "../execution-core/recovery.mjs";
@@ -531,6 +532,12 @@ function main() {
   };
   emitBrokerHeartbeat();
   const heartbeatId = setInterval(emitBrokerHeartbeat, BROKER_HEARTBEAT_INTERVAL_MS);
+  // CTL-1277: periodic state+labels reconcile of the board cache vs live Linear.
+  // Off by default; operators opt in via CATALYST_CACHE_RECONCILE=shadow then =enforce.
+  // The summary log line is Loki-queryable (see the sensing-substrate skill).
+  const cacheReconcileId = startCacheReconcileTimer({
+    log: (level, obj, msg) => (log[level] || log.info)(obj, msg),
+  });
   log.info(
     {
       pid: process.pid,
@@ -554,6 +561,7 @@ function main() {
     clearInterval(watchdogId);
     clearInterval(heartbeatId); // CTL-1171: stop the liveness heartbeat
     clearInterval(driftCheckId); // CTL-1161: drift-check backstop timer
+    if (cacheReconcileId) clearInterval(cacheReconcileId); // CTL-1277: cache reconcile
     // CTL-529: the debounce timer handles are router module-internal.
     clearDebounceTimers();
     // CTL-351: emit a parallel shutdown event so subscribers can pair


### PR DESCRIPTION
## What

The board cache (`filter-state.db ticket_state`) is **webhook-fed only**, so a single missed `linear.issue.*` webhook leaves a row's state/labels wrong indefinitely and the board lies — proven: **CTL-764 live=Implement but cache=Todo**. Nothing periodically re-syncs it. This is the **interim bridge** for board cache-truth (the delegate's invariant #0), the thing that stops the board lying *this week*.

## Changes (broker-only, fence-clean)

- **`cache-reconcile.mjs`** — generalizes the CTL-1031 one-shot label backfill into a periodic **state + labels** sweep over the working set:
  - pure `decideReconcile` (key-presence, case-insensitive state match, order-insensitive labels) + injectable IO (`linearis issues read` / `upsertTicketDescriptor`) + a timer.
  - writes **only the drifted fields** via the key-presence upsert contract — every other column (assignee, priority, estimate, relations, fence projection) is untouched.
  - terminal tickets skipped, **fail-soft** per ticket, per-pass cap, one **Loki-queryable** audit line per pass (queryable via the `sensing-substrate` skill).
- Wired into `broker/index.mjs` main() + shutdown.

## Safety

**Off by default** (`CATALYST_CACHE_RECONCILE=off`). Operators opt in via `=shadow` (logs what it *would* write, touches nothing) then `=enforce`. 22 unit tests (pure decision + every IO path mocked). No `scheduler.mjs`.

## Sequencing

Interim bridge — the durable fix is the **Pillar-1 cloud read-mirror** (design doc landed today), whose reconciler reuses this exact delta-fetch+diff shape (not throwaway). **Relations** are the follow-up **CTL-1278** (no relation webhooks → needs full-poll + delete-absent).

## Review note

Core-loop broker infra — opened for review, **do not auto-merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)