### PR TITLE
fix(dev): CTL-1317 — Rulebook crashes on /rules (undefined s.length) — read cfg as { rows }

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/thresholds-appendix.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/thresholds-appendix.tsx
@@ -21,9 +21,14 @@ export function ThresholdsAppendix() {
     fetch("/api/beliefs/cfg")
       .then((r) => {
         if (!r.ok) throw new Error(`${r.status}`);
-        return r.json() as Promise<{ cfg: CfgRow[] }>;
+        // CTL-1317: the server returns { rows } (server.ts /api/beliefs/cfg), NOT
+        // { cfg }. Reading the wrong key set rows = undefined, which slipped past
+        // the `rows === null` guard below and crashed on rows.length (#185-adjacent
+        // TypeError on every /rules visit). Read `rows`, and fall back to [] so a
+        // future shape drift degrades to "no thresholds" instead of crashing.
+        return r.json() as Promise<{ rows?: CfgRow[] }>;
       })
-      .then((d) => setRows(d.cfg))
+      .then((d) => setRows(d.rows ?? []))
       .catch(() => setUnavailable(true));
   }, []);
 
@@ -34,7 +39,7 @@ export function ThresholdsAppendix() {
       </p>
       {unavailable ? (
         <p className="text-xs text-muted-foreground">Thresholds unavailable.</p>
-      ) : rows === null ? (
+      ) : rows == null ? (
         <p className="text-xs text-muted-foreground">Loading…</p>
       ) : rows.length === 0 ? (
         <p className="text-xs text-muted-foreground">No thresholds configured.</p>


### PR DESCRIPTION
## Bug
Clicking **Rulebook** (`/rules`) crashed the whole surface with `undefined is not an object (evaluating 's.length')`. Found during a full nav-surface crash sweep — `/rules` was the only affected route.

## Root cause
`ThresholdsAppendix` fetches `/api/beliefs/cfg` and read `d.cfg`, but the server returns `{ rows: [...] }` (server.ts `/api/beliefs/cfg`, ~line 4380). So `rows` was set to `undefined`; the `rows === null` loading guard missed it (`undefined !== null`) and fell through to `rows.length` → TypeError on every `/rules` visit.

## Fix
- Read the correct key: `setRows(d.rows ?? [])` (with `[]` fallback so a future shape drift degrades to "no thresholds" instead of crashing).
- Harden the guard: `rows == null` (catches `undefined` too).

## Verification
Typecheck clean; hot-deployed + verified live on **mini & mini-2** — the rulebook renders fully (preface, strata ladder, thresholds).