### PR TITLE
fix(dev): CTL-1302 — board-health selectAnchor prefers a self-owned ticket (multi-host)

### DIFF
--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -480,12 +480,28 @@ export function proposeMoves(invariants, b) {
 // eligible queue. Returns null when the board offers no ticket handle at all
 // (a pure stranded-node / project-silence anomaly with an empty queue) — the
 // caller then takes no action this scan (those tier-3 moves are escalate-only).
+//
+// CTL-1302: the anchor MUST be one THIS host HRW-owns. Otherwise, on a multi-host
+// board, picking the first flagged ticket (which may be foreign-owned) and then
+// HRW-skipping at the act site stalls the whole scan even when this host owns a
+// LATER flagged ticket it could act on. So we filter every candidate to self-owned
+// before applying the tier-1 > tier-2 > eligible priority. Single-host (no roster /
+// no ownerForTicket / multiHost false) owns everything → behavior unchanged.
 export function selectAnchor(moves, board) {
-  const firstTicket = (arr) => (arr ?? []).map((m) => m && m.ticket).find(Boolean) ?? null;
+  const owns = (ticket) => {
+    if (!ticket) return false;
+    if (!board || !board.multiHost || typeof board.ownerForTicket !== "function") return true;
+    try {
+      return board.ownerForTicket(ticket, board.roster) === board.self;
+    } catch {
+      return true; // fail-open: a broken HRW read must not block self-owned actuation
+    }
+  };
+  const firstOwned = (arr) => (arr ?? []).map((m) => m && m.ticket).filter(Boolean).find(owns) ?? null;
   return (
-    firstTicket(moves?.tier1) ??
-    firstTicket(moves?.tier2) ??
-    (board?.eligible?.[0]?.id ?? null)
+    firstOwned(moves?.tier1) ??
+    firstOwned(moves?.tier2) ??
+    ((board?.eligible ?? []).map((e) => e && e.id).filter(Boolean).find(owns) ?? null)
   );
 }
 
@@ -619,16 +635,14 @@ export function boardHealthPass({
   // binds is the audited-real, capped, cooldown'd defaultInvokeRecoveryPass.
   let actResult;
   if (mode === "enforce" && typeof act === "function" && dec.gate.decision === "proceed") {
+    // CTL-1302: selectAnchor already HRW-filters to a SELF-OWNED ticket (or null
+    // when this host owns none of the flagged/eligible) — so there is no separate
+    // cross-host skip here. A null anchor means "nothing of mine to act on this
+    // scan" (e.g. all flagged work is owned by other hosts, or only host/project
+    // tier-3 moves with no ticket handle).
     const anchor = selectAnchor(dec.moves, board);
-    let owner = null;
-    if (anchor && multiHost && board.ownerForTicket) {
-      try { owner = board.ownerForTicket(anchor, board.roster); } catch { owner = null; }
-    }
     if (!anchor) {
-      log({ reason: "no-anchor" }, "board-health: proceed but no ticket anchor — no holistic dispatch this scan");
-    } else if (owner && owner !== board.self) {
-      // HRW gate — only the host that owns the anchor dispatches (no cross-host double-act).
-      log({ anchor, owner }, "board-health: anchor owned by another host (HRW) — skipping holistic dispatch");
+      log({ reason: "no-owned-anchor" }, "board-health: proceed but no self-owned ticket anchor — no holistic dispatch this scan");
     } else {
       const boardContext = buildBoardContext(board, invariants);
       try {

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -561,7 +561,7 @@ describe("boardHealthPass — mode branching + shadow safety", () => {
     expect(r.ran).toBe(true);
   });
 
-  test("enforce + multiHost: HRW gate skips when the anchor is owned by another host", () => {
+  test("enforce + multiHost: no self-owned flagged ticket → no dispatch (CTL-1302: selectAnchor returns null)", () => {
     const acted = [];
     boardHealthPass({
       orchDir: "/tmp/x",
@@ -592,6 +592,75 @@ describe("boardHealthPass — mode branching + shadow safety", () => {
     expect(selectAnchor({ tier1: [{ move: "kick-dispatch" }], tier2: [{ ticket: "CTL-B", move: "re-dispatch-blocker" }], tier3: [] }, board)).toBe("CTL-B");
     expect(selectAnchor({ tier1: [{ move: "kick-dispatch" }], tier2: [], tier3: [{ host: "mini-2" }] }, board)).toBe("CTL-ELIG");
     expect(selectAnchor({ tier1: [], tier2: [], tier3: [{ host: "mini-2" }] }, { eligible: [] })).toBe(null);
+  });
+
+  // ─── CTL-1302: selectAnchor must prefer a SELF-OWNED flagged ticket ──────────
+  // The bug (observed live on mini 2026-06-21): selectAnchor picked the FIRST
+  // flagged ticket regardless of HRW ownership; if that was foreign-owned the act
+  // block HRW-skipped the WHOLE scan instead of trying a later flagged ticket this
+  // host owns. So on a multi-host board, board-health stalled instead of acting on
+  // owned work. selectAnchor must filter to self-owned (single-host owns all).
+  test("selectAnchor (CTL-1302) prefers a self-owned flagged ticket over a foreign-owned earlier one", () => {
+    const board = {
+      self: "mini", multiHost: true, roster: ["mini", "mini-2"],
+      ownerForTicket: (t) => (t === "CTL-MINE" ? "mini" : "mini-2"),
+      eligible: [],
+    };
+    const moves = { tier1: [{ ticket: "CTL-FOREIGN", move: "nudge" }, { ticket: "CTL-MINE", move: "nudge" }], tier2: [], tier3: [] };
+    expect(selectAnchor(moves, board)).toBe("CTL-MINE");
+  });
+
+  test("selectAnchor (CTL-1302) returns null when this host owns NONE of the flagged/eligible", () => {
+    const board = {
+      self: "mini", multiHost: true, roster: ["mini", "mini-2"],
+      ownerForTicket: () => "mini-2", eligible: [{ id: "CTL-E" }],
+    };
+    const moves = { tier1: [{ ticket: "CTL-A", move: "nudge" }], tier2: [{ ticket: "CTL-B", move: "re-dispatch-blocker" }], tier3: [] };
+    expect(selectAnchor(moves, board)).toBe(null);
+  });
+
+  test("selectAnchor (CTL-1302) falls back to a self-owned eligible ticket (skips foreign eligible)", () => {
+    const board = {
+      self: "mini", multiHost: true, roster: ["mini", "mini-2"],
+      ownerForTicket: (t) => (t === "CTL-E2" ? "mini" : "mini-2"),
+      eligible: [{ id: "CTL-E1" }, { id: "CTL-E2" }], // E1 foreign, E2 mine
+    };
+    const moves = { tier1: [{ move: "kick-dispatch" }], tier2: [], tier3: [] };
+    expect(selectAnchor(moves, board)).toBe("CTL-E2");
+  });
+
+  test("selectAnchor (CTL-1302) single-host (no ownerForTicket / multiHost false) owns all — unchanged", () => {
+    expect(selectAnchor({ tier1: [{ ticket: "CTL-X", move: "nudge" }], tier2: [], tier3: [] }, { eligible: [{ id: "CTL-1" }] })).toBe("CTL-X");
+    expect(selectAnchor({ tier1: [{ ticket: "CTL-X", move: "nudge" }], tier2: [], tier3: [] }, { multiHost: false, ownerForTicket: () => "mini-2", self: "mini", eligible: [] })).toBe("CTL-X");
+  });
+
+  test("boardHealthPass (CTL-1302): multiHost dispatches against the self-owned flagged ticket, not the foreign first one", () => {
+    const acted = [];
+    boardHealthPass({
+      orchDir: "/tmp/x",
+      mode: "enforce",
+      // two stalled workers: CTL-FOREIGN (mini-2) flagged first, CTL-MINE (mini) flagged second
+      getBoard: () => [{ identifier: "CTL-FOREIGN" }, { identifier: "CTL-MINE" }],
+      getWorkerSignals: () => [
+        { ticket: "CTL-FOREIGN", phase: "implement", status: "running", updatedAt: new Date(NOW - 6 * HOUR).toISOString() },
+        { ticket: "CTL-MINE", phase: "implement", status: "running", updatedAt: new Date(NOW - 6 * HOUR).toISOString() },
+      ],
+      getEligible: () => [],
+      roster: ["mini", "mini-2"],
+      self: "mini",
+      multiHost: true,
+      capacity: { maxParallel: 4, liveCount: 2, freeSlots: 2 },
+      readEventRing: () => [],
+      ownerForTicket: (t) => (t === "CTL-MINE" ? "mini" : "mini-2"),
+      getReconcileMarkers: () => ({}),
+      lastRunMs: 0,
+      intervalMs: 0,
+      now: () => NOW,
+      emit: () => {},
+      act: (payload) => { acted.push(payload); return { dispatched: true }; },
+    });
+    expect(acted.length).toBe(1);
+    expect(acted[0].anchor).toBe("CTL-MINE"); // NOT CTL-FOREIGN (which it doesn't own)
   });
 
   test("throttle: a call within intervalMs returns {ran:false,reason:throttled} with NO emit", () => {


### PR DESCRIPTION
## What

Fixes a multi-host correctness bug in CTL-1300's board-health holistic dispatch: `selectAnchor` picked the **first flagged ticket regardless of HRW ownership**, so if that anchor was foreign-owned the act block HRW-skipped the **whole scan** — even when this host owned a *later* flagged ticket it could act on. board-health would stall instead of acting on its own work.

**Observed live on mini (2026-06-21, board-health=enforce):** flagged `[CTL-1298, CTL-1154, CTL-1214]` with HRW `CTL-1154→mini-2`, `CTL-1214→mini`. selectAnchor picked CTL-1154 → daemon log `board-health: anchor owned by another host (HRW) — skipping holistic dispatch`. mini never tried **CTL-1214**, which it owns.

## Fix

`selectAnchor` now filters every candidate to **self-owned** (via `ownerForTicket` + `self` + `roster` already on the boardState) before applying the `tier-1 nudge > tier-2 re-dispatch-blocker > top eligible` priority. Returns `null` only when this host owns none of the flagged/eligible. **Single-host** (no roster / no `ownerForTicket` / `multiHost:false`) owns everything → behavior unchanged. The now-redundant cross-host re-check in `boardHealthPass` is removed (selectAnchor guarantees ownership). HRW read fails open (a broken read won't block self-owned actuation).

## Tests (TDD)

5 new cases: prefer-owned-over-foreign-earlier, null-when-none-owned, self-owned-eligible fallback (skips foreign eligible), single-host-unchanged, + a `boardHealthPass` multi-host integration case asserting it dispatches against the self-owned ticket (not the foreign first one). **426 adjacent tests pass** (board-health + seam + recovery-reasoning + recovery); `bun build daemon.mjs` clean; reward-hacking scan clean.

Direct follow-up to **CTL-1300** (board-health delegate ACTS). Relates to CTL-850 / CTL-1191 (HRW).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
