### PR TITLE
fix(dev): CTL-1298 — CI build-resolution gate for daemon.mjs import graph

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -54,6 +54,16 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Verify import graph (bun build resolution check)
+        # CTL-1298: resolve daemon.mjs's full transitive import graph so a missing
+        # named export (the CTL-1093 outage: getCatalystRepoDir added to daemon.mjs
+        # without an export in config.mjs) fails CI before merge. daemon.mjs is not
+        # imported by any included test (daemon.test.mjs is excluded for fs.watch
+        # flakiness), so its import graph is otherwise never validated. bun build
+        # walks the static graph and exits non-zero on any unresolved import without
+        # executing the code; it transitively covers index.mjs -> monitor.mjs too.
+        run: bun build daemon.mjs --target=node --outfile /dev/null
+
       - name: Run stable unit tests
         # EXCLUDED SUITES — do NOT add these back without fixing the underlying
         # timing / sandbox incompatibility:


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-21T14:36:00Z -->
<!-- Last updated: 2026-06-21T14:36:00Z -->
<!-- PR: #2307 -->
<!-- Previous commits: ec29d59a40947683d5a399886f30fc06f6704ea2 -->

## Summary

Adds a `bun build` import-graph resolution step to the `execution-core-unit-tests` CI workflow so that a boot-breaking unresolved import in `daemon.mjs` fails the build before it can merge to main.

**Root cause being closed:** CTL-1093 added `import { getCatalystRepoDir }` to `daemon.mjs` without exporting it from `config.mjs`. CI passed because no test file directly imports `daemon.mjs` (the `daemon.test.mjs` suite is excluded for `fs.watch` flakiness). The missing export only surfaced at runtime, making every execution-core daemon boot SyntaxError on main — a fleet-wide outage hotfixed in #2291. This PR installs the gate so the same class of regression can never merge again.

## Changes Made

### CI / Workflow Changes

**`.github/workflows/execution-core-tests.yml`** (+10 lines)

- Added `Verify import graph (bun build resolution check)` step before the unit-test suite runs
- Command: `bun build daemon.mjs --target=node --outfile /dev/null`
- `bun build` walks the full static import graph and exits non-zero on any unresolved named export without executing code — a cheap, side-effect-free gate
- Transitively covers `index.mjs → monitor.mjs` since `daemon.mjs` imports them

## How to Verify It

- [x] `execution-core-unit-tests` CI job passes ✅ (30s run — new step included)
- [x] All other CI checks pass ✅ (audit-references, check-versions, docs-gate, gitleaks, validate)
- [ ] Manually verify regression: introduce a bad import in `daemon.mjs` and confirm the CI step fails (local: `bun build plugins/dev/scripts/execution-core/daemon.mjs --target=node --outfile /dev/null`)

## Related Issues/PRs

- Fixes https://linear.app/adva/issue/CTL-1298


<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1093
