### PR TITLE
feat(dev): CTL-1204 — gitleaks secret-scanning CI gate + optional pre-commit hook

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,7 +11,19 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write # gitleaks-action posts a PR summary comment
+
+# The free OSS gitleaks CLI (MIT) is installed from a pinned official release
+# tarball and verified by SHA-256 before use. Only the gitleaks-ACTION wrapper
+# requires a paid org license; the binary does not. See CTL-1204.
+env:
+  GITLEAKS_VERSION: "8.28.0"
+  # SHA-256 of gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz from the official
+  # gitleaks_${GITLEAKS_VERSION}_checksums.txt release asset. Pin both.
+  GITLEAKS_SHA256: "a65b5253807a68ac0cafa4414031fd740aeb55f54fb7e55f386acb52e6a840eb"
+  # Custom exit code for "leaks found", chosen to be distinct from gitleaks'
+  # default (1), which it overloads for BOTH leaks and operational errors.
+  # With --exit-code 7: 7 == leaks (real red gate); any other nonzero == error.
+  GITLEAKS_LEAK_EXIT: "7"
 
 jobs:
   gitleaks:
@@ -20,9 +32,90 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # full history for push/schedule scans
-      - uses: gitleaks/gitleaks-action@v3
+          # Full history so push/schedule scans and PR commit-range diffs resolve.
+          fetch-depth: 0
+
+      - name: Install pinned gitleaks binary (verify checksum)
+        run: |
+          set -euo pipefail
+          tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${tarball}"
+          echo "Downloading ${url}"
+          # --fail => nonzero on HTTP >=400; --retry rides out transient blips.
+          # No failure-swallowing: a failed download MUST fail the step.
+          curl --fail --show-error --silent --location --retry 3 --retry-delay 2 \
+            --output "${tarball}" "${url}"
+          echo "${GITLEAKS_SHA256}  ${tarball}" | sha256sum --check --strict -
+          tar -xzf "${tarball}" gitleaks
+          install -m 0755 gitleaks /usr/local/bin/gitleaks
+          rm -f "${tarball}" gitleaks
+          # Fail loudly if the binary is somehow unusable (defence in depth).
+          # goreleaser builds with {{.Version}}, which strips the leading "v",
+          # so `gitleaks version` prints exactly "8.28.0".
+          installed="$(gitleaks version)"
+          echo "Installed gitleaks ${installed}"
+          test "${installed}" = "${GITLEAKS_VERSION}"
+
+      - name: Scan for secrets
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_CONFIG: .gitleaks.toml
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          # PR scans get a tight commit range; everything else scans full history.
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          args=(git
+            --config .gitleaks.toml
+            --redact
+            --no-banner
+            --exit-code "${GITLEAKS_LEAK_EXIT}"
+            --report-format sarif
+            --report-path gitleaks-report.sarif
+          )
+
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            # Guard: if the PR SHAs are empty we must NOT silently scan nothing.
+            # An empty range would otherwise make gitleaks inspect zero commits
+            # and exit 0 (false-green). Fail loudly instead.
+            if [ -z "${PR_BASE_SHA}" ] || [ -z "${PR_HEAD_SHA}" ]; then
+              echo "::error::PR base/head SHA missing (base='${PR_BASE_SHA}' head='${PR_HEAD_SHA}') — cannot scope PR scan."
+              exit 1
+            fi
+            echo "PR scan: ${PR_BASE_SHA}..${PR_HEAD_SHA}"
+            # Scan only commits introduced by the PR. base..head excludes the
+            # base tip itself, so only the PR's new commits are inspected.
+            args+=(--log-opts "${PR_BASE_SHA}..${PR_HEAD_SHA}")
+          else
+            echo "Full-history scan (event: ${GITHUB_EVENT_NAME})"
+          fi
+
+          # Run gitleaks WITHOUT `set -e` aborting on its nonzero exit, so we can
+          # branch on the exact code. This is the heart of the true-gate design.
+          set +e
+          gitleaks "${args[@]}"
+          code=$?
+          set -e
+
+          case "${code}" in
+            0)
+              echo "gitleaks: no leaks found."
+              ;;
+            "${GITLEAKS_LEAK_EXIT}")
+              echo "::error::gitleaks found one or more secrets. See annotations / SARIF report."
+              exit 1
+              ;;
+            *)
+              # ANY other nonzero (1, 126, 130, ...) is an operational error:
+              # bad flag, scan crash, corrupt repo, OOM. NEVER pass on error.
+              echo "::error::gitleaks failed to run (exit ${code}) — treating as FAILURE, not a clean pass."
+              exit 1
+              ;;
+          esac
+
+      - name: Upload SARIF report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-sarif
+          path: gitleaks-report.sarif
+          if-no-files-found: ignore

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,28 @@
+name: gitleaks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    # Weekly full-history sweep (Mondays 06:00 UTC).
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+  pull-requests: write # gitleaks-action posts a PR summary comment
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history for push/schedule scans
+      - uses: gitleaks/gitleaks-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -10,29 +10,40 @@ useDefault = true
 [allowlist]
 description = "Known-benign fixtures and documentation placeholders (CTL-1204)"
 
-# Path-based: test directories are fixture-only; allowlist wholesale.
+# Path-based: test directories / co-located test files are fixture-only.
 paths = [
   '''plugins/dev/scripts/lib/__tests__/.*''',
   '''plugins/dev/scripts/__tests__/.*''',
   '''plugins/dev/scripts/orch-monitor/__tests__/.*''',
   '''plugins/dev/scripts/execution-core/.*\.test\.mjs''',
+  # Co-located unit tests anywhere under scripts/ (e.g. lib/api-key-health.test.mjs,
+  # orch-monitor/ui/src/hooks/use-push-subscription.test.ts) carry fake fixtures.
+  '''plugins/dev/scripts/.*\.test\.(mjs|ts|tsx)''',
   '''cma/.*''',
   '''\.gitleaks\.toml''',
 ]
 
 # Regex-based: specific fake values + doc placeholders that live outside the
 # path allowlist above (READMEs, website docs, agent prompts, code comments).
-# Matched against the detected secret value.
+# Matched against the detected secret value. Anchored with ^...$ and length-
+# bounded so they cannot suppress a real token that merely shares a prefix
+# (CTL-1204 verify hardening: unanchored quantifiers over-match by substring).
 regexes = [
-  '''ghp_test[a-z_]*''',
-  '''ghp_benigntoken123''',
-  '''lin_api_test[a-z0-9_]*''',
-  '''lin_api_fake[a-z0-9_]*''',
-  '''lin_api_(abc|xyz|x|tok)\b''',
-  '''test_lin_api_token_x+''',
-  '''lin_oauth_[a-z0-9]*''',
-  '''sk-ant-xxx''',
-  '''xoxb-fake''',
-  # Documentation placeholders ending in ... / … (NOT real tokens).
-  '''(lin_api_|github_pat_|sntrys_)(\.\.\.|…)''',
+  '''^ghp_test[a-z_]{0,32}$''',
+  '''^ghp_benigntoken123$''',
+  '''^lin_api_test[a-z0-9_]{0,32}$''',
+  '''^lin_api_fake[a-z0-9_]{0,32}$''',
+  '''^lin_api_(abc|xyz|x|tok)$''',
+  '''^test_lin_api_token_x+$''',
+  '''^lin_oauth_[a-z0-9]{1,16}$''',
+  '''^sk-ant-xxx$''',
+  '''^xoxb-fake$''',
+  # Documentation placeholders (NOT real tokens): a bare "YOUR_API_KEY" in
+  # curl examples, and prefixed tokens that trail off in an ellipsis
+  # (e.g. sntrys_abc123..., lin_api_..., github_pat_…).
+  '''^YOUR_API_KEY$''',
+  '''^(lin_api_|github_pat_|sntrys_)[a-z0-9]*(\.\.\.|…)$''',
+  # Public OAuth client identifier in catalyst-agent/accounts.mjs — a public
+  # client_id (not a secret); exact value only.
+  '''^9d1c250a-e61b-44d9-88ed-5944d1962f5e$''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,38 @@
+# Gitleaks configuration (CTL-1204).
+# Extends the upstream default ruleset; adds allowlists ONLY for known
+# fake/placeholder tokens in test fixtures and documentation so the baseline
+# scan is clean. Real secrets in non-fixture source remain detectable.
+title = "catalyst gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known-benign fixtures and documentation placeholders (CTL-1204)"
+
+# Path-based: test directories are fixture-only; allowlist wholesale.
+paths = [
+  '''plugins/dev/scripts/lib/__tests__/.*''',
+  '''plugins/dev/scripts/__tests__/.*''',
+  '''plugins/dev/scripts/orch-monitor/__tests__/.*''',
+  '''plugins/dev/scripts/execution-core/.*\.test\.mjs''',
+  '''cma/.*''',
+  '''\.gitleaks\.toml''',
+]
+
+# Regex-based: specific fake values + doc placeholders that live outside the
+# path allowlist above (READMEs, website docs, agent prompts, code comments).
+# Matched against the detected secret value.
+regexes = [
+  '''ghp_test[a-z_]*''',
+  '''ghp_benigntoken123''',
+  '''lin_api_test[a-z0-9_]*''',
+  '''lin_api_fake[a-z0-9_]*''',
+  '''lin_api_(abc|xyz|x|tok)\b''',
+  '''test_lin_api_token_x+''',
+  '''lin_oauth_[a-z0-9]*''',
+  '''sk-ant-xxx''',
+  '''xoxb-fake''',
+  # Documentation placeholders ending in ... / … (NOT real tokens).
+  '''(lin_api_|github_pat_|sntrys_)(\.\.\.|…)''',
+]

--- a/plugins/dev/scripts/__tests__/gitleaks-config.test.sh
+++ b/plugins/dev/scripts/__tests__/gitleaks-config.test.sh
@@ -14,7 +14,7 @@ fi
 
 # 1. Config exists and parses / extends defaults (static asserts — always run).
 [[ -f "$CFG" ]] || { echo "FAIL: .gitleaks.toml missing"; exit 1; }
-grep -q 'useDefault' "$CFG" || { echo "FAIL: must [extend] useDefault=true"; exit 1; }
+grep -qE 'useDefault\s*=\s*true' "$CFG" || { echo "FAIL: must [extend] useDefault=true"; exit 1; }
 
 # 2. Baseline full-history scan is clean (the real gate).
 ( cd "$REPO_ROOT" && gitleaks detect --config .gitleaks.toml --no-banner --redact ) \

--- a/plugins/dev/scripts/__tests__/gitleaks-config.test.sh
+++ b/plugins/dev/scripts/__tests__/gitleaks-config.test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Tests for .gitleaks.toml (CTL-1204): config parses, extends defaults,
+# allowlists the known fake fixtures, and yields a clean baseline scan.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+CFG="${REPO_ROOT}/.gitleaks.toml"
+
+# Skip the whole suite (not fail) when the binary is unavailable — dev hosts vary.
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "SKIP: gitleaks binary not installed"
+  exit 0
+fi
+
+# 1. Config exists and parses / extends defaults (static asserts — always run).
+[[ -f "$CFG" ]] || { echo "FAIL: .gitleaks.toml missing"; exit 1; }
+grep -q 'useDefault' "$CFG" || { echo "FAIL: must [extend] useDefault=true"; exit 1; }
+
+# 2. Baseline full-history scan is clean (the real gate).
+( cd "$REPO_ROOT" && gitleaks detect --config .gitleaks.toml --no-banner --redact ) \
+  || { echo "FAIL: baseline gitleaks scan found findings"; exit 1; }
+
+echo "PASS: gitleaks baseline clean"

--- a/plugins/dev/scripts/__tests__/gitleaks-precommit-hook.test.sh
+++ b/plugins/dev/scripts/__tests__/gitleaks-precommit-hook.test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Tests for scripts/hooks/pre-commit (CTL-1204).
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+HOOK="${REPO_ROOT}/scripts/hooks/pre-commit"
+
+# Static asserts (always run).
+[[ -f "$HOOK" ]]   || { echo "FAIL: hook missing"; exit 1; }
+[[ -x "$HOOK" ]]   || { echo "FAIL: hook not executable"; exit 1; }
+grep -q 'protect --staged' "$HOOK" || { echo "FAIL: hook must call gitleaks protect --staged"; exit 1; }
+
+# Graceful no-op path: simulate missing binary via PATH override → exit 0 + warning.
+# Use /bin/bash explicitly so the PATH restriction only affects gitleaks lookup,
+# not the bash invocation itself.
+out="$(PATH="/nonexistent" /bin/bash "$HOOK" 2>&1)"; rc=$?
+[[ $rc -eq 0 ]] || { echo "FAIL: hook must exit 0 when gitleaks absent (got rc=$rc)"; exit 1; }
+grep -qi 'gitleaks' <<<"$out" || { echo "FAIL: hook should warn when gitleaks absent"; exit 1; }
+
+# Behavioral asserts need the real binary; SKIP otherwise.
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "SKIP: gitleaks binary not installed (behavioral asserts skipped)"
+  exit 0
+fi
+
+echo "PASS: pre-commit hook static + no-op behavior"

--- a/plugins/dev/scripts/__tests__/gitleaks-workflow.test.sh
+++ b/plugins/dev/scripts/__tests__/gitleaks-workflow.test.sh
@@ -1,19 +1,59 @@
 #!/usr/bin/env bash
-# Tests for .github/workflows/gitleaks.yml (CTL-1204): triggers, action ref,
-# fetch-depth, config + license wiring.
+# Tests for .github/workflows/gitleaks.yml (CTL-1204): asserts the license-free
+# OSS-binary design — pinned version + checksum, correct triggers, the repo
+# config, PR-range vs full-history scanning, and a TRUE exit-code gate with no
+# silent false-green. Replaces the old gitleaks-action assertions.
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 WF="${REPO_ROOT}/.github/workflows/gitleaks.yml"
 fail=0
-chk() { grep -Eq "$2" "$WF" || { echo "FAIL: $1"; fail=1; }; }
+chk()  { grep -Eq -- "$2" "$WF" || { echo "FAIL: $1"; fail=1; }; }
+absent() { grep -Eq -- "$2" "$WF" && { echo "FAIL: $1"; fail=1; } || true; }
 
 [[ -f "$WF" ]] || { echo "FAIL: workflow missing"; exit 1; }
-chk "uses gitleaks-action@v3"       'gitleaks/gitleaks-action@v3'
-chk "pull_request trigger"          '^\s*pull_request:'
-chk "push to main trigger"          'branches:\s*\[.*main.*\]|- main'
-chk "fetch-depth 0"                 'fetch-depth:\s*0'
-chk "GITLEAKS_CONFIG points at toml" 'GITLEAKS_CONFIG:\s*\.gitleaks\.toml'
-chk "GITLEAKS_LICENSE from secrets" 'GITLEAKS_LICENSE:\s*\$\{\{.*secrets\.GITLEAKS_LICENSE'
-chk "weekly schedule sweep"         'cron:\s*"0 6 \* \* 1"'
+
+# --- No paid action, no license anywhere ---------------------------------
+absent "must NOT use gitleaks-action"      'gitleaks/gitleaks-action'
+absent "must NOT reference a license"      'GITLEAKS_LICENSE'
+
+# --- Triggers ------------------------------------------------------------
+chk "pull_request trigger"                 '^\s*pull_request:'
+chk "push to main trigger"                 'branches:\s*\[.*main.*\]|- main'
+chk "workflow_dispatch trigger"            '^\s*workflow_dispatch:'
+chk "weekly schedule sweep"                'cron:\s*"0 6 \* \* 1"'
+
+# --- Checkout + history --------------------------------------------------
+chk "pinned checkout action"               'actions/checkout@v4'
+chk "fetch-depth 0"                        'fetch-depth:\s*0'
+
+# --- Pinned, checksum-verified supply chain ------------------------------
+chk "pinned gitleaks version"              'GITLEAKS_VERSION:\s*"?8\.28\.0"?'
+chk "pinned sha256 of release tarball"     'GITLEAKS_SHA256:\s*"?[0-9a-f]{64}"?'
+chk "downloads official release tarball"   'github\.com/gitleaks/gitleaks/releases/download'
+chk "verifies checksum"                    'sha256sum (--check|-c)'
+chk "curl fails on http error"             'curl .*--fail'
+chk "asserts installed version"            'test "\$\{installed\}" = "\$\{GITLEAKS_VERSION\}"'
+
+# --- Uses the repo config ------------------------------------------------
+chk "passes --config .gitleaks.toml"       '--config\s+\.gitleaks\.toml'
+
+# --- Correct v8.28 subcommand (NOT the deprecated detect) ----------------
+chk "uses 'gitleaks git' subcommand"       'gitleaks "\$\{args\[@\]\}"|^\s*args=\(git'
+chk "PR range via --log-opts"              '--log-opts'
+chk "PR scan conditional on pull_request"  'GITHUB_EVENT_NAME.*=.*pull_request'
+chk "guards against empty PR SHAs"         '-z "\$\{PR_BASE_SHA\}"|-z "\$\{PR_HEAD_SHA\}"'
+
+# --- TRUE gate + no silent false-green -----------------------------------
+# Custom leak exit code distinguishes leaks (gate red) from operational errors.
+chk "custom leak exit code set"            '--exit-code\s+"?\$\{GITLEAKS_LEAK_EXIT\}"?|GITLEAKS_LEAK_EXIT:\s*"?7"?'
+chk "captures exit code"                   'code=\$\?'
+chk "leak case exits nonzero"              'GITLEAKS_LEAK_EXIT\}"?\)'
+chk "error catch-all branch"               '\*\)'
+chk "error branch emits FAILURE exit 1"    'treating as FAILURE'
+
+# No swallowing of failures.
+absent "no '|| true' swallowing"           '\|\|\s*true'
+absent "no 'continue-on-error'"            'continue-on-error'
+
 [[ $fail -eq 0 ]] && echo "PASS: gitleaks workflow well-formed" || exit 1

--- a/plugins/dev/scripts/__tests__/gitleaks-workflow.test.sh
+++ b/plugins/dev/scripts/__tests__/gitleaks-workflow.test.sh
@@ -14,5 +14,6 @@ chk "pull_request trigger"          '^\s*pull_request:'
 chk "push to main trigger"          'branches:\s*\[.*main.*\]|- main'
 chk "fetch-depth 0"                 'fetch-depth:\s*0'
 chk "GITLEAKS_CONFIG points at toml" 'GITLEAKS_CONFIG:\s*\.gitleaks\.toml'
-chk "GITLEAKS_LICENSE wired"        'GITLEAKS_LICENSE'
+chk "GITLEAKS_LICENSE from secrets" 'GITLEAKS_LICENSE:\s*\$\{\{.*secrets\.GITLEAKS_LICENSE'
+chk "weekly schedule sweep"         'cron:\s*"0 6 \* \* 1"'
 [[ $fail -eq 0 ]] && echo "PASS: gitleaks workflow well-formed" || exit 1

--- a/plugins/dev/scripts/__tests__/gitleaks-workflow.test.sh
+++ b/plugins/dev/scripts/__tests__/gitleaks-workflow.test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Tests for .github/workflows/gitleaks.yml (CTL-1204): triggers, action ref,
+# fetch-depth, config + license wiring.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+WF="${REPO_ROOT}/.github/workflows/gitleaks.yml"
+fail=0
+chk() { grep -Eq "$2" "$WF" || { echo "FAIL: $1"; fail=1; }; }
+
+[[ -f "$WF" ]] || { echo "FAIL: workflow missing"; exit 1; }
+chk "uses gitleaks-action@v3"       'gitleaks/gitleaks-action@v3'
+chk "pull_request trigger"          '^\s*pull_request:'
+chk "push to main trigger"          'branches:\s*\[.*main.*\]|- main'
+chk "fetch-depth 0"                 'fetch-depth:\s*0'
+chk "GITLEAKS_CONFIG points at toml" 'GITLEAKS_CONFIG:\s*\.gitleaks\.toml'
+chk "GITLEAKS_LICENSE wired"        'GITLEAKS_LICENSE'
+[[ $fail -eq 0 ]] && echo "PASS: gitleaks workflow well-formed" || exit 1

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -14,7 +14,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 CONFIG_ARG=()
 [[ -f "${REPO_ROOT}/.gitleaks.toml" ]] && CONFIG_ARG=(--config "${REPO_ROOT}/.gitleaks.toml")
 
-if ! gitleaks protect --staged --no-banner --redact "${CONFIG_ARG[@]}"; then
+if ! gitleaks protect --staged --no-banner --redact ${CONFIG_ARG[@]+"${CONFIG_ARG[@]}"}; then
   echo "gitleaks found a potential secret in staged changes — commit blocked." >&2
   echo "   Review the finding above. If it is a known-benign fixture, add it to .gitleaks.toml." >&2
   exit 1

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Pre-commit secret scan (CTL-1204). Blocks commits that stage a real secret.
+# No-ops (exit 0) with a warning when the gitleaks binary is not installed, so
+# developers without gitleaks are not blocked — CI is the hard gate.
+set -uo pipefail
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "gitleaks not installed — skipping local secret scan (CI still gates). " \
+       "Install: https://github.com/gitleaks/gitleaks#installing" >&2
+  exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+CONFIG_ARG=()
+[[ -f "${REPO_ROOT}/.gitleaks.toml" ]] && CONFIG_ARG=(--config "${REPO_ROOT}/.gitleaks.toml")
+
+if ! gitleaks protect --staged --no-banner --redact "${CONFIG_ARG[@]}"; then
+  echo "gitleaks found a potential secret in staged changes — commit blocked." >&2
+  echo "   Review the finding above. If it is a known-benign fixture, add it to .gitleaks.toml." >&2
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## CTL-1204 — gitleaks secret-scanning gate

CI and pre-commit should reject any commit that introduces a secret.

### What
- **`.github/workflows/gitleaks.yml`** — CI job that runs gitleaks on PRs/pushes and fails the build on any finding.
- **`.gitleaks.toml`** — repo-tuned ruleset + allowlist (avoids false positives on fixtures/docs).
- **`scripts/hooks/pre-commit`** — optional local hook that runs gitleaks pre-commit (opt-in; documented).
- **Tests** — 3 bash suites covering config validity, workflow wiring, and the pre-commit hook behavior.

### Why
Closes the gap where a leaked credential could land on `main` with no automated gate (companion to CTL-1203 secrets-600 hygiene).

### Notes
- Purely additive (6 net-new files, 0 deletions). Rebased clean onto current `main`.
- Resumed from stranded mini worktree commits (originally blocked on a missing `workflow` OAuth scope on the daemon push token).

🤖 Board-janitor finish of a stalled PR (focused worker, not a re-delegation).