### PR TITLE
feat(dev): CTL-1291 — chartable control-loop numerics via OTel attribute promotion

### DIFF
--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -853,6 +853,45 @@ function resolveOrchDir() {
 // what board-data.mjs:loadRecoveryOutcomes matches on. This is the load-bearing
 // half of the emit↔read contract.
 
+// promoteNumericAttrs — CTL-1291. Promote bounded numerics + bounded enums from
+// a recovery event's details{} block into OTel attributes so a dashboard can
+// CHART them. The forwarder ships ONLY attributes (+ event.name) to Loki —
+// body.payload is dropped from the log LINE — so any number left only in
+// details is unqueryable ("the event fired" but not "what it carried"). PURE.
+// Cardinality guard: arrays promote as LENGTH (never the roster); only finite
+// numbers and strings ≤64 chars pass; free-text/high-card stays in body.payload.
+// (CTL-1290 appends a "recovery.board-scan" branch here.)
+function promoteNumericAttrs(type, details) {
+  if (!details || typeof details !== "object") return {};
+  const a = {};
+  const num = (k, v) => {
+    if (typeof v === "number" && Number.isFinite(v)) a[k] = v;
+  };
+  const str = (k, v) => {
+    if (typeof v === "string" && v.length > 0 && v.length <= 64) a[k] = v;
+  };
+  if (type === "recovery.tick") {
+    num("recovery.queue_size", details.queueSize);
+    num("recovery.processed", details.processed);
+    num("recovery.decisions.fix_seam", details.decisions?.fix_seam);
+    num("recovery.decisions.fix_bounded_llm", details.decisions?.fix_bounded_llm);
+    num("recovery.decisions.escalate", details.decisions?.escalate);
+    num("recovery.actions.fixed", details.actions?.fixed);
+    num("recovery.actions.fix_failed", details.actions?.fixFailed);
+    num("recovery.actions.escalated", details.actions?.escalated);
+    num("recovery.actions.deferred", details.actions?.deferred);
+    num("recovery.actions.errors", details.actions?.errors);
+    num("recovery.ledger_skipped", details.ledgerSkipped?.length);
+    num("recovery.terminal_skipped", details.terminalSkipped?.length);
+    str("recovery.mode", details.mode);
+  } else if (type === "recovery.decision") {
+    num("recovery.rule", details.rule);
+    str("recovery.decision", details.decision);
+    str("recovery.mode", details.mode);
+  }
+  return a;
+}
+
 // buildRecoveryEnvelope — pure. Assembles the canonical envelope for a
 // recovery.* event. Exported so tests can assert the contract shape directly.
 export function buildRecoveryEnvelope(event, { now } = {}) {
@@ -889,6 +928,8 @@ export function buildRecoveryEnvelope(event, { now } = {}) {
       // ← the CTL key — what loadRecoveryOutcomes keys its outcome map on.
       "event.label": ticket,
       ...(fix_class != null ? { "recovery.fix_class": fix_class } : {}),
+      // CTL-1291: bounded numerics/enums promoted so the numbers are chartable.
+      ...promoteNumericAttrs(type, details),
     },
     // human-readable mirror; also the reader's fallback ticket-key source.
     body: { payload: { ticket, type, fix_class, reason, details, escalation } },

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -771,6 +771,97 @@ describe("buildRecoveryEnvelope (emit↔read contract)", () => {
   });
 });
 
+// ─── CTL-1291: chartable numeric/enum attribute promotion ───────────────────
+// The forwarder ships ONLY OTel attributes (+ event.name) to Loki; body.payload
+// is dropped from the log line. So the numbers a recovery.tick/decision carries
+// are unqueryable until they ride out as attributes. Promote bounded numerics +
+// bounded enums; arrays promote as LENGTH (never the roster — cardinality).
+describe("buildRecoveryEnvelope numeric/enum promotion (CTL-1291)", () => {
+  test("recovery.tick promotes counts + mode enum to attributes", () => {
+    const details = {
+      mode: "enforce",
+      queueSize: 12,
+      processed: 3,
+      decisions: { fix_seam: 1, fix_bounded_llm: 1, escalate: 1 },
+      actions: { fixed: 2, fixFailed: 0, escalated: 1, deferred: 0, errors: 0 },
+      ledgerSkipped: ["CTL-1", "CTL-2"],
+      terminalSkipped: ["CTL-3"],
+    };
+    const env = buildRecoveryEnvelope({ type: "recovery.tick", ticket: null, reason: "r", details });
+    const a = env.attributes;
+    expect(a["recovery.queue_size"]).toBe(12);
+    expect(a["recovery.processed"]).toBe(3);
+    expect(a["recovery.decisions.fix_seam"]).toBe(1);
+    expect(a["recovery.decisions.fix_bounded_llm"]).toBe(1);
+    expect(a["recovery.decisions.escalate"]).toBe(1);
+    expect(a["recovery.actions.fixed"]).toBe(2);
+    expect(a["recovery.actions.fix_failed"]).toBe(0);
+    expect(a["recovery.actions.escalated"]).toBe(1);
+    expect(a["recovery.actions.deferred"]).toBe(0);
+    expect(a["recovery.actions.errors"]).toBe(0);
+    // arrays promote as LENGTH, never the roster
+    expect(a["recovery.ledger_skipped"]).toBe(2);
+    expect(a["recovery.terminal_skipped"]).toBe(1);
+    expect(a["recovery.mode"]).toBe("enforce");
+    // the rosters themselves must NOT become attributes (cardinality)
+    expect(Array.isArray(a["recovery.ledger_skipped"])).toBe(false);
+    expect(a["recovery.ledgerSkipped"]).toBeUndefined();
+  });
+
+  test("recovery.decision promotes rule (num) + decision/mode (enum)", () => {
+    const env = buildRecoveryEnvelope({
+      type: "recovery.decision",
+      ticket: "CTL-1029",
+      fix_class: "bounded-llm",
+      details: { rule: 2, decision: "fix", mode: "shadow" },
+    });
+    const a = env.attributes;
+    expect(a["recovery.rule"]).toBe(2);
+    expect(a["recovery.decision"]).toBe("fix");
+    expect(a["recovery.mode"]).toBe("shadow");
+    expect(a["event.label"]).toBe("CTL-1029"); // unchanged canonical attr
+  });
+
+  test("body.payload.details stays intact (back-compat / dual-write)", () => {
+    const details = {
+      mode: "enforce",
+      queueSize: 7,
+      processed: 1,
+      decisions: { fix_seam: 0, fix_bounded_llm: 0, escalate: 0 },
+      actions: { fixed: 0, fixFailed: 0, escalated: 0, deferred: 0, errors: 0 },
+      ledgerSkipped: [],
+      terminalSkipped: [],
+    };
+    const env = buildRecoveryEnvelope({ type: "recovery.tick", ticket: null, details });
+    expect(env.body.payload.details).toEqual(details);
+  });
+
+  test("null / malformed details → no promoted attrs, never throws", () => {
+    const env1 = buildRecoveryEnvelope({ type: "recovery.tick", ticket: null, details: null });
+    expect(env1.attributes["recovery.queue_size"]).toBeUndefined();
+    const env2 = buildRecoveryEnvelope({ type: "recovery.tick", ticket: null, details: "nope" });
+    expect(env2.attributes["recovery.queue_size"]).toBeUndefined();
+  });
+
+  test("non-finite numbers and over-long strings are dropped", () => {
+    const env = buildRecoveryEnvelope({
+      type: "recovery.tick",
+      ticket: null,
+      details: { mode: "x".repeat(100), queueSize: Infinity, processed: NaN },
+    });
+    expect(env.attributes["recovery.queue_size"]).toBeUndefined();
+    expect(env.attributes["recovery.processed"]).toBeUndefined();
+    expect(env.attributes["recovery.mode"]).toBeUndefined(); // >64 chars dropped
+  });
+
+  test("unknown recovery.* type promotes nothing (e.g. recovery.fixed)", () => {
+    const env = buildRecoveryEnvelope({ type: "recovery.fixed", ticket: "CTL-9", details: { foo: 1 } });
+    expect(env.attributes["recovery.queue_size"]).toBeUndefined();
+    expect(env.attributes["recovery.rule"]).toBeUndefined();
+    expect(env.attributes["event.name"]).toBe("recovery.fixed"); // canonical attrs intact
+  });
+});
+
 // ─── CTL-1176: host-local cooldown + intent ledger ──────────────────────────
 describe("recovery-intent ledger (cooldown + max-attempts + escalated)", () => {
   let orchDir;

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -284,6 +284,21 @@ function defaultEmitComplete({ orchDir, signal }, { spawn = spawnSync } = {}) {
 // `ticketType` is resolved by the caller from triage.json (resolveTicketType);
 // when omitted it defaults to UNKNOWN_TICKET_TYPE so the attribute is ALWAYS
 // present, never inconsistently missing (the gherkin contract).
+// vetAttrs — CTL-1291. Keep only chartable, low-cardinality values (finite
+// numbers + short strings) from a caller's attrExtras, so promoting gauge
+// numbers to attributes can NEVER blow up Loki stream cardinality with
+// free-text or arrays. Free-text (reason/decision_reason) is deliberately not
+// passed in attrExtras and stays in body.payload.
+function vetAttrs(obj) {
+  if (!obj || typeof obj !== "object") return {};
+  const out = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (typeof v === "number" && Number.isFinite(v)) out[k] = v;
+    else if (typeof v === "string" && v.length > 0 && v.length <= 64) out[k] = v;
+  }
+  return out;
+}
+
 function buildEventEnvelope({
   phase,
   ticket,
@@ -291,6 +306,8 @@ function buildEventEnvelope({
   action,
   reason,
   payloadExtras = {},
+  // CTL-1291: vetted numeric/enum attrs to promote so dashboards can chart them.
+  attrExtras = {},
   severityText = "WARN",
   severityNumber = 13,
   ticketType = UNKNOWN_TICKET_TYPE,
@@ -319,6 +336,7 @@ function buildEventEnvelope({
         "catalyst.orchestration": orchId ?? ticket,
         "linear.issue.identifier": ticket,
         "catalyst.ticket.type": ticketType ?? UNKNOWN_TICKET_TYPE,
+        ...vetAttrs(attrExtras), // CTL-1291: chartable gauge numbers
       },
       body: { payload: { phase, ticket, status: action, reason, ...payloadExtras } },
     }) + "\n"
@@ -1096,6 +1114,14 @@ export function defaultAppendParallelismSampledEvent({
         bg_count: bgCount,
         maxParallel_current: maxParallelCurrent,
       },
+      // CTL-1291: slots-in-use (bg_count) + parallelism (maxParallel_current)
+      // promoted so they're chartable, not just the sampling event's rate.
+      attrExtras: {
+        "scheduler.bg_count": bgCount,
+        "scheduler.max_parallel_current": maxParallelCurrent,
+        "scheduler.load1": load1,
+        "scheduler.mem_free_pct": memFreePct,
+      },
     }),
     "parallelism-sampled"
   );
@@ -1156,6 +1182,19 @@ export function defaultAppendAutotuneGaugeEvent({
         load_per_core: loadPerCore,
         mem_free_pct: memFreePct,
         decision_reason: reason,
+      },
+      // CTL-1291: effective/target parallelism + running_workers (slots-in-use)
+      // promoted to attributes so the gauge renders as a numeric series.
+      // (Real OTLP gauge metrics → Prometheus are deferred as a follow-up;
+      // these Loki structured-metadata series satisfy "chartable as a series".)
+      // decision_reason (free-text) stays in body.payload only — cardinality.
+      attrExtras: {
+        "scheduler.max_parallel_effective": maxParallelEffective,
+        "scheduler.max_parallel_target": maxParallelTarget,
+        "scheduler.running_workers": runningWorkers,
+        "scheduler.load1": load1,
+        "scheduler.load_per_core": loadPerCore,
+        "scheduler.mem_free_pct": memFreePct,
       },
     }),
     "autotune-gauge"

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -3172,6 +3172,60 @@ describe("dispatch lifecycle event envelopes (CTL-660)", () => {
     expect(env.body.payload.mem_free_pct).toBe(42.5);
     expect(env.body.payload.decision_reason).toBe("converge-to-setpoint");
   });
+
+  // CTL-1291: the gauge numbers must ride out as ATTRIBUTES (not just
+  // body.payload) so a dashboard can chart parallelism + slots-in-use as a
+  // numeric series. Free-text (decision_reason/reason) stays in body.payload —
+  // never promoted (cardinality). body.payload is left intact (dual-write).
+  test("autotune-gauge promotes numeric gauges to attributes (CTL-1291)", () => {
+    const ok = defaultAppendAutotuneGaugeEvent({
+      label: "execution-core",
+      maxParallelEffective: 4,
+      maxParallelTarget: 6,
+      runningWorkers: 3,
+      load1: 2.4,
+      loadPerCore: 0.3,
+      memFreePct: 42.5,
+      reason: "converge-to-setpoint",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    const a = env.attributes;
+    expect(a["scheduler.max_parallel_effective"]).toBe(4);
+    expect(a["scheduler.max_parallel_target"]).toBe(6);
+    expect(a["scheduler.running_workers"]).toBe(3);
+    expect(a["scheduler.load1"]).toBe(2.4);
+    expect(a["scheduler.load_per_core"]).toBe(0.3);
+    expect(a["scheduler.mem_free_pct"]).toBe(42.5);
+    // free-text NOT promoted to an attribute (stays in body.payload only)
+    expect(a["scheduler.decision_reason"]).toBeUndefined();
+    expect(a["decision_reason"]).toBeUndefined();
+    // body.payload intact (back-compat)
+    expect(env.body.payload.running_workers).toBe(3);
+    expect(env.body.payload.decision_reason).toBe("converge-to-setpoint");
+  });
+
+  test("parallelism-sampled promotes slots/parallelism to attributes (CTL-1291)", () => {
+    const ok = defaultAppendParallelismSampledEvent({
+      label: "execution-core",
+      load1: 1.5,
+      load5: 1.2,
+      load15: 1.0,
+      memFreePct: 55.0,
+      bgCount: 2,
+      maxParallelCurrent: 5,
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    const a = env.attributes;
+    expect(a["scheduler.bg_count"]).toBe(2); // slots-in-use
+    expect(a["scheduler.max_parallel_current"]).toBe(5); // parallelism
+    expect(a["scheduler.load1"]).toBe(1.5);
+    expect(a["scheduler.mem_free_pct"]).toBe(55.0);
+    // body.payload intact (back-compat)
+    expect(env.body.payload.bg_count).toBe(2);
+    expect(env.body.payload.maxParallel_current).toBe(5);
+  });
 });
 
 // CTL-1044: the generic operator-event appender. This is the PRODUCTION default


### PR DESCRIPTION
## What

`otel-forward` ships only OTel attributes (+ `event.name`) to Loki — `body.payload` is dropped from the log line. So the rich numbers our control-loop events carry (`recovery.tick` queue depth / processed / action breakdown; `recovery.decision` rule/decision; the scheduler `parallelism-sampled` / `autotune-gauge` gauges) were **unqueryable**: dashboards could show *that* an event fired, never *what it carried*. This promotes bounded numerics + bounded enums into attributes so they're chartable.

## How

- **`recovery-reasoning.mjs`** — pure `promoteNumericAttrs(type, details)` spread into `buildRecoveryEnvelope`:
  - `recovery.tick` → `recovery.queue_size`, `recovery.processed`, `recovery.decisions.*`, `recovery.actions.*`, `recovery.ledger_skipped`/`terminal_skipped` (lengths), `recovery.mode`
  - `recovery.decision` → `recovery.rule`, `recovery.decision`, `recovery.mode`
- **`recovery.mjs`** — `vetAttrs()` cardinality guard + opt-in `attrExtras` seam on `buildEventEnvelope`, wired into `parallelism-sampled` (`scheduler.bg_count`/`max_parallel_current`) + `autotune-gauge` (`scheduler.running_workers`/`max_parallel_effective`/`max_parallel_target`).

## Safety

- **Cardinality-safe**: only finite numbers + bounded enums (`mode` ∈ 2, `decision` ∈ 3) promoted; arrays promote as length; free-text (`reason`/`decision_reason`) stays in `body.payload`; strings capped at 64.
- **Back-compat**: additive on the attributes block only — `body.payload` byte-identical; board reader (`loadRecoveryOutcomes`, per-key lookups) unaffected; ~13 other `buildEventEnvelope` callers default `attrExtras={}`.
- Tests: **103 + 271 green**; adversarial 4-lens review = **SHIP**, zero code defects.

## External dependency / follow-ups

- ⚠️ **catalyst-otel collector** (off-repo, `100.65.193.30`): these ride as OTLP log-record attributes → Loki structured metadata. To become *first-class* structured-metadata keys, the collector's `transform/logs` needs `set(attributes["recovery_..."], …)`. Cardinality-safety holds **as long as the collector keeps log-record attributes as structured metadata, not stream labels**.
- Deferred: real OTLP gauges → Prometheus (these structured-metadata series satisfy "chartable as a series").

Unblocks OTL-18. Closes CTL-1291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
