### PR TITLE
fix(dev): CTL-1299 — populate evidence.signal so recovery-pass bounded-LLM FIX rung fires

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -180,4 +180,5 @@ jobs:
             worktree-safety.test.mjs \
             worktree.test.mjs \
             recovery-reasoning.test.mjs \
+            recovery-evidence.test.mjs \
             unstuck-act-seams.test.mjs

--- a/plugins/dev/scripts/execution-core/recovery-evidence.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-evidence.mjs
@@ -23,7 +23,17 @@ export function buildRecoveryItems(signals, { db = null, getBeliefs = null } = {
   return signals.map((sig) => {
     const raw = sig.raw ?? {};
     const bgJobId = raw.bg_job_id ?? null;
-    let evidence = { ...raw };
+    // CTL-1299: expose the raw signal under `.signal` as well as the existing
+    // top-level spread. classifyTicket / checkBoundedLlmFixes read
+    // `evidence.signal.{failureReason,stalledReason}` (recovery-reasoning.mjs:416,
+    // 528,534,590) — without this `.signal` is always undefined, the bounded-LLM
+    // FIX rung is structurally dead, and every stalled ticket collapses to
+    // escalate-only. The top-level spread is retained so the deterministic-reason
+    // path (checkDeterministicErrors reads top-level evidence.failureReason) and
+    // the existing linearTerminal/beliefState readers keep working. `signal` is
+    // null (not {}) when there is no signal file, so an absent signal stays falsy
+    // for the classifier's early-return guard.
+    let evidence = { ...raw, signal: sig.raw ?? null };
     if (typeof getBeliefs === "function") {
       const beliefState = getBeliefs(db, sig.ticket);
       if (beliefState != null) {

--- a/plugins/dev/scripts/execution-core/recovery-evidence.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-evidence.test.mjs
@@ -7,6 +7,7 @@
 
 import { describe, test, expect } from "bun:test";
 import { buildRecoveryItems } from "./recovery-evidence.mjs";
+import { defaultClassifyTicket } from "./recovery-reasoning.mjs";
 
 describe("buildRecoveryItems (CTL-1241)", () => {
   const sig = (ticket, raw = {}) => ({ ticket, phase: "implement", raw });
@@ -47,11 +48,78 @@ describe("buildRecoveryItems (CTL-1241)", () => {
     expect(items[0].evidence.beliefState).toBeUndefined();
   });
 
-  test("handles null raw gracefully — evidence is {} not null", () => {
+  test("handles null raw gracefully — evidence carries signal:null, no raw fields", () => {
     const items = buildRecoveryItems(
       [{ ticket: "CTL-3", phase: "triage", raw: null }],
       { getBeliefs: () => null }
     );
-    expect(items[0].evidence).toEqual({});
+    // CTL-1299: a missing signal file yields signal:null (falsy → classifier's
+    // early-return guard still treats it as "no signal"), and no spurious raw fields.
+    expect(items[0].evidence).toEqual({ signal: null });
+  });
+});
+
+// ─── CTL-1299: evidence.signal starvation fix ────────────────────────────────
+//
+// The bounded-LLM FIX rung was structurally dead in production: buildRecoveryItems
+// spread the raw signal at the TOP level of evidence, but classifyTicket /
+// checkBoundedLlmFixes read `evidence.signal.{failureReason,stalledReason}` →
+// always undefined → every stalled ticket collapsed to escalate-only. The CTL-1241
+// tests above passed because they only checked top-level fields; the regression
+// lived in the GAP between buildRecoveryItems' output shape and what the classifier
+// reads. These tests close that gap by feeding the REAL buildRecoveryItems output
+// to the production classifier — the test that would have caught the prod-dead bug.
+describe("buildRecoveryItems → classifier (CTL-1299 — evidence.signal)", () => {
+  // production signal shape: readWorkerSignals attaches the full signal-file JSON
+  // as `sig.raw`. A stalled/failed worker carries failureReason/stalledReason there.
+  const prodSig = (ticket, raw) => ({ ticket, phase: raw.phase ?? "pr", raw });
+
+  test("evidence.signal carries the raw signal (failureReason/stalledReason resolvable)", () => {
+    const raw = { bg_job_id: "job-1", phase: "pr", status: "stalled", stalledReason: "source_conflict_ctl708_unavailable" };
+    const items = buildRecoveryItems([prodSig("CTL-A", raw)], {});
+    expect(items[0].evidence.signal).toBeDefined();
+    expect(items[0].evidence.signal.stalledReason).toBe("source_conflict_ctl708_unavailable");
+    // top-level spread is retained (back-compat for the deterministic-reason path)
+    expect(items[0].evidence.stalledReason).toBe("source_conflict_ctl708_unavailable");
+    expect(items[0].evidence.bg_job_id).toBe("job-1");
+  });
+
+  test("a source-conflict stall classifies as bounded-llm FIX (not escalate)", () => {
+    const raw = { bg_job_id: "job-2", phase: "pr", status: "stalled", stalledReason: "source_conflict_ctl708_unavailable" };
+    const items = buildRecoveryItems([prodSig("CTL-B", raw)], {});
+    const classification = defaultClassifyTicket(items[0].evidence);
+    expect(classification.decision).toBe("fix");
+    expect(classification.fix_class).toBe("bounded-llm");
+    // the brief (generateRemediateBrief output) is what drives phase-remediate —
+    // guard against a future change that wires the signal but degrades the brief.
+    expect(typeof classification.details.brief).toBe("string");
+    expect(classification.details.brief.length).toBeGreaterThan(0);
+  });
+
+  test("a merge-conflict failure classifies as bounded-llm FIX (not escalate)", () => {
+    const raw = { bg_job_id: "job-3", phase: "pr", status: "failed", failureReason: "merge-conflict" };
+    const items = buildRecoveryItems([prodSig("CTL-C", raw)], {});
+    const classification = defaultClassifyTicket(items[0].evidence);
+    expect(classification.decision).toBe("fix");
+    expect(classification.fix_class).toBe("bounded-llm");
+    expect(typeof classification.details.brief).toBe("string");
+    expect(classification.details.brief.length).toBeGreaterThan(0);
+  });
+
+  test("back-compat: a deterministic-seam reason still classifies as fix via top-level failureReason", () => {
+    // checkDeterministicErrors reads evidence.failureReason (top-level) — the
+    // top-level spread must survive the fix.
+    const raw = { bg_job_id: "job-4", phase: "pr", status: "failed", failureReason: "orphan-sweep-stale" };
+    const items = buildRecoveryItems([prodSig("CTL-D", raw)], {});
+    const classification = defaultClassifyTicket(items[0].evidence);
+    expect(classification.decision).toBe("fix");
+    expect(classification.fix_class).toBe("orphan_stale");
+  });
+
+  test("a stall with no recognizable reason still escalates (fix does not over-fire)", () => {
+    const raw = { bg_job_id: "job-5", phase: "implement", status: "needs-human", failureReason: "design-decision-required" };
+    const items = buildRecoveryItems([prodSig("CTL-E", raw)], {});
+    const classification = defaultClassifyTicket(items[0].evidence);
+    expect(classification.decision).toBe("escalate");
   });
 });


### PR DESCRIPTION
## What

Fixes the **evidence.signal starvation** that made recovery-pass's bounded-LLM **FIX** rung structurally dead in production (CTL-1299). The pass — `enforce` on mini — collapsed to **escalate-only** for every stalled ticket: it commented, it never fixed.

## Root cause

`buildRecoveryItems` (`recovery-evidence.mjs`) built `evidence = { ...raw }`, spreading the raw signal-file JSON at the **top level**. But the classifiers read `evidence.signal`:

- `defaultClassifyTicket` destructures `{ logsOutput, jobState, signal, ... } = evidence` (`recovery-reasoning.mjs:416`)
- `checkBoundedLlmFixes` reads `signal?.failureReason` / `signal?.stalledReason` (`recovery-reasoning.mjs:528,534,590`)

`evidence.signal` was always `undefined`, so the bounded-LLM rung returned `null` and the pass fell through to Rule 3 (escalate/human). The existing unit tests hand-built `evidence.signal = {…}` — a shape production never feeds — so they stayed green while prod was dead. (Verified by the 2026-06-20 shadow-vs-real audit, `wf_f93bcc75-09d`.)

## Fix

`evidence = { ...raw, signal: sig.raw ?? null }` in `buildRecoveryItems`:

- Populates `evidence.signal` so the bounded-LLM rung sees `signal.failureReason` / `signal.stalledReason`.
- Retains the top-level spread for the deterministic-reason path (`checkDeterministicErrors` reads top-level `evidence.failureReason`) and the `linearTerminal` / `beliefState` readers.
- `signal: null` (not `{}`) when there is no signal file — every reader uses optional chaining and the classifier's early-return guard treats `null` as falsy.
- Bonus: also un-starves two downstream readers — the escalation reason (`recovery-reasoning.mjs:678`) and the dispatched brief's `diagnosis.signal` (`:1352`), both previously always null.

## Tests

New cases in `recovery-evidence.test.mjs` feed **real `buildRecoveryItems` output** to the **production `defaultClassifyTicket`** — the test the old hand-built tests never wrote:

- source-conflict stall (`stalledReason`) → bounded-llm FIX (+ brief present)
- merge-conflict failure (`failureReason`) → bounded-llm FIX (+ brief present)
- orphan-stale → deterministic FIX preserved (top-level path)
- design-decision-required → still escalates (no over-fire)
- null-raw → `signal:null`, no spurious fields

Also **registered `recovery-evidence.test.mjs` in the CI allowlist** (`execution-core-tests.yml`) — it was absent and running vacuously.

Adversarial-verify (3 independent lenses + synthesis) returned **lgtm**: it reverted the one-line fix and confirmed 4/10 tests go RED (anti-vacuity proven), verified `sig.raw` is the right object against `signal-reader.mjs:213`, and ran the full suite **119/119**.

## Scope / follow-up

This lights up an **already-enforce** pass; no flag flip. Sister ticket **CTL-1300** wires board-health's act seam to dispatch the holistic recovery-pass delegate (whose FIX rung this PR repairs).

Relates to CTL-1290 (board-health parent), CTL-1176 (the per-item rung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
