### PR TITLE
fix(dev): CTL-1174 — gate dispatch on delegate-ONLY + delegate-on-Todo (unwedge the board)

### DIFF
--- a/plugins/dev/scripts/broker/broker-state.d.mts
+++ b/plugins/dev/scripts/broker/broker-state.d.mts
@@ -21,6 +21,8 @@ export interface TicketDescriptor {
   estimate: number | null;
   resolution: string | null;
   assignee: string | null;
+  /** CTL-1174: Linear delegate UUID (app-user/bot) from broker cache. null = unset. */
+  delegate: string | null;
   uuid: string | null;
   removed: boolean;
   removedAt: string | null;
@@ -44,6 +46,8 @@ export interface UpsertTicketDescriptorInput {
   estimate?: number | null;
   resolution?: string | null;
   assignee?: string | null;
+  /** CTL-1174: delegate UUID (key-presence: absent = keep). */
+  delegate?: string | null;
   uuid?: string | null;
   removed?: boolean;
 }

--- a/plugins/dev/scripts/broker/broker-state.mjs
+++ b/plugins/dev/scripts/broker/broker-state.mjs
@@ -121,6 +121,7 @@ export function openBrokerStateDb(dbPath = DEFAULT_DB_PATH) {
     "estimate INTEGER",
     "resolution TEXT",
     "assignee TEXT",
+    "delegate TEXT",
     "uuid TEXT",
     "removed_at TEXT",
     "owner_host TEXT",
@@ -529,6 +530,7 @@ const DESCRIPTOR_COLUMNS = {
   estimate: "estimate",
   resolution: "resolution",
   assignee: "assignee",
+  delegate: "delegate",
   uuid: "uuid",
 };
 
@@ -612,6 +614,7 @@ function rowToTicketDescriptor(row) {
     estimate: typeof row.estimate === "number" ? row.estimate : null,
     resolution: row.resolution ?? null,
     assignee: row.assignee ?? null,
+    delegate: row.delegate ?? null,
     uuid: row.uuid ?? null,
     removed: row.removed_at != null,
     removedAt: row.removed_at ?? null,

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -1498,6 +1498,22 @@ function foldLinearIssueDescriptor(name, detail, eventTicket) {
         (Array.isArray(detail.updatedFromKeys) && detail.updatedFromKeys.includes("assigneeId"));
       if (changeEvidenced) descriptor.assignee = v;
     }
+    if ("toDelegateId" in detail) {
+      const v = detail.toDelegateId ?? null;
+      // CTL-1174: mirror the CTL-821 assignee guard — a bare null CLEARS only
+      // when the change is evidenced, else it is "unknown" and KEEPS (a partial
+      // Linear payload must never spuriously un-delegate a bot-owned ticket →
+      // re-claim). Accept BOTH updatedFrom key spellings since Linear's exact
+      // key is unverified (Open Question #2) — accepting both fails toward KEEP.
+      const changeEvidenced =
+        v !== null ||
+        name === "linear.issue.delegate_changed" ||
+        detail.action === "create" ||
+        (Array.isArray(detail.updatedFromKeys) &&
+          (detail.updatedFromKeys.includes("delegateId") ||
+            detail.updatedFromKeys.includes("delegate")));
+      if (changeEvidenced) descriptor.delegate = v;
+    }
     if (detail.toLabels != null) descriptor.labels = detail.toLabels;
     if (uuid) descriptor.uuid = uuid;
     upsertTicketDescriptor(descriptor);

--- a/plugins/dev/scripts/execution-core/eligible-set.mjs
+++ b/plugins/dev/scripts/execution-core/eligible-set.mjs
@@ -82,6 +82,11 @@ function contentKey(tickets) {
       t.parent ?? null,
       t.estimate ?? null,
       relationsSignature(t),
+      // CTL-1174: delegate in the signature so an out-of-band delegate change
+      // forces a projection rewrite (the CONTENTKEY PROJECTION TRAP). `?? null`
+      // collapses undefined/null identically — a batch outage leaves delegate
+      // unset and must not churn the set on the next successful poll.
+      t.delegate ?? null,
     ]),
   );
 }

--- a/plugins/dev/scripts/execution-core/eligible-set.test.mjs
+++ b/plugins/dev/scripts/execution-core/eligible-set.test.mjs
@@ -232,6 +232,59 @@ describe("setProjectEligible", () => {
     });
     expect(existsSync(projFile("alpha"))).toBe(true);
   });
+
+  test("CTL-1174: a delegate-only delta DOES rewrite the file (delegate is in the content key)", async () => {
+    // Pre-CTL-1174 projection has no delegate; reconcile now carries delegate UUID.
+    // Without delegate in contentKey, the rewrite would be skipped → silent starvation
+    // (a foreign delegate would never trigger the claim guard refresh).
+    setProjectEligible("alpha", [{ identifier: "A-1", state: "Todo", priority: 1, delegate: null }], {
+      source: "reconcile",
+      query: {},
+    });
+    const mtime1 = statSync(projFile("alpha")).mtimeMs;
+    await sleep(15);
+    setProjectEligible(
+      "alpha",
+      [{ identifier: "A-1", state: "Todo", priority: 1, delegate: "bot-uuid-ff78d890" }],
+      { source: "reconcile", query: {} },
+    );
+    expect(statSync(projFile("alpha")).mtimeMs).toBeGreaterThan(mtime1);
+    const doc = JSON.parse(readFileSync(projFile("alpha"), "utf8"));
+    expect(doc.tickets[0].delegate).toBe("bot-uuid-ff78d890");
+  });
+
+  test("CTL-1174: unchanged delegate does NOT rewrite the file (no spurious churn)", async () => {
+    setProjectEligible(
+      "alpha",
+      [{ identifier: "A-1", state: "Todo", priority: 1, delegate: "bot-uuid-ff78d890" }],
+      { source: "reconcile", query: {} },
+    );
+    const mtime1 = statSync(projFile("alpha")).mtimeMs;
+    await sleep(15);
+    // Same delegate — no rewrite expected.
+    setProjectEligible(
+      "alpha",
+      [{ identifier: "A-1", state: "Todo", priority: 1, delegate: "bot-uuid-ff78d890" }],
+      { source: "reconcile", query: {} },
+    );
+    expect(statSync(projFile("alpha")).mtimeMs).toBe(mtime1);
+  });
+
+  test("CTL-1174: undefined delegate treated as null in contentKey (no spurious churn vs null)", async () => {
+    // A ticket freshly read via linearis has no delegate field → undefined → normalized to null.
+    // A second reconcile with delegate:null must NOT trigger a rewrite.
+    setProjectEligible("alpha", [{ identifier: "A-1", state: "Todo", priority: 1 }], {
+      source: "reconcile",
+      query: {},
+    });
+    const mtime1 = statSync(projFile("alpha")).mtimeMs;
+    await sleep(15);
+    setProjectEligible("alpha", [{ identifier: "A-1", state: "Todo", priority: 1, delegate: null }], {
+      source: "reconcile",
+      query: {},
+    });
+    expect(statSync(projFile("alpha")).mtimeMs).toBe(mtime1);
+  });
 });
 
 describe("removeTicket", () => {

--- a/plugins/dev/scripts/execution-core/gateway-read.mjs
+++ b/plugins/dev/scripts/execution-core/gateway-read.mjs
@@ -76,6 +76,7 @@ export function createGatewayReader({ dbPath = defaultDbPath() } = {}) {
         priority: row.priority ?? null,
         resolution: row.resolution ?? null,
         assignee: row.assignee ?? null,
+        delegate: row.delegate ?? null,
         uuid: row.uuid ?? null,
         removed: row.removed_at != null,
         removedAt: row.removed_at ?? null,

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -497,11 +497,21 @@ export function fetchTicketAssignee(
   if (gateway) {
     const d = gateway.getDescriptor(identifier);
     if (d && !d.removed) {
-      return {
-        known: true,
-        assignee: d.assignee ?? null,
-        delegate: d.delegate === undefined ? null : d.delegate,
-      };
+      const cachedDelegate = d.delegate === undefined ? null : d.delegate;
+      // CTL-1174 LATCH FIX: a cached delegate of null is indistinguishable from
+      // "never projected into the broker store" — and the store is NEVER written
+      // with the orchestrator's own self-delegation (the webhook fold is dormant +
+      // bot-suppressed; cache-reconcile + the eligible batch don't read delegate).
+      // Returning cached-null here makes the delegate-on-Todo gate re-delegate
+      // forever and never observe its own write. So on a cached NULL delegate,
+      // CONFIRM LIVE before treating it as undelegated; a non-null cached delegate
+      // is authoritative (only an actor sets it) and stays rate-free.
+      if (cachedDelegate !== null) {
+        return { known: true, assignee: d.assignee ?? null, delegate: cachedDelegate };
+      }
+      const drHit = fetchDelegate(identifier);
+      if (!drHit.known) return { known: false }; // unreadable → HOLD (never claim on unknown)
+      return { known: true, assignee: d.assignee ?? null, delegate: drHit.delegate ?? null };
     }
     // Gateway miss: live read for assignee, then delegate.
     const { code, stdout } = exec("linearis", ["issues", "read", identifier]);

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -537,16 +537,20 @@ export function isAssigneeClaimable(assignee, botUserIds) {
   return botUserIds instanceof Set && botUserIds.has(assignee);
 }
 
-// isClaimable — CTL-1174 delegate-aware claim predicate. A ticket is ours iff
-// BOTH the assignee and the delegate gates pass. Model: assignee = human
-// responsibility (back off); delegate = bot ownership (ours).
-//   claimable iff (assignee ∈ {null,bot}) AND (delegate ∈ {null,bot})
-// undefined delegate is coerced to null (back-compat: old {known,assignee}
-// shape from no-gateway callers treats absent delegate as "unset" = claimable).
+// isClaimable — CTL-1174 (delegate-ONLY claim predicate). The human ASSIGNEE is
+// IRRELEVANT: a Linear bot can never BE an assignee (app-user UUIDs route to
+// Issue.delegate; assigning one returns HTTP 400 "App user not valid"), so a
+// human always holds the assignee and gating on it permanently starves the
+// board (CTL-781's stopgap). A ticket is the daemon's to claim IFF it is
+// DELEGATED to the orchestrator bot.
+//   claimable iff delegate ∈ bot-ids
+// An UNDELEGATED ticket (delegate == null/undefined) is NOT claimable here — it
+// is first delegated by the delegate-on-Todo step at the call sites (which then
+// makes this gate pass next reconcile). The `assignee` arg is retained for
+// call-site/signature compatibility but is deliberately unused.
 export function isClaimable(assignee, delegate, botUserIds) {
   const d = delegate === undefined ? null : delegate;
-  const inBots = (id) => id == null || (botUserIds instanceof Set && botUserIds.has(id));
-  return isAssigneeClaimable(assignee, botUserIds) && inBots(d);
+  return d != null && botUserIds instanceof Set && botUserIds.has(d);
 }
 
 // CTL-1173: raw GraphQL read for Issue.delegate.id — Linear routes an app-user

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -110,6 +110,9 @@ function normalizeTicket(node) {
     parent: node.parent?.identifier ?? node.parent ?? null,
     relations: node.relations ?? { nodes: [] },
     inverseRelations: node.inverseRelations ?? { nodes: [] },
+    // CTL-1174: delegate defaults null from linearis (linearis cannot read delegate).
+    // The batched GraphQL enrichment in runEligibleQuery overwrites this.
+    delegate: node.delegate?.id ?? node.delegate ?? null,
   };
 }
 
@@ -479,15 +482,42 @@ export function classifyTicketResolution(
 // fetchTicketAssignee — the CTL-781 respect-assignment read: the ticket's
 // current assignee UUID (or null = unassigned), gateway-first so the hot
 // new-work predicate is rate-free, live `linearis issues read` on a miss.
-// Tri-state return so callers can distinguish "known unassigned" from
-// "couldn't read": { known: true, assignee: string|null } | { known: false }.
-// A not-removed descriptor is trusted regardless of age (the assignment gate
-// is rate-free by design; a stale miss is corrected by the future Reconciler).
-export function fetchTicketAssignee(identifier, { exec = defaultExec, gateway } = {}) {
+// CTL-1174: extends the return shape to include `delegate` when a gateway is
+// provided. Gateway hit: { known:true, assignee, delegate } (delegate coerced
+// undefined→null for pre-Phase-1 DBs). Gateway miss: live assignee read +
+// injected fetchDelegate (default fetchTicketDelegate) — a failed delegate read
+// returns { known:false } (HOLD) so an unknown delegate never triggers a
+// claim. Cost bound: fetchDelegate is NOT called when the assignee read fails.
+// When no gateway is provided the old { known, assignee } shape is returned
+// (back-compat for callers that do not wire the gateway, e.g. CLI tools).
+export function fetchTicketAssignee(
+  identifier,
+  { exec = defaultExec, gateway, fetchDelegate = fetchTicketDelegate } = {}
+) {
   if (gateway) {
     const d = gateway.getDescriptor(identifier);
-    if (d && !d.removed) return { known: true, assignee: d.assignee ?? null };
+    if (d && !d.removed) {
+      return {
+        known: true,
+        assignee: d.assignee ?? null,
+        delegate: d.delegate === undefined ? null : d.delegate,
+      };
+    }
+    // Gateway miss: live read for assignee, then delegate.
+    const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
+    if (code !== 0) return { known: false };
+    let assignee;
+    try {
+      const node = JSON.parse(stdout);
+      assignee = node?.assignee?.id ?? null;
+    } catch {
+      return { known: false };
+    }
+    const dr = fetchDelegate(identifier);
+    if (!dr.known) return { known: false };
+    return { known: true, assignee, delegate: dr.delegate ?? null };
   }
+  // No gateway: old behavior — live read only, no delegate (back-compat).
   const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
   if (code !== 0) return { known: false };
   try {
@@ -505,6 +535,18 @@ export function fetchTicketAssignee(identifier, { exec = defaultExec, gateway } 
 export function isAssigneeClaimable(assignee, botUserIds) {
   if (assignee == null) return true;
   return botUserIds instanceof Set && botUserIds.has(assignee);
+}
+
+// isClaimable — CTL-1174 delegate-aware claim predicate. A ticket is ours iff
+// BOTH the assignee and the delegate gates pass. Model: assignee = human
+// responsibility (back off); delegate = bot ownership (ours).
+//   claimable iff (assignee ∈ {null,bot}) AND (delegate ∈ {null,bot})
+// undefined delegate is coerced to null (back-compat: old {known,assignee}
+// shape from no-gateway callers treats absent delegate as "unset" = claimable).
+export function isClaimable(assignee, delegate, botUserIds) {
+  const d = delegate === undefined ? null : delegate;
+  const inBots = (id) => id == null || (botUserIds instanceof Set && botUserIds.has(id));
+  return isAssigneeClaimable(assignee, botUserIds) && inBots(d);
 }
 
 // CTL-1173: raw GraphQL read for Issue.delegate.id — Linear routes an app-user
@@ -567,11 +609,120 @@ export function fetchTicketDelegate(identifier, { runQuery = runDelegateOnce } =
   return { known: true, delegate: nodes[0]?.delegate?.id ?? null };
 }
 
+// CTL-1174: batched delegate fetch for the eligible-set enrichment path.
+// One GraphQL POST per ≤250-ticket chunk, team-scoped via team key + ticket
+// numbers. Mirrors the CTL-784 BATCH_QUERY / defaultBatchExec pattern.
+// Open Question #2: `number: { in: [...] }` is unverified — if unsupported,
+// exec returns null and the fail-safe collapses to an empty Map (AC#2 not met
+// but no crash, no churn). Confirm via the Phase 10 live-API check.
+const DELEGATE_BATCH_QUERY = `query CtlDelegateBatch($team: String!, $nums: [Float!]) {
+  issues(filter: { team: { key: { eq: $team } }, number: { in: $nums } }, first: ${BATCH_CHUNK_SIZE}) {
+    nodes { identifier delegate { id } }
+  }
+}`;
+
+// buildDelegateBatchCurlArgs — same curl argv skeleton as buildBatchCurlArgs;
+// payload uses team + numeric ticket numbers parsed from identifiers.
+export function buildDelegateBatchCurlArgs(team, identifiers, { token = "", ca } = {}) {
+  const nums = (identifiers ?? [])
+    .map((id) => { const m = /^([A-Za-z][A-Za-z0-9]*)-(\d+)$/.exec(id ?? ""); return m ? Number(m[2]) : null; })
+    .filter((n) => n !== null);
+  const payload = JSON.stringify({ query: DELEGATE_BATCH_QUERY, variables: { team, nums } });
+  const caArgs = ca && existsSync(ca) ? ["--cacert", ca] : [];
+  const args = [
+    "-sS",
+    "--max-time",
+    "30",
+    ...caArgs,
+    "-X",
+    "POST",
+    LINEAR_GRAPHQL_ENDPOINT,
+    "-H",
+    `Authorization: ${authHeader(token)}`,
+    "-H",
+    "Content-Type: application/json",
+    "-w",
+    "\n%{http_code}",
+    "--data",
+    "@-",
+  ];
+  return { args, payload };
+}
+
+function runDelegateBatchOnce(team, identifiers) {
+  const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
+  const { args, payload } = buildDelegateBatchCurlArgs(team, identifiers, {
+    token,
+    ca: process.env.NODE_EXTRA_CA_CERTS,
+  });
+  const res = spawnSync("curl", args, { input: payload, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+  if (res.status !== 0) {
+    return { nodes: null, auth: false, ratelimit: false, curlFailed: true };
+  }
+  const out = res.stdout ?? "";
+  const nl = out.lastIndexOf("\n");
+  const httpCode = Number(out.slice(nl + 1).trim());
+  const body = out.slice(0, Math.max(0, nl));
+  if (httpCode === 401) return { nodes: null, auth: true, ratelimit: false, curlFailed: false };
+  if (httpCode === 429) return { nodes: null, auth: false, ratelimit: true, curlFailed: false };
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return { nodes: null, auth: false, ratelimit: false, curlFailed: false };
+  }
+  if (parsed?.errors) {
+    const auth = isBatchAuthError(parsed.errors);
+    const ratelimit = !auth && isBatchRateLimited(parsed.errors);
+    return { nodes: null, auth, ratelimit, curlFailed: false };
+  }
+  return { nodes: parsed?.data?.issues?.nodes ?? [], auth: false, ratelimit: false, curlFailed: false };
+}
+
+// defaultDelegateBatchExec — CTL-1174. Clone of defaultBatchExec for the
+// delegate-batch path: same linearBreaker short-circuit, same auth-retry via
+// linearReminter, same 429 → recordRateLimited. Returns nodes[] or null.
+function defaultDelegateBatchExec(team, identifiers) {
+  if (linearBreaker.isOpen()) return null;
+  let r = runDelegateBatchOnce(team, identifiers);
+  if (r.auth && linearReminter.attempt()) r = runDelegateBatchOnce(team, identifiers);
+  if (r.ratelimit) { linearBreaker.recordRateLimited(); return null; }
+  if (r.nodes == null) return null;
+  linearBreaker.recordSuccess();
+  return r.nodes;
+}
+
+// fetchTicketsDelegateBatch — CTL-1174. Resolve `delegate.id` for a set of
+// identifiers in one or more batched GraphQL POSTs. Returns
+// Map<identifier, string|null>. Absent (not returned) ids are NOT in the Map
+// so callers can distinguish "no delegate found" from "delegate is null".
+// Fail-safe: a null chunk result keeps those ids absent; never throws.
+export function fetchTicketsDelegateBatch(team, identifiers, { exec = defaultDelegateBatchExec } = {}) {
+  const ids = [...new Set((identifiers ?? []).filter(Boolean))];
+  const result = new Map();
+  if (!team || ids.length === 0) return result;
+  for (let i = 0; i < ids.length; i += BATCH_CHUNK_SIZE) {
+    const chunk = ids.slice(i, i + BATCH_CHUNK_SIZE);
+    const nodes = exec(team, chunk);
+    if (!nodes) continue; // fail-safe: these ids stay absent from the Map
+    for (const node of nodes) {
+      if (node?.identifier) {
+        result.set(node.identifier, node.delegate?.id ?? null);
+      }
+    }
+  }
+  return result;
+}
+
 // runEligibleQuery — run the query, parse + normalize, apply the priority
 // floor. A non-zero linearis exit THROWS (never a silent []): a silent empty
 // would let one failed poll flatten a project's eligible set to zero. The
 // caller (Phase 4 reconcile) catches the throw and preserves the prior set.
-export function runEligibleQuery(query, { exec = defaultExec } = {}) {
+// CTL-1174: `delegateExec` is the exec seam for the best-effort delegate
+// batch enrichment. Wrapped in try/catch so a delegate hiccup never blocks
+// the state/priority/relations refresh. An absent key (batch miss) leaves
+// the ticket's delegate field unset; `?? null` in contentKey collapses it.
+export function runEligibleQuery(query, { exec = defaultExec, delegateExec = defaultDelegateBatchExec } = {}) {
   const { code, stdout, stderr } = exec("linearis", buildLinearisArgs(query));
   if (code !== 0) {
     throw new Error(`linearis issues list failed (exit ${code}): ${(stderr || "").trim()}`);
@@ -587,6 +738,23 @@ export function runEligibleQuery(query, { exec = defaultExec } = {}) {
   // (1=Urgent … 4=Low). 0 ("No priority") is always below any floor.
   if (query.priority != null) {
     tickets = tickets.filter((t) => t.priority >= 1 && t.priority <= query.priority);
+  }
+  // CTL-1174: best-effort delegate enrichment from a single batched GraphQL POST.
+  // Never throws — a delegate hiccup must not block the state/priority refresh.
+  if (tickets.length > 0) {
+    try {
+      const dmap = fetchTicketsDelegateBatch(
+        query.team,
+        tickets.map((t) => t.identifier),
+        { exec: delegateExec }
+      );
+      for (const t of tickets) {
+        const d = dmap.get(t.identifier);
+        if (d !== undefined) t.delegate = d;
+      }
+    } catch {
+      /* best-effort: a delegate hiccup never blocks the state/priority/relations refresh */
+    }
   }
   return tickets;
 }

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -1166,49 +1166,40 @@ describe("fetchTicketDelegate (CTL-1173)", () => {
 
 // ── isClaimable (CTL-1174) ────────────────────────────────────────────────────
 
-describe("isClaimable (CTL-1174)", () => {
+describe("isClaimable (CTL-1174 — delegate-ONLY)", () => {
   const BOT = "bot-uuid-ff78d890";
   const HUMAN = "human-uuid-abcd1234";
   const bots = new Set([BOT]);
 
-  test("(null, null, botSet) → true: unassigned + undelegated is always claimable", () => {
-    expect(isClaimable(null, null, bots)).toBe(true);
-  });
-
-  test("(null, null, empty Set) → true: no bots registered, no foreign owner", () => {
-    expect(isClaimable(null, null, new Set())).toBe(true);
-  });
-
-  test("(null, null, undefined) → true: no botUserIds at all", () => {
-    expect(isClaimable(null, null, undefined)).toBe(true);
-  });
-
-  test("(null, BOT, botSet) → true: our bot holds the delegate slot", () => {
+  test("delegated to our orchestrator → claimable, regardless of assignee", () => {
     expect(isClaimable(null, BOT, bots)).toBe(true);
+    expect(isClaimable(HUMAN, BOT, bots)).toBe(true); // assignee irrelevant — the whole point
   });
 
-  test("(null, 'foreign', botSet) → false: foreign delegate blocks the claim (AC#1)", () => {
-    expect(isClaimable(null, "foreign-uuid-xyz", bots)).toBe(false);
-  });
-
-  test("(BOT, BOT, botSet) → true: bot owns both assignee and delegate", () => {
-    expect(isClaimable(BOT, BOT, bots)).toBe(true);
-  });
-
-  test("(HUMAN, null, botSet) → false: human assignee always blocks regardless of delegate", () => {
+  test("UNDELEGATED → NOT claimable (must be delegated-on-Todo first), regardless of assignee", () => {
+    expect(isClaimable(null, null, bots)).toBe(false);
     expect(isClaimable(HUMAN, null, bots)).toBe(false);
+    expect(isClaimable(BOT, null, bots)).toBe(false);
   });
 
-  test("(HUMAN, BOT, botSet) → false: human assignee wins even with our bot delegate", () => {
-    expect(isClaimable(HUMAN, BOT, bots)).toBe(false);
+  test("undefined delegate coerced to null → NOT claimable (no-gateway shape = not yet delegated)", () => {
+    expect(isClaimable(null, undefined, bots)).toBe(false);
+    expect(isClaimable(BOT, undefined, bots)).toBe(false);
   });
 
-  test("(null, undefined, botSet) → true: undefined coerced to null (back-compat no-gateway shape)", () => {
-    expect(isClaimable(null, undefined, bots)).toBe(true);
+  test("delegated to a DIFFERENT actor → not ours", () => {
+    expect(isClaimable(null, "foreign-uuid-xyz", bots)).toBe(false);
+    expect(isClaimable(HUMAN, "foreign-uuid-xyz", bots)).toBe(false);
   });
 
-  test("(BOT, undefined, botSet) → true: undefined coerced to null, bot assignee passes", () => {
-    expect(isClaimable(BOT, undefined, bots)).toBe(true);
+  test("the human ASSIGNEE is irrelevant — verdict depends only on the delegate", () => {
+    expect(isClaimable(HUMAN, BOT, bots)).toBe(isClaimable(null, BOT, bots));
+    expect(isClaimable(HUMAN, null, bots)).toBe(isClaimable(null, null, bots));
+  });
+
+  test("empty/absent botUserIds → false (the call-site wrapper disables the gate; the predicate itself is strict)", () => {
+    expect(isClaimable(null, BOT, new Set())).toBe(false);
+    expect(isClaimable(null, BOT, undefined)).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -17,8 +17,11 @@ import {
   classifyTicketResolution,
   fetchTicketAssignee,
   isAssigneeClaimable,
+  isClaimable,
   buildDelegateCurlArgs,
   fetchTicketDelegate,
+  buildDelegateBatchCurlArgs,
+  fetchTicketsDelegateBatch,
 } from "./linear-query.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 
@@ -1018,35 +1021,40 @@ describe("fetchTicketState — gateway state-freshness boundary (CTL-823)", () =
 describe("fetchTicketAssignee (CTL-781)", () => {
   const BOT = "ff78d890-7906-4c22-b2f5-020bd150c790";
 
-  test("gateway descriptor present + !removed → {known:true, assignee:<uuid>}, zero exec", () => {
+  test("gateway descriptor present + !removed → {known:true, assignee:<uuid>, delegate:null}, zero exec", () => {
     const exec = fakeExec({ code: 0, stdout: "{}" });
+    // CTL-1174: gateway hit now returns delegate from descriptor (undefined→null for pre-Phase-1 DBs)
     const gateway = fakeGateway({ ticket: "CTL-1", assignee: BOT, removed: false, updatedAt: FRESH() });
     const r = fetchTicketAssignee("CTL-1", { exec, gateway });
-    expect(r).toEqual({ known: true, assignee: BOT });
+    expect(r).toEqual({ known: true, assignee: BOT, delegate: null });
     expect(exec.calls.length).toBe(0);
   });
 
-  test("gateway descriptor present with assignee null → {known:true, assignee:null}, zero exec", () => {
+  test("gateway descriptor present with assignee null → {known:true, assignee:null, delegate:null}, zero exec", () => {
     const exec = fakeExec({ code: 0, stdout: "{}" });
     const gateway = fakeGateway({ ticket: "CTL-2", assignee: null, removed: false, updatedAt: FRESH() });
     const r = fetchTicketAssignee("CTL-2", { exec, gateway });
-    expect(r).toEqual({ known: true, assignee: null });
+    expect(r).toEqual({ known: true, assignee: null, delegate: null });
     expect(exec.calls.length).toBe(0);
   });
 
-  test("gateway descriptor removed → falls through to live read", () => {
+  test("gateway descriptor removed → falls through to live read (CTL-1174: injects fetchDelegate)", () => {
     const exec = fakeExec({ code: 0, stdout: JSON.stringify({ assignee: { id: BOT } }) });
     const gateway = fakeGateway({ ticket: "CTL-3", assignee: BOT, removed: true, updatedAt: FRESH() });
-    const r = fetchTicketAssignee("CTL-3", { exec, gateway });
-    expect(r).toEqual({ known: true, assignee: BOT });
+    // CTL-1174: gateway miss now also fetches delegate; inject to avoid real curl
+    const fetchDelegate = () => ({ known: true, delegate: null });
+    const r = fetchTicketAssignee("CTL-3", { exec, gateway, fetchDelegate });
+    expect(r).toEqual({ known: true, assignee: BOT, delegate: null });
     expect(exec.calls.length).toBe(1);
   });
 
-  test("gateway absent/miss (getDescriptor null) → live read parses assignee.id", () => {
+  test("gateway absent/miss (getDescriptor null) → live read parses assignee.id (CTL-1174: injects fetchDelegate)", () => {
     const exec = fakeExec({ code: 0, stdout: JSON.stringify({ assignee: { id: BOT } }) });
     const gateway = fakeGateway(null);
-    const r = fetchTicketAssignee("CTL-4", { exec, gateway });
-    expect(r).toEqual({ known: true, assignee: BOT });
+    // CTL-1174: gateway miss now also fetches delegate; inject to avoid real curl
+    const fetchDelegate = () => ({ known: true, delegate: null });
+    const r = fetchTicketAssignee("CTL-4", { exec, gateway, fetchDelegate });
+    expect(r).toEqual({ known: true, assignee: BOT, delegate: null });
     expect(exec.calls.length).toBe(1);
   });
 
@@ -1153,5 +1161,190 @@ describe("fetchTicketDelegate (CTL-1173)", () => {
   test("empty nodes array → { known:true, delegate:null }", () => {
     const runQuery = () => ({ nodes: [] });
     expect(fetchTicketDelegate("CTL-1", { runQuery })).toEqual({ known: true, delegate: null });
+  });
+});
+
+// ── isClaimable (CTL-1174) ────────────────────────────────────────────────────
+
+describe("isClaimable (CTL-1174)", () => {
+  const BOT = "bot-uuid-ff78d890";
+  const HUMAN = "human-uuid-abcd1234";
+  const bots = new Set([BOT]);
+
+  test("(null, null, botSet) → true: unassigned + undelegated is always claimable", () => {
+    expect(isClaimable(null, null, bots)).toBe(true);
+  });
+
+  test("(null, null, empty Set) → true: no bots registered, no foreign owner", () => {
+    expect(isClaimable(null, null, new Set())).toBe(true);
+  });
+
+  test("(null, null, undefined) → true: no botUserIds at all", () => {
+    expect(isClaimable(null, null, undefined)).toBe(true);
+  });
+
+  test("(null, BOT, botSet) → true: our bot holds the delegate slot", () => {
+    expect(isClaimable(null, BOT, bots)).toBe(true);
+  });
+
+  test("(null, 'foreign', botSet) → false: foreign delegate blocks the claim (AC#1)", () => {
+    expect(isClaimable(null, "foreign-uuid-xyz", bots)).toBe(false);
+  });
+
+  test("(BOT, BOT, botSet) → true: bot owns both assignee and delegate", () => {
+    expect(isClaimable(BOT, BOT, bots)).toBe(true);
+  });
+
+  test("(HUMAN, null, botSet) → false: human assignee always blocks regardless of delegate", () => {
+    expect(isClaimable(HUMAN, null, bots)).toBe(false);
+  });
+
+  test("(HUMAN, BOT, botSet) → false: human assignee wins even with our bot delegate", () => {
+    expect(isClaimable(HUMAN, BOT, bots)).toBe(false);
+  });
+
+  test("(null, undefined, botSet) → true: undefined coerced to null (back-compat no-gateway shape)", () => {
+    expect(isClaimable(null, undefined, bots)).toBe(true);
+  });
+
+  test("(BOT, undefined, botSet) → true: undefined coerced to null, bot assignee passes", () => {
+    expect(isClaimable(BOT, undefined, bots)).toBe(true);
+  });
+});
+
+// ── buildDelegateBatchCurlArgs (CTL-1174) ────────────────────────────────────
+
+describe("buildDelegateBatchCurlArgs (CTL-1174)", () => {
+  test("POSTs to the GraphQL endpoint", () => {
+    const { args } = buildDelegateBatchCurlArgs("CTL", ["CTL-1"], { token: "lin_oauth_x" });
+    expect(args).toContain("https://api.linear.app/graphql");
+    expect(args[args.indexOf("-X") + 1]).toBe("POST");
+  });
+
+  test("reads payload from stdin (--data @-)", () => {
+    const { args } = buildDelegateBatchCurlArgs("CTL", ["CTL-1"], { token: "lin_oauth_x" });
+    expect(args[args.indexOf("--data") + 1]).toBe("@-");
+  });
+
+  test("variables include team and parsed ticket numbers", () => {
+    const { payload } = buildDelegateBatchCurlArgs("CTL", ["CTL-1", "CTL-42"], { token: "lin_oauth_x" });
+    const vars = JSON.parse(payload).variables;
+    expect(vars.team).toBe("CTL");
+    expect(vars.nums).toEqual([1, 42]);
+  });
+
+  test("query projects identifier and delegate fields", () => {
+    const { payload } = buildDelegateBatchCurlArgs("CTL", ["CTL-1"], { token: "lin_oauth_x" });
+    const q = JSON.parse(payload).query;
+    expect(q).toContain("identifier");
+    expect(q).toContain("delegate");
+  });
+
+  test("malformed identifiers are excluded from nums (not NaN)", () => {
+    const { payload } = buildDelegateBatchCurlArgs("CTL", ["CTL-1", "NOTANID"], { token: "tok" });
+    const vars = JSON.parse(payload).variables;
+    expect(vars.nums).toEqual([1]);
+  });
+});
+
+// ── fetchTicketsDelegateBatch (CTL-1174) ─────────────────────────────────────
+
+describe("fetchTicketsDelegateBatch (CTL-1174)", () => {
+  const BOT = "bot-uuid-ff78d890";
+
+  test("empty identifiers → empty Map, exec NOT called", () => {
+    const calls = [];
+    const exec = (...a) => { calls.push(a); return []; };
+    const result = fetchTicketsDelegateBatch("CTL", [], { exec });
+    expect(result.size).toBe(0);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("null team → empty Map, exec NOT called", () => {
+    const calls = [];
+    const exec = (...a) => { calls.push(a); return []; };
+    const result = fetchTicketsDelegateBatch(null, ["CTL-1"], { exec });
+    expect(result.size).toBe(0);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("nodes with delegate id → Map<identifier, delegateId>", () => {
+    const exec = () => [
+      { identifier: "CTL-1", delegate: { id: BOT } },
+      { identifier: "CTL-2", delegate: null },
+    ];
+    const result = fetchTicketsDelegateBatch("CTL", ["CTL-1", "CTL-2"], { exec });
+    expect(result.get("CTL-1")).toBe(BOT);
+    expect(result.get("CTL-2")).toBeNull();
+  });
+
+  test("exec returns null → fail-safe empty Map (no crash)", () => {
+    const exec = () => null;
+    expect(() => fetchTicketsDelegateBatch("CTL", ["CTL-1"], { exec })).not.toThrow();
+    expect(fetchTicketsDelegateBatch("CTL", ["CTL-1"], { exec }).size).toBe(0);
+  });
+
+  test("deduplicates identifiers before passing to exec", () => {
+    const calls = [];
+    const exec = (team, ids) => { calls.push(ids.slice()); return []; };
+    fetchTicketsDelegateBatch("CTL", ["CTL-1", "CTL-1", "CTL-2"], { exec });
+    expect(calls[0]).toHaveLength(2);
+    expect(calls[0]).toContain("CTL-1");
+    expect(calls[0]).toContain("CTL-2");
+  });
+
+  test("absent id from exec result stays absent from Map (not mapped to null)", () => {
+    const exec = () => [{ identifier: "CTL-1", delegate: { id: BOT } }];
+    const result = fetchTicketsDelegateBatch("CTL", ["CTL-1", "CTL-2"], { exec });
+    expect(result.has("CTL-1")).toBe(true);
+    expect(result.has("CTL-2")).toBe(false);
+  });
+});
+
+// ── runEligibleQuery — delegate enrichment (CTL-1174) ─────────────────────────
+
+describe("runEligibleQuery — delegate enrichment (CTL-1174)", () => {
+  const query = { team: "CTL", status: "Todo", project: null, label: null, priority: null };
+  const BOT = "bot-uuid-ff78d890";
+
+  test("normalizeTicket defaults delegate to null when linearis omits it", () => {
+    const exec = fakeExec({ stdout: ticketsJson([{ identifier: "CTL-1", state: { name: "Todo" } }]) });
+    // delegateExec miss → null → delegate stays null
+    const delegateExec = () => null;
+    const tickets = runEligibleQuery(query, { exec, delegateExec });
+    expect(tickets[0].delegate).toBeNull();
+  });
+
+  test("delegate hydrated from batch when id returned", () => {
+    const exec = fakeExec({ stdout: ticketsJson([{ identifier: "CTL-1", state: { name: "Todo" } }]) });
+    const delegateExec = () => [{ identifier: "CTL-1", delegate: { id: BOT } }];
+    const tickets = runEligibleQuery(query, { exec, delegateExec });
+    expect(tickets[0].delegate).toBe(BOT);
+  });
+
+  test("delegate null when batch returns node with null delegate (explicit clear)", () => {
+    const exec = fakeExec({ stdout: ticketsJson([{ identifier: "CTL-1", state: { name: "Todo" } }]) });
+    const delegateExec = () => [{ identifier: "CTL-1", delegate: null }];
+    const tickets = runEligibleQuery(query, { exec, delegateExec });
+    expect(tickets[0].delegate).toBeNull();
+  });
+
+  test("batch failure → delegate stays null, no throw (best-effort fail-safe)", () => {
+    const exec = fakeExec({ stdout: ticketsJson([{ identifier: "CTL-1", state: { name: "Todo" } }]) });
+    const delegateExec = () => { throw new Error("network failure"); };
+    let tickets;
+    expect(() => { tickets = runEligibleQuery(query, { exec, delegateExec }); }).not.toThrow();
+    expect(tickets[0].delegate).toBeNull();
+  });
+
+  test("skips delegate batch entirely when zero tickets survive priority floor", () => {
+    // priority: 4 (Low) tickets filtered by floor 2 → 0 survive → no batch call
+    const exec = fakeExec({
+      stdout: ticketsJson([{ identifier: "CTL-1", state: { name: "Todo" }, priority: 4 }]),
+    });
+    const calls = [];
+    const delegateExec = (...a) => { calls.push(a); return null; };
+    runEligibleQuery({ ...query, priority: 2 }, { exec, delegateExec });
+    expect(calls).toHaveLength(0);
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -1,7 +1,7 @@
 // Unit tests for the execution-core Linear eligible query (CTL-535 Phase 2).
 // Run: cd plugins/dev/scripts/execution-core && bun test linear-query.test.mjs
 
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
 import {
   buildLinearisArgs,
   runEligibleQuery,
@@ -1020,22 +1020,51 @@ describe("fetchTicketState — gateway state-freshness boundary (CTL-823)", () =
 
 describe("fetchTicketAssignee (CTL-781)", () => {
   const BOT = "ff78d890-7906-4c22-b2f5-020bd150c790";
+  const HUMAN = "11111111-1111-1111-1111-111111111111";
 
-  test("gateway descriptor present + !removed → {known:true, assignee:<uuid>, delegate:null}, zero exec", () => {
+  test("gateway hit, delegate cached null → CONFIRMS LIVE via fetchDelegate (latch fix); zero exec", () => {
     const exec = fakeExec({ code: 0, stdout: "{}" });
-    // CTL-1174: gateway hit now returns delegate from descriptor (undefined→null for pre-Phase-1 DBs)
     const gateway = fakeGateway({ ticket: "CTL-1", assignee: BOT, removed: false, updatedAt: FRESH() });
-    const r = fetchTicketAssignee("CTL-1", { exec, gateway });
+    const fetchDelegate = mock(() => ({ known: true, delegate: null }));
+    const r = fetchTicketAssignee("CTL-1", { exec, gateway, fetchDelegate });
     expect(r).toEqual({ known: true, assignee: BOT, delegate: null });
-    expect(exec.calls.length).toBe(0);
+    expect(exec.calls.length).toBe(0); // live confirm uses fetchDelegate (curl), not exec
+    expect(fetchDelegate).toHaveBeenCalledTimes(1); // cached-null is confirmed live (CTL-1174 latch fix)
   });
 
-  test("gateway descriptor present with assignee null → {known:true, assignee:null, delegate:null}, zero exec", () => {
+  test("gateway hit, assignee null + delegate cached null → confirms live; zero exec", () => {
     const exec = fakeExec({ code: 0, stdout: "{}" });
     const gateway = fakeGateway({ ticket: "CTL-2", assignee: null, removed: false, updatedAt: FRESH() });
-    const r = fetchTicketAssignee("CTL-2", { exec, gateway });
+    const fetchDelegate = mock(() => ({ known: true, delegate: null }));
+    const r = fetchTicketAssignee("CTL-2", { exec, gateway, fetchDelegate });
     expect(r).toEqual({ known: true, assignee: null, delegate: null });
     expect(exec.calls.length).toBe(0);
+    expect(fetchDelegate).toHaveBeenCalledTimes(1);
+  });
+
+  test("LATCH FIX: gateway delegate cached null but LIVE delegate is the bot → returns delegate:BOT (gate sees its own write)", () => {
+    const exec = fakeExec({ code: 0, stdout: "{}" });
+    const gateway = fakeGateway({ ticket: "CTL-2b", assignee: HUMAN, removed: false, updatedAt: FRESH() });
+    const fetchDelegate = mock(() => ({ known: true, delegate: BOT })); // delegate landed live after self-delegation
+    const r = fetchTicketAssignee("CTL-2b", { exec, gateway, fetchDelegate });
+    expect(r).toEqual({ known: true, assignee: HUMAN, delegate: BOT });
+  });
+
+  test("LATCH: gateway delegate cached null + live read unreadable → {known:false} (HOLD, never claim on unknown)", () => {
+    const exec = fakeExec({ code: 0, stdout: "{}" });
+    const gateway = fakeGateway({ ticket: "CTL-2c", assignee: null, removed: false, updatedAt: FRESH() });
+    const fetchDelegate = mock(() => ({ known: false }));
+    const r = fetchTicketAssignee("CTL-2c", { exec, gateway, fetchDelegate });
+    expect(r).toEqual({ known: false });
+  });
+
+  test("gateway delegate cached NON-null (BOT) → authoritative, fetchDelegate NOT called (rate-free)", () => {
+    const exec = fakeExec({ code: 0, stdout: "{}" });
+    const gateway = fakeGateway({ ticket: "CTL-2d", assignee: HUMAN, delegate: BOT, removed: false, updatedAt: FRESH() });
+    const fetchDelegate = mock(() => ({ known: true, delegate: null }));
+    const r = fetchTicketAssignee("CTL-2d", { exec, gateway, fetchDelegate });
+    expect(r).toEqual({ known: true, assignee: HUMAN, delegate: BOT });
+    expect(fetchDelegate).not.toHaveBeenCalled(); // non-null cached delegate is authoritative
   });
 
   test("gateway descriptor removed → falls through to live read (CTL-1174: injects fetchDelegate)", () => {

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -41,7 +41,13 @@ import {
 import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
 import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS
 import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry.mjs";
-import { runEligibleQuery, fetchTicketAssignee, isAssigneeClaimable } from "./linear-query.mjs";
+import {
+  runEligibleQuery,
+  fetchTicketAssignee,
+  isAssigneeClaimable,
+  isClaimable,
+  fetchTicketsDelegateBatch,
+} from "./linear-query.mjs";
 import {
   setProjectEligible,
   removeTicket,
@@ -131,6 +137,14 @@ export function parseIssueUpdatedEvent(event) {
     descriptionChanged: payload.descriptionChanged === true, // CTL-749
     actorId: payload.actorId ?? null, // CTL-749
     actorName: payload.actorName ?? null, // CTL-749
+    // CTL-1174: delegate tri-state (KEY-PRESENCE mirrors toEstimate).
+    // string → bot UUID set; null → explicitly cleared; undefined → absent (keep).
+    toDelegate:
+      typeof payload.toDelegateId === "string"
+        ? payload.toDelegateId
+        : "toDelegateId" in payload
+          ? null
+          : undefined,
   };
 }
 
@@ -197,6 +211,9 @@ export function handleIssueUpdatedEvent(
       // CTL-957: forward estimate into the eligible projection when present
       // (undefined = absent from payload = keep stored value).
       if (parsed.toEstimate !== undefined) upd.estimate = parsed.toEstimate;
+      // CTL-1174: forward delegate into the eligible projection when present
+      // (undefined = absent from payload = keep stored value).
+      if (parsed.toDelegate !== undefined) upd.delegate = parsed.toDelegate;
       upsertTicket(query.team, upd);
     } else {
       removeTicket(query.team, parsed.identifier);
@@ -251,7 +268,7 @@ const knownProjects = new Set();
 // `monitor.reconcile.failing.<TEAM>` event onto the unified event log so the
 // orch-monitor dashboard surfaces the silently-starving team, and a recovering
 // poll clears the alert. `appendHealthEvent` is an injectable test seam.
-export function reconcileProject(team, { exec, appendHealthEvent } = {}) {
+export function reconcileProject(team, { exec, delegateExec, appendHealthEvent } = {}) {
   const entry = getProjectConfig(team);
   if (!entry) {
     log.warn({ team }, "reconcile: no registry entry for team — skipping");
@@ -260,7 +277,7 @@ export function reconcileProject(team, { exec, appendHealthEvent } = {}) {
   const query = resolveEligibleQuery(entry);
   let tickets;
   try {
-    tickets = runEligibleQuery(query, { exec });
+    tickets = runEligibleQuery(query, { exec, delegateExec });
   } catch (err) {
     log.error({ team, err: err.message }, "reconcile poll failed — preserving prior eligible set");
     // CTL-867: escalate persistent failures beyond the buried log line.
@@ -295,10 +312,10 @@ export function reconcileProject(team, { exec, appendHealthEvent } = {}) {
 // reconcileAll — full reconcile of every registered team (the missed-webhook
 // backstop). Re-reads registry.json each call so a team added to the registry
 // is picked up and one removed is dropped within one tick.
-export function reconcileAll({ exec, appendHealthEvent } = {}) {
+export function reconcileAll({ exec, delegateExec, appendHealthEvent } = {}) {
   const projects = listProjects();
   const seen = new Set(projects.map((p) => p.team));
-  for (const p of projects) reconcileProject(p.team, { exec, appendHealthEvent });
+  for (const p of projects) reconcileProject(p.team, { exec, delegateExec, appendHealthEvent });
   for (const stale of knownProjects) {
     if (!seen.has(stale)) {
       dropProject(stale);
@@ -593,16 +610,22 @@ function dispatchTriage(
     );
     return false;
   }
-  // CTL-781: respect-assignment gate — a →Triage/→Todo ticket assigned to a
-  // non-bot is a human's; never claim it. Gateway-first, live read on miss;
-  // unknown holds (sweepMissingTriage retries next reconcile). Empty/absent
-  // botUserIds disables the gate (CTL-749 fail-open convention).
+  // CTL-781/CTL-1174: respect-assignment + delegate gate. A →Triage/→Todo
+  // ticket assigned to a human, or delegated to a non-bot, is not ours.
+  // Gateway-first, live read on miss; unknown holds (sweepMissingTriage
+  // retries next reconcile). Empty/absent botUserIds disables the gate
+  // (CTL-749 fail-open convention).
   if (botUserIds instanceof Set && botUserIds.size > 0) {
     const a = fetchAssignee(identifier, { gateway });
-    if (!a.known || !isAssigneeClaimable(a.assignee, botUserIds)) {
+    if (!a.known || !isClaimable(a.assignee, a.delegate, botUserIds)) {
       log.info(
-        { identifier, known: a.known, assignee: a.known ? (a.assignee ?? null) : undefined },
-        "monitor: triage dispatch skipped — respect-assignment (CTL-781)"
+        {
+          identifier,
+          known: a.known,
+          assignee: a.known ? (a.assignee ?? null) : undefined,
+          delegate: a.known ? (a.delegate ?? null) : undefined,
+        },
+        "monitor: triage dispatch skipped — respect-assignment/delegate (CTL-1174)"
       );
       return false;
     }

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -617,15 +617,28 @@ function dispatchTriage(
   // (CTL-749 fail-open convention).
   if (botUserIds instanceof Set && botUserIds.size > 0) {
     const a = fetchAssignee(identifier, { gateway });
-    if (!a.known || !isClaimable(a.assignee, a.delegate, botUserIds)) {
+    if (!a.known) {
+      // Unreadable delegate → HOLD (sweepMissingTriage retries next reconcile).
+      log.info({ identifier, known: false }, "monitor: triage dispatch held — delegate unreadable (CTL-1174)");
+      return false;
+    }
+    if (a.delegate == null) {
+      // CTL-1174 DELEGATE-ON-TODO: an undelegated Todo ticket is claimed by
+      // DELEGATING it to the orchestrator now (the assignee is irrelevant), then
+      // HELD this tick — it dispatches once the delegate lands in the cache
+      // (webhook-projected). This is what gets queued-but-untriaged items moving.
+      const d = applyAssignee({ ticket: identifier, userId: botWriteId });
       log.info(
-        {
-          identifier,
-          known: a.known,
-          assignee: a.known ? (a.assignee ?? null) : undefined,
-          delegate: a.known ? (a.delegate ?? null) : undefined,
-        },
-        "monitor: triage dispatch skipped — respect-assignment/delegate (CTL-1174)"
+        { identifier, applied: d.applied, reason: d.reason },
+        "monitor: delegated to orchestrator — will dispatch once delegate lands (CTL-1174)"
+      );
+      return false;
+    }
+    if (!isClaimable(a.assignee, a.delegate, botUserIds)) {
+      // Delegated to a different actor (another bot/human) → not ours.
+      log.info(
+        { identifier, delegate: a.delegate ?? null },
+        "monitor: triage dispatch skipped — delegated to another actor (CTL-1174)"
       );
       return false;
     }

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -1687,11 +1687,11 @@ describe("dispatchTriage — CTL-781 respect-assignment + self-assign", () => {
     };
   }
 
-  test("→Triage for a human-assigned ticket → NO dispatch, budget not decremented", () => {
+  test("→Triage UNDELEGATED + human-assigned → delegate-then-hold: NO dispatch, applyAssignee CALLED (assignee irrelevant, CTL-1174)", () => {
     enroll("ENG", { status: "Ready" });
     const dispatch = mock(() => ({ code: 0 }));
     const applyAssignee = mock(() => ({ applied: true, reason: null }));
-    const fetchAssignee = () => ({ known: true, assignee: HUMAN });
+    const fetchAssignee = () => ({ known: true, assignee: HUMAN, delegate: null });
     handleStateChangedEvent(toTriageEvent("ENG-H1"), {
       dispatch,
       orchDir,
@@ -1701,17 +1701,18 @@ describe("dispatchTriage — CTL-781 respect-assignment + self-assign", () => {
       applyAssignee,
       triageBudget: { remaining: 5 },
     });
-    expect(dispatch).not.toHaveBeenCalled();
-    expect(applyAssignee).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled(); // held — not yet delegated to us
+    expect(applyAssignee).toHaveBeenCalledTimes(1); // delegate-on-Todo: claim by delegating
+    expect(applyAssignee.mock.calls[0][0]).toMatchObject({ ticket: "ENG-H1", userId: BOT });
   });
 
-  test("→Triage for an unassigned ticket → dispatch fires AND applyAssignee called with botWriteId", () => {
+  test("→Triage UNDELEGATED (unassigned) → delegate-then-hold: NO dispatch this tick, applyAssignee called with botWriteId (CTL-1174)", () => {
     enroll("ENG", { status: "Ready" });
     const dispatch = mock(() => ({ code: 0 }));
     const applyTriageStatus = mock(() => ({ applied: true, verified: true, from_state: "Todo", to_state: "Triage", reason: null }));
     const appendEvent = mock(() => {});
     const applyAssignee = mock(() => ({ applied: true, reason: null }));
-    const fetchAssignee = () => ({ known: true, assignee: null });
+    const fetchAssignee = () => ({ known: true, assignee: null, delegate: null });
     handleStateChangedEvent(toTriageEvent("ENG-N1"), {
       dispatch,
       orchDir,
@@ -1723,15 +1724,15 @@ describe("dispatchTriage — CTL-781 respect-assignment + self-assign", () => {
       applyAssignee,
       triageBudget: { remaining: 5 },
     });
-    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).not.toHaveBeenCalled();
     expect(applyAssignee).toHaveBeenCalledTimes(1);
     expect(applyAssignee.mock.calls[0][0]).toMatchObject({ ticket: "ENG-N1", userId: BOT });
   });
 
-  test("→Triage for a bot-assigned ticket → dispatch fires (re-claim of own ticket OK)", () => {
+  test("→Triage DELEGATED to our orchestrator → dispatch fires (even if assignee is a human, CTL-1174)", () => {
     enroll("ENG", { status: "Ready" });
     const dispatch = mock(() => ({ code: 0 }));
-    const fetchAssignee = () => ({ known: true, assignee: BOT });
+    const fetchAssignee = () => ({ known: true, assignee: HUMAN, delegate: BOT });
     handleStateChangedEvent(toTriageEvent("ENG-B1"), {
       dispatch,
       orchDir,
@@ -1770,13 +1771,13 @@ describe("dispatchTriage — CTL-781 respect-assignment + self-assign", () => {
     expect(fetchAssignee).not.toHaveBeenCalled();
   });
 
-  test("applyAssignee absent/failing → dispatch still completes, applyTriageStatus + appendEvent unaffected", () => {
+  test("a DELEGATED ticket dispatches; applyTriageStatus + appendEvent fire (delegate-on-Todo already done, CTL-1174)", () => {
     enroll("ENG", { status: "Ready" });
     const dispatch = mock(() => ({ code: 0 }));
     const applyTriageStatus = mock(() => ({ applied: true, verified: true, from_state: "Todo", to_state: "Triage", reason: null }));
     const appendEvent = mock(() => {});
     const applyAssignee = mock(() => ({ applied: false, reason: "transient" }));
-    const fetchAssignee = () => ({ known: true, assignee: null });
+    const fetchAssignee = () => ({ known: true, assignee: HUMAN, delegate: BOT });
     handleStateChangedEvent(toTriageEvent("ENG-FA1"), {
       dispatch,
       orchDir,
@@ -1793,11 +1794,11 @@ describe("dispatchTriage — CTL-781 respect-assignment + self-assign", () => {
     expect(appendEvent).toHaveBeenCalledTimes(1);
   });
 
-  test("botWriteId absent → applyAssignee still called with userId:undefined (loud-no-op, CTL-1011)", () => {
+  test("botWriteId absent on an UNDELEGATED ticket → delegate-on-Todo calls applyAssignee userId:undefined (loud-no-op, CTL-1011), holds", () => {
     enroll("ENG", { status: "Ready" });
     const dispatch = mock(() => ({ code: 0 }));
     const applyAssignee = mock(() => ({ applied: false, reason: "invalid-user" }));
-    const fetchAssignee = () => ({ known: true, assignee: null });
+    const fetchAssignee = () => ({ known: true, assignee: null, delegate: null });
     handleStateChangedEvent(toTriageEvent("ENG-NU1"), {
       dispatch,
       orchDir,
@@ -1807,7 +1808,7 @@ describe("dispatchTriage — CTL-781 respect-assignment + self-assign", () => {
       applyAssignee,
       triageBudget: { remaining: 5 },
     });
-    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).not.toHaveBeenCalled(); // held — undelegated
     expect(applyAssignee).toHaveBeenCalledTimes(1);
     expect(applyAssignee.mock.calls[0][0]).toMatchObject({ ticket: "ENG-NU1", userId: undefined });
   });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -69,6 +69,7 @@ import {
   classifyTicketResolution,
   fetchTicketAssignee,
   isAssigneeClaimable,
+  isClaimable,
   readTicketLabels,
 } from "./linear-query.mjs";
 import { gatewayLabelsHit } from "./gateway-read.mjs"; // CTL-1079
@@ -4740,24 +4741,25 @@ export function schedulerTick(
     // CTL-671: circuit breaker — stop re-dispatching a new-work ticket that has
     // failed its entry-phase dispatch THRESHOLD times in a row.
     if (maybeTripCircuitBreaker(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE)) continue;
-    // CTL-781: respect-assignment gate — claim only assignee ∈ {null, bot}.
-    // Gateway-first (rate-free); live read only on a miss. An unreadable
-    // assignee HOLDS the candidate this tick (fail-safe) — it is not a dispatch
-    // failure, so no cooldown marker and no failure event. Empty/absent
-    // botUserIds disables the gate (CTL-749 fail-open convention).
+    // CTL-781/CTL-1174: respect-assignment + delegate gate.
+    // Claim only when assignee ∈ {null,bot} AND delegate ∈ {null,bot}.
+    // Gateway-first (rate-free); live read on a miss. An unreadable
+    // assignee or delegate HOLDS the candidate this tick (fail-safe) — no
+    // cooldown marker, no failure event. Empty/absent botUserIds disables
+    // the gate (CTL-749 fail-open convention).
     if (botUserIds instanceof Set && botUserIds.size > 0) {
       const a = fetchAssignee(t.identifier, { gateway, exec });
       if (!a.known) {
         log.debug(
           { ticket: t.identifier },
-          "ctl-781: assignee unreadable — holding candidate this tick"
+          "ctl-781: assignee/delegate unreadable — holding candidate this tick"
         );
         continue;
       }
-      if (!isAssigneeClaimable(a.assignee, botUserIds)) {
+      if (!isClaimable(a.assignee, a.delegate, botUserIds)) {
         log.debug(
-          { ticket: t.identifier, assignee: a.assignee },
-          "ctl-781: candidate assigned to a non-bot — skipping (respect-assignment)"
+          { ticket: t.identifier, assignee: a.assignee, delegate: a.delegate },
+          "ctl-1174: candidate not claimable (assignee/delegate respect-gate) — skipping"
         );
         continue;
       }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4752,14 +4752,28 @@ export function schedulerTick(
       if (!a.known) {
         log.debug(
           { ticket: t.identifier },
-          "ctl-781: assignee/delegate unreadable — holding candidate this tick"
+          "ctl-1174: delegate unreadable — holding candidate this tick"
+        );
+        continue;
+      }
+      if (a.delegate == null) {
+        // CTL-1174 delegate-on-Todo: claim by delegating to the orchestrator now
+        // (assignee is irrelevant); HOLD this tick — dispatches once the
+        // delegate lands in the cache (webhook-projected). Best-effort.
+        safeWrite(() => writeStatus.applyAssignee?.({ ticket: t.identifier, userId: botWriteId }), {
+          ticket: t.identifier,
+          phase: "delegate-on-todo",
+        });
+        log.debug(
+          { ticket: t.identifier },
+          "ctl-1174: undelegated — delegated to orchestrator, holding this tick"
         );
         continue;
       }
       if (!isClaimable(a.assignee, a.delegate, botUserIds)) {
         log.debug(
-          { ticket: t.identifier, assignee: a.assignee, delegate: a.delegate },
-          "ctl-1174: candidate not claimable (assignee/delegate respect-gate) — skipping"
+          { ticket: t.identifier, delegate: a.delegate },
+          "ctl-1174: delegated to another actor — skipping"
         );
         continue;
       }

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -8178,8 +8178,17 @@ describe("schedulerTick — CTL-781 respect-assignment + self-assign", () => {
     };
   }
 
-  function gatewayStub(assigneeByTicket) {
-    return { getDescriptor: (id) => ({ assignee: assigneeByTicket[id] ?? null, removed: false }) };
+  function gatewayStub(byTicket) {
+    // bare value = assignee (back-compat); object { assignee, delegate } sets both.
+    return {
+      getDescriptor: (id) => {
+        const v = byTicket[id];
+        if (v && typeof v === "object") {
+          return { assignee: v.assignee ?? null, delegate: v.delegate ?? null, removed: false };
+        }
+        return { assignee: v ?? null, delegate: null, removed: false };
+      },
+    };
   }
 
   beforeEach(() => {
@@ -8201,7 +8210,7 @@ describe("schedulerTick — CTL-781 respect-assignment + self-assign", () => {
     expect(existsSync(join(orchDir, ".dispatch-cooldowns", "CTL-H1", "research"))).toBe(false);
   });
 
-  test("null-assignee candidate dispatches AND applyAssignee is called with botWriteId after verify", () => {
+  test("UNDELEGATED candidate → delegate-then-hold: NO dispatch, applyAssignee (delegate-on-Todo) called with botWriteId (CTL-1174)", () => {
     const dispatch = fakeDispatch();
     const assigneeCalls = [];
     const writeStatus = {
@@ -8213,7 +8222,7 @@ describe("schedulerTick — CTL-781 respect-assignment + self-assign", () => {
         return { applied: true, reason: null };
       },
     };
-    const gateway = gatewayStub({ "CTL-N1": null });
+    const gateway = gatewayStub({ "CTL-N1": null }); // assignee=null, delegate=null → undelegated
     schedulerTick(orchDir, {
       readEligible: () => [candidateTicket("CTL-N1")],
       dispatch,
@@ -8223,16 +8232,16 @@ describe("schedulerTick — CTL-781 respect-assignment + self-assign", () => {
       botUserIds: new Set([BOT]),
       botWriteId: BOT,
       gateway,
-      hasTriageArtifact: () => true, // CTL-1150: bypass triage gate, subject is applyAssignee
+      hasTriageArtifact: () => true,
     });
-    expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-N1"]);
+    expect(dispatch.calls).toHaveLength(0); // held — not yet delegated to us
     expect(assigneeCalls).toHaveLength(1);
     expect(assigneeCalls[0]).toMatchObject({ ticket: "CTL-N1", userId: BOT });
   });
 
-  test("bot-assigned candidate (assignee in botUserIds) dispatches normally", () => {
+  test("candidate DELEGATED to our orchestrator dispatches normally (assignee irrelevant, CTL-1174)", () => {
     const dispatch = fakeDispatch();
-    const gateway = gatewayStub({ "CTL-B1": BOT });
+    const gateway = gatewayStub({ "CTL-B1": { assignee: HUMAN, delegate: BOT } });
     schedulerTick(orchDir, {
       readEligible: () => [candidateTicket("CTL-B1")],
       dispatch,
@@ -8240,7 +8249,7 @@ describe("schedulerTick — CTL-781 respect-assignment + self-assign", () => {
       liveBackgroundCount: () => 0,
       botUserIds: new Set([BOT]),
       gateway,
-      hasTriageArtifact: () => true, // CTL-1150: bypass triage gate, subject is bot-assigned dispatch
+      hasTriageArtifact: () => true,
     });
     expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-B1"]);
   });
@@ -8322,7 +8331,7 @@ describe("schedulerTick — CTL-781 respect-assignment + self-assign", () => {
     expect(fetchAssigneeCalls).toHaveLength(0);
   });
 
-  test("botWriteId absent → dispatch proceeds, applyAssignee called with userId:undefined (loud-no-op, CTL-1011)", () => {
+  test("botWriteId absent on UNDELEGATED candidate → delegate-on-Todo calls applyAssignee userId:undefined (loud-no-op), holds (CTL-1174)", () => {
     const dispatch = fakeDispatch();
     const assigneeCalls = [];
     const writeStatus = {
@@ -8343,16 +8352,16 @@ describe("schedulerTick — CTL-781 respect-assignment + self-assign", () => {
       liveBackgroundCount: () => 0,
       botUserIds: new Set([BOT]),
       gateway,
-      hasTriageArtifact: () => true, // CTL-1150: bypass triage gate, subject is botWriteId-absent
+      hasTriageArtifact: () => true,
     });
-    expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-WI1"]);
-    // CTL-1011: applyAssignee is now always invoked; the deduped invalid-user
+    expect(dispatch.calls).toHaveLength(0); // held — undelegated
+    // delegate-on-Todo still invokes applyAssignee; the deduped invalid-user
     // branch handles the null/undefined botWriteId instead of silently skipping.
     expect(assigneeCalls).toHaveLength(1);
     expect(assigneeCalls[0]).toMatchObject({ ticket: "CTL-WI1", userId: undefined });
   });
 
-  test("applyAssignee failure (applied:false) does not fail the dispatch — ticket still advances", () => {
+  test("a DELEGATED candidate dispatches even if the post-dispatch self-assign fails (CTL-1174)", () => {
     const dispatch = fakeDispatch();
     const writeStatus = {
       applyPhaseStatus: () => ({ applied: true, reason: null }),
@@ -8360,7 +8369,7 @@ describe("schedulerTick — CTL-781 respect-assignment + self-assign", () => {
       applyLabel: () => {},
       applyAssignee: () => ({ applied: false, reason: "transient" }),
     };
-    const gateway = gatewayStub({ "CTL-AF1": null });
+    const gateway = gatewayStub({ "CTL-AF1": { delegate: BOT } });
     const r = schedulerTick(orchDir, {
       readEligible: () => [candidateTicket("CTL-AF1")],
       dispatch,

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
@@ -777,3 +777,100 @@ describe("parseLinearWebhookEvent — issueCommentMention", () => {
     expect(result.kind).toBe("ignored");
   });
 });
+
+// ── CTL-1174: toDelegateId extraction + delegate_changed topic ────────────────
+
+describe("parseLinearWebhookEvent — Issue toDelegateId (CTL-1174)", () => {
+  const BOT = "bot-uuid-ff78d890";
+
+  it("extracts toDelegateId from data.delegate.id when present", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        updatedFrom: { delegateId: "old-delegate" },
+        data: {
+          id: "i1",
+          identifier: "CTL-210",
+          team: { key: "CTL" },
+          delegate: { id: BOT },
+        },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.toDelegateId).toBe(BOT);
+  });
+
+  it("toDelegateId is undefined when data.delegate key is absent (KEY-PRESENCE: keep stored value)", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({ updatedFrom: { stateId: "old-state" } })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.toDelegateId).toBeUndefined();
+  });
+
+  it("toDelegateId is null when data.delegate key is present but null (explicit clear)", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        updatedFrom: { delegateId: "old-delegate" },
+        data: {
+          id: "i1",
+          identifier: "CTL-210",
+          team: { key: "CTL" },
+          delegate: null,
+        },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.toDelegateId).toBeNull();
+  });
+
+  it("updatedFrom.delegateId → topic 'linear.issue.delegate_changed'", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        updatedFrom: { delegateId: "old-delegate" },
+        data: { id: "i1", identifier: "CTL-210", team: { key: "CTL" }, delegate: { id: BOT } },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.topic).toBe("linear.issue.delegate_changed");
+  });
+
+  it("delegate_changed is lower priority than assignee_changed", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        updatedFrom: { assigneeId: "old-user", delegateId: "old-delegate" },
+        data: {
+          id: "i1",
+          identifier: "CTL-210",
+          team: { key: "CTL" },
+          assignee: { id: "new-user", name: "Alice" },
+          delegate: { id: BOT },
+        },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.topic).toBe("linear.issue.assignee_changed");
+  });
+
+  it("assignee-only webhook leaves toDelegateId undefined (real-world safety: no fabricated clear)", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        updatedFrom: { assigneeId: "old-user" },
+        data: {
+          id: "i1",
+          identifier: "CTL-210",
+          team: { key: "CTL" },
+          assignee: { id: "new-user", name: "Alice" },
+        },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.toDelegateId).toBeUndefined();
+    expect(ev.topic).toBe("linear.issue.assignee_changed");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
@@ -1157,3 +1157,61 @@ describe("buildLinearEventLogEnvelope — agent_session and mention", () => {
     expect(env).toBeNull();
   });
 });
+
+// ── CTL-1174: toDelegateId forwarded in body.payload ─────────────────────────
+
+describe("buildLinearEventLogEnvelope — toDelegateId (CTL-1174)", () => {
+  const BOT = "bot-uuid-ff78d890";
+
+  function delegateIssueEvent(
+    toDelegateId: string | null | undefined
+  ): Parameters<typeof buildLinearEventLogEnvelope>[0] {
+    return {
+      kind: "issue" as const,
+      action: "update" as const,
+      topic: "linear.issue.delegate_changed",
+      ticket: "CTL-1174",
+      teamKey: "CTL",
+      data: {},
+      updatedFromKeys: ["delegateId"],
+      issueId: null,
+      actorId: null,
+      actorName: null,
+      toState: null,
+      toPriority: null,
+      toAssigneeId: null,
+      toAssigneeName: null,
+      toLabels: null,
+      toProject: null,
+      toProjectId: null,
+      previousFromValues: {},
+      description: null,
+      descriptionChanged: false,
+      toDelegateId,
+    };
+  }
+
+  it("toDelegateId: BOT → forwarded as non-null in body.payload", () => {
+    const env = buildLinearEventLogEnvelope(delegateIssueEvent(BOT), TS);
+    expect(env).not.toBeNull();
+    const payload = env!.body.payload as Record<string, unknown>;
+    expect(payload.toDelegateId).toBe(BOT);
+  });
+
+  it("toDelegateId: null → serializes as null in body.payload (explicit clear)", () => {
+    const env = buildLinearEventLogEnvelope(delegateIssueEvent(null), TS);
+    expect(env).not.toBeNull();
+    const payload = env!.body.payload as Record<string, unknown>;
+    expect(payload.toDelegateId).toBeNull();
+    expect("toDelegateId" in payload).toBe(true);
+  });
+
+  it("toDelegateId: undefined → key DROPPED from body.payload JSON (key-presence: fold keeps stored value)", () => {
+    const env = buildLinearEventLogEnvelope(delegateIssueEvent(undefined), TS);
+    expect(env).not.toBeNull();
+    // undefined serializes as absent in JSON — check via round-trip, as the broker fold
+    // reads from the event log (JSON), not the in-memory JS object.
+    const jsonPayload = JSON.parse(JSON.stringify(env!.body.payload)) as Record<string, unknown>;
+    expect("toDelegateId" in jsonPayload).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/ticket-detail-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ticket-detail-reader.test.ts
@@ -32,6 +32,7 @@ function descriptor(partial: Partial<TicketDescriptor>): TicketDescriptor {
     fencePhase: partial.fencePhase ?? null,
     claimedAt: partial.claimedAt ?? null,
     heldSince: partial.heldSince ?? null,
+    delegate: partial.delegate ?? null, // CTL-1174
     updatedAt: partial.updatedAt ?? "2026-06-08T12:00:00.000Z",
   };
 }

--- a/plugins/dev/scripts/orch-monitor/__tests__/ticket-search-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ticket-search-reader.test.ts
@@ -30,6 +30,7 @@ function descriptor(partial: Partial<TicketDescriptor>): TicketDescriptor {
     fencePhase: null,
     claimedAt: null,
     heldSince: null,
+    delegate: null, // CTL-1174
     updatedAt: "2026-06-08T12:00:00.000Z",
   };
 }

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
@@ -81,6 +81,15 @@ export type LinearWebhookEvent =
        * in the webhook payload — KEY-PRESENCE: absent → keep stored value. CTL-957.
        */
       toEstimate?: number | null;
+      /**
+       * CTL-1174: Current delegate UUID from data.delegate.id. undefined when the
+       * `delegate` key is absent from the payload (KEY-PRESENCE: absent → keep);
+       * null when the key is present but cleared (explicit un-delegate). DEFENSIVE:
+       * Linear does NOT reliably carry delegate in Issue webhooks (routes to
+       * AgentSessionEvent) — this field is dormant scaffolding that activates if
+       * Linear ever surfaces it.
+       */
+      toDelegateId?: string | null;
     }
   | {
       kind: "comment";
@@ -161,7 +170,10 @@ function actionLabel(value: unknown): string {
  * Pick the topic for an Issue event based on action and (for updates) the
  * fields changed in updatedFrom.
  *
- * Priority for updates: state > priority > assignee > generic.
+ * Priority for updates: state > priority > assignee > delegate > generic.
+ * CTL-1174: delegate_changed is lower priority than assignee. The exact
+ * updatedFrom key Linear uses for delegate is unverified ("delegateId" is the
+ * likely key by analogy with "assigneeId"); we check both spellings defensively.
  */
 function issueTopic(action: "create" | "update" | "remove", updatedFromKeys: string[]): string {
   if (action === "create") return "linear.issue.created";
@@ -169,6 +181,9 @@ function issueTopic(action: "create" | "update" | "remove", updatedFromKeys: str
   if (updatedFromKeys.includes("stateId")) return "linear.issue.state_changed";
   if (updatedFromKeys.includes("priority")) return "linear.issue.priority_changed";
   if (updatedFromKeys.includes("assigneeId")) return "linear.issue.assignee_changed";
+  if (updatedFromKeys.includes("delegateId") || updatedFromKeys.includes("delegate")) {
+    return "linear.issue.delegate_changed";
+  }
   return "linear.issue.updated";
 }
 
@@ -214,6 +229,14 @@ function parseIssue(payload: Record<string, unknown>): LinearWebhookEvent {
   const toEstimate = "estimate" in data
     ? (typeof data.estimate === "number" ? data.estimate : null)
     : undefined; // absent → keep stored value
+  // CTL-1174: delegate UUID — KEY-PRESENCE so the broker fold can distinguish
+  // "payload said nothing about delegate" (absent key → keep) from "delegate
+  // was explicitly cleared" (key present, value null). DEFENSIVE: Linear does
+  // NOT reliably emit delegate in Issue webhooks; this is dormant scaffolding.
+  const delegateObj = isObject(data.delegate) ? data.delegate : null;
+  const toDelegateId = "delegate" in data
+    ? (delegateObj !== null ? getOptStr(delegateObj, "id") : null)
+    : undefined; // absent → key-presence KEEP
   return {
     kind: "issue",
     action,
@@ -236,6 +259,7 @@ function parseIssue(payload: Record<string, unknown>): LinearWebhookEvent {
     description,
     descriptionChanged,
     toEstimate,
+    toDelegateId,
   };
 }
 

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
@@ -158,6 +158,7 @@ export function buildLinearEventLogEnvelope(
           description: event.description,           // CTL-749
           descriptionChanged: event.descriptionChanged, // CTL-749
           toEstimate: event.toEstimate,            // CTL-957
+          toDelegateId: event.toDelegateId,        // CTL-1174 (undefined drops key from JSON)
         },
       });
     }


### PR DESCRIPTION
## Root cause: the board is wedged on assignee-gating

5 open slots, a waiting Todo queue, **zero dispatch**. The daemon gates dispatch on the human **assignee** (CTL-781 "respect-assignment"). A Linear bot can **never be an assignee** — app-user UUIDs route to `Issue.delegate`; assigning one returns HTTP 400 *"App user not valid"*. So the assignee field only ever holds a human, and gating on it makes **every Todo ticket the operator touches permanently un-claimable**.

This was a 3-ticket program: CTL-781 (assignee stopgap, merged) → CTL-1173 (delegate write, merged) → **CTL-1174 (delegate gate, #2094 — never merged, sat in Validate)**. And CTL-1174 as designed **AND-composed** `assignee && delegate`, which still wouldn't unwedge it.

## The fix (delegate-ONLY, per operator intent: "the assignee shouldn't matter anymore")

- **`isClaimable` → delegate-only**: claimable iff `delegate ∈ bot-ids`. An **undelegated** ticket is *not* claimable. Assignee arg retained for signature-compat, unused.
- **delegate-on-Todo** (both gate sites): an undelegated candidate is claimed by **delegating it to the orchestrator now** (`applyAssignee` → routes the app-user UUID to `Issue.delegate`, verified by read-back), then **held** this tick; it dispatches next reconcile once the delegate lands in the cache. Delegated-to-us → dispatch; delegated-elsewhere → skip; unreadable → hold.

Builds on `origin/CTL-1174`'s cache projection + gateway-aware delegate fetch (rate-safe: the gate reads delegate **cache-first**, never per-tick curl).

## Verification

- **Live-verified the delegate-write works on mini**: all dispatched tickets carry `delegate=ff78d890-…`, **zero OAuth scope failures**. The #1 risk (flaky app-actor OAuth mint) is cleared.
- Tests: **linear-query 136 / monitor 127 / scheduler 501 / eligible-set 27 / broker 19 — all green.** Gate tests rewritten to the delegate model (assignee irrelevant; undelegated→delegate-then-hold; delegated→dispatch; delegated-elsewhere→skip).

## ⚠️ DEPLOYMENT IS GATED — do NOT just merge + restart

Two coupled preconditions (I did **not** do these autonomously):

1. **Clean the board first.** **17 tickets are secretly-Done** (merged PRs, cache still non-terminal: CTL-1108, CTL-1214, CTL-1004/1005/1056/1165/1171/1205/1222/1272/1277/1278, CTL-644/646/789/820, OTL-18). Once the gate flips + delegate-on-Todo runs, the daemon would **delegate and re-dispatch these already-merged tickets**. Move them to Done before/with the flip.
2. **exec-core restart is operator-gated.** The gate lives in `monitor.mjs` (safe restart) **and** `scheduler.mjs` (exec-core). Loading it needs an exec-core restart.

**Runbook (operator):** (a) mark the 17 secretly-Done → Done + clear their stale signals; (b) merge this PR; (c) broker auto-pull lands the source; (d) restart exec-core on mini (then mini-2, staggered — boot-reconcile burst can trip the per-host Linear breaker); (e) watch: undelegated Todo items get `delegate=orchestrator` then dispatch; the cache `delegate` column populates from webhooks. **Rollback**: revert to the assignee gate (`isAssigneeClaimable`) + restart. Fail-open: empty `botUserIds` disables the gate entirely.

**Cache warmup note**: existing `ticket_state` rows lack `delegate` until re-reconciled/re-webhooked; during warmup the gate re-delegates (idempotent) until the cache catches up.

Closes CTL-1174. Supersedes #2094.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
