### PR TITLE
feat(dev): CTL-1300 — board-health delegate ACTS (holistic recovery-pass dispatch on enforce)

### DIFF
--- a/plugins/dev/scripts/execution-core/board-health-seam.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health-seam.test.mjs
@@ -58,6 +58,26 @@ describe("schedulerTick — board-health seam (CTL-1290 §9.4)", () => {
     expect(typeof o.getWorkerSignals).toBe("function");
   });
 
+  test("threads boardHealth.act through to boardHealthPassFn (CTL-1300 holistic seam)", () => {
+    const calls = [];
+    const actStub = () => ({ dispatched: true });
+    schedulerTick(orchDir, {
+      readEligible: () => [{ identifier: "CTL-1" }],
+      dispatch: () => ({ code: 0 }),
+      writeStatus: () => {},
+      reclaimDeadWork: () => "noop",
+      concurrency: { maxParallel: 4 },
+      liveBackgroundCount: () => 4,
+      boardHealth: { mode: "enforce", act: actStub },
+      boardHealthPassFn: (opts) => {
+        calls.push(opts);
+        return { ran: true, ranAtMs: 1 };
+      },
+    });
+    expect(calls.length).toBe(1);
+    expect(calls[0].act).toBe(actStub); // the daemon-bound act seam reaches the pass
+  });
+
   test("boardHealth.mode:off → boardHealthPassFn NOT called", () => {
     const calls = [];
     schedulerTick(orchDir, {

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -24,12 +24,14 @@
 //      pulls from recovery-reasoning.mjs (defaultEmitEvent) is append-only on this
 //      path (the spawn-bearing recovery helpers there are never reached from here).
 //      The only actuation surface is the injected `act` dep — reachable ONLY in
-//      enforce, and the scheduler passes none in CTL-1290 (actuation is a follow-up).
+//      enforce. CTL-1300 wires the daemon binding to inject it (a holistic
+//      recovery-pass dispatch); shadow/off and a bare schedulerTick never reach it.
 //
 // Ships behind CATALYST_BOARD_HEALTH (config.mjs readBoardHealthConfig), default
 // SHADOW (the deliberate ADR-023 deviation — shadow emits one recovery.board-scan
 // heartbeat per cadence and mutates nothing). CATALYST_BOARD_HEALTH=0/off is the
-// kill-switch; a future ticket wires enforce.
+// kill-switch; enforce (CTL-1300) dispatches ONE holistic recovery-pass delegate
+// per proceeding scan, anchored + carrying the whole-board context — operator-gated.
 
 import { isThrottled } from "./config.mjs";
 import { defaultEmitEvent } from "./recovery-reasoning.mjs"; // → buildRecoveryEnvelope (CTL-1291 promotes the numbers)
@@ -467,6 +469,26 @@ export function proposeMoves(invariants, b) {
   return { tier1, tier2, tier3 };
 }
 
+// ── selectAnchor — PURE (CTL-1300). The holistic delegate's whole point is that
+// ONE dispatched recovery-pass session reads the WHOLE board (via the injected
+// boardContext) and keeps it moving. But the actuator we reuse
+// (defaultInvokeRecoveryPass) is keyed to a single ticket — it writes
+// workers/<ticket>/recovery-pass.json and dispatches a recovery-pass worker for
+// that ticket. So the holistic pass needs ONE anchor ticket as the dispatch
+// handle. Anchor where the work is most stuck: a flagged worker (tier-1 nudge),
+// else a blocked ticket (tier-2 re-dispatch-blocker), else the top of the
+// eligible queue. Returns null when the board offers no ticket handle at all
+// (a pure stranded-node / project-silence anomaly with an empty queue) — the
+// caller then takes no action this scan (those tier-3 moves are escalate-only).
+export function selectAnchor(moves, board) {
+  const firstTicket = (arr) => (arr ?? []).map((m) => m && m.ticket).find(Boolean) ?? null;
+  return (
+    firstTicket(moves?.tier1) ??
+    firstTicket(moves?.tier2) ??
+    (board?.eligible?.[0]?.id ?? null)
+  );
+}
+
 // ── (5) buildBoardContext — PURE. The whole-board brief the dispatched delegate
 // gets injected into recovery-pass.json (today it gets NONE).
 export function buildBoardContext(boardState, invariants) {
@@ -564,7 +586,7 @@ export function boardHealthPass({
   intervalMs = BOARD_HEALTH_INTERVAL_MS,
   isThrottledFn = isThrottled,
   emit = defaultEmitEvent,
-  act = undefined, // ONLY reachable in enforce; the scheduler passes NOTHING in CTL-1290
+  act = undefined, // ONLY reachable in enforce; the daemon injects it (CTL-1300), shadow/off never do
   now = () => Date.now(),
   log = () => {},
 } = {}) {
@@ -587,20 +609,37 @@ export function boardHealthPass({
     log({ err: err.message }, "board-health: emit failed (continuing)");
   }
 
-  // enforce-ONLY actuation, and only if a caller injected an `act` seam. The
-  // scheduler does NOT in CTL-1290 → enforce is inert here. Guard kept so a
-  // future ticket can wire it without re-touching the safety structure.
+  // enforce-ONLY actuation (CTL-1300), and only if a caller injected an `act`
+  // seam. SHADOW-FIRST is preserved structurally: shadow never reaches here, and
+  // the scheduler injects an `act` ONLY in the daemon binding (operator-gated via
+  // CATALYST_BOARD_HEALTH=enforce). This is the HOLISTIC dispatch — ONE
+  // recovery-pass delegate per proceeding scan, anchored to board-health's chosen
+  // ticket and carrying the whole-board boardContext (the delegate reasons across
+  // the WHOLE board, not once per proposed move). The actuator the scheduler
+  // binds is the audited-real, capped, cooldown'd defaultInvokeRecoveryPass.
+  let actResult;
   if (mode === "enforce" && typeof act === "function" && dec.gate.decision === "proceed") {
-    for (const move of [...dec.moves.tier1, ...dec.moves.tier2, ...dec.moves.tier3]) {
-      if (multiHost && move.ticket && board.ownerForTicket) {
-        let owner;
-        try { owner = board.ownerForTicket(move.ticket, board.roster); } catch { owner = null; }
-        if (owner && owner !== board.self) continue; // HRW gate — don't act on another host's item
+    const anchor = selectAnchor(dec.moves, board);
+    let owner = null;
+    if (anchor && multiHost && board.ownerForTicket) {
+      try { owner = board.ownerForTicket(anchor, board.roster); } catch { owner = null; }
+    }
+    if (!anchor) {
+      log({ reason: "no-anchor" }, "board-health: proceed but no ticket anchor — no holistic dispatch this scan");
+    } else if (owner && owner !== board.self) {
+      // HRW gate — only the host that owns the anchor dispatches (no cross-host double-act).
+      log({ anchor, owner }, "board-health: anchor owned by another host (HRW) — skipping holistic dispatch");
+    } else {
+      const boardContext = buildBoardContext(board, invariants);
+      try {
+        actResult = act({ anchor, boardContext, decision: dec, board }) ?? null;
+        log({ anchor, dispatched: actResult?.dispatched ?? null }, "board-health: holistic recovery-pass delegate actuated");
+      } catch (err) {
+        log({ err: err.message, anchor }, "board-health: act failed (continuing)");
       }
-      try { act(move, board); } catch (err) { log({ err: err.message, move }, "board-health: act failed (continuing)"); }
     }
   }
 
   _lastRunMs = nowMs;
-  return { ran: true, mode, ranAtMs: nowMs, invariants, decision: dec };
+  return { ran: true, mode, ranAtMs: nowMs, invariants, decision: dec, act: actResult ?? null };
 }

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -14,6 +14,7 @@ import {
   evaluateInvariants,
   decideBoardHealth,
   proposeMoves,
+  selectAnchor,
   buildBoardContext,
   buildBoardScanEvent,
   boardHealthPass,
@@ -495,18 +496,72 @@ describe("boardHealthPass — mode branching + shadow safety", () => {
     expect(emits[0].details.mode).toBe("enforce");
   });
 
-  test("mode:enforce WITH act stub → act called once per proposed move (future-wiring proof)", () => {
+  test("mode:enforce WITH act → ONE holistic dispatch carrying anchor + boardContext (CTL-1300)", () => {
     const emits = [];
     const acted = [];
-    boardHealthPass(
-      flaggedDeps({ mode: "enforce", emit: (e) => emits.push(e), act: (move) => acted.push(move) }),
+    const r = boardHealthPass(
+      flaggedDeps({
+        mode: "enforce",
+        emit: (e) => emits.push(e),
+        act: (payload) => { acted.push(payload); return { dispatched: true, attempts: 1 }; },
+      }),
     );
-    // the flagged board proposes exactly one tier-1 kick-dispatch
+    // ONE delegate per proceeding scan — NOT one per proposed move.
     expect(acted.length).toBe(1);
-    expect(acted[0].move).toBe("kick-dispatch");
+    // the dispatch-wedge board proposes only a (ticketless) kick-dispatch → anchor
+    // falls back to the top eligible ticket.
+    expect(acted[0].anchor).toBe("CTL-1");
+    // the delegate gets the WHOLE-board context, not a per-item brief.
+    expect(acted[0].boardContext.schema).toBe("recovery-board-context/v1");
+    expect(acted[0].decision.gate.decision).toBe("proceed");
+    // the act result is threaded back into the pass result (observability).
+    expect(r.act).toEqual({ dispatched: true, attempts: 1 });
   });
 
-  test("enforce + multiHost: HRW gate skips a move owned by another host", () => {
+  test("anchor prefers a flagged stuck worker (tier-1 nudge) over the eligible queue", () => {
+    const acted = [];
+    boardHealthPass(
+      flaggedDeps({
+        mode: "enforce",
+        emit: () => {},
+        // a worker idling well past phase-normal → worker-age flags it → tier-1 nudge w/ ticket
+        getWorkerSignals: () => [
+          { ticket: "CTL-STUCK", phase: "implement", status: "running", updatedAt: new Date(NOW - 10 * HOUR).toISOString() },
+        ],
+        act: (payload) => acted.push(payload),
+      }),
+    );
+    expect(acted.length).toBe(1);
+    expect(acted[0].anchor).toBe("CTL-STUCK"); // nudge ticket beats eligible[0]=CTL-1
+  });
+
+  test("proceed but NO ticket anchor (only a host/project move + empty queue) → no dispatch", () => {
+    const acted = [];
+    const r = boardHealthPass({
+      orchDir: "/tmp/x",
+      mode: "enforce",
+      getBoard: () => [{ identifier: "CTL-A" }],
+      getWorkerSignals: () => [],
+      getEligible: () => [], // empty queue → no eligible-fallback anchor
+      roster: ["mini", "mini-2"],
+      self: "mini",
+      multiHost: true,
+      capacity: { maxParallel: 4, liveCount: 1, freeSlots: 3 }, // free>0 → past the no-free-slots gate
+      readEventRing: () => [],
+      ownerForTicket: () => "mini", // mini owns CTL-A
+      getReconcileMarkers: () => ({ mini: { consecutiveFailures: 2 } }), // stranded: owns work + reconcile failing
+      lastRunMs: 0,
+      intervalMs: 0,
+      now: () => NOW,
+      emit: () => {},
+      act: (payload) => acted.push(payload),
+    });
+    // strandedNode → tier-3 host move (no ticket); empty queue → selectAnchor null → no dispatch
+    expect(acted.length).toBe(0);
+    expect(r.ran).toBe(true);
+  });
+
+  test("enforce + multiHost: HRW gate skips when the anchor is owned by another host", () => {
     const acted = [];
     boardHealthPass({
       orchDir: "/tmp/x",
@@ -519,16 +574,24 @@ describe("boardHealthPass — mode branching + shadow safety", () => {
       multiHost: true,
       capacity: { maxParallel: 4, liveCount: 1, freeSlots: 3 },
       readEventRing: () => [],
-      ownerForTicket: () => "mini-2", // every ticket owned by the OTHER host
+      ownerForTicket: () => "mini-2", // the anchor (nudge CTL-OWNED-ELSEWHERE) is owned by the OTHER host
       getReconcileMarkers: () => ({}),
       lastRunMs: 0,
       intervalMs: 0,
       now: () => NOW,
       emit: () => {},
-      act: (move) => acted.push(move),
+      act: (payload) => acted.push(payload),
     });
-    // the only proposed move (nudge CTL-OWNED-ELSEWHERE) is owned by mini-2 → skipped
+    // anchor = CTL-OWNED-ELSEWHERE, owned by mini-2 → HRW gate skips the holistic dispatch
     expect(acted.length).toBe(0);
+  });
+
+  test("selectAnchor: tier-1 nudge > tier-2 re-dispatch-blocker > top eligible > null", () => {
+    const board = { eligible: [{ id: "CTL-ELIG" }] };
+    expect(selectAnchor({ tier1: [{ move: "kick-dispatch" }, { ticket: "CTL-N", move: "nudge" }], tier2: [{ ticket: "CTL-B", move: "re-dispatch-blocker" }], tier3: [] }, board)).toBe("CTL-N");
+    expect(selectAnchor({ tier1: [{ move: "kick-dispatch" }], tier2: [{ ticket: "CTL-B", move: "re-dispatch-blocker" }], tier3: [] }, board)).toBe("CTL-B");
+    expect(selectAnchor({ tier1: [{ move: "kick-dispatch" }], tier2: [], tier3: [{ host: "mini-2" }] }, board)).toBe("CTL-ELIG");
+    expect(selectAnchor({ tier1: [], tier2: [], tier3: [{ host: "mini-2" }] }, { eligible: [] })).toBe(null);
   });
 
   test("throttle: a call within intervalMs returns {ran:false,reason:throttled} with NO emit", () => {

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -990,13 +990,14 @@ export function readDeadDocWorkerConfig() {
 // itself a dark state. It emits ONE throttled `recovery.board-scan` heartbeat per
 // cadence and mutates NOTHING — the no-mutation guarantee is structural in
 // board-health.mjs (no process-spawning import; the `act` seam is enforce-gated
-// and the scheduler supplies none). The ticket's whole value IS that shadow
+// and shadow/off never reach it). The ticket's whole value IS that shadow
 // telemetry, so a shadow default ships the feature on; CATALYST_BOARD_HEALTH=0/off
 // is the kill-switch.
 //   off     → strict no-op: behaviour byte-for-byte identical to pre-CTL-1290.
 //   shadow  → scan + emit recovery.board-scan, take NO action (the default).
-//   enforce → additionally act on proposed moves — UNWIRED in CTL-1290 (the
-//             scheduler passes no `act` seam, so enforce is inert until a follow-up).
+//   enforce → additionally ACT (CTL-1300): on a proceeding scan, dispatch ONE
+//             holistic recovery-pass delegate anchored to a flagged ticket and
+//             carrying the whole-board context. Operator-gated — never auto-enabled.
 export const BOARD_HEALTH_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2BoardHealth() {

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -3800,10 +3800,12 @@ export function schedulerTick(
   // the daemon threads the `boardHealth` seam (its real-IO readers); a bare
   // schedulerTick (unit test) passes none → the pass is inert and does zero real
   // IO. Every snapshot var is already in scope here (eligible above, roster/self/
-  // multiHost at tick top, maxParallel/liveCount just above) — no re-query. NO
-  // `act` seam is passed → enforce is inert in this ticket (actuation is a
-  // follow-up). Wrapped in try/catch: a board-health failure must never break the
-  // tick. Throttled internally to BOARD_HEALTH_INTERVAL_MS.
+  // multiHost at tick top, maxParallel/liveCount just above) — no re-query.
+  // CTL-1300: the optional `act` seam is threaded too — supplied ONLY by the
+  // daemon binding (the holistic recovery-pass dispatcher) and reached ONLY in
+  // enforce; a bare tick / shadow passes none → mutation-free. Wrapped in
+  // try/catch: a board-health failure must never break the tick. Throttled
+  // internally to BOARD_HEALTH_INTERVAL_MS.
   if (_boardHealth) {
     const _bhMode = _boardHealth.mode ?? readBoardHealthConfig().mode;
     if (_bhMode !== "off") {
@@ -3822,8 +3824,11 @@ export function schedulerTick(
           ownerForTicket,
           getReconcileMarkers: _boardHealth.getReconcileMarkers,
           lastRunMs: _boardHealthLastRunMs,
-          // emit defaults to defaultEmitEvent; NO `act` passed → shadow & enforce
-          // are both mutation-free in this ticket.
+          // emit defaults to defaultEmitEvent. CTL-1300: thread the optional `act`
+          // seam — supplied ONLY by the daemon binding (the holistic recovery-pass
+          // dispatcher) and reached ONLY in enforce. A bare schedulerTick / shadow
+          // mode passes no `act` → mutation-free (the shadow-first guarantee).
+          act: _boardHealth.act,
           log: (o, m) => log.warn?.(o, m),
           now,
         });
@@ -5631,12 +5636,57 @@ function runTick() {
       // pass is inert (no real broker-DB / event-log / reconcile reads). Mode
       // resolves inside the hook via readBoardHealthConfig (env > Layer-2 >
       // "shadow"), so the daemon ships shadow-on by default while tests stay
-      // quiet. Operators kill it with CATALYST_BOARD_HEALTH=0/off. NO `act` seam
-      // is threaded → enforce is inert this ticket (actuation is a follow-up).
+      // quiet. Operators kill it with CATALYST_BOARD_HEALTH=0/off.
+      //
+      // CTL-1300: the HOLISTIC `act` seam — bound ONLY here (the daemon) and
+      // reached ONLY in enforce (operator-gated via CATALYST_BOARD_HEALTH=enforce;
+      // shadow never calls it). On a proceeding board scan it dispatches ONE
+      // recovery-pass delegate, anchored to board-health's chosen ticket and
+      // carrying the whole-board boardContext, by reusing the audited-real, capped,
+      // cooldown'd defaultInvokeRecoveryPass (recoveryInvokeRecoveryPass) — NOT a
+      // new mutator. The brief's boardContext gives the dispatched delegate
+      // whole-board eyes (printDispatchedBrief renders it; the recovery-pass skill
+      // consumes it as its Step -1 board scan).
+      //
+      // The executor reuses the SAME host-local cooldown ledger the per-item
+      // recovery path uses (recoveryShouldSkipItem/recoveryRecordIntent, the 30-min
+      // RECOVERY_COOLDOWN_MS window): board-health's 5-min interval throttle alone
+      // would re-dispatch a chronically-flagged anchor every 5 min, and the
+      // recovery-pass cap only counts `.complete` events so a repeatedly-FAILING
+      // anchor never trips it. Gating the anchor on the cooldown ledger (skip when
+      // already acted within the window; record the intent after dispatching) bounds
+      // re-dispatch of one anchor to once per cooldown window, exactly like the
+      // per-item path (scheduler.mjs recovery block).
       boardHealth: runningOpts.boardHealth ?? {
         getBoard: () => getAllTicketDescriptors({ includeRemoved: false }),
         readEventRing: () => readBoardHealthEventTail(),
         getReconcileMarkers: () => readReconcileHealthMarkers({}),
+        act: ({ anchor, boardContext, decision }) => {
+          const deps = { orchDir: runningOpts.orchDir };
+          // Reuse the recovery cooldown ledger so we don't re-dispatch the same
+          // anchor every board-health interval (the cap counts only `.complete`).
+          if (recoveryShouldSkipItem(anchor, deps)) {
+            return { dispatched: false, reason: "recovery-cooldown", anchor };
+          }
+          const r = recoveryInvokeRecoveryPass(
+            anchor,
+            {
+              boardContext,
+              reason: `board-health: ${decision?.gate?.reason ?? "board anomaly"} — holistic recovery-pass delegate`,
+            },
+            deps,
+          );
+          // Start the cooldown window on a dispatch attempt (success OR failure) so
+          // a failing anchor isn't re-dispatched until the window elapses.
+          try {
+            recoveryRecordIntent(
+              anchor,
+              { type: "recovery-pass", decision: "fix", fix_class: "board-health", outcome: !!r?.dispatched, source: "board-health" },
+              deps,
+            );
+          } catch { /* ledger write is best-effort — never block the tick */ }
+          return r;
+        },
       },
     });
     // CTL-935 Phase 2: free-slots / R8 shadow comparator. Runs AFTER schedulerTick

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -188,6 +188,18 @@ The script's banner is your context:
 - `MODE=dispatched` → the brief block + tail-of-logs is printed; you own that ONE
   ticket. Go to the Step-0..4 fix loop. (Brief missing → it falls through to a
   ticket-scoped sweep and you reconstruct the diagnosis yourself.)
+  - **HOLISTIC dispatch (CTL-1300) — when the brief carries a `board context
+    (whole-board, read-only)` block** (printed under the header
+    `--- board context (whole-board, read-only) ---`): the
+    daemon-side **board-health delegate** (CTL-1290) already ran the Step -1 board
+    scan and dispatched you ON a detected board anomaly. Your `CATALYST_TICKET` is
+    only the **anchor** (the dispatch handle) — your **mandate is the WHOLE board**,
+    exactly like the operator sweep. CONSUME the injected board context as your
+    Step -1 result (its slots / eligible-queue / stuck-workers / stranded-nodes /
+    invariants are the daemon's findings — do NOT re-derive the scan cold), then
+    keep the board moving: walk the anomalies it surfaced and the flagged set, FIX
+    or ESCALATE per the 3-tier rope. Verify-before-act still applies to anything
+    you touch.
 - `MODE=sweep` → a `STUCK YOURS <ticket> [...]` line per owned item, then (when
   multiHost) a `CONTEXT` group of items another host owns, and a
   `TOTAL: N items (M yours, K context)` summary. ACT on the YOURS items — walk
@@ -341,6 +353,17 @@ worst wedges emit NO item signal at all (the scheduler silently holding dispatch
 a node that stopped participating, a blocker nobody scheduled). A human sees those
 in two seconds; your job is to see them too. Walk these board-level invariants; for
 each, print `BOARD <invariant> OK` or `BOARD <invariant> ANOMALY: <what> → <action>`.
+
+> **If your brief carried an injected board context (CTL-1300 holistic dispatch),
+> START FROM IT — don't re-derive cold.** When the daemon-side board-health delegate
+> dispatched you, the `board context (whole-board, read-only)` block already carries
+> this scan's result: per-invariant `{ok, failed}`, the stuck workers + ages, the
+> stranded nodes + their owned tickets, slots, and the eligible-queue depth. Treat
+> those as the daemon's authoritative findings for the invariants below — confirm
+> and ACT on them rather than re-running the full LogQL/PromQL sweep from scratch
+> (the daemon already paid that cost; re-hammering Loki/Linear is itself a wedge
+> cause). Drop to the live queries only to fill a gap the injected context did not
+> cover, or to verify-before-act on a specific item you are about to touch.
 
 > **Your eyes here are the sensing substrate — these checks are queries, not vibes.**
 > The copy-paste LogQL/PromQL recipes, the silent-daemon detector, and a per-signal

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -250,13 +250,13 @@ The **phantom worker-dir validity sweep** quarantines a `workers/<ticket>/` dir 
 
 ### Board-health delegate (CTL-1290)
 
-On a low-frequency cadence the scheduler runs a **whole-board health scan**: a read-only pass that evaluates board-level invariants the per-item signals never surface — a silently-held dispatch (open slots + a waiting queue + no recent dispatch), a worker idling far past its phase-normal age, a ticket blocked by a dead blocker chain, a project gone silent, a rate-limit cliff, a node that owns work but whose reconcile is failing. It emits one **`recovery.board-scan`** event per cadence (the numbers ride out as chartable OTel attributes via CTL-1291) and proposes tiered remediation moves **without acting**.
+On a low-frequency cadence the scheduler runs a **whole-board health scan**: a read-only pass that evaluates board-level invariants the per-item signals never surface — a silently-held dispatch (open slots + a waiting queue + no recent dispatch), a worker idling far past its phase-normal age, a ticket blocked by a dead blocker chain, a project gone silent, a rate-limit cliff, a node that owns work but whose reconcile is failing. It emits one **`recovery.board-scan`** event per cadence (the numbers ride out as chartable OTel attributes via CTL-1291) and proposes tiered remediation moves. In `shadow` (the default) it takes **no action**; in `enforce` (CTL-1300) a proceeding scan dispatches **one holistic recovery-pass delegate** — see the `enforce` row below.
 
 Mode resolves from the env var (a single operator knob) over Layer-2 over the default. Unlike the rest of the recovery family (which ships `off`), the board-health delegate **defaults to `shadow`**: shadow is itself a dark state — it emits the scan and mutates nothing (the no-mutation guarantee is structural, not configured), so the telemetry that is the feature's whole point ships on.
 
 | Key | Default | Notes |
 |---|---|---|
-| `CATALYST_BOARD_HEALTH` _(env var)_ | `shadow` | `off` / `0` (kill-switch — strict no-op), `shadow` (scan + emit `recovery.board-scan`, take no action), `enforce` (additionally act on proposed moves — **inert in this release**: no actuation seam is wired yet). Garbage values fall back to `shadow`. Overrides Layer-2. |
+| `CATALYST_BOARD_HEALTH` _(env var)_ | `shadow` | `off` / `0` (kill-switch — strict no-op), `shadow` (scan + emit `recovery.board-scan`, take no action), `enforce` (CTL-1300 — on a proceeding scan, dispatch **one holistic recovery-pass delegate** anchored to a flagged ticket and carrying the whole-board context; reuses the capped + cooldown'd recovery-pass actuator. **Operator-gated — never auto-enabled**). Garbage values fall back to `shadow`. Overrides Layer-2. |
 | `catalyst.boardHealth.mode` _(Layer-2)_ | `shadow` | Same three values; honored when the env var is unset. |
 | `CATALYST_BH_INTERVAL_MS` | `300000` (5 min) | Cadence floor — the scan runs at most once per interval per host. |
 | `CATALYST_BH_DISPATCH_STALL_MS` | `600000` (10 min) | Dispatch-liveness threshold: free slots + a queue + no dispatch within this window flags a wedge. |


### PR DESCRIPTION
## What

Makes the **board-health delegate ACT** (CTL-1300). CTL-1290 shipped it shadow-first — it scans the whole board on cadence, emits `recovery.board-scan`, proposes tier-1/2/3 moves, but the enforce `act` seam was never threaded (inert). This wires it as **ONE holistic dispatch** (Ryan-chosen design, not per-move fan-out): on a proceeding scan, dispatch **a single recovery-pass delegate** anchored to a flagged ticket and carrying the **whole-board `boardContext`**, reusing the audited-real, capped, cooldown'd `defaultInvokeRecoveryPass` — **no new mutator**.

## How

- **`board-health.mjs`** — new pure `selectAnchor(moves, board)` (tier-1 `nudge` → tier-2 `re-dispatch-blocker` → top eligible → `null`). `boardHealthPass`'s enforce block now builds `boardContext = buildBoardContext(board, invariants)`, selects + HRW-gates the anchor, calls `act({anchor, boardContext, decision, board})` **once**, and threads the result into the return.
- **`scheduler.mjs`** — `act` threaded through the hook; the **daemon binding** supplies the real executor → `recoveryInvokeRecoveryPass(anchor, {boardContext, reason}, {orchDir})`. The executor is gated by the **recovery cooldown ledger** (`shouldSkipItem`/`recordIntent`) so a chronically-flagged anchor is bounded to `RECOVERY_MAX_ATTEMPTS` (2), ≥30 min apart — not re-dispatched every 5-min board-health interval.
- **`recovery-pass/SKILL.md`** — when the brief carries a `board context (whole-board, read-only)` block, the delegate **consumes it as its Step -1 board scan** and acts whole-board (the anchor is just the dispatch handle), instead of re-deriving the scan cold. (`printDispatchedBrief` already renders it; the skill now uses it.)
- **`configuration.md`** + stale "enforce is inert / no act seam" comments updated.

## Safety — SHADOW-FIRST preserved (the load-bearing CTL-1290 property)

`act` is reachable **only in enforce** AND **only when the daemon injects it** — shadow, off, and a bare `schedulerTick` take **zero mutating action**. Default stays `shadow`; **enforce is operator-gated, never auto-enabled**. Single dispatch per proceeding scan; HRW-gated anchor (no cross-host double-act); throttled to `BOARD_HEALTH_INTERVAL_MS` (5 min) and bounded by the recovery cooldown/attempt ledger.

## Verification

- **5-lens adversarial-verify** (shadow-safety / dispatch-correctness / HRW-cap-storm / SKILL.md / regression): shadow-first confirmed airtight; the one medium finding (holistic path bypassed the recovery cooldown ledger → 5-min re-dispatch drip) is **fixed in this PR** by routing the anchor through `shouldSkipItem`/`recordIntent`. Doc + comment-staleness findings also fixed.
- Tests: `board-health` (37) + seam (incl. a new `act`-threading case) + `recovery-reasoning` + `recovery` — **421 pass, 0 fail**. New holistic cases (one dispatch, anchor priority, boardContext shape, HRW skip, no-anchor skip) cover the path.
- `bun build daemon.mjs --target=bun` — **clean** (no boot-breaking imports).

## Follow-up (noted, not blocking)

The recovery-pass cap counts only `phase.recovery-pass.complete.*` events, so a repeatedly-*failing* anchor doesn't progress the cap — the cooldown ledger added here is what bounds it (2 attempts, 30-min apart). Counting `.failed` toward the cap is a separate recovery-pass concern affecting the per-item path too.

Relates to CTL-1290 (parent), CTL-1176 (per-item rung), CTL-1299 (the FIX rung the dispatched delegate now relies on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
