### PR TITLE
fix(dev): CTL-1277 — broker boot-crash (pino logger binding)

### DIFF
--- a/plugins/dev/scripts/broker/cache-reconcile.mjs
+++ b/plugins/dev/scripts/broker/cache-reconcile.mjs
@@ -133,6 +133,20 @@ function fetchLive(ticket) {
   return { state: extractState(json), labels: extractLabelNames(json), error: null };
 }
 
+// logSink — normalize a pino-style logger object into a safe (level,obj,msg)
+// sink. MUST call via member access — `logger[level](obj, msg)` preserves pino's
+// `this`; pulling the method out first (`(logger[level] || logger.info)(...)`)
+// DETACHES it and pino throws `this[msgPrefixSym]` at the first log call, which
+// crashed the broker at boot on the original CTL-1277 wiring. A missing/garbage
+// logger → a no-op sink (telemetry never breaks the reconcile).
+function logSink(logger) {
+  if (!logger || typeof logger !== "object") return () => {};
+  return (level, obj, msg) => {
+    const fn = typeof logger[level] === "function" ? level : "info";
+    if (typeof logger[fn] === "function") logger[fn](obj, msg);
+  };
+}
+
 // reconcileCacheState — one full pass over the working set. Injectable deps keep
 // it unit-testable with no spawn / no DB. Returns a summary {mode,scanned,changed,
 // failed,tickets[]} for the audit emit. NEVER throws — a per-ticket failure is
@@ -143,8 +157,9 @@ export function reconcileCacheState({
   getAll = getAllTicketDescriptors,
   fetch = fetchLive,
   upsert = upsertTicketDescriptor,
-  log = () => {},
+  logger,
 } = {}) {
+  const log = logSink(logger);
   if (mode === "off") return { mode, scanned: 0, changed: 0, failed: 0, tickets: [] };
 
   let descriptors;
@@ -217,9 +232,10 @@ export function startCacheReconcileTimer({
   config = readCacheReconcileConfig(),
   reconcile = reconcileCacheState,
   emit = () => {},
-  log = () => {},
+  logger,
   setTimer = setInterval,
 } = {}) {
+  const log = logSink(logger);
   const { mode, intervalMs, perPassCap } = config;
   if (mode === "off") {
     log("info", { mode }, "ctl-1277 cache-reconcile: disabled (CATALYST_CACHE_RECONCILE=off)");
@@ -230,7 +246,7 @@ export function startCacheReconcileTimer({
   const runPass = () => {
     let summary;
     try {
-      summary = reconcile({ mode, perPassCap, log });
+      summary = reconcile({ mode, perPassCap, logger });
     } catch (e) {
       log("warn", { err: String(e?.message ?? e) }, "cache-reconcile: pass threw — caught (fail-soft)");
       return;

--- a/plugins/dev/scripts/broker/cache-reconcile.test.mjs
+++ b/plugins/dev/scripts/broker/cache-reconcile.test.mjs
@@ -2,6 +2,7 @@
 // Pure decision + injectable IO: no linearis spawn, no DB.
 
 import { describe, test, expect } from "bun:test";
+import pino from "pino";
 import {
   extractState,
   decideReconcile,
@@ -9,6 +10,20 @@ import {
   readCacheReconcileConfig,
   startCacheReconcileTimer,
 } from "./cache-reconcile.mjs";
+
+// pinoLikeLogger — methods THROW if invoked with the wrong `this`, exactly like
+// pino (which dereferences this[msgPrefixSym]). Reproduces the CTL-1277 broker
+// boot-crash: the old wiring pulled the method out of the logger and called it
+// detached.
+function pinoLikeLogger() {
+  const calls = [];
+  const logger = {
+    info(obj, msg) { if (this !== logger) throw new TypeError("detached this"); calls.push(["info", obj, msg]); },
+    warn(obj, msg) { if (this !== logger) throw new TypeError("detached this"); calls.push(["warn", obj, msg]); },
+    debug(obj, msg) { if (this !== logger) throw new TypeError("detached this"); calls.push(["debug", obj, msg]); },
+  };
+  return { logger, calls };
+}
 
 describe("extractState", () => {
   test("pulls state.name from a linearis read object", () => {
@@ -229,5 +244,56 @@ describe("startCacheReconcileTimer", () => {
       setTimer: (fn) => { pass = fn; return 1; },
     });
     expect(() => pass()).not.toThrow();
+  });
+});
+
+// CTL-1277 hotfix: the broker crashed at boot because the wiring detached the
+// pino method from its instance. These reproduce the exact crash and guard it.
+describe("logger binding (broker boot-crash regression)", () => {
+  test("OFF-mode startup log does NOT throw with a pino-like logger (the prod crash)", () => {
+    const { logger, calls } = pinoLikeLogger();
+    expect(() =>
+      startCacheReconcileTimer({ config: { mode: "off", intervalMs: 1000, perPassCap: 10 }, logger }),
+    ).not.toThrow();
+    expect(calls.some(([lvl]) => lvl === "info")).toBe(true); // the "disabled" line logged, bound
+  });
+
+  test("enabled startup log is bound (this === logger)", () => {
+    const { logger, calls } = pinoLikeLogger();
+    expect(() =>
+      startCacheReconcileTimer({
+        config: { mode: "enforce", intervalMs: 1000, perPassCap: 10 },
+        logger,
+        setTimer: () => 1,
+      }),
+    ).not.toThrow();
+    expect(calls.some(([, obj]) => obj && obj.mode === "enforce")).toBe(true);
+  });
+
+  test("reconcile pass logs through a pino-like logger without detaching", () => {
+    const { logger } = pinoLikeLogger();
+    expect(() =>
+      reconcileCacheState({
+        mode: "enforce",
+        getAll: () => [{ ticket: "CTL-1", state: "Todo", labels: [] }],
+        fetch: () => ({ state: "Implement", labels: [] }),
+        upsert: () => {},
+        logger,
+      }),
+    ).not.toThrow();
+  });
+
+  test("REAL pino logger: off-mode boot does not throw (end-to-end proof)", () => {
+    const realLogger = pino({ level: "silent" });
+    expect(() =>
+      startCacheReconcileTimer({ config: { mode: "off", intervalMs: 1000, perPassCap: 10 }, logger: realLogger }),
+    ).not.toThrow();
+  });
+
+  test("a garbage / missing logger is a safe no-op (never throws)", () => {
+    expect(() => startCacheReconcileTimer({ config: { mode: "off", intervalMs: 1, perPassCap: 1 } })).not.toThrow();
+    expect(() =>
+      reconcileCacheState({ mode: "enforce", getAll: () => [{ ticket: "X", state: "Todo" }], fetch: () => ({ state: "Done", labels: [] }), upsert: () => {}, logger: 42 }),
+    ).not.toThrow();
   });
 });

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -535,9 +535,7 @@ function main() {
   // CTL-1277: periodic state+labels reconcile of the board cache vs live Linear.
   // Off by default; operators opt in via CATALYST_CACHE_RECONCILE=shadow then =enforce.
   // The summary log line is Loki-queryable (see the sensing-substrate skill).
-  const cacheReconcileId = startCacheReconcileTimer({
-    log: (level, obj, msg) => (log[level] || log.info)(obj, msg),
-  });
+  const cacheReconcileId = startCacheReconcileTimer({ logger: log });
   log.info(
     {
       pid: process.pid,


### PR DESCRIPTION
## Incident

The CTL-1277 wiring **crashed the broker at boot on mini** (it auto-reloaded into the merged code and went down). Cause: `index.mjs`'s log adapter `(log[level] || log.info)(obj, msg)` pulled the method off the pino instance and called it **detached**, so pino threw `this[msgPrefixSym]` at the very first log line — the off-mode "disabled" startup log. It crashed regardless of mode.

## Fix

- `cache-reconcile.mjs` takes a `logger` **object** and routes through a `logSink` helper that calls `logger[level](obj, msg)` via **member access** (preserves pino's `this`). `index.mjs` passes `{ logger: log }` directly — no detachable adapter. Garbage/missing logger → safe no-op.
- **Regression tests reproduce the exact crash**: a pino-like logger whose methods throw on a wrong `this`, plus a **real `pino()` off-mode boot** that must not throw. 30/30 pass.

## Risk

Restores the broker. Reconcile still off by default. No `scheduler.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)