### PR TITLE
feat(dev): CTL-1307 — machine-level CATALYST_CLOUD_TOKEN from catalyst-cluster repo

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -124,6 +124,7 @@ jobs:
             claim.test.mjs \
             claude-agents.test.mjs \
             claude-ids.test.mjs \
+            cloud-token-env.test.mjs \
             cluster-claim-sync.test.mjs \
             cluster-claim.test.mjs \
             comms-drain.test.mjs \

--- a/docs/cluster-onboarding.md
+++ b/docs/cluster-onboarding.md
@@ -150,6 +150,77 @@ To activate mini-2 and begin accepting work:
 
 4. **Monitor the reaper** — once activated, mini-2 worktrees are eligible for reaping (CTL-1218). Watch for safe signal+merge patterns before auto-reap.
 
+## Provisioning the shared cloud token (`CATALYST_CLOUD_TOKEN`, CTL-1307)
+
+`CATALYST_CLOUD_TOKEN` is a single **shared** service credential (the catalyst-cloud `ADMIN_TOKEN`,
+interim per CTC-27 / ADR-0006) that must be **identical on every node**. It is an **optional
+extension**: setting it changes nothing on its own — nothing in Catalyst reads it, and a node stays
+fully local-only until the operator separately opts into cloud services. Only the opt-in,
+out-of-repo cloud host-sync daemon (`catalyst-replica` / `catalyst-cloud`) consumes it. It is safe
+to roll out cluster-wide without altering default behavior.
+
+It is stored once in the `catalyst-cluster` repo (encrypted, alongside the other secrets) and flows
+to every node's **machine-level environment** automatically — no manual per-host step.
+
+### Add or rotate the token (laptop only)
+
+Per the cluster repo's write policy, all `secrets/` writes are operator-initiated from the laptop and
+serialized (pull → edit → push); SOPS re-encryption rewrites the whole data-key wrap, so concurrent
+commits don't merge.
+
+```bash
+cd ~/catalyst/catalyst-cluster        # the clone with your age key + sops installed
+git pull --ff-only
+
+# Create/rotate the dedicated cloud-token secret. The existing .sops.yaml rule
+# (path_regex 'secrets/.*\.json$') already covers this filename — no .sops.yaml change.
+cat > /tmp/cluster-cloud.json <<'JSON'
+{ "catalyst": { "cloud": { "token": "<catalyst-cloud ADMIN_TOKEN>" } } }
+JSON
+sops --encrypt --input-type json --output-type json /tmp/cluster-cloud.json \
+  > secrets/cluster-cloud.sops.json
+rm -f /tmp/cluster-cloud.json
+
+git add secrets/cluster-cloud.sops.json
+git commit -m "feat: add shared CATALYST_CLOUD_TOKEN (CTL-1307)"
+git push
+```
+
+### How each node picks it up
+
+Each node converges automatically (prerequisite: the node already has the `catalyst-cluster` repo
+cloned and its age key at `~/.config/catalyst/age.key` — the same prerequisite as every other cluster
+secret):
+
+1. `cluster-sync` (daemon boot, and the periodic pull) decrypts `secrets/cluster-cloud.sops.json` to
+   `~/.config/catalyst/cluster-cloud.json` (mode `0600`).
+2. `catalyst-stack start` (boot + every keep-alive) runs `cloud-token-env.mjs`, which writes the
+   secret to `~/.config/catalyst/cluster.env` (mode `0600`) and adds a non-secret guard line to
+   `~/.zshenv` that sources it.
+3. Every login/zsh shell — and any cloud daemon **(re)started in a shell context** — inherits
+   `CATALYST_CLOUD_TOKEN`.
+
+### Apply immediately (instead of waiting for the keep-alive)
+
+On each node that has opted into cloud services:
+
+```bash
+# 1. re-decrypt (or just restart the daemon)
+catalyst cluster sync
+# 2. project the token into the machine-level env now
+catalyst-stack sync-cloud-env
+# 3. restart the cloud host-sync daemon in a shell context so it inherits the value
+#    (the same pattern used for the per-host Linear keys)
+```
+
+`catalyst doctor` reports an advisory `cloud-token` check: `INFO` when no token is provisioned
+(local-only, expected), `WARN` when a token is decrypted but not yet projected (or is stale), `PASS`
+when it is projected to the machine-level env.
+
+> **Scope note:** `catalyst-join` does not itself clone the `catalyst-cluster` repo or provision the
+> age key (a pre-existing prerequisite shared by *all* cluster secrets, tracked separately). Once
+> those prerequisites are in place, the cloud token is picked up with no per-host step.
+
 ## Troubleshooting
 
 ### Join script fails with "doctor gate failed"

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -21,6 +21,14 @@
 #   catalyst-stack install-services [--interval <sec>] [--sync-interval <sec>] [--print]
 #   catalyst-stack uninstall-services
 #   catalyst-stack services-status
+#   catalyst-stack sync-cloud-env
+#
+# sync-cloud-env (CTL-1307):
+#   Project the cluster-shared CATALYST_CLOUD_TOKEN (decrypted by cluster-sync into
+#   ~/.config/catalyst/cluster-cloud.json) into this node's machine-level env — a
+#   0600 ~/.config/catalyst/cluster.env sourced by a guard line in ~/.zshenv. Run
+#   on demand after a token rotation; otherwise it runs automatically as part of
+#   'catalyst-stack start' (boot + keep-alive). No-op when no token is provisioned.
 #
 # install-services (CTL-1166, CTL-1236, CTL-1285, CTL-1306):
 #   Install FOUR launchd LaunchAgents:
@@ -551,6 +559,37 @@ cmd_parity() {
   exit "$PARITY_DRIFT"
 }
 
+# _cloud_token_env_run [quiet] — CTL-1307. Project the cluster-shared
+# CATALYST_CLOUD_TOKEN into this node's machine-level environment. The token is
+# decrypted by cluster-sync into ~/.config/catalyst/cluster-cloud.json; this
+# delegates to execution-core/cloud-token-env.mjs, which writes the 0600
+# ~/.config/catalyst/cluster.env and ensures a non-secret source-guard in
+# ~/.zshenv. FAIL-OPEN + idempotent: a node with no token decrypted is a no-op,
+# and this NEVER blocks stack start. Default behavior is unchanged — nothing in
+# catalyst reads CATALYST_CLOUD_TOKEN; only the opt-in cloud host-sync daemon does.
+_cloud_token_env_run() {
+  local quiet="${1:-}"
+  local mod="${SCRIPT_DIR}/execution-core/cloud-token-env.mjs"
+  [[ -f "$mod" ]] || return 0
+  local rt=""
+  if command -v bun >/dev/null 2>&1; then rt="bun"
+  elif command -v node >/dev/null 2>&1; then rt="node"
+  else return 0; fi
+  if [[ "$quiet" == "quiet" ]]; then
+    "$rt" "$mod" >/dev/null 2>&1 || true
+  else
+    "$rt" "$mod" || true
+  fi
+}
+
+# cmd_sync_cloud_env — on-demand projection of the cluster cloud token into
+# machine-level env (CTL-1307). Same work the keep-alive does, but surfaces the
+# module's output. Use after rotating the token or to apply it immediately
+# instead of waiting for the next keep-alive tick.
+cmd_sync_cloud_env() {
+  _cloud_token_env_run
+}
+
 # ─── Top-level commands ─────────────────────────────────────────────────────
 cmd_start() {
   local use_proxy="no"
@@ -591,6 +630,11 @@ cmd_start() {
   # owns shipper resurrection, so it survives stack stop/restart and restarts
   # instantly on death instead of waiting for the next 600s tick.
   start_shipper || warn "continuing without log-shipper (daemon logs won't be shipped to Loki)"
+
+  # CTL-1307: project the cluster-shared cloud token into machine-level env, if
+  # one has been decrypted from the catalyst-cluster repo. Quiet + fail-open: a
+  # node not opted into catalyst-cloud has no token and this is a silent no-op.
+  _cloud_token_env_run quiet
 
   log ""
   log "stack up — current state:"
@@ -1114,6 +1158,7 @@ case "${1:-}" in
   install-services)   shift; cmd_install_services "$@" ;;
   uninstall-services) shift; cmd_uninstall_services ;;
   services-status)    shift; cmd_services_status ;;
+  sync-cloud-env)     shift; cmd_sync_cloud_env "$@" ;;
   status|"") cmd_status ;;
   -h|--help)
     sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'

--- a/plugins/dev/scripts/execution-core/cloud-token-env.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-token-env.mjs
@@ -1,0 +1,215 @@
+// cloud-token-env.mjs — CTL-1307. Project the cluster-shared CATALYST_CLOUD_TOKEN
+// into the node's MACHINE-LEVEL environment.
+//
+// WHAT
+// ----
+// CATALYST_CLOUD_TOKEN is a single SHARED service credential (the catalyst-cloud
+// ADMIN_TOKEN, interim per CTC-27 / ADR-0006), IDENTICAL on every node. It lives
+// encrypted in the private catalyst-cluster repo as secrets/cluster-cloud.sops.json
+// and is decrypted at daemon boot by cluster-sync.mjs (syncClusterSecrets) into
+// ~/.config/catalyst/cluster-cloud.json (mode 0o600), exactly like every other
+// cluster-shared secret. This module reads that decrypted artifact and projects the
+// token as an ENVIRONMENT VARIABLE so the opt-in, OUT-OF-THIS-REPO host-sync daemon
+// (catalyst-replica / catalyst-cloud) can present it as a bearer to the cloud feed.
+//
+// WHERE (two surfaces, mirroring how every other machine-level secret env var is
+// provisioned on this fleet — see ~/.zshenv's existing CATALYST_WEBHOOK_SECRET,
+// GITHUB_TOKEN, etc.):
+//   1. ~/.config/catalyst/cluster.env  (mode 0o600)  — `export CATALYST_CLOUD_TOKEN=…`
+//      The SECRET lives here only, never in the (commonly 0644) shell profile.
+//   2. ~/.zshenv  — a single NON-secret guard line that sources cluster.env, so
+//      every login/zsh shell — and any daemon (re)started in a shell context, which
+//      is this fleet's convention for env-key pickup — inherits CATALYST_CLOUD_TOKEN.
+//
+// WHO RUNS IT
+// ----------
+// This is a SHORT-LIVED script invoked by the shell launcher (catalyst-stack
+// cmd_start at boot + keep-alive, and `catalyst-stack sync-cloud-env` on demand) —
+// NOT the long-lived execution-core daemon. The launcher decides WHEN to project;
+// this module owns HOW. cluster-sync.mjs stays a pure decrypt module.
+//
+// POSTURE: FAIL-OPEN. Any failure (no decrypted token yet, unwritable file) leaves
+// the node exactly as it was and never throws / never exits non-zero. A node with no
+// token decrypted is a no-op — so a non-cloud node and a not-yet-synced node are both
+// left untouched. Setting the token changes NO local catalyst behavior: nothing in
+// this repo reads CATALYST_CLOUD_TOKEN; only the opt-in cloud host-sync daemon does.
+
+import {
+  readFileSync,
+  writeFileSync,
+  chmodSync,
+  mkdirSync,
+  renameSync,
+  appendFileSync,
+} from "node:fs";
+import { resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+
+// Sentinel-delimited managed block in ~/.zshenv. The block holds only the
+// NON-secret source-guard; the token itself stays in the 0o600 cluster.env.
+export const GUARD_BEGIN = "# >>> catalyst cloud-token env (CTL-1307) >>>";
+export const GUARD_END = "# <<< catalyst cloud-token env (CTL-1307) <<<";
+// Literal $HOME so the line is portable to whatever user sources it.
+export const GUARD_SOURCE_LINE =
+  '[ -r "$HOME/.config/catalyst/cluster.env" ] && . "$HOME/.config/catalyst/cluster.env"';
+
+function defaultConfigDir() {
+  return process.env.CATALYST_CONFIG_DIR || resolve(homedir(), ".config", "catalyst");
+}
+function defaultZshenvPath() {
+  return process.env.CATALYST_ZSHENV_FILE || resolve(homedir(), ".zshenv");
+}
+
+// shellSingleQuote — wrap a value as a safe single-quoted POSIX-shell literal,
+// escaping embedded single quotes ('  ->  '\'' ). Defeats command/expansion
+// injection from a hostile token value when the line is later sourced.
+export function shellSingleQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+// renderClusterEnv — the exact 0o600 cluster.env content for a token. Pure.
+export function renderClusterEnv(token) {
+  return (
+    "# Managed by catalyst (CTL-1307) — cluster-shared cloud token. Do not edit by hand.\n" +
+    "# Source: catalyst-cluster secrets/cluster-cloud.sops.json -> ~/.config/catalyst/cluster-cloud.json (cluster-sync).\n" +
+    `export CATALYST_CLOUD_TOKEN=${shellSingleQuote(token)}\n`
+  );
+}
+
+// readCloudToken — extract .catalyst.cloud.token from the decrypted cluster-cloud.json.
+// Returns "" when absent / unreadable / malformed / non-string (never throws).
+export function readCloudToken(opts = {}) {
+  const { configDir = defaultConfigDir(), readFile = (p) => readFileSync(p, "utf8") } = opts;
+  try {
+    const obj = JSON.parse(readFile(resolve(configDir, "cluster-cloud.json")));
+    const t = obj?.catalyst?.cloud?.token;
+    return typeof t === "string" ? t : "";
+  } catch {
+    return "";
+  }
+}
+
+// defaultWriteFileAtomic — write via tmp + rename so a concurrent daemon boot
+// never observes a half-written cluster.env. 0o600 on both tmp and final.
+function defaultWriteFileAtomic(dest, body) {
+  const dir = dirname(dest);
+  mkdirSync(dir, { recursive: true });
+  const tmp = resolve(dir, `.cluster.env.${process.pid}.tmp`);
+  writeFileSync(tmp, body, { mode: 0o600 });
+  chmodSync(tmp, 0o600);
+  renameSync(tmp, dest);
+  chmodSync(dest, 0o600);
+}
+
+// writeClusterEnv — atomically write cluster.env (0o600) IFF the content changed.
+// Idempotent: a repeated boot with the same token is a no-op (no rewrite). A
+// rotated token (value changed) is detected by the content diff and rewritten.
+// Returns { written: boolean, reason }.
+export function writeClusterEnv(token, opts = {}) {
+  const {
+    configDir = defaultConfigDir(),
+    readFile = (p) => readFileSync(p, "utf8"),
+    writeFileAtomic = defaultWriteFileAtomic,
+  } = opts;
+  const dest = resolve(configDir, "cluster.env");
+  const body = renderClusterEnv(token);
+  try {
+    if (readFile(dest) === body) return { written: false, reason: "unchanged" };
+  } catch {
+    /* missing / unreadable → fall through and write */
+  }
+  writeFileAtomic(dest, body);
+  return { written: true, reason: "written" };
+}
+
+// ensureZshenvGuard — idempotently add the sentinel-marked NON-secret source-guard
+// block to ~/.zshenv. grep-style presence check on GUARD_BEGIN so it is never
+// duplicated across boots. Creates ~/.zshenv if absent (append). The token never
+// touches this file — only the guard that sources the 0o600 cluster.env.
+// Returns { added: boolean, reason }.
+export function ensureZshenvGuard(opts = {}) {
+  const {
+    zshenvPath = defaultZshenvPath(),
+    readFile = (p) => readFileSync(p, "utf8"),
+    appendFile = (p, s) => appendFileSync(p, s),
+  } = opts;
+  let existing = "";
+  try {
+    existing = readFile(zshenvPath);
+  } catch {
+    /* missing → append creates it */
+  }
+  if (existing.includes(GUARD_BEGIN)) return { added: false, reason: "present" };
+  const block = `\n${GUARD_BEGIN}\n${GUARD_SOURCE_LINE}\n${GUARD_END}\n`;
+  appendFile(zshenvPath, block);
+  return { added: true, reason: "added" };
+}
+
+// syncCloudTokenEnv — the entrypoint. FAIL-OPEN: never throws.
+// No token decrypted → no-op (node left untouched). Otherwise: write the 0o600
+// cluster.env and ensure the ~/.zshenv guard. Returns a status object.
+export function syncCloudTokenEnv(opts = {}) {
+  const { logger = console } = opts;
+  const result = { token: false, clusterEnv: null, zshenv: null, reason: null };
+
+  let token = "";
+  try {
+    token = readCloudToken(opts);
+  } catch {
+    token = "";
+  }
+  if (!token) {
+    result.reason = "no-token";
+    return result;
+  }
+  // A multi-line value can't sit on one `export` line and signals corruption —
+  // refuse rather than emit a broken (and potentially injectable) profile entry.
+  if (/[\r\n]/.test(token)) {
+    logger.warn?.("[cloud-token-env] refusing multi-line CATALYST_CLOUD_TOKEN (corrupt?)");
+    result.reason = "multiline-token";
+    return result;
+  }
+
+  result.token = true;
+  try {
+    result.clusterEnv = writeClusterEnv(token, opts);
+  } catch (err) {
+    logger.warn?.(`[cloud-token-env] cluster.env write failed (${err?.message ?? err}); continuing`);
+    result.clusterEnv = { written: false, reason: "error" };
+  }
+  try {
+    result.zshenv = ensureZshenvGuard(opts);
+  } catch (err) {
+    logger.warn?.(`[cloud-token-env] ~/.zshenv guard failed (${err?.message ?? err}); continuing`);
+    result.zshenv = { added: false, reason: "error" };
+  }
+  return result;
+}
+
+// CLI entry — invoked by catalyst-stack (cmd_start + `sync-cloud-env`). Always
+// exits 0 (fail-open): provisioning the token must never wedge stack startup.
+const _invokedDirectly =
+  typeof process !== "undefined" &&
+  Array.isArray(process.argv) &&
+  typeof process.argv[1] === "string" &&
+  process.argv[1].endsWith("cloud-token-env.mjs");
+
+if (_invokedDirectly) {
+  const res = syncCloudTokenEnv();
+  if (res.token) {
+    const parts = [];
+    if (res.clusterEnv?.written) parts.push("cluster.env updated");
+    else if (res.clusterEnv?.reason === "unchanged") parts.push("cluster.env unchanged");
+    if (res.zshenv?.added) parts.push("~/.zshenv guard added");
+    process.stdout.write(
+      `[cloud-token-env] ${parts.length ? parts.join("; ") : "up to date"}\n`,
+    );
+  } else if (res.reason === "multiline-token") {
+    process.stdout.write("[cloud-token-env] refused malformed (multi-line) token — nothing written\n");
+  } else {
+    process.stdout.write(
+      "[cloud-token-env] no cloud token provisioned — node stays local-only (nothing to do)\n",
+    );
+  }
+  process.exit(0);
+}

--- a/plugins/dev/scripts/execution-core/cloud-token-env.test.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-token-env.test.mjs
@@ -1,0 +1,231 @@
+// cloud-token-env.test.mjs — CTL-1307. Hermetic: every test points the module at a
+// throwaway tmp config dir + tmp ~/.zshenv via opts, so no real ~/.config/catalyst
+// or ~/.zshenv is ever touched.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test cloud-token-env.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  statSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readCloudToken,
+  renderClusterEnv,
+  shellSingleQuote,
+  writeClusterEnv,
+  ensureZshenvGuard,
+  syncCloudTokenEnv,
+  GUARD_BEGIN,
+  GUARD_END,
+} from "./cloud-token-env.mjs";
+
+const QUIET = { warn() {}, info() {} };
+let configDir, zshenvPath;
+
+beforeEach(() => {
+  configDir = mkdtempSync(join(tmpdir(), "cte-config-"));
+  zshenvPath = join(mkdtempSync(join(tmpdir(), "cte-home-")), ".zshenv");
+});
+afterEach(() => {
+  rmSync(configDir, { recursive: true, force: true });
+  rmSync(zshenvPath, { force: true });
+});
+
+const writeClusterCloudJson = (token) =>
+  writeFileSync(
+    join(configDir, "cluster-cloud.json"),
+    JSON.stringify({ catalyst: { cloud: { token } } }),
+  );
+const clusterEnvPath = () => join(configDir, "cluster.env");
+
+describe("shellSingleQuote", () => {
+  test("wraps a plain value", () => {
+    expect(shellSingleQuote("abc123")).toBe("'abc123'");
+  });
+  test("escapes embedded single quotes (injection-safe)", () => {
+    // a'b  ->  'a'\''b'
+    expect(shellSingleQuote("a'b")).toBe("'a'\\''b'");
+  });
+  test("a command-injection attempt stays inert single-quoted data", () => {
+    const evil = "x'; rm -rf $HOME; echo '";
+    const quoted = shellSingleQuote(evil);
+    // The whole thing is a single quoted literal — no unescaped quote can break out.
+    expect(quoted.startsWith("'")).toBe(true);
+    expect(quoted.endsWith("'")).toBe(true);
+    expect(quoted).toBe("'x'\\''; rm -rf $HOME; echo '\\'''");
+  });
+});
+
+describe("readCloudToken", () => {
+  test("reads catalyst.cloud.token from cluster-cloud.json", () => {
+    writeClusterCloudJson("admintok_123");
+    expect(readCloudToken({ configDir })).toBe("admintok_123");
+  });
+  test("absent file → empty string (never throws)", () => {
+    expect(readCloudToken({ configDir })).toBe("");
+  });
+  test("malformed JSON → empty string (never throws)", () => {
+    writeFileSync(join(configDir, "cluster-cloud.json"), "{not json");
+    expect(readCloudToken({ configDir })).toBe("");
+  });
+  test("missing token key → empty string", () => {
+    writeFileSync(join(configDir, "cluster-cloud.json"), JSON.stringify({ catalyst: { cloud: {} } }));
+    expect(readCloudToken({ configDir })).toBe("");
+  });
+});
+
+describe("renderClusterEnv", () => {
+  test("emits a single export line with the token single-quoted", () => {
+    const body = renderClusterEnv("tok");
+    expect(body).toContain("export CATALYST_CLOUD_TOKEN='tok'\n");
+    expect(body.endsWith("\n")).toBe(true);
+  });
+});
+
+describe("writeClusterEnv", () => {
+  test("writes cluster.env at 0600 with the export line", () => {
+    const res = writeClusterEnv("tok_abc", { configDir });
+    expect(res).toEqual({ written: true, reason: "written" });
+    const body = readFileSync(clusterEnvPath(), "utf8");
+    expect(body).toContain("export CATALYST_CLOUD_TOKEN='tok_abc'");
+    expect(statSync(clusterEnvPath()).mode & 0o777).toBe(0o600);
+  });
+
+  test("idempotent: identical token → no rewrite (written:false)", () => {
+    writeClusterEnv("same", { configDir });
+    const res = writeClusterEnv("same", { configDir });
+    expect(res).toEqual({ written: false, reason: "unchanged" });
+  });
+
+  test("rotation: changed token → rewrite with the new value", () => {
+    writeClusterEnv("old", { configDir });
+    const res = writeClusterEnv("new", { configDir });
+    expect(res.written).toBe(true);
+    const body = readFileSync(clusterEnvPath(), "utf8");
+    expect(body).toContain("export CATALYST_CLOUD_TOKEN='new'");
+    expect(body).not.toContain("'old'");
+  });
+
+  test("writes are atomic — final file is complete, no stray tmp left", () => {
+    writeClusterEnv("tok", { configDir });
+    // Only cluster.env should remain (the tmp was renamed away).
+    const stray = existsSync(join(configDir, ".cluster.env." + process.pid + ".tmp"));
+    expect(stray).toBe(false);
+  });
+});
+
+describe("ensureZshenvGuard", () => {
+  test("adds the sentinel-marked guard block once", () => {
+    const res = ensureZshenvGuard({ zshenvPath });
+    expect(res).toEqual({ added: true, reason: "added" });
+    const body = readFileSync(zshenvPath, "utf8");
+    expect(body).toContain(GUARD_BEGIN);
+    expect(body).toContain(GUARD_END);
+    expect(body).toContain("cluster.env");
+    // The token is NOT in the profile — only the source guard.
+    expect(body).not.toContain("CATALYST_CLOUD_TOKEN=");
+  });
+
+  test("idempotent: second call does not duplicate the block", () => {
+    ensureZshenvGuard({ zshenvPath });
+    const res = ensureZshenvGuard({ zshenvPath });
+    expect(res).toEqual({ added: false, reason: "present" });
+    const body = readFileSync(zshenvPath, "utf8");
+    const occurrences = body.split(GUARD_BEGIN).length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  test("preserves existing ~/.zshenv content (append, not overwrite)", () => {
+    writeFileSync(zshenvPath, "export EXISTING=1\n");
+    ensureZshenvGuard({ zshenvPath });
+    const body = readFileSync(zshenvPath, "utf8");
+    expect(body).toContain("export EXISTING=1");
+    expect(body).toContain(GUARD_BEGIN);
+  });
+
+  test("missing ~/.zshenv → created with the guard", () => {
+    expect(existsSync(zshenvPath)).toBe(false);
+    ensureZshenvGuard({ zshenvPath });
+    expect(existsSync(zshenvPath)).toBe(true);
+    expect(readFileSync(zshenvPath, "utf8")).toContain(GUARD_BEGIN);
+  });
+});
+
+describe("syncCloudTokenEnv (entrypoint, fail-open)", () => {
+  test("no cluster-cloud.json → no-op, no files touched", () => {
+    const res = syncCloudTokenEnv({ configDir, zshenvPath, logger: QUIET });
+    expect(res.token).toBe(false);
+    expect(res.reason).toBe("no-token");
+    expect(existsSync(clusterEnvPath())).toBe(false);
+    expect(existsSync(zshenvPath)).toBe(false);
+  });
+
+  test("token present → writes cluster.env AND the ~/.zshenv guard", () => {
+    writeClusterCloudJson("admintok_xyz");
+    const res = syncCloudTokenEnv({ configDir, zshenvPath, logger: QUIET });
+    expect(res.token).toBe(true);
+    expect(res.clusterEnv.written).toBe(true);
+    expect(res.zshenv.added).toBe(true);
+    expect(readFileSync(clusterEnvPath(), "utf8")).toContain("export CATALYST_CLOUD_TOKEN='admintok_xyz'");
+    expect(readFileSync(zshenvPath, "utf8")).toContain(GUARD_BEGIN);
+  });
+
+  test("repeated sync is fully idempotent (nothing rewritten/duplicated)", () => {
+    writeClusterCloudJson("tok");
+    syncCloudTokenEnv({ configDir, zshenvPath, logger: QUIET });
+    const res = syncCloudTokenEnv({ configDir, zshenvPath, logger: QUIET });
+    expect(res.clusterEnv.written).toBe(false);
+    expect(res.zshenv.added).toBe(false);
+    const occurrences = readFileSync(zshenvPath, "utf8").split(GUARD_BEGIN).length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  test("rotation: new token in cluster-cloud.json → cluster.env updated", () => {
+    writeClusterCloudJson("old");
+    syncCloudTokenEnv({ configDir, zshenvPath, logger: QUIET });
+    writeClusterCloudJson("rotated");
+    const res = syncCloudTokenEnv({ configDir, zshenvPath, logger: QUIET });
+    expect(res.clusterEnv.written).toBe(true);
+    expect(readFileSync(clusterEnvPath(), "utf8")).toContain("export CATALYST_CLOUD_TOKEN='rotated'");
+  });
+
+  test("multi-line token → refused, nothing written (fail-open)", () => {
+    writeClusterCloudJson("line1\nline2");
+    const res = syncCloudTokenEnv({ configDir, zshenvPath, logger: QUIET });
+    expect(res.token).toBe(false);
+    expect(res.reason).toBe("multiline-token");
+    expect(existsSync(clusterEnvPath())).toBe(false);
+  });
+
+  test("token with shell metacharacters stays inert single-quoted data", () => {
+    writeClusterCloudJson("a'b$c`d");
+    syncCloudTokenEnv({ configDir, zshenvPath, logger: QUIET });
+    const body = readFileSync(clusterEnvPath(), "utf8");
+    expect(body).toContain("export CATALYST_CLOUD_TOKEN='a'\\''b$c`d'");
+  });
+
+  test("never throws even when cluster.env dir is read-only (write failure)", () => {
+    writeClusterCloudJson("tok");
+    const boom = () => {
+      throw new Error("EROFS");
+    };
+    // Inject a failing atomic writer to simulate an unwritable target.
+    const res = syncCloudTokenEnv({
+      configDir,
+      zshenvPath,
+      writeFileAtomic: boom,
+      logger: QUIET,
+    });
+    expect(res.token).toBe(true);
+    expect(res.clusterEnv.reason).toBe("error");
+    // ~/.zshenv guard still attempted (independent of cluster.env failure).
+    expect(res.zshenv.added).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/cluster-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.mjs
@@ -15,6 +15,13 @@
 //                                    node-local host.name / cluster anchor /
 //                                    monitor webhook state, overlays bot creds)
 //   config-<projectKey>.sops.json → config-<projectKey>.json
+//   cluster-cloud.sops.json       → cluster-cloud.json  (CTL-1307: the shared
+//                                    catalyst-cloud token { catalyst.cloud.token } —
+//                                    a separate file so its rotation/GC lifecycle is
+//                                    independent of bot creds, superseded per CTC-46.
+//                                    Decrypted by the generic destForSecret path
+//                                    below; cloud-token-env.mjs then projects it into
+//                                    the machine-level environment. No special-casing.)
 //
 // Roster (cluster.json.roster) is read LIVE per tick by config.getClusterHosts();
 // secrets here are decrypted at BOOT. So a roster change needs no restart, but a

--- a/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
@@ -49,6 +49,11 @@ describe("destForSecret (CTL-1211)", () => {
       resolve("/cfg", "config-catalyst-workspace.json"),
     );
   });
+  test("cluster-cloud maps to cluster-cloud.json (CTL-1307, generic path)", () => {
+    expect(destForSecret("cluster-cloud.sops.json", "/cfg")).toBe(
+      resolve("/cfg", "cluster-cloud.json"),
+    );
+  });
 });
 
 describe("syncClusterSecrets (CTL-1211)", () => {

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -1324,6 +1324,96 @@ export function checkReaper(deps = {}) {
   return checks;
 }
 
+// checkCloudTokenEnv — CTL-1307. ADVISORY ONLY (never FAIL): the cluster-shared
+// CATALYST_CLOUD_TOKEN is an OPTIONAL extension — a node stays fully local-only
+// without it, so its absence must NEVER block activation. WARN only on DRIFT: the
+// token has been decrypted from the catalyst-cluster repo (cluster-cloud.json)
+// but is not yet projected into the machine-level env (cluster.env + ~/.zshenv
+// guard). All reads are injectable + fail-open.
+export function checkCloudTokenEnv(deps = {}) {
+  const {
+    configDir = process.env.CATALYST_CONFIG_DIR || resolve(homedir(), ".config", "catalyst"),
+    zshenvPath = process.env.CATALYST_ZSHENV_FILE || resolve(homedir(), ".zshenv"),
+    readFile = (p) => readFileSync(p, "utf8"),
+  } = deps;
+  const checks = [];
+
+  let token = "";
+  try {
+    const obj = JSON.parse(readFile(resolve(configDir, "cluster-cloud.json")));
+    const t = obj?.catalyst?.cloud?.token;
+    token = typeof t === "string" ? t : "";
+  } catch {
+    /* absent / malformed → no token decrypted */
+  }
+
+  if (!token) {
+    checks.push(
+      mkCheck(
+        "cloud-token",
+        STATUS.INFO,
+        "no cluster cloud token decrypted — node is local-only (expected unless opted into catalyst-cloud)",
+      ),
+    );
+    return checks;
+  }
+
+  let clusterEnv = "";
+  try {
+    clusterEnv = readFile(resolve(configDir, "cluster.env"));
+  } catch {
+    /* missing → not projected */
+  }
+  // Expected single-quoted export line (mirrors cloud-token-env.mjs escaping).
+  const expected = `export CATALYST_CLOUD_TOKEN='${token.replace(/'/g, "'\\''")}'`;
+  if (!clusterEnv.includes("export CATALYST_CLOUD_TOKEN=")) {
+    checks.push(
+      mkCheck(
+        "cloud-token",
+        STATUS.WARN,
+        "cloud token decrypted but NOT projected to ~/.config/catalyst/cluster.env — run 'catalyst-stack sync-cloud-env'",
+      ),
+    );
+    return checks;
+  }
+  if (!clusterEnv.includes(expected)) {
+    checks.push(
+      mkCheck(
+        "cloud-token",
+        STATUS.WARN,
+        "cluster.env CATALYST_CLOUD_TOKEN is STALE vs cluster-cloud.json — run 'catalyst-stack sync-cloud-env' and restart cloud daemons",
+      ),
+    );
+    return checks;
+  }
+
+  let zshenv = "";
+  try {
+    zshenv = readFile(zshenvPath);
+  } catch {
+    /* missing → no guard */
+  }
+  if (!zshenv.includes("catalyst cloud-token env")) {
+    checks.push(
+      mkCheck(
+        "cloud-token",
+        STATUS.WARN,
+        "cluster.env present but ~/.zshenv lacks the source-guard — shells (and shell-launched cloud daemons) won't inherit CATALYST_CLOUD_TOKEN",
+      ),
+    );
+    return checks;
+  }
+
+  checks.push(
+    mkCheck(
+      "cloud-token",
+      STATUS.PASS,
+      "cluster cloud token projected to machine-level env (cluster.env + ~/.zshenv guard)",
+    ),
+  );
+  return checks;
+}
+
 // runDoctor — orchestrate all checks, render, and return the fail count.
 export async function runDoctor(opts = {}) {
   const {
@@ -1349,6 +1439,7 @@ export async function runDoctor(opts = {}) {
     () => checkThoughts(), // CTL-1293: member thoughts repo provisioned + non-foreign primary
     () => checkClaudeSettings(), // CTL-1231: member settings.json pins host identity + OTLP endpoint
     () => checkReaper(), // CTL-1306: orphan-sweep reaper installed + baked path still exists (not dead-127)
+    () => checkCloudTokenEnv(), // CTL-1307: cluster cloud token decrypted → projected to machine-level env (advisory)
   ];
 
   const fns = checkFns ?? defaultChecks;

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -18,6 +18,7 @@ import {
   checkThoughts,
   checkClaudeSettings,
   checkReaper,
+  checkCloudTokenEnv,
   summarize,
   renderJson,
   renderHuman,
@@ -1071,5 +1072,94 @@ describe("checkReaper", () => {
     });
     expect(checks[0].name).toBe("reaper-health");
     expect(checks[0].status).toBe(STATUS.PASS);
+  });
+});
+
+// ─── checkCloudTokenEnv (CTL-1307) ───────────────────────────────────────────
+
+describe("checkCloudTokenEnv", () => {
+  const CFG = "/cfg";
+  const ZSH = "/home/.zshenv";
+  const clusterCloud = (token) => JSON.stringify({ catalyst: { cloud: { token } } });
+  const exportLine = (token) => `export CATALYST_CLOUD_TOKEN='${token.replace(/'/g, "'\\''")}'`;
+  // readFile factory: map virtual paths → content; throw (ENOENT) when omitted.
+  const reader =
+    ({ cloud, env, zsh } = {}) =>
+    (p) => {
+      if (p.endsWith("cluster-cloud.json")) {
+        if (cloud === undefined) throw new Error("ENOENT");
+        return cloud;
+      }
+      if (p.endsWith("cluster.env")) {
+        if (env === undefined) throw new Error("ENOENT");
+        return env;
+      }
+      if (p === ZSH) {
+        if (zsh === undefined) throw new Error("ENOENT");
+        return zsh;
+      }
+      throw new Error("ENOENT");
+    };
+
+  it("INFO when no token is decrypted (local-only node)", () => {
+    const checks = checkCloudTokenEnv({ configDir: CFG, zshenvPath: ZSH, readFile: reader({}) });
+    expect(checks[0].name).toBe("cloud-token");
+    expect(checks[0].status).toBe(STATUS.INFO);
+  });
+
+  it("WARN when token decrypted but cluster.env is missing (not projected)", () => {
+    const checks = checkCloudTokenEnv({
+      configDir: CFG,
+      zshenvPath: ZSH,
+      readFile: reader({ cloud: clusterCloud("tok") }),
+    });
+    expect(checks[0].status).toBe(STATUS.WARN);
+    expect(checks[0].detail).toContain("NOT projected");
+  });
+
+  it("WARN when cluster.env holds a STALE token value", () => {
+    const checks = checkCloudTokenEnv({
+      configDir: CFG,
+      zshenvPath: ZSH,
+      readFile: reader({ cloud: clusterCloud("new"), env: exportLine("old") + "\n" }),
+    });
+    expect(checks[0].status).toBe(STATUS.WARN);
+    expect(checks[0].detail).toContain("STALE");
+  });
+
+  it("WARN when cluster.env matches but ~/.zshenv lacks the guard", () => {
+    const checks = checkCloudTokenEnv({
+      configDir: CFG,
+      zshenvPath: ZSH,
+      readFile: reader({ cloud: clusterCloud("tok"), env: exportLine("tok") + "\n", zsh: "export OTHER=1\n" }),
+    });
+    expect(checks[0].status).toBe(STATUS.WARN);
+    expect(checks[0].detail).toContain("source-guard");
+  });
+
+  it("PASS when token is projected and the ~/.zshenv guard is present", () => {
+    const checks = checkCloudTokenEnv({
+      configDir: CFG,
+      zshenvPath: ZSH,
+      readFile: reader({
+        cloud: clusterCloud("tok"),
+        env: exportLine("tok") + "\n",
+        zsh: "# >>> catalyst cloud-token env (CTL-1307) >>>\n. cluster.env\n",
+      }),
+    });
+    expect(checks[0].status).toBe(STATUS.PASS);
+  });
+
+  it("never returns a FAIL status (the token is optional)", () => {
+    // Every branch must be at most WARN — absence/drift must not block activation.
+    const branches = [
+      reader({}),
+      reader({ cloud: clusterCloud("tok") }),
+      reader({ cloud: clusterCloud("new"), env: exportLine("old") + "\n" }),
+    ];
+    for (const readFile of branches) {
+      const checks = checkCloudTokenEnv({ configDir: CFG, zshenvPath: ZSH, readFile });
+      for (const c of checks) expect(c.status).not.toBe(STATUS.FAIL);
+    }
   });
 });

--- a/website/src/content/docs/reference/cluster-config-mirror.md
+++ b/website/src/content/docs/reference/cluster-config-mirror.md
@@ -38,6 +38,7 @@ and
 | Cluster roster | `catalyst-cluster` repo → `cluster.json` `roster[]` | **SHARED** | Add the new node's name to `cluster.json.roster` and push. `cluster-sync` pulls it and the next scheduler tick honors it — no restart. *(The legacy committed `.catalyst/hosts.json` roster was retired in CTL-1274; the daemon no longer reads it.)* |
 | Layer-1 project config | `.catalyst/config.json` | **SHARED** | Committed to git; present after `git clone` |
 | Liveness anchor issue | `~/.config/catalyst/config.json` → `catalyst.cluster.livenessAnchorIssue` | **SHARED** | Copy from the seed node; one Linear ticket identifier per fleet |
+| Cloud token (`CATALYST_CLOUD_TOKEN`) | `catalyst-cluster` repo → `secrets/cluster-cloud.sops.json` `catalyst.cloud.token` | **SHARED** | One shared catalyst-cloud service credential (CTL-1307). Add it once to the cluster repo (SOPS); `cluster-sync` decrypts it to `~/.config/catalyst/cluster-cloud.json` and `cloud-token-env.mjs` projects it to the machine-level env (`cluster.env` + `~/.zshenv` guard) on every node. **Intentionally unread by catalyst core** — a prerequisite for the opt-in cloud path, not a switch that turns it on. |
 | Plugin source | `~/catalyst/plugin-source/` | **SHARED** | Pull from the same git remote; `setup-plugin-source.sh` does this |
 | Linear team/state map | Layer-1 `catalyst.linear.teamKey` / `stateMap` | **SHARED** | Present after `git clone` via `.catalyst/config.json` |
 | `catalyst.host.name` | `~/.config/catalyst/config.json` → `catalyst.host.name` | **PER-NODE** | Set to the new node's unique roster entry (must match an entry in the `catalyst-cluster` repo's `cluster.json.roster`; a name that isn't in the roster owns zero tickets under HRW) |
@@ -56,6 +57,19 @@ and
 > the fleet acts on behalf of the same app. The tokens live in machine-global
 > `~/.config/catalyst/config.json` (not in the per-project `config-<key>.json`) so all nodes can
 > share them without per-project duplication.
+
+> **Why the cloud token is SHARED + machine-level (CTL-1307):** `CATALYST_CLOUD_TOKEN` is a single
+> service credential (the catalyst-cloud `ADMIN_TOKEN`, interim per CTC-27 / ADR-0006) that must be
+> **identical on every node**, so it lives once in the `catalyst-cluster` repo's
+> `secrets/cluster-cloud.sops.json` (a *separate* SOPS file from `cluster-bots` so its rotation/GC
+> lifecycle is independent — it is superseded by per-tenant org-scoped keys per CTC-46). `cluster-sync`
+> decrypts it to `~/.config/catalyst/cluster-cloud.json`; `cloud-token-env.mjs` (run by `catalyst-stack`
+> at boot + keep-alive, or on demand via `catalyst-stack sync-cloud-env`) projects it into the
+> **machine-level environment**: the secret is written to a `0600` `~/.config/catalyst/cluster.env`,
+> and a single non-secret guard line in `~/.zshenv` sources it — so every login shell, and any cloud
+> daemon (re)started in a shell context (this fleet's convention for env-key pickup), inherits
+> `CATALYST_CLOUD_TOKEN`. **Default behavior is unchanged:** nothing in catalyst reads the variable;
+> a node stays fully local-only until the operator separately opts into cloud services.
 
 ---
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -228,6 +228,44 @@ Never commit this. One file per project, linked by `projectKey`. It holds API ke
 
 Only set up the integrations you use — the setup script asks about each one.
 
+## Cluster machine-level cloud token (`CATALYST_CLOUD_TOKEN`, CTL-1307)
+
+`CATALYST_CLOUD_TOKEN` is a single **shared** service credential — the catalyst-cloud
+`ADMIN_TOKEN` (interim, per CTC-27 / ADR-0006) — that must be **identical on every node**. It is an
+**optional extension**: provisioning the token does **not** by itself change Catalyst's behavior.
+Catalyst stays in its normal **local-only** state unless **both** the token is set **and** you have
+specifically configured Catalyst to use the cloud (e.g. local replication + cloud-fed read). Nothing
+in Catalyst reads the variable; only the opt-in cloud host-sync daemon (out-of-repo:
+`catalyst-replica` / `catalyst-cloud`) consumes it. So it is safe to provision cluster-wide without
+altering default behavior.
+
+**Where it lives (shared state):** encrypted in the `catalyst-cluster` repo as
+`secrets/cluster-cloud.sops.json` (a separate SOPS file from `cluster-bots`, so the cloud token can
+rotate / be garbage-collected independently — it is superseded by per-tenant org-scoped keys per
+CTC-46):
+
+```json
+{ "catalyst": { "cloud": { "token": "<catalyst-cloud ADMIN_TOKEN>" } } }
+```
+
+**How it reaches each node's machine-level environment (no manual per-host step):**
+
+1. `cluster-sync` (daemon boot) decrypts it to `~/.config/catalyst/cluster-cloud.json` (mode `0600`),
+   the same path every other cluster-shared secret takes.
+2. `cloud-token-env.mjs` — run by `catalyst-stack start` (boot + keep-alive), or on demand via
+   `catalyst-stack sync-cloud-env` — projects it:
+   - writes the secret to `~/.config/catalyst/cluster.env` (mode `0600`), and
+   - ensures a single **non-secret** guard line in `~/.zshenv` that sources `cluster.env`.
+3. Every login/zsh shell — and any cloud daemon **(re)started in a shell context**, this fleet's
+   convention for env-key pickup — then inherits `CATALYST_CLOUD_TOKEN`.
+
+Rotation is boot-scoped: after the value changes in the cluster repo, run `catalyst cluster sync`
+(or restart the daemon) to re-decrypt, then `catalyst-stack sync-cloud-env`, and restart any cloud
+daemon so it picks up the new value. `catalyst doctor` reports an advisory `cloud-token` WARN if a
+token is decrypted but not yet projected to the machine-level env. The operator runbook for
+adding/rotating the secret in the `catalyst-cluster` repo lives in the `docs/cluster-onboarding.md`
+developer guide ("Provisioning the shared cloud token").
+
 ## GitHub merge rules live in GitHub
 
 Catalyst can open PRs, fix CI, answer review bots, and merge. But GitHub decides what must pass before code lands. Those rules live in **GitHub branch protection or rulesets**, not in `.catalyst/config.json`.


### PR DESCRIPTION
## What

Provision the shared **`CATALYST_CLOUD_TOKEN`** into every cluster node's **machine-level environment**, sourced from the `catalyst-cluster` repo — **without changing default local-only behavior**. (CTL-1307)

The token is a single SHARED service credential (the catalyst-cloud `ADMIN_TOKEN`, interim per CTC-27 / ADR-0006), identical on every node. It is consumed only by the **opt-in, out-of-repo** host-sync daemon (`catalyst-replica` / `catalyst-cloud`); **nothing in this repo reads it**. Providing the token is a prerequisite for the cloud path, not a switch that turns it on — so this is safe to roll out cluster-wide without altering default behavior.

## How

| Layer | Change |
|---|---|
| **Storage** (cluster repo, operator) | `secrets/cluster-cloud.sops.json` = `{ catalyst: { cloud: { token } } }` — a *dedicated* SOPS file (independent rotation/GC lifecycle from bot creds; superseded by per-tenant keys per CTC-46). Covered by the existing `.sops.yaml` rule — **no `.sops.yaml` change**. |
| **Decrypt** | The **existing** `cluster-sync` (`syncClusterSecrets`) decrypts it to `~/.config/catalyst/cluster-cloud.json` (0600) via the generic `destForSecret` path — **no decrypt-code change** (doc comment only). |
| **Projection** (`cloud-token-env.mjs`, new) | A short-lived script — invoked by the **shell launcher**, not the long-lived daemon — reads the token and writes a **0600** `~/.config/catalyst/cluster.env` (atomic tmp+rename, shell-escaped `export`), then ensures a single **non-secret** source-guard line in `~/.zshenv`. Fail-open, idempotent, rotation-aware. |
| **Wiring** (`catalyst-stack`) | Runs the projection at `start` (boot + 600s keep-alive); adds a `sync-cloud-env` subcommand for on-demand / post-rotation application. |
| **Health** (`doctor.mjs`) | Advisory `cloud-token` check — `INFO` (no token, local-only), `WARN` (decrypted but not projected / stale / missing guard), `PASS` (projected). **Never `FAIL`** — the token is optional and must not block activation. |

### Why `~/.zshenv` (via a 0600 `cluster.env`)
This fleet's established machine-level secret-env mechanism is `~/.zshenv` (it already holds `CATALYST_WEBHOOK_SECRET`, `GITHUB_TOKEN`, the per-host `lin_api_*` keys, etc.), and daemons are restarted in a shell context to inherit it — which is exactly the ticket's "host-sync daemons must be restarted with the value set." The secret stays in a **0600** `cluster.env`; `~/.zshenv` gets only the non-secret guard line that sources it, so the credential is *not* placed in the (commonly 0644) profile.

## Acceptance criteria

- ✅ **Node boots → token present in machine-level env** — `cluster-sync` decrypts at boot; `catalyst-stack start` projects to `cluster.env` + `~/.zshenv` guard.
- ✅ **Identical across nodes** — single shared SOPS secret.
- ✅ **Fresh join picks it up automatically** — first daemon boot decrypts; the next `catalyst-stack start` (keep-alive) projects, no per-host step. *(Prerequisite — cluster-repo clone + age key — is shared by all cluster secrets and tracked separately; documented.)*
- ✅ **Token set but cloud not configured → stays local-only** — grep-verified: nothing in this repo reads `CATALYST_CLOUD_TOKEN`.
- ✅ **Token set + opt-in → host-sync authenticates** — the env var is positioned for the out-of-repo consumer.
- ✅ **Stored encrypted in the cluster repo** — `secrets/cluster-cloud.sops.json`, same age recipients as the other secrets.

## Operator step (not in this PR)
The actual secret must be encrypted into the `catalyst-cluster` repo with the real `ADMIN_TOKEN` (laptop-only, per the cluster write policy). Exact `sops` runbook is in `docs/cluster-onboarding.md` → "Provisioning the shared cloud token". For immediate application on an opted-in node: `catalyst cluster sync && catalyst-stack sync-cloud-env`, then restart the cloud daemon in a shell context.

## Tests
- New **CI-gated** `cloud-token-env.test.mjs` (23 cases: escaping/injection-safety, atomic write, 0600 perms, idempotency, rotation, multi-line rejection, fail-open) — added to `execution-core-tests.yml`.
- `cluster-sync.test.mjs`: `cluster-cloud.sops.json → cluster-cloud.json` contract.
- `doctor.test.mjs`: advisory `cloud-token` check (INFO/WARN/PASS, never FAIL).
- All 122 touched-suite tests pass; `bash -n` clean; modules `bun build`-clean.

Reviewed adversarially across correctness / security / criteria lenses (zero confirmed findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
