### PR TITLE
feat(dev): CTL-1282 — cache reconcile async + re-entrancy guard (non-blocking)

### DIFF
--- a/plugins/dev/scripts/broker/cache-reconcile.mjs
+++ b/plugins/dev/scripts/broker/cache-reconcile.mjs
@@ -20,7 +20,7 @@
 // column (assignee, priority, estimate, relations, fence projection) is left
 // untouched.
 
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import {
   getAllTicketDescriptors,
   upsertTicketDescriptor,
@@ -106,31 +106,47 @@ export function decideReconcile({ current, fetchedState, fetchedLabels }) {
   };
 }
 
-// fetchLive — spawn `linearis issues read <ticket>` and parse its JSON.
-// linearis emits JSON by default (NO --json flag) and EATS STDIN in loops, so
-// we pass stdin "ignore". Returns { state, labels, error }: state/labels null on
-// any failure (fail-soft — leave the row for the next pass).
+// fetchLive — ASYNC `linearis issues read <ticket>` (CTL-1282). Uses non-blocking
+// `spawn` (NOT spawnSync) so a pass never freezes the broker's event loop:
+// webhook routing keeps flowing while we await each read. linearis emits JSON by
+// default (NO --json flag) and EATS STDIN in loops, so stdin is "ignore". Resolves
+// { state, labels, error }: state/labels null on any failure (fail-soft — leave the
+// row for the next pass). NEVER rejects.
 function fetchLive(ticket) {
-  let res;
-  try {
-    res = spawnSync("linearis", ["issues", "read", ticket], {
-      stdio: ["ignore", "pipe", "pipe"],
-      encoding: "utf8",
-      timeout: 30_000,
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn("linearis", ["issues", "read", ticket], { stdio: ["ignore", "pipe", "pipe"] });
+    } catch (e) {
+      resolve({ state: null, labels: null, error: String(e?.message ?? e) });
+      return;
+    }
+    let out = "";
+    let err = "";
+    let done = false;
+    const finish = (v) => { if (!done) { done = true; clearTimeout(timer); resolve(v); } };
+    const timer = setTimeout(() => {
+      try { child.kill("SIGKILL"); } catch {}
+      finish({ state: null, labels: null, error: "timeout after 30s" });
+    }, 30_000);
+    child.stdout.on("data", (d) => { out += d; });
+    child.stderr.on("data", (d) => { err += d; });
+    child.on("error", (e) => finish({ state: null, labels: null, error: String(e?.message ?? e) }));
+    child.on("close", (code) => {
+      if (code !== 0 || !out) {
+        finish({ state: null, labels: null, error: err.trim() || `exit ${code}` });
+        return;
+      }
+      let json;
+      try {
+        json = JSON.parse(out);
+      } catch (e) {
+        finish({ state: null, labels: null, error: `unparseable JSON: ${String(e)}` });
+        return;
+      }
+      finish({ state: extractState(json), labels: extractLabelNames(json), error: null });
     });
-  } catch (e) {
-    return { state: null, labels: null, error: String(e?.message ?? e) };
-  }
-  if (res.status !== 0 || !res.stdout) {
-    return { state: null, labels: null, error: (res.stderr || "").trim() || `exit ${res.status}` };
-  }
-  let json;
-  try {
-    json = JSON.parse(res.stdout);
-  } catch (e) {
-    return { state: null, labels: null, error: `unparseable JSON: ${String(e)}` };
-  }
-  return { state: extractState(json), labels: extractLabelNames(json), error: null };
+  });
 }
 
 // logSink — normalize a pino-style logger object into a safe (level,obj,msg)
@@ -147,11 +163,13 @@ function logSink(logger) {
   };
 }
 
-// reconcileCacheState — one full pass over the working set. Injectable deps keep
-// it unit-testable with no spawn / no DB. Returns a summary {mode,scanned,changed,
-// failed,tickets[]} for the audit emit. NEVER throws — a per-ticket failure is
-// counted and skipped (fail-soft).
-export function reconcileCacheState({
+// reconcileCacheState — one full pass over the working set. ASYNC (CTL-1282):
+// awaits each fetch SEQUENTIALLY (gentle on the per-host Linear key — the
+// self-constraint) while keeping the event loop free between reads. Injectable
+// deps keep it unit-testable with no spawn / no DB. Returns a summary
+// {mode,scanned,changed,failed,tickets[]} for the audit emit. NEVER throws — a
+// per-ticket failure is counted and skipped (fail-soft).
+export async function reconcileCacheState({
   mode = "off",
   perPassCap = 250,
   getAll = getAllTicketDescriptors,
@@ -182,7 +200,7 @@ export function reconcileCacheState({
     scanned += 1;
     let live;
     try {
-      live = fetch(ticket);
+      live = await fetch(ticket);
     } catch (e) {
       live = { state: null, labels: null, error: String(e?.message ?? e) };
     }
@@ -243,13 +261,25 @@ export function startCacheReconcileTimer({
   }
   log("info", { mode, intervalMs, perPassCap }, "ctl-1277 cache-reconcile: enabled");
 
-  const runPass = () => {
+  // Re-entrancy guard (CTL-1282): the pass is now async and can outlast the
+  // interval. If the previous pass is still running when the timer fires, SKIP
+  // this tick — never run two passes concurrently (double API load + double
+  // writes). A pass that throws still clears the flag (finally).
+  let running = false;
+  const runPass = async () => {
+    if (running) {
+      log("debug", {}, "cache-reconcile: previous pass still running — skipping tick");
+      return;
+    }
+    running = true;
     let summary;
     try {
-      summary = reconcile({ mode, perPassCap, logger });
+      summary = await reconcile({ mode, perPassCap, logger });
     } catch (e) {
       log("warn", { err: String(e?.message ?? e) }, "cache-reconcile: pass threw — caught (fail-soft)");
       return;
+    } finally {
+      running = false;
     }
     try {
       emit({

--- a/plugins/dev/scripts/broker/cache-reconcile.test.mjs
+++ b/plugins/dev/scripts/broker/cache-reconcile.test.mjs
@@ -92,25 +92,25 @@ describe("decideReconcile — pure drift decision", () => {
 
 const desc = (over = {}) => ({ ticket: "CTL-1", state: "Todo", labels: [], ...over });
 
-describe("reconcileCacheState — full pass", () => {
-  test("mode=off is a no-op (never fetches or writes)", () => {
+describe("reconcileCacheState — full pass (async, CTL-1282)", () => {
+  test("mode=off is a no-op (never fetches or writes)", async () => {
     let fetched = 0;
-    const out = reconcileCacheState({
+    const out = await reconcileCacheState({
       mode: "off",
       getAll: () => [desc()],
-      fetch: () => { fetched++; return { state: "Implement", labels: [] }; },
+      fetch: async () => { fetched++; return { state: "Implement", labels: [] }; },
       upsert: () => { throw new Error("must not write"); },
     });
     expect(out.scanned).toBe(0);
     expect(fetched).toBe(0);
   });
 
-  test("enforce writes ONLY the drifted field (key-presence)", () => {
+  test("enforce writes ONLY the drifted field (key-presence)", async () => {
     const writes = [];
-    const out = reconcileCacheState({
+    const out = await reconcileCacheState({
       mode: "enforce",
       getAll: () => [desc({ ticket: "CTL-764", state: "Todo", labels: ["x"] })],
-      fetch: () => ({ state: "Implement", labels: ["x"] }),
+      fetch: async () => ({ state: "Implement", labels: ["x"] }),
       upsert: (p) => writes.push(p),
     });
     expect(out.scanned).toBe(1);
@@ -119,47 +119,47 @@ describe("reconcileCacheState — full pass", () => {
     expect("labels" in writes[0]).toBe(false); // labels matched → not written
   });
 
-  test("shadow counts the change but writes nothing", () => {
+  test("shadow counts the change but writes nothing", async () => {
     let wrote = false;
-    const out = reconcileCacheState({
+    const out = await reconcileCacheState({
       mode: "shadow",
       getAll: () => [desc({ state: "Todo" })],
-      fetch: () => ({ state: "Implement", labels: [] }),
+      fetch: async () => ({ state: "Implement", labels: [] }),
       upsert: () => { wrote = true; },
     });
     expect(out.changed).toBe(1);
     expect(wrote).toBe(false);
   });
 
-  test("idempotent: no drift → no write", () => {
+  test("idempotent: no drift → no write", async () => {
     const writes = [];
-    const out = reconcileCacheState({
+    const out = await reconcileCacheState({
       mode: "enforce",
       getAll: () => [desc({ state: "Implement", labels: ["a"] })],
-      fetch: () => ({ state: "Implement", labels: ["a"] }),
+      fetch: async () => ({ state: "Implement", labels: ["a"] }),
       upsert: (p) => writes.push(p),
     });
     expect(out.changed).toBe(0);
     expect(writes).toEqual([]);
   });
 
-  test("terminal tickets are skipped (not fetched)", () => {
+  test("terminal tickets are skipped (not fetched)", async () => {
     let fetched = 0;
-    const out = reconcileCacheState({
+    const out = await reconcileCacheState({
       mode: "enforce",
       getAll: () => [desc({ ticket: "CTL-D", state: "Done" }), desc({ ticket: "CTL-C", state: "Canceled" })],
-      fetch: () => { fetched++; return { state: "Implement", labels: [] }; },
+      fetch: async () => { fetched++; return { state: "Implement", labels: [] }; },
       upsert: () => {},
     });
     expect(out.scanned).toBe(0);
     expect(fetched).toBe(0);
   });
 
-  test("fail-soft: a fetch error counts as failed and never throws", () => {
-    const out = reconcileCacheState({
+  test("fail-soft: a fetch error counts as failed and never throws", async () => {
+    const out = await reconcileCacheState({
       mode: "enforce",
       getAll: () => [desc({ ticket: "CTL-A" }), desc({ ticket: "CTL-B", state: "Todo" })],
-      fetch: (t) => (t === "CTL-A" ? { state: null, labels: null, error: "exit 1" } : { state: "Implement", labels: [] }),
+      fetch: async (t) => (t === "CTL-A" ? { state: null, labels: null, error: "exit 1" } : { state: "Implement", labels: [] }),
       upsert: () => {},
     });
     expect(out.scanned).toBe(2);
@@ -167,25 +167,36 @@ describe("reconcileCacheState — full pass", () => {
     expect(out.changed).toBe(1);
   });
 
-  test("an upsert throw is fail-soft (counted failed, not changed)", () => {
-    const out = reconcileCacheState({
+  test("a REJECTED fetch promise is fail-soft (counted failed, never throws)", async () => {
+    const out = await reconcileCacheState({
+      mode: "enforce",
+      getAll: () => [desc({ ticket: "CTL-A", state: "Todo" })],
+      fetch: async () => { throw new Error("spawn EPIPE"); },
+      upsert: () => {},
+    });
+    expect(out.scanned).toBe(1);
+    expect(out.failed).toBe(1);
+  });
+
+  test("an upsert throw is fail-soft (counted failed, not changed)", async () => {
+    const out = await reconcileCacheState({
       mode: "enforce",
       getAll: () => [desc({ state: "Todo" })],
-      fetch: () => ({ state: "Implement", labels: [] }),
+      fetch: async () => ({ state: "Implement", labels: [] }),
       upsert: () => { throw new Error("db locked"); },
     });
     expect(out.failed).toBe(1);
     expect(out.changed).toBe(0);
   });
 
-  test("perPassCap bounds the work", () => {
+  test("perPassCap bounds the work", async () => {
     const many = Array.from({ length: 10 }, (_, i) => desc({ ticket: `CTL-${i}`, state: "Todo" }));
     let fetched = 0;
-    const out = reconcileCacheState({
+    const out = await reconcileCacheState({
       mode: "enforce",
       perPassCap: 3,
       getAll: () => many,
-      fetch: () => { fetched++; return { state: "Implement", labels: [] }; },
+      fetch: async () => { fetched++; return { state: "Implement", labels: [] }; },
       upsert: () => {},
     });
     expect(out.scanned).toBe(3);
@@ -221,29 +232,48 @@ describe("startCacheReconcileTimer", () => {
     expect(armed).toBe(false);
   });
 
-  test("enabled arms a timer; its pass emits an audit event", () => {
+  test("enabled arms a timer; its async pass emits an audit event", async () => {
     let pass;
     const emits = [];
     startCacheReconcileTimer({
       config: { mode: "enforce", intervalMs: 1000, perPassCap: 10 },
-      reconcile: () => ({ mode: "enforce", scanned: 2, changed: 1, failed: 0, tickets: [] }),
+      reconcile: async () => ({ mode: "enforce", scanned: 2, changed: 1, failed: 0, tickets: [] }),
       emit: (e) => emits.push(e),
       setTimer: (fn) => { pass = fn; return 42; },
     });
     expect(typeof pass).toBe("function");
-    pass();
+    await pass();
     expect(emits).toEqual([{ kind: "cache.reconcile", mode: "enforce", scanned: 2, changed: 1, failed: 0 }]);
   });
 
-  test("a throwing pass is caught (fail-soft) and emit failure never propagates", () => {
+  test("a throwing pass is caught (fail-soft) and emit failure never propagates", async () => {
     let pass;
     startCacheReconcileTimer({
       config: { mode: "enforce", intervalMs: 1000, perPassCap: 10 },
-      reconcile: () => { throw new Error("boom"); },
+      reconcile: async () => { throw new Error("boom"); },
       emit: () => { throw new Error("emit boom"); },
       setTimer: (fn) => { pass = fn; return 1; },
     });
-    expect(() => pass()).not.toThrow();
+    await expect(pass()).resolves.toBeUndefined();
+  });
+
+  test("re-entrancy guard: an overlapping tick is SKIPPED while a pass runs (CTL-1282)", async () => {
+    let pass;
+    let passCount = 0;
+    let release;
+    const gate = new Promise((r) => { release = r; });
+    startCacheReconcileTimer({
+      config: { mode: "enforce", intervalMs: 1, perPassCap: 10 },
+      reconcile: async () => { passCount++; await gate; return { mode: "enforce", scanned: 0, changed: 0, failed: 0, tickets: [] }; },
+      setTimer: (fn) => { pass = fn; return 1; },
+    });
+    const first = pass();      // running=true, awaits the gate
+    await pass();              // fires mid-pass → must skip (no second reconcile)
+    expect(passCount).toBe(1);
+    release();
+    await first;              // first completes, running=false
+    await pass();             // now free → a real second pass runs
+    expect(passCount).toBe(2);
   });
 });
 
@@ -270,17 +300,17 @@ describe("logger binding (broker boot-crash regression)", () => {
     expect(calls.some(([, obj]) => obj && obj.mode === "enforce")).toBe(true);
   });
 
-  test("reconcile pass logs through a pino-like logger without detaching", () => {
+  test("reconcile pass logs through a pino-like logger without detaching", async () => {
     const { logger } = pinoLikeLogger();
-    expect(() =>
+    await expect(
       reconcileCacheState({
         mode: "enforce",
         getAll: () => [{ ticket: "CTL-1", state: "Todo", labels: [] }],
-        fetch: () => ({ state: "Implement", labels: [] }),
+        fetch: async () => ({ state: "Implement", labels: [] }),
         upsert: () => {},
         logger,
       }),
-    ).not.toThrow();
+    ).resolves.toBeDefined();
   });
 
   test("REAL pino logger: off-mode boot does not throw (end-to-end proof)", () => {
@@ -290,10 +320,10 @@ describe("logger binding (broker boot-crash regression)", () => {
     ).not.toThrow();
   });
 
-  test("a garbage / missing logger is a safe no-op (never throws)", () => {
+  test("a garbage / missing logger is a safe no-op (never throws)", async () => {
     expect(() => startCacheReconcileTimer({ config: { mode: "off", intervalMs: 1, perPassCap: 1 } })).not.toThrow();
-    expect(() =>
-      reconcileCacheState({ mode: "enforce", getAll: () => [{ ticket: "X", state: "Todo" }], fetch: () => ({ state: "Done", labels: [] }), upsert: () => {}, logger: 42 }),
-    ).not.toThrow();
+    await expect(
+      reconcileCacheState({ mode: "enforce", getAll: () => [{ ticket: "X", state: "Todo" }], fetch: async () => ({ state: "Done", labels: [] }), upsert: () => {}, logger: 42 }),
+    ).resolves.toBeDefined();
   });
 });


### PR DESCRIPTION
Follow-up to CTL-1277. The reconcile used blocking `spawnSync` per ticket — freezing the broker event loop for a whole pass (seen live in shadow on mini). Makes it async: non-blocking `spawn`, sequential awaits (event loop free between reads), and a **re-entrancy guard** so an overlapping interval tick is skipped. Kept in the broker (sole writer of ticket_state; cloud mirror is the real decouple). 32 tests incl re-entrancy + rejected-fetch fail-soft. Off by default. Core-loop broker — review, no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)