### PR TITLE
docs(meta): fix wrong install/cluster instructions + stale stack claims

### DIFF
--- a/website/src/content/docs/getting-started/how-catalyst-works.md
+++ b/website/src/content/docs/getting-started/how-catalyst-works.md
@@ -21,7 +21,7 @@ Set the ticket's priority (Urgent, High, Medium, or Low) and drag it to your **T
 
 ### 3. Catalyst picks it up on its own
 
-You don't run a command. The executor sees the ticket and starts — within seconds, or on its next check (about every 10 minutes). It moves the ticket to **Triage**, sizes it up as small, medium, large, or epic, and posts that estimate as a comment on the ticket. Large and epic tickets automatically get a stronger model and more thinking time during planning.
+You don't run a command. The executor sees the ticket and starts — within seconds, or on its next check (about every 10 minutes). It moves the card into your **in-progress** lane, sizes it up as small, medium, large, or epic, and posts that estimate as a comment on the ticket. Large and epic tickets automatically get a stronger model and more thinking time during planning. (Which lane the card lands in follows your Linear workflow — a separate Triage column only appears if you map one in your `stateMap`.)
 
 ### 4. Watch it ship
 

--- a/website/src/content/docs/getting-started/how-catalyst-works.md
+++ b/website/src/content/docs/getting-started/how-catalyst-works.md
@@ -21,7 +21,7 @@ Set the ticket's priority (Urgent, High, Medium, or Low) and drag it to your **T
 
 ### 3. Catalyst picks it up on its own
 
-You don't run a command. The executor sees the ticket and starts — within seconds, or on its next check (about every 10 minutes). It moves the card into your **in-progress** lane, sizes it up as small, medium, large, or epic, and posts that estimate as a comment on the ticket. Large and epic tickets automatically get a stronger model and more thinking time during planning. (Which lane the card lands in follows your Linear workflow — a separate Triage column only appears if you map one in your `stateMap`.)
+You don't run a command. The executor sees the ticket and starts — within seconds, or on its next check (about every 10 minutes). It moves the ticket to **Triage**, sizes it up as small, medium, large, or epic, and posts that estimate as a comment on the ticket. Large and epic tickets automatically get a stronger model and more thinking time during planning.
 
 ### 4. Watch it ship
 

--- a/website/src/content/docs/getting-started/index.md
+++ b/website/src/content/docs/getting-started/index.md
@@ -62,7 +62,7 @@ catalyst-events help
 
 ## 4. Start the stack
 
-Bring the three core Catalyst services up in dependency order (broker → monitor → execution-core), plus the opt-in mitmproxy capture service if you pass `--proxy`:
+Bring the three core Catalyst services up in dependency order (monitor → broker → execution-core), plus the opt-in mitmproxy capture service if you pass `--proxy`:
 
 ```bash
 catalyst-stack start

--- a/website/src/content/docs/getting-started/reboot-and-updates.md
+++ b/website/src/content/docs/getting-started/reboot-and-updates.md
@@ -34,7 +34,10 @@ it. The agent runs `catalyst-stack start` at login (`RunAtLoad`) and again every
 10 minutes as an idempotent keep-alive — because `start` is ordered
 (monitor → broker → execution-core) and no-ops a running daemon, it never
 double-starts and it self-heals a daemon that crashed between intervals. Output
-goes to `~/catalyst/stack-launchd.log`.
+goes to `~/catalyst/stack-launchd.log`. (`install-services` also installs two
+companion agents — `catalyst-thoughts-sync`, which keeps your thoughts checkouts
+fresh, and `catalyst-log-shipper` — so `services-status` lists three agents; see
+the [catalyst-stack reference](/reference/catalyst-stack/).)
 
 ```bash
 catalyst-stack install-services --interval 300   # change the keep-alive cadence (seconds)
@@ -77,8 +80,8 @@ The script **refuses** to register a linked git worktree or a checkout on any
 branch other than `main` — the plugin source must be pristine so the unattended
 ff-only auto-pull always succeeds.
 
-Keep it fresh with `catalyst-stack hotpatch` (below) — and, once it ships, the
-broker auto-refreshes it on every merge to `main`. `catalyst-stack parity`
+Keep it fresh with `catalyst-stack hotpatch` (below) — and the broker
+auto-refreshes it on every merge to `main` (ff-only pull). `catalyst-stack parity`
 flags it as drift if the checkout ever ends up off `main` or becomes a linked
 worktree.
 

--- a/website/src/content/docs/reference/catalyst-stack.md
+++ b/website/src/content/docs/reference/catalyst-stack.md
@@ -1,20 +1,24 @@
 ---
 title: catalyst-stack
-description: Reference for the catalyst-stack CLI — start, stop, restart, and hotpatch the four Catalyst services.
+description: Reference for the catalyst-stack CLI — start, stop, restart, and hotpatch the Catalyst service stack.
 sidebar:
   order: 10
 ---
 
-`catalyst-stack` is the canonical command for bringing the Catalyst service stack up and down. It starts the four services in dependency order and is idempotent — already-running services are left alone.
+`catalyst-stack` is the canonical command for bringing the Catalyst service stack up and down. It starts the services in dependency order and is idempotent — already-running services are left alone.
 
 ## Dependency order
 
 | Start order | Stop order |
 |-------------|------------|
-| mitmproxy (opt-in, `--proxy` only) | execution-core |
-| broker | monitor |
-| monitor | broker |
-| execution-core | mitmproxy |
+| mitmproxy (opt-in, `--proxy` only) | log-shipper |
+| monitor | execution-core |
+| broker | otel-forward |
+| execution-core | monitor |
+| otel-forward | broker |
+| log-shipper | mitmproxy |
+
+The core daemons start **monitor → broker → execution-core** (CTL-1084 known-good order; the daemon always comes up last), followed by `otel-forward` and the `log-shipper`. Once `install-services` is run, the log-shipper is supervised by its own launchd `KeepAlive` agent (see below), so `catalyst-stack` defers to launchd for it.
 
 ## Subcommands
 
@@ -24,9 +28,9 @@ sidebar:
 | `stop` | Stop all services in reverse order. |
 | `restart` | Stop then start. Accepts the same flags as `start`. |
 | `status` | Print running/stopped state for each service. |
-| `install-services` | Install a launchd LaunchAgent that auto-starts the stack on boot. macOS only. |
-| `uninstall-services` | Unload and remove the auto-start LaunchAgent (leaves running daemons up). |
-| `services-status` | Show whether the auto-start LaunchAgent is installed and loaded. |
+| `install-services` | Install the launchd LaunchAgents (stack keep-alive, thoughts-sync, log-shipper) that auto-start on boot. macOS only. |
+| `uninstall-services` | Unload and remove the auto-start LaunchAgents (leaves running daemons up). |
+| `services-status` | Show whether the auto-start LaunchAgents are installed and loaded. |
 
 ## Flags
 
@@ -86,18 +90,23 @@ plugins/dev/scripts/setup-plugin-source.sh [--path DIR] [--repo-url URL] [--forc
 
 ### `install-services` / `uninstall-services` / `services-status`
 
-Auto-start the stack on boot via a single launchd LaunchAgent
-(`ai.coalesce.catalyst-stack`), so a reboot never leaves the fleet down.
+Auto-start the stack on boot via **three** launchd LaunchAgents — the stack keep-alive
+(`ai.coalesce.catalyst-stack`), the thoughts-sync agent
+(`ai.coalesce.catalyst-thoughts-sync`, which fast-forwards your thoughts checkouts so
+research agents read fresh peer state), and the log-shipper
+(`ai.coalesce.catalyst-log-shipper`, which supervises Grafana Alloy with `KeepAlive`) —
+so a reboot never leaves the fleet down.
 
 ```bash
-catalyst-stack install-services                 # write + load the agent
-catalyst-stack install-services --interval 300  # keep-alive cadence in seconds (default 600)
-catalyst-stack install-services --print         # print the plist to stdout, install nothing
-catalyst-stack services-status                  # installed? loaded?
-catalyst-stack uninstall-services               # unload + remove (running daemons stay up)
+catalyst-stack install-services                     # write + load all three agents
+catalyst-stack install-services --interval 300      # stack keep-alive cadence, seconds (default 600)
+catalyst-stack install-services --sync-interval 120 # thoughts-sync cadence, seconds (default 300)
+catalyst-stack install-services --print             # print the plists to stdout, install nothing
+catalyst-stack services-status                      # installed? loaded?
+catalyst-stack uninstall-services                   # unload + remove all three (running daemons stay up)
 ```
 
-The agent runs `catalyst-stack start` at login (`RunAtLoad`) and every `--interval`
+The stack agent runs `catalyst-stack start` at login (`RunAtLoad`) and every `--interval`
 seconds. Because `start` is ordered (monitor → broker → execution-core) and no-ops a
 running service, the agent never double-starts and self-heals a daemon that died
 between intervals. It is a **per-user LaunchAgent** (the stack runs as you, with

--- a/website/src/content/docs/reference/cluster-config-mirror.md
+++ b/website/src/content/docs/reference/cluster-config-mirror.md
@@ -22,23 +22,25 @@ see the [configuration reference](/reference/configuration/).
 
 When you provision a second node, copy everything marked **SHARED** verbatim and regenerate
 everything marked **PER-NODE**. The classification is encoded in
-[`config.mjs:174-185`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/config.mjs#L174-L185)
-(`getHostName`, PER-NODE),
-[`config.mjs:192-204`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/config.mjs#L192-L204)
-(`getClusterHosts`, SHARED), and
-[`config.mjs:221-238`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/config.mjs#L221-L238)
-(`getLivenessAnchorIssue`, SHARED).
+[`config.mjs` `getHostName`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/config.mjs#L199-L212)
+(PER-NODE),
+[`config.mjs` `resolveClusterHosts`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/config.mjs#L278-L302)
+(the roster — SHARED, resolved live from the `catalyst-cluster` repo via
+[`readClusterConfig`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/config.mjs#L183)),
+and
+[`config.mjs` `getLivenessAnchorIssue`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/config.mjs#L335-L348)
+(SHARED).
 
 | Config item | File / key | Class | On mirror |
 |---|---|---|---|
 | Bot OAuth orchestrator token | `~/.config/catalyst/config.json` → `catalyst.linear.bot.orchestrator.*` | **SHARED** | Copy the whole `catalyst.linear.bot` block (one Linear app per workspace; identical across nodes) |
 | Bot OAuth worker token | `~/.config/catalyst/config.json` → `catalyst.linear.bot.worker.*` | **SHARED** | Same block — worker and orchestrator tokens are workspace-scoped, not host-scoped |
-| Cluster roster | `.catalyst/hosts.json` | **SHARED** | Committed to git; add the new node's name and push |
+| Cluster roster | `catalyst-cluster` repo → `cluster.json` `roster[]` | **SHARED** | Add the new node's name to `cluster.json.roster` and push. `cluster-sync` pulls it and the next scheduler tick honors it — no restart. *(The legacy committed `.catalyst/hosts.json` roster was retired in CTL-1274; the daemon no longer reads it.)* |
 | Layer-1 project config | `.catalyst/config.json` | **SHARED** | Committed to git; present after `git clone` |
 | Liveness anchor issue | `~/.config/catalyst/config.json` → `catalyst.cluster.livenessAnchorIssue` | **SHARED** | Copy from the seed node; one Linear ticket identifier per fleet |
 | Plugin source | `~/catalyst/plugin-source/` | **SHARED** | Pull from the same git remote; `setup-plugin-source.sh` does this |
 | Linear team/state map | Layer-1 `catalyst.linear.teamKey` / `stateMap` | **SHARED** | Present after `git clone` via `.catalyst/config.json` |
-| `catalyst.host.name` | `~/.config/catalyst/config.json` → `catalyst.host.name` | **PER-NODE** | Set to the new node's unique roster entry (must match an entry in `hosts.json`) |
+| `catalyst.host.name` | `~/.config/catalyst/config.json` → `catalyst.host.name` | **PER-NODE** | Set to the new node's unique roster entry (must match an entry in the `catalyst-cluster` repo's `cluster.json.roster`; a name that isn't in the roster owns zero tickets under HRW) |
 | `repoRoot` | `~/catalyst/execution-core/registry.json` → `repoRoot` | **PER-NODE** | The absolute path on the new host; written by `catalyst-execution-core register` |
 | Claude Code account login | macOS Keychain or `~/.claude/.credentials.json` | **PER-NODE** | Run `claude` interactively on the new host; each node uses its own account |
 | OTel endpoints | `~/.config/catalyst/config.json` → OTel keys | **PER-NODE** | Tailscale addresses differ per node; set in Layer-2 on each host |

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -122,7 +122,7 @@ For `execution-core` mode, the number of workers comes from a separate committed
 
 ### Which tickets the daemon picks up
 
-In `execution-core` mode, the daemon reads a central registry at `~/catalyst/execution-core/registry.json`. Each project there has an `eligibleQuery` that says which tickets are ready — for example, `status: "Ready"`. The setup tool `setup-execution-core-states.sh` writes this for you; you don't edit it by hand. That mode also needs six Linear states to exist — `Ready`, `Research`, `Plan`, `Implement`, `Validate`, and `PR` — which the same tool creates.
+In `execution-core` mode, the daemon reads a central registry at `~/catalyst/execution-core/registry.json`. Each project there has an `eligibleQuery` that says which tickets the daemon should pick up — `status: "Todo"`. The setup tool `setup-execution-core-states.sh` writes this for you; you don't edit it by hand. That mode also relies on the pipeline states — `Research`, `Plan`, `Implement`, `Validate`, and `PR` — which the same tool creates on top of the `Todo` and `Triage` states your team workflow already has.
 
 If the registry is missing (a fresh or headless host), enroll a project with
 `catalyst-execution-core register --team <TEAM> --repo-root <path>` rather than writing the


### PR DESCRIPTION
## Docs correctness pass (first-time-user focus)

A 5-agent fan-out review of the user docs (report: `thoughts/shared/research/2026-06-20_docs-review-install-join.md`, 37 findings) surfaced places where a **first-time user follows a flat-wrong instruction**. This PR fixes the **must-fix correctness** items and the **stale "shipped" claims**. The multi-node join rewrite is intentionally **held until PR #2286 (CTL-1292) merges**; the new-page/structure adds are a separate follow-up.

### 🔴 Correctness — a user would hit a wrong instruction today
| Doc | Was | Now |
|---|---|---|
| `reference/cluster-config-mirror.md` | roster in committed `.catalyst/hosts.json`; `host.name` matches it | catalyst-cluster repo's `cluster.json.roster` (hosts.json **retired**, CTL-1274). The old text silently strands a node owning 0 tickets. Also refreshed stale `config.mjs` anchors. |
| `getting-started/index.md` | start order `broker → monitor → execution-core` | `monitor → broker → execution-core` |
| `reference/configuration.md` | eligible state `"Ready"` | `"Todo"`; pipeline states created on top of Todo + Triage |

> **Note:** an earlier revision of this PR also reworded "moves the ticket to Triage" in `how-catalyst-works.md` — that was **reverted**. The original is correct: `setup-execution-core-states.sh` rewrites the stateMap with `triage → Triage` (after `setup-catalyst.sh`'s intermediate map), so an execution-core node really does move the card to the Triage column.

### Stale "shipped" claims (erode trust)
- **`catalyst-stack.md`** — `install-services` installs **3 launchd agents** (stack + thoughts-sync + log-shipper), not one; corrected the dependency-order table (`monitor → broker → execution-core → otel-forward → log-shipper`), documented `--sync-interval`, dropped the brittle "four services" count.
- **`reboot-and-updates.md`** — noted the two companion agents; broker plugin-source auto-pull has shipped (dropped the "once it ships" hedge).

### Verification
`astro build` passes — 330 pages, no errors.

### Held for follow-up (not in this PR)
- Multi-node **join** documentation as one-command-clean → **waits for PR #2286** (today's released join still half-provisions a member).
- Adds: a "run `catalyst doctor` to verify" step (the word "doctor" is in zero docs today), a first-run troubleshooting block, a concrete first-ticket walkthrough; moving cluster/join content off the newcomer "Start Here" path to an advanced reference page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)