### PR TITLE
fix(dev): CTL-1288 — cache reconcile covers the whole board via per-tier rotation cursors

### DIFF
--- a/plugins/dev/scripts/broker/cache-reconcile.mjs
+++ b/plugins/dev/scripts/broker/cache-reconcile.mjs
@@ -55,6 +55,38 @@ function isTerminal(state) {
   return TERMINAL_STATES.has(String(state ?? "").toLowerCase());
 }
 
+// CTL-1288: Backlog is the ONE non-terminal state that is both huge (hundreds of
+// rows) and rarely display-critical (a Backlog ticket is not "stuck"). The
+// active-pipeline non-terminal states (PR/Implement/Todo/Triage/Research/Validate/
+// Remediate) are the VISIBLE board where a stale phantom (cache=PR but live=Done)
+// actually misleads an operator. We reconcile ALL active-pipeline rows every pass
+// and ROTATE a cursor window through Backlog — so phantoms in the visible board
+// clear within one interval while the whole table is still covered over successive
+// passes, all under perPassCap (the rate-limit self-constraint).
+function isBacklog(state) {
+  return String(state ?? "").toLowerCase() === "backlog";
+}
+
+// rotateWindow — take up to n items from a ticket-sorted list, starting at the
+// first ticket strictly greater than `cursor` (resume point), wrapping around.
+// Using `ticket > cursor` (not an index) is resilient to the list changing
+// between passes: if the exact cursor ticket was removed, we resume at the next
+// one. nextCursor is the last ticket taken (drives the next pass), or the
+// unchanged cursor when nothing was taken. No item appears twice in one window
+// (Math.min bound), so a pass never double-fetches the same ticket.
+export function rotateWindow(list, cursor, n) {
+  if (n <= 0 || list.length === 0) return { window: [], nextCursor: cursor };
+  let start = 0;
+  if (cursor != null) {
+    const idx = list.findIndex((d) => d.ticket > cursor);
+    start = idx === -1 ? 0 : idx; // cursor ≥ last ticket → wrap to the start
+  }
+  const take = Math.min(n, list.length);
+  const window = [];
+  for (let i = 0; i < take; i++) window.push(list[(start + i) % list.length]);
+  return { window, nextCursor: window[window.length - 1].ticket };
+}
+
 // extractState — pull the state NAME out of a `linearis issues read` JSON object.
 // linearis returns `state: { id, name }`. Returns the name string, or null when
 // state is absent/malformed (caller treats null as "unknown — do not touch").
@@ -172,23 +204,57 @@ function logSink(logger) {
 export async function reconcileCacheState({
   mode = "off",
   perPassCap = 250,
+  // CTL-1288: TWO rotation cursors (ticket ids), one per tier, threaded across
+  // passes by startCacheReconcileTimer. `{ active, backlog }`; null = start of tier.
+  // A separate cursor per tier means NEITHER tier can starve — active rotates if it
+  // exceeds its budget, and Backlog always gets a reserved floor of the cap.
+  cursor = { active: null, backlog: null },
   getAll = getAllTicketDescriptors,
   fetch = fetchLive,
   upsert = upsertTicketDescriptor,
   logger,
 } = {}) {
   const log = logSink(logger);
-  if (mode === "off") return { mode, scanned: 0, changed: 0, failed: 0, tickets: [] };
+  const inCursor = cursor ?? { active: null, backlog: null };
+  if (mode === "off") return { mode, scanned: 0, changed: 0, failed: 0, tickets: [], nextCursor: inCursor };
 
   let descriptors;
   try {
     descriptors = getAll({ includeRemoved: false }) || [];
   } catch (e) {
     log("warn", { err: String(e?.message ?? e) }, "cache-reconcile: getAll failed — skipping pass");
-    return { mode, scanned: 0, changed: 0, failed: 0, tickets: [] };
+    return { mode, scanned: 0, changed: 0, failed: 0, tickets: [], nextCursor: inCursor };
   }
 
-  const working = descriptors.filter((d) => d && d.ticket && !isTerminal(d.state)).slice(0, perPassCap);
+  // CTL-1288: two-tier selection within perPassCap, each tier rotated by its OWN
+  // cursor so NEITHER starves (the active>=cap hole that a single shared cursor
+  // had: active.slice(cap) starved the active tail AND zeroed Backlog's remainder).
+  //   • Active-pipeline non-terminal (PR/Implement/Todo/… — the VISIBLE board where
+  //     a stale phantom misleads): reconciled every pass when it fits its budget,
+  //     else rotated through over ceil(active/budget) passes — never starved.
+  //   • Backlog (huge, rarely display-critical): a reserved floor of the cap, so it
+  //     ALWAYS makes progress even when active is at/over its budget, rotated to
+  //     cover the whole tier over successive passes.
+  // |window| ≤ activeBudget + (cap-activeBudget) = cap → the rate-limit constraint
+  // holds exactly. Pre-CTL-1288: a single `.slice(0, cap)` with no cursor re-synced
+  // the same alphabetical prefix forever; ~(total-cap) rows never reconciled.
+  // NOTE: the per-tier cursor compares ticket ids with `>` (rotateWindow) and the
+  // descriptors arrive `ORDER BY ticket` (broker-state.mjs) — the SAME lexicographic
+  // collation, so cursor "next" agrees with fetch order. These MUST stay identical.
+  const nonTerminal = descriptors.filter((d) => d && d.ticket && !isTerminal(d.state));
+  const active = nonTerminal.filter((d) => !isBacklog(d.state));
+  const backlog = nonTerminal.filter((d) => isBacklog(d.state));
+  // Reserve ~20% of the cap (≥1 when Backlog is non-empty) so Backlog never starves
+  // even if active overflows its budget; active gets the rest and rotates within it.
+  const backlogReserve = backlog.length === 0 ? 0 : Math.min(backlog.length, Math.max(1, Math.floor(perPassCap / 5)));
+  const activeBudget = Math.max(0, perPassCap - backlogReserve);
+  const { window: activeWin, nextCursor: nextActive } = rotateWindow(active, inCursor.active, activeBudget);
+  // Backlog fills whatever the cap has left after active's actual take (active may
+  // use less than its budget → Backlog gets the leftover too; never less than the reserve).
+  const remaining = perPassCap - activeWin.length;
+  const { window: backlogWin, nextCursor: nextBacklog } = rotateWindow(backlog, inCursor.backlog, remaining);
+  const nextCursor = { active: nextActive, backlog: nextBacklog };
+  const working = [...activeWin, ...backlogWin];
 
   let scanned = 0;
   let changed = 0;
@@ -206,7 +272,15 @@ export async function reconcileCacheState({
     }
     if (live.error || (live.state === null && live.labels === null)) {
       failed += 1;
-      log("debug", { ticket, err: live.error }, "cache-reconcile: fetch unusable — left for next pass");
+      // CTL-1288 trade-off: the cursor advances to the last TAKEN ticket (not the
+      // last SUCCEEDED), so a fetch-failed ticket's retry waits until its tier
+      // wraps rather than next interval. This is DELIBERATE forward progress: a
+      // persistently-failing ticket (malformed, or a hard 429) must NOT freeze the
+      // cursor and block every ticket behind it. Transient correlated failures
+      // (rate-limit windows) wouldn't benefit from an immediate retry anyway —
+      // they're still throttled — and active-tier rows are revisited within ~1
+      // cycle regardless, so the bounded wrap-latency is acceptable.
+      log("debug", { ticket, err: live.error }, "cache-reconcile: fetch unusable — left for next wrap");
       continue;
     }
 
@@ -240,7 +314,7 @@ export async function reconcileCacheState({
     }
   }
 
-  return { mode, scanned, changed, failed, tickets };
+  return { mode, scanned, changed, failed, tickets, nextCursor };
 }
 
 // startCacheReconcileTimer — wire the periodic pass into the broker. Returns the
@@ -266,6 +340,10 @@ export function startCacheReconcileTimer({
   // this tick — never run two passes concurrently (double API load + double
   // writes). A pass that throws still clears the flag (finally).
   let running = false;
+  // CTL-1288: per-tier rotation cursors, persisted across passes for the life of
+  // the broker process (in-memory is sufficient — a restart simply resumes each
+  // tier from its start; coverage stays complete, just re-walks from the top).
+  let cursor = { active: null, backlog: null };
   const runPass = async () => {
     if (running) {
       log("debug", {}, "cache-reconcile: previous pass still running — skipping tick");
@@ -274,7 +352,8 @@ export function startCacheReconcileTimer({
     running = true;
     let summary;
     try {
-      summary = await reconcile({ mode, perPassCap, logger });
+      summary = await reconcile({ mode, perPassCap, cursor, logger });
+      cursor = summary.nextCursor ?? cursor; // advance the Backlog rotation window
     } catch (e) {
       log("warn", { err: String(e?.message ?? e) }, "cache-reconcile: pass threw — caught (fail-soft)");
       return;

--- a/plugins/dev/scripts/broker/cache-reconcile.test.mjs
+++ b/plugins/dev/scripts/broker/cache-reconcile.test.mjs
@@ -9,6 +9,7 @@ import {
   reconcileCacheState,
   readCacheReconcileConfig,
   startCacheReconcileTimer,
+  rotateWindow,
 } from "./cache-reconcile.mjs";
 
 // pinoLikeLogger — methods THROW if invoked with the wrong `this`, exactly like
@@ -325,5 +326,197 @@ describe("logger binding (broker boot-crash regression)", () => {
     await expect(
       reconcileCacheState({ mode: "enforce", getAll: () => [{ ticket: "X", state: "Todo" }], fetch: async () => ({ state: "Done", labels: [] }), upsert: () => {}, logger: 42 }),
     ).resolves.toBeDefined();
+  });
+});
+
+// ─── CTL-1288: rotation cursor + active-pipeline priority ────────────────────
+describe("rotateWindow (CTL-1288)", () => {
+  const L = (...ids) => ids.map((id) => ({ ticket: id })); // ticket-sorted list
+
+  test("n<=0 or empty list → empty window, cursor unchanged", () => {
+    expect(rotateWindow(L("CTL-1", "CTL-2"), null, 0)).toEqual({ window: [], nextCursor: null });
+    expect(rotateWindow([], "CTL-5", 3)).toEqual({ window: [], nextCursor: "CTL-5" });
+  });
+
+  test("null cursor starts at the beginning; nextCursor is the last taken", () => {
+    const { window, nextCursor } = rotateWindow(L("CTL-1", "CTL-2", "CTL-3"), null, 2);
+    expect(window.map((d) => d.ticket)).toEqual(["CTL-1", "CTL-2"]);
+    expect(nextCursor).toBe("CTL-2");
+  });
+
+  test("cursor resumes at the first ticket strictly greater than it", () => {
+    const { window, nextCursor } = rotateWindow(L("CTL-1", "CTL-2", "CTL-3", "CTL-4"), "CTL-2", 2);
+    expect(window.map((d) => d.ticket)).toEqual(["CTL-3", "CTL-4"]);
+    expect(nextCursor).toBe("CTL-4");
+  });
+
+  test("removed cursor ticket → resumes at the next-greater (resilient to churn)", () => {
+    // "CTL-2" no longer in the list; resume at CTL-3 (first > CTL-2).
+    const { window } = rotateWindow(L("CTL-1", "CTL-3", "CTL-4"), "CTL-2", 1);
+    expect(window.map((d) => d.ticket)).toEqual(["CTL-3"]);
+  });
+
+  test("cursor at/after the end wraps to the start", () => {
+    const { window, nextCursor } = rotateWindow(L("CTL-1", "CTL-2", "CTL-3"), "CTL-9", 2);
+    expect(window.map((d) => d.ticket)).toEqual(["CTL-1", "CTL-2"]);
+    expect(nextCursor).toBe("CTL-2");
+  });
+
+  test("n >= list length covers the whole list with NO duplicates", () => {
+    const { window } = rotateWindow(L("CTL-1", "CTL-2", "CTL-3"), "CTL-2", 99);
+    expect(window.map((d) => d.ticket).sort()).toEqual(["CTL-1", "CTL-2", "CTL-3"]);
+    expect(new Set(window.map((d) => d.ticket)).size).toBe(3); // no double-fetch
+  });
+
+  test("successive passes advance through the whole list, then wrap", () => {
+    const list = L("CTL-1", "CTL-2", "CTL-3", "CTL-4", "CTL-5");
+    let cursor = null;
+    const seen = [];
+    for (let pass = 0; pass < 3; pass++) {
+      const r = rotateWindow(list, cursor, 2);
+      seen.push(r.window.map((d) => d.ticket));
+      cursor = r.nextCursor;
+    }
+    expect(seen).toEqual([["CTL-1", "CTL-2"], ["CTL-3", "CTL-4"], ["CTL-5", "CTL-1"]]);
+  });
+});
+
+describe("reconcileCacheState two-tier selection (CTL-1288)", () => {
+  // a board with active-pipeline rows + more Backlog than the remaining cap
+  const board = () => [
+    desc({ ticket: "CTL-100", state: "PR" }),
+    desc({ ticket: "CTL-101", state: "Implement" }),
+    desc({ ticket: "CTL-B1", state: "Backlog" }),
+    desc({ ticket: "CTL-B2", state: "Backlog" }),
+    desc({ ticket: "CTL-B3", state: "Backlog" }),
+    desc({ ticket: "CTL-D1", state: "Done" }), // terminal — never reconciled
+  ];
+
+  test("active-pipeline rows are reconciled EVERY pass regardless of cursor", async () => {
+    const fetchedAll = [];
+    // tiny cap: 2 active + 1 backlog slot. Run two passes; active must appear both.
+    let cursor = null;
+    for (let pass = 0; pass < 2; pass++) {
+      const fetched = [];
+      const out = await reconcileCacheState({
+        mode: "enforce", perPassCap: 3, cursor,
+        getAll: () => board(),
+        fetch: async (t) => { fetched.push(t); return { state: "Backlog", labels: [] }; },
+        upsert: () => {},
+      });
+      cursor = out.nextCursor;
+      fetchedAll.push(fetched);
+    }
+    // CTL-100 (PR) and CTL-101 (Implement) fetched on BOTH passes; never terminal CTL-D1.
+    for (const f of fetchedAll) {
+      expect(f).toContain("CTL-100");
+      expect(f).toContain("CTL-101");
+      expect(f).not.toContain("CTL-D1");
+    }
+  });
+
+  test("Backlog is rotated across passes; whole Backlog covered, no per-pass duplicates", async () => {
+    let cursor = null;
+    const backlogSeen = new Set();
+    for (let pass = 0; pass < 3; pass++) {
+      const fetched = [];
+      const out = await reconcileCacheState({
+        mode: "enforce", perPassCap: 3, cursor,
+        getAll: () => board(),
+        fetch: async (t) => { fetched.push(t); return { state: "Backlog", labels: [] }; },
+        upsert: () => {},
+      });
+      cursor = out.nextCursor;
+      // exactly one backlog per pass (cap 3 - 2 active = 1 remaining), no dupes within a pass
+      const bl = fetched.filter((t) => t.startsWith("CTL-B"));
+      expect(bl.length).toBe(1);
+      bl.forEach((t) => backlogSeen.add(t));
+    }
+    expect([...backlogSeen].sort()).toEqual(["CTL-B1", "CTL-B2", "CTL-B3"]); // all 3 covered over 3 passes
+  });
+
+  test("a PR-state phantom (cache=PR, live=Done) is corrected in ONE pass (active tier)", async () => {
+    const writes = [];
+    const out = await reconcileCacheState({
+      mode: "enforce", perPassCap: 250, cursor: null,
+      getAll: () => [desc({ ticket: "CTL-1191", state: "PR" })],
+      fetch: async () => ({ state: "Done", labels: [] }),
+      upsert: (p) => writes.push(p),
+    });
+    expect(out.changed).toBe(1);
+    expect(writes).toEqual([{ ticket: "CTL-1191", state: "Done" }]);
+  });
+
+  test("a pass never issues more than perPassCap fetches (rate-limit bound)", async () => {
+    const many = Array.from({ length: 500 }, (_, i) => desc({ ticket: `CTL-B${String(i).padStart(3, "0")}`, state: "Backlog" }));
+    let fetches = 0;
+    const out = await reconcileCacheState({
+      mode: "enforce", perPassCap: 50, cursor: null,
+      getAll: () => many,
+      fetch: async () => { fetches++; return { state: "Backlog", labels: [] }; },
+      upsert: () => {},
+    });
+    expect(fetches).toBeLessThanOrEqual(50);
+    expect(out.scanned).toBeLessThanOrEqual(50);
+  });
+
+  test("returns a per-tier nextCursor so the timer can thread it across passes", async () => {
+    const out = await reconcileCacheState({
+      mode: "shadow", perPassCap: 1, cursor: null,
+      getAll: () => [desc({ ticket: "CTL-B1", state: "Backlog" }), desc({ ticket: "CTL-B2", state: "Backlog" })],
+      fetch: async () => ({ state: "Backlog", labels: [] }),
+      upsert: () => {},
+    });
+    expect(out.nextCursor.backlog).toBe("CTL-B1");
+    expect(out.nextCursor).toHaveProperty("active");
+  });
+
+  // ── CTL-1288 verify-workflow regression: active>=budget must NOT starve either tier ──
+  test("active tier rotates when it exceeds its budget — no active-tail starvation", async () => {
+    // 5 active, cap=4 → backlogReserve=1, activeBudget=3 → active rotates 3/pass,
+    // all 5 covered within 2 passes; backlog still gets its reserve.
+    const rows = () => [
+      ...["CTL-A1", "CTL-A2", "CTL-A3", "CTL-A4", "CTL-A5"].map((t) => desc({ ticket: t, state: "PR" })),
+      desc({ ticket: "CTL-Z1", state: "Backlog" }),
+    ];
+    let cursor = { active: null, backlog: null };
+    const activeSeen = new Set();
+    let backlogTotal = 0;
+    for (let pass = 0; pass < 2; pass++) {
+      const fetched = [];
+      const out = await reconcileCacheState({
+        mode: "enforce", perPassCap: 4, cursor,
+        getAll: rows, fetch: async (t) => { fetched.push(t); return { state: "PR", labels: [] }; }, upsert: () => {},
+      });
+      cursor = out.nextCursor;
+      expect(fetched.length).toBeLessThanOrEqual(4); // cap bound holds under overflow
+      fetched.filter((t) => t.startsWith("CTL-A")).forEach((t) => activeSeen.add(t));
+      backlogTotal += fetched.filter((t) => t.startsWith("CTL-Z")).length;
+    }
+    expect([...activeSeen].sort()).toEqual(["CTL-A1", "CTL-A2", "CTL-A3", "CTL-A4", "CTL-A5"]); // tail NOT starved
+    expect(backlogTotal).toBeGreaterThanOrEqual(1); // backlog got the reserve despite active overflow
+  });
+
+  test("Backlog keeps its reserve when active fills the cap (no Backlog starvation)", async () => {
+    // 10 active, cap=5 → backlogReserve=1, activeBudget=4 → backlog ALWAYS gets ≥1.
+    const rows = () => [
+      ...Array.from({ length: 10 }, (_, i) => desc({ ticket: `CTL-A${i}`, state: "Implement" })),
+      desc({ ticket: "CTL-Z1", state: "Backlog" }), desc({ ticket: "CTL-Z2", state: "Backlog" }),
+    ];
+    let cursor = { active: null, backlog: null };
+    const backlogSeen = new Set();
+    for (let pass = 0; pass < 2; pass++) {
+      const fetched = [];
+      const out = await reconcileCacheState({
+        mode: "enforce", perPassCap: 5, cursor,
+        getAll: rows, fetch: async (t) => { fetched.push(t); return { state: "Implement", labels: [] }; }, upsert: () => {},
+      });
+      cursor = out.nextCursor;
+      expect(fetched.length).toBeLessThanOrEqual(5);
+      const bl = fetched.filter((t) => t.startsWith("CTL-Z"));
+      expect(bl.length).toBeGreaterThanOrEqual(1); // reserve floor honored every pass
+      bl.forEach((t) => backlogSeen.add(t));
+    }
+    expect([...backlogSeen].sort()).toEqual(["CTL-Z1", "CTL-Z2"]); // backlog fully covered, never starved
   });
 });


### PR DESCRIPTION
## What

The CTL-1277 board-cache reconcile re-synced the **same alphabetical prefix every pass** and left the rest of the board to drift forever. Fix: cover the whole `ticket_state` table via **two independent per-tier rotation cursors** within `perPassCap`, so phantom "stuck" tickets clear instead of lingering.

## Why (verified live 2026-06-19)

`reconcileCacheState` swept the whole table filtered to non-terminal, then `.slice(0, perPassCap=250)` with **no rotation cursor**. With ~505 non-terminal rows (442 Backlog alone), ~255 tickets past the prefix **never reconciled**. Confirmed drift: **CTL-1191 / CTL-1279 / CTL-1255 → `cache=PR` but `live=Done`**; the board reported ~28 "stuck in PR" tickets of which only ~1 had a real open PR. This phantom drift is the bulk of an operator-reported "ton of things stuck with free slots open."

## Fix (fence-clean: `broker/cache-reconcile.mjs` + tests only)

Two per-tier rotation cursors `{active, backlog}` so **neither tier can starve**:
- **Active-pipeline non-terminal** (PR/Implement/Todo/Triage/Research/Validate/Remediate — the visible board) reconciles every pass when it fits its budget, else rotates over `ceil(active/budget)` passes.
- **Backlog** gets a reserved floor (~20% of cap, ≥1) and rotates — always makes progress even when active is at/over budget; whole tier covered over successive passes.
- `|window| = activeWin + backlogWin ≤ perPassCap` exactly → rate-limit self-constraint holds.

Cache-only via `upsertTicketDescriptor` key-presence (no Linear/GitHub/worker write). Off by default (`CATALYST_CACHE_RECONCILE`).

## Adversarial verification (3-lens workflow, then fixed)

An adversarial verify workflow (coverage / churn / rate-safety lenses) **refuted** the first single-shared-cursor draft: when `active.length >= cap`, the active tail *and* all of Backlog silently never reconciled (`remaining=0`). This PR's per-tier cursors + Backlog reserve close that hole, with **active-overflow regression tests** added. The verifier's upheld findings (cap bound, churn resilience, cache-only, lexicographic-collation agreement, no-boot-crash) carry over.

Fetch-failed tickets advance the cursor (deliberate **forward progress / poison-pill resistance** — documented), retried within one tier wrap.

## Tests

`cache-reconcile.test.mjs`: **43 tests** — `rotateWindow` mechanics (wrap/churn/no-dup), two-tier selection, **active>budget rotation (no tail starvation)**, **Backlog reserve floor (no Backlog starvation)**, PR-phantom-clears-in-one-pass, ≤cap fetch bound, per-tier `nextCursor`. All green (62/62 with broker-state).

Relates to CTL-1277, CTL-1278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)