### PR TITLE
fix(dev): restore export on getCatalystRepoDir — daemon boot broken fleet-wide

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -161,7 +161,10 @@ export function getLayer2ConfigPath() {
 // CATALYST_CONFIG_FILE points at <repoRoot>/.catalyst/config.json (mirrors the
 // reaper-config resolution in daemon.mjs main()); otherwise fall back to the
 // daemon's cwd. Re-resolved per call so tests can redirect via the env var.
-function getCatalystRepoDir() {
+// CTL-1093 (#1927) added a named import of this in daemon.mjs but landed without
+// the `export`, breaking daemon boot fleet-wide ("Export named 'getCatalystRepoDir'
+// not found"). Export restored so the import resolves.
+export function getCatalystRepoDir() {
   const cfgFile = process.env.CATALYST_CONFIG_FILE;
   if (cfgFile) {
     // <repoRoot>/.catalyst/config.json → <repoRoot>/.catalyst


### PR DESCRIPTION
## Problem

**main is currently un-bootable.** #1927 (CTL-1093, a stale out-of-order merge) added a named import of `getCatalystRepoDir` to `daemon.mjs:50` but left `config.mjs` with the function module-private (no `export`). Every execution-core daemon boot now fails:

```
SyntaxError: Export named 'getCatalystRepoDir' not found in module .../config.mjs
```

No node can (re)start on `main`. The fleet is alive only because the running daemons hold pre-#1927 code in memory; any restart kills them, and the broker auto-pull keeps `plugin-source` pinned to this broken main.

## Fix

Add the missing `export` to `getCatalystRepoDir` in `config.mjs` (one line) so daemon.mjs's import resolves.

## Verification

- `bun -e "import { getCatalystRepoDir } from './config.mjs'"` → resolves to a function.
- `bun build ./daemon.mjs` → all imports resolve (previously failed).

## Follow-ups (separate)

- CI did not catch a boot-breaking missing export — `execution-core-unit-tests` should fail-fast on a `bun build daemon.mjs` import-resolution check.
- Discovered during the CTL-1174 delegate-gate deploy; a cross-host claim↔HRW orphan (CTL-859/862) is also being tracked separately.