### PR TITLE
feat(dev): CTL-1290 — board-health delegate (shadow-first)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -108,6 +108,7 @@ jobs:
             autotune-lifecycle.test.mjs \
             autotune-writeback.test.mjs \
             board-health.test.mjs \
+            board-health-seam.test.mjs \
             boot-resume-approval.test.mjs \
             boot-resume.test.mjs \
             claim.test.mjs \

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -107,6 +107,7 @@ jobs:
             autotune-decision.test.mjs \
             autotune-lifecycle.test.mjs \
             autotune-writeback.test.mjs \
+            board-health.test.mjs \
             boot-resume-approval.test.mjs \
             boot-resume.test.mjs \
             claim.test.mjs \

--- a/plugins/dev/scripts/execution-core/board-health-seam.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health-seam.test.mjs
@@ -1,0 +1,87 @@
+// board-health-seam.test.mjs — CTL-1290. The THIN scheduler-seam test (§9.4).
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test board-health-seam.test.mjs
+//
+// Lives in its OWN file (not scheduler.test.mjs) so it runs in CI:
+// scheduler.test.mjs is excluded from the CI allowlist for its real-timer /
+// fs.watch "debounced tick" suite. These three cases call schedulerTick ONCE,
+// synchronously, with injected stubs — no timers, no fs.watch — so they are
+// CI-safe. The pass LOGIC is covered by board-health.test.mjs; here we assert
+// ONLY the seam: the hook fires the injected boardHealthPassFn with the in-scope
+// capacity + eligible when the daemon threads `boardHealth`, honors the mode
+// gate, and is INERT on a bare tick (the property that keeps every other
+// schedulerTick test from doing real board-health IO).
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { schedulerTick } from "./scheduler.mjs";
+
+let orchDir;
+let catalystDir;
+let prevCatalystDir;
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "bh-seam-"));
+  prevCatalystDir = process.env.CATALYST_DIR;
+  catalystDir = mkdtempSync(join(tmpdir(), "bh-seam-cat-"));
+  process.env.CATALYST_DIR = catalystDir; // getEventLogPath() resolves under the fixture
+});
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+  rmSync(catalystDir, { recursive: true, force: true });
+});
+
+describe("schedulerTick — board-health seam (CTL-1290 §9.4)", () => {
+  test("threads boardHealth → boardHealthPassFn called once with capacity + eligible", () => {
+    const calls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [{ identifier: "CTL-1" }, { identifier: "CTL-2" }],
+      dispatch: () => ({ code: 0 }),
+      writeStatus: () => {},
+      reclaimDeadWork: () => "noop",
+      concurrency: { maxParallel: 4 },
+      liveBackgroundCount: () => 4, // freeSlots=0 → Pass 2 dispatch is a clean no-op
+      boardHealth: { mode: "shadow" },
+      boardHealthPassFn: (opts) => {
+        calls.push(opts);
+        return { ran: true, ranAtMs: 1 };
+      },
+    });
+    expect(calls.length).toBe(1);
+    const o = calls[0];
+    expect(o.mode).toBe("shadow");
+    expect(o.capacity).toEqual({ maxParallel: 4, liveCount: 4, freeSlots: 0 });
+    expect(o.getEligible().map((e) => e.identifier)).toEqual(["CTL-1", "CTL-2"]);
+    expect(typeof o.getWorkerSignals).toBe("function");
+  });
+
+  test("boardHealth.mode:off → boardHealthPassFn NOT called", () => {
+    const calls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus: () => {},
+      reclaimDeadWork: () => "noop",
+      liveBackgroundCount: () => 0,
+      boardHealth: { mode: "off" },
+      boardHealthPassFn: (opts) => calls.push(opts),
+    });
+    expect(calls.length).toBe(0);
+  });
+
+  test("no boardHealth seam (bare tick) → boardHealthPassFn NOT called (inert)", () => {
+    const calls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus: () => {},
+      reclaimDeadWork: () => "noop",
+      liveBackgroundCount: () => 0,
+      boardHealthPassFn: (opts) => calls.push(opts),
+    });
+    expect(calls.length).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -1,0 +1,584 @@
+// board-health.mjs — CTL-1290. The holistic board-health delegate pass.
+//
+// A read-only, on-cadence scan of the WHOLE board: it evaluates board-level
+// invariants (the wedges that emit NO per-item signal — a silently-held
+// dispatch, a node that stopped participating, a dead blocker chain), runs a
+// cheap-gate funnel, and — SHADOW-FIRST — emits a `recovery.board-scan` event
+// proposing safe Tier-1/2/3 moves WITHOUT acting. This is the daemon-side
+// implementation of the holistic mandate that until now lived ONLY in
+// recovery-pass/SKILL.md (the dispatched delegate got a per-item brief with
+// zero board context). The flagged per-item set is an INPUT, not the gate.
+//
+// LOAD-BEARING SAFETY PROPERTIES (verify by reading this file):
+//   1. PURE core. evaluateInvariants / decideBoardHealth / proposeMoves /
+//      buildBoardContext / buildBoardScanEvent take a normalized boardState and
+//      return data — no IO, no wall-clock, no mutation.
+//   2. INJECTED IO. assembleBoardState + boardHealthPass take EVERY IO dep as a
+//      param, so this module unit-tests with plain stubs AND never imports
+//      bun:sqlite (the board snapshot reader is bound at the scheduler call
+//      site, which already runs under Bun — see MEMORY vite_config_bun_sqlite_trap).
+//   3. SHADOW TAKES ZERO MUTATING ACTION. This module imports NOTHING that can
+//      spawn a process (no child_process, no gh/git, no dispatch). emit() only
+//      appends a JSONL line (observability, not a board mutation). The only
+//      actuation surface is the injected `act` dep — reachable ONLY in enforce,
+//      and the scheduler does NOT pass one in CTL-1290 (actuation is a follow-up).
+//
+// Ships behind CATALYST_BOARD_HEALTH (config.mjs readBoardHealthConfig), default
+// OFF (ADR-023). Operators flip a host to shadow to collect recovery.board-scan
+// telemetry, review it, then a future ticket enables enforce.
+
+import { isThrottled } from "./config.mjs";
+import { defaultEmitEvent } from "./recovery-reasoning.mjs"; // → buildRecoveryEnvelope (CTL-1291 promotes the numbers)
+
+// ── thresholds + cadence (env-tunable, bounded defaults) ─────────────────────
+const DEFAULT_THRESHOLDS = {
+  dispatchStallMs: Number(process.env.CATALYST_BH_DISPATCH_STALL_MS) || 10 * 60_000,
+  workerAgeMs: Number(process.env.CATALYST_BH_WORKER_AGE_MS) || 4 * 3_600_000,
+  projectSilenceMs: Number(process.env.CATALYST_BH_PROJECT_SILENCE_MS) || 24 * 3_600_000,
+};
+
+// single-LLM cadence floor: most ticks are a near-instant no-op (cheap gates),
+// but the LLM-bearing review is bounded to once per interval per host.
+export const BOARD_HEALTH_INTERVAL_MS =
+  Number(process.env.CATALYST_BH_INTERVAL_MS) || 5 * 60_000;
+
+// per-phase "normal" worker age (v1 flat fallback; per-phase p95 is a follow-up).
+const PHASE_NORMAL_MS = {
+  triage: 1 * 3_600_000,
+  research: 1 * 3_600_000,
+  plan: 1 * 3_600_000,
+  implement: 4 * 3_600_000,
+  verify: 2 * 3_600_000,
+  review: 2 * 3_600_000,
+  pr: 2 * 3_600_000,
+  "monitor-merge": 24 * 3_600_000,
+  "monitor-deploy": 24 * 3_600_000,
+};
+
+// statuses that mean "this worker is finished" — excluded from worker-age.
+const TERMINAL_STATUSES = new Set(["complete", "completed", "done", "merged", "skipped"]);
+// linear states a blocker can sit in and still NOT be a dead chain.
+const BLOCKER_DONE_RE = /done|complete|merged|cancel|duplicate/i;
+
+let _lastRunMs = 0; // host-local throttle state (mirrors unstuck-sweep)
+
+// ── small pure helpers ───────────────────────────────────────────────────────
+function invariant(ok, failed, observable, flagged, note, extra = {}) {
+  return { ok, failed, observable, flagged, note, ...extra };
+}
+function emptyMoves() {
+  return { tier1: [], tier2: [], tier3: [] };
+}
+function isTerminalStatus(status) {
+  return status != null && TERMINAL_STATUSES.has(String(status).toLowerCase());
+}
+function dedupeFlagged(invariants) {
+  const seen = new Set();
+  for (const v of Object.values(invariants)) {
+    for (const f of v.flagged ?? []) seen.add(f);
+  }
+  return [...seen];
+}
+
+// extractBlockers — pull blocked_by target ids out of a descriptor's relations,
+// tolerating the several shapes the cache/broker emit (array of relation
+// objects, or a flat {blockedBy:[...]}). Returns [] on anything unparseable —
+// blocked-tree degrades to "no blockers seen", never throws.
+function extractBlockers(descriptor) {
+  if (!descriptor) return [];
+  let rel = descriptor.relations ?? descriptor.blockedBy ?? null;
+  if (typeof rel === "string") {
+    try { rel = JSON.parse(rel); } catch { return []; }
+  }
+  if (!rel) return [];
+  const ids = [];
+  const push = (x) => {
+    if (!x) return;
+    const id = x.identifier ?? x.relatedIssue?.identifier ?? x.ticket ?? (typeof x === "string" ? x : null);
+    if (id) ids.push(id);
+  };
+  if (Array.isArray(rel)) {
+    for (const r of rel) {
+      const t = (r?.type ?? "").toLowerCase();
+      if (t && !/block/.test(t)) continue; // only blocked_by/blocks edges
+      push(r);
+    }
+  } else if (Array.isArray(rel.blockedBy)) {
+    for (const r of rel.blockedBy) push(r);
+  }
+  return ids;
+}
+
+// deriveRing — distill the bounded recent-event tail into the few out-of-band
+// signals the invariants need. Best-effort: an event class that isn't present
+// yields null/empty, and the dependent invariant degrades to observable:false.
+function deriveRing(events, nowMs) {
+  const ring = {
+    recentDispatchTs: null,
+    cacheReconcile: null,
+    accountRatelimit: null,
+    reconcileFailing: new Set(),
+  };
+  for (const ev of events ?? []) {
+    const name = ev?.attributes?.["event.name"] ?? ev?.["event.name"] ?? ev?.type ?? "";
+    const payload = ev?.body?.payload ?? ev?.payload ?? {};
+    const tsMs = ev?.ts ? Date.parse(ev.ts) : NaN;
+    if (/\.dispatch(\.|$)|worker[.-]create|new-work/i.test(name)) {
+      if (Number.isFinite(tsMs)) ring.recentDispatchTs = Math.max(ring.recentDispatchTs ?? 0, tsMs);
+    } else if (/cache\.reconcile/i.test(name)) {
+      ring.cacheReconcile = {
+        changed: payload.changed ?? payload.corrected ?? 0,
+        scanned: payload.scanned ?? null,
+        failed: payload.failed ?? 0,
+        mode: payload.mode ?? null,
+      };
+    } else if (/account\.ratelimit|ratelimit\.sampled/i.test(name)) {
+      ring.accountRatelimit = { nearCliff: !!(payload.nearCliff ?? payload.near_cliff), ...payload };
+    } else if (/reconcile\.failing/i.test(name)) {
+      const team = payload.team ?? name.split(".").pop();
+      if (team) ring.reconcileFailing.add(team);
+    }
+  }
+  // guard against a stale dispatch ts in the future / absurd past
+  if (ring.recentDispatchTs != null && (ring.recentDispatchTs > nowMs + 60_000)) {
+    ring.recentDispatchTs = nowMs;
+  }
+  return ring;
+}
+
+// ── (1) assembleBoardState — the ONE impure reader (reads only, never writes) ─
+export function assembleBoardState({
+  orchDir,
+  getBoard = () => [],
+  getWorkerSignals = () => [],
+  getEligible = () => [],
+  roster = [],
+  self = "",
+  multiHost = false,
+  capacity = { maxParallel: 0, liveCount: 0, freeSlots: 0 },
+  readEventRing = () => [],
+  ownerForTicket = null,
+  getReconcileMarkers = () => ({}),
+  now = () => Date.now(),
+} = {}) {
+  const nowMs = now();
+  const safe = (fn, fallback) => {
+    try {
+      const v = fn();
+      return v == null ? fallback : v;
+    } catch {
+      return fallback;
+    }
+  };
+
+  const ticketsById = new Map();
+  for (const d of safe(() => getBoard(), [])) {
+    if (!d) continue;
+    const id = d.identifier ?? d.ticket ?? d.id;
+    if (id) ticketsById.set(id, d);
+  }
+
+  const signals = safe(() => getWorkerSignals(), []).map((s) => {
+    const updatedAt = s.updatedAt ?? s.updated_at ?? null;
+    const updatedMs = updatedAt ? Date.parse(updatedAt) : NaN;
+    return {
+      ticket: s.ticket ?? s.identifier ?? null,
+      phase: s.phase ?? null,
+      status: s.status ?? null,
+      updatedAt,
+      ageMs: Number.isFinite(updatedMs) ? nowMs - updatedMs : null,
+      host: s.host ?? s.owner_host ?? null,
+    };
+  });
+
+  const eligible = safe(() => getEligible(), []).map((e) => ({
+    id: e.identifier ?? e.id ?? e.ticket ?? null,
+    priority: e.priority ?? null,
+    createdAt: e.createdAt ?? e.created_at ?? null,
+    project: e.project ?? e.projectName ?? null,
+    state: e.state ?? e.linear_state ?? null,
+    updatedAt: e.updatedAt ?? e.updated_at ?? null,
+  }));
+
+  return Object.freeze({
+    ticketsById,
+    signals,
+    eligible,
+    roster: Array.isArray(roster) ? roster : [],
+    self: self ?? "",
+    multiHost: !!multiHost,
+    capacity: {
+      maxParallel: capacity?.maxParallel ?? 0,
+      liveCount: capacity?.liveCount ?? 0,
+      freeSlots: capacity?.freeSlots ?? 0,
+    },
+    reconcileMarkers: safe(() => getReconcileMarkers(), {}),
+    ring: deriveRing(safe(() => readEventRing({ orchDir }), []), nowMs),
+    ownerForTicket: typeof ownerForTicket === "function" ? ownerForTicket : null,
+    now: nowMs,
+  });
+}
+
+// ── (2) evaluateInvariants — PURE. Each check fails-open on a throw. ─────────
+export function evaluateInvariants(boardState, { thresholds = DEFAULT_THRESHOLDS } = {}) {
+  const checks = {
+    cacheCoherence: () => checkCacheCoherence(boardState),
+    dispatchLiveness: () => checkDispatchLiveness(boardState, thresholds),
+    workerAge: () => checkWorkerAge(boardState, thresholds),
+    blockedTree: () => checkBlockedTree(boardState),
+    projectSilence: () => checkProjectSilence(boardState, thresholds),
+    rateLimitHeadroom: () => checkRateLimitHeadroom(boardState),
+    strandedNode: () => checkStrandedNode(boardState),
+  };
+  const out = {};
+  for (const [name, fn] of Object.entries(checks)) {
+    try {
+      out[name] = fn();
+    } catch (err) {
+      // a throwing invariant must never abort the scan — fail open, but record.
+      out[name] = invariant(true, 0, true, [], `check error: ${err.message}`, { error: err.message });
+    }
+  }
+  return out;
+}
+
+// #0 — cache coherence (post-CTL-1288). Trust the broker reconcile summary in
+// the ring; never re-diff Linear inline (the self-constraint: read once, batch).
+function checkCacheCoherence(b) {
+  const cr = b.ring?.cacheReconcile;
+  if (!cr) return invariant(true, 0, false, [], "cache reconcile off/unseen → coherence unknown");
+  const changed = Number(cr.changed) || 0;
+  return invariant(changed === 0, changed > 0 ? 1 : 0, true, [], `last reconcile corrected ${changed} row(s)`);
+}
+
+// #1 — dispatch liveness (the liveness-hold wedge): open slots + a waiting queue
+// + ~no recent dispatch. The single most important silent wedge.
+function checkDispatchLiveness(b, t) {
+  const free = b.capacity.freeSlots;
+  const queued = b.eligible.length;
+  if (free <= 0 || queued <= 0) {
+    return invariant(true, 0, true, [], `no wedge (free=${free}, queued=${queued})`);
+  }
+  const last = b.ring?.recentDispatchTs ?? null;
+  const staleMs = last == null ? null : b.now - last;
+  const wedged = last == null ? true : staleMs > t.dispatchStallMs;
+  return invariant(
+    !wedged,
+    wedged ? 1 : 0,
+    true,
+    wedged ? b.eligible.slice(0, 5).map((e) => e.id).filter(Boolean) : [],
+    wedged
+      ? `${free} free slot(s) + ${queued} queued + ${last == null ? "no recent dispatch seen" : `${Math.round(staleMs / 60_000)}m since dispatch`} → wedge`
+      : "dispatch live",
+  );
+}
+
+// #2 — worker age: a non-terminal worker idling far past its phase normal
+// (the CTL-1186 88h-in-slot class), even if it emits no stuck signal.
+function checkWorkerAge(b, t) {
+  const flagged = [];
+  for (const s of b.signals) {
+    if (!s.ticket || s.ageMs == null) continue;
+    if (isTerminalStatus(s.status)) continue;
+    const limit = PHASE_NORMAL_MS[s.phase] ?? t.workerAgeMs;
+    if (s.ageMs > limit) flagged.push(s.ticket);
+  }
+  return invariant(
+    flagged.length === 0,
+    flagged.length,
+    true,
+    flagged,
+    flagged.length ? `${flagged.length} worker(s) past phase-normal age` : "all workers within normal age",
+  );
+}
+
+// #3 — blocked tree alive: nothing blocked by a blocker that is itself
+// unscheduled (not eligible/in-flight) and not done.
+function checkBlockedTree(b) {
+  const scheduled = new Set([
+    ...b.eligible.map((e) => e.id),
+    ...b.signals.map((s) => s.ticket),
+  ].filter(Boolean));
+  const flagged = [];
+  for (const [id, d] of b.ticketsById) {
+    for (const blockerId of extractBlockers(d)) {
+      const blocker = b.ticketsById.get(blockerId);
+      const blockerState = blocker ? (blocker.state ?? blocker.linear_state ?? null) : null;
+      const blockerDone = blockerState != null && BLOCKER_DONE_RE.test(blockerState);
+      if (!blockerDone && !scheduled.has(blockerId)) {
+        flagged.push(id);
+        break;
+      }
+    }
+  }
+  return invariant(
+    flagged.length === 0,
+    flagged.length,
+    true,
+    flagged,
+    flagged.length ? `${flagged.length} ticket(s) blocked by an unscheduled/stuck blocker` : "blocked tree alive",
+    { caveat: "relations may be stale (cache; reconciled out-of-band)" },
+  );
+}
+
+// #4 — project silence (weakest signal; updatedAt is a movement proxy). Only
+// observable when descriptors carry both project + updatedAt.
+function checkProjectSilence(b, t) {
+  const byProject = new Map(); // project → max updatedMs
+  const consider = (project, updatedAt) => {
+    if (!project || !updatedAt) return;
+    const ms = Date.parse(updatedAt);
+    if (!Number.isFinite(ms)) return;
+    byProject.set(project, Math.max(byProject.get(project) ?? 0, ms));
+  };
+  for (const e of b.eligible) consider(e.project, e.updatedAt);
+  for (const [, d] of b.ticketsById) consider(d.project ?? d.projectName, d.updatedAt ?? d.updated_at);
+  if (byProject.size === 0) {
+    return invariant(true, 0, false, [], "no project/updatedAt join available → not observable");
+  }
+  const flagged = [];
+  for (const [project, lastMs] of byProject) {
+    if (b.now - lastMs > t.projectSilenceMs) flagged.push(project);
+  }
+  return invariant(
+    flagged.length === 0,
+    flagged.length,
+    true,
+    flagged,
+    flagged.length ? `${flagged.length} project(s) silent past cadence` : "all projects moving",
+    { caveat: "updatedAt is a movement proxy" },
+  );
+}
+
+// #5 — rate-limit headroom. Anthropic proxy via the ring; Linear/GitHub have no
+// durable out-of-band 429 signal yet (breaker is in-proc only) → observable:false.
+function checkRateLimitHeadroom(b) {
+  const rl = b.ring?.accountRatelimit;
+  if (!rl) {
+    return invariant(true, 0, false, [], "no out-of-band rate-limit signal (Linear/GitHub breaker in-proc only)");
+  }
+  const near = !!rl.nearCliff;
+  return invariant(!near, near ? 1 : 0, true, [], near ? "near a rate-limit cliff" : "rate-limit headroom ok");
+}
+
+// #6 — stranded node (mini-2 class): a rostered host that HRW-owns a share of
+// the board but whose team reconcile is failing. Cross-host PEER liveness needs
+// the heartbeat/Loki path → only the local-marker form ships now.
+function checkStrandedNode(b) {
+  if (!b.ownerForTicket || b.roster.length === 0) {
+    return invariant(true, 0, false, [], "no roster/HRW → stranded-node not observable");
+  }
+  const ownedByHost = new Map();
+  for (const [id] of b.ticketsById) {
+    let owner;
+    try { owner = b.ownerForTicket(id, b.roster); } catch { owner = null; }
+    if (!owner) continue;
+    ownedByHost.set(owner, (ownedByHost.get(owner) ?? 0) + 1);
+  }
+  const failing = b.ring?.reconcileFailing ?? new Set();
+  const markers = b.reconcileMarkers ?? {};
+  const flagged = [];
+  for (const host of b.roster) {
+    const share = ownedByHost.get(host) ?? 0;
+    if (share <= 0) continue;
+    const markerFail = (markers[host]?.consecutiveFailures ?? 0) > 0;
+    const ringFail = failing.has(host);
+    if (markerFail || ringFail) flagged.push(host);
+  }
+  // observable only if we have SOME reconcile signal to judge against.
+  const haveSignal = Object.keys(markers).length > 0 || failing.size > 0;
+  return invariant(
+    flagged.length === 0,
+    flagged.length,
+    haveSignal,
+    flagged,
+    flagged.length
+      ? `node(s) stranded (own work, reconcile failing): ${flagged.join(", ")}`
+      : haveSignal
+        ? "all rostered nodes participating"
+        : "no reconcile-health signal → peer liveness not observable",
+  );
+}
+
+// ── (3) decideBoardHealth — PURE. The cheap-gate funnel. First match wins. ───
+export function decideBoardHealth(invariants, boardState) {
+  const observableFailed = Object.values(invariants).filter((v) => v.observable && !v.ok);
+  const invariantsFailed = observableFailed.reduce((n, v) => n + (Number(v.failed) || 0), 0);
+
+  // Gate 1 — all observable invariants green → skip (no LLM thrash).
+  if (observableFailed.length === 0) {
+    return decision("skip", "all-green", invariantsFailed, emptyMoves());
+  }
+  // Gate 2 — failures exist but no free slot to dispatch a fix → skip.
+  if ((boardState.capacity?.freeSlots ?? 0) <= 0) {
+    return decision("skip", "no-free-slots", invariantsFailed, emptyMoves());
+  }
+  // Gate 3 — near a rate-limit cliff → acting now risks 429s → skip (and obey it).
+  const rl = invariants.rateLimitHeadroom;
+  if (rl && rl.observable && !rl.ok) {
+    return decision("skip", "rate-limit-cliff", invariantsFailed, emptyMoves());
+  }
+  // Gate 4 — real failures + headroom → proceed; compute proposed moves.
+  return decision("proceed", `${observableFailed.length} invariant(s) flagged`, invariantsFailed, proposeMoves(invariants, boardState));
+}
+
+function decision(gateDecision, reason, invariantsFailed, moves) {
+  return {
+    gate: { decision: gateDecision, reason },
+    invariantsFailed,
+    proposed: { tier1: moves.tier1.length, tier2: moves.tier2.length, tier3: moves.tier3.length },
+    moves,
+  };
+}
+
+// ── (4) proposeMoves — PURE. Maps failed invariants → tiered proposals. Never
+// executes. The tier is "does this change the SYSTEM or just unstick a THING?"
+export function proposeMoves(invariants, b) {
+  const tier1 = [];
+  const tier2 = [];
+  const tier3 = [];
+  if (invariants.dispatchLiveness && !invariants.dispatchLiveness.ok) {
+    tier1.push({ move: "kick-dispatch", rationale: invariants.dispatchLiveness.note });
+  }
+  for (const t of invariants.workerAge?.flagged ?? []) {
+    if (!invariants.workerAge.ok) tier1.push({ ticket: t, move: "nudge", rationale: "worker past phase-normal age" });
+  }
+  if (invariants.cacheCoherence && invariants.cacheCoherence.observable && !invariants.cacheCoherence.ok) {
+    tier1.push({ move: "note-cache-drift", rationale: invariants.cacheCoherence.note });
+  }
+  for (const t of invariants.blockedTree?.flagged ?? []) {
+    if (!invariants.blockedTree.ok) tier2.push({ ticket: t, move: "re-dispatch-blocker", rationale: "blocked by unscheduled/stuck blocker" });
+  }
+  for (const h of invariants.strandedNode?.flagged ?? []) {
+    if (!invariants.strandedNode.ok) tier3.push({ host: h, move: "escalate-stranded-node", rationale: "rostered node owns work but reconcile is failing" });
+  }
+  for (const p of invariants.projectSilence?.flagged ?? []) {
+    if (!invariants.projectSilence.ok) tier3.push({ project: p, move: "escalate-project-silence", rationale: "no movement in expected cadence" });
+  }
+  return { tier1, tier2, tier3 };
+}
+
+// ── (5) buildBoardContext — PURE. The whole-board brief the dispatched delegate
+// gets injected into recovery-pass.json (today it gets NONE).
+export function buildBoardContext(boardState, invariants) {
+  const stuckWorkers = (invariants.workerAge?.flagged ?? []).map((t) => {
+    const s = boardState.signals.find((x) => x.ticket === t);
+    return {
+      ticket: t,
+      phase: s?.phase ?? null,
+      status: s?.status ?? null,
+      ageSeconds: s?.ageMs != null ? Math.round(s.ageMs / 1000) : null,
+    };
+  });
+  return {
+    schema: "recovery-board-context/v1",
+    snapshotAt: new Date(boardState.now).toISOString(),
+    host: { self: boardState.self, roster: boardState.roster, multiHost: boardState.multiHost },
+    slots: {
+      capacity: boardState.capacity.maxParallel,
+      inUse: boardState.capacity.liveCount,
+      free: boardState.capacity.freeSlots,
+    },
+    eligibleQueue: {
+      depth: boardState.eligible.length,
+      topTickets: boardState.eligible.slice(0, 5).map((e) => e.id).filter(Boolean),
+    },
+    stuckWorkers,
+    strandedNodes: (invariants.strandedNode?.flagged ?? []).map((h) => ({ host: h })),
+    invariants: Object.fromEntries(
+      Object.entries(invariants).map(([k, v]) => [k, { ok: v.ok, failed: v.failed }]),
+    ),
+  };
+}
+
+// ── (6) buildBoardScanEvent — PURE. The flat event reused through the CTL-1287
+// emit envelope. Scalars at the top of details (CTL-1291 promotes them to
+// chartable attributes); rosters/move arrays stay in details → body.payload.
+export function buildBoardScanEvent({ mode, invariants, decision }) {
+  const totalMoves = decision.proposed.tier1 + decision.proposed.tier2 + decision.proposed.tier3;
+  return {
+    type: "recovery.board-scan",
+    ticket: null, // board/fleet-scoped → event.label:null; the board reader ignores it (correct)
+    fix_class: null,
+    reason:
+      `board-health scan (${mode}): ${decision.invariantsFailed} invariant(s) flagged, ` +
+      `gate=${decision.gate.decision}, ${totalMoves} move(s) proposed`,
+    details: {
+      mode,
+      // ── chartable scalars (CTL-1291 promoteNumericAttrs) ──
+      invariantsFailed: decision.invariantsFailed,
+      gateDecision: decision.gate.decision,
+      gateReason: decision.gate.reason,
+      proposedTier1: decision.proposed.tier1,
+      proposedTier2: decision.proposed.tier2,
+      proposedTier3: decision.proposed.tier3,
+      invariants: Object.fromEntries(
+        Object.entries(invariants).map(([k, v]) => [k, { ok: v.ok, failed: v.failed, observable: v.observable }]),
+      ),
+      // ── rosters/proposals: stay in body.payload, NEVER promoted (cardinality) ──
+      flagged: dedupeFlagged(invariants),
+      tier1Moves: decision.moves.tier1,
+      tier2Moves: decision.moves.tier2,
+      tier3Moves: decision.moves.tier3,
+    },
+  };
+}
+
+// ── (7) boardHealthPass — the single scheduler entry. The ONE place mode branches.
+export function boardHealthPass({
+  mode,
+  orchDir,
+  getBoard,
+  getWorkerSignals,
+  getEligible,
+  roster,
+  self,
+  multiHost,
+  capacity,
+  readEventRing,
+  ownerForTicket,
+  getReconcileMarkers,
+  lastRunMs = _lastRunMs,
+  intervalMs = BOARD_HEALTH_INTERVAL_MS,
+  isThrottledFn = isThrottled,
+  emit = defaultEmitEvent,
+  act = undefined, // ONLY reachable in enforce; the scheduler passes NOTHING in CTL-1290
+  now = () => Date.now(),
+  log = () => {},
+} = {}) {
+  if (mode === "off") return { ran: false, reason: "off" }; // strict no-op
+  const nowMs = now();
+  if (isThrottledFn(lastRunMs, intervalMs, nowMs)) {
+    return { ran: false, reason: "throttled" }; // no emit, no act
+  }
+
+  const board = assembleBoardState({
+    orchDir, getBoard, getWorkerSignals, getEligible,
+    roster, self, multiHost, capacity, readEventRing, ownerForTicket, getReconcileMarkers, now,
+  });
+  const invariants = evaluateInvariants(board, {});
+  const dec = decideBoardHealth(invariants, board);
+
+  try {
+    emit(buildBoardScanEvent({ mode, invariants, decision: dec })); // shadow AND enforce
+  } catch (err) {
+    log({ err: err.message }, "board-health: emit failed (continuing)");
+  }
+
+  // enforce-ONLY actuation, and only if a caller injected an `act` seam. The
+  // scheduler does NOT in CTL-1290 → enforce is inert here. Guard kept so a
+  // future ticket can wire it without re-touching the safety structure.
+  if (mode === "enforce" && typeof act === "function" && dec.gate.decision === "proceed") {
+    for (const move of [...dec.moves.tier1, ...dec.moves.tier2, ...dec.moves.tier3]) {
+      if (multiHost && move.ticket && board.ownerForTicket) {
+        let owner;
+        try { owner = board.ownerForTicket(move.ticket, board.roster); } catch { owner = null; }
+        if (owner && owner !== board.self) continue; // HRW gate — don't act on another host's item
+      }
+      try { act(move, board); } catch (err) { log({ err: err.message, move }, "board-health: act failed (continuing)"); }
+    }
+  }
+
+  _lastRunMs = nowMs;
+  return { ran: true, mode, ranAtMs: nowMs, invariants, decision: dec };
+}

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -17,15 +17,19 @@
 //      param, so this module unit-tests with plain stubs AND never imports
 //      bun:sqlite (the board snapshot reader is bound at the scheduler call
 //      site, which already runs under Bun — see MEMORY vite_config_bun_sqlite_trap).
-//   3. SHADOW TAKES ZERO MUTATING ACTION. This module imports NOTHING that can
-//      spawn a process (no child_process, no gh/git, no dispatch). emit() only
-//      appends a JSONL line (observability, not a board mutation). The only
-//      actuation surface is the injected `act` dep — reachable ONLY in enforce,
-//      and the scheduler does NOT pass one in CTL-1290 (actuation is a follow-up).
+//   3. SHADOW TAKES ZERO MUTATING ACTION. In the shadow path this module performs
+//      NO process spawning and NO board mutation: its only side effect is emit(),
+//      which appends a single JSONL line (observability, not a mutation). It does
+//      not import child_process / gh / git / dispatch directly; the one symbol it
+//      pulls from recovery-reasoning.mjs (defaultEmitEvent) is append-only on this
+//      path (the spawn-bearing recovery helpers there are never reached from here).
+//      The only actuation surface is the injected `act` dep — reachable ONLY in
+//      enforce, and the scheduler passes none in CTL-1290 (actuation is a follow-up).
 //
 // Ships behind CATALYST_BOARD_HEALTH (config.mjs readBoardHealthConfig), default
-// OFF (ADR-023). Operators flip a host to shadow to collect recovery.board-scan
-// telemetry, review it, then a future ticket enables enforce.
+// SHADOW (the deliberate ADR-023 deviation — shadow emits one recovery.board-scan
+// heartbeat per cadence and mutates nothing). CATALYST_BOARD_HEALTH=0/off is the
+// kill-switch; a future ticket wires enforce.
 
 import { isThrottled } from "./config.mjs";
 import { defaultEmitEvent } from "./recovery-reasoning.mjs"; // → buildRecoveryEnvelope (CTL-1291 promotes the numbers)
@@ -123,7 +127,12 @@ function deriveRing(events, nowMs) {
     const name = ev?.attributes?.["event.name"] ?? ev?.["event.name"] ?? ev?.type ?? "";
     const payload = ev?.body?.payload ?? ev?.payload ?? {};
     const tsMs = ev?.ts ? Date.parse(ev.ts) : NaN;
-    if (/\.dispatch(\.|$)|worker[.-]create|new-work/i.test(name)) {
+    // Only dispatch SUCCESS signals count as "the dispatcher is alive". A failing
+    // loop (phase.dispatch.{failed,escalated,runaway}) must NOT clear the silent-
+    // hold wedge — those are the LOUD failure modes other guards catch (circuit
+    // breaker, runaway alert); counting them here would green the invariant exactly
+    // when dispatch is broken. requested|launched = the scheduler actually acting.
+    if (/\.dispatch\.(requested|launched)(\.|$)|worker[.-]create|new-work/i.test(name)) {
       if (Number.isFinite(tsMs)) ring.recentDispatchTs = Math.max(ring.recentDispatchTs ?? 0, tsMs);
     } else if (/cache\.reconcile/i.test(name)) {
       ring.cacheReconcile = {
@@ -484,7 +493,20 @@ export function buildBoardContext(boardState, invariants) {
       topTickets: boardState.eligible.slice(0, 5).map((e) => e.id).filter(Boolean),
     },
     stuckWorkers,
-    strandedNodes: (invariants.strandedNode?.flagged ?? []).map((h) => ({ host: h })),
+    strandedNodes: (invariants.strandedNode?.flagged ?? []).map((host) => ({
+      host,
+      // the tickets HRW-owned by this stranded host — the delegate's actionable
+      // payload (which work is at risk on the node that stopped reconciling).
+      ownedTickets: boardState.ownerForTicket
+        ? [...boardState.ticketsById.keys()].filter((id) => {
+            try {
+              return boardState.ownerForTicket(id, boardState.roster) === host;
+            } catch {
+              return false;
+            }
+          })
+        : [],
+    })),
     invariants: Object.fromEntries(
       Object.entries(invariants).map(([k, v]) => [k, { ok: v.ok, failed: v.failed }]),
     ),

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -358,6 +358,21 @@ describe("buildBoardContext", () => {
     ]);
     expect(ctx.invariants.workerAge).toEqual({ ok: false, failed: 1 });
   });
+
+  test("strandedNodes carry their HRW-owned tickets (schema {host, ownedTickets})", () => {
+    const board = mkBoard({
+      roster: ["mini", "mini-2"],
+      ticketsById: new Map([
+        ["CTL-A", { identifier: "CTL-A" }],
+        ["CTL-B", { identifier: "CTL-B" }],
+        ["CTL-C", { identifier: "CTL-C" }],
+      ]),
+      ownerForTicket: (id) => (id === "CTL-C" ? "mini" : "mini-2"),
+    });
+    const invs = { ...allGreen(), strandedNode: inv(false, 1, true, ["mini-2"]) };
+    const ctx = buildBoardContext(board, invs);
+    expect(ctx.strandedNodes).toEqual([{ host: "mini-2", ownedTickets: ["CTL-A", "CTL-B"] }]);
+  });
 });
 
 // ─── assembleBoardState — the one impure reader (reads only) ─────────────────
@@ -383,6 +398,33 @@ describe("assembleBoardState", () => {
     // worker-age still flags off the top-level signal fields — no evidence.signal needed
     const r = evaluateInvariants(board);
     expect(r.workerAge.flagged).toEqual(["CTL-A"]);
+  });
+
+  test("deriveRing: dispatch SUCCESS events set recentDispatchTs; failed/escalated/runaway do NOT", () => {
+    const ring = (name) =>
+      assembleBoardState({
+        readEventRing: () => [{ attributes: { "event.name": name }, ts: new Date(NOW - MIN).toISOString() }],
+        now: () => NOW,
+      }).ring.recentDispatchTs;
+    // success / activity signals → counted (dispatcher is alive)
+    expect(ring("phase.dispatch.launched.CTL-1")).toBe(NOW - MIN);
+    expect(ring("phase.dispatch.requested.CTL-1")).toBe(NOW - MIN);
+    expect(ring("new-work")).toBe(NOW - MIN);
+    // loud-failure signals → NOT counted (must not green the silent-hold wedge)
+    expect(ring("phase.dispatch.failed.CTL-1")).toBeNull();
+    expect(ring("phase.dispatch.escalated.CTL-1")).toBeNull();
+    expect(ring("phase.dispatch.runaway.CTL-1")).toBeNull();
+  });
+
+  test("dispatchLiveness stays WEDGED when the only recent dispatch events are failures", () => {
+    const board = assembleBoardState({
+      getEligible: () => [{ identifier: "CTL-1" }],
+      capacity: { maxParallel: 4, liveCount: 0, freeSlots: 4 },
+      // a fail-loop: recent phase.dispatch.failed events, no launched/requested
+      readEventRing: () => [{ attributes: { "event.name": "phase.dispatch.failed.CTL-1" }, ts: new Date(NOW - MIN).toISOString() }],
+      now: () => NOW,
+    });
+    expect(evaluateInvariants(board).dispatchLiveness.ok).toBe(false); // wedge NOT masked by failures
   });
 
   test("each reader fails soft — a throwing dep degrades to []/{}, never throws", () => {

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -1,0 +1,512 @@
+// board-health.test.mjs — CTL-1290. Validates the board-health delegate module.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test board-health.test.mjs
+//
+// The module is split pure-core / injected-IO precisely so the invariants and
+// the cheap-gate funnel are unit-testable WITHOUT a daemon, a DB, or wall-clock.
+// These tests hand-build boardState snapshots (pure) and stub every IO dep
+// (impure) — the load-bearing safety property (shadow takes zero mutating
+// action) is asserted by passing `act: () => { throw }` and proving no throw.
+
+import { describe, test, expect } from "bun:test";
+import {
+  assembleBoardState,
+  evaluateInvariants,
+  decideBoardHealth,
+  proposeMoves,
+  buildBoardContext,
+  buildBoardScanEvent,
+  boardHealthPass,
+} from "./board-health.mjs";
+
+const NOW = Date.parse("2026-06-20T12:00:00Z");
+const MIN = 60_000;
+const HOUR = 3_600_000;
+
+// A complete, default-healthy boardState shape (the frozen output assembleBoardState
+// produces). Overrides are shallow-merged per top-level key.
+function mkBoard(o = {}) {
+  return {
+    ticketsById: o.ticketsById ?? new Map(),
+    signals: o.signals ?? [],
+    eligible: o.eligible ?? [],
+    roster: o.roster ?? [],
+    self: o.self ?? "mini",
+    multiHost: o.multiHost ?? false,
+    capacity: { maxParallel: 4, liveCount: 0, freeSlots: 4, ...(o.capacity ?? {}) },
+    reconcileMarkers: o.reconcileMarkers ?? {},
+    ring: {
+      recentDispatchTs: null,
+      cacheReconcile: null,
+      accountRatelimit: null,
+      reconcileFailing: new Set(),
+      ...(o.ring ?? {}),
+    },
+    ownerForTicket: o.ownerForTicket ?? null,
+    now: o.now ?? NOW,
+  };
+}
+
+// ─── evaluateInvariants — one green + one failing per invariant ──────────────
+describe("evaluateInvariants — per-invariant green/fail", () => {
+  test("cacheCoherence: reconcile changed>0 → fail; changed=0 → ok; unseen → not observable", () => {
+    const failed = evaluateInvariants(mkBoard({ ring: { cacheReconcile: { changed: 3 } } }));
+    expect(failed.cacheCoherence.ok).toBe(false);
+    expect(failed.cacheCoherence.failed).toBe(1);
+    expect(failed.cacheCoherence.observable).toBe(true);
+
+    const green = evaluateInvariants(mkBoard({ ring: { cacheReconcile: { changed: 0 } } }));
+    expect(green.cacheCoherence.ok).toBe(true);
+    expect(green.cacheCoherence.failed).toBe(0);
+
+    const unseen = evaluateInvariants(mkBoard({ ring: { cacheReconcile: null } }));
+    expect(unseen.cacheCoherence.observable).toBe(false);
+  });
+
+  test("dispatchLiveness: free slots + queue + stale dispatch → wedge; live dispatch → ok", () => {
+    const wedged = evaluateInvariants(
+      mkBoard({
+        capacity: { maxParallel: 4, liveCount: 0, freeSlots: 4 },
+        eligible: [{ id: "CTL-1" }, { id: "CTL-2" }],
+        ring: { recentDispatchTs: NOW - 30 * MIN }, // > 10min default stall
+      }),
+    );
+    expect(wedged.dispatchLiveness.ok).toBe(false);
+    expect(wedged.dispatchLiveness.failed).toBe(1);
+    expect(wedged.dispatchLiveness.flagged).toContain("CTL-1");
+
+    const live = evaluateInvariants(
+      mkBoard({
+        eligible: [{ id: "CTL-1" }],
+        capacity: { maxParallel: 4, liveCount: 0, freeSlots: 4 },
+        ring: { recentDispatchTs: NOW - 1 * MIN }, // recent
+      }),
+    );
+    expect(live.dispatchLiveness.ok).toBe(true);
+  });
+
+  test("dispatchLiveness: no free slots OR empty queue → no wedge (ok)", () => {
+    const noSlots = evaluateInvariants(
+      mkBoard({ capacity: { freeSlots: 0 }, eligible: [{ id: "CTL-1" }], ring: { recentDispatchTs: null } }),
+    );
+    expect(noSlots.dispatchLiveness.ok).toBe(true);
+    const noQueue = evaluateInvariants(
+      mkBoard({ capacity: { freeSlots: 4 }, eligible: [], ring: { recentDispatchTs: null } }),
+    );
+    expect(noQueue.dispatchLiveness.ok).toBe(true);
+  });
+
+  test("workerAge: non-terminal worker past phase-normal age flags; within-age + terminal do not", () => {
+    const r = evaluateInvariants(
+      mkBoard({
+        signals: [
+          { ticket: "CTL-OLD", phase: "implement", status: "running", ageMs: 5 * HOUR }, // > 4h impl normal
+          { ticket: "CTL-YOUNG", phase: "implement", status: "running", ageMs: 1 * HOUR },
+          { ticket: "CTL-DONE", phase: "implement", status: "complete", ageMs: 99 * HOUR }, // terminal → skip
+        ],
+      }),
+    );
+    expect(r.workerAge.ok).toBe(false);
+    expect(r.workerAge.failed).toBe(1);
+    expect(r.workerAge.flagged).toEqual(["CTL-OLD"]);
+  });
+
+  test("workerAge: research phase has a tighter (1h) normal than the 4h default", () => {
+    const r = evaluateInvariants(
+      mkBoard({ signals: [{ ticket: "CTL-R", phase: "research", status: "running", ageMs: 2 * HOUR }] }),
+    );
+    expect(r.workerAge.flagged).toEqual(["CTL-R"]);
+  });
+
+  test("blockedTree: blocked by an unscheduled non-done blocker → flag; done/scheduled blocker → ok", () => {
+    const ticketsById = new Map([
+      ["CTL-A", { identifier: "CTL-A", relations: [{ type: "blocked_by", identifier: "CTL-B" }] }],
+      ["CTL-B", { identifier: "CTL-B", state: "In Progress" }],
+    ]);
+    const flagged = evaluateInvariants(mkBoard({ ticketsById }));
+    expect(flagged.blockedTree.ok).toBe(false);
+    expect(flagged.blockedTree.flagged).toEqual(["CTL-A"]);
+
+    const doneById = new Map([
+      ["CTL-A", { identifier: "CTL-A", relations: [{ type: "blocked_by", identifier: "CTL-B" }] }],
+      ["CTL-B", { identifier: "CTL-B", state: "Done" }],
+    ]);
+    expect(evaluateInvariants(mkBoard({ ticketsById: doneById })).blockedTree.ok).toBe(true);
+
+    // blocker present in the eligible queue → scheduled → not a dead chain
+    const scheduled = evaluateInvariants(
+      mkBoard({ ticketsById, eligible: [{ id: "CTL-B" }] }),
+    );
+    expect(scheduled.blockedTree.ok).toBe(true);
+  });
+
+  test("projectSilence: project quiet past threshold flags; recent movement ok; no join → not observable", () => {
+    const silent = evaluateInvariants(
+      mkBoard({ eligible: [{ id: "CTL-A", project: "P1", updatedAt: new Date(NOW - 25 * HOUR).toISOString() }] }),
+    );
+    expect(silent.projectSilence.ok).toBe(false);
+    expect(silent.projectSilence.flagged).toEqual(["P1"]);
+
+    const moving = evaluateInvariants(
+      mkBoard({ eligible: [{ id: "CTL-A", project: "P1", updatedAt: new Date(NOW - 1 * HOUR).toISOString() }] }),
+    );
+    expect(moving.projectSilence.ok).toBe(true);
+
+    const noJoin = evaluateInvariants(mkBoard({ eligible: [{ id: "CTL-A" }] }));
+    expect(noJoin.projectSilence.observable).toBe(false);
+  });
+
+  test("rateLimitHeadroom: near-cliff flags (observable); absent signal → not observable", () => {
+    const near = evaluateInvariants(mkBoard({ ring: { accountRatelimit: { nearCliff: true } } }));
+    expect(near.rateLimitHeadroom.ok).toBe(false);
+    expect(near.rateLimitHeadroom.failed).toBe(1);
+    expect(near.rateLimitHeadroom.observable).toBe(true);
+
+    const absent = evaluateInvariants(mkBoard({ ring: { accountRatelimit: null } }));
+    expect(absent.rateLimitHeadroom.observable).toBe(false);
+  });
+
+  test("strandedNode: rostered host owns work + reconcile failing → flag (observable)", () => {
+    const ticketsById = new Map([["CTL-A", { identifier: "CTL-A" }]]);
+    const ownerForTicket = () => "mini-2";
+    const r = evaluateInvariants(
+      mkBoard({
+        ticketsById,
+        roster: ["mini", "mini-2"],
+        ownerForTicket,
+        reconcileMarkers: { "mini-2": { consecutiveFailures: 3 } },
+      }),
+    );
+    expect(r.strandedNode.ok).toBe(false);
+    expect(r.strandedNode.observable).toBe(true);
+    expect(r.strandedNode.flagged).toEqual(["mini-2"]);
+  });
+
+  test("strandedNode: no HRW owner fn OR no reconcile signal → not observable", () => {
+    const noHrw = evaluateInvariants(mkBoard({ roster: ["mini", "mini-2"], ownerForTicket: null }));
+    expect(noHrw.strandedNode.observable).toBe(false);
+
+    const ticketsById = new Map([["CTL-A", { identifier: "CTL-A" }]]);
+    const noSignal = evaluateInvariants(
+      mkBoard({ ticketsById, roster: ["mini", "mini-2"], ownerForTicket: () => "mini-2", reconcileMarkers: {} }),
+    );
+    expect(noSignal.strandedNode.observable).toBe(false);
+  });
+
+  test("a throwing invariant fails OPEN ({ok:true,error}) and never aborts the scan", () => {
+    // ticketsById that throws when iterated (blockedTree walks it).
+    const boom = {
+      get size() { return 1; },
+      [Symbol.iterator]() { throw new Error("boom"); },
+    };
+    const r = evaluateInvariants(mkBoard({ ticketsById: boom }));
+    expect(r.blockedTree.ok).toBe(true);
+    expect(r.blockedTree.error).toBeDefined();
+    // the rest of the scan still completed
+    expect(r.dispatchLiveness).toBeDefined();
+    expect(r.workerAge).toBeDefined();
+  });
+});
+
+// ─── decideBoardHealth — the cheap-gate funnel (§6) ─────────────────────────
+function inv(ok, failed = 0, observable = true, flagged = []) {
+  return { ok, failed, observable, flagged, note: "" };
+}
+function allGreen() {
+  return {
+    cacheCoherence: inv(true),
+    dispatchLiveness: inv(true),
+    workerAge: inv(true),
+    blockedTree: inv(true),
+    projectSilence: inv(true),
+    rateLimitHeadroom: inv(true),
+    strandedNode: inv(true),
+  };
+}
+
+describe("decideBoardHealth — ordered gates, first match wins", () => {
+  test("Gate 1: all observable green → skip/all-green, proposed all 0", () => {
+    const d = decideBoardHealth(allGreen(), mkBoard({ capacity: { freeSlots: 4 } }));
+    expect(d.gate.decision).toBe("skip");
+    expect(d.gate.reason).toBe("all-green");
+    expect(d.proposed).toEqual({ tier1: 0, tier2: 0, tier3: 0 });
+    expect(d.invariantsFailed).toBe(0);
+  });
+
+  test("Gate 2: failures but freeSlots===0 → skip/no-free-slots", () => {
+    const invs = { ...allGreen(), dispatchLiveness: inv(false, 1) };
+    const d = decideBoardHealth(invs, mkBoard({ capacity: { freeSlots: 0 } }));
+    expect(d.gate.decision).toBe("skip");
+    expect(d.gate.reason).toBe("no-free-slots");
+  });
+
+  test("Gate 3: failures + free slots + rate-limit cliff → skip/rate-limit-cliff", () => {
+    const invs = { ...allGreen(), dispatchLiveness: inv(false, 1), rateLimitHeadroom: inv(false, 1) };
+    const d = decideBoardHealth(invs, mkBoard({ capacity: { freeSlots: 4 } }));
+    expect(d.gate.decision).toBe("skip");
+    expect(d.gate.reason).toBe("rate-limit-cliff");
+  });
+
+  test("Gate 4: real observable failures + headroom → proceed + tiered proposals", () => {
+    const invs = { ...allGreen(), dispatchLiveness: inv(false, 1) };
+    const d = decideBoardHealth(invs, mkBoard({ capacity: { freeSlots: 4 } }));
+    expect(d.gate.decision).toBe("proceed");
+    expect(d.gate.reason).toMatch(/invariant\(s\) flagged/);
+    expect(d.invariantsFailed).toBe(1);
+    expect(d.proposed.tier1).toBe(1); // dispatch wedge → kick-dispatch
+  });
+
+  test("every return carries a non-empty gate.reason", () => {
+    for (const board of [mkBoard({ capacity: { freeSlots: 4 } }), mkBoard({ capacity: { freeSlots: 0 } })]) {
+      const d = decideBoardHealth({ ...allGreen(), dispatchLiveness: inv(false, 1) }, board);
+      expect(typeof d.gate.reason).toBe("string");
+      expect(d.gate.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("observable:false failure is EXCLUDED from invariantsFailed and never triggers proceed", () => {
+    const invs = { ...allGreen(), rateLimitHeadroom: inv(false, 1, /*observable*/ false) };
+    const d = decideBoardHealth(invs, mkBoard({ capacity: { freeSlots: 4 } }));
+    expect(d.gate.decision).toBe("skip");
+    expect(d.gate.reason).toBe("all-green");
+    expect(d.invariantsFailed).toBe(0);
+  });
+});
+
+// ─── proposeMoves — failed invariants → correct tier buckets ────────────────
+describe("proposeMoves — tiering", () => {
+  test("dispatch wedge → tier1 kick-dispatch; worker-age → tier1 nudge per ticket", () => {
+    const invs = {
+      ...allGreen(),
+      dispatchLiveness: inv(false, 1),
+      workerAge: inv(false, 2, true, ["CTL-1", "CTL-2"]),
+    };
+    const m = proposeMoves(invs, mkBoard());
+    expect(m.tier1.some((x) => x.move === "kick-dispatch")).toBe(true);
+    expect(m.tier1.filter((x) => x.move === "nudge").map((x) => x.ticket)).toEqual(["CTL-1", "CTL-2"]);
+  });
+
+  test("blocked-tree → tier2; stranded-node + project-silence → tier3", () => {
+    const invs = {
+      ...allGreen(),
+      blockedTree: inv(false, 1, true, ["CTL-A"]),
+      strandedNode: inv(false, 1, true, ["mini-2"]),
+      projectSilence: inv(false, 1, true, ["P1"]),
+    };
+    const m = proposeMoves(invs, mkBoard());
+    expect(m.tier2.map((x) => x.move)).toContain("re-dispatch-blocker");
+    expect(m.tier3.map((x) => x.move)).toEqual(
+      expect.arrayContaining(["escalate-stranded-node", "escalate-project-silence"]),
+    );
+  });
+
+  test("all-green → no moves; counts in decideBoardHealth match the arrays", () => {
+    const m = proposeMoves(allGreen(), mkBoard());
+    expect(m).toEqual({ tier1: [], tier2: [], tier3: [] });
+
+    const invs = { ...allGreen(), dispatchLiveness: inv(false, 1), blockedTree: inv(false, 1, true, ["CTL-A"]) };
+    const d = decideBoardHealth(invs, mkBoard({ capacity: { freeSlots: 4 } }));
+    expect(d.proposed.tier1).toBe(d.moves.tier1.length);
+    expect(d.proposed.tier2).toBe(d.moves.tier2.length);
+    expect(d.proposed.tier3).toBe(d.moves.tier3.length);
+  });
+});
+
+// ─── buildBoardScanEvent — the flat event the emit envelope rides ───────────
+describe("buildBoardScanEvent", () => {
+  test("type/ticket/scalars at top of details; rosters as arrays; mode echoed", () => {
+    const invs = { ...allGreen(), dispatchLiveness: inv(false, 1, true, ["CTL-1"]) };
+    const decision = decideBoardHealth(invs, mkBoard({ capacity: { freeSlots: 4 } }));
+    const ev = buildBoardScanEvent({ mode: "shadow", invariants: invs, decision });
+
+    expect(ev.type).toBe("recovery.board-scan");
+    expect(ev.ticket).toBeNull();
+    expect(ev.fix_class).toBeNull();
+    expect(ev.details.mode).toBe("shadow");
+    expect(ev.details.invariantsFailed).toBe(1);
+    expect(ev.details.gateDecision).toBe("proceed");
+    expect(typeof ev.details.gateReason).toBe("string");
+    expect(ev.details.proposedTier1).toBe(decision.proposed.tier1);
+    // per-invariant {ok,failed,observable}
+    expect(ev.details.invariants.dispatchLiveness).toEqual({ ok: false, failed: 1, observable: true });
+    // rosters/move arrays live in details (→ body.payload), as arrays
+    expect(Array.isArray(ev.details.flagged)).toBe(true);
+    expect(ev.details.flagged).toContain("CTL-1");
+    expect(Array.isArray(ev.details.tier1Moves)).toBe(true);
+  });
+});
+
+// ─── buildBoardContext — the whole-board brief the delegate gets injected ────
+describe("buildBoardContext", () => {
+  test("stuckWorkers from flagged signals; invariants block; slots + queue", () => {
+    const board = mkBoard({
+      self: "mini",
+      roster: ["mini"],
+      capacity: { maxParallel: 4, liveCount: 2, freeSlots: 2 },
+      eligible: [{ id: "CTL-1" }, { id: "CTL-2" }],
+      signals: [{ ticket: "CTL-OLD", phase: "implement", status: "running", ageMs: 5 * HOUR }],
+    });
+    const invs = { ...allGreen(), workerAge: inv(false, 1, true, ["CTL-OLD"]) };
+    const ctx = buildBoardContext(board, invs);
+
+    expect(ctx.schema).toBe("recovery-board-context/v1");
+    expect(ctx.slots).toEqual({ capacity: 4, inUse: 2, free: 2 });
+    expect(ctx.eligibleQueue.depth).toBe(2);
+    expect(ctx.eligibleQueue.topTickets).toEqual(["CTL-1", "CTL-2"]);
+    expect(ctx.stuckWorkers).toEqual([
+      { ticket: "CTL-OLD", phase: "implement", status: "running", ageSeconds: Math.round(5 * HOUR / 1000) },
+    ]);
+    expect(ctx.invariants.workerAge).toEqual({ ok: false, failed: 1 });
+  });
+});
+
+// ─── assembleBoardState — the one impure reader (reads only) ─────────────────
+describe("assembleBoardState", () => {
+  test("normalizes descriptors/signals/eligible; reads signal.updatedAt/phase TOP-LEVEL (no evidence.signal)", () => {
+    const board = assembleBoardState({
+      orchDir: "/tmp/x",
+      getBoard: () => [{ identifier: "CTL-A", state: "In Progress" }],
+      // a raw signal with NO `evidence` field — age must still compute from top-level updatedAt
+      getWorkerSignals: () => [{ ticket: "CTL-A", phase: "implement", status: "running", updatedAt: new Date(NOW - 5 * HOUR).toISOString() }],
+      getEligible: () => [{ identifier: "CTL-B", project: "P1" }],
+      roster: ["mini"],
+      self: "mini",
+      multiHost: false,
+      capacity: { maxParallel: 4, liveCount: 1, freeSlots: 3 },
+      readEventRing: () => [],
+      getReconcileMarkers: () => ({}),
+      now: () => NOW,
+    });
+    expect(board.ticketsById.get("CTL-A").state).toBe("In Progress");
+    expect(board.signals[0].ageMs).toBe(5 * HOUR);
+    expect(board.eligible[0].id).toBe("CTL-B");
+    // worker-age still flags off the top-level signal fields — no evidence.signal needed
+    const r = evaluateInvariants(board);
+    expect(r.workerAge.flagged).toEqual(["CTL-A"]);
+  });
+
+  test("each reader fails soft — a throwing dep degrades to []/{}, never throws", () => {
+    const board = assembleBoardState({
+      orchDir: "/tmp/x",
+      getBoard: () => { throw new Error("db down"); },
+      getWorkerSignals: () => { throw new Error("signals down"); },
+      getEligible: () => { throw new Error("eligible down"); },
+      readEventRing: () => { throw new Error("ring down"); },
+      getReconcileMarkers: () => { throw new Error("markers down"); },
+      now: () => NOW,
+    });
+    expect(board.ticketsById.size).toBe(0);
+    expect(board.signals).toEqual([]);
+    expect(board.eligible).toEqual([]);
+    // and a full scan over the degraded board still runs
+    expect(() => evaluateInvariants(board)).not.toThrow();
+  });
+});
+
+// ─── boardHealthPass — injected IO, the ONE place mode branches ──────────────
+function flaggedDeps(extra = {}) {
+  // a board that trips dispatchLiveness (free slots + queue + no recent dispatch)
+  return {
+    orchDir: "/tmp/x",
+    getBoard: () => [],
+    getWorkerSignals: () => [],
+    getEligible: () => [{ identifier: "CTL-1" }, { identifier: "CTL-2" }],
+    roster: [],
+    self: "mini",
+    multiHost: false,
+    capacity: { maxParallel: 4, liveCount: 0, freeSlots: 4 },
+    readEventRing: () => [], // no dispatch events → wedge
+    getReconcileMarkers: () => ({}),
+    lastRunMs: 0,
+    intervalMs: 0, // never throttled
+    now: () => NOW,
+    ...extra,
+  };
+}
+
+describe("boardHealthPass — mode branching + shadow safety", () => {
+  test("mode:off → strict no-op: no emit, act never called, returns {ran:false,reason:off}", () => {
+    const emits = [];
+    const r = boardHealthPass(
+      flaggedDeps({ mode: "off", emit: (e) => emits.push(e), act: () => { throw new Error("must not act"); } }),
+    );
+    expect(r).toEqual({ ran: false, reason: "off" });
+    expect(emits.length).toBe(0);
+  });
+
+  test("mode:shadow → emits ONE recovery.board-scan (mode=shadow); act is NEVER called (no throw)", () => {
+    const emits = [];
+    const r = boardHealthPass(
+      flaggedDeps({ mode: "shadow", emit: (e) => emits.push(e), act: () => { throw new Error("shadow must not act"); } }),
+    );
+    expect(r.ran).toBe(true);
+    expect(emits.length).toBe(1);
+    expect(emits[0].type).toBe("recovery.board-scan");
+    expect(emits[0].details.mode).toBe("shadow");
+  });
+
+  test("mode:enforce with NO act seam (the scheduler reality) → emits, mutates nothing, no throw", () => {
+    const emits = [];
+    const r = boardHealthPass(flaggedDeps({ mode: "enforce", emit: (e) => emits.push(e) }));
+    expect(r.ran).toBe(true);
+    expect(emits.length).toBe(1);
+    expect(emits[0].details.mode).toBe("enforce");
+  });
+
+  test("mode:enforce WITH act stub → act called once per proposed move (future-wiring proof)", () => {
+    const emits = [];
+    const acted = [];
+    boardHealthPass(
+      flaggedDeps({ mode: "enforce", emit: (e) => emits.push(e), act: (move) => acted.push(move) }),
+    );
+    // the flagged board proposes exactly one tier-1 kick-dispatch
+    expect(acted.length).toBe(1);
+    expect(acted[0].move).toBe("kick-dispatch");
+  });
+
+  test("enforce + multiHost: HRW gate skips a move owned by another host", () => {
+    const acted = [];
+    boardHealthPass({
+      orchDir: "/tmp/x",
+      mode: "enforce",
+      getBoard: () => [{ identifier: "CTL-OWNED-ELSEWHERE" }],
+      getWorkerSignals: () => [{ ticket: "CTL-OWNED-ELSEWHERE", phase: "implement", status: "running", updatedAt: new Date(NOW - 5 * HOUR).toISOString() }],
+      getEligible: () => [],
+      roster: ["mini", "mini-2"],
+      self: "mini",
+      multiHost: true,
+      capacity: { maxParallel: 4, liveCount: 1, freeSlots: 3 },
+      readEventRing: () => [],
+      ownerForTicket: () => "mini-2", // every ticket owned by the OTHER host
+      getReconcileMarkers: () => ({}),
+      lastRunMs: 0,
+      intervalMs: 0,
+      now: () => NOW,
+      emit: () => {},
+      act: (move) => acted.push(move),
+    });
+    // the only proposed move (nudge CTL-OWNED-ELSEWHERE) is owned by mini-2 → skipped
+    expect(acted.length).toBe(0);
+  });
+
+  test("throttle: a call within intervalMs returns {ran:false,reason:throttled} with NO emit", () => {
+    const emits = [];
+    const r = boardHealthPass(
+      flaggedDeps({
+        mode: "shadow",
+        emit: (e) => emits.push(e),
+        lastRunMs: NOW - 1 * MIN, // 1min ago
+        intervalMs: 5 * MIN, // 5min floor → throttled
+      }),
+    );
+    expect(r).toEqual({ ran: false, reason: "throttled" });
+    expect(emits.length).toBe(0);
+  });
+
+  test("fail-soft: a throwing emit is caught — the pass still returns {ran:true}", () => {
+    const r = boardHealthPass(
+      flaggedDeps({ mode: "shadow", emit: () => { throw new Error("emit blew up"); } }),
+    );
+    expect(r.ran).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -982,6 +982,46 @@ export function readDeadDocWorkerConfig() {
   return { mode };
 }
 
+// CTL-1290: board-health delegate mode reader. Mirrors the recovery-family
+// readers (readRecoveryPassConfig / readDeadDocWorkerConfig) EXACTLY — env
+// (CATALYST_BOARD_HEALTH) overrides Layer-2 (.catalyst.boardHealth.mode) —
+// with ONE deliberate deviation: the safe default is "shadow", not "off".
+// Justification (spec §11.1, ADR-023 deviation, confirmed acceptable): shadow is
+// itself a dark state. It emits ONE throttled `recovery.board-scan` heartbeat per
+// cadence and mutates NOTHING — the no-mutation guarantee is structural in
+// board-health.mjs (no process-spawning import; the `act` seam is enforce-gated
+// and the scheduler supplies none). The ticket's whole value IS that shadow
+// telemetry, so a shadow default ships the feature on; CATALYST_BOARD_HEALTH=0/off
+// is the kill-switch.
+//   off     → strict no-op: behaviour byte-for-byte identical to pre-CTL-1290.
+//   shadow  → scan + emit recovery.board-scan, take NO action (the default).
+//   enforce → additionally act on proposed moves — UNWIRED in CTL-1290 (the
+//             scheduler passes no `act` seam, so enforce is inert until a follow-up).
+export const BOARD_HEALTH_MODES = new Set(["off", "shadow", "enforce"]);
+
+function readLayer2BoardHealth() {
+  try {
+    const b = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.boardHealth;
+    return b && typeof b === "object" ? b : {};
+  } catch { return {}; }
+}
+
+export function readBoardHealthConfig(env = process.env) {
+  const l2 = readLayer2BoardHealth();
+  const v = env.CATALYST_BOARD_HEALTH;
+  let mode;
+  if (v === "0") {
+    mode = "off"; // kill-switch
+  } else if (typeof v === "string" && BOARD_HEALTH_MODES.has(v)) {
+    mode = v;
+  } else if (typeof l2.mode === "string" && BOARD_HEALTH_MODES.has(l2.mode)) {
+    mode = l2.mode;
+  } else {
+    mode = "shadow"; // CTL-1290 floor: shadow mutates nothing; garbage → shadow
+  }
+  return { mode };
+}
+
 // --- Governance snapshot for operator visibility (CTL-1062/CTL-1084) ---
 // READ-ONLY, NEVER load-bearing. Recomputes each governance value the same way
 // its per-tick gate site does so the heartbeat payload and the

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -34,6 +34,7 @@ import {
   resolveClusterHosts,
   CLUSTER_SYNC_INTERVAL_MS,
   readDeadDocWorkerConfig,
+  readBoardHealthConfig,
   DEAD_DOC_WORKER_TRANSCRIPT_SILENCE_MS,
 } from "./config.mjs";
 
@@ -804,5 +805,61 @@ describe("readDeadDocWorkerConfig (CTL-1245)", () => {
   });
   test("transcript-silence floor defaults to 30 minutes", () => {
     expect(DEAD_DOC_WORKER_TRANSCRIPT_SILENCE_MS).toBe(30 * 60_000);
+  });
+});
+
+describe("readBoardHealthConfig (CTL-1290)", () => {
+  const BH_ENVS = ["CATALYST_BOARD_HEALTH", "CATALYST_LAYER2_CONFIG_FILE"];
+  let saved = {}, tmp;
+  beforeEach(() => {
+    for (const k of BH_ENVS) { saved[k] = process.env[k]; delete process.env[k]; }
+    tmp = mkdtempSync(join(tmpdir(), "ctl1290-bh-"));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = join(tmp, "absent.json");
+  });
+  afterEach(() => {
+    for (const k of BH_ENVS) { saved[k] === undefined ? delete process.env[k] : (process.env[k] = saved[k]); }
+    saved = {}; rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("default: mode=shadow (the CTL-1290 floor — NOT off; shadow mutates nothing)", () => {
+    expect(readBoardHealthConfig().mode).toBe("shadow");
+  });
+  test("CATALYST_BOARD_HEALTH=0 maps to mode:off (kill-switch)", () => {
+    process.env.CATALYST_BOARD_HEALTH = "0";
+    expect(readBoardHealthConfig().mode).toBe("off");
+  });
+  test("env off / shadow / enforce are honored", () => {
+    process.env.CATALYST_BOARD_HEALTH = "off";
+    expect(readBoardHealthConfig().mode).toBe("off");
+    process.env.CATALYST_BOARD_HEALTH = "shadow";
+    expect(readBoardHealthConfig().mode).toBe("shadow");
+    process.env.CATALYST_BOARD_HEALTH = "enforce";
+    expect(readBoardHealthConfig().mode).toBe("enforce");
+  });
+  test("garbage env → falls back to shadow (NOT off)", () => {
+    process.env.CATALYST_BOARD_HEALTH = "banana";
+    expect(readBoardHealthConfig().mode).toBe("shadow");
+  });
+  test("reads catalyst.boardHealth.mode from Layer-2 when env absent", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { boardHealth: { mode: "off" } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    expect(readBoardHealthConfig().mode).toBe("off");
+  });
+  test("env wins over Layer-2", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { boardHealth: { mode: "off" } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    process.env.CATALYST_BOARD_HEALTH = "enforce";
+    expect(readBoardHealthConfig().mode).toBe("enforce");
+  });
+  test("malformed Layer-2 file → shadow (never throws)", () => {
+    const cfg = join(tmp, "config.json"); writeFileSync(cfg, "{ not json");
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    expect(readBoardHealthConfig().mode).toBe("shadow");
+  });
+  test("accepts an injected env bag (env param overrides process.env)", () => {
+    process.env.CATALYST_BOARD_HEALTH = "shadow";
+    expect(readBoardHealthConfig({ CATALYST_BOARD_HEALTH: "0" }).mode).toBe("off");
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery-pass-context.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-pass-context.mjs
@@ -266,6 +266,24 @@ function printDispatchedBrief(ticket, orchDir) {
   }
   console.log("--- guidance ---");
   console.log(brief.guidance || "(none)");
+  // CTL-1290: the whole-board, read-only snapshot (recovery-pass-brief/v2). Gives
+  // the delegate the context the per-item brief never had — slots, queue depth,
+  // which OTHER workers are stuck, which nodes are stranded — so it acts on the
+  // board, not just this one ticket.
+  if (brief.boardContext) {
+    console.log("--- board context (whole-board, read-only) ---");
+    const bc = brief.boardContext;
+    console.log(`slots: ${bc.slots?.inUse}/${bc.slots?.capacity} (${bc.slots?.free} free)`);
+    console.log(`eligible queue depth: ${bc.eligibleQueue?.depth ?? 0}`);
+    if (bc.stuckWorkers?.length) {
+      console.log(
+        `stuck workers: ${bc.stuckWorkers.map((w) => `${w.ticket}(${w.phase},${w.ageSeconds}s)`).join(", ")}`,
+      );
+    }
+    if (bc.strandedNodes?.length) {
+      console.log(`stranded nodes: ${bc.strandedNodes.map((n) => n.host).join(", ")}`);
+    }
+  }
   console.log("--- recent log buffer (tail 40) ---");
   const logs = brief?.diagnosis?.logsOutput || "(no logs captured)";
   const tail = String(logs).split("\n").slice(-40).join("\n");

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -889,6 +889,21 @@ function promoteNumericAttrs(type, details) {
     num("recovery.rule", details.rule);
     str("recovery.decision", details.decision);
     str("recovery.mode", details.mode);
+  } else if (type === "recovery.board-scan") {
+    // CTL-1290: whole-board health scan. Bounded scalars + enums chart; the
+    // per-invariant failed-count rides as recovery.inv.<name>.failed. Rosters and
+    // move-proposal arrays stay in body.payload (cardinality) — only their COUNTS
+    // (invariants_failed, proposed.tier1/2/3) promote.
+    num("recovery.invariants_failed", details.invariantsFailed);
+    num("recovery.proposed.tier1", details.proposedTier1);
+    num("recovery.proposed.tier2", details.proposedTier2);
+    num("recovery.proposed.tier3", details.proposedTier3);
+    str("recovery.gate_decision", details.gateDecision);
+    str("recovery.gate_reason", details.gateReason);
+    str("recovery.mode", details.mode);
+    for (const [name, r] of Object.entries(details.invariants ?? {})) {
+      num(`recovery.inv.${name}.failed`, r?.failed);
+    }
   }
   return a;
 }
@@ -1277,7 +1292,7 @@ export function defaultInvokeRecoveryPass(ticket, briefObj = {}, deps = {}) {
     return { success: false, dispatched: false, attempts: 0, reason: "no orchDir", details: {} };
   }
 
-  const { brief, reason, evidence, phase, bgJobId, failureReason } = briefObj;
+  const { brief, reason, evidence, phase, bgJobId, failureReason, boardContext } = briefObj;
 
   // Lazy imports — same rationale as defaultInvokeRemediateCapped (avoid loading
   // the dispatch graph on the off/shadow paths; no import cycle).
@@ -1317,11 +1332,17 @@ export function defaultInvokeRecoveryPass(ticket, briefObj = {}, deps = {}) {
   //     passes failed instead of redoing them.
   const seamsTried = readUnstuckSeamsTried(orchDir, ticket, phase);
   const recoveryBrief = {
-    schema: "recovery-pass-brief/v1",
+    schema: "recovery-pass-brief/v2", // v2 (CTL-1290): adds the whole-board boardContext block
     ticket,
     phase: phase ?? null,
     bgJobId: bgJobId ?? null,
     failureReason: failureReason ?? null,
+    // CTL-1290: the holistic, read-only board snapshot (slots/queue/stuck-workers/
+    // invariants) produced by board-health.buildBoardContext. Until now the
+    // dispatched delegate got a per-item brief with ZERO board context; this is
+    // how the daemon-side board scan reaches the LLM session. Null when the caller
+    // (e.g. the per-item recovery pass) has no board scan to attach.
+    boardContext: boardContext ?? null,
     // The DIAGNOSE output (read-only): claude logs buffer + bg job state + signal
     // + belief state. The skill reads this instead of re-diagnosing from scratch.
     diagnosis: {

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -861,6 +861,64 @@ describe("buildRecoveryEnvelope numeric/enum promotion (CTL-1291)", () => {
     expect(env.attributes["recovery.rule"]).toBeUndefined();
     expect(env.attributes["event.name"]).toBe("recovery.fixed"); // canonical attrs intact
   });
+
+  // ─── CTL-1290: the recovery.board-scan branch ───────────────────────────────
+  test("recovery.board-scan promotes board scalars, gate enums, and per-invariant failed counts", () => {
+    const details = {
+      mode: "shadow",
+      invariantsFailed: 2,
+      gateDecision: "proceed",
+      gateReason: "2 invariant(s) flagged",
+      proposedTier1: 1,
+      proposedTier2: 0,
+      proposedTier3: 1,
+      invariants: {
+        dispatchLiveness: { ok: false, failed: 1, observable: true },
+        projectSilence: { ok: false, failed: 1, observable: true },
+        workerAge: { ok: true, failed: 0, observable: true },
+      },
+      flagged: ["CTL-1", "CTL-2"],
+      tier1Moves: [{ move: "kick-dispatch" }],
+      tier3Moves: [{ project: "P1", move: "escalate-project-silence" }],
+    };
+    const env = buildRecoveryEnvelope({ type: "recovery.board-scan", ticket: null, reason: "r", details });
+    const a = env.attributes;
+    expect(a["recovery.invariants_failed"]).toBe(2);
+    expect(a["recovery.proposed.tier1"]).toBe(1);
+    expect(a["recovery.proposed.tier2"]).toBe(0);
+    expect(a["recovery.proposed.tier3"]).toBe(1);
+    expect(a["recovery.gate_decision"]).toBe("proceed");
+    expect(a["recovery.gate_reason"]).toBe("2 invariant(s) flagged");
+    expect(a["recovery.mode"]).toBe("shadow");
+    // per-invariant failed counts chart individually
+    expect(a["recovery.inv.dispatchLiveness.failed"]).toBe(1);
+    expect(a["recovery.inv.projectSilence.failed"]).toBe(1);
+    expect(a["recovery.inv.workerAge.failed"]).toBe(0);
+    // board-scoped → event.label is null (the board reader ignores it; no per-ticket fold)
+    expect(a["event.label"]).toBeNull();
+  });
+
+  test("recovery.board-scan never promotes rosters/move arrays (cardinality)", () => {
+    const details = {
+      mode: "shadow",
+      invariantsFailed: 1,
+      gateDecision: "proceed",
+      gateReason: "1 invariant(s) flagged",
+      proposedTier1: 1, proposedTier2: 0, proposedTier3: 0,
+      invariants: { dispatchLiveness: { ok: false, failed: 1, observable: true } },
+      flagged: ["CTL-1", "CTL-2", "CTL-3"],
+      tier1Moves: [{ move: "kick-dispatch" }],
+    };
+    const env = buildRecoveryEnvelope({ type: "recovery.board-scan", ticket: null, details });
+    const a = env.attributes;
+    // no attribute value is an array, and the raw rosters are not lifted by key
+    for (const v of Object.values(a)) expect(Array.isArray(v)).toBe(false);
+    expect(a["recovery.flagged"]).toBeUndefined();
+    expect(a["recovery.tier1Moves"]).toBeUndefined();
+    expect(a.flagged).toBeUndefined();
+    // back-compat: the full details object still rides in body.payload
+    expect(env.body.payload.details).toEqual(details);
+  });
 });
 
 // ─── CTL-1176: host-local cooldown + intent ledger ──────────────────────────
@@ -1236,9 +1294,11 @@ describe("defaultInvokeRecoveryPass (CTL-1176 rung 3)", () => {
     const briefPath = pathJoin(wdir, "recovery-pass.json");
     expect(existsSync(briefPath)).toBe(true);
     const brief = JSON.parse(readFileSync(briefPath, "utf8"));
-    expect(brief.schema).toBe("recovery-pass-brief/v1");
+    expect(brief.schema).toBe("recovery-pass-brief/v2");
     expect(brief.ticket).toBe("CTL-501");
     expect(brief.failureReason).toBe("merge-conflict");
+    // CTL-1290: boardContext present (null here — no board scan attached by this caller)
+    expect(brief.boardContext).toBeNull();
     expect(brief.diagnosis.logsOutput).toContain("CONFLICT");
     expect(brief.diagnosis.beliefState).toEqual({ x: 1 });
     // Consumed the hands' history — the two markers, not redone.
@@ -1247,6 +1307,30 @@ describe("defaultInvokeRecoveryPass (CTL-1176 rung 3)", () => {
     expect(brief.guidance).toContain("resolve");
     // No verify.json fake-finding injection.
     expect(existsSync(pathJoin(wdir, "verify.json"))).toBe(false);
+  });
+
+  test("CTL-1290: boardContext from briefObj is written into the v2 brief", () => {
+    const boardContext = {
+      schema: "recovery-board-context/v1",
+      slots: { capacity: 4, inUse: 3, free: 1 },
+      eligibleQueue: { depth: 2, topTickets: ["CTL-1", "CTL-2"] },
+      stuckWorkers: [{ ticket: "CTL-9", phase: "implement", status: "running", ageSeconds: 18000 }],
+      strandedNodes: [],
+      invariants: { dispatchLiveness: { ok: false, failed: 1 } },
+    };
+    const result = defaultInvokeRecoveryPass(
+      "CTL-503",
+      { brief: "x", reason: "stuck", boardContext },
+      {
+        orchDir,
+        eventScanMod: { countRecoveryPassCycles: () => 0 },
+        dispatchMod: { dispatchTicket: () => ({ code: 0, worktreePath: "/tmp/wt", signal: {} }) },
+      },
+    );
+    expect(result.dispatched).toBe(true);
+    const brief = JSON.parse(readFileSync(pathJoin(orchDir, "workers", "CTL-503", "recovery-pass.json"), "utf8"));
+    expect(brief.schema).toBe("recovery-pass-brief/v2");
+    expect(brief.boardContext).toEqual(boardContext);
   });
 
   test("dispatch failure (non-zero code) → success:false, dispatched:false", () => {

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -228,7 +228,7 @@ import {
 // to production deps at the unstuckSweep wiring point below. Wiring this does NOT
 // flip enforce on — the mode gate stays at its safe 'off' default (ADR-023).
 import { buildUnstuckActSeams } from "./unstuck-act-seams.mjs";
-import { readUnstuckSweepConfig, readRecoveryPassConfig, isThrottled } from "./config.mjs";
+import { readUnstuckSweepConfig, readRecoveryPassConfig, readBoardHealthConfig, isThrottled } from "./config.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
 // module (best-effort — every write swallows its own failures).
@@ -269,7 +269,10 @@ import {
 } from "./config.mjs";
 import { emitDrainedEvent as defaultEmitDrainedEvent } from "./drain-event.mjs"; // CTL-1095: drained sentinel
 import { defaultCheckSequencing } from "./sequencing.mjs"; // CTL-537
-import { ownedBy } from "./hrw.mjs"; // CTL-850: HRW ownership filter (CTL-1191 also uses it for the diagnostician gate)
+import { ownedBy, ownerForTicket } from "./hrw.mjs"; // CTL-850: HRW ownership filter (CTL-1191 also uses it for the diagnostician gate); ownerForTicket: CTL-1290 board-health stranded-node + enforce HRW gate
+import { boardHealthPass } from "./board-health.mjs"; // CTL-1290: the whole-board health delegate (shadow-first)
+import { getAllTicketDescriptors } from "../broker/broker-state.mjs"; // CTL-1290: board snapshot (reads only). bun:sqlite-backed — safe here: scheduler.mjs is daemon-only and NOT in the orch-monitor vite/UI graph (see MEMORY vite_config_bun_sqlite_trap).
+import { readReconcileHealthMarkers } from "./reconcile-health.mjs"; // CTL-1290: stranded-node reconcile signal
 import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-850: cross-host claim soft-CAS
 // CTL-954: team estimation method — lazy-cached from Linear, used to expand
 // the allowed estimate point set beyond the hard-coded Fibonacci values.
@@ -2527,6 +2530,32 @@ export function defaultClearStall(orchDir, writeStatus) {
   };
 }
 
+// CTL-1290: board-health throttle state (host-local, mirrors the unstuck-sweep /
+// recovery-pass cadence vars). The single-LLM cadence floor lives in
+// BOARD_HEALTH_INTERVAL_MS; this holds the last run ms across ticks.
+let _boardHealthLastRunMs = 0;
+
+// CTL-1290: bounded tail of the unified event log → the records board-health's
+// deriveRing distills (recent dispatch ts, cache.reconcile summary, account
+// rate-limit, reconcile-failing teams). This is the documented FALLBACK for the
+// CTL-1257 shared ring (not yet threadable here). Best-effort: any read/parse
+// error degrades to [] so the dependent invariants flag observable:false rather
+// than throwing the tick.
+function readBoardHealthEventTail(maxLines = 800) {
+  try {
+    const raw = readFileSync(getEventLogPath(), "utf8");
+    const lines = raw.split("\n");
+    const out = [];
+    for (const line of lines.slice(-maxLines)) {
+      if (!line) continue;
+      try { out.push(JSON.parse(line)); } catch { /* skip a partial/garbled line */ }
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
 // schedulerTick — one pull cycle: (1) advancement sweep, (2) new-work pull,
 // (3) terminal-Done sweep (CTL-558). Idempotent and restart-safe — derives
 // every action from filesystem state. `exec` is the injectable seam for the
@@ -2747,6 +2776,14 @@ export function schedulerTick(
     recoveryPass: {
       mode: _recoveryPassMode = undefined,
     } = {},
+    // CTL-1290: board-health delegate seam. Threaded by the daemon (runTick) with
+    // the real-IO seams (board snapshot / event-ring / reconcile markers) — mirrors
+    // the stallJanitor census wiring. Undefined on a bare schedulerTick (unit
+    // tests) → the pass is INERT (does no real IO, never emits). Mode resolves
+    // inside the hook via readBoardHealthConfig (env > Layer-2 > "shadow") unless
+    // the caller pins `boardHealth.mode`. `boardHealthPassFn` is the §9.4 test seam.
+    boardHealth: _boardHealth = undefined,
+    boardHealthPassFn = boardHealthPass,
     // CTL-1095: drain gate — node-level refusal of new-work admission. Default
     // reads the drain flag file from orchDir; tests inject a stub.
     isDraining = () => isDrainingDefault(orchDir),
@@ -3758,6 +3795,47 @@ export function schedulerTick(
   // sweep (subtracting resumedCount in sweep 2) rather than re-shelling-out.
   const maxParallel = readMaxParallel(orchDir, concurrency);
   const liveCount = liveBackgroundCount();
+
+  // CTL-1290: board-health delegate cadence hook — SHADOW-FIRST. Runs ONLY when
+  // the daemon threads the `boardHealth` seam (its real-IO readers); a bare
+  // schedulerTick (unit test) passes none → the pass is inert and does zero real
+  // IO. Every snapshot var is already in scope here (eligible above, roster/self/
+  // multiHost at tick top, maxParallel/liveCount just above) — no re-query. NO
+  // `act` seam is passed → enforce is inert in this ticket (actuation is a
+  // follow-up). Wrapped in try/catch: a board-health failure must never break the
+  // tick. Throttled internally to BOARD_HEALTH_INTERVAL_MS.
+  if (_boardHealth) {
+    const _bhMode = _boardHealth.mode ?? readBoardHealthConfig().mode;
+    if (_bhMode !== "off") {
+      try {
+        const _bhResult = boardHealthPassFn({
+          mode: _bhMode,
+          orchDir,
+          getBoard: _boardHealth.getBoard,
+          getWorkerSignals: () => readWorkerSignals(orchDir),
+          getEligible: () => eligible, // already read this tick
+          roster,
+          self,
+          multiHost,
+          capacity: { maxParallel, liveCount, freeSlots: computeFreeSlots(maxParallel, liveCount) },
+          readEventRing: _boardHealth.readEventRing,
+          ownerForTicket,
+          getReconcileMarkers: _boardHealth.getReconcileMarkers,
+          lastRunMs: _boardHealthLastRunMs,
+          // emit defaults to defaultEmitEvent; NO `act` passed → shadow & enforce
+          // are both mutation-free in this ticket.
+          log: (o, m) => log.warn?.(o, m),
+          now,
+        });
+        if (_bhResult?.ran) _boardHealthLastRunMs = _bhResult.ranAtMs;
+      } catch (err) {
+        log.warn?.(
+          { step: "board-health", err: err.message },
+          "scheduler: board-health pass failed — continuing tick (CTL-1290)",
+        );
+      }
+    }
+  }
 
   // (STEP A) CTL-755 admission-control compute — gate the triage→research
   // promotion by deps + priority + capacity. PURE-COMPUTE + labelOnce escalation
@@ -5547,6 +5625,19 @@ function runTick() {
       // CTL-1150: thread the triage-artifact predicate (undefined → inline
       // existsSync default in schedulerTick; test seam via startScheduler).
       hasTriageArtifact: runningOpts.hasTriageArtifact,
+      // CTL-1290: thread the board-health delegate's real-IO seams. Like the
+      // stallJanitor/unstuckSweep censuses above, these are bound ONLY in the
+      // daemon — a bare schedulerTick (unit test) passes no `boardHealth` so the
+      // pass is inert (no real broker-DB / event-log / reconcile reads). Mode
+      // resolves inside the hook via readBoardHealthConfig (env > Layer-2 >
+      // "shadow"), so the daemon ships shadow-on by default while tests stay
+      // quiet. Operators kill it with CATALYST_BOARD_HEALTH=0/off. NO `act` seam
+      // is threaded → enforce is inert this ticket (actuation is a follow-up).
+      boardHealth: runningOpts.boardHealth ?? {
+        getBoard: () => getAllTicketDescriptors({ includeRemoved: false }),
+        readEventRing: () => readBoardHealthEventTail(),
+        getReconcileMarkers: () => readReconcileHealthMarkers({}),
+      },
     });
     // CTL-935 Phase 2: free-slots / R8 shadow comparator. Runs AFTER schedulerTick
     // (which produces the authoritative freeSlots value) — apples-to-apples because

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -10428,60 +10428,6 @@ describe("drained-sentinel emission (CTL-1095)", () => {
   });
 });
 
-// ─── CTL-1290: board-health delegate seam (§9.4 — thin) ──────────────────────
-// The pass logic is fully covered by board-health.test.mjs. Here we assert ONLY
-// the scheduler seam: the hook fires the injected boardHealthPassFn with the
-// in-scope capacity + eligible when the daemon threads `boardHealth`, honors the
-// mode gate, and is INERT on a bare tick (the property that keeps every other
-// schedulerTick test from doing real board-health IO).
-describe("schedulerTick — board-health seam (CTL-1290)", () => {
-  test("threads boardHealth → boardHealthPassFn called once with capacity + eligible", () => {
-    const calls = [];
-    schedulerTick(orchDir, {
-      readEligible: () => [{ identifier: "CTL-1" }, { identifier: "CTL-2" }],
-      dispatch: () => ({ code: 0 }),
-      writeStatus: () => {},
-      reclaimDeadWork: () => "noop",
-      concurrency: { maxParallel: 4 },
-      liveBackgroundCount: () => 4, // freeSlots=0 → Pass 2 dispatch is a clean no-op
-      boardHealth: { mode: "shadow" },
-      boardHealthPassFn: (opts) => {
-        calls.push(opts);
-        return { ran: true, ranAtMs: 1 };
-      },
-    });
-    expect(calls.length).toBe(1);
-    const o = calls[0];
-    expect(o.mode).toBe("shadow");
-    expect(o.capacity).toEqual({ maxParallel: 4, liveCount: 4, freeSlots: 0 });
-    expect(o.getEligible().map((e) => e.identifier)).toEqual(["CTL-1", "CTL-2"]);
-    expect(typeof o.getWorkerSignals).toBe("function");
-  });
-
-  test("boardHealth.mode:off → boardHealthPassFn NOT called", () => {
-    const calls = [];
-    schedulerTick(orchDir, {
-      readEligible: () => [],
-      dispatch: () => ({ code: 0 }),
-      writeStatus: () => {},
-      reclaimDeadWork: () => "noop",
-      liveBackgroundCount: () => 0,
-      boardHealth: { mode: "off" },
-      boardHealthPassFn: (opts) => calls.push(opts),
-    });
-    expect(calls.length).toBe(0);
-  });
-
-  test("no boardHealth seam (bare tick) → boardHealthPassFn NOT called (inert)", () => {
-    const calls = [];
-    schedulerTick(orchDir, {
-      readEligible: () => [],
-      dispatch: () => ({ code: 0 }),
-      writeStatus: () => {},
-      reclaimDeadWork: () => "noop",
-      liveBackgroundCount: () => 0,
-      boardHealthPassFn: (opts) => calls.push(opts),
-    });
-    expect(calls.length).toBe(0);
-  });
-});
+// CTL-1290: the board-health scheduler-seam tests live in board-health-seam.test.mjs
+// (a CI-included file) — scheduler.test.mjs is excluded from the CI allowlist for
+// its real-timer suite, so the seam coverage would not run here.

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -10427,3 +10427,61 @@ describe("drained-sentinel emission (CTL-1095)", () => {
     expect(emitDrainedMock).toHaveBeenCalledTimes(2);
   });
 });
+
+// ─── CTL-1290: board-health delegate seam (§9.4 — thin) ──────────────────────
+// The pass logic is fully covered by board-health.test.mjs. Here we assert ONLY
+// the scheduler seam: the hook fires the injected boardHealthPassFn with the
+// in-scope capacity + eligible when the daemon threads `boardHealth`, honors the
+// mode gate, and is INERT on a bare tick (the property that keeps every other
+// schedulerTick test from doing real board-health IO).
+describe("schedulerTick — board-health seam (CTL-1290)", () => {
+  test("threads boardHealth → boardHealthPassFn called once with capacity + eligible", () => {
+    const calls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [{ identifier: "CTL-1" }, { identifier: "CTL-2" }],
+      dispatch: () => ({ code: 0 }),
+      writeStatus: () => {},
+      reclaimDeadWork: () => "noop",
+      concurrency: { maxParallel: 4 },
+      liveBackgroundCount: () => 4, // freeSlots=0 → Pass 2 dispatch is a clean no-op
+      boardHealth: { mode: "shadow" },
+      boardHealthPassFn: (opts) => {
+        calls.push(opts);
+        return { ran: true, ranAtMs: 1 };
+      },
+    });
+    expect(calls.length).toBe(1);
+    const o = calls[0];
+    expect(o.mode).toBe("shadow");
+    expect(o.capacity).toEqual({ maxParallel: 4, liveCount: 4, freeSlots: 0 });
+    expect(o.getEligible().map((e) => e.identifier)).toEqual(["CTL-1", "CTL-2"]);
+    expect(typeof o.getWorkerSignals).toBe("function");
+  });
+
+  test("boardHealth.mode:off → boardHealthPassFn NOT called", () => {
+    const calls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus: () => {},
+      reclaimDeadWork: () => "noop",
+      liveBackgroundCount: () => 0,
+      boardHealth: { mode: "off" },
+      boardHealthPassFn: (opts) => calls.push(opts),
+    });
+    expect(calls.length).toBe(0);
+  });
+
+  test("no boardHealth seam (bare tick) → boardHealthPassFn NOT called (inert)", () => {
+    const calls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus: () => {},
+      reclaimDeadWork: () => "noop",
+      liveBackgroundCount: () => 0,
+      boardHealthPassFn: (opts) => calls.push(opts),
+    });
+    expect(calls.length).toBe(0);
+  });
+});

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -248,6 +248,21 @@ The execution-core scheduler protects itself against a single ticket dominating 
 
 The **phantom worker-dir validity sweep** quarantines a `workers/<ticket>/` dir only when all three hold: the ticket is definitively **not-found** in Linear (a clean exit-0 not-found body — a nonzero exit or transient outage classifies as `unknown` and is never quarantined), it is **not in the eligible set**, and it has **no live bg worker**. This conjunction guarantees a transient Linear outage can never quarantine a healthy, resolvable, in-flight ticket. `SCHEDULER_CIRCUIT_BREAKER_THRESHOLD` is the Linear-independent backstop; the runaway knobs are observability only.
 
+### Board-health delegate (CTL-1290)
+
+On a low-frequency cadence the scheduler runs a **whole-board health scan**: a read-only pass that evaluates board-level invariants the per-item signals never surface — a silently-held dispatch (open slots + a waiting queue + no recent dispatch), a worker idling far past its phase-normal age, a ticket blocked by a dead blocker chain, a project gone silent, a rate-limit cliff, a node that owns work but whose reconcile is failing. It emits one **`recovery.board-scan`** event per cadence (the numbers ride out as chartable OTel attributes via CTL-1291) and proposes tiered remediation moves **without acting**.
+
+Mode resolves from the env var (a single operator knob) over Layer-2 over the default. Unlike the rest of the recovery family (which ships `off`), the board-health delegate **defaults to `shadow`**: shadow is itself a dark state — it emits the scan and mutates nothing (the no-mutation guarantee is structural, not configured), so the telemetry that is the feature's whole point ships on.
+
+| Key | Default | Notes |
+|---|---|---|
+| `CATALYST_BOARD_HEALTH` _(env var)_ | `shadow` | `off` / `0` (kill-switch — strict no-op), `shadow` (scan + emit `recovery.board-scan`, take no action), `enforce` (additionally act on proposed moves — **inert in this release**: no actuation seam is wired yet). Garbage values fall back to `shadow`. Overrides Layer-2. |
+| `catalyst.boardHealth.mode` _(Layer-2)_ | `shadow` | Same three values; honored when the env var is unset. |
+| `CATALYST_BH_INTERVAL_MS` | `300000` (5 min) | Cadence floor — the scan runs at most once per interval per host. |
+| `CATALYST_BH_DISPATCH_STALL_MS` | `600000` (10 min) | Dispatch-liveness threshold: free slots + a queue + no dispatch within this window flags a wedge. |
+| `CATALYST_BH_WORKER_AGE_MS` | `14400000` (4 h) | Fallback worker-age threshold (per-phase normals override it). |
+| `CATALYST_BH_PROJECT_SILENCE_MS` | `86400000` (24 h) | Project-silence threshold (no ticket movement in the project past this window). |
+
 ### Ingestion-silence detector (CTL-1122)
 
 The broker tails every event, so it is the surviving process that can notice when an upstream ingestion source has gone silent — the out-of-process check the monitor cannot do for itself (its own health probe reports `up` iff it answers, so it can never observe its own death). Each watchdog tick the broker judges per-source event recency and edge-triggers `catalyst.ingestion.{stale,recovered}` (emit-only — it takes no corrective action; CTL-1123 is the consumer). These knobs are env vars on the `catalyst-broker` process:


### PR DESCRIPTION
## What

Wires the **board-health delegate** (CTL-1290) into the execution-core scheduler: a read-only, on-cadence scan of the *whole board* that evaluates board-level invariants the per-item signals never surface — a silently-held dispatch, a worker idling past its phase-normal age, a dead blocker chain, a silent project, a rate-limit cliff, a stranded node — runs a cheap-gate funnel, and emits one **`recovery.board-scan`** event proposing tiered remediation moves **without acting**.

Builds on the module committed WIP in `7f35bc18`; this PR validates it (TDD), adds the config flag, the scheduler hook, brief injection, the CTL-1291 data-path branch, CI registration, and docs.

**Shadow-first.** Default mode is `shadow` (the one deliberate ADR-023 deviation — shadow emits the scan and mutates nothing; the no-mutation guarantee is structural). `CATALYST_BOARD_HEALTH=0/off` is the kill-switch. **`enforce` is inert this ticket** — no `act` seam is threaded; actuation is a follow-up.

## Changes

- **`board-health.mjs`** (module): 7 exports — pure core (`evaluateInvariants`, `decideBoardHealth`, `proposeMoves`, `buildBoardContext`, `buildBoardScanEvent`) + injected-IO (`assembleBoardState`, `boardHealthPass`). Zero process-spawning imports; the board snapshot reader is injected (dodges the `bun:sqlite`/vite trap).
- **`board-health.test.mjs`** (NEW, 34 cases) + **`board-health-seam.test.mjs`** (NEW, 3 cases): per-invariant green/fail, the cheap-gate funnel, the shadow-safety proof (`act:()=>{throw}` is never called), throttle, fail-soft, and the scheduler seam.
- **`config.mjs`**: `BOARD_HEALTH_MODES` + `readBoardHealthConfig` (default `shadow`, Layer-2 + env) + tests.
- **`recovery-reasoning.mjs`**: `promoteNumericAttrs` gains the `recovery.board-scan` branch (CTL-1291 data-path) so the scan's numbers are chartable; brief injection threads `boardContext` into the **v2** recovery-pass brief — the dispatched delegate finally gets whole-board context.
- **`recovery-pass-context.mjs`**: renders the board-context block in the dispatched brief.
- **`scheduler.mjs`**: the minimal hook after the per-tick capacity hoist. Bound to the **stallJanitor pattern** — the daemon (`runTick`) threads the real-IO seams; a bare `schedulerTick` is **inert** (no real broker-DB / event-log / reconcile reads), so the pass never perturbs the unit suite.
- **CI**: `board-health.test.mjs` + `board-health-seam.test.mjs` registered in the execution-core allowlist.
- **docs**: `CATALYST_BOARD_HEALTH` + `.catalyst.boardHealth.mode` in `configuration.md`.

## Verification

- All new/extended unit tests green: board-health 34, seam 3, config (+8), recovery-reasoning (+3 board-scan, +1 brief).
- `bun build daemon.mjs` clean (no boot-breaking imports).
- `scheduler.test.mjs` full suite matches the pre-existing baseline (the 7 local failures — CTL-653 / CTL-868 / CTL-781 — fail identically on the base `8a5b1271` and are env-dependent, unrelated to this change).
- Two adversarial review passes (correctness + spec-conformance). Findings fixed in `0d70aa45`: dispatch-liveness regex was matching `phase.dispatch.{failed,escalated,runaway}` (would green the wedge during a failing dispatch loop) → narrowed to success signals; `strandedNodes` now carries `{host, ownedTickets}` per spec §5.2; seam tests moved to a CI-included file.

## Follow-ups (not this PR)

- **catalyst-otel** (separate repo): add the `recovery_*` structured-metadata promotion to `collector-config.yaml → transform/logs` so the new attributes become first-class Loki labels. Until then the numbers still ride to Loki as generic OTLP attributes (queryable, just not first-class).
- **enforce actuation**: wire the `act` seam + HRW gate (the structure is in place, currently unthreaded).

Spec: `thoughts/shared/plans/2026-06-19-ctl-1290-1291-board-health-delegate-impl-spec.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)