### PR TITLE
feat(dev): CTL-1292 — catalyst-join provisions a member node to fully-operational state

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-join.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-join.test.sh
@@ -710,6 +710,42 @@ run "T2.11 single-host node: clone-OK + push-fail warns and proceeds (CTL-1293)"
     CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
     bash '$JOIN' --bundle '$SINGLEHOST_WH_BUNDLE' >/dev/null 2>&1"
 
+# T2.12: (CTL-1231) provision ~/.claude/settings.json — synthesize the per-host
+# OTEL_RESOURCE_ATTRIBUTES (NEVER the seed's host.name), carry the allow-listed
+# shared slice, and write the OTLP endpoint into the daemon env file.
+CLAUDE_SETTINGS_BUNDLE="${SCRATCH}/claude-settings.json"
+cat > "$CLAUDE_SETTINGS_BUNDLE" <<'BEOF'
+{
+  "layer1Identity": {"projectKey": "CTL", "teamKey": "T1", "stateMap": {}},
+  "botCreds": {"orchestrator": "tok_orch", "worker": "tok_worker"},
+  "hostsRoster": ["test-node"],
+  "livenessAnchorIssue": "CTL-1",
+  "repoUrl": "https://github.com/example/repo",
+  "pluginSourceUrl": "https://github.com/example/plugins",
+  "otlpEndpointHint": "http://otel.test:4317",
+  "claudeSettings": {"model": "claude-opus-4-8", "env": {"CLAUDE_CODE_ENABLE_TELEMETRY": "1"}}
+}
+BEOF
+
+run "T2.12 provisions settings.json w/ per-host OTEL attrs + daemon OTLP endpoint (CTL-1231)" bash -c "
+  h='${SCRATCH}/h212'
+  env -i HOME=\"\$h\" CATALYST_DIR='${SCRATCH}/c212' CATALYST_HOST_NAME='test-node' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$CLAUDE_SETTINGS_BUNDLE' >/dev/null 2>&1
+  s=\"\$h/.claude/settings.json\"
+  jq -e '.env.OTEL_RESOURCE_ATTRIBUTES == \"host.name=test-node\"' \"\$s\" >/dev/null &&
+  jq -e '.env.OTEL_EXPORTER_OTLP_ENDPOINT == \"http://otel.test:4317\"' \"\$s\" >/dev/null &&
+  jq -e '.model == \"claude-opus-4-8\"' \"\$s\" >/dev/null &&
+  jq -e '.env.CLAUDE_CODE_ENABLE_TELEMETRY == \"1\"' \"\$s\" >/dev/null &&
+  grep -q '^OTEL_EXPORTER_OTLP_ENDPOINT=http://otel.test:4317\$' \"\$h/.config/catalyst/execution-core.env\""
+
 # ── Phase 3: Provisioner orchestration ────────────────────────────────────────
 
 echo ""

--- a/plugins/dev/scripts/__tests__/catalyst-join.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-join.test.sh
@@ -671,6 +671,45 @@ run "T2.9 single-host roster OMITS webhook block — double-dispatch guard (CTL-
   # monitor block must be absent (or at least carry no smeeChannel)
   ! jq -e '.catalyst.monitor.github.smeeChannel // empty | length > 0' \"\$cfg\" >/dev/null"
 
+# T2.10 / T2.11: (CTL-1293) provision-thoughts that CLONES OK but fails push-auth
+# is FATAL on a multiHost member (roster>1 owns work → must sync thoughts to
+# peers) but warn-and-proceed on a single-host / Stage-0 SHADOW node.
+PT_CLONE_PUSHFAIL_STUB="${STUBS2}/stub-provision-thoughts-pushfail.sh"
+cat > "$PT_CLONE_PUSHFAIL_STUB" <<'EOF'
+#!/usr/bin/env bash
+# Simulate the read-only strand: primary clone present + valid HEAD, exit non-zero.
+prim="${CATALYST_DIR}/hlt/coalesce-labs/thoughts"
+mkdir -p "$prim"
+git -C "$prim" init -q
+git -C "$prim" -c user.email=t@example.com -c user.name=t commit -q --allow-empty -m init
+exit 1
+EOF
+chmod +x "$PT_CLONE_PUSHFAIL_STUB"
+
+run "T2.10 multiHost member: clone-OK + push-fail is FATAL (CTL-1293)" bash -c "
+  env -i HOME='${SCRATCH}/h210' CATALYST_DIR='${SCRATCH}/c210' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='$PT_CLONE_PUSHFAIL_STUB' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$MULTIHOST_WH_BUNDLE' >/dev/null 2>&1; [[ \$? -ne 0 ]]"
+
+run "T2.11 single-host node: clone-OK + push-fail warns and proceeds (CTL-1293)" bash -c "
+  env -i HOME='${SCRATCH}/h211' CATALYST_DIR='${SCRATCH}/c211' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='$PT_CLONE_PUSHFAIL_STUB' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$SINGLEHOST_WH_BUNDLE' >/dev/null 2>&1"
+
 # ── Phase 3: Provisioner orchestration ────────────────────────────────────────
 
 echo ""

--- a/plugins/dev/scripts/__tests__/catalyst-join.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-join.test.sh
@@ -603,6 +603,74 @@ run "T2.7c null IDENTITY keys (projectKey/teamKey/stateMap=null) rejected (no fa
     CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
     bash '$JOIN' --bundle '$NULL_IDENTITY_BUNDLE' >/dev/null 2>&1; [[ \$? -ne 0 ]]"
 
+# T2.8 / T2.9: (CTL-1284) webhook ingestion is provisioned ONLY on a multiHost
+# member (roster length > 1). On a single-host roster the monitor block must NOT
+# be written — at length 1 HRW is a no-op and claimDispatch is skipped, so
+# ingestion would double-dispatch. The bundle carries non-secret monitorWebhooks.
+MULTIHOST_WH_BUNDLE="${SCRATCH}/multihost-wh.json"
+cat > "$MULTIHOST_WH_BUNDLE" <<'BEOF'
+{
+  "layer1Identity": {"projectKey": "CTL", "teamKey": "T1", "stateMap": {}},
+  "botCreds": {"orchestrator": "tok_orch", "worker": "tok_worker"},
+  "hostsRoster": ["mini", "mini-2"],
+  "livenessAnchorIssue": "CTL-1",
+  "repoUrl": "https://github.com/example/repo",
+  "pluginSourceUrl": "https://github.com/example/plugins",
+  "monitorWebhooks": {
+    "github": {"smeeChannel": "https://smee.io/GH"},
+    "linear": {"smeeChannel": "https://smee.io/LIN", "ctl": {"webhookId": "wh-ctl"}}
+  }
+}
+BEOF
+
+SINGLEHOST_WH_BUNDLE="${SCRATCH}/singlehost-wh.json"
+cat > "$SINGLEHOST_WH_BUNDLE" <<'BEOF'
+{
+  "layer1Identity": {"projectKey": "CTL", "teamKey": "T1", "stateMap": {}},
+  "botCreds": {"orchestrator": "tok_orch", "worker": "tok_worker"},
+  "hostsRoster": ["mini"],
+  "livenessAnchorIssue": "CTL-1",
+  "repoUrl": "https://github.com/example/repo",
+  "pluginSourceUrl": "https://github.com/example/plugins",
+  "monitorWebhooks": {
+    "github": {"smeeChannel": "https://smee.io/GH"},
+    "linear": {"smeeChannel": "https://smee.io/LIN", "ctl": {"webhookId": "wh-ctl"}}
+  }
+}
+BEOF
+
+run "T2.8 multiHost roster provisions catalyst.monitor webhook block (CTL-1284)" bash -c "
+  h='${SCRATCH}/h28'
+  env -i HOME=\"\$h\" CATALYST_DIR='${SCRATCH}/c28' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$MULTIHOST_WH_BUNDLE' >/dev/null 2>&1
+  cfg=\"\$h/.config/catalyst/config.json\"
+  jq -e '.catalyst.monitor.github.smeeChannel == \"https://smee.io/GH\"' \"\$cfg\" >/dev/null &&
+  jq -e '.catalyst.monitor.linear.ctl.webhookId == \"wh-ctl\"' \"\$cfg\" >/dev/null"
+
+run "T2.9 single-host roster OMITS webhook block — double-dispatch guard (CTL-1284)" bash -c "
+  h='${SCRATCH}/h29'
+  env -i HOME=\"\$h\" CATALYST_DIR='${SCRATCH}/c29' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$SINGLEHOST_WH_BUNDLE' >/dev/null 2>&1
+  cfg=\"\$h/.config/catalyst/config.json\"
+  # monitor block must be absent (or at least carry no smeeChannel)
+  ! jq -e '.catalyst.monitor.github.smeeChannel // empty | length > 0' \"\$cfg\" >/dev/null"
+
 # ── Phase 3: Provisioner orchestration ────────────────────────────────────────
 
 echo ""

--- a/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
@@ -374,6 +374,19 @@ run "install-services --print injects HOME + catalyst bin on PATH" bash -c "
   '${STACK}' install-services --print 2>&1 | grep -q '.catalyst/bin'
 "
 
+# CTL-1289: the daemon shells out to linearis/node/claude every tick; on a
+# joined member those live under ~/.local. The stack plist PATH must include the
+# member's npm/user prefix, and must STILL carry homebrew/system dirs (seed
+# no-regression — the seed resolves its tools from homebrew).
+run "install-services --print: stack plist PATH includes ~/.local member prefix (CTL-1289)" bash -c "
+  out=\$('${STACK}' install-services --print 2>&1)
+  path_line=\$(printf '%s\n' \"\$out\" | awk '/ai.coalesce.catalyst-stack/{found=1} found' | grep -A1 '<key>PATH</key>' | tail -1)
+  printf '%s' \"\$path_line\" | grep -q '.local/node/bin' &&
+  printf '%s' \"\$path_line\" | grep -q '.local/bin' &&
+  printf '%s' \"\$path_line\" | grep -q '/opt/homebrew/bin' &&
+  printf '%s' \"\$path_line\" | grep -q '/usr/bin'
+"
+
 run "install-services --print is side-effect-free (writes no plist)" bash -c "
   fh='${SCRATCH}/se_home'; mkdir -p \"\$fh/Library/LaunchAgents\";
   HOME=\"\$fh\" '${STACK}' install-services --print >/dev/null 2>&1;

--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -122,6 +122,12 @@ cmd_start() {
 	local _daemon_env="${CATALYST_EXECUTION_CORE_ENV:-${HOME}/.config/catalyst/execution-core.env}"
 	# shellcheck disable=SC1090
 	[[ -f "$_daemon_env" ]] && source "$_daemon_env"
+	# CTL-1289: belt-and-suspenders — a daemon started by hand (not via the
+	# catalyst-stack launchd plist, which already sets _stack_agent_path) inherits
+	# whatever PATH the invoking shell had, which on a fresh member can omit the
+	# npm/user prefix where linearis/node/claude live. Prepend them so the daemon's
+	# per-tick spawns (reconcile/liveness/runtime) resolve regardless of launcher.
+	export PATH="${HOME}/.local/node/bin:${HOME}/.local/bin:${PATH}"
 	# CTL-1084: resolve durable governance flags (Layer-2 + any explicit env override)
 	# and export them so the daemon — and every per-tick gate that reads process.env —
 	# inherits the durable value with no manual re-export ritual. Best-effort: a failure

--- a/plugins/dev/scripts/catalyst-join.sh
+++ b/plugins/dev/scripts/catalyst-join.sh
@@ -532,12 +532,25 @@ do_provision_thoughts() {
   fi
   # provision-thoughts failed — usually push-auth (an M2 precondition), not the
   # clone. If the primary thoughts repo is present AND has a usable HEAD (a real
-  # read-OK clone, not a partial/interrupted one), a Stage-0 SHADOW node can
-  # proceed; push auth must be verified-green before M2 activation. Else fail.
+  # read-OK clone, not a partial/interrupted one), severity depends on whether
+  # this node will own work.
   local primary="${CATALYST_DIR:-$HOME/catalyst}/hlt/coalesce-labs/thoughts"
   if [[ -d "$primary/.git" ]] && git -C "$primary" rev-parse --verify -q HEAD >/dev/null 2>&1; then
-    warn "provision-thoughts: clone OK but push-auth/verify incomplete — acceptable for Stage-0 SHADOW."
-    warn "Configure CATALYST_JOIN_GITHUB_TOKEN (or 'gh auth login') and re-run before M2 activation."
+    # CTL-1293: a multiHost MEMBER (roster>1) WILL own HRW work, and a worker
+    # that can't push thoughts strands its research/learnings/handoffs (peers
+    # never see them) — so an unverified push is a HARD blocker, not a warning.
+    # A single-host / Stage-0 SHADOW node (roster<=1) owns no work and has no
+    # peers to sync to, so it may warn-and-proceed. The previous unconditional
+    # "acceptable for SHADOW" downgrade was the silent strand.
+    local pt_roster_len
+    pt_roster_len="$(echo "$BUNDLE_JSON" | jq '(.hostsRoster // []) | length' 2>/dev/null)"
+    if [[ "${pt_roster_len:-0}" -gt 1 ]]; then
+      fail "provision-thoughts: clone OK but push-auth UNVERIFIED on a multiHost member (roster=${pt_roster_len})."
+      fail "A member that owns work MUST sync thoughts to peers. Set CATALYST_JOIN_GITHUB_TOKEN (or 'gh auth login') and re-run."
+      return 1
+    fi
+    warn "provision-thoughts: clone OK but push-auth/verify incomplete — acceptable for single-host/Stage-0 SHADOW."
+    warn "Configure CATALYST_JOIN_GITHUB_TOKEN (or 'gh auth login') and re-run before activating as a member."
     return 0
   fi
   fail "provision-thoughts failed before a usable primary thoughts clone. Check GitHub auth / network."

--- a/plugins/dev/scripts/catalyst-join.sh
+++ b/plugins/dev/scripts/catalyst-join.sh
@@ -594,6 +594,30 @@ merge_shared_config() {
       | .catalyst.layer1Identity.stateMap //= $la_statemap
     ' "$cfg" > "$tmp" && mv "$tmp" "$cfg" || { rm -f "$tmp"; return 1; }
   info "SHARED config merged into ${cfg}"
+
+  # CTL-1284: webhook ingestion wiring (non-secret smee channels + per-team
+  # webhookId map; HMAC secrets travel via SOPS/cluster-sync, not the bundle).
+  # GATED on multiHost — roster length > 1. At roster length 1, HRW is an
+  # identity no-op AND claimDispatch is skipped, so a single node ingesting
+  # webhooks would actuate every inbound event → double-dispatch. The bundle's
+  # hostsRoster is the conservative, present-at-config-merge-time signal (the
+  # live resolveClusterHosts() may not yet see the cluster-repo roster here).
+  local roster_len monitor_wh
+  roster_len="$(echo "$BUNDLE_JSON" | jq '(.hostsRoster // []) | length')"
+  monitor_wh="$(echo "$BUNDLE_JSON" | jq '.monitorWebhooks // null')"
+  if [[ "${roster_len:-0}" -gt 1 && "$monitor_wh" != "null" ]]; then
+    local tmp2
+    tmp2="$(mktemp "$(dirname "$cfg")/.config.XXXXXX")"
+    # Deep-merge ($wh * existing): existing node-local values WIN (non-clobber),
+    # new keys from the bundle are added.
+    jq --argjson wh "$monitor_wh" '
+        .catalyst //= {}
+        | .catalyst.monitor = ($wh * (.catalyst.monitor // {}))
+      ' "$cfg" > "$tmp2" && mv "$tmp2" "$cfg" || { rm -f "$tmp2"; return 1; }
+    info "webhook ingestion wired (multiHost roster=${roster_len})"
+  else
+    info "webhook ingestion NOT wired (roster=${roster_len:-0}) — single-host double-dispatch guard"
+  fi
 }
 
 persist_host_name() {

--- a/plugins/dev/scripts/catalyst-join.sh
+++ b/plugins/dev/scripts/catalyst-join.sh
@@ -656,6 +656,56 @@ persist_host_name() {
   PERSISTED_HOST_NAME="$host_name"
 }
 
+# CTL-1231: provision ~/.claude/settings.json (telemetry posture + autonomy
+# defaults) and the daemon's OTLP endpoint. Runs AFTER persist_host_name so the
+# per-host OTEL_RESOURCE_ATTRIBUTES can be synthesized from PERSISTED_HOST_NAME.
+provision_claude_settings() {
+  local host_name="$1"
+  [[ -n "$host_name" ]] || { warn "provision_claude_settings: empty host name — skipping"; return 0; }
+  local settings_dir="$HOME/.claude"
+  local settings="$settings_dir/settings.json"
+  local cs otlp
+  cs="$(echo "$BUNDLE_JSON" | jq '.claudeSettings // null')"
+  otlp="$(bundle_get '.otlpEndpointHint')"
+
+  mkdir -p "$settings_dir"
+  [[ -f "$settings" ]] || echo '{}' > "$settings"
+
+  local tmp
+  tmp="$(mktemp "${settings_dir}/.settings.XXXXXX")"
+  # Deep-merge the shared slice UNDER the existing file ($shared * existing →
+  # existing wins, non-clobber so a hand-tuned member file is preserved), then
+  # ALWAYS synthesize the per-host OTEL_RESOURCE_ATTRIBUTES (never copy the
+  # seed's host.name) and set the OTLP endpoint with //= (member override wins).
+  jq \
+    --argjson cs "$cs" \
+    --arg host "$host_name" \
+    --arg otlp "$otlp" \
+    '
+      ( if $cs == null then {} else $cs end ) as $shared
+      | ($shared * .)
+      | .env //= {}
+      | .env.OTEL_RESOURCE_ATTRIBUTES = ("host.name=" + $host)
+      | ( if $otlp != "" then .env.OTEL_EXPORTER_OTLP_ENDPOINT //= $otlp else . end )
+    ' "$settings" > "$tmp" && mv "$tmp" "$settings" || { rm -f "$tmp"; return 1; }
+  chmod 0644 "$settings" 2>/dev/null || true
+  info "~/.claude/settings.json provisioned (host.name=${host_name})"
+
+  # Daemon-context endpoint: the launchd execution-core daemon and the
+  # bg-workers it spawns read OTEL_EXPORTER_OTLP_ENDPOINT from this env file, NOT
+  # from settings.json. Unset → all worker telemetry exports nowhere. Append
+  # only when absent — NEVER overwrite (preserves proxy/CA lines, etc.).
+  if [[ -n "$otlp" ]]; then
+    local ec_env="$HOME/.config/catalyst/execution-core.env"
+    mkdir -p "$(dirname "$ec_env")"
+    touch "$ec_env"
+    if ! grep -q '^OTEL_EXPORTER_OTLP_ENDPOINT=' "$ec_env" 2>/dev/null; then
+      printf 'OTEL_EXPORTER_OTLP_ENDPOINT=%s\n' "$otlp" >> "$ec_env"
+      info "daemon OTLP endpoint written to execution-core.env"
+    fi
+  fi
+}
+
 write_local_roster() {
   local host_name="$1"
   local local_roster="${CATALYST_DIR}/cluster/local-hosts.json"
@@ -684,6 +734,7 @@ do_config_merge() {
   # the captured value. Same shell — run_stage calls "$@" directly, no subshell.
   PERSISTED_HOST_NAME=""
   persist_host_name || return 1
+  provision_claude_settings "$PERSISTED_HOST_NAME" || return 1
   write_local_roster "$PERSISTED_HOST_NAME" || return 1
 }
 

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -799,8 +799,17 @@ _stack_host_name() {
 
 # _stack_agent_path — PATH for the launchd job so it finds the catalyst CLIs,
 # bun/node, and git in launchd's otherwise-minimal environment.
+#
+# CTL-1289: include the member's npm/user prefix (~/.local/node/bin for node,
+# ~/.local/bin for linearis/claude). A `catalyst-join`-joined member installs
+# those CLIs under ~/.local; the launchd daemon shells out to them every tick
+# (reconcile → linearis, liveness snapshot → claude, linearis runtime → node),
+# so omitting these dirs makes every spawn exit-127 and the node strands
+# silently (frozen eligible set, freeSlots=0). Mirrors the proven join-shell
+# PATH order (catalyst-join.sh:719). Additive: the seed's homebrew/system tools
+# remain on PATH, and prepended member dirs that don't exist are a no-op.
 _stack_agent_path() {
-  printf '%s\n' "${HOME}/.catalyst/bin:${HOME}/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  printf '%s\n' "${HOME}/.catalyst/bin:${HOME}/.local/node/bin:${HOME}/.local/bin:${HOME}/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 }
 
 # render_stack_plist <cmd> <interval> [host_name] — emit the LaunchAgent plist XML to stdout.

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -1069,6 +1069,91 @@ export function checkThoughts(deps = {}) {
   return checks;
 }
 
+// ─── Phase 5e: Claude settings.json (CTL-1231) ───────────────────────────────
+
+// catalyst-join never wrote ~/.claude/settings.json, so a member's interactive
+// `claude` sessions lacked the OTLP endpoint + telemetry toggles, and — worse —
+// the per-host OTEL_RESOURCE_ATTRIBUTES host.name pin was unset, so telemetry
+// mis-attributed the host. This check (multiHost-gated, like the others) FAILs a
+// member whose settings.json is absent, doesn't pin host.name=<self>, or has no
+// OTLP endpoint in EITHER settings.json or the daemon env file (the latter is
+// what the launchd daemon + bg-workers actually read).
+
+function defaultReadClaudeSettings() {
+  try {
+    return JSON.parse(readFileSync(resolve(homedir(), ".claude", "settings.json"), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function defaultDaemonEnvHasOtlp() {
+  try {
+    const txt = readFileSync(resolve(homedir(), ".config", "catalyst", "execution-core.env"), "utf8");
+    return /^OTEL_EXPORTER_OTLP_ENDPOINT=.+/m.test(txt);
+  } catch {
+    return false;
+  }
+}
+
+export function checkClaudeSettings(deps = {}) {
+  const {
+    resolveRoster = resolveClusterHosts,
+    readSettings = defaultReadClaudeSettings,
+    getHost = getHostName,
+    daemonEnvHasOtlp = defaultDaemonEnvHasOtlp,
+  } = deps;
+
+  const roster = resolveRoster();
+  if (!roster?.multiHost) {
+    return [
+      mkCheck(
+        "claude-settings",
+        STATUS.PASS,
+        "single-host node — settings.json provisioning not activation-gating",
+      ),
+    ];
+  }
+
+  const s = readSettings();
+  if (!s || typeof s !== "object") {
+    return [
+      mkCheck(
+        "claude-settings",
+        STATUS.FAIL,
+        "~/.claude/settings.json absent or unparseable — telemetry + host identity unset for interactive sessions",
+      ),
+    ];
+  }
+
+  const checks = [];
+  const self = getHost();
+  const ra = s?.env?.OTEL_RESOURCE_ATTRIBUTES ?? "";
+  checks.push(
+    typeof ra === "string" && ra.includes(`host.name=${self}`)
+      ? mkCheck("claude-settings-host", STATUS.PASS, `settings.json pins host.name=${self}`)
+      : mkCheck(
+          "claude-settings-host",
+          STATUS.FAIL,
+          `settings.json OTEL_RESOURCE_ATTRIBUTES does not pin host.name=${self} (got "${ra}") — telemetry mis-attributes this host`,
+        ),
+  );
+
+  const settingsOtlp = s?.env?.OTEL_EXPORTER_OTLP_ENDPOINT ?? "";
+  const hasOtlp = (typeof settingsOtlp === "string" && settingsOtlp.length > 0) || daemonEnvHasOtlp();
+  checks.push(
+    hasOtlp
+      ? mkCheck("claude-settings-otlp", STATUS.PASS, "OTLP endpoint set (settings.json or daemon env file)")
+      : mkCheck(
+          "claude-settings-otlp",
+          STATUS.FAIL,
+          "OTLP endpoint unset in BOTH settings.json and execution-core.env — daemon + worker telemetry exports nowhere",
+        ),
+  );
+
+  return checks;
+}
+
 // ─── Phase 6: Renderer, exit code, runDoctor ─────────────────────────────────
 
 // summarize — aggregate check results into counts.
@@ -1158,6 +1243,7 @@ export async function runDoctor(opts = {}) {
     () => checkDaemonToolPath(), // CTL-1289: daemon launchd PATH resolves linearis/node/claude
     () => checkWebhookIngestion(), // CTL-1284: multiHost member ingests webhooks; single-host does not
     () => checkThoughts(), // CTL-1293: member thoughts repo provisioned + non-foreign primary
+    () => checkClaudeSettings(), // CTL-1231: member settings.json pins host identity + OTLP endpoint
   ];
 
   const fns = checkFns ?? defaultChecks;

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -838,6 +838,113 @@ export function checkDaemonToolPath(deps = {}) {
   ];
 }
 
+// ─── Phase 5c: Webhook ingestion (CTL-1284) ──────────────────────────────────
+
+// A `catalyst-join`-joined MEMBER must ingest inbound GitHub/Linear webhooks —
+// without them monitor-merge CI-waits and comment-wakes degrade to polling. But
+// a SINGLE-host node must NOT ingest: at roster length 1 HRW is an identity
+// no-op and claimDispatch is skipped, so a lone node would actuate every inbound
+// event → double-dispatch. This check asserts: single-host → PASS (ingestion
+// legitimately off); multiHost → at least one webhook route is FULLY wired (smee
+// channel + matching HMAC secret on disk), with no half-wired webhookId (id
+// configured but secret file missing). FAILs so the activation gate fail-closes.
+
+function defaultWebhookConfigDir() {
+  return resolve(homedir(), ".config", "catalyst");
+}
+
+function defaultReadMonitor() {
+  try {
+    const obj = JSON.parse(readFileSync(layer2Path(), "utf8"));
+    return obj?.catalyst?.monitor ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultSecretFileNonEmpty(dir, name) {
+  try {
+    return readFileSync(resolve(dir, name), "utf8").trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function checkWebhookIngestion(deps = {}) {
+  const {
+    resolveRoster = resolveClusterHosts,
+    monitor = defaultReadMonitor(),
+    configDir = defaultWebhookConfigDir(),
+    secretFileNonEmpty = defaultSecretFileNonEmpty,
+  } = deps;
+
+  const roster = resolveRoster();
+  if (!roster?.multiHost) {
+    return [
+      mkCheck(
+        "webhook-ingestion",
+        STATUS.PASS,
+        "single-host roster — webhook ingestion legitimately disabled (double-dispatch guard)",
+      ),
+    ];
+  }
+
+  const m = monitor ?? {};
+
+  // GitHub route: smee channel + a github HMAC secret (file or env).
+  const ghSmee = typeof m.github?.smeeChannel === "string" ? m.github.smeeChannel : "";
+  const ghSecret =
+    secretFileNonEmpty(configDir, "webhook-secret") ||
+    (process.env.CATALYST_WEBHOOK_SECRET ?? "").length > 0;
+  const githubWired = ghSmee.length > 0 && ghSecret;
+
+  // Linear route: smee channel + ≥1 keyed webhookId whose HMAC secret resolves.
+  const linear =
+    m.linear && typeof m.linear === "object" && !Array.isArray(m.linear) ? m.linear : {};
+  const linSmee = typeof linear.smeeChannel === "string" ? linear.smeeChannel : "";
+  const webhookKeys = Object.keys(linear).filter((k) => {
+    const e = linear[k];
+    return (
+      e && typeof e === "object" && !Array.isArray(e) &&
+      typeof e.webhookId === "string" && e.webhookId.length > 0
+    );
+  });
+  const keySecretWired = (k) =>
+    secretFileNonEmpty(
+      configDir,
+      k === "workspace" ? "linear-webhook-secret" : `linear-webhook-secret-${k}`,
+    ) || (process.env.CATALYST_LINEAR_WEBHOOK_SECRET ?? "").length > 0;
+  const wiredKeys = webhookKeys.filter(keySecretWired);
+  const danglingKeys = webhookKeys.filter((k) => !keySecretWired(k));
+  const linearWired = linSmee.length > 0 && wiredKeys.length > 0;
+
+  if (!githubWired && !linearWired) {
+    return [
+      mkCheck(
+        "webhook-ingestion",
+        STATUS.FAIL,
+        `multiHost member but NO webhook route enabled — github(smee=${ghSmee ? "set" : "unset"},secret=${ghSecret ? "set" : "unset"}) linear(smee=${linSmee ? "set" : "unset"},wiredKeys=${wiredKeys.length}); monitor-merge/comment-wakes will degrade to polling`,
+      ),
+    ];
+  }
+  if (danglingKeys.length > 0) {
+    return [
+      mkCheck(
+        "webhook-ingestion",
+        STATUS.FAIL,
+        `multiHost member with half-wired Linear webhook(s): ${danglingKeys.join(", ")} configured (webhookId) but missing HMAC secret file (linear-webhook-secret-<key>)`,
+      ),
+    ];
+  }
+  return [
+    mkCheck(
+      "webhook-ingestion",
+      STATUS.PASS,
+      `webhook ingestion wired (github=${githubWired}, linear=${linearWired}, linear keys=${wiredKeys.length})`,
+    ),
+  ];
+}
+
 // ─── Phase 6: Renderer, exit code, runDoctor ─────────────────────────────────
 
 // summarize — aggregate check results into counts.
@@ -925,6 +1032,7 @@ export async function runDoctor(opts = {}) {
     () => checkConnectivity({ seed, otel }),
     () => checkSecretsHygiene(),
     () => checkDaemonToolPath(), // CTL-1289: daemon launchd PATH resolves linearis/node/claude
+    () => checkWebhookIngestion(), // CTL-1284: multiHost member ingests webhooks; single-host does not
   ];
 
   const fns = checkFns ?? defaultChecks;

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -724,6 +724,120 @@ export function checkSecretsHygiene(deps = {}) {
   return checks;
 }
 
+// ─── Phase 5: Daemon-runtime tool PATH (CTL-1289) ────────────────────────────
+
+// The execution-core daemon is NOT pure OAuth — it shells out to `linearis`
+// (reconcile), `claude` (liveness snapshot) and `node` (linearis's
+// `#!/usr/bin/env node` runtime) every tick. On a `catalyst-join`-joined member
+// those CLIs live under ~/.local/{bin,node/bin}; if the launchd daemon's PATH
+// omits them, every spawn exit-127s and the node strands SILENTLY — it boots
+// clean, emits heartbeats, shows `owns N`, but reconcile freezes, the liveness
+// snapshot never warms (freeSlots=0 → new-work held) and the GC/reaper sweeps
+// fail-closed. This check is the load-bearing daemon-context assertion: it
+// resolves the three CLIs against the DAEMON's PATH — the installed launchd
+// plist's <key>PATH</key>, NOT process.env.PATH, which the join shell enriches
+// (catalyst-join.sh:719) and would FALSE-PASS — and FAILs (not WARNs) so the
+// activation gate fail-closes instead of stranding.
+
+// defaultDaemonPath — extract the PATH the launchd daemon actually runs with,
+// from the installed catalyst-stack plist. Tests the persisted state, so a
+// stale plist (installed before the CTL-1289 fix) is caught. null = not installed.
+function defaultDaemonPath() {
+  const plist = resolve(
+    homedir(), "Library", "LaunchAgents", "ai.coalesce.catalyst-stack.plist",
+  );
+  try {
+    const xml = readFileSync(plist, "utf8");
+    const m = xml.match(/<key>PATH<\/key>\s*<string>([^<]*)<\/string>/);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+// defaultResolveInPath — does `cmd` resolve to an executable under `pathStr`?
+// Uses `command -v` with positional args (no shell injection).
+function defaultResolveInPath(cmd, pathStr) {
+  const r = spawnSync("sh", ["-c", 'command -v "$1" >/dev/null 2>&1', "sh", cmd], {
+    timeout: 5_000,
+    env: { ...process.env, PATH: pathStr },
+  });
+  return r.status === 0;
+}
+
+// defaultSmokeProbe — run `cmd args` under `pathStr` and return the exit code.
+// ENOENT (cmd itself absent) maps to 127; the caller only cares whether the
+// result is the 127 strand signature (a shelled-out dependency unresolved).
+// Auth/network failures surface as a NON-127 exit, so they never false-FAIL.
+function defaultSmokeProbe(cmd, args, pathStr) {
+  const r = spawnSync(cmd, args, {
+    timeout: 12_000,
+    env: { ...process.env, PATH: pathStr },
+  });
+  if (r.error) return r.error.code === "ENOENT" ? 127 : -1;
+  return r.status;
+}
+
+// checkDaemonToolPath — assert the daemon's launchd PATH can resolve and run the
+// CLIs it shells out to. Injectable deps for unit testing.
+export function checkDaemonToolPath(deps = {}) {
+  const {
+    daemonPath = defaultDaemonPath(),
+    resolveInPath = defaultResolveInPath,
+    smokeProbe = defaultSmokeProbe,
+    tools = ["linearis", "node", "claude"],
+  } = deps;
+
+  if (!daemonPath) {
+    return [
+      mkCheck(
+        "daemon-tool-path",
+        STATUS.WARN,
+        "no installed catalyst-stack launchd plist found — cannot assert the daemon's PATH; run `catalyst-stack install-services`",
+      ),
+    ];
+  }
+
+  const missing = tools.filter((t) => !resolveInPath(t, daemonPath));
+  if (missing.length > 0) {
+    return [
+      mkCheck(
+        "daemon-tool-path",
+        STATUS.FAIL,
+        `daemon launchd PATH cannot resolve: ${missing.join(", ")} — the daemon shells out to these every tick; missing → exit-127 silent strand (frozen eligible set, freeSlots=0). PATH=${daemonPath}`,
+      ),
+    ];
+  }
+
+  // All resolve — smoke-probe that they don't exit-127 under the daemon PATH
+  // (catches e.g. linearis resolving but its node runtime not, or a broken wrapper).
+  const probes = [
+    ["linearis", ["issues", "list", "-l", "1"]],
+    ["claude", ["agents", "--json"]],
+  ].filter(([cmd]) => tools.includes(cmd));
+  const exit127 = probes
+    .filter(([cmd, args]) => smokeProbe(cmd, args, daemonPath) === 127)
+    .map(([cmd]) => cmd);
+
+  if (exit127.length > 0) {
+    return [
+      mkCheck(
+        "daemon-tool-path",
+        STATUS.FAIL,
+        `${exit127.join(", ")} exit-127 under the daemon PATH (a shelled-out dependency is unresolved) — the precise strand signature`,
+      ),
+    ];
+  }
+
+  return [
+    mkCheck(
+      "daemon-tool-path",
+      STATUS.PASS,
+      `daemon launchd PATH resolves linearis/node/claude and they run (no exit-127)`,
+    ),
+  ];
+}
+
 // ─── Phase 6: Renderer, exit code, runDoctor ─────────────────────────────────
 
 // summarize — aggregate check results into counts.
@@ -802,7 +916,7 @@ export async function runDoctor(opts = {}) {
     expectedBotUserId = null,
   } = opts;
 
-  // Default check suite — all 5 check functions with real deps
+  // Default check suite — all check functions with real deps
   const defaultChecks = [
     () => checkHostIdentity(),
     () => checkHrwPartition(),
@@ -810,6 +924,7 @@ export async function runDoctor(opts = {}) {
     () => checkBotCredentials({ expectedBotUserId }),
     () => checkConnectivity({ seed, otel }),
     () => checkSecretsHygiene(),
+    () => checkDaemonToolPath(), // CTL-1289: daemon launchd PATH resolves linearis/node/claude
   ];
 
   const fns = checkFns ?? defaultChecks;

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -945,6 +945,130 @@ export function checkWebhookIngestion(deps = {}) {
   ];
 }
 
+// ─── Phase 5d: Thoughts provisioning (CTL-1293) ──────────────────────────────
+
+// A cluster MEMBER is a full worker: research/learnings/handoffs must sync to
+// peers via the HumanLayer thoughts repo. A half-provisioned thoughts layer
+// strands silently — worse, a missing/legacy humanlayer.json falls back to a
+// FOREIGN repo (groundworkapp / rightsite-cloud), polluting it with catalyst
+// thoughts. This check gates severity on multiHost (a single-host node has no
+// peers to sync to, so thoughts-push is not activation-gating — matches the
+// webhook gate). On a multiHost member it FAILs loudly when humanlayer.json is
+// absent, resolves to a foreign primary, has empty repoMappings (bg agents then
+// fall back to a global/phantom repo), or the primary clone is missing.
+
+function defaultReadHumanlayer() {
+  try {
+    const p = resolve(homedir(), ".config", "humanlayer", "humanlayer.json");
+    return JSON.parse(readFileSync(p, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function defaultThoughtsCloneOk(dir) {
+  try {
+    if (!existsSync(resolve(dir, ".git"))) return false;
+    execFileSync("git", ["-C", dir, "rev-parse", "--verify", "-q", "HEAD"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function checkThoughts(deps = {}) {
+  const {
+    resolveRoster = resolveClusterHosts,
+    readHumanlayer = defaultReadHumanlayer,
+    cloneOk = defaultThoughtsCloneOk,
+  } = deps;
+
+  const roster = resolveRoster();
+  if (!roster?.multiHost) {
+    return [
+      mkCheck(
+        "thoughts",
+        STATUS.PASS,
+        "single-host node — thoughts peer-sync not activation-gating",
+      ),
+    ];
+  }
+
+  const hl = readHumanlayer();
+  const t = hl?.thoughts;
+  if (!t || typeof t !== "object") {
+    return [
+      mkCheck(
+        "thoughts",
+        STATUS.FAIL,
+        "~/.config/humanlayer/humanlayer.json absent or has no .thoughts — a member's research/learnings/handoffs won't sync",
+      ),
+    ];
+  }
+
+  const checks = [];
+  const thoughtsRepo = typeof t.thoughtsRepo === "string" ? t.thoughtsRepo : "";
+  const defaultProfile = typeof t.defaultProfile === "string" ? t.defaultProfile : "";
+
+  // Pollution guard: primary must be coalesce-labs, NEVER a foreign repo. The
+  // global thoughtsRepo fallback defaulting to groundworkapp/rightsite-cloud is
+  // the exact pollution bug (locked invariant: provision-thoughts-invariant.test.sh).
+  if (/groundworkapp|rightsite-cloud/i.test(thoughtsRepo) || /groundworkapp|rightsite-cloud/i.test(defaultProfile)) {
+    checks.push(
+      mkCheck(
+        "thoughts-primary",
+        STATUS.FAIL,
+        `humanlayer.json primary resolves to a FOREIGN repo (thoughtsRepo="${thoughtsRepo}", defaultProfile="${defaultProfile}") — pollutes groundworkapp/rightsite-cloud; must be coalesce-labs`,
+      ),
+    );
+  } else if (/coalesce-labs/i.test(thoughtsRepo) || defaultProfile === "coalesce-labs") {
+    checks.push(mkCheck("thoughts-primary", STATUS.PASS, "humanlayer.json primary = coalesce-labs"));
+  } else {
+    checks.push(
+      mkCheck(
+        "thoughts-primary",
+        STATUS.WARN,
+        `humanlayer.json primary unrecognized (thoughtsRepo="${thoughtsRepo}", defaultProfile="${defaultProfile}")`,
+      ),
+    );
+  }
+
+  // repoMappings non-empty — headless bg agents resolve their thoughts repo from
+  // this map (no direnv); empty → global/phantom-repo fallback.
+  const mappings = t.repoMappings;
+  const mappingCount =
+    mappings && typeof mappings === "object" && !Array.isArray(mappings)
+      ? Object.keys(mappings).length
+      : 0;
+  checks.push(
+    mappingCount > 0
+      ? mkCheck("thoughts-repo-mappings", STATUS.PASS, `repoMappings present (${mappingCount})`)
+      : mkCheck(
+          "thoughts-repo-mappings",
+          STATUS.FAIL,
+          "humanlayer.json repoMappings empty — headless bg agents fall back to a global/phantom repo",
+        ),
+  );
+
+  // Primary clone present (members keep it under ~/catalyst/hlt/<org>/thoughts;
+  // the seed's embedded-clone layout doesn't, so scope this to the hlt/ layout).
+  if (thoughtsRepo.includes("/hlt/")) {
+    checks.push(
+      cloneOk(thoughtsRepo)
+        ? mkCheck("thoughts-clone", STATUS.PASS, "primary thoughts clone present with a valid HEAD")
+        : mkCheck(
+            "thoughts-clone",
+            STATUS.FAIL,
+            `primary thoughts clone missing or corrupt at ${thoughtsRepo} — read-only/partial strand`,
+          ),
+    );
+  }
+
+  return checks;
+}
+
 // ─── Phase 6: Renderer, exit code, runDoctor ─────────────────────────────────
 
 // summarize — aggregate check results into counts.
@@ -1033,6 +1157,7 @@ export async function runDoctor(opts = {}) {
     () => checkSecretsHygiene(),
     () => checkDaemonToolPath(), // CTL-1289: daemon launchd PATH resolves linearis/node/claude
     () => checkWebhookIngestion(), // CTL-1284: multiHost member ingests webhooks; single-host does not
+    () => checkThoughts(), // CTL-1293: member thoughts repo provisioned + non-foreign primary
   ];
 
   const fns = checkFns ?? defaultChecks;

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -16,6 +16,7 @@ import {
   checkDaemonToolPath,
   checkWebhookIngestion,
   checkThoughts,
+  checkClaudeSettings,
   summarize,
   renderJson,
   renderHuman,
@@ -741,6 +742,68 @@ describe("checkThoughts", () => {
     expect(verdict(checks, "thoughts-primary")).toBe(STATUS.PASS);
     expect(verdict(checks, "thoughts-repo-mappings")).toBe(STATUS.PASS);
     expect(verdict(checks, "thoughts-clone")).toBe(STATUS.PASS);
+    expect(checks.every((c) => c.status === STATUS.PASS)).toBe(true);
+  });
+});
+
+// ─── Phase 5e: checkClaudeSettings (CTL-1231) ────────────────────────────────
+
+describe("checkClaudeSettings", () => {
+  const single = () => ({ hosts: ["mini"], source: "single-host", multiHost: false });
+  const multi = () => ({ hosts: ["mini", "mini-2"], source: "cluster-repo", multiHost: true });
+  const host = () => "mini-2";
+  const verdict = (checks, name) => checks.find((c) => c.name === name)?.status;
+
+  it("PASSes a single-host node regardless of settings (not gating)", () => {
+    const checks = checkClaudeSettings({ resolveRoster: single, readSettings: () => null });
+    expect(checks[0].name).toBe("claude-settings");
+    expect(checks[0].status).toBe(STATUS.PASS);
+  });
+
+  it("FAILs a multiHost member with no settings.json", () => {
+    const checks = checkClaudeSettings({ resolveRoster: multi, readSettings: () => null, getHost: host });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("settings.json");
+  });
+
+  it("FAILs when host.name is not pinned for this host", () => {
+    const checks = checkClaudeSettings({
+      resolveRoster: multi,
+      getHost: host,
+      readSettings: () => ({ env: { OTEL_RESOURCE_ATTRIBUTES: "host.name=laptop", OTEL_EXPORTER_OTLP_ENDPOINT: "http://o:4317" } }),
+      daemonEnvHasOtlp: () => true,
+    });
+    expect(verdict(checks, "claude-settings-host")).toBe(STATUS.FAIL);
+  });
+
+  it("FAILs when OTLP endpoint is unset in both settings.json and daemon env", () => {
+    const checks = checkClaudeSettings({
+      resolveRoster: multi,
+      getHost: host,
+      readSettings: () => ({ env: { OTEL_RESOURCE_ATTRIBUTES: "host.name=mini-2" } }),
+      daemonEnvHasOtlp: () => false,
+    });
+    expect(verdict(checks, "claude-settings-otlp")).toBe(STATUS.FAIL);
+  });
+
+  it("PASSes when OTLP endpoint is set only in the daemon env file", () => {
+    const checks = checkClaudeSettings({
+      resolveRoster: multi,
+      getHost: host,
+      readSettings: () => ({ env: { OTEL_RESOURCE_ATTRIBUTES: "host.name=mini-2" } }),
+      daemonEnvHasOtlp: () => true,
+    });
+    expect(verdict(checks, "claude-settings-host")).toBe(STATUS.PASS);
+    expect(verdict(checks, "claude-settings-otlp")).toBe(STATUS.PASS);
+  });
+
+  it("PASSes a fully-provisioned member (host pinned + settings.json endpoint)", () => {
+    const checks = checkClaudeSettings({
+      resolveRoster: multi,
+      getHost: host,
+      readSettings: () => ({ env: { OTEL_RESOURCE_ATTRIBUTES: "host.name=mini-2", OTEL_EXPORTER_OTLP_ENDPOINT: "http://o:4317" } }),
+      daemonEnvHasOtlp: () => false,
+    });
     expect(checks.every((c) => c.status === STATUS.PASS)).toBe(true);
   });
 });

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -3,7 +3,7 @@
 //
 // Run: cd plugins/dev/scripts/execution-core && bun test doctor.test.mjs
 
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import {
   STATUS,
   mkCheck,
@@ -14,6 +14,7 @@ import {
   checkConnectivity,
   checkSecretsHygiene,
   checkDaemonToolPath,
+  checkWebhookIngestion,
   summarize,
   renderJson,
   renderHuman,
@@ -571,6 +572,97 @@ describe("checkDaemonToolPath", () => {
     expect(checks[0].status).toBe(STATUS.PASS);
     // smoke-probes linearis + claude (node is resolution-only)
     expect(probed).toEqual(["linearis", "claude"]);
+  });
+});
+
+// ─── Phase 5c: checkWebhookIngestion (CTL-1284) ──────────────────────────────
+
+describe("checkWebhookIngestion", () => {
+  // Isolate the env-var secret fallbacks the check honors (matching
+  // webhook-config.ts) so a dev shell with these set can't mask a dangling key.
+  const SECRET_ENVS = ["CATALYST_WEBHOOK_SECRET", "CATALYST_LINEAR_WEBHOOK_SECRET"];
+  let savedEnv = {};
+  beforeEach(() => {
+    for (const k of SECRET_ENVS) { savedEnv[k] = process.env[k]; delete process.env[k]; }
+  });
+  afterEach(() => {
+    for (const k of SECRET_ENVS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+  });
+
+  const singleHost = () => ({ hosts: ["mini"], source: "single-host", multiHost: false });
+  const multiHost = () => ({ hosts: ["mini", "mini-2"], source: "cluster-repo", multiHost: true });
+  const noSecrets = () => false;
+  const allSecrets = () => true;
+
+  it("PASSes a single-host node regardless of monitor config (double-dispatch guard)", () => {
+    const checks = checkWebhookIngestion({
+      resolveRoster: singleHost,
+      monitor: null,
+      secretFileNonEmpty: noSecrets,
+    });
+    expect(checks[0].name).toBe("webhook-ingestion");
+    expect(checks[0].status).toBe(STATUS.PASS);
+    expect(checks[0].detail).toContain("single-host");
+  });
+
+  it("FAILs a multiHost node with no webhook route enabled", () => {
+    const checks = checkWebhookIngestion({
+      resolveRoster: multiHost,
+      monitor: { github: { smeeChannel: "" }, linear: {} },
+      secretFileNonEmpty: noSecrets,
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("NO webhook route");
+  });
+
+  it("PASSes a multiHost node with the GitHub route fully wired", () => {
+    const checks = checkWebhookIngestion({
+      resolveRoster: multiHost,
+      monitor: { github: { smeeChannel: "https://smee.io/GH" } },
+      secretFileNonEmpty: (_dir, name) => name === "webhook-secret",
+    });
+    expect(checks[0].status).toBe(STATUS.PASS);
+  });
+
+  it("PASSes a multiHost node with a keyed Linear route fully wired", () => {
+    const checks = checkWebhookIngestion({
+      resolveRoster: multiHost,
+      monitor: { linear: { smeeChannel: "https://smee.io/LIN", ctl: { webhookId: "wh-ctl" } } },
+      secretFileNonEmpty: (_dir, name) => name === "linear-webhook-secret-ctl",
+    });
+    expect(checks[0].status).toBe(STATUS.PASS);
+    expect(checks[0].detail).toContain("linear keys=1");
+  });
+
+  it("FAILs a multiHost node with a half-wired webhookId (id set, secret file missing)", () => {
+    const checks = checkWebhookIngestion({
+      resolveRoster: multiHost,
+      // github route IS wired (so the failure is specifically the dangling key)
+      monitor: {
+        github: { smeeChannel: "https://smee.io/GH" },
+        linear: { smeeChannel: "https://smee.io/LIN", ctl: { webhookId: "wh-ctl" } },
+      },
+      secretFileNonEmpty: (_dir, name) => name === "webhook-secret", // ctl secret absent
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("half-wired");
+    expect(checks[0].detail).toContain("ctl");
+  });
+
+  it("PASSes when all routes and keyed secrets resolve", () => {
+    const checks = checkWebhookIngestion({
+      resolveRoster: multiHost,
+      monitor: {
+        github: { smeeChannel: "https://smee.io/GH" },
+        linear: { smeeChannel: "https://smee.io/LIN", ctl: { webhookId: "wh-ctl" }, adv: { webhookId: "wh-adv" } },
+      },
+      secretFileNonEmpty: allSecrets,
+    });
+    expect(checks[0].status).toBe(STATUS.PASS);
+    expect(checks[0].detail).toContain("linear keys=2");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -15,6 +15,7 @@ import {
   checkSecretsHygiene,
   checkDaemonToolPath,
   checkWebhookIngestion,
+  checkThoughts,
   summarize,
   renderJson,
   renderHuman,
@@ -663,6 +664,84 @@ describe("checkWebhookIngestion", () => {
     });
     expect(checks[0].status).toBe(STATUS.PASS);
     expect(checks[0].detail).toContain("linear keys=2");
+  });
+});
+
+// ─── Phase 5d: checkThoughts (CTL-1293) ──────────────────────────────────────
+
+describe("checkThoughts", () => {
+  const single = () => ({ hosts: ["mini"], source: "single-host", multiHost: false });
+  const multi = () => ({ hosts: ["mini", "mini-2"], source: "cluster-repo", multiHost: true });
+  const cleanHl = () => ({
+    thoughts: {
+      thoughtsRepo: "/Users/x/catalyst/hlt/coalesce-labs/thoughts",
+      defaultProfile: "coalesce-labs",
+      repoMappings: { "/Users/x/repo": { repo: "catalyst-workspace", profile: "coalesce-labs" } },
+    },
+  });
+  const okClone = () => true;
+
+  const verdict = (checks, name) => checks.find((c) => c.name === name)?.status;
+
+  it("PASSes a single-host node regardless of thoughts state (not gating)", () => {
+    const checks = checkThoughts({ resolveRoster: single, readHumanlayer: () => null });
+    expect(checks[0].name).toBe("thoughts");
+    expect(checks[0].status).toBe(STATUS.PASS);
+    expect(checks[0].detail).toContain("single-host");
+  });
+
+  it("FAILs a multiHost member with no humanlayer.json", () => {
+    const checks = checkThoughts({ resolveRoster: multi, readHumanlayer: () => null });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("humanlayer.json");
+  });
+
+  it("FAILs a multiHost member whose primary resolves to a foreign repo (groundworkapp guard)", () => {
+    const checks = checkThoughts({
+      resolveRoster: multi,
+      readHumanlayer: () => ({
+        thoughts: {
+          thoughtsRepo: "/Users/x/catalyst/hlt/groundworkapp/thoughts",
+          defaultProfile: "rightsite-cloud",
+          repoMappings: { "/r": { repo: "x", profile: "rightsite-cloud" } },
+        },
+      }),
+      cloneOk: okClone,
+    });
+    expect(verdict(checks, "thoughts-primary")).toBe(STATUS.FAIL);
+    expect(checks.find((c) => c.name === "thoughts-primary").detail).toMatch(/foreign|groundworkapp/i);
+  });
+
+  it("FAILs a multiHost member with empty repoMappings", () => {
+    const checks = checkThoughts({
+      resolveRoster: multi,
+      readHumanlayer: () => ({
+        thoughts: {
+          thoughtsRepo: "/Users/x/catalyst/hlt/coalesce-labs/thoughts",
+          defaultProfile: "coalesce-labs",
+          repoMappings: {},
+        },
+      }),
+      cloneOk: okClone,
+    });
+    expect(verdict(checks, "thoughts-repo-mappings")).toBe(STATUS.FAIL);
+  });
+
+  it("FAILs a multiHost member whose primary hlt clone is missing", () => {
+    const checks = checkThoughts({
+      resolveRoster: multi,
+      readHumanlayer: cleanHl,
+      cloneOk: () => false,
+    });
+    expect(verdict(checks, "thoughts-clone")).toBe(STATUS.FAIL);
+  });
+
+  it("PASSes a fully-provisioned multiHost member", () => {
+    const checks = checkThoughts({ resolveRoster: multi, readHumanlayer: cleanHl, cloneOk: okClone });
+    expect(verdict(checks, "thoughts-primary")).toBe(STATUS.PASS);
+    expect(verdict(checks, "thoughts-repo-mappings")).toBe(STATUS.PASS);
+    expect(verdict(checks, "thoughts-clone")).toBe(STATUS.PASS);
+    expect(checks.every((c) => c.status === STATUS.PASS)).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -13,6 +13,7 @@ import {
   checkBotCredentials,
   checkConnectivity,
   checkSecretsHygiene,
+  checkDaemonToolPath,
   summarize,
   renderJson,
   renderHuman,
@@ -514,6 +515,62 @@ describe("checkSecretsHygiene", () => {
     expect(checks.find((c) => c.name === "layer2-perms")?.status).toBe(STATUS.INFO);
     expect(checks.find((c) => c.name === "config-not-in-git")?.status).toBe(STATUS.INFO);
     expect(checks.find((c) => c.name === "no-secrets-in-layer1")?.status).toBe(STATUS.PASS);
+  });
+});
+
+// ─── Phase 5b: checkDaemonToolPath (CTL-1289) ────────────────────────────────
+
+describe("checkDaemonToolPath", () => {
+  const GOOD_PATH = "/Users/x/.local/node/bin:/Users/x/.local/bin:/usr/bin";
+
+  it("WARNs when no installed launchd plist is found (daemonPath null)", () => {
+    const checks = checkDaemonToolPath({ daemonPath: null });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].name).toBe("daemon-tool-path");
+    expect(checks[0].status).toBe(STATUS.WARN);
+  });
+
+  it("FAILs when the daemon PATH cannot resolve a required CLI", () => {
+    const checks = checkDaemonToolPath({
+      daemonPath: GOOD_PATH,
+      resolveInPath: (cmd) => cmd !== "linearis", // linearis missing
+      smokeProbe: () => 0,
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("linearis");
+    expect(checks[0].detail).toContain("exit-127");
+  });
+
+  it("FAILs on the exit-127 strand signature even when all CLIs resolve", () => {
+    const checks = checkDaemonToolPath({
+      daemonPath: GOOD_PATH,
+      resolveInPath: () => true,
+      smokeProbe: (cmd) => (cmd === "linearis" ? 127 : 0),
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("linearis");
+    expect(checks[0].detail).toContain("127");
+  });
+
+  it("does NOT FAIL on a non-127 exit (auth/network failure is not a strand)", () => {
+    const checks = checkDaemonToolPath({
+      daemonPath: GOOD_PATH,
+      resolveInPath: () => true,
+      smokeProbe: () => 1, // e.g. linearis ran but had no token
+    });
+    expect(checks[0].status).toBe(STATUS.PASS);
+  });
+
+  it("PASSes when all CLIs resolve and run without exit-127", () => {
+    const probed = [];
+    const checks = checkDaemonToolPath({
+      daemonPath: GOOD_PATH,
+      resolveInPath: () => true,
+      smokeProbe: (cmd) => { probed.push(cmd); return 0; },
+    });
+    expect(checks[0].status).toBe(STATUS.PASS);
+    // smoke-probes linearis + claude (node is resolution-only)
+    expect(probed).toEqual(["linearis", "claude"]);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/join-bundle.mjs
+++ b/plugins/dev/scripts/execution-core/join-bundle.mjs
@@ -74,6 +74,48 @@ function resolvePluginSourceUrl(l2) {
   return null;
 }
 
+// CTL-1284: extract the NON-SECRET webhook wiring a member needs to ingest
+// inbound GitHub/Linear events — smee channel URLs + the per-team webhookId map
+// that readAllLinearSecrets keys on. HMAC secrets are NEVER carried here; they
+// travel via the SOPS secret-files path (cluster-sync.mjs). Returns null when the
+// seed has no monitor block. The CONSUMER (merge_shared_config) gates writing
+// these onto a member by roster length > 1 — a single-host member must NOT
+// ingest webhooks (HRW no-op + claimDispatch skipped → double-dispatch).
+function extractMonitorWebhooks(l2) {
+  const monitor = l2?.catalyst?.monitor;
+  if (!monitor || typeof monitor !== "object") return null;
+  const out = {};
+
+  const ghSmee = monitor.github?.smeeChannel;
+  if (typeof ghSmee === "string" && ghSmee) {
+    out.github = { smeeChannel: ghSmee };
+  }
+
+  const linear = monitor.linear;
+  if (linear && typeof linear === "object" && !Array.isArray(linear)) {
+    const lin = {};
+    if (typeof linear.smeeChannel === "string" && linear.smeeChannel) {
+      lin.smeeChannel = linear.smeeChannel;
+    }
+    // Per-team keyed entries: { ctl: {webhookId, smeeChannel, resourceTypes}, ... }.
+    // Keep only non-secret identifiers; drop registeredAt and anything else.
+    for (const key of Object.keys(linear)) {
+      const entry = linear[key];
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+      if (typeof entry.webhookId !== "string" || !entry.webhookId) continue;
+      const e = { webhookId: entry.webhookId };
+      if (typeof entry.smeeChannel === "string" && entry.smeeChannel) {
+        e.smeeChannel = entry.smeeChannel;
+      }
+      if (Array.isArray(entry.resourceTypes)) e.resourceTypes = entry.resourceTypes;
+      lin[key] = e;
+    }
+    if (Object.keys(lin).length > 0) out.linear = lin;
+  }
+
+  return Object.keys(out).length > 0 ? out : null;
+}
+
 export function assembleJoinBundle() {
   // Pin CATALYST_CONFIG_FILE to the registry repoRoot so the cwd-dependent
   // Layer-1 identity read (layer1Path → <repoRoot>/.catalyst/config.json)
@@ -113,6 +155,10 @@ export function assembleJoinBundle() {
     },
     repoUrl,
     pluginSourceUrl: resolvePluginSourceUrl(l2) || repoUrl,
+    // CTL-1284: non-secret webhook wiring (smee channels + per-team webhookId
+    // map). null when the seed has no monitor block. multiHost-gated by the
+    // consumer; deliberately NOT in BUNDLE_REQUIRED_KEYS.
+    monitorWebhooks: extractMonitorWebhooks(l2),
   };
 }
 

--- a/plugins/dev/scripts/execution-core/join-bundle.mjs
+++ b/plugins/dev/scripts/execution-core/join-bundle.mjs
@@ -116,6 +116,54 @@ function extractMonitorWebhooks(l2) {
   return Object.keys(out).length > 0 ? out : null;
 }
 
+// CTL-1231: carry a SHARED-only, secret-free slice of the seed's
+// ~/.claude/settings.json so a member's interactive `claude` sessions inherit
+// the cluster's telemetry posture + autonomy defaults. Built from an EXPLICIT
+// allow-list of named keys (never "copy env minus a deny-list"), so a secret
+// can't leak by omission. Deliberately EXCLUDES: secret-bearing env keys
+// (AIRTABLE/SHADCN/*_TOKEN/*_KEY), OTEL_RESOURCE_ATTRIBUTES (per-host —
+// synthesized at merge), OTEL_EXPORTER_OTLP_ENDPOINT (carried via
+// otlpEndpointHint), and absolute laptop paths.
+const CLAUDE_ENV_ALLOW = [
+  "CLAUDE_CODE_ENABLE_TELEMETRY",
+  "OTEL_METRICS_EXPORTER",
+  "OTEL_LOGS_EXPORTER",
+  "OTEL_EXPORTER_OTLP_PROTOCOL",
+  "OTEL_METRIC_EXPORT_INTERVAL",
+  "OTEL_LOGS_EXPORT_INTERVAL",
+  "OTEL_SERVICE_NAME",
+];
+const CLAUDE_TOP_ALLOW = ["model", "cleanupPeriodDays", "alwaysThinkingEnabled", "includeCoAuthoredBy"];
+
+function claudeSettingsPath() {
+  return (
+    process.env.CATALYST_CLAUDE_SETTINGS_FILE ||
+    resolve(homedir(), ".claude", "settings.json")
+  );
+}
+
+function extractClaudeSettings() {
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(claudeSettingsPath(), "utf8"));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const out = {};
+  for (const k of CLAUDE_TOP_ALLOW) {
+    if (parsed[k] !== undefined) out[k] = parsed[k];
+  }
+  if (parsed.env && typeof parsed.env === "object") {
+    const env = {};
+    for (const k of CLAUDE_ENV_ALLOW) {
+      if (parsed.env[k] !== undefined) env[k] = parsed.env[k];
+    }
+    if (Object.keys(env).length > 0) out.env = env;
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
 export function assembleJoinBundle() {
   // Pin CATALYST_CONFIG_FILE to the registry repoRoot so the cwd-dependent
   // Layer-1 identity read (layer1Path → <repoRoot>/.catalyst/config.json)
@@ -159,6 +207,10 @@ export function assembleJoinBundle() {
     // map). null when the seed has no monitor block. multiHost-gated by the
     // consumer; deliberately NOT in BUNDLE_REQUIRED_KEYS.
     monitorWebhooks: extractMonitorWebhooks(l2),
+    // CTL-1231: allow-listed, secret-free ~/.claude/settings.json slice (telemetry
+    // posture + autonomy defaults). null when the seed has no settings. Optional
+    // (existence-only) — an older seed degrades gracefully.
+    claudeSettings: extractClaudeSettings(),
   };
 }
 

--- a/plugins/dev/scripts/execution-core/join-bundle.test.mjs
+++ b/plugins/dev/scripts/execution-core/join-bundle.test.mjs
@@ -160,6 +160,41 @@ describe("assembleJoinBundle", () => {
     expect(b.otlpEndpointHint).toBe("http://from-l2:4318");
   });
 
+  // CTL-1284: non-secret webhook wiring (smee channels + per-team webhookId map).
+  test("monitorWebhooks is null when the seed has no monitor block", () => {
+    expect(assembleJoinBundle().monitorWebhooks).toBeNull();
+  });
+
+  test("monitorWebhooks carries non-secret smee channels + per-team webhookId map", () => {
+    writeLayer2({
+      ...LAYER2_FIXTURE,
+      catalyst: {
+        ...LAYER2_FIXTURE.catalyst,
+        monitor: {
+          github: { smeeChannel: "https://smee.io/GH", webhookSecretEnv: "X" },
+          linear: {
+            smeeChannel: "https://smee.io/LIN",
+            ctl: { webhookId: "wh-ctl", smeeChannel: "https://smee.io/LIN", registeredAt: "2026-01-01", resourceTypes: ["Issue"] },
+            adv: { webhookId: "wh-adv" },
+          },
+        },
+      },
+    });
+    const wh = assembleJoinBundle().monitorWebhooks;
+    expect(wh.github).toEqual({ smeeChannel: "https://smee.io/GH" });
+    expect(wh.linear.smeeChannel).toBe("https://smee.io/LIN");
+    expect(wh.linear.ctl).toEqual({
+      webhookId: "wh-ctl",
+      smeeChannel: "https://smee.io/LIN",
+      resourceTypes: ["Issue"],
+    });
+    expect(wh.linear.adv).toEqual({ webhookId: "wh-adv" });
+    // registeredAt is dropped; no secrets ever appear.
+    expect(JSON.stringify(wh)).not.toContain("registeredAt");
+    expect(JSON.stringify(wh)).not.toContain("Secret");
+    expect(JSON.stringify(wh)).not.toContain("secret");
+  });
+
   test("missing layer2 produces null/empty fields without throwing", () => {
     process.env.CATALYST_LAYER2_CONFIG_FILE = join(repoDir, "absent.json");
     const b = assembleJoinBundle();

--- a/plugins/dev/scripts/execution-core/join-bundle.test.mjs
+++ b/plugins/dev/scripts/execution-core/join-bundle.test.mjs
@@ -26,6 +26,8 @@ const BUNDLE_ENVS = [
   // resolved via CATALYST_CLUSTER_DIR — saved/restored so the fixture clone here
   // never leaks into other suites that share the default ~/catalyst path.
   "CATALYST_CLUSTER_DIR",
+  // CTL-1231: claude settings.json path override (extractClaudeSettings).
+  "CATALYST_CLAUDE_SETTINGS_FILE",
 ];
 
 let saved = {};
@@ -193,6 +195,55 @@ describe("assembleJoinBundle", () => {
     expect(JSON.stringify(wh)).not.toContain("registeredAt");
     expect(JSON.stringify(wh)).not.toContain("Secret");
     expect(JSON.stringify(wh)).not.toContain("secret");
+  });
+
+  // CTL-1231: allow-listed, secret-free ~/.claude/settings.json slice. The
+  // extractor reads $HOME/.claude/settings.json, so point HOME at a fixture dir.
+  test("claudeSettings carries allow-listed keys and EXCLUDES secrets/per-host/paths", () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "jb-home-"));
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    const settingsFile = join(fakeHome, ".claude", "settings.json");
+    writeFileSync(
+      settingsFile,
+      JSON.stringify({
+        model: "claude-opus-4-8",
+        cleanupPeriodDays: 30,
+        alwaysThinkingEnabled: true,
+        env: {
+          CLAUDE_CODE_ENABLE_TELEMETRY: "1",
+          OTEL_METRICS_EXPORTER: "otlp",
+          OTEL_SERVICE_NAME: "catalyst",
+          // these MUST be excluded:
+          AIRTABLE_API_KEY: "secret-airtable",
+          SHADCN_TOKEN: "secret-shadcn",
+          OTEL_RESOURCE_ATTRIBUTES: "host.name=laptop",
+          OTEL_EXPORTER_OTLP_ENDPOINT: "http://laptop:4317",
+          GITHUB_SOURCE_ROOT: "/Users/laptop/code",
+        },
+      }),
+    );
+    const savedSettings = process.env.CATALYST_CLAUDE_SETTINGS_FILE;
+    process.env.CATALYST_CLAUDE_SETTINGS_FILE = settingsFile;
+    try {
+      const cs = assembleJoinBundle().claudeSettings;
+      expect(cs.model).toBe("claude-opus-4-8");
+      expect(cs.cleanupPeriodDays).toBe(30);
+      expect(cs.alwaysThinkingEnabled).toBe(true);
+      expect(cs.env.CLAUDE_CODE_ENABLE_TELEMETRY).toBe("1");
+      expect(cs.env.OTEL_SERVICE_NAME).toBe("catalyst");
+      // exclusions — none of these may appear anywhere in the slice
+      const blob = JSON.stringify(cs);
+      expect(blob).not.toContain("secret-airtable");
+      expect(blob).not.toContain("secret-shadcn");
+      expect(blob).not.toContain("AIRTABLE_API_KEY");
+      expect(blob).not.toContain("OTEL_RESOURCE_ATTRIBUTES");
+      expect(blob).not.toContain("OTEL_EXPORTER_OTLP_ENDPOINT");
+      expect(blob).not.toContain("GITHUB_SOURCE_ROOT");
+    } finally {
+      if (savedSettings === undefined) delete process.env.CATALYST_CLAUDE_SETTINGS_FILE;
+      else process.env.CATALYST_CLAUDE_SETTINGS_FILE = savedSettings;
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
   });
 
   test("missing layer2 produces null/empty fields without throwing", () => {


### PR DESCRIPTION
## CTL-1292 — member-node full-provisioning (sequenced, 4 surfaces)

`catalyst-join` provisioned a member to a state that **boots clean** (doctor passes, HRW `owns N`) but **stranded silently** in four independent ways — every surface a member needs to *operate* was treated as node-local and left unset, and the doctor's 6 read-only suites asserted nothing about operational readiness. This makes join reproduce the seed's *operating* state, not just its identity, and makes `doctor` fail **loudly** when it can't.

Four fixes land **in order on one branch** (they all edit `merge_shared_config` + `doctor.mjs defaultChecks` + `join-bundle.mjs`, so parallel PRs would collide). The recurring spine per surface: **extend bundle → provision in `merge_shared_config` → add a daemon-context doctor FAIL**.

| Commit | Ticket | Fix |
|---|---|---|
| `cc552372` | **CTL-1289** daemon PATH | `_stack_agent_path()` (+`cmd_start`) include `~/.local/{bin,node/bin}` where a member's linearis/node/claude live; the daemon shelled out to these every tick → exit-127 silent strand. `checkDaemonToolPath` reads the **plist** PATH (not `process.env`) + smoke-probes for exit-127. |
| `57018bf2` | **CTL-1284** webhooks | Bundle carries non-secret `monitorWebhooks` (smee channels + per-team `webhookId` map; HMAC secrets stay on the SOPS path). `merge_shared_config` writes `catalyst.monitor.*` **only when roster > 1** — single-host ingestion would double-dispatch (HRW no-op + claimDispatch skipped). `checkWebhookIngestion`. |
| `cf937db5` | **CTL-1293** thoughts | Member push-auth failure is now **fatal when roster > 1** (a worker that can't push thoughts strands research/learnings/handoffs); single-host still warn-proceeds. `checkThoughts` FAILs on a foreign primary (groundworkapp/rightsite-cloud pollution guard), empty `repoMappings`, or a missing clone. |
| `afb04e8c` | **CTL-1231** settings.json | Bundle carries an **allow-listed, secret-free** `claudeSettings` slice. `provision_claude_settings` synthesizes per-host `OTEL_RESOURCE_ATTRIBUTES=host.name=<self>` (never the seed's) and writes the OTLP endpoint into `execution-core.env` so the daemon + bg-workers export telemetry. `checkClaudeSettings`. |

### Doctor operational-readiness gate
`defaultChecks` grows **6 → 10**. Each new suite runs in (a model of) the daemon's PATH/runtime context — not the join shell's enriched env — and **FAILs** (not WARNs) so `do_doctor_gate` fail-closes. The three config-dependent checks (webhooks/thoughts/settings) are **multiHost-gated**: PASS on a single-host node (and in clean-scratch / CI, which have no member state), FAIL only for a real member. `checkDaemonToolPath` WARNs when no plist is installed.

### Two load-bearing safety invariants
- **multiHost gate** on webhook provisioning (CTL-1284) — prevents single-host double-dispatch.
- **groundworkapp guard** on thoughts (CTL-1293) — prevents polluting a foreign repo.

### Tests
- `doctor.test.mjs`: +18 unit tests across the 4 new check functions (all injectable, env-isolated).
- `join-bundle.test.mjs`: bundle extractors carry non-secret wiring only (webhook `registeredAt`/secrets dropped; settings secrets/per-host/paths excluded).
- `catalyst-join.test.sh`: T2.8/T2.9 (webhook multiHost gate), T2.10/T2.11 (thoughts fatal-on-member), T2.12 (settings per-host OTEL + daemon OTLP endpoint).
- `catalyst-stack.test.sh`: plist PATH includes the member prefix, retains homebrew/system (seed no-regression).
- Full execution-core suite: **zero new failures** vs `main` (the 16 pre-existing failures are environment-sensitive hostname tests + flaky scheduler storm repros — identical set on both).

### Not in this PR (Phase 5 — acceptance gate)
Clean-room re-provision of **mini-2** (NEVER mini) off the fixed installer, with no manual fixups: reconcile warms, an HRW-owned ticket walks the pipeline to merge, a webhook is ingested, and a thought syncs to a peer. The mini-2 runtime stopgaps stay in place until this lands (a fresh re-provision drops them, which is exactly what validates the fix).

Research + plan: `thoughts/shared/research/2026-06-19_ctl-128*.md` + `thoughts/shared/plans/2026-06-19_ctl-1292_member-provisioning.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)