### PR TITLE
feat(dev): CTL-1287 — recovery delegate emits per-tick recovery.tick/recovery.decision

### DIFF
--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -127,10 +127,29 @@ export function reasoningRecoveryPass(items, opts = {}) {
   // CTL-1176: count of FIX-actions actually taken this invocation (enforce only).
   let fixesThisTick = 0;
 
+  // CTL-1287: per-tick decision visibility. The recovery pass historically emitted
+  // ONLY on action (recovery.fixed / recovery.escalated); every skip was a bare
+  // log() to stdout, invisible to Loki — so a board where every flagged item is
+  // latched-escalated looked identical to a board the delegate never examined.
+  // These counters + skip rosters feed one recovery.tick rollup per invocation
+  // (the "did the delegate fire, and why/why-not" headline); recovery.decision is
+  // emitted per classified item. ledgerSkipped is coarse (cooldown OR escalated-
+  // latch) — splitting it needs the per-tick orchDir ledger read, which only
+  // reaches this pure function via a scheduler.mjs injection (fenced; fast-follow).
+  const tickStats = {
+    queueSize: items.length,
+    processed: 0,
+    decisions: { fix_seam: 0, fix_bounded_llm: 0, escalate: 0 },
+    actions: { fixed: 0, fixFailed: 0, escalated: 0, deferred: 0, errors: 0 },
+    ledgerSkipped: [],
+    terminalSkipped: [],
+  };
+
   for (const item of items) {
     // Check cooldown / already-escalated
     if (shouldSkipItem(item.ticket)) {
       log(`recovery-reasoning: ${item.ticket} skipped (cooldown/escalated)`);
+      tickStats.ledgerSkipped.push(item.ticket);
       continue;
     }
 
@@ -138,6 +157,7 @@ export function reasoningRecoveryPass(items, opts = {}) {
     // Mirrors classifyStalledTicket's linearTerminal skip (unstuck-sweep.mjs:95-97).
     if (item.evidence?.linearTerminal) {
       log(`recovery-reasoning: ${item.ticket} skipped (linear-terminal)`);
+      tickStats.terminalSkipped.push(item.ticket);
       continue;
     }
 
@@ -164,6 +184,7 @@ export function reasoningRecoveryPass(items, opts = {}) {
       classification = classifyTicket(evidence, { log });
     } catch (err) {
       log(`recovery-reasoning: ${item.ticket} classification error: ${err.message}`);
+      tickStats.actions.errors += 1;
       results.push({
         ticket: item.ticket,
         decision: "error",
@@ -173,6 +194,23 @@ export function reasoningRecoveryPass(items, opts = {}) {
     }
 
     const { decision, fix_class, details } = classification;
+
+    // CTL-1287: this item reached the classifier — emit its per-item decision
+    // (rule 1=seam, 2=bounded-llm, 3=escalate) and tally for the recovery.tick
+    // rollup. Emitted in BOTH shadow and enforce: it records the classifier's
+    // verdict, independent of whether the mode then acts on it.
+    tickStats.processed += 1;
+    const rule = decision === "escalate" ? 3 : fix_class === "bounded-llm" ? 2 : 1;
+    if (decision === "escalate") tickStats.decisions.escalate += 1;
+    else if (fix_class === "bounded-llm") tickStats.decisions.fix_bounded_llm += 1;
+    else tickStats.decisions.fix_seam += 1;
+    emitEvent({
+      type: "recovery.decision",
+      ticket: item.ticket,
+      fix_class,
+      reason: details?.reason ?? null,
+      details: { rule, decision, mode },
+    });
 
     // GUARDED-FIX: act based on decision, record outcome
     let outcome = null;
@@ -239,6 +277,7 @@ export function reasoningRecoveryPass(items, opts = {}) {
         // so the next scheduler tick processes them. Bounds a one-sweep storm.
         if (fixesThisTick >= maxFixesPerTick) {
           actionLog.push(`deferred: per-tick fix cap (${maxFixesPerTick}) reached`);
+          tickStats.actions.deferred += 1;
           log(
             `recovery-reasoning: ${item.ticket} deferred — per-tick fix cap ${maxFixesPerTick} reached`,
           );
@@ -300,8 +339,10 @@ export function reasoningRecoveryPass(items, opts = {}) {
 
         if (fixOutcome.success) {
           actionLog.push("emitted recovery.fixed");
+          tickStats.actions.fixed += 1;
         } else {
           actionLog.push("emitted recovery.fix-failed");
+          tickStats.actions.fixFailed += 1;
         }
       } else if (decision === "escalate") {
         const escalationPayload = buildEscalationPayload(item, classification);
@@ -334,6 +375,7 @@ export function reasoningRecoveryPass(items, opts = {}) {
           escalation: escalationPayload,
         });
         actionLog.push("emitted recovery.escalated");
+        tickStats.actions.escalated += 1;
 
         outcome = { decision, reason: classification.details.reason, actionLog, mode: "enforce" };
       }
@@ -341,6 +383,21 @@ export function reasoningRecoveryPass(items, opts = {}) {
 
     results.push(outcome || { ticket: item.ticket, decision, error: "no outcome" });
   }
+
+  // CTL-1287: one rollup per invocation — the "did the delegate fire, and
+  // why/why-not" headline. The scheduler only invokes this pass with a non-empty
+  // queue (scheduler.mjs gates on rItems.length > 0), so this never spams Loki on
+  // a quiet board: a recovery.tick line means there WAS flagged work this tick.
+  // A LogQL filter on `recovery.tick` reconstructs every tick's reasoning across
+  // the fleet — e.g. "queueSize:12 processed:0 ledgerSkipped:[12 tickets]" reads
+  // as "the delegate looked, and everything is latched to a human".
+  emitEvent({
+    type: "recovery.tick",
+    reason: `recovery pass (${mode}): ${tickStats.processed} processed, ${
+      tickStats.ledgerSkipped.length + tickStats.terminalSkipped.length
+    } skipped`,
+    details: { mode, ...tickStats },
+  });
 
   return {
     processed: results.length,

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -669,7 +669,14 @@ describe("reasoningRecoveryPass cooldown skip", () => {
     );
     expect(result.processed).toBe(0);
     expect(acted).toBe(false);
-    expect(events.length).toBe(0);
+    // CTL-1287: the pass now emits ONE recovery.tick rollup per invocation even
+    // when every item is skipped (that's the whole point — a silently-skipped
+    // board is no longer invisible). The skipped ticket appears in ledgerSkipped,
+    // and NO action event (recovery.fixed/escalated/decision) is emitted.
+    const actionEvents = events.filter((e) => e.type !== "recovery.tick");
+    expect(actionEvents.length).toBe(0);
+    const tick = events.find((e) => e.type === "recovery.tick");
+    expect(tick.details.ledgerSkipped).toEqual(["CTL-9"]);
   });
 });
 
@@ -1230,5 +1237,128 @@ describe("CTL-1241 — R12 escalate_human belief wired into recovery evidence", 
     expect(result.decision).toBe("escalate");
     expect(result.fix_class).toBe("human");
     expect(result.details.reason).toContain("Rule belief R12 escalate_human fired");
+  });
+});
+
+// ─── CTL-1287: per-tick decision visibility (recovery.tick / recovery.decision) ─
+describe("reasoningRecoveryPass decision visibility (CTL-1287)", () => {
+  // Common injections that keep the pass pure (no shell-out, no real ledger).
+  const inert = {
+    postComment: () => {},
+    recordIntent: () => {},
+    invokeRemediateCapped: () => ({ success: true, reason: "fixed", details: {} }),
+  };
+
+  test("emits exactly one recovery.tick rollup per invocation, with queueSize", () => {
+    const events = [];
+    reasoningRecoveryPass(
+      [
+        { ticket: "CTL-1", evidence: { logsOutput: "stale main" } },
+        { ticket: "CTL-2", evidence: { logsOutput: "unknown error" } },
+      ],
+      { mode: "enforce", emitEvent: (e) => events.push(e), ...inert },
+    );
+    const ticks = events.filter((e) => e.type === "recovery.tick");
+    expect(ticks.length).toBe(1);
+    expect(ticks[0].details.queueSize).toBe(2);
+    expect(ticks[0].details.mode).toBe("enforce");
+  });
+
+  test("recovery.tick details carry decision + action counters", () => {
+    const events = [];
+    reasoningRecoveryPass(
+      [
+        { ticket: "CTL-1", evidence: { logsOutput: "stale main" } }, // bounded-llm fix
+        { ticket: "CTL-2", evidence: { logsOutput: "unknown error", beliefState: { escalate_human: true } } }, // escalate
+      ],
+      { mode: "enforce", emitEvent: (e) => events.push(e), ...inert },
+    );
+    const tick = events.find((e) => e.type === "recovery.tick").details;
+    expect(tick.processed).toBe(2);
+    expect(tick.decisions.fix_bounded_llm).toBe(1);
+    expect(tick.decisions.escalate).toBe(1);
+    expect(tick.actions.fixed).toBe(1);
+    expect(tick.actions.escalated).toBe(1);
+  });
+
+  test("ledger-skipped items land in ledgerSkipped[] and are NOT processed", () => {
+    const events = [];
+    reasoningRecoveryPass(
+      [
+        { ticket: "CTL-1", evidence: { logsOutput: "stale main" } }, // processed
+        { ticket: "CTL-2", evidence: { logsOutput: "stale main" } }, // skipped
+      ],
+      {
+        mode: "enforce",
+        shouldSkipItem: (t) => t === "CTL-2",
+        emitEvent: (e) => events.push(e),
+        ...inert,
+      },
+    );
+    const tick = events.find((e) => e.type === "recovery.tick").details;
+    expect(tick.ledgerSkipped).toEqual(["CTL-2"]);
+    expect(tick.processed).toBe(1);
+    // a skipped item never reaches the classifier → no recovery.decision for it
+    expect(events.some((e) => e.type === "recovery.decision" && e.ticket === "CTL-2")).toBe(false);
+  });
+
+  test("linear-terminal items land in terminalSkipped[]", () => {
+    const events = [];
+    reasoningRecoveryPass(
+      [{ ticket: "CTL-999", evidence: { linearTerminal: true, signal: {} } }],
+      { mode: "enforce", emitEvent: (e) => events.push(e), ...inert },
+    );
+    const tick = events.find((e) => e.type === "recovery.tick").details;
+    expect(tick.terminalSkipped).toEqual(["CTL-999"]);
+    expect(tick.processed).toBe(0);
+  });
+
+  test("emits a recovery.decision per classified item with the routing rule", () => {
+    const events = [];
+    reasoningRecoveryPass(
+      [
+        { ticket: "CTL-1", evidence: { logsOutput: "push rejected no workflow scope" } }, // seam → rule 1
+        { ticket: "CTL-2", evidence: { logsOutput: "stale main" } }, // bounded-llm → rule 2
+        { ticket: "CTL-3", evidence: { logsOutput: "unknown error", beliefState: { escalate_human: true } } }, // escalate → rule 3
+      ],
+      { mode: "shadow", emitEvent: (e) => events.push(e), postComment: () => {} },
+    );
+    const decisions = events.filter((e) => e.type === "recovery.decision");
+    expect(decisions.length).toBe(3);
+    expect(decisions.find((d) => d.ticket === "CTL-1").details.rule).toBe(1);
+    expect(decisions.find((d) => d.ticket === "CTL-2").details.rule).toBe(2);
+    expect(decisions.find((d) => d.ticket === "CTL-3").details.rule).toBe(3);
+  });
+
+  test("deferred items (fix cap) are counted in actions.deferred", () => {
+    const events = [];
+    reasoningRecoveryPass(
+      Array.from({ length: 4 }, (_, i) => ({ ticket: `CTL-${10 + i}`, evidence: { logsOutput: "stale main" } })),
+      { mode: "enforce", maxFixesPerTick: 2, emitEvent: (e) => events.push(e), ...inert },
+    );
+    const tick = events.find((e) => e.type === "recovery.tick").details;
+    expect(tick.actions.fixed).toBe(2);
+    expect(tick.actions.deferred).toBe(2);
+  });
+
+  test("mode=off emits no recovery.tick (the pass short-circuits)", () => {
+    const events = [];
+    reasoningRecoveryPass([{ ticket: "CTL-1", evidence: {} }], {
+      mode: "off",
+      emitEvent: (e) => events.push(e),
+    });
+    expect(events.length).toBe(0);
+  });
+
+  test("buildRecoveryEnvelope shapes a ticket-less recovery.tick (label null, action 'tick')", () => {
+    const env = buildRecoveryEnvelope({
+      type: "recovery.tick",
+      details: { mode: "enforce", queueSize: 3 },
+    });
+    expect(env.attributes["event.name"]).toBe("recovery.tick");
+    expect(env.attributes["event.action"]).toBe("tick");
+    expect(env.attributes["event.label"]).toBeNull();
+    expect(env.severityText).toBe("INFO");
+    expect(env.body.payload.details.queueSize).toBe(3);
   });
 });


### PR DESCRIPTION
## What

Makes the recovery delegate's per-tick decisions **Loki-queryable**. `reasoningRecoveryPass` previously emitted only on action (`recovery.fixed` / `recovery.escalated`); every skip (cooldown, escalated-latch, linear-terminal) was a bare `log()` to stdout. Once an item latches `escalated` it's silently skipped every tick — so a board where every flagged item is handed-to-human looked identical to one the delegate never examined.

**Proven live 2026-06-19** during the CTL-1029 dispatch repro: ~17 escalate-class ledger entries, **zero** queryable `recovery.*` events explaining them.

## Events added (existing `emitEvent` / `buildRecoveryEnvelope` path → event-log → Alloy → Loki)

- **`recovery.tick`** (1 per invocation): `{mode, queueSize, processed, decisions:{fix_seam,fix_bounded_llm,escalate}, actions:{fixed,fixFailed,escalated,deferred,errors}, ledgerSkipped:[tickets], terminalSkipped:[tickets]}`
- **`recovery.decision`** (per classified item): `{ticket, rule (1=seam/2=bounded-llm/3=escalate), decision, fix_class, reason}`

A LogQL filter on `recovery.tick` now reconstructs every tick's reasoning across mini/mini-2 — e.g. `queueSize:12 processed:0 ledgerSkipped:[12]` reads as *"the delegate looked, everything is latched to a human."*

## Safety / scope

- **Fence-clean**: `recovery-reasoning.mjs` + tests only — **no `scheduler.mjs` edit**.
- Board read-model (`loadRecoveryOutcomes`) matches only `recovery.fixed`/`would-fix`, so it **ignores** both new types — no projection change.
- `recovery.tick` only fires when there's flagged work (scheduler gates on `rItems.length > 0`), so no quiet-board Loki spam.
- Return contract (`processed: results.length`) unchanged.

## Notes / fast-follow

- `ledgerSkipped` is **coarse** (cooldown OR escalated-latch). Splitting it needs the per-tick `orchDir` ledger read, which only reaches this pure function via a `scheduler.mjs` injection (currently fenced — cluster-roster track). Documented fast-follow.
- Per-item `recovery.skipped` events were intentionally rejected (latched items would emit ~17×/tick = Loki storm); skip detail is folded into the per-tick rollup arrays.

## Tests

`recovery-reasoning.test.mjs`: +8 cases (tick rollup, counters, ledger/terminal skip rosters, per-item decision rule, deferred counting, mode=off no-tick, ticket-less envelope). **97/97 pass.** Updated one pre-existing cooldown test to the new "one tick rollup even when all-skipped" contract. `board-data-recovery.test.mjs` 9/9 (reader unaffected).

Enabler for the holistic board-level pass (A2) and OTL-17. Relates to CTL-1266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)